### PR TITLE
Add MDS046 rule for ordered list numbering style enforcement

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -26,7 +26,7 @@ footer: |
 | 107 | 🔲     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                      |
 | 108 | 🔲     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                      |
 | 109 | 🔲     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                              |
-| 110 | 🔲     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
+| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
 | 111 | 🔲     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                            |
 | 112 | 🔲     | opus   | [Flavor profiles refactor](plan/112_flavor-profiles.md)                                              |
 | 113 | 🔲     | sonnet | [User-defined flavor profiles](plan/113_user-defined-profiles.md)                                    |

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -52,6 +52,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/nomultipleblanks"
 	_ "github.com/jeduden/mdsmith/internal/rules/notrailingpunctuation"
 	_ "github.com/jeduden/mdsmith/internal/rules/notrailingspaces"
+	_ "github.com/jeduden/mdsmith/internal/rules/orderedlistnumbering"
 	_ "github.com/jeduden/mdsmith/internal/rules/paragraphreadability"
 	_ "github.com/jeduden/mdsmith/internal/rules/paragraphstructure"
 	_ "github.com/jeduden/mdsmith/internal/rules/requiredstructure"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/neurosnap/sentences v1.1.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/tetratelabs/wazero v1.11.0
 	github.com/yuin/goldmark v1.8.2
 	go.abhg.dev/goldmark/frontmatter v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -227,7 +228,6 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
-	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/neurosnap/sentences v1.1.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/tetratelabs/wazero v1.11.0
 	github.com/yuin/goldmark v1.8.2
 	go.abhg.dev/goldmark/frontmatter v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -228,6 +227,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
+	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.12.0 // indirect

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/nomultipleblanks"
 	_ "github.com/jeduden/mdsmith/internal/rules/notrailingpunctuation"
 	_ "github.com/jeduden/mdsmith/internal/rules/notrailingspaces"
+	_ "github.com/jeduden/mdsmith/internal/rules/orderedlistnumbering"
 	_ "github.com/jeduden/mdsmith/internal/rules/paragraphreadability"
 	_ "github.com/jeduden/mdsmith/internal/rules/paragraphstructure"
 	_ "github.com/jeduden/mdsmith/internal/rules/requiredstructure"

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -124,8 +124,22 @@ wrap: markdown
 
 When the fix changes a marker's digit width (for example, item 10
 growing from `1.` to `10.`), the rule re-indents the item's
-continuation lines so the content column still aligns with the
-new marker prefix.
+continuation lines and any nested blocks so the content column
+still aligns with the new marker prefix. Blank lines inside the
+item are left unchanged so the fix does not introduce trailing
+whitespace.
+
+Each list is checked independently. A nested ordered
+list inside a list item is treated as its own list. The
+outer list's style does not exempt the nested list.
+
+When a list's first item starts at a number different
+from the configured `start`, the rule emits only the
+start-mismatch diagnostic for that list. Per-item
+diagnostics would use the configured `start` as their
+baseline, matching what auto-fix produces. Reporting
+them alongside "wrong start" would name renumbering
+that the start fix already covers.
 
 ## Meta-Information
 

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -1,0 +1,139 @@
+---
+id: MDS046
+name: ordered-list-numbering
+status: ready
+description: Ordered list items must be numbered in the configured style.
+---
+# MDS046: ordered-list-numbering
+
+Ordered list items must be numbered in the configured style.
+
+## Settings
+
+| Setting | Type   | Default        | Description                                          |
+|---------|--------|----------------|------------------------------------------------------|
+| `style` | string | `"sequential"` | `"sequential"` (1. 2. 3.) or `"all-ones"` (1. 1. 1.) |
+| `start` | int    | `1`            | Required first number for every ordered list         |
+
+## Config
+
+Enable with sequential numbering:
+
+```yaml
+rules:
+  ordered-list-numbering:
+    style: sequential
+    start: 1
+```
+
+Disable (default):
+
+```yaml
+rules:
+  ordered-list-numbering: false
+```
+
+All-ones style (insertion-friendly):
+
+```yaml
+rules:
+  ordered-list-numbering:
+    style: all-ones
+    start: 1
+```
+
+## Examples
+
+### Good -- sequential
+
+<?include
+file: good/sequential.md
+wrap: markdown
+?>
+
+```markdown
+# Title
+
+1. first item
+2. second item
+3. third item
+```
+
+<?/include?>
+
+### Good -- all-ones
+
+<?include
+file: good/all-ones.md
+wrap: markdown
+?>
+
+```markdown
+# Title
+
+1. first item
+1. second item
+1. third item
+```
+
+<?/include?>
+
+### Bad -- sequential style with all-ones source
+
+<?include
+file: bad/sequential-mismatch.md
+wrap: markdown
+?>
+
+```markdown
+# Title
+
+1. first item
+1. second item
+1. third item
+```
+
+<?/include?>
+
+### Bad -- wrong start
+
+<?include
+file: bad/wrong-start.md
+wrap: markdown
+?>
+
+```markdown
+# Title
+
+5. first item
+6. second item
+```
+
+<?/include?>
+
+## Diagnostics
+
+- `ordered list starts at {actual}; configured start is {expected}` —
+  the first item's number does not match the configured `start`. Fires
+  once per list, on the first item's line.
+- `ordered list item {position} numbered {actual}; expected {expected}`
+  — an item later in the list deviates from the expected number under
+  the configured `style`.
+
+## Edge Cases
+
+When the fix changes a marker's digit width (for example, item 10
+growing from `1.` to `10.`), the rule re-indents the item's
+continuation lines so the content column still aligns with the
+new marker prefix.
+
+## Meta-Information
+
+- **ID**: MDS046
+- **Name**: `ordered-list-numbering`
+- **Status**: ready
+- **Default**: disabled
+- **Fixable**: yes
+- **Implementation**:
+  [source](./)
+- **Category**: list

--- a/internal/rules/MDS046-ordered-list-numbering/bad/all-ones-mismatch.md
+++ b/internal/rules/MDS046-ordered-list-numbering/bad/all-ones-mismatch.md
@@ -1,0 +1,17 @@
+---
+settings:
+  style: all-ones
+  start: 1
+diagnostics:
+  - line: 4
+    column: 1
+    message: "ordered list item 2 numbered 3; expected 1"
+  - line: 5
+    column: 1
+    message: "ordered list item 3 numbered 7; expected 1"
+---
+# Title
+
+1. first item
+3. second item
+7. third item

--- a/internal/rules/MDS046-ordered-list-numbering/bad/sequential-mismatch.md
+++ b/internal/rules/MDS046-ordered-list-numbering/bad/sequential-mismatch.md
@@ -1,0 +1,17 @@
+---
+settings:
+  style: sequential
+  start: 1
+diagnostics:
+  - line: 4
+    column: 1
+    message: "ordered list item 2 numbered 1; expected 2"
+  - line: 5
+    column: 1
+    message: "ordered list item 3 numbered 1; expected 3"
+---
+# Title
+
+1. first item
+1. second item
+1. third item

--- a/internal/rules/MDS046-ordered-list-numbering/bad/width-grow.md
+++ b/internal/rules/MDS046-ordered-list-numbering/bad/width-grow.md
@@ -1,0 +1,54 @@
+---
+settings:
+  style: sequential
+  start: 1
+diagnostics:
+  - line: 4
+    column: 1
+    message: "ordered list item 2 numbered 1; expected 2"
+  - line: 5
+    column: 1
+    message: "ordered list item 3 numbered 1; expected 3"
+  - line: 6
+    column: 1
+    message: "ordered list item 4 numbered 1; expected 4"
+  - line: 7
+    column: 1
+    message: "ordered list item 5 numbered 1; expected 5"
+  - line: 8
+    column: 1
+    message: "ordered list item 6 numbered 1; expected 6"
+  - line: 9
+    column: 1
+    message: "ordered list item 7 numbered 1; expected 7"
+  - line: 10
+    column: 1
+    message: "ordered list item 8 numbered 1; expected 8"
+  - line: 11
+    column: 1
+    message: "ordered list item 9 numbered 1; expected 9"
+  - line: 12
+    column: 1
+    message: "ordered list item 10 numbered 1; expected 10"
+  - line: 14
+    column: 1
+    message: "ordered list item 11 numbered 1; expected 11"
+  - line: 15
+    column: 1
+    message: "ordered list item 12 numbered 1; expected 12"
+---
+# Title
+
+1. one
+1. two
+1. three
+1. four
+1. five
+1. six
+1. seven
+1. eight
+1. nine
+1. ten
+   continuation of ten
+1. eleven
+1. twelve

