### PR TITLE
Plan 130: Binary distribution via npm, PyPI, asdf, mise, and VS Code

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -14,50 +14,50 @@ footer: |
 
 ?>
 
-| ID  | Status | Model  | Title                                                                                                       |
-|-----|--------|--------|-------------------------------------------------------------------------------------------------------------|
-| 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                     |
-| 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                  |
-| 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                              |
-| 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                      |
-| 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                                   |
-| 105 | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                           |
-| 106 | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                           |
-| 107 | ✅     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                             |
-| 108 | ✅     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                             |
-| 109 | ✅     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                                     |
-| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                           |
-| 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                                   |
-| 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                       |
-| 113 | 🔲     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                      |
-| 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md)        |
-| 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                          |
-| 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                    |
-| 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                     |
-| 122 | 🔲     | sonnet | [VS Code hover help and palette commands](plan/122_vscode-hover-and-palette.md)                             |
-| 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                       |
-| 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                         |
-| 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                 |
-| 127 | ✅     | sonnet | [Single H1 per file rule](plan/127_single-h1.md)                                                            |
-| 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                         |
-| 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)               |
-| 130 | 🔲     | opus   | [Distribute mdsmith binaries via npm, PyPI, asdf, and mise](plan/130_binary-distribution-and-versioning.md) |
-| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                  |
-| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                |
-| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                            |
-| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                     |
-| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                             |
-| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                  |
-| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)        |
-| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                         |
-| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                           |
-| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)             |
-| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)              |
-| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                      |
-| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                             |
-| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                     |
-| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)            |
-| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                         |
-| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                          |
-| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                               |
+| ID  | Status | Model  | Title                                                                                                                                 |
+|-----|--------|--------|---------------------------------------------------------------------------------------------------------------------------------------|
+| 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                               |
+| 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                            |
+| 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                                                        |
+| 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                                                |
+| 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                                                             |
+| 105 | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                                                     |
+| 106 | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                                                     |
+| 107 | ✅     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                                                       |
+| 108 | ✅     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                                                       |
+| 109 | ✅     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                                                               |
+| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                                                     |
+| 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                                                             |
+| 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                                                 |
+| 113 | 🔲     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                                                |
+| 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md)                                  |
+| 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                                    |
+| 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                              |
+| 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                                               |
+| 122 | 🔲     | sonnet | [VS Code hover help and palette commands](plan/122_vscode-hover-and-palette.md)                                                       |
+| 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                                                 |
+| 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                                                   |
+| 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                                           |
+| 127 | ✅     | sonnet | [Single H1 per file rule](plan/127_single-h1.md)                                                                                      |
+| 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                                                   |
+| 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)                                         |
+| 130 | 🔳     | opus   | [Distribute mdsmith binaries via npm, PyPI, asdf, mise, and the VS Code marketplaces](plan/130_binary-distribution-and-versioning.md) |
+| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                            |
+| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                          |
+| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                      |
+| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                               |
+| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                                       |
+| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                            |
+| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                                  |
+| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                                   |
+| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                                     |
+| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                                       |
+| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                                        |
+| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                                |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                                       |
+| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                               |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                                      |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                                   |
+| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                                    |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                                         |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,49 +14,50 @@ footer: |
 
 ?>
 
-| ID  | Status | Model  | Title                                                                                                |
-|-----|--------|--------|------------------------------------------------------------------------------------------------------|
-| 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)              |
-| 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                           |
-| 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                       |
-| 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)               |
-| 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                            |
-| 105 | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                    |
-| 106 | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                    |
-| 107 | ✅     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                      |
-| 108 | ✅     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                      |
-| 109 | ✅     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                              |
-| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                    |
-| 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                            |
-| 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                |
-| 113 | 🔲     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                               |
-| 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md) |
-| 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                   |
-| 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)             |
-| 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                              |
-| 122 | 🔲     | sonnet | [VS Code hover help and palette commands](plan/122_vscode-hover-and-palette.md)                      |
-| 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                |
-| 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                  |
-| 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                          |
-| 127 | ✅     | sonnet | [Single H1 per file rule](plan/127_single-h1.md)                                                     |
-| 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                  |
-| 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)        |
-| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)           |
-| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                         |
-| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                     |
-| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                              |
-| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                      |
-| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                           |
-| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md) |
-| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                  |
-| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                    |
-| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)      |
-| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)       |
-| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                               |
-| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                      |
-| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)              |
-| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)     |
-| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                  |
-| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                   |
-| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                        |
+| ID  | Status | Model  | Title                                                                                                       |
+|-----|--------|--------|-------------------------------------------------------------------------------------------------------------|
+| 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                     |
+| 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                  |
+| 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                              |
+| 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                      |
+| 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                                   |
+| 105 | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                           |
+| 106 | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                           |
+| 107 | ✅     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                             |
+| 108 | ✅     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                             |
+| 109 | ✅     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                                     |
+| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                           |
+| 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                                   |
+| 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                       |
+| 113 | 🔲     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                      |
+| 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md)        |
+| 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                          |
+| 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                    |
+| 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                     |
+| 122 | 🔲     | sonnet | [VS Code hover help and palette commands](plan/122_vscode-hover-and-palette.md)                             |
+| 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                       |
+| 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                         |
+| 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                 |
+| 127 | ✅     | sonnet | [Single H1 per file rule](plan/127_single-h1.md)                                                            |
+| 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                         |
+| 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)               |
+| 130 | 🔲     | opus   | [Distribute mdsmith binaries via npm, PyPI, asdf, and mise](plan/130_binary-distribution-and-versioning.md) |
+| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                  |
+| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                |
+| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                            |
+| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                     |
+| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                             |
+| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                  |
+| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)        |
+| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                         |
+| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                           |
+| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)             |
+| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)              |
+| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                      |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                             |
+| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                     |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)            |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                         |
+| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                          |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                               |
 <?/catalog?>

--- a/plan/130_binary-distribution-and-versioning.md
+++ b/plan/130_binary-distribution-and-versioning.md
@@ -28,12 +28,12 @@ regardless of the channel.
 
 ## Background
 
