### PR TITLE
ci: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

- Adds `merge_group` trigger to CI workflow so checks run on merge queue entries
- Required for enabling GitHub merge queues on `main`

## Remaining manual steps (repo settings)

After merging this PR:
1. Enable branch protection on `main` with required status checks: `lint`, `mdsmith`, `test`
2. Enable "Require merge queue" in the branch protection rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)