### PR TITLE
Bump merge-queue mdsmith binary to v0.10.0

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Install mdsmith merge driver and pre-merge-commit hook
         env:
-          MDSMITH_VERSION: v0.9.0
-          MDSMITH_SHA256: db39f381fe6d7497f41a179a3bc00e573b6b4abb6381b05337d32677dac5f99d
+          MDSMITH_VERSION: v0.10.0
+          MDSMITH_SHA256: 8a7d223ebf86595e4a09f8c0f17b96df451fea456bfa790ed4119b53fa48a0e8
         run: |
           # Install to a stable path that will persist for the hook to use
           mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
## Summary

- Bumps `MDSMITH_VERSION` in `.github/workflows/merge-queue.yml` from v0.9.0 → v0.10.0 with the matching `MDSMITH_SHA256`.
- v0.10.0 includes PR #215's fix-path hydration work (GeneratedRanges suppression + per-file context wiring), which keeps the merge driver's `mdsmith fix .` in agreement with `mdsmith check .` so the queue stops reporting catalog-body false positives.

## Test plan

- [ ] CI green on the bump itself.
- [ ] After merge, observe the merge queue handle a PR with a regenerable catalog/include section without spurious MDS001 / MDS014 / MDS026 inside generated bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)