### PR TITLE
Reorganize installation and editor integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ pip install mdsmith            # or: uvx mdsmith / pipx install mdsmith
 Editor extension (LSP-backed; runs `mdsmith lsp`):
 
 ```bash
-code --install-extension jeduden.mdsmith     # VS Code, Codespaces, GitHub.dev
+code --install-extension jeduden.mdsmith     # VS Code, Codespaces (Marketplace)
 codium --install-extension jeduden.mdsmith   # Cursor, VSCodium, Theia, Gitpod (Open VSX)
 ```
 
-Any LSP-aware editor (Neovim, Helix, JetBrains) works by
-pointing at `mdsmith lsp`.
+Any LSP-aware editor (Neovim, Helix, JetBrains via the LSP
+plugin) works by pointing at `mdsmith lsp`.
 
 More: [all install channels](docs/guides/install.md) covers
-direct downloads, asdf, and mise.
+direct downloads and mise (asdf pending).
 [VS Code integration](docs/guides/editors/vscode.md) covers
 settings, code actions, and troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ row: "- [{summary}]({filename})"
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 <?/catalog?>
 
-## 📦 Installation
+## 📦 Install
+
+CLI:
 
 ```bash
 go install github.com/jeduden/mdsmith/cmd/mdsmith@latest
@@ -95,34 +97,20 @@ npm install -g @mdsmith/cli    # or: npx @mdsmith/cli
 pip install mdsmith            # or: uvx mdsmith / pipx install mdsmith
 ```
 
-More options live in
-[docs/guides/install.md](docs/guides/install.md). It covers direct
-downloads, the VS Code extension on the Marketplace and Open VSX,
-and asdf and mise once their registry entries land.
-
-## ✏️ Editor integration
-
-The mdsmith VS Code extension renders diagnostics inline.
-Each fixable rule contributes a quick fix. A
-`source.fixAll.mdsmith` action runs `mdsmith fix` on the
-buffer.
+Editor extension (LSP-backed; runs `mdsmith lsp`):
 
 ```bash
-# stock VS Code, GitHub Codespaces, GitHub.dev (Marketplace)
-code --install-extension jeduden.mdsmith
-# Cursor, VSCodium, Theia, Gitpod (Open VSX)
-codium --install-extension jeduden.mdsmith
+code --install-extension jeduden.mdsmith     # VS Code, Codespaces, GitHub.dev
+codium --install-extension jeduden.mdsmith   # Cursor, VSCodium, Theia, Gitpod (Open VSX)
 ```
 
-The extension is a thin LSP client. The lint pipeline runs
-in the Go binary, so any LSP-aware editor (Neovim, Helix,
-JetBrains via the LSP plugin) gets the same diagnostics by
+Any LSP-aware editor (Neovim, Helix, JetBrains) works by
 pointing at `mdsmith lsp`.
 
-See [VS Code Integration](docs/guides/editors/vscode.md)
-for settings (`mdsmith.path`, `mdsmith.run`,
-`mdsmith.fixOnSave`, `mdsmith.trace.server`), code actions,
-and troubleshooting.
+More: [all install channels](docs/guides/install.md) covers
+direct downloads, asdf, and mise.
+[VS Code integration](docs/guides/editors/vscode.md) covers
+settings, code actions, and troubleshooting.
 
 ## 🚀 Usage
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ codium --install-extension jeduden.mdsmith   # Cursor, VSCodium, Theia, Gitpod (
 Any LSP-aware editor (Neovim, Helix, JetBrains via the LSP
 plugin) works by pointing at `mdsmith lsp`.
 
+Claude Code plugin (inline diagnostics plus definition,
+references, symbol search, and call-hierarchy queries
+across your docs):
+
+```text
+/plugin marketplace add jeduden/mdsmith
+/plugin install mdsmith-lsp@mdsmith
+/reload-plugins
+```
+
 More: the [install guide](docs/guides/install.md) covers
 direct downloads and mise (asdf pending).
 [VS Code integration](docs/guides/editors/vscode.md) covers

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ row: "- [{summary}]({filename})"
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 <?/catalog?>
 
-## 📦 Install
+## 📦 Installation
 
 CLI:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ codium --install-extension jeduden.mdsmith   # Cursor, VSCodium, Theia, Gitpod (
 Any LSP-aware editor (Neovim, Helix, JetBrains via the LSP
 plugin) works by pointing at `mdsmith lsp`.
 
-More: [all install channels](docs/guides/install.md) covers
+More: the [install guide](docs/guides/install.md) covers
 direct downloads and mise (asdf pending).
 [VS Code integration](docs/guides/editors/vscode.md) covers
 settings, code actions, and troubleshooting.


### PR DESCRIPTION
## Summary
Restructured the Installation and Editor Integration sections of the README to be more concise and scannable. The two sections are merged into one, with CLI, editor extension, and Claude Code plugin install commands presented compactly alongside links to the deeper guides.

## Key Changes
- Merged the former "Editor integration" section into "Installation" so all install paths live in one place
- Reorganized content into clear subsections: CLI, editor extension, and Claude Code plugin
- Consolidated VS Code / Open VSX install commands into a single code block with platform notes as inline comments
- Added the Claude Code plugin install commands (`/plugin marketplace add` + `install mdsmith-lsp@mdsmith`)
- Moved verbose explanations to reference links rather than inline text
- Noted JetBrains needs the LSP plugin and that asdf support is still pending

## Notable Details
- The `## 📦 Installation` heading is preserved so existing `#-installation` anchor links keep working
- Installation instructions for Go, npm, and pip remain unchanged
- References to detailed guides in `docs/guides/install.md` and `docs/guides/editors/vscode.md` are preserved but presented more concisely
- The LSP-backed nature of the editor extension is still clearly communicated

https://claude.ai/code/session_01QxgTxHDjpwaJo5GjyuPzx7