### PR TITLE
Add gh-resolve-threads skill and update PR workflow docs

### DIFF
--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -16,10 +16,6 @@ user-invocable: true
 allowed-tools: >-
   Bash(gh pr:*), Bash(gh api:*), Bash(gh auth:*),
   Bash(gh --version:*),
-  Bash(curl:*), Bash(sha256sum:*), Bash(tar:*),
-  Bash(cp:*),
-  Bash(apt-get:*), Bash(wget:*), Bash(tee:*),
-  Bash(mkdir:*), Bash(dpkg:*), Bash(type:*),
   Bash(git push:*), Bash(git add:*),
   Bash(git commit:*), Bash(git branch:*)
 ---
@@ -162,30 +158,49 @@ If both fail, the user needs to allow
 `release-assets.githubusercontent.com` or
 `cli.github.com` in their network config.
 
-Authenticate if needed:
+Authenticate if needed. First check status:
 
 ```bash
 gh auth status
 ```
 
+If unauthenticated, log in. With a token in the
+environment:
+
 ```bash
 gh auth login --with-token <<< "${GITHUB_TOKEN}"
 ```
 
-## Step 2 — Identify PR and repo
+If `GITHUB_TOKEN` is not set, run the interactive
+flow instead and follow the prompts:
+
+```bash
+gh auth login
+```
+
+## Step 2 — Identify PR, owner, and repo
 
 ```bash
 gh pr view --json number -q '.number'
 ```
 
-Note the number as `$PR`. Then:
+Note the number as `$PR`. Then fetch the head repo
+owner and name as separate values (matching
+`/merge-queue`):
+
+```bash
+gh pr view --json headRepositoryOwner \
+  -q '.headRepositoryOwner.login'
+```
+
+Note the result as `$OWNER`. Then:
 
 ```bash
 gh pr view --json headRepository \
-  -q '.headRepository.owner.login + "/" + .headRepository.name'
+  -q '.headRepository.name'
 ```
 
-Note the repo (e.g. `owner/name`) as `$REPO`.
+Note the result as `$REPO`.
 
 ## Step 3 — Fetch review threads
 
@@ -215,7 +230,7 @@ query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
       }
     }
   }
-}' -f owner="${REPO%%/*}" -f repo="${REPO##*/}" -F pr="$PR"
+}' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR"
 ```
 
 Returns the first 100 threads (10 comments each). If
@@ -246,7 +261,7 @@ query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
       }
     }
   }
-}' -f owner="${REPO%%/*}" -f repo="${REPO##*/}" \
+}' -f owner="$OWNER" -f repo="$REPO" \
    -F pr="$PR" -f cursor="<endCursor>"
 ```
 
@@ -285,7 +300,7 @@ bot looks at the latest commit:
 
 ```bash
 gh api --method POST \
-  "repos/$REPO/pulls/$PR/requested_reviewers" \
+  "repos/$OWNER/$REPO/pulls/$PR/requested_reviewers" \
   -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 

--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -78,8 +78,19 @@ from the same checksums file before downloading.
 tar xz -C /tmp -f /tmp/gh.tar.gz
 ```
 
+Copy the binary into a directory on `$PATH`. Use
+`/usr/local/bin/gh` for a system-wide install (needs
+root):
+
 ```bash
 cp /tmp/gh_2.92.0_linux_amd64/bin/gh /usr/local/bin/gh
+```
+
+Or use `$HOME/.local/bin/gh` for a user-local install
+(no root needed; ensure that directory is on `$PATH`):
+
+```bash
+cp /tmp/gh_2.92.0_linux_amd64/bin/gh "$HOME/.local/bin/gh"
 ```
 
 ```bash
@@ -118,13 +129,15 @@ Print the architecture in its own block:
 dpkg --print-architecture
 ```
 
-Note the value (e.g. `amd64`) as `$ARCH`. Then write
-the sources list. The heredoc references `$ARCH` from
-your shell — no command substitution runs inside:
+Substitute the printed value (e.g. `amd64`) for
+`ARCH_PLACEHOLDER` in the heredoc below before
+running. The `<<'EOF'` quoting prevents any shell
+expansion inside the body — the literal text after
+substitution is what gets written:
 
 ```bash
-tee /etc/apt/sources.list.d/github-cli.list > /dev/null <<EOF
-deb [arch=$ARCH signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
+tee /etc/apt/sources.list.d/github-cli.list > /dev/null <<'EOF'
+deb [arch=ARCH_PLACEHOLDER signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
 EOF
 ```
 
