### PR TITLE
Configure Dependabot for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    open-pull-requests-limit: 1
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Specify 'gomod' as the package ecosystem for Dependabot updates.