### PR TITLE
Add merge-queue skill and document label-driven merge workflow

### DIFF
--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -114,7 +114,7 @@ threads.
 Check that Copilot reviewed the latest commit:
 
 ```bash
-gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" \
+gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews" \
   -q '[.[] | select(.user.login ==
   "copilot-pull-request-reviewer[bot]")]
   | last | .commit_id'

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -28,8 +28,11 @@ Note the number as `$PR`.
 
 ### 2. Verify readiness
 
-Confirm CI is green and no review threads are
-unresolved before enqueuing:
+Confirm CI is green, no review threads are
+unresolved, and the latest commit has a Copilot
+review before enqueuing.
+
+Check CI:
 
 ```bash
 gh pr checks "$PR" --json name,state
@@ -38,6 +41,32 @@ gh pr checks "$PR" --json name,state
 All checks must show `SUCCESS`. If any are
 `FAILURE` or `PENDING`, stop and report the
 blockers instead of enqueuing.
+
+Check that Copilot reviewed the latest commit:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/$PR/reviews" \
+  -q '[.[] | select(.user.login ==
+  "copilot-pull-request-reviewer[bot]")]
+  | last | .commit_id'
+```
+
+Compare the returned commit SHA with the PR head:
+
+```bash
+gh pr view "$PR" --json commits \
+  -q '.commits[-1].oid'
+```
+
+If the two SHAs do not match, Copilot has not
+reviewed the latest push. Request a review and
+wait before enqueuing:
+
+```bash
+gh api --method POST \
+  "repos/{owner}/{repo}/pulls/$PR/requested_reviewers" \
+  -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+```
 
 ### 3. Add the `queue` label
 

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: merge-queue
+description: >-
+  Enqueue a PR into the merge queue after CI is green
+  and reviews are resolved.
+user-invocable: true
+allowed-tools: >-
+  Bash(gh pr:*), Bash(gh run:*), Bash(gh api:*),
+  Bash(git branch:*)
+argument-hint: "[PR number]"
+---
+
+Enqueue a PR into the label-driven merge queue
+(`jeduden/merge-queue-action`).
+
+## Steps
+
+### 1. Identify the PR
+
+If a PR number was passed as an argument, use it.
+Otherwise detect it from the current branch:
+
+```bash
+gh pr view --json number -q '.number'
+```
+
+Note the number as `$PR`.
+
+### 2. Verify readiness
+
+Confirm CI is green and no review threads are
+unresolved before enqueuing:
+
+```bash
+gh pr checks "$PR" --json name,state
+```
+
+All checks must show `SUCCESS`. If any are
+`FAILURE` or `PENDING`, stop and report the
+blockers instead of enqueuing.
+
+### 3. Add the `queue` label
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+### 4. Monitor label progression
+
+The action moves the PR through three labels:
+
+| Label          | Meaning                           |
+|----------------|-----------------------------------|
+| `queue`        | PR is waiting to be picked up     |
+| `queue:active` | PR is in the current batch        |
+| `queue:failed` | CI failed or merge conflict found |
+
+Check the current label:
+
+```bash
+gh pr view "$PR" --json labels \
+  -q '.labels[].name'
+```
+
+Check the merge queue workflow run:
+
+```bash
+gh run list --workflow merge-queue.yml \
+  --limit 1
+```
+
+### 5. Handle failure
+
+If the label changes to `queue:failed`, read the
+action's comment on the PR for the failure cause:
+
+```bash
+gh pr view "$PR" --comments
+```
+
+Fix the issue, push, then swap labels to
+re-enter the queue:
+
+```bash
+gh pr edit "$PR" --remove-label queue:failed
+```
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+### 6. Confirm merge
+
+The PR is merged when `gh pr view "$PR"` shows
+state `MERGED`. Report success and the merge
+commit SHA:
+
+```bash
+gh pr view "$PR" --json state,mergeCommit \
+  -q '.state + " " + .mergeCommit.oid'
+```

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -45,12 +45,17 @@ review before enqueuing.
 Check CI:
 
 ```bash
-gh pr checks "$PR" --json name,state
+gh pr checks "$PR" --json name,state,conclusion
 ```
 
-All checks must show `SUCCESS`. If any are
-`FAILURE` or `PENDING`, stop and report the
-blockers instead of enqueuing.
+`gh pr checks` returns `state` as `COMPLETED` or
+`IN_PROGRESS`. The pass/fail verdict lives in
+`conclusion`: `SUCCESS`, `FAILURE`, or `null`
+while a check is still running.
+
+Every check must have `state = COMPLETED` and
+`conclusion = SUCCESS`. Stop if any check is
+pending or reports a non-success conclusion.
 
 Check for unresolved review threads:
 

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -48,9 +48,21 @@ gh pr view "$PR" --json headRepository \
   -q '.headRepository.name'
 ```
 
-Note as `$REPO`. The merge queue only accepts
-same-repo PRs, so head and base repo are the
-same.
+Note as `$REPO`.
+
+Verify the PR is eligible for the merge queue.
+The base branch must be `main` and the PR must
+not be cross-repository:
+
+```bash
+gh pr view "$PR" --json baseRefName,isCrossRepository \
+  -q '.baseRefName + " " + (.isCrossRepository | tostring)'
+```
+
+Stop if the base branch is not `main` or
+`isCrossRepository` is `true`. The merge queue
+workflow only runs for same-repo PRs targeting
+`main`.
 
 ### 2. Verify readiness
 

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -33,23 +33,24 @@ Otherwise detect it from the current branch:
 gh pr view --json number -q '.number'
 ```
 
-Note the number as `$PR`. Then get the base
-repo owner and name for API calls (PR endpoints
-live on the base repo, not the head repo):
+Note the number as `$PR`. Then get the repo
+owner and name for API calls:
 
 ```bash
