### PR TITLE
Use debug branch of merge-queue-action for testing

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,7 +34,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@fd94568d534e31322ce59898030b340a7c36202d # v0.5.0
+      - uses: jeduden/merge-queue-action@claude/debug-merge-queue-action-QRX4B # debug branch
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Updated the merge-queue workflow to use a debug branch of the merge-queue-action for testing and debugging purposes.

## Changes
- Updated `jeduden/merge-queue-action` reference from the stable v0.5.0 release to the `claude/debug-merge-queue-action-QRX4B` debug branch
- This allows testing of changes to the merge queue action before they are released

## Notes
This is a temporary change for debugging. The action reference should be reverted to a stable release version once testing is complete.

https://claude.ai/code/session_01QYzcoTGRUeJgkdKGmKdjwB