### PR TITLE
Add MDS035 rule to flag renderer-specific TOC directives

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -45,6 +45,6 @@ footer: |
 | 85  | 🔲     | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)            |
 | 86  | 🔲     | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                             |
 | 87  | 🔲     | [Flavor validation for GitHub Alerts](plan/87_markdown-flavor-github-alerts.md)                                 |
-| 88  | 🔲     | [TOC directive migration aid](plan/88_toc-directive-migration.md)                                               |
+| 88  | ✅     | [TOC directive migration aid](plan/88_toc-directive-migration.md)                                               |
 | 89  | 🔲     | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                               |
 <?/catalog?>

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -55,6 +55,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/singletrailingnewline"
 	_ "github.com/jeduden/mdsmith/internal/rules/tableformat"
 	_ "github.com/jeduden/mdsmith/internal/rules/tablereadability"
+	_ "github.com/jeduden/mdsmith/internal/rules/tocdirective"
 	_ "github.com/jeduden/mdsmith/internal/rules/tokenbudget"
 	_ "github.com/jeduden/mdsmith/internal/rules/unclosedcodeblock"
 )

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -263,6 +263,24 @@ mdsmith has the strongest cross-file and project-level
 features. The merge driver and regenerable sections are
 unique to mdsmith.
 
+### Renderer Portability
+
+Several Markdown renderers expand non-standard
+tokens into tables of contents. Common
+variants are `[TOC]` (Python-Markdown),
+`[[_TOC_]]` (GitLab, Azure DevOps), `[[toc]]`
+(markdown-it, VitePress), and `${toc}` (some
+VitePress configs). CommonMark and goldmark —
+the engine mdsmith uses — expand none of
+them. They render as literal text.
+
+[MDS035][mds035] (toc-directive, opt-in) flags
+each of the four tokens on its own line. For
+`[TOC]`, the rule suppresses the diagnostic
+when a matching link reference definition
+makes it a legitimate link. No other linter
+in this comparison detects these tokens.
+
 ### Runtime and Integration
 
 | Property       | mdsmith    | markdownlint   | remark-lint  | Prettier     | Vale       | textlint     | LLM         |
@@ -456,6 +474,7 @@ relaxed rules) for presentation files.
 [mds028]: ../../internal/rules/MDS028-token-budget/README.md
 [mds029]: ../../internal/rules/MDS029-conciseness-scoring/README.md
 [mds030]: ../../internal/rules/MDS030-empty-section-body/README.md
+[mds035]: ../../internal/rules/MDS035-toc-directive/README.md
 <!-- markdownlint links -->
 [markdownlint]: https://github.com/DavidAnson/markdownlint
 [markdownlint-cli2]: https://github.com/DavidAnson/markdownlint-cli2

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/singletrailingnewline"
 	_ "github.com/jeduden/mdsmith/internal/rules/tableformat"
 	_ "github.com/jeduden/mdsmith/internal/rules/tablereadability"
+	_ "github.com/jeduden/mdsmith/internal/rules/tocdirective"
 	_ "github.com/jeduden/mdsmith/internal/rules/tokenbudget"
 )
 

--- a/internal/engine/categories_test.go
+++ b/internal/engine/categories_test.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/notrailingpunctuation"
 	_ "github.com/jeduden/mdsmith/internal/rules/notrailingspaces"
 	_ "github.com/jeduden/mdsmith/internal/rules/singletrailingnewline"
+	_ "github.com/jeduden/mdsmith/internal/rules/tocdirective"
 	_ "github.com/jeduden/mdsmith/internal/rules/tokenbudget"
 )
 

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -47,6 +48,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/singletrailingnewline"
 	_ "github.com/jeduden/mdsmith/internal/rules/tableformat"
 	_ "github.com/jeduden/mdsmith/internal/rules/tablereadability"
+	_ "github.com/jeduden/mdsmith/internal/rules/tocdirective"
 	_ "github.com/jeduden/mdsmith/internal/rules/tokenbudget"
 	_ "github.com/jeduden/mdsmith/internal/rules/unclosedcodeblock"
 
@@ -101,8 +103,11 @@ func parseFixtureFrontMatter(
 	return fm.Settings, fm.Diagnostics, content
 }
 
-// applySettingsToRule applies fixture settings to a rule. It saves and restores
-// the default settings after the test to avoid polluting the global singleton.
+// applySettingsToRule applies fixture settings to a rule. It snapshots the
+// rule's value before the change and restores it on test cleanup, so that
+// rules whose internal state cannot be recreated from DefaultSettings
+// alone (e.g. directory-structure's `configured` flag) do not leak state
+// into later tests.
 func applySettingsToRule(
 	t *testing.T, r rule.Rule, settings map[string]any,
 ) {
@@ -119,10 +124,15 @@ func applySettingsToRule(
 		)
 	}
 
