### PR TITLE
Implement file kinds system and ship documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,7 @@ row: "- [{summary}](../{filename})"
 - [User guides for mdsmith directives, structure enforcement, and migration.](../docs/guides/index.md)
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](../docs/guides/metrics-tradeoffs.md)
 - [CLI commands, flags, exit codes, and output format.](../docs/reference/cli.md)
+- [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](../docs/reference/globs.md)
 <?/catalog?>
 
 ### Development Workflow

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,7 @@ row: "- [{summary}](../{filename})"
 - [How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.](../docs/guides/directives/enforcing-structure.md)
 - [How to use catalog and include directives to generate and embed content in Markdown files.](../docs/guides/directives/generating-content.md)
 - [Key differences between Hugo templates and mdsmith directives for users familiar with Hugo.](../docs/guides/directives/hugo-migration.md)
+- [How to declare file kinds, assign files to them, and read the merged rule config that results.](../docs/guides/file-kinds.md)
 - [User guides for mdsmith directives, structure enforcement, and migration.](../docs/guides/index.md)
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](../docs/guides/metrics-tradeoffs.md)
 - [CLI commands, flags, exit codes, and output format.](../docs/reference/cli.md)

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -42,9 +42,7 @@ rules:
     max-words-per-cell: 30
   cross-file-reference-integrity:
     include: []
-    exclude:
-      # Placeholder link in internal/rules/proto.md; not a real repo path.
-      - "../../../docs/background/archetypes/NAME"
+    exclude: []
     strict: true
   token-budget:
     max: 8000
@@ -159,7 +157,7 @@ overrides:
     rules:
       required-structure:
         schema: internal/rules/proto.md
-  - files: ["plan/*.md"]
+  - files: ["plan/[0-9]*_*.md"]
     rules:
       required-structure:
         schema: plan/proto.md
@@ -203,7 +201,7 @@ overrides:
       paragraph-structure:
         max-sentences: 12
         max-words-per-sentence: 120
-  - files: ["docs/security/*.md"]
+  - files: ["docs/security/[0-9]*.md"]
     rules:
       line-length:
         max: 600
@@ -242,7 +240,58 @@ ignore:
   - "internal/rules/*/good/**"
   - "internal/rules/*/fixed/**"
   - ".claude/worktrees/**"
-  - ".claude/skills/proto.md"
-  - "plan/proto.md"
-  - "internal/rules/proto.md"
-  - "docs/security/proto.md"
+
+kinds:
+  proto:
+    rules:
+      # proto.md files lead with directives and placeholder
+      # headings rather than a content level-1 heading; the
+      # opt-in placeholder vocabulary cannot rewrite that
+      # structure, so the structural heading rules step aside
+      # for this kind.
+      first-line-heading: false
+      heading-increment: false
+      blank-line-around-headings: false
+      no-emphasis-as-heading: false
+      # Links in proto.md bodies are placeholder text
+      # (e.g. `NAME`, not `{name}`) — they aren't real
+      # repo paths and var-token cannot match them. Plan
+      # 98's archetype-to-kinds rename will eliminate the
+      # one remaining placeholder link.
+      cross-file-reference-integrity: false
+      paragraph-readability: false
+      paragraph-structure: false
+  plan:
+    rules:
+      required-structure:
+        schema: plan/proto.md
+  rule-readme:
+    rules:
+      required-structure:
+        schema: internal/rules/proto.md
+  skill:
+    rules:
+      required-structure:
+        schema: .claude/skills/proto.md
+  security-note:
+    rules:
+      required-structure:
+        schema: docs/security/proto.md
+
+# kind-assignment order matters: proto applies first so each
+# proto.md also picks up its project kind, whose
+# required-structure.schema points back at the file itself.
+# That marks proto.md as its own schema, suppressing the
+# "<?require?> outside a schema" warning and skipping
+# structural self-validation.
+kind-assignment:
+  - files: ["**/proto.md"]
+    kinds: [proto]
+  - files: ["plan/proto.md", "plan/[0-9]*_*.md"]
+    kinds: [plan]
+  - files: ["internal/rules/proto.md", "internal/rules/MDS*/README.md"]
+    kinds: [rule-readme]
+  - files: [".claude/skills/proto.md", ".claude/skills/*/SKILL.md"]
+    kinds: [skill]
+  - files: ["docs/security/proto.md", "docs/security/[0-9]*.md"]
+    kinds: [security-note]

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -277,11 +277,11 @@ kinds:
 kind-assignment:
   - files: ["**/proto.md"]
     kinds: [proto]
-  - files: ["plan/proto.md", "plan/[0-9]*_*.md"]
+  - files: ["plan/*.md"]
     kinds: [plan]
   - files: ["internal/rules/proto.md", "internal/rules/MDS*/README.md"]
     kinds: [rule-readme]
   - files: [".claude/skills/proto.md", ".claude/skills/*/SKILL.md"]
     kinds: [skill]
-  - files: ["docs/security/proto.md", "docs/security/*.md"]
+  - files: ["docs/security/*.md"]
     kinds: [security-note]

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -94,8 +94,9 @@ overrides:
         max: 600
   - files: [".claude/skills/*/SKILL.md"]
     rules:
-      required-structure:
-        schema: .claude/skills/proto.md
+      # required-structure.schema for SKILL.md files comes
+      # from the `skill` kind; this override only carries
+      # the SKILL-specific heading-rule tweaks.
       first-line-heading: false
       heading-increment: false
   - files: ["AGENTS.md", ".github/copilot-instructions.md"]
@@ -274,14 +275,21 @@ kinds:
 # That marks proto.md as its own schema, suppressing the
 # "<?require?> outside a schema" warning and skipping
 # structural self-validation.
+#
+# The non-proto globs below use exclusion patterns
+# ([0-9]*) that match the project's filename conventions
+# while skipping proto.md. The schema kinds explicitly
+# list proto.md alongside the convention glob so each
+# proto.md still picks up its kind's
+# required-structure.schema.
 kind-assignment:
   - files: ["**/proto.md"]
     kinds: [proto]
-  - files: ["plan/*.md"]
+  - files: ["plan/proto.md", "plan/[0-9]*_*.md"]
     kinds: [plan]
   - files: ["internal/rules/proto.md", "internal/rules/MDS*/README.md"]
     kinds: [rule-readme]
   - files: [".claude/skills/proto.md", ".claude/skills/*/SKILL.md"]
     kinds: [skill]
-  - files: ["docs/security/*.md"]
+  - files: ["docs/security/proto.md", "docs/security/[0-9]*.md"]
     kinds: [security-note]

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -194,7 +194,7 @@ overrides:
       paragraph-structure:
         max-sentences: 12
         max-words-per-sentence: 120
-  - files: ["docs/security/*.md"]
+  - files: ["docs/security/*.md", "!docs/security/proto.md"]
     rules:
       line-length:
         max: 600
@@ -269,27 +269,30 @@ kinds:
       required-structure:
         schema: docs/security/proto.md
 