-gh pr view "$PR" --json baseRepository \
-  -q '.baseRepository.owner.login'
+gh pr view "$PR" --json headRepositoryOwner \
+  -q '.headRepositoryOwner.login'
 ```
 
 Note as `$OWNER`. Then:
 
 ```bash
-gh pr view "$PR" --json baseRepository \
-  -q '.baseRepository.name'
+gh pr view "$PR" --json headRepository \
+  -q '.headRepository.name'
 ```
 
-Note as `$REPO`.
+Note as `$REPO`. The merge queue only accepts
+same-repo PRs, so head and base repo are the
+same.
 
 ### 2. Verify readiness
 

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -13,6 +13,16 @@ argument-hint: "[PR number]"
 Enqueue a PR into the label-driven merge queue
 (`jeduden/merge-queue-action`).
 
+## Before you run commands
+
+Run each fenced Bash block as its own Bash call.
+Do not combine commands into one shell invocation,
+and do not prefix commands with inline environment
+or shell variable assignments. Allowed-tools
+matching checks the command prefix, so changing
+that prefix can cause an otherwise-allowed `gh`
+command to be blocked.
+
 ## Steps
 
 ### 1. Identify the PR
@@ -41,6 +51,27 @@ gh pr checks "$PR" --json name,state
 All checks must show `SUCCESS`. If any are
 `FAILURE` or `PENDING`, stop and report the
 blockers instead of enqueuing.
+
+Check for unresolved review threads:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}' -f owner=OWNER -f repo=REPO -F pr="$PR" \
+  -q '[.data.repository.pullRequest.reviewThreads.nodes[]
+  | select(.isResolved == false)] | length'
+```
+
+Stop if the count is greater than zero. Run
+`/pr-fixup` first to address the remaining
+threads.
 
 Check that Copilot reviewed the latest commit:
 
@@ -91,11 +122,20 @@ gh pr view "$PR" --json labels \
   -q '.labels[].name'
 ```
 
-Check the merge queue workflow run:
+Check the merge queue workflow run for the PR's
+head branch (repo-wide listing would return
+unrelated PRs when multiple are queued):
+
+```bash
+gh pr view "$PR" --json headRefName \
+  -q '.headRefName'
+```
+
+Note the branch as `$BRANCH`, then:
 
 ```bash
 gh run list --workflow merge-queue.yml \
-  --limit 1
+  --branch "$BRANCH" --limit 1
 ```
 
 ### 5. Handle failure

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -45,17 +45,18 @@ review before enqueuing.
 Check CI:
 
 ```bash
-gh pr checks "$PR" --json name,state,conclusion
+gh pr checks "$PR" --json name,state,bucket
 ```
 
-`gh pr checks` returns `state` as `COMPLETED` or
-`IN_PROGRESS`. The pass/fail verdict lives in
-`conclusion`: `SUCCESS`, `FAILURE`, or `null`
-while a check is still running.
+`gh pr checks` returns two fields worth reading.
+`state` is one of `SUCCESS`, `FAILURE`,
+`IN_PROGRESS`, `QUEUED`, `SKIPPING`. `bucket`
+collapses those into `pass`, `fail`, `pending`,
+`skipping`.
 
-Every check must have `state = COMPLETED` and
-`conclusion = SUCCESS`. Stop if any check is
-pending or reports a non-success conclusion.
+Every check must show `bucket = pass`. Stop if
+any check is `pending`, `fail`, or otherwise
+non-pass.
 
 Check for unresolved review threads:
 

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -34,7 +34,22 @@ Otherwise detect it from the current branch:
 gh pr view --json number -q '.number'
 ```
 
-Note the number as `$PR`.
+Note the number as `$PR`. Then get the repo
+owner and name for later API calls:
+
+```bash
+gh pr view "$PR" --json headRepository \
+  -q '.headRepository.owner.login'
+```
+
+Note as `$OWNER`. Then:
+
+```bash
+gh pr view "$PR" --json headRepository \
+  -q '.headRepository.name'
+```
+
+Note as `$REPO`.
 
 ### 2. Verify readiness
 
@@ -70,7 +85,7 @@ query($owner: String!, $repo: String!, $pr: Int!) {
       }
     }
   }
-}' -f owner=OWNER -f repo=REPO -F pr="$PR" \
+}' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" \
   -q '[.data.repository.pullRequest.reviewThreads.nodes[]
   | select(.isResolved == false)] | length'
 ```
@@ -82,7 +97,7 @@ threads.
 Check that Copilot reviewed the latest commit:
 
 ```bash
-gh api "repos/{owner}/{repo}/pulls/$PR/reviews" \
+gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" \
   -q '[.[] | select(.user.login ==
   "copilot-pull-request-reviewer[bot]")]
   | last | .commit_id'
@@ -101,7 +116,7 @@ wait before enqueuing:
 
 ```bash
 gh api --method POST \
-  "repos/{owner}/{repo}/pulls/$PR/requested_reviewers" \
+  "repos/$OWNER/$REPO/pulls/$PR/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -5,8 +5,7 @@ description: >-
   and reviews are resolved.
 user-invocable: true
 allowed-tools: >-
-  Bash(gh pr:*), Bash(gh run:*), Bash(gh api:*),
-  Bash(git branch:*)
+  Bash(gh pr:*), Bash(gh run:*), Bash(gh api:*)
 argument-hint: "[PR number]"
 ---
 
@@ -34,19 +33,20 @@ Otherwise detect it from the current branch:
 gh pr view --json number -q '.number'
 ```
 
-Note the number as `$PR`. Then get the repo
-owner and name for later API calls:
+Note the number as `$PR`. Then get the base
+repo owner and name for API calls (PR endpoints
+live on the base repo, not the head repo):
 
 ```bash
-gh pr view "$PR" --json headRepository \
-  -q '.headRepository.owner.login'
+gh pr view "$PR" --json baseRepository \
+  -q '.baseRepository.owner.login'
 ```
 
 Note as `$OWNER`. Then:
 
 ```bash
-gh pr view "$PR" --json headRepository \
-  -q '.headRepository.name'
+gh pr view "$PR" --json baseRepository \
+  -q '.baseRepository.name'
 ```
 
 Note as `$REPO`.
