### PR TITLE
Upgrade merge-queue-action to v0.6.0

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,7 +34,7 @@ jobs:
       actions: write
       issues: write
     steps:
-      - uses: jeduden/merge-queue-action@2b5630af6314550ba236eafb80ec4363bc67ef68 # v0.5.2
+      - uses: jeduden/merge-queue-action@5adb5a76e27e96f1da5efd36f097a2c5233e9ad3 # v0.6.0
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
## Summary
Updates the `jeduden/merge-queue-action` GitHub Action to version 0.6.0, which includes bug fixes and improvements to the merge queue workflow automation.

## Changes
- Updated `jeduden/merge-queue-action` from v0.5.2 to v0.6.0
  - Commit hash: `2b5630af6314550ba236eafb80ec4363bc67ef68` → `5adb5a76e27e96f1da5efd36f097a2c5233e9ad3`

## Details
This upgrade brings the latest improvements and fixes from the merge-queue-action project to enhance the reliability and functionality of the automated merge queue workflow.

https://claude.ai/code/session_01PQsnJQXw3Pyk8c12dxkGS3