### PR TITLE
Fix glob resolution in catalog directives within included files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -129,6 +129,7 @@ reflect) without saying what is checked against what.
 ### Development Reference
 
 <?include
+source-dir: "."
 file: docs/development/index.md
 strip-frontmatter: "true"
 heading-level: "absolute"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,7 @@ mdsmith — a Markdown linter written in Go.
 - [Plan template; see PLAN.md for status, plans live in plan/](../plan/proto.md)
 
 <?catalog
+source-dir: "."
 glob:
   - "docs/**/*.md"
   - "!docs/research/**"

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -248,20 +248,41 @@ func splitIncludeExclude(glob string) (include, exclude []string) {
 	return include, exclude
 }
 
+// resolveGlobFS returns the filesystem to use for glob resolution and
+// a path prefix for display filenames. When source-dir is set (injected
+// by include expansion), globs resolve from that subdirectory of RootFS
+// and matched filenames are prefixed so links work from the including file.
+func resolveGlobFS(f *lint.File, params map[string]string) (globFS fs.FS, prefix string) {
+	sourceDir := params["source-dir"]
+	if sourceDir == "" || f.RootFS == nil {
+		return f.FS, ""
+	}
+	sub, err := fs.Sub(f.RootFS, sourceDir)
+	if err != nil {
+		return f.FS, ""
+	}
+	return sub, sourceDir
+}
+
 // buildCatalogEntries resolves glob matches, reads front matter, and
 // returns sorted file entries for the catalog directive.
 func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
-	files := resolveGlobMatches(f, params)
+	globFS, prefix := resolveGlobFS(f, params)
+	files := resolveGlobMatchesFrom(globFS, f, params)
 
 	sortKey, descending := parseSort(params)
 	_, hasRow := params["row"]
 	needFM := hasRow || (sortKey != "path" && sortKey != "filename")
 
 	entries := make([]fileEntry, 0, len(files))
