### PR TITLE
Implement auto-fix for markdown flavor validation rule

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -23,7 +23,7 @@ footer: |
 | 83  | ✅     | [Security hardening batch](plan/83_security-hardening-batch.md)                                      |
 | 84  | ✅     | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                           |
 | 85  | 🔳     | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md) |
-| 86  | 🔳     | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                  |
+| 86  | ✅     | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                  |
 | 89  | ✅     | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                    |
 | 90  | ✅     | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)      |
 | 91  | ✅     | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)       |

--- a/internal/rules/MDS034-markdown-flavor/fixed/commonmark-bare-url.md
+++ b/internal/rules/MDS034-markdown-flavor/fixed/commonmark-bare-url.md
@@ -1,0 +1,3 @@
+# Heading
+
+Visit <https://example.com> for details.

--- a/internal/rules/MDS034-markdown-flavor/fixed/commonmark-heading-id.md
+++ b/internal/rules/MDS034-markdown-flavor/fixed/commonmark-heading-id.md
@@ -1,0 +1,3 @@
+# Heading
+
+Body text.

--- a/internal/rules/MDS034-markdown-flavor/fixed/commonmark-strikethrough.md
+++ b/internal/rules/MDS034-markdown-flavor/fixed/commonmark-strikethrough.md
@@ -1,0 +1,3 @@
+# Heading
+
+Text crossed out here.

--- a/internal/rules/MDS034-markdown-flavor/fixed/commonmark-subscript.md
+++ b/internal/rules/MDS034-markdown-flavor/fixed/commonmark-subscript.md
@@ -1,0 +1,3 @@
+# Heading
+
+H2O is water.

--- a/internal/rules/MDS034-markdown-flavor/fixed/commonmark-superscript.md
+++ b/internal/rules/MDS034-markdown-flavor/fixed/commonmark-superscript.md
@@ -1,0 +1,3 @@
+# Heading
+
+E = mc2 is famous.

--- a/internal/rules/MDS034-markdown-flavor/fixed/commonmark-task-list.md
+++ b/internal/rules/MDS034-markdown-flavor/fixed/commonmark-task-list.md
@@ -1,0 +1,4 @@
+# Heading
+
+- done
+- todo

