### PR TITLE
Restructure demo.tape with use case-based narrative flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,8 @@ records a terminal demo GIF. When editing this file:
   non-zero exits don't abort the recording — no need
   to append `; true` to commands
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
-  list; copy it to `/tmp` for check/fix steps
+  list; the hidden setup copies it to a temp dir
+  for check/fix steps
 - Keep Sleep durations short (1–2 s) so VHS renders
   quickly in CI
 - Only use fixable lint rules in `demo/sample.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,8 @@ records a terminal demo GIF. When editing this file:
   non-zero exits don't abort the recording — no need
   to append `; true` to commands
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
-  list; copy it to `/tmp` for check/fix steps
+  list; the hidden setup copies it to a temp dir
+  for check/fix steps
 - Keep Sleep durations short (1–2 s) so VHS renders
   quickly in CI
 - Only use fixable lint rules in `demo/sample.md`

--- a/demo.tape
+++ b/demo.tape
@@ -10,8 +10,9 @@
 #   - Hidden setup runs set +e, adds mdsmith to PATH,
 #     and prepares temp dirs so visible commands match
 #     what a developer would actually type.
-#   - demo/sample.md is ignored by .mdsmith.yml; copy
-#     it to /tmp for check/fix to bypass the ignore.
+#   - demo/sample.md is ignored by .mdsmith.yml; the
+#     hidden setup copies it to a temp dir and runs
+#     check/fix there as sample.md.
 #   - Keep Sleep durations short (1-2s per step) to
 #     avoid long VHS render times in CI.
 


### PR DESCRIPTION
## Summary
Refactored the VHS demo tape script to present mdsmith functionality through organized use cases rather than isolated commands. The new structure guides viewers through realistic workflows with clearer narration and better pacing.

## Key Changes
- **Reorganized into 5 use cases**: Initialize a project, Lint and fix files, Explore rules, Query front matter, and Metrics
- **Added narrative comments**: Each section now includes descriptive headers and inline explanations of what's being demonstrated
- **Improved pacing**: Reduced sleep durations from 2s to 1s per step and added intermediate pauses between commands for better readability
- **Enhanced clarity**: Added "clear" commands between major sections to reset the terminal view
- **Better command flow**: Broke down complex one-liners into logical steps with explanatory text before each action
- **Consistent formatting**: Standardized comment style and spacing throughout the script

## Implementation Details
- Changed comment style from "Step N:" to "Use case N:" for better semantic meaning
- Separated commands that were previously chained together to allow viewers to see each step's output
- Added contextual text (e.g., "# Initialize mdsmith in a new directory") before executing commands
- Maintained the original functionality while making the demo more educational and easier to follow
- Kept total render time reasonable by using shorter, more frequent sleep intervals

https://claude.ai/code/session_01Co7gxV4ixn6g6fJsyuMmu3