### PR TITLE
Document VS Code extension and LSP editor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ sibling for CI.
 
 **✏️ See lint errors live in your editor.**
 The [VS Code extension][vsc-mp] runs `mdsmith lsp` and
-shows inline squiggles, per-rule quick fixes, and a
-`source.fixAll.mdsmith` action that hooks into save. Also
-on [Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
+shows inline squiggles, per-rule quick fixes, and an
+opt-in `source.fixAll.mdsmith` action for fix-on-save
+(set `mdsmith.fixOnSave: true` to enable). Also on
+[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
 Gitpod. Any LSP-aware editor — Neovim, Helix, JetBrains —
 works the same way by pointing at `mdsmith lsp`.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ in place. Multi-pass fixing resolves cascading changes so
 you don't run it twice. `mdsmith check` is the read-only
 sibling for CI.
 
+**✏️ See lint errors live in your editor.**
+The [VS Code extension][vsc-mp] runs `mdsmith lsp` and
+shows inline squiggles, per-rule quick fixes, and a
+`source.fixAll.mdsmith` action that hooks into save. Also
+on [Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
+Gitpod. Any LSP-aware editor — Neovim, Helix, JetBrains —
+works the same way by pointing at `mdsmith lsp`.
+
 **🔗 Catch broken links before they merge.**
 Refactors silently break Markdown links and anchors.
 [`cross-file-reference-integrity`](internal/rules/MDS027-cross-file-reference-integrity/README.md)
@@ -90,6 +98,30 @@ More options live in
 [docs/guides/install.md](docs/guides/install.md). It covers direct
 downloads, the VS Code extension on the Marketplace and Open VSX,
 and asdf and mise once their registry entries land.
+
+## ✏️ Editor integration
+
+The mdsmith VS Code extension renders diagnostics inline.
+Each fixable rule contributes a quick fix. A
+`source.fixAll.mdsmith` action runs `mdsmith fix` on the
+buffer.
+
+```bash
+# stock VS Code, GitHub Codespaces, GitHub.dev (Marketplace)
+code --install-extension jeduden.mdsmith
+# Cursor, VSCodium, Theia, Gitpod (Open VSX)
+codium --install-extension jeduden.mdsmith
+```
+
+The extension is a thin LSP client. The lint pipeline runs
+in the Go binary, so any LSP-aware editor (Neovim, Helix,
+JetBrains via the LSP plugin) gets the same diagnostics by
+pointing at `mdsmith lsp`.
+
+See [VS Code Integration](docs/guides/editors/vscode.md)
+for settings (`mdsmith.path`, `mdsmith.run`,
+`mdsmith.fixOnSave`, `mdsmith.trace.server`), code actions,
+and troubleshooting.
 
 ## 🚀 Usage
 
@@ -190,3 +222,5 @@ mdsmith upgrades become an explicit, reviewable change. Run
 [grc-link]: https://goreportcard.com/report/github.com/jeduden/mdsmith
 [cov-badge]: https://codecov.io/gh/jeduden/mdsmith/branch/main/graph/badge.svg
 [cov-link]: https://codecov.io/gh/jeduden/mdsmith/branch/main
+[vsc-mp]: https://marketplace.visualstudio.com/items?itemName=jeduden.mdsmith
+[vsc-ovsx]: https://open-vsx.org/extension/jeduden/mdsmith

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -37,15 +37,24 @@ gets the same behavior by pointing at `mdsmith lsp`.
 
 ## Install
 
-The extension is shipped as a `.vsix` artifact next
-to the Go binaries on each release. Install it with:
+Each release publishes the extension to the Visual
+Studio Marketplace, to Open VSX, and as a `.vsix`
+attached to the GitHub release. Pick one:
 
 ```bash
+# stock VS Code, GitHub Codespaces, GitHub.dev (Marketplace)
+code --install-extension jeduden.mdsmith
+# Cursor, VSCodium, Theia, Gitpod (Open VSX)
+codium --install-extension jeduden.mdsmith
+# Air-gapped or version-pinned: download from the release page
 code --install-extension mdsmith-<version>.vsix
 ```
 
-Marketplace publication is gated on release planning;
-until then the `.vsix` is the supported install path.
+The Marketplace, Open VSX, and GitHub-release `.vsix`
+have identical SHA-256 sums; the same artifact is
+uploaded to all three. See
+[Installation: VS Code extension](../install.md#vs-code-extension)
+for the channel-by-channel breakdown.
 
 ## Settings
 


### PR DESCRIPTION
## Summary
This PR updates the README to document the mdsmith VS Code extension and LSP editor integration capabilities, making it easier for users to discover and use the extension across different editors.

## Changes
- Added a prominent callout in the feature overview highlighting the VS Code extension with inline diagnostics, quick fixes, and save-on-fix functionality
- Added a new "Editor integration" section with:
  - Installation instructions for VS Code (Marketplace) and other editors via Open VSX (Cursor, VSCodium, Theia, Gitpod)
  - Explanation of the LSP client architecture and support for other LSP-aware editors (Neovim, Helix, JetBrains)
  - Reference to the VS Code integration guide with configuration options and troubleshooting
- Added reference links for the VS Code Marketplace and Open VSX extension pages

## Details
The documentation emphasizes that the extension is a thin LSP client wrapping the Go binary's lint pipeline, enabling consistent diagnostics across any LSP-aware editor, not just VS Code. This positions mdsmith as editor-agnostic while highlighting the rich VS Code experience.

https://claude.ai/code/session_01RCV1PqXj35NwfNL6QbgogL