### PR TITLE
Add `kinds` subcommand and `--explain` flag for rule provenance

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -30,7 +30,7 @@ footer: |
 | 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                               |
 | 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                      |
 | 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)              |
-| 95  | 🔲     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)     |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)     |
 | 96  | 🔲     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
 | 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                   |
 | 98  | 🔲     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |

--- a/cmd/mdsmith/explain_e2e_test.go
+++ b/cmd/mdsmith/explain_e2e_test.go
@@ -1,0 +1,108 @@
+package main_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// explainCfg sets line-length to 30 via a kind so that a too-long line
+// in a kind-assigned file triggers a diagnostic with provenance.
+const explainCfg = `kinds:
+  short:
+    rules:
+      line-length:
+        max: 30
+kind-assignment:
+  - files: ["short.md"]
+    kinds: [short]
+rules:
+  line-length:
+    max: 500
+`
+
+func TestExplain_TextTrailerNamesRuleAndSource(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"), []byte(explainCfg), 0o644))
+	long := "# Title\n\n" + strings.Repeat("x", 60) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "short.md"), []byte(long), 0o644))
+
+	_, stderr, code := runBinaryInDir(t, dir, "",
+		"check", "--explain", "--no-color", "short.md")
+	require.Equal(t, 1, code, "diagnostic expected; stderr=%q", stderr)
+	// The trailer mentions the rule and the kinds.short source.
+	assert.Contains(t, stderr, "line-length")
+	assert.Contains(t, stderr, "kinds.short")
+	// The trailer mentions the offending leaf.
+	assert.Contains(t, stderr, "settings.max")
+}
+
+func TestExplain_JSONHasExplanationField(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"), []byte(explainCfg), 0o644))
+	long := "# Title\n\n" + strings.Repeat("x", 60) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "short.md"), []byte(long), 0o644))
+
+	_, stderr, code := runBinaryInDir(t, dir, "",
+		"check", "--explain", "-f", "json", "short.md")
+	require.Equal(t, 1, code)
+
+	if strings.TrimSpace(stderr) == "" {
+		t.Fatalf("expected JSON output on stderr, got empty")
+	}
+
+	var diags []struct {
+		Rule        string `json:"rule"`
+		Name        string `json:"name"`
+		Explanation *struct {
+			Rule   string `json:"rule"`
+			Leaves []struct {
+				Path   string `json:"path"`
+				Value  any    `json:"value"`
+				Source string `json:"source"`
+			} `json:"leaves"`
+		} `json:"explanation"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stderr), &diags))
+	require.NotEmpty(t, diags)
+	for _, d := range diags {
+		if d.Name == "line-length" {
+			require.NotNil(t, d.Explanation, "explanation must be populated")
+			assert.Equal(t, "line-length", d.Explanation.Rule)
+			var sawMax bool
+			for _, l := range d.Explanation.Leaves {
+				if l.Path == "settings.max" {
+					sawMax = true
+					assert.Equal(t, "kinds.short", l.Source)
+					assert.EqualValues(t, 30, l.Value)
+				}
+			}
+			assert.True(t, sawMax, "settings.max leaf must be present")
+			return
+		}
+	}
+	t.Fatalf("did not find a line-length diagnostic in %q", stderr)
+}
+
+func TestExplain_OmittedWhenFlagUnset(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"), []byte(explainCfg), 0o644))
+	long := "# Title\n\n" + strings.Repeat("x", 60) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "short.md"), []byte(long), 0o644))
+
+	_, stderr, code := runBinaryInDir(t, dir, "",
+		"check", "--no-color", "short.md")
+	require.Equal(t, 1, code)
+	assert.NotContains(t, stderr, "kinds.short", "no provenance trailer without --explain")
+}

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -86,6 +86,9 @@ func runKindsList(args []string) int {
 		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds list [--json]")
 	}
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
 		return 2
 	}
 	if fs.NArg() > 0 {
@@ -136,6 +139,9 @@ func runKindsShow(args []string) int {
 		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds show <name> [--json]")
 	}
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
 		return 2
 	}
 	if fs.NArg() != 1 {
@@ -165,6 +171,37 @@ func runKindsShow(args []string) int {
 	return 0
 }
 
+// kindSchemaPath extracts a kind's required-structure.schema setting,
+// returning a clear stderr error and a non-zero exit code on every
+// way the kind can fail to resolve to a schema string.
+func kindSchemaPath(body config.KindBody, name string) (string, int) {
+	rs, ok := body.Rules["required-structure"]
+	if !ok || !rs.Enabled {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q does not configure required-structure\n", name)
+		return "", 2
+	}
+	rawSchema, hasSchema := rs.Settings["schema"]
+	if !hasSchema {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q has no required-structure.schema set\n", name)
+		return "", 2
+	}
+	schema, ok := rawSchema.(string)
+	if !ok {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q required-structure.schema must be a string, got %T (%v)\n",
+			name, rawSchema, rawSchema)
+		return "", 2
+	}
+	if schema == "" {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q has no required-structure.schema set\n", name)
+		return "", 2
+	}
+	return schema, 0
+}
+
 // runKindsPath prints the resolved schema path of the kind's
 // required-structure rule. Exits 2 when the kind is unknown or the
 // kind does not configure a schema.
@@ -174,6 +211,9 @@ func runKindsPath(args []string) int {
 		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds path <name>")
 	}
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
 		return 2
 	}
 	if fs.NArg() != 1 {
@@ -193,29 +233,9 @@ func runKindsPath(args []string) int {
 		return 2
 	}
 
-	rs, ok := body.Rules["required-structure"]
-	if !ok || !rs.Enabled {
-		fmt.Fprintf(os.Stderr,
-			"mdsmith: kind %q does not configure required-structure\n", name)
-		return 2
-	}
-	rawSchema, hasSchema := rs.Settings["schema"]
-	if !hasSchema {
-		fmt.Fprintf(os.Stderr,
-			"mdsmith: kind %q has no required-structure.schema set\n", name)
-		return 2
-	}
-	schema, ok := rawSchema.(string)
-	if !ok {
-		fmt.Fprintf(os.Stderr,
-			"mdsmith: kind %q required-structure.schema must be a string, got %T (%v)\n",
-			name, rawSchema, rawSchema)
-		return 2
-	}
-	if schema == "" {
-		fmt.Fprintf(os.Stderr,
-			"mdsmith: kind %q has no required-structure.schema set\n", name)
-		return 2
+	schema, code := kindSchemaPath(body, name)
+	if code != 0 {
+		return code
 	}
 	resolved := schema
 	if !filepath.IsAbs(schema) {
@@ -277,6 +297,9 @@ func runKindsResolve(args []string) int {
 		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds resolve <file> [--json]")
 	}
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
 		return 2
 	}
 	if fs.NArg() != 1 {
@@ -308,6 +331,9 @@ func runKindsWhy(args []string) int {
 		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds why <file> <rule> [--json]")
 	}
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
 		return 2
 	}
 	if fs.NArg() != 2 {

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -1,17 +1,16 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	flag "github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
 
 	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/kindsout"
 	"github.com/jeduden/mdsmith/internal/lint"
 )
 
@@ -78,51 +77,6 @@ func sortedKindNames(cfg *config.Config) []string {
 	return names
 }
 
-// kindBodyForJSON renders a KindBody as a JSON-friendly value with
-// rules and categories separated, using the rule config's marshal
-// form (settings map or bool).
-type kindBodyJSON struct {
-	Name       string                 `json:"name"`
-	Rules      map[string]ruleCfgJSON `json:"rules"`
-	Categories map[string]bool        `json:"categories,omitempty"`
-}
-
-// ruleCfgJSON serializes a RuleCfg to JSON. A disabled rule is the
-// boolean false; an enabled rule with settings is its settings map;
-// an enabled rule without settings is the boolean true.
-type ruleCfgJSON struct {
-	v any
-}
-
-// MarshalJSON implements json.Marshaler for ruleCfgJSON.
-func (r ruleCfgJSON) MarshalJSON() ([]byte, error) {
-	return json.Marshal(r.v)
-}
-
-func makeKindBodyJSON(name string, body config.KindBody) kindBodyJSON {
-	rules := make(map[string]ruleCfgJSON, len(body.Rules))
-	for k, v := range body.Rules {
-		rules[k] = ruleCfgJSON{v: ruleCfgValue(v)}
-	}
-	return kindBodyJSON{
-		Name:       name,
-		Rules:      rules,
-		Categories: body.Categories,
-	}
-}
-
-// ruleCfgValue returns the JSON-friendly value of a RuleCfg, matching
-// its YAML marshalling: false, true, or the settings map.
-func ruleCfgValue(rc config.RuleCfg) any {
-	if !rc.Enabled && rc.Settings == nil {
-		return false
-	}
-	if rc.Enabled && len(rc.Settings) > 0 {
-		return rc.Settings
-	}
-	return true
-}
-
 // runKindsList prints declared kinds with their merged bodies.
 func runKindsList(args []string) int {
 	fs := flag.NewFlagSet("kinds list", flag.ContinueOnError)
@@ -148,10 +102,10 @@ func runKindsList(args []string) int {
 
 	if asJSON {
 		out := struct {
-			Kinds []kindBodyJSON `json:"kinds"`
-		}{Kinds: make([]kindBodyJSON, 0, len(names))}
+			Kinds []kindsout.BodyJSON `json:"kinds"`
+		}{Kinds: make([]kindsout.BodyJSON, 0, len(names))}
 		for _, name := range names {
-			out.Kinds = append(out.Kinds, makeKindBodyJSON(name, cfg.Kinds[name]))
+			out.Kinds = append(out.Kinds, kindsout.MakeBodyJSON(name, cfg.Kinds[name]))
 		}
 		return writeJSON(os.Stdout, out)
 	}
@@ -166,40 +120,11 @@ func runKindsList(args []string) int {
 				return printErr(err)
 			}
 		}
-		if err := writeKindBodyText(os.Stdout, name, cfg.Kinds[name]); err != nil {
+		if err := kindsout.WriteBodyText(os.Stdout, name, cfg.Kinds[name]); err != nil {
 			return printErr(err)
 		}
 	}
 	return 0
-}
-
-// writeKindBodyText renders a kind body as YAML with a header line
-// naming the kind. Useful for both list and show.
-func writeKindBodyText(w *os.File, name string, body config.KindBody) error {
-	if _, err := fmt.Fprintf(w, "%s:\n", name); err != nil {
-		return err
-	}
-	wrap := struct {
-		Rules      map[string]config.RuleCfg `yaml:"rules,omitempty"`
-		Categories map[string]bool           `yaml:"categories,omitempty"`
-	}{
-		Rules:      body.Rules,
-		Categories: body.Categories,
-	}
-	data, err := yaml.Marshal(wrap)
-	if err != nil {
-		return err
-	}
-	if len(data) == 0 || strings.TrimSpace(string(data)) == "{}" {
-		_, err := fmt.Fprintln(w, "  (empty)")
-		return err
-	}
-	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
-		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // runKindsShow prints one kind's merged body.
@@ -231,12 +156,11 @@ func runKindsShow(args []string) int {
 	}
 
 	if asJSON {
-		return writeJSON(os.Stdout, makeKindBodyJSON(name, body))
+		return writeJSON(os.Stdout, kindsout.MakeBodyJSON(name, body))
 	}
 
-	if err := writeKindBodyText(os.Stdout, name, body); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
+	if err := kindsout.WriteBodyText(os.Stdout, name, body); err != nil {
+		return printErr(err)
 	}
 	return 0
 }
@@ -275,7 +199,19 @@ func runKindsPath(args []string) int {
 			"mdsmith: kind %q does not configure required-structure\n", name)
 		return 2
 	}
-	schema, _ := rs.Settings["schema"].(string)
+	rawSchema, hasSchema := rs.Settings["schema"]
+	if !hasSchema {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q has no required-structure.schema set\n", name)
+		return 2
+	}
+	schema, ok := rawSchema.(string)
+	if !ok {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q required-structure.schema must be a string, got %T (%v)\n",
+			name, rawSchema, rawSchema)
+		return 2
+	}
 	if schema == "" {
 		fmt.Fprintf(os.Stderr,
 			"mdsmith: kind %q has no required-structure.schema set\n", name)
@@ -289,8 +225,7 @@ func runKindsPath(args []string) int {
 		}
 	}
 	if _, err := fmt.Fprintln(os.Stdout, resolved); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
+		return printErr(err)
 	}
 	return 0
 }
@@ -356,9 +291,12 @@ func runKindsResolve(args []string) int {
 	}
 
 	if asJSON {
-		return writeJSON(os.Stdout, fileResolutionJSON(res))
+		return writeJSON(os.Stdout, kindsout.FileResolution(res))
 	}
-	return writeFileResolutionText(os.Stdout, res)
+	if err := kindsout.WriteFileResolutionText(os.Stdout, res); err != nil {
+		return printErr(err)
+	}
+	return 0
 }
 
 // runKindsWhy prints the full merge chain for one rule on one file.
@@ -391,218 +329,21 @@ func runKindsWhy(args []string) int {
 	}
 
 	if asJSON {
-		return writeJSON(os.Stdout, ruleResolutionJSON(res.File, rr))
+		return writeJSON(os.Stdout, kindsout.RuleResolution(res.File, rr))
 	}
-	return writeRuleResolutionText(os.Stdout, res.File, rr)
+	if err := kindsout.WriteRuleResolutionText(os.Stdout, res.File, rr); err != nil {
+		return printErr(err)
+	}
+	return 0
 }
 
 // writeJSON emits v as pretty-printed JSON. Returns a non-zero exit
 // code on encoding error.
-func writeJSON(w *os.File, v any) int {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(v); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
+func writeJSON(w io.Writer, v any) int {
+	if err := kindsout.WriteJSON(w, v); err != nil {
+		return printErr(err)
 	}
 	return 0
-}
-
-// --- JSON shape for resolve / why ---
-
-type resolvedKindJSON struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
-}
-
-type leafJSON struct {
-	Path   string          `json:"path"`
-	Value  any             `json:"value"`
-	Source string          `json:"source"`
-	Chain  []leafChainJSON `json:"chain,omitempty"`
-}
-
-type leafChainJSON struct {
-	Source string `json:"source"`
-	Value  any    `json:"value"`
-}
-
-type layerJSON struct {
-	Source string `json:"source"`
-	Set    bool   `json:"set"`
-	Value  any    `json:"value,omitempty"`
-}
-
-type ruleResolutionJSONShape struct {
-	File   string      `json:"file"`
-	Rule   string      `json:"rule"`
-	Final  any         `json:"final"`
-	Layers []layerJSON `json:"layers"`
-	Leaves []leafJSON  `json:"leaves"`
-}
-
-type fileResolutionJSONShape struct {
-	File       string                 `json:"file"`
-	Kinds      []resolvedKindJSON     `json:"kinds"`
-	Categories map[string]bool        `json:"categories,omitempty"`
-	Rules      map[string]ruleSummary `json:"rules"`
-}
-
-type ruleSummary struct {
-	Final  any        `json:"final"`
-	Leaves []leafJSON `json:"leaves"`
-}
-
-func fileResolutionJSON(res *config.FileResolution) fileResolutionJSONShape {
-	out := fileResolutionJSONShape{
-		File:       res.File,
-		Kinds:      make([]resolvedKindJSON, 0, len(res.Kinds)),
-		Categories: res.Categories,
-		Rules:      make(map[string]ruleSummary, len(res.Rules)),
-	}
-	for _, k := range res.Kinds {
-		out.Kinds = append(out.Kinds, resolvedKindJSON{
-			Name: k.Name, Source: string(k.Source),
-		})
-	}
-	for name, rr := range res.Rules {
-		out.Rules[name] = ruleSummary{
-			Final:  ruleCfgValue(rr.Final),
-			Leaves: leavesJSON(rr.Leaves),
-		}
-	}
-	return out
-}
-
-func ruleResolutionJSON(file string, rr config.RuleResolution) ruleResolutionJSONShape {
-	layers := make([]layerJSON, 0, len(rr.Layers))
-	for _, l := range rr.Layers {
-		entry := layerJSON{Source: l.Source, Set: l.Set}
-		if l.Set {
-			entry.Value = ruleCfgValue(l.Value)
-		}
-		layers = append(layers, entry)
-	}
-	return ruleResolutionJSONShape{
-		File:   file,
-		Rule:   rr.Rule,
-		Final:  ruleCfgValue(rr.Final),
-		Layers: layers,
-		Leaves: leavesJSON(rr.Leaves),
-	}
-}
-
-func leavesJSON(leaves []config.Leaf) []leafJSON {
-	out := make([]leafJSON, 0, len(leaves))
-	for _, l := range leaves {
-		entry := leafJSON{
-			Path:   l.Path,
-			Value:  l.Value,
-			Source: l.Source(),
-		}
-		for _, c := range l.Chain {
-			entry.Chain = append(entry.Chain, leafChainJSON{
-				Source: c.Source, Value: c.Value,
-			})
-		}
-		out = append(out, entry)
-	}
-	return out
-}
-
-// --- Text rendering for resolve / why ---
-
-// fpf is a write-with-error-check helper that swallows the byte count
-// from fmt.Fprintf so callers only need to track the error.
-func fpf(w *os.File, format string, args ...any) error {
-	_, err := fmt.Fprintf(w, format, args...)
-	return err
-}
-
-func writeFileResolutionText(w *os.File, res *config.FileResolution) int {
-	if err := fpf(w, "file: %s\n", res.File); err != nil {
-		return printErr(err)
-	}
-	if err := fpf(w, "effective kinds:\n"); err != nil {
-		return printErr(err)
-	}
-	if len(res.Kinds) == 0 {
-		if err := fpf(w, "  (none)\n"); err != nil {
-			return printErr(err)
-		}
-	} else {
-		for _, k := range res.Kinds {
-			if err := fpf(w, "  - %s (from %s)\n", k.Name, k.Source); err != nil {
-				return printErr(err)
-			}
-		}
-	}
-
-	if err := fpf(w, "rules:\n"); err != nil {
-		return printErr(err)
-	}
-	names := make([]string, 0, len(res.Rules))
-	for name := range res.Rules {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		rr := res.Rules[name]
-		if err := fpf(w, "  %s:\n", name); err != nil {
-			return printErr(err)
-		}
-		for _, leaf := range rr.Leaves {
-			if err := fpf(w, "    %s = %s  (from %s)\n",
-				leaf.Path, formatValue(leaf.Value), leaf.Source()); err != nil {
-				return printErr(err)
-			}
-		}
-	}
-	return 0
-}
-
-func writeRuleResolutionText(w *os.File, file string, rr config.RuleResolution) int {
-	if err := fpf(w, "file: %s\nrule: %s\n\nmerge chain (oldest -> newest):\n",
-		file, rr.Rule); err != nil {
-		return printErr(err)
-	}
-	for _, l := range rr.Layers {
-		var line string
-		if l.Set {
-			line = fmt.Sprintf("  %-30s set    %s\n",
-				l.Source, formatValue(ruleCfgValue(l.Value)))
-		} else {
-			line = fmt.Sprintf("  %-30s no-op  (rule untouched)\n", l.Source)
-		}
-		if err := fpf(w, "%s", line); err != nil {
-			return printErr(err)
-		}
-	}
-	if err := fpf(w, "\nper-leaf provenance:\n"); err != nil {
-		return printErr(err)
-	}
-	for _, leaf := range rr.Leaves {
-		if err := fpf(w, "  %s = %s  (winning source: %s)\n",
-			leaf.Path, formatValue(leaf.Value), leaf.Source()); err != nil {
-			return printErr(err)
-		}
-		for _, c := range leaf.Chain {
-			if err := fpf(w, "    %-28s %s\n", c.Source, formatValue(c.Value)); err != nil {
-				return printErr(err)
-			}
-		}
-	}
-	return 0
-}
-
-// formatValue renders a leaf value compactly (JSON-like) so settings
-// maps / lists / scalars all print on one line.
-func formatValue(v any) string {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Sprintf("%v", v)
-	}
-	return string(b)
 }
 
 func printErr(err error) int {

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -266,8 +266,9 @@ func readFrontMatterKinds(path string, maxBytes int64) ([]string, error) {
 //
 // When the config disables front matter (`front-matter: false`), front
 // matter is neither parsed nor validated so the resolution mirrors the
-// engine's behavior; the file is still stat'd to surface a clear error
-// for missing or unreadable paths.
+// engine's behavior. The file is still opened and read (and checked
+// against max-input-size) to surface readability errors and to match
+// the engine's rejection of oversized or unreadable paths.
 func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, int) {
 	cfg, _, code := kindsConfig()
 	if code != 0 {
@@ -290,9 +291,20 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 			return nil, nil, 2
 		}
-	} else if _, err := os.Stat(path); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
-		return nil, nil, 2
+	} else {
+		// front-matter disabled: no kinds from front matter, but still
+		// attempt an open/read to mirror the engine's readability and
+		// max-input-size checks (os.Stat passes on directories and
+		// unreadable paths).
+		maxBytes, err := resolveMaxInputBytes(cfg, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return nil, nil, 2
+		}
+		if _, err := lint.ReadFileLimited(path, maxBytes); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
+			return nil, nil, 2
+		}
 	}
 
 	return config.ResolveFile(cfg, path, fmKinds), cfg, 0

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -1,0 +1,611 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+const kindsUsage = `Usage: mdsmith kinds <subcommand> [args]
+
+Subcommands:
+  list                  Print declared kinds with their merged bodies.
+  show <name>           Print one kind's merged body.
+  path <name>           Print the resolved schema path of the kind's
+                        required-structure rule, if any.
+  resolve <file>        Print the resolved kind list and merged rule
+                        config for a file, with per-leaf provenance.
+  why <file> <rule>     Print the full merge chain for one rule on
+                        one file, including no-op layers.
+
+Each subcommand accepts --json for stable structured output.
+`
+
+// runKinds dispatches the kinds subcommand.
+func runKinds(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, kindsUsage)
+		return 0
+	}
+	switch args[0] {
+	case "--help", "-h":
+		fmt.Fprint(os.Stderr, kindsUsage)
+		return 0
+	case "list":
+		return runKindsList(args[1:])
+	case "show":
+		return runKindsShow(args[1:])
+	case "path":
+		return runKindsPath(args[1:])
+	case "resolve":
+		return runKindsResolve(args[1:])
+	case "why":
+		return runKindsWhy(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kinds: unknown subcommand %q\n\n%s",
+			args[0], kindsUsage)
+		return 2
+	}
+}
+
+// kindsConfig loads the merged config and returns it. Errors are
+// printed to stderr and a non-zero exit code is returned.
+func kindsConfig() (*config.Config, string, int) {
+	cfg, cfgPath, err := loadConfig("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, "", 2
+	}
+	return cfg, cfgPath, 0
+}
+
+func sortedKindNames(cfg *config.Config) []string {
+	names := make([]string, 0, len(cfg.Kinds))
+	for name := range cfg.Kinds {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// kindBodyForJSON renders a KindBody as a JSON-friendly value with
+// rules and categories separated, using the rule config's marshal
+// form (settings map or bool).
+type kindBodyJSON struct {
+	Name       string                 `json:"name"`
+	Rules      map[string]ruleCfgJSON `json:"rules"`
+	Categories map[string]bool        `json:"categories,omitempty"`
+}
+
+// ruleCfgJSON serializes a RuleCfg to JSON. A disabled rule is the
+// boolean false; an enabled rule with settings is its settings map;
+// an enabled rule without settings is the boolean true.
+type ruleCfgJSON struct {
+	v any
+}
+
+// MarshalJSON implements json.Marshaler for ruleCfgJSON.
+func (r ruleCfgJSON) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.v)
+}
+
+func makeKindBodyJSON(name string, body config.KindBody) kindBodyJSON {
+	rules := make(map[string]ruleCfgJSON, len(body.Rules))
+	for k, v := range body.Rules {
+		rules[k] = ruleCfgJSON{v: ruleCfgValue(v)}
+	}
+	return kindBodyJSON{
+		Name:       name,
+		Rules:      rules,
+		Categories: body.Categories,
+	}
+}
+
+// ruleCfgValue returns the JSON-friendly value of a RuleCfg, matching
+// its YAML marshalling: false, true, or the settings map.
+func ruleCfgValue(rc config.RuleCfg) any {
+	if !rc.Enabled && rc.Settings == nil {
+		return false
+	}
+	if rc.Enabled && len(rc.Settings) > 0 {
+		return rc.Settings
+	}
+	return true
+}
+
+// runKindsList prints declared kinds with their merged bodies.
+func runKindsList(args []string) int {
+	fs := flag.NewFlagSet("kinds list", flag.ContinueOnError)
+	var asJSON bool
+	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds list [--json]")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(os.Stderr, "mdsmith: kinds list takes no positional arguments")
+		return 2
+	}
+
+	cfg, _, code := kindsConfig()
+	if code != 0 {
+		return code
+	}
+
+	names := sortedKindNames(cfg)
+
+	if asJSON {
+		out := struct {
+			Kinds []kindBodyJSON `json:"kinds"`
+		}{Kinds: make([]kindBodyJSON, 0, len(names))}
+		for _, name := range names {
+			out.Kinds = append(out.Kinds, makeKindBodyJSON(name, cfg.Kinds[name]))
+		}
+		return writeJSON(os.Stdout, out)
+	}
+
+	if len(names) == 0 {
+		fmt.Fprintln(os.Stderr, "mdsmith: no kinds declared in config")
+		return 0
+	}
+	for i, name := range names {
+		if i > 0 {
+			if _, err := fmt.Fprintln(os.Stdout); err != nil {
+				return printErr(err)
+			}
+		}
+		if err := writeKindBodyText(os.Stdout, name, cfg.Kinds[name]); err != nil {
+			return printErr(err)
+		}
+	}
+	return 0
+}
+
+// writeKindBodyText renders a kind body as YAML with a header line
+// naming the kind. Useful for both list and show.
+func writeKindBodyText(w *os.File, name string, body config.KindBody) error {
+	if _, err := fmt.Fprintf(w, "%s:\n", name); err != nil {
+		return err
+	}
+	wrap := struct {
+		Rules      map[string]config.RuleCfg `yaml:"rules,omitempty"`
+		Categories map[string]bool           `yaml:"categories,omitempty"`
+	}{
+		Rules:      body.Rules,
+		Categories: body.Categories,
+	}
+	data, err := yaml.Marshal(wrap)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 || strings.TrimSpace(string(data)) == "{}" {
+		_, err := fmt.Fprintln(w, "  (empty)")
+		return err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runKindsShow prints one kind's merged body.
+func runKindsShow(args []string) int {
+	fs := flag.NewFlagSet("kinds show", flag.ContinueOnError)
+	var asJSON bool
+	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds show <name> [--json]")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "mdsmith: kinds show requires exactly one kind name")
+		return 2
+	}
+	name := fs.Arg(0)
+
+	cfg, _, code := kindsConfig()
+	if code != 0 {
+		return code
+	}
+
+	body, ok := cfg.Kinds[name]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "mdsmith: unknown kind %q\n", name)
+		return 2
+	}
+
+	if asJSON {
+		return writeJSON(os.Stdout, makeKindBodyJSON(name, body))
+	}
+
+	if err := writeKindBodyText(os.Stdout, name, body); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	return 0
+}
+
+// runKindsPath prints the resolved schema path of the kind's
+// required-structure rule. Exits 2 when the kind is unknown or the
+// kind does not configure a schema.
+func runKindsPath(args []string) int {
+	fs := flag.NewFlagSet("kinds path", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds path <name>")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "mdsmith: kinds path requires exactly one kind name")
+		return 2
+	}
+	name := fs.Arg(0)
+
+	cfg, cfgPath, code := kindsConfig()
+	if code != 0 {
+		return code
+	}
+
+	body, ok := cfg.Kinds[name]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "mdsmith: unknown kind %q\n", name)
+		return 2
+	}
+
+	rs, ok := body.Rules["required-structure"]
+	if !ok || !rs.Enabled {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q does not configure required-structure\n", name)
+		return 2
+	}
+	schema, _ := rs.Settings["schema"].(string)
+	if schema == "" {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: kind %q has no required-structure.schema set\n", name)
+		return 2
+	}
+	resolved := schema
+	if !filepath.IsAbs(schema) {
+		root := rootDirFromConfig(cfgPath)
+		if root != "" {
+			resolved = filepath.Join(root, schema)
+		}
+	}
+	if _, err := fmt.Fprintln(os.Stdout, resolved); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	return 0
+}
+
+// readFrontMatterKinds reads a file and parses its front-matter kinds: list.
+// Returns nil kinds when the file has no front matter or no kinds: field.
+func readFrontMatterKinds(path string, maxBytes int64) ([]string, error) {
+	data, err := lint.ReadFileLimited(path, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	prefix, _ := lint.StripFrontMatter(data)
+	return lint.ParseFrontMatterKinds(prefix)
+}
+
+// resolveFileFromCLI loads config, parses the file's front matter for
+// kinds: and returns a FileResolution. Errors are printed to stderr.
+func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, int) {
+	cfg, _, code := kindsConfig()
+	if code != 0 {
+		return nil, nil, code
+	}
+	maxBytes, err := resolveMaxInputBytes(cfg, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, nil, 2
+	}
+
+	fmKinds, err := readFrontMatterKinds(path, maxBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
+		return nil, nil, 2
+	}
+	if err := config.ValidateFrontMatterKinds(cfg, path, fmKinds); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, nil, 2
+	}
+
+	return config.ResolveFile(cfg, path, fmKinds), cfg, 0
+}
+
+// runKindsResolve prints the resolved kind list and merged rule config
+// for a single file, with per-leaf provenance.
+func runKindsResolve(args []string) int {
+	fs := flag.NewFlagSet("kinds resolve", flag.ContinueOnError)
+	var asJSON bool
+	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds resolve <file> [--json]")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "mdsmith: kinds resolve requires exactly one file argument")
+		return 2
+	}
+	path := fs.Arg(0)
+
+	res, _, code := resolveFileFromCLI(path)
+	if code != 0 {
+		return code
+	}
+
+	if asJSON {
+		return writeJSON(os.Stdout, fileResolutionJSON(res))
+	}
+	return writeFileResolutionText(os.Stdout, res)
+}
+
+// runKindsWhy prints the full merge chain for one rule on one file.
+func runKindsWhy(args []string) int {
+	fs := flag.NewFlagSet("kinds why", flag.ContinueOnError)
+	var asJSON bool
+	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds why <file> <rule> [--json]")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "mdsmith: kinds why requires <file> and <rule>")
+		return 2
+	}
+	path, ruleName := fs.Arg(0), fs.Arg(1)
+
+	res, _, code := resolveFileFromCLI(path)
+	if code != 0 {
+		return code
+	}
+
+	rr, ok := res.Rules[ruleName]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "mdsmith: rule %q not found in effective config for %s\n",
+			ruleName, path)
+		return 2
+	}
+
+	if asJSON {
+		return writeJSON(os.Stdout, ruleResolutionJSON(res.File, rr))
+	}
+	return writeRuleResolutionText(os.Stdout, res.File, rr)
+}
+
+// writeJSON emits v as pretty-printed JSON. Returns a non-zero exit
+// code on encoding error.
+func writeJSON(w *os.File, v any) int {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	return 0
+}
+
+// --- JSON shape for resolve / why ---
+
+type resolvedKindJSON struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+}
+
+type leafJSON struct {
+	Path   string          `json:"path"`
+	Value  any             `json:"value"`
+	Source string          `json:"source"`
+	Chain  []leafChainJSON `json:"chain,omitempty"`
+}
+
+type leafChainJSON struct {
+	Source string `json:"source"`
+	Value  any    `json:"value"`
+}
+
+type layerJSON struct {
+	Source string `json:"source"`
+	Set    bool   `json:"set"`
+	Value  any    `json:"value,omitempty"`
+}
+
+type ruleResolutionJSONShape struct {
+	File   string      `json:"file"`
+	Rule   string      `json:"rule"`
+	Final  any         `json:"final"`
+	Layers []layerJSON `json:"layers"`
+	Leaves []leafJSON  `json:"leaves"`
+}
+
+type fileResolutionJSONShape struct {
+	File       string                 `json:"file"`
+	Kinds      []resolvedKindJSON     `json:"kinds"`
+	Categories map[string]bool        `json:"categories,omitempty"`
+	Rules      map[string]ruleSummary `json:"rules"`
+}
+
+type ruleSummary struct {
+	Final  any        `json:"final"`
+	Leaves []leafJSON `json:"leaves"`
+}
+
+func fileResolutionJSON(res *config.FileResolution) fileResolutionJSONShape {
+	out := fileResolutionJSONShape{
+		File:       res.File,
+		Kinds:      make([]resolvedKindJSON, 0, len(res.Kinds)),
+		Categories: res.Categories,
+		Rules:      make(map[string]ruleSummary, len(res.Rules)),
+	}
+	for _, k := range res.Kinds {
+		out.Kinds = append(out.Kinds, resolvedKindJSON{
+			Name: k.Name, Source: string(k.Source),
+		})
+	}
+	for name, rr := range res.Rules {
+		out.Rules[name] = ruleSummary{
+			Final:  ruleCfgValue(rr.Final),
+			Leaves: leavesJSON(rr.Leaves),
+		}
+	}
+	return out
+}
+
+func ruleResolutionJSON(file string, rr config.RuleResolution) ruleResolutionJSONShape {
+	layers := make([]layerJSON, 0, len(rr.Layers))
+	for _, l := range rr.Layers {
+		entry := layerJSON{Source: l.Source, Set: l.Set}
+		if l.Set {
+			entry.Value = ruleCfgValue(l.Value)
+		}
+		layers = append(layers, entry)
+	}
+	return ruleResolutionJSONShape{
+		File:   file,
+		Rule:   rr.Rule,
+		Final:  ruleCfgValue(rr.Final),
+		Layers: layers,
+		Leaves: leavesJSON(rr.Leaves),
+	}
+}
+
+func leavesJSON(leaves []config.Leaf) []leafJSON {
+	out := make([]leafJSON, 0, len(leaves))
+	for _, l := range leaves {
+		entry := leafJSON{
+			Path:   l.Path,
+			Value:  l.Value,
+			Source: l.Source(),
+		}
+		for _, c := range l.Chain {
+			entry.Chain = append(entry.Chain, leafChainJSON{
+				Source: c.Source, Value: c.Value,
+			})
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// --- Text rendering for resolve / why ---
+
+// fpf is a write-with-error-check helper that swallows the byte count
+// from fmt.Fprintf so callers only need to track the error.
+func fpf(w *os.File, format string, args ...any) error {
+	_, err := fmt.Fprintf(w, format, args...)
+	return err
+}
+
+func writeFileResolutionText(w *os.File, res *config.FileResolution) int {
+	if err := fpf(w, "file: %s\n", res.File); err != nil {
+		return printErr(err)
+	}
+	if err := fpf(w, "effective kinds:\n"); err != nil {
+		return printErr(err)
+	}
+	if len(res.Kinds) == 0 {
+		if err := fpf(w, "  (none)\n"); err != nil {
+			return printErr(err)
+		}
+	} else {
+		for _, k := range res.Kinds {
+			if err := fpf(w, "  - %s (from %s)\n", k.Name, k.Source); err != nil {
+				return printErr(err)
+			}
+		}
+	}
+
+	if err := fpf(w, "rules:\n"); err != nil {
+		return printErr(err)
+	}
+	names := make([]string, 0, len(res.Rules))
+	for name := range res.Rules {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		rr := res.Rules[name]
+		if err := fpf(w, "  %s:\n", name); err != nil {
+			return printErr(err)
+		}
+		for _, leaf := range rr.Leaves {
+			if err := fpf(w, "    %s = %s  (from %s)\n",
+				leaf.Path, formatValue(leaf.Value), leaf.Source()); err != nil {
+				return printErr(err)
+			}
+		}
+	}
+	return 0
+}
+
+func writeRuleResolutionText(w *os.File, file string, rr config.RuleResolution) int {
+	if err := fpf(w, "file: %s\nrule: %s\n\nmerge chain (oldest -> newest):\n",
+		file, rr.Rule); err != nil {
+		return printErr(err)
+	}
+	for _, l := range rr.Layers {
+		var line string
+		if l.Set {
+			line = fmt.Sprintf("  %-30s set    %s\n",
+				l.Source, formatValue(ruleCfgValue(l.Value)))
+		} else {
+			line = fmt.Sprintf("  %-30s no-op  (rule untouched)\n", l.Source)
+		}
+		if err := fpf(w, "%s", line); err != nil {
+			return printErr(err)
+		}
+	}
+	if err := fpf(w, "\nper-leaf provenance:\n"); err != nil {
+		return printErr(err)
+	}
+	for _, leaf := range rr.Leaves {
+		if err := fpf(w, "  %s = %s  (winning source: %s)\n",
+			leaf.Path, formatValue(leaf.Value), leaf.Source()); err != nil {
+			return printErr(err)
+		}
+		for _, c := range leaf.Chain {
+			if err := fpf(w, "    %-28s %s\n", c.Source, formatValue(c.Value)); err != nil {
+				return printErr(err)
+			}
+		}
+	}
+	return 0
+}
+
+// formatValue renders a leaf value compactly (JSON-like) so settings
+// maps / lists / scalars all print on one line.
+func formatValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func printErr(err error) int {
+	fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+	return 2
+}

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -40,15 +40,15 @@ func runKinds(args []string) int {
 		fmt.Fprint(os.Stderr, kindsUsage)
 		return 0
 	case "list":
-		return runKindsList(args[1:])
+		return runKindsList(os.Stdout, args[1:])
 	case "show":
-		return runKindsShow(args[1:])
+		return runKindsShow(os.Stdout, args[1:])
 	case "path":
-		return runKindsPath(args[1:])
+		return runKindsPath(os.Stdout, args[1:])
 	case "resolve":
-		return runKindsResolve(args[1:])
+		return runKindsResolve(os.Stdout, args[1:])
 	case "why":
-		return runKindsWhy(args[1:])
+		return runKindsWhy(os.Stdout, args[1:])
 	default:
 		fmt.Fprintf(os.Stderr,
 			"mdsmith: kinds: unknown subcommand %q\n\n%s",
@@ -78,7 +78,7 @@ func sortedKindNames(cfg *config.Config) []string {
 }
 
 // runKindsList prints declared kinds with their merged bodies.
-func runKindsList(args []string) int {
+func runKindsList(stdout io.Writer, args []string) int {
 	fs := flag.NewFlagSet("kinds list", flag.ContinueOnError)
 	var asJSON bool
 	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
@@ -110,7 +110,7 @@ func runKindsList(args []string) int {
 		for _, name := range names {
 			out.Kinds = append(out.Kinds, kindsout.MakeBodyJSON(name, cfg.Kinds[name]))
 		}
-		return writeJSON(os.Stdout, out)
+		return writeJSON(stdout, out)
 	}
 
 	if len(names) == 0 {
@@ -119,11 +119,11 @@ func runKindsList(args []string) int {
 	}
 	for i, name := range names {
 		if i > 0 {
-			if _, err := fmt.Fprintln(os.Stdout); err != nil {
+			if _, err := fmt.Fprintln(stdout); err != nil {
 				return printErr(err)
 			}
 		}
-		if err := kindsout.WriteBodyText(os.Stdout, name, cfg.Kinds[name]); err != nil {
+		if err := kindsout.WriteBodyText(stdout, name, cfg.Kinds[name]); err != nil {
 			return printErr(err)
 		}
 	}
@@ -131,7 +131,7 @@ func runKindsList(args []string) int {
 }
 
 // runKindsShow prints one kind's merged body.
-func runKindsShow(args []string) int {
+func runKindsShow(stdout io.Writer, args []string) int {
 	fs := flag.NewFlagSet("kinds show", flag.ContinueOnError)
 	var asJSON bool
 	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
@@ -162,10 +162,10 @@ func runKindsShow(args []string) int {
 	}
 
 	if asJSON {
-		return writeJSON(os.Stdout, kindsout.MakeBodyJSON(name, body))
+		return writeJSON(stdout, kindsout.MakeBodyJSON(name, body))
 	}
 
-	if err := kindsout.WriteBodyText(os.Stdout, name, body); err != nil {
+	if err := kindsout.WriteBodyText(stdout, name, body); err != nil {
 		return printErr(err)
 	}
 	return 0
@@ -205,7 +205,7 @@ func kindSchemaPath(body config.KindBody, name string) (string, int) {
 // runKindsPath prints the resolved schema path of the kind's
 // required-structure rule. Exits 2 when the kind is unknown or the
 // kind does not configure a schema.
-func runKindsPath(args []string) int {
+func runKindsPath(stdout io.Writer, args []string) int {
 	fs := flag.NewFlagSet("kinds path", flag.ContinueOnError)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: mdsmith kinds path <name>")
@@ -244,7 +244,7 @@ func runKindsPath(args []string) int {
 			resolved = filepath.Join(root, schema)
 		}
 	}
-	if _, err := fmt.Fprintln(os.Stdout, resolved); err != nil {
+	if _, err := fmt.Fprintln(stdout, resolved); err != nil {
 		return printErr(err)
 	}
 	return 0
@@ -263,24 +263,35 @@ func readFrontMatterKinds(path string, maxBytes int64) ([]string, error) {
 
 // resolveFileFromCLI loads config, parses the file's front matter for
 // kinds: and returns a FileResolution. Errors are printed to stderr.
+//
+// When the config disables front matter (`front-matter: false`), front
+// matter is neither parsed nor validated so the resolution mirrors the
+// engine's behavior; the file is still stat'd to surface a clear error
+// for missing or unreadable paths.
 func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, int) {
 	cfg, _, code := kindsConfig()
 	if code != 0 {
 		return nil, nil, code
 	}
-	maxBytes, err := resolveMaxInputBytes(cfg, "")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return nil, nil, 2
-	}
 
-	fmKinds, err := readFrontMatterKinds(path, maxBytes)
-	if err != nil {
+	var fmKinds []string
+	if frontMatterEnabled(cfg) {
+		maxBytes, err := resolveMaxInputBytes(cfg, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return nil, nil, 2
+		}
+		fmKinds, err = readFrontMatterKinds(path, maxBytes)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
+			return nil, nil, 2
+		}
+		if err := config.ValidateFrontMatterKinds(cfg, path, fmKinds); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return nil, nil, 2
+		}
+	} else if _, err := os.Stat(path); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
-		return nil, nil, 2
-	}
-	if err := config.ValidateFrontMatterKinds(cfg, path, fmKinds); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, nil, 2
 	}
 
@@ -289,7 +300,7 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 
 // runKindsResolve prints the resolved kind list and merged rule config
 // for a single file, with per-leaf provenance.
-func runKindsResolve(args []string) int {
+func runKindsResolve(stdout io.Writer, args []string) int {
 	fs := flag.NewFlagSet("kinds resolve", flag.ContinueOnError)
 	var asJSON bool
 	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
@@ -314,16 +325,16 @@ func runKindsResolve(args []string) int {
 	}
 
 	if asJSON {
-		return writeJSON(os.Stdout, kindsout.FileResolution(res))
+		return writeJSON(stdout, kindsout.FileResolution(res))
 	}
-	if err := kindsout.WriteFileResolutionText(os.Stdout, res); err != nil {
+	if err := kindsout.WriteFileResolutionText(stdout, res); err != nil {
 		return printErr(err)
 	}
 	return 0
 }
 
 // runKindsWhy prints the full merge chain for one rule on one file.
-func runKindsWhy(args []string) int {
+func runKindsWhy(stdout io.Writer, args []string) int {
 	fs := flag.NewFlagSet("kinds why", flag.ContinueOnError)
 	var asJSON bool
 	fs.BoolVar(&asJSON, "json", false, "Emit JSON output")
@@ -355,9 +366,9 @@ func runKindsWhy(args []string) int {
 	}
 
 	if asJSON {
-		return writeJSON(os.Stdout, kindsout.RuleResolution(res.File, rr))
+		return writeJSON(stdout, kindsout.RuleResolution(res.File, rr))
 	}
-	if err := kindsout.WriteRuleResolutionText(os.Stdout, res.File, rr); err != nil {
+	if err := kindsout.WriteRuleResolutionText(stdout, res.File, rr); err != nil {
 		return printErr(err)
 	}
 	return 0

--- a/cmd/mdsmith/kinds_e2e_test.go
+++ b/cmd/mdsmith/kinds_e2e_test.go
@@ -53,6 +53,15 @@ overrides:
         max: 900
 `
 
+func TestKinds_HelpKindsCLITopic(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "help", "kinds-cli")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "Kinds Subcommand")
+	assert.Contains(t, stdout, "resolve <file>")
+	assert.Contains(t, stdout, "why <file> <rule>")
+}
+
 func TestKinds_NoArgsShowsUsage(t *testing.T) {
 	dir := kindsTestDir(t, sampleKindsCfg, nil)
 	_, stderr, code := runBinaryInDir(t, dir, "", "kinds")
@@ -175,6 +184,19 @@ func TestKinds_PathExits2OnUnknownKind(t *testing.T) {
 	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "ghost")
 	assert.Equal(t, 2, code)
 	assert.Contains(t, stderr, "unknown kind")
+}
+
+func TestKinds_PathExits2WhenSchemaIsNonString(t *testing.T) {
+	cfg := `kinds:
+  plan:
+    rules:
+      required-structure:
+        schema: 42
+`
+	dir := kindsTestDir(t, cfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "plan")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "schema must be a string")
 }
 
 func TestKinds_ResolveTextShowsPerLeafProvenance(t *testing.T) {

--- a/cmd/mdsmith/kinds_e2e_test.go
+++ b/cmd/mdsmith/kinds_e2e_test.go
@@ -1,0 +1,320 @@
+package main_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kindsTestDir creates a temp working directory seeded with a
+// .mdsmith.yml of cfgYAML and any extra files keyed by relative path.
+func kindsTestDir(t *testing.T, cfgYAML string, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"), []byte(cfgYAML), 0o644))
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+	return dir
+}
+
+const sampleKindsCfg = `kinds:
+  plan:
+    rules:
+      max-file-length:
+        max: 500
+      paragraph-readability: false
+  proto:
+    rules:
+      paragraph-readability: false
+    categories:
+      meta: false
+kind-assignment:
+  - files: ["plan/[0-9]*_*.md"]
+    kinds: [plan]
+  - files: ["**/proto.md"]
+    kinds: [proto]
+rules:
+  max-file-length:
+    max: 300
+overrides:
+  - files: ["plan/9_big.md"]
+    rules:
+      max-file-length:
+        max: 900
+`
+
+func TestKinds_NoArgsShowsUsage(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "Subcommands:")
+	assert.Contains(t, stderr, "resolve")
+	assert.Contains(t, stderr, "why")
+}
+
+func TestKinds_UnknownSubcommand(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "nope")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "unknown subcommand")
+}
+
+func TestKinds_ListPrintsAllSorted(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "list")
+	require.Equal(t, 0, code)
+	// Sorted alphabetically: plan, proto.
+	planIdx := strings.Index(stdout, "plan:")
+	protoIdx := strings.Index(stdout, "proto:")
+	require.True(t, planIdx >= 0, "plan: must appear in output")
+	require.True(t, protoIdx >= 0, "proto: must appear in output")
+	assert.Less(t, planIdx, protoIdx)
+	assert.Contains(t, stdout, "max-file-length")
+	assert.Contains(t, stdout, "paragraph-readability")
+}
+
+func TestKinds_ListJSON(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "list", "--json")
+	require.Equal(t, 0, code)
+	var out struct {
+		Kinds []struct {
+			Name       string          `json:"name"`
+			Rules      map[string]any  `json:"rules"`
+			Categories map[string]bool `json:"categories,omitempty"`
+		} `json:"kinds"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+	require.Len(t, out.Kinds, 2)
+	assert.Equal(t, "plan", out.Kinds[0].Name)
+	assert.Equal(t, "proto", out.Kinds[1].Name)
+	assert.False(t, out.Kinds[0].Rules["paragraph-readability"].(bool))
+}
+
+func TestKinds_ListEmptyConfigPrintsMessage(t *testing.T) {
+	dir := kindsTestDir(t, "rules: {}\n", nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "list")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "no kinds declared")
+}
+
+func TestKinds_ShowPrintsMergedBody(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "show", "plan")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "plan:")
+	assert.Contains(t, stdout, "max-file-length")
+	assert.Contains(t, stdout, "max: 500")
+}
+
+func TestKinds_ShowJSON(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "show", "plan", "--json")
+	require.Equal(t, 0, code)
+	var out struct {
+		Name  string         `json:"name"`
+		Rules map[string]any `json:"rules"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+	assert.Equal(t, "plan", out.Name)
+}
+
+func TestKinds_ShowUnknownExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "show", "ghost")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "unknown kind")
+}
+
+func TestKinds_ShowMissingNameExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "show")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "exactly one kind name")
+}
+
+func TestKinds_PathPrintsResolvedSchemaPath(t *testing.T) {
+	cfg := `kinds:
+  plan:
+    rules:
+      required-structure:
+        schema: plan/proto.md
+`
+	dir := kindsTestDir(t, cfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "path", "plan")
+	require.Equal(t, 0, code)
+	got := strings.TrimSpace(stdout)
+	assert.True(t, strings.HasSuffix(got, filepath.Join("plan", "proto.md")),
+		"path output %q should end with plan/proto.md", got)
+}
+
+func TestKinds_PathExits2WhenNoSchemaSet(t *testing.T) {
+	cfg := `kinds:
+  plan:
+    rules:
+      paragraph-readability: false
+`
+	dir := kindsTestDir(t, cfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "plan")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "does not configure required-structure")
+}
+
+func TestKinds_PathExits2OnUnknownKind(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "ghost")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "unknown kind")
+}
+
+func TestKinds_ResolveTextShowsPerLeafProvenance(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, map[string]string{
+		"plan/9_big.md": "# Title\n",
+	})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "plan/9_big.md")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "file: plan/9_big.md")
+	assert.Contains(t, stdout, "plan (from kind-assignment[0])")
+	assert.Contains(t, stdout, "max-file-length")
+	// Override applies to plan/9_big.md, so the winning source for max is overrides[0].
+	assert.Contains(t, stdout, "settings.max")
+	assert.Contains(t, stdout, "(from overrides[0])")
+}
+
+func TestKinds_ResolveJSONHasKindsRulesAndLeaves(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, map[string]string{
+		"plan/95_kind-rule-resolution-cli.md": "# T\n",
+	})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds",
+		"resolve", "plan/95_kind-rule-resolution-cli.md", "--json")
+	require.Equal(t, 0, code)
+	var out struct {
+		File  string `json:"file"`
+		Kinds []struct {
+			Name   string `json:"name"`
+			Source string `json:"source"`
+		} `json:"kinds"`
+		Rules map[string]struct {
+			Final  any `json:"final"`
+			Leaves []struct {
+				Path   string `json:"path"`
+				Value  any    `json:"value"`
+				Source string `json:"source"`
+			} `json:"leaves"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+	assert.Equal(t, "plan/95_kind-rule-resolution-cli.md", out.File)
+	require.Len(t, out.Kinds, 1)
+	assert.Equal(t, "plan", out.Kinds[0].Name)
+	assert.Equal(t, "kind-assignment[0]", out.Kinds[0].Source)
+
+	mfl, ok := out.Rules["max-file-length"]
+	require.True(t, ok)
+	// settings.max should have source kinds.plan (since this file does not match overrides[0]).
+	var sawMax bool
+	for _, l := range mfl.Leaves {
+		if l.Path == "settings.max" {
+			sawMax = true
+			assert.Equal(t, "kinds.plan", l.Source)
+			assert.EqualValues(t, 500, l.Value)
+		}
+	}
+	assert.True(t, sawMax, "settings.max leaf must be present")
+}
+
+func TestKinds_ResolveFromFrontMatter(t *testing.T) {
+	cfg := `kinds:
+  proto:
+    rules:
+      line-length:
+        max: 120
+rules:
+  line-length:
+    max: 80
+`
+	doc := "---\nkinds: [proto]\n---\n# T\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"doc.md": doc})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "doc.md")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "proto (from front-matter)")
+}
+
+func TestKinds_ResolveMissingFileArg(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "exactly one file argument")
+}
+
+func TestKinds_WhyTextShowsMergeChain(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, map[string]string{
+		"plan/9_big.md": "# T\n",
+	})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "why",
+		"plan/9_big.md", "max-file-length")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "rule: max-file-length")
+	assert.Contains(t, stdout, "merge chain")
+	assert.Contains(t, stdout, "default")
+	assert.Contains(t, stdout, "kinds.plan")
+	assert.Contains(t, stdout, "overrides[0]")
+	assert.Contains(t, stdout, "winning source: overrides[0]")
+}
+
+func TestKinds_WhyJSON(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, map[string]string{
+		"plan/9_big.md": "# T\n",
+	})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "why",
+		"plan/9_big.md", "max-file-length", "--json")
+	require.Equal(t, 0, code)
+	var out struct {
+		File   string `json:"file"`
+		Rule   string `json:"rule"`
+		Layers []struct {
+			Source string `json:"source"`
+			Set    bool   `json:"set"`
+		} `json:"layers"`
+		Leaves []struct {
+			Path   string `json:"path"`
+			Source string `json:"source"`
+			Chain  []struct {
+				Source string `json:"source"`
+			} `json:"chain"`
+		} `json:"leaves"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+	assert.Equal(t, "max-file-length", out.Rule)
+	require.Len(t, out.Layers, 3)
+	assert.Equal(t, "default", out.Layers[0].Source)
+	assert.Equal(t, "kinds.plan", out.Layers[1].Source)
+	assert.Equal(t, "overrides[0]", out.Layers[2].Source)
+}
+
+func TestKinds_WhyUnknownRuleExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, map[string]string{
+		"doc.md": "# T\n",
+	})
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "why",
+		"doc.md", "no-such-rule")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "not found in effective config")
+}
+
+func TestKinds_WhyMissingArgsExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "why", "x")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "<file> and <rule>")
+}

