### PR TITLE
Update merge-queue-action to v0.5.1

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,7 +34,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@claude/debug-merge-queue-action-QRX4B # debug branch
+      - uses: jeduden/merge-queue-action@v0.5.1
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,7 +34,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@v0.5.1
+      - uses: jeduden/merge-queue-action@e42783e834759214cb61b18535f770508543e5aa # v0.5.1
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Updates the merge-queue-action workflow to use the stable v0.5.1 release instead of a debug branch.

## Changes
- Replaced the debug branch reference (`claude/debug-merge-queue-action-QRX4B`) with the official v0.5.1 release tag in the merge-queue workflow

## Details
This change removes the temporary debug branch dependency and pins the workflow to a specific stable version, improving reliability and maintainability of the CI/CD pipeline.

https://claude.ai/code/session_01G8Ro3d1b1x3CmYvBKZ5UDQ