### PR TITLE
Preserve file permissions and fix option injection in merge operations

### DIFF
--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -100,6 +100,17 @@ var osWriteFile = os.WriteFile
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
 func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
+	// Validate and capture the mode of ours before letting git write to it,
+	// so a symlink at ours cannot be followed by git merge-file.
+	if err := guardRegularFile(ours); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
+	// Preserve the original permissions of git's temp file.
+	// os.WriteFile only applies perm on creation; chmod enforces it
+	// on existing files too (e.g. if git truncated rather than recreated).
+	oursMode := mergeFileMode(ours, 0o644)
+
 	// Step 1: standard 3-way merge into ours.
 	// Use "--" to prevent file paths starting with "-" from being
 	// interpreted as git options (option injection).
@@ -120,15 +131,6 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	content, err := lint.ReadFileLimited(ours, maxBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading merge result: %v\n", err)
-		return nil, 2
-	}
-
-	// Preserve the original permissions of git's temp file.
-	// os.WriteFile only applies perm on creation; chmod enforces it
-	// on existing files too (e.g. if git truncated rather than recreated).
-	oursMode := mergeFileMode(ours, 0o644)
-	if err := guardRegularFile(ours); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2
 	}
 	cleaned := stripSectionConflicts(content)

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -72,11 +72,13 @@ func runMergeDriver(args []string) int {
 	}
 }
 
-// mergeFileMode returns the mode of the named file, or defaultMode if
-// the file cannot be stat'd (e.g. does not exist yet).
+// mergeFileMode returns the permission bits of the named file, or
+// defaultMode if the file cannot be stat'd (e.g. does not exist yet).
+// It returns only Perm() (the low 9 bits) to avoid passing file-type
+// bits to os.WriteFile / os.Chmod.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Stat(name); err == nil {
-		return info.Mode()
+		return info.Mode().Perm()
 	}
 	return defaultMode
 }
@@ -112,11 +114,16 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	}
 
 	// Preserve the original permissions of git's temp file.
+	// os.WriteFile only applies perm on creation; chmod enforces it
+	// on existing files too (e.g. if git truncated rather than recreated).
 	oursMode := mergeFileMode(ours, 0o644)
 	cleaned := stripSectionConflicts(content)
 	if err := osWriteFile(ours, cleaned, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
 		return nil, 2
+	}
+	if err := os.Chmod(ours, oursMode); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: chmod merge result: %v\n", err)
 	}
 	return cleaned, 0
 }
@@ -228,6 +235,9 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 	if err := osWriteFile(ours, fixed, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
+	}
+	if err := os.Chmod(ours, oursMode); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: chmod merge output: %v\n", err)
 	}
 
 	return fixed, 0

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -72,17 +72,25 @@ func runMergeDriver(args []string) int {
 	}
 }
 
-// mergeFileMode returns the named file's mode with file-type bits masked off
-// (info.Mode() &^ os.ModeType), or defaultMode if the file cannot be stat'd.
-// os.Stat follows symlinks, so ModeSymlink is never set in the result; the
-// mask simply strips ModeDir and other type bits while preserving rwx and
-// setuid/setgid/sticky — wider than Mode().Perm() which returns only the
-// low 9 bits.
+// mergeFileMode returns the named file's permission bits (mode &^ ModeType),
+// or defaultMode if the file cannot be stat'd. Uses Lstat so symlinks are
+// not followed; callers that need a regular-file guarantee should also call
+// guardRegularFile.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
-	if info, err := os.Stat(name); err == nil {
+	if info, err := os.Lstat(name); err == nil {
 		return info.Mode() &^ os.ModeType
 	}
 	return defaultMode
+}
+
+// guardRegularFile returns an error if path exists and is not a regular file
+// (e.g. a symlink or directory), preventing writes from following links
+// outside the worktree.
+func guardRegularFile(path string) error {
+	if info, err := os.Lstat(path); err == nil && !info.Mode().IsRegular() {
+		return fmt.Errorf("%s: not a regular file", path)
+	}
+	return nil
 }
 
 // osWriteFile is a variable so tests can substitute a failing implementation
@@ -119,6 +127,10 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	// os.WriteFile only applies perm on creation; chmod enforces it
 	// on existing files too (e.g. if git truncated rather than recreated).
 	oursMode := mergeFileMode(ours, 0o644)
+	if err := guardRegularFile(ours); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
 	cleaned := stripSectionConflicts(content)
 	if err := osWriteFile(ours, cleaned, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
@@ -197,6 +209,14 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 	pathnameMode := mergeFileMode(pathname, 0o644)
 	oursMode := mergeFileMode(ours, 0o644)
 
+	if err := guardRegularFile(pathname); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
+	if err := guardRegularFile(ours); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
 	backup, backupErr := lint.ReadFileLimited(pathname, maxBytes)
 	if backupErr != nil && !os.IsNotExist(backupErr) {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -72,12 +72,12 @@ func runMergeDriver(args []string) int {
 	}
 }
 
-// mergeFileMode returns the named file's mode with file-type bits
-// (ModeDir, ModeSymlink, …) masked off, or defaultMode if the file
-// cannot be stat'd (e.g. does not exist yet). The returned value is
-// info.Mode() &^ os.ModeType, which keeps the rwx permission bits
-// along with setuid/setgid/sticky — wider than Mode().Perm(), which
-// returns only the low 9 bits.
+// mergeFileMode returns the named file's mode with file-type bits masked off
+// (info.Mode() &^ os.ModeType), or defaultMode if the file cannot be stat'd.
+// os.Stat follows symlinks, so ModeSymlink is never set in the result; the
+// mask simply strips ModeDir and other type bits while preserving rwx and
+// setuid/setgid/sticky — wider than Mode().Perm() which returns only the
+// low 9 bits.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Stat(name); err == nil {
 		return info.Mode() &^ os.ModeType

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -72,11 +72,22 @@ func runMergeDriver(args []string) int {
 	}
 }
 
+// mergeFileMode returns the mode of the named file, or defaultMode if
+// the file cannot be stat'd (e.g. does not exist yet).
+func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
+	if info, err := os.Stat(name); err == nil {
+		return info.Mode()
+	}
+	return defaultMode
+}
+
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
 func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	// Step 1: standard 3-way merge into ours.
-	mergeCmd := exec.Command("git", "merge-file", ours, base, theirs)
+	// Use "--" to prevent file paths starting with "-" from being
+	// interpreted as git options (option injection).
+	mergeCmd := exec.Command("git", "merge-file", "--", ours, base, theirs)
 	mergeCmd.Stderr = os.Stderr
 	mergeErr := mergeCmd.Run()
 
@@ -96,8 +107,10 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 		return nil, 2
 	}
 
+	// Preserve the original permissions of git's temp file.
+	oursMode := mergeFileMode(ours, 0o644)
 	cleaned := stripSectionConflicts(content)
