### PR TITLE
Suppress diagnostics inside generated sections during fix

### DIFF
--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -135,17 +135,11 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 		modified = path
 	}
 
-	finalFile, err := lint.NewFile(path, current)
+	finalFile, err := buildPostFixFile(path, current, lf, dirFS)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("parsing %q after fix: %w", path, err))
 		return beforeDiags, beforeDiags, modified, errs
 	}
-	finalFile.FS = dirFS
-	finalFile.RootFS = lf.RootFS
-	finalFile.RootDir = lf.RootDir
-	finalFile.FrontMatter = lf.FrontMatter
-	finalFile.LineOffset = lf.LineOffset
-	finalFile.GeneratedRanges = gensection.FindAllGeneratedRanges(finalFile)
 
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
@@ -153,6 +147,30 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 		explain.Attach(diags, f.Config, path, fmKinds)
 	}
 	return beforeDiags, diags, modified, errs
+}
+
+// buildPostFixFile parses post-fix bytes and mirrors onto the new
+// *lint.File the parse-time and resolution context that the engine
+// runner sets per-file (see runner.go ~line 90-108). Without these,
+// the post-fix CheckRules call would diverge from both the pre-fix
+// call and from `mdsmith check` for rules that consult these fields:
+// MaxInputBytes (catalog/include/requiredstructure secondary reads),
+// StripFrontMatter (cross-file coordinate alignment), GeneratedRanges
+// (generated-section diagnostic suppression).
+func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) (*lint.File, error) {
+	finalFile, err := lint.NewFile(path, source)
+	if err != nil {
+		return nil, err
+	}
+	finalFile.FS = dirFS
+	finalFile.RootFS = lf.RootFS
+	finalFile.RootDir = lf.RootDir
+	finalFile.FrontMatter = lf.FrontMatter
+	finalFile.LineOffset = lf.LineOffset
+	finalFile.StripFrontMatter = lf.StripFrontMatter
+	finalFile.MaxInputBytes = lf.MaxInputBytes
+	finalFile.GeneratedRanges = gensection.FindAllGeneratedRanges(finalFile)
+	return finalFile, nil
 }
 
 // applyFixPasses repeatedly applies fixable rules until the content stabilizes.

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -149,7 +149,7 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 	beforeDiags, checkErrs := engine.CheckRules(lf, f.Rules, effective)
 	errs = append(errs, append(settingsErrs, checkErrs...)...)
 
-	current := f.applyFixPasses(path, lf.Source, fixable, dirFS, &errs)
+	current := f.applyFixPasses(path, lf.Source, fixable, lf, dirFS, &errs)
 
 	var modified string
 	if !bytes.Equal(lf.Source, current) {
@@ -175,35 +175,44 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 	return beforeDiags, diags, modified, errs
 }
 