--- a/cmd/mdsmith/kinds_e2e_test.go
+++ b/cmd/mdsmith/kinds_e2e_test.go
@@ -340,3 +340,214 @@ func TestKinds_WhyMissingArgsExits2(t *testing.T) {
 	assert.Equal(t, 2, code)
 	assert.Contains(t, stderr, "<file> and <rule>")
 }
+
+// kindsBadConfigDir writes an unparseable .mdsmith.yml so loadConfig
+// fails inside kindsConfig(). Mirrors archetypes' badConfigDir.
+func kindsBadConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"),
+		[]byte(":\n\tbad yaml\n"), 0o644))
+	return dir
+}
+
+func TestKinds_ListFailsOnBadConfig(t *testing.T) {
+	dir := kindsBadConfigDir(t)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "list")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "mdsmith:")
+}
+
+func TestKinds_ShowFailsOnBadConfig(t *testing.T) {
+	dir := kindsBadConfigDir(t)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "show", "x")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "mdsmith:")
+}
+
+func TestKinds_PathFailsOnBadConfig(t *testing.T) {
+	dir := kindsBadConfigDir(t)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "x")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "mdsmith:")
+}
+
+func TestKinds_ResolveFailsOnBadConfig(t *testing.T) {
+	dir := kindsBadConfigDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "doc.md"), []byte("# T\n"), 0o644))
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "mdsmith:")
+}
+
+func TestKinds_WhyFailsOnBadConfig(t *testing.T) {
+	dir := kindsBadConfigDir(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "doc.md"), []byte("# T\n"), 0o644))
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "why", "doc.md", "rule")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "mdsmith:")
+}
+
+func TestKinds_ResolveMissingFileExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "no-such.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "no-such.md")
+}
+
+func TestKinds_ResolveRejectsInvalidFrontMatterKind(t *testing.T) {
+	cfg := `kinds:
+  plan: {}
+`
+	doc := "---\nkinds: [ghost]\n---\n# T\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"doc.md": doc})
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "ghost")
+}
+
+func TestKinds_ResolveFailsOnInvalidMaxInputSize(t *testing.T) {
+	cfg := "max-input-size: bogus\nrules: {}\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"doc.md": "# T\n"})
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "max-input-size")
+}
+
+// Each subcommand's fs.Usage is called by pflag when it sees --help.
+func TestKinds_ListHelpFlag(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "list", "--help")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "kinds list")
+}
+
+func TestKinds_ShowHelpFlag(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "show", "--help")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "kinds show")
+}
+
+func TestKinds_PathHelpFlag(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "--help")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "kinds path")
+}
+
+func TestKinds_ResolveHelpFlag(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "--help")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "kinds resolve")
+}
+
+func TestKinds_WhyHelpFlag(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "why", "--help")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "kinds why")
+}
+
+func TestKinds_HelpFlagOnRoot(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "--help")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stderr, "Subcommands:")
+}
+
+// Invalid flag triggers fs.Parse error (and Usage is printed to stderr).
+func TestKinds_ListInvalidFlagExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, _, code := runBinaryInDir(t, dir, "", "kinds", "list", "--bogus")
+	assert.Equal(t, 2, code)
+}
+
+func TestKinds_ShowInvalidFlagExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, _, code := runBinaryInDir(t, dir, "", "kinds", "show", "--bogus")
+	assert.Equal(t, 2, code)
+}
+
+func TestKinds_PathInvalidFlagExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, _, code := runBinaryInDir(t, dir, "", "kinds", "path", "--bogus")
+	assert.Equal(t, 2, code)
+}
+
+func TestKinds_ResolveInvalidFlagExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "--bogus")
+	assert.Equal(t, 2, code)
+}
+
+func TestKinds_WhyInvalidFlagExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, _, code := runBinaryInDir(t, dir, "", "kinds", "why", "--bogus")
+	assert.Equal(t, 2, code)
+}
+
+func TestKinds_ListExtraArgExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "list", "extra")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "no positional arguments")
+}
+
+func TestKinds_PathTooManyArgsExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "a", "b")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "exactly one kind name")
+}
+
+func TestKinds_ResolveTooManyArgsExits2(t *testing.T) {
+	dir := kindsTestDir(t, sampleKindsCfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "a", "b")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "exactly one file argument")
+}
+
+// kinds path branch: required-structure rule disabled (false).
+func TestKinds_PathExits2WhenRequiredStructureDisabled(t *testing.T) {
+	cfg := `kinds:
+  plan:
+    rules:
+      required-structure: false
+`
+	dir := kindsTestDir(t, cfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "plan")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "does not configure required-structure")
+}
+
+// kinds path branch: schema set to empty string.
+func TestKinds_PathExits2WhenSchemaIsEmptyString(t *testing.T) {
+	cfg := `kinds:
+  plan:
+    rules:
+      required-structure:
+        schema: ""
+`
+	dir := kindsTestDir(t, cfg, nil)
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "path", "plan")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "no required-structure.schema set")
+}
+
+// kinds path branch: absolute schema path is returned as-is.
+func TestKinds_PathPreservesAbsoluteSchema(t *testing.T) {
+	cfg := `kinds:
+  plan:
+    rules:
+      required-structure:
+        schema: /etc/passwd
+`
+	dir := kindsTestDir(t, cfg, nil)
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "path", "plan")
+	require.Equal(t, 0, code)
+	assert.Equal(t, "/etc/passwd", strings.TrimSpace(stdout))
+}

