### PR TITLE
Plans 105-113: flavor profiles and seven new Markdown style rules

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -21,6 +21,11 @@ footer: |
 | 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                       |
 | 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)               |
 | 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                            |
+| 105 | 🔲     |        | [No inline HTML rule](plan/105_no-inline-html.md)                                                    |
+| 106 | 🔲     |        | [Emphasis style rule](plan/106_emphasis-style.md)                                                    |
+| 107 | 🔲     |        | [No reference-style links rule](plan/107_no-reference-style.md)                                      |
+| 108 | 🔲     |        | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                      |
+| 109 | 🔲     |        | [List marker style rule](plan/109_list-marker-style.md)                                              |
 | 120 | 🔲     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                   |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |
@@ -40,5 +45,4 @@ footer: |
 | 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
 | 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                   |
 | 98  | 🔲     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |
-| 99  | 🔲     |        | [No inline HTML rule](plan/99_no-inline-html.md)                                                     |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -21,15 +21,15 @@ footer: |
 | 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                       |
 | 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)               |
 | 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                            |
-| 105 | 🔲     |        | [No inline HTML rule](plan/105_no-inline-html.md)                                                    |
-| 106 | 🔲     |        | [Emphasis style rule](plan/106_emphasis-style.md)                                                    |
-| 107 | 🔲     |        | [No reference-style links rule](plan/107_no-reference-style.md)                                      |
-| 108 | 🔲     |        | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                      |
-| 109 | 🔲     |        | [List marker style rule](plan/109_list-marker-style.md)                                              |
-| 110 | 🔲     |        | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
-| 111 | 🔲     |        | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                            |
-| 112 | 🔲     |        | [Flavor profiles refactor](plan/112_flavor-profiles.md)                                              |
-| 113 | 🔲     |        | [User-defined flavor profiles](plan/113_user-defined-profiles.md)                                    |
+| 105 | 🔲     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                    |
+| 106 | 🔲     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                    |
+| 107 | 🔲     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                      |
+| 108 | 🔲     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                      |
+| 109 | 🔲     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                              |
+| 110 | 🔲     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
+| 111 | 🔲     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                            |
+| 112 | 🔲     | opus   | [Flavor profiles refactor](plan/112_flavor-profiles.md)                                              |
+| 113 | 🔲     | sonnet | [User-defined flavor profiles](plan/113_user-defined-profiles.md)                                    |
 | 120 | 🔲     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                   |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,6 +26,9 @@ footer: |
 | 107 | 🔲     |        | [No reference-style links rule](plan/107_no-reference-style.md)                                      |
 | 108 | 🔲     |        | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                      |
 | 109 | 🔲     |        | [List marker style rule](plan/109_list-marker-style.md)                                              |
+| 110 | 🔲     |        | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
+| 111 | 🔲     |        | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                            |
+| 112 | 🔲     |        | [Flavor profiles refactor](plan/112_flavor-profiles.md)                                              |
 | 120 | 🔲     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                   |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |

--- a/PLAN.md
+++ b/PLAN.md
@@ -40,4 +40,5 @@ footer: |
 | 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
 | 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                   |
 | 98  | 🔲     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |
+| 99  | 🔲     |        | [No inline HTML rule](plan/99_no-inline-html.md)                                                     |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -29,6 +29,7 @@ footer: |
 | 110 | 🔲     |        | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
 | 111 | 🔲     |        | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                            |
 | 112 | 🔲     |        | [Flavor profiles refactor](plan/112_flavor-profiles.md)                                              |
+| 113 | 🔲     |        | [User-defined flavor profiles](plan/113_user-defined-profiles.md)                                    |
 | 120 | 🔲     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                   |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |

--- a/plan/105_no-inline-html.md
+++ b/plan/105_no-inline-html.md
@@ -91,10 +91,13 @@ need.
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with empty
+- `profile: portable` activates with empty
   `allow` and `allow-comments: true`.
-- `profile: mdsmith-relaxed` activates with
+- `profile: github` activates with
   `allow: [details, summary, sub, sup, kbd]`.
+- `profile: plain` activates with empty `allow`
+  and `allow-comments: false` (HTML comments leak
+  through as literal text in plaintext readers).
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/105_no-inline-html.md
+++ b/plan/105_no-inline-html.md
@@ -4,11 +4,11 @@ title: No inline HTML rule
 status: "🔲"
 summary: >-
   New rule MDS039 that flags raw HTML in Markdown
-  (block and inline), with an allowlist for tags that
-  have no Markdown equivalent. Closes the largest
-  attack surface for XSS and the largest source of
-  parser ambiguity, per the bgslabs.org/why-are-we-
-  using-markdown rant.
+  (block and inline), with an allowlist for tags
+  that have no Markdown equivalent. Closes the
+  largest attack surface for XSS and the largest
+  source of parser ambiguity, per the "Why are we
+  using Markdown?" bgslabs.org rant.
 model: sonnet
 ---
 # No inline HTML rule
@@ -38,11 +38,15 @@ types for raw HTML:
 
 The PI block parser
 ([internal/lint/pi.go](../internal/lint/pi.go))
-already replaces `<?name ... ?>` directives with a
-distinct AST node, so directives are *not* HTMLBlocks
-and will not be flagged by this rule. HTML comments
-(`<!-- ... -->`) remain `*ast.HTMLBlock`s — see the
-allowlist discussion below.
+already replaces block-level `<?name ... ?>`
+directives with a distinct AST node, so block
+directives are *not* HTMLBlocks. Inline
+`<?name ... ?>` inside a paragraph lands as
+`*ast.RawHTML`. The rule must skip both forms
+unconditionally — see "What is *not* flagged"
+below. HTML comments (`<!-- ... -->`) remain
+`*ast.HTMLBlock`s — see the allowlist discussion
+below.
 
 ### Why a separate rule from MDS034
 
@@ -107,11 +111,15 @@ deep-merge.
 Walk `f.AST`. For every `*ast.HTMLBlock` and every
 `*ast.RawHTML`:
 
-1. Extract the tag name (lowercase) from the raw
+1. If the bytes start with `<?`, skip
+   unconditionally. This covers inline mdsmith
+   directives that the block PI parser does not
+   reach. The allowance is not configurable.
+2. Extract the tag name (lowercase) from the raw
    bytes. If the bytes start with `<!--`, treat as a
    comment and skip when `allow-comments` is true.
-2. If the tag name is in `allow`, skip.
-3. Otherwise emit a diagnostic at the node's start
+3. If the tag name is in `allow`, skip.
+4. Otherwise emit a diagnostic at the node's start
    line/column: `inline HTML <{tag}> is not allowed;
    use a Markdown construct or an mdsmith directive
    instead`.
@@ -128,8 +136,11 @@ tags (`<br/>`, `<img/>`) count once.
 - Inline code spans (`*ast.CodeSpan`).
 - Autolinks (`<https://example.com>`) and email
   autolinks — these are `*ast.AutoLink`, not RawHTML.
-- mdsmith directives (`<?name ... ?>`) — already
-  carved out by the PI parser.
+- mdsmith directives (`<?name ... ?>`) — block
+  forms are carved out by the PI parser; inline
+  forms are skipped explicitly by step 1 of
+  Detection. The allowance is unconditional and not
+  affected by `allow:` or `allow-comments:`.
 - HTML entities in text (`&amp;`, `&#x2014;`) — these
   are `*ast.Text` after entity decoding; flagging
   them would be a separate rule.
@@ -199,8 +210,14 @@ distinct.
 - [ ] `<!-- comment -->` emits no diagnostic when
       `allow-comments: true`, and one diagnostic
       naming `<!--` when `allow-comments: false`.
-- [ ] `<?include file: foo.md ?>` and `<?catalog ... ?>`
-      emit no diagnostic.
+- [ ] `<?include file: foo.md ?>` and
+      `<?catalog ... ?>` block directives emit no
+      diagnostic.
+- [ ] `text <?inline?> text` inline directive emits
+      no diagnostic.
+- [ ] An inline `<?...?>` directive emits no
+      diagnostic even when `allow: []` and
+      `allow-comments: false`.
 - [ ] `<https://example.com>` autolink emits no
       diagnostic.
 - [ ] Fenced code blocks containing HTML emit no

--- a/plan/105_no-inline-html.md
+++ b/plan/105_no-inline-html.md
@@ -3,7 +3,7 @@ id: 105
 title: No inline HTML rule
 status: "🔲"
 summary: >-
-  New rule MDS039 that flags raw HTML in Markdown
+  New rule MDS041 that flags raw HTML in Markdown
   (block and inline), with an allowlist for tags
   that have no Markdown equivalent. Closes the
   largest attack surface for XSS and the largest
@@ -185,9 +185,9 @@ distinct.
    handler.
 5. Implement `rule.Defaultable` returning `false`
    so the rule is opt-in.
-6. Register as MDS039 in category `meta`.
+6. Register as MDS041 in category `meta`.
 7. Add fixture tests in
