### PR TITLE
Simplify CI workflows by removing chromium caching and installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,28 +72,15 @@ jobs:
           path: |
             ~/vhs-bin
           key: vhs-0.10.0-ttyd-1.7.7-${{ runner.os }}-${{ runner.arch }}
-      - name: Detect Ubuntu release
-        id: ubuntu-release
-        run: |
-          . /etc/os-release
-          echo "version_id=$VERSION_ID" >> "$GITHUB_OUTPUT"
-      - name: Cache apt packages
-        id: apt-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ~/apt-cache
-          key: apt-ffmpeg-chromium-${{ runner.os }}-${{ runner.arch }}-ubuntu-${{ steps.ubuntu-release.outputs.version_id }}-${{ github.run_id }}
-          restore-keys: |
-            apt-ffmpeg-chromium-${{ runner.os }}-${{ runner.arch }}-ubuntu-${{ steps.ubuntu-release.outputs.version_id }}-
       - name: Install VHS runtime dependencies
         run: |
-          if [ -d ~/apt-cache ] && ls ~/apt-cache/*.deb >/dev/null 2>&1; then
-            sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
-          fi
+          # Google Chrome is pre-installed on GitHub runners and
+          # go-rod (used by VHS) finds it via launcher.LookPath().
+          # Installing chromium via apt on Ubuntu 24.04 triggers a
+          # slow snap install (~500 MB of dependencies), so we skip
+          # it and only install ffmpeg.
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ffmpeg chromium-browser || sudo apt-get install -y -qq ffmpeg chromium
-          mkdir -p ~/apt-cache
-          cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
+          sudo apt-get install -y -qq ffmpeg
           if [ -f ~/vhs-bin/ttyd ]; then
             sudo install ~/vhs-bin/ttyd /usr/local/bin/ttyd
           else

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -33,31 +33,15 @@ jobs:
           path: |
             ~/vhs-bin
           key: vhs-0.10.0-ttyd-1.7.7-${{ runner.os }}-${{ runner.arch }}
-      - name: Detect Ubuntu release and week
-        id: ubuntu-release
-        run: |
-          . /etc/os-release
-          echo "version_id=$VERSION_ID" >> "$GITHUB_OUTPUT"
-          echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
-      - name: Cache apt packages
-        id: apt-cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ~/apt-cache
-          key: apt-ffmpeg-chromium-${{ runner.os }}-${{ runner.arch }}-ubuntu-${{ steps.ubuntu-release.outputs.version_id }}-${{ steps.ubuntu-release.outputs.week }}
-          restore-keys: |
-            apt-ffmpeg-chromium-${{ runner.os }}-${{ runner.arch }}-ubuntu-${{ steps.ubuntu-release.outputs.version_id }}-
       - name: Install VHS runtime dependencies
         run: |
-          if [ "${{ steps.apt-cache.outputs.cache-hit }}" = "true" ] && ls ~/apt-cache/*.deb >/dev/null 2>&1; then
-            sudo dpkg -i ~/apt-cache/*.deb 2>/dev/null || true
-            sudo apt-get install -y -qq --fix-broken
-          else
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq ffmpeg chromium-browser || sudo apt-get install -y -qq ffmpeg chromium
-            mkdir -p ~/apt-cache
-            cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
-          fi
+          # Google Chrome is pre-installed on GitHub runners and
+          # go-rod (used by VHS) finds it via launcher.LookPath().
+          # Installing chromium via apt on Ubuntu 24.04 triggers a
+          # slow snap install (~500 MB of dependencies), so we skip
+          # it and only install ffmpeg.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg
           if [ -f ~/vhs-bin/ttyd ]; then
             sudo install ~/vhs-bin/ttyd /usr/local/bin/ttyd
           else


### PR DESCRIPTION
## Summary
This PR simplifies the GitHub Actions workflows by removing the complex apt package caching logic and chromium installation, leveraging the fact that Google Chrome is pre-installed on GitHub runners.

## Key Changes
- **Removed apt package caching**: Eliminated the `Cache apt packages` step and related Ubuntu release detection logic from both `ci.yml` and `demo.yml` workflows
- **Removed chromium installation**: Stopped explicitly installing chromium/chromium-browser via apt, as Google Chrome is already available on GitHub runners
- **Simplified dependency installation**: Now only installs ffmpeg, which is the only package that needs to be installed
- **Added clarifying comments**: Documented why chromium installation is skipped (to avoid slow snap installs on Ubuntu 24.04) and how go-rod finds the pre-installed Chrome

## Implementation Details
The changes rely on the fact that:
- Google Chrome is pre-installed on GitHub-hosted runners
- The go-rod library (used by VHS) automatically discovers Chrome via `launcher.LookPath()`
- Installing chromium via apt on Ubuntu 24.04 triggers a slow snap installation (~500 MB of dependencies)

This simplification reduces workflow complexity, improves CI speed, and eliminates the need to maintain cache keys across different Ubuntu versions.

https://claude.ai/code/session_01TSM7vXoHjfqBSp6H4HnGeq