### PR TITLE
Add pre-merge-commit hook to resolve file ordering race

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -25,18 +25,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
 
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version-file: go.mod
-
       - name: Install mdsmith merge driver
-        # Build from the checked-out source so the merge driver and
-        # its pre-merge-commit hook always match the directive schema
-        # of the branch being queued. A pinned release binary lags
-        # behind whenever the catalog/include schema evolves and can
-        # silently produce stale generated sections.
+        env:
+          MDSMITH_VERSION: v0.5.0
+          MDSMITH_SHA256: 87519781aa7b5ab147d5ab1d75d4e0a1c6213479110055972a21025b537ce171
         run: |
-          go build -o "$RUNNER_TEMP/mdsmith" ./cmd/mdsmith
+          curl -fsSL "https://github.com/jeduden/mdsmith/releases/download/${MDSMITH_VERSION}/mdsmith-linux-amd64" \
+            -o "$RUNNER_TEMP/mdsmith"
+          echo "${MDSMITH_SHA256}  $RUNNER_TEMP/mdsmith" | sha256sum -c
+          chmod +x "$RUNNER_TEMP/mdsmith"
           "$RUNNER_TEMP/mdsmith" merge-driver install
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -25,15 +25,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
 
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+
       - name: Install mdsmith merge driver
-        env:
-          MDSMITH_VERSION: v0.5.0
-          MDSMITH_SHA256: 87519781aa7b5ab147d5ab1d75d4e0a1c6213479110055972a21025b537ce171
+        # Build from the checked-out source so the merge driver and
+        # its pre-merge-commit hook always match the directive schema
+        # of the branch being queued. A pinned release binary lags
+        # behind whenever the catalog/include schema evolves and can
+        # silently produce stale generated sections.
         run: |
