### PR TITLE
Add plan 60 for corpus acquisition taxonomy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -40,7 +40,7 @@ footer: |
 | 57  | 🔲      | [Spike yzma for Embedded Weasel Detection](plan/57_spike-yzma-weasel-detection.md)                 |
 | 58  | 🔲      | [Select and Package Fast Weasel Classifier (CPU Fallback)](plan/58_classifier-model-selection-and-embedding.md) |
 | 59  | 🔲      | [Classifier Evaluation Baseline](plan/59_classifier-evaluation-baseline.md)                           |
-| 60  | 🔲      | [Corpus Acquisition and Taxonomy](plan/60_corpus-acquisition.md)                          |
 | 60  | 🔲      | [DU-Style Metrics Ranking](plan/60_du-style-metrics-ranking.md)                                 |
 | 61  | 🔲      | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                        |
+| 62  | 🔲      | [Corpus Acquisition and Taxonomy](plan/62_corpus-acquisition.md)                          |
 <!-- /catalog -->

--- a/plan/62_corpus-acquisition.md
+++ b/plan/62_corpus-acquisition.md
@@ -1,5 +1,5 @@
 ---
-id: 60
+id: 62
 title: Corpus Acquisition and Taxonomy
 status: 🔲
 ---


### PR DESCRIPTION
## Summary
- add plan 60 for acquiring and labeling a Markdown corpus
- define taxonomy coverage including agent docs, Diataxis docs, ADR/RFC, and related technical doc categories
- add acceptance criteria for licensing, provenance, balancing, QA, and refresh workflows

## Validation
- go run ./cmd/mdsmith check plan/60_corpus-acquisition.md
- go test ./...
- go tool golangci-lint run