-   `internal/rules/MDS039-no-inline-html/` with
+   `internal/rules/MDS041-no-inline-html/` with
    `good/` and `bad/` examples (paragraph with
    `<span>`, block with `<div>`, comment, allowlisted
    tag, directive, autolink — verify the directive

--- a/plan/105_no-inline-html.md
+++ b/plan/105_no-inline-html.md
@@ -1,5 +1,5 @@
 ---
-id: 99
+id: 105
 title: No inline HTML rule
 status: "🔲"
 summary: >-

--- a/plan/105_no-inline-html.md
+++ b/plan/105_no-inline-html.md
@@ -9,7 +9,7 @@ summary: >-
   attack surface for XSS and the largest source of
   parser ambiguity, per the bgslabs.org/why-are-we-
   using-markdown rant.
-model: ""
+model: sonnet
 ---
 # No inline HTML rule
 

--- a/plan/105_no-inline-html.md
+++ b/plan/105_no-inline-html.md
@@ -86,6 +86,19 @@ default, matching the rest of the codebase except
 default empty list does so by listing every tag they
 need.
 
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with empty
+  `allow` and `allow-comments: true`.
+- `profile: mdsmith-relaxed` activates with
+  `allow: [details, summary, sub, sup, kbd]`.
+
+User overrides on top of the profile still win via
+deep-merge.
+
 ### Detection
 
 Walk `f.AST`. For every `*ast.HTMLBlock` and every

--- a/plan/106_emphasis-style.md
+++ b/plan/106_emphasis-style.md
@@ -65,6 +65,20 @@ and the new MDS039.
 
 Disabled by default (opt-in) — existing corpora vary.
 
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with
+  `bold: asterisk`, `italic: underscore`, and
+  `forbid-mixed-nesting: true`.
+- `profile: mdsmith-relaxed` activates with the
+  same defaults.
+
+User overrides on top of the profile still win via
+deep-merge.
+
 ### Detection
 
 Walk the AST. For every `*ast.Emphasis`:

--- a/plan/106_emphasis-style.md
+++ b/plan/106_emphasis-style.md
@@ -3,7 +3,7 @@ id: 106
 title: Emphasis style rule
 status: "🔲"
 summary: >-
-  New rule MDS040 that pins one delimiter per role:
+  New rule MDS042 that pins one delimiter per role:
   one of asterisk or underscore for bold, one for
   italic. Removes the bold/italic ambiguity called
   out as "Exhibit A" in the bgslabs.org markdown
@@ -43,7 +43,7 @@ whose delimiter differs from its parent Emphasis.
 ### Why a separate rule from MDS018
 
 MDS018 (no-emphasis-as-heading) flags emphasis used
-*as a heading*. MDS040 flags emphasis with the wrong
+*as a heading*. MDS042 flags emphasis with the wrong
 *delimiter*. The two rules can coexist on the same
 file without overlap.
 
@@ -61,7 +61,7 @@ rules:
 
 Category: `whitespace` is wrong; use a new category
 or reuse `meta`. **Chosen: `meta`**, matching MDS034
-and the new MDS039.
+and the new MDS041.
 
 Disabled by default (opt-in) — existing corpora vary.
 
@@ -131,9 +131,9 @@ mixed emphasis delimiters: {outer} wraps {inner}
 4. Implement `rule.Defaultable` returning `false`.
 5. Implement `Fix()` for bold and italic delimiter
    replacement; skip triple-delimiter runs.
-6. Register as MDS040 in category `meta`.
+6. Register as MDS042 in category `meta`.
 7. Add fixture tests in
-   `internal/rules/MDS040-emphasis-style/` covering
+   `internal/rules/MDS042-emphasis-style/` covering
    each delimiter combination, mixed nesting, triple
    delimiters, and emphasis inside code spans
    (must not flag).

--- a/plan/106_emphasis-style.md
+++ b/plan/106_emphasis-style.md
@@ -8,7 +8,7 @@ summary: >-
   italic. Removes the bold/italic ambiguity called
   out as "Exhibit A" in the bgslabs.org markdown
   rant.
-model: ""
+model: sonnet
 ---
 # Emphasis style rule
 

--- a/plan/106_emphasis-style.md
+++ b/plan/106_emphasis-style.md
@@ -70,11 +70,14 @@ Disabled by default (opt-in) — existing corpora vary.
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with
+- `profile: portable` activates with
   `bold: asterisk`, `italic: underscore`, and
   `forbid-mixed-nesting: true`.
-- `profile: mdsmith-relaxed` activates with the
+- `profile: github` activates with the
   same defaults.
+- `profile: plain` activates with the same
+  defaults. (A future `no-emphasis` rule would
+  forbid `*` and `_` runs entirely under `plain`.)
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/106_emphasis-style.md
+++ b/plan/106_emphasis-style.md
@@ -1,0 +1,141 @@
+---
+id: 106
+title: Emphasis style rule
+status: "🔲"
+summary: >-
+  New rule MDS040 that pins one delimiter per role:
+  one of asterisk or underscore for bold, one for
+  italic. Removes the bold/italic ambiguity called
+  out as "Exhibit A" in the bgslabs.org markdown
+  rant.
+model: ""
+---
+# Emphasis style rule
+
+## Goal
+
+Let users pin a single delimiter for bold and a single
+delimiter for italic. CommonMark accepts `**bold**`,
+`__bold__`, `*italic*`, and `_italic_` interchangeably.
+Multiple delimiters in one corpus produce inconsistent
+diffs and stress every parser implementation. This rule
+makes the choice explicit and enforces it.
+
+## Background
+
+### What goldmark exposes
+
+Bold and italic both render to `*ast.Emphasis` nodes.
+The node carries a `Level` field: `1` for italic, `2`
+for bold. The chosen delimiter character does not
+appear on the AST node — it must be read back from
+the source via the node's first child segment, looking
+at the byte immediately before the segment start.
+
+### Mixed-nesting cases
+
+The rant flags cross-delimiter nests like `_*bold*_`
+and `*_bold_*` as ambiguous. CommonMark resolves
+them deterministically, but humans cannot. A
+`forbid-mixed-nesting` setting flags any Emphasis
+whose delimiter differs from its parent Emphasis.
+
+### Why a separate rule from MDS018
+
+MDS018 (no-emphasis-as-heading) flags emphasis used
+*as a heading*. MDS040 flags emphasis with the wrong
+*delimiter*. The two rules can coexist on the same
+file without overlap.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  emphasis-style:
+    bold: asterisk        # asterisk | underscore
+    italic: underscore    # asterisk | underscore
+    forbid-mixed-nesting: true
+```
+
+Category: `whitespace` is wrong; use a new category
+or reuse `meta`. **Chosen: `meta`**, matching MDS034
+and the new MDS039.
+
+Disabled by default (opt-in) — existing corpora vary.
+
+### Detection
+
+Walk the AST. For every `*ast.Emphasis`:
+
+1. Find the byte immediately before the first child
+   segment to read the actual opening delimiter.
+2. If `Level == 2` and the byte does not match the
+   `bold` setting, emit one diagnostic.
+3. If `Level == 1` and the byte does not match the
+   `italic` setting, emit one diagnostic.
+4. If `forbid-mixed-nesting` is true and the parent
+   chain contains an Emphasis with a different
+   delimiter, emit one diagnostic.
+
+### Auto-fix
+
+Replace the opening and closing delimiter bytes in
+the source. Bold uses two delimiter characters per
+side, italic uses one. The fix is byte-for-byte
+substitution; no AST rewrite is required.
+
+Edge case: when bold and italic share the same
+delimiter character (e.g. both `asterisk`), the
+boundary between `***bolditalic***` and `___both___`
+becomes ambiguous to fix mechanically. Skip auto-fix
+for triple-delimiter runs and emit the diagnostic
+only.
+
+### Error messages
+
+```text
+bold uses {actual}; configured style is {expected}
+italic uses {actual}; configured style is {expected}
+mixed emphasis delimiters: {outer} wraps {inner}
+```
+
+## Tasks
+
+1. Scaffold `internal/rules/emphasisstyle/` with
+   `rule.go`, `rule_test.go`, and `init()`
+   `rule.Register`.
+2. Implement `Check()` walking `*ast.Emphasis` and
+   reading the source byte before each emphasis
+   segment.
+3. Implement `rule.Configurable` for `bold`,
+   `italic`, and `forbid-mixed-nesting`.
+4. Implement `rule.Defaultable` returning `false`.
+5. Implement `Fix()` for bold and italic delimiter
+   replacement; skip triple-delimiter runs.
+6. Register as MDS040 in category `meta`.
+7. Add fixture tests in
+   `internal/rules/MDS040-emphasis-style/` covering
+   each delimiter combination, mixed nesting, triple
+   delimiters, and emphasis inside code spans
+   (must not flag).
+8. Add rule README.
+
+## Acceptance Criteria
+
+- [ ] `**bold**` with `bold: asterisk` emits no
+      diagnostic.
+- [ ] `__bold__` with `bold: asterisk` emits one
+      diagnostic and fixes to `**bold**`.
+- [ ] `*italic*` with `italic: underscore` emits one
+      diagnostic and fixes to `_italic_`.
+- [ ] `_*x*_` with `forbid-mixed-nesting: true` emits
+      one diagnostic for the mixed nest.
+- [ ] `***x***` triple-delimiter run emits a
+      diagnostic but is not auto-fixed.
+- [ ] Emphasis inside `` `code` `` and fenced code
+      blocks emits no diagnostic.
+- [ ] Rule is disabled by default.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/107_no-reference-style.md
+++ b/plan/107_no-reference-style.md
@@ -81,10 +81,12 @@ because the number carries no anchor.
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with
+- `profile: portable` activates with
   `allow-footnotes: false`.
-- `profile: mdsmith-relaxed` does not activate
+- `profile: github` does not activate
   this rule.
+- `profile: plain` activates with
+  `allow-footnotes: false`.
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/107_no-reference-style.md
+++ b/plan/107_no-reference-style.md
@@ -3,7 +3,7 @@ id: 107
 title: No reference-style links rule
 status: "🔲"
 summary: >-
-  New rule MDS041 that forbids reference-style links
+  New rule MDS043 that forbids reference-style links
   and footnotes. These constructs require global
   definition resolution, moving Markdown from a
   context-free to a context-sensitive grammar — the
@@ -49,11 +49,11 @@ shape — `[text](url)` vs `[text][id]` vs `[text][]`
 ### Why a separate rule from MDS034
 
 MDS034 (markdown-flavor) flags footnotes as a flavor
-extension. MDS041 forbids them even on flavors that
+extension. MDS043 forbids them even on flavors that
 support them, because the *grammar* concern is
 independent of the renderer concern. The two rules
 can be enabled together; MDS034 fires when the flavor
-is `commonmark` and the file uses footnotes, MDS041
+is `commonmark` and the file uses footnotes, MDS043
 fires when the policy forbids footnotes regardless
 of flavor.
 
@@ -142,7 +142,7 @@ unused reference definition: [{id}]
 4. Implement unused-definition detection.
 5. Implement inline-rewrite auto-fix for
    reference-style links only.
-6. Register as MDS041 in category `link`.
+6. Register as MDS043 in category `link`.
 7. Add fixture tests covering inline, full
    reference, collapsed reference, shortcut
    reference, footnote (with and without

--- a/plan/107_no-reference-style.md
+++ b/plan/107_no-reference-style.md
@@ -76,6 +76,19 @@ The definition must sit immediately after the
 referencing paragraph. Numeric `[^1]` is rejected
 because the number carries no anchor.
 
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with
+  `allow-footnotes: false`.
+- `profile: mdsmith-relaxed` does not activate
+  this rule.
+
+User overrides on top of the profile still win via
+deep-merge.
+
 ### Detection
 
 Walk `*ast.Link` nodes. For each link, read the

--- a/plan/107_no-reference-style.md
+++ b/plan/107_no-reference-style.md
@@ -8,7 +8,7 @@ summary: >-
   definition resolution, moving Markdown from a
   context-free to a context-sensitive grammar — the
   "Exhibit D" complaint in the bgslabs.org rant.
-model: ""
+model: opus
 ---
 # No reference-style links rule
 

--- a/plan/107_no-reference-style.md
+++ b/plan/107_no-reference-style.md
@@ -1,0 +1,159 @@
+---
+id: 107
+title: No reference-style links rule
+status: "🔲"
+summary: >-
+  New rule MDS041 that forbids reference-style links
+  and footnotes. These constructs require global
+  definition resolution, moving Markdown from a
+  context-free to a context-sensitive grammar — the
+  "Exhibit D" complaint in the bgslabs.org rant.
+model: ""
+---
+# No reference-style links rule
+
+## Goal
+
+Let users forbid the link forms whose meaning depends
+on declarations elsewhere in the document. Inline
+links (`[text](url)`) are fully local. Reference
+links (`[text][id]` plus `[id]: url`) and footnotes
+(`[^n]` plus `[^n]: ...`) require a global pass over
+the file to resolve. Forbidding them keeps every link
+diff readable in isolation and removes one of the two
+cases that pushes Markdown grammar above context-free.
+
+## Background
+
+### What goldmark exposes
+
+- Inline links → `*ast.Link` with non-nil `Destination`
+  on the node itself.
+- Reference links → also `*ast.Link`, but resolved
+  via `parser.Reference` that goldmark stores in the
+  document context. The original source uses the
+  `[text][id]` shape.
+- Reference definitions → not an AST node by default;
+  they are consumed during parsing and never appear
+  in the tree.
+- Footnotes → `*ast.Footnote` and
+  `*ast.FootnoteReference`, available only when the
+  footnote extension is enabled.
+
+The check must inspect the *source*, not just the
+AST. Goldmark resolves inline links and reference
+links to the same `*ast.Link` node. The original
+shape — `[text](url)` vs `[text][id]` vs `[text][]`
+— is recoverable only from the source bytes.
+
+### Why a separate rule from MDS034
+
+MDS034 (markdown-flavor) flags footnotes as a flavor
+extension. MDS041 forbids them even on flavors that
+support them, because the *grammar* concern is
+independent of the renderer concern. The two rules
+can be enabled together; MDS034 fires when the flavor
+is `commonmark` and the file uses footnotes, MDS041
+fires when the policy forbids footnotes regardless
+of flavor.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  no-reference-style:
+    allow-footnotes: false   # opt back in if needed
+```
+
+Category: `link`. Disabled by default (opt-in).
+
+When `allow-footnotes: true`, footnote references
+are accepted under two constraints. The reference
+must use the `[^slug]` shape with a meaningful slug.
+The definition must sit immediately after the
+referencing paragraph. Numeric `[^1]` is rejected
+because the number carries no anchor.
+
+### Detection
+
+Walk `*ast.Link` nodes. For each link, read the
+source bytes between the closing `]` and the next
+non-whitespace character:
+
+- `(` → inline link, accept.
+- `[` → reference or collapsed reference, flag as
+  `reference-style link`.
+- nothing → shortcut reference (`[text]` alone),
+  flag as `reference-style link`.
+
+Walk `*ast.FootnoteReference`. When `allow-footnotes`
+is false, flag every occurrence. When true, validate
+the slug format and the definition placement.
+
+Reference *definitions* (`[id]: url`) emit a
+diagnostic of their own when no inline-style link
+in the file uses the `id`, since they are dead code.
+When the file has reference-style links, the link
+diagnostics already cover the issue and the
+definition is left alone.
+
+### Auto-fix
+
+Reference-style → inline: substitute the resolved
+URL into the link, drop the definition. Possible
+when goldmark already resolved the reference.
+
+Footnote → inline: not auto-fixed. The footnote text
+is meant to be visually separated; turning it into
+`(...)` parentheticals changes the document.
+
+### Error messages
+
+```text
+reference-style link; use inline form [text](url)
+footnote reference; footnotes are not allowed
+footnote slug is numeric; use a meaningful slug
+unused reference definition: [{id}]
+```
+
+## Tasks
+
+1. Scaffold `internal/rules/noreferencestyle/`.
+2. Implement source-aware link form detection.
+3. Implement footnote checks gated on
+   `allow-footnotes`.
+4. Implement unused-definition detection.
+5. Implement inline-rewrite auto-fix for
+   reference-style links only.
+6. Register as MDS041 in category `link`.
+7. Add fixture tests covering inline, full
+   reference, collapsed reference, shortcut
+   reference, footnote (with and without
+   `allow-footnotes`), unused definition, and
+   numeric footnote slug.
+8. Add rule README.
+
+## Acceptance Criteria
+
+- [ ] `[text](url)` emits no diagnostic.
+- [ ] `[text][id]` plus `[id]: url` emits one
+      diagnostic per link occurrence and fixes to
+      `[text](url)`.
+- [ ] `[text][]` collapsed reference emits one
+      diagnostic.
+- [ ] `[text]` shortcut reference (with matching
+      definition) emits one diagnostic.
+- [ ] `[^1]` with `allow-footnotes: false` emits one
+      diagnostic.
+- [ ] `[^1]` with `allow-footnotes: true` emits one
+      diagnostic for numeric slug.
+- [ ] `[^slug]` with `allow-footnotes: true` and
+      definition right after the paragraph emits no
+      diagnostic.
+- [ ] `[id]: url` with no link referencing it emits
+      one diagnostic.
+- [ ] Rule is disabled by default.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/108_horizontal-rule-style.md
+++ b/plan/108_horizontal-rule-style.md
@@ -65,11 +65,13 @@ Category: `whitespace`. Disabled by default (opt-in).
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with
+- `profile: portable` activates with
   `style: dash`, `length: 3`, and
   `require-blank-lines: true`.
-- `profile: mdsmith-relaxed` does not activate
+- `profile: github` does not activate
   this rule.
+- `profile: plain` activates with `style: dash`,
+  `length: 3`, and `require-blank-lines: true`.
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/108_horizontal-rule-style.md
+++ b/plan/108_horizontal-rule-style.md
@@ -3,7 +3,7 @@ id: 108
 title: Horizontal rule style rule
 status: "🔲"
 summary: >-
-  New rule MDS042 that pins one of `---`, `***`, or
+  New rule MDS044 that pins one of `---`, `***`, or
   `___` for thematic breaks and requires blank lines
   on both sides so the rule cannot be confused with
   a setext heading underline. Closes one of the
@@ -35,13 +35,13 @@ the source line that produced the node.
 Setext headings (`Title\n=====` or `Title\n-----`)
 are `*ast.Heading` with `IsSetext` true. MDS002
 already lets users pin ATX-only, which removes the
-collision risk from one direction. MDS042 closes the
+collision risk from one direction. MDS044 closes the
 other direction: even with setext allowed, a
 horizontal rule must not look like a setext underline.
 
 ### Why a separate rule from MDS002
 
-MDS002 is about *headings*. MDS042 is about
+MDS002 is about *headings*. MDS044 is about
 *thematic breaks*. They share an underlying syntax
 collision but operate on disjoint AST node types and
 have independent toggles.
@@ -115,7 +115,7 @@ horizontal rule needs a blank line {above|below}
    `length`, and `require-blank-lines`.
 4. Implement `Fix()` rewriting the line and adding
    surrounding blank lines.
-5. Register as MDS042 in category `whitespace`.
+5. Register as MDS044 in category `whitespace`.
 6. Add fixture tests covering each delimiter
    choice, wrong length, internal spaces, missing
    blank lines, and a thematic break adjacent to a

--- a/plan/108_horizontal-rule-style.md
+++ b/plan/108_horizontal-rule-style.md
@@ -1,0 +1,125 @@
+---
+id: 108
+title: Horizontal rule style rule
+status: "🔲"
+summary: >-
+  New rule MDS042 that pins one of `---`, `***`, or
+  `___` for thematic breaks and requires blank lines
+  on both sides so the rule cannot be confused with
+  a setext heading underline. Closes one of the
+  ambiguity cases in "Exhibit C" of the bgslabs.org
+  rant.
+model: ""
+---
+# Horizontal rule style rule
+
+## Goal
+
+Let users pin a single delimiter for thematic breaks.
+CommonMark accepts `---`, `***`, and `___` (with any
+length ≥ 3 and any internal spaces). One of the three
+also collides with the setext heading underline:
+`---` under text becomes an `<h2>` instead of a
+horizontal rule. This rule pins one delimiter and
+requires surrounding blank lines so the collision
+cannot occur.
+
+## Background
+
+### What goldmark exposes
+
+Thematic breaks are `*ast.ThematicBreak`. The node
+carries no delimiter information; the rule must read
+the source line that produced the node.
+
+Setext headings (`Title\n=====` or `Title\n-----`)
+are `*ast.Heading` with `IsSetext` true. MDS002
+already lets users pin ATX-only, which removes the
+collision risk from one direction. MDS042 closes the
+other direction: even with setext allowed, a
+horizontal rule must not look like a setext underline.
+
+### Why a separate rule from MDS002
+
+MDS002 is about *headings*. MDS042 is about
+*thematic breaks*. They share an underlying syntax
+collision but operate on disjoint AST node types and
+have independent toggles.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  horizontal-rule-style:
+    style: dash          # dash | asterisk | underscore
+    length: 3            # required exact length
+    require-blank-lines: true
+```
+
+Category: `whitespace`. Disabled by default (opt-in).
+
+### Detection
+
+Walk `*ast.ThematicBreak`. For each node:
+
+1. Read the source line. Strip leading/trailing
+   whitespace.
+2. If any character is not the configured delimiter,
+   emit `wrong delimiter`.
+3. If internal spaces exist, emit `delimiter has
+   internal spaces`.
+4. If the visible character count differs from
+   `length`, emit `wrong length`.
+5. If `require-blank-lines` is true and the previous
+   or next line is non-blank, emit `missing blank
+   line`.
+
+### Auto-fix
+
+Replace the line with the canonical delimiter
+repeated `length` times. Insert a blank line above
+and below if missing.
+
+### Error messages
+
+```text
+horizontal rule uses {actual}; configured style is {expected}
+horizontal rule has internal spaces
+horizontal rule has length {actual}; configured length is {expected}
+horizontal rule needs a blank line {above|below}
+```
+
+## Tasks
+
+1. Scaffold `internal/rules/horizontalrulestyle/`.
+2. Implement `Check()` walking `*ast.ThematicBreak`.
+3. Implement `rule.Configurable` for `style`,
+   `length`, and `require-blank-lines`.
+4. Implement `Fix()` rewriting the line and adding
+   surrounding blank lines.
+5. Register as MDS042 in category `whitespace`.
+6. Add fixture tests covering each delimiter
+   choice, wrong length, internal spaces, missing
+   blank lines, and a thematic break adjacent to a
+   setext heading underline.
+7. Add rule README.
+
+## Acceptance Criteria
+
+- [ ] `---` with `style: dash` and `length: 3` emits
+      no diagnostic.
+- [ ] `***` with `style: dash` emits one diagnostic
+      and fixes to `---`.
+- [ ] `- - -` emits an internal-spaces diagnostic.
+- [ ] `-----` with `length: 3` emits a length
+      diagnostic and fixes to `---`.
+- [ ] A thematic break with no blank line above
+      emits one diagnostic when
+      `require-blank-lines: true`.
+- [ ] A setext heading underline (`====` after
+      text) emits no diagnostic from this rule.
+- [ ] Rule is disabled by default.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/108_horizontal-rule-style.md
+++ b/plan/108_horizontal-rule-style.md
@@ -60,6 +60,20 @@ rules:
 
 Category: `whitespace`. Disabled by default (opt-in).
 
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with
+  `style: dash`, `length: 3`, and
+  `require-blank-lines: true`.
+- `profile: mdsmith-relaxed` does not activate
+  this rule.
+
+User overrides on top of the profile still win via
+deep-merge.
+
 ### Detection
 
 Walk `*ast.ThematicBreak`. For each node:

--- a/plan/108_horizontal-rule-style.md
+++ b/plan/108_horizontal-rule-style.md
@@ -9,7 +9,7 @@ summary: >-
   a setext heading underline. Closes one of the
   ambiguity cases in "Exhibit C" of the bgslabs.org
   rant.
-model: ""
+model: sonnet
 ---
 # Horizontal rule style rule
 

--- a/plan/109_list-marker-style.md
+++ b/plan/109_list-marker-style.md
@@ -1,0 +1,117 @@
+---
+id: 109
+title: List marker style rule
+status: "🔲"
+summary: >-
+  New rule MDS043 that pins one of `-`, `*`, or `+`
+  as the bullet for unordered lists. Removes the
+  three-way ambiguity called out in "Exhibit C" of
+  the bgslabs.org rant.
+model: ""
+---
+# List marker style rule
+
+## Goal
+
+Let users pin a single bullet character for unordered
+lists. CommonMark accepts `-`, `*`, and `+`
+interchangeably. Mixed markers in one corpus produce
+noisy diffs and surprise readers when nested lists
+flip styles. This rule pins the marker globally.
+
+## Background
+
+### What goldmark exposes
+
+Unordered lists are `*ast.List` with `IsOrdered() ==
+false`. The marker character is on the node as
+`Marker` (a `byte`). Each `*ast.ListItem` carries
+the same marker.
+
+### Interaction with MDS016
+
+MDS016 (list-indent) enforces nesting indentation,
+not marker choice. The two rules can fire on the
+same list independently.
+
+### Nested-list option
+
+Some style guides want nested lists to use a
+*different* marker for visual distinction (e.g. `-`
+at the top level, `*` at the next). The rule
+supports this with `nested:` as an ordered list of
+markers cycled by depth. The default is to use the
+same marker at every depth.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  list-marker-style:
+    style: dash          # dash | asterisk | plus
+    nested: []           # optional [dash, asterisk]
+                         # cycles by depth
+```
+
+Category: `list`. Disabled by default (opt-in).
+
+### Detection
+
+Walk `*ast.List` with `!IsOrdered()`. For each list:
+
+1. Compute the depth — the count of `*ast.List`
+   ancestors.
+2. Determine the expected marker. When `nested` is
+   empty, use `style`. Otherwise use
+   `nested[depth % len(nested)]`.
+3. If `list.Marker` differs, emit one diagnostic per
+   list (not per item) at the first item's line.
+
+### Auto-fix
+
+Replace the marker byte at each item's start. The
+indent column does not change because all three
+markers are one byte wide.
+
+### Error messages
+
+```text
+unordered list uses {actual}; configured style is {expected}
+unordered list at depth {n} uses {actual}; expected {expected}
+```
+
+## Tasks
+
+1. Scaffold `internal/rules/listmarkerstyle/`.
+2. Implement `Check()` walking `*ast.List` and
+   computing depth.
+3. Implement `rule.Configurable` for `style` and
+   `nested`. Document `nested` as replace-mode.
+4. Implement `Fix()` replacing the marker byte at
+   each item start.
+5. Register as MDS043 in category `list`.
+6. Add fixture tests covering each marker choice,
+   mixed markers in one list, nested lists with and
+   without `nested` set, and ordered lists (must
+   not flag).
+7. Add rule README.
+
+## Acceptance Criteria
+
+- [ ] `- item` with `style: dash` emits no diagnostic.
+- [ ] `* item` with `style: dash` emits one
+      diagnostic and fixes to `- item`.
+- [ ] `+ item` with `style: dash` emits one
+      diagnostic and fixes to `- item`.
+- [ ] A nested list using `*` inside a `-` parent
+      emits no diagnostic when
+      `nested: [dash, asterisk]`.
+- [ ] A nested list using `-` inside a `-` parent
+      emits one diagnostic when
+      `nested: [dash, asterisk]`.
+- [ ] Ordered lists (`1. item`) emit no diagnostic.
+- [ ] Rule is disabled by default.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/109_list-marker-style.md
+++ b/plan/109_list-marker-style.md
@@ -62,10 +62,12 @@ Category: `list`. Disabled by default (opt-in).
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with
+- `profile: portable` activates with
   `style: dash` and empty `nested`.
-- `profile: mdsmith-relaxed` activates with the
+- `profile: github` activates with the
   same defaults.
+- `profile: plain` activates with the same
+  defaults.
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/109_list-marker-style.md
+++ b/plan/109_list-marker-style.md
@@ -7,7 +7,7 @@ summary: >-
   as the bullet for unordered lists. Removes the
   three-way ambiguity called out in "Exhibit C" of
   the bgslabs.org rant.
-model: ""
+model: sonnet
 ---
 # List marker style rule
 

--- a/plan/109_list-marker-style.md
+++ b/plan/109_list-marker-style.md
@@ -3,7 +3,7 @@ id: 109
 title: List marker style rule
 status: "🔲"
 summary: >-
-  New rule MDS043 that pins one of `-`, `*`, or `+`
+  New rule MDS045 that pins one of `-`, `*`, or `+`
   as the bullet for unordered lists. Removes the
   three-way ambiguity called out in "Exhibit C" of
   the bgslabs.org rant.
@@ -106,7 +106,7 @@ unordered list at depth {n} uses {actual}; expected {expected}
    `nested`. Document `nested` as replace-mode.
 4. Implement `Fix()` replacing the marker byte at
    each item start.
-5. Register as MDS043 in category `list`.
+5. Register as MDS045 in category `list`.
 6. Add fixture tests covering each marker choice,
    mixed markers in one list, nested lists with and
    without `nested` set, and ordered lists (must

--- a/plan/109_list-marker-style.md
+++ b/plan/109_list-marker-style.md
@@ -57,6 +57,19 @@ rules:
 
 Category: `list`. Disabled by default (opt-in).
 
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with
+  `style: dash` and empty `nested`.
+- `profile: mdsmith-relaxed` activates with the
+  same defaults.
+
+User overrides on top of the profile still win via
+deep-merge.
+
 ### Detection
 
 Walk `*ast.List` with `!IsOrdered()`. For each list:

--- a/plan/110_ordered-list-numbering.md
+++ b/plan/110_ordered-list-numbering.md
@@ -3,7 +3,7 @@ id: 110
 title: Ordered list numbering rule
 status: "🔲"
 summary: >-
-  New rule MDS044 that pins how ordered lists number
+  New rule MDS046 that pins how ordered lists number
   their items: literal sequential (`1. 2. 3.`) or all
   ones (`1. 1. 1.`). Removes the "ordered list which
   doesn't care how you ordered them" surprise from
@@ -51,11 +51,11 @@ The rant's complaint targets the *mismatch* between
 source and output, not either choice on its own. A
 team picks one and stops thinking about it.
 
-### Interaction with MDS016 and MDS043
+### Interaction with MDS016 and MDS045
 
-MDS016 (list-indent) handles indentation. MDS043
+MDS016 (list-indent) handles indentation. MDS045
 (list-marker-style) handles the unordered marker.
-MDS044 only handles ordered numbering. The three
+MDS046 only handles ordered numbering. The three
 rules can fire on the same list independently.
 
 ## Design
@@ -129,7 +129,7 @@ ordered list item {position} numbered {actual}; expected {expected}
 5. Implement `Fix()` rewriting numbers and adjusting
    continuation indentation when marker width
    changes.
-6. Register as MDS044 in category `list`.
+6. Register as MDS046 in category `list`.
 7. Add fixture tests covering each style, the
    width-change case (single-digit to double-digit),
    wrong start, nested ordered lists, and unordered

--- a/plan/110_ordered-list-numbering.md
+++ b/plan/110_ordered-list-numbering.md
@@ -76,10 +76,12 @@ Category: `list`. Disabled by default (opt-in).
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with
+- `profile: portable` activates with
   `style: sequential` and `start: 1`.
-- `profile: mdsmith-relaxed` does not activate
+- `profile: github` does not activate
   this rule.
+- `profile: plain` activates with
+  `style: sequential` and `start: 1`.
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/110_ordered-list-numbering.md
+++ b/plan/110_ordered-list-numbering.md
@@ -1,0 +1,155 @@
+---
+id: 110
+title: Ordered list numbering rule
+status: "🔲"
+summary: >-
+  New rule MDS044 that pins how ordered lists number
+  their items: literal sequential (`1. 2. 3.`) or all
+  ones (`1. 1. 1.`). Removes the "ordered list which
+  doesn't care how you ordered them" surprise from
+  "Exhibit C" of the bgslabs.org rant.
+model: ""
+---
+# Ordered list numbering rule
+
+## Goal
+
+Let users pin how ordered list items are numbered in
+the source. CommonMark only reads the first item's
+number and increments from there in the rendered
+output. The remaining numbers are decorative — `1. 1.
+1.` and `1. 7. 99.` both render as `1, 2, 3`. This
+silent rewrite surprises authors and produces noisy
+diffs when an editor renumbers items it did not
+touch. The rule pins one of two source styles so
+what the author writes matches what the reader sees.
+
+## Background
+
+### What goldmark exposes
+
+Ordered lists are `*ast.List` with `IsOrdered() ==
+true`. The starting number is on the node as `Start`.
+Each `*ast.ListItem` has a position but goldmark
+discards the literal number written by the author —
+it only stores the marker character and the start.
+
+The check must read the source line of each list
+item to recover the literal number written.
+
+### Style choices
+
+- `sequential` — items number `1. 2. 3. ...` matching
+  their position. Surprises nobody. Painful when
+  inserting an item in the middle of a long list,
+  because every following number shifts.
+- `all-ones` — every item uses `1.` (or whichever
+  number the list starts with). Insertion is free.
+  The rendered output still numbers correctly.
+
+The rant's complaint targets the *mismatch* between
+source and output, not either choice on its own. A
+team picks one and stops thinking about it.
+
+### Interaction with MDS016 and MDS043
+
+MDS016 (list-indent) handles indentation. MDS043
+(list-marker-style) handles the unordered marker.
+MDS044 only handles ordered numbering. The three
+rules can fire on the same list independently.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  ordered-list-numbering:
+    style: sequential   # sequential | all-ones
+    start: 1            # required first number
+```
+
+Category: `list`. Disabled by default (opt-in).
+
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with
+  `style: sequential` and `start: 1`.
+- `profile: mdsmith-relaxed` does not activate
+  this rule.
+
+User overrides on top of the profile still win via
+deep-merge.
+
+### Detection
+
+Walk `*ast.List` with `IsOrdered()`. For each list:
+
+1. Read `list.Start`. If it differs from the `start`
+   setting, emit one diagnostic for the first item.
+2. For each item, read the source line and parse the
+   leading number.
+3. Compute the expected number based on `style`. For
+   `sequential`, expected is `start + i`. For
+   `all-ones`, expected is `start` for every item.
+4. If the literal number differs from expected, emit
+   one diagnostic at the item's line.
+
+### Auto-fix
+
+Replace the literal number on each item line with
+the expected number. The marker character (`.` or
+`)`) and trailing space are preserved.
+
+Width changes (e.g. `9.` → `10.`) shift the item's
+content column. The fix re-indents continuation
+lines to match the new marker width so list-indent
+stays consistent.
+
+### Error messages
+
+```text
+ordered list starts at {actual}; configured start is {expected}
+ordered list item {position} numbered {actual}; expected {expected}
+```
+
+## Tasks
+
+1. Scaffold `internal/rules/orderedlistnumbering/`.
+2. Implement `Check()` walking ordered `*ast.List`.
+3. Implement source-line parsing for the literal
+   item number.
+4. Implement `rule.Configurable` for `style` and
+   `start`.
+5. Implement `Fix()` rewriting numbers and adjusting
+   continuation indentation when marker width
+   changes.
+6. Register as MDS044 in category `list`.
+7. Add fixture tests covering each style, the
+   width-change case (single-digit to double-digit),
+   wrong start, nested ordered lists, and unordered
+   lists (must not flag).
+8. Add rule README.
+
+## Acceptance Criteria
+
+- [ ] `1. a\n2. b\n3. c` with `style: sequential`
+      emits no diagnostic.
+- [ ] `1. a\n1. b\n1. c` with `style: sequential`
+      emits two diagnostics and fixes to `1. 2. 3.`.
+- [ ] `1. a\n1. b\n1. c` with `style: all-ones`
+      emits no diagnostic.
+- [ ] `1. a\n3. b\n7. c` with `style: all-ones`
+      emits two diagnostics and fixes to all `1.`.
+- [ ] `5. a\n6. b` with `start: 1` emits one
+      diagnostic naming the wrong start.
+- [ ] A 12-item sequential list fixes the
+      single-to-double-digit boundary without
+      breaking continuation indent.
+- [ ] Unordered lists emit no diagnostic.
+- [ ] Rule is disabled by default.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/110_ordered-list-numbering.md
+++ b/plan/110_ordered-list-numbering.md
@@ -8,7 +8,7 @@ summary: >-
   ones (`1. 1. 1.`). Removes the "ordered list which
   doesn't care how you ordered them" surprise from
   "Exhibit C" of the bgslabs.org rant.
-model: ""
+model: sonnet
 ---
 # Ordered list numbering rule
 

--- a/plan/111_ambiguous-emphasis.md
+++ b/plan/111_ambiguous-emphasis.md
@@ -9,7 +9,7 @@ summary: >-
   Targets the parser-stress cases ("Exhibit A") and
   the ReDoS pattern shape called out in the
   bgslabs.org rant.
-model: ""
+model: sonnet
 ---
 # Ambiguous emphasis rule
 

--- a/plan/111_ambiguous-emphasis.md
+++ b/plan/111_ambiguous-emphasis.md
@@ -87,11 +87,13 @@ Category: `meta`. Disabled by default (opt-in).
 [Plan 112](112_flavor-profiles.md) ships profiles
 that auto-enable this rule:
 
-- `profile: mdsmith-strict` activates with
+- `profile: portable` activates with
   `max-run: 2`, `forbid-escaped-in-run: true`, and
   `forbid-adjacent-same-delim: true`.
-- `profile: mdsmith-relaxed` does not activate
+- `profile: github` does not activate
   this rule.
+- `profile: plain` activates with the same
+  settings as `portable`.
 
 User overrides on top of the profile still win via
 deep-merge.

--- a/plan/111_ambiguous-emphasis.md
+++ b/plan/111_ambiguous-emphasis.md
@@ -3,7 +3,7 @@ id: 111
 title: Ambiguous emphasis rule
 status: "🔲"
 summary: >-
-  New rule MDS045 that flags emphasis runs whose
+  New rule MDS047 that flags emphasis runs whose
   meaning a human cannot predict at a glance even
   though CommonMark resolves them deterministically.
   Targets the parser-stress cases ("Exhibit A") and
@@ -61,10 +61,10 @@ chose, not whether a human could have predicted
 that choice. The rule scans the raw source line for
 the suspicious shapes instead.
 
-### Interaction with MDS040
+### Interaction with MDS042
 
-MDS040 (emphasis-style) pins which delimiter is
-used. MDS045 catches the ambiguous *combinations*
+MDS042 (emphasis-style) pins which delimiter is
+used. MDS047 catches the ambiguous *combinations*
 that survive a delimiter pin. They can fire
 independently on the same line.
 
@@ -143,7 +143,7 @@ adjacent same-delimiter emphasis is ambiguous
 4. Implement `rule.Configurable` for `max-run`,
    `forbid-escaped-in-run`, and
    `forbid-adjacent-same-delim`.
-5. Register as MDS045 in category `meta`.
+5. Register as MDS047 in category `meta`.
 6. Add fixture tests covering each pattern,
    patterns inside code spans (must not flag),
    patterns inside fenced code blocks (must not

--- a/plan/111_ambiguous-emphasis.md
+++ b/plan/111_ambiguous-emphasis.md
@@ -1,0 +1,166 @@
+---
+id: 111
+title: Ambiguous emphasis rule
+status: "🔲"
+summary: >-
+  New rule MDS045 that flags emphasis runs whose
+  meaning a human cannot predict at a glance even
+  though CommonMark resolves them deterministically.
+  Targets the parser-stress cases ("Exhibit A") and
+  the ReDoS pattern shape called out in the
+  bgslabs.org rant.
+model: ""
+---
+# Ambiguous emphasis rule
+
+## Goal
+
+Let users forbid emphasis sequences that are
+*technically* valid but unreadable. The CommonMark
+emphasis algorithm runs a left-flanking and
+right-flanking delimiter scan that can pair `*` and
+`_` runs in non-obvious ways. The output is
+well-defined; the source is not. Examples from the
+rant include `*****\*a*` and `***Peter* Piper**
+_Picked___a___Pack_`. The rule names a small,
+auditable set of "you cannot tell at a glance"
+shapes and refuses them.
+
+## Background
+
+### What counts as ambiguous
+
+Three patterns cover most of the surprise:
+
+1. **Long delimiter runs** — three or more contiguous
+   `*` or `_` characters at one boundary (e.g.
+   `***`, `____`, `*****`). CommonMark splits the
+   run between bold and italic by counting from the
+   matching closing run; the split rarely matches
+   author intent.
+2. **Adjacent same-character delimiters across word
+   boundaries** — `__a__b__` or `*a*b*`. The
+   flanking rules can pair these multiple ways
+   depending on surrounding whitespace. Different
+   parsers have historically disagreed on these.
+3. **Escaped emphasis adjacent to delimiter runs** —
+   `*\*x*`, `*****\*a*`. Backslash-escapes inside a
+   long run interact with the flanking scan in ways
+   no human reads correctly. This is also the shape
+   the markdown-it ReDoS CVE exploited.
+
+Each pattern is a static check on the source bytes.
+The AST is not consulted because goldmark has
+already collapsed the ambiguity.
+
+### Why source-only
+
+Goldmark resolves these patterns to a definite AST.
+Walking the AST tells the rule what the parser
+chose, not whether a human could have predicted
+that choice. The rule scans the raw source line for
+the suspicious shapes instead.
+
+### Interaction with MDS040
+
+MDS040 (emphasis-style) pins which delimiter is
+used. MDS045 catches the ambiguous *combinations*
+that survive a delimiter pin. They can fire
+independently on the same line.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  ambiguous-emphasis:
+    max-run: 2          # delimiter run length cap
+    forbid-escaped-in-run: true
+    forbid-adjacent-same-delim: true
+```
+
+Category: `meta`. Disabled by default (opt-in).
+
+### Flavor activation
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+that auto-enable this rule:
+
+- `profile: mdsmith-strict` activates with
+  `max-run: 2`, `forbid-escaped-in-run: true`, and
+  `forbid-adjacent-same-delim: true`.
+- `profile: mdsmith-relaxed` does not activate
+  this rule.
+
+User overrides on top of the profile still win via
+deep-merge.
+
+### Detection
+
+Read the source line by line, skipping ranges
+covered by `*ast.CodeSpan`, `*ast.FencedCodeBlock`,
+and `*ast.CodeBlock`.
+
+For each non-code range:
+
+1. Find every contiguous run of `*` or `_`. If the
+   run length exceeds `max-run`, emit one
+   diagnostic.
+2. If the run contains a backslash-escaped `*` or
+   `_` adjacent to it (`*\*` or `_\_`) and
+   `forbid-escaped-in-run` is true, emit one
+   diagnostic.
+3. Find `<delim>word<delim>word<delim>` patterns
+   where the same single-character delimiter appears
+   three times on the line with non-whitespace
+   between them. When `forbid-adjacent-same-delim`
+   is true, emit one diagnostic.
+
+### Auto-fix
+
+No auto-fix. The right rewrite depends on author
+intent, which the rule cannot recover. The
+diagnostic message suggests adding a space, an HTML
+entity, or splitting the run.
+
+### Error messages
+
+```text
+emphasis run of {n} delimiters; max is {max-run}
+escaped delimiter inside emphasis run
+adjacent same-delimiter emphasis is ambiguous
+```
+
+## Tasks
+
+1. Scaffold `internal/rules/ambiguousemphasis/`.
+2. Implement source-range computation that excludes
+   code spans and code blocks.
+3. Implement the three pattern detectors.
+4. Implement `rule.Configurable` for `max-run`,
+   `forbid-escaped-in-run`, and
+   `forbid-adjacent-same-delim`.
+5. Register as MDS045 in category `meta`.
+6. Add fixture tests covering each pattern,
+   patterns inside code spans (must not flag),
+   patterns inside fenced code blocks (must not
+   flag), and the rant's exact strings
+   (`*****\*a*`, `***Peter* Piper**`).
+7. Add rule README.
+
+## Acceptance Criteria
+
+- [ ] `**bold**` emits no diagnostic.
+- [ ] `***bold-italic***` emits one diagnostic when
+      `max-run: 2`.
+- [ ] `*****\*a*` emits diagnostics for both run
+      length and escaped-in-run.
+- [ ] `__a__b__` emits one
+      adjacent-same-delim diagnostic.
+- [ ] The same patterns inside `` `code` `` or a
+      fenced block emit no diagnostic.
+- [ ] No auto-fix is attempted.
+- [ ] Rule is disabled by default.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/112_flavor-profiles.md
+++ b/plan/112_flavor-profiles.md
@@ -9,7 +9,7 @@ summary: >-
   Three profiles ship: portable (CommonMark
   everywhere), github (GFM on github.com), and plain
   (Markdown that survives `cat`).
-model: ""
+model: opus
 ---
 # Flavor profiles refactor
 

--- a/plan/112_flavor-profiles.md
+++ b/plan/112_flavor-profiles.md
@@ -1,0 +1,220 @@
+---
+id: 112
+title: Flavor profiles refactor
+status: "🔲"
+summary: >-
+  Refactor MDS034 from "extension support detector"
+  to a flavor orchestrator. Add a profile concept
+  that bundles extension policy with style policy.
+  Selecting `flavor: mdsmith-strict` activates
+  MDS039-MDS045 with preset settings, giving teams a
+  single knob for the strict-Markdown subset
+  proposed in the bgslabs.org rant review.
+model: ""
+---
+# Flavor profiles refactor
+
+## Goal
+
+Make `flavor:` the single knob for "what subset of
+Markdown does this project use." Today MDS034 only
+answers which extensions a renderer supports. This
+plan extends it to also answer which CommonMark
+constructs a team allows and which style choices
+they pin. One config key, one mental model.
+
+## Background
+
+### Today's flavor model
+
+MDS034
+([internal/rules/markdownflavor/](../internal/rules/markdownflavor/))
+defines three flavors: `commonmark`, `gfm`,
+`goldmark`. Each declares which of 12 extension
+features it supports. The rule emits diagnostics
+when the configured flavor does not support a
+feature the file uses.
+
+Settings:
+
+```yaml
+rules:
+  markdown-flavor:
+    flavor: gfm
+```
+
+The flavor controls only MDS034's own diagnostics.
+Other rules (MDS012 no-bare-urls, MDS018
+no-emphasis-as-heading, etc.) are configured
+independently.
+
+### What plans 105-111 add
+
+Seven new rules cover MDS039 through MDS045. Each
+restricts a different CommonMark ambiguity. Today
+they would each be enabled and configured
+separately:
+
+```yaml
+rules:
+  no-inline-html: true
+  no-reference-style: { allow-footnotes: false }
+  emphasis-style: { bold: asterisk, italic: underscore }
+  horizontal-rule-style: { style: dash, length: 3 }
+  list-marker-style: { style: dash }
+  ordered-list-numbering: { style: sequential, start: 1 }
+  ambiguous-emphasis: { max-run: 2 }
+  markdown-flavor: { flavor: commonmark }
+```
+
+Eight separate knobs to land on a strict
+Markdown setup. The user request is to collapse
+these into one.
+
+### Why "profile" and not "flavor"
+
+A flavor today corresponds to a renderer. Adding
+`mdsmith-strict` as a flavor would suggest there is
+a renderer by that name, which there is not. The
+plan introduces **profiles** as a layer above
+flavors. A profile names a flavor *plus* a set of
+rule presets. Selecting a profile applies both.
+
+This keeps the existing `flavor:` enum honest
+(`commonmark | gfm | goldmark`) and adds a separate
+`profile:` field for opinionated bundles.
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  markdown-flavor:
+    flavor: commonmark        # renderer grammar
+    profile: mdsmith-strict   # opinionated bundle
+```
+
+Both fields are optional. `flavor` defaults to
+`commonmark`. `profile` defaults to empty.
+
+When a profile is set, it implies a flavor. Setting
+both is allowed only when they agree; a mismatch
+(e.g. `flavor: gfm` with a profile that requires
+`commonmark`) is a config error.
+
+### Built-in profiles
+
+Two profiles ship initially:
+
+- **`mdsmith-strict`** — `flavor: commonmark`, all
+  of MDS039-MDS045 enabled with the recommended
+  defaults (no inline HTML, no reference links,
+  asterisk bold, underscore italic, dash HR, dash
+  list marker, sequential ordered numbering, max
+  emphasis run 2).
+- **`mdsmith-relaxed`** — `flavor: gfm`, MDS039
+  enabled with `<details>` and `<summary>` in the
+  allowlist, MDS040 and MDS043 enabled with
+  defaults, the rest disabled. Targets teams that
+  use GFM for GitHub rendering but still want
+  consistent emphasis and bullet style.
+
+Profiles are declared in
+`internal/rules/markdownflavor/profiles.go` as a
+table: profile name → flavor + rule preset map.
+
+### How preset application works
+
+Profiles do not re-implement the rule logic. They
+push settings into the existing rule registry
+during config load. The flow:
+
+1. Config loader reads `markdown-flavor.profile`.
+2. If non-empty, it looks up the profile table.
+3. For each rule named in the profile preset, the
+   loader applies the preset *as a base layer*
+   under any user override.
+
+This piggybacks on the existing deep-merge config
+([plan 97](97_deep-merge-config.md)). User overrides
+still win — a team can set
+`profile: mdsmith-strict` and then opt back in to
+inline HTML for `<sub>` and `<sup>` by setting
+`rules.no-inline-html.allow: [sub, sup]`. The
+preset provides the floor.
+
+### MDS034 runtime changes
+
+MDS034's `Check()` does not gain new diagnostics.
+Its job stays the same. Detect unsupported
+extensions for the configured flavor. The profile
+mechanism is a config-layer concern. The reasons:
+
+- Each rule already owns its detection logic.
+  Duplicating into MDS034 would create two places
+  that emit the same diagnostic.
+- Tests for MDS039-MDS045 should not depend on
+  MDS034 being enabled.
+- Disabling MDS034 should not silently disable the
+  style rules a profile turned on.
+
+What MDS034 does gain: a `profile` field in its
+`ApplySettings` handler, plus validation that
+`flavor` and `profile` agree.
+
+### Failure modes
+
+- Unknown profile name → config error at load time
+  with the list of valid names.
+- Profile/flavor disagreement → config error naming
+  both values.
+- Profile names a rule that no longer exists →
+  config error naming the rule. Profiles are
+  versioned with the codebase; this case only
+  fires after a removal.
+
+## Tasks
+
+1. Add `profiles.go` in
+   `internal/rules/markdownflavor/` with the
+   profile table and a `Lookup(name string)
+   (Profile, error)` helper.
+2. Extend `ApplySettings` on MDS034 to accept
+   `profile` and validate against `flavor`.
+3. Wire profile-preset application into the config
+   loader as a base layer beneath user overrides.
+   Reuse the deep-merge path from plan 97.
+4. Add a `profile` field to the kinds resolution
+   output ([plan 95](95_kind-rule-resolution-cli.md))
+   so `mdsmith kinds --explain` shows which rules a
+   profile turned on.
+5. Document the two built-in profiles in
+   `docs/guides/directives/enforcing-structure.md`
+   or a new `docs/reference/profiles.md`.
+6. Add fixture tests under
+   `internal/rules/MDS034-markdown-flavor/profiles/`
+   covering each profile applied to a passing file
+   and a failing file.
+
+## Acceptance Criteria
+
+- [ ] Setting `profile: mdsmith-strict` enables
+      MDS039-MDS045 with documented preset values.
+- [ ] User overrides win over profile presets via
+      deep-merge (e.g. extending the inline-HTML
+      allowlist).
+- [ ] Setting both `flavor: gfm` and a profile that
+      requires `commonmark` produces a config error.
+- [ ] Setting an unknown profile name produces a
+      config error naming the field.
+- [ ] `mdsmith kinds --explain` reports which rules
+      a profile activated and with which settings.
+- [ ] MDS034 itself does not emit new diagnostic
+      types; all profile-driven diagnostics come
+      from MDS039-MDS045.
+- [ ] Disabling MDS034 does not disable the rules a
+      profile turned on (the preset has already
+      been applied at config load).
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/112_flavor-profiles.md
+++ b/plan/112_flavor-profiles.md
@@ -49,7 +49,7 @@ independently.
 
 ### What plans 105-111 add
 
-Seven new rules cover MDS039 through MDS045. Each
+Seven new rules cover MDS041 through MDS047. Each
 restricts a different CommonMark ambiguity. Today
 they would each be enabled and configured
 separately:
@@ -108,15 +108,15 @@ Three profiles ship initially. Each names a target.
 
 - **`portable`** — Markdown that renders the same in
   every CommonMark parser. `flavor: commonmark`, all
-  of MDS039-MDS045 enabled with recommended defaults
+  of MDS041-MDS047 enabled with recommended defaults
   (no inline HTML, no reference links, asterisk
   bold, underscore italic, dash HR, dash list
   marker, sequential ordered numbering, max emphasis
   run 2).
 - **`github`** — Markdown that renders well on
-  github.com. `flavor: gfm`, MDS039 enabled with
+  github.com. `flavor: gfm`, MDS041 enabled with
   `<details>` and `<summary>` in the allowlist,
-  MDS040 and MDS043 enabled with defaults, the rest
+  MDS042 and MDS045 enabled with defaults, the rest
   disabled. Targets teams that use GFM for GitHub
   rendering but still want consistent emphasis and
   bullet style.
@@ -124,7 +124,7 @@ Three profiles ship initially. Each names a target.
   rendered output should look about the same as the
   source viewed in a plaintext reader. Same
   activations as `portable` today, plus
-  `allow-comments: false` on MDS039 (HTML comments
+  `allow-comments: false` on MDS041 (HTML comments
   leak through as `<!-- ... -->` in plaintext).
 
 The `plain` profile sits close to `portable` in
@@ -182,7 +182,7 @@ mechanism is a config-layer concern. The reasons:
 - Each rule already owns its detection logic.
   Duplicating into MDS034 would create two places
   that emit the same diagnostic.
-- Tests for MDS039-MDS045 should not depend on
+- Tests for MDS041-MDS047 should not depend on
   MDS034 being enabled.
 - Disabling MDS034 should not silently disable the
   style rules a profile turned on.
@@ -228,13 +228,13 @@ What MDS034 does gain: a `profile` field in its
 ## Acceptance Criteria
 
 - [ ] Setting `profile: portable` enables
-      MDS039-MDS045 with documented preset values.
-- [ ] Setting `profile: github` enables MDS039,
-      MDS040, MDS043 with their documented presets
+      MDS041-MDS047 with documented preset values.
+- [ ] Setting `profile: github` enables MDS041,
+      MDS042, MDS045 with their documented presets
       and leaves the rest disabled.
 - [ ] Setting `profile: plain` enables
-      MDS039-MDS045 with the portable presets plus
-      `allow-comments: false` on MDS039.
+      MDS041-MDS047 with the portable presets plus
+      `allow-comments: false` on MDS041.
 - [ ] User overrides win over profile presets via
       deep-merge (e.g. extending the inline-HTML
       allowlist).
@@ -246,7 +246,7 @@ What MDS034 does gain: a `profile` field in its
       a profile activated and with which settings.
 - [ ] MDS034 itself does not emit new diagnostic
       types; all profile-driven diagnostics come
-      from MDS039-MDS045.
+      from MDS041-MDS047.
 - [ ] Disabling MDS034 does not disable the rules a
       profile turned on (the preset has already
       been applied at config load).

--- a/plan/112_flavor-profiles.md
+++ b/plan/112_flavor-profiles.md
@@ -6,10 +6,9 @@ summary: >-
   Refactor MDS034 from "extension support detector"
   to a flavor orchestrator. Add a profile concept
   that bundles extension policy with style policy.
-  Selecting `flavor: mdsmith-strict` activates
-  MDS039-MDS045 with preset settings, giving teams a
-  single knob for the strict-Markdown subset
-  proposed in the bgslabs.org rant review.
+  Three profiles ship: portable (CommonMark
+  everywhere), github (GFM on github.com), and plain
+  (Markdown that survives `cat`).
 model: ""
 ---
 # Flavor profiles refactor
@@ -74,7 +73,7 @@ these into one.
 ### Why "profile" and not "flavor"
 
 A flavor today corresponds to a renderer. Adding
-`mdsmith-strict` as a flavor would suggest there is
+`portable` as a flavor would suggest there is
 a renderer by that name, which there is not. The
 plan introduces **profiles** as a layer above
 flavors. A profile names a flavor *plus* a set of
@@ -92,7 +91,7 @@ This keeps the existing `flavor:` enum honest
 rules:
   markdown-flavor:
     flavor: commonmark        # renderer grammar
-    profile: mdsmith-strict   # opinionated bundle
+    profile: portable   # opinionated bundle
 ```
 
 Both fields are optional. `flavor` defaults to
@@ -105,20 +104,48 @@ both is allowed only when they agree; a mismatch
 
 ### Built-in profiles
 
-Two profiles ship initially:
+Three profiles ship initially. Each names a target.
 
-- **`mdsmith-strict`** — `flavor: commonmark`, all
-  of MDS039-MDS045 enabled with the recommended
-  defaults (no inline HTML, no reference links,
-  asterisk bold, underscore italic, dash HR, dash
-  list marker, sequential ordered numbering, max
-  emphasis run 2).
-- **`mdsmith-relaxed`** — `flavor: gfm`, MDS039
-  enabled with `<details>` and `<summary>` in the
-  allowlist, MDS040 and MDS043 enabled with
-  defaults, the rest disabled. Targets teams that
-  use GFM for GitHub rendering but still want
-  consistent emphasis and bullet style.
+- **`portable`** — Markdown that renders the same in
+  every CommonMark parser. `flavor: commonmark`, all
+  of MDS039-MDS045 enabled with recommended defaults
+  (no inline HTML, no reference links, asterisk
+  bold, underscore italic, dash HR, dash list
+  marker, sequential ordered numbering, max emphasis
+  run 2).
+- **`github`** — Markdown that renders well on
+  github.com. `flavor: gfm`, MDS039 enabled with
+  `<details>` and `<summary>` in the allowlist,
+  MDS040 and MDS043 enabled with defaults, the rest
+  disabled. Targets teams that use GFM for GitHub
+  rendering but still want consistent emphasis and
+  bullet style.
+- **`plain`** — Markdown that survives `cat`. The
+  rendered output should look about the same as the
+  source viewed in a plaintext reader. Same
+  activations as `portable` today, plus
+  `allow-comments: false` on MDS039 (HTML comments
+  leak through as `<!-- ... -->` in plaintext).
+
+The `plain` profile sits close to `portable` in
+this plan. A truly plaintext-faithful profile would
+need extra rules that do not exist yet:
+
+- **no-emphasis** — forbid `*` and `_` runs entirely.
+  In plaintext readers they appear as literal
+  characters around the word, which is noise.
+- **no-fenced-code** — require indented code blocks
+  rather than fenced ones, since the fence delimiters
+  show up literally.
+- **prefer-bare-urls** — invert MDS012 so
+  `https://example.com` is preferred over
+  `[text](url)`, since the latter renders as
+  `[text](url)` literally in plaintext.
+
+These three rules are out of scope for this plan
+and would land as plans 113-115. When they ship,
+the `plain` profile gains them automatically and
+diverges from `portable`.
 
 Profiles are declared in
 `internal/rules/markdownflavor/profiles.go` as a
@@ -139,7 +166,7 @@ during config load. The flow:
 This piggybacks on the existing deep-merge config
 ([plan 97](97_deep-merge-config.md)). User overrides
 still win — a team can set
-`profile: mdsmith-strict` and then opt back in to
+`profile: portable` and then opt back in to
 inline HTML for `<sub>` and `<sup>` by setting
 `rules.no-inline-html.allow: [sub, sup]`. The
 preset provides the floor.
@@ -189,7 +216,7 @@ What MDS034 does gain: a `profile` field in its
    output ([plan 95](95_kind-rule-resolution-cli.md))
    so `mdsmith kinds --explain` shows which rules a
    profile turned on.
-5. Document the two built-in profiles in
+5. Document the three built-in profiles in
    `docs/guides/directives/enforcing-structure.md`
    or a new `docs/reference/profiles.md`.
 6. Add fixture tests under
@@ -199,8 +226,14 @@ What MDS034 does gain: a `profile` field in its
 
 ## Acceptance Criteria
 
-- [ ] Setting `profile: mdsmith-strict` enables
+- [ ] Setting `profile: portable` enables
       MDS039-MDS045 with documented preset values.
+- [ ] Setting `profile: github` enables MDS039,
+      MDS040, MDS043 with their documented presets
+      and leaves the rest disabled.
+- [ ] Setting `profile: plain` enables
+      MDS039-MDS045 with the portable presets plus
+      `allow-comments: false` on MDS039.
 - [ ] User overrides win over profile presets via
       deep-merge (e.g. extending the inline-HTML
       allowlist).

--- a/plan/112_flavor-profiles.md
+++ b/plan/112_flavor-profiles.md
@@ -143,8 +143,9 @@ need extra rules that do not exist yet:
   `[text](url)` literally in plaintext.
 
 These three rules are out of scope for this plan
-and would land as plans 113-115. When they ship,
-the `plain` profile gains them automatically and
+and would land in follow-up plans for the
+plaintext-focused rules. When they ship, the
+`plain` profile gains them automatically and
 diverges from `portable`.
 
 Profiles are declared in

--- a/plan/113_user-defined-profiles.md
+++ b/plan/113_user-defined-profiles.md
@@ -9,7 +9,7 @@ summary: >-
   shape as the built-in `portable`, `github`, and
   `plain`. No inheritance — each profile stands
   alone.
-model: ""
+model: sonnet
 ---
 # User-defined flavor profiles
 

--- a/plan/113_user-defined-profiles.md
+++ b/plan/113_user-defined-profiles.md
@@ -1,0 +1,195 @@
+---
+id: 113
+title: User-defined flavor profiles
+status: "🔲"
+summary: >-
+  Extend the profile system from plan 112 with a
+  top-level `profiles:` key in `.mdsmith.yml`. Teams
+  can define their own profile inline, with the same
+  shape as the built-in `portable`, `github`, and
+  `plain`. No inheritance — each profile stands
+  alone.
+model: ""
+---
+# User-defined flavor profiles
+
+## Goal
+
+Let a team define a profile inline in their
+`.mdsmith.yml` without forking mdsmith. The three
+built-in profiles cover common cases; this plan
+covers everything else. A team that wants "GFM plus
+no inline HTML plus dash bullets but allow
+footnotes" gets there in seven lines of YAML.
+
+## Background
+
+### What plan 112 ships
+
+[Plan 112](112_flavor-profiles.md) ships profiles
+as a closed table baked into the binary. The
+`Lookup(name string) (Profile, error)` helper
+returns one of `portable`, `github`, or `plain`,
+or a config error. Adding a fourth profile requires
+a code change.
+
+### Why inline and not external
+
+[Plan 112's review](#) considered three ways to
+open the system: inline in `.mdsmith.yml`, separate
+profile files, and inheritance via `extends:`. This
+plan ships only the inline form. Reasons:
+
+- The repo's `.mdsmith.yml` is already the source
+  of truth for everything else mdsmith reads.
+  Teams know where to look.
+- Separate files add a path-resolution layer
+  (relative? absolute? from which directory?) that
+  pays off mostly when the profile is shared across
+  repos. Within one repo, inline is shorter.
+- `extends:` is genuinely useful but doubles the
+  validation surface. Defer until a team asks.
+
+A team that wants cross-repo reuse can copy the
+seven lines, which is the same friction as managing
+a separate file with no resolver bugs.
+
+## Design
+
+### Configuration
+
+A new top-level `profiles:` key in `.mdsmith.yml`:
+
+```yaml
+profiles:
+  our-team:
+    flavor: gfm
+    rules:
+      no-inline-html:
+        allow: [details, summary, kbd]
+      list-marker-style:
+        style: dash
+      no-reference-style:
+        allow-footnotes: true
+
+rules:
+  markdown-flavor:
+    profile: our-team
+```
+
+The `profiles:` map mirrors the built-in profile
+table from plan 112. Each entry is a
+`{ flavor, rules }` pair. The `rules` block uses
+the same schema as the top-level `rules` block.
+
+### Name collisions
+
+User-defined names must not collide with the three
+built-in profile names. Defining a `profiles.portable`
+in `.mdsmith.yml` produces a config error. The
+built-in names are reserved so docs and tutorials
+keep meaning what they say.
+
+### Resolution order
+
+When `markdown-flavor.profile` resolves:
+
+1. Look up the name in user-defined `profiles:`
+   first.
+2. Fall back to the built-in table.
+3. If neither matches, emit a config error listing
+   both sets of names.
+
+User profiles cannot shadow built-ins. Collisions
+are rejected at parse time. The lookup order is
+documented anyway so future maintainers see the
+precedence explicitly.
+
+### Validation
+
+Each user-defined profile is validated at config
+load:
+
+- `flavor` must be one of `commonmark | gfm |
+  goldmark`.
+- Each key under `rules:` must name a registered
+  rule.
+- Each rule's settings must validate against that
+  rule's existing schema (the same code path that
+  validates a top-level `rules:` block).
+
+Validation errors name the profile and the rule:
+`profile "our-team" rule "no-inline-html": unknown
+setting "allowed"`.
+
+### Interaction with the user's `rules:` block
+
+User-defined profiles apply as a base layer beneath
+any top-level `rules:` overrides. This matches how
+built-in profiles work in plan 112. A team can set
+`profile: our-team` and then override one rule in
+the top-level `rules:` block. The override wins.
+
+### MDS034 changes
+
+`Lookup(name)` from plan 112 grows a second arg —
+the user-defined profile map from config. The
+signature becomes
+`Lookup(name string, userProfiles map[string]Profile)
+(Profile, error)`. The config loader reads
+`profiles:` once at startup and passes the map
+through.
+
+No new diagnostics. The check logic in MDS034 is
+unchanged.
+
+## Tasks
+
+1. Add `Profiles` field to the top-level config
+   struct in `internal/config/`.
+2. Add YAML parsing for the `profiles:` block with
+   the same schema as the built-in profile table.
+3. Add reserved-name validation rejecting
+   `portable`, `github`, and `plain` as user names.
+4. Per-rule settings validation: reuse the
+   `ApplySettings` validation path each rule
+   already implements, called against an empty
+   instance.
+5. Extend `markdownflavor.Lookup` to consult the
+   user map first, then the built-in table.
+6. Wire the user map through the config loader to
+   the lookup site.
+7. Update `mdsmith kinds --explain` so user profile
+   names appear with a `(user)` suffix to
+   distinguish them from built-ins.
+8. Add fixture tests under
+   `internal/rules/MDS034-markdown-flavor/profiles/user/`
+   covering: a valid user profile, a name collision
+   with a built-in, an unknown rule name, an
+   invalid rule setting, and a top-level rules
+   override on a user profile.
+9. Document `profiles:` in the same place plan 112
+   documents the built-ins.
+
+## Acceptance Criteria
+
+- [ ] `profiles:` block in `.mdsmith.yml` defines a
+      named profile with `flavor:` and `rules:`.
+- [ ] `markdown-flavor.profile: our-team` selects a
+      user-defined profile and applies its rule
+      presets.
+- [ ] Defining `profiles.portable` (or `github` /
+      `plain`) produces a config error naming the
+      reserved name.
+- [ ] An unknown profile name lists both built-in
+      and user-defined options in the error
+      message.
+- [ ] Top-level `rules:` overrides win over user
+      profile presets via deep-merge.
+- [ ] Invalid rule names or settings inside a user
+      profile produce a config error naming the
+      profile and the rule.
+- [ ] `mdsmith kinds --explain` distinguishes user
+      profiles from built-ins in its output.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/113_user-defined-profiles.md
+++ b/plan/113_user-defined-profiles.md
@@ -35,10 +35,10 @@ a code change.
 
 ### Why inline and not external
 
-[Plan 112's review](#) considered three ways to
-open the system: inline in `.mdsmith.yml`, separate
-profile files, and inheritance via `extends:`. This
-plan ships only the inline form. Reasons:
+Plan 112 considered three ways to open the system:
+inline in `.mdsmith.yml`, separate profile files,
+and inheritance via `extends:`. This plan ships
+only the inline form. Reasons:
 
 - The repo's `.mdsmith.yml` is already the source
   of truth for everything else mdsmith reads.

--- a/plan/99_no-inline-html.md
+++ b/plan/99_no-inline-html.md
@@ -1,0 +1,199 @@
+---
+id: 99
+title: No inline HTML rule
+status: "🔲"
+summary: >-
+  New rule MDS039 that flags raw HTML in Markdown
+  (block and inline), with an allowlist for tags that
+  have no Markdown equivalent. Closes the largest
+  attack surface for XSS and the largest source of
+  parser ambiguity, per the bgslabs.org/why-are-we-
+  using-markdown rant.
+model: ""
+---
+# No inline HTML rule
+
+## Goal
+
+Let users forbid raw HTML in their Markdown. Inline
+HTML drives most XSS CVEs in Markdown renderers. It
+also drives most parser ambiguity, since every
+Markdown parser must also be a forgiving HTML parser.
+Teams that adopt this rule keep their corpus in pure
+Markdown plus the project's [directive
+vocabulary](../docs/background/archetypes/generated-section/README.md).
+
+## Background
+
+### What counts as inline HTML
+
+Goldmark's CommonMark parser produces two AST node
+types for raw HTML:
+
+- `*ast.HTMLBlock` — block-level HTML (a `<div>` on
+  its own line, an HTML comment paragraph, a `<table>`
+  block).
+- `*ast.RawHTML` — inline HTML inside a paragraph
+  (`text <span>marked</span> text`, `<br>`, `<kbd>x</kbd>`).
+
+The PI block parser
+([internal/lint/pi.go](../internal/lint/pi.go))
+already replaces `<?name ... ?>` directives with a
+distinct AST node, so directives are *not* HTMLBlocks
+and will not be flagged by this rule. HTML comments
+(`<!-- ... -->`) remain `*ast.HTMLBlock`s — see the
+allowlist discussion below.
+
+### Why a separate rule from MDS034
+
+MDS034 (markdown-flavor) restricts which *Markdown
+extensions* a file may use. Raw HTML is part of
+CommonMark itself, so MDS034 cannot flag it without
+overloading its meaning. A dedicated rule keeps the
+two policies independently togglable: a team can
+allow GFM tables but still forbid raw `<table>`.
+
+### Prior art
+
+- markdownlint's MD033 (`no-inline-html`) takes the
+  same shape: a single boolean plus an `allowed_elements`
+  list. We follow that interface so users migrating
+  from markdownlint get a familiar knob.
+- markdownlint flags by tag name (string). We do the
+  same — the AST node carries the raw bytes, from
+  which we extract the tag name with a small regex
+  (`<\/?([a-zA-Z][a-zA-Z0-9-]*)`).
+
+## Design
+
+### Configuration
+
+```yaml
+rules:
+  no-inline-html:
+    allow: []          # tag names that are permitted
+    allow-comments: true   # <!-- ... --> stay legal by default
+```
+
+Category: `meta`. Disabled by default (opt-in) — the
+mdsmith repo itself uses inline HTML in places (e.g.
+`<sub>`, `<details>` in docs) and existing users
+should not regress.
+
+`allow` is a list-typed setting. It **replaces** by
+default, matching the rest of the codebase except
+`placeholders:`. A team that wants to extend the
+default empty list does so by listing every tag they
+need.
+
+### Detection
+
+Walk `f.AST`. For every `*ast.HTMLBlock` and every
+`*ast.RawHTML`:
+
+1. Extract the tag name (lowercase) from the raw
+   bytes. If the bytes start with `<!--`, treat as a
+   comment and skip when `allow-comments` is true.
+2. If the tag name is in `allow`, skip.
+3. Otherwise emit a diagnostic at the node's start
+   line/column: `inline HTML <{tag}> is not allowed;
+   use a Markdown construct or an mdsmith directive
+   instead`.
+
+Closing tags (`</div>`) emit no extra diagnostic —
+the opening tag already produced one. Self-closing
+tags (`<br/>`, `<img/>`) count once.
+
+### What is *not* flagged
+
+- Fenced and indented code blocks (the AST keeps
+  these as `*ast.FencedCodeBlock` / `*ast.CodeBlock`,
+  not HTML).
+- Inline code spans (`*ast.CodeSpan`).
+- Autolinks (`<https://example.com>`) and email
+  autolinks — these are `*ast.AutoLink`, not RawHTML.
+- mdsmith directives (`<?name ... ?>`) — already
+  carved out by the PI parser.
+- HTML entities in text (`&amp;`, `&#x2014;`) — these
+  are `*ast.Text` after entity decoding; flagging
+  them would be a separate rule.
+
+### Auto-fix
+
+No auto-fix in v1. The right replacement is
+context-dependent: `<br>` may want `  \n`, `<b>` may
+want `**`, `<details>` wants a future
+`<?details?>` directive that does not exist yet.
+Emitting a wrong fix is worse than emitting none.
+Track a follow-up plan once a directive replacement
+exists for the most common allowlisted tags.
+
+### Error messages
+
+Single message template, lowercase, no trailing
+punctuation, per the project's code style:
+
+```text
+inline HTML <{tag}> is not allowed
+```
+
+When `allow-comments: false` flags a comment, the
+tag is reported as `<!--` so the message stays
+distinct.
+
+## Tasks
+
+1. Scaffold `internal/rules/noinlinehtml/` with
+   `rule.go`, `rule_test.go`, and the `init()`
+   `rule.Register` call.
+2. Implement `Check()` walking the AST for
+   `*ast.HTMLBlock` and `*ast.RawHTML`.
+3. Add tag-name extraction helper with unit tests
+   covering opening, closing, self-closing,
+   uppercase, hyphenated (`<my-tag>`), and malformed
+   inputs.
+4. Implement `rule.Configurable` for `allow` and
+   `allow-comments`; document `allow` as
+   replace-mode in the rule's `ApplySettings`
+   handler.
+5. Implement `rule.Defaultable` returning `false`
+   so the rule is opt-in.
+6. Register as MDS039 in category `meta`.
+7. Add fixture tests in
+   `internal/rules/MDS039-no-inline-html/` with
+   `good/` and `bad/` examples (paragraph with
+   `<span>`, block with `<div>`, comment, allowlisted
+   tag, directive, autolink — verify the directive
+   and autolink fixtures stay clean).
+8. Add rule README following the MDS012 template.
+9. Update the docs catalog and the rule index so
+   `<?catalog?>` regenerates the entry.
+10. Run `mdsmith check .` and `go test ./...` until
+    both pass.
+
+## Acceptance Criteria
+
+- [ ] `<div>...</div>` on its own line emits one
+      diagnostic naming the `<div>` tag.
+- [ ] `text <span>x</span> text` inside a paragraph
+      emits one diagnostic naming the `<span>` tag.
+- [ ] `<br/>` and `<br>` both emit exactly one
+      diagnostic.
+- [ ] A tag listed in `allow:` emits no diagnostic.
+- [ ] `<!-- comment -->` emits no diagnostic when
+      `allow-comments: true`, and one diagnostic
+      naming `<!--` when `allow-comments: false`.
+- [ ] `<?include file: foo.md ?>` and `<?catalog ... ?>`
+      emit no diagnostic.
+- [ ] `<https://example.com>` autolink emits no
+      diagnostic.
+- [ ] Fenced code blocks containing HTML emit no
+      diagnostic.
+- [ ] Rule is disabled by default; enabling it via
+      `rules.no-inline-html: true` activates checking
+      with empty allowlist.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues
+- [ ] `mdsmith check .` passes on the repo with the
+      rule disabled (no regression for existing
+      docs).


### PR DESCRIPTION
## Summary

This PR is **planning documentation only** — no rule packages, no config-loader changes, no behavior changes. Each plan describes a future implementation; the plans are tracked in `PLAN.md` and will be picked up in follow-up PRs (some on sonnet, some on opus, per the assigned `model:` field).

## What's planned

### Flavor profiles system (plan 112, opus)

A `profile:` configuration field that bundles extension policy with style policy. Three built-in profiles ship:

- **`portable`** — CommonMark-compatible Markdown with strict style rules. Renders the same in every parser.
- **`github`** — GFM-flavored Markdown optimized for github.com rendering with selective style enforcement.
- **`plain`** — Markdown that survives `cat`. Same activations as `portable` plus `allow-comments: false` on MDS039.

Profiles apply rule presets as a base layer beneath user overrides via the existing deep-merge config (plan 97). MDS034's `Check()` does not gain new diagnostics — the profile mechanism is config-layer only, so each rule stays independently testable.

### Seven new linting rules (plans 105-111)

| Plan | Rule | Article concern |
|------|------|-----------------|
| 105 | MDS039 no-inline-html | XSS CVEs and parser ambiguity (Exhibit B) |
| 106 | MDS040 emphasis-style | Bold/italic delimiter ambiguity (Exhibit A) |
| 107 | MDS041 no-reference-style | CFG → CSG grammar shift (Exhibit D) |
| 108 | MDS042 horizontal-rule-style | HR / setext heading collision (Exhibit C) |
| 109 | MDS043 list-marker-style | `-` vs `*` vs `+` (Exhibit C) |
| 110 | MDS044 ordered-list-numbering | Source/output mismatch (Exhibit C) |
| 111 | MDS045 ambiguous-emphasis | Stress-case parser inputs and ReDoS shape (Exhibit A) |

All seven follow the same architecture: `Check()` + `Fix()` (where determinable) + `Configurable` + `Defaultable`. Each is opt-in, with profiles activating them in bundles.

### User-defined profiles (plan 113)

A top-level `profiles:` key in `.mdsmith.yml` for inline profile definitions. Users define their own bundle with the same `{ flavor, rules }` shape as the built-ins. Built-in names are reserved; collisions reject at parse time. No `extends:` inheritance — that's deferred until a team asks.

## Notes for reviewers

- These plans cite the bgslabs.org "Why are we using Markdown?" rant as the source for the listed concerns.
- Implementation will land in follow-up PRs, one per plan, picked up per the `model:` assignment.
- The `<?...?>` directive shape is unconditionally allowed by MDS039 (both block and inline forms) and not affected by `allow:` or `allow-comments:`.

https://claude.ai/code/session_01LkJB3kTH92kLzpFKVpysoK