-[release.yml](../.github/workflows/release.yml) already
-builds `mdsmith-<goos>-<goarch>[.exe]` for the cross
-product of linux, darwin, and windows with amd64 and
-arm64. It also packages the VS Code extension as a
-`.vsix` and uploads everything plus a `checksums.txt` to
-a GitHub release. The Go binary embeds the tag via
+[release.yml](../.github/workflows/release.yml)
+already builds `mdsmith-<goos>-<goarch>[.exe]` for
+linux and darwin on amd64 and arm64, plus windows on
+amd64. It also packages the VS Code extension as a
+`.vsix` and uploads everything plus a `checksums.txt`
+to a GitHub release. The Go binary embeds the tag via
 `-ldflags="-X main.version=${VERSION}"` (see
 [main.go](../cmd/mdsmith/main.go)).
 
@@ -41,16 +41,14 @@ Three gaps remain. First,
 [editors/vscode/package.json](../editors/vscode/package.json)
 ships a hard-coded `"version": "0.1.2"`; the
 `vsce package --out` flag only controls the filename.
-
 Second, there is no npm, PyPI, asdf, or mise channel.
 
 Third, the `.vsix` is only attached to the GitHub
 release. It is not on the Visual Studio Marketplace,
 so VS Code's "Install" button cannot find it. It is
 not on Open VSX either, so VSCodium, Cursor, Theia,
-and Gitpod users have no source.
-
-This plan closes all three gaps in one pass.
+and Gitpod users have no source. This plan closes
+all three gaps in one pass.
 
 ## Distribution strategy per manager
 
@@ -80,9 +78,17 @@ install time, so mdsmith stays installable in offline
 or air-gapped CI and clear of supply-chain policies
 that ban network calls during install.
 
-Sources live under `npm/mdsmith/` (the root) and
-`npm/platforms/<goos>-<goarch>/` (one each, generated
-at release time from a template).
+The root lives at `npm/mdsmith/`. Each subpackage
+lives at `npm/platforms/<node-platform>-<node-arch>/`.
+The release script renames Go assets to match:
+
+| Release asset               | npm package             |
+|-----------------------------|-------------------------|
+| `mdsmith-linux-amd64`       | `@mdsmith/linux-x64`    |
+| `mdsmith-linux-arm64`       | `@mdsmith/linux-arm64`  |
+| `mdsmith-darwin-amd64`      | `@mdsmith/darwin-x64`   |
+| `mdsmith-darwin-arm64`      | `@mdsmith/darwin-arm64` |
+| `mdsmith-windows-amd64.exe` | `@mdsmith/win32-x64`    |
 
 ### PyPI
 
@@ -118,36 +124,30 @@ resolves without an explicit URL.
 
 ### mise
 
-The preferred path is to add an entry to the mise
-registry that points at the existing GitHub releases
-through the `ubi` backend. mise's `ubi` backend reads
-GitHub release assets directly given the asset naming
-we already use, so `mise use mdsmith@latest` works
-without us shipping any plugin code. File a PR to
-`mise-plugins/registry`. The fallback path is the asdf
-plugin above: mise consumes asdf plugins natively, so
-`mise use asdf:jeduden/asdf-mdsmith` keeps working
-even before the registry PR lands. The new
-`docs/guides/install.md` (added by task 9) documents
-the registry path as primary and the asdf path as the
-fallback.
+Preferred path: add an entry to `mise-plugins/registry`
+using the `ubi` backend. mise's `ubi` reads GitHub
+release assets directly given our naming, so
+`mise use mdsmith@latest` works without us shipping
+plugin code. Fallback: mise consumes asdf plugins
+natively, so `mise use asdf:jeduden/asdf-mdsmith`
+keeps working even before the registry PR lands.
+Document the registry path as primary in
+`docs/guides/install.md` (task 9).
 
 ### VS Code Marketplace and Open VSX
 
-Publish the same `.vsix` to two registries. The Visual
-Studio Marketplace (`marketplace.visualstudio.com`) is
-what stock VS Code queries. Open VSX (`open-vsx.org`)
-is what VSCodium, Cursor, Theia, and Gitpod query.
-Most extensions publish to both. The `.vsix` is
-identical; only the upload step differs.
-
-Both uploads run from the existing `vscode` job in
+Publish the same `.vsix` to two registries. Stock VS
+Code queries the Visual Studio Marketplace
+(`marketplace.visualstudio.com`); VSCodium, Cursor,
+Theia, and Gitpod query Open VSX (`open-vsx.org`).
+The `.vsix` is identical, only the upload tool
+differs. Both uploads run from the existing `vscode`
+job in
 [release.yml](../.github/workflows/release.yml) after
 `vsce package`. Use `@vscode/vsce` for Marketplace
-and `ovsx` for Open VSX, both invoked with
-`--packagePath` so they upload the exact `.vsix` that
-was packaged and that is also attached to the GitHub
-release. That keeps all three artifacts
+and `ovsx` for Open VSX, both with `--packagePath`
+pointing at the exact `.vsix` the GitHub release
+also attaches, so all three artifacts stay
 byte-identical.
 
 Auth uses two GitHub Actions secrets:

