### PR TITLE
Limit demo output for mdsmith help rule command

### DIFF
--- a/demo.tape
+++ b/demo.tape
@@ -275,7 +275,7 @@ Show
 Type "# Look up a specific lint rule"
 Enter
 Sleep 100ms
-Type "mdsmith help rule line-length"
+Type "mdsmith help rule line-length | head -20"
 Sleep 100ms
 Enter
 Sleep 100ms


### PR DESCRIPTION
This change modifies the demo.tape script to pipe the output of the `mdsmith help rule line-length` command through `head -20`, limiting the displayed output to the first 20 lines.

## Summary
Updated the demo script to show a truncated version of the help rule output, making the demo more concise and focused.

## Key Changes
- Modified the `mdsmith help rule line-length` command to include `| head -20` pipe, limiting output to the first 20 lines of the help documentation

## Details
This change improves the demo experience by preventing excessively long help text from dominating the screen during the demonstration, while still showing enough information to be useful.

https://claude.ai/code/session_01MY7VhDYqKP35JwbQMzmWTL