### PR TITLE
Update merge-queue-action to v0.4.1

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -32,7 +32,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@66ff7bed25876a7ed71987341157fc6e52b03319 # v0.4.0
+      - uses: jeduden/merge-queue-action@10aad589472d158972acc028efbfbcd2ee579af2 # v0.4.1
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Updates the `jeduden/merge-queue-action` dependency to the latest patch version (v0.4.1).

## Changes
- Updated `merge-queue-action` from v0.4.0 to v0.4.1
  - Commit hash: `66ff7bed25876a7ed71987341157fc6e52b03319` → `10aad589472d158972acc028efbfbcd2ee579af2`

This patch update includes bug fixes and improvements from the merge-queue-action project.

https://claude.ai/code/session_01TktDyX44PW8KpWshzT4SQE