--- a/internal/rules/markdownflavor/fix.go
+++ b/internal/rules/markdownflavor/fix.go
@@ -1,0 +1,246 @@
+package markdownflavor
+
+import (
+	"sort"
+
+	"github.com/yuin/goldmark/ast"
+	extast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/text"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rules/markdownflavor/ext"
+)
+
+// edit describes a single byte-range substitution to apply to f.Source.
+// All edits are computed against the original source; applyEdits sorts
+// them in reverse and rewrites the buffer once.
+type edit struct {
+	start, end int
+	repl       []byte
+}
+
+// fixByteRangeFeatures collects edits for the six byte-range features
+// (heading IDs, strikethrough, task lists, superscript, subscript, and
+// bare-URL autolinks) and returns the rewritten source. Features that
+// the configured flavor accepts are skipped. The function returns the
+// original source unchanged when no edit applies.
+func (r *Rule) fixByteRangeFeatures(f *lint.File) []byte {
+	var edits []edit
+
+	// Heading IDs, strikethrough, task lists, superscript, subscript
+	// are detected via the dual parser tree.
+	if r.needsAnyDualFix() {
+		doc := Parser().Parser().Parse(text.NewReader(f.Source))
+		_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			edits = append(edits, r.dualNodeEdits(f, n)...)
+			return ast.WalkContinue, nil
+		})
+	}
+
+	// Bare URLs are detected on the main CommonMark AST so URLs inside
+	// code spans / fences are skipped (insideNonBareContext).
+	if !r.Flavor.Supports(FeatureBareURLAutolinks) {
+		for _, fin := range detectBareURLs(f) {
+			edits = append(edits, wrapBareURL(f.Source, fin))
+		}
+	}
+
+	if len(edits) == 0 {
+		return f.Source
+	}
+	return applyEdits(f.Source, edits)
+}
+
+// needsAnyDualFix reports whether any of the dual-parser fixable
+// features is unsupported by the configured flavor. Used to skip the
+// dual re-parse when there is nothing to do.
+func (r *Rule) needsAnyDualFix() bool {
+	for _, feat := range []Feature{
+		FeatureHeadingIDs, FeatureStrikethrough, FeatureTaskLists,
+		FeatureSuperscript, FeatureSubscript,
+	} {
+		if !r.Flavor.Supports(feat) {
+			return true
+		}
+	}
+	return false
+}
+
+// dualNodeEdits returns the edits to remove an unsupported feature
+// produced from a dual-parser AST node. Returns nil when the node is
+// either supported or not a fixable feature.
+func (r *Rule) dualNodeEdits(f *lint.File, n ast.Node) []edit {
+	switch node := n.(type) {
+	case *ast.Heading:
+		if r.Flavor.Supports(FeatureHeadingIDs) {
+			return nil
+		}
+		return headingIDEdits(f, node)
+	case *extast.Strikethrough:
+		if r.Flavor.Supports(FeatureStrikethrough) {
+			return nil
+		}
+		return delimiterPairEdits(f.Source, node, "~~")
+	case *extast.TaskCheckBox:
+		if r.Flavor.Supports(FeatureTaskLists) {
+			return nil
+		}
+		return taskCheckBoxEdits(f, node)
+	case *ext.SuperscriptNode:
+		if r.Flavor.Supports(FeatureSuperscript) {
+			return nil
+		}
+		return delimiterPairEdits(f.Source, node, "^")
+	case *ext.SubscriptNode:
+		if r.Flavor.Supports(FeatureSubscript) {
+			return nil
+		}
+		return delimiterPairEdits(f.Source, node, "~")
+	}
+	return nil
+}
+
+// headingIDEdits returns the edit that drops a "{#id}" attribute block
+// plus any whitespace separating it from the heading text. Returns nil
+// when the heading carries no id attribute.
+func headingIDEdits(f *lint.File, h *ast.Heading) []edit {
+	fin, ok := findHeadingID(f, h)
+	if !ok {
+		return nil
+	}
+	hx, ok := fin.Extra.(HeadingIDExtra)
+	if !ok {
+		return nil
+	}
+	start := hx.AttrStart
+	for start > 0 && (f.Source[start-1] == ' ' || f.Source[start-1] == '\t') {
+		start--
+	}
+	return []edit{{start: start, end: hx.AttrEnd, repl: nil}}
+}
+
+// delimiterPairEdits returns edits removing the opening and closing
+// delimiter runs that wrap an inline node. The function locates each
+// delimiter from the inner-content span derived from descendant text
+// segments — the dual parser does not record segment offsets on the
+// wrapper node itself.
+func delimiterPairEdits(source []byte, n ast.Node, marker string) []edit {
+	innerStart, innerEnd, ok := innerSpan(n)
+	if !ok {
+		return nil
+	}
+	openStart := innerStart - len(marker)
+	closeEnd := innerEnd + len(marker)
+	if openStart < 0 || closeEnd > len(source) {
+		return nil
+	}
+	if string(source[openStart:innerStart]) != marker {
+		return nil
+	}
+	if string(source[innerEnd:closeEnd]) != marker {
+		return nil
+	}
+	return []edit{
+		{start: openStart, end: innerStart, repl: nil},
+		{start: innerEnd, end: closeEnd, repl: nil},
+	}
+}
+
+// innerSpan returns the byte range covered by descendant text segments.
+// The bounds are conservative: spans for nested inline nodes are
+// gathered by walking, so a span like `~~before *bold* after~~` reports
+// the range from the start of "before" to the end of "after". Returns
+// false when the node carries no descendant text.
+func innerSpan(n ast.Node) (int, int, bool) {
+	start := -1
+	end := -1
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		s, e, ok := childTextRange(c)
+		if !ok {
+			continue
+		}
+		if start == -1 || s < start {
+			start = s
+		}
+		if e > end {
+			end = e
+		}
+	}
+	if start == -1 {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// childTextRange returns the [start, stop) byte range covered by a
+// child inline node. ast.Text exposes its segment directly; container
+// inlines (emphasis, strong, code spans inside content, etc.) report
+// the union of their descendants' spans.
+func childTextRange(n ast.Node) (int, int, bool) {
+	if t, ok := n.(*ast.Text); ok {
+		return t.Segment.Start, t.Segment.Stop, true
+	}
+	s, e, ok := innerSpan(n)
+	return s, e, ok
+}
+
+// taskCheckBoxEdits removes the "[X]" run plus a single trailing
+// space when present. Per the plan, the bullet itself is preserved.
+func taskCheckBoxEdits(f *lint.File, n *extast.TaskCheckBox) []edit {
+	block := nearestBlockAncestor(n)
+	if block == nil {
+		return nil
+	}
+	lines := block.Lines()
+	if lines == nil || lines.Len() == 0 {
+		return nil
+	}
+	start := lines.At(0).Start
+	if start+3 > len(f.Source) {
+		return nil
+	}
+	if f.Source[start] != '[' || f.Source[start+2] != ']' {
+		return nil
+	}
+	end := start + 3
+	if end < len(f.Source) && f.Source[end] == ' ' {
+		end++
+	}
+	return []edit{{start: start, end: end, repl: nil}}
+}
+
+// wrapBareURL wraps a bare URL in angle brackets so the renderer treats
+// it as a CommonMark autolink. The detector reports a precise span via
+// fin.Start / fin.End.
+func wrapBareURL(source []byte, fin Finding) edit {
+	url := source[fin.Start:fin.End]
+	repl := make([]byte, 0, len(url)+2)
+	repl = append(repl, '<')
+	repl = append(repl, url...)
+	repl = append(repl, '>')
+	return edit{start: fin.Start, end: fin.End, repl: repl}
+}
+
+// applyEdits rewrites src by applying every edit. Edits are sorted in
+// descending start order so each rewrite leaves earlier offsets valid.
+// Overlapping edits are dropped silently (last writer wins): the
+// detection layer never produces overlaps for the features we fix.
+func applyEdits(src []byte, edits []edit) []byte {
+	sort.SliceStable(edits, func(i, j int) bool {
+		return edits[i].start > edits[j].start
+	})
+	out := make([]byte, len(src))
+	copy(out, src)
+	prevStart := len(src) + 1
+	for _, e := range edits {
+		if e.end > prevStart {
+			continue
+		}
+		out = append(append(append([]byte(nil), out[:e.start]...), e.repl...), out[e.end:]...)
+		prevStart = e.start
+	}
+	return out
+}

--- a/internal/rules/markdownflavor/fix.go
+++ b/internal/rules/markdownflavor/fix.go
@@ -11,9 +11,9 @@ import (
 	"github.com/jeduden/mdsmith/internal/rules/markdownflavor/ext"
 )
 
-// edit describes a single byte-range substitution to apply to f.Source.
-// All edits are computed against the original source; applyEdits sorts
-// them in reverse and rewrites the buffer once.
+// edit describes a single byte-range substitution to apply to source.
+// applyEdits assumes non-overlapping spans and rewrites the buffer in
+// one pass.
 type edit struct {
 	start, end int
 	repl       []byte
@@ -23,12 +23,10 @@ type edit struct {
 // (heading IDs, strikethrough, task lists, superscript, subscript, and
 // bare-URL autolinks) and returns the rewritten source. Features that
 // the configured flavor accepts are skipped. The function returns the
-// original source unchanged when no edit applies.
+// source unchanged when no edit applies.
 func (r *Rule) fixByteRangeFeatures(f *lint.File) []byte {
 	var edits []edit
 
-	// Heading IDs, strikethrough, task lists, superscript, subscript
-	// are detected via the dual parser tree.
 	if r.needsAnyDualFix() {
 		doc := Parser().Parser().Parse(text.NewReader(f.Source))
 		_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -40,8 +38,6 @@ func (r *Rule) fixByteRangeFeatures(f *lint.File) []byte {
 		})
 	}
 
-	// Bare URLs are detected on the main CommonMark AST so URLs inside
-	// code spans / fences are skipped (insideNonBareContext).
 	if !r.Flavor.Supports(FeatureBareURLAutolinks) {
 		for _, fin := range detectBareURLs(f) {
 			edits = append(edits, wrapBareURL(f.Source, fin))
@@ -54,9 +50,9 @@ func (r *Rule) fixByteRangeFeatures(f *lint.File) []byte {
 	return applyEdits(f.Source, edits)
 }
 
-// needsAnyDualFix reports whether any of the dual-parser fixable
-// features is unsupported by the configured flavor. Used to skip the
-// dual re-parse when there is nothing to do.
+// needsAnyDualFix reports whether any dual-parser fixable feature is
+// unsupported by the configured flavor. Skips the dual re-parse for
+// flavors that accept every dual feature (e.g. FlavorAny, Pandoc).
 func (r *Rule) needsAnyDualFix() bool {
 	for _, feat := range []Feature{
 		FeatureHeadingIDs, FeatureStrikethrough, FeatureTaskLists,
@@ -83,7 +79,7 @@ func (r *Rule) dualNodeEdits(f *lint.File, n ast.Node) []edit {
 		if r.Flavor.Supports(FeatureStrikethrough) {
 			return nil
 		}
-		return delimiterPairEdits(f.Source, node, "~~")
+		return delimiterPairEdits(node, len("~~"))
 	case *extast.TaskCheckBox:
 		if r.Flavor.Supports(FeatureTaskLists) {
 			return nil
@@ -93,123 +89,63 @@ func (r *Rule) dualNodeEdits(f *lint.File, n ast.Node) []edit {
 		if r.Flavor.Supports(FeatureSuperscript) {
 			return nil
 		}
-		return delimiterPairEdits(f.Source, node, "^")
+		return delimiterPairEdits(node, len("^"))
 	case *ext.SubscriptNode:
 		if r.Flavor.Supports(FeatureSubscript) {
 			return nil
 		}
-		return delimiterPairEdits(f.Source, node, "~")
+		return delimiterPairEdits(node, len("~"))
 	}
 	return nil
 }
 
 // headingIDEdits returns the edit that drops a "{#id}" attribute block
 // plus any whitespace separating it from the heading text. Returns nil
-// when the heading carries no id attribute.
+// when the heading carries no id attribute. findHeadingID always stores
+// a HeadingIDExtra in fin.Extra, so the type assertion is unchecked.
 func headingIDEdits(f *lint.File, h *ast.Heading) []edit {
 	fin, ok := findHeadingID(f, h)
 	if !ok {
 		return nil
 	}
-	hx, ok := fin.Extra.(HeadingIDExtra)
-	if !ok {
-		return nil
-	}
+	hx := fin.Extra.(HeadingIDExtra)
 	start := hx.AttrStart
 	for start > 0 && (f.Source[start-1] == ' ' || f.Source[start-1] == '\t') {
 		start--
 	}
-	return []edit{{start: start, end: hx.AttrEnd, repl: nil}}
+	return []edit{{start: start, end: hx.AttrEnd}}
 }
 
 // delimiterPairEdits returns edits removing the opening and closing
-// delimiter runs that wrap an inline node. The function locates each
-// delimiter from the inner-content span derived from descendant text
-// segments — the dual parser does not record segment offsets on the
-// wrapper node itself.
-func delimiterPairEdits(source []byte, n ast.Node, marker string) []edit {
-	innerStart, innerEnd, ok := innerSpan(n)
-	if !ok {
-		return nil
-	}
-	openStart := innerStart - len(marker)
-	closeEnd := innerEnd + len(marker)
-	if openStart < 0 || closeEnd > len(source) {
-		return nil
-	}
-	if string(source[openStart:innerStart]) != marker {
-		return nil
-	}
-	if string(source[innerEnd:closeEnd]) != marker {
+// delimiter runs that wrap an inline node. Only nodes with a single
+// Text child are fixed; goldmark merges adjacent text inlines so a
+// second sibling (whether Text-typed or not) implies nested inline
+// markup like `~~*bold*~~` or a softbreak inside the wrapper, where
+// reconstructing each child's own marker span is brittle. The fix
+// declines and the diagnostic remains for the user to resolve.
+func delimiterPairEdits(n ast.Node, markerLen int) []edit {
+	t, ok := n.FirstChild().(*ast.Text)
+	if !ok || t.NextSibling() != nil {
 		return nil
 	}
 	return []edit{
-		{start: openStart, end: innerStart, repl: nil},
-		{start: innerEnd, end: closeEnd, repl: nil},
+		{start: t.Segment.Start - markerLen, end: t.Segment.Start},
+		{start: t.Segment.Stop, end: t.Segment.Stop + markerLen},
 	}
-}
-
-// innerSpan returns the byte range covered by descendant text segments.
-// The bounds are conservative: spans for nested inline nodes are
-// gathered by walking, so a span like `~~before *bold* after~~` reports
-// the range from the start of "before" to the end of "after". Returns
-// false when the node carries no descendant text.
-func innerSpan(n ast.Node) (int, int, bool) {
-	start := -1
-	end := -1
-	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-		s, e, ok := childTextRange(c)
-		if !ok {
-			continue
-		}
-		if start == -1 || s < start {
-			start = s
-		}
-		if e > end {
-			end = e
-		}
-	}
-	if start == -1 {
-		return 0, 0, false
-	}
-	return start, end, true
-}
-
-// childTextRange returns the [start, stop) byte range covered by a
-// child inline node. ast.Text exposes its segment directly; container
-// inlines (emphasis, strong, code spans inside content, etc.) report
-// the union of their descendants' spans.
-func childTextRange(n ast.Node) (int, int, bool) {
-	if t, ok := n.(*ast.Text); ok {
-		return t.Segment.Start, t.Segment.Stop, true
-	}
-	s, e, ok := innerSpan(n)
-	return s, e, ok
 }
 
 // taskCheckBoxEdits removes the "[X]" run plus a single trailing
 // space when present. Per the plan, the bullet itself is preserved.
+// The dual parser places every TaskCheckBox at the start of a
+// TextBlock so block.Lines().At(0).Start always points at '['.
 func taskCheckBoxEdits(f *lint.File, n *extast.TaskCheckBox) []edit {
 	block := nearestBlockAncestor(n)
-	if block == nil {
-		return nil
-	}
-	lines := block.Lines()
-	if lines == nil || lines.Len() == 0 {
-		return nil
-	}
-	start := lines.At(0).Start
-	if start+3 > len(f.Source) {
-		return nil
-	}
-	if f.Source[start] != '[' || f.Source[start+2] != ']' {
-		return nil
-	}
+	start := block.Lines().At(0).Start
 	end := start + 3
 	if end < len(f.Source) && f.Source[end] == ' ' {
 		end++
 	}
-	return []edit{{start: start, end: end, repl: nil}}
+	return []edit{{start: start, end: end}}
 }
 
 // wrapBareURL wraps a bare URL in angle brackets so the renderer treats
@@ -224,23 +160,25 @@ func wrapBareURL(source []byte, fin Finding) edit {
 	return edit{start: fin.Start, end: fin.End, repl: repl}
 }
 
-// applyEdits rewrites src by applying every edit. Edits are sorted in
-// descending start order so each rewrite leaves earlier offsets valid.
-// Overlapping edits are dropped silently (last writer wins): the
-// detection layer never produces overlaps for the features we fix.
+// applyEdits rewrites src by appending unchanged spans and replacement
+// bytes in a single pass. Edits are sorted by ascending start offset;
+// the detection layer never produces overlapping edits for the
+// features we fix, so applyEdits assumes non-overlapping spans.
 func applyEdits(src []byte, edits []edit) []byte {
 	sort.SliceStable(edits, func(i, j int) bool {
-		return edits[i].start > edits[j].start
+		return edits[i].start < edits[j].start
 	})
-	out := make([]byte, len(src))
-	copy(out, src)
-	prevStart := len(src) + 1
+	size := len(src)
 	for _, e := range edits {
-		if e.end > prevStart {
-			continue
-		}
-		out = append(append(append([]byte(nil), out[:e.start]...), e.repl...), out[e.end:]...)
-		prevStart = e.start
+		size += len(e.repl) - (e.end - e.start)
 	}
+	out := make([]byte, 0, size)
+	cursor := 0
+	for _, e := range edits {
+		out = append(out, src[cursor:e.start]...)
+		out = append(out, e.repl...)
+		cursor = e.end
+	}
+	out = append(out, src[cursor:]...)
 	return out
 }

--- a/internal/rules/markdownflavor/fix_test.go
+++ b/internal/rules/markdownflavor/fix_test.go
@@ -109,9 +109,10 @@ func TestRuleFixBareURLGFMAccepts(t *testing.T) {
 
 // --- combined -----------------------------------------------------------
 
-// TestRuleFixMultipleFeaturesOnOneLine covers reverse-order edit
-// application: two byte-range edits on the same line must compose
-// without one corrupting the other's offsets.
+// TestRuleFixMultipleFeaturesOnOneLine covers the ascending single-
+// pass build in applyEdits: two byte-range edits on the same line
+// must compose into a contiguous output without one corrupting the
+// other's spans.
 func TestRuleFixMultipleFeaturesOnOneLine(t *testing.T) {
 	got := fixWith(t, "commonmark",
 		"# Heading {#top}\n\nText ~~old~~ at https://example.com.\n")

--- a/internal/rules/markdownflavor/fix_test.go
+++ b/internal/rules/markdownflavor/fix_test.go
@@ -1,0 +1,118 @@
+package markdownflavor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixWith parses src into a *lint.File, applies the configured rule's
+// Fix, and returns the result as a string for compact assertion.
+func fixWith(t *testing.T, flavor, src string) string {
+	t.Helper()
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"flavor": flavor}))
+	return string(r.Fix(mkFile(t, src)))
+}
+
+// --- heading IDs --------------------------------------------------------
+
+func TestRuleFixHeadingIDRemovesAttributeBlock(t *testing.T) {
+	got := fixWith(t, "commonmark", "# Heading {#top}\n\nBody text.\n")
+	assert.Equal(t, "# Heading\n\nBody text.\n", got)
+}
+
+func TestRuleFixHeadingIDPreservesTrailingNewline(t *testing.T) {
+	// A heading at end-of-file with no trailing newline must stay that way.
+	got := fixWith(t, "commonmark", "# Heading {#top}")
+	assert.Equal(t, "# Heading", got)
+}
+
+func TestRuleFixHeadingIDMultiple(t *testing.T) {
+	src := "# A {#a}\n\n## B {#b}\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t, "# A\n\n## B\n", got)
+}
+
+func TestRuleFixHeadingIDGoldmarkAccepts(t *testing.T) {
+	// goldmark supports heading IDs, so Fix must not strip them.
+	src := "# Heading {#top}\n"
+	got := fixWith(t, "goldmark", src)
+	assert.Equal(t, src, got)
+}
+
+// --- strikethrough ------------------------------------------------------
+
+func TestRuleFixStrikethroughRemovesMarkers(t *testing.T) {
+	got := fixWith(t, "commonmark", "Text ~~crossed out~~ here.\n")
+	assert.Equal(t, "Text crossed out here.\n", got)
+}
+
+func TestRuleFixStrikethroughGFMAccepts(t *testing.T) {
+	src := "Text ~~crossed out~~ here.\n"
+	got := fixWith(t, "gfm", src)
+	assert.Equal(t, src, got)
+}
+
+// --- task lists ---------------------------------------------------------
+
+func TestRuleFixTaskListRemovesMarker(t *testing.T) {
+	src := "- [x] done\n- [ ] todo\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t, "- done\n- todo\n", got)
+}
+
+func TestRuleFixTaskListPreservesBullet(t *testing.T) {
+	// The plan calls out `*` and `+` bullets explicitly.
+	src := "* [X] one\n+ [ ] two\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t, "* one\n+ two\n", got)
+}
+
+func TestRuleFixTaskListGFMAccepts(t *testing.T) {
+	src := "- [x] done\n"
+	got := fixWith(t, "gfm", src)
+	assert.Equal(t, src, got)
+}
+
+// --- superscript --------------------------------------------------------
+
+func TestRuleFixSuperscriptRemovesCarets(t *testing.T) {
+	got := fixWith(t, "commonmark", "E = mc^2^ is famous.\n")
+	assert.Equal(t, "E = mc2 is famous.\n", got)
+}
+
+// --- subscript ----------------------------------------------------------
+
+func TestRuleFixSubscriptRemovesTildes(t *testing.T) {
+	got := fixWith(t, "commonmark", "H~2~O is water.\n")
+	assert.Equal(t, "H2O is water.\n", got)
+}
+
+// --- bare URLs ----------------------------------------------------------
+
+func TestRuleFixBareURLWrapsInAngleBrackets(t *testing.T) {
+	got := fixWith(t, "commonmark",
+		"Visit https://example.com for details.\n")
+	assert.Equal(t,
+		"Visit <https://example.com> for details.\n", got)
+}
+
+func TestRuleFixBareURLGFMAccepts(t *testing.T) {
+	src := "Visit https://example.com for details.\n"
+	got := fixWith(t, "gfm", src)
+	assert.Equal(t, src, got)
+}
+
+// --- combined -----------------------------------------------------------
+
+// TestRuleFixMultipleFeaturesOnOneLine covers reverse-order edit
+// application: two byte-range edits on the same line must compose
+// without one corrupting the other's offsets.
+func TestRuleFixMultipleFeaturesOnOneLine(t *testing.T) {
+	got := fixWith(t, "commonmark",
+		"# Heading {#top}\n\nText ~~old~~ at https://example.com.\n")
+	assert.Equal(t,
+		"# Heading\n\nText old at <https://example.com>.\n", got)
+}

--- a/internal/rules/markdownflavor/fix_test.go
+++ b/internal/rules/markdownflavor/fix_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/rules/markdownflavor/ext"
 )
 
 // fixWith parses src into a *lint.File, applies the configured rule's
@@ -115,4 +117,73 @@ func TestRuleFixMultipleFeaturesOnOneLine(t *testing.T) {
 		"# Heading {#top}\n\nText ~~old~~ at https://example.com.\n")
 	assert.Equal(t,
 		"# Heading\n\nText old at <https://example.com>.\n", got)
+}
+
+// TestRuleFixAlertAndByteRangeFeatureCompose verifies that Fix() runs
+// alerts stripping AND byte-range fixes in the same call. Before the
+// pipeline composition fix, alerts caused an early return that left
+// strikethrough / bare URLs / heading IDs unfixed in alert-bearing
+// docs; the next fixer pass would catch them, but it required two
+// passes for what should be one.
+func TestRuleFixAlertAndByteRangeFeatureCompose(t *testing.T) {
+	src := "> [!NOTE]\n> Visit https://example.com for ~~old~~ details.\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t,
+		"> Visit <https://example.com> for old details.\n", got)
+}
+
+// TestRuleFixStrikethroughWithNestedInlineSkips guards the robustness
+// of delimiterPairEdits: a wrapper containing nested inline markup
+// (emphasis, link, code span) cannot be safely unwrapped without
+// tracking each nested marker's own span, so the fix declines and the
+// diagnostic remains for the user.
+func TestRuleFixStrikethroughWithNestedInlineSkips(t *testing.T) {
+	src := "Text ~~*bold*~~ here.\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t, src, got)
+}
+
+// TestRuleFixStrikethroughWithMixedChildrenSkips exercises the
+// sibling loop in delimiterPairEdits: a wrapper whose first child is
+// Text but whose later children include nested inline markup must
+// still skip the fix.
+func TestRuleFixStrikethroughWithMixedChildrenSkips(t *testing.T) {
+	src := "Text ~~start *mid* end~~ here.\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t, src, got)
+}
+
+// TestRuleFixFlavorAnyIsNoop covers the early-out paths in Fix and
+// fixByteRangeFeatures when the flavor accepts every tracked feature.
+func TestRuleFixFlavorAnyIsNoop(t *testing.T) {
+	src := "# Head {#top}\n\nText ~~strike~~ and https://example.com\n"
+	got := fixWith(t, "any", src)
+	assert.Equal(t, src, got)
+}
+
+// TestRuleDualNodeEditsSupportedFeaturesReturnNil exercises the
+// "feature is supported" branches in dualNodeEdits for super/sub.
+// Pandoc supports every dual-parser feature so needsAnyDualFix is
+// false in real Fix calls; we invoke dualNodeEdits directly with a
+// constructed AST so the supports-branch returns are reached.
+func TestRuleDualNodeEditsSupportedFeaturesReturnNil(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"flavor": "pandoc"}))
+	assert.Nil(t, r.dualNodeEdits(nil, &ext.SuperscriptNode{}))
+	assert.Nil(t, r.dualNodeEdits(nil, &ext.SubscriptNode{}))
+}
+
+// TestApplyEditsHandlesAdjacentEdits guards the single-pass build in
+// applyEdits: adjacent edits (e.g. an opening and closing delimiter
+// of a strikethrough) must compose into a contiguous output without
+// dropping or duplicating bytes between them.
+func TestApplyEditsHandlesAdjacentEdits(t *testing.T) {
+	src := []byte("ab~~xy~~cd")
+	edits := []edit{
+		{start: 2, end: 4},                     // opening "~~"
+		{start: 6, end: 8},                     // closing "~~"
+		{start: 0, end: 0, repl: []byte("> ")}, // pure insertion at start
+	}
+	got := applyEdits(src, edits)
+	assert.Equal(t, "> abxycd", string(got))
 }

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -1,6 +1,7 @@
 package markdownflavor
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -95,15 +96,30 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	return diags
 }
 
-// Fix implements rule.FixableRule. It removes the [!TOKEN] marker line from
-// GitHub Alert blockquotes when the configured flavor does not support them.
-// If the marker is the only line in the blockquote, the whole blockquote is
-// removed.
+// Fix implements rule.FixableRule. It removes the [!TOKEN] marker line
+// from GitHub Alert blockquotes (line-level edit, runs first because
+// the lazy-continuation handling rewrites multiple lines), then falls
+// through to fixByteRangeFeatures for the six byte-range features:
+// heading IDs, strikethrough, task lists, superscript, subscript, and
+// bare-URL autolinks. Each feature is fixed only when the configured
+// flavor does not support it.
 func (r *Rule) Fix(f *lint.File) []byte {
-	if r.Flavor == flavorInvalid || r.Flavor.Supports(FeatureGitHubAlerts) {
+	if r.Flavor == flavorInvalid {
 		return f.Source
 	}
+	if !r.Flavor.Supports(FeatureGitHubAlerts) {
+		if out := r.fixGitHubAlerts(f); !bytes.Equal(out, f.Source) {
+			return out
+		}
+	}
+	return r.fixByteRangeFeatures(f)
+}
 
+// fixGitHubAlerts strips [!TOKEN] alert markers from blockquotes,
+// re-adding "> " on lazy-continuation lines so the blockquote stays
+// well-formed after the marker line goes away. If the marker is the
+// only line in the blockquote, the whole blockquote is removed.
+func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 	skip := map[int]bool{}
 	addPrefix := map[int]bool{} // lazy-continuation lines that lose blockquote context
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -96,23 +96,30 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	return diags
 }
 
-// Fix implements rule.FixableRule. It removes the [!TOKEN] marker line
-// from GitHub Alert blockquotes (line-level edit, runs first because
-// the lazy-continuation handling rewrites multiple lines), then falls
-// through to fixByteRangeFeatures for the six byte-range features:
-// heading IDs, strikethrough, task lists, superscript, subscript, and
-// bare-URL autolinks. Each feature is fixed only when the configured
-// flavor does not support it.
+// Fix implements rule.FixableRule. It first removes the [!TOKEN]
+// marker line from GitHub Alert blockquotes (line-level edit, with
+// lazy-continuation handling), then runs the byte-range fix pipeline
+// over the result for heading IDs, strikethrough, task lists,
+// superscript, subscript, and bare-URL autolinks. Each feature is
+// fixed only when the configured flavor does not support it. When
+// alerts are stripped the byte-range pass re-parses the rewritten
+// source so AST offsets match the new bytes.
 func (r *Rule) Fix(f *lint.File) []byte {
 	if r.Flavor == flavorInvalid {
 		return f.Source
 	}
+	current := f
 	if !r.Flavor.Supports(FeatureGitHubAlerts) {
-		if out := r.fixGitHubAlerts(f); !bytes.Equal(out, f.Source) {
-			return out
+		stripped := r.fixGitHubAlerts(f)
+		if !bytes.Equal(stripped, f.Source) {
+			reparsed, err := lint.NewFile(f.Path, stripped)
+			if err != nil {
+				return stripped
+			}
+			current = reparsed
 		}
 	}
-	return r.fixByteRangeFeatures(f)
+	return r.fixByteRangeFeatures(current)
 }
 
 // fixGitHubAlerts strips [!TOKEN] alert markers from blockquotes,

--- a/plan/86_markdown-flavor-validation.md
+++ b/plan/86_markdown-flavor-validation.md
@@ -1,7 +1,7 @@
 ---
 id: 86
 title: Markdown flavor validation
-status: "🔳"
+status: "✅"
 summary: >-
   New rule MDS034 that validates Markdown files against
   a declared flavor (CommonMark, GFM, Goldmark, etc.)
@@ -221,9 +221,11 @@ math, abbreviations.
       inline, and abbreviations
 - [x] Error messages name the unsupported feature and
       the configured flavor
-- [ ] `mdsmith fix` auto-fixes fixable features
-      <!-- Fix pipeline not implemented in this
-      slice. -->
+- [x] `mdsmith fix` auto-fixes fixable features
+      (heading IDs, strikethrough, task lists,
+      superscript, subscript, bare-URL autolinks
+      via `<url>` wrapping; GitHub Alerts marker
+      stripping was already implemented)
 - [x] Non-fixable features produce diagnostics only
 - [x] Invalid flavor name produces a config error
 - [x] Rule is disabled by default (opt-in)


### PR DESCRIPTION
## Summary
Implements the auto-fix functionality for the markdown flavor validation rule (MDS034), enabling `mdsmith fix` to automatically correct unsupported markdown features based on the configured flavor.

## Key Changes

- **Added `fix.go`**: New module implementing byte-range edit infrastructure for fixing six unsupported markdown features:
  - Heading IDs (removes `{#id}` attribute blocks)
  - Strikethrough (removes `~~` delimiters)
  - Task lists (removes `[x]` checkboxes while preserving bullets)
  - Superscript (removes `^` delimiters)
  - Subscript (removes `~` delimiters)
  - Bare-URL autolinks (wraps URLs in angle brackets `<url>`)

- **Updated `rule.go`**: Refactored `Fix()` method to:
  - First apply GitHub Alerts marker stripping (line-level edit)
  - Re-parse the rewritten source so AST offsets stay valid
  - Then delegate to `fixByteRangeFeatures()` for the six byte-range features in the same call
  - Only apply fixes for features unsupported by the configured flavor

- **Added comprehensive test coverage** (`fix_test.go`):
  - Tests for each fixable feature in isolation
  - Tests verifying features are preserved when the flavor supports them
  - Composition test for alerts + byte-range fixes in a single `Fix()` call
  - Multi-edit composition test ensuring two edits on the same line compose correctly
  - Graceful skip test for nested inline markup (e.g. `~~*bold*~~`)

- **Added golden test fixtures**: Six markdown files demonstrating the expected output after fixing each feature type for CommonMark flavor

## Implementation Details

`applyEdits` sorts edits by ascending start offset and builds the output in a single forward pass: it appends each unchanged span from the source, then the edit's replacement bytes, advancing a cursor across non-overlapping edits. The output buffer is pre-sized from the cumulative size delta so the build runs in O(len(src) + total edit work) without per-edit reallocation.

The dual-parser technique detects features like heading IDs and strikethrough by parsing with an extended markdown parser, while bare URLs are detected on the standard CommonMark AST to correctly skip URLs inside code spans and fences.

`delimiterPairEdits` only rewrites wrappers with a single Text child; nested inline markup (emphasis, links, code spans) declines the fix and leaves the diagnostic for the user, since locating the wrapper marker through nested children would require recursively reconstructing each child's own marker span.

The plan status for MDS034 is now marked complete (✅).

https://claude.ai/code/session_01HyTXePzdUP6WLrwX571gk8