### PR TITLE
Add LSP/Claude Code support plans (132–134, 151–152)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -34,7 +34,7 @@ footer: |
 | 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                                    |
 | 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                              |
 | 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                                               |
-| 122 | 🔲     | sonnet | [VS Code hover help and palette commands](plan/122_vscode-hover-and-palette.md)                                                       |
+| 122 | 🔲     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                                      |
 | 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                                                 |
 | 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                                                   |
 | 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                                           |
@@ -43,6 +43,9 @@ footer: |
 | 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)                                         |
 | 130 | 🔳     | opus   | [Distribute mdsmith binaries via npm, PyPI, asdf, mise, and the VS Code marketplaces](plan/130_binary-distribution-and-versioning.md) |
 | 131 | ✅     | opus   | [LSP symbol navigation for agents (Claude)](plan/131_lsp-symbol-navigation.md)                                                        |
+| 132 | 🔲     | sonnet | [Package mdsmith LSP as a Claude Code plugin](plan/132_claude-code-plugin.md)                                                         |
+| 133 | 🔲     | sonnet | [LSP hover for rule and directive docs](plan/133_lsp-hover.md)                                                                        |
+| 134 | 🔲     | sonnet | [LSP completion for anchors, refs, kinds, and directive args](plan/134_lsp-completion.md)                                             |
 | 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                                  |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                            |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                          |

--- a/PLAN.md
+++ b/PLAN.md
@@ -47,6 +47,8 @@ footer: |
 | 133 | 🔲     | sonnet | [LSP hover for rule and directive docs](plan/133_lsp-hover.md)                                                                        |
 | 134 | 🔲     | sonnet | [LSP completion for anchors, refs, kinds, and directive args](plan/134_lsp-completion.md)                                             |
 | 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                                  |
+| 151 | 🔲     | opus   | [LSP rename for headings and link-reference labels](plan/151_lsp-rename.md)                                                           |
+| 152 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/152_claude-code-skills-agents-hooks.md)                                  |
 | 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                            |
 | 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                          |
 | 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                      |

--- a/plan/122_vscode-hover-and-palette.md
+++ b/plan/122_vscode-hover-and-palette.md
@@ -1,28 +1,24 @@
 ---
 id: 122
-title: VS Code hover help and palette commands
+title: VS Code palette commands
 status: "🔲"
 model: sonnet
 summary: >-
-  Add `textDocument/hover` to the LSP server so rule
-  help text shows on hover over a diagnostic, plus a
-  small set of VS Code command-palette entries —
+  A small set of VS Code command-palette entries —
   `init`, `merge-driver install`, `fix workspace`,
   `kinds why`, `kinds resolve` — that cover the
-  remaining subcommands without adding chrome to the
-  editor.
+  remaining mdsmith subcommands without adding chrome
+  to the editor. Hover help is split into plan 133.
 ---
-# VS Code hover help and palette commands
+# VS Code palette commands
 
 ## Goal
 
-After plan 121 ships diagnostics and code actions,
-two questions stay unanswered from the editor:
-"what does this rule mean?" and "how do I run a
+After plan 121 ships diagnostics and code actions
+and plan 133 adds hover for rule docs, one question
+stays unanswered from the editor: "how do I run a
 mdsmith subcommand without leaving VS Code?". This
-plan answers both with hover (for the first
-question) and a short palette menu (for the
-second).
+plan answers it with a short palette menu.
 
 The plan deliberately ships no permanent UI chrome.
 No CodeLens, no status-bar item, no activity-bar
@@ -33,12 +29,12 @@ first feature they would disable.
 ## Background
 
 Plan 121 covers diagnostics and per-file fixes.
-Eight subcommands stay outside the editor:
-`help`, `kinds`, `archetypes`, `metrics`,
-`query`, `init`, `merge-driver`, `version`. A
-reviewer audit grouped them:
+Plan 133 covers hover for rule and directive docs.
+Seven subcommands stay outside the editor:
+`kinds`, `archetypes`, `metrics`, `query`, `init`,
+`merge-driver`, `version`. A reviewer audit
+grouped them:
 
-- **Hover**: `help` (what does this rule mean?).
 - **Palette**: `init`, `merge-driver install`,
   fix-everything, `kinds why`, `kinds resolve`.
 - **CLI only**: `archetypes`, `metrics`, `query`,
@@ -46,33 +42,6 @@ reviewer audit grouped them:
   view or status-bar pill surfacing these.
 
 ## Design
-
-### Hover
-
-Capability: `hoverProvider = true`.
-
-A `textDocument/hover` request arrives with a
-position. When the position falls inside a
-diagnostic range, the server returns Markdown:
-
-- The diagnostic message (one line).
-- The rule's docs, loaded the same way
-  `mdsmith help rule <id|name>` loads them via
-  [`internal/rules.LookupRule`](../internal/rules/ruledocs.go).
-
-When no diagnostic covers the position, the server
-checks for a `<?directive?>` block. If one is
-under the cursor, the hover returns that
-directive's docs, sourced from the existing files
-under [docs/guides/directives/](../docs/guides/directives/).
-This plan does not add a new `mdsmith help
-directives` CLI topic; the directive content is
-loaded directly by the LSP server.
-
-Hover does not link to `kinds why`. Reviewers
-flagged that link as part of the over-surfaced
-kinds chrome; the palette command below is the
-single entry point.
 
 ### Palette commands
 
@@ -133,7 +102,7 @@ in `editors/vscode/package.json`:
 "capabilities": {
   "untrustedWorkspaces": {
     "supported": "limited",
-    "description": "Diagnostics and hover work in restricted mode. Commands that modify files outside the editor are disabled until the workspace is trusted.",
+    "description": "Diagnostics work in restricted mode. Commands that modify files outside the editor are disabled until the workspace is trusted.",
     "restrictedConfigurations": [
       "mdsmith.path",
       "mdsmith.config"
@@ -142,9 +111,8 @@ in `editors/vscode/package.json`:
 }
 ```
 
-- `"limited"` lets the language client and hover
-  load in an untrusted workspace; neither writes
-  files.
+- `"limited"` lets the language client load in an
+  untrusted workspace; it never writes files.
 - The two destructive palette commands hide
   behind `when: isWorkspaceTrusted` on their
   menu entries. Handlers re-check
@@ -156,44 +124,6 @@ in `editors/vscode/package.json`:
 - The extension subscribes to
   `onDidGrantWorkspaceTrust`; gated commands
   appear without a reload after trust is granted.
-
-### Rule docs render in VS Code's Markdown engine
-
-VS Code's hover renderer is Markdown-only and
-strips inline HTML. The plan does not sanitize at
-runtime. It enforces "no inline HTML" at lint
-time on the rule README files. The vehicle is the
-existing `rule-readme` kind in `.mdsmith.yml`.
-That kind already targets
-`internal/rules/MDS*/README.md`.
-
-Today the kind only pins
-`required-structure.schema`. The plan adds
-MDS041 (`no-inline-html`). The rule is opt-in
-by default. A settings mapping turns it on. There
-is no `enabled` key — see
-[`RuleCfg.UnmarshalYAML`](../internal/config/config.go):
-
-```yaml
-kinds:
-  rule-readme:
-    rules:
-      required-structure:
-        schema: internal/rules/proto.md
-      no-inline-html:
-        allow: [kbd]
-```
-
-A spot audit of
-[`internal/rules/MDS*/README.md`](../internal/rules)
-found no raw HTML outside code blocks. The
-change is purely preventive. It stops a future
-contributor from adding HTML the hover would
-silently drop.
-
-Editing `.mdsmith.yml` requires user consent per
-[`CLAUDE.md`](../CLAUDE.md). The task surfaces
-the diff first.
 
 ### What this plan removes
 
@@ -211,46 +141,31 @@ feedback.
 
 ## Tasks
 
-1. Wire hover's rule lookup through the existing
-   [`internal/rules`](../internal/rules) APIs
-   (`LookupRule(query) (string, error)` and
-   `ListRules()`) so the hover body matches what
-   `mdsmith help rule <id|name>` prints. Cover
-   known rules, unknown rules, and rules whose
-   docs have no rule-specific body.
-2. Add `textDocument/hover` to the LSP server.
-   Match the position against active diagnostic
-   ranges. Fall through to the directive index
-   when no diagnostic covers the cursor. Add an
-   integration test in
-   [`cmd/mdsmith`](../cmd/mdsmith) that drives the
-   hover request and asserts the response.
-3. Register the five palette commands in
+1. Register the five palette commands in
    `editors/vscode/package.json`. Add one handler
    per command in `editors/vscode/src/commands/`.
    Each spawns the binary, surfaces stderr, and
    shows a notification on non-zero exit.
-4. Implement `mdsmith.fixWorkspace`. Run
+2. Implement `mdsmith.fixWorkspace`. Run
    `mdsmith fix .` from the workspace root. Parse
    the `stats:` line from stderr (see
    `printRunStats`). Show a notification with the
    fixed-of-total count. Cover with a VS Code
    extension test that mocks the child process.
-5. Implement `mdsmith.kinds.why` and
+3. Implement `mdsmith.kinds.why` and
    `mdsmith.kinds.resolve` against the
    `mdsmith-kinds:` virtual document scheme.
    Register a `TextDocumentContentProvider` that
    returns the JSON output rendered as Markdown.
-6. Update the VS Code guide
+4. Update the VS Code guide
    `docs/guides/editors/vscode.md` (created in
-   plan 121) with one section per surface: hover
-   and each palette command.
-7. Add a CLI-subcommand table to
+   plan 121) with one section per palette command.
+5. Add a CLI-subcommand table to
    `docs/guides/editors/vscode.md` listing every
    subcommand and its editor entry point. Mark
    `archetypes`, `metrics`, `query`, and `version`
    as "CLI only".
-8. Wire workspace trust per the design above. Add
+6. Wire workspace trust per the design above. Add
    the `capabilities.untrustedWorkspaces` block to
    `editors/vscode/package.json`. Gate the
    `fixWorkspace` and `mergeDriver.install` menu
@@ -259,22 +174,9 @@ feedback.
    handler. Subscribe to
    `onDidGrantWorkspaceTrust` to refresh the
    command surface without a reload.
-9. Propose enabling `no-inline-html` on the
-   `rule-readme` kind in `.mdsmith.yml`. Surface
-   the diff before applying. CLAUDE.md treats
-   linter configuration as user-consent
-   territory; this task lands the change only
-   after authorisation. Add a regression test:
-   a fixture rule README with a raw `<span>`
-   outside a code block fails `mdsmith check`.
 
 ## Acceptance Criteria
 
-- [ ] Hovering over a `MDS001` squiggle in VS Code
-      shows the line-length help body inline.
-- [ ] Hovering inside a `<?catalog?>` directive
-      shows the catalog directive docs even when no
-      diagnostic is present.
 - [ ] The command palette lists the five
       `mdsmith.*` commands in a workspace with a
       Markdown file open.
@@ -304,10 +206,6 @@ feedback.
 - [ ] An untrusted workspace cannot redirect
       `mdsmith.path` or `mdsmith.config`; the
       extension uses the user-level value.
-- [ ] After the `rule-readme` kind change lands,
-      a fixture rule README containing a raw
-      `<span>` outside a code block fails
-      `mdsmith check` with `MDS041`.
 
 ## ...
 

--- a/plan/122_vscode-hover-and-palette.md
+++ b/plan/122_vscode-hover-and-palette.md
@@ -29,17 +29,24 @@ first feature they would disable.
 ## Background
 
 Plan 121 covers diagnostics and per-file fixes.
-Plan 133 covers hover for rule and directive docs.
-Seven subcommands stay outside the editor:
-`kinds`, `archetypes`, `metrics`, `query`, `init`,
-`merge-driver`, `version`. A reviewer audit
-grouped them:
+Plan 133 covers hover for `help rule` and
+directive docs only — the rest of `mdsmith help`
+(e.g. `help metrics`, `help kinds`,
+`help concepts`) stays CLI-only since those topics
+have no in-buffer anchor to hover over. Eight
+subcommands stay outside the editor:
+`help`, `kinds`, `archetypes`, `metrics`,
+`query`, `init`, `merge-driver`, `version`. A
+reviewer audit grouped them:
 
 - **Palette**: `init`, `merge-driver install`,
   fix-everything, `kinds why`, `kinds resolve`.
-- **CLI only**: `archetypes`, `metrics`, `query`,
-  `version` — reviewers would uninstall a tree
-  view or status-bar pill surfacing these.
+- **Hover (plan 133)**: `help rule <id>` and the
+  directive-doc subset.
+- **CLI only**: the rest of `help`, `archetypes`,
+  `metrics`, `query`, `version` — reviewers would
+  uninstall a tree view or status-bar pill
+  surfacing these.
 
 ## Design
 

--- a/plan/132_claude-code-plugin.md
+++ b/plan/132_claude-code-plugin.md
@@ -16,8 +16,11 @@ summary: >-
 
 ## Goal
 
-Let a Claude Code user install mdsmith with one
-command: `/plugin install mdsmith-lsp@mdsmith`.
+Let a Claude Code user install mdsmith from this
+repository with two standard `/plugin` commands.
+First, register the catalog one-time with `/plugin
+marketplace add jeduden/mdsmith`. Then install the
+plugin with `/plugin install mdsmith-lsp@mdsmith`.
 After install, the agent sees Markdown diagnostics
 inline after every edit. The agent can also use
 go-to-definition, find references, symbol search,

--- a/plan/132_claude-code-plugin.md
+++ b/plan/132_claude-code-plugin.md
@@ -179,13 +179,21 @@ documented stdio invocation.
    [`docs/guides/install.md`](../docs/guides/install.md)
    listing the two `/plugin` commands and linking
    to the new editor README.
-5. Add the new plugin paths to
-   [`.mdsmith.yml`](../.mdsmith.yml)'s `ignore:`
-   only if they hold non-Markdown JSON that triggers
-   no-bare-urls or similar; otherwise leave as-is.
-   This change is config-touching, so surface the
-   diff before applying per
-   [CLAUDE.md](../CLAUDE.md).
+5. Update [.mdsmith.yml](../.mdsmith.yml)'s
+   `directory-structure.allowed` list to include
+   `.claude-plugin/**` (the new top-level
+   marketplace dir). The current allow-list (lines
+   63–74) covers `.claude/**` but not
+   `.claude-plugin/**`; without the addition,
+   `mdsmith check .` fails on the new manifest.
+   `editors/**` is already allowed, so the plugin
+   manifest under `editors/claude-code/` does not
+   need a separate entry. This change is
+   config-touching, so surface the diff before
+   applying per [CLAUDE.md](../CLAUDE.md). Add an
+   `ignore:` entry too if the JSON manifests
+   trigger any rules; default to leaving them
+   linted.
 6. Validate the manifest locally with
    `claude plugin validate ./editors/claude-code` (or
    `/plugin validate` inside an active Claude Code
@@ -217,6 +225,10 @@ documented stdio invocation.
       and receive the heading location.
 - [ ] `claude plugin validate` reports no errors on
       the new manifests.
+- [ ] After the `.mdsmith.yml`
+      `directory-structure.allowed` update, `mdsmith
+      check .` passes against the new
+      `.claude-plugin/marketplace.json` location.
 - [ ] When the `mdsmith` binary is absent from
       `$PATH`, the `/plugin` Errors tab shows
       `Executable not found in $PATH` (no silent

--- a/plan/132_claude-code-plugin.md
+++ b/plan/132_claude-code-plugin.md
@@ -1,0 +1,249 @@
+---
+id: 132
+title: Package mdsmith LSP as a Claude Code plugin
+status: "🔲"
+model: sonnet
+summary: >-
+  Ship a `.claude-plugin/marketplace.json` plus a
+  plugin manifest declaring `lspServers` so Claude
+  Code can install mdsmith from this repository and
+  auto-spawn `mdsmith lsp` on `.md` files, exposing
+  diagnostics, definitions, references, symbols,
+  implementations, and call hierarchy to the agent
+  without manual editor setup.
+---
+# Package mdsmith LSP as a Claude Code plugin
+
+## Goal
+
+Let a Claude Code user install mdsmith with one
+command: `/plugin install mdsmith-lsp@mdsmith`.
+After install, the agent sees Markdown diagnostics
+inline after every edit. The agent can also use
+go-to-definition, find references, symbol search,
+and call hierarchy across the docs.
+
+## Background
+
+Claude Code's [code intelligence][cc-ci] bundles
+LSP plugins for a fixed set of languages
+(`gopls-lsp`, `pyright-lsp`, `typescript-lsp`, …).
+Markdown is not on the list. The same docs note
+that users can [create their own LSP plugin][cc-lsp]
+for languages outside the bundle.
+
+[cc-ci]: https://code.claude.com/docs/en/discover-plugins#code-intelligence
+[cc-lsp]: https://code.claude.com/docs/en/plugins-reference#lsp-servers
+
+Plan 121 shipped `mdsmith lsp` over stdio with
+diagnostics and code actions. Plan 131 added the
+six navigation methods Claude Code consumes
+(`documentSymbol`, `definition`, `implementation`,
+`references`, `workspace/symbol`, `callHierarchy`).
+The server is wire-ready; only the Claude Code
+discovery layer is missing. Today a user has to
+hand-edit settings to spawn the binary.
+
+## Non-Goals
+
+- Bundling the `mdsmith` binary inside the plugin.
+  The binary ships through the channels in plan 130
+  (npm, PyPI, asdf, mise, GitHub release, VS Code
+  marketplace). The plugin documents the binary
+  prerequisite the same way `gopls-lsp` documents
+  `gopls`.
+- Authoring tools (slash commands, agents, hooks).
+  Scope is the LSP wiring only.
+- Submitting to the official Anthropic marketplace.
+  This plan only ships a self-hosted marketplace
+  inside `jeduden/mdsmith`; submission is a separate
+  decision.
+
+## Design
+
+### Repository layout
+
+```text
+.claude-plugin/
+  marketplace.json        # marketplace catalog at repo root
+editors/
+  claude-code/
+    .claude-plugin/
+      plugin.json         # plugin manifest with lspServers
+    README.md             # install + binary prerequisite
+  vscode/                 # existing VS Code extension
+```
+
+The marketplace at the repo root lists one plugin
+sourced from `./editors/claude-code/`. This mirrors
+the per-editor split already in place under
+[editors/](../editors/) and keeps the VS Code
+extension untouched.
+
+### `marketplace.json`
+
+```json
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "mdsmith",
+  "owner": {
+    "name": "Jens-Uwe Eden",
+    "url": "https://github.com/jeduden"
+  },
+  "description": "Markdown linter for Claude Code via LSP",
+  "plugins": [
+    {
+      "name": "mdsmith-lsp",
+      "source": "./editors/claude-code",
+      "description": "Inline mdsmith diagnostics and Markdown navigation"
+    }
+  ]
+}
+```
+
+### `plugin.json`
+
+The manifest uses the inline `lspServers` form so
+the plugin ships in a single file. `extensionToLanguage`
+maps both common Markdown extensions to the
+`markdown` language identifier.
+
+```json
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mdsmith-lsp",
+  "description": "Inline mdsmith diagnostics and Markdown navigation via LSP",
+  "homepage": "https://github.com/jeduden/mdsmith",
+  "repository": "https://github.com/jeduden/mdsmith",
+  "license": "MIT",
+  "keywords": ["markdown", "linter", "lsp"],
+  "lspServers": {
+    "mdsmith": {
+      "command": "mdsmith",
+      "args": ["lsp"],
+      "extensionToLanguage": {
+        ".md": "markdown",
+        ".markdown": "markdown"
+      }
+    }
+  }
+}
+```
+
+The `command` resolves against `$PATH`. Users who
+installed `mdsmith` via npm, PyPI, asdf, or mise
+(plan 130) get the binary on `$PATH` automatically.
+Users with a custom path can override
+`mdsmithLspPath` (no per-plugin config exists yet,
+so the documented fallback is to put the binary on
+`$PATH`).
+
+### Discovery and install
+
+Two install paths, both standard Claude Code flows:
+
+- `/plugin marketplace add jeduden/mdsmith` then
+  `/plugin install mdsmith-lsp@mdsmith` (browse and
+  install from the catalog).
+- Direct: `/plugin install mdsmith-lsp@mdsmith`
+  after the marketplace is added.
+
+After install, `/reload-plugins` activates the
+server. Subsequent `.md` opens trigger
+`textDocument/didOpen` and the diagnostics flow.
+
+### Backwards compatibility
+
+The plugin manifest is additive. The repo's
+existing VS Code extension, npm scripts, and CI are
+untouched. Users on other editors keep using the
+documented stdio invocation.
+
+## Tasks
+
+1. Add `.claude-plugin/marketplace.json` at the
+   repository root with one plugin entry pointing
+   to `./editors/claude-code`.
+2. Add `editors/claude-code/.claude-plugin/plugin.json`
+   declaring the inline `lspServers` block above.
+3. Add `editors/claude-code/README.md` with:
+   install command, binary prerequisite, pointer
+   to [the install guide](../docs/guides/install.md)
+   for the binary, troubleshooting (the same
+   `Executable not found in $PATH` failure mode the
+   Claude Code docs warn about).
+4. Add a "Claude Code" section to
+   [`docs/guides/install.md`](../docs/guides/install.md)
+   listing the two `/plugin` commands and linking
+   to the new editor README.
+5. Add the new plugin paths to
+   [`.mdsmith.yml`](../.mdsmith.yml)'s `ignore:`
+   only if they hold non-Markdown JSON that triggers
+   no-bare-urls or similar; otherwise leave as-is.
+   This change is config-touching, so surface the
+   diff before applying per
+   [CLAUDE.md](../CLAUDE.md).
+6. Validate the manifest locally with
+   `claude plugin validate ./editors/claude-code` (or
+   `/plugin validate` inside an active Claude Code
+   session).
+7. Smoke-test end-to-end: in a scratch repo, run
+   `/plugin marketplace add ./` (pointing at a
+   local clone), `/plugin install mdsmith-lsp@mdsmith`,
+   open a `.md` file with a known violation, confirm
+   the diagnostic appears in Claude Code's output,
+   and confirm a navigation request (e.g.
+   `definition` on an anchor link) round-trips.
+8. Add the plugin install path to
+   [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+   alongside the existing VS Code pointer.
+
+## Acceptance Criteria
+
+- [ ] `/plugin marketplace add jeduden/mdsmith`
+      registers the marketplace without errors.
+- [ ] `/plugin install mdsmith-lsp@mdsmith` installs
+      the plugin to user scope.
+- [ ] After install and `/reload-plugins`, opening
+      a `.md` file with a known MDS rule violation
+      surfaces the diagnostic to the agent (visible
+      via Ctrl+O when the "diagnostics found"
+      indicator appears).
+- [ ] After install, the agent can run
+      `textDocument/definition` on an anchor link
+      and receive the heading location.
+- [ ] `claude plugin validate` reports no errors on
+      the new manifests.
+- [ ] When the `mdsmith` binary is absent from
+      `$PATH`, the `/plugin` Errors tab shows
+      `Executable not found in $PATH` (no silent
+      hang, no generic crash).
+- [ ] [`docs/guides/install.md`](../docs/guides/install.md)
+      documents the Claude Code install path and
+      the binary prerequisite.
+- [ ] `mdsmith check .` passes with the new files.
+- [ ] All tests pass: `go test ./...`.
+
+## Open Questions
+
+- **Marketplace location.** Hosting under
+  `jeduden/mdsmith` gates discovery on the
+  upstream repo. A separate
+  `jeduden/mdsmith-claude-plugin` repo would
+  decouple plugin releases from binary releases
+  but doubles the maintenance surface. Default to
+  in-repo; revisit if release cadences diverge.
+- **Plugin name collisions.** `mdsmith-lsp`
+  matches the official plugin naming convention
+  (`<tool>-lsp`). Confirm the name is unclaimed if
+  the plugin is later submitted to the official
+  Anthropic marketplace.
+- **Binary version pinning.** The plugin will use
+  whatever `mdsmith` version is on `$PATH`. If a
+  future LSP capability requires a specific
+  version, the plugin would need a version probe
+  on `initialize`. Out of scope here.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/133_lsp-hover.md
+++ b/plan/133_lsp-hover.md
@@ -1,0 +1,200 @@
+---
+id: 133
+title: LSP hover for rule and directive docs
+status: "🔲"
+model: sonnet
+summary: >-
+  Add `textDocument/hover` to `mdsmith lsp` so editors
+  and Claude Code see rule help on hover over a
+  diagnostic squiggle and directive docs on hover
+  inside a `<?…?>` block. Rule docs reuse the body
+  `mdsmith help rule <id>` prints; directive docs
+  come from the existing files under
+  `docs/guides/directives/`.
+---
+# LSP hover for rule and directive docs
+
+## Goal
+
+Surface rule and directive documentation inline in
+the editor without leaving the buffer. Hovering
+over an `MDS001` squiggle should show the
+line-length help body; hovering inside a
+`<?catalog?>` block should show the catalog
+directive docs. Same content the CLI prints, no
+duplication.
+
+## Background
+
+Plan 121 shipped diagnostics and code actions.
+Plan 131 shipped navigation. Hover is the only
+surface in Claude Code's [code intelligence][cc-ci]
+list still missing from `mdsmith lsp` ("get type
+info on hover").
+
+[cc-ci]: https://code.claude.com/docs/en/discover-plugins#code-intelligence
+
+Plan 122 originally bundled hover with a set of VS
+Code palette commands. The two ship independently:
+hover is server-side and benefits every LSP client
+(Claude Code, Neovim, Helix, JetBrains); the
+palette is VS Code-only chrome. This plan extracts
+the hover work so it can land without waiting on
+the palette decisions.
+
+## Non-Goals
+
+- Hover content for non-mdsmith concepts (front-
+  matter schemas, Markdown spec quirks). Scope is
+  rule docs and directive docs only.
+- A new `mdsmith help directives` CLI topic. The
+  directive content is loaded directly by the LSP
+  server from the existing files under
+  [docs/guides/directives/](../docs/guides/directives/).
+- Hover on link targets, headings, or kind values.
+  Definition / implementation already cover those
+  with a click-through; hover here is reserved for
+  documentation, not navigation preview.
+
+## Design
+
+### Capability
+
+Advertise `hoverProvider = true` in the server's
+`initialize` response.
+
+### Resolution order
+
+A `textDocument/hover` request arrives with a
+position. The server resolves in two passes:
+
+**Diagnostic-first.** If the position falls inside
+any active diagnostic range for the document, the
+server returns a `MarkupContent` with kind
+`markdown`. The body holds the diagnostic message
+on one line, a blank line, then the rule's docs.
+Rule docs load via
+[`internal/rules.LookupRule`](../internal/rules/ruledocs.go)
+— the same lookup `mdsmith help rule <id|name>`
+uses.
+
+**Directive fallback.** If no diagnostic covers the
+cursor, the server checks for a `<?directive ...?>`
+block at that position (via
+[`lint/pi_parser.go`](../internal/lint/pi_parser.go)).
+If one matches, the server returns the directive
+docs from [docs/guides/directives/](../docs/guides/directives/).
+
+If neither matches, the server returns `null` (no
+hover).
+
+### Range hint
+
+Each hover response sets `range` to the matched
+span — the diagnostic range, or the directive
+block range. Clients render the hover anchored to
+that span.
+
+### Markdown safety
+
+VS Code, Claude Code, and most LSP clients render
+hover content as Markdown and strip inline HTML.
+Rule and directive docs in this repo today are
+clean of HTML outside code blocks, but a future
+contributor could add a `<span>` or `<details>`
+that would silently disappear from the hover.
+
+This plan adds a preventive guard: enable
+`no-inline-html` (MDS041) on the existing
+`rule-readme` kind in [.mdsmith.yml](../.mdsmith.yml).
+The rule is opt-in by default. The same kind
+already targets [`internal/rules/MDS*/README.md`](../internal/rules)
+and pins `required-structure.schema`. Adding the
+opt-in setting:
+
+```yaml
+kinds:
+  rule-readme:
+    rules:
+      required-structure:
+        schema: internal/rules/proto.md
+      no-inline-html:
+        allow: [kbd]
+```
+
+A spot audit of the existing rule README files
+found no raw HTML outside code blocks; this is
+purely preventive.
+
+Editing `.mdsmith.yml` requires explicit user
+consent per [CLAUDE.md](../CLAUDE.md). The task
+that lands the kind change surfaces the diff
+first.
+
+### Backwards compatibility
+
+`hoverProvider` is additive. Clients that ignore
+the capability see the same server. The
+`no-inline-html` opt-in only fires on the
+`rule-readme` kind; no other Markdown is affected.
+
+## Tasks
+
+1. Wire hover's rule lookup through
+   [`internal/rules`](../internal/rules) APIs
+   (`LookupRule(query) (string, error)` and
+   `ListRules()`). Cover known rules, unknown
+   rules, and rules whose docs have no
+   rule-specific body (fall back to a generic
+   "see `mdsmith help rule <id>`" line).
+2. Add `textDocument/hover` to the LSP server in
+   [`internal/lsp/server.go`](../internal/lsp/server.go).
+   Implement the diagnostic-first then directive-
+   fallback resolution. Return `null` when neither
+   matches.
+3. Add a directive-doc loader that reads from
+   [docs/guides/directives/](../docs/guides/directives/)
+   keyed by directive name. Cache the parsed
+   contents on first read.
+4. Add an integration test in
+   [`cmd/mdsmith`](../cmd/mdsmith) that drives an
+   `initialize` → `didOpen` → `hover` round trip
+   for both the diagnostic and directive cases,
+   and the no-match case.
+5. Add `hoverProvider` to the capability table in
+   [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+   and document the resolution order.
+6. Propose enabling `no-inline-html` on the
+   `rule-readme` kind in [.mdsmith.yml](../.mdsmith.yml).
+   Surface the diff to the user before applying.
+   Add a regression test fixture: a rule README
+   with a raw `<span>` outside a code block fails
+   `mdsmith check` with `MDS041`.
+
+## Acceptance Criteria
+
+- [ ] `hoverProvider` appears in the
+      `initialize` capabilities response.
+- [ ] Hovering over an `MDS001` diagnostic
+      returns a `MarkupContent` whose body
+      contains the line-length help text.
+- [ ] Hovering inside a `<?catalog?>` directive
+      returns the catalog directive docs even when
+      no diagnostic is present at the cursor.
+- [ ] Hovering on plain prose (no diagnostic, no
+      directive) returns `null`.
+- [ ] After the `rule-readme` kind change lands,
+      a fixture rule README containing a raw
+      `<span>` outside a code block fails
+      `mdsmith check` with `MDS041`.
+- [ ] [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+      lists `hoverProvider` in the capability
+      table.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no
+      issues.
+- [ ] `mdsmith check .` passes.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/134_lsp-completion.md
+++ b/plan/134_lsp-completion.md
@@ -64,7 +64,7 @@ Advertise:
 
 ```jsonc
 "completionProvider": {
-  "triggerCharacters": ["#", "[", "/", "\""],
+  "triggerCharacters": ["#", "[", ":", "/", "\""],
   "resolveProvider": false
 }
 ```
@@ -85,6 +85,7 @@ under the cursor. One handler per tag:
 | `[text](#…` (no path)           | Headings in current file        | `Reference`  |
 | `[text](./other.md#…`           | Headings in `other.md`          | `Reference`  |
 | `[text][…`                      | Link-ref labels in current file | `Reference`  |
+| Front-matter `kind:` value      | Kind names from `.mdsmith.yml`  | `EnumMember` |
 | Front-matter `kinds:` list item | Kind names from `.mdsmith.yml`  | `EnumMember` |
 | `<?include file: "…"?>` arg     | Workspace `.md` paths           | `File`       |
 | `<?build source: "…"?>` arg     | Workspace `.md` paths           | `File`       |
@@ -117,16 +118,26 @@ in CommonMark).
 
 ### Kind completion
 
-The canonical front-matter key for kind assignment
-is `kinds:` (a YAML list), parsed by
-[`lint.ParseFrontMatterKinds`](../internal/lint/frontmatter.go).
-When the cursor sits inside a `kinds:` list value
-(typically after `- ` on a new list line), the
+The LSP server's existing `effectiveKindsFor` helper
+in [`internal/lsp/symbols.go`](../internal/lsp/symbols.go)
+already accepts both front-matter forms: the scalar
+`kind: <name>` and the list `kinds: [a, b]`. The
+scalar form is treated as a single-element kinds
+list. The list form is parsed by
+[`lint.ParseFrontMatterKinds`](../internal/lint/frontmatter.go);
+the scalar form is parsed by `frontMatterScalarKind`
+in the same `symbols.go` file.
+
+Completion mirrors that. When the cursor sits in a
+scalar `kind:` value, or inside a `kinds:` list
+item (typically after `- ` on a new list line), the
 handler returns the kind names declared in
-[.mdsmith.yml](../.mdsmith.yml). The scalar form
-`kind:` is not supported by the parser and is not
-offered for completion. The config is already
-loaded by the server (plan 121) and re-read on
+[.mdsmith.yml](../.mdsmith.yml). Supporting both
+keeps completion consistent with the existing
+`definition`, `references`, and `implementation`
+handlers, which already resolve via
+`effectiveKindsFor`. The config is already loaded
+by the server (plan 121) and re-read on
 `.mdsmith.yml` change.
 
 ### Directive-arg completion
@@ -180,14 +191,16 @@ server.
 4. Implement ref-label completion using the
    current file's link-ref defs. Test that
    definitions from other files are excluded.
-5. Implement kind completion for `kinds:` list
-   items against the loaded config. Skip the
-   scalar `kind:` form (not parsed by
-   `lint.ParseFrontMatterKinds`). Test that
-   `.mdsmith.yml` changes flush the cache
-   (config-watcher in plan 121 already triggers a
-   re-read; verify completion picks up the new
-   kinds).
+5. Implement kind completion against the loaded
+   config for both front-matter forms: scalar
+   `kind:` and `kinds:` list items. Mirror the
+   existing parsing in `effectiveKindsFor`
+   (`internal/lsp/symbols.go`) so completion
+   stays consistent with `definition` /
+   `implementation`. Test that `.mdsmith.yml`
+   changes flush the cache (config-watcher in
+   plan 121 already triggers a re-read; verify
+   completion picks up the new kinds).
 6. Implement directive-arg completion across
    `<?include?>`, `<?build?>`, and `<?catalog?>`.
    Return paths relative to the open buffer.
@@ -205,7 +218,7 @@ server.
 
 - [ ] `completionProvider` appears in the
       `initialize` capabilities response with
-      `triggerCharacters: ["#", "[", "/", "\""]`.
+      `triggerCharacters: ["#", "[", ":", "/", "\""]`.
 - [ ] Completion triggered after `[x](#` returns
       every heading in the current file by anchor
       slug.
@@ -217,8 +230,11 @@ server.
       files.
 - [ ] Completion inside a `kinds:` list item in
       front matter returns every kind name in
-      `.mdsmith.yml`. The scalar `kind:` form is
-      not offered.
+      `.mdsmith.yml`.
+- [ ] Completion after scalar `kind:` in front
+      matter returns every kind name in
+      `.mdsmith.yml`, matching the
+      `effectiveKindsFor` server behavior.
 - [ ] Completion triggered inside an
       `<?include file: "…"?>` arg returns
       workspace `.md` paths whose prefix matches.
@@ -250,9 +266,11 @@ server.
   position is inside a code span or fenced block;
   reuse the same AST walk diagnostics use.
 - **Completion in front matter values that are not
-  `kind:`.** The handler should only fire on
-  `kind:` to avoid noise. Match by the YAML key
-  preceding the cursor.
+  `kind:` or `kinds:`.** The handler should only
+  fire on those two keys to avoid noise. Match by
+  the YAML key preceding the cursor; treat scalar
+  `kind:` and list `kinds:` as the two valid
+  contexts and skip everything else.
 
 ## ...
 

--- a/plan/134_lsp-completion.md
+++ b/plan/134_lsp-completion.md
@@ -158,13 +158,14 @@ at completion time.
 Completion shares the symbol index plan 131 builds
 (`internal/lsp/index`). Cold completion is bounded
 by index lookup time; the bench in
-[`internal/lsp/index/bench_test.go`](../internal/lsp/bench_test.go)
-already establishes a per-`didChange` budget under
-20 ms on 10 000 files. Completion adds a substring
-match over the index slice, which is O(N) in the
-file's heading count and O(M) in the workspace
-file count for cross-file paths. A 1 000-file
-workspace returns under 50 ms.
+[`internal/lsp/index/bench_test.go`](../internal/lsp/index/bench_test.go)
+already establishes a cold-build budget of 1 s and
+a per-`didChange` update budget under 20 ms on a
+1 000-file synthetic corpus. Completion adds a
+substring match over the index slice, which is
+O(N) in the file's heading count and O(M) in the
+workspace file count for cross-file paths. A
+1 000-file workspace returns under 50 ms.
 
 ### Backwards compatibility
 

--- a/plan/134_lsp-completion.md
+++ b/plan/134_lsp-completion.md
@@ -1,0 +1,248 @@
+---
+id: 134
+title: LSP completion for anchors, refs, kinds, and directive args
+status: "🔲"
+model: sonnet
+summary: >-
+  Add `textDocument/completion` to `mdsmith lsp` so
+  editors and agents can complete heading anchors in
+  same-file and cross-file Markdown links, link
+  reference labels, kind names in front matter, and
+  `.md` paths in directive args. Reuses the workspace
+  symbol index plan 131 already builds.
+---
+# LSP completion for anchors, refs, kinds, and directive args
+
+## Goal
+
+Let an LSP client complete the four token classes
+mdsmith already indexes: heading anchors, link-ref
+labels, kind names, and directive file paths.
+Completion runs without grep. Agents stop
+fabricating anchors and ref labels that do not
+exist.
+
+## Background
+
+Plan 131 shipped the workspace symbol index. The
+index backs definition, references, implementation,
+and call hierarchy. Completion is the inverse
+lookup. Given a partial token at the cursor, the
+handler returns matching index entries. The data
+is already there; this plan adds a handler.
+
+Claude Code's [code intelligence][cc-ci] docs do
+not list completion explicitly. Completion is a
+standard LSP surface, and any LSP-aware agent or
+editor will use it when present. The value is
+high for Markdown authoring. Anchor and ref-label
+fabrication is a common agent failure mode.
+Completion eliminates it.
+
+[cc-ci]: https://code.claude.com/docs/en/discover-plugins#code-intelligence
+
+## Non-Goals
+
+- Snippet templates beyond plain identifier
+  insertion. No `[$1](#$2)` body completions.
+- Completion of free-form heading text. This plan
+  only completes targets that already exist in the
+  index.
+- Front-matter field-name completion. That requires
+  schema integration (CUE / JSON Schema) and is
+  better paired with a future schema-driven plan.
+- Completion of directive names (`<?include`,
+  `<?catalog`, `<?build`). Few directives exist and
+  contributors learn them quickly; the win is
+  small. Revisit if user feedback requests it.
+
+## Design
+
+### Capability
+
+Advertise:
+
+```jsonc
+"completionProvider": {
+  "triggerCharacters": ["#", "[", ":", "/"],
+  "resolveProvider": false
+}
+```
+
+`resolveProvider` is false. All completion data
+(label, detail, sortText) is computed in one pass
+from the index. No second-stage lookup is needed.
+
+### Trigger contexts
+
+A new helper in
+[`internal/lsp/index/locate.go`](../internal/lsp/index/locate.go)
+returns a completion-context tag and the prefix
+under the cursor. One handler per tag:
+
+| Cursor on…                  | Items returned                  | `kind`       |
+|-----------------------------|---------------------------------|--------------|
+| `[text](#…` (no path)       | Headings in current file        | `Reference`  |
+| `[text](./other.md#…`       | Headings in `other.md`          | `Reference`  |
+| `[text][…`                  | Link-ref labels in current file | `Reference`  |
+| Front-matter `kind: …`      | Kind names from `.mdsmith.yml`  | `EnumMember` |
+| `<?include file: "…"?>` arg | Workspace `.md` paths           | `File`       |
+| `<?build source: "…"?>` arg | Workspace `.md` paths           | `File`       |
+| `<?catalog glob:…` entry    | Workspace `.md` paths           | `File`       |
+
+`detail` carries the source location (file path
+for headings, `.mdsmith.yml` for kinds). `sortText`
+prioritises same-file matches above cross-file
+matches for anchors.
+
+### Anchor completion
+
+For `[text](#…)` the handler walks the open
+buffer's heading list (already cached by the
+symbol index). For `[text](./other.md#…)` the
+handler resolves `./other.md` against the document
+URI and pulls headings from the index slice for
+that file. Slugs come from
+[`mdtext.CollectTOCItems`](../internal/mdtext/mdtext.go)
+to match the same anchor format link resolution
+already uses.
+
+### Ref-label completion
+
+For `[text][…]` the handler returns every
+`LinkReferenceDefinition` label captured by the
+index for the current file. Definitions in other
+files are not returned (link refs are file-local
+in CommonMark).
+
+### Kind completion
+
+For front-matter `kind: …` the handler returns the
+kind names declared in [.mdsmith.yml](../.mdsmith.yml).
+The config is already loaded by the server (plan
+121) and re-read on `.mdsmith.yml` change.
+
+### Directive-arg completion
+
+For `<?include file: "…"?>` and `<?build source:
+"…"?>`, the handler walks the workspace `.md`
+files (the same set the index covers) and returns
+paths whose prefix matches. Paths are returned
+relative to the open buffer's directory.
+
+For `<?catalog glob: ["…"]?>` the same source set
+applies. Glob characters in the prefix are
+escaped; the handler does not try to expand globs
+at completion time.
+
+### Position and performance
+
+Completion shares the symbol index plan 131 builds
+(`internal/lsp/index`). Cold completion is bounded
+by index lookup time; the bench in
+[`internal/lsp/index/bench_test.go`](../internal/lsp/bench_test.go)
+already establishes a per-`didChange` budget under
+20 ms on 10 000 files. Completion adds a substring
+match over the index slice, which is O(N) in the
+file's heading count and O(M) in the workspace
+file count for cross-file paths. A 1 000-file
+workspace returns under 50 ms.
+
+### Backwards compatibility
+
+`completionProvider` is additive. Clients that
+ignore the capability see the same post-plan-131
+server.
+
+## Tasks
+
+1. Extend
+   [`internal/lsp/index/locate.go`](../internal/lsp/index/locate.go)
+   with a `completionContext(uri, pos)` helper
+   returning `(tag, prefix, replaceRange)`. Cover
+   each tag in the table with a unit test.
+2. Add `textDocument/completion` to the server in
+   [`internal/lsp/server.go`](../internal/lsp/server.go),
+   dispatching per tag. Return an empty list (not
+   `null`) when no items match, so clients do not
+   trigger an error path.
+3. Implement anchor completion (current file +
+   cross-file) using the index. Cover both same-
+   file and `./other.md#` cases with integration
+   tests.
+4. Implement ref-label completion using the
+   current file's link-ref defs. Test that
+   definitions from other files are excluded.
+5. Implement kind completion against the loaded
+   config. Test that `.mdsmith.yml` changes flush
+   the cache (config-watcher in plan 121 already
+   triggers a re-read; verify completion picks up
+   the new kinds).
+6. Implement directive-arg completion across
+   `<?include?>`, `<?build?>`, and `<?catalog?>`.
+   Return paths relative to the open buffer.
+7. Advertise `completionProvider` with the trigger
+   characters above. Add an end-to-end test in
+   [`cmd/mdsmith`](../cmd/mdsmith) that drives
+   `initialize` → `didOpen` → `completion` for at
+   least one of each tag.
+8. Add a "Completion" section to
+   [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+   with the trigger-character list and the table
+   of supported contexts.
+
+## Acceptance Criteria
+
+- [ ] `completionProvider` appears in the
+      `initialize` capabilities response with
+      `triggerCharacters: ["#", "[", ":", "/"]`.
+- [ ] Completion triggered after `[x](#` returns
+      every heading in the current file by anchor
+      slug.
+- [ ] Completion triggered after `[x](./other.md#`
+      returns every heading in `other.md`.
+- [ ] Completion triggered after `[x][` returns
+      every link-reference label defined in the
+      current file and excludes labels from other
+      files.
+- [ ] Completion triggered after `kind:` (front
+      matter only) returns every kind name in
+      `.mdsmith.yml`.
+- [ ] Completion triggered inside an
+      `<?include file: "…"?>` arg returns
+      workspace `.md` paths whose prefix matches.
+- [ ] Completion outside any of the above contexts
+      returns an empty list (not `null`, no
+      error).
+- [ ] Completion latency stays under 50 ms on a
+      synthetic 1 000-file workspace; bench reused
+      from plan 131.
+- [ ] [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+      lists `completionProvider` in the capability
+      table and documents the supported contexts.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no
+      issues.
+- [ ] `mdsmith check .` passes.
+
+## Open Questions
+
+- **Heading slug ambiguity.** When two headings in
+  one file collapse to the same slug,
+  [`mdtext.CollectTOCItems`](../internal/mdtext/mdtext.go)
+  appends `-1`, `-2`, …. Completion should return
+  every disambiguated form. Verify in the
+  integration test.
+- **Completion in code blocks.** The trigger
+  characters fire inside fenced code blocks too.
+  The handler should return an empty list when the
+  position is inside a code span or fenced block;
+  reuse the same AST walk diagnostics use.
+- **Completion in front matter values that are not
+  `kind:`.** The handler should only fire on
+  `kind:` to avoid noise. Match by the YAML key
+  preceding the cursor.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/134_lsp-completion.md
+++ b/plan/134_lsp-completion.md
@@ -64,7 +64,7 @@ Advertise:
 
 ```jsonc
 "completionProvider": {
-  "triggerCharacters": ["#", "[", ":", "/"],
+  "triggerCharacters": ["#", "[", "/", "\""],
   "resolveProvider": false
 }
 ```
@@ -80,15 +80,15 @@ A new helper in
 returns a completion-context tag and the prefix
 under the cursor. One handler per tag:
 
-| Cursor on…                  | Items returned                  | `kind`       |
-|-----------------------------|---------------------------------|--------------|
-| `[text](#…` (no path)       | Headings in current file        | `Reference`  |
-| `[text](./other.md#…`       | Headings in `other.md`          | `Reference`  |
-| `[text][…`                  | Link-ref labels in current file | `Reference`  |
-| Front-matter `kind: …`      | Kind names from `.mdsmith.yml`  | `EnumMember` |
-| `<?include file: "…"?>` arg | Workspace `.md` paths           | `File`       |
-| `<?build source: "…"?>` arg | Workspace `.md` paths           | `File`       |
-| `<?catalog glob:…` entry    | Workspace `.md` paths           | `File`       |
+| Cursor on…                      | Items returned                  | `kind`       |
+|---------------------------------|---------------------------------|--------------|
+| `[text](#…` (no path)           | Headings in current file        | `Reference`  |
+| `[text](./other.md#…`           | Headings in `other.md`          | `Reference`  |
+| `[text][…`                      | Link-ref labels in current file | `Reference`  |
+| Front-matter `kinds:` list item | Kind names from `.mdsmith.yml`  | `EnumMember` |
+| `<?include file: "…"?>` arg     | Workspace `.md` paths           | `File`       |
+| `<?build source: "…"?>` arg     | Workspace `.md` paths           | `File`       |
+| `<?catalog glob:…` entry        | Workspace `.md` paths           | `File`       |
 
 `detail` carries the source location (file path
 for headings, `.mdsmith.yml` for kinds). `sortText`
@@ -117,10 +117,17 @@ in CommonMark).
 
 ### Kind completion
 
-For front-matter `kind: …` the handler returns the
-kind names declared in [.mdsmith.yml](../.mdsmith.yml).
-The config is already loaded by the server (plan
-121) and re-read on `.mdsmith.yml` change.
+The canonical front-matter key for kind assignment
+is `kinds:` (a YAML list), parsed by
+[`lint.ParseFrontMatterKinds`](../internal/lint/frontmatter.go).
+When the cursor sits inside a `kinds:` list value
+(typically after `- ` on a new list line), the
+handler returns the kind names declared in
+[.mdsmith.yml](../.mdsmith.yml). The scalar form
+`kind:` is not supported by the parser and is not
+offered for completion. The config is already
+loaded by the server (plan 121) and re-read on
+`.mdsmith.yml` change.
 
 ### Directive-arg completion
 
@@ -173,11 +180,14 @@ server.
 4. Implement ref-label completion using the
    current file's link-ref defs. Test that
    definitions from other files are excluded.
-5. Implement kind completion against the loaded
-   config. Test that `.mdsmith.yml` changes flush
-   the cache (config-watcher in plan 121 already
-   triggers a re-read; verify completion picks up
-   the new kinds).
+5. Implement kind completion for `kinds:` list
+   items against the loaded config. Skip the
+   scalar `kind:` form (not parsed by
+   `lint.ParseFrontMatterKinds`). Test that
+   `.mdsmith.yml` changes flush the cache
+   (config-watcher in plan 121 already triggers a
+   re-read; verify completion picks up the new
+   kinds).
 6. Implement directive-arg completion across
    `<?include?>`, `<?build?>`, and `<?catalog?>`.
    Return paths relative to the open buffer.
@@ -195,7 +205,7 @@ server.
 
 - [ ] `completionProvider` appears in the
       `initialize` capabilities response with
-      `triggerCharacters: ["#", "[", ":", "/"]`.
+      `triggerCharacters: ["#", "[", "/", "\""]`.
 - [ ] Completion triggered after `[x](#` returns
       every heading in the current file by anchor
       slug.
@@ -205,9 +215,10 @@ server.
       every link-reference label defined in the
       current file and excludes labels from other
       files.
-- [ ] Completion triggered after `kind:` (front
-      matter only) returns every kind name in
-      `.mdsmith.yml`.
+- [ ] Completion inside a `kinds:` list item in
+      front matter returns every kind name in
+      `.mdsmith.yml`. The scalar `kind:` form is
+      not offered.
 - [ ] Completion triggered inside an
       `<?include file: "…"?>` arg returns
       workspace `.md` paths whose prefix matches.

--- a/plan/134_lsp-completion.md
+++ b/plan/134_lsp-completion.md
@@ -140,6 +140,22 @@ handlers, which already resolve via
 by the server (plan 121) and re-read on
 `.mdsmith.yml` change.
 
+Note: scalar `kind:` is an LSP-layer convenience.
+The lint pipeline parses only `kinds:` via
+[`lint.ParseFrontMatterKinds`](../internal/lint/frontmatter.go),
+and the user-facing
+[file-kinds guide](../docs/guides/file-kinds.md)
+documents only the list form.
+
+So `mdsmith check` and `mdsmith fix` will not
+honor a scalar `kind:` even though the LSP
+treats both as equivalent. A future plan can
+align the lint pipeline and the docs with the
+LSP behavior. Until then, completion offers
+`kind:` because `effectiveKindsFor` already
+does, but contributors should prefer `kinds:`
+in fixtures.
+
 ### Directive-arg completion
 
 For `<?include file: "…"?>` and `<?build source:

--- a/plan/151_lsp-rename.md
+++ b/plan/151_lsp-rename.md
@@ -1,0 +1,283 @@
+---
+id: 151
+title: LSP rename for headings and link-reference labels
+status: "🔲"
+model: opus
+summary: >-
+  Add `textDocument/prepareRename` and
+  `textDocument/rename` to `mdsmith lsp` so an editor
+  or agent can rename a heading and have every
+  workspace anchor link rewritten in one
+  `WorkspaceEdit`. Also covers link-reference label
+  rename within the current file.
+---
+# LSP rename for headings and link-reference labels
+
+## Goal
+
+Let an LSP client rename a heading from one
+buffer. Every workspace anchor link that points
+at it (`[text](file.md#anchor)`,
+`[text](#anchor)`) updates in one atomic
+`WorkspaceEdit`. The same flow handles link-ref
+label renames. Each shortcut and full reference
+use in the file updates with the def.
+
+Without this, an agent that restructures Markdown
+breaks anchors silently. MDS027
+(cross-file-reference-integrity) catches the
+breakage on the next lint pass, but only after the
+fact.
+
+## Background
+
+Plan 131 shipped the workspace symbol index plus
+`definition`, `references`, `implementation`,
+and call hierarchy. Rename was a non-goal there.
+Heading rewrites need anchor fixups across the
+workspace. The team wanted that work in its own
+plan.
+
+The index already knows every edge it needs:
+
+- Headings keyed by `(file, anchor)`.
+- Anchor links keyed by `(file, anchor)`.
+- Link-ref defs and uses keyed by `(file, label)`.
+
+Slug computation uses
+[`mdtext.CollectTOCItems`](../internal/mdtext/mdtext.go).
+The same function disambiguates duplicate slugs by
+appending `-1`, `-2`, …; rename has to recompute
+the full slug map for the file to know whether the
+new heading text collides with an existing one.
+
+## Non-Goals
+
+- File rename (`workspace/willRename` /
+  `didRename`). Separate concern; rewrites the
+  link path, not the anchor.
+- Renaming a `kind:` value or a `kinds:` list
+  entry. Kinds live in
+  [.mdsmith.yml](../.mdsmith.yml); editing the
+  config from an LSP rename would conflict with
+  the user-consent rule in
+  [CLAUDE.md](../CLAUDE.md).
+- Renaming a directive name. Few directives, low
+  value.
+- Renaming front-matter keys. Schema work owns
+  that.
+- Markdown reflow after rename. The edit replaces
+  the old heading text with the new text only;
+  surrounding paragraph wrapping is left to the
+  user or to `mdsmith fix`.
+
+## Design
+
+### Capability
+
+```jsonc
+"renameProvider": {
+  "prepareProvider": true
+}
+```
+
+`prepareProvider` is true because the rename range
+for a heading excludes the leading `#`s and the
+trailing closing `#`s (if any). The client needs
+the explicit range so the rename popup highlights
+only the heading text.
+
+### `textDocument/prepareRename`
+
+Returns the rename range for the symbol under the
+cursor:
+
+| Cursor on…                    | Range returned                                    |
+|-------------------------------|---------------------------------------------------|
+| Heading text                  | The text run between leading and trailing markers |
+| `[label]: url` definition     | The label text inside `[…]`                       |
+| `[text][label]` reference use | The label text inside `[…][label]`                |
+| Anywhere else                 | `null` (rename not supported here)                |
+
+Setext headings (`=====` / `-----`) are also in
+scope: the range is the heading line, the
+underline stays as-is.
+
+### `textDocument/rename`
+
+Computes a `WorkspaceEdit` per symbol kind.
+
+#### Heading rename
+
+1. Recompute the file's full slug map under the
+   new heading text using
+   [`mdtext.CollectTOCItems`](../internal/mdtext/mdtext.go).
+2. Map old slug → new slug. If the new slug
+   collides with another heading in the file
+   (because the disambiguator now resolves
+   differently), return an LSP error
+   (`InvalidParams` with a `data` field naming the
+   colliding heading) rather than silently
+   shifting numbered suffixes. Slug collisions
+   are rare and surprising; failing loud is
+   better than corrupting cross-file links.
+3. Build the `WorkspaceEdit`:
+
+  - One `TextEdit` on the heading line in the
+     current file.
+  - One `TextEdit` per workspace anchor link
+     pointing at `(file, oldSlug)`. The match
+     uses the same edge table that powers
+     `textDocument/references` for headings.
+  - Same-file anchor links (`[text](#oldSlug)`)
+     are included.
+  - Setext heading renames touch only the text
+     line; the underline keeps its byte length
+     even if the text length changes (CommonMark
+     does not require the underline width to
+     match the text).
+
+#### Link-ref label rename
+
+1. The rename is file-local — link-ref defs and
+   their uses do not cross files in CommonMark.
+2. Build the `WorkspaceEdit`:
+
+  - One edit on the `[label]: url` definition.
+  - One edit per `[text][label]` and shortcut
+     `[label]` use in the same file.
+
+3. Collisions: if the new label matches another
+   defined label, return `InvalidParams`. MDS029
+   (no-unused-link-definitions) and MDS028
+   (no-undefined-reference-labels) would surface
+   the breakage anyway, but the LSP error catches
+   it before the edit applies.
+
+### Disambiguator handling
+
+`mdtext.CollectTOCItems` appends `-1`, `-2`, …
+when two headings share a base slug. A rename can
+shift those numbers:
+
+```markdown
+## Setup        <!-- slug "setup" -->
+## Setup        <!-- slug "setup-1" -->
+```
+
+Renaming the first to "Configuration" shifts the
+second's slug from `setup-1` to `setup`. Any
+anchor pointing at `#setup-1` silently breaks.
+The plan addresses this two ways:
+
+- The slug-collision check in step 2 of heading
+  rename catches the case where the rename makes
+  the *new* heading's slug collide with another.
+- A separate "shift detection" pass walks the
+  slug map after the rename and finds any heading
+  whose slug changed even though it wasn't
+  renamed. Each shifted slug becomes another
+  `TextEdit` rewriting links pointing at the old
+  slug to the new one. This keeps the workspace
+  consistent.
+
+The integration test covers a three-heading file
+with a duplicate-name pair to verify shift
+detection.
+
+### Position and performance
+
+Rename reuses the index from plan 131. Cost:
+
+- `prepareRename`: O(1) — single position lookup.
+- `rename` (heading): O(headings in file) for
+  slug recompute, plus O(workspace anchor links
+  to this file) for the edge walk. The 1 000-file
+  benchmark in
+  [`internal/lsp/index/bench_test.go`](../internal/lsp/index/bench_test.go)
+  upper-bounds this at well under 100 ms.
+- `rename` (link-ref): O(uses in current file)
+  only.
+
+### Backwards compatibility
+
+`renameProvider` is additive. Clients that ignore
+the capability see the post-plan-134 server.
+
+## Tasks
+
+1. Add `prepareRename` to the server
+   ([`internal/lsp/server.go`](../internal/lsp/server.go))
+   dispatching on the position-tag from
+   [`internal/lsp/index/locate.go`](../internal/lsp/index/locate.go).
+   Return null for unsupported positions.
+2. Implement heading rename. Use
+   `mdtext.CollectTOCItems` for slug recomputation.
+   Surface slug-collision errors via
+   `InvalidParams`. Cover same-file and cross-file
+   anchor edges.
+3. Implement shift detection for the
+   disambiguator case. Add a unit test with two
+   headings sharing a base slug.
+4. Implement link-ref label rename. Cover full
+   `[text][label]` and shortcut `[label]` uses.
+5. Advertise `renameProvider.prepareProvider =
+   true` in the `initialize` capabilities.
+6. Add an end-to-end integration test in
+   [`cmd/mdsmith`](../cmd/mdsmith) driving
+   `initialize` → `didOpen` (across three files)
+   → `prepareRename` → `rename` → assert the
+   resulting `WorkspaceEdit` covers every expected
+   edge.
+7. Add a "Rename" section to
+   [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+   with the prepareRename range table and the
+   collision-error contract.
+
+## Acceptance Criteria
+
+- [ ] `renameProvider.prepareProvider = true`
+      appears in the `initialize` capabilities.
+- [ ] `prepareRename` on a heading returns the
+      heading text range (excluding leading `#`s).
+- [ ] `prepareRename` on plain prose returns
+      `null`.
+- [ ] `rename` on a heading rewrites the heading
+      text in the current file and every anchor
+      link in the workspace pointing at the old
+      slug.
+- [ ] `rename` triggers shift detection: when a
+      duplicate-name disambiguator changes,
+      affected anchors update too.
+- [ ] `rename` on a link-ref definition rewrites
+      every `[text][label]` and shortcut `[label]`
+      use in the same file.
+- [ ] A heading rename whose new slug collides
+      with an existing heading in the same file
+      fails with an LSP `InvalidParams` error
+      naming the colliding heading.
+- [ ] [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
+      documents `renameProvider` and the
+      collision contract.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no
+      issues.
+- [ ] `mdsmith check .` passes.
+
+## Open Questions
+
+- **Cross-file link-ref defs.** Some Markdown
+  flavors (not CommonMark) allow shared link-ref
+  files. The plan keeps link-ref rename
+  file-local; revisit if a future flavor profile
+  introduces cross-file refs.
+- **Annotation behavior.** A `WorkspaceEdit` can
+  include `changeAnnotations` so the client shows
+  a confirmation dialog ("rename heading and 47
+  anchor links?"). The first pass returns a flat
+  edit; add annotations later if reviewer
+  feedback requests them.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/152_claude-code-skills-agents-hooks.md
+++ b/plan/152_claude-code-skills-agents-hooks.md
@@ -51,16 +51,13 @@ separate plugins.
 
 ## Non-Goals
 
-- An MCP server. mdsmith has no API surface that
-  benefits from MCP; the LSP server already
-  exposes everything an editor or agent needs.
-- Bundling binaries inside the plugin. Plan 130
-  covers binary distribution.
-- Output styles. No clear use case yet.
-- Themes. No clear use case.
-- A combined single plugin. Skills/agents/hooks
-  ship as a separate plugin so users can install
-  the LSP without pulling in the heavier set.
+- An MCP server. The LSP already exposes
+  everything an editor or agent needs.
+- Bundling binaries. Plan 130 covers that.
+- Output styles or themes. No clear use case.
+- A combined single plugin. Splitting LSP from
+  the rest lets users install only what they
+  want.
 
 ## Design
 
@@ -171,12 +168,16 @@ single file that was just edited.
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "mdsmith fix \"$CLAUDE_FILE_PATH\""
+        "command": "mdsmith fix -- \"$CLAUDE_FILE_PATH\""
       }
     ]
   }
 }
 ```
+
+The `--` terminator stops `$CLAUDE_FILE_PATH` from
+being parsed as a flag if a filename starts with
+`-`.
 
 The hook is opt-in via the plugin's enable/disable
 toggle. Users who prefer to run `fix` manually
@@ -240,17 +241,16 @@ but it does not auto-install.
    should be required — confirm during smoke
    test.
 8. Extend [.mdsmith.yml](../.mdsmith.yml)'s
-   `kind-assignment` and the matching override
-   block to cover
+   `kind-assignment` block (and the matching
+   `overrides:` entries that disable
+   `first-line-heading` and `heading-increment`
+   for SKILL.md files) to cover
    `editors/claude-code-tools/skills/*/SKILL.md`.
    The existing `skill` kind currently targets
-   only `.claude/skills/*/SKILL.md` (lines 93
-   and 99 of `.mdsmith.yml`); without the
-   extension the new SKILL.md files would fail
-   `first-line-heading` and other rules the
-   `skill` override disables. Surface the diff
-   per [CLAUDE.md](../CLAUDE.md) before
-   applying.
+   only `.claude/skills/*/SKILL.md`; without
+   the extension, the new SKILL.md files would
+   fail those rules. Surface the diff per
+   [CLAUDE.md](../CLAUDE.md) before applying.
 9. Add a `README.md` covering install, the three
    skills, the agent, the hook, and the binary
    prerequisite.

--- a/plan/152_claude-code-skills-agents-hooks.md
+++ b/plan/152_claude-code-skills-agents-hooks.md
@@ -1,0 +1,298 @@
+---
+id: 152
+title: Claude Code plugin extensions — skills, agents, hooks
+status: "🔲"
+model: sonnet
+summary: >-
+  Extend the Claude Code marketplace from plan 132
+  with a second plugin (`mdsmith-tools`) that bundles
+  three slash-command skills (`fix`, `kinds`,
+  `check`), a `markdown-reviewer` subagent, and a
+  post-edit lint hook so Claude Code users get a
+  richer Markdown workflow beyond the LSP-only plugin.
+---
+# Claude Code plugin extensions — skills, agents, hooks
+
+## Goal
+
+Ship a second plugin in the mdsmith Claude Code
+marketplace from plan 132. The new plugin adds
+the three component types the LSP plugin omits:
+skills, subagents, and hooks. Skills run mdsmith
+workflows by name. The subagent delegates
+Markdown review. The hook lints files
+automatically after every edit. None of these
+work from the bare LSP server.
+
+## Background
+
+Plan 132 ships `mdsmith-lsp`. That plugin is LSP
+only. The marketplace lives at the repo root.
+The Claude Code [plugin reference][plug-ref]
+defines five component types:
+
+[plug-ref]: https://code.claude.com/docs/en/plugins-reference
+
+| Component   | Plan 132 | This plan |
+|-------------|----------|-----------|
+| LSP servers | ✅       | —         |
+| Skills      | —        | ✅        |
+| Agents      | —        | ✅        |
+| Hooks       | —        | ✅        |
+| MCP servers | —        | (skip)    |
+
+LSP and skills/agents/hooks separate cleanly.
+A user who wants only diagnostics installs
+`mdsmith-lsp`. A user who wants the full
+workflow installs both. The split mirrors the
+official-marketplace convention. `gopls-lsp`
+ships LSP only; richer Go tooling lives in
+separate plugins.
+
+## Non-Goals
+
+- An MCP server. mdsmith has no API surface that
+  benefits from MCP; the LSP server already
+  exposes everything an editor or agent needs.
+- Bundling binaries inside the plugin. Plan 130
+  covers binary distribution.
+- Output styles. No clear use case yet.
+- Themes. No clear use case.
+- A combined single plugin. Skills/agents/hooks
+  ship as a separate plugin so users can install
+  the LSP without pulling in the heavier set.
+
+## Design
+
+### Repository layout
+
+```text
+.claude-plugin/
+  marketplace.json          # adds mdsmith-tools entry
+editors/
+  claude-code/              # mdsmith-lsp (plan 132)
+  claude-code-tools/        # mdsmith-tools (this plan)
+    .claude-plugin/
+      plugin.json
+    skills/
+      fix/SKILL.md
+      kinds/SKILL.md
+      check/SKILL.md
+    agents/
+      markdown-reviewer.md
+    hooks/
+      hooks.json
+    README.md
+```
+
+The `editors/claude-code-tools/` directory mirrors
+the layout of `editors/claude-code/`. The
+marketplace.json from plan 132 grows a second
+entry pointing at it.
+
+### Marketplace update
+
+```json
+{
+  "plugins": [
+    {
+      "name": "mdsmith-lsp",
+      "source": "./editors/claude-code",
+      "description": "Inline mdsmith diagnostics and Markdown navigation"
+    },
+    {
+      "name": "mdsmith-tools",
+      "source": "./editors/claude-code-tools",
+      "description": "Markdown skills, reviewer agent, and post-edit lint hook"
+    }
+  ]
+}
+```
+
+### Skills
+
+Each skill is a directory under `skills/` with a
+`SKILL.md` file. Skills are namespaced by plugin:
+`/mdsmith-tools:fix`, `/mdsmith-tools:kinds`,
+`/mdsmith-tools:check`.
+
+| Skill   | Body                                                  | Wraps                                             |
+|---------|-------------------------------------------------------|---------------------------------------------------|
+| `fix`   | Run `mdsmith fix .` on the workspace, summarize stats | [`mdsmith fix`](../docs/reference/cli/fix.md)     |
+| `kinds` | Show kind assignments and resolved rule config        | [`mdsmith kinds`](../docs/reference/cli/kinds.md) |
+| `check` | Run `mdsmith check .` and show diagnostics            | [`mdsmith check`](../docs/reference/cli/check.md) |
+
+`fix` is the highest-leverage skill: when an agent
+edits Markdown across many files, one command
+applies all the auto-fixes. `kinds` answers "what
+rules apply to this file?". `check` is a deliberate
+duplicate of LSP diagnostics for users who installed
+`mdsmith-tools` without `mdsmith-lsp`.
+
+Each `SKILL.md` follows the schema documented in
+the Claude Code [Skills][skills-ref] reference.
+Front matter sets `name`, `description`, and an
+optional `tools` list. The body explains when to
+invoke and what to run.
+
+[skills-ref]: https://code.claude.com/docs/en/skills
+
+### Agent: `markdown-reviewer`
+
+A specialised subagent for reviewing Markdown
+pull requests and document drafts. Tools: Read,
+Grep, Bash (`mdsmith check`), GitHub MCP for PR
+comments. Description steers Claude to delegate
+when a task involves "review this docs PR" or
+"check this Markdown for style issues".
+
+The agent shells out to `mdsmith check --json`
+and `mdsmith metrics` to surface readability,
+length, and structural issues, then writes a
+structured review summary. It does not auto-fix
+— users delegate that to the `fix` skill or to
+the LSP `source.fixAll.mdsmith` action.
+
+### Hooks
+
+One hook: `PostToolUse` on `Edit` and `Write` of
+`*.md` files. The hook runs `mdsmith fix` on the
+single file that was just edited.
+
+```jsonc
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "mdsmith fix \"$CLAUDE_FILE_PATH\""
+      }
+    ]
+  }
+}
+```
+
+The hook is opt-in via the plugin's enable/disable
+toggle. Users who prefer to run `fix` manually
+disable the plugin or fork it without the hook.
+
+The hook does not fire on `MultiEdit` because the
+LSP `source.fixAll.mdsmith` action covers the
+multi-buffer case more cleanly. Document this in
+the plugin README so users are not surprised.
+
+### `plugin.json`
+
+```json
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mdsmith-tools",
+  "description": "Markdown skills, reviewer agent, and post-edit lint hook",
+  "homepage": "https://github.com/jeduden/mdsmith",
+  "repository": "https://github.com/jeduden/mdsmith",
+  "license": "MIT",
+  "keywords": ["markdown", "review", "lint"],
+  "skills": "./skills/",
+  "agents": ["./agents/markdown-reviewer.md"],
+  "hooks": "./hooks/hooks.json"
+}
+```
+
+No inline component definitions; each component
+loads from its standard location so the manifest
+stays small.
+
+### Backwards compatibility
+
+`mdsmith-lsp` (plan 132) is unchanged. The
+marketplace.json gains one entry. Users who
+already installed `mdsmith-lsp` see the new
+plugin in `/plugin marketplace update` output
+but it does not auto-install.
+
+## Tasks
+
+1. Create the `editors/claude-code-tools/`
+   directory with the layout above.
+2. Add the `plugin.json` manifest declaring
+   `skills`, `agents`, and `hooks` paths.
+3. Write the three SKILL.md files (`fix`,
+   `kinds`, `check`). Each shells out to the
+   matching CLI subcommand and surfaces stderr
+   on non-zero exit.
+4. Write `agents/markdown-reviewer.md` with the
+   agent definition. Front matter plus a body
+   describing capabilities and triggers.
+5. Add `hooks/hooks.json` with the `PostToolUse`
+   entry.
+6. Extend the marketplace.json from plan 132 to
+   include the new plugin entry.
+7. Update [.mdsmith.yml](../.mdsmith.yml)'s
+   `directory-structure.allowed` if needed to
+   cover the new path. `editors/**` is already
+   allowed (per plan 132's audit), so no change
+   should be required — confirm during smoke
+   test.
+8. Add a `README.md` covering install, the three
+   skills, the agent, the hook, and the binary
+   prerequisite.
+9. Document the new plugin in
+   [docs/guides/install.md](../docs/guides/install.md)
+   under the Claude Code section plan 132 added.
+10. Smoke-test end-to-end: install `mdsmith-tools`
+    in a scratch workspace, run each skill, invoke
+    the agent on a sample Markdown file, edit a
+    `.md` file and verify the post-edit hook
+    runs `mdsmith fix`.
+
+## Acceptance Criteria
+
+- [ ] `/plugin install mdsmith-tools@mdsmith`
+      succeeds after `/reload-plugins`.
+- [ ] `/mdsmith-tools:fix` runs `mdsmith fix .`
+      and reports the fix-of-total count.
+- [ ] `/mdsmith-tools:kinds` shows kind
+      assignments for the current file.
+- [ ] `/mdsmith-tools:check` runs
+      `mdsmith check .` and surfaces diagnostics
+      to the agent.
+- [ ] The `markdown-reviewer` agent appears in
+      the agent picker and produces a structured
+      review summary on a sample Markdown PR.
+- [ ] After editing a `.md` file via Claude
+      Code's Edit or Write tool, `mdsmith fix`
+      runs automatically on that file.
+- [ ] `claude plugin validate
+      ./editors/claude-code-tools` reports no
+      errors.
+- [ ] [docs/guides/install.md](../docs/guides/install.md)
+      documents both `mdsmith-lsp` and
+      `mdsmith-tools` install paths.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `mdsmith check .` passes including the new
+      manifests and SKILL.md files.
+
+## Open Questions
+
+- **Combined plugin alternative.** A single
+  `mdsmith` plugin bundling LSP + skills + agent
+  + hook would be one install instead of two.
+  The split mirrors the official-marketplace
+  convention (`gopls-lsp` is LSP-only) but adds
+  user friction. Revisit if reviewer feedback
+  prefers a single plugin.
+- **Hook scope.** Running `mdsmith fix` after
+  every Edit can be surprising in projects where
+  the user prefers manual fixes. The hook is
+  opt-in via plugin enable, but a per-file
+  ignore mechanism may be needed.
+- **Agent vs. skill for review.** The
+  `markdown-reviewer` agent is heavyweight.
+  A `/mdsmith-tools:review <file>` skill might
+  cover most use cases more cheaply. Build the
+  agent first, drop to a skill if telemetry
+  shows low invocation.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/152_claude-code-skills-agents-hooks.md
+++ b/plan/152_claude-code-skills-agents-hooks.md
@@ -92,6 +92,12 @@ entry pointing at it.
 
 ### Marketplace update
 
+The full `marketplace.json` (per plan 132) keeps
+its `name`, `owner`, `description`, and
+`$schema` fields. Only the `plugins` array
+grows. The block below is a fragment, not a
+complete file:
+
 ```json
 {
   "plugins": [
@@ -233,13 +239,25 @@ but it does not auto-install.
    allowed (per plan 132's audit), so no change
    should be required — confirm during smoke
    test.
-8. Add a `README.md` covering install, the three
+8. Extend [.mdsmith.yml](../.mdsmith.yml)'s
+   `kind-assignment` and the matching override
+   block to cover
+   `editors/claude-code-tools/skills/*/SKILL.md`.
+   The existing `skill` kind currently targets
+   only `.claude/skills/*/SKILL.md` (lines 93
+   and 99 of `.mdsmith.yml`); without the
+   extension the new SKILL.md files would fail
+   `first-line-heading` and other rules the
+   `skill` override disables. Surface the diff
+   per [CLAUDE.md](../CLAUDE.md) before
+   applying.
+9. Add a `README.md` covering install, the three
    skills, the agent, the hook, and the binary
    prerequisite.
-9. Document the new plugin in
-   [docs/guides/install.md](../docs/guides/install.md)
-   under the Claude Code section plan 132 added.
-10. Smoke-test end-to-end: install `mdsmith-tools`
+10. Document the new plugin in
+    [docs/guides/install.md](../docs/guides/install.md)
+    under the Claude Code section plan 132 added.
+11. Smoke-test end-to-end: install `mdsmith-tools`
     in a scratch workspace, run each skill, invoke
     the agent on a sample Markdown file, edit a
     `.md` file and verify the post-edit hook
@@ -275,23 +293,18 @@ but it does not auto-install.
 ## Open Questions
 
 - **Combined plugin alternative.** A single
-  `mdsmith` plugin bundling LSP + skills + agent
-  + hook would be one install instead of two.
-  The split mirrors the official-marketplace
-  convention (`gopls-lsp` is LSP-only) but adds
-  user friction. Revisit if reviewer feedback
-  prefers a single plugin.
-- **Hook scope.** Running `mdsmith fix` after
-  every Edit can be surprising in projects where
-  the user prefers manual fixes. The hook is
-  opt-in via plugin enable, but a per-file
-  ignore mechanism may be needed.
+  `mdsmith` plugin bundling everything is one
+  install vs two. Split mirrors the official
+  convention (`gopls-lsp` is LSP-only). Revisit
+  if reviewers prefer one plugin.
+- **Hook scope.** Auto-`fix` on every Edit may
+  surprise users who prefer manual fixes. The
+  hook is opt-in via plugin enable; a per-file
+  override may be needed later.
 - **Agent vs. skill for review.** The
-  `markdown-reviewer` agent is heavyweight.
-  A `/mdsmith-tools:review <file>` skill might
-  cover most use cases more cheaply. Build the
-  agent first, drop to a skill if telemetry
-  shows low invocation.
+  `markdown-reviewer` agent is heavyweight; a
+  `/mdsmith-tools:review` skill might cover
+  most cases more cheaply.
 
 ## ...
 


### PR DESCRIPTION
This PR adds five planning documents that close the gaps between mdsmith's LSP server and Claude Code's [code intelligence](https://code.claude.com/docs/en/discover-plugins#code-intelligence) feature set, and refactors plan 122 to split off its hover content.

## Summary
Five new plans guide the next iterations of mdsmith's LSP capabilities and Claude Code plugin support. Plan 122 (VS Code palette commands) is also refactored to split out hover into its own plan.

## Key Changes

- **Plan 132: Package mdsmith LSP as a Claude Code plugin** (`plan/132_claude-code-plugin.md`)
  - `.claude-plugin/marketplace.json` at repo root + `editors/claude-code/.claude-plugin/plugin.json` declaring `lspServers`
  - Two-step install (`/plugin marketplace add` then `/plugin install`)
  - Adds a task to update `.mdsmith.yml`'s `directory-structure.allowed` to permit `.claude-plugin/**`

- **Plan 133: LSP hover for rule and directive docs** (`plan/133_lsp-hover.md`)
  - `textDocument/hover` with diagnostic-first resolution and directive fallback
  - Markdown-safety guard via `no-inline-html` on the `rule-readme` kind

- **Plan 134: LSP completion for anchors, refs, kinds, and directive args** (`plan/134_lsp-completion.md`)
  - `textDocument/completion` with `triggerCharacters: ["#", "[", ":", "/", "\""]`
  - Heading anchors (same-file and cross-file), link-reference labels, kind names (both scalar `kind:` and list `kinds:` mirroring `effectiveKindsFor`), and `.md` paths in directive args
  - Notes that scalar `kind:` is an LSP-layer convenience the lint pipeline does not honor

- **Plan 151: LSP rename for headings and link-reference labels** (`plan/151_lsp-rename.md`)
  - `textDocument/prepareRename` + `textDocument/rename`
  - Heading rename rewrites every cross-file anchor link in one `WorkspaceEdit`; link-ref label rename updates every use in the file
  - Disambiguator shift detection (when removing one of two identically-named headings shifts the slug of the other)
  - Slug-collision errors surface via `InvalidParams`
  - Picks up the work plan 131 listed as a non-goal

- **Plan 152: Claude Code plugin extensions — skills, agents, hooks** (`plan/152_claude-code-skills-agents-hooks.md`)
  - Second plugin (`mdsmith-tools`) in the marketplace from plan 132
  - Three skills: `/mdsmith-tools:fix`, `/mdsmith-tools:kinds`, `/mdsmith-tools:check`
  - `markdown-reviewer` subagent for docs PRs
  - `PostToolUse` hook on Edit/Write of `*.md` runs `mdsmith fix` on the touched file

- **Plan 122 refactoring** (`plan/122_vscode-hover-and-palette.md`)
  - Hover moved to plan 133 to separate concerns
  - Title trimmed to "VS Code palette commands"
  - Background restructured into Palette / Hover (plan 133) / CLI-only buckets

## Implementation Notes

All five new plans follow the established pattern with clear goals, non-goals, design sections, task breakdowns, and acceptance criteria. The plans build on prior work (plan 121's diagnostics, plan 131's symbol index) and maintain backwards compatibility by advertising new LSP capabilities additively.

https://claude.ai/code/session_01RsvvPinou2uKU33vhDFcYq