--- a/cmd/mdsmith/kinds_unit_test.go
+++ b/cmd/mdsmith/kinds_unit_test.go
@@ -19,21 +19,17 @@ import (
 // and why have a non-trivial chain to render.
 const kindsTestConfig = `rules:
   line-length:
-    enabled: true
     max: 80
 kinds:
   alpha:
     rules:
       line-length:
-        enabled: true
         max: 30
       required-structure:
-        enabled: true
         schema: schemas/alpha.yml
   beta:
     rules:
       line-length:
-        enabled: true
         max: 40
 kind-assignment:
   - files: ["alpha/*"]
@@ -282,13 +278,11 @@ func TestRunKindsResolve_FrontMatterDisabledSkipsParsing(t *testing.T) {
 	cfgBody := `front-matter: false
 rules:
   line-length:
-    enabled: true
     max: 80
 kinds:
   alpha:
     rules:
       line-length:
-        enabled: true
         max: 30
 `
 	dir := chdirToConfig(t, cfgBody)

--- a/cmd/mdsmith/kinds_unit_test.go
+++ b/cmd/mdsmith/kinds_unit_test.go
@@ -317,6 +317,20 @@ func TestRunKindsResolve_FrontMatterDisabledMissingFileReportsError(t *testing.T
 	assert.Contains(t, strings.ToLower(got), "no such")
 }
 
+// TestRunKindsResolve_FrontMatterDisabledDirectoryReportsError confirms
+// that passing a directory as the file argument is rejected with an
+// error when front-matter is disabled (os.Stat would have accepted it).
+func TestRunKindsResolve_FrontMatterDisabledDirectoryReportsError(t *testing.T) {
+	cfgBody := "front-matter: false\nrules: {}\n"
+	dir := chdirToConfig(t, cfgBody)
+
+	got := captureStderr(func() {
+		var buf bytes.Buffer
+		assert.Equal(t, 2, runKindsResolve(&buf, []string{dir}))
+	})
+	assert.Contains(t, got, "reading ")
+}
+
 // Compile-time assertion that the failing writers implement io.Writer.
 var (
 	_ io.Writer = alwaysFailingWriter{}

--- a/cmd/mdsmith/kinds_unit_test.go
+++ b/cmd/mdsmith/kinds_unit_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kindsTestConfig is the YAML used by tests below: two kinds, one with
+// a required-structure schema, plus a kind-assignment rule so resolve
+// and why have a non-trivial chain to render.
+const kindsTestConfig = `rules:
+  line-length:
+    enabled: true
+    max: 80
+kinds:
+  alpha:
+    rules:
+      line-length:
+        enabled: true
+        max: 30
+      required-structure:
+        enabled: true
+        schema: schemas/alpha.yml
+  beta:
+    rules:
+      line-length:
+        enabled: true
+        max: 40
+kind-assignment:
+  - files: ["alpha/*"]
+    kinds: ["alpha"]
+`
+
+// chdirToConfig writes the given config body into a temp dir, changes
+// the process working directory there, and returns the dir. The
+// original CWD is restored on cleanup.
+func chdirToConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".mdsmith.yml"), []byte(body), 0o644))
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	require.NoError(t, os.Chdir(dir))
+	return dir
+}
+
+// alwaysFailingWriter returns an error from every Write.
+type alwaysFailingWriter struct{}
+
+func (alwaysFailingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("disk full")
+}
+
+// failOnBareNewlineWriter succeeds for every Write whose payload is not
+// exactly "\n", and fails for the bare-newline payload that
+// fmt.Fprintln(w) emits when called with no arguments.
+type failOnBareNewlineWriter struct{}
+
+func (failOnBareNewlineWriter) Write(p []byte) (int, error) {
+	if len(p) == 1 && p[0] == '\n' {
+		return 0, errors.New("disk full")
+	}
+	return len(p), nil
+}
+
+// --- runKinds dispatch ---
+
+func TestRunKinds_NoArgsPrintsUsage(t *testing.T) {
+	got := captureStderr(func() {
+		assert.Equal(t, 0, runKinds(nil))
+	})
+	assert.Contains(t, got, "Usage: mdsmith kinds")
+}
+
+func TestRunKinds_HelpFlagPrintsUsage(t *testing.T) {
+	got := captureStderr(func() {
+		assert.Equal(t, 0, runKinds([]string{"--help"}))
+	})
+	assert.Contains(t, got, "Usage: mdsmith kinds")
+}
+
+// --- runKindsList ---
+
+func TestRunKindsList_StdoutWriteFailureExitsTwo(t *testing.T) {
+	chdirToConfig(t, kindsTestConfig)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsList(alwaysFailingWriter{}, nil))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+func TestRunKindsList_JSONStdoutWriteFailureExitsTwo(t *testing.T) {
+	chdirToConfig(t, kindsTestConfig)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsList(alwaysFailingWriter{}, []string{"--json"}))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+// TestRunKindsList_SeparatorWriteFailureExitsTwo covers the
+// per-iteration separator newline write inside runKindsList: a writer
+// that only fails on bare-newline payloads lets the first kind's body
+// print successfully, then errors on the separator before the second
+// kind starts.
+func TestRunKindsList_SeparatorWriteFailureExitsTwo(t *testing.T) {
+	chdirToConfig(t, kindsTestConfig)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsList(failOnBareNewlineWriter{}, nil))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+// TestRunKindsList_NoKindsExitsZero exercises the empty-config branch.
+func TestRunKindsList_NoKindsExitsZero(t *testing.T) {
+	chdirToConfig(t, "rules: {}\n")
+	var buf bytes.Buffer
+	stderr := captureStderr(func() {
+		assert.Equal(t, 0, runKindsList(&buf, nil))
+	})
+	assert.Contains(t, stderr, "no kinds declared")
+}
+
+// --- runKindsShow ---
+
+func TestRunKindsShow_StdoutWriteFailureExitsTwo(t *testing.T) {
+	chdirToConfig(t, kindsTestConfig)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsShow(alwaysFailingWriter{}, []string{"alpha"}))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+// --- runKindsPath ---
+
+func TestRunKindsPath_StdoutWriteFailureExitsTwo(t *testing.T) {
+	chdirToConfig(t, kindsTestConfig)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsPath(alwaysFailingWriter{}, []string{"alpha"}))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+// --- kindSchemaPath ---
+
+func TestKindSchemaPath_NoRequiredStructure(t *testing.T) {
+	got := captureStderr(func() {
+		_, code := kindSchemaPath(config.KindBody{}, "k")
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "does not configure required-structure")
+}
+
+func TestKindSchemaPath_RequiredStructureDisabled(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"required-structure": {Enabled: false},
+		},
+	}
+	got := captureStderr(func() {
+		_, code := kindSchemaPath(body, "k")
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "does not configure required-structure")
+}
+
+// TestKindSchemaPath_NoSchemaKey covers the explicit !hasSchema branch
+// where required-structure is enabled but the schema key is absent
+// entirely (distinct from being present with an empty string).
+func TestKindSchemaPath_NoSchemaKey(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"required-structure": {Enabled: true},
+		},
+	}
+	got := captureStderr(func() {
+		_, code := kindSchemaPath(body, "k")
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "no required-structure.schema set")
+}
+
+func TestKindSchemaPath_NonStringSchema(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"required-structure": {
+				Enabled:  true,
+				Settings: map[string]any{"schema": 42},
+			},
+		},
+	}
+	got := captureStderr(func() {
+		_, code := kindSchemaPath(body, "k")
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "must be a string")
+	assert.Contains(t, got, "int")
+}
+
+func TestKindSchemaPath_EmptyStringSchema(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"required-structure": {
+				Enabled:  true,
+				Settings: map[string]any{"schema": ""},
+			},
+		},
+	}
+	got := captureStderr(func() {
+		_, code := kindSchemaPath(body, "k")
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "no required-structure.schema set")
+}
+
+func TestKindSchemaPath_ValidString(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"required-structure": {
+				Enabled:  true,
+				Settings: map[string]any{"schema": "schemas/foo.yml"},
+			},
+		},
+	}
+	schema, code := kindSchemaPath(body, "k")
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "schemas/foo.yml", schema)
+}
+
+// --- runKindsResolve / runKindsWhy ---
+
+// kindsTestFile writes a markdown file with a kinds: front matter and
+// returns its absolute path. The chdir target stays on the test's CWD.
+func kindsTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestRunKindsResolve_StdoutWriteFailureExitsTwo(t *testing.T) {
+	dir := chdirToConfig(t, kindsTestConfig)
+	path := kindsTestFile(t, dir, "x.md", "# Hello\n")
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsResolve(alwaysFailingWriter{}, []string{path}))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+func TestRunKindsWhy_StdoutWriteFailureExitsTwo(t *testing.T) {
+	dir := chdirToConfig(t, kindsTestConfig)
+	path := kindsTestFile(t, dir, "x.md", "# Hello\n")
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runKindsWhy(alwaysFailingWriter{}, []string{path, "line-length"}))
+	})
+	assert.Contains(t, got, "disk full")
+}
+
+// TestRunKindsResolve_FrontMatterDisabledSkipsParsing covers the new
+// branch in resolveFileFromCLI: when `front-matter: false` is set the
+// helper neither parses nor validates the file's front-matter `kinds:`
+// entries, so a kind name that would otherwise be rejected by
+// ValidateFrontMatterKinds does not break the command.
+func TestRunKindsResolve_FrontMatterDisabledSkipsParsing(t *testing.T) {
+	cfgBody := `front-matter: false
+rules:
+  line-length:
+    enabled: true
+    max: 80
+kinds:
+  alpha:
+    rules:
+      line-length:
+        enabled: true
+        max: 30
+`
+	dir := chdirToConfig(t, cfgBody)
+	// Front-matter declares an undeclared kind; when front-matter is
+	// disabled this must be ignored rather than rejected.
+	path := kindsTestFile(t, dir, "x.md", "---\nkinds: [phantom]\n---\n# Hi\n")
+
+	var buf bytes.Buffer
+	stderr := captureStderr(func() {
+		assert.Equal(t, 0, runKindsResolve(&buf, []string{path}))
+	})
+	assert.Empty(t, stderr)
+	assert.Contains(t, buf.String(), "file: ")
+	// No effective kinds when front matter is ignored and no
+	// kind-assignment rule matched.
+	assert.Contains(t, buf.String(), "(none)")
+}
+
+// TestRunKindsResolve_FrontMatterDisabledMissingFileReportsError
+// confirms the helper still reports a clear error when the file is
+// missing while front matter is disabled.
+func TestRunKindsResolve_FrontMatterDisabledMissingFileReportsError(t *testing.T) {
+	cfgBody := "front-matter: false\nrules: {}\n"
+	dir := chdirToConfig(t, cfgBody)
+
+	missing := filepath.Join(dir, "no-such.md")
+	got := captureStderr(func() {
+		var buf bytes.Buffer
+		assert.Equal(t, 2, runKindsResolve(&buf, []string{missing}))
+	})
+	assert.Contains(t, got, "reading ")
+	assert.Contains(t, strings.ToLower(got), "no such")
+}
+
+// Compile-time assertion that the failing writers implement io.Writer.
+var (
+	_ io.Writer = alwaysFailingWriter{}
+	_ io.Writer = failOnBareNewlineWriter{}
+)

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1147,7 +1147,7 @@ schema is documented in docs/reference/cli.md.
 
 Provenance layers are: 'default' (top-level rules: + built-ins),
 'kinds.<name>' (one per kind in the effective list), and
-'overrides[i]' (one per matching glob override entry).
+'overrides[<i>]' (one per matching glob override entry).
 
 See also: 'mdsmith check --explain' / 'mdsmith fix --explain' to
 attach the same provenance trailer to each diagnostic.

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -78,6 +78,7 @@ Commands:
   metrics        Show and rank shared Markdown metrics
   merge-driver   Git merge driver for regenerable sections
   archetypes     Discover, show, and locate archetype schemas
+  kinds          Inspect declared kinds and resolve effective config per file
   init           Generate a default .mdsmith.yml config file
   version        Print version and exit
 
@@ -127,6 +128,8 @@ func run() int {
 		return runMergeDriver(os.Args[2:])
 	case "archetypes":
 		return runArchetypes(os.Args[2:])
+	case "kinds":
+		return runKinds(os.Args[2:])
 	case "init":
 		return runInit(os.Args[2:])
 	case "version":
@@ -156,14 +159,8 @@ func printVersion() {
 func runCheck(args []string) int {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	var (
-		configPath     string
-		format         string
-		noColor        bool
-		quiet          bool
-		verbose        bool
-		noGitignore    bool
-		followSymlinks bool
-		maxInputSize   string
+		configPath, format, maxInputSize                              string
+		noColor, quiet, verbose, noGitignore, followSymlinks, explain bool
 	)
 
 	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
@@ -176,6 +173,7 @@ func runCheck(args []string) int {
 		"Follow symlinks; omitted defers to follow-symlinks config (default skip); "+
 			"=false forces skip over any config opt-in")
 	fs.StringVar(&maxInputSize, "max-input-size", "", "Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
+	fs.BoolVar(&explain, "explain", false, "Attach per-leaf rule provenance to each diagnostic")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mdsmith check [flags] [files...]\n\n"+
@@ -207,29 +205,23 @@ func runCheck(args []string) int {
 	hasStdin, fileArgs := splitStdinArg(allArgs)
 
 	if hasStdin {
-		return checkStdin(format, noColor, quiet, verbose, configPath, maxInputSize)
+		return checkStdin(format, noColor, quiet, verbose, configPath, maxInputSize, explain)
 	}
 
 	if len(fileArgs) > 0 {
-		return checkFiles(fileArgs, configPath, format, noColor, quiet, verbose, walk, maxInputSize)
+		return checkFiles(fileArgs, configPath, format, noColor, quiet, verbose, walk, maxInputSize, explain)
 	}
 
 	// No file args and no stdin: discover files from config.
-	return checkDiscovered(configPath, format, noColor, quiet, verbose, walk, maxInputSize)
+	return checkDiscovered(configPath, format, noColor, quiet, verbose, walk, maxInputSize, explain)
 }
 
 // runFix implements the "fix" subcommand: auto-fix lint issues in place.
 func runFix(args []string) int {
 	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
 	var (
-		configPath     string
-		format         string
-		noColor        bool
-		quiet          bool
-		verbose        bool
-		noGitignore    bool
-		followSymlinks bool
-		maxInputSize   string
+		configPath, format, maxInputSize                              string
+		noColor, quiet, verbose, noGitignore, followSymlinks, explain bool
 	)
 
 	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
@@ -242,6 +234,7 @@ func runFix(args []string) int {
 		"Follow symlinks; omitted defers to follow-symlinks config (default skip); "+
 			"=false forces skip over any config opt-in")
 	fs.StringVar(&maxInputSize, "max-input-size", "", "Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
+	fs.BoolVar(&explain, "explain", false, "Attach per-leaf rule provenance to each remaining diagnostic")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mdsmith fix [flags] [files...]\n\n"+
@@ -278,11 +271,11 @@ func runFix(args []string) int {
 	}
 
 	if len(fileArgs) > 0 {
-		return fixFiles(fileArgs, configPath, format, noColor, quiet, verbose, walk, maxInputSize)
+		return fixFiles(fileArgs, configPath, format, noColor, quiet, verbose, walk, maxInputSize, explain)
 	}
 
 	// No file args: discover files from config.
-	return fixDiscovered(configPath, format, noColor, quiet, verbose, walk, maxInputSize)
+	return fixDiscovered(configPath, format, noColor, quiet, verbose, walk, maxInputSize, explain)
 }
 
 // runQuery implements the "query" subcommand: select files by CUE
@@ -531,7 +524,7 @@ func printRunStats(format string, quiet bool, stats runStats) {
 func checkFiles(
 	fileArgs []string, configPath, format string,
 	noColor, quiet, verbose bool, walk walkCLI,
-	maxInputSize string,
+	maxInputSize string, explain bool,
 ) int {
 	cfg, cfgPath, logger, files, maxBytes, code := loadAndResolve(
 		fileArgs, configPath, verbose, walk, maxInputSize,
@@ -547,6 +540,7 @@ func checkFiles(
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
+		Explain:          explain,
 	}
 	result := runner.Run(files)
 	printErrors(result.Errors)
@@ -577,7 +571,7 @@ func checkFiles(
 func fixFiles(
 	fileArgs []string, configPath, format string,
 	noColor, quiet, verbose bool, walk walkCLI,
-	maxInputSize string,
+	maxInputSize string, explain bool,
 ) int {
 	cfg, cfgPath, logger, files, maxBytes, code := loadAndResolve(
 		fileArgs, configPath, verbose, walk, maxInputSize,
@@ -593,6 +587,7 @@ func fixFiles(
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
+		Explain:          explain,
 	}
 	fixResult := fixer.Fix(files)
 	printErrors(fixResult.Errors)
@@ -640,7 +635,7 @@ func readStdinLimited(maxBytes int64) ([]byte, error) {
 
 // checkStdin reads from stdin, lints the content, and returns the appropriate
 // exit code. Uses runner.RunSource to ensure Configurable settings are applied.
-func checkStdin(format string, noColor, quiet, verbose bool, configPath, maxInputSize string) int {
+func checkStdin(format string, noColor, quiet, verbose bool, configPath, maxInputSize string, explain bool) int {
 	logger := &vlog.Logger{Enabled: verbose, W: os.Stderr}
 
 	cfg, cfgPath, err := loadConfig(configPath)
@@ -671,6 +666,7 @@ func checkStdin(format string, noColor, quiet, verbose bool, configPath, maxInpu
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
+		Explain:          explain,
 	}
 	result := runner.RunSource("<stdin>", source)
 	printErrors(result.Errors)
@@ -790,7 +786,7 @@ func discoverFiles(
 func checkDiscovered(
 	configPath, format string,
 	noColor, quiet, verbose bool, walk walkCLI,
-	maxInputSize string,
+	maxInputSize string, explain bool,
 ) int {
 	cfg, cfgPath, logger, files, code := discoverFiles(configPath, verbose, walk)
 	if code >= 0 {
@@ -810,6 +806,7 @@ func checkDiscovered(
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
+		Explain:          explain,
 	}
 	result := runner.Run(files)
 	printErrors(result.Errors)
@@ -841,7 +838,7 @@ func checkDiscovered(
 func fixDiscovered(
 	configPath, format string,
 	noColor, quiet, verbose bool, walk walkCLI,
-	maxInputSize string,
+	maxInputSize string, explain bool,
 ) int {
 	cfg, cfgPath, logger, files, code := discoverFiles(configPath, verbose, walk)
 	if code >= 0 {
@@ -861,6 +858,7 @@ func fixDiscovered(
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
+		Explain:          explain,
 	}
 	fixResult := fixer.Fix(files)
 	printErrors(fixResult.Errors)
@@ -1037,6 +1035,7 @@ Topics:
   rule [id|name]        Show rule documentation
   metrics [id|name]     Show metric documentation
   kinds                 Show concept page for file kinds
+  kinds-cli             Summarize the 'kinds' subcommand surface
   placeholder-grammar   Show placeholder vocabulary reference
 `
 
@@ -1054,6 +1053,8 @@ func runHelp(args []string) int {
 		return runHelpMetrics(args[1:])
 	case "kinds":
 		return runHelpKinds()
+	case "kinds-cli":
+		return runHelpKindsCLI()
 	case "placeholder-grammar":
 		return runHelpConcept("placeholder-grammar")
 	default:
@@ -1123,6 +1124,38 @@ Rules never reference kind names. New kinds cannot regress existing behavior.
 // runHelpKinds prints the kinds concept page.
 func runHelpKinds() int {
 	fmt.Print(helpKindsText)
+	return 0
+}
+
+const helpKindsCLIText = `Kinds Subcommand
+
+mdsmith kinds <subcommand> [args]
+
+Subcommands:
+  list                  Print declared kinds with their merged bodies.
+  show <name>           Print one kind's merged body.
+  path <name>           Print the resolved schema path of the kind's
+                        required-structure rule, if any.
+  resolve <file>        Print the resolved kind list and merged rule
+                        config for a file, with per-leaf provenance.
+  why <file> <rule>     Print the full merge chain for one rule on
+                        one file: every applicable layer, including
+                        no-ops, with the value at each step.
+
+Each subcommand accepts --json for stable structured output. The
+schema is documented in docs/reference/cli.md.
+
+Provenance layers are: 'default' (top-level rules: + built-ins),
+'kinds.<name>' (one per kind in the effective list), and
+'overrides[i]' (one per matching glob override entry).
+
+See also: 'mdsmith check --explain' / 'mdsmith fix --explain' to
+attach the same provenance trailer to each diagnostic.
+`
+
+// runHelpKindsCLI prints the kinds-cli help topic.
+func runHelpKindsCLI() int {
+	fmt.Print(helpKindsCLIText)
 	return 0
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -100,15 +100,6 @@ not the host that pulls it in.
 Each subcommand accepts `--json` for stable structured
 output. Unknown kinds and unresolved schemas exit `2`.
 
-Provenance layer sources:
-
-- `default` — built-ins plus top-level `rules:`.
-- `kinds.<name>` — one per kind in the effective list.
-- `overrides[<i>]` — one per matching glob override
-  (zero-indexed).
-- `front-matter override` — reserved for future
-  per-file rule overrides.
-
 ## `--explain` on `check` / `fix`
 
 `--explain` attaches per-leaf rule provenance to each
@@ -119,76 +110,50 @@ JSON adds an `explanation` field (see schema below).
 ## JSON Schemas
 
 Stable shapes for LSP / tool consumption. `leaves[]`
-always lists every leaf of the final rule config:
-`enabled` plus one entry per `settings.<key>`. Output
-never elides leaves.
+always lists every leaf of the final rule config —
+`enabled` plus one entry per `settings.<key>`; output
+never elides leaves. Source labels: `default`,
+`front-matter override`, `front-matter`,
+`kind-assignment[<i>]`, `kinds.<name>`, or
+`overrides[<i>]`.
 
-`check --explain` adds an `explanation` to each diag
-(omitted without `--explain`):
-
-```json
-"explanation": {
-  "rule": "line-length",
-  "leaves": [
-    {"path": "enabled", "value": true, "source": "default"},
-    {"path": "settings.max", "value": 30, "source": "kinds.short"}
-  ]
-}
-```
-
-`kinds list` → `{"kinds": [<body>...]}`; `show` → one
-body. Body shape: `{"name", "rules", "categories"}`.
-`rules[<name>]` follows the YAML rule-cfg union:
-`false`, `true`, or the settings map.
-
-`kinds resolve <file>`:
+`check --explain` adds an `explanation` field to each
+diag (omitted without `--explain`):
 
 ```json
-{
-  "file": "plan/95.md",
-  "kinds": [{"name": "plan", "source": "kind-assignment[0]"}],
-  "categories": {"meta": true},
-  "rules": {
-    "max-file-length": {
-      "final": {"max": 500},
-      "leaves": [
-        {"path": "enabled", "value": true, "source": "default"},
-        {"path": "settings.max", "value": 500, "source": "kinds.plan"}
-      ]
-    }
-  }
-}
+"explanation": {"rule": "line-length", "leaves": [
+  {"path": "enabled", "value": true, "source": "default"},
+  {"path": "settings.max", "value": 30, "source": "kinds.short"}
+]}
 ```
 
-`kinds[].source` is `front-matter` or
-`kind-assignment[<i>]`.
+`kinds list` → `{"kinds": [<body>...]}`; `show <name>`
+→ one body. Body: `{"name", "rules", "categories"}`
+where `rules[<name>]` follows the YAML rule-cfg union
+(`false`, `true`, or the settings map).
 
-`kinds why <file> <rule>` (`leaves[].chain` records
-every layer that set the leaf):
+`kinds resolve <file>` returns `{file, kinds, categories,
+rules}`. Each rule entry is `{final, leaves}` with a leaf
+per `enabled` and `settings.<key>`.
+
+`kinds why <file> <rule>` adds two arrays. `layers[]`
+lists every applicable layer in chain order. No-op layers
+carry `"set": false` and omit `value`. `leaves[].chain`
+records the layers that set the leaf, in chain order:
 
 ```json
-{
-  "file": "plan/9_big.md",
-  "rule": "max-file-length",
-  "final": {"max": 900},
-  "layers": [
-    {"source": "default", "set": true, "value": {"max": 300}},
-    {"source": "kinds.plan", "set": true, "value": {"max": 500}},
-    {"source": "overrides[0]", "set": true, "value": {"max": 900}}
-  ],
-  "leaves": [
-    {"path": "settings.max", "value": 900,
-     "source": "overrides[0]",
-     "chain": [
-       {"source": "default", "value": 300},
-       {"source": "kinds.plan", "value": 500},
-       {"source": "overrides[0]", "value": 900}
-     ]}
-  ]
-}
+{"file": "plan/9_big.md", "rule": "max-file-length",
+ "final": {"max": 900},
+ "layers": [
+   {"source": "default", "set": true, "value": {"max": 300}},
+   {"source": "kinds.plan", "set": true, "value": {"max": 500}},
+   {"source": "overrides[0]", "set": true, "value": {"max": 900}}],
+ "leaves": [{"path": "settings.max", "value": 900,
+   "source": "overrides[0]", "chain": [
+     {"source": "default", "value": 300},
+     {"source": "kinds.plan", "value": 500},
+     {"source": "overrides[0]", "value": 900}]}]}
 ```
-
-No-op layers carry `"set": false` and omit `value`.
 
 ## `archetypes` Subcommands
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -118,28 +118,26 @@ JSON adds an `explanation` field (see schema below).
 
 ## JSON Schemas
 
-Stable shapes intended for LSP / VS Code extension
-consumption.
+Stable shapes for LSP / tool consumption. `leaves[]`
+always lists every leaf of the final rule config:
+`enabled` plus one entry per `settings.<key>`. Output
+never elides leaves.
 
-`check --explain` adds an `explanation` field to each
-diagnostic; omitted unless `--explain` is set:
+`check --explain` adds an `explanation` to each diag
+(omitted without `--explain`):
 
 ```json
 "explanation": {
   "rule": "line-length",
   "leaves": [
+    {"path": "enabled", "value": true, "source": "default"},
     {"path": "settings.max", "value": 30, "source": "kinds.short"}
   ]
 }
 ```
 
-`kinds list` returns `{"kinds": [<body>...]}`; `show`
-returns one body. Body shape:
-
-```json
-{"name": "plan", "rules": {...}, "categories": {...}}
-```
-
+`kinds list` → `{"kinds": [<body>...]}`; `show` → one
+body. Body shape: `{"name", "rules", "categories"}`.
 `rules[<name>]` follows the YAML rule-cfg union:
 `false`, `true`, or the settings map.
 
@@ -154,6 +152,7 @@ returns one body. Body shape:
     "max-file-length": {
       "final": {"max": 500},
       "leaves": [
+        {"path": "enabled", "value": true, "source": "default"},
         {"path": "settings.max", "value": 500, "source": "kinds.plan"}
       ]
     }
@@ -164,7 +163,8 @@ returns one body. Body shape:
 `kinds[].source` is `front-matter` or
 `kind-assignment[<i>]`.
 
-`kinds why <file> <rule>`:
+`kinds why <file> <rule>` (`leaves[].chain` records
+every layer that set the leaf):
 
 ```json
 {
@@ -181,6 +181,7 @@ returns one body. Body shape:
      "source": "overrides[0]",
      "chain": [
        {"source": "default", "value": 300},
+       {"source": "kinds.plan", "value": 500},
        {"source": "overrides[0]", "value": 900}
      ]}
   ]
@@ -188,7 +189,6 @@ returns one body. Body shape:
 ```
 
 No-op layers carry `"set": false` and omit `value`.
-`leaves[].chain` records only layers that set that leaf.
 
 ## `archetypes` Subcommands
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,7 @@ mdsmith <command> [flags] [files...]
 | `metrics`      | List and rank shared metrics                   |
 | `merge-driver` | Git merge driver for regenerable sections      |
 | `archetypes`   | Scaffold, list, show, and locate archetypes    |
+| `kinds`        | Inspect declared kinds and resolve config      |
 | `init`         | Generate `.mdsmith.yml`                        |
 | `version`      | Print version, exit                            |
 
@@ -85,6 +86,109 @@ file: content between the `<?include?>` and `<?catalog?>`
 markers is excluded. This matches the lint-once model —
 embedded content is measured against the source file,
 not the host that pulls it in.
+
+## `kinds` Subcommands
+
+| Subcommand          | Description                                        |
+|---------------------|----------------------------------------------------|
+| `list`              | Print declared kinds and their merged bodies       |
+| `show <name>`       | Print one kind's merged body                       |
+| `path <name>`       | Print resolved schema path of `required-structure` |
+| `resolve <file>`    | Resolved kind list and per-leaf provenance summary |
+| `why <file> <rule>` | Full per-rule merge chain, including no-op layers  |
+
+Each subcommand accepts `--json` for stable structured
+output. Unknown kinds and unresolved schemas exit `2`.
+
+Provenance layer sources:
+
+- `default` — built-ins plus top-level `rules:`.
+- `kinds.<name>` — one per kind in the effective list.
+- `overrides[<i>]` — one per matching glob override
+  (zero-indexed).
+- `front-matter override` — reserved for future
+  per-file rule overrides.
+
+## `--explain` on `check` / `fix`
+
+`--explain` attaches per-leaf rule provenance to each
+diagnostic. Text output prints a `└─` trailer naming
+the rule and the winning source for each leaf setting;
+JSON adds an `explanation` field (see schema below).
+
+## JSON Schemas
+
+Stable shapes intended for LSP / VS Code extension
+consumption.
+
+`check --explain` adds an `explanation` field to each
+diagnostic; omitted unless `--explain` is set:
+
+```json
+"explanation": {
+  "rule": "line-length",
+  "leaves": [
+    {"path": "settings.max", "value": 30, "source": "kinds.short"}
+  ]
+}
+```
+
+`kinds list` returns `{"kinds": [<body>...]}`; `show`
+returns one body. Body shape:
+
+```json
+{"name": "plan", "rules": {...}, "categories": {...}}
+```
+
+`rules[<name>]` follows the YAML rule-cfg union:
+`false`, `true`, or the settings map.
+
+`kinds resolve <file>`:
+
+```json
+{
+  "file": "plan/95.md",
+  "kinds": [{"name": "plan", "source": "kind-assignment[0]"}],
+  "categories": {"meta": true},
+  "rules": {
+    "max-file-length": {
+      "final": {"max": 500},
+      "leaves": [
+        {"path": "settings.max", "value": 500, "source": "kinds.plan"}
+      ]
+    }
+  }
+}
+```
+
+`kinds[].source` is `front-matter` or
+`kind-assignment[<i>]`.
+
+`kinds why <file> <rule>`:
+
+```json
+{
+  "file": "plan/9_big.md",
+  "rule": "max-file-length",
+  "final": {"max": 900},
+  "layers": [
+    {"source": "default", "set": true, "value": {"max": 300}},
+    {"source": "kinds.plan", "set": true, "value": {"max": 500}},
+    {"source": "overrides[0]", "set": true, "value": {"max": 900}}
+  ],
+  "leaves": [
+    {"path": "settings.max", "value": 900,
+     "source": "overrides[0]",
+     "chain": [
+       {"source": "default", "value": 300},
+       {"source": "overrides[0]", "value": 900}
+     ]}
+  ]
+}
+```
+
+No-op layers carry `"set": false` and omit `value`.
+`leaves[].chain` records only layers that set that leaf.
 
 ## `archetypes` Subcommands
 

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -176,7 +176,15 @@ func buildRuleResolution(name string, layers []layerInfo) RuleResolution {
 		if ok {
 			cp := copyRuleCfg(v)
 			chain = append(chain, LayerEntry{Source: l.Source, Set: true, Value: cp})
-			final = cp
+			if !seen {
+				final = cp
+			} else {
+				// Deep-merge later layers onto the running effective so
+				// `final` mirrors the engine's merged config (e.g. a
+				// bool-only kind toggling Enabled does not erase
+				// inherited Settings).
+				final = mergeRuleCfg(name, final, cp)
+			}
 			seen = true
 		} else {
 			chain = append(chain, LayerEntry{Source: l.Source, Set: false})

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -1,0 +1,268 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Provenance layer-source string forms. A layer source is a stable
+// identifier that names one step in the rule-config merge pipeline.
+//
+//   - "default"               built-in defaults plus the user's top-level rules:
+//   - "kinds.<name>"          a kind body in the file's effective kind list
+//   - "overrides[<i>]"        the i-th override entry that matched this file
+//   - "front-matter override" the file's own front-matter rule overrides
+//
+// "default" collapses built-in defaults and the user's top-level rules:
+// block, since cfg.Rules already has them merged. "front-matter override"
+// is reserved for the future per-file front-matter rules: feature.
+const (
+	layerSourceDefault     = "default"
+	layerSourceFrontMatter = "front-matter override"
+)
+
+// KindAssignmentSource describes how a kind ended up in the effective list.
+// Either "front-matter" or "kind-assignment[<i>]".
+type KindAssignmentSource string
+
+// ResolvedKind names a kind in the effective list and how it was assigned.
+type ResolvedKind struct {
+	Name   string
+	Source KindAssignmentSource
+}
+
+// LayerEntry is one applicable merge layer for a single rule. Source
+// identifies the layer; Set indicates whether this layer touched the rule;
+// Value, when Set is true, is the rule's RuleCfg supplied by this layer.
+type LayerEntry struct {
+	Source string
+	Set    bool
+	Value  RuleCfg
+}
+
+// LeafChainEntry records a layer that set a single leaf, with the value
+// the leaf had at that layer.
+type LeafChainEntry struct {
+	Source string
+	Value  any
+}
+
+// Leaf bundles a leaf path (e.g., "enabled" or "settings.max"), its
+// winning value, and the chain of layers that set it (oldest → newest).
+type Leaf struct {
+	Path  string
+	Value any
+	Chain []LeafChainEntry
+}
+
+// Source returns the winning layer source for this leaf — the source of
+// the last entry in the chain. An empty string indicates the leaf has no
+// source (which should not happen for leaves emitted by Resolve).
+func (l Leaf) Source() string {
+	if len(l.Chain) == 0 {
+		return ""
+	}
+	return l.Chain[len(l.Chain)-1].Source
+}
+
+// RuleResolution describes the merge of one rule for one file.
+type RuleResolution struct {
+	Rule   string
+	Final  RuleCfg
+	Layers []LayerEntry
+	Leaves []Leaf
+}
+
+// LeafByPath returns the Leaf with the given path, or nil if absent.
+func (rr *RuleResolution) LeafByPath(path string) *Leaf {
+	for i := range rr.Leaves {
+		if rr.Leaves[i].Path == path {
+			return &rr.Leaves[i]
+		}
+	}
+	return nil
+}
+
+// FileResolution is the per-file resolution: kind list (with assignment
+// sources) and per-rule resolution. Rules is keyed by rule name.
+type FileResolution struct {
+	File       string
+	Kinds      []ResolvedKind
+	Rules      map[string]RuleResolution
+	Categories map[string]bool
+}
+
+// ResolveFile builds the full provenance picture for a single file.
+// fmKinds is the kinds: list parsed from the file's front matter.
+func ResolveFile(cfg *Config, filePath string, fmKinds []string) *FileResolution {
+	kinds := resolveKindsWithSources(cfg, filePath, fmKinds)
+	layers := buildLayers(cfg, filePath, kinds)
+
+	names := allRuleNames(layers)
+	rules := make(map[string]RuleResolution, len(names))
+	for _, name := range names {
+		rules[name] = buildRuleResolution(name, layers)
+	}
+
+	kindNames := make([]string, len(kinds))
+	for i, k := range kinds {
+		kindNames[i] = k.Name
+	}
+	cats := effectiveCats(cfg, filePath, kindNames)
+
+	return &FileResolution{
+		File:       filePath,
+		Kinds:      kinds,
+		Rules:      rules,
+		Categories: cats,
+	}
+}
+
+// layerInfo captures one applicable merge layer's source and its rule
+// settings. Layers that are not applicable to the file (non-matching
+// overrides) are not included.
+type layerInfo struct {
+	Source string
+	Rules  map[string]RuleCfg
+}
+
+func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo {
+	layers := []layerInfo{
+		{Source: layerSourceDefault, Rules: cfg.Rules},
+	}
+	for _, k := range kinds {
+		body, ok := cfg.Kinds[k.Name]
+		if !ok {
+			continue
+		}
+		layers = append(layers, layerInfo{
+			Source: "kinds." + k.Name,
+			Rules:  body.Rules,
+		})
+	}
+	for i, o := range cfg.Overrides {
+		if matchesAny(o.Files, filePath) {
+			layers = append(layers, layerInfo{
+				Source: fmt.Sprintf("overrides[%d]", i),
+				Rules:  o.Rules,
+			})
+		}
+	}
+	return layers
+}
+
+func allRuleNames(layers []layerInfo) []string {
+	seen := map[string]bool{}
+	for _, l := range layers {
+		for name := range l.Rules {
+			seen[name] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func buildRuleResolution(name string, layers []layerInfo) RuleResolution {
+	chain := make([]LayerEntry, 0, len(layers))
+	var final RuleCfg
+	var seen bool
+	for _, l := range layers {
+		v, ok := l.Rules[name]
+		if ok {
+			cp := copyRuleCfg(v)
+			chain = append(chain, LayerEntry{Source: l.Source, Set: true, Value: cp})
+			final = cp
+			seen = true
+		} else {
+			chain = append(chain, LayerEntry{Source: l.Source, Set: false})
+		}
+	}
+	if !seen {
+		// Rule never appears in any applicable layer; should not happen
+		// when called via ResolveFile (allRuleNames filters to seen).
+		return RuleResolution{Rule: name}
+	}
+	return RuleResolution{
+		Rule:   name,
+		Final:  final,
+		Layers: chain,
+		Leaves: buildLeaves(final, chain),
+	}
+}
+
+func buildLeaves(final RuleCfg, chain []LayerEntry) []Leaf {
+	paths := []string{"enabled"}
+	if final.Settings != nil {
+		keys := make([]string, 0, len(final.Settings))
+		for k := range final.Settings {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			paths = append(paths, "settings."+k)
+		}
+	}
+
+	leaves := make([]Leaf, 0, len(paths))
+	for _, p := range paths {
+		var leafChain []LeafChainEntry
+		var winning any
+		for _, layer := range chain {
+			if !layer.Set {
+				continue
+			}
+			v, ok := leafValue(layer.Value, p)
+			if !ok {
+				continue
+			}
+			leafChain = append(leafChain, LeafChainEntry{Source: layer.Source, Value: v})
+			winning = v
+		}
+		leaves = append(leaves, Leaf{Path: p, Value: winning, Chain: leafChain})
+	}
+	return leaves
+}
+
+func leafValue(rc RuleCfg, path string) (any, bool) {
+	if path == "enabled" {
+		return rc.Enabled, true
+	}
+	const prefix = "settings."
+	if strings.HasPrefix(path, prefix) {
+		if rc.Settings == nil {
+			return nil, false
+		}
+		v, ok := rc.Settings[path[len(prefix):]]
+		return v, ok
+	}
+	return nil, false
+}
+
+func resolveKindsWithSources(cfg *Config, filePath string, fmKinds []string) []ResolvedKind {
+	seen := make(map[string]bool)
+	var result []ResolvedKind
+	add := func(name string, source KindAssignmentSource) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		result = append(result, ResolvedKind{Name: name, Source: source})
+	}
+	for _, k := range fmKinds {
+		add(k, "front-matter")
+	}
+	for i, entry := range cfg.KindAssignment {
+		if matchesAny(entry.Files, filePath) {
+			src := KindAssignmentSource(fmt.Sprintf("kind-assignment[%d]", i))
+			for _, k := range entry.Kinds {
+				add(k, src)
+			}
+		}
+	}
+	return result
+}

--- a/internal/config/provenance_edges_test.go
+++ b/internal/config/provenance_edges_test.go
@@ -74,14 +74,49 @@ func TestBuildRuleResolution_RuleNeverInLayers(t *testing.T) {
 	assert.Nil(t, rr.Leaves)
 }
 
+// TestBuildRuleResolution_BoolOnlyLayerPreservesInheritedSettings
+// pins the deep-merge behavior in buildRuleResolution: a bool-only
+// later layer toggles Enabled but must not erase the running merged
+// Settings, and the inherited leaf must still report its original
+// source.
+func TestBuildRuleResolution_BoolOnlyLayerPreservesInheritedSettings(t *testing.T) {
+	cfg := &Config{
+		Rules: map[string]RuleCfg{
+			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+		Kinds: map[string]KindBody{
+			// Bool-only layer: toggles Enabled off, no Settings.
+			"off": {Rules: map[string]RuleCfg{
+				"line-length": {Enabled: false},
+			}},
+		},
+		KindAssignment: []KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"off"}},
+		},
+	}
+	res := ResolveFile(cfg, "x.md", nil)
+	rr := res.Rules["line-length"]
+	require.NotNil(t, rr)
+	assert.False(t, rr.Final.Enabled, "kind layer must toggle Enabled off")
+	require.NotNil(t, rr.Final.Settings,
+		"deep-merge must preserve inherited Settings even when later layer is bool-only")
+	assert.EqualValues(t, 80, rr.Final.Settings["max"])
+
+	maxLeaf := rr.LeafByPath("settings.max")
+	require.NotNil(t, maxLeaf)
+	require.Len(t, maxLeaf.Chain, 1)
+	assert.Equal(t, "default", maxLeaf.Chain[0].Source,
+		"settings.max provenance must point at the default layer that set it")
+}
+
 // TestBuildLeaves_ChainSkipsLayersMissingPath covers the buildLeaves
 // branch where one layer in the chain does not set a particular leaf
 // path: it must not appear in that leaf's Chain, but other layers that
-// do set the path still contribute. Because effectiveRules replaces
-// (rather than deep-merges) RuleCfg, the only way to leave the final
-// Settings keyed by `max` while a previous layer has no Settings is to
-// declare the rule with no Settings in the default layer and add the
-// keyed value via a kind layer.
+// do set the path still contribute. effectiveRules deep-merges RuleCfg
+// across layers, so an earlier layer can declare the rule with no
+// Settings while a later layer adds `settings.max`. The final RuleCfg
+// then includes `max`, but the leaf chain for `settings.max` should
+// include only the layer that actually set that path.
 func TestBuildLeaves_ChainSkipsLayersMissingPath(t *testing.T) {
 	cfg := &Config{
 		Rules: map[string]RuleCfg{

--- a/internal/config/provenance_edges_test.go
+++ b/internal/config/provenance_edges_test.go
@@ -60,3 +60,51 @@ func TestLeafValue_SettingsNil(t *testing.T) {
 	assert.False(t, ok)
 	assert.Nil(t, v)
 }
+
+// TestBuildRuleResolution_RuleNeverInLayers covers the defensive !seen
+// branch of buildRuleResolution: when no applicable layer sets the rule,
+// the function returns an empty RuleResolution rather than panicking.
+func TestBuildRuleResolution_RuleNeverInLayers(t *testing.T) {
+	layers := []layerInfo{
+		{Source: "default", Rules: map[string]RuleCfg{"other": {Enabled: true}}},
+	}
+	rr := buildRuleResolution("missing", layers)
+	assert.Equal(t, "missing", rr.Rule)
+	assert.Empty(t, rr.Layers)
+	assert.Nil(t, rr.Leaves)
+}
+
+// TestBuildLeaves_ChainSkipsLayersMissingPath covers the buildLeaves
+// branch where one layer in the chain does not set a particular leaf
+// path: it must not appear in that leaf's Chain, but other layers that
+// do set the path still contribute. Because effectiveRules replaces
+// (rather than deep-merges) RuleCfg, the only way to leave the final
+// Settings keyed by `max` while a previous layer has no Settings is to
+// declare the rule with no Settings in the default layer and add the
+// keyed value via a kind layer.
+func TestBuildLeaves_ChainSkipsLayersMissingPath(t *testing.T) {
+	cfg := &Config{
+		Rules: map[string]RuleCfg{
+			// Default declares the rule but does not set max.
+			"line-length": {Enabled: true},
+		},
+		Kinds: map[string]KindBody{
+			// Kind sets max=30 — this becomes the final RuleCfg after merge.
+			"size": {Rules: map[string]RuleCfg{
+				"line-length": {Enabled: true, Settings: map[string]any{"max": 30}},
+			}},
+		},
+		KindAssignment: []KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"size"}},
+		},
+	}
+	res := ResolveFile(cfg, "x.md", nil)
+	rr := res.Rules["line-length"]
+	maxLeaf := rr.LeafByPath("settings.max")
+	require.NotNil(t, maxLeaf)
+	// The default layer's RuleCfg has Settings == nil so leafValue
+	// returns ok=false and the layer must be omitted from the chain.
+	// Only the kind layer contributes.
+	require.Len(t, maxLeaf.Chain, 1)
+	assert.Equal(t, "kinds.size", maxLeaf.Chain[0].Source)
+}

--- a/internal/config/provenance_edges_test.go
+++ b/internal/config/provenance_edges_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeaf_SourceEmptyChain covers the empty-chain branch of Leaf.Source.
+func TestLeaf_SourceEmptyChain(t *testing.T) {
+	leaf := Leaf{Path: "x", Value: nil, Chain: nil}
+	assert.Equal(t, "", leaf.Source())
+}
+
+// TestRuleResolution_LeafByPathMissing covers the not-found branch of
+// LeafByPath.
+func TestRuleResolution_LeafByPathMissing(t *testing.T) {
+	rr := &RuleResolution{
+		Leaves: []Leaf{{Path: "enabled"}},
+	}
+	assert.Nil(t, rr.LeafByPath("settings.nope"))
+	require.NotNil(t, rr.LeafByPath("enabled"))
+}
+
+// TestResolveFile_SkipsUndeclaredKindFromFrontMatter covers the
+// `cfg.Kinds[name]` lookup branch in buildLayers when a front-matter
+// kind has no declared body.
+func TestResolveFile_SkipsUndeclaredKindFromFrontMatter(t *testing.T) {
+	cfg := &Config{
+		Rules: map[string]RuleCfg{
+			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+		// no Kinds map: front-matter "ghost" cannot resolve to a body.
+	}
+	res := ResolveFile(cfg, "x.md", []string{"ghost"})
+	require.NotNil(t, res)
+	// ghost still appears in the kind list (resolveKindsWithSources adds it),
+	// but no kind layer is appended to the merge chain.
+	require.Len(t, res.Kinds, 1)
+	assert.Equal(t, "ghost", res.Kinds[0].Name)
+	rr := res.Rules["line-length"]
+	require.Len(t, rr.Layers, 1, "only the default layer applies")
+	assert.Equal(t, "default", rr.Layers[0].Source)
+}
+
+// TestLeafValue_UnknownPath covers the fall-through branch of leafValue
+// when the path is neither "enabled" nor a "settings." prefix.
+func TestLeafValue_UnknownPath(t *testing.T) {
+	rc := RuleCfg{Enabled: true, Settings: map[string]any{"a": 1}}
+	v, ok := leafValue(rc, "garbage.path")
+	assert.False(t, ok)
+	assert.Nil(t, v)
+}
+
+// TestLeafValue_SettingsNil covers the rc.Settings == nil branch.
+func TestLeafValue_SettingsNil(t *testing.T) {
+	rc := RuleCfg{Enabled: true}
+	v, ok := leafValue(rc, "settings.max")
+	assert.False(t, ok)
+	assert.Nil(t, v)
+}

--- a/internal/config/provenance_test.go
+++ b/internal/config/provenance_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadAndMergeFromString parses a user config from yml and merges it on
+// top of an empty defaults config so the result has the same shape as
+// configs produced by the CLI's loadConfig path.
+func resolveFromYAML(t *testing.T, yml string) *Config {
+	t.Helper()
+	loaded := loadFromString(t, yml)
+	defaults := &Config{Rules: map[string]RuleCfg{}}
+	return Merge(defaults, loaded)
+}
+
+func TestResolveFile_KindsAndOverridesProvenance(t *testing.T) {
+	yml := `
+rules:
+  max-file-length:
+    max: 300
+kinds:
+  plan:
+    rules:
+      max-file-length:
+        max: 500
+kind-assignment:
+  - files: ["plan/*.md"]
+    kinds: [plan]
+overrides:
+  - files: ["plan/big.md"]
+    rules:
+      max-file-length:
+        max: 900
+`
+	cfg := resolveFromYAML(t, yml)
+
+	res := ResolveFile(cfg, "plan/big.md", nil)
+	require.NotNil(t, res)
+
+	require.Len(t, res.Kinds, 1)
+	assert.Equal(t, "plan", res.Kinds[0].Name)
+	assert.Equal(t, KindAssignmentSource("kind-assignment[0]"), res.Kinds[0].Source)
+
+	rr, ok := res.Rules["max-file-length"]
+	require.True(t, ok, "max-file-length must appear in rules")
+
+	// Three applicable layers: default, kinds.plan, overrides[0].
+	require.Len(t, rr.Layers, 3)
+	assert.Equal(t, "default", rr.Layers[0].Source)
+	assert.True(t, rr.Layers[0].Set)
+	assert.Equal(t, "kinds.plan", rr.Layers[1].Source)
+	assert.True(t, rr.Layers[1].Set)
+	assert.Equal(t, "overrides[0]", rr.Layers[2].Source)
+	assert.True(t, rr.Layers[2].Set)
+
+	// Final value is from overrides[0].
+	assert.Equal(t, 900, rr.Final.Settings["max"])
+
+	// Per-leaf provenance: settings.max chain has three entries.
+	leaf := rr.LeafByPath("settings.max")
+	require.NotNil(t, leaf)
+	require.Len(t, leaf.Chain, 3)
+	assert.Equal(t, "default", leaf.Chain[0].Source)
+	assert.Equal(t, 300, leaf.Chain[0].Value)
+	assert.Equal(t, "kinds.plan", leaf.Chain[1].Source)
+	assert.Equal(t, 500, leaf.Chain[1].Value)
+	assert.Equal(t, "overrides[0]", leaf.Chain[2].Source)
+	assert.Equal(t, 900, leaf.Chain[2].Value)
+	assert.Equal(t, "overrides[0]", leaf.Source())
+}
+
+func TestResolveFile_KindAppliedFromFrontMatter(t *testing.T) {
+	yml := `
+rules:
+  line-length:
+    max: 80
+kinds:
+  proto:
+    rules:
+      line-length:
+        max: 120
+`
+	cfg := resolveFromYAML(t, yml)
+	res := ResolveFile(cfg, "doc.md", []string{"proto"})
+
+	require.Len(t, res.Kinds, 1)
+	assert.Equal(t, "proto", res.Kinds[0].Name)
+	assert.Equal(t, KindAssignmentSource("front-matter"), res.Kinds[0].Source)
+
+	rr := res.Rules["line-length"]
+	leaf := rr.LeafByPath("settings.max")
+	require.NotNil(t, leaf)
+	assert.Equal(t, "kinds.proto", leaf.Source())
+	assert.Equal(t, 120, leaf.Value)
+}
+
+func TestResolveFile_NoOpKindLayerStillInChain(t *testing.T) {
+	yml := `
+rules:
+  line-length:
+    max: 80
+  paragraph-readability: false
+kinds:
+  proto:
+    rules:
+      paragraph-readability: false
+kind-assignment:
+  - files: ["doc.md"]
+    kinds: [proto]
+`
+	cfg := resolveFromYAML(t, yml)
+	res := ResolveFile(cfg, "doc.md", nil)
+
+	rr := res.Rules["line-length"]
+	require.Len(t, rr.Layers, 2, "default + kinds.proto")
+	assert.True(t, rr.Layers[0].Set, "default sets line-length")
+	assert.False(t, rr.Layers[1].Set, "kinds.proto does not set line-length")
+}
+
+func TestResolveFile_OverridesExclusiveToMatchingFiles(t *testing.T) {
+	yml := `
+rules:
+  line-length:
+    max: 80
+overrides:
+  - files: ["other.md"]
+    rules:
+      line-length:
+        max: 200
+`
+	cfg := resolveFromYAML(t, yml)
+	res := ResolveFile(cfg, "doc.md", nil)
+
+	rr := res.Rules["line-length"]
+	// Override does not match doc.md, so only the default layer is in the chain.
+	require.Len(t, rr.Layers, 1)
+	assert.Equal(t, "default", rr.Layers[0].Source)
+}
+
+func TestResolveFile_KindsListPreservesOrderAndDedup(t *testing.T) {
+	yml := `
+kinds:
+  plan: {}
+  proto: {}
+kind-assignment:
+  - files: ["doc.md"]
+    kinds: [proto, plan]
+  - files: ["doc.md"]
+    kinds: [plan]
+`
+	cfg := resolveFromYAML(t, yml)
+	// front-matter declares plan first, then kind-assignment adds proto and (dup) plan.
+	res := ResolveFile(cfg, "doc.md", []string{"plan"})
+
+	require.Len(t, res.Kinds, 2)
+	assert.Equal(t, "plan", res.Kinds[0].Name)
+	assert.Equal(t, KindAssignmentSource("front-matter"), res.Kinds[0].Source)
+	assert.Equal(t, "proto", res.Kinds[1].Name)
+	assert.Equal(t, KindAssignmentSource("kind-assignment[0]"), res.Kinds[1].Source)
+}

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/explain"
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -93,8 +94,8 @@ func (r *Runner) Run(paths []string) *Result {
 		r.logRules(effective)
 
 		diags, errs := CheckRules(f, r.Rules, effective)
-		if r.Explain && len(diags) > 0 {
-			r.attachExplanations(diags, path, fmKinds)
+		if r.Explain {
+			explain.Attach(diags, r.Config, path, fmKinds)
 		}
 		res.Diagnostics = append(res.Diagnostics, diags...)
 		res.Errors = append(res.Errors, errs...)
@@ -102,28 +103,6 @@ func (r *Runner) Run(paths []string) *Result {
 
 	sortDiagnostics(res.Diagnostics)
 	return res
-}
-
-// attachExplanations populates Diagnostic.Explanation for each diag
-// emitted by a file path using the rule's resolved leaves.
-func (r *Runner) attachExplanations(diags []lint.Diagnostic, path string, fmKinds []string) {
-	res := config.ResolveFile(r.Config, path, fmKinds)
-	for i := range diags {
-		rr, ok := res.Rules[diags[i].RuleName]
-		if !ok {
-			continue
-		}
-		leaves := make([]lint.ExplanationLeaf, 0, len(rr.Leaves))
-		for _, l := range rr.Leaves {
-			leaves = append(leaves, lint.ExplanationLeaf{
-				Path: l.Path, Value: l.Value, Source: l.Source(),
-			})
-		}
-		diags[i].Explanation = &lint.Explanation{
-			Rule:   diags[i].RuleName,
-			Leaves: leaves,
-		}
-	}
 }
 
 // RunSource lints in-memory source bytes (e.g. from stdin) and returns a
@@ -164,8 +143,8 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 	r.logRules(effective)
 
 	diags, errs := CheckRules(f, r.Rules, effective)
-	if r.Explain && len(diags) > 0 {
-		r.attachExplanations(diags, path, fmKinds)
+	if r.Explain {
+		explain.Attach(diags, r.Config, path, fmKinds)
 	}
 	res.Diagnostics = append(res.Diagnostics, diags...)
 	res.Errors = append(res.Errors, errs...)

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -27,6 +27,9 @@ type Runner struct {
 	// MaxInputBytes is the maximum file size in bytes before a file is
 	// skipped with an error. Zero or negative means unlimited.
 	MaxInputBytes int64
+	// Explain, when true, attaches per-leaf rule provenance to each
+	// diagnostic so output formatters can render an explanation trailer.
+	Explain bool
 	// gitignoreCache caches GitignoreMatchers by directory to avoid
 	// re-walking the filesystem for each file.
 	gitignoreCache map[string]*lint.GitignoreMatcher
@@ -90,12 +93,37 @@ func (r *Runner) Run(paths []string) *Result {
 		r.logRules(effective)
 
 		diags, errs := CheckRules(f, r.Rules, effective)
+		if r.Explain && len(diags) > 0 {
+			r.attachExplanations(diags, path, fmKinds)
+		}
 		res.Diagnostics = append(res.Diagnostics, diags...)
 		res.Errors = append(res.Errors, errs...)
 	}
 
 	sortDiagnostics(res.Diagnostics)
 	return res
+}
+
+// attachExplanations populates Diagnostic.Explanation for each diag
+// emitted by a file path using the rule's resolved leaves.
+func (r *Runner) attachExplanations(diags []lint.Diagnostic, path string, fmKinds []string) {
+	res := config.ResolveFile(r.Config, path, fmKinds)
+	for i := range diags {
+		rr, ok := res.Rules[diags[i].RuleName]
+		if !ok {
+			continue
+		}
+		leaves := make([]lint.ExplanationLeaf, 0, len(rr.Leaves))
+		for _, l := range rr.Leaves {
+			leaves = append(leaves, lint.ExplanationLeaf{
+				Path: l.Path, Value: l.Value, Source: l.Source(),
+			})
+		}
+		diags[i].Explanation = &lint.Explanation{
+			Rule:   diags[i].RuleName,
+			Leaves: leaves,
+		}
+	}
 }
 
 // RunSource lints in-memory source bytes (e.g. from stdin) and returns a
@@ -136,6 +164,9 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 	r.logRules(effective)
 
 	diags, errs := CheckRules(f, r.Rules, effective)
+	if r.Explain && len(diags) > 0 {
+		r.attachExplanations(diags, path, fmKinds)
+	}
 	res.Diagnostics = append(res.Diagnostics, diags...)
 	res.Errors = append(res.Errors, errs...)
 

--- a/internal/engine/runner_explain_test.go
+++ b/internal/engine/runner_explain_test.go
@@ -48,36 +48,26 @@ func TestRunner_ExplainAttachesProvenanceToDiagnostics(t *testing.T) {
 	assert.True(t, sawMax, "settings.max leaf must appear in the explanation")
 }
 
-// TestRunner_ExplainSkipsDiagnosticsForUnknownRule covers the branch in
-// attachExplanations that skips rules absent from the resolved config.
-func TestRunner_ExplainSkipsDiagnosticsForUnknownRule(t *testing.T) {
+// TestRunner_ExplainEmptyDiagsIsNoOp ensures the runner does not call
+// into the shared explain helper when there are no diagnostics.
+func TestRunner_ExplainEmptyDiagsIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.md")
 	require.NoError(t, os.WriteFile(path, []byte("# Hello\n"), 0o644))
 
-	// Rule is enabled (so it runs) but we attach explanations using a config
-	// where the rule name is missing from cfg.Rules — simulating a rule that
-	// emits a diagnostic with a RuleName not tracked by config.
 	cfg := &config.Config{
 		Rules: map[string]config.RuleCfg{
-			"mock-rule": {Enabled: true},
+			"silent-rule": {Enabled: true},
 		},
 	}
-
 	runner := &Runner{
 		Config:  cfg,
-		Rules:   []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		Rules:   []rule.Rule{&silentRule{id: "MDS998", name: "silent-rule"}},
 		Explain: true,
 	}
 	result := runner.Run([]string{path})
-	require.Len(t, result.Diagnostics, 1)
-	// Manually overwrite the diagnostic's RuleName to one missing from cfg.Rules
-	// and re-run attachExplanations to exercise the skip branch.
-	result.Diagnostics[0].RuleName = "absent-rule"
-	result.Diagnostics[0].Explanation = nil
-	runner.attachExplanations(result.Diagnostics, path, nil)
-	assert.Nil(t, result.Diagnostics[0].Explanation,
-		"unknown rule should leave Explanation nil")
+	assert.Empty(t, result.Diagnostics)
+	assert.Empty(t, result.Errors)
 }
 
 // TestRunner_RunSourceExplainAttachesProvenance covers the RunSource

--- a/internal/engine/runner_explain_test.go
+++ b/internal/engine/runner_explain_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunner_ExplainAttachesProvenanceToDiagnostics covers the runner's
+// attachExplanations path: when Explain is true, each diagnostic emitted
+// for a file gets per-leaf source info from the merged config.
+func TestRunner_ExplainAttachesProvenanceToDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+	require.NoError(t, os.WriteFile(path, []byte("# Hello\n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-rule": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+	}
+
+	runner := &Runner{
+		Config:  cfg,
+		Rules:   []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		Explain: true,
+	}
+	result := runner.Run([]string{path})
+	require.Len(t, result.Diagnostics, 1)
+
+	exp := result.Diagnostics[0].Explanation
+	require.NotNil(t, exp, "explanation must be populated when Explain is true")
+	assert.Equal(t, "mock-rule", exp.Rule)
+
+	var sawMax bool
+	for _, l := range exp.Leaves {
+		if l.Path == "settings.max" {
+			sawMax = true
+			assert.Equal(t, "default", l.Source)
+			assert.Equal(t, 80, l.Value)
+		}
+	}
+	assert.True(t, sawMax, "settings.max leaf must appear in the explanation")
+}
+
+// TestRunner_ExplainSkipsDiagnosticsForUnknownRule covers the branch in
+// attachExplanations that skips rules absent from the resolved config.
+func TestRunner_ExplainSkipsDiagnosticsForUnknownRule(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+	require.NoError(t, os.WriteFile(path, []byte("# Hello\n"), 0o644))
+
+	// Rule is enabled (so it runs) but we attach explanations using a config
+	// where the rule name is missing from cfg.Rules — simulating a rule that
+	// emits a diagnostic with a RuleName not tracked by config.
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-rule": {Enabled: true},
+		},
+	}
+
+	runner := &Runner{
+		Config:  cfg,
+		Rules:   []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		Explain: true,
+	}
+	result := runner.Run([]string{path})
+	require.Len(t, result.Diagnostics, 1)
+	// Manually overwrite the diagnostic's RuleName to one missing from cfg.Rules
+	// and re-run attachExplanations to exercise the skip branch.
+	result.Diagnostics[0].RuleName = "absent-rule"
+	result.Diagnostics[0].Explanation = nil
+	runner.attachExplanations(result.Diagnostics, path, nil)
+	assert.Nil(t, result.Diagnostics[0].Explanation,
+		"unknown rule should leave Explanation nil")
+}
+
+// TestRunner_RunSourceExplainAttachesProvenance covers the RunSource
+// branch when Explain is set.
+func TestRunner_RunSourceExplainAttachesProvenance(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-rule": {Enabled: true},
+		},
+	}
+	runner := &Runner{
+		Config:  cfg,
+		Rules:   []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		Explain: true,
+	}
+	result := runner.RunSource("<stdin>", []byte("# Hi\n"))
+	require.Len(t, result.Diagnostics, 1)
+	require.NotNil(t, result.Diagnostics[0].Explanation)
+	assert.Equal(t, "mock-rule", result.Diagnostics[0].Explanation.Rule)
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -1,0 +1,40 @@
+// Package explain attaches per-leaf rule provenance to lint
+// diagnostics. It bridges internal/config (which computes a file's
+// effective rule resolution) and internal/lint (which carries the
+// optional Explanation payload on a Diagnostic), so the engine and
+// fixer share one implementation rather than duplicating the loop.
+package explain
+
+import (
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// Attach populates Diagnostic.Explanation for each diag emitted at a
+// file path using the rule's resolved per-leaf provenance.
+//
+// Diagnostics whose RuleName is not present in the file's effective
+// rule config are left untouched: the explain trailer is best-effort
+// and never invents provenance for rules that were never resolved.
+func Attach(diags []lint.Diagnostic, cfg *config.Config, path string, fmKinds []string) {
+	if len(diags) == 0 {
+		return
+	}
+	res := config.ResolveFile(cfg, path, fmKinds)
+	for i := range diags {
+		rr, ok := res.Rules[diags[i].RuleName]
+		if !ok {
+			continue
+		}
+		leaves := make([]lint.ExplanationLeaf, 0, len(rr.Leaves))
+		for _, l := range rr.Leaves {
+			leaves = append(leaves, lint.ExplanationLeaf{
+				Path: l.Path, Value: l.Value, Source: l.Source(),
+			})
+		}
+		diags[i].Explanation = &lint.Explanation{
+			Rule:   diags[i].RuleName,
+			Leaves: leaves,
+		}
+	}
+}

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -1,0 +1,98 @@
+package explain
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttach_PopulatesExplanation is the happy-path: each diag whose
+// rule appears in the resolved config gets its leaves attached.
+func TestAttach_PopulatesExplanation(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+	}
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "line-length",
+		Severity: lint.Error, Message: "too long",
+	}}
+
+	Attach(diags, cfg, "x.md", nil)
+	require.NotNil(t, diags[0].Explanation)
+	assert.Equal(t, "line-length", diags[0].Explanation.Rule)
+
+	var sawMax bool
+	for _, l := range diags[0].Explanation.Leaves {
+		if l.Path == "settings.max" {
+			sawMax = true
+			assert.Equal(t, "default", l.Source)
+			assert.Equal(t, 80, l.Value)
+		}
+	}
+	assert.True(t, sawMax, "settings.max leaf must appear in the explanation")
+}
+
+// TestAttach_SkipsDiagsForUnknownRule covers the branch where a
+// diagnostic's RuleName is absent from the resolved config — the
+// helper must leave Explanation nil rather than fabricate provenance.
+func TestAttach_SkipsDiagsForUnknownRule(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length": {Enabled: true},
+		},
+	}
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS999", RuleName: "phantom-rule",
+	}}
+	Attach(diags, cfg, "x.md", nil)
+	assert.Nil(t, diags[0].Explanation)
+}
+
+// TestAttach_EmptyDiagsIsNoOp guards the early-return branch and
+// avoids the wasted ResolveFile call when there is nothing to attach.
+func TestAttach_EmptyDiagsIsNoOp(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{"line-length": {Enabled: true}},
+	}
+	Attach(nil, cfg, "x.md", nil)
+	Attach([]lint.Diagnostic{}, cfg, "x.md", nil)
+	// No panic, no allocation; nothing to assert beyond a successful return.
+}
+
+// TestAttach_FrontMatterKindsApplied ensures the helper threads through
+// fmKinds so kind-driven leaf sources show up correctly.
+func TestAttach_FrontMatterKindsApplied(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+		Kinds: map[string]config.KindBody{
+			"short": {Rules: map[string]config.RuleCfg{
+				"line-length": {Enabled: true, Settings: map[string]any{"max": 30}},
+			}},
+		},
+	}
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "line-length",
+	}}
+	Attach(diags, cfg, "x.md", []string{"short"})
+	require.NotNil(t, diags[0].Explanation)
+
+	var sawMax bool
+	for _, l := range diags[0].Explanation.Leaves {
+		if l.Path == "settings.max" {
+			sawMax = true
+			assert.Equal(t, "kinds.short", l.Source)
+			assert.Equal(t, 30, l.Value)
+		}
+	}
+	assert.True(t, sawMax)
+}

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -27,6 +27,10 @@ type Fixer struct {
 	// MaxInputBytes is the maximum file size in bytes before a file is
 	// skipped with an error. Zero or negative means unlimited.
 	MaxInputBytes int64
+	// Explain, when true, attaches per-leaf rule provenance to each
+	// remaining diagnostic so output formatters can render an
+	// explanation trailer.
+	Explain bool
 }
 
 // Result holds the outcome of a fix run.
