### PR TITLE
Add comprehensive mdsmith vs mdbase research documentation

### DIFF
--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -169,6 +169,67 @@ to CommonMark parsers). Dataview inline fields are not
 front matter and will not be read by mdsmith's
 `require`/`schema` directives.
 
+### [mdbase][]
+
+Specification for treating folders of Markdown files
+as typed, queryable data collections. Split across
+three repos: the [spec][mdbase-spec], a TypeScript
+reference impl ([mdbase][mdbase-ts]), and a Node 22+
+[CLI][mdbase-cli]. MIT, version 0.2.1 (early release
+as of 2026-05). It overlaps with mdsmith's file-kinds
+and front-matter schema work. Both tools target the
+same Obsidian-vault audience.
+
+A collection is a directory with an `mdbase.yaml`
+config plus a `_types/` folder. Type definitions are
+Markdown files: schema in front matter, docs in body.
+The spec defines:
+
+- 12 field types (string, integer, date, enum, link,
+  tags, etc.) with inheritance and computed fields
+- File-to-type assignment via explicit declaration,
+  path globs, or field presence
+- An expression language for filtering, sorting,
+  grouping, and summaries, designed for compatibility
+  with Obsidian [Bases][obsidian-bases] syntax
+- Reference tracking that rewrites wiki and Markdown
+  links when files are renamed
+- SQLite-backed cache and watch mode for incremental
+  re-evaluation
+- 34 error codes spanning 6 validation strictness
+  levels
+- 6 conformance tiers, from Core (CRUD only) through
+  Full (caching, batch operations, watch mode)
+
+mdbase and mdsmith both treat front-matter-tagged
+Markdown as data, but pick different tradeoffs:
+
+| Aspect              | mdbase                                  | mdsmith                                                |
+|---------------------|-----------------------------------------|--------------------------------------------------------|
+| Artifact            | Spec + TS impl + Node CLI               | Single Go binary                                       |
+| Scope               | Data layer (types, queries, refs)       | Linter + fixer + generator                             |
+| Type definitions    | Markdown files under `_types/`          | [File kinds][file-kinds] in `.mdsmith.yml`             |
+| File-to-type match  | Explicit, path globs, or field presence | Path globs in `.mdsmith.yml`                           |
+| Front-matter schema | 12 built-in field types, inheritance    | CUE schema via [MDS020][mds020] (`required-structure`) |
+| Query language      | Obsidian Bases–compatible expressions   | CUE expressions (`mdsmith query`)                      |
+| Rename refactor     | Rewrites incoming links                 | No (integrity check only, [MDS027][mds027])            |
+| Cache               | SQLite, watch mode                      | None (stateless per run)                               |
+| Prose / structure   | Out of scope                            | 30+ rules (line length, headings, readability, …)      |
+| Generated content   | Out of scope                            | catalog, include, toc, build directives                |
+| Editor integration  | LSP server (separate repo)              | `mdsmith lsp` + VS Code extension                      |
+| Status              | Spec v0.2.1, early release              | Stable rules; only [MDS029][mds029] experimental       |
+
+The two are complementary in principle: mdbase manages
+a typed vault while mdsmith lints prose, structure,
+and generated sections on the same files. Both read
+YAML front matter and neither rewrites the other's
+metadata, so they coexist on disk. They do not yet
+share schemas: mdsmith's CUE schemas in
+[MDS020][mds020] cannot consume mdbase `_types/`
+definitions, and mdbase implementations do not read
+mdsmith's `.mdsmith.yml`. Teams adopting both today
+maintain the type definition twice.
+
 Using language models (GPT-4, Claude, etc.) directly to
 check prose quality, conciseness, and style. This is
 emerging through dedicated CLI tools and AI review bots.
@@ -739,6 +800,13 @@ you need a stable rule set while these land.
 [Obsidian]: https://obsidian.md/
 [obsidian-fm]: https://help.obsidian.md/Editing+and+formatting/Obsidian+Flavored+Markdown
 [obsidian-linter]: https://github.com/platers/obsidian-linter
+[obsidian-bases]: https://help.obsidian.md/bases
+<!-- mdbase links -->
+[mdbase]: https://mdbase.dev/
+[mdbase-spec]: https://github.com/callumalpass/mdbase-spec
+[mdbase-ts]: https://github.com/callumalpass/mdbase
+[mdbase-cli]: https://github.com/callumalpass/mdbase-cli
+[file-kinds]: ../guides/file-kinds.md
 <!-- mdsmith plan + security + reference links -->
 [mdsmith-sec]: ../security/2026-04-05-adversarial-markdown.md
 [conventions]: ../reference/conventions.md

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -172,63 +172,16 @@ front matter and will not be read by mdsmith's
 ### [mdbase][]
 
 Specification for treating folders of Markdown files
-as typed, queryable data collections. Split across
-three repos: the [spec][mdbase-spec], a TypeScript
-reference impl ([mdbase][mdbase-ts]), and a Node 22+
-[CLI][mdbase-cli]. MIT, version 0.2.1 (early release
-as of 2026-05). It overlaps with mdsmith's file-kinds
-and front-matter schema work. Both tools target the
-same Obsidian-vault audience.
+as typed, queryable data collections. Reference impl
+in TypeScript, with a Node CLI and a Rust LSP. MIT,
+version 0.2.1 (early release as of 2026-05). The same
+files-on-disk philosophy as mdsmith, but scoped to the
+data layer: types, queries, and rename refactoring
+rather than prose linting.
 
-A collection is a directory with an `mdbase.yaml`
-config plus a `_types/` folder. Type definitions are
-Markdown files: schema in front matter, docs in body.
-The spec defines:
-
-- 12 field types (string, integer, date, enum, link,
-  tags, etc.) with inheritance and computed fields
-- File-to-type assignment via explicit declaration,
-  path globs, or field presence
-- An expression language for filtering, sorting,
-  grouping, and summaries, designed for compatibility
-  with Obsidian [Bases][obsidian-bases] syntax
-- Reference tracking that rewrites wiki and Markdown
-  links when files are renamed
-- SQLite-backed cache and watch mode for incremental
-  re-evaluation
-- 34 error codes spanning 6 validation strictness
-  levels
-- 6 conformance tiers, from Core (CRUD only) through
-  Full (caching, batch operations, watch mode)
-
-mdbase and mdsmith both treat front-matter-tagged
-Markdown as data, but pick different tradeoffs:
-
-| Aspect              | mdbase                                  | mdsmith                                                |
-|---------------------|-----------------------------------------|--------------------------------------------------------|
-| Artifact            | Spec + TS impl + Node CLI               | Single Go binary                                       |
-| Scope               | Data layer (types, queries, refs)       | Linter + fixer + generator                             |
-| Type definitions    | Markdown files under `_types/`          | [File kinds][file-kinds] in `.mdsmith.yml`             |
-| File-to-type match  | Explicit, path globs, or field presence | Path globs in `.mdsmith.yml`                           |
-| Front-matter schema | 12 built-in field types, inheritance    | CUE schema via [MDS020][mds020] (`required-structure`) |
-| Query language      | Obsidian Bases–compatible expressions   | CUE expressions (`mdsmith query`)                      |
-| Rename refactor     | Rewrites incoming links                 | No (integrity check only, [MDS027][mds027])            |
-| Cache               | SQLite, watch mode                      | None (stateless per run)                               |
-| Prose / structure   | Out of scope                            | 30+ rules (line length, headings, readability, …)      |
-| Generated content   | Out of scope                            | catalog, include, toc, build directives                |
-| Editor integration  | LSP server (separate repo)              | `mdsmith lsp` + VS Code extension                      |
-| Status              | Spec v0.2.1, early release              | Stable rules; only [MDS029][mds029] experimental       |
-
-The two are complementary in principle: mdbase manages
-a typed vault while mdsmith lints prose, structure,
-and generated sections on the same files. Both read
-YAML front matter and neither rewrites the other's
-metadata, so they coexist on disk. They do not yet
-share schemas: mdsmith's CUE schemas in
-[MDS020][mds020] cannot consume mdbase `_types/`
-definitions, and mdbase implementations do not read
-mdsmith's `.mdsmith.yml`. Teams adopting both today
-maintain the type definition twice.
+See the [deep-dive comparison][mdbase-deep-dive].
+It covers types, queries, validation, links, the fix
+engine, workflows, and how to run both tools together.
 
 Using language models (GPT-4, Claude, etc.) directly to
 check prose quality, conciseness, and style. This is
@@ -800,13 +753,9 @@ you need a stable rule set while these land.
 [Obsidian]: https://obsidian.md/
 [obsidian-fm]: https://help.obsidian.md/Editing+and+formatting/Obsidian+Flavored+Markdown
 [obsidian-linter]: https://github.com/platers/obsidian-linter
-[obsidian-bases]: https://help.obsidian.md/bases
 <!-- mdbase links -->
 [mdbase]: https://mdbase.dev/
-[mdbase-spec]: https://github.com/callumalpass/mdbase-spec
-[mdbase-ts]: https://github.com/callumalpass/mdbase
-[mdbase-cli]: https://github.com/callumalpass/mdbase-cli
-[file-kinds]: ../guides/file-kinds.md
+[mdbase-deep-dive]: ../research/mdbase-vs-mdsmith/README.md
 <!-- mdsmith plan + security + reference links -->
 [mdsmith-sec]: ../security/2026-04-05-adversarial-markdown.md
 [conventions]: ../reference/conventions.md

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -179,6 +179,44 @@ files-on-disk philosophy as mdsmith, but scoped to the
 data layer: types, queries, and rename refactoring
 rather than prose linting.
 
+A small example shows the overlap and the split.
+Both tools read this `.md` file as-is:
+
+```markdown
+---
+title: Migrate auth to OIDC
+status: in-progress
+priority: 3
+due: 2026-06-01
+---
+# Migrate auth to OIDC
+
+The current SAML flow has two open issues. We will
+swap to OIDC over the next sprint.
+
+See the [migration log](./auth-migration-log.md).
+```
+
+What each tool **does** with the same bytes:
+
+| Layer                          | mdsmith                                       | mdbase                                                    |
+|--------------------------------|-----------------------------------------------|-----------------------------------------------------------|
+| YAML front matter              | reads it; can validate shape via CUE schema   | reads it; validates against `_types/task.md`              |
+| Body content (prose, headings) | lints line length, headings, prose, links     | not in scope                                              |
+| Cross-file link                | flags broken `auth-migration-log.md` (MDS027) | flags broken link (L4) and rewrites it on rename (L5)     |
+| `status: in-progress`          | available to `mdsmith query`                  | filterable in Bases queries; appears in backlink graphs   |
+| `due: 2026-06-01`              | available to query                            | filterable with date arithmetic (`due <= today() + "7d"`) |
+| `mdsmith fix` runs             | reformats tables, regenerates TOC/catalog     | n/a                                                       |
+| `mdbase rename` runs           | n/a                                           | moves the file and rewrites every incoming link           |
+| Body conciseness, readability  | yes (MDS023, MDS024, MDS028)                  | no                                                        |
+
+The **shared** layer is the YAML front matter:
+both tools treat `status`, `priority`, `due` as
+typed data. The **split** is the body — mdsmith
+owns prose, structure, and generated content;
+mdbase owns rename refactoring, the link graph,
+and richer queries.
+
 See the [deep-dive comparison][mdbase-deep-dive].
 It covers types, queries, validation, links, the fix
 engine, workflows, and how to run both tools together.

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -210,12 +210,20 @@ What each tool **does** with the same bytes:
 | `mdbase rename` runs           | n/a                                           | moves the file and rewrites every incoming link           |
 | Body conciseness, readability  | yes (MDS023, MDS024, MDS028)                  | no                                                        |
 
-The **shared** layer is the YAML front matter:
-both tools treat `status`, `priority`, `due` as
-typed data. The **split** is the body — mdsmith
-owns prose, structure, and generated content;
-mdbase owns rename refactoring, the link graph,
-and richer queries.
+The **shared** layer is the YAML front matter.
+Both tools read `status`, `priority`, `due` as
+structured fields. mdbase enforces field types
+out of the box via `_types/`. mdsmith does the
+same when a CUE schema is wired up via MDS020;
+without one, it treats them as plain YAML.
+
+The **current surface difference** sits in the
+body and the link graph. mdsmith ships prose,
+structure, and generated-content rules today.
+mdbase ships rename refactoring, the link graph,
+and richer queries today. Either surface is a
+snapshot, not a charter — see the deep-dive for
+evolutionary candidates either way.
 
 See the [deep-dive comparison][mdbase-deep-dive].
 It covers types, queries, validation, links, the fix

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -199,16 +199,16 @@ See the [migration log](./auth-migration-log.md).
 
 What each tool **does** with the same bytes:
 
-| Layer                          | mdsmith                                       | mdbase                                                    |
-|--------------------------------|-----------------------------------------------|-----------------------------------------------------------|
-| YAML front matter              | reads it; can validate shape via CUE schema   | reads it; validates against `_types/task.md`              |
-| Body content (prose, headings) | lints line length, headings, prose, links     | not in scope                                              |
-| Cross-file link                | flags broken `auth-migration-log.md` (MDS027) | flags broken link (L4) and rewrites it on rename (L5)     |
-| `status: in-progress`          | available to `mdsmith query`                  | filterable in Bases queries; appears in backlink graphs   |
-| `due: 2026-06-01`              | available to query                            | filterable with date arithmetic (`due <= today() + "7d"`) |
-| `mdsmith fix` runs             | reformats tables, regenerates TOC/catalog     | n/a                                                       |
-| `mdbase rename` runs           | n/a                                           | moves the file and rewrites every incoming link           |
-| Body conciseness, readability  | yes (MDS023, MDS024, MDS028)                  | no                                                        |
+| Layer                                     | mdsmith                                                 | mdbase                                                    |
+|-------------------------------------------|---------------------------------------------------------|-----------------------------------------------------------|
+| YAML front matter                         | reads it; can validate shape via CUE schema             | reads it; validates against `_types/task.md`              |
+| Body content (prose, headings)            | lints line length, headings, prose, links               | not in scope                                              |
+| Cross-file link                           | flags broken `auth-migration-log.md` (MDS027)           | flags broken link (L4) and rewrites it on rename (L5)     |
+| `status: in-progress`                     | available to `mdsmith query`                            | filterable in Bases queries; appears in backlink graphs   |
+| `due: 2026-06-01`                         | available to query                                      | filterable with date arithmetic (`due <= today() + "7d"`) |
+| `mdsmith fix` runs                        | reformats tables, regenerates TOC/catalog               | n/a                                                       |
+| `mdbase rename` runs                      | n/a                                                     | moves the file and rewrites every incoming link           |
+| Body readability, structure, token budget | yes (MDS023 ARI, MDS024 sentences, MDS028 token budget) | no                                                        |
 
 The **shared** layer is the YAML front matter.
 Both tools read `status`, `priority`, `due` as

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -1,5 +1,7 @@
 ---
-summary: Deep-dive comparison of mdsmith and mdbase — two file-first, plain-Markdown-on-disk approaches with non-overlapping responsibilities.
+summary: >-
+  Deep-dive comparison of mdsmith and mdbase — two file-first, plain-
+  Markdown-on-disk approaches with non-overlapping responsibilities.
 status: 🔳
 ---
 # mdsmith vs mdbase

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -26,9 +26,20 @@ Markdown stack they own.
   comparison: daily authoring, repo bootstrap, schema
   evolution, file rename, CI, editor session,
   Obsidian-vault use, LLM/agent use
+- [use-cases.md](use-cases.md) — seven concrete
+  worked scenarios (open-source repo, Obsidian
+  vault, RFC tracker, task tracker, agent-
+  maintained runbooks, knowledge graph, mixed
+  wiki+plan tracker) that exercise where each
+  tool fits
 - [interop.md](interop.md) — running both tools on
   the same files: coexistence, the dual-schema
   problem, recommended layouts, future bridge
+- [learn-from-mdbase.md](learn-from-mdbase.md) —
+  systematic gap enumeration: every mdbase
+  capability mdsmith doesn't have, triaged into
+  in-scope / out-of-scope / in-flight, with a
+  per-gap mini-plan for the in-scope ones
 
 ## TL;DR
 
@@ -98,7 +109,7 @@ the SQLite cache live only in mdbase.
 | Distribution     | one Go binary                     | npm package + CLI + LSP                 |
 | Maturity         | stable rules, MDS029 experimental | early release; conformance levels 1–6   |
 | License          | MIT                               | MIT                                     |
-| Language         | Go 1.24+                          | TypeScript / Rust                       |
+| Language         | Go 1.25+ (per `go.mod`)           | TypeScript / Rust                       |
 | Runtime deps     | none                              | Node 22+ (TS impl); Rust LSP standalone |
 | Network          | none                              | none                                    |
 | Persistent state | none                              | optional SQLite cache                   |
@@ -136,12 +147,19 @@ schema. mdsmith reads CUE; mdbase reads its own DSL.
 
 ## Reading order
 
-Start with [features.md](features.md) for the
-mechanical comparison. Then read
-[workflows.md](workflows.md) for what daily work
-looks like under each. Finally,
-[interop.md](interop.md) describes how to run them
-together if you want both layers.
+For a tool comparison, start with
+[features.md](features.md) for the mechanical
+breakdown, then [workflows.md](workflows.md) for
+daily-work feel, then [use-cases.md](use-cases.md)
+for seven concrete scenarios that show where each
+tool fits, and finally [interop.md](interop.md)
+for combining both.
+
+For a design exercise, read
+[learn-from-mdbase.md](learn-from-mdbase.md):
+every gap mdsmith has against mdbase, triaged and
+sketched as a mini-plan. Twelve in-scope items
+plus rationale for the out-of-scope ones.
 
 ## Sources
 
@@ -155,9 +173,12 @@ together if you want both layers.
 - mdbase CLI: <https://github.com/callumalpass/mdbase-cli>
 - mdbase LSP (Rust):
   <https://github.com/callumalpass/mdbase-lsp>
-- mdsmith codebase as of branch
-  `claude/compare-mdsmith-mdbase-nVAqH`
-  (54 rules, Go 1.24+, MIT)
+- mdsmith codebase as of 2026-05 (54 rules,
+  Go 1.25+ per `go.mod`, MIT). The original
+  research pass landed in the PR that introduced
+  this folder; commit history under
+  `docs/research/mdbase-vs-mdsmith/` is the
+  authoritative trail.
 
 [file-kinds]: ../../guides/file-kinds.md
 [mds020]: ../../../internal/rules/MDS020-required-structure/README.md

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -1,0 +1,164 @@
+---
+summary: Deep-dive comparison of mdsmith and mdbase — two file-first, plain-Markdown-on-disk approaches with non-overlapping responsibilities.
+status: 🔳
+---
+# mdsmith vs mdbase
+
+This research note compares
+[mdsmith](https://github.com/jeduden/mdsmith) — a Go
+Markdown linter — with [mdbase](https://mdbase.dev) — a
+specification for typed, queryable Markdown collections,
+with a TypeScript reference implementation, a Node CLI,
+and a Rust LSP. Both treat plain `.md` files on disk as
+the source of truth and refuse to introduce a separate
+artifact format. They differ on which layer of the
+Markdown stack they own.
+
+## Documents in this folder
+
+- [README.md](README.md) — this overview
+- [features.md](features.md) — feature-by-feature
+  comparison: distribution, config, type system,
+  validation, queries, links, generated content,
+  prose linting, conventions, cache, CLI, LSP,
+  output formats
+- [workflows.md](workflows.md) — way-of-working
+  comparison: daily authoring, repo bootstrap, schema
+  evolution, file rename, CI, editor session,
+  Obsidian-vault use, LLM/agent use
+- [interop.md](interop.md) — running both tools on
+  the same files: coexistence, the dual-schema
+  problem, recommended layouts, future bridge
+
+## TL;DR
+
+The two tools are complementary, not competitive.
+
+**mdbase** is a specification for typed Markdown
+collections. It defines how a folder of `.md` files
+becomes a queryable, schema-validated database.
+Implementations provide CRUD, schema typing, link
+resolution, rename refactoring, query expressions
+(Bases-compatible), and an SQLite-backed cache. The
+spec is at version 0.2.1 (early release) with
+reference implementations in TypeScript, a Node CLI,
+and a Rust LSP.
+
+**mdsmith** is a single Go binary that lints, fixes,
+and regenerates Markdown. It owns prose readability,
+structural rules, generated sections (catalog, TOC,
+include, build), and a CUE-based front-matter schema.
+54 rules ship in the binary. Stable today, no
+network, no daemon, no cache.
+
+Both projects:
+
+- Treat the filesystem as authoritative
+- Refuse a proprietary file format
+- Ship offline, single-binary or single-package
+- Target the same Obsidian-and-Git audience
+- Read YAML front matter as the structured layer
+
+The overlap region is **front-matter typing and
+querying**. mdsmith's [file kinds][file-kinds] and
+[required-structure][mds020] rule cover the same
+ground as mdbase types, but with different syntax
+(CUE vs an mdbase-specific schema DSL) and different
+ownership (lint config vs `_types/` Markdown files).
+The non-overlap region is **everything else**: prose
+rules, fixers, and regenerable sections live only in
+mdsmith; rename refactoring, the query language, and
+the SQLite cache live only in mdbase.
+
+## When to use which
+
+| Need                                          | Reach for                  |
+|-----------------------------------------------|----------------------------|
+| Lint Markdown structure and style             | mdsmith                    |
+| Enforce paragraph readability or token budget | mdsmith                    |
+| Auto-generate catalogs, TOCs, includes        | mdsmith                    |
+| Reformat tables, fix trailing whitespace      | mdsmith                    |
+| Validate front-matter shape                   | either                     |
+| Query files by front-matter field             | either                     |
+| Rename a file and update all backlinks        | mdbase                     |
+| Compute backlinks for a knowledge graph       | mdbase                     |
+| Watch a folder for changes (event stream)     | mdbase                     |
+| Index 10k+ files for fast queries             | mdbase                     |
+| Run in CI as a single static binary           | mdsmith                    |
+| Edit a vault in Obsidian with typed schemas   | mdbase                     |
+| Block PRs on broken cross-file links          | mdsmith ([MDS027][mds027]) |
+| Block PRs on missing front-matter fields      | either                     |
+
+## Status snapshot (2026-05)
+
+| Property         | mdsmith                           | mdbase                                  |
+|------------------|-----------------------------------|-----------------------------------------|
+| Spec version     | n/a (single impl)                 | 0.2.1                                   |
+| Reference impl   | mdsmith (Go)                      | mdbase (TS), mdbase-rs (Rust LSP)       |
+| Distribution     | one Go binary                     | npm package + CLI + LSP                 |
+| Maturity         | stable rules, MDS029 experimental | early release; conformance levels 1–6   |
+| License          | MIT                               | MIT                                     |
+| Language         | Go 1.24+                          | TypeScript / Rust                       |
+| Runtime deps     | none                              | Node 22+ (TS impl); Rust LSP standalone |
+| Network          | none                              | none                                    |
+| Persistent state | none                              | optional SQLite cache                   |
+| Plugin system    | no (rules baked in)               | no (spec is fixed; impls vary)          |
+
+## Same problem, different layer
+
+A picture helps. Both tools sit on the same files but
+own different layers of behavior.
+
+```text
+            ┌──────────────────────────────────────┐
+            │ Markdown source files (.md)          │
+            │   YAML front matter + body content   │
+            └──────────────────────────────────────┘
+                          │
+        ┌─────────────────┼──────────────────┐
+        │                 │                  │
+        ▼                 ▼                  ▼
+   mdsmith owns:     overlap region:    mdbase owns:
+   - prose rules     - FM typing        - rename refactor
+   - structure       - FM querying      - backlink graph
+   - readability     - kind/type        - watch events
+   - catalog, TOC      assignment       - SQLite index
+   - include, build  - schema           - link traversal
+   - merge driver      validation       - CRUD operations
+   - LSP diagnostics                    - Bases queries
+   - 54 lint rules                      - migrations
+```
+
+The "overlap region" is where teams running both will
+feel friction: today there is no way to share the
+schema. mdsmith reads CUE; mdbase reads its own DSL.
+[interop.md](interop.md) covers the workarounds.
+
+## Reading order
+
+Start with [features.md](features.md) for the
+mechanical comparison. Then read
+[workflows.md](workflows.md) for what daily work
+looks like under each. Finally,
+[interop.md](interop.md) describes how to run them
+together if you want both layers.
+
+## Sources
+
+- mdbase specification:
+  <https://github.com/callumalpass/mdbase-spec>
+  (sections 0–15, appendices A–D, version 0.2.1)
+- mdbase project site:
+  <https://mdbase.dev>
+- mdbase TypeScript reference impl:
+  <https://github.com/callumalpass/mdbase>
+- mdbase CLI: <https://github.com/callumalpass/mdbase-cli>
+- mdbase LSP (Rust):
+  <https://github.com/callumalpass/mdbase-lsp>
+- mdsmith codebase as of branch
+  `claude/compare-mdsmith-mdbase-nVAqH`
+  (54 rules, Go 1.24+, MIT)
+
+[file-kinds]: ../../guides/file-kinds.md
+[mds020]: ../../../internal/rules/MDS020-required-structure/README.md
+[mds027]: ../../../internal/rules/MDS027-cross-file-reference-integrity/README.md

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -102,7 +102,7 @@ DSL compatible with Obsidian Bases for queries,
 optional SQLite-backed caching, watch mode, and
 rename with link rewriting.
 
-**Both projects in detail share these properties.** Together, these properties hold for both:
+Shared by both projects:
 
 - Files on disk are authoritative
 - No proprietary format

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -1,8 +1,8 @@
 ---
 summary: >-
   Deep-dive comparison of mdsmith and mdbase — two file-first, plain-
-  Markdown-on-disk approaches with non-overlapping responsibilities.
-status: 🔳
+  Markdown-on-disk approaches to the same substrate, with different
+  surfaces today and overlapping evolutionary candidates.
 ---
 # mdsmith vs mdbase
 
@@ -13,8 +13,14 @@ specification for typed, queryable Markdown collections,
 with a TypeScript reference implementation, a Node CLI,
 and a Rust LSP. Both treat plain `.md` files on disk as
 the source of truth and refuse to introduce a separate
-artifact format. They differ on which layer of the
-Markdown stack they own.
+artifact format. The substrate they read is the same
+(YAML front matter, Markdown body, link graph). What
+differs today is which surfaces each tool exposes
+over that substrate. Neither tool's exposure is a
+permanent split — see
+[learn-from-mdbase.md](learn-from-mdbase.md) for the
+candidate directions and the cost-vs-benefit triggers
+for each.
 
 ## Documents in this folder
 
@@ -32,88 +38,112 @@ Markdown stack they own.
   worked scenarios (open-source repo, Obsidian
   vault, RFC tracker, task tracker, agent-
   maintained runbooks, knowledge graph, mixed
-  wiki+plan tracker) that exercise where each
-  tool fits
+  wiki+plan tracker) showing which tool fits each
+  use case best **today**
 - [interop.md](interop.md) — running both tools on
   the same files: coexistence, the dual-schema
   problem, recommended layouts, future bridge
 - [learn-from-mdbase.md](learn-from-mdbase.md) —
   systematic gap enumeration: every mdbase
-  capability mdsmith doesn't have, with a per-gap
-  mini-plan covering goal, sketch, surface,
-  effort, and the **trigger** under which
-  shipping it becomes worth the cost. mdsmith's
-  feature set is open; this doc maps candidates
-  rather than committing to any.
+  capability mdsmith doesn't yet expose, with a
+  per-gap mini-plan covering goal, sketch, surface,
+  effort, and the **trigger** under which shipping
+  it becomes worth the cost. mdsmith's feature set
+  is open; this doc maps candidates.
 - [aggregation-use-cases.md](aggregation-use-cases.md)
   — six worked aggregation workloads (sprint
   dashboard, reviewer-load report, knowledge-graph
   backlinks, time-bucketed velocity, cross-type
   join, real-time editor decoration), the cases
   where a SQLite-class index pays vs. where it
-  doesn't, and a serious look at stateless-fast
-  (`fzf` / `ripgrep`-style) approaches as an
-  alternative to a persistent cache. The deepest
-  open design question for mdsmith.
+  doesn't, an analysis of the costs an index
+  actually carries (sync-check, OS file cache,
+  background indexing with priority queries), and
+  a serious look at stateless-fast (`fzf` /
+  `ripgrep`-style) approaches as an alternative.
 
 ## TL;DR
 
-The two tools are complementary, not competitive.
+Two tools, one substrate, different surfaces today.
 
-**mdbase** is a specification for typed Markdown
-collections. It defines how a folder of `.md` files
-becomes a queryable, schema-validated database.
-Implementations provide CRUD, schema typing, link
-resolution, rename refactoring, query expressions
-(Bases-compatible), and an SQLite-backed cache. The
-spec is at version 0.2.1 (early release) with
-reference implementations in TypeScript, a Node CLI,
-and a Rust LSP.
+**Same substrate.** Both projects read plain `.md`
+files with YAML front matter and Markdown body.
+Both can in principle parse front matter, walk a
+link graph, evaluate expressions over the result,
+and produce diagnostics. There is no fundamental
+capability split between the two projects —
+the underlying data model is shared.
 
-**mdsmith** is a single Go binary that lints, fixes,
-and regenerates Markdown. It owns prose readability,
-structural rules, generated sections (catalog, TOC,
-include, build), and a CUE-based front-matter schema.
-54 rules ship in the binary. Stable today, no
-network, no daemon, no cache.
+**Different surfaces today.**
+[mdsmith](https://github.com/jeduden/mdsmith)
+ships a Go binary that focuses on linting and
+fixing: 54 rules covering prose readability,
+structural conventions, generated sections
+(catalog, TOC, include, build), front-matter
+schema validation via [MDS020][mds020]
+(`proto.md` schemas with CUE in the front matter),
+and a CUE-struct-literal `query` subcommand. No
+persistent state, stateless re-read per run.
+[mdbase](https://mdbase.dev) is a specification
+plus reference impls (TS, Rust LSP, Node CLI)
+that focuses on typed records: a 12-type FM
+field taxonomy, CRUD operations, an expression
+DSL compatible with Obsidian Bases for queries,
+optional SQLite-backed caching, watch mode, and
+rename with link rewriting.
 
-Both projects:
+**Both projects in detail share these properties.** Together, these properties hold for both:
 
-- Treat the filesystem as authoritative
-- Refuse a proprietary file format
-- Ship offline, single-binary or single-package
-- Target the same Obsidian-and-Git audience
-- Read YAML front matter as the structured layer
+- Files on disk are authoritative
+- No proprietary format
+- Offline operation
+- YAML front matter as the structured layer
+- Both can grow toward each other; neither has a
+  fixed feature set
 
-The overlap region is **front-matter typing and
-querying**. mdsmith's [file kinds][file-kinds] and
-[required-structure][mds020] rule cover the same
-ground as mdbase types, but with different syntax
-(CUE vs an mdbase-specific schema DSL) and different
-ownership (lint config vs `_types/` Markdown files).
-The non-overlap region is **everything else**: prose
-rules, fixers, and regenerable sections live only in
-mdsmith; rename refactoring, the query language, and
-the SQLite cache live only in mdbase.
+**Where the surfaces don't yet meet.** The
+[learn-from-mdbase.md](learn-from-mdbase.md)
+catalogue describes ~30 capabilities present in
+mdbase that mdsmith does not yet expose, with a
+**trigger** for each — the concrete condition
+under which shipping that capability becomes
+worth the cost. None of the entries are
+out-of-bounds; they all sit somewhere on a
+cost-vs-benefit curve. Symmetrically, mdbase
+does not expose mdsmith's surface either — prose
+linting, regenerable sections, a fix engine —
+and could in principle grow toward those.
 
-## When to use which
+## When to use which today
 
-| Need                                          | Reach for                  |
-|-----------------------------------------------|----------------------------|
-| Lint Markdown structure and style             | mdsmith                    |
-| Enforce paragraph readability or token budget | mdsmith                    |
-| Auto-generate catalogs, TOCs, includes        | mdsmith                    |
-| Reformat tables, fix trailing whitespace      | mdsmith                    |
-| Validate front-matter shape                   | either                     |
-| Query files by front-matter field             | either                     |
-| Rename a file and update all backlinks        | mdbase                     |
-| Compute backlinks for a knowledge graph       | mdbase                     |
-| Watch a folder for changes (event stream)     | mdbase                     |
-| Index 10k+ files for fast queries             | mdbase                     |
-| Run in CI as a single static binary           | mdsmith                    |
-| Edit a vault in Obsidian with typed schemas   | mdbase                     |
-| Block PRs on broken cross-file links          | mdsmith ([MDS027][mds027]) |
-| Block PRs on missing front-matter fields      | either                     |
+The table below describes which tool best serves
+each workflow **with the surfaces shipped as of
+2026-05**. None of these are permanent
+assignments; the candidate-evolution column
+points at the trigger if it exists.
+
+| Workflow                                      | Best fit today             | Candidate for the other side |
+|-----------------------------------------------|----------------------------|------------------------------|
+| Lint Markdown structure and style             | mdsmith                    | —                            |
+| Enforce paragraph readability or token budget | mdsmith                    | —                            |
+| Auto-generate catalogs, TOCs, includes        | mdsmith                    | —                            |
+| Reformat tables, fix trailing whitespace      | mdsmith                    | —                            |
+| Validate front-matter shape                   | either                     | shared today                 |
+| Query files by front-matter field             | either                     | shared today                 |
+| Rename a file and update all backlinks        | mdbase                     | mdsmith L-3 / C-4            |
+| Compute backlinks for a knowledge graph       | mdbase                     | mdsmith L-4                  |
+| Watch a folder for changes (event stream)     | mdbase                     | mdsmith P-2                  |
+| Index 10k+ files for fast queries             | mdbase                     | mdsmith P-1                  |
+| Run in CI as a single static binary           | mdsmith                    | —                            |
+| Edit a vault in Obsidian with typed schemas   | mdbase                     | mdsmith S-1..S-3             |
+| Block PRs on broken cross-file links          | mdsmith ([MDS027][mds027]) | —                            |
+| Block PRs on missing front-matter fields      | either                     | shared today                 |
+| Wikilink validation                           | mdbase                     | mdsmith L-1                  |
+| Aggregations (group / count / avg)            | mdbase                     | mdsmith Q-5                  |
+
+The "candidate" column references mini-plan IDs
+from [learn-from-mdbase.md](learn-from-mdbase.md).
+Each carries its own trigger condition.
 
 ## Status snapshot (2026-05)
 
@@ -130,35 +160,59 @@ the SQLite cache live only in mdbase.
 | Persistent state | none                              | optional SQLite cache                   |
 | Plugin system    | no (rules baked in)               | no (spec is fixed; impls vary)          |
 
-## Same problem, different layer
+## Same substrate, different surfaces
 
-A picture helps. Both tools sit on the same files but
-own different layers of behavior.
+Both tools read the same on-disk substrate.
+What each currently exposes from that substrate
+is a snapshot, not a charter.
 
 ```text
-            ┌──────────────────────────────────────┐
-            │ Markdown source files (.md)          │
-            │   YAML front matter + body content   │
-            └──────────────────────────────────────┘
-                          │
-        ┌─────────────────┼──────────────────┐
-        │                 │                  │
-        ▼                 ▼                  ▼
-   mdsmith owns:     overlap region:    mdbase owns:
-   - prose rules     - FM typing        - rename refactor
-   - structure       - FM querying      - backlink graph
-   - readability     - kind/type        - watch events
-   - catalog, TOC      assignment       - SQLite index
-   - include, build  - schema           - link traversal
-   - merge driver      validation       - CRUD operations
-   - LSP diagnostics                    - Bases queries
-   - 54 lint rules                      - migrations
+                ┌────────────────────────────────────────┐
+                │ Shared on-disk substrate (.md files)   │
+                │   YAML front matter + Markdown body    │
+                │   + cross-file link graph              │
+                └────────────────────────────────────────┘
+                                  │
+              ┌───────────────────┴────────────────────┐
+              │                                        │
+              ▼                                        ▼
+    mdsmith surfaces today                  mdbase surfaces today
+    ─────────────────────                   ─────────────────────
+    - lint diagnostics + fix                - typed CRUD operations
+    - 54 rules (prose, structure)           - field-typed schemas
+    - generated sections                    - rename + ref rewrite
+      (catalog, TOC, include, build)        - Bases query DSL
+    - CUE FM schema (MDS020)                - SQLite cache
+    - LSP: diagnostics, code actions        - watch mode events
+    - merge driver                          - LSP: completion, hover,
+    - CUE query                               go-to-definition
+
+   Each surface has a `proto.md`-style       Each surface has a typed
+   schema as the contract; both             record as the contract;
+   parse the same FM bytes.                 both parse the same FM bytes.
+
+                ┌────────────────────────────────────────┐
+                │ Candidate evolutions either way        │
+                │   see learn-from-mdbase.md +           │
+                │   aggregation-use-cases.md             │
+                └────────────────────────────────────────┘
 ```
 
-The "overlap region" is where teams running both will
-feel friction: today there is no way to share the
-schema. mdsmith reads CUE; mdbase reads its own DSL.
-[interop.md](interop.md) covers the workarounds.
+The "candidate evolutions either way" row is the
+point. mdsmith does not have wikilinks, rename
+refactor, or backlinks today; each is a candidate
+with a trigger. mdbase does not have prose
+linting, generated sections, or a fix engine
+today; the same applies in reverse if anyone
+takes that direction. The substrate supports
+both halves; the surfaces are choices, made
+under cost-vs-benefit.
+
+What teams running both feel today is friction
+in the **schema layer specifically** — both
+tools want to validate the same FM, and neither
+reads the other's schema language.
+[interop.md](interop.md) walks the workarounds.
 
 ## Reading order
 
@@ -167,20 +221,18 @@ For a tool comparison, start with
 breakdown, then [workflows.md](workflows.md) for
 daily-work feel, then [use-cases.md](use-cases.md)
 for seven concrete scenarios that show where each
-tool fits, and finally [interop.md](interop.md)
+tool fits today, and finally [interop.md](interop.md)
 for combining both.
 
 For a design exercise, read
 [learn-from-mdbase.md](learn-from-mdbase.md):
-every gap mdsmith has against mdbase, sketched as
-a mini-plan with a concrete trigger for when
-shipping it would pay. Then dive into
+every gap with a mini-plan and a trigger. Then
+dive into
 [aggregation-use-cases.md](aggregation-use-cases.md)
-for the toughest open question — when, if ever,
-mdsmith should grow an index — including a
-serious look at stateless-fast (`fzf` /
-`ripgrep`-style) approaches as an alternative to
-a SQLite cache.
+for the toughest open question — when an index
+pays — including a serious look at stateless-fast
+(`fzf` / `ripgrep`-style) approaches as an
+alternative to a persistent cache.
 
 ## Sources
 
@@ -195,12 +247,11 @@ a SQLite cache.
 - mdbase LSP (Rust):
   <https://github.com/callumalpass/mdbase-lsp>
 - mdsmith codebase as of 2026-05 (54 rules,
-  Go 1.25+ per `go.mod`, MIT). The original
-  research pass landed in the PR that introduced
-  this folder; commit history under
+  Go 1.25+ per `go.mod`, MIT). The research
+  pass landed in the PR that introduced this
+  folder; commit history under
   `docs/research/mdbase-vs-mdsmith/` is the
   authoritative trail.
 
-[file-kinds]: ../../guides/file-kinds.md
 [mds020]: ../../../internal/rules/MDS020-required-structure/README.md
 [mds027]: ../../../internal/rules/MDS027-cross-file-reference-integrity/README.md

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -37,9 +37,22 @@ Markdown stack they own.
   problem, recommended layouts, future bridge
 - [learn-from-mdbase.md](learn-from-mdbase.md) —
   systematic gap enumeration: every mdbase
-  capability mdsmith doesn't have, triaged into
-  in-scope / out-of-scope / in-flight, with a
-  per-gap mini-plan for the in-scope ones
+  capability mdsmith doesn't have, with a per-gap
+  mini-plan covering goal, sketch, surface,
+  effort, and the **trigger** under which
+  shipping it becomes worth the cost. mdsmith's
+  feature set is open; this doc maps candidates
+  rather than committing to any.
+- [aggregation-use-cases.md](aggregation-use-cases.md)
+  — six worked aggregation workloads (sprint
+  dashboard, reviewer-load report, knowledge-graph
+  backlinks, time-bucketed velocity, cross-type
+  join, real-time editor decoration), the cases
+  where a SQLite-class index pays vs. where it
+  doesn't, and a serious look at stateless-fast
+  (`fzf` / `ripgrep`-style) approaches as an
+  alternative to a persistent cache. The deepest
+  open design question for mdsmith.
 
 ## TL;DR
 
@@ -157,9 +170,15 @@ for combining both.
 
 For a design exercise, read
 [learn-from-mdbase.md](learn-from-mdbase.md):
-every gap mdsmith has against mdbase, triaged and
-sketched as a mini-plan. Twelve in-scope items
-plus rationale for the out-of-scope ones.
+every gap mdsmith has against mdbase, sketched as
+a mini-plan with a concrete trigger for when
+shipping it would pay. Then dive into
+[aggregation-use-cases.md](aggregation-use-cases.md)
+for the toughest open question — when, if ever,
+mdsmith should grow an index — including a
+serious look at stateless-fast (`fzf` /
+`ripgrep`-style) approaches as an alternative to
+a SQLite cache.
 
 ## Sources
 

--- a/docs/research/mdbase-vs-mdsmith/README.md
+++ b/docs/research/mdbase-vs-mdsmith/README.md
@@ -61,6 +61,16 @@ for each.
   background indexing with priority queries), and
   a serious look at stateless-fast (`fzf` /
   `ripgrep`-style) approaches as an alternative.
+- [query-and-types.md](query-and-types.md) —
+  in-depth comparison of the query languages
+  (CUE struct literal vs Bases-compatible DSL)
+  and the type systems. Walks what each tool
+  actually types (FM? body? filenames?), how
+  schemas compose, the expressiveness matrix
+  between the two languages, and the answer to
+  whether mdbase's type system is limited to
+  front matter (almost — with two named
+  exceptions).
 
 ## TL;DR
 

--- a/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
@@ -311,6 +311,32 @@ files, link-graph lookup), the saved work is
 construction. Validation is ~120ms. Here the
 cache pays clearly.
 
+**This applies to mdbase too.** A one-shot
+`mdbase query` invocation without watch mode
+running has the same validation cost as a
+hypothetical mdsmith with-cache run. The mdbase
+SQLite cache wins decisively only in two regimes:
+
+- **Long-lived sessions with watch mode.** The
+  watcher (spec §15) keeps the cache live with
+  the filesystem, amortizing validation across
+  many queries. First-query latency stays high,
+  but subsequent queries skip validation.
+- **Repeated queries within one process.** The
+  validation cost is paid once at startup; every
+  query in the same session benefits.
+
+For the `cd repo && mdbase query …` pattern that
+matches a CI job or an agent loop, the SQLite
+cache narrows the gap with stateless re-read
+significantly. The dominant winning case for
+SQLite over stateless is the always-on watch-mode
+deployment, which mdbase explicitly designs for
+(spec §15 mandates watch mode at conformance
+level 6) but which fits a smaller share of
+real-world workflows than the spec-first framing
+implies.
+
 ### OS file cache is the implicit warm cache
 
 Linux's page cache, macOS's UBC, Windows' system
@@ -477,6 +503,187 @@ options fall short for the access pattern, and
 `T_sync` is comfortably below `T_warm`. Until
 then, none of the persistent options earn their
 operational baggage.
+
+## What the mdbase query layer actually is
+
+A few questions about the architecture come up
+when reading the spec. The answers shape both
+the cost picture and the security posture.
+
+### Does mdbase query body content beyond links?
+
+Per spec §10, queries can reach the body via
+`file.body`, which is "the raw markdown text
+including syntax characters". Methods: substring
+match (`.contains`), regex (`.matches`). That is
+the full surface.
+
+What this means in practice:
+
+- **Yes:** "any file containing the word
+  `OIDC`" is a one-line `where` clause.
+- **No:** "any file whose first heading starts
+  with `Migration`" — there's no AST access; the
+  body is treated as a string.
+- **No:** "any file with at least three H2
+  headings" — same reason.
+- **No:** "any file with a fenced code block
+  tagged `cue`" — needs structural parsing.
+- **Partial:** "any file that mentions a project
+  name in its first paragraph" — only via regex
+  on the prefix, no first-paragraph concept.
+
+The body is a blob, not an AST. mdsmith's lint
+engine has full AST access for every file (it
+must, to lint structurally), but this isn't
+exposed to `mdsmith query` today. Surfacing it
+would be a Q-3 follow-on (see
+[learn-from-mdbase.md](learn-from-mdbase.md)),
+not a fundamental capability gap.
+
+For users who want structural body queries
+**today**, neither tool ships them. mdsmith
+could add them more cheaply because the parse
+already happens; mdbase would need to extend its
+expression language and its index schema.
+
+### Is the query language SQL?
+
+No. mdbase's query language is the expression
+DSL defined in spec §11: operators, string and
+list methods, date functions, link traversal,
+designed for compatibility with Obsidian Bases
+syntax. Users do not write SQL.
+
+Implementation-internal, an SQLite-backed impl
+likely compiles the DSL down to SQL for the
+cached path — translating
+
+```text
+status == "open" && priority >= 3
+```
+
+to roughly
+
+```sql
+SELECT path FROM files
+WHERE json_extract(fm,'$.status') = 'open'
+  AND json_extract(fm,'$.priority') >= 3
+```
+
+depending on schema. But the
+compilation is implementation-defined and not
+visible to users.
+
+This means three things:
+
+- The user-facing surface is restricted by
+  design. There is no SQL drop-through, no
+  `JOIN` syntax, no subqueries beyond the spec's
+  `asFile()` traversal (depth-limited at 10).
+- Different impls can use different storage:
+  SQLite, in-memory map, Bolt-style KV, even a
+  hypothetical PostgreSQL-backed impl. The DSL
+  stays the same.
+- Query compatibility across impls is the
+  spec's contract; storage choice is private
+  per impl.
+
+mdsmith's `mdsmith query` uses CUE struct
+literals as its query language, which is also
+not SQL but is a richer constraint language at
+the cost of less ergonomic value-comparison
+syntax. Q-7 in
+[learn-from-mdbase.md](learn-from-mdbase.md)
+explores adding a Bases-compatible front-end.
+
+### What is the security posture of the query layer?
+
+mdbase's spec is largely silent on security;
+each impl picks its own posture. The threat
+surface for an SQLite-backed impl includes:
+
+1. **Injection through the DSL.** If the impl
+   compiles user expressions to SQL by string
+   concatenation rather than parameter binding,
+   crafted expressions could escape the
+   intended query. Best practice is prepared
+   statements with `?` placeholders for
+   user-provided values; a careful impl never
+   builds SQL from raw user input. The spec
+   does not mandate this, so it depends on the
+   impl's hygiene.
+2. **Path traversal in link resolution.** Spec
+   §8 mandates path sandboxing (`..` cannot
+   escape the collection root). The
+   `path_traversal` error code in appendix C
+   confirms impls must reject escape attempts.
+   Mostly a settled question.
+3. **Resource exhaustion via traversal.** The
+   spec sets a default `asFile()` depth limit
+   of 10 and an expression nesting limit of 64
+   levels. These bound deep walks but not
+   wide ones — a query like
+   `where: any(items, x -> any(x.deps, ...))`
+   over a large list field can still be
+   expensive. Impls add their own time/row
+   budgets.
+4. **YAML attacks on the parse step.** Anchor
+   bombs ("billion laughs") and similar attacks
+   are real on YAML-FM-heavy collections. The
+   spec doesn't mandate a guard. mdsmith
+   rejects YAML anchors and aliases by default
+   (`internal/yamlutil`); an mdbase impl would
+   need to do the same for parity.
+5. **Cache file integrity.** The `.mdbase/`
+   folder (typically gitignored) holds the
+   SQLite file. If another process can write
+   to it, false rows can be injected.
+   Mitigation: the spec mandates the cache be
+   rebuildable from files alone, so users can
+   recover with `mdbase cache rebuild`. The
+   attack window is "between rebuilds".
+6. **Untrusted type definitions.** If
+   `_types/*.md` are user-controlled (e.g. a
+   PR adds a type), a hostile type file could
+   declare expensive constraints, large
+   `default_strict` impacts, or filesystem
+   patterns that grow unboundedly. Impls
+   typically treat type files as trusted; CI
+   pipelines should scope where they come from.
+
+mdsmith ran a 10-finding adversarial review
+documented in
+`docs/security/2026-04-05-adversarial-markdown.md`.
+mdbase impls (TS, Rust LSP, CLI) have not
+published equivalent reviews at the time of
+writing. For projects that ingest untrusted
+contributor Markdown, the practical guidance is
+the same as for any tool that parses untrusted
+input: validate inputs, bound resources,
+parameterize queries, sandbox paths. The spec
+helps with paths and depth; the rest is impl
+quality.
+
+### Side-by-side query-layer summary
+
+| Concern                      | mdsmith                   | mdbase                             |
+|------------------------------|---------------------------|------------------------------------|
+| User query language          | CUE struct literal        | Bases-compatible DSL (spec §11)    |
+| Body access in queries       | not yet (planned Q-3)     | yes (`file.body.contains/matches`) |
+| Body structure access        | no (lint AST is internal) | no                                 |
+| SQL surface to user          | none                      | none                               |
+| Storage abstraction          | n/a (no persistent index) | DSL → impl-defined backend         |
+| Path traversal sandbox       | yes (MDS027 + repo root)  | yes (spec §8 mandate)              |
+| YAML anchor/alias guard      | yes (mdsmith hardening)   | impl-defined (spec silent)         |
+| Resource limits in query     | rule timeouts (impl)      | depth ≤ 10, nesting ≤ 64           |
+| Adversarial review published | yes (10 findings)         | not at the time of writing         |
+
+Reading across: mdbase wins on body content
+matching (because they shipped it). mdsmith wins
+on hardened parsing today (because they did the
+review). Both share the path-sandboxing baseline
+the spec mandates.
 
 ## When the index pays
 

--- a/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
@@ -1,5 +1,9 @@
 ---
-summary: Concrete use cases for query aggregations and the toughest open question for mdsmith — whether the index that makes them fast in mdbase has a stateless equivalent. Walks the workload shapes, the SQLite payoff, and the fzf / ripgrep-style alternative.
+summary: >-
+  Concrete use cases for query aggregations and the toughest open
+  question for mdsmith — whether the index that makes them fast in
+  mdbase has a stateless equivalent. Walks the workload shapes, the
+  SQLite payoff, and the fzf / ripgrep-style alternative.
 status: 🔳
 ---
 # Aggregation use cases and the index question
@@ -254,6 +258,225 @@ shape is option 2 from
 in-memory, process-scoped index in the LSP
 server. No disk cache; the editor session keeps
 state, the CLI does not.
+
+## What an index actually costs
+
+Before deciding whether the index pays, the
+estimate above ("seconds cold without cache,
+sub-millisecond with cache") is too coarse. The
+reality has three confounders that narrow the
+band where a persistent cache wins.
+
+### Sync-check overhead is not free
+
+A persistent index has its own startup cost
+before any query runs. At minimum it must
+verify the cache is current. Two layers of check
+exist (mdbase spec §13):
+
+1. **mtime sweep.** `stat()` every file in the
+   collection, compare against the cached
+   mtime. A `stat()` is a few microseconds when
+   the dirent is in the OS cache, more on a
+   cold filesystem. 5,000 files × ~10μs ≈ 50ms.
+   50,000 files ≈ 500ms.
+2. **Hash on doubt.** When mtime is unreliable
+   (network filesystems, build tools that
+   `touch`, file-system clock skew across
+   machines), the impl falls back to hashing
+   file contents. SHA-256 of a 4KB file is
+   ~30μs of CPU, plus the read. 5,000 files ≈
+   150ms of hashing alone, more if the OS
+   cache is cold.
+
+Combined: a clean cache validation pass on a
+50,000-file corpus is on the order of a second.
+**That is in the same range as a fresh parallel
+parse of the same corpus** (see the sketch
+under "What a real benchmark plan would
+measure" below). The cache wins only when the
+saved work — parse time, link-graph build,
+aggregation — clearly exceeds the validation
+cost.
+
+For a query like A-1 (sprint dashboard, 5,800
+files, simple FM filter), the saved work is ~600ms
+of parsing and a `WHERE` clause. The validation
+cost is ~50ms. The cache wins, but by less than
+the naive analysis suggests.
+
+For a query like A-3 (backlinks panel, 12,000
+files, link-graph lookup), the saved work is
+~2 seconds of full-body parse plus link-edge
+construction. Validation is ~120ms. Here the
+cache pays clearly.
+
+### OS file cache is the implicit warm cache
+
+Linux's page cache, macOS's UBC, Windows' system
+cache — every modern OS keeps recently-read
+files in RAM. The first `mdsmith check` reads
+files from disk; the second reads them from
+memory at memcpy speed.
+
+For a typical project this matters more than
+any application-level cache:
+
+- A 50MB vault fits entirely in OS cache on any
+  development machine. Once read, repeated reads
+  are RAM-speed (≈10GB/s) for as long as the
+  pages stay resident.
+- The pages stay resident until evicted (LRU
+  pressure, typically minutes-to-hours of idle)
+  or the file is modified (the dirty page is
+  flushed and re-read on next access).
+- `stat()` results are cached the same way. A
+  warm `stat()` is ~1μs.
+
+The implication: **mdsmith's "stateless re-read"
+is, in practice, a re-read from RAM**, not from
+disk, for any corpus that fits in available
+memory and any session that runs more than once.
+A persistent application cache duplicates work
+the OS already does for free. Where it wins is
+*parsing* work — the conversion from raw bytes
+to a structured index — which the OS does not
+cache.
+
+So the question shifts: at what corpus size, and
+for what workload, does the parsing cost dominate
+to the point where caching the parse result pays
+for the cache's own validation overhead?
+
+### Background indexing with priority queries
+
+A third option sits between "rebuild on every
+run" and "fully persisted index": **build the
+index in memory at startup, in the background,
+while queries run against the partial state and
+get hoisted in priority.**
+
+The pattern is well-trodden in IDEs.
+IntelliJ and the TypeScript language server
+both work this way: the editor opens
+immediately, indexing starts in the background,
+and any feature that needs not-yet-indexed data
+either jumps the queue (re-prioritizing the
+relevant subdirectory) or falls back to a
+slower path until the index catches up.
+
+For mdsmith the shape would be:
+
+- **Cold start.** Spawn a background indexer
+  goroutine that walks the workspace and parses
+  files in priority order: `kind:` matches first,
+  then files referenced by an open query, then
+  the rest.
+- **Query arrives.** The query thread checks
+  the in-progress index. Files it needs but
+  doesn't find get pushed to the front of the
+  indexer's queue. Once parsed, the result is
+  returned.
+- **Tail.** The indexer keeps building until
+  the workspace is fully indexed or the process
+  exits.
+
+This works **only when the process is
+long-lived** — an LSP session, an
+`mdsmith watch` daemon (P-2), or an interactive
+REPL. For a one-shot CLI command (`mdsmith query
+... && exit`) the process exits before the
+background work finishes, so the value is
+small. The pattern is therefore not a
+replacement for stateless one-shot, but an
+extension of the in-memory in-LSP option from
+the P-1 alternatives table.
+
+What it buys:
+
+- **Apparent cold-start latency drops.** The
+  user sees the first query result fast even on
+  a 50,000-file workspace, because the indexer
+  does not need to be complete to answer
+  point queries.
+- **No persistent state.** The whole index lives
+  in process memory. Restart and rebuild; no
+  staleness, no schema migration, no `.mdbase/`
+  on disk.
+- **Iteratively useful.** A workspace that's
+  10% indexed can already answer 90% of "find
+  this kind" queries when that kind is what was
+  prioritized.
+
+What it costs:
+
+- Indexer state machine and priority queue
+  (modest implementation work, well-understood
+  pattern).
+- Memory bounded by workspace size; mdsmith's
+  existing 512MB GOMEMLIMIT covers most cases.
+- More complex than "rebuild fresh per query",
+  less complex than a persistent on-disk store.
+
+### What this means for the trigger
+
+The trigger for adding a persistent on-disk
+cache (P-1 in
+[learn-from-mdbase.md](learn-from-mdbase.md))
+is therefore narrower than "cold-start cost
+dominates". It needs to survive three filters
+in sequence:
+
+1. **OS-cache filter.** Repeated runs on a
+   stable corpus are already fast through the
+   page cache. A persistent cache helps only
+   when the *parsed* index — not the raw bytes
+   — is what's expensive to rebuild. Confirm by
+   profiling the second invocation, not the
+   first.
+2. **Sync-check filter.** The savings from
+   skipping parse work must clearly exceed the
+   cost of validating the cache against the
+   filesystem. This is the gap between "naive
+   re-parse takes 1s" and "cache validation
+   takes 0.5s".
+3. **In-memory-with-priority filter.** A
+   long-lived process can already get most of
+   the latency benefit with background indexing
+   in RAM, without the operational cost of an
+   on-disk cache. Confirm the workload genuinely
+   needs cross-process freshness or restart-time
+   warmth.
+
+Surviving all three is a higher bar than "cold
+start is slow on a big repo". The wiggle room
+is real and worth using before reaching for
+persistent state.
+
+### What a real benchmark plan would measure
+
+For the choice to be informed rather than
+guessed, the next step is concrete numbers on a
+real corpus. A benchmark plan would compare
+five configurations on synthetic 1k / 10k / 50k
+file workspaces:
+
+| Config                                | Cold start | 2nd run | Notes                             |
+|---------------------------------------|------------|---------|-----------------------------------|
+| stateless re-read, OS cache cold      | T_cold     | —       | upper bound; rare in practice     |
+| stateless re-read, OS cache warm      | T_warm     | T_warm  | the realistic baseline            |
+| in-memory index, lazy build, in-LSP   | T_warm     | <1ms    | for long-lived processes          |
+| in-memory index with priority queries | <T_warm    | <1ms    | ditto, with apparent latency win  |
+| persistent on-disk cache, mtime sync  | T_sync     | <1ms    | T_sync ≈ stat + index lookup      |
+| persistent on-disk cache, hash sync   | T_hash     | <1ms    | T_hash > T_sync, paranoid setting |
+
+The decision lands when `T_warm` for the
+relevant workload exceeds an interactive
+threshold (typically 100ms), the in-memory
+options fall short for the access pattern, and
+`T_sync` is comfortably below `T_warm`. Until
+then, none of the persistent options earn their
+operational baggage.
 
 ## When the index pays
 

--- a/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
@@ -710,6 +710,64 @@ A few questions about the architecture come up
 when reading the spec. The answers shape both
 the cost picture and the security posture.
 
+### Does the cache store the full body?
+
+Spec §13 lists what the cache should track: file
+metadata, parsed front matter, type assignments,
+field values, **link graphs**, and **full-text
+indexes**. It does not mandate "store the entire
+body verbatim in a SQL row" — only that an FTS
+index exists and that the cache is rebuildable
+from files alone.
+
+An SQLite-backed impl has two reasonable shapes,
+both spec-conformant:
+
+- **Content-in-FTS.** The full body lives inside
+  an FTS5 virtual table. Cache size ≈ corpus
+  size plus index. All body queries answered
+  locally in SQLite.
+- **External-content FTS.** FTS5 maintains the
+  inverted index only; bodies stay on disk.
+  Cache is much smaller. `file.body.contains`
+  hits the index first; if the impl needs a
+  context snippet, it re-reads the file.
+
+Neither is mandated. The TS reference impl's
+choice is an implementation detail not pinned
+by the spec.
+
+What this means for the workloads in this doc:
+
+- **A-3 backlinks.** The link graph is a
+  derived structure — `(source, target, anchor,
+  kind)` rows — not body content. An impl can
+  cache the link graph without storing body
+  bytes at all. Storage mode is irrelevant.
+- **A-6 editor decoration.** Needs the target's
+  `title` (front matter), not body. FM cache
+  alone is enough.
+- **Q-3 body full-text search.** This is where
+  body storage matters. FTS-only keeps the
+  cache small; inline-content trades disk for
+  fewer subsequent reads.
+
+Building the cache reads every body once
+regardless of mode (you cannot index without
+reading the bytes). The first cold build cost
+is identical between the two shapes; steady-
+state size and re-read patterns differ.
+
+For mdsmith's choice if it ever lands a cache
+(P-1 in
+[learn-from-mdbase.md](learn-from-mdbase.md)),
+the same trade-off applies. Body-only workloads
+that look like A-3 or A-6 don't need bodies in
+the cache at all — caching the link graph and
+FM is enough. Q-3-like workloads do need an FTS
+index; whether bodies inline or external is a
+size-vs-IO call.
+
 ### Does mdbase query body content beyond links?
 
 Per spec §10, queries can reach the body via

--- a/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
@@ -768,6 +768,177 @@ FM is enough. Q-3-like workloads do need an FTS
 index; whether bodies inline or external is a
 size-vs-IO call.
 
+### What the reference impls actually do
+
+The spec is permissive about cache architecture.
+There are two reference implementations of mdbase
+today, and they make materially different
+choices. Both affect the cost estimates above.
+
+**TypeScript impl** ([`mdbase`][mdbase-ts]) —
+used by `mdbase-cli`.
+
+Reading [`src/cache/async-store.ts`][async-store]:
+
+- **SQLite via `sql.js` (WebAssembly).** The
+  cache uses [`sql.js`][sqljs], not a native
+  driver. The entire database loads into RAM at
+  process start, mutates in-memory, and writes
+  back on `flush()`/`close()`. No incremental
+  disk writes; no `mmap`.
+- **Schema declares more than it populates.**
+  Tables: `files` (path, mtime_ms, size,
+  content_hash, frontmatter_json, body,
+  types_json), plus `field_values` (denormalized
+  FM with text/number/int columns and indexes),
+  `links` (edge table), `tags`, and `meta`. The
+  standard `upsertFile` writes only the `files`
+  row. `field_values`, `links`, and `tags` are
+  scaffolded but not populated by the basic
+  cache writer.
+- **Body inline, no FTS5.** Body is a TEXT
+  column on `files`. Body queries scan linearly
+  through in-memory strings.
+- **Staleness via mtime_ms + size.**
+  `content_hash` exists as a column but is not
+  populated or checked in the code paths
+  reviewed.
+- **Link index built per query.** Each query
+  that needs backlinks calls `buildLinkIndex`
+  against the in-memory file cache, walks every
+  file's typed link fields and body links, and
+  builds a `Map<targetPath, Set<sourcePath>>`
+  from scratch. The on-disk `links` table is
+  not consulted.
+
+**Rust impl** ([`mdbase-rs`][mdbase-rs]) — used
+by `mdbase-lsp`.
+
+Reading [`src/cache/schema.sql`][rs-schema] and
+[`src/cache/indexer.rs`][rs-indexer]:
+
+- **Native SQLite via `rusqlite` (bundled).**
+  Real persistent SQLite file with incremental
+  writes; no full memory load. This is the
+  shape that makes "persistent cache" earn its
+  name.
+- **Schema actively populated.** Tables: `files`
+  (path, mtime_ns, ctime_ns, size,
+  frontmatter_json, body, effective_json,
+  parse_error), `file_types` (path, type_name),
+  `links` (source_path, target_path, location,
+  field, raw_target), `unique_values` (type +
+  field + value + path, for ID uniqueness),
+  `meta`. The indexer writes to **all** of
+  these on update.
+- **Body inline, no FTS5.** Same as TS.
+- **Staleness via mtime_ns** (nanosecond
+  precision; TS uses ms). No content hash.
+- **Effective FM cached.** `effective_json`
+  stores the merged FM with defaults applied,
+  so reads skip recomputing defaults.
+- **Link table actively used.** Backlinks can be
+  served from the indexed `links(target_path)`
+  table — a B-tree probe rather than a per-
+  query rebuild.
+
+**Side-by-side at the storage layer.** The two impls in one table:
+
+| Concern                 | TS impl (`mdbase`)           | Rust impl (`mdbase-rs`)              |
+|-------------------------|------------------------------|--------------------------------------|
+| SQLite binding          | `sql.js` (WebAssembly)       | `rusqlite` with bundled SQLite       |
+| Persistence model       | In-memory; flush on close    | Incremental disk writes              |
+| Body storage            | Inline TEXT column           | Inline TEXT column                   |
+| FTS index               | None                         | None                                 |
+| Staleness               | `mtime_ms` + `size`          | `mtime_ns` (+ separate ctime column) |
+| Content hash            | Column exists, unused        | Not in schema                        |
+| Effective FM cached     | No (recomputed)              | Yes (`effective_json`)               |
+| `files` table populated | Yes                          | Yes                                  |
+| `links` table populated | No (rebuilt per query)       | Yes                                  |
+| `file_types` populated  | n/a (uses `types_json` blob) | Yes (denormalized rows)              |
+| `unique_values`         | n/a                          | Yes (for ID uniqueness checks)       |
+| Body queries            | Linear scan in RAM           | Linear scan via SQL                  |
+
+**What this means for the cost estimates above.** Walking the worked use cases:
+
+- **A-3 backlinks at 12,000 files.** The
+  "indexed edge lookup, sub-millisecond" claim
+  fits the **Rust impl** (B-tree on
+  `links(target_path)`). The **TS impl** rebuilds
+  the link index per query from in-memory FM +
+  body — fast at RAM speed but tens of
+  milliseconds, not sub-ms. The two impls have
+  noticeably different latency on this workload.
+- **A-6 editor decoration.** The Rust LSP can
+  serve title lookups via direct table read on
+  `file_types`/`files`. The TS impl pattern
+  (rebuild per query) is fine for occasional
+  decoration but not per-keystroke.
+- **Q-3 body full-text search.** Linear scan
+  either way — both impls store body inline
+  with no FTS5. Acceptable for ad-hoc queries,
+  not for interactive use at scale.
+- **Cache size.** Both store body inline; cache
+  size ≈ corpus size + FM/types overhead. TS at
+  10,000 files of 5KB average = ~50MB; Rust
+  similar.
+- **Cold start to first query.** TS loads the
+  whole cache file into RAM (~hundreds of ms
+  at 50MB plus `sql.js` WASM init). Rust opens
+  the SQLite file and runs queries against it
+  via the OS page cache; cold start is much
+  cheaper.
+
+A different conforming impl — native SQLite
+with FTS5, or a non-SQL store, or content-
+addressed loose objects — would have other
+trade-offs. The cost analysis in the rest of
+this doc was written against the spec's
+permissive picture; the actual impls sit at
+two distinct points on the persistence /
+indexing spectrum.
+
+**For mdsmith's hypothetical cache** (P-1),
+both impls are useful prior art:
+
+- **TS-shape (in-memory + flush-on-close).** A
+  persistent file that's fully loaded at
+  startup. Operationally close to option 2
+  (in-memory) in the P-1 alternatives table
+  plus a save-on-exit step. Doesn't need
+  SQLite's machinery; could be written as a
+  Go `gob` blob or BoltDB.
+- **Rust-shape (incremental persistent
+  SQLite).** Real database with indexed access
+  and small-disk-write update model. Closer to
+  option 5 in the P-1 alternatives table. Pays
+  for the cost of indexed joins, FTS5 if added,
+  and concurrent reader/writer separation.
+
+The choice between them depends on which
+workloads matter and whether incremental writes
+are needed during a session. mdsmith's existing
+LSP-resident config cache already follows the
+in-memory pattern; extending that to a link
+graph and FM map (without persistence) is the
+cheapest extension. Persistence — TS-shape or
+Rust-shape — is a separate decision triggered
+by cross-session warmth needs (see the trigger
+analysis in
+[learn-from-mdbase.md](learn-from-mdbase.md)).
+
+[mdbase-ts]: https://github.com/callumalpass/mdbase
+[mdbase-rs]: https://github.com/callumalpass/mdbase-rs
+[async-store]:
+  https://github.com/callumalpass/mdbase/blob/main/src/cache/async-store.ts
+[query-engine]:
+  https://github.com/callumalpass/mdbase/blob/main/src/operations/query-engine.ts
+[rs-schema]:
+  https://github.com/callumalpass/mdbase-rs/blob/main/src/cache/schema.sql
+[rs-indexer]:
+  https://github.com/callumalpass/mdbase-rs/blob/main/src/cache/indexer.rs
+[sqljs]: https://github.com/sql-js/sql.js
+
 ### Does mdbase query body content beyond links?
 
 Per spec §10, queries can reach the body via

--- a/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
@@ -1,0 +1,429 @@
+---
+summary: Concrete use cases for query aggregations and the toughest open question for mdsmith — whether the index that makes them fast in mdbase has a stateless equivalent. Walks the workload shapes, the SQLite payoff, and the fzf / ripgrep-style alternative.
+status: 🔳
+---
+# Aggregation use cases and the index question
+
+mdbase's strongest argument for a SQLite cache is
+aggregation: grouping, counting, summing, joining
+across typed records at vault scale. mdsmith does
+not have aggregation today and does not have a
+persistent index. This document walks the use
+cases, looks at when the SQLite payoff is real
+versus marginal, and explores whether mdsmith
+could serve the same workloads stateless — the
+way `fzf` and `ripgrep` do for their domains.
+
+The point is to have a concrete picture of the
+workload before committing to (or against) an
+index. Triggers in
+[learn-from-mdbase.md](learn-from-mdbase.md)
+mention this doc; this is where they get
+detailed.
+
+## Aggregation workload shapes
+
+Aggregation is not one thing. Five shapes recur
+across teams that adopt mdbase or want to:
+
+| Shape       | Example                                           | Cost driver              |
+|-------------|---------------------------------------------------|--------------------------|
+| count       | "How many open tasks per assignee?"               | scan all matching FM     |
+| sum / avg   | "Total estimated hours per project."              | scan + arithmetic        |
+| top-N       | "Five oldest unresolved bugs."                    | scan + sort              |
+| join        | "List tasks whose assignee.role = 'reviewer'."    | scan + cross-file lookup |
+| time bucket | "Plans completed per week over the last quarter." | scan + date math + group |
+
+mdbase serves all five with a SQL query against
+its index. mdsmith would have to scan files per
+query today; with an index, it could serve them
+the same way. With a stateless-fast approach (see
+section 5), four out of five are reachable
+without state.
+
+## Worked use cases
+
+### A-1: Sprint dashboard
+
+**Setting.** Engineering team tracks tasks as
+Markdown files under `tasks/`. ~800 active tasks,
+~5,000 historical. CI runs a "sprint dashboard"
+job after every push that produces a status
+summary as JSON, fed into a Slack notification.
+
+**Query.** The query shape:
+
+```yaml
+types: [task]
+where: status == "in-progress"
+group_by: assignee
+aggregate:
+  - count
+  - field: priority
+    op: avg
+order_by: count desc
+```
+
+**What it produces.** A two-column table:
+assignee, in-progress task count, average
+priority. ~10 rows.
+
+**Cost driver.** 5,800 files scanned, 800
+matching, 800 grouped. Per-file work is parsing
+the FM (~1ms cold). 5.8 seconds cold, 50ms warm.
+
+**With mdbase.** SQLite index makes this a single
+`SELECT assignee, COUNT(*), AVG(priority) FROM tasks
+WHERE status='in-progress' GROUP BY assignee`.
+Sub-millisecond.
+
+**With mdsmith stateless.** Parallel re-read
+through every `.md` file in `tasks/`, filter by
+FM, count and average in-process. With ripgrep-
+class IO and FM parsing in Go, ~600ms cold on
+modern hardware. JSON output piped to the next
+step.
+
+**Verdict.** Stateless is fine for a CI job
+running once per push. The 600ms is hidden in
+the test pipeline.
+
+### A-2: Reviewer load report
+
+**Setting.** Documentation team. ~3,000 RFCs.
+Weekly report: "Show all RFCs whose author or
+reviewer is X, grouped by status, with the
+five-most-recent in each group."
+
+**Query.** The query shape:
+
+```yaml
+types: [rfc]
+where: 'author == "alice" || "alice" in reviewers'
+group_by: status
+aggregate:
+  - count
+  - field: created
+    op: max
+top_per_group: 5
+order_by: created desc
+```
+
+**Cost driver.** 3,000 files scanned, 200
+matching, 200 grouped, top-5 per group. Per-file
+work the same ~1ms.
+
+**With mdbase.** Index hit on the `author`
+column, secondary scan of the `reviewers` array,
+GROUP BY in SQL. Sub-second even cold; the cache
+warms across queries.
+
+**With mdsmith stateless.** Same parallel re-read
+shape. ~300ms cold for the filter alone; sort and
+top-5 per group in process. Total ~400ms.
+
+**Verdict.** Stateless still works but the gap is
+narrowing. At 30,000 RFCs the per-query cost
+(~3 seconds) starts to feel slow for an interactive
+dashboard.
+
+### A-3: Knowledge-graph backlinks at scale
+
+**Setting.** Research lab vault. 12,000 notes
+with dense `[[wikilinks]]`. Researcher opens a
+paper note and wants the backlinks panel:
+"What cites this paper?" In milliseconds.
+
+**Query.** The query shape:
+
+```yaml
+backlinks_to: notes/chen-2024.md
+group_by: tag
+order_by: count desc
+limit: 50
+```
+
+**Cost driver.** 12,000 files; the link graph is
+the load-bearing structure. Each query needs an
+edge lookup `(target → sources)` and then a group
+by tag.
+
+**With mdbase.** Indexed `(target_path, source_path)`
+edge table. The lookup is a single B-tree probe;
+the group-by uses the cached tag column.
+Sub-millisecond.
+
+**With mdsmith stateless.** Re-read 12,000 files
+to rebuild the link graph per query. Even with
+parallel IO and fast parsing, ~2 seconds cold.
+Unacceptable for an interactive backlinks panel.
+
+**Verdict.** Stateless does not work at this
+scale for interactive use. This is the case
+where the SQLite-class index pays.
+
+### A-4: Time-bucketed velocity
+
+**Setting.** Plan tracker. ~500 plans across
+two years. Quarterly review: "Plans completed
+per month, last 12 months."
+
+**Query.** The query shape:
+
+```yaml
+types: [plan]
+where: status == "✅" && completed_at >= today() - "365d"
+group_by: time_bucket(completed_at, "1M")
+aggregate: count
+order_by: time_bucket asc
+```
+
+**Cost driver.** 500 files; light. The time-
+bucket logic is the interesting part.
+
+**With mdbase.** Date functions in expressions
+plus GROUP BY on the bucket key. Trivial in SQL.
+
+**With mdsmith stateless.** Parallel parse, in-
+process bucket, count. ~50ms even cold.
+
+**Verdict.** Stateless wins. The corpus is
+small, the aggregation is light. Adding a cache
+would only slow things down.
+
+### A-5: Cross-type join
+
+**Setting.** Mixed product wiki. RFC type lists
+its `owner: alice`. Task type also has
+`assignee: alice`. Query: "List Alice's open RFCs
+with at least one in-progress related task."
+
+**Query.** The query shape:
+
+```yaml
+types: [rfc]
+where: |
+  owner == "alice" &&
+  status == "open" &&
+  any(related_tasks, t -> t.asFile().status == "in-progress")
+```
+
+**Cost driver.** ~200 RFCs, ~5,000 tasks. Each
+matching RFC triggers per-task lookups on
+`related_tasks`, which is a list of paths.
+
+**With mdbase.** The `asFile()` call goes through
+the index: link target → cached FM → status
+column. ~10 lookups per RFC, all O(log n).
+Total: 200 × 10 = 2,000 index hits. Fast.
+
+**With mdsmith stateless.** Re-read all RFCs
+(filter), then re-read each related task (200 ×
+~3 hops × ~1ms parse = 600ms additional). Total
+~1 second cold. Acceptable but not great.
+
+**Verdict.** Marginal. At this scale, stateless
+is on the edge. Once joins go more than two
+hops or the corpus doubles, the index pays.
+
+### A-6: Real-time editor decoration
+
+**Setting.** Researcher in VS Code wants
+inline decoration: every wikilink shows the
+target's title in light text after the link.
+Updates as files change.
+
+**Query.** Per visible link, fetch
+`asFile().title`. Hundreds of times per file
+open, called from the LSP server.
+
+**Cost driver.** Latency. 50ms feels slow;
+200ms is unacceptable.
+
+**With mdbase.** Index-backed lookup.
+Sub-millisecond per resolution.
+
+**With mdsmith stateless.** Per-resolution disk
+read. Even with read coalescing, 5–10ms per
+target file. With 100 visible links: 500ms-1s of
+work per editor open. Bad.
+
+**Verdict.** This is an LSP case. The right
+shape is option 2 from
+[learn-from-mdbase.md §P-1](learn-from-mdbase.md):
+in-memory, process-scoped index in the LSP
+server. No disk cache; the editor session keeps
+state, the CLI does not.
+
+## When the index pays
+
+Reading across the six cases, three signals
+predict when an index earns its cost:
+
+1. **Interactive latency.** A query that runs
+   inside a UI (LSP decoration, backlinks panel,
+   editor hover) needs <100ms response. Stateless
+   re-read gets there only at small file counts.
+2. **Repeated queries on a stable corpus.** A CI
+   job runs once per push and caches don't help.
+   A researcher running queries all day in a
+   stable vault sees the cache pay every minute.
+3. **Cross-file joins beyond one hop.** Single-
+   file queries scale linearly with the corpus.
+   Joins multiply the cost; an index turns each
+   hop from O(n) to O(log n).
+
+The cross-product:
+
+| Use case             | Latency need | Repeated? | Joins?  | Index pays? |
+|----------------------|--------------|-----------|---------|-------------|
+| A-1 sprint dashboard | CI (seconds) | no        | no      | no          |
+| A-2 reviewer load    | weekly job   | no        | one hop | borderline  |
+| A-3 backlinks panel  | UI (<100ms)  | yes       | one hop | yes         |
+| A-4 velocity         | report (~s)  | no        | no      | no          |
+| A-5 cross-type join  | report (~s)  | no        | 2+ hops | borderline  |
+| A-6 editor decor     | UI (<50ms)   | yes       | one hop | yes         |
+
+Two of six clearly need an index; two clearly
+don't; two sit on the edge. The interesting
+design question for mdsmith is whether the two
+clear cases (A-3 backlinks panel, A-6 editor
+decoration) can be served by an in-memory index
+inside the LSP server without ever shipping a
+persistent on-disk cache.
+
+## Stateless-fast: the `fzf` / `ripgrep` model
+
+Both `fzf` and `ripgrep` are well known for being
+fast without persistent state. They work because
+of three properties:
+
+1. **Aggressive parallelism.** Both tools fan out
+   across all available cores. ripgrep walks the
+   filesystem with concurrent producers and
+   consumers; fzf processes input lines in
+   parallel.
+2. **Tight inner loops.** ripgrep's regex engine
+   uses Aho-Corasick and Teddy SIMD matching;
+   fzf's scoring is hand-tuned. Per-line cost
+   is in the tens of nanoseconds.
+3. **No fsync, no parsing of structure.**
+   ripgrep matches bytes, not ASTs. fzf doesn't
+   know what it's matching. The work that's
+   skipped is the work that would need an index.
+
+For an FM-aware tool like mdsmith, the analogy
+holds for parts of the workload:
+
+**What mdsmith could ripgrep-class.** Workloads where the stateless model holds:
+
+- **Body full-text search (Q-3).** Already
+  ripgrep's domain; mdsmith could shell out, or
+  embed `regexp/syntax` and walk files
+  in parallel.
+- **FM filtering (Q-1, Q-2, A-1, A-4).** Reading
+  YAML between `---` delimiters and matching a
+  small struct against a CUE struct is cheap if
+  parallelized. Estimate: 10,000 files in
+  ~500ms cold on a modern laptop.
+- **Aggregations on FM only (A-1, A-4).** Group
+  and count after the parallel parse. The
+  aggregation itself is microseconds; the parse
+  dominates.
+
+**What ripgrep-class hits limits on.** Workloads
+where statelessness breaks down:
+
+- **Backlinks at scale (A-3).** Building the link
+  graph means parsing every link in every body,
+  not just FM. ~10× more parse work. At 10,000
+  files this is 5+ seconds cold — too slow for an
+  interactive panel.
+- **Multi-hop joins (A-5).** Each hop multiplies
+  the work. Two hops over 10,000 files is
+  50+ seconds without a cache.
+- **Editor-LSP decoration (A-6).** Per-keystroke
+  parsing is hopeless at any corpus size. The
+  LSP server must keep state.
+
+**The pattern.** Stateless-fast handles workloads
+where each query touches each file exactly once
+and the per-file work is small (<1ms). It breaks
+down where the same data is touched repeatedly
+(LSP decoration), where the access pattern is
+graph-shaped (joins, backlinks at scale), or
+where work per file is heavy (full-body parse).
+
+## A pragmatic path for mdsmith
+
+These design choices are open. The shape that
+falls out of the workload analysis is:
+
+1. **Make the stateless path as fast as possible
+   first.** Parallel walk via the existing
+   `internal/discovery` package, FM parse with
+   `gopkg.in/yaml.v3`, in-process filtering and
+   aggregation. Target: 10,000 files / 500ms
+   cold. This lifts A-1, A-2, A-4 without any
+   new state.
+2. **Add an in-memory link graph in the LSP
+   server.** Plan 131 already builds toward
+   this. Extending the LSP's process-scoped
+   state to cover backlinks (L-4) and decoration
+   (A-6) costs nothing in the CLI workflow and
+   handles the two cases that need <100ms
+   response.
+3. **Defer persistent on-disk index until a real
+   trigger fires.** Real profiling on a real
+   corpus showing CLI cold-start dominates. Or
+   a feature like Q-5 aggregations whose joins
+   make stateless infeasible at the user's
+   scale. When it does fire, the choice between
+   BoltDB-style and SQLite is a measurable one,
+   not a guess.
+
+The summary slogan, if one helps: **stateless by
+default; in-memory in the LSP; persistent only
+when the workload proves it.**
+
+This is not a commitment. Triggers in
+[learn-from-mdbase.md](learn-from-mdbase.md)
+might fire in any order, and a real user case can
+override any of these choices. The point of
+walking the workloads here is to make sure the
+choice is informed when it lands.
+
+## Open questions
+
+A real plan to act on any of this would have to
+settle:
+
+- **What is the actual cold-start cost today?**
+  Benchmarks on a 1k / 10k / 50k file synthetic
+  corpus would replace the estimates above.
+- **Does parallel FM-only parse hit IO or CPU
+  limits first?** Determines whether mmap or
+  fanout-readers is the right shape.
+- **Can the LSP in-memory graph subsystem be
+  cleanly factored so that, if a CLI cache is
+  ever added, both share one builder?** Reuse
+  matters more than the storage choice.
+- **What's the corpus-size threshold where each
+  workload shape (A-1..A-6) tips into needing
+  the index?** Should be measured, not guessed.
+- **Is there a half-step: an "ephemeral"
+  in-memory cache mode for one CLI invocation
+  that runs many queries (e.g., a script
+  block)?** Cheap to add, useful in agent loops.
+
+## Sources
+
+- [`fzf` README on architecture and SIMD scoring][fzf]
+- [`ripgrep` "How fast is it" notes][rg]
+- mdbase spec §10 (querying), §13 (caching), and
+  appendix A.2 (task-management worked example)
+- mdsmith codebase 2026-05: `internal/discovery`,
+  `internal/lint/file.go`, `internal/query/query.go`
+
+[fzf]: https://github.com/junegunn/fzf
+[rg]: https://github.com/BurntSushi/ripgrep/blob/master/FAQ.md

--- a/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/aggregation-use-cases.md
@@ -4,7 +4,6 @@ summary: >-
   question for mdsmith — whether the index that makes them fast in
   mdbase has a stateless equivalent. Walks the workload shapes, the
   SQLite payoff, and the fzf / ripgrep-style alternative.
-status: 🔳
 ---
 # Aggregation use cases and the index question
 
@@ -45,6 +44,45 @@ the same way. With a stateless-fast approach (see
 section 5), four out of five are reachable
 without state.
 
+## Operational mode matters more than tool choice
+
+Each use case below names an **operational mode**
+assumption before quoting numbers, because the
+mode dominates the comparison far more than the
+tool. There are two modes:
+
+- **Cold-start mode.** A one-shot CLI invocation
+  in a fresh process. CI runners (which spin up
+  ephemeral containers per push), agent loops
+  that exec subcommands, and ad-hoc terminal use
+  all fall here. No persistent state survives
+  between runs except what is on disk and in
+  the OS file cache.
+- **Long-lived-session mode.** A running process
+  that handles many queries: an LSP server
+  attached to an editor, a `mdbase watch`
+  daemon, an interactive REPL. State (parsed
+  AST, link graph, FM index) survives between
+  queries.
+
+Both tools can be evaluated under either mode.
+The analyses below compare like-with-like:
+
+| Mode               | mdbase                                           | mdsmith                                                                                  |
+|--------------------|--------------------------------------------------|------------------------------------------------------------------------------------------|
+| Cold start         | validate cache (stat + maybe hash) → query       | parse files in parallel → query                                                          |
+| Long-lived session | watch mode keeps cache live → query is index hit | in-memory index built lazily / on-demand → query is index hit (P-1 / plan 131 territory) |
+
+The persistent SQLite cache is **not** what
+makes mdbase fast in long-lived mode; the live
+in-memory state is. The cache exists to bridge
+between sessions (or to skip parsing during
+validation). Granting a running server to mdbase
+means granting one to mdsmith too — and once
+both have one, the parse work has already been
+done in either tool. The numbers below reflect
+this.
+
 ## Worked use cases
 
 ### A-1: Sprint dashboard
@@ -54,6 +92,11 @@ Markdown files under `tasks/`. ~800 active tasks,
 ~5,000 historical. CI runs a "sprint dashboard"
 job after every push that produces a status
 summary as JSON, fed into a Slack notification.
+
+**Mode assumption.** Cold start. CI runners are
+ephemeral containers; cache state from previous
+runs does not survive. Both tools start fresh
+on every push.
 
 **Query.** The query shape:
 
@@ -72,14 +115,19 @@ order_by: count desc
 assignee, in-progress task count, average
 priority. ~10 rows.
 
-**Cost driver.** 5,800 files scanned, 800
-matching, 800 grouped. Per-file work is parsing
-the FM (~1ms cold). 5.8 seconds cold, 50ms warm.
+**Cost driver.** 5,800 files. Per-file work is
+parsing the FM (~100μs–1ms warm CPU).
 
-**With mdbase.** SQLite index makes this a single
-`SELECT assignee, COUNT(*), AVG(priority) FROM tasks
-WHERE status='in-progress' GROUP BY assignee`.
-Sub-millisecond.
+**With mdbase, cold start.** No prior cache.
+Either build the cache from scratch (~600ms of
+parse work, comparable to a fresh re-read) and
+then run the SQL, or skip the cache and walk
+files. Total wall time roughly the same as
+mdsmith stateless. **The "sub-millisecond" SQL
+query only applies once the cache exists** — and
+that requires either a previous run whose cache
+survived (rare in CI) or a long-lived process
+that built the index earlier.
 
 **With mdsmith stateless.** Parallel re-read
 through every `.md` file in `tasks/`, filter by
@@ -88,9 +136,24 @@ class IO and FM parsing in Go, ~600ms cold on
 modern hardware. JSON output piped to the next
 step.
 
-**Verdict.** Stateless is fine for a CI job
-running once per push. The 600ms is hidden in
-the test pipeline.
+**With either tool in long-lived mode.** Not
+applicable to this use case — CI runs are
+one-shot. If the team moved to a long-running
+sprint-dashboard service that watched the
+`tasks/` folder, both tools could serve queries
+from a warm in-memory state in <1ms each. The
+incremental cost of running a service for this
+purpose is operationally larger than the
+one-shot CI cost.
+
+**Verdict.** Roughly equivalent for the CI use
+case. ~600ms parse on either side is hidden in
+the test pipeline. Switching to mdbase does not
+buy speed here unless the team also adopts a
+long-running indexer, at which point mdsmith's
+in-memory equivalent (P-1 option 2 in
+[learn-from-mdbase.md](learn-from-mdbase.md))
+would close the gap symmetrically.
 
 ### A-2: Reviewer load report
 
@@ -98,6 +161,9 @@ the test pipeline.
 Weekly report: "Show all RFCs whose author or
 reviewer is X, grouped by status, with the
 five-most-recent in each group."
+
+**Mode assumption.** Cold start. Weekly cron
+job in CI; no surviving cache.
 
 **Query.** The query shape:
 
@@ -113,23 +179,37 @@ top_per_group: 5
 order_by: created desc
 ```
 
-**Cost driver.** 3,000 files scanned, 200
-matching, 200 grouped, top-5 per group. Per-file
-work the same ~1ms.
+**Cost driver.** 3,000 files. Per-file work the
+same ~100μs–1ms.
 
-**With mdbase.** Index hit on the `author`
-column, secondary scan of the `reviewers` array,
-GROUP BY in SQL. Sub-second even cold; the cache
-warms across queries.
+**With mdbase, cold start.** Cache build (~300ms)
 
-**With mdsmith stateless.** Same parallel re-read
-shape. ~300ms cold for the filter alone; sort and
-top-5 per group in process. Total ~400ms.
++ SQL query (~1ms) ≈ 300ms total. If the runner
+preserves `.mdbase/` between weekly runs, only
+files changed since last week need re-parse;
+weekly delta on a stable corpus is small, so
+~50ms validation + 1ms query ≈ 50ms. CI
+preservation depends on caching strategy.
 
-**Verdict.** Stateless still works but the gap is
-narrowing. At 30,000 RFCs the per-query cost
-(~3 seconds) starts to feel slow for an interactive
-dashboard.
+**With mdsmith stateless.** Parallel re-read,
+filter by FM, sort and top-5 per group
+in process. ~400ms cold.
+
+**With either in long-lived mode.** Both serve
+sub-ms after the first query in the session.
+Not applicable to a weekly cron unless the team
+runs a daemon for it.
+
+**Verdict.** Cold-vs-cold both around 300–400ms.
+mdbase wins meaningfully only when weekly
+cache state is preserved between runs (CI cache
+buckets), at which point it drops to ~50ms.
+mdsmith would need a similar persistence
+mechanism (P-1) to match. At 30,000 RFCs the
+cold-start gap widens — both tools take ~3
+seconds without preserved state — and either's
+preserved-state version becomes the obvious
+choice.
 
 ### A-3: Knowledge-graph backlinks at scale
 
@@ -137,6 +217,20 @@ dashboard.
 with dense `[[wikilinks]]`. Researcher opens a
 paper note and wants the backlinks panel:
 "What cites this paper?" In milliseconds.
+
+**Mode assumption.** Long-lived editor session.
+The researcher has the editor open all day;
+queries run inside that session.
+
+**Pre-conditions matter for this one.** Three
+distinct points in the session:
+
+- **Pre-1: cold session** — editor just opened,
+  no warm state.
+- **Pre-2: first backlink query** — researcher
+  asks "what cites this?" for the first time.
+- **Pre-3: subsequent backlink queries** —
+  later in the same session.
 
 **Query.** The query shape:
 
@@ -152,25 +246,65 @@ the load-bearing structure. Each query needs an
 edge lookup `(target → sources)` and then a group
 by tag.
 
-**With mdbase.** Indexed `(target_path, source_path)`
-edge table. The lookup is a single B-tree probe;
-the group-by uses the cached tag column.
-Sub-millisecond.
+**With mdbase, watch mode running.** Across the three pre-conditions:
 
-**With mdsmith stateless.** Re-read 12,000 files
-to rebuild the link graph per query. Even with
-parallel IO and fast parsing, ~2 seconds cold.
-Unacceptable for an interactive backlinks panel.
+- Pre-1: at session start, mdbase has either a
+  warm SQLite cache (from prior session) or
+  rebuilds it (~2s for 12k files of full-body
+  parse). With cache preserved, validation pass
+  takes ~120ms.
+- Pre-2: first query, indexed edge lookup,
+  sub-millisecond.
+- Pre-3: subsequent, also sub-ms.
 
-**Verdict.** Stateless does not work at this
-scale for interactive use. This is the case
-where the SQLite-class index pays.
+**With mdsmith stateless CLI.** Across the same three pre-conditions:
+
+- Pre-1: not applicable; CLI doesn't persist a
+  session.
+- Pre-2: re-read 12,000 files, ~2 seconds cold.
+  Unacceptable as an interactive panel.
+- Pre-3: same — every query is a cold start.
+
+**With mdsmith in-memory link graph in the LSP
+server (planned, P-1 option 2 + plan 131).**
+Across the same pre-conditions:
+
+- Pre-1: at LSP startup, walk the workspace and
+  build the link graph in memory. ~2s on 12k
+  files (parallel parse). Or build it in the
+  background with priority queries (see
+  "Background indexing" earlier in this doc),
+  so the editor opens immediately and the
+  index fills out.
+- Pre-2: indexed edge lookup, sub-millisecond.
+- Pre-3: sub-ms; the in-memory graph stays warm
+  for the session.
+
+**Verdict.** With the editor session
+explicitly assumed, both tools serve queries in
+sub-millisecond after the first cold build.
+mdsmith CLI does not work for this use case at
+this scale; mdsmith's planned LSP-resident link
+graph does. The win for mdbase is the
+cross-session warmth from the SQLite cache: a
+researcher closing and reopening the editor
+gets a faster Pre-1 with mdbase than with
+mdsmith's in-memory-only model.
+
+That cross-session warmth is the actual SQLite
+payoff. Whether it justifies the cache
+operational cost depends on how often the
+editor restarts versus stays open all day.
 
 ### A-4: Time-bucketed velocity
 
 **Setting.** Plan tracker. ~500 plans across
 two years. Quarterly review: "Plans completed
 per month, last 12 months."
+
+**Mode assumption.** Cold start. Quarterly
+report run by hand or in CI; no surviving
+cache assumed.
 
 **Query.** The query shape:
 
@@ -185,15 +319,23 @@ order_by: time_bucket asc
 **Cost driver.** 500 files; light. The time-
 bucket logic is the interesting part.
 
-**With mdbase.** Date functions in expressions
-plus GROUP BY on the bucket key. Trivial in SQL.
+**With mdbase, cold start.** Cache build
+(~50ms) + SQL with GROUP BY on bucket key
+(~1ms) ≈ 50ms total.
 
 **With mdsmith stateless.** Parallel parse, in-
 process bucket, count. ~50ms even cold.
 
-**Verdict.** Stateless wins. The corpus is
-small, the aggregation is light. Adding a cache
-would only slow things down.
+**With either in long-lived mode.** Sub-ms after
+first query; not relevant for a quarterly job.
+
+**Verdict.** Roughly equivalent at this scale
+in cold-start mode. The corpus is small enough
+that cache validation overhead and fresh parse
+work converge. mdbase's GROUP BY syntax is
+nicer to read; mdsmith would need Q-5
+aggregations to match. The choice here is
+expressiveness, not speed.
 
 ### A-5: Cross-type join
 
@@ -201,6 +343,11 @@ would only slow things down.
 its `owner: alice`. Task type also has
 `assignee: alice`. Query: "List Alice's open RFCs
 with at least one in-progress related task."
+
+**Mode assumption.** Either. The query is run
+ad-hoc from the CLI in some teams, embedded in
+a dashboard that polls in others. Numbers below
+cover both modes.
 
 **Query.** The query shape:
 
@@ -216,19 +363,31 @@ where: |
 matching RFC triggers per-task lookups on
 `related_tasks`, which is a list of paths.
 
-**With mdbase.** The `asFile()` call goes through
-the index: link target → cached FM → status
-column. ~10 lookups per RFC, all O(log n).
-Total: 200 × 10 = 2,000 index hits. Fast.
+**With mdbase, cold start.** Cache build
+(~500ms for 5,200 files) + traversal-aware SQL
+(2,000 index hits ≈ 10ms) ≈ 500ms total.
+
+**With mdbase, long-lived (watch mode).** Cache
+warm; ~10ms per query.
 
 **With mdsmith stateless.** Re-read all RFCs
-(filter), then re-read each related task (200 ×
-~3 hops × ~1ms parse = 600ms additional). Total
-~1 second cold. Acceptable but not great.
+(filter, ~200ms), then read each related task
+(200 RFCs × ~3 hops × ~1ms parse = 600ms). Total
+~800ms cold.
 
-**Verdict.** Marginal. At this scale, stateless
-is on the edge. Once joins go more than two
-hops or the corpus doubles, the index pays.
+**With mdsmith long-lived (LSP-resident link
+graph + planned L-5 traversal).** Same ~10ms
+per query as mdbase, after the cold index
+build.
+
+**Verdict.** Cold-vs-cold roughly comparable
+(500–800ms). Long-lived mode lets either tool
+serve queries in tens of milliseconds. The
+SQLite cache pays for cross-session warmth, the
+same as A-3. At larger scales (20k+ tasks, 4+
+hops) the cold-start gap widens for both,
+favoring whichever tool has a working long-
+lived path.
 
 ### A-6: Real-time editor decoration
 
@@ -237,6 +396,24 @@ inline decoration: every wikilink shows the
 target's title in light text after the link.
 Updates as files change.
 
+**Mode assumption.** Long-lived editor session
+with LSP server attached. Decoration runs on
+every keystroke that affects rendering, so this
+is unequivocally a session-mode use case;
+stateless CLI does not apply.
+
+**Pre-conditions matter.** Four moments matter inside the session:
+
+- **Pre-1: editor opens** — first decoration
+  pass on the visible file.
+- **Pre-2: typing inside the file** — link
+  targets unchanged, decorations stable.
+- **Pre-3: navigating to a different file** —
+  new decorations.
+- **Pre-4: external file change** — target
+  file's title updated, decoration must
+  refresh.
+
 **Query.** Per visible link, fetch
 `asFile().title`. Hundreds of times per file
 open, called from the LSP server.
@@ -244,20 +421,43 @@ open, called from the LSP server.
 **Cost driver.** Latency. 50ms feels slow;
 200ms is unacceptable.
 
-**With mdbase.** Index-backed lookup.
-Sub-millisecond per resolution.
+**With mdbase, watch mode.** Across the four pre-conditions:
 
-**With mdsmith stateless.** Per-resolution disk
-read. Even with read coalescing, 5–10ms per
-target file. With 100 visible links: 500ms-1s of
-work per editor open. Bad.
+- Pre-1: ~120ms validation if cache exists,
+  else ~2s rebuild. After that, decorations
+  resolve sub-millisecond.
+- Pre-2/3/4: sub-ms each, regardless of
+  surrounding edits.
 
-**Verdict.** This is an LSP case. The right
-shape is option 2 from
-[learn-from-mdbase.md §P-1](learn-from-mdbase.md):
-in-memory, process-scoped index in the LSP
-server. No disk cache; the editor session keeps
-state, the CLI does not.
+**With mdsmith stateless CLI.** Not applicable;
+the CLI exits between queries. A per-decoration
+shell-out would cost 5–10ms per resolution
+just for process startup, plus disk read. Fails
+all four pre-conditions.
+
+**With mdsmith LSP-resident link graph (planned
+P-1 option 2 + plan 131).** Across the same four
+pre-conditions:
+
+- Pre-1: ~2s cold rebuild, or instant if
+  background indexing is in place and the
+  editor opens before the index completes
+  (decorations fill in as targets become
+  resolvable).
+- Pre-2: sub-ms (no link-target changes).
+- Pre-3: sub-ms.
+- Pre-4: relies on the LSP's
+  `didChangeWatchedFiles` invalidating one
+  file's cache entry; <10ms refresh.
+
+**Verdict.** Both tools handle this in
+long-lived mode. Stateless does not work for
+either; the question is just whether the
+long-lived process is mdbase-lsp or mdsmith's
+LSP. Cross-session warmth (Pre-1 specifically)
+is where mdbase's persistent cache wins;
+restart frequency determines whether that
+matters.
 
 ## What an index actually costs
 
@@ -685,41 +885,68 @@ on hardened parsing today (because they did the
 review). Both share the path-sandboxing baseline
 the spec mandates.
 
-## When the index pays
+## When operational mode + persistence pays
 
-Reading across the six cases, three signals
-predict when an index earns its cost:
+Reading across the six cases with the
+mode-and-pre-condition framing, three signals
+predict whether *some* form of cached or
+indexed state earns its cost:
 
-1. **Interactive latency.** A query that runs
+1. **Interactive latency.** Queries that run
    inside a UI (LSP decoration, backlinks panel,
-   editor hover) needs <100ms response. Stateless
-   re-read gets there only at small file counts.
-2. **Repeated queries on a stable corpus.** A CI
-   job runs once per push and caches don't help.
-   A researcher running queries all day in a
-   stable vault sees the cache pay every minute.
+   editor hover) need <100ms response. Stateless
+   one-shot CLI does not get there at workspace
+   scale; some form of long-lived state is
+   required.
+2. **Cross-session restart cost.** If a tool's
+   long-lived process restarts often (editor
+   close-and-reopen, agent loop respawn), warm
+   state must be reconstructed each time. A
+   persistent cache that survives restart pays
+   here. A pure in-memory model rebuilds.
 3. **Cross-file joins beyond one hop.** Single-
    file queries scale linearly with the corpus.
-   Joins multiply the cost; an index turns each
-   hop from O(n) to O(log n).
+   Joins multiply the cost; any form of index
+   (persistent or in-memory) turns each hop
+   from O(n) to O(log n).
 
-The cross-product:
+The cross-product, with explicit modes:
 
-| Use case             | Latency need | Repeated? | Joins?  | Index pays? |
-|----------------------|--------------|-----------|---------|-------------|
-| A-1 sprint dashboard | CI (seconds) | no        | no      | no          |
-| A-2 reviewer load    | weekly job   | no        | one hop | borderline  |
-| A-3 backlinks panel  | UI (<100ms)  | yes       | one hop | yes         |
-| A-4 velocity         | report (~s)  | no        | no      | no          |
-| A-5 cross-type join  | report (~s)  | no        | 2+ hops | borderline  |
-| A-6 editor decor     | UI (<50ms)   | yes       | one hop | yes         |
+| Use case              | Mode (most natural) | Latency need | Joins?  | Cold-shot OK? | Long-lived helps? | Persistent cache adds? |
+|-----------------------|---------------------|--------------|---------|---------------|-------------------|------------------------|
+| A-1 sprint dashboard  | one-shot CI         | seconds      | no      | yes           | no (one-shot)     | only if CI preserves   |
+| A-2 reviewer load     | one-shot weekly     | seconds      | one hop | yes           | not natural       | only if CI preserves   |
+| A-3 backlinks panel   | long-lived editor   | <100ms       | one hop | no            | yes (decisive)    | cross-restart warmth   |
+| A-4 velocity          | one-shot quarterly  | seconds      | no      | yes           | no (one-shot)     | minimal                |
+| A-5 cross-type join   | either              | seconds–ms   | 2+ hops | yes (cold)    | yes (warm)        | cross-restart warmth   |
+| A-6 editor decoration | long-lived LSP      | <50ms        | one hop | no            | yes (decisive)    | cross-restart warmth   |
 
-Two of six clearly need an index; two clearly
-don't; two sit on the edge. The interesting
-design question for mdsmith is whether the two
-clear cases (A-3 backlinks panel, A-6 editor
-decoration) can be served by an in-memory index
-inside the LSP server without ever shipping a
+Two patterns fall out:
+
+- **Cold-shot use cases (A-1, A-2, A-4).**
+  Roughly equivalent across both tools at
+  cold-vs-cold. Persistent cache helps only if
+  the runner preserves it (CI cache buckets).
+  This is more about the deployment than the
+  tool.
+- **Long-lived use cases (A-3, A-5, A-6).**
+  Both tools serve sub-millisecond after the
+  first cold build *within* a session. The
+  distinguishing axis is **cross-session
+  warmth**: does state survive restart? mdbase's
+  SQLite cache is the most direct way to make
+  that warmth survive a process exit. mdsmith's
+  current trajectory (in-memory in the LSP)
+  rebuilds at session start; whether that's
+  acceptable depends on how often sessions
+  restart.
+
+The interesting design question for mdsmith is
+whether the two clear long-lived cases (A-3
+backlinks panel, A-6 editor decoration) can be
+served by an in-memory index inside the LSP
+server, plus background indexing to mask cold
+build, without ever shipping a
 persistent on-disk cache.
 
 ## Stateless-fast: the `fzf` / `ripgrep` model

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -1,0 +1,1108 @@
+---
+summary: Feature-by-feature comparison of mdsmith and mdbase across distribution, configuration, type system, validation, queries, links, generated content, prose linting, conventions, cache, CLI, LSP, output formats, and security posture.
+status: 🔳
+---
+# Feature-by-feature comparison
+
+This document walks the surface of each tool side by
+side. Each section names what the feature is, how
+mdsmith does it (with code citations), how mdbase
+defines it (with spec section refs), and where the
+overlap or gap is. Conformance level (`L1`–`L6`) refers
+to mdbase's six tiers in spec section 14.
+
+## 1. Distribution and runtime
+
+| Aspect       | mdsmith                               | mdbase                                                               |
+|--------------|---------------------------------------|----------------------------------------------------------------------|
+| Artifact     | One Go binary (`mdsmith`)             | Spec + reference impl (`mdbase`, TS) + CLI + Rust LSP                |
+| Install      | `go install` or download release      | `npm install`, or build LSP via `cargo build --release`              |
+| Runtime      | None (static binary)                  | Node 22+ for TS impl and CLI; standalone for LSP                     |
+| Plugin model | None — rules baked in at compile time | None at the spec level — but each impl can add tools/extensions      |
+| Network      | None at any phase                     | None — files-as-truth principle (spec §0)                            |
+| Spec layer   | n/a — single implementation           | Specification document at version 0.2.1                              |
+| Conformance  | n/a                                   | Implementations declare a level: e.g. `Conformance: Level 4 (Links)` |
+
+mdbase trades a single canonical tool for an open
+standard with multiple conforming implementations.
+Today only one implementation suite exists, but the
+spec is structured so a second-party Go or Python
+impl could replace it without users changing their
+files. mdsmith makes the opposite bet: one binary
+owns all behavior.
+
+## 2. Configuration
+
+### mdsmith: `.mdsmith.yml`
+
+Top-level YAML at the project root. Optional. Layered
+config resolves per file (see CLAUDE.md and
+`internal/config/load.go`):
+
+```text
+defaults
+  ↓ deep-merge
+convention preset (portable | github | plain)
+  ↓ deep-merge
+top-level rules:
+  ↓ deep-merge
+overrides: [{glob, rules}, …]
+  ↓ deep-merge
+kinds assigned to file (front-matter or kind-assignment)
+```
+
+Deep-merge semantics (see
+`internal/config/deepmerge.go`):
+
+- Maps recurse key-by-key
+- Scalars are replaced wholesale
+- Lists replace by default; rules opt into append via
+  the `rule.ListMerger` interface (e.g.,
+  `placeholders:`, `proper-names.names:`)
+- A bool-only layer (`rule-name: false`) toggles
+  `enabled` without erasing inherited settings
+
+### mdbase: `mdbase.yaml`
+
+Single config file at the collection root. Required:
+`spec_version: "0.2.1"`. All other settings optional
+(spec §4):
+
+| Field                | Default                           | Purpose                                |
+|----------------------|-----------------------------------|----------------------------------------|
+| `name`               | —                                 | Human-readable label                   |
+| `description`        | —                                 | Free-form purpose                      |
+| `extensions`         | `[]`                              | Extra Markdown extensions beyond `.md` |
+| `exclude`            | `.git`, `node_modules`, `.mdbase` | Paths or globs to skip                 |
+| `include_subfolders` | `true`                            | Recurse into directories               |
+| `types_folder`       | `_types`                          | Where type files live                  |
+| `explicit_type_keys` | `["type", "types"]`               | Front-matter keys for explicit type    |
+| `migrations_folder`  | `<types>/_migrations`             | Migration manifests (L6)               |
+| `default_validation` | `warn`                            | Off / warn / error                     |
+| `default_strict`     | `false`                           | Reject unknown front-matter fields     |
+| `write_nulls`        | `omit`                            | How nulls persist on write             |
+| `write_defaults`     | `true`                            | Materialize default-filled fields      |
+| `write_empty_lists`  | `true`                            | Persist `[]` rather than omitting      |
+| `timezone`           | system                            | IANA name for date functions           |
+| `id_field`           | `id`                              | Primary key for link resolution        |
+| `rename_update_refs` | `true`                            | Rewrite incoming links on rename       |
+| `cache_folder`       | `.mdbase`                         | SQLite cache location                  |
+
+### Where they overlap
+
+| Concern                | mdsmith equivalent             | mdbase equivalent           |
+|------------------------|--------------------------------|-----------------------------|
+| Project root marker    | `.mdsmith.yml` (optional)      | `mdbase.yaml` (required)    |
+| Ignore patterns        | `ignore:` glob list            | `exclude:` glob list        |
+| Per-path overrides     | `overrides: [{glob, rules}]`   | per-type `path_glob`        |
+| Per-role rule bundle   | `kinds:` map                   | type files in `_types/`     |
+| Schema validation flag | per-rule severity (Error/Warn) | `default_validation` global |
+
+mdbase declares schemas as Markdown files in
+`_types/`; mdsmith declares them as CUE schema files
+referenced from `.mdsmith.yml`. This is the cleanest
+illustration of the tools' opposite bets:
+
+- mdsmith pulls schemas into the lint config alongside
+  rule settings.
+- mdbase pushes schemas into the vault as first-class
+  content, so the schema travels with the data.
+
+## 3. Type / kind definitions
+
+### mdsmith: file kinds
+
+Defined in `.mdsmith.yml` under the `kinds:` map. A
+kind is a named bundle of rule overrides plus
+optionally a CUE schema and category toggles
+(`internal/config/config.go`):
+
+```yaml
+kinds:
+  proto:
+    rules:
+      first-line-heading: false
+      heading-increment: false
+      required-structure:
+        schema: internal/concepts/rule.cue
+  api-doc:
+    rules:
+      line-length:
+        max: 120
+      token-budget:
+        max: 4000
+```
+
+Assignment to files works in two ways:
+
+1. Front-matter declaration — `kinds: [proto]` or
+   `kind: proto` in the file's YAML
+2. Glob from `kind-assignment:` in `.mdsmith.yml`
+
+Inheritance: there is no kind-to-kind inheritance.
+A file can carry multiple kinds; each is deep-merged
+into the effective config in declaration order.
+
+### mdbase: types
+
+Defined as Markdown files in `_types/`, e.g.
+`_types/task.md` (spec §5). The front matter declares
+the schema; the body documents the type for humans
+who open the vault:
+
+```markdown
+---
+name: task
+extends: base
+strict: warn
+path_pattern: tasks/{date}-{title}.md
+fields:
+  status:
+    type: enum
+    values: [open, in-progress, done]
+    required: true
+  priority:
+    type: integer
+    min: 1
+    max: 5
+    default: 3
+  due:
+    type: date
+  assignee:
+    type: link
+    target: person
+    validate_exists: true
+  tags:
+    type: list
+    items:
+      type: string
+computed:
+  days_overdue:
+    type: integer
+    expr: (today() - due) / 86400000
+---
+# Task
+
+A unit of work with a status, priority, and assignee.
+Inherits id, created_at, modified_at from base.
+```
+
+Inheritance: single inheritance via `extends`. Child
+fields completely override parent fields with the
+same name (no constraint merging). Circular chains
+are detected and rejected.
+
+Computed fields (declared in `computed:`) evaluate
+at read time using the expression language from
+spec §11. They are not persisted to the front matter;
+queries can still reference them.
+
+**Side by side.** In summary:
+
+| Aspect              | mdsmith kinds                  | mdbase types                                |
+|---------------------|--------------------------------|---------------------------------------------|
+| Storage             | YAML in `.mdsmith.yml`         | Markdown files in `_types/`                 |
+| Travels with files  | No (config-only)               | Yes (in-vault)                              |
+| Inheritance         | None                           | Single (`extends`)                          |
+| Computed fields     | No                             | Yes (expression-based, read-time)           |
+| Bundles rule config | Yes (deep-merge)               | No (rules are mdsmith's, not mdbase's)      |
+| Bundles schema      | Yes (CUE path)                 | Yes (declarative DSL)                       |
+| Multi-type per file | Yes (kind list, deep-merged)   | Yes (multi-match, intersect constraints)    |
+| Path constraint     | `kind-assignment` globs        | `path_pattern` (validates and generates)    |
+| Discoverability     | Run `mdsmith kinds` to inspect | List `_types/`; each type doc is the schema |
+
+The crucial difference: an mdbase type file is
+itself a valid Markdown file in the vault, so any
+text editor reads it. An mdsmith kind is YAML inside
+the linter config and is invisible from the editor's
+file tree unless the user opens `.mdsmith.yml`.
+
+## 4. File-to-type / kind matching
+
+**mdsmith.**
+Two mechanisms (see CLAUDE.md):
+
+- Front-matter `kinds: [name]` or `kind: name`
+- `kind-assignment:` block in `.mdsmith.yml`:
+
+  ```yaml
+  kind-assignment:
+    - glob: ["docs/api/**"]
+      kinds: [api-doc]
+  ```
+
+A file can have any number of kinds; each is merged
+in declaration order. There is no field-presence
+auto-matching.
+
+**mdbase.**
+Three mechanisms (spec §6), evaluated in priority
+order:
+
+1. **Explicit declaration** — front-matter `type:` or
+   `types:` (configurable via `explicit_type_keys`).
+   Takes precedence; match rules are bypassed.
+2. **`path_glob`** — glob in the type file's match
+   block, e.g. `path_glob: "tasks/**/*.md"`.
+3. **`fields_present`** — type matches when listed
+   fields are non-null in the front matter.
+
+Multi-condition rules combine with AND. Files can
+match zero, one, or many types. When multiple types
+match, fields are validated against the intersection
+of their constraints (most restrictive wins; conflicts
+become errors).
+
+| Mechanism             | mdsmith       | mdbase                 |
+|-----------------------|---------------|------------------------|
+| Front-matter declare  | yes           | yes (highest priority) |
+| Glob                  | yes           | yes                    |
+| Field presence        | no            | yes                    |
+| Field-value condition | no            | yes (`where:` block)   |
+| Multi-match merge     | deep-merge    | constraint intersect   |
+| Untyped allowed       | yes (no kind) | yes (no match)         |
+
+mdbase wins on declarative power: a `where:` block
+can match e.g. `status: open` files automatically.
+mdsmith requires explicit kind tags or globs.
+
+## 5. Field type system
+
+### mdsmith: CUE schemas
+
+Front-matter validation happens via [MDS020
+required-structure][mds020]. Schemas are CUE files
+referenced from `.mdsmith.yml` or kind config:
+
+```cue
+// internal/concepts/rule.cue
+package rule
+
+#Rule: {
+    id:          string
+    name:        string
+    status:      "ready" | "not-ready"
+    description: string
+    settings?: {[string]: _}
+}
+```
+
+CUE provides rich constraints: regex patterns, enum
+disjunctions, optional fields with `?`, structural
+types, value coercion. Errors are reported as MDS020
+diagnostics with line/column anchors.
+
+### mdbase: 12 field types
+
+Spec §7 defines a fixed taxonomy:
+
+| Type     | Constraints                                         |
+|----------|-----------------------------------------------------|
+| string   | `min_length`, `max_length`, regex `pattern`         |
+| integer  | `min`, `max`                                        |
+| number   | `min`, `max` (IEEE 754)                             |
+| boolean  | accepts `yes`/`no` aliases, normalized on write     |
+| date     | ISO 8601 `YYYY-MM-DD`, year range 0001–9999         |
+| datetime | ISO 8601 with optional timezone, preserved on write |
+| time     | `HH:MM` or `HH:MM:SS`                               |
+| enum     | required `values:` list, case-sensitive             |
+| list     | `items:` typing, `min_items`, `max_items`, `unique` |
+| object   | `fields:` map, max nesting depth ≥ 16               |
+| link     | `target:` type, `validate_exists`                   |
+| any      | no validation; useful for migration                 |
+
+Universal options on every field: `type`, `required`,
+`default`, `generated`, `description`, `deprecated`,
+`unique`. Null semantics are explicit: a default is
+not applied when a field is present-but-null.
+
+**Comparison.** Side-by-side breakdown:
+
+| Concern                 | mdsmith (CUE)                 | mdbase (DSL)                                    |
+|-------------------------|-------------------------------|-------------------------------------------------|
+| Validation language     | CUE, an external language     | Inline YAML in type front matter                |
+| Type discoverability    | Read CUE files                | Read `_types/*.md`                              |
+| Built-in types          | Anything CUE supports         | 12 fixed types                                  |
+| Custom constraints      | Yes (full CUE)                | Limited to the per-type knobs                   |
+| Inheritance             | CUE definitions / unification | `extends:` single inheritance                   |
+| Computed fields         | No (CUE is purely structural) | Yes (expression-based)                          |
+| Generated values        | No                            | `generated:` (ULID, UUID, sequence, timestamps) |
+| Deprecation flag        | No                            | Yes (`deprecated: true`)                        |
+| Cross-field constraints | Yes (CUE)                     | Limited                                         |
+
+CUE is the more powerful constraint language;
+mdbase's DSL is simpler but covers the typical Markdown
+collection well. mdbase has built-in support for
+generated values (ULIDs and timestamps written on
+create), which mdsmith lacks: mdsmith does not author
+files, so it has no notion of write-time generation.
+
+## 6. Validation model
+
+**mdsmith.**
+Per-rule severity (`error`, `warning`). Every rule
+declares its own default severity. The CLI exits
+non-zero only on errors; warnings are reported but
+do not block.
+
+CI gate via `mdsmith check .`:
+
+```bash
+mdsmith check .
+# exit code 0 if no errors; non-zero on any error
+```
+
+Schema validation specifically lives in [MDS020][mds020].
+A schema mismatch is an error. There is no global
+"strict" toggle — strictness is encoded in each
+schema (CUE either accepts or rejects).
+
+**mdbase.**
+Three global validation modes, set in `mdbase.yaml`
+(spec §9):
+
+| Mode    | Behavior                                     |
+|---------|----------------------------------------------|
+| `off`   | No validation; tools accept anything         |
+| `warn`  | Reports issues; operations succeed (default) |
+| `error` | Reports issues and aborts the operation      |
+
+Plus a separate `default_strict:` (true / false /
+"warn") that controls whether unknown front-matter
+keys are flagged.
+
+Validation covers six checks:
+
+1. Required fields are present and non-null
+2. Types match or coerce safely
+3. Constraints (length, range, pattern, enum)
+4. Strictness (unknown fields)
+5. Link existence (when `validate_exists: true`)
+6. ID uniqueness across the collection
+
+**Side by side.** In summary:
+
+| Concern               | mdsmith                    | mdbase                                  |
+|-----------------------|----------------------------|-----------------------------------------|
+| Severity granularity  | Per rule                   | Three global modes (off/warn/error)     |
+| Strict unknown fields | Per CUE schema             | Global `default_strict`                 |
+| Output format         | `text` or `json`; LSP wire | Code + path + field + line/column       |
+| Error code count      | 54 rule IDs (one per rule) | 34 error codes (spec appendix C)        |
+| Aborts on error       | exits non-zero             | aborts the CRUD op when mode = `error`  |
+| Severity location     | declared by each rule      | global, with optional per-type override |
+
+mdsmith's severity model is rule-local. mdbase's is
+mode-global, except where `validation:` overrides
+locally on a type or query. The mdsmith model is
+more granular for linting; the mdbase model is
+better aligned with CRUD operations that need a clear
+"abort or proceed" decision.
+
+## 7. Front-matter handling
+
+| Aspect                        | mdsmith                                    | mdbase                                                  |
+|-------------------------------|--------------------------------------------|---------------------------------------------------------|
+| Format                        | YAML only (`---` fences)                   | YAML only (`---` fences)                                |
+| Parser                        | `gopkg.in/yaml.v3` via `internal/yamlutil` | implementation-defined; spec mandates YAML 1.2 subset   |
+| TOML / JSON FM                | not parsed                                 | not in spec                                             |
+| Obsidian inline `key:: value` | not recognized                             | not in spec (but `compatibility` notes it)              |
+| Anchor / alias attack         | rejected (security hardening)              | implementation-defined                                  |
+| Effective FM (post-defaults)  | concept absent; rules see raw YAML         | yes — `effective frontmatter` includes defaults         |
+| Computed fields               | n/a                                        | included in `effective frontmatter` for queries         |
+| Null semantics                | YAML default                               | explicit: present-null bypasses defaults and uniqueness |
+
+mdsmith treats front matter as plain YAML the rules
+read directly. mdbase adds a layer: the **effective
+frontmatter** is the raw YAML merged with defaults
+and computed fields. Queries operate on the effective
+view, not the raw bytes. This matters for tools that
+want to see "the data as if all defaults were applied"
+without rewriting the file on disk.
+
+## 8. Query language
+
+### mdsmith: CUE struct literal
+
+```bash
+mdsmith query 'status: "✅"' plan/
+mdsmith query 'meta: {priority: int, status: "open"}' .
+```
+
+The argument is a CUE struct literal that the engine
+unifies against each file's front matter
+(`internal/query/query.go`). Unification succeeds
+when the file's data is a subtype of the query
+struct. `Match` adds an explicit existence check so
+queries cannot match a file that simply omits a
+field.
+
+CUE's full expression language is available: regex,
+disjunctions, optional fields, computed bounds. There
+is no body search, no sort, no pagination — `query`
+just emits matching paths.
+
+### mdbase: Bases-compatible expression DSL
+
+Spec §10 defines a richer model with clauses:
+
+```yaml
+types: [task]
+folder: tasks
+where: status == "open" && priority >= 3 && due <= today() + "7d"
+order_by:
+  - field: due
+    direction: asc
+limit: 20
+offset: 0
+```
+
+Plus access namespaces:
+
+- bare names → effective front matter (`status`)
+- `file.*` → metadata (`file.mtime`, `file.size`,
+  `file.path`)
+- `file.body` → full-text search on raw Markdown
+- `formula.*` → computed fields
+
+Operators and methods (spec §11):
+
+- comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- logical: `&&`, `||`, `!`
+- arithmetic: `+`, `-`, `*`, `/`, `%`
+- null coalescing: `value ?? default`
+- string methods: `.length`, `.contains`, `.startsWith`,
+  `.endsWith`, `.lower`, `.upper`, `.trim`,
+  `.matches(regex)`, `.replace(p, r)`
+- list methods: `.length`, `.contains`, `.filter(expr)`,
+  `.map(expr)`, `.reduce(expr, init)`
+- date functions: `now()`, `today()`, `date(s)`,
+  `datetime(s)`, with `.year`, `.month`, `.day`, etc.
+- date arithmetic with duration strings: `"7d"`, `"1w"`,
+  `"1M"` (months), `"1y"`, `"2h"`, `"30m"`, `"45s"`
+  — case-sensitive (capital M = month, lowercase = minute)
+- conditionals: `if(cond, then, else)`
+- existence: `exists(field)`, `value.isEmpty()`,
+  `value.isType("string"|"number"|...)`
+- link traversal: `link.asFile().property` (max depth 10)
+- type-mismatch errors return null and emit
+  `type_error` rather than aborting the query
+
+**Side by side.** In summary:
+
+| Capability        | mdsmith               | mdbase                              |
+|-------------------|-----------------------|-------------------------------------|
+| Filter by FM      | yes (CUE unification) | yes (expression `where:`)           |
+| Sort              | no                    | yes (`order_by`)                    |
+| Pagination        | no                    | yes (`limit`/`offset`)              |
+| Body search       | no                    | yes (`file.body`)                   |
+| Cross-file fields | no                    | yes (`asFile()` traversal)          |
+| Date arithmetic   | via CUE bounds        | first-class duration strings        |
+| Aggregation       | no                    | yes (`Query+`: formulas, summaries) |
+| Tooling           | one CLI flag          | CLI + library + LSP                 |
+
+For ad-hoc CI filters ("which files have
+`status: blocked`?"), mdsmith query is enough. For
+running a vault as a database (showing all
+overdue tasks grouped by assignee), mdbase wins.
+
+## 9. Link handling
+
+**mdsmith.**
+MDS027 (cross-file-reference-integrity) validates
+Markdown links and same-file anchors:
+
+- File links: `[text](path/to/file.md)` — checks the
+  target file exists
+- Heading anchors: `[text](file.md#section)` — checks
+  the heading exists, using GitHub anchor slug rules
+- Same-file anchors: `[text](#local)` — checks H1–H6
+  in the current file
+- External links (`http://`, `https://`, `mailto:`)
+  are skipped
+
+Settings: `include`, `exclude` globs;
+`strict: true|false` (whether to also check
+non-Markdown targets); `placeholders:` list (tokens
+treated as opaque, e.g. `var-token`).
+
+Wikilinks (`[[Page]]`) are not parsed — they pass
+through as text. There is no link rewriting on file
+rename.
+
+**mdbase.**
+Spec §8 defines link parsing, resolution, and
+traversal as a first-class concern.
+
+Three input formats:
+
+- Wikilinks: `[[target]]`, `[[target|alias]]`,
+  `[[target#anchor]]`
+- Markdown links: `[text](path.md)`
+- Bare paths: `./sibling.md`, `../parent/file.md`
+
+Resolution (in order):
+
+1. ID-field match (when type constraint exists)
+2. Filename match in Markdown files
+3. Tiebreakers: same-directory preference, shortest
+   path, alphabetical order
+
+Path sandboxing prevents escape attempts (so
+`../../etc/passwd` cannot resolve outside the
+collection). Non-Markdown files are not record
+candidates for simple-name resolution.
+
+Traversal: `link.asFile()` resolves the link and
+returns the target file. Multi-hop is allowed up to
+depth 10. Null propagation prevents errors during
+incomplete chains.
+
+**Side by side.** In summary:
+
+| Capability                      | mdsmith              | mdbase                     |
+|---------------------------------|----------------------|----------------------------|
+| Markdown link existence check   | yes                  | yes (L4)                   |
+| Same-file anchor check          | yes (#heading)       | yes                        |
+| Cross-file heading anchor check | yes                  | yes                        |
+| Wikilink parsing                | no (treated as text) | yes (`[[...]]`)            |
+| Link aliases                    | n/a                  | yes (`[[t\|alias]]`)       |
+| ID-field link resolution        | no                   | yes                        |
+| Path sandboxing                 | yes                  | yes (L4)                   |
+| Multi-hop traversal             | no                   | yes (`asFile()`, depth 10) |
+| Auto-rewrite on rename          | no                   | yes (L5)                   |
+| Backlink graph                  | no                   | yes (L5)                   |
+
+mdbase is the link-aware tool. mdsmith catches broken
+links but does not maintain the graph.
+
+## 10. Cross-file integrity and rename
+
+mdsmith MDS027 validates and reports
+broken links. It does not rewrite anything: a rename
+breaks links, MDS027 catches it on the next lint, the
+human or LLM agent fixes them.
+
+mdbase L5 (`References`) requires:
+
+- **Rename with reference updates** — moving or
+  renaming a file rewrites incoming wikilinks and
+  Markdown links across the collection. Link styles
+  are preserved (a wikilink stays a wikilink). ID-based
+  links may skip rewriting if the target's `id_field`
+  did not change.
+- **Backlink computation** — a query like "what
+  links to this file?" runs against the link graph.
+
+Concurrency model: rename uses optimistic concurrency
+via mtime checks. Reference updates are best-effort
+file-by-file. A rename can succeed while individual
+reference updates fail (reported per-file).
+
+| Capability              | mdsmith | mdbase               |
+|-------------------------|---------|----------------------|
+| Detect broken link      | yes     | yes                  |
+| Auto-rewrite incoming   | no      | yes (L5)             |
+| Link-style preservation | n/a     | yes                  |
+| Backlinks query         | no      | yes (L5, via cache)  |
+| Concurrency safety      | n/a     | optimistic via mtime |
+
+Practical impact: in mdbase you can rename a file in
+one command and downstream links stay green. In
+mdsmith you must do the rewrite manually (or via a
+separate tool) and re-lint.
+
+## 11. CRUD operations
+
+mdsmith does not author files. It edits content
+inside files via `mdsmith fix`, but it does not
+create or delete `.md` files. It does not have a
+notion of file-creation operations at all.
+
+mdbase L1 defines a full CRUD surface (spec §12):
+
+| Operation | Behavior                                                                                                                 |
+|-----------|--------------------------------------------------------------------------------------------------------------------------|
+| Create    | New file with type inference, defaults, and generated values; validates before write; atomic                             |
+| Read      | Loads file, parses front matter and body, resolves types, returns metadata + effective FM                                |
+| Update    | Merges new field values; recalculates types; applies generated strategies (e.g. `now_on_write`); validates merged result |
+| Delete    | Removes file; optionally warns about incoming references that would break                                                |
+| Rename    | Moves file; optionally rewrites references (L5)                                                                          |
+| Batch     | `--where` filter to target many files; validate-all then apply, or best-effort                                           |
+
+`--dry-run` mode validates without writing. The
+`generated:` field strategies cover ULID, UUID,
+sequences, and timestamps — useful for files created
+programmatically.
+
+| Capability             | mdsmith                         | mdbase                         |
+|------------------------|---------------------------------|--------------------------------|
+| Create file            | no                              | yes (L1)                       |
+| Read with effective FM | indirect (via lint)             | yes (L1)                       |
+| Update field           | no (only fix-driven body edits) | yes (L1)                       |
+| Delete file            | no                              | yes (L1)                       |
+| Rename                 | no                              | yes (L5 with refs, L1 without) |
+| Batch ops              | per-rule; no `--where`          | yes (`--where` selector)       |
+
+This is the cleanest "different layer" cut. mdsmith
+is read-and-fix; mdbase is read-write-CRUD.
+
+## 12. Generated and regenerable content
+
+### mdsmith: directives
+
+Block-form processing instructions. Each pairs with
+a rule that detects drift and a fix that regenerates
+the body. Five active directives, all using the form
+`<?name [params]?>...body...<?/name?>`:
+
+| Directive                | Rule             | Generates                                                 |
+|--------------------------|------------------|-----------------------------------------------------------|
+| `<?catalog?>`            | [MDS019][mds019] | Table of files matching a glob, with FM fields as columns |
+| `<?include?>`            | [MDS021][mds021] | Inline content from another Markdown file                 |
+| `<?toc?>`                | [MDS038][mds038] | Nested heading list with GitHub anchors                   |
+| `<?build?>`              | [MDS039][mds039] | Body from a recipe template (no execution today)          |
+| `<?required-structure?>` | [MDS020][mds020] | Heading-by-heading template enforcement                   |
+
+Plus support directives:
+
+- `<?allow-empty-section?>` — opt out of the
+  empty-section rule per-section
+- `<?ignore?>` — opt out of all rules for a span
+
+The fix engine (`internal/fix/fix.go`) regenerates
+each directive body. When `mdsmith fix` runs, it
+re-evaluates the directive parameters and rewrites
+the body between markers. The source file remains
+valid Markdown at all times — readers see the
+generated content even when the linter has not run.
+
+### mdbase: not in scope
+
+Spec §0–15 do not define a generation directive
+syntax. mdbase covers the data layer only. A
+collection that needs generated TOCs or catalogs
+relies on a static-site generator or a separate tool
+(such as mdsmith).
+
+**Side by side.** In summary:
+
+| Capability         | mdsmith                    | mdbase |
+|--------------------|----------------------------|--------|
+| Directive syntax   | `<?name?>...<?/name?>`     | none   |
+| Catalog (FM table) | yes                        | no     |
+| Include            | yes                        | no     |
+| TOC                | yes                        | no     |
+| Build artifacts    | yes (recipes; no exec yet) | no     |
+| Drift detection    | yes (per directive rule)   | no     |
+| Auto-regenerate    | yes (`mdsmith fix`)        | no     |
+
+This is an mdsmith-only layer. A team using mdbase
+who also wants generated tables of contents would
+need to run a second tool, or write their own tooling
+that uses the mdbase library.
+
+## 13. Prose, readability, and structure rules
+
+mdsmith ships 54 rules organized loosely by category.
+mdbase has none — it does not lint prose at all.
+
+### Prose & readability (mdsmith only)
+
+| Rule   | Concern                                                     |
+|--------|-------------------------------------------------------------|
+| MDS023 | Paragraph readability (ARI grade index)                     |
+| MDS024 | Paragraph structure (max sentences, max words per sentence) |
+| MDS028 | Token budget (LLM-context-window aware)                     |
+| MDS029 | Conciseness scoring (experimental, classifier-based)        |
+| MDS037 | Duplicated content across files                             |
+
+### Structure (mdsmith only)
+
+| Rule       | Concern                                                |
+|------------|--------------------------------------------------------|
+| MDS001     | Line length (default 80, exclude code/tables/urls)     |
+| MDS002–005 | Heading style, increment, first line, no duplicates    |
+| MDS006–009 | Whitespace (trailing spaces, hard tabs, blank lines)   |
+| MDS010–011 | Fenced code style and language tag                     |
+| MDS012     | No bare URLs                                           |
+| MDS013–015 | Blank lines around headings, lists, fenced code        |
+| MDS016     | List indent                                            |
+| MDS017–018 | Heading punctuation, no emphasis as heading            |
+| MDS022     | Max file length (lines)                                |
+| MDS025–026 | Table format and table readability                     |
+| MDS030     | Empty section body                                     |
+| MDS031     | Unclosed code block                                    |
+| MDS032     | No empty alt text                                      |
+| MDS033     | Directory structure                                    |
+| MDS034     | Markdown flavor (CommonMark / GFM gate)                |
+| MDS035     | TOC token (`[TOC]` and friends)                        |
+| MDS036     | Max section length                                     |
+| MDS041–054 | Inline HTML, emphasis, lists, ambiguous emphasis, etc. |
+
+### Cross-file & generation (mdsmith only)
+
+| Rule   | Concern                                             |
+|--------|-----------------------------------------------------|
+| MDS019 | Catalog directive                                   |
+| MDS020 | Required structure (CUE schema validation)          |
+| MDS021 | Include directive                                   |
+| MDS027 | Cross-file reference integrity                      |
+| MDS038 | TOC directive                                       |
+| MDS039 | Build directive                                     |
+| MDS040 | Recipe safety (build command syntax check)          |
+| MDS048 | Git-hook sync (`.gitattributes` and pre-merge hook) |
+
+**Observation.**mdbase has no equivalent. A vault using mdbase for
+data layering still needs a linter for prose quality,
+heading conventions, and table formatting. mdsmith
+fits this gap.
+
+## 14. Conventions and presets
+
+mdsmith ships three built-in conventions
+(`internal/rules/markdownflavor/conventions.go`):
+
+| Convention | Markdown flavor | Notable presets                                            |
+|------------|-----------------|------------------------------------------------------------|
+| portable   | CommonMark      | no inline HTML; emphasis bold=`*` italic=`_`; HR=`---`     |
+| github     | GFM             | inline HTML allow [details, summary]; emphasis as portable |
+| plain      | CommonMark      | minimal: only the strictest baseline                       |
+
+Selecting a convention sets all the relevant
+formatting rules at once; user `rules:` still wins
+on top via deep-merge.
+
+Plan 113 covers user-defined conventions: teams
+package their own preset bundles. Today only the
+three built-ins exist.
+
+mdbase has no equivalent. The spec does not describe
+preset bundles; each implementation chooses what
+to ship by default. Validation modes (off/warn/error)
+are not bundles, just toggles.
+
+## 15. Cache, watch, daemon
+
+| Concern          | mdsmith                  | mdbase                                         |
+|------------------|--------------------------|------------------------------------------------|
+| Persistent cache | none                     | optional SQLite at `.mdbase/index.sqlite` (L6) |
+| Cache rebuild    | n/a                      | `mdbase cache rebuild`                         |
+| Staleness check  | n/a                      | mtime + content hash                           |
+| Watch mode       | none                     | event stream (L6); 7 event types               |
+| Debounce         | n/a                      | 100–500ms window                               |
+| Daemon           | none                     | implementation-defined (LSP is the closest)    |
+| LSP cache        | per-session config cache | per-session config cache                       |
+
+The cache is the biggest runtime difference. mdbase
+expects to be useful at vault sizes of 10k+ files;
+the SQLite index makes that practical. mdsmith
+re-reads everything every run; on small repos this
+is a feature (deterministic, no stale state). On
+huge corpuses it is a limitation.
+
+mdbase's seven watch events: `file_created`,
+`file_modified`, `file_deleted`, `file_renamed`,
+`type_definition_updated`, `config_changed`,
+`validation_error`. Listeners can react in real time
+to any of these.
+
+## 16. CLI surface
+
+**mdsmith.** mdsmith side:
+
+```text
+mdsmith check [files...]            # lint
+mdsmith fix [files...]              # autofix in place
+mdsmith query <expr> [files...]     # CUE-based filter
+mdsmith init                        # write default .mdsmith.yml
+mdsmith metrics rank [files...]     # rank by metric
+mdsmith metrics list                # available metrics
+mdsmith kinds                       # show effective kinds per file
+mdsmith help [topic]                # offline rule docs
+mdsmith lsp                         # JSON-RPC over stdio
+mdsmith merge-driver install [globs] # git merge driver
+mdsmith merge-driver run …          # invoked by git
+mdsmith pre-merge-commit install    # git hook installer
+mdsmith version                     # build version
+```
+
+### mdbase (CLI implementation)
+
+The spec does not mandate a CLI shape, but the
+TypeScript CLI ships approximately:
+
+```text
+mdbase init                # bootstrap mdbase.yaml + _types/
+mdbase types               # list / inspect types
+mdbase validate [path]     # run schema validation
+mdbase query <query>       # run a Bases-syntax query
+mdbase create <type>       # create a new typed file
+mdbase update <path>       # update a file's fields
+mdbase rename <old> <new>  # rename + update refs (L5)
+mdbase delete <path>       # delete a file
+mdbase cache rebuild       # rebuild SQLite index (L6)
+mdbase cache clear         # drop cache
+mdbase watch               # event stream (L6)
+mdbase migrate             # apply migration manifests (L6)
+mdbase infer-types         # bootstrap types from existing FM
+```
+
+(Exact subcommands depend on the implementation;
+spec §0 lists "CLI tools for querying and manipulating
+collections" as a target audience but does not fix
+command names.)
+
+**Side by side.** In summary:
+
+| Capability           | mdsmith                    | mdbase (TS CLI)              |
+|----------------------|----------------------------|------------------------------|
+| Lint                 | `check`                    | (out of scope, per spec)     |
+| Autofix              | `fix`                      | n/a                          |
+| Schema validate      | `check` (MDS020)           | `validate`                   |
+| Query                | `query`                    | `query`                      |
+| Create file          | n/a                        | `create`                     |
+| Rename + update refs | n/a                        | `rename`                     |
+| Watch                | n/a                        | `watch`                      |
+| Cache rebuild        | n/a                        | `cache rebuild`              |
+| LSP                  | `lsp`                      | separate `mdbase-lsp` binary |
+| Git merge driver     | `merge-driver install`     | n/a                          |
+| Git pre-merge hook   | `pre-merge-commit install` | n/a                          |
+| Initialize project   | `init`                     | `init`                       |
+| Built-in rule docs   | `help <rule-id>`           | (spec docs only)             |
+
+## 17. LSP / editor integration
+
+**mdsmith.** mdsmith side:
+
+`mdsmith lsp` runs JSON-RPC 2.0 over stdio. Used by
+the VS Code extension. Implements:
+
+- `textDocument/publishDiagnostics` — diagnostic
+  push on save / change
+- `textDocument/codeAction` — `quickFix` per
+  diagnostic, `sourceFixAll` for whole-file fix
+- `workspace/configuration` — reads `mdsmith.config`
+  (config path) and `mdsmith.run` (`onSave`,
+  `onType`, `off`)
+- `workspace/didChangeWatchedFiles` — invalidates
+  cached config when `.mdsmith.yml` changes
+
+Not implemented: hover, completions, signature help,
+definition, references, rename. The server is
+diagnostic-and-fix only.
+
+Source: `internal/lsp/server.go`,
+`internal/lsp/diagnostics.go`,
+`internal/lsp/protocol.go`.
+
+**mdbase.**
+A separate `mdbase-lsp` binary (Rust) provides
+language-server features over the typed collection.
+Per the project README it covers:
+
+- diagnostics (validation errors)
+- completions (field names, enum values, type names)
+- hover info (type definitions, field constraints)
+- go-to-definition (link target, type)
+
+The Rust LSP is independent from the TypeScript
+reference implementation. It reads `mdbase.yaml`
+and the collection directly.
+
+**Side by side.** In summary:
+
+| LSP feature                 | mdsmith              | mdbase-lsp          |
+|-----------------------------|----------------------|---------------------|
+| Diagnostics                 | yes                  | yes                 |
+| Code actions / quick fix    | yes                  | n/a (no autofix)    |
+| Completion (field names)    | no                   | yes                 |
+| Hover (schema info)         | no                   | yes                 |
+| Go-to-definition            | no                   | yes                 |
+| Find references / backlinks | no                   | yes (via L5)        |
+| Rename refactor             | no                   | yes (L5)            |
+| Watched files reload        | yes (`.mdsmith.yml`) | yes (`mdbase.yaml`) |
+
+The two LSPs are non-overlapping in practice. A team
+running both gets diagnostics from each, code actions
+from mdsmith, and completion/navigation from mdbase.
+
+## 18. Output formats
+
+mdsmith (`internal/output/`):
+
+- `text` — human-readable with file:line:col, rule
+  ID, message, source snippet, ANSI color (toggle
+  with `--no-color`)
+- `json` — array of diagnostic objects with file,
+  line, column, severity, rule-id, rule-name, message
+- LSP wire format via the LSP server
+- `--explain` flag attaches per-leaf rule provenance
+
+No SARIF support today.
+
+mdbase: spec §9 mandates each diagnostic carry
+`path`, `field`, `code`, `message`, `severity`, with
+optional `line`, `column` for LSP-style reporting.
+Output format is implementation-defined; reference
+impls produce JSON.
+
+| Format         | mdsmith  | mdbase reference impl |
+|----------------|----------|-----------------------|
+| Text (TTY)     | yes      | yes                   |
+| JSON           | yes      | yes                   |
+| LSP wire       | yes      | yes (`mdbase-lsp`)    |
+| SARIF          | no       | no (not specified)    |
+| GitHub Actions | via JSON | via JSON              |
+
+## 19. Conformance and extension model
+
+**mdsmith.**
+No conformance tiers — there is one binary.
+Extension is via plan-driven internal rule additions
+(`internal/rules/<id>-<name>/`). User-defined
+conventions (plan 113) and user-defined rules are
+not yet shipped. A team that wants a new rule today
+contributes upstream.
+
+**mdbase.**
+Six conformance levels (spec §14):
+
+| Level | Name       | Adds                                                   |
+|-------|------------|--------------------------------------------------------|
+| 1     | Core       | Config, frontmatter, types, validation, CRUD           |
+| 2     | Matching   | Path globs, field presence, multi-type                 |
+| 3     | Querying   | Filter, sort, limit, expressions, body search          |
+| 4     | Links      | Wikilinks, markdown, bare paths, resolution, traversal |
+| 5     | References | Rename with reference updates, backlinks               |
+| 6     | Full       | SQLite cache + staleness, batch ops, watch, migrations |
+
+Each level carries a YAML test suite. An impl declares
+its level, e.g.:
+
+```text
+mdbase-tool v1.0.0
+Conformance: Level 4 (Links)
+Specification: 0.2.1
+```
+
+A new conforming impl can ship with only Level 1
+support and grow upward; users know what to expect.
+
+**Comparison.** Side-by-side breakdown:
+
+| Aspect                 | mdsmith            | mdbase                              |
+|------------------------|--------------------|-------------------------------------|
+| Spec / impl separation | no (single tool)   | yes (spec-first)                    |
+| Extension model        | upstream PRs       | new conforming impl                 |
+| Versioning             | semver of binary   | spec version + impl semver          |
+| Multi-impl interop     | n/a                | yes (any L_n impl reads same files) |
+| User-defined rules     | not yet (plan 113) | not in spec; per-impl               |
+
+mdbase's spec-first model is more robust to
+ecosystem fragmentation. mdsmith's single-impl model
+is simpler to reason about but creates a single
+point of fork should the project stall.
+
+## 20. Security posture
+
+**mdsmith.** mdsmith side:
+
+- Single static binary; no runtime dependencies
+- Offline at every phase
+- YAML billion-laughs guard: anchors and aliases are
+  rejected (`internal/yamlutil/yamlutil.go`)
+- Path traversal guards in build directive (rejects
+  `..` in output paths)
+- Recipe safety (MDS040) validates command syntax at
+  lint time; build directive does not execute today
+- Process-level GOMEMLIMIT bounds CUE evaluation
+- Atomic writes in fix mode
+- 10-finding adversarial review documented in
+  `docs/security/2026-04-05-adversarial-markdown.md`
+
+**mdbase.**
+The spec is silent on most security concerns. What
+it does mandate:
+
+- Path sandboxing in link resolution (spec §8) —
+  links cannot resolve outside the collection root
+- Optimistic concurrency via mtime (spec §12) —
+  prevents lost updates
+- `path_traversal` error code (Appendix C) — implies
+  impls reject escape attempts
+- File-watch debouncing (spec §15) — prevents event
+  storms, indirectly bounds resource use
+
+No spec-level requirements on YAML billion-laughs,
+adversarial input, or memory bounds. Each impl
+chooses its own posture. The TypeScript impl in
+particular brings a Node module graph as supply-chain
+surface.
+
+| Hardening            | mdsmith           | mdbase spec    | mdbase TS impl |
+|----------------------|-------------------|----------------|----------------|
+| Single binary        | yes               | n/a            | no (npm tree)  |
+| Offline              | yes               | mandated       | yes            |
+| YAML alias rejection | yes               | unspecified    | impl-defined   |
+| Path traversal block | yes               | mandated (§8)  | yes            |
+| ANSI escape sanitize | yes               | unspecified    | unknown        |
+| Memory bounds        | yes (GOMEMLIMIT)  | unspecified    | impl-defined   |
+| Adversarial review   | yes (10 findings) | n/a            | unknown        |
+| Atomic writes        | yes               | mandated (§12) | yes            |
+
+For untrusted Markdown (PRs from external
+contributors, third-party content) mdsmith ships
+with the harder posture today. An mdbase impl can
+match it but would need to declare its hardening
+explicitly.
+
+## 21. Determinism and idempotence
+
+| Property                         | mdsmith           | mdbase                         |
+|----------------------------------|-------------------|--------------------------------|
+| Same input → same output         | yes               | yes                            |
+| Order-independent                | yes (stable sort) | yes (deterministic resolution) |
+| Repeated `fix` converges         | yes (multi-pass)  | n/a (no fix layer)             |
+| Cache invalidation deterministic | n/a (no cache)    | mtime + hash                   |
+| Multi-impl agree                 | n/a               | yes (test suite)               |
+
+Both tools are deterministic by design. mdbase's
+multi-impl model carries more test obligation: every
+conforming impl must produce the same answer for
+the conformance test cases.
+
+## 22. Comparison summary
+
+| Domain                  | Owner        |
+|-------------------------|--------------|
+| Prose readability       | mdsmith only |
+| Heading and list rules  | mdsmith only |
+| Whitespace fixing       | mdsmith only |
+| Code-fence enforcement  | mdsmith only |
+| Token budget for LLMs   | mdsmith only |
+| Generated TOC / catalog | mdsmith only |
+| Include directive       | mdsmith only |
+| Build directive         | mdsmith only |
+| Git merge driver        | mdsmith only |
+| Front-matter typing     | shared       |
+| Front-matter querying   | shared       |
+| Schema validation       | shared       |
+| File-to-role assignment | shared       |
+| Wikilink parsing        | mdbase only  |
+| Rename refactoring      | mdbase only  |
+| Backlink graph          | mdbase only  |
+| SQLite index            | mdbase only  |
+| Watch / event stream    | mdbase only  |
+| CRUD operations         | mdbase only  |
+| Migrations              | mdbase only  |
+| Computed fields         | mdbase only  |
+| Generated values        | mdbase only  |
+| LSP completions / hover | mdbase only  |
+| LSP diagnostics         | shared       |
+| LSP code actions        | mdsmith only |
+
+[mds019]: ../../../internal/rules/MDS019-catalog/README.md
+[mds020]: ../../../internal/rules/MDS020-required-structure/README.md
+[mds021]: ../../../internal/rules/MDS021-include/README.md
+[mds038]: ../../../internal/rules/MDS038-toc/README.md
+[mds039]: ../../../internal/rules/MDS039-build/README.md

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -580,6 +580,188 @@ For ad-hoc CI filters ("which files have
 running a vault as a database (showing all
 overdue tasks grouped by assignee), mdbase wins.
 
+### Concrete query examples
+
+Eight worked queries against the same task corpus,
+showing the syntactic and capability differences.
+The corpus has FM like
+`{ id, title, status, priority, due, assignee,
+related_tasks }` per file.
+
+**Q-A: simple equality filter.** List files where `status == "open"`.
+
+```bash
+# mdsmith
+mdsmith query 'status: "open"' tasks/
+```
+
+```yaml
+# mdbase
+types: [task]
+where: status == "open"
+```
+
+Both work today. The mdsmith form is a CUE
+struct literal; mdbase uses an expression
+string.
+
+**Q-B: compound boolean.** Open tasks with priority at least 3.
+
+```bash
+# mdsmith — compound conditions in CUE need
+# inequality bounds and conjunction inside one struct
+mdsmith query 'status: "open", priority: int & >=3' tasks/
+```
+
+```yaml
+# mdbase
+types: [task]
+where: status == "open" && priority >= 3
+```
+
+The mdbase syntax is more familiar; the CUE
+form is exact and composes with existing
+struct schemas.
+
+**Q-C: date range — "due in the next 7 days".** Open tasks due in the next week.
+
+```bash
+# mdsmith — CUE has no first-class duration arithmetic
+# in the query surface; users either compute the bound
+# externally and substitute, or post-filter:
+DUE_LIMIT="$(date -u -d '+7 days' +%Y-%m-%d)"
+mdsmith query "status: \"open\", due: <= \"${DUE_LIMIT}\"" tasks/
+```
+
+```yaml
+# mdbase
+types: [task]
+where: status == "open" && due <= today() + "7d"
+```
+
+mdbase wins on ergonomics here. The shell
+substitution works for mdsmith but is awkward
+in CI (every job recomputes the bound).
+Closing this gap is Q-4 in
+[learn-from-mdbase.md](learn-from-mdbase.md).
+
+**Q-D: list contains — "tasks tagged urgent".**
+Tasks whose `tags` list includes `urgent`.
+
+```bash
+# mdsmith — list membership via CUE list literal
+mdsmith query 'tags: ["urgent", ...]' tasks/
+```
+
+```yaml
+# mdbase
+types: [task]
+where: tags.contains("urgent")
+```
+
+Both work; the CUE form requires the list to
+match exactly the literal; the variant
+`'tags: [..., "urgent", ...]'` is needed for
+"contains" rather than "starts with". mdbase's
+method form is more readable.
+
+**Q-E: cross-file traversal — "RFCs whose owner
+is a senior engineer".** Filter on a field of
+the linked person record.
+
+```yaml
+# mdbase: assumes person files have a level field
+types: [rfc]
+where: owner.asFile().level == "senior"
+```
+
+```text
+# mdsmith: not expressible in `query` today.
+# Workaround:
+#   1. mdsmith query 'level: "senior"' people/
+#   2. capture the file basenames as a set
+#   3. mdsmith query "owner: <name>" rfcs/ for each
+# This is L-5 / Q-6 in learn-from-mdbase.md.
+```
+
+**Q-F: body content — "tasks mentioning OIDC".**
+Filter by a substring in the body.
+
+```yaml
+# mdbase
+types: [task]
+where: file.body.contains("OIDC")
+```
+
+```bash
+# mdsmith: combine `query` with ripgrep
+mdsmith query 'kind: "task"' tasks/ | xargs rg -l 'OIDC'
+```
+
+mdsmith works via shell composition; mdbase
+keeps it inside the query DSL. Q-3 in
+[learn-from-mdbase.md](learn-from-mdbase.md)
+sketches a native `--body-contains` flag.
+
+**Q-G: sort and limit — "top 5 oldest open tasks".** The five oldest open tasks.
+
+```yaml
+# mdbase
+types: [task]
+where: status == "open"
+order_by:
+  - field: created
+    direction: asc
+limit: 5
+```
+
+```bash
+# mdsmith: filter, then pipe
+mdsmith query 'status: "open"' tasks/ \
+  | xargs grep -l "^created:" \
+  | sort -t: -k2 \
+  | head -5
+```
+
+The shell pipeline gets verbose. Q-1 / Q-2 in
+[learn-from-mdbase.md](learn-from-mdbase.md)
+add `--order-by` and `--limit` flags.
+
+**Q-H: aggregation — "count open tasks per
+assignee".** Group by assignee, count.
+
+```yaml
+# mdbase
+types: [task]
+where: status == "open"
+group_by: assignee
+aggregate:
+  - count
+order_by: count desc
+```
+
+```bash
+# mdsmith: filter + jq, or filter + awk
+mdsmith query 'status: "open"' --format json tasks/ \
+  | jq -r '.[].frontmatter.assignee' \
+  | sort | uniq -c | sort -rn
+```
+
+Aggregation is mdbase-only territory today.
+Q-5 in [learn-from-mdbase.md](learn-from-mdbase.md)
+sketches what native support would look like.
+
+**Reading across.** mdsmith's query covers the
+common filter case ergonomically and composes
+with shell tools for everything else. mdbase
+covers more inside the DSL — date arithmetic,
+cross-file traversal, body search, aggregation
+— at the cost of a richer language to learn.
+For ad-hoc CI use, mdsmith plus pipes works.
+For interactive vault navigation where the user
+is composing many queries quickly, mdbase pays
+for its language complexity.
+
 ## 9. Link handling
 
 **mdsmith.**

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -646,11 +646,12 @@ Closing this gap is Q-4 in
 [learn-from-mdbase.md](learn-from-mdbase.md).
 
 **Q-D: list contains — "tasks tagged urgent".**
-Tasks whose `tags` list includes `urgent`.
+Tasks whose `tags` list includes `urgent` at any
+position.
 
 ```bash
-# mdsmith — list membership via CUE list literal
-mdsmith query 'tags: ["urgent", ...]' tasks/
+# mdsmith — "contains" via CUE list pattern with leading + trailing ellipsis
+mdsmith query 'tags: [..., "urgent", ...]' tasks/
 ```
 
 ```yaml
@@ -659,11 +660,13 @@ types: [task]
 where: tags.contains("urgent")
 ```
 
-Both work; the CUE form requires the list to
-match exactly the literal; the variant
-`'tags: [..., "urgent", ...]'` is needed for
-"contains" rather than "starts with". mdbase's
-method form is more readable.
+Both work. The CUE form needs the leading
+`...` to allow elements before `"urgent"`;
+without it (`'tags: ["urgent", ...]'`) the
+match is "starts with `urgent`", not
+"contains". mdbase's method form
+(`tags.contains(...)`) is more readable for
+membership.
 
 **Q-E: cross-file traversal — "RFCs whose owner
 is a senior engineer".** Filter on a field of

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -1,5 +1,9 @@
 ---
-summary: Feature-by-feature comparison of mdsmith and mdbase across distribution, configuration, type system, validation, queries, links, generated content, prose linting, conventions, cache, CLI, LSP, output formats, and security posture.
+summary: >-
+  Feature-by-feature comparison of mdsmith and mdbase across
+  distribution, configuration, type system, validation, queries, links,
+  generated content, prose linting, conventions, cache, CLI, LSP, output
+  formats, and security posture.
 status: 🔳
 ---
 # Feature-by-feature comparison

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -872,10 +872,10 @@ command names.)
 
 ## 17. LSP / editor integration
 
-**mdsmith.** mdsmith side:
-
+**mdsmith today.**
 `mdsmith lsp` runs JSON-RPC 2.0 over stdio. Used by
-the VS Code extension. Implements:
+the VS Code extension and any LSP-aware editor or
+agent. Implements:
 
 - `textDocument/publishDiagnostics` — diagnostic
   push on save / change
@@ -887,13 +887,47 @@ the VS Code extension. Implements:
 - `workspace/didChangeWatchedFiles` — invalidates
   cached config when `.mdsmith.yml` changes
 
-Not implemented: hover, completions, signature help,
-definition, references, rename. The server is
-diagnostic-and-fix only.
+Not implemented today: hover, completions,
+signature help, definition, references, rename. The
+shipped server is diagnostic-and-fix only.
 
 Source: `internal/lsp/server.go`,
 `internal/lsp/diagnostics.go`,
 `internal/lsp/protocol.go`.
+
+**mdsmith planned (plans 122 and 131).**
+Two open plans extend the LSP toward parity with
+typical code-LSPs and toward explicit support for
+agent-driven navigation (Claude Code's LSP tool,
+Neovim, Helix):
+
+- **Plan 122** adds `textDocument/hover` for rule
+  IDs and directive names, surfacing the offline
+  rule docs and directive parameter help inline.
+- **Plan 131** ([PR #238][pr238]) adds symbol
+  navigation: `documentSymbol`, `definition`,
+  `implementation`, `references`,
+  `workspace/symbol`, plus call hierarchy
+  (`prepareCallHierarchy`, `incomingCalls`,
+  `outgoingCalls`). The design models a Markdown
+  file as a "function" and outbound references
+  (links, includes, catalog matches, build
+  targets) as "calls", so an agent can ask
+  "who depends on this runbook?" or "what does
+  this overview embed?" through standard LSP
+  methods.
+
+Plan 131 explicitly maps the nine LSP methods that
+Claude Code's LSP tool exposes (symbol, definition,
+implementation, hover, references, workspace
+symbol, call hierarchy in / out / prepare) onto
+the existing AST and link graph. This is the
+"LSP for agents" arc.
+
+Performance budgets in plan 131: cold index build
+under 1s on 1,000 files, incremental update under
+20ms per `didChange`. Memory cap reuses plan 121's
+512 MB `GOMEMLIMIT`.
 
 **mdbase.**
 A separate `mdbase-lsp` binary (Rust) provides
@@ -907,24 +941,66 @@ Per the project README it covers:
 
 The Rust LSP is independent from the TypeScript
 reference implementation. It reads `mdbase.yaml`
-and the collection directly.
+and the collection directly. Symbol-level
+navigation (documentSymbol, references, workspace
+symbol, call hierarchy) is not advertised in the
+project README at the time of writing.
 
-**Side by side.** In summary:
+**Side by side.** Three columns: mdsmith today,
+mdsmith after plans 122 + 131 land, and
+mdbase-lsp today.
 
-| LSP feature                 | mdsmith              | mdbase-lsp          |
-|-----------------------------|----------------------|---------------------|
-| Diagnostics                 | yes                  | yes                 |
-| Code actions / quick fix    | yes                  | n/a (no autofix)    |
-| Completion (field names)    | no                   | yes                 |
-| Hover (schema info)         | no                   | yes                 |
-| Go-to-definition            | no                   | yes                 |
-| Find references / backlinks | no                   | yes (via L5)        |
-| Rename refactor             | no                   | yes (L5)            |
-| Watched files reload        | yes (`.mdsmith.yml`) | yes (`mdbase.yaml`) |
+| LSP feature              | mdsmith today | mdsmith planned   | mdbase-lsp       |
+|--------------------------|---------------|-------------------|------------------|
+| `publishDiagnostics`     | yes           | yes               | yes              |
+| `codeAction` (quick fix) | yes           | yes               | n/a (no autofix) |
+| `codeAction` (fix all)   | yes           | yes               | n/a              |
+| `hover`                  | no            | yes (plan 122)    | yes              |
+| `completion`             | no            | no (out of scope) | yes              |
+| `documentSymbol`         | no            | yes (plan 131)    | partial          |
+| `definition`             | no            | yes (plan 131)    | yes              |
+| `implementation`         | no            | yes (plan 131)    | unknown          |
+| `references`             | no            | yes (plan 131)    | unknown          |
+| `workspace/symbol`       | no            | yes (plan 131)    | unknown          |
+| `prepareCallHierarchy`   | no            | yes (plan 131)    | no               |
+| `incomingCalls`          | no            | yes (plan 131)    | no               |
+| `outgoingCalls`          | no            | yes (plan 131)    | no               |
+| `rename`                 | no            | no (out of scope) | yes (L5)         |
+| `signatureHelp`          | no            | no                | no               |
+| `semanticTokens`         | no            | no                | no               |
+| `inlayHint`              | no            | no                | no               |
+| `codeLens`               | no            | no                | no               |
+| `didChangeWatchedFiles`  | yes (`.yml`)  | yes (`**/*.md`)   | yes              |
 
-The two LSPs are non-overlapping in practice. A team
-running both gets diagnostics from each, code actions
-from mdsmith, and completion/navigation from mdbase.
+The two LSPs are non-overlapping in practice
+today. A team running both gets diagnostics from
+each, code actions from mdsmith, and completion +
+navigation from mdbase. Once plan 131 lands,
+mdsmith covers the navigation surface as well —
+specifically the call-hierarchy view on the
+include/catalog/build graph that mdbase does not
+model.
+
+**LSP for AI agents.** Both projects are
+explicitly positioned for use by AI agents over
+LSP, but with different framings:
+
+- mdbase-lsp gives an agent the typed-vault view:
+  "what fields does this type allow", "where is
+  this link's target". The schema is the agent's
+  reading frame.
+- mdsmith plan 131 gives an agent the
+  document-graph view: outline, anchors, includes,
+  catalog matches, build targets. The link graph
+  is the agent's reading frame.
+
+For an agent rewriting prose with structural
+awareness, mdsmith's planned outline + call
+hierarchy is the closer fit. For an agent
+reasoning about typed records (queries,
+constraints, generated values), mdbase-lsp wins.
+A team using both serves both reading frames over
+LSP without leaving the editor protocol.
 
 ## 18. Output formats
 
@@ -1106,3 +1182,4 @@ the conformance test cases.
 [mds021]: ../../../internal/rules/MDS021-include/README.md
 [mds038]: ../../../internal/rules/MDS038-toc/README.md
 [mds039]: ../../../internal/rules/MDS039-build/README.md
+[pr238]: https://github.com/jeduden/mdsmith/pull/238

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -4,7 +4,6 @@ summary: >-
   distribution, configuration, type system, validation, queries, links,
   generated content, prose linting, conventions, cache, CLI, LSP, output
   formats, and security posture.
-status: 🔳
 ---
 # Feature-by-feature comparison
 

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -98,15 +98,21 @@ Single config file at the collection root. Required:
 | Per-role rule bundle   | `kinds:` map                   | type files in `_types/`     |
 | Schema validation flag | per-rule severity (Error/Warn) | `default_validation` global |
 
-mdbase declares schemas as Markdown files in
-`_types/`; mdsmith declares them as CUE schema files
-referenced from `.mdsmith.yml`. This is the cleanest
-illustration of the tools' opposite bets:
+Both tools declare schemas as Markdown files. The
+difference is where the file lives and what it
+covers:
 
-- mdsmith pulls schemas into the lint config alongside
-  rule settings.
-- mdbase pushes schemas into the vault as first-class
-  content, so the schema travels with the data.
+- mdbase types live in a fixed `_types/` folder
+  next to the content, discoverable from the file
+  tree alone. The front matter carries the typed
+  schema; the body is documentation.
+- mdsmith schemas (typically `proto.md`) live
+  wherever the team puts them, referenced from a
+  kind in `.mdsmith.yml` via
+  `required-structure.schema:`. The front matter
+  carries CUE expressions; the body carries the
+  required heading template. mdsmith schemas
+  validate body structure as well as front matter.
 
 ## 3. Type / kind definitions
 
@@ -114,17 +120,16 @@ illustration of the tools' opposite bets:
 
 Defined in `.mdsmith.yml` under the `kinds:` map. A
 kind is a named bundle of rule overrides plus
-optionally a CUE schema and category toggles
-(`internal/config/config.go`):
+optionally a `required-structure.schema:` pointer
+to a Markdown schema file (`proto.md`) and category
+toggles (`internal/config/config.go`):
 
 ```yaml
 kinds:
-  proto:
+  rule-readme:
     rules:
-      first-line-heading: false
-      heading-increment: false
       required-structure:
-        schema: internal/concepts/rule.cue
+        schema: internal/rules/proto.md
   api-doc:
     rules:
       line-length:
@@ -135,13 +140,19 @@ kinds:
 
 Assignment to files works in two ways:
 
-1. Front-matter declaration — `kinds: [proto]` or
-   `kind: proto` in the file's YAML
+1. Front-matter declaration — `kinds: [rule-readme]`
+   or `kind: rule-readme` in the file's YAML
 2. Glob from `kind-assignment:` in `.mdsmith.yml`
 
 Inheritance: there is no kind-to-kind inheritance.
 A file can carry multiple kinds; each is deep-merged
 into the effective config in declaration order.
+
+(Note: `internal/concepts/` in this repo holds
+implementation architecture documentation
+— placeholder grammar, concept notes — not
+user-facing schemas. Schemas are the `proto.md`
+files referenced from kinds.)
 
 ### mdbase: types
 
@@ -197,25 +208,33 @@ at read time using the expression language from
 spec §11. They are not persisted to the front matter;
 queries can still reference them.
 
-**Side by side.** In summary:
+**Side by side.** A kind in mdsmith is the
+user-facing concept that ties files to a rule
+bundle and an optional schema; a type in mdbase is
+the user-facing concept that ties files to a typed
+schema. Both can carry a Markdown schema file.
 
-| Aspect              | mdsmith kinds                  | mdbase types                                |
-|---------------------|--------------------------------|---------------------------------------------|
-| Storage             | YAML in `.mdsmith.yml`         | Markdown files in `_types/`                 |
-| Travels with files  | No (config-only)               | Yes (in-vault)                              |
-| Inheritance         | None                           | Single (`extends`)                          |
-| Computed fields     | No                             | Yes (expression-based, read-time)           |
-| Bundles rule config | Yes (deep-merge)               | No (rules are mdsmith's, not mdbase's)      |
-| Bundles schema      | Yes (CUE path)                 | Yes (declarative DSL)                       |
-| Multi-type per file | Yes (kind list, deep-merged)   | Yes (multi-match, intersect constraints)    |
-| Path constraint     | `kind-assignment` globs        | `path_pattern` (validates and generates)    |
-| Discoverability     | Run `mdsmith kinds` to inspect | List `_types/`; each type doc is the schema |
+| Aspect                    | mdsmith kinds                                                            | mdbase types                                 |
+|---------------------------|--------------------------------------------------------------------------|----------------------------------------------|
+| User-facing concept       | `kind` (per-file role)                                                   | `type` (per-file shape)                      |
+| Kind/type definition      | `kinds:` map in `.mdsmith.yml`                                           | Markdown file in `_types/`                   |
+| Schema file format        | Markdown `proto.md` (CUE in FM, headings in body)                        | Markdown in `_types/` (DSL in FM, body docs) |
+| Schema travels with files | Yes — the `proto.md` is in the repo                                      | Yes — `_types/*.md` is in the vault          |
+| Inheritance               | None across kinds; schemas compose via `<?include?>`                     | Single (`extends`)                           |
+| Computed fields           | No                                                                       | Yes (expression-based, read-time)            |
+| Bundles rule config       | Yes (deep-merge)                                                         | No (rules are mdsmith's, not mdbase's)       |
+| Validates body structure  | Yes (heading template + `<?require?>`)                                   | No (body is documentation only)              |
+| Multi-type per file       | Yes (kind list, deep-merged)                                             | Yes (multi-match, intersect constraints)     |
+| Path constraint           | `kind-assignment` globs                                                  | `path_pattern` (validates and generates)     |
+| Discoverability           | `mdsmith kinds` lists effective config; schema files are normal Markdown | List `_types/`                               |
 
-The crucial difference: an mdbase type file is
-itself a valid Markdown file in the vault, so any
-text editor reads it. An mdsmith kind is YAML inside
-the linter config and is invisible from the editor's
-file tree unless the user opens `.mdsmith.yml`.
+A kind without a schema is still useful: it can
+just toggle rule settings for a slice of files
+(e.g. `proto` disables structural rules on
+`proto.md` files themselves). A kind with a
+schema points at a `proto.md` that validates
+matched files. The two concepts compose via
+deep-merge.
 
 ## 4. File-to-type / kind matching
 
@@ -268,29 +287,75 @@ mdsmith requires explicit kind tags or globs.
 
 ## 5. Field type system
 
-### mdsmith: CUE schemas
+### mdsmith: schema files via [MDS020][mds020]
 
-Front-matter validation happens via [MDS020
-required-structure][mds020]. Schemas are CUE files
-referenced from `.mdsmith.yml` or kind config:
+Front-matter and body-structure validation both
+happen through [MDS020 required-structure][mds020].
+A schema is a Markdown file (typically named
+`proto.md`) referenced from a kind in `.mdsmith.yml`:
 
-```cue
-// internal/concepts/rule.cue
-package rule
-
-#Rule: {
-    id:          string
-    name:        string
-    status:      "ready" | "not-ready"
-    description: string
-    settings?: {[string]: _}
-}
+```yaml
+kinds:
+  rule-readme:
+    rules:
+      required-structure:
+        schema: internal/rules/proto.md
 ```
 
-CUE provides rich constraints: regex patterns, enum
-disjunctions, optional fields with `?`, structural
-types, value coercion. Errors are reported as MDS020
-diagnostics with line/column anchors.
+The schema file itself carries CUE expressions in
+its YAML front matter (validating the document's
+front matter) and a heading template in its body
+(validating the document's heading structure).
+Example schema:
+
+```markdown
+---
+id: '=~"^MDS[0-9]{3}$"'
+name: 'string & != ""'
+status: '"ready" | "not-ready"'
+description: 'string & != ""'
+"settings?": {[string]: _}
+---
+<?require
+filename: "[0-9]*-*/README.md"
+?>
+
+# ?
+
+## Settings
+
+## Examples
+
+## Meta-Information
+```
+
+CUE in the front matter provides rich constraints
+(regex, enum disjunctions, optional fields, value
+coercion). The body provides the heading template
+that documents must match. `<?require?>` declares
+extra constraints (e.g. filename glob).
+`<?include?>` lets schemas compose by splicing in
+fragments. Errors surface as MDS020 diagnostics
+with line/column anchors.
+
+This means an mdsmith schema and an mdbase type
+file have very similar shape: both are Markdown
+files with declarative front matter, and both
+travel with the project under version control.
+The differences sit in scope and ownership:
+
+- mdsmith schemas validate **both** front matter
+  (CUE) **and** body heading structure (template).
+- mdbase types validate only the front matter
+  (typed fields, constraints, generated values),
+  and the body is documentation for humans.
+- mdsmith schemas are referenced from `kinds:` in
+  `.mdsmith.yml`. They live anywhere; the
+  project convention is one `proto.md` next to
+  the files it describes.
+- mdbase types live under a fixed `_types/`
+  folder so they are discoverable from the file
+  tree alone.
 
 ### mdbase: 12 field types
 
@@ -318,17 +383,19 @@ not applied when a field is present-but-null.
 
 **Comparison.** Side-by-side breakdown:
 
-| Concern                 | mdsmith (CUE)                 | mdbase (DSL)                                    |
-|-------------------------|-------------------------------|-------------------------------------------------|
-| Validation language     | CUE, an external language     | Inline YAML in type front matter                |
-| Type discoverability    | Read CUE files                | Read `_types/*.md`                              |
-| Built-in types          | Anything CUE supports         | 12 fixed types                                  |
-| Custom constraints      | Yes (full CUE)                | Limited to the per-type knobs                   |
-| Inheritance             | CUE definitions / unification | `extends:` single inheritance                   |
-| Computed fields         | No (CUE is purely structural) | Yes (expression-based)                          |
-| Generated values        | No                            | `generated:` (ULID, UUID, sequence, timestamps) |
-| Deprecation flag        | No                            | Yes (`deprecated: true`)                        |
-| Cross-field constraints | Yes (CUE)                     | Limited                                         |
+| Concern                 | mdsmith (CUE)                                    | mdbase (DSL)                                    |
+|-------------------------|--------------------------------------------------|-------------------------------------------------|
+| Schema file format      | `proto.md` (CUE in FM, heading template in body) | `_types/<name>.md` (DSL in FM, docs in body)    |
+| Validation language     | CUE in front matter                              | Inline YAML in type front matter                |
+| Type discoverability    | Read the `proto.md` referenced by a kind         | Read `_types/*.md`                              |
+| Built-in types          | Anything CUE supports                            | 12 fixed types                                  |
+| Custom constraints      | Yes (full CUE)                                   | Limited to the per-type knobs                   |
+| Inheritance             | CUE unification + schema `<?include?>`           | `extends:` single inheritance                   |
+| Body structure check    | Yes (heading template, `<?require?>`)            | No (out of scope)                               |
+| Computed fields         | No (CUE is purely structural)                    | Yes (expression-based)                          |
+| Generated values        | No                                               | `generated:` (ULID, UUID, sequence, timestamps) |
+| Deprecation flag        | No                                               | Yes (`deprecated: true`)                        |
+| Cross-field constraints | Yes (CUE)                                        | Limited                                         |
 
 CUE is the more powerful constraint language;
 mdbase's DSL is simpler but covers the typical Markdown
@@ -752,7 +819,7 @@ mdbase has none — it does not lint prose at all.
 | MDS040 | Recipe safety (build command syntax check)          |
 | MDS048 | Git-hook sync (`.gitattributes` and pre-merge hook) |
 
-**Observation.**mdbase has no equivalent. A vault using mdbase for
+**Observation.** mdbase has no equivalent. A vault using mdbase for
 data layering still needs a linter for prose quality,
 heading conventions, and table formatting. mdsmith
 fits this gap.
@@ -901,20 +968,22 @@ typical code-LSPs and toward explicit support for
 agent-driven navigation (Claude Code's LSP tool,
 Neovim, Helix):
 
-- **Plan 122** adds `textDocument/hover` for rule
-  IDs and directive names, surfacing the offline
-  rule docs and directive parameter help inline.
-- **Plan 131** ([PR #238][pr238]) adds symbol
-  navigation: `documentSymbol`, `definition`,
-  `implementation`, `references`,
-  `workspace/symbol`, plus call hierarchy
-  (`prepareCallHierarchy`, `incomingCalls`,
-  `outgoingCalls`). The design models a Markdown
-  file as a "function" and outbound references
-  (links, includes, catalog matches, build
-  targets) as "calls", so an agent can ask
-  "who depends on this runbook?" or "what does
-  this overview embed?" through standard LSP
+- **Plan 122** ([`plan/122_vscode-hover-and-palette.md`][plan122])
+  adds `textDocument/hover` for rule IDs and
+  directive names, surfacing the offline rule docs
+  and directive parameter help inline.
+- **Plan 131** is tracked in [PR #238][pr238]; the
+  plan file lives on that branch and is not yet on
+  `main`. It adds symbol navigation:
+  `documentSymbol`, `definition`, `implementation`,
+  `references`, `workspace/symbol`, plus call
+  hierarchy (`prepareCallHierarchy`,
+  `incomingCalls`, `outgoingCalls`). The design
+  models a Markdown file as a "function" and
+  outbound references (links, includes, catalog
+  matches, build targets) as "calls", so an agent
+  can ask "who depends on this runbook?" or "what
+  does this overview embed?" through standard LSP
   methods.
 
 Plan 131 explicitly maps the nine LSP methods that
@@ -1183,3 +1252,4 @@ the conformance test cases.
 [mds038]: ../../../internal/rules/MDS038-toc/README.md
 [mds039]: ../../../internal/rules/MDS039-build/README.md
 [pr238]: https://github.com/jeduden/mdsmith/pull/238
+[plan122]: ../../../plan/122_vscode-hover-and-palette.md

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -693,15 +693,16 @@ types: [task]
 where: file.body.contains("OIDC")
 ```
 
-```bash
-# mdsmith: combine `query` with ripgrep
-mdsmith query 'kind: "task"' tasks/ | xargs rg -l 'OIDC'
+```text
+# mdsmith: not expressible in `query` today. The
+# right answer is a native body-content matcher
+# built into mdsmith, not a pipe to an external
+# tool — mdsmith ships as a single static binary
+# and should not require ripgrep or grep on PATH.
+# Q-3 in learn-from-mdbase.md sketches a native
+# `--body-contains REGEX` flag using Go's regexp
+# engine and the existing parallel file walk.
 ```
-
-mdsmith works via shell composition; mdbase
-keeps it inside the query DSL. Q-3 in
-[learn-from-mdbase.md](learn-from-mdbase.md)
-sketches a native `--body-contains` flag.
 
 **Q-G: sort and limit — "top 5 oldest open tasks".** The five oldest open tasks.
 
@@ -715,15 +716,17 @@ order_by:
 limit: 5
 ```
 
-```bash
-# mdsmith: filter, then pipe
-mdsmith query 'status: "open"' tasks/ \
-  | xargs grep -l "^created:" \
-  | sort -t: -k2 \
-  | head -5
+```text
+# mdsmith: not expressible in `query` today.
+# Q-1 (`--order-by`) and Q-2 (`--limit`) in
+# learn-from-mdbase.md add native flags;
+# until they land, the user filters with
+# `mdsmith query` and orders/limits in the
+# calling script. The native answer is in
+# mdsmith, not in a pipe.
 ```
 
-The shell pipeline gets verbose. Q-1 / Q-2 in
+Q-1 / Q-2 in
 [learn-from-mdbase.md](learn-from-mdbase.md)
 add `--order-by` and `--limit` flags.
 
@@ -740,25 +743,35 @@ aggregate:
 order_by: count desc
 ```
 
-```bash
-# mdsmith: filter + jq, or filter + awk
-mdsmith query 'status: "open"' --format json tasks/ \
-  | jq -r '.[].frontmatter.assignee' \
-  | sort | uniq -c | sort -rn
+```text
+# mdsmith: not expressible in `query` today.
+# Q-5 in learn-from-mdbase.md sketches a native
+# `--group-by` / `--aggregate` surface on
+# `mdsmith query`. mdsmith should not require
+# jq, awk, or other external tools to do
+# aggregation — the binary ships standalone.
 ```
 
-Aggregation is mdbase-only territory today.
-Q-5 in [learn-from-mdbase.md](learn-from-mdbase.md)
-sketches what native support would look like.
+Aggregation lives in the mdbase DSL today;
+mdsmith would grow a native equivalent if the
+trigger fires.
 
 **Reading across.** mdsmith's query covers the
-common filter case ergonomically and composes
-with shell tools for everything else. mdbase
+common filter case ergonomically. mdbase
 covers more inside the DSL — date arithmetic,
 cross-file traversal, body search, aggregation
 — at the cost of a richer language to learn.
-For ad-hoc CI use, mdsmith plus pipes works.
-For interactive vault navigation where the user
+The candidate plans (Q-1 through Q-5 in
+[learn-from-mdbase.md](learn-from-mdbase.md))
+all describe **native mdsmith** implementations
+of these capabilities, not workarounds via
+shell pipelines or external dependencies.
+mdsmith's single-binary identity is preserved
+either way: today by keeping `query` simple, or
+later by adding the native operations alongside
+the existing parallel-walk and FM-parse
+infrastructure. For interactive vault
+navigation where the user
 is composing many queries quickly, mdbase pays
 for its language complexity.
 

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -727,16 +727,29 @@ is read-and-fix; mdbase is read-write-CRUD.
 
 Block-form processing instructions. Each pairs with
 a rule that detects drift and a fix that regenerates
-the body. Five active directives, all using the form
+the body. Four active body-generating directives,
+all using the form
 `<?name [params]?>...body...<?/name?>`:
 
-| Directive                | Rule             | Generates                                                 |
-|--------------------------|------------------|-----------------------------------------------------------|
-| `<?catalog?>`            | [MDS019][mds019] | Table of files matching a glob, with FM fields as columns |
-| `<?include?>`            | [MDS021][mds021] | Inline content from another Markdown file                 |
-| `<?toc?>`                | [MDS038][mds038] | Nested heading list with GitHub anchors                   |
-| `<?build?>`              | [MDS039][mds039] | Body from a recipe template (no execution today)          |
-| `<?required-structure?>` | [MDS020][mds020] | Heading-by-heading template enforcement                   |
+| Directive     | Rule             | Generates                                                 |
+|---------------|------------------|-----------------------------------------------------------|
+| `<?catalog?>` | [MDS019][mds019] | Table of files matching a glob, with FM fields as columns |
+| `<?include?>` | [MDS021][mds021] | Inline content from another Markdown file                 |
+| `<?toc?>`     | [MDS038][mds038] | Nested heading list with GitHub anchors                   |
+| `<?build?>`   | [MDS039][mds039] | Body from a recipe template (no execution today)          |
+
+Heading-template enforcement is **not** a
+directive; it is the [MDS020][mds020] rule
+applied to a kind whose
+`required-structure.schema:` points at a schema
+file (typically `proto.md`). The schema's body
+carries the required heading skeleton; the rule
+checks that real files match. Schemas can
+themselves use `<?include?>` to compose
+fragments, and a schema-only PI `<?require?>`
+declares filename / structural constraints
+(spec'd in
+`internal/rules/MDS020-required-structure/README.md`).
 
 Plus support directives:
 

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -49,10 +49,15 @@ convention preset (portable | github | plain)
   ↓ deep-merge
 top-level rules:
   ↓ deep-merge
-overrides: [{glob, rules}, …]
-  ↓ deep-merge
 kinds assigned to file (front-matter or kind-assignment)
+  ↓ deep-merge
+overrides: [{glob, rules}, …]
 ```
+
+(Layer order matches `internal/config/merge.go`'s
+`effectiveRules`: defaults → convention → user
+rules → kinds → overrides, with later layers
+winning on conflict.)
 
 Deep-merge semantics (see
 `internal/config/deepmerge.go`):

--- a/docs/research/mdbase-vs-mdsmith/features.md
+++ b/docs/research/mdbase-vs-mdsmith/features.md
@@ -1019,27 +1019,27 @@ project README at the time of writing.
 mdsmith after plans 122 + 131 land, and
 mdbase-lsp today.
 
-| LSP feature              | mdsmith today | mdsmith planned   | mdbase-lsp       |
-|--------------------------|---------------|-------------------|------------------|
-| `publishDiagnostics`     | yes           | yes               | yes              |
-| `codeAction` (quick fix) | yes           | yes               | n/a (no autofix) |
-| `codeAction` (fix all)   | yes           | yes               | n/a              |
-| `hover`                  | no            | yes (plan 122)    | yes              |
-| `completion`             | no            | no (out of scope) | yes              |
-| `documentSymbol`         | no            | yes (plan 131)    | partial          |
-| `definition`             | no            | yes (plan 131)    | yes              |
-| `implementation`         | no            | yes (plan 131)    | unknown          |
-| `references`             | no            | yes (plan 131)    | unknown          |
-| `workspace/symbol`       | no            | yes (plan 131)    | unknown          |
-| `prepareCallHierarchy`   | no            | yes (plan 131)    | no               |
-| `incomingCalls`          | no            | yes (plan 131)    | no               |
-| `outgoingCalls`          | no            | yes (plan 131)    | no               |
-| `rename`                 | no            | no (out of scope) | yes (L5)         |
-| `signatureHelp`          | no            | no                | no               |
-| `semanticTokens`         | no            | no                | no               |
-| `inlayHint`              | no            | no                | no               |
-| `codeLens`               | no            | no                | no               |
-| `didChangeWatchedFiles`  | yes (`.yml`)  | yes (`**/*.md`)   | yes              |
+| LSP feature              | mdsmith today | mdsmith planned | mdbase-lsp       |
+|--------------------------|---------------|-----------------|------------------|
+| `publishDiagnostics`     | yes           | yes             | yes              |
+| `codeAction` (quick fix) | yes           | yes             | n/a (no autofix) |
+| `codeAction` (fix all)   | yes           | yes             | n/a              |
+| `hover`                  | no            | yes (plan 122)  | yes              |
+| `completion`             | no            | not yet planned | yes              |
+| `documentSymbol`         | no            | yes (plan 131)  | partial          |
+| `definition`             | no            | yes (plan 131)  | yes              |
+| `implementation`         | no            | yes (plan 131)  | unknown          |
+| `references`             | no            | yes (plan 131)  | unknown          |
+| `workspace/symbol`       | no            | yes (plan 131)  | unknown          |
+| `prepareCallHierarchy`   | no            | yes (plan 131)  | no               |
+| `incomingCalls`          | no            | yes (plan 131)  | no               |
+| `outgoingCalls`          | no            | yes (plan 131)  | no               |
+| `rename`                 | no            | candidate (L-3) | yes (L5)         |
+| `signatureHelp`          | no            | no              | no               |
+| `semanticTokens`         | no            | no              | no               |
+| `inlayHint`              | no            | no              | no               |
+| `codeLens`               | no            | no              | no               |
+| `didChangeWatchedFiles`  | yes (`.yml`)  | yes (`**/*.md`) | yes              |
 
 The two LSPs are non-overlapping in practice
 today. A team running both gets diagnostics from

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -102,25 +102,39 @@ project wants mdsmith to keep enforcing the
 heading template while letting mdbase own FM
 typing, use A.2 instead.
 
-**A.2: Keep MDS020 with a permissive FM schema.**
-Define an mdsmith schema (`proto.md`) whose front
-matter accepts anything (`[string]: _`) but whose
-body still carries the heading template. mdsmith
-validates structure, mdbase validates FM, neither
-overlaps:
+**A.2: Keep mdsmith's heading-template
+enforcement (caveat).** The intent is "mdsmith
+validates body structure, mdbase validates FM,
+neither overlaps". mdsmith does not currently
+ship a clean way to express this: MDS020's
+schema is one document with FM constraints AND
+a body template, and the rule applies both.
+Three partial routes are available, each with
+trade-offs:
 
-```markdown
-<!-- common/permissive-fm.md -->
----
-[string]: _    # accept any FM; mdbase will validate
----
-# {title}
+- **Schema with empty front-matter block.**
+  Author a `proto.md` whose YAML front matter is
+  empty (still has the `---` fences but no
+  keys), so the CUE schema is empty and matches
+  any FM. The body template still validates
+  headings. Verify on your repo: behavior on
+  unknown FM keys depends on the rule's
+  `default_strict` and any per-kind override.
+- **Schema that mirrors mdbase's types.** Write
+  the same FM constraints in mdsmith CUE that
+  mdbase has in DSL. Both tools then validate FM
+  redundantly. Tedious to keep in sync; bundles
+  the dual-schema problem this whole strategy
+  was trying to avoid.
+- **Disable required-structure entirely (back
+  to A.1).** Simplest. Accepts the loss of
+  body-structure enforcement.
 
-## ?
-```
-
-Then reference it from the kind that owns body
-structure but lets mdbase own FM.
+A future mdsmith config option that toggles
+"validate body structure only, skip FM" within
+MDS020 would close the gap cleanly. Today
+A.1 is the practical pick unless body
+heading-template enforcement is critical.
 
 Pros:
 
@@ -132,10 +146,11 @@ Pros:
 Cons:
 
 - mdsmith cannot block PRs on FM-shape errors
-  (rely on `mdbase validate` in CI)
+  under A.1 (rely on `mdbase validate` in CI)
 - The CUE constraint surface (cross-field, regex,
-  bounds) is not available unless A.2 is used and
-  even then only at body-structure granularity
+  bounds) is not available under A.1
+- A.2's three routes each carry the caveats
+  above; none is fully clean today
 
 This is the recommended pattern when you want the
 mdbase typed-vault experience plus mdsmith's

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -1,5 +1,8 @@
 ---
-summary: Running mdsmith and mdbase on the same files — coexistence model, the dual-schema problem, recommended layouts, suggested integration patterns, and a sketch of a future schema bridge.
+summary: >-
+  Running mdsmith and mdbase on the same files — coexistence model, the
+  dual-schema problem, recommended layouts, suggested integration
+  patterns, and a sketch of a future schema bridge.
 status: 🔳
 ---
 # Interop and combined use

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -1,0 +1,402 @@
+---
+summary: Running mdsmith and mdbase on the same files — coexistence model, the dual-schema problem, recommended layouts, suggested integration patterns, and a sketch of a future schema bridge.
+status: 🔳
+---
+# Interop and combined use
+
+This document covers what happens when both tools
+read the same files. The short answer: they coexist
+cleanly on disk because their write surfaces do not
+collide, but the dual-schema problem makes typed
+front matter more work than it should be.
+
+## 1. Coexistence on disk
+
+Both tools read YAML front matter and Markdown body
+content. Neither tool requires a proprietary
+serialization. Files written by one are valid for
+the other.
+
+Write surfaces:
+
+| Tool    | What it writes                                                                                                                                                              |
+|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| mdsmith | Body fixes (`mdsmith fix`); generated section bodies (catalog, TOC, include, build); `.gitattributes` + git hooks via merge-driver / pre-merge-commit installers            |
+| mdbase  | Front-matter via CRUD ops (`create`, `update`); incoming-link rewrites on `rename`; SQLite cache at `.mdbase/index.sqlite`; migration manifests under `_types/_migrations/` |
+
+These do not overlap. Specifically:
+
+- mdsmith does not edit front matter (rules read it;
+  fixes target body content)
+- mdbase does not edit body content (CRUD targets
+  fields, not paragraphs; rename rewrites links but
+  not surrounding prose)
+
+So a file edited by mdbase remains lint-clean if it
+was clean before, and a file fixed by mdsmith
+remains valid against its mdbase type if it was
+valid before. The exception is the front-matter
+*shape*, which both tools have opinions about — that
+is the dual-schema problem.
+
+## 2. The dual-schema problem
+
+Both tools want to validate front matter, and
+neither can read the other's schema language.
+
+| Concern                            | mdsmith                                    | mdbase                                 |
+|------------------------------------|--------------------------------------------|----------------------------------------|
+| Schema language                    | CUE (`*.cue` files referenced from config) | mdbase DSL (YAML inside `_types/*.md`) |
+| Schema location                    | `internal/concepts/` or anywhere in repo   | `_types/` in the collection            |
+| Schema discoverable from file tree | only by reading `.mdsmith.yml`             | yes — `_types/*.md` are normal files   |
+| Reads the other's schema           | no                                         | no                                     |
+
+The pain points:
+
+1. **Define-once is impossible.** A team that wants
+   typed FM under both tools maintains two
+   definitions of every type. Field renames must be
+   applied twice. Constraint changes must be
+   applied twice.
+2. **Drift is silent.** If only one schema is
+   updated, the other tool keeps validating against
+   the old shape. A file might pass mdsmith and fail
+   mdbase, or vice versa.
+3. **Tooling cannot cross-reference.** A schema
+   editor for mdsmith does not see mdbase types; a
+   schema editor for mdbase does not see CUE
+   constraints.
+
+There is no automated bridge today. Strategies that
+work in practice are below.
+
+## 3. Strategies for combined use
+
+### Strategy A: Use mdbase as the source of truth
+
+Pick mdbase types as the authoritative schema. Use
+mdsmith for **everything else** (prose, structure,
+generated content, link integrity) and skip MDS020
+entirely.
+
+```yaml
+# .mdsmith.yml
+rules:
+  required-structure: false  # mdbase owns FM validation
+```
+
+Pros:
+
+- One schema layer (`_types/`) to maintain
+- mdsmith stays focused on what it does best
+- The schema is self-documenting (each type file
+  has a body explaining the type)
+
+Cons:
+
+- mdsmith cannot block PRs on FM-shape errors;
+  rely on `mdbase validate` in CI
+- The CUE constraint surface (cross-field, regex,
+  bounds) is not available
+
+This is the recommended pattern when you want the
+mdbase typed-vault experience plus mdsmith's
+linting.
+
+### Strategy B: Use mdsmith CUE as the source of truth
+
+The opposite: keep CUE as the authoritative schema.
+Use mdbase as a query and rename tool only, with
+its validation set to `off`:
+
+```yaml
+# mdbase.yaml
+spec_version: "0.2.1"
+default_validation: off
+```
+
+Pros:
+
+- One schema layer (CUE) to maintain
+- CUE's full constraint power
+- Seamless on existing mdsmith repos
+
+Cons:
+
+- mdbase types still exist as data-layer hints
+  (otherwise queries can't filter by type)
+- Can't use mdbase create/update because they
+  validate-on-write — workaround: use raw FM editing
+  and rely on mdsmith for shape
+
+This pattern fits teams already invested in mdsmith
+who want only mdbase's rename-and-query features.
+
+### Strategy C: Maintain both, by hand
+
+Keep CUE schemas and mdbase types in sync manually.
+Convention: a single PR updates both. A pre-commit
+check could compare the two but no such tool exists
+today.
+
+Pros:
+
+- Both tools enforce on PRs; defense in depth
+- Schema authoring stays close to either tool's
+  natural surface
+
+Cons:
+
+- Drift is the default state
+- Diff review must check that schemas match
+
+Use only if both validation surfaces matter and the
+drift cost is acceptable.
+
+### Strategy D: Generate one from the other
+
+Write a script that:
+
+- Reads `_types/*.md` (mdbase types)
+- Emits CUE schemas under `internal/concepts/` or
+  similar
+
+Or the reverse direction. Run the script in CI; fail
+if the generated output drifts from committed
+content.
+
+Pros:
+
+- Single source of truth, low drift risk
+- Can be incremental (only types that need both)
+
+Cons:
+
+- The script is real engineering effort
+- Some constraints don't translate (CUE regex →
+  mdbase `pattern:` works; CUE cross-field
+  constraints → mdbase has no equivalent)
+
+This is the "right answer" but requires building a
+bridge nobody has built yet. See section 7 for a
+sketch.
+
+## 4. Recommended folder layout
+
+Below is one layout that runs both tools cleanly.
+
+```text
+my-vault/
+├── mdbase.yaml              # mdbase config
+├── .mdsmith.yml             # mdsmith config
+├── _types/                  # mdbase type defs (Strategy A)
+│   ├── note.md
+│   ├── task.md
+│   └── person.md
+├── internal/concepts/       # mdsmith CUE schemas (if Strategy B/C)
+│   └── note.cue
+├── notes/                   # actual content
+│   ├── 2026-05-05-meeting.md
+│   └── …
+├── tasks/
+│   └── …
+├── _types/_migrations/      # mdbase migrations (L6)
+└── .mdbase/                 # gitignored cache
+    └── index.sqlite
+```
+
+`.gitignore` entries:
+
+```text
+.mdbase/
+```
+
+`.mdsmith.yml` `ignore:` entries:
+
+```yaml
+ignore:
+  - "_types/**"      # mdbase owns these; skip MDS020 etc.
+  - ".mdbase/**"
+```
+
+`mdbase.yaml` `exclude:` entries:
+
+```yaml
+exclude:
+  - .git
+  - node_modules
+  - .mdbase
+  - .mdsmith.yml   # not a content file
+```
+
+This keeps each tool out of the other's territory.
+mdsmith does not lint type files (mdbase owns them).
+mdbase does not consider hidden config files as part
+of the collection.
+
+## 5. Rules to disable when using both
+
+mdsmith rules to consider disabling under
+**Strategy A (mdbase owns FM)**:
+
+| Rule             | Reason to disable                                |
+|------------------|--------------------------------------------------|
+| MDS020           | mdbase validates FM shape                        |
+| MDS027           | optional: mdbase L4 also checks links — pick one |
+| MDS019 (catalog) | mdbase queries can produce equivalent listings   |
+
+Keep these:
+
+- All prose / structure / readability rules — mdbase
+  has nothing equivalent
+- `<?include?>` — useful regardless
+- `<?toc?>` — useful regardless
+- Merge driver — useful regardless
+
+Conversely under **Strategy B (mdsmith owns FM)**,
+disable mdbase validation:
+
+```yaml
+# mdbase.yaml
+default_validation: off
+```
+
+…and rely on `mdsmith check` for FM shape. mdbase
+becomes a query/rename tool only.
+
+## 6. Sample CI pipeline
+
+Combined CI for a vault running both tools:
+
+```yaml
+# .github/workflows/lint.yml
+name: lint
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: go install github.com/jeduden/mdsmith/cmd/mdsmith@latest
+      - run: npm install -g mdbase-cli
+      - run: mdsmith check .
+      - run: mdbase validate
+```
+
+Both run on every PR. They produce independent
+reports; either failing fails the job. Order does
+not matter — the tools do not write during validation.
+
+If you also want fix-mode in CI (as a regression
+guard against drift in generated sections):
+
+```yaml
+      - run: mdsmith fix .
+      - run: |
+          if ! git diff --quiet; then
+            echo "mdsmith fix produced changes; commit them"
+            git --no-pager diff
+            exit 1
+          fi
+```
+
+This catches a contributor who edited a generated
+section by hand.
+
+## 7. Future: a schema bridge
+
+There is room for a small tool that translates
+between the two schema surfaces. Sketch:
+
+```text
+                    mdbase _types/*.md
+                        │
+                        ▼
+              ┌─────────────────────┐
+              │  schema-bridge tool │
+              │   (read both,       │
+              │   diff, generate)   │
+              └─────────────────────┘
+                        │
+                        ▼
+                 internal/concepts/*.cue
+```
+
+A first cut would handle the common subset:
+
+- `string` with `min_length` / `max_length` / `pattern`
+  → CUE `=~ "regex" & strings.MinRunes(N)`
+- `integer` with `min`/`max` → CUE `int & >=N & <=M`
+- `enum` with `values` → CUE disjunction
+- `list` with `items` → CUE list type
+- `object` with `fields` → CUE struct
+- `required` → CUE non-optional
+- `default` → CUE default value `*"x" | string`
+
+Things that don't translate cleanly:
+
+- mdbase `link` with `target` — needs cross-file
+  resolution that CUE alone cannot express
+- mdbase `computed:` — CUE has expressions but
+  evaluation semantics differ
+- mdbase `generated:` (ULID, timestamps on write) —
+  CUE is purely structural; no write-time hooks
+- CUE cross-field constraints (`if x then y >= 0`) —
+  mdbase has no equivalent
+
+The bridge tool would round-trip the common cases
+and emit warnings where one side has constraints
+the other cannot represent. This is a clear
+opportunity for a small contribution to either
+ecosystem.
+
+## 8. When to skip one tool
+
+A team running both does not always benefit. Cases
+where one tool alone is enough:
+
+| Project shape                                          | Use only            |
+|--------------------------------------------------------|---------------------|
+| Open-source repo with `docs/` and a README             | mdsmith             |
+| Static site Markdown (Hugo / Jekyll / Astro)           | mdsmith + SSG       |
+| Personal Obsidian vault, no CI, no schemas             | mdbase (or neither) |
+| Knowledge graph with backlinks and rename-heavy work   | mdbase              |
+| Plan / RFC tracker with status fields and prose review | mdsmith             |
+| Mixed vault + docs site for a product                  | both                |
+
+The core trigger to add the second tool:
+
+- Add **mdsmith** when you start caring about prose
+  consistency, structural rules, generated TOCs,
+  or Markdown across many contributors.
+- Add **mdbase** when you start caring about typed
+  records, rename safety, backlinks, or queries
+  beyond `grep`.
+
+## 9. Open questions
+
+A few things this comparison doesn't answer:
+
+1. How does mdbase's SQLite cache interact with
+   editor saves on Windows where `.mdbase/index.sqlite`
+   is a binary file with active locks?
+2. Does mdbase-lsp expose code actions for adding a
+   missing required field, the way mdsmith does for
+   formatting fixes?
+3. Can mdsmith ship a `link-rename` subcommand that
+   approximates mdbase L5 rename for projects that
+   don't want a second tool?
+4. Is there appetite in either project to specify a
+   shared FM-schema interchange format?
+
+These are tractable questions, but answering them
+needs experimentation against real vaults. The
+research note ends here; the experiments are
+follow-up work.

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -284,11 +284,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'   # match mdsmith's go.mod
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: go install github.com/jeduden/mdsmith/cmd/mdsmith@latest
+      # Pin a specific mdsmith release to keep CI reproducible.
+      - run: go install github.com/jeduden/mdsmith/cmd/mdsmith@vX.Y.Z
       - run: npm install -g mdbase-cli
       - run: mdsmith check .
       - run: mdbase validate
@@ -297,6 +298,10 @@ jobs:
 Both run on every PR. They produce independent
 reports; either failing fails the job. Order does
 not matter — the tools do not write during validation.
+The Go version should track mdsmith's `go.mod`
+directive; pinning the install version (rather than
+`@latest`) keeps CI reproducible across mdsmith
+releases.
 
 If you also want fix-mode in CI (as a regression
 guard against drift in generated sections):

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -3,7 +3,6 @@ summary: >-
   Running mdsmith and mdbase on the same files — coexistence model, the
   dual-schema problem, recommended layouts, suggested integration
   patterns, and a sketch of a future schema bridge.
-status: 🔳
 ---
 # Interop and combined use
 

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -44,12 +44,13 @@ is the dual-schema problem.
 Both tools want to validate front matter, and
 neither can read the other's schema language.
 
-| Concern                            | mdsmith                                    | mdbase                                 |
-|------------------------------------|--------------------------------------------|----------------------------------------|
-| Schema language                    | CUE (`*.cue` files referenced from config) | mdbase DSL (YAML inside `_types/*.md`) |
-| Schema location                    | `internal/concepts/` or anywhere in repo   | `_types/` in the collection            |
-| Schema discoverable from file tree | only by reading `.mdsmith.yml`             | yes — `_types/*.md` are normal files   |
-| Reads the other's schema           | no                                         | no                                     |
+| Concern                            | mdsmith                                                                    | mdbase                               |
+|------------------------------------|----------------------------------------------------------------------------|--------------------------------------|
+| Schema file format                 | Markdown `proto.md` (CUE in front matter, heading template in body)        | Markdown in `_types/<name>.md` (DSL) |
+| Schema reference                   | `kinds: { <name>: { rules: { required-structure: { schema: <path> } } } }` | folder convention `_types/`          |
+| Schema location                    | anywhere referenced by a kind, by convention next to the files             | fixed `_types/` folder               |
+| Schema discoverable from file tree | yes — `proto.md` is a normal Markdown file                                 | yes — `_types/*.md` are normal files |
+| Reads the other's schema           | no                                                                         | no                                   |
 
 The pain points:
 
@@ -158,8 +159,11 @@ drift cost is acceptable.
 Write a script that:
 
 - Reads `_types/*.md` (mdbase types)
-- Emits CUE schemas under `internal/concepts/` or
-  similar
+- Emits matching mdsmith `proto.md` schema files
+  next to the matching kind, with the type DSL
+  translated into CUE in the front matter and the
+  documentation body preserved or replaced with a
+  heading template
 
 Or the reverse direction. Run the script in CI; fail
 if the generated output drifts from committed
@@ -188,17 +192,17 @@ Below is one layout that runs both tools cleanly.
 ```text
 my-vault/
 ├── mdbase.yaml              # mdbase config
-├── .mdsmith.yml             # mdsmith config
+├── .mdsmith.yml             # mdsmith config (kinds + rules)
 ├── _types/                  # mdbase type defs (Strategy A)
 │   ├── note.md
 │   ├── task.md
 │   └── person.md
-├── internal/concepts/       # mdsmith CUE schemas (if Strategy B/C)
-│   └── note.cue
 ├── notes/                   # actual content
+│   ├── proto.md             # mdsmith schema (Strategy B/C; CUE in FM)
 │   ├── 2026-05-05-meeting.md
 │   └── …
 ├── tasks/
+│   ├── proto.md             # mdsmith schema for tasks
 │   └── …
 ├── _types/_migrations/      # mdbase migrations (L6)
 └── .mdbase/                 # gitignored cache
@@ -326,7 +330,9 @@ between the two schema surfaces. Sketch:
               └─────────────────────┘
                         │
                         ▼
-                 internal/concepts/*.cue
+              mdsmith proto.md schemas
+              (CUE in front matter,
+               heading template in body)
 ```
 
 A first cut would handle the common subset:

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -78,29 +78,64 @@ work in practice are below.
 ### Strategy A: Use mdbase as the source of truth
 
 Pick mdbase types as the authoritative schema. Use
-mdsmith for **everything else** (prose, structure,
-generated content, link integrity) and skip MDS020
-entirely.
+mdsmith for prose, structure, generated content,
+and link integrity. Decide explicitly what to do
+with MDS020.
+
+Two configurations work, with different
+trade-offs:
+
+**A.1: Disable MDS020 entirely.** Simplest. The
+mdbase types validate front matter; mdsmith does
+not touch FM shape:
 
 ```yaml
 # .mdsmith.yml
 rules:
-  required-structure: false  # mdbase owns FM validation
+  required-structure: false  # mdbase owns all FM + structure checks
 ```
+
+Note this also disables MDS020's heading-template
+enforcement (the body-structure half of the rule),
+since `false` toggles the whole rule. If the
+project wants mdsmith to keep enforcing the
+heading template while letting mdbase own FM
+typing, use A.2 instead.
+
+**A.2: Keep MDS020 with a permissive FM schema.**
+Define an mdsmith schema (`proto.md`) whose front
+matter accepts anything (`[string]: _`) but whose
+body still carries the heading template. mdsmith
+validates structure, mdbase validates FM, neither
+overlaps:
+
+```markdown
+<!-- common/permissive-fm.md -->
+---
+[string]: _    # accept any FM; mdbase will validate
+---
+# {title}
+
+## ?
+```
+
+Then reference it from the kind that owns body
+structure but lets mdbase own FM.
 
 Pros:
 
-- One schema layer (`_types/`) to maintain
-- mdsmith stays focused on what it does best
+- One source of FM truth (`_types/`)
+- mdsmith stays focused on linting and structure
 - The schema is self-documenting (each type file
   has a body explaining the type)
 
 Cons:
 
-- mdsmith cannot block PRs on FM-shape errors;
-  rely on `mdbase validate` in CI
+- mdsmith cannot block PRs on FM-shape errors
+  (rely on `mdbase validate` in CI)
 - The CUE constraint surface (cross-field, regex,
-  bounds) is not available
+  bounds) is not available unless A.2 is used and
+  even then only at body-structure granularity
 
 This is the recommended pattern when you want the
 mdbase typed-vault experience plus mdsmith's
@@ -217,13 +252,34 @@ my-vault/
 .mdbase/
 ```
 
-`.mdsmith.yml` `ignore:` entries:
+`.mdsmith.yml` settings — pick the granularity
+deliberately:
 
 ```yaml
+# Option 1: full exclusion (no mdsmith lint at all on _types/)
 ignore:
-  - "_types/**"      # mdbase owns these; skip MDS020 etc.
+  - "_types/**"      # mdbase owns these end-to-end
+  - ".mdbase/**"     # gitignored cache, never lint
+
+# Option 2: lint prose/whitespace in _types/, just skip schema
+# validation conflicts. Replace the _types/ ignore line above with:
+overrides:
+  - glob: ["_types/**"]
+    rules:
+      required-structure: false  # mdbase owns FM shape
+ignore:
   - ".mdbase/**"
 ```
+
+`ignore:` skips **all** mdsmith rules — including
+prose readability, line length, table formatting,
+and link integrity — for the matched files. That
+matches the "mdbase owns these end-to-end"
+intent. If the team wants type files to be
+linted for prose and whitespace consistency
+(they are normal Markdown after all) but doesn't
+want MDS020 fighting mdbase, the `overrides:`
+form is the better fit.
 
 `mdbase.yaml` `exclude:` entries:
 

--- a/docs/research/mdbase-vs-mdsmith/interop.md
+++ b/docs/research/mdbase-vs-mdsmith/interop.md
@@ -268,16 +268,25 @@ my-vault/
 ```
 
 `.mdsmith.yml` settings — pick the granularity
-deliberately:
+deliberately. Two copy/paste-valid options:
+
+**Option 1: full exclusion** (no mdsmith lint at
+all on `_types/`).
 
 ```yaml
-# Option 1: full exclusion (no mdsmith lint at all on _types/)
+# .mdsmith.yml
 ignore:
   - "_types/**"      # mdbase owns these end-to-end
   - ".mdbase/**"     # gitignored cache, never lint
+```
 
-# Option 2: lint prose/whitespace in _types/, just skip schema
-# validation conflicts. Replace the _types/ ignore line above with:
+**Option 2: lint prose/whitespace in `_types/`,
+skip schema-validation conflicts only.** Disable
+just `required-structure` on `_types/` via an
+override; everything else still runs.
+
+```yaml
+# .mdsmith.yml
 overrides:
   - glob: ["_types/**"]
     rules:
@@ -290,11 +299,11 @@ ignore:
 prose readability, line length, table formatting,
 and link integrity — for the matched files. That
 matches the "mdbase owns these end-to-end"
-intent. If the team wants type files to be
-linted for prose and whitespace consistency
-(they are normal Markdown after all) but doesn't
-want MDS020 fighting mdbase, the `overrides:`
-form is the better fit.
+intent in Option 1. If the team wants type
+files to be linted for prose and whitespace
+consistency (they are normal Markdown after all)
+but doesn't want MDS020 fighting mdbase, the
+`overrides:` form in Option 2 is the better fit.
 
 `mdbase.yaml` `exclude:` entries:
 

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -1,5 +1,8 @@
 ---
-summary: Systematic enumeration of mdbase capabilities mdsmith does not yet have, with a per-gap mini-plan covering goal, design sketch, surface, effort, trigger, and open questions.
+summary: >-
+  Systematic enumeration of mdbase capabilities mdsmith does not yet
+  have, with a per-gap mini-plan covering goal, design sketch, surface,
+  effort, trigger, and open questions.
 status: 🔳
 ---
 # What mdsmith can learn from mdbase
@@ -106,14 +109,14 @@ sketch.
 
 ### Cache, watch, migrations, conformance, LSP
 
-| ID  | Gap                                    | Effort | Trigger / status                                                              |
-|-----|----------------------------------------|--------|-------------------------------------------------------------------------------|
-| P-1 | Persistent on-disk index               | L      | profiling on a real >5k-file repo shows the cold-start cost is the bottleneck |
-| P-2 | Watch mode beyond LSP per-session      | M      | a CLI workflow needs cross-process freshness (rare today)                     |
-| V-1 | Migration manifests                    | L      | mdsmith grows write-back to FM (S-5 / C-2) and breaking schema changes hurt   |
-| X-1 | Spec-first / multi-impl model          | XL     | a second implementation appears (fork, or upstream split); revisit then       |
-| H-1 | LSP hover for rules / directives       | —      | in-flight (plan 122)                                                          |
-| H-2 | LSP symbol navigation + call hierarchy | —      | in-flight (plan 131, PR #238)                                                 |
+| ID  | Gap                                    | Effort | Trigger / status                                                                                                       |
+|-----|----------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------|
+| P-1 | Persistent on-disk index               | L      | profiling shows parse cost dominates after netting out OS cache and any in-memory index (see aggregation-use-cases.md) |
+| P-2 | Watch mode beyond LSP per-session      | M      | a CLI workflow needs cross-process freshness (rare today)                                                              |
+| V-1 | Migration manifests                    | L      | mdsmith grows write-back to FM (S-5 / C-2) and breaking schema changes hurt                                            |
+| X-1 | Spec-first / multi-impl model          | XL     | a second implementation appears (fork, or upstream split); revisit then                                                |
+| H-1 | LSP hover for rules / directives       | —      | in-flight (plan 122)                                                                                                   |
+| H-2 | LSP symbol navigation + call hierarchy | —      | in-flight (plan 131, PR #238)                                                                                          |
 
 ## Schema language plans
 
@@ -985,13 +988,21 @@ limit.
 **Goal.** A cache of parsed FM, link edges, and
 computed fields that survives across CLI runs.
 
-**Trigger.** Profiling on a real >5k-file repo
-shows the cold-start parse cost dominates wall
-time, OR an in-flight feature (Q-5 aggregations,
-L-4 backlinks at scale) makes per-run rebuild
-visibly slow. The deeper analysis below
-(*A closer look at P-1*) walks six implementation
-options and what would tip the choice.
+**Trigger.** A persistent cache earns its cost
+only after surviving three filters: OS-cache
+(repeated runs are already RAM-fast through the
+page cache), sync-check (validating the on-disk
+cache against the filesystem isn't free —
+50,000 files takes ~500ms of `stat` alone), and
+in-memory-with-priority (a long-lived process
+gets most of the win without the operational
+baggage). The deeper walk-through is in
+[aggregation-use-cases.md §"What an index
+actually costs"](aggregation-use-cases.md). The
+short version: ship this when the *parsed*
+index is what's expensive, not the raw read,
+and a long-lived process can't already cover
+the access pattern.
 
 **Sketch.** See the next section.
 

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -1,0 +1,941 @@
+---
+summary: Systematic enumeration of mdbase capabilities mdsmith does not yet have, with a per-gap mini-plan covering goal, design sketch, surface, effort, and open questions.
+status: 🔳
+---
+# What mdsmith can learn from mdbase
+
+This document is a research exercise, not a roadmap.
+It enumerates every mdbase capability that mdsmith
+either lacks or expresses differently, triages each
+into in-scope / out-of-scope / already-in-flight,
+and sketches a mini-plan for the in-scope ones. The
+goal is to give a future maintainer a list of
+discrete, well-framed work items they can promote
+into actual `plan/<n>_*.md` files when the time
+comes.
+
+## Method
+
+1. Walk every section of [features.md](features.md).
+2. For each row where mdbase has a capability and
+   mdsmith does not, note it as a gap with a short
+   identifier (e.g. `S-1`, `Q-3`).
+3. Triage:
+
+  - **In-scope** — fits the existing mdsmith
+     mission (lint, fix, generate over Markdown
+     files in a repo) and would benefit a real use
+     case from [use-cases.md](use-cases.md).
+  - **Out-of-scope** — would change what mdsmith
+     is. Note why and the principled alternative.
+  - **In-flight** — already covered by an open
+     plan or PR.
+
+4. For each in-scope gap, write a mini-plan with:
+
+  - **Goal** — one sentence
+  - **Sketch** — proposed mechanism, including
+     concrete syntax where it helps
+  - **Surface** — what new config / CLI / output
+     the user sees
+  - **Effort** — S / M / L (a day, a week, a
+     month)
+  - **Depends on** — gaps or existing plans this
+     builds on
+  - **Open questions** — things a real plan would
+     have to settle
+
+## Triage tables
+
+Tables split by area for readability. Twelve
+in-scope gaps follow as mini-plans below; the
+out-of-scope and in-flight items get a brief
+rationale at the end.
+
+### Schema language (S)
+
+| ID  | Gap                                          | Status       | Priority |
+|-----|----------------------------------------------|--------------|----------|
+| S-1 | Inline schema in `kinds:`                    | in-scope     | high     |
+| S-2 | Named field-type taxonomy as CUE shortcuts   | in-scope     | medium   |
+| S-3 | Schema inheritance (`extends:`)              | in-scope     | medium   |
+| S-4 | Computed fields surfaced in catalog / query  | in-scope     | medium   |
+| S-5 | Generated values on write (ULID, timestamps) | out-of-scope | n/a      |
+| S-6 | Field deprecation flag                       | in-scope     | low      |
+
+### File-to-kind matching (M)
+
+| ID  | Gap                                      | Status   | Priority |
+|-----|------------------------------------------|----------|----------|
+| M-1 | Field-presence kind assignment           | in-scope | high     |
+| M-2 | Field-value kind assignment (`where:`)   | in-scope | low      |
+| M-3 | `path-pattern` (validates and generates) | in-scope | medium   |
+
+### CRUD and rename (C)
+
+| ID  | Gap                            | Status       | Priority |
+|-----|--------------------------------|--------------|----------|
+| C-1 | Create typed file              | out-of-scope | n/a      |
+| C-2 | Update fields from CLI         | out-of-scope | n/a      |
+| C-3 | Delete with broken-ref warning | out-of-scope | n/a      |
+| C-4 | Atomic rename + ref rewrite    | in-scope     | high     |
+| C-5 | Batch ops with `--where`       | out-of-scope | n/a      |
+| C-6 | Dry-run mode for fix           | in-scope     | low      |
+
+### Links (L)
+
+| ID  | Gap                                   | Status          | Priority |
+|-----|---------------------------------------|-----------------|----------|
+| L-1 | Wikilink awareness                    | in-scope        | high     |
+| L-2 | ID-field link resolution              | out-of-scope    | n/a      |
+| L-3 | Auto-rewrite incoming links on rename | in-scope (=C-4) | high     |
+| L-4 | Backlinks subcommand                  | in-scope        | high     |
+| L-5 | Multi-hop link traversal in queries   | out-of-scope    | n/a      |
+
+### Query (Q)
+
+| ID  | Gap                                   | Status       | Priority |
+|-----|---------------------------------------|--------------|----------|
+| Q-1 | Sort (`--order-by`)                   | in-scope     | medium   |
+| Q-2 | Pagination (`--limit` / `--offset`)   | in-scope     | low      |
+| Q-3 | Body full-text search in query        | in-scope     | medium   |
+| Q-4 | Date arithmetic with duration strings | in-scope     | low      |
+| Q-5 | Aggregations (formulas, summaries)    | out-of-scope | n/a      |
+| Q-6 | Cross-file traversal in queries       | out-of-scope | n/a      |
+| Q-7 | Bases-compatible expression syntax    | in-scope     | low      |
+
+### Cache, watch, migrations, conformance, LSP
+
+| ID  | Gap                                    | Status          | Priority |
+|-----|----------------------------------------|-----------------|----------|
+| P-1 | SQLite-backed cache for large repos    | out-of-scope    | n/a      |
+| P-2 | Watch mode beyond LSP per-session      | out-of-scope    | n/a      |
+| V-1 | Migration manifests                    | out-of-scope    | n/a      |
+| X-1 | Spec-first / multi-impl model          | out-of-scope    | n/a      |
+| H-1 | LSP hover for rules / directives       | in-flight (122) | n/a      |
+| H-2 | LSP symbol navigation + call hierarchy | in-flight (131) | n/a      |
+
+## Schema language plans
+
+### S-1: Inline schema in the `kinds` map
+
+**Goal.** Let `kinds:` carry a schema directly,
+without forcing every kind to point at a separate
+`proto.md`.
+
+**Sketch.** Extend the kind config to accept an
+optional `schema:` block alongside (or instead of)
+`required-structure.schema:`:
+
+```yaml
+kinds:
+  task:
+    rules:
+      line-length:
+        max: 100
+    schema:
+      frontmatter:
+        id: '=~"^TASK-[0-9]{4}$"'
+        status: '"open" | "in-progress" | "done"'
+        priority: 'int & >=1 & <=5'
+        "due?": "string"  # ISO date
+      structure:
+        - "# {title}"
+        - "## Goal"
+        - "## Acceptance"
+      require:
+        filename: "TASK-[0-9]+.md"
+```
+
+The schema engine receives a parsed AST whether
+it came from inline YAML or from a referenced
+`proto.md`. The current `proto.md` mechanism stays
+as the path for schemas that include heading
+templates with rich body content; inline schemas
+cover the common case.
+
+**Surface.** Three things change for the user:
+
+- New `schema:` key in each kind
+- `mdsmith kinds` command shows whether a kind's
+  schema is inline or file-referenced
+- Existing `required-structure.schema:` still works
+
+**Effort.** M (1–2 weeks). Touches config types,
+the schema loader, and `mdsmith kinds` output.
+Mostly mechanical.
+
+**Depends on.** Nothing.
+
+**Open questions.** Should inline `structure:`
+support the full directive set (`<?include?>` for
+fragment composition)? Probably yes, for parity.
+
+### S-2: Named field-type taxonomy as CUE shortcuts
+
+**Goal.** Make CUE schemas more ergonomic by
+shipping reusable definitions for the common types
+mdbase names directly (date, datetime, enum, link).
+
+**Sketch.** Add a small CUE library
+`internal/cue/types.cue` that defines:
+
+```cue
+package mdsmith
+
+#date:     =~"^\\d{4}-\\d{2}-\\d{2}$"
+#datetime: =~"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"
+#email:    =~"^[^@]+@[^@]+$"
+#url:      =~"^https?://"
+#filename: =~"^[A-Za-z0-9_-]+\\.md$"
+```
+
+Schemas import the package and reference the
+definitions:
+
+```cue
+package proto
+
+import "github.com/jeduden/mdsmith/types"
+
+created:  types.#date
+modified: types.#datetime
+```
+
+Optionally expose a more compact YAML shorthand in
+inline schemas (S-1):
+
+```yaml
+schema:
+  frontmatter:
+    created: date     # resolves to types.#date
+    homepage: url
+    contact: email
+```
+
+**Surface.** A new package import path; optional
+shorthand in inline schemas.
+
+**Effort.** S (a few days). Defining the patterns
+is small; wiring the shorthand is the bulk.
+
+**Depends on.** S-1 makes the YAML shorthand
+useful; without it the patterns are still helpful
+in `proto.md` schemas.
+
+**Open questions.** What's the canonical list?
+Start with the seven mdbase covers (string, int,
+number, bool, date, datetime, time, enum, link)
+and grow from real use.
+
+### S-3: Schema inheritance via `extends`
+
+**Goal.** Let one kind / schema extend another so
+common front-matter fields live in a base schema.
+
+**Sketch.** Two parts:
+
+- **In `kinds:`** — `extends:` lists parent kinds
+  whose rule overrides apply before this one (today
+  this is implicit deep-merge by declaration order;
+  `extends:` makes it explicit).
+- **In schemas** — CUE already supports
+  unification, so `import` + struct embedding
+  covers it. For inline schemas (S-1), extend the
+  block:
+
+  ```yaml
+  schema:
+    extends: [base]
+    frontmatter:
+      status: '"open" | "done"'
+  ```
+
+  The schema engine merges the parent's CUE struct
+  with the child's, with child-wins on overlapping
+  keys (mdbase semantics).
+
+**Surface.** New `extends:` key in kind / inline
+schema; documented in the file-kinds guide.
+
+**Effort.** S–M. CUE already handles unification;
+the lift is exposing the merge in the inline DSL.
+
+**Depends on.** S-1.
+
+**Open questions.** Single inheritance (mdbase) or
+multiple? Multiple is more powerful but harder to
+debug. Recommend single for parity, with `<?include?>`
+covering composition.
+
+### S-4: Computed fields in catalog / query
+
+**Goal.** Let users define expressions that derive
+a field from other front-matter fields, surface
+the result in `<?catalog?>` columns and `mdsmith
+query`, and never persist it back to disk.
+
+**Sketch.** Computed fields live in the schema
+(inline or proto.md) under a `computed:` block:
+
+```yaml
+schema:
+  frontmatter:
+    due: string       # ISO date
+  computed:
+    days_overdue:
+      type: int
+      expr: time.Parse("2006-01-02", due).Before(time.Now())
+```
+
+The expression language reuses CUE; an extra small
+helper for date arithmetic (Q-4) makes typical
+cases readable. Catalog references computed values
+as `{computed.days_overdue}`. Query treats them as
+read-only fields.
+
+**Surface.** New `computed:` block in schemas;
+catalog template extension.
+
+**Effort.** M. CUE evaluation per file is
+manageable; the catalog templating change is small.
+
+**Depends on.** S-1 (for inline syntax), Q-4 (for
+date arithmetic to be useful).
+
+**Open questions.** Performance — naive evaluation
+runs the expression per file per render. Cache
+across a single `mdsmith fix` run. Beyond that,
+out of scope.
+
+### S-6: Field deprecation flag
+
+**Goal.** Let a schema mark a field deprecated;
+mdsmith warns when it appears in front matter.
+
+**Sketch.** In the schema, `deprecated: true` on a
+field. MDS020 emits a Warning (not an Error) when
+the field is present.
+
+```yaml
+schema:
+  frontmatter:
+    legacy_owner:
+      type: string
+      deprecated: true
+      message: "use 'owner' instead"
+```
+
+**Surface.** Schema field-level `deprecated:` and
+`message:` keys; new MDS020 sub-diagnostic.
+
+**Effort.** S.
+
+**Depends on.** S-1.
+
+**Open questions.** None worth blocking on.
+
+## File-to-kind matching plans
+
+### M-1: Field-presence kind assignment
+
+**Goal.** Auto-assign a kind when specific
+front-matter fields are present, removing the need
+for an explicit `kind:` tag.
+
+**Sketch.** Extend `kind-assignment:` with a
+`fields-present:` selector:
+
+```yaml
+kind-assignment:
+  - glob: ["docs/**"]
+    kinds: [doc]
+  - fields-present: [status, priority, assignee]
+    kinds: [task]
+```
+
+Selectors combine with AND; multiple entries
+combine with OR (matching the existing glob
+semantics). A file matching no entry stays
+untyped, like today.
+
+**Surface.** New `fields-present:` key in
+`kind-assignment:` entries; documented in the
+file-kinds guide.
+
+**Effort.** S.
+
+**Depends on.** Nothing.
+
+**Open questions.** Should presence-based matching
+fire on null values (present but null)? Mirror
+mdbase's "non-null required" semantics.
+
+### M-2: Field-value kind assignment via `where`
+
+**Goal.** Auto-assign a kind based on a CUE
+expression over front matter, e.g. "files where
+status is 'open'".
+
+**Sketch.** Extend `kind-assignment:` with a
+`where:` selector that takes a CUE struct
+literal — same syntax as `mdsmith query`:
+
+```yaml
+kind-assignment:
+  - where: 'kind: "plan", status: "in-progress"'
+    kinds: [active-plan]
+```
+
+Useful for derived kinds: "active plans get a
+stricter token budget than archived plans". A
+config-time CUE compile per kind keeps the cost
+low.
+
+**Surface.** New `where:` key in
+`kind-assignment:` entries.
+
+**Effort.** S–M.
+
+**Depends on.** Nothing.
+
+**Open questions.** Performance at scale; if
+`where:` runs per file per kind, n×m cost. A
+trie-based prefilter on the keys mentioned in
+`where:` mitigates. Defer until the feature is in
+real use.
+
+### M-3: `path-pattern` (validates and generates)
+
+**Goal.** Let a kind declare a filename pattern
+that validates existing files (does the path
+match?) and templates new ones (where should a
+new file live?).
+
+**Sketch.** Add `path-pattern:` to a kind:
+
+```yaml
+kinds:
+  plan:
+    rules:
+      required-structure:
+        schema: plan/proto.md
+    path-pattern: "plan/{id:int}_{slug}.md"
+```
+
+Validation: a file claiming `kind: plan` whose
+path doesn't fit `plan/<int>_<slug>.md` produces
+an MDS020 Error. Templating: `mdsmith query` could
+emit candidate paths from this pattern (low
+priority).
+
+**Surface.** New `path-pattern:` key in kind
+config; new MDS020 sub-diagnostic.
+
+**Effort.** S.
+
+**Depends on.** Nothing.
+
+**Open questions.** Field substitution syntax —
+braces with type tags as above, or simpler globs?
+Match what mdbase does for portability.
+
+## Link plans
+
+### L-1: Wikilink awareness
+
+**Goal.** Make MDS027 understand `[[Page]]`,
+`[[Page|alias]]`, `[[Page#anchor]]` so wikilink-
+heavy vaults can use mdsmith without flagging
+every wikilink as text.
+
+**Sketch.** Add a wikilink parser to the lint
+pipeline (alongside the existing Markdown link
+extractor in `internal/lint/`). Resolution rules
+follow goldmark's link-resolution conventions plus
+mdbase spec §8 (filename match in `.md` files;
+sandboxed to repo root). Configurable via
+`cross-file-reference-integrity.wikilinks:`:
+
+```yaml
+rules:
+  cross-file-reference-integrity:
+    wikilinks: true        # default false today
+    wikilink-style: simple # | obsidian
+```
+
+Two styles because Obsidian and other tools
+disagree on tiebreakers and aliases.
+
+**Surface.** New rule settings; new diagnostic
+flavors for broken wikilinks.
+
+**Effort.** M. Parsing is small; resolution rules
+need test coverage across Obsidian / Foam /
+Logseq variants.
+
+**Depends on.** Nothing.
+
+**Open questions.** Should mdsmith canonicalize
+wikilinks (rewrite to Markdown links on `fix`)?
+Probably no — that's a refactor, not a lint, and
+breaks Obsidian for users who want wikilinks.
+
+### L-3 / C-4: Atomic rename + reference rewrite
+
+**Goal.** A `mdsmith refactor rename <old> <new>`
+subcommand that moves a file and rewrites every
+incoming link.
+
+**Sketch.** New subcommand:
+
+```bash
+mdsmith refactor rename docs/old.md docs/new.md
+mdsmith refactor rename --heading "Old name" --to "New name" docs/file.md
+```
+
+Two modes:
+
+- **File rename.** Moves `docs/old.md` to
+  `docs/new.md`. Rewrites every `[text](docs/old.md)`,
+  `[text](docs/old.md#anchor)`, and `[[old]]` in
+  the workspace. Anchors normalized via the same
+  GitHub-slug rules MDS027 uses.
+- **Heading rename.** Updates the heading text in
+  the source file and rewrites every cross-file
+  anchor link pointing at the old slug.
+
+`--dry-run` prints the proposed edits without
+writing. Optimistic-concurrency check uses mtime
+(file changed on disk during rename → abort).
+
+**Surface.** New `mdsmith refactor` subcommand
+group with `rename` and (later) other refactors.
+
+**Effort.** L. Rename is the new write surface
+mdsmith hasn't had before. Test matrix is large
+(wikilinks, anchors, edge cases like links in
+fenced code blocks).
+
+**Depends on.** L-1 (wikilinks) for full coverage.
+
+**Open questions.** Should rename also update
+`<?include?>` and `<?build?>` directive paths?
+Yes, for consistency. Should it touch front-matter
+fields containing paths (`source: file.md`)?
+Probably not without explicit opt-in — they aren't
+syntactically links.
+
+### L-4: Backlinks subcommand
+
+**Goal.** A `mdsmith backlinks <file>` command
+that lists every workspace file with a link to
+the target.
+
+**Sketch.** Reuses the link graph that MDS027
+already builds during a check pass:
+
+```bash
+mdsmith backlinks docs/api.md
+# docs/index.md:14: [API reference](api.md)
+# docs/getting-started.md:42: [api docs](./api.md)
+# plan/045_api-overhaul.md:8: [api](../docs/api.md)
+
+mdsmith backlinks docs/api.md#authentication
+# docs/index.md:18
+# docs/security.md:33
+```
+
+JSON output for agents (`--format json`).
+
+**Surface.** New `mdsmith backlinks` subcommand;
+JSON output spec.
+
+**Effort.** S. Most of the engine is in MDS027
+already; surface it as a CLI command.
+
+**Depends on.** L-1 to cover wikilinks (otherwise
+the result misses Obsidian-style backlinks).
+
+**Open questions.** Performance at 10k files —
+the link graph builds fast but the output may be
+unwieldy. `--limit N` plus filtering by glob
+covers the common case.
+
+## Query plans
+
+### Q-1, Q-2: Sort and pagination
+
+**Goal.** Support `--order-by FIELD` and
+`--limit N` / `--offset N` on `mdsmith query`.
+
+**Sketch.** New flags:
+
+```bash
+mdsmith query 'status: "open"' --order-by priority --order desc --limit 20
+mdsmith query 'kind: "task"' --order-by due --offset 50 --limit 50
+```
+
+Sorts after CUE unification (i.e. on filtered
+result set). Stable sort with deterministic
+secondary key (path) so output is reproducible.
+
+**Surface.** Three new flags on `query`; JSON
+output unchanged.
+
+**Effort.** S (a day or two).
+
+**Depends on.** Nothing.
+
+**Open questions.** Sort by computed fields
+(S-4)? Yes, when S-4 lands.
+
+### Q-3: Body full-text search in query
+
+**Goal.** Filter files by body content as well as
+front matter.
+
+**Sketch.** New flag `--body-contains REGEX`:
+
+```bash
+mdsmith query 'kind: "doc"' --body-contains 'TODO|FIXME'
+```
+
+Anchors to body only (not front matter, not
+inside fenced code unless `--include-code`). The
+regex engine is Go's `regexp` package.
+
+**Surface.** New flag; JSON output includes a
+`matches` array per file when `--match-context`
+set.
+
+**Effort.** S–M.
+
+**Depends on.** Nothing.
+
+**Open questions.** Should it support multiple
+patterns (AND / OR)? One pattern keeps the
+surface small; users can pipe through `grep` for
+more complex needs.
+
+### Q-4: Date arithmetic with duration strings
+
+**Goal.** Make CUE queries readable for "due in
+the next 7 days":
+
+```bash
+mdsmith query 'due: <=time.Add(time.Now(), "7d24h")' tasks/
+```
+
+**Sketch.** Add a small CUE package
+`internal/cue/time.cue` that defines `Add`,
+`Sub`, and parsing helpers, exposed in the query
+namespace by default. Match the duration-string
+grammar mdbase uses (`"7d"`, `"1w"`, `"1M"`,
+`"1y"`, `"2h"`, `"30m"`, `"45s"`; capital M for
+months, lowercase for minutes — error on
+ambiguous unit).
+
+The CUE package wraps `time.Parse` /
+`time.ParseDuration` with month / year support
+that Go's `time` lacks; clamp month-overflow to
+the last day of the target month, matching
+mdbase.
+
+**Surface.** New CUE helpers visible in `query`
+expressions; documented in
+`docs/reference/cli/query.md`.
+
+**Effort.** M.
+
+**Depends on.** Nothing.
+
+**Open questions.** Time zone — query against
+local time or UTC? mdbase uses an `mdbase.yaml`-
+configurable IANA zone. mdsmith could read a
+top-level `timezone:` config key.
+
+### Q-7: Bases-compatible expression syntax
+
+**Goal.** Optionally accept Obsidian Bases-style
+expressions in `mdsmith query`, so users coming
+from a vault don't have to learn CUE for simple
+filters.
+
+**Sketch.** Add a `--lang bases` flag:
+
+```bash
+mdsmith query --lang bases 'status == "open" && priority >= 3'
+mdsmith query 'status: "open"'   # CUE, current default
+```
+
+Translation happens at the boundary: parse Bases
+syntax into a CUE struct literal and unify as
+today. Only the subset that maps cleanly: `==`,
+`!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`,
+plus `.startsWith` / `.contains` / `.matches` on
+strings.
+
+**Surface.** New `--lang` flag; new doc page on
+the supported subset.
+
+**Effort.** M. Parser is small; the work is the
+test matrix.
+
+**Depends on.** Nothing.
+
+**Open questions.** Worth the cost? Argument for:
+lower onboarding for Obsidian users. Argument
+against: two query languages, two failure modes,
+two doc surfaces. **Recommendation: defer until a
+real user asks for it.** The exploration here is
+primarily evaluative. CUE is more powerful and
+already documented; Bases is more familiar to
+some. If we do add it, structure it as a
+translation pass, not a parallel implementation.
+
+## Operational plan
+
+### C-6: `--dry-run` for fix
+
+**Goal.** Show what `mdsmith fix` would change
+without writing.
+
+**Sketch.** New flag `--dry-run`:
+
+```bash
+mdsmith fix --dry-run docs/
+# docs/api.md: would fix 3 violations (MDS001, MDS006, MDS019)
+# docs/index.md: would regenerate <?catalog?> body
+```
+
+Emits the same diagnostics shape as `check` plus
+a per-file summary of fixed-vs-unfixed counts.
+Combine with `--format json` for tooling.
+
+**Surface.** New `--dry-run` flag.
+
+**Effort.** S. The fix engine already produces a
+fixed-content buffer before writing; gate the
+write.
+
+**Depends on.** Nothing.
+
+**Open questions.** None.
+
+## Out-of-scope items: rationale
+
+For each "out-of-scope" gap, a one-line reason and
+the principled alternative.
+
+| ID  | Why not                                                                    | Alternative                                 |
+|-----|----------------------------------------------------------------------------|---------------------------------------------|
+| S-5 | mdsmith does not author files; agents and humans do                        | Use `mdbase create` for typed scaffolding   |
+| C-1 | mdsmith is lint-and-fix, not author-and-edit                               | Editor / agent / mdbase                     |
+| C-2 | Same as C-1                                                                | Same                                        |
+| C-3 | Same as C-1                                                                | Same                                        |
+| C-5 | Batch CRUD is out-of-scope; lint/fix already scopes by glob                | mdbase batch ops, or a shell loop           |
+| L-2 | ID-field resolution requires a canonical ID system mdsmith does not impose | Use mdbase if you need ID-keyed links       |
+| L-5 | Multi-hop traversal couples query with link graph; large complexity        | mdbase Bases queries with `asFile()`        |
+| Q-5 | Aggregations grow into a database surface mdsmith does not own             | mdbase Query+ formulas / summaries          |
+| Q-6 | Same coupling as L-5                                                       | Same                                        |
+| P-1 | Stateless re-read is a design feature: deterministic, no stale state       | mdbase SQLite cache for vault-scale work    |
+| P-2 | LSP per-session covers editor flows; persistent daemon adds risk           | LSP, plus mdbase watch mode for vault flows |
+| V-1 | Migrations require write-back to data files; mdsmith does not              | mdbase migrate manifests                    |
+| X-1 | mdsmith is the implementation; spec-first costs maintenance                | If forks happen, revisit                    |
+
+The recurring theme: mdsmith owns the
+**read-and-fix-source** layer. Anything that wants
+to **author or edit data** crosses a category line.
+mdbase's CRUD-and-cache layer is the principled
+home for those features.
+
+### A closer look at P-1 (SQLite cache)
+
+The one-line rationale above hides a real design
+question worth pulling apart, since the cache is
+mdbase's biggest runtime difference from mdsmith.
+
+**Why SQLite at all.** mdbase carries an index of
+files, parsed front matter, computed-field
+results, and link edges. At vault scale (5k–50k
+files) re-reading every file on every query is
+slow: seconds per query versus milliseconds. The
+spec calls SQLite "Recommended" because it gives
+ACID writes, queryable indexes, single-file
+storage, and ubiquity, with the trade-off that
+the cache file is binary and not human-readable
+(spec §13). Some impls might choose a JSON line
+file or an in-memory map; SQLite is the default
+because the queries are relational.
+
+**Staleness check at startup.** A correct cache
+must invalidate when source files change.
+mdbase's spec §13 mandates two signals:
+
+- **Modification time (mtime).** Cheap. Used as
+  the first-pass check. If a file's mtime is
+  newer than the cached entry's, re-parse it.
+- **Content hash.** Used when mtime is
+  unreliable (network filesystems, build systems
+  that touch files without changing content). On
+  a hash mismatch the entry is rebuilt.
+
+The cache is rebuildable from the files alone, so
+"correct on stale" is acceptable: the worst case
+is an extra parse pass at startup. The cache is
+also deletable without data loss — `.mdbase/` can
+be removed at any time.
+
+A read-only command like `mdbase query` walks
+every entry and verifies mtime against the cached
+record before trusting it. If the cache is large
+relative to the workspace this becomes the
+bottleneck; impls add a watcher (spec §15) so the
+cache stays current between queries.
+
+**What queries actually run on the cache.** Three
+shapes dominate in mdbase's CRUD and query
+surfaces:
+
+1. **Front-matter filtering.** "All files where
+   `status == 'open'` and `priority >= 3`." The
+   cache stores parsed FM as columns or a JSON
+   blob with a generated indexing layer; SQLite's
+   `WHERE` does the rest. Equivalent to
+   `SELECT path FROM files WHERE status='open' AND priority>=3`.
+2. **Backlink lookup.** "What files link to
+   `docs/api.md` (or its `auth` heading)?" Stored
+   as a normalized link-edge table:
+   `(source_path, target_path, target_anchor, link_kind)`.
+   A point query finds incoming edges in one
+   index lookup.
+3. **ID resolution.** "Resolve `[[chen-2024]]` to
+   a file." A unique index on the configured
+   `id_field` makes this O(log n) instead of a
+   full scan.
+
+Plus the L4 traversal (`link.asFile().property`)
+which is recursive and benefits from the
+denormalized FM in the cache.
+
+**Alternatives mdsmith could consider.** If
+mdsmith ever needed an index — for backlinks
+(L-4), wikilinks (L-1), or fast `query` over
+large repos — these are the candidate
+implementations, ranked by complexity:
+
+1. **No cache, parallel re-read.** What mdsmith
+   does today. Reads files in parallel, parses
+   each, builds an in-memory link graph for the
+   duration of the run. Determinism is high,
+   memory is bounded, but cold-start time scales
+   linearly with file count. Fine to ~5k files.
+2. **In-memory index with mtime invalidation,
+   process-scoped.** The LSP server already does
+   this for compiled config. Extend to a link
+   graph and FM map. Survives one editor session;
+   does not survive process exit. Good fit for
+   LSP, no fit for one-shot CLI.
+3. **Memory-mapped file index** (e.g.,
+   FlatBuffers or a Go `gob` blob). Persistent
+   across runs, bounded format, no SQL. Requires
+   a custom query API; no `WHERE`-clause power.
+   Fast load (mmap is constant-time) but every
+   query rescans the chunk it cares about. Good
+   for backlinks (point lookup) and tag indexes;
+   bad for FM filtering with multiple predicates.
+4. **Embedded key-value store** (BoltDB,
+   Badger). Persistent, transactional, no
+   external dependency. Schema is hand-rolled
+   like option 3. Easier to evolve than mmap.
+   No SQL means complex predicates need
+   application-side filtering after a key scan.
+5. **SQLite (mdbase's choice).** Persistent,
+   ACID, full SQL, mature ecosystem.
+   `modernc.org/sqlite` is a pure-Go driver so a
+   static binary stays static. Trade-off: schema
+   migrations and an extra dependency surface.
+6. **Full-text search engine** (Bleve,
+   Tantivy via cgo). Useful only if Q-3 (body
+   FTS) becomes central. Overkill otherwise.
+
+**Where mdsmith would land.** Probably option 2
+for the LSP server (extending what's there) and
+option 4 (BoltDB-style) if a persistent on-disk
+cache is ever needed. Option 5 (SQLite) carries
+the most operational baggage — a binary cache
+file that needs schema versioning, a driver
+dependency, and a "delete it if it gets weird"
+escape hatch — for capability mdsmith does not
+yet need. The strongest argument for SQLite is
+mdbase's Q-5 aggregations; mdsmith does not plan
+to ship those.
+
+The right framing for now: **add an in-memory
+link graph to the LSP server (option 2)** when
+plan 131 lands, since `documentSymbol` /
+`references` / call hierarchy all want one. If a
+follow-up plan adds backlinks to the CLI (L-4),
+prototype with parallel re-read (option 1) and
+only escalate to a persistent cache when real
+profiling shows a regression on a real corpus.
+
+## In-flight items
+
+| ID  | Plan / PR          | Notes                                         |
+|-----|--------------------|-----------------------------------------------|
+| H-1 | plan 122           | Hover for rule and directive docs             |
+| H-2 | plan 131 (PR #238) | Symbol navigation, references, call hierarchy |
+
+## Suggested sequencing
+
+If a maintainer wants to ship a few of these, the
+ones with the highest payoff per unit of effort
+are:
+
+1. **L-1 (wikilink awareness)** — unlocks Obsidian
+   vault use; small effort, high impact.
+2. **L-4 (backlinks subcommand)** — surfaces
+   value already in MDS027; small effort.
+3. **M-1 (field-presence kind assignment)** —
+   ergonomic win; small effort.
+4. **C-6 (dry-run for fix)** — agent-friendly;
+   small effort.
+5. **S-1 (inline schema)** — ergonomic win for
+   teams not wanting a separate proto.md; medium
+   effort but unlocks S-3, S-4, S-6.
+6. **Q-1 / Q-2 (sort and limit)** — small effort,
+   makes `query` actually useful in scripts.
+7. **L-3 / C-4 (rename refactor)** — large effort
+   but high-leverage; closes the biggest workflow
+   gap.
+
+The remaining items are nice-to-haves whose
+priority depends on real user demand.
+
+## What this exercise revealed
+
+Three structural observations fall out of working
+through the gaps systematically.
+
+1. **mdsmith's stateless single-pass design is a
+   feature, not a missing piece.** Most "missing"
+   features (cache, watch, CRUD, migrations) trade
+   determinism for capability. The right answer
+   for vault-scale typed-record work is mdbase,
+   not a richer mdsmith.
+
+2. **mdsmith's schema mechanism is closer to
+   mdbase's than the surface suggests.** Both use
+   Markdown files with declarative front matter as
+   schemas. The differences (CUE vs DSL, body
+   structure check vs body-as-docs) are real but
+   smaller than they look. S-1 + S-2 + S-3 close
+   most of the ergonomic gap.
+
+3. **The link graph is mdsmith's biggest
+   underused asset.** MDS027 already builds it.
+   Backlinks (L-4), wikilinks (L-1), and rename
+   refactor (L-3) all flow from making that graph
+   first-class instead of a per-rule internal.

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -187,8 +187,16 @@ mdbase names directly (date, datetime, enum, link).
 `email`, `url`) starts paying more than the cost of teaching
 users two ways to spell the same constraint.
 
-**Sketch.** Add a small CUE library
-`internal/cue/types.cue` that defines:
+**Sketch.** Ship a small CUE library that
+schemas can import. The library lives at a
+publicly importable module path (e.g.
+`github.com/jeduden/mdsmith/types`); the source
+in this repo would sit somewhere like
+`cue/types/types.cue` or be exposed via
+mdsmith's CUE overlay (Go's `internal/` path
+is not importable from outside, so a public
+module path is required for schemas in user
+projects). The library defines common patterns:
 
 ```cue
 package mdsmith
@@ -212,6 +220,11 @@ created:  types.#date
 modified: types.#datetime
 ```
 
+(The exact module path is illustrative; this
+mini-plan would need to settle the canonical
+location and how mdsmith ships the overlay so
+external schemas can resolve the import.)
+
 Optionally expose a more compact YAML shorthand in
 inline schemas (S-1):
 
@@ -234,9 +247,9 @@ useful; without it the patterns are still helpful
 in `proto.md` schemas.
 
 **Open questions.** What's the canonical list?
-Start with the seven mdbase covers (string, int,
-number, bool, date, datetime, time, enum, link)
-and grow from real use.
+Start with the nine mdbase scalar types (string,
+int, number, bool, date, datetime, time, enum,
+link) and grow from real use.
 
 ### S-3: Schema inheritance via `extends`
 

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -3,7 +3,6 @@ summary: >-
   Systematic enumeration of mdbase capabilities mdsmith does not yet
   have, with a per-gap mini-plan covering goal, design sketch, surface,
   effort, trigger, and open questions.
-status: 🔳
 ---
 # What mdsmith can learn from mdbase
 

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -56,14 +56,15 @@ sketch.
 
 ### Schema language (S)
 
-| ID  | Gap                                          | Effort | Trigger / status                                            |
-|-----|----------------------------------------------|--------|-------------------------------------------------------------|
-| S-1 | Inline schema in `kinds:`                    | M      | one team asks for a schema without a separate `proto.md`    |
-| S-2 | Named field-type taxonomy as CUE shortcuts   | S      | S-1 lands and the YAML shorthand becomes useful             |
-| S-3 | Schema inheritance (`extends:`)              | S–M    | a project has three or more schemas with shared fields      |
-| S-4 | Computed fields surfaced in catalog / query  | M      | a real catalog wants a field derived from FM                |
-| S-5 | Generated values on write (ULID, timestamps) | M      | mdsmith grows a `create` or scaffolding subcommand          |
-| S-6 | Field deprecation flag                       | S      | a real schema migration needs to deprecate without breaking |
+| ID  | Gap                                                        | Effort | Trigger / status                                                                                 |
+|-----|------------------------------------------------------------|--------|--------------------------------------------------------------------------------------------------|
+| S-1 | Inline schema in `kinds:`                                  | M      | one team asks for a schema without a separate `proto.md`                                         |
+| S-2 | Named field-type taxonomy as CUE shortcuts                 | S      | S-1 lands and the YAML shorthand becomes useful                                                  |
+| S-3 | Schema inheritance (`extends:`)                            | S–M    | a project has three or more schemas with shared fields                                           |
+| S-4 | Computed fields surfaced in catalog / query                | M      | a real catalog wants a field derived from FM                                                     |
+| S-5 | Generated values on write (ULID, timestamps)               | M      | mdsmith grows a `create` or scaffolding subcommand                                               |
+| S-6 | Field deprecation flag                                     | S      | a real schema migration needs to deprecate without breaking                                      |
+| S-7 | Rich body schema (sections, fields, refs, acronyms, index) | L      | a project authors structured Markdown (deck, runbook, training) where current MDS020 falls short |
 
 ### File-to-kind matching (M)
 
@@ -369,6 +370,220 @@ schema:
 **Depends on.** S-1.
 
 **Open questions.** None worth blocking on.
+
+### S-7: Rich body schema for structural document types
+
+**Goal.** Type the body of structured Markdown
+documents beyond the heading sequence: nested
+sections with per-field content rules (word and
+character counts, forbidden text patterns,
+required patterns, skip rules), cross-reference
+validation, acronym tracking, and document-wide
+index generation. This closes the
+"structural body typing" gap noted in
+[query-and-types.md](query-and-types.md) §
+"Where each is genuinely silent".
+
+**Trigger.** A real project authors structured
+Markdown beyond docs and RFCs — presentation
+decks (slides plus speaker notes), training
+material (lessons plus exercises), structured
+runbooks (incidents plus steps plus
+verification), regulatory documents (clauses
+plus citations). Today every such project
+writes custom lint scripts. The trigger fires
+when two or more of these projects emerge and
+the constraint vocabulary repeats; that is when
+shipping a generic schema language pays.
+
+**Sketch.** A schema language (the form is
+open — could be a richer YAML in `proto.md`
+front matter, a separate CUE-flavoured DSL, or
+an extension of the existing MDS020 schema)
+covering five capabilities current MDS020 does
+not address. The illustrative shape, sketched
+for a presentation-deck schema:
+
+```yaml
+sections:
+  - heading: "## Deck Parameters"
+    required: true
+  - heading: "## Horizontal Flow"
+    required: true
+    aliases: ["## Horizontal Flow (Title Sequence)"]
+  - heading: "## Section"
+    required: true
+    repeatable: true
+    pattern: "## Section \\d+:.*"
+  - heading: "## Backup Slides"
+    required: true
+    children:
+      pattern: "### B{n}:*"
+      sequential: false      # gaps allowed
+      fields:
+        - heading: "#### Extends"
+          required: true
+        - heading: "#### Pull condition"
+          required: true
+        - heading: "#### Speaker notes"
+          required: false
+          max_words: 300
+
+# Slide definition (children of Section headings)
+slides:
+  pattern: "### Slide {n}"
+  sequential: true            # no gaps, no duplicates
+  fields:
+    - heading: "#### Action Title"
+      required: true
+      min_words: 3
+      max_words: 12
+      max_chars: 65
+      forbidden_starts: ["We ", "Our "]
+      forbidden_contains: [" and "]
+      skip_slides: [1]        # cover slide exempt
+    - heading: "#### Speaker notes"
+      required: true
+      max_words: 300
+      required_patterns:
+        - pattern: "TRANSITION:"
+          error: "Missing TRANSITION marker"
+          skip_slides: [-1]   # last slide exempt
+
+# Cross-reference validation
+cross_references:
+  - pattern: "Slide (\\d+)"
+    must_match: "### Slide {n}"
+    skip_lines_matching: "^> \\*\\*"  # skip version-history blockquotes
+  - pattern: "\\bB(\\d+)\\b"
+    must_match: "### B{n}"
+
+# Acronym tracking — flag acronyms used before expansion
+acronym_tracking:
+  known_safe: [AI, IDE, PR, CI, CD, QA, URL, API, KPI]
+  scope: on_slide_content       # which h4 sections to check
+
+# Cross-ref ban: "Slide N" refs that break leave-behind PDFs
+cross_ref_standalone:
+  ban_in: [On-slide content, Visual concept]
+  allow_in: [Speaker notes, Editorial notes]
+
+# Index output for downstream tooling
+index:
+  output: ".narrative-index.json"
+  include: [slide_map, backup_map, cross_ref_graph, word_counts]
+```
+
+The five capabilities, each absent from MDS020
+today:
+
+1. **Hierarchical body structure** — nested
+   sections with required/optional/repeatable
+   semantics, plus child patterns
+   (`### Slide {n}` with sequential / non-
+   sequential numbering).
+2. **Per-field content rules** — word and
+   character counts, forbidden / required text
+   patterns, regex-based pattern checks, scoped
+   skip rules (e.g. "cover slide is exempt
+   from the action-title length cap").
+3. **Cross-reference validation** — text like
+   "Slide 5" must resolve to an actual
+   `### Slide 5` heading; broken refs are
+   diagnostics. Skip rules let version-history
+   blockquotes carry stale refs without
+   firing.
+4. **Acronym tracking** — flag acronym uses
+   that appear before their expansion, with a
+   known-safe allowlist and a per-field scope.
+5. **Index generation** — produce a JSON index
+   of the document's structure (slide map,
+   backup map, cross-reference graph, word
+   counts per subsection) for downstream
+   tooling. Effectively a side-output of the
+   parse pass that already happens during lint.
+
+**Surface.** A new schema format alongside (or
+extending) the current `proto.md` schema body.
+Either an extension of MDS020 (richer schema
+language inside the existing rule) or a sister
+rule (MDS-something) that runs alongside.
+`mdsmith fix` regenerates the index file when
+the document changes; `mdsmith check` reports
+violations with file/line/column anchors.
+
+**Effort.** L. This is the largest schema-side
+candidate. The schema language needs careful
+design (CUE? YAML? hybrid?), the validator does
+real work (per-field rules, cross-reference
+resolution, acronym tracking are each their own
+small subsystem), and index generation adds an
+output surface.
+
+**Depends on.** S-1 (inline schemas) as a
+stepping stone — the YAML form here is in
+spirit an inline schema. Possibly S-3
+(`extends`) so common section patterns can be
+shared across kinds.
+
+**Open questions.** Six things a real plan would
+have to settle:
+
+- **Schema language choice.** YAML in `proto.md`
+  front matter (close to mdbase's style) vs.
+  extending CUE (close to current mdsmith) vs.
+  a new DSL designed for this. Each has costs.
+- **Composition with MDS020.** Is this a richer
+  MDS020 schema, or a sister rule that runs
+  alongside? Composition matters: a project
+  might want both heading-template constraints
+  (MDS020 today) and the richer body rules
+  (this proposal) on the same files.
+- **Index output location and format.** JSON
+  next to the source file, gitignored cache,
+  or somewhere else? What's the schema of the
+  index? mdbase's `effective_json` per-file
+  cache is one shape; a per-document
+  `.narrative-index.json` is another.
+- **Cross-reference scope.** "Slide 5" refs
+  must resolve, but version-history
+  blockquotes break this. The schema example
+  has `skip_lines_matching`; that's a
+  configurable escape hatch. Does it
+  generalize?
+- **Relationship to mdbase types.** mdbase
+  types declare FM shape; this proposal
+  declares body structure. They are
+  orthogonal in scope, but a project running
+  both wants one definition file, not two.
+  How would the schema bridge
+  ([interop.md §7](interop.md)) cover the
+  body half?
+- **Performance.** Per-field word counts and
+  cross-reference resolution scale with file
+  size. Most documents are small; runbooks and
+  decks fit. Books would not.
+
+**Why this matters in the comparison.** mdbase's
+data-layer typing and mdsmith's heading-template
+schemas both stop at the boundary of "rich body
+structure". A user with a 50-slide deck or a
+long structured runbook gets the same answer
+from either tool today: write your own lint
+script. S-7 would close this gap from mdsmith's
+side; mdbase doesn't have a path to closing it
+without going outside its data-layer scope.
+
+This is the most ambitious schema candidate in
+this catalogue. It is not trivial — the
+sketch above is itself a "needs work" design.
+But it is the right shape for the gap, and the
+direction is consistent with mdsmith's existing
+broader-rule-set approach: declarative schema
+language, lint-time enforcement, drift detection,
+auto-fix where the change is regenerable
+(the index is regenerable; word-count
+violations are not).
 
 ## File-to-kind matching plans
 

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -1,18 +1,17 @@
 ---
-summary: Systematic enumeration of mdbase capabilities mdsmith does not yet have, with a per-gap mini-plan covering goal, design sketch, surface, effort, and open questions.
+summary: Systematic enumeration of mdbase capabilities mdsmith does not yet have, with a per-gap mini-plan covering goal, design sketch, surface, effort, trigger, and open questions.
 status: 🔳
 ---
 # What mdsmith can learn from mdbase
 
 This document is a research exercise, not a roadmap.
-It enumerates every mdbase capability that mdsmith
-either lacks or expresses differently, triages each
-into in-scope / out-of-scope / already-in-flight,
-and sketches a mini-plan for the in-scope ones. The
-goal is to give a future maintainer a list of
-discrete, well-framed work items they can promote
-into actual `plan/<n>_*.md` files when the time
-comes.
+mdsmith does not have a closed feature set; it is
+evolving. Every gap below is a candidate direction.
+The point of the exercise is to map the candidates,
+sketch each one concretely enough to argue about,
+and name the **trigger** under which shipping it
+becomes worth the cost — not to declare any of them
+in or out.
 
 ## Method
 
@@ -20,100 +19,101 @@ comes.
 2. For each row where mdbase has a capability and
    mdsmith does not, note it as a gap with a short
    identifier (e.g. `S-1`, `Q-3`).
-3. Triage:
+3. For each gap, record:
 
-  - **In-scope** — fits the existing mdsmith
-     mission (lint, fix, generate over Markdown
-     files in a repo) and would benefit a real use
-     case from [use-cases.md](use-cases.md).
-  - **Out-of-scope** — would change what mdsmith
-     is. Note why and the principled alternative.
-  - **In-flight** — already covered by an open
-     plan or PR.
+  - an **effort** estimate (S / M / L: a day, a
+     week, a month)
+  - a **trigger**: a concrete condition under
+     which shipping the gap is worth the cost
+     (real user demand, a profiling result, a
+     dependency from another shipped feature, a
+     coherence pull from a subsystem)
+  - whether work is already in flight (linking
+     the open plan or PR)
 
-4. For each in-scope gap, write a mini-plan with:
+4. Write a mini-plan per gap with:
 
   - **Goal** — one sentence
+  - **Trigger** — when shipping becomes worth it
   - **Sketch** — proposed mechanism, including
      concrete syntax where it helps
   - **Surface** — what new config / CLI / output
      the user sees
-  - **Effort** — S / M / L (a day, a week, a
-     month)
+  - **Effort** — S / M / L
   - **Depends on** — gaps or existing plans this
      builds on
   - **Open questions** — things a real plan would
      have to settle
 
-## Triage tables
+## Capability tables
 
-Tables split by area for readability. Twelve
-in-scope gaps follow as mini-plans below; the
-out-of-scope and in-flight items get a brief
-rationale at the end.
+Tables split by area for readability. Each row
+names a candidate direction with effort and
+trigger; the mini-plan below carries the design
+sketch.
 
 ### Schema language (S)
 
-| ID  | Gap                                          | Status       | Priority |
-|-----|----------------------------------------------|--------------|----------|
-| S-1 | Inline schema in `kinds:`                    | in-scope     | high     |
-| S-2 | Named field-type taxonomy as CUE shortcuts   | in-scope     | medium   |
-| S-3 | Schema inheritance (`extends:`)              | in-scope     | medium   |
-| S-4 | Computed fields surfaced in catalog / query  | in-scope     | medium   |
-| S-5 | Generated values on write (ULID, timestamps) | out-of-scope | n/a      |
-| S-6 | Field deprecation flag                       | in-scope     | low      |
+| ID  | Gap                                          | Effort | Trigger / status                                            |
+|-----|----------------------------------------------|--------|-------------------------------------------------------------|
+| S-1 | Inline schema in `kinds:`                    | M      | one team asks for a schema without a separate `proto.md`    |
+| S-2 | Named field-type taxonomy as CUE shortcuts   | S      | S-1 lands and the YAML shorthand becomes useful             |
+| S-3 | Schema inheritance (`extends:`)              | S–M    | a project has three or more schemas with shared fields      |
+| S-4 | Computed fields surfaced in catalog / query  | M      | a real catalog wants a field derived from FM                |
+| S-5 | Generated values on write (ULID, timestamps) | M      | mdsmith grows a `create` or scaffolding subcommand          |
+| S-6 | Field deprecation flag                       | S      | a real schema migration needs to deprecate without breaking |
 
 ### File-to-kind matching (M)
 
-| ID  | Gap                                      | Status   | Priority |
-|-----|------------------------------------------|----------|----------|
-| M-1 | Field-presence kind assignment           | in-scope | high     |
-| M-2 | Field-value kind assignment (`where:`)   | in-scope | low      |
-| M-3 | `path-pattern` (validates and generates) | in-scope | medium   |
+| ID  | Gap                                      | Effort | Trigger / status                                                 |
+|-----|------------------------------------------|--------|------------------------------------------------------------------|
+| M-1 | Field-presence kind assignment           | S      | a project tags >100 files with `kinds:` boilerplate              |
+| M-2 | Field-value kind assignment (`where:`)   | S–M    | a project wants derived kinds (e.g. open-task vs archived-task)  |
+| M-3 | `path-pattern` (validates and generates) | S      | a project enforces filename conventions today via custom scripts |
 
 ### CRUD and rename (C)
 
-| ID  | Gap                            | Status       | Priority |
-|-----|--------------------------------|--------------|----------|
-| C-1 | Create typed file              | out-of-scope | n/a      |
-| C-2 | Update fields from CLI         | out-of-scope | n/a      |
-| C-3 | Delete with broken-ref warning | out-of-scope | n/a      |
-| C-4 | Atomic rename + ref rewrite    | in-scope     | high     |
-| C-5 | Batch ops with `--where`       | out-of-scope | n/a      |
-| C-6 | Dry-run mode for fix           | in-scope     | low      |
+| ID  | Gap                            | Effort | Trigger / status                                                           |
+|-----|--------------------------------|--------|----------------------------------------------------------------------------|
+| C-1 | Create typed file              | M      | a user-facing demand for scaffolding from inside mdsmith (e.g. agent loop) |
+| C-2 | Update fields from CLI         | M      | C-1 lands; consistency pulls update along                                  |
+| C-3 | Delete with broken-ref warning | S      | C-1 / C-2 ship; deletion completes the CRUD surface                        |
+| C-4 | Atomic rename + ref rewrite    | L      | rename pain shows up in real workflows (issue threads, agent retries)      |
+| C-5 | Batch ops with `--where`       | M      | a CRUD surface (C-1..C-4) needs scoping beyond globs                       |
+| C-6 | Dry-run mode for fix           | S      | first agent or CI user asks to preview changes                             |
 
 ### Links (L)
 
-| ID  | Gap                                   | Status          | Priority |
-|-----|---------------------------------------|-----------------|----------|
-| L-1 | Wikilink awareness                    | in-scope        | high     |
-| L-2 | ID-field link resolution              | out-of-scope    | n/a      |
-| L-3 | Auto-rewrite incoming links on rename | in-scope (=C-4) | high     |
-| L-4 | Backlinks subcommand                  | in-scope        | high     |
-| L-5 | Multi-hop link traversal in queries   | out-of-scope    | n/a      |
+| ID  | Gap                                   | Effort | Trigger / status                                                         |
+|-----|---------------------------------------|--------|--------------------------------------------------------------------------|
+| L-1 | Wikilink awareness                    | M      | the first Obsidian-vault user files a "wikilinks aren't validated" issue |
+| L-2 | ID-field link resolution              | M      | a project imposes its own ID system and wants link-by-ID                 |
+| L-3 | Auto-rewrite incoming links on rename | L      | (covered by C-4)                                                         |
+| L-4 | Backlinks subcommand                  | S      | first agent or doc-team request for "what links to X"                    |
+| L-5 | Multi-hop link traversal in queries   | M      | a project wants `[[A]] → asFile().status` semantics in `query`           |
 
 ### Query (Q)
 
-| ID  | Gap                                   | Status       | Priority |
-|-----|---------------------------------------|--------------|----------|
-| Q-1 | Sort (`--order-by`)                   | in-scope     | medium   |
-| Q-2 | Pagination (`--limit` / `--offset`)   | in-scope     | low      |
-| Q-3 | Body full-text search in query        | in-scope     | medium   |
-| Q-4 | Date arithmetic with duration strings | in-scope     | low      |
-| Q-5 | Aggregations (formulas, summaries)    | out-of-scope | n/a      |
-| Q-6 | Cross-file traversal in queries       | out-of-scope | n/a      |
-| Q-7 | Bases-compatible expression syntax    | in-scope     | low      |
+| ID  | Gap                                   | Effort | Trigger / status                                                |
+|-----|---------------------------------------|--------|-----------------------------------------------------------------|
+| Q-1 | Sort (`--order-by`)                   | S      | first script piping `query` through `sort` complains            |
+| Q-2 | Pagination (`--limit` / `--offset`)   | S      | first script wraps `query` with `head` / `tail`                 |
+| Q-3 | Body full-text search in query        | S–M    | first user request for FM + body filter combined                |
+| Q-4 | Date arithmetic with duration strings | M      | due-date / mtime queries become common in CI                    |
+| Q-5 | Aggregations (formulas, summaries)    | L      | a recurring "group plans by status" pattern shows up in user CI |
+| Q-6 | Cross-file traversal in queries       | M      | L-1 + L-4 ship; traversal becomes the obvious next step         |
+| Q-7 | Bases-compatible expression syntax    | M      | enough Obsidian users ask for it that two query languages pays  |
 
 ### Cache, watch, migrations, conformance, LSP
 
-| ID  | Gap                                    | Status          | Priority |
-|-----|----------------------------------------|-----------------|----------|
-| P-1 | SQLite-backed cache for large repos    | out-of-scope    | n/a      |
-| P-2 | Watch mode beyond LSP per-session      | out-of-scope    | n/a      |
-| V-1 | Migration manifests                    | out-of-scope    | n/a      |
-| X-1 | Spec-first / multi-impl model          | out-of-scope    | n/a      |
-| H-1 | LSP hover for rules / directives       | in-flight (122) | n/a      |
-| H-2 | LSP symbol navigation + call hierarchy | in-flight (131) | n/a      |
+| ID  | Gap                                    | Effort | Trigger / status                                                              |
+|-----|----------------------------------------|--------|-------------------------------------------------------------------------------|
+| P-1 | Persistent on-disk index               | L      | profiling on a real >5k-file repo shows the cold-start cost is the bottleneck |
+| P-2 | Watch mode beyond LSP per-session      | M      | a CLI workflow needs cross-process freshness (rare today)                     |
+| V-1 | Migration manifests                    | L      | mdsmith grows write-back to FM (S-5 / C-2) and breaking schema changes hurt   |
+| X-1 | Spec-first / multi-impl model          | XL     | a second implementation appears (fork, or upstream split); revisit then       |
+| H-1 | LSP hover for rules / directives       | —      | in-flight (plan 122)                                                          |
+| H-2 | LSP symbol navigation + call hierarchy | —      | in-flight (plan 131, PR #238)                                                 |
 
 ## Schema language plans
 
@@ -122,6 +122,10 @@ rationale at the end.
 **Goal.** Let `kinds:` carry a schema directly,
 without forcing every kind to point at a separate
 `proto.md`.
+
+**Trigger.** A team or contributor asks for an inline schema rather than
+maintaining a separate `proto.md` per kind, especially when the
+schema is small enough to read at a glance from the config.
 
 **Sketch.** Extend the kind config to accept an
 optional `schema:` block alongside (or instead of)
@@ -176,6 +180,10 @@ fragment composition)? Probably yes, for parity.
 **Goal.** Make CUE schemas more ergonomic by
 shipping reusable definitions for the common types
 mdbase names directly (date, datetime, enum, link).
+
+**Trigger.** S-1 lands and the YAML shorthand for common types (`date`,
+`email`, `url`) starts paying more than the cost of teaching
+users two ways to spell the same constraint.
 
 **Sketch.** Add a small CUE library
 `internal/cue/types.cue` that defines:
@@ -233,6 +241,10 @@ and grow from real use.
 **Goal.** Let one kind / schema extend another so
 common front-matter fields live in a base schema.
 
+**Trigger.** A project carries three or more schemas with overlapping
+required fields (e.g. all RFCs share `id`, `status`, `created`,
+`authors`) and the duplication has begun to drift.
+
 **Sketch.** Two parts:
 
 - **In `kinds:`** — `extends:` lists parent kinds
@@ -275,6 +287,10 @@ a field from other front-matter fields, surface
 the result in `<?catalog?>` columns and `mdsmith
 query`, and never persist it back to disk.
 
+**Trigger.** A real catalog or query case wants a field derived from FM
+rather than stored — for example `days_since_review` — strongly
+enough that users are working around the gap.
+
 **Sketch.** Computed fields live in the schema
 (inline or proto.md) under a `computed:` block:
 
@@ -313,6 +329,10 @@ out of scope.
 **Goal.** Let a schema mark a field deprecated;
 mdsmith warns when it appears in front matter.
 
+**Trigger.** A schema change needs to deprecate a field without breaking
+existing files, and the absence of a soft-deprecation signal
+forces a hard removal.
+
 **Sketch.** In the schema, `deprecated: true` on a
 field. MDS020 emits a Warning (not an Error) when
 the field is present.
@@ -342,6 +362,10 @@ schema:
 **Goal.** Auto-assign a kind when specific
 front-matter fields are present, removing the need
 for an explicit `kind:` tag.
+
+**Trigger.** A project tags more than ~100 files with `kinds:` boilerplate
+and the duplication is painful enough that auto-assignment by
+FM shape is worth a new mechanism.
 
 **Sketch.** Extend `kind-assignment:` with a
 `fields-present:` selector:
@@ -377,6 +401,10 @@ mdbase's "non-null required" semantics.
 expression over front matter, e.g. "files where
 status is 'open'".
 
+**Trigger.** A project wants derived kinds — `open-task` vs `archived-task`,
+draft vs published — and globs aren't expressive enough to
+capture the distinction.
+
 **Sketch.** Extend `kind-assignment:` with a
 `where:` selector that takes a CUE struct
 literal — same syntax as `mdsmith query`:
@@ -411,6 +439,10 @@ real use.
 that validates existing files (does the path
 match?) and templates new ones (where should a
 new file live?).
+
+**Trigger.** A project enforces filename conventions today via custom CI
+scripts and would benefit from declaring the pattern alongside
+the kind.
 
 **Sketch.** Add `path-pattern:` to a kind:
 
@@ -449,6 +481,10 @@ Match what mdbase does for portability.
 heavy vaults can use mdsmith without flagging
 every wikilink as text.
 
+**Trigger.** The first Obsidian-vault user files a "wikilinks aren't
+validated" issue, or a docs team adopts wikilinks for navigation
+and finds MDS027 silent.
+
 **Sketch.** Add a wikilink parser to the lint
 pipeline (alongside the existing Markdown link
 extractor in `internal/lint/`). Resolution rules
@@ -486,6 +522,11 @@ breaks Obsidian for users who want wikilinks.
 **Goal.** A `mdsmith refactor rename <old> <new>`
 subcommand that moves a file and rewrites every
 incoming link.
+
+**Trigger.** Rename pain shows up in real workflows — recurring PRs that
+touch tens of files for one rename, or agent retries looping on
+broken links — strongly enough that a one-shot refactor command
+pays.
 
 **Sketch.** New subcommand:
 
@@ -532,6 +573,10 @@ syntactically links.
 that lists every workspace file with a link to
 the target.
 
+**Trigger.** First agent or docs-team request for "what links to this file?"
+The link graph becomes load-bearing for navigation or impact
+analysis.
+
 **Sketch.** Reuses the link graph that MDS027
 already builds during a check pass:
 
@@ -569,6 +614,9 @@ covers the common case.
 **Goal.** Support `--order-by FIELD` and
 `--limit N` / `--offset N` on `mdsmith query`.
 
+**Trigger.** First script that pipes `mdsmith query` through `sort` / `head` /
+`tail` files an issue asking for native flags. Low bar; small fix.
+
 **Sketch.** New flags:
 
 ```bash
@@ -594,6 +642,10 @@ output unchanged.
 
 **Goal.** Filter files by body content as well as
 front matter.
+
+**Trigger.** First user asks for a query that combines FM filtering with body
+content — typically agents or CI scripts looking for `TODO`
+markers in scoped subsets of the corpus.
 
 **Sketch.** New flag `--body-contains REGEX`:
 
@@ -626,6 +678,10 @@ the next 7 days":
 ```bash
 mdsmith query 'due: <=time.Add(time.Now(), "7d24h")' tasks/
 ```
+
+**Trigger.** Due-date, mtime, or created-since queries become common in CI,
+and CUE's lack of duration arithmetic forces verbose timestamp
+construction.
 
 **Sketch.** Add a small CUE package
 `internal/cue/time.cue` that defines `Add`,
@@ -661,6 +717,10 @@ top-level `timezone:` config key.
 expressions in `mdsmith query`, so users coming
 from a vault don't have to learn CUE for simple
 filters.
+
+**Trigger.** Enough Obsidian users ask for Bases-style filters to overcome
+the cost of supporting two query languages. Likely never, but
+the sketch is here so a real request lands on solid ground.
 
 **Sketch.** Add a `--lang bases` flag:
 
@@ -701,6 +761,10 @@ translation pass, not a parallel implementation.
 **Goal.** Show what `mdsmith fix` would change
 without writing.
 
+**Trigger.** First agent or CI user asks to preview changes before writing —
+typically when agents run `mdsmith fix` autonomously and want a
+safety net.
+
 **Sketch.** New flag `--dry-run`:
 
 ```bash
@@ -723,32 +787,280 @@ write.
 
 **Open questions.** None.
 
-## Out-of-scope items: rationale
+## Mini-plans-lite for the heavier directions
 
-For each "out-of-scope" gap, a one-line reason and
-the principled alternative.
+Several directions cross the line from
+"read-and-fix" into write, persistence, or
+multi-impl territory. They are fully on the table;
+they just carry larger trade-offs and clearer
+triggers. Each gets a brief sketch and the
+condition under which it would pay.
 
-| ID  | Why not                                                                    | Alternative                                 |
-|-----|----------------------------------------------------------------------------|---------------------------------------------|
-| S-5 | mdsmith does not author files; agents and humans do                        | Use `mdbase create` for typed scaffolding   |
-| C-1 | mdsmith is lint-and-fix, not author-and-edit                               | Editor / agent / mdbase                     |
-| C-2 | Same as C-1                                                                | Same                                        |
-| C-3 | Same as C-1                                                                | Same                                        |
-| C-5 | Batch CRUD is out-of-scope; lint/fix already scopes by glob                | mdbase batch ops, or a shell loop           |
-| L-2 | ID-field resolution requires a canonical ID system mdsmith does not impose | Use mdbase if you need ID-keyed links       |
-| L-5 | Multi-hop traversal couples query with link graph; large complexity        | mdbase Bases queries with `asFile()`        |
-| Q-5 | Aggregations grow into a database surface mdsmith does not own             | mdbase Query+ formulas / summaries          |
-| Q-6 | Same coupling as L-5                                                       | Same                                        |
-| P-1 | Stateless re-read is a design feature: deterministic, no stale state       | mdbase SQLite cache for vault-scale work    |
-| P-2 | LSP per-session covers editor flows; persistent daemon adds risk           | LSP, plus mdbase watch mode for vault flows |
-| V-1 | Migrations require write-back to data files; mdsmith does not              | mdbase migrate manifests                    |
-| X-1 | mdsmith is the implementation; spec-first costs maintenance                | If forks happen, revisit                    |
+### S-5: Generated values on write
 
-The recurring theme: mdsmith owns the
-**read-and-fix-source** layer. Anything that wants
-to **author or edit data** crosses a category line.
-mdbase's CRUD-and-cache layer is the principled
-home for those features.
+**Goal.** Support `generated:` strategies (ULID,
+UUID, sequence, `now_on_write`) that fill a field
+when a typed file is created.
+
+**Trigger.** mdsmith grows a `create` or
+scaffolding subcommand (C-1) and users want
+ULID-keyed records or `created` timestamps filled
+automatically. Without C-1 there is no write
+moment for these to fire.
+
+**Sketch.** Schema field block adds
+`generated: ulid | uuid | sequence | now_on_write`.
+The create command applies the strategy at write
+time; the lint engine treats generated fields as
+present-in-effective-FM whether or not they are
+on disk.
+
+**Effort.** M after C-1.
+**Depends on.** C-1.
+
+### C-1: Create typed file (`mdsmith create`)
+
+**Goal.** Scaffold a new typed file from a kind's
+schema, filling defaults and generated values.
+
+**Trigger.** A user-facing demand for scaffolding
+from inside mdsmith — an agent loop that wants to
+issue one command, a docs team that wants a
+templated `new-rfc` flow without external tooling.
+
+**Sketch.** New `mdsmith create <kind> [path]`
+subcommand. Reads the kind's schema, prompts for
+required fields without defaults (or accepts
+`--field key=value`), writes the file atomically.
+The body uses the schema's heading template if
+present.
+
+**Effort.** M.
+**Depends on.** S-1 makes the schema legible
+inline; without it the command still works, just
+reads from `proto.md`.
+
+### C-2: Update fields from CLI
+
+**Goal.** Edit one or more FM fields in a file
+without opening an editor.
+
+**Trigger.** C-1 lands and consistency pulls
+update along. Or an agent loop wants to flip
+`status: open` → `status: done` programmatically.
+
+**Sketch.** New `mdsmith update <path> --field key=value`.
+Validates against the file's effective kind /
+schema before writing. Atomic write with mtime
+optimistic-concurrency check.
+
+**Effort.** M.
+**Depends on.** C-1 (shared write surface).
+
+### C-3: Delete with broken-ref warning
+
+**Goal.** Delete a file and warn about incoming
+references that will break.
+
+**Trigger.** C-1 / C-2 ship; deletion completes
+the CRUD surface. Without the other two it is a
+small odd one-off.
+
+**Sketch.** `mdsmith delete <path>` runs MDS027's
+link graph in reverse, lists incoming references,
+asks for confirmation (or `--force`), then
+removes the file.
+
+**Effort.** S after the link-graph work for L-4.
+**Depends on.** L-4.
+
+### C-5: Batch ops with `--where`
+
+**Goal.** Apply create / update / delete across
+files matching a query.
+
+**Trigger.** A CRUD surface (C-1..C-4) has
+shipped and users want to scope batch edits
+beyond what globs express.
+
+**Sketch.** `mdsmith update --where 'status: "open"' --field reviewer=alice`.
+Validates all matched files first, then applies;
+fails fast on validation errors unless `--continue`.
+`--dry-run` previews.
+
+**Effort.** M after C-2.
+**Depends on.** C-2, C-6.
+
+### L-2: ID-field link resolution
+
+**Goal.** Resolve `[[chen-2024]]` to a file
+whose `id_field` equals `chen-2024`, regardless
+of filename.
+
+**Trigger.** A project imposes its own ID system
+(citation keys, ticket IDs) and wants link-by-ID
+that survives renames.
+
+**Sketch.** Config knob
+`cross-file-reference-integrity.id-field: id`.
+When the link target has no path separator and
+no `.md` extension, MDS027 first tries ID-field
+match, then filename match. Same wikilink-style
+resolution rules as mdbase L4.
+
+**Effort.** M.
+**Depends on.** L-1 (the wikilink form is the
+primary user surface).
+
+### L-5: Multi-hop link traversal in queries
+
+**Goal.** Let `mdsmith query` walk a link to its
+target and read the target's FM, e.g.
+`assignee.asFile().role`.
+
+**Trigger.** L-1 + L-4 ship and users start asking
+"filter tasks by assignee.role" — i.e. queries
+that cross the link graph rather than just FM.
+
+**Sketch.** Add `.asFile()` to the CUE query
+namespace. Resolves the link in front matter,
+returns the target's effective FM as a struct.
+Depth limit (default 5). Null propagation on
+broken links.
+
+**Effort.** M.
+**Depends on.** L-1, L-4. Possibly P-1 for
+performance at scale (each hop reads another
+file).
+
+### Q-5: Aggregations (formulas, summaries)
+
+**Goal.** Group, count, sum, min/max, percentile
+across a query result set.
+
+**Trigger.** A recurring "group plans by status,
+count each" pattern shows up in user CI scripts —
+typically when teams use `mdsmith query` as a
+lightweight reporting layer.
+
+**Sketch.** A new flag combo, e.g.
+
+```bash
+mdsmith query 'kind: "plan"' \
+  --group-by status \
+  --aggregate count,priority:avg
+```
+
+Output is a tabular result, JSON-serializable.
+Reuses the in-memory result set produced by Q-1
+through Q-4.
+
+**Effort.** L.
+**Depends on.** Q-1 (sort), Q-3 (body filter).
+This is the strongest argument for an index: at
+scale, computing aggregations from a fresh parse
+pass per query is the costly pattern. See
+[the aggregation use cases doc](aggregation-use-cases.md)
+for a deeper exploration of where the index pays
+and where stateless approaches still hold up.
+
+### Q-6: Cross-file traversal in queries
+
+**Goal.** Query expressions that follow link
+fields into other files (the query-language form
+of L-5).
+
+**Trigger.** L-5 ships and users ask for the
+same in batch queries.
+
+**Sketch.** Same `.asFile()` accessor in CUE
+expressions, evaluated per-file with the depth
+limit.
+
+**Effort.** included in L-5.
+**Depends on.** L-5.
+
+### P-1: Persistent on-disk index
+
+**Goal.** A cache of parsed FM, link edges, and
+computed fields that survives across CLI runs.
+
+**Trigger.** Profiling on a real >5k-file repo
+shows the cold-start parse cost dominates wall
+time, OR an in-flight feature (Q-5 aggregations,
+L-4 backlinks at scale) makes per-run rebuild
+visibly slow. The deeper analysis below
+(*A closer look at P-1*) walks six implementation
+options and what would tip the choice.
+
+**Sketch.** See the next section.
+
+**Effort.** L.
+**Depends on.** Whichever feature triggers it.
+
+### P-2: Watch mode beyond LSP per-session
+
+**Goal.** A persistent watcher that reflects file
+changes into a shared cache or event stream
+between CLI invocations.
+
+**Trigger.** A CLI workflow needs cross-process
+freshness — for example, a long-running agent
+that fires `mdsmith query` repeatedly and the
+mdsmith side wants warm state. Today the LSP
+session covers editor cases.
+
+**Sketch.** Optional `mdsmith watch` daemon that
+runs alongside the project, exposing a Unix
+socket for queries. Other CLI invocations check
+for the socket, use it if present, fall back to
+stateless run otherwise.
+
+**Effort.** M.
+**Depends on.** P-1 (a daemon without a cache is
+just a re-runner).
+
+### V-1: Migration manifests
+
+**Goal.** Declare schema-version deltas and
+backfill expressions, applied via `mdsmith migrate`.
+
+**Trigger.** mdsmith grows write-back to FM
+(via S-5 / C-2), and breaking schema changes
+start hurting real projects with hundreds of
+already-typed files.
+
+**Sketch.** YAML manifests under a
+`<schemas>/_migrations/` folder. Each names
+`from_version`, `to_version`, and a list of
+field-level transforms (rename, default backfill,
+type coerce). `mdsmith migrate` walks files of
+the affected kinds and applies transforms with
+optimistic-concurrency mtime checks.
+
+**Effort.** L.
+**Depends on.** C-2.
+
+### X-1: Spec-first / multi-impl model
+
+**Goal.** Promote mdsmith's behavior to a
+specification so other implementations can
+conform.
+
+**Trigger.** A second implementation appears —
+either a fork that needs to merge back, or an
+upstream split (e.g. a Rust port). Until then
+the cost of spec maintenance has no payoff.
+
+**Sketch.** Extract the rule semantics, schema
+DSL, query language, and directive grammar into
+a versioned spec under `spec/`. Add a
+conformance test suite in YAML. Tier
+implementations by capability ("conformance
+level") the way mdbase does.
+
+**Effort.** XL.
+**Depends on.** Real second-impl pressure.
 
 ### A closer look at P-1 (SQLite cache)
 
@@ -860,26 +1172,62 @@ implementations, ranked by complexity:
    Tantivy via cgo). Useful only if Q-3 (body
    FTS) becomes central. Overkill otherwise.
 
-**Where mdsmith would land.** Probably option 2
-for the LSP server (extending what's there) and
-option 4 (BoltDB-style) if a persistent on-disk
-cache is ever needed. Option 5 (SQLite) carries
-the most operational baggage — a binary cache
-file that needs schema versioning, a driver
-dependency, and a "delete it if it gets weird"
-escape hatch — for capability mdsmith does not
-yet need. The strongest argument for SQLite is
-mdbase's Q-5 aggregations; mdsmith does not plan
-to ship those.
+**Where mdsmith might land.** The choice depends
+on which trigger fires. Option 2 (in-memory,
+process-scoped) is already implicit in the LSP
+server and is the cheapest extension for plan 131
+needs (`documentSymbol`, `references`, call
+hierarchy). For one-shot CLI use, option 1
+(parallel re-read with no cache) holds up to
+roughly 5k files on commodity hardware; beyond
+that the choice between options 3, 4, and 5
+depends on which queries dominate.
 
-The right framing for now: **add an in-memory
-link graph to the LSP server (option 2)** when
-plan 131 lands, since `documentSymbol` /
-`references` / call hierarchy all want one. If a
-follow-up plan adds backlinks to the CLI (L-4),
-prototype with parallel re-read (option 1) and
-only escalate to a persistent cache when real
-profiling shows a regression on a real corpus.
+The strongest argument for SQLite (option 5) is
+relational aggregation (Q-5): grouping, counting,
+joining across types. If mdsmith grows in that
+direction the SQL surface pays for itself. If
+mdsmith stays predominantly in
+filter-and-emit-paths territory, option 4
+(BoltDB / Badger) gives most of the persistence
+without the SQL maintenance cost.
+
+A pragmatic sequencing:
+
+- **Today** — option 1 (no cache) covers the
+  CLI; option 2 (in-memory) covers the LSP.
+- **First trigger** — when a real profiling
+  case shows cold-start as the bottleneck, or
+  when L-4 / Q-5 demand cross-file traversal at
+  scale, prototype option 4 and measure.
+- **Second trigger** — if the prototype's
+  hand-rolled queries become unwieldy, escalate
+  to option 5 (SQLite). The migration is well-
+  understood: BoltDB's bucket model maps onto
+  SQL tables.
+
+Three less-conventional alternatives are also
+worth a serious look. They sit alongside the six
+above rather than replacing them; see
+[aggregation-use-cases.md](aggregation-use-cases.md)
+for the deeper exploration:
+
+- **Stateless-fast (`fzf` / `ripgrep` style).**
+  Re-read every run, but make the read fast
+  enough that no cache is needed. ripgrep
+  searches millions of lines per second; an FM
+  + body parser tuned the same way could put
+  cold-start under one second on tens of
+  thousands of files.
+- **Content-addressed cache (`git`-style
+  objects).** A loose-objects directory of
+  hashed FM blobs. No staleness check at all:
+  the hash is the cache key. Faster than mtime
+  but slower than mmap.
+- **Tiered: fast cold start + opt-in warm
+  daemon.** Default to stateless. A
+  `mdsmith watch` daemon (P-2) adds warm
+  caching only for sessions that elect it.
 
 ## In-flight items
 
@@ -888,54 +1236,60 @@ profiling shows a regression on a real corpus.
 | H-1 | plan 122           | Hover for rule and directive docs             |
 | H-2 | plan 131 (PR #238) | Symbol navigation, references, call hierarchy |
 
-## Suggested sequencing
+## Sequencing observations
 
-If a maintainer wants to ship a few of these, the
-ones with the highest payoff per unit of effort
-are:
+Where the gaps cluster suggests a few natural
+groupings rather than a fixed roadmap. None of
+these are commitments; each waits for the trigger
+named in its mini-plan.
 
-1. **L-1 (wikilink awareness)** — unlocks Obsidian
-   vault use; small effort, high impact.
-2. **L-4 (backlinks subcommand)** — surfaces
-   value already in MDS027; small effort.
-3. **M-1 (field-presence kind assignment)** —
-   ergonomic win; small effort.
-4. **C-6 (dry-run for fix)** — agent-friendly;
-   small effort.
-5. **S-1 (inline schema)** — ergonomic win for
-   teams not wanting a separate proto.md; medium
-   effort but unlocks S-3, S-4, S-6.
-6. **Q-1 / Q-2 (sort and limit)** — small effort,
-   makes `query` actually useful in scripts.
-7. **L-3 / C-4 (rename refactor)** — large effort
-   but high-leverage; closes the biggest workflow
-   gap.
-
-The remaining items are nice-to-haves whose
-priority depends on real user demand.
+- **Quick ergonomic wins.** L-1, L-4, M-1, C-6,
+  Q-1, Q-2 are all small in effort and respond
+  to triggers a single user request can satisfy.
+  They unblock larger work without committing to
+  it.
+- **Schema ergonomics cluster.** S-1 unlocks S-2,
+  S-3, S-4, S-6 by making inline schemas the
+  primary surface. If schema work happens at all,
+  it tends to start here.
+- **The link-graph cluster.** L-1, L-4, L-3 / C-4
+  all read or write the same workspace link
+  graph. Doing them together reuses the parsing
+  and indexing investment.
+- **The CRUD cluster.** C-1 makes C-2, C-3, C-5,
+  S-5, V-1 reachable. Without C-1 the others
+  have no write moment to attach to. Whether to
+  enter the cluster at all depends on whether
+  mdsmith should grow a write surface; that is a
+  bigger product question than any single gap.
+- **The index cluster.** P-1, P-2, Q-5, Q-6, L-5
+  all become more attractive together. The
+  trigger for one is often the trigger for
+  several; the [aggregation use-cases
+  doc](aggregation-use-cases.md) walks the
+  combined trade-off.
 
 ## What this exercise revealed
 
-Three structural observations fall out of working
-through the gaps systematically.
+Three observations fall out of working through
+the gaps systematically. They are descriptive,
+not prescriptive — each leaves room for the
+direction to change as triggers fire.
 
-1. **mdsmith's stateless single-pass design is a
-   feature, not a missing piece.** Most "missing"
-   features (cache, watch, CRUD, migrations) trade
-   determinism for capability. The right answer
-   for vault-scale typed-record work is mdbase,
-   not a richer mdsmith.
-
-2. **mdsmith's schema mechanism is closer to
-   mdbase's than the surface suggests.** Both use
-   Markdown files with declarative front matter as
-   schemas. The differences (CUE vs DSL, body
-   structure check vs body-as-docs) are real but
-   smaller than they look. S-1 + S-2 + S-3 close
-   most of the ergonomic gap.
-
+1. **Most "missing" features are write-side or
+   cache-side.** Cache, watch, CRUD, migrations
+   each trade some of mdsmith's determinism for
+   capability. None are wrong; each carries a
+   visible trigger and a visible cost.
+2. **Schemas are closer than the surface
+   suggests.** Both mdsmith and mdbase use
+   Markdown files with declarative front matter.
+   The differences (CUE vs DSL, body structure
+   check vs body-as-docs) are real but smaller
+   than they look. S-1 + S-2 + S-3 close most of
+   the ergonomic gap if the trigger ever fires.
 3. **The link graph is mdsmith's biggest
    underused asset.** MDS027 already builds it.
    Backlinks (L-4), wikilinks (L-1), and rename
-   refactor (L-3) all flow from making that graph
-   first-class instead of a per-rule internal.
+   refactor (L-3) all flow from promoting that
+   graph to a first-class subsystem.

--- a/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
+++ b/docs/research/mdbase-vs-mdsmith/learn-from-mdbase.md
@@ -376,149 +376,141 @@ schema:
 **Goal.** Type the body of structured Markdown
 documents beyond the heading sequence: nested
 sections with per-field content rules (word and
-character counts, forbidden text patterns,
-required patterns, skip rules), cross-reference
+character counts, forbidden / required text
+patterns, scoped skip rules), cross-reference
 validation, acronym tracking, and document-wide
-index generation. This closes the
+index generation. Closes the
 "structural body typing" gap noted in
 [query-and-types.md](query-and-types.md) §
-"Where each is genuinely silent".
+"What's missing in both".
 
-**Trigger.** A real project authors structured
-Markdown beyond docs and RFCs — presentation
-decks (slides plus speaker notes), training
-material (lessons plus exercises), structured
-runbooks (incidents plus steps plus
-verification), regulatory documents (clauses
-plus citations). Today every such project
-writes custom lint scripts. The trigger fires
-when two or more of these projects emerge and
-the constraint vocabulary repeats; that is when
-shipping a generic schema language pays.
+**Trigger.** Two or more projects in the same
+repo (or in adjacent repos a team maintains)
+author structured Markdown beyond docs and RFCs
+— runbooks, training material, presentation
+decks, regulatory documents, change-log
+manifests — and the constraint vocabulary
+starts to repeat across their custom lint
+scripts. That repeat is the signal: a generic
+schema language earns its keep when teams
+discover they want the same eight rules in
+three different places.
 
-**Sketch.** A schema language (the form is
-open — could be a richer YAML in `proto.md`
-front matter, a separate CUE-flavoured DSL, or
-an extension of the existing MDS020 schema)
-covering five capabilities current MDS020 does
-not address. The illustrative shape, sketched
-for a presentation-deck schema:
+**Sketch.** A schema describes a document's
+body the way MDS020 today describes a heading
+template, but reaches deeper. The form is
+genuinely open — the language could be richer
+YAML in `proto.md` front matter, extended CUE,
+or a small DSL designed for this. The shape
+below is an illustrative skeleton, not a
+finished design; it sketches what the schema
+language would need to express. The example is
+a runbook because runbooks are common,
+generic, and exercise every capability without
+a vocabulary tied to one domain.
 
 ```yaml
+# illustrative — not a final syntax
+
 sections:
-  - heading: "## Deck Parameters"
+  - heading: "## Overview"
     required: true
-  - heading: "## Horizontal Flow"
+
+  - heading: "## Symptoms"
     required: true
-    aliases: ["## Horizontal Flow (Title Sequence)"]
-  - heading: "## Section"
-    required: true
-    repeatable: true
-    pattern: "## Section \\d+:.*"
-  - heading: "## Backup Slides"
+    aliases: ["## Indicators"]
+
+  - heading: "## Diagnosis"
     required: true
     children:
-      pattern: "### B{n}:*"
-      sequential: false      # gaps allowed
+      pattern: "### Step {n}"
+      sequential: true               # no gaps; no duplicates
       fields:
-        - heading: "#### Extends"
+        - heading: "#### Check"
           required: true
-        - heading: "#### Pull condition"
+          max_words: 50
+        - heading: "#### Expected"
           required: true
-        - heading: "#### Speaker notes"
+        - heading: "#### If different"
           required: false
-          max_words: 300
+          required_patterns:
+            - pattern: "see Step \\d+"
+              error: "missing forward reference"
+              skip_indices: [-1]     # last step exempt
 
-# Slide definition (children of Section headings)
-slides:
-  pattern: "### Slide {n}"
-  sequential: true            # no gaps, no duplicates
-  fields:
-    - heading: "#### Action Title"
-      required: true
-      min_words: 3
-      max_words: 12
-      max_chars: 65
-      forbidden_starts: ["We ", "Our "]
-      forbidden_contains: [" and "]
-      skip_slides: [1]        # cover slide exempt
-    - heading: "#### Speaker notes"
-      required: true
-      max_words: 300
-      required_patterns:
-        - pattern: "TRANSITION:"
-          error: "Missing TRANSITION marker"
-          skip_slides: [-1]   # last slide exempt
+  - heading: "## Pass criteria"
+    required: true
+    fields:
+      - heading: "#### Indicator"
+        required: true
+        max_words: 30
+        forbidden_starts: ["We ", "The system "]
+        forbidden_contains: ["should", "may", "might"]
 
-# Cross-reference validation
+  - heading: "## References"
+    required: false
+
+# Cross-reference validation: "Step 4" mentions
+# must resolve to an actual "### Step 4" heading.
 cross_references:
-  - pattern: "Slide (\\d+)"
-    must_match: "### Slide {n}"
-    skip_lines_matching: "^> \\*\\*"  # skip version-history blockquotes
-  - pattern: "\\bB(\\d+)\\b"
-    must_match: "### B{n}"
+  - pattern: "\\bStep (\\d+)\\b"
+    must_match: "### Step {n}"
+    skip_lines_matching: "^> "       # skip blockquoted text
 
-# Acronym tracking — flag acronyms used before expansion
+# Flag acronyms before their first expansion;
+# allowlist covers infrastructure terms.
 acronym_tracking:
-  known_safe: [AI, IDE, PR, CI, CD, QA, URL, API, KPI]
-  scope: on_slide_content       # which h4 sections to check
+  known_safe: [API, HTTP, TLS, DNS, IAM, CDN, SLA, JSON]
+  scope: ["#### Check", "#### Expected"]
 
-# Cross-ref ban: "Slide N" refs that break leave-behind PDFs
-cross_ref_standalone:
-  ban_in: [On-slide content, Visual concept]
-  allow_in: [Speaker notes, Editorial notes]
-
-# Index output for downstream tooling
+# Generate a JSON side-output for downstream tooling.
 index:
-  output: ".narrative-index.json"
-  include: [slide_map, backup_map, cross_ref_graph, word_counts]
+  output: ".runbook-index.json"
+  include: [step_map, cross_ref_graph, word_counts]
 ```
 
-The five capabilities, each absent from MDS020
-today:
+The shape exercises five capabilities current
+MDS020 does not address:
 
-1. **Hierarchical body structure** — nested
-   sections with required/optional/repeatable
-   semantics, plus child patterns
-   (`### Slide {n}` with sequential / non-
-   sequential numbering).
-2. **Per-field content rules** — word and
-   character counts, forbidden / required text
-   patterns, regex-based pattern checks, scoped
-   skip rules (e.g. "cover slide is exempt
-   from the action-title length cap").
-3. **Cross-reference validation** — text like
-   "Slide 5" must resolve to an actual
-   `### Slide 5` heading; broken refs are
-   diagnostics. Skip rules let version-history
-   blockquotes carry stale refs without
-   firing.
-4. **Acronym tracking** — flag acronym uses
-   that appear before their expansion, with a
-   known-safe allowlist and a per-field scope.
-5. **Index generation** — produce a JSON index
-   of the document's structure (slide map,
-   backup map, cross-reference graph, word
-   counts per subsection) for downstream
-   tooling. Effectively a side-output of the
-   parse pass that already happens during lint.
+1. **Hierarchical body structure.** Nested
+   sections with required / optional /
+   repeatable semantics; child patterns
+   (`### Step {n}`) with sequential or
+   non-sequential numbering.
+2. **Per-field content rules.** Word counts,
+   character counts, forbidden starts and
+   contents, required text patterns, scoped
+   skip rules (e.g. "the last step is exempt
+   from the forward-reference requirement").
+3. **Cross-reference validation.** Text like
+   "Step 4" must resolve to a real
+   `### Step 4` heading; broken refs are
+   diagnostics. Skip rules let blockquoted
+   stale text pass through.
+4. **Acronym tracking.** First-use detection
+   with a known-safe allowlist and a
+   per-section scope.
+5. **Index generation.** A JSON side-output
+   of the parse pass — step map, cross-ref
+   graph, per-field word counts. Downstream
+   tooling consumes the index instead of
+   re-parsing the document.
 
 **Surface.** A new schema format alongside (or
-extending) the current `proto.md` schema body.
-Either an extension of MDS020 (richer schema
-language inside the existing rule) or a sister
-rule (MDS-something) that runs alongside.
-`mdsmith fix` regenerates the index file when
-the document changes; `mdsmith check` reports
-violations with file/line/column anchors.
+extending) the current `proto.md` body. Either
+an extension of MDS020 (richer schema language
+inside the existing rule) or a sister rule that
+runs alongside. `mdsmith fix` regenerates the
+index file when the document changes;
+`mdsmith check` reports violations with file /
+line / column anchors.
 
-**Effort.** L. This is the largest schema-side
+**Effort.** L. The largest schema-side
 candidate. The schema language needs careful
-design (CUE? YAML? hybrid?), the validator does
-real work (per-field rules, cross-reference
-resolution, acronym tracking are each their own
-small subsystem), and index generation adds an
-output surface.
+design; the validator does real work (per-field
+rules, cross-reference resolution, acronym
+tracking are each a small subsystem); index
+generation adds an output surface.
 
 **Depends on.** S-1 (inline schemas) as a
 stepping stone — the YAML form here is in
@@ -535,22 +527,20 @@ have to settle:
   a new DSL designed for this. Each has costs.
 - **Composition with MDS020.** Is this a richer
   MDS020 schema, or a sister rule that runs
-  alongside? Composition matters: a project
-  might want both heading-template constraints
-  (MDS020 today) and the richer body rules
-  (this proposal) on the same files.
+  alongside? A project might want both
+  heading-template constraints (MDS020 today)
+  and the richer body rules on the same files.
 - **Index output location and format.** JSON
   next to the source file, gitignored cache,
-  or somewhere else? What's the schema of the
-  index? mdbase's `effective_json` per-file
-  cache is one shape; a per-document
-  `.narrative-index.json` is another.
-- **Cross-reference scope.** "Slide 5" refs
-  must resolve, but version-history
-  blockquotes break this. The schema example
-  has `skip_lines_matching`; that's a
-  configurable escape hatch. Does it
-  generalize?
+  or somewhere else? mdbase's
+  `effective_json` per-file cache is one
+  shape; a per-document `.runbook-index.json`
+  is another.
+- **Cross-reference scope.** Refs must resolve,
+  but blockquoted text and version-history
+  notes break this. The schema example has
+  `skip_lines_matching`; that's a configurable
+  escape hatch. Does it generalize?
 - **Relationship to mdbase types.** mdbase
   types declare FM shape; this proposal
   declares body structure. They are
@@ -561,8 +551,8 @@ have to settle:
   body half?
 - **Performance.** Per-field word counts and
   cross-reference resolution scale with file
-  size. Most documents are small; runbooks and
-  decks fit. Books would not.
+  size. Runbooks, decks, training modules
+  fit; books would not.
 
 **Why this matters in the comparison.** mdbase's
 data-layer typing and mdsmith's heading-template

--- a/docs/research/mdbase-vs-mdsmith/query-and-types.md
+++ b/docs/research/mdbase-vs-mdsmith/query-and-types.md
@@ -261,7 +261,7 @@ constraint in the query must be satisfiable
 against the file's FM.
 
 ```bash
-mdsmith query 'status: "open" & priority: int & >=3' tasks/
+mdsmith query 'status: "open", priority: int & >=3' tasks/
 ```
 
 - **Lexically a CUE expression.** Comments,
@@ -349,7 +349,7 @@ limit: 20
 Take **"open tasks at priority 3 or above"**.
 
 ```bash
-mdsmith query 'status: "open" & priority: int & >=3'
+mdsmith query 'status: "open", priority: int & >=3'
 ```
 
 The mdsmith form says: the file's FM must

--- a/docs/research/mdbase-vs-mdsmith/query-and-types.md
+++ b/docs/research/mdbase-vs-mdsmith/query-and-types.md
@@ -26,74 +26,201 @@ Three questions guide the structure:
 3. Where do the two diverge in expressiveness,
    and where does each break down?
 
-## What gets typed
+## What gets typed (full enforcement surface)
 
-The short version: **mdbase types the front
-matter and the filename pattern; mdsmith schemas
-type the front matter and the body heading
-structure. Neither types the body content as a
-structured value.** Both treat `file.body` as a
-string for query purposes but neither has a
-"this paragraph must have these properties"
-type system.
+The honest answer requires looking at **all** the
+mechanisms each tool ships, not just the ones
+labelled "type system". mdbase has a single
+mechanism (the type system in `_types/`).
+mdsmith has two: MDS020 schemas (the closest
+direct analogue to mdbase types) **and** a
+broader rule set of 54 lint rules, many of which
+encode structural constraints on the document.
+Treating the rules as out-of-scope would
+underrate mdsmith's actual coverage.
 
-Concretely:
+So the framing here is: **what does each tool
+collectively enforce about a document?** The
+mechanism (typed schema vs lint rule) matters
+less than the shape of the enforcement.
 
-| Aspect typed                                    | mdbase                                          | mdsmith schemas (MDS020)             |
-|-------------------------------------------------|-------------------------------------------------|--------------------------------------|
-| Front matter field types                        | yes — 12 named field types (spec §7)            | yes — CUE expressions in schema FM   |
-| Field-level constraints (min, max, regex)       | yes (per-type knobs)                            | yes (full CUE)                       |
-| Required vs optional fields                     | yes (`required: true`)                          | yes (CUE `?` suffix or non-`?`)      |
-| Filename pattern                                | yes (`path_pattern: "tasks/{date}-{title}.md"`) | yes (`<?require?>` with `filename`)  |
-| Computed FM fields                              | yes (`computed:` block, expression-based)       | no (CUE is structural, not computed) |
-| Cross-field constraints                         | limited (per-type knobs)                        | yes (full CUE: `if a then b >= 0`)   |
-| Type assignment via FM presence                 | yes (`fields_present`, `where`)                 | no (kinds via explicit tag or glob)  |
-| Body heading structure                          | no — body is a `file.body` string               | yes — schema body carries template   |
-| Body content patterns (paragraphs, code blocks) | no                                              | no                                   |
-| Body cross-references                           | no (link graph is separate)                     | no (cross-file links are MDS027)     |
-| Sentence-level prose properties                 | no                                              | no (handled by separate rules)       |
-| Cross-file value coherence                      | yes (`unique_values` in Rust impl)              | no                                   |
+### Full enforcement matrix
 
-So the answer to "is mdbase's type system limited
-to front matter?" is **almost — but with two
-extensions worth naming**:
+Three columns per group: what mdbase types via
+its schema; what mdsmith's MDS020 schema types;
+what mdsmith's broader rule set enforces. Cells
+are evaluated as "the user can declare this
+constraint and have it enforced". Tables are
+split by category for readability.
+
+#### Front matter and type assignment
+
+| Aspect                         | mdbase types             | mdsmith MDS020 schema       | mdsmith broader rule set |
+|--------------------------------|--------------------------|-----------------------------|--------------------------|
+| FM field types                 | yes (12 named types, §7) | yes (CUE in schema FM)      | n/a                      |
+| FM field constraints           | per-type knobs           | full CUE                    | n/a                      |
+| FM required / optional         | `required: true`         | CUE `?` suffix              | n/a                      |
+| FM cross-field constraints     | limited                  | full CUE (`if/then`)        | n/a                      |
+| Computed FM fields             | yes (`computed:` block)  | no (CUE is structural)      | n/a                      |
+| Generated FM values            | yes (ULID, timestamps)   | n/a (mdsmith doesn't write) | n/a                      |
+| Type assignment by FM presence | yes (`fields_present`)   | no                          | no (kinds: globs / tags) |
+| Type assignment by FM where    | yes (`where:`)           | no                          | no                       |
+
+#### Filename, directory, headings
+
+| Aspect                    | mdbase types   | mdsmith MDS020 schema       | mdsmith broader rule set                  |
+|---------------------------|----------------|-----------------------------|-------------------------------------------|
+| Filename pattern          | `path_pattern` | `<?require?>` filename glob | MDS033 directory-structure                |
+| First-heading rule        | no             | template's first H1         | MDS004 first-line-heading                 |
+| Heading level increments  | no             | template implies it         | MDS003 heading-increment                  |
+| Heading uniqueness        | no             | no                          | MDS005 no-duplicate-headings              |
+| Single H1 per file        | no             | template's H1               | MDS051 single-h1                          |
+| Heading punctuation       | no             | no                          | MDS017 no-trailing-punctuation-in-heading |
+| Emphasis used as heading  | no             | no                          | MDS018 no-emphasis-as-heading             |
+| Required heading sequence | no             | yes (template body)         | n/a (this *is* MDS020)                    |
+
+#### Section and file caps; prose
+
+| Aspect                         | mdbase types | mdsmith MDS020 schema | mdsmith broader rule set                  |
+|--------------------------------|--------------|-----------------------|-------------------------------------------|
+| Section emptiness              | no           | no                    | MDS030 empty-section-body                 |
+| Section length cap             | no           | no                    | MDS036 max-section-length                 |
+| File length cap                | no           | no                    | MDS022 max-file-length                    |
+| Token budget (LLM context)     | no           | no                    | MDS028 token-budget                       |
+| Paragraph readability (ARI)    | no           | no                    | MDS023 paragraph-readability              |
+| Paragraph structure            | no           | no                    | MDS024 paragraph-structure                |
+| Conciseness                    | no           | no                    | MDS029 conciseness-scoring (experimental) |
+| Cross-file content duplication | no           | no                    | MDS037 duplicated-content                 |
+
+#### Tables, code, lists
+
+| Aspect                         | mdbase types | mdsmith MDS020 schema | mdsmith broader rule set             |
+|--------------------------------|--------------|-----------------------|--------------------------------------|
+| Table format                   | no           | no                    | MDS025 table-format                  |
+| Table readability              | no           | no                    | MDS026 table-readability             |
+| Fenced code style              | no           | no                    | MDS010 fenced-code-style             |
+| Fenced code language tag       | no           | no                    | MDS011 fenced-code-language          |
+| Blank lines around fenced code | no           | no                    | MDS015 blank-line-around-fenced-code |
+| Unclosed code block            | no           | no                    | MDS031 unclosed-code-block           |
+| Spaces in code spans           | no           | no                    | MDS052 no-space-in-code-spans        |
+| List marker style              | no           | no                    | MDS045 list-marker-style             |
+| Ordered list numbering         | no           | no                    | MDS046 ordered-list-numbering        |
+| List indent                    | no           | no                    | MDS016 list-indent                   |
+
+#### Links, references, cross-file
+
+| Aspect                      | mdbase types                       | mdsmith MDS020 schema | mdsmith broader rule set              |
+|-----------------------------|------------------------------------|-----------------------|---------------------------------------|
+| Bare URLs                   | no                                 | no                    | MDS012 no-bare-urls                   |
+| Cross-file link integrity   | yes (L4 + `validate_exists`)       | no                    | MDS027 cross-file-reference-integrity |
+| Cross-file rename safety    | yes (L5 rewrites refs)             | no                    | no (MDS027 detects, doesn't fix)      |
+| Wikilink resolution         | yes (L4 — `[[Page]]`)              | no                    | no (L-1 candidate)                    |
+| ID-based link resolution    | yes (`id_field` per spec)          | no                    | no (L-2 candidate)                    |
+| Cross-file value uniqueness | yes (`unique` per type, Rust impl) | no                    | no                                    |
+| Reference-style link policy | no                                 | no                    | MDS043 no-reference-style             |
+| Unused link reference defs  | no                                 | no                    | MDS053 no-unused-link-definitions     |
+| Undefined reference labels  | no                                 | no                    | MDS054 no-undefined-reference-labels  |
+| Spaces in link text         | no                                 | no                    | MDS049 no-space-in-link-text          |
+
+#### Style, formatting, generated content
+
+| Aspect                           | mdbase types | mdsmith MDS020 schema | mdsmith broader rule set      |
+|----------------------------------|--------------|-----------------------|-------------------------------|
+| Image alt text                   | no           | no                    | MDS032 no-empty-alt-text      |
+| Inline HTML policy               | no           | no                    | MDS041 no-inline-html         |
+| Emphasis style                   | no           | no                    | MDS042 emphasis-style         |
+| Horizontal rule style            | no           | no                    | MDS044 horizontal-rule-style  |
+| Ambiguous emphasis               | no           | no                    | MDS047 ambiguous-emphasis     |
+| Proper-name capitalization       | no           | no                    | MDS050 proper-names           |
+| Markdown flavor (CommonMark/GFM) | no           | no                    | MDS034 markdown-flavor        |
+| Trailing whitespace / tabs       | no           | no                    | MDS006–009 whitespace rules   |
+| Line length                      | no           | no                    | MDS001 line-length            |
+| Blank lines around blocks        | no           | no                    | MDS013–015                    |
+| Generated section drift          | no           | no                    | MDS019/021/038/039 directives |
+| Build recipe safety              | no           | no                    | MDS040 recipe-safety          |
+
+The table is one-sided in row count — that's
+the point. mdsmith's enforcement surface is
+**broad and shallow** (54 rules covering many
+document properties). mdbase's is **narrow and
+deep** (one type system, but it goes deep on
+field-level constraints, generated values,
+cross-file uniqueness, and link integrity).
+
+### So is mdbase's type system limited to FM?
+
+Yes, with two named extensions:
 
 1. **Filename `path_pattern`.** A type can
-   declare a path template like
-   `tasks/{date}-{title}.md`. Files claiming
-   that type are validated against it. The
-   pattern uses FM field values, so it ties FM
-   to filesystem layout. Not strictly "in" the
-   FM, but derived from it.
+   declare `path_pattern: "tasks/{date}-{title}.md"`,
+   tying FM field values to filesystem layout.
 2. **Cross-file `unique_values`.** The Rust
-   reference impl maintains a `unique_values`
-   table for ID uniqueness across the
-   collection. A type can declare `id` is
-   unique; the validator checks no two files
-   share the same ID. The constraint is
-   per-field, but it spans files.
+   reference impl maintains a per-collection
+   uniqueness table; types can declare `unique`
+   on an `id` field.
 
-Beyond those two, every typed assertion in
-mdbase reduces to a property of one file's front
-matter (or a derivation of it). The body is
-unstructured from the type system's perspective.
+Beyond those, every typed assertion in mdbase
+reduces to a property of one file's FM (or a
+derivation of it via computed fields, or a
+property of the link graph the FM declares).
+The body content is unstructured from the type
+system's perspective. `file.body` is queryable
+as a string but not typed.
 
-mdsmith goes one layer further: a schema's body
-*is* a heading template, and MDS020 enforces
-that the document's headings match. So mdsmith
-types both **the file-as-record** (FM, like
-mdbase) and **the file-as-document** (heading
-skeleton, unlike mdbase). This is a real
-distinction in what the schema authors are
-allowed to assert.
+### So what about mdsmith's "type system"?
 
-Neither tool types body content beyond
-structure. Whether a paragraph is well-formed
-prose, whether a code block has the right
-language tag, whether a list contains a TODO —
-these live in mdsmith's *separate rule set* (not
-its schemas), and in mdbase they live nowhere
-(out of scope for the data layer).
+mdsmith does not have one type system; it has
+**MDS020 schemas plus a 54-rule constraint
+library**. Two distinct surfaces:
+
+1. **MDS020 schema** (`proto.md` per kind):
+   types FM via CUE expressions; types body
+   heading structure via the template; types
+   filename via `<?require?>`.
+2. **The broader rule set**: imposes structural
+   constraints on headings (level increments,
+   uniqueness, single-H1), paragraphs
+   (readability, structure, conciseness), code
+   blocks, tables, links, lists, file length,
+   token budget, directory layout, prose
+   style, and more — all without a per-file
+   schema declaration. Rules apply by default
+   or per-kind override.
+
+The two surfaces compose. A schema can declare
+"this file's FM has fields X and Y, and its body
+has these headings"; the surrounding rule set
+adds "and the prose is readable, the tables fit,
+the headings increment, no link is broken".
+
+This is a real architectural difference: mdbase
+puts everything in the type, mdsmith splits
+between per-kind schemas and per-rule
+enforcement. Either approach can express most
+constraints; the language for declaring them
+differs. mdbase's vocabulary is "type fields";
+mdsmith's is "rules with settings".
+
+### Where each is genuinely silent
+
+Both tools share a few gaps:
+
+- **Body content patterns beyond headings.** Whether
+  paragraph N is a definition, whether a list
+  contains a TODO, whether a code block is
+  Python — neither tool ships a way to declare
+  this.
+- **Schema-aware query validation.** A typo in
+  a field name returns no results rather than
+  "no such field in type X" at parse time.
+- **Cross-tool schema portability.** mdsmith
+  CUE and mdbase DSL describe overlapping
+  shapes; nothing translates between them.
+
+mdsmith's experimental MDS029
+(conciseness-scoring) is a step toward
+content-quality typing but is opt-in and
+classifier-based rather than declarative.
 
 ## How the type definitions look
 
@@ -198,7 +325,7 @@ directly.
 | Computed at read time             | `computed: { expr: ... }`                 | not directly (CUE is structural)                |
 | Filename template                 | `path_pattern: "tasks/{date}-{title}.md"` | `<?require?>` with regex / glob                 |
 | Body heading template             | not in scope                              | schema body                                     |
-| Schema composition                | `extends: base`                           | CUE imports + `<?include?>` in schema body      |
+| Schema composition                | `extends: base`                           | `<?include?>` in schema body (no CUE imports)   |
 | Inheritance overrides             | child fields fully replace parent's       | CUE unification (intersection)                  |
 
 CUE wins on cross-field constraints, structural
@@ -278,10 +405,13 @@ mdsmith query 'status: "open", priority: int & >=3' tasks/
   field that is supposed to be an int is
   matched against an int constraint and fails
   cleanly if the FM has the wrong type.
-- **Composable via CUE imports.** A query can
-  import a definition from a `.cue` file and
-  reference it (`import "x.com/types"`,
-  `task.#OpenHigh`). Rarely used today.
+- **Not composable across files today.** The
+  CLI argument is wrapped in `{...}` and
+  compiled as an expression body
+  (`internal/query/query.go`), so CUE
+  `import "..."` and `package` declarations are
+  not accepted at this surface. Reuse happens at
+  the shell level — variables, scripts.
 - **Limited to filtering.** No sort, limit,
   body access, traversal, or aggregation. The
   command emits matching paths to stdout.
@@ -328,21 +458,21 @@ limit: 20
 
 ### Side by side as languages
 
-| Concern                   | mdsmith CUE                        | mdbase Bases DSL                       |
-|---------------------------|------------------------------------|----------------------------------------|
-| Surface form              | one expression (struct literal)    | YAML doc + expression strings          |
-| Filtering                 | unification (constraint match)     | boolean expression eval                |
-| Sort                      | no                                 | `order_by` clause                      |
-| Pagination                | no                                 | `limit` / `offset`                     |
-| Body access               | no (FM only)                       | `file.body.contains/.matches`          |
-| Cross-file traversal      | no                                 | `link.asFile().property` (depth ≤ 10)  |
-| Aggregation               | no                                 | `group_by` + `aggregate` + `formulas`  |
-| Date arithmetic           | bounds via CUE `>=`/`<=` on string | duration strings (`+ "7d"`)            |
-| Type checking of query    | structural unification             | runtime evaluation; type_error per row |
-| Composition / imports     | CUE imports                        | none beyond YAML structure             |
-| Reusable named queries    | yes (CUE definitions)              | not in the spec                        |
-| Error on bad query syntax | parse error before execution       | parse error before execution           |
-| Error on type mismatch    | unification failure                | per-row null + type_error diagnostic   |
+| Concern                   | mdsmith CUE                                   | mdbase Bases DSL                       |
+|---------------------------|-----------------------------------------------|----------------------------------------|
+| Surface form              | one expression (struct literal)               | YAML doc + expression strings          |
+| Filtering                 | unification (constraint match)                | boolean expression eval                |
+| Sort                      | no                                            | `order_by` clause                      |
+| Pagination                | no                                            | `limit` / `offset`                     |
+| Body access               | no (FM only)                                  | `file.body.contains/.matches`          |
+| Cross-file traversal      | no                                            | `link.asFile().property` (depth ≤ 10)  |
+| Aggregation               | no                                            | `group_by` + `aggregate` + `formulas`  |
+| Date arithmetic           | bounds via CUE `>=`/`<=` on string            | duration strings (`+ "7d"`)            |
+| Type checking of query    | structural unification                        | runtime evaluation; type_error per row |
+| Composition / imports     | none at the CLI surface (no `import` allowed) | none beyond YAML structure             |
+| Reusable named queries    | shell-level only (variables, scripts)         | not in the spec                        |
+| Error on bad query syntax | parse error before execution                  | parse error before execution           |
+| Error on type mismatch    | unification failure                           | per-row null + type_error diagnostic   |
 
 ### Two ways to read the same query
 
@@ -445,43 +575,56 @@ fields:
 ---
 ```
 
-**mdsmith: CUE imports + schema include.** A
-schema can `<?include?>` another schema's body
-fragments to share heading templates. The CUE
-in the schema's FM can import shared
-definitions:
+**mdsmith: schema body include + per-field CUE.**
+mdsmith schemas don't compose via CUE imports.
+The schema's FM is parsed as YAML and converted
+into a closed CUE struct (`deriveFrontMatterCUE`
+in the MDS020 implementation), so each field's
+constraint is the YAML value (a CUE expression
+encoded as a string). There's no `import "..."`
+in the schema's FM.
 
-```cue
-// internal/concepts/base.cue
-package concepts
+What does compose:
 
-#Base: {
-    id: =~"^[A-Z]+-[0-9]+$"
-    created: =~"^\\d{4}-\\d{2}-\\d{2}"
-}
+- **Body templates via `<?include?>`.** A
+  schema's body can splice in fragments from
+  other schema bodies, sharing heading
+  templates across kinds.
+- **Field-level CUE expressions.** Each field's
+  constraint is a CUE string; constraints can
+  reference CUE built-ins (`strings.MinRunes`,
+  regex `=~`, disjunctions `|`, etc.) inline.
+  Reuse across schemas means copy-pasting the
+  expression string today.
+
+```markdown
+<!-- common/base-template.md (a schema-body fragment) -->
+# {title}
+
+## Description
+
+## Status notes
 ```
 
 ```markdown
 <!-- tasks/proto.md -->
 ---
-import "github.com/jeduden/mdsmith/concepts"
-concepts.#Base
+id: '=~"^[A-Z]+-[0-9]+$"'
+created: '=~"^\\d{4}-\\d{2}-\\d{2}"'
 status: '"open" | "done"'
 ---
 <?include
 file: ../common/base-template.md
 ?>
-
-# {title}
-
-## Status notes
 ```
 
-CUE's unification means the imported
-constraints intersect with the child's
-constraints — closer to mdbase's "extends"
-semantics, but more powerful (the child can
-strengthen, not just override).
+The `<?include?>` is structural composition;
+the FM constraints are independent per-field
+CUE strings. A future plan could add CUE
+imports to schemas (S-3 in
+[learn-from-mdbase.md](learn-from-mdbase.md)
+sketches the inheritance angle), but it is
+not in mdsmith today.
 
 ### Query composition
 

--- a/docs/research/mdbase-vs-mdsmith/query-and-types.md
+++ b/docs/research/mdbase-vs-mdsmith/query-and-types.md
@@ -1,0 +1,567 @@
+---
+summary: >-
+  Deep dive into the query languages and type systems of mdsmith and mdbase
+  — what each tool actually types, how schemas and queries compose, where
+  the languages diverge in expressiveness, and the answer to whether
+  mdbase's type system is limited to front matter.
+---
+# Query languages and type systems
+
+This doc goes deeper than the catalog tables in
+[features.md §5](features.md) (type system) and
+[§8](features.md) (query language). The summary
+there names the surfaces; this doc walks the
+shape of each, side by side, with concrete
+examples of what the languages can and cannot
+express.
+
+Three questions guide the structure:
+
+1. What does each tool's type system actually
+   type? (Front matter? Body? Filenames?
+   Computed values?)
+2. What do the query languages look like as
+   languages — syntax, semantics, composition,
+   error handling?
+3. Where do the two diverge in expressiveness,
+   and where does each break down?
+
+## What gets typed
+
+The short version: **mdbase types the front
+matter and the filename pattern; mdsmith schemas
+type the front matter and the body heading
+structure. Neither types the body content as a
+structured value.** Both treat `file.body` as a
+string for query purposes but neither has a
+"this paragraph must have these properties"
+type system.
+
+Concretely:
+
+| Aspect typed                                    | mdbase                                          | mdsmith schemas (MDS020)             |
+|-------------------------------------------------|-------------------------------------------------|--------------------------------------|
+| Front matter field types                        | yes — 12 named field types (spec §7)            | yes — CUE expressions in schema FM   |
+| Field-level constraints (min, max, regex)       | yes (per-type knobs)                            | yes (full CUE)                       |
+| Required vs optional fields                     | yes (`required: true`)                          | yes (CUE `?` suffix or non-`?`)      |
+| Filename pattern                                | yes (`path_pattern: "tasks/{date}-{title}.md"`) | yes (`<?require?>` with `filename`)  |
+| Computed FM fields                              | yes (`computed:` block, expression-based)       | no (CUE is structural, not computed) |
+| Cross-field constraints                         | limited (per-type knobs)                        | yes (full CUE: `if a then b >= 0`)   |
+| Type assignment via FM presence                 | yes (`fields_present`, `where`)                 | no (kinds via explicit tag or glob)  |
+| Body heading structure                          | no — body is a `file.body` string               | yes — schema body carries template   |
+| Body content patterns (paragraphs, code blocks) | no                                              | no                                   |
+| Body cross-references                           | no (link graph is separate)                     | no (cross-file links are MDS027)     |
+| Sentence-level prose properties                 | no                                              | no (handled by separate rules)       |
+| Cross-file value coherence                      | yes (`unique_values` in Rust impl)              | no                                   |
+
+So the answer to "is mdbase's type system limited
+to front matter?" is **almost — but with two
+extensions worth naming**:
+
+1. **Filename `path_pattern`.** A type can
+   declare a path template like
+   `tasks/{date}-{title}.md`. Files claiming
+   that type are validated against it. The
+   pattern uses FM field values, so it ties FM
+   to filesystem layout. Not strictly "in" the
+   FM, but derived from it.
+2. **Cross-file `unique_values`.** The Rust
+   reference impl maintains a `unique_values`
+   table for ID uniqueness across the
+   collection. A type can declare `id` is
+   unique; the validator checks no two files
+   share the same ID. The constraint is
+   per-field, but it spans files.
+
+Beyond those two, every typed assertion in
+mdbase reduces to a property of one file's front
+matter (or a derivation of it). The body is
+unstructured from the type system's perspective.
+
+mdsmith goes one layer further: a schema's body
+*is* a heading template, and MDS020 enforces
+that the document's headings match. So mdsmith
+types both **the file-as-record** (FM, like
+mdbase) and **the file-as-document** (heading
+skeleton, unlike mdbase). This is a real
+distinction in what the schema authors are
+allowed to assert.
+
+Neither tool types body content beyond
+structure. Whether a paragraph is well-formed
+prose, whether a code block has the right
+language tag, whether a list contains a TODO —
+these live in mdsmith's *separate rule set* (not
+its schemas), and in mdbase they live nowhere
+(out of scope for the data layer).
+
+## How the type definitions look
+
+A worked example: a `task` type with five fields
+(`id`, `title`, `status`, `priority`,
+`assignee`), filename pattern, and the
+constraint that `priority` is between 1 and 5.
+
+### mdbase: `_types/task.md`
+
+```markdown
+---
+name: task
+extends: base
+strict: warn
+path_pattern: tasks/{date}-{title}.md
+fields:
+  id:
+    type: string
+    pattern: "^TASK-[0-9]{4}$"
+    required: true
+    unique: true
+    generated: ulid
+  title:
+    type: string
+    required: true
+    min_length: 5
+  status:
+    type: enum
+    values: [open, in-progress, done]
+    required: true
+    default: open
+  priority:
+    type: integer
+    min: 1
+    max: 5
+    default: 3
+  assignee:
+    type: link
+    target: person
+    validate_exists: true
+computed:
+  days_overdue:
+    type: integer
+    expr: (today() - due) / 86400000
+---
+# Task
+
+A unit of work with a status, priority, and
+assignee.
+```
+
+The type's *schema* is the front matter; the
+body is human-facing documentation. Computed
+fields (`days_overdue`) live in a dedicated
+block and are evaluated at read time.
+
+### mdsmith: `tasks/proto.md`
+
+```markdown
+---
+id: '=~"^TASK-[0-9]{4}$"'
+title: 'string & strings.MinRunes(5)'
+status: '"open" | "in-progress" | "done"'
+priority: 'int & >=1 & <=5'
+assignee: 'string'
+"due?": 'string & =~"^\\d{4}-\\d{2}-\\d{2}$"'
+---
+<?require
+filename: "TASK-[0-9]+.md"
+?>
+
+# {title}
+
+## Description
+
+## Acceptance criteria
+
+## Status notes
+```
+
+The type's *FM constraints* are CUE expressions
+in the schema's front matter. The type's
+*structure constraints* are the heading template
+in the schema's body. The `<?require?>` PI
+declares filename rules. CUE handles regex,
+disjunctions, ranges, and optional fields
+directly.
+
+### What each can and cannot express
+
+| Constraint                        | mdbase DSL                                | mdsmith CUE                                     |
+|-----------------------------------|-------------------------------------------|-------------------------------------------------|
+| Regex on string                   | `pattern: "^TASK-[0-9]{4}$"`              | `=~"^TASK-[0-9]{4}$"`                           |
+| Numeric range                     | `min: 1, max: 5`                          | `int & >=1 & <=5`                               |
+| Enum                              | `values: [open, …]`                       | `"open" \| "in-progress" \| "done"`             |
+| Optional field                    | omit `required: true`                     | append `?` to the key (`"due?"`)                |
+| Default value                     | `default: open`                           | not directly; CUE has `*"open" \| string`       |
+| Generated value (ULID, timestamp) | `generated: ulid`                         | not in the schema (mdsmith doesn't write FM)    |
+| Unique across collection          | `unique: true`                            | not directly                                    |
+| Cross-field implication           | not in DSL                                | `if status == "done" then completed_at != null` |
+| Computed at read time             | `computed: { expr: ... }`                 | not directly (CUE is structural)                |
+| Filename template                 | `path_pattern: "tasks/{date}-{title}.md"` | `<?require?>` with regex / glob                 |
+| Body heading template             | not in scope                              | schema body                                     |
+| Schema composition                | `extends: base`                           | CUE imports + `<?include?>` in schema body      |
+| Inheritance overrides             | child fields fully replace parent's       | CUE unification (intersection)                  |
+
+CUE wins on cross-field constraints, structural
+inheritance, and rich pattern composition.
+mdbase wins on default values, generated values
+(ULID, timestamps), and computed fields. Most of
+the gap on each side is closable in principle —
+mdsmith could grow defaults and generated
+fields (S-5, S-6 in
+[learn-from-mdbase.md](learn-from-mdbase.md));
+mdbase's spec §11 expression language could
+grow to express more cross-field constraints.
+
+## When types fire
+
+Type checking happens at three different moments
+across the two tools, with implications for how
+errors surface.
+
+| Moment                      | mdbase                                            | mdsmith                                        |
+|-----------------------------|---------------------------------------------------|------------------------------------------------|
+| File creation (`create`)    | yes — validates before persisting                 | n/a (mdsmith doesn't author files)             |
+| File update (CRUD `update`) | yes — validates merged result                     | n/a                                            |
+| Lint pass (`mdsmith check`) | n/a (mdbase doesn't lint)                         | yes — MDS020 validates against schema          |
+| Query against a typed field | yes — type errors return null + emit `type_error` | indirectly (CUE unification fails on mismatch) |
+| Editor save (LSP)           | mdbase-lsp surfaces validation errors             | mdsmith LSP surfaces MDS020 diagnostics        |
+| Migration / backfill        | yes (L6 migration manifests apply transforms)     | n/a                                            |
+
+The asymmetry is that **mdbase types fire on
+write**; **mdsmith schemas fire on lint**. The
+mdbase model gives earlier feedback (the file
+is rejected before bad FM ever lands on disk).
+The mdsmith model is less invasive (any text
+editor can write whatever; the lint pass tells
+you later) but blocks at PR time via CI.
+
+For an agent loop the difference matters: an
+agent writing files via `mdbase create` learns
+of type errors at the moment of creation. An
+agent writing files via raw editor + `mdsmith
+check` learns at the next lint pass. Neither
+strictly better; the agent design picks the
+trade-off.
+
+## Query languages, side by side
+
+The features.md catalog lists operators and
+methods. This section walks **what kind of
+language each is** and where the practical
+limits sit.
+
+### mdsmith query: CUE struct literal
+
+`mdsmith query EXPR FILES` accepts a CUE struct
+literal. The engine wraps it in `{...}` and
+unifies it against each file's effective front
+matter. Unification succeeds when the file's
+data is a *subtype* of the query — every
+constraint in the query must be satisfiable
+against the file's FM.
+
+```bash
+mdsmith query 'status: "open" & priority: int & >=3' tasks/
+```
+
+- **Lexically a CUE expression.** Comments,
+  imports, definitions all available (rarely
+  used in practice; queries are usually
+  one-line struct literals).
+- **Semantically a constraint, not a script.**
+  No iteration, no aggregation, no `for`. The
+  result is "every file whose FM passes the
+  constraint" — a set membership test, not a
+  computation.
+- **Type-aware.** Constraints like `int`,
+  `string`, `[…]` operate on CUE types, so a
+  field that is supposed to be an int is
+  matched against an int constraint and fails
+  cleanly if the FM has the wrong type.
+- **Composable via CUE imports.** A query can
+  import a definition from a `.cue` file and
+  reference it (`import "x.com/types"`,
+  `task.#OpenHigh`). Rarely used today.
+- **Limited to filtering.** No sort, limit,
+  body access, traversal, or aggregation. The
+  command emits matching paths to stdout.
+
+### mdbase query: Bases-compatible expression
+
+`mdbase query` takes a query *document* (YAML
+struct with `types`, `where`, `order_by`, etc.).
+The `where` value is a string expression in the
+DSL described in spec §11.
+
+```yaml
+types: [task]
+where: status == "open" && priority >= 3
+order_by:
+  - field: due
+    direction: asc
+limit: 20
+```
+
+- **Lexically a small expression DSL.**
+  Operators (`==`, `<`, `&&`), method calls
+  (`.contains`, `.matches`), function calls
+  (`today()`, `if(...)`).
+- **Semantically an evaluation.** The expression
+  is evaluated *for each file* against its
+  effective FM (and link graph, body string,
+  computed fields). Evaluation produces a
+  boolean for `where`, a value for `order_by`,
+  a count for aggregations.
+- **Type-flexible.** Type errors on individual
+  values return null and emit a `type_error`
+  diagnostic but do not abort the query
+  (spec §11). Compare to CUE which fails the
+  unification entirely.
+- **Composable via the surrounding YAML.**
+  `types`, `folder`, `where`, `order_by`,
+  `limit`, `offset`, `group_by`, `aggregate`,
+  `formulas`, `summaries`, `top_per_group`.
+- **Covers more than filtering.** Sort,
+  pagination, body search, cross-file
+  traversal, aggregation, formulas — all
+  inside the DSL.
+
+### Side by side as languages
+
+| Concern                   | mdsmith CUE                        | mdbase Bases DSL                       |
+|---------------------------|------------------------------------|----------------------------------------|
+| Surface form              | one expression (struct literal)    | YAML doc + expression strings          |
+| Filtering                 | unification (constraint match)     | boolean expression eval                |
+| Sort                      | no                                 | `order_by` clause                      |
+| Pagination                | no                                 | `limit` / `offset`                     |
+| Body access               | no (FM only)                       | `file.body.contains/.matches`          |
+| Cross-file traversal      | no                                 | `link.asFile().property` (depth ≤ 10)  |
+| Aggregation               | no                                 | `group_by` + `aggregate` + `formulas`  |
+| Date arithmetic           | bounds via CUE `>=`/`<=` on string | duration strings (`+ "7d"`)            |
+| Type checking of query    | structural unification             | runtime evaluation; type_error per row |
+| Composition / imports     | CUE imports                        | none beyond YAML structure             |
+| Reusable named queries    | yes (CUE definitions)              | not in the spec                        |
+| Error on bad query syntax | parse error before execution       | parse error before execution           |
+| Error on type mismatch    | unification failure                | per-row null + type_error diagnostic   |
+
+### Two ways to read the same query
+
+Take **"open tasks at priority 3 or above"**.
+
+```bash
+mdsmith query 'status: "open" & priority: int & >=3'
+```
+
+The mdsmith form says: the file's FM must
+unify with the struct
+`{status: "open", priority: int & >=3}`. This
+is a **constraint match**: any file whose FM
+already has `status` and `priority` with those
+properties is in the result.
+
+```yaml
+where: status == "open" && priority >= 3
+```
+
+The mdbase form says: for each file, evaluate
+this boolean expression in a context where
+`status` and `priority` are the file's FM
+values. Files where the expression is true are
+in the result. This is **expression
+evaluation**.
+
+Both reach the same set of files for this
+query. The languages differ in what they
+encourage: CUE encourages thinking about FM as
+a typed shape; Bases encourages thinking about
+FM as named values you compute over.
+
+## Type-aware queries
+
+A subtle point: do the queries actually know the
+schema of the data they're filtering?
+
+**mdsmith CUE query.** Yes, structurally.
+`priority: int & >=3` enforces that the FM's
+`priority` is an int (or the query fails to
+match). But the query does *not* consult the
+mdsmith schema — it doesn't know there's a
+schema declaring `priority: int & >=1 & <=5`.
+You can write `priority: int & >=99` and run
+it; no schema-level validation happens, you
+just get an empty result.
+
+**mdbase query.** Per spec §11 the query
+consults the type system insofar as it knows
+field types (so `priority >= 3` errors with
+`type_error` if a file has `priority: "high"`).
+But "consults the schema" in the strong sense —
+"refuse to compile a query that references a
+field the schema doesn't declare" — isn't part
+of the spec. The TS impl doesn't do this; the
+Rust impl reads `effective_json` (FM with
+defaults) but evaluates the expression
+generically.
+
+**What's missing in both.** Neither tool
+does **schema-aware query validation**: a query
+that references `prirority` (typo) just returns
+no results, rather than reporting "no such
+field in type `task`". This is a small but
+real gap; closing it would surface query bugs
+earlier. mdbase's schema is rich enough to
+support it; mdsmith CUE could grow it via
+schema imports.
+
+## Composition
+
+How types and queries compose differs sharply.
+
+### Type composition
+
+**mdbase: `extends`.** A type can extend
+another. Child fields fully replace parent
+fields with the same name. Single inheritance,
+no diamond. Worked example: `task` extends
+`base`, inheriting `id`, `created_at`,
+`modified_at`.
+
+```yaml
+# _types/base.md
+---
+name: base
+fields:
+  id: { type: string, required: true, unique: true }
+  created_at: { type: datetime, generated: now_on_create }
+  modified_at: { type: datetime, generated: now_on_write }
+---
+
+# _types/task.md
+---
+name: task
+extends: base
+fields:
+  status: { type: enum, values: [open, done] }
+---
+```
+
+**mdsmith: CUE imports + schema include.** A
+schema can `<?include?>` another schema's body
+fragments to share heading templates. The CUE
+in the schema's FM can import shared
+definitions:
+
+```cue
+// internal/concepts/base.cue
+package concepts
+
+#Base: {
+    id: =~"^[A-Z]+-[0-9]+$"
+    created: =~"^\\d{4}-\\d{2}-\\d{2}"
+}
+```
+
+```markdown
+<!-- tasks/proto.md -->
+---
+import "github.com/jeduden/mdsmith/concepts"
+concepts.#Base
+status: '"open" | "done"'
+---
+<?include
+file: ../common/base-template.md
+?>
+
+# {title}
+
+## Status notes
+```
+
+CUE's unification means the imported
+constraints intersect with the child's
+constraints — closer to mdbase's "extends"
+semantics, but more powerful (the child can
+strengthen, not just override).
+
+### Query composition
+
+Neither tool ships a "named, reusable query"
+abstraction. mdbase queries are documents;
+mdsmith queries are command-line strings. Both
+projects could grow query libraries; neither
+has prioritized it.
+
+## Migration between syntaxes
+
+For a team running both tools (the
+[interop.md](interop.md) territory), it's worth
+knowing which queries translate between
+syntaxes and which don't.
+
+| mdbase Bases query                   | Equivalent mdsmith CUE                                | Notes                                             |
+|--------------------------------------|-------------------------------------------------------|---------------------------------------------------|
+| `status == "open"`                   | `status: "open"`                                      | trivial                                           |
+| `priority >= 3`                      | `priority: int & >=3`                                 | trivial                                           |
+| `tags.contains("urgent")`            | `tags: [..., "urgent", ...]`                          | CUE syntax for list-contains is awkward but works |
+| `status == "open" && priority >= 3`  | `status: "open", priority: int & >=3`                 | trivial                                           |
+| `due <= today() + "7d"`              | external date substitution                            | Q-4 in learn-from-mdbase.md                       |
+| `assignee.asFile().role == "senior"` | not expressible                                       | L-5 in learn-from-mdbase.md                       |
+| `file.body.contains("OIDC")`         | not in `query`; needs native `--body-contains`        | Q-3 in learn-from-mdbase.md                       |
+| `group_by: status, aggregate: count` | not in `query`; needs native group / aggregate        | Q-5 in learn-from-mdbase.md                       |
+| `order_by: due, limit: 20`           | not in `query`; needs native `--order-by` / `--limit` | Q-1 / Q-2 in learn-from-mdbase.md                 |
+
+The takeaway: **mdsmith CUE handles the filter
+core well; mdbase handles everything else.** A
+schema-aware bridge that translates the common
+filter forms in both directions is feasible
+(see interop.md §7 schema bridge sketch); a
+bridge that handles aggregation and traversal
+would need to compile to native operations on
+both sides.
+
+## What's missing in both
+
+Looking across the two systems, three
+capabilities are absent everywhere and would
+benefit either side.
+
+1. **Structural body typing.** Neither tool
+   types "body must have an H1, then 2+ H2s,
+   each followed by a paragraph". mdsmith
+   schemas come closest with the heading
+   template, but they don't reach inside
+   sections (no "first paragraph must mention
+   the project name"). For doc consistency
+   this is genuinely useful and not yet
+   covered.
+2. **Schema-aware query validation.** A typo
+   in a field name silently returns no
+   results. Either tool's schema layer is rich
+   enough to power "no such field" errors at
+   query parse time, but neither does it.
+3. **Cross-implementation schema portability.**
+   mdsmith CUE and mdbase DSL describe
+   overlapping shapes; nothing converts
+   between them automatically.
+   [interop.md §7](interop.md) sketches a
+   bridge that doesn't exist yet.
+
+The first two are clear candidates for either
+project. The third is a coordination problem
+that needs cross-tool buy-in.
+
+## Sources
+
+- mdbase spec §5 (types), §6 (matching),
+  §7 (field types), §10 (querying), §11
+  (expressions): <https://github.com/callumalpass/mdbase-spec>
+- TS reference impl source:
+  <https://github.com/callumalpass/mdbase>
+- Rust reference impl source:
+  <https://github.com/callumalpass/mdbase-rs>
+- mdsmith MDS020 README:
+  `internal/rules/MDS020-required-structure/README.md`
+- mdsmith query implementation:
+  `internal/query/query.go`
+- CUE language reference:
+  <https://cuelang.org/docs/references/>

--- a/docs/research/mdbase-vs-mdsmith/query-and-types.md
+++ b/docs/research/mdbase-vs-mdsmith/query-and-types.md
@@ -55,16 +55,17 @@ split by category for readability.
 
 #### Front matter and type assignment
 
-| Aspect                         | mdbase types             | mdsmith MDS020 schema       | mdsmith broader rule set |
-|--------------------------------|--------------------------|-----------------------------|--------------------------|
-| FM field types                 | yes (12 named types, §7) | yes (CUE in schema FM)      | n/a                      |
-| FM field constraints           | per-type knobs           | full CUE                    | n/a                      |
-| FM required / optional         | `required: true`         | CUE `?` suffix              | n/a                      |
-| FM cross-field constraints     | limited                  | full CUE (`if/then`)        | n/a                      |
-| Computed FM fields             | yes (`computed:` block)  | no (CUE is structural)      | n/a                      |
-| Generated FM values            | yes (ULID, timestamps)   | n/a (mdsmith doesn't write) | n/a                      |
-| Type assignment by FM presence | yes (`fields_present`)   | no                          | no (kinds: globs / tags) |
-| Type assignment by FM where    | yes (`where:`)           | no                          | no                       |
+| Aspect                           | mdbase types             | mdsmith MDS020 schema          | mdsmith broader rule set                            |
+|----------------------------------|--------------------------|--------------------------------|-----------------------------------------------------|
+| FM field types                   | yes (12 named types, §7) | yes (CUE in schema FM)         | n/a                                                 |
+| FM field constraints             | per-type knobs           | full CUE                       | n/a                                                 |
+| FM required / optional           | `required: true`         | CUE `?` suffix                 | n/a                                                 |
+| FM cross-field constraints       | limited                  | full CUE (`if/then`)           | n/a                                                 |
+| Computed FM fields               | yes (`computed:` block)  | no (CUE is structural)         | n/a                                                 |
+| Generated FM values              | yes (ULID, timestamps)   | n/a (mdsmith doesn't write)    | n/a                                                 |
+| Type assignment by FM presence   | yes (`fields_present`)   | no                             | no (kinds: globs / tags)                            |
+| Type assignment by FM where      | yes (`where:`)           | no                             | no                                                  |
+| FM ↔ body sync (e.g. title ↔ H1) | no                       | yes (placeholders in template) | yes (catalog/include/build directives drift-detect) |
 
 #### Filename, directory, headings
 
@@ -221,6 +222,123 @@ mdsmith's experimental MDS029
 (conciseness-scoring) is a step toward
 content-quality typing but is opt-in and
 classifier-based rather than declarative.
+
+## Front matter and body — keeping them in sync
+
+Front matter and body are structurally disjoint
+pieces of a Markdown file. The YAML at the top
+parses to one tree, the Markdown below to another;
+nothing in standard Markdown makes them
+co-vary. A file with `title: Migration Plan` and
+a body H1 reading `# Outline` is syntactically
+fine — but obviously incoherent. What does each
+tool offer to **enforce coherence between front
+matter and body**?
+
+This is a place mdsmith is materially stronger
+than mdbase, and it falls out of the broader
+rule-set/directive split:
+
+### mdsmith mechanisms for FM↔body sync
+
+Five mechanisms tie FM to body content, all
+schema-style or directive-driven:
+
+| Mechanism                     | What it ties                                                                                                                   | Rule                        |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| Heading template placeholders | `# {title}` in schema body → body H1 must match FM `title`                                                                     | MDS020 (required-structure) |
+| Catalog directive             | `<?catalog?>` table cells reference FM fields like `{summary}`, `{filename}` of matched files                                  | MDS019 (catalog)            |
+| Include directive variables   | `<?include?>` body can substitute FM fields from the host file                                                                 | MDS021 (include)            |
+| Build directive params        | `<?build?>` recipe params can come from FM                                                                                     | MDS039 (build)              |
+| TOC directive                 | `<?toc?>` derives body section list from body headings (not from FM, but keeps a body-derived index in sync with body content) | MDS038 (toc)                |
+
+The first four detect drift: edit the FM, the
+body table or heading is now stale; `mdsmith fix`
+regenerates it. The fifth tracks body-internal
+sync (heading list ↔ TOC).
+
+Concretely, an MDS020 schema body of the form
+
+```markdown
+---
+title: 'string'
+---
+# {title}
+
+## Description
+```
+
+requires that any document tagged with this kind
+has a body H1 matching its FM `title` exactly
+(after placeholder substitution). Change the FM
+title without touching the body, and the lint
+fires on the next run.
+
+### mdbase mechanisms for FM↔body sync
+
+mdbase has one mechanism, and it ties FM to the
+**filesystem**, not the body:
+
+| Mechanism      | What it ties                      | Where   |
+|----------------|-----------------------------------|---------|
+| `path_pattern` | FM field values → filename / path | spec §5 |
+
+A type like `tasks/{date}-{title}.md` enforces
+that an FM `date: 2026-05-04, title: oidc` file
+lives at `tasks/2026-05-04-oidc.md`. Useful, but
+about filesystem layout.
+
+For the body itself, mdbase offers nothing.
+`file.body` is queryable as a string; queries
+can compare FM fields against body substrings
+(`file.body.contains(title)`) at read time, but
+there is no enforcement: writing a body that
+doesn't match FM is permitted by mdbase. The
+spec does not define body templates, body
+heading constraints, or body-from-FM generation.
+
+### Side-by-side
+
+| Sync direction           | mdsmith                                   | mdbase         |
+|--------------------------|-------------------------------------------|----------------|
+| FM → filename            | n/a (MDS033 directory-structure separate) | `path_pattern` |
+| FM → body H1             | MDS020 heading template with `{title}`    | no             |
+| FM → body table cells    | `<?catalog?>` directive (drift-detected)  | no             |
+| FM → body include vars   | `<?include?>` directive variables         | no             |
+| FM → body build artifact | `<?build?>` directive                     | no             |
+| Body → body TOC          | `<?toc?>` directive                       | no             |
+| FM → query-only check    | (could grow; not present)                 | yes, read-only |
+
+### What this implies
+
+An mdbase team using FM as the typed source of
+truth has no built-in way to ensure their body
+H1 matches their FM title, that a catalog page
+reflects current FM, or that referenced FM
+fields appear in the body. They handle this
+with conventions or external tools.
+
+An mdsmith team has these out of the box. The
+five directives cover most FM→body relations
+that come up in practice; MDS020 placeholders
+are the last-mile linker for the schema-body
+case.
+
+This is not a gap mdbase is silent on by
+oversight — the tool is scoped to data-layer
+typing. Body content is treated as opaque
+prose. mdsmith covers it because the broader
+rule-and-directive surface includes generated
+content and template-driven validation.
+
+For the question "what does each tool offer to
+keep FM and body in sync?", the honest answer
+is: **mdsmith ships explicit FM↔body sync
+mechanisms across schemas and directives;
+mdbase offers FM↔filename via `path_pattern`
+and nothing on the body side.** A team that
+needs both is running mdsmith for the body sync
+even if mdbase owns the FM types.
 
 ## How the type definitions look
 

--- a/docs/research/mdbase-vs-mdsmith/query-and-types.md
+++ b/docs/research/mdbase-vs-mdsmith/query-and-types.md
@@ -792,9 +792,19 @@ benefit either side.
    schemas come closest with the heading
    template, but they don't reach inside
    sections (no "first paragraph must mention
-   the project name"). For doc consistency
-   this is genuinely useful and not yet
-   covered.
+   the project name", no "this field has a
+   word-count cap", no cross-reference
+   resolution between body sections). For
+   structured Markdown documents — decks,
+   runbooks, training material, regulatory
+   text — this is the largest untyped surface.
+   **Candidate plan: S-7** in
+   [learn-from-mdbase.md](learn-from-mdbase.md)
+   sketches a rich-body-schema language with
+   nested sections, per-field rules
+   (word/char counts, forbidden patterns,
+   skip rules), cross-reference validation,
+   acronym tracking, and index generation.
 2. **Schema-aware query validation.** A typo
    in a field name silently returns no
    results. Either tool's schema layer is rich
@@ -807,9 +817,11 @@ benefit either side.
    [interop.md §7](interop.md) sketches a
    bridge that doesn't exist yet.
 
-The first two are clear candidates for either
-project. The third is a coordination problem
-that needs cross-tool buy-in.
+S-7 is the most ambitious of the three. The
+other two are clear candidates for either
+project; the cross-impl bridge is a
+coordination problem that needs cross-tool
+buy-in.
 
 ## Sources
 

--- a/docs/research/mdbase-vs-mdsmith/use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/use-cases.md
@@ -1,5 +1,8 @@
 ---
-summary: Concrete worked scenarios that exercise the differences between mdsmith and mdbase, showing where each tool fits naturally and where the gaps surface.
+summary: >-
+  Concrete worked scenarios that exercise the differences between
+  mdsmith and mdbase, showing where each tool fits naturally and where
+  the gaps surface.
 status: 🔳
 ---
 # Use cases and worked examples

--- a/docs/research/mdbase-vs-mdsmith/use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/use-cases.md
@@ -409,10 +409,10 @@ the rollout schedule.
   acceptance reference a real doc?"
 
 **mdsmith approach.** Covers all the docs concerns
-plus plan-front-matter validation via a `plan` kind
-
-+ proto.md schema. MDS019 generates the index.
-MDS027 validates cross-file links. No backlinks.
+plus plan-front-matter validation via a `plan`
+kind plus a `proto.md` schema. MDS019 generates
+the index. MDS027 validates cross-file links. No
+backlinks.
 
 **mdbase approach.** Plan tracker is a perfect fit
 for typed schemas; docs are out of scope. `_types/plan.md`

--- a/docs/research/mdbase-vs-mdsmith/use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/use-cases.md
@@ -1,0 +1,456 @@
+---
+summary: Concrete worked scenarios that exercise the differences between mdsmith and mdbase, showing where each tool fits naturally and where the gaps surface.
+status: 🔳
+---
+# Use cases and worked examples
+
+This document is a set of concrete scenarios. Each
+takes a real-shaped task and walks through what the
+team would do with mdsmith, with mdbase, and with
+both. The point is to make the abstract differences
+in [features.md](features.md) feel mechanical: when
+do they actually bite?
+
+## Use-case index
+
+| #   | Scenario                                   | Best fit       |
+|-----|--------------------------------------------|----------------|
+| U-1 | Open-source repo: docs/ tree               | mdsmith        |
+| U-2 | Personal Obsidian vault (PKB)              | mdbase         |
+| U-3 | RFC / spec tracker with status fields      | mdsmith (lean) |
+| U-4 | Issue / task tracker as Markdown           | mdbase (lean)  |
+| U-5 | AI-agent-maintained runbooks               | mdsmith        |
+| U-6 | Knowledge graph with backlinks and renames | mdbase         |
+| U-7 | Mixed: product wiki + typed plan tracker   | both, layered  |
+
+Each scenario uses the same structure:
+
+- **Setting** — two or three sentences of context
+- **Sample file** — the front matter and body shape
+- **What the team needs** — a list of capabilities
+- **mdsmith approach** — concrete commands and config
+- **mdbase approach** — concrete commands and config
+- **Verdict** — which tool fits and why
+
+## U-1: Open-source repo with `docs/` tree
+
+**Setting.** A Go library with a `docs/` folder. 120
+Markdown files: README, getting-started, reference
+docs, contributor guide, plus per-feature explainers.
+Twenty contributors over four years. PRs from
+strangers come in regularly.
+
+**Sample file.** Front matter and body shape:
+
+```markdown
+---
+title: Configuring transport timeouts
+summary: How to tune the http.Client timeout knobs.
+---
+# Configuring transport timeouts
+
+Three timeout knobs decide how the client behaves on
+slow networks: connect, response-header, and
+end-to-end. Set them with…
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Block PRs on broken cross-file links
+- Enforce heading conventions
+- Auto-generate a doc-index table from front matter
+- Catch verbose paragraphs and overlong files
+- Run in CI as a single binary
+- Zero install friction for new contributors
+
+**mdsmith approach.** `go install` on the binary;
+`mdsmith check .` in CI. The repo's `.mdsmith.yml`
+sets line length, paragraph readability (ARI),
+heading rules, and a `<?catalog?>` directive at the
+top of `docs/index.md` that rebuilds on
+`mdsmith fix`.
+
+**mdbase approach.** None of the team's needs map
+onto mdbase. The vault has no typed records, no
+backlinks worth indexing, and no rename refactor
+load. Adding `mdbase.yaml` would not help.
+
+**Verdict.** mdsmith is the natural fit. The repo
+is text-with-front-matter, and the value is in
+prose / structure linting and generated indexes.
+mdbase would be inert.
+
+## U-2: Personal Obsidian vault
+
+**Setting.** A solo knowledge-worker keeping ~3,000
+Markdown notes in an Obsidian vault committed to
+Git. Daily journal, project notes, meeting notes,
+recipes, book reviews, all linked with `[[wikilinks]]`.
+
+**Sample file.** Front matter and body shape:
+
+```markdown
+---
+type: daily
+date: 2026-05-04
+mood: focused
+energy: 6
+---
+# 2026-05-04
+
+Worked on [[mdsmith]]. Closed a thread on
+[[plan-131]]. Read [[Designing Data-Intensive
+Applications]] chapter 3.
+
+## tomorrow
+- review [[plan-122]]
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Validate front matter: `date` is ISO, `mood` is
+  one of a known set, `energy` is 1–10
+- Show backlinks: every page that mentions
+  `[[plan-131]]`
+- Rename `plan-131` to `plan-131-lsp-symbols` and
+  rewrite every wikilink across the vault
+- Query "all daily notes from 2026-Q1 with
+  energy >= 7"
+- Fast operation at 3,000 files
+
+**mdsmith approach.** mdsmith treats `[[wikilinks]]`
+as plain text. MDS027 cannot validate them. There
+is no rename refactor and no backlink index. Front
+matter validation works (CUE in proto.md), but
+that's a small slice of the need.
+
+**mdbase approach.** Native fit. `_types/daily.md`
+declares the schema. Wikilinks resolve through the
+L4 link parser. `mdbase rename plan-131 plan-131-lsp-symbols`
+rewrites every incoming link. SQLite cache makes
+queries instant. The Rust LSP gives the editor
+hover, completion, and backlinks.
+
+**Verdict.** mdbase. mdsmith has nothing to add to
+a wikilink-heavy vault other than line-length and
+paragraph-readability rules — useful but secondary.
+
+## U-3: RFC / spec tracker
+
+**Setting.** A platform team writing 60 long-form
+RFCs over two years. Each RFC follows a strict
+template: problem, alternatives, decision,
+implementation. Front matter carries id, title,
+authors, status, and a `supersedes:` chain.
+
+**Sample file.** Front matter and body shape:
+
+```markdown
+---
+id: RFC-027
+title: Object storage abstraction
+authors: [alice, bob]
+status: accepted
+created: 2026-02-14
+supersedes: [RFC-019]
+---
+# RFC-027: Object storage abstraction
+
+## Problem
+
+## Alternatives
+
+## Decision
+
+## Implementation
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Enforce the four-section heading template
+- Validate front matter (status is one of a fixed
+  set, id matches `RFC-NNN`, dates are ISO)
+- Generate an index table of all RFCs sorted by id
+- Block PRs on broken `supersedes:` references
+- Catch readability regressions in long sections
+
+**mdsmith approach.** `kinds: [rfc]` with
+`required-structure.schema: rfcs/proto.md`. The
+`proto.md` carries the four-heading template and
+CUE for the front matter. `<?catalog?>` builds the
+index table. MDS023 / MDS024 catch readability.
+MDS027 validates link integrity. The team gets
+everything in one tool.
+
+**mdbase approach.** `_types/rfc.md` declares the
+typed schema. Status enum, id pattern, ISO dates
+all map cleanly. Queries find blocked RFCs.
+Backlinks find supersession chains. But: no
+heading-template enforcement, no readability
+checks, no index-table generation in-place.
+
+**Verdict.** mdsmith leans. The four-section
+template is the structural backbone of the artifact;
+mdsmith owns that. mdbase types add typed-data
+nicety, but the team can get most of the same
+guarantees from CUE in the mdsmith proto.md.
+Pairing both works (see [interop.md](interop.md)),
+but mdsmith alone covers more of the need.
+
+## U-4: Issue / task tracker as Markdown
+
+**Setting.** A small team tracking work as
+Markdown files in `tasks/`. Each task is a record
+with status, priority, assignee, due date, and a
+description body. ~500 tasks active at any time.
+Heavy CRUD: tasks created / updated / closed
+several times per day.
+
+**Sample file.** Front matter and body shape:
+
+```markdown
+---
+id: TASK-0231
+title: Migrate auth to OIDC
+status: in-progress
+priority: 3
+assignee: alice
+due: 2026-06-01
+---
+# TASK-0231: Migrate auth to OIDC
+
+The current SAML flow has two open issues. We will
+swap to OIDC over the next sprint.
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Create a new task with `id` and `created` filled
+  automatically
+- Update `status` from the CLI without opening the
+  file
+- Query "open tasks, priority >= 3, due in 7 days"
+- Rename `TASK-0231` to `TASK-0231-oidc-migration`
+  and update every reference
+- Compute "days overdue" without storing it
+- Watch a folder and notify on changes
+
+**mdsmith approach.** mdsmith does not author or
+edit front matter. Task creation and update happen
+in the editor or via shell. `mdsmith query` filters
+by FM but cannot sort or compute days-overdue.
+Renames are manual; MDS027 catches the breakage.
+There is no watch mode beyond the LSP per-session.
+
+**mdbase approach.** Native CRUD. `mdbase create task`
+fills in `id` (ULID), `created` (`now_on_write`),
+defaults. `mdbase update TASK-0231 --status done`
+edits the file. Bases query covers sort, filter,
+and the computed `days_overdue` field. `mdbase rename`
+
++ `mdbase watch` round out the workflow.
+
+**Verdict.** mdbase. This is the canonical use case
+mdbase was designed for. mdsmith can lint task
+files for prose quality and structural rules, but
+the day-to-day data plane is mdbase's territory.
+
+## U-5: AI-agent-maintained runbooks
+
+**Setting.** A platform team's runbook set lives
+under `runbooks/`. ~80 files, each describing a
+service incident response. An AI agent (Claude
+Code) is part of the maintenance loop: it ingests
+postmortems, updates runbooks, generates new ones,
+and reorganizes the set on demand.
+
+**Sample file.** Front matter and body shape:
+
+```markdown
+---
+service: auth-gateway
+severity: high
+last-incident: 2026-04-22
+on-call-rotation: platform
+---
+# Auth gateway: 5xx spike
+
+## Symptoms
+
+## First steps
+
+## Escalation
+
+## Verification
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Agent verifies its edits with deterministic exit
+  codes
+- Agent regenerates the index table at
+  `runbooks/index.md` after creating files
+- Editor LSP exposes outline, go-to-definition,
+  and "what depends on this runbook?" so the agent
+  can navigate
+- Block PRs that break the heading template or
+  cross-file links
+- No network calls during lint or fix
+
+**mdsmith approach.** `mdsmith check .` for
+verification, `mdsmith fix .` for regenerating the
+catalog and TOC, JSON output for parsing. After
+plan 131 lands, the LSP gives the agent
+documentSymbol, definition, and call hierarchy. No
+network anywhere.
+
+**mdbase approach.** mdbase-lsp gives the agent
+typed-vault navigation: completion of field names,
+hover with field constraints. `mdbase create runbook`
+scaffolds new files. But mdbase does not lint
+prose, fix tables, or regenerate the index.
+
+**Verdict.** mdsmith is the agent's primary tool.
+mdbase-lsp adds value once typing is in place but
+is not the foundation. After plan 131 lands the
+agent gains the document-graph view it needs to
+plan multi-file edits.
+
+## U-6: Knowledge graph with renames
+
+**Setting.** A research lab's shared vault. ~12,000
+Markdown files with dense `[[wikilink]]` cross-
+references. Files get renamed often as concepts get
+sharper. Backlinks are how researchers discover
+related work.
+
+**Sample file.** Front matter and body shape:
+
+```markdown
+---
+tags: [transformer, attention, scaling-laws]
+authors: [chen-2024]
+---
+# Notes on Chen et al. (2024)
+
+The paper extends [[scaling-laws]] to mixture-of-
+experts and confirms the [[chinchilla-law]]
+prediction with one caveat. Compare with
+[[Kaplan-2020]].
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Backlinks panel: "what cites this paper?"
+- Rename `chinchilla-law` to `chinchilla-2022`
+  across 12,000 files in seconds
+- Search by tag, by author, by year
+- Trust the rename: zero broken links after
+- Index that scales to 12,000 files
+
+**mdsmith approach.** Scales poorly. No backlinks,
+no wikilink awareness, no rename refactor.
+Per-run re-read of all files makes interactive use
+slow. mdsmith does not solve this problem.
+
+**mdbase approach.** Designed for it. SQLite cache
+keeps backlinks instantaneous. Wikilink resolution
+is L4. Rename rewrites all incoming links in one
+operation. Watch mode keeps the index live.
+
+**Verdict.** mdbase, decisively.
+
+## U-7: Mixed product wiki + typed plan tracker
+
+**Setting.** A 30-engineer team. The repo holds
+a product wiki (`docs/`, prose-heavy, generated
+indexes) AND a plan tracker (`plan/`, typed
+records with status / owner / acceptance
+criteria). The two surfaces share a single vault
+because plans link to docs and vice versa.
+
+**Sample plan file.** Plan record shape:
+
+```markdown
+---
+id: 145
+title: Multi-tenant key rotation
+status: in-progress
+owner: alice
+acceptance:
+  - rotation runs without downtime
+  - documented in docs/security/key-rotation.md
+---
+# Plan 145: Multi-tenant key rotation
+```
+
+**Sample doc file.** Doc shape:
+
+```markdown
+---
+title: Key rotation
+summary: How keys are rotated across tenants.
+---
+# Key rotation
+
+See [plan 145](../../plan/145_key-rotation.md) for
+the rollout schedule.
+```
+
+**What the team needs.** Concrete capabilities they want:
+
+- Lint prose in `docs/`
+- Validate plan front matter (status enum, id pattern)
+- Generate the plan index table
+- Backlinks: "what plans link to this doc?"
+- Cross-file integrity: "does the plan's
+  acceptance reference a real doc?"
+
+**mdsmith approach.** Covers all the docs concerns
+plus plan-front-matter validation via a `plan` kind
+
++ proto.md schema. MDS019 generates the index.
+MDS027 validates cross-file links. No backlinks.
+
+**mdbase approach.** Plan tracker is a perfect fit
+for typed schemas; docs are out of scope. `_types/plan.md`
+typifies the plan; backlinks panel surfaces "what
+plans cite this doc". Bases queries find blocked
+plans.
+
+**Verdict.** Both, layered. mdsmith owns the docs
+prose / structure / catalog work and validates plan
+front matter via proto.md. mdbase types the plan
+records, surfaces backlinks for the
+plans-cite-docs graph, and feeds queries the team
+runs interactively. See
+[interop.md](interop.md) section 4 for a folder
+layout that runs both cleanly.
+
+## Pattern across the seven cases
+
+| #   | Prose / structure load | Typed-record load | Rename / backlink load | Best fit       |
+|-----|------------------------|-------------------|------------------------|----------------|
+| U-1 | high                   | low               | low                    | mdsmith        |
+| U-2 | low                    | medium            | high                   | mdbase         |
+| U-3 | high                   | medium            | low                    | mdsmith (lean) |
+| U-4 | low                    | high              | medium                 | mdbase (lean)  |
+| U-5 | high                   | low               | low                    | mdsmith        |
+| U-6 | low                    | medium            | very high              | mdbase         |
+| U-7 | high                   | high              | medium                 | both           |
+
+Three signals predict the fit:
+
+1. **Prose / structure load** — does the artifact
+   have prose that needs linting and generated
+   sections that need regenerating? If yes, mdsmith.
+2. **Typed-record load** — are files records with
+   constrained shapes whose types matter at write
+   time? If yes, mdbase.
+3. **Rename / backlink load** — does the team
+   rename often, and do incoming links matter? If
+   yes, mdbase.
+
+A team scores each axis. Two-or-three highs in
+the same column point at one tool; mixed scores
+point at running both.

--- a/docs/research/mdbase-vs-mdsmith/use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/use-cases.md
@@ -246,9 +246,9 @@ There is no watch mode beyond the LSP per-session.
 fills in `id` (ULID), `created` (`now_on_write`),
 defaults. `mdbase update TASK-0231 --status done`
 edits the file. Bases query covers sort, filter,
-and the computed `days_overdue` field. `mdbase rename`
-
-+ `mdbase watch` round out the workflow.
+and the computed `days_overdue` field.
+`mdbase rename` plus `mdbase watch` round out the
+workflow.
 
 **Verdict.** mdbase. This is the canonical use case
 mdbase was designed for. mdsmith can lint task

--- a/docs/research/mdbase-vs-mdsmith/use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/use-cases.md
@@ -191,7 +191,7 @@ Backlinks find supersession chains. But: no
 heading-template enforcement, no readability
 checks, no index-table generation in-place.
 
-**Verdict.** mdsmith leans. The four-section
+**Verdict.** mdsmith (lean). The four-section
 template is the structural backbone of the artifact;
 mdsmith owns that. mdbase types add typed-data
 nicety, but the team can get most of the same

--- a/docs/research/mdbase-vs-mdsmith/use-cases.md
+++ b/docs/research/mdbase-vs-mdsmith/use-cases.md
@@ -3,7 +3,6 @@ summary: >-
   Concrete worked scenarios that exercise the differences between
   mdsmith and mdbase, showing where each tool fits naturally and where
   the gaps surface.
-status: 🔳
 ---
 # Use cases and worked examples
 

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -1,5 +1,8 @@
 ---
-summary: Way-of-working comparison — daily authoring, repo bootstrap, schema evolution, file rename, CI pipeline, editor session, Obsidian-vault use, LLM/agent workflows, contributor onboarding.
+summary: >-
+  Way-of-working comparison — daily authoring, repo bootstrap, schema
+  evolution, file rename, CI pipeline, editor session, Obsidian-vault
+  use, LLM/agent workflows, contributor onboarding.
 status: 🔳
 ---
 # Way-of-working comparison

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -1,0 +1,551 @@
+---
+summary: Way-of-working comparison — daily authoring, repo bootstrap, schema evolution, file rename, CI pipeline, editor session, Obsidian-vault use, LLM/agent workflows, contributor onboarding.
+status: 🔳
+---
+# Way-of-working comparison
+
+Features only matter when they meet a workflow. This
+document walks the same tasks under each tool. The
+question is not "what can each do" but "what does it
+feel like to do this work."
+
+## 1. Bootstrap a new project
+
+**mdsmith.** mdsmith side:
+
+```bash
+cd my-docs
+mdsmith init                # writes default .mdsmith.yml
+mdsmith check .             # passes immediately on most repos
+```
+
+`mdsmith init` writes a config matching the
+out-of-the-box rule defaults. The repo is now linted
+on every `check`. Adding kinds, schemas, and
+overrides is opt-in — projects with no special needs
+never edit `.mdsmith.yml` after init.
+
+**mdbase.** mdbase side:
+
+```bash
+cd my-collection
+mdbase init                 # writes mdbase.yaml + _types/ folder
+$EDITOR _types/note.md      # author the first type
+mdbase validate             # validates current files
+```
+
+`mdbase init` creates the minimum collection: an
+`mdbase.yaml` with `spec_version: "0.2.1"` and an
+empty `_types/` folder. The user must author types
+to get value. Untyped collections are valid (spec
+permits zero types) but trivial — the tool acts as
+a structured-YAML reader at that point.
+
+Adoption path that the spec explicitly recommends
+(Appendix D):
+
+1. Start untyped (raw YAML front matter)
+2. Run `mdbase infer-types` to bootstrap types from
+   existing front matter
+3. Tighten validation level from `off` → `warn` →
+   `error` over time
+4. Add path globs and field-presence rules to
+   auto-match files
+
+| Bootstrap step      | mdsmith              | mdbase                  |
+|---------------------|----------------------|-------------------------|
+| Init                | one command          | one command             |
+| Useful immediately  | yes (rule defaults)  | only after typing files |
+| Schema authoring    | optional             | central activity        |
+| Run-cost first time | seconds (lints repo) | seconds (validates)     |
+
+mdsmith is "lint everything by default; opt out
+where wrong." mdbase is "describe types first; type
+coverage grows over time."
+
+## 2. Author a new file
+
+**mdsmith.**
+The user creates the file in any editor. mdsmith
+runs on save (via LSP) or on commit (via pre-merge
+hook or CI). Diagnostics surface where the file
+violates rules; the user fixes them or lets
+`mdsmith fix` rewrite the body.
+
+mdsmith does not author files. There is no template
+mechanism beyond `<?required-structure?>` (which
+enforces a heading skeleton) and `<?include?>` /
+`<?catalog?>` (which fill in body content).
+
+**mdbase.**
+The user can either:
+
+- Edit a `.md` file by hand and save it
+- Run `mdbase create task` to scaffold a typed file
+  from defaults and `generated:` strategies (ULID,
+  `now_on_write`, etc.)
+
+`mdbase create` writes the front matter according
+to the type. Required fields without defaults are
+left blank for the user to fill in (or rejected if
+strict mode is on).
+
+| Authoring task                      | mdsmith                                    | mdbase                            |
+|-------------------------------------|--------------------------------------------|-----------------------------------|
+| Create `.md` from template          | hand or `<?include?>` from a template file | `mdbase create <type>`            |
+| Fill required fields                | manual                                     | manual + auto-defaults            |
+| Generated values (ULID, timestamps) | no                                         | yes (`generated:` strategies)     |
+| Validate on write                   | n/a (mdsmith doesn't write)                | yes (validates before persisting) |
+| Lint after write                    | yes (LSP / CI)                             | n/a (lint is mdsmith's domain)    |
+
+mdsmith is post-hoc: edit then verify. mdbase has a
+write-time path: scaffold then verify before commit.
+
+## 3. Daily editor session
+
+### mdsmith via VS Code extension
+
+Diagnostics appear inline as the user types. The
+"Quick Fix" lightbulb offers per-diagnostic fixes
+and a "Fix all in file" action. On save, the file
+relints. `.mdsmith.yml` changes invalidate the
+session cache automatically.
+
+What is missing: completion (e.g. heading anchors,
+link targets, front-matter field names). The LSP
+implements only diagnostics and code actions.
+
+### mdbase via mdbase-lsp (Rust)
+
+Diagnostics for type errors, link errors,
+constraint violations. Plus:
+
+- Completion for field names, enum values, type names
+- Hover with type definition and field constraints
+- Go-to-definition on link targets and types
+
+What is missing: autofix. mdbase-lsp does not
+rewrite content the way mdsmith does — it surfaces
+errors but expects the user to resolve them.
+
+### Both servers running
+
+Many editors can run multiple LSPs on the same
+buffer. The user gets:
+
+- mdsmith → diagnostics + autofix on prose, structure,
+  catalog, TOC, include
+- mdbase-lsp → diagnostics + completion + navigation
+  on types and links
+
+The two diagnostic streams use distinct rule IDs and
+error codes, so duplicates are rare. Both servers
+respect per-file front matter and read the same
+on-disk content.
+
+| Editor experience        | mdsmith only | mdbase-lsp only | both running |
+|--------------------------|--------------|-----------------|--------------|
+| Inline diagnostics       | yes          | yes             | both streams |
+| Quick fix per diagnostic | yes          | no              | mdsmith only |
+| Fix all in file          | yes          | no              | mdsmith only |
+| Field-name completion    | no           | yes             | mdbase only  |
+| Type-name hover          | no           | yes             | mdbase only  |
+| Go-to type definition    | no           | yes             | mdbase only  |
+| Backlinks panel          | no           | yes (L5)        | mdbase only  |
+
+## 4. Schema evolution
+
+**mdsmith.**
+Editing a CUE schema is editing a regular file under
+version control. The next `mdsmith check` re-validates
+all files against the updated schema. Files that no
+longer comply produce MDS020 diagnostics.
+
+There is no migration mechanism: if a schema change
+is breaking, the user fixes the affected files
+manually, possibly in the same PR.
+
+Typical patterns:
+
+- Add an optional field — no migration needed
+- Add a required field — existing files break; fix
+  them in the same commit
+- Tighten a constraint — existing violators surface;
+  fix them or relax the constraint
+
+**mdbase.**
+Spec §5 ("Schema Evolution") and L6 migrations
+codify the lifecycle.
+
+Permitted changes without migration:
+
+- Adding optional fields
+- Adding default values
+- Loosening constraints
+
+Breaking changes (require migration manifest at L6):
+
+- Adding required fields
+- Changing field types
+- Removing fields (treated per `strict:` setting)
+- Tightening enum values
+
+A migration manifest is a YAML file in the
+`<types>/_migrations/` folder. It declares the
+schema version delta and a backfill expression. The
+implementation runs the backfill on `mdbase migrate`.
+
+Example manifest pattern (illustrative):
+
+```yaml
+from_version: 1
+to_version: 2
+backfill:
+  - type: task
+    field: priority
+    expr: 3   # default for the new required field
+```
+
+| Schema-evolution step | mdsmith                      | mdbase                                  |
+|-----------------------|------------------------------|-----------------------------------------|
+| Add optional field    | edit CUE; no migration       | edit type; no migration                 |
+| Add required field    | edit CUE; manually fix files | migration manifest with backfill        |
+| Change field type     | edit CUE; manually fix files | migration manifest                      |
+| Track schema versions | git history                  | git history + migration version numbers |
+| Bulk update files     | external scripts             | `mdbase migrate` (L6)                   |
+
+mdbase's migration story is the more mature one for
+mature collections. mdsmith's story is "it's just
+text — change it and fix the breakage in the same
+commit."
+
+## 5. Rename a file
+
+**mdsmith.** mdsmith side:
+
+```bash
+mv docs/old-name.md docs/new-name.md
+mdsmith check .
+# MDS027 reports broken links in every file that
+# referenced docs/old-name.md
+```
+
+Then fix each broken link manually or via search-
+and-replace. A separate refactoring tool can
+automate this; mdsmith does not provide one.
+
+### mdbase L5
+
+```bash
+mdbase rename docs/old-name.md docs/new-name.md
+# moves the file; rewrites incoming wikilinks and
+# Markdown links across the collection; preserves
+# link styles; reports per-file failures
+```
+
+The rename is a single command. Reference updates
+are best-effort and per-file: a permission error on
+one file does not abort the rename. The user gets a
+list of files that were not updated.
+
+| Rename step            | mdsmith                  | mdbase L5                     |
+|------------------------|--------------------------|-------------------------------|
+| Move file              | `mv`                     | `mdbase rename`               |
+| Detect broken links    | `mdsmith check` (MDS027) | n/a (already rewritten)       |
+| Auto-rewrite incoming  | no                       | yes                           |
+| Preserve wikilink form | n/a                      | yes (wikilink stays wikilink) |
+| Concurrent-edit safety | n/a (no rewrite)         | optimistic mtime check        |
+
+Rename is the most common task where mdsmith feels
+the absence of a graph. Teams that rename often,
+especially in vault-style projects, get more value
+from mdbase here.
+
+## 6. Find and select files
+
+**mdsmith.** mdsmith side:
+
+```bash
+mdsmith query 'status: "✅"' plan/
+# emits paths of plan files where status is "✅"
+```
+
+The output is a list of file paths. Pipe into other
+tools as needed. There is no body search, no sort,
+no pagination.
+
+**mdbase.** mdbase side:
+
+```bash
+mdbase query '
+  types: [task]
+  where: status == "open" && priority >= 3
+  order_by: [{field: due, direction: asc}]
+  limit: 20
+'
+# emits a structured result set
+```
+
+The output is a JSON array of file objects with
+metadata (path, types, effective FM, mtime, size,
+optionally body). Sortable, paginatable, with body
+search via `file.body.contains(...)`.
+
+| Selection task         | mdsmith             | mdbase                    |
+|------------------------|---------------------|---------------------------|
+| Filter by FM field     | yes                 | yes                       |
+| Sort by FM field       | no (pipe to `sort`) | yes                       |
+| Paginate               | no (head/tail)      | yes (`limit`/`offset`)    |
+| Body full-text search  | no                  | yes (`file.body`)         |
+| Cross-file traversal   | no                  | yes (`asFile().property`) |
+| Aggregation / grouping | no                  | yes (`Query+`)            |
+| Available in scripts   | yes                 | yes                       |
+
+For ad-hoc CI checks ("filter to ready plans"),
+mdsmith query suffices. For knowledge-base browsing
+("show overdue tasks grouped by assignee"), mdbase
+is built for it.
+
+## 7. CI pipeline
+
+### mdsmith-only repo
+
+```yaml
+# .github/workflows/lint.yml
+- run: go install github.com/jeduden/mdsmith/cmd/mdsmith@vX.Y.Z
+- run: mdsmith check .
+```
+
+One install step, one check command, one binary on
+the PATH. Total CI time is dominated by Go install.
+
+### mdbase-only repo
+
+```yaml
+- run: npm install -g mdbase-cli
+- run: mdbase validate
+- run: mdbase query 'where: status == "draft"' >/tmp/drafts.json
+```
+
+Node setup plus validation. Optional cache build
+(`mdbase cache rebuild`) for repeat queries.
+
+### Both
+
+```yaml
+- run: go install github.com/jeduden/mdsmith/cmd/mdsmith@vX.Y.Z
+- run: npm install -g mdbase-cli
+- run: mdsmith check .
+- run: mdbase validate
+```
+
+Two phases, two reports. Unify into a single status
+check or surface as separate checks. Diagnostics
+do not overlap: mdsmith reports prose and structure
+issues; mdbase reports schema and link issues.
+
+| CI concern               | mdsmith only      | mdbase only       | both          |
+|--------------------------|-------------------|-------------------|---------------|
+| Single tool install      | go binary         | npm package       | go + npm      |
+| Cold-cache lint time     | seconds           | seconds           | additive      |
+| Lint failure exits CI    | yes               | when `error` mode | both          |
+| Diff-only mode           | path-based filter | path-based filter | both per side |
+| Output format for review | text or JSON      | JSON              | per-tool      |
+
+## 8. Pre-commit / pre-merge
+
+**mdsmith.** mdsmith side:
+
+```bash
+mdsmith pre-merge-commit install
+mdsmith merge-driver install '*.md'
+```
+
+The pre-merge-commit hook runs `mdsmith fix` after
+a merge. The merge driver auto-resolves conflicts
+inside generated sections (catalog, include, TOC,
+build) by regenerating them. Both are mdsmith-specific.
+
+**mdbase.**
+The spec does not mandate hooks. An impl could ship
+a `pre-commit` style hook to run `mdbase validate`,
+but it is not part of the spec. Teams typically wire
+this themselves via `lefthook`, `husky`, or
+`pre-commit`.
+
+| Hook concern                    | mdsmith                            | mdbase          |
+|---------------------------------|------------------------------------|-----------------|
+| Pre-commit lint                 | external runner                    | external runner |
+| Pre-merge-commit fix            | `mdsmith pre-merge-commit install` | external        |
+| Merge-conflict driver           | `mdsmith merge-driver`             | none            |
+| Auto-resolve generated sections | yes                                | n/a             |
+
+Generated-section conflicts are an mdsmith-specific
+problem (mdbase does not generate body content).
+The merge driver only matters for users with
+catalog / TOC / include / build directives.
+
+## 9. Obsidian vault use case
+
+A team that maintains an Obsidian vault and wants
+both linting and structured data:
+
+- mdbase fits naturally — vault-style folders, type
+  files in `_types/`, wikilinks first-class, Bases
+  query syntax familiar to Dataview users
+- mdsmith adds structural and prose linting that
+  Obsidian itself does not provide
+
+Vaults need:
+
+- Wikilink validation → mdbase (mdsmith treats them
+  as text)
+- Heading and table consistency → mdsmith
+- Front-matter type checks → either or both
+- Backlink panel → mdbase via LSP
+- Daily-note template generation → external (Obsidian
+  Templater plugin) or mdsmith `<?include?>`
+
+See [interop.md](interop.md) for how to lay out a
+vault that runs both tools.
+
+## 10. LLM / agent workflows
+
+This is where the file-first design pays off for
+both tools.
+
+### Agent reads a file
+
+The agent reads the raw `.md` file. Front matter is
+the structured layer. Both tools see the same bytes.
+No build step, no `public/` artifact tree, no
+proprietary format. The agent can:
+
+- Open the file with any tool
+- Make edits
+- Save the file
+- Re-run `mdsmith check` or `mdbase validate` to
+  verify
+
+### Agent writes a file
+
+mdsmith does not author files; the agent produces
+the body and front matter. After writing, the agent
+runs `mdsmith fix` to regenerate any directive
+bodies (catalog, TOC, include).
+
+mdbase has `mdbase create <type>`. The agent can
+delegate scaffolding to mdbase, get a typed shell
+with defaults filled in, and then fill in the body.
+
+### Agent renames a file
+
+mdsmith: `mv` then fix broken links by hand. The
+agent has to find every link.
+
+mdbase: `mdbase rename` does the work. The agent
+issues one command.
+
+### Agent runs queries
+
+Both tools support querying. mdbase's richer query
+language lets the agent ask "all files with status
+== 'open' and priority >= 3" without iterating.
+mdsmith's CUE query covers the simpler "filter by
+field" case.
+
+### Agent verifies its own work
+
+Both tools are CI-friendly: deterministic, exit
+code, JSON output. After an edit, the agent runs
+the relevant tool, parses the JSON, and decides
+what to fix next.
+
+| Agent task            | mdsmith                            | mdbase                       |
+|-----------------------|------------------------------------|------------------------------|
+| Read file             | direct                             | direct                       |
+| Write body            | direct + `mdsmith fix` regenerates | direct                       |
+| Scaffold typed file   | n/a                                | `mdbase create`              |
+| Validate FM shape     | `mdsmith check` (MDS020)           | `mdbase validate`            |
+| Rename + update refs  | manual fix                         | `mdbase rename`              |
+| Query collection      | `mdsmith query` (CUE)              | `mdbase query` (richer)      |
+| Block on broken links | `mdsmith check` (MDS027)           | `mdbase validate` link rules |
+| Format diagnostics    | text or JSON                       | JSON                         |
+| Determinism           | yes                                | yes                          |
+
+For agent-driven docs work the two tools are
+complementary. mdsmith excels at "verify and fix
+content"; mdbase excels at "navigate and edit
+typed records."
+
+## 11. Onboarding a new contributor
+
+### mdsmith repo
+
+The contributor:
+
+1. Clones the repo
+2. Runs `go install github.com/jeduden/mdsmith/cmd/mdsmith`
+3. Reads `.mdsmith.yml` (and CLAUDE.md if present)
+4. Runs `mdsmith check .` and fixes any drift
+5. Runs `mdsmith help <rule-id>` to read embedded
+   docs offline
+
+`mdsmith kinds` shows the resolved rule config per
+file, helpful for understanding why a particular
+file lints differently from neighbours.
+
+### mdbase repo
+
+The contributor:
+
+1. Clones the repo
+2. Installs `mdbase-cli` (npm) or `mdbase-lsp` (cargo)
+3. Reads `mdbase.yaml` for config
+4. Reads `_types/*.md` — every type file is a
+   self-documenting Markdown file with the schema
+   in its front matter and a description in its body
+5. Runs `mdbase validate` to confirm the collection
+   is healthy
+
+mdbase has a discoverability advantage here: the
+type files are visible in any file tree, and each
+has its own documentation. mdsmith's kinds live
+inside `.mdsmith.yml`, which is a single config file
+the contributor must read top to bottom.
+
+| Onboarding step          | mdsmith                                   | mdbase                            |
+|--------------------------|-------------------------------------------|-----------------------------------|
+| Install                  | one binary                                | npm + cargo                       |
+| Config to read           | `.mdsmith.yml`                            | `mdbase.yaml` + `_types/`         |
+| Per-type docs            | `internal/rules/<id>/README.md` (in repo) | `_types/<name>.md` body (in repo) |
+| Inspect effective config | `mdsmith kinds`                           | `mdbase types --inspect`          |
+| Offline rule docs        | `mdsmith help <id>`                       | spec doc on github                |
+
+## 12. Mental model summary
+
+| Concept                         | mdsmith says              | mdbase says               |
+|---------------------------------|---------------------------|---------------------------|
+| What's a file?                  | Text to lint and fix      | A typed record            |
+| What's metadata?                | YAML the rules read       | Effective FM + computed   |
+| Who validates?                  | Per-rule severity         | Per-mode (off/warn/error) |
+| Who creates?                    | Humans (mdsmith doesn't)  | mdsmith + `mdbase create` |
+| Who renames?                    | `mv` + manual link fix    | `mdbase rename`           |
+| Who indexes?                    | No one (re-read each run) | SQLite (L6)               |
+| Who watches?                    | LSP per-session           | Watch mode (L6)           |
+| Who lints prose?                | mdsmith                   | (out of scope)            |
+| Who handles structure rules?    | mdsmith                   | (out of scope)            |
+| Who generates content?          | mdsmith directives        | (out of scope)            |
+| Who generates artifacts (HTML)? | external SSG              | external SSG              |
+
+A mental shortcut:
+
+- **mdsmith** treats Markdown as text that should
+  follow rules.
+- **mdbase** treats Markdown as records in a folder-
+  database.
+
+Both can be true of the same files at the same time.
+The combined workflow gets both: typed, queryable,
+rename-safe records that are also well-formed,
+readable, and have synced generated sections.

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -111,9 +111,28 @@ and a "Fix all in file" action. On save, the file
 relints. `.mdsmith.yml` changes invalidate the
 session cache automatically.
 
-What is missing: completion (e.g. heading anchors,
-link targets, front-matter field names). The LSP
-implements only diagnostics and code actions.
+What is missing today: completion, hover, and any
+form of navigation (definition, references, outline,
+call hierarchy). The shipped LSP is
+diagnostic-and-fix only.
+
+What is planned: hover for rule and directive docs
+(plan 122) and full symbol navigation (plan 131,
+PR #238). After plan 131 lands, the editor session
+also gets:
+
+- File outline (`documentSymbol`) following the
+  heading tree, with directives and front-matter
+  keys hung off appropriately
+- Go-to-definition from anchor links, file links,
+  and `[text][label]` references
+- "Find all references" on a heading, link-ref
+  label, file, or `kind:` value
+- Workspace symbol search across headings, labels,
+  kinds, and front-matter titles
+- Call hierarchy: "who includes / catalogs / links
+  to this file" (incoming) and "what does this
+  file include / link out to" (outgoing)
 
 ### mdbase via mdbase-lsp (Rust)
 
@@ -133,25 +152,35 @@ errors but expects the user to resolve them.
 Many editors can run multiple LSPs on the same
 buffer. The user gets:
 
-- mdsmith → diagnostics + autofix on prose, structure,
-  catalog, TOC, include
-- mdbase-lsp → diagnostics + completion + navigation
-  on types and links
+- mdsmith → diagnostics + autofix on prose,
+  structure, catalog, TOC, include; outline +
+  navigation + call hierarchy after plan 131
+- mdbase-lsp → diagnostics + completion + hover +
+  go-to-definition on types and links
 
-The two diagnostic streams use distinct rule IDs and
-error codes, so duplicates are rare. Both servers
-respect per-file front matter and read the same
-on-disk content.
+The two diagnostic streams use distinct rule IDs
+and error codes, so duplicates are rare. Both
+servers respect per-file front matter and read the
+same on-disk content. Navigation results are
+complementary: mdsmith plan 131 gives the
+include/catalog graph; mdbase-lsp gives the
+typed-link graph.
 
-| Editor experience        | mdsmith only | mdbase-lsp only | both running |
-|--------------------------|--------------|-----------------|--------------|
-| Inline diagnostics       | yes          | yes             | both streams |
-| Quick fix per diagnostic | yes          | no              | mdsmith only |
-| Fix all in file          | yes          | no              | mdsmith only |
-| Field-name completion    | no           | yes             | mdbase only  |
-| Type-name hover          | no           | yes             | mdbase only  |
-| Go-to type definition    | no           | yes             | mdbase only  |
-| Backlinks panel          | no           | yes (L5)        | mdbase only  |
+| Editor experience        | mdsmith today | mdsmith planned        | mdbase-lsp |
+|--------------------------|---------------|------------------------|------------|
+| Inline diagnostics       | yes           | yes                    | yes        |
+| Quick fix per diagnostic | yes           | yes                    | no         |
+| Fix all in file          | yes           | yes                    | no         |
+| Field-name completion    | no            | no                     | yes        |
+| Type-name hover          | no            | yes (rules/directives) | yes        |
+| Go-to type definition    | no            | partial (`kind:`)      | yes        |
+| Go-to anchor / heading   | no            | yes (plan 131)         | yes        |
+| Workspace symbol search  | no            | yes (plan 131)         | unknown    |
+| File outline             | no            | yes (plan 131)         | partial    |
+| Find references          | no            | yes (plan 131)         | unknown    |
+| Call hierarchy           | no            | yes (plan 131)         | no         |
+| Rename refactor          | no            | no                     | yes (L5)   |
+| Backlinks panel          | no            | yes (plan 131)         | yes (L5)   |
 
 ## 4. Schema evolution
 
@@ -461,22 +490,64 @@ code, JSON output. After an edit, the agent runs
 the relevant tool, parses the JSON, and decides
 what to fix next.
 
-| Agent task            | mdsmith                            | mdbase                       |
-|-----------------------|------------------------------------|------------------------------|
-| Read file             | direct                             | direct                       |
-| Write body            | direct + `mdsmith fix` regenerates | direct                       |
-| Scaffold typed file   | n/a                                | `mdbase create`              |
-| Validate FM shape     | `mdsmith check` (MDS020)           | `mdbase validate`            |
-| Rename + update refs  | manual fix                         | `mdbase rename`              |
-| Query collection      | `mdsmith query` (CUE)              | `mdbase query` (richer)      |
-| Block on broken links | `mdsmith check` (MDS027)           | `mdbase validate` link rules |
-| Format diagnostics    | text or JSON                       | JSON                         |
-| Determinism           | yes                                | yes                          |
+### Agent navigates over LSP
+
+Some agents (Claude Code, for one) have a built-in
+LSP tool that exposes nine standard LSP methods —
+`textDocument/documentSymbol`, `definition`,
+`implementation`, `hover`, `references`,
+`workspace/symbol`, plus `prepareCallHierarchy` and
+the two call-direction methods. Both tools target
+this surface, but differently.
+
+- **mdbase-lsp** today gives the agent the typed
+  view: completion of field names, hover with
+  type definitions, go-to-definition on a link's
+  target. Symbol-level workspace navigation
+  (find-references on a heading, outline,
+  call hierarchy on the include graph) is not
+  advertised in the project README at the time of
+  writing.
+- **mdsmith** today exposes only diagnostics and
+  code actions over LSP. Plan 131 (PR #238) adds
+  `documentSymbol`, `definition`, `implementation`,
+  `references`, `workspace/symbol`, and call
+  hierarchy. The plan explicitly maps the nine
+  Claude-LSP methods onto the existing AST and
+  link graph.
+
+Once plan 131 lands, an agent can ask the mdsmith
+LSP "what files include this runbook?" via
+`incomingCalls`, "what does this overview embed?"
+via `outgoingCalls`, "show me the outline" via
+`documentSymbol`, and "find every link to this
+heading" via `references` — all without leaving
+the LSP protocol.
+
+### Side-by-side agent surface
+
+| Agent task                 | mdsmith today  | mdsmith planned | mdbase-lsp      |
+|----------------------------|----------------|-----------------|-----------------|
+| Read file                  | direct         | direct          | direct          |
+| Write body                 | direct + fix   | direct + fix    | direct          |
+| Scaffold typed file        | n/a            | n/a             | `mdbase create` |
+| Validate FM shape          | `check` MDS020 | `check` MDS020  | `validate`      |
+| Rename + update refs       | manual         | manual          | `mdbase rename` |
+| Query collection           | `query` (CUE)  | `query` (CUE)   | `query` Bases   |
+| Block on broken links      | `check` MDS027 | `check` MDS027  | `validate`      |
+| File outline (LSP)         | no             | yes (plan 131)  | partial         |
+| Go-to-def on anchor link   | no             | yes (plan 131)  | yes             |
+| Find heading references    | no             | yes (plan 131)  | unknown         |
+| Workspace symbol search    | no             | yes (plan 131)  | unknown         |
+| Call hierarchy on includes | no             | yes (plan 131)  | no              |
+| Hover rule docs            | no             | yes (plan 122)  | n/a             |
+| Hover type / field         | no             | no              | yes             |
 
 For agent-driven docs work the two tools are
 complementary. mdsmith excels at "verify and fix
-content"; mdbase excels at "navigate and edit
-typed records."
+content" plus, after plan 131, "navigate the
+document graph"; mdbase excels at "navigate and
+edit typed records."
 
 ## 11. Onboarding a new contributor
 

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -559,7 +559,10 @@ edit typed records."
 The contributor:
 
 1. Clones the repo
-2. Runs `go install github.com/jeduden/mdsmith/cmd/mdsmith`
+2. Builds from the clone with
+   `go install ./cmd/mdsmith`, or pins a release
+   with
+   `go install github.com/jeduden/mdsmith/cmd/mdsmith@vX.Y.Z`
 3. Reads `.mdsmith.yml` (and CLAUDE.md if present)
 4. Runs `mdsmith check .` and fixes any drift
 5. Runs `mdsmith help <rule-id>` to read embedded

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -117,8 +117,10 @@ call hierarchy). The shipped LSP is
 diagnostic-and-fix only.
 
 What is planned: hover for rule and directive docs
-(plan 122) and full symbol navigation (plan 131,
-PR #238). After plan 131 lands, the editor session
+([plan 122][plan122w]) and full symbol navigation
+(plan 131, tracked in [PR #238][pr238w]; the plan
+file lives on that branch and is not yet on
+`main`). After plan 131 lands, the editor session
 also gets:
 
 - File outline (`documentSymbol`) following the
@@ -509,11 +511,12 @@ this surface, but differently.
   advertised in the project README at the time of
   writing.
 - **mdsmith** today exposes only diagnostics and
-  code actions over LSP. Plan 131 (PR #238) adds
-  `documentSymbol`, `definition`, `implementation`,
-  `references`, `workspace/symbol`, and call
-  hierarchy. The plan explicitly maps the nine
-  Claude-LSP methods onto the existing AST and
+  code actions over LSP. Plan 131 ([PR #238][pr238w];
+  the plan file is on that branch, not yet on
+  `main`) adds `documentSymbol`, `definition`,
+  `implementation`, `references`, `workspace/symbol`,
+  and call hierarchy. The plan explicitly maps the
+  nine Claude-LSP methods onto the existing AST and
   link graph.
 
 Once plan 131 lands, an agent can ask the mdsmith
@@ -600,7 +603,7 @@ the contributor must read top to bottom.
 | What's a file?                  | Text to lint and fix      | A typed record            |
 | What's metadata?                | YAML the rules read       | Effective FM + computed   |
 | Who validates?                  | Per-rule severity         | Per-mode (off/warn/error) |
-| Who creates?                    | Humans (mdsmith doesn't)  | mdsmith + `mdbase create` |
+| Who creates?                    | Humans (mdsmith doesn't)  | Humans or `mdbase create` |
 | Who renames?                    | `mv` + manual link fix    | `mdbase rename`           |
 | Who indexes?                    | No one (re-read each run) | SQLite (L6)               |
 | Who watches?                    | LSP per-session           | Watch mode (L6)           |
@@ -620,3 +623,6 @@ Both can be true of the same files at the same time.
 The combined workflow gets both: typed, queryable,
 rename-safe records that are also well-formed,
 readable, and have synced generated sections.
+
+[plan122w]: ../../../plan/122_vscode-hover-and-palette.md
+[pr238w]: https://github.com/jeduden/mdsmith/pull/238

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -600,7 +600,7 @@ the contributor must read top to bottom.
 | Config to read           | `.mdsmith.yml`                            | `mdbase.yaml` + `_types/`         |
 | Per-type docs            | `internal/rules/<id>/README.md` (in repo) | `_types/<name>.md` body (in repo) |
 | Inspect effective config | `mdsmith kinds`                           | `mdbase types --inspect`          |
-| Offline rule docs        | `mdsmith help <id>`                       | spec doc on github                |
+| Offline rule docs        | `mdsmith help <id>`                       | spec doc on GitHub                |
 
 ## 12. Mental model summary
 

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -168,21 +168,22 @@ complementary: mdsmith plan 131 gives the
 include/catalog graph; mdbase-lsp gives the
 typed-link graph.
 
-| Editor experience        | mdsmith today | mdsmith planned        | mdbase-lsp |
-|--------------------------|---------------|------------------------|------------|
-| Inline diagnostics       | yes           | yes                    | yes        |
-| Quick fix per diagnostic | yes           | yes                    | no         |
-| Fix all in file          | yes           | yes                    | no         |
-| Field-name completion    | no            | no                     | yes        |
-| Type-name hover          | no            | yes (rules/directives) | yes        |
-| Go-to type definition    | no            | partial (`kind:`)      | yes        |
-| Go-to anchor / heading   | no            | yes (plan 131)         | yes        |
-| Workspace symbol search  | no            | yes (plan 131)         | unknown    |
-| File outline             | no            | yes (plan 131)         | partial    |
-| Find references          | no            | yes (plan 131)         | unknown    |
-| Call hierarchy           | no            | yes (plan 131)         | no         |
-| Rename refactor          | no            | no                     | yes (L5)   |
-| Backlinks panel          | no            | yes (plan 131)         | yes (L5)   |
+| Editor experience        | mdsmith today | mdsmith planned   | mdbase-lsp |
+|--------------------------|---------------|-------------------|------------|
+| Inline diagnostics       | yes           | yes               | yes        |
+| Quick fix per diagnostic | yes           | yes               | no         |
+| Fix all in file          | yes           | yes               | no         |
+| Field-name completion    | no            | no                | yes        |
+| Rule / directive hover   | no            | yes (plan 122)    | n/a        |
+| Type / kind hover        | no            | no                | yes        |
+| Go-to type definition    | no            | partial (`kind:`) | yes        |
+| Go-to anchor / heading   | no            | yes (plan 131)    | yes        |
+| Workspace symbol search  | no            | yes (plan 131)    | unknown    |
+| File outline             | no            | yes (plan 131)    | partial    |
+| Find references          | no            | yes (plan 131)    | unknown    |
+| Call hierarchy           | no            | yes (plan 131)    | no         |
+| Rename refactor          | no            | no                | yes (L5)   |
+| Backlinks panel          | no            | yes (plan 131)    | yes (L5)   |
 
 ## 4. Schema evolution
 

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -3,7 +3,6 @@ summary: >-
   Way-of-working comparison — daily authoring, repo bootstrap, schema
   evolution, file rename, CI pipeline, editor session, Obsidian-vault
   use, LLM/agent workflows, contributor onboarding.
-status: 🔳
 ---
 # Way-of-working comparison
 

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -74,10 +74,12 @@ hook or CI). Diagnostics surface where the file
 violates rules; the user fixes them or lets
 `mdsmith fix` rewrite the body.
 
-mdsmith does not author files. There is no template
-mechanism beyond `<?required-structure?>` (which
-enforces a heading skeleton) and `<?include?>` /
-`<?catalog?>` (which fill in body content).
+mdsmith does not author files. The closest things
+to a template are MDS020's schema files (a
+`proto.md` whose body carries a heading skeleton
+that real files must match) and the `<?include?>`
+/ `<?catalog?>` directives (which fill in body
+content).
 
 **mdbase.**
 The user can either:

--- a/docs/research/mdbase-vs-mdsmith/workflows.md
+++ b/docs/research/mdbase-vs-mdsmith/workflows.md
@@ -13,7 +13,8 @@ feel like to do this work."
 
 ## 1. Bootstrap a new project
 
-**mdsmith.** mdsmith side:
+**mdsmith.** Init writes a default config; the
+first lint runs straight away.
 
 ```bash
 cd my-docs
@@ -27,7 +28,8 @@ on every `check`. Adding kinds, schemas, and
 overrides is opt-in — projects with no special needs
 never edit `.mdsmith.yml` after init.
 
-**mdbase.** mdbase side:
+**mdbase.** Init creates the collection skeleton;
+the first type comes next.
 
 ```bash
 cd my-collection
@@ -257,7 +259,8 @@ commit."
 
 ## 5. Rename a file
 
-**mdsmith.** mdsmith side:
+**mdsmith.** Plain `mv` plus a re-lint surfaces broken
+links; rewriting them is manual.
 
 ```bash
 mv docs/old-name.md docs/new-name.md
@@ -299,7 +302,8 @@ from mdbase here.
 
 ## 6. Find and select files
 
-**mdsmith.** mdsmith side:
+**mdsmith.** A CUE struct literal filters files by
+front matter.
 
 ```bash
 mdsmith query 'status: "✅"' plan/
@@ -310,7 +314,8 @@ The output is a list of file paths. Pipe into other
 tools as needed. There is no body search, no sort,
 no pagination.
 
-**mdbase.** mdbase side:
+**mdbase.** A query document carries `types`,
+`where`, sort and pagination.
 
 ```bash
 mdbase query '
@@ -390,7 +395,10 @@ issues; mdbase reports schema and link issues.
 
 ## 8. Pre-commit / pre-merge
 
-**mdsmith.** mdsmith side:
+**mdsmith.** Two installers wire git hooks: the
+pre-merge-commit runs `mdsmith fix` after a merge,
+and the merge driver auto-resolves conflicts inside
+generated sections.
 
 ```bash
 mdsmith pre-merge-commit install


### PR DESCRIPTION
## Summary

This PR adds a research folder (`docs/research/mdbase-vs-mdsmith/`) with **eight** comparison documents between mdsmith (a Go Markdown linter) and mdbase (a specification for typed, queryable Markdown collections, with TS and Rust reference implementations). Together they walk the conceptual differences, work through concrete scenarios, sketch how to combine the tools, and explore where mdsmith could evolve toward (or deliberately past) mdbase's design points.

## Documents added

- **README.md** — overview, TL;DR matrix, when-to-use table with a "candidate for the other side" column, status snapshot, the same-substrate-different-surfaces mental model, navigation
- **features.md** — feature-by-feature comparison covering distribution, configuration, type/kind systems, file matching, field types, validation, front matter, queries (with eight worked dual-syntax examples Q-A through Q-H), links, generated content (catalog/include/toc/build), prose linting, conventions, cache, CLI, LSP (today + plans 122/131), output formats, conformance, security, determinism
- **workflows.md** — way-of-working comparison: bootstrap, authoring, daily editor session, schema evolution, file rename, query, CI, pre-commit, Obsidian-vault use, LLM/agent workflows (with explicit Claude Code LSP-tool mapping), contributor onboarding
- **use-cases.md** — seven concrete worked scenarios (open-source repo, Obsidian vault, RFC tracker, task tracker, agent-maintained runbooks, knowledge graph, mixed wiki+plan tracker) plus a 3-axis scoring rubric (prose load × typed-record load × rename load)
- **interop.md** — running both tools on the same files: coexistence model, the dual-schema problem, four combination strategies (with explicit caveats on the partial routes), recommended folder layout, sample CI, future schema bridge sketch
- **learn-from-mdbase.md** — systematic enumeration of every mdbase capability mdsmith doesn't yet expose. Each gap gets a mini-plan with goal, sketch, surface, effort, and a **trigger** — the concrete condition under which shipping it becomes worth the cost. mdsmith's feature set is treated as open; the doc maps candidates rather than committing to any.
- **aggregation-use-cases.md** — six worked aggregation workloads with explicit operational-mode assumptions (cold-start vs long-lived-session) and per-use-case pre-conditions. Includes an analysis of what an index actually costs (sync-check overhead, OS file cache, background indexing with priority queries), a serious look at stateless-fast (`fzf` / `ripgrep`-style) approaches as an alternative, and grounded coverage of what the two reference impls (`mdbase` TS via sql.js, `mdbase-rs` Rust via rusqlite) actually do at the storage layer.
- **query-and-types.md** — in-depth comparison of the query languages (CUE struct literal vs Bases-compatible DSL) and the type systems. Walks what each tool actually types, how schemas compose, the expressiveness matrix between the two languages, and the answer to whether mdbase's type system is limited to front matter (almost — with two named exceptions: `path_pattern` filename templates and the Rust impl's `unique_values` cross-file table).

Plus a brief mdbase pointer in `docs/background/markdown-linters.md` with a concrete worked example showing what each tool does with the same `.md` file.

## Notable details

- All documents use `summary: >-` folded YAML scalar front matter to match repo convention (e.g. `docs/guides/file-kinds.md`); they intentionally omit `status:` since this is a research note, not a tracked plan, and other research docs in the repo (`docs/research/conciseness/`, `docs/research/corpus/`) follow the same pattern
- Extensive side-by-side comparison tables
- Code examples and YAML/CUE snippets for each major difference
- Spec section refs (e.g. "spec §4", "L1–L6") ground claims about mdbase
- Source citations: mdbase spec sections 0–15 and appendices A–D, version 0.2.1; TS reference impl `callumalpass/mdbase`; Rust reference impl `callumalpass/mdbase-rs`
- `mdsmith check .` passes on all 180 files

## Framing notes

- mdsmith and mdbase are not framed as having fixed scope. The shared on-disk substrate (FM, body, link graph) supports any of the use cases discussed; what differs is which surfaces each tool currently exposes, and at what cost.
- `learn-from-mdbase.md` does not assert "in-scope" or "out-of-scope" for any candidate. Each gap carries a trigger condition.
- `aggregation-use-cases.md` makes operational-mode assumptions explicit (cold-start CI vs long-lived editor session) so cost comparisons are like-with-like rather than mdbase-warm-vs-mdsmith-cold.
- Where mdsmith would close a gap, the candidate plans describe **native** mdsmith implementations, not workarounds via shell pipelines or external tools (no `pipe to ripgrep` etc.) — mdsmith's single-binary identity is preserved.

https://claude.ai/code/session_01MaUmRwLMk5UDoxe5twpqAV