--- a/plan/130_binary-distribution-and-versioning.md
+++ b/plan/130_binary-distribution-and-versioning.md
@@ -1,0 +1,287 @@
+---
+id: 130
+title: Distribute mdsmith binaries via npm, PyPI, asdf, and mise
+status: "🔲"
+summary: >-
+  Publish the prebuilt mdsmith binaries already produced
+  by the release workflow through npm, PyPI (consumed by
+  pip and uv), asdf, and mise on every git tag. Derive
+  every published manifest's version from the tag instead
+  of a hard-coded literal.
+model: opus
+---
+# Distribute mdsmith binaries via npm, PyPI, asdf, and mise
+
+## Goal
+
+Each `v*` tag should ship the existing release binaries
+through four extra channels: npm, PyPI, asdf, and mise.
+Every published manifest should carry the tag version,
+not a hand-edited string. Users pick the package manager
+their stack already uses; mdsmith reports the same
+version regardless of the channel.
+
+## Background
+
+[release.yml](../.github/workflows/release.yml) already
+builds `mdsmith-<goos>-<goarch>[.exe]` for the cross
+product of linux, darwin, and windows with amd64 and
+arm64. It also packages the VS Code extension as a
+`.vsix` and uploads everything plus a `checksums.txt` to
+a GitHub release. The Go binary embeds the tag via
+`-ldflags="-X main.version=${VERSION}"` (see
+[main.go](../cmd/mdsmith/main.go)).
+
+Two gaps remain.
+
+First, the `.vsix` job strips the leading `v` from the
+tag for the filename, but
+[editors/vscode/package.json](../editors/vscode/package.json)
+still ships a hard-coded `"version": "0.1.2"`. The
+`vsce package --out` flag controls only the filename.
+The manifest inside the package keeps the literal.
+
+Second, there is no npm, PyPI, asdf, or mise channel.
+This plan adds all four and fixes the version drift in
+the same pass so the same machinery covers every
+channel.
+
+## Distribution strategy per manager
+
+### npm
+
+Use the `optionalDependencies` per-platform pattern.
+This is what esbuild, biome, swc, and turbo settled on.
+
+The user installs one root package: `mdsmith`. It
+lists `optionalDependencies` for one subpackage per
+platform. The names are `@mdsmith/linux-x64`,
+`@mdsmith/linux-arm64`, `@mdsmith/darwin-x64`,
+`@mdsmith/darwin-arm64`, and `@mdsmith/win32-x64`.
+Each subpackage sets `os` and `cpu`. npm installs
+only the matching one and skips the rest.
+
+Each subpackage carries the prebuilt binary at
+`bin/mdsmith` (or `mdsmith.exe`) and a tiny
+`package.json` that declares `bin`. The root package's
+`bin/mdsmith.js` shim resolves the platform package via
+`require.resolve` and `execFileSync`s its binary. No
+`postinstall` hook downloads from GitHub at install
+time. That keeps mdsmith installable in offline or
+air-gapped CI and keeps it clear of supply-chain
+policies that ban network calls during install.
+
+Sources live under `npm/mdsmith/` (the root) and
+`npm/platforms/<goos>-<goarch>/` (one each). The
+platform subpackages are generated at release time
+from a template.
+
+### PyPI
+
+Use the per-platform wheel with bundled binary
+pattern. ruff and uv ship this way. `cibuildwheel` is
+overkill since mdsmith does not compile any C — we
+only need to attach a prebuilt binary to a wheel with
+the right platform tag.
+
+Build one wheel per platform tag: linux x86_64,
+linux aarch64, macOS x86_64, macOS arm64, win amd64.
+Each wheel ships `mdsmith/_bin/mdsmith[.exe]` and a
+small `mdsmith/__main__.py` that `os.execv`s the
+bundled binary. The wheel exposes a console script
+entry point also named `mdsmith`.
+
+Add an sdist `mdsmith-<ver>.tar.gz` with a
+`pyproject.toml` build that fails fast with a clear
+message when no wheel exists for the user's platform.
+That keeps `pip install mdsmith` from silently doing
+nothing on an unsupported arch.
+
+This setup works under `pip install mdsmith`,
+`uv pip install mdsmith`, `pipx install mdsmith`,
+`uvx mdsmith`, and `python -m mdsmith`. Sources live
+under `python/`.
+
+### asdf
+
+Publish a separate repo `jeduden/asdf-mdsmith` with
+the standard asdf plugin layout:
+
+- `bin/list-all` calls `git ls-remote --tags` on the
+  mdsmith repo. No GitHub token is required and it
+  works behind firewalls that allow HTTPS git.
+- `bin/download` `curl -fL`s the matching
+  `mdsmith-<goos>-<goarch>` from the release.
+- `bin/install` verifies against `checksums.txt` and
+  places the binary as `bin/mdsmith` in the install
+  path.
+- `bin/list-bin-paths` prints `bin`.
+
+After one release cycle of self-hosted use, file a PR
+to `asdf-vm/asdf-plugins` so `asdf plugin add mdsmith`
+resolves without an explicit URL.
+
+### mise
+
+Two paths, picked in order.
+
+The preferred path is to add an entry to the mise
+registry that points at the existing GitHub releases
+through the `ubi` backend. mise's `ubi` backend reads
+GitHub release assets directly given the asset
+naming we already use, so `mise use mdsmith@latest`
+works without us shipping any plugin code. File a PR
+to `mise-plugins/registry`.
+
+The fallback path is the asdf plugin above. mise
+consumes asdf plugins natively, so
+`mise use asdf:jeduden/asdf-mdsmith` keeps working
+even before the registry PR lands.
+
+The new `docs/guides/install.md` (added by task 9
+below) documents the registry path as primary. The
+asdf path is the documented fallback.
+
+### Out of scope
+
+Homebrew tap, Scoop bucket, AUR, Chocolatey, Nix
+flake, GoReleaser migration, and a Docker image are
+all sensible follow-ups. None block the four channels
+above. Each can be added in a later plan once the
+versioning machinery is in place.
+
+## Versioning from the git tag
+
+Today the only manifest with a hard-coded version is
+[editors/vscode/package.json](../editors/vscode/package.json).
+The npm root, npm platform subpackages, and the Python
+wheel all need the same treatment.
+
+The approach: never commit a real version. Pin every
+manifest at `"version": "0.0.0-dev"`. Rewrite each
+manifest in CI from `${GITHUB_REF_NAME#v}` before
+publishing.
+
+Concretely:
+
+- Add a `scripts/set-version.sh <ver>` helper. It takes
+  the cleaned tag (no leading `v`) and rewrites
+  `editors/vscode/package.json`, `npm/mdsmith/package.json`,
+  each `npm/platforms/*/package.json`, and
+  `python/pyproject.toml`. It also bumps the
+  `optionalDependencies` pin of each platform package
+  in the root so they match.
+- Wire the helper into
+  [release.yml](../.github/workflows/release.yml) as a
+  step that runs before each `package` or `publish`
+  step.
+- Add a CI guard in
+  [ci.yml](../.github/workflows/ci.yml) that fails on
+  non-tag builds when any tracked manifest has a
+  version other than `0.0.0-dev`. That blocks
+  accidental hand edits from reaching `main`.
+- Keep surfacing the tag to the Go binary the way
+  [release.yml](../.github/workflows/release.yml)
+  already does (`-X main.version=${VERSION}`). The
+  npm shim and the wheel both invoke the embedded
+  binary, so `mdsmith version` reports the tag on
+  every channel.
+
+## Tasks
+
+1. Add `scripts/set-version.sh`. Add a unit test (a
+   Bash test or a small Go test fixture) that asserts
+   each tracked manifest is rewritten correctly and
+   the script is idempotent.
+2. Add a `version-guard` step to
+   [ci.yml](../.github/workflows/ci.yml) that fails
+   on non-tag builds when any tracked manifest has a
+   non-`0.0.0-dev` version.
+3. Set
+   [editors/vscode/package.json](../editors/vscode/package.json)
+   `version` to `0.0.0-dev`. Run `set-version.sh` in
+   the `vscode` job of
+   [release.yml](../.github/workflows/release.yml)
+   before `vsce package`. Verify by inspecting the
+   generated `.vsix` `package.json` in the job log.
+4. Scaffold `npm/mdsmith/` with `package.json` and
+   `bin/mdsmith.js`. Add a Bun unit test (consistent
+   with the VS Code extension) that mocks
+   `os.platform()` and `os.arch()` and verifies the
+   shim resolves to the expected platform package
+   path. Mirror the lint and format settings used by
+   the VS Code extension.
+5. Add `scripts/build-npm-platforms.sh`. Given the
+   downloaded GitHub release artifacts, it emits one
+   directory per platform with the binary in `bin/`
+   and a generated `package.json`. Add a new `npm`
+   job in [release.yml](../.github/workflows/release.yml)
+   that depends on `build`, downloads the artifacts,
+   runs the generator, and `npm publish --access public`s
+   each subpackage. The root publishes last so users
+   never see a missing optional dependency.
+6. Add `python/pyproject.toml`,
+   `python/mdsmith/__init__.py`, and
+   `python/mdsmith/__main__.py`. Add
+   `scripts/build-wheels.sh`. Wire a `pypi` job in
+   [release.yml](../.github/workflows/release.yml)
+   that downloads the binary artifacts, stages them
+   under `python/mdsmith/_bin/`, builds one wheel per
+   platform tag with `python -m build`, and uploads
+   via `pypa/gh-action-pypi-publish` using PyPI
+   trusted publishing (OIDC). No long-lived token.
+7. Create the `jeduden/asdf-mdsmith` repo with
+   `bin/list-all`, `bin/download`, `bin/install`, and
+   `bin/list-bin-paths`. Add a CI workflow that runs
+   `asdf install mdsmith latest` against the most
+   recent release and asserts
+   `mdsmith version` matches. Open a PR to
+   `asdf-vm/asdf-plugins` after one successful
+   release cycle.
+8. Submit a PR to `mise-plugins/registry` adding
+   mdsmith via the `ubi` backend pointing at
+   `jeduden/mdsmith` releases.
+9. Add `docs/guides/install.md` covering
+   `npm i -g mdsmith`, `npx mdsmith`,
+   `pip install mdsmith`, `uvx mdsmith`,
+   `mise use mdsmith@latest`, `asdf install mdsmith`,
+   and the existing direct-download flow. Link it
+   from the README and the catalog table in
+   [CLAUDE.md](../CLAUDE.md).
+10. Add a post-release smoke test job that runs in
+    one clean container per channel
+    (`node:lts-alpine`, `python:3.12-slim`,
+    a mise base image) and asserts
+    `mdsmith version` prints the expected tag.
+
+## Acceptance Criteria
+
+- [ ] Pushing a `vX.Y.Z` tag publishes
+      `mdsmith@X.Y.Z` and the five platform
+      subpackages on npm.
+- [ ] The same tag publishes `mdsmith==X.Y.Z` wheels
+      for the five supported platform tags on PyPI.
+- [ ] The same tag still produces the existing
+      GitHub release assets and `.vsix`.
+- [ ] `npm i -g mdsmith && mdsmith version` prints
+      `mdsmith vX.Y.Z` on linux-x64, linux-arm64,
+      darwin-x64, darwin-arm64, and win32-x64.
+- [ ] `pip install mdsmith==X.Y.Z && mdsmith version`
+      and `uvx mdsmith@X.Y.Z version` print
+      `mdsmith vX.Y.Z` on the same five platforms.
+- [ ] `mise use mdsmith@X.Y.Z && mdsmith version`
+      prints `mdsmith vX.Y.Z`.
+- [ ] `asdf plugin add mdsmith` followed by
+      `asdf install mdsmith X.Y.Z` prints
+      `mdsmith vX.Y.Z`.
+- [ ] The `.vsix` from the `vscode` job has its
+      internal `package.json` `version` equal to
+      `X.Y.Z`.
+- [ ] CI on `main` fails when any tracked manifest
+      has a version other than `0.0.0-dev`.
+- [ ] The new `docs/guides/install.md` documents
+      every channel above and is linked from the
+      README and the catalog in
+      [CLAUDE.md](../CLAUDE.md).
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues.