@@ -81,14 +81,18 @@ query($owner: String!, $repo: String!, $pr: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage }
         nodes { isResolved }
       }
     }
   }
-}' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" \
-  -q '[.data.repository.pullRequest.reviewThreads.nodes[]
-  | select(.isResolved == false)] | length'
+}'  -f owner="$OWNER" -f repo="$REPO" -F pr="$PR"
 ```
+
+Count entries where `isResolved` is `false`. Also
+check `pageInfo.hasNextPage` — if `true`, there
+are more than 100 threads and you must paginate
+before trusting the count.
 
 Stop if the count is greater than zero. Run
 `/pr-fixup` first to address the remaining

--- a/.claude/skills/pr-fixup/SKILL.md
+++ b/.claude/skills/pr-fixup/SKILL.md
@@ -304,34 +304,8 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and proceed to step 11.
-
-### 11. Enqueue the PR for merge
-
-Add the `queue` label to enter the merge queue
-(`jeduden/merge-queue-action`):
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
-
-The action batches labeled PRs (oldest first) into
-a temporary branch and runs CI against it. If CI
-passes, `main` fast-forwards automatically.
-
-Labels track progress: `queue` → `queue:active`
-(in batch) → merged. On failure the action applies
-`queue:failed` and posts a comment with the cause.
-Fix the issue (return to step 6), push, then swap
-labels to re-enter:
-
-```bash
-gh pr edit "$PR" --remove-label queue:failed
-```
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
+the recurring loop. The PR is ready for merge —
+use `/merge-queue` to enqueue it.
 
 ## Notes
 
@@ -345,5 +319,6 @@ gh pr edit "$PR" --add-label queue
   (step 3). Regular pushes after that show
   incremental progress.
 
-The PR is merged once the queue batch passes CI.
+Use `/merge-queue` to enqueue the PR once it is
+ready.
 <?/include?>

--- a/.claude/skills/pr-fixup/SKILL.md
+++ b/.claude/skills/pr-fixup/SKILL.md
@@ -164,8 +164,8 @@ loop iteration.
 List failed checks, then get the run ID:
 
 ```bash
-gh pr checks "$PR" --json name,state,conclusion \
-  -q '.[] | select(.conclusion == "FAILURE")'
+gh pr checks "$PR" --json name,state,bucket \
+  -q '.[] | select(.bucket == "fail")'
 ```
 
 ```bash

--- a/.claude/skills/pr-fixup/SKILL.md
+++ b/.claude/skills/pr-fixup/SKILL.md
@@ -49,8 +49,8 @@ If missing, install from
 brew install gh
 ```
 
-If `brew` is unavailable, download the release tarball
-from the [GitHub releases page](https://github.com/cli/cli/releases).
+If `brew` is unavailable, download from the
+[GitHub releases page](https://github.com/cli/cli/releases).
 If not authenticated, run `gh auth login` or set
 `GITHUB_TOKEN`.
 
@@ -111,9 +111,8 @@ go run ./cmd/mdsmith check .
 go tool golangci-lint run --fix ./...
 ```
 
-The `--fix` flag auto-corrects formatting issues
-(goimports, gofmt). If it produces changes, stage and
-include them in the next commit.
+The `--fix` flag auto-corrects formatting issues.
+Stage any changes in the next commit.
 
 ### 4. Push changes
 
@@ -162,14 +161,12 @@ loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 
-Fetch the failed job log:
+List failed checks, then get the run ID:
 
 ```bash
 gh pr checks "$PR" --json name,state,conclusion \
   -q '.[] | select(.conclusion == "FAILURE")'
 ```
-
-Get the run ID of the most recent failure:
 
 ```bash
 gh run list --branch "$BRANCH" \
@@ -177,7 +174,7 @@ gh run list --branch "$BRANCH" \
   --json databaseId -q '.[0].databaseId'
 ```
 
-Note the run ID as `$RUN_ID`. Then download the log:
+Note the run ID as `$RUN_ID`. Then view the log:
 
 ```bash
 gh run view "$RUN_ID" --log-failed
@@ -307,24 +304,46 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and report that the PR is ready
-for merge.
+the recurring loop and proceed to step 11.
+
+### 11. Enqueue the PR for merge
+
+Add the `queue` label to enter the merge queue
+(`jeduden/merge-queue-action`):
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+The action batches labeled PRs (oldest first) into
+a temporary branch and runs CI against it. If CI
+passes, `main` fast-forwards automatically.
+
+Labels track progress: `queue` → `queue:active`
+(in batch) → merged. On failure the action applies
+`queue:failed` and posts a comment with the cause.
+Fix the issue (return to step 6), push, then swap
+labels to re-enter:
+
+```bash
+gh pr edit "$PR" --remove-label queue:failed
+```
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
 
 ## Notes
 
-- This workflow works in both local environments and
-  Claude Code web sandbox. Step 1 installs `gh` if
-  missing.
-- Always run `mdsmith check .` and
-  `golangci-lint run --fix ./...` before committing to
-  catch linting and formatting issues early.
-- Keep fix commits small and focused — one commit per
-  CI fix, one commit per batch of related review
-  comments.
-- Use `--force-with-lease` only after rebase (step 3).
-  After that, append fix commits with regular pushes so
-  reviewers can see incremental progress.
+- Works in both local and Claude Code web
+  environments. Step 1 installs `gh` if missing.
+- Run `mdsmith check .` and
+  `golangci-lint run --fix` before committing.
+- Keep fix commits small — one per CI fix, one per
+  batch of related review comments.
+- Use `--force-with-lease` only after rebase
+  (step 3). Regular pushes after that show
+  incremental progress.
 
-Once the unresolved count is 0 and CI is green, the PR
-is ready for merge.
+The PR is merged once the queue batch passes CI.
 <?/include?>

--- a/.claude/skills/pr-fixup/SKILL.md
+++ b/.claude/skills/pr-fixup/SKILL.md
@@ -312,7 +312,8 @@ use `/merge-queue` to enqueue it.
 - Works in both local and Claude Code web
   environments. Step 1 installs `gh` if missing.
 - Run `mdsmith check .` and
-  `golangci-lint run --fix` before committing.
+  `go tool golangci-lint run --fix ./...`
+  before committing.
 - Keep fix commits small — one per CI fix, one per
   batch of related review comments.
 - Use `--force-with-lease` only after rebase

--- a/.claude/skills/pr-fixup/SKILL.md
+++ b/.claude/skills/pr-fixup/SKILL.md
@@ -151,13 +151,13 @@ let the next loop iteration verify the result.
 Check CI status:
 
 ```bash