-// buildPostFixFile parses post-fix bytes and mirrors onto the new
-// *lint.File the parse-time and resolution context that the engine
-// runner sets per-file (see runner.go ~line 90-108). Without these,
-// the post-fix CheckRules call would diverge from both the pre-fix
-// call and from `mdsmith check` for rules that consult these fields:
-// MaxInputBytes (catalog/include/requiredstructure secondary reads),
-// StripFrontMatter (cross-file coordinate alignment), GeneratedRanges
-// (generated-section diagnostic suppression), GitignoreFunc (catalog
-// glob filtering).
+// hydrateLintFile copies onto a freshly-parsed *lint.File the parse-
+// time and resolution context that the engine.Runner sets per-file
+// (see runner.go ~line 90-108): FS, RootFS/RootDir, FrontMatter,
+// LineOffset, StripFrontMatter, MaxInputBytes, GitignoreFunc, and
+// GeneratedRanges (recomputed for the parsed bytes). Used by both
+// the post-fix CheckRules call and the parsedFile inside each
+// applyFixPasses iteration so rules see the same File regardless of
+// which Fixer phase invokes them. Without this, fixable rules like
+// catalog (consults GetGitignore for glob filtering) and include
+// (consults MaxInputBytes for secondary reads) silently produce
+// different post-fix bytes than `mdsmith check` would have validated.
+func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS) {
+	parsed.FS = dirFS
+	parsed.RootFS = lf.RootFS
+	parsed.RootDir = lf.RootDir
+	parsed.FrontMatter = lf.FrontMatter
+	parsed.LineOffset = lf.LineOffset
+	parsed.StripFrontMatter = lf.StripFrontMatter
+	parsed.MaxInputBytes = lf.MaxInputBytes
+	parsed.GitignoreFunc = lf.GitignoreFunc
+	parsed.GeneratedRanges = gensection.FindAllGeneratedRanges(parsed)
+}
+
+// buildPostFixFile parses post-fix bytes and hydrates them with the
+// per-file context from lf so the post-fix CheckRules call sees the
+// same lint.File the runner would.
 func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) (*lint.File, error) {
 	finalFile, err := lint.NewFile(path, source)
 	if err != nil {
 		return nil, err
 	}
-	finalFile.FS = dirFS
-	finalFile.RootFS = lf.RootFS
-	finalFile.RootDir = lf.RootDir
-	finalFile.FrontMatter = lf.FrontMatter
-	finalFile.LineOffset = lf.LineOffset
-	finalFile.StripFrontMatter = lf.StripFrontMatter
-	finalFile.MaxInputBytes = lf.MaxInputBytes
-	finalFile.GitignoreFunc = lf.GitignoreFunc
-	finalFile.GeneratedRanges = gensection.FindAllGeneratedRanges(finalFile)
+	hydrateLintFile(finalFile, lf, dirFS)
 	return finalFile, nil
 }
 
 // applyFixPasses repeatedly applies fixable rules until the content stabilizes.
 func (f *Fixer) applyFixPasses(
-	path string, source []byte, fixable []rule.FixableRule, dirFS fs.FS, errs *[]error,
+	path string, source []byte, fixable []rule.FixableRule, lf *lint.File, dirFS fs.FS, errs *[]error,
 ) []byte {
 	const maxPasses = 10
 	current := source
@@ -216,10 +225,7 @@ func (f *Fixer) applyFixPasses(
 				*errs = append(*errs, fmt.Errorf("parsing %q: %w", path, err))
 				break
 			}
-			parsedFile.FS = dirFS
-			if f.RootDir != "" {
-				parsedFile.SetRootDir(f.RootDir)
-			}
+			hydrateLintFile(parsedFile, lf, dirFS)
 
 			diags := fr.Check(parsedFile)
 			if len(diags) == 0 {

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -33,6 +33,32 @@ type Fixer struct {
 	// remaining diagnostic so output formatters can render an
 	// explanation trailer.
 	Explain bool
+
+	// gitignoreCache caches GitignoreMatchers by directory so the
+	// matcher tree is walked once per directory across a fix run,
+	// matching the engine.Runner cache contract that catalog and
+	// other gitignore-aware rules expect.
+	gitignoreCache map[string]*lint.GitignoreMatcher
+}
+
+// cachedGitignore returns a GitignoreMatcher for the given directory,
+// creating and caching it on first use. Mirrors engine.Runner so the
+// fix path's lint.File values give catalog (and any other rule that
+// calls f.GetGitignore()) the same matcher the check path would.
+func (f *Fixer) cachedGitignore(dir string) *lint.GitignoreMatcher {
+	if f.gitignoreCache == nil {
+		f.gitignoreCache = make(map[string]*lint.GitignoreMatcher)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		absDir = filepath.Clean(dir)
+	}
+	if m, ok := f.gitignoreCache[absDir]; ok {
+		return m
+	}
+	m := lint.NewGitignoreMatcher(absDir)
+	f.gitignoreCache[absDir] = m
+	return m
 }
 
 // Result holds the outcome of a fix run.
@@ -156,7 +182,8 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 // call and from `mdsmith check` for rules that consult these fields:
 // MaxInputBytes (catalog/include/requiredstructure secondary reads),
 // StripFrontMatter (cross-file coordinate alignment), GeneratedRanges
-// (generated-section diagnostic suppression).
+// (generated-section diagnostic suppression), GitignoreFunc (catalog
+// glob filtering).
 func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) (*lint.File, error) {
 	finalFile, err := lint.NewFile(path, source)
 	if err != nil {
@@ -169,6 +196,7 @@ func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) (*
 	finalFile.LineOffset = lf.LineOffset
 	finalFile.StripFrontMatter = lf.StripFrontMatter
 	finalFile.MaxInputBytes = lf.MaxInputBytes
+	finalFile.GitignoreFunc = lf.GitignoreFunc
 	finalFile.GeneratedRanges = gensection.FindAllGeneratedRanges(finalFile)
 	return finalFile, nil
 }
@@ -241,10 +269,17 @@ func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []st
 		return nil, nil, nil, fmt.Errorf("parsing %q: %w", path, err)
 	}
 	lf.MaxInputBytes = f.MaxInputBytes
-	dirFS := os.DirFS(filepath.Dir(path))
+	dir := filepath.Dir(path)
+	dirFS := os.DirFS(dir)
 	lf.FS = dirFS
+	gitignoreDir := dir
 	if f.RootDir != "" {
 		lf.SetRootDir(f.RootDir)
+		gitignoreDir = f.RootDir
+	}
+	gd := gitignoreDir // capture for closure
+	lf.GitignoreFunc = func() *lint.GitignoreMatcher {
+		return f.cachedGitignore(gd)
 	}
 	kinds, err := lint.ParseFrontMatterKinds(lf.FrontMatter)
 	if err != nil {

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -47,21 +47,23 @@ type Fixer struct {
 // lint.File values give catalog (and any other rule that calls
 // f.GetGitignore()) the same matcher the check path would.
 //
-// The cache is keyed on the raw dir string. lint.NewGitignoreMatcher
-// canonicalizes the path internally before walking, so the matcher
-// itself is correctly rooted regardless of whether dir was passed
-// absolute or relative; the cache key just has to be deterministic
-// across calls within a Fix run, which prepareFile guarantees by
-// always passing the same form (filepath.Dir(path) or f.RootDir).
+// The cache key is filepath.Clean(dir). Clean is total (no error
+// path) and idempotent, and it collapses equivalent forms like
+// "./sub" and "sub" / "sub/" so callers passing the same logical
+// directory in slightly different syntactic forms share one cache
+// entry. lint.NewGitignoreMatcher canonicalizes its argument
+// internally (filepath.Abs) before walking, so the matcher itself is
+// correctly rooted even when the cleaned key is still relative.
 func (f *Fixer) cachedGitignore(dir string) *lint.GitignoreMatcher {
 	if f.gitignoreCache == nil {
 		f.gitignoreCache = make(map[string]*lint.GitignoreMatcher)
 	}
-	if m, ok := f.gitignoreCache[dir]; ok {
+	key := filepath.Clean(dir)
+	if m, ok := f.gitignoreCache[key]; ok {
 		return m
 	}
-	m := lint.NewGitignoreMatcher(dir)
-	f.gitignoreCache[dir] = m
+	m := lint.NewGitignoreMatcher(key)
+	f.gitignoreCache[key] = m
 	return m
 }
 

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -45,14 +45,19 @@ type Fixer struct {
 // creating and caching it on first use. Mirrors engine.Runner so the
 // fix path's lint.File values give catalog (and any other rule that
 // calls f.GetGitignore()) the same matcher the check path would.
+//
+// filepath.Abs is allowed to error (it can fail when the process
+// can't read its current directory); on that path it returns the
+// input string unchanged, which is still a usable cache key — the
+// only consequence is that two callers passing the same relative
+// path from different working directories would share a cache entry,
+// which is acceptable for the fix pipeline that always passes either
+// filepath.Dir(path) or f.RootDir.
 func (f *Fixer) cachedGitignore(dir string) *lint.GitignoreMatcher {
 	if f.gitignoreCache == nil {
 		f.gitignoreCache = make(map[string]*lint.GitignoreMatcher)
 	}
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		absDir = filepath.Clean(dir)
-	}
+	absDir, _ := filepath.Abs(dir)
 	if m, ok := f.gitignoreCache[absDir]; ok {
 		return m
 	}
@@ -161,11 +166,7 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 		modified = path
 	}
 
-	finalFile, err := buildPostFixFile(path, current, lf, dirFS)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("parsing %q after fix: %w", path, err))
-		return beforeDiags, beforeDiags, modified, errs
-	}
+	finalFile := buildPostFixFile(path, current, lf, dirFS)
 
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
@@ -201,13 +202,10 @@ func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS) {
 // buildPostFixFile parses post-fix bytes and hydrates them with the
 // per-file context from lf so the post-fix CheckRules call sees the
 // same lint.File the runner would.
-func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) (*lint.File, error) {
-	finalFile, err := lint.NewFile(path, source)
-	if err != nil {
-		return nil, err
-	}
+func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) *lint.File {
+	finalFile, _ := lint.NewFile(path, source) // NewFile never errors with current implementation
 	hydrateLintFile(finalFile, lf, dirFS)
-	return finalFile, nil
+	return finalFile
 }
 
 // applyFixPasses repeatedly applies fixable rules until the content stabilizes.

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/engine"
 	"github.com/jeduden/mdsmith/internal/explain"
@@ -118,6 +119,7 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 	f.logRules(effective)
 
 	fixable, settingsErrs := f.fixableRules(effective)
+	lf.GeneratedRanges = gensection.FindAllGeneratedRanges(lf)
 	beforeDiags, checkErrs := engine.CheckRules(lf, f.Rules, effective)
 	errs = append(errs, append(settingsErrs, checkErrs...)...)
 
@@ -143,6 +145,7 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 	finalFile.RootDir = lf.RootDir
 	finalFile.FrontMatter = lf.FrontMatter
 	finalFile.LineOffset = lf.LineOffset
+	finalFile.GeneratedRanges = gensection.FindAllGeneratedRanges(finalFile)
 
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -42,27 +42,26 @@ type Fixer struct {
 }
 
 // cachedGitignore returns a GitignoreMatcher for the given directory,
-// creating and caching it on first use. Mirrors engine.Runner so the
-// fix path's lint.File values give catalog (and any other rule that
-// calls f.GetGitignore()) the same matcher the check path would.
+// creating and caching it on first use so the matcher tree is walked
+// once per (Fixer, dir). Mirrors engine.Runner so the fix path's
+// lint.File values give catalog (and any other rule that calls
+// f.GetGitignore()) the same matcher the check path would.
 //
-// filepath.Abs is allowed to error (it can fail when the process
-// can't read its current directory); on that path it returns the
-// input string unchanged, which is still a usable cache key — the
-// only consequence is that two callers passing the same relative
-// path from different working directories would share a cache entry,
-// which is acceptable for the fix pipeline that always passes either
-// filepath.Dir(path) or f.RootDir.
+// The cache is keyed on the raw dir string. lint.NewGitignoreMatcher
+// canonicalizes the path internally before walking, so the matcher
+// itself is correctly rooted regardless of whether dir was passed
+// absolute or relative; the cache key just has to be deterministic
+// across calls within a Fix run, which prepareFile guarantees by
+// always passing the same form (filepath.Dir(path) or f.RootDir).
 func (f *Fixer) cachedGitignore(dir string) *lint.GitignoreMatcher {
 	if f.gitignoreCache == nil {
 		f.gitignoreCache = make(map[string]*lint.GitignoreMatcher)
 	}
-	absDir, _ := filepath.Abs(dir)
-	if m, ok := f.gitignoreCache[absDir]; ok {
+	if m, ok := f.gitignoreCache[dir]; ok {
 		return m
 	}
-	m := lint.NewGitignoreMatcher(absDir)
-	f.gitignoreCache[absDir] = m
+	m := lint.NewGitignoreMatcher(dir)
+	f.gitignoreCache[dir] = m
 	return m
 }
 

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -102,3 +102,74 @@ func TestFix_SuppressesDiagnosticsInsideCatalogBody(t *testing.T) {
 		"pre-fix Failures should exclude the generated-body line, got %d (no filtering applied)",
 		result.Failures)
 }
+
+// fieldRecordingRule captures f.MaxInputBytes and f.StripFrontMatter
+// on every Check invocation. Rules in the wild (catalog, include,
+// duplicatedcontent, requiredstructure, crossfilereferenceintegrity)
+// consult these fields when reading secondary files; if the Fixer's
+// post-fix lint pass receives a *lint.File where these are zero, the
+// post-fix CheckRules call diverges from the pre-fix call and from
+// the Runner.
+type fieldRecordingRule struct {
+	id       string
+	name     string
+	maxBytes []int64
+	stripFM  []bool
+}
+
+func (r *fieldRecordingRule) ID() string       { return r.id }
+func (r *fieldRecordingRule) Name() string     { return r.name }
+func (r *fieldRecordingRule) Category() string { return "test" }
+func (r *fieldRecordingRule) Check(f *lint.File) []lint.Diagnostic {
+	r.maxBytes = append(r.maxBytes, f.MaxInputBytes)
+	r.stripFM = append(r.stripFM, f.StripFrontMatter)
+	return nil
+}
+
+// TestFix_FinalFileInheritsParseTimeFields verifies that the post-fix
+// CheckRules call receives a *lint.File whose MaxInputBytes and
+// StripFrontMatter mirror the pre-fix file's values. The Runner
+// already establishes these on its single File before linting; the
+// Fixer parses a fresh finalFile after applyFixPasses and must
+// propagate the same fields, otherwise rules that consult them (e.g.
+// catalog/include reading secondary files, duplicatedcontent computing
+// cross-file coordinates) silently diverge between fix and check on
+// the same source bytes.
+func TestFix_FinalFileInheritsParseTimeFields(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(mdPath, []byte("---\ntitle: t\n---\n# Doc\n"), 0o644))
+
+	const ruleName = "field-recorder"
+	const wantMaxBytes int64 = 4096
+	rec := &fieldRecordingRule{id: "MDS998", name: ruleName}
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			ruleName: {Enabled: true},
+		},
+	}
+
+	fixer := &Fixer{
+		Config:           cfg,
+		Rules:            []rule.Rule{rec},
+		StripFrontMatter: true,
+		MaxInputBytes:    wantMaxBytes,
+	}
+
+	result := fixer.Fix([]string{mdPath})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	// Two CheckRules calls per file: one pre-fix on lf, one post-fix
+	// on finalFile. Both must see the configured values.
+	require.Len(t, rec.maxBytes, 2,
+		"expected one Check call pre-fix and one post-fix, got %d", len(rec.maxBytes))
+	for i, got := range rec.maxBytes {
+		assert.Equal(t, wantMaxBytes, got,
+			"call %d: MaxInputBytes not propagated to lint.File", i)
+	}
+	for i, got := range rec.stripFM {
+		assert.True(t, got,
+			"call %d: StripFrontMatter not propagated to lint.File", i)
+	}
+}

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -103,6 +103,64 @@ func TestFix_SuppressesDiagnosticsInsideCatalogBody(t *testing.T) {
 		result.Failures)
 }
 
