### PR TITLE
release: harden supply chain with CGO=0, SLSA provenance, cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,16 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          # Force a static binary on every target. Cross-compiles
-          # auto-disable CGO, but the native linux/amd64 build
-          # would otherwise pull in glibc-resolved net and
-          # os/user, breaking the manylinux_2_17 wheel and the
-          # @mdsmith/linux-x64 npm package on Alpine/musl and
-          # systems with glibc older than the wheel tag claims.
+          # Disable cgo so the native linux/amd64 build resolves
+          # net and os/user purely in Go. Cross-compiles already
+          # auto-disable CGO; the native build would otherwise
+          # bind glibc's resolver into the binary, breaking the
+          # manylinux_2_17 wheel and the @mdsmith/linux-x64 npm
+          # package on Alpine/musl and on systems whose glibc is
+          # older than the wheel tag claims. macOS and Windows
+          # binaries still link the platform syscall layer
+          # (libSystem, kernel32) — this knob is about avoiding
+          # glibc on Linux, not achieving full static linkage.
           CGO_ENABLED: "0"
           VERSION: ${{ github.ref_name }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,13 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          # Force a static binary on every target. Cross-compiles
+          # auto-disable CGO, but the native linux/amd64 build
+          # would otherwise pull in glibc-resolved net and
+          # os/user, breaking the manylinux_2_17 wheel and the
+          # @mdsmith/linux-x64 npm package on Alpine/musl and
+          # systems with glibc older than the wheel tag claims.
+          CGO_ENABLED: "0"
           VERSION: ${{ github.ref_name }}
         run: |
           ext=""
@@ -278,14 +285,56 @@ jobs:
   release:
     needs: [build, vscode]
     runs-on: ubuntu-latest
+    # `id-token: write` mints the OIDC token that
+    # `actions/attest-build-provenance` and `cosign sign-blob`
+    # exchange for a short-lived Sigstore credential. No
+    # long-lived secrets. `attestations: write` is the dedicated
+    # scope the GitHub attestations API gates the
+    # provenance upload on.
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           merge-multiple: true
       - name: Create checksums
         run: sha256sum mdsmith-* > checksums.txt
+      - name: Generate SLSA build provenance
+        # Attests every binary the build matrix produced (and the
+        # .vsix the vscode job uploaded — `mdsmith-*` matches both).
+        # Each attestation ties the file's SHA-256 back to this
+        # workflow run and the commit it was built from. Consumers
+        # verify with:
+        #   gh attestation verify mdsmith-<plat> -R jeduden/mdsmith
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: "mdsmith-*"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign checksums with cosign
+        # Keyless Sigstore signature on the checksum file. The
+        # GitHub OIDC token binds the signature to this exact
+        # workflow file at this exact tag, so an attacker who
+        # rewrites checksums.txt on the release page can't also
+        # forge a matching signature without compromising
+        # release.yml on this repo. Verify with:
+        #   cosign verify-blob \
+        #     --certificate checksums.txt.pem \
+        #     --signature checksums.txt.sig \
+        #     --certificate-identity-regexp \
+        #       "^https://github.com/jeduden/mdsmith/.github/workflows/release.yml@" \
+        #     --certificate-oidc-issuer \
+        #       https://token.actions.githubusercontent.com \
+        #     checksums.txt
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign-blob \
+            --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem \
+            checksums.txt
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -295,6 +344,8 @@ jobs:
           files: |
             mdsmith-*
             checksums.txt
+            checksums.txt.sig
+            checksums.txt.pem
 
   smoke-test:
     # Wait until every channel is on the new version before checking

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -130,11 +130,18 @@ move the binary onto `$PATH`:
 
 ```bash
 base="https://github.com/jeduden/mdsmith/releases/latest/download"
-curl -L -o mdsmith       "$base/mdsmith-linux-amd64"
-curl -L -o checksums.txt "$base/checksums.txt"
+curl -L -o mdsmith-linux-amd64 "$base/mdsmith-linux-amd64"
+curl -L -o checksums.txt       "$base/checksums.txt"
 sha256sum -c <(grep mdsmith-linux-amd64 checksums.txt)
-install -m 0755 mdsmith /usr/local/bin/mdsmith
+install -m 0755 mdsmith-linux-amd64 /usr/local/bin/mdsmith
 ```
+
+Keep the binary saved under its release-asset name
+(`mdsmith-linux-amd64`) until verification is done —
+both `sha256sum -c` and `gh attestation verify` below
+match local files against that exact name. `install`
+copies the file rather than moving it, so the original
+remains for the verification steps.
 
 For supply-chain-sensitive deployments, the release
 also ships a SLSA build provenance attestation per

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -136,6 +136,36 @@ sha256sum -c <(grep mdsmith-linux-amd64 checksums.txt)
 install -m 0755 mdsmith /usr/local/bin/mdsmith
 ```
 
+For supply-chain-sensitive deployments, the release
+also ships a SLSA build provenance attestation per
+binary and a Sigstore signature on `checksums.txt`.
+Verify the provenance with `gh`:
+
+```bash
+gh attestation verify mdsmith-linux-amd64 \
+  -R jeduden/mdsmith
+```
+
+Verify the checksums-file signature with `cosign`:
+
+```bash
+curl -L -o checksums.txt.sig "$base/checksums.txt.sig"
+curl -L -o checksums.txt.pem "$base/checksums.txt.pem"
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature   checksums.txt.sig \
+  --certificate-identity-regexp \
+    "^https://github.com/jeduden/mdsmith/.github/workflows/release.yml@" \
+  --certificate-oidc-issuer \
+    https://token.actions.githubusercontent.com \
+  checksums.txt
+```
+
+Both verifications resolve through the workflow's
+GitHub OIDC identity, so a forged binary or rewritten
+checksums file fails verification unless the attacker
+also controls `release.yml` on `jeduden/mdsmith`.
+
 This path is also the documented fallback if any of
 the package channels above is unavailable on a given
 day.


### PR DESCRIPTION
## Summary

Closes the four supply-chain gaps from the binary-delivery research:

- **`CGO_ENABLED=0`** on the build matrix — the native linux/amd64 build was the only target where CGO was implicitly on, which links glibc-resolved `net` and `os/user`. The manylinux_2_17 wheel and the `@mdsmith/linux-x64` npm package both claim portability that breaks on Alpine/musl and old-glibc systems without this.
- **SLSA build provenance** via `actions/attest-build-provenance@v4.1.0` over `mdsmith-*` (the 5 binaries + the `.vsix`). Verifiable with `gh attestation verify <file> -R jeduden/mdsmith`.
- **Cosign keyless signature** on `checksums.txt` via `sigstore/cosign-installer@v4.1.2` and `cosign sign-blob`. The `.sig` and `.pem` ride along on the GitHub release. Defends against the case where an attacker who can replace a binary on the release page also rewrites `checksums.txt` — forging a valid signature on a rewritten checksum would require compromising `release.yml` on this repo.
- **`pypa/gh-action-pypi-publish` pin verified** as `cef2210` = **v1.14.0**, well past v1.11.0 when PEP 740 attestations became the default. No bump needed.

`docs/guides/install.md` gets a verification snippet for both `gh attestation verify` and `cosign verify-blob` so users actually have a path to use the new artifacts.

## Changes

| File | What |
|---|---|
| `.github/workflows/release.yml` | `CGO_ENABLED=0` env on build job; `id-token: write` + `attestations: write` perms on release job; provenance + cosign steps; `.sig`/`.pem` in release upload |
| `docs/guides/install.md` | Verification commands for provenance and cosign signature |

## Test plan

- [ ] YAML parses (verified locally: `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] `mdsmith check docs/guides/install.md` passes (verified locally)
- [ ] First real validation is the next `v*` tag — the workflow is tag-triggered. Consider cutting a `v0.13.2-rc1` pre-release first to catch any cosign / attestation config issues before a regular release.
- [ ] After release: confirm `gh attestation verify mdsmith-linux-amd64 -R jeduden/mdsmith` returns success
- [ ] After release: confirm `cosign verify-blob` against the published `.pem`/`.sig` succeeds

## Notes

- The `mdsmith-*` glob in `subject-path` intentionally includes the `.vsix` (since the vscode artifact is named `mdsmith-VERSION.vsix` and `download-artifact` flattens names with `merge-multiple: true`). Attesting the extension is a bonus, not a problem.
- macOS notarization is intentionally out of scope per the task spec — Gatekeeper warnings on first launch remain a known friction point separate from this PR.
- No SBOM in this PR — also out of scope per spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYJgXNFY33SD7czsGPXN1P)_