--- a/plan/130_binary-distribution-and-versioning.md
+++ b/plan/130_binary-distribution-and-versioning.md
@@ -18,13 +18,12 @@ model: opus
 
 ## Goal
 
-Each `v*` tag should ship the existing release binaries
-through five extra channels: npm, PyPI, asdf, mise, and
-the two VS Code extension registries. Every published
-manifest should carry the tag version, not a hand-edited
-string. Users pick the package manager their stack
-already uses, and mdsmith reports the same version
-regardless of the channel.
+Each `v*` tag should ship the existing binaries
+through five extra channels: npm, PyPI, asdf, mise,
+and the two VS Code extension registries. Every
+published manifest carries the tag version (not a
+hand-edited string), so `mdsmith version` reports
+the same value on every channel.
 
 ## Background
 
@@ -110,16 +109,18 @@ Publish a separate repo `jeduden/asdf-mdsmith` with
 the standard plugin layout:
 
 - `bin/list-all` calls `git ls-remote --tags` on the
-  mdsmith repo. No GitHub token is required; it works
-  behind firewalls that allow HTTPS git.
+  mdsmith repo, then strips `refs/tags/`, drops the
+  `^{}` deref entries, and removes the leading `v`
+  so the output is plain `X.Y.Z` as asdf expects. No
+  GitHub token required; works through HTTPS git.
 - `bin/download` `curl -fL`s the matching release
   asset.
 - `bin/install` verifies it against `checksums.txt`
   and places the binary as `bin/mdsmith`.
 - `bin/list-bin-paths` prints `bin`.
 
