### PR TITLE
Add placeholder grammar support for template content

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,7 @@ row: "- [{summary}](../{filename})"
 ?>
 - [How generated sections work — markers, directives, and fix behavior.](../docs/background/archetypes/generated-section/README.md)
 - [Shared patterns (archetypes) reused across multiple linting rules.](../docs/background/archetypes/README.md)
+- [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](../docs/background/concepts/placeholder-grammar.md)
 - [Comparison of mdsmith with other Markdown linters and formatters.](../docs/background/markdown-linters.md)
 - [Codecov coverage gate and CI status checks.](../docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](../docs/development/file-placement.md)

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -70,6 +70,7 @@ rules:
       - "demo/**"
       - "internal/rules/**"
       - "internal/metrics/**"
+      - "internal/concepts/**"
       - ".claude/**"
       - ".github/**"
   catalog: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ row: "- [{summary}]({filename})"
 ?>
 - [How generated sections work — markers, directives, and fix behavior.](docs/background/archetypes/generated-section/README.md)
 - [Shared patterns (archetypes) reused across multiple linting rules.](docs/background/archetypes/README.md)
+- [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](docs/background/concepts/placeholder-grammar.md)
 - [Comparison of mdsmith with other Markdown linters and formatters.](docs/background/markdown-linters.md)
 - [Codecov coverage gate and CI status checks.](docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](docs/development/file-placement.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ row: "- [{summary}]({filename})"
 ?>
 - [How generated sections work — markers, directives, and fix behavior.](docs/background/archetypes/generated-section/README.md)
 - [Shared patterns (archetypes) reused across multiple linting rules.](docs/background/archetypes/README.md)
+- [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](docs/background/concepts/placeholder-grammar.md)
 - [Comparison of mdsmith with other Markdown linters and formatters.](docs/background/markdown-linters.md)
 - [Codecov coverage gate and CI status checks.](docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](docs/development/file-placement.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -28,7 +28,7 @@ footer: |
 | 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)      |
 | 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)       |
 | 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                               |
-| 93  | 🔲     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                      |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                      |
 | 94  | 🔲     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)              |
 | 95  | 🔲     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)     |
 | 96  | 🔲     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -11,6 +11,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 
+	"github.com/jeduden/mdsmith/internal/concepts"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/discovery"
 	"github.com/jeduden/mdsmith/internal/engine"
