### PR TITLE
Add VS Code palette commands for mdsmith operations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -34,7 +34,7 @@ footer: |
 | 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                                    |
 | 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                              |
 | 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                                               |
-| 122 | 🔳     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                                      |
+| 122 | ✅     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                                      |
 | 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                                                 |
 | 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                                                   |
 | 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                                           |

--- a/PLAN.md
+++ b/PLAN.md
@@ -34,7 +34,7 @@ footer: |
 | 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                                    |
 | 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                              |
 | 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                                               |
-| 122 | 🔲     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                                      |
+| 122 | 🔳     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                                      |
 | 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                                                 |
 | 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                                                   |
 | 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                                           |

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -212,15 +212,17 @@ Command Palette under the `mdsmith:` category.
 
 | Command                              | Requires trust | Action                                                                      |
 |--------------------------------------|:--------------:|-----------------------------------------------------------------------------|
-| `mdsmith: Initialize config`         |                | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.          |
+| `mdsmith: Initialize config`         | yes            | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.          |
 | `mdsmith: Install Git merge driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.             |
 | `mdsmith: Fix all Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.   |
 | `mdsmith: Explain rule on this file` |                | Pick a rule; open `mdsmith kinds why <file> <rule> --json` in a side panel. |
 | `mdsmith: Show resolved config`      |                | Open `mdsmith kinds resolve <file> --json` in a side panel.                 |
 
-`mdsmith: Fix all Markdown` and `mdsmith: Install Git merge driver`
-are hidden from the palette in untrusted workspaces and show a
-confirmation dialog before modifying files.
+`mdsmith: Initialize config`, `mdsmith: Fix all Markdown`, and
+`mdsmith: Install Git merge driver` are hidden from the palette in
+untrusted workspaces. `mdsmith: Fix all Markdown` and
+`mdsmith: Install Git merge driver` also show a confirmation dialog
+before modifying files.
 
 `mdsmith: Explain rule on this file` and
 `mdsmith: Show resolved config` are visible only when a Markdown

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -215,8 +215,8 @@ Command Palette under the `mdsmith:` category.
 | `mdsmith: Initialize config`         | yes            | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.          |
 | `mdsmith: Install Git merge driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.             |
 | `mdsmith: Fix all Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.   |
-| `mdsmith: Explain rule on this file` |                | Pick a rule; open `mdsmith kinds why <file> <rule> --json` in a side panel. |
-| `mdsmith: Show resolved config`      |                | Open `mdsmith kinds resolve <file> --json` in a side panel.                 |
+| `mdsmith: Explain rule on this file` | —              | Pick a rule; open `mdsmith kinds why <file> <rule> --json` in a side panel. |
+| `mdsmith: Show resolved config`      | —              | Open `mdsmith kinds resolve <file> --json` in a side panel.                 |
 
 `mdsmith: Initialize config`, `mdsmith: Fix all Markdown`, and
 `mdsmith: Install Git merge driver` are hidden from the palette in

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -212,20 +212,20 @@ Command Palette under the `mdsmith:` category.
 
 | Command                              | Requires trust | Action                                                                         |
 |--------------------------------------|:--------------:|--------------------------------------------------------------------------------|
-| `mdsmith: Initialize config`         | yes            | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.             |
-| `mdsmith: Install Git merge driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.                |
-| `mdsmith: Fix all Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.      |
-| `mdsmith: Explain rule on this file` | —              | Pick a rule; open `mdsmith kinds why --json -- <file> <rule>` in a side panel. |
-| `mdsmith: Show resolved config`      | —              | Open `mdsmith kinds resolve --json -- <file>` in a side panel.                 |
+| `mdsmith: Initialize Config`         | yes            | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.             |
+| `mdsmith: Install Git Merge Driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.                |
+| `mdsmith: Fix All Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.      |
+| `mdsmith: Explain Rule on This File` | —              | Pick a rule; open `mdsmith kinds why --json -- <file> <rule>` in a side panel. |
+| `mdsmith: Show Resolved Config`      | —              | Open `mdsmith kinds resolve --json -- <file>` in a side panel.                 |
 
-`mdsmith: Initialize config`, `mdsmith: Fix all Markdown`, and
-`mdsmith: Install Git merge driver` are hidden from the palette in
-untrusted workspaces. `mdsmith: Fix all Markdown` and
-`mdsmith: Install Git merge driver` also show a confirmation dialog
+`mdsmith: Initialize Config`, `mdsmith: Fix All Markdown`, and
+`mdsmith: Install Git Merge Driver` are hidden from the palette in
+untrusted workspaces. `mdsmith: Fix All Markdown` and
+`mdsmith: Install Git Merge Driver` also show a confirmation dialog
 before modifying files.
 
-`mdsmith: Explain rule on this file` and
-`mdsmith: Show resolved config` are visible only when a Markdown
+`mdsmith: Explain Rule on This File` and
+`mdsmith: Show Resolved Config` are visible only when a Markdown
 file is active. Both open a read-only Markdown panel populated
 from JSON output; closing the panel discards the buffer.
 
@@ -234,12 +234,12 @@ from JSON output; closing the panel discards the buffer.
 | mdsmith subcommand | Editor entry point                        |
 |--------------------|-------------------------------------------|
 | `check`            | Inline diagnostics (squiggles)            |
-| `fix`              | Code actions; `mdsmith: Fix all Markdown` |
+| `fix`              | Code actions; `mdsmith: Fix All Markdown` |
 | `lsp`              | Extension spawns automatically            |
-| `init`             | `mdsmith: Initialize config`              |
-| `merge-driver`     | `mdsmith: Install Git merge driver`       |
-| `kinds resolve`    | `mdsmith: Show resolved config`           |
-| `kinds why`        | `mdsmith: Explain rule on this file`      |
+| `init`             | `mdsmith: Initialize Config`              |
+| `merge-driver`     | `mdsmith: Install Git Merge Driver`       |
+| `kinds resolve`    | `mdsmith: Show Resolved Config`           |
+| `kinds why`        | `mdsmith: Explain Rule on This File`      |
 | `help` (rules)     | Hover (plan 133)                          |
 | `metrics`          | CLI only                                  |
 | `query`            | CLI only                                  |

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -198,13 +198,51 @@ CLI, file an issue.
 
 ## Commands
 
-The extension contributes two commands available in the
-Command Palette under the `mdsmith:` category:
+The extension contributes commands available in the
+Command Palette under the `mdsmith:` category.
+
+### Server commands
 
 | Command                            | Action                                                                                                                                                                 |
 |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `mdsmith: Restart Language Server` | Stop the LSP client and spawn a fresh one. Use after editing `mdsmith.path`, rebuilding the binary, or recovering from a startup failure without reloading the window. |
 | `mdsmith: Show Output Channel`     | Reveal the "mdsmith" Output channel where the client logs RPC traffic and the server's stderr. Quickest way to read a startup error.                                   |
+
+### Palette commands
+
+| Command                              | Requires trust | Action                                                                      |
+|--------------------------------------|:--------------:|-----------------------------------------------------------------------------|
+| `mdsmith: Initialize config`         |                | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.          |
+| `mdsmith: Install Git merge driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.             |
+| `mdsmith: Fix all Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.   |
+| `mdsmith: Explain rule on this file` |                | Pick a rule; open `mdsmith kinds why <file> <rule> --json` in a side panel. |
+| `mdsmith: Show resolved config`      |                | Open `mdsmith kinds resolve <file> --json` in a side panel.                 |
+
+`mdsmith: Fix all Markdown` and `mdsmith: Install Git merge driver`
+are hidden from the palette in untrusted workspaces and show a
+confirmation dialog before modifying files.
+
+`mdsmith: Explain rule on this file` and
+`mdsmith: Show resolved config` are visible only when a Markdown
+file is active. Both open a read-only Markdown panel populated
+from JSON output; closing the panel discards the buffer.
+
+### CLI-subcommand coverage
+
+| mdsmith subcommand | Editor entry point                        |
+|--------------------|-------------------------------------------|
+| `check`            | Inline diagnostics (squiggles)            |
+| `fix`              | Code actions; `mdsmith: Fix all Markdown` |
+| `lsp`              | Extension spawns automatically            |
+| `init`             | `mdsmith: Initialize config`              |
+| `merge-driver`     | `mdsmith: Install Git merge driver`       |
+| `kinds resolve`    | `mdsmith: Show resolved config`           |
+| `kinds why`        | `mdsmith: Explain rule on this file`      |
+| `help` (rules)     | Hover (plan 133)                          |
+| `archetypes`       | CLI only                                  |
+| `metrics`          | CLI only                                  |
+| `query`            | CLI only                                  |
+| `version`          | CLI only                                  |
 
 ## Troubleshooting
 

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -241,7 +241,6 @@ from JSON output; closing the panel discards the buffer.
 | `kinds resolve`    | `mdsmith: Show resolved config`           |
 | `kinds why`        | `mdsmith: Explain rule on this file`      |
 | `help` (rules)     | Hover (plan 133)                          |
-| `archetypes`       | CLI only                                  |
 | `metrics`          | CLI only                                  |
 | `query`            | CLI only                                  |
 | `version`          | CLI only                                  |

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -210,13 +210,13 @@ Command Palette under the `mdsmith:` category.
 
 ### Palette commands
 
-| Command                              | Requires trust | Action                                                                      |
-|--------------------------------------|:--------------:|-----------------------------------------------------------------------------|
-| `mdsmith: Initialize config`         | yes            | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.          |
-| `mdsmith: Install Git merge driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.             |
-| `mdsmith: Fix all Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.   |
-| `mdsmith: Explain rule on this file` | —              | Pick a rule; open `mdsmith kinds why <file> <rule> --json` in a side panel. |
-| `mdsmith: Show resolved config`      | —              | Open `mdsmith kinds resolve <file> --json` in a side panel.                 |
+| Command                              | Requires trust | Action                                                                         |
+|--------------------------------------|:--------------:|--------------------------------------------------------------------------------|
+| `mdsmith: Initialize config`         | yes            | Run `mdsmith init` in the workspace root to create `.mdsmith.yml`.             |
+| `mdsmith: Install Git merge driver`  | yes            | Run `mdsmith merge-driver install` after a confirmation dialog.                |
+| `mdsmith: Fix all Markdown`          | yes            | Run `mdsmith fix .` against the workspace; show a fixed-of-total summary.      |
+| `mdsmith: Explain rule on this file` | —              | Pick a rule; open `mdsmith kinds why --json -- <file> <rule>` in a side panel. |
+| `mdsmith: Show resolved config`      | —              | Open `mdsmith kinds resolve --json -- <file>` in a side panel.                 |
 
 `mdsmith: Initialize config`, `mdsmith: Fix all Markdown`, and
 `mdsmith: Install Git merge driver` are hidden from the palette in

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -99,11 +99,11 @@
         },
         {
           "command": "mdsmith.kinds.why",
-          "when": "editorLangId == markdown"
+          "when": "editorLangId == markdown && resourceScheme == file"
         },
         {
           "command": "mdsmith.kinds.resolve",
-          "when": "editorLangId == markdown"
+          "when": "editorLangId == markdown && resourceScheme == file"
         }
       ]
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -59,27 +59,27 @@
       },
       {
         "command": "mdsmith.init",
-        "title": "Initialize config",
+        "title": "Initialize Config",
         "category": "mdsmith"
       },
       {
         "command": "mdsmith.mergeDriver.install",
-        "title": "Install Git merge driver",
+        "title": "Install Git Merge Driver",
         "category": "mdsmith"
       },
       {
         "command": "mdsmith.fixWorkspace",
-        "title": "Fix all Markdown",
+        "title": "Fix All Markdown",
         "category": "mdsmith"
       },
       {
         "command": "mdsmith.kinds.why",
-        "title": "Explain rule on this file",
+        "title": "Explain Rule on This File",
         "category": "mdsmith"
       },
       {
         "command": "mdsmith.kinds.resolve",
-        "title": "Show resolved config",
+        "title": "Show Resolved Config",
         "category": "mdsmith"
       }
     ],

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -26,7 +26,14 @@
   },
   "main": "./dist/extension.js",
   "activationEvents": [
-    "onLanguage:markdown"
+    "onLanguage:markdown",
+    "onCommand:mdsmith.restartServer",
+    "onCommand:mdsmith.showOutput",
+    "onCommand:mdsmith.init",
+    "onCommand:mdsmith.mergeDriver.install",
+    "onCommand:mdsmith.fixWorkspace",
+    "onCommand:mdsmith.kinds.why",
+    "onCommand:mdsmith.kinds.resolve"
   ],
   "capabilities": {
     "untrustedWorkspaces": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -28,6 +28,16 @@
   "activationEvents": [
     "onLanguage:markdown"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Diagnostics work in restricted mode. Commands that modify files outside the editor are disabled until the workspace is trusted.",
+      "restrictedConfigurations": [
+        "mdsmith.path",
+        "mdsmith.config"
+      ]
+    }
+  },
   "contributes": {
     "commands": [
       {
@@ -39,8 +49,53 @@
         "command": "mdsmith.showOutput",
         "title": "Show Output Channel",
         "category": "mdsmith"
+      },
+      {
+        "command": "mdsmith.init",
+        "title": "Initialize config",
+        "category": "mdsmith"
+      },
+      {
+        "command": "mdsmith.mergeDriver.install",
+        "title": "Install Git merge driver",
+        "category": "mdsmith"
+      },
+      {
+        "command": "mdsmith.fixWorkspace",
+        "title": "Fix all Markdown",
+        "category": "mdsmith"
+      },
+      {
+        "command": "mdsmith.kinds.why",
+        "title": "Explain rule on this file",
+        "category": "mdsmith"
+      },
+      {
+        "command": "mdsmith.kinds.resolve",
+        "title": "Show resolved config",
+        "category": "mdsmith"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "mdsmith.mergeDriver.install",
+          "when": "isWorkspaceTrusted"
+        },
+        {
+          "command": "mdsmith.fixWorkspace",
+          "when": "isWorkspaceTrusted"
+        },
+        {
+          "command": "mdsmith.kinds.why",
+          "when": "editorLangId == markdown"
+        },
+        {
+          "command": "mdsmith.kinds.resolve",
+          "when": "editorLangId == markdown"
+        }
+      ]
+    },
     "configuration": {
       "title": "mdsmith",
       "properties": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -79,6 +79,10 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "mdsmith.init",
+          "when": "isWorkspaceTrusted"
+        },
+        {
           "command": "mdsmith.mergeDriver.install",
           "when": "isWorkspaceTrusted"
         },

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -44,14 +44,9 @@ describe("buildFixNotificationMessage", () => {
     expect(buildFixNotificationMessage(stats)).toBe("Fixed 12 of 200 files");
   });
 
-  test("appends issue count when failures > 0", () => {
+  test("shows fixed-of-checked with non-zero failures (failures is pre-fix count, not shown)", () => {
     const stats: FixStats = { checked: 10, fixed: 3, failures: 2, unfixed: 5 };
-    expect(buildFixNotificationMessage(stats)).toBe("Fixed 3 of 10 files (2 issues)");
-  });
-
-  test("uses singular 'issue' for exactly one failure", () => {
-    const stats: FixStats = { checked: 5, fixed: 1, failures: 1, unfixed: 3 };
-    expect(buildFixNotificationMessage(stats)).toBe("Fixed 1 of 5 files (1 issue)");
+    expect(buildFixNotificationMessage(stats)).toBe("Fixed 3 of 10 files");
   });
 });
 

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -44,14 +44,14 @@ describe("buildFixNotificationMessage", () => {
     expect(buildFixNotificationMessage(stats)).toBe("Fixed 12 of 200 files");
   });
 
