### PR TITLE
Improve security of merge-queue workflow token handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           sarif_file: results.sarif
+      # `zizmor --format sarif` always exits 0 so the SARIF reaches
+      # the upload step. Re-run in text mode after the upload to
+      # exit 13 on any finding, which fails the job and blocks the
+      # PR. Use if: always() so a fork PR (where the upload step is
+      # skipped) still gates on findings.
+      - name: Fail on findings
+        if: always()
+        run: zizmor .
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -16,8 +16,9 @@ concurrency:
   group: merge-queue
   cancel-in-progress: false
 
-# The queue job authenticates via MERGE_QUEUE_TOKEN; the default
-# GITHUB_TOKEN only needs contents: read for the initial checkout.
+# Only merge-queue-action below needs MERGE_QUEUE_TOKEN's elevated
+# scope; the rest of the job runs under the default GITHUB_TOKEN
+# capped at read-only.
 permissions:
   contents: read
 
@@ -28,11 +29,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.MERGE_QUEUE_TOKEN }}
-          # Don't write the token to .git/config — merge-queue-action
-          # consumes it via its own `token` input below, so persisting
-          # is unnecessary and would leak credentials into any later
-          # step that runs git.
+          # Default GITHUB_TOKEN (constrained by the permissions: block
+          # above) is enough for read-only checkout. MERGE_QUEUE_TOKEN
+          # stays scoped to the merge-queue-action step that actually
+          # needs branch-protection bypass.
           persist-credentials: false
 
       - name: Install mdsmith merge driver and pre-merge-commit hook

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -16,6 +16,11 @@ concurrency:
   group: merge-queue
   cancel-in-progress: false
 
+# The queue job authenticates via MERGE_QUEUE_TOKEN; the default
+# GITHUB_TOKEN only needs contents: read for the initial checkout.
+permissions:
+  contents: read
+
 jobs:
   queue:
     runs-on: ubuntu-latest
@@ -24,6 +29,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+          # Don't write the token to .git/config — merge-queue-action
+          # consumes it via its own `token` input below, so persisting
+          # is unnecessary and would leak credentials into any later
+          # step that runs git.
+          persist-credentials: false
 
       - name: Install mdsmith merge driver and pre-merge-commit hook
         env:


### PR DESCRIPTION
## Summary
This change enhances the security posture of the merge-queue workflow by implementing explicit permission scoping and preventing credential persistence in git configuration.

## Key Changes
- **Added explicit permissions block**: Declares that the workflow only requires `contents: read` permission for the initial checkout, following the principle of least privilege
- **Disabled credential persistence**: Set `persist-credentials: false` in the checkout action to prevent the `MERGE_QUEUE_TOKEN` from being written to `.git/config`

## Implementation Details
The `MERGE_QUEUE_TOKEN` is consumed directly by the merge-queue-action via its own `token` input parameter, making it unnecessary to persist credentials in git configuration. By disabling persistence, we prevent the token from being exposed to subsequent workflow steps that might execute git commands, reducing the attack surface and limiting credential exposure.

The explicit permissions declaration also ensures that if the workflow is compromised, the damage is limited to read-only access to repository contents, as the token used for merge operations is managed separately through the dedicated secret.

https://claude.ai/code/session_01GgxHEWjX7hWvF6Teob2HJB