### PR TITLE
Update cosign to use --bundle flag instead of separate signature/certificate files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,14 @@ jobs:
           subject-path: "mdsmith-*"
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin cosign to a known v3.x release. The sign-blob step
+          # below relies on `--bundle` being the required output
+          # path (cosign 3.0.0 promoted it from optional to
+          # required); pinning shields the release from a future
+          # installer default rolling forward to a major that
+          # changes the bundle contract again.
+          cosign-release: "v3.0.6"
       - name: Sign checksums with cosign
         # Keyless Sigstore signature on the checksum file. The
         # GitHub OIDC token binds the signature to this exact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,10 +323,13 @@ jobs:
         # workflow file at this exact tag, so an attacker who
         # rewrites checksums.txt on the release page can't also
         # forge a matching signature without compromising
-        # release.yml on this repo. Verify with:
+        # release.yml on this repo. The bundle file carries both
+        # the signature and the signing certificate; cosign 3.x
+        # deprecated the separate --output-signature /
+        # --output-certificate flags in favor of --bundle.
+        # Verify with:
         #   cosign verify-blob \
-        #     --certificate checksums.txt.pem \
-        #     --signature checksums.txt.sig \
+        #     --bundle checksums.txt.bundle \
         #     --certificate-identity-regexp \
         #       "^https://github.com/jeduden/mdsmith/.github/workflows/release.yml@" \
         #     --certificate-oidc-issuer \
@@ -336,8 +339,7 @@ jobs:
           COSIGN_YES: "true"
         run: |
           cosign sign-blob \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.bundle \
             checksums.txt
       - name: Create release
         env:
@@ -348,8 +350,7 @@ jobs:
           files: |
             mdsmith-*
             checksums.txt
-            checksums.txt.sig
-            checksums.txt.pem
+            checksums.txt.bundle
 
   smoke-test:
     # Wait until every channel is on the new version before checking

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -156,11 +156,9 @@ gh attestation verify mdsmith-linux-amd64 \
 Verify the checksums-file signature with `cosign`:
 
 ```bash
-curl -L -o checksums.txt.sig "$base/checksums.txt.sig"
-curl -L -o checksums.txt.pem "$base/checksums.txt.pem"
+curl -L -o checksums.txt.bundle "$base/checksums.txt.bundle"
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature   checksums.txt.sig \
+  --bundle checksums.txt.bundle \
   --certificate-identity-regexp \
     "^https://github.com/jeduden/mdsmith/.github/workflows/release.yml@" \
   --certificate-oidc-issuer \

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -153,7 +153,10 @@ gh attestation verify mdsmith-linux-amd64 \
   -R jeduden/mdsmith
 ```
 
-Verify the checksums-file signature with `cosign`:
+Verify the checksums-file signature with `cosign`
+(requires cosign v3.0.0 or newer — earlier versions
+do not accept `verify-blob --bundle`; check yours
+with `cosign version`):
 
 ```bash
 curl -L -o checksums.txt.bundle "$base/checksums.txt.bundle"


### PR DESCRIPTION
## Summary
Updates the release workflow and installation documentation to use cosign 3.x's `--bundle` flag instead of the deprecated separate `--output-signature` and `--output-certificate` flags.

## Key Changes
- **Release workflow (.github/workflows/release.yml)**:
  - Updated `cosign sign-blob` command to use `--bundle checksums.txt.bundle` instead of separate `--output-signature` and `--output-certificate` flags
  - Updated verification instructions in comments to use `--bundle checksums.txt.bundle` instead of separate `--certificate` and `--signature` flags
  - Changed release artifact uploads to include only `checksums.txt.bundle` instead of `checksums.txt.sig` and `checksums.txt.pem`
  - Added explanatory comment about cosign 3.x deprecating the separate flags in favor of bundled format

- **Installation guide (docs/guides/install.md)**:
  - Simplified verification instructions to download single `checksums.txt.bundle` file instead of two separate files
  - Updated `cosign verify-blob` command to use `--bundle` flag

## Implementation Details
The bundle format consolidates the signature and signing certificate into a single file, simplifying distribution and verification while maintaining the same security guarantees. The changes are backward-incompatible with cosign versions prior to 3.x.

https://claude.ai/code/session_01Kfb2sd9dmb5iaxb3BrXeeN