### PR TITLE
Background docs: Increase max file length limit from 500 to 1000

### DIFF
--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -100,7 +100,7 @@ overrides:
       line-length:
         stern: true
       max-file-length:
-        max: 500
+        max: 1000
       token-budget:
         max: 12000
         mode: heuristic


### PR DESCRIPTION
## Summary
Updated the mdsmith configuration to increase the maximum file length constraint, allowing for background docs.

## Changes
- Increased `max-file-length` limit from 500 to 1000 in `.mdsmith.yml`

## Details
This change relaxes the file length restriction in the mdsmith linter configuration, doubling the previous limit. This allows documentation files to be up to 1000 lines long before triggering a linting violation, providing more flexibility for comprehensive documentation without requiring artificial file splits.

https://claude.ai/code/session_01TpAStcQ55P4mTmba2Dq7g4