### PR TITLE
Upgrade merge-queue-action to v0.4.0

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -32,7 +32,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@e5ec6faf13c700775aa47f910c60003cf3e6b2f6 # v0.3.0
+      - uses: jeduden/merge-queue-action@66ff7bed25876a7ed71987341157fc6e52b03319 # v0.4.0
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
- Bump `jeduden/merge-queue-action` from v0.2.0 to v0.4.0 in `.github/workflows/merge-queue.yml`
- Pinned to commit `66ff7be` (v0.4.0)

## Test plan
- [ ] Merge-queue workflow runs successfully on next queued PR

https://claude.ai/code/session_01XsAfsEAg6K5GCyhF7tKhhL