### PR TITLE
Plan 131: LSP symbol navigation for agents (Claude)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -42,7 +42,7 @@ footer: |
 | 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                                                   |
 | 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)                                         |
 | 130 | 🔳     | opus   | [Distribute mdsmith binaries via npm, PyPI, asdf, mise, and the VS Code marketplaces](plan/130_binary-distribution-and-versioning.md) |
-| 130 | 🔲     | opus   | [LSP symbol navigation for agents (Claude)](plan/130_lsp-symbol-navigation.md)                                                        |
+| 131 | 🔲     | opus   | [LSP symbol navigation for agents (Claude)](plan/131_lsp-symbol-navigation.md)                                                        |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                            |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                          |
 | 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                      |

--- a/PLAN.md
+++ b/PLAN.md
@@ -42,6 +42,7 @@ footer: |
 | 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                                                   |
 | 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)                                         |
 | 130 | 🔳     | opus   | [Distribute mdsmith binaries via npm, PyPI, asdf, mise, and the VS Code marketplaces](plan/130_binary-distribution-and-versioning.md) |
+| 130 | 🔲     | opus   | [LSP symbol navigation for agents (Claude)](plan/130_lsp-symbol-navigation.md)                                                        |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                            |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                          |
 | 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                      |

--- a/plan/130_lsp-symbol-navigation.md
+++ b/plan/130_lsp-symbol-navigation.md
@@ -1,0 +1,307 @@
+---
+id: 130
+title: LSP symbol navigation for agents (Claude)
+status: "🔲"
+model: opus
+summary: >-
+  Extend `mdsmith lsp` with the document-symbol,
+  definition, implementation, references,
+  workspace-symbol, and call-hierarchy methods so an
+  LSP-aware agent (Claude's LSP tool, Neovim, Helix)
+  can navigate Markdown by heading outline, anchor
+  and file links, and the include/catalog graph.
+---
+# LSP symbol navigation for agents (Claude)
+
+## Goal
+
+Let an LSP client navigate Markdown like code: list
+the file outline, jump from links to targets,
+enumerate references to a heading, search by name,
+and walk the include/catalog graph as a call
+hierarchy. The server reuses the existing AST and
+config plumbing.
+
+## Background
+
+Plan 121 shipped `mdsmith lsp` with diagnostics and
+code actions. Plan 122 adds hover for rule and
+directive docs. Neither covers symbol navigation.
+
+Claude's LSP tool exposes nine methods:
+
+| LSP method                          | Agent intent                    |
+|-------------------------------------|---------------------------------|
+| `textDocument/documentSymbol`       | List symbols in this file       |
+| `textDocument/definition`           | Where is this defined?          |
+| `textDocument/implementation`       | Where is the concrete behavior? |
+| `textDocument/hover`                | What is this?                   |
+| `textDocument/references`           | Who uses this?                  |
+| `workspace/symbol`                  | Find a symbol by name           |
+| `textDocument/prepareCallHierarchy` | Anchor a call-graph view        |
+| `callHierarchy/incomingCalls`       | Who calls this?                 |
+| `callHierarchy/outgoingCalls`       | What does this call?            |
+
+mdsmith already understands the edges these methods
+need: headings, anchor and file links, link-ref
+defs, front-matter `kind:`, and directive
+arguments. The
+[MDS027 rule](../internal/rules/MDS027-cross-file-reference-integrity)
+walks every link target. Catalog expands globs.
+
+## Non-Goals
+
+- New transports. Stdio stays.
+- Rename refactoring. Heading rewrites need anchor
+  fixups across the workspace; separate plan.
+- Type hierarchy. No Markdown analogue.
+- Code lens, inlay hints, semantic tokens.
+- Indexing outside the workspace root. The index
+  obeys the existing
+  [`internal/discovery`](../internal/discovery)
+  walk.
+
+## Design
+
+### Symbol model
+
+A symbol is one of four things, with a `SymbolKind`
+chosen so picker UIs bucket each sensibly:
+
+| Concept                   | `SymbolKind`   | Container                 |
+|---------------------------|----------------|---------------------------|
+| Heading (H1–H6)           | `String` (15)  | parent heading            |
+| Link-reference definition | `Key` (20)     | file                      |
+| Front-matter field        | `Property` (7) | file                      |
+| Directive (`<?name … ?>`) | `Event` (24)   | enclosing heading or file |
+
+Headings drive the outline; the others sit flat.
+The cross-document key is `(file, anchor)` for
+headings (slug from
+[`mdtext.CollectTOCItems`](../internal/mdtext/mdtext.go))
+and `(file, label)` for link refs.
+
+### Workspace index
+
+A new package `internal/lsp/index` holds the
+symbol graph. It stores headings, link-reference
+defs, front-matter top-level keys, directives, and
+both directions of the reference edges (link
+targets, include / catalog / build targets).
+
+Build is lazy on the first symbol request. Update
+is incremental:
+
+- `didOpen` / `didChange` / `didSave` re-parses one
+  buffer and swaps its slice.
+- `**/*.md` watcher (added here; today's watcher
+  covers only `.mdsmith.yml`) invalidates one file.
+- `.mdsmith.yml` change rebuilds the whole index
+  because kind / ignore globs may shift scope.
+
+The index calls
+[`lint.ParseFile`](../internal/lint/file.go) once
+per file. Existing visitors cover headings and
+link targets. A new visitor captures
+`*ast.LinkReferenceDef` and front-matter keys.
+Memory at 10 000 files is ~300K entries, well
+under plan 121's 512 MB `GOMEMLIMIT`.
+
+### `textDocument/documentSymbol`
+
+Returns a `DocumentSymbol[]` tree rooted at H1s.
+Each heading carries name, anchor in `detail`,
+range from heading to next sibling, and children.
+Front-matter keys hang off a synthetic top-of-file
+symbol. Directives become children of their
+enclosing heading.
+
+Capability: `documentSymbolProvider = true`.
+
+### `textDocument/definition` and `…/implementation`
+
+Both share one `resolveTarget(uri, position)` core.
+`Implementation` returns multi-target sets where
+`Definition` returns one.
+
+| Cursor on…                     | `Definition`                 | `Implementation` adds      |
+|--------------------------------|------------------------------|----------------------------|
+| `[text](#anchor)`              | heading in this file         | —                          |
+| `[text](./other.md)`           | line 1 of `other.md`         | —                          |
+| `[text](./other.md#anchor)`    | heading in `other.md`        | —                          |
+| `[text][label]`                | matching `[label]: url`      | —                          |
+| `<?include file: "x.md"?>` arg | `x.md` line 1                | —                          |
+| `<?build source: "x.md"?>` arg | `x.md` line 1                | —                          |
+| `kind:` value in front matter  | kind block in `.mdsmith.yml` | every file with that kind  |
+| Heading line                   | the heading                  | every link target matching |
+
+A small helper `internal/lsp/index/locate.go` maps
+a position to an AST node and a token tag (heading,
+anchorLink, fileLink, refUse, refDef, directiveArg,
+frontMatterKey, frontMatterValue). One unit test
+per token tag.
+
+Capabilities: `definitionProvider = true`,
+`implementationProvider = true`.
+
+### `textDocument/references`
+
+| Cursor on…                | References returned                              |
+|---------------------------|--------------------------------------------------|
+| Heading                   | every workspace link to `(file, anchor)`         |
+| `[label]: url` definition | every `[text][label]` and shortcut in the file   |
+| File line 1               | every link target with this path (no anchor)     |
+| `kind:` value             | every file with that kind assignment             |
+| Directive block           | every directive whose `file:` / `source:` = this |
+
+`includeDeclaration: false` excludes the heading or
+definition itself. Capability:
+`referencesProvider = true`.
+
+### `workspace/symbol`
+
+The query is a case-insensitive substring. It
+matches heading text, link-ref labels, kind names,
+and front-matter `title:`. The relative path goes
+in `containerName`. Capability:
+`workspaceSymbolProvider = true`.
+
+### Call hierarchy
+
+A Markdown file is the unit of "function"; an
+outbound reference is a "call". This fits doc
+workflows: `incomingCalls` answers "who depends on
+this runbook?", `outgoingCalls` answers "what does
+this overview embed?".
+
+`prepareCallHierarchy` accepts three cursor
+positions. On line 1, the item is the file. On a
+heading, the item is that heading section and
+calls are scoped to its range. On a directive arg,
+the item is the target file.
+
+`incomingCalls` returns every edge into the item.
+Sources include cross-file links, `<?include?>`,
+`<?catalog?>` matches, and `<?build?>`. Each entry
+carries the source file and the reference line.
+`outgoingCalls` returns every edge out of the
+item. Catalog matches reuse the cached glob
+expansions for MDS019.
+
+Capability: `callHierarchyProvider = true`.
+
+### Position and performance
+
+Ranges follow the UTF-16 column convention plan
+121 set; the
+[`utf16Length`](../internal/lsp/diagnostics.go)
+helper extends unchanged. Budgets: cold build
+under 1 s on 1 000 files, incremental update under
+20 ms per `didChange`. A new
+`internal/lsp/index/bench_test.go` measures both
+on synthetic 100 / 1 000 / 10 000-file workspaces;
+the plan 121 benchmark CI step picks it up.
+
+### Backwards compatibility
+
+Diagnostics and code-action behavior are
+unchanged. New capabilities are additive. A client
+that ignores them sees the post-plan-121 server.
+
+## Tasks
+
+1. Add `internal/lsp/index` with the symbol graph
+   types and `Build` / `Update` / `Remove` entry
+   points. Cover heading collection, link-ref defs,
+   front-matter keys, and directive parsing in unit
+   tests. Reuse `mdtext.CollectTOCItems`.
+2. Add the inbound / outbound edge tables. Sources:
+   anchor links, file links, `<?include?>`,
+   `<?catalog?>`, `<?build?>`. Reuse
+   [`lint/pi_parser.go`](../internal/lint/pi_parser.go).
+3. Add `internal/lsp/index/locate.go` mapping a
+   document URI plus position to an AST node and
+   token tag. One test per tag.
+4. Wire the index into the server. Build lazily on
+   first symbol request; update on document
+   events; rebuild on `.mdsmith.yml` change;
+   invalidate on `**/*.md` watcher events. Extend
+   [`registerWatchers`](../internal/lsp/server.go).
+5. Implement `textDocument/documentSymbol` and add
+   the capability. Integration test against a
+   fixture with H1/H2/H3 headings, directives, and
+   link refs.
+6. Implement `textDocument/definition` and
+   `textDocument/implementation`. Cover every row
+   in the design table.
+7. Implement `textDocument/references`. Cover the
+   five rows; verify `includeDeclaration`.
+8. Implement `workspace/symbol`. Cover heading,
+   kind, and `title:` matches.
+9. Implement `prepareCallHierarchy`,
+   `incomingCalls`, `outgoingCalls`. Cover file /
+   heading / directive prepare paths and round-
+   trip on a three-file include chain.
+10. Add the bench file and the budget thresholds.
+    The CI step from plan 121 covers it.
+11. Extend
+    [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+    with a "Symbol navigation" section, the
+    symbol-kind table, and call-hierarchy
+    semantics.
+12. Update
+    [the VS Code guide](../docs/guides/editors/vscode.md)
+    with a short "Outline and Go to Definition"
+    note.
+13. Add an end-to-end test in
+    [`cmd/mdsmith`](../cmd/mdsmith) driving
+    `initialize` → `didOpen` → `documentSymbol` →
+    `definition` → `references` →
+    `prepareCallHierarchy` → `incomingCalls` →
+    `shutdown` → `exit`.
+
+## Acceptance Criteria
+
+- [ ] `documentSymbol` returns a hierarchical
+      outline whose nesting matches heading levels.
+- [ ] `definition` jumps to a heading from an
+      anchor link, to line 1 of a file from a
+      relative link, and to the matching reference
+      def from `[text][ref]`.
+- [ ] `implementation` on a `kind:` value returns
+      one location per file assigned that kind.
+- [ ] `references` on a heading returns every
+      workspace anchor link to it;
+      `includeDeclaration: false` excludes the
+      heading itself.
+- [ ] `workspace/symbol` substring queries match
+      headings, link-ref labels, front-matter
+      titles, and kind names.
+- [ ] `prepareCallHierarchy` on a file returns one
+      item; `incomingCalls` lists files that
+      include / link to it; `outgoingCalls` lists
+      files it includes / links to.
+- [ ] Cold-build benchmark reports under 1 s on
+      1 000 files; incremental-update under 20 ms
+      per `didChange`. Invocation:
+      `go test -run=^$ -bench=. ./internal/lsp/...`
+- [ ] [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+      lists every new capability and the symbol-
+      kind table.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no
+      issues.
+- [ ] `mdsmith check .` passes including the new
+      docs and the updated `PLAN.md` catalog.
+
+## Open Questions
+
+- **Catalog glob expansion in `incomingCalls`.** A
+  glob like `**/*.md` would inflate result lists.
+  The first pass collapses each catalog block to
+  one entry. Add an `expandCatalog` flag later if
+  needed.
+- **`findReferences` across include boundaries.**
+  A heading in an included file is reachable via
+  both files. The first pass reports both; flag
+  if noisy.

--- a/plan/131_lsp-symbol-navigation.md
+++ b/plan/131_lsp-symbol-navigation.md
@@ -46,7 +46,7 @@ mdsmith already understands the edges these methods
 need: headings, anchor and file links, link-ref
 defs, front-matter `kind:`, and directive
 arguments. The
-[MDS027 rule](../internal/rules/MDS027-cross-file-reference-integrity)
+[MDS027 rule](../internal/rules/MDS027-cross-file-reference-integrity/README.md)
 walks every link target. Catalog expands globs.
 
 ## Non-Goals
@@ -103,7 +103,7 @@ The index calls
 [`lint.ParseFile`](../internal/lint/file.go) once
 per file. Existing visitors cover headings and
 link targets. A new visitor captures
-`*ast.LinkReferenceDef` and front-matter keys.
+`*ast.LinkReferenceDefinition` and front-matter keys.
 Memory at 10 000 files is ~300K entries, well
 under plan 121's 512 MB `GOMEMLIMIT`.
 

--- a/plan/131_lsp-symbol-navigation.md
+++ b/plan/131_lsp-symbol-navigation.md
@@ -1,5 +1,5 @@
 ---
-id: 130
+id: 131
 title: LSP symbol navigation for agents (Claude)
 status: "🔲"
 model: opus


### PR DESCRIPTION
## Summary

This PR adds a comprehensive plan for implementing LSP symbol navigation capabilities in `mdsmith lsp`, enabling Claude and other LSP-aware agents to navigate Markdown documents like code through headings, links, and the include/catalog graph.

## Changes

- **New plan document** (`plan/131_lsp-symbol-navigation.md`): Detailed specification for extending the LSP server with symbol navigation methods
- **Updated PLAN.md**: Added plan 131 to the catalog with status and model information

## Key Features Planned

The plan outlines implementation of six LSP methods to support agent-driven navigation:

- **`textDocument/documentSymbol`**: List file outline as hierarchical heading tree
- **`textDocument/definition`**: Jump from links to targets (headings, files, reference definitions)
- **`textDocument/implementation`**: Multi-target resolution (e.g., all files with a given `kind:`)
- **`textDocument/references`**: Find all workspace references to a symbol
- **`workspace/symbol`**: Case-insensitive substring search across headings, labels, and metadata
- **Call hierarchy** (`prepareCallHierarchy`, `incomingCalls`, `outgoingCalls`): Model files as functions and references as calls to show dependency graphs

## Design Highlights

- **Symbol model**: Four symbol kinds (headings, link-reference definitions, front-matter fields, directives) with appropriate `SymbolKind` values for UI bucketing
- **Workspace index**: New `internal/lsp/index` package with lazy build on first request and incremental updates on document changes
- **Performance budgets**: Cold build under 1s on 1,000 files; incremental updates under 20ms per `didChange`
- **Reuses existing infrastructure**: Leverages `mdtext.CollectTOCItems`, `lint.ParseFile`, and existing AST visitors

## Implementation Plan

13 concrete tasks covering index construction, position mapping, server integration, method implementations, benchmarking, documentation, and end-to-end testing.

## Acceptance Criteria

Includes measurable criteria for outline correctness, definition/implementation/references accuracy, symbol search functionality, call hierarchy semantics, performance benchmarks, and documentation completeness.

(Renumbered from 130 → 131 because plan 130 was claimed by an in-flight binary-distribution plan that landed first.)

https://claude.ai/code/session_01RoS5UiVF9ucNHh1Vzs97Np