### PR TITLE
Return relative paths from Discover() for consistent pattern matching

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -122,7 +122,7 @@ func (w *walker) visit(path string, info os.FileInfo, walkErr error) error {
 	}
 
 	if w.matchesAny(rel) {
-		w.addFile(path)
+		w.addFile(rel, path)
 	}
 	return nil
 }
@@ -161,15 +161,14 @@ func (w *walker) matchesAny(rel string) bool {
 	return false
 }
 
-// addFile adds a file to the result set if not already seen.
-func (w *walker) addFile(path string) {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		absPath = path
-	}
+// addFile adds a file to the result set if not already seen. The rel path
+// (relative to BaseDir, using forward slashes) is stored in the result so
+// that config override patterns match consistently regardless of discovery
+// method. The absPath is used only for deduplication.
+func (w *walker) addFile(rel, absPath string) {
 	if !w.seen[absPath] {
 		w.seen[absPath] = true
-		w.result = append(w.result, path)
+		w.result = append(w.result, rel)
 	}
 }
 

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -217,6 +217,39 @@ func TestDiscover_ExactFilePattern(t *testing.T) {
 	}
 }
 
+func TestDiscover_ReturnsRelativePaths(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "slides.md", "# Slides\n")
+	writeFile(t, dir, "docs/guide.md", "# Guide\n")
+
+	files, err := Discover(Options{
+		Patterns: []string{"**/*.md"},
+		BaseDir:  dir,
+	})
+	if err != nil {
+		t.Fatalf("Discover error: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(files), files)
+	}
+
+	// Discovered paths must be relative to BaseDir so that override
+	// patterns like "slides.md" match consistently (issue #40).
+	for _, f := range files {
+		if filepath.IsAbs(f) {
+			t.Errorf("discovered path should be relative, got absolute: %s", f)
+		}
+	}
+
+	want := map[string]bool{"docs/guide.md": true, "slides.md": true}
+	for _, f := range files {
+		if !want[f] {
+			t.Errorf("unexpected path %q; want relative paths like slides.md or docs/guide.md", f)
+		}
+	}
+}
+
 func TestDiscover_NoDuplicates(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "README.md", "# Hello\n")


### PR DESCRIPTION
## Summary
Modified the `Discover()` function to return file paths relative to `BaseDir` instead of absolute paths. This ensures that override patterns in configuration files match consistently regardless of how files are discovered.

## Changes
- Updated `walker.addFile()` to accept and store relative paths (using forward slashes) in results instead of absolute paths
- Modified `walker.visit()` to pass the relative path to `addFile()` for storage in results
- Absolute paths are now used only internally for deduplication via the `seen` map
- Added test case `TestDiscover_ReturnsRelativePaths()` to verify that discovered paths are relative to `BaseDir` and match expected patterns like `"slides.md"` and `"docs/guide.md"`

## Implementation Details
- The relative path is computed during the walk and passed to `addFile()` alongside the absolute path
- Deduplication still uses absolute paths to prevent duplicates across different discovery methods
- This change ensures that user-facing override patterns (e.g., `"slides.md"`) work consistently with the discovered file paths (fixes issue #40)

https://claude.ai/code/session_01Hi6NHJeKAQP6HVXwbspjW4