### PR TITLE
Add verbose mode (-v/--verbose) for diagnostic output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ No file args and no stdin exits 0
 | `--no-color`     | Plain output   |
 | `--no-gitignore` | Skip gitignore |
 | `-q`, `--quiet`    | Quiet mode     |
+| `-v`, `--verbose`  | Verbose output |
 
 ### Global Flags
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,7 +21,7 @@ footer: |
 | 34  | 🔲      | [Paragraph Readability Score](plan/34_paragraph-readability.md)              |
 | 35  | 🔲      | [Paragraph Structure Limits](plan/35_paragraph-structure.md)               |
 | 40  | 🔲      | [Normalize rule READMEs to proto template](plan/40_normalize-rule-readmes.md) |
-| 41  | 🔲      | [Verbose Mode](plan/41_verbose-mode.md)                             |
+| 41  | ✅      | [Verbose Mode](plan/41_verbose-mode.md)                             |
 | 42  | 🔲      | [Find a Better Project Name](plan/42_project-rename.md)               |
 | 43  | 🔲      | [Default File Discovery](plan/43_default-file-discovery.md)                   |
 | 44  | 🔲      | [Rule Docs Command](plan/44_rule-docs-command.md)                        |

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,0 +1,22 @@
+package log
+
+import (
+	"fmt"
+	"io"
+)
+
+// Logger writes verbose diagnostic messages when Enabled is true.
+// Output goes to the configured writer (typically stderr).
+type Logger struct {
+	Enabled bool
+	W       io.Writer
+}
+
+// Printf writes a formatted message to W when Enabled is true.
+// It is a no-op when Enabled is false.
+func (l *Logger) Printf(format string, args ...any) {
+	if !l.Enabled {
+		return
+	}
+	_, _ = fmt.Fprintf(l.W, format+"\n", args...)
+}

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPrintf_Enabled(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{Enabled: true, W: &buf}
+
+	l.Printf("config: %s", ".tidymark.yml")
+
+	want := "config: .tidymark.yml\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestPrintf_Disabled(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{Enabled: false, W: &buf}
+
+	l.Printf("config: %s", ".tidymark.yml")
+
+	if got := buf.String(); got != "" {
+		t.Errorf("expected no output, got %q", got)
+	}
+}
+
+func TestPrintf_MultipleMessages(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{Enabled: true, W: &buf}
+
+	l.Printf("file: %s", "README.md")
+	l.Printf("rule: %s %s", "TM001", "line-length")
+
+	want := "file: README.md\nrule: TM001 line-length\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/plan/41_verbose-mode.md
+++ b/plan/41_verbose-mode.md
@@ -1,7 +1,7 @@
 ---
 id: 41
 title: Verbose Mode
-status: 🔲
+status: ✅
 ---
 # Verbose Mode
 


### PR DESCRIPTION
## Summary
Adds a new `--verbose` / `-v` flag to the `check` and `fix` subcommands that outputs diagnostic information to stderr, including the config file path, processed files, enabled rules, and fix pass summaries.

## Key Changes

- **New Logger package** (`internal/log/logger.go`): Simple conditional logger that writes to stderr when enabled
- **Verbose flag support**: Added `--verbose` / `-v` flag to both `check` and `fix` subcommands
- **Quiet suppresses verbose**: When both `--quiet` and `--verbose` are specified, quiet takes precedence
- **Enhanced Runner and Fixer**: Both now accept a Logger and output:
  - Config file path when loaded
  - Each processed file path
  - Enabled rules for each file
  - Fix pass progress and stability information
- **Refactored output formatting**: Extracted `formatDiagnostics()` and `printErrors()` helper functions to reduce duplication
- **Updated loadConfig()**: Now returns the config path in addition to the config object, enabling verbose output of which config was loaded
- **Comprehensive test coverage**: Added 8 new e2e tests covering verbose mode behavior, short flags, summary output, interaction with quiet mode, and JSON format compatibility

## Implementation Details

- Verbose output goes to stderr to keep stdout clean for piping
- Logger is optional in Runner/Fixer; a disabled logger is returned if none is set to avoid nil checks
- Rules are logged only when verbose is enabled to avoid unnecessary iteration
- The verbose flag is properly integrated into all three code paths: file checking, stdin checking, and file fixing

https://claude.ai/code/session_01X7QuDRZQkXyqadPsAcCrej