### PR TITLE
Mark plan item 98 as complete: Replace archetypes with kinds

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -58,5 +58,5 @@ footer: |
 | 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)     |
 | 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
 | 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                   |
-| 98  | 🔲     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |
 <?/catalog?>

--- a/plan/98_replace-archetypes-with-kinds.md
+++ b/plan/98_replace-archetypes-with-kinds.md
@@ -1,7 +1,7 @@
 ---
 id: 98
 title: Replace `archetypes` with `kinds`
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Remove the `archetypes` CLI subcommand, config key,


### PR DESCRIPTION
## Summary
This PR marks plan item 98 as complete, reflecting the successful implementation of replacing the `archetypes` feature with `kinds` throughout the codebase.

## Changes
- Updated the status of plan item 98 from incomplete (🔲) to complete (✅) in both the main plan catalog and the detailed plan document
- This indicates that the `archetypes` CLI subcommand, config key, and related functionality have been successfully replaced with the `kinds` implementation

## Details
The completion of this plan item represents the culmination of the kinds feature rollout, which included:
- Kind/rule resolution observability (item 95)
- Adoption in the mdsmith repository and documentation (item 96)
- Deep-merge support for kinds and overrides (item 97)
- Full replacement of the legacy archetypes system (item 98)

https://claude.ai/code/session_01DK5oDMP8jmsuiE76kbycZE