### PR TITLE
Update MDS020 description to surface front matter validation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -28,7 +28,7 @@ footer: |
 | 45  | ✅      | [Derive allRuleNames from Rule Registry](plan/45_derive-allrulenames.md)                                |
 | 46  | ✅      | [Design table readability measure](plan/46_table-readability.md)                                      |
 | 47  | ✅      | [Token Budget Awareness](plan/47_token-budget-awareness.md)                                                |
-| 48  | 🔲      | [Front Matter Validation](plan/48_front-matter-validation.md)                                               |
+| 48  | ✅      | [Front Matter Validation](plan/48_front-matter-validation.md)                                               |
 | 49  | ✅      | [Cross-File Reference Integrity](plan/49_cross-file-reference-integrity.md)                                        |
 | 50  | 🔲      | [Redundancy / Duplication Detection](plan/50_redundancy-duplication-detection.md)                                    |
 | 51  | 🔲      | [Section-Level Size Limits](plan/51_section-level-size-limits.md)                                             |

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ row: "| [{{.id}}]({{.filename}}) | `{{.name}}` | {{.status}} | {{.description}} 
 | [MDS017](internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md) | `no-trailing-punctuation-in-heading` | ready     | Headings should not end with punctuation.                                               |
 | [MDS018](internal/rules/MDS018-no-emphasis-as-heading/README.md) | `no-emphasis-as-heading`             | ready     | Don't use bold or emphasis on a standalone line as a heading substitute.                |
 | [MDS019](internal/rules/MDS019-catalog/README.md) | `catalog`                            | ready     | Catalog content must reflect selected front matter fields from files matching its glob. |
-| [MDS020](internal/rules/MDS020-required-structure/README.md) | `required-structure`                 | ready     | Document must match the heading structure defined by its template.                      |
+| [MDS020](internal/rules/MDS020-required-structure/README.md) | `required-structure`                 | ready     | Document structure and front matter must match its template.                            |
 | [MDS021](internal/rules/MDS021-include/README.md) | `include`                            | ready     | Include section content must match the referenced file.                                 |
 | [MDS022](internal/rules/MDS022-max-file-length/README.md) | `max-file-length`                    | ready     | File must not exceed maximum number of lines.                                           |
 | [MDS023](internal/rules/MDS023-paragraph-readability/README.md) | `paragraph-readability`              | ready     | Paragraph readability grade must not exceed a threshold.                                |

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -2,11 +2,11 @@
 id: MDS020
 name: required-structure
 status: ready
-description: Document must match the heading structure defined by its template.
+description: Document structure and front matter must match its template.
 ---
 # MDS020: required-structure
 
-Document must match the heading structure defined by its
+Document structure and front matter must match its
 template.
 
 - **ID**: MDS020

--- a/plan/48_front-matter-validation.md
+++ b/plan/48_front-matter-validation.md
@@ -1,7 +1,7 @@
 ---
 id: 48
 title: Front Matter Validation
-status: 🔲
+status: ✅
 ---
 # Front Matter Validation
 
@@ -9,6 +9,14 @@ status: 🔲
 
 Validate YAML front matter in Markdown files against a schema
 to prevent silent metadata breakage in agent workflows.
+
+## Implementation
+
+The required-structure rule (MDS020) validates front matter
+with CUE. Top-level fields in the template become a CUE
+schema. Each matched document's front matter is checked
+against that schema. See
+`internal/rules/requiredstructure/rule.go`.
 
 ## Tasks
 
@@ -21,8 +29,8 @@ to prevent silent metadata breakage in agent workflows.
 
 ## Acceptance Criteria
 
-- [ ] Rule fails when required front matter fields are missing.
-- [ ] Rule fails when field types or allowed values are invalid.
-- [ ] Errors include file path and field name.
-- [ ] All tests pass: `go test ./...`
-- [ ] `golangci-lint run` reports no issues
+- [x] Rule fails when required front matter fields are missing.
+- [x] Rule fails when field types or allowed values are invalid.
+- [x] Errors include file path and field name.
+- [x] All tests pass: `go test ./...`
+- [x] `golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

- Update MDS020 required-structure description from "Document must match the heading structure defined by its template" to "Document structure and front matter must match its template" so agents discover CUE front matter validation from the rule listing.
- Mark plan 48 (Front Matter Validation) as ✅ — its AC is fully covered by MDS020's CUE schema support.

## Test plan

- [x] `go test ./internal/rules/...` passes
- [x] `mdsmith check .` passes (0 failures)
- [x] `mdsmith help rule` shows updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)