-# kind-assignment order matters: proto applies first so each
-# proto.md also picks up its project kind, whose
-# required-structure.schema points back at the file itself.
-# That marks proto.md as its own schema, suppressing the
-# "<?require?> outside a schema" warning and skipping
-# structural self-validation.
+# kind-assignment order matters: the proto kind applies
+# first so each proto.md also picks up its project kind,
+# whose required-structure.schema points back at the file
+# itself. That marks proto.md as its own schema,
+# suppressing the "<?require?> outside a schema" warning
+# and skipping structural self-validation.
 #
-# The non-proto globs below use exclusion patterns
-# ([0-9]*) that match the project's filename conventions
-# while skipping proto.md. The schema kinds explicitly
-# list proto.md alongside the convention glob so each
-# proto.md still picks up its kind's
-# required-structure.schema.
+# Each project kind matches its directory's *.md files
+# (so proto.md is included and inherits the schema). The
+# proto kind disables structural rules on proto.md;
+# project-kind/override settings deep-merge over that.
+#
+# See docs/reference/globs.md for glob and exclusion
+# semantics — note that "!"-exclusion in kind-assignment
+# would strip the schema from proto.md, so it is not used
+# here.
 kind-assignment:
   - files: ["**/proto.md"]
     kinds: [proto]
-  - files: ["plan/proto.md", "plan/[0-9]*_*.md"]
+  - files: ["plan/*.md"]
     kinds: [plan]
   - files: ["internal/rules/proto.md", "internal/rules/MDS*/README.md"]
     kinds: [rule-readme]
   - files: [".claude/skills/proto.md", ".claude/skills/*/SKILL.md"]
     kinds: [skill]
-  - files: ["docs/security/proto.md", "docs/security/[0-9]*.md"]
+  - files: ["docs/security/*.md"]
     kinds: [security-note]

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -193,7 +193,7 @@ overrides:
       paragraph-structure:
         max-sentences: 12
         max-words-per-sentence: 120
-  - files: ["docs/security/[0-9]*.md"]
+  - files: ["docs/security/*.md"]
     rules:
       line-length:
         max: 600
@@ -201,8 +201,6 @@ overrides:
           - code-blocks
           - tables
           - urls
-      required-structure:
-        schema: docs/security/proto.md
       max-file-length:
         max: 1000
       paragraph-readability: false
@@ -285,5 +283,5 @@ kind-assignment:
     kinds: [rule-readme]
   - files: [".claude/skills/proto.md", ".claude/skills/*/SKILL.md"]
     kinds: [skill]
-  - files: ["docs/security/proto.md", "docs/security/[0-9]*.md"]
+  - files: ["docs/security/proto.md", "docs/security/*.md"]
     kinds: [security-note]

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -153,14 +153,6 @@ overrides:
     rules:
       list-indent:
         spaces: 4
-  - files: ["internal/rules/MDS*/README.md"]
-    rules:
-      required-structure:
-        schema: internal/rules/proto.md
-  - files: ["plan/[0-9]*_*.md"]
-    rules:
-      required-structure:
-        schema: plan/proto.md
   - files: ["docs/background/*.md"]
     rules:
       line-length:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ row: "- [{summary}]({filename})"
 - [User guides for mdsmith directives, structure enforcement, and migration.](docs/guides/index.md)
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](docs/guides/metrics-tradeoffs.md)
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)
+- [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 <?/catalog?>
 
 ## Development Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ row: "- [{summary}]({filename})"
 - [How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.](docs/guides/directives/enforcing-structure.md)
 - [How to use catalog and include directives to generate and embed content in Markdown files.](docs/guides/directives/generating-content.md)
 - [Key differences between Hugo templates and mdsmith directives for users familiar with Hugo.](docs/guides/directives/hugo-migration.md)
+- [How to declare file kinds, assign files to them, and read the merged rule config that results.](docs/guides/file-kinds.md)
 - [User guides for mdsmith directives, structure enforcement, and migration.](docs/guides/index.md)
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](docs/guides/metrics-tradeoffs.md)
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ row: "- [{summary}]({filename})"
 - [How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.](docs/guides/directives/enforcing-structure.md)
 - [How to use catalog and include directives to generate and embed content in Markdown files.](docs/guides/directives/generating-content.md)
 - [Key differences between Hugo templates and mdsmith directives for users familiar with Hugo.](docs/guides/directives/hugo-migration.md)
+- [How to declare file kinds, assign files to them, and read the merged rule config that results.](docs/guides/file-kinds.md)
 - [User guides for mdsmith directives, structure enforcement, and migration.](docs/guides/index.md)
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](docs/guides/metrics-tradeoffs.md)
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ row: "- [{summary}]({filename})"
 - [User guides for mdsmith directives, structure enforcement, and migration.](docs/guides/index.md)
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](docs/guides/metrics-tradeoffs.md)
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)
+- [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 <?/catalog?>
 
 ## Development Workflow

--- a/PLAN.md
+++ b/PLAN.md
@@ -16,6 +16,7 @@ footer: |
 
 | ID  | Status | Model  | Title                                                                                                |
 |-----|--------|--------|------------------------------------------------------------------------------------------------------|
+| 120 | 🔲     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                   |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |
 | 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                     |

--- a/PLAN.md
+++ b/PLAN.md
@@ -31,7 +31,7 @@ footer: |
 | 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                      |
 | 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)              |
 | 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)     |
-| 96  | 🔲     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
 | 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                   |
 | 98  | 🔲     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |
 <?/catalog?>

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -85,25 +85,34 @@ order.
 kind-assignment:
   - files: ["**/proto.md"]
     kinds: [proto]
-  - files: ["plan/proto.md", "plan/[0-9]*_*.md"]
+  - files: ["plan/*.md"]
     kinds: [plan]
