### PR TITLE
Complete wasm-embedded-inference spike with wazero integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 eval/corpus/config.local.yml
 coverage.out
 cover.out
+/.tmp/
+docs/research/conciseness/spikes/wasm-embedded-inference/classifier.wasm
+internal/rules/concisenessscoring/wasmclassifier/classifier.wasm

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,7 +18,7 @@ footer: |
 |-----|--------|------------------------------------------------------------------------------------------------------|
 | 52  | ✅     | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
 | 61  | 🔳     | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |
-| 65  | 🔲     | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                     |
+| 65  | ✅     | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                     |
 | 78  | ✅     | [Query subcommand for front-matter filtering](plan/78_query-command.md)                              |
 | 83  | ✅     | [Security hardening batch](plan/83_security-hardening-batch.md)                                      |
 | 84  | 🔲     | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                           |

--- a/cmd/mdsmith/spike_wasm_classifier.go
+++ b/cmd/mdsmith/spike_wasm_classifier.go
@@ -1,0 +1,11 @@
+//go:build spike_wasm_classifier
+
+package main
+
+import "github.com/jeduden/mdsmith/internal/rules/concisenessscoring/wasmclassifier"
+
+func init() {
+	// Force-link the embedded wasm artifact so binary-size deltas can be
+	// measured for the wasm-embedded-inference spike.
+	_ = wasmclassifier.WasmArtifactBytes()
+}

--- a/docs/research/conciseness/spikes/wasm-embedded-inference/README.md
+++ b/docs/research/conciseness/spikes/wasm-embedded-inference/README.md
@@ -2,33 +2,213 @@
 
 ## Goal
 
-Test whether mdsmith can run weasel detection via an embedded `.wasm`
-module without runtime dynamic library dependencies.
+Evaluate a WASM-based inference path that can be embedded in mdsmith
+with no runtime dynamic library dependency. Compare it against the
+current MDS029 heuristic, the pure-Go classifier spike (plan 64),
+and the yzma embedded spike.
 
-## Why This Spike Exists
+## Environment
 
-This is a separate option from:
+- Date: 2026-04-22
+- OS: Linux 4.4.0 (amd64)
+- Go: 1.25.8
+- wazero: v1.11.0 (pure-Go runtime, wazevo optimizing compiler)
+- Harness:
+  `docs/research/conciseness/spikes/wasm-embedded-inference/run.sh`
 
-- `spikes/yzma-embedded-weasel-detection` (native dynamic libs)
-- `spikes/go-native-linear-classifier` (all-Go model code)
+## Prototype
 
-WASM may offer a middle path:
+Implementation files:
 
-- portable artifact format
-- deterministic runtime with pinned module bytes
-- stronger isolation around inference execution
+- wasm guest source:
+  `docs/research/conciseness/spikes/wasm-embedded-inference/wasm/main.go`
+- host harness:
+  `docs/research/conciseness/spikes/wasm-embedded-inference/main.go`
+- size-measurement hook:
+  `internal/rules/concisenessscoring/wasmclassifier/embed.go`
+- build-tag stub:
+  `cmd/mdsmith/spike_wasm_classifier.go`
 
-## Candidate Runtime
+The guest reuses the plan-64 classifier package verbatim
+(`internal/rules/concisenessscoring/classifier`) so the wasm-vs-native
+comparison isolates runtime cost. The guest is compiled with
+`GOOS=wasip1 GOARCH=wasm -buildmode=c-shared`, which produces a WASI
+reactor module exposing:
 
-Initial candidate: `wazero` (pure-Go WebAssembly runtime).
+- `alloc(size int32) int32` — reserve guest memory for host input
+- `free(ptr int32)` — release a prior alloc
+- `classify(ptr, len int32) int64` — returns `(outPtr<<32)|outLen`
+  pointing at a JSON result in a static guest buffer
 
-## Evaluation Focus
+The host calls `_initialize` once, then calls `alloc`, writes the
+input text into guest linear memory, calls `classify`, and reads the
+JSON result. `wazero.NewRuntime` uses its default optimizing compiler
+(wazevo) on linux/amd64.
 
-1. cold start and warm latency
-2. memory overhead under repeated calls
-3. binary-size cost of embedded `.wasm`
-4. determinism and fallback behavior
+## Module Loading Strategy
 
-## Next Step
+- wazero runtime is created with default config
+  (`wazero.NewRuntimeConfig().WithCloseOnContextDone(true)`).
+- WASI preview 1 is registered via
+  `wasi_snapshot_preview1.Instantiate`.
+- Module is instantiated with `WithStartFunctions()` (empty) so wazero
+  does not auto-run `_start`; the host then calls `_initialize`
+  explicitly, matching reactor-module semantics.
+- One module instance is reused for all calls. Re-instantiating per
+  call would pay the `~1.7 s` compile cost again.
 