-After one release cycle of self-hosted use, file a PR
-to `asdf-vm/asdf-plugins` so `asdf plugin add mdsmith`
+After one release cycle, file a PR to
+`asdf-vm/asdf-plugins` so `asdf plugin add mdsmith`
 resolves without an explicit URL.
 
 ### mise

--- a/plan/130_binary-distribution-and-versioning.md
+++ b/plan/130_binary-distribution-and-versioning.md
@@ -1,25 +1,30 @@
 ---
 id: 130
-title: Distribute mdsmith binaries via npm, PyPI, asdf, and mise
-status: "🔲"
+title: >-
+  Distribute mdsmith binaries via npm, PyPI, asdf,
+  mise, and the VS Code marketplaces
+status: "🔳"
 summary: >-
   Publish the prebuilt mdsmith binaries already produced
   by the release workflow through npm, PyPI (consumed by
-  pip and uv), asdf, and mise on every git tag. Derive
-  every published manifest's version from the tag instead
-  of a hard-coded literal.
+  pip and uv), asdf, and mise on every git tag, and
+  publish the VS Code extension to the Visual Studio
+  Marketplace and Open VSX. Derive every published
+  manifest's version from the tag instead of a
+  hard-coded literal.
 model: opus
 ---
-# Distribute mdsmith binaries via npm, PyPI, asdf, and mise
+# Distribute mdsmith via npm, PyPI, asdf, mise, and VS Code marketplaces
 
 ## Goal
 
 Each `v*` tag should ship the existing release binaries
-through four extra channels: npm, PyPI, asdf, and mise.
-Every published manifest should carry the tag version,
-not a hand-edited string. Users pick the package manager
-their stack already uses; mdsmith reports the same
-version regardless of the channel.
+through five extra channels: npm, PyPI, asdf, mise, and
+the two VS Code extension registries. Every published
+manifest should carry the tag version, not a hand-edited
+string. Users pick the package manager their stack
+already uses, and mdsmith reports the same version
+regardless of the channel.
 
 ## Background
 
@@ -32,89 +37,79 @@ a GitHub release. The Go binary embeds the tag via
 `-ldflags="-X main.version=${VERSION}"` (see
 [main.go](../cmd/mdsmith/main.go)).
 
-Two gaps remain.
-
-First, the `.vsix` job strips the leading `v` from the
-tag for the filename, but
+Three gaps remain. First,
 [editors/vscode/package.json](../editors/vscode/package.json)
-still ships a hard-coded `"version": "0.1.2"`. The
-`vsce package --out` flag controls only the filename.
-The manifest inside the package keeps the literal.
+ships a hard-coded `"version": "0.1.2"`; the
+`vsce package --out` flag only controls the filename.
 
 Second, there is no npm, PyPI, asdf, or mise channel.
-This plan adds all four and fixes the version drift in
-the same pass so the same machinery covers every
-channel.
+
+Third, the `.vsix` is only attached to the GitHub
+release. It is not on the Visual Studio Marketplace,
+so VS Code's "Install" button cannot find it. It is
+not on Open VSX either, so VSCodium, Cursor, Theia,
+and Gitpod users have no source.
+
+This plan closes all three gaps in one pass.
 
 ## Distribution strategy per manager
 
 ### npm
 
-Use the `optionalDependencies` per-platform pattern.
-This is what esbuild, biome, swc, and turbo settled on.
+Use the `optionalDependencies` per-platform pattern
+(esbuild, biome, swc, and turbo all ship this way).
 
-The user installs one root package: `mdsmith`. It
+The user installs one root package, `mdsmith`. It
 lists `optionalDependencies` for one subpackage per
-platform. The names are `@mdsmith/linux-x64`,
-`@mdsmith/linux-arm64`, `@mdsmith/darwin-x64`,
-`@mdsmith/darwin-arm64`, and `@mdsmith/win32-x64`.
+platform:
+
+- `@mdsmith/linux-x64`
+- `@mdsmith/linux-arm64`
+- `@mdsmith/darwin-x64`
+- `@mdsmith/darwin-arm64`
+- `@mdsmith/win32-x64`
+
 Each subpackage sets `os` and `cpu`. npm installs
-only the matching one and skips the rest.
+only the one that matches.
 
 Each subpackage carries the prebuilt binary at
-`bin/mdsmith` (or `mdsmith.exe`) and a tiny
-`package.json` that declares `bin`. The root package's
-`bin/mdsmith.js` shim resolves the platform package via
-`require.resolve` and `execFileSync`s its binary. No
-`postinstall` hook downloads from GitHub at install
-time. That keeps mdsmith installable in offline or
-air-gapped CI and keeps it clear of supply-chain
-policies that ban network calls during install.
+`bin/mdsmith[.exe]`. The root's `bin/mdsmith.js` shim
+resolves the platform package via `require.resolve`
+and execs its binary. No `postinstall` hook runs at
+install time, so mdsmith stays installable in offline
+or air-gapped CI and clear of supply-chain policies
+that ban network calls during install.
 
 Sources live under `npm/mdsmith/` (the root) and
-`npm/platforms/<goos>-<goarch>/` (one each). The
-platform subpackages are generated at release time
-from a template.
+`npm/platforms/<goos>-<goarch>/` (one each, generated
+at release time from a template).
 
 ### PyPI
 
 Use the per-platform wheel with bundled binary
