### PR TITLE
Complete plan 55 LocalAI spike under spikes/localai-weasel-detection

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -35,7 +35,7 @@ footer: |
 | 52  | 🔲      | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)        |
 | 53  | 🔲      | [Conciseness Scoring](plan/53_conciseness-scoring.md)                                      |
 | 54  | 🔲      | [Conciseness Metrics Design and Implementation](plan/54_metrics-guide-tradeoffs.md)            |
-| 55  | 🔲      | [Spike LocalAI for Weasel Detection](plan/55_spike-localai-weasel-detection.md)                       |
+| 55  | ✅      | [Spike LocalAI for Weasel Detection](plan/55_spike-localai-weasel-detection.md)                       |
 | 56  | 🔲      | [Spike Ollama for Weasel Detection](plan/56_spike-ollama-weasel-detection.md)                        |
 | 57  | 🔲      | [Spike yzma for Embedded Weasel Detection](plan/57_spike-yzma-weasel-detection.md)                 |
 | 58  | 🔳      | [Select and Package Fast Weasel Classifier (CPU Fallback)](plan/58_classifier-model-selection-and-embedding.md) |

--- a/plan/55_spike-localai-weasel-detection.md
+++ b/plan/55_spike-localai-weasel-detection.md
@@ -1,7 +1,7 @@
 ---
 id: 55
 title: Spike LocalAI for Weasel Detection
-status: 🔲
+status: ✅
 ---
 # Spike LocalAI for Weasel Detection
 
@@ -32,3 +32,9 @@ for weasel-language detection in mdsmith.
 - [ ] CPU latency and memory metrics are documented for the spike corpus.
 - [ ] Integration approach and failure handling are documented.
 - [ ] Recommendation is made: proceed, defer, or reject for mdsmith.
+
+## Notes
+
+- Spike report:
+  [`spikes/localai-weasel-detection/README.md`](
+    ../spikes/localai-weasel-detection/README.md)