-Execute `plan/65_spike-wasm-embedded-inference.md`.
+## Determinism
+
+- In-process repeats (`determinism-runs=5`): `unique_hashes=1`.
+- Process-restart repeats (5 independent runs): `unique_hashes=1`.
+- Digest:
+  `7a1dc229f814d75c3969317ceddbade75c4d5ab4e0f133da98c1dbb917381620`.
+
+Result: deterministic outputs were confirmed across repeat runs and
+restarts.
+
+## Latency and Memory
+
+Measured with `ROUNDS=4000` (`24,000` requests total):
+
+| Metric                 | Value       |
+|------------------------|-------------|
+| Guest load (compile)   | 1699.40 ms  |
+| Requests               | 24,000      |
+| Avg latency            | 2022.38 us  |
+| P50 latency            | 1952.17 us  |
+| P95 latency            | 2464.15 us  |
+| Max latency            | 12915.37 us |
+| RSS after load         | 136,616 KB  |
+| RSS after bench        | 109,152 KB  |
+| Heap alloc after bench | 21,483 KB   |
+| Heap sys after bench   | 84,832 KB   |
+| Total alloc delta      | 40,812 KB   |
+
+Per-sample risk scores (same inputs, same model as plan 64):
+
+- `weasel-01`: 0.9743
+- `weasel-02`: 0.6186
+- `weasel-03`: 0.8545
+- `direct-01`: 0.1893
+- `direct-02`: 0.1073
+- `direct-03`: 0.3308
+
+The embedded threshold for this spike artifact is `0.20`. Classifier
+weights are `cue-linear-v2` (current head), which is why these scores
+differ from the plan-64 snapshot; the same weights in the go-native
+harness produce identical scores.
+
+## Binary-Size Impact
+
+Measured by building `cmd/mdsmith` with and without the
+`spike_wasm_classifier` tag:
+
+- base mdsmith: 27,817,743 bytes
+- mdsmith with embedded wasm classifier: 31,992,461 bytes
+- delta: 4,174,718 bytes (~4.17 MB)
+- wasm artifact alone: 3,993,759 bytes (~3.99 MB)
+
+The ~181 KB gap between the artifact bytes and the binary delta is
+the linked wazero runtime plus `wasi_snapshot_preview1` import. The
+wasm artifact is Go's own runtime + classifier package compiled for
+`wasip1`, which accounts for nearly all of the 3.99 MB; the classifier
+logic is a small fraction of that.
+
+## Cross-Spike Comparison
+
+All four paths score the same corpus with the same linear weights
+(except MDS029, which has its own heuristic):
+
+| Path                | Avg latency | Startup  | RSS bench  | Binary delta |
+|---------------------|-------------|----------|------------|--------------|
+| MDS029 heuristic    | n/a (no ML) | 0        | baseline   | 0 B          |
+| go-native (plan 64) | 3.38 us     | 0.28 ms  | 7,776 KB   | 480 B        |
+| wasm + wazero       | 2,022.38 us | 1,699 ms | 109,152 KB | 4,174,718 B  |
+| yzma embedded       | 51,670 us   | 199.61ms | 84,480 KB  | 524,288 B +  |
+
+yzma also requires an 86 MB dynamic library bundle at runtime plus an
+84 MB GGUF model on disk. The wasm path ships everything in-process
+with no external files and no dynamic library dependency.
+
+## Artifact Update Workflow
+
+Safe wasm-artifact update path:
+
+1. Update classifier source
+   (`internal/rules/concisenessscoring/classifier/*.go` or
+   `data/cue-linear.json`).
+2. Run
+   `docs/research/conciseness/spikes/wasm-embedded-inference/run.sh`.
+   The script recompiles the wasm guest and refreshes both the
+   harness-local copy and
+   `internal/rules/concisenessscoring/wasmclassifier/classifier.wasm`.
+3. Record the new `wasm_artifact_sha256` and `wasm_artifact_bytes`
+   lines from `bench.txt`.
+4. Pin the new SHA256 into a `const` next to the `//go:embed`
+   directive in a future production integration (mirroring
+   `classifier.EmbeddedArtifactSHA256`).
+5. Run the spike harness to confirm the `determinism_digest` is
+   stable across five process restarts before shipping.
+
+Integrity checks:
+
+- SHA256 pin on the embedded wasm bytes prevents silent substitution.
+- wazero itself validates the WebAssembly module on instantiate; a
+  corrupt artifact fails loud at startup.
+- Version pinning: the classifier artifact inside the wasm retains
+  its own `model_id`/`version` (echoed as `cue-linear-v2` /
+  `2026-04-05` in the harness output), so drift between host and
+  guest is observable at runtime.
+
+## Fallback Boundaries
+
+Recommended fallback rules if the wasm path were adopted:
+
+1. Compile-time guard with a `wasm_classifier` build tag so
+   non-wasm-capable builds omit the 4 MB artifact and the wazero
+   dependency entirely.
+2. Runtime: instantiate the module once at MDS029 first use. On
+   failure (checksum mismatch, wasm validation error, wazero compile
+   error), fall back to the heuristic path and emit a verbose
+   diagnostic counting the event.
+3. Per-call: wrap `classify` with a bounded `context.WithTimeout`
+   (suggested 50 ms, well above the 2,464 us p95 observed here). On
+   timeout or error, treat as a classifier failure and fall back to
+   heuristic for that paragraph.
+4. Surface backend selection in `--verbose` output only; keep the
+   default diagnostic schema identical to the go-native backend so
+   rule output is indistinguishable end-to-end.
+
+## Recommendation
+
+Reject this path for mdsmith at the current classifier size.
+
+Rationale:
+
+- The pure-Go classifier (plan 64) already delivers the same
+  deterministic output with a 480 B binary cost, 3 us avg latency,
+  and 7.8 MB RSS. Wasm adds no capability the Go path lacks.
+- The wasm path is ~600x slower per call, uses ~14x the RSS, and
+  grows the binary by ~4.17 MB. Most of that cost is the wasip1
+  runtime embedded in the guest artifact, not the classifier.
+- The 1.7 s wazero compile on first use would regress cold-start
+  time for short `mdsmith check` invocations.
+- WASI reactor support still requires `-buildmode=c-shared`, a
+  `_initialize` call, and module-side pinning tricks; this is
+  tractable but adds moving parts with no offsetting benefit here.
+
+When wasm would become interesting:
+
+- If the classifier were authored in Rust or another language and we
+  wanted polyglot reuse without FFI.
+- If classifier weights/topology had to be hot-swappable at runtime
+  in a sandboxed way (wazero provides memory isolation that plain-Go
+  embeds do not).
+- If the model grew large enough that the 4 MB wasip1 runtime cost
+  became negligible relative to weight bytes.
+
+Gate for future revisit: reopen this path only if a future classifier
+from plan 58 (a) is not practically authorable in pure Go, or (b)
+requires the sandbox isolation wazero provides. Otherwise keep the
+pure-Go classifier as the CPU fallback for MDS029.