+// gitignoreProbeRule records, on every Check call, whether the file
+// has a non-nil GitignoreFunc set. Rules in the wild (catalog uses
+// f.GetGitignore() in resolveGitignore) silently lose gitignore
+// filtering when the matcher is nil — so a missing GitignoreFunc on
+// the Fixer's lint.File causes catalog output to disagree between
+// `mdsmith fix` and `mdsmith check` on the same source bytes.
+type gitignoreProbeRule struct {
+	id         string
+	name       string
+	hasMatcher []bool
+}
+
+func (r *gitignoreProbeRule) ID() string       { return r.id }
+func (r *gitignoreProbeRule) Name() string     { return r.name }
+func (r *gitignoreProbeRule) Category() string { return "test" }
+func (r *gitignoreProbeRule) Check(f *lint.File) []lint.Diagnostic {
+	r.hasMatcher = append(r.hasMatcher, f.GetGitignore() != nil)
+	return nil
+}
+
+// TestFix_FilesHaveGitignoreFunc verifies that the Fixer wires
+// GitignoreFunc onto its *lint.File the same way the Runner does, so
+// rules that consult f.GetGitignore() (catalog) behave identically
+// during fix and check. Without this, a catalog directive whose glob
+// matches gitignored files would include those files in the fix-time
+// regenerated catalog body but exclude them at check time.
+func TestFix_FilesHaveGitignoreFunc(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(mdPath, []byte("# Doc\n"), 0o644))
+
+	const ruleName = "gitignore-probe"
+	probe := &gitignoreProbeRule{id: "MDS997", name: ruleName}
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			ruleName: {Enabled: true},
+		},
+	}
+
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{probe},
+	}
+
+	result := fixer.Fix([]string{mdPath})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	// Pre-fix and post-fix Check calls; both must see a usable
+	// gitignore matcher (parity with engine.Runner's per-file setup).
+	require.Len(t, probe.hasMatcher, 2,
+		"expected one Check call pre-fix and one post-fix, got %d", len(probe.hasMatcher))
+	for i, ok := range probe.hasMatcher {
+		assert.True(t, ok,
+			"call %d: f.GetGitignore() returned nil — Fixer did not wire GitignoreFunc", i)
+	}
+}
+
 // fieldRecordingRule captures f.MaxInputBytes and f.StripFrontMatter
 // on every Check invocation. Rules in the wild (catalog, include,
 // duplicatedcontent, requiredstructure, crossfilereferenceintegrity)

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -228,32 +228,47 @@ func TestFix_FilesHaveGitignoreFuncWithRootDir(t *testing.T) {
 	}
 }
 