--- a/internal/rules/MDS046-ordered-list-numbering/bad/wrong-start.md
+++ b/internal/rules/MDS046-ordered-list-numbering/bad/wrong-start.md
@@ -1,0 +1,13 @@
+---
+settings:
+  style: sequential
+  start: 1
+diagnostics:
+  - line: 3
+    column: 1
+    message: "ordered list starts at 5; configured start is 1"
+---
+# Title
+
+5. first item
+6. second item

--- a/internal/rules/MDS046-ordered-list-numbering/fixed/all-ones-mismatch.md
+++ b/internal/rules/MDS046-ordered-list-numbering/fixed/all-ones-mismatch.md
@@ -1,0 +1,5 @@
+# Title
+
+1. first item
+1. second item
+1. third item

--- a/internal/rules/MDS046-ordered-list-numbering/fixed/sequential-mismatch.md
+++ b/internal/rules/MDS046-ordered-list-numbering/fixed/sequential-mismatch.md
@@ -1,0 +1,5 @@
+# Title
+
+1. first item
+2. second item
+3. third item

--- a/internal/rules/MDS046-ordered-list-numbering/fixed/width-grow.md
+++ b/internal/rules/MDS046-ordered-list-numbering/fixed/width-grow.md
@@ -1,0 +1,15 @@
+# Title
+
+1. one
+2. two
+3. three
+4. four
+5. five
+6. six
+7. seven
+8. eight
+9. nine
+10. ten
+    continuation of ten
+11. eleven
+12. twelve

--- a/internal/rules/MDS046-ordered-list-numbering/fixed/wrong-start.md
+++ b/internal/rules/MDS046-ordered-list-numbering/fixed/wrong-start.md
@@ -1,0 +1,4 @@
+# Title
+
+1. first item
+2. second item

--- a/internal/rules/MDS046-ordered-list-numbering/good/all-ones.md
+++ b/internal/rules/MDS046-ordered-list-numbering/good/all-ones.md
@@ -1,0 +1,10 @@
+---
+settings:
+  style: all-ones
+  start: 1
+---
+# Title
+
+1. first item
+1. second item
+1. third item

--- a/internal/rules/MDS046-ordered-list-numbering/good/sequential.md
+++ b/internal/rules/MDS046-ordered-list-numbering/good/sequential.md
@@ -1,0 +1,5 @@
+# Title
+
+1. first item
+2. second item
+3. third item

--- a/internal/rules/MDS046-ordered-list-numbering/good/unordered.md
+++ b/internal/rules/MDS046-ordered-list-numbering/good/unordered.md
@@ -1,0 +1,5 @@
+# Title
+
+- alpha
+- bravo
+- charlie

--- a/internal/rules/index.md
+++ b/internal/rules/index.md
@@ -57,4 +57,5 @@ row: "| [{id}]({filename}) | `{name}` | {status} | {description} |"
 | [MDS036](MDS036-max-section-length/README.md)                 | `max-section-length`                 | ready     | Section length must not exceed per-level or per-heading limits.                               |
 | [MDS037](MDS037-duplicated-content/README.md)                 | `duplicated-content`                 | ready     | Paragraphs should not repeat verbatim across Markdown files.                                  |
 | [MDS038](MDS038-toc/README.md)                                | `toc`                                | ready     | Keep toc generated heading lists in sync with document headings.                              |
+| [MDS046](MDS046-ordered-list-numbering/README.md)             | `ordered-list-numbering`             | ready     | Ordered list items must be numbered in the configured style.                                  |
 <?/catalog?>

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/fencedcodestyle"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
 	"github.com/yuin/goldmark/ast"
 )