-pattern. ruff and uv ship this way. `cibuildwheel` is
-overkill since mdsmith does not compile any C — we
-only need to attach a prebuilt binary to a wheel with
-the right platform tag.
-
-Build one wheel per platform tag: linux x86_64,
-linux aarch64, macOS x86_64, macOS arm64, win amd64.
-Each wheel ships `mdsmith/_bin/mdsmith[.exe]` and a
-small `mdsmith/__main__.py` that `os.execv`s the
-bundled binary. The wheel exposes a console script
-entry point also named `mdsmith`.
-
-Add an sdist `mdsmith-<ver>.tar.gz` with a
-`pyproject.toml` build that fails fast with a clear
-message when no wheel exists for the user's platform.
-That keeps `pip install mdsmith` from silently doing
-nothing on an unsupported arch.
-
-This setup works under `pip install mdsmith`,
-`uv pip install mdsmith`, `pipx install mdsmith`,
-`uvx mdsmith`, and `python -m mdsmith`. Sources live
-under `python/`.
+pattern (ruff and uv ship this way). One wheel per
+platform tag (linux x86_64, linux aarch64, macOS
+x86_64, macOS arm64, win amd64) ships
+`mdsmith/_bin/mdsmith[.exe]` and a console-script
+entry point `mdsmith` that `os.execv`s the bundled
+binary. An sdist's build fails fast with a clear
+message on unsupported platforms so `pip install`
+does not silently do nothing. Works under `pip`,
+`uv pip`, `pipx`, `uvx`, and `python -m mdsmith`.
+Sources live under `python/`.
 
 ### asdf
 
 Publish a separate repo `jeduden/asdf-mdsmith` with
-the standard asdf plugin layout:
+the standard plugin layout:
 
 - `bin/list-all` calls `git ls-remote --tags` on the
-  mdsmith repo. No GitHub token is required and it
-  works behind firewalls that allow HTTPS git.
-- `bin/download` `curl -fL`s the matching
-  `mdsmith-<goos>-<goarch>` from the release.
-- `bin/install` verifies against `checksums.txt` and
-  places the binary as `bin/mdsmith` in the install
-  path.
+  mdsmith repo. No GitHub token is required; it works
+  behind firewalls that allow HTTPS git.
+- `bin/download` `curl -fL`s the matching release
+  asset.
+- `bin/install` verifies it against `checksums.txt`
+  and places the binary as `bin/mdsmith`.
 - `bin/list-bin-paths` prints `bin`.
 
 After one release cycle of self-hosted use, file a PR
@@ -123,110 +118,135 @@ resolves without an explicit URL.
 
 ### mise
 
-Two paths, picked in order.
-
 The preferred path is to add an entry to the mise
 registry that points at the existing GitHub releases
 through the `ubi` backend. mise's `ubi` backend reads
-GitHub release assets directly given the asset
-naming we already use, so `mise use mdsmith@latest`
-works without us shipping any plugin code. File a PR
-to `mise-plugins/registry`.
-
-The fallback path is the asdf plugin above. mise
-consumes asdf plugins natively, so
+GitHub release assets directly given the asset naming
+we already use, so `mise use mdsmith@latest` works
+without us shipping any plugin code. File a PR to
+`mise-plugins/registry`. The fallback path is the asdf
+plugin above: mise consumes asdf plugins natively, so
 `mise use asdf:jeduden/asdf-mdsmith` keeps working
-even before the registry PR lands.
+even before the registry PR lands. The new
+`docs/guides/install.md` (added by task 9) documents
+the registry path as primary and the asdf path as the
+fallback.
 
-The new `docs/guides/install.md` (added by task 9
-below) documents the registry path as primary. The
-asdf path is the documented fallback.
+### VS Code Marketplace and Open VSX
+
+Publish the same `.vsix` to two registries. The Visual
+Studio Marketplace (`marketplace.visualstudio.com`) is
+what stock VS Code queries. Open VSX (`open-vsx.org`)
+is what VSCodium, Cursor, Theia, and Gitpod query.
+Most extensions publish to both. The `.vsix` is
+identical; only the upload step differs.
+
+Both uploads run from the existing `vscode` job in
+[release.yml](../.github/workflows/release.yml) after
+`vsce package`. Use `@vscode/vsce` for Marketplace
+and `ovsx` for Open VSX, both invoked with
+`--packagePath` so they upload the exact `.vsix` that
+was packaged and that is also attached to the GitHub
+release. That keeps all three artifacts
+byte-identical.
+
+Auth uses two GitHub Actions secrets:
+
+- `VSCE_PAT` — an Azure DevOps PAT scoped to
+  "Marketplace > Manage" for the `jeduden` publisher.
+  No OIDC option exists for the Marketplace today.
+- `OVSX_PAT` — an Open VSX publisher token, created
+  after claiming the namespace on `open-vsx.org`.
+
+Azure caps PATs at one year; rotate Open VSX annually
+too and record the rotation date in
+[CLAUDE.md](../CLAUDE.md). If publishing to either
+registry fails, the GitHub release `.vsix` remains
+the documented fallback.
 
 ### Out of scope
 
-Homebrew tap, Scoop bucket, AUR, Chocolatey, Nix
-flake, GoReleaser migration, and a Docker image are
-all sensible follow-ups. None block the four channels
-above. Each can be added in a later plan once the
-versioning machinery is in place.
+Homebrew, Scoop, AUR, Chocolatey, Nix, GoReleaser,
+and Docker are follow-ups; none block this plan.
 
 ## Versioning from the git tag
 
 Today the only manifest with a hard-coded version is
 [editors/vscode/package.json](../editors/vscode/package.json).
-The npm root, npm platform subpackages, and the Python
-wheel all need the same treatment.
+The npm root, npm platform subpackages, and the
+Python wheel all need the same treatment.
 
-The approach: never commit a real version. Pin every
-manifest at `"version": "0.0.0-dev"`. Rewrite each
-manifest in CI from `${GITHUB_REF_NAME#v}` before
-publishing.
+Approach: never commit a real version. Pin every
+manifest at `"version": "0.0.0-dev"`. A new
+`scripts/set-version.sh <ver>` helper takes the
+cleaned tag (no leading `v`) and rewrites every
+tracked manifest:
 
