### PR TITLE
Add configurable file-size limit to prevent OOM

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -38,7 +38,7 @@ footer: |
 | 78  | 🔲     | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                         |
 | 79  | ✅     | [Nested front-matter access](plan/79_nested-frontmatter-access.md)                                              |
 | 80  | ✅     | [Terminal recording in README](plan/80_terminal-recording-readme.md)                                            |
-| 81  | 🔲     | [OOM mitigation: configurable file-size limit](plan/81_oom-file-size-limit.md)                                  |
+| 81  | ✅     | [OOM mitigation: configurable file-size limit](plan/81_oom-file-size-limit.md)                                  |
 | 82  | ✅     | [YAML billion-laughs mitigation](plan/82_yaml-billion-laughs.md)                                                |
 | 83  | 🔳     | [Security hardening batch](plan/83_security-hardening-batch.md)                                                 |
 | 84  | 🔲     | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                      |

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1523,3 +1523,31 @@ func TestCheckStdin_MaxInputSize_Unlimited(t *testing.T) {
 		"check", "--max-input-size", "0", "-")
 	assert.Equal(t, 0, exitCode, "expected exit code 0 with unlimited stdin")
 }
+
+func TestMetricsRank_MaxInputSize_InvalidValue(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "a.md", "# Hello\n")
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"metrics", "rank", "--max-input-size", "bad-value", "a.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for invalid size")
+	assert.Contains(t, stderr, "invalid max-input-size")
+}
+
+func TestMetricsRank_MaxInputSize_RespectsConfig(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("rules: {}\nmax-input-size: \"5\"\n"), 0o644,
+	))
+
+	writeFixture(t, dir, "a.md", "# Hello world\n")
+
+	// Config sets 5-byte limit → 14-byte file should fail.
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"metrics", "rank", "a.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for oversized file")
+	assert.Contains(t, stderr, "file too large")
+}

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1390,3 +1390,88 @@ func TestE2E_MergeDriver_SectionMarkersInsideConflict_Preserved(t *testing.T) {
 	assert.Contains(t, content, "=======", "expected ======= separator preserved")
 	assert.Contains(t, content, ">>>>>>>", "expected >>>>>>> marker preserved")
 }
+
+// ── max-input-size ──────────────────────────────────────────────
+
+func TestCheck_MaxInputSize_ExceedingLimit(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+
+	// Create a file larger than 100 bytes.
+	bigContent := make([]byte, 200)
+	for i := range bigContent {
+		bigContent[i] = 'x'
+	}
+	bigContent[0] = '#'
+	bigContent[1] = ' '
+	writeFixture(t, dir, "big.md", string(bigContent))
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"check", "--max-input-size", "100", "big.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for oversized file")
+	assert.Contains(t, stderr, "file too large")
+	assert.Contains(t, stderr, "max 100")
+}
+
+func TestCheck_MaxInputSize_UnderLimit(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+
+	writeFixture(t, dir, "small.md", "# Hello\n")
+
+	_, _, exitCode := runBinaryInDir(t, dir, "",
+		"check", "--max-input-size", "2MB", "small.md")
+	assert.Equal(t, 0, exitCode, "expected exit code 0 for small file")
+}
+
+func TestCheck_MaxInputSize_Unlimited(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+
+	writeFixture(t, dir, "any.md", "# Hello\n")
+
+	_, _, exitCode := runBinaryInDir(t, dir, "",
+		"check", "--max-input-size", "0", "any.md")
+	assert.Equal(t, 0, exitCode, "expected exit code 0 with unlimited size")
+}
+
+func TestFix_MaxInputSize_ExceedingLimit(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+
+	bigContent := make([]byte, 200)
+	for i := range bigContent {
+		bigContent[i] = 'x'
+	}
+	bigContent[0] = '#'
+	bigContent[1] = ' '
+	writeFixture(t, dir, "big.md", string(bigContent))
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"fix", "--max-input-size", "100", "big.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for oversized file")
+	assert.Contains(t, stderr, "file too large")
+}
+
+func TestCheck_MaxInputSize_ConfigOverride(t *testing.T) {
+	dir := t.TempDir()
+	// Write config with max-input-size: 5 (very small)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("rules: {}\nmax-input-size: \"5\"\n"), 0o644,
+	))
+
+	writeFixture(t, dir, "small.md", "# Hello\n")
+
+	// Config sets 5-byte limit → 8-byte file should fail.
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"check", "small.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 from config limit")
+	assert.Contains(t, stderr, "file too large")
+
+	// CLI flag overrides config → unlimited.
+	_, _, exitCode2 := runBinaryInDir(t, dir, "",
+		"check", "--max-input-size", "0", "small.md")
+	assert.Equal(t, 0, exitCode2, "expected exit code 0 with CLI override to unlimited")
+}

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1475,3 +1475,51 @@ func TestCheck_MaxInputSize_ConfigOverride(t *testing.T) {
 		"check", "--max-input-size", "0", "small.md")
 	assert.Equal(t, 0, exitCode2, "expected exit code 0 with CLI override to unlimited")
 }
+
+func TestCheck_MaxInputSize_InvalidValue(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "a.md", "# Hello\n")
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"check", "--max-input-size", "not-a-size", "a.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for invalid size")
+	assert.Contains(t, stderr, "invalid max-input-size")
+}
+
+func TestFix_MaxInputSize_InvalidValue(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "a.md", "# Hello\n")
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"fix", "--max-input-size", "1TB", "a.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for unrecognized unit")
+	assert.Contains(t, stderr, "invalid max-input-size")
+}
+
+func TestCheckStdin_MaxInputSize_ExceedingLimit(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+
+	bigContent := make([]byte, 200)
+	for i := range bigContent {
+		bigContent[i] = 'x'
+	}
+	bigContent[0] = '#'
+	bigContent[1] = ' '
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, string(bigContent),
+		"check", "--max-input-size", "50", "-")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for oversized stdin")
+	assert.Contains(t, stderr, "file too large")
+}
+
+func TestCheckStdin_MaxInputSize_Unlimited(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+
+	_, _, exitCode := runBinaryInDir(t, dir, "# Hello\n",
+		"check", "--max-input-size", "0", "-")
+	assert.Equal(t, 0, exitCode, "expected exit code 0 with unlimited stdin")
+}

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1551,3 +1551,14 @@ func TestMetricsRank_MaxInputSize_RespectsConfig(t *testing.T) {
 	assert.Equal(t, 2, exitCode, "expected exit code 2 for oversized file")
 	assert.Contains(t, stderr, "file too large")
 }