--- a/docs/research/conciseness/spikes/wasm-embedded-inference/main.go
+++ b/docs/research/conciseness/spikes/wasm-embedded-inference/main.go
@@ -98,27 +98,34 @@ func (g *guestHandle) Close() error {
 
 func (g *guestHandle) Classify(text string) (classifyResult, error) {
 	input := []byte(text)
-	allocRet, err := g.alloc.Call(g.ctx, uint64(len(input)))
-	if err != nil {
-		return classifyResult{}, fmt.Errorf("alloc: %w", err)
-	}
-	ptr := uint32(allocRet[0])
-	if ptr == 0 {
-		return classifyResult{}, errors.New("alloc returned null ptr")
-	}
-	defer func() { _, _ = g.free.Call(g.ctx, uint64(ptr)) }()
+	var ptr uint32
 
-	if !g.memory.Write(ptr, input) {
-		return classifyResult{}, errors.New("memory.Write failed")
+	if len(input) > 0 {
+		allocRet, err := g.alloc.Call(g.ctx, uint64(len(input)))
+		if err != nil {
+			return classifyResult{}, fmt.Errorf("alloc: %w", err)
+		}
+		ptr = uint32(allocRet[0])
+		if ptr == 0 {
+			return classifyResult{}, errors.New("alloc returned null ptr")
+		}
+		defer func() { _, _ = g.free.Call(g.ctx, uint64(ptr)) }()
+
+		if !g.memory.Write(ptr, input) {
+			return classifyResult{}, errors.New("memory.Write failed")
+		}
 	}
 
 	ret, err := g.classify.Call(g.ctx, uint64(ptr), uint64(len(input)))
 	if err != nil {
 		return classifyResult{}, fmt.Errorf("classify: %w", err)
 	}
-	packed := ret[0]
-	outPtr := uint32(packed >> 32)
-	outLen := uint32(packed & 0xFFFFFFFF)
+	packed := int64(ret[0])
+	if packed < 0 {
+		return classifyResult{}, errors.New("guest signaled output truncation")
+	}
+	outPtr := uint32(uint64(packed) >> 32)
+	outLen := uint32(uint64(packed) & 0xFFFFFFFF)
 	raw, ok := g.memory.Read(outPtr, outLen)
 	if !ok {
 		return classifyResult{}, errors.New("memory.Read failed")

--- a/docs/research/conciseness/spikes/wasm-embedded-inference/main.go
+++ b/docs/research/conciseness/spikes/wasm-embedded-inference/main.go
@@ -1,0 +1,424 @@
+//go:build ignore
+
+// Command wasm-spike is the host harness for the wasm-embedded-inference
+// spike. It embeds the wasm classifier artifact via go:embed, hosts it
+// with wazero, and measures determinism + latency + memory on the same
+// six-sample corpus the yzma and go-native spikes used.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+)
+
+// Embedded wasm artifact produced by the wasm/ subdirectory. run.sh
+// compiles wasm/main.go with GOOS=wasip1 GOARCH=wasm and copies the
+// result here before building this harness.
+//
+//go:embed classifier.wasm
+var wasmArtifact []byte
+
+type sample struct {
+	ID   string
+	Text string
+}
+
+var corpus = []sample{
+	{
+		ID:   "weasel-01",
+		Text: "This approach may potentially improve outcomes in many situations.",
+	},
+	{
+		ID:   "direct-01",
+		Text: "Run go test ./... before submitting the pull request.",
+	},
+	{
+		ID:   "weasel-02",
+		Text: "It seems the API is kind of unreliable under heavy load.",
+	},
+	{
+		ID:   "direct-02",
+		Text: "Set timeout to 2s and retry once on HTTP 503.",
+	},
+	{
+		ID:   "weasel-03",
+		Text: "You might want to consider adding additional validation checks.",
+	},
+	{
+		ID:   "direct-03",
+		Text: "The parser accepts front matter and heading sections.",
+	},
+}
+
+type runConfig struct {
+	mode            string
+	rounds          int
+	determinismRuns int
+}
+
+type classifyResult struct {
+	Label     string  `json:"label"`
+	RiskScore float64 `json:"risk_score"`
+	Threshold float64 `json:"threshold"`
+	ModelID   string  `json:"model_id"`
+	Version   string  `json:"version"`
+	Cues      string  `json:"cues"`
+}
+
+type guestHandle struct {
+	ctx      context.Context
+	runtime  wazero.Runtime
+	module   api.Module
+	alloc    api.Function
+	free     api.Function
+	classify api.Function
+	memory   api.Memory
+}
+
+func (g *guestHandle) Close() error {
+	return g.runtime.Close(g.ctx)
+}
+
+func (g *guestHandle) Classify(text string) (classifyResult, error) {
+	input := []byte(text)
+	allocRet, err := g.alloc.Call(g.ctx, uint64(len(input)))
+	if err != nil {
+		return classifyResult{}, fmt.Errorf("alloc: %w", err)
+	}
+	ptr := uint32(allocRet[0])
+	if ptr == 0 {
+		return classifyResult{}, errors.New("alloc returned null ptr")
+	}
+	defer func() { _, _ = g.free.Call(g.ctx, uint64(ptr)) }()
+
+	if !g.memory.Write(ptr, input) {
+		return classifyResult{}, errors.New("memory.Write failed")
+	}
+
+	ret, err := g.classify.Call(g.ctx, uint64(ptr), uint64(len(input)))
+	if err != nil {
+		return classifyResult{}, fmt.Errorf("classify: %w", err)
+	}
+	packed := ret[0]
+	outPtr := uint32(packed >> 32)
+	outLen := uint32(packed & 0xFFFFFFFF)
+	raw, ok := g.memory.Read(outPtr, outLen)
+	if !ok {
+		return classifyResult{}, errors.New("memory.Read failed")
+	}
+	buf := make([]byte, len(raw))
+	copy(buf, raw)
+
+	var result classifyResult
+	if err := json.Unmarshal(buf, &result); err != nil {
+		return classifyResult{}, fmt.Errorf("decode result: %w", err)
+	}
+	return result, nil
+}
+
+func newGuest(ctx context.Context) (*guestHandle, error) {
+	r := wazero.NewRuntimeWithConfig(
+		ctx,
+		wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
+	)
+	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
+		_ = r.Close(ctx)
+		return nil, fmt.Errorf("wasi instantiate: %w", err)
+	}
+	cfg := wazero.NewModuleConfig().
+		WithStdout(os.Stderr).
+		WithStderr(os.Stderr).
+		WithStartFunctions(). // reactor: do not auto-run _start
+		WithArgs("classifier-wasm")
+	mod, err := r.InstantiateWithConfig(ctx, wasmArtifact, cfg)
+	if err != nil {
+		_ = r.Close(ctx)
+		return nil, fmt.Errorf("instantiate module: %w", err)
+	}
+	if initFn := mod.ExportedFunction("_initialize"); initFn != nil {
+		if _, err := initFn.Call(ctx); err != nil {
+			_ = r.Close(ctx)
+			return nil, fmt.Errorf("_initialize: %w", err)
+		}
+	}
+	g := &guestHandle{
+		ctx:      ctx,
+		runtime:  r,
+		module:   mod,
+		alloc:    mod.ExportedFunction("alloc"),
+		free:     mod.ExportedFunction("free"),
+		classify: mod.ExportedFunction("classify"),
+		memory:   mod.Memory(),
+	}
+	if g.alloc == nil || g.free == nil || g.classify == nil {
+		_ = r.Close(ctx)
+		return nil, errors.New("missing exported function on wasm module")
+	}
+	if g.memory == nil {
+		_ = r.Close(ctx)
+		return nil, errors.New("wasm module has no exported memory")
+	}
+	return g, nil
+}
+
+func main() {
+	cfg, err := parseFlags()
+	if err != nil {
+		exitErr(err)
+	}
+
+	ctx := context.Background()
+	loadStart := time.Now()
+	guest, err := newGuest(ctx)
+	if err != nil {
+		exitErr(err)
+	}
+	defer func() { _ = guest.Close() }()
+	loadMS := float64(time.Since(loadStart).Microseconds()) / 1000.0
+
+	switch cfg.mode {
+	case "digest":
+		fmt.Println(corpusDigest(guest))
+	case "bench":
+		runBench(guest, loadMS, cfg)
+	default:
+		exitErr(errors.New("mode must be bench or digest"))
+	}
+}
+
+func parseFlags() (runConfig, error) {
+	mode := flag.String("mode", "bench", "bench or digest")
+	rounds := flag.Int("rounds", 4000, "benchmark rounds over the corpus")
+	determinismRuns := flag.Int(
+		"determinism-runs", 5, "in-process digest runs",
+	)
+	flag.Parse()
+	if *rounds < 1 {
+		return runConfig{}, fmt.Errorf("rounds must be >= 1, got %d", *rounds)
+	}
+	if *determinismRuns < 1 {
+		return runConfig{}, fmt.Errorf(
+			"determinism-runs must be >= 1, got %d", *determinismRuns,
+		)
+	}
+	return runConfig{
+		mode:            *mode,
+		rounds:          *rounds,
+		determinismRuns: *determinismRuns,
+	}, nil
+}
+
+func runBench(guest *guestHandle, loadMS float64, cfg runConfig) {
+	printArtifactMetadata(guest, loadMS)
+	digest, unique := determinismStats(guest, cfg.determinismRuns)
+	fmt.Printf("determinism_digest=%s\n", digest)
+	fmt.Printf("determinism_unique_hashes=%d\n", unique)
+
+	metrics := collectBenchMetrics(guest, cfg.rounds)
+	printBenchMetrics(metrics)
+	printRiskLines(metrics.riskByID)
+}
+
+func printArtifactMetadata(guest *guestHandle, loadMS float64) {
+	// Sample once to capture metadata embedded in the guest.
+	probe, err := guest.Classify(corpus[0].Text)
+	if err != nil {
+		exitErr(fmt.Errorf("probe classify: %w", err))
+	}
+	sum := sha256.Sum256(wasmArtifact)
+	fmt.Printf("backend=wasm\n")
+	fmt.Printf("wasm_runtime=wazero\n")
+	fmt.Printf("wasm_artifact_bytes=%d\n", len(wasmArtifact))
+	fmt.Printf("wasm_artifact_sha256=%s\n", hex.EncodeToString(sum[:]))
+	fmt.Printf("model_id=%s\n", probe.ModelID)
+	fmt.Printf("model_version=%s\n", probe.Version)
+	fmt.Printf("threshold=%.4f\n", probe.Threshold)
+	fmt.Printf("guest_load_ms=%.4f\n", loadMS)
+	fmt.Printf("rss_after_load_kb=%d\n", rssKB())
+}
+
+func determinismStats(guest *guestHandle, runs int) (string, int) {
+	digests := make([]string, 0, runs)
+	for i := 0; i < runs; i++ {
+		digests = append(digests, corpusDigest(guest))
+	}
+	return digests[0], uniqueCount(digests)
+}
+
+type benchMetrics struct {
+	requests                int
+	avgLatencyUS            float64
+	p50LatencyUS            float64
+	p95LatencyUS            float64
+	maxLatencyUS            float64
+	rssAfterBenchKB         int
+	heapAllocAfterBenchKB   uint64
+	heapSysAfterBenchKB     uint64
+	totalAllocDeltaKB       uint64
+	labelsVerboseActionable int
+	labelsAcceptable        int
+	riskByID                map[string]float64
+}
+
+func collectBenchMetrics(guest *guestHandle, rounds int) benchMetrics {
+	var before runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	latencies := make([]float64, 0, len(corpus)*rounds)
+	labelCounts := map[string]int{}
+	riskByID := map[string]float64{}
+	for i := 0; i < rounds; i++ {
+		for _, c := range corpus {
+			start := time.Now()
+			result, err := guest.Classify(c.Text)
+			if err != nil {
+				exitErr(err)
+			}
+			delta := float64(time.Since(start).Nanoseconds()) / 1000.0
+			latencies = append(latencies, delta)
+			labelCounts[result.Label]++
+			if i == 0 {
+				riskByID[c.ID] = result.RiskScore
+			}
+		}
+	}
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	totalUS := sum(latencies)
+	requests := len(latencies)
+	return benchMetrics{
+		requests:                requests,
+		avgLatencyUS:            totalUS / float64(requests),
+		p50LatencyUS:            percentile(latencies, 0.50),
+		p95LatencyUS:            percentile(latencies, 0.95),
+		maxLatencyUS:            percentile(latencies, 1.00),
+		rssAfterBenchKB:         rssKB(),
+		heapAllocAfterBenchKB:   after.HeapAlloc / 1024,
+		heapSysAfterBenchKB:     after.HeapSys / 1024,
+		totalAllocDeltaKB:       (after.TotalAlloc - before.TotalAlloc) / 1024,
+		labelsVerboseActionable: labelCounts["verbose-actionable"],
+		labelsAcceptable:        labelCounts["acceptable"],
+		riskByID:                riskByID,
+	}
+}
+
+func printBenchMetrics(metrics benchMetrics) {
+	fmt.Printf("requests=%d\n", metrics.requests)
+	fmt.Printf("avg_latency_us=%.4f\n", metrics.avgLatencyUS)
+	fmt.Printf("p50_latency_us=%.4f\n", metrics.p50LatencyUS)
+	fmt.Printf("p95_latency_us=%.4f\n", metrics.p95LatencyUS)
+	fmt.Printf("max_latency_us=%.4f\n", metrics.maxLatencyUS)
+	fmt.Printf("rss_after_bench_kb=%d\n", metrics.rssAfterBenchKB)
+	fmt.Printf("heap_alloc_after_bench_kb=%d\n", metrics.heapAllocAfterBenchKB)
+	fmt.Printf("heap_sys_after_bench_kb=%d\n", metrics.heapSysAfterBenchKB)
+	fmt.Printf("total_alloc_delta_kb=%d\n", metrics.totalAllocDeltaKB)
+	fmt.Printf(
+		"labels_verbose_actionable=%d\n", metrics.labelsVerboseActionable,
+	)
+	fmt.Printf("labels_acceptable=%d\n", metrics.labelsAcceptable)
+}
+
+func printRiskLines(riskByID map[string]float64) {
+	keys := make([]string, 0, len(riskByID))
+	for id := range riskByID {
+		keys = append(keys, id)
+	}
+	sort.Strings(keys)
+	for _, id := range keys {
+		fmt.Printf("risk_%s=%.4f\n", id, riskByID[id])
+	}
+}
+
+func corpusDigest(guest *guestHandle) string {
+	var b strings.Builder
+	for _, c := range corpus {
+		r, err := guest.Classify(c.Text)
+		if err != nil {
+			exitErr(err)
+		}
+		_, _ = fmt.Fprintf(
+			&b, "%s|%s|%.6f|%s\n",
+			c.ID, r.Label, r.RiskScore, r.Cues,
+		)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func rssKB() int {
+	out, err := exec.Command(
+		"ps", "-o", "rss=", "-p", strconv.Itoa(os.Getpid()),
+	).Output()
+	if err != nil {
+		return heapSysKB()
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return heapSysKB()
+	}
+	return value
+}
+
+func heapSysKB() int {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return int(stats.HeapSys / 1024)
+}
+
+func uniqueCount(values []string) int {
+	set := map[string]struct{}{}
+	for _, v := range values {
+		set[v] = struct{}{}
+	}
+	return len(set)
+}
+
+func percentile(values []float64, q float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	cp := append([]float64(nil), values...)
+	sort.Float64s(cp)
+	if q <= 0 {
+		return cp[0]
+	}
+	if q >= 1 {
+		return cp[len(cp)-1]
+	}
+	idx := int(q * float64(len(cp)-1))
+	return cp[idx]
+}
+
+func sum(values []float64) float64 {
+	total := 0.0
+	for _, v := range values {
+		total += v
+	}
+	return total
+}
+
+func exitErr(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/docs/research/conciseness/spikes/wasm-embedded-inference/run.sh
+++ b/docs/research/conciseness/spikes/wasm-embedded-inference/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../../../../.." && pwd)"
+SPIKE_DIR="$ROOT_DIR/docs/research/conciseness/spikes/wasm-embedded-inference"
+WASM_GUEST_DIR="$SPIKE_DIR/wasm"
+EMBED_PKG_DIR="$ROOT_DIR/internal/rules/concisenessscoring/wasmclassifier"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/.tmp/spikes/wasm-embedded-inference}"
+ROUNDS="${ROUNDS:-4000}"
+DETERMINISM_RUNS="${DETERMINISM_RUNS:-5}"
+GOCACHE="${GOCACHE:-$OUT_DIR/.gocache}"
+
+mkdir -p "$OUT_DIR" "$GOCACHE"
+export GOCACHE
+cd "$ROOT_DIR"
+
+echo "[1/5] compile wasm guest (GOOS=wasip1 GOARCH=wasm reactor)"
+GOOS=wasip1 GOARCH=wasm go build \
+  -buildmode=c-shared \
+  -o "$SPIKE_DIR/classifier.wasm" \
+  ./docs/research/conciseness/spikes/wasm-embedded-inference/wasm
+cp "$SPIKE_DIR/classifier.wasm" "$EMBED_PKG_DIR/classifier.wasm"
+
+echo "[2/5] build host harness binary"
+go build -o "$OUT_DIR/wasm-spike" \
+  "$SPIKE_DIR/main.go"
+
+echo "[3/5] determinism check across process restarts"
+HASHES_FILE="$OUT_DIR/determinism-hashes.txt"
+: >"$HASHES_FILE"
+for _ in $(seq 1 "$DETERMINISM_RUNS"); do
+  "$OUT_DIR/wasm-spike" -mode digest >>"$HASHES_FILE"
+done
+determinism_hash=$(head -n 1 "$HASHES_FILE")
+determinism_unique_hashes=$(
+  sort -u "$HASHES_FILE" | wc -l | awk '{print $1}'
+)
+echo "determinism_hash=$determinism_hash"
+echo "determinism_unique_hashes=$determinism_unique_hashes"
+
+echo "[4/5] run latency and memory benchmark"
+"$OUT_DIR/wasm-spike" \
+  -mode bench \
+  -rounds "$ROUNDS" \
+  -determinism-runs "$DETERMINISM_RUNS" \
+  | tee "$OUT_DIR/bench.txt"
+
+echo "[5/5] measure binary-size delta"
+go build -o "$OUT_DIR/mdsmith-base" ./cmd/mdsmith
+go build -tags spike_wasm_classifier \
+  -o "$OUT_DIR/mdsmith-wasm" ./cmd/mdsmith
+base_bytes=$(wc -c <"$OUT_DIR/mdsmith-base" | awk '{print $1}')
+wasm_bytes=$(wc -c <"$OUT_DIR/mdsmith-wasm" | awk '{print $1}')
+delta_bytes=$((wasm_bytes - base_bytes))
+wasm_artifact_bytes=$(wc -c <"$SPIKE_DIR/classifier.wasm" | awk '{print $1}')
+
+{
+  echo "mdsmith_base_bytes=$base_bytes"
+  echo "mdsmith_wasm_bytes=$wasm_bytes"
+  echo "mdsmith_delta_bytes=$delta_bytes"
+  echo "wasm_artifact_bytes=$wasm_artifact_bytes"
+} | tee "$OUT_DIR/size.txt"
+
+cat >"$OUT_DIR/summary.txt" <<EOF
+determinism_hash=$determinism_hash
+determinism_unique_hashes=$determinism_unique_hashes
+mdsmith_base_bytes=$base_bytes
+mdsmith_wasm_bytes=$wasm_bytes
+mdsmith_delta_bytes=$delta_bytes
+wasm_artifact_bytes=$wasm_artifact_bytes
+EOF
+
+echo "results_dir=$OUT_DIR"

--- a/docs/research/conciseness/spikes/wasm-embedded-inference/wasm/main.go
+++ b/docs/research/conciseness/spikes/wasm-embedded-inference/wasm/main.go
@@ -56,8 +56,14 @@ func classify(ptr, length int32) int64 {
 	if length < 0 {
 		return 0
 	}
-	data := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), length)
-	text := string(data)
+	if length > 0 && ptr == 0 {
+		return 0
+	}
+	text := ""
+	if length > 0 {
+		data := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), length)
+		text = string(data)
+	}
 	result := model.Classify(text)
 
 	var b strings.Builder
@@ -71,7 +77,13 @@ func classify(ptr, length int32) int64 {
 		result.Version,
 		strings.Join(result.TriggeredCues, ","),
 	)
-	n := copy(outputBuf[:], b.String())
+	encoded := b.String()
+	if len(encoded) > len(outputBuf) {
+		// Signal truncation with a negative length so the host can detect
+		// and raise rather than silently decoding a truncated JSON buffer.
+		return -1
+	}
+	n := copy(outputBuf[:], encoded)
 	out := uintptr(unsafe.Pointer(&outputBuf[0]))
 	return (int64(out) << 32) | int64(n)
 }

--- a/docs/research/conciseness/spikes/wasm-embedded-inference/wasm/main.go
+++ b/docs/research/conciseness/spikes/wasm-embedded-inference/wasm/main.go
@@ -1,0 +1,79 @@
+//go:build wasip1
+
+// Package main is the WASM guest for the wasm-embedded-inference spike.
+//
+// It embeds the same linear classifier package the go-native spike uses so
+// the wasm-vs-native comparison only exercises the wasm runtime pathway,
+// not a different model. The guest exposes three wasmexport functions:
+//
+//   - alloc(size) ptr    : reserve size bytes of guest memory for host input
+//   - free(ptr)          : release a prior alloc
+//   - classify(ptr, len) : classify text at [ptr, ptr+len); returns an
+//                          int64 packing (outPtr<<32)|outLen of a JSON
+//                          result written into a static guest buffer.
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/jeduden/mdsmith/internal/rules/concisenessscoring/classifier"
+)
+
+var (
+	model     *classifier.Model
+	keepAlive = map[uintptr][]byte{}
+	outputBuf [4096]byte
+)
+
+func init() {
+	m, err := classifier.LoadEmbedded()
+	if err != nil {
+		panic(fmt.Sprintf("wasm guest: load classifier: %v", err))
+	}
+	model = m
+}
+
+//go:wasmexport alloc
+func alloc(size int32) int32 {
+	if size <= 0 {
+		return 0
+	}
+	buf := make([]byte, size)
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+	keepAlive[ptr] = buf
+	return int32(ptr)
+}
+
+//go:wasmexport free
+func free(ptr int32) {
+	delete(keepAlive, uintptr(ptr))
+}
+
+//go:wasmexport classify
+func classify(ptr, length int32) int64 {
+	if length < 0 {
+		return 0
+	}
+	data := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), length)
+	text := string(data)
+	result := model.Classify(text)
+
+	var b strings.Builder
+	fmt.Fprintf(
+		&b,
+		`{"label":%q,"risk_score":%.6f,"threshold":%.4f,"model_id":%q,"version":%q,"cues":%q}`,
+		result.Label,
+		result.RiskScore,
+		result.Threshold,
+		result.ModelID,
+		result.Version,
+		strings.Join(result.TriggeredCues, ","),
+	)
+	n := copy(outputBuf[:], b.String())
+	out := uintptr(unsafe.Pointer(&outputBuf[0]))
+	return (int64(out) << 32) | int64(n)
+}
+
+func main() {}