@@ -379,6 +380,14 @@ func blockFirstLine(f *lint.File, n ast.Node) int {
 }
 
 func blockLastLine(f *lint.File, n ast.Node) int {
+	// FencedCodeBlock.Lines() covers only the content lines; the closing
+	// fence sits on the line after the last content segment's Stop. Use
+	// the shared helper so the indent shift covers the closing fence
+	// when a marker digit-width changes (otherwise the fence outdents
+	// and breaks the block).
+	if fcb, ok := n.(*ast.FencedCodeBlock); ok {
+		return fencedcodestyle.FenceCloseLine(f, fcb)
+	}
 	if n.Lines().Len() > 0 {
 		return f.LineOfOffset(n.Lines().At(n.Lines().Len() - 1).Start)
 	}

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -273,7 +273,10 @@ func expectedNumber(style string, start, i int) int {
 // parseListItemNumber finds the literal number on a list-item line.
 // Returns the number, the byte indices of the digits within the line,
 // and the marker character ('.' or ')'). ok is false when the line
-// does not begin with an ordered-list marker.
+// does not begin with an ordered-list marker, or when the digit run
+// is too long to fit in an int (CommonMark caps markers at 9 digits;
+// raw source lines can carry longer digit runs that we treat as
+// non-markers rather than risk an overflowed value flowing into Fix).
 func parseListItemNumber(line []byte) (number int, digitStart, digitEnd int, markerChar byte, ok bool) {
 	i := 0
 	for i < len(line) && line[i] == ' ' {
@@ -281,7 +284,6 @@ func parseListItemNumber(line []byte) (number int, digitStart, digitEnd int, mar
 	}
 	digitStart = i
 	for i < len(line) && isDigit(line[i]) {
-		number = number*10 + int(line[i]-'0')
 		i++
 	}
 	digitEnd = i
@@ -294,6 +296,11 @@ func parseListItemNumber(line []byte) (number int, digitStart, digitEnd int, mar
 	if line[i] != '.' && line[i] != ')' {
 		return 0, 0, 0, 0, false
 	}
+	n, err := strconv.Atoi(string(line[digitStart:digitEnd]))
+	if err != nil {
+		return 0, 0, 0, 0, false
+	}
+	number = n
 	markerChar = line[i]
 	return number, digitStart, digitEnd, markerChar, true
 }

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -48,10 +48,6 @@ func (r *Rule) EnabledByDefault() bool { return false }
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
-	configStart := r.Start
-	if configStart < 0 {
-		configStart = 1
-	}
 
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -61,41 +57,39 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		if !ok || !list.IsOrdered() {
 			return ast.WalkContinue, nil
 		}
-		diags = append(diags, r.checkList(f, list, configStart)...)
+		diags = append(diags, r.checkList(f, list)...)
 		return ast.WalkContinue, nil
 	})
 
 	return diags
 }
 
-// checkList emits diagnostics for one ordered list.
-func (r *Rule) checkList(f *lint.File, list *ast.List, configStart int) []lint.Diagnostic {
-	firstItem, _ := firstChildListItem(list)
-	if firstItem == nil {
-		return nil
-	}
-	firstLine := firstLineOfListItem(f, firstItem)
-	if firstLine < 1 {
-		return nil
-	}
-
+// checkList emits diagnostics for one ordered list. Nested ordered
+// lists are checked independently — each list owns its own item
+// numbering. When the list's start does not match the configured
+// start, the start-mismatch diagnostic is the only one emitted: per
+// item-numbering diagnostics use the configured start as their
+// baseline (matching what Fix produces), so reporting them alongside
+// "wrong start" would tell the user to renumber items that the start
+// fix would already correct.
+func (r *Rule) checkList(f *lint.File, list *ast.List) []lint.Diagnostic {
 	var diags []lint.Diagnostic
-	actualStart := list.Start
-	startMismatch := actualStart != configStart
-	if startMismatch {
-		diags = append(diags, r.diag(f, firstLine, fmt.Sprintf(
-			"ordered list starts at %d; configured start is %d",
-			actualStart, configStart,
-		)))
-	}
-
+	startMismatch := list.Start != r.Start
 	i := 0
 	for c := list.FirstChild(); c != nil; c = c.NextSibling() {
-		item, ok := c.(*ast.ListItem)
-		if !ok {
+		item := c.(*ast.ListItem)
+		line := firstLineOfListItem(f, item)
+		if i == 0 && startMismatch {
+			diags = append(diags, r.diag(f, line, fmt.Sprintf(
+				"ordered list starts at %d; configured start is %d",
+				list.Start, r.Start,
+			)))
+		}
+		if startMismatch {
+			i++
 			continue
 		}
-		if d, ok := r.checkItem(f, item, i, actualStart, startMismatch); ok {
+		if d, ok := r.checkItem(f, line, i); ok {
 			diags = append(diags, d)
 		}
 		i++
@@ -103,27 +97,12 @@ func (r *Rule) checkList(f *lint.File, list *ast.List, configStart int) []lint.D
 	return diags
 }
 
-// checkItem produces a diagnostic for one list item when its literal
-// number does not match the expected number under the configured style.
-// The first item is suppressed when the list-start mismatch already
-// fired there.
-func (r *Rule) checkItem(
-	f *lint.File, item *ast.ListItem,
-	i, baseStart int, startMismatch bool,
-) (lint.Diagnostic, bool) {
-	line := firstLineOfListItem(f, item)
-	if line < 1 || line > len(f.Lines) {
-		return lint.Diagnostic{}, false
-	}
-	literal, _, _, _, parseOK := parseListItemNumber(f.Lines[line-1])
-	if !parseOK {
-		return lint.Diagnostic{}, false
-	}
-	expected := expectedNumber(r.Style, baseStart, i)
+// checkItem produces a diagnostic when an item's literal number does
+// not match the expected number under the configured style and start.
+func (r *Rule) checkItem(f *lint.File, line, i int) (lint.Diagnostic, bool) {
+	literal, _, _, _, _ := parseListItemNumber(f.Lines[line-1])
+	expected := expectedNumber(r.Style, r.Start, i)
 	if literal == expected {
-		return lint.Diagnostic{}, false
-	}
-	if i == 0 && startMismatch {
 		return lint.Diagnostic{}, false
 	}
 	return r.diag(f, line, fmt.Sprintf(
@@ -151,11 +130,6 @@ type markerEdit struct {
 
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
-	configStart := r.Start
-	if configStart < 0 {
-		configStart = 1
-	}
-
 	markerEdits := map[int]markerEdit{}
 	indentDeltas := map[int]int{}
 
@@ -167,7 +141,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		if !ok || !list.IsOrdered() {
 			return ast.WalkContinue, nil
 		}
-		r.collectListEdits(f, list, configStart, markerEdits, indentDeltas)
+		r.collectListEdits(f, list, markerEdits, indentDeltas)
 		return ast.WalkContinue, nil
 	})
 
@@ -194,16 +168,13 @@ func (r *Rule) Fix(f *lint.File) []byte {
 // collectListEdits records marker rewrites and continuation-indent
 // shifts for one ordered list.
 func (r *Rule) collectListEdits(
-	f *lint.File, list *ast.List, configStart int,
+	f *lint.File, list *ast.List,
 	markerEdits map[int]markerEdit, indentDeltas map[int]int,
 ) {
 	i := 0
 	for c := list.FirstChild(); c != nil; c = c.NextSibling() {
-		item, ok := c.(*ast.ListItem)
-		if !ok {
-			continue
-		}
-		r.collectItemEdits(f, item, i, configStart, markerEdits, indentDeltas)
+		item := c.(*ast.ListItem)
+		r.collectItemEdits(f, item, i, markerEdits, indentDeltas)
 		i++
 	}
 }
@@ -211,18 +182,12 @@ func (r *Rule) collectListEdits(
 // collectItemEdits records the marker rewrite and the indent delta on
 // continuation lines for one list item.
 func (r *Rule) collectItemEdits(
-	f *lint.File, item *ast.ListItem, i, configStart int,
+	f *lint.File, item *ast.ListItem, i int,
 	markerEdits map[int]markerEdit, indentDeltas map[int]int,
 ) {
 	line := firstLineOfListItem(f, item)
-	if line < 1 || line > len(f.Lines) {
-		return
-	}
-	literal, _, _, _, parseOK := parseListItemNumber(f.Lines[line-1])
-	if !parseOK {
-		return
-	}
-	expected := expectedNumber(r.Style, configStart, i)
+	literal, _, _, _, _ := parseListItemNumber(f.Lines[line-1])
+	expected := expectedNumber(r.Style, r.Start, i)
 	if literal != expected {
 		markerEdits[line] = markerEdit{newDigits: expected}
 	}
@@ -230,20 +195,19 @@ func (r *Rule) collectItemEdits(
 	if delta == 0 {
 		return
 	}
-	lastLine := lastLineOfNode(f, item)
-	if lastLine < line {
-		lastLine = line
-	}
+	lastLine := lastLineOfListItem(f, item)
 	for ln := line + 1; ln <= lastLine; ln++ {
 		indentDeltas[ln] += delta
 	}
 }
 
 // applyIndentShift adjusts the leading-whitespace width of a line by
-// shift bytes. Negative shifts that exceed the existing leading
-// whitespace are ignored to avoid eating non-space content.
+// shift bytes. Blank lines are left alone — padding a blank line
+// would create trailing whitespace. Negative shifts that exceed the
+// existing leading whitespace are ignored to avoid eating non-space
+// content.
 func applyIndentShift(line []byte, shift int) []byte {
-	if shift == 0 {
+	if shift == 0 || isBlank(line) {
 		return line
 	}
 	if shift > 0 {
@@ -255,6 +219,15 @@ func applyIndentShift(line []byte, shift int) []byte {
 		return line
 	}
 	return line[n:]
+}
+
+func isBlank(line []byte) bool {
+	for _, b := range line {
+		if b != ' ' && b != '\t' {
+			return false
+		}
+	}
+	return true
 }
 
 // replaceLeadingDigits replaces a run of digits at the start of a line
@@ -315,15 +288,13 @@ func parseListItemNumber(line []byte) (number int, digitStart, digitEnd int, mar
 
 func isDigit(b byte) bool { return b >= '0' && b <= '9' }
 
+// digitWidth returns the number of decimal digits in n. n is always
+// non-negative in this rule's call sites (item numbers).
 func digitWidth(n int) int {
 	if n == 0 {
 		return 1
 	}
 	w := 0
-	if n < 0 {
-		w = 1
-		n = -n
-	}
 	for n > 0 {
 		n /= 10
 		w++
@@ -334,108 +305,65 @@ func digitWidth(n int) int {
 func countLeadingSpaces(line []byte) int {
 	n := 0
 	for _, b := range line {
-		if b == ' ' {
-			n++
-			continue
+		if b != ' ' {
+			break
 		}
-		break
+		n++
 	}
 	return n
 }
 
-func firstChildListItem(list *ast.List) (*ast.ListItem, int) {
-	idx := 0
-	for c := list.FirstChild(); c != nil; c = c.NextSibling() {
-		if li, ok := c.(*ast.ListItem); ok {
-			return li, idx
-		}
-		idx++
-	}
-	return nil, 0
-}
-
+// firstLineOfListItem returns the 1-based source line of an item's
+// marker. ListItem.Lines() is empty in goldmark; the marker line lives
+// on the first block child (paragraph, code block, nested list).
 func firstLineOfListItem(f *lint.File, li *ast.ListItem) int {
-	if li.Lines().Len() > 0 {
-		return f.LineOfOffset(li.Lines().At(0).Start)
-	}
-	if li.HasChildren() {
-		for c := li.FirstChild(); c != nil; c = c.NextSibling() {
-			line := lineOfNode(f, c)
-			if line > 0 {
-				return line
-			}
+	for c := li.FirstChild(); c != nil; c = c.NextSibling() {
+		if line := blockFirstLine(f, c); line > 0 {
+			return line
 		}
 	}
 	return 0
 }
 
-func lineOfNode(f *lint.File, n ast.Node) int {
-	if t, ok := n.(*ast.Text); ok {
-		return f.LineOfOffset(t.Segment.Start)
-	}
-	if isInlineNode(n) {
-		if n.HasChildren() {
-			for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-				if l := lineOfNode(f, c); l > 0 {
-					return l
-				}
-			}
-		}
-		return 0
-	}
-	if n.Lines().Len() > 0 {
-		return f.LineOfOffset(n.Lines().At(0).Start)
-	}
-	if n.HasChildren() {
-		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-			if l := lineOfNode(f, c); l > 0 {
-				return l
-			}
-		}
-	}
-	return 0
-}
-
-func lastLineOfNode(f *lint.File, n ast.Node) int {
-	if t, ok := n.(*ast.Text); ok {
-		stop := t.Segment.Stop
-		if stop > 0 {
-			stop--
-		}
-		return f.LineOfOffset(stop)
-	}
-	if isInlineNode(n) {
-		if n.HasChildren() {
-			for c := n.LastChild(); c != nil; c = c.PreviousSibling() {
-				if l := lastLineOfNode(f, c); l > 0 {
-					return l
-				}
-			}
-		}
-		return 0
-	}
+// lastLineOfListItem returns the 1-based source line of the item's
+// last descendant block.
+func lastLineOfListItem(f *lint.File, li *ast.ListItem) int {
 	last := 0
-	if n.Lines().Len() > 0 {
-		seg := n.Lines().At(n.Lines().Len() - 1)
-		last = f.LineOfOffset(seg.Start)
-	}
-	if n.HasChildren() {
-		for c := n.LastChild(); c != nil; c = c.PreviousSibling() {
-			if l := lastLineOfNode(f, c); l > last {
-				last = l
-			}
+	for c := li.FirstChild(); c != nil; c = c.NextSibling() {
+		if l := blockLastLine(f, c); l > last {
+			last = l
 		}
 	}
 	return last
 }
 
-func isInlineNode(n ast.Node) bool {
-	switch n.(type) {
-	case *ast.Text, *ast.String, *ast.CodeSpan, *ast.Emphasis,
-		*ast.Link, *ast.Image, *ast.AutoLink, *ast.RawHTML:
-		return true
+// blockFirstLine returns the first source line of a block node.
+// Recurses only through container blocks (whose Lines() is empty),
+// which are themselves block children — inline children whose Lines()
+// would panic are never reached.
+func blockFirstLine(f *lint.File, n ast.Node) int {
+	if n.Lines().Len() > 0 {
+		return f.LineOfOffset(n.Lines().At(0).Start)
 	}
-	return false
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if l := blockFirstLine(f, c); l > 0 {
+			return l
+		}
+	}
+	return 0
+}
+
+func blockLastLine(f *lint.File, n ast.Node) int {
+	if n.Lines().Len() > 0 {
+		return f.LineOfOffset(n.Lines().At(n.Lines().Len() - 1).Start)
+	}
+	last := 0
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if l := blockLastLine(f, c); l > last {
+			last = l
+		}
+	}
+	return last
 }
 
 // ApplySettings implements rule.Configurable.

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -100,7 +100,13 @@ func (r *Rule) checkList(f *lint.File, list *ast.List) []lint.Diagnostic {
 // checkItem produces a diagnostic when an item's literal number does
 // not match the expected number under the configured style and start.
 func (r *Rule) checkItem(f *lint.File, line, i int) (lint.Diagnostic, bool) {
-	literal, _, _, _, _ := parseListItemNumber(f.Lines[line-1])
+	if line <= 0 || line > len(f.Lines) {
+		return lint.Diagnostic{}, false
+	}
+	literal, _, _, _, ok := parseListItemNumber(f.Lines[line-1])
+	if !ok {
+		return lint.Diagnostic{}, false
+	}
 	expected := expectedNumber(r.Style, r.Start, i)
 	if literal == expected {
 		return lint.Diagnostic{}, false
@@ -186,7 +192,13 @@ func (r *Rule) collectItemEdits(
 	markerEdits map[int]markerEdit, indentDeltas map[int]int,
 ) {
 	line := firstLineOfListItem(f, item)
-	literal, _, _, _, _ := parseListItemNumber(f.Lines[line-1])
+	if line <= 0 || line > len(f.Lines) {
+		return
+	}
+	literal, _, _, _, ok := parseListItemNumber(f.Lines[line-1])
+	if !ok {
+		return
+	}
 	expected := expectedNumber(r.Style, r.Start, i)
 	if literal != expected {
 		markerEdits[line] = markerEdit{newDigits: expected}
@@ -314,9 +326,15 @@ func countLeadingSpaces(line []byte) int {
 }
 
 // firstLineOfListItem returns the 1-based source line of an item's
-// marker. ListItem.Lines() is empty in goldmark; the marker line lives
-// on the first block child (paragraph, code block, nested list).
+// marker. When the ListItem carries line segments, the first segment's
+// start offset gives the marker line directly. Otherwise the marker
+// line is derived from the first block child (paragraph, code block,
+// nested list).
 func firstLineOfListItem(f *lint.File, li *ast.ListItem) int {
+	if li.Lines().Len() > 0 {
+		seg := li.Lines().At(0)
+		return f.LineOfOffset(seg.Start)
+	}
 	for c := li.FirstChild(); c != nil; c = c.NextSibling() {
 		if line := blockFirstLine(f, c); line > 0 {
 			return line

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -1,0 +1,482 @@
+// Package orderedlistnumbering implements MDS046, which pins how
+// ordered list items are numbered in the source: literal sequential
+// (1. 2. 3.) or all-ones (1. 1. 1.). CommonMark renders both the same,
+// but the choice controls what the source text shows authors and
+// reviewers.
+package orderedlistnumbering
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/settings"
+	"github.com/yuin/goldmark/ast"
+)
+
+// Style values for the rule's `style` setting.
+const (
+	StyleSequential = "sequential"
+	StyleAllOnes    = "all-ones"
+)
+
+func init() {
+	rule.Register(&Rule{Style: StyleSequential, Start: 1})
+}
+
+// Rule pins the numbering style of ordered lists in source.
+type Rule struct {
+	Style string
+	Start int
+}
+
+// ID implements rule.Rule.
+func (r *Rule) ID() string { return "MDS046" }
+
+// Name implements rule.Rule.
+func (r *Rule) Name() string { return "ordered-list-numbering" }
+
+// Category implements rule.Rule.
+func (r *Rule) Category() string { return "list" }
+
+// EnabledByDefault implements rule.Defaultable. The rule is opt-in:
+// users pick a project convention and turn the rule on.
+func (r *Rule) EnabledByDefault() bool { return false }
+
+// Check implements rule.Rule.
+func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	var diags []lint.Diagnostic
+	configStart := r.Start
+	if configStart < 0 {
+		configStart = 1
+	}
+
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		list, ok := n.(*ast.List)
+		if !ok || !list.IsOrdered() {
+			return ast.WalkContinue, nil
+		}
+		diags = append(diags, r.checkList(f, list, configStart)...)
+		return ast.WalkContinue, nil
+	})
+
+	return diags
+}
+
+// checkList emits diagnostics for one ordered list.
+func (r *Rule) checkList(f *lint.File, list *ast.List, configStart int) []lint.Diagnostic {
+	firstItem, _ := firstChildListItem(list)
+	if firstItem == nil {
+		return nil
+	}
+	firstLine := firstLineOfListItem(f, firstItem)
+	if firstLine < 1 {
+		return nil
+	}
+
+	var diags []lint.Diagnostic
+	actualStart := list.Start
+	startMismatch := actualStart != configStart
+	if startMismatch {
+		diags = append(diags, r.diag(f, firstLine, fmt.Sprintf(
+			"ordered list starts at %d; configured start is %d",
+			actualStart, configStart,
+		)))
+	}
+
+	i := 0
+	for c := list.FirstChild(); c != nil; c = c.NextSibling() {
+		item, ok := c.(*ast.ListItem)
+		if !ok {
+			continue
+		}
+		if d, ok := r.checkItem(f, item, i, actualStart, startMismatch); ok {
+			diags = append(diags, d)
+		}
+		i++
+	}
+	return diags
+}
+
+// checkItem produces a diagnostic for one list item when its literal
+// number does not match the expected number under the configured style.
+// The first item is suppressed when the list-start mismatch already
+// fired there.
+func (r *Rule) checkItem(
+	f *lint.File, item *ast.ListItem,
+	i, baseStart int, startMismatch bool,
+) (lint.Diagnostic, bool) {
+	line := firstLineOfListItem(f, item)
+	if line < 1 || line > len(f.Lines) {
+		return lint.Diagnostic{}, false
+	}
+	literal, _, _, _, parseOK := parseListItemNumber(f.Lines[line-1])
+	if !parseOK {
+		return lint.Diagnostic{}, false
+	}
+	expected := expectedNumber(r.Style, baseStart, i)
+	if literal == expected {
+		return lint.Diagnostic{}, false
+	}
+	if i == 0 && startMismatch {
+		return lint.Diagnostic{}, false
+	}
+	return r.diag(f, line, fmt.Sprintf(
+		"ordered list item %d numbered %d; expected %d",
+		i+1, literal, expected,
+	)), true
+}
+
+func (r *Rule) diag(f *lint.File, line int, msg string) lint.Diagnostic {
+	return lint.Diagnostic{
+		File:     f.Path,
+		Line:     line,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  msg,
+	}
+}
+
+// markerEdit replaces the literal number at a marker line.
+type markerEdit struct {
+	newDigits int
+}
+
+// Fix implements rule.FixableRule.
+func (r *Rule) Fix(f *lint.File) []byte {
+	configStart := r.Start
+	if configStart < 0 {
+		configStart = 1
+	}
+
+	markerEdits := map[int]markerEdit{}
+	indentDeltas := map[int]int{}
+
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		list, ok := n.(*ast.List)
+		if !ok || !list.IsOrdered() {
+			return ast.WalkContinue, nil
+		}
+		r.collectListEdits(f, list, configStart, markerEdits, indentDeltas)
+		return ast.WalkContinue, nil
+	})
+
+	if len(markerEdits) == 0 && len(indentDeltas) == 0 {
+		out := make([]byte, len(f.Source))
+		copy(out, f.Source)
+		return out
+	}
+
+	resultLines := make([][]byte, len(f.Lines))
+	for i, line := range f.Lines {
+		lineNum := i + 1
+		newLine := append([]byte(nil), line...)
+		newLine = applyIndentShift(newLine, indentDeltas[lineNum])
+		if e, ok := markerEdits[lineNum]; ok {
+			newLine = replaceLeadingDigits(newLine, e.newDigits)
+		}
+		resultLines[i] = newLine
+	}
+
+	return bytes.Join(resultLines, []byte("\n"))
+}
+
+// collectListEdits records marker rewrites and continuation-indent
+// shifts for one ordered list.
+func (r *Rule) collectListEdits(
+	f *lint.File, list *ast.List, configStart int,
+	markerEdits map[int]markerEdit, indentDeltas map[int]int,
+) {
+	i := 0
+	for c := list.FirstChild(); c != nil; c = c.NextSibling() {
+		item, ok := c.(*ast.ListItem)
+		if !ok {
+			continue
+		}
+		r.collectItemEdits(f, item, i, configStart, markerEdits, indentDeltas)
+		i++
+	}
+}
+
+// collectItemEdits records the marker rewrite and the indent delta on
+// continuation lines for one list item.
+func (r *Rule) collectItemEdits(
+	f *lint.File, item *ast.ListItem, i, configStart int,
+	markerEdits map[int]markerEdit, indentDeltas map[int]int,
+) {
+	line := firstLineOfListItem(f, item)
+	if line < 1 || line > len(f.Lines) {
+		return
+	}
+	literal, _, _, _, parseOK := parseListItemNumber(f.Lines[line-1])
+	if !parseOK {
+		return
+	}
+	expected := expectedNumber(r.Style, configStart, i)
+	if literal != expected {
+		markerEdits[line] = markerEdit{newDigits: expected}
+	}
+	delta := digitWidth(expected) - digitWidth(literal)
+	if delta == 0 {
+		return
+	}
+	lastLine := lastLineOfNode(f, item)
+	if lastLine < line {
+		lastLine = line
+	}
+	for ln := line + 1; ln <= lastLine; ln++ {
+		indentDeltas[ln] += delta
+	}
+}
+
+// applyIndentShift adjusts the leading-whitespace width of a line by
+// shift bytes. Negative shifts that exceed the existing leading
+// whitespace are ignored to avoid eating non-space content.
+func applyIndentShift(line []byte, shift int) []byte {
+	if shift == 0 {
+		return line
+	}
+	if shift > 0 {
+		pad := bytes.Repeat([]byte(" "), shift)
+		return append(pad, line...)
+	}
+	n := -shift
+	if countLeadingSpaces(line) < n {
+		return line
+	}
+	return line[n:]
+}
+
+// replaceLeadingDigits replaces a run of digits at the start of a line
+// (after any leading whitespace) with the decimal form of n.
+func replaceLeadingDigits(line []byte, n int) []byte {
+	leading := countLeadingSpaces(line)
+	digitStart := leading
+	digitEnd := leading
+	for digitEnd < len(line) && isDigit(line[digitEnd]) {
+		digitEnd++
+	}
+	if digitEnd == digitStart {
+		return line
+	}
+	out := make([]byte, 0, len(line)+8)
+	out = append(out, line[:digitStart]...)
+	out = append(out, []byte(strconv.Itoa(n))...)
+	out = append(out, line[digitEnd:]...)
+	return out
+}
+
+// expectedNumber returns the number an item at index i (0-based) should
+// have, given the rule's style and the list's start value.
+func expectedNumber(style string, start, i int) int {
+	if style == StyleAllOnes {
+		return start
+	}
+	return start + i
+}
+
+// parseListItemNumber finds the literal number on a list-item line.
+// Returns the number, the byte indices of the digits within the line,
+// and the marker character ('.' or ')'). ok is false when the line
+// does not begin with an ordered-list marker.
+func parseListItemNumber(line []byte) (number int, digitStart, digitEnd int, markerChar byte, ok bool) {
+	i := 0
+	for i < len(line) && line[i] == ' ' {
+		i++
+	}
+	digitStart = i
+	for i < len(line) && isDigit(line[i]) {
+		number = number*10 + int(line[i]-'0')
+		i++
+	}
+	digitEnd = i
+	if digitEnd == digitStart {
+		return 0, 0, 0, 0, false
+	}
+	if i >= len(line) {
+		return 0, 0, 0, 0, false
+	}
+	if line[i] != '.' && line[i] != ')' {
+		return 0, 0, 0, 0, false
+	}
+	markerChar = line[i]
+	return number, digitStart, digitEnd, markerChar, true
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+func digitWidth(n int) int {
+	if n == 0 {
+		return 1
+	}
+	w := 0
+	if n < 0 {
+		w = 1
+		n = -n
+	}
+	for n > 0 {
+		n /= 10
+		w++
+	}
+	return w
+}
+
+func countLeadingSpaces(line []byte) int {
+	n := 0
+	for _, b := range line {
+		if b == ' ' {
+			n++
+			continue
+		}
+		break
+	}
+	return n
+}
+
+func firstChildListItem(list *ast.List) (*ast.ListItem, int) {
+	idx := 0
+	for c := list.FirstChild(); c != nil; c = c.NextSibling() {
+		if li, ok := c.(*ast.ListItem); ok {
+			return li, idx
+		}
+		idx++
+	}
+	return nil, 0
+}
+
+func firstLineOfListItem(f *lint.File, li *ast.ListItem) int {
+	if li.Lines().Len() > 0 {
+		return f.LineOfOffset(li.Lines().At(0).Start)
+	}
+	if li.HasChildren() {
+		for c := li.FirstChild(); c != nil; c = c.NextSibling() {
+			line := lineOfNode(f, c)
+			if line > 0 {
+				return line
+			}
+		}
+	}
+	return 0
+}
+
+func lineOfNode(f *lint.File, n ast.Node) int {
+	if t, ok := n.(*ast.Text); ok {
+		return f.LineOfOffset(t.Segment.Start)
+	}
+	if isInlineNode(n) {
+		if n.HasChildren() {
+			for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+				if l := lineOfNode(f, c); l > 0 {
+					return l
+				}
+			}
+		}
+		return 0
+	}
+	if n.Lines().Len() > 0 {
+		return f.LineOfOffset(n.Lines().At(0).Start)
+	}
+	if n.HasChildren() {
+		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+			if l := lineOfNode(f, c); l > 0 {
+				return l
+			}
+		}
+	}
+	return 0
+}
+
+func lastLineOfNode(f *lint.File, n ast.Node) int {
+	if t, ok := n.(*ast.Text); ok {
+		stop := t.Segment.Stop
+		if stop > 0 {
+			stop--
+		}
+		return f.LineOfOffset(stop)
+	}
+	if isInlineNode(n) {
+		if n.HasChildren() {
+			for c := n.LastChild(); c != nil; c = c.PreviousSibling() {
+				if l := lastLineOfNode(f, c); l > 0 {
+					return l
+				}
+			}
+		}
+		return 0
+	}
+	last := 0
+	if n.Lines().Len() > 0 {
+		seg := n.Lines().At(n.Lines().Len() - 1)
+		last = f.LineOfOffset(seg.Start)
+	}
+	if n.HasChildren() {
+		for c := n.LastChild(); c != nil; c = c.PreviousSibling() {
+			if l := lastLineOfNode(f, c); l > last {
+				last = l
+			}
+		}
+	}
+	return last
+}
+
+func isInlineNode(n ast.Node) bool {
+	switch n.(type) {
+	case *ast.Text, *ast.String, *ast.CodeSpan, *ast.Emphasis,
+		*ast.Link, *ast.Image, *ast.AutoLink, *ast.RawHTML:
+		return true
+	}
+	return false
+}
+
+// ApplySettings implements rule.Configurable.
+func (r *Rule) ApplySettings(s map[string]any) error {
+	for k, v := range s {
+		switch k {
+		case "style":
+			str, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("ordered-list-numbering: style must be a string, got %T", v)
+			}
+			if str != StyleSequential && str != StyleAllOnes {
+				return fmt.Errorf("ordered-list-numbering: invalid style %q (valid: sequential, all-ones)", str)
+			}
+			r.Style = str
+		case "start":
+			n, ok := settings.ToInt(v)
+			if !ok {
+				return fmt.Errorf("ordered-list-numbering: start must be an integer, got %T", v)
+			}
+			if n < 0 {
+				return fmt.Errorf("ordered-list-numbering: start must be non-negative, got %d", n)
+			}
+			r.Start = n
+		default:
+			return fmt.Errorf("ordered-list-numbering: unknown setting %q", k)
+		}
+	}
+	return nil
+}
+
+// DefaultSettings implements rule.Configurable.
+func (r *Rule) DefaultSettings() map[string]any {
+	return map[string]any{
+		"style": StyleSequential,
+		"start": 1,
+	}
+}
+
+var (
+	_ rule.Configurable = (*Rule)(nil)
+	_ rule.FixableRule  = (*Rule)(nil)
+	_ rule.Defaultable  = (*Rule)(nil)
+)

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -1,0 +1,247 @@
+package orderedlistnumbering
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuleMetadata(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "MDS046", r.ID())
+	assert.Equal(t, "ordered-list-numbering", r.Name())
+	assert.Equal(t, "list", r.Category())
+	assert.False(t, r.EnabledByDefault(), "rule must be opt-in")
+}
+
+func TestCheck_Sequential_GoodList(t *testing.T) {
+	src := []byte("1. a\n2. b\n3. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_Sequential_AllOnesIsBad(t *testing.T) {
+	src := []byte("1. a\n1. b\n1. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	require.Len(t, diags, 2)
+	assert.Equal(t, 2, diags[0].Line)
+	assert.Equal(t, 3, diags[1].Line)
+	assert.Contains(t, diags[0].Message, "item 2")
+	assert.Contains(t, diags[0].Message, "expected 2")
+}
+
+func TestCheck_AllOnes_GoodList(t *testing.T) {
+	src := []byte("1. a\n1. b\n1. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleAllOnes, Start: 1}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_AllOnes_FlagsNonOnes(t *testing.T) {
+	src := []byte("1. a\n3. b\n7. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleAllOnes, Start: 1}
+	diags := r.Check(f)
+	require.Len(t, diags, 2)
+	assert.Equal(t, 2, diags[0].Line)
+	assert.Equal(t, 3, diags[1].Line)
+	assert.Contains(t, diags[0].Message, "expected 1")
+}
+
+func TestCheck_WrongStart(t *testing.T) {
+	src := []byte("5. a\n6. b\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "wrong start should fire one diag and suppress per-item dups")
+	assert.Equal(t, 1, diags[0].Line)
+	assert.Contains(t, diags[0].Message, "starts at 5")
+	assert.Contains(t, diags[0].Message, "configured start is 1")
+}
+
+func TestCheck_UnorderedListNotFlagged(t *testing.T) {
+	src := []byte("- a\n- b\n- c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_NestedOrderedList(t *testing.T) {
+	src := []byte("1. parent\n   1. child\n   1. child two\n2. parent two\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "outer list ok; inner list flags one item")
+	assert.Equal(t, 3, diags[0].Line)
+}
+
+func TestFix_SequentialFromAllOnes(t *testing.T) {
+	src := []byte("1. a\n1. b\n1. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	got := r.Fix(f)
+	want := "1. a\n2. b\n3. c\n"
+	assert.Equal(t, want, string(got))
+}
+
+func TestFix_AllOnesFromMixed(t *testing.T) {
+	src := []byte("1. a\n3. b\n7. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleAllOnes, Start: 1}
+	got := r.Fix(f)
+	want := "1. a\n1. b\n1. c\n"
+	assert.Equal(t, want, string(got))
+}
+
+func TestFix_DigitWidthGrowth_AdjustsContinuation(t *testing.T) {
+	// 12 items, all "1." with all-ones, fixed to sequential.
+	// Items 10-12 will grow from "1." to "10." ... "12." (+1 char).
+	// Continuation lines under those items must shift right by 1.
+	src := []byte("" +
+		"1. one\n" +
+		"1. two\n" +
+		"1. three\n" +
+		"1. four\n" +
+		"1. five\n" +
+		"1. six\n" +
+		"1. seven\n" +
+		"1. eight\n" +
+		"1. nine\n" +
+		"1. ten\n" +
+		"   continuation of ten\n" +
+		"1. eleven\n" +
+		"1. twelve\n",
+	)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	got := r.Fix(f)
+	want := "" +
+		"1. one\n" +
+		"2. two\n" +
+		"3. three\n" +
+		"4. four\n" +
+		"5. five\n" +
+		"6. six\n" +
+		"7. seven\n" +
+		"8. eight\n" +
+		"9. nine\n" +
+		"10. ten\n" +
+		"    continuation of ten\n" +
+		"11. eleven\n" +
+		"12. twelve\n"
+	assert.Equal(t, want, string(got))
+}
+
+func TestFix_DigitWidthShrink_AdjustsContinuation(t *testing.T) {
+	// 12-item sequential list fixed to all-ones; items 10-12 shrink.
+	src := []byte("" +
+		"1. one\n" +
+		"2. two\n" +
+		"3. three\n" +
+		"4. four\n" +
+		"5. five\n" +
+		"6. six\n" +
+		"7. seven\n" +
+		"8. eight\n" +
+		"9. nine\n" +
+		"10. ten\n" +
+		"    continuation of ten\n" +
+		"11. eleven\n" +
+		"12. twelve\n",
+	)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleAllOnes, Start: 1}
+	got := r.Fix(f)
+	want := "" +
+		"1. one\n" +
+		"1. two\n" +
+		"1. three\n" +
+		"1. four\n" +
+		"1. five\n" +
+		"1. six\n" +
+		"1. seven\n" +
+		"1. eight\n" +
+		"1. nine\n" +
+		"1. ten\n" +
+		"   continuation of ten\n" +
+		"1. eleven\n" +
+		"1. twelve\n"
+	assert.Equal(t, want, string(got))
+}
+
+func TestFix_NoChangeWhenAlreadyCorrect(t *testing.T) {
+	src := []byte("1. a\n2. b\n3. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	got := r.Fix(f)
+	assert.Equal(t, string(src), string(got))
+}
+
+func TestApplySettings_Style(t *testing.T) {
+	r := &Rule{Style: StyleSequential, Start: 1}
+	require.NoError(t, r.ApplySettings(map[string]any{"style": "all-ones"}))
+	assert.Equal(t, StyleAllOnes, r.Style)
+}
+
+func TestApplySettings_Start(t *testing.T) {
+	r := &Rule{Style: StyleSequential, Start: 1}
+	require.NoError(t, r.ApplySettings(map[string]any{"start": 3}))
+	assert.Equal(t, 3, r.Start)
+}
+
+func TestApplySettings_InvalidStyle(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"style": "wibble"})
+	assert.Error(t, err)
+}
+
+func TestApplySettings_InvalidStartType(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"start": "one"})
+	assert.Error(t, err)
+}
+
+func TestApplySettings_NegativeStart(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"start": -1})
+	assert.Error(t, err)
+}
+
+func TestApplySettings_UnknownKey(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"oops": true})
+	assert.Error(t, err)
+}
+
+func TestDefaultSettings(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	assert.Equal(t, StyleSequential, ds["style"])
+	assert.Equal(t, 1, ds["start"])
+}
+
+func TestRegistered(t *testing.T) {
+	require.NotNil(t, rule.ByID("MDS046"), "rule must register itself")
+}

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -289,6 +289,13 @@ func TestParseListItemNumber_ParenMarker(t *testing.T) {
 	assert.Equal(t, byte(')'), marker)
 }
 
+func TestParseListItemNumber_OverflowDigits(t *testing.T) {
+	// A 30-digit marker overflows int. parseListItemNumber must reject
+	// it rather than wrap to a bogus value that could corrupt Fix.
+	_, _, _, _, ok := parseListItemNumber([]byte("123456789012345678901234567890. item"))
+	assert.False(t, ok)
+}
+
 func TestApplyIndentShift_Zero(t *testing.T) {
 	in := []byte("hello")
 	out := applyIndentShift(in, 0)

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -230,6 +232,12 @@ func TestApplySettings_InvalidStyle(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestApplySettings_StyleNotString(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"style": 42})
+	assert.Error(t, err)
+}
+
 func TestApplySettings_InvalidStartType(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{"start": "one"})
@@ -377,4 +385,97 @@ func TestFix_WidthGrowth_RecursesIntoNestedList(t *testing.T) {
 		"\n" +
 		"11. eleven\n"
 	assert.Equal(t, want, string(got))
+}
+
+func TestCheckItem_ZeroLine(t *testing.T) {
+	r := &Rule{Style: StyleSequential, Start: 1}
+	f, err := lint.NewFile("test.md", []byte("1. a\n"))
+	require.NoError(t, err)
+	d, ok := r.checkItem(f, 0, 0)
+	assert.False(t, ok)
+	assert.Equal(t, lint.Diagnostic{}, d)
+}
+
+func TestCheckItem_LineOutOfBounds(t *testing.T) {
+	r := &Rule{Style: StyleSequential, Start: 1}
+	f, err := lint.NewFile("test.md", []byte("1. a\n"))
+	require.NoError(t, err)
+	d, ok := r.checkItem(f, 999, 0)
+	assert.False(t, ok)
+	assert.Equal(t, lint.Diagnostic{}, d)
+}
+
+func TestCheckItem_NonMarkerLine(t *testing.T) {
+	r := &Rule{Style: StyleSequential, Start: 1}
+	f, err := lint.NewFile("test.md", []byte("hello world\n"))
+	require.NoError(t, err)
+	d, ok := r.checkItem(f, 1, 0)
+	assert.False(t, ok)
+	assert.Equal(t, lint.Diagnostic{}, d)
+}
+
+func TestCollectItemEdits_EmptyItem(t *testing.T) {
+	// A ListItem with no children yields firstLineOfListItem=0,
+	// triggering the bounds guard in collectItemEdits.
+	r := &Rule{Style: StyleSequential, Start: 1}
+	f, err := lint.NewFile("test.md", []byte("1. a\n"))
+	require.NoError(t, err)
+	item := ast.NewListItem(0)
+	markerEdits := map[int]markerEdit{}
+	indentDeltas := map[int]int{}
+	r.collectItemEdits(f, item, 0, markerEdits, indentDeltas)
+	assert.Empty(t, markerEdits)
+	assert.Empty(t, indentDeltas)
+}
+
+func TestFirstLineOfListItem_WithLineSegments(t *testing.T) {
+	// Manually populate Lines() on a ListItem to exercise the
+	// li.Lines().Len() > 0 fast path in firstLineOfListItem.
+	src := []byte("1. a\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	item := ast.NewListItem(0)
+	item.Lines().Append(text.NewSegment(0, 4))
+	line := firstLineOfListItem(f, item)
+	assert.Equal(t, 1, line)
+}
+
+func TestCollectItemEdits_NonMarkerLine(t *testing.T) {
+	// A ListItem whose Lines() point to a non-marker line exercises the
+	// !ok guard in collectItemEdits (and the li.Lines() path in firstLineOfListItem).
+	r := &Rule{Style: StyleSequential, Start: 1}
+	f, err := lint.NewFile("test.md", []byte("hello\n"))
+	require.NoError(t, err)
+	item := ast.NewListItem(0)
+	item.Lines().Append(text.NewSegment(0, 5)) // "hello" — not a list marker
+	markerEdits := map[int]markerEdit{}
+	indentDeltas := map[int]int{}
+	r.collectItemEdits(f, item, 0, markerEdits, indentDeltas)
+	assert.Empty(t, markerEdits)
+	assert.Empty(t, indentDeltas)
+}
+
+func TestCheck_BlockquoteInListItem(t *testing.T) {
+	// An item whose content starts with a blockquote exercises
+	// blockFirstLine's container-block recursion path: BlockQuote
+	// has Lines().Len()==0 and must be recursed into to find the
+	// paragraph that carries the source line.
+	src := []byte("1. > quoted\n2. normal\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestFix_BlockquoteInListItem(t *testing.T) {
+	// Same scenario for Fix: blockFirstLine recursion must correctly
+	// locate the outer list marker so the fix leaves it unchanged
+	// (already sequential).
+	src := []byte("1. > quoted\n2. normal\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	got := r.Fix(f)
+	assert.Equal(t, string(src), string(got))
 }

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -475,6 +475,55 @@ func TestCheck_BlockquoteInListItem(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+func TestFix_WidthGrowth_AdjustsClosingFence(t *testing.T) {
+	// Regression: when a list item's marker grows (1. → 10.), the indent
+	// shift must extend to the closing fence of any fenced code block
+	// inside that item. Goldmark's FencedCodeBlock.Lines() covers only
+	// content lines, so naively using the last segment's Start would
+	// stop the shift before the closing fence, outdenting it and breaking
+	// the block.
+	src := []byte("" +
+		"1. one\n" +
+		"1. two\n" +
+		"1. three\n" +
+		"1. four\n" +
+		"1. five\n" +
+		"1. six\n" +
+		"1. seven\n" +
+		"1. eight\n" +
+		"1. nine\n" +
+		"1. ten\n" +
+		"\n" +
+		"   ```\n" +
+		"   code\n" +
+		"   ```\n" +
+		"\n" +
+		"1. eleven\n",
+	)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	got := r.Fix(f)
+	want := "" +
+		"1. one\n" +
+		"2. two\n" +
+		"3. three\n" +
+		"4. four\n" +
+		"5. five\n" +
+		"6. six\n" +
+		"7. seven\n" +
+		"8. eight\n" +
+		"9. nine\n" +
+		"10. ten\n" +
+		"\n" +
+		"    ```\n" +
+		"    code\n" +
+		"    ```\n" +
+		"\n" +
+		"11. eleven\n"
+	assert.Equal(t, want, string(got))
+}
+
 func TestFix_BlockquoteInListItem(t *testing.T) {
 	// Same scenario for Fix: blockFirstLine recursion must correctly
 	// locate the outer list marker so the fix leaves it unchanged

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -73,6 +73,19 @@ func TestCheck_WrongStart(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "configured start is 1")
 }
 
+func TestCheck_WrongStart_SuppressesPerItemDiagsForRest(t *testing.T) {
+	// Without suppression the items would also fire ("expected 2",
+	// "expected 3") under configured start=1, contradicting the
+	// auto-fix output that simply renumbers from 1.
+	src := []byte("5. a\n5. b\n5. c\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "starts at 5")
+}
+
 func TestCheck_UnorderedListNotFlagged(t *testing.T) {
 	src := []byte("- a\n- b\n- c\n")
 	f, err := lint.NewFile("test.md", src)
@@ -244,4 +257,124 @@ func TestDefaultSettings(t *testing.T) {
 
 func TestRegistered(t *testing.T) {
 	require.NotNil(t, rule.ByID("MDS046"), "rule must register itself")
+}
+
+func TestParseListItemNumber_NoDigits(t *testing.T) {
+	_, _, _, _, ok := parseListItemNumber([]byte("hello"))
+	assert.False(t, ok)
+}
+
+func TestParseListItemNumber_DigitsOnlyNoMarker(t *testing.T) {
+	_, _, _, _, ok := parseListItemNumber([]byte("12"))
+	assert.False(t, ok, "digits with no marker char must not parse")
+}
+
+func TestParseListItemNumber_DigitsWrongFollower(t *testing.T) {
+	_, _, _, _, ok := parseListItemNumber([]byte("12x"))
+	assert.False(t, ok, "non-marker char after digits must not parse")
+}
+
+func TestParseListItemNumber_ParenMarker(t *testing.T) {
+	n, _, _, marker, ok := parseListItemNumber([]byte("3) item"))
+	require.True(t, ok)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, byte(')'), marker)
+}
+
+func TestApplyIndentShift_Zero(t *testing.T) {
+	in := []byte("hello")
+	out := applyIndentShift(in, 0)
+	assert.Equal(t, "hello", string(out))
+}
+
+func TestApplyIndentShift_NegativeExceedsLeading(t *testing.T) {
+	// Asking for -3 when only 1 leading space is present must
+	// return the line unchanged so we never eat content.
+	in := []byte(" hello")
+	out := applyIndentShift(in, -3)
+	assert.Equal(t, " hello", string(out))
+}
+
+func TestReplaceLeadingDigits_NoDigits(t *testing.T) {
+	in := []byte("hello")
+	out := replaceLeadingDigits(in, 7)
+	assert.Equal(t, "hello", string(out))
+}
+
+func TestDigitWidth(t *testing.T) {
+	assert.Equal(t, 1, digitWidth(0))
+	assert.Equal(t, 1, digitWidth(9))
+	assert.Equal(t, 2, digitWidth(10))
+	assert.Equal(t, 3, digitWidth(123))
+}
+
+func TestApplySettings_FloatStart(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"start": 5.0}))
+	assert.Equal(t, 5, r.Start)
+}
+
+func TestCheck_NestedListItemContinuationLines(t *testing.T) {
+	// An item whose content spans multiple block children
+	// (paragraph + nested list) exercises lastLineOfListItem's
+	// recursion through both children.
+	src := []byte("" +
+		"1. parent\n" +
+		"\n" +
+		"   continuation\n" +
+		"\n" +
+		"   - nested\n" +
+		"2. next\n",
+	)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestFix_WidthGrowth_RecursesIntoNestedList(t *testing.T) {
+	// Item 10 in the outer list contains a nested unordered
+	// list. When the outer marker grows from "1." to "10.",
+	// the indent shift must extend through the nested list
+	// content lines — exercises blockLastLine's recursion
+	// through container blocks.
+	src := []byte("" +
+		"1. one\n" +
+		"1. two\n" +
+		"1. three\n" +
+		"1. four\n" +
+		"1. five\n" +
+		"1. six\n" +
+		"1. seven\n" +
+		"1. eight\n" +
+		"1. nine\n" +
+		"1. ten\n" +
+		"\n" +
+		"   - nested under ten\n" +
+		"   - nested under ten too\n" +
+		"\n" +
+		"1. eleven\n",
+	)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleSequential, Start: 1}
+	got := r.Fix(f)
+	want := "" +
+		"1. one\n" +
+		"2. two\n" +
+		"3. three\n" +
+		"4. four\n" +
+		"5. five\n" +
+		"6. six\n" +
+		"7. seven\n" +
+		"8. eight\n" +
+		"9. nine\n" +
+		"10. ten\n" +
+		"\n" +
+		"    - nested under ten\n" +
+		"    - nested under ten too\n" +
+		"\n" +
+		"11. eleven\n"
+	assert.Equal(t, want, string(got))
 }

--- a/plan/110_ordered-list-numbering.md
+++ b/plan/110_ordered-list-numbering.md
@@ -132,8 +132,9 @@ ordered list item {position} numbered {actual}; expected {expected}
 6. [x] Register as MDS046 in category `list`.
 7. [x] Add fixture tests covering each style, the
    width-change case (single-digit to double-digit),
-   wrong start, nested ordered lists, and unordered
-   lists (must not flag).
+   wrong start, nested ordered lists (each nested list
+   is checked independently), and unordered lists
+   (which the rule must not flag).
 8. [x] Add rule README.
 
 ## Acceptance Criteria

--- a/plan/110_ordered-list-numbering.md
+++ b/plan/110_ordered-list-numbering.md
@@ -1,7 +1,7 @@
 ---
 id: 110
 title: Ordered list numbering rule
-status: "🔲"
+status: "✅"
 summary: >-
   New rule MDS046 that pins how ordered lists number
   their items: literal sequential (`1. 2. 3.`) or all
@@ -120,38 +120,38 @@ ordered list item {position} numbered {actual}; expected {expected}
 
 ## Tasks
 
-1. Scaffold `internal/rules/orderedlistnumbering/`.
-2. Implement `Check()` walking ordered `*ast.List`.
-3. Implement source-line parsing for the literal
+1. [x] Scaffold `internal/rules/orderedlistnumbering/`.
+2. [x] Implement `Check()` walking ordered `*ast.List`.
+3. [x] Implement source-line parsing for the literal
    item number.
-4. Implement `rule.Configurable` for `style` and
+4. [x] Implement `rule.Configurable` for `style` and
    `start`.
-5. Implement `Fix()` rewriting numbers and adjusting
+5. [x] Implement `Fix()` rewriting numbers and adjusting
    continuation indentation when marker width
    changes.
-6. Register as MDS046 in category `list`.
-7. Add fixture tests covering each style, the
+6. [x] Register as MDS046 in category `list`.
+7. [x] Add fixture tests covering each style, the
    width-change case (single-digit to double-digit),
    wrong start, nested ordered lists, and unordered
    lists (must not flag).
-8. Add rule README.
+8. [x] Add rule README.
 
 ## Acceptance Criteria
 
-- [ ] `1. a\n2. b\n3. c` with `style: sequential`
+- [x] `1. a\n2. b\n3. c` with `style: sequential`
       emits no diagnostic.
-- [ ] `1. a\n1. b\n1. c` with `style: sequential`
+- [x] `1. a\n1. b\n1. c` with `style: sequential`
       emits two diagnostics and fixes to `1. 2. 3.`.
-- [ ] `1. a\n1. b\n1. c` with `style: all-ones`
+- [x] `1. a\n1. b\n1. c` with `style: all-ones`
       emits no diagnostic.
-- [ ] `1. a\n3. b\n7. c` with `style: all-ones`
+- [x] `1. a\n3. b\n7. c` with `style: all-ones`
       emits two diagnostics and fixes to all `1.`.
-- [ ] `5. a\n6. b` with `start: 1` emits one
+- [x] `5. a\n6. b` with `start: 1` emits one
       diagnostic naming the wrong start.
-- [ ] A 12-item sequential list fixes the
+- [x] A 12-item sequential list fixes the
       single-to-double-digit boundary without
       breaking continuation indent.
-- [ ] Unordered lists emit no diagnostic.
-- [ ] Rule is disabled by default.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] Unordered lists emit no diagnostic.
+- [x] Rule is disabled by default.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

Implements MDS046, a new opt-in rule that pins how ordered lists are numbered in source: `sequential` (1. 2. 3.) or `all-ones` (1. 1. 1.), with a configurable required first number.

## Key Changes

- **Rule** (`internal/rules/orderedlistnumbering/rule.go`): walks ordered `*ast.List` nodes, parses the literal number from each item's source line, and emits diagnostics when the literal does not match the expected number under the configured `style` and `start`. Each list (including nested ordered lists) is checked independently.
- **Auto-fix**: rewrites markers and shifts the indentation of continuation lines / nested blocks when a marker's digit width changes (e.g. `9.` → `10.`). Blank lines inside a list item are left unchanged so the fix never introduces trailing whitespace.
- **Settings**: `style` accepts `sequential` (default) or `all-ones`; `start` is a non-negative integer (default `1`). Invalid values are rejected at config-load time in `ApplySettings`.
- **Default state**: opt-in (`EnabledByDefault() == false`).

## Diagnostic Semantics

When a list's first item starts at a number different from the configured `start`, only the start-mismatch diagnostic is emitted for that list. Per-item diagnostics use the configured `start` as their baseline (matching what the auto-fix produces), so reporting them alongside "wrong start" would name renumbering that the start fix already covers.

## Tests & Docs

- Unit tests in `rule_test.go` cover sequential/all-ones styles, wrong-start suppression, nested ordered lists, the digit-width boundary in both directions, blank-line preservation through nested blocks, and settings validation.
- Folder fixtures under `internal/rules/MDS046-ordered-list-numbering/{good,bad,fixed}/` exercise the same behaviors via the integration runner.
- Rule README documents settings, examples, diagnostics, and edge cases (digit-width re-indent, nested lists, start-mismatch suppression).

## Plan

`plan/110_ordered-list-numbering.md` flipped to `✅`; `PLAN.md` and `internal/rules/index.md` catalogs regenerated.

https://claude.ai/code/session_01GNiW2C45t8J536sfSraMtL