@@ -167,12 +180,16 @@ Note the repo (e.g. `owner/name`) as `$REPO`.
 
 ## Step 3 — Fetch review threads
 
+The query accepts an optional `$cursor` variable so
+the same snippet works for both the first page and
+subsequent pages:
+
 ```bash
 gh api graphql -f query='
-query($owner: String!, $repo: String!, $pr: Int!) {
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -193,10 +210,39 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 ```
 
 Returns the first 100 threads (10 comments each). If
-`pageInfo.hasNextPage` is `true`, paginate by passing
-the returned `endCursor` as an `after:` argument until
-it is `false` — otherwise unresolved threads beyond the
-first 100 will be silently omitted.
+`pageInfo.hasNextPage` is `true`, rerun the same call
+with `-f cursor="<endCursor>"` appended (using the
+`endCursor` returned in the previous response). Repeat
+until `hasNextPage` is `false`:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              body
+              author { login }
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="${REPO%%/*}" -f repo="${REPO##*/}" \
+   -F pr="$PR" -f cursor="<endCursor>"
+```
+
+Otherwise unresolved threads beyond the first 100 are
+silently omitted.
 
 For each unresolved thread, note its `id` and read the
 comment at `comments.nodes[0]` to understand what to

--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: gh-resolve-threads
 description: >-
-  Resolve pull request review threads using the gh
-  CLI. MUST use this skill whenever you need to
+  Canonical workflow for resolving pull request review
+  threads via the gh CLI — single source of truth that
+  other skills (e.g. pr-fixup) should defer to instead
+  of duplicating. MUST use whenever you need to
   resolve, fetch, or interact with PR review threads.
   GitHub MCP CANNOT resolve review threads and CANNOT
   retrieve thread IDs — do NOT attempt GitHub MCP for
@@ -10,8 +12,6 @@ description: >-
   threads", "mark as resolved", "address review
   comments", "clean up the PR", "which comments are
   still open", or any reference to PR review feedback.
-  If already in the pr-fixup skill, still follow these
-  steps for thread resolution — do not improvise.
 user-invocable: true
 allowed-tools: >-
   Bash(gh pr:*), Bash(gh api:*), Bash(gh auth:*),
@@ -87,15 +87,19 @@ cp /tmp/gh_2.92.0_linux_amd64/bin/gh /usr/local/bin/gh
 ```
 
 Or use `$HOME/.local/bin/gh` for a user-local install
-(no root needed; ensure that directory is on `$PATH`):
+(no root needed; ensure that directory is on `$PATH`).
+Make sure the directory exists first:
+
+```bash
+mkdir -p "$HOME/.local/bin"
+```
 
 ```bash
 cp /tmp/gh_2.92.0_linux_amd64/bin/gh "$HOME/.local/bin/gh"
 ```
 
-```bash
-gh auth login --with-token <<< "${GITHUB_TOKEN}"
-```
+Authentication is handled by the trailing
+"Authenticate if needed" block.
 
 If that fails (redirect blocked), try apt. Each line
 is its own Bash call:
@@ -104,8 +108,13 @@ is its own Bash call:
 type -p wget >/dev/null
 ```
 
-If that exits non-zero, install wget first (separate
-block so `apt-get` is the leading command):
+If that exits non-zero, refresh the package index then
+install wget (separate blocks so each leading command
+is allowlisted):
+
+```bash
+apt-get update
+```
 
 ```bash
 apt-get install wget -y

--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -90,21 +90,41 @@ If that fails (redirect blocked), try apt. Each line
 is its own Bash call:
 
 ```bash
-type -p wget >/dev/null || apt-get install wget -y
+type -p wget >/dev/null
+```
+
+If that exits non-zero, install wget first (separate
+block so `apt-get` is the leading command):
+
+```bash
+apt-get install wget -y
 ```
 
 ```bash
 mkdir -p -m 755 /etc/apt/keyrings
 ```
 
+Download the keyring directly to its destination
+(no pipe, single-command):
+
 ```bash
-wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+wget -q -O /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  https://cli.github.com/packages/githubcli-archive-keyring.gpg
 ```
