### PR TITLE
fix: remove sed Output-path rewrite from VHS isolation step

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -39,10 +39,17 @@ jobs:
           go install github.com/charmbracelet/vhs@v0.10.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-      - name: Record demo
+      - name: Record demo in isolated directory
         run: |
-          vhs demo.tape
-          cp assets/demo.gif /tmp/demo.gif
+          # Run VHS in a temp directory so demo.tape commands
+          # cannot modify the repo working tree.
+          iso="$(mktemp -d)"
+          tar --exclude='.git' -cf - . | (cd "$iso" && tar -xf -)
+          # No Output-path rewrite needed — VHS runs inside $iso,
+          # so relative Output assets/demo.gif writes to $iso/assets/.
+          (cd "$iso" && vhs demo.tape)
+          cp "$iso/assets/demo.gif" /tmp/demo.gif
+          rm -rf "$iso"
 
       - name: Push GIF to assets branch
         run: |
@@ -53,7 +60,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # Remove untracked build artifacts so branch switch succeeds.
-          rm -f assets/demo.gif mdsmith
+          rm -f mdsmith
 
           # Check if assets branch exists on remote
           if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Removed the `sed` command that rewrote the VHS `Output` directive from
  a relative path to an absolute path — VHS v0.10.0 fails immediately
  when given an absolute Output path
- Kept the isolated temp directory approach intact so demo.tape commands
  cannot modify the repo working tree
- Added cleanup of the untracked `mdsmith` binary before the assets
  branch switch

## Root cause

The Demo GIF workflow's "Record demo in isolated directory" step failed
in <1 second (before VHS started recording). The `sed` rewrote
`Output assets/demo.gif` to `Output /tmp/tmp.XXXX/assets/demo.gif`.
Since VHS already runs inside the isolated directory via `cd "$iso"`,
the relative path naturally resolves to `$iso/assets/demo.gif` — the
rewrite was unnecessary and broke VHS.

## Test plan

- [x] CI demo job passes on this branch (VHS records successfully)
- [x] All other CI checks pass (zizmor, lint, mdsmith, test, CodeQL)

https://claude.ai/code/session_01KEyytmfWS4UzC4HW8fkLZo