### PR TITLE
Fix v0.13.0 release blockers: repo URL shape + pypa-publish docker pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,15 +190,22 @@ jobs:
         # Platform packages publish first so the root never advertises
         # an optionalDependency npm cannot find. The root package
         # publishes last, after every platform exists.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        #
+        # Auth uses npm Trusted Publishing (OIDC): the workflow's
+        # `id-token: write` permission mints an OIDC token that npm
+        # exchanges for a short-lived publish credential. No
+        # NODE_AUTH_TOKEN required. Each of the six packages
+        # (@mdsmith/cli + 5 platform subpackages) needs a Trusted
+        # Publisher configured at
+        # https://www.npmjs.com/package/<name>/access (or, for
+        # packages that don't exist yet, as a "pending publisher"
+        # at https://www.npmjs.com/settings/<user>/trusted-publishers)
+        # pointing at jeduden/mdsmith and release.yml.
         run: |
           for pkg in npm/dist/*; do
             (cd "$pkg" && npm publish --access public --provenance)
           done
       - name: Publish root package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: npm/mdsmith
         run: npm publish --access public --provenance
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Build platform wheels
         run: go run ./cmd/mdsmith-release build-wheels artifacts python/dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: python/dist
 

--- a/internal/release/buildnpm.go
+++ b/internal/release/buildnpm.go
@@ -75,7 +75,7 @@ func (t *Toolkit) buildOneNpmPlatform(rootDir, artifactsDir, outDir, version str
   "homepage": "https://github.com/jeduden/mdsmith",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jeduden/mdsmith"
+    "url": "git+https://github.com/jeduden/mdsmith.git"
   },
   "os": ["%s"],
   "cpu": ["%s"],

--- a/internal/release/buildnpm_test.go
+++ b/internal/release/buildnpm_test.go
@@ -38,17 +38,29 @@ func assertPlatformPackage(t *testing.T, out, dir, bin, expectedOS, expectedCPU,
 	require.NoError(t, err, "read %s", manifest)
 
 	var pkg struct {
-		Name    string   `json:"name"`
-		Version string   `json:"version"`
-		OS      []string `json:"os"`
-		CPU     []string `json:"cpu"`
-		Files   []string `json:"files"`
+		Name       string   `json:"name"`
+		Version    string   `json:"version"`
+		OS         []string `json:"os"`
+		CPU        []string `json:"cpu"`
+		Files      []string `json:"files"`
+		Repository struct {
+			Type string `json:"type"`
+			URL  string `json:"url"`
+		} `json:"repository"`
 	}
 	require.NoError(t, json.Unmarshal(body, &pkg), "decode %s", manifest)
 	assert.Equal(t, "@mdsmith/"+dir, pkg.Name, "%s name", manifest)
 	assert.Equal(t, expectedVer, pkg.Version, "%s version", manifest)
 	assert.Equal(t, []string{expectedOS}, pkg.OS, "%s os", manifest)
 	assert.Equal(t, []string{expectedCPU}, pkg.CPU, "%s cpu", manifest)
+	// repository.url uses the `git+https://…/repo.git` shape so
+	// `npm publish` doesn't normalise it (and warn) at upload
+	// time. A bare `https://github.com/...` URL trips the
+	// "auto-corrected" warning and a future npm version may
+	// outright reject it.
+	assert.Equal(t, "git", pkg.Repository.Type, "%s repository.type", manifest)
+	assert.Equal(t, "git+https://github.com/jeduden/mdsmith.git", pkg.Repository.URL,
+		"%s repository.url", manifest)
 }
 
 func TestBuildNpmPlatformsLayout(t *testing.T) {

--- a/npm/mdsmith/package.json
+++ b/npm/mdsmith/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/jeduden/mdsmith",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jeduden/mdsmith"
+    "url": "git+https://github.com/jeduden/mdsmith.git"
   },
   "keywords": [
     "markdown",


### PR DESCRIPTION
## Summary

Three failures from the v0.13.0 tag run, each addressed below:

1. **npm `repository.url` warning** — npm normalised the bare `https://github.com/jeduden/mdsmith` URL to `git+https://github.com/jeduden/mdsmith.git` and warned the publisher to fix it. Update the platform-package template (`internal/release/buildnpm.go`) and the npm root manifest (`npm/mdsmith/package.json`) to use the canonical shape, and add a regression assertion in `TestBuildNpmPlatformsLayout`.
2. **pypa/gh-action-pypi-publish docker pull failed** — the action's docker image at `ghcr.io/pypa/gh-action-pypi-publish:6733eb7d…` doesn't exist. pypa only tags the docker image at the SHA pointed to by their `release/v1` branch, not at every git tag SHA. Re-pin from the v1.14.0 tag SHA to the current `release/v1` HEAD (`cef22109`) so the image lookup succeeds.
3. **npm `EOTP` (account 2FA OTP required)** — switch the npm publish to **Trusted Publishing (OIDC)** instead of the classic Automation token. The workflow drops `NODE_AUTH_TOKEN` from both publish steps; auth flows through the existing `id-token: write` permission and the `--provenance` flag. The npm CLI exchanges the GitHub OIDC token for a short-lived publish credential. Removes the OTP failure mode entirely and lets us delete `NPM_TOKEN` from the repo secrets.

## Pre-tag setup needed (npm side)

For each of the six packages, configure a Trusted Publisher on npmjs.com:

- `@mdsmith/cli`, `@mdsmith/linux-x64`, `@mdsmith/linux-arm64`, `@mdsmith/darwin-x64`, `@mdsmith/darwin-arm64`, `@mdsmith/win32-x64`

Per package: <https://www.npmjs.com/package/PACKAGE/access> → **Trusted Publishers** → Add → GitHub Actions, repo `jeduden/mdsmith`, workflow `release.yml`, environment blank.

For the **packages that don't exist yet** (the platform subpackages — v0.13.0 only got as far as `@mdsmith/darwin-arm64` before failing on OTP), use **Pending Trusted Publishers** instead:

<https://www.npmjs.com/settings/jeduden/trusted-publishers> → Add → fill in the package name + the same GitHub Actions / repo / workflow fields. The pending entry converts to a regular Trusted Publisher on first successful publish.

After both steps are done, retag (e.g. `v0.13.1`) and the full pipeline should succeed end-to-end without any `NPM_TOKEN`.

## Test plan

- [x] `go test ./internal/release/...` passes.
- [x] `mdsmith check .` is clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` validates the workflow.

https://claude.ai/code/session_015MPUo4nJ4iySQES6J3ByQ6