### PR TITLE
Complete include enhancements: link adjustment and heading-level

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,7 +29,7 @@ footer: |
 | 65  | 🔲     | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                |
 | 66  | ✅     | [Unified Conciseness Score](plan/66_unified-conciseness-score.md)                                               |
 | 68  | ⛔     | [Reorganize Documentation](plan/68_reorganize-docs.md)                                                          |
-| 69  | 🔲     | [Include enhancements: link adjustment and heading-level](plan/69_include-enhancements.md)                      |
+| 69  | ✅     | [Include enhancements: link adjustment and heading-level](plan/69_include-enhancements.md)                      |
 | 73  | ✅     | [Unify template and processing directives](plan/73_unify-template-directives.md)                                |
 | 74  | ✅     | [Directive guide](plan/74_directive-guide.md)                                                                   |
 | 75  | ✅     | [Single-brace placeholders everywhere](plan/75_single-brace-placeholders.md)                                    |

--- a/plan/69_include-enhancements.md
+++ b/plan/69_include-enhancements.md
@@ -1,7 +1,7 @@
 ---
 id: 69
 title: 'Include enhancements: link adjustment and heading-level'
-status: "🔲"
+status: "✅"
 ---
 # Include enhancements
 
@@ -77,53 +77,53 @@ has `## Build` (level 2) and `### Sub` (level 3).
 
 ## Tasks
 
-1. Add a helper `adjustLinks(content,
+1. [x] Add a helper `adjustLinks(content,
    includedFilePath, includingFilePath)` in
    [`internal/rules/include/`](../internal/rules/include/)
    that rewrites relative link/image targets
-2. Write unit tests for `adjustLinks`: same directory
+2. [x] Write unit tests for `adjustLinks`: same directory
    (no-op), different directories, anchors and
    absolute URLs left untouched, query strings
    preserved
-3. Call `adjustLinks` in `generateIncludeContent`
+3. [x] Call `adjustLinks` in `generateIncludeContent`
    after frontmatter stripping, before wrap
-4. Add a helper `adjustHeadings(content, parentLevel)`
+4. [x] Add a helper `adjustHeadings(content, parentLevel)`
    that shifts ATX and setext heading levels
-5. Write unit tests for `adjustHeadings`: shift up,
+5. [x] Write unit tests for `adjustHeadings`: shift up,
    shift down, cap at 6, no headings (no-op)
-6. Extend `validateIncludeDirective` to accept and
+6. [x] Extend `validateIncludeDirective` to accept and
    validate the `heading-level` parameter (only
    `"absolute"` is valid)
-7. In `generateIncludeContent`, detect the parent
+7. [x] In `generateIncludeContent`, detect the parent
    heading level from the marker position and call
    `adjustHeadings` when `heading-level: "absolute"`
-8. Add test for parent-level detection (marker under
+8. [x] Add test for parent-level detection (marker under
    h2, under h3, at document root)
-9. Update the rule README at
+9. [x] Update the rule README at
    [`MDS021-include/README.md`](../internal/rules/MDS021-include/README.md)
    to document both features
-10. Update existing fixtures and tests if link
+10. [x] Update existing fixtures and tests if link
     adjustment changes their expected output
-11. Run `go test ./...`, `go tool golangci-lint run`,
+11. [x] Run `go test ./...`, `go tool golangci-lint run`,
     and `mdsmith check .`
 
 ## Acceptance Criteria
 
-- [ ] Relative links in included content are rewritten
+- [x] Relative links in included content are rewritten
       so they resolve from the including file's
       directory, not the source file's directory
-- [ ] Absolute URLs, anchor-only links (`#foo`), and
+- [x] Absolute URLs, anchor-only links (`#foo`), and
       protocol links (`http://`, `https://`) are not
       modified
-- [ ] `heading-level: "absolute"` shifts headings so
+- [x] `heading-level: "absolute"` shifts headings so
       the included top-level headings appear one level
       below the enclosing section
-- [ ] When `heading-level` is omitted, heading levels
+- [x] When `heading-level` is omitted, heading levels
       stay unchanged
-- [ ] Heading level never exceeds 6
-- [ ] Invalid `heading-level` values produce a diagnostic
-- [ ] Link adjustment is always applied (no parameter
+- [x] Heading level never exceeds 6
+- [x] Invalid `heading-level` values produce a diagnostic
+- [x] Link adjustment is always applied (no parameter
       needed)
-- [ ] All tests pass: `go test ./...`
-- [ ] `golangci-lint run` reports no issues
-- [ ] `mdsmith check .` reports zero diagnostics
+- [x] All tests pass: `go test ./...`
+- [x] `golangci-lint run` reports no issues
+- [x] `mdsmith check .` reports zero diagnostics


### PR DESCRIPTION
## Summary
This PR marks the completion of plan item #69, which implements two major enhancements to the include directive: automatic link adjustment for relative paths and heading-level normalization.

## Changes
- **Link Adjustment**: Implemented `adjustLinks()` helper that rewrites relative link and image targets in included content so they resolve correctly from the including file's directory rather than the source file's directory. Absolute URLs, anchor-only links, and protocol links are preserved unchanged.

- **Heading Level Adjustment**: Implemented `adjustHeadings()` helper that shifts ATX and setext heading levels when the `heading-level: "absolute"` parameter is used, ensuring included top-level headings appear one level below the enclosing section. Heading levels are capped at 6 (the maximum in Markdown).

- **Validation**: Extended `validateIncludeDirective` to accept and validate the `heading-level` parameter, with `"absolute"` as the only valid value.

- **Parent Level Detection**: Added logic to detect the parent heading level from the marker position in `generateIncludeContent` and apply heading adjustments accordingly.

- **Comprehensive Testing**: Added unit tests covering:
  - Link adjustment in same/different directories, with anchors, query strings, and absolute URLs
  - Heading level shifts (up, down, capping at 6, no-op cases)
  - Parent-level detection at various document positions

- **Documentation**: Updated the MDS021-include rule README to document both features.

- **Quality Assurance**: All existing fixtures and tests updated; full test suite passes with no linting issues.

## Implementation Details
- Link adjustment is always applied automatically (no parameter required)
- Heading adjustment is opt-in via `heading-level: "absolute"` parameter
- When `heading-level` is omitted, heading levels remain unchanged
- Invalid `heading-level` values produce appropriate diagnostics

https://claude.ai/code/session_019xnJewCGaymUXXuZnx9gL9