--- a/spikes/localai-weasel-detection/README.md
+++ b/spikes/localai-weasel-detection/README.md
@@ -1,0 +1,164 @@
+---
+title: LocalAI Weasel Detection Spike
+description: Determinism, CPU latency, memory, and integration
+  trade-offs for LocalAI as a weasel-language backend.
+---
+# LocalAI Weasel Detection Spike
+
+## Scope
+
+This spike evaluates LocalAI as a local inference backend for
+weasel-language detection in mdsmith (plan 55).
+The target was deterministic behavior under fixed settings,
+plus CPU latency and memory measurements.
+
+## Environment
+
+- Host: macOS (`darwin/arm64`)
+- Runtime: Docker
+- LocalAI image: `localai/localai:latest-aio-cpu`
+- LocalAI binary version: `v3.11.0`
+- Text model: `llama-3.2-1b-instruct:q4_k_m`
+- Corpus:
+  `spikes/localai-weasel-detection/corpus/*.md`
+
+## Reproducible Setup
+
+```bash
+docker run -d --rm --name localai-plan55 -p 18080:8080 \
+  localai/localai:latest-aio-cpu
+
+docker exec localai-plan55 /local-ai models install \
+  localai@llama-3.2-1b-instruct:q4_k_m
+
+docker restart localai-plan55
+
+LOCALAI_CONTAINER=localai-plan55 RUNS=6 \
+  spikes/localai-weasel-detection/localai_weasel_benchmark.sh
+```
+
+The script stores raw responses and metrics under
+`.tmp/spikes/localai-weasel-detection/`.
+
+## Deterministic Controls
+
+The request used fixed sampling controls:
+
+- `temperature: 0`
+- `top_p: 1`
+- `seed: 42`
+- `presence_penalty: 0`
+- `frequency_penalty: 0`
+
+## Results
+
+### Determinism (same process)
+
+Across 6 repeated calls per file, each file produced one unique response hash:
+
+- `direct-01`: `unique_hashes=1`
+- `direct-02`: `unique_hashes=1`
+- `weasel-01`: `unique_hashes=1`
+- `weasel-02`: `unique_hashes=1`
+
+### Determinism (restart)
+
+A restart check (`restart-a` vs `restart-b`) produced identical hashes
+for all four files.
+
+### CPU Latency
+
+| File      | Avg latency (s) | Max latency (s) |
+|-----------|----------------:|----------------:|
+| `direct-01` | 5.8662          | 6.8727          |
+| `direct-02` | 5.6662          | 6.4932          |
+| `weasel-01` | 4.0441          | 4.2428          |
+| `weasel-02` | 3.1619          | 3.4312          |
+
+Overall: average `4.6846s`, min `2.8216s`, max `6.8727s` (`n=24`).
+
+### Memory
+
+`docker stats` samples during requests:
+
+- Average: `495.5 MiB`
+- Range: `473.3 MiB` to `510.8 MiB`
+
+### Startup Cost
+
+Restart-to-ready measurements:
+
+- Run 1: `18s`
+- Run 2: `16s`
+- Run 3: `14s`
+
+### Operational Footprint
+
+- LocalAI image size: `292,172,060` bytes (~279 MiB)
+- `/models` footprint in this setup: `2.6 GiB`
+- First-time setup requires network pulls for image and models.
+- After model install, restart runs used local artifacts only.
+- Key artifacts:
+  - `llama-3.2-1b-instruct-q4_k_m.gguf`: `771 MiB`
+  - `stable-diffusion-v1-5-pruned-emaonly-Q4_0.gguf`: `1.5 GiB`
+  - `granite-embedding-107m-multilingual-f16.gguf`: `211 MiB`
+- Model gallery metadata declares license: `llama3.2`
+- Startup logs repeatedly showed a bundled image backend error:
+  missing `/backends/cpu-stablediffusion-ggml/run.sh`.
+
+## Output and Quality Notes
+
+- Determinism was strong with fixed sampling.
+- Output schema compliance was weak:
+  strict JSON parse succeeded `0/24` times on raw message content.
+- One direct example produced an unrelated shell command response.
+- In this tiny corpus sample, direct examples were not reliably
+  classified as direct.
+
+These quality issues are model/prompt-level, but they affect
+backend viability for strict lint diagnostics.
+
+## Proposed mdsmith Integration Shape
+
+Use LocalAI as an optional external service backend:
+
+```yaml
+weasel-detection:
+  provider: localai
+  endpoint: http://127.0.0.1:18080/v1/chat/completions
+  model: llama-3.2-1b-instruct:q4_k_m
+  timeout: 8s
+  retries: 0
+  deterministic:
+    temperature: 0
+    top-p: 1
+    seed: 42
+```
+
+Request contract:
+
+- single paragraph in, structured label out (`weasel`/`direct` + score)
+- no streaming
+- strict timeout and no retry by default to protect lint latency
+
+Failure handling:
+
+- On connection errors, timeout, or parse failures:
+  - do not fail the lint run
+  - skip this check (or run a local heuristic fallback if enabled)
+  - emit debug-only telemetry in verbose mode
+
+## Recommendation
+
+Defer LocalAI adoption for mdsmith weasel detection as a default path.
+
+Reasoning:
+
+1. Determinism is acceptable, but output-shape reliability is not.
+2. End-to-end CPU latency is high for per-paragraph lint usage.
+3. Operational footprint is heavy for default local tooling.
+
+LocalAI remains viable as an experimental optional backend after:
+
+- stronger prompt/grammar constraints with high parse success, and
+- model selection work focused on small, stable classifiers.

--- a/spikes/localai-weasel-detection/corpus/direct-01.md
+++ b/spikes/localai-weasel-detection/corpus/direct-01.md
@@ -1,0 +1,4 @@
+# Direct Example 1
+
+The API returns a `200` when the request is valid and a
+`400` when required fields are missing.

--- a/spikes/localai-weasel-detection/corpus/direct-02.md
+++ b/spikes/localai-weasel-detection/corpus/direct-02.md
@@ -1,0 +1,4 @@
+# Direct Example 2
+
+Run `go test ./...` before merging and include the command
+output in the pull request description.

--- a/spikes/localai-weasel-detection/corpus/weasel-01.md
+++ b/spikes/localai-weasel-detection/corpus/weasel-01.md
@@ -1,0 +1,4 @@
+# Weasel Example 1
+
+Basically, we should probably improve this section at some point
+so readers can maybe understand it better.

--- a/spikes/localai-weasel-detection/corpus/weasel-02.md
+++ b/spikes/localai-weasel-detection/corpus/weasel-02.md
@@ -1,0 +1,4 @@
+# Weasel Example 2
+
+It is generally considered important to try to keep this document
+reasonably concise where possible.