-Concretely:
+- [editors/vscode/package.json](../editors/vscode/package.json)
+- `npm/mdsmith/package.json`, including the
+  `optionalDependencies` pins of each platform
+  package
+- each `npm/platforms/*/package.json`
+- `python/pyproject.toml`
 
-- Add a `scripts/set-version.sh <ver>` helper. It takes
-  the cleaned tag (no leading `v`) and rewrites
-  `editors/vscode/package.json`, `npm/mdsmith/package.json`,
-  each `npm/platforms/*/package.json`, and
-  `python/pyproject.toml`. It also bumps the
-  `optionalDependencies` pin of each platform package
-  in the root so they match.
-- Wire the helper into
-  [release.yml](../.github/workflows/release.yml) as a
-  step that runs before each `package` or `publish`
-  step.
-- Add a CI guard in
-  [ci.yml](../.github/workflows/ci.yml) that fails on
-  non-tag builds when any tracked manifest has a
-  version other than `0.0.0-dev`. That blocks
-  accidental hand edits from reaching `main`.
-- Keep surfacing the tag to the Go binary the way
-  [release.yml](../.github/workflows/release.yml)
-  already does (`-X main.version=${VERSION}`). The
-  npm shim and the wheel both invoke the embedded
-  binary, so `mdsmith version` reports the tag on
-  every channel.
+[release.yml](../.github/workflows/release.yml) runs
+it before each `package` or `publish` step. A
+`version-guard` job in
+[ci.yml](../.github/workflows/ci.yml) fails non-tag
+builds when any manifest deviates from `0.0.0-dev`.
+That blocks hand edits from reaching `main`.
+
+The Go binary keeps embedding the tag via
+`-X main.version=${VERSION}`. The npm shim and the
+wheel exec that binary, so `mdsmith version` matches
+the tag on every channel.
 
 ## Tasks
 
-1. Add `scripts/set-version.sh`. Add a unit test (a
-   Bash test or a small Go test fixture) that asserts
-   each tracked manifest is rewritten correctly and
-   the script is idempotent.
+1. Add `scripts/set-version.sh` plus a unit test that
+   asserts each tracked manifest is rewritten
+   correctly and the script is idempotent.
 2. Add a `version-guard` step to
    [ci.yml](../.github/workflows/ci.yml) that fails
    on non-tag builds when any tracked manifest has a
    non-`0.0.0-dev` version.
 3. Set
    [editors/vscode/package.json](../editors/vscode/package.json)
-   `version` to `0.0.0-dev`. Run `set-version.sh` in
-   the `vscode` job of
-   [release.yml](../.github/workflows/release.yml)
-   before `vsce package`. Verify by inspecting the
-   generated `.vsix` `package.json` in the job log.
+   `version` to `0.0.0-dev`. In the `vscode` job of
+   [release.yml](../.github/workflows/release.yml),
+   run `set-version.sh` before `vsce package`, then
+   add two publish steps that reuse the exact `.vsix`
+   the job produced: `bunx --bun @vscode/vsce publish
+   --packagePath <vsix> --pat $VSCE_PAT` for the
+   Marketplace and `bunx --bun ovsx publish <vsix>
+   --pat $OVSX_PAT` for Open VSX. Before the first
+   tag, claim the `jeduden` namespace on Open VSX,
+   mint a Marketplace PAT scoped to "Marketplace >
+   Manage", and store both as `VSCE_PAT` and
+   `OVSX_PAT` repository secrets.
 4. Scaffold `npm/mdsmith/` with `package.json` and
-   `bin/mdsmith.js`. Add a Bun unit test (consistent
-   with the VS Code extension) that mocks
+   `bin/mdsmith.js`. Add a Bun unit test that mocks
    `os.platform()` and `os.arch()` and verifies the
    shim resolves to the expected platform package
-   path. Mirror the lint and format settings used by
-   the VS Code extension.
-5. Add `scripts/build-npm-platforms.sh`. Given the
-   downloaded GitHub release artifacts, it emits one
-   directory per platform with the binary in `bin/`
-   and a generated `package.json`. Add a new `npm`
-   job in [release.yml](../.github/workflows/release.yml)
-   that depends on `build`, downloads the artifacts,
-   runs the generator, and `npm publish --access public`s
-   each subpackage. The root publishes last so users
+   path. Mirror the lint/format setup used by the VS
+   Code extension.
+5. Add `scripts/build-npm-platforms.sh` that, given
+   the downloaded GitHub release artifacts, emits
+   one directory per platform with the binary in
+   `bin/` and a generated `package.json`. Add a new
+   `npm` job in
+   [release.yml](../.github/workflows/release.yml)
+   that depends on `build`, downloads artifacts, runs
+   the generator, and `npm publish --access public`s
+   each subpackage. Root publishes last so users
    never see a missing optional dependency.
 6. Add `python/pyproject.toml`,
    `python/mdsmith/__init__.py`, and
    `python/mdsmith/__main__.py`. Add
    `scripts/build-wheels.sh`. Wire a `pypi` job in
    [release.yml](../.github/workflows/release.yml)
-   that downloads the binary artifacts, stages them
-   under `python/mdsmith/_bin/`, builds one wheel per
+   that stages the binary artifacts under
+   `python/mdsmith/_bin/`, builds one wheel per
    platform tag with `python -m build`, and uploads
    via `pypa/gh-action-pypi-publish` using PyPI
    trusted publishing (OIDC). No long-lived token.
@@ -234,10 +254,9 @@ Concretely:
    `bin/list-all`, `bin/download`, `bin/install`, and
    `bin/list-bin-paths`. Add a CI workflow that runs
    `asdf install mdsmith latest` against the most
-   recent release and asserts
-   `mdsmith version` matches. Open a PR to
-   `asdf-vm/asdf-plugins` after one successful
-   release cycle.
+   recent release and asserts `mdsmith version`
+   matches. Open a PR to `asdf-vm/asdf-plugins` after
+   one successful release cycle.
 8. Submit a PR to `mise-plugins/registry` adding
    mdsmith via the `ubi` backend pointing at
    `jeduden/mdsmith` releases.
@@ -245,24 +264,24 @@ Concretely:
    `npm i -g mdsmith`, `npx mdsmith`,
    `pip install mdsmith`, `uvx mdsmith`,
    `mise use mdsmith@latest`, `asdf install mdsmith`,