-gh pr checks "$PR" --json name,state
+gh pr checks "$PR" --json name,state,bucket
 ```
 
-If all checks show `SUCCESS`, proceed to step 7. If
-any show `FAILURE`, proceed to step 6. If checks are
-still `IN_PROGRESS` or `PENDING`, wait for the next
-loop iteration.
+If every check has `bucket = pass`, proceed to
+step 7. If any show `bucket = fail`, proceed to
+step 6. If any show `bucket = pending`, wait for
+the next loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 

--- a/.github/AGENTS-PR-FIXUP.md
+++ b/.github/AGENTS-PR-FIXUP.md
@@ -42,8 +42,8 @@ If missing, install from
 brew install gh
 ```
 
-If `brew` is unavailable, download the release tarball
-from the [GitHub releases page](https://github.com/cli/cli/releases).
+If `brew` is unavailable, download from the
+[GitHub releases page](https://github.com/cli/cli/releases).
 If not authenticated, run `gh auth login` or set
 `GITHUB_TOKEN`.
 
@@ -104,9 +104,8 @@ go run ./cmd/mdsmith check .
 go tool golangci-lint run --fix ./...
 ```
 
-The `--fix` flag auto-corrects formatting issues
-(goimports, gofmt). If it produces changes, stage and
-include them in the next commit.
+The `--fix` flag auto-corrects formatting issues.
+Stage any changes in the next commit.
 
 ### 4. Push changes
 
@@ -155,14 +154,12 @@ loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 
-Fetch the failed job log:
+List failed checks, then get the run ID:
 
 ```bash
 gh pr checks "$PR" --json name,state,conclusion \
   -q '.[] | select(.conclusion == "FAILURE")'
 ```
-
-Get the run ID of the most recent failure:
 
 ```bash
 gh run list --branch "$BRANCH" \
@@ -170,7 +167,7 @@ gh run list --branch "$BRANCH" \
   --json databaseId -q '.[0].databaseId'
 ```
 
-Note the run ID as `$RUN_ID`. Then download the log:
+Note the run ID as `$RUN_ID`. Then view the log:
 
 ```bash
 gh run view "$RUN_ID" --log-failed
@@ -300,24 +297,46 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and report that the PR is ready
-for merge.
+the recurring loop and proceed to step 11.
+
+### 11. Enqueue the PR for merge
+
+Add the `queue` label to enter the merge queue
+(`jeduden/merge-queue-action`):
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+The action batches labeled PRs (oldest first) into
+a temporary branch and runs CI against it. If CI
+passes, `main` fast-forwards automatically.
+
+Labels track progress: `queue` → `queue:active`
+(in batch) → merged. On failure the action applies
+`queue:failed` and posts a comment with the cause.
+Fix the issue (return to step 6), push, then swap
+labels to re-enter:
+
+```bash
+gh pr edit "$PR" --remove-label queue:failed
+```
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
 
 ## Notes
 
-- This workflow works in both local environments and
-  Claude Code web sandbox. Step 1 installs `gh` if
-  missing.
-- Always run `mdsmith check .` and
-  `golangci-lint run --fix ./...` before committing to
-  catch linting and formatting issues early.
-- Keep fix commits small and focused — one commit per
-  CI fix, one commit per batch of related review
-  comments.
-- Use `--force-with-lease` only after rebase (step 3).
-  After that, append fix commits with regular pushes so
-  reviewers can see incremental progress.
+- Works in both local and Claude Code web
+  environments. Step 1 installs `gh` if missing.
+- Run `mdsmith check .` and
+  `golangci-lint run --fix` before committing.
+- Keep fix commits small — one per CI fix, one per
+  batch of related review comments.
+- Use `--force-with-lease` only after rebase
+  (step 3). Regular pushes after that show
+  incremental progress.
 
-Once the unresolved count is 0 and CI is green, the PR
-is ready for merge.
+The PR is merged once the queue batch passes CI.
 <?/include?>

--- a/.github/AGENTS-PR-FIXUP.md
+++ b/.github/AGENTS-PR-FIXUP.md
@@ -297,34 +297,8 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and proceed to step 11.
-
-### 11. Enqueue the PR for merge
-
-Add the `queue` label to enter the merge queue
-(`jeduden/merge-queue-action`):
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
-
-The action batches labeled PRs (oldest first) into
-a temporary branch and runs CI against it. If CI
-passes, `main` fast-forwards automatically.
-
-Labels track progress: `queue` → `queue:active`
-(in batch) → merged. On failure the action applies
-`queue:failed` and posts a comment with the cause.
-Fix the issue (return to step 6), push, then swap
-labels to re-enter:
-
-```bash
-gh pr edit "$PR" --remove-label queue:failed
-```
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
+the recurring loop. The PR is ready for merge —
+use `/merge-queue` to enqueue it.
 
 ## Notes
 
@@ -338,5 +312,6 @@ gh pr edit "$PR" --add-label queue
   (step 3). Regular pushes after that show
   incremental progress.
 
-The PR is merged once the queue batch passes CI.
+Use `/merge-queue` to enqueue the PR once it is
+ready.
 <?/include?>

--- a/.github/AGENTS-PR-FIXUP.md
+++ b/.github/AGENTS-PR-FIXUP.md
@@ -305,7 +305,8 @@ use `/merge-queue` to enqueue it.
 - Works in both local and Claude Code web
   environments. Step 1 installs `gh` if missing.
 - Run `mdsmith check .` and
-  `golangci-lint run --fix` before committing.
+  `go tool golangci-lint run --fix ./...`
+  before committing.
 - Keep fix commits small — one per CI fix, one per
   batch of related review comments.
 - Use `--force-with-lease` only after rebase

--- a/.github/AGENTS-PR-FIXUP.md
+++ b/.github/AGENTS-PR-FIXUP.md
@@ -157,8 +157,8 @@ loop iteration.
 List failed checks, then get the run ID:
 
 ```bash
-gh pr checks "$PR" --json name,state,conclusion \
-  -q '.[] | select(.conclusion == "FAILURE")'
+gh pr checks "$PR" --json name,state,bucket \
+  -q '.[] | select(.bucket == "fail")'
 ```
 
 ```bash

--- a/.github/AGENTS-PR-FIXUP.md
+++ b/.github/AGENTS-PR-FIXUP.md
@@ -144,13 +144,13 @@ let the next loop iteration verify the result.
 Check CI status:
 
 ```bash
-gh pr checks "$PR" --json name,state
+gh pr checks "$PR" --json name,state,bucket
 ```
 
-If all checks show `SUCCESS`, proceed to step 7. If
-any show `FAILURE`, proceed to step 6. If checks are
-still `IN_PROGRESS` or `PENDING`, wait for the next
-loop iteration.
+If every check has `bucket = pass`, proceed to
+step 7. If any show `bucket = fail`, proceed to
+step 6. If any show `bucket = pending`, wait for
+the next loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,7 @@ row: "- [{summary}](../{filename})"
 - [Codecov coverage gate and CI status checks.](../docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](../docs/development/file-placement.md)
 - [Build commands, project layout, code style, test fixtures, coverage gate, and merge conflicts.](../docs/development/index.md)
+- [Label-driven merge queue workflow using jeduden/merge-queue-action.](../docs/development/merge-queue.md)
 - [Rebase, CI monitoring, and review comment resolution.](../docs/development/pr-fixup-workflow.md)
 - [How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.](../docs/guides/directives/enforcing-structure.md)
 - [How to use catalog and include directives to generate and embed content in Markdown files.](../docs/guides/directives/generating-content.md)
@@ -137,6 +138,7 @@ See also:
 
 - [Coverage gate](../docs/development/coverage.md)
 - [File placement](../docs/development/file-placement.md)
+- [Merge queue](../docs/development/merge-queue.md)
 - [PR fixup workflow](../docs/development/pr-fixup-workflow.md)
 
 #### Build & Test Commands

--- a/.github/copilot-pr-fixup.md
+++ b/.github/copilot-pr-fixup.md
@@ -150,8 +150,8 @@ loop iteration.
 List failed checks, then get the run ID:
 
 ```bash
-gh pr checks "$PR" --json name,state,conclusion \
-  -q '.[] | select(.conclusion == "FAILURE")'
+gh pr checks "$PR" --json name,state,bucket \
+  -q '.[] | select(.bucket == "fail")'
 ```
 
 ```bash

--- a/.github/copilot-pr-fixup.md
+++ b/.github/copilot-pr-fixup.md
@@ -35,8 +35,8 @@ If missing, install from
 brew install gh
 ```
 
-If `brew` is unavailable, download the release tarball
-from the [GitHub releases page](https://github.com/cli/cli/releases).
+If `brew` is unavailable, download from the
+[GitHub releases page](https://github.com/cli/cli/releases).
 If not authenticated, run `gh auth login` or set
 `GITHUB_TOKEN`.
 
@@ -97,9 +97,8 @@ go run ./cmd/mdsmith check .
 go tool golangci-lint run --fix ./...
 ```
 
-The `--fix` flag auto-corrects formatting issues
-(goimports, gofmt). If it produces changes, stage and
-include them in the next commit.
+The `--fix` flag auto-corrects formatting issues.
+Stage any changes in the next commit.
 
 ### 4. Push changes
 
@@ -148,14 +147,12 @@ loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 
-Fetch the failed job log:
+List failed checks, then get the run ID:
 
 ```bash
 gh pr checks "$PR" --json name,state,conclusion \
   -q '.[] | select(.conclusion == "FAILURE")'
 ```
-
-Get the run ID of the most recent failure:
 
 ```bash
 gh run list --branch "$BRANCH" \
@@ -163,7 +160,7 @@ gh run list --branch "$BRANCH" \
   --json databaseId -q '.[0].databaseId'
 ```
 
-Note the run ID as `$RUN_ID`. Then download the log:
+Note the run ID as `$RUN_ID`. Then view the log:
 
 ```bash
 gh run view "$RUN_ID" --log-failed
@@ -293,24 +290,46 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and report that the PR is ready
-for merge.
+the recurring loop and proceed to step 11.
+
+### 11. Enqueue the PR for merge
+
+Add the `queue` label to enter the merge queue
+(`jeduden/merge-queue-action`):
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+The action batches labeled PRs (oldest first) into
+a temporary branch and runs CI against it. If CI
+passes, `main` fast-forwards automatically.
+
+Labels track progress: `queue` → `queue:active`
+(in batch) → merged. On failure the action applies
+`queue:failed` and posts a comment with the cause.
+Fix the issue (return to step 6), push, then swap
+labels to re-enter:
+
+```bash
+gh pr edit "$PR" --remove-label queue:failed
+```
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
 
 ## Notes
 
-- This workflow works in both local environments and
-  Claude Code web sandbox. Step 1 installs `gh` if
-  missing.
-- Always run `mdsmith check .` and
-  `golangci-lint run --fix ./...` before committing to
-  catch linting and formatting issues early.
-- Keep fix commits small and focused — one commit per
-  CI fix, one commit per batch of related review
-  comments.
-- Use `--force-with-lease` only after rebase (step 3).
-  After that, append fix commits with regular pushes so
-  reviewers can see incremental progress.
+- Works in both local and Claude Code web
+  environments. Step 1 installs `gh` if missing.
+- Run `mdsmith check .` and
+  `golangci-lint run --fix` before committing.
+- Keep fix commits small — one per CI fix, one per
+  batch of related review comments.
+- Use `--force-with-lease` only after rebase
+  (step 3). Regular pushes after that show
+  incremental progress.
 
-Once the unresolved count is 0 and CI is green, the PR
-is ready for merge.
+The PR is merged once the queue batch passes CI.
 <?/include?>

--- a/.github/copilot-pr-fixup.md
+++ b/.github/copilot-pr-fixup.md
@@ -137,13 +137,13 @@ let the next loop iteration verify the result.
 Check CI status:
 
 ```bash
-gh pr checks "$PR" --json name,state
+gh pr checks "$PR" --json name,state,bucket
 ```
 
-If all checks show `SUCCESS`, proceed to step 7. If
-any show `FAILURE`, proceed to step 6. If checks are
-still `IN_PROGRESS` or `PENDING`, wait for the next
-loop iteration.
+If every check has `bucket = pass`, proceed to
+step 7. If any show `bucket = fail`, proceed to
+step 6. If any show `bucket = pending`, wait for
+the next loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 

--- a/.github/copilot-pr-fixup.md
+++ b/.github/copilot-pr-fixup.md
@@ -298,7 +298,8 @@ use `/merge-queue` to enqueue it.
 - Works in both local and Claude Code web
   environments. Step 1 installs `gh` if missing.
 - Run `mdsmith check .` and
-  `golangci-lint run --fix` before committing.
+  `go tool golangci-lint run --fix ./...`
+  before committing.
 - Keep fix commits small — one per CI fix, one per
   batch of related review comments.
 - Use `--force-with-lease` only after rebase

--- a/.github/copilot-pr-fixup.md
+++ b/.github/copilot-pr-fixup.md
@@ -290,34 +290,8 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and proceed to step 11.
-
-### 11. Enqueue the PR for merge
-
-Add the `queue` label to enter the merge queue
-(`jeduden/merge-queue-action`):
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
-
-The action batches labeled PRs (oldest first) into
-a temporary branch and runs CI against it. If CI
-passes, `main` fast-forwards automatically.
-
-Labels track progress: `queue` → `queue:active`
-(in batch) → merged. On failure the action applies
-`queue:failed` and posts a comment with the cause.
-Fix the issue (return to step 6), push, then swap
-labels to re-enter:
-
-```bash
-gh pr edit "$PR" --remove-label queue:failed
-```
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
+the recurring loop. The PR is ready for merge —
+use `/merge-queue` to enqueue it.
 
 ## Notes
 
@@ -331,5 +305,6 @@ gh pr edit "$PR" --add-label queue
   (step 3). Regular pushes after that show
   incremental progress.
 
-The PR is merged once the queue batch passes CI.
+Use `/merge-queue` to enqueue the PR once it is
+ready.
 <?/include?>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ row: "- [{summary}]({filename})"
 - [Codecov coverage gate and CI status checks.](docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](docs/development/file-placement.md)
 - [Build commands, project layout, code style, test fixtures, coverage gate, and merge conflicts.](docs/development/index.md)
+- [Label-driven merge queue workflow using jeduden/merge-queue-action.](docs/development/merge-queue.md)
 - [Rebase, CI monitoring, and review comment resolution.](docs/development/pr-fixup-workflow.md)
 - [How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.](docs/guides/directives/enforcing-structure.md)
 - [How to use catalog and include directives to generate and embed content in Markdown files.](docs/guides/directives/generating-content.md)
@@ -144,6 +145,7 @@ See also:
 
 - [Coverage gate](docs/development/coverage.md)
 - [File placement](docs/development/file-placement.md)
+- [Merge queue](docs/development/merge-queue.md)
 - [PR fixup workflow](docs/development/pr-fixup-workflow.md)
 
 ### Build & Test Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ row: "- [{summary}]({filename})"
 - [Codecov coverage gate and CI status checks.](docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](docs/development/file-placement.md)
 - [Build commands, project layout, code style, test fixtures, coverage gate, and merge conflicts.](docs/development/index.md)
+- [Label-driven merge queue workflow using jeduden/merge-queue-action.](docs/development/merge-queue.md)
 - [Rebase, CI monitoring, and review comment resolution.](docs/development/pr-fixup-workflow.md)
 - [How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.](docs/guides/directives/enforcing-structure.md)
 - [How to use catalog and include directives to generate and embed content in Markdown files.](docs/guides/directives/generating-content.md)
@@ -130,6 +131,7 @@ See also:
 
 - [Coverage gate](docs/development/coverage.md)
 - [File placement](docs/development/file-placement.md)
+- [Merge queue](docs/development/merge-queue.md)
 - [PR fixup workflow](docs/development/pr-fixup-workflow.md)
 
 ### Build & Test Commands

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -8,6 +8,7 @@ See also:
 
 - [Coverage gate](coverage.md)
 - [File placement](file-placement.md)
+- [Merge queue](merge-queue.md)
 - [PR fixup workflow](pr-fixup-workflow.md)
 
 ## Build & Test Commands

--- a/docs/development/merge-queue.md
+++ b/docs/development/merge-queue.md
@@ -9,7 +9,7 @@ GitHub merge button. Add the `queue` label after CI
 is green and reviews are resolved:
 
 ```bash
-gh pr edit "$PR" --add-label queue
+gh pr edit --add-label queue
 ```
 
 **How it works**: the action collects all PRs labeled
@@ -33,8 +33,8 @@ a comment explaining the cause. Fix the issue, push,
 then replace the label to re-enter the queue:
 
 ```bash
-gh pr edit "$PR" --remove-label queue:failed
-gh pr edit "$PR" --add-label queue
+gh pr edit --remove-label queue:failed
+gh pr edit --add-label queue
 ```
 
 **Bisection**: when a multi-PR batch fails, the

--- a/docs/development/merge-queue.md
+++ b/docs/development/merge-queue.md
@@ -1,0 +1,55 @@
+---
+title: Merge Queue
+summary: Label-driven merge queue workflow using jeduden/merge-queue-action.
+---
+# Merge Queue
+
+PRs merge via `jeduden/merge-queue-action`, not the
+GitHub merge button. Add the `queue` label after CI
+is green and reviews are resolved:
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+**How it works**: the action collects all PRs labeled
+`queue` (oldest first), merges up to `batch_size` (5)
+into a temporary `merge-queue/batch-*` branch
+server-side, then dispatches the CI workflow against
+that branch. If CI passes, `main` fast-forwards to
+the batch head and the batch branch is deleted.
+
+**Label state machine**: three labels track
+progression through the queue:
+
+| Label          | Meaning                           |
+|----------------|-----------------------------------|
+| `queue`        | PR is waiting to be picked up     |
+| `queue:active` | PR is in the current batch        |
+| `queue:failed` | CI failed or merge conflict found |
+
+On failure the action adds `queue:failed` and posts
+a comment explaining the cause. Fix the issue, push,
+then replace the label to re-enter the queue:
+
+```bash
+gh pr edit "$PR" --remove-label queue:failed
+gh pr edit "$PR" --add-label queue
+```
+
+**Bisection**: when a multi-PR batch fails, the
+action recursively bisects the batch until the
+failing PR is isolated. Single-PR failures are
+reported immediately.
+
+**Eligibility**: only same-repo PRs targeting `main`.
+Fork PRs cannot enter the queue.
+
+**Manual dispatch**: maintainers can trigger the
+queue workflow via `workflow_dispatch`. Pass PR
+numbers in `batch_prs` or enable `bisect` mode to
+debug a failing batch.
+
+The [PR fixup workflow](pr-fixup-workflow.md) covers
+getting a PR to merge-ready state. Use the
+`/merge-queue` skill to enqueue.

--- a/docs/development/pr-fixup-workflow.md
+++ b/docs/development/pr-fixup-workflow.md
@@ -149,8 +149,8 @@ loop iteration.
 List failed checks, then get the run ID:
 
 ```bash
-gh pr checks "$PR" --json name,state,conclusion \
-  -q '.[] | select(.conclusion == "FAILURE")'
+gh pr checks "$PR" --json name,state,bucket \
+  -q '.[] | select(.bucket == "fail")'
 ```
 
 ```bash

--- a/docs/development/pr-fixup-workflow.md
+++ b/docs/development/pr-fixup-workflow.md
@@ -34,8 +34,8 @@ If missing, install from
 brew install gh
 ```
 
-If `brew` is unavailable, download the release tarball
-from the [GitHub releases page](https://github.com/cli/cli/releases).
+If `brew` is unavailable, download from the
+[GitHub releases page](https://github.com/cli/cli/releases).
 If not authenticated, run `gh auth login` or set
 `GITHUB_TOKEN`.
 
@@ -96,9 +96,8 @@ go run ./cmd/mdsmith check .
 go tool golangci-lint run --fix ./...
 ```
 
-The `--fix` flag auto-corrects formatting issues
-(goimports, gofmt). If it produces changes, stage and
-include them in the next commit.
+The `--fix` flag auto-corrects formatting issues.
+Stage any changes in the next commit.
 
 ### 4. Push changes
 
@@ -147,14 +146,12 @@ loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 
-Fetch the failed job log:
+List failed checks, then get the run ID:
 
 ```bash
 gh pr checks "$PR" --json name,state,conclusion \
   -q '.[] | select(.conclusion == "FAILURE")'
 ```
-
-Get the run ID of the most recent failure:
 
 ```bash
 gh run list --branch "$BRANCH" \
@@ -162,7 +159,7 @@ gh run list --branch "$BRANCH" \
   --json databaseId -q '.[0].databaseId'
 ```
 
-Note the run ID as `$RUN_ID`. Then download the log:
+Note the run ID as `$RUN_ID`. Then view the log:
 
 ```bash
 gh run view "$RUN_ID" --log-failed
@@ -292,23 +289,45 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and report that the PR is ready
-for merge.
+the recurring loop and proceed to step 11.
+
+### 11. Enqueue the PR for merge
+
+Add the `queue` label to enter the merge queue
+(`jeduden/merge-queue-action`):
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
+
+The action batches labeled PRs (oldest first) into
+a temporary branch and runs CI against it. If CI
+passes, `main` fast-forwards automatically.
+
+Labels track progress: `queue` → `queue:active`
+(in batch) → merged. On failure the action applies
+`queue:failed` and posts a comment with the cause.
+Fix the issue (return to step 6), push, then swap
+labels to re-enter:
+
+```bash
+gh pr edit "$PR" --remove-label queue:failed
+```
+
+```bash
+gh pr edit "$PR" --add-label queue
+```
 
 ## Notes
 
-- This workflow works in both local environments and
-  Claude Code web sandbox. Step 1 installs `gh` if
-  missing.
-- Always run `mdsmith check .` and
-  `golangci-lint run --fix ./...` before committing to
-  catch linting and formatting issues early.
-- Keep fix commits small and focused — one commit per
-  CI fix, one commit per batch of related review
-  comments.
-- Use `--force-with-lease` only after rebase (step 3).
-  After that, append fix commits with regular pushes so
-  reviewers can see incremental progress.
+- Works in both local and Claude Code web
+  environments. Step 1 installs `gh` if missing.
+- Run `mdsmith check .` and
+  `golangci-lint run --fix` before committing.
+- Keep fix commits small — one per CI fix, one per
+  batch of related review comments.
+- Use `--force-with-lease` only after rebase
+  (step 3). Regular pushes after that show
+  incremental progress.
 
-Once the unresolved count is 0 and CI is green, the PR
-is ready for merge.
+The PR is merged once the queue batch passes CI.

--- a/docs/development/pr-fixup-workflow.md
+++ b/docs/development/pr-fixup-workflow.md
@@ -297,7 +297,8 @@ use `/merge-queue` to enqueue it.
 - Works in both local and Claude Code web
   environments. Step 1 installs `gh` if missing.
 - Run `mdsmith check .` and
-  `golangci-lint run --fix` before committing.
+  `go tool golangci-lint run --fix ./...`
+  before committing.
 - Keep fix commits small — one per CI fix, one per
   batch of related review comments.
 - Use `--force-with-lease` only after rebase

--- a/docs/development/pr-fixup-workflow.md
+++ b/docs/development/pr-fixup-workflow.md
@@ -289,34 +289,8 @@ gh pr checks "$PR"
 
 Re-run the step 7 query and filter for unresolved
 threads. If the count is 0 and CI is green, cancel
-the recurring loop and proceed to step 11.
-
-### 11. Enqueue the PR for merge
-
-Add the `queue` label to enter the merge queue
-(`jeduden/merge-queue-action`):
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
-
-The action batches labeled PRs (oldest first) into
-a temporary branch and runs CI against it. If CI
-passes, `main` fast-forwards automatically.
-
-Labels track progress: `queue` → `queue:active`
-(in batch) → merged. On failure the action applies
-`queue:failed` and posts a comment with the cause.
-Fix the issue (return to step 6), push, then swap
-labels to re-enter:
-
-```bash
-gh pr edit "$PR" --remove-label queue:failed
-```
-
-```bash
-gh pr edit "$PR" --add-label queue
-```
+the recurring loop. The PR is ready for merge —
+use `/merge-queue` to enqueue it.
 
 ## Notes
 
@@ -330,4 +304,5 @@ gh pr edit "$PR" --add-label queue
   (step 3). Regular pushes after that show
   incremental progress.
 
-The PR is merged once the queue batch passes CI.
+Use `/merge-queue` to enqueue the PR once it is
+ready.

--- a/docs/development/pr-fixup-workflow.md
+++ b/docs/development/pr-fixup-workflow.md
@@ -136,13 +136,13 @@ let the next loop iteration verify the result.
 Check CI status:
 
 ```bash
-gh pr checks "$PR" --json name,state
+gh pr checks "$PR" --json name,state,bucket
 ```
 
-If all checks show `SUCCESS`, proceed to step 7. If
-any show `FAILURE`, proceed to step 6. If checks are
-still `IN_PROGRESS` or `PENDING`, wait for the next
-loop iteration.
+If every check has `bucket = pass`, proceed to
+step 7. If any show `bucket = fail`, proceed to
+step 6. If any show `bucket = pending`, wait for
+the next loop iteration.
 
 ### 6. On CI failure — diagnose and fix
 


### PR DESCRIPTION
## Summary

This change introduces documentation and tooling for a label-driven merge queue workflow using `jeduden/merge-queue-action`. It adds a new Claude skill for enqueueing PRs and updates development documentation to explain the merge queue process.

## Key Changes

- **New skill**: `.claude/skills/merge-queue/SKILL.md` — A user-invocable skill that guides users through enqueueing a PR into the merge queue, including:
  - Identifying the PR number from arguments or current branch
  - Verifying CI is green and Copilot has reviewed the latest commit
  - Adding the `queue` label to trigger the merge action
  - Monitoring label progression through `queue` → `queue:active` → `queue:failed` states
  - Handling failures by fixing issues and re-entering the queue

- **Documentation updates** across multiple files (AGENTS.md, CLAUDE.md, docs/development/index.md, .github/copilot-instructions.md):
  - Added "Merge Queue" section explaining how `jeduden/merge-queue-action` works
  - Documented the label state machine and batch processing (up to 5 PRs per batch)
  - Explained bisection behavior for multi-PR batch failures
  - Clarified eligibility (same-repo PRs targeting `main` only)
  - Noted manual dispatch capability via `workflow_dispatch`

- **PR fixup workflow refinements** (docs/development/pr-fixup-workflow.md and related skill files):
  - Updated final step to reference `/merge-queue` skill for enqueueing
  - Simplified notes section for clarity
  - Minor wording improvements for conciseness

## Implementation Details

The merge queue operates as a label-driven state machine:
- PRs labeled `queue` are collected oldest-first and batched (max 5)
- Batches are merged into temporary `merge-queue/batch-*` branches server-side
- CI runs against the batch; if it passes, `main` fast-forwards and the batch branch is deleted
- On failure, the action adds `queue:failed` and posts a diagnostic comment
- Multi-PR batch failures trigger recursive bisection to isolate the problematic PR

The new skill provides step-by-step guidance for users to verify readiness (CI green, Copilot review present) before enqueueing, and handles the label manipulation workflow for both initial queueing and recovery from failures.

https://claude.ai/code/session_01B8wwrwR7vHqZWgVhRPz9pL