-          curl -fsSL "https://github.com/jeduden/mdsmith/releases/download/${MDSMITH_VERSION}/mdsmith-linux-amd64" \
-            -o "$RUNNER_TEMP/mdsmith"
-          echo "${MDSMITH_SHA256}  $RUNNER_TEMP/mdsmith" | sha256sum -c
-          chmod +x "$RUNNER_TEMP/mdsmith"
+          go build -o "$RUNNER_TEMP/mdsmith" ./cmd/mdsmith
           "$RUNNER_TEMP/mdsmith" merge-driver install
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1236,6 +1236,18 @@ func TestE2E_MergeDriver_Install(t *testing.T) {
 	content := string(attrs)
 	assert.Contains(t, content, "PLAN.md merge=mdsmith", "expected PLAN.md entry in .gitattributes")
 	assert.Contains(t, content, "README.md merge=mdsmith", "expected README.md entry in .gitattributes")
+
+	// Verify pre-merge-commit hook was installed and is executable.
+	hookPath := filepath.Join(dir, ".git", "hooks", "pre-merge-commit")
+	info, err := os.Stat(hookPath)
+	require.NoError(t, err, "expected pre-merge-commit hook at %s", hookPath)
+	assert.NotZero(t, info.Mode()&0o111, "hook must be executable")
+	hookData, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(hookData), "fix",
+		"hook must invoke mdsmith fix; got:\n%s", hookData)
+	assert.Contains(t, string(hookData), "PLAN.md")
+	assert.Contains(t, string(hookData), "README.md")
 }
 
 func TestE2E_MergeDriver_Install_Idempotent(t *testing.T) {

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1413,6 +1413,146 @@ func TestE2E_MergeDriver_SectionMarkersInsideConflict_Preserved(t *testing.T) {
 	assert.Contains(t, content, ">>>>>>>", "expected >>>>>>> marker preserved")
 }
 
+// TestE2E_MergeDriver_FileOrderingRace_Resolved reproduces the
+// CI failure from run 24971661273.
+//
+// Two branches each bump the status of a different plan file from
+// 🔲 to ✅ AND each regenerate PLAN.md against their own working
+// tree. When the branches are merged, both sides have modified
+// PLAN.md vs base, so git invokes the merge driver. The driver's
+// own `mdsmith fix` reads sibling plan/*.md files from the
+// working tree at that moment — but git has not yet processed
+// every plan path, so the regenerated catalog is stale relative
+// to the final merged state.
+//
+// With the pre-merge-commit hook installed by `merge-driver
+// install`, mdsmith fix runs again after every per-file merge has
+// settled, so PLAN.md ends up consistent with plan/*.md.
+const planTmpl = `---
+id: %d
+title: Plan %d
+status: "%s"
+---
+# Plan %d
+
+Body.
+`
+
+const planMdTmpl = "# Plans\n\n" +
+	"<?catalog\n" +
+	"glob:\n  - \"plan/*.md\"\n" +
+	"sort: id\n" +
+	"header: |\n\n  | ID | Status | Title |\n  |----|--------|-------|\n" +
+	"row: \"| {id} | {status} | [{title}]({filename}) |\"\n" +
+	"footer: |\n\n" +
+	"?>\n" +
+	"<?/catalog?>\n"
+
+// completePlanOnBranch creates branch from start, sets plan/<id>.md
+// status to ✅, regenerates PLAN.md, and commits.
+func completePlanOnBranch(t *testing.T, dir, branch, start string, planID int) {
+	t.Helper()
+	gitInDir(t, dir, "checkout", "-b", branch, start)
+	writeFixture(t, dir, fmt.Sprintf("plan/%02d.md", planID),
+		fmt.Sprintf(planTmpl, planID, planID, "✅", planID))
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "%s fix failed: %s", branch, stderr)
+	gitCommit(t, dir, fmt.Sprintf("complete plan %d", planID))
+}
+
+func TestE2E_MergeDriver_FileOrderingRace_Resolved(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	// Catalog over plan/*.md, sorted by id; rule names match the
+	// directives the merge driver knows how to regenerate.
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+
+	// Populate the catalog body once so the base commit is clean.
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	completePlanOnBranch(t, dir, "ours", seedSHA, 1)
+	completePlanOnBranch(t, dir, "theirs", seedSHA, 2)
+
+	// Install the merge driver — registers git config + the
+	// pre-merge-commit hook that closes the race.
+	gitInDir(t, dir, "checkout", "ours")
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+
+	// Merge theirs into ours. Both sides modified PLAN.md, so the
+	// per-file driver runs; the hook then re-fixes once every plan
+	// file is in its final merged state.
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-ff", "-m", "merge theirs", "theirs").CombinedOutput()
+	require.NoError(t, err, "git merge failed: %s", out)
+
+	// PLAN.md catalog must reflect the post-merge plan files.
+	plan, err := os.ReadFile(filepath.Join(dir, "PLAN.md"))
+	require.NoError(t, err)
+	planStr := string(plan)
+	assert.Regexp(t, `\| 1 +\| ✅ +\|`, planStr,
+		"row 1 must show ✅ in merged PLAN.md, got:\n%s", planStr)
+	assert.Regexp(t, `\| 2 +\| ✅ +\|`, planStr,
+		"row 2 must show ✅ in merged PLAN.md, got:\n%s", planStr)
+
+	// Source plan files must agree with the catalog rows.
+	for _, path := range []string{"plan/01.md", "plan/02.md"} {
+		data, err := os.ReadFile(filepath.Join(dir, path))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `status: "✅"`,
+			"%s status must be ✅ after merge", path)
+	}
+
+	// Whole-tree consistency: a fresh check must report no issues
+	// — exactly what failed in CI run 24971661273.
+	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code,
+		"check after merge must pass; stderr:\n%s", stderr)
+}
+
+// gitInit initializes a git repo with isolated user/sign config so
+// commits succeed on machines that have global signing turned on.
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmds := [][]string{
+		{"init", "-q", "-b", "main", dir},
+		{"-C", dir, "config", "user.name", "test"},
+		{"-C", dir, "config", "user.email", "test@example.com"},
+		{"-C", dir, "config", "commit.gpgsign", "false"},
+		{"-C", dir, "config", "tag.gpgsign", "false"},
+	}
+	for _, c := range cmds {
+		out, err := exec.Command("git", c...).CombinedOutput()
+		require.NoError(t, err, "git %v: %s", c, out)
+	}
+}
+
+// gitInDir runs git in dir and returns stdout. Test fails on non-zero.
+func gitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", dir}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return string(out)
+}
+
+// gitCommit stages everything and commits with the given message.
+func gitCommit(t *testing.T, dir, msg string) {
+	t.Helper()
+	gitInDir(t, dir, "add", "-A")
+	gitInDir(t, dir, "commit", "-q", "-m", msg)
+}
+
 // ── max-input-size ──────────────────────────────────────────────
 
 func TestCheck_MaxInputSize_ExceedingLimit(t *testing.T) {

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1267,6 +1267,29 @@ func TestE2E_MergeDriver_Install_Idempotent(t *testing.T) {
 	assert.Equal(t, 1, count, "expected 1 PLAN.md entry, got %d; content:\n%s", count, attrs)
 }
 
+func TestE2E_MergeDriver_Install_UnmanagedHook(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run(), "git init")
+
+	// Place a user-authored hook (no mdsmith marker) before running install.
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
+	userHook := "#!/bin/sh\necho user hook\n"
+	require.NoError(t, os.WriteFile(hookPath, []byte(userHook), 0o755))
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	assert.Equal(t, 2, exitCode,
+		"expected exit 2 when unmanaged pre-merge-commit hook exists; stderr: %s", stderr)
+	assert.Contains(t, stderr, "pre-merge-commit",
+		"error must reference the hook path; stderr: %s", stderr)
+
+	// Verify the user hook was not clobbered.
+	data, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	assert.Equal(t, userHook, string(data), "user hook content must be preserved")
+}
+
 func TestE2E_MergeDriver_Install_CustomFiles(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -192,7 +193,6 @@ func isolateDir(t *testing.T, dir string) {
 	}
 }
 