-   and the existing direct-download flow. Link it
-   from the README and the catalog table in
-   [CLAUDE.md](../CLAUDE.md).
-10. Add a post-release smoke test job that runs in
+   the Marketplace and Open VSX install paths for
+   the VS Code extension, and the existing
+   direct-download flow. Link it from the README and
+   the catalog in [CLAUDE.md](../CLAUDE.md).
+10. Add a post-release smoke-test job that runs in
     one clean container per channel
-    (`node:lts-alpine`, `python:3.12-slim`,
-    a mise base image) and asserts
-    `mdsmith version` prints the expected tag.
+    (`node:lts-alpine`, `python:3.12-slim`, a mise
+    base image) and asserts `mdsmith version` prints
+    the expected tag.
 
 ## Acceptance Criteria
 
-- [ ] Pushing a `vX.Y.Z` tag publishes
-      `mdsmith@X.Y.Z` and the five platform
-      subpackages on npm.
+- [ ] Pushing a `vX.Y.Z` tag publishes `mdsmith@X.Y.Z`
+      and the five platform subpackages on npm.
 - [ ] The same tag publishes `mdsmith==X.Y.Z` wheels
       for the five supported platform tags on PyPI.
-- [ ] The same tag still produces the existing
-      GitHub release assets and `.vsix`.
+- [ ] The same tag still produces the existing GitHub
+      release assets and `.vsix`.
 - [ ] `npm i -g mdsmith && mdsmith version` prints
       `mdsmith vX.Y.Z` on linux-x64, linux-arm64,
       darwin-x64, darwin-arm64, and win32-x64.
@@ -271,12 +290,21 @@ Concretely:
       `mdsmith vX.Y.Z` on the same five platforms.
 - [ ] `mise use mdsmith@X.Y.Z && mdsmith version`
       prints `mdsmith vX.Y.Z`.
-- [ ] `asdf plugin add mdsmith` followed by
+- [ ] `asdf plugin add mdsmith` then
       `asdf install mdsmith X.Y.Z` prints
       `mdsmith vX.Y.Z`.
 - [ ] The `.vsix` from the `vscode` job has its
       internal `package.json` `version` equal to
       `X.Y.Z`.
+- [ ] After the tag job finishes, `jeduden.mdsmith`
+      `X.Y.Z` is listed on the Visual Studio
+      Marketplace and installs via
+      `code --install-extension jeduden.mdsmith`.
+- [ ] The same version is listed on Open VSX and
+      installs in VSCodium via
+      `codium --install-extension jeduden.mdsmith`.
+- [ ] The Marketplace, Open VSX, and GitHub release
+      `.vsix` have identical SHA-256 sums.
 - [ ] CI on `main` fails when any tracked manifest
       has a version other than `0.0.0-dev`.
 - [ ] The new `docs/guides/install.md` documents

--- a/plan/130_binary-distribution-and-versioning.md
+++ b/plan/130_binary-distribution-and-versioning.md
@@ -218,13 +218,13 @@ the tag on every channel.
    run `set-version.sh` before `vsce package`, then
    add two publish steps that reuse the exact `.vsix`
    the job produced: `bunx --bun @vscode/vsce publish
-   --packagePath <vsix> --pat $VSCE_PAT` for the
-   Marketplace and `bunx --bun ovsx publish <vsix>
-   --pat $OVSX_PAT` for Open VSX. Before the first
-   tag, claim the `jeduden` namespace on Open VSX,
-   mint a Marketplace PAT scoped to "Marketplace >
-   Manage", and store both as `VSCE_PAT` and
-   `OVSX_PAT` repository secrets.
+   --packagePath <vsix> --pat $VSCE_PAT` (Marketplace)
+   and `bunx --bun ovsx publish --packagePath <vsix>
+   --pat $OVSX_PAT` (Open VSX). Before the first tag,
+   claim the `jeduden` namespace on Open VSX, mint a
+   Marketplace PAT scoped to "Marketplace > Manage",
+   and store both as `VSCE_PAT` and `OVSX_PAT`
+   repository secrets.
 4. Scaffold `npm/mdsmith/` with `package.json` and
    `bin/mdsmith.js`. Add a Bun unit test that mocks
    `os.platform()` and `os.arch()` and verifies the


### PR DESCRIPTION
## Summary

This PR adds a comprehensive plan for distributing mdsmith binaries through multiple package managers and extension registries. Plan 130 outlines the strategy to publish prebuilt binaries to npm, PyPI, asdf, mise, and the VS Code marketplaces, while ensuring all published manifests derive their versions from git tags rather than hard-coded literals.

## Key Changes

- **New plan document** (`plan/130_binary-distribution-and-versioning.md`): Specification covering:
  - Distribution strategy for each package manager (npm with optional dependencies pattern, PyPI wheels, asdf plugin, mise registry integration)
  - VS Code extension publishing to both Visual Studio Marketplace and Open VSX
  - Versioning approach using `scripts/set-version.sh` to dynamically set versions from git tags
  - 10 concrete implementation tasks with acceptance criteria

- **Updated PLAN.md**: Added Plan 130 to the roadmap table with status "🔳" (in progress) and opus model designation

## Implementation Strategy

The plan establishes:
- **npm**: Root package with platform-specific optional dependencies (`@mdsmith/linux-x64`, etc.) using a JavaScript shim
- **PyPI**: Per-platform wheels with bundled binaries, supporting pip, uv, pipx, and uvx
- **asdf/mise**: Plugin-based distribution with GitHub release asset integration
- **VS Code**: Single `.vsix` published to both Marketplace and Open VSX with identical SHA-256 checksums
- **Versioning**: All manifests pinned to `0.0.0-dev` in source; `set-version.sh` rewrites them at release time; CI guards against manual version edits on main

## Acceptance Criteria

The plan includes acceptance criteria covering successful publication across all channels, version consistency, and CI safeguards. See the Acceptance Criteria section of the plan for the authoritative list.

https://claude.ai/code/session_01JJFzkyUFU4WtSQtF2zkEgW