@@ -132,7 +136,32 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
+	if f.Explain && len(diags) > 0 {
+		f.attachExplanations(diags, path, fmKinds)
+	}
 	return beforeDiags, diags, modified, errs
+}
+
+// attachExplanations populates Diagnostic.Explanation for each diag
+// emitted by a file path using the rule's resolved leaves.
+func (f *Fixer) attachExplanations(diags []lint.Diagnostic, path string, fmKinds []string) {
+	res := config.ResolveFile(f.Config, path, fmKinds)
+	for i := range diags {
+		rr, ok := res.Rules[diags[i].RuleName]
+		if !ok {
+			continue
+		}
+		leaves := make([]lint.ExplanationLeaf, 0, len(rr.Leaves))
+		for _, l := range rr.Leaves {
+			leaves = append(leaves, lint.ExplanationLeaf{
+				Path: l.Path, Value: l.Value, Source: l.Source(),
+			})
+		}
+		diags[i].Explanation = &lint.Explanation{
+			Rule:   diags[i].RuleName,
+			Leaves: leaves,
+		}
+	}
 }
 
 // applyFixPasses repeatedly applies fixable rules until the content stabilizes.

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/engine"
+	"github.com/jeduden/mdsmith/internal/explain"
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -136,32 +137,10 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
-	if f.Explain && len(diags) > 0 {
-		f.attachExplanations(diags, path, fmKinds)
+	if f.Explain {
+		explain.Attach(diags, f.Config, path, fmKinds)
 	}
 	return beforeDiags, diags, modified, errs
-}
-
-// attachExplanations populates Diagnostic.Explanation for each diag
-// emitted by a file path using the rule's resolved leaves.
-func (f *Fixer) attachExplanations(diags []lint.Diagnostic, path string, fmKinds []string) {
-	res := config.ResolveFile(f.Config, path, fmKinds)
-	for i := range diags {
-		rr, ok := res.Rules[diags[i].RuleName]
-		if !ok {
-			continue
-		}
-		leaves := make([]lint.ExplanationLeaf, 0, len(rr.Leaves))
-		for _, l := range rr.Leaves {
-			leaves = append(leaves, lint.ExplanationLeaf{
-				Path: l.Path, Value: l.Value, Source: l.Source(),
-			})
-		}
-		diags[i].Explanation = &lint.Explanation{
-			Rule:   diags[i].RuleName,
-			Leaves: leaves,
-		}
-	}
 }
 
 // applyFixPasses repeatedly applies fixable rules until the content stabilizes.

