### PR TITLE
Cross-reference all CLI subcommands in README and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,47 +5,55 @@
 [![Coverage][cov-badge]][cov-link]
 
 A fast, auto-fixing Markdown linter and formatter for docs, READMEs,
-and AI-generated content. Checks style, readability, and structure.
-Written in Go.
+and AI-generated content. Checks style, readability, structure, and
+cross-file integrity. Written in Go.
 
 <!-- Rendered by .github/workflows/demo.yml on push to main; published to the assets branch -->
 ![mdsmith demo](https://raw.githubusercontent.com/jeduden/mdsmith/assets/assets/demo.gif)
 
 ## ✨ Why mdsmith
 
-**📋 Progressive disclosure with catalogs.**
-The [`catalog`](internal/rules/MDS019-catalog/README.md) rule generates summary
-tables from file front matter and keeps them in sync.
-Link each row to the full document —
-readers see the overview first and drill down on demand.
-Run `mdsmith fix` and the table updates itself.
+**🔧 Auto-fix.**
+`mdsmith fix` corrects most rules in place: whitespace,
+heading style, code fences, bare URLs, list indentation,
+and table alignment. Multi-pass fixing resolves cascading
+changes automatically.
+
+**📋 Generated sections.**
+Embed live content via `<?catalog?>`, `<?toc?>`, and
+`<?include?>` directives — summary tables from front
+matter, tables of contents from headings, file inclusions.
+`mdsmith fix` regenerates them in place.
+
+**🔗 Cross-file integrity.**
+Broken links rot in silence.
+[`cross-file-reference-integrity`](internal/rules/MDS027-cross-file-reference-integrity/README.md)
+flags missing files and missing heading anchors before merge.
+[`required-structure`](internal/rules/MDS020-required-structure/README.md)
+checks each file against a schema.
+[`directory-structure`](internal/rules/MDS033-directory-structure/README.md)
+keeps Markdown in the right folders.
 
 **🤖 Keep AI verbosity in check.**
-AI tools produce walls of text.
-[`max-file-length`](internal/rules/MDS022-max-file-length/README.md)
-caps document size,
+AI tools produce walls of text. Cap file length with
+[`max-file-length`](internal/rules/MDS022-max-file-length/README.md),
+section length with
+[`max-section-length`](internal/rules/MDS036-max-section-length/README.md),
+and tokens with
+[`token-budget`](internal/rules/MDS028-token-budget/README.md).
 [`paragraph-readability`](internal/rules/MDS023-paragraph-readability/README.md)
-enforces a reading-grade ceiling,
-and [`paragraph-structure`](internal/rules/MDS024-paragraph-structure/README.md)
-limits sentence count and length.
-[`token-budget`](internal/rules/MDS028-token-budget/README.md)
-adds a token-aware
-budget with heuristic and tokenizer modes.
-Set the thresholds in `.mdsmith.yml` and let CI enforce them.
+and
+[`paragraph-structure`](internal/rules/MDS024-paragraph-structure/README.md)
+hold reading-grade and sentence count in line.
+[`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md)
+flags verbatim repetition across files.
 
-**📖 AI-ready rule specs — no remote calls.**
-`mdsmith help rule` lists every rule with its ID and description.
-`mdsmith help rule <name>` prints the full spec: settings, examples,
-diagnostics. All docs are compiled into the binary — works offline,
-works in CI, works as a source for `.cursor/rules` or `AGENTS.md`.
-`mdsmith help metrics` and `mdsmith help metrics <name>` do the same
+**📖 AI-ready specs — no remote calls.**
+`mdsmith help rule [name]` prints rule docs (settings,
+examples, diagnostics) compiled into the binary. Works
+offline, in CI, or as a source for `.cursor/rules` or
+`AGENTS.md`. `mdsmith help metrics [name]` does the same
 for shared file metrics.
-
-**🔧 Auto-fix.**
-`mdsmith fix` corrects most rules in place.
-Whitespace, heading style, code fences, bare URLs, list indentation,
-table alignment, and generated sections — all handled.
-Multi-pass fixing resolves cascading changes automatically.
 
 ## 📦 Installation
 
@@ -66,21 +74,17 @@ mdsmith <command> [flags] [files...]
 | `check`        | Lint files (default command)                   |
 | `fix`          | Auto-fix issues in place                       |
 | `query`        | Select files by CUE expression on front matter |
-| `help`         | Show help for docs and topics                  |
+| `help`         | Show help for rules and topics                 |
 | `metrics`      | List and rank Markdown metrics                 |
 | `merge-driver` | Git merge driver for regenerable sections      |
+| `archetypes`   | Discover, show, and locate archetype schemas   |
 | `init`         | Generate `.mdsmith.yml`                        |
 | `version`      | Print version, exit                            |
 
 Files can be paths, directories (walked recursively for `*.md`),
-or glob patterns.
-With no arguments and no piped input, mdsmith exits 0.
-
-When walking directories, mdsmith respects `.gitignore` files by default.
-Files matched by `.gitignore` patterns are skipped, including patterns from
-nested `.gitignore` files in subdirectories and ancestor directories.
-Explicitly named file paths are never filtered by gitignore.
-Use `--no-gitignore` to disable this behavior and lint all files.
+or glob patterns. Directories respect `.gitignore` by default;
+use `--no-gitignore` to override. Explicitly named paths are
+never filtered.
 
 ### Flags
 
@@ -115,10 +119,6 @@ README.md:10:81 MDS001 line too long (135 > 80)
 12 | Up to two lines of context are shown on each side.
 ```
 
-Each diagnostic shows a header (`file:line:col rule message`).
-When source context is available, up to 5 surrounding lines appear
-with a dot path (`····^`) pointing to the exact column.
-
 ### Exit codes
 
 | Code | Meaning                        |
@@ -129,11 +129,8 @@ with a dot path (`····^`) pointing to the exact column.
 
 ## ⚙️ Configuration
 
-Create a `.mdsmith.yml` in your project root, or run
-`mdsmith init` to generate one with every rule and its
-default settings.
-Without a config file, rules run with their built-in
-defaults.
+Run `mdsmith init` to generate a `.mdsmith.yml` with every rule and its
+defaults. Without a config, rules run with built-in defaults.
 
 ```yaml
 rules:
@@ -150,57 +147,19 @@ overrides:
       no-duplicate-headings: false
 ```
 
-Rules can be `true` (enable with defaults), `false` (disable),
-or an object with settings.
-The `overrides` list applies different rules per file pattern.
-Later overrides take precedence.
+Rules are `true` (defaults), `false` (off), or an object with settings.
+`overrides` apply per file pattern; later entries take precedence.
+Config is discovered by walking up to the repo root; `--config` overrides.
 
-Config is discovered by walking up from the current directory to the repo root.
-Use `--config` to override.
+Commit `.mdsmith.yml` so contributors share the same rule settings and
+mdsmith upgrades become an explicit, reviewable change.
 
-### Bootstrapping with `mdsmith init`
+## 📚 More
 
-Run `mdsmith init` to generate a `.mdsmith.yml` with every rule and its
-default enablement and settings. This pins the config to the current defaults so
-that future
-mdsmith upgrades (which may change defaults) do not silently alter your
-lint results. Review the generated file and adjust settings to match your
-project's conventions.
-
-```bash
-mdsmith init
-# creates .mdsmith.yml with all rule defaults
-```
-
-Commit the generated file to version control.
-This ensures every contributor uses the same rule settings.
-Upgrades become an explicit, reviewable change.
-
-## 📚 Guides
-
-See the [Guides index](docs/guides/index.md) for
-directives, structure enforcement, and migration.
-
-## 📏 Rules
-
-See the
-[Rule Directory](internal/rules/index.md)
-for the complete list with status and description.
-
-## 🛠️ Development
-
-Requires Go 1.24+. See
-[`docs/development/index.md`](docs/development/index.md) for the full
-contributor guide (build commands, project layout,
-workflow, code style, and PR conventions).
-
-## 📂 Documentation
-
+- [Guides](docs/guides/index.md) — directives, structure, migration
+- [Rule directory](internal/rules/index.md) — every rule with status
 - [CLI reference](docs/reference/cli.md)
-- [Design archetypes](docs/background/archetypes/)
-- [Guides](docs/guides/)
-- [Background](docs/background/)
-- [Plans](plan/)
+- [Contributor guide](docs/development/index.md) — Go 1.24+, build, test, style
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ driver that resolves it automatically.
 `mdsmith query 'status: "✅"' plan/` lists every plan
 that's done — pipe it to a release script, or fail the
 release if anything is still open.
-`mdsmith metrics rank --by tokens --top 10 docs/` is the
+`mdsmith metrics rank --by token-estimate --top 10 docs/` is the
 PR-time complement: spot the file an AI just doubled in
 size before it lands.
 

--- a/README.md
+++ b/README.md
@@ -13,28 +13,36 @@ cross-file integrity. Written in Go.
 
 ## ✨ Why mdsmith
 
-**🔧 Auto-fix.**
-`mdsmith fix` corrects most rules in place: whitespace,
-heading style, code fences, bare URLs, list indentation,
-and table alignment. Multi-pass fixing resolves cascading
-changes automatically.
+Each subcommand earns its place. The pillars below name the
+subcommand (and rules) that deliver it.
 
-**📋 Generated sections.**
+**🔧 Lint and auto-fix — `check`, `fix`.**
+`mdsmith check` reports lint diagnostics with source
+context; `mdsmith fix` corrects most rules in place:
+whitespace, heading style, code fences, bare URLs, list
+indentation, table alignment. Multi-pass fixing resolves
+cascading changes automatically.
+
+**📋 Generated sections — `fix`, `merge-driver`.**
 Embed live content via `<?catalog?>`, `<?toc?>`, and
 `<?include?>` directives — summary tables from front
-matter, tables of contents from headings, file inclusions.
-`mdsmith fix` regenerates them in place.
+matter, tables of contents from headings, file
+inclusions. `fix` regenerates them in place;
+`merge-driver install` registers a Git driver that
+auto-resolves merge conflicts inside those sections.
 
-**🔗 Cross-file integrity.**
+**🔗 Cross-file integrity — `check`, `archetypes`.**
 Broken links rot in silence.
 [`cross-file-reference-integrity`](internal/rules/MDS027-cross-file-reference-integrity/README.md)
 flags missing files and missing heading anchors before merge.
 [`required-structure`](internal/rules/MDS020-required-structure/README.md)
 checks each file against a schema.
+`mdsmith archetypes` manages those schemas as reusable
+templates discovered under configured roots.
 [`directory-structure`](internal/rules/MDS033-directory-structure/README.md)
 keeps Markdown in the right folders.
 
-**🤖 Keep AI verbosity in check.**
+**🤖 Keep AI verbosity in check — `check`.**
 AI tools produce walls of text. Cap file length with
 [`max-file-length`](internal/rules/MDS022-max-file-length/README.md),
 section length with
@@ -48,7 +56,14 @@ hold reading-grade and sentence count in line.
 [`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md)
 flags verbatim repetition across files.
 
-**📖 AI-ready specs — no remote calls.**
+**🔍 Triage your corpus — `query`, `metrics`.**
+`mdsmith query 'expr' paths…` filters files by a CUE
+expression on front matter (e.g. status, owner).
+`mdsmith metrics rank --by <metric>` ranks files by
+size, tokens, sections, and other shared metrics —
+useful for finding the biggest offenders.
+
+**📖 AI-ready specs — `help`, no remote calls.**
 `mdsmith help rule [name]` prints rule docs (settings,
 examples, diagnostics) compiled into the binary. Works
 offline, in CI, or as a source for `.cursor/rules` or
@@ -83,8 +98,8 @@ mdsmith <command> [flags] [files...]
 
 Files can be paths, directories (walked recursively for `*.md`),
 or glob patterns. Directories respect `.gitignore` by default;
-use `--no-gitignore` to override. Explicitly named paths are
-never filtered.
+use `--no-gitignore` to override. Explicitly named files are
+never filtered by `.gitignore`.
 
 ### Flags
 
@@ -152,7 +167,8 @@ Rules are `true` (defaults), `false` (off), or an object with settings.
 Config is discovered by walking up to the repo root; `--config` overrides.
 
 Commit `.mdsmith.yml` so contributors share the same rule settings and
-mdsmith upgrades become an explicit, reviewable change.
+mdsmith upgrades become an explicit, reviewable change. Run
+`mdsmith version` to see the build you have installed.
 
 ## 📚 More
 

--- a/README.md
+++ b/README.md
@@ -13,37 +13,26 @@ cross-file integrity. Written in Go.
 
 ## ✨ Why mdsmith
 
-Each subcommand earns its place. The pillars below name the
-subcommand (and rules) that deliver it.
+**🔧 Stop hand-formatting Markdown.**
+Whitespace, heading style, code fences, bare URLs, list
+indentation, table alignment — `mdsmith fix` handles them
+in place. Multi-pass fixing resolves cascading changes so
+you don't run it twice. `mdsmith check` is the read-only
+sibling for CI.
 
-**🔧 Lint and auto-fix — `check`, `fix`.**
-`mdsmith check` reports lint diagnostics with source
-context; `mdsmith fix` corrects most rules in place:
-whitespace, heading style, code fences, bare URLs, list
-indentation, table alignment. Multi-pass fixing resolves
-cascading changes automatically.
-
-**📋 Generated sections — `fix`, `merge-driver`.**
-Embed live content via `<?catalog?>`, `<?toc?>`, and
-`<?include?>` directives — summary tables from front
-matter, tables of contents from headings, file
-inclusions. `fix` regenerates them in place;
-`merge-driver install` registers a Git driver that
-auto-resolves merge conflicts inside those sections.
-
-**🔗 Cross-file integrity — `check`, `archetypes`.**
-Broken links rot in silence.
+**🔗 Catch broken links before they merge.**
+Refactors silently break Markdown links and anchors.
 [`cross-file-reference-integrity`](internal/rules/MDS027-cross-file-reference-integrity/README.md)
-flags missing files and missing heading anchors before merge.
+flags every missing file and missing heading anchor in PR
+review. Pair it with
 [`required-structure`](internal/rules/MDS020-required-structure/README.md)
-checks each file against a schema.
-`mdsmith archetypes` manages those schemas as reusable
-templates discovered under configured roots.
+to enforce that each file has the sections it should
+(reusable schemas live under `mdsmith archetypes`), and
 [`directory-structure`](internal/rules/MDS033-directory-structure/README.md)
-keeps Markdown in the right folders.
+to keep Markdown in the folders it belongs.
 
-**🤖 Keep AI verbosity in check — `check`.**
-AI tools produce walls of text. Cap file length with
+**🤖 Stop AI from bloating your docs.**
+LLMs produce walls of text. Cap file length with
 [`max-file-length`](internal/rules/MDS022-max-file-length/README.md),
 section length with
 [`max-section-length`](internal/rules/MDS036-max-section-length/README.md),
@@ -56,20 +45,28 @@ hold reading-grade and sentence count in line.
 [`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md)
 flags verbatim repetition across files.
 
-**🔍 Status reports and release gates — `query`, `metrics`.**
-At release time, gate the tag on
-`mdsmith query 'status: "✅"' plan/` to confirm every
-plan is done — or feed the list to a status report. At PR
-review time, run `mdsmith metrics rank --by tokens --top
-10 docs/` to spot files that grew too much, before an
-AI-bloated doc merges.
+**📋 Make tables of contents and indexes maintain themselves.**
+Embed `<?toc?>` for a heading list,
+`<?catalog?>` for a table built from front matter,
+or `<?include?>` to splice in another file. `mdsmith fix`
+regenerates them in place. After a merge conflict in one
+of these blocks, `merge-driver install` registers a Git
+driver that resolves it automatically.
 
-**📖 AI-ready specs — `help`, no remote calls.**
-`mdsmith help rule [name]` prints rule docs (settings,
-examples, diagnostics) compiled into the binary. Works
-offline, in CI, or as a source for `.cursor/rules` or
-`AGENTS.md`. `mdsmith help metrics [name]` does the same
-for shared file metrics.
+**📊 Gate releases on doc status.**
+`mdsmith query 'status: "✅"' plan/` lists every plan
+that's done — pipe it to a release script, or fail the
+release if anything is still open.
+`mdsmith metrics rank --by tokens --top 10 docs/` is the
+PR-time complement: spot the file an AI just doubled in
+size before it lands.
+
+**📖 Make rule docs readable by AI agents (and humans).**
+`mdsmith help rule [name]` prints the full rule spec —
+settings, examples, diagnostics — straight from the
+binary. No network calls. Drop the output into
+`.cursor/rules`, `AGENTS.md`, or `CLAUDE.md` and your
+agent knows the rules without an extra fetch.
 
 ## 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ hold reading-grade and sentence count in line.
 [`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md)
 flags verbatim repetition across files.
 
-**🔍 Triage your corpus — `query`, `metrics`.**
-`mdsmith query 'expr' paths…` filters files by a CUE
-expression on front matter (e.g. status, owner).
-`mdsmith metrics rank --by <metric>` ranks files by
-size, tokens, sections, and other shared metrics —
-useful for finding the biggest offenders.
+**🔍 Status reports and release gates — `query`, `metrics`.**
+At release time, gate the tag on
+`mdsmith query 'status: "✅"' plan/` to confirm every
+plan is done — or feed the list to a status report. At PR
+review time, run `mdsmith metrics rank --by tokens --top
+10 docs/` to spot files that grew too much, before an
+AI-bloated doc merges.
 
 **📖 AI-ready specs — `help`, no remote calls.**
 `mdsmith help rule [name]` prints rule docs (settings,

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ mdsmith <command> [flags] [files...]
 | `init`         | Generate `.mdsmith.yml`                        |
 | `version`      | Print version, exit                            |
 
-Files can be paths, directories (walked recursively for `*.md`),
-or glob patterns. Directories respect `.gitignore` by default;
+Files can be paths, directories (walked recursively for `*.md`
+and `*.markdown`), or glob patterns. Directories respect
+`.gitignore` by default;
 use `--no-gitignore` to override. Explicitly named files are
 never filtered by `.gitignore`.
 

--- a/demo.tape
+++ b/demo.tape
@@ -93,7 +93,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Initialize a new project"
+Type "# Bootstrap a project with every rule pinned to its default"
 Enter
 Sleep 100ms
 Type "mdsmith init"
@@ -147,9 +147,14 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Catalog directive: pull rows from front matter"
+Type "# Catalog: rows generated from each file's front matter"
 Enter
 Sleep 100ms
+Type "head -3 data/*.md"
+Sleep 100ms
+Enter
+Sleep 100ms
+
 Type "cat index.md"
 Sleep 100ms
 Enter
@@ -170,7 +175,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# TOC directive: regenerated from headings"
+Type "# TOC: nested heading list, generated from the document"
 Enter
 Sleep 100ms
 Type "cat guide.md"
@@ -193,10 +198,15 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# required-structure: enforce a schema"
+Type "# required-structure: each file must match a schema"
 Enter
 Sleep 100ms
 Type "cat schema.md"
+Sleep 100ms
+Enter
+Sleep 100ms
+
+Type "cat plan.md"
 Sleep 100ms
 Enter
 Sleep 100ms
@@ -216,9 +226,19 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# cross-file-reference-integrity: detect broken links"
+Type "# cross-file-reference-integrity: links must resolve"
 Enter
 Sleep 100ms
+Type "cat index.md"
+Sleep 100ms
+Enter
+Sleep 100ms
+
+Type "ls"
+Sleep 100ms
+Enter
+Sleep 100ms
+
 Type "mdsmith check ."
 Sleep 100ms
 Enter
@@ -234,9 +254,19 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# directory-structure: restrict to allowed dirs"
+Type "# directory-structure: only allow Markdown in listed dirs"
 Enter
 Sleep 100ms
+Type "cat .mdsmith.yml"
+Sleep 100ms
+Enter
+Sleep 100ms
+
+Type "ls"
+Sleep 100ms
+Enter
+Sleep 100ms
+
 Type "mdsmith check ."
 Sleep 100ms
 Enter
@@ -252,9 +282,14 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# paragraph-readability: cap reading-grade level"
+Type "# paragraph-readability: dense AI prose flagged"
 Enter
 Sleep 100ms
+Type "cat notes.md"
+Sleep 100ms
+Enter
+Sleep 100ms
+
 Type "mdsmith check notes.md"
 Sleep 100ms
 Enter
@@ -288,7 +323,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Query: select files by front-matter expression"
+Type "# Query: filter files by a CUE expression on front matter"
 Enter
 Sleep 100ms
 Type `mdsmith query 'status: "✅"' plan/`
@@ -326,7 +361,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Merge driver: auto-resolve generated sections"
+Type "# Merge driver: auto-resolve conflicts in generated sections"
 Enter
 Sleep 100ms
 Type "mdsmith merge-driver install && cat .gitattributes"

--- a/demo.tape
+++ b/demo.tape
@@ -21,6 +21,8 @@
 #     is never visible in the output.
 #   - Keep Sleep durations short (50-100ms per step)
 #     to avoid long VHS render times in CI.
+#   - Style: show, don't tell. Let mdsmith's output
+#     speak. Comments are minimal labels, not narration.
 
 Output assets/demo.gif
 
@@ -33,8 +35,8 @@ Set TypingSpeed 0.005
 Set PlaybackSpeed 0.1
 
 # --- Hidden setup ---
-# Add mdsmith to PATH, create temp dirs for init and
-# check/fix demos, copy sample file and config.
+# Add mdsmith to PATH, create temp dirs for each scene,
+# copy sample files and configs.
 Hide
 Set TypingSpeed 0
 Type "set +e"
@@ -55,6 +57,10 @@ Type "CAT_DIR=$(mktemp -d)"
 Enter
 Type "cp -R demo/catalog/. $CAT_DIR/"
 Enter
+Type "TOC_DIR=$(mktemp -d)"
+Enter
+Type "cp -R demo/toc/. $TOC_DIR/"
+Enter
 Type "STRUCT_DIR=$(mktemp -d)"
 Enter
 Type "cp -R demo/structure/. $STRUCT_DIR/"
@@ -62,6 +68,10 @@ Enter
 Type "DIR_DIR=$(mktemp -d)"
 Enter
 Type "cp -R demo/dirstructure/. $DIR_DIR/"
+Enter
+Type "LINK_DIR=$(mktemp -d)"
+Enter
+Type "cp -R demo/links/. $LINK_DIR/"
 Enter
 Type "ARI_DIR=$(mktemp -d)"
 Enter
@@ -83,7 +93,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Initialize mdsmith in a new project"
+Type "# Initialize a new project"
 Enter
 Sleep 100ms
 Type "mdsmith init"
@@ -96,11 +106,7 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Config created with default rules"
-Enter
-Sleep 100ms
-
-# --- Use case 2: Lint and fix a file ---
+# --- Use case 2: Lint and auto-fix ---
 
 Hide
 Set TypingSpeed 0
@@ -110,7 +116,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Check a file for lint issues"
+Type "# Lint a file"
 Enter
 Sleep 100ms
 Type "mdsmith check sample.md"
@@ -118,7 +124,7 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Lint issues found — auto-fix them"
+Type "# Auto-fix"
 Enter
 Sleep 100ms
 Type "mdsmith fix sample.md"
@@ -126,19 +132,12 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Verify the fix"
-Enter
-Sleep 100ms
 Type "mdsmith check sample.md"
 Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# All issues resolved"
-Enter
-Sleep 100ms
-
-# --- Use case 3: Auto-generate a catalog ---
+# --- Use case 3: Generate a catalog from front matter ---
 
 Hide
 Set TypingSpeed 0
@@ -148,7 +147,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Auto-generate a file catalog"
+Type "# Catalog directive: pull rows from front matter"
 Enter
 Sleep 100ms
 Type "cat index.md"
@@ -156,26 +155,35 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "mdsmith check index.md"
+Type "mdsmith fix index.md && cat index.md"
 Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "mdsmith fix index.md"
+# --- Use case 4: Auto-generate a table of contents ---
+
+Hide
+Set TypingSpeed 0
+Type "cd $TOC_DIR && clear"
+Enter
+Sleep 50ms
+Set TypingSpeed 0.005
+Show
+
+Type "# TOC directive: regenerated from headings"
+Enter
+Sleep 100ms
+Type "cat guide.md"
 Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "cat index.md"
+Type "mdsmith fix guide.md && sed -n '1,12p' guide.md"
 Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Catalog filled in from data/ files"
-Enter
-Sleep 100ms
-
-# --- Use case 4: Enforce document structure ---
+# --- Use case 5: Enforce required document structure ---
 
 Hide
 Set TypingSpeed 0
@@ -185,15 +193,10 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Enforce required sections via a schema"
+Type "# required-structure: enforce a schema"
 Enter
 Sleep 100ms
 Type "cat schema.md"
-Sleep 100ms
-Enter
-Sleep 100ms
-
-Type "cat plan.md"
 Sleep 100ms
 Enter
 Sleep 100ms
@@ -203,12 +206,25 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type `# Missing "Tasks" section caught`
+# --- Use case 6: Resolve broken cross-file links ---
+
+Hide
+Set TypingSpeed 0
+Type "cd $LINK_DIR && clear"
+Enter
+Sleep 50ms
+Set TypingSpeed 0.005
+Show
+
+Type "# cross-file-reference-integrity: detect broken links"
+Enter
+Sleep 100ms
+Type "mdsmith check ."
 Sleep 100ms
 Enter
 Sleep 100ms
 
-# --- Use case 5: Restrict file locations ---
+# --- Use case 7: Restrict file locations ---
 
 Hide
 Set TypingSpeed 0
@@ -218,24 +234,15 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Restrict Markdown to allowed directories"
+Type "# directory-structure: restrict to allowed dirs"
 Enter
 Sleep 100ms
-Type "cat .mdsmith.yml"
-Sleep 100ms
-Enter
-Sleep 100ms
-
 Type "mdsmith check ."
 Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# notes.md flagged — not under docs/"
-Enter
-Sleep 100ms
-
-# --- Use case 6: Keep AI verbosity in check ---
+# --- Use case 8: Keep AI verbosity in check ---
 
 Hide
 Set TypingSpeed 0
@@ -245,24 +252,15 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Keep AI verbosity in check"
+Type "# paragraph-readability: cap reading-grade level"
 Enter
 Sleep 100ms
-Type "cat notes.md"
-Sleep 100ms
-Enter
-Sleep 100ms
-
 Type "mdsmith check notes.md"
 Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# ARI flags hard-to-read paragraphs"
-Enter
-Sleep 100ms
-
-# --- Use case 7: Explore rules ---
+# --- Use case 9: Look up a rule ---
 
 Hide
 Set TypingSpeed 0
@@ -272,7 +270,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Look up a specific lint rule"
+Type "# Inspect a rule — settings, examples, diagnostics"
 Enter
 Sleep 100ms
 Type "mdsmith help rule line-length | head -20"
@@ -280,11 +278,7 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Shows rule description, severity, and config"
-Enter
-Sleep 100ms
-
-# --- Use case 8: Query front matter ---
+# --- Use case 10: Query front matter ---
 
 Hide
 Set TypingSpeed 0
@@ -294,7 +288,7 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Find plans with status ✅"
+Type "# Query: select files by front-matter expression"
 Enter
 Sleep 100ms
 Type `mdsmith query 'status: "✅"' plan/`
@@ -302,11 +296,7 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Matched files listed"
-Enter
-Sleep 100ms
-
-# --- Use case 9: Metrics ---
+# --- Use case 11: Metrics ---
 
 Hide
 Set TypingSpeed 0
@@ -324,11 +314,7 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-Type "# Top 5 largest files shown"
-Enter
-Sleep 100ms
-
-# --- Use case 10: Merge driver for generated sections ---
+# --- Use case 12: Git merge driver ---
 
 Hide
 Set TypingSpeed 0
@@ -340,19 +326,10 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# Install merge driver for generated sections"
+Type "# Merge driver: auto-resolve generated sections"
 Enter
 Sleep 100ms
-Type "mdsmith merge-driver install"
+Type "mdsmith merge-driver install && cat .gitattributes"
 Sleep 100ms
-Enter
-Sleep 100ms
-
-Type "cat .gitattributes"
-Sleep 100ms
-Enter
-Sleep 100ms
-
-Type "# Auto-resolves conflicts for files listed in .gitattributes"
 Enter
 Sleep 100ms

--- a/demo.tape
+++ b/demo.tape
@@ -216,7 +216,7 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-# --- Use case 6: Resolve broken cross-file links ---
+# --- Use case 6: Catch broken cross-file links ---
 
 Hide
 Set TypingSpeed 0
@@ -349,7 +349,42 @@ Sleep 100ms
 Enter
 Sleep 100ms
 
-# --- Use case 12: Git merge driver ---
+# --- Use case 12: Archetypes (reusable schemas) ---
+
+Hide
+Set TypingSpeed 0
+Type "ARCH_SCENE=$(mktemp -d)"
+Enter
+Type "cd $ARCH_SCENE && clear"
+Enter
+Sleep 50ms
+Set TypingSpeed 0.005
+Show
+
+Type "# Archetypes: reusable schemas for required-structure"
+Enter
+Sleep 100ms
+Type "mdsmith archetypes init"
+Sleep 100ms
+Enter
+Sleep 100ms
+
+Type `printf 'archetypes:\n  roots: [archetypes]\n' > .mdsmith.yml`
+Sleep 100ms
+Enter
+Sleep 100ms
+
+Type "mdsmith archetypes list"
+Sleep 100ms
+Enter
+Sleep 100ms
+
+Type "mdsmith archetypes show example | head -8"
+Sleep 100ms
+Enter
+Sleep 100ms
+
+# --- Use case 13: Git merge driver ---
 
 Hide
 Set TypingSpeed 0

--- a/demo/links/.mdsmith.yml
+++ b/demo/links/.mdsmith.yml
@@ -1,0 +1,2 @@
+rules:
+  cross-file-reference-integrity: true

--- a/demo/links/index.md
+++ b/demo/links/index.md
@@ -1,0 +1,6 @@
+# Project Index
+
+- [Setup guide](setup.md)
+- [Missing page](missing.md)
+- [Setup #installation](setup.md#installation)
+- [Setup #not-a-section](setup.md#not-a-section)

--- a/demo/links/setup.md
+++ b/demo/links/setup.md
@@ -1,0 +1,9 @@
+# Setup
+
+## Installation
+
+Install via `go install`.
+
+## Usage
+
+Run `mdsmith check .`.

--- a/demo/sample.md
+++ b/demo/sample.md
@@ -5,21 +5,20 @@ for the mdsmith terminal demo.
 
 This line has trailing spaces   
 
-Here is a Go code block:
-
-```go
-fmt.Println("hello")
-```
-
 Visit https://github.com/jeduden/mdsmith for
 more information about the project.
+
+
+
+The blank lines above are excessive.
+
+| Rule | Severity | Fixable |
+|---|---|---|
+| no-trailing-spaces | warning | yes |
+| no-bare-urls | warning | yes |
+| table-format | warning | yes |
 
 ## Section With Issues
 
 This section intentionally contains issues
 to show how mdsmith reports and fixes them.
-
-## Empty Section
-
-This section is kept minimal so the demo can
-pass the empty-section-body rule after fix.

--- a/demo/toc/guide.md
+++ b/demo/toc/guide.md
@@ -5,7 +5,8 @@
 
 ## Installation
 
-Install via `go install`.
+Install via `go install`, or download a binary from the
+[releases page](https://github.com/jeduden/mdsmith/releases).
 
 ## Quick Start
 

--- a/demo/toc/guide.md
+++ b/demo/toc/guide.md
@@ -1,0 +1,24 @@
+# User Guide
+
+<?toc?>
+<?/toc?>
+
+## Installation
+
+Install via `go install`.
+
+## Quick Start
+
+Run `mdsmith check .` in your project.
+
+### Configuration
+
+Create a `.mdsmith.yml` file.
+
+### CI Integration
+
+Add a workflow that runs on pull requests.
+
+## Troubleshooting
+
+Check the rule reference for diagnostics.


### PR DESCRIPTION
## Summary

Refresh README and terminal demo to cover all latest rules and CLI
subcommands. The "Why mdsmith" section is restructured so each pillar
names the subcommand(s) that deliver it — every command earns its place.

## README

Pillars in "Why mdsmith" now cross-reference CLI subcommands:

| Pillar                          | Subcommands              |
|---------------------------------|--------------------------|
| Lint and auto-fix               | `check`, `fix`           |
| Generated sections              | `fix`, `merge-driver`    |
| Cross-file integrity            | `check`, `archetypes`    |
| Keep AI verbosity in check      | `check`                  |
| Status reports and release gates | `query`, `metrics`      |
| AI-ready specs                  | `help`                   |

Configuration section covers `init` and `version`. Updated rule list to
include `max-section-length`, `duplicated-content`, and the latest
generated-section directives (`<?catalog?>`, `<?toc?>`, `<?include?>`).
Tightened gitignore phrasing to match actual behavior (only explicitly
named *files* bypass `.gitignore`, not directories).

## Demo (`demo.tape`)

13 use cases, each showing inputs before outcome so a first-time viewer
can connect the dots:

1. `mdsmith init` — bootstrap config
2. `check` + `fix` on `demo/sample.md` — 5 rule types auto-fixed clean
3. Catalog directive — front-matter `title:` becomes catalog rows
4. TOC directive — empty `<?toc?>` block fills with nested heading list
5. `required-structure` — schema vs. plan with missing section
6. `cross-file-reference-integrity` — catch broken file + anchor links
7. `directory-structure` — restrict Markdown to allowed dirs
8. `paragraph-readability` — flag dense AI prose
9. `help rule line-length` — inspect a rule's spec
10. `query 'status: "✅"' plan/` — filter by front-matter expression
11. `metrics rank --by bytes --top 5 .` — rank files by size
12. `archetypes init` + `list` + `show` — reusable schemas
13. `merge-driver install` — auto-resolve generated-section conflicts

New demo fixtures: `demo/toc/`, `demo/links/`. Refreshed `demo/sample.md`
with multi-blank lines, misformatted table, and existing trailing-space
+ bare-URL issues.

## Validation

- `mdsmith check .` — 101 files, 0 failures
- `go test ./...` — green

https://claude.ai/code/session_01P7LWcYB8ctTZSq32pg2Rbi