### PR TITLE
Add coverage instrumentation to e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,21 +44,23 @@ jobs:
           # are only exercised via the subprocess binary, so the
           # test-process counters are always zero.
           tail -n +2 unit.cov | grep -v 'cmd/mdsmith/' >> merged.cov || true
-          if [ ! -f "$GITHUB_WORKSPACE/e2e-cover/e2e_coverage.txt" ]; then
-            echo "e2e_coverage.txt not found in E2E_COVERDIR — cmd/mdsmith coverage will be missing" >&2
+          e2e_profile="$GITHUB_WORKSPACE/e2e-cover/e2e_coverage.txt"
+          if [ ! -f "$e2e_profile" ]; then
+            echo "e2e_coverage.txt not found — cmd/mdsmith coverage will be missing" >&2
             exit 1
           fi
-          if [ -f "$GITHUB_WORKSPACE/e2e-cover/e2e_coverage.txt" ]; then
-            unit_mode_line=$(head -1 unit.cov)
-            e2e_mode_line=$(head -1 "$GITHUB_WORKSPACE/e2e-cover/e2e_coverage.txt")
-            if [ "$unit_mode_line" != "$e2e_mode_line" ]; then
-              echo "Coverage mode mismatch between unit.cov ('$unit_mode_line') and e2e_coverage.txt ('$e2e_mode_line')" >&2
-              exit 1
-            fi
-            # Only include cmd/mdsmith coverage from the e2e profile to avoid
-            # duplicating blocks for packages already present in unit.cov.
-            tail -n +2 "$GITHUB_WORKSPACE/e2e-cover/e2e_coverage.txt" | grep 'cmd/mdsmith/' >> merged.cov || true
+          unit_mode_line=$(head -1 unit.cov)
+          e2e_mode_line=$(head -1 "$e2e_profile")
+          if [ "$unit_mode_line" != "$e2e_mode_line" ]; then
+            echo "Coverage mode mismatch: unit='$unit_mode_line' e2e='$e2e_mode_line'" >&2
+            exit 1
           fi
+          e2e_lines=$(tail -n +2 "$e2e_profile" | grep -c 'cmd/mdsmith/' || true)
+          if [ "$e2e_lines" -eq 0 ]; then
+            echo "e2e profile contains no cmd/mdsmith/ coverage lines" >&2
+            exit 1
+          fi
+          tail -n +2 "$e2e_profile" | grep 'cmd/mdsmith/' >> merged.cov
       - name: Coverage summary
         run: |
           total=$(go tool cover -func=merged.cov | tail -1)

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -50,13 +50,15 @@ func TestMain(m *testing.M) {
 	// set by the caller, so it can be combined with unit-test coverage.
 	if outDir := os.Getenv("E2E_COVERDIR"); outDir != "" {
 		if err := os.MkdirAll(outDir, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: cannot create E2E_COVERDIR %s: %v\n", outDir, err)
+			fmt.Fprintf(os.Stderr, "E2E_COVERDIR: cannot create %s: %v\n", outDir, err)
+			code = 1
 		} else {
 			mergeCmd := exec.Command("go", "tool", "covdata", "textfmt",
 				"-i="+coverDir, "-o="+filepath.Join(outDir, "e2e_coverage.txt"))
 			mergeCmd.Stderr = os.Stderr
 			if err := mergeCmd.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to merge coverage data: %v\n", err)
+				fmt.Fprintf(os.Stderr, "E2E_COVERDIR: failed to export coverage: %v\n", err)
+				code = 1
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
This PR adds code coverage instrumentation to end-to-end tests, enabling coverage data from e2e test runs to be collected and merged with unit test coverage reports.

## Key Changes
- Build the binary with the `-cover` flag to enable coverage instrumentation
- Create a temporary directory to collect coverage data from all e2e test runs
- Set the `GOCOVERDIR` environment variable when executing the binary in e2e tests to write coverage data
- Merge e2e coverage data into a text profile when `E2E_COVERDIR` environment variable is set by the caller
- Add `TestE2E_CoverageInstrumentation` test to verify the binary was built with coverage support

## Implementation Details
- Coverage data is collected in a shared temporary directory (`coverDir`) created during test initialization
- After all e2e tests complete, coverage data is merged using `go tool covdata textfmt` if `E2E_COVERDIR` is set
- The `GOCOVERDIR` environment variable is passed to both `runBinary()` and `runBinaryInDir()` helper functions
- A new test verifies that coverage instrumentation is working by checking that coverage files are written when the binary runs
- Temporary directories are cleaned up after test completion

https://claude.ai/code/session_01J8XcaCRLjX3UMisFaZHMX7