-	defaults := cr.DefaultSettings()
-	t.Cleanup(func() {
-		_ = cr.ApplySettings(defaults)
-	})
+	// Snapshot via reflect so cleanup fully restores the pre-test state.
+	rv := reflect.ValueOf(r)
+	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		snapshot := reflect.New(rv.Elem().Type()).Elem()
+		snapshot.Set(rv.Elem())
+		t.Cleanup(func() {
+			rv.Elem().Set(snapshot)
+		})
+	}
 
 	if err := cr.ApplySettings(settings); err != nil {
 		t.Fatalf("applying settings: %v", err)

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -55,10 +55,13 @@ func (f *File) GetGitignore() *GitignoreMatcher {
 	return f.gitignoreVal
 }
 
-// NewFile parses source as Markdown and returns a File.
-func NewFile(path string, source []byte) (*File, error) {
-	reader := text.NewReader(source)
-	p := parser.NewParser(
+// NewParser returns a goldmark parser configured identically to the one
+// used by NewFile. Rules that need to re-inspect a document (for example,
+// to consult the link reference definition map) should use this so that
+// processing-instruction blocks and other mdsmith-specific parsing
+// decisions stay consistent with the original lint parse.
+func NewParser() parser.Parser {
+	return parser.NewParser(
 		parser.WithBlockParsers(
 			append(parser.DefaultBlockParsers(),
 				PIBlockParserPrioritized(),
@@ -71,7 +74,12 @@ func NewFile(path string, source []byte) (*File, error) {
 			parser.DefaultParagraphTransformers()...,
 		),
 	)
-	node := p.Parse(reader)
+}
+
+// NewFile parses source as Markdown and returns a File.
+func NewFile(path string, source []byte) (*File, error) {
+	reader := text.NewReader(source)
+	node := NewParser().Parse(reader)
 
 	lines := bytes.Split(source, []byte("\n"))
 

--- a/internal/rules/MDS035-toc-directive/README.md
+++ b/internal/rules/MDS035-toc-directive/README.md
@@ -1,0 +1,127 @@
+---
+id: MDS035
+name: toc-directive
+status: ready
+description: Flag renderer-specific TOC directives that render as literal text on CommonMark and goldmark.
+---
+# MDS035: toc-directive
+
+Flag renderer-specific TOC directives that
+render as literal text on CommonMark and
+goldmark.
+
+- **ID**: MDS035
+- **Name**: `toc-directive`
+- **Status**: ready
+- **Default**: disabled (opt-in)
+- **Fixable**: no
+- **Implementation**:
+  [source](./)
+- **Category**: meta
+
+## What it detects
+
+Four directive variants appear in the wild,
+each expanded by a different renderer:
+
+| Token       | Expanded by                            |
+|-------------|----------------------------------------|
+| `[TOC]`     | Python-Markdown, MultiMarkdown, Pandoc |
+| `[[_TOC_]]` | GitLab Flavored Markdown, Azure DevOps |
+| `[[toc]]`   | markdown-it-toc-done-right, VitePress  |
+| `${toc}`    | some VitePress configurations          |
+
+CommonMark and goldmark do not expand any of
+them; authors see the directive token in the
+rendered output instead of a table of
+contents. The rule flags each token when it
+appears on its own line inside a paragraph so
+authors can replace it, delete it, or maintain
+the list manually.
+
+`[TOC]` alone is also valid CommonMark
+shortcut reference link syntax. When the
+document contains a matching
+`[TOC]: <url>` definition, the rule
+suppresses the diagnostic because the token
+resolves to a real link rather than rendering
+as literal text.
+
+## Why not auto-fix
+
+The right replacement depends on intent. For
+file-index usage — an index page listing
+sibling documents — mdsmith's
+[`<?catalog?>`](../MDS019-catalog/README.md)
+directive is the replacement. For in-document
+heading TOCs, mdsmith has no equivalent; the
+author must drop the directive or maintain a
+manual list. The rule is detection-only and
+names both cases in its message.
+
+## Config
+
+Enable:
+
+```yaml
+rules:
+  toc-directive: true
+```
+
+Disable (default):
+
+```yaml
+rules:
+  toc-directive: false
+```
+
+## Examples
+
+### Good
+
+<?include
+file: good/default.md
+wrap: markdown
+?>
+
+````markdown
+# Document with no TOC directives
+
+This document has no renderer-specific TOC
+markers, so MDS035 stays silent.
+
+Normal prose is unaffected, and inline code
+like `[TOC]` or `${toc}` is not flagged because
+the tokens are inside code spans.
+
+```text
+[TOC]
+[[_TOC_]]
+[[toc]]
+${toc}
+```
+
+Even the fenced block above is a code block,
+not a paragraph, so nothing is reported.
+````
+
+<?/include?>
+
+### Bad
+
+<?include
+file: bad/bracketed.md
+wrap: markdown
+?>
+
+```markdown
+# Python-Markdown TOC directive
+
+[TOC]
+
+Everything below the directive renders fine,
+but the directive itself appears as literal
+text on CommonMark and goldmark renderers.
+```
+
+<?/include?>

--- a/internal/rules/MDS035-toc-directive/bad/bracketed.md
+++ b/internal/rules/MDS035-toc-directive/bad/bracketed.md
@@ -1,0 +1,13 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: "unsupported TOC directive `[TOC]`; mdsmith has no heading TOC equivalent; use `<?catalog?>` for file indexes (MDS019)"
+---
+# Python-Markdown TOC directive
+
+[TOC]
+
+Everything below the directive renders fine,
+but the directive itself appears as literal
+text on CommonMark and goldmark renderers.

--- a/internal/rules/MDS035-toc-directive/bad/gitlab.md
+++ b/internal/rules/MDS035-toc-directive/bad/gitlab.md
@@ -1,0 +1,13 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: "unsupported TOC directive `[[_TOC_]]`; mdsmith has no heading TOC equivalent; use `<?catalog?>` for file indexes (MDS019)"
+---
+# GitLab-flavored TOC directive
+
+[[_TOC_]]
+
+GitLab Flavored Markdown and Azure DevOps
+expand this into a TOC; CommonMark and
+goldmark render it as plain text.

--- a/internal/rules/MDS035-toc-directive/bad/markdown-it.md
+++ b/internal/rules/MDS035-toc-directive/bad/markdown-it.md
@@ -1,0 +1,13 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: "unsupported TOC directive `[[toc]]`; mdsmith has no heading TOC equivalent; use `<?catalog?>` for file indexes (MDS019)"
+---
+# markdown-it / VitePress TOC directive
+
+[[toc]]
+
+markdown-it-toc-done-right and VitePress
+replace this with a generated heading TOC;
+CommonMark leaves it as literal text.

--- a/internal/rules/MDS035-toc-directive/bad/vitepress-dollar.md
+++ b/internal/rules/MDS035-toc-directive/bad/vitepress-dollar.md
@@ -1,0 +1,13 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: "unsupported TOC directive `${toc}`; mdsmith has no heading TOC equivalent; use `<?catalog?>` for file indexes (MDS019)"
+---
+# VitePress dollar-brace TOC directive
+
+${toc}
+
+Some VitePress configurations expand this
+token. CommonMark and goldmark render it as
+literal text.

--- a/internal/rules/MDS035-toc-directive/good/default.md
+++ b/internal/rules/MDS035-toc-directive/good/default.md
@@ -1,0 +1,22 @@
+---
+settings:
+diagnostics:
+---
+# Document with no TOC directives
+
+This document has no renderer-specific TOC
+markers, so MDS035 stays silent.
+
+Normal prose is unaffected, and inline code
+like `[TOC]` or `${toc}` is not flagged because
+the tokens are inside code spans.
+
+```text
+[TOC]
+[[_TOC_]]
+[[toc]]
+${toc}
+```
+
+Even the fenced block above is a code block,
+not a paragraph, so nothing is reported.

--- a/internal/rules/MDS035-toc-directive/good/with-link-ref.md
+++ b/internal/rules/MDS035-toc-directive/good/with-link-ref.md
@@ -1,0 +1,13 @@
+---
+settings:
+diagnostics:
+---
+# TOC as legitimate link
+
+[TOC]: https://example.com/toc
+
+See the [TOC] above for the full list.
+
+A matching link reference definition is
+present, so `[TOC]` renders as a link. The
+rule does not flag this file.

--- a/internal/rules/index.md
+++ b/internal/rules/index.md
@@ -17,40 +17,41 @@ header: |
   |------|------|--------|-------------|
 row: "| [{id}]({filename}) | `{name}` | {status} | {description} |"
 ?>
-| Rule                                                          | Name                                 | Status    | Description                                                                             |
-|---------------------------------------------------------------|--------------------------------------|-----------|-----------------------------------------------------------------------------------------|
-| [MDS001](MDS001-line-length/README.md)                        | `line-length`                        | ready     | Line exceeds maximum length.                                                            |
-| [MDS002](MDS002-heading-style/README.md)                      | `heading-style`                      | ready     | Heading style must be consistent.                                                       |
-| [MDS003](MDS003-heading-increment/README.md)                  | `heading-increment`                  | ready     | Heading levels should increment by one. No jumping from `#` to `###`.                   |
-| [MDS004](MDS004-first-line-heading/README.md)                 | `first-line-heading`                 | ready     | First line of the file should be a heading.                                             |
-| [MDS005](MDS005-no-duplicate-headings/README.md)              | `no-duplicate-headings`              | ready     | No two headings should have the same text.                                              |
-| [MDS006](MDS006-no-trailing-spaces/README.md)                 | `no-trailing-spaces`                 | ready     | No trailing whitespace at the end of lines.                                             |
-| [MDS007](MDS007-no-hard-tabs/README.md)                       | `no-hard-tabs`                       | ready     | No tab characters. Use spaces instead.                                                  |
-| [MDS008](MDS008-no-multiple-blanks/README.md)                 | `no-multiple-blanks`                 | ready     | No more than one consecutive blank line.                                                |
-| [MDS009](MDS009-single-trailing-newline/README.md)            | `single-trailing-newline`            | ready     | File must end with exactly one newline character.                                       |
-| [MDS010](MDS010-fenced-code-style/README.md)                  | `fenced-code-style`                  | ready     | Fenced code blocks must use a consistent delimiter.                                     |
-| [MDS011](MDS011-fenced-code-language/README.md)               | `fenced-code-language`               | ready     | Fenced code blocks must specify a language.                                             |
-| [MDS012](MDS012-no-bare-urls/README.md)                       | `no-bare-urls`                       | ready     | URLs must be wrapped in angle brackets or as a link, not left bare.                     |
-| [MDS013](MDS013-blank-line-around-headings/README.md)         | `blank-line-around-headings`         | ready     | Headings must have a blank line before and after.                                       |
-| [MDS014](MDS014-blank-line-around-lists/README.md)            | `blank-line-around-lists`            | ready     | Lists must have a blank line before and after.                                          |
-| [MDS015](MDS015-blank-line-around-fenced-code/README.md)      | `blank-line-around-fenced-code`      | ready     | Fenced code blocks must have a blank line before and after.                             |
-| [MDS016](MDS016-list-indent/README.md)                        | `list-indent`                        | ready     | List items must use consistent indentation.                                             |
-| [MDS017](MDS017-no-trailing-punctuation-in-heading/README.md) | `no-trailing-punctuation-in-heading` | ready     | Headings should not end with punctuation.                                               |
-| [MDS018](MDS018-no-emphasis-as-heading/README.md)             | `no-emphasis-as-heading`             | ready     | Don't use bold or emphasis on a standalone line as a heading substitute.                |
-| [MDS019](MDS019-catalog/README.md)                            | `catalog`                            | ready     | Catalog content must reflect selected front matter fields from files matching its glob. |
-| [MDS020](MDS020-required-structure/README.md)                 | `required-structure`                 | ready     | Document structure and front matter must match its schema.                              |
-| [MDS021](MDS021-include/README.md)                            | `include`                            | ready     | Include section content must match the referenced file.                                 |
-| [MDS022](MDS022-max-file-length/README.md)                    | `max-file-length`                    | ready     | File must not exceed maximum number of lines.                                           |
-| [MDS023](MDS023-paragraph-readability/README.md)              | `paragraph-readability`              | ready     | Paragraph readability index must not exceed a threshold.                                |
-| [MDS024](MDS024-paragraph-structure/README.md)                | `paragraph-structure`                | ready     | Paragraphs must not exceed sentence and word limits.                                    |
-| [MDS025](MDS025-table-format/README.md)                       | `table-format`                       | ready     | Tables must have consistent column widths and padding.                                  |
-| [MDS026](MDS026-table-readability/README.md)                  | `table-readability`                  | ready     | Tables must stay within readability complexity limits.                                  |
-| [MDS027](MDS027-cross-file-reference-integrity/README.md)     | `cross-file-reference-integrity`     | ready     | Links to local files and heading anchors must resolve.                                  |
-| [MDS028](MDS028-token-budget/README.md)                       | `token-budget`                       | ready     | File must not exceed a token budget.                                                    |
-| [MDS029](MDS029-conciseness-scoring/README.md)                | `conciseness-scoring`                | not-ready | Paragraph conciseness score must not fall below a threshold.                            |
-| [MDS030](MDS030-empty-section-body/README.md)                 | `empty-section-body`                 | ready     | Section headings must include meaningful body content.                                  |
-| [MDS031](MDS031-unclosed-code-block/README.md)                | `unclosed-code-block`                | ready     | Fenced code blocks must have a closing fence delimiter.                                 |
-| [MDS032](MDS032-no-empty-alt-text/README.md)                  | `no-empty-alt-text`                  | ready     | Images must have non-empty alt text for accessibility.                                  |
-| [MDS033](MDS033-directory-structure/README.md)                | `directory-structure`                | ready     | Markdown files must exist only in explicitly allowed directories.                       |
-| [MDS036](MDS036-max-section-length/README.md)                 | `max-section-length`                 | ready     | Section length must not exceed per-level or per-heading limits.                         |
+| Rule                                                          | Name                                 | Status    | Description                                                                                   |
+|---------------------------------------------------------------|--------------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| [MDS001](MDS001-line-length/README.md)                        | `line-length`                        | ready     | Line exceeds maximum length.                                                                  |
+| [MDS002](MDS002-heading-style/README.md)                      | `heading-style`                      | ready     | Heading style must be consistent.                                                             |
+| [MDS003](MDS003-heading-increment/README.md)                  | `heading-increment`                  | ready     | Heading levels should increment by one. No jumping from `#` to `###`.                         |
+| [MDS004](MDS004-first-line-heading/README.md)                 | `first-line-heading`                 | ready     | First line of the file should be a heading.                                                   |
+| [MDS005](MDS005-no-duplicate-headings/README.md)              | `no-duplicate-headings`              | ready     | No two headings should have the same text.                                                    |
+| [MDS006](MDS006-no-trailing-spaces/README.md)                 | `no-trailing-spaces`                 | ready     | No trailing whitespace at the end of lines.                                                   |
+| [MDS007](MDS007-no-hard-tabs/README.md)                       | `no-hard-tabs`                       | ready     | No tab characters. Use spaces instead.                                                        |
+| [MDS008](MDS008-no-multiple-blanks/README.md)                 | `no-multiple-blanks`                 | ready     | No more than one consecutive blank line.                                                      |
+| [MDS009](MDS009-single-trailing-newline/README.md)            | `single-trailing-newline`            | ready     | File must end with exactly one newline character.                                             |
+| [MDS010](MDS010-fenced-code-style/README.md)                  | `fenced-code-style`                  | ready     | Fenced code blocks must use a consistent delimiter.                                           |
+| [MDS011](MDS011-fenced-code-language/README.md)               | `fenced-code-language`               | ready     | Fenced code blocks must specify a language.                                                   |
+| [MDS012](MDS012-no-bare-urls/README.md)                       | `no-bare-urls`                       | ready     | URLs must be wrapped in angle brackets or as a link, not left bare.                           |
+| [MDS013](MDS013-blank-line-around-headings/README.md)         | `blank-line-around-headings`         | ready     | Headings must have a blank line before and after.                                             |
+| [MDS014](MDS014-blank-line-around-lists/README.md)            | `blank-line-around-lists`            | ready     | Lists must have a blank line before and after.                                                |
+| [MDS015](MDS015-blank-line-around-fenced-code/README.md)      | `blank-line-around-fenced-code`      | ready     | Fenced code blocks must have a blank line before and after.                                   |
+| [MDS016](MDS016-list-indent/README.md)                        | `list-indent`                        | ready     | List items must use consistent indentation.                                                   |
+| [MDS017](MDS017-no-trailing-punctuation-in-heading/README.md) | `no-trailing-punctuation-in-heading` | ready     | Headings should not end with punctuation.                                                     |
+| [MDS018](MDS018-no-emphasis-as-heading/README.md)             | `no-emphasis-as-heading`             | ready     | Don't use bold or emphasis on a standalone line as a heading substitute.                      |
+| [MDS019](MDS019-catalog/README.md)                            | `catalog`                            | ready     | Catalog content must reflect selected front matter fields from files matching its glob.       |
+| [MDS020](MDS020-required-structure/README.md)                 | `required-structure`                 | ready     | Document structure and front matter must match its schema.                                    |
+| [MDS021](MDS021-include/README.md)                            | `include`                            | ready     | Include section content must match the referenced file.                                       |
+| [MDS022](MDS022-max-file-length/README.md)                    | `max-file-length`                    | ready     | File must not exceed maximum number of lines.                                                 |
+| [MDS023](MDS023-paragraph-readability/README.md)              | `paragraph-readability`              | ready     | Paragraph readability index must not exceed a threshold.                                      |
+| [MDS024](MDS024-paragraph-structure/README.md)                | `paragraph-structure`                | ready     | Paragraphs must not exceed sentence and word limits.                                          |
+| [MDS025](MDS025-table-format/README.md)                       | `table-format`                       | ready     | Tables must have consistent column widths and padding.                                        |
+| [MDS026](MDS026-table-readability/README.md)                  | `table-readability`                  | ready     | Tables must stay within readability complexity limits.                                        |
+| [MDS027](MDS027-cross-file-reference-integrity/README.md)     | `cross-file-reference-integrity`     | ready     | Links to local files and heading anchors must resolve.                                        |
+| [MDS028](MDS028-token-budget/README.md)                       | `token-budget`                       | ready     | File must not exceed a token budget.                                                          |
+| [MDS029](MDS029-conciseness-scoring/README.md)                | `conciseness-scoring`                | not-ready | Paragraph conciseness score must not fall below a threshold.                                  |
+| [MDS030](MDS030-empty-section-body/README.md)                 | `empty-section-body`                 | ready     | Section headings must include meaningful body content.                                        |
+| [MDS031](MDS031-unclosed-code-block/README.md)                | `unclosed-code-block`                | ready     | Fenced code blocks must have a closing fence delimiter.                                       |
+| [MDS032](MDS032-no-empty-alt-text/README.md)                  | `no-empty-alt-text`                  | ready     | Images must have non-empty alt text for accessibility.                                        |
+| [MDS033](MDS033-directory-structure/README.md)                | `directory-structure`                | ready     | Markdown files must exist only in explicitly allowed directories.                             |
+| [MDS035](MDS035-toc-directive/README.md)                      | `toc-directive`                      | ready     | Flag renderer-specific TOC directives that render as literal text on CommonMark and goldmark. |
+| [MDS036](MDS036-max-section-length/README.md)                 | `max-section-length`                 | ready     | Section length must not exceed per-level or per-heading limits.                               |
 <?/catalog?>

--- a/internal/rules/tocdirective/rule.go
+++ b/internal/rules/tocdirective/rule.go
@@ -1,0 +1,138 @@
+// Package tocdirective implements MDS035, which flags renderer-specific
+// table-of-contents directives that render as literal text on CommonMark
+// and goldmark.
+package tocdirective
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+func init() {
+	rule.Register(&Rule{})
+}
+
+// tocVariant pairs a line-level detection regex with the exact directive
+// token echoed back in diagnostics.
+type tocVariant struct {
+	pattern *regexp.Regexp
+	token   string
+	// isLinkRefCandidate marks `[TOC]`, which is syntactically a valid
+	// CommonMark shortcut reference link and must be suppressed when a
+	// matching link reference definition exists.
+	isLinkRefCandidate bool
+}
+
+// variants lists the four renderer-specific TOC directives detected by the
+// rule. The regex anchors ensure each directive occupies the entire line
+// (trailing whitespace allowed); anything else on the line rules it out.
+var variants = []tocVariant{
+	{pattern: regexp.MustCompile(`^\[TOC\][ \t]*$`), token: "[TOC]", isLinkRefCandidate: true},
+	{pattern: regexp.MustCompile(`^\[\[_TOC_\]\][ \t]*$`), token: "[[_TOC_]]"},
+	{pattern: regexp.MustCompile(`^\[\[toc\]\][ \t]*$`), token: "[[toc]]"},
+	{pattern: regexp.MustCompile(`^\$\{toc\}[ \t]*$`), token: "${toc}"},
+}
+
+// Rule detects renderer-specific TOC directives.
+type Rule struct{}
+
+// ID implements rule.Rule.
+func (r *Rule) ID() string { return "MDS035" }
+
+// Name implements rule.Rule.
+func (r *Rule) Name() string { return "toc-directive" }
+
+// Category implements rule.Rule.
+func (r *Rule) Category() string { return "meta" }
+
+// EnabledByDefault implements rule.Defaultable.
+func (r *Rule) EnabledByDefault() bool { return false }
+
+// Check implements rule.Rule.
+func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	if f == nil || f.AST == nil {
+		return nil
+	}
+
+	hasTOCRef := hasTOCLinkReference(f.Source)
+
+	var diags []lint.Diagnostic
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		para, ok := n.(*ast.Paragraph)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		lines := para.Lines()
+		for i := 0; i < lines.Len(); i++ {
+			seg := lines.At(i)
+			lineText := strings.TrimRight(
+				string(seg.Value(f.Source)), "\r\n",
+			)
+			v, matched := matchVariant(lineText)
+			if !matched {
+				continue
+			}
+			if v.isLinkRefCandidate && hasTOCRef {
+				continue
+			}
+			diags = append(diags, lint.Diagnostic{
+				File:     f.Path,
+				Line:     f.LineOfOffset(seg.Start),
+				Column:   1,
+				RuleID:   r.ID(),
+				RuleName: r.Name(),
+				Severity: lint.Warning,
+				Message:  buildMessage(v.token),
+			})
+		}
+		return ast.WalkContinue, nil
+	})
+	return diags
+}
+
+func matchVariant(line string) (tocVariant, bool) {
+	for _, v := range variants {
+		if v.pattern.MatchString(line) {
+			return v, true
+		}
+	}
+	return tocVariant{}, false
+}
+
+func buildMessage(token string) string {
+	return fmt.Sprintf(
+		"unsupported TOC directive `%s`; "+
+			"mdsmith has no heading TOC equivalent; "+
+			"use `<?catalog?>` for file indexes (MDS019)",
+		token,
+	)
+}
+
+// hasTOCLinkReference returns true when the document defines a link
+// reference with label "TOC" (CommonMark-normalized). Re-parsing is the
+// simplest way to delegate label normalization and code-block scoping to
+// goldmark itself, rather than approximating them with a source-level
+// scan.
+func hasTOCLinkReference(source []byte) bool {
+	if len(source) == 0 {
+		return false
+	}
+	md := goldmark.New()
+	ctx := parser.NewContext()
+	md.Parser().Parse(text.NewReader(source), parser.WithContext(ctx))
+	_, ok := ctx.Reference("toc")
+	return ok
+}
+
+var _ rule.Defaultable = (*Rule)(nil)

--- a/internal/rules/tocdirective/rule.go
+++ b/internal/rules/tocdirective/rule.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
-	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
@@ -120,17 +119,17 @@ func buildMessage(token string) string {
 }
 
 // hasTOCLinkReference returns true when the document defines a link
-// reference with label "TOC" (CommonMark-normalized). Re-parsing is the
-// simplest way to delegate label normalization and code-block scoping to
-// goldmark itself, rather than approximating them with a source-level
-// scan.
+// reference with label "TOC" (CommonMark-normalized). It re-parses with
+// lint.NewParser so the parser configuration (including mdsmith's PI
+// block parser) matches the original lint parse; otherwise content
+// absorbed into a processing-instruction block could register as a link
+// reference here while being hidden from the rule's AST walk.
 func hasTOCLinkReference(source []byte) bool {
 	if len(source) == 0 {
 		return false
 	}
-	md := goldmark.New()
 	ctx := parser.NewContext()
-	md.Parser().Parse(text.NewReader(source), parser.WithContext(ctx))
+	lint.NewParser().Parse(text.NewReader(source), parser.WithContext(ctx))
 	_, ok := ctx.Reference("toc")
 	return ok
 }

--- a/internal/rules/tocdirective/rule_test.go
+++ b/internal/rules/tocdirective/rule_test.go
@@ -1,0 +1,186 @@
+package tocdirective
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestID(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "MDS035", r.ID())
+}
+
+func TestName(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "toc-directive", r.Name())
+}
+
+func TestCategory(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "meta", r.Category())
+}
+
+func TestEnabledByDefault_OptIn(t *testing.T) {
+	var r rule.Defaultable = &Rule{}
+	assert.False(t, r.EnabledByDefault(),
+		"MDS035 must be opt-in (disabled by default)")
+}
+
+func TestCheck_BracketedTOC(t *testing.T) {
+	src := []byte("# Title\n\n[TOC]\n\nContent.\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "MDS035", diags[0].RuleID)
+	assert.Equal(t, lint.Warning, diags[0].Severity)
+	assert.Equal(t, 3, diags[0].Line)
+	assert.Contains(t, diags[0].Message, "`[TOC]`")
+	assert.Contains(t, diags[0].Message, "<?catalog?>")
+	assert.Contains(t, diags[0].Message, "MDS019")
+}
+
+func TestCheck_GitLabTOC(t *testing.T) {
+	src := []byte("# Title\n\n[[_TOC_]]\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "`[[_TOC_]]`")
+	assert.Equal(t, 3, diags[0].Line)
+}
+
+func TestCheck_MarkdownItTOC(t *testing.T) {
+	src := []byte("# Title\n\n[[toc]]\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "`[[toc]]`")
+	assert.Equal(t, 3, diags[0].Line)
+}
+
+func TestCheck_VitepressDollarTOC(t *testing.T) {
+	src := []byte("# Title\n\n${toc}\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "`${toc}`")
+	assert.Equal(t, 3, diags[0].Line)
+}
+
+func TestCheck_TOCInsideFencedCodeBlock_NoDiagnostic(t *testing.T) {
+	src := []byte("# Title\n\n```\n[TOC]\n[[_TOC_]]\n[[toc]]\n${toc}\n```\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_TOCInsideIndentedCodeBlock_NoDiagnostic(t *testing.T) {
+	src := []byte("# Title\n\n    [TOC]\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_TOCInsideInlineCodeSpan_NoDiagnostic(t *testing.T) {
+	src := []byte("# Title\n\nUse `[TOC]` for TOC.\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_TOCWithLinkRefDefinition_NoDiagnostic(t *testing.T) {
+	// [TOC] resolves to https://example.com via the link reference
+	// definition, so it is a legitimate link and must not be flagged.
+	src := []byte("# Title\n\n[TOC]: https://example.com\n\n[TOC]\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_TOCWithLowercaseLinkRefDefinition_NoDiagnostic(t *testing.T) {
+	// Label match is case-insensitive per CommonMark: `[TOC]` matches
+	// `[toc]: ...`.
+	src := []byte("# Title\n\n[toc]: https://example.com\n\n[TOC]\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_OtherVariantsWithTOCLinkRef_StillFlagged(t *testing.T) {
+	// The link-ref suppression applies only to the `[TOC]` pattern; the
+	// other three tokens cannot be valid CommonMark references.
+	src := []byte("# Title\n\n[TOC]: https://example.com\n\n[[_TOC_]]\n\n[[toc]]\n\n${toc}\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 3)
+	assert.Contains(t, diags[0].Message, "`[[_TOC_]]`")
+	assert.Contains(t, diags[1].Message, "`[[toc]]`")
+	assert.Contains(t, diags[2].Message, "`${toc}`")
+}
+
+func TestCheck_TOCWithTrailingWhitespace(t *testing.T) {
+	src := []byte("# Title\n\n[TOC]   \n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Equal(t, 3, diags[0].Line)
+}
+
+func TestCheck_TOCNotOnOwnLine_NoDiagnostic(t *testing.T) {
+	// `[TOC]` embedded in prose should not be flagged; the rule targets
+	// the directive-on-its-own-line usage.
+	src := []byte("# Title\n\nSee the [TOC] above for details.\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_NoTOCTokens_NoDiagnostic(t *testing.T) {
+	src := []byte("# Title\n\nJust some paragraph text.\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_EmptyFile(t *testing.T) {
+	f, err := lint.NewFile("t.md", nil)
+	require.NoError(t, err)
+	assert.Empty(t, (&Rule{}).Check(f))
+}
+
+func TestCheck_NoFix(t *testing.T) {
+	// The rule is detection-only and must not implement FixableRule.
+	var r any = &Rule{}
+	_, ok := r.(rule.FixableRule)
+	assert.False(t, ok, "MDS035 must be detection-only (no Fix)")
+}

--- a/plan/88_toc-directive-migration.md
+++ b/plan/88_toc-directive-migration.md
@@ -1,7 +1,7 @@
 ---
 id: 88
 title: TOC directive migration aid
-status: "🔲"
+status: "✅"
 summary: >-
   New rule MDS035 that flags renderer-specific
   table-of-contents directives (`[TOC]`,
@@ -197,47 +197,48 @@ alone.
 
 ## Tasks
 
-1. Create `internal/rules/MDS035-toc-directive/`
-   with `rule.go`, `README.md`
-2. Implement paragraph-scoped line scanning for
-   the four directive patterns
-3. For the `[TOC]` pattern, consult the goldmark
-   parser context's link reference definition
-   map; suppress the diagnostic when a label
-   `TOC` (case-insensitive) is defined
-4. Implement `rule.Defaultable` with
+1. [x] Create `internal/rules/MDS035-toc-directive/`
+   with `README.md`, and the implementation in
+   `internal/rules/tocdirective/rule.go`
+2. [x] Implement paragraph-scoped line scanning
+   for the four directive patterns
+3. [x] For the `[TOC]` pattern, consult the
+   goldmark parser context's link reference
+   definition map; suppress the diagnostic when
+   a label `TOC` (case-insensitive) is defined
+4. [x] Implement `rule.Defaultable` with
    `EnabledByDefault` returning `false`
-5. Register as MDS035 in category `meta`
-6. Add good/bad fixtures with front-matter
+5. [x] Register as MDS035 in category `meta`
+6. [x] Add good/bad fixtures with front-matter
    specifying the expected diagnostics, including
-   a good fixture that has `[TOC]: https://x` as
-   a reference definition alongside a `[TOC]`
+   a good fixture that has `[TOC]: https://x`
+   as a reference definition alongside a `[TOC]`
    line
-7. Document the rule in the flavor comparison
-   table in
+7. [x] Document the rule in the renderer
+   portability section in
    [docs/background/markdown-linters.md](../docs/background/markdown-linters.md)
 
 ## Acceptance Criteria
 
-- [ ] `[TOC]` on its own line produces a
+- [x] `[TOC]` on its own line produces a
       diagnostic that names both the heading-TOC
       gap and the `<?catalog?>` file-index
       alternative
-- [ ] `[[_TOC_]]` on its own line produces the
+- [x] `[[_TOC_]]` on its own line produces the
       same diagnostic
-- [ ] `[[toc]]` on its own line produces the
+- [x] `[[toc]]` on its own line produces the
       same diagnostic
-- [ ] `${toc}` on its own line produces the
+- [x] `${toc}` on its own line produces the
       same diagnostic
-- [ ] `[TOC]` inside a fenced code block
+- [x] `[TOC]` inside a fenced code block
       produces no diagnostic
-- [ ] `[TOC]` inside an inline code span
+- [x] `[TOC]` inside an inline code span
       produces no diagnostic
-- [ ] `[TOC]` used as legitimate link text
+- [x] `[TOC]` used as legitimate link text
       (with a matching `[TOC]: url` definition)
       produces no diagnostic
-- [ ] Rule is disabled by default (opt-in)
-- [ ] No auto-fix is applied
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] Rule is disabled by default (opt-in)
+- [x] No auto-fix is applied
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues


### PR DESCRIPTION
## Summary

Implements MDS035 (toc-directive), a new opt-in linting rule that detects renderer-specific table-of-contents directives that render as literal text in CommonMark and goldmark.

## Key Changes

- **New rule implementation** (`internal/rules/tocdirective/rule.go`):
  - Detects four TOC directive variants: `[TOC]`, `[[_TOC_]]`, `[[toc]]`, and `${toc}`
  - Scans paragraphs line-by-line using regex patterns to identify directives on their own line
  - Suppresses `[TOC]` diagnostics when a matching link reference definition exists (case-insensitive per CommonMark)
  - Properly ignores directives inside code blocks and inline code spans via AST walking
  - Registered as MDS035 in the `meta` category, disabled by default (opt-in)

- **Comprehensive test suite** (`internal/rules/tocdirective/rule_test.go`):
  - Tests all four directive variants
  - Validates suppression of directives in code blocks (fenced and indented)
  - Validates suppression of directives in inline code spans
  - Tests link reference definition matching (case-insensitive)
  - Confirms rule is detection-only (no auto-fix)

- **Documentation and fixtures**:
  - Rule documentation in `internal/rules/MDS035-toc-directive/README.md` with rationale for detection-only approach
  - Good fixture showing directives in code blocks and inline code (no diagnostics)
  - Good fixture demonstrating `[TOC]` as legitimate link via reference definition
  - Bad fixtures for each of the four directive variants

- **Integration updates**:
  - Registered rule in test imports and main command
  - Updated plan status to complete
  - Added renderer portability section to `docs/background/markdown-linters.md`
  - Updated rule index documentation

## Implementation Details

The rule uses goldmark's parser context to check for link reference definitions, delegating label normalization and code-block scoping to the parser rather than approximating them at the source level. This ensures accurate handling of CommonMark's case-insensitive label matching and proper exclusion of definitions inside code blocks.

The diagnostic message guides users toward two alternatives: `<?catalog?>` for file-index use cases (MDS019) or manual maintenance for in-document heading TOCs.

https://claude.ai/code/session_01T569bC9ogHHf5A6Cgxn9NW