-	for _, path := range files {
-		fields := map[string]any{"filename": path}
+	for _, p := range files {
+		displayPath := p
+		if prefix != "" {
+			displayPath = path.Join(prefix, p)
+		}
+		fields := map[string]any{"filename": displayPath}
 		if needFM {
-			for k, v := range readFrontMatter(f.FS, path) {
+			for k, v := range readFrontMatter(globFS, p) {
 				fields[k] = v
 			}
 		}
@@ -275,13 +296,19 @@ func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
 // resolveGlobMatches expands include patterns, filters out exclude and
 // gitignore matches, and returns deduplicated file paths.
 func resolveGlobMatches(f *lint.File, params map[string]string) []string {
+	return resolveGlobMatchesFrom(f.FS, f, params)
+}
+
+// resolveGlobMatchesFrom is like resolveGlobMatches but uses the given
+// FS for glob resolution instead of f.FS.
+func resolveGlobMatchesFrom(globFS fs.FS, f *lint.File, params map[string]string) []string {
 	includePatterns, excludePatterns := splitIncludeExclude(params["glob"])
 	matcher, base := resolveGitignore(f, params)
 
 	seen := make(map[string]bool)
 	var files []string
 	for _, pattern := range includePatterns {
-		matches, err := doublestar.Glob(f.FS, pattern)
+		matches, err := doublestar.Glob(globFS, pattern)
 		if err != nil {
 			continue
 		}
@@ -289,7 +316,7 @@ func resolveGlobMatches(f *lint.File, params map[string]string) []string {
 			if seen[m] {
 				continue
 			}
-			info, err := fs.Stat(f.FS, m)
+			info, err := fs.Stat(globFS, m)
 			if err != nil || info.IsDir() {
 				continue
 			}
@@ -316,7 +343,11 @@ func resolveGitignore(f *lint.File, params map[string]string) (*lint.GitignoreMa
 	if matcher == nil {
 		return nil, ""
 	}
-	base, err := filepath.Abs(filepath.Dir(f.Path))
+	baseDir := filepath.Dir(f.Path)
+	if sd := params["source-dir"]; sd != "" && f.RootDir != "" {
+		baseDir = filepath.Join(f.RootDir, sd)
+	}
+	base, err := filepath.Abs(baseDir)
 	if err != nil {
 		return nil, ""
 	}

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -363,7 +363,10 @@ func resolveGitignore(f *lint.File, params map[string]string) (*lint.GitignoreMa
 	}
 	baseDir := filepath.Dir(f.Path)
 	if sd := params["source-dir"]; sd != "" && f.RootDir != "" {
-		baseDir = filepath.Join(f.RootDir, sd)
+		sd = path.Clean(sd)
+		if !filepath.IsAbs(sd) && !containsDotDot(sd) {
+			baseDir = filepath.Join(f.RootDir, sd)
+		}
 	}
 	base, err := filepath.Abs(baseDir)
 	if err != nil {

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -251,17 +251,40 @@ func splitIncludeExclude(glob string) (include, exclude []string) {
 // resolveGlobFS returns the filesystem to use for glob resolution and
 // a path prefix for display filenames. When source-dir is set (injected
 // by include expansion), globs resolve from that subdirectory of RootFS
-// and matched filenames are prefixed so links work from the including file.
+// and matched filenames are prefixed relative to the catalog-owning
+// file's directory so links work correctly.
 func resolveGlobFS(f *lint.File, params map[string]string) (globFS fs.FS, prefix string) {
 	sourceDir := params["source-dir"]
 	if sourceDir == "" || f.RootFS == nil {
 		return f.FS, ""
 	}
+
+	sourceDir = path.Clean(sourceDir)
+	fileDir := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
+
+	// Compute prefix relative to the file's directory so display
+	// filenames produce correct links from the including file.
+	relPrefix, err := filepath.Rel(fileDir, sourceDir)
+	if err != nil {
+		return f.FS, ""
+	}
+	relPrefix = filepath.ToSlash(relPrefix)
+
+	if sourceDir == "." {
+		if relPrefix == "." {
+			return f.RootFS, ""
+		}
+		return f.RootFS, relPrefix
+	}
+
 	sub, err := fs.Sub(f.RootFS, sourceDir)
 	if err != nil {
 		return f.FS, ""
 	}
-	return sub, sourceDir
+	if relPrefix == "." {
+		return sub, ""
+	}
+	return sub, relPrefix
 }
 
 // buildCatalogEntries resolves glob matches, reads front matter, and
@@ -293,14 +316,9 @@ func buildCatalogEntries(f *lint.File, params map[string]string) []fileEntry {
 	return entries
 }
 
-// resolveGlobMatches expands include patterns, filters out exclude and
-// gitignore matches, and returns deduplicated file paths.
-func resolveGlobMatches(f *lint.File, params map[string]string) []string {
-	return resolveGlobMatchesFrom(f.FS, f, params)
-}
-
-// resolveGlobMatchesFrom is like resolveGlobMatches but uses the given
-// FS for glob resolution instead of f.FS.
+// resolveGlobMatchesFrom expands include patterns using the given FS,
+// filters out exclude and gitignore matches, and returns deduplicated
+// file paths.
 func resolveGlobMatchesFrom(globFS fs.FS, f *lint.File, params map[string]string) []string {
 	includePatterns, excludePatterns := splitIncludeExclude(params["glob"])
 	matcher, base := resolveGitignore(f, params)

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3307,3 +3307,64 @@ source-dir: "docs/dev"
 	assert.Contains(t, result, "dev/api.md")
 	assert.NotContains(t, result, "docs/dev/api.md")
 }
+
+func TestCatalog_SourceDirRootFromRootFile(t *testing.T) {
+	// source-dir: "." with file at root → relPrefix is ".", so no prefix.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "."
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"alpha.md": {Data: []byte("# A\n")},
+		"beta.md":  {Data: []byte("# B\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// File is at root, source-dir is root → no prefix needed.
+	assert.Contains(t, result, "[alpha.md](alpha.md)")
+	assert.Contains(t, result, "[beta.md](beta.md)")
+}
+
+func TestCatalog_SourceDirSameAsFileDir(t *testing.T) {
+	// source-dir matches the file's own directory → relPrefix is ".".
+	src := `<?catalog
+glob: "*.md"
+source-dir: "docs"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"docs/one.md": {Data: []byte("# One\n")},
+	}
+	f := newTestFile(t, "docs/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// No prefix needed since source-dir == file dir.
+	assert.Contains(t, result, "[one.md](one.md)")
+}
+
+func TestCatalog_SourceDirNoRootFS(t *testing.T) {
+	// Without RootFS, source-dir is ignored and globs use f.FS.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "sub"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"top.md": {Data: []byte("# Top\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	// Deliberately not setting f.RootFS.
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, "top.md")
+}

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3411,3 +3411,24 @@ source-dir: "/proj/sub"
 
 	assert.Contains(t, result, "fallback.md")
 }
+
+func TestCatalog_SourceDirTraversalIgnored(t *testing.T) {
+	// source-dir with ".." should not escape the project root for
+	// gitignore resolution. resolveGlobFS rejects it via fs.Sub;
+	// resolveGitignore must also reject it.
+	src := `<?catalog
+glob: "*.md"
+source-dir: ".."
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"top.md": {Data: []byte("# Top\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	// Should not panic or escape; falls back to f.FS.
+	result := string(r.Fix(f))
+	assert.Contains(t, result, "top.md")
+}

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3368,3 +3368,46 @@ source-dir: "sub"
 
 	assert.Contains(t, result, "top.md")
 }
+
+func TestCatalog_SourceDirRelPrefixError(t *testing.T) {
+	// filepath.Rel fails when one path is absolute and the other
+	// relative. resolveGlobFS should fall back to f.FS.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "sub"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"top.md":   {Data: []byte("# Top\n")},
+		"sub/a.md": {Data: []byte("# A\n")},
+	}
+	f := newTestFile(t, "/absolute/path/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// Falls back to f.FS since Rel fails.
+	assert.Contains(t, result, "top.md")
+}
+
+func TestCatalog_SourceDirInvalidSubFS(t *testing.T) {
+	// fs.Sub rejects paths starting with "/". When both file path
+	// and source-dir are absolute, filepath.Rel succeeds but fs.Sub
+	// fails. resolveGlobFS should fall back to f.FS.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "/proj/sub"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"fallback.md": {Data: []byte("# Fallback\n")},
+	}
+	f := newTestFile(t, "/proj/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, "fallback.md")
+}

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3182,3 +3182,80 @@ func TestCatalogInjection_BothNewlineAndLink(t *testing.T) {
 	diags := checkCatalogInjection("index.md", 5, entries)
 	assert.Len(t, diags, 2, "should report both newline and ]( issues")
 }
+
+// =====================================================================
+// source-dir: glob resolution from included file's directory (#133)
+// =====================================================================
+
+func TestCatalog_SourceDirResolvesGlobFromSubdir(t *testing.T) {
+	// When source-dir is set, globs should resolve relative to that
+	// directory, not the file's own directory. This supports catalog
+	// directives transplanted by include expansion.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "docs/dev"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"docs/dev/api.md":   {Data: []byte("# API\n")},
+		"docs/dev/guide.md": {Data: []byte("# Guide\n")},
+		"README.md":         {Data: []byte("# Root\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// Filenames should be prefixed with the source-dir so links
+	// resolve correctly from the including file.
+	assert.Contains(t, result, "docs/dev/api.md")
+	assert.Contains(t, result, "docs/dev/guide.md")
+	assert.NotContains(t, result, "README.md")
+}
+
+func TestCatalog_SourceDirWithFrontMatter(t *testing.T) {
+	// source-dir should also read front matter from the correct directory.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "sub"
+row: "- [{title}]({filename})"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"sub/one.md": {Data: []byte("---\ntitle: One\n---\n# One\n")},
+		"sub/two.md": {Data: []byte("---\ntitle: Two\n---\n# Two\n")},
+	}
+	f := newTestFile(t, "root.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, "- [One](sub/one.md)")
+	assert.Contains(t, result, "- [Two](sub/two.md)")
+}
+
+func TestCatalog_SourceDirExcludePatterns(t *testing.T) {
+	// Exclude patterns should work relative to source-dir.
+	src := `<?catalog
+glob:
+  - "*.md"
+  - "!internal.md"
+source-dir: "docs"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"docs/public.md":   {Data: []byte("# Public\n")},
+		"docs/internal.md": {Data: []byte("# Internal\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, "docs/public.md")
+	// The excluded file should not appear as a link in the generated content.
+	assert.NotContains(t, result, "[internal.md](docs/internal.md)")
+}

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3259,3 +3259,51 @@ source-dir: "docs"
 	// The excluded file should not appear as a link in the generated content.
 	assert.NotContains(t, result, "[internal.md](docs/internal.md)")
 }
+
+func TestCatalog_SourceDirRoot(t *testing.T) {
+	// source-dir: "." means globs resolve from the project root.
+	// This happens when a subdirectory file includes a root-level file.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "."
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"api.md":        {Data: []byte("# API\n")},
+		"guide.md":      {Data: []byte("# Guide\n")},
+		"docs/other.md": {Data: []byte("# Other\n")},
+	}
+	f := newTestFile(t, "docs/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// From docs/index.md, root files need a ../ prefix.
+	assert.Contains(t, result, "../api.md")
+	assert.Contains(t, result, "../guide.md")
+	assert.NotContains(t, result, "other.md")
+}
+
+func TestCatalog_SourceDirFromSubdirIncluder(t *testing.T) {
+	// When the catalog-owning file is in a subdirectory and source-dir
+	// points to a sibling subdirectory, the prefix should be relative.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "docs/dev"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"docs/dev/api.md": {Data: []byte("# API\n")},
+		"README.md":       {Data: []byte("# Root\n")},
+	}
+	f := newTestFile(t, "docs/intro.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// From docs/intro.md, docs/dev/api.md is at dev/api.md.
+	assert.Contains(t, result, "dev/api.md")
+	assert.NotContains(t, result, "docs/dev/api.md")
+}

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -246,6 +246,19 @@ func processIncludedContent(
 	includedPath := path.Join(path.Dir(filePath), file)
 	text = adjustLinks(text, includedPath, filePath)
 
+	// Inject source-dir into processing instructions so downstream
+	// directives (e.g. catalog) resolve globs relative to the included
+	// file's directory, not the including file's directory (#133).
+	// Skip when content will be wrapped in a code fence, since wrapped
+	// content is displayed as code and PIs are not parsed.
+	if _, wrapped := params["wrap"]; !wrapped {
+		includedDir := path.Dir(includedPath)
+		includerDir := path.Dir(filePath)
+		if includedDir != includerDir && includedDir != "." {
+			text = injectSourceDir(text, includedDir)
+		}
+	}
+
 	if params["heading-level"] == "absolute" {
 		text = adjustHeadings(text, findParentHeadingLevel(f, line))
 	}
@@ -377,6 +390,67 @@ func (r *Rule) expandNestedIncludes(
 	}
 
 	return f.Source, nil
+}
+
+// injectSourceDir adds a source-dir parameter to processing instruction
+// start markers in text. It parses the text as Markdown to avoid modifying
+// PIs inside code blocks.
+func injectSourceDir(text, sourceDir string) string {
+	parsed, err := lint.NewFile("", []byte(text))
+	if err != nil {
+		return text
+	}
+
+	// Collect byte offsets where the source-dir line should be inserted.
+	type injection struct {
+		offset int
+	}
+	var injections []injection
+
+	for n := parsed.AST.FirstChild(); n != nil; n = n.NextSibling() {
+		pi, ok := n.(*lint.ProcessingInstruction)
+		if !ok {
+			continue
+		}
+		// Skip end markers (<?/name?>).
+		if strings.HasPrefix(pi.Name, "/") {
+			continue
+		}
+		firstSeg := pi.Lines().At(0)
+		// Skip single-line PIs (<?name ...?>).
+		if pi.HasClosure() && pi.ClosureLine.Start == firstSeg.Start {
+			continue
+		}
+		// Skip if source-dir is already present in the PI body.
+		already := false
+		for i := 1; i < pi.Lines().Len(); i++ {
+			seg := pi.Lines().At(i)
+			if strings.Contains(string(seg.Value([]byte(text))), "source-dir:") {
+				already = true
+				break
+			}
+		}
+		if already {
+			continue
+		}
+
+		injections = append(injections, injection{offset: firstSeg.Stop})
+	}
+
+	if len(injections) == 0 {
+		return text
+	}
+
+	sdLine := fmt.Sprintf("source-dir: \"%s\"\n", sourceDir)
+	var b strings.Builder
+	prev := 0
+	for _, inj := range injections {
+		b.WriteString(text[prev:inj.offset])
+		b.WriteString(sdLine)
+		prev = inj.offset
+	}
+	b.WriteString(text[prev:])
+	return b.String()
 }
 
 var _ rule.FixableRule = (*Rule)(nil)

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
@@ -441,7 +442,7 @@ func injectSourceDir(text, sourceDir string) string {
 		return text
 	}
 
-	sdLine := fmt.Sprintf("source-dir: \"%s\"\n", sourceDir)
+	sdLine := fmt.Sprintf("source-dir: %s\n", strconv.Quote(sourceDir))
 	var b strings.Builder
 	prev := 0
 	for _, inj := range injections {

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -254,7 +254,7 @@ func processIncludedContent(
 	if _, wrapped := params["wrap"]; !wrapped {
 		includedDir := path.Dir(includedPath)
 		includerDir := path.Dir(filePath)
-		if includedDir != includerDir && includedDir != "." {
+		if includedDir != includerDir {
 			text = injectSourceDir(text, includedDir)
 		}
 	}

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -679,6 +679,61 @@ func TestFix_RecursiveExpansionSubdir(t *testing.T) {
 }
 
 // =====================================================================
+// source-dir injection for nested directives (#133)
+// =====================================================================
+
+func TestFix_InjectsSourceDirIntoCatalog(t *testing.T) {
+	// When an included file contains a <?catalog?> directive, the
+	// include expansion should inject source-dir so the catalog
+	// resolves globs relative to the included file's directory.
+	fsys := fstest.MapFS{
+		"docs/dev/index.md": {Data: []byte(
+			"<?catalog\nglob: \"*.md\"\n?>\n<?/catalog?>\n",
+		)},
+	}
+	src := "<?include\nfile: docs/dev/index.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "README.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, "source-dir:")
+	assert.Contains(t, result, "docs/dev")
+}
+
+func TestFix_InjectsSourceDirPreservesExistingParams(t *testing.T) {
+	// source-dir injection should not disturb other catalog parameters.
+	fsys := fstest.MapFS{
+		"sub/catalog.md": {Data: []byte(
+			"<?catalog\nglob: \"*.md\"\nsort: path\n?>\n<?/catalog?>\n",
+		)},
+	}
+	src := "<?include\nfile: sub/catalog.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "root.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, "source-dir:")
+	assert.Contains(t, result, "glob:")
+	assert.Contains(t, result, "sort: path")
+}
+
+func TestFix_NoSourceDirWhenSameDir(t *testing.T) {
+	// When the included file is in the same directory as the including
+	// file, no source-dir is needed.
+	fsys := fstest.MapFS{
+		"catalog.md": {Data: []byte(
+			"<?catalog\nglob: \"*.md\"\n?>\n<?/catalog?>\n",
+		)},
+	}
+	src := "<?include\nfile: catalog.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "index.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.NotContains(t, result, "source-dir:")
+}
+
+// =====================================================================
 // No FS
 // =====================================================================
 

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -733,6 +733,22 @@ func TestFix_NoSourceDirWhenSameDir(t *testing.T) {
 	assert.NotContains(t, result, "source-dir:")
 }
 
+func TestFix_InjectsSourceDirForRootInclude(t *testing.T) {
+	// When a subdir file includes a root-level file, source-dir: "."
+	// should be injected so catalog globs resolve from the project root.
+	fsys := fstest.MapFS{
+		"root-catalog.md": {Data: []byte(
+			"<?catalog\nglob: \"*.md\"\n?>\n<?/catalog?>\n",
+		)},
+	}
+	src := "<?include\nfile: ../root-catalog.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "docs/index.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.Contains(t, result, `source-dir: "."`)
+}
+
 // =====================================================================
 // No FS
 // =====================================================================

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -749,6 +749,50 @@ func TestFix_InjectsSourceDirForRootInclude(t *testing.T) {
 	assert.Contains(t, result, `source-dir: "."`)
 }
 
+func TestFix_SkipsSourceDirForSingleLinePI(t *testing.T) {
+	// Single-line PIs like <?foo?> should not get source-dir injected.
+	fsys := fstest.MapFS{
+		"sub/content.md": {Data: []byte(
+			"<?foo?>\nSome text\n",
+		)},
+	}
+	src := "<?include\nfile: sub/content.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "root.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.NotContains(t, result, "source-dir:")
+}
+
+func TestFix_SkipsSourceDirIfAlreadyPresent(t *testing.T) {
+	// If a PI already has source-dir, don't inject a second one.
+	fsys := fstest.MapFS{
+		"sub/content.md": {Data: []byte(
+			"<?catalog\nsource-dir: \"other\"\nglob: \"*.md\"\n?>\n<?/catalog?>\n",
+		)},
+	}
+	src := "<?include\nfile: sub/content.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "root.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	// Should keep the existing source-dir, not add another.
+	assert.Equal(t, 1, strings.Count(result, "source-dir:"))
+}
+
+func TestFix_NoSourceDirForPlainText(t *testing.T) {
+	// Included content with no PIs should not get source-dir.
+	fsys := fstest.MapFS{
+		"sub/plain.md": {Data: []byte("# Plain\n\nJust text.\n")},
+	}
+	src := "<?include\nfile: sub/plain.md\n?>\nold\n<?/include?>\n"
+	f := newTestFile(t, "root.md", src, fsys)
+	r := &Rule{}
+	result := string(r.Fix(f))
+
+	assert.NotContains(t, result, "source-dir:")
+}
+
 // =====================================================================
 // No FS
 // =====================================================================

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -672,7 +672,7 @@ func TestFix_RecursiveExpansionSubdir(t *testing.T) {
 	r := &Rule{}
 	got := string(r.Fix(f))
 	want := "# A\n\n<?include\nfile: sub/b.md\n?>\n" +
-		"# B\n\n<?include\nfile: c.md\n?>\n" +
+		"# B\n\n<?include\nsource-dir: \"sub\"\nfile: c.md\n?>\n" +
 		"Fresh from C\n<?/include?>\n<?/include?>\n"
 	assert.Equal(t, want, got,
 		"Fix output mismatch\ngot:\n%s\nwant:\n%s", got, want)


### PR DESCRIPTION
## Summary
This PR fixes glob resolution for catalog directives that are transplanted into documents via file inclusion. When a catalog directive is included from a subdirectory, its glob patterns now correctly resolve relative to that subdirectory rather than the including file's directory.

## Key Changes

- **Include rule enhancement**: Added `injectSourceDir()` function that automatically injects a `source-dir` parameter into multi-line processing instructions when content is included from a different directory. This ensures downstream directives (like catalog) know where to resolve globs from.

- **Catalog rule updates**: 
  - Added `resolveGlobFS()` to determine the correct filesystem and path prefix for glob resolution based on the `source-dir` parameter
  - Refactored `resolveGlobMatches()` into `resolveGlobMatchesFrom()` to accept an explicit filesystem for glob resolution
  - Updated `buildCatalogEntries()` to use the source-dir-aware filesystem and prefix matched filenames so links resolve correctly from the including file
  - Fixed `resolveGitignore()` to compute the gitignore base directory relative to source-dir when present

- **Test coverage**: Added comprehensive tests for:
  - Glob resolution from subdirectories with source-dir
  - Front matter reading from the correct directory
  - Exclude patterns working relative to source-dir
  - Source-dir injection into included catalog directives
  - Preservation of existing parameters during injection
  - Avoiding unnecessary injection when files are in the same directory

## Implementation Details

The solution works by having the include rule detect when content is being included from a different directory and automatically inject a `source-dir` parameter into multi-line processing instructions. This parameter is then used by the catalog rule to:
1. Resolve globs against the correct subdirectory of the root filesystem
2. Prefix matched filenames so they resolve correctly from the including file's location
3. Read front matter from files in the correct directory

The injection is skipped for single-line PIs and when content is wrapped in code fences (where PIs aren't parsed).

https://claude.ai/code/session_01VN3XGWEbs4qRPet8qBia59