### PR TITLE
Plan: Add MDS034 markdown-flavor validation rule

### DIFF
--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -44,7 +44,7 @@ rules:
     include: []
     exclude:
       # Placeholder link in internal/rules/proto.md; not a real repo path.
-      - "../../../docs/design/archetypes/NAME"
+      - "../../../docs/background/archetypes/NAME"
     strict: true
   token-budget:
     max: 8000
@@ -62,6 +62,16 @@ rules:
     max-words-per-sentence: 40
   # Experimental rule: keep disabled until classifier-backed scoring is ready.
   conciseness-scoring: false
+  directory-structure:
+    allowed:
+      - "."
+      - "docs/**"
+      - "plan/**"
+      - "demo/**"
+      - "internal/rules/**"
+      - "internal/metrics/**"
+      - ".claude/**"
+      - ".github/**"
   catalog: true
   required-structure: true
   include: true
@@ -79,7 +89,7 @@ overrides:
       blank-line-around-lists: false
   - files: [".claude/skills/*/SKILL.md",
             ".github/copilot-pr-fixup.md",
-            "AGENTS-PR-FIXUP.md"]
+            ".github/AGENTS-PR-FIXUP.md"]
     rules:
       max-file-length:
         max: 600
@@ -192,6 +202,37 @@ overrides:
       paragraph-structure:
         max-sentences: 12
         max-words-per-sentence: 120
+  - files: ["docs/security/*.md"]
+    rules:
+      line-length:
+        max: 600
+        exclude:
+          - code-blocks
+          - tables
+          - urls
+      required-structure:
+        schema: docs/security/proto.md
+      max-file-length:
+        max: 1000
+      paragraph-readability: false
+      paragraph-structure: false
+      no-emphasis-as-heading: false
+      token-budget:
+        max: 16000
+        mode: heuristic
+        tokens-per-word: 1.33
+        tokenizer: builtin
+        encoding: cl100k_base
+  - files: ["docs/research/**"]
+    rules:
+      first-line-heading: false
+      heading-increment: false
+      paragraph-readability: false
+      paragraph-structure: false
+      token-budget: false
+      max-file-length: false
+      cross-file-reference-integrity: false
+      required-structure: false
 
 ignore:
   - "demo/**"
@@ -203,3 +244,4 @@ ignore:
   - ".claude/skills/proto.md"
   - "plan/proto.md"
   - "internal/rules/proto.md"
+  - "docs/security/proto.md"

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -44,7 +44,7 @@ rules:
     include: []
     exclude:
       # Placeholder link in internal/rules/proto.md; not a real repo path.
-      - "../../../docs/background/archetypes/NAME"
+      - "../../../docs/design/archetypes/NAME"
     strict: true
   token-budget:
     max: 8000
@@ -62,16 +62,6 @@ rules:
     max-words-per-sentence: 40
   # Experimental rule: keep disabled until classifier-backed scoring is ready.
   conciseness-scoring: false
-  directory-structure:
-    allowed:
-      - "."
-      - "docs/**"
-      - "plan/**"
-      - "demo/**"
-      - "internal/rules/**"
-      - "internal/metrics/**"
-      - ".claude/**"
-      - ".github/**"
   catalog: true
   required-structure: true
   include: true
@@ -89,7 +79,7 @@ overrides:
       blank-line-around-lists: false
   - files: [".claude/skills/*/SKILL.md",
             ".github/copilot-pr-fixup.md",
-            ".github/AGENTS-PR-FIXUP.md"]
+            "AGENTS-PR-FIXUP.md"]
     rules:
       max-file-length:
         max: 600
@@ -202,37 +192,6 @@ overrides:
       paragraph-structure:
         max-sentences: 12
         max-words-per-sentence: 120
-  - files: ["docs/security/*.md"]
-    rules:
-      line-length:
-        max: 600
-        exclude:
-          - code-blocks
-          - tables
-          - urls
-      required-structure:
-        schema: docs/security/proto.md
-      max-file-length:
-        max: 1000
-      paragraph-readability: false
-      paragraph-structure: false
-      no-emphasis-as-heading: false
-      token-budget:
-        max: 16000
-        mode: heuristic
-        tokens-per-word: 1.33
-        tokenizer: builtin
-        encoding: cl100k_base
-  - files: ["docs/research/**"]
-    rules:
-      first-line-heading: false
-      heading-increment: false
-      paragraph-readability: false
-      paragraph-structure: false
-      token-budget: false
-      max-file-length: false
-      cross-file-reference-integrity: false
-      required-structure: false
 
 ignore:
   - "demo/**"
@@ -244,4 +203,3 @@ ignore:
   - ".claude/skills/proto.md"
   - "plan/proto.md"
   - "internal/rules/proto.md"
-  - "docs/security/proto.md"

--- a/PLAN.md
+++ b/PLAN.md
@@ -43,4 +43,5 @@ footer: |
 | 83  | 🔳     | [Security hardening batch](plan/83_security-hardening-batch.md)                                                 |
 | 84  | 🔲     | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                      |
 | 85  | 🔲     | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)            |
+| 86  | 🔲     | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                             |
 <?/catalog?>

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -90,13 +90,34 @@ for ambiguous syntax like `:` (definition lists) and
 goldmark parser with all available extensions enabled
 and re-parses the source. The main parse tree used by
 other rules is untouched. This gives precise AST
-detection without risk to existing rules. Regex
-fallback is used only for the few features without a
-goldmark extension (math, abbreviations,
-superscript/subscript).
+detection without risk to existing rules.
 
-Goldmark built-in extensions cover most features with
-zero third-party dependencies:
+For the four features without a goldmark built-in
+extension, three approaches were compared:
+
+1. **Third-party extensions.** Existing packages
+   (`litao91/goldmark-mathjax`, `bowman2001/
+   goldmark-supersubscript`, `zmtcreative/
+   gm-abbreviations`) are abandoned or have zero
+   adoption. Hugo's `hugo-goldmark-extensions` is
+   actively maintained but tightly coupled to Hugo's
+   rendering pipeline. None are suitable as
+   dependencies.
+
+2. **Custom goldmark extensions (chosen for 3).**
+   Based on the existing PI block parser (~160 LOC),
+   the cost per extension is:
+   - Inline delimiter (`^sup^`, `~sub~`): ~200 LOC
+     with tests
+   - Block fence (`$$...$$`): ~200 LOC with tests
+   - Block def + inline (`*[abbr]: ...`): ~400 LOC
+     with tests
+
+3. **Regex with code-fence skip (chosen for 2).**
+   Best for ambiguous syntax (`$` is common in prose)
+   and rare features (abbreviations).
+
+Final detection strategy per feature:
 
 | Feature | Goldmark built-in | Detection |
 |---|---|---|
@@ -107,10 +128,18 @@ zero third-party dependencies:
 | Definition lists | `extension.DefinitionList` | AST |
 | Heading IDs | `parser.WithAttribute()` | AST |
 | Autolinks | `extension.Linkify` | AST |
-| Math | none built-in | regex |
-| Abbreviations | none built-in | regex |
-| Superscript | none built-in | regex |
-| Subscript | none built-in | regex |
+| Superscript | custom inline ext | AST |
+| Subscript | custom inline ext | AST |
+| Math block | custom block ext | AST |
+| Math inline | none | regex |
+| Abbreviations | none | regex |
+
+Custom extensions for superscript, subscript, and
+math-block because their delimiters are unambiguous
+and the extensions are small (~200 LOC each). Regex
+for math-inline (`$` is too common for reliable
+parsing) and abbreviations (rarest feature, ~400 LOC
+extension not worth it for detection-only).
 
 The dual-parser cost is one extra parse per file, only
 when MDS034 is enabled. Since MDS034 is opt-in and
@@ -185,17 +214,23 @@ any feature where `flavor.Features[f] == false`.
 #### Dual parser setup
 
 MDS034 builds a second goldmark parser in its