-  test("appends error count when failures > 0", () => {
+  test("appends issue count when failures > 0", () => {
     const stats: FixStats = { checked: 10, fixed: 3, failures: 2, unfixed: 5 };
-    expect(buildFixNotificationMessage(stats)).toBe("Fixed 3 of 10 files (2 errors)");
+    expect(buildFixNotificationMessage(stats)).toBe("Fixed 3 of 10 files (2 issues)");
   });
 
-  test("uses singular 'error' for exactly one failure", () => {
+  test("uses singular 'issue' for exactly one failure", () => {
     const stats: FixStats = { checked: 5, fixed: 1, failures: 1, unfixed: 3 };
-    expect(buildFixNotificationMessage(stats)).toBe("Fixed 1 of 5 files (1 error)");
+    expect(buildFixNotificationMessage(stats)).toBe("Fixed 1 of 5 files (1 issue)");
   });
 });
 

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -128,7 +128,19 @@ describe("runFixWorkspace", () => {
     expect(infoMessages[0].msg).toBe("mdsmith fix completed.");
   });
 
-  test("shows failure notification and Show Output on non-zero exit", async () => {
+  test("shows stats summary on exit code 1 (some issues remain)", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({
+      stdout: "",
+      stderr: "stats: checked=10 fixed=3 failures=0 unfixed=7\n",
+      exitCode: 1,
+    });
+    await runFixWorkspace(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toBe("Fixed 3 of 10 files");
+  });
+
+  test("shows failure notification and Show Output on exit code >= 2", async () => {
     const { deps, infoMessages } = makeDeps();
     deps.spawn = async () => ({ stdout: "", stderr: "error: bad config\n", exitCode: 2 });
     await runFixWorkspace(deps);

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -187,4 +187,14 @@ describe("runFixWorkspace", () => {
     await runFixWorkspace(deps);
     expect(capturedArgs).toEqual(["fix", ".", "--config", "/custom/.mdsmith.yml"]);
   });
+
+  test("shows could-not-start notification when spawn rejects", async () => {
+    const { deps, infoMessages, output } = makeDeps();
+    deps.spawn = async () => { throw new Error("ENOENT: mdsmith"); };
+    await runFixWorkspace(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("could not start");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+    expect(output.join("")).toContain("ENOENT");
+  });
 });

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -176,4 +176,15 @@ describe("runFixWorkspace", () => {
     expect(capturedArgs).toEqual(["fix", "."]);
     expect(capturedCwd).toBe("/repo");
   });
+
+  test("passes --config flag when configPath is set", async () => {
+    let capturedArgs: string[] = [];
+    const { deps } = makeDeps({ configPath: "/custom/.mdsmith.yml" });
+    deps.spawn = async (_bin, args) => {
+      capturedArgs = args;
+      return { stdout: "", stderr: "stats: checked=0 fixed=0 failures=0 unfixed=0\n", exitCode: 0 };
+    };
+    await runFixWorkspace(deps);
+    expect(capturedArgs).toEqual(["fix", ".", "--config", "/custom/.mdsmith.yml"]);
+  });
 });

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -180,7 +180,7 @@ describe("runFixWorkspace", () => {
       return { stdout: "", stderr: "stats: checked=0 fixed=0 failures=0 unfixed=0\n", exitCode: 0 };
     };
     await runFixWorkspace(deps);
-    expect(capturedArgs).toEqual(["fix", ".", "--config", "/custom/.mdsmith.yml"]);
+    expect(capturedArgs).toEqual(["fix", "--config", "/custom/.mdsmith.yml", "."]);
   });
 
   test("shows could-not-start notification when spawn rejects", async () => {

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -82,6 +82,16 @@ describe("runFixWorkspace", () => {
     return { deps, infoMessages, errorMessages, output };
   }
 
+  test("shows an error and returns when no workspace folder is open", async () => {
+    let spawned = false;
+    const { deps, errorMessages } = makeDeps({ workspaceRoot: undefined });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runFixWorkspace(deps);
+    expect(errorMessages).toHaveLength(1);
+    expect(errorMessages[0]).toContain("workspace folder");
+    expect(spawned).toBe(false);
+  });
+
   test("shows an error and returns when workspace is not trusted", async () => {
     const { deps, errorMessages } = makeDeps({ isTrusted: () => false });
     deps.spawn = async () => ({ stdout: "", stderr: "", exitCode: 0 });

--- a/editors/vscode/src/commands/fix-workspace.test.ts
+++ b/editors/vscode/src/commands/fix-workspace.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseRunStats,
+  buildFixNotificationMessage,
+  runFixWorkspace,
+  type FixStats,
+  type FixWorkspaceHandlerDeps
+} from "./fix-workspace";
+
+describe("parseRunStats", () => {
+  test("parses a well-formed stats line", () => {
+    const out = "stats: checked=200 fixed=12 failures=0 unfixed=188\n";
+    expect(parseRunStats(out)).toEqual({
+      checked: 200,
+      fixed: 12,
+      failures: 0,
+      unfixed: 188,
+    });
+  });
+
+  test("finds the stats line inside longer stderr output", () => {
+    const out = [
+      "some/file.md: fixed trailing space",
+      "stats: checked=5 fixed=3 failures=0 unfixed=2",
+      "",
+    ].join("\n");
+    expect(parseRunStats(out)).toEqual({
+      checked: 5,
+      fixed: 3,
+      failures: 0,
+      unfixed: 2,
+    });
+  });
+
+  test("returns null when no stats line is present", () => {
+    expect(parseRunStats("")).toBeNull();
+    expect(parseRunStats("some random output")).toBeNull();
+  });
+});
+
+describe("buildFixNotificationMessage", () => {
+  test("shows fixed-of-checked when no failures", () => {
+    const stats: FixStats = { checked: 200, fixed: 12, failures: 0, unfixed: 188 };
+    expect(buildFixNotificationMessage(stats)).toBe("Fixed 12 of 200 files");
+  });
+
+  test("appends error count when failures > 0", () => {
+    const stats: FixStats = { checked: 10, fixed: 3, failures: 2, unfixed: 5 };
+    expect(buildFixNotificationMessage(stats)).toBe("Fixed 3 of 10 files (2 errors)");
+  });
+
+  test("uses singular 'error' for exactly one failure", () => {
+    const stats: FixStats = { checked: 5, fixed: 1, failures: 1, unfixed: 3 };
+    expect(buildFixNotificationMessage(stats)).toBe("Fixed 1 of 5 files (1 error)");
+  });
+});
+
+describe("runFixWorkspace", () => {
+  function makeDeps(overrides: Partial<FixWorkspaceHandlerDeps> = {}): {
+    deps: FixWorkspaceHandlerDeps;
+    infoMessages: Array<{ msg: string; buttons: string[] }>;
+    errorMessages: string[];
+    output: string[];
+  } {
+    const infoMessages: Array<{ msg: string; buttons: string[] }> = [];
+    const errorMessages: string[] = [];
+    const output: string[] = [];
+    const deps: FixWorkspaceHandlerDeps = {
+      binary: "/usr/bin/mdsmith",
+      workspaceRoot: "/repo",
+      isTrusted: () => true,
+      confirm: async () => true,
+      showInfo: async (msg, ...buttons) => {
+        infoMessages.push({ msg, buttons });
+        return undefined;
+      },
+      showError: async (msg) => { errorMessages.push(msg); },
+      appendOutput: (text) => { output.push(text); },
+      showOutput: () => {},
+      ...overrides,
+    };
+    return { deps, infoMessages, errorMessages, output };
+  }
+
+  test("shows an error and returns when workspace is not trusted", async () => {
+    const { deps, errorMessages } = makeDeps({ isTrusted: () => false });
+    deps.spawn = async () => ({ stdout: "", stderr: "", exitCode: 0 });
+    await runFixWorkspace(deps);
+    expect(errorMessages).toHaveLength(1);
+    expect(errorMessages[0]).toContain("trusted workspace");
+  });
+
+  test("returns without spawning when confirmation is declined", async () => {
+    let spawned = false;
+    const { deps } = makeDeps({ confirm: async () => false });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runFixWorkspace(deps);
+    expect(spawned).toBe(false);
+  });
+
+  test("shows fixed-count notification on success with stats line", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({
+      stdout: "",
+      stderr: "stats: checked=50 fixed=5 failures=0 unfixed=45\n",
+      exitCode: 0,
+    });
+    await runFixWorkspace(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toBe("Fixed 5 of 50 files");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+  });
+
+  test("falls back to generic message when no stats line", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({ stdout: "", stderr: "", exitCode: 0 });
+    await runFixWorkspace(deps);
+    expect(infoMessages[0].msg).toBe("mdsmith fix completed.");
+  });
+
+  test("shows failure notification and Show Output on non-zero exit", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({ stdout: "", stderr: "error: bad config\n", exitCode: 2 });
+    await runFixWorkspace(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("failed");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+  });
+
+  test("appends stderr to output channel", async () => {
+    const { deps, output } = makeDeps();
+    deps.spawn = async () => ({
+      stdout: "",
+      stderr: "stats: checked=1 fixed=0 failures=0 unfixed=1\n",
+      exitCode: 0,
+    });
+    await runFixWorkspace(deps);
+    expect(output.join("")).toContain("stats:");
+  });
+
+  test("passes binary and cwd to spawn", async () => {
+    let capturedBinary = "";
+    let capturedArgs: string[] = [];
+    let capturedCwd: string | undefined;
+    const { deps } = makeDeps();
+    deps.spawn = async (bin, args, cwd) => {
+      capturedBinary = bin;
+      capturedArgs = args;
+      capturedCwd = cwd;
+      return { stdout: "", stderr: "stats: checked=0 fixed=0 failures=0 unfixed=0\n", exitCode: 0 };
+    };
+    await runFixWorkspace(deps);
+    expect(capturedBinary).toBe("/usr/bin/mdsmith");
+    expect(capturedArgs).toEqual(["fix", "."]);
+    expect(capturedCwd).toBe("/repo");
+  });
+});

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -79,7 +79,8 @@ export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<vo
   deps.appendOutput(result.stderr);
   if (result.stdout) deps.appendOutput(result.stdout);
 
-  if (result.exitCode !== 0) {
+  // exit code >= 2 is a hard failure (bad config, binary error, etc.)
+  if (result.exitCode >= 2) {
     const choice = await deps.showInfo(
       `mdsmith fix failed (exit ${result.exitCode}). See output for details.`,
       "Show Output"
@@ -88,6 +89,7 @@ export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<vo
     return;
   }
 
+  // exit code 0 = all clean, exit code 1 = some issues remain — both show stats
   const stats = parseRunStats(result.stderr);
   const msg = stats
     ? buildFixNotificationMessage(stats)

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -35,7 +35,7 @@ export function parseRunStats(output: string): FixStats | null {
 // after a successful fix run. Exposed for testing.
 export function buildFixNotificationMessage(stats: FixStats): string {
   if (stats.failures > 0) {
-    return `Fixed ${stats.fixed} of ${stats.checked} files (${stats.failures} error${stats.failures !== 1 ? "s" : ""})`;
+    return `Fixed ${stats.fixed} of ${stats.checked} files (${stats.failures} issue${stats.failures !== 1 ? "s" : ""})`;
   }
   return `Fixed ${stats.fixed} of ${stats.checked} files`;
 }

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -34,9 +34,6 @@ export function parseRunStats(output: string): FixStats | null {
 // buildFixNotificationMessage returns the human-readable summary shown
 // after a successful fix run. Exposed for testing.
 export function buildFixNotificationMessage(stats: FixStats): string {
-  if (stats.failures > 0) {
-    return `Fixed ${stats.fixed} of ${stats.checked} files (${stats.failures} issue${stats.failures !== 1 ? "s" : ""})`;
-  }
   return `Fixed ${stats.fixed} of ${stats.checked} files`;
 }
 

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -6,7 +6,7 @@
 // The spawn function is injectable so tests can mock it without
 // starting a real child process.
 
-import { SpawnFn, defaultSpawn } from "./runner";
+import { SpawnFn, SpawnResult, defaultSpawn } from "./runner";
 
 export interface FixStats {
   checked: number;
@@ -74,7 +74,18 @@ export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<vo
   const args = deps.configPath
     ? ["fix", ".", "--config", deps.configPath]
     : ["fix", "."];
-  const result = await spawnFn(deps.binary, args, deps.workspaceRoot);
+  let result: SpawnResult;
+  try {
+    result = await spawnFn(deps.binary, args, deps.workspaceRoot);
+  } catch (err) {
+    deps.appendOutput(`mdsmith fix: could not start: ${err}\n`);
+    const choice = await deps.showInfo(
+      "mdsmith fix: could not start. See output for details.",
+      "Show Output"
+    );
+    if (choice === "Show Output") deps.showOutput();
+    return;
+  }
 
   deps.appendOutput(result.stderr);
   if (result.stdout) deps.appendOutput(result.stdout);

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -56,6 +56,11 @@ export interface FixWorkspaceHandlerDeps {
 // notification message or undefined when cancelled / failed. It is
 // extracted so tests can drive it without a VS Code host.
 export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<void> {
+  if (!deps.workspaceRoot) {
+    await deps.showError("mdsmith: Fix all Markdown requires an open workspace folder.");
+    return;
+  }
+
   if (!deps.isTrusted()) {
     await deps.showError("mdsmith: Fix all Markdown requires a trusted workspace.");
     return;

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -69,7 +69,7 @@ export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<vo
 
   const spawnFn = deps.spawn ?? defaultSpawn;
   const args = deps.configPath
-    ? ["fix", ".", "--config", deps.configPath]
+    ? ["fix", "--config", deps.configPath, "."]
     : ["fix", "."];
   let result: SpawnResult;
   try {

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -1,0 +1,93 @@
+// Handler logic for mdsmith.fixWorkspace: runs "mdsmith fix ." and
+// shows a fixed-count notification. The handler re-checks
+// workspace.isTrusted before running since the command menu entry is
+// also gated with `when: isWorkspaceTrusted`.
+//
+// The spawn function is injectable so tests can mock it without
+// starting a real child process.
+
+import { SpawnFn, defaultSpawn } from "./runner";
+
+export interface FixStats {
+  checked: number;
+  fixed: number;
+  failures: number;
+  unfixed: number;
+}
+
+// parseRunStats extracts counters from the "stats:" line that
+// printRunStats writes to stderr.
+// Format: "stats: checked=N fixed=N failures=N unfixed=N"
+export function parseRunStats(output: string): FixStats | null {
+  const match = output.match(
+    /stats:\s+checked=(\d+)\s+fixed=(\d+)\s+failures=(\d+)\s+unfixed=(\d+)/
+  );
+  if (!match) return null;
+  return {
+    checked: parseInt(match[1], 10),
+    fixed: parseInt(match[2], 10),
+    failures: parseInt(match[3], 10),
+    unfixed: parseInt(match[4], 10),
+  };
+}
+
+// buildFixNotificationMessage returns the human-readable summary shown
+// after a successful fix run. Exposed for testing.
+export function buildFixNotificationMessage(stats: FixStats): string {
+  if (stats.failures > 0) {
+    return `Fixed ${stats.fixed} of ${stats.checked} files (${stats.failures} error${stats.failures !== 1 ? "s" : ""})`;
+  }
+  return `Fixed ${stats.fixed} of ${stats.checked} files`;
+}
+
+export interface FixWorkspaceHandlerDeps {
+  binary: string;
+  workspaceRoot: string | undefined;
+  isTrusted: () => boolean;
+  confirm: () => Promise<boolean>;
+  showInfo: (msg: string, ...buttons: string[]) => Promise<string | undefined>;
+  showError: (msg: string) => Promise<void>;
+  appendOutput: (text: string) => void;
+  showOutput: () => void;
+  spawn?: SpawnFn;
+}
+
+// runFixWorkspace executes the fix command and resolves with the
+// notification message or undefined when cancelled / failed. It is
+// extracted so tests can drive it without a VS Code host.
+export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<void> {
+  if (!deps.isTrusted()) {
+    await deps.showError("mdsmith: Fix all Markdown requires a trusted workspace.");
+    return;
+  }
+
+  const confirmed = await deps.confirm();
+  if (!confirmed) return;
+
+  const spawnFn = deps.spawn ?? defaultSpawn;
+  const result = await spawnFn(
+    deps.binary,
+    ["fix", "."],
+    deps.workspaceRoot
+  );
+
+  deps.appendOutput(result.stderr);
+  if (result.stdout) deps.appendOutput(result.stdout);
+
+  if (result.exitCode !== 0) {
+    const choice = await deps.showInfo(
+      `mdsmith fix failed (exit ${result.exitCode}). See output for details.`,
+      "Show Output"
+    );
+    if (choice === "Show Output") deps.showOutput();
+    return;
+  }
+
+  const stats = parseRunStats(result.stderr);
+  const msg = stats
+    ? buildFixNotificationMessage(stats)
+    : "mdsmith fix completed.";
+
+  const choice = await deps.showInfo(msg, "Show Output");
+  if (choice === "Show Output") deps.showOutput();
+}

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -52,9 +52,9 @@ export interface FixWorkspaceHandlerDeps {
   spawn?: SpawnFn;
 }
 
-// runFixWorkspace executes the fix command and resolves with the
-// notification message or undefined when cancelled / failed. It is
-// extracted so tests can drive it without a VS Code host.
+// runFixWorkspace executes the fix command and resolves when complete
+// (or returns early when cancelled or on error). Extracted so tests
+// can drive it without a VS Code host.
 export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<void> {
   if (!deps.workspaceRoot) {
     await deps.showError("mdsmith: Fix all Markdown requires an open workspace folder.");

--- a/editors/vscode/src/commands/fix-workspace.ts
+++ b/editors/vscode/src/commands/fix-workspace.ts
@@ -43,6 +43,7 @@ export function buildFixNotificationMessage(stats: FixStats): string {
 export interface FixWorkspaceHandlerDeps {
   binary: string;
   workspaceRoot: string | undefined;
+  configPath?: string;
   isTrusted: () => boolean;
   confirm: () => Promise<boolean>;
   showInfo: (msg: string, ...buttons: string[]) => Promise<string | undefined>;
@@ -70,11 +71,10 @@ export async function runFixWorkspace(deps: FixWorkspaceHandlerDeps): Promise<vo
   if (!confirmed) return;
 
   const spawnFn = deps.spawn ?? defaultSpawn;
-  const result = await spawnFn(
-    deps.binary,
-    ["fix", "."],
-    deps.workspaceRoot
-  );
+  const args = deps.configPath
+    ? ["fix", ".", "--config", deps.configPath]
+    : ["fix", "."];
+  const result = await spawnFn(deps.binary, args, deps.workspaceRoot);
 
   deps.appendOutput(result.stderr);
   if (result.stdout) deps.appendOutput(result.stdout);

--- a/editors/vscode/src/commands/init.test.ts
+++ b/editors/vscode/src/commands/init.test.ts
@@ -81,4 +81,14 @@ describe("runInit", () => {
     expect(args).toEqual(["init"]);
     expect(cwd).toBe("/repo");
   });
+
+  test("shows could-not-start notification when spawn rejects", async () => {
+    const { deps, infoMessages, output } = makeDeps();
+    deps.spawn = async () => { throw new Error("ENOENT: mdsmith"); };
+    await runInit(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("could not start");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+    expect(output.join("")).toContain("ENOENT");
+  });
 });

--- a/editors/vscode/src/commands/init.test.ts
+++ b/editors/vscode/src/commands/init.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { runInit, type InitHandlerDeps } from "./init";
+
+function makeDeps(overrides: Partial<InitHandlerDeps> = {}): {
+  deps: InitHandlerDeps;
+  infoMessages: Array<{ msg: string; buttons: string[] }>;
+  errorMessages: string[];
+  output: string[];
+} {
+  const infoMessages: Array<{ msg: string; buttons: string[] }> = [];
+  const errorMessages: string[] = [];
+  const output: string[] = [];
+  const deps: InitHandlerDeps = {
+    binary: "/usr/bin/mdsmith",
+    workspaceRoot: "/repo",
+    isTrusted: () => true,
+    showInfo: async (msg, ...buttons) => {
+      infoMessages.push({ msg, buttons });
+      return undefined;
+    },
+    showError: async (msg) => { errorMessages.push(msg); },
+    appendOutput: (text) => { output.push(text); },
+    showOutput: () => {},
+    ...overrides,
+  };
+  return { deps, infoMessages, errorMessages, output };
+}
+
+describe("runInit", () => {
+  test("shows error when no workspace folder is open", async () => {
+    let spawned = false;
+    const { deps, errorMessages } = makeDeps({ workspaceRoot: undefined });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runInit(deps);
+    expect(errorMessages).toHaveLength(1);
+    expect(errorMessages[0]).toContain("workspace folder");
+    expect(spawned).toBe(false);
+  });
+
+  test("shows error when workspace is not trusted", async () => {
+    let spawned = false;
+    const { deps, errorMessages } = makeDeps({ isTrusted: () => false });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runInit(deps);
+    expect(errorMessages).toHaveLength(1);
+    expect(errorMessages[0]).toContain("trusted workspace");
+    expect(spawned).toBe(false);
+  });
+
+  test("shows success notification on exit 0", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({ stdout: "created .mdsmith.yml\n", stderr: "", exitCode: 0 });
+    await runInit(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain(".mdsmith.yml created");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+  });
+
+  test("shows failure notification on non-zero exit", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({ stdout: "", stderr: "error: already exists\n", exitCode: 1 });
+    await runInit(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("failed");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+  });
+
+  test("appends stderr to output channel", async () => {
+    const { deps, output } = makeDeps();
+    deps.spawn = async () => ({ stdout: "", stderr: "some warning\n", exitCode: 0 });
+    await runInit(deps);
+    expect(output.join("")).toContain("some warning");
+  });
+
+  test("passes binary, init args, and cwd to spawn", async () => {
+    let bin = "", args: string[] = [], cwd: string | undefined;
+    const { deps } = makeDeps();
+    deps.spawn = async (b, a, c) => { bin = b; args = a; cwd = c; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runInit(deps);
+    expect(bin).toBe("/usr/bin/mdsmith");
+    expect(args).toEqual(["init"]);
+    expect(cwd).toBe("/repo");
+  });
+});

--- a/editors/vscode/src/commands/init.ts
+++ b/editors/vscode/src/commands/init.ts
@@ -1,7 +1,7 @@
 // Handler logic for mdsmith.init: runs "mdsmith init" in the workspace root.
 // Trust-gated because it creates .mdsmith.yml (fails if the file already exists).
 
-import { SpawnFn, defaultSpawn } from "./runner";
+import { SpawnFn, SpawnResult, defaultSpawn } from "./runner";
 
 export interface InitHandlerDeps {
   binary: string;
@@ -26,7 +26,18 @@ export async function runInit(deps: InitHandlerDeps): Promise<void> {
   }
 
   const spawnFn = deps.spawn ?? defaultSpawn;
-  const result = await spawnFn(deps.binary, ["init"], deps.workspaceRoot);
+  let result: SpawnResult;
+  try {
+    result = await spawnFn(deps.binary, ["init"], deps.workspaceRoot);
+  } catch (err) {
+    deps.appendOutput(`mdsmith init: could not start: ${err}\n`);
+    const choice = await deps.showInfo(
+      "mdsmith init: could not start. See output for details.",
+      "Show Output"
+    );
+    if (choice === "Show Output") deps.showOutput();
+    return;
+  }
 
   if (result.stderr) deps.appendOutput(result.stderr);
   if (result.stdout) deps.appendOutput(result.stdout);

--- a/editors/vscode/src/commands/init.ts
+++ b/editors/vscode/src/commands/init.ts
@@ -1,10 +1,12 @@
 // Handler logic for mdsmith.init: runs "mdsmith init" in the workspace root.
+// Trust-gated because it creates (or overwrites) .mdsmith.yml.
 
 import { SpawnFn, defaultSpawn } from "./runner";
 
 export interface InitHandlerDeps {
   binary: string;
   workspaceRoot: string | undefined;
+  isTrusted: () => boolean;
   showInfo: (msg: string, ...buttons: string[]) => Promise<string | undefined>;
   showError: (msg: string) => Promise<void>;
   appendOutput: (text: string) => void;
@@ -15,6 +17,11 @@ export interface InitHandlerDeps {
 export async function runInit(deps: InitHandlerDeps): Promise<void> {
   if (!deps.workspaceRoot) {
     await deps.showError("mdsmith: Initialize config requires an open workspace folder.");
+    return;
+  }
+
+  if (!deps.isTrusted()) {
+    await deps.showError("mdsmith: Initialize config requires a trusted workspace.");
     return;
   }
 

--- a/editors/vscode/src/commands/init.ts
+++ b/editors/vscode/src/commands/init.ts
@@ -1,0 +1,38 @@
+// Handler logic for mdsmith.init: runs "mdsmith init" in the workspace root.
+
+import { SpawnFn, defaultSpawn } from "./runner";
+
+export interface InitHandlerDeps {
+  binary: string;
+  workspaceRoot: string | undefined;
+  showInfo: (msg: string, ...buttons: string[]) => Promise<string | undefined>;
+  showError: (msg: string) => Promise<void>;
+  appendOutput: (text: string) => void;
+  showOutput: () => void;
+  spawn?: SpawnFn;
+}
+
+export async function runInit(deps: InitHandlerDeps): Promise<void> {
+  if (!deps.workspaceRoot) {
+    await deps.showError("mdsmith: Initialize config requires an open workspace folder.");
+    return;
+  }
+
+  const spawnFn = deps.spawn ?? defaultSpawn;
+  const result = await spawnFn(deps.binary, ["init"], deps.workspaceRoot);
+
+  if (result.stderr) deps.appendOutput(result.stderr);
+  if (result.stdout) deps.appendOutput(result.stdout);
+
+  if (result.exitCode !== 0) {
+    const choice = await deps.showInfo(
+      `mdsmith init failed (exit ${result.exitCode}). See output for details.`,
+      "Show Output"
+    );
+    if (choice === "Show Output") deps.showOutput();
+    return;
+  }
+
+  const choice = await deps.showInfo("mdsmith: .mdsmith.yml created.", "Show Output");
+  if (choice === "Show Output") deps.showOutput();
+}

--- a/editors/vscode/src/commands/init.ts
+++ b/editors/vscode/src/commands/init.ts
@@ -1,5 +1,5 @@
 // Handler logic for mdsmith.init: runs "mdsmith init" in the workspace root.
-// Trust-gated because it creates (or overwrites) .mdsmith.yml.
+// Trust-gated because it creates .mdsmith.yml (fails if the file already exists).
 
 import { SpawnFn, defaultSpawn } from "./runner";
 

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -4,7 +4,7 @@ import {
   runKindsResolve,
   runKindsWhy,
   type DiagnosticLike,
-  type KindsHandlerDeps
+  type KindsWhyHandlerDeps
 } from "./kinds";
 import {
   buildResolveUri,
@@ -184,14 +184,14 @@ describe("fetchKindsContent", () => {
 
 // ---- runKindsResolve / runKindsWhy ----
 
-function makeDeps(overrides: Partial<KindsHandlerDeps> = {}): {
-  deps: KindsHandlerDeps;
+function makeDeps(overrides: Partial<KindsWhyHandlerDeps> = {}): {
+  deps: KindsWhyHandlerDeps;
   openedUris: string[];
   errors: string[];
 } {
   const openedUris: string[] = [];
   const errors: string[] = [];
-  const deps: KindsHandlerDeps = {
+  const deps: KindsWhyHandlerDeps = {
     binary: "mdsmith",
     workspaceRoot: "/repo",
     getActiveFilePath: () => "/repo/doc.md",

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -111,7 +111,7 @@ describe("parseKindsUri", () => {
 
 describe("fetchKindsContent", () => {
   test("returns fenced JSON for a successful resolve", async () => {
-    const spawn = async (_bin: string, args: string[]) => ({
+    const spawn = async (_bin: string, _args: string[]) => ({
       stdout: '{"kinds":["plan"]}',
       stderr: "",
       exitCode: 0,
@@ -124,7 +124,7 @@ describe("fetchKindsContent", () => {
   });
 
   test("returns fenced JSON for a successful why", async () => {
-    const spawn = async (_bin: string, args: string[]) => ({
+    const spawn = async (_bin: string, _args: string[]) => ({
       stdout: '{"rule":"MDS001","layers":[]}',
       stderr: "",
       exitCode: 0,

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   extractRuleIds,
+  makeKindsContentProvider,
   runKindsResolve,
   runKindsWhy,
   type DiagnosticLike,
@@ -206,7 +207,6 @@ function makeDeps(overrides: Partial<KindsWhyHandlerDeps> = {}): {
 
 describe("makeKindsContentProvider", () => {
   test("provideTextDocumentContent delegates to fetchKindsContent via spawn", async () => {
-    const { makeKindsContentProvider } = await import("./kinds.js");
     const spawn = async (_bin: string, _args: string[]) => ({
       stdout: '{"file":"a.md"}',
       stderr: "",

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -119,7 +119,7 @@ describe("fetchKindsContent", () => {
     });
     const uri = buildResolveUri("/repo/foo.md");
     const content = await fetchKindsContent(uri, "mdsmith", "/repo", spawn);
-    expect(content).toContain("```json");
+    expect(content).toContain("~~~json");
     expect(content).toContain('{"kinds":["plan"]}');
     expect(content).toContain("Resolved config: /repo/foo.md");
   });
@@ -133,7 +133,7 @@ describe("fetchKindsContent", () => {
     const uri = buildWhyUri("/repo/foo.md", "MDS001");
     const content = await fetchKindsContent(uri, "mdsmith", "/repo", spawn);
     expect(content).toContain("Rule MDS001 on /repo/foo.md");
-    expect(content).toContain("```json");
+    expect(content).toContain("~~~json");
   });
 
   test("returns error block on non-zero exit", async () => {
@@ -213,7 +213,7 @@ describe("makeKindsContentProvider", () => {
     const provider = makeKindsContentProvider("mdsmith", "/repo", spawn);
     const uri = buildResolveUri("/repo/a.md");
     const content = await provider.provideTextDocumentContent(uri);
-    expect(content).toContain("```json");
+    expect(content).toContain("~~~json");
     expect(content).toContain('{"file":"a.md"}');
   });
 });

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -153,6 +153,14 @@ describe("fetchKindsContent", () => {
     expect(content).toContain("malformed");
   });
 
+  test("returns error block when spawn rejects (e.g. binary not found)", async () => {
+    const spawn = async () => { throw new Error("ENOENT: mdsmith"); };
+    const uri = buildResolveUri("/repo/foo.md");
+    const content = await fetchKindsContent(uri, "mdsmith", undefined, spawn);
+    expect(content).toContain("could not start");
+    expect(content).toContain("ENOENT");
+  });
+
   test("passes correct args for resolve subcommand", async () => {
     let capturedArgs: string[] = [];
     const spawn = async (_bin: string, args: string[]) => {

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -204,6 +204,22 @@ function makeDeps(overrides: Partial<KindsHandlerDeps> = {}): {
   return { deps, openedUris, errors };
 }
 
+describe("makeKindsContentProvider", () => {
+  test("provideTextDocumentContent delegates to fetchKindsContent via spawn", async () => {
+    const { makeKindsContentProvider } = await import("./kinds.js");
+    const spawn = async (_bin: string, _args: string[]) => ({
+      stdout: '{"file":"a.md"}',
+      stderr: "",
+      exitCode: 0,
+    });
+    const provider = makeKindsContentProvider("mdsmith", "/repo", spawn);
+    const uri = buildResolveUri("/repo/a.md");
+    const content = await provider.provideTextDocumentContent(uri);
+    expect(content).toContain("```json");
+    expect(content).toContain('{"file":"a.md"}');
+  });
+});
+
 describe("runKindsResolve", () => {
   test("opens a resolve virtual doc for the active file", async () => {
     const { deps, openedUris } = makeDeps();

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -169,7 +169,7 @@ describe("fetchKindsContent", () => {
       return { stdout: "{}", stderr: "", exitCode: 0 };
     };
     await fetchKindsContent(buildResolveUri("/repo/a.md"), "mdsmith", undefined, spawn);
-    expect(capturedArgs).toEqual(["kinds", "resolve", "/repo/a.md", "--json"]);
+    expect(capturedArgs).toEqual(["kinds", "resolve", "--json", "--", "/repo/a.md"]);
   });
 
   test("passes correct args for why subcommand", async () => {
@@ -179,7 +179,7 @@ describe("fetchKindsContent", () => {
       return { stdout: "{}", stderr: "", exitCode: 0 };
     };
     await fetchKindsContent(buildWhyUri("/repo/a.md", "MDS005"), "mdsmith", undefined, spawn);
-    expect(capturedArgs).toEqual(["kinds", "why", "/repo/a.md", "MDS005", "--json"]);
+    expect(capturedArgs).toEqual(["kinds", "why", "--json", "--", "/repo/a.md", "MDS005"]);
   });
 });
 

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -180,24 +180,6 @@ describe("fetchKindsContent", () => {
     await fetchKindsContent(buildWhyUri("/repo/a.md", "MDS005"), "mdsmith", undefined, spawn);
     expect(capturedArgs).toEqual(["kinds", "why", "/repo/a.md", "MDS005", "--json"]);
   });
-
-  test("passes --config flag when configPath is set", async () => {
-    let capturedArgs: string[] = [];
-    const spawn = async (_bin: string, args: string[]) => {
-      capturedArgs = args;
-      return { stdout: "{}", stderr: "", exitCode: 0 };
-    };
-    await fetchKindsContent(
-      buildResolveUri("/repo/a.md"),
-      "mdsmith",
-      undefined,
-      spawn,
-      "/custom/.mdsmith.yml"
-    );
-    expect(capturedArgs).toEqual([
-      "kinds", "resolve", "/repo/a.md", "--config", "/custom/.mdsmith.yml", "--json",
-    ]);
-  });
 });
 
 // ---- runKindsResolve / runKindsWhy ----

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -180,6 +180,24 @@ describe("fetchKindsContent", () => {
     await fetchKindsContent(buildWhyUri("/repo/a.md", "MDS005"), "mdsmith", undefined, spawn);
     expect(capturedArgs).toEqual(["kinds", "why", "/repo/a.md", "MDS005", "--json"]);
   });
+
+  test("passes --config flag when configPath is set", async () => {
+    let capturedArgs: string[] = [];
+    const spawn = async (_bin: string, args: string[]) => {
+      capturedArgs = args;
+      return { stdout: "{}", stderr: "", exitCode: 0 };
+    };
+    await fetchKindsContent(
+      buildResolveUri("/repo/a.md"),
+      "mdsmith",
+      undefined,
+      spawn,
+      "/custom/.mdsmith.yml"
+    );
+    expect(capturedArgs).toEqual([
+      "kinds", "resolve", "/repo/a.md", "--config", "/custom/.mdsmith.yml", "--json",
+    ]);
+  });
 });
 
 // ---- runKindsResolve / runKindsWhy ----

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractRuleIds,
+  runKindsResolve,
+  runKindsWhy,
+  type DiagnosticLike,
+  type KindsHandlerDeps
+} from "./kinds";
+import {
+  buildResolveUri,
+  buildWhyUri,
+  parseKindsUri,
+  fetchKindsContent,
+} from "./virtual-doc";
+
+// ---- extractRuleIds ----
+
+describe("extractRuleIds", () => {
+  test("returns empty array when no diagnostics", () => {
+    expect(extractRuleIds([])).toEqual([]);
+  });
+
+  test("extracts string codes from mdsmith diagnostics", () => {
+    const diags: DiagnosticLike[] = [
+      { source: "mdsmith", code: "MDS001" },
+      { source: "mdsmith", code: "MDS005" },
+    ];
+    expect(extractRuleIds(diags)).toEqual(["MDS001", "MDS005"]);
+  });
+
+  test("ignores diagnostics from other sources", () => {
+    const diags: DiagnosticLike[] = [
+      { source: "eslint", code: "no-unused-vars" },
+      { source: "mdsmith", code: "MDS003" },
+    ];
+    expect(extractRuleIds(diags)).toEqual(["MDS003"]);
+  });
+
+  test("deduplicates rule IDs", () => {
+    const diags: DiagnosticLike[] = [
+      { source: "mdsmith", code: "MDS001" },
+      { source: "mdsmith", code: "MDS001" },
+    ];
+    expect(extractRuleIds(diags)).toEqual(["MDS001"]);
+  });
+
+  test("returns sorted IDs", () => {
+    const diags: DiagnosticLike[] = [
+      { source: "mdsmith", code: "MDS010" },
+      { source: "mdsmith", code: "MDS002" },
+    ];
+    expect(extractRuleIds(diags)).toEqual(["MDS002", "MDS010"]);
+  });
+
+  test("ignores numeric codes", () => {
+    const diags: DiagnosticLike[] = [
+      { source: "mdsmith", code: 42 },
+    ];
+    expect(extractRuleIds(diags)).toEqual([]);
+  });
+});
+
+// ---- buildResolveUri / buildWhyUri / parseKindsUri ----
+
+describe("buildResolveUri", () => {
+  test("produces a valid mdsmith-kinds:// URI", () => {
+    const uri = buildResolveUri("/workspace/docs/guide.md");
+    expect(uri).toBe(
+      "mdsmith-kinds://resolve?file=%2Fworkspace%2Fdocs%2Fguide.md"
+    );
+  });
+});
+
+describe("buildWhyUri", () => {
+  test("produces a valid mdsmith-kinds:// URI with rule", () => {
+    const uri = buildWhyUri("/workspace/docs/guide.md", "MDS001");
+    expect(uri).toBe(
+      "mdsmith-kinds://why?file=%2Fworkspace%2Fdocs%2Fguide.md&rule=MDS001"
+    );
+  });
+});
+
+describe("parseKindsUri", () => {
+  test("parses a resolve URI", () => {
+    const uri = buildResolveUri("/repo/foo.md");
+    expect(parseKindsUri(uri)).toEqual({
+      command: "resolve",
+      file: "/repo/foo.md",
+      rule: undefined,
+    });
+  });
+
+  test("parses a why URI", () => {
+    const uri = buildWhyUri("/repo/foo.md", "MDS001");
+    expect(parseKindsUri(uri)).toEqual({
+      command: "why",
+      file: "/repo/foo.md",
+      rule: "MDS001",
+    });
+  });
+
+  test("returns null for malformed URI", () => {
+    expect(parseKindsUri("mdsmith-kinds://unknown?file=/foo.md")).toBeNull();
+    expect(parseKindsUri("http://example.com")).toBeNull();
+    expect(parseKindsUri("mdsmith-kinds://why?rule=MDS001")).toBeNull();
+    expect(parseKindsUri("mdsmith-kinds://why?file=/foo.md")).toBeNull();
+  });
+});
+
+// ---- fetchKindsContent ----
+
+describe("fetchKindsContent", () => {
+  test("returns fenced JSON for a successful resolve", async () => {
+    const spawn = async (_bin: string, args: string[]) => ({
+      stdout: '{"kinds":["plan"]}',
+      stderr: "",
+      exitCode: 0,
+    });
+    const uri = buildResolveUri("/repo/foo.md");
+    const content = await fetchKindsContent(uri, "mdsmith", "/repo", spawn);
+    expect(content).toContain("```json");
+    expect(content).toContain('{"kinds":["plan"]}');
+    expect(content).toContain("Resolved config: /repo/foo.md");
+  });
+
+  test("returns fenced JSON for a successful why", async () => {
+    const spawn = async (_bin: string, args: string[]) => ({
+      stdout: '{"rule":"MDS001","layers":[]}',
+      stderr: "",
+      exitCode: 0,
+    });
+    const uri = buildWhyUri("/repo/foo.md", "MDS001");
+    const content = await fetchKindsContent(uri, "mdsmith", "/repo", spawn);
+    expect(content).toContain("Rule MDS001 on /repo/foo.md");
+    expect(content).toContain("```json");
+  });
+
+  test("returns error block on non-zero exit", async () => {
+    const spawn = async () => ({
+      stdout: "",
+      stderr: "kinds resolve: config not found\n",
+      exitCode: 2,
+    });
+    const uri = buildResolveUri("/repo/foo.md");
+    const content = await fetchKindsContent(uri, "mdsmith", "/repo", spawn);
+    expect(content).toContain("failed");
+    expect(content).toContain("config not found");
+  });
+
+  test("returns error for malformed URI", async () => {
+    const spawn = async () => ({ stdout: "", stderr: "", exitCode: 0 });
+    const content = await fetchKindsContent("invalid://uri", "mdsmith", undefined, spawn);
+    expect(content).toContain("malformed");
+  });
+
+  test("passes correct args for resolve subcommand", async () => {
+    let capturedArgs: string[] = [];
+    const spawn = async (_bin: string, args: string[]) => {
+      capturedArgs = args;
+      return { stdout: "{}", stderr: "", exitCode: 0 };
+    };
+    await fetchKindsContent(buildResolveUri("/repo/a.md"), "mdsmith", undefined, spawn);
+    expect(capturedArgs).toEqual(["kinds", "resolve", "/repo/a.md", "--json"]);
+  });
+
+  test("passes correct args for why subcommand", async () => {
+    let capturedArgs: string[] = [];
+    const spawn = async (_bin: string, args: string[]) => {
+      capturedArgs = args;
+      return { stdout: "{}", stderr: "", exitCode: 0 };
+    };
+    await fetchKindsContent(buildWhyUri("/repo/a.md", "MDS005"), "mdsmith", undefined, spawn);
+    expect(capturedArgs).toEqual(["kinds", "why", "/repo/a.md", "MDS005", "--json"]);
+  });
+});
+
+// ---- runKindsResolve / runKindsWhy ----
+
+function makeDeps(overrides: Partial<KindsHandlerDeps> = {}): {
+  deps: KindsHandlerDeps;
+  openedUris: string[];
+  errors: string[];
+} {
+  const openedUris: string[] = [];
+  const errors: string[] = [];
+  const deps: KindsHandlerDeps = {
+    binary: "mdsmith",
+    workspaceRoot: "/repo",
+    getActiveFilePath: () => "/repo/doc.md",
+    getDiagnostics: () => [],
+    pickRule: async (rules) => rules[0],
+    openVirtualDoc: async (uri) => { openedUris.push(uri); },
+    showError: async (msg) => { errors.push(msg); },
+    ...overrides,
+  };
+  return { deps, openedUris, errors };
+}
+
+describe("runKindsResolve", () => {
+  test("opens a resolve virtual doc for the active file", async () => {
+    const { deps, openedUris } = makeDeps();
+    await runKindsResolve(deps);
+    expect(openedUris).toHaveLength(1);
+    expect(openedUris[0]).toContain("mdsmith-kinds://resolve");
+    expect(openedUris[0]).toContain(encodeURIComponent("/repo/doc.md"));
+  });
+
+  test("shows error when no active file", async () => {
+    const { deps, errors } = makeDeps({ getActiveFilePath: () => undefined });
+    await runKindsResolve(deps);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("Markdown file");
+  });
+});
+
+describe("runKindsWhy", () => {
+  test("picks a rule and opens a why virtual doc", async () => {
+    const { deps, openedUris } = makeDeps({
+      getDiagnostics: () => [
+        { source: "mdsmith", code: "MDS001" },
+      ],
+    });
+    await runKindsWhy(deps);
+    expect(openedUris).toHaveLength(1);
+    expect(openedUris[0]).toContain("mdsmith-kinds://why");
+    expect(openedUris[0]).toContain("rule=MDS001");
+  });
+
+  test("returns without opening when rule pick is cancelled", async () => {
+    const { deps, openedUris } = makeDeps({
+      pickRule: async () => undefined,
+    });
+    await runKindsWhy(deps);
+    expect(openedUris).toHaveLength(0);
+  });
+
+  test("shows error when no active file", async () => {
+    const { deps, errors } = makeDeps({ getActiveFilePath: () => undefined });
+    await runKindsWhy(deps);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -193,8 +193,6 @@ function makeDeps(overrides: Partial<KindsWhyHandlerDeps> = {}): {
   const openedUris: string[] = [];
   const errors: string[] = [];
   const deps: KindsWhyHandlerDeps = {
-    binary: "mdsmith",
-    workspaceRoot: "/repo",
     getActiveFilePath: () => "/repo/doc.md",
     getDiagnostics: () => [],
     pickRule: async (rules) => rules[0],

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -22,18 +22,23 @@ export function extractRuleIds(diagnostics: DiagnosticLike[]): string[] {
   return Array.from(ids).sort();
 }
 
-export interface KindsHandlerDeps {
+// KindsResolveHandlerDeps covers the resolve command, which needs no rule picker.
+export interface KindsResolveHandlerDeps {
   binary: string;
   workspaceRoot: string | undefined;
   getActiveFilePath: () => string | undefined;
   getDiagnostics: (filePath: string) => DiagnosticLike[];
-  pickRule: (rules: string[]) => Promise<string | undefined>;
   openVirtualDoc: (uri: string) => Promise<void>;
   showError: (msg: string) => Promise<void>;
   spawn?: SpawnFn;
 }
 
-export async function runKindsResolve(deps: KindsHandlerDeps): Promise<void> {
+// KindsWhyHandlerDeps extends resolve deps with a rule picker for the why command.
+export interface KindsWhyHandlerDeps extends KindsResolveHandlerDeps {
+  pickRule: (rules: string[]) => Promise<string | undefined>;
+}
+
+export async function runKindsResolve(deps: KindsResolveHandlerDeps): Promise<void> {
   const filePath = deps.getActiveFilePath();
   if (!filePath) {
     await deps.showError("mdsmith: Open a Markdown file first.");
@@ -44,7 +49,7 @@ export async function runKindsResolve(deps: KindsHandlerDeps): Promise<void> {
   await deps.openVirtualDoc(uri);
 }
 
-export async function runKindsWhy(deps: KindsHandlerDeps): Promise<void> {
+export async function runKindsWhy(deps: KindsWhyHandlerDeps): Promise<void> {
   const filePath = deps.getActiveFilePath();
   if (!filePath) {
     await deps.showError("mdsmith: Open a Markdown file first.");

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -3,7 +3,7 @@
 // JSON output of the corresponding kinds subcommand.
 
 import { SpawnFn, defaultSpawn } from "./runner";
-import { buildResolveUri, buildWhyUri } from "./virtual-doc";
+import { buildResolveUri, buildWhyUri, fetchKindsContent } from "./virtual-doc";
 
 export interface DiagnosticLike {
   code?: string | number | { value: string | number; target: unknown };
@@ -83,7 +83,6 @@ export function makeKindsContentProvider(
 ): KindsContentProvider {
   return {
     async provideTextDocumentContent(uri: string): Promise<string> {
-      const { fetchKindsContent } = await import("./virtual-doc.js");
       return fetchKindsContent(uri, binary, workspaceRoot, spawn);
     },
   };

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -79,13 +79,12 @@ export interface KindsContentProvider {
 export function makeKindsContentProvider(
   binary: string,
   workspaceRoot: string | undefined,
-  spawn: SpawnFn = defaultSpawn,
-  configPath?: string
+  spawn: SpawnFn = defaultSpawn
 ): KindsContentProvider {
   return {
     async provideTextDocumentContent(uri: string): Promise<string> {
       const { fetchKindsContent } = await import("./virtual-doc.js");
-      return fetchKindsContent(uri, binary, workspaceRoot, spawn, configPath);
+      return fetchKindsContent(uri, binary, workspaceRoot, spawn);
     },
   };
 }

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -78,7 +78,7 @@ export function makeKindsContentProvider(
 ): KindsContentProvider {
   return {
     async provideTextDocumentContent(uri: string): Promise<string> {
-      const { fetchKindsContent } = await import("./virtual-doc");
+      const { fetchKindsContent } = await import("./virtual-doc.js");
       return fetchKindsContent(uri, binary, workspaceRoot, spawn);
     },
   };

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -23,14 +23,13 @@ export function extractRuleIds(diagnostics: DiagnosticLike[]): string[] {
 }
 
 // KindsResolveHandlerDeps covers the resolve command, which needs no rule picker.
+// binary/workspaceRoot/spawn are NOT included here — they belong to
+// makeKindsContentProvider, which owns the spawning.
 export interface KindsResolveHandlerDeps {
-  binary: string;
-  workspaceRoot: string | undefined;
   getActiveFilePath: () => string | undefined;
   getDiagnostics: (filePath: string) => DiagnosticLike[];
   openVirtualDoc: (uri: string) => Promise<void>;
   showError: (msg: string) => Promise<void>;
-  spawn?: SpawnFn;
 }
 
 // KindsWhyHandlerDeps extends resolve deps with a rule picker for the why command.

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -1,0 +1,85 @@
+// Handler logic for mdsmith.kinds.why and mdsmith.kinds.resolve.
+// Both commands open a read-only virtual document populated from the
+// JSON output of the corresponding kinds subcommand.
+
+import { SpawnFn, defaultSpawn } from "./runner";
+import { buildResolveUri, buildWhyUri } from "./virtual-doc";
+
+export interface DiagnosticLike {
+  code?: string | number | { value: string | number; target: unknown };
+  source?: string;
+}
+
+// extractRuleIds pulls the mdsmith rule IDs (e.g. "MDS001") out of an
+// array of VS Code diagnostic objects. Only diagnostics whose source is
+// "mdsmith" and whose code is a plain string are included.
+export function extractRuleIds(diagnostics: DiagnosticLike[]): string[] {
+  const ids = new Set<string>();
+  for (const d of diagnostics) {
+    if (d.source !== "mdsmith") continue;
+    if (typeof d.code === "string" && d.code) ids.add(d.code);
+  }
+  return Array.from(ids).sort();
+}
+
+export interface KindsHandlerDeps {
+  binary: string;
+  workspaceRoot: string | undefined;
+  getActiveFilePath: () => string | undefined;
+  getDiagnostics: (filePath: string) => DiagnosticLike[];
+  pickRule: (rules: string[]) => Promise<string | undefined>;
+  openVirtualDoc: (uri: string) => Promise<void>;
+  showError: (msg: string) => Promise<void>;
+  spawn?: SpawnFn;
+}
+
+export async function runKindsResolve(deps: KindsHandlerDeps): Promise<void> {
+  const filePath = deps.getActiveFilePath();
+  if (!filePath) {
+    await deps.showError("mdsmith: Open a Markdown file first.");
+    return;
+  }
+
+  const uri = buildResolveUri(filePath);
+  await deps.openVirtualDoc(uri);
+}
+
+export async function runKindsWhy(deps: KindsHandlerDeps): Promise<void> {
+  const filePath = deps.getActiveFilePath();
+  if (!filePath) {
+    await deps.showError("mdsmith: Open a Markdown file first.");
+    return;
+  }
+
+  const diagnostics = deps.getDiagnostics(filePath);
+  const ruleIds = extractRuleIds(diagnostics);
+
+  const rule = await deps.pickRule(ruleIds);
+  if (!rule) return;
+
+  const uri = buildWhyUri(filePath, rule);
+  await deps.openVirtualDoc(uri);
+}
+
+// KindsContentProvider is the structural interface for a VS Code
+// TextDocumentContentProvider. Defined here so extension.ts can
+// implement it without importing vscode in this module.
+export interface KindsContentProvider {
+  provideTextDocumentContent(uri: string): Promise<string>;
+}
+
+// makeKindsContentProvider returns a content provider that fetches
+// kinds output for the given binary and workspace. The spawn function
+// is injectable for testing.
+export function makeKindsContentProvider(
+  binary: string,
+  workspaceRoot: string | undefined,
+  spawn: SpawnFn = defaultSpawn
+): KindsContentProvider {
+  return {
+    async provideTextDocumentContent(uri: string): Promise<string> {
+      const { fetchKindsContent } = await import("./virtual-doc");
+      return fetchKindsContent(uri, binary, workspaceRoot, spawn);
+    },
+  };
+}

--- a/editors/vscode/src/commands/kinds.ts
+++ b/editors/vscode/src/commands/kinds.ts
@@ -79,12 +79,13 @@ export interface KindsContentProvider {
 export function makeKindsContentProvider(
   binary: string,
   workspaceRoot: string | undefined,
-  spawn: SpawnFn = defaultSpawn
+  spawn: SpawnFn = defaultSpawn,
+  configPath?: string
 ): KindsContentProvider {
   return {
     async provideTextDocumentContent(uri: string): Promise<string> {
       const { fetchKindsContent } = await import("./virtual-doc.js");
-      return fetchKindsContent(uri, binary, workspaceRoot, spawn);
+      return fetchKindsContent(uri, binary, workspaceRoot, spawn, configPath);
     },
   };
 }

--- a/editors/vscode/src/commands/merge-driver.test.ts
+++ b/editors/vscode/src/commands/merge-driver.test.ts
@@ -82,4 +82,14 @@ describe("runMergeDriverInstall", () => {
     expect(args).toEqual(["merge-driver", "install"]);
     expect(cwd).toBe("/repo");
   });
+
+  test("shows could-not-start notification when spawn rejects", async () => {
+    const { deps, infoMessages, output } = makeDeps();
+    deps.spawn = async () => { throw new Error("ENOENT: mdsmith"); };
+    await runMergeDriverInstall(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("could not start");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+    expect(output.join("")).toContain("ENOENT");
+  });
 });

--- a/editors/vscode/src/commands/merge-driver.test.ts
+++ b/editors/vscode/src/commands/merge-driver.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { runMergeDriverInstall, type MergeDriverHandlerDeps } from "./merge-driver";
+
+function makeDeps(overrides: Partial<MergeDriverHandlerDeps> = {}): {
+  deps: MergeDriverHandlerDeps;
+  infoMessages: Array<{ msg: string; buttons: string[] }>;
+  errorMessages: string[];
+  output: string[];
+} {
+  const infoMessages: Array<{ msg: string; buttons: string[] }> = [];
+  const errorMessages: string[] = [];
+  const output: string[] = [];
+  const deps: MergeDriverHandlerDeps = {
+    binary: "/usr/bin/mdsmith",
+    workspaceRoot: "/repo",
+    isTrusted: () => true,
+    confirm: async () => true,
+    showInfo: async (msg, ...buttons) => {
+      infoMessages.push({ msg, buttons });
+      return undefined;
+    },
+    showError: async (msg) => { errorMessages.push(msg); },
+    appendOutput: (text) => { output.push(text); },
+    showOutput: () => {},
+    ...overrides,
+  };
+  return { deps, infoMessages, errorMessages, output };
+}
+
+describe("runMergeDriverInstall", () => {
+  test("shows error when no workspace folder is open", async () => {
+    let spawned = false;
+    const { deps, errorMessages } = makeDeps({ workspaceRoot: undefined });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runMergeDriverInstall(deps);
+    expect(errorMessages).toHaveLength(1);
+    expect(errorMessages[0]).toContain("workspace folder");
+    expect(spawned).toBe(false);
+  });
+
+  test("shows error when workspace is not trusted", async () => {
+    let spawned = false;
+    const { deps, errorMessages } = makeDeps({ isTrusted: () => false });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runMergeDriverInstall(deps);
+    expect(errorMessages).toHaveLength(1);
+    expect(errorMessages[0]).toContain("trusted workspace");
+    expect(spawned).toBe(false);
+  });
+
+  test("returns without spawning when confirmation is declined", async () => {
+    let spawned = false;
+    const { deps } = makeDeps({ confirm: async () => false });
+    deps.spawn = async () => { spawned = true; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runMergeDriverInstall(deps);
+    expect(spawned).toBe(false);
+  });
+
+  test("shows success notification on exit 0", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({ stdout: "", stderr: "installed\n", exitCode: 0 });
+    await runMergeDriverInstall(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("installed");
+    expect(infoMessages[0].buttons).toContain("Show Output");
+  });
+
+  test("shows failure notification on non-zero exit", async () => {
+    const { deps, infoMessages } = makeDeps();
+    deps.spawn = async () => ({ stdout: "", stderr: "not a git repo\n", exitCode: 2 });
+    await runMergeDriverInstall(deps);
+    expect(infoMessages).toHaveLength(1);
+    expect(infoMessages[0].msg).toContain("failed");
+  });
+
+  test("passes binary, merge-driver install args, and cwd to spawn", async () => {
+    let bin = "", args: string[] = [], cwd: string | undefined;
+    const { deps } = makeDeps();
+    deps.spawn = async (b, a, c) => { bin = b; args = a; cwd = c; return { stdout: "", stderr: "", exitCode: 0 }; };
+    await runMergeDriverInstall(deps);
+    expect(bin).toBe("/usr/bin/mdsmith");
+    expect(args).toEqual(["merge-driver", "install"]);
+    expect(cwd).toBe("/repo");
+  });
+});

--- a/editors/vscode/src/commands/merge-driver.ts
+++ b/editors/vscode/src/commands/merge-driver.ts
@@ -3,7 +3,7 @@
 // The command is trust-gated; the handler re-checks isTrusted() in
 // case the workspace trust state changed after registration.
 
-import { SpawnFn, defaultSpawn } from "./runner";
+import { SpawnFn, SpawnResult, defaultSpawn } from "./runner";
 
 export interface MergeDriverHandlerDeps {
   binary: string;
@@ -32,11 +32,22 @@ export async function runMergeDriverInstall(deps: MergeDriverHandlerDeps): Promi
   if (!confirmed) return;
 
   const spawnFn = deps.spawn ?? defaultSpawn;
-  const result = await spawnFn(
-    deps.binary,
-    ["merge-driver", "install"],
-    deps.workspaceRoot
-  );
+  let result: SpawnResult;
+  try {
+    result = await spawnFn(
+      deps.binary,
+      ["merge-driver", "install"],
+      deps.workspaceRoot
+    );
+  } catch (err) {
+    deps.appendOutput(`mdsmith merge-driver install: could not start: ${err}\n`);
+    const choice = await deps.showInfo(
+      "mdsmith merge-driver install: could not start. See output for details.",
+      "Show Output"
+    );
+    if (choice === "Show Output") deps.showOutput();
+    return;
+  }
 
   if (result.stderr) deps.appendOutput(result.stderr);
   if (result.stdout) deps.appendOutput(result.stdout);

--- a/editors/vscode/src/commands/merge-driver.ts
+++ b/editors/vscode/src/commands/merge-driver.ts
@@ -18,6 +18,11 @@ export interface MergeDriverHandlerDeps {
 }
 
 export async function runMergeDriverInstall(deps: MergeDriverHandlerDeps): Promise<void> {
+  if (!deps.workspaceRoot) {
+    await deps.showError("mdsmith: Install Git merge driver requires an open workspace folder.");
+    return;
+  }
+
   if (!deps.isTrusted()) {
     await deps.showError("mdsmith: Install Git merge driver requires a trusted workspace.");
     return;

--- a/editors/vscode/src/commands/merge-driver.ts
+++ b/editors/vscode/src/commands/merge-driver.ts
@@ -1,0 +1,50 @@
+// Handler logic for mdsmith.mergeDriver.install: runs
+// "mdsmith merge-driver install" after a confirmation dialog.
+// The command is trust-gated; the handler re-checks isTrusted() in
+// case the workspace trust state changed after registration.
+
+import { SpawnFn, defaultSpawn } from "./runner";
+
+export interface MergeDriverHandlerDeps {
+  binary: string;
+  workspaceRoot: string | undefined;
+  isTrusted: () => boolean;
+  confirm: () => Promise<boolean>;
+  showInfo: (msg: string, ...buttons: string[]) => Promise<string | undefined>;
+  showError: (msg: string) => Promise<void>;
+  appendOutput: (text: string) => void;
+  showOutput: () => void;
+  spawn?: SpawnFn;
+}
+
+export async function runMergeDriverInstall(deps: MergeDriverHandlerDeps): Promise<void> {
+  if (!deps.isTrusted()) {
+    await deps.showError("mdsmith: Install Git merge driver requires a trusted workspace.");
+    return;
+  }
+
+  const confirmed = await deps.confirm();
+  if (!confirmed) return;
+
+  const spawnFn = deps.spawn ?? defaultSpawn;
+  const result = await spawnFn(
+    deps.binary,
+    ["merge-driver", "install"],
+    deps.workspaceRoot
+  );
+
+  if (result.stderr) deps.appendOutput(result.stderr);
+  if (result.stdout) deps.appendOutput(result.stdout);
+
+  if (result.exitCode !== 0) {
+    const choice = await deps.showInfo(
+      `mdsmith merge-driver install failed (exit ${result.exitCode}). See output for details.`,
+      "Show Output"
+    );
+    if (choice === "Show Output") deps.showOutput();
+    return;
+  }
+
+  const choice = await deps.showInfo("mdsmith: Git merge driver installed.", "Show Output");
+  if (choice === "Show Output") deps.showOutput();
+}

--- a/editors/vscode/src/commands/runner.test.ts
+++ b/editors/vscode/src/commands/runner.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { defaultSpawn } from "./runner";
+
+describe("defaultSpawn", () => {
+  test("captures stdout, stderr, and exit code from a real process", async () => {
+    // Use a shell one-liner that writes to both stdout and stderr, then exits 0.
+    const result = await defaultSpawn(
+      "sh",
+      ["-c", "echo out; echo err >&2; exit 0"]
+    );
+    expect(result.stdout.trim()).toBe("out");
+    expect(result.stderr.trim()).toBe("err");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("captures a non-zero exit code", async () => {
+    const result = await defaultSpawn("sh", ["-c", "exit 2"]);
+    expect(result.exitCode).toBe(2);
+  });
+
+  test("rejects when the binary does not exist", async () => {
+    await expect(
+      defaultSpawn("__no_such_binary_mdsmith__", [])
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/editors/vscode/src/commands/runner.test.ts
+++ b/editors/vscode/src/commands/runner.test.ts
@@ -3,18 +3,18 @@ import { defaultSpawn } from "./runner";
 
 describe("defaultSpawn", () => {
   test("captures stdout, stderr, and exit code from a real process", async () => {
-    // Use a shell one-liner that writes to both stdout and stderr, then exits 0.
-    const result = await defaultSpawn(
-      "sh",
-      ["-c", "echo out; echo err >&2; exit 0"]
-    );
+    // Use node -e so the test is cross-platform (no shell required).
+    const result = await defaultSpawn("node", [
+      "-e",
+      "process.stdout.write('out\\n'); process.stderr.write('err\\n'); process.exit(0);",
+    ]);
     expect(result.stdout.trim()).toBe("out");
     expect(result.stderr.trim()).toBe("err");
     expect(result.exitCode).toBe(0);
   });
 
   test("captures a non-zero exit code", async () => {
-    const result = await defaultSpawn("sh", ["-c", "exit 2"]);
+    const result = await defaultSpawn("node", ["-e", "process.exit(2);"]);
     expect(result.exitCode).toBe(2);
   });
 

--- a/editors/vscode/src/commands/runner.test.ts
+++ b/editors/vscode/src/commands/runner.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { defaultSpawn } from "./runner";
 
 describe("defaultSpawn", () => {
+  // Use the current runtime (Node when running under Node, Bun under Bun)
+  // so the test never assumes a "node" binary exists on PATH.
+  const runtime = process.execPath;
+
   test("captures stdout, stderr, and exit code from a real process", async () => {
-    // Use node -e so the test is cross-platform (no shell required).
-    const result = await defaultSpawn("node", [
+    const result = await defaultSpawn(runtime, [
       "-e",
       "process.stdout.write('out\\n'); process.stderr.write('err\\n'); process.exit(0);",
     ]);
@@ -14,7 +17,7 @@ describe("defaultSpawn", () => {
   });
 
   test("captures a non-zero exit code", async () => {
-    const result = await defaultSpawn("node", ["-e", "process.exit(2);"]);
+    const result = await defaultSpawn(runtime, ["-e", "process.exit(2);"]);
     expect(result.exitCode).toBe(2);
   });
 

--- a/editors/vscode/src/commands/runner.ts
+++ b/editors/vscode/src/commands/runner.ts
@@ -20,7 +20,10 @@ export type SpawnFn = (
 // the process cannot be started (e.g. ENOENT).
 export const defaultSpawn: SpawnFn = (binary, args, cwd) =>
   new Promise((resolve, reject) => {
-    const proc = nodeSpawn(binary, args, cwd ? { cwd } : {});
+    const proc = nodeSpawn(binary, args, {
+      ...(cwd ? { cwd } : {}),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     let stdout = "";
     let stderr = "";
     proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });

--- a/editors/vscode/src/commands/runner.ts
+++ b/editors/vscode/src/commands/runner.ts
@@ -1,0 +1,32 @@
+// Shared helper for spawning mdsmith subcommands from palette command handlers.
+// The SpawnFn type is injectable so tests can mock child process execution.
+
+import { spawn as nodeSpawn } from "node:child_process";
+
+export interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type SpawnFn = (
+  binary: string,
+  args: string[],
+  cwd?: string
+) => Promise<SpawnResult>;
+
+// defaultSpawn runs the binary with args, captures stdout and stderr,
+// and resolves with the result on any exit code. Rejects only when
+// the process cannot be started (e.g. ENOENT).
+export const defaultSpawn: SpawnFn = (binary, args, cwd) =>
+  new Promise((resolve, reject) => {
+    const proc = nodeSpawn(binary, args, cwd ? { cwd } : {});
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+    proc.on("error", reject);
+    proc.on("close", (code: number | null) => {
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+  });

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -6,7 +6,7 @@
 //   mdsmith-kinds://resolve?file=<encoded-path>
 //   mdsmith-kinds://why?file=<encoded-path>&rule=<rule-id>
 
-import { dirname } from "path";
+import { dirname } from "node:path";
 import { SpawnFn, defaultSpawn } from "./runner";
 
 export const KINDS_SCHEME = "mdsmith-kinds";

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -61,10 +61,10 @@ export async function fetchKindsContent(
 ): Promise<string> {
   const parsed = parseKindsUri(uri);
   if (!parsed) {
-    return `**mdsmith: malformed kinds URI**\n\n\`\`\`\n${uri}\n\`\`\``;
+    return `**mdsmith: malformed kinds URI**\n\n~~~\n${uri}\n~~~`;
   }
   if (!isAbsolute(parsed.file)) {
-    return `**mdsmith: kinds URI file path must be absolute**\n\n\`\`\`\n${parsed.file}\n\`\`\``;
+    return `**mdsmith: kinds URI file path must be absolute**\n\n~~~\n${parsed.file}\n~~~`;
   }
 
   const args =
@@ -76,11 +76,11 @@ export async function fetchKindsContent(
   try {
     result = await spawn(binary, args, workspaceRoot ?? dirname(parsed.file));
   } catch (err) {
-    return `**mdsmith ${args.slice(0, 2).join(" ")} could not start**\n\n\`\`\`\n${err}\n\`\`\``;
+    return `**mdsmith ${args.slice(0, 2).join(" ")} could not start**\n\n~~~\n${err}\n~~~`;
   }
 
   if (result.exitCode !== 0) {
-    return `**mdsmith ${args.slice(0, 2).join(" ")} failed (exit ${result.exitCode})**\n\n\`\`\`\n${result.stderr.trim()}\n\`\`\``;
+    return `**mdsmith ${args.slice(0, 2).join(" ")} failed (exit ${result.exitCode})**\n\n~~~\n${result.stderr.trim()}\n~~~`;
   }
 
   const label =
@@ -88,5 +88,5 @@ export async function fetchKindsContent(
       ? `Resolved config: ${parsed.file}`
       : `Rule ${parsed.rule} on ${parsed.file}`;
 
-  return `# ${label}\n\n\`\`\`json\n${result.stdout.trim()}\n\`\`\``;
+  return `# ${label}\n\n~~~json\n${result.stdout.trim()}\n~~~`;
 }

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -31,7 +31,7 @@ export function parseKindsUri(uri: string): {
   file: string;
   rule?: string;
 } | null {
-  const match = uri.match(/^mdsmith-kinds:\/\/(resolve|why)\?(.+)$/);
+  const match = uri.match(new RegExp(`^${KINDS_SCHEME}://(resolve|why)\\?(.+)$`));
   if (!match) return null;
   const command = match[1] as "resolve" | "why";
   const params = new URLSearchParams(match[2]);

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -61,10 +61,10 @@ export async function fetchKindsContent(
 ): Promise<string> {
   const parsed = parseKindsUri(uri);
   if (!parsed) {
-    return `<!-- mdsmith: malformed kinds URI: ${uri} -->`;
+    return `**mdsmith: malformed kinds URI**\n\n\`\`\`\n${uri}\n\`\`\``;
   }
   if (!isAbsolute(parsed.file)) {
-    return `<!-- mdsmith: kinds URI file path must be absolute: ${parsed.file} -->`;
+    return `**mdsmith: kinds URI file path must be absolute**\n\n\`\`\`\n${parsed.file}\n\`\`\``;
   }
 
   const args =

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -6,7 +6,7 @@
 //   mdsmith-kinds://resolve?file=<encoded-path>
 //   mdsmith-kinds://why?file=<encoded-path>&rule=<rule-id>
 
-import { dirname } from "node:path";
+import { dirname, isAbsolute } from "node:path";
 import { SpawnFn, defaultSpawn } from "./runner";
 
 export const KINDS_SCHEME = "mdsmith-kinds";
@@ -63,11 +63,14 @@ export async function fetchKindsContent(
   if (!parsed) {
     return `<!-- mdsmith: malformed kinds URI: ${uri} -->`;
   }
+  if (!isAbsolute(parsed.file)) {
+    return `<!-- mdsmith: kinds URI file path must be absolute: ${parsed.file} -->`;
+  }
 
   const args =
     parsed.command === "resolve"
-      ? ["kinds", "resolve", parsed.file, "--json"]
-      : ["kinds", "why", parsed.file, parsed.rule!, "--json"];
+      ? ["kinds", "resolve", "--json", "--", parsed.file]
+      : ["kinds", "why", "--json", "--", parsed.file, parsed.rule!];
 
   let result: Awaited<ReturnType<typeof spawn>>;
   try {

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -27,18 +27,25 @@ export function buildWhyUri(filePath: string, rule: string): string {
 
 // parseKindsUri extracts command, file, and optional rule from a
 // mdsmith-kinds: URI string. Returns null when the URI is malformed.
+// Uses URL parsing so both "mdsmith-kinds://resolve?file=…" and the
+// normalized form "mdsmith-kinds://resolve/?file=…" are accepted.
 export function parseKindsUri(uri: string): {
   command: "resolve" | "why";
   file: string;
   rule?: string;
 } | null {
-  const match = uri.match(new RegExp(`^${KINDS_SCHEME}://(resolve|why)\\?(.+)$`));
-  if (!match) return null;
-  const command = match[1] as "resolve" | "why";
-  const params = new URLSearchParams(match[2]);
-  const file = params.get("file");
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== `${KINDS_SCHEME}:`) return null;
+  const command = url.hostname;
+  if (command !== "resolve" && command !== "why") return null;
+  const file = url.searchParams.get("file");
   if (!file) return null;
-  const rule = params.get("rule") ?? undefined;
+  const rule = url.searchParams.get("rule") ?? undefined;
   if (command === "why" && !rule) return null;
   return { command, file, rule };
 }
@@ -50,21 +57,17 @@ export async function fetchKindsContent(
   uri: string,
   binary: string,
   workspaceRoot: string | undefined,
-  spawn: SpawnFn = defaultSpawn,
-  configPath?: string
+  spawn: SpawnFn = defaultSpawn
 ): Promise<string> {
   const parsed = parseKindsUri(uri);
   if (!parsed) {
     return `<!-- mdsmith: malformed kinds URI: ${uri} -->`;
   }
 
-  const baseArgs =
+  const args =
     parsed.command === "resolve"
-      ? ["kinds", "resolve", parsed.file]
-      : ["kinds", "why", parsed.file, parsed.rule!];
-  const args = configPath
-    ? [...baseArgs, "--config", configPath, "--json"]
-    : [...baseArgs, "--json"];
+      ? ["kinds", "resolve", parsed.file, "--json"]
+      : ["kinds", "why", parsed.file, parsed.rule!, "--json"];
 
   let result: Awaited<ReturnType<typeof spawn>>;
   try {

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -6,6 +6,7 @@
 //   mdsmith-kinds://resolve?file=<encoded-path>
 //   mdsmith-kinds://why?file=<encoded-path>&rule=<rule-id>
 
+import { dirname } from "path";
 import { SpawnFn, defaultSpawn } from "./runner";
 
 export const KINDS_SCHEME = "mdsmith-kinds";
@@ -63,7 +64,7 @@ export async function fetchKindsContent(
 
   let result: Awaited<ReturnType<typeof spawn>>;
   try {
-    result = await spawn(binary, args, workspaceRoot);
+    result = await spawn(binary, args, workspaceRoot ?? dirname(parsed.file));
   } catch (err) {
     return `**mdsmith ${args.slice(0, 2).join(" ")} could not start**\n\n\`\`\`\n${err}\n\`\`\``;
   }

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -50,17 +50,21 @@ export async function fetchKindsContent(
   uri: string,
   binary: string,
   workspaceRoot: string | undefined,
-  spawn: SpawnFn = defaultSpawn
+  spawn: SpawnFn = defaultSpawn,
+  configPath?: string
 ): Promise<string> {
   const parsed = parseKindsUri(uri);
   if (!parsed) {
     return `<!-- mdsmith: malformed kinds URI: ${uri} -->`;
   }
 
-  const args =
+  const baseArgs =
     parsed.command === "resolve"
-      ? ["kinds", "resolve", parsed.file, "--json"]
-      : ["kinds", "why", parsed.file, parsed.rule!, "--json"];
+      ? ["kinds", "resolve", parsed.file]
+      : ["kinds", "why", parsed.file, parsed.rule!];
+  const args = configPath
+    ? [...baseArgs, "--config", configPath, "--json"]
+    : [...baseArgs, "--json"];
 
   let result: Awaited<ReturnType<typeof spawn>>;
   try {

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -61,7 +61,12 @@ export async function fetchKindsContent(
       ? ["kinds", "resolve", parsed.file, "--json"]
       : ["kinds", "why", parsed.file, parsed.rule!, "--json"];
 
-  const result = await spawn(binary, args, workspaceRoot);
+  let result: Awaited<ReturnType<typeof spawn>>;
+  try {
+    result = await spawn(binary, args, workspaceRoot);
+  } catch (err) {
+    return `**mdsmith ${args.slice(0, 2).join(" ")} could not start**\n\n\`\`\`\n${err}\n\`\`\``;
+  }
 
   if (result.exitCode !== 0) {
     return `**mdsmith ${args.slice(0, 2).join(" ")} failed (exit ${result.exitCode})**\n\n\`\`\`\n${result.stderr.trim()}\n\`\`\``;

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -1,0 +1,76 @@
+// TextDocumentContentProvider for the mdsmith-kinds: URI scheme.
+// URIs encode the subcommand and arguments so the provider knows what
+// to run without any external state. Closing the tab discards the buffer.
+//
+// URI format:
+//   mdsmith-kinds://resolve?file=<encoded-path>
+//   mdsmith-kinds://why?file=<encoded-path>&rule=<rule-id>
+
+import { SpawnFn, defaultSpawn } from "./runner";
+
+export const KINDS_SCHEME = "mdsmith-kinds";
+
+// buildResolveUri returns the virtual-document URI for "kinds resolve".
+export function buildResolveUri(filePath: string): string {
+  return `${KINDS_SCHEME}://resolve?file=${encodeURIComponent(filePath)}`;
+}
+
+// buildWhyUri returns the virtual-document URI for "kinds why".
+export function buildWhyUri(filePath: string, rule: string): string {
+  return (
+    `${KINDS_SCHEME}://why` +
+    `?file=${encodeURIComponent(filePath)}` +
+    `&rule=${encodeURIComponent(rule)}`
+  );
+}
+
+// parseKindsUri extracts command, file, and optional rule from a
+// mdsmith-kinds: URI string. Returns null when the URI is malformed.
+export function parseKindsUri(uri: string): {
+  command: "resolve" | "why";
+  file: string;
+  rule?: string;
+} | null {
+  const match = uri.match(/^mdsmith-kinds:\/\/(resolve|why)\?(.+)$/);
+  if (!match) return null;
+  const command = match[1] as "resolve" | "why";
+  const params = new URLSearchParams(match[2]);
+  const file = params.get("file");
+  if (!file) return null;
+  const rule = params.get("rule") ?? undefined;
+  if (command === "why" && !rule) return null;
+  return { command, file, rule };
+}
+
+// fetchKindsContent runs the appropriate mdsmith kinds subcommand and
+// returns the stdout (JSON) rendered as a fenced code block. On error
+// the stderr is returned as plain text.
+export async function fetchKindsContent(
+  uri: string,
+  binary: string,
+  workspaceRoot: string | undefined,
+  spawn: SpawnFn = defaultSpawn
+): Promise<string> {
+  const parsed = parseKindsUri(uri);
+  if (!parsed) {
+    return `<!-- mdsmith: malformed kinds URI: ${uri} -->`;
+  }
+
+  const args =
+    parsed.command === "resolve"
+      ? ["kinds", "resolve", parsed.file, "--json"]
+      : ["kinds", "why", parsed.file, parsed.rule!, "--json"];
+
+  const result = await spawn(binary, args, workspaceRoot);
+
+  if (result.exitCode !== 0) {
+    return `**mdsmith ${args.slice(0, 2).join(" ")} failed (exit ${result.exitCode})**\n\n\`\`\`\n${result.stderr.trim()}\n\`\`\``;
+  }
+
+  const label =
+    parsed.command === "resolve"
+      ? `Resolved config: ${parsed.file}`
+      : `Rule ${parsed.rule} on ${parsed.file}`;
+
+  return `# ${label}\n\n\`\`\`json\n${result.stdout.trim()}\n\`\`\``;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -422,8 +422,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const uriStr = uri.toString();
           const parsed = parseKindsUri(uriStr);
           const workspaceRoot = parsed
-            ? (vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))?.uri.fsPath
-               ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath)
+            ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))?.uri.fsPath
             : undefined;
           const provider = makeKindsContentProvider(getBinary(), workspaceRoot);
           return provider.provideTextDocumentContent(uriStr);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -429,10 +429,15 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         provideTextDocumentContent: (uri: vscode.Uri) => {
           const uriStr = uri.toString();
           const parsed = parseKindsUri(uriStr);
-          const workspaceRoot = parsed
-            ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))?.uri.fsPath
+          // Derive the workspace folder from the file encoded in the URI so
+          // binary/config lookups use the correct per-folder settings even
+          // when the active editor is the virtual doc itself.
+          const fileFolder = parsed
+            ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))
             : undefined;
-          const provider = makeKindsContentProvider(getBinary(), workspaceRoot);
+          const binaryScope = fileFolder?.uri ?? getActiveFileUri();
+          const binary = resolveActiveBinary(context.extensionPath, binaryScope);
+          const provider = makeKindsContentProvider(binary, fileFolder?.uri.fsPath);
           return provider.provideTextDocumentContent(uriStr);
         },
       }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -345,6 +345,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const doc = await vscode.workspace.openTextDocument(
             vscode.Uri.parse(uri)
           );
+          await vscode.languages.setTextDocumentLanguage(doc, "markdown");
           await vscode.window.showTextDocument(doc, {
             preview: true,
             viewColumn: vscode.ViewColumn.Beside,
@@ -381,6 +382,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const doc = await vscode.workspace.openTextDocument(
             vscode.Uri.parse(uri)
           );
+          await vscode.languages.setTextDocumentLanguage(doc, "markdown");
           await vscode.window.showTextDocument(doc, {
             preview: true,
             viewColumn: vscode.ViewColumn.Beside,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -174,14 +174,11 @@ function disposeConfigWatcher(): void {
   }
 }
 
-// showOutput reveals the "mdsmith" output channel where the
-// language client logs RPC traffic and the server's stderr.
+// showOutput reveals the "mdsmith" output channel. Uses
+// getOutputChannel() so the standalone channel created by palette
+// commands is also reachable when the LSP client is not running.
 function showOutput(): void {
-  // The LanguageClient registers an OutputChannel under
-  // outputChannelName ("mdsmith"). Calling outputChannel.show on
-  // the client's own handle is the safest way to reveal it without
-  // importing internals.
-  client?.outputChannel.show(true);
+  getOutputChannel().show(true);
 }
 
 // MdsmithErrorHandler replaces vscode-languageclient's default
@@ -343,10 +340,6 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           vscode.window.activeTextEditor?.document.uri.fsPath,
         getDiagnostics: (filePath) =>
           vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
-        pickRule: async (rules) =>
-          vscode.window.showQuickPick(rules, {
-            placeHolder: "Pick a rule ID (no diagnostics — enter any rule ID)",
-          }),
         openVirtualDoc: async (uri) => {
           const doc = await vscode.workspace.openTextDocument(
             vscode.Uri.parse(uri)

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -259,8 +259,8 @@ function getOutputChannel(): vscode.OutputChannel {
 
 // resolveActiveBinary reads `mdsmith.path` at call time so the palette
 // commands pick up config edits without a window reload.
-function resolveActiveBinary(extensionPath: string): string {
-  const cfg = vscode.workspace.getConfiguration("mdsmith");
+function resolveActiveBinary(extensionPath: string, scope?: vscode.Uri): string {
+  const cfg = vscode.workspace.getConfiguration("mdsmith", scope);
   return resolveBinary(cfg.get<string>("path", "mdsmith"), extensionPath);
 }
 
@@ -270,7 +270,11 @@ function resolveActiveBinary(extensionPath: string): string {
 // when condition, which VS Code re-evaluates automatically when trust
 // is granted — no onDidGrantWorkspaceTrust subscription is required.
 function registerPaletteCommands(context: vscode.ExtensionContext): void {
-  const getBinary = () => resolveActiveBinary(context.extensionPath);
+  const getActiveFileUri = (): vscode.Uri | undefined => {
+    const uri = vscode.window.activeTextEditor?.document.uri;
+    return uri?.scheme === "file" ? uri : undefined;
+  };
+  const getBinary = () => resolveActiveBinary(context.extensionPath, getActiveFileUri());
   // In multi-root workspaces, prefer the folder containing the active
   // editor so file-modifying commands operate in the folder the user is
   // working in. Falls back to the first folder when there is no active
@@ -288,7 +292,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
     return folders[0].uri.fsPath;
   };
   const getConfigPath = (): string | undefined => {
-    const v = vscode.workspace.getConfiguration("mdsmith").get<string>("config", "");
+    const v = vscode.workspace.getConfiguration("mdsmith", getActiveFileUri()).get<string>("config", "");
     return v || undefined;
   };
   const isTrusted = () => vscode.workspace.isTrusted;
@@ -358,8 +362,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("mdsmith.kinds.resolve", async () => {
       await runKindsResolve({
-        getActiveFilePath: () =>
-          vscode.window.activeTextEditor?.document.uri.fsPath,
+        getActiveFilePath: () => getActiveFileUri()?.fsPath,
         getDiagnostics: (filePath) =>
           vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
         openVirtualDoc: async (uri) => {
@@ -379,8 +382,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("mdsmith.kinds.why", async () => {
       await runKindsWhy({
-        getActiveFilePath: () =>
-          vscode.window.activeTextEditor?.document.uri.fsPath,
+        getActiveFilePath: () => getActiveFileUri()?.fsPath,
         getDiagnostics: (filePath) =>
           vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
         pickRule: async (rules) => {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -268,7 +268,22 @@ function resolveActiveBinary(extensionPath: string): string {
 // is granted — no onDidGrantWorkspaceTrust subscription is required.
 function registerPaletteCommands(context: vscode.ExtensionContext): void {
   const getBinary = () => resolveActiveBinary(context.extensionPath);
-  const getWorkspaceRoot = () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  // In multi-root workspaces, prefer the folder containing the active
+  // editor so file-modifying commands operate in the folder the user is
+  // working in. Falls back to the first folder when there is no active
+  // editor or it lives outside any workspace folder.
+  const getWorkspaceRoot = (): string | undefined => {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) return undefined;
+    if (folders.length > 1) {
+      const activeUri = vscode.window.activeTextEditor?.document.uri;
+      if (activeUri) {
+        const folder = vscode.workspace.getWorkspaceFolder(activeUri);
+        if (folder) return folder.uri.fsPath;
+      }
+    }
+    return folders[0].uri.fsPath;
+  };
   const getConfigPath = (): string | undefined => {
     const v = vscode.workspace.getConfiguration("mdsmith").get<string>("config", "");
     return v || undefined;

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -313,6 +313,18 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
     showOutput: () => getOutputChannel().show(true),
   });
 
+  // showNotification routes failures (messages containing "failed" or
+  // "could not start") to showWarningMessage so they surface as warnings
+  // rather than appearing informational to the user.
+  const showNotification = (msg: string, ...buttons: string[]): Promise<string | undefined> => {
+    const isFailure = msg.includes("failed") || msg.includes("could not start");
+    return Promise.resolve(
+      isFailure
+        ? vscode.window.showWarningMessage(msg, ...buttons)
+        : vscode.window.showInformationMessage(msg, ...buttons)
+    );
+  };
+
   const confirmDestructive = (label: string) => async () => {
     const answer = await vscode.window.showWarningMessage(
       `Run \`${label}\` in the workspace? This will modify files.`,
@@ -330,7 +342,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         workspaceRoot: getWorkspaceRoot(),
         isTrusted,
         showInfo: (msg, ...buttons) =>
-          Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
+          showNotification(msg, ...buttons),
         showError: (msg) =>
           Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
         ...od,
@@ -345,7 +357,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         isTrusted,
         confirm: confirmDestructive("mdsmith merge-driver install"),
         showInfo: (msg, ...buttons) =>
-          Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
+          showNotification(msg, ...buttons),
         showError: (msg) =>
           Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
         ...od,
@@ -361,7 +373,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         isTrusted,
         confirm: confirmDestructive("mdsmith fix ."),
         showInfo: (msg, ...buttons) =>
-          Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
+          showNotification(msg, ...buttons),
         showError: (msg) =>
           Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
         ...od,

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -297,8 +297,9 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         binary: getBinary(),
         workspaceRoot: getWorkspaceRoot(),
         showInfo: (msg, ...buttons) =>
-          vscode.window.showInformationMessage(msg, ...buttons),
-        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+          Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
+        showError: (msg) =>
+          Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
         ...od,
       });
     }),
@@ -311,8 +312,9 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         isTrusted,
         confirm: confirmDestructive("mdsmith merge-driver install"),
         showInfo: (msg, ...buttons) =>
-          vscode.window.showInformationMessage(msg, ...buttons),
-        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+          Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
+        showError: (msg) =>
+          Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
         ...od,
       });
     }),
@@ -325,8 +327,9 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         isTrusted,
         confirm: confirmDestructive("mdsmith fix ."),
         showInfo: (msg, ...buttons) =>
-          vscode.window.showInformationMessage(msg, ...buttons),
-        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+          Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
+        showError: (msg) =>
+          Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
         ...od,
       });
     }),
@@ -352,7 +355,8 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
             viewColumn: vscode.ViewColumn.Beside,
           });
         },
-        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+        showError: (msg) =>
+          Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
       });
     }),
 
@@ -387,7 +391,8 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
             viewColumn: vscode.ViewColumn.Beside,
           });
         },
-        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+        showError: (msg) =>
+          Promise.resolve(vscode.window.showErrorMessage(msg)).then(() => {}),
       });
     }),
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -420,7 +420,8 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const uriStr = uri.toString();
           const parsed = parseKindsUri(uriStr);
           const workspaceRoot = parsed
-            ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))?.uri.fsPath
+            ? (vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))?.uri.fsPath
+               ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath)
             : undefined;
           const provider = makeKindsContentProvider(getBinary(), workspaceRoot);
           return provider.provideTextDocumentContent(uriStr);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -24,7 +24,6 @@ import { runInit } from "./commands/init";
 import { runMergeDriverInstall } from "./commands/merge-driver";
 import { runKindsResolve, runKindsWhy, makeKindsContentProvider } from "./commands/kinds";
 import { KINDS_SCHEME } from "./commands/virtual-doc";
-import { defaultSpawn } from "./commands/runner";
 
 let client: LanguageClient | undefined;
 // Track the .mdsmith.yml file watcher across the activate /
@@ -406,9 +405,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         provideTextDocumentContent: (uri: vscode.Uri) => {
           const provider = makeKindsContentProvider(
             getBinary(),
-            getWorkspaceRoot(),
-            defaultSpawn,
-            getConfigPath()
+            getWorkspaceRoot()
           );
           return provider.provideTextDocumentContent(uri.toString());
         },

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -358,8 +358,6 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("mdsmith.kinds.resolve", async () => {
       await runKindsResolve({
-        binary: getBinary(),
-        workspaceRoot: getWorkspaceRoot(),
         getActiveFilePath: () =>
           vscode.window.activeTextEditor?.document.uri.fsPath,
         getDiagnostics: (filePath) =>
@@ -381,8 +379,6 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("mdsmith.kinds.why", async () => {
       await runKindsWhy({
-        binary: getBinary(),
-        workspaceRoot: getWorkspaceRoot(),
         getActiveFilePath: () =>
           vscode.window.activeTextEditor?.document.uri.fsPath,
         getDiagnostics: (filePath) =>

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -410,14 +410,10 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       }
     ),
 
-    // Reveal the trust-gated commands without a reload when trust is granted.
-    vscode.workspace.onDidGrantWorkspaceTrust(() => {
-      void vscode.commands.executeCommand(
-        "setContext",
-        "mdsmith.workspaceTrusted",
-        true
-      );
-    })
+    // VS Code automatically re-evaluates the built-in `isWorkspaceTrusted`
+    // context when trust is granted, so menu entries gated with
+    // `when: isWorkspaceTrusted` appear without a reload — no explicit
+    // handler needed here.
   );
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -274,7 +274,6 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
     const uri = vscode.window.activeTextEditor?.document.uri;
     return uri?.scheme === "file" ? uri : undefined;
   };
-  const getBinary = () => resolveActiveBinary(context.extensionPath, getActiveFileUri());
   // In multi-root workspaces, prefer the folder containing the active
   // editor so file-modifying commands operate in the folder the user is
   // working in. Falls back to the first folder when there is no active
@@ -291,8 +290,17 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
     }
     return folders[0].uri.fsPath;
   };
+  // Scope configuration lookups to the workspace folder being operated on
+  // so per-folder mdsmith.path / mdsmith.config values are respected in
+  // multi-root workspaces. Falls back to the active file URI when no
+  // workspace folder is available (e.g. for the kinds virtual-doc commands).
+  const getConfigScope = (): vscode.Uri | undefined => {
+    const root = getWorkspaceRoot();
+    return root ? vscode.Uri.file(root) : getActiveFileUri();
+  };
+  const getBinary = () => resolveActiveBinary(context.extensionPath, getConfigScope());
   const getConfigPath = (): string | undefined => {
-    const v = vscode.workspace.getConfiguration("mdsmith", getActiveFileUri()).get<string>("config", "");
+    const v = vscode.workspace.getConfiguration("mdsmith", getConfigScope()).get<string>("config", "");
     return v || undefined;
   };
   const isTrusted = () => vscode.workspace.isTrusted;

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -366,8 +366,8 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const doc = await vscode.workspace.openTextDocument(
             vscode.Uri.parse(uri)
           );
-          await vscode.languages.setTextDocumentLanguage(doc, "markdown");
-          await vscode.window.showTextDocument(doc, {
+          const mdDoc = await vscode.languages.setTextDocumentLanguage(doc, "markdown");
+          await vscode.window.showTextDocument(mdDoc, {
             preview: true,
             viewColumn: vscode.ViewColumn.Beside,
           });
@@ -401,8 +401,8 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const doc = await vscode.workspace.openTextDocument(
             vscode.Uri.parse(uri)
           );
-          await vscode.languages.setTextDocumentLanguage(doc, "markdown");
-          await vscode.window.showTextDocument(doc, {
+          const mdDoc = await vscode.languages.setTextDocumentLanguage(doc, "markdown");
+          await vscode.window.showTextDocument(mdDoc, {
             preview: true,
             viewColumn: vscode.ViewColumn.Beside,
           });

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -296,6 +296,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       await runInit({
         binary: getBinary(),
         workspaceRoot: getWorkspaceRoot(),
+        isTrusted,
         showInfo: (msg, ...buttons) =>
           Promise.resolve(vscode.window.showInformationMessage(msg, ...buttons)),
         showError: (msg) =>
@@ -436,4 +437,11 @@ export async function deactivate(): Promise<void> {
   // tight and configWatcher does not survive into a subsequent
   // activation.
   disposeConfigWatcher();
+  // Dispose the standalone output channel created when the LSP
+  // client is not running. context.subscriptions is flushed after
+  // deactivate returns, so dispose explicitly here for tight ordering.
+  if (standaloneOutputChannel) {
+    standaloneOutputChannel.dispose();
+    standaloneOutputChannel = undefined;
+  }
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -19,6 +19,11 @@ import {
   startupErrorMessage
 } from "./wiring";
 import { resolveBinary } from "./binary";
+import { runFixWorkspace } from "./commands/fix-workspace";
+import { runInit } from "./commands/init";
+import { runMergeDriverInstall } from "./commands/merge-driver";
+import { runKindsResolve, runKindsWhy, makeKindsContentProvider } from "./commands/kinds";
+import { KINDS_SCHEME } from "./commands/virtual-doc";
 
 let client: LanguageClient | undefined;
 // Track the .mdsmith.yml file watcher across the activate /
@@ -37,6 +42,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("mdsmith.restartServer", () => restartServer(context)),
     vscode.commands.registerCommand("mdsmith.showOutput", () => showOutput())
   );
+
+  registerPaletteCommands(context);
 
   // Wire fix-on-save once. The handler reads the setting on every
   // save so toggling the option does not require a restart.
@@ -234,6 +241,179 @@ async function promptRestartAfterRepeatedFailures(): Promise<void> {
   } else if (choice === "Show Output") {
     showOutput();
   }
+}
+
+// getOutputChannel lazily accesses the output channel that the
+// LanguageClient registers under "mdsmith". Falls back to creating a
+// standalone channel when the client is not running so palette commands
+// can still surface stderr.
+let standaloneOutputChannel: vscode.OutputChannel | undefined;
+
+function getOutputChannel(): vscode.OutputChannel {
+  if (client?.outputChannel) return client.outputChannel;
+  if (!standaloneOutputChannel) {
+    standaloneOutputChannel = vscode.window.createOutputChannel("mdsmith");
+  }
+  return standaloneOutputChannel;
+}
+
+// resolveActiveBinary reads `mdsmith.path` at call time so the palette
+// commands pick up config edits without a window reload.
+function resolveActiveBinary(extensionPath: string): string {
+  const cfg = vscode.workspace.getConfiguration("mdsmith");
+  return resolveBinary(cfg.get<string>("path", "mdsmith"), extensionPath);
+}
+
+// registerPaletteCommands wires the five mdsmith.* palette commands and
+// registers the mdsmith-kinds: virtual-document scheme. Called once from
+// activate(); the trust-gated commands also subscribe to
+// onDidGrantWorkspaceTrust so they appear without a reload.
+function registerPaletteCommands(context: vscode.ExtensionContext): void {
+  const getBinary = () => resolveActiveBinary(context.extensionPath);
+  const getWorkspaceRoot = () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const isTrusted = () => vscode.workspace.isTrusted;
+
+  const outputDeps = () => ({
+    appendOutput: (text: string) => {
+      const ch = getOutputChannel();
+      ch.append(text);
+    },
+    showOutput: () => getOutputChannel().show(true),
+  });
+
+  const confirmDestructive = (label: string) => async () => {
+    const answer = await vscode.window.showWarningMessage(
+      `Run \`${label}\` in the workspace? This will modify files.`,
+      { modal: true },
+      "Proceed"
+    );
+    return answer === "Proceed";
+  };
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("mdsmith.init", async () => {
+      const od = outputDeps();
+      await runInit({
+        binary: getBinary(),
+        workspaceRoot: getWorkspaceRoot(),
+        showInfo: (msg, ...buttons) =>
+          vscode.window.showInformationMessage(msg, ...buttons),
+        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+        ...od,
+      });
+    }),
+
+    vscode.commands.registerCommand("mdsmith.mergeDriver.install", async () => {
+      const od = outputDeps();
+      await runMergeDriverInstall({
+        binary: getBinary(),
+        workspaceRoot: getWorkspaceRoot(),
+        isTrusted,
+        confirm: confirmDestructive("mdsmith merge-driver install"),
+        showInfo: (msg, ...buttons) =>
+          vscode.window.showInformationMessage(msg, ...buttons),
+        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+        ...od,
+      });
+    }),
+
+    vscode.commands.registerCommand("mdsmith.fixWorkspace", async () => {
+      const od = outputDeps();
+      await runFixWorkspace({
+        binary: getBinary(),
+        workspaceRoot: getWorkspaceRoot(),
+        isTrusted,
+        confirm: confirmDestructive("mdsmith fix ."),
+        showInfo: (msg, ...buttons) =>
+          vscode.window.showInformationMessage(msg, ...buttons),
+        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+        ...od,
+      });
+    }),
+
+    vscode.commands.registerCommand("mdsmith.kinds.resolve", async () => {
+      await runKindsResolve({
+        binary: getBinary(),
+        workspaceRoot: getWorkspaceRoot(),
+        getActiveFilePath: () =>
+          vscode.window.activeTextEditor?.document.uri.fsPath,
+        getDiagnostics: (filePath) =>
+          vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
+        pickRule: async (rules) =>
+          vscode.window.showQuickPick(rules, {
+            placeHolder: "Pick a rule ID (no diagnostics — enter any rule ID)",
+          }),
+        openVirtualDoc: async (uri) => {
+          const doc = await vscode.workspace.openTextDocument(
+            vscode.Uri.parse(uri)
+          );
+          await vscode.window.showTextDocument(doc, {
+            preview: true,
+            viewColumn: vscode.ViewColumn.Beside,
+          });
+        },
+        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+      });
+    }),
+
+    vscode.commands.registerCommand("mdsmith.kinds.why", async () => {
+      await runKindsWhy({
+        binary: getBinary(),
+        workspaceRoot: getWorkspaceRoot(),
+        getActiveFilePath: () =>
+          vscode.window.activeTextEditor?.document.uri.fsPath,
+        getDiagnostics: (filePath) =>
+          vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
+        pickRule: async (rules) => {
+          const items =
+            rules.length > 0
+              ? rules
+              : await vscode.window.showInputBox({
+                  prompt: "No active diagnostics. Enter a rule ID (e.g. MDS001)",
+                  placeHolder: "MDS001",
+                }).then((v) => (v ? [v] : []));
+          if (!items || items.length === 0) return undefined;
+          if (items.length === 1) return items[0];
+          return vscode.window.showQuickPick(items, {
+            placeHolder: "Pick a rule to explain",
+          });
+        },
+        openVirtualDoc: async (uri) => {
+          const doc = await vscode.workspace.openTextDocument(
+            vscode.Uri.parse(uri)
+          );
+          await vscode.window.showTextDocument(doc, {
+            preview: true,
+            viewColumn: vscode.ViewColumn.Beside,
+          });
+        },
+        showError: (msg) => vscode.window.showErrorMessage(msg).then(() => {}),
+      });
+    }),
+
+    // Register the virtual document provider for the mdsmith-kinds: scheme.
+    vscode.workspace.registerTextDocumentContentProvider(
+      KINDS_SCHEME,
+      {
+        provideTextDocumentContent: (uri: vscode.Uri) => {
+          const provider = makeKindsContentProvider(
+            getBinary(),
+            getWorkspaceRoot()
+          );
+          return provider.provideTextDocumentContent(uri.toString());
+        },
+      }
+    ),
+
+    // Reveal the trust-gated commands without a reload when trust is granted.
+    vscode.workspace.onDidGrantWorkspaceTrust(() => {
+      void vscode.commands.executeCommand(
+        "setContext",
+        "mdsmith.workspaceTrusted",
+        true
+      );
+    })
+  );
 }
 
 export async function deactivate(): Promise<void> {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -24,6 +24,7 @@ import { runInit } from "./commands/init";
 import { runMergeDriverInstall } from "./commands/merge-driver";
 import { runKindsResolve, runKindsWhy, makeKindsContentProvider } from "./commands/kinds";
 import { KINDS_SCHEME } from "./commands/virtual-doc";
+import { defaultSpawn } from "./commands/runner";
 
 let client: LanguageClient | undefined;
 // Track the .mdsmith.yml file watcher across the activate /
@@ -269,6 +270,10 @@ function resolveActiveBinary(extensionPath: string): string {
 function registerPaletteCommands(context: vscode.ExtensionContext): void {
   const getBinary = () => resolveActiveBinary(context.extensionPath);
   const getWorkspaceRoot = () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const getConfigPath = (): string | undefined => {
+    const v = vscode.workspace.getConfiguration("mdsmith").get<string>("config", "");
+    return v || undefined;
+  };
   const isTrusted = () => vscode.workspace.isTrusted;
 
   const outputDeps = () => ({
@@ -323,6 +328,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       await runFixWorkspace({
         binary: getBinary(),
         workspaceRoot: getWorkspaceRoot(),
+        configPath: getConfigPath(),
         isTrusted,
         confirm: confirmDestructive("mdsmith fix ."),
         showInfo: (msg, ...buttons) =>
@@ -400,7 +406,9 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         provideTextDocumentContent: (uri: vscode.Uri) => {
           const provider = makeKindsContentProvider(
             getBinary(),
-            getWorkspaceRoot()
+            getWorkspaceRoot(),
+            defaultSpawn,
+            getConfigPath()
           );
           return provider.provideTextDocumentContent(uri.toString());
         },

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -419,7 +419,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
         provideTextDocumentContent: (uri: vscode.Uri) => {
           const provider = makeKindsContentProvider(
             getBinary(),
-            getWorkspaceRoot()
+            undefined
           );
           return provider.provideTextDocumentContent(uri.toString());
         },

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -370,7 +370,12 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("mdsmith.kinds.resolve", async () => {
       await runKindsResolve({
-        getActiveFilePath: () => getActiveFileUri()?.fsPath,
+        getActiveFilePath: () => {
+          const editor = vscode.window.activeTextEditor;
+          if (!editor || editor.document.uri.scheme !== "file") return undefined;
+          if (editor.document.languageId !== "markdown") return undefined;
+          return editor.document.uri.fsPath;
+        },
         getDiagnostics: (filePath) =>
           vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
         openVirtualDoc: async (uri) => {
@@ -390,7 +395,12 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("mdsmith.kinds.why", async () => {
       await runKindsWhy({
-        getActiveFilePath: () => getActiveFileUri()?.fsPath,
+        getActiveFilePath: () => {
+          const editor = vscode.window.activeTextEditor;
+          if (!editor || editor.document.uri.scheme !== "file") return undefined;
+          if (editor.document.languageId !== "markdown") return undefined;
+          return editor.document.uri.fsPath;
+        },
         getDiagnostics: (filePath) =>
           vscode.languages.getDiagnostics(vscode.Uri.file(filePath)),
         pickRule: async (rules) => {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -445,6 +445,14 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const fileFolder = parsed
             ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))
             : undefined;
+          // When workspace folders are open, reject files outside the workspace
+          // to prevent crafted URIs from analyzing arbitrary paths on disk.
+          const folders = vscode.workspace.workspaceFolders;
+          if (parsed && folders && folders.length > 0 && !fileFolder) {
+            return Promise.resolve(
+              `**mdsmith: file is outside the workspace**\n\n\`\`\`\n${parsed.file}\n\`\`\``
+            );
+          }
           const binaryScope = fileFolder?.uri ?? getActiveFileUri();
           const binary = resolveActiveBinary(context.extensionPath, binaryScope);
           const provider = makeKindsContentProvider(binary, fileFolder?.uri.fsPath);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -263,8 +263,9 @@ function resolveActiveBinary(extensionPath: string): string {
 
 // registerPaletteCommands wires the five mdsmith.* palette commands and
 // registers the mdsmith-kinds: virtual-document scheme. Called once from
-// activate(); the trust-gated commands also subscribe to
-// onDidGrantWorkspaceTrust so they appear without a reload.
+// activate(). Trust-gated commands use the built-in isWorkspaceTrusted
+// when condition, which VS Code re-evaluates automatically when trust
+// is granted — no onDidGrantWorkspaceTrust subscription is required.
 function registerPaletteCommands(context: vscode.ExtensionContext): void {
   const getBinary = () => resolveActiveBinary(context.extensionPath);
   const getWorkspaceRoot = () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -23,7 +23,7 @@ import { runFixWorkspace } from "./commands/fix-workspace";
 import { runInit } from "./commands/init";
 import { runMergeDriverInstall } from "./commands/merge-driver";
 import { runKindsResolve, runKindsWhy, makeKindsContentProvider } from "./commands/kinds";
-import { KINDS_SCHEME } from "./commands/virtual-doc";
+import { KINDS_SCHEME, parseKindsUri } from "./commands/virtual-doc";
 
 let client: LanguageClient | undefined;
 // Track the .mdsmith.yml file watcher across the activate /
@@ -417,11 +417,13 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       KINDS_SCHEME,
       {
         provideTextDocumentContent: (uri: vscode.Uri) => {
-          const provider = makeKindsContentProvider(
-            getBinary(),
-            undefined
-          );
-          return provider.provideTextDocumentContent(uri.toString());
+          const uriStr = uri.toString();
+          const parsed = parseKindsUri(uriStr);
+          const workspaceRoot = parsed
+            ? vscode.workspace.getWorkspaceFolder(vscode.Uri.file(parsed.file))?.uri.fsPath
+            : undefined;
+          const provider = makeKindsContentProvider(getBinary(), workspaceRoot);
+          return provider.provideTextDocumentContent(uriStr);
         },
       }
     ),

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -99,7 +99,10 @@ async function startServer(context: vscode.ExtensionContext): Promise<void> {
   disposeConfigWatcher();
   configWatcher = vscode.workspace.createFileSystemWatcher("**/.mdsmith.yml");
   context.subscriptions.push(configWatcher);
-  const clientOptions: LanguageClientOptions = buildClientOptions(configWatcher);
+  const clientOptions: LanguageClientOptions = buildClientOptions(
+    configWatcher,
+    getOutputChannel()
+  );
   // Replace the default ErrorHandler (DoNotRestart after 5 close
   // events in 3 minutes) with one that gives the user a clear
   // recovery path. We let the client keep restarting up to a
@@ -240,18 +243,18 @@ async function promptRestartAfterRepeatedFailures(): Promise<void> {
   }
 }
 
-// getOutputChannel lazily accesses the output channel that the
-// LanguageClient registers under "mdsmith". Falls back to creating a
-// standalone channel when the client is not running so palette commands
-// can still surface stderr.
-let standaloneOutputChannel: vscode.OutputChannel | undefined;
+// getOutputChannel returns the single "mdsmith" OutputChannel shared
+// between palette commands and the LanguageClient. Created lazily on
+// first use so we don't reserve a channel before anyone needs it; the
+// same instance is passed into LanguageClientOptions.outputChannel so
+// the LSP client doesn't register a second channel with the same name.
+let outputChannel: vscode.OutputChannel | undefined;
 
 function getOutputChannel(): vscode.OutputChannel {
-  if (client?.outputChannel) return client.outputChannel;
-  if (!standaloneOutputChannel) {
-    standaloneOutputChannel = vscode.window.createOutputChannel("mdsmith");
+  if (!outputChannel) {
+    outputChannel = vscode.window.createOutputChannel("mdsmith");
   }
-  return standaloneOutputChannel;
+  return outputChannel;
 }
 
 // resolveActiveBinary reads `mdsmith.path` at call time so the palette
@@ -453,11 +456,11 @@ export async function deactivate(): Promise<void> {
   // tight and configWatcher does not survive into a subsequent
   // activation.
   disposeConfigWatcher();
-  // Dispose the standalone output channel created when the LSP
-  // client is not running. context.subscriptions is flushed after
-  // deactivate returns, so dispose explicitly here for tight ordering.
-  if (standaloneOutputChannel) {
-    standaloneOutputChannel.dispose();
-    standaloneOutputChannel = undefined;
+  // Dispose the shared output channel. context.subscriptions is
+  // flushed after deactivate returns, so dispose explicitly here
+  // for tight ordering.
+  if (outputChannel) {
+    outputChannel.dispose();
+    outputChannel = undefined;
   }
 }

--- a/editors/vscode/src/wiring.test.ts
+++ b/editors/vscode/src/wiring.test.ts
@@ -89,7 +89,15 @@ describe("buildClientOptions", () => {
 
   test("forwards a shared OutputChannel and omits outputChannelName", () => {
     const watcher: FileSystemWatcherLike = {};
-    const channel = { id: "shared" };
+    const channel = {
+      name: "mdsmith",
+      append: () => {},
+      appendLine: () => {},
+      clear: () => {},
+      show: () => {},
+      hide: () => {},
+      dispose: () => {},
+    };
     const opts = buildClientOptions(watcher, channel);
     expect(opts.outputChannel as unknown).toBe(channel as unknown);
     expect(opts.outputChannelName).toBeUndefined();

--- a/editors/vscode/src/wiring.test.ts
+++ b/editors/vscode/src/wiring.test.ts
@@ -84,6 +84,15 @@ describe("buildClientOptions", () => {
     // short-circuit the typecheck.
     expect(opts.synchronize?.fileEvents as unknown).toBe(watcher as unknown);
     expect(opts.outputChannelName).toBe("mdsmith");
+    expect(opts.outputChannel).toBeUndefined();
+  });
+
+  test("forwards a shared OutputChannel and omits outputChannelName", () => {
+    const watcher: FileSystemWatcherLike = {};
+    const channel = { id: "shared" };
+    const opts = buildClientOptions(watcher, channel);
+    expect(opts.outputChannel as unknown).toBe(channel as unknown);
+    expect(opts.outputChannelName).toBeUndefined();
   });
 });
 

--- a/editors/vscode/src/wiring.ts
+++ b/editors/vscode/src/wiring.ts
@@ -40,11 +40,19 @@ export function buildServerOptions(
   };
 }
 
-// OutputChannelLike is a marker for a vscode.OutputChannel instance
-// forwarded into LanguageClientOptions. Defined here so wiring.ts
-// stays decoupled from the `vscode` runtime package; the real
-// instance is supplied by extension.ts.
-export interface OutputChannelLike {}
+// OutputChannelLike captures the OutputChannel methods that
+// vscode-languageclient calls when LanguageClientOptions.outputChannel
+// is set. Defined structurally so wiring.ts stays decoupled from the
+// `vscode` runtime package while still rejecting unrelated objects.
+export interface OutputChannelLike {
+  readonly name: string;
+  append(value: string): void;
+  appendLine(value: string): void;
+  clear(): void;
+  show(preserveFocus?: boolean): void;
+  hide(): void;
+  dispose(): void;
+}
 
 export function buildClientOptions(
   configWatcher: FileSystemWatcherLike,

--- a/editors/vscode/src/wiring.ts
+++ b/editors/vscode/src/wiring.ts
@@ -40,10 +40,17 @@ export function buildServerOptions(
   };
 }
 
+// OutputChannelLike is a marker for a vscode.OutputChannel instance
+// forwarded into LanguageClientOptions. Defined here so wiring.ts
+// stays decoupled from the `vscode` runtime package; the real
+// instance is supplied by extension.ts.
+export interface OutputChannelLike {}
+
 export function buildClientOptions(
-  configWatcher: FileSystemWatcherLike
+  configWatcher: FileSystemWatcherLike,
+  outputChannel?: OutputChannelLike
 ): LanguageClientOptions {
-  return {
+  const opts: LanguageClientOptions = {
     documentSelector: [
       { scheme: "file", language: "markdown" }
     ],
@@ -51,9 +58,18 @@ export function buildClientOptions(
       // Cast: LanguageClientOptions wants the full vscode interface,
       // but at runtime only the shape we expose matters.
       fileEvents: configWatcher as never
-    },
-    outputChannelName: "mdsmith"
+    }
   };
+  if (outputChannel) {
+    // Sharing one OutputChannel between palette commands and the LSP
+    // client avoids two channels with the same name once the client
+    // starts. Cast through never because LanguageClientOptions wants
+    // the real vscode.OutputChannel type which we don't import here.
+    opts.outputChannel = outputChannel as never;
+  } else {
+    opts.outputChannelName = "mdsmith";
+  }
+  return opts;
 }
 
 export function startupErrorMessage(err: unknown): string {

--- a/plan/122_vscode-hover-and-palette.md
+++ b/plan/122_vscode-hover-and-palette.md
@@ -1,7 +1,7 @@
 ---
 id: 122
 title: VS Code palette commands
-status: "🔲"
+status: "🔳"
 model: sonnet
 summary: >-
   A small set of VS Code command-palette entries —
@@ -148,31 +148,31 @@ feedback.
 
 ## Tasks
 
-1. Register the five palette commands in
+1. [x] Register the five palette commands in
    `editors/vscode/package.json`. Add one handler
    per command in `editors/vscode/src/commands/`.
    Each spawns the binary, surfaces stderr, and
    shows a notification on non-zero exit.
-2. Implement `mdsmith.fixWorkspace`. Run
+2. [x] Implement `mdsmith.fixWorkspace`. Run
    `mdsmith fix .` from the workspace root. Parse
    the `stats:` line from stderr (see
    `printRunStats`). Show a notification with the
    fixed-of-total count. Cover with a VS Code
    extension test that mocks the child process.
-3. Implement `mdsmith.kinds.why` and
+3. [x] Implement `mdsmith.kinds.why` and
    `mdsmith.kinds.resolve` against the
    `mdsmith-kinds:` virtual document scheme.
    Register a `TextDocumentContentProvider` that
    returns the JSON output rendered as Markdown.
-4. Update the VS Code guide
+4. [x] Update the VS Code guide
    `docs/guides/editors/vscode.md` (created in
    plan 121) with one section per palette command.
-5. Add a CLI-subcommand table to
+5. [x] Add a CLI-subcommand table to
    `docs/guides/editors/vscode.md` listing every
    subcommand and its editor entry point. Mark
    `archetypes`, `metrics`, `query`, and `version`
    as "CLI only".
-6. Wire workspace trust per the design above. Add
+6. [x] Wire workspace trust per the design above. Add
    the `capabilities.untrustedWorkspaces` block to
    `editors/vscode/package.json`. Gate the
    `fixWorkspace` and `mergeDriver.install` menu
@@ -184,33 +184,33 @@ feedback.
 
 ## Acceptance Criteria
 
-- [ ] The command palette lists the five
+- [x] The command palette lists the five
       `mdsmith.*` commands in a workspace with a
       Markdown file open.
-- [ ] `mdsmith: Fix all Markdown` runs through a
+- [x] `mdsmith: Fix all Markdown` runs through a
       confirmation dialog, executes
       `mdsmith fix .`, and shows the fixed-count
       notification.
-- [ ] `mdsmith: Explain rule on this file` opens a
+- [x] `mdsmith: Explain rule on this file` opens a
       virtual document with the kinds-why output
       for the selected rule.
-- [ ] No CodeLens, status-bar item, or
+- [x] No CodeLens, status-bar item, or
       activity-bar container is registered by the
       extension (verified by a CI grep on
       `editors/vscode/package.json`).
-- [ ] All tests pass: `go test ./...` and
+- [x] All tests pass: `go test ./...` and
       `npm test` inside `editors/vscode/`.
-- [ ] `go tool golangci-lint run` reports no
+- [x] `go tool golangci-lint run` reports no
       issues.
-- [ ] `mdsmith check .` passes (subject to plan
+- [x] `mdsmith check .` passes (subject to plan
       121's open question about `editors/**`
       exclusion).
-- [ ] Opening an untrusted workspace hides the
+- [x] Opening an untrusted workspace hides the
       `mdsmith.fixWorkspace` and
       `mdsmith.mergeDriver.install` palette
       entries; granting trust reveals them
       without a reload.
-- [ ] An untrusted workspace cannot redirect
+- [x] An untrusted workspace cannot redirect
       `mdsmith.path` or `mdsmith.config`; the
       extension uses the user-level value.
 

--- a/plan/122_vscode-hover-and-palette.md
+++ b/plan/122_vscode-hover-and-palette.md
@@ -1,7 +1,7 @@
 ---
 id: 122
 title: VS Code palette commands
-status: "🔳"
+status: "✅"
 model: sonnet
 summary: >-
   A small set of VS Code command-palette entries —

--- a/plan/122_vscode-hover-and-palette.md
+++ b/plan/122_vscode-hover-and-palette.md
@@ -33,9 +33,9 @@ Plan 133 covers hover for `help rule` and
 directive docs only — the rest of `mdsmith help`
 (e.g. `help metrics`, `help kinds`,
 `help concepts`) stays CLI-only since those topics
-have no in-buffer anchor to hover over. Eight
+have no in-buffer anchor to hover over. Seven
 subcommands stay outside the editor:
-`help`, `kinds`, `archetypes`, `metrics`,
+`help`, `kinds`, `metrics`,
 `query`, `init`, `merge-driver`, `version`. A
 reviewer audit grouped them:
 
@@ -43,8 +43,8 @@ reviewer audit grouped them:
   fix-everything, `kinds why`, `kinds resolve`.
 - **Hover (plan 133)**: `help rule <id>` and the
   directive-doc subset.
-- **CLI only**: the rest of `help`, `archetypes`,
-  `metrics`, `query`, `version` — reviewers would
+- **CLI only**: the rest of `help`, `metrics`,
+  `query`, `version` — reviewers would
   uninstall a tree view or status-bar pill
   surfacing these.
 
@@ -170,7 +170,7 @@ feedback.
 5. [x] Add a CLI-subcommand table to
    `docs/guides/editors/vscode.md` listing every
    subcommand and its editor entry point. Mark
-   `archetypes`, `metrics`, `query`, and `version`
+   `metrics`, `query`, and `version`
    as "CLI only".
 6. [x] Wire workspace trust per the design above. Add
    the `capabilities.untrustedWorkspaces` block to


### PR DESCRIPTION
## Summary

This PR implements five new VS Code command-palette commands that expose mdsmith functionality directly to users without requiring CLI interaction. The commands are registered in the extension and include handlers for initialization, workspace fixing, git merge driver installation, and rule explanation/config resolution via virtual documents.

## Key Changes

- **New palette commands**: Added five commands to `package.json`:
  - `mdsmith.init` - Initialize `.mdsmith.yml` config (trust-gated)
  - `mdsmith.mergeDriver.install` - Install git merge driver (trust-gated)
  - `mdsmith.fixWorkspace` - Run `mdsmith fix .` with fixed-count notification (trust-gated)
  - `mdsmith.kinds.why` - Explain a rule on the current file
  - `mdsmith.kinds.resolve` - Show resolved config for the current file

- **Command handlers**: Created modular handler implementations:
  - `src/commands/init.ts` - Runs `mdsmith init` and shows completion notification
  - `src/commands/fix-workspace.ts` - Runs `mdsmith fix .`, parses stats line, displays fixed-of-total summary
  - `src/commands/merge-driver.ts` - Runs `mdsmith merge-driver install` with confirmation
  - `src/commands/kinds.ts` - Extracts rule IDs from diagnostics and opens virtual documents
  - `src/commands/virtual-doc.ts` - Implements `mdsmith-kinds://` URI scheme for read-only JSON output
  - `src/commands/runner.ts` - Shared child process spawning utility with injectable `SpawnFn`

- **Virtual document provider**: Registered `mdsmith-kinds:` scheme that:
  - Encodes command and arguments in URI query parameters
  - Runs `mdsmith kinds resolve` or `mdsmith kinds why` on demand
  - Renders JSON output as fenced code blocks in Markdown
  - Handles errors gracefully with stderr display

- **Trust gating**: Commands that modify files (`init`, `fixWorkspace`, `mergeDriver.install`) are:
  - Gated in `package.json` with `when: isWorkspaceTrusted`
  - Re-checked at runtime before execution
  - `fixWorkspace` and `mergeDriver.install` also require explicit user confirmation via dialog
  - VS Code re-evaluates `isWorkspaceTrusted` automatically when trust is granted — no `onDidGrantWorkspaceTrust` subscription is required

- **Activation events**: All seven contributed commands are listed explicitly in `activationEvents` so the extension activates when any palette command is invoked, regardless of whether a Markdown file is open

- **Comprehensive test coverage**: Added test suites for all handlers:
  - `src/commands/kinds.test.ts` - Tests rule extraction, URI parsing, content fetching
  - `src/commands/fix-workspace.test.ts` - Tests stats parsing, notification messages, spawn integration

- **Extension integration**: Updated `extension.ts` to:
  - Register all palette commands with appropriate VS Code APIs
  - Wire dependency injection for binary resolution, workspace root, diagnostics, UI dialogs
  - Implement lazy output channel creation for commands running outside LSP client

- **Documentation**: Updated `docs/guides/editors/vscode.md` with:
  - Separate sections for server commands vs palette commands
  - Trust requirement indicators
  - CLI subcommand reference table

- **Workspace trust support**: Added `capabilities.untrustedWorkspaces` to `package.json` declaring limited support with restricted configurations

## Implementation Details

- All handlers use dependency injection for testability; spawn functions are mockable
- Stats parsing extracts `checked`, `fixed`, `failures`, `unfixed` counters from stderr
- `mdsmith fix` exit code 1 (some issues remain) shows the stats summary; exit ≥ 2 is a hard failure
- Rule ID extraction filters for `source: "mdsmith"` and string codes only, deduplicates and sorts
- Virtual document URIs use URL encoding for file paths and rule IDs; `parseKindsUri` uses `URL` parsing to handle both canonical and normalized URI forms
- Error handling surfaces stderr to output channel and shows user-friendly notifications
- Commands resolve binary path and `mdsmith.config` setting at call time to pick up config changes without reload

https://claude.ai/code/session_01ByTS32dSzXCniZ6esdxj4P