### PR TITLE
Upgrade merge-queue-action to v0.3.0

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -32,7 +32,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@5e81e8d3023229ed0b2bfc9f7f764a701b362d9c # v0.2.0
+      - uses: jeduden/merge-queue-action@e5ec6faf13c700775aa47f910c60003cf3e6b2f6 # v0.3.0
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Updates the `jeduden/merge-queue-action` GitHub Action to version 0.3.0, which includes improvements and fixes from the upstream project.

## Changes
- Updated `jeduden/merge-queue-action` from v0.2.0 to v0.3.0
- Updated action reference from commit `5e81e8d3023229ed0b2bfc9f7f764a701b362d9c` to `e5ec6faf13c700775aa47f910c60003cf3e6b2f6`

## Details
This upgrade brings the merge queue workflow to the latest stable version of the action, ensuring access to the latest features, bug fixes, and security improvements provided by the upstream maintainers.

https://claude.ai/code/session_01XsAfsEAg6K5GCyhF7tKhhL