### PR TITLE
MDS036: add per-heading fixtures and correct plan 51 wording

### DIFF
--- a/internal/rules/MDS036-max-section-length/bad/per-heading.md
+++ b/internal/rules/MDS036-max-section-length/bad/per-heading.md
@@ -1,0 +1,18 @@
+---
+settings:
+  max: 0
+  per-heading:
+    - pattern: "^Changelog$"
+      max: 2
+diagnostics:
+  - line: 3
+    column: 1
+    message: 'section "## Changelog" too long (5 > 2)'
+---
+# Overview
+
+## Changelog
+
+- entry one
+- entry two
+- entry three

--- a/internal/rules/MDS036-max-section-length/good/per-heading.md
+++ b/internal/rules/MDS036-max-section-length/good/per-heading.md
@@ -1,0 +1,17 @@
+---
+settings:
+  max: 0
+  per-heading:
+    - pattern: "^Short$"
+      max: 4
+---
+# Title
+
+## Short
+
+One line.
+
+## Longer section with no matching pattern
+
+This section is longer but stays untouched because only headings
+matching `^Short$` are capped and the default `max` is zero.

--- a/plan/51_section-level-size-limits.md
+++ b/plan/51_section-level-size-limits.md
@@ -14,7 +14,7 @@ to prevent oversized headings from hiding in otherwise compliant files.
 
 1. [x] Define section boundary detection rules for heading levels.
 2. [x] Add configuration for per-heading or per-pattern limits.
-3. [x] Implement rule to count section length by lines or tokens.
+3. [x] Implement rule to count section length by lines.
 4. [x] Document configuration and examples.
 
 ## Acceptance Criteria


### PR DESCRIPTION
Follow-up to #143 addressing the last two Copilot review comments that arrived after that PR entered the merge queue.

## Summary

- Add `good/per-heading.md` and `bad/per-heading.md` fixtures so the regex-based override path is exercised end-to-end through fixture YAML decoding (not just unit tests).
- Correct plan 51 task 3 text from "by lines or tokens" to "by lines" — the implementation is line-based only.

## Test plan

- [x] `go test ./internal/integration/... ./internal/rules/maxsectionlength/...`
- [x] `go tool golangci-lint run ./...`
- [x] `go run ./cmd/mdsmith check .`