--- a/spikes/localai-weasel-detection/localai_weasel_benchmark.sh
+++ b/spikes/localai-weasel-detection/localai_weasel_benchmark.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SPIKE_DIR="${SPIKE_DIR:-$ROOT_DIR/spikes/localai-weasel-detection}"
+CORPUS_DIR="${CORPUS_DIR:-$SPIKE_DIR/corpus}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.tmp/spikes/localai-weasel-detection}"
+LOCALAI_URL="${LOCALAI_URL:-http://127.0.0.1:18080/v1/chat/completions}"
+MODEL="${MODEL:-llama-3.2-1b-instruct:q4_k_m}"
+RUNS="${RUNS:-5}"
+SEED="${SEED:-42}"
+LOCALAI_CONTAINER="${LOCALAI_CONTAINER:-}"
+
+mkdir -p "$OUT_DIR/raw"
+RESULTS_CSV="$OUT_DIR/results.csv"
+SUMMARY_TXT="$OUT_DIR/summary.txt"
+
+printf 'file,run,latency_s,mem_usage,response_sha256,label,confidence\n' \
+  >"$RESULTS_CSV"
+
+for file in "$CORPUS_DIR"/*.md; do
+  base="$(basename "$file" .md)"
+  text="$(tail -n +3 "$file" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')"
+
+  for run in $(seq 1 "$RUNS"); do
+    payload="$(
+      jq -n \
+        --arg model "$MODEL" \
+        --arg text "$text" \
+        --argjson seed "$SEED" \
+        '{
+          model: $model,
+          temperature: 0,
+          top_p: 1,
+          seed: $seed,
+          max_tokens: 120,
+          presence_penalty: 0,
+          frequency_penalty: 0,
+          messages: [
+            {
+              role: "system",
+              content: "Classify whether the paragraph uses weasel language. Return compact JSON with keys label, confidence, rationale. label must be weasel or direct."
+            },
+            {role: "user", content: $text}
+          ]
+        }'
+    )"
+
+    response_file="$OUT_DIR/raw/${base}-run${run}.json"
+    latency="$(
+      curl -s -o "$response_file" -w '%{time_total}' \
+        -H 'Content-Type: application/json' \
+        -d "$payload" \
+        "$LOCALAI_URL"
+    )"
+
+    content="$(jq -r '.choices[0].message.content // ""' "$response_file")"
+    hash="$(
+      printf '%s' "$content" | LC_ALL=C shasum -a 256 | awk '{print $1}'
+    )"
+    label="$(
+      printf '%s' "$content" | jq -r '.label // "parse_error"' \
+        2>/dev/null || echo "parse_error"
+    )"
+    confidence="$(
+      printf '%s' "$content" | jq -r '.confidence // "parse_error"' \
+        2>/dev/null || echo "parse_error"
+    )"
+
+    mem_usage="n/a"
+    if [[ -n "$LOCALAI_CONTAINER" ]]; then
+      mem_usage="$(
+        docker stats --no-stream --format '{{.MemUsage}}' \
+          "$LOCALAI_CONTAINER" 2>/dev/null \
+          | awk -F'/' '{gsub(/^[ \t]+|[ \t]+$/, "", $1); print $1}'
+      )"
+      if [[ -z "$mem_usage" ]]; then
+        mem_usage="n/a"
+      fi
+    fi
+
+    printf '%s,%s,%s,%s,%s,%s,%s\n' \
+      "$base" "$run" "$latency" "$mem_usage" "$hash" "$label" "$confidence" \
+      >>"$RESULTS_CSV"
+  done
+done
+
+{
+  printf 'model=%s\n' "$MODEL"
+  printf 'seed=%s\n' "$SEED"
+  printf 'runs_per_file=%s\n\n' "$RUNS"
+  awk -F, '
+    NR > 1 {
+      count[$1]++
+      sum[$1] += $3
+      if ($3 > max[$1]) {
+        max[$1] = $3
+      }
+      hash_seen[$1 SUBSEP $5] = 1
+    }
+    END {
+      for (f in count) {
+        unique = 0
+        for (k in hash_seen) {
+          split(k, parts, SUBSEP)
+          if (parts[1] == f) {
+            unique++
+          }
+        }
+        printf "%s unique_hashes=%d avg_latency_s=%.4f max_latency_s=%.4f\n",
+          f, unique, sum[f] / count[f], max[f]
+      }
+    }
+  ' "$RESULTS_CSV" | sort
+} >"$SUMMARY_TXT"
+
+printf 'Wrote %s\n' "$RESULTS_CSV"
+printf 'Wrote %s\n' "$SUMMARY_TXT"


### PR DESCRIPTION
## Summary
- add and mark complete plan 55 (LocalAI weasel detection spike)
- place all spike artifacts under `spikes/localai-weasel-detection/` (report, corpus, benchmark runner)
- include deterministic-run, latency, memory, and operational-footprint findings with a recommendation

## Validation
- `go run ./cmd/mdsmith check .`
- `go test ./...`
- `go tool golangci-lint run`