-`Check()` method:
+`Check()` method with all built-in extensions plus
+three custom detection-only extensions:
 
 ```go
 p := goldmark.New(
     goldmark.WithExtensions(
+        // Built-in extensions
         extension.Table,
         extension.Strikethrough,
         extension.TaskList,
         extension.Footnote,
         extension.DefinitionList,
         extension.Linkify,
+        // Custom detection-only extensions
+        &SuperscriptExt{},
+        &SubscriptExt{},
+        &MathBlockExt{},
     ),
     goldmark.WithParserOptions(
         parser.WithAttribute(),
@@ -206,7 +241,36 @@ p := goldmark.New(
 This parser is created once per rule instance (not
 per file) and reused across calls.
 
-#### AST detectors (7 features)
+#### Custom goldmark extensions (3)
+
+Three small detection-only extensions, each ~200 LOC
+with tests. They live in
+`internal/rules/markdownflavor/ext/` and follow
+the same pattern as the existing PI block parser
+(`internal/lint/pi.go`):
+
+**SuperscriptExt** -- inline delimiter parser for
+`^text^`. Implements `parser.InlineParser` with
+trigger byte `^`. Produces `KindSuperscript` AST
+nodes. ~100 LOC parser + ~50 LOC node definition.
+
+**SubscriptExt** -- inline delimiter parser for
+`~text~`. Implements `parser.InlineParser` with
+trigger byte `~`. Must distinguish single `~` from
+double `~~` (strikethrough). ~120 LOC parser + ~50
+LOC node definition.
+
+**MathBlockExt** -- block parser for `$$...$$`
+fences. Implements `parser.BlockParser` with trigger
+byte `$`. Produces `KindMathBlock` AST nodes.
+Modeled on goldmark's built-in fenced-code-block
+parser. ~110 LOC parser + ~50 LOC node definition.
+
+These extensions only need to parse (produce AST
+nodes with source positions). They do not need to
+render -- mdsmith never renders HTML.
+
+#### AST detectors (10 features)
 
 Walk the extension-aware AST and collect node
 locations:
@@ -221,23 +285,28 @@ locations:
   `Attribute()` list
 - Autolinks: `extast.KindLinkify` (bare URL nodes
   created by the linkify extension)
+- Superscript: custom `KindSuperscript`
+- Subscript: custom `KindSubscript`
+- Math block: custom `KindMathBlock`
 
 Each detector returns `(line, column)` pairs from
 the node segment positions.
 
-#### Regex detectors (4 features)
+#### Regex detectors (2 features)
 
-For features without a goldmark extension, scan raw
-source lines. Skip lines inside fenced code blocks
-and inline code spans to avoid false positives:
+Regex fallback only for features where a goldmark
+extension is impractical:
 
-- Math inline: `\$[^$\n]+\$` not preceded/followed
-  by `$`
-- Math block: `^\$\$$` as opening/closing fence
-- Abbreviations: `^\*\[[^\]]+\]:`
-- Superscript: `\^[^^]+\^` (not inside code)
-- Subscript: `(?<![~])~(?!~)[^~\n]+~(?!~)` to avoid
-  matching strikethrough `~~`
+- **Math inline** (`$...$`): `\$[^$\n]+\$` not
+  preceded/followed by `$`. The `$` character is too
+  common in prose and code for reliable delimiter
+  parsing; regex with context-awareness (skip code
+  blocks, check surrounding chars) is more precise
+  for detection.
+- **Abbreviations** (`*[abbr]: ...`):
+  `^\*\[[^\]]+\]:`. Rarest feature (~400 LOC
+  extension for block def + inline replacement). Not
+  worth the investment for detection-only.
 
 The code-fence skip logic reuses the fenced-code-block
 line ranges from the AST (which the main parser
@@ -303,34 +372,48 @@ subset. Non-fixable features produce diagnostics only.
 
 1. Add feature enum and flavor registry in
    `internal/rules/markdownflavor/features.go`
-2. Build dual parser: create a second goldmark parser
-   with `extension.Table`, `extension.Strikethrough`,
-   `extension.TaskList`, `extension.Footnote`,
-   `extension.DefinitionList`, `extension.Linkify`,
-   and `parser.WithAttribute()` enabled
-3. Add AST-based detectors for tables, task lists,
-   strikethrough, autolinks, footnotes, definition
-   lists, heading attributes (7 features via AST)
-4. Add regex-based detectors for math, abbreviations,
-   superscript, subscript (4 features via regex) with
-   fenced-code-block skip logic
-5. Implement `rule.go` with `Check()` that re-parses
+2. Write custom `SuperscriptExt` inline parser and
+   `KindSuperscript` AST node in
+   `internal/rules/markdownflavor/ext/superscript.go`
+3. Write custom `SubscriptExt` inline parser and
+   `KindSubscript` AST node in
+   `internal/rules/markdownflavor/ext/subscript.go`
+   (handle `~` vs `~~` disambiguation)
+4. Write custom `MathBlockExt` block parser and
+   `KindMathBlock` AST node in
+   `internal/rules/markdownflavor/ext/mathblock.go`
+5. Add tests for the three custom extensions in
+   `internal/rules/markdownflavor/ext/*_test.go`
+6. Build dual parser: create a second goldmark parser
+   with built-in extensions (`Table`, `Strikethrough`,
+   `TaskList`, `Footnote`, `DefinitionList`,
+   `Linkify`, `WithAttribute`) plus the three custom
+   extensions
+7. Add AST-based detectors for 10 features (tables,
+   task lists, strikethrough, autolinks, footnotes,
+   definition lists, heading attributes, superscript,
+   subscript, math block)
+8. Add regex-based detectors for math inline and
+   abbreviations (2 features) with fenced-code-block
+   skip logic
+9. Implement `rule.go` with `Check()` that re-parses
    with the dual parser, runs all detectors, and
    reports unsupported features
-6. Implement `Fix()` for fixable features (autolinks,
-   strikethrough, heading IDs, task lists)
-7. Add `Configurable` interface: `ApplySettings` for
-   `flavor` string, validate against known flavors
-8. Register rule as MDS034 `markdown-flavor` in
-   category `meta`
-9. Add test fixtures:
-   `internal/rules/MDS034-markdown-flavor/bad/` with
-   files using each unsupported feature per flavor,
-   `good/` with files using only supported features,
-   `fixed/` with expected auto-fix output
-10. Add rule README following
+10. Implement `Fix()` for fixable features (autolinks,
+    strikethrough, heading IDs, task lists,
+    superscript, subscript)
+11. Add `Configurable` interface: `ApplySettings` for
+    `flavor` string, validate against known flavors
+12. Register rule as MDS034 `markdown-flavor` in
+    category `meta`
+13. Add test fixtures:
+    `internal/rules/MDS034-markdown-flavor/bad/` with
+    files using each unsupported feature per flavor,
+    `good/` with files using only supported features,
+    `fixed/` with expected auto-fix output
+14. Add rule README following
     `internal/rules/proto.md` schema
-11. Document the rule in `docs/reference/cli.md` and
+15. Document the rule in `docs/reference/cli.md` and
     add a note to
     `docs/guides/directives/enforcing-structure.md`
     about flavor enforcement

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -118,9 +118,15 @@ Five extensions in
 - **SubscriptExt**: inline `~text~`, distinguishes
   single `~` from strikethrough `~~`, ~170 LOC
 - **MathBlockExt**: block `$$...$$` fence, ~160 LOC
-- **MathInlineExt**: inline `$...$` with Pandoc-style
-  flanking (opening `$` preceded by whitespace, not
-  followed by whitespace), ~200 LOC
+- **MathInlineExt**: inline `$...$` matching Pandoc
+  `tex_math_dollars`
+  (<https://pandoc.org/MANUAL.html#extension-tex_math_dollars>):
+  opening `$` is allowed when the next character is
+  not whitespace; closing `$` is allowed when the
+  previous character is not whitespace and the next
+  character is not a digit. Allows `($x$)` and
+  `foo $x+1$ bar`, rejects `$ x $` and `$20`,
+  ~200 LOC
 - **AbbreviationExt**: block `*[term]: expansion`
   parser + paragraph transformer that marks every
   inline occurrence of the term, ~400 LOC
@@ -144,7 +150,10 @@ Fixable features and their fixes:
   autolink
 - heading IDs: remove `{#id}`
 - strikethrough: remove `~~`
-- task lists: `- [ ]` to `- `
+- task lists: for `-`, `*`, or `+` bullets with
+  `[ ]`, `[x]`, or `[X]`, remove the task marker
+  and keep the bullet (e.g. `- [ ]` to `- `,
+  `* [x]` to `* `)
 - superscript: remove `^`
 - subscript: remove `~`
 

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -100,7 +100,7 @@ struct directly.
 ### Custom extensions
 
 Five extensions in
-[internal/rules/markdownflavor/ext/](../internal/rules/markdownflavor/ext/):
+`internal/rules/markdownflavor/ext/`:
 
 - **SuperscriptExt**: inline `^text^`, ~150 LOC
 - **SubscriptExt**: inline `~text~`, distinguishes

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -32,10 +32,20 @@ has footnotes, heading IDs, and more. Pandoc adds
 math, citations, and sub/superscript. MyST targets
 Sphinx with roles and directives.
 
-Twelve features vary across flavors: tables, task
-lists, strikethrough, bare-URL autolinks, footnotes,
-heading
-IDs, math, and five others.
+Twelve features vary across flavors:
+
+- tables
+- task lists
+- strikethrough
+- bare-URL autolinks
+- footnotes
+- heading IDs
+- inline math
+- block math
+- definition lists
+- abbreviations
+- superscript
+- subscript
 
 ### Detection approach
 

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -126,12 +126,20 @@ brackets"). Severity: `warning`.
 
 ### Auto-fix
 
-Fixable: bare-URL autolinks (wrap in `<url>`), heading
-IDs
-(remove `{#id}`), strikethrough (remove `~~`), task
-lists (`- [ ]` to `- `), superscript (remove `^`),
-subscript (remove `~`). Non-fixable: tables,
-footnotes, definition lists, math, abbreviations.
+Fixable features and their fixes:
+
+- bare-URL autolinks with a scheme: wrap in `<url>`.
+  `www.`-only URLs become `[url](http://url)` since
+  `<www.example.com>` is not a valid CommonMark
+  autolink
+- heading IDs: remove `{#id}`
+- strikethrough: remove `~~`
+- task lists: `- [ ]` to `- `
+- superscript: remove `^`
+- subscript: remove `~`
+
+Non-fixable: tables, footnotes, definition lists,
+math, abbreviations.
 
 ## Tasks
 
@@ -165,14 +173,25 @@ footnotes, definition lists, math, abbreviations.
       strikethrough, and bare-URL autolinks
 - [ ] `flavor: gfm` accepts GFM features, flags
       footnotes, definition lists, math
-- [ ] `flavor: goldmark` accepts Goldmark defaults,
-      flags Pandoc-only features
+- [ ] `flavor: goldmark` accepts tables, task lists,
+      strikethrough, and bare-URL autolinks; flags
+      footnotes, definition lists, superscript,
+      subscript, math blocks, math inline, and
+      abbreviations
 - [ ] Error messages name the unsupported feature and
       the configured flavor
 - [ ] `mdsmith fix` auto-fixes fixable features
 - [ ] Non-fixable features produce diagnostics only
 - [ ] Invalid flavor name produces a config error
 - [ ] Rule is disabled by default (opt-in)
-- [ ] Rule does not conflict with MDS012
+- [ ] With `flavor: commonmark`, MDS034 reports bare
+      URLs as unsupported autolinks
+- [ ] With `flavor: gfm` or `flavor: goldmark`,
+      MDS034 treats bare URLs as supported syntax and
+      does not emit a flavor diagnostic for them
+- [ ] MDS034 does not emit a duplicate bare-URL
+      diagnostic when the configured flavor supports
+      bare URLs, even if MDS012 still enforces its
+      own bare-URL style rule
 - [ ] All tests pass: `go test ./...`
 - [ ] `go tool golangci-lint run` reports no issues

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -23,7 +23,8 @@ when files move between tools.
 
 Nine common flavors exist. CommonMark is the strict
 baseline. GFM adds tables, task lists, strikethrough,
-and autolinks. Goldmark supports GFM-like features
+and bare-URL autolinks. Goldmark supports GFM-like
+features
 plus optional footnotes, heading IDs, and math.
 
 Other flavors add more features. PHP Markdown Extra
@@ -32,7 +33,8 @@ math, citations, and sub/superscript. MyST targets
 Sphinx with roles and directives.
 
 Twelve features vary across flavors: tables, task
-lists, strikethrough, autolinks, footnotes, heading
+lists, strikethrough, bare-URL autolinks, footnotes,
+heading
 IDs, math, and five others.
 
 ### Detection approach
@@ -124,7 +126,8 @@ brackets"). Severity: `warning`.
 
 ### Auto-fix
 
-Fixable: autolinks (wrap in `<url>`), heading IDs
+Fixable: bare-URL autolinks (wrap in `<url>`), heading
+IDs
 (remove `{#id}`), strikethrough (remove `~~`), task
 lists (`- [ ]` to `- `), superscript (remove `^`),
 subscript (remove `~`). Non-fixable: tables,
@@ -159,7 +162,7 @@ footnotes, definition lists, math, abbreviations.
 ## Acceptance Criteria
 
 - [ ] `flavor: commonmark` flags tables, task lists,
-      strikethrough, and autolinks
+      strikethrough, and bare-URL autolinks
 - [ ] `flavor: gfm` accepts GFM features, flags
       footnotes, definition lists, math
 - [ ] `flavor: goldmark` accepts Goldmark defaults,

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -92,8 +92,8 @@ and re-parses the source. The main parse tree used by
 other rules is untouched. This gives precise AST
 detection without risk to existing rules.
 
-For the four features without a goldmark built-in
-extension, three approaches were compared:
+For the five features without a goldmark built-in
+extension, two approaches were compared:
 
 1. **Third-party extensions.** Existing packages
    (`litao91/goldmark-mathjax`, `bowman2001/
@@ -104,7 +104,7 @@ extension, three approaches were compared:
    rendering pipeline. None are suitable as
    dependencies.
 
-2. **Custom goldmark extensions (chosen for 4).**
+2. **Custom goldmark extensions (chosen for all 5).**
    Based on the existing PI block parser (~160 LOC),
    the cost per extension is:
    - Inline delimiter (`^sup^`, `~sub~`): ~200 LOC
@@ -114,27 +114,32 @@ extension, three approaches were compared:
      ~250 LOC with tests (Pandoc-style: `$` must be
      preceded by whitespace/start-of-line and not
      followed by whitespace)
-   - Block def + inline (`*[abbr]: ...`): ~400 LOC
-     with tests
+   - Block def + inline text matching
+     (`*[abbr]: ...`): ~400 LOC with tests
 
-3. **Regex on raw source (chosen for 1).**
-   Abbreviation definitions (`*[abbr]: ...`) are
-   unambiguous at line-start. We only need to detect
-   the definition line to flag "you're using
-   abbreviation syntax" -- not every inline occurrence.
-   A full abbreviation extension (~400 LOC) would need
-   block-level definitions plus inline text
-   replacement, which is disproportionate for
-   detection-only.
+All five need parser extensions because diagnostics
+must report every occurrence of unsupported syntax
+with precise line/column. Regex cannot reliably find
+inline uses of abbreviations, math delimiters, or
+super/subscript inside code spans, link URLs, or
+other raw contexts.
 
-Math-inline cannot use regex: `$` is common in prose
-(`costs $5`), environment variables (`$PATH`), and
-code. A regex cannot distinguish `$x+y$` from
-`costs $5 and $10` without delimiter-state tracking.
-A parser extension with Pandoc-style flanking rules
-solves this correctly.
+Abbreviations are the most complex: the extension
+must parse `*[abbr]: Full Text` definitions at block
+level, then scan paragraph text nodes for every
+occurrence of the abbreviated term. Each occurrence
+produces a diagnostic -- without this, a user would
+see one warning on the definition but have no idea
+how much of their document depends on abbreviation
+expansion.
 
-Final detection strategy per feature:
+Math-inline also requires a parser extension: `$` is
+common in prose (`costs $5`), environment variables
+(`$PATH`), and code. Pandoc-style flanking rules
+(opening `$` preceded by whitespace and not followed
+by whitespace) disambiguate correctly.
+
+Final detection strategy -- all features via AST:
 
 | Feature | Goldmark built-in | Detection |
 |---|---|---|
@@ -149,15 +154,11 @@ Final detection strategy per feature:
 | Subscript | custom inline ext | AST |
 | Math block | custom block ext | AST |
 | Math inline | custom inline ext | AST |
-| Abbreviations | none | regex |
+| Abbreviations | custom block+inline ext | AST |
 
-Custom extensions for superscript, subscript,
-math-block, and math-inline (4 total, ~850 LOC with
-tests). Regex only for abbreviation definitions --
-the definition syntax `*[abbr]:` is unambiguous at
-block level, and detecting usage sites would require
-full abbreviation expansion (not needed for
-flavor-checking).
+Custom extensions: 5 total, ~1250 LOC with tests.
+All 12 features detected via AST -- no regex
+fallback.
 
 The dual-parser cost is one extra parse per file, only
 when MDS034 is enabled. Since MDS034 is opt-in and
@@ -233,7 +234,7 @@ any feature where `flavor.Features[f] == false`.
 
 MDS034 builds a second goldmark parser in its
 `Check()` method with all built-in extensions plus
-four custom detection-only extensions:
+five custom detection-only extensions:
 
 ```go
 p := goldmark.New(
@@ -250,6 +251,7 @@ p := goldmark.New(
         &SubscriptExt{},
         &MathBlockExt{},
         &MathInlineExt{},
+        &AbbreviationExt{},
     ),
     goldmark.WithParserOptions(
         parser.WithAttribute(),
@@ -260,10 +262,10 @@ p := goldmark.New(
 This parser is created once per rule instance (not
 per file) and reused across calls.
 
-#### Custom goldmark extensions (4)
+#### Custom goldmark extensions (5)
 
-Four small detection-only extensions, ~850 LOC total
-with tests. They live in
+Five detection-only extensions, ~1250 LOC total with
+tests. They live in
 `internal/rules/markdownflavor/ext/` and follow
 the same pattern as the existing PI block parser
 (`internal/lint/pi.go`):
@@ -295,11 +297,23 @@ start-of-line, or punctuation. This disambiguates
 `$x+y$` (math) from `costs $5` (currency).
 ~150 LOC parser + ~50 LOC node definition.
 
+**AbbreviationExt** -- block parser for `*[abbr]: ...`
+definitions plus a paragraph transformer that finds
+inline occurrences. Two components:
+- Block parser: detects `*[term]: expansion` at line
+  start, produces `KindAbbreviationDef` nodes, stores
+  the term string.
+- Paragraph transformer: after block parsing, walks
+  paragraph text segments and marks occurrences of
+  each defined term as `KindAbbreviationUse` nodes.
+~250 LOC parser + ~100 LOC node definitions + ~50
+LOC transformer. The most complex custom extension.
+
 These extensions only need to parse (produce AST
 nodes with source positions). They do not need to
 render -- mdsmith never renders HTML.
 
-#### AST detectors (11 features)
+#### AST detectors (12 features -- all via AST)
 
 Walk the extension-aware AST and collect node
 locations:
@@ -318,27 +332,14 @@ locations:
 - Subscript: custom `KindSubscript`
 - Math block: custom `KindMathBlock`
 - Math inline: custom `KindMathInline`
+- Abbreviation definitions: custom `KindAbbreviationDef`
+- Abbreviation uses: custom `KindAbbreviationUse`
 
 Each detector returns `(line, column)` pairs from
-the node segment positions.
-
-#### Regex detector (1 feature)
-
-Only abbreviation definitions use regex:
-
-- **Abbreviations** (`*[abbr]: ...`):
-  `^\*\[[^\]]+\]:` at line start. The definition
-  syntax is unambiguous at block level. A full
-  abbreviation extension (~400 LOC) would need block
-  definitions plus inline text replacement --
-  disproportionate when we only need to detect "this
-  file uses abbreviation syntax." We do not attempt
-  to detect inline *usage* of abbreviations (every
-  occurrence of the abbreviated text) since flagging
-  the definition is sufficient.
-
-The code-fence skip logic reuses the fenced-code-block
-line ranges from the main AST.
+the node segment positions. Abbreviation uses flag
+every occurrence of the abbreviated term in paragraph
+text so the user sees the full scope of the
+dependency.
 
 #### Error messages
 
@@ -417,40 +418,44 @@ subset. Non-fixable features produce diagnostics only.
    by whitespace, closing `$` not preceded by
    whitespace, opening preceded by whitespace or
    punctuation or start-of-line)
-6. Add tests for the four custom extensions in
+6. Write custom `AbbreviationExt` block parser,
+   paragraph transformer, `KindAbbreviationDef` and
+   `KindAbbreviationUse` AST nodes in
+   `internal/rules/markdownflavor/ext/abbreviation.go`
+7. Add tests for the five custom extensions in
    `internal/rules/markdownflavor/ext/*_test.go`;
    math-inline tests must cover `$x+y$` (math) vs
-   `costs $5` (currency) vs `$PATH` (env var)
-7. Build dual parser: create a second goldmark parser
+   `costs $5` (currency) vs `$PATH` (env var);
+   abbreviation tests must verify that every inline
+   occurrence of a defined term is flagged
+8. Build dual parser: create a second goldmark parser
    with built-in extensions (`Table`, `Strikethrough`,
    `TaskList`, `Footnote`, `DefinitionList`,
-   `Linkify`, `WithAttribute`) plus the four custom
+   `Linkify`, `WithAttribute`) plus the five custom
    extensions
-8. Add AST-based detectors for 11 features (tables,
-   task lists, strikethrough, autolinks, footnotes,
-   definition lists, heading attributes, superscript,
-   subscript, math block, math inline)
-9. Add regex-based detector for abbreviation
-   definitions (1 feature) with fenced-code-block
-   skip logic
-9. Implement `rule.go` with `Check()` that re-parses
-   with the dual parser, runs all detectors, and
-   reports unsupported features
-10. Implement `Fix()` for fixable features (autolinks,
+9. Add AST-based detectors for all 12 features
+   (tables, task lists, strikethrough, autolinks,
+   footnotes, definition lists, heading attributes,
+   superscript, subscript, math block, math inline,
+   abbreviations)
+10. Implement `rule.go` with `Check()` that re-parses
+    with the dual parser, runs all detectors, and
+    reports unsupported features
+11. Implement `Fix()` for fixable features (autolinks,
     strikethrough, heading IDs, task lists,
     superscript, subscript)
-11. Add `Configurable` interface: `ApplySettings` for
+12. Add `Configurable` interface: `ApplySettings` for
     `flavor` string, validate against known flavors
-12. Register rule as MDS034 `markdown-flavor` in
+13. Register rule as MDS034 `markdown-flavor` in
     category `meta`
-13. Add test fixtures:
+14. Add test fixtures:
     `internal/rules/MDS034-markdown-flavor/bad/` with
     files using each unsupported feature per flavor,
     `good/` with files using only supported features,
     `fixed/` with expected auto-fix output
-14. Add rule README following
+15. Add rule README following
     `internal/rules/proto.md` schema
-15. Document the rule in `docs/reference/cli.md` and
+16. Document the rule in `docs/reference/cli.md` and
     add a note to
     `docs/guides/directives/enforcing-structure.md`
     about flavor enforcement

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -104,18 +104,35 @@ extension, three approaches were compared:
    rendering pipeline. None are suitable as
    dependencies.
 
-2. **Custom goldmark extensions (chosen for 3).**
+2. **Custom goldmark extensions (chosen for 4).**
    Based on the existing PI block parser (~160 LOC),
    the cost per extension is:
    - Inline delimiter (`^sup^`, `~sub~`): ~200 LOC
      with tests
    - Block fence (`$$...$$`): ~200 LOC with tests
+   - Inline delimiter with flanking rules (`$...$`):
+     ~250 LOC with tests (Pandoc-style: `$` must be
+     preceded by whitespace/start-of-line and not
+     followed by whitespace)
    - Block def + inline (`*[abbr]: ...`): ~400 LOC
      with tests
 
-3. **Regex with code-fence skip (chosen for 2).**
-   Best for ambiguous syntax (`$` is common in prose)
-   and rare features (abbreviations).
+3. **Regex on raw source (chosen for 1).**
+   Abbreviation definitions (`*[abbr]: ...`) are
+   unambiguous at line-start. We only need to detect
+   the definition line to flag "you're using
+   abbreviation syntax" -- not every inline occurrence.
+   A full abbreviation extension (~400 LOC) would need
+   block-level definitions plus inline text
+   replacement, which is disproportionate for
+   detection-only.
+
+Math-inline cannot use regex: `$` is common in prose
+(`costs $5`), environment variables (`$PATH`), and
+code. A regex cannot distinguish `$x+y$` from
+`costs $5 and $10` without delimiter-state tracking.
+A parser extension with Pandoc-style flanking rules
+solves this correctly.
 
 Final detection strategy per feature:
 
@@ -131,15 +148,16 @@ Final detection strategy per feature:
 | Superscript | custom inline ext | AST |
 | Subscript | custom inline ext | AST |
 | Math block | custom block ext | AST |
-| Math inline | none | regex |
+| Math inline | custom inline ext | AST |
 | Abbreviations | none | regex |
 
-Custom extensions for superscript, subscript, and
-math-block because their delimiters are unambiguous
-and the extensions are small (~200 LOC each). Regex
-for math-inline (`$` is too common for reliable
-parsing) and abbreviations (rarest feature, ~400 LOC
-extension not worth it for detection-only).
+Custom extensions for superscript, subscript,
+math-block, and math-inline (4 total, ~850 LOC with
+tests). Regex only for abbreviation definitions --
+the definition syntax `*[abbr]:` is unambiguous at
+block level, and detecting usage sites would require
+full abbreviation expansion (not needed for
+flavor-checking).
 
 The dual-parser cost is one extra parse per file, only
 when MDS034 is enabled. Since MDS034 is opt-in and
@@ -215,7 +233,7 @@ any feature where `flavor.Features[f] == false`.
 
 MDS034 builds a second goldmark parser in its
 `Check()` method with all built-in extensions plus
-three custom detection-only extensions:
+four custom detection-only extensions:
 
 ```go
 p := goldmark.New(
@@ -231,6 +249,7 @@ p := goldmark.New(
         &SuperscriptExt{},
         &SubscriptExt{},
         &MathBlockExt{},
+        &MathInlineExt{},
     ),
     goldmark.WithParserOptions(
         parser.WithAttribute(),
@@ -241,9 +260,9 @@ p := goldmark.New(
 This parser is created once per rule instance (not
 per file) and reused across calls.
 
-#### Custom goldmark extensions (3)
+#### Custom goldmark extensions (4)
 
-Three small detection-only extensions, each ~200 LOC
+Four small detection-only extensions, ~850 LOC total
 with tests. They live in
 `internal/rules/markdownflavor/ext/` and follow
 the same pattern as the existing PI block parser
@@ -266,11 +285,21 @@ byte `$`. Produces `KindMathBlock` AST nodes.
 Modeled on goldmark's built-in fenced-code-block
 parser. ~110 LOC parser + ~50 LOC node definition.
 
+**MathInlineExt** -- inline delimiter parser for
+`$...$`. Implements `parser.InlineParser` with
+trigger byte `$`. Uses Pandoc-style flanking rules:
+opening `$` must not be followed by whitespace,
+closing `$` must not be preceded by whitespace, and
+the opening `$` must be preceded by whitespace,
+start-of-line, or punctuation. This disambiguates
+`$x+y$` (math) from `costs $5` (currency).
+~150 LOC parser + ~50 LOC node definition.
+
 These extensions only need to parse (produce AST
 nodes with source positions). They do not need to
 render -- mdsmith never renders HTML.
 
-#### AST detectors (10 features)
+#### AST detectors (11 features)
 
 Walk the extension-aware AST and collect node
 locations:
@@ -288,29 +317,28 @@ locations:
 - Superscript: custom `KindSuperscript`
 - Subscript: custom `KindSubscript`
 - Math block: custom `KindMathBlock`
+- Math inline: custom `KindMathInline`
 
 Each detector returns `(line, column)` pairs from
 the node segment positions.
 
-#### Regex detectors (2 features)
+#### Regex detector (1 feature)
 
-Regex fallback only for features where a goldmark
-extension is impractical:
+Only abbreviation definitions use regex:
 
-- **Math inline** (`$...$`): `\$[^$\n]+\$` not
-  preceded/followed by `$`. The `$` character is too
-  common in prose and code for reliable delimiter
-  parsing; regex with context-awareness (skip code
-  blocks, check surrounding chars) is more precise
-  for detection.
 - **Abbreviations** (`*[abbr]: ...`):
-  `^\*\[[^\]]+\]:`. Rarest feature (~400 LOC
-  extension for block def + inline replacement). Not
-  worth the investment for detection-only.
+  `^\*\[[^\]]+\]:` at line start. The definition
+  syntax is unambiguous at block level. A full
+  abbreviation extension (~400 LOC) would need block
+  definitions plus inline text replacement --
+  disproportionate when we only need to detect "this
+  file uses abbreviation syntax." We do not attempt
+  to detect inline *usage* of abbreviations (every
+  occurrence of the abbreviated text) since flagging
+  the definition is sufficient.
 
 The code-fence skip logic reuses the fenced-code-block
-line ranges from the AST (which the main parser
-already identifies correctly as CommonMark).
+line ranges from the main AST.
 
 #### Error messages
 
@@ -382,19 +410,28 @@ subset. Non-fixable features produce diagnostics only.
 4. Write custom `MathBlockExt` block parser and
    `KindMathBlock` AST node in
    `internal/rules/markdownflavor/ext/mathblock.go`
-5. Add tests for the three custom extensions in
-   `internal/rules/markdownflavor/ext/*_test.go`
-6. Build dual parser: create a second goldmark parser
+5. Write custom `MathInlineExt` inline parser and
+   `KindMathInline` AST node in
+   `internal/rules/markdownflavor/ext/mathinline.go`
+   (Pandoc-style flanking: opening `$` not followed
+   by whitespace, closing `$` not preceded by
+   whitespace, opening preceded by whitespace or
+   punctuation or start-of-line)
+6. Add tests for the four custom extensions in
+   `internal/rules/markdownflavor/ext/*_test.go`;
+   math-inline tests must cover `$x+y$` (math) vs
+   `costs $5` (currency) vs `$PATH` (env var)
+7. Build dual parser: create a second goldmark parser
    with built-in extensions (`Table`, `Strikethrough`,
    `TaskList`, `Footnote`, `DefinitionList`,
-   `Linkify`, `WithAttribute`) plus the three custom
+   `Linkify`, `WithAttribute`) plus the four custom
    extensions
-7. Add AST-based detectors for 10 features (tables,
+8. Add AST-based detectors for 11 features (tables,
    task lists, strikethrough, autolinks, footnotes,
    definition lists, heading attributes, superscript,
-   subscript, math block)
-8. Add regex-based detectors for math inline and
-   abbreviations (2 features) with fenced-code-block
+   subscript, math block, math inline)
+9. Add regex-based detector for abbreviation
+   definitions (1 feature) with fenced-code-block
    skip logic
 9. Implement `rule.go` with `Check()` that re-parses
    with the dual parser, runs all detectors, and

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -12,10 +12,10 @@ summary: >-
 
 ## Goal
 
-Let users declare a target Markdown flavor so mdsmith
-can flag syntax that the target renderer will not
-understand, preventing silent rendering failures when
-files move between tools.
+Let users declare a target Markdown flavor. mdsmith
+then flags syntax that the target renderer will not
+understand. This prevents silent rendering failures
+when files move between tools.
 
 ## Background
 
@@ -25,19 +25,15 @@ Nine common flavors exist. CommonMark is the strict
 baseline. GFM adds tables, task lists, strikethrough,
 and autolinks. Goldmark supports GFM-like features
 plus optional footnotes, heading IDs, and math.
-PHP Markdown Extra adds footnotes, abbreviations,
-definition lists, and heading IDs. Pandoc extends
-CommonMark with footnotes, definition lists, math,
-citations, superscript, subscript, and heading IDs.
-MyST adds directives, roles, and math. MultiMarkdown
-supports metadata, footnotes, citations, and math.
-GitLab extends GFM with math, diagrams, and
-footnotes. R Markdown builds on Pandoc.
 
-Twelve syntax features differ across flavors: tables,
-task lists, strikethrough, autolinks, footnotes,
-definition lists, math inline, math block, heading
-IDs, abbreviations, superscript, and subscript.
+Other flavors add more features. PHP Markdown Extra
+has footnotes, heading IDs, and more. Pandoc adds
+math, citations, and sub/superscript. MyST targets
+Sphinx with roles and directives.
+
+Twelve features vary across flavors: tables, task
+lists, strikethrough, autolinks, footnotes, heading
+IDs, math, and five others.
 
 ### Detection approach
 
@@ -94,13 +90,12 @@ p := goldmark.New(
 )
 ```
 
-MDS034 should not store the parser on the rule struct
-directly: mdsmith clones configurable rules per file
-([internal/rule/clone.go](../internal/rule/clone.go)),
-so each clone would rebuild the parser. Cache the
-parser in package-level shared state instead, such as
-a `sync.Once` singleton or a flavor-keyed map guarded
-by a mutex.
+mdsmith clones configurable rules per file
+([internal/rule/clone.go](../internal/rule/clone.go)).
+Storing the parser on the rule struct would rebuild it
+per clone. Cache the parser in package-level shared
+state instead (e.g. a `sync.Once` singleton or a
+flavor-keyed map guarded by a mutex).
 
 ### Custom extensions
 

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -63,20 +63,58 @@ enabled by default.
 
 ### Detection approach
 
-mdsmith already parses with Goldmark. The strategy is:
+mdsmith's main parser (`internal/lint/file.go`)
+uses only default CommonMark block/inline parsers
+plus the custom PI parser. No goldmark extensions
+are enabled -- not even tables or strikethrough.
+This means the current AST represents pure CommonMark;
+extension syntax (tables, footnotes, etc.) appears
+as plain paragraph text.
 
-1. **AST-based detection**: Parse with all extensions
-   enabled. Walk the AST and flag node types that the
-   target flavor does not support (tables, task lists,
-   strikethrough).
-2. **Regex-based detection**: Some features (footnote
-   references, definition lists, math delimiters,
-   heading IDs, abbreviations) may not produce AST
-   nodes if the extension is not loaded. Detect these
-   via line-level regex patterns on the raw source.
-3. **Combined**: Use AST when the extension is loaded,
-   fall back to regex for extensions Goldmark does not
-   support.
+Three approaches were evaluated:
+
+**A. Enable all extensions in the main parser.**
+Precise AST detection, but changes the parse tree
+for every rule. A pipe-table that currently parses
+as a paragraph would become a `Table` node, risking
+breakage in MDS001-MDS033. Rejected.
+
+**B. Regex-only on raw source.** Zero parser impact,
+but produces false positives inside fenced code
+blocks, inline code spans, and HTML comments. Would
+need to re-implement code-block-awareness. Fragile
+for ambiguous syntax like `:` (definition lists) and
+`$` (math). Rejected as primary approach.
+
+**C. Dual parser (chosen).** MDS034 creates a second
+goldmark parser with all available extensions enabled
+and re-parses the source. The main parse tree used by
+other rules is untouched. This gives precise AST
+detection without risk to existing rules. Regex
+fallback is used only for the few features without a
+goldmark extension (math, abbreviations,
+superscript/subscript).
+
+Goldmark built-in extensions cover most features with
+zero third-party dependencies:
+
+| Feature | Goldmark built-in | Detection |
+|---|---|---|
+| Tables | `extension.Table` | AST |
+| Strikethrough | `extension.Strikethrough` | AST |
+| Task lists | `extension.TaskList` | AST |
+| Footnotes | `extension.Footnote` | AST |
+| Definition lists | `extension.DefinitionList` | AST |
+| Heading IDs | `parser.WithAttribute()` | AST |
+| Autolinks | `extension.Linkify` | AST |
+| Math | none built-in | regex |
+| Abbreviations | none built-in | regex |
+| Superscript | none built-in | regex |
+| Subscript | none built-in | regex |
+
+The dual-parser cost is one extra parse per file, only
+when MDS034 is enabled. Since MDS034 is opt-in and
+disabled by default, most users pay zero cost.
 
 ### Scoping: which flavors to support initially
 
@@ -144,27 +182,66 @@ Each flavor is a set of booleans. Checking is: walk
 the document, identify which features are used, report
 any feature where `flavor.Features[f] == false`.
 
-#### Detection methods
+#### Dual parser setup
 
-Each feature needs a detector. Two kinds:
+MDS034 builds a second goldmark parser in its
+`Check()` method:
 
-1. **AST detector**: Walks parsed AST nodes.
-   - Tables: `ast.KindTable` (from goldmark extension)
-   - Task lists: check `ast.ListItem` with
-     `HasChildren` of type checkbox
-   - Strikethrough: `extension.KindStrikethrough`
+```go
+p := goldmark.New(
+    goldmark.WithExtensions(
+        extension.Table,
+        extension.Strikethrough,
+        extension.TaskList,
+        extension.Footnote,
+        extension.DefinitionList,
+        extension.Linkify,
+    ),
+    goldmark.WithParserOptions(
+        parser.WithAttribute(),
+    ),
+)
+```
 
-2. **Regex detector**: Scans raw source lines.
-   - Footnotes: `^\[\^[^\]]+\]:` (definition) and
-     `\[\^[^\]]+\]` (reference)
-   - Definition lists: line starting with `:` after
-     a term line
-   - Math: `\$[^$]+\$` (inline), `^\$\$$` (block)
-   - Heading IDs: `\{#[\w-]+\}` at end of heading
-   - Abbreviations: `^\*\[[^\]]+\]:`
-   - Superscript: `\^[^^]+\^`
-   - Subscript: `~[^~]+~` (careful not to conflict
-     with strikethrough `~~`)
+This parser is created once per rule instance (not
+per file) and reused across calls.
+
+#### AST detectors (7 features)
+
+Walk the extension-aware AST and collect node
+locations:
+
+- Tables: `ast.KindTable`
+- Strikethrough: `extast.KindStrikethrough`
+- Task lists: `extast.KindTaskCheckBox`
+- Footnotes: `extast.KindFootnote` and
+  `extast.KindFootnoteBacklink`
+- Definition lists: `extast.KindDefinitionList`
+- Heading attributes: heading nodes with non-empty
+  `Attribute()` list
+- Autolinks: `extast.KindLinkify` (bare URL nodes
+  created by the linkify extension)
+
+Each detector returns `(line, column)` pairs from
+the node segment positions.
+
+#### Regex detectors (4 features)
+
+For features without a goldmark extension, scan raw
+source lines. Skip lines inside fenced code blocks
+and inline code spans to avoid false positives:
+
+- Math inline: `\$[^$\n]+\$` not preceded/followed
+  by `$`
+- Math block: `^\$\$$` as opening/closing fence
+- Abbreviations: `^\*\[[^\]]+\]:`
+- Superscript: `\^[^^]+\^` (not inside code)
+- Subscript: `(?<![~])~(?!~)[^~\n]+~(?!~)` to avoid
+  matching strikethrough `~~`
+
+The code-fence skip logic reuses the fenced-code-block
+line ranges from the AST (which the main parser
+already identifies correctly as CommonMark).
 
 #### Error messages
 
@@ -226,27 +303,34 @@ subset. Non-fixable features produce diagnostics only.
 
 1. Add feature enum and flavor registry in
    `internal/rules/markdownflavor/features.go`
-2. Add AST-based detectors for tables, task lists,
-   strikethrough, autolinks
-3. Add regex-based detectors for footnotes, definition
-   lists, math, heading IDs, abbreviations,
-   superscript, subscript
-4. Implement `rule.go` with `Check()` that runs
-   detectors and reports unsupported features
-5. Implement `Fix()` for fixable features (autolinks,
+2. Build dual parser: create a second goldmark parser
+   with `extension.Table`, `extension.Strikethrough`,
+   `extension.TaskList`, `extension.Footnote`,
+   `extension.DefinitionList`, `extension.Linkify`,
+   and `parser.WithAttribute()` enabled
+3. Add AST-based detectors for tables, task lists,
+   strikethrough, autolinks, footnotes, definition
+   lists, heading attributes (7 features via AST)
+4. Add regex-based detectors for math, abbreviations,
+   superscript, subscript (4 features via regex) with
+   fenced-code-block skip logic
+5. Implement `rule.go` with `Check()` that re-parses
+   with the dual parser, runs all detectors, and
+   reports unsupported features
+6. Implement `Fix()` for fixable features (autolinks,
    strikethrough, heading IDs, task lists)
-6. Add `Configurable` interface: `ApplySettings` for
+7. Add `Configurable` interface: `ApplySettings` for
    `flavor` string, validate against known flavors
-7. Register rule as MDS034 `markdown-flavor` in
+8. Register rule as MDS034 `markdown-flavor` in
    category `meta`
-8. Add test fixtures:
+9. Add test fixtures:
    `internal/rules/MDS034-markdown-flavor/bad/` with
    files using each unsupported feature per flavor,
    `good/` with files using only supported features,
    `fixed/` with expected auto-fix output
-9. Add rule README following
-   `internal/rules/proto.md` schema
-10. Document the rule in `docs/reference/cli.md` and
+10. Add rule README following
+    `internal/rules/proto.md` schema
+11. Document the rule in `docs/reference/cli.md` and
     add a note to
     `docs/guides/directives/enforcing-structure.md`
     about flavor enforcement

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -19,234 +19,66 @@ files move between tools.
 
 ## Background
 
-### Common Markdown flavors
+### Flavors and syntax differences
 
-Different renderers support different supersets of
-Markdown. The most common flavors, ordered roughly by
-adoption:
+Nine common flavors exist: CommonMark (strict
+baseline), GFM (tables, task lists, strikethrough,
+autolinks), Goldmark (GFM-like + optional footnotes,
+heading IDs, math), PHP Markdown Extra (footnotes,
+abbreviations, definition lists, heading IDs), Pandoc
+(footnotes, definition lists, math, citations,
+superscript, subscript, heading IDs), MyST
+(directives, roles, math), MultiMarkdown (metadata,
+footnotes, citations, math), GitLab (GFM + math,
+diagrams, footnotes), and R Markdown (Pandoc-based).
 
-| Flavor | Base | Key extensions | Used by |
-|---|---|---|---|
-| CommonMark | --- | strict baseline spec | many renderers |
-| GFM | CommonMark | tables, task lists, strikethrough, autolinks | GitHub, VS Code |
-| Goldmark (default) | CommonMark | tables, strikethrough, task lists, linkify | Hugo, mdsmith |
-| PHP Markdown Extra | original | footnotes, abbreviations, definition lists, fenced code, tables, heading IDs | WordPress plugins |
-| Pandoc | CommonMark | footnotes, definition lists, math, citations, superscript, subscript, heading IDs | academic, Pandoc |
-| MyST | CommonMark | directives, roles, cross-references, math | Sphinx, Jupyter Book |
-| MultiMarkdown | original | metadata, footnotes, citations, math, tables, cross-references | MultiMarkdown app |
-| GitLab | GFM | math blocks, diagrams (Mermaid), footnotes, inline diff | GitLab |
-| R Markdown | Pandoc | code chunks, inline R, output formats | RStudio, knitr |
-
-### Syntax differences that matter
-
-These are the concrete features that differ across
-flavors and can be detected at the AST or text level:
-
-| Feature | CommonMark | GFM | Goldmark | Pandoc | PHP Extra |
-|---|---|---|---|---|---|
-| Tables | no | yes | yes | yes | yes |
-| Task lists | no | yes | yes | no | no |
-| Strikethrough `~~x~~` | no | yes | yes | yes | no |
-| Autolinks (bare URLs) | no | yes | yes | no | no |
-| Footnotes `[^1]` | no | no | ext | yes | yes |
-| Definition lists | no | no | no | yes | yes |
-| Math `$x$` / `$$x$$` | no | partial | ext | yes | no |
-| Heading IDs `{#id}` | no | no | ext | yes | yes |
-| Abbreviations | no | no | no | no | yes |
-| Superscript `^x^` | no | no | no | yes | no |
-| Subscript `~x~` | no | no | no | yes | no |
-| Pipe tables only | --- | yes | yes | yes | yes |
-| Grid tables | no | no | no | yes | no |
-
-"ext" means available as a Goldmark extension but not
-enabled by default.
+Twelve syntax features differ across flavors: tables,
+task lists, strikethrough, autolinks, footnotes,
+definition lists, math inline, math block, heading
+IDs, abbreviations, superscript, and subscript.
 
 ### Detection approach
 
-mdsmith's main parser (`internal/lint/file.go`)
-uses only default CommonMark block/inline parsers
-plus the custom PI parser. No goldmark extensions
-are enabled -- not even tables or strikethrough.
-This means the current AST represents pure CommonMark;
-extension syntax (tables, footnotes, etc.) appears
-as plain paragraph text.
+The main parser uses only CommonMark block/inline
+parsers. Enabling extensions there would change the
+AST for all 33 existing rules. Regex-only detection
+produces false positives inside code blocks and inline
+code spans.
 
-Three approaches were evaluated:
+**Chosen: dual parser.** MDS034 re-parses with a
+second goldmark parser that has all extensions enabled.
+The main parse tree stays untouched.
 
-**A. Enable all extensions in the main parser.**
-Precise AST detection, but changes the parse tree
-for every rule. A pipe-table that currently parses
-as a paragraph would become a `Table` node, risking
-breakage in MDS001-MDS033. Rejected.
-
-**B. Regex-only on raw source.** Zero parser impact,
-but produces false positives inside fenced code
-blocks, inline code spans, and HTML comments. Would
-need to re-implement code-block-awareness. Fragile
-for ambiguous syntax like `:` (definition lists) and
-`$` (math). Rejected as primary approach.
-
-**C. Dual parser (chosen).** MDS034 creates a second
-goldmark parser with all available extensions enabled
-and re-parses the source. The main parse tree used by
-other rules is untouched. This gives precise AST
-detection without risk to existing rules.
-
-For the five features without a goldmark built-in
-extension, two approaches were compared:
-
-1. **Third-party extensions.** Existing packages
-   (`litao91/goldmark-mathjax`, `bowman2001/
-   goldmark-supersubscript`, `zmtcreative/
-   gm-abbreviations`) are abandoned or have zero
-   adoption. Hugo's `hugo-goldmark-extensions` is
-   actively maintained but tightly coupled to Hugo's
-   rendering pipeline. None are suitable as
-   dependencies.
-
-2. **Custom goldmark extensions (chosen for all 5).**
-   Based on the existing PI block parser (~160 LOC),
-   the cost per extension is:
-   - Inline delimiter (`^sup^`, `~sub~`): ~200 LOC
-     with tests
-   - Block fence (`$$...$$`): ~200 LOC with tests
-   - Inline delimiter with flanking rules (`$...$`):
-     ~250 LOC with tests (Pandoc-style: `$` must be
-     preceded by whitespace/start-of-line and not
-     followed by whitespace)
-   - Block def + inline text matching
-     (`*[abbr]: ...`): ~400 LOC with tests
-
-All five need parser extensions because diagnostics
-must report every occurrence of unsupported syntax
-with precise line/column. Regex cannot reliably find
-inline uses of abbreviations, math delimiters, or
-super/subscript inside code spans, link URLs, or
-other raw contexts.
-
-Abbreviations are the most complex: the extension
-must parse `*[abbr]: Full Text` definitions at block
-level, then scan paragraph text nodes for every
-occurrence of the abbreviated term. Each occurrence
-produces a diagnostic -- without this, a user would
-see one warning on the definition but have no idea
-how much of their document depends on abbreviation
-expansion.
-
-Math-inline also requires a parser extension: `$` is
-common in prose (`costs $5`), environment variables
-(`$PATH`), and code. Pandoc-style flanking rules
-(opening `$` preceded by whitespace and not followed
-by whitespace) disambiguate correctly.
-
-Final detection strategy -- all features via AST:
-
-| Feature | Goldmark built-in | Detection |
-|---|---|---|
-| Tables | `extension.Table` | AST |
-| Strikethrough | `extension.Strikethrough` | AST |
-| Task lists | `extension.TaskList` | AST |
-| Footnotes | `extension.Footnote` | AST |
-| Definition lists | `extension.DefinitionList` | AST |
-| Heading IDs | `parser.WithAttribute()` | AST |
-| Autolinks | `extension.Linkify` | AST |
-| Superscript | custom inline ext | AST |
-| Subscript | custom inline ext | AST |
-| Math block | custom block ext | AST |
-| Math inline | custom inline ext | AST |
-| Abbreviations | custom block+inline ext | AST |
-
-Custom extensions: 5 total, ~1250 LOC with tests.
-All 12 features detected via AST -- no regex
-fallback.
-
-The dual-parser cost is one extra parse per file, only
-when MDS034 is enabled. Since MDS034 is opt-in and
-disabled by default, most users pay zero cost.
-
-### Scoping: which flavors to support initially
-
-Start with the three most common targets:
-
-- **commonmark** -- strict CommonMark spec
-- **gfm** -- GitHub Flavored Markdown
-- **goldmark** -- Goldmark with default extensions
-
-These cover the vast majority of use cases. Additional
-flavors (Pandoc, PHP Extra, MyST) can be added later
-by extending the feature table.
+Goldmark has built-in extensions for 7 features. Five
+custom detection-only extensions (~1250 LOC total with
+tests) cover the rest. All 12 features detected via
+AST -- no regex fallback. Each custom extension
+follows the PI block parser pattern
+(`internal/lint/pi.go`).
 
 ## Design
 
-### New rule: MDS034 `markdown-flavor`
-
-Category: `meta`. Enabled by default: no (opt-in).
-
-#### Configuration
+### Configuration
 
 ```yaml
 rules:
   markdown-flavor:
     flavor: gfm  # commonmark | gfm | goldmark
-    # Future: allow per-feature overrides
-    # allow:
-    #   - footnotes
-    # deny:
-    #   - autolinks
 ```
 
-#### Flavor feature registry
+Category: `meta`. Disabled by default (opt-in).
 
-Internal data structure mapping each flavor to its
-supported feature set:
-
-```go
-// internal/rules/markdownflavor/features.go
-
-type Feature string
-
-const (
-    Tables        Feature = "tables"
-    TaskLists     Feature = "task-lists"
-    Strikethrough Feature = "strikethrough"
-    Autolinks     Feature = "autolinks"
-    Footnotes     Feature = "footnotes"
-    DefinitionLists Feature = "definition-lists"
-    MathInline    Feature = "math-inline"
-    MathBlock     Feature = "math-block"
-    HeadingIDs    Feature = "heading-ids"
-    Abbreviations Feature = "abbreviations"
-    Superscript   Feature = "superscript"
-    Subscript     Feature = "subscript"
-)
-
-type Flavor struct {
-    Name     string
-    Features map[Feature]bool
-}
-```
-
-Each flavor is a set of booleans. Checking is: walk
-the document, identify which features are used, report
-any feature where `flavor.Features[f] == false`.
-
-#### Dual parser setup
-
-MDS034 builds a second goldmark parser in its
-`Check()` method with all built-in extensions plus
-five custom detection-only extensions:
+### Dual parser
 
 ```go
 p := goldmark.New(
     goldmark.WithExtensions(
-        // Built-in extensions
         extension.Table,
         extension.Strikethrough,
         extension.TaskList,
         extension.Footnote,
         extension.DefinitionList,
         extension.Linkify,
-        // Custom detection-only extensions
         &SuperscriptExt{},
         &SubscriptExt{},
         &MathBlockExt{},
@@ -259,229 +91,80 @@ p := goldmark.New(
 )
 ```
 
-This parser is created once per rule instance (not
-per file) and reused across calls.
+Created once per rule instance, reused across files.
 
-#### Custom goldmark extensions (5)
+### Custom extensions
 
-Five detection-only extensions, ~1250 LOC total with
-tests. They live in
-`internal/rules/markdownflavor/ext/` and follow
-the same pattern as the existing PI block parser
-(`internal/lint/pi.go`):
+Five extensions in
+`internal/rules/markdownflavor/ext/`:
 
-**SuperscriptExt** -- inline delimiter parser for
-`^text^`. Implements `parser.InlineParser` with
-trigger byte `^`. Produces `KindSuperscript` AST
-nodes. ~100 LOC parser + ~50 LOC node definition.
+- **SuperscriptExt**: inline `^text^`, ~150 LOC
+- **SubscriptExt**: inline `~text~`, distinguishes
+  single `~` from strikethrough `~~`, ~170 LOC
+- **MathBlockExt**: block `$$...$$` fence, ~160 LOC
+- **MathInlineExt**: inline `$...$` with Pandoc-style
+  flanking (opening `$` preceded by whitespace, not
+  followed by whitespace), ~200 LOC
+- **AbbreviationExt**: block `*[term]: expansion`
+  parser + paragraph transformer that marks every
+  inline occurrence of the term, ~400 LOC
 
-**SubscriptExt** -- inline delimiter parser for
-`~text~`. Implements `parser.InlineParser` with
-trigger byte `~`. Must distinguish single `~` from
-double `~~` (strikethrough). ~120 LOC parser + ~50
-LOC node definition.
+Detection-only (no HTML rendering needed).
 
-**MathBlockExt** -- block parser for `$$...$$`
-fences. Implements `parser.BlockParser` with trigger
-byte `$`. Produces `KindMathBlock` AST nodes.
-Modeled on goldmark's built-in fenced-code-block
-parser. ~110 LOC parser + ~50 LOC node definition.
+### Error messages
 
-**MathInlineExt** -- inline delimiter parser for
-`$...$`. Implements `parser.InlineParser` with
-trigger byte `$`. Uses Pandoc-style flanking rules:
-opening `$` must not be followed by whitespace,
-closing `$` must not be preceded by whitespace, and
-the opening `$` must be preceded by whitespace,
-start-of-line, or punctuation. This disambiguates
-`$x+y$` (math) from `costs $5` (currency).
-~150 LOC parser + ~50 LOC node definition.
+Each message names the feature and the flavor:
+`{feature} is not supported by {flavor}`. Fixable
+features include a suggestion (e.g. "wrap in angle
+brackets"). Severity: `warning`.
 
-**AbbreviationExt** -- block parser for `*[abbr]: ...`
-definitions plus a paragraph transformer that finds
-inline occurrences. Two components:
-- Block parser: detects `*[term]: expansion` at line
-  start, produces `KindAbbreviationDef` nodes, stores
-  the term string.
-- Paragraph transformer: after block parsing, walks
-  paragraph text segments and marks occurrences of
-  each defined term as `KindAbbreviationUse` nodes.
-~250 LOC parser + ~100 LOC node definitions + ~50
-LOC transformer. The most complex custom extension.
+### Auto-fix
 
-These extensions only need to parse (produce AST
-nodes with source positions). They do not need to
-render -- mdsmith never renders HTML.
-
-#### AST detectors (12 features -- all via AST)
-
-Walk the extension-aware AST and collect node
-locations:
-
-- Tables: `ast.KindTable`
-- Strikethrough: `extast.KindStrikethrough`
-- Task lists: `extast.KindTaskCheckBox`
-- Footnotes: `extast.KindFootnote` and
-  `extast.KindFootnoteBacklink`
-- Definition lists: `extast.KindDefinitionList`
-- Heading attributes: heading nodes with non-empty
-  `Attribute()` list
-- Autolinks: `extast.KindLinkify` (bare URL nodes
-  created by the linkify extension)
-- Superscript: custom `KindSuperscript`
-- Subscript: custom `KindSubscript`
-- Math block: custom `KindMathBlock`
-- Math inline: custom `KindMathInline`
-- Abbreviation definitions: custom `KindAbbreviationDef`
-- Abbreviation uses: custom `KindAbbreviationUse`
-
-Each detector returns `(line, column)` pairs from
-the node segment positions. Abbreviation uses flag
-every occurrence of the abbreviated term in paragraph
-text so the user sees the full scope of the
-dependency.
-
-#### Error messages
-
-Messages follow existing mdsmith conventions: state
-the concrete constraint, name the feature.
-
-| Feature | Message |
-|---|---|
-| Tables | `table syntax is not supported by {flavor}; convert to a list or use a supported renderer` |
-| Task lists | `task list (checkbox) syntax is not supported by {flavor}` |
-| Strikethrough | `strikethrough (~~text~~) is not supported by {flavor}` |
-| Autolinks | `bare URL autolink is not supported by {flavor}; wrap in angle brackets or use [text](url)` |
-| Footnotes | `footnote syntax is not supported by {flavor}` |
-| Definition lists | `definition list syntax is not supported by {flavor}` |
-| Math (inline) | `inline math ($...$) is not supported by {flavor}` |
-| Math (block) | `block math ($$...$$) is not supported by {flavor}` |
-| Heading IDs | `heading ID attribute ({#id}) is not supported by {flavor}` |
-| Abbreviations | `abbreviation definition is not supported by {flavor}` |
-| Superscript | `superscript (^text^) is not supported by {flavor}` |
-| Subscript | `subscript (~text~) is not supported by {flavor}` |
-
-All messages use severity `warning` (the syntax may
-still render as plain text, it just won't render as
-intended).
-
-#### Auto-fix
-
-Some features have natural downgrades; others do not.
-
-| Feature | Fixable | Fix strategy |
-|---|---|---|
-| Autolinks | yes | Wrap bare URL in `<url>` or `[url](url)` |
-| Strikethrough | partial | Remove `~~` delimiters, leaving plain text |
-| Heading IDs | yes | Remove `{#id}` suffix from heading line |
-| Tables | no | No lossless downgrade exists |
-| Task lists | partial | Replace `- [ ]` / `- [x]` with `- ` / `- (done) ` |
-| Footnotes | no | Requires restructuring (inline the note) -- too complex for auto-fix |
-| Definition lists | no | Requires restructuring |
-| Math | no | No Markdown-only fallback |
-| Abbreviations | no | Requires expanding all uses |
-| Superscript | partial | Remove `^` delimiters |
-| Subscript | partial | Remove `~` delimiters |
-
-The rule implements `FixableRule` for the fixable
-subset. Non-fixable features produce diagnostics only.
-
-### Integration with existing rules
-
-- **MDS012 (no-bare-urls)** already flags bare URLs.
-  When `markdown-flavor: { flavor: gfm }` is set,
-  autolinks are valid GFM. The flavor rule should not
-  conflict: MDS012 is about style preference, MDS034
-  is about spec compliance. Document the interaction
-  in the rule README.
-- **MDS002 (heading-style)** is orthogonal -- both ATX
-  and setext are valid in all flavors.
+Fixable: autolinks (wrap in `<url>`), heading IDs
+(remove `{#id}`), strikethrough (remove `~~`), task
+lists (`- [ ]` to `- `), superscript (remove `^`),
+subscript (remove `~`). Non-fixable: tables,
+footnotes, definition lists, math, abbreviations.
 
 ## Tasks
 
 1. Add feature enum and flavor registry in
    `internal/rules/markdownflavor/features.go`
-2. Write custom `SuperscriptExt` inline parser and
-   `KindSuperscript` AST node in
+2. Write `SuperscriptExt` inline parser in
    `internal/rules/markdownflavor/ext/superscript.go`
-3. Write custom `SubscriptExt` inline parser and
-   `KindSubscript` AST node in
+3. Write `SubscriptExt` inline parser in
    `internal/rules/markdownflavor/ext/subscript.go`
-   (handle `~` vs `~~` disambiguation)
-4. Write custom `MathBlockExt` block parser and
-   `KindMathBlock` AST node in
+4. Write `MathBlockExt` block parser in
    `internal/rules/markdownflavor/ext/mathblock.go`
-5. Write custom `MathInlineExt` inline parser and
-   `KindMathInline` AST node in
+5. Write `MathInlineExt` inline parser in
    `internal/rules/markdownflavor/ext/mathinline.go`
-   (Pandoc-style flanking: opening `$` not followed
-   by whitespace, closing `$` not preceded by
-   whitespace, opening preceded by whitespace or
-   punctuation or start-of-line)
-6. Write custom `AbbreviationExt` block parser,
-   paragraph transformer, `KindAbbreviationDef` and
-   `KindAbbreviationUse` AST nodes in
+6. Write `AbbreviationExt` block parser + paragraph
+   transformer in
    `internal/rules/markdownflavor/ext/abbreviation.go`
-7. Add tests for the five custom extensions in
-   `internal/rules/markdownflavor/ext/*_test.go`;
-   math-inline tests must cover `$x+y$` (math) vs
-   `costs $5` (currency) vs `$PATH` (env var);
-   abbreviation tests must verify that every inline
-   occurrence of a defined term is flagged
-8. Build dual parser: create a second goldmark parser
-   with built-in extensions (`Table`, `Strikethrough`,
-   `TaskList`, `Footnote`, `DefinitionList`,
-   `Linkify`, `WithAttribute`) plus the five custom
-   extensions
+7. Add tests for all five custom extensions
+8. Build dual parser with built-in + custom extensions
 9. Add AST-based detectors for all 12 features
-   (tables, task lists, strikethrough, autolinks,
-   footnotes, definition lists, heading attributes,
-   superscript, subscript, math block, math inline,
-   abbreviations)
-10. Implement `rule.go` with `Check()` that re-parses
-    with the dual parser, runs all detectors, and
-    reports unsupported features
-11. Implement `Fix()` for fixable features (autolinks,
-    strikethrough, heading IDs, task lists,
-    superscript, subscript)
-12. Add `Configurable` interface: `ApplySettings` for
-    `flavor` string, validate against known flavors
-13. Register rule as MDS034 `markdown-flavor` in
-    category `meta`
-14. Add test fixtures:
-    `internal/rules/MDS034-markdown-flavor/bad/` with
-    files using each unsupported feature per flavor,
-    `good/` with files using only supported features,
-    `fixed/` with expected auto-fix output
-15. Add rule README following
-    `internal/rules/proto.md` schema
-16. Document the rule in `docs/reference/cli.md` and
-    add a note to
-    `docs/guides/directives/enforcing-structure.md`
-    about flavor enforcement
+10. Implement `rule.go` with `Check()` and `Fix()`
+11. Add `Configurable` interface for `flavor` setting
+12. Register as MDS034 in category `meta`
+13. Add test fixtures in
+    `internal/rules/MDS034-markdown-flavor/`
+14. Add rule README and update docs
 
 ## Acceptance Criteria
 
-- [ ] `markdown-flavor: { flavor: commonmark }` flags
-      tables, task lists, strikethrough, and autolinks
-- [ ] `markdown-flavor: { flavor: gfm }` accepts
-      tables, task lists, strikethrough, autolinks but
-      flags footnotes, definition lists, math
-- [ ] `markdown-flavor: { flavor: goldmark }` accepts
-      Goldmark default extensions, flags Pandoc-only
-      features
-- [ ] Error messages name the specific unsupported
-      feature and the configured flavor
-- [ ] `mdsmith fix` auto-fixes autolinks (wraps in
-      angle brackets) and heading IDs (removes `{#id}`)
-- [ ] `mdsmith fix` auto-fixes strikethrough and task
-      lists with plain-text fallbacks
-- [ ] Non-fixable features (tables, footnotes, math)
-      produce diagnostics only, no fix attempted
-- [ ] Invalid flavor name in config produces a clear
-      configuration error
+- [ ] `flavor: commonmark` flags tables, task lists,
+      strikethrough, and autolinks
+- [ ] `flavor: gfm` accepts GFM features, flags
+      footnotes, definition lists, math
+- [ ] `flavor: goldmark` accepts Goldmark defaults,
+      flags Pandoc-only features
+- [ ] Error messages name the unsupported feature and
+      the configured flavor
+- [ ] `mdsmith fix` auto-fixes fixable features
+- [ ] Non-fixable features produce diagnostics only
+- [ ] Invalid flavor name produces a config error
 - [ ] Rule is disabled by default (opt-in)
 - [ ] Rule does not conflict with MDS012
-      (no-bare-urls) when both are enabled
 - [ ] All tests pass: `go test ./...`
 - [ ] `go tool golangci-lint run` reports no issues

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -54,7 +54,7 @@ custom detection-only extensions (~1250 LOC total with
 tests) cover the rest. All 12 features detected via
 AST -- no regex fallback. Each custom extension
 follows the PI block parser pattern
-(`internal/lint/pi.go`).
+([internal/lint/pi.go](../internal/lint/pi.go)).
 
 ## Design
 
@@ -91,12 +91,16 @@ p := goldmark.New(
 )
 ```
 
-Created once per rule instance, reused across files.
+Because mdsmith clones configurable rules per file
+([internal/rule/clone.go](../internal/rule/clone.go)),
+MDS034 should cache the parser via `sync.Once` or a
+flavor-keyed cache rather than storing it on the rule
+struct directly.
 
 ### Custom extensions
 
 Five extensions in
-`internal/rules/markdownflavor/ext/`:
+[internal/rules/markdownflavor/ext/](../internal/rules/markdownflavor/ext/):
 
 - **SuperscriptExt**: inline `^text^`, ~150 LOC
 - **SubscriptExt**: inline `~text~`, distinguishes
@@ -145,7 +149,8 @@ footnotes, definition lists, math, abbreviations.
 8. Build dual parser with built-in + custom extensions
 9. Add AST-based detectors for all 12 features
 10. Implement `rule.go` with `Check()` and `Fix()`
-11. Add `Configurable` interface for `flavor` setting
+11. Implement `rule.Configurable` for MDS034: add
+    `ApplySettings` and `DefaultSettings` for `flavor`
 12. Register as MDS034 in category `meta`
 13. Add test fixtures in
     `internal/rules/MDS034-markdown-flavor/`

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -23,9 +23,11 @@ when files move between tools.
 
 Nine common flavors exist. CommonMark is the strict
 baseline. GFM adds tables, task lists, strikethrough,
-and bare-URL autolinks. Goldmark supports GFM-like
-features
-plus optional footnotes, heading IDs, and math.
+and bare-URL autolinks. For MDS034, `goldmark` means
+the default Goldmark configuration: GFM-like tables,
+task lists, strikethrough, bare-URL autolinks, and
+heading IDs, but not optional footnote,
+definition-list, or math extensions.
 
 Other flavors add more features. PHP Markdown Extra
 has footnotes, heading IDs, and more. Pandoc adds

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -21,16 +21,18 @@ files move between tools.
 
 ### Flavors and syntax differences
 
-Nine common flavors exist: CommonMark (strict
-baseline), GFM (tables, task lists, strikethrough,
-autolinks), Goldmark (GFM-like + optional footnotes,
-heading IDs, math), PHP Markdown Extra (footnotes,
-abbreviations, definition lists, heading IDs), Pandoc
-(footnotes, definition lists, math, citations,
-superscript, subscript, heading IDs), MyST
-(directives, roles, math), MultiMarkdown (metadata,
-footnotes, citations, math), GitLab (GFM + math,
-diagrams, footnotes), and R Markdown (Pandoc-based).
+Nine common flavors exist. CommonMark is the strict
+baseline. GFM adds tables, task lists, strikethrough,
+and autolinks. Goldmark supports GFM-like features
+plus optional footnotes, heading IDs, and math.
+PHP Markdown Extra adds footnotes, abbreviations,
+definition lists, and heading IDs. Pandoc extends
+CommonMark with footnotes, definition lists, math,
+citations, superscript, subscript, and heading IDs.
+MyST adds directives, roles, and math. MultiMarkdown
+supports metadata, footnotes, citations, and math.
+GitLab extends GFM with math, diagrams, and
+footnotes. R Markdown builds on Pandoc.
 
 Twelve syntax features differ across flavors: tables,
 task lists, strikethrough, autolinks, footnotes,
@@ -54,7 +56,8 @@ custom detection-only extensions (~1250 LOC total with
 tests) cover the rest. All 12 features detected via
 AST -- no regex fallback. Each custom extension
 follows the PI block parser pattern
-([internal/lint/pi.go](../internal/lint/pi.go)).
+([internal/lint/pi_parser.go](../internal/lint/pi_parser.go),
+[internal/lint/pi.go](../internal/lint/pi.go)).
 
 ## Design
 
@@ -91,11 +94,13 @@ p := goldmark.New(
 )
 ```
 
-Because mdsmith clones configurable rules per file
+MDS034 should not store the parser on the rule struct
+directly: mdsmith clones configurable rules per file
 ([internal/rule/clone.go](../internal/rule/clone.go)),
-MDS034 should cache the parser via `sync.Once` or a
-flavor-keyed cache rather than storing it on the rule
-struct directly.
+so each clone would rebuild the parser. Cache the
+parser in package-level shared state instead, such as
+a `sync.Once` singleton or a flavor-keyed map guarded
+by a mutex.
 
 ### Custom extensions
 

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -1,0 +1,278 @@
+---
+id: 86
+title: Markdown flavor validation
+status: "🔲"
+summary: >-
+  New rule MDS034 that validates Markdown files against
+  a declared flavor (CommonMark, GFM, Goldmark, etc.)
+  and reports unsupported syntax with auto-fix where
+  possible.
+---
+# Markdown flavor validation
+
+## Goal
+
+Let users declare a target Markdown flavor so mdsmith
+can flag syntax that the target renderer will not
+understand, preventing silent rendering failures when
+files move between tools.
+
+## Background
+
+### Common Markdown flavors
+
+Different renderers support different supersets of
+Markdown. The most common flavors, ordered roughly by
+adoption:
+
+| Flavor | Base | Key extensions | Used by |
+|---|---|---|---|
+| CommonMark | --- | strict baseline spec | many renderers |
+| GFM | CommonMark | tables, task lists, strikethrough, autolinks | GitHub, VS Code |
+| Goldmark (default) | CommonMark | tables, strikethrough, task lists, linkify | Hugo, mdsmith |
+| PHP Markdown Extra | original | footnotes, abbreviations, definition lists, fenced code, tables, heading IDs | WordPress plugins |
+| Pandoc | CommonMark | footnotes, definition lists, math, citations, superscript, subscript, heading IDs | academic, Pandoc |
+| MyST | CommonMark | directives, roles, cross-references, math | Sphinx, Jupyter Book |
+| MultiMarkdown | original | metadata, footnotes, citations, math, tables, cross-references | MultiMarkdown app |
+| GitLab | GFM | math blocks, diagrams (Mermaid), footnotes, inline diff | GitLab |
+| R Markdown | Pandoc | code chunks, inline R, output formats | RStudio, knitr |
+
+### Syntax differences that matter
+
+These are the concrete features that differ across
+flavors and can be detected at the AST or text level:
+
+| Feature | CommonMark | GFM | Goldmark | Pandoc | PHP Extra |
+|---|---|---|---|---|---|
+| Tables | no | yes | yes | yes | yes |
+| Task lists | no | yes | yes | no | no |
+| Strikethrough `~~x~~` | no | yes | yes | yes | no |
+| Autolinks (bare URLs) | no | yes | yes | no | no |
+| Footnotes `[^1]` | no | no | ext | yes | yes |
+| Definition lists | no | no | no | yes | yes |
+| Math `$x$` / `$$x$$` | no | partial | ext | yes | no |
+| Heading IDs `{#id}` | no | no | ext | yes | yes |
+| Abbreviations | no | no | no | no | yes |
+| Superscript `^x^` | no | no | no | yes | no |
+| Subscript `~x~` | no | no | no | yes | no |
+| Pipe tables only | --- | yes | yes | yes | yes |
+| Grid tables | no | no | no | yes | no |
+
+"ext" means available as a Goldmark extension but not
+enabled by default.
+
+### Detection approach
+
+mdsmith already parses with Goldmark. The strategy is:
+
+1. **AST-based detection**: Parse with all extensions
+   enabled. Walk the AST and flag node types that the
+   target flavor does not support (tables, task lists,
+   strikethrough).
+2. **Regex-based detection**: Some features (footnote
+   references, definition lists, math delimiters,
+   heading IDs, abbreviations) may not produce AST
+   nodes if the extension is not loaded. Detect these
+   via line-level regex patterns on the raw source.
+3. **Combined**: Use AST when the extension is loaded,
+   fall back to regex for extensions Goldmark does not
+   support.
+
+### Scoping: which flavors to support initially
+
+Start with the three most common targets:
+
+- **commonmark** -- strict CommonMark spec
+- **gfm** -- GitHub Flavored Markdown
+- **goldmark** -- Goldmark with default extensions
+
+These cover the vast majority of use cases. Additional
+flavors (Pandoc, PHP Extra, MyST) can be added later
+by extending the feature table.
+
+## Design
+
+### New rule: MDS034 `markdown-flavor`
+
+Category: `meta`. Enabled by default: no (opt-in).
+
+#### Configuration
+
+```yaml
+rules:
+  markdown-flavor:
+    flavor: gfm  # commonmark | gfm | goldmark
+    # Future: allow per-feature overrides
+    # allow:
+    #   - footnotes
+    # deny:
+    #   - autolinks
+```
+
+#### Flavor feature registry
+
+Internal data structure mapping each flavor to its
+supported feature set:
+
+```go
+// internal/rules/markdownflavor/features.go
+
+type Feature string
+
+const (
+    Tables        Feature = "tables"
+    TaskLists     Feature = "task-lists"
+    Strikethrough Feature = "strikethrough"
+    Autolinks     Feature = "autolinks"
+    Footnotes     Feature = "footnotes"
+    DefinitionLists Feature = "definition-lists"
+    MathInline    Feature = "math-inline"
+    MathBlock     Feature = "math-block"
+    HeadingIDs    Feature = "heading-ids"
+    Abbreviations Feature = "abbreviations"
+    Superscript   Feature = "superscript"
+    Subscript     Feature = "subscript"
+)
+
+type Flavor struct {
+    Name     string
+    Features map[Feature]bool
+}
+```
+
+Each flavor is a set of booleans. Checking is: walk
+the document, identify which features are used, report
+any feature where `flavor.Features[f] == false`.
+
+#### Detection methods
+
+Each feature needs a detector. Two kinds:
+
+1. **AST detector**: Walks parsed AST nodes.
+   - Tables: `ast.KindTable` (from goldmark extension)
+   - Task lists: check `ast.ListItem` with
+     `HasChildren` of type checkbox
+   - Strikethrough: `extension.KindStrikethrough`
+
+2. **Regex detector**: Scans raw source lines.
+   - Footnotes: `^\[\^[^\]]+\]:` (definition) and
+     `\[\^[^\]]+\]` (reference)
+   - Definition lists: line starting with `:` after
+     a term line
+   - Math: `\$[^$]+\$` (inline), `^\$\$$` (block)
+   - Heading IDs: `\{#[\w-]+\}` at end of heading
+   - Abbreviations: `^\*\[[^\]]+\]:`
+   - Superscript: `\^[^^]+\^`
+   - Subscript: `~[^~]+~` (careful not to conflict
+     with strikethrough `~~`)
+
+#### Error messages
+
+Messages follow existing mdsmith conventions: state
+the concrete constraint, name the feature.
+
+| Feature | Message |
+|---|---|
+| Tables | `table syntax is not supported by {flavor}; convert to a list or use a supported renderer` |
+| Task lists | `task list (checkbox) syntax is not supported by {flavor}` |
+| Strikethrough | `strikethrough (~~text~~) is not supported by {flavor}` |
+| Autolinks | `bare URL autolink is not supported by {flavor}; wrap in angle brackets or use [text](url)` |
+| Footnotes | `footnote syntax is not supported by {flavor}` |
+| Definition lists | `definition list syntax is not supported by {flavor}` |
+| Math (inline) | `inline math ($...$) is not supported by {flavor}` |
+| Math (block) | `block math ($$...$$) is not supported by {flavor}` |
+| Heading IDs | `heading ID attribute ({#id}) is not supported by {flavor}` |
+| Abbreviations | `abbreviation definition is not supported by {flavor}` |
+| Superscript | `superscript (^text^) is not supported by {flavor}` |
+| Subscript | `subscript (~text~) is not supported by {flavor}` |
+
+All messages use severity `warning` (the syntax may
+still render as plain text, it just won't render as
+intended).
+
+#### Auto-fix
+
+Some features have natural downgrades; others do not.
+
+| Feature | Fixable | Fix strategy |
+|---|---|---|
+| Autolinks | yes | Wrap bare URL in `<url>` or `[url](url)` |
+| Strikethrough | partial | Remove `~~` delimiters, leaving plain text |
+| Heading IDs | yes | Remove `{#id}` suffix from heading line |
+| Tables | no | No lossless downgrade exists |
+| Task lists | partial | Replace `- [ ]` / `- [x]` with `- ` / `- (done) ` |
+| Footnotes | no | Requires restructuring (inline the note) -- too complex for auto-fix |
+| Definition lists | no | Requires restructuring |
+| Math | no | No Markdown-only fallback |
+| Abbreviations | no | Requires expanding all uses |
+| Superscript | partial | Remove `^` delimiters |
+| Subscript | partial | Remove `~` delimiters |
+
+The rule implements `FixableRule` for the fixable
+subset. Non-fixable features produce diagnostics only.
+
+### Integration with existing rules
+
+- **MDS012 (no-bare-urls)** already flags bare URLs.
+  When `markdown-flavor: { flavor: gfm }` is set,
+  autolinks are valid GFM. The flavor rule should not
+  conflict: MDS012 is about style preference, MDS034
+  is about spec compliance. Document the interaction
+  in the rule README.
+- **MDS002 (heading-style)** is orthogonal -- both ATX
+  and setext are valid in all flavors.
+
+## Tasks
+
+1. Add feature enum and flavor registry in
+   `internal/rules/markdownflavor/features.go`
+2. Add AST-based detectors for tables, task lists,
+   strikethrough, autolinks
+3. Add regex-based detectors for footnotes, definition
+   lists, math, heading IDs, abbreviations,
+   superscript, subscript
+4. Implement `rule.go` with `Check()` that runs
+   detectors and reports unsupported features
+5. Implement `Fix()` for fixable features (autolinks,
+   strikethrough, heading IDs, task lists)
+6. Add `Configurable` interface: `ApplySettings` for
+   `flavor` string, validate against known flavors
+7. Register rule as MDS034 `markdown-flavor` in
+   category `meta`
+8. Add test fixtures:
+   `internal/rules/MDS034-markdown-flavor/bad/` with
+   files using each unsupported feature per flavor,
+   `good/` with files using only supported features,
+   `fixed/` with expected auto-fix output
+9. Add rule README following
+   `internal/rules/proto.md` schema
+10. Document the rule in `docs/reference/cli.md` and
+    add a note to
+    `docs/guides/directives/enforcing-structure.md`
+    about flavor enforcement
+
+## Acceptance Criteria
+
+- [ ] `markdown-flavor: { flavor: commonmark }` flags
+      tables, task lists, strikethrough, and autolinks
+- [ ] `markdown-flavor: { flavor: gfm }` accepts
+      tables, task lists, strikethrough, autolinks but
+      flags footnotes, definition lists, math
+- [ ] `markdown-flavor: { flavor: goldmark }` accepts
+      Goldmark default extensions, flags Pandoc-only
+      features
+- [ ] Error messages name the specific unsupported
+      feature and the configured flavor
+- [ ] `mdsmith fix` auto-fixes autolinks (wraps in
+      angle brackets) and heading IDs (removes `{#id}`)
+- [ ] `mdsmith fix` auto-fixes strikethrough and task
+      lists with plain-text fallbacks
+- [ ] Non-fixable features (tables, footnotes, math)
+      produce diagnostics only, no fix attempted
+- [ ] Invalid flavor name in config produces a clear
+      configuration error
+- [ ] Rule is disabled by default (opt-in)
+- [ ] Rule does not conflict with MDS012
+      (no-bare-urls) when both are enabled
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -170,14 +170,20 @@ math, abbreviations.
 ## Acceptance Criteria
 
 - [ ] `flavor: commonmark` flags tables, task lists,
-      strikethrough, and bare-URL autolinks
-- [ ] `flavor: gfm` accepts GFM features, flags
-      footnotes, definition lists, math
-- [ ] `flavor: goldmark` accepts tables, task lists,
-      strikethrough, and bare-URL autolinks; flags
-      footnotes, definition lists, superscript,
+      strikethrough, bare-URL autolinks, footnotes,
+      definition lists, heading IDs, superscript,
       subscript, math blocks, math inline, and
       abbreviations
+- [ ] `flavor: gfm` accepts tables, task lists,
+      strikethrough, and bare-URL autolinks; flags
+      footnotes, definition lists, heading IDs,
+      superscript, subscript, math blocks, math
+      inline, and abbreviations
+- [ ] `flavor: goldmark` accepts tables, task lists,
+      strikethrough, bare-URL autolinks, and heading
+      IDs; flags footnotes, definition lists,
+      superscript, subscript, math blocks, math
+      inline, and abbreviations
 - [ ] Error messages name the unsupported feature and
       the configured flavor
 - [ ] `mdsmith fix` auto-fixes fixable features

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -23,8 +23,8 @@ when files move between tools.
 
 Nine common flavors exist. CommonMark is the strict
 baseline. GFM adds tables, task lists, strikethrough,
-and bare-URL autolinks. For MDS034, `goldmark` means
-the default Goldmark configuration: GFM-like tables,
+and bare-URL autolinks. For MDS034, `goldmark` is
+an mdsmith-defined profile: Goldmark plus tables,
 task lists, strikethrough, bare-URL autolinks, and
 heading IDs, but not optional footnote,
 definition-list, or math extensions.
@@ -183,10 +183,12 @@ math, abbreviations.
 10. Implement `rule.go` with `Check()` and `Fix()`
 11. Implement `rule.Configurable` for MDS034: add
     `ApplySettings` and `DefaultSettings` for `flavor`
-12. Register as MDS034 in category `meta`
-13. Add test fixtures in
+12. Implement `rule.Defaultable` (`EnabledByDefault`
+    returns `false`) so the rule is opt-in
+13. Register as MDS034 in category `meta`
+14. Add test fixtures in
     `internal/rules/MDS034-markdown-flavor/`
-14. Add rule README and update docs
+15. Add rule README and update docs
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

This PR adds a comprehensive design plan for MDS034, a new opt-in rule that validates Markdown files against a declared flavor (CommonMark, GFM, or Goldmark) and reports unsupported syntax with auto-fix capabilities where applicable.

## Key Changes

- **New planning document** (`plan/86_markdown-flavor-validation.md`): Detailed specification for MDS034 including:
  - Background on common Markdown flavors and their syntax differences
  - Evaluation of three detection approaches, selecting a dual-parser strategy to avoid impacting existing rules
  - Justification for five custom goldmark extensions (~1250 LOC total) to detect features without built-in support (superscript, subscript, math inline/block, abbreviations)
  - Feature registry mapping each flavor to supported syntax
  - AST-based detection for all 12 features (tables, task lists, strikethrough, autolinks, footnotes, definition lists, heading IDs, superscript, subscript, math block, math inline, abbreviations)
  - Auto-fix strategy for fixable features (autolinks, strikethrough, heading IDs, task lists, superscript, subscript)
  - Clear error messages and integration notes with existing rules

- **Updated PLAN.md**: Added entry for plan #86 in the roadmap

## Notable Implementation Details

- **Dual parser approach**: MDS034 creates a second goldmark parser with all extensions enabled, leaving the main parser untouched to avoid breaking existing rules (MDS001-MDS033)
- **Custom extensions**: Five detection-only extensions follow the pattern of the existing PI block parser, producing AST nodes with precise source positions for diagnostics
- **Abbreviation complexity**: The abbreviation extension includes both block-level definition parsing and paragraph-level occurrence detection to report every use of abbreviated terms
- **Math inline disambiguation**: Uses Pandoc-style flanking rules to distinguish `$x+y$` (math) from `costs $5` (currency) and `$PATH` (environment variables)
- **Opt-in by default**: Rule is disabled by default, so most users pay zero performance cost
- **Comprehensive test coverage**: Includes 16 detailed acceptance criteria and test fixture requirements

https://claude.ai/code/session_01NXoimZjyg4zz55zx1YXi7W