### PR TITLE
Configure git identity before merge queue action

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -34,6 +34,16 @@ jobs:
       actions: write
       issues: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.email "merge-queue@users.noreply.github.com"
+          git config user.name  "merge-queue-bot"
+
       - uses: jeduden/merge-queue-action@5adb5a76e27e96f1da5efd36f097a2c5233e9ad3 # v0.6.0
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+          persist-credentials: false
 
       - name: Configure git identity
         run: |


### PR DESCRIPTION
## Summary
Added git configuration and repository checkout steps to the merge queue workflow before executing the merge queue action.

## Key Changes
- Added `actions/checkout` step with full history (`fetch-depth: 0`) and custom token authentication
- Added git configuration step to set user email and name for the merge-queue-bot identity

## Implementation Details
These preparatory steps ensure that the merge queue action has:
- A properly checked out repository with full git history available
- Configured git user identity (`merge-queue@users.noreply.github.com` / `merge-queue-bot`) for any git operations that may be performed during the merge queue process
- Authentication via the `MERGE_QUEUE_TOKEN` secret for both checkout and subsequent operations

https://claude.ai/code/session_014hGMbN9kAK6NJWKkEXirHx