### PR TITLE
Isolate corpus test git config from host signing settings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -25,6 +25,6 @@ footer: |
 | 85  | 🔳     | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md) |
 | 86  | 🔳     | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                  |
 | 89  | 🔲     | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                    |
-| 90  | 🔲     | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)      |
+| 90  | ✅     | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)      |
 | 91  | 🔲     | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)       |
 <?/catalog?>

--- a/internal/corpus/clone_test.go
+++ b/internal/corpus/clone_test.go
@@ -107,6 +107,9 @@ func makeBareRepo(t *testing.T) (repoPath string, commit string) {
 	runGit(t, "init", work)
 	runGitInDir(t, work, "config", "user.name", "Test User")
 	runGitInDir(t, work, "config", "user.email", "test@example.com")
+	runGitInDir(t, work, "config", "commit.gpgsign", "false")
+	runGitInDir(t, work, "config", "tag.gpgsign", "false")
+	runGitInDir(t, work, "config", "gpg.format", "openpgp")
 
 	docsDir := filepath.Join(work, "docs")
 	if err := os.MkdirAll(docsDir, 0o755); err != nil {

--- a/plan/90_corpus-test-git-config-isolation.md
+++ b/plan/90_corpus-test-git-config-isolation.md
@@ -1,7 +1,7 @@
 ---
 id: 90
 title: Isolate corpus test git config from host signing
-status: "🔲"
+status: "✅"
 summary: >-
   Pin commit.gpgsign, tag.gpgsign, and gpg.format
   off for the temporary repositories built by
@@ -56,10 +56,10 @@ create commits and are unaffected.
 
 ## Acceptance Criteria
 
-- [ ] `go test ./internal/corpus/...` passes on a
+- [x] `go test ./internal/corpus/...` passes on a
       host with `commit.gpgsign=true` globally set.
-- [ ] `makeBareRepo` never reads
+- [x] `makeBareRepo` never reads
       `gpg.program` or `gpg.x509.program` from the
       global git config.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary
This PR completes the implementation of isolating corpus test git configurations from host-level signing settings. The changes ensure that temporary repositories created during corpus tests are not affected by global git configuration settings like `commit.gpgsign=true`.

## Key Changes
- Added explicit git config settings to `makeBareRepo()` to disable GPG signing for commits and tags:
  - `commit.gpgsign=false`
  - `tag.gpgsign=false`
  - `gpg.format=openpgp`
- Updated acceptance criteria checklist to mark all items as complete

## Implementation Details
The fix isolates the test repositories by explicitly configuring git signing behavior at the repository level, preventing the test from inheriting potentially problematic global git configurations from the host system. This ensures that `go test ./internal/corpus/...` passes reliably regardless of the developer's personal git signing preferences.

All acceptance criteria have been verified:
- Corpus tests pass with `commit.gpgsign=true` globally set
- `makeBareRepo` no longer reads signing-related config from global git config
- All tests pass
- No linting issues reported

https://claude.ai/code/session_013emCLHCdDZGijB1FAmP5QB