-// writeFixture creates a file with the given content in the given directory.
 // gitHooksDir returns the effective hooks directory for the git repo at dir,
 // derived via git itself so it respects core.hooksPath.
 func gitHooksDir(t *testing.T, dir string) string {
@@ -206,6 +206,7 @@ func gitHooksDir(t *testing.T, dir string) string {
 	return filepath.Clean(p)
 }
 
+// writeFixture creates a file with the given content in the given directory.
 func writeFixture(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
@@ -1255,7 +1256,9 @@ func TestE2E_MergeDriver_Install(t *testing.T) {
 	hookPath := filepath.Join(gitHooksDir(t, dir), "pre-merge-commit")
 	info, err := os.Stat(hookPath)
 	require.NoError(t, err, "expected pre-merge-commit hook at %s", hookPath)
-	assert.NotZero(t, info.Mode()&0o111, "hook must be executable")
+	if runtime.GOOS != "windows" {
+		assert.NotZero(t, info.Mode()&0o111, "hook must be executable")
+	}
 	hookData, err := os.ReadFile(hookPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(hookData), "fix",

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -193,6 +193,19 @@ func isolateDir(t *testing.T, dir string) {
 }
 
 // writeFixture creates a file with the given content in the given directory.
+// gitHooksDir returns the effective hooks directory for the git repo at dir,
+// derived via git itself so it respects core.hooksPath.
+func gitHooksDir(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--git-path", "hooks").Output()
+	require.NoError(t, err, "git rev-parse --git-path hooks")
+	p := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(dir, p)
+	}
+	return filepath.Clean(p)
+}
+
 func writeFixture(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
@@ -1238,7 +1251,8 @@ func TestE2E_MergeDriver_Install(t *testing.T) {
 	assert.Contains(t, content, "README.md merge=mdsmith", "expected README.md entry in .gitattributes")
 
 	// Verify pre-merge-commit hook was installed and is executable.
-	hookPath := filepath.Join(dir, ".git", "hooks", "pre-merge-commit")
+	// Use gitHooksDir to respect core.hooksPath if set globally.
+	hookPath := filepath.Join(gitHooksDir(t, dir), "pre-merge-commit")
 	info, err := os.Stat(hookPath)
 	require.NoError(t, err, "expected pre-merge-commit hook at %s", hookPath)
 	assert.NotZero(t, info.Mode()&0o111, "hook must be executable")
@@ -1272,7 +1286,8 @@ func TestE2E_MergeDriver_Install_UnmanagedHook(t *testing.T) {
 	require.NoError(t, exec.Command("git", "init", dir).Run(), "git init")
 
 	// Place a user-authored hook (no mdsmith marker) before running install.
-	hooksDir := filepath.Join(dir, ".git", "hooks")
+	// Use gitHooksDir so setup targets the same path that install will check.
+	hooksDir := gitHooksDir(t, dir)
 	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
 	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
 	userHook := "#!/bin/sh\necho user hook\n"

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -472,7 +472,7 @@ func ensurePreMergeCommitHook(repoRoot string, files []string) error {
 	var fixCmds strings.Builder
 	for _, f := range files {
 		fmt.Fprintf(&fixCmds,
-			"if [ -e %s ]; then\n  %s fix %s\n  git add -- %s\nfi\n",
+			"if [ -e %s ]; then\n  %s fix -- %s\n  git add -- %s\nfi\n",
 			shellQuote(f), shellQuote(exe), shellQuote(f), shellQuote(f))
 	}
 

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -397,7 +397,7 @@ func runMergeDriverInstall(args []string) int {
 		return 2
 	}
 
-	hookPath := filepath.Join(repoRoot, ".git", "hooks", "pre-merge-commit")
+	hookPath := filepath.Join(resolveHooksDir(repoRoot), "pre-merge-commit")
 	fmt.Fprintf(os.Stderr, "mdsmith: merge driver 'mdsmith' installed\n")
 	fmt.Fprintf(os.Stderr, "  git config: merge.mdsmith.driver\n")
 	fmt.Fprintf(os.Stderr, "  .gitattributes: %s\n", attrPath)
@@ -410,7 +410,24 @@ func runMergeDriverInstall(args []string) int {
 // stomping on a user-authored hook of the same name.
 const preMergeCommitHookMarker = "# mdsmith merge-driver pre-merge-commit hook"
 
-// ensurePreMergeCommitHook writes .git/hooks/pre-merge-commit so
+// resolveHooksDir returns the directory where git hooks should be
+// installed. It respects core.hooksPath if configured so that
+// installations work correctly in repos that redirect hooks to a
+// custom path (e.g. via git config or a repo management tool).
+// Falls back to .git/hooks when git cannot be queried.
+func resolveHooksDir(repoRoot string) string {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--git-path", "hooks")
+	if out, err := cmd.Output(); err == nil {
+		p := strings.TrimSpace(string(out))
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(repoRoot, p)
+		}
+		return filepath.Clean(p)
+	}
+	return filepath.Join(repoRoot, ".git", "hooks")
+}
+
+// ensurePreMergeCommitHook writes the pre-merge-commit hook so
 // that after git resolves all per-file merges (including any
 // driver-resolved sections) and before the merge commit is
 // created, mdsmith fix runs once on the registered files.
@@ -427,27 +444,35 @@ func ensurePreMergeCommitHook(repoRoot string, files []string) error {
 		return fmt.Errorf("cannot locate mdsmith binary: %w", err)
 	}
 
-	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
+	hooksDir := resolveHooksDir(repoRoot)
 	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
 
 	// Refuse to clobber a hook the user wrote themselves; replace
-	// only hooks that carry our marker.
-	if existing, err := os.ReadFile(hookPath); err == nil {
+	// only hooks that carry our marker. A non-ENOENT read error is
+	// treated as a safety failure to avoid silently overwriting an
+	// unreadable hook.
+	existing, readErr := os.ReadFile(hookPath)
+	switch {
+	case readErr == nil:
 		if !strings.Contains(string(existing), preMergeCommitHookMarker) {
 			return fmt.Errorf(
 				"%s already exists and is not managed by mdsmith; "+
 					"remove or merge it manually",
 				hookPath)
 		}
+	case os.IsNotExist(readErr):
+		// Hook doesn't exist; safe to create.
+	default:
+		return fmt.Errorf("reading existing hook %s: %w", hookPath, readErr)
 	}
 
-	// Build the per-file fix loop. Files that no longer exist
-	// (e.g. renamed in this branch) are skipped so the hook stays
-	// resilient across schema changes.
-	var fixLoop strings.Builder
+	// Build per-file fix commands as separate lines so that "set -e"
+	// aborts the hook if mdsmith fix or git add fails. Files that no
+	// longer exist (e.g. renamed in this branch) are skipped.
+	var fixCmds strings.Builder
 	for _, f := range files {
-		fmt.Fprintf(&fixLoop,
-			"if [ -e %s ]; then %s fix %s && git add -- %s; fi\n",
+		fmt.Fprintf(&fixCmds,
+			"if [ -e %s ]; then\n  %s fix %s\n  git add -- %s\nfi\n",
 			shellQuote(f), shellQuote(exe), shellQuote(f), shellQuote(f))
 	}
 
@@ -458,7 +483,7 @@ func ensurePreMergeCommitHook(repoRoot string, files []string) error {
 		"# state of every source file. Re-install with:\n" +
 		"#   mdsmith merge-driver install\n" +
 		"set -e\n" +
-		fixLoop.String()
+		fixCmds.String()
 
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		return fmt.Errorf("creating %s: %w", hooksDir, err)

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -391,10 +391,82 @@ func runMergeDriverInstall(args []string) int {
 		return 2
 	}
 
+	if err := ensurePreMergeCommitHook(repoRoot, files); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: installing pre-merge-commit hook: %v\n", err)
+		return 2
+	}
+
+	hookPath := filepath.Join(repoRoot, ".git", "hooks", "pre-merge-commit")
 	fmt.Fprintf(os.Stderr, "mdsmith: merge driver 'mdsmith' installed\n")
 	fmt.Fprintf(os.Stderr, "  git config: merge.mdsmith.driver\n")
 	fmt.Fprintf(os.Stderr, "  .gitattributes: %s\n", attrPath)
+	fmt.Fprintf(os.Stderr, "  pre-merge-commit hook: %s\n", hookPath)
 	return 0
+}
+
+// preMergeCommitHookMarker identifies the hook as managed by
+// mdsmith so re-running install can safely replace it without
+// stomping on a user-authored hook of the same name.
+const preMergeCommitHookMarker = "# mdsmith merge-driver pre-merge-commit hook"
+
+// ensurePreMergeCommitHook writes .git/hooks/pre-merge-commit so
+// that after git resolves all per-file merges (including any
+// driver-resolved sections) and before the merge commit is
+// created, mdsmith fix runs once on the registered files.
+//
+// The per-file merge driver cannot do this on its own: when it
+// runs on PLAN.md, sibling plan/*.md source files may still hold
+// "ours" content because git has not merged them yet, so the
+// regenerated catalog reflects a stale view of its sources. The
+// pre-merge-commit hook re-fixes the same files once every path
+// has reached its final merged state.
+func ensurePreMergeCommitHook(repoRoot string, files []string) error {
+	exe, err := resolveInstalledBinary()
+	if err != nil {
+		return fmt.Errorf("cannot locate mdsmith binary: %w", err)
+	}
+
+	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
+	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
+
+	// Refuse to clobber a hook the user wrote themselves; replace
+	// only hooks that carry our marker.
+	if existing, err := os.ReadFile(hookPath); err == nil {
+		if !strings.Contains(string(existing), preMergeCommitHookMarker) {
+			return fmt.Errorf(
+				"%s already exists and is not managed by mdsmith; "+
+					"remove or merge it manually",
+				hookPath)
+		}
+	}
+
+	// Build the per-file fix loop. Files that no longer exist
+	// (e.g. renamed in this branch) are skipped so the hook stays
+	// resilient across schema changes.
+	var fixLoop strings.Builder
+	for _, f := range files {
+		fmt.Fprintf(&fixLoop,
+			"if [ -e %s ]; then %s fix %s && git add -- %s; fi\n",
+			shellQuote(f), shellQuote(exe), shellQuote(f), shellQuote(f))
+	}
+
+	content := "#!/bin/sh\n" +
+		preMergeCommitHookMarker + "\n" +
+		"# Re-runs mdsmith fix once git has resolved every per-file\n" +
+		"# merge, so generated sections reflect the final merged\n" +
+		"# state of every source file. Re-install with:\n" +
+		"#   mdsmith merge-driver install\n" +
+		"set -e\n" +
+		fixLoop.String()
+
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", hooksDir, err)
+	}
+	if err := os.WriteFile(hookPath, []byte(content), 0o755); err != nil {
+		return fmt.Errorf("writing %s: %w", hookPath, err)
+	}
+	return nil
 }
 
 // registerMergeDriver writes the merge.mdsmith.* keys to local

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -471,15 +471,17 @@ func TestEnsurePreMergeCommitHook_CreatesExecutableHook(t *testing.T) {
 	hookPath := filepath.Join(dir, ".git", "hooks", "pre-merge-commit")
 	info, err := os.Stat(hookPath)
 	require.NoError(t, err, "hook must exist at %s", hookPath)
-	// Hook must be executable for git to invoke it.
-	assert.NotZero(t, info.Mode()&0o111, "hook must have an execute bit set")
+	// Hook must be executable for git to invoke it (POSIX only).
+	if runtime.GOOS != "windows" {
+		assert.NotZero(t, info.Mode()&0o111, "hook must have an execute bit set")
+	}
 
 	data, err := os.ReadFile(hookPath)
 	require.NoError(t, err)
 	content := string(data)
 	assert.Contains(t, content, preMergeCommitHookMarker)
-	assert.Contains(t, content, "'/usr/local/bin/mdsmith' fix",
-		"hook must invoke the resolved mdsmith binary with fix")
+	assert.Contains(t, content, "'/usr/local/bin/mdsmith' fix --",
+		"hook must invoke the resolved mdsmith binary with fix --")
 	assert.Contains(t, content, "'PLAN.md'")
 	assert.Contains(t, content, "'README.md'")
 }

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -575,6 +576,9 @@ func TestShellQuote_PathWithSpaces(t *testing.T) {
 }
 
 func TestEnsurePreMergeCommitHook_UnreadableHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not applicable on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("running as root: permission checks don't apply")
 	}
@@ -596,6 +600,9 @@ func TestEnsurePreMergeCommitHook_UnreadableHook(t *testing.T) {
 }
 
 func TestEnsurePreMergeCommitHook_MkdirAllFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not applicable on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("running as root: permission checks don't apply")
 	}
@@ -615,6 +622,9 @@ func TestEnsurePreMergeCommitHook_MkdirAllFails(t *testing.T) {
 }
 
 func TestEnsurePreMergeCommitHook_WriteFileFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not applicable on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("running as root: permission checks don't apply")
 	}
@@ -644,11 +654,18 @@ func TestResolveHooksDir_NotGitRepo(t *testing.T) {
 }
 
 func TestResolveHooksDir_DefaultGitRepo(t *testing.T) {
-	// Real git repo without custom hooksPath: returns .git/hooks.
+	// Derive expected path from git itself so the test is resilient
+	// against a global core.hooksPath set in the developer's git config.
 	dir := t.TempDir()
 	require.NoError(t, exec.Command("git", "init", dir).Run())
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--git-path", "hooks").Output()
+	require.NoError(t, err)
+	expected := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(expected) {
+		expected = filepath.Join(dir, expected)
+	}
 	got := resolveHooksDir(dir)
-	assert.Equal(t, filepath.Join(dir, ".git", "hooks"), got)
+	assert.Equal(t, filepath.Clean(expected), got)
 }
 
 func TestResolveHooksDir_CustomRelativeHooksPath(t *testing.T) {

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -573,3 +573,99 @@ func TestShellQuote_ContainsSingleQuote(t *testing.T) {
 func TestShellQuote_PathWithSpaces(t *testing.T) {
 	assert.Equal(t, "'/home/my user/bin/mdsmith'", shellQuote("/home/my user/bin/mdsmith"))
 }
+
+func TestEnsurePreMergeCommitHook_UnreadableHook(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: permission checks don't apply")
+	}
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
+	// Write-only: os.ReadFile returns a non-ENOENT error.
+	require.NoError(t, os.WriteFile(hookPath, []byte("#!/bin/sh\n"), 0o200))
+	t.Cleanup(func() { _ = os.Chmod(hookPath, 0o755) })
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	err := ensurePreMergeCommitHook(dir, []string{"PLAN.md"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading existing hook")
+}
+
+func TestEnsurePreMergeCommitHook_MkdirAllFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: permission checks don't apply")
+	}
+	dir := t.TempDir()
+	// .git exists but is not writable, so MkdirAll(.git/hooks) fails.
+	gitDir := filepath.Join(dir, ".git")
+	require.NoError(t, os.Mkdir(gitDir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(gitDir, 0o755) })
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	err := ensurePreMergeCommitHook(dir, []string{"PLAN.md"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating")
+}
+
+func TestEnsurePreMergeCommitHook_WriteFileFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: permission checks don't apply")
+	}
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	// Remove write permission so os.WriteFile on the hook file fails.
+	require.NoError(t, os.Chmod(hooksDir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(hooksDir, 0o755) })
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	err := ensurePreMergeCommitHook(dir, []string{"PLAN.md"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing")
+}
+
+// --- resolveHooksDir ---
+
+func TestResolveHooksDir_NotGitRepo(t *testing.T) {
+	// Not a git repo: git fails, falls back to .git/hooks.
+	dir := t.TempDir()
+	got := resolveHooksDir(dir)
+	assert.Equal(t, filepath.Join(dir, ".git", "hooks"), got)
+}
+
+func TestResolveHooksDir_DefaultGitRepo(t *testing.T) {
+	// Real git repo without custom hooksPath: returns .git/hooks.
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run())
+	got := resolveHooksDir(dir)
+	assert.Equal(t, filepath.Join(dir, ".git", "hooks"), got)
+}
+
+func TestResolveHooksDir_CustomRelativeHooksPath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "config",
+		"core.hooksPath", "custom-hooks").Run())
+	got := resolveHooksDir(dir)
+	assert.Equal(t, filepath.Join(dir, "custom-hooks"), got)
+}
+
+func TestResolveHooksDir_CustomAbsoluteHooksPath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run())
+	absPath := filepath.Join(dir, "abs-hooks")
+	require.NoError(t, exec.Command("git", "-C", dir, "config",
+		"core.hooksPath", absPath).Run())
+	got := resolveHooksDir(dir)
+	assert.Equal(t, absPath, got)
+}

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -453,6 +453,95 @@ func TestIsTemporaryBinary_RelativePath_RelErrorReturnsFalse(t *testing.T) {
 	assert.False(t, isTemporaryBinary("relative/path/mdsmith"))
 }
 
+// --- ensurePreMergeCommitHook ---
+
+func TestEnsurePreMergeCommitHook_CreatesExecutableHook(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755))
+
+	// Stub binary resolution so the hook content is deterministic.
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	err := ensurePreMergeCommitHook(dir, []string{"PLAN.md", "README.md"})
+	require.NoError(t, err)
+
+	hookPath := filepath.Join(dir, ".git", "hooks", "pre-merge-commit")
+	info, err := os.Stat(hookPath)
+	require.NoError(t, err, "hook must exist at %s", hookPath)
+	// Hook must be executable for git to invoke it.
+	assert.NotZero(t, info.Mode()&0o111, "hook must have an execute bit set")
+
+	data, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, preMergeCommitHookMarker)
+	assert.Contains(t, content, "'/usr/local/bin/mdsmith' fix",
+		"hook must invoke the resolved mdsmith binary with fix")
+	assert.Contains(t, content, "'PLAN.md'")
+	assert.Contains(t, content, "'README.md'")
+}
+
+func TestEnsurePreMergeCommitHook_OverwritesManagedHook(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
+	// Pre-existing hook with our marker — install must replace it.
+	old := "#!/bin/sh\n" + preMergeCommitHookMarker + "\n# stale content\n"
+	require.NoError(t, os.WriteFile(hookPath, []byte(old), 0o755))
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	require.NoError(t, ensurePreMergeCommitHook(dir, []string{"PLAN.md"}))
+
+	data, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "stale content",
+		"managed hook must be replaced, not preserved")
+	assert.Contains(t, string(data), "'PLAN.md'")
+}
+
+func TestEnsurePreMergeCommitHook_RefusesUnmanagedHook(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
+	// User-authored hook without our marker — must be left intact.
+	user := "#!/bin/sh\necho user hook\n"
+	require.NoError(t, os.WriteFile(hookPath, []byte(user), 0o755))
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	err := ensurePreMergeCommitHook(dir, []string{"PLAN.md"})
+	require.Error(t, err, "must fail when an unmanaged hook is present")
+
+	data, err := os.ReadFile(hookPath)
+	require.NoError(t, err)
+	assert.Equal(t, user, string(data), "unmanaged hook content must be untouched")
+}
+
+func TestEnsurePreMergeCommitHook_BinaryNotFound(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "hooks"), 0o755))
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) {
+		return filepath.Join(os.TempDir(), "go-run-fake", "mdsmith"), nil
+	}
+	t.Setenv("PATH", "")
+
+	err := ensurePreMergeCommitHook(dir, []string{"PLAN.md"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot locate mdsmith binary")
+}
+
 // --- registerMergeDriver ---
 
 func TestRegisterMergeDriver_BinaryNotFound_ReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds a `pre-merge-commit` git hook to the merge driver installation process. The hook re-runs `mdsmith fix` after git has resolved all per-file merges, fixing a race condition where generated sections could become stale when multiple source files are modified in a merge.

## Problem

When merging branches that both modify a generated file (e.g., `PLAN.md`) and its source files (e.g., `plan/*.md`), the per-file merge driver runs on `PLAN.md` before git has finished merging the source files. This causes the regenerated catalog to reflect an incomplete view of the sources, resulting in stale generated content.

## Solution

- **New `ensurePreMergeCommitHook()` function**: Creates `.git/hooks/pre-merge-commit` that runs `mdsmith fix` on all registered files after git completes all per-file merges
- **Hook management**: The hook includes a marker (`preMergeCommitHookMarker`) so `merge-driver install` can safely replace managed hooks without clobbering user-authored hooks
- **Resilient file handling**: The hook checks for file existence before fixing, allowing it to survive schema changes and file renames
- **Installation integration**: `runMergeDriverInstall()` now calls `ensurePreMergeCommitHook()` and reports the hook path in its output

## Key Changes

- Added `ensurePreMergeCommitHook()` to generate and install the pre-merge-commit hook with proper error handling
- Added `shellQuote()` helper for safe shell escaping of file paths in the hook script
- Updated `runMergeDriverInstall()` to install the hook alongside the merge driver config and `.gitattributes`
- Added comprehensive unit tests covering hook creation, replacement of managed hooks, refusal to overwrite user hooks, and binary resolution failures
- Added end-to-end test `TestE2E_MergeDriver_FileOrderingRace_Resolved` that reproduces the original CI failure and verifies the fix
- Updated CI workflow to build mdsmith from source rather than using a pinned release, ensuring the merge driver and hook always match the directive schema of the branch being merged

## Implementation Details

- Hook content is generated with proper shell quoting to handle file paths safely
- The hook uses `set -e` to fail fast if any `mdsmith fix` invocation fails
- Existing hooks are checked for the management marker before being replaced
- The hook gracefully skips files that no longer exist (`if [ -e file ]`)
- Binary resolution uses the same mechanism as the merge driver itself for consistency

https://claude.ai/code/session_012XG9t645SL8z2RW9ik79gw