+
+Print the architecture in its own block:
+
+```bash
+dpkg --print-architecture
+```
+
+Note the value (e.g. `amd64`) as `$ARCH`. Then write
+the sources list. The heredoc references `$ARCH` from
+your shell — no command substitution runs inside:
 
 ```bash
 tee /etc/apt/sources.list.d/github-cli.list > /dev/null <<EOF
-deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
+deb [arch=$ARCH signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
 EOF
 ```
 
@@ -196,7 +216,13 @@ git commit -m "fix: address review comments"
 ```
 
 ```bash
-git push origin "$(git branch --show-current)"
+git branch --show-current
+```
+
+Note the branch as `$BRANCH`. Then:
+
+```bash
+git push origin "$BRANCH"
 ```
 
 After every push, request a Copilot re-review so the

--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -16,6 +16,10 @@ user-invocable: true
 allowed-tools: >-
   Bash(gh pr:*), Bash(gh api:*), Bash(gh auth:*),
   Bash(gh --version:*),
+  Bash(curl:*), Bash(sha256sum:*), Bash(tar:*),
+  Bash(cp:*),
+  Bash(apt-get:*), Bash(wget:*), Bash(tee:*),
+  Bash(mkdir:*), Bash(dpkg:*), Bash(type:*),
   Bash(git push:*), Bash(git add:*),
   Bash(git commit:*), Bash(git branch:*)
 ---
@@ -88,15 +92,17 @@ echo "${GITHUB_TOKEN}" | gh auth login --with-token
 ## Step 2 — Identify PR and repo
 
 ```bash
-PR=$(gh pr view --json number -q '.number')
-echo "PR: $PR"
+gh pr view --json number -q '.number'
 ```
 
+Note the number as `$PR`. Then:
+
 ```bash
-REPO=$(gh pr view --json headRepository \
-  -q '.headRepository.owner.login + "/" + .headRepository.name')
-echo "Repo: $REPO"
+gh pr view --json headRepository \
+  -q '.headRepository.owner.login + "/" + .headRepository.name'
 ```
+
+Note the repo (e.g. `owner/name`) as `$REPO`.
 
 ## Step 3 — Fetch review threads
 
@@ -106,6 +112,7 @@ query($owner: String!, $repo: String!, $pr: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
@@ -123,6 +130,12 @@ query($owner: String!, $repo: String!, $pr: Int!) {
   }
 }' -f owner="${REPO%%/*}" -f repo="${REPO##*/}" -F pr="$PR"
 ```
+
+Returns the first 100 threads (10 comments each). If
+`pageInfo.hasNextPage` is `true`, paginate by passing
+the returned `endCursor` as an `after:` argument until
+it is `false` — otherwise unresolved threads beyond the
+first 100 will be silently omitted.
 
 For each unresolved thread, note its `id` and read the
 comment at `comments.nodes[0]` to understand what to

--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -40,22 +40,33 @@ PR's branch.
 gh --version
 ```
 
-If missing, install from GitHub releases. The block
-below downloads `gh` v2.92.0 and verifies the
-published SHA256 before extracting:
+If missing, install `gh` v2.92.0 from GitHub releases.
+Run each block as its own Bash call so allowlist
+prefix matching keeps working — every command starts
+with an allowed prefix, with no leading shell
+assignment, subshell, or `echo` pipe.
+
+Download the linux_amd64 tarball:
 
 ```bash
-GH_VERSION=2.92.0
-# Hash for gh_${GH_VERSION}_linux_amd64.tar.gz from
-# https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_checksums.txt
-GH_SHA256=b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4
 curl -fsSL --max-time 600 \
-  "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+  "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_amd64.tar.gz" \
   -o /tmp/gh.tar.gz
-echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c -
-tar xz -C /tmp -f /tmp/gh.tar.gz
-cp /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh
-echo "${GITHUB_TOKEN}" | gh auth login --with-token
+```
+
+Verify the SHA256 before extracting. The hash below
+matches the published checksums at this URL:
+
+```text
+https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_checksums.txt
+```
+
+The heredoc keeps `sha256sum` as the leading command:
+
+```bash
+sha256sum -c - <<'EOF'
+b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4  /tmp/gh.tar.gz
+EOF
 ```
 
 If `sha256sum -c` reports a mismatch, stop and report
@@ -63,16 +74,46 @@ the failure — do not run the unverified binary. For
 non-amd64 Linux or macOS, fetch the matching hash
 from the same checksums file before downloading.
 
-If that fails (redirect blocked), try apt:
+```bash
+tar xz -C /tmp -f /tmp/gh.tar.gz
+```
 
 ```bash