-// fixPassProbeRule is a fixable rule that records, on each Check
-// invocation inside applyFixPasses, whether the parsedFile carries
-// the per-file context (MaxInputBytes / StripFrontMatter /
-// GitignoreFunc / GeneratedRanges) that the engine.Runner sets. Its
-// Fix returns the source unchanged so applyFixPasses stabilizes
-// after one iteration.
+// fileSnapshot records the per-file context fields that should be
+// hydrated identically across pre-fix Check, fix-pass Check, fix-pass
+// Fix, and post-fix Check. Captured on every invocation so the test
+// can assert hydration in each phase independently.
+type fileSnapshot struct {
+	maxBytes int64
+	stripFM  bool
+	hasGI    bool
+	hasRange bool
+}
+
+func snapshotOf(f *lint.File) fileSnapshot {
+	return fileSnapshot{
+		maxBytes: f.MaxInputBytes,
+		stripFM:  f.StripFrontMatter,
+		hasGI:    f.GetGitignore() != nil,
+		hasRange: len(f.GeneratedRanges) > 0,
+	}
+}
+
+// fixPassProbeRule is a fixable rule that records every Check and
+// Fix invocation it receives. Check returns a diagnostic on its
+// second call so that applyFixPasses (which runs Check after the
+// pre-fix engine.CheckRules has already run Check once) sees a
+// non-empty diagnostic list and is forced to call Fix. Fix returns
+// the source unchanged so applyFixPasses stabilizes after one
+// iteration.
 type fixPassProbeRule struct {
-	id       string
-	name     string
-	maxBytes []int64
-	stripFM  []bool
-	hasGI    []bool
-	hasRange []bool
+	id           string
+	name         string
+	checkSnaps   []fileSnapshot
+	fixSnaps     []fileSnapshot
+	triggerOnNth int // 1-based: which Check call returns a diag
 }
 
 func (r *fixPassProbeRule) ID() string       { return r.id }
 func (r *fixPassProbeRule) Name() string     { return r.name }
 func (r *fixPassProbeRule) Category() string { return "test" }
 func (r *fixPassProbeRule) Check(f *lint.File) []lint.Diagnostic {
-	r.maxBytes = append(r.maxBytes, f.MaxInputBytes)
-	r.stripFM = append(r.stripFM, f.StripFrontMatter)
-	r.hasGI = append(r.hasGI, f.GetGitignore() != nil)
-	r.hasRange = append(r.hasRange, len(f.GeneratedRanges) > 0)
-	// Return one diagnostic on the first call so applyFixPasses also
-	// invokes Fix; subsequent calls return nil so the loop stabilizes.
-	if len(r.maxBytes) == 1 {
+	r.checkSnaps = append(r.checkSnaps, snapshotOf(f))
+	if len(r.checkSnaps) == r.triggerOnNth {
 		return []lint.Diagnostic{{
 			File: f.Path, Line: 1, Column: 1,
 			RuleID: r.id, RuleName: r.name,
@@ -262,17 +277,31 @@ func (r *fixPassProbeRule) Check(f *lint.File) []lint.Diagnostic {
 	}
 	return nil
 }
-func (r *fixPassProbeRule) Fix(f *lint.File) []byte { return f.Source }
+func (r *fixPassProbeRule) Fix(f *lint.File) []byte {
+	r.fixSnaps = append(r.fixSnaps, snapshotOf(f))
+	return f.Source
+}
 
 var _ rule.FixableRule = (*fixPassProbeRule)(nil)
 
 // TestFix_FixPassesHydrateLintFile verifies that the parsedFile used
 // inside applyFixPasses carries the same per-file context that the
-// pre-fix and post-fix CheckRules calls already use. Without this,
-// fixable rules that consult these fields during their own Check or
-// Fix (notably catalog: GetGitignore for glob filtering, include:
-// MaxInputBytes for secondary reads) silently produce different
-// post-fix bytes than `mdsmith check` would have validated against.
+// pre-fix and post-fix CheckRules calls already use, AND that the
+// hydration is present when applyFixPasses calls fr.Fix (not just
+// fr.Check). Without this, fixable rules that consult these fields
+// during their own Check or Fix (notably catalog: GetGitignore for
+// glob filtering, include: MaxInputBytes for secondary reads)
+// silently produce different post-fix bytes than `mdsmith check`
+// would have validated against.
+//
+// Phase layout (one fixable rule, Fix returns same source):
+//  1. pre-fix engine.CheckRules → Check call #1
+//  2. applyFixPasses pass 1     → Check call #2, then Fix call #1
+//     (loop sees source unchanged → break)
+//  3. post-fix engine.CheckRules → Check call #3
+//
+// The probe is configured to return a diagnostic on Check call #2 so
+// that step 2's Fix actually fires.
 func TestFix_FixPassesHydrateLintFile(t *testing.T) {
 	dir := t.TempDir()
 	mdPath := filepath.Join(dir, "doc.md")
@@ -284,7 +313,7 @@ func TestFix_FixPassesHydrateLintFile(t *testing.T) {
 
 	const ruleName = "fix-pass-probe"
 	const wantMaxBytes int64 = 8192
-	probe := &fixPassProbeRule{id: "MDS996", name: ruleName}
+	probe := &fixPassProbeRule{id: "MDS996", name: ruleName, triggerOnNth: 2}
 
 	cfg := &config.Config{
 		Rules: map[string]config.RuleCfg{
@@ -302,26 +331,22 @@ func TestFix_FixPassesHydrateLintFile(t *testing.T) {
 	result := fixer.Fix([]string{mdPath})
 	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
 
-	// applyFixPasses calls Check at least once on parsedFile; that
-	// parsedFile must carry the per-file context.
-	require.NotEmpty(t, probe.maxBytes,
-		"fixable rule was never invoked inside applyFixPasses")
-	for i, got := range probe.maxBytes {
-		assert.Equal(t, wantMaxBytes, got,
-			"fix-pass call %d: MaxInputBytes not propagated to parsedFile", i)
+	// Three Check calls (pre-fix, fix-pass, post-fix) and exactly
+	// one Fix call (from inside applyFixPasses). If the fix-pass
+	// Check had no diagnostic to trigger Fix, fixSnaps would be
+	// empty — that is the regression this test guards against.
+	require.Len(t, probe.checkSnaps, 3,
+		"expected 3 Check calls (pre-fix + fix-pass + post-fix), got %d", len(probe.checkSnaps))
+	require.Len(t, probe.fixSnaps, 1,
+		"expected 1 Fix call from inside applyFixPasses, got %d", len(probe.fixSnaps))
+
+	want := fileSnapshot{maxBytes: wantMaxBytes, stripFM: true, hasGI: true, hasRange: true}
+	phases := []string{"pre-fix Check", "fix-pass Check", "post-fix Check"}
+	for i, got := range probe.checkSnaps {
+		assert.Equal(t, want, got, "%s: per-file context not hydrated", phases[i])
 	}
-	for i, got := range probe.stripFM {
-		assert.True(t, got,
-			"fix-pass call %d: StripFrontMatter not propagated to parsedFile", i)
-	}
-	for i, got := range probe.hasGI {
-		assert.True(t, got,
-			"fix-pass call %d: GitignoreFunc not propagated to parsedFile", i)
-	}
-	for i, got := range probe.hasRange {
-		assert.True(t, got,
-			"fix-pass call %d: GeneratedRanges not populated on parsedFile (catalog body unprotected)", i)
-	}
+	assert.Equal(t, want, probe.fixSnaps[0],
+		"fix-pass Fix: per-file context not hydrated (catalog/include rules would silently behave differently)")
 }
 
 // fieldRecordingRule captures f.MaxInputBytes and f.StripFrontMatter

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -161,6 +161,137 @@ func TestFix_FilesHaveGitignoreFunc(t *testing.T) {
 	}
 }
 
+// TestFix_FilesHaveGitignoreFuncWithRootDir covers the prepareFile
+// branch where Fixer.RootDir is set (gitignore matcher is anchored at
+// the root rather than the file's directory). Without a test that
+// configures RootDir, the branch flipping gitignoreDir = f.RootDir is
+// never executed.
+func TestFix_FilesHaveGitignoreFuncWithRootDir(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(mdPath, []byte("# Doc\n"), 0o644))
+
+	const ruleName = "gitignore-probe-root"
+	probe := &gitignoreProbeRule{id: "MDS995", name: ruleName}
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			ruleName: {Enabled: true},
+		},
+	}
+
+	fixer := &Fixer{
+		Config:  cfg,
+		Rules:   []rule.Rule{probe},
+		RootDir: dir,
+	}
+
+	result := fixer.Fix([]string{mdPath})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+	require.Len(t, probe.hasMatcher, 2,
+		"expected pre-fix and post-fix Check calls, got %d", len(probe.hasMatcher))
+	for i, ok := range probe.hasMatcher {
+		assert.True(t, ok,
+			"call %d: f.GetGitignore() returned nil under RootDir mode", i)
+	}
+}
+
+// fixPassProbeRule is a fixable rule that records, on each Check
+// invocation inside applyFixPasses, whether the parsedFile carries
+// the per-file context (MaxInputBytes / StripFrontMatter /
+// GitignoreFunc / GeneratedRanges) that the engine.Runner sets. Its
+// Fix returns the source unchanged so applyFixPasses stabilizes
+// after one iteration.
+type fixPassProbeRule struct {
+	id       string
+	name     string
+	maxBytes []int64
+	stripFM  []bool
+	hasGI    []bool
+	hasRange []bool
+}
+
+func (r *fixPassProbeRule) ID() string       { return r.id }
+func (r *fixPassProbeRule) Name() string     { return r.name }
+func (r *fixPassProbeRule) Category() string { return "test" }
+func (r *fixPassProbeRule) Check(f *lint.File) []lint.Diagnostic {
+	r.maxBytes = append(r.maxBytes, f.MaxInputBytes)
+	r.stripFM = append(r.stripFM, f.StripFrontMatter)
+	r.hasGI = append(r.hasGI, f.GetGitignore() != nil)
+	r.hasRange = append(r.hasRange, len(f.GeneratedRanges) > 0)
+	// Return one diagnostic on the first call so applyFixPasses also
+	// invokes Fix; subsequent calls return nil so the loop stabilizes.
+	if len(r.maxBytes) == 1 {
+		return []lint.Diagnostic{{
+			File: f.Path, Line: 1, Column: 1,
+			RuleID: r.id, RuleName: r.name,
+			Severity: lint.Warning, Message: "trigger fix",
+		}}
+	}
+	return nil
+}
+func (r *fixPassProbeRule) Fix(f *lint.File) []byte { return f.Source }
+
+var _ rule.FixableRule = (*fixPassProbeRule)(nil)
+
+// TestFix_FixPassesHydrateLintFile verifies that the parsedFile used
+// inside applyFixPasses carries the same per-file context that the
+// pre-fix and post-fix CheckRules calls already use. Without this,
+// fixable rules that consult these fields during their own Check or
+// Fix (notably catalog: GetGitignore for glob filtering, include:
+// MaxInputBytes for secondary reads) silently produce different
+// post-fix bytes than `mdsmith check` would have validated against.
+func TestFix_FixPassesHydrateLintFile(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "doc.md")
+	host := "---\ntitle: t\n---\n# Doc\n\n" +
+		"<?catalog\nglob: \"*.md\"\nrow: \"- {filename}\"\n?>\n" +
+		"- doc.md\n" +
+		"<?/catalog?>\n"
+	require.NoError(t, os.WriteFile(mdPath, []byte(host), 0o644))
+
+	const ruleName = "fix-pass-probe"
+	const wantMaxBytes int64 = 8192
+	probe := &fixPassProbeRule{id: "MDS996", name: ruleName}
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			ruleName: {Enabled: true},
+		},
+	}
+
+	fixer := &Fixer{
+		Config:           cfg,
+		Rules:            []rule.Rule{probe},
+		StripFrontMatter: true,
+		MaxInputBytes:    wantMaxBytes,
+	}
+
+	result := fixer.Fix([]string{mdPath})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	// applyFixPasses calls Check at least once on parsedFile; that
+	// parsedFile must carry the per-file context.
+	require.NotEmpty(t, probe.maxBytes,
+		"fixable rule was never invoked inside applyFixPasses")
+	for i, got := range probe.maxBytes {
+		assert.Equal(t, wantMaxBytes, got,
+			"fix-pass call %d: MaxInputBytes not propagated to parsedFile", i)
+	}
+	for i, got := range probe.stripFM {
+		assert.True(t, got,
+			"fix-pass call %d: StripFrontMatter not propagated to parsedFile", i)
+	}
+	for i, got := range probe.hasGI {
+		assert.True(t, got,
+			"fix-pass call %d: GitignoreFunc not propagated to parsedFile", i)
+	}
+	for i, got := range probe.hasRange {
+		assert.True(t, got,
+			"fix-pass call %d: GeneratedRanges not populated on parsedFile (catalog body unprotected)", i)
+	}
+}
+
 // fieldRecordingRule captures f.MaxInputBytes and f.StripFrontMatter
 // on every Check invocation. Rules in the wild (catalog, include,
 // duplicatedcontent, requiredstructure, crossfilereferenceintegrity)

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -161,36 +161,42 @@ func TestFix_FilesHaveGitignoreFunc(t *testing.T) {
 	}
 }
 
-// TestFixer_CachedGitignore_DistinctKeys directly exercises the
-// cache contract: distinct inputs must yield distinct matchers, and
-// a repeat input must hit the cache. The previous implementation
-// canonicalized via filepath.Abs and silently swallowed Abs's error
-// return, which would collapse every relative path to the empty
-// string ("") cache key on Abs failure (e.g., unreadable cwd) and
-// share one matcher across unrelated directories.
-func TestFixer_CachedGitignore_DistinctKeys(t *testing.T) {
+// TestFixer_CachedGitignore_KeyContract pins the cache-key contract:
+//   - Distinct directories yield distinct matchers.
+//   - Repeated input hits the cache (same pointer).
+//   - Equivalent path forms ("./sub" vs "sub", "sub/" vs "sub")
+//     collapse to one cache entry, matching what filepath.Clean
+//     produces. This is the case Copilot flagged: a raw-key
+//     implementation would create a fresh matcher per syntactic form,
+//     undermining the cache.
+func TestFixer_CachedGitignore_KeyContract(t *testing.T) {
 	fixer := &Fixer{}
 
 	a1 := fixer.cachedGitignore("/tmp/aaa")
 	b := fixer.cachedGitignore("/tmp/bbb")
 	a2 := fixer.cachedGitignore("/tmp/aaa")
-	empty1 := fixer.cachedGitignore("")
-	empty2 := fixer.cachedGitignore("")
 
 	require.NotNil(t, a1)
 	require.NotNil(t, b)
-	require.NotNil(t, empty1)
 
 	assert.NotSame(t, a1, b,
-		"different directories must produce different matchers; the previous "+
-			"Abs-no-fallback impl shared one cache entry across unrelated dirs "+
-			"on the Abs-error path")
+		"different directories must produce different matchers")
 	assert.Same(t, a1, a2,
 		"repeated input must hit the cache and return the same matcher pointer")
-	assert.Same(t, empty1, empty2,
-		"empty-string input is its own cache entry, not aliased with /tmp/aaa")
-	assert.NotSame(t, a1, empty1,
-		"empty-string input must not collide with /tmp/aaa")
+
+	// Equivalent forms collapse via filepath.Clean.
+	plain := fixer.cachedGitignore("sub")
+	dotPrefix := fixer.cachedGitignore("./sub")
+	trailingSlash := fixer.cachedGitignore("sub/")
+	doubleSlash := fixer.cachedGitignore("sub//")
+	assert.Same(t, plain, dotPrefix,
+		`"./sub" and "sub" must share a cache entry (filepath.Clean equivalence)`)
+	assert.Same(t, plain, trailingSlash,
+		`"sub/" and "sub" must share a cache entry`)
+	assert.Same(t, plain, doubleSlash,
+		`"sub//" and "sub" must share a cache entry`)
+	assert.NotSame(t, a1, plain,
+		"unrelated directories must not collide")
 }
 
 // TestFix_FilesHaveGitignoreFuncWithRootDir covers the prepareFile

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -161,6 +161,38 @@ func TestFix_FilesHaveGitignoreFunc(t *testing.T) {
 	}
 }
 
