### PR TITLE
Upgrade merge-queue-action to v0.5.0

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,7 +34,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@10aad589472d158972acc028efbfbcd2ee579af2 # v0.4.1
+      - uses: jeduden/merge-queue-action@fd94568d534e31322ce59898030b340a7c36202d # v0.5.0
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Updates the `jeduden/merge-queue-action` dependency from v0.4.1 to v0.5.0 in the merge queue workflow.

## Changes
- Updated `jeduden/merge-queue-action` action reference from commit `10aad589472d158972acc028efbfbcd2ee579af2` (v0.4.1) to `fd94568d534e31322ce59898030b340a7c36202d` (v0.5.0)

## Details
This upgrade brings the latest improvements and fixes from the merge-queue-action project. The action configuration and parameters remain unchanged, ensuring compatibility with the existing merge queue workflow setup.

https://claude.ai/code/session_01PzbArqsff3zfZWXxqNZCTe