@@ -1033,9 +1034,10 @@ func printDeprecations(cfg *config.Config) {
 const helpUsageText = `Usage: mdsmith help <topic>
 
 Topics:
-  rule [id|name]      Show rule documentation
-  metrics [id|name]   Show metric documentation
-  kinds               Show concept page for file kinds
+  rule [id|name]        Show rule documentation
+  metrics [id|name]     Show metric documentation
+  kinds                 Show concept page for file kinds
+  placeholder-grammar   Show placeholder vocabulary reference
 `
 
 // runHelp implements the "help" subcommand.
@@ -1052,6 +1054,8 @@ func runHelp(args []string) int {
 		return runHelpMetrics(args[1:])
 	case "kinds":
 		return runHelpKinds()
+	case "placeholder-grammar":
+		return runHelpConcept("placeholder-grammar")
 	default:
 		fmt.Fprintf(os.Stderr, "mdsmith: help: unknown topic %q\n", args[0])
 		return 2
@@ -1119,6 +1123,17 @@ Rules never reference kind names. New kinds cannot regress existing behavior.
 // runHelpKinds prints the kinds concept page.
 func runHelpKinds() int {
 	fmt.Print(helpKindsText)
+	return 0
+}
+
+// runHelpConcept prints the named concept page.
+func runHelpConcept(name string) int {
+	content, err := concepts.Lookup(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	fmt.Print(content)
 	return 0
 }
 

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -592,6 +592,14 @@ func TestRunHelp_KindsDispatch_ExitsZero(t *testing.T) {
 	assert.Contains(t, out, "kind-assignment")
 }
 
+func TestRunHelp_ConceptDispatch_ExitsZero(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelp([]string{"placeholder-grammar"})
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, out, "Placeholder grammar")
+}
+
 // --- runHelpRule ---
 
 func TestRunHelpRule_NoArgs_ListsRules(t *testing.T) {

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -600,6 +600,11 @@ func TestRunHelp_ConceptDispatch_ExitsZero(t *testing.T) {
 	assert.Contains(t, out, "Placeholder grammar")
 }
 
+func TestRunHelpConcept_UnknownConcept_ExitsTwo(t *testing.T) {
+	code := runHelpConcept("no-such-concept")
+	assert.Equal(t, 2, code)
+}
+
 // --- runHelpRule ---
 
 func TestRunHelpRule_NoArgs_ListsRules(t *testing.T) {

--- a/docs/background/concepts/placeholder-grammar.md
+++ b/docs/background/concepts/placeholder-grammar.md
@@ -70,12 +70,12 @@ from `internal/placeholders`:
 
 ## Opt-in rules
 
-| Rule ID | Rule name                        | Tokens honored                                         |
+| Rule ID | Rule name                        | Useful tokens                                          |
 |---------|----------------------------------|--------------------------------------------------------|
-| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`              |
-| MDS004  | `first-line-heading`             | `heading-question`, `var-token`                        |
-| MDS018  | `no-emphasis-as-heading`         | `var-token`                                            |
+| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token` |
+| MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section` |
+| MDS018  | `no-emphasis-as-heading`         | `var-token`, `heading-question`, `placeholder-section` |
 | MDS020  | `required-structure`             | `cue-frontmatter`                                      |
 | MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section` |
 | MDS024  | `paragraph-structure`            | `var-token`, `heading-question`, `placeholder-section` |
-| MDS027  | `cross-file-reference-integrity` | `var-token`                                            |
+| MDS027  | `cross-file-reference-integrity` | `var-token`, `heading-question`, `placeholder-section` |

--- a/docs/background/concepts/placeholder-grammar.md
+++ b/docs/background/concepts/placeholder-grammar.md
@@ -1,0 +1,81 @@
+---
+summary: >-
+  How the placeholder vocabulary lets rules treat template tokens as
+  opaque rather than flagging them as content violations.
+---
+# Placeholder grammar
+
+Placeholder grammar is an opt-in vocabulary of named tokens that rules
+can treat as opaque. A rule with a `placeholders:` setting consults the
+shared helper and suppresses diagnostics for content that matches a
+configured token. This lets template files coexist with linting: rules
+that apply to real content still run, but placeholder tokens do not
+trigger false positives.
+
+## Token vocabulary
+
+| Token name            | Matches                                                          |
+|-----------------------|------------------------------------------------------------------|
+| `var-token`           | `{identifier}` interpolation placeholders (`{title}`, `{a.b.c}`) |
+| `heading-question`    | A heading whose text is exactly `?`                              |
+| `placeholder-section` | A heading whose text is exactly `...`                            |
+| `cue-frontmatter`     | CUE constraint expressions in front-matter values                |
+
+The vocabulary is closed. Adding a token requires one change in
+`internal/placeholders/placeholders.go` plus per-rule opt-ins; no rule
+hardcodes token names in its own logic.
+
+## The `placeholders:` setting contract
+
+Any rule that opts in exposes `placeholders:` as a setting through the
+[`Configurable`](../../../internal/rule/rule.go) interface. The value
+is a list of token names:
+
+```yaml
+kinds:
+  proto:
+    rules:
+      first-line-heading:
+        placeholders: [heading-question]
+      heading-increment:
+        placeholders: [heading-question, placeholder-section]
+      cross-file-reference-integrity:
+        placeholders: [var-token]
+      paragraph-readability:
+        placeholders: [var-token]
+      paragraph-structure:
+        placeholders: [var-token]
+      required-structure:
+        placeholders: [cue-frontmatter]
+```
+
+When `placeholders:` is empty (the default), every rule produces the
+same diagnostics it does today — there is no behavioral change.
+
+## How rules opt in
+
+A rule adds `Placeholders []string` to its struct and calls the helper
+from `internal/placeholders`:
+
+- `ContainsBodyToken(text, tokens)` — returns true if text matches any
+  configured body token. Used by heading and paragraph rules to skip
+  checks on placeholder content.
+- `MaskBodyTokens(text, tokens)` — replaces matched tokens with
+  neutral text for analysis (e.g. `{title}` → `word`). Used by
+  paragraph-readability and paragraph-structure to check non-placeholder
+  parts of the text.
+- `HasCUEFrontmatter(tokens)` — returns true if `cue-frontmatter` is
+  configured. Used by required-structure to skip CUE front-matter
+  validation.
+
+## Opt-in rules
+
+| Rule ID | Rule name                        | Tokens honored                                         |
+|---------|----------------------------------|--------------------------------------------------------|
+| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`              |
+| MDS004  | `first-line-heading`             | `heading-question`, `var-token`                        |
+| MDS018  | `no-emphasis-as-heading`         | `var-token`                                            |
+| MDS020  | `required-structure`             | `cue-frontmatter`                                      |
+| MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section` |
+| MDS024  | `paragraph-structure`            | `var-token`, `heading-question`, `placeholder-section` |
+| MDS027  | `cross-file-reference-integrity` | `var-token`                                            |

--- a/internal/concepts/concepts.go
+++ b/internal/concepts/concepts.go
@@ -1,0 +1,38 @@
+// Package concepts provides embedded concept-page documentation for
+// mdsmith topics that span multiple rules or subsystems.
+package concepts
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+//go:embed *.md
+var conceptsFS embed.FS
+
+// Lookup returns the content of the named concept page with its front
+// matter stripped. Returns an error if no concept page with that name
+// exists.
+func Lookup(name string) (string, error) {
+	data, err := fs.ReadFile(conceptsFS, name+".md")
+	if err != nil {
+		return "", fmt.Errorf("unknown concept %q", name)
+	}
+	return stripFrontMatter(string(data)), nil
+}
+
+// stripFrontMatter removes the leading YAML front matter block (--- ... ---)
+// and any immediately following blank line from content.
+func stripFrontMatter(content string) string {
+	if !strings.HasPrefix(content, "---\n") {
+		return content
+	}
+	end := strings.Index(content[4:], "\n---\n")
+	if end < 0 {
+		return content
+	}
+	body := content[4+end+5:]
+	return strings.TrimLeft(body, "\n")
+}

--- a/internal/concepts/concepts_internal_test.go
+++ b/internal/concepts/concepts_internal_test.go
@@ -1,0 +1,17 @@
+package concepts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripFrontMatter_NoFrontMatter(t *testing.T) {
+	result := stripFrontMatter("# Title\n\nBody text.\n")
+	assert.Equal(t, "# Title\n\nBody text.\n", result)
+}
+
+func TestStripFrontMatter_UnclosedFrontMatter(t *testing.T) {
+	result := stripFrontMatter("---\nkey: value\n")
+	assert.Equal(t, "---\nkey: value\n", result)
+}

--- a/internal/concepts/concepts_test.go
+++ b/internal/concepts/concepts_test.go
@@ -1,0 +1,30 @@
+package concepts_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/concepts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookup_KnownConcept_ReturnsFrontMatterStripped(t *testing.T) {
+	content, err := concepts.Lookup("placeholder-grammar")
+	require.NoError(t, err)
+	assert.False(t, strings.HasPrefix(content, "---"),
+		"front matter should be stripped")
+	assert.Contains(t, content, "Placeholder grammar")
+}
+
+func TestLookup_UnknownConcept_ReturnsError(t *testing.T) {
+	_, err := concepts.Lookup("no-such-concept")
+	assert.ErrorContains(t, err, `unknown concept "no-such-concept"`)
+}
+
+func TestLookup_DoesNotStartWithBlankLine(t *testing.T) {
+	content, err := concepts.Lookup("placeholder-grammar")
+	require.NoError(t, err)
+	assert.False(t, strings.HasPrefix(content, "\n"),
+		"content should not start with a blank line after front matter")
+}

--- a/internal/concepts/placeholder-grammar.md
+++ b/internal/concepts/placeholder-grammar.md
@@ -38,14 +38,14 @@ kinds:
 
 ## Opt-in rules
 
-| Rule ID | Rule name                        | Useful tokens                             |
-|---------|----------------------------------|-------------------------------------------|
-| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section` |
-| MDS004  | `first-line-heading`             | `heading-question`, `var-token`           |
-| MDS018  | `no-emphasis-as-heading`         | `var-token`                               |
-| MDS020  | `required-structure`             | `cue-frontmatter`                         |
-| MDS023  | `paragraph-readability`          | `var-token`                               |
-| MDS024  | `paragraph-structure`            | `var-token`                               |
-| MDS027  | `cross-file-reference-integrity` | `var-token`                               |
+| Rule ID | Rule name                        | Useful tokens                                          |
+|---------|----------------------------------|--------------------------------------------------------|
+| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token` |
+| MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section` |
+| MDS018  | `no-emphasis-as-heading`         | `var-token`, `heading-question`, `placeholder-section` |
+| MDS020  | `required-structure`             | `cue-frontmatter`                                      |
+| MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section` |
+| MDS024  | `paragraph-structure`            | `var-token`, `heading-question`, `placeholder-section` |
+| MDS027  | `cross-file-reference-integrity` | `var-token`, `heading-question`, `placeholder-section` |
 
 See also: docs/background/concepts/placeholder-grammar.md

--- a/internal/concepts/placeholder-grammar.md
+++ b/internal/concepts/placeholder-grammar.md
@@ -1,0 +1,51 @@
+---
+name: placeholder-grammar
+summary: >-
+  How the placeholder vocabulary lets rules treat template tokens as
+  opaque rather than flagging them as content violations.
+---
+# Placeholder grammar
+
+Placeholder grammar is an opt-in vocabulary that lets rules treat
+template content as opaque. A rule with a `placeholders:` setting
+skips diagnostics for content that matches a configured token.
+
+## Token vocabulary
+
+| Token name            | Matches                                                          |
+|-----------------------|------------------------------------------------------------------|
+| `var-token`           | `{identifier}` interpolation placeholders (`{title}`, `{a.b.c}`) |
+| `heading-question`    | A heading whose text is exactly `?`                              |
+| `placeholder-section` | A heading whose text is exactly `...`                            |
+| `cue-frontmatter`     | CUE constraint expressions in front-matter values                |
+
+## The `placeholders:` setting
+
+Any opt-in rule accepts `placeholders:` as a list of token names.
+When empty (default), rule behavior is unchanged.
+
+```yaml
+kinds:
+  proto:
+    rules:
+      first-line-heading:
+        placeholders: [heading-question]
+      cross-file-reference-integrity:
+        placeholders: [var-token]
+      required-structure:
+        placeholders: [cue-frontmatter]
+```
+
+## Opt-in rules
+
+| Rule ID | Rule name                        | Useful tokens                             |
+|---------|----------------------------------|-------------------------------------------|
+| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section` |
+| MDS004  | `first-line-heading`             | `heading-question`, `var-token`           |
+| MDS018  | `no-emphasis-as-heading`         | `var-token`                               |
+| MDS020  | `required-structure`             | `cue-frontmatter`                         |
+| MDS023  | `paragraph-readability`          | `var-token`                               |
+| MDS024  | `paragraph-structure`            | `var-token`                               |
+| MDS027  | `cross-file-reference-integrity` | `var-token`                               |
+
+See also: docs/background/concepts/placeholder-grammar.md

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -731,7 +731,6 @@ func TestDumpDefaults_NonConfigurableRulesHaveNoSettings(t *testing.T) {
 
 	// These rules should NOT have settings.
 	nonConfigurableRules := []string{
-		"heading-increment",
 		"no-duplicate-headings",
 		"no-trailing-spaces",
 		"no-hard-tabs",
@@ -742,7 +741,6 @@ func TestDumpDefaults_NonConfigurableRulesHaveNoSettings(t *testing.T) {
 		"blank-line-around-lists",
 		"blank-line-around-fenced-code",
 		"no-trailing-punctuation-in-heading",
-		"no-emphasis-as-heading",
 		"catalog",
 	}
 

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -161,12 +161,12 @@ func replaceVarTokens(text string) string {
 	// Split on field boundaries: the parts between placeholders are
 	// kept, the placeholders are replaced.
 	parts := fieldinterp.SplitOnFields(text)
-	fields := fieldinterp.Fields(text)
+	placeholderCount := len(parts) - 1
 
 	var b strings.Builder
 	for i, part := range parts {
 		b.WriteString(part)
-		if i < len(fields) {
+		if i < placeholderCount {
 			b.WriteString(neutralText[VarToken])
 		}
 	}

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -1,0 +1,174 @@
+// Package placeholders provides a shared vocabulary of placeholder tokens
+// that rules can opt into to treat template content as opaque rather than
+// content violations.
+//
+// A rule adds a `placeholders:` setting (a list of token names) via the
+// Configurable interface. When checking a node it calls ContainsBodyToken
+// or MaskBodyTokens to decide whether to skip or neutralize the content.
+//
+// The four initial tokens are:
+//
+//   - var-token       — {identifier} interpolation placeholders
+//   - heading-question — headings whose text is exactly "?"
+//   - placeholder-section — headings whose text is exactly "..."
+//   - cue-frontmatter  — CUE constraint expressions in front-matter values
+package placeholders
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/fieldinterp"
+)
+
+// Named placeholder tokens.
+const (
+	VarToken           = "var-token"
+	HeadingQuestion    = "heading-question"
+	PlaceholderSection = "placeholder-section"
+	CUEFrontmatter     = "cue-frontmatter"
+)
+
+// questionPattern matches a heading text that is exactly "?".
+var questionPattern = regexp.MustCompile(`^\s*\?\s*$`)
+
+// ellipsisPattern matches a heading text that is exactly "...".
+var ellipsisPattern = regexp.MustCompile(`^\s*\.\.\.\s*$`)
+
+// neutralText is the neutral replacement per body token.
+var neutralText = map[string]string{
+	VarToken:           "word",
+	HeadingQuestion:    "Placeholder",
+	PlaceholderSection: "Placeholder Section",
+}
+
+// IsKnown reports whether name is a recognized token name.
+func IsKnown(name string) bool {
+	switch name {
+	case VarToken, HeadingQuestion, PlaceholderSection, CUEFrontmatter:
+		return true
+	}
+	return false
+}
+
+// Validate returns an error if any token name in the list is unknown.
+func Validate(tokens []string) error {
+	for _, tok := range tokens {
+		if !IsKnown(tok) {
+			return fmt.Errorf("unknown placeholder token %q", tok)
+		}
+	}
+	return nil
+}
+
+// ContainsBodyToken reports whether text matches any of the named body
+// tokens. cue-frontmatter is a front-matter–only token and is ignored.
+func ContainsBodyToken(text string, tokens []string) bool {
+	for _, tok := range tokens {
+		switch tok {
+		case VarToken:
+			if fieldinterp.ContainsField(text) {
+				return true
+			}
+		case HeadingQuestion:
+			if questionPattern.MatchString(text) {
+				return true
+			}
+		case PlaceholderSection:
+			if ellipsisPattern.MatchString(text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// MaskBodyTokens replaces placeholder token patterns in text with neutral
+// content. cue-frontmatter is not a body token and is left unchanged.
+// Whole-text tokens (heading-question, placeholder-section) replace the
+// entire text when they match; substring tokens (var-token) replace each
+// occurrence in place.
+func MaskBodyTokens(text string, tokens []string) string {
+	for _, tok := range tokens {
+		switch tok {
+		case VarToken:
+			// Replace all {field} occurrences with a neutral word.
+			text = replaceVarTokens(text)
+		case HeadingQuestion:
+			if questionPattern.MatchString(text) {
+				return neutralText[HeadingQuestion]
+			}
+		case PlaceholderSection:
+			if ellipsisPattern.MatchString(text) {
+				return neutralText[PlaceholderSection]
+			}
+		}
+	}
+	return text
+}
+
+// IsAllBodyTokens reports whether text (trimmed) consists only of
+// placeholder token patterns, with no other content. Unlike MaskBodyTokens,
+// this strips placeholder patterns to empty rather than replacing with
+// neutral text, so only non-placeholder content remains.
+func IsAllBodyTokens(text string, tokens []string) bool {
+	stripped := stripBodyTokens(text, tokens)
+	return strings.TrimSpace(stripped) == ""
+}
+
+// stripBodyTokens removes all placeholder token patterns from text,
+// leaving only non-placeholder content (for IsAllBodyTokens).
+func stripBodyTokens(text string, tokens []string) string {
+	for _, tok := range tokens {
+		switch tok {
+		case VarToken:
+			if !fieldinterp.ContainsField(text) {
+				continue
+			}
+			parts := fieldinterp.SplitOnFields(text)
+			text = strings.Join(parts, "")
+		case HeadingQuestion:
+			if questionPattern.MatchString(text) {
+				return ""
+			}
+		case PlaceholderSection:
+			if ellipsisPattern.MatchString(text) {
+				return ""
+			}
+		}
+	}
+	return text
+}
+
+// HasCUEFrontmatter reports whether cue-frontmatter is in the token list.
+func HasCUEFrontmatter(tokens []string) bool {
+	for _, tok := range tokens {
+		if tok == CUEFrontmatter {
+			return true
+		}
+	}
+	return false
+}
+
+// replaceVarTokens replaces all {field} interpolation placeholders with
+// the neutral word "word". It delegates detection to fieldinterp and uses
+// a simple split/join over field boundaries.
+func replaceVarTokens(text string) string {
+	if !fieldinterp.ContainsField(text) {
+		return text
+	}
+	// Split on field boundaries: the parts between placeholders are
+	// kept, the placeholders are replaced.
+	parts := fieldinterp.SplitOnFields(text)
+	fields := fieldinterp.Fields(text)
+
+	var b strings.Builder
+	for i, part := range parts {
+		b.WriteString(part)
+		if i < len(fields) {
+			b.WriteString(neutralText[VarToken])
+		}
+	}
+	return b.String()
+}

--- a/internal/placeholders/placeholders_test.go
+++ b/internal/placeholders/placeholders_test.go
@@ -1,0 +1,288 @@
+package placeholders_test
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/placeholders"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKnown(t *testing.T) {
+	assert.True(t, placeholders.IsKnown(placeholders.VarToken))
+	assert.True(t, placeholders.IsKnown(placeholders.HeadingQuestion))
+	assert.True(t, placeholders.IsKnown(placeholders.PlaceholderSection))
+	assert.True(t, placeholders.IsKnown(placeholders.CUEFrontmatter))
+	assert.False(t, placeholders.IsKnown("unknown-token"))
+	assert.False(t, placeholders.IsKnown(""))
+}
+
+func TestValidate(t *testing.T) {
+	assert.NoError(t, placeholders.Validate(nil))
+	assert.NoError(t, placeholders.Validate([]string{}))
+	assert.NoError(t, placeholders.Validate([]string{placeholders.VarToken}))
+	assert.NoError(t, placeholders.Validate([]string{
+		placeholders.VarToken,
+		placeholders.HeadingQuestion,
+		placeholders.PlaceholderSection,
+		placeholders.CUEFrontmatter,
+	}))
+	err := placeholders.Validate([]string{"bad-token"})
+	assert.ErrorContains(t, err, `unknown placeholder token "bad-token"`)
+}
+
+func TestContainsBodyToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		tokens []string
+		want   bool
+	}{
+		{
+			name:   "var-token detected",
+			text:   "Hello {name} world",
+			tokens: []string{placeholders.VarToken},
+			want:   true,
+		},
+		{
+			name:   "var-token nested path",
+			text:   "{a.b.c}",
+			tokens: []string{placeholders.VarToken},
+			want:   true,
+		},
+		{
+			name:   "heading-question exact",
+			text:   "?",
+			tokens: []string{placeholders.HeadingQuestion},
+			want:   true,
+		},
+		{
+			name:   "heading-question with whitespace",
+			text:   "  ?  ",
+			tokens: []string{placeholders.HeadingQuestion},
+			want:   true,
+		},
+		{
+			name:   "heading-question not a partial match",
+			text:   "What?",
+			tokens: []string{placeholders.HeadingQuestion},
+			want:   false,
+		},
+		{
+			name:   "placeholder-section exact",
+			text:   "...",
+			tokens: []string{placeholders.PlaceholderSection},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := placeholders.ContainsBodyToken(tt.text, tt.tokens)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestContainsBodyToken_SectionAndEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		tokens []string
+		want   bool
+	}{
+		{
+			name:   "placeholder-section with whitespace",
+			text:   "  ...  ",
+			tokens: []string{placeholders.PlaceholderSection},
+			want:   true,
+		},
+		{
+			name:   "placeholder-section not partial",
+			text:   "more...",
+			tokens: []string{placeholders.PlaceholderSection},
+			want:   false,
+		},
+		{
+			name:   "cue-frontmatter ignored for body",
+			text:   "int & >=1",
+			tokens: []string{placeholders.CUEFrontmatter},
+			want:   false,
+		},
+		{
+			name:   "empty token list",
+			text:   "{var}",
+			tokens: []string{},
+			want:   false,
+		},
+		{
+			name:   "nil token list",
+			text:   "{var}",
+			tokens: nil,
+			want:   false,
+		},
+		{
+			name:   "multiple tokens, first matches",
+			text:   "?",
+			tokens: []string{placeholders.HeadingQuestion, placeholders.VarToken},
+			want:   true,
+		},
+		{
+			name:   "multiple tokens, second matches",
+			text:   "{id}",
+			tokens: []string{placeholders.HeadingQuestion, placeholders.VarToken},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := placeholders.ContainsBodyToken(tt.text, tt.tokens)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMaskBodyTokens(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		tokens []string
+		want   string
+	}{
+		{
+			name:   "var-token replaced",
+			text:   "Hello {name} world",
+			tokens: []string{placeholders.VarToken},
+			want:   "Hello word world",
+		},
+		{
+			name:   "var-token only",
+			text:   "{id}",
+			tokens: []string{placeholders.VarToken},
+			want:   "word",
+		},
+		{
+			name:   "multiple var-tokens",
+			text:   "{id}: {title}",
+			tokens: []string{placeholders.VarToken},
+			want:   "word: word",
+		},
+		{
+			name:   "heading-question replaced",
+			text:   "?",
+			tokens: []string{placeholders.HeadingQuestion},
+			want:   "Placeholder",
+		},
+		{
+			name:   "heading-question not partial",
+			text:   "What?",
+			tokens: []string{placeholders.HeadingQuestion},
+			want:   "What?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := placeholders.MaskBodyTokens(tt.text, tt.tokens)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMaskBodyTokens_SectionAndEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		tokens []string
+		want   string
+	}{
+		{
+			name:   "placeholder-section replaced",
+			text:   "...",
+			tokens: []string{placeholders.PlaceholderSection},
+			want:   "Placeholder Section",
+		},
+		{
+			name:   "cue-frontmatter not a body token",
+			text:   "int & >=1",
+			tokens: []string{placeholders.CUEFrontmatter},
+			want:   "int & >=1",
+		},
+		{
+			name:   "empty token list leaves text unchanged",
+			text:   "{var}",
+			tokens: []string{},
+			want:   "{var}",
+		},
+		{
+			// fieldinterp treats {{ as escaped {; the text has no {field}
+			// placeholders so MaskBodyTokens leaves it unchanged.
+			name:   "escaped braces not replaced",
+			text:   "{{not-a-placeholder}}",
+			tokens: []string{placeholders.VarToken},
+			want:   "{{not-a-placeholder}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := placeholders.MaskBodyTokens(tt.text, tt.tokens)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsAllBodyTokens(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		tokens []string
+		want   bool
+	}{
+		{
+			name:   "only var-token",
+			text:   "{id}",
+			tokens: []string{placeholders.VarToken},
+			want:   true,
+		},
+		{
+			name:   "var-token with other text",
+			text:   "{id} some text",
+			tokens: []string{placeholders.VarToken},
+			want:   false,
+		},
+		{
+			name:   "heading-question only",
+			text:   "?",
+			tokens: []string{placeholders.HeadingQuestion},
+			want:   true,
+		},
+		{
+			name:   "placeholder-section only",
+			text:   "...",
+			tokens: []string{placeholders.PlaceholderSection},
+			want:   true,
+		},
+		{
+			name:   "empty text",
+			text:   "",
+			tokens: []string{placeholders.VarToken},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := placeholders.IsAllBodyTokens(tt.text, tt.tokens)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHasCUEFrontmatter(t *testing.T) {
+	assert.True(t, placeholders.HasCUEFrontmatter([]string{placeholders.CUEFrontmatter}))
+	assert.True(t, placeholders.HasCUEFrontmatter([]string{placeholders.VarToken, placeholders.CUEFrontmatter}))
+	assert.False(t, placeholders.HasCUEFrontmatter([]string{placeholders.VarToken}))
+	assert.False(t, placeholders.HasCUEFrontmatter(nil))
+	assert.False(t, placeholders.HasCUEFrontmatter([]string{}))
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -136,3 +136,41 @@ func TestMatch_JSONMarshalError(t *testing.T) {
 	result := m.Match(map[string]any{"status": make(chan int)})
 	assert.False(t, result, "json.Marshal error should cause Match to return false")
 }
+
+// =====================================================================
+// Placeholder grammar regression: CUE-pattern front matter
+// =====================================================================
+
+// TestMatch_CUEPatternFrontMatter verifies that a file with CUE-pattern
+// front-matter values (as found in proto.md) can still be selected by
+// the query matcher when the query uses field-existence checks.
+//
+// Files like proto.md hold CUE schema expressions as front-matter values
+// (e.g. id: 'int & >=1'). The YAML parser reads them as ordinary strings,
+// so readFrontMatterRaw produces map[string]any{"id": "int & >=1", ...}.
+// The matcher should be able to select such files by field presence.
+func TestMatch_CUEPatternFrontMatter(t *testing.T) {
+	// Simulate the front matter of plan/proto.md after YAML parsing.
+	fm := map[string]any{
+		"id":      "int & >=1",
+		"title":   `string & != ""`,
+		"status":  `"🔲" | "🔳" | "✅" | "⛔"`,
+		"summary": `string | *""`,
+		"model":   `"haiku" | "sonnet" | "opus" | *""`,
+	}
+
+	// Query by field existence (underscore = any CUE value).
+	m, err := Compile(`id: _`)
+	require.NoError(t, err)
+	assert.True(t, m.Match(fm), "file with CUE-pattern id field should be selectable by {id: _}")
+
+	// Query by the literal CUE-expression string value.
+	m2, err := Compile(`id: "int & >=1"`)
+	require.NoError(t, err)
+	assert.True(t, m2.Match(fm), "file with CUE-pattern id field should match literal string query")
+
+	// Query for a field that is absent returns false.
+	m3, err := Compile(`missing: _`)
+	require.NoError(t, err)
+	assert.False(t, m3.Match(fm), "absent field should not match")
+}

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -8,6 +8,14 @@ description: Heading levels should increment by one. No jumping from `#` to `###
 
 Heading levels should increment by one. No jumping from `#` to `###`.
 
+## Settings
+
+| Setting        | Type | Default | Description                                                                                                                |
+|----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `heading-question`, `placeholder-section`.
+
 ## Config
 
 Enable:
@@ -68,3 +76,7 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -14,7 +14,7 @@ Heading levels should increment by one. No jumping from `#` to `###`.
 |----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `heading-question`, `placeholder-section`.
+Useful tokens: `heading-question`, `placeholder-section`, `var-token`.
 
 ## Config
 

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -15,7 +15,7 @@ First line of the file should be a heading.
 | `level`        | int  | 1       | Required heading level for the first line                                                                                  |
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `heading-question`, `var-token`.
+Useful tokens: `heading-question`, `var-token`, `placeholder-section`.
 
 ## Config
 

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -10,9 +10,12 @@ First line of the file should be a heading.
 
 ## Settings
 
-| Setting | Type | Default | Description                               |
-|---------|------|---------|-------------------------------------------|
-| `level` | int  | 1       | Required heading level for the first line |
+| Setting        | Type | Default | Description                                                                                                                |
+|----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `level`        | int  | 1       | Required heading level for the first line                                                                                  |
+| `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `heading-question`, `var-token`.
 
 ## Config
 
@@ -106,3 +109,7 @@ Some content here.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -8,6 +8,14 @@ description: Don't use bold or emphasis on a standalone line as a heading substi
 
 Don't use bold or emphasis on a standalone line as a heading substitute.
 
+## Settings
+
+| Setting        | Type | Default | Description                                                                                                                |
+|----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `var-token`.
+
 ## Config
 
 Enable:
@@ -66,3 +74,7 @@ This is a normal paragraph.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -14,7 +14,7 @@ Don't use bold or emphasis on a standalone line as a heading substitute.
 |----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `var-token`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 ## Config
 

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -18,7 +18,7 @@ schema.
 | `archetype-roots` | [ ]string | `["archetypes"]` | Directories searched for `<name>.md` schemas; earlier roots shadow later ones                                              |
 | `placeholders`    | list      | `[]`             | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `cue-frontmatter`.
+Useful tokens: `cue-frontmatter`.
 
 When both `schema` and `archetype` are empty the rule
 skips structure and front matter validation, but still

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -11,11 +11,14 @@ schema.
 
 ## Settings
 
-| Setting           | Type      | Default          | Description                                                                   |
-|-------------------|-----------|------------------|-------------------------------------------------------------------------------|
-| `schema`          | string    | `""`             | Path to a schema file                                                         |
-| `archetype`       | string    | `""`             | Archetype name; resolved against `archetype-roots`                            |
-| `archetype-roots` | [ ]string | `["archetypes"]` | Directories searched for `<name>.md` schemas; earlier roots shadow later ones |
+| Setting           | Type      | Default          | Description                                                                                                                |
+|-------------------|-----------|------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `schema`          | string    | `""`             | Path to a schema file                                                                                                      |
+| `archetype`       | string    | `""`             | Archetype name; resolved against `archetype-roots`                                                                         |
+| `archetype-roots` | [ ]string | `["archetypes"]` | Directories searched for `<name>.md` schemas; earlier roots shadow later ones                                              |
+| `placeholders`    | list      | `[]`             | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `cue-frontmatter`.
 
 When both `schema` and `archetype` are empty the rule
 skips structure and front matter validation, but still
@@ -229,3 +232,7 @@ Describe the goal here.
 - **Guide**:
   [directive guide](../../../docs/guides/directives/enforcing-structure.md)
 - **Category**: meta
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -16,7 +16,7 @@ Paragraph readability index must not exceed a threshold.
 | `min-words`    | int   | 20      | Minimum word count to check a paragraph                                                                                    |
 | `placeholders` | list  | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `var-token`, `heading-question`, `placeholder-section`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 Paragraphs with fewer words than `min-words` are skipped.
 Markdown tables and code blocks are skipped.

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -10,10 +10,13 @@ Paragraph readability index must not exceed a threshold.
 
 ## Settings
 
-| Setting     | Type  | Default | Description                             |
-|-------------|-------|---------|-----------------------------------------|
-| `max-index` | float | 14.0    | Maximum allowed readability index (ARI) |
-| `min-words` | int   | 20      | Minimum word count to check a paragraph |
+| Setting        | Type  | Default | Description                                                                                                                |
+|----------------|-------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `max-index`    | float | 14.0    | Maximum allowed readability index (ARI)                                                                                    |
+| `min-words`    | int   | 20      | Minimum word count to check a paragraph                                                                                    |
+| `placeholders` | list  | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 Paragraphs with fewer words than `min-words` are skipped.
 Markdown tables and code blocks are skipped.
@@ -87,3 +90,7 @@ The implementation of concurrent distributed systems requires sophisticated unde
 - **Implementation**:
   [source](./)
 - **Category**: meta
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -16,7 +16,7 @@ Paragraphs must not exceed sentence and word limits.
 | `max-words-per-sentence` | int  | 40      | Maximum words per sentence                                                                                                 |
 | `placeholders`           | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `var-token`, `heading-question`, `placeholder-section`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 Markdown tables and code blocks are skipped.
 

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -10,10 +10,13 @@ Paragraphs must not exceed sentence and word limits.
 
 ## Settings
 
-| Setting                  | Type | Default | Description                     |
-|--------------------------|------|---------|---------------------------------|
-| `max-sentences`          | int  | 6       | Maximum sentences per paragraph |
-| `max-words-per-sentence` | int  | 40      | Maximum words per sentence      |
+| Setting                  | Type | Default | Description                                                                                                                |
+|--------------------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `max-sentences`          | int  | 6       | Maximum sentences per paragraph                                                                                            |
+| `max-words-per-sentence` | int  | 40      | Maximum words per sentence                                                                                                 |
+| `placeholders`           | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 Markdown tables and code blocks are skipped.
 
@@ -83,3 +86,7 @@ Dogs bark. Cats meow. Birds sing. Fish swim. Frogs croak. Snakes hiss. Bees buzz
 - **Implementation**:
   [source](./)
 - **Category**: meta
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -17,7 +17,7 @@ Links to local files and heading anchors must resolve.
 | `strict`       | bool | `false` | check non-Markdown file links                                                                                              |
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Supported tokens: `var-token`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 With `strict: false`, only Markdown targets (`.md`, `.markdown`)
 are checked. External links (`http:`, `https:`, `mailto:`) are

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -10,11 +10,14 @@ Links to local files and heading anchors must resolve.
 
 ## Settings
 
-| Setting   | Type | Default | Description                   |
-|-----------|------|---------|-------------------------------|
-| `include` | list | `[]`    | glob patterns to include      |
-| `exclude` | list | `[]`    | glob patterns to skip         |
-| `strict`  | bool | `false` | check non-Markdown file links |
+| Setting        | Type | Default | Description                                                                                                                |
+|----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `include`      | list | `[]`    | glob patterns to include                                                                                                   |
+| `exclude`      | list | `[]`    | glob patterns to skip                                                                                                      |
+| `strict`       | bool | `false` | check non-Markdown file links                                                                                              |
+| `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+
+Supported tokens: `var-token`.
 
 With `strict: false`, only Markdown targets (`.md`, `.markdown`)
 are checked. External links (`http:`, `https:`, `mailto:`) are
@@ -126,3 +129,7 @@ See [guide](bad/ref/guide.md#missing-section).
 - **Implementation**:
   [source](./)
 - **Category**: link
+
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -150,9 +150,6 @@ func (r *Rule) checkLink(
 func checkLocalAnchor(
 	path string, line, col int, r *Rule, target linkTarget, selfAnchors map[string]bool,
 ) []lint.Diagnostic {
-	if target.Anchor == "" {
-		return nil
-	}
 	if selfAnchors[normalizeAnchor(target.Anchor)] {
 		return nil
 	}

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/mdtext"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/yuin/goldmark/ast"
 )
@@ -22,9 +23,10 @@ func init() {
 // Rule checks Markdown links for missing target files and missing heading
 // anchors in linked Markdown files.
 type Rule struct {
-	Include []string
-	Exclude []string
-	Strict  bool
+	Include      []string
+	Exclude      []string
+	Strict       bool
+	Placeholders []string // placeholder tokens to treat as opaque
 }
 
 // ID implements rule.Rule.
@@ -99,16 +101,14 @@ func (r *Rule) checkLink(
 		return nil
 	}
 
+	if placeholders.ContainsBodyToken(target.Raw, r.Placeholders) {
+		return nil
+	}
+
 	line, col := linkPosition(f, linkNode)
 
 	if target.LocalAnchor {
-		if target.Anchor == "" {
-			return nil
-		}
-		if selfAnchors[normalizeAnchor(target.Anchor)] {
-			return nil
-		}
-		return []lint.Diagnostic{brokenHeadingDiag(f.Path, line, col, r, target.Raw)}
+		return checkLocalAnchor(f.Path, line, col, r, target, selfAnchors)
 	}
 
 	linkPath := normalizeLinkPath(target.Path)
@@ -147,6 +147,18 @@ func (r *Rule) checkLink(
 	return []lint.Diagnostic{brokenHeadingDiag(f.Path, line, col, r, target.Raw)}
 }
 
+func checkLocalAnchor(
+	path string, line, col int, r *Rule, target linkTarget, selfAnchors map[string]bool,
+) []lint.Diagnostic {
+	if target.Anchor == "" {
+		return nil
+	}
+	if selfAnchors[normalizeAnchor(target.Anchor)] {
+		return nil
+	}
+	return []lint.Diagnostic{brokenHeadingDiag(path, line, col, r, target.Raw)}
+}
+
 // ApplySettings implements rule.Configurable.
 func (r *Rule) ApplySettings(settings map[string]any) error {
 	for k, v := range settings {
@@ -178,6 +190,18 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 				)
 			}
 			r.Strict = b
+		case "placeholders":
+			toks, ok := toStringSlice(v)
+			if !ok {
+				return fmt.Errorf(
+					"cross-file-reference-integrity: placeholders must be a list of strings, got %T",
+					v,
+				)
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("cross-file-reference-integrity: %w", err)
+			}
+			r.Placeholders = toks
 		default:
 			return fmt.Errorf(
 				"cross-file-reference-integrity: unknown setting %q",
@@ -185,7 +209,10 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 			)
 		}
 	}
+	return r.validateGlobSettings()
+}
 
+func (r *Rule) validateGlobSettings() error {
 	if _, err := compileMatchers(r.Include); err != nil {
 		return fmt.Errorf(
 			"cross-file-reference-integrity: include has invalid glob pattern: %w",
@@ -198,16 +225,16 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 			err,
 		)
 	}
-
 	return nil
 }
 
 // DefaultSettings implements rule.Configurable.
 func (r *Rule) DefaultSettings() map[string]any {
 	return map[string]any{
-		"include": []string{},
-		"exclude": []string{},
-		"strict":  false,
+		"include":      []string{},
+		"exclude":      []string{},
+		"strict":       false,
+		"placeholders": []string{},
 	}
 }
 

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -749,3 +749,50 @@ func TestCheck_AbsoluteFilepathLinkSkipped(t *testing.T) {
 	diags := (&Rule{}).Check(f)
 	require.Len(t, diags, 0, "absolute-path links must be skipped, got: %v", diagMessages(diags))
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_Placeholder_VarTokenInLink_Suppressed(t *testing.T) {
+	// A link whose destination contains a var-token placeholder should
+	// not be flagged when var-token is configured.
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "test.md")
+	writeFile(t, srcPath, "# Title\n\n[link]({base}/docs/page.md)\n")
+	f := newLintFile(t, srcPath)
+	r := &Rule{Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "var-token in link destination should suppress diagnostic")
+}
+
+func TestCheck_Placeholder_VarTokenInLink_EmptyPlaceholders(t *testing.T) {
+	// Without placeholders, a link with a placeholder in the destination is
+	// flagged as a broken link (the path doesn't exist).
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "test.md")
+	writeFile(t, srcPath, "# Title\n\n[link]({base}/docs/page.md)\n")
+	f := newLintFile(t, srcPath)
+	r := &Rule{Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "broken link without placeholders should be flagged")
+}
+
+func TestApplySettings_Placeholders_CrossFile(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"var-token"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"var-token"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken_CrossFile(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad"}})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings_CrossFile(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	require.Equal(t, []string{}, ds["placeholders"])
+}

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -791,6 +791,13 @@ func TestApplySettings_Placeholders_UnknownToken_CrossFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestApplySettings_Placeholders_NonList_CrossFile(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list of strings")
+}
+
 func TestDefaultSettings_CrossFile(t *testing.T) {
 	r := &Rule{}
 	ds := r.DefaultSettings()

--- a/internal/rules/firstlineheading/rule.go
+++ b/internal/rules/firstlineheading/rule.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
 	"github.com/yuin/goldmark/ast"
 )
@@ -15,7 +17,8 @@ func init() {
 
 // Rule checks that the first line of the file is a heading of the configured level.
 type Rule struct {
-	Level int // expected heading level (default: 1)
+	Level        int      // expected heading level (default: 1)
+	Placeholders []string // placeholder tokens to treat as opaque
 }
 
 // ID implements rule.Rule.
@@ -55,6 +58,12 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	}
 
 	if heading.Level != level {
+		// If the heading text matches a configured placeholder token,
+		// treat it as opaque and suppress the level diagnostic.
+		text := astutil.HeadingText(heading, f.Source)
+		if placeholders.ContainsBodyToken(text, r.Placeholders) {
+			return nil
+		}
 		return r.diag(f, fmt.Sprintf("first heading should be level %d, got %d", level, heading.Level))
 	}
 
@@ -87,6 +96,15 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 				return fmt.Errorf("first-line-heading: level must be 1-6, got %d", n)
 			}
 			r.Level = n
+		case "placeholders":
+			toks, ok := settings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf("first-line-heading: placeholders must be a list of strings, got %T", v)
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("first-line-heading: %w", err)
+			}
+			r.Placeholders = toks
 		default:
 			return fmt.Errorf("first-line-heading: unknown setting %q", k)
 		}
@@ -97,7 +115,8 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 // DefaultSettings implements rule.Configurable.
 func (r *Rule) DefaultSettings() map[string]any {
 	return map[string]any{
-		"level": 1,
+		"level":        1,
+		"placeholders": []string{},
 	}
 }
 

--- a/internal/rules/firstlineheading/rule_test.go
+++ b/internal/rules/firstlineheading/rule_test.go
@@ -264,3 +264,72 @@ func TestHeadingLine_FallbackReturn1(t *testing.T) {
 	line := headingLine(h, f)
 	assert.Equal(t, 1, line)
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_PlaceholderHeadingQuestion_WrongLevel_Suppressed(t *testing.T) {
+	// A heading-question placeholder at the wrong level should not be flagged
+	// when heading-question is in the placeholders list.
+	src := []byte("## ?\n\nSome text\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Level: 1, Placeholders: []string{"heading-question"}}
+	diags := r.Check(f)
+	assert.Empty(t, diags, "heading-question placeholder should suppress level mismatch")
+}
+
+func TestCheck_PlaceholderHeadingQuestion_WrongLevel_EmptyPlaceholders(t *testing.T) {
+	// Without placeholders configured, wrong-level heading is still flagged.
+	src := []byte("## ?\n\nSome text\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Level: 1, Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "should flag wrong-level heading without placeholders configured")
+	assert.Equal(t, "first heading should be level 1, got 2", diags[0].Message)
+}
+
+func TestCheck_PlaceholderVarToken_WrongLevel_Suppressed(t *testing.T) {
+	// When var-token is configured and the heading text is a placeholder,
+	// the level check is suppressed.
+	src := []byte("## {title}\n\nSome text\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Level: 1, Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	assert.Empty(t, diags, "var-token placeholder heading should suppress level check")
+}
+
+func TestCheck_PlaceholderVarToken_WrongLevel_EmptyPlaceholders(t *testing.T) {
+	// Without placeholders, var-token heading still fails the level check.
+	src := []byte("## {title}\n\nSome text\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Level: 1, Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "should flag wrong-level heading without placeholders configured")
+}
+
+func TestApplySettings_Placeholders_Valid(t *testing.T) {
+	r := &Rule{Level: 1}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"heading-question", "var-token"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"heading-question", "var-token"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken(t *testing.T) {
+	r := &Rule{Level: 1}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"no-such-token"},
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no-such-token")
+}
+
+func TestDefaultSettings_IncludesPlaceholders(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	assert.Equal(t, []string{}, ds["placeholders"])
+}

--- a/internal/rules/firstlineheading/rule_test.go
+++ b/internal/rules/firstlineheading/rule_test.go
@@ -328,6 +328,13 @@ func TestApplySettings_Placeholders_UnknownToken(t *testing.T) {
 	assert.ErrorContains(t, err, "no-such-token")
 }
 
+func TestApplySettings_Placeholders_NonList_FirstLineHeading(t *testing.T) {
+	r := &Rule{Level: 1}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "list of strings")
+}
+
 func TestDefaultSettings_IncludesPlaceholders(t *testing.T) {
 	r := &Rule{}
 	ds := r.DefaultSettings()

--- a/internal/rules/headingincrement/rule.go
+++ b/internal/rules/headingincrement/rule.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
+	"github.com/jeduden/mdsmith/internal/rules/settings"
 	"github.com/yuin/goldmark/ast"
 )
 
@@ -14,7 +16,9 @@ func init() {
 }
 
 // Rule checks that heading levels only increment by one.
-type Rule struct{}
+type Rule struct {
+	Placeholders []string // placeholder tokens to treat as opaque
+}
 
 // ID implements rule.Rule.
 func (r *Rule) ID() string { return "MDS003" }
@@ -40,9 +44,16 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		}
 
 		level := heading.Level
+
+		// Check if this heading's text matches a configured placeholder.
+		// Placeholder headings skip the increment diagnostic but still
+		// update prevLevel so subsequent headings track correctly.
+		isPlaceholder := len(r.Placeholders) > 0 &&
+			placeholders.ContainsBodyToken(astutil.HeadingText(heading, f.Source), r.Placeholders)
+
 		if prevLevel == 0 {
 			// First heading: should be h1
-			if level > 1 {
+			if level > 1 && !isPlaceholder {
 				line := astutil.HeadingLine(heading, f)
 				diags = append(diags, lint.Diagnostic{
 					File:     f.Path,
@@ -54,7 +65,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 					Message:  fmt.Sprintf("first heading level should be 1, got %d", level),
 				})
 			}
-		} else if level > prevLevel+1 {
+		} else if level > prevLevel+1 && !isPlaceholder {
 			line := astutil.HeadingLine(heading, f)
 			diags = append(diags, lint.Diagnostic{
 				File:     f.Path,
@@ -74,3 +85,32 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 
 	return diags
 }
+
+// ApplySettings implements rule.Configurable.
+func (r *Rule) ApplySettings(s map[string]any) error {
+	for k, v := range s {
+		switch k {
+		case "placeholders":
+			toks, ok := settings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf("heading-increment: placeholders must be a list of strings, got %T", v)
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("heading-increment: %w", err)
+			}
+			r.Placeholders = toks
+		default:
+			return fmt.Errorf("heading-increment: unknown setting %q", k)
+		}
+	}
+	return nil
+}
+
+// DefaultSettings implements rule.Configurable.
+func (r *Rule) DefaultSettings() map[string]any {
+	return map[string]any{
+		"placeholders": []string{},
+	}
+}
+
+var _ rule.Configurable = (*Rule)(nil)

--- a/internal/rules/headingincrement/rule_test.go
+++ b/internal/rules/headingincrement/rule_test.go
@@ -73,3 +73,69 @@ func TestName(t *testing.T) {
 		t.Errorf("expected heading-increment, got %s", r.Name())
 	}
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_PlaceholderHeadingQuestion_SkipsLevel(t *testing.T) {
+	// A heading with text "?" configured as heading-question should not
+	// produce a diagnostic even when its level skips.
+	src := []byte("# H1\n\n### ?\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{"heading-question"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "heading-question placeholder should suppress skip-level diagnostic")
+}
+
+func TestCheck_PlaceholderSection_SkipsLevel(t *testing.T) {
+	// A heading with text "..." configured as placeholder-section should not
+	// produce a diagnostic even when its level skips.
+	src := []byte("# H1\n\n### ...\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{"placeholder-section"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "placeholder-section should suppress skip-level diagnostic")
+}
+
+func TestCheck_PlaceholderHeadingQuestion_EmptyList_StillFlags(t *testing.T) {
+	// Without placeholders configured, skipped levels are still flagged.
+	src := []byte("# H1\n\n### ?\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "should flag skipped level without placeholders configured")
+}
+
+func TestCheck_Placeholder_LevelTracked(t *testing.T) {
+	// Placeholder headings still update the level tracker.
+	// After h1, a placeholder h3, h4 is ok (following placeholder's level).
+	src := []byte("# H1\n\n### ?\n\n#### H4\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{"heading-question"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "h4 after placeholder h3 should be valid")
+}
+
+func TestApplySettings_Placeholders_HeadingIncrement(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"heading-question", "placeholder-section"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"heading-question", "placeholder-section"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken_HeadingIncrement(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad-token"}})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings_HeadingIncrement(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	require.Equal(t, []string{}, ds["placeholders"])
+}

--- a/internal/rules/headingincrement/rule_test.go
+++ b/internal/rules/headingincrement/rule_test.go
@@ -134,6 +134,20 @@ func TestApplySettings_Placeholders_UnknownToken_HeadingIncrement(t *testing.T) 
 	require.Error(t, err)
 }
 
+func TestApplySettings_Placeholders_NonList_HeadingIncrement(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list of strings")
+}
+
+func TestApplySettings_UnknownKey_HeadingIncrement(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"unknownkey": true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown setting")
+}
+
 func TestDefaultSettings_HeadingIncrement(t *testing.T) {
 	r := &Rule{}
 	ds := r.DefaultSettings()

--- a/internal/rules/noemphasisasheading/rule.go
+++ b/internal/rules/noemphasisasheading/rule.go
@@ -2,6 +2,7 @@ package noemphasisasheading
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/placeholders"
@@ -62,20 +63,8 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 
 		// If the emphasis text contains a configured placeholder token,
 		// treat it as opaque and suppress the diagnostic.
-		if len(r.Placeholders) > 0 {
-			var emphText string
-			_ = ast.Walk(firstChild, func(inner ast.Node, entering bool) (ast.WalkStatus, error) {
-				if !entering {
-					return ast.WalkContinue, nil
-				}
-				if t, ok2 := inner.(*ast.Text); ok2 {
-					emphText += string(t.Segment.Value(f.Source))
-				}
-				return ast.WalkContinue, nil
-			})
-			if placeholders.ContainsBodyToken(emphText, r.Placeholders) {
-				return ast.WalkContinue, nil
-			}
+		if emphasisContainsPlaceholder(firstChild, f.Source, r.Placeholders) {
+			return ast.WalkContinue, nil
 		}
 
 		line := astutil.ParagraphLine(para, f)
@@ -93,6 +82,28 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	})
 
 	return diags
+}
+
+func emphasisContainsPlaceholder(n ast.Node, src []byte, toks []string) bool {
+	if len(toks) == 0 {
+		return false
+	}
+	var sb strings.Builder
+	found := false
+	_ = ast.Walk(n, func(inner ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if t, ok := inner.(*ast.Text); ok {
+			sb.Write(t.Segment.Value(src))
+			if placeholders.ContainsBodyToken(sb.String(), toks) {
+				found = true
+				return ast.WalkStop, nil
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	return found
 }
 
 // ApplySettings implements rule.Configurable.

--- a/internal/rules/noemphasisasheading/rule.go
+++ b/internal/rules/noemphasisasheading/rule.go
@@ -1,9 +1,13 @@
 package noemphasisasheading
 
 import (
+	"fmt"
+
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
+	"github.com/jeduden/mdsmith/internal/rules/settings"
 	"github.com/yuin/goldmark/ast"
 )
 
@@ -13,7 +17,9 @@ func init() {
 
 // Rule checks that emphasis/strong emphasis is not used as a heading substitute.
 // A paragraph whose only content is emphasis or strong emphasis is flagged.
-type Rule struct{}
+type Rule struct {
+	Placeholders []string // placeholder tokens to treat as opaque
+}
 
 // ID implements rule.Rule.
 func (r *Rule) ID() string { return "MDS018" }
@@ -54,6 +60,24 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			return ast.WalkContinue, nil
 		}
 
+		// If the emphasis text contains a configured placeholder token,
+		// treat it as opaque and suppress the diagnostic.
+		if len(r.Placeholders) > 0 {
+			var emphText string
+			_ = ast.Walk(firstChild, func(inner ast.Node, entering bool) (ast.WalkStatus, error) {
+				if !entering {
+					return ast.WalkContinue, nil
+				}
+				if t, ok2 := inner.(*ast.Text); ok2 {
+					emphText += string(t.Segment.Value(f.Source))
+				}
+				return ast.WalkContinue, nil
+			})
+			if placeholders.ContainsBodyToken(emphText, r.Placeholders) {
+				return ast.WalkContinue, nil
+			}
+		}
+
 		line := astutil.ParagraphLine(para, f)
 		diags = append(diags, lint.Diagnostic{
 			File:     f.Path,
@@ -70,3 +94,32 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 
 	return diags
 }
+
+// ApplySettings implements rule.Configurable.
+func (r *Rule) ApplySettings(s map[string]any) error {
+	for k, v := range s {
+		switch k {
+		case "placeholders":
+			toks, ok := settings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf("no-emphasis-as-heading: placeholders must be a list of strings, got %T", v)
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("no-emphasis-as-heading: %w", err)
+			}
+			r.Placeholders = toks
+		default:
+			return fmt.Errorf("no-emphasis-as-heading: unknown setting %q", k)
+		}
+	}
+	return nil
+}
+
+// DefaultSettings implements rule.Configurable.
+func (r *Rule) DefaultSettings() map[string]any {
+	return map[string]any{
+		"placeholders": []string{},
+	}
+}
+
+var _ rule.Configurable = (*Rule)(nil)

--- a/internal/rules/noemphasisasheading/rule_test.go
+++ b/internal/rules/noemphasisasheading/rule_test.go
@@ -88,3 +88,47 @@ func TestCategory(t *testing.T) {
 		t.Error("expected non-empty category")
 	}
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_Placeholder_VarTokenInEmphasis_Suppressed(t *testing.T) {
+	// Emphasis wrapping a var-token placeholder should not be flagged
+	// when var-token is configured.
+	src := []byte("# Title\n\n*{title}*\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "var-token in emphasis should suppress diagnostic")
+}
+
+func TestCheck_Placeholder_VarTokenInEmphasis_EmptyList(t *testing.T) {
+	// Without placeholders configured, emphasis with var-token is still flagged.
+	src := []byte("# Title\n\n*{title}*\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "should flag emphasis-as-heading without placeholders configured")
+}
+
+func TestApplySettings_Placeholders_NoEmphasisAsHeading(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"var-token"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"var-token"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken_NoEmphasisAsHeading(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad"}})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings_NoEmphasisAsHeading(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	require.Equal(t, []string{}, ds["placeholders"])
+}

--- a/internal/rules/noemphasisasheading/rule_test.go
+++ b/internal/rules/noemphasisasheading/rule_test.go
@@ -112,6 +112,31 @@ func TestCheck_Placeholder_VarTokenInEmphasis_EmptyList(t *testing.T) {
 	require.Len(t, diags, 1, "should flag emphasis-as-heading without placeholders configured")
 }
 
+func TestCheck_Placeholder_NoMatch_StillFlags(t *testing.T) {
+	// Emphasis whose text does not match any configured placeholder is still flagged.
+	// This also exercises the !entering branch of the inner AST walk.
+	src := []byte("# Title\n\n*plain text*\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "emphasis-as-heading with non-matching placeholder should still be flagged")
+}
+
+func TestApplySettings_Placeholders_NonList_NoEmphasisAsHeading(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list of strings")
+}
+
+func TestApplySettings_UnknownKey_NoEmphasisAsHeading(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"unknownkey": true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown setting")
+}
+
 func TestApplySettings_Placeholders_NoEmphasisAsHeading(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{

--- a/internal/rules/paragraphreadability/rule.go
+++ b/internal/rules/paragraphreadability/rule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/mdtext"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
@@ -24,9 +25,10 @@ func init() {
 // a configured maximum. Uses the Automated Readability Index by
 // default.
 type Rule struct {
-	MaxIndex float64
-	MinWords int
-	Index    IndexFunc
+	MaxIndex     float64
+	MinWords     int
+	Index        IndexFunc
+	Placeholders []string // placeholder tokens to treat as opaque
 }
 
 // ID implements rule.Rule.
@@ -63,6 +65,9 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			}
 
 			text := mdtext.ExtractPlainText(para, f.Source)
+			if len(r.Placeholders) > 0 {
+				text = placeholders.MaskBodyTokens(text, r.Placeholders)
+			}
 			words := mdtext.CountWords(text)
 			if words < minWords {
 				return ast.WalkContinue, nil
@@ -125,6 +130,18 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 				)
 			}
 			r.MinWords = n
+		case "placeholders":
+			toks, ok := settings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf(
+					"paragraph-readability: placeholders must be a list of strings, got %T",
+					v,
+				)
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("paragraph-readability: %w", err)
+			}
+			r.Placeholders = toks
 		default:
 			return fmt.Errorf(
 				"paragraph-readability: unknown setting %q", k,
@@ -137,8 +154,9 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 // DefaultSettings implements rule.Configurable.
 func (r *Rule) DefaultSettings() map[string]any {
 	return map[string]any{
-		"max-index": 14.0,
-		"min-words": 20,
+		"max-index":    14.0,
+		"min-words":    20,
+		"placeholders": []string{},
 	}
 }
 

--- a/internal/rules/paragraphreadability/rule_test.go
+++ b/internal/rules/paragraphreadability/rule_test.go
@@ -224,3 +224,53 @@ func TestCategory(t *testing.T) {
 		t.Errorf("expected meta, got %s", r.Category())
 	}
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_Placeholder_VarToken_MaskedBelowMinWords(t *testing.T) {
+	// A paragraph containing only a var-token is masked to a single word
+	// ("word"), which is below min-words (20), so no diagnostic is produced.
+	src := []byte("# Title\n\n{summary}\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{MaxIndex: 14.0, MinWords: 20, Index: ARI, Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "var-token paragraph masked below min-words should produce no diagnostic")
+}
+
+func TestCheck_Placeholder_EmptyList_PlaceholderTextFlagged(t *testing.T) {
+	// Without placeholders configured, behavior is unchanged: a paragraph
+	// with very few words never reaches the readability threshold anyway.
+	// We verify the rule still runs normally when placeholders is empty.
+	longPara := "The implementation of concurrent distributed systems requires sophisticated " +
+		"understanding of fundamental computational paradigms and synchronization mechanisms " +
+		"that must guarantee linearizability across heterogeneous processing environments " +
+		"and architectural configurations."
+	src := []byte("# Title\n\n" + longPara + "\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{MaxIndex: 14.0, MinWords: 20, Index: ARI, Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "long hard-to-read paragraph should still be flagged")
+}
+
+func TestApplySettings_Placeholders_ParagraphReadability(t *testing.T) {
+	r := &Rule{MaxIndex: 14.0, MinWords: 20, Index: ARI}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"var-token"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"var-token"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken_ParagraphReadability(t *testing.T) {
+	r := &Rule{MaxIndex: 14.0, MinWords: 20, Index: ARI}
+	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad"}})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings_ParagraphReadability_IncludesPlaceholders(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	require.Equal(t, []string{}, ds["placeholders"])
+}

--- a/internal/rules/paragraphreadability/rule_test.go
+++ b/internal/rules/paragraphreadability/rule_test.go
@@ -269,6 +269,13 @@ func TestApplySettings_Placeholders_UnknownToken_ParagraphReadability(t *testing
 	require.Error(t, err)
 }
 
+func TestApplySettings_Placeholders_NonList_ParagraphReadability(t *testing.T) {
+	r := &Rule{MaxIndex: 14.0, MinWords: 20, Index: ARI}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list of strings")
+}
+
 func TestDefaultSettings_ParagraphReadability_IncludesPlaceholders(t *testing.T) {
 	r := &Rule{}
 	ds := r.DefaultSettings()

--- a/internal/rules/paragraphstructure/rule.go
+++ b/internal/rules/paragraphstructure/rule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/mdtext"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
@@ -20,6 +21,7 @@ func init() {
 type Rule struct {
 	MaxSentences int
 	MaxWords     int
+	Placeholders []string // placeholder tokens to treat as opaque
 }
 
 // ID implements rule.Rule.
@@ -48,6 +50,9 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		}
 
 		text := mdtext.ExtractPlainText(para, f.Source)
+		if len(r.Placeholders) > 0 {
+			text = placeholders.MaskBodyTokens(text, r.Placeholders)
+		}
 		sentences := mdtext.SplitSentences(text)
 		line := astutil.ParagraphLine(para, f)
 
@@ -120,6 +125,17 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 				)
 			}
 			r.MaxWords = n
+		case "placeholders":
+			toks, ok := settings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf(
+					"paragraph-structure: placeholders must be a list of strings, got %T", v,
+				)
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("paragraph-structure: %w", err)
+			}
+			r.Placeholders = toks
 		default:
 			return fmt.Errorf("paragraph-structure: unknown setting %q", k)
 		}
@@ -132,6 +148,7 @@ func (r *Rule) DefaultSettings() map[string]any {
 	return map[string]any{
 		"max-sentences":          6,
 		"max-words-per-sentence": 40,
+		"placeholders":           []string{},
 	}
 }
 

--- a/internal/rules/paragraphstructure/rule_test.go
+++ b/internal/rules/paragraphstructure/rule_test.go
@@ -205,3 +205,49 @@ func TestCategory(t *testing.T) {
 		t.Errorf("expected meta, got %s", r.Category())
 	}
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_Placeholder_VarToken_MaskedToWord(t *testing.T) {
+	// A paragraph consisting only of a var-token placeholder is masked to
+	// "word." (one word, one sentence), well below max-sentences and max-words,
+	// so no diagnostic is produced.
+	src := []byte("# Title\n\n{body}\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{MaxSentences: 6, MaxWords: 40, Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "var-token paragraph masked to neutral word should produce no diagnostic")
+}
+
+func TestCheck_Placeholder_EmptyList_StructureChecksRun(t *testing.T) {
+	// Without placeholders configured, behavior is unchanged.
+	// A paragraph with many sentences still gets flagged.
+	src := []byte("# Title\n\nFirst. Second. Third. Fourth. Fifth. Sixth. Seventh.\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{MaxSentences: 6, MaxWords: 40, Placeholders: []string{}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "over-sentence paragraph should still be flagged without placeholders")
+}
+
+func TestApplySettings_Placeholders_ParagraphStructure(t *testing.T) {
+	r := &Rule{MaxSentences: 6, MaxWords: 40}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"var-token"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"var-token"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken_ParagraphStructure(t *testing.T) {
+	r := &Rule{MaxSentences: 6, MaxWords: 40}
+	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad"}})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings_ParagraphStructure_IncludesPlaceholders(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	require.Equal(t, []string{}, ds["placeholders"])
+}

--- a/internal/rules/paragraphstructure/rule_test.go
+++ b/internal/rules/paragraphstructure/rule_test.go
@@ -246,6 +246,13 @@ func TestApplySettings_Placeholders_UnknownToken_ParagraphStructure(t *testing.T
 	require.Error(t, err)
 }
 
+func TestApplySettings_Placeholders_NonList_ParagraphStructure(t *testing.T) {
+	r := &Rule{MaxSentences: 6, MaxWords: 40}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list of strings")
+}
+
 func TestDefaultSettings_ParagraphStructure_IncludesPlaceholders(t *testing.T) {
 	r := &Rule{}
 	ds := r.DefaultSettings()

--- a/internal/rules/paragraphstructure/rule_test.go
+++ b/internal/rules/paragraphstructure/rule_test.go
@@ -210,7 +210,7 @@ func TestCategory(t *testing.T) {
 
 func TestCheck_Placeholder_VarToken_MaskedToWord(t *testing.T) {
 	// A paragraph consisting only of a var-token placeholder is masked to
-	// "word." (one word, one sentence), well below max-sentences and max-words,
+	// "word" (one word, no punctuation), well below max-sentences and max-words,
 	// so no diagnostic is produced.
 	src := []byte("# Title\n\n{body}\n")
 	f, err := lint.NewFile("test.md", src)

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -88,3 +88,7 @@ rules:
      Default may include key settings: "enabled, max: 80".
      Categories: code, heading, line, link, list, meta,
      whitespace. Delete Archetype bullet if not used. -->
+
+## ...
+
+<?allow-empty-section?>

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
+	rulesettings "github.com/jeduden/mdsmith/internal/rules/settings"
 	"github.com/yuin/goldmark/ast"
 	"gopkg.in/yaml.v3"
 )
@@ -65,9 +66,11 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 			}
 			r.ArchetypeRoots = roots
 		case "placeholders":
-			toks, err := asStringList("placeholders", v)
-			if err != nil {
-				return err
+			toks, ok := rulesettings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf(
+					"required-structure: placeholders must be a list of strings, got %T", v,
+				)
 			}
 			if err := placeholders.Validate(toks); err != nil {
 				return fmt.Errorf("required-structure: %w", err)

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/archetypes"
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/yuin/goldmark/ast"
 	"gopkg.in/yaml.v3"
@@ -29,6 +30,7 @@ type Rule struct {
 	Schema         string   // path to schema file
 	Archetype      string   // name of an archetype schema discovered under ArchetypeRoots
 	ArchetypeRoots []string // directories searched for archetypes; defaults to [archetypes.DefaultRoot]
+	Placeholders   []string // placeholder tokens to treat as opaque
 }
 
 // ID implements rule.Rule.
@@ -62,6 +64,15 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 				return err
 			}
 			r.ArchetypeRoots = roots
+		case "placeholders":
+			toks, err := asStringList("placeholders", v)
+			if err != nil {
+				return err
+			}
+			if err := placeholders.Validate(toks); err != nil {
+				return fmt.Errorf("required-structure: %w", err)
+			}
+			r.Placeholders = toks
 		default:
 			return fmt.Errorf("required-structure: unknown setting %q", k)
 		}
@@ -104,6 +115,7 @@ func (r *Rule) DefaultSettings() map[string]any {
 		"schema":          "",
 		"archetype":       "",
 		"archetype-roots": []string{archetypes.DefaultRoot},
+		"placeholders":    []string{},
 	}
 }
 
@@ -155,10 +167,14 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// Check structure: required headings present and in order.
 	diags = append(diags, checkStructure(f, sch, docHeadings)...)
 
-	// Validate document front matter against schema-embedded CUE constraints.
-	if err := validateFrontMatterCUE(sch.Config.FrontMatterCUE, docFMRaw); err != nil {
-		diags = append(diags, makeDiag(f.Path, 1,
-			fmt.Sprintf("front matter does not satisfy schema CUE constraints: %v", err)))
+	// Validate document front matter against schema-embedded CUE constraints,
+	// unless the cue-frontmatter placeholder token is configured (which marks
+	// the front-matter values as CUE expressions rather than concrete data).
+	if !placeholders.HasCUEFrontmatter(r.Placeholders) {
+		if err := validateFrontMatterCUE(sch.Config.FrontMatterCUE, docFMRaw); err != nil {
+			diags = append(diags, makeDiag(f.Path, 1,
+				fmt.Sprintf("front matter does not satisfy schema CUE constraints: %v", err)))
+		}
 	}
 
 	// Check frontmatter-body sync using raw map for nested access.

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -1867,12 +1867,7 @@ status: '"🔲" | "🔳" | "✅"'
 	f := newTestFile(t, "proto.md",
 		"---\nid: 'int & >=1'\nstatus: '\"🔲\" | \"🔳\" | \"✅\"'\n---\n# Template\n")
 	diags := r.Check(f)
-	// No CUE constraint violation should be reported.
-	for _, d := range diags {
-		if strings.Contains(d.Message, "CUE constraints") {
-			t.Errorf("should not report CUE constraint violation when cue-frontmatter configured, got: %s", d.Message)
-		}
-	}
+	require.Empty(t, diags, "expected no diagnostics when cue-frontmatter placeholder is configured")
 }
 
 func TestCheck_Placeholder_CUEFrontmatter_EmptyList_StillValidates(t *testing.T) {
@@ -1910,6 +1905,13 @@ func TestApplySettings_Placeholders_UnknownToken_RequiredStructure(t *testing.T)
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad"}})
 	require.Error(t, err)
+}
+
+func TestApplySettings_Placeholders_NonList_RequiredStructure(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": "not-a-list"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list of strings")
 }
 
 func TestDefaultSettings_RequiredStructure_IncludesPlaceholders(t *testing.T) {

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -1850,3 +1850,70 @@ func TestValidateCUESchemaSyntax_InvalidCUE(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid schema frontmatter CUE")
 }
+
+// --- Placeholder tests ---
+
+func TestCheck_Placeholder_CUEFrontmatter_Suppressed(t *testing.T) {
+	// When cue-frontmatter is configured, the front-matter CUE validation
+	// is skipped, so a document with CUE-pattern front-matter values passes.
+	schemaPath := writeSchema(t, `---
+id: 'int & >=1'
+status: '"🔲" | "🔳" | "✅"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath, Placeholders: []string{"cue-frontmatter"}}
+	// The document's front matter contains CUE expressions, not concrete values.
+	f := newTestFile(t, "proto.md",
+		"---\nid: 'int & >=1'\nstatus: '\"🔲\" | \"🔳\" | \"✅\"'\n---\n# Template\n")
+	diags := r.Check(f)
+	// No CUE constraint violation should be reported.
+	for _, d := range diags {
+		if strings.Contains(d.Message, "CUE constraints") {
+			t.Errorf("should not report CUE constraint violation when cue-frontmatter configured, got: %s", d.Message)
+		}
+	}
+}
+
+func TestCheck_Placeholder_CUEFrontmatter_EmptyList_StillValidates(t *testing.T) {
+	// Without cue-frontmatter in placeholders, CUE validation runs normally.
+	schemaPath := writeSchema(t, `---
+id: 'int & >=1'
+status: '"🔲" | "🔳" | "✅"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath, Placeholders: []string{}}
+	// Document with a CUE expression as a value violates the int constraint.
+	f := newTestFile(t, "doc.md",
+		"---\nid: 'int & >=1'\nstatus: \"✅\"\n---\n# Title\n")
+	diags := r.Check(f)
+	var hasCUEDiag bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "CUE constraints") {
+			hasCUEDiag = true
+		}
+	}
+	assert.True(t, hasCUEDiag, "CUE constraint violation should be reported without placeholder")
+}
+
+func TestApplySettings_Placeholders_RequiredStructure(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"placeholders": []any{"cue-frontmatter"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cue-frontmatter"}, r.Placeholders)
+}
+
+func TestApplySettings_Placeholders_UnknownToken_RequiredStructure(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"placeholders": []any{"bad"}})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings_RequiredStructure_IncludesPlaceholders(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	require.Equal(t, []string{}, ds["placeholders"])
+}

--- a/plan/93_placeholder-grammar.md
+++ b/plan/93_placeholder-grammar.md
@@ -1,7 +1,7 @@
 ---
 id: 93
 title: Placeholder grammar — opt-in token vocabulary
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Lift the ad-hoc placeholder escapes (`# ?`, `## ...`,
@@ -134,32 +134,32 @@ the list comes from config.
 
 ## Acceptance Criteria
 
-- [ ] The helper recognizes the four initial tokens
+- [x] The helper recognizes the four initial tokens
       and exposes detection + masking APIs.
-- [ ] Each opt-in rule reads its `placeholders:`
+- [x] Each opt-in rule reads its `placeholders:`
       setting via `Configurable` and consults the
       helper (verified by per-rule unit test).
-- [ ] With `placeholders:` empty, every rule produces
+- [x] With `placeholders:` empty, every rule produces
       the same diagnostics it does today (regression
       test).
-- [ ] With `placeholders:` set, configured tokens
+- [x] With `placeholders:` set, configured tokens
       produce no diagnostics from that rule.
-- [ ] `catalog` front-matter interpolation and
+- [x] `catalog` front-matter interpolation and
       engine front-matter parsing honor the same
       vocabulary (test covers a CUE-pattern value in
       a `<?catalog?>`-eligible file).
-- [ ] Adding a new token is a one-file change in the
+- [x] Adding a new token is a one-file change in the
       helper plus per-rule opt-ins; no rule names
       tokens hardcoded in its logic (enforced by
       review).
-- [ ] Concept page at
+- [x] Concept page at
       `docs/background/concepts/placeholder-grammar.md`
       describes the contract and is linked from each
       opt-in rule README.
-- [ ] `mdsmith help placeholder-grammar` prints the
+- [x] `mdsmith help placeholder-grammar` prints the
       concept page summary.
-- [ ] `mdsmith query` parses a file with CUE-pattern
+- [x] `mdsmith query` parses a file with CUE-pattern
       front matter under a placeholder-aware kind
       (covered by test).
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

Implement a shared placeholder token vocabulary that allows rules to treat template content as opaque rather than flagging it as violations. This enables linting of template files without false positives on placeholder tokens.

## Key Changes

- **New `internal/placeholders` package**: Provides a closed vocabulary of four placeholder tokens (`var-token`, `heading-question`, `placeholder-section`, `cue-frontmatter`) with detection and masking APIs:
  - `IsKnown()` / `Validate()` — token validation
  - `ContainsBodyToken()` — detect if text matches a placeholder
  - `MaskBodyTokens()` — replace placeholders with neutral content for analysis
  - `IsAllBodyTokens()` — check if text consists only of placeholders
  - `HasCUEFrontmatter()` — check for front-matter-only tokens

- **Rule opt-in support**: Six rules now accept a `placeholders:` setting via the `Configurable` interface:
  - `first-line-heading` (MDS004)
  - `heading-increment` (MDS003)
  - `no-emphasis-as-heading` (MDS018)
  - `cross-file-reference-integrity` (MDS027)
  - `paragraph-readability` (MDS023)
  - `paragraph-structure` (MDS024)
  - `required-structure` (MDS020)

- **Concept documentation**: Added `internal/concepts` package with embedded markdown documentation and a `Lookup()` API for retrieving concept pages. Includes placeholder-grammar concept documentation.

- **Comprehensive test coverage**: Added unit tests for all placeholder functions and per-rule integration tests verifying that:
  - Placeholders suppress diagnostics when configured
  - Behavior is unchanged when `placeholders:` is empty
  - Settings are properly applied and validated

## Implementation Details

- Placeholder detection uses regex patterns for whole-text tokens (`?`, `...`) and delegates to `fieldinterp` for variable token detection (`{field}`)
- Masking replaces tokens with neutral text: `{field}` → `word`, `?` → `Placeholder`, `...` → `Placeholder Section`
- `cue-frontmatter` is front-matter-only and ignored by body-token functions
- Rules check placeholders before performing their normal validation, allowing placeholder content to pass through unchanged
- All changes are backward compatible: empty `placeholders:` list produces identical behavior to before

https://claude.ai/code/session_01Q6a1ZWEGh2KNTTmxpMp7Br