### PR TITLE
Add merge queue workflow for automated PR batching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   merge_group:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -32,7 +32,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@52c1f24b19880bf2f68a422d7d53551f19ffe4d0 # v0.1.0
+      - uses: jeduden/merge-queue-action@5e81e8d3023229ed0b2bfc9f7f764a701b362d9c # v0.2.0
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: jeduden/merge-queue-action@52c1f24b19880bf2f68a422d7d53551f19ffe4d0 # v0.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml
           batch_size: "5"
           bisect: ${{ github.event.inputs.bisect || false }}

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,35 @@
+name: Merge Queue
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      batch_prs:
+        type: string
+        required: false
+      bisect:
+        type: boolean
+        default: false
+
+concurrency:
+  group: merge-queue
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  issues: write
+
+jobs:
+  queue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jeduden/merge-queue-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ci_workflow: .github/workflows/ci.yml
+          batch_size: "5"
+          bisect: ${{ github.event.inputs.bisect || false }}
+          batch_prs: ${{ github.event.inputs.batch_prs || '' }}

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -20,7 +20,11 @@ permissions: {}
 
 jobs:
   queue:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'queue'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.label.name == 'queue' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -16,15 +16,17 @@ concurrency:
   group: merge-queue
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
-  actions: write
-  issues: write
+permissions: {}
 
 jobs:
   queue:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'queue'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+      issues: write
     steps:
       - uses: jeduden/merge-queue-action@52c1f24b19880bf2f68a422d7d53551f19ffe4d0 # v0.1.0
         with:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -26,7 +26,7 @@ jobs:
   queue:
     runs-on: ubuntu-latest
     steps:
-      - uses: jeduden/merge-queue-action@v1
+      - uses: jeduden/merge-queue-action@52c1f24b19880bf2f68a422d7d53551f19ffe4d0 # v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
- **New merge queue workflow** (`.github/workflows/merge-queue.yml`): Bors-style merge queue using `jeduden/merge-queue-action@v0.2.0` (pinned to SHA `5e81e8d`) that batches up to 5 PRs, runs CI on the batch, and fast-forwards `main` on success.
- **CI workflow update** (`.github/workflows/ci.yml`): Added `workflow_dispatch` trigger so the merge-queue-action can dispatch CI runs on batch branches.

## Security
- Action pinned to commit SHA per repo policy
- Workflow-level `permissions: {}` with job-level overrides
- Fork PRs excluded (GITHUB_TOKEN is read-only for forks)
- Scoped to PRs targeting `main` only
- Uses dedicated `MERGE_QUEUE_TOKEN` PAT (GITHUB_TOKEN cannot trigger workflow_dispatch)

## Setup required
Create three labels on the repo: `queue`, `queue:active`, `queue:failed`

https://claude.ai/code/session_01PaY1bzDUzFEQQxFcNKUSA5