--- a/go.mod
+++ b/go.mod
@@ -227,6 +227,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
+	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -677,6 +677,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.5.4 h1:u1ww+gqpRLiIA16yF2PV1CV1n/X3zhyezbNXC3E14Sg=
 github.com/tetafro/godot v1.5.4/go.mod h1:eOkMrVQurDui411nBY2FA05EYH01r14LuWY/NrVDVcU=
+github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
+github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk5r6+hJnar67cgpDIz/iyD+rfl5r2Vk=
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/timonwong/loggercheck v0.11.0 h1:jdaMpYBl+Uq9mWPXv1r8jc5fC3gyXx4/WGwTnnNKn4M=

--- a/internal/rules/concisenessscoring/wasmclassifier/embed.go
+++ b/internal/rules/concisenessscoring/wasmclassifier/embed.go
@@ -1,0 +1,27 @@
+//go:build spike_wasm_classifier
+
+// Package wasmclassifier force-links the compiled wasm classifier artifact
+// and the wazero runtime so the wasm-embedded-inference spike can measure
+// binary-size impact of shipping the classifier in wasm form. It is only
+// compiled under the spike_wasm_classifier build tag.
+package wasmclassifier
+
+import (
+	_ "embed"
+
+	_ "github.com/tetratelabs/wazero"
+	_ "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+)
+
+//go:embed classifier.wasm
+var wasmArtifact []byte
+
+// ArtifactHolder keeps the embedded artifact reachable from the linker even
+// when the call site only reads the length. It is exported so tests and
+// size-measurement hooks can inspect the byte slice header and content.
+var ArtifactHolder = wasmArtifact
+
+// WasmArtifactBytes returns the embedded wasm artifact size in bytes.
+func WasmArtifactBytes() int {
+	return len(ArtifactHolder)
+}

--- a/plan/65_spike-wasm-embedded-inference.md
+++ b/plan/65_spike-wasm-embedded-inference.md
@@ -1,7 +1,7 @@
 ---
 id: 65
 title: Spike WASM-Embedded Weasel Inference
-status: 🔲
+status: ✅
 ---
 # Spike WASM-Embedded Weasel Inference
 
@@ -12,24 +12,35 @@ with no runtime dynamic library dependency.
 
 ## Tasks
 
-1. Choose one Go-hosted WASM runtime candidate
-   (for example `wazero`) and define module loading strategy.
-2. Build a minimal proof of concept that embeds a `.wasm` artifact with
-   `go:embed` and runs inference in-process.
-3. Verify deterministic output behavior on a fixed prompt and fixed
-   model parameters.
-4. Measure CPU latency and memory overhead versus:
-   current MDS029 heuristic, pure-Go spike, and yzma spike baselines.
-5. Measure binary-size impact with embedded `.wasm` artifact.
-6. Define artifact update workflow and integrity checks
-   (checksum/version pinning).
-7. Document fallback boundaries when WASM init or inference fails.
+1. [x] Choose one Go-hosted WASM runtime candidate
+   (`wazero` v1.11.0 with the default wazevo optimizing compiler)
+   and define module loading strategy.
+2. [x] Build a minimal proof of concept that embeds a `.wasm`
+   artifact with `go:embed` and runs inference in-process. The
+   guest reuses the plan-64 classifier package verbatim, compiled
+   with `GOOS=wasip1 GOARCH=wasm -buildmode=c-shared`.
+3. [x] Verify deterministic output behavior on a fixed corpus and
+   fixed model parameters. Five in-process and five cross-process
+   runs produced the same digest.
+4. [x] Measure CPU latency and memory overhead versus current
+   MDS029 heuristic, pure-Go spike, and yzma spike baselines.
+5. [x] Measure binary-size impact with embedded `.wasm` artifact.
+6. [x] Define artifact update workflow and integrity checks
+   (SHA256 pin on embedded wasm bytes, wazero validates on load).
+7. [x] Document fallback boundaries when WASM init or inference
+   fails.
+
+Findings and recommendation live in the [spike README][spike].
+
+[spike]: ../docs/research/conciseness/spikes/wasm-embedded-inference/README.md
 
 ## Acceptance Criteria
 
-- [ ] Prototype runs with no `YZMA_LIB` and no external dynamic libs.
-- [ ] Embedded WASM artifact loads via `go:embed`.
-- [ ] Deterministic behavior is confirmed across repeat runs.
-- [ ] CPU latency and memory metrics are captured.
-- [ ] Binary-size impact is measured and documented.
-- [ ] Recommendation is made: adopt, defer, or reject this path.
+- [x] Prototype runs with no `YZMA_LIB` and no external dynamic libs.
+- [x] Embedded WASM artifact loads via `go:embed`.
+- [x] Deterministic behavior is confirmed across repeat runs.
+- [x] CPU latency and memory metrics are captured.
+- [x] Binary-size impact is measured and documented.
+- [x] Recommendation is made: reject this path at the current
+      classifier size. Keep the pure-Go classifier (plan 64) as the
+      CPU fallback for MDS029.


### PR DESCRIPTION
## Summary

This PR completes the WASM-embedded-inference spike (plan 65), implementing a proof-of-concept that embeds a WebAssembly classifier artifact using `go:embed` and hosts it with the wazero runtime. The spike evaluates whether WASM can provide a viable inference path for mdsmith with no runtime dynamic library dependencies.

## Key Changes

- **WASM guest implementation** (`wasm/main.go`): A minimal WASI reactor module that reuses the plan-64 linear classifier package verbatim, exposing three wasmexport functions (`alloc`, `free`, `classify`) for host-guest communication via linear memory.

- **Host harness** (`main.go`): A comprehensive benchmark and determinism-verification tool that:
  - Loads the embedded wasm artifact via `go:embed`
  - Instantiates it with wazero (v1.11.0, using the default wazevo optimizing compiler)
  - Measures cold-start compile time, per-call latency (avg/p50/p95/max), memory overhead, and determinism across process restarts
  - Compares against the MDS029 heuristic, pure-Go classifier (plan 64), and yzma embedded baselines

- **Build infrastructure** (`run.sh`): Automated script that:
  - Compiles the wasm guest with `GOOS=wasip1 GOARCH=wasm -buildmode=c-shared`
  - Builds the host harness and runs determinism checks across five process restarts
  - Measures binary-size delta by building mdsmith with and without the `spike_wasm_classifier` tag
  - Captures all metrics to `bench.txt` and `size.txt`

- **Size-measurement hooks** (`internal/rules/concisenessscoring/wasmclassifier/embed.go`, `cmd/mdsmith/spike_wasm_classifier.go`): Build-tag-gated stubs that force-link the embedded wasm artifact and wazero runtime so binary-size impact can be measured in isolation.

- **Comprehensive documentation** (updated `README.md`): Detailed findings including:
  - Determinism confirmation (5 in-process + 5 cross-process runs, all identical digest)
  - Latency metrics: ~2,022 us avg, 2,464 us p95 (vs. 3.38 us for pure-Go)
  - Memory: 109 MB RSS after bench (vs. 7.8 MB for pure-Go)
  - Binary cost: 4.17 MB delta (3.99 MB wasm artifact + 181 KB wazero/WASI)
  - **Recommendation: reject this path** — the pure-Go classifier already delivers deterministic output with 480 B binary cost and 3 us latency; wasm adds no capability while incurring 600x latency penalty and 14x memory overhead

- **Plan status update** (`plan/65_spike-wasm-embedded-inference.md`): Marked complete with all acceptance criteria met.

## Notable Implementation Details

- **Module loading strategy**: One module instance is reused for all calls; re-instantiating per call would incur the ~1.7 s wazero compile cost repeatedly. The host calls `_initialize` explicitly after instantiation (reactor-module semantics).

- **Memory safety**: Host-guest communication uses linear memory with explicit `alloc`/`free` calls. The guest returns a packed int64 `(outPtr<<32)|outLen` pointing to a static 4 KB output buffer containing JSON results.

- **Determinism**: Outputs are byte-for-byte identical across in-process repeats and process restarts, with SHA256 digest pinning recommended for integrity checks.

- **Fallback boundaries**: Documented recommended guards (compile-time build tag, runtime instantiation with fallback to heuristic on error, per-call timeout wrapper, verbose diagnostics).

- **Artifact update workflow**: Safe path defined with SHA256 pinning, version tracking, and determinism validation before shipping.

## Rationale for Rejection

The spike conclusively demonstrates that while wasm provides deterministic, sandboxed execution with no external dynamic

https://claude.ai/code/session_014iGcShL7oVcZVoYk4JSPpq