--- a/internal/fix/fix_explain_test.go
+++ b/internal/fix/fix_explain_test.go
@@ -1,0 +1,77 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFix_ExplainAttachesProvenanceToRemainingDiagnostics covers the
+// fixer's attachExplanations path: when Explain is true, each
+// diagnostic remaining after the fix pass gets per-leaf source info.
+func TestFix_ExplainAttachesProvenanceToRemainingDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "test.md")
+	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello\n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-nonfixable": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+	}
+
+	fixer := &Fixer{
+		Config: cfg,
+		Rules: []rule.Rule{
+			&mockNonFixableRule{id: "MDS999", name: "mock-nonfixable"},
+		},
+		Explain: true,
+	}
+	result := fixer.Fix([]string{mdFile})
+	require.Len(t, result.Diagnostics, 1)
+	exp := result.Diagnostics[0].Explanation
+	require.NotNil(t, exp, "explanation must be populated when Explain is true")
+	assert.Equal(t, "mock-nonfixable", exp.Rule)
+
+	var sawMax bool
+	for _, l := range exp.Leaves {
+		if l.Path == "settings.max" {
+			sawMax = true
+			assert.Equal(t, "default", l.Source)
+			assert.Equal(t, 80, l.Value)
+		}
+	}
+	assert.True(t, sawMax, "settings.max leaf must appear in the explanation")
+}
+
+// TestFix_ExplainSkipsDiagnosticForUnknownRule covers the branch in
+// attachExplanations that skips rules absent from the resolved config.
+func TestFix_ExplainSkipsDiagnosticForUnknownRule(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "test.md")
+	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello\n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-nonfixable": {Enabled: true},
+		},
+	}
+	fixer := &Fixer{
+		Config:  cfg,
+		Rules:   []rule.Rule{&mockNonFixableRule{id: "MDS999", name: "mock-nonfixable"}},
+		Explain: true,
+	}
+	result := fixer.Fix([]string{mdFile})
+	require.Len(t, result.Diagnostics, 1)
+	// Re-attach with a RuleName not in cfg.Rules to exercise the skip branch.
+	result.Diagnostics[0].RuleName = "absent-rule"
+	result.Diagnostics[0].Explanation = nil
+	fixer.attachExplanations(result.Diagnostics, mdFile, nil)
+	assert.Nil(t, result.Diagnostics[0].Explanation,
+		"unknown rule should leave Explanation nil")
+}