-  - files: [".claude/skills/proto.md",
-            ".claude/skills/*/SKILL.md"]
-    kinds: [skill]
+  - files: ["internal/rules/proto.md",
+            "internal/rules/MDS*/README.md"]
+    kinds: [rule-readme]
 ```
 
 Globs use the same matcher as `overrides:` and `ignore:`
 (see [Glob patterns](../reference/globs.md)). The plan
-entry above uses `plan/[0-9]*_*.md` — the leading-digit
-pattern matches every numbered plan file but skips
-`proto.md`, which is then handled separately. A `!`-prefix
-on a pattern re-excludes a path; that's useful in
-`overrides:` (where excluding `proto.md` from
-content-tuning settings is harmless) but not in
-`kind-assignment:` for schema kinds, because excluding
-`proto.md` there would also strip the
-`required-structure.schema` that marks it as its own
-schema.
+entry uses `plan/*.md`, which matches every plan file
+including `proto.md`. The directory glob naturally
+includes `proto.md`, and that is what we want here: the
+proto kind disables structural rules on `proto.md`, while
+the plan kind supplies `required-structure.schema:` so
+the file is recognized as its own schema.
+
+Where the directory glob targets a different filename
+(for example `internal/rules/MDS*/README.md`, which does
+not match `internal/rules/proto.md`), list the schema
+file explicitly alongside the convention glob.
+
+A `!`-prefix on a pattern re-excludes a path. Use it in
+`overrides:` to keep content-tuning settings off
+`proto.md` (the proto kind already handles those
+files). Avoid `!`-exclusion in `kind-assignment:` for a
+schema kind — excluding `proto.md` there would also
+strip the `required-structure.schema:` that marks the
+file as its own schema.
 
 When a file should belong to two kinds, two entries can
 match it. The order of those entries fixes the merge
@@ -111,11 +120,10 @@ order — kinds picked up earlier appear earlier in the
 effective list.
 
 In the example above, `plan/proto.md` matches both
-`**/proto.md` (proto kind) and the explicit `plan/proto.md`
-entry (plan kind), so its effective kind list is
-`[proto, plan]`. A regular plan file like
-`plan/96_kinds-adoption-and-docs.md` only matches the
-`plan/[0-9]*_*.md` glob, so it resolves to `[plan]`.
+`**/proto.md` (proto kind) and `plan/*.md` (plan kind),
+so its effective kind list is `[proto, plan]`. A regular
+plan file like `plan/96_kinds-adoption-and-docs.md` only
+matches `plan/*.md`, so it resolves to `[plan]`.
 
 ## Merge order
 

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -92,12 +92,18 @@ kind-assignment:
     kinds: [skill]
 ```
 
-Globs use the same matcher as `overrides:` and `ignore:`.
-There is no `!`-negation; to exclude a narrower path,
-write a glob that doesn't match it. The plan entry above
-uses `plan/[0-9]*_*.md` — the leading-digit pattern
-matches every numbered plan file but skips `proto.md`,
-which is then handled separately.
+Globs use the same matcher as `overrides:` and `ignore:`
+(see [Glob patterns](../reference/globs.md)). The plan
+entry above uses `plan/[0-9]*_*.md` — the leading-digit
+pattern matches every numbered plan file but skips
+`proto.md`, which is then handled separately. A `!`-prefix
+on a pattern re-excludes a path; that's useful in
+`overrides:` (where excluding `proto.md` from
+content-tuning settings is harmless) but not in
+`kind-assignment:` for schema kinds, because excluding
+`proto.md` there would also strip the
+`required-structure.schema` that marks it as its own
+schema.
 
 When a file should belong to two kinds, two entries can
 match it. The order of those entries fixes the merge

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -1,0 +1,207 @@
+---
+title: File Kinds
+summary: >-
+  How to declare file kinds, assign files to them, and read
+  the merged rule config that results.
+---
+# File Kinds
+
+A **kind** is a named bundle of rule settings that mdsmith
+applies to a set of files. Kinds let you share per-rule
+tuning across files that serve the same purpose — schema
+templates, plan documents, rule READMEs, prompts, security
+notes — without copying the same overrides into every glob
+that matches them.
+
+mdsmith ships **no built-in kinds**. Each project picks the
+names that fit its repository.
+
+## Declaring a kind
+
+Kinds live under the `kinds:` key in `.mdsmith.yml`. Each
+kind body has the same shape as an entry under
+`overrides:`, minus `files:` — files are bound to kinds
+separately.
+
+```yaml
+kinds:
+  plan:
+    rules:
+      required-structure:
+        schema: plan/proto.md
+      paragraph-readability: false
+  proto:
+    rules:
+      first-line-heading: false
+      paragraph-readability: false
+```
+
+A kind that sets `rules.required-structure.schema:`
+attaches that CUE schema to every file of the kind. A kind
+that sets `rule-name: false` disables the rule for every
+file of the kind.
+
+Referencing an undeclared kind name from front matter or
+`kind-assignment:` is a config error.
+
+## Assigning files to kinds
+
+A file's effective kind list is built from two sources,
+concatenated in this order:
+
+1. The file's own front-matter `kinds:` field (a YAML
+   list).
+2. Matching entries in `kind-assignment:`, in the order
+   they appear in the config; within an entry, kinds in
+   the order listed.
+
+Duplicate names are dropped after their first occurrence.
+
+### Front-matter assignment
+
+A file can declare its kinds inline. Use this for one-off
+files where a glob doesn't make sense.
+
+```markdown
+---
+kinds: [plan]
+id: 92
+status: 🔲
+---
+# File kinds
+```
+
+A multi-kind file uses a multi-element list:
+`kinds: [draft, worksheet]`. Merge order matches list
+order.
+
+### Glob assignment
+
+`kind-assignment:` is a list of entries. Each entry has
+`files:` (the same glob shape as `overrides:` and
+`ignore:`) and `kinds:` (the names to apply).
+
+```yaml
+kind-assignment:
+  - files: ["**/proto.md"]
+    kinds: [proto]
+  - files: ["plan/proto.md", "plan/[0-9]*_*.md"]
+    kinds: [plan]
+  - files: [".claude/skills/proto.md",
+            ".claude/skills/*/SKILL.md"]
+    kinds: [skill]
+```
+
+Globs use the same matcher as `overrides:` and `ignore:`.
+There is no `!`-negation; to exclude a narrower path,
+write a glob that doesn't match it. `plan/[0-9]*_*.md`
+naturally excludes `plan/proto.md`. To pick up the
+narrower file with a different kind, list it explicitly
+in another `kind-assignment:` entry — duplicate kinds
+across entries are deduplicated, and the most specific
+glob can carry an additional kind.
+
+A file that should belong to two kinds (for example, the
+schema template that is both a `proto` and a `plan` file)
+appears in both globs:
+
+```yaml
+- files: ["**/proto.md"]
+  kinds: [proto]
+- files: ["plan/proto.md", "plan/[0-9]*_*.md"]
+  kinds: [plan]
+```
+
+`plan/proto.md` resolves to `[proto, plan]`; `plan/96.md`
+resolves to `[plan]`.
+
+## Merge order
+
+Rule settings come from four layers, applied in this
+order from lowest to highest precedence:
+
+1. Top-level `rules:` defaults.
+2. Each kind in the file's effective kind list, in order.
+3. Each `overrides:` entry whose `files:` glob matches,
+   in config order.
+
+Within each kind and each override, a rule mentioned in
+the layer **replaces the rule's entire config block** —
+nested settings do not deep-merge. This matches today's
+`overrides:` semantics.
+
+The block-replace contract has one consequence worth
+spelling out: if a kind sets one setting on a rule, it
+loses the rule's other settings. A kind that wants to add
+a `placeholders:` token to a rule that already had
+`level: 1` configured at the top level must restate
+`level: 1` in the kind body, or the rule will reset to
+its built-in default level.
+
+## Conflict resolution
+
+When two kinds in the effective list configure the same
+rule, the **later kind wins** — its rule block replaces
+the earlier kind's rule block in full. The same applies
+between kinds and overrides: a matching `overrides:`
+entry replaces whatever the kinds produced for that rule.
+
+Order is list-driven, so the result is stable across
+runs.
+
+### Putting it together
+
+For a file resolved as `[proto, plan]` with the kinds
+above:
+
+- `required-structure` comes from `plan` (later kind
+  replaces `proto`'s body, even if `proto` had set the
+  rule).
+- `paragraph-readability: false` comes from `proto` (the
+  `plan` kind doesn't touch it).
+- `first-line-heading: false` comes from `proto` (the
+  `plan` kind doesn't touch it).
+
+If a glob override on `plan/*.md` then sets
+`max-file-length: { max: 500 }`, that override applies on
+top of the kinds and replaces only the
+`max-file-length` rule.
+
+## Troubleshooting
+
+When a file produces an unexpected diagnostic — or the
+diagnostic you expected doesn't fire — start with the
+resolved kind list and the merged rule config for that
+file.
+
+`mdsmith kinds resolve <file>` (introduced by the
+`kinds` subcommand) prints both: the effective kind list
+and the merged rule settings, with a per-leaf source so
+you can see which layer set each value. Use it whenever
+the rule config you read in `.mdsmith.yml` doesn't match
+the diagnostics on a file.
+
+Until that subcommand lands, the same information is
+recoverable by reading `.mdsmith.yml` against the merge
+rules above:
+
+1. Read the file's front matter for any `kinds:` field.
+2. Walk `kind-assignment:` top to bottom and collect
+   every entry whose `files:` glob matches the file.
+3. Concatenate the two lists, dropping duplicates after
+   first occurrence — that's the effective kind list.
+4. Apply each kind body in order, then each matching
+   `overrides:` entry. Each layer replaces the rule
+   block it touches.
+
+For a quick primer on the same model from the CLI, run
+`mdsmith help kinds`.
+
+## See also
+
+- [Enforcing Document Structure with Schemas](directives/enforcing-structure.md)
+  — how `required-structure` reads the schema attached by
+  a kind.
+- [Placeholder grammar](../background/concepts/placeholder-grammar.md)
+  — opt-in tokens that let kinds keep template files
+  green under the same rules used for content.

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -94,26 +94,22 @@ kind-assignment:
 
 Globs use the same matcher as `overrides:` and `ignore:`.
 There is no `!`-negation; to exclude a narrower path,
-write a glob that doesn't match it. `plan/[0-9]*_*.md`
-naturally excludes `plan/proto.md`. To pick up the
-narrower file with a different kind, list it explicitly
-in another `kind-assignment:` entry — duplicate kinds
-across entries are deduplicated, and the most specific
-glob can carry an additional kind.
+write a glob that doesn't match it. The plan entry above
+uses `plan/[0-9]*_*.md` — the leading-digit pattern
+matches every numbered plan file but skips `proto.md`,
+which is then handled separately.
 
-A file that should belong to two kinds (for example, the
-schema template that is both a `proto` and a `plan` file)
-appears in both globs:
+When a file should belong to two kinds, two entries can
+match it. The order of those entries fixes the merge
+order — kinds picked up earlier appear earlier in the
+effective list.
 
-```yaml
-- files: ["**/proto.md"]
-  kinds: [proto]
-- files: ["plan/proto.md", "plan/[0-9]*_*.md"]
-  kinds: [plan]
-```
-
-`plan/proto.md` resolves to `[proto, plan]`; `plan/96.md`
-resolves to `[plan]`.
+In the example above, `plan/proto.md` matches both
+`**/proto.md` (proto kind) and the explicit `plan/proto.md`
+entry (plan kind), so its effective kind list is
+`[proto, plan]`. A regular plan file like
+`plan/96_kinds-adoption-and-docs.md` only matches the
+`plan/[0-9]*_*.md` glob, so it resolves to `[plan]`.
 
 ## Merge order
 

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -180,13 +180,17 @@ diagnostic you expected doesn't fire — start with the
 resolved kind list and the merged rule config for that
 file.
 
-A planned `mdsmith kinds resolve <file>` subcommand
-(tracked in plan 95) will print both: the effective kind
-list and the merged rule settings, with a per-leaf source
-so you can see which layer set each value.
+`mdsmith kinds resolve <file>` prints both: the effective
+kind list and the merged rule settings, with a per-leaf
+source so you can see which layer set each value. Add
+`--json` for a structured form. For a single rule's full
+merge chain, use `mdsmith kinds why <file> <rule>`. To
+attach the same source trailer to each diagnostic, run
+`mdsmith check --explain` (or `fix --explain`).
 
-Until that lands, the same information is recoverable by
-reading `.mdsmith.yml` against the merge rules above:
+If you'd rather walk the merge by hand, the same
+information is recoverable by reading `.mdsmith.yml`
+against the merge rules above:
 
 1. Read the file's front matter for any `kinds:` field.
 2. Walk `kind-assignment:` top to bottom and collect

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -120,31 +120,38 @@ resolves to `[plan]`.
 Rule settings come from four layers, applied in this
 order from lowest to highest precedence:
 
-1. Top-level `rules:` defaults.
-2. Each kind in the file's effective kind list, in order.
-3. Each `overrides:` entry whose `files:` glob matches,
+1. The rule's built-in defaults.
+2. Top-level `rules:` defaults.
+3. Each kind in the file's effective kind list, in order.
+4. Each `overrides:` entry whose `files:` glob matches,
    in config order.
 
-Within each kind and each override, a rule mentioned in
-the layer **replaces the rule's entire config block** —
-nested settings do not deep-merge. This matches today's
-`overrides:` semantics.
+Across all four layers the config is **deep-merged**
+rule by rule:
 
-The block-replace contract has one consequence worth
-spelling out: if a kind sets one setting on a rule, it
-loses the rule's other settings. A kind that wants to add
-a `placeholders:` token to a rule that already had
-`level: 1` configured at the top level must restate
-`level: 1` in the kind body, or the rule will reset to
-its built-in default level.
+- **Maps** merge key by key — a setting from an earlier
+  layer survives if the later layer doesn't touch the
+  same key.
+- **Scalar** values at a leaf replace the earlier value
+  wholesale.
+- **List** settings replace by default. A rule can opt
+  a specific list key into append mode (the
+  `placeholders:` setting is the canonical example).
+- A **bool-only** entry such as `rule-name: false`
+  toggles `enabled` without erasing any other settings
+  the rule inherited from earlier layers.
+
+Because the merge is key-by-key, a kind that sets one
+key on a rule leaves the rule's other settings intact
+from whichever earlier layer configured them.
 
 ## Conflict resolution
 
 When two kinds in the effective list configure the same
-rule, the **later kind wins** — its rule block replaces
-the earlier kind's rule block in full. The same applies
-between kinds and overrides: a matching `overrides:`
-entry replaces whatever the kinds produced for that rule.
+rule, the **later kind wins** — its settings deep-merge
+over the earlier kind's settings for that rule, with
+later scalar values overwriting earlier ones key by key.
+The same applies between kinds and overrides.
 
 Order is list-driven, so the result is stable across
 runs.
@@ -154,9 +161,8 @@ runs.
 For a file resolved as `[proto, plan]` with the kinds
 above:
 
-- `required-structure` comes from `plan` (later kind
-  replaces `proto`'s body, even if `proto` had set the
-  rule).
+- `required-structure` comes from `plan` (the `proto`
+  kind doesn't set it, so `plan`'s setting stands).
 - `paragraph-readability: false` comes from `proto` (the
   `plan` kind doesn't touch it).
 - `first-line-heading: false` comes from `proto` (the
@@ -174,25 +180,23 @@ diagnostic you expected doesn't fire — start with the
 resolved kind list and the merged rule config for that
 file.
 
-`mdsmith kinds resolve <file>` (introduced by the
-`kinds` subcommand) prints both: the effective kind list
-and the merged rule settings, with a per-leaf source so
-you can see which layer set each value. Use it whenever
-the rule config you read in `.mdsmith.yml` doesn't match
-the diagnostics on a file.
+A planned `mdsmith kinds resolve <file>` subcommand
+(tracked in plan 95) will print both: the effective kind
+list and the merged rule settings, with a per-leaf source
+so you can see which layer set each value.
 
-Until that subcommand lands, the same information is
-recoverable by reading `.mdsmith.yml` against the merge
-rules above:
+Until that lands, the same information is recoverable by
+reading `.mdsmith.yml` against the merge rules above:
 
 1. Read the file's front matter for any `kinds:` field.
 2. Walk `kind-assignment:` top to bottom and collect
    every entry whose `files:` glob matches the file.
 3. Concatenate the two lists, dropping duplicates after
    first occurrence — that's the effective kind list.
-4. Apply each kind body in order, then each matching
-   `overrides:` entry. Each layer replaces the rule
-   block it touches.
+4. Apply built-in defaults, then the top-level `rules:`
+   block, then each kind body in order, then each
+   matching `overrides:` entry. Each layer deep-merges
+   its settings over the accumulated config.
 
 For a quick primer on the same model from the CLI, run
 `mdsmith help kinds`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -21,5 +21,6 @@ row: "| [{title}]({filename}) | {summary} |"
 | [Choosing Readability, Conciseness, and Token Budget Metrics](metrics-tradeoffs.md) | Trade-offs and threshold guidance for readability, structure, length, and token budgets.                |
 | [Coming from Hugo](directives/hugo-migration.md)                                    | Key differences between Hugo templates and mdsmith directives for users familiar with Hugo.             |
 | [Enforcing Document Structure with Schemas](directives/enforcing-structure.md)      | How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames. |
+| [File Kinds](file-kinds.md)                                                         | How to declare file kinds, assign files to them, and read the merged rule config that results.          |
 | [Generating Content with Directives](directives/generating-content.md)              | How to use catalog and include directives to generate and embed content in Markdown files.              |
 <?/catalog?>

--- a/docs/reference/globs.md
+++ b/docs/reference/globs.md
@@ -63,8 +63,9 @@ nothing.
 
 ## Directive globs (`<?catalog?>`)
 
-`<?catalog?>` accepts a `glob:` parameter that is split
-on whitespace/newlines into a list. The matcher is
+`<?catalog?>` accepts a `glob:` parameter whose patterns
+are split on newlines into a list. A YAML `glob:` list
+becomes one pattern per line. The matcher is
 [`doublestar`](https://github.com/bmatcuk/doublestar),
 which supports `**`, brace expansion, and other
 extensions on top of the standard glob syntax.

--- a/docs/reference/globs.md
+++ b/docs/reference/globs.md
@@ -1,0 +1,112 @@
+---
+summary: >-
+  Glob pattern syntax across mdsmith config, directives,
+  and CLI argument expansion, with the supported
+  exclusion semantics for each surface.
+---
+# Glob patterns
+
+mdsmith uses globs in three places. The supported syntax
+and the exclusion semantics differ at each one. This page
+documents the current behavior; the long-term goal is to
+unify on a single matcher and a single naming convention,
+but that's a separate effort — until it lands, the table
+below is the source of truth.
+
+## Surfaces and matchers
+
+| Surface                  | Matcher                | Field name      | `!`-exclusion |
+|--------------------------|------------------------|-----------------|---------------|
+| `ignore:`                | `gobwas/glob`          | list of strings | yes           |
+| `overrides:.files`       | `gobwas/glob`          | `files:`        | yes           |
+| `kind-assignment:.files` | `gobwas/glob`          | `files:`        | yes           |
+| `<?catalog?>`            | `doublestar`           | `glob:`         | yes           |
+| CLI argument expansion   | stdlib `filepath.Glob` | positional      | no            |
+
+## Config globs (`ignore:`, `overrides:`, `kind-assignment:`)
+
+A pattern matches a file if it matches any of:
+
+- the raw path as given (`docs/foo.md`),
+- the cleaned path (`docs/./foo.md` → `docs/foo.md`), or
+- the basename (`foo.md`).
+
+Basename matching means a pattern like `CHANGELOG.md` (no
+slash) matches `CHANGELOG.md` in any directory.
+
+### Exclusion with `!`-prefix
+
+A pattern prefixed with `!` is an exclusion pattern. The
+list matches a file when at least one non-negated pattern
+matches and no exclusion pattern matches. The order of
+include and exclude entries does not matter — exclusion
+always wins.
+
+```yaml
+overrides:
+  - files: ["docs/security/*.md", "!docs/security/proto.md"]
+    rules:
+      max-file-length:
+        max: 1000
+```
+
+A list containing only exclusion patterns matches
+nothing.
+
+### Limits
+
+- No `**` recursive matching unless the underlying
+  `gobwas/glob` syntax supports it for the specific
+  pattern; prefer explicit subdirectories.
+- No brace expansion (`{a,b}`).
+- A pattern that fails to compile is silently skipped.
+
+## Directive globs (`<?catalog?>`)
+
+`<?catalog?>` accepts a `glob:` parameter that is split
+on whitespace/newlines into a list. The matcher is
+[`doublestar`](https://github.com/bmatcuk/doublestar),
+which supports `**`, brace expansion, and other
+extensions on top of the standard glob syntax.
+
+`!`-prefix exclusion works the same way as in config:
+include patterns gather candidates, exclude patterns
+remove from the result.
+
+```markdown
+<?catalog
+glob:
+  - "plan/*.md"
+  - "!plan/proto.md"
+?>
+```
+
+The directive requires at least one non-negated include
+pattern; a glob list of only exclusions is rejected at
+lint time.
+
+## CLI argument expansion
+
+Positional arguments to `mdsmith check` and `mdsmith fix`
+are expanded with the standard library's `filepath.Glob`.
+That matcher does not support `**`, brace expansion, or
+`!`-prefix exclusion. Use shell expansion (or wrap with
+`find`) for anything beyond a single-level pattern.
+
+```bash
+mdsmith check 'plan/*.md'   # works
+mdsmith check '**/*.md'     # falls through as a literal
+                            # path on most shells
+```
+
+For repeatable scoping, prefer `ignore:` /
+`kind-assignment:` in `.mdsmith.yml` over CLI globs.
+
+## Future work
+
+The split between `gobwas/glob`, `doublestar`, and
+`filepath.Glob`, and between the `files:` and `glob:`
+field names, is a known source of confusion. A future
+plan will pick one matcher (likely `doublestar`) and
+one field name, migrate the three call sites, and
+deprecate the displaced one.

--- a/internal/config/ignore.go
+++ b/internal/config/ignore.go
@@ -44,8 +44,8 @@ func globMatchAny(patterns []string, filePath string) bool {
 
 // IsIgnored returns true if the file path matches any of the given
 // ignore patterns. It checks the raw path, the cleaned path, and
-// the base name. A pattern prefixed with "!" re-includes a path that
-// would otherwise match an earlier ignore pattern.
+// the base name. A pattern prefixed with "!" excludes a path even if
+// another ignore pattern also matches, regardless of list order.
 func IsIgnored(patterns []string, path string) bool {
 	return globMatchAny(patterns, path)
 }

--- a/internal/config/ignore.go
+++ b/internal/config/ignore.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/gobwas/glob"
 )
@@ -10,25 +11,41 @@ import (
 // patterns. It checks the raw path, the cleaned path, and the base name
 // so that patterns without path separators (e.g. "slides.md") match files
 // in any directory.
+//
+// A pattern prefixed with "!" is an exclusion pattern. The path matches
+// the list when at least one non-negated pattern matches and no
+// exclusion pattern matches; an exclusion pattern always wins over an
+// inclusion pattern, regardless of list order. A list containing only
+// exclusion patterns matches nothing.
 func globMatchAny(patterns []string, filePath string) bool {
 	cleanPath := filepath.Clean(filePath)
 	base := filepath.Base(filePath)
 
+	matchedInclude := false
 	for _, pattern := range patterns {
+		isExclude := strings.HasPrefix(pattern, "!")
+		if isExclude {
+			pattern = pattern[1:]
+		}
 		g, err := glob.Compile(pattern)
 		if err != nil {
 			continue
 		}
-		if g.Match(filePath) || g.Match(cleanPath) || g.Match(base) {
-			return true
+		if !g.Match(filePath) && !g.Match(cleanPath) && !g.Match(base) {
+			continue
 		}
+		if isExclude {
+			return false
+		}
+		matchedInclude = true
 	}
-	return false
+	return matchedInclude
 }
 
 // IsIgnored returns true if the file path matches any of the given
 // ignore patterns. It checks the raw path, the cleaned path, and
-// the base name.
+// the base name. A pattern prefixed with "!" re-includes a path that
+// would otherwise match an earlier ignore pattern.
 func IsIgnored(patterns []string, path string) bool {
 	return globMatchAny(patterns, path)
 }

--- a/internal/config/ignore_test.go
+++ b/internal/config/ignore_test.go
@@ -34,3 +34,25 @@ func TestIsIgnored_CleanedPath(t *testing.T) {
 	patterns := []string{"vendor/**"}
 	assert.True(t, IsIgnored(patterns, "vendor/./lib.md"), "expected cleaned path to match")
 }
+
+func TestIsIgnored_NegationReIncludes(t *testing.T) {
+	patterns := []string{"plan/*.md", "!plan/proto.md"}
+	assert.True(t, IsIgnored(patterns, "plan/96_kinds.md"),
+		"plan/96_kinds.md should match the inclusion pattern")
+	assert.False(t, IsIgnored(patterns, "plan/proto.md"),
+		"plan/proto.md should be re-excluded by the negation")
+}
+
+func TestIsIgnored_NegationOrderIndependent(t *testing.T) {
+	beforeInclude := []string{"!plan/proto.md", "plan/*.md"}
+	assert.False(t, IsIgnored(beforeInclude, "plan/proto.md"),
+		"negation must win even when listed before its inclusion")
+}
+
+func TestIsIgnored_OnlyExclusionsMatchNothing(t *testing.T) {
+	patterns := []string{"!plan/proto.md"}
+	assert.False(t, IsIgnored(patterns, "plan/proto.md"),
+		"a list of only exclusions should not match anything")
+	assert.False(t, IsIgnored(patterns, "plan/96_kinds.md"),
+		"a list of only exclusions should not match anything")
+}

--- a/internal/config/ignore_test.go
+++ b/internal/config/ignore_test.go
@@ -40,7 +40,7 @@ func TestIsIgnored_NegationReIncludes(t *testing.T) {
 	assert.True(t, IsIgnored(patterns, "plan/96_kinds.md"),
 		"plan/96_kinds.md should match the inclusion pattern")
 	assert.False(t, IsIgnored(patterns, "plan/proto.md"),
-		"plan/proto.md should be re-excluded by the negation")
+		"plan/proto.md should be re-included by the negation")
 }
 
 func TestIsIgnored_NegationOrderIndependent(t *testing.T) {

--- a/plan/120_glob-unification.md
+++ b/plan/120_glob-unification.md
@@ -1,0 +1,161 @@
+---
+id: 120
+title: Unify glob matcher and field naming across mdsmith
+status: "🔲"
+model: sonnet
+summary: >-
+  Pick one glob library and one field name (`files:` vs
+  `glob:`), migrate `ignore:`, `overrides:`,
+  `kind-assignment:`, `<?catalog?>`, and CLI argument
+  expansion to use them consistently, and deprecate the
+  displaced surface.
+---
+# Unify glob matcher and field naming across mdsmith
+
+## Goal
+
+Use one glob matcher and one field name across every
+glob surface in mdsmith. Config sections, directives,
+and CLI argument expansion should accept the same
+syntax. Users learn the rules once.
+
+## Background
+
+Today three independent glob systems coexist, summarized
+in [docs/reference/globs.md](../docs/reference/globs.md):
+
+| Surface                                                   | Matcher                | Field name | `!`-exclusion          |
+|-----------------------------------------------------------|------------------------|------------|------------------------|
+| `ignore:` / `overrides:.files` / `kind-assignment:.files` | `gobwas/glob`          | `files:`   | yes (added in plan 96) |
+| `<?catalog?>`                                             | `doublestar`           | `glob:`    | yes                    |
+| CLI argument expansion                                    | stdlib `filepath.Glob` | positional | no                     |
+
+The split surfaces concretely as:
+
+- `**` recursion works in `<?catalog?>` but is matcher-
+  dependent for `ignore:` patterns.
+- Brace expansion (`{a,b}`) works in `<?catalog?>` but
+  not in config.
+- The CLI accepts none of the above; users have to lean
+  on shell expansion.
+- The same list-of-patterns concept is called `files:`
+  in some places and `glob:` in others.
+
+Plan 96 added `!`-prefix exclusion to the config matcher
+and documented the current state. Unifying the three
+surfaces is a larger change that deserves its own plan.
+
+## Design
+
+### Matcher
+
+`doublestar` is the most capable of the three. It
+supports `**`, brace expansion, character classes, and a
+well-defined matching algorithm. It already powers
+`<?catalog?>` with the `!`-exclusion semantics plan 96
+wired into config. Standardizing on it preserves catalog
+behavior. Config and CLI gain a strict superset of what
+they support today.
+
+The shared matcher lives in a new package
+(`internal/globpath` or a sibling) and exposes:
+
+- `Match(pattern, path) bool` — single-pattern match
+  with the same path/cleaned-path/basename fallbacks the
+  config matcher uses today.
+- `MatchAny(patterns, path) bool` — list match with
+  `!`-prefix exclusion (the same semantics as plan 96's
+  `globMatchAny`).
+- `SplitIncludeExclude(patterns)` — for callers that
+  need the split form (catalog uses this today).
+
+### Field name
+
+`glob:` is the better fit. It names the syntactic
+artifact (a glob pattern) rather than the result (a
+file list), and `<?catalog?>` and `<?include?>` already
+use a glob-style vocabulary. `files:` is in older
+config blocks but is the easier side to migrate because
+it only appears in two keys (`overrides:`, `kind-
+assignment:`).
+
+Migration plan:
+
+1. Add `glob:` as the canonical key on each block,
+   accepting the same list shape.
+2. Keep `files:` as a deprecated alias that loads into
+   the same field; emit a deprecation warning when it is
+   used.
+3. Update `mdsmith init` and the docs to write `glob:`.
+4. Schedule removal of `files:` for the release after
+   the deprecation window.
+
+### CLI argument expansion
+
+Replace the `filepath.Glob` call in
+[`resolveGlob`](../internal/lint/files.go) with the
+shared matcher. CLI args now accept the same syntax as
+config — including `**` and `!`-exclusion — and stop
+silently failing on patterns the standard library
+doesn't grasp.
+
+## Tasks
+
+1. Land the shared matcher package (new
+   `internal/globpath`) with `Match`, `MatchAny`, and
+   `SplitIncludeExclude`. Cover include-only, exclude-
+   only, mixed-order, `**` recursion, and brace
+   expansion in unit tests.
+2. Migrate
+   [`internal/config/ignore.go`](../internal/config/ignore.go)
+   to call the shared matcher; remove the `gobwas/glob`
+   dependency from `internal/config/`.
+3. Migrate
+   [`internal/rules/catalog/rule.go`](../internal/rules/catalog/rule.go)
+   to call the shared matcher; remove its private
+   `splitIncludeExclude`.
+4. Migrate
+   [`internal/lint/files.go:347`](../internal/lint/files.go)
+   `resolveGlob` to call the shared matcher.
+5. Add `glob:` as the canonical key on `overrides:` and
+   `kind-assignment:` entries. Keep `files:` as a
+   deprecated alias and surface a deprecation warning
+   via `cfg.Deprecations`.
+6. Update `mdsmith init` to emit `glob:`; update
+   [docs/reference/globs.md](../docs/reference/globs.md),
+   [docs/guides/file-kinds.md](../docs/guides/file-kinds.md),
+   the `mdsmith help kinds` page, and any rule
+   READMEs / fixtures that reference `files:`.
+7. Add a regression test: a config that uses `files:`
+   loads correctly and produces a deprecation warning;
+   the same config rewritten with `glob:` produces no
+   warning and the same effective rule config.
+8. Drop `gobwas/glob` from `go.mod` once no callers
+   remain.
+
+## Acceptance Criteria
+
+- [ ] Every glob surface in mdsmith — config, catalog,
+      CLI argument expansion — resolves through one
+      shared matcher; `gobwas/glob` and the stdlib
+      `filepath.Glob` are no longer imported by
+      production code.
+- [ ] `**` recursion, brace expansion, and `!`-prefix
+      exclusion behave identically across all three
+      surfaces (covered by tests).
+- [ ] `overrides:` and `kind-assignment:` accept
+      `glob:` as the canonical key. `files:` continues
+      to work and emits a deprecation warning naming
+      the offending block.
+- [ ] `mdsmith init` writes `glob:`; existing `files:`
+      configs in the repo are migrated.
+- [ ] [docs/reference/globs.md](../docs/reference/globs.md)
+      collapses the three-surface table into a single
+      surface and documents the deprecation timeline
+      for `files:`.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/96_kinds-adoption-and-docs.md
+++ b/plan/96_kinds-adoption-and-docs.md
@@ -161,12 +161,13 @@ Each `proto.md` file resolves to two kinds.
 
 - The broad `**/proto.md` entry picks up the proto kind.
 - A directory-scoped entry picks up the project-specific
-  kind. For `plan/` and `docs/security/` the directory
-  glob (`plan/*.md`, `docs/security/*.md`) already
-  matches `proto.md`. For `internal/rules/` and
-  `.claude/skills/` the directory glob targets a
-  different filename (`MDS*/README.md`, `*/SKILL.md`),
-  so those entries also list `proto.md` explicitly.
+  kind. The convention globs are exclusion patterns —
+  `plan/[0-9]*_*.md` and `docs/security/[0-9]*.md` match
+  numbered plans and date-prefixed security notes
+  without matching `proto.md`. Each schema kind lists
+  its `proto.md` path explicitly so the file still picks
+  up the kind that supplies its
+  `required-structure.schema:`.
 
 The later schema kind sets `required-structure.schema:`
 to `proto.md` itself. That marks the file as its own

--- a/plan/96_kinds-adoption-and-docs.md
+++ b/plan/96_kinds-adoption-and-docs.md
@@ -1,7 +1,7 @@
 ---
 id: 96
 title: Adopt kinds in mdsmith repo and ship the docs
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Declare the kinds this repo needs, drop the four
@@ -123,43 +123,76 @@ plan — the collision is gone.
 
 ## Tasks
 
-1. Add the kind declarations and `kind-assignment:`
+1. [x] Add the kind declarations and `kind-assignment:`
    entries shown above to `.mdsmith.yml`.
-2. Drop the four `proto.md` entries from `ignore:`
+2. [x] Drop the four `proto.md` entries from `ignore:`
    and the placeholder-link entry from
    `cross-file-reference-integrity.exclude:`.
-3. Confirm `mdsmith check .` stays green; iterate on
+3. [x] Confirm `mdsmith check .` stays green; iterate on
    kind bodies if any rule still flags a placeholder
    that's part of a real schema/template file.
-4. Write `docs/guides/file-kinds.md` covering kind
+4. [x] Write `docs/guides/file-kinds.md` covering kind
    declaration, assignment (front matter + globs),
    merge order, and conflict resolution. Walk through
    `mdsmith kinds resolve <file>` as the
    troubleshooting path.
-5. Update each rule README that gained a
+5. [x] Update each rule README that gained a
    `placeholders:` setting to link to the
-   placeholder-grammar concept page.
+   placeholder-grammar concept page (already covered
+   by plan 93).
+
+## Implementation Notes
+
+The proto kind disables seven rules outright:
+`first-line-heading`, `heading-increment`,
+`blank-line-around-headings`, `no-emphasis-as-heading`,
+`cross-file-reference-integrity`, `paragraph-readability`,
+`paragraph-structure`.
+
+Body tokens cannot mask the structural placement of
+`<?require?>` directives and HTML comments before the
+first heading. The one external link in
+`internal/rules/proto.md` uses an unbraced `NAME`
+placeholder. No token matches that form. Plan 98 will
+replace the link as part of the archetype-to-kinds
+rename.
+
+`kind-assignment:` lists each `proto.md` path twice.
+
+- The broad `**/proto.md` entry picks up the proto kind.
+- The directory-scoped entry picks up the
+  project-specific kind.
+
+The later schema kind sets `required-structure.schema:`
+to `proto.md` itself. That marks the file as its own
+schema. The "<?require?> outside a schema file" warning
+then stays silent.
+
+The `plan/*.md` and `docs/security/*.md` overrides were
+narrowed to `plan/[0-9]*_*.md` and
+`docs/security/[0-9]*.md`. They no longer collide with
+the proto kind on `proto.md` files.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith check .` passes with the four
+- [x] `mdsmith check .` passes with the four
       `proto.md` entries removed from `.mdsmith.yml`
       `ignore:` and the placeholder-link
       `cross-file-reference-integrity.exclude:`
       entry removed.
-- [ ] Each `proto.md` file is linted under its
+- [x] Each `proto.md` file is linted under its
       project kind, with placeholder-aware rules
       passing on its placeholder-rich body.
-- [ ] Adding a new schema file requires no
+- [x] Adding a new schema file requires no
       `ignore:` change — assigning it to an existing
       kind via `kind-assignment:` is enough.
-- [ ] `docs/guides/file-kinds.md` exists, describes
+- [x] `docs/guides/file-kinds.md` exists, describes
       declaration / assignment / merge / conflict
       resolution, and references
       `mdsmith kinds resolve` as the troubleshooting
       path.
-- [ ] Each rule that gained a `placeholders:`
+- [x] Each rule that gained a `placeholders:`
       setting in plan 93 has a README link to the
       placeholder-grammar concept page.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues

--- a/plan/96_kinds-adoption-and-docs.md
+++ b/plan/96_kinds-adoption-and-docs.md
@@ -161,13 +161,12 @@ Each `proto.md` file resolves to two kinds.
 
 - The broad `**/proto.md` entry picks up the proto kind.
 - A directory-scoped entry picks up the project-specific
-  kind. The convention globs are exclusion patterns —
-  `plan/[0-9]*_*.md` and `docs/security/[0-9]*.md` match
-  numbered plans and date-prefixed security notes
-  without matching `proto.md`. Each schema kind lists
-  its `proto.md` path explicitly so the file still picks
-  up the kind that supplies its
-  `required-structure.schema:`.
+  kind. The plan and docs/security entries use `*.md`
+  globs that naturally include `proto.md`. The
+  internal/rules and .claude/skills directory globs
+  target a different filename (`MDS*/README.md`,
+  `*/SKILL.md`), so those entries list `proto.md`
+  explicitly alongside the convention glob.
 
 The later schema kind sets `required-structure.schema:`
 to `proto.md` itself. That marks the file as its own
@@ -176,14 +175,19 @@ then stays silent. With deep-merge (plan 97) the schema
 setting from the project kind composes with the proto
 kind's other settings rather than replacing them.
 
-The redundant schema overrides were removed:
+`!`-prefix exclusion (added to the config matcher in
+this plan) is used in the `docs/security/*.md` override
+to keep its content tunings off `proto.md`. It is not
+used in `kind-assignment:` for schema kinds — excluding
+`proto.md` from the project kind would strip the
+schema. See [docs/reference/globs.md](../docs/reference/globs.md)
+for full glob semantics.
 
-- `plan/*.md`
-- `docs/security/*.md`
-- `internal/rules/MDS*/README.md`
-
-Each schema now lives in its kind. Schema attachment
-for a file class lives in one place.
+The redundant schema overrides on `plan/*.md`,
+`docs/security/*.md`, and `internal/rules/MDS*/README.md`
+were removed once the matching kinds covered them.
+Schema attachment for a file class now lives in one
+place.
 
 ## Acceptance Criteria
 

--- a/plan/96_kinds-adoption-and-docs.md
+++ b/plan/96_kinds-adoption-and-docs.md
@@ -157,21 +157,32 @@ placeholder. No token matches that form. Plan 98 will
 replace the link as part of the archetype-to-kinds
 rename.
 
-`kind-assignment:` lists each `proto.md` path twice.
+Each `proto.md` file resolves to two kinds.
 
 - The broad `**/proto.md` entry picks up the proto kind.
-- The directory-scoped entry picks up the
-  project-specific kind.
+- A directory-scoped entry picks up the project-specific
+  kind. For `plan/` and `docs/security/` the directory
+  glob (`plan/*.md`, `docs/security/*.md`) already
+  matches `proto.md`. For `internal/rules/` and
+  `.claude/skills/` the directory glob targets a
+  different filename (`MDS*/README.md`, `*/SKILL.md`),
+  so those entries also list `proto.md` explicitly.
 
 The later schema kind sets `required-structure.schema:`
 to `proto.md` itself. That marks the file as its own
 schema. The "<?require?> outside a schema file" warning
-then stays silent.
+then stays silent. With deep-merge (plan 97) the schema
+setting from the project kind composes with the proto
+kind's other settings rather than replacing them.
 
-The `plan/*.md` and `docs/security/*.md` overrides were
-narrowed to `plan/[0-9]*_*.md` and
-`docs/security/[0-9]*.md`. They no longer collide with
-the proto kind on `proto.md` files.
+The redundant schema overrides were removed:
+
+- `plan/*.md`
+- `docs/security/*.md`
+- `internal/rules/MDS*/README.md`
+
+Each schema now lives in its kind. Schema attachment
+for a file class lives in one place.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

Adopts the file-kinds system in this repo, ships the user-facing guide, adds `!`-prefix exclusion to config globs, and tracks the deeper glob unification in plan 120.

## Key changes

- **`kinds:` and `kind-assignment:` in `.mdsmith.yml`.** Five kinds: `proto`, `plan`, `rule-readme`, `skill`, `security-note`. The `proto` kind disables structural and reference rules that conflict with placeholder-rich schema templates. Each project kind sets its own `required-structure.schema:` pointing back at its `proto.md`.

- **`kind-assignment:` matches `proto.md` directly.** Each project kind's directory glob (`plan/*.md`, `docs/security/*.md`) naturally includes `proto.md`, and the `internal/rules` and `.claude/skills` entries list `proto.md` explicitly alongside their non-overlapping convention globs (`MDS*/README.md`, `*/SKILL.md`). This dual matching is required: the project kind has to apply to `proto.md` so the file is recognized as its own schema and the `<?require?>`-outside-a-schema warning stays silent.

- **`!`-prefix exclusion in config globs.** `internal/config/ignore.go` now treats a `!`-prefixed pattern as exclusion (order-independent — exclusion always wins). Used in the `docs/security/*.md` override (`!docs/security/proto.md`) so its content tunings stop applying to the schema template. Not used in `kind-assignment:` for schema kinds — excluding `proto.md` there would strip the schema attachment.

- **Removed the four `proto.md` entries from `ignore:`** and the placeholder-link entry from `cross-file-reference-integrity.exclude:`. Removed the redundant `required-structure.schema` overrides on `plan/*.md`, `docs/security/*.md`, `internal/rules/MDS*/README.md`, and `.claude/skills/*/SKILL.md` — schema attachment now lives only in the corresponding kind.

- **`docs/guides/file-kinds.md`** — new user guide covering declaration, front-matter and glob assignment, merge order (deep-merge), conflict resolution, and the `mdsmith kinds resolve` / `kinds why` / `check --explain` troubleshooting CLI.

- **`docs/reference/globs.md`** — new reference describing the three glob surfaces in mdsmith today (config matcher, `<?catalog?>`, CLI argument expansion), the matcher used at each, the field name (`files:` vs `glob:`), and which surfaces support `!`-prefix exclusion.

- **`plan/120_glob-unification.md`** — new plan tracking the follow-up unification work: collapse `gobwas/glob`, `doublestar`, and `filepath.Glob` onto one matcher; rename `files:` to `glob:` with a deprecation alias; migrate the three call sites.

- **Plan 96 ✅.** All tasks and acceptance criteria checked off, with implementation notes describing the structural-rule disablements in the proto kind, the dual `kind-assignment` matching pattern, and the `!`-prefix usage.

- **Navigation indexes** (PLAN.md, docs/guides/index.md, docs/reference/cli.md, CLAUDE.md, AGENTS.md, .github/copilot-instructions.md) refreshed via `mdsmith fix`.

## Verification

- `mdsmith check .` clean (117 files)
- `go test ./...` clean
- `go tool golangci-lint run` clean