-(type -p wget >/dev/null || apt-get install wget -y)
+cp /tmp/gh_2.92.0_linux_amd64/bin/gh /usr/local/bin/gh
+```
+
+```bash
+gh auth login --with-token <<< "${GITHUB_TOKEN}"
+```
+
+If that fails (redirect blocked), try apt. Each line
+is its own Bash call:
+
+```bash
+type -p wget >/dev/null || apt-get install wget -y
+```
+
+```bash
 mkdir -p -m 755 /etc/apt/keyrings
+```
+
+```bash
 wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-apt-get update && apt-get install gh -y
+```
+
+```bash
+tee /etc/apt/sources.list.d/github-cli.list > /dev/null <<EOF
+deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main
+EOF
+```
+
+```bash
+apt-get update
+```
+
+```bash
+apt-get install gh -y
 ```
 
 If both fail, the user needs to allow
@@ -86,7 +127,7 @@ gh auth status
 ```
 
 ```bash
-echo "${GITHUB_TOKEN}" | gh auth login --with-token
+gh auth login --with-token <<< "${GITHUB_TOKEN}"
 ```
 
 ## Step 2 — Identify PR and repo

--- a/.claude/skills/gh-resolve-threads/SKILL.md
+++ b/.claude/skills/gh-resolve-threads/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: gh-resolve-threads
+description: >-
+  Resolve pull request review threads using the gh
+  CLI. MUST use this skill whenever you need to
+  resolve, fetch, or interact with PR review threads.
+  GitHub MCP CANNOT resolve review threads and CANNOT
+  retrieve thread IDs — do NOT attempt GitHub MCP for
+  anything thread-related. Trigger on "resolve
+  threads", "mark as resolved", "address review
+  comments", "clean up the PR", "which comments are
+  still open", or any reference to PR review feedback.
+  If already in the pr-fixup skill, still follow these
+  steps for thread resolution — do not improvise.
+user-invocable: true
+allowed-tools: >-
+  Bash(gh pr:*), Bash(gh api:*), Bash(gh auth:*),
+  Bash(gh --version:*),
+  Bash(git push:*), Bash(git add:*),
+  Bash(git commit:*), Bash(git branch:*)
+---
+
+# Resolve PR Review Threads via `gh` CLI
+
+GitHub MCP cannot resolve threads or retrieve thread
+IDs. Use `gh` CLI and GraphQL as described below. Run
+each fenced block as its own Bash call — do not chain
+with `&&`.
+
+**Prerequisite:** You must be inside a git repo on the
+PR's branch.
+
+## Step 1 — Ensure `gh` is installed and authenticated
+
+```bash
+gh --version
+```
+
+If missing, install from GitHub releases. The block
+below downloads `gh` v2.92.0 and verifies the
+published SHA256 before extracting:
+
+```bash
+GH_VERSION=2.92.0
+# Hash for gh_${GH_VERSION}_linux_amd64.tar.gz from
+# https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_checksums.txt
+GH_SHA256=b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4
+curl -fsSL --max-time 600 \
+  "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+  -o /tmp/gh.tar.gz
+echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c -
+tar xz -C /tmp -f /tmp/gh.tar.gz
+cp /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
+```
+
+If `sha256sum -c` reports a mismatch, stop and report
+the failure — do not run the unverified binary. For
+non-amd64 Linux or macOS, fetch the matching hash
+from the same checksums file before downloading.
+
+If that fails (redirect blocked), try apt:
+
+```bash
+(type -p wget >/dev/null || apt-get install wget -y)
+mkdir -p -m 755 /etc/apt/keyrings
+wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+apt-get update && apt-get install gh -y
+```
+
+If both fail, the user needs to allow
+`release-assets.githubusercontent.com` or
+`cli.github.com` in their network config.
+
+Authenticate if needed:
+
+```bash
+gh auth status
+```
+
+```bash
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
+```
+
+## Step 2 — Identify PR and repo
+
+```bash
+PR=$(gh pr view --json number -q '.number')
+echo "PR: $PR"
+```
+
+```bash
+REPO=$(gh pr view --json headRepository \
+  -q '.headRepository.owner.login + "/" + .headRepository.name')
+echo "Repo: $REPO"
+```
+
+## Step 3 — Fetch review threads
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 10) {
+            nodes {
+              body
+              author { login }
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="${REPO%%/*}" -f repo="${REPO##*/}" -F pr="$PR"
+```
+
+For each unresolved thread, note its `id` and read the
+comment at `comments.nodes[0]` to understand what to
+fix and where.
+
+## Step 4 — Address comments, commit, push
+
+Make the code changes for each unresolved thread. Skip
+threads you cannot or should not address. Then:
+
+```bash
+git add -A
+```
+
+```bash
+git commit -m "fix: address review comments"
+```
+
+```bash
+git push origin "$(git branch --show-current)"
+```
+
+After every push, request a Copilot re-review so the
+bot looks at the latest commit:
+
+```bash
+gh api --method POST \
+  "repos/$REPO/pulls/$PR/requested_reviewers" \
+  -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+```
+
+## Step 5 — Resolve addressed threads
+
+For each thread you addressed, resolve it using its
+`id` from step 3:
+
+```bash
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}' -f threadId="THREAD_NODE_ID"
+```
+
+Resolve one at a time. Do NOT resolve threads you did
+not address.
+
+## Step 6 — Verify
+
+Re-run the step 3 query. Confirm addressed threads
+show `"isResolved": true`. Report to the user what
+was resolved and what remains open.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,7 +84,7 @@ re-review (the skills do this automatically).
 When implementing work tracked by `plan/`:
 
 - Update the plan file **as part of the
-  implementation**, not as follow-up
+  implementation**, not as a follow-up
 - Check off each task and acceptance criterion as it
   is completed or verified
 - Move front-matter `status` from `🔲` to `🔳` on
@@ -96,7 +96,8 @@ When implementing work tracked by `plan/`:
 
 ### Terminal Demo (`demo.tape`)
 
-VHS tape that records the demo GIF. When editing:
+`demo.tape` is the VHS tape that records the demo
+GIF. When editing it:
 
 - Use backtick-delimited strings for embedded quotes:
   `` Type `cmd 'status: "✅"'` ``. Do NOT use `\"`
@@ -106,7 +107,8 @@ VHS tape that records the demo GIF. When editing:
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
   list; hidden setup copies it to a temp dir for
   check/fix steps
-- Keep Sleeps short (1–2 s) for fast CI renders
+- Keep Sleep durations short (1–2 s) for fast CI
+  renders
 - Use only fixable rules in `demo/sample.md` (trailing
   spaces, long lines, bare URLs) so the fix→check
   flow works

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,69 +73,43 @@ row: "- [{summary}](../{filename})"
 
 ### PR Workflow
 
-Use `gh` for all GitHub PR operations:
-
-```bash
-# View PR comments
-gh pr view <number> --comments
-
-# List review comments on a PR
-gh api repos/"$(gh repo view --json nameWithOwner \
-  -q '.nameWithOwner')"/pulls/<number>/comments \
-  --paginate
-
-# Resolve a review thread after addressing it
-gh api graphql -f query='mutation {
-  resolveReviewThread(input: {threadId: "ID"}) {
-    thread { id isResolved }
-  }
-}'
-
-# Push updates after addressing comments
-git push origin <branch>
-```
-
-These commands are auto-approved in
-[`.claude/settings.json`](../.claude/settings.json).
+Use the `/pr-fixup`, `/gh-resolve-threads`, and
+`/merge-queue` skills for PR work — they cover
+rebases, CI monitoring, thread resolution, and merge
+enqueuing. After every push, request a Copilot
+re-review (the skills do this automatically).
 
 ### Plan Maintenance
 
-When implementing work tracked by a plan file in
-`plan/`:
+When implementing work tracked by `plan/`:
 
 - Update the plan file **as part of the
-  implementation**, not as a separate follow-up
-- Check off each task (`- [x]`) as it is completed
-- Check off each acceptance criterion when verified
-- When all acceptance criteria are met, change the
-  front-matter `status` from `🔲` or `🔳` to `✅`
-- When work begins on a not-started plan, change
-  `status` from `🔲` to `🔳`
-- If the implementation deviates from the plan
-  (e.g. a parameter name changes), update the plan
-  text to match what was actually built
-- Run `mdsmith fix PLAN.md` after changing a plan's
-  front matter so the catalog table stays current
+  implementation**, not as follow-up
+- Check off each task and acceptance criterion as it
+  is completed or verified
+- Move front-matter `status` from `🔲` to `🔳` on
+  start, then to `✅` when all criteria pass
+- If implementation deviates, update plan text to
+  match what was built
+- Run `mdsmith fix PLAN.md` after editing plan front
+  matter so the catalog table stays current
 
 ### Terminal Demo (`demo.tape`)
 
-The repo includes a VHS tape file (`demo.tape`) that
-records a terminal demo GIF. When editing this file:
+VHS tape that records the demo GIF. When editing:
 
-- VHS uses backtick-delimited strings to embed quotes:
-  `` Type `cmd 'status: "✅"'` `` — do NOT use `\"`
-  inside double-quoted Type strings (VHS crashes)
-- The tape runs `set +e` (hidden) at the start so
-  non-zero exits don't abort the recording — no need
-  to append `; true` to commands
+- Use backtick-delimited strings for embedded quotes:
+  `` Type `cmd 'status: "✅"'` ``. Do NOT use `\"`
+  inside double-quoted Type strings — VHS crashes
+- A hidden `set +e` runs at start, so don't append
+  `; true` to commands
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
-  list; the hidden setup copies it to a temp dir
-  for check/fix steps
-- Keep Sleep durations short (1–2 s) so VHS renders
-  quickly in CI
-- Only use fixable lint rules in `demo/sample.md`
-  (e.g. trailing spaces, long lines, bare URLs) so
-  the "fix then clean check" flow works
+  list; hidden setup copies it to a temp dir for
+  check/fix steps
+- Keep Sleeps short (1–2 s) for fast CI renders
+- Use only fixable rules in `demo/sample.md` (trailing
+  spaces, long lines, bare URLs) so the fix→check
+  flow works
 
 ### Writing Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ re-review (the skills do this automatically).
 When implementing work tracked by `plan/`:
 
 - Update the plan file **as part of the
-  implementation**, not as follow-up
+  implementation**, not as a follow-up
 - Check off each task and acceptance criterion as it
   is completed or verified
 - Move front-matter `status` from `🔲` to `🔳` on
@@ -102,7 +102,8 @@ When implementing work tracked by `plan/`:
 
 ## Terminal Demo (`demo.tape`)
 
-VHS tape that records the demo GIF. When editing:
+`demo.tape` is the VHS tape that records the demo
+GIF. When editing it:
 
 - Use backtick-delimited strings for embedded quotes:
   `` Type `cmd 'status: "✅"'` ``. Do NOT use `\"`
@@ -112,7 +113,8 @@ VHS tape that records the demo GIF. When editing:
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
   list; hidden setup copies it to a temp dir for
   check/fix steps
-- Keep Sleeps short (1–2 s) for fast CI renders
+- Keep Sleep durations short (1–2 s) for fast CI
+  renders
 - Use only fixable rules in `demo/sample.md` (trailing
   spaces, long lines, bare URLs) so the fix→check
   flow works

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,69 +79,43 @@ row: "- [{summary}]({filename})"
 
 ## PR Workflow
 
-Use `gh` for all GitHub PR operations:
-
-```bash
-# View PR comments
-gh pr view <number> --comments
-
-# List review comments on a PR
-gh api repos/"$(gh repo view --json nameWithOwner \
-  -q '.nameWithOwner')"/pulls/<number>/comments \
-  --paginate
-
-# Resolve a review thread after addressing it
-gh api graphql -f query='mutation {
-  resolveReviewThread(input: {threadId: "ID"}) {
-    thread { id isResolved }
-  }
-}'
-
-# Push updates after addressing comments
-git push origin <branch>
-```
-
-These commands are auto-approved in
-[`.claude/settings.json`](.claude/settings.json).
+Use the `/pr-fixup`, `/gh-resolve-threads`, and
+`/merge-queue` skills for PR work — they cover
+rebases, CI monitoring, thread resolution, and merge
+enqueuing. After every push, request a Copilot
+re-review (the skills do this automatically).
 
 ## Plan Maintenance
 
-When implementing work tracked by a plan file in
-`plan/`:
+When implementing work tracked by `plan/`:
 
 - Update the plan file **as part of the
-  implementation**, not as a separate follow-up
-- Check off each task (`- [x]`) as it is completed
-- Check off each acceptance criterion when verified
-- When all acceptance criteria are met, change the
-  front-matter `status` from `🔲` or `🔳` to `✅`
-- When work begins on a not-started plan, change
-  `status` from `🔲` to `🔳`
-- If the implementation deviates from the plan
-  (e.g. a parameter name changes), update the plan
-  text to match what was actually built
-- Run `mdsmith fix PLAN.md` after changing a plan's
-  front matter so the catalog table stays current
+  implementation**, not as follow-up
+- Check off each task and acceptance criterion as it
+  is completed or verified
+- Move front-matter `status` from `🔲` to `🔳` on
+  start, then to `✅` when all criteria pass
+- If implementation deviates, update plan text to
+  match what was built
+- Run `mdsmith fix PLAN.md` after editing plan front
+  matter so the catalog table stays current
 
 ## Terminal Demo (`demo.tape`)
 
-The repo includes a VHS tape file (`demo.tape`) that
-records a terminal demo GIF. When editing this file:
+VHS tape that records the demo GIF. When editing:
 
-- VHS uses backtick-delimited strings to embed quotes:
-  `` Type `cmd 'status: "✅"'` `` — do NOT use `\"`
-  inside double-quoted Type strings (VHS crashes)
-- The tape runs `set +e` (hidden) at the start so
-  non-zero exits don't abort the recording — no need
-  to append `; true` to commands
+- Use backtick-delimited strings for embedded quotes:
+  `` Type `cmd 'status: "✅"'` ``. Do NOT use `\"`
+  inside double-quoted Type strings — VHS crashes
+- A hidden `set +e` runs at start, so don't append
+  `; true` to commands
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
-  list; the hidden setup copies it to a temp dir
-  for check/fix steps
-- Keep Sleep durations short (1–2 s) so VHS renders
-  quickly in CI
-- Only use fixable lint rules in `demo/sample.md`
-  (e.g. trailing spaces, long lines, bare URLs) so
-  the "fix then clean check" flow works
+  list; hidden setup copies it to a temp dir for
+  check/fix steps
+- Keep Sleeps short (1–2 s) for fast CI renders
+- Use only fixable rules in `demo/sample.md` (trailing
+  spaces, long lines, bare URLs) so the fix→check
+  flow works
 
 ## Writing Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ re-review (the skills do this automatically).
 When implementing work tracked by `plan/`:
 
 - Update the plan file **as part of the
-  implementation**, not as follow-up
+  implementation**, not as a follow-up
 - Check off each task and acceptance criterion as it
   is completed or verified
 - Move front-matter `status` from `🔲` to `🔳` on
@@ -88,7 +88,8 @@ When implementing work tracked by `plan/`:
 
 ## Terminal Demo (`demo.tape`)
 
-VHS tape that records the demo GIF. When editing:
+`demo.tape` is the VHS tape that records the demo
+GIF. When editing it:
 
 - Use backtick-delimited strings for embedded quotes:
   `` Type `cmd 'status: "✅"'` ``. Do NOT use `\"`
@@ -98,7 +99,8 @@ VHS tape that records the demo GIF. When editing:
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
   list; hidden setup copies it to a temp dir for
   check/fix steps
-- Keep Sleeps short (1–2 s) for fast CI renders
+- Keep Sleep durations short (1–2 s) for fast CI
+  renders
 - Use only fixable rules in `demo/sample.md` (trailing
   spaces, long lines, bare URLs) so the fix→check
   flow works

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,69 +65,43 @@ row: "- [{summary}]({filename})"
 
 ## PR Workflow
 
-Use `gh` for all GitHub PR operations:
-
-```bash
-# View PR comments
-gh pr view <number> --comments
-
-# List review comments on a PR
-gh api repos/"$(gh repo view --json nameWithOwner \
-  -q '.nameWithOwner')"/pulls/<number>/comments \
-  --paginate
-
-# Resolve a review thread after addressing it
-gh api graphql -f query='mutation {
-  resolveReviewThread(input: {threadId: "ID"}) {
-    thread { id isResolved }
-  }
-}'
-
-# Push updates after addressing comments
-git push origin <branch>
-```
-
-These commands are auto-approved in
-[`.claude/settings.json`](.claude/settings.json).
+Use the `/pr-fixup`, `/gh-resolve-threads`, and
+`/merge-queue` skills for PR work — they cover
+rebases, CI monitoring, thread resolution, and merge
+enqueuing. After every push, request a Copilot
+re-review (the skills do this automatically).
 
 ## Plan Maintenance
 
-When implementing work tracked by a plan file in
-`plan/`:
+When implementing work tracked by `plan/`:
 
 - Update the plan file **as part of the
-  implementation**, not as a separate follow-up
-- Check off each task (`- [x]`) as it is completed
-- Check off each acceptance criterion when verified
-- When all acceptance criteria are met, change the
-  front-matter `status` from `🔲` or `🔳` to `✅`
-- When work begins on a not-started plan, change
-  `status` from `🔲` to `🔳`
-- If the implementation deviates from the plan
-  (e.g. a parameter name changes), update the plan
-  text to match what was actually built
-- Run `mdsmith fix PLAN.md` after changing a plan's
-  front matter so the catalog table stays current
+  implementation**, not as follow-up
+- Check off each task and acceptance criterion as it
+  is completed or verified
+- Move front-matter `status` from `🔲` to `🔳` on
+  start, then to `✅` when all criteria pass
+- If implementation deviates, update plan text to
+  match what was built
+- Run `mdsmith fix PLAN.md` after editing plan front
+  matter so the catalog table stays current
 
 ## Terminal Demo (`demo.tape`)
 
-The repo includes a VHS tape file (`demo.tape`) that
-records a terminal demo GIF. When editing this file:
+VHS tape that records the demo GIF. When editing:
 
-- VHS uses backtick-delimited strings to embed quotes:
-  `` Type `cmd 'status: "✅"'` `` — do NOT use `\"`
-  inside double-quoted Type strings (VHS crashes)
-- The tape runs `set +e` (hidden) at the start so
-  non-zero exits don't abort the recording — no need
-  to append `; true` to commands
+- Use backtick-delimited strings for embedded quotes:
+  `` Type `cmd 'status: "✅"'` ``. Do NOT use `\"`
+  inside double-quoted Type strings — VHS crashes
+- A hidden `set +e` runs at start, so don't append
+  `; true` to commands
 - `demo/sample.md` is in the `.mdsmith.yml` ignore
-  list; the hidden setup copies it to a temp dir
-  for check/fix steps
-- Keep Sleep durations short (1–2 s) so VHS renders
-  quickly in CI
-- Only use fixable lint rules in `demo/sample.md`
-  (e.g. trailing spaces, long lines, bare URLs) so
-  the "fix then clean check" flow works
+  list; hidden setup copies it to a temp dir for
+  check/fix steps
+- Keep Sleeps short (1–2 s) for fast CI renders
+- Use only fixable rules in `demo/sample.md` (trailing
+  spaces, long lines, bare URLs) so the fix→check
+  flow works
 
 ## Writing Guidelines
 


### PR DESCRIPTION
## Summary
This PR introduces a new `gh-resolve-threads` skill for resolving GitHub PR review threads via the `gh` CLI, and updates documentation across multiple files to reference the new skill-based workflow instead of inline commands.

## Key Changes

- **New skill**: Added `.claude/skills/gh-resolve-threads/SKILL.md` with comprehensive instructions for:
  - Installing and authenticating the `gh` CLI
  - Fetching PR review threads via GraphQL
  - Addressing review comments and committing changes
  - Resolving threads one at a time after addressing them
  - Verifying resolution status
  - Explicitly notes that GitHub MCP cannot resolve threads or retrieve thread IDs

- **Documentation updates**: Simplified PR workflow guidance in three files (`.github/copilot-instructions.md`, `AGENTS.md`, `CLAUDE.md`) by:
  - Removing inline `gh` command examples and GraphQL mutation snippets
  - Directing users to use `/pr-fixup`, `/gh-resolve-threads`, and `/merge-queue` skills instead
  - Condensing verbose explanations of plan maintenance and demo tape editing into more concise bullet points
  - Emphasizing that skills handle Copilot re-review requests automatically

## Implementation Details

The skill provides step-by-step guidance with separate Bash blocks (not chained with `&&`) for:
- Verifying `gh` installation with fallback installation methods (direct download with SHA256 verification, or apt)
- Extracting PR number and repository info
- Querying review threads with pagination support (first: 100)
- Committing and pushing changes
- Resolving threads individually using their GraphQL node IDs
- Re-requesting Copilot reviews after each push

The skill is marked as user-invocable and restricted to specific `gh` and `git` commands via the `allowed-tools` field.

https://claude.ai/code/session_016QXKotjcxNCxbQfTip4BuN