### PR TITLE
Add user-defined Markdown conventions support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,7 +29,7 @@ footer: |
 | 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                                                     |
 | 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                                                             |
 | 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                                                 |
-| 113 | 🔲     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                                                |
+| 113 | ✅     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                                                |
 | 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md)                                  |
 | 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                                    |
 | 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                              |

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -25,7 +25,27 @@ root. The `test` job in `.github/workflows/ci.yml`
 uploads the merged coverage profile to Codecov after
 each run.
 
-To reproduce CI's merged coverage locally:
+## Branch and function coverage
+
+Statement coverage does not track which branches of
+an `if` or `switch` were taken.
+[gobco](https://github.com/rillig/gobco) provides
+condition-level branch coverage:
+
+```bash
+go tool gobco ./...
+```
+
+Flags:
+
+- `-branch` — report branch coverage instead of
+  condition coverage.
+- `-list-all` — include fully-covered conditions in
+  the output (default: only partially-covered).
+- `-stats file.json` — persist results across runs to
+  track progress over time.
+
+## Reproducing CI statement coverage locally
 
 ```bash
 mkdir -p e2e-cover

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -211,8 +211,7 @@ User-defined conventions are validated at config load:
 Validation errors name the convention and the rule:
 
 ```text
-convention "our-team" rule "no-inline-html":
-    unknown setting "allowed"
+convention "our-team" rule "no-inline-html": no-inline-html: unknown setting "allowed"
 ```
 
 ### Reserved names
@@ -231,8 +230,7 @@ is impossible. When neither table matches, the error
 lists both sets:
 
 ```text
-unknown convention "bogus" (valid: github, our-team,
-    plain, portable)
+unknown convention "bogus" (valid: github, our-team, plain, portable)
 ```
 
 ### Interaction with top-level rules

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -172,6 +172,86 @@ This split keeps MDS034 focused on "what does this
 renderer interpret as a feature." Conventions
 orchestrate style separately.
 
+## User-defined conventions
+
+The three built-in conventions cover common cases.
+Teams that need something custom define it inline in
+`.mdsmith.yml`. The top-level `conventions:` key holds
+the map:
+
+```yaml
+conventions:
+  our-team:
+    flavor: gfm
+    rules:
+      no-inline-html:
+        allow: [details, summary, kbd]
+      list-marker-style:
+        style: dash
+      no-reference-style:
+        allow-footnotes: true
+
+convention: our-team
+```
+
+Each entry is a `{ flavor, rules }` pair. The `rules`
+block uses the same schema as the top-level `rules:`
+block.
+
+### Validation
+
+User-defined conventions are validated at config load:
+
+- `flavor` must be a recognised flavor string such as
+  `commonmark`, `gfm`, or `goldmark`.
+- Each key under `rules:` must name a registered rule.
+- Each rule's settings must pass the rule's own schema
+  check.
+
+Validation errors name the convention and the rule:
+
+```text
+convention "our-team" rule "no-inline-html":
+    unknown setting "allowed"
+```
+
+### Reserved names
+
+The built-in names `portable`, `github`, and `plain`
+are reserved. Defining a `conventions.portable` entry
+is a config error. This keeps the built-in names
+stable across docs and tutorials.
+
+### Resolution order
+
+The lookup checks user-defined conventions first,
+then falls back to the built-in table. Collisions with
+reserved names are rejected at load time, so shadowing
+is impossible. When neither table matches, the error
+lists both sets:
+
+```text
+unknown convention "bogus" (valid: github, our-team,
+    plain, portable)
+```
+
+### Interaction with top-level rules
+
+User-defined conventions apply as a base layer, exactly
+like the built-in conventions. A top-level `rules:`
+entry overrides the convention preset for that rule.
+The rest of the preset remains.
+
+### Inspecting user conventions
+
+`mdsmith kinds resolve <file>` labels user convention
+layers with a `(user)` suffix. Built-in conventions
+carry no suffix. Example merge-chain output:
+
+```text
+convention.our-team (user)   set    {flavor: gfm}
+```
+
 ## Inspecting an effective convention
 
 `mdsmith kinds resolve <file>` shows the merge

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 tool (
 	github.com/charmbracelet/vhs
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/rillig/gobco
 )
 
 require (
@@ -205,6 +206,7 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/raeperd/recvcheck v0.2.0 // indirect
+	github.com/rillig/gobco v1.3.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4l
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
 github.com/raeperd/recvcheck v0.2.0 h1:GnU+NsbiCqdC2XX5+vMZzP+jAJC5fht7rcVTAhX74UI=
 github.com/raeperd/recvcheck v0.2.0/go.mod h1:n04eYkwIR0JbgD73wT8wL4JjPC3wm0nFtzBnWNocnYU=
+github.com/rillig/gobco v1.3.4 h1:4weHt9u2CyTOnEJ/7z6fAcHZvJHy1pNXm8danDh3TA8=
+github.com/rillig/gobco v1.3.4/go.mod h1:VvLaz1Pm73AQQ2JVBFWQz6BdZVSQg0YffxW3yXwEArM=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,18 @@ var ValidCategories = []string{
 // discovery when no file arguments are given on the command line.
 var DefaultFiles = []string{"**/*.md", "**/*.markdown"}
 
+// UserConvention is a user-defined convention bundle declared in the
+// top-level `conventions:` block in .mdsmith.yml. It has the same
+// { flavor, rules } shape as the built-in convention table.
+type UserConvention struct {
+	// Flavor is the Markdown flavor MDS034 should validate against
+	// (e.g. "commonmark", "gfm", "goldmark").
+	Flavor string `yaml:"flavor"`
+	// Rules maps rule names to their presets, using the same schema
+	// as the top-level `rules:` block.
+	Rules map[string]RuleCfg `yaml:"rules,omitempty"`
+}
+
 // Config is the top-level configuration.
 type Config struct {
 	Rules          map[string]RuleCfg    `yaml:"rules"`
@@ -38,12 +50,18 @@ type Config struct {
 	Build          BuildConfig           `yaml:"build,omitempty"`
 
 	// Convention names a Markdown convention bundle. Built-in
-	// values: "portable", "github", "plain". Empty means no
-	// convention; the user's top-level rules and the built-in
-	// defaults are the only base layers. See
-	// internal/rules/markdownflavor/conventions.go for the table
-	// and docs/reference/conventions.md for end-user docs.
+	// values: "portable", "github", "plain". User-defined
+	// conventions may also be referenced here after being declared
+	// under the top-level `conventions:` key. Empty means no
+	// convention. See internal/rules/markdownflavor/conventions.go
+	// and docs/reference/conventions.md.
 	Convention string `yaml:"convention,omitempty"`
+
+	// Conventions holds user-defined convention bundles declared
+	// under the top-level `conventions:` key. Each entry is a
+	// { flavor, rules } pair. Names must not collide with the
+	// built-in conventions ("portable", "github", "plain").
+	Conventions map[string]UserConvention `yaml:"conventions,omitempty"`
 
 	// LegacyNoFollowSymlinks captures the removed `no-follow-symlinks`
 	// key. Its presence surfaces a deprecation warning via

--- a/internal/config/convention.go
+++ b/internal/config/convention.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/markdownflavor"
 )
 
@@ -27,10 +28,21 @@ import (
 //     rejected at config load so the error surfaces once, not on
 //     every check.
 func applyConvention(cfg *Config) error {
-	if cfg == nil || cfg.Convention == "" {
+	if cfg == nil {
 		return nil
 	}
-	convention, err := markdownflavor.Lookup(cfg.Convention)
+
+	// Validate and convert all user-defined conventions upfront, even
+	// when no convention is selected — this catches typos at load time.
+	userMap, err := buildUserConventionMap(cfg)
+	if err != nil {
+		return err
+	}
+
+	if cfg.Convention == "" {
+		return nil
+	}
+	convention, err := markdownflavor.Lookup(cfg.Convention, userMap)
 	if err != nil {
 		return fmt.Errorf("convention: %w", err)
 	}
@@ -88,6 +100,100 @@ func copyConventionPreset(p map[string]RuleCfg) map[string]RuleCfg {
 		out[k] = copyRuleCfg(v)
 	}
 	return out
+}
+
+// buildUserConventionMap validates every entry in cfg.Conventions and
+// returns them as a map[string]markdownflavor.Convention ready for
+// Lookup. Validation checks:
+//   - The name must not be a reserved built-in name.
+//   - The flavor must be a recognised flavor string.
+//   - Each rule name must be registered.
+//   - Each rule's settings must pass the rule's own ApplySettings
+//     check (called on a cloned instance so the registry is unaffected).
+//
+// Returns nil when cfg.Conventions is empty.
+func buildUserConventionMap(cfg *Config) (map[string]markdownflavor.Convention, error) {
+	if len(cfg.Conventions) == 0 {
+		return nil, nil
+	}
+
+	reserved := make(map[string]bool, len(markdownflavor.ConventionNames()))
+	for _, name := range markdownflavor.ConventionNames() {
+		reserved[name] = true
+	}
+
+	result := make(map[string]markdownflavor.Convention, len(cfg.Conventions))
+	for name, uc := range cfg.Conventions {
+		if reserved[name] {
+			return nil, fmt.Errorf(
+				"conventions.%s: name is reserved by a built-in convention",
+				name,
+			)
+		}
+
+		fl, ok := markdownflavor.ParseFlavor(uc.Flavor)
+		if !ok {
+			return nil, fmt.Errorf(
+				"convention %q: unknown flavor %q",
+				name, uc.Flavor,
+			)
+		}
+
+		rules := make(map[string]markdownflavor.RulePreset, len(uc.Rules))
+		for ruleName, rc := range uc.Rules {
+			r := rule.ByName(ruleName)
+			if r == nil {
+				return nil, fmt.Errorf(
+					"convention %q: unknown rule %q",
+					name, ruleName,
+				)
+			}
+			if len(rc.Settings) > 0 {
+				if err := validateConventionRuleSettings(r, name, ruleName, rc.Settings); err != nil {
+					return nil, err
+				}
+			}
+			rules[ruleName] = markdownflavor.RulePreset{
+				Enabled:  rc.Enabled,
+				Settings: cloneSettings(rc.Settings),
+			}
+		}
+
+		result[name] = markdownflavor.Convention{
+			Name:   name,
+			Flavor: fl,
+			Rules:  rules,
+		}
+	}
+	return result, nil
+}
+
+// validateConventionRuleSettings clones the rule and calls
+// ApplySettings to check that settings is well-formed. Using a clone
+// avoids mutating the shared singleton in the rule registry.
+func validateConventionRuleSettings(
+	r rule.Rule,
+	conventionName, ruleName string,
+	settings map[string]any,
+) error {
+	if _, ok := r.(rule.Configurable); !ok {
+		return fmt.Errorf(
+			"convention %q rule %q: rule has no configurable settings",
+			conventionName, ruleName,
+		)
+	}
+	clone := rule.CloneRule(r)
+	cc, ok := clone.(rule.Configurable)
+	if !ok {
+		return fmt.Errorf(
+			"convention %q rule %q: cloned rule is not configurable",
+			conventionName, ruleName,
+		)
+	}
+	if err := cc.ApplySettings(settings); err != nil {
+		return fmt.Errorf("convention %q rule %q: %w", conventionName, ruleName, err)
+	}
+	return nil
 }
 
 // validateConventionScalar returns an error when the top-level

--- a/internal/config/convention.go
+++ b/internal/config/convention.go
@@ -182,14 +182,7 @@ func validateConventionRuleSettings(
 			conventionName, ruleName,
 		)
 	}
-	clone := rule.CloneRule(r)
-	cc, ok := clone.(rule.Configurable)
-	if !ok {
-		return fmt.Errorf(
-			"convention %q rule %q: cloned rule is not configurable",
-			conventionName, ruleName,
-		)
-	}
+	cc := rule.CloneRule(r).(rule.Configurable)
 	if err := cc.ApplySettings(settings); err != nil {
 		return fmt.Errorf("convention %q rule %q: %w", conventionName, ruleName, err)
 	}

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	// Register markdown-flavor so rule.ByName lookups in deep-merge
-	// resolve while the convention mechanism is exercised.
+	// Register rules so rule.ByName lookups resolve while the
+	// convention mechanism is exercised.
 	_ "github.com/jeduden/mdsmith/internal/rules/emphasisstyle"
 	_ "github.com/jeduden/mdsmith/internal/rules/markdownflavor"
+	_ "github.com/jeduden/mdsmith/internal/rules/nohardtabs"
 )
 
 func TestApplyConvention_NoConventionSet_NoOp(t *testing.T) {
@@ -576,6 +577,29 @@ func TestLoad_UserConvention_ReservedName(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "portable")
 	assert.Contains(t, err.Error(), "reserved")
+}
+
+func TestApplyConvention_UserConvention_NonConfigurableRuleWithSettings(t *testing.T) {
+	// no-hard-tabs has no ApplySettings; passing settings for it must
+	// return a "rule has no configurable settings" error.
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"no-hard-tabs": {
+						Enabled:  true,
+						Settings: map[string]any{"some-setting": "val"},
+					},
+				},
+			},
+		},
+	}
+	err := applyConvention(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "our-team")
+	assert.Contains(t, err.Error(), "no-hard-tabs")
+	assert.Contains(t, err.Error(), "no configurable settings")
 }
 
 func TestMerge_PreservesUserConventions(t *testing.T) {

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -352,6 +352,255 @@ func TestConvention_EnablesOptInRuleEndToEnd(t *testing.T) {
 		"convention preset must populate flavor on MDS034")
 }
 
+// ---- User-defined convention tests ----
+
+func TestApplyConvention_UserConvention_Valid(t *testing.T) {
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"markdown-flavor": {
+						Enabled:  true,
+						Settings: map[string]any{"flavor": "gfm"},
+					},
+				},
+			},
+		},
+		Convention: "our-team",
+	}
+	require.NoError(t, applyConvention(cfg))
+	require.NotNil(t, cfg.ConventionPreset)
+	mf, ok := cfg.ConventionPreset["markdown-flavor"]
+	require.True(t, ok, "preset must contain markdown-flavor")
+	assert.True(t, mf.Enabled)
+	assert.Equal(t, "gfm", mf.Settings["flavor"])
+}
+
+func TestApplyConvention_UserConvention_ReservedName(t *testing.T) {
+	for _, reserved := range []string{"portable", "github", "plain"} {
+		t.Run(reserved, func(t *testing.T) {
+			cfg := &Config{
+				Conventions: map[string]UserConvention{
+					reserved: {Flavor: "gfm"},
+				},
+			}
+			err := applyConvention(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), reserved)
+			assert.Contains(t, err.Error(), "reserved")
+		})
+	}
+}
+
+func TestApplyConvention_UserConvention_InvalidFlavor(t *testing.T) {
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {Flavor: "notaflavor"},
+		},
+	}
+	err := applyConvention(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "our-team")
+	assert.Contains(t, err.Error(), "notaflavor")
+}
+
+func TestApplyConvention_UserConvention_UnknownRule(t *testing.T) {
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"no-such-rule": {Enabled: true},
+				},
+			},
+		},
+	}
+	err := applyConvention(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "our-team")
+	assert.Contains(t, err.Error(), "no-such-rule")
+}
+
+func TestApplyConvention_UserConvention_InvalidSetting(t *testing.T) {
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"markdown-flavor": {
+						Enabled:  true,
+						Settings: map[string]any{"no-such-setting": "val"},
+					},
+				},
+			},
+		},
+	}
+	err := applyConvention(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "our-team")
+	assert.Contains(t, err.Error(), "markdown-flavor")
+	assert.Contains(t, err.Error(), "no-such-setting")
+}
+
+func TestApplyConvention_UserConvention_TopLevelRulesOverride(t *testing.T) {
+	// User convention enables markdown-flavor with gfm; user's top-level
+	// rules override it with commonmark. The user rule wins.
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"markdown-flavor": {
+						Enabled:  true,
+						Settings: map[string]any{"flavor": "gfm"},
+					},
+				},
+			},
+		},
+		Convention: "our-team",
+		Rules: map[string]RuleCfg{
+			"markdown-flavor": {
+				Enabled:  true,
+				Settings: map[string]any{"flavor": "gfm"}, // must match convention flavor
+			},
+		},
+		ExplicitRules: map[string]bool{"markdown-flavor": true},
+	}
+	require.NoError(t, applyConvention(cfg))
+
+	got := Effective(cfg, "doc.md", nil)
+	mf, ok := got["markdown-flavor"]
+	require.True(t, ok)
+	assert.True(t, mf.Enabled)
+	// User rule is explicit, so it wins over the convention preset.
+	assert.Equal(t, "gfm", mf.Settings["flavor"])
+}
+
+func TestApplyConvention_UserConvention_ErrorListsBothSets(t *testing.T) {
+	// When convention: references an unknown name, the error must list
+	// both built-in and user-defined convention names.
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {Flavor: "gfm"},
+		},
+		Convention: "bogus",
+	}
+	err := applyConvention(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bogus")
+	assert.Contains(t, err.Error(), "our-team",
+		"error must include user-defined convention names")
+	assert.Contains(t, err.Error(), "portable",
+		"error must include built-in convention names")
+}
+
+func TestApplyConvention_UserConvention_NotSelectedStillValidated(t *testing.T) {
+	// A user convention declared but not selected must still be validated.
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"bad-convention": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"no-such-rule": {Enabled: true},
+				},
+			},
+		},
+		// Convention is NOT set — we don't select bad-convention.
+	}
+	err := applyConvention(cfg)
+	require.Error(t, err, "unselected convention with bad rule must still fail")
+	assert.Contains(t, err.Error(), "no-such-rule")
+}
+
+func TestProvenance_UserConventionLayerHasUserSuffix(t *testing.T) {
+	cfg := &Config{
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"markdown-flavor": {
+						Enabled:  true,
+						Settings: map[string]any{"flavor": "gfm"},
+					},
+				},
+			},
+		},
+		Convention: "our-team",
+	}
+	require.NoError(t, applyConvention(cfg))
+
+	res := ResolveFile(cfg, "doc.md", nil)
+	rr, ok := res.Rules["markdown-flavor"]
+	require.True(t, ok)
+
+	var sources []string
+	for _, l := range rr.Layers {
+		sources = append(sources, l.Source)
+	}
+	require.Contains(t, sources, "convention.our-team (user)",
+		"user convention layer must carry the (user) suffix")
+}
+
+func TestLoad_UserConvention_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mdsmith.yml")
+	yaml := `conventions:
+  our-team:
+    flavor: gfm
+    rules:
+      markdown-flavor:
+        flavor: gfm
+convention: our-team
+`
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "our-team", cfg.Convention)
+	assert.NotNil(t, cfg.ConventionPreset)
+	mf, ok := cfg.ConventionPreset["markdown-flavor"]
+	require.True(t, ok)
+	assert.Equal(t, "gfm", mf.Settings["flavor"])
+}
+
+func TestLoad_UserConvention_ReservedName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mdsmith.yml")
+	yaml := "conventions:\n  portable:\n    flavor: gfm\n"
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "portable")
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+func TestMerge_PreservesUserConventions(t *testing.T) {
+	loaded := &Config{
+		Convention: "our-team",
+		Conventions: map[string]UserConvention{
+			"our-team": {
+				Flavor: "gfm",
+				Rules: map[string]RuleCfg{
+					"markdown-flavor": {Enabled: true, Settings: map[string]any{"flavor": "gfm"}},
+				},
+			},
+		},
+		ConventionPreset: map[string]RuleCfg{
+			"markdown-flavor": {Enabled: true, Settings: map[string]any{"flavor": "gfm"}},
+		},
+	}
+	merged := Merge(&Config{Rules: map[string]RuleCfg{}}, loaded)
+	assert.Equal(t, "our-team", merged.Convention)
+	require.Contains(t, merged.Conventions, "our-team")
+	assert.Equal(t, "gfm", merged.Conventions["our-team"].Flavor)
+
+	// Mutating the merged map must not bleed into the source.
+	merged.Conventions["our-team"] = UserConvention{Flavor: "tampered"}
+	assert.Equal(t, "gfm", loaded.Conventions["our-team"].Flavor)
+}
+
 func TestMerge_PreservesConvention(t *testing.T) {
 	loaded := &Config{
 		Convention: "portable",

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -11,6 +11,7 @@ import (
 
 	// Register markdown-flavor so rule.ByName lookups in deep-merge
 	// resolve while the convention mechanism is exercised.
+	_ "github.com/jeduden/mdsmith/internal/rules/emphasisstyle"
 	_ "github.com/jeduden/mdsmith/internal/rules/markdownflavor"
 )
 
@@ -444,37 +445,38 @@ func TestApplyConvention_UserConvention_InvalidSetting(t *testing.T) {
 }
 
 func TestApplyConvention_UserConvention_TopLevelRulesOverride(t *testing.T) {
-	// User convention enables markdown-flavor with gfm; user's top-level
-	// rules override it with commonmark. The user rule wins.
+	// Convention presets emphasis-style with bold=asterisk; user's top-level
+	// rules override bold to underscore. The user layer wins.
 	cfg := &Config{
 		Conventions: map[string]UserConvention{
 			"our-team": {
 				Flavor: "gfm",
 				Rules: map[string]RuleCfg{
-					"markdown-flavor": {
+					"emphasis-style": {
 						Enabled:  true,
-						Settings: map[string]any{"flavor": "gfm"},
+						Settings: map[string]any{"bold": "asterisk"},
 					},
 				},
 			},
 		},
 		Convention: "our-team",
 		Rules: map[string]RuleCfg{
-			"markdown-flavor": {
+			"emphasis-style": {
 				Enabled:  true,
-				Settings: map[string]any{"flavor": "gfm"}, // must match convention flavor
+				Settings: map[string]any{"bold": "underscore"},
 			},
 		},
-		ExplicitRules: map[string]bool{"markdown-flavor": true},
+		ExplicitRules: map[string]bool{"emphasis-style": true},
 	}
 	require.NoError(t, applyConvention(cfg))
 
 	got := Effective(cfg, "doc.md", nil)
-	mf, ok := got["markdown-flavor"]
+	es, ok := got["emphasis-style"]
 	require.True(t, ok)
-	assert.True(t, mf.Enabled)
-	// User rule is explicit, so it wins over the convention preset.
-	assert.Equal(t, "gfm", mf.Settings["flavor"])
+	assert.True(t, es.Enabled)
+	// User's explicit setting overrides the convention preset.
+	assert.Equal(t, "underscore", es.Settings["bold"],
+		"top-level rules must win over user convention preset")
 }
 
 func TestApplyConvention_UserConvention_ErrorListsBothSets(t *testing.T) {

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -47,6 +47,7 @@ func Merge(defaults, loaded *Config) *Config {
 		KindAssignment:         copyKindAssignment(loaded.KindAssignment),
 		Build:                  copyBuildConfig(loaded.Build),
 		Convention:             loaded.Convention,
+		Conventions:            copyUserConventions(loaded.Conventions),
 		ConventionPreset:       copyConventionPreset(loaded.ConventionPreset),
 	}
 }
@@ -99,8 +100,26 @@ func copyConfig(cfg *Config) *Config {
 		KindAssignment:         copyKindAssignment(cfg.KindAssignment),
 		Build:                  copyBuildConfig(cfg.Build),
 		Convention:             cfg.Convention,
+		Conventions:            copyUserConventions(cfg.Conventions),
 		ConventionPreset:       copyConventionPreset(cfg.ConventionPreset),
 	}
+}
+
+// copyUserConventions returns a deep copy of a user-defined
+// conventions map. Returns nil when the input is nil.
+func copyUserConventions(m map[string]UserConvention) map[string]UserConvention {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]UserConvention, len(m))
+	for k, v := range m {
+		rules := make(map[string]RuleCfg, len(v.Rules))
+		for rk, rv := range v.Rules {
+			rules[rk] = copyRuleCfg(rv)
+		}
+		out[k] = UserConvention{Flavor: v.Flavor, Rules: rules}
+	}
+	return out
 }
 
 // copyBuildConfig returns a deep copy of a BuildConfig, duplicating the

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -152,8 +152,12 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 		layers = append(layers, layerInfo{Source: layerSourceDefault, Rules: defaults})
 	}
 	if cfg.Convention != "" && len(cfg.ConventionPreset) > 0 {
+		source := "convention." + cfg.Convention
+		if _, isUser := cfg.Conventions[cfg.Convention]; isUser {
+			source += " (user)"
+		}
 		layers = append(layers, layerInfo{
-			Source: "convention." + cfg.Convention,
+			Source: source,
 			Rules:  cfg.ConventionPreset,
 		})
 	}

--- a/internal/rules/markdownflavor/conventions.go
+++ b/internal/rules/markdownflavor/conventions.go
@@ -163,22 +163,37 @@ var conventions = map[string]Convention{
 	},
 }
 
-// Lookup returns the convention table entry for name. It returns an
-// error naming the field and listing valid names when name is not a
-// known convention, matching the failure-mode contract in plan 112.
+// Lookup returns the convention with the given name. It first checks
+// userConventions (user-defined entries from .mdsmith.yml), then the
+// built-in table. Returns a deep copy so callers can mutate the
+// result without corrupting the shared tables. Error lists both sets
+// of valid names when neither matches.
 //
-// The returned Convention is a deep copy of the package-level table
-// entry. Callers may mutate the result without corrupting the
-// shared built-in table.
-func Lookup(name string) (Convention, error) {
+// userConventions may be nil; a nil map is treated as empty.
+func Lookup(name string, userConventions map[string]Convention) (Convention, error) {
+	if c, ok := userConventions[name]; ok {
+		return cloneConvention(c), nil
+	}
 	c, ok := conventions[name]
 	if !ok {
+		names := conventionNamesWithUser(userConventions)
 		return Convention{}, fmt.Errorf(
 			"unknown convention %q (valid: %s)",
-			name, strings.Join(ConventionNames(), ", "),
+			name, strings.Join(names, ", "),
 		)
 	}
 	return cloneConvention(c), nil
+}
+
+// conventionNamesWithUser returns a sorted list of all available
+// convention names — built-in names plus user-defined names.
+func conventionNamesWithUser(userConventions map[string]Convention) []string {
+	names := ConventionNames()
+	for name := range userConventions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // cloneConvention returns a deep copy of c. Each rule preset's

--- a/internal/rules/markdownflavor/conventions_test.go
+++ b/internal/rules/markdownflavor/conventions_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLookup_Portable(t *testing.T) {
-	c, err := Lookup("portable")
+	c, err := Lookup("portable", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "portable", c.Name)
 	assert.Equal(t, FlavorCommonMark, c.Flavor)
@@ -27,7 +27,7 @@ func TestLookup_Portable(t *testing.T) {
 }
 
 func TestLookup_Github(t *testing.T) {
-	c, err := Lookup("github")
+	c, err := Lookup("github", nil)
 	require.NoError(t, err)
 	assert.Equal(t, FlavorGFM, c.Flavor)
 
@@ -42,7 +42,7 @@ func TestLookup_Github(t *testing.T) {
 }
 
 func TestLookup_Plain(t *testing.T) {
-	c, err := Lookup("plain")
+	c, err := Lookup("plain", nil)
 	require.NoError(t, err)
 	assert.Equal(t, FlavorCommonMark, c.Flavor)
 
@@ -53,7 +53,7 @@ func TestLookup_Plain(t *testing.T) {
 }
 
 func TestLookup_Unknown(t *testing.T) {
-	_, err := Lookup("bogus")
+	_, err := Lookup("bogus", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown convention")
 	assert.Contains(t, err.Error(), "bogus")
@@ -120,7 +120,7 @@ func TestLookup_ReturnsDeepCopy(t *testing.T) {
 	// Mutating the returned Convention must not corrupt the
 	// package-level table. Lookup is exported, so callers could
 	// otherwise rewrite the built-ins by accident.
-	first, err := Lookup("portable")
+	first, err := Lookup("portable", nil)
 	require.NoError(t, err)
 	first.Rules["markdown-flavor"].Settings["flavor"] = "tampered"
 	first.Rules["new-rule"] = RulePreset{Enabled: true}
@@ -129,7 +129,7 @@ func TestLookup_ReturnsDeepCopy(t *testing.T) {
 		allow.Settings["allow"] = []any{"tampered"}
 	}
 
-	second, err := Lookup("portable")
+	second, err := Lookup("portable", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "commonmark",
 		second.Rules["markdown-flavor"].Settings["flavor"],
@@ -137,6 +137,44 @@ func TestLookup_ReturnsDeepCopy(t *testing.T) {
 	_, hasNewRule := second.Rules["new-rule"]
 	assert.False(t, hasNewRule,
 		"new entries on the first copy must not leak into the table")
+}
+
+func TestLookup_UserConvention(t *testing.T) {
+	userMap := map[string]Convention{
+		"our-team": {
+			Name:   "our-team",
+			Flavor: FlavorGFM,
+			Rules: map[string]RulePreset{
+				"list-marker-style": {Enabled: true, Settings: map[string]any{"style": "dash"}},
+			},
+		},
+	}
+	c, err := Lookup("our-team", userMap)
+	require.NoError(t, err)
+	assert.Equal(t, "our-team", c.Name)
+	assert.Equal(t, FlavorGFM, c.Flavor)
+	lm, ok := c.Rules["list-marker-style"]
+	require.True(t, ok)
+	assert.Equal(t, "dash", lm.Settings["style"])
+}
+
+func TestLookup_UserConventionFallsBackToBuiltin(t *testing.T) {
+	userMap := map[string]Convention{
+		"our-team": {Name: "our-team", Flavor: FlavorGFM},
+	}
+	c, err := Lookup("portable", userMap)
+	require.NoError(t, err)
+	assert.Equal(t, "portable", c.Name)
+}
+
+func TestLookup_UnknownListsUserAndBuiltin(t *testing.T) {
+	userMap := map[string]Convention{
+		"our-team": {Name: "our-team", Flavor: FlavorGFM},
+	}
+	_, err := Lookup("bogus", userMap)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "our-team", "error must list user convention name")
+	assert.Contains(t, err.Error(), "portable", "error must list built-in name")
 }
 
 func TestConventionNamesSorted(t *testing.T) {

--- a/plan/113_user-defined-profiles.md
+++ b/plan/113_user-defined-profiles.md
@@ -1,7 +1,7 @@
 ---
 id: 113
 title: User-defined Markdown conventions
-status: "🔲"
+status: "✅"
 summary: >-
   Extend the convention system from plan 112 with a
   top-level `conventions:` block in `.mdsmith.yml`.
@@ -171,24 +171,24 @@ unchanged.
 
 ## Acceptance Criteria
 
-- [ ] `conventions:` block in `.mdsmith.yml`
+- [x] `conventions:` block in `.mdsmith.yml`
       defines a named convention with `flavor:` and
       `rules:`.
-- [ ] Top-level `convention: our-team` selects a
+- [x] Top-level `convention: our-team` selects a
       user-defined convention and applies its rule
       presets.
-- [ ] Defining `conventions.portable` (or `github` /
+- [x] Defining `conventions.portable` (or `github` /
       `plain`) produces a config error naming the
       reserved name.
-- [ ] An unknown convention name lists both
+- [x] An unknown convention name lists both
       built-in and user-defined options in the error
       message.
-- [ ] Top-level `rules:` overrides win over user
+- [x] Top-level `rules:` overrides win over user
       convention presets via deep-merge.
-- [ ] Invalid rule names or settings inside a user
+- [x] Invalid rule names or settings inside a user
       convention produce a config error naming the
       convention and the rule.
-- [ ] `mdsmith kinds resolve` distinguishes user
+- [x] `mdsmith kinds resolve` distinguishes user
       conventions from built-ins in its output.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
Implement user-defined conventions feature, allowing teams to declare custom Markdown convention bundles in `.mdsmith.yml` via a top-level `conventions:` block.

## Summary
This change extends the convention system to support user-defined conventions alongside the three built-in conventions (portable, github, plain). Users can now declare custom convention bundles with a flavor and rule presets, then select them via `convention: our-team`.

## Key Changes

- **Config structure**: Added `UserConvention` type and `Conventions` map field to `Config` struct to hold user-defined convention declarations
- **Validation**: Implemented `buildUserConventionMap()` to validate all user conventions at config load time:
  - Prevents reserved names (portable, github, plain) from being shadowed
  - Validates flavor strings against known flavors
  - Validates rule names exist in the registry
  - Validates rule settings pass each rule's schema check
- **Lookup enhancement**: Modified `markdownflavor.Lookup()` to accept a user conventions map and check it before falling back to built-in conventions
- **Error messages**: Updated error reporting to list both user-defined and built-in convention names when an unknown convention is referenced
- **Provenance tracking**: Added `(user)` suffix to convention layer sources in `ResolveFile()` output to distinguish user conventions from built-ins
- **Config merging**: Updated `Merge()` and `copyConfig()` to preserve user conventions with deep copying to prevent mutation leaks
- **Comprehensive tests**: Added 13 new test cases covering valid conventions, reserved names, invalid flavors, unknown rules, invalid settings, override behavior, and YAML loading

## Implementation Details

- User conventions are validated even when not selected, catching configuration errors at load time
- Top-level `rules:` entries override convention presets via the existing merge mechanism
- User convention validation uses cloned rule instances to avoid mutating the shared rule registry
- Deep copying is applied throughout to prevent accidental mutation of shared data structures

https://claude.ai/code/session_01TmosNE7azCMEn3zwmkFYpR