+// TestFixer_CachedGitignore_DistinctKeys directly exercises the
+// cache contract: distinct inputs must yield distinct matchers, and
+// a repeat input must hit the cache. The previous implementation
+// canonicalized via filepath.Abs and silently swallowed Abs's error
+// return, which would collapse every relative path to the empty
+// string ("") cache key on Abs failure (e.g., unreadable cwd) and
+// share one matcher across unrelated directories.
+func TestFixer_CachedGitignore_DistinctKeys(t *testing.T) {
+	fixer := &Fixer{}
+
+	a1 := fixer.cachedGitignore("/tmp/aaa")
+	b := fixer.cachedGitignore("/tmp/bbb")
+	a2 := fixer.cachedGitignore("/tmp/aaa")
+	empty1 := fixer.cachedGitignore("")
+	empty2 := fixer.cachedGitignore("")
+
+	require.NotNil(t, a1)
+	require.NotNil(t, b)
+	require.NotNil(t, empty1)
+
+	assert.NotSame(t, a1, b,
+		"different directories must produce different matchers; the previous "+
+			"Abs-no-fallback impl shared one cache entry across unrelated dirs "+
+			"on the Abs-error path")
+	assert.Same(t, a1, a2,
+		"repeated input must hit the cache and return the same matcher pointer")
+	assert.Same(t, empty1, empty2,
+		"empty-string input is its own cache entry, not aliased with /tmp/aaa")
+	assert.NotSame(t, a1, empty1,
+		"empty-string input must not collide with /tmp/aaa")
+}
+
 // TestFix_FilesHaveGitignoreFuncWithRootDir covers the prepareFile
 // branch where Fixer.RootDir is set (gitignore matcher is anchored at
 // the root rather than the file's directory). Without a test that

--- a/internal/fix/fix_generated_ranges_test.go
+++ b/internal/fix/fix_generated_ranges_test.go
@@ -1,0 +1,104 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// alwaysFiringRule emits one diagnostic per line in the file. It is
+// non-fixable, so any diagnostic the engine doesn't filter survives
+// into the post-fix result.
+type alwaysFiringRule struct {
+	id   string
+	name string
+}
+
+func (r *alwaysFiringRule) ID() string       { return r.id }
+func (r *alwaysFiringRule) Name() string     { return r.name }
+func (r *alwaysFiringRule) Category() string { return "test" }
+
+func (r *alwaysFiringRule) Check(f *lint.File) []lint.Diagnostic {
+	diags := make([]lint.Diagnostic, 0, len(f.Lines))
+	for i := range f.Lines {
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     i + 1,
+			Column:   1,
+			RuleID:   r.id,
+			RuleName: r.name,
+			Severity: lint.Warning,
+			Message:  "always",
+		})
+	}
+	return diags
+}
+
+// TestFix_SuppressesDiagnosticsInsideCatalogBody mirrors
+// engine.TestLintOnce_CatalogHost on the fix path: diagnostics whose
+// lines fall inside a <?catalog?> generated body must not surface
+// from the host's perspective. Without this, `mdsmith fix` and
+// `mdsmith check` disagree on the same source bytes — check filters
+// the body, fix doesn't — which is what surfaced as a CI-only failure
+// in the merge queue when the pre-merge-commit hook ran fix on a
+// merge containing a long catalog summary.
+func TestFix_SuppressesDiagnosticsInsideCatalogBody(t *testing.T) {
+	dir := t.TempDir()
+
+	// Lines:
+	// 1: # Catalog Host
+	// 2: (empty)
+	// 3: <?catalog
+	// 4: glob: "*.md"
+	// 5: row: "- {filename}"
+	// 6: ?>
+	// 7: - body-line.md         <-- generated-body content (line 7)
+	// 8: <?/catalog?>
+	host := "# Catalog Host\n\n" +
+		"<?catalog\nglob: \"*.md\"\nrow: \"- {filename}\"\n?>\n" +
+		"- body-line.md\n" +
+		"<?/catalog?>\n"
+	hostPath := filepath.Join(dir, "host.md")
+	require.NoError(t, os.WriteFile(hostPath, []byte(host), 0o644))
+
+	const ruleName = "always-fires"
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			ruleName: {Enabled: true},
+		},
+	}
+
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&alwaysFiringRule{id: "MDS999", name: ruleName}},
+	}
+
+	result := fixer.Fix([]string{hostPath})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	// Line 7 is inside the generated catalog body. A diagnostic on
+	// that line must be filtered out before reaching the result.
+	for _, d := range result.Diagnostics {
+		if d.RuleName == ruleName && d.Line == 7 {
+			t.Errorf("fix surfaced %s diagnostic from inside <?catalog?> body (line 7): %s",
+				ruleName, d.Message)
+		}
+	}
+
+	// Pre-fix Failures count must also exclude the generated-body
+	// line. The host has 9 line entries (8 source lines plus the
+	// trailing-newline split) but line 7 is inside the generated
+	// body, so fewer than 9 should remain after generated-body
+	// filtering. The strict-less assertion stays robust to unrelated
+	// trailing-line counting tweaks.
+	assert.Less(t, result.Failures, 9,
+		"pre-fix Failures should exclude the generated-body line, got %d (no filtering applied)",
+		result.Failures)
+}


### PR DESCRIPTION
## Summary

Fix a class of `mdsmith fix` vs `mdsmith check` divergences caused by the Fixer not setting up its `*lint.File` values the way the engine.Runner does. Each commit in this PR addresses one missing per-file context field on the fix path; the final commits factor the wiring into a single helper used by every Fixer phase and drop dead defensive code.

## What was broken

The engine.Runner sets up each `*lint.File` with FS, RootFS/RootDir, FrontMatter, LineOffset, StripFrontMatter, MaxInputBytes, GitignoreFunc, and GeneratedRanges before calling `engine.CheckRules` (`internal/engine/runner.go:90-108`). Various rules consult these fields:

- `MaxInputBytes` — catalog/include/requiredstructure secondary file reads
- `StripFrontMatter` — duplicatedcontent cross-file coordinate alignment
- `GitignoreFunc` — catalog glob filtering (`resolveGitignore`)
- `GeneratedRanges` — engine-level diagnostic suppression for `<?catalog?>` / `<?include?>` bodies

The Fixer's three lint passes (pre-fix, per-iteration fix-pass, post-fix) each parsed their own `*lint.File` via `lint.NewFile` but only set FS/RootDir, leaving the rest at zero values. That meant:

1. **The merge queue's `mdsmith fix .` reported false MDS001 / MDS014 / MDS026 violations inside `<?catalog?>` bodies** that `mdsmith check` correctly suppressed (CI run [25252572788](https://github.com/jeduden/mdsmith/actions/runs/25252572788/job/74046813387): `failures=7 unfixed=6` while local check was clean).
2. catalog regenerations during fix could include gitignored files that check would have excluded.
3. include/requiredstructure secondary reads ran without size limits during fix.

## What changed

- `internal/fix/fix.go`:
  - **`hydrateLintFile`** helper that copies the full per-file context onto a freshly-parsed `*lint.File`.
  - **`buildPostFixFile`** uses the helper for the post-fix CheckRules input.
  - **`applyFixPasses`** uses the helper for the parsedFile passed to each fixable rule (catalog/include/etc.).
  - **`prepareFile`** sets `lf.GitignoreFunc` via a per-Fixer `cachedGitignore` (mirrors `engine.Runner.cachedGitignore`).
  - **`Fixer.gitignoreCache`** field + `Fixer.cachedGitignore` method.
- `internal/fix/fix_generated_ranges_test.go` — five red/green regression tests:
  - `TestFix_SuppressesDiagnosticsInsideCatalogBody` — diagnostics inside `<?catalog?>` body filtered.
  - `TestFix_FinalFileInheritsParseTimeFields` — `MaxInputBytes` / `StripFrontMatter` propagated to post-fix file.
  - `TestFix_FilesHaveGitignoreFunc` (+ `WithRootDir` variant) — `GitignoreFunc` non-nil during pre/post-fix Check.
  - `TestFix_FixPassesHydrateLintFile` — same context present on the parsedFile inside each fix iteration.

## Verification

- Each behavioral change is red/green TDD: new test fails on the parent commit, passes after the patch.
- `go test ./...` clean.
- `go vet ./...` and `golangci-lint run ./internal/fix/...` clean.
- Coverage on all new functions in `internal/fix/fix.go`: `hydrateLintFile`, `buildPostFixFile`, `cachedGitignore` all at **100%**. `applyFixPasses` and `prepareFile` exercise both `RootDir` branches and the new hydration call; their remaining gaps are pre-existing dead error paths around `lint.NewFile` / `lint.NewFileFromSource` (which never return errors in the current implementation).
- End-to-end on the failing merge tree (`merge-queue/batch-bisect-210-1777727156`): patched binary takes `mdsmith fix .` from `failures=7 unfixed=6` to `failures=1 unfixed=0` (the one remaining MDS019 is the genuine catalog-stale that fix actually fixes).

## Test plan

- [x] `go test ./internal/fix/`
- [x] `go test ./...`
- [x] `go test ./internal/fix/ -covermode=count -coverprofile=...` — verify branch coverage on new code
- [x] Run patched binary against the merge-queue branch that originally failed CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