+
+func TestQuery_MaxInputSize_InvalidValue(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "a.md", "---\nid: 1\n---\n# Hello\n")
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"query", "--max-input-size", "not-a-size", "id: 1", "a.md")
+	assert.Equal(t, 2, exitCode, "expected exit code 2 for invalid size")
+	assert.Contains(t, stderr, "invalid max-input-size")
+}

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -276,15 +276,22 @@ func runFix(args []string) int {
 
 // runQuery implements the "query" subcommand: select files by CUE
 // expression on front matter.
-func runQuery(args []string) int {
-	fs := flag.NewFlagSet("query", flag.ContinueOnError)
-	var (
-		nul     bool
-		verbose bool
-	)
+type queryOptions struct {
+	nul          bool
+	verbose      bool
+	configPath   string
+	maxInputSize string
+}
 
-	fs.BoolVarP(&nul, "null", "0", false, "NUL-delimit output (for xargs -0)")
-	fs.BoolVarP(&verbose, "verbose", "v", false, "Print skipped files and reasons on stderr")
+func parseQueryFlags(args []string) (queryOptions, []string, error) {
+	fs := flag.NewFlagSet("query", flag.ContinueOnError)
+	var opts queryOptions
+
+	fs.BoolVarP(&opts.nul, "null", "0", false, "NUL-delimit output (for xargs -0)")
+	fs.BoolVarP(&opts.verbose, "verbose", "v", false, "Print skipped files and reasons on stderr")
+	fs.StringVarP(&opts.configPath, "config", "c", "", "Override config file path")
+	fs.StringVar(&opts.maxInputSize, "max-input-size", "",
+		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: mdsmith query [flags] <cue-expr> [files...]\n\n"+
@@ -295,10 +302,17 @@ func runQuery(args []string) int {
 	}
 
 	if err := fs.Parse(args); err != nil {
+		return opts, nil, err
+	}
+	return opts, fs.Args(), nil
+}
+
+func runQuery(args []string) int {
+	opts, posArgs, err := parseQueryFlags(args)
+	if err != nil {
 		return 2
 	}
 
-	posArgs := fs.Args()
 	if len(posArgs) == 0 {
 		fmt.Fprintf(os.Stderr, "mdsmith: query requires a CUE expression argument\n")
 		return 2
@@ -317,19 +331,29 @@ func runQuery(args []string) int {
 		fileArgs = []string{"."}
 	}
 
-	opts := lint.ResolveOpts{}
-	files, err := lint.ResolveFilesWithOpts(fileArgs, opts)
+	files, err := lint.ResolveFilesWithOpts(fileArgs, lint.ResolveOpts{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
+	cfg, _, err := loadConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	maxBytes, err := resolveMaxInputBytes(cfg, opts.maxInputSize)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
 
 	delim := "\n"
-	if nul {
+	if opts.nul {
 		delim = "\x00"
 	}
 
-	matched := queryFiles(matcher, files, delim, verbose)
+	matched := queryFiles(matcher, files, delim, opts.verbose, maxBytes)
 	if matched > 0 {
 		return 0
 	}
@@ -338,10 +362,10 @@ func runQuery(args []string) int {
 
 // queryFiles tests each file against matcher and writes matching paths
 // to stdout. Returns the number of matches.
-func queryFiles(matcher *query.Matcher, files []string, delim string, verbose bool) int {
+func queryFiles(matcher *query.Matcher, files []string, delim string, verbose bool, maxBytes int64) int {
 	matched := 0
 	for _, f := range files {
-		fm, err := readFrontMatterRaw(f)
+		fm, err := readFrontMatterRaw(f, maxBytes)
 		if err != nil {
 			if verbose {
 				fmt.Fprintf(os.Stderr, "skip %s: %v\n", f, err)
@@ -366,8 +390,8 @@ func queryFiles(matcher *query.Matcher, files []string, delim string, verbose bo
 
 // readFrontMatterRaw reads a file, strips front matter, and
 // unmarshals YAML into map[string]any (preserving numeric types).
-func readFrontMatterRaw(path string) (map[string]any, error) {
-	data, err := lint.ReadFileLimited(path, lint.DefaultMaxInputBytes)
+func readFrontMatterRaw(path string, maxBytes int64) (map[string]any, error) {
+	data, err := lint.ReadFileLimited(path, maxBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -581,7 +582,8 @@ func fixFiles(
 // readStdinLimited reads stdin with an optional size limit.
 // When maxBytes <= 0 no limit is applied.
 func readStdinLimited(maxBytes int64) ([]byte, error) {
-	if maxBytes > 0 {
+	// Treat MaxInt64 as unlimited to avoid overflow in the +1 sentinel.
+	if maxBytes > 0 && maxBytes < math.MaxInt64 {
 		data, err := io.ReadAll(io.LimitReader(os.Stdin, maxBytes+1))
 		if err != nil {
 			return nil, err

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -492,25 +492,11 @@ func checkFiles(
 	noColor, quiet, verbose, noGitignore, noFollowSymlinks bool,
 	maxInputSize string,
 ) int {
-	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
-
-	cfg, cfgPath, err := loadConfig(configPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
-	if cfgPath != "" {
-		logger.Printf("config: %s", cfgPath)
-	}
-
-	opts := resolveOpts(cfg, noGitignore, noFollowSymlinks)
-	files, err := lint.ResolveFilesWithOpts(fileArgs, opts)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
-	if len(files) == 0 {
-		return 0
+	cfg, cfgPath, logger, files, maxBytes, code := loadAndResolve(
+		fileArgs, configPath, verbose, noGitignore, noFollowSymlinks, maxInputSize,
+	)
+	if code >= 0 {
+		return code
 	}
 
 	runner := &engine.Runner{
@@ -519,7 +505,7 @@ func checkFiles(
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    resolveMaxInputBytes(cfg, maxInputSize),
+		MaxInputBytes:    maxBytes,
 	}
 	result := runner.Run(files)
 	printErrors(result.Errors)
@@ -552,28 +538,13 @@ func fixFiles(
 	noColor, quiet, verbose, noGitignore, noFollowSymlinks bool,
 	maxInputSize string,
 ) int {
-	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
-
-	cfg, cfgPath, err := loadConfig(configPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
-	if cfgPath != "" {
-		logger.Printf("config: %s", cfgPath)
+	cfg, cfgPath, logger, files, maxBytes, code := loadAndResolve(
+		fileArgs, configPath, verbose, noGitignore, noFollowSymlinks, maxInputSize,
+	)
+	if code >= 0 {
+		return code
 	}
 
-	opts := resolveOpts(cfg, noGitignore, noFollowSymlinks)
-	files, err := lint.ResolveFilesWithOpts(fileArgs, opts)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
-	if len(files) == 0 {
-		return 0
-	}
-
-	maxBytes := resolveMaxInputBytes(cfg, maxInputSize)
 	fixer := &fixpkg.Fixer{
 		Config:           cfg,
 		Rules:            rule.All(),
@@ -639,7 +610,11 @@ func checkStdin(format string, noColor, quiet, verbose bool, configPath, maxInpu
 		logger.Printf("config: %s", cfgPath)
 	}
 
-	maxBytes := resolveMaxInputBytes(cfg, maxInputSize)
+	maxBytes, err := resolveMaxInputBytes(cfg, maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
 
 	source, err := readStdinLimited(maxBytes)
 	if err != nil {
@@ -678,6 +653,44 @@ func checkStdin(format string, noColor, quiet, verbose bool, configPath, maxInpu
 		return 1
 	}
 	return 0
+}
+
+// loadAndResolve loads config, resolves file paths, and parses the max
+// input size. Returns exit code >= 0 on error (caller should return it)
+// or -1 on success.
+func loadAndResolve(
+	fileArgs []string, configPath string,
+	verbose, noGitignore, noFollowSymlinks bool,
+	maxInputSize string,
+) (*config.Config, string, *vlog.Logger, []string, int64, int) {
+	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
+
+	cfg, cfgPath, err := loadConfig(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, "", nil, nil, 0, 2
+	}
+	if cfgPath != "" {
+		logger.Printf("config: %s", cfgPath)
+	}
+
+	opts := resolveOpts(cfg, noGitignore, noFollowSymlinks)
+	files, err := lint.ResolveFilesWithOpts(fileArgs, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, "", nil, nil, 0, 2
+	}
+	if len(files) == 0 {
+		return nil, "", nil, nil, 0, 0
+	}
+
+	maxBytes, err := resolveMaxInputBytes(cfg, maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, "", nil, nil, 0, 2
+	}
+
+	return cfg, cfgPath, logger, files, maxBytes, -1
 }
 
 // splitStdinArg separates a "-" argument (stdin) from file arguments.
@@ -742,13 +755,19 @@ func checkDiscovered(
 		return code
 	}
 
+	maxBytes, err := resolveMaxInputBytes(cfg, maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
 	runner := &engine.Runner{
 		Config:           cfg,
 		Rules:            rule.All(),
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    resolveMaxInputBytes(cfg, maxInputSize),
+		MaxInputBytes:    maxBytes,
 	}
 	result := runner.Run(files)
 	printErrors(result.Errors)
@@ -787,7 +806,12 @@ func fixDiscovered(
 		return code
 	}
 
-	maxBytes := resolveMaxInputBytes(cfg, maxInputSize)
+	maxBytes, err := resolveMaxInputBytes(cfg, maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
 	fixer := &fixpkg.Fixer{
 		Config:           cfg,
 		Rules:            rule.All(),
@@ -840,20 +864,19 @@ func resolveOpts(cfg *config.Config, noGitignore, noFollowSymlinks bool) lint.Re
 
 // resolveMaxInputBytes returns the effective max-input-size in bytes.
 // CLI flag overrides config; if neither is set, the default (2 MB) is used.
-func resolveMaxInputBytes(cfg *config.Config, cliFlag string) int64 {
+func resolveMaxInputBytes(cfg *config.Config, cliFlag string) (int64, error) {
 	raw := cliFlag
 	if raw == "" {
 		raw = cfg.MaxInputSize
 	}
 	if raw == "" {
-		return lint.DefaultMaxInputBytes
+		return lint.DefaultMaxInputBytes, nil
 	}
 	n, err := config.ParseSize(raw)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: invalid max-input-size %q: %v\n", raw, err)
-		return lint.DefaultMaxInputBytes
+		return 0, fmt.Errorf("invalid max-input-size %q: %w", raw, err)
 	}
-	return n
+	return n, nil
 }
 
 func frontMatterEnabled(cfg *config.Config) bool {

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -153,6 +153,7 @@ func runCheck(args []string) int {
 		verbose          bool
 		noGitignore      bool
 		noFollowSymlinks bool
+		maxInputSize     string
 	)
 
 	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
@@ -162,6 +163,7 @@ func runCheck(args []string) int {
 	fs.BoolVarP(&verbose, "verbose", "v", false, "Show config, files, and rules on stderr")
 	fs.BoolVar(&noGitignore, "no-gitignore", false, "Disable .gitignore filtering when walking directories")
 	fs.BoolVar(&noFollowSymlinks, "no-follow-symlinks", false, "Skip symbolic links when walking directories")
+	fs.StringVar(&maxInputSize, "max-input-size", "", "Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mdsmith check [flags] [files...]\n\n"+
@@ -188,15 +190,21 @@ func runCheck(args []string) int {
 	hasStdin, fileArgs := splitStdinArg(allArgs)
 
 	if hasStdin {
-		return checkStdin(format, noColor, quiet, verbose, configPath)
+		return checkStdin(format, noColor, quiet, verbose, configPath, maxInputSize)
 	}
 
 	if len(fileArgs) > 0 {
-		return checkFiles(fileArgs, configPath, format, noColor, quiet, verbose, noGitignore, noFollowSymlinks)
+		return checkFiles(
+			fileArgs, configPath, format, noColor, quiet, verbose,
+			noGitignore, noFollowSymlinks, maxInputSize,
+		)
 	}
 
 	// No file args and no stdin: discover files from config.
-	return checkDiscovered(configPath, format, noColor, quiet, verbose, noGitignore, noFollowSymlinks)
+	return checkDiscovered(
+		configPath, format, noColor, quiet, verbose,
+		noGitignore, noFollowSymlinks, maxInputSize,
+	)
 }
 
 // runFix implements the "fix" subcommand: auto-fix lint issues in place.
@@ -210,6 +218,7 @@ func runFix(args []string) int {
 		verbose          bool
 		noGitignore      bool
 		noFollowSymlinks bool
+		maxInputSize     string
 	)
 
 	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
@@ -219,6 +228,7 @@ func runFix(args []string) int {
 	fs.BoolVarP(&verbose, "verbose", "v", false, "Show config, files, and rules on stderr")
 	fs.BoolVar(&noGitignore, "no-gitignore", false, "Disable .gitignore filtering when walking directories")
 	fs.BoolVar(&noFollowSymlinks, "no-follow-symlinks", false, "Skip symbolic links when walking directories")
+	fs.StringVar(&maxInputSize, "max-input-size", "", "Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mdsmith fix [flags] [files...]\n\n"+
@@ -250,11 +260,17 @@ func runFix(args []string) int {
 	}
 
 	if len(fileArgs) > 0 {
-		return fixFiles(fileArgs, configPath, format, noColor, quiet, verbose, noGitignore, noFollowSymlinks)
+		return fixFiles(
+			fileArgs, configPath, format, noColor, quiet, verbose,
+			noGitignore, noFollowSymlinks, maxInputSize,
+		)
 	}
 
 	// No file args: discover files from config.
-	return fixDiscovered(configPath, format, noColor, quiet, verbose, noGitignore, noFollowSymlinks)
+	return fixDiscovered(
+		configPath, format, noColor, quiet, verbose,
+		noGitignore, noFollowSymlinks, maxInputSize,
+	)
 }
 
 // runQuery implements the "query" subcommand: select files by CUE
@@ -350,7 +366,7 @@ func queryFiles(matcher *query.Matcher, files []string, delim string, verbose bo
 // readFrontMatterRaw reads a file, strips front matter, and
 // unmarshals YAML into map[string]any (preserving numeric types).
 func readFrontMatterRaw(path string) (map[string]any, error) {
-	data, err := os.ReadFile(path)
+	data, err := lint.ReadFileLimited(path, lint.DefaultMaxInputBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -474,6 +490,7 @@ func printRunStats(format string, quiet bool, stats runStats) {
 func checkFiles(
 	fileArgs []string, configPath, format string,
 	noColor, quiet, verbose, noGitignore, noFollowSymlinks bool,
+	maxInputSize string,
 ) int {
 	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
 
@@ -502,6 +519,7 @@ func checkFiles(
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
+		MaxInputBytes:    resolveMaxInputBytes(cfg, maxInputSize),
 	}
 	result := runner.Run(files)
 	printErrors(result.Errors)
@@ -532,6 +550,7 @@ func checkFiles(
 func fixFiles(
 	fileArgs []string, configPath, format string,
 	noColor, quiet, verbose, noGitignore, noFollowSymlinks bool,
+	maxInputSize string,
 ) int {
 	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
 
@@ -554,12 +573,14 @@ func fixFiles(
 		return 0
 	}
 
+	maxBytes := resolveMaxInputBytes(cfg, maxInputSize)
 	fixer := &fixpkg.Fixer{
 		Config:           cfg,
 		Rules:            rule.All(),
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
+		MaxInputBytes:    maxBytes,
 	}
 	fixResult := fixer.Fix(files)
 	printErrors(fixResult.Errors)
@@ -586,16 +607,28 @@ func fixFiles(
 	return 0
 }
 
+// readStdinLimited reads stdin with an optional size limit.
+// When maxBytes <= 0 no limit is applied.
+func readStdinLimited(maxBytes int64) ([]byte, error) {
+	if maxBytes > 0 {
+		data, err := io.ReadAll(io.LimitReader(os.Stdin, maxBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(data)) > maxBytes {
+			return nil, fmt.Errorf(
+				"reading \"<stdin>\": file too large "+
+					"(%d bytes, max %d)", int64(len(data)), maxBytes)
+		}
+		return data, nil
+	}
+	return io.ReadAll(os.Stdin)
+}
+
 // checkStdin reads from stdin, lints the content, and returns the appropriate
 // exit code. Uses runner.RunSource to ensure Configurable settings are applied.
-func checkStdin(format string, noColor, quiet, verbose bool, configPath string) int {
+func checkStdin(format string, noColor, quiet, verbose bool, configPath, maxInputSize string) int {
 	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
-
-	source, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: reading stdin: %v\n", err)
-		return 2
-	}
 
 	cfg, cfgPath, err := loadConfig(configPath)
 	if err != nil {
@@ -606,12 +639,21 @@ func checkStdin(format string, noColor, quiet, verbose bool, configPath string) 
 		logger.Printf("config: %s", cfgPath)
 	}
 
+	maxBytes := resolveMaxInputBytes(cfg, maxInputSize)
+
+	source, err := readStdinLimited(maxBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
 	runner := &engine.Runner{
 		Config:           cfg,
 		Rules:            rule.All(),
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
+		MaxInputBytes:    maxBytes,
 	}
 	result := runner.RunSource("<stdin>", source)
 	printErrors(result.Errors)
@@ -693,6 +735,7 @@ func discoverFiles(
 func checkDiscovered(
 	configPath, format string,
 	noColor, quiet, verbose, noGitignore, noFollowSymlinks bool,
+	maxInputSize string,
 ) int {
 	cfg, cfgPath, logger, files, code := discoverFiles(configPath, verbose, noGitignore, noFollowSymlinks)
 	if code >= 0 {
@@ -705,6 +748,7 @@ func checkDiscovered(
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
+		MaxInputBytes:    resolveMaxInputBytes(cfg, maxInputSize),
 	}
 	result := runner.Run(files)
 	printErrors(result.Errors)
@@ -736,18 +780,21 @@ func checkDiscovered(
 func fixDiscovered(
 	configPath, format string,
 	noColor, quiet, verbose, noGitignore, noFollowSymlinks bool,
+	maxInputSize string,
 ) int {
 	cfg, cfgPath, logger, files, code := discoverFiles(configPath, verbose, noGitignore, noFollowSymlinks)
 	if code >= 0 {
 		return code
 	}
 
+	maxBytes := resolveMaxInputBytes(cfg, maxInputSize)
 	fixer := &fixpkg.Fixer{
 		Config:           cfg,
 		Rules:            rule.All(),
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
+		MaxInputBytes:    maxBytes,
 	}
 	fixResult := fixer.Fix(files)
 	printErrors(fixResult.Errors)
@@ -789,6 +836,24 @@ func resolveOpts(cfg *config.Config, noGitignore, noFollowSymlinks bool) lint.Re
 		opts.NoFollowSymlinks = []string{"**"}
 	}
 	return opts
+}
+
+// resolveMaxInputBytes returns the effective max-input-size in bytes.
+// CLI flag overrides config; if neither is set, the default (2 MB) is used.
+func resolveMaxInputBytes(cfg *config.Config, cliFlag string) int64 {
+	raw := cliFlag
+	if raw == "" {
+		raw = cfg.MaxInputSize
+	}
+	if raw == "" {
+		return lint.DefaultMaxInputBytes
+	}
+	n, err := config.ParseSize(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: invalid max-input-size %q: %v\n", raw, err)
+		return lint.DefaultMaxInputBytes
+	}
+	return n
 }
 
 func frontMatterEnabled(cfg *config.Config) bool {

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -56,6 +56,38 @@ func runMergeDriver(args []string) int {
 	}
 }
 
+// mergeAndClean performs the 3-way merge and strips conflict markers.
+// Returns the cleaned content and an exit code (0 on success).
+func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
+	// Step 1: standard 3-way merge into ours.
+	mergeCmd := exec.Command("git", "merge-file", ours, base, theirs)
+	mergeCmd.Stderr = os.Stderr
+	mergeErr := mergeCmd.Run()
+
+	// git merge-file exits 1 for conflicts, 2+ for fatal errors.
+	// Non-ExitError (e.g. git not found) is also fatal.
+	if mergeErr != nil {
+		if exitErr, ok := mergeErr.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+			fmt.Fprintf(os.Stderr, "mdsmith: git merge-file failed: %v\n", mergeErr)
+			return nil, 2
+		}
+	}
+
+	// Step 2: strip conflict markers inside regenerable sections.
+	content, err := lint.ReadFileLimited(ours, maxBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: reading merge result: %v\n", err)
+		return nil, 2
+	}
+
+	cleaned := stripSectionConflicts(content)
+	if err := os.WriteFile(ours, cleaned, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
+		return nil, 2
+	}
+	return cleaned, 0
+}
+
 // runMergeDriverRun implements the git merge driver protocol.
 // Arguments: <base> <ours> <theirs> <pathname>
 //
@@ -79,36 +111,27 @@ func runMergeDriverRun(args []string) int {
 
 	base, ours, theirs, pathname := args[0], args[1], args[2], args[3]
 
-	// Step 1: standard 3-way merge into ours.
-	mergeCmd := exec.Command("git", "merge-file", ours, base, theirs)
-	mergeCmd.Stderr = os.Stderr
-	mergeErr := mergeCmd.Run()
-
-	// git merge-file exits 1 for conflicts, 2+ for fatal errors.
-	// Non-ExitError (e.g. git not found) is also fatal.
-	if mergeErr != nil {
-		if exitErr, ok := mergeErr.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
-			fmt.Fprintf(os.Stderr, "mdsmith: git merge-file failed: %v\n", mergeErr)
-			return 2
-		}
-	}
-
-	// Step 2: strip conflict markers inside regenerable sections.
-	content, err := lint.ReadFileLimited(ours, lint.DefaultMaxInputBytes)
+	// Resolve the effective max-input-size from config so the merge
+	// driver honors the same limit as check/fix.
+	cfg, _, err := loadConfig("")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: reading merge result: %v\n", err)
+		fmt.Fprintf(os.Stderr, "mdsmith: loading config: %v\n", err)
+		return 2
+	}
+	maxBytes, err := resolveMaxInputBytes(cfg, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
 
-	cleaned := stripSectionConflicts(content)
-	if err := os.WriteFile(ours, cleaned, 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
-		return 2
+	cleaned, rc := mergeAndClean(base, ours, theirs, maxBytes)
+	if rc != 0 {
+		return rc
 	}
 
 	// Step 3: run mdsmith fix at the real path and write result
 	// back to ours.
-	fixed, rc := fixAtRealPath(cleaned, ours, pathname)
+	fixed, rc := fixAtRealPath(cleaned, ours, pathname, maxBytes)
 	if rc != 0 {
 		return rc
 	}
@@ -126,14 +149,14 @@ func runMergeDriverRun(args []string) int {
 
 // fixAtRealPath writes cleaned content to pathname, runs mdsmith
 // fix, copies the result to ours, and restores pathname.
-func fixAtRealPath(cleaned []byte, ours, pathname string) ([]byte, int) {
+func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byte, int) {
 	// Capture the original file mode so we can preserve permissions.
 	fileMode := os.FileMode(0644)
 	if info, err := os.Stat(pathname); err == nil {
 		fileMode = info.Mode()
 	}
 
-	backup, backupErr := lint.ReadFileLimited(pathname, lint.DefaultMaxInputBytes)
+	backup, backupErr := lint.ReadFileLimited(pathname, maxBytes)
 	if backupErr != nil && !os.IsNotExist(backupErr) {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)
 		return nil, 2
@@ -143,11 +166,11 @@ func fixAtRealPath(cleaned []byte, ours, pathname string) ([]byte, int) {
 		return nil, 2
 	}
 
-	fixErr := fixFileInPlace(pathname)
+	fixErr := fixFileInPlace(pathname, maxBytes)
 
 	// Restore the original working tree file before checking
 	// fixErr, so the working tree is always left clean.
-	fixed, err := lint.ReadFileLimited(pathname, lint.DefaultMaxInputBytes)
+	fixed, err := lint.ReadFileLimited(pathname, maxBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)
 		return nil, 2
@@ -180,7 +203,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string) ([]byte, int) {
 }
 
 // fixFileInPlace runs the mdsmith fix pipeline on a single file.
-func fixFileInPlace(path string) error {
+func fixFileInPlace(path string, maxBytes int64) error {
 	cfg, _, err := loadConfig("")
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -191,6 +214,7 @@ func fixFileInPlace(path string) error {
 		Rules:            rule.All(),
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           &vlog.Logger{},
+		MaxInputBytes:    maxBytes,
 	}
 
 	result := fixer.Fix([]string{path})

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	fixpkg "github.com/jeduden/mdsmith/internal/fix"
+	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
 )
@@ -93,7 +94,7 @@ func runMergeDriverRun(args []string) int {
 	}
 
 	// Step 2: strip conflict markers inside regenerable sections.
-	content, err := os.ReadFile(ours)
+	content, err := lint.ReadFileLimited(ours, lint.DefaultMaxInputBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading merge result: %v\n", err)
 		return 2
@@ -132,7 +133,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string) ([]byte, int) {
 		fileMode = info.Mode()
 	}
 
-	backup, backupErr := os.ReadFile(pathname)
+	backup, backupErr := lint.ReadFileLimited(pathname, lint.DefaultMaxInputBytes)
 	if backupErr != nil && !os.IsNotExist(backupErr) {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)
 		return nil, 2
@@ -146,7 +147,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string) ([]byte, int) {
 
 	// Restore the original working tree file before checking
 	// fixErr, so the working tree is always left clean.
-	fixed, err := os.ReadFile(pathname)
+	fixed, err := lint.ReadFileLimited(pathname, lint.DefaultMaxInputBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)
 		return nil, 2

--- a/cmd/mdsmith/metrics.go
+++ b/cmd/mdsmith/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
+	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	metricspkg "github.com/jeduden/mdsmith/internal/metrics"
 )
@@ -159,17 +160,18 @@ func executeMetricsRank(opts metricsRankOptions, fileArgs []string) int {
 		return 2
 	}
 
-	files, err := resolveRankFiles(opts, fileArgs)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
-
 	cfg, _, err := loadConfig(opts.configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
+
+	files, err := resolveRankFiles(cfg, opts, fileArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
 	maxBytes, err := resolveMaxInputBytes(cfg, opts.maxInputSize)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
@@ -240,12 +242,7 @@ func resolveRankSelection(
 	return defs, byDef, order, nil
 }
 
-func resolveRankFiles(opts metricsRankOptions, fileArgs []string) ([]string, error) {
-	cfg, _, err := loadConfig(opts.configPath)
-	if err != nil {
-		return nil, err
-	}
-
+func resolveRankFiles(cfg *config.Config, opts metricsRankOptions, fileArgs []string) ([]string, error) {
 	resolveOptions := resolveOpts(cfg, opts.noGitignore, opts.noFollowSymlinks)
 	return lint.ResolveFilesWithOpts(fileArgs, resolveOptions)
 }

--- a/cmd/mdsmith/metrics.go
+++ b/cmd/mdsmith/metrics.go
@@ -162,7 +162,7 @@ func executeMetricsRank(opts metricsRankOptions, fileArgs []string) int {
 		return 2
 	}
 
-	rows, err := metricspkg.Collect(files, defs)
+	rows, err := metricspkg.Collect(files, defs, lint.DefaultMaxInputBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2

--- a/cmd/mdsmith/metrics.go
+++ b/cmd/mdsmith/metrics.go
@@ -99,6 +99,7 @@ type metricsRankOptions struct {
 	format           string
 	noGitignore      bool
 	noFollowSymlinks bool
+	maxInputSize     string
 }
 
 func runMetricsRank(args []string) int {
@@ -122,6 +123,8 @@ func parseMetricsRankOptions(args []string) (metricsRankOptions, []string, error
 	fs.StringVarP(&opts.format, "format", "f", "text", "Output format: text, json")
 	fs.BoolVar(&opts.noGitignore, "no-gitignore", false, "Disable .gitignore filtering when walking directories")
 	fs.BoolVar(&opts.noFollowSymlinks, "no-follow-symlinks", false, "Skip symbolic links when walking directories")
+	fs.StringVar(&opts.maxInputSize, "max-input-size", "",
+		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(
@@ -162,7 +165,18 @@ func executeMetricsRank(opts metricsRankOptions, fileArgs []string) int {
 		return 2
 	}
 
-	rows, err := metricspkg.Collect(files, defs, lint.DefaultMaxInputBytes)
+	cfg, _, err := loadConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	maxBytes, err := resolveMaxInputBytes(cfg, opts.maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
+	rows, err := metricspkg.Collect(files, defs, maxBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,13 +43,35 @@ match, exits 0.
 | `-q`, `--quiet`    | Quiet mode                           |
 | `-v`, `--verbose`  | Verbose output                       |
 
-`--max-input-size` sets the byte-size cap for any file
-read during linting. Files exceeding the limit are skipped
-and reported as runtime errors on stderr. Exit code follows
-the usual precedence: `1` when lint diagnostics are found
-(even if some files were skipped), `2` when only runtime
-errors occur. An invalid `--max-input-size` value always
-exits `2`. Accepts `KB`, `MB`, `GB` suffixes (binary:
+## Other Subcommand Flags
+
+`query` accepts `-c`/`--config`, `-v`/`--verbose`,
+`-0`/`--null`, and `--max-input-size`.
+
+`metrics rank` accepts `-c`/`--config`, `-f`/`--format`,
+`--no-gitignore`, `--no-follow-symlinks`,
+`--max-input-size`, plus `--metrics`, `--by`, `--order`,
+`--top`.
+
+## `--max-input-size`
+
+Sets the byte-size cap for any input file read by
+commands that support the flag (`check`, `fix`, `query`,
+`metrics rank`). Behavior on oversize input:
+
+- `check` / `fix`: file is skipped and reported as a
+  runtime error on stderr. Exit code follows the usual
+  precedence — `1` when lint diagnostics are found (even
+  if some files were skipped), `2` when only runtime
+  errors occur.
+- `query`: file is skipped; the per-file error is only
+  printed on stderr when `--verbose` is set. Exit code
+  `1` if no files matched, `0` on a match.
+- `metrics rank`: the whole run fails with exit code
+  `2` on the first oversize file.
+
+An invalid `--max-input-size` value always exits `2`.
+Accepts `KB`, `MB`, `GB` suffixes (binary:
 1 MB = 1,048,576 bytes), bare integers (bytes), or `0`
 to disable the limit. Default: `2MB`. The CLI flag
 overrides the `max-input-size` key in `.mdsmith.yml`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,14 +33,23 @@ match, exits 0.
 
 ## Subcommand Flags (check, fix)
 
-| Flag              | Description      |
-|-------------------|------------------|
-| `-c`, `--config`  | Config path      |
-| `-f`, `--format`  | `text` or `json` |
-| `--no-color`      | Plain output     |
-| `--no-gitignore`  | Skip gitignore   |
-| `-q`, `--quiet`   | Quiet mode       |
-| `-v`, `--verbose` | Verbose output   |
+| Flag               | Description                          |
+|--------------------|--------------------------------------|
+| `-c`, `--config`   | Config path                          |
+| `-f`, `--format`   | `text` or `json`                     |
+| `--max-input-size` | Max file size (e.g. `2MB`, `0`=none) |
+| `--no-color`       | Plain output                         |
+| `--no-gitignore`   | Skip gitignore                       |
+| `-q`, `--quiet`    | Quiet mode                           |
+| `-v`, `--verbose`  | Verbose output                       |
+
+`--max-input-size` sets the byte-size cap for any file
+read during linting. Files exceeding the limit are skipped
+with an error (exit code 2). Accepts `KB`, `MB`, `GB`
+suffixes (binary: 1 MB = 1,048,576 bytes), bare integers
+(bytes), or `0` to disable the limit. Default: `2MB`.
+The CLI flag overrides the `max-input-size` key in
+`.mdsmith.yml`.
 
 ## Global Flags
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,11 +45,14 @@ match, exits 0.
 
 `--max-input-size` sets the byte-size cap for any file
 read during linting. Files exceeding the limit are skipped
-with an error (exit code 2). Accepts `KB`, `MB`, `GB`
-suffixes (binary: 1 MB = 1,048,576 bytes), bare integers
-(bytes), or `0` to disable the limit. Default: `2MB`.
-The CLI flag overrides the `max-input-size` key in
-`.mdsmith.yml`.
+and reported as runtime errors on stderr. Exit code follows
+the usual precedence: `1` when lint diagnostics are found
+(even if some files were skipped), `2` when only runtime
+errors occur. An invalid `--max-input-size` value always
+exits `2`. Accepts `KB`, `MB`, `GB` suffixes (binary:
+1 MB = 1,048,576 bytes), bare integers (bytes), or `0`
+to disable the limit. Default: `2MB`. The CLI flag
+overrides the `max-input-size` key in `.mdsmith.yml`.
 
 ## Global Flags
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Categories       map[string]bool    `yaml:"categories"`
 	Files            []string           `yaml:"files"`
 	NoFollowSymlinks []string           `yaml:"no-follow-symlinks"`
+	MaxInputSize     string             `yaml:"max-input-size"`
 
 	// ExplicitRules tracks rule names that were explicitly set in
 	// the user config (not just inherited from defaults). This is

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1297,3 +1297,74 @@ func TestYamlHasKeyRejectsAnchor(t *testing.T) {
 	yml := []byte("base: &base\n  enabled: true\n")
 	assert.False(t, yamlHasKey(yml, "base"))
 }
+
+func TestMergeMaxInputSize_FromLoaded(t *testing.T) {
+	defaults := &Config{
+		Rules: map[string]RuleCfg{"a": {Enabled: true}},
+	}
+	loaded := &Config{
+		Rules:        map[string]RuleCfg{},
+		MaxInputSize: "500KB",
+	}
+	merged := Merge(defaults, loaded)
+	assert.Equal(t, "500KB", merged.MaxInputSize)
+}
+
+func TestMergeMaxInputSize_DefaultWhenOmitted(t *testing.T) {
+	defaults := &Config{
+		Rules:        map[string]RuleCfg{"a": {Enabled: true}},
+		MaxInputSize: "2MB",
+	}
+	loaded := &Config{
+		Rules: map[string]RuleCfg{},
+	}
+	merged := Merge(defaults, loaded)
+	assert.Equal(t, "2MB", merged.MaxInputSize)
+}
+
+func TestMergeNilLoaded_PreservesMaxInputSize(t *testing.T) {
+	defaults := &Config{
+		Rules:        map[string]RuleCfg{"a": {Enabled: true}},
+		MaxInputSize: "1GB",
+	}
+	merged := Merge(defaults, nil)
+	assert.Equal(t, "1GB", merged.MaxInputSize)
+}
+
+func TestReadLimitedConfig_Normal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(path, []byte("rules: {}\n"), 0o644))
+	data, err := readLimitedConfig(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "rules")
+}
+
+func TestReadLimitedConfig_OversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mdsmith.yml")
+	// Write a file larger than maxConfigBytes (1 MB).
+	oversized := make([]byte, maxConfigBytes+1)
+	for i := range oversized {
+		oversized[i] = '#'
+	}
+	require.NoError(t, os.WriteFile(path, oversized, 0o644))
+	_, err := readLimitedConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestReadLimitedConfig_MissingFile(t *testing.T) {
+	_, err := readLimitedConfig("/nonexistent/.mdsmith.yml")
+	require.Error(t, err)
+}
+
+func TestLoadMaxInputSizeFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("max-input-size: 500KB\nrules: {}\n"), 0o644))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, "500KB", cfg.MaxInputSize)
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -10,11 +11,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// maxConfigBytes is a generous cap for the config file size (1 MB).
+// Config files should be small; this prevents accidental OOM from
+// pointing at a huge file.
+const maxConfigBytes int64 = 1024 * 1024
+
 const configFileName = ".mdsmith.yml"
 
 // Load reads and parses a config file at the given path.
 func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
+	data, err := readLimitedConfig(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
@@ -133,6 +139,23 @@ func DumpDefaults() *Config {
 		Categories: categories,
 		Files:      DefaultFiles,
 	}
+}
+
+// readLimitedConfig reads a config file with a size cap to prevent OOM.
+func readLimitedConfig(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read-only file
+	data, err := io.ReadAll(io.LimitReader(f, maxConfigBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxConfigBytes {
+		return nil, fmt.Errorf("config file %q too large (%d bytes, max %d)", path, int64(len(data)), maxConfigBytes)
+	}
+	return data, nil
 }
 
 func enabledByDefault(r rule.Rule) bool {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -148,12 +148,26 @@ func readLimitedConfig(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
+
+	// Stat for accurate size in error messages.
+	var actualSize int64 = -1
+	if info, err := f.Stat(); err == nil {
+		actualSize = info.Size()
+	}
+
 	data, err := io.ReadAll(io.LimitReader(f, maxConfigBytes+1))
 	if err != nil {
 		return nil, err
 	}
 	if int64(len(data)) > maxConfigBytes {
-		return nil, fmt.Errorf("config file %q too large (%d bytes, max %d)", path, int64(len(data)), maxConfigBytes)
+		reported := actualSize
+		if reported < 0 {
+			reported = int64(len(data))
+		}
+		return nil, fmt.Errorf(
+			"config file %q too large (%d bytes, max %d)",
+			path, reported, maxConfigBytes,
+		)
 	}
 	return data, nil
 }

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -7,21 +7,7 @@ package config
 // category not mentioned in loaded keeps its default value (true).
 func Merge(defaults, loaded *Config) *Config {
 	if loaded == nil {
-		// No user config: return a copy of defaults.
-		rules := make(map[string]RuleCfg, len(defaults.Rules))
-		for k, v := range defaults.Rules {
-			rules[k] = v
-		}
-		cats := copyCategories(defaults.Categories)
-		files := copyStrings(defaults.Files)
-		noFollow := copyStrings(defaults.NoFollowSymlinks)
-		return &Config{
-			Rules:            rules,
-			FrontMatter:      defaults.FrontMatter,
-			Categories:       cats,
-			Files:            files,
-			NoFollowSymlinks: noFollow,
-		}
+		return copyConfig(defaults)
 	}
 
 	rules := make(map[string]RuleCfg, len(defaults.Rules))
@@ -56,6 +42,11 @@ func Merge(defaults, loaded *Config) *Config {
 		explicit[k] = true
 	}
 
+	maxInputSize := defaults.MaxInputSize
+	if loaded.MaxInputSize != "" {
+		maxInputSize = loaded.MaxInputSize
+	}
+
 	return &Config{
 		Rules:            rules,
 		Ignore:           loaded.Ignore,
@@ -66,6 +57,23 @@ func Merge(defaults, loaded *Config) *Config {
 		FilesExplicit:    filesExplicit,
 		ExplicitRules:    explicit,
 		NoFollowSymlinks: loaded.NoFollowSymlinks,
+		MaxInputSize:     maxInputSize,
+	}
+}
+
+// copyConfig returns a shallow copy of a Config with copied slices and maps.
+func copyConfig(cfg *Config) *Config {
+	rules := make(map[string]RuleCfg, len(cfg.Rules))
+	for k, v := range cfg.Rules {
+		rules[k] = v
+	}
+	return &Config{
+		Rules:            rules,
+		FrontMatter:      cfg.FrontMatter,
+		Categories:       copyCategories(cfg.Categories),
+		Files:            copyStrings(cfg.Files),
+		NoFollowSymlinks: copyStrings(cfg.NoFollowSymlinks),
+		MaxInputSize:     cfg.MaxInputSize,
 	}
 }
 

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -61,19 +61,30 @@ func Merge(defaults, loaded *Config) *Config {
 	}
 }
 
-// copyConfig returns a shallow copy of a Config with copied slices and maps.
+// copyConfig returns a shallow copy of a Config with copied slices and
+// maps. Scalar fields and struct slices (Overrides) are shared by
+// reference — the defaults case does not carry Ignore/Overrides data,
+// but copying every field keeps the helper safe for any caller.
 func copyConfig(cfg *Config) *Config {
 	rules := make(map[string]RuleCfg, len(cfg.Rules))
 	for k, v := range cfg.Rules {
 		rules[k] = v
 	}
+	explicit := make(map[string]bool, len(cfg.ExplicitRules))
+	for k, v := range cfg.ExplicitRules {
+		explicit[k] = v
+	}
 	return &Config{
 		Rules:            rules,
+		Ignore:           copyStrings(cfg.Ignore),
+		Overrides:        cfg.Overrides,
 		FrontMatter:      cfg.FrontMatter,
 		Categories:       copyCategories(cfg.Categories),
 		Files:            copyStrings(cfg.Files),
 		NoFollowSymlinks: copyStrings(cfg.NoFollowSymlinks),
 		MaxInputSize:     cfg.MaxInputSize,
+		ExplicitRules:    explicit,
+		FilesExplicit:    cfg.FilesExplicit,
 	}
 }
 

--- a/internal/config/size.go
+++ b/internal/config/size.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -45,6 +46,9 @@ func ParseSize(s string) (int64, error) {
 			}
 			if n < 0 {
 				return 0, fmt.Errorf("negative size %q", s)
+			}
+			if n > math.MaxInt64/sf.multiplier {
+				return 0, fmt.Errorf("size %q overflows int64", s)
 			}
 			return n * sf.multiplier, nil
 		}

--- a/internal/config/size.go
+++ b/internal/config/size.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseSize parses a human-readable size string into bytes.
+// Accepted formats: "2MB", "500KB", "1GB", bare integer (bytes), "0" (unlimited).
+// Case-insensitive. Uses binary units (1 KB = 1024, 1 MB = 1048576, 1 GB = 1073741824).
+func ParseSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size string")
+	}
+
+	upper := strings.ToUpper(s)
+
+	// Try bare integer first.
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if n < 0 {
+			return 0, fmt.Errorf("negative size %q", s)
+		}
+		return n, nil
+	}
+
+	// Try suffix-based parsing.
+	type suffix struct {
+		label      string
+		multiplier int64
+	}
+	suffixes := []suffix{
+		{"GB", 1024 * 1024 * 1024},
+		{"MB", 1024 * 1024},
+		{"KB", 1024},
+	}
+
+	for _, sf := range suffixes {
+		if strings.HasSuffix(upper, sf.label) {
+			numStr := strings.TrimSpace(s[:len(s)-len(sf.label)])
+			n, err := strconv.ParseInt(numStr, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid size %q: %w", s, err)
+			}
+			if n < 0 {
+				return 0, fmt.Errorf("negative size %q", s)
+			}
+			return n * sf.multiplier, nil
+		}
+	}
+
+	return 0, fmt.Errorf("invalid size %q: unrecognized unit (use KB, MB, or GB)", s)
+}

--- a/internal/config/size_test.go
+++ b/internal/config/size_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"2MB", 2 * 1024 * 1024},
+		{"2mb", 2 * 1024 * 1024},
+		{"2Mb", 2 * 1024 * 1024},
+		{"500KB", 500 * 1024},
+		{"500kb", 500 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
+		{"0", 0},
+		{"1024", 1024},
+		{"100", 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSize(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseSize_Invalid(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantErr string
+	}{
+		{"", "empty size string"},
+		{"abc", "unrecognized unit"},
+		{"-1", "negative size"},
+		{"-5MB", "negative size"},
+		{"2TB", "unrecognized unit"},
+		{"2.5MB", "invalid size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := ParseSize(tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/internal/config/size_test.go
+++ b/internal/config/size_test.go
@@ -43,6 +43,7 @@ func TestParseSize_Invalid(t *testing.T) {
 		{"-5MB", "negative size"},
 		{"2TB", "unrecognized unit"},
 		{"2.5MB", "invalid size"},
+		{"9999999999GB", "overflows int64"},
 	}
 
 	for _, tt := range tests {

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -23,6 +23,9 @@ type Runner struct {
 	// RootDir is the project root directory (parent of .mdsmith.yml).
 	// Used by rules that need to read files relative to the project root.
 	RootDir string
+	// MaxInputBytes is the maximum file size in bytes before a file is
+	// skipped with an error. Zero or negative means unlimited.
+	MaxInputBytes int64
 	// gitignoreCache caches GitignoreMatchers by directory to avoid
 	// re-walking the filesystem for each file.
 	gitignoreCache map[string]*lint.GitignoreMatcher
@@ -49,7 +52,7 @@ func (r *Runner) Run(paths []string) *Result {
 
 		r.log().Printf("file: %s", path)
 
-		source, err := os.ReadFile(path)
+		source, err := lint.ReadFileLimited(path, r.MaxInputBytes)
 		if err != nil {
 			res.Errors = append(res.Errors, fmt.Errorf("reading %q: %w", path, err))
 			continue
@@ -60,6 +63,7 @@ func (r *Runner) Run(paths []string) *Result {
 			res.Errors = append(res.Errors, fmt.Errorf("parsing %q: %w", path, err))
 			continue
 		}
+		f.MaxInputBytes = r.MaxInputBytes
 		dir := filepath.Dir(path)
 		f.FS = os.DirFS(dir)
 		gitignoreDir := dir

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -109,6 +109,7 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 		res.Errors = append(res.Errors, fmt.Errorf("parsing %q: %w", path, err))
 		return res
 	}
+	f.MaxInputBytes = r.MaxInputBytes
 	if r.RootDir != "" {
 		f.SetRootDir(r.RootDir)
 	}

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -24,6 +24,9 @@ type Fixer struct {
 	// RootDir is the project root directory (parent of .mdsmith.yml).
 	// Used by rules that need to read files relative to the project root.
 	RootDir string
+	// MaxInputBytes is the maximum file size in bytes before a file is
+	// skipped with an error. Zero or negative means unlimited.
+	MaxInputBytes int64
 }
 
 // Result holds the outcome of a fix run.
@@ -81,7 +84,7 @@ func (f *Fixer) Fix(paths []string) *Result {
 func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, string, []error) {
 	var errs []error
 
-	source, err := os.ReadFile(path)
+	source, err := lint.ReadFileLimited(path, f.MaxInputBytes)
 	if err != nil {
 		return nil, nil, "", []error{fmt.Errorf("reading %q: %w", path, err)}
 	}
@@ -96,6 +99,7 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 		return nil, nil, "", []error{fmt.Errorf("parsing %q: %w", path, err)}
 	}
 
+	lf.MaxInputBytes = f.MaxInputBytes
 	dirFS := os.DirFS(filepath.Dir(path))
 	lf.FS = dirFS
 	if f.RootDir != "" {

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -22,6 +22,11 @@ type File struct {
 	FrontMatter []byte
 	LineOffset  int
 
+	// MaxInputBytes is the maximum file size in bytes that rules
+	// should enforce when reading secondary files (includes, schemas,
+	// cross-references). Zero or negative means unlimited.
+	MaxInputBytes int64
+
 	// GitignoreFunc is a lazy factory for the gitignore matcher.
 	// It is called at most once (on first access via GetGitignore)
 	// and the result is cached. Rules that do not call GetGitignore

--- a/internal/lint/limits.go
+++ b/internal/lint/limits.go
@@ -1,0 +1,76 @@
+package lint
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+// DefaultMaxInputBytes is the default file-size cap (2 MB, binary).
+const DefaultMaxInputBytes int64 = 2 * 1024 * 1024
+
+// ReadFileLimited reads path from disk, returning an error if the file
+// exceeds max bytes. When max <= 0 no limit is applied (unlimited mode).
+func ReadFileLimited(path string, max int64) ([]byte, error) {
+	if max <= 0 {
+		return os.ReadFile(path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read-only file
+
+	return readLimited(f, path, max)
+}
+
+// ReadFSFileLimited reads name from fsys, returning an error if the file
+// exceeds max bytes. When max <= 0 no limit is applied (unlimited mode).
+func ReadFSFileLimited(fsys fs.FS, name string, max int64) ([]byte, error) {
+	if max <= 0 {
+		return fs.ReadFile(fsys, name)
+	}
+
+	f, err := fsys.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on read-only file
+
+	return readLimited(f, name, max)
+}
+
+// readLimited reads from r up to max+1 bytes. If the read returns more
+// than max bytes the file is too large. The +1 sentinel distinguishes
+// "exactly at limit" from "truncated".
+// readLimited reads from r up to max+1 bytes. If the read returns more
+// than max bytes the file is too large. The +1 sentinel distinguishes
+// "exactly at limit" from "truncated".
+//
+// When the underlying reader is a file, we stat it first to report the
+// actual file size in the error message. For non-file readers (or when
+// stat fails), we report the truncated read length.
+func readLimited(r io.Reader, name string, max int64) ([]byte, error) {
+	// Try to get actual file size for a better error message.
+	var actualSize int64 = -1
+	if st, ok := r.(interface{ Stat() (os.FileInfo, error) }); ok {
+		if info, err := st.Stat(); err == nil {
+			actualSize = info.Size()
+		}
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		reported := actualSize
+		if reported < 0 {
+			reported = int64(len(data))
+		}
+		return nil, fmt.Errorf("reading %q: file too large (%d bytes, max %d)", name, reported, max)
+	}
+	return data, nil
+}

--- a/internal/lint/limits.go
+++ b/internal/lint/limits.go
@@ -45,9 +45,6 @@ func ReadFSFileLimited(fsys fs.FS, name string, max int64) ([]byte, error) {
 // readLimited reads from r up to max+1 bytes. If the read returns more
 // than max bytes the file is too large. The +1 sentinel distinguishes
 // "exactly at limit" from "truncated".
-// readLimited reads from r up to max+1 bytes. If the read returns more
-// than max bytes the file is too large. The +1 sentinel distinguishes
-// "exactly at limit" from "truncated".
 //
 // When the underlying reader is a file, we stat it first to report the
 // actual file size in the error message. For non-file readers (or when
@@ -70,7 +67,7 @@ func readLimited(r io.Reader, name string, max int64) ([]byte, error) {
 		if reported < 0 {
 			reported = int64(len(data))
 		}
-		return nil, fmt.Errorf("reading %q: file too large (%d bytes, max %d)", name, reported, max)
+		return nil, fmt.Errorf("file too large (%d bytes, max %d)", reported, max)
 	}
 	return data, nil
 }

--- a/internal/lint/limits.go
+++ b/internal/lint/limits.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 )
 
@@ -11,9 +12,11 @@ import (
 const DefaultMaxInputBytes int64 = 2 * 1024 * 1024
 
 // ReadFileLimited reads path from disk, returning an error if the file
-// exceeds max bytes. When max <= 0 no limit is applied (unlimited mode).
+// exceeds max bytes. When max <= 0 or max == math.MaxInt64 no limit is
+// applied (unlimited mode). MaxInt64 is treated as unlimited because the
+// +1 sentinel used internally would overflow.
 func ReadFileLimited(path string, max int64) ([]byte, error) {
-	if max <= 0 {
+	if max <= 0 || max == math.MaxInt64 {
 		return os.ReadFile(path)
 	}
 
@@ -27,9 +30,10 @@ func ReadFileLimited(path string, max int64) ([]byte, error) {
 }
 
 // ReadFSFileLimited reads name from fsys, returning an error if the file
-// exceeds max bytes. When max <= 0 no limit is applied (unlimited mode).
+// exceeds max bytes. When max <= 0 or max == math.MaxInt64 no limit is
+// applied (unlimited mode).
 func ReadFSFileLimited(fsys fs.FS, name string, max int64) ([]byte, error) {
-	if max <= 0 {
+	if max <= 0 || max == math.MaxInt64 {
 		return fs.ReadFile(fsys, name)
 	}
 

--- a/internal/lint/limits_test.go
+++ b/internal/lint/limits_test.go
@@ -1,6 +1,7 @@
 package lint_test
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,6 +84,26 @@ func TestReadFileLimited_EmptyFile(t *testing.T) {
 func TestReadFileLimited_NotFound(t *testing.T) {
 	_, err := lint.ReadFileLimited("/nonexistent/file.md", 100)
 	require.Error(t, err)
+}
+
+func TestReadFileLimited_MaxInt64Unlimited(t *testing.T) {
+	// MaxInt64 must be treated as unlimited to avoid overflow in max+1.
+	dir := t.TempDir()
+	p := filepath.Join(dir, "file.md")
+	require.NoError(t, os.WriteFile(p, []byte("hello"), 0o644))
+
+	data, err := lint.ReadFileLimited(p, math.MaxInt64)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), data)
+}
+
+func TestReadFSFileLimited_MaxInt64Unlimited(t *testing.T) {
+	fsys := fstest.MapFS{
+		"test.md": &fstest.MapFile{Data: []byte("hello")},
+	}
+	data, err := lint.ReadFSFileLimited(fsys, "test.md", math.MaxInt64)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), data)
 }
 
 func TestReadFSFileLimited_Normal(t *testing.T) {

--- a/internal/lint/limits_test.go
+++ b/internal/lint/limits_test.go
@@ -1,0 +1,128 @@
+package lint_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFileLimited_Normal(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "small.md")
+	require.NoError(t, os.WriteFile(p, []byte("hello"), 0o644))
+
+	data, err := lint.ReadFileLimited(p, 100)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), data)
+}
+
+func TestReadFileLimited_AtLimit(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "exact.md")
+	content := make([]byte, 50)
+	for i := range content {
+		content[i] = 'x'
+	}
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+
+	data, err := lint.ReadFileLimited(p, 50)
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestReadFileLimited_OverLimit(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "huge.md")
+	content := make([]byte, 100)
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+
+	_, err := lint.ReadFileLimited(p, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file too large")
+	assert.Contains(t, err.Error(), "100 bytes")
+	assert.Contains(t, err.Error(), "max 50")
+}
+
+func TestReadFileLimited_ZeroUnlimited(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.md")
+	content := make([]byte, 10000)
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+
+	data, err := lint.ReadFileLimited(p, 0)
+	require.NoError(t, err)
+	assert.Len(t, data, 10000)
+}
+
+func TestReadFileLimited_NegativeUnlimited(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.md")
+	content := make([]byte, 10000)
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+
+	data, err := lint.ReadFileLimited(p, -1)
+	require.NoError(t, err)
+	assert.Len(t, data, 10000)
+}
+
+func TestReadFileLimited_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "empty.md")
+	require.NoError(t, os.WriteFile(p, nil, 0o644))
+
+	data, err := lint.ReadFileLimited(p, 100)
+	require.NoError(t, err)
+	assert.Empty(t, data)
+}
+
+func TestReadFileLimited_NotFound(t *testing.T) {
+	_, err := lint.ReadFileLimited("/nonexistent/file.md", 100)
+	require.Error(t, err)
+}
+
+func TestReadFSFileLimited_Normal(t *testing.T) {
+	fsys := fstest.MapFS{
+		"test.md": &fstest.MapFile{Data: []byte("hello")},
+	}
+	data, err := lint.ReadFSFileLimited(fsys, "test.md", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), data)
+}
+
+func TestReadFSFileLimited_OverLimit(t *testing.T) {
+	content := make([]byte, 100)
+	fsys := fstest.MapFS{
+		"big.md": &fstest.MapFile{Data: content},
+	}
+	_, err := lint.ReadFSFileLimited(fsys, "big.md", 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file too large")
+}
+
+func TestReadFSFileLimited_ZeroUnlimited(t *testing.T) {
+	content := make([]byte, 10000)
+	fsys := fstest.MapFS{
+		"big.md": &fstest.MapFile{Data: content},
+	}
+	data, err := lint.ReadFSFileLimited(fsys, "big.md", 0)
+	require.NoError(t, err)
+	assert.Len(t, data, 10000)
+}
+
+func TestReadFSFileLimited_AtLimit(t *testing.T) {
+	content := make([]byte, 50)
+	for i := range content {
+		content[i] = 'a'
+	}
+	fsys := fstest.MapFS{
+		"exact.md": &fstest.MapFile{Data: content},
+	}
+	data, err := lint.ReadFSFileLimited(fsys, "exact.md", 50)
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
+}

--- a/internal/metrics/metrics_coverage_test.go
+++ b/internal/metrics/metrics_coverage_test.go
@@ -17,7 +17,7 @@ func TestCollect_BasicFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello\n\nworld\n"), 0o644))
 
 	defs := Defaults(ScopeFile)
-	rows, err := Collect([]string{mdFile}, defs)
+	rows, err := Collect([]string{mdFile}, defs, 0)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, mdFile, rows[0].Path)
@@ -38,7 +38,7 @@ func TestCollect_MultipleFiles(t *testing.T) {
 		}},
 	}
 
-	rows, err := Collect([]string{f1, f2}, defs)
+	rows, err := Collect([]string{f1, f2}, defs, 0)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 }
@@ -46,13 +46,13 @@ func TestCollect_MultipleFiles(t *testing.T) {
 func TestCollect_NonexistentFile(t *testing.T) {
 	defs := Defaults(ScopeFile)
 	missing := filepath.Join(t.TempDir(), "does-not-exist.md")
-	_, err := Collect([]string{missing}, defs)
+	_, err := Collect([]string{missing}, defs, 0)
 	assert.Error(t, err)
 }
 
 func TestCollect_EmptyPaths(t *testing.T) {
 	defs := Defaults(ScopeFile)
-	rows, err := Collect([]string{}, defs)
+	rows, err := Collect([]string{}, defs, 0)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }

--- a/internal/metrics/rank.go
+++ b/internal/metrics/rank.go
@@ -3,9 +3,10 @@ package metrics
 import (
 	"fmt"
 	"math"
-	"os"
 	"sort"
 	"strconv"
+
+	"github.com/jeduden/mdsmith/internal/lint"
 )
 
 // Row holds computed metric values for a single file.
@@ -15,10 +16,11 @@ type Row struct {
 }
 
 // Collect computes all selected metrics for each file path.
-func Collect(paths []string, defs []Definition) ([]Row, error) {
+// maxBytes limits the file size that will be read; zero or negative means unlimited.
+func Collect(paths []string, defs []Definition, maxBytes int64) ([]Row, error) {
 	rows := make([]Row, 0, len(paths))
 	for _, path := range paths {
-		source, err := os.ReadFile(path)
+		source, err := lint.ReadFileLimited(path, maxBytes)
 		if err != nil {
 			return nil, fmt.Errorf("reading %q: %w", path, err)
 		}

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -85,6 +85,9 @@ func (r *Rule) Generate(f *lint.File, filePath string, line int,
 	params map[string]string, columns map[string]gensection.ColumnConfig,
 ) (string, []lint.Diagnostic) {
 	cols := fromGensectionColumns(columns)
+	// Read errors (e.g. "file too large") are fatal for generation:
+	// a partially-rendered catalog would silently hide missing rows,
+	// which is worse than failing loudly with a clear diagnostic.
 	entries, entryDiags := buildCatalogEntries(f, params, filePath, line)
 	if len(entryDiags) > 0 {
 		return "", entryDiags

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -85,7 +85,10 @@ func (r *Rule) Generate(f *lint.File, filePath string, line int,
 	params map[string]string, columns map[string]gensection.ColumnConfig,
 ) (string, []lint.Diagnostic) {
 	cols := fromGensectionColumns(columns)
-	entries := buildCatalogEntries(f, params)
+	entries, entryDiags := buildCatalogEntries(f, params, filePath, line)
+	if len(entryDiags) > 0 {
+		return "", entryDiags
+	}
 
 	// Check if any matched file includes (directly or indirectly) the
 	// catalog-owning file. If so, the catalog body would contain itself.
@@ -288,8 +291,15 @@ func resolveGlobFS(f *lint.File, params map[string]string) (globFS fs.FS, prefix
 }
 
 // buildCatalogEntries resolves glob matches, reads front matter, and
-// returns sorted file entries for the catalog directive.
-func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
+// returns sorted file entries for the catalog directive. Read errors
+// (notably "file too large") are returned as diagnostics attached to
+// the directive's file+line. Callers in the Generate path treat any
+// returned diagnostic as fatal to avoid producing an incomplete catalog;
+// check-only callers (checkInjection, checkCaseMismatches) discard the
+// diagnostics because Generate already surfaces them.
+func buildCatalogEntries(
+	f *lint.File, params map[string]string, filePath string, line int,
+) ([]fileEntry, []lint.Diagnostic) {
 	globFS, prefix := resolveGlobFS(f, params)
 	files := resolveGlobMatchesFrom(globFS, f, params)
 
@@ -297,6 +307,7 @@ func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
 	_, hasRow := params["row"]
 	needFM := hasRow || (sortKey != "path" && sortKey != "filename")
 
+	var diags []lint.Diagnostic
 	entries := make([]fileEntry, 0, len(files))
 	for _, p := range files {
 		displayPath := p
@@ -305,7 +316,13 @@ func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
 		}
 		fields := map[string]any{"filename": displayPath}
 		if needFM {
-			for k, v := range readFrontMatter(globFS, p, f.MaxInputBytes) {
+			fm, err := readFrontMatter(globFS, p, f.MaxInputBytes)
+			if err != nil {
+				diags = append(diags, makeDiag(filePath, line,
+					fmt.Sprintf("cannot read front matter from %q: %v", displayPath, err)))
+				continue
+			}
+			for k, v := range fm {
 				fields[k] = v
 			}
 		}
@@ -313,7 +330,7 @@ func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
 	}
 
 	sortEntries(entries, sortKey, descending)
-	return entries
+	return entries, diags
 }
 
 // resolveGlobMatchesFrom expands include patterns using the given FS,
@@ -441,7 +458,8 @@ func (r *Rule) checkInjection(f *lint.File) []lint.Diagnostic {
 		if dir == nil || len(parseDiags) > 0 {
 			continue
 		}
-		entries := buildCatalogEntries(f, dir.Params)
+		// Ignore entry diagnostics here; Generate surfaces them.
+		entries, _ := buildCatalogEntries(f, dir.Params, f.Path, mp.StartLine)
 		diags = append(diags, checkCatalogInjection(f.Path, mp.StartLine, entries)...)
 	}
 	return diags
@@ -517,16 +535,19 @@ func sortValue(entry fileEntry, key string) string {
 
 // readFrontMatter reads a file's YAML front matter and returns it as
 // a map preserving nested structure for CUE path resolution.
-// Returns nil if no front matter is found or on any error.
-func readFrontMatter(fsys fs.FS, path string, maxBytes int64) map[string]any {
+// Returns (nil, nil) if no front matter is found or content is
+// malformed. Returns (nil, err) when the file itself cannot be read —
+// notably when it exceeds the configured max-input-size — so callers
+// can surface the failure instead of treating it as "no front matter".
+func readFrontMatter(fsys fs.FS, path string, maxBytes int64) (map[string]any, error) {
 	data, err := lint.ReadFSFileLimited(fsys, path, maxBytes)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	prefix, _ := lint.StripFrontMatter(data)
 	if prefix == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Extract the YAML between --- delimiters.
@@ -534,19 +555,19 @@ func readFrontMatter(fsys fs.FS, path string, maxBytes int64) map[string]any {
 	s = strings.TrimPrefix(s, "---\n")
 	idx := strings.Index(s, "---\n")
 	if idx < 0 {
-		return nil
+		return nil, nil
 	}
 	yamlStr := s[:idx]
 
 	var raw map[string]any
 	if err := lint.RejectYAMLAliases([]byte(yamlStr)); err != nil {
-		return nil
+		return nil, nil
 	}
 	if err := yaml.Unmarshal([]byte(yamlStr), &raw); err != nil {
-		return nil
+		return nil, nil
 	}
 
-	return raw
+	return raw, nil
 }
 
 // checkCatalogIncludeCycle checks whether any file matched by the catalog
@@ -720,7 +741,8 @@ func (r *Rule) checkCaseMismatches(f *lint.File) []lint.Diagnostic {
 		if !hasNonBuiltin {
 			continue
 		}
-		entries := buildCatalogEntries(f, dir.Params)
+		// Ignore entry diagnostics here; Generate surfaces them.
+		entries, _ := buildCatalogEntries(f, dir.Params, f.Path, mp.StartLine)
 		diags = append(diags, checkFieldCaseMismatches(f.Path, mp.StartLine, row, entries)...)
 	}
 	return diags

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -305,7 +305,7 @@ func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
 		}
 		fields := map[string]any{"filename": displayPath}
 		if needFM {
-			for k, v := range readFrontMatter(globFS, p) {
+			for k, v := range readFrontMatter(globFS, p, f.MaxInputBytes) {
 				fields[k] = v
 			}
 		}
@@ -518,8 +518,8 @@ func sortValue(entry fileEntry, key string) string {
 // readFrontMatter reads a file's YAML front matter and returns it as
 // a map preserving nested structure for CUE path resolution.
 // Returns nil if no front matter is found or on any error.
-func readFrontMatter(fsys fs.FS, path string) map[string]any {
-	data, err := fs.ReadFile(fsys, path)
+func readFrontMatter(fsys fs.FS, path string, maxBytes int64) map[string]any {
+	data, err := lint.ReadFSFileLimited(fsys, path, maxBytes)
 	if err != nil {
 		return nil
 	}
@@ -565,7 +565,7 @@ func checkCatalogIncludeCycle(
 	catalogFile := filepath.Base(filePath)
 	for _, entry := range entries {
 		matchedPath := fieldinterp.Stringify(entry.fields["filename"])
-		if fileIncludesTarget(f.FS, matchedPath, catalogFile) {
+		if fileIncludesTarget(f.FS, matchedPath, catalogFile, f.MaxInputBytes) {
 			return []lint.Diagnostic{makeDiag(filePath, line,
 				fmt.Sprintf(
 					"catalog includes %q which includes %q via <?include?>, creating a cycle",
@@ -579,10 +579,10 @@ func checkCatalogIncludeCycle(
 // include directives that (directly or indirectly) reference the
 // target file. Uses a visited set to avoid infinite recursion.
 func fileIncludesTarget(
-	fsys fs.FS, filePath, target string,
+	fsys fs.FS, filePath, target string, maxBytes int64,
 ) bool {
 	visited := map[string]bool{filePath: true}
-	return scanIncludesForTarget(fsys, filePath, target, visited, 0)
+	return scanIncludesForTarget(fsys, filePath, target, visited, 0, maxBytes)
 }
 
 // maxIncludeDepth mirrors the include rule's depth limit for consistency.
@@ -590,12 +590,12 @@ const maxIncludeDepth = 10
 
 func scanIncludesForTarget(
 	fsys fs.FS, filePath, target string,
-	visited map[string]bool, depth int,
+	visited map[string]bool, depth int, maxBytes int64,
 ) bool {
 	if depth > maxIncludeDepth {
 		return false
 	}
-	data, err := fs.ReadFile(fsys, filePath)
+	data, err := lint.ReadFSFileLimited(fsys, filePath, maxBytes)
 	if err != nil {
 		return false
 	}
@@ -624,7 +624,7 @@ func scanIncludesForTarget(
 			continue
 		}
 		visited[resolved] = true
-		found := scanIncludesForTarget(fsys, resolved, target, visited, depth+1)
+		found := scanIncludesForTarget(fsys, resolved, target, visited, depth+1, maxBytes)
 		delete(visited, resolved)
 		if found {
 			return true

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -1882,7 +1882,7 @@ func TestReadFrontMatter_Valid(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ndescription: World\n---\n# Content\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	if fm["title"] != "Hello" {
 		t.Errorf("expected title Hello, got %q", fm["title"])
 	}
@@ -1895,7 +1895,7 @@ func TestReadFrontMatter_NoFrontMatter(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("# No front matter\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	assert.Nil(t, fm, "expected nil for no front matter, got %v", fm)
 }
 
@@ -1903,7 +1903,7 @@ func TestReadFrontMatter_InvalidYAML(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ninvalid: [yaml\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	assert.Nil(t, fm, "expected nil for invalid YAML, got %v", fm)
 }
 
@@ -1911,7 +1911,7 @@ func TestReadFrontMatter_NonStringValue(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ncount: 42\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	if fm["title"] != "Hello" {
 		t.Errorf("expected title Hello, got %q", fm["title"])
 	}
@@ -1922,7 +1922,7 @@ func TestReadFrontMatter_NonStringValue(t *testing.T) {
 
 func TestReadFrontMatter_UnreadableFile(t *testing.T) {
 	fs := fstest.MapFS{}
-	fm := readFrontMatter(fs, "missing.md", 0)
+	fm, _ := readFrontMatter(fs, "missing.md", 0)
 	assert.Nil(t, fm, "expected nil for missing file, got %v", fm)
 }
 
@@ -1930,7 +1930,7 @@ func TestReadFrontMatter_EmptyFile(t *testing.T) {
 	fs := fstest.MapFS{
 		"empty.md": {Data: []byte("")},
 	}
-	fm := readFrontMatter(fs, "empty.md", 0)
+	fm, _ := readFrontMatter(fs, "empty.md", 0)
 	assert.Nil(t, fm, "expected nil for empty file, got %v", fm)
 }
 
@@ -1939,7 +1939,7 @@ func TestReadFrontMatter_OnlyOpeningDelimiter(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	assert.Nil(t, fm, "expected nil for unclosed front matter, got %v", fm)
 }
 
@@ -1948,7 +1948,7 @@ func TestReadFrontMatter_BooleanValue(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ndraft: true\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	if fm["draft"] != true {
 		t.Errorf("expected draft true, got %v", fm["draft"])
 	}
@@ -1959,7 +1959,7 @@ func TestReadFrontMatter_ListValue(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ntags: [go, lint]\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md", 0)
+	fm, _ := readFrontMatter(fs, "a.md", 0)
 	if fm["title"] != "Hello" {
 		t.Errorf("expected title Hello, got %q", fm["title"])
 	}
@@ -3128,7 +3128,7 @@ func TestReadFrontMatter_AnchorReturnsNil(t *testing.T) {
 		"doc.md": {Data: []byte(
 			"---\nbase: &base\n  id: 1\n---\n# Title\n")},
 	}
-	result := readFrontMatter(mapFS, "doc.md", 0)
+	result, _ := readFrontMatter(mapFS, "doc.md", 0)
 	assert.Nil(t, result)
 }
 

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -1922,8 +1922,9 @@ func TestReadFrontMatter_NonStringValue(t *testing.T) {
 
 func TestReadFrontMatter_UnreadableFile(t *testing.T) {
 	fs := fstest.MapFS{}
-	fm, _ := readFrontMatter(fs, "missing.md", 0)
+	fm, err := readFrontMatter(fs, "missing.md", 0)
 	assert.Nil(t, fm, "expected nil for missing file, got %v", fm)
+	assert.Error(t, err, "expected error for missing file")
 }
 
 func TestReadFrontMatter_EmptyFile(t *testing.T) {

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -1882,7 +1882,7 @@ func TestReadFrontMatter_Valid(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ndescription: World\n---\n# Content\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	if fm["title"] != "Hello" {
 		t.Errorf("expected title Hello, got %q", fm["title"])
 	}
@@ -1895,7 +1895,7 @@ func TestReadFrontMatter_NoFrontMatter(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("# No front matter\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	assert.Nil(t, fm, "expected nil for no front matter, got %v", fm)
 }
 
@@ -1903,7 +1903,7 @@ func TestReadFrontMatter_InvalidYAML(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ninvalid: [yaml\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	assert.Nil(t, fm, "expected nil for invalid YAML, got %v", fm)
 }
 
@@ -1911,7 +1911,7 @@ func TestReadFrontMatter_NonStringValue(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ncount: 42\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	if fm["title"] != "Hello" {
 		t.Errorf("expected title Hello, got %q", fm["title"])
 	}
@@ -1922,7 +1922,7 @@ func TestReadFrontMatter_NonStringValue(t *testing.T) {
 
 func TestReadFrontMatter_UnreadableFile(t *testing.T) {
 	fs := fstest.MapFS{}
-	fm := readFrontMatter(fs, "missing.md")
+	fm := readFrontMatter(fs, "missing.md", 0)
 	assert.Nil(t, fm, "expected nil for missing file, got %v", fm)
 }
 
@@ -1930,7 +1930,7 @@ func TestReadFrontMatter_EmptyFile(t *testing.T) {
 	fs := fstest.MapFS{
 		"empty.md": {Data: []byte("")},
 	}
-	fm := readFrontMatter(fs, "empty.md")
+	fm := readFrontMatter(fs, "empty.md", 0)
 	assert.Nil(t, fm, "expected nil for empty file, got %v", fm)
 }
 
@@ -1939,7 +1939,7 @@ func TestReadFrontMatter_OnlyOpeningDelimiter(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	assert.Nil(t, fm, "expected nil for unclosed front matter, got %v", fm)
 }
 
@@ -1948,7 +1948,7 @@ func TestReadFrontMatter_BooleanValue(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ndraft: true\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	if fm["draft"] != true {
 		t.Errorf("expected draft true, got %v", fm["draft"])
 	}
@@ -1959,7 +1959,7 @@ func TestReadFrontMatter_ListValue(t *testing.T) {
 	fs := fstest.MapFS{
 		"a.md": {Data: []byte("---\ntitle: Hello\ntags: [go, lint]\n---\n")},
 	}
-	fm := readFrontMatter(fs, "a.md")
+	fm := readFrontMatter(fs, "a.md", 0)
 	if fm["title"] != "Hello" {
 		t.Errorf("expected title Hello, got %q", fm["title"])
 	}
@@ -3128,7 +3128,7 @@ func TestReadFrontMatter_AnchorReturnsNil(t *testing.T) {
 		"doc.md": {Data: []byte(
 			"---\nbase: &base\n  id: 1\n---\n# Title\n")},
 	}
-	result := readFrontMatter(mapFS, "doc.md")
+	result := readFrontMatter(mapFS, "doc.md", 0)
 	assert.Nil(t, result)
 }
 

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -1927,12 +1927,23 @@ func TestReadFrontMatter_UnreadableFile(t *testing.T) {
 	assert.Error(t, err, "expected error for missing file")
 }
 
+func TestReadFrontMatter_SizeLimitExceeded(t *testing.T) {
+	fs := fstest.MapFS{
+		"big.md": {Data: []byte("---\ntitle: Big\n---\n" + strings.Repeat("x", 200))},
+	}
+	fm, err := readFrontMatter(fs, "big.md", 10)
+	assert.Nil(t, fm, "expected nil for oversized file")
+	assert.Error(t, err, "expected error for oversized file")
+	assert.Contains(t, err.Error(), "file too large")
+}
+
 func TestReadFrontMatter_EmptyFile(t *testing.T) {
 	fs := fstest.MapFS{
 		"empty.md": {Data: []byte("")},
 	}
-	fm, _ := readFrontMatter(fs, "empty.md", 0)
+	fm, err := readFrontMatter(fs, "empty.md", 0)
 	assert.Nil(t, fm, "expected nil for empty file, got %v", fm)
+	assert.NoError(t, err, "empty file should not cause error")
 }
 
 func TestReadFrontMatter_OnlyOpeningDelimiter(t *testing.T) {
@@ -3185,7 +3196,6 @@ func TestCatalogInjection_BothNewlineAndLink(t *testing.T) {
 }
 
 // =====================================================================
-<<<<<<< HEAD
 // source-dir: glob resolution from included file's directory (#133)
 // =====================================================================
 

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3184,6 +3184,7 @@ func TestCatalogInjection_BothNewlineAndLink(t *testing.T) {
 }
 
 // =====================================================================
+<<<<<<< HEAD
 // source-dir: glob resolution from included file's directory (#133)
 // =====================================================================
 
@@ -3431,4 +3432,54 @@ source-dir: ".."
 	// Should not panic or escape; falls back to f.FS.
 	result := string(r.Fix(f))
 	assert.Contains(t, result, "top.md")
+}
+
+// =====================================================================
+// buildCatalogEntries error diagnostics (file-size limit)
+// =====================================================================
+
+func TestBuildCatalogEntries_SizeLimit_EmitsDiagnostic(t *testing.T) {
+	bigContent := strings.Repeat("x", 100)
+	fsys := fstest.MapFS{
+		"big.md": &fstest.MapFile{
+			Data: []byte("---\ntitle: Big\n---\n" + bigContent),
+		},
+	}
+	f := &lint.File{
+		Path:          "index.md",
+		FS:            fsys,
+		MaxInputBytes: 20,
+	}
+	params := map[string]string{
+		"glob": "big.md",
+		"row":  "- [{title}](big.md)",
+	}
+
+	entries, diags := buildCatalogEntries(f, params, "index.md", 1)
+	assert.Empty(t, entries, "entry skipped due to read failure")
+	require.Len(t, diags, 1, "expected one diagnostic")
+	assert.Contains(t, diags[0].Message, "cannot read front matter")
+	assert.Contains(t, diags[0].Message, "file too large")
+}
+
+func TestBuildCatalogEntries_Normal_NoDiagnostics(t *testing.T) {
+	fsys := fstest.MapFS{
+		"a.md": &fstest.MapFile{
+			Data: []byte("---\ntitle: A\n---\n# A\n"),
+		},
+	}
+	f := &lint.File{
+		Path:          "index.md",
+		FS:            fsys,
+		MaxInputBytes: 1000,
+	}
+	params := map[string]string{
+		"glob": "a.md",
+		"row":  "- [{title}](a.md)",
+	}
+
+	entries, diags := buildCatalogEntries(f, params, "index.md", 1)
+	assert.Len(t, entries, 1, "entry should be kept")
+	assert.Empty(t, diags)
+	assert.Equal(t, "A", entries[0].fields["title"])
 }

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -237,6 +237,7 @@ func anchorsForFile(target targetFile, cache map[string]map[string]bool) (map[st
 }
 
 func resolveTargetFile(f *lint.File, linkPath, resolvedRoot string) (targetFile, bool) {
+	maxBytes := f.MaxInputBytes
 	if path, ok := resolveTargetOSPath(f.Path, linkPath); ok {
 		if _, err := os.Stat(path); err == nil {
 			// Reject links that resolve outside the project root,
@@ -247,7 +248,7 @@ func resolveTargetFile(f *lint.File, linkPath, resolvedRoot string) (targetFile,
 			return targetFile{
 				cacheKey: "os:" + path,
 				read: func() ([]byte, error) {
-					return os.ReadFile(path)
+					return lint.ReadFileLimited(path, maxBytes)
 				},
 			}, true
 		}
@@ -264,7 +265,7 @@ func resolveTargetFile(f *lint.File, linkPath, resolvedRoot string) (targetFile,
 	return targetFile{
 		cacheKey: "fs:" + fsPath,
 		read: func() ([]byte, error) {
-			return fs.ReadFile(f.FS, fsPath)
+			return lint.ReadFSFileLimited(f.FS, fsPath, maxBytes)
 		},
 	}, true
 }

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -139,7 +139,7 @@ func (r *Rule) checkLink(
 
 	targetAnchors, err := anchorsForFile(targetFile, anchorCache)
 	if err != nil {
-		return []lint.Diagnostic{brokenFileDiag(f.Path, line, col, r, target.Raw)}
+		return []lint.Diagnostic{unreadableTargetDiag(f.Path, line, col, r, target.Raw, err)}
 	}
 	if targetAnchors[normalizeAnchor(target.Anchor)] {
 		return nil
@@ -573,6 +573,22 @@ func brokenFileDiag(path string, line, col int, r *Rule, target string) lint.Dia
 		RuleName: r.Name(),
 		Severity: lint.Warning,
 		Message:  fmt.Sprintf("broken link target %q not found", target),
+	}
+}
+
+// unreadableTargetDiag reports a link whose target exists on the
+// filesystem but cannot be read (e.g. exceeds the configured
+// max-input-size). The underlying error is surfaced so users can
+// distinguish these from genuinely missing targets.
+func unreadableTargetDiag(path string, line, col int, r *Rule, target string, err error) lint.Diagnostic {
+	return lint.Diagnostic{
+		File:     path,
+		Line:     line,
+		Column:   col,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  fmt.Sprintf("cannot read link target %q: %v", target, err),
 	}
 }
 

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1,6 +1,7 @@
 package crossfilereferenceintegrity
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -379,6 +380,41 @@ func TestResolveTargetFile_AllowsInsideRoot(t *testing.T) {
 
 	_, ok := resolveTargetFile(f, "../target.md", resolvedRoot)
 	require.True(t, ok, "should allow link within root")
+}
+
+// TestResolveTargetFile_MaxInputBytes verifies that the read closure
+// returned by resolveTargetFile honors f.MaxInputBytes — an oversized
+// target file should produce a "file too large" error, which callers
+// surface via unreadableTargetDiag instead of a misleading "not found".
+func TestResolveTargetFile_MaxInputBytes(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.md")
+	writeFile(t, target, "# Target\n\n"+strings.Repeat("x", 200))
+
+	f := &lint.File{
+		Path:          filepath.Join(root, "doc.md"),
+		FS:            os.DirFS(root),
+		MaxInputBytes: 50,
+	}
+	resolvedRoot := resolveAbsRoot(root)
+
+	tgt, ok := resolveTargetFile(f, "target.md", resolvedRoot)
+	require.True(t, ok, "expected target resolution to succeed")
+
+	_, err := tgt.read()
+	require.Error(t, err, "expected file too large error")
+	require.Contains(t, err.Error(), "file too large")
+}
+
+func TestUnreadableTargetDiag(t *testing.T) {
+	r := &Rule{}
+	err := errors.New("file too large (200 bytes, max 50)")
+	d := unreadableTargetDiag("doc.md", 5, 10, r, "target.md", err)
+	require.Equal(t, "doc.md", d.File)
+	require.Equal(t, 5, d.Line)
+	require.Equal(t, 10, d.Column)
+	require.Contains(t, d.Message, "cannot read link target")
+	require.Contains(t, d.Message, "file too large")
 }
 
 func TestIsWithinRoot_RelativeTarget(t *testing.T) {

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -195,7 +195,7 @@ func (r *Rule) generateIncludeContent(
 	data, err := lint.ReadFSFileLimited(readFS, readPath, f.MaxInputBytes)
 	if err != nil {
 		return "", []lint.Diagnostic{makeDiag(filePath, line,
-			fmt.Sprintf("include file %q not found: %v", file, err))}
+			fmt.Sprintf("cannot read include file %q: %v", file, err))}
 	}
 
 	// Track this file and recursively expand nested includes.

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -192,7 +192,7 @@ func (r *Rule) generateIncludeContent(
 		return "", diags
 	}
 
-	data, err := fs.ReadFile(readFS, readPath)
+	data, err := lint.ReadFSFileLimited(readFS, readPath, f.MaxInputBytes)
 	if err != nil {
 		return "", []lint.Diagnostic{makeDiag(filePath, line,
 			fmt.Sprintf("include file %q not found: %v", file, err))}
@@ -206,7 +206,7 @@ func (r *Rule) generateIncludeContent(
 			delete(r.visited, resolvedFile)
 			r.chain = r.chain[:len(r.chain)-1]
 		}()
-		expanded, expandDiags := r.expandNestedIncludes(readFS, data, resolvedFile)
+		expanded, expandDiags := r.expandNestedIncludes(readFS, data, resolvedFile, f.MaxInputBytes)
 		if len(expandDiags) > 0 {
 			// Remap diagnostics to this include directive so the
 			// lint pipeline uses the correct file for context.
@@ -342,7 +342,7 @@ func containsDotDotElement(p string) bool {
 // directives and recursively expands them, so that a single fix pass
 // produces the fully flattened output regardless of file order.
 func (r *Rule) expandNestedIncludes(
-	readFS fs.FS, data []byte, resolvedFile string,
+	readFS fs.FS, data []byte, resolvedFile string, maxBytes int64,
 ) ([]byte, []lint.Diagnostic) {
 	// Parse the full data including frontmatter so that marker pair
 	// line numbers match the real file. Goldmark treats frontmatter
@@ -352,6 +352,7 @@ func (r *Rule) expandNestedIncludes(
 	if err != nil {
 		return data, nil
 	}
+	f.MaxInputBytes = maxBytes
 	f.FS = readFS
 	// RootFS must be set so resolveIncludePath uses root-relative
 	// readPath. Without it, readPath is the raw file parameter,

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -203,7 +203,7 @@ func TestCheck_MissingFile(t *testing.T) {
 	f := newTestFile(t, "doc.md", src, fsys)
 	r := &Rule{}
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, "not found")
+	expectDiagMsg(t, diags, "cannot read include file")
 }
 
 // =====================================================================

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -503,7 +503,7 @@ func expandSchemaInclude(
 	fragData, err := lint.ReadFileLimited(includedPath, maxBytes)
 	if err != nil {
 		return nil, "", fmt.Errorf(
-			"schema include file %q not found: %w", includedPath, err)
+			"cannot read schema include file %q: %w", includedPath, err)
 	}
 
 	_, fragContent := lint.StripFrontMatter(fragData)

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -3,7 +3,6 @@ package requiredstructure
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -86,7 +85,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			fmt.Sprintf("cannot read schema %q: %v", r.Schema, err)))
 	}
 
-	sch, err := parseSchema(schData, r.Schema)
+	sch, err := parseSchema(schData, r.Schema, f.MaxInputBytes)
 	if err != nil {
 		return append(diags, r.diag(f.Path, 1,
 			fmt.Sprintf("invalid schema %q: %v", r.Schema, err)))
@@ -351,7 +350,7 @@ const maxSchemaIncludeDepth = 10
 // parseSchema reads schema bytes, extracts frontmatter config and
 // required headings. When schemaPath is non-empty, <?include?> directives
 // are expanded and their headings spliced in.
-func parseSchema(data []byte, schemaPath string) (*parsedSchema, error) {
+func parseSchema(data []byte, schemaPath string, maxBytes int64) (*parsedSchema, error) {
 	prefix, content := lint.StripFrontMatter(data)
 
 	cfg, err := parseSchemaFrontMatter(prefix)
@@ -378,7 +377,7 @@ func parseSchema(data []byte, schemaPath string) (*parsedSchema, error) {
 		visited := map[string]bool{cleanPath: true}
 		chain := []string{cleanPath}
 		var fp string
-		headings, fp, err = extractSchemaHeadings(f, schemaPath, visited, chain)
+		headings, fp, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes)
 		if err != nil {
 			return nil, err
 		}
@@ -413,7 +412,7 @@ func parseSchema(data []byte, schemaPath string) (*parsedSchema, error) {
 // It uses a visited set for cycle detection.
 func extractSchemaHeadings(
 	schemaFile *lint.File, schemaPath string,
-	visited map[string]bool, chain []string,
+	visited map[string]bool, chain []string, maxBytes int64,
 ) ([]docHeading, string, error) {
 	var headings []docHeading
 	var filenamePattern string
@@ -434,7 +433,7 @@ func extractSchemaHeadings(
 				return ast.WalkContinue, nil
 			}
 			fragHeadings, fp, walkErr := expandSchemaInclude(
-				node, schemaFile.Source, schemaPath, visited, chain)
+				node, schemaFile.Source, schemaPath, visited, chain, maxBytes)
 			if walkErr != nil {
 				return ast.WalkStop, walkErr
 			}
@@ -482,7 +481,7 @@ func resolveSchemaIncludePath(
 
 func expandSchemaInclude(
 	pi *lint.ProcessingInstruction, source []byte,
-	schemaPath string, visited map[string]bool, chain []string,
+	schemaPath string, visited map[string]bool, chain []string, maxBytes int64,
 ) ([]docHeading, string, error) {
 	includedPath, err := resolveSchemaIncludePath(pi, source, schemaPath)
 	if err != nil {
@@ -501,7 +500,7 @@ func expandSchemaInclude(
 			"cyclic include: %s", strings.Join(chainCopy, " -> "))
 	}
 
-	fragData, err := os.ReadFile(includedPath)
+	fragData, err := lint.ReadFileLimited(includedPath, maxBytes)
 	if err != nil {
 		return nil, "", fmt.Errorf(
 			"schema include file %q not found: %w", includedPath, err)
@@ -522,7 +521,7 @@ func expandSchemaInclude(
 	visited[includedPath] = true
 	chain = append(chain, includedPath)
 	fragHeadings, fp2, err := extractSchemaHeadings(
-		fragFile, includedPath, visited, chain)
+		fragFile, includedPath, visited, chain, maxBytes)
 	delete(visited, includedPath)
 	if err != nil {
 		return nil, "", err
@@ -1031,9 +1030,9 @@ func readSchemaFile(f *lint.File, schema string) ([]byte, error) {
 		if clean == ".." || strings.HasPrefix(clean, "../") {
 			return nil, fmt.Errorf("schema path %q escapes project root", schema)
 		}
-		return fs.ReadFile(f.RootFS, clean)
+		return lint.ReadFSFileLimited(f.RootFS, clean, f.MaxInputBytes)
 	}
-	return os.ReadFile(schema)
+	return lint.ReadFileLimited(schema, f.MaxInputBytes)
 }
 
 func makeDiag(file string, line int, msg string) lint.Diagnostic {

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -166,7 +166,7 @@ func TestParseSchema_Headings(t *testing.T) {
 
 ### Bad
 `
-	tmpl, err := parseSchema([]byte(schemaSrc), "")
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err, "unexpected error: %v", err)
 	if len(tmpl.Headings) != 5 {
 		t.Fatalf(
@@ -193,7 +193,7 @@ func TestParseSchema_SyncPoints(t *testing.T) {
 
 {description}
 `
-	tmpl, err := parseSchema([]byte(schemaSrc), "")
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err, "unexpected error: %v", err)
 	headingSyncs := tmpl.SyncPoints[0]
 	if len(headingSyncs) < 2 {
@@ -235,7 +235,7 @@ func TestParseSchema_StrictOrder(t *testing.T) {
 
 ## Acceptance Criteria
 `
-	tmpl, err := parseSchema([]byte(schemaSrc), "")
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err, "unexpected error: %v", err)
 	if len(tmpl.Headings) != 4 {
 		t.Fatalf(
@@ -666,7 +666,7 @@ func TestParseSchema_SchemaInclude(t *testing.T) {
 	schemaPath := filepath.Join(dir, "schema.md")
 	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0o644))
 
-	tmpl, err := parseSchema([]byte(schema), schemaPath)
+	tmpl, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.NoError(t, err)
 	require.Len(t, tmpl.Headings, 3)
 	assert.Equal(t, "?", tmpl.Headings[0].Text)
@@ -687,7 +687,7 @@ func TestParseSchema_SchemaIncludeRequireMerge(t *testing.T) {
 	schemaPath := filepath.Join(dir, "schema.md")
 	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0o644))
 
-	tmpl, err := parseSchema([]byte(schema), schemaPath)
+	tmpl, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.NoError(t, err)
 	assert.Equal(t, `[0-9]*_*.md`, tmpl.Config.FilenamePattern)
 	require.Len(t, tmpl.Headings, 3)
@@ -707,7 +707,7 @@ func TestParseSchema_SchemaIncludeIgnoresFragmentFM(t *testing.T) {
 	schemaPath := filepath.Join(dir, "schema.md")
 	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0o644))
 
-	tmpl, err := parseSchema([]byte(schema), schemaPath)
+	tmpl, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.NoError(t, err)
 	// CUE schema should only come from root, not fragment.
 	assert.Contains(t, tmpl.Config.FrontMatterCUE, "id")
@@ -722,7 +722,7 @@ func TestParseSchema_SchemaIncludeCycleDetected(t *testing.T) {
 	schemaPath := filepath.Join(dir, "schema.md")
 	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0o644))
 
-	_, err := parseSchema([]byte(schema), schemaPath)
+	_, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cyclic include")
 }
@@ -740,7 +740,7 @@ func TestParseSchema_SchemaIncludeIndirectCycle(t *testing.T) {
 	schemaPath := filepath.Join(dir, "a.md")
 	require.NoError(t, os.WriteFile(schemaPath, []byte(schema), 0o644))
 
-	_, err := parseSchema([]byte(schema), schemaPath)
+	_, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cyclic include")
 }

--- a/plan/81_oom-file-size-limit.md
+++ b/plan/81_oom-file-size-limit.md
@@ -1,7 +1,7 @@
 ---
 id: 81
 title: 'OOM mitigation: configurable file-size limit'
-status: "🔲"
+status: "✅"
 summary: >-
   Guard every file-read path against OOM by enforcing
   a configurable byte-size cap (default 2 MB).
@@ -124,45 +124,45 @@ during `ApplySettings` or via the runner).
 
 ## Tasks
 
-1. Add `internal/lint/limits.go` with
+1. [x] Add `internal/lint/limits.go` with
    `ReadFileLimited` and `ReadFSFileLimited`
-2. Add `internal/lint/limits_test.go` with tests for
+2. [x] Add `internal/lint/limits_test.go` with tests for
    normal, at-limit, over-limit, zero (unlimited),
    and empty-file cases
-3. Add `internal/config/size.go` with `ParseSize`
-4. Add `internal/config/size_test.go` with tests for
+3. [x] Add `internal/config/size.go` with `ParseSize`
+4. [x] Add `internal/config/size_test.go` with tests for
    `2MB`, `500KB`, `0`, bare integer, invalid input
-5. Add `MaxInputSize` field to `config.Config`
-6. Add `MaxInputBytes` field to `engine.Runner` and
-   `fix.Fixer`
-7. Add `--max-input-size` flag to `check` and `fix`
+5. [x] Add `MaxInputSize` field to `config.Config`
+6. [x] Add `MaxInputBytes` field to `engine.Runner` and
+   `fix.Fixer` (and `lint.File` for rule threading)
+7. [x] Add `--max-input-size` flag to `check` and `fix`
    subcommands
-8. Replace `os.ReadFile` with `ReadFileLimited` at all
+8. [x] Replace `os.ReadFile` with `ReadFileLimited` at all
    primary read sites (runner, fixer, stdin)
-9. Replace `os.ReadFile` / `fs.ReadFile` at all
+9. [x] Replace `os.ReadFile` / `fs.ReadFile` at all
    secondary read sites (include, catalog,
    cross-file-ref, required-structure, metrics, merge
    driver, config)
-10. Thread `MaxInputBytes` to rules that read files
-    (via `lint.File` field or rule configuration)
-11. Add integration test: file exceeding limit produces
+10. [x] Thread `MaxInputBytes` to rules that read files
+    (via `lint.File` field)
+11. [x] Add integration test: file exceeding limit produces
     error diagnostic and exit code 2
-12. Document `max-input-size` in `docs/reference/cli.md`
+12. [x] Document `max-input-size` in `docs/reference/cli.md`
 
 ## Acceptance Criteria
 
-- [ ] `ReadFileLimited` returns error for files
+- [x] `ReadFileLimited` returns error for files
       exceeding the configured limit
-- [ ] `ReadFileLimited` succeeds for files at or below
+- [x] `ReadFileLimited` succeeds for files at or below
       the limit (no off-by-one)
-- [ ] `ReadFileLimited` with `max <= 0` applies no
+- [x] `ReadFileLimited` with `max <= 0` applies no
       limit (unlimited mode)
-- [ ] `ParseSize` handles `2MB`, `500KB`, `1GB`, bare
+- [x] `ParseSize` handles `2MB`, `500KB`, `1GB`, bare
       integers, and `0`
-- [ ] `.mdsmith.yml` `max-input-size` key is respected
-- [ ] `--max-input-size` CLI flag overrides config
-- [ ] `--max-input-size 0` disables the limit
-- [ ] All ~15 read sites use the limited helper
-- [ ] Error message includes actual size and limit
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] `.mdsmith.yml` `max-input-size` key is respected
+- [x] `--max-input-size` CLI flag overrides config
+- [x] `--max-input-size 0` disables the limit
+- [x] All ~15 read sites use the limited helper
+- [x] Error message includes actual size and limit
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

Implements a configurable file-size limit across all file-read paths in mdsmith to prevent out-of-memory (OOM) errors when processing unexpectedly large files. The default limit is 2 MB, configurable via `.mdsmith.yml` or the `--max-input-size` CLI flag.

## Key Changes

- **New size-limit helpers** (`internal/lint/limits.go`):
  - `ReadFileLimited()` and `ReadFSFileLimited()` enforce byte-size caps on file reads
  - Zero or negative limits disable the cap (unlimited mode)
  - Error messages include actual file size and configured limit

- **Size parsing** (`internal/config/size.go`):
  - `ParseSize()` parses human-readable sizes: `2MB`, `500KB`, `1GB`, bare integers, or `0`
  - Case-insensitive, uses binary units (1 MB = 1,048,576 bytes)

- **Configuration**:
  - Added `MaxInputSize` field to `config.Config`
  - Added `MaxInputBytes` field to `engine.Runner`, `fix.Fixer`, and `lint.File`
  - Config file reads capped at 1 MB to prevent accidental OOM from config itself

- **CLI integration**:
  - New `--max-input-size` flag on `check` and `fix` subcommands
  - CLI flag overrides config file setting
  - Default: `2MB`

- **Comprehensive coverage**:
  - Replaced ~15 `os.ReadFile()` and `fs.ReadFile()` calls with limited variants
  - Affected: runner, fixer, stdin, includes, catalog, cross-file references, required-structure, metrics, merge driver, and config loading
  - Rules access limit via `lint.File.MaxInputBytes` field

- **Testing**:
  - Unit tests for `ReadFileLimited`, `ReadFSFileLimited`, and `ParseSize`
  - E2E tests: file exceeding limit produces error diagnostic and exit code 2
  - Config override test: CLI flag overrides config setting

## Implementation Details

- Files exceeding the limit are rejected with exit code 2 and a clear error message
- The `+1` sentinel in `readLimited()` distinguishes "exactly at limit" from "truncated"
- When available, actual file size is reported in error messages (via `Stat()`)
- Unlimited mode (`max <= 0`) bypasses all limit checks for performance
- Config merge logic refactored to use new `copyConfig()` helper for consistency

https://claude.ai/code/session_01HHssHCn4zfbMv1praKoxGJ