--- a/internal/fix/fix_explain_test.go
+++ b/internal/fix/fix_explain_test.go
@@ -49,9 +49,9 @@ func TestFix_ExplainAttachesProvenanceToRemainingDiagnostics(t *testing.T) {
 	assert.True(t, sawMax, "settings.max leaf must appear in the explanation")
 }
 
-// TestFix_ExplainSkipsDiagnosticForUnknownRule covers the branch in
-// attachExplanations that skips rules absent from the resolved config.
-func TestFix_ExplainSkipsDiagnosticForUnknownRule(t *testing.T) {
+// TestFix_ExplainOmittedWhenFlagUnset ensures the fixer does not
+// populate Diagnostic.Explanation when Explain is false.
+func TestFix_ExplainOmittedWhenFlagUnset(t *testing.T) {
 	dir := t.TempDir()
 	mdFile := filepath.Join(dir, "test.md")
 	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello\n"), 0o644))
@@ -62,16 +62,11 @@ func TestFix_ExplainSkipsDiagnosticForUnknownRule(t *testing.T) {
 		},
 	}
 	fixer := &Fixer{
-		Config:  cfg,
-		Rules:   []rule.Rule{&mockNonFixableRule{id: "MDS999", name: "mock-nonfixable"}},
-		Explain: true,
+		Config: cfg,
+		Rules:  []rule.Rule{&mockNonFixableRule{id: "MDS999", name: "mock-nonfixable"}},
 	}
 	result := fixer.Fix([]string{mdFile})
 	require.Len(t, result.Diagnostics, 1)
-	// Re-attach with a RuleName not in cfg.Rules to exercise the skip branch.
-	result.Diagnostics[0].RuleName = "absent-rule"
-	result.Diagnostics[0].Explanation = nil
-	fixer.attachExplanations(result.Diagnostics, mdFile, nil)
 	assert.Nil(t, result.Diagnostics[0].Explanation,
-		"unknown rule should leave Explanation nil")
+		"Explanation must remain nil when Explain is false")
 }

--- a/internal/kindsout/kindsout.go
+++ b/internal/kindsout/kindsout.go
@@ -1,0 +1,304 @@
+// Package kindsout renders the output of the 'mdsmith kinds'
+// subcommand surface: declared-kind bodies, per-file resolutions,
+// and per-rule merge chains. It exposes both stable JSON shapes
+// (for LSPs and other tools) and human-readable text.
+package kindsout
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// --- JSON shapes ---
+
+// BodyJSON is the JSON form of a kind body, used by `kinds list` and
+// `kinds show`.
+type BodyJSON struct {
+	Name       string                 `json:"name"`
+	Rules      map[string]RuleCfgJSON `json:"rules"`
+	Categories map[string]bool        `json:"categories,omitempty"`
+}
+
+// RuleCfgJSON serializes a config.RuleCfg using its YAML union form:
+// false (disabled), true (enabled, no settings), or the settings map.
+type RuleCfgJSON struct {
+	v any
+}
+
+// MarshalJSON implements json.Marshaler.
+func (r RuleCfgJSON) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.v)
+}
+
+// MakeBodyJSON renders a KindBody as a JSON-friendly value.
+func MakeBodyJSON(name string, body config.KindBody) BodyJSON {
+	rules := make(map[string]RuleCfgJSON, len(body.Rules))
+	for k, v := range body.Rules {
+		rules[k] = RuleCfgJSON{v: RuleCfgValue(v)}
+	}
+	return BodyJSON{
+		Name:       name,
+		Rules:      rules,
+		Categories: body.Categories,
+	}
+}
+
+// RuleCfgValue returns the JSON-friendly value of a RuleCfg, matching
+// its YAML marshalling: false, true, or the settings map.
+func RuleCfgValue(rc config.RuleCfg) any {
+	if !rc.Enabled && rc.Settings == nil {
+		return false
+	}
+	if rc.Enabled && len(rc.Settings) > 0 {
+		return rc.Settings
+	}
+	return true
+}
+
+// ResolvedKindJSON names a kind in the effective list and how it was
+// assigned ("front-matter" or "kind-assignment[<i>]").
+type ResolvedKindJSON struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+}
+
+// LeafJSON is one effective leaf with its winning source and the chain
+// of layers that set it.
+type LeafJSON struct {
+	Path   string          `json:"path"`
+	Value  any             `json:"value"`
+	Source string          `json:"source"`
+	Chain  []LeafChainJSON `json:"chain,omitempty"`
+}
+
+// LeafChainJSON is one layer in a leaf's merge chain.
+type LeafChainJSON struct {
+	Source string `json:"source"`
+	Value  any    `json:"value"`
+}
+
+// LayerJSON describes one applicable merge layer for a rule. When Set
+// is false the layer did not touch the rule and Value is omitted.
+type LayerJSON struct {
+	Source string `json:"source"`
+	Set    bool   `json:"set"`
+	Value  any    `json:"value,omitempty"`
+}
+
+// RuleResolutionJSON is the JSON form of a per-rule merge chain.
+type RuleResolutionJSON struct {
+	File   string      `json:"file"`
+	Rule   string      `json:"rule"`
+	Final  any         `json:"final"`
+	Layers []LayerJSON `json:"layers"`
+	Leaves []LeafJSON  `json:"leaves"`
+}
+
+// RuleSummaryJSON is the per-rule summary inside a file resolution:
+// the final config and per-leaf provenance.
+type RuleSummaryJSON struct {
+	Final  any        `json:"final"`
+	Leaves []LeafJSON `json:"leaves"`
+}
+
+// FileResolutionJSON is the JSON form of a file's effective config.
+type FileResolutionJSON struct {
+	File       string                     `json:"file"`
+	Kinds      []ResolvedKindJSON         `json:"kinds"`
+	Categories map[string]bool            `json:"categories,omitempty"`
+	Rules      map[string]RuleSummaryJSON `json:"rules"`
+}
+
+// FileResolution converts a config.FileResolution to its JSON shape.
+func FileResolution(res *config.FileResolution) FileResolutionJSON {
+	out := FileResolutionJSON{
+		File:       res.File,
+		Kinds:      make([]ResolvedKindJSON, 0, len(res.Kinds)),
+		Categories: res.Categories,
+		Rules:      make(map[string]RuleSummaryJSON, len(res.Rules)),
+	}
+	for _, k := range res.Kinds {
+		out.Kinds = append(out.Kinds, ResolvedKindJSON{
+			Name: k.Name, Source: string(k.Source),
+		})
+	}
+	for name, rr := range res.Rules {
+		out.Rules[name] = RuleSummaryJSON{
+			Final:  RuleCfgValue(rr.Final),
+			Leaves: leavesJSON(rr.Leaves),
+		}
+	}
+	return out
+}
+
+// RuleResolution converts a config.RuleResolution to its JSON shape.
+func RuleResolution(file string, rr config.RuleResolution) RuleResolutionJSON {
+	layers := make([]LayerJSON, 0, len(rr.Layers))
+	for _, l := range rr.Layers {
+		entry := LayerJSON{Source: l.Source, Set: l.Set}
+		if l.Set {
+			entry.Value = RuleCfgValue(l.Value)
+		}
+		layers = append(layers, entry)
+	}
+	return RuleResolutionJSON{
+		File:   file,
+		Rule:   rr.Rule,
+		Final:  RuleCfgValue(rr.Final),
+		Layers: layers,
+		Leaves: leavesJSON(rr.Leaves),
+	}
+}
+
+func leavesJSON(leaves []config.Leaf) []LeafJSON {
+	out := make([]LeafJSON, 0, len(leaves))
+	for _, l := range leaves {
+		entry := LeafJSON{
+			Path:   l.Path,
+			Value:  l.Value,
+			Source: l.Source(),
+		}
+		for _, c := range l.Chain {
+			entry.Chain = append(entry.Chain, LeafChainJSON{
+				Source: c.Source, Value: c.Value,
+			})
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// WriteJSON emits v as pretty-printed JSON.
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// --- Text rendering ---
+
+// WriteBodyText prints a kind body as YAML, wrapped with a header line
+// naming the kind.
+func WriteBodyText(w io.Writer, name string, body config.KindBody) error {
+	if _, err := fmt.Fprintf(w, "%s:\n", name); err != nil {
+		return err
+	}
+	wrap := struct {
+		Rules      map[string]config.RuleCfg `yaml:"rules,omitempty"`
+		Categories map[string]bool           `yaml:"categories,omitempty"`
+	}{
+		Rules:      body.Rules,
+		Categories: body.Categories,
+	}
+	data, err := yaml.Marshal(wrap)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 || strings.TrimSpace(string(data)) == "{}" {
+		_, err := fmt.Fprintln(w, "  (empty)")
+		return err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteFileResolutionText renders a per-file resolution as text, with
+// effective kinds and per-leaf source info for every rule.
+func WriteFileResolutionText(w io.Writer, res *config.FileResolution) error {
+	if _, err := fmt.Fprintf(w, "file: %s\n", res.File); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "effective kinds:"); err != nil {
+		return err
+	}
+	if len(res.Kinds) == 0 {
+		if _, err := fmt.Fprintln(w, "  (none)"); err != nil {
+			return err
+		}
+	} else {
+		for _, k := range res.Kinds {
+			if _, err := fmt.Fprintf(w, "  - %s (from %s)\n", k.Name, k.Source); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := fmt.Fprintln(w, "rules:"); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(res.Rules))
+	for name := range res.Rules {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		rr := res.Rules[name]
+		if _, err := fmt.Fprintf(w, "  %s:\n", name); err != nil {
+			return err
+		}
+		for _, leaf := range rr.Leaves {
+			if _, err := fmt.Fprintf(w, "    %s = %s  (from %s)\n",
+				leaf.Path, FormatValue(leaf.Value), leaf.Source()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// WriteRuleResolutionText renders a per-rule merge chain as text,
+// including no-op layers and the chain for every leaf.
+func WriteRuleResolutionText(w io.Writer, file string, rr config.RuleResolution) error {
+	if _, err := fmt.Fprintf(w, "file: %s\nrule: %s\n\nmerge chain (oldest -> newest):\n",
+		file, rr.Rule); err != nil {
+		return err
+	}
+	for _, l := range rr.Layers {
+		var line string
+		if l.Set {
+			line = fmt.Sprintf("  %-30s set    %s\n",
+				l.Source, FormatValue(RuleCfgValue(l.Value)))
+		} else {
+			line = fmt.Sprintf("  %-30s no-op  (rule untouched)\n", l.Source)
+		}
+		if _, err := fmt.Fprint(w, line); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "\nper-leaf provenance:"); err != nil {
+		return err
+	}
+	for _, leaf := range rr.Leaves {
+		if _, err := fmt.Fprintf(w, "  %s = %s  (winning source: %s)\n",
+			leaf.Path, FormatValue(leaf.Value), leaf.Source()); err != nil {
+			return err
+		}
+		for _, c := range leaf.Chain {
+			if _, err := fmt.Fprintf(w, "    %-28s %s\n",
+				c.Source, FormatValue(c.Value)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// FormatValue renders a leaf value compactly (JSON-like) so settings
+// maps, lists, and scalars all print on one line.
+func FormatValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}

--- a/internal/kindsout/kindsout.go
+++ b/internal/kindsout/kindsout.go
@@ -192,7 +192,7 @@ func WriteJSON(w io.Writer, v any) error {
 // WriteBodyText prints a kind body as YAML, wrapped with a header line
 // naming the kind.
 func WriteBodyText(w io.Writer, name string, body config.KindBody) error {
-	if _, err := fmt.Fprintf(w, "%s:\n", name); err != nil {
+	if _, err := fmt.Fprintf(w, "%s:\n", sanitizeControl(name)); err != nil {
 		return err
 	}
 	wrap := struct {
@@ -221,7 +221,7 @@ func WriteBodyText(w io.Writer, name string, body config.KindBody) error {
 // WriteFileResolutionText renders a per-file resolution as text, with
 // effective kinds and per-leaf source info for every rule.
 func WriteFileResolutionText(w io.Writer, res *config.FileResolution) error {
-	if _, err := fmt.Fprintf(w, "file: %s\n", res.File); err != nil {
+	if _, err := fmt.Fprintf(w, "file: %s\n", sanitizeControl(res.File)); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintln(w, "effective kinds:"); err != nil {
@@ -233,7 +233,8 @@ func WriteFileResolutionText(w io.Writer, res *config.FileResolution) error {
 		}
 	} else {
 		for _, k := range res.Kinds {
-			if _, err := fmt.Fprintf(w, "  - %s (from %s)\n", k.Name, k.Source); err != nil {
+			if _, err := fmt.Fprintf(w, "  - %s (from %s)\n",
+				sanitizeControl(k.Name), sanitizeControl(string(k.Source))); err != nil {
 				return err
 			}
 		}
@@ -249,12 +250,13 @@ func WriteFileResolutionText(w io.Writer, res *config.FileResolution) error {
 	sort.Strings(names)
 	for _, name := range names {
 		rr := res.Rules[name]
-		if _, err := fmt.Fprintf(w, "  %s:\n", name); err != nil {
+		if _, err := fmt.Fprintf(w, "  %s:\n", sanitizeControl(name)); err != nil {
 			return err
 		}
 		for _, leaf := range rr.Leaves {
 			if _, err := fmt.Fprintf(w, "    %s = %s  (from %s)\n",
-				leaf.Path, FormatValue(leaf.Value), leaf.Source()); err != nil {
+				sanitizeControl(leaf.Path), FormatValue(leaf.Value),
+				sanitizeControl(leaf.Source())); err != nil {
 				return err
 			}
 		}
@@ -266,16 +268,17 @@ func WriteFileResolutionText(w io.Writer, res *config.FileResolution) error {
 // including no-op layers and the chain for every leaf.
 func WriteRuleResolutionText(w io.Writer, file string, rr config.RuleResolution) error {
 	if _, err := fmt.Fprintf(w, "file: %s\nrule: %s\n\nmerge chain (oldest -> newest):\n",
-		file, rr.Rule); err != nil {
+		sanitizeControl(file), sanitizeControl(rr.Rule)); err != nil {
 		return err
 	}
 	for _, l := range rr.Layers {
 		var line string
 		if l.Set {
 			line = fmt.Sprintf("  %-30s set    %s\n",
-				l.Source, FormatValue(RuleCfgValue(l.Value)))
+				sanitizeControl(l.Source), FormatValue(RuleCfgValue(l.Value)))
 		} else {
-			line = fmt.Sprintf("  %-30s no-op  (rule untouched)\n", l.Source)
+			line = fmt.Sprintf("  %-30s no-op  (rule untouched)\n",
+				sanitizeControl(l.Source))
 		}
 		if _, err := fmt.Fprint(w, line); err != nil {
 			return err
@@ -286,12 +289,13 @@ func WriteRuleResolutionText(w io.Writer, file string, rr config.RuleResolution)
 	}
 	for _, leaf := range rr.Leaves {
 		if _, err := fmt.Fprintf(w, "  %s = %s  (winning source: %s)\n",
-			leaf.Path, FormatValue(leaf.Value), leaf.Source()); err != nil {
+			sanitizeControl(leaf.Path), FormatValue(leaf.Value),
+			sanitizeControl(leaf.Source())); err != nil {
 			return err
 		}
 		for _, c := range leaf.Chain {
 			if _, err := fmt.Fprintf(w, "    %-28s %s\n",
-				c.Source, FormatValue(c.Value)); err != nil {
+				sanitizeControl(c.Source), FormatValue(c.Value)); err != nil {
 				return err
 			}
 		}
@@ -307,4 +311,16 @@ func FormatValue(v any) string {
 		return fmt.Sprintf("%v", v)
 	}
 	return string(b)
+}
+
+// sanitizeControl strips C0/C1 control characters from s so that
+// user-controlled strings (kind names, rule names, file paths, source
+// labels) cannot inject newlines or ANSI escapes into text output.
+func sanitizeControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/internal/kindsout/kindsout.go
+++ b/internal/kindsout/kindsout.go
@@ -52,10 +52,16 @@ func MakeBodyJSON(name string, body config.KindBody) BodyJSON {
 // RuleCfgValue returns the JSON-friendly value of a RuleCfg, matching
 // its YAML marshalling: false, true, or the settings map.
 func RuleCfgValue(rc config.RuleCfg) any {
-	if !rc.Enabled && rc.Settings == nil {
+	// A disabled rule maps to `false` regardless of inherited Settings.
+	// Deep-merge can produce {Enabled: false, Settings: <inherited>}
+	// when a bool-only later layer toggles the rule off; reporting
+	// `final: true` (or the settings map) in that case would
+	// contradict the `enabled` leaf. The per-leaf chain still carries
+	// the inherited values for tooling that needs them.
+	if !rc.Enabled {
 		return false
 	}
-	if rc.Enabled && len(rc.Settings) > 0 {
+	if len(rc.Settings) > 0 {
 		return rc.Settings
 	}
 	return true

--- a/internal/kindsout/kindsout_test.go
+++ b/internal/kindsout/kindsout_test.go
@@ -38,6 +38,15 @@ func TestRuleCfgValue_AllForms(t *testing.T) {
 	m, ok := v.(map[string]any)
 	require.True(t, ok)
 	assert.EqualValues(t, 30, m["max"])
+
+	// Deep-merge can leave Enabled=false with non-nil Settings (a
+	// bool-only layer toggling Enabled while inheriting Settings from
+	// an earlier layer). The output value must report `false` so it
+	// cannot contradict the `enabled` leaf.
+	assert.Equal(t, false, RuleCfgValue(config.RuleCfg{
+		Enabled:  false,
+		Settings: map[string]any{"max": 30},
+	}))
 }
 
 func TestRuleCfgJSON_Marshal(t *testing.T) {

--- a/internal/kindsout/kindsout_test.go
+++ b/internal/kindsout/kindsout_test.go
@@ -1,0 +1,326 @@
+package kindsout
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingWriter returns the configured error from every Write so we
+// can exercise the error-handling branches in WriteBodyText / etc.
+type failingWriter struct {
+	err   error
+	after int // number of successful writes before erroring
+	calls int
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls > w.after {
+		return 0, w.err
+	}
+	return len(p), nil
+}
+
+func TestRuleCfgValue_AllForms(t *testing.T) {
+	assert.Equal(t, false, RuleCfgValue(config.RuleCfg{Enabled: false}))
+	assert.Equal(t, true, RuleCfgValue(config.RuleCfg{Enabled: true}))
+	v := RuleCfgValue(config.RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"max": 30},
+	})
+	m, ok := v.(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 30, m["max"])
+}
+
+func TestRuleCfgJSON_Marshal(t *testing.T) {
+	r := RuleCfgJSON{v: false}
+	data, err := r.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "false", string(data))
+}
+
+func TestMakeBodyJSON_PreservesShape(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"line-length":           {Enabled: true, Settings: map[string]any{"max": 30}},
+			"paragraph-readability": {Enabled: false},
+		},
+		Categories: map[string]bool{"meta": true},
+	}
+	out := MakeBodyJSON("plan", body)
+	assert.Equal(t, "plan", out.Name)
+	require.Contains(t, out.Rules, "line-length")
+	require.Contains(t, out.Rules, "paragraph-readability")
+
+	enc, err := json.Marshal(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(enc), `"line-length":{"max":30}`)
+	assert.Contains(t, string(enc), `"paragraph-readability":false`)
+}
+
+func TestWriteBodyText_RendersYAMLBody(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"line-length": {Enabled: true, Settings: map[string]any{"max": 30}},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, WriteBodyText(&buf, "plan", body))
+	out := buf.String()
+	assert.Contains(t, out, "plan:")
+	assert.Contains(t, out, "rules:")
+	assert.Contains(t, out, "max: 30")
+}
+
+func TestWriteBodyText_EmptyBodyRendersPlaceholder(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteBodyText(&buf, "ghost", config.KindBody{}))
+	out := buf.String()
+	assert.Contains(t, out, "ghost:")
+	assert.Contains(t, out, "(empty)")
+}
+
+func TestWriteBodyText_HeaderWriteError(t *testing.T) {
+	w := &failingWriter{err: errors.New("disk full"), after: 0}
+	err := WriteBodyText(w, "plan", config.KindBody{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disk full")
+}
+
+func TestWriteBodyText_BodyWriteError(t *testing.T) {
+	w := &failingWriter{err: errors.New("nope"), after: 1}
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{"x": {Enabled: true}},
+	}
+	err := WriteBodyText(w, "plan", body)
+	require.Error(t, err)
+}
+
+func TestWriteBodyText_EmptyPlaceholderWriteError(t *testing.T) {
+	w := &failingWriter{err: errors.New("nope"), after: 1}
+	err := WriteBodyText(w, "ghost", config.KindBody{})
+	require.Error(t, err)
+}
+
+// makeFileResolution builds a minimal FileResolution with one rule and
+// two layers so writers exercise both the kinds and rules branches.
+func makeFileResolution(t *testing.T) *config.FileResolution {
+	t.Helper()
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+		Kinds: map[string]config.KindBody{
+			"short": {Rules: map[string]config.RuleCfg{
+				"line-length": {Enabled: true, Settings: map[string]any{"max": 30}},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"short"}},
+		},
+	}
+	return config.ResolveFile(cfg, "x.md", nil)
+}
+
+func TestWriteFileResolutionText_Full(t *testing.T) {
+	res := makeFileResolution(t)
+	var buf bytes.Buffer
+	require.NoError(t, WriteFileResolutionText(&buf, res))
+	out := buf.String()
+	assert.Contains(t, out, "file: x.md")
+	assert.Contains(t, out, "short (from kind-assignment[0])")
+	assert.Contains(t, out, "line-length")
+	assert.Contains(t, out, "settings.max = 30")
+	assert.Contains(t, out, "(from kinds.short)")
+}
+
+func TestWriteFileResolutionText_NoKinds(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{"line-length": {Enabled: true}},
+	}
+	res := config.ResolveFile(cfg, "x.md", nil)
+	var buf bytes.Buffer
+	require.NoError(t, WriteFileResolutionText(&buf, res))
+	assert.Contains(t, buf.String(), "(none)")
+}
+
+func TestWriteFileResolutionText_WriteErrorPropagates(t *testing.T) {
+	res := makeFileResolution(t)
+	for after := 0; after < 6; after++ {
+		w := &failingWriter{err: errors.New("io"), after: after}
+		err := WriteFileResolutionText(w, res)
+		assert.Error(t, err, "expected error for write #%d", after)
+	}
+}
+
+func TestWriteRuleResolutionText_FullAndNoOpLayers(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length":           {Enabled: true, Settings: map[string]any{"max": 80}},
+			"paragraph-readability": {Enabled: true},
+		},
+		Kinds: map[string]config.KindBody{
+			// short does not touch line-length, so it appears as a no-op layer.
+			"short": {Rules: map[string]config.RuleCfg{
+				"paragraph-readability": {Enabled: false},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"short"}},
+		},
+	}
+	res := config.ResolveFile(cfg, "x.md", nil)
+	rr := res.Rules["line-length"]
+	var buf bytes.Buffer
+	require.NoError(t, WriteRuleResolutionText(&buf, "x.md", rr))
+	out := buf.String()
+	assert.Contains(t, out, "rule: line-length")
+	assert.Contains(t, out, "default")
+	assert.Contains(t, out, "no-op")
+	assert.Contains(t, out, "kinds.short")
+	assert.Contains(t, out, "winning source: default")
+}
+
+func TestWriteRuleResolutionText_WriteErrorPropagates(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"r": {Enabled: true, Settings: map[string]any{"v": 1}},
+		},
+		Kinds: map[string]config.KindBody{
+			"k": {Rules: map[string]config.RuleCfg{
+				"r": {Enabled: true, Settings: map[string]any{"v": 2}},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"k"}},
+		},
+	}
+	res := config.ResolveFile(cfg, "x.md", nil)
+	rr := res.Rules["r"]
+	for after := 0; after < 8; after++ {
+		w := &failingWriter{err: errors.New("io"), after: after}
+		err := WriteRuleResolutionText(w, "x.md", rr)
+		assert.Error(t, err, "expected error for write #%d", after)
+	}
+}
+
+func TestWriteJSON_RendersIndentedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteJSON(&buf, map[string]int{"a": 1}))
+	assert.Contains(t, buf.String(), "\"a\": 1")
+	assert.Equal(t, "\n", buf.String()[len(buf.String())-1:])
+}
+
+func TestWriteJSON_EncodingError(t *testing.T) {
+	// channels are not encodable
+	err := WriteJSON(&bytes.Buffer{}, make(chan int))
+	require.Error(t, err)
+}
+
+func TestWriteJSON_WriteError(t *testing.T) {
+	w := &failingWriter{err: errors.New("io"), after: 0}
+	err := WriteJSON(w, map[string]int{"a": 1})
+	require.Error(t, err)
+}
+
+func TestFormatValue_Scalars(t *testing.T) {
+	assert.Equal(t, "30", FormatValue(30))
+	assert.Equal(t, "true", FormatValue(true))
+	assert.Equal(t, "\"hi\"", FormatValue("hi"))
+	assert.Equal(t, "null", FormatValue(nil))
+}
+
+func TestFormatValue_FallbackForUnmarshalable(t *testing.T) {
+	// channel is not JSON-encodable; FormatValue falls back to %v,
+	// which prints the channel's pointer address.
+	out := FormatValue(make(chan int))
+	assert.NotEmpty(t, out)
+	assert.True(t, strings.HasPrefix(out, "0x"),
+		"expected pointer-like fallback, got %q", out)
+}
+
+func TestFileResolutionJSON_Shape(t *testing.T) {
+	res := makeFileResolution(t)
+	out := FileResolution(res)
+	assert.Equal(t, "x.md", out.File)
+	require.Len(t, out.Kinds, 1)
+	assert.Equal(t, "short", out.Kinds[0].Name)
+	assert.Equal(t, "kind-assignment[0]", out.Kinds[0].Source)
+	rr, ok := out.Rules["line-length"]
+	require.True(t, ok)
+	var sawMax bool
+	for _, l := range rr.Leaves {
+		if l.Path == "settings.max" {
+			sawMax = true
+			assert.Equal(t, "kinds.short", l.Source)
+		}
+	}
+	assert.True(t, sawMax)
+}
+
+func TestRuleResolutionJSON_IncludesNoOpLayers(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length":           {Enabled: true, Settings: map[string]any{"max": 80}},
+			"paragraph-readability": {Enabled: true},
+		},
+		Kinds: map[string]config.KindBody{
+			"short": {Rules: map[string]config.RuleCfg{
+				"paragraph-readability": {Enabled: false},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"short"}},
+		},
+	}
+	res := config.ResolveFile(cfg, "x.md", nil)
+	rr := res.Rules["line-length"]
+	out := RuleResolution("x.md", rr)
+	require.Len(t, out.Layers, 2)
+	assert.Equal(t, "default", out.Layers[0].Source)
+	assert.True(t, out.Layers[0].Set)
+	assert.Equal(t, "kinds.short", out.Layers[1].Source)
+	assert.False(t, out.Layers[1].Set, "no-op layer for line-length")
+}
+
+func TestLeavesJSON_PreservesChain(t *testing.T) {
+	res := makeFileResolution(t)
+	rr := res.Rules["line-length"]
+	out := RuleResolution("x.md", rr)
+	for _, l := range out.Leaves {
+		if l.Path == "settings.max" {
+			require.Len(t, l.Chain, 2)
+			assert.Equal(t, "default", l.Chain[0].Source)
+			assert.Equal(t, "kinds.short", l.Chain[1].Source)
+			return
+		}
+	}
+	t.Fatalf("settings.max leaf missing from %v", out.Leaves)
+}
+
+// Ensure WriteBodyText output is sorted deterministically.
+func TestWriteBodyText_DeterministicOutput(t *testing.T) {
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"a": {Enabled: false},
+			"b": {Enabled: false},
+			"c": {Enabled: false},
+		},
+	}
+	var first, second bytes.Buffer
+	require.NoError(t, WriteBodyText(&first, "plan", body))
+	require.NoError(t, WriteBodyText(&second, "plan", body))
+	assert.Equal(t, first.String(), second.String())
+	// All three names appear.
+	for _, name := range []string{"a", "b", "c"} {
+		assert.True(t, strings.Contains(first.String(), name))
+	}
+}

--- a/internal/kindsout/kindsout_test.go
+++ b/internal/kindsout/kindsout_test.go
@@ -355,6 +355,65 @@ func TestWriteFileResolutionText_NoneWriteError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestSanitizeControl_StripsCtrls covers the sanitizeControl helper.
+func TestSanitizeControl_StripsCtrls(t *testing.T) {
+	assert.Equal(t, "ab", sanitizeControl("a\nb"))     // C0: LF
+	assert.Equal(t, "ab", sanitizeControl("a\x07b"))   // C0: BEL
+	assert.Equal(t, "ab", sanitizeControl("a\x1bb"))   // C0: ESC
+	assert.Equal(t, "ab", sanitizeControl("a\u009fb")) // C1: U+009F
+	assert.Equal(t, "hello", sanitizeControl("hello"))
+}
+
+// TestWriteBodyText_SanitizesKindName ensures control chars in the kind
+// name are stripped from the header line.
+func TestWriteBodyText_SanitizesKindName(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteBodyText(&buf, "evil\nkind", config.KindBody{}))
+	assert.NotContains(t, buf.String(), "\n\n") // no extra blank line from injected newline
+	assert.Contains(t, buf.String(), "evilkind:")
+}
+
+// TestWriteFileResolutionText_SanitizesKindName ensures control chars
+// in kind names (from user YAML) are stripped from the text output.
+func TestWriteFileResolutionText_SanitizesKindName(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line-length": {Enabled: true},
+		},
+		Kinds: map[string]config.KindBody{
+			"evil\x1bkind": {Rules: map[string]config.RuleCfg{
+				"line-length": {Enabled: true},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"x.md"}, Kinds: []string{"evil\x1bkind"}},
+		},
+	}
+	res := config.ResolveFile(cfg, "x.md", nil)
+	var buf bytes.Buffer
+	require.NoError(t, WriteFileResolutionText(&buf, res))
+	assert.NotContains(t, buf.String(), "\x1b")
+	assert.Contains(t, buf.String(), "evilkind")
+}
+
+// TestWriteRuleResolutionText_SanitizesFields ensures control chars in
+// file/rule/source fields are stripped from the text output.
+func TestWriteRuleResolutionText_SanitizesFields(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"line\x07length": {Enabled: true, Settings: map[string]any{"max": 80}},
+		},
+	}
+	res := config.ResolveFile(cfg, "evil\x07file.md", nil)
+	rr := res.Rules["line\x07length"]
+	var buf bytes.Buffer
+	require.NoError(t, WriteRuleResolutionText(&buf, "evil\x07file.md", rr))
+	out := buf.String()
+	assert.NotContains(t, out, "\x07")
+	assert.Contains(t, out, "linelength")  // BEL stripped from rule name
+	assert.Contains(t, out, "evilfile.md") // BEL stripped from file name
+}
+
 // Ensure WriteBodyText output is sorted deterministically.
 func TestWriteBodyText_DeterministicOutput(t *testing.T) {
 	body := config.KindBody{

--- a/internal/kindsout/kindsout_test.go
+++ b/internal/kindsout/kindsout_test.go
@@ -306,6 +306,46 @@ func TestLeavesJSON_PreservesChain(t *testing.T) {
 	t.Fatalf("settings.max leaf missing from %v", out.Leaves)
 }
 
+// erroringYAMLMarshaler implements yaml.Marshaler with a method that
+// always returns an error so we can drive yaml.Marshal down its
+// error-return path.
+type erroringYAMLMarshaler struct{}
+
+func (erroringYAMLMarshaler) MarshalYAML() (any, error) {
+	return nil, errors.New("synthetic marshal error")
+}
+
+// TestWriteBodyText_YAMLMarshalError covers the yaml.Marshal failure
+// branch: a setting whose value implements yaml.Marshaler and returns
+// an error makes yaml.Marshal surface that error rather than panicking.
+func TestWriteBodyText_YAMLMarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	body := config.KindBody{
+		Rules: map[string]config.RuleCfg{
+			"x": {
+				Enabled:  true,
+				Settings: map[string]any{"bad": erroringYAMLMarshaler{}},
+			},
+		},
+	}
+	err := WriteBodyText(&buf, "k", body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "synthetic marshal error")
+}
+
+// TestWriteFileResolutionText_NoneWriteError covers the (none) Fprintln
+// error branch: an empty kinds list combined with a writer that fails
+// after the first two writes.
+func TestWriteFileResolutionText_NoneWriteError(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{"r": {Enabled: true}},
+	}
+	res := config.ResolveFile(cfg, "x.md", nil)
+	w := &failingWriter{err: errors.New("io"), after: 2}
+	err := WriteFileResolutionText(w, res)
+	require.Error(t, err)
+}
+
 // Ensure WriteBodyText output is sorted deterministically.
 func TestWriteBodyText_DeterministicOutput(t *testing.T) {
 	body := config.KindBody{

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -31,4 +31,24 @@ type Diagnostic struct {
 	Message         string
 	SourceLines     []string // context lines around the diagnostic; empty if unavailable
 	SourceStartLine int      // 1-based line number of first entry in SourceLines
+	// Explanation, when non-nil, attaches per-leaf provenance for the
+	// rule that fired. Populated by the CLI when --explain is on.
+	Explanation *Explanation
+}
+
+// Explanation describes the provenance of a rule's effective config at
+// the file that produced a diagnostic. It is attached to a Diagnostic
+// when the CLI runs with --explain so the trailer / JSON output can
+// name the rule and the source of each setting that contributed.
+type Explanation struct {
+	Rule   string
+	Leaves []ExplanationLeaf
+}
+
+// ExplanationLeaf is one leaf setting and the layer that set its final
+// value, formatted for surface output.
+type ExplanationLeaf struct {
+	Path   string
+	Value  any
+	Source string
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -11,15 +11,27 @@ import (
 type JSONFormatter struct{}
 
 type jsonDiagnostic struct {
-	File            string   `json:"file"`
-	Line            int      `json:"line"`
-	Column          int      `json:"column"`
-	Rule            string   `json:"rule"`
-	Name            string   `json:"name"`
-	Severity        string   `json:"severity"`
-	Message         string   `json:"message"`
-	SourceLines     []string `json:"source_lines,omitempty"`
-	SourceStartLine int      `json:"source_start_line,omitempty"`
+	File            string           `json:"file"`
+	Line            int              `json:"line"`
+	Column          int              `json:"column"`
+	Rule            string           `json:"rule"`
+	Name            string           `json:"name"`
+	Severity        string           `json:"severity"`
+	Message         string           `json:"message"`
+	SourceLines     []string         `json:"source_lines,omitempty"`
+	SourceStartLine int              `json:"source_start_line,omitempty"`
+	Explanation     *jsonExplanation `json:"explanation,omitempty"`
+}
+
+type jsonExplanation struct {
+	Rule   string                `json:"rule"`
+	Leaves []jsonExplanationLeaf `json:"leaves"`
+}
+
+type jsonExplanationLeaf struct {
+	Path   string `json:"path"`
+	Value  any    `json:"value"`
+	Source string `json:"source"`
 }
 
 // Format writes diagnostics as a pretty-printed JSON array.
@@ -37,9 +49,23 @@ func (f *JSONFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 			Message:         d.Message,
 			SourceLines:     d.SourceLines,
 			SourceStartLine: d.SourceStartLine,
+			Explanation:     explanationToJSON(d.Explanation),
 		})
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(items)
+}
+
+func explanationToJSON(e *lint.Explanation) *jsonExplanation {
+	if e == nil {
+		return nil
+	}
+	leaves := make([]jsonExplanationLeaf, 0, len(e.Leaves))
+	for _, l := range e.Leaves {
+		leaves = append(leaves, jsonExplanationLeaf{
+			Path: l.Path, Value: l.Value, Source: l.Source,
+		})
+	}
+	return &jsonExplanation{Rule: e.Rule, Leaves: leaves}
 }

--- a/internal/output/output_coverage_test.go
+++ b/internal/output/output_coverage_test.go
@@ -226,3 +226,55 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+// TestFormat_ExplanationWriterError covers the propagation branch in
+// Format: the header succeeds, the diagnostic has no SourceLines so
+// formatSnippet writes nothing, and the explanation trailer write fails.
+func TestFormat_ExplanationWriterError(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	w := &limitedWriter{limit: 1}
+
+	diagnostics := []lint.Diagnostic{
+		{
+			File:     "test.md",
+			Line:     1,
+			Column:   1,
+			RuleID:   "MDS001",
+			RuleName: "test",
+			Message:  "test",
+			Explanation: &lint.Explanation{
+				Rule: "test",
+				Leaves: []lint.ExplanationLeaf{
+					{Path: "settings.max", Value: 80, Source: "default"},
+				},
+			},
+		},
+	}
+
+	err := f.Format(w, diagnostics)
+	assert.Error(t, err, "expected error from failing explanation write")
+}
+
+// TestFormat_CaretWriterError covers the writeCaretLine error return in
+// formatSnippet: the header and source line succeed, but the caret
+// gutter write fails.
+func TestFormat_CaretWriterError(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	w := &limitedWriter{limit: 2}
+
+	diagnostics := []lint.Diagnostic{
+		{
+			File:            "test.md",
+			Line:            1,
+			Column:          1,
+			RuleID:          "MDS001",
+			RuleName:        "test",
+			Message:         "test",
+			SourceLines:     []string{"hello"},
+			SourceStartLine: 1,
+		},
+	}
+
+	err := f.Format(w, diagnostics)
+	assert.Error(t, err, "expected error from failing caret write")
+}

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -75,6 +75,12 @@ func (f *TextFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 // formatExplanation writes a one-line trailer naming the rule and
 // the winning source of each leaf setting that contributed to the
 // rule's effective config. No-op when explanation is nil.
+//
+// Rule names, leaf paths, leaf values, and source labels can come from
+// user-controlled YAML (kind names, settings keys/values), so each
+// piece is run through sanitizeControl before it's joined into the
+// single-line trailer to prevent newlines or ANSI escapes from
+// breaking the format or injecting terminal sequences.
 func (f *TextFormatter) formatExplanation(w io.Writer, e *lint.Explanation) error {
 	if e == nil {
 		return nil
@@ -82,18 +88,21 @@ func (f *TextFormatter) formatExplanation(w io.Writer, e *lint.Explanation) erro
 	parts := make([]string, 0, len(e.Leaves))
 	for _, l := range e.Leaves {
 		parts = append(parts, fmt.Sprintf("%s=%s (%s)",
-			l.Path, formatLeafValue(l.Value), l.Source))
+			sanitizeControl(l.Path),
+			sanitizeControl(formatLeafValue(l.Value)),
+			sanitizeControl(l.Source)))
 	}
 	body := strings.Join(parts, ", ")
 	if body == "" {
 		body = "(no settings)"
 	}
+	rule := sanitizeControl(e.Rule)
 	prefix := "  └─ "
 	if f.Color {
-		_, err := fmt.Fprintf(w, "%s\033[2m%s: %s\033[0m\n", prefix, e.Rule, body)
+		_, err := fmt.Fprintf(w, "%s\033[2m%s: %s\033[0m\n", prefix, rule, body)
 		return err
 	}
-	_, err := fmt.Fprintf(w, "%s%s: %s\n", prefix, e.Rule, body)
+	_, err := fmt.Fprintf(w, "%s%s: %s\n", prefix, rule, body)
 	return err
 }
 

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -127,9 +127,6 @@ func (f *TextFormatter) formatSnippet(w io.Writer, d lint.Diagnostic) error {
 
 	maxLineNum := d.SourceStartLine + len(d.SourceLines) - 1
 	gutterWidth := len(fmt.Sprintf("%d", maxLineNum))
-	if gutterWidth < 1 {
-		gutterWidth = 1
-	}
 
 	for i, line := range d.SourceLines {
 		lineNum := d.SourceStartLine + i

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -63,8 +64,47 @@ func (f *TextFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 		if err := f.formatSnippet(w, d); err != nil {
 			return err
 		}
+
+		if err := f.formatExplanation(w, d.Explanation); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// formatExplanation writes a one-line trailer naming the rule and
+// the winning source of each leaf setting that contributed to the
+// rule's effective config. No-op when explanation is nil.
+func (f *TextFormatter) formatExplanation(w io.Writer, e *lint.Explanation) error {
+	if e == nil {
+		return nil
+	}
+	parts := make([]string, 0, len(e.Leaves))
+	for _, l := range e.Leaves {
+		parts = append(parts, fmt.Sprintf("%s=%s (%s)",
+			l.Path, formatLeafValue(l.Value), l.Source))
+	}
+	body := strings.Join(parts, ", ")
+	if body == "" {
+		body = "(no settings)"
+	}
+	prefix := "  └─ "
+	if f.Color {
+		_, err := fmt.Fprintf(w, "%s\033[2m%s: %s\033[0m\n", prefix, e.Rule, body)
+		return err
+	}
+	_, err := fmt.Fprintf(w, "%s%s: %s\n", prefix, e.Rule, body)
+	return err
+}
+
+// formatLeafValue renders a leaf value compactly (JSON-like) so settings
+// maps / lists / scalars all print on one line.
+func formatLeafValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
 }
 
 // formatSnippet writes the source context lines with a line-number gutter

--- a/internal/output/text_explain_test.go
+++ b/internal/output/text_explain_test.go
@@ -69,6 +69,18 @@ func TestTextFormatter_ExplainOmittedWhenNil(t *testing.T) {
 	assert.NotContains(t, buf.String(), "└─")
 }
 
+func TestFormatLeafValue_UnmarshalableFallsBackToFmt(t *testing.T) {
+	// channels are not JSON-encodable; formatLeafValue falls back to %v.
+	out := formatLeafValue(make(chan int))
+	assert.NotEmpty(t, out)
+}
+
+func TestFormatLeafValue_Scalars(t *testing.T) {
+	assert.Equal(t, "30", formatLeafValue(30))
+	assert.Equal(t, "true", formatLeafValue(true))
+	assert.Equal(t, "null", formatLeafValue(nil))
+}
+
 func TestTextFormatter_ExplainEmptyLeavesPrintsNoSettings(t *testing.T) {
 	f := &TextFormatter{Color: false}
 	var buf bytes.Buffer

--- a/internal/output/text_explain_test.go
+++ b/internal/output/text_explain_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -93,4 +94,47 @@ func TestTextFormatter_ExplainEmptyLeavesPrintsNoSettings(t *testing.T) {
 	}}
 	require.NoError(t, f.Format(&buf, diags))
 	assert.Contains(t, buf.String(), "(no settings)")
+}
+
+// TestTextFormatter_ExplainSanitizesControlChars makes sure that
+// rule/leaf/source values from user-controlled YAML cannot break the
+// single-line trailer with newlines or inject terminal escape codes.
+func TestTextFormatter_ExplainSanitizesControlChars(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	var buf bytes.Buffer
+
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "evil",
+		Severity: lint.Error, Message: "msg",
+		Explanation: &lint.Explanation{
+			Rule: "evil\nrule\x1b[31m",
+			Leaves: []lint.ExplanationLeaf{
+				{
+					Path:   "settings.bad\x07key",
+					Value:  "v\x1b[31m",
+					Source: "kinds.bad\nkind",
+				},
+			},
+		},
+	}}
+	require.NoError(t, f.Format(&buf, diags))
+
+	out := buf.String()
+	// One trailer line; no embedded newlines, no ESC, no BEL after split.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	var trailer string
+	for _, ln := range lines {
+		if strings.Contains(ln, "└─") {
+			trailer = ln
+			break
+		}
+	}
+	require.NotEmpty(t, trailer, "trailer line not found in %q", out)
+	assert.NotContains(t, trailer, "\x1b")
+	assert.NotContains(t, trailer, "\x07")
+	// Sanitized rule/leaf/source content remains visible.
+	assert.Contains(t, trailer, "evilrule")
+	assert.Contains(t, trailer, "settings.badkey")
+	assert.Contains(t, trailer, "kinds.badkind")
 }

--- a/internal/output/text_explain_test.go
+++ b/internal/output/text_explain_test.go
@@ -1,0 +1,84 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTextFormatter_ExplainTrailerPlain(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	var buf bytes.Buffer
+
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "line-length",
+		Severity: lint.Error, Message: "too long",
+		Explanation: &lint.Explanation{
+			Rule: "line-length",
+			Leaves: []lint.ExplanationLeaf{
+				{Path: "enabled", Value: true, Source: "default"},
+				{Path: "settings.max", Value: 30, Source: "kinds.short"},
+			},
+		},
+	}}
+	require.NoError(t, f.Format(&buf, diags))
+
+	out := buf.String()
+	assert.Contains(t, out, "└─ line-length:")
+	assert.Contains(t, out, "enabled=true (default)")
+	assert.Contains(t, out, "settings.max=30 (kinds.short)")
+	assert.NotContains(t, out, "\033[", "no color codes when Color is false")
+}
+
+func TestTextFormatter_ExplainTrailerColor(t *testing.T) {
+	f := &TextFormatter{Color: true}
+	var buf bytes.Buffer
+
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "line-length",
+		Severity: lint.Error, Message: "too long",
+		Explanation: &lint.Explanation{
+			Rule:   "line-length",
+			Leaves: []lint.ExplanationLeaf{{Path: "enabled", Value: true, Source: "default"}},
+		},
+	}}
+	require.NoError(t, f.Format(&buf, diags))
+
+	out := buf.String()
+	// dim ANSI sequence around the trailer body
+	assert.Contains(t, out, "\033[2m")
+	assert.Contains(t, out, "line-length:")
+	assert.Contains(t, out, "└─")
+}
+
+func TestTextFormatter_ExplainOmittedWhenNil(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	var buf bytes.Buffer
+
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "line-length",
+		Severity: lint.Error, Message: "too long",
+	}}
+	require.NoError(t, f.Format(&buf, diags))
+	assert.NotContains(t, buf.String(), "└─")
+}
+
+func TestTextFormatter_ExplainEmptyLeavesPrintsNoSettings(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	var buf bytes.Buffer
+
+	diags := []lint.Diagnostic{{
+		File: "x.md", Line: 1, Column: 1,
+		RuleID: "MDS001", RuleName: "rule",
+		Severity: lint.Error, Message: "msg",
+		Explanation: &lint.Explanation{Rule: "rule"},
+	}}
+	require.NoError(t, f.Format(&buf, diags))
+	assert.Contains(t, buf.String(), "(no settings)")
+}

--- a/plan/95_kind-rule-resolution-cli.md
+++ b/plan/95_kind-rule-resolution-cli.md
@@ -1,7 +1,7 @@
 ---
 id: 95
 title: Kind/rule resolution observability via `kinds` subcommand
-status: "🔲"
+status: "✅"
 model: opus
 summary: >-
   Replace `mdsmith config kinds/show/why` with a
@@ -111,58 +111,59 @@ per-leaf settings with their merge chains.
 
 ## Tasks
 
-1. Add a per-leaf provenance tracker to the config-
-   merge pipeline. Each leaf setting's final value
-   carries a list `[{layer, value, source}]`.
-2. Add `mdsmith kinds list` (text + `--json`).
-3. Add `mdsmith kinds show <name>` and
+1. [x] Add a per-leaf provenance tracker to the
+   config-merge pipeline. Each leaf setting's final
+   value carries a list `[{layer, value, source}]`.
+2. [x] Add `mdsmith kinds list` (text + `--json`).
+3. [x] Add `mdsmith kinds show <name>` and
    `mdsmith kinds path <name>`.
-4. Add `mdsmith kinds resolve <file>` rendering the
-   resolved kind list and per-leaf provenance
+4. [x] Add `mdsmith kinds resolve <file>` rendering
+   the resolved kind list and per-leaf provenance
    summary; add `--json`.
-5. Add `mdsmith kinds why <file> <rule>` rendering
-   the full merge chain for a single rule; add
-   `--json`.
-6. Add `--explain` flag to `check` and `fix`. After
-   each diagnostic, print a one-line trailer naming
-   the rule and the winning source of the setting
-   that triggered the flag; in `--json` output the
-   diagnostic carries an `explanation` object.
-7. Document the JSON schema briefly in
+5. [x] Add `mdsmith kinds why <file> <rule>`
+   rendering the full merge chain for a single
+   rule; add `--json`.
+6. [x] Add `--explain` flag to `check` and `fix`.
+   After each diagnostic, print a one-line trailer
+   naming the rule and the winning source of the
+   setting that triggered the flag; in `--json`
+   output the diagnostic carries an `explanation`
+   object.
+7. [x] Document the JSON schema briefly in
    `docs/reference/cli.md`.
-8. `mdsmith help kinds-cli` prints the subcommand
-   summary.
+8. [x] `mdsmith help kinds-cli` prints the
+   subcommand summary.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith kinds list` prints declared kinds
+- [x] `mdsmith kinds list` prints declared kinds
       with their merged bodies.
-- [ ] `mdsmith kinds show <name>` prints one kind's
+- [x] `mdsmith kinds show <name>` prints one kind's
       merged body; exits 2 on unknown name.
-- [ ] `mdsmith kinds path <name>` prints the path
+- [x] `mdsmith kinds path <name>` prints the path
       of the kind's `required-structure.schema:` if
       set; exits 2 otherwise.
-- [ ] `mdsmith kinds resolve <file>` prints the
+- [x] `mdsmith kinds resolve <file>` prints the
       resolved kind list and merged rule config;
       every leaf is tagged with its source (default
       / kind name / override / front-matter)
       (covered by test).
-- [ ] `mdsmith kinds why <file> <rule>` prints the
+- [x] `mdsmith kinds why <file> <rule>` prints the
       full merge chain — every layer that did or
       did not touch each leaf — for a single rule
       on a single file (covered by test).
-- [ ] `mdsmith check --explain` prints, after each
+- [x] `mdsmith check --explain` prints, after each
       diagnostic, a trailer naming the rule and the
       source of the setting that triggered it
       (covered by test).
-- [ ] `--json` on each `kinds` subcommand and on
+- [x] `--json` on each `kinds` subcommand and on
       `check --explain` produces a stable structured
       form documented in `docs/reference/cli.md`
       (schema regression test).
-- [ ] No new state is required of rule
+- [x] No new state is required of rule
       implementations; provenance lives in the merge
       pipeline only.
-- [ ] `mdsmith help kinds-cli` summarizes the
+- [x] `mdsmith help kinds-cli` summarizes the
       subcommand surface.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

This PR implements observability features for understanding how rule configurations are resolved and merged for individual files. It adds a new `kinds` subcommand with multiple sub-operations and an `--explain` flag to `check`/`fix` that attaches per-leaf rule provenance to diagnostics.

## Key Changes

### New `kinds` Subcommand (`cmd/mdsmith/kinds.go`)
- **`kinds list`** — Print all declared kinds with their merged rule bodies (text and `--json`)
- **`kinds show <name>`** — Print a single kind's merged configuration
- **`kinds path <name>`** — Resolve and print the schema path for a kind's `required-structure` rule
- **`kinds resolve <file>`** — Show the effective kind list and per-leaf rule provenance for a file, with sources (text and `--json`)
- **`kinds why <file> <rule>`** — Display the full merge chain for one rule on one file, including no-op layers (text and `--json`)

### Provenance Tracking (`internal/config/provenance.go`)
- New types to track rule resolution with per-layer and per-leaf provenance:
  - `ResolvedKind` — kind name + assignment source (front-matter or kind-assignment)
  - `LayerEntry` — one merge layer with source and whether it set the rule
  - `Leaf` — a leaf setting path (e.g., `settings.max`) with its value and full merge chain
  - `RuleResolution` — complete merge history for one rule
  - `FileResolution` — resolved kinds and all rule resolutions for a file
- `ResolveFile()` builds the full provenance picture by merging layers (default → kinds → overrides) and tracking each leaf's chain of values

### `--explain` Flag on `check` / `fix`
- New `--explain` flag attaches per-leaf rule provenance to each diagnostic
- Text output prints a `└─` trailer naming the rule and winning source for each leaf
- JSON output adds an `explanation` field with rule name and leaf details
- Implementation in `internal/engine/runner.go` and `internal/fix/fix.go` calls `attachExplanations()` to populate `Diagnostic.Explanation`

### Output Formatting
- `internal/output/text.go` — New `formatExplanation()` renders the trailer with colored output support
- `internal/output/json.go` — New `jsonExplanation` struct for stable JSON schema
- `internal/lint/diagnostic.go` — New `Explanation` type on `Diagnostic`

### Documentation
- Updated `docs/reference/cli.md` with `kinds` subcommand reference, provenance layer sources, and JSON schema examples
- Updated `cmd/mdsmith/main.go` help text to mention the new `kinds` command
- Marked plan item 95 as complete

## Testing

- `cmd/mdsmith/kinds_e2e_test.go` — End-to-end tests for all `kinds` subcommands, JSON output, and error cases
- `cmd/mdsmith/explain_e2e_test.go` — Tests for `--explain` flag on `check` with text and JSON output
- `internal/config/provenance_test.go` — Unit tests for `ResolveFile()` covering kinds, overrides, front-matter, and deduplication

## Notable Implementation Details

- Provenance layer sources use stable identifiers: `"default"`, `"kinds.<name>"`, `"overrides[<i>]"`, `"front-matter override"`
- Leaf chains preserve the full history of values across layers, enabling "why did this setting have this value?" queries
- JSON output uses a union type for rule configs (false, true, or settings map) matching YAML marshalling
- Text rendering sorts kinds and rules alphabetically for consistent output

https://claude.ai/code/session_016uwwVB39BEoYDc8o2RJAtD