### PR TITLE
Support diff3-style merge conflict markers in merge driver

### DIFF
--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -217,8 +217,8 @@ func regenDirectiveNames() []string {
 // discovered dynamically from registered gensection.Directive rules.
 // Conflict markers outside these sections are left unchanged.
 //
-// Both standard (<<<, ===, >>>) and diff3 (<<<, |||, ===, >>>)
-// conflict styles are supported.
+// Both standard (<<<<<<<, =======, >>>>>>>) and diff3
+// (<<<<<<<, |||||||, =======, >>>>>>>) conflict styles are supported.
 //
 // The ======= separator is only stripped when it appears between
 // <<<<<<< and >>>>>>> to avoid false positives with Markdown

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -31,6 +31,9 @@ func TestStripSectionConflicts_Diff3CatalogConflict(t *testing.T) {
 	if strings.Contains(result, "|||||||") {
 		t.Error("expected ||||||| base marker stripped")
 	}
+	if strings.Contains(result, "=======") {
+		t.Error("expected ======= separator stripped")
+	}
 	if strings.Contains(result, ">>>>>>>") {
 		t.Error("expected >>>>>>> marker stripped")
 	}
@@ -55,6 +58,9 @@ func TestStripSectionConflicts_Diff3OutsideSection_Preserved(t *testing.T) {
 	}
 	if !strings.Contains(result, "|||||||") {
 		t.Error("expected ||||||| marker preserved outside section")
+	}
+	if !strings.Contains(result, "=======") {
+		t.Error("expected ======= separator preserved outside section")
 	}
 	if !strings.Contains(result, ">>>>>>>") {
 		t.Error("expected >>>>>>> marker preserved outside section")


### PR DESCRIPTION
## Summary
Extended the merge driver's conflict marker stripping logic to handle diff3-style conflict markers (which include a `|||||||` base section) in addition to the standard 3-way merge markers.

## Changes
- Added `isConflictBase()` function to detect diff3-style base section markers (`|||||||`)
- Updated `stripSectionConflicts()` to strip base markers when inside regenerable sections, matching the behavior for standard conflict markers
- Updated documentation to clarify support for both standard (`<<<<<<<`, `=======`, `>>>>>>>`) and diff3 (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`) conflict styles
- Added comprehensive test coverage:
  - `TestStripSectionConflicts_Diff3CatalogConflict`: Verifies all four marker types are stripped inside regenerable sections
  - `TestStripSectionConflicts_Diff3OutsideSection_Preserved`: Verifies markers outside regenerable sections are preserved for manual resolution

## Implementation Details
The fix follows the existing pattern for handling conflict markers. When a conflict is detected inside a regenerable section (like a `<?catalog?>` block), the base marker line is skipped during output, just like the open, separator, and close markers. This allows the merge driver to automatically resolve conflicts in regenerable sections regardless of the git merge conflict style configuration.

https://claude.ai/code/session_01934jTttFSujU2GCfBMoCVS