-	if err := os.WriteFile(ours, cleaned, 0644); err != nil {
+	if err := os.WriteFile(ours, cleaned, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
 		return nil, 2
 	}
@@ -166,18 +179,16 @@ func runMergeDriverRun(args []string) int {
 // fixAtRealPath writes cleaned content to pathname, runs mdsmith
 // fix, copies the result to ours, and restores pathname.
 func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byte, int) {
-	// Capture the original file mode so we can preserve permissions.
-	fileMode := os.FileMode(0644)
-	if info, err := os.Stat(pathname); err == nil {
-		fileMode = info.Mode()
-	}
+	// Capture the original file modes so we can preserve permissions.
+	pathnameMode := mergeFileMode(pathname, 0o644)
+	oursMode := mergeFileMode(ours, 0o644)
 
 	backup, backupErr := lint.ReadFileLimited(pathname, maxBytes)
 	if backupErr != nil && !os.IsNotExist(backupErr) {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)
 		return nil, 2
 	}
-	if err := os.WriteFile(pathname, cleaned, fileMode); err != nil {
+	if err := os.WriteFile(pathname, cleaned, pathnameMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing to %s: %v\n", pathname, err)
 		return nil, 2
 	}
@@ -194,7 +205,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 
 	var restoreErr error
 	if backupErr == nil {
-		restoreErr = os.WriteFile(pathname, backup, fileMode)
+		restoreErr = os.WriteFile(pathname, backup, pathnameMode)
 	} else if os.IsNotExist(backupErr) {
 		restoreErr = os.Remove(pathname)
 	}
@@ -210,7 +221,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		return fixed, 2
 	}
 
-	if err := os.WriteFile(ours, fixed, 0644); err != nil {
+	if err := os.WriteFile(ours, fixed, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
 	}

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -100,11 +100,13 @@ var osWriteFile = os.WriteFile
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
 func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
-	// Validate and capture the mode of ours before letting git write to it,
-	// so a symlink at ours cannot be followed by git merge-file.
-	if err := guardRegularFile(ours); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return nil, 2
+	// Validate all three inputs before letting git read or write them,
+	// so symlinks cannot pull in data from outside the worktree.
+	for _, path := range []string{ours, base, theirs} {
+		if err := guardRegularFile(path); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return nil, 2
+		}
 	}
 	// Preserve the original permissions of git's temp file.
 	// os.WriteFile only applies perm on creation; chmod enforces it

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -74,8 +74,7 @@ func runMergeDriver(args []string) int {
 
 // mergeFileMode returns the low 9 permission bits (Mode().Perm()) of the named
 // file, or defaultMode if the file cannot be stat'd for any reason (including
-// ENOENT and permission errors). Uses Lstat so symlinks are not followed;
-// callers should guard the path with guardFn before invoking this helper.
+// ENOENT and permission errors). Uses Lstat so symlinks are not followed.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Lstat(name); err == nil {
 		return info.Mode().Perm()

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -93,6 +93,10 @@ func guardRegularFile(path string) error {
 	return nil
 }
 
+// guardFn is a variable so tests can substitute a failing implementation
+// to exercise guardRegularFile error paths without creating real symlinks.
+var guardFn = guardRegularFile
+
 // osWriteFile is a variable so tests can substitute a failing implementation
 // to exercise error paths without needing OS tricks.
 var osWriteFile = os.WriteFile
@@ -103,7 +107,7 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	// Validate all three inputs before letting git read or write them,
 	// so symlinks cannot pull in data from outside the worktree.
 	for _, path := range []string{ours, base, theirs} {
-		if err := guardRegularFile(path); err != nil {
+		if err := guardFn(path); err != nil {
 			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 			return nil, 2
 		}
@@ -136,6 +140,11 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 		return nil, 2
 	}
 	cleaned := stripSectionConflicts(content)
+	// Re-check immediately before writing to narrow the TOCTOU window.
+	if err := guardFn(ours); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
 	if err := osWriteFile(ours, cleaned, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
 		return nil, 2
@@ -209,21 +218,25 @@ func runMergeDriverRun(args []string) int {
 // fixAtRealPath writes cleaned content to pathname, runs mdsmith
 // fix, copies the result to ours, and restores pathname.
 func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byte, int) {
-	// Capture the original file modes so we can preserve permissions.
 	pathnameMode := mergeFileMode(pathname, 0o644)
 	oursMode := mergeFileMode(ours, 0o644)
 
-	if err := guardRegularFile(pathname); err != nil {
+	if err := guardFn(pathname); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2
 	}
-	if err := guardRegularFile(ours); err != nil {
+	if err := guardFn(ours); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2
 	}
 	backup, backupErr := lint.ReadFileLimited(pathname, maxBytes)
 	if backupErr != nil && !os.IsNotExist(backupErr) {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)
+		return nil, 2
+	}
+	// Re-check immediately before writing to narrow the TOCTOU window.
+	if err := guardFn(pathname); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2
 	}
 	if err := osWriteFile(pathname, cleaned, pathnameMode); err != nil {
@@ -233,32 +246,21 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 
 	fixErr := fixFileInPlace(pathname, maxBytes)
 
-	// Restore the original working tree file before checking
-	// fixErr, so the working tree is always left clean.
-	fixed, err := lint.ReadFileLimited(pathname, maxBytes)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)
-		return nil, 2
+	fixed, code := readAndRestore(pathname, backup, backupErr, pathnameMode, maxBytes)
+	if code != 0 {
+		return fixed, code
 	}
 
-	var restoreErr error
-	if backupErr == nil {
-		restoreErr = os.WriteFile(pathname, backup, pathnameMode)
-	} else if os.IsNotExist(backupErr) {
-		restoreErr = os.Remove(pathname)
-	}
-	if restoreErr != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: restoring %s: %v\n", pathname, restoreErr)
-		return fixed, 2
-	}
-
-	// Check fixErr before writing to ours so broken content is
-	// not used as the merge result.
 	if fixErr != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: fix failed: %v\n", fixErr)
 		return fixed, 2
 	}
 
+	// Re-check ours immediately before writing the final merge result.
+	if err := guardFn(ours); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
 	if err := osWriteFile(ours, fixed, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
@@ -268,6 +270,34 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		return nil, 2
 	}
 
+	return fixed, 0
+}
+
+// readAndRestore reads the fixed content from pathname, restores its original
+// content (or removes it if it did not previously exist), and returns the fixed
+// bytes. A non-zero exit code means the caller should propagate the error.
+func readAndRestore(pathname string, backup []byte, backupErr error, mode os.FileMode, maxBytes int64) ([]byte, int) {
+	fixed, err := lint.ReadFileLimited(pathname, maxBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)
+		return nil, 2
+	}
+
+	var restoreErr error
+	if backupErr == nil {
+		// Re-check before restore to narrow TOCTOU window.
+		if err := guardFn(pathname); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return fixed, 2
+		}
+		restoreErr = osWriteFile(pathname, backup, mode)
+	} else if os.IsNotExist(backupErr) {
+		restoreErr = os.Remove(pathname)
+	}
+	if restoreErr != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: restoring %s: %v\n", pathname, restoreErr)
+		return fixed, 2
+	}
 	return fixed, 0
 }
 

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -81,6 +81,10 @@ func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	return defaultMode
 }
 
+// osWriteFile is a variable so tests can substitute a failing implementation
+// to exercise error paths without needing OS tricks.
+var osWriteFile = os.WriteFile
+
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
 func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
@@ -110,7 +114,7 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	// Preserve the original permissions of git's temp file.
 	oursMode := mergeFileMode(ours, 0o644)
 	cleaned := stripSectionConflicts(content)
-	if err := os.WriteFile(ours, cleaned, oursMode); err != nil {
+	if err := osWriteFile(ours, cleaned, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
 		return nil, 2
 	}
@@ -188,7 +192,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)
 		return nil, 2
 	}
-	if err := os.WriteFile(pathname, cleaned, pathnameMode); err != nil {
+	if err := osWriteFile(pathname, cleaned, pathnameMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing to %s: %v\n", pathname, err)
 		return nil, 2
 	}
@@ -221,7 +225,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		return fixed, 2
 	}
 
-	if err := os.WriteFile(ours, fixed, oursMode); err != nil {
+	if err := osWriteFile(ours, fixed, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
 	}

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -134,9 +134,9 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 			return nil, 2
 		}
 	}
-	// Preserve the original permissions of git's temp file.
-	// os.WriteFile only applies perm on creation; chmod enforces it
-	// on existing files too (e.g. if git truncated rather than recreated).
+	// Capture the permissions of git's temp file. os.WriteFile preserves
+	// the existing mode on truncating writes, so this is only the fallback
+	// creation mode for files that do not yet exist.
 	oursMode := mergeFileMode(ours, 0o644)
 
 	// Step 1: standard 3-way merge into ours.
@@ -156,6 +156,11 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	}
 
 	// Step 2: strip conflict markers inside regenerable sections.
+	// Re-check before reading to guard against a symlink swap after the merge.
+	if err := guardFn(ours); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
 	content, err := lint.ReadFileLimited(ours, maxBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading merge result: %v\n", err)
@@ -169,10 +174,6 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 	}
 	if err := osWriteFile(ours, cleaned, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
-		return nil, 2
-	}
-	if err := chmodFunc(ours, oursMode); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: chmod merge result: %v\n", err)
 		return nil, 2
 	}
 	return cleaned, 0
@@ -287,11 +288,6 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
 	}
-	if err := chmodFunc(ours, oursMode); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: chmod merge output: %v\n", err)
-		return nil, 2
-	}
-
 	return fixed, 0
 }
 
@@ -299,6 +295,11 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 // content (or removes it if it did not previously exist), and returns the fixed
 // bytes. A non-zero exit code means the caller should propagate the error.
 func readAndRestore(pathname string, backup []byte, backupErr error, mode os.FileMode, maxBytes int64) ([]byte, int) {
+	// Re-check before reading the fixed result to guard against a symlink swap.
+	if err := guardFn(pathname); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
 	fixed, err := readFileLimited(pathname, maxBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -72,10 +72,12 @@ func runMergeDriver(args []string) int {
 	}
 }
 
-// mergeFileMode returns the permission bits of the named file, or
-// defaultMode if the file cannot be stat'd (e.g. does not exist yet).
-// It strips file-type bits (ModeDir, ModeSymlink, …) but preserves
-// special permission bits (setuid/setgid/sticky) if present.
+// mergeFileMode returns the named file's mode with file-type bits
+// (ModeDir, ModeSymlink, …) masked off, or defaultMode if the file
+// cannot be stat'd (e.g. does not exist yet). The returned value is
+// info.Mode() &^ os.ModeType, which keeps the rwx permission bits
+// along with setuid/setgid/sticky — wider than Mode().Perm(), which
+// returns only the low 9 bits.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Stat(name); err == nil {
 		return info.Mode() &^ os.ModeType

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -73,9 +73,9 @@ func runMergeDriver(args []string) int {
 }
 
 // mergeFileMode returns the low 9 permission bits (Mode().Perm()) of the named
-// file, or defaultMode if the file cannot be stat'd. Uses Lstat so symlinks are
-// not followed; callers that need a regular-file guarantee should also call
-// guardRegularFile.
+// file, or defaultMode if the file cannot be stat'd for any reason (including
+// ENOENT and permission errors). Uses Lstat so symlinks are not followed;
+// callers should guard the path with guardFn before invoking this helper.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Lstat(name); err == nil {
 		return info.Mode().Perm()

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -74,11 +74,11 @@ func runMergeDriver(args []string) int {
 
 // mergeFileMode returns the permission bits of the named file, or
 // defaultMode if the file cannot be stat'd (e.g. does not exist yet).
-// It returns only Perm() (the low 9 bits) to avoid passing file-type
-// bits to os.WriteFile / os.Chmod.
+// It strips file-type bits (ModeDir, ModeSymlink, …) but preserves
+// special permission bits (setuid/setgid/sticky) if present.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Stat(name); err == nil {
-		return info.Mode().Perm()
+		return info.Mode() &^ os.ModeType
 	}
 	return defaultMode
 }
@@ -122,8 +122,9 @@ func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing cleaned merge: %v\n", err)
 		return nil, 2
 	}
-	if err := os.Chmod(ours, oursMode); err != nil {
+	if err := chmodFunc(ours, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: chmod merge result: %v\n", err)
+		return nil, 2
 	}
 	return cleaned, 0
 }
@@ -236,8 +237,9 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
 	}
-	if err := os.Chmod(ours, oursMode); err != nil {
+	if err := chmodFunc(ours, oursMode); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: chmod merge output: %v\n", err)
+		return nil, 2
 	}
 
 	return fixed, 0

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -83,11 +83,25 @@ func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	return defaultMode
 }
 
-// guardRegularFile returns an error if path exists and is not a regular file
-// (e.g. a symlink or directory), preventing writes from following links
-// outside the worktree.
+// lstatFn is a variable so tests can substitute a failing implementation
+// to exercise non-ENOENT Lstat error paths in guardRegularFile.
+var lstatFn = os.Lstat
+
+// guardRegularFile returns an error if:
+//   - path exists and is not a regular file (symlink, directory, …), or
+//   - os.Lstat fails for any reason other than ENOENT.
+//
+// A missing file (ENOENT) is allowed; the caller decides whether that
+// is an error at a higher level.
 func guardRegularFile(path string) error {
-	if info, err := os.Lstat(path); err == nil && !info.Mode().IsRegular() {
+	info, err := lstatFn(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("%s: lstat: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
 		return fmt.Errorf("%s: not a regular file", path)
 	}
 	return nil
@@ -100,6 +114,10 @@ var guardFn = guardRegularFile
 // osWriteFile is a variable so tests can substitute a failing implementation
 // to exercise error paths without needing OS tricks.
 var osWriteFile = os.WriteFile
+
+// readFileLimited is a variable so tests can substitute a failing
+// implementation to exercise the read-fixed-file error path in readAndRestore.
+var readFileLimited = lint.ReadFileLimited
 
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
@@ -277,7 +295,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 // content (or removes it if it did not previously exist), and returns the fixed
 // bytes. A non-zero exit code means the caller should propagate the error.
 func readAndRestore(pathname string, backup []byte, backupErr error, mode os.FileMode, maxBytes int64) ([]byte, int) {
-	fixed, err := lint.ReadFileLimited(pathname, maxBytes)
+	fixed, err := readFileLimited(pathname, maxBytes)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)
 		return nil, 2
@@ -292,6 +310,11 @@ func readAndRestore(pathname string, backup []byte, backupErr error, mode os.Fil
 		}
 		restoreErr = osWriteFile(pathname, backup, mode)
 	} else if os.IsNotExist(backupErr) {
+		// Re-check before removal to avoid removing a swapped-in directory.
+		if err := guardFn(pathname); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return fixed, 2
+		}
 		restoreErr = os.Remove(pathname)
 	}
 	if restoreErr != nil {

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -119,6 +119,10 @@ var osWriteFile = os.WriteFile
 // implementation to exercise the read-fixed-file error path in readAndRestore.
 var readFileLimited = lint.ReadFileLimited
 
+// fixFileInPlaceFn is a variable so tests can substitute a failing
+// implementation to exercise the fix-failed error path in fixAtRealPath.
+var fixFileInPlaceFn = fixFileInPlace
+
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
 func mergeAndClean(base, ours, theirs string, maxBytes int64) ([]byte, int) {
@@ -262,7 +266,7 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		return nil, 2
 	}
 
-	fixErr := fixFileInPlace(pathname, maxBytes)
+	fixErr := fixFileInPlaceFn(pathname, maxBytes)
 
 	fixed, code := readAndRestore(pathname, backup, backupErr, pathnameMode, maxBytes)
 	if code != 0 {

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -72,13 +72,13 @@ func runMergeDriver(args []string) int {
 	}
 }
 
-// mergeFileMode returns the named file's permission bits (mode &^ ModeType),
-// or defaultMode if the file cannot be stat'd. Uses Lstat so symlinks are
+// mergeFileMode returns the low 9 permission bits (Mode().Perm()) of the named
+// file, or defaultMode if the file cannot be stat'd. Uses Lstat so symlinks are
 // not followed; callers that need a regular-file guarantee should also call
 // guardRegularFile.
 func mergeFileMode(name string, defaultMode os.FileMode) os.FileMode {
 	if info, err := os.Lstat(name); err == nil {
-		return info.Mode() &^ os.ModeType
+		return info.Mode().Perm()
 	}
 	return defaultMode
 }

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -851,3 +851,71 @@ func TestRunMergeDriverInstall_CustomIncludeGlobs(t *testing.T) {
 	assert.NotContains(t, content, "*.md merge=mdsmith\n*.markdown",
 		"default include set must be replaced when custom globs are given")
 }
+
+func TestMergeAndClean_DashPrefixedFilenames_NoOptionInjection(t *testing.T) {
+	// Regression test: file paths starting with "-" must not be
+	// interpreted as git options. The "--" separator added to the
+	// git merge-file call prevents option injection.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+
+	// Use a filename that starts with "-" to trigger option injection
+	// if "--" is missing from the git merge-file invocation.
+	base := filepath.Join(dir, "-base.md")
+	ours := filepath.Join(dir, "-ours.md")
+	theirs := filepath.Join(dir, "-theirs.md")
+
+	content := "# Hello\n"
+	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+
+	_, code := mergeAndClean(base, ours, theirs, 1<<20)
+	assert.Equal(t, 0, code, "merge with dash-prefixed filenames must succeed")
+}
+
+func TestMergeAndClean_PreservesOursFileMode(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits not meaningful on Windows")
+	}
+	dir := t.TempDir()
+
+	base := filepath.Join(dir, "base.md")
+	ours := filepath.Join(dir, "ours.md")
+	theirs := filepath.Join(dir, "theirs.md")
+
+	content := "# Hello\n"
+	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte(content), 0o600))
+	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+
+	_, code := mergeAndClean(base, ours, theirs, 1<<20)
+	require.Equal(t, 0, code)
+
+	info, err := os.Stat(ours)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"mergeAndClean must preserve the original permissions of ours")
+}
+
+func TestMergeFileMode_ExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits not meaningful on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.md")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o755))
+
+	got := mergeFileMode(path, 0o644)
+	assert.Equal(t, os.FileMode(0o755), got.Perm())
+}
+
+func TestMergeFileMode_MissingFile_UsesDefault(t *testing.T) {
+	got := mergeFileMode("/nonexistent/path/file.md", 0o644)
+	assert.Equal(t, os.FileMode(0o644), got)
+}

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -917,7 +917,8 @@ func TestMergeFileMode_ExistingFile(t *testing.T) {
 }
 
 func TestMergeFileMode_MissingFile_UsesDefault(t *testing.T) {
-	got := mergeFileMode("/nonexistent/path/file.md", 0o644)
+	missing := filepath.Join(t.TempDir(), "nonexistent.md")
+	got := mergeFileMode(missing, 0o644)
 	assert.Equal(t, os.FileMode(0o644), got)
 }
 

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -933,9 +933,10 @@ func TestGuardRegularFile_LstatNonENOENTError_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "lstat")
 }
 
-func TestMergeAndClean_ReGuardFails_ExitsTwo(t *testing.T) {
-	// The re-check of ours immediately before osWriteFile (4th guardFn call
-	// in mergeAndClean: ours/base/theirs at start, then ours again pre-write).
+func TestMergeAndClean_PreReadGuardFails_ExitsTwo(t *testing.T) {
+	// guardFn call sequence in mergeAndClean:
+	//   1 = ours, 2 = base, 3 = theirs (loop), 4 = ours pre-read, 5 = ours pre-write
+	// This test exercises call 4 (the pre-read re-check).
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -953,7 +954,41 @@ func TestMergeAndClean_ReGuardFails_ExitsTwo(t *testing.T) {
 	t.Cleanup(func() { guardFn = orig })
 	guardFn = func(path string) error {
 		calls++
-		if calls == 4 { // 4th call = re-check of ours before write
+		if calls == 4 {
+			return fmt.Errorf("injected pre-read guard")
+		}
+		return orig(path)
+	}
+
+	got := captureStderr(func() {
+		_, code := mergeAndClean(base, ours, theirs, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected pre-read guard")
+}
+
+func TestMergeAndClean_ReGuardFails_ExitsTwo(t *testing.T) {
+	// guardFn call sequence in mergeAndClean:
+	//   1 = ours, 2 = base, 3 = theirs (loop), 4 = ours pre-read, 5 = ours pre-write
+	// This test exercises call 5 (the pre-write re-check).
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	content := "# Hello\n"
+	base := filepath.Join(dir, "base.md")
+	ours := filepath.Join(dir, "ours.md")
+	theirs := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+
+	var calls int
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	guardFn = func(path string) error {
+		calls++
+		if calls == 5 { // 5th call = re-check of ours before write
 			return fmt.Errorf("injected: %s not regular", path)
 		}
 		return orig(path)
@@ -1051,59 +1086,6 @@ func TestFixAtRealPath_WriteToOursFails_ExitsTwo(t *testing.T) {
 	assert.Contains(t, got, "writing merge output")
 }
 
-func TestMergeAndClean_ChmodFails_ExitsTwo(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-	dir := t.TempDir()
-
-	content := "# Hello\n"
-	base := filepath.Join(dir, "base.md")
-	ours := filepath.Join(dir, "ours.md")
-	theirs := filepath.Join(dir, "theirs.md")
-	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
-	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
-
-	orig := chmodFunc
-	t.Cleanup(func() { chmodFunc = orig })
-	chmodFunc = func(string, os.FileMode) error {
-		return fmt.Errorf("mock chmod failure")
-	}
-
-	got := captureStderr(func() {
-		_, code := mergeAndClean(base, ours, theirs, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "chmod merge result")
-}
-
-func TestFixAtRealPath_ChmodFails_ExitsTwo(t *testing.T) {
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	content := []byte("# Hello\n\nWorld.\n")
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, content, 0o644))
-	require.NoError(t, os.WriteFile(ours, content, 0o644))
-
-	orig := chmodFunc
-	t.Cleanup(func() { chmodFunc = orig })
-	chmodFunc = func(string, os.FileMode) error {
-		return fmt.Errorf("mock chmod failure")
-	}
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath(content, ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "chmod merge output")
-}
-
 // guardCallN returns a guardFn replacement that delegates to the real
 // guardRegularFile for the first n-1 calls, then returns an error on call n,
 // then delegates again for all subsequent calls.
@@ -1143,7 +1125,11 @@ func TestFixAtRealPath_ThirdGuardFails_ExitsTwo(t *testing.T) {
 }
 
 func TestFixAtRealPath_FourthGuardFails_ExitsTwo(t *testing.T) {
-	// 4th guardFn call = re-check of pathname before restore write.
+	// guardFn call sequence in fixAtRealPath + readAndRestore (backup exists):
+	//   1 = pathname, 2 = ours (start), 3 = pathname pre-write,
+	//   4 = pathname pre-read (readAndRestore), 5 = pathname pre-restore,
+	//   6 = ours pre-final-write
+	// This test exercises call 4 (pre-read guard in readAndRestore).
 	dir := t.TempDir()
 	origWd, err := os.Getwd()
 	require.NoError(t, err)
@@ -1157,7 +1143,31 @@ func TestFixAtRealPath_FourthGuardFails_ExitsTwo(t *testing.T) {
 
 	orig := guardFn
 	t.Cleanup(func() { guardFn = orig })
-	guardFn = guardCallN(4, "injected pre-restore guard")
+	guardFn = guardCallN(4, "injected pre-read guard")
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected pre-read guard")
+}
+
+func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
+	// guardFn call 5 = re-check of pathname before restore write.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	guardFn = guardCallN(5, "injected pre-restore guard")
 
 	got := captureStderr(func() {
 		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
@@ -1166,8 +1176,8 @@ func TestFixAtRealPath_FourthGuardFails_ExitsTwo(t *testing.T) {
 	assert.Contains(t, got, "injected pre-restore guard")
 }
 
-func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
-	// 5th guardFn call = re-check of ours before final write.
+func TestFixAtRealPath_SixthGuardFails_ExitsTwo(t *testing.T) {
+	// guardFn call 6 = re-check of ours before final write.
 	dir := t.TempDir()
 	origWd, err := os.Getwd()
 	require.NoError(t, err)
@@ -1181,7 +1191,7 @@ func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
 
 	orig := guardFn
 	t.Cleanup(func() { guardFn = orig })
-	guardFn = guardCallN(5, "injected pre-ours-write guard")
+	guardFn = guardCallN(6, "injected pre-ours-write guard")
 
 	got := captureStderr(func() {
 		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
@@ -1256,10 +1266,10 @@ func TestFixAtRealPath_GuardBeforeRemoveFails_ExitsTwo(t *testing.T) {
 	//   1 = pathname at top of fixAtRealPath
 	//   2 = ours at top of fixAtRealPath
 	//   3 = pathname re-check before write
-	//   4 = pathname re-check before os.Remove in readAndRestore
-	// (the restore guard inside readAndRestore is skipped because backupErr
-	// is ENOENT, so the ENOENT branch runs instead)
-	guardFn = guardCallN(4, "injected pre-remove guard")
+	//   4 = pathname pre-read in readAndRestore
+	//   5 = pathname re-check before os.Remove in readAndRestore
+	// (the restore guard is skipped because backupErr is ENOENT)
+	guardFn = guardCallN(5, "injected pre-remove guard")
 
 	got := captureStderr(func() {
 		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -918,4 +919,123 @@ func TestMergeFileMode_ExistingFile(t *testing.T) {
 func TestMergeFileMode_MissingFile_UsesDefault(t *testing.T) {
 	got := mergeFileMode("/nonexistent/path/file.md", 0o644)
 	assert.Equal(t, os.FileMode(0o644), got)
+}
+
+func TestMergeAndClean_WriteFileFails_ExitsTwo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+
+	content := "# Hello\n"
+	base := filepath.Join(dir, "base.md")
+	ours := filepath.Join(dir, "ours.md")
+	theirs := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+
+	orig := osWriteFile
+	t.Cleanup(func() { osWriteFile = orig })
+	osWriteFile = func(string, []byte, os.FileMode) error {
+		return fmt.Errorf("mock write failure")
+	}
+
+	got := captureStderr(func() {
+		_, code := mergeAndClean(base, ours, theirs, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "writing cleaned merge")
+}
+
+func TestFixAtRealPath_WriteToPathnameFails_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	content := []byte("# Hello\n")
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, content, 0o644))
+	require.NoError(t, os.WriteFile(ours, content, 0o644))
+
+	orig := osWriteFile
+	t.Cleanup(func() { osWriteFile = orig })
+	osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		if name == pathname {
+			return fmt.Errorf("mock: write to pathname failed")
+		}
+		return os.WriteFile(name, data, perm)
+	}
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath(content, ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "writing to")
+}
+
+func TestFixAtRealPath_WriteToOursFails_ExitsTwo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	content := []byte("# Hello\n")
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, content, 0o644))
+	require.NoError(t, os.WriteFile(ours, content, 0o644))
+
+	orig := osWriteFile
+	t.Cleanup(func() { osWriteFile = orig })
+	osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		if name == ours {
+			return fmt.Errorf("mock: write to ours failed")
+		}
+		return os.WriteFile(name, data, perm)
+	}
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath(content, ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "writing merge output")
+}
+
+func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	content := []byte("# Hello\n\nWorld.\n")
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, content, 0o644))
+	require.NoError(t, os.WriteFile(ours, content, 0o600))
+
+	fixed, code := fixAtRealPath(content, ours, pathname, 1<<20)
+	require.Equal(t, 0, code)
+	assert.NotEmpty(t, fixed)
+
+	info, err := os.Stat(ours)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"fixAtRealPath must preserve the original permissions of ours")
 }

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -922,6 +922,39 @@ func TestMergeFileMode_MissingFile_UsesDefault(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o644), got)
 }
 
+func TestMergeAndClean_ReGuardFails_ExitsTwo(t *testing.T) {
+	// The re-check of ours immediately before osWriteFile (4th guardFn call
+	// in mergeAndClean: ours/base/theirs at start, then ours again pre-write).
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	content := "# Hello\n"
+	base := filepath.Join(dir, "base.md")
+	ours := filepath.Join(dir, "ours.md")
+	theirs := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+
+	var calls int
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	guardFn = func(path string) error {
+		calls++
+		if calls == 4 { // 4th call = re-check of ours before write
+			return fmt.Errorf("injected: %s not regular", path)
+		}
+		return orig(path)
+	}
+
+	got := captureStderr(func() {
+		_, code := mergeAndClean(base, ours, theirs, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected")
+}
+
 func TestMergeAndClean_WriteFileFails_ExitsTwo(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -1058,6 +1091,92 @@ func TestFixAtRealPath_ChmodFails_ExitsTwo(t *testing.T) {
 		assert.Equal(t, 2, code)
 	})
 	assert.Contains(t, got, "chmod merge output")
+}
+
+// guardCallN returns a guardFn replacement that delegates to the real
+// guardRegularFile for the first n-1 calls, then returns an error on call n,
+// then delegates again for all subsequent calls.
+func guardCallN(n int, msg string) func(string) error {
+	var calls int
+	return func(path string) error {
+		calls++
+		if calls == n {
+			return fmt.Errorf("%s: %s", path, msg)
+		}
+		return guardRegularFile(path)
+	}
+}
+
+func TestFixAtRealPath_ThirdGuardFails_ExitsTwo(t *testing.T) {
+	// 3rd guardFn call = re-check of pathname immediately before write.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	guardFn = guardCallN(3, "injected pre-write guard")
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected pre-write guard")
+}
+
+func TestFixAtRealPath_FourthGuardFails_ExitsTwo(t *testing.T) {
+	// 4th guardFn call = re-check of pathname before restore write.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	guardFn = guardCallN(4, "injected pre-restore guard")
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected pre-restore guard")
+}
+
+func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
+	// 5th guardFn call = re-check of ours before final write.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	guardFn = guardCallN(5, "injected pre-ours-write guard")
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected pre-ours-write guard")
 }
 
 func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1190,6 +1190,31 @@ func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
 	assert.Contains(t, got, "injected pre-ours-write guard")
 }
 
+func TestFixAtRealPath_FixFails_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := fixFileInPlaceFn
+	t.Cleanup(func() { fixFileInPlaceFn = orig })
+	fixFileInPlaceFn = func(string, int64) error {
+		return fmt.Errorf("mock fix failure")
+	}
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "fix failed")
+}
+
 func TestFixAtRealPath_PathnameNotExist_RemovesAfterFix(t *testing.T) {
 	// When pathname doesn't exist before the merge, fixAtRealPath should
 	// remove the temp file it created rather than restoring non-existent content.

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1227,11 +1227,13 @@ func TestFixAtRealPath_GuardBeforeRemoveFails_ExitsTwo(t *testing.T) {
 
 	orig := guardFn
 	t.Cleanup(func() { guardFn = orig })
-	// Calls: 1=pathname top, 2=ours top, 3=pathname pre-write,
-	//        6=pathname pre-remove (4 & 5 are from fixAtRealPath ours re-check
-	//        and the re-check inside readAndRestore before restore — but since
-	//        backupErr is ENOENT the restore guard (call 4) isn't taken and we
-	//        go straight to the Remove guard).
+	// guardFn call sequence for the ENOENT-backup path:
+	//   1 = pathname at top of fixAtRealPath
+	//   2 = ours at top of fixAtRealPath
+	//   3 = pathname re-check before write
+	//   4 = pathname re-check before os.Remove in readAndRestore
+	// (the restore guard inside readAndRestore is skipped because backupErr
+	// is ENOENT, so the ENOENT branch runs instead)
 	guardFn = guardCallN(4, "injected pre-remove guard")
 
 	got := captureStderr(func() {

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -857,23 +857,23 @@ func TestMergeAndClean_DashPrefixedFilenames_NoOptionInjection(t *testing.T) {
 	// Regression test: file paths starting with "-" must not be
 	// interpreted as git options. The "--" separator added to the
 	// git merge-file call prevents option injection.
+	// Use relative paths so the argv elements passed to git actually
+	// start with "-" (absolute paths like /tmp/dir/-base.md do not).
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
 	dir := t.TempDir()
-
-	// Use a filename that starts with "-" to trigger option injection
-	// if "--" is missing from the git merge-file invocation.
-	base := filepath.Join(dir, "-base.md")
-	ours := filepath.Join(dir, "-ours.md")
-	theirs := filepath.Join(dir, "-theirs.md")
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
 
 	content := "# Hello\n"
-	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
-	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile("-base.md", []byte(content), 0o644))
+	require.NoError(t, os.WriteFile("-ours.md", []byte(content), 0o644))
+	require.NoError(t, os.WriteFile("-theirs.md", []byte(content), 0o644))
 
-	_, code := mergeAndClean(base, ours, theirs, 1<<20)
+	_, code := mergeAndClean("-base.md", "-ours.md", "-theirs.md", 1<<20)
 	assert.Equal(t, 0, code, "merge with dash-prefixed filenames must succeed")
 }
 
@@ -978,10 +978,6 @@ func TestFixAtRealPath_WriteToPathnameFails_ExitsTwo(t *testing.T) {
 }
 
 func TestFixAtRealPath_WriteToOursFails_ExitsTwo(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-
 	dir := t.TempDir()
 	origWd, err := os.Getwd()
 	require.NoError(t, err)
@@ -1011,9 +1007,6 @@ func TestFixAtRealPath_WriteToOursFails_ExitsTwo(t *testing.T) {
 }
 
 func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
 	if runtime.GOOS == "windows" {
 		t.Skip("file mode bits not meaningful on Windows")
 	}

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -913,7 +913,7 @@ func TestMergeFileMode_ExistingFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("x"), 0o755))
 
 	got := mergeFileMode(path, 0o644)
-	assert.Equal(t, os.FileMode(0o755), got.Perm())
+	assert.Equal(t, os.FileMode(0o755), got)
 }
 
 func TestMergeFileMode_MissingFile_UsesDefault(t *testing.T) {
@@ -1005,6 +1005,59 @@ func TestFixAtRealPath_WriteToOursFails_ExitsTwo(t *testing.T) {
 		assert.Equal(t, 2, code)
 	})
 	assert.Contains(t, got, "writing merge output")
+}
+
+func TestMergeAndClean_ChmodFails_ExitsTwo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+
+	content := "# Hello\n"
+	base := filepath.Join(dir, "base.md")
+	ours := filepath.Join(dir, "ours.md")
+	theirs := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(base, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte(content), 0o644))
+
+	orig := chmodFunc
+	t.Cleanup(func() { chmodFunc = orig })
+	chmodFunc = func(string, os.FileMode) error {
+		return fmt.Errorf("mock chmod failure")
+	}
+
+	got := captureStderr(func() {
+		_, code := mergeAndClean(base, ours, theirs, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "chmod merge result")
+}
+
+func TestFixAtRealPath_ChmodFails_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	content := []byte("# Hello\n\nWorld.\n")
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, content, 0o644))
+	require.NoError(t, os.WriteFile(ours, content, 0o644))
+
+	orig := chmodFunc
+	t.Cleanup(func() { chmodFunc = orig })
+	chmodFunc = func(string, os.FileMode) error {
+		return fmt.Errorf("mock chmod failure")
+	}
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath(content, ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "chmod merge output")
 }
 
 func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -922,6 +922,17 @@ func TestMergeFileMode_MissingFile_UsesDefault(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o644), got)
 }
 
+func TestGuardRegularFile_LstatNonENOENTError_ReturnsError(t *testing.T) {
+	orig := lstatFn
+	t.Cleanup(func() { lstatFn = orig })
+	lstatFn = func(string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("mock lstat failure")
+	}
+	err := guardRegularFile("anypath")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lstat")
+}
+
 func TestMergeAndClean_ReGuardFails_ExitsTwo(t *testing.T) {
 	// The re-check of ours immediately before osWriteFile (4th guardFn call
 	// in mergeAndClean: ours/base/theirs at start, then ours again pre-write).
@@ -1177,6 +1188,113 @@ func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
 		assert.Equal(t, 2, code)
 	})
 	assert.Contains(t, got, "injected pre-ours-write guard")
+}
+
+func TestFixAtRealPath_PathnameNotExist_RemovesAfterFix(t *testing.T) {
+	// When pathname doesn't exist before the merge, fixAtRealPath should
+	// remove the temp file it created rather than restoring non-existent content.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "newfile.md")
+	ours := filepath.Join(dir, "ours.md")
+	// pathname does NOT exist — backup will be ENOENT.
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	fixed, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+	assert.Equal(t, 0, code)
+	assert.NotEmpty(t, fixed)
+	// pathname should have been removed after the fix cycle.
+	_, statErr := os.Stat(pathname)
+	assert.True(t, os.IsNotExist(statErr), "pathname should be removed after fix")
+}
+
+func TestFixAtRealPath_GuardBeforeRemoveFails_ExitsTwo(t *testing.T) {
+	// 6th guardFn call = re-check of pathname before os.Remove in the
+	// ENOENT-backup branch of readAndRestore.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "newfile.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := guardFn
+	t.Cleanup(func() { guardFn = orig })
+	// Calls: 1=pathname top, 2=ours top, 3=pathname pre-write,
+	//        6=pathname pre-remove (4 & 5 are from fixAtRealPath ours re-check
+	//        and the re-check inside readAndRestore before restore — but since
+	//        backupErr is ENOENT the restore guard (call 4) isn't taken and we
+	//        go straight to the Remove guard).
+	guardFn = guardCallN(4, "injected pre-remove guard")
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "injected pre-remove guard")
+}
+
+func TestFixAtRealPath_ReadFixedFileFails_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	orig := readFileLimited
+	t.Cleanup(func() { readFileLimited = orig })
+	readFileLimited = func(string, int64) ([]byte, error) {
+		return nil, fmt.Errorf("mock read fixed failure")
+	}
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "reading fixed file")
+}
+
+func TestFixAtRealPath_RestoreWriteFails_ExitsTwo(t *testing.T) {
+	// Restore write (2nd osWriteFile call) fails.
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	var writeCount int
+	orig := osWriteFile
+	t.Cleanup(func() { osWriteFile = orig })
+	osWriteFile = func(name string, data []byte, perm os.FileMode) error {
+		writeCount++
+		if writeCount == 2 { // second write = restore
+			return fmt.Errorf("mock restore failure")
+		}
+		return orig(name, data, perm)
+	}
+
+	got := captureStderr(func() {
+		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, got, "restoring")
 }
 
 func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {

--- a/cmd/mdsmith/mergedriver_unix_test.go
+++ b/cmd/mdsmith/mergedriver_unix_test.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuardRegularFile_Symlink_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	link := filepath.Join(dir, "link.md")
+	require.NoError(t, os.WriteFile(target, []byte("content"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	err := guardRegularFile(link)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}
+
+func TestMergeAndClean_OursIsSymlink_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	link := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(target, []byte("# content\n"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	base := filepath.Join(dir, "base.md")
+	theirs := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(base, []byte("# content\n"), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte("# content\n"), 0o644))
+
+	_, code := mergeAndClean(base, link, theirs, 1<<20)
+	assert.Equal(t, 2, code)
+}
+
+func TestFixAtRealPath_PathnameIsSymlink_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	link := filepath.Join(dir, "pathname.md")
+	require.NoError(t, os.WriteFile(target, []byte("# content\n"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(ours, []byte("# content\n"), 0o644))
+
+	_, code := fixAtRealPath([]byte("# content\n"), ours, link, 1<<20)
+	assert.Equal(t, 2, code)
+}

--- a/cmd/mdsmith/mergedriver_unix_test.go
+++ b/cmd/mdsmith/mergedriver_unix_test.go
@@ -39,6 +39,38 @@ func TestMergeAndClean_OursIsSymlink_ExitsTwo(t *testing.T) {
 	assert.Equal(t, 2, code)
 }
 
+func TestMergeAndClean_BaseIsSymlink_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	link := filepath.Join(dir, "base.md")
+	require.NoError(t, os.WriteFile(target, []byte("# content\n"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	ours := filepath.Join(dir, "ours.md")
+	theirs := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(ours, []byte("# content\n"), 0o644))
+	require.NoError(t, os.WriteFile(theirs, []byte("# content\n"), 0o644))
+
+	_, code := mergeAndClean(link, ours, theirs, 1<<20)
+	assert.Equal(t, 2, code)
+}
+
+func TestMergeAndClean_TheirsIsSymlink_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	link := filepath.Join(dir, "theirs.md")
+	require.NoError(t, os.WriteFile(target, []byte("# content\n"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	base := filepath.Join(dir, "base.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(base, []byte("# content\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# content\n"), 0o644))
+
+	_, code := mergeAndClean(base, ours, link, 1<<20)
+	assert.Equal(t, 2, code)
+}
+
 func TestFixAtRealPath_PathnameIsSymlink_ExitsTwo(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.md")

--- a/cmd/mdsmith/mergedriver_unix_test.go
+++ b/cmd/mdsmith/mergedriver_unix_test.go
@@ -52,3 +52,17 @@ func TestFixAtRealPath_PathnameIsSymlink_ExitsTwo(t *testing.T) {
 	_, code := fixAtRealPath([]byte("# content\n"), ours, link, 1<<20)
 	assert.Equal(t, 2, code)
 }
+
+func TestFixAtRealPath_OursIsSymlink_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	pathname := filepath.Join(dir, "pathname.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("# content\n"), 0o644))
+
+	oursTarget := filepath.Join(dir, "ours-target.md")
+	oursLink := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(oursTarget, []byte("# content\n"), 0o644))
+	require.NoError(t, os.Symlink(oursTarget, oursLink))
+
+	_, code := fixAtRealPath([]byte("# content\n"), oursLink, pathname, 1<<20)
+	assert.Equal(t, 2, code)
+}

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -766,17 +766,24 @@ func WriteGitattributes(path string, globs Globs) error {
 		}
 	}
 
-	// Preserve the existing file's permissions; fall back to 0o644 for new files.
-	// os.WriteFile only applies perm on creation; os.Chmod enforces it on
-	// existing files too (truncation does not change the file's mode).
-	// Chmod is skipped for new files to respect the caller's umask.
+	return writeGitattributesFile(path, newContent.String())
+}
+
+// writeGitattributesFile writes content to path, preserving an existing regular
+// file's permissions. Symlinks are rejected to prevent writes outside the repo.
+func writeGitattributesFile(path, content string) error {
+	// Use Lstat so symlinks are detected rather than followed; writing through
+	// a symlink could modify a file outside the repository.
 	mode := os.FileMode(0o644)
 	existed := false
-	if info, err := os.Stat(path); err == nil {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("writing %s: refusing to write through symlink", path)
+		}
 		mode = info.Mode() &^ os.ModeType
 		existed = true
 	}
-	if err := writeFile(path, []byte(newContent.String()), mode); err != nil {
+	if err := writeFile(path, []byte(content), mode); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	if existed {

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -758,7 +758,12 @@ func WriteGitattributes(path string, globs Globs) error {
 		}
 	}
 
-	return os.WriteFile(path, []byte(newContent.String()), 0644)
+	// Preserve the existing file's permissions; fall back to 0o644 for new files.
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode()
+	}
+	return os.WriteFile(path, []byte(newContent.String()), mode)
 }
 
 // StageGitattributes runs `git add -- .gitattributes` against repoRoot

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -798,26 +798,36 @@ func writeGitattributesFile(path, content string) error {
 	return nil
 }
 
-// createTempFn, syncTempFn, closeTempFn, and chmodFn are variables so tests
-// can inject failures into atomicWriteGitattributes without OS-level tricks.
+// createTempFn, syncTempFn, closeTempFn, chmodFn, and fstatFn are variables
+// so tests can inject failures into atomicWriteGitattributes without OS tricks.
 var createTempFn = os.CreateTemp
 var syncTempFn = (*os.File).Sync
 var closeTempFn = (*os.File).Close
 var chmodFn = os.Chmod
+var fstatFn = (*os.File).Stat
 
 // atomicWriteGitattributes writes data to a temp file in the same directory
 // as path, sets its permissions, then renames it over path. The rename
 // replaces the directory entry atomically, so it cannot follow a symlink
 // that might have been introduced between an earlier lstat check and the write.
 func atomicWriteGitattributes(path string, data []byte, mode os.FileMode) error {
-	// Verify an existing target is writable. os.Rename can replace read-only
-	// files when the directory is writable, so we check explicitly.
-	if _, err := lstatFile(path); err == nil {
+	// Verify an existing target is writable and has not been swapped to a
+	// symlink. os.Rename can replace read-only files when the directory is
+	// writable, so we check writability explicitly. We then compare lstat and
+	// fstat to detect a TOCTOU swap between the lstat and the open.
+	if lstatInfo, err := lstatFile(path); err == nil {
 		f, err := os.OpenFile(path, os.O_WRONLY, 0)
 		if err != nil {
 			return err
 		}
+		fdInfo, statErr := fstatFn(f)
 		_ = f.Close()
+		if statErr != nil {
+			return statErr
+		}
+		if !os.SameFile(lstatInfo, fdInfo) {
+			return fmt.Errorf("%s: file changed since lstat", path)
+		}
 	} else if !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -19,6 +19,10 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
+// readFile and writeFile are variables so tests can substitute failing
+// implementations to exercise error paths in WriteGitattributes.
+var readFile = os.ReadFile
+
 // writeFile is a variable so tests can substitute a failing implementation
 // to exercise the os.WriteFile error path in WriteGitattributes.
 var writeFile = os.WriteFile
@@ -707,7 +711,15 @@ func GlobsEqual(a, b Globs) bool {
 // text, eol=lf, linguist settings, other merge drivers) are never
 // dropped.
 func WriteGitattributes(path string, globs Globs) error {
-	existing, err := os.ReadFile(path)
+	// Reject symlinks and non-regular files before any I/O so neither the
+	// read nor the write follows a link to a path outside the repository.
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("writing %s: not a regular file", path)
+		}
+	}
+
+	existing, err := readFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("reading %s: %w", path, err)
 	}
@@ -769,17 +781,12 @@ func WriteGitattributes(path string, globs Globs) error {
 	return writeGitattributesFile(path, newContent.String())
 }
 
-// writeGitattributesFile writes content to path, preserving an existing regular
-// file's permissions. Symlinks are rejected to prevent writes outside the repo.
+// writeGitattributesFile writes content to path, preserving an existing
+// file's permissions. The caller must ensure path is a regular file.
 func writeGitattributesFile(path, content string) error {
-	// Use Lstat so symlinks are detected rather than followed; writing through
-	// a symlink could modify a file outside the repository.
 	mode := os.FileMode(0o644)
 	existed := false
 	if info, err := os.Lstat(path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("writing %s: refusing to write through symlink", path)
-		}
 		mode = info.Mode() &^ os.ModeType
 		existed = true
 	}

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -27,10 +27,6 @@ var readFile = os.ReadFile
 // to exercise the os.WriteFile error path in WriteGitattributes.
 var writeFile = os.WriteFile
 
-// chmodFile is a variable so tests can substitute a failing implementation
-// to exercise the os.Chmod error path in WriteGitattributes.
-var chmodFile = os.Chmod
-
 // PreMergeCommitMarker is the comment line written into the
 // pre-merge-commit hook so that mdsmith (and the git-hook-sync rule)
 // can recognise hooks it manages without stomping on user-authored
@@ -786,22 +782,17 @@ func WriteGitattributes(path string, globs Globs) error {
 // narrow the TOCTOU window between WriteGitattributes' initial check and
 // the actual write.
 func writeGitattributesFile(path, content string) error {
+	// Default mode for new files; os.WriteFile preserves existing mode
+	// on truncating writes so no chmod is needed for existing files.
 	mode := os.FileMode(0o644)
-	existed := false
 	if info, err := os.Lstat(path); err == nil {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("writing %s: not a regular file", path)
 		}
 		mode = info.Mode() &^ os.ModeType
-		existed = true
 	}
 	if err := writeFile(path, []byte(content), mode); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
-	}
-	if existed {
-		if err := chmodFile(path, mode); err != nil {
-			return fmt.Errorf("chmod %s: %w", path, err)
-		}
 	}
 	return nil
 }

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -782,11 +782,16 @@ func WriteGitattributes(path string, globs Globs) error {
 }
 
 // writeGitattributesFile writes content to path, preserving an existing
-// file's permissions. The caller must ensure path is a regular file.
+// file's permissions. Re-validates that path is still a regular file to
+// narrow the TOCTOU window between WriteGitattributes' initial check and
+// the actual write.
 func writeGitattributesFile(path, content string) error {
 	mode := os.FileMode(0o644)
 	existed := false
 	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("writing %s: not a regular file", path)
+		}
 		mode = info.Mode() &^ os.ModeType
 		existed = true
 	}

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -759,11 +759,16 @@ func WriteGitattributes(path string, globs Globs) error {
 	}
 
 	// Preserve the existing file's permissions; fall back to 0o644 for new files.
+	// os.WriteFile only applies perm on creation; os.Chmod enforces it on
+	// existing files too (truncation does not change the file's mode).
 	mode := os.FileMode(0o644)
 	if info, err := os.Stat(path); err == nil {
-		mode = info.Mode()
+		mode = info.Mode().Perm()
 	}
-	return os.WriteFile(path, []byte(newContent.String()), mode)
+	if err := os.WriteFile(path, []byte(newContent.String()), mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
 }
 
 // StageGitattributes runs `git add -- .gitattributes` against repoRoot

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -773,10 +773,12 @@ func WriteGitattributes(path string, globs Globs) error {
 		existed = true
 	}
 	if err := writeFile(path, []byte(newContent.String()), mode); err != nil {
-		return err
+		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	if existed {
-		return os.Chmod(path, mode)
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("chmod %s: %w", path, err)
+		}
 	}
 	return nil
 }

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -798,8 +798,8 @@ func writeGitattributesFile(path, content string) error {
 	return nil
 }
 
-// createTempFn, closeTempFn, and chmodFn are variables so tests can inject
-// failures into atomicWriteGitattributes without needing OS-level tricks.
+// createTempFn, syncTempFn, closeTempFn, and chmodFn are variables so tests
+// can inject failures into atomicWriteGitattributes without OS-level tricks.
 var createTempFn = os.CreateTemp
 var syncTempFn = (*os.File).Sync
 var closeTempFn = (*os.File).Close
@@ -810,6 +810,17 @@ var chmodFn = os.Chmod
 // replaces the directory entry atomically, so it cannot follow a symlink
 // that might have been introduced between an earlier lstat check and the write.
 func atomicWriteGitattributes(path string, data []byte, mode os.FileMode) error {
+	// Verify an existing target is writable. os.Rename can replace read-only
+	// files when the directory is writable, so we check explicitly.
+	if _, err := lstatFile(path); err == nil {
+		f, err := os.OpenFile(path, os.O_WRONLY, 0)
+		if err != nil {
+			return err
+		}
+		_ = f.Close()
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	dir := filepath.Dir(path)
 	tmp, err := createTempFn(dir, ".mdsmith-gitattributes-*")
 	if err != nil {

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -19,10 +19,10 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
-// readFile, writeFile, and lstatFile are variables so tests can substitute
+// readFile, atomicWriteFn, and lstatFile are variables so tests can substitute
 // failing implementations to exercise error paths in WriteGitattributes.
 var readFile = os.ReadFile
-var writeFile = os.WriteFile
+var atomicWriteFn = atomicWriteGitattributes
 var lstatFile = os.Lstat
 
 // PreMergeCommitMarker is the comment line written into the
@@ -778,13 +778,11 @@ func WriteGitattributes(path string, globs Globs) error {
 	return writeGitattributesFile(path, newContent.String())
 }
 
-// writeGitattributesFile writes content to path, preserving an existing
-// file's permissions. Re-validates that path is still a regular file to
-// narrow the TOCTOU window between WriteGitattributes' initial check and
-// the actual write.
+// writeGitattributesFile writes content to path using a temp-then-rename
+// strategy. Even if path is swapped to a symlink between the lstat guard in
+// WriteGitattributes and this call, os.Rename replaces the directory entry
+// rather than following the link, so the write cannot escape the repository.
 func writeGitattributesFile(path, content string) error {
-	// Default mode for new files; os.WriteFile preserves existing mode
-	// on truncating writes so no chmod is needed for existing files.
 	mode := os.FileMode(0o644)
 	if info, err := lstatFile(path); err == nil {
 		if !info.Mode().IsRegular() {
@@ -794,10 +792,41 @@ func writeGitattributesFile(path, content string) error {
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("writing %s: lstat: %w", path, err)
 	}
-	if err := writeFile(path, []byte(content), mode); err != nil {
+	if err := atomicWriteFn(path, []byte(content), mode); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	return nil
+}
+
+// createTempFn, closeTempFn, and chmodFn are variables so tests can inject
+// failures into atomicWriteGitattributes without needing OS-level tricks.
+var createTempFn = os.CreateTemp
+var closeTempFn = (*os.File).Close
+var chmodFn = os.Chmod
+
+// atomicWriteGitattributes writes data to a temp file in the same directory
+// as path, sets its permissions, then renames it over path. The rename
+// replaces the directory entry atomically, so it cannot follow a symlink
+// that might have been introduced between an earlier lstat check and the write.
+func atomicWriteGitattributes(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := createTempFn(dir, ".mdsmith-gitattributes-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := closeTempFn(tmp); err != nil {
+		return err
+	}
+	if err := chmodFn(tmpName, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // StageGitattributes runs `git add -- .gitattributes` against repoRoot

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -788,7 +788,7 @@ func writeGitattributesFile(path, content string) error {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("writing %s: not a regular file", path)
 		}
-		mode = info.Mode().Perm()
+		mode = info.Mode() &^ os.ModeType
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("writing %s: lstat: %w", path, err)
 	}
@@ -801,6 +801,7 @@ func writeGitattributesFile(path, content string) error {
 // createTempFn, closeTempFn, and chmodFn are variables so tests can inject
 // failures into atomicWriteGitattributes without needing OS-level tricks.
 var createTempFn = os.CreateTemp
+var syncTempFn = (*os.File).Sync
 var closeTempFn = (*os.File).Close
 var chmodFn = os.Chmod
 
@@ -817,6 +818,10 @@ func atomicWriteGitattributes(path string, data []byte, mode os.FileMode) error 
 	tmpName := tmp.Name()
 	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := syncTempFn(tmp); err != nil {
 		_ = tmp.Close()
 		return err
 	}

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -19,13 +19,11 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
-// readFile and writeFile are variables so tests can substitute failing
-// implementations to exercise error paths in WriteGitattributes.
+// readFile, writeFile, and lstatFile are variables so tests can substitute
+// failing implementations to exercise error paths in WriteGitattributes.
 var readFile = os.ReadFile
-
-// writeFile is a variable so tests can substitute a failing implementation
-// to exercise the os.WriteFile error path in WriteGitattributes.
 var writeFile = os.WriteFile
+var lstatFile = os.Lstat
 
 // PreMergeCommitMarker is the comment line written into the
 // pre-merge-commit hook so that mdsmith (and the git-hook-sync rule)
@@ -710,10 +708,12 @@ func WriteGitattributes(path string, globs Globs) error {
 	// Reject symlinks and non-regular files before any I/O to reduce the
 	// risk of following a link to a path outside the repository.
 	// A narrow TOCTOU window remains between this check and the I/O calls.
-	if info, err := os.Lstat(path); err == nil {
+	if info, err := lstatFile(path); err == nil {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("writing %s: not a regular file", path)
 		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("writing %s: lstat: %w", path, err)
 	}
 
 	existing, err := readFile(path)
@@ -786,11 +786,13 @@ func writeGitattributesFile(path, content string) error {
 	// Default mode for new files; os.WriteFile preserves existing mode
 	// on truncating writes so no chmod is needed for existing files.
 	mode := os.FileMode(0o644)
-	if info, err := os.Lstat(path); err == nil {
+	if info, err := lstatFile(path); err == nil {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("writing %s: not a regular file", path)
 		}
 		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("writing %s: lstat: %w", path, err)
 	}
 	if err := writeFile(path, []byte(content), mode); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -707,8 +707,9 @@ func GlobsEqual(a, b Globs) bool {
 // text, eol=lf, linguist settings, other merge drivers) are never
 // dropped.
 func WriteGitattributes(path string, globs Globs) error {
-	// Reject symlinks and non-regular files before any I/O so neither the
-	// read nor the write follows a link to a path outside the repository.
+	// Reject symlinks and non-regular files before any I/O to reduce the
+	// risk of following a link to a path outside the repository.
+	// A narrow TOCTOU window remains between this check and the I/O calls.
 	if info, err := os.Lstat(path); err == nil {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("writing %s: not a regular file", path)
@@ -789,7 +790,7 @@ func writeGitattributesFile(path, content string) error {
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("writing %s: not a regular file", path)
 		}
-		mode = info.Mode() &^ os.ModeType
+		mode = info.Mode().Perm()
 	}
 	if err := writeFile(path, []byte(content), mode); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -19,6 +19,10 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
+// writeFile is a variable so tests can substitute a failing implementation
+// to exercise the os.WriteFile error path in WriteGitattributes.
+var writeFile = os.WriteFile
+
 // PreMergeCommitMarker is the comment line written into the
 // pre-merge-commit hook so that mdsmith (and the git-hook-sync rule)
 // can recognise hooks it manages without stomping on user-authored
@@ -761,14 +765,20 @@ func WriteGitattributes(path string, globs Globs) error {
 	// Preserve the existing file's permissions; fall back to 0o644 for new files.
 	// os.WriteFile only applies perm on creation; os.Chmod enforces it on
 	// existing files too (truncation does not change the file's mode).
+	// Chmod is skipped for new files to respect the caller's umask.
 	mode := os.FileMode(0o644)
+	existed := false
 	if info, err := os.Stat(path); err == nil {
-		mode = info.Mode().Perm()
+		mode = info.Mode() &^ os.ModeType
+		existed = true
 	}
-	if err := os.WriteFile(path, []byte(newContent.String()), mode); err != nil {
+	if err := writeFile(path, []byte(newContent.String()), mode); err != nil {
 		return err
 	}
-	return os.Chmod(path, mode)
+	if existed {
+		return os.Chmod(path, mode)
+	}
+	return nil
 }
 
 // StageGitattributes runs `git add -- .gitattributes` against repoRoot

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -23,6 +23,10 @@ import (
 // to exercise the os.WriteFile error path in WriteGitattributes.
 var writeFile = os.WriteFile
 
+// chmodFile is a variable so tests can substitute a failing implementation
+// to exercise the os.Chmod error path in WriteGitattributes.
+var chmodFile = os.Chmod
+
 // PreMergeCommitMarker is the comment line written into the
 // pre-merge-commit hook so that mdsmith (and the git-hook-sync rule)
 // can recognise hooks it manages without stomping on user-authored
@@ -776,7 +780,7 @@ func WriteGitattributes(path string, globs Globs) error {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	if existed {
-		if err := os.Chmod(path, mode); err != nil {
+		if err := chmodFile(path, mode); err != nil {
 			return fmt.Errorf("chmod %s: %w", path, err)
 		}
 	}

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1135,17 +1135,32 @@ func TestWriteGitattributes_ChmodFails_ReturnsWrappedError(t *testing.T) {
 	assert.Contains(t, err.Error(), "chmod")
 }
 
-func TestWriteGitattributes_PropagatesNonENOENTReadError(t *testing.T) {
-	// .gitattributes is a directory, so os.ReadFile returns a
-	// non-IsNotExist error. WriteGitattributes must surface that
-	// rather than silently overwriting the directory.
+func TestWriteGitattributes_ReadFileFails_ReturnsWrappedError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+	require.NoError(t, os.WriteFile(path, []byte("existing\n"), 0o644))
+
+	orig := readFile
+	t.Cleanup(func() { readFile = orig })
+	readFile = func(string) ([]byte, error) {
+		return nil, fmt.Errorf("mock read failure")
+	}
+
+	err := WriteGitattributes(path, Globs{Include: []string{"*.md"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading")
+}
+
+func TestWriteGitattributes_RejectsDirectory(t *testing.T) {
+	// .gitattributes is a directory — the Lstat guard must reject it
+	// before any read or write is attempted.
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitattributes")
 	require.NoError(t, os.Mkdir(path, 0o755))
 
 	err := WriteGitattributes(path, Globs{Include: []string{"*.md"}})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reading")
+	assert.Contains(t, err.Error(), "not a regular file")
 }
 
 func TestHookMatchesCanonical_RejectsCanonicalLinesInsideComments(t *testing.T) {

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1118,23 +1118,6 @@ func TestWriteGitattributes_WriteFileFails_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestWriteGitattributes_ChmodFails_ReturnsWrappedError(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".gitattributes")
-	// Pre-create the file so the chmod branch (existed=true) is taken.
-	require.NoError(t, os.WriteFile(path, []byte("existing\n"), 0o644))
-
-	orig := chmodFile
-	t.Cleanup(func() { chmodFile = orig })
-	chmodFile = func(string, os.FileMode) error {
-		return fmt.Errorf("mock chmod failure")
-	}
-
-	err := WriteGitattributes(path, Globs{Include: []string{"a.md"}})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "chmod")
-}
-
 func TestWriteGitattributes_ReadFileFails_ReturnsWrappedError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitattributes")

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1224,6 +1224,44 @@ func TestAtomicWriteGitattributes_LstatNonENOENTError_ReturnsError(t *testing.T)
 	assert.Contains(t, err.Error(), "mock lstat failure")
 }
 
+func TestAtomicWriteGitattributes_FstatFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+	require.NoError(t, os.WriteFile(path, []byte("existing"), 0o644))
+
+	orig := fstatFn
+	t.Cleanup(func() { fstatFn = orig })
+	fstatFn = func(*os.File) (os.FileInfo, error) {
+		return nil, fmt.Errorf("mock fstat failure")
+	}
+
+	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock fstat failure")
+}
+
+func TestAtomicWriteGitattributes_LstatFdMismatch_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+	other := filepath.Join(dir, "other")
+	require.NoError(t, os.WriteFile(path, []byte("existing"), 0o644))
+	require.NoError(t, os.WriteFile(other, []byte("other"), 0o644))
+
+	otherInfo, err := os.Lstat(other)
+	require.NoError(t, err)
+
+	// Inject lstatFile to return info for 'other' (different inode than path).
+	orig := lstatFile
+	t.Cleanup(func() { lstatFile = orig })
+	lstatFile = func(string) (os.FileInfo, error) {
+		return otherInfo, nil
+	}
+
+	err = atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changed since lstat")
+}
+
 func TestWriteGitattributes_LstatNonENOENTError_ReturnsError(t *testing.T) {
 	orig := lstatFile
 	t.Cleanup(func() { lstatFile = orig })

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1197,6 +1198,30 @@ func TestAtomicWriteGitattributes_ChmodFails_ReturnsError(t *testing.T) {
 	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mock chmod failure")
+}
+
+func TestAtomicWriteGitattributes_TargetIsDirectory_ReturnsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not reliable on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	require.NoError(t, os.Mkdir(target, 0o755))
+
+	err := atomicWriteGitattributes(target, []byte("content"), 0o644)
+	require.Error(t, err)
+}
+
+func TestAtomicWriteGitattributes_LstatNonENOENTError_ReturnsError(t *testing.T) {
+	orig := lstatFile
+	t.Cleanup(func() { lstatFile = orig })
+	lstatFile = func(string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("mock lstat failure")
+	}
+
+	err := atomicWriteGitattributes("/any/path", []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock lstat failure")
 }
 
 func TestWriteGitattributes_LstatNonENOENTError_ReturnsError(t *testing.T) {

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1104,18 +1104,84 @@ func TestExtractGlobs_SkipsSingleFieldLines(t *testing.T) {
 	assert.Empty(t, got.Exclude)
 }
 
-func TestWriteGitattributes_WriteFileFails_ReturnsError(t *testing.T) {
+func TestWriteGitattributes_AtomicWriteFails_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitattributes")
 
-	orig := writeFile
-	t.Cleanup(func() { writeFile = orig })
-	writeFile = func(string, []byte, os.FileMode) error {
+	orig := atomicWriteFn
+	t.Cleanup(func() { atomicWriteFn = orig })
+	atomicWriteFn = func(string, []byte, os.FileMode) error {
 		return fmt.Errorf("mock write failure")
 	}
 
 	err := WriteGitattributes(path, Globs{Include: []string{"a.md"}})
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mock write failure")
+}
+
+func TestAtomicWriteGitattributes_CreateTempFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	orig := createTempFn
+	t.Cleanup(func() { createTempFn = orig })
+	createTempFn = func(string, string) (*os.File, error) {
+		return nil, fmt.Errorf("mock createtemp failure")
+	}
+
+	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock createtemp failure")
+}
+
+func TestAtomicWriteGitattributes_WriteFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	origCreate := createTempFn
+	t.Cleanup(func() { createTempFn = origCreate })
+	// Return a closed file so Write fails.
+	createTempFn = func(dir, pattern string) (*os.File, error) {
+		f, err := os.CreateTemp(dir, pattern)
+		if err != nil {
+			return nil, err
+		}
+		_ = f.Close()
+		return f, nil
+	}
+
+	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+}
+
+func TestAtomicWriteGitattributes_CloseFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	orig := closeTempFn
+	t.Cleanup(func() { closeTempFn = orig })
+	closeTempFn = func(*os.File) error {
+		return fmt.Errorf("mock close failure")
+	}
+
+	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock close failure")
+}
+
+func TestAtomicWriteGitattributes_ChmodFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	orig := chmodFn
+	t.Cleanup(func() { chmodFn = orig })
+	chmodFn = func(string, os.FileMode) error {
+		return fmt.Errorf("mock chmod failure")
+	}
+
+	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock chmod failure")
 }
 
 func TestWriteGitattributes_LstatNonENOENTError_ReturnsError(t *testing.T) {

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1118,6 +1118,28 @@ func TestWriteGitattributes_WriteFileFails_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWriteGitattributes_LstatNonENOENTError_ReturnsError(t *testing.T) {
+	orig := lstatFile
+	t.Cleanup(func() { lstatFile = orig })
+	lstatFile = func(string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("mock lstat failure")
+	}
+	err := WriteGitattributes("/any/path", Globs{Include: []string{"*.md"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lstat")
+}
+
+func TestWriteGitattributesFile_LstatNonENOENTError_ReturnsError(t *testing.T) {
+	orig := lstatFile
+	t.Cleanup(func() { lstatFile = orig })
+	lstatFile = func(string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("mock lstat failure")
+	}
+	err := writeGitattributesFile("/any/path", "content")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lstat")
+}
+
 func TestWriteGitattributes_ReadFileFails_ReturnsWrappedError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitattributes")

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1118,6 +1118,23 @@ func TestWriteGitattributes_WriteFileFails_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWriteGitattributes_ChmodFails_ReturnsWrappedError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+	// Pre-create the file so the chmod branch (existed=true) is taken.
+	require.NoError(t, os.WriteFile(path, []byte("existing\n"), 0o644))
+
+	orig := chmodFile
+	t.Cleanup(func() { chmodFile = orig })
+	chmodFile = func(string, os.FileMode) error {
+		return fmt.Errorf("mock chmod failure")
+	}
+
+	err := WriteGitattributes(path, Globs{Include: []string{"a.md"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chmod")
+}
+
 func TestWriteGitattributes_PropagatesNonENOENTReadError(t *testing.T) {
 	// .gitattributes is a directory, so os.ReadFile returns a
 	// non-IsNotExist error. WriteGitattributes must surface that

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1154,6 +1154,21 @@ func TestAtomicWriteGitattributes_WriteFails_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestAtomicWriteGitattributes_SyncFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	orig := syncTempFn
+	t.Cleanup(func() { syncTempFn = orig })
+	syncTempFn = func(*os.File) error {
+		return fmt.Errorf("mock sync failure")
+	}
+
+	err := atomicWriteGitattributes(path, []byte("content"), 0o644)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mock sync failure")
+}
+
 func TestAtomicWriteGitattributes_CloseFails_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".gitattributes")

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1,6 +1,7 @@
 package githooks
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1101,6 +1102,20 @@ func TestExtractGlobs_SkipsSingleFieldLines(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []string{"*.md"}, got.Include)
 	assert.Empty(t, got.Exclude)
+}
+
+func TestWriteGitattributes_WriteFileFails_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	orig := writeFile
+	t.Cleanup(func() { writeFile = orig })
+	writeFile = func(string, []byte, os.FileMode) error {
+		return fmt.Errorf("mock write failure")
+	}
+
+	err := WriteGitattributes(path, Globs{Include: []string{"a.md"}})
+	assert.Error(t, err)
 }
 
 func TestWriteGitattributes_PropagatesNonENOENTReadError(t *testing.T) {

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWriteGitattributes_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.gitattributes")
+	link := filepath.Join(dir, ".gitattributes")
+
+	require.NoError(t, os.WriteFile(target, []byte("existing\n"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	err := WriteGitattributes(link, Globs{Include: []string{"a.md"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+}
+
 func TestWriteGitattributes_ReturnsErrorForUnreadableExistingFile(t *testing.T) {
 	// Mode 0000 only blocks reads for non-root users; root bypasses
 	// file permission bits, so this assertion can't hold under uid 0.

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -27,3 +27,21 @@ func TestWriteGitattributes_ReturnsErrorForUnreadableExistingFile(t *testing.T) 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "reading")
 }
+
+func TestWriteGitattributes_PreservesExistingFileMode(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("file permission bits don't restrict root")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitattributes")
+
+	// Write with a non-default mode to verify it is preserved.
+	require.NoError(t, os.WriteFile(path, []byte("*.txt text\n"), 0o600))
+
+	require.NoError(t, WriteGitattributes(path, Globs{Include: []string{"docs.md"}}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"WriteGitattributes must not change the existing file's permission bits")
+}

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWriteGitattributesFile_RejectsSymlink(t *testing.T) {
+	// Call writeGitattributesFile directly to exercise its own Lstat guard
+	// (defense-in-depth against TOCTOU between WriteGitattributes' initial
+	// check and the actual write).
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.gitattributes")
+	link := filepath.Join(dir, ".gitattributes")
+	require.NoError(t, os.WriteFile(target, []byte("existing\n"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	err := writeGitattributesFile(link, "new content\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}
+
 func TestWriteGitattributes_RejectsSymlink(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "real.gitattributes")

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -21,7 +21,7 @@ func TestWriteGitattributes_RejectsSymlink(t *testing.T) {
 
 	err := WriteGitattributes(link, Globs{Include: []string{"a.md"}})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "symlink")
+	assert.Contains(t, err.Error(), "not a regular file")
 }
 
 func TestWriteGitattributes_ReturnsErrorForUnreadableExistingFile(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR addresses two security and correctness issues in the merge driver and git attributes handling:

1. **Security fix**: Prevent option injection attacks when processing filenames starting with &#34;-&#34;
2. **Correctness fix**: Preserve file permissions throughout merge and git attributes operations

## Key Changes

- **Added `mergeFileMode()` helper function** to safely retrieve file mode with a sensible default, eliminating code duplication
- **Fixed option injection vulnerability** in `mergeAndClean()` by adding the &#34;--&#34; separator to the `git merge-file` command, preventing filenames starting with &#34;-&#34; from being interpreted as git options
- **Preserve file permissions in merge operations**: 
  - `mergeAndClean()` now preserves the original permissions of the &#34;ours&#34; file when writing the merge result
  - `fixAtRealPath()` now preserves permissions of both the working file and the &#34;ours&#34; file
- **Preserve file permissions in git attributes**: `WriteGitattributes()` now preserves existing `.gitattributes` file permissions instead of always writing with 0644 mode

## Implementation Details

- The `mergeFileMode()` helper uses `os.Lstat()` (not `os.Stat`) to retrieve the existing file mode without following symlinks, and falls back to the provided default (typically 0o644) on any lstat error — including ENOENT and permission errors. Callers that require a regular-file guarantee invoke `guardFn` separately.
- File mode preservation is applied consistently across all file write operations in the merge workflow
- Added comprehensive test coverage including:
  - Regression test for dash-prefixed filenames to prevent option injection
  - Tests verifying file mode preservation in merge operations
  - Tests for the new `mergeFileMode()` helper function
  - Test for `.gitattributes` permission preservation on Unix systems

https://claude.ai/code/session_01UFDupDRxvbPgETqngjCta7