### PR TITLE
Add `mdsmith list backlinks` subcommand to query incoming links

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,7 @@ row: "- [{summary}](../{filename})"
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](../docs/guides/metrics-tradeoffs.md)
 - [Declare a document-structure schema inline on a kind or in a proto.md file, validate headings and front matter, and tighten rule config per section.](../docs/guides/schemas.md)
 - [CLI commands, flags, exit codes, and output format.](../docs/reference/cli.md)
+- [List workspace links that point at a file.](../docs/reference/cli/backlinks.md)
 - [Lint Markdown files for style issues.](../docs/reference/cli/check.md)
 - [Auto-fix lint issues in Markdown files in place.](../docs/reference/cli/fix.md)
 - [Show built-in documentation for rules, metrics, and concept pages.](../docs/reference/cli/help.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,7 @@ row: "- [{summary}](../{filename})"
 - [Show built-in documentation for rules, metrics, and concept pages.](../docs/reference/cli/help.md)
 - [Generate a default `.mdsmith.yml` config in the current directory.](../docs/reference/cli/init.md)
 - [Inspect declared file kinds and resolve effective rule config per file.](../docs/reference/cli/kinds.md)
+- [Selection-style commands that walk the workspace and emit matches.](../docs/reference/cli/list.md)
 - [Run a Language Server Protocol server on stdio for editor integrations.](../docs/reference/cli/lsp.md)
 - [Git merge driver that resolves conflicts inside generated sections.](../docs/reference/cli/merge-driver.md)
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](../docs/reference/cli/metrics.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ row: "- [{summary}]({filename})"
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](docs/guides/metrics-tradeoffs.md)
 - [Declare a document-structure schema inline on a kind or in a proto.md file, validate headings and front matter, and tighten rule config per section.](docs/guides/schemas.md)
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)
+- [List workspace links that point at a file.](docs/reference/cli/backlinks.md)
 - [Lint Markdown files for style issues.](docs/reference/cli/check.md)
 - [Auto-fix lint issues in Markdown files in place.](docs/reference/cli/fix.md)
 - [Show built-in documentation for rules, metrics, and concept pages.](docs/reference/cli/help.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ row: "- [{summary}]({filename})"
 - [Show built-in documentation for rules, metrics, and concept pages.](docs/reference/cli/help.md)
 - [Generate a default `.mdsmith.yml` config in the current directory.](docs/reference/cli/init.md)
 - [Inspect declared file kinds and resolve effective rule config per file.](docs/reference/cli/kinds.md)
+- [Selection-style commands that walk the workspace and emit matches.](docs/reference/cli/list.md)
 - [Run a Language Server Protocol server on stdio for editor integrations.](docs/reference/cli/lsp.md)
 - [Git merge driver that resolves conflicts inside generated sections.](docs/reference/cli/merge-driver.md)
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](docs/reference/cli/metrics.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ row: "- [{summary}]({filename})"
 - [Trade-offs and threshold guidance for readability, structure, length, and token budgets.](docs/guides/metrics-tradeoffs.md)
 - [Declare a document-structure schema inline on a kind or in a proto.md file, validate headings and front matter, and tighten rule config per section.](docs/guides/schemas.md)
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)
+- [List workspace links that point at a file.](docs/reference/cli/backlinks.md)
 - [Lint Markdown files for style issues.](docs/reference/cli/check.md)
 - [Auto-fix lint issues in Markdown files in place.](docs/reference/cli/fix.md)
 - [Show built-in documentation for rules, metrics, and concept pages.](docs/reference/cli/help.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ row: "- [{summary}]({filename})"
 - [Show built-in documentation for rules, metrics, and concept pages.](docs/reference/cli/help.md)
 - [Generate a default `.mdsmith.yml` config in the current directory.](docs/reference/cli/init.md)
 - [Inspect declared file kinds and resolve effective rule config per file.](docs/reference/cli/kinds.md)
+- [Selection-style commands that walk the workspace and emit matches.](docs/reference/cli/list.md)
 - [Run a Language Server Protocol server on stdio for editor integrations.](docs/reference/cli/lsp.md)
 - [Git merge driver that resolves conflicts inside generated sections.](docs/reference/cli/merge-driver.md)
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](docs/reference/cli/metrics.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -49,7 +49,7 @@ footer: |
 | 135 | 🔲     | sonnet | [Schema inheritance via `extends`](plan/135_schema-extends.md)                                                            |
 | 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                   |
 | 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
-| 138 | 🔲     | sonnet | [`mdsmith backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                        |
+| 138 | 🔳     | sonnet | [`mdsmith backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                        |
 | 139 | 🔲     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
 | 140 | 🔲     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |

--- a/PLAN.md
+++ b/PLAN.md
@@ -49,7 +49,7 @@ footer: |
 | 135 | 🔲     | sonnet | [Schema inheritance via `extends`](plan/135_schema-extends.md)                                                            |
 | 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                   |
 | 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
-| 138 | ✅     | sonnet | [`mdsmith backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                        |
+| 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                   |
 | 139 | 🔲     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
 | 140 | 🔲     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |

--- a/PLAN.md
+++ b/PLAN.md
@@ -49,7 +49,7 @@ footer: |
 | 135 | 🔲     | sonnet | [Schema inheritance via `extends`](plan/135_schema-extends.md)                                                            |
 | 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                   |
 | 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
-| 138 | 🔳     | sonnet | [`mdsmith backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                        |
+| 138 | ✅     | sonnet | [`mdsmith backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                        |
 | 139 | 🔲     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
 | 140 | 🔲     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 ?>
 | Command                                                      | Description                                                                          |
 |--------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| [`backlinks`](docs/reference/cli/backlinks.md)               | List workspace links that point at a file.                                           |
 | [`check`](docs/reference/cli/check.md)                       | Lint Markdown files for style issues.                                                |
 | [`fix`](docs/reference/cli/fix.md)                           | Auto-fix lint issues in Markdown files in place.                                     |
 | [`help`](docs/reference/cli/help.md)                         | Show built-in documentation for rules, metrics, and concept pages.                   |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ of these blocks, `merge-driver install` registers a Git
 driver that resolves it automatically.
 
 **📊 Gate releases on doc status.**
-`mdsmith query 'status: "✅"' plan/` lists every plan
+`mdsmith list query 'status: "✅"' plan/` lists every plan
 that's done — pipe it to a release script, or fail the
 release if anything is still open.
 `mdsmith metrics rank --by token-estimate --top 10 docs/` is the
@@ -143,17 +143,18 @@ row: "| [`{command}`]({filename}) | {summary} |"
 ?>
 | Command                                                      | Description                                                                          |
 |--------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| [`backlinks`](docs/reference/cli/backlinks.md)               | List workspace links that point at a file.                                           |
 | [`check`](docs/reference/cli/check.md)                       | Lint Markdown files for style issues.                                                |
 | [`fix`](docs/reference/cli/fix.md)                           | Auto-fix lint issues in Markdown files in place.                                     |
 | [`help`](docs/reference/cli/help.md)                         | Show built-in documentation for rules, metrics, and concept pages.                   |
 | [`init`](docs/reference/cli/init.md)                         | Generate a default `.mdsmith.yml` config in the current directory.                   |
 | [`kinds`](docs/reference/cli/kinds.md)                       | Inspect declared file kinds and resolve effective rule config per file.              |
+| [`list`](docs/reference/cli/list.md)                         | Selection-style commands that walk the workspace and emit matches.                   |
+| [`list backlinks`](docs/reference/cli/backlinks.md)          | List workspace links that point at a file.                                           |
+| [`list query`](docs/reference/cli/query.md)                  | Select Markdown files by a CUE expression on front matter.                           |
 | [`lsp`](docs/reference/cli/lsp.md)                           | Run a Language Server Protocol server on stdio for editor integrations.              |
 | [`merge-driver`](docs/reference/cli/merge-driver.md)         | Git merge driver that resolves conflicts inside generated sections.                  |
 | [`metrics`](docs/reference/cli/metrics.md)                   | List and rank shared Markdown metrics (file length, token estimate, readability, …). |
 | [`pre-merge-commit`](docs/reference/cli/pre-merge-commit.md) | Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.      |
-| [`query`](docs/reference/cli/query.md)                       | Select Markdown files by a CUE expression on front matter.                           |
 | [`version`](docs/reference/cli/version.md)                   | Print the mdsmith build version and exit.                                            |
 <?/catalog?>
 

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/jeduden/mdsmith/internal/globpath"
+	"github.com/jeduden/mdsmith/internal/linkgraph"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// backlinkRecord is one incoming link to the queried target.
+type backlinkRecord struct {
+	Source string `json:"source"`
+	Line   int    `json:"line"`
+	Text   string `json:"text"`
+	Target string `json:"target"`
+}
+
+// backlinksOptions bundles the parsed CLI flags for `backlinks`.
+type backlinksOptions struct {
+	configPath      string
+	format          string
+	maxInputSize    string
+	includePatterns []string
+	limit           int
+	walk            walkCLI
+}
+
+// parseBacklinksFlags parses the flags for `mdsmith backlinks` and
+// returns the options plus the remaining positional arguments.
+func parseBacklinksFlags(args []string) (backlinksOptions, []string, error) {
+	fs := flag.NewFlagSet("backlinks", flag.ContinueOnError)
+	var (
+		opts                        backlinksOptions
+		noGitignore, followSymlinks bool
+	)
+	fs.StringVarP(&opts.configPath, "config", "c", "", "Override config file path")
+	fs.StringVarP(&opts.format, "format", "f", "text", "Output format: text, json")
+	fs.StringArrayVar(&opts.includePatterns, "include", nil,
+		"Restrict sources to paths matching glob (repeatable)")
+	fs.IntVar(&opts.limit, "limit", 0, "Cap output at N rows (0 = no cap)")
+	fs.BoolVar(&noGitignore, "no-gitignore", false, "Disable .gitignore filtering when walking directories")
+	fs.BoolVar(&followSymlinks, "follow-symlinks", false,
+		"Follow symlinks; omitted defers to follow-symlinks config (default skip); "+
+			"=false forces skip over any config opt-in")
+	fs.StringVar(&opts.maxInputSize, "max-input-size", "",
+		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, "Usage: mdsmith backlinks [flags] <target>\n\n"+
+			"List every workspace link that points at <target>. Optionally\n"+
+			"scope by anchor with `path#anchor`.\n\n"+
+			"Exit codes: 0 found, 1 none, 2 error\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return opts, nil, err
+	}
+	opts.walk = walkCLI{
+		noGitignore:    noGitignore,
+		followSymlinks: followSymlinksOverride(fs, followSymlinks),
+	}
+	return opts, fs.Args(), nil
+}
+
+// runBacklinks implements the "backlinks" subcommand: list every
+// workspace link that points at <target> (optionally scoped to an
+// anchor on the target).
+func runBacklinks(args []string) int {
+	opts, posArgs, err := parseBacklinksFlags(args)
+	if err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: backlinks"); code >= 0 {
+			return code
+		}
+	}
+
+	if len(posArgs) == 0 {
+		fmt.Fprint(os.Stderr, "mdsmith: backlinks requires a target file argument\n")
+		return 2
+	}
+	if len(posArgs) > 1 {
+		fmt.Fprintf(os.Stderr, "mdsmith: backlinks takes one target argument, got %d\n", len(posArgs))
+		return 2
+	}
+
+	targetPath, targetAnchor := splitTarget(posArgs[0])
+	if targetPath == "" {
+		fmt.Fprint(os.Stderr, "mdsmith: backlinks target must include a file path\n")
+		return 2
+	}
+
+	cfg, cfgPath, _, files, code := discoverFiles(opts.configPath, false, opts.walk)
+	if code >= 0 {
+		// 0 means "config + discovery returned no files"; for backlinks
+		// that is just "no results", not an error.
+		if code == 0 {
+			return emitBacklinks(os.Stdout, nil, opts.format, opts.limit)
+		}
+		return code
+	}
+
+	maxBytes, err := resolveMaxInputBytes(cfg, opts.maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
+	rootDir := rootDirFromConfig(cfgPath)
+	wantTarget := normalizeWorkspacePath(targetPath, rootDir)
+
+	records := collectBacklinks(files, rootDir, wantTarget, targetAnchor, opts.includePatterns, maxBytes)
+
+	return emitBacklinks(os.Stdout, records, opts.format, opts.limit)
+}
+
+// splitTarget separates `path#anchor` into (path, anchor). A bare
+// path returns ("path", ""). A leading `#` (anchor-only) returns
+// ("", "anchor") — that is rejected by the caller because backlinks
+// always operate on a file target.
+func splitTarget(arg string) (path, anchor string) {
+	if i := strings.IndexByte(arg, '#'); i >= 0 {
+		return arg[:i], arg[i+1:]
+	}
+	return arg, ""
+}
+
+// normalizeWorkspacePath returns a workspace-relative form of target,
+// keyed by rootDir. Absolute paths are converted via filepath.Rel.
+// Paths that escape rootDir return the cleaned absolute form so they
+// match nothing — backlinks are workspace-internal only.
+func normalizeWorkspacePath(target, rootDir string) string {
+	t := filepath.ToSlash(target)
+	t = strings.TrimPrefix(t, "./")
+	if filepath.IsAbs(filepath.FromSlash(t)) && rootDir != "" {
+		absRoot, _ := filepath.Abs(rootDir)
+		rel, err := filepath.Rel(absRoot, filepath.FromSlash(t))
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			t = filepath.ToSlash(rel)
+		}
+	}
+	return path.Clean(t)
+}
+
+// collectBacklinks walks every source file in files, extracts its
+// outgoing links via linkgraph, and returns one record per link whose
+// resolved workspace-relative target equals wantTarget. When anchor
+// is non-empty, the link's anchor must also match (after slugifying).
+// includePatterns, when non-empty, filters source paths.
+func collectBacklinks(
+	files []string,
+	rootDir, wantTarget, wantAnchor string,
+	includePatterns []string,
+	maxBytes int64,
+) []backlinkRecord {
+	wantAnchorSlug := ""
+	if wantAnchor != "" {
+		wantAnchorSlug = linkgraph.NormalizeAnchor(wantAnchor)
+	}
+
+	var records []backlinkRecord
+	for _, src := range files {
+		srcRel := workspaceRelativePath(src, rootDir)
+		if !sourceMatches(srcRel, includePatterns) {
+			continue
+		}
+		// A file never lists itself in its own backlinks.
+		if srcRel == wantTarget {
+			continue
+		}
+		data, err := lint.ReadFileLimited(src, maxBytes)
+		if err != nil {
+			continue
+		}
+		// Reuse the lint pipeline's front-matter handling so line
+		// numbers in records match what users see in editors.
+		f, err := lint.NewFileFromSource(src, data, true)
+		if err != nil {
+			continue
+		}
+		for _, link := range linkgraph.ExtractLinks(f) {
+			t := link.Target
+			if t.LocalAnchor || t.Path == "" {
+				continue
+			}
+			resolved := resolveLinkTarget(srcRel, t.Path)
+			if resolved == "" || resolved != wantTarget {
+				continue
+			}
+			if wantAnchorSlug != "" {
+				if linkgraph.NormalizeAnchor(t.Anchor) != wantAnchorSlug {
+					continue
+				}
+			}
+			records = append(records, backlinkRecord{
+				Source: srcRel,
+				Line:   link.Line,
+				Text:   link.Text,
+				Target: t.Raw,
+			})
+		}
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].Source != records[j].Source {
+			return records[i].Source < records[j].Source
+		}
+		return records[i].Line < records[j].Line
+	})
+	return records
+}
+
+// workspaceRelativePath returns p relative to rootDir using forward
+// slashes. When rootDir is empty or p cannot be made relative, p is
+// returned as-is with separators normalized.
+func workspaceRelativePath(p, rootDir string) string {
+	cleaned := filepath.ToSlash(p)
+	if rootDir == "" {
+		return strings.TrimPrefix(cleaned, "./")
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return strings.TrimPrefix(cleaned, "./")
+	}
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return strings.TrimPrefix(cleaned, "./")
+	}
+	rel, err := filepath.Rel(absRoot, abs)
+	if err != nil {
+		return strings.TrimPrefix(cleaned, "./")
+	}
+	return filepath.ToSlash(rel)
+}
+
+// resolveLinkTarget joins srcRel's directory with the link's path and
+// returns the workspace-relative result. Both inputs use forward
+// slashes. Absolute paths and ones that escape the workspace root
+// return "" so callers treat them as "outside the graph".
+func resolveLinkTarget(srcRel, linkPath string) string {
+	srcRel = strings.ReplaceAll(srcRel, `\`, `/`)
+	linkPath = strings.ReplaceAll(linkPath, `\`, `/`)
+	if path.IsAbs(srcRel) || path.IsAbs(linkPath) {
+		return ""
+	}
+	dir := path.Dir(srcRel)
+	cleaned := path.Clean(path.Join(dir, linkPath))
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return ""
+	}
+	return cleaned
+}
+
+// sourceMatches reports whether src should be considered, given the
+// list of --include globs. An empty list lets every source through.
+func sourceMatches(src string, includePatterns []string) bool {
+	if len(includePatterns) == 0 {
+		return true
+	}
+	for _, pat := range includePatterns {
+		if globpath.Match(pat, src) {
+			return true
+		}
+	}
+	return false
+}
+
+// emitBacklinks writes records to w using format. limit caps the
+// output; 0 means no cap. Exit code: 0 when records were emitted,
+// 1 when none were found, 2 on write error.
+func emitBacklinks(w io.Writer, records []backlinkRecord, format string, limit int) int {
+	if limit > 0 && len(records) > limit {
+		records = records[:limit]
+	}
+	switch format {
+	case "json":
+		// Stable shape: empty results emit `[]`, not `null`, so
+		// downstream tools can `length()` without a nil branch.
+		out := records
+		if out == nil {
+			out = []backlinkRecord{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: writing json: %v\n", err)
+			return 2
+		}
+	case "text", "":
+		for _, r := range records {
+			if _, err := fmt.Fprintf(w, "%s:%d: [%s](%s)\n", r.Source, r.Line, r.Text, r.Target); err != nil {
+				fmt.Fprintf(os.Stderr, "mdsmith: writing output: %v\n", err)
+				return 2
+			}
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "mdsmith: unknown --format %q (want text or json)\n", format)
+		return 2
+	}
+	if len(records) == 0 {
+		return 1
+	}
+	return 0
+}

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -81,7 +81,7 @@ func parseBacklinksFlags(args []string) (backlinksOptions, []string, error) {
 func runBacklinks(args []string) int {
 	opts, posArgs, err := parseBacklinksFlags(args)
 	if err != nil {
-		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: backlinks"); code >= 0 {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: list backlinks"); code >= 0 {
 			return code
 		}
 	}
@@ -135,11 +135,11 @@ func runBacklinks(args []string) int {
 // exit code with a message already written to stderr.
 func validateBacklinksArgs(opts backlinksOptions, posArgs []string) (targetPath, targetAnchor string, code int) {
 	if len(posArgs) == 0 {
-		fmt.Fprint(os.Stderr, "mdsmith: backlinks requires a target file argument\n")
+		fmt.Fprint(os.Stderr, "mdsmith: list backlinks requires a target file argument\n")
 		return "", "", 2
 	}
 	if len(posArgs) > 1 {
-		fmt.Fprintf(os.Stderr, "mdsmith: backlinks takes one target argument, got %d\n", len(posArgs))
+		fmt.Fprintf(os.Stderr, "mdsmith: list backlinks takes one target argument, got %d\n", len(posArgs))
 		return "", "", 2
 	}
 	// Route the target through the same parser the link walker uses
@@ -154,7 +154,7 @@ func validateBacklinksArgs(opts backlinksOptions, posArgs []string) (targetPath,
 		return "", "", 2
 	}
 	if parsed.LocalAnchor {
-		fmt.Fprint(os.Stderr, "mdsmith: backlinks target must include a file path\n")
+		fmt.Fprint(os.Stderr, "mdsmith: list backlinks target must include a file path\n")
 		return "", "", 2
 	}
 	targetPath, targetAnchor = parsed.Path, parsed.Anchor

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	flag "github.com/spf13/pflag"
 
+	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/globpath"
 	"github.com/jeduden/mdsmith/internal/linkgraph"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -112,7 +113,7 @@ func runBacklinks(args []string) int {
 
 	records, errs := collectBacklinks(
 		files, rootDir, wantTarget, targetAnchor,
-		opts.includePatterns, maxBytes, frontMatterEnabled(cfg),
+		opts.includePatterns, cfg.Ignore, maxBytes, frontMatterEnabled(cfg),
 	)
 	for _, e := range errs {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", e)
@@ -145,6 +146,15 @@ func validateBacklinksArgs(opts backlinksOptions, posArgs []string) (targetPath,
 	targetPath, targetAnchor = splitTarget(posArgs[0])
 	if targetPath == "" {
 		fmt.Fprint(os.Stderr, "mdsmith: backlinks target must include a file path\n")
+		return "", "", 2
+	}
+	// `<target>` is workspace-relative by contract. An absolute path
+	// or a parent-traversal entry normalises to something outside the
+	// workspace and would silently match nothing — which a caller
+	// cannot distinguish from a genuine empty result. Reject upfront
+	// so the failure is loud.
+	if !isWorkspaceRelativeTarget(targetPath) {
+		fmt.Fprintf(os.Stderr, "mdsmith: target %q must be workspace-relative\n", targetPath)
 		return "", "", 2
 	}
 	if err := validateIncludePatterns(opts.includePatterns); err != nil {
@@ -217,6 +227,8 @@ func normalizeWorkspacePath(target, rootDir string) string {
 // resolved workspace-relative target equals wantTarget. When anchor
 // is non-empty, the link's anchor must also match (after slugifying).
 // includePatterns, when non-empty, filters source paths.
+// ignorePatterns are config `ignore:` globs; matched sources are
+// skipped so backlinks output respects the same scope as check/fix.
 //
 // stripFrontMatter must mirror the config's frontMatter setting so
 // reported line numbers match MDS027 / the engine for the same file.
@@ -227,7 +239,7 @@ func normalizeWorkspacePath(target, rootDir string) string {
 func collectBacklinks(
 	files []string,
 	rootDir, wantTarget, wantAnchor string,
-	includePatterns []string,
+	includePatterns, ignorePatterns []string,
 	maxBytes int64,
 	stripFrontMatter bool,
 ) ([]backlinkRecord, []error) {
@@ -240,55 +252,20 @@ func collectBacklinks(
 	var errs []error
 	for _, src := range files {
 		srcRel := workspaceRelativePath(src, rootDir)
-		if !sourceMatches(srcRel, includePatterns) {
+		if !sourceMatches(srcRel, includePatterns) ||
+			config.IsIgnored(ignorePatterns, srcRel) ||
+			srcRel == wantTarget {
 			continue
 		}
-		// A file never lists itself in its own backlinks.
-		if srcRel == wantTarget {
-			continue
-		}
-		data, err := lint.ReadFileLimited(src, maxBytes)
+		rs, err := extractBacklinksFromSource(
+			src, srcRel, wantTarget, wantAnchorSlug,
+			maxBytes, stripFrontMatter,
+		)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("reading %s: %w", srcRel, err))
+			errs = append(errs, err)
 			continue
 		}
-		// Reuse the lint pipeline's front-matter handling so line
-		// numbers in records match what users see in editors. Mirror
-		// the config's frontMatter setting so backlinks stays aligned
-		// with MDS027 when stripping is turned off.
-		f, err := lint.NewFileFromSource(src, data, stripFrontMatter)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("parsing %s: %w", srcRel, err))
-			continue
-		}
-		for _, link := range linkgraph.ExtractLinks(f) {
-			t := link.Target
-			// Skip same-file anchor refs: backlinks only surfaces
-			// cross-file edges. linkgraph guarantees a non-empty
-			// Path whenever LocalAnchor is false.
-			if t.LocalAnchor {
-				continue
-			}
-			resolved := resolveLinkTarget(srcRel, t.Path)
-			if resolved == "" || resolved != wantTarget {
-				continue
-			}
-			if wantAnchorSlug != "" {
-				if linkgraph.NormalizeAnchor(t.Anchor) != wantAnchorSlug {
-					continue
-				}
-			}
-			records = append(records, backlinkRecord{
-				Source: srcRel,
-				// ExtractLinks returns body-relative lines (rules need
-				// that for the engine's offset-adjustment); the CLI
-				// shows file-relative line numbers, so add f.LineOffset
-				// back in.
-				Line:   link.Line + f.LineOffset,
-				Text:   link.Text,
-				Target: t.Raw,
-			})
-		}
+		records = append(records, rs...)
 	}
 	sort.SliceStable(records, func(i, j int) bool {
 		if records[i].Source != records[j].Source {
@@ -297,6 +274,55 @@ func collectBacklinks(
 		return records[i].Line < records[j].Line
 	})
 	return records, errs
+}
+
+// extractBacklinksFromSource reads one source file, parses it, and
+// returns the backlink records (and any read/parse error) for links
+// that resolve to wantTarget. wantAnchorSlug is the already-slugified
+// anchor query, or "" to match any anchor.
+func extractBacklinksFromSource(
+	src, srcRel, wantTarget, wantAnchorSlug string,
+	maxBytes int64, stripFrontMatter bool,
+) ([]backlinkRecord, error) {
+	data, err := lint.ReadFileLimited(src, maxBytes)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", srcRel, err)
+	}
+	// Reuse the lint pipeline's front-matter handling so line numbers
+	// in records match what users see in editors. Mirror the config's
+	// frontMatter setting so backlinks stays aligned with MDS027 when
+	// stripping is turned off.
+	f, err := lint.NewFileFromSource(src, data, stripFrontMatter)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", srcRel, err)
+	}
+	var out []backlinkRecord
+	for _, link := range linkgraph.ExtractLinks(f) {
+		t := link.Target
+		// Skip same-file anchor refs: backlinks only surfaces cross-
+		// file edges. linkgraph guarantees a non-empty Path whenever
+		// LocalAnchor is false.
+		if t.LocalAnchor {
+			continue
+		}
+		resolved := resolveLinkTarget(srcRel, t.Path)
+		if resolved == "" || resolved != wantTarget {
+			continue
+		}
+		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(t.Anchor) != wantAnchorSlug {
+			continue
+		}
+		out = append(out, backlinkRecord{
+			Source: srcRel,
+			// ExtractLinks returns body-relative lines (rules need
+			// that for the engine's offset-adjustment); the CLI shows
+			// file-relative line numbers, so add f.LineOffset back in.
+			Line:   link.Line + f.LineOffset,
+			Text:   link.Text,
+			Target: t.Raw,
+		})
+	}
+	return out, nil
 }
 
 // workspaceRelativePath returns p relative to rootDir using forward
@@ -356,6 +382,19 @@ func isAbsOrDriveOrUNC(p string) bool {
 		}
 	}
 	return strings.HasPrefix(p, "//")
+}
+
+// isWorkspaceRelativeTarget reports whether target is a usable
+// workspace-relative path. Absolute paths (POSIX / Windows / UNC)
+// and parent-traversal entries are rejected so the caller can fail
+// loudly instead of silently producing an empty result set.
+func isWorkspaceRelativeTarget(target string) bool {
+	t := filepath.ToSlash(target)
+	if isAbsOrDriveOrUNC(t) {
+		return false
+	}
+	cleaned := path.Clean(t)
+	return cleaned != ".." && !strings.HasPrefix(cleaned, "../")
 }
 
 // sourceMatches reports whether src should be considered, given the

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -85,28 +85,9 @@ func runBacklinks(args []string) int {
 		}
 	}
 
-	if len(posArgs) == 0 {
-		fmt.Fprint(os.Stderr, "mdsmith: backlinks requires a target file argument\n")
-		return 2
-	}
-	if len(posArgs) > 1 {
-		fmt.Fprintf(os.Stderr, "mdsmith: backlinks takes one target argument, got %d\n", len(posArgs))
-		return 2
-	}
-
-	targetPath, targetAnchor := splitTarget(posArgs[0])
-	if targetPath == "" {
-		fmt.Fprint(os.Stderr, "mdsmith: backlinks target must include a file path\n")
-		return 2
-	}
-
-	if err := validateIncludePatterns(opts.includePatterns); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
-	if opts.limit < 0 {
-		fmt.Fprintf(os.Stderr, "mdsmith: --limit must be >= 0 (got %d)\n", opts.limit)
-		return 2
+	targetPath, targetAnchor, code := validateBacklinksArgs(opts, posArgs)
+	if code >= 0 {
+		return code
 	}
 
 	cfg, cfgPath, _, files, code := discoverFiles(opts.configPath, false, opts.walk)
@@ -128,7 +109,10 @@ func runBacklinks(args []string) int {
 	rootDir := rootDirFromConfig(cfgPath)
 	wantTarget := normalizeWorkspacePath(targetPath, rootDir)
 
-	records, errs := collectBacklinks(files, rootDir, wantTarget, targetAnchor, opts.includePatterns, maxBytes)
+	records, errs := collectBacklinks(
+		files, rootDir, wantTarget, targetAnchor,
+		opts.includePatterns, maxBytes, frontMatterEnabled(cfg),
+	)
 	for _, e := range errs {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", e)
 	}
@@ -142,6 +126,35 @@ func runBacklinks(args []string) int {
 		return 2
 	}
 	return code
+}
+
+// validateBacklinksArgs checks the positional arg shape and the
+// numeric/glob flag invariants for backlinks. It returns the parsed
+// target (path + anchor) plus code = -1 on success, or a non-negative
+// exit code with a message already written to stderr.
+func validateBacklinksArgs(opts backlinksOptions, posArgs []string) (targetPath, targetAnchor string, code int) {
+	if len(posArgs) == 0 {
+		fmt.Fprint(os.Stderr, "mdsmith: backlinks requires a target file argument\n")
+		return "", "", 2
+	}
+	if len(posArgs) > 1 {
+		fmt.Fprintf(os.Stderr, "mdsmith: backlinks takes one target argument, got %d\n", len(posArgs))
+		return "", "", 2
+	}
+	targetPath, targetAnchor = splitTarget(posArgs[0])
+	if targetPath == "" {
+		fmt.Fprint(os.Stderr, "mdsmith: backlinks target must include a file path\n")
+		return "", "", 2
+	}
+	if err := validateIncludePatterns(opts.includePatterns); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return "", "", 2
+	}
+	if opts.limit < 0 {
+		fmt.Fprintf(os.Stderr, "mdsmith: --limit must be >= 0 (got %d)\n", opts.limit)
+		return "", "", 2
+	}
+	return targetPath, targetAnchor, -1
 }
 
 // validateIncludePatterns rejects any --include glob that doublestar
@@ -195,6 +208,9 @@ func normalizeWorkspacePath(target, rootDir string) string {
 // is non-empty, the link's anchor must also match (after slugifying).
 // includePatterns, when non-empty, filters source paths.
 //
+// stripFrontMatter must mirror the config's frontMatter setting so
+// reported line numbers match MDS027 / the engine for the same file.
+//
 // Per-file read or parse failures do not abort the walk; instead they
 // are collected and returned so the caller can surface them on stderr
 // alongside whatever results were produced.
@@ -203,6 +219,7 @@ func collectBacklinks(
 	rootDir, wantTarget, wantAnchor string,
 	includePatterns []string,
 	maxBytes int64,
+	stripFrontMatter bool,
 ) ([]backlinkRecord, []error) {
 	wantAnchorSlug := ""
 	if wantAnchor != "" {
@@ -226,8 +243,10 @@ func collectBacklinks(
 			continue
 		}
 		// Reuse the lint pipeline's front-matter handling so line
-		// numbers in records match what users see in editors.
-		f, err := lint.NewFileFromSource(src, data, true)
+		// numbers in records match what users see in editors. Mirror
+		// the config's frontMatter setting so backlinks stays aligned
+		// with MDS027 when stripping is turned off.
+		f, err := lint.NewFileFromSource(src, data, stripFrontMatter)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("parsing %s: %w", srcRel, err))
 			continue

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -143,21 +142,29 @@ func validateBacklinksArgs(opts backlinksOptions, posArgs []string) (targetPath,
 		fmt.Fprintf(os.Stderr, "mdsmith: backlinks takes one target argument, got %d\n", len(posArgs))
 		return "", "", 2
 	}
-	targetPath, targetAnchor = splitTarget(posArgs[0])
-	if targetPath == "" {
+	// Route the target through the same parser the link walker uses
+	// (linkgraph.ParseTarget) so the CLI accepts exactly the shapes
+	// that can ever appear as a link destination. This rejects
+	// malformed percent escapes, query-only inputs, schemed URLs, and
+	// other forms with no corresponding link target — all of which
+	// would otherwise pass and produce a silent empty result.
+	parsed, ok := linkgraph.ParseTarget(posArgs[0])
+	if !ok {
+		fmt.Fprintf(os.Stderr, "mdsmith: invalid target %q\n", posArgs[0])
+		return "", "", 2
+	}
+	if parsed.LocalAnchor {
 		fmt.Fprint(os.Stderr, "mdsmith: backlinks target must include a file path\n")
 		return "", "", 2
 	}
+	targetPath, targetAnchor = parsed.Path, parsed.Anchor
 	// `<target>` is workspace-relative by contract. An absolute path
 	// or a parent-traversal entry normalises to something outside the
 	// workspace and would silently match nothing — which a caller
 	// cannot distinguish from a genuine empty result. Reject upfront
-	// so the failure is loud. Decode percent-escapes first so an
-	// encoded `%2Fetc%2Fpasswd` or `%2e%2e/foo.md` can't slip past the
-	// absolute / `..` checks.
-	if decoded, err := url.PathUnescape(targetPath); err == nil {
-		targetPath = decoded
-	}
+	// so the failure is loud. ParseTarget already percent-decoded the
+	// path, so `%2Fetc...` and `%2e%2e/...` are checked here in their
+	// decoded form.
 	if !isWorkspaceRelativeTarget(targetPath) {
 		fmt.Fprintf(os.Stderr, "mdsmith: target %q must be workspace-relative\n", targetPath)
 		return "", "", 2
@@ -186,32 +193,13 @@ func validateIncludePatterns(patterns []string) error {
 	return nil
 }
 
-// splitTarget separates `path#anchor` into (path, anchor). A bare
-// path returns ("path", ""). A leading `#` (anchor-only) returns
-// ("", "anchor") — that is rejected by the caller because backlinks
-// always operate on a file target.
-func splitTarget(arg string) (path, anchor string) {
-	if i := strings.IndexByte(arg, '#'); i >= 0 {
-		return arg[:i], arg[i+1:]
-	}
-	return arg, ""
-}
-
 // normalizeWorkspacePath returns the cleaned workspace-relative form
 // of target. validateBacklinksArgs already rejects absolute paths
-// and `..` traversals (including percent-encoded forms), so this
-// helper only has to handle a relative, decoded path: strip a
-// leading `./`, normalize separators, and clean the result.
-//
-// Percent-decoding is also done here so the CLI target aligns with
-// linkgraph.ParseTarget, which decodes the destinations it extracts
-// from Markdown links. Without this step, a query like
-// `backlinks docs/my%20file.md` would never match `[X](my%20file.md)`
-// (which resolves to `docs/my file.md` under the workspace root).
+// and `..` traversals and routes the input through
+// linkgraph.ParseTarget (which percent-decodes), so this helper only
+// has to handle a relative, decoded path: strip a leading `./`,
+// normalize separators, and clean the result.
 func normalizeWorkspacePath(target string) string {
-	if decoded, err := url.PathUnescape(target); err == nil {
-		target = decoded
-	}
 	t := filepath.ToSlash(target)
 	t = strings.TrimPrefix(t, "./")
 	return path.Clean(t)

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -104,6 +104,10 @@ func runBacklinks(args []string) int {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
+	if opts.limit < 0 {
+		fmt.Fprintf(os.Stderr, "mdsmith: --limit must be >= 0 (got %d)\n", opts.limit)
+		return 2
+	}
 
 	cfg, cfgPath, _, files, code := discoverFiles(opts.configPath, false, opts.walk)
 	if code >= 0 {
@@ -174,7 +178,11 @@ func normalizeWorkspacePath(target, rootDir string) string {
 	if filepath.IsAbs(filepath.FromSlash(t)) && rootDir != "" {
 		absRoot, _ := filepath.Abs(rootDir)
 		rel, err := filepath.Rel(absRoot, filepath.FromSlash(t))
-		if err == nil && !strings.HasPrefix(rel, "..") {
+		// `HasPrefix(rel, "..")` would misclassify in-root files
+		// whose names happen to start with two dots (e.g.
+		// `..notes.md`). Only treat a leading `..` followed by a
+		// path separator (or the bare `..`) as a true escape.
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			t = filepath.ToSlash(rel)
 		}
 	}

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -252,9 +252,11 @@ func collectBacklinks(
 	var errs []error
 	for _, src := range files {
 		srcRel := workspaceRelativePath(src, rootDir)
+		// Self-links count: the contract is "every workspace file
+		// that links to <target>", and a file that links to itself
+		// satisfies that as literally as any other source.
 		if !sourceMatches(srcRel, includePatterns) ||
-			config.IsIgnored(ignorePatterns, srcRel) ||
-			srcRel == wantTarget {
+			config.IsIgnored(ignorePatterns, srcRel) {
 			continue
 		}
 		rs, err := extractBacklinksFromSource(

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -37,7 +37,7 @@ type backlinksOptions struct {
 	walk            walkCLI
 }
 
-// parseBacklinksFlags parses the flags for `mdsmith backlinks` and
+// parseBacklinksFlags parses the flags for `mdsmith list backlinks` and
 // returns the options plus the remaining positional arguments.
 func parseBacklinksFlags(args []string) (backlinksOptions, []string, error) {
 	fs := flag.NewFlagSet("backlinks", flag.ContinueOnError)
@@ -58,7 +58,7 @@ func parseBacklinksFlags(args []string) (backlinksOptions, []string, error) {
 		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, "Usage: mdsmith backlinks [flags] <target>\n\n"+
+		fmt.Fprint(os.Stderr, "Usage: mdsmith list backlinks [flags] <target>\n\n"+
 			"List every workspace link that points at <target>. Optionally\n"+
 			"scope by anchor with `path#anchor`.\n\n"+
 			"Exit codes: 0 found, 1 none, 2 error\n\nFlags:\n")

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	flag "github.com/spf13/pflag"
 
 	"github.com/jeduden/mdsmith/internal/globpath"
@@ -99,6 +100,11 @@ func runBacklinks(args []string) int {
 		return 2
 	}
 
+	if err := validateIncludePatterns(opts.includePatterns); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
 	cfg, cfgPath, _, files, code := discoverFiles(opts.configPath, false, opts.walk)
 	if code >= 0 {
 		// 0 means "config + discovery returned no files"; for backlinks
@@ -118,9 +124,25 @@ func runBacklinks(args []string) int {
 	rootDir := rootDirFromConfig(cfgPath)
 	wantTarget := normalizeWorkspacePath(targetPath, rootDir)
 
-	records := collectBacklinks(files, rootDir, wantTarget, targetAnchor, opts.includePatterns, maxBytes)
+	records, errs := collectBacklinks(files, rootDir, wantTarget, targetAnchor, opts.includePatterns, maxBytes)
+	for _, e := range errs {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", e)
+	}
 
 	return emitBacklinks(os.Stdout, records, opts.format, opts.limit)
+}
+
+// validateIncludePatterns rejects any --include glob that doublestar
+// would silently reject (returning false from every Match call). A
+// typo like `--include "["` would otherwise filter out every source
+// and surface as "no backlinks found" instead of a clear error.
+func validateIncludePatterns(patterns []string) error {
+	for _, p := range patterns {
+		if !doublestar.ValidatePattern(p) {
+			return fmt.Errorf("invalid --include glob %q", p)
+		}
+	}
+	return nil
 }
 
 // splitTarget separates `path#anchor` into (path, anchor). A bare
@@ -156,18 +178,23 @@ func normalizeWorkspacePath(target, rootDir string) string {
 // resolved workspace-relative target equals wantTarget. When anchor
 // is non-empty, the link's anchor must also match (after slugifying).
 // includePatterns, when non-empty, filters source paths.
+//
+// Per-file read or parse failures do not abort the walk; instead they
+// are collected and returned so the caller can surface them on stderr
+// alongside whatever results were produced.
 func collectBacklinks(
 	files []string,
 	rootDir, wantTarget, wantAnchor string,
 	includePatterns []string,
 	maxBytes int64,
-) []backlinkRecord {
+) ([]backlinkRecord, []error) {
 	wantAnchorSlug := ""
 	if wantAnchor != "" {
 		wantAnchorSlug = linkgraph.NormalizeAnchor(wantAnchor)
 	}
 
 	var records []backlinkRecord
+	var errs []error
 	for _, src := range files {
 		srcRel := workspaceRelativePath(src, rootDir)
 		if !sourceMatches(srcRel, includePatterns) {
@@ -179,12 +206,14 @@ func collectBacklinks(
 		}
 		data, err := lint.ReadFileLimited(src, maxBytes)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("reading %s: %w", srcRel, err))
 			continue
 		}
 		// Reuse the lint pipeline's front-matter handling so line
 		// numbers in records match what users see in editors.
 		f, err := lint.NewFileFromSource(src, data, true)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("parsing %s: %w", srcRel, err))
 			continue
 		}
 		for _, link := range linkgraph.ExtractLinks(f) {
@@ -203,7 +232,11 @@ func collectBacklinks(
 			}
 			records = append(records, backlinkRecord{
 				Source: srcRel,
-				Line:   link.Line,
+				// ExtractLinks returns body-relative lines (rules need
+				// that for the engine's offset-adjustment); the CLI
+				// shows file-relative line numbers, so add f.LineOffset
+				// back in.
+				Line:   link.Line + f.LineOffset,
 				Text:   link.Text,
 				Target: t.Raw,
 			})
@@ -215,7 +248,7 @@ func collectBacklinks(
 		}
 		return records[i].Line < records[j].Line
 	})
-	return records
+	return records, errs
 }
 
 // workspaceRelativePath returns p relative to rootDir using forward

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -185,7 +186,16 @@ func splitTarget(arg string) (path, anchor string) {
 // keyed by rootDir. Absolute paths are converted via filepath.Rel.
 // Paths that escape rootDir return the cleaned absolute form so they
 // match nothing — backlinks are workspace-internal only.
+//
+// Percent-encoded segments are decoded so the CLI target aligns with
+// linkgraph.ParseTarget, which decodes the destinations it extracts
+// from Markdown links. Without this step, a query like
+// `backlinks docs/my%20file.md` would never match `[X](my%20file.md)`
+// (which resolves to `docs/my file.md` under the workspace root).
 func normalizeWorkspacePath(target, rootDir string) string {
+	if decoded, err := url.PathUnescape(target); err == nil {
+		target = decoded
+	}
 	t := filepath.ToSlash(target)
 	t = strings.TrimPrefix(t, "./")
 	if filepath.IsAbs(filepath.FromSlash(t)) && rootDir != "" {

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -109,7 +109,7 @@ func runBacklinks(args []string) int {
 	}
 
 	rootDir := rootDirFromConfig(cfgPath)
-	wantTarget := normalizeWorkspacePath(targetPath, rootDir)
+	wantTarget := normalizeWorkspacePath(targetPath)
 
 	records, errs := collectBacklinks(
 		files, rootDir, wantTarget, targetAnchor,
@@ -152,7 +152,12 @@ func validateBacklinksArgs(opts backlinksOptions, posArgs []string) (targetPath,
 	// or a parent-traversal entry normalises to something outside the
 	// workspace and would silently match nothing — which a caller
 	// cannot distinguish from a genuine empty result. Reject upfront
-	// so the failure is loud.
+	// so the failure is loud. Decode percent-escapes first so an
+	// encoded `%2Fetc%2Fpasswd` or `%2e%2e/foo.md` can't slip past the
+	// absolute / `..` checks.
+	if decoded, err := url.PathUnescape(targetPath); err == nil {
+		targetPath = decoded
+	}
 	if !isWorkspaceRelativeTarget(targetPath) {
 		fmt.Fprintf(os.Stderr, "mdsmith: target %q must be workspace-relative\n", targetPath)
 		return "", "", 2
@@ -192,33 +197,23 @@ func splitTarget(arg string) (path, anchor string) {
 	return arg, ""
 }
 
-// normalizeWorkspacePath returns a workspace-relative form of target,
-// keyed by rootDir. Absolute paths are converted via filepath.Rel.
-// Paths that escape rootDir return the cleaned absolute form so they
-// match nothing — backlinks are workspace-internal only.
+// normalizeWorkspacePath returns the cleaned workspace-relative form
+// of target. validateBacklinksArgs already rejects absolute paths
+// and `..` traversals (including percent-encoded forms), so this
+// helper only has to handle a relative, decoded path: strip a
+// leading `./`, normalize separators, and clean the result.
 //
-// Percent-encoded segments are decoded so the CLI target aligns with
+// Percent-decoding is also done here so the CLI target aligns with
 // linkgraph.ParseTarget, which decodes the destinations it extracts
 // from Markdown links. Without this step, a query like
 // `backlinks docs/my%20file.md` would never match `[X](my%20file.md)`
 // (which resolves to `docs/my file.md` under the workspace root).
-func normalizeWorkspacePath(target, rootDir string) string {
+func normalizeWorkspacePath(target string) string {
 	if decoded, err := url.PathUnescape(target); err == nil {
 		target = decoded
 	}
 	t := filepath.ToSlash(target)
 	t = strings.TrimPrefix(t, "./")
-	if filepath.IsAbs(filepath.FromSlash(t)) && rootDir != "" {
-		absRoot, _ := filepath.Abs(rootDir)
-		rel, err := filepath.Rel(absRoot, filepath.FromSlash(t))
-		// `HasPrefix(rel, "..")` would misclassify in-root files
-		// whose names happen to start with two dots (e.g.
-		// `..notes.md`). Only treat a leading `..` followed by a
-		// path separator (or the bare `..`) as a true escape.
-		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			t = filepath.ToSlash(rel)
-		}
-	}
 	return path.Clean(t)
 }
 

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -129,7 +129,15 @@ func runBacklinks(args []string) int {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", e)
 	}
 
-	return emitBacklinks(os.Stdout, records, opts.format, opts.limit)
+	code = emitBacklinks(os.Stdout, records, opts.format, opts.limit)
+	// Exit-code precedence: records found wins (0), then runtime
+	// errors (2), then clean empty result (1). This matches `check`,
+	// where diagnostics outrank per-file read errors but a fully
+	// failed run reports the error.
+	if code == 1 && len(errs) > 0 {
+		return 2
+	}
+	return code
 }
 
 // validateIncludePatterns rejects any --include glob that doublestar
@@ -218,7 +226,10 @@ func collectBacklinks(
 		}
 		for _, link := range linkgraph.ExtractLinks(f) {
 			t := link.Target
-			if t.LocalAnchor || t.Path == "" {
+			// Skip same-file anchor refs: backlinks only surfaces
+			// cross-file edges. linkgraph guarantees a non-empty
+			// Path whenever LocalAnchor is false.
+			if t.LocalAnchor {
 				continue
 			}
 			resolved := resolveLinkTarget(srcRel, t.Path)
@@ -252,36 +263,37 @@ func collectBacklinks(
 }
 
 // workspaceRelativePath returns p relative to rootDir using forward
-// slashes. When rootDir is empty or p cannot be made relative, p is
-// returned as-is with separators normalized.
+// slashes. When rootDir is empty or filepath.Rel cannot relate the
+// paths, p is returned as-is with separators normalized.
 func workspaceRelativePath(p, rootDir string) string {
-	cleaned := filepath.ToSlash(p)
+	fallback := strings.TrimPrefix(filepath.ToSlash(p), "./")
 	if rootDir == "" {
-		return strings.TrimPrefix(cleaned, "./")
+		return fallback
 	}
 	abs, err := filepath.Abs(p)
 	if err != nil {
-		return strings.TrimPrefix(cleaned, "./")
+		return fallback
 	}
 	absRoot, err := filepath.Abs(rootDir)
 	if err != nil {
-		return strings.TrimPrefix(cleaned, "./")
+		return fallback
 	}
 	rel, err := filepath.Rel(absRoot, abs)
 	if err != nil {
-		return strings.TrimPrefix(cleaned, "./")
+		return fallback
 	}
 	return filepath.ToSlash(rel)
 }
 
 // resolveLinkTarget joins srcRel's directory with the link's path and
 // returns the workspace-relative result. Both inputs use forward
-// slashes. Absolute paths and ones that escape the workspace root
-// return "" so callers treat them as "outside the graph".
+// slashes. Absolute paths (including Windows drive letters and UNC
+// prefixes) and ones that escape the workspace root return "" so
+// callers treat them as "outside the graph".
 func resolveLinkTarget(srcRel, linkPath string) string {
 	srcRel = strings.ReplaceAll(srcRel, `\`, `/`)
 	linkPath = strings.ReplaceAll(linkPath, `\`, `/`)
-	if path.IsAbs(srcRel) || path.IsAbs(linkPath) {
+	if isAbsOrDriveOrUNC(srcRel) || isAbsOrDriveOrUNC(linkPath) {
 		return ""
 	}
 	dir := path.Dir(srcRel)
@@ -290,6 +302,23 @@ func resolveLinkTarget(srcRel, linkPath string) string {
 		return ""
 	}
 	return cleaned
+}
+
+// isAbsOrDriveOrUNC reports whether p is absolute under any of the
+// schemes mdsmith targets: POSIX-style leading `/`, Windows drive
+// letters like `C:/`, or UNC prefixes like `//host`. `path.IsAbs`
+// alone misses the Windows forms because the path package is Unix-only.
+func isAbsOrDriveOrUNC(p string) bool {
+	if path.IsAbs(p) {
+		return true
+	}
+	if len(p) >= 2 && p[1] == ':' {
+		c := p[0]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			return true
+		}
+	}
+	return strings.HasPrefix(p, "//")
 }
 
 // sourceMatches reports whether src should be considered, given the

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitTarget(t *testing.T) {
+	cases := []struct {
+		input      string
+		wantPath   string
+		wantAnchor string
+	}{
+		{"docs/api.md", "docs/api.md", ""},
+		{"docs/api.md#section", "docs/api.md", "section"},
+		{"docs/api.md#with-dashes", "docs/api.md", "with-dashes"},
+		{"#anchor-only", "", "anchor-only"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			p, a := splitTarget(tc.input)
+			assert.Equal(t, tc.wantPath, p)
+			assert.Equal(t, tc.wantAnchor, a)
+		})
+	}
+}
+
+func TestResolveLinkTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		linkPath string
+		want     string
+	}{
+		{"sibling", "docs/index.md", "api.md", "docs/api.md"},
+		{"dot-prefix", "docs/index.md", "./api.md", "docs/api.md"},
+		{"parent dir", "docs/sub/index.md", "../api.md", "docs/api.md"},
+		{"two levels up", "plan/045.md", "../docs/api.md", "docs/api.md"},
+		{"escapes root", "docs/api.md", "../../etc/passwd", ""},
+		{"absolute link", "docs/api.md", "/etc/passwd", ""},
+		{"absolute source", "/abs/docs/api.md", "guide.md", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveLinkTarget(tc.src, tc.linkPath)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNormalizeWorkspacePath(t *testing.T) {
+	root := t.TempDir()
+	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("docs/api.md", root))
+	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("./docs/api.md", root))
+	// Absolute path inside root maps to relative.
+	abs := filepath.Join(root, "docs", "api.md")
+	assert.Equal(t, "docs/api.md", normalizeWorkspacePath(abs, root))
+}
+
+func TestSourceMatches(t *testing.T) {
+	assert.True(t, sourceMatches("docs/api.md", nil))
+	assert.True(t, sourceMatches("docs/api.md", []string{"docs/**"}))
+	assert.False(t, sourceMatches("plan/045.md", []string{"docs/**"}))
+	assert.True(t, sourceMatches("plan/045.md", []string{"docs/**", "plan/**"}))
+}
+
+func TestEmitBacklinks_Text(t *testing.T) {
+	var buf bytes.Buffer
+	records := []backlinkRecord{
+		{Source: "a.md", Line: 1, Text: "ref", Target: "x.md"},
+		{Source: "b.md", Line: 2, Text: "ref2", Target: "./x.md"},
+	}
+	code := emitBacklinks(&buf, records, "text", 0)
+	assert.Equal(t, 0, code)
+	out := buf.String()
+	assert.Contains(t, out, "a.md:1: [ref](x.md)\n")
+	assert.Contains(t, out, "b.md:2: [ref2](./x.md)\n")
+}
+
+func TestEmitBacklinks_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	records := []backlinkRecord{
+		{Source: "a.md", Line: 1, Text: "ref", Target: "x.md"},
+	}
+	code := emitBacklinks(&buf, records, "json", 0)
+	assert.Equal(t, 0, code)
+	var decoded []backlinkRecord
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, records, decoded)
+}
+
+func TestEmitBacklinks_JSONEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	code := emitBacklinks(&buf, nil, "json", 0)
+	assert.Equal(t, 1, code, "no records → exit 1")
+	// `[]` is the documented stable shape; never `null`.
+	assert.Contains(t, buf.String(), "[]")
+	assert.NotContains(t, buf.String(), "null")
+}
+
+func TestEmitBacklinks_Limit(t *testing.T) {
+	records := []backlinkRecord{
+		{Source: "a.md", Line: 1},
+		{Source: "b.md", Line: 1},
+		{Source: "c.md", Line: 1},
+	}
+	var buf bytes.Buffer
+	code := emitBacklinks(&buf, records, "text", 2)
+	assert.Equal(t, 0, code)
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Len(t, lines, 2)
+}
+
+func TestEmitBacklinks_UnknownFormat(t *testing.T) {
+	var buf bytes.Buffer
+	code := emitBacklinks(&buf, []backlinkRecord{{Source: "a.md"}}, "yaml", 0)
+	assert.Equal(t, 2, code)
+}
+
+// TestCollectBacklinks_End2End covers the path/anchor combinations the
+// plan's acceptance criteria call out: three sources, anchor scoping,
+// include filter, limit.
+func TestCollectBacklinks_End2End(t *testing.T) {
+	root := t.TempDir()
+	mkdir := func(rel string) {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, rel), 0o755))
+	}
+	write := func(rel, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644))
+	}
+	mkdir("docs")
+	mkdir("plan")
+	mkdir("docs/sub")
+	write("docs/api.md", "# API\n\n## Authentication\n\n## Endpoints\n")
+	write("docs/index.md", "# Index\n\nSee [API reference](api.md).\n")
+	write("docs/sub/guide.md", "# Guide\n\nUse [api docs](../api.md#authentication).\n")
+	write("plan/045_api-overhaul.md", "# Plan\n\n[api](../docs/api.md)\n")
+	// File that does NOT link to api.md.
+	write("docs/changelog.md", "# Changelog\n\n[plan](../plan/045_api-overhaul.md)\n")
+
+	files := []string{
+		filepath.Join(root, "docs/api.md"),
+		filepath.Join(root, "docs/changelog.md"),
+		filepath.Join(root, "docs/index.md"),
+		filepath.Join(root, "docs/sub/guide.md"),
+		filepath.Join(root, "plan/045_api-overhaul.md"),
+	}
+
+	t.Run("three sources, no anchor", func(t *testing.T) {
+		got := collectBacklinks(files, root, "docs/api.md", "", nil, 0)
+		require.Len(t, got, 3)
+		assert.Equal(t, "docs/index.md", got[0].Source)
+		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
+		assert.Equal(t, "plan/045_api-overhaul.md", got[2].Source)
+	})
+
+	t.Run("anchor scopes to one source", func(t *testing.T) {
+		got := collectBacklinks(files, root, "docs/api.md", "authentication", nil, 0)
+		require.Len(t, got, 1)
+		assert.Equal(t, "docs/sub/guide.md", got[0].Source)
+	})
+
+	t.Run("anchor with no hits returns empty", func(t *testing.T) {
+		got := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, 0)
+		assert.Empty(t, got)
+	})
+
+	t.Run("include filter excludes plan/", func(t *testing.T) {
+		got := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, 0)
+		require.Len(t, got, 2)
+		assert.Equal(t, "docs/index.md", got[0].Source)
+		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
+	})
+}

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -208,7 +208,7 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 	root, files := setupCollectBacklinksFixture(t)
 
 	t.Run("three sources, no anchor", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, 0, true)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, nil, 0, true)
 		require.Empty(t, errs)
 		require.Len(t, got, 3)
 		assert.Equal(t, "docs/index.md", got[0].Source)
@@ -217,20 +217,20 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 	})
 
 	t.Run("anchor scopes to one source", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "authentication", nil, 0, true)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "authentication", nil, nil, 0, true)
 		require.Empty(t, errs)
 		require.Len(t, got, 1)
 		assert.Equal(t, "docs/sub/guide.md", got[0].Source)
 	})
 
 	t.Run("anchor with no hits returns empty", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, 0, true)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, nil, 0, true)
 		assert.Empty(t, errs)
 		assert.Empty(t, got)
 	})
 
 	t.Run("include filter excludes plan/", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, 0, true)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, nil, 0, true)
 		require.Empty(t, errs)
 		require.Len(t, got, 2)
 		assert.Equal(t, "docs/index.md", got[0].Source)
@@ -242,28 +242,44 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 		// collectBacklinks captures the error rather than swallowing.
 		bad := filepath.Join(root, "does-not-exist.md")
 		filesWithBad := append([]string{bad}, files...)
-		got, errs := collectBacklinks(filesWithBad, root, "docs/api.md", "", nil, 0, true)
+		got, errs := collectBacklinks(filesWithBad, root, "docs/api.md", "", nil, nil, 0, true)
 		// The other files still contribute results.
 		assert.NotEmpty(t, got)
 		require.Len(t, errs, 1)
 		assert.Contains(t, errs[0].Error(), "does-not-exist.md")
 	})
 
-	t.Run("local-anchor links are skipped", func(t *testing.T) {
-		// Source contains only a same-file anchor link, no cross-file
-		// reference to the target. linkgraph yields a LocalAnchor=true
-		// link; collectBacklinks must skip it without trying to
-		// resolve a path target.
-		anchorOnly := filepath.Join(root, "anchor-only.md")
-		require.NoError(t, os.WriteFile(anchorOnly,
-			[]byte("# Intro\n\nJump to [section](#section).\n\n## Section\n"), 0o644))
-		filesWithAnchor := append([]string{anchorOnly}, files...)
-		got, errs := collectBacklinks(filesWithAnchor, root, "docs/api.md", "", nil, 0, true)
-		assert.Empty(t, errs)
-		// Same three matches as before; anchor-only.md contributes nothing.
-		assert.Len(t, got, 3)
-	})
+}
 
+func TestCollectBacklinks_LocalAnchorSkipped(t *testing.T) {
+	// Source contains only a same-file anchor link, no cross-file
+	// reference to the target. linkgraph yields a LocalAnchor=true
+	// link; collectBacklinks must skip it without trying to resolve a
+	// path target.
+	root, files := setupCollectBacklinksFixture(t)
+	anchorOnly := filepath.Join(root, "anchor-only.md")
+	require.NoError(t, os.WriteFile(anchorOnly,
+		[]byte("# Intro\n\nJump to [section](#section).\n\n## Section\n"), 0o644))
+	filesWithAnchor := append([]string{anchorOnly}, files...)
+	got, errs := collectBacklinks(filesWithAnchor, root, "docs/api.md", "", nil, nil, 0, true)
+	assert.Empty(t, errs)
+	// Same three matches as before; anchor-only.md contributes nothing.
+	assert.Len(t, got, 3)
+}
+
+func TestCollectBacklinks_IgnorePatternsExclude(t *testing.T) {
+	// `plan/**` ignores the plan/* source that links to api.md;
+	// the other two sources still produce records.
+	root, files := setupCollectBacklinksFixture(t)
+	got, errs := collectBacklinks(
+		files, root, "docs/api.md", "",
+		nil, []string{"plan/**"}, 0, true,
+	)
+	require.Empty(t, errs)
+	require.Len(t, got, 2)
+	for _, r := range got {
+		assert.NotContains(t, r.Source, "plan/")
+	}
 }
 
 // TestCollectBacklinks_FrontMatterStrippingDisabled verifies the
@@ -277,7 +293,7 @@ func TestCollectBacklinks_FrontMatterStrippingDisabled(t *testing.T) {
 	require.NoError(t, os.WriteFile(fmSrc,
 		[]byte("---\ntitle: x\n---\n# H\n\nSee [api](docs/api.md).\n"), 0o644))
 	filesWithFM := append([]string{fmSrc}, files...)
-	got, errs := collectBacklinks(filesWithFM, root, "docs/api.md", "", nil, 0, false)
+	got, errs := collectBacklinks(filesWithFM, root, "docs/api.md", "", nil, nil, 0, false)
 	require.Empty(t, errs)
 	var fmRec *backlinkRecord
 	for i := range got {
@@ -320,7 +336,7 @@ func TestCollectBacklinks_SortStable(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"), []byte(body), 0o644))
 
 	files := []string{filepath.Join(root, "src.md"), filepath.Join(root, "target.md")}
-	got, errs := collectBacklinks(files, root, "target.md", "", nil, 0, true)
+	got, errs := collectBacklinks(files, root, "target.md", "", nil, nil, 0, true)
 	require.Empty(t, errs)
 	require.Len(t, got, 2)
 	assert.Equal(t, "src.md", got[0].Source)

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -13,26 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSplitTarget(t *testing.T) {
-	cases := []struct {
-		input      string
-		wantPath   string
-		wantAnchor string
-	}{
-		{"docs/api.md", "docs/api.md", ""},
-		{"docs/api.md#section", "docs/api.md", "section"},
-		{"docs/api.md#with-dashes", "docs/api.md", "with-dashes"},
-		{"#anchor-only", "", "anchor-only"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			p, a := splitTarget(tc.input)
-			assert.Equal(t, tc.wantPath, p)
-			assert.Equal(t, tc.wantAnchor, a)
-		})
-	}
-}
-
 func TestResolveLinkTarget(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -64,17 +44,6 @@ func TestResolveLinkTarget(t *testing.T) {
 func TestNormalizeWorkspacePath(t *testing.T) {
 	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("docs/api.md"))
 	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("./docs/api.md"))
-}
-
-// TestNormalizeWorkspacePath_PercentEncoded verifies that the CLI
-// target accepts percent-encoded path components and decodes them
-// to match link paths. linkgraph.ParseTarget decodes link
-// destinations (e.g. `my%20file.md` → `my file.md`), so the user-
-// supplied query must do the same or `mdsmith backlinks
-// docs/my%20file.md` would silently match nothing.
-func TestNormalizeWorkspacePath_PercentEncoded(t *testing.T) {
-	assert.Equal(t, "docs/my file.md",
-		normalizeWorkspacePath("docs/my%20file.md"))
 }
 
 func TestSourceMatches(t *testing.T) {

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -196,7 +196,7 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 	root, files := setupCollectBacklinksFixture(t)
 
 	t.Run("three sources, no anchor", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, 0, true)
 		require.Empty(t, errs)
 		require.Len(t, got, 3)
 		assert.Equal(t, "docs/index.md", got[0].Source)
@@ -205,20 +205,20 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 	})
 
 	t.Run("anchor scopes to one source", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "authentication", nil, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "authentication", nil, 0, true)
 		require.Empty(t, errs)
 		require.Len(t, got, 1)
 		assert.Equal(t, "docs/sub/guide.md", got[0].Source)
 	})
 
 	t.Run("anchor with no hits returns empty", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, 0, true)
 		assert.Empty(t, errs)
 		assert.Empty(t, got)
 	})
 
 	t.Run("include filter excludes plan/", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, 0, true)
 		require.Empty(t, errs)
 		require.Len(t, got, 2)
 		assert.Equal(t, "docs/index.md", got[0].Source)
@@ -230,7 +230,7 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 		// collectBacklinks captures the error rather than swallowing.
 		bad := filepath.Join(root, "does-not-exist.md")
 		filesWithBad := append([]string{bad}, files...)
-		got, errs := collectBacklinks(filesWithBad, root, "docs/api.md", "", nil, 0)
+		got, errs := collectBacklinks(filesWithBad, root, "docs/api.md", "", nil, 0, true)
 		// The other files still contribute results.
 		assert.NotEmpty(t, got)
 		require.Len(t, errs, 1)
@@ -246,11 +246,38 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 		require.NoError(t, os.WriteFile(anchorOnly,
 			[]byte("# Intro\n\nJump to [section](#section).\n\n## Section\n"), 0o644))
 		filesWithAnchor := append([]string{anchorOnly}, files...)
-		got, errs := collectBacklinks(filesWithAnchor, root, "docs/api.md", "", nil, 0)
+		got, errs := collectBacklinks(filesWithAnchor, root, "docs/api.md", "", nil, 0, true)
 		assert.Empty(t, errs)
 		// Same three matches as before; anchor-only.md contributes nothing.
 		assert.Len(t, got, 3)
 	})
+
+}
+
+// TestCollectBacklinks_FrontMatterStrippingDisabled verifies the
+// stripFrontMatter parameter is honored. When set to false (matching
+// `frontMatter: false` in config), collectBacklinks parses the entire
+// file including its front matter — line numbers stay in raw file
+// coordinates rather than body-relative.
+func TestCollectBacklinks_FrontMatterStrippingDisabled(t *testing.T) {
+	root, files := setupCollectBacklinksFixture(t)
+	fmSrc := filepath.Join(root, "fm-src.md")
+	require.NoError(t, os.WriteFile(fmSrc,
+		[]byte("---\ntitle: x\n---\n# H\n\nSee [api](docs/api.md).\n"), 0o644))
+	filesWithFM := append([]string{fmSrc}, files...)
+	got, errs := collectBacklinks(filesWithFM, root, "docs/api.md", "", nil, 0, false)
+	require.Empty(t, errs)
+	var fmRec *backlinkRecord
+	for i := range got {
+		if got[i].Source == "fm-src.md" {
+			fmRec = &got[i]
+			break
+		}
+	}
+	require.NotNil(t, fmRec)
+	// Front matter spans 3 lines; the link sits on the 6th line.
+	// stripFrontMatter=false → no LineOffset adjustment → 6.
+	assert.Equal(t, 6, fmRec.Line)
 }
 
 func TestValidateIncludePatterns(t *testing.T) {
@@ -281,7 +308,7 @@ func TestCollectBacklinks_SortStable(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"), []byte(body), 0o644))
 
 	files := []string{filepath.Join(root, "src.md"), filepath.Join(root, "target.md")}
-	got, errs := collectBacklinks(files, root, "target.md", "", nil, 0)
+	got, errs := collectBacklinks(files, root, "target.md", "", nil, 0, true)
 	require.Empty(t, errs)
 	require.Len(t, got, 2)
 	assert.Equal(t, "src.md", got[0].Source)

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -70,6 +70,33 @@ func TestNormalizeWorkspacePath(t *testing.T) {
 	assert.Equal(t, "docs/api.md", normalizeWorkspacePath(abs, root))
 }
 
+// TestNormalizeWorkspacePath_FileNameStartsWithTwoDots guards against
+// the prefix-check bug: a legitimate workspace file like `..foo.md`
+// (whose relative path starts with two dots without a separator)
+// must not be misclassified as a parent-directory traversal.
+func TestNormalizeWorkspacePath_FileNameStartsWithTwoDots(t *testing.T) {
+	root := t.TempDir()
+	abs := filepath.Join(root, "..foo.md")
+	got := normalizeWorkspacePath(abs, root)
+	assert.Equal(t, "..foo.md", got,
+		"file name beginning with two dots must still be treated as in-workspace")
+}
+
+// TestNormalizeWorkspacePath_RealParentTraversalRejected confirms
+// that absolute paths genuinely outside the workspace fall back to
+// the cleaned absolute form (so backlinks against them match nothing).
+func TestNormalizeWorkspacePath_RealParentTraversalRejected(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Dir(root)
+	outside := filepath.Join(parent, "outside.md")
+	got := normalizeWorkspacePath(outside, root)
+	// The path is not made workspace-relative; the cleaned absolute
+	// (forward-slashed) form is returned and won't match any
+	// workspace-internal source path.
+	assert.NotEqual(t, "..outside.md", got)
+	assert.NotEqual(t, "outside.md", got)
+}
+
 func TestSourceMatches(t *testing.T) {
 	assert.True(t, sourceMatches("docs/api.md", nil))
 	assert.True(t, sourceMatches("docs/api.md", []string{"docs/**"}))

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -97,6 +97,18 @@ func TestNormalizeWorkspacePath_RealParentTraversalRejected(t *testing.T) {
 	assert.NotEqual(t, "outside.md", got)
 }
 
+// TestNormalizeWorkspacePath_PercentEncoded verifies that the CLI
+// target accepts percent-encoded path components and decodes them
+// to match link paths. linkgraph.ParseTarget decodes link
+// destinations (e.g. `my%20file.md` → `my file.md`), so the user-
+// supplied query must do the same or `mdsmith backlinks
+// docs/my%20file.md` would silently match nothing.
+func TestNormalizeWorkspacePath_PercentEncoded(t *testing.T) {
+	root := t.TempDir()
+	assert.Equal(t, "docs/my file.md",
+		normalizeWorkspacePath("docs/my%20file.md", root))
+}
+
 func TestSourceMatches(t *testing.T) {
 	assert.True(t, sourceMatches("docs/api.md", nil))
 	assert.True(t, sourceMatches("docs/api.md", []string{"docs/**"}))

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -282,6 +282,25 @@ func TestCollectBacklinks_IgnorePatternsExclude(t *testing.T) {
 	}
 }
 
+// TestCollectBacklinks_SelfLink confirms self-references count as
+// incoming edges. The contract is "every workspace file that links
+// to <target>" — a file that links to itself satisfies that as
+// literally as any other source.
+func TestCollectBacklinks_SelfLink(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	// docs/api.md links to itself via `api.md`.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "api.md"),
+		[]byte("# API\n\nSee [back to top](api.md).\n"), 0o644))
+	files := []string{filepath.Join(root, "docs", "api.md")}
+
+	got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	require.Len(t, got, 1)
+	assert.Equal(t, "docs/api.md", got[0].Source)
+	assert.Equal(t, "api.md", got[0].Target)
+}
+
 // TestCollectBacklinks_FrontMatterStrippingDisabled verifies the
 // stripFrontMatter parameter is honored. When set to false (matching
 // `frontMatter: false` in config), collectBacklinks parses the entire

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -62,39 +62,8 @@ func TestResolveLinkTarget(t *testing.T) {
 }
 
 func TestNormalizeWorkspacePath(t *testing.T) {
-	root := t.TempDir()
-	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("docs/api.md", root))
-	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("./docs/api.md", root))
-	// Absolute path inside root maps to relative.
-	abs := filepath.Join(root, "docs", "api.md")
-	assert.Equal(t, "docs/api.md", normalizeWorkspacePath(abs, root))
-}
-
-// TestNormalizeWorkspacePath_FileNameStartsWithTwoDots guards against
-// the prefix-check bug: a legitimate workspace file like `..foo.md`
-// (whose relative path starts with two dots without a separator)
-// must not be misclassified as a parent-directory traversal.
-func TestNormalizeWorkspacePath_FileNameStartsWithTwoDots(t *testing.T) {
-	root := t.TempDir()
-	abs := filepath.Join(root, "..foo.md")
-	got := normalizeWorkspacePath(abs, root)
-	assert.Equal(t, "..foo.md", got,
-		"file name beginning with two dots must still be treated as in-workspace")
-}
-
-// TestNormalizeWorkspacePath_RealParentTraversalRejected confirms
-// that absolute paths genuinely outside the workspace fall back to
-// the cleaned absolute form (so backlinks against them match nothing).
-func TestNormalizeWorkspacePath_RealParentTraversalRejected(t *testing.T) {
-	root := t.TempDir()
-	parent := filepath.Dir(root)
-	outside := filepath.Join(parent, "outside.md")
-	got := normalizeWorkspacePath(outside, root)
-	// The path is not made workspace-relative; the cleaned absolute
-	// (forward-slashed) form is returned and won't match any
-	// workspace-internal source path.
-	assert.NotEqual(t, "..outside.md", got)
-	assert.NotEqual(t, "outside.md", got)
+	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("docs/api.md"))
+	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("./docs/api.md"))
 }
 
 // TestNormalizeWorkspacePath_PercentEncoded verifies that the CLI
@@ -104,9 +73,8 @@ func TestNormalizeWorkspacePath_RealParentTraversalRejected(t *testing.T) {
 // supplied query must do the same or `mdsmith backlinks
 // docs/my%20file.md` would silently match nothing.
 func TestNormalizeWorkspacePath_PercentEncoded(t *testing.T) {
-	root := t.TempDir()
 	assert.Equal(t, "docs/my file.md",
-		normalizeWorkspacePath("docs/my%20file.md", root))
+		normalizeWorkspacePath("docs/my%20file.md"))
 }
 
 func TestSourceMatches(t *testing.T) {

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -124,11 +124,12 @@ func TestEmitBacklinks_UnknownFormat(t *testing.T) {
 	assert.Equal(t, 2, code)
 }
 
-// TestCollectBacklinks_End2End covers the path/anchor combinations the
-// plan's acceptance criteria call out: three sources, anchor scoping,
-// include filter, limit.
-func TestCollectBacklinks_End2End(t *testing.T) {
-	root := t.TempDir()
+// setupCollectBacklinksFixture creates a small workspace with three
+// distinct sources linking to docs/api.md so the end-to-end tests can
+// share one filesystem layout.
+func setupCollectBacklinksFixture(t *testing.T) (root string, files []string) {
+	t.Helper()
+	root = t.TempDir()
 	mkdir := func(rel string) {
 		require.NoError(t, os.MkdirAll(filepath.Join(root, rel), 0o755))
 	}
@@ -145,16 +146,25 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 	// File that does NOT link to api.md.
 	write("docs/changelog.md", "# Changelog\n\n[plan](../plan/045_api-overhaul.md)\n")
 
-	files := []string{
+	files = []string{
 		filepath.Join(root, "docs/api.md"),
 		filepath.Join(root, "docs/changelog.md"),
 		filepath.Join(root, "docs/index.md"),
 		filepath.Join(root, "docs/sub/guide.md"),
 		filepath.Join(root, "plan/045_api-overhaul.md"),
 	}
+	return root, files
+}
+
+// TestCollectBacklinks_End2End covers the path/anchor combinations the
+// plan's acceptance criteria call out: three sources, anchor scoping,
+// include filter, limit.
+func TestCollectBacklinks_End2End(t *testing.T) {
+	root, files := setupCollectBacklinksFixture(t)
 
 	t.Run("three sources, no anchor", func(t *testing.T) {
-		got := collectBacklinks(files, root, "docs/api.md", "", nil, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, 0)
+		require.Empty(t, errs)
 		require.Len(t, got, 3)
 		assert.Equal(t, "docs/index.md", got[0].Source)
 		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
@@ -162,20 +172,83 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 	})
 
 	t.Run("anchor scopes to one source", func(t *testing.T) {
-		got := collectBacklinks(files, root, "docs/api.md", "authentication", nil, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "authentication", nil, 0)
+		require.Empty(t, errs)
 		require.Len(t, got, 1)
 		assert.Equal(t, "docs/sub/guide.md", got[0].Source)
 	})
 
 	t.Run("anchor with no hits returns empty", func(t *testing.T) {
-		got := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, 0)
+		assert.Empty(t, errs)
 		assert.Empty(t, got)
 	})
 
 	t.Run("include filter excludes plan/", func(t *testing.T) {
-		got := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, 0)
+		got, errs := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, 0)
+		require.Empty(t, errs)
 		require.Len(t, got, 2)
 		assert.Equal(t, "docs/index.md", got[0].Source)
 		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
 	})
+
+	t.Run("unreadable source surfaces as error", func(t *testing.T) {
+		// A path that does not exist on disk: ReadFileLimited fails;
+		// collectBacklinks captures the error rather than swallowing.
+		bad := filepath.Join(root, "does-not-exist.md")
+		filesWithBad := append([]string{bad}, files...)
+		got, errs := collectBacklinks(filesWithBad, root, "docs/api.md", "", nil, 0)
+		// The other files still contribute results.
+		assert.NotEmpty(t, got)
+		require.Len(t, errs, 1)
+		assert.Contains(t, errs[0].Error(), "does-not-exist.md")
+	})
+}
+
+func TestValidateIncludePatterns(t *testing.T) {
+	assert.NoError(t, validateIncludePatterns(nil))
+	assert.NoError(t, validateIncludePatterns([]string{"docs/**", "plan/*.md"}))
+	// `[` opens a character class that's never closed; doublestar
+	// would silently mismatch every path, so we reject it upfront.
+	err := validateIncludePatterns([]string{"["})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --include glob")
+}
+
+func TestWorkspaceRelativePath_EmptyRootDir(t *testing.T) {
+	// When rootDir is empty, the helper just strips a leading "./"
+	// and forwards the path through.
+	assert.Equal(t, "docs/api.md", workspaceRelativePath("./docs/api.md", ""))
+	assert.Equal(t, "docs/api.md", workspaceRelativePath("docs/api.md", ""))
+}
+
+// TestCollectBacklinks_SortStable verifies that two records from the
+// same source file are returned in line order (the secondary key in
+// the SliceStable comparator).
+func TestCollectBacklinks_SortStable(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "target.md"), []byte("# T\n"), 0o644))
+	// Two links to target.md from the SAME source: line 3 and line 5.
+	body := "# Src\n\nFirst [a](target.md), and\n\nsecond [b](target.md).\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"), []byte(body), 0o644))
+
+	files := []string{filepath.Join(root, "src.md"), filepath.Join(root, "target.md")}
+	got, errs := collectBacklinks(files, root, "target.md", "", nil, 0)
+	require.Empty(t, errs)
+	require.Len(t, got, 2)
+	assert.Equal(t, "src.md", got[0].Source)
+	assert.Equal(t, "src.md", got[1].Source)
+	assert.Less(t, got[0].Line, got[1].Line, "same-source records sort by line")
+}
+
+func TestEmitBacklinks_LimitZeroNoCap(t *testing.T) {
+	// limit=0 means "no cap" — every record is emitted.
+	records := make([]backlinkRecord, 5)
+	for i := range records {
+		records[i] = backlinkRecord{Source: "a.md", Line: i + 1}
+	}
+	var buf bytes.Buffer
+	code := emitBacklinks(&buf, records, "text", 0)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 5, strings.Count(buf.String(), "\n"))
 }

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +47,11 @@ func TestResolveLinkTarget(t *testing.T) {
 		{"escapes root", "docs/api.md", "../../etc/passwd", ""},
 		{"absolute link", "docs/api.md", "/etc/passwd", ""},
 		{"absolute source", "/abs/docs/api.md", "guide.md", ""},
+		// Windows-style absolutes — path.IsAbs alone misses these.
+		{"drive letter link", "docs/api.md", "C:/Windows/system.md", ""},
+		{"drive letter source", "C:/docs/api.md", "guide.md", ""},
+		{"UNC link", "docs/api.md", "//server/share/file.md", ""},
+		{"UNC source", "//server/share/api.md", "guide.md", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -203,6 +209,21 @@ func TestCollectBacklinks_End2End(t *testing.T) {
 		require.Len(t, errs, 1)
 		assert.Contains(t, errs[0].Error(), "does-not-exist.md")
 	})
+
+	t.Run("local-anchor links are skipped", func(t *testing.T) {
+		// Source contains only a same-file anchor link, no cross-file
+		// reference to the target. linkgraph yields a LocalAnchor=true
+		// link; collectBacklinks must skip it without trying to
+		// resolve a path target.
+		anchorOnly := filepath.Join(root, "anchor-only.md")
+		require.NoError(t, os.WriteFile(anchorOnly,
+			[]byte("# Intro\n\nJump to [section](#section).\n\n## Section\n"), 0o644))
+		filesWithAnchor := append([]string{anchorOnly}, files...)
+		got, errs := collectBacklinks(filesWithAnchor, root, "docs/api.md", "", nil, 0)
+		assert.Empty(t, errs)
+		// Same three matches as before; anchor-only.md contributes nothing.
+		assert.Len(t, got, 3)
+	})
 }
 
 func TestValidateIncludePatterns(t *testing.T) {
@@ -251,4 +272,23 @@ func TestEmitBacklinks_LimitZeroNoCap(t *testing.T) {
 	code := emitBacklinks(&buf, records, "text", 0)
 	assert.Equal(t, 0, code)
 	assert.Equal(t, 5, strings.Count(buf.String(), "\n"))
+}
+
+// failingWriter is an io.Writer that returns an error on every Write
+// so tests can exercise emitBacklinks' write-error branches.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("simulated write failure")
+}
+
+func TestEmitBacklinks_TextWriteError(t *testing.T) {
+	records := []backlinkRecord{{Source: "a.md", Line: 1, Text: "t", Target: "x.md"}}
+	code := emitBacklinks(failingWriter{}, records, "text", 0)
+	assert.Equal(t, 2, code)
+}
+
+func TestEmitBacklinks_JSONWriteError(t *testing.T) {
+	code := emitBacklinks(failingWriter{}, []backlinkRecord{{Source: "a.md", Line: 1}}, "json", 0)
+	assert.Equal(t, 2, code)
 }

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -262,6 +262,26 @@ func TestE2E_Backlinks_EncodedEscapeRejected(t *testing.T) {
 	}
 }
 
+// TestE2E_Backlinks_MalformedTargetRejected ensures inputs the link
+// parser cannot decode (malformed percent escapes, query-only URLs,
+// schemed URLs) fail loudly with exit 2 instead of silently producing
+// an empty result.
+func TestE2E_Backlinks_MalformedTargetRejected(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	cases := []string{
+		"docs/my%ZZfile.md", // %ZZ is not a valid percent-escape
+		"?q=1",              // query-only, no path
+		"https://example.com/x.md",
+	}
+	for _, target := range cases {
+		t.Run(target, func(t *testing.T) {
+			_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", target)
+			require.Equal(t, 2, exitCode)
+			assert.Contains(t, stderr, "invalid target")
+		})
+	}
+}
+
 func TestE2E_Backlinks_RespectsIgnore(t *testing.T) {
 	// Sources matched by `ignore:` patterns must not contribute
 	// backlinks, mirroring `check` / `fix` behavior.

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -135,6 +135,17 @@ func TestE2E_Backlinks_AnchorOnlyTarget_ExitsTwo(t *testing.T) {
 	assert.Contains(t, stderr, "target must include a file path")
 }
 
+func TestE2E_Backlinks_NegativeLimit_ExitsTwo(t *testing.T) {
+	// --limit is documented as `0 = no cap`; negative values would
+	// otherwise be silently treated as "no cap" because emitBacklinks
+	// only caps when limit > 0. Reject upfront.
+	dir := setupBacklinksWorkspace(t)
+	_, stderr, exitCode := runBinaryInDir(
+		t, dir, "", "backlinks", "--limit", "-1", "docs/api.md")
+	require.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "--limit must be >= 0")
+}
+
 func TestE2E_Backlinks_InvalidMaxInputSize_ExitsTwo(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
 	_, stderr, exitCode := runBinaryInDir(

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -1,0 +1,115 @@
+package main_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// backlinkRecordE2E mirrors cmd/mdsmith.backlinkRecord with exported
+// JSON keys. Kept local to avoid coupling the test package to the
+// internal struct definition.
+type backlinkRecordE2E struct {
+	Source string `json:"source"`
+	Line   int    `json:"line"`
+	Text   string `json:"text"`
+	Target string `json:"target"`
+}
+
+// setupBacklinksWorkspace creates a minimal workspace with three
+// distinct sources linking to docs/api.md, plus an anchor case.
+func setupBacklinksWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mk := func(rel string) {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, rel), 0o755))
+	}
+	wf := func(rel, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644))
+	}
+	mk("docs/sub")
+	mk("plan")
+	// Mark the temp dir as a project root so config discovery does
+	// not climb out into the repo's own .mdsmith.yml.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	wf(".mdsmith.yml", "files:\n  - \"**/*.md\"\nrules:\n  cross-file-reference-integrity: false\n")
+	wf("docs/api.md", "# API\n\n## Authentication\n\n## Endpoints\n")
+	wf("docs/index.md", "# Index\n\nSee [API reference](api.md).\n")
+	wf("docs/sub/guide.md", "# Guide\n\nUse [api docs](../api.md#authentication).\n")
+	wf("plan/045_api-overhaul.md", "# Plan\n\n[api](../docs/api.md)\n")
+	wf("docs/changelog.md", "# Changelog\n\n[plan](../plan/045_api-overhaul.md)\n")
+	return dir
+}
+
+func TestE2E_Backlinks_ThreeSources_Text(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/api.md")
+	require.Equal(t, 0, exitCode, "expected exit 0 when matches found")
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 3, "expected 3 backlink rows, got: %q", stdout)
+	// Sorted by source path.
+	assert.True(t, strings.HasPrefix(lines[0], "docs/index.md:"))
+	assert.True(t, strings.HasPrefix(lines[1], "docs/sub/guide.md:"))
+	assert.True(t, strings.HasPrefix(lines[2], "plan/045_api-overhaul.md:"))
+	assert.Contains(t, lines[0], "[API reference](api.md)")
+}
+
+func TestE2E_Backlinks_Anchor_Filter(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/api.md#authentication")
+	require.Equal(t, 0, exitCode)
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 1, "anchor-scoped query expected to return one row, got: %q", stdout)
+	assert.Contains(t, lines[0], "docs/sub/guide.md")
+}
+
+func TestE2E_Backlinks_Anchor_NoHits_ExitsOne(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/api.md#no-such-section")
+	require.Equal(t, 1, exitCode, "no matches → exit 1")
+	assert.Empty(t, strings.TrimSpace(stdout))
+}
+
+func TestE2E_Backlinks_JSON_Shape(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "--format", "json", "docs/api.md")
+	require.Equal(t, 0, exitCode)
+	var got []backlinkRecordE2E
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	require.Len(t, got, 3)
+	// Stable shape per docs/reference/cli/backlinks.md.
+	assert.Equal(t, "docs/index.md", got[0].Source)
+	assert.Equal(t, "API reference", got[0].Text)
+	assert.Equal(t, "api.md", got[0].Target)
+	assert.Greater(t, got[0].Line, 0)
+}
+
+func TestE2E_Backlinks_IncludeAndLimit(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	// --include docs/** filters out the plan/ source; --limit 1
+	// then caps the remaining two rows.
+	stdout, _, exitCode := runBinaryInDir(
+		t, dir, "", "backlinks", "--include", "docs/**", "--limit", "1", "docs/api.md")
+	require.Equal(t, 0, exitCode)
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 1, "include + limit: expected 1 row, got: %q", stdout)
+	assert.Contains(t, lines[0], "docs/index.md")
+	assert.NotContains(t, stdout, "plan/")
+}
+
+func TestE2E_Backlinks_NoTarget_ExitsTwo(t *testing.T) {
+	_, stderr, exitCode := runBinary(t, "", "backlinks")
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "requires a target file argument")
+}
+
+func TestE2E_Backlinks_HelpFlag(t *testing.T) {
+	_, stderr, exitCode := runBinary(t, "", "backlinks", "--help")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "Usage: mdsmith backlinks")
+}

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -223,6 +223,47 @@ func TestE2E_Backlinks_DiscoveryEmpty_ExitsOne(t *testing.T) {
 	require.Equal(t, 1, exitCode)
 }
 
+func TestE2E_Backlinks_AbsoluteTarget_ExitsTwo(t *testing.T) {
+	// `<target>` is documented as workspace-relative. An absolute path
+	// would otherwise normalize to a path outside the workspace and
+	// silently match nothing, indistinguishable from a real empty
+	// result. Reject upfront.
+	dir := setupBacklinksWorkspace(t)
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", "/etc/passwd")
+	require.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "must be workspace-relative")
+}
+
+func TestE2E_Backlinks_ParentTraversalTarget_ExitsTwo(t *testing.T) {
+	// Same justification: `../foo.md` resolves outside the workspace
+	// and would silently match nothing.
+	dir := setupBacklinksWorkspace(t)
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", "../foo.md")
+	require.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "must be workspace-relative")
+}
+
+func TestE2E_Backlinks_RespectsIgnore(t *testing.T) {
+	// Sources matched by `ignore:` patterns must not contribute
+	// backlinks, mirroring `check` / `fix` behavior.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "vendor"), 0o755))
+	cfg := "files:\n  - \"**/*.md\"\nignore:\n  - \"vendor/**\"\n" +
+		"rules:\n  cross-file-reference-integrity: false\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "target.md"), []byte("# Target\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.md"),
+		[]byte("# Src\n\n[ok](target.md)\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor", "lib.md"),
+		[]byte("# Vendor\n\n[skip](../target.md)\n"), 0o644))
+
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "target.md")
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "src.md:")
+	assert.NotContains(t, stdout, "vendor/", "ignored sources must not appear in backlinks output")
+}
+
 func TestE2E_Backlinks_FrontMatterLines_FileRelative(t *testing.T) {
 	// Regression for the body-vs-file-relative line bug: when the
 	// source file has front matter, the backlinks CLI must show the

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -243,6 +243,25 @@ func TestE2E_Backlinks_ParentTraversalTarget_ExitsTwo(t *testing.T) {
 	assert.Contains(t, stderr, "must be workspace-relative")
 }
 
+// TestE2E_Backlinks_EncodedEscapeRejected guards against a bypass of
+// the workspace-relative target contract: `%2Fetc%2Fpasswd` decodes
+// to `/etc/passwd` and `%2e%2e/foo.md` to `../foo.md`, both of which
+// must be rejected with exit 2.
+func TestE2E_Backlinks_EncodedEscapeRejected(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	cases := []string{
+		"%2Fetc%2Fpasswd",
+		"%2e%2e/foo.md",
+	}
+	for _, target := range cases {
+		t.Run(target, func(t *testing.T) {
+			_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", target)
+			require.Equal(t, 2, exitCode)
+			assert.Contains(t, stderr, "must be workspace-relative")
+		})
+	}
+}
+
 func TestE2E_Backlinks_RespectsIgnore(t *testing.T) {
 	// Sources matched by `ignore:` patterns must not contribute
 	// backlinks, mirroring `check` / `fix` behavior.

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -48,7 +48,7 @@ func setupBacklinksWorkspace(t *testing.T) string {
 
 func TestE2E_Backlinks_ThreeSources_Text(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/api.md")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "docs/api.md")
 	require.Equal(t, 0, exitCode, "expected exit 0 when matches found")
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 	require.Len(t, lines, 3, "expected 3 backlink rows, got: %q", stdout)
@@ -61,7 +61,7 @@ func TestE2E_Backlinks_ThreeSources_Text(t *testing.T) {
 
 func TestE2E_Backlinks_Anchor_Filter(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/api.md#authentication")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "docs/api.md#authentication")
 	require.Equal(t, 0, exitCode)
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 	require.Len(t, lines, 1, "anchor-scoped query expected to return one row, got: %q", stdout)
@@ -70,14 +70,14 @@ func TestE2E_Backlinks_Anchor_Filter(t *testing.T) {
 
 func TestE2E_Backlinks_Anchor_NoHits_ExitsOne(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/api.md#no-such-section")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "docs/api.md#no-such-section")
 	require.Equal(t, 1, exitCode, "no matches → exit 1")
 	assert.Empty(t, strings.TrimSpace(stdout))
 }
 
 func TestE2E_Backlinks_JSON_Shape(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "--format", "json", "docs/api.md")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "--format", "json", "docs/api.md")
 	require.Equal(t, 0, exitCode)
 	var got []backlinkRecordE2E
 	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
@@ -94,7 +94,7 @@ func TestE2E_Backlinks_IncludeAndLimit(t *testing.T) {
 	// --include docs/** filters out the plan/ source; --limit 1
 	// then caps the remaining two rows.
 	stdout, _, exitCode := runBinaryInDir(
-		t, dir, "", "backlinks", "--include", "docs/**", "--limit", "1", "docs/api.md")
+		t, dir, "", "list", "backlinks", "--include", "docs/**", "--limit", "1", "docs/api.md")
 	require.Equal(t, 0, exitCode)
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 	require.Len(t, lines, 1, "include + limit: expected 1 row, got: %q", stdout)
@@ -103,34 +103,34 @@ func TestE2E_Backlinks_IncludeAndLimit(t *testing.T) {
 }
 
 func TestE2E_Backlinks_NoTarget_ExitsTwo(t *testing.T) {
-	_, stderr, exitCode := runBinary(t, "", "backlinks")
+	_, stderr, exitCode := runBinary(t, "", "list", "backlinks")
 	assert.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "requires a target file argument")
 }
 
 func TestE2E_Backlinks_HelpFlag(t *testing.T) {
-	_, stderr, exitCode := runBinary(t, "", "backlinks", "--help")
+	_, stderr, exitCode := runBinary(t, "", "list", "backlinks", "--help")
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stderr, "Usage: mdsmith backlinks")
+	assert.Contains(t, stderr, "Usage: mdsmith list backlinks")
 }
 
 func TestE2E_Backlinks_InvalidIncludeGlob_ExitsTwo(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
 	_, stderr, exitCode := runBinaryInDir(
-		t, dir, "", "backlinks", "--include", "[", "docs/api.md")
+		t, dir, "", "list", "backlinks", "--include", "[", "docs/api.md")
 	require.Equal(t, 2, exitCode, "invalid glob must exit 2, not silently match nothing")
 	assert.Contains(t, stderr, "invalid --include glob")
 }
 
 func TestE2E_Backlinks_TooManyArgs_ExitsTwo(t *testing.T) {
-	_, stderr, exitCode := runBinary(t, "", "backlinks", "a.md", "b.md")
+	_, stderr, exitCode := runBinary(t, "", "list", "backlinks", "a.md", "b.md")
 	require.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "takes one target argument")
 }
 
 func TestE2E_Backlinks_AnchorOnlyTarget_ExitsTwo(t *testing.T) {
 	// "#anchor" alone has no file path; backlinks always require one.
-	_, stderr, exitCode := runBinary(t, "", "backlinks", "#anchor-only")
+	_, stderr, exitCode := runBinary(t, "", "list", "backlinks", "#anchor-only")
 	require.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "target must include a file path")
 }
@@ -141,7 +141,7 @@ func TestE2E_Backlinks_NegativeLimit_ExitsTwo(t *testing.T) {
 	// only caps when limit > 0. Reject upfront.
 	dir := setupBacklinksWorkspace(t)
 	_, stderr, exitCode := runBinaryInDir(
-		t, dir, "", "backlinks", "--limit", "-1", "docs/api.md")
+		t, dir, "", "list", "backlinks", "--limit", "-1", "docs/api.md")
 	require.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "--limit must be >= 0")
 }
@@ -149,7 +149,7 @@ func TestE2E_Backlinks_NegativeLimit_ExitsTwo(t *testing.T) {
 func TestE2E_Backlinks_InvalidMaxInputSize_ExitsTwo(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
 	_, stderr, exitCode := runBinaryInDir(
-		t, dir, "", "backlinks", "--max-input-size", "garbage", "docs/api.md")
+		t, dir, "", "list", "backlinks", "--max-input-size", "garbage", "docs/api.md")
 	require.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "max-input-size")
 }
@@ -158,7 +158,7 @@ func TestE2E_Backlinks_JSON_EmptyResult(t *testing.T) {
 	dir := setupBacklinksWorkspace(t)
 	// A target that exists but has no incoming links.
 	stdout, _, exitCode := runBinaryInDir(
-		t, dir, "", "backlinks", "--format", "json", "docs/changelog.md")
+		t, dir, "", "list", "backlinks", "--format", "json", "docs/changelog.md")
 	require.Equal(t, 1, exitCode, "no matches → exit 1")
 	// Stable shape: `[]`, never `null`.
 	assert.Contains(t, stdout, "[]")
@@ -180,7 +180,7 @@ func TestE2E_Backlinks_UnreadableSource_ExitsTwo(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "target.md"), []byte("# Target\n"), 0o644))
 
 	_, stderr, exitCode := runBinaryInDir(
-		t, dir, "", "backlinks", "--max-input-size", "10", "target.md")
+		t, dir, "", "list", "backlinks", "--max-input-size", "10", "target.md")
 	require.Equal(t, 2, exitCode, "unreadable sources → runtime error → exit 2")
 	assert.Contains(t, stderr, "reading src.md")
 }
@@ -202,11 +202,11 @@ func TestE2E_Backlinks_PercentEncodedTarget(t *testing.T) {
 		[]byte("# Src\n\nSee [it](docs/my%20file.md).\n"), 0o644))
 
 	// Encoded query form.
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/my%20file.md")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "docs/my%20file.md")
 	require.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "src.md:")
 	// Decoded query form must also match.
-	stdout, _, exitCode = runBinaryInDir(t, dir, "", "backlinks", "docs/my file.md")
+	stdout, _, exitCode = runBinaryInDir(t, dir, "", "list", "backlinks", "docs/my file.md")
 	require.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "src.md:")
 }
@@ -219,7 +219,7 @@ func TestE2E_Backlinks_DiscoveryEmpty_ExitsOne(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
 		[]byte("files:\n  - \"no-such-pattern/**/*.md\"\nrules: {}\n"), 0o644))
 
-	_, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "target.md")
+	_, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "target.md")
 	require.Equal(t, 1, exitCode)
 }
 
@@ -229,7 +229,7 @@ func TestE2E_Backlinks_AbsoluteTarget_ExitsTwo(t *testing.T) {
 	// silently match nothing, indistinguishable from a real empty
 	// result. Reject upfront.
 	dir := setupBacklinksWorkspace(t)
-	_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", "/etc/passwd")
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "/etc/passwd")
 	require.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "must be workspace-relative")
 }
@@ -238,7 +238,7 @@ func TestE2E_Backlinks_ParentTraversalTarget_ExitsTwo(t *testing.T) {
 	// Same justification: `../foo.md` resolves outside the workspace
 	// and would silently match nothing.
 	dir := setupBacklinksWorkspace(t)
-	_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", "../foo.md")
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "../foo.md")
 	require.Equal(t, 2, exitCode)
 	assert.Contains(t, stderr, "must be workspace-relative")
 }
@@ -255,7 +255,7 @@ func TestE2E_Backlinks_EncodedEscapeRejected(t *testing.T) {
 	}
 	for _, target := range cases {
 		t.Run(target, func(t *testing.T) {
-			_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", target)
+			_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", target)
 			require.Equal(t, 2, exitCode)
 			assert.Contains(t, stderr, "must be workspace-relative")
 		})
@@ -275,7 +275,7 @@ func TestE2E_Backlinks_MalformedTargetRejected(t *testing.T) {
 	}
 	for _, target := range cases {
 		t.Run(target, func(t *testing.T) {
-			_, stderr, exitCode := runBinaryInDir(t, dir, "", "backlinks", target)
+			_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", target)
 			require.Equal(t, 2, exitCode)
 			assert.Contains(t, stderr, "invalid target")
 		})
@@ -297,7 +297,7 @@ func TestE2E_Backlinks_RespectsIgnore(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor", "lib.md"),
 		[]byte("# Vendor\n\n[skip](../target.md)\n"), 0o644))
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "target.md")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "target.md")
 	require.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "src.md:")
 	assert.NotContains(t, stdout, "vendor/", "ignored sources must not appear in backlinks output")
@@ -317,7 +317,7 @@ func TestE2E_Backlinks_FrontMatterLines_FileRelative(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.md"),
 		[]byte("---\ntitle: src\n---\n# Src\n\nSee [it](target.md).\n"), 0o644))
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "target.md")
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "backlinks", "target.md")
 	require.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "src.md:6:")
 }

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -185,6 +185,32 @@ func TestE2E_Backlinks_UnreadableSource_ExitsTwo(t *testing.T) {
 	assert.Contains(t, stderr, "reading src.md")
 }
 
+func TestE2E_Backlinks_PercentEncodedTarget(t *testing.T) {
+	// A workspace file with a space in its name, linked to via
+	// `%20` from another source. linkgraph.ParseTarget decodes the
+	// link destination to `my file.md`, so the CLI target must also
+	// decode to match — otherwise `backlinks docs/my%20file.md`
+	// silently returns nothing.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("files:\n  - \"**/*.md\"\nrules:\n  cross-file-reference-integrity: false\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "docs", "my file.md"),
+		[]byte("# Target\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.md"),
+		[]byte("# Src\n\nSee [it](docs/my%20file.md).\n"), 0o644))
+
+	// Encoded query form.
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "docs/my%20file.md")
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "src.md:")
+	// Decoded query form must also match.
+	stdout, _, exitCode = runBinaryInDir(t, dir, "", "backlinks", "docs/my file.md")
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "src.md:")
+}
+
 func TestE2E_Backlinks_DiscoveryEmpty_ExitsOne(t *testing.T) {
 	// A workspace whose `files:` glob matches nothing should exit 1
 	// (no backlinks found) rather than crash.

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -113,3 +113,62 @@ func TestE2E_Backlinks_HelpFlag(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stderr, "Usage: mdsmith backlinks")
 }
+
+func TestE2E_Backlinks_InvalidIncludeGlob_ExitsTwo(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	_, stderr, exitCode := runBinaryInDir(
+		t, dir, "", "backlinks", "--include", "[", "docs/api.md")
+	require.Equal(t, 2, exitCode, "invalid glob must exit 2, not silently match nothing")
+	assert.Contains(t, stderr, "invalid --include glob")
+}
+
+func TestE2E_Backlinks_TooManyArgs_ExitsTwo(t *testing.T) {
+	_, stderr, exitCode := runBinary(t, "", "backlinks", "a.md", "b.md")
+	require.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "takes one target argument")
+}
+
+func TestE2E_Backlinks_AnchorOnlyTarget_ExitsTwo(t *testing.T) {
+	// "#anchor" alone has no file path; backlinks always require one.
+	_, stderr, exitCode := runBinary(t, "", "backlinks", "#anchor-only")
+	require.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "target must include a file path")
+}
+
+func TestE2E_Backlinks_InvalidMaxInputSize_ExitsTwo(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	_, stderr, exitCode := runBinaryInDir(
+		t, dir, "", "backlinks", "--max-input-size", "garbage", "docs/api.md")
+	require.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "max-input-size")
+}
+
+func TestE2E_Backlinks_JSON_EmptyResult(t *testing.T) {
+	dir := setupBacklinksWorkspace(t)
+	// A target that exists but has no incoming links.
+	stdout, _, exitCode := runBinaryInDir(
+		t, dir, "", "backlinks", "--format", "json", "docs/changelog.md")
+	require.Equal(t, 1, exitCode, "no matches → exit 1")
+	// Stable shape: `[]`, never `null`.
+	assert.Contains(t, stdout, "[]")
+	assert.NotContains(t, stdout, "null")
+}
+
+func TestE2E_Backlinks_FrontMatterLines_FileRelative(t *testing.T) {
+	// Regression for the body-vs-file-relative line bug: when the
+	// source file has front matter, the backlinks CLI must show the
+	// file-relative line number, not the body-relative one.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("files:\n  - \"**/*.md\"\nrules:\n  cross-file-reference-integrity: false\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "target.md"),
+		[]byte("# Target\n"), 0o644))
+	// 3 lines of front matter, blank, heading, blank, link → line 6.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.md"),
+		[]byte("---\ntitle: src\n---\n# Src\n\nSee [it](target.md).\n"), 0o644))
+
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "target.md")
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "src.md:6:")
+}

--- a/cmd/mdsmith/e2e_backlinks_test.go
+++ b/cmd/mdsmith/e2e_backlinks_test.go
@@ -154,6 +154,38 @@ func TestE2E_Backlinks_JSON_EmptyResult(t *testing.T) {
 	assert.NotContains(t, stdout, "null")
 }
 
+func TestE2E_Backlinks_UnreadableSource_ExitsTwo(t *testing.T) {
+	// When every source file is too large to read, collectBacklinks
+	// reports an error per file and emits no records. Per the doc'd
+	// precedence (records → 0, runtime err → 2, clean empty → 1) the
+	// exit code must be 2, not 1.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("files:\n  - \"**/*.md\"\nrules:\n  cross-file-reference-integrity: false\n"), 0o644))
+	// 200 bytes of body — comfortably larger than the 10-byte cap.
+	src := "# Src\n\n[ref](target.md) " + strings.Repeat("x", 200) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.md"), []byte(src), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "target.md"), []byte("# Target\n"), 0o644))
+
+	_, stderr, exitCode := runBinaryInDir(
+		t, dir, "", "backlinks", "--max-input-size", "10", "target.md")
+	require.Equal(t, 2, exitCode, "unreadable sources → runtime error → exit 2")
+	assert.Contains(t, stderr, "reading src.md")
+}
+
+func TestE2E_Backlinks_DiscoveryEmpty_ExitsOne(t *testing.T) {
+	// A workspace whose `files:` glob matches nothing should exit 1
+	// (no backlinks found) rather than crash.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("files:\n  - \"no-such-pattern/**/*.md\"\nrules: {}\n"), 0o644))
+
+	_, _, exitCode := runBinaryInDir(t, dir, "", "backlinks", "target.md")
+	require.Equal(t, 1, exitCode)
+}
+
 func TestE2E_Backlinks_FrontMatterLines_FileRelative(t *testing.T) {
 	// Regression for the body-vs-file-relative line bug: when the
 	// source file has front matter, the backlinks CLI must show the

--- a/cmd/mdsmith/e2e_coverage_test.go
+++ b/cmd/mdsmith/e2e_coverage_test.go
@@ -22,7 +22,7 @@ func TestE2E_Query_Verbose_ExpressionNotSatisfied(t *testing.T) {
 
 	// Pass the file explicitly (not the dir) to avoid gitignore filtering.
 	missPath := filepath.Join(dir, "miss.md")
-	_, stderr, exitCode := runBinaryInDir(t, dir, "", "query", "-v", `status: "✅"`, missPath)
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "query", "-v", `status: "✅"`, missPath)
 	assert.Equal(t, 1, exitCode, "expected exit 1 when no files match")
 	assert.Contains(t, stderr, "expression not satisfied",
 		"expected 'expression not satisfied' in verbose stderr, got: %s", stderr)
@@ -427,7 +427,8 @@ func TestE2E_Query_Verbose_MixedResults(t *testing.T) {
 	matchPath := filepath.Join(dir, "match.md")
 	missPath := filepath.Join(dir, "miss.md")
 	plainPath := filepath.Join(dir, "plain.md")
-	stdout, stderr, exitCode := runBinaryInDir(t, dir, "", "query", "-v", `status: "✅"`, matchPath, missPath, plainPath)
+	stdout, stderr, exitCode := runBinaryInDir(
+		t, dir, "", "list", "query", "-v", `status: "✅"`, matchPath, missPath, plainPath)
 	assert.Equal(t, 0, exitCode, "expected exit 0 (at least one match)")
 	assert.Contains(t, stdout, "match.md", "expected match.md in stdout")
 	assert.Contains(t, stderr, "expression not satisfied",

--- a/cmd/mdsmith/e2e_query_test.go
+++ b/cmd/mdsmith/e2e_query_test.go
@@ -15,7 +15,7 @@ func TestE2E_Query_Match_ExitsZero(t *testing.T) {
 	writeFixture(t, dir, "a.md", "---\nstatus: \"✅\"\nid: 1\n---\n# Done\n\nContent here.\n")
 	writeFixture(t, dir, "b.md", "---\nstatus: \"🔲\"\nid: 2\n---\n# Todo\n\nContent here.\n")
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`, dir)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`, dir)
 	assert.Equal(t, 0, exitCode, "expected exit 0 on match")
 	assert.Contains(t, stdout, "a.md")
 	assert.NotContains(t, stdout, "b.md")
@@ -25,7 +25,7 @@ func TestE2E_Query_NoMatch_ExitsOne(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "a.md", "---\nstatus: \"🔲\"\n---\n# Todo\n\nContent here.\n")
 
-	_, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`, dir)
+	_, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`, dir)
 	assert.Equal(t, 1, exitCode, "expected exit 1 when no files match")
 }
 
@@ -33,7 +33,7 @@ func TestE2E_Query_InvalidCUE_ExitsTwo(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "a.md", "---\nstatus: \"✅\"\n---\n# Title\n\nContent here.\n")
 
-	_, stderr, exitCode := runBinaryInDir(t, dir, "", "query", `status: [[[`, dir)
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: [[[`, dir)
 	assert.Equal(t, 2, exitCode, "expected exit 2 for invalid CUE")
 	assert.Contains(t, stderr, "invalid CUE expression")
 }
@@ -43,7 +43,7 @@ func TestE2E_Query_NulDelimiter(t *testing.T) {
 	writeFixture(t, dir, "a.md", "---\nstatus: \"✅\"\n---\n# Done\n\nContent here.\n")
 	writeFixture(t, dir, "b.md", "---\nstatus: \"✅\"\n---\n# Also done\n\nContent here.\n")
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "query", "-0", `status: "✅"`, dir)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", "-0", `status: "✅"`, dir)
 	assert.Equal(t, 0, exitCode)
 	// NUL-delimited: split by \x00
 	parts := strings.Split(stdout, "\x00")
@@ -62,7 +62,7 @@ func TestE2E_Query_NoFrontMatter_Skipped(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "no-fm.md", "# No front matter\n\nJust content here.\n")
 
-	_, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`, dir)
+	_, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`, dir)
 	assert.Equal(t, 1, exitCode, "expected exit 1 when no files have front matter")
 }
 
@@ -71,12 +71,12 @@ func TestE2E_Query_ProtoSkipped(t *testing.T) {
 	// Proto file has schema strings, not concrete values.
 	writeFixture(t, dir, "proto.md", "---\nstatus: '\"🔲\" | \"🔳\" | \"✅\"'\n---\n# Proto\n\nTemplate.\n")
 
-	_, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`, dir)
+	_, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`, dir)
 	assert.Equal(t, 1, exitCode, "proto template should not match")
 }
 
 func TestE2E_Query_NoArgs_ExitsTwo(t *testing.T) {
-	_, stderr, exitCode := runBinary(t, "", "query")
+	_, stderr, exitCode := runBinary(t, "", "list", "query")
 	assert.Equal(t, 2, exitCode, "expected exit 2 with no args")
 	assert.Contains(t, stderr, "requires a CUE expression")
 }
@@ -85,7 +85,7 @@ func TestE2E_Query_Verbose_ShowsSkipped(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "no-fm.md", "# No front matter\n\nJust content.\n")
 
-	_, stderr, exitCode := runBinaryInDir(t, dir, "", "query", "-v", `status: "✅"`, dir)
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "list", "query", "-v", `status: "✅"`, dir)
 	assert.Equal(t, 1, exitCode)
 	assert.Contains(t, stderr, "no front matter")
 }
@@ -95,7 +95,7 @@ func TestE2E_Query_CompoundExpression(t *testing.T) {
 	writeFixture(t, dir, "a.md", "---\nstatus: \"✅\"\nid: 60\n---\n# High ID\n\nContent here.\n")
 	writeFixture(t, dir, "b.md", "---\nstatus: \"✅\"\nid: 30\n---\n# Low ID\n\nContent here.\n")
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅", id: >50`, dir)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅", id: >50`, dir)
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "a.md")
 	assert.NotContains(t, stdout, "b.md")
@@ -105,7 +105,7 @@ func TestE2E_Query_MultipleFiles_PrintsOnePath(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "match.md", "---\nstatus: \"✅\"\n---\n# Match\n\nContent here.\n")
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`, filepath.Join(dir, "match.md"))
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`, filepath.Join(dir, "match.md"))
 	assert.Equal(t, 0, exitCode)
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 	assert.Len(t, lines, 1, "expected exactly one matching path")
@@ -115,7 +115,7 @@ func TestE2E_Query_EmptyFrontMatter_Skipped(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "empty-fm.md", "---\n---\n# Empty front matter\n\nContent here.\n")
 
-	_, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`, dir)
+	_, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`, dir)
 	assert.Equal(t, 1, exitCode, "empty front matter should not match")
 }
 
@@ -123,15 +123,15 @@ func TestE2E_Query_NoFileArgs_DefaultsCwd(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "a.md", "---\nstatus: \"✅\"\n---\n# Done\n\nContent here.\n")
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "", "query", `status: "✅"`)
+	stdout, _, exitCode := runBinaryInDir(t, dir, "", "list", "query", `status: "✅"`)
 	assert.Equal(t, 0, exitCode, "should discover files from cwd")
 	assert.Contains(t, stdout, "a.md")
 }
 
 func TestE2E_Query_HelpFlag(t *testing.T) {
-	_, stderr, exitCode := runBinary(t, "", "query", "--help")
+	_, stderr, exitCode := runBinary(t, "", "list", "query", "--help")
 	assert.Equal(t, 0, exitCode, "--help is a successful exit per pflag.ErrHelp")
-	assert.Contains(t, stderr, "Usage: mdsmith query")
+	assert.Contains(t, stderr, "Usage: mdsmith list query")
 }
 
 func TestE2E_Query_AnchorFrontMatterSkipped(t *testing.T) {
@@ -140,7 +140,7 @@ func TestE2E_Query_AnchorFrontMatterSkipped(t *testing.T) {
 		"---\nbase: &base\n  status: ok\n---\n# Title\n\nContent here.\n")
 
 	stdout, stderr, exitCode := runBinaryInDir(
-		t, dir, "", "query", "--verbose", `status: "ok"`, dir)
+		t, dir, "", "list", "query", "--verbose", `status: "ok"`, dir)
 	// File with anchor front matter must not match.
 	assert.Equal(t, 1, exitCode, "anchor file should not match")
 	assert.NotContains(t, stdout, "anchor.md")

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1767,7 +1767,7 @@ func TestQuery_MaxInputSize_InvalidValue(t *testing.T) {
 	writeFixture(t, dir, "a.md", "---\nid: 1\n---\n# Hello\n")
 
 	_, stderr, exitCode := runBinaryInDir(t, dir, "",
-		"query", "--max-input-size", "not-a-size", "id: 1", "a.md")
+		"list", "query", "--max-input-size", "not-a-size", "id: 1", "a.md")
 	assert.Equal(t, 2, exitCode, "expected exit code 2 for invalid size")
 	assert.Contains(t, stderr, "invalid max-input-size")
 }

--- a/cmd/mdsmith/list.go
+++ b/cmd/mdsmith/list.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const listUsage = `Usage: mdsmith list <subcommand> [flags] [args]
+
+Subcommands:
+  query <cue-expr>      Select Markdown files whose front matter
+                        satisfies a CUE expression.
+  backlinks <target>    List workspace links that point at a file
+                        (optionally scoped to an anchor).
+
+Run 'mdsmith list <subcommand> --help' for flags and exit codes.
+`
+
+// runList dispatches the list subcommand to its selection-style
+// children (query, backlinks, …). Each child runs an independent walk
+// of the workspace and emits matches in its own shape; the parent is
+// just a router.
+func runList(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, listUsage)
+		return 0
+	}
+	switch args[0] {
+	case "--help", "-h":
+		fmt.Fprint(os.Stderr, listUsage)
+		return 0
+	case "query":
+		return runQuery(args[1:])
+	case "backlinks":
+		return runBacklinks(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: list: unknown subcommand %q\n\n%s",
+			args[0], listUsage)
+		return 2
+	}
+}

--- a/cmd/mdsmith/list_e2e_test.go
+++ b/cmd/mdsmith/list_e2e_test.go
@@ -1,0 +1,29 @@
+package main_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestE2E_List_NoArgs_PrintsUsage(t *testing.T) {
+	_, stderr, exitCode := runBinary(t, "", "list")
+	assert.Equal(t, 0, exitCode, "list with no sub prints usage and exits 0")
+	assert.Contains(t, stderr, "Usage: mdsmith list <subcommand>")
+	assert.Contains(t, stderr, "query")
+	assert.Contains(t, stderr, "backlinks")
+}
+
+func TestE2E_List_HelpFlag(t *testing.T) {
+	_, stderr, exitCode := runBinary(t, "", "list", "--help")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "Usage: mdsmith list <subcommand>")
+}
+
+func TestE2E_List_UnknownSubcommand_ExitsTwo(t *testing.T) {
+	_, stderr, exitCode := runBinary(t, "", "list", "nope")
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "unknown subcommand")
+	// Usage banner accompanies the error for discoverability.
+	assert.Contains(t, stderr, "Usage: mdsmith list <subcommand>")
+}

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -289,13 +289,13 @@ func parseQueryFlags(args []string) (queryOptions, []string, error) {
 func runQuery(args []string) int {
 	opts, posArgs, err := parseQueryFlags(args)
 	if err != nil {
-		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: query"); code >= 0 {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: list query"); code >= 0 {
 			return code
 		}
 	}
 
 	if len(posArgs) == 0 {
-		fmt.Fprintf(os.Stderr, "mdsmith: query requires a CUE expression argument\n")
+		fmt.Fprintf(os.Stderr, "mdsmith: list query requires a CUE expression argument\n")
 		return 2
 	}
 

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -42,6 +42,7 @@ Commands:
   check             Lint Markdown files (default when given file arguments)
   fix               Auto-fix lint issues in place
   query             Select files by CUE expression on front matter
+  backlinks         List workspace links that point at a file
   help              Show help for rules and topics
   metrics           Show and rank shared Markdown metrics
   merge-driver      Git merge driver for regenerable sections
@@ -89,6 +90,8 @@ func run() int {
 		return runFix(os.Args[2:])
 	case "query":
 		return runQuery(os.Args[2:])
+	case "backlinks":
+		return runBacklinks(os.Args[2:])
 	case "help":
 		return runHelp(os.Args[2:])
 	case "metrics":

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -41,8 +41,7 @@ const usageText = `Usage: mdsmith <command> [flags] [files...]
 Commands:
   check             Lint Markdown files (default when given file arguments)
   fix               Auto-fix lint issues in place
-  query             Select files by CUE expression on front matter
-  backlinks         List workspace links that point at a file
+  list              Select files by query (front matter or link graph)
   help              Show help for rules and topics
   metrics           Show and rank shared Markdown metrics
   merge-driver      Git merge driver for regenerable sections
@@ -88,10 +87,8 @@ func run() int {
 		return runCheck(os.Args[2:])
 	case "fix":
 		return runFix(os.Args[2:])
-	case "query":
-		return runQuery(os.Args[2:])
-	case "backlinks":
-		return runBacklinks(os.Args[2:])
+	case "list":
+		return runList(os.Args[2:])
 	case "help":
 		return runHelp(os.Args[2:])
 	case "metrics":
@@ -276,7 +273,7 @@ func parseQueryFlags(args []string) (queryOptions, []string, error) {
 		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, "Usage: mdsmith query [flags] <cue-expr> [files...]\n\n"+
+		fmt.Fprint(os.Stderr, "Usage: mdsmith list query [flags] <cue-expr> [files...]\n\n"+
 			"Print paths of Markdown files whose front matter satisfies a CUE expression.\n"+
 			"With no file arguments, searches the current directory recursively.\n\n"+
 			"Exit codes: 0 match, 1 no match, 2 error\n\nFlags:\n")

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -41,7 +41,7 @@ const usageText = `Usage: mdsmith <command> [flags] [files...]
 Commands:
   check             Lint Markdown files (default when given file arguments)
   fix               Auto-fix lint issues in place
-  list              Select files by query (front matter or link graph)
+  list              Walk the workspace and emit matches (files or link records)
   help              Show help for rules and topics
   metrics           Show and rank shared Markdown metrics
   merge-driver      Git merge driver for regenerable sections

--- a/demo.tape
+++ b/demo.tape
@@ -370,7 +370,7 @@ Show
 Type "# Query: filter files by a CUE expression on front matter"
 Enter
 Sleep 100ms
-Type `mdsmith query 'status: "✅"' plan/`
+Type `mdsmith list query 'status: "✅"' plan/`
 Sleep 100ms
 Enter
 Sleep 300ms

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -204,7 +204,7 @@ What each tool **does** with the same bytes:
 | YAML front matter                         | reads it; can validate shape via CUE schema             | reads it; validates against `_types/task.md`              |
 | Body content (prose, headings)            | lints line length, headings, prose, links               | not in scope                                              |
 | Cross-file link                           | flags broken `auth-migration-log.md` (MDS027)           | flags broken link (L4) and rewrites it on rename (L5)     |
-| `status: in-progress`                     | available to `mdsmith query`                            | filterable in Bases queries; appears in backlink graphs   |
+| `status: in-progress`                     | available to `mdsmith list query`                       | filterable in Bases queries; appears in backlink graphs   |
 | `due: 2026-06-01`                         | available to query                                      | filterable with date arithmetic (`due <= today() + "7d"`) |
 | `mdsmith fix` runs                        | reformats tables, regenerates TOC/catalog               | n/a                                                       |
 | `mdbase rename` runs                      | n/a                                                     | moves the file and rewrites every incoming link           |
@@ -380,24 +380,24 @@ markdownlint fixes structural violations.
 
 ### Cross-File and Project Features
 
-| Capability           | mdsmith          | markdownlint | remark-lint                     |
-|----------------------|------------------|--------------|---------------------------------|
-| Link integrity       | [MDS027][mds027] | no           | [remark-validate-links][rl-vl]  |
-| Include sections     | [MDS021][mds021] | no           | no                              |
-| Catalog generation   | [MDS019][mds019] | no           | no                              |
-| Required structure   | [MDS020][mds020] | no           | no                              |
-| Front-matter query   | `mdsmith query`  | no           | no                              |
-| Git merge driver     | yes              | no           | no                              |
-| Metrics ranking      | yes              | no           | no                              |
-| Gitignore aware      | yes              | yes          | no                              |
-| Front matter support | yes              | via plugin   | via [remark-frontmatter][rl-fm] |
+| Capability           | mdsmith              | markdownlint | remark-lint                     |
+|----------------------|----------------------|--------------|---------------------------------|
+| Link integrity       | [MDS027][mds027]     | no           | [remark-validate-links][rl-vl]  |
+| Include sections     | [MDS021][mds021]     | no           | no                              |
+| Catalog generation   | [MDS019][mds019]     | no           | no                              |
+| Required structure   | [MDS020][mds020]     | no           | no                              |
+| Front-matter query   | `mdsmith list query` | no           | no                              |
+| Git merge driver     | yes                  | no           | no                              |
+| Metrics ranking      | yes                  | no           | no                              |
+| Gitignore aware      | yes                  | yes          | no                              |
+| Front matter support | yes                  | via plugin   | via [remark-frontmatter][rl-fm] |
 
 mdsmith has the strongest cross-file and project-level
 features. The merge driver and regenerable sections are
 unique to mdsmith. The `query` subcommand
 ([plan 78][plan78]) selects files by a CUE expression
 over front matter (e.g.
-`mdsmith query 'status: "✅"' plan/`), which no other
+`mdsmith list query 'status: "✅"' plan/`), which no other
 tool in this comparison offers natively.
 
 ### Renderer Portability

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -394,7 +394,7 @@ markdownlint fixes structural violations.
 
 mdsmith has the strongest cross-file and project-level
 features. The merge driver and regenerable sections are
-unique to mdsmith. The `query` subcommand
+unique to mdsmith. The `list query` subcommand
 ([plan 78][plan78]) selects files by a CUE expression
 over front matter (e.g.
 `mdsmith list query 'status: "✅"' plan/`), which no other

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 ?>
 | Command                                       | Description                                                                          |
 |-----------------------------------------------|--------------------------------------------------------------------------------------|
+| [`backlinks`](cli/backlinks.md)               | List workspace links that point at a file.                                           |
 | [`check`](cli/check.md)                       | Lint Markdown files for style issues.                                                |
 | [`fix`](cli/fix.md)                           | Auto-fix lint issues in Markdown files in place.                                     |
 | [`help`](cli/help.md)                         | Show built-in documentation for rules, metrics, and concept pages.                   |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,17 +20,18 @@ row: "| [`{command}`]({filename}) | {summary} |"
 ?>
 | Command                                       | Description                                                                          |
 |-----------------------------------------------|--------------------------------------------------------------------------------------|
-| [`backlinks`](cli/backlinks.md)               | List workspace links that point at a file.                                           |
 | [`check`](cli/check.md)                       | Lint Markdown files for style issues.                                                |
 | [`fix`](cli/fix.md)                           | Auto-fix lint issues in Markdown files in place.                                     |
 | [`help`](cli/help.md)                         | Show built-in documentation for rules, metrics, and concept pages.                   |
 | [`init`](cli/init.md)                         | Generate a default `.mdsmith.yml` config in the current directory.                   |
 | [`kinds`](cli/kinds.md)                       | Inspect declared file kinds and resolve effective rule config per file.              |
+| [`list`](cli/list.md)                         | Selection-style commands that walk the workspace and emit matches.                   |
+| [`list backlinks`](cli/backlinks.md)          | List workspace links that point at a file.                                           |
+| [`list query`](cli/query.md)                  | Select Markdown files by a CUE expression on front matter.                           |
 | [`lsp`](cli/lsp.md)                           | Run a Language Server Protocol server on stdio for editor integrations.              |
 | [`merge-driver`](cli/merge-driver.md)         | Git merge driver that resolves conflicts inside generated sections.                  |
 | [`metrics`](cli/metrics.md)                   | List and rank shared Markdown metrics (file length, token estimate, readability, …). |
 | [`pre-merge-commit`](cli/pre-merge-commit.md) | Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.      |
-| [`query`](cli/query.md)                       | Select Markdown files by a CUE expression on front matter.                           |
 | [`version`](cli/version.md)                   | Print the mdsmith build version and exit.                                            |
 <?/catalog?>
 

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -15,7 +15,8 @@ mdsmith backlinks [flags] <target>
 
 `<target>` is workspace-relative. Append `#anchor` to
 restrict matches to links whose anchor resolves to the
-named heading.
+named heading. Absolute paths and parent-traversal
+entries (`../foo.md`) are rejected with exit code 2.
 
 ## Flags
 

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -1,0 +1,107 @@
+---
+command: backlinks
+summary: List workspace links that point at a file.
+---
+# `mdsmith backlinks`
+
+Print every workspace file that links to `<target>`,
+one row per incoming link. The link graph is the same
+one MDS027 (cross-file-reference-integrity) walks for
+broken-link checking, queried in reverse.
+
+```text
+mdsmith backlinks [flags] <target>
+```
+
+`<target>` is workspace-relative. Append `#anchor` to
+restrict matches to links whose anchor resolves to the
+named heading.
+
+## Flags
+
+| Flag                | Default | Description                                         |
+|---------------------|---------|-----------------------------------------------------|
+| `-c`, `--config`    | auto    | Override config path                                |
+| `-f`, `--format`    | `text`  | Output format: `text` or `json`                     |
+| `--include GLOB`    | none    | Restrict sources to paths matching glob; repeatable |
+| `--limit N`         | `0`     | Cap output at N rows (`0` = no cap)                 |
+| `--no-gitignore`    | false   | Disable `.gitignore` filtering during walk          |
+| `--follow-symlinks` | false   | Follow symlinks to regular files                    |
+| `--max-input-size`  | `2MB`   | Max file size (e.g. `2MB`, `0`=none)                |
+
+File discovery follows the `files:` patterns in
+`.mdsmith.yml` and the same `ignore:` rules `check` and
+`fix` use.
+
+## Output
+
+**text** (default):
+
+```text
+docs/index.md:14: [API reference](api.md)
+docs/getting-started.md:42: [api docs](./api.md)
+plan/045_api-overhaul.md:8: [api](../docs/api.md)
+```
+
+Each row carries the source path, the 1-based source
+line, the visible link text, and the link target as it
+appears in the source. Output is sorted by source path
+then line, so `--limit` paginates deterministically.
+
+**json**:
+
+```json
+[
+  {
+    "source": "docs/index.md",
+    "line": 14,
+    "text": "API reference",
+    "target": "api.md"
+  },
+  {
+    "source": "plan/045_api-overhaul.md",
+    "line": 8,
+    "text": "api",
+    "target": "../docs/api.md"
+  }
+]
+```
+
+Keys are stable. Empty results emit `[]`, not `null`.
+
+## Examples
+
+List everything that points at `docs/api.md`:
+
+```bash
+mdsmith backlinks docs/api.md
+```
+
+Filter to a specific anchor on the target:
+
+```bash
+mdsmith backlinks docs/api.md#authentication
+```
+
+Limit to the plan directory and the first ten rows:
+
+```bash
+mdsmith backlinks --include "plan/**" --limit 10 docs/api.md
+```
+
+## Scope
+
+The command resolves the same direct Markdown links
+MDS027 sees. The graph covers `[text](path)` and
+`[text](path#anchor)`. Reference-style links
+(`[text][label]`), wiki-style links (`[[page]]`), and
+external URLs are out of scope. They would only join
+the result set once the matching parser support lands.
+
+## Exit codes
+
+| Code | Meaning                 |
+|------|-------------------------|
+| 0    | At least one match      |
+| 1    | No incoming links found |
+| 2    | Runtime/parse error     |

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -26,8 +26,15 @@ named heading.
 | `--include GLOB`    | none    | Restrict sources to paths matching glob; repeatable |
 | `--limit N`         | `0`     | Cap output at N rows (`0` = no cap)                 |
 | `--no-gitignore`    | false   | Disable `.gitignore` filtering during walk          |
-| `--follow-symlinks` | false   | Follow symlinks to regular files                    |
+| `--follow-symlinks` | config  | Follow symlinks; tri-state — see below              |
 | `--max-input-size`  | `2MB`   | Max file size (e.g. `2MB`, `0`=none)                |
+
+`--follow-symlinks` semantics match
+[`mdsmith check`](check.md#flags). Omit the flag to
+defer to the `follow-symlinks:` config key (default
+skip). `--follow-symlinks` (or `=true`) opts in for
+this run. `=false` forces skip even when config opts
+in.
 
 File discovery follows the `files:` patterns in
 `.mdsmith.yml` and the same `ignore:` rules `check` and

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -1,8 +1,8 @@
 ---
-command: backlinks
+command: list backlinks
 summary: List workspace links that point at a file.
 ---
-# `mdsmith backlinks`
+# `mdsmith list backlinks`
 
 Print every workspace file that links to `<target>`,
 one row per incoming link. The link graph is the same
@@ -10,7 +10,7 @@ one MDS027 (cross-file-reference-integrity) walks for
 broken-link checking, queried in reverse.
 
 ```text
-mdsmith backlinks [flags] <target>
+mdsmith list backlinks [flags] <target>
 ```
 
 `<target>` is workspace-relative. Append `#anchor` to
@@ -82,19 +82,19 @@ Keys are stable. Empty results emit `[]`, not `null`.
 List everything that points at `docs/api.md`:
 
 ```bash
-mdsmith backlinks docs/api.md
+mdsmith list backlinks docs/api.md
 ```
 
 Filter to a specific anchor on the target:
 
 ```bash
-mdsmith backlinks docs/api.md#authentication
+mdsmith list backlinks docs/api.md#authentication
 ```
 
 Limit to the plan directory and the first ten rows:
 
 ```bash
-mdsmith backlinks --include "plan/**" --limit 10 docs/api.md
+mdsmith list backlinks --include "plan/**" --limit 10 docs/api.md
 ```
 
 ## Scope

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -100,8 +100,15 @@ the result set once the matching parser support lands.
 
 ## Exit codes
 
-| Code | Meaning                 |
-|------|-------------------------|
-| 0    | At least one match      |
-| 1    | No incoming links found |
-| 2    | Runtime/parse error     |
+| Code | Meaning               |
+|------|-----------------------|
+| 0    | At least one match    |
+| 1    | No matches, no errors |
+| 2    | Runtime/parse error   |
+
+Per-file read failures are printed to stderr and never
+abort the walk: matches from the surviving files still
+appear on stdout. The exit code reflects the worst
+outcome — `0` when any record was emitted, `2` when
+nothing matched but errors occurred, `1` only on a
+clean empty result.

--- a/docs/reference/cli/list.md
+++ b/docs/reference/cli/list.md
@@ -1,0 +1,24 @@
+---
+command: list
+summary: Selection-style commands that walk the workspace and emit matches.
+---
+# `mdsmith list`
+
+Parent for the selection-style subcommands. Each child
+walks every workspace Markdown file (filtered by
+`.mdsmith.yml` `files:` / `ignore:`) and emits matches
+in its own shape; the parent itself is just a router.
+
+```text
+mdsmith list <subcommand> [flags] [args]
+```
+
+## Subcommands
+
+| Subcommand                  | Description                                                  |
+|-----------------------------|--------------------------------------------------------------|
+| [`query`](query.md)         | Select files by a CUE expression on front matter.            |
+| [`backlinks`](backlinks.md) | List incoming links that point at a target file (or anchor). |
+
+Run `mdsmith list <subcommand> --help` for per-command
+flags, exit codes, and worked examples.

--- a/docs/reference/cli/query.md
+++ b/docs/reference/cli/query.md
@@ -1,14 +1,14 @@
 ---
-command: query
+command: list query
 summary: Select Markdown files by a CUE expression on front matter.
 ---
-# `mdsmith query`
+# `mdsmith list query`
 
 Print paths of Markdown files whose front matter satisfies
 a CUE expression.
 
 ```text
-mdsmith query [flags] <cue-expr> [files...]
+mdsmith list query [flags] <cue-expr> [files...]
 ```
 
 With no file arguments, searches the current directory
@@ -27,9 +27,9 @@ recursively. Files without front matter are skipped (use
 ## Examples
 
 ```bash
-mdsmith query 'status: "✅"' plan/
-mdsmith query '#mdsxx & {status: "ready"}' internal/rules/
-mdsmith query -0 'kinds: [..."plan"...]' . | xargs -0 wc -l
+mdsmith list query 'status: "✅"' plan/
+mdsmith list query '#mdsxx & {status: "ready"}' internal/rules/
+mdsmith list query -0 'kinds: [..."plan"...]' . | xargs -0 wc -l
 ```
 
 The expression is full CUE — match scalars, regex, list

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -172,14 +172,11 @@ func linkPosition(f *lint.File, n ast.Node) (int, int) {
 	if offset < 0 {
 		return 1, 1
 	}
-	line := f.LineOfOffset(offset)
-	lineStart := 0
-	for i := 0; i < offset && i < len(f.Source); i++ {
-		if f.Source[i] == '\n' {
-			lineStart = i + 1
-		}
-	}
-	return line, offset - lineStart + 1
+	// f.ColumnOfOffset scans backward from offset to the previous
+	// newline, so it's O(column) per call instead of the O(offset)
+	// forward scan a hand-rolled version would do — meaningful for
+	// `mdsmith backlinks` which can call this many times per file.
+	return f.LineOfOffset(offset), f.ColumnOfOffset(offset)
 }
 
 func firstTextOffset(n ast.Node) int {

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -44,10 +44,10 @@ func ParseTarget(dest string) (Target, bool) {
 		return Target{}, false
 	}
 
+	// u.Opaque is non-empty only on URLs with a scheme; the scheme
+	// check above already short-circuits that case, so we can read
+	// the path component directly.
 	path := u.Path
-	if path == "" && u.Opaque != "" {
-		path = u.Opaque
-	}
 
 	if path == "" && u.Fragment != "" {
 		return Target{
@@ -206,8 +206,8 @@ func linkText(link *ast.Link, source []byte) string {
 }
 
 // linkPosition returns the 1-based source line and column of a link
-// node. The returned line does NOT include f.LineOffset; ExtractLinks
-// applies the offset before returning.
+// node, in body-relative coordinates (no f.LineOffset applied — see
+// the Link doc for why).
 func linkPosition(f *lint.File, n ast.Node) (int, int) {
 	offset := firstTextOffset(n)
 	if offset < 0 {

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -5,7 +5,6 @@
 package linkgraph
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -17,9 +16,15 @@ import (
 
 // Target is the parsed shape of a link destination URL.
 //
-// Raw is the original destination string. Path and Anchor are URL-
-// decoded. LocalAnchor is true when the destination was an anchor-only
+// Raw is the original destination string as it appeared in the source.
+// Path and Anchor are the decoded path and fragment components — both
+// are populated from url.URL, which percent-decodes them on parse.
+// LocalAnchor is true when the destination was an anchor-only
 // reference (e.g. `#section`).
+//
+// Anchor matching against CollectAnchors output must still go through
+// NormalizeAnchor: that runs Slugify (and a defensive PathUnescape) to
+// produce the same form CollectAnchors stores.
 type Target struct {
 	Raw         string
 	Path        string
@@ -125,41 +130,21 @@ func ExtractLinks(f *lint.File) []Link {
 }
 
 // CollectAnchors returns the set of heading anchors defined in f, with
-// GitHub-compatible disambiguation suffixes (-1, -2, …) when the same
-// slug repeats. The set keys are the slugified anchor names; values
-// are always true so callers can use map-lookup.
+// GitHub-compatible disambiguation suffixes (-1, -2, …) when slugs
+// would otherwise collide. Uniqueness is enforced against the running
+// set of produced anchors so a sequence like "Intro" / "Intro" /
+// "Intro-1" yields three distinct keys (`intro`, `intro-1`,
+// `intro-1-1`) rather than two distinct ones with a collision.
+// The set keys are the slugified anchor names; values are always true
+// so callers can use map-lookup.
 func CollectAnchors(f *lint.File) map[string]bool {
 	anchors := make(map[string]bool)
 	if f == nil || f.AST == nil {
 		return anchors
 	}
-	seen := make(map[string]int)
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		h, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		slug := mdtext.Slugify(headingText(h, f.Source))
-		if slug == "" {
-			return ast.WalkContinue, nil
-		}
-
-		count := seen[slug]
-		anchor := slug
-		if count > 0 {
-			anchor = fmt.Sprintf("%s-%d", slug, count)
-		}
-		seen[slug] = count + 1
-		anchors[anchor] = true
-
-		return ast.WalkContinue, nil
-	})
-
+	for _, item := range mdtext.CollectTOCItems(f.AST, f.Source) {
+		anchors[item.Anchor] = true
+	}
 	return anchors
 }
 
@@ -170,32 +155,6 @@ func NormalizeAnchor(raw string) string {
 		raw = decoded
 	}
 	return mdtext.Slugify(raw)
-}
-
-// headingText concatenates the heading's text-bearing leaves into a
-// plain string. Code spans and other inline nodes pass through their
-// text children. This mirrors the behavior MDS027 used before the
-// link-graph refactor; LSP/index uses a richer ExtractPlainText but
-// the two agree on heading content because headings contain only
-// text-like children in practice.
-func headingText(node ast.Node, source []byte) string {
-	var b strings.Builder
-	appendHeadingText(&b, node, source)
-	return b.String()
-}
-
-func appendHeadingText(b *strings.Builder, node ast.Node, source []byte) {
-	switch n := node.(type) {
-	case *ast.Text:
-		b.Write(n.Segment.Value(source))
-		return
-	case *ast.String:
-		b.Write(n.Value)
-		return
-	}
-	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
-		appendHeadingText(b, child, source)
-	}
 }
 
 // linkText returns the visible link text (everything between `[` and

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -83,7 +83,7 @@ func ParseTarget(dest string) (Target, bool) {
 // Line is body-relative — counted from the start of the parsed body,
 // not the original file. Lint rules return body-relative diagnostics
 // because the engine applies f.LineOffset for front-matter adjustment.
-// CLI callers (like `mdsmith backlinks`) that want file-relative line
+// CLI callers (like `mdsmith list backlinks`) that want file-relative line
 // numbers must add f.LineOffset themselves.
 type Link struct {
 	Line   int
@@ -175,7 +175,7 @@ func linkPosition(f *lint.File, n ast.Node) (int, int) {
 	// f.ColumnOfOffset scans backward from offset to the previous
 	// newline, so it's O(column) per call instead of the O(offset)
 	// forward scan a hand-rolled version would do — meaningful for
-	// `mdsmith backlinks` which can call this many times per file.
+	// `mdsmith list backlinks` which can call this many times per file.
 	return f.LineOfOffset(offset), f.ColumnOfOffset(offset)
 }
 

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -74,6 +74,12 @@ func ParseTarget(dest string) (Target, bool) {
 // from ExtractLinks results because their destinations resolve through
 // the link-reference map rather than a URL; the link-graph builder
 // only sees direct destinations.
+//
+// Line is body-relative — counted from the start of the parsed body,
+// not the original file. Lint rules return body-relative diagnostics
+// because the engine applies f.LineOffset for front-matter adjustment.
+// CLI callers (like `mdsmith backlinks`) that want file-relative line
+// numbers must add f.LineOffset themselves.
 type Link struct {
 	Line   int
 	Column int
@@ -82,8 +88,8 @@ type Link struct {
 }
 
 // ExtractLinks walks f.AST and returns every regular Markdown link in
-// document order. f.LineOffset (front matter) is applied so Line is in
-// the original file's coordinate system.
+// document order. Lines are body-relative (post front-matter strip);
+// see the Link doc for why.
 func ExtractLinks(f *lint.File) []Link {
 	if f == nil || f.AST == nil {
 		return nil
@@ -108,7 +114,7 @@ func ExtractLinks(f *lint.File) []Link {
 		}
 		line, col := linkPosition(f, l)
 		out = append(out, Link{
-			Line:   line + f.LineOffset,
+			Line:   line,
 			Column: col,
 			Text:   linkText(l, f.Source),
 			Target: target,

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -1,0 +1,236 @@
+// Package linkgraph extracts Markdown links and heading anchors so the
+// link-validity rule (MDS027) and the `backlinks` subcommand share one
+// implementation of the link walk, anchor slug rules, and target
+// parsing.
+package linkgraph
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdtext"
+)
+
+// Target is the parsed shape of a link destination URL.
+//
+// Raw is the original destination string. Path and Anchor are URL-
+// decoded. LocalAnchor is true when the destination was an anchor-only
+// reference (e.g. `#section`).
+type Target struct {
+	Raw         string
+	Path        string
+	Anchor      string
+	LocalAnchor bool
+}
+
+// ParseTarget parses a Markdown link destination into a Target.
+// Returns ok=false when the destination is empty, has a scheme or
+// host (treated as external), or has neither a path nor a fragment.
+func ParseTarget(dest string) (Target, bool) {
+	dest = strings.TrimSpace(dest)
+	if dest == "" || strings.HasPrefix(dest, "//") {
+		return Target{}, false
+	}
+
+	u, err := url.Parse(dest)
+	if err != nil {
+		return Target{}, false
+	}
+	if u.Scheme != "" || u.Host != "" {
+		return Target{}, false
+	}
+
+	path := u.Path
+	if path == "" && u.Opaque != "" {
+		path = u.Opaque
+	}
+
+	if path == "" && u.Fragment != "" {
+		return Target{
+			Raw:         dest,
+			Anchor:      u.Fragment,
+			LocalAnchor: true,
+		}, true
+	}
+
+	if path == "" {
+		return Target{}, false
+	}
+
+	return Target{
+		Raw:    dest,
+		Path:   path,
+		Anchor: u.Fragment,
+	}, true
+}
+
+// Link is one parsed Markdown link occurrence in a source file.
+//
+// Reference-style links (`[text][label]`) are intentionally omitted
+// from ExtractLinks results because their destinations resolve through
+// the link-reference map rather than a URL; the link-graph builder
+// only sees direct destinations.
+type Link struct {
+	Line   int
+	Column int
+	Text   string
+	Target Target
+}
+
+// ExtractLinks walks f.AST and returns every regular Markdown link in
+// document order. f.LineOffset (front matter) is applied so Line is in
+// the original file's coordinate system.
+func ExtractLinks(f *lint.File) []Link {
+	if f == nil || f.AST == nil {
+		return nil
+	}
+	var out []Link
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		l, ok := n.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		// Reference-style links carry l.Reference; the link-graph
+		// builder skips them so callers see one shape per link.
+		if l.Reference != nil {
+			return ast.WalkContinue, nil
+		}
+		target, ok := ParseTarget(string(l.Destination))
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		line, col := linkPosition(f, l)
+		out = append(out, Link{
+			Line:   line + f.LineOffset,
+			Column: col,
+			Text:   linkText(l, f.Source),
+			Target: target,
+		})
+		return ast.WalkContinue, nil
+	})
+	return out
+}
+
+// CollectAnchors returns the set of heading anchors defined in f, with
+// GitHub-compatible disambiguation suffixes (-1, -2, …) when the same
+// slug repeats. The set keys are the slugified anchor names; values
+// are always true so callers can use map-lookup.
+func CollectAnchors(f *lint.File) map[string]bool {
+	anchors := make(map[string]bool)
+	if f == nil || f.AST == nil {
+		return anchors
+	}
+	seen := make(map[string]int)
+
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		slug := mdtext.Slugify(headingText(h, f.Source))
+		if slug == "" {
+			return ast.WalkContinue, nil
+		}
+
+		count := seen[slug]
+		anchor := slug
+		if count > 0 {
+			anchor = fmt.Sprintf("%s-%d", slug, count)
+		}
+		seen[slug] = count + 1
+		anchors[anchor] = true
+
+		return ast.WalkContinue, nil
+	})
+
+	return anchors
+}
+
+// NormalizeAnchor URL-decodes raw and slugifies it so the result can
+// be compared against CollectAnchors output.
+func NormalizeAnchor(raw string) string {
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		raw = decoded
+	}
+	return mdtext.Slugify(raw)
+}
+
+// headingText concatenates the heading's text-bearing leaves into a
+// plain string. Code spans and other inline nodes pass through their
+// text children. This mirrors the behavior MDS027 used before the
+// link-graph refactor; LSP/index uses a richer ExtractPlainText but
+// the two agree on heading content because headings contain only
+// text-like children in practice.
+func headingText(node ast.Node, source []byte) string {
+	var b strings.Builder
+	appendHeadingText(&b, node, source)
+	return b.String()
+}
+
+func appendHeadingText(b *strings.Builder, node ast.Node, source []byte) {
+	switch n := node.(type) {
+	case *ast.Text:
+		b.Write(n.Segment.Value(source))
+		return
+	case *ast.String:
+		b.Write(n.Value)
+		return
+	}
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		appendHeadingText(b, child, source)
+	}
+}
+
+// linkText returns the visible link text (everything between `[` and
+// `]`). Image alt text and emphasis are flattened to plain text so
+// JSON/text output stays readable.
+func linkText(link *ast.Link, source []byte) string {
+	return mdtext.ExtractPlainText(link, source)
+}
+
+// linkPosition returns the 1-based source line and column of a link
+// node. The returned line does NOT include f.LineOffset; ExtractLinks
+// applies the offset before returning.
+func linkPosition(f *lint.File, n ast.Node) (int, int) {
+	offset := firstTextOffset(n)
+	if offset < 0 {
+		return 1, 1
+	}
+	line := f.LineOfOffset(offset)
+	lineStart := 0
+	for i := 0; i < offset && i < len(f.Source); i++ {
+		if f.Source[i] == '\n' {
+			lineStart = i + 1
+		}
+	}
+	return line, offset - lineStart + 1
+}
+
+func firstTextOffset(n ast.Node) int {
+	offset := -1
+	_ = ast.Walk(n, func(cur ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		text, ok := cur.(*ast.Text)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		if offset == -1 || text.Segment.Start < offset {
+			offset = text.Segment.Start
+		}
+		return ast.WalkContinue, nil
+	})
+	return offset
+}

--- a/internal/linkgraph/linkgraph_test.go
+++ b/internal/linkgraph/linkgraph_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 )
@@ -135,4 +136,49 @@ func TestExtractLinks_AgreesWithMDS027(t *testing.T) {
 	require.Len(t, links, 3)
 	texts := []string{links[0].Text, links[1].Text, links[2].Text}
 	assert.Equal(t, []string{"one", "two", "three"}, texts)
+}
+
+// TestParseTarget_MalformedURL exercises the url.Parse error branch.
+// A control character in the URL is invalid per RFC 3986 and makes
+// url.Parse return an error.
+func TestParseTarget_MalformedURL(t *testing.T) {
+	// %ZZ is an invalid percent-encoded escape; url.Parse rejects it.
+	_, ok := ParseTarget("guide.md%ZZ")
+	assert.False(t, ok)
+}
+
+// TestCollectAnchors_AstStringNode constructs a heading whose body is
+// an ast.String node (created by some inline transforms, but not by
+// the default parser). The headingText walker must read the value of
+// such nodes to compute the slug; without coverage of this branch,
+// any future parser extension that emits ast.String would silently
+// produce an empty slug.
+func TestCollectAnchors_AstStringNode(t *testing.T) {
+	heading := ast.NewHeading(2)
+	heading.AppendChild(heading, ast.NewString([]byte("hello world")))
+	root := ast.NewDocument()
+	root.AppendChild(root, heading)
+	f := &lint.File{AST: root, Source: nil}
+
+	anchors := CollectAnchors(f)
+	assert.True(t, anchors["hello-world"], "ast.String value should drive the slug")
+}
+
+// TestExtractLinks_LinkWithNoTextChildren covers the linkPosition
+// `offset < 0` fallback. A link node without any text children yields
+// firstTextOffset = -1, so linkPosition returns (1, 1).
+func TestExtractLinks_LinkWithNoTextChildren(t *testing.T) {
+	// Construct an AST with one bare ast.Link and no text under it.
+	root := ast.NewDocument()
+	para := ast.NewParagraph()
+	link := ast.NewLink()
+	link.Destination = []byte("a.md")
+	para.AppendChild(para, link)
+	root.AppendChild(root, para)
+	f := &lint.File{AST: root, Source: nil}
+
+	links := ExtractLinks(f)
+	require.Len(t, links, 1)
+	assert.Equal(t, 1, links[0].Line, "no-text link → linkPosition falls back to (1, 1)")
+	assert.Equal(t, 1, links[0].Column)
 }

--- a/internal/linkgraph/linkgraph_test.go
+++ b/internal/linkgraph/linkgraph_test.go
@@ -164,6 +164,23 @@ func TestParseTarget_MalformedURL(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestCollectAnchors_AstStringHeading guards against a regression:
+// when a heading's child is an *ast.String (emitted by typographer
+// or smart-quote extensions), the slug must still pick up the
+// string's value. mdtext.ExtractPlainText is the shared routine that
+// handles this; without the dedicated branch the heading collapses
+// to an empty slug and anchor lookups silently miss.
+func TestCollectAnchors_AstStringHeading(t *testing.T) {
+	heading := ast.NewHeading(2)
+	heading.AppendChild(heading, ast.NewString([]byte("hello world")))
+	root := ast.NewDocument()
+	root.AppendChild(root, heading)
+	f := &lint.File{AST: root, Source: nil}
+
+	anchors := CollectAnchors(f)
+	assert.True(t, anchors["hello-world"], "ast.String value should drive the slug")
+}
+
 // TestExtractLinks_LinkWithNoTextChildren covers the linkPosition
 // `offset < 0` fallback. A link node without any text children yields
 // firstTextOffset = -1, so linkPosition returns (1, 1).

--- a/internal/linkgraph/linkgraph_test.go
+++ b/internal/linkgraph/linkgraph_test.go
@@ -108,6 +108,23 @@ func TestCollectAnchors(t *testing.T) {
 	assert.False(t, anchors[""], "empty-text headings produce no slug")
 }
 
+// TestCollectAnchors_CollisionWithPreNumberedHeading guards against
+// the disambiguation bug where two "Intro" headings followed by an
+// "Intro-1" heading collapse onto the same `intro-1` anchor — the
+// duplicate "Intro" generates `intro-1`, then the literal "Intro-1"
+// heading also slugifies to `intro-1` and overwrites it. The fix
+// must give each heading a globally unique anchor.
+func TestCollectAnchors_CollisionWithPreNumberedHeading(t *testing.T) {
+	f := newFile(t, "# Intro\n\n# Intro\n\n# Intro-1\n")
+	anchors := CollectAnchors(f)
+	// All three headings must appear under distinct anchors. The
+	// canonical GitHub behavior is to keep numbering until no
+	// collision exists, so the third heading becomes `intro-1-1`.
+	assert.True(t, anchors["intro"], "first heading keeps the plain slug")
+	assert.True(t, anchors["intro-1"], "second heading uses the next free suffix")
+	assert.True(t, anchors["intro-1-1"], "third heading must not collide with the second")
+}
+
 func TestCollectAnchors_NilFile(t *testing.T) {
 	got := CollectAnchors(nil)
 	assert.NotNil(t, got)
@@ -145,23 +162,6 @@ func TestParseTarget_MalformedURL(t *testing.T) {
 	// %ZZ is an invalid percent-encoded escape; url.Parse rejects it.
 	_, ok := ParseTarget("guide.md%ZZ")
 	assert.False(t, ok)
-}
-
-// TestCollectAnchors_AstStringNode constructs a heading whose body is
-// an ast.String node (created by some inline transforms, but not by
-// the default parser). The headingText walker must read the value of
-// such nodes to compute the slug; without coverage of this branch,
-// any future parser extension that emits ast.String would silently
-// produce an empty slug.
-func TestCollectAnchors_AstStringNode(t *testing.T) {
-	heading := ast.NewHeading(2)
-	heading.AppendChild(heading, ast.NewString([]byte("hello world")))
-	root := ast.NewDocument()
-	root.AppendChild(root, heading)
-	f := &lint.File{AST: root, Source: nil}
-
-	anchors := CollectAnchors(f)
-	assert.True(t, anchors["hello-world"], "ast.String value should drive the slug")
 }
 
 // TestExtractLinks_LinkWithNoTextChildren covers the linkPosition

--- a/internal/linkgraph/linkgraph_test.go
+++ b/internal/linkgraph/linkgraph_test.go
@@ -85,15 +85,17 @@ func TestExtractLinks_NilFile(t *testing.T) {
 	assert.Nil(t, ExtractLinks(nil))
 }
 
-func TestExtractLinks_RespectsLineOffset(t *testing.T) {
+func TestExtractLinks_LinesAreBodyRelative(t *testing.T) {
 	source := []byte("---\ntitle: x\n---\nSee [g](g.md).\n")
 	f, err := lint.NewFileFromSource("file.md", source, true)
 	require.NoError(t, err)
 	links := ExtractLinks(f)
 	require.Len(t, links, 1)
-	// Front matter occupies 3 lines; the link's body-relative line is
-	// 1, so the file-relative line is 1 + 3 = 4.
-	assert.Equal(t, 4, links[0].Line)
+	// Body starts after the 3-line front-matter prefix. The link is
+	// on body line 1; lint rules will have f.AdjustDiagnostics add
+	// f.LineOffset later, so ExtractLinks must NOT pre-apply it.
+	assert.Equal(t, 1, links[0].Line)
+	assert.Equal(t, 3, f.LineOffset, "front matter occupies 3 lines")
 }
 
 func TestCollectAnchors(t *testing.T) {

--- a/internal/linkgraph/linkgraph_test.go
+++ b/internal/linkgraph/linkgraph_test.go
@@ -1,0 +1,136 @@
+package linkgraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+func newFile(t *testing.T, source string) *lint.File {
+	t.Helper()
+	f, err := lint.NewFile("test.md", []byte(source))
+	require.NoError(t, err)
+	return f
+}
+
+func TestParseTarget(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   Target
+		wantOK bool
+	}{
+		{"empty", "", Target{}, false},
+		{"protocol-relative", "//example.com/x", Target{}, false},
+		{"scheme", "https://example.com", Target{}, false},
+		{"plain path", "guide.md", Target{Raw: "guide.md", Path: "guide.md"}, true},
+		{"path with anchor", "guide.md#sec", Target{Raw: "guide.md#sec", Path: "guide.md", Anchor: "sec"}, true},
+		{"anchor only", "#sec", Target{Raw: "#sec", Anchor: "sec", LocalAnchor: true}, true},
+		{"query only rejected", "?q=1", Target{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseTarget(tc.input)
+			assert.Equal(t, tc.wantOK, ok)
+			if ok {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestExtractLinks_Basic(t *testing.T) {
+	f := newFile(t, "# Doc\n\nSee [guide](guide.md#intro) and [home](/).\n")
+	links := ExtractLinks(f)
+	require.Len(t, links, 2)
+
+	assert.Equal(t, "guide", links[0].Text)
+	assert.Equal(t, "guide.md", links[0].Target.Path)
+	assert.Equal(t, "intro", links[0].Target.Anchor)
+	assert.False(t, links[0].Target.LocalAnchor)
+	assert.Equal(t, 3, links[0].Line)
+	assert.Greater(t, links[0].Column, 0)
+
+	assert.Equal(t, "home", links[1].Text)
+	assert.Equal(t, "/", links[1].Target.Path)
+}
+
+func TestExtractLinks_LocalAnchor(t *testing.T) {
+	f := newFile(t, "# Doc\n\nGo [up](#top).\n")
+	links := ExtractLinks(f)
+	require.Len(t, links, 1)
+	assert.True(t, links[0].Target.LocalAnchor)
+	assert.Equal(t, "top", links[0].Target.Anchor)
+}
+
+func TestExtractLinks_SkipsReferenceStyle(t *testing.T) {
+	src := "# Doc\n\nSee [other][label].\n\n[label]: other.md\n"
+	f := newFile(t, src)
+	links := ExtractLinks(f)
+	// Reference-style links resolve via the ref map, not a URL; the
+	// graph builder skips them.
+	assert.Empty(t, links)
+}
+
+func TestExtractLinks_SkipsExternal(t *testing.T) {
+	f := newFile(t, "# Doc\n\nSee [out](https://example.com).\n")
+	links := ExtractLinks(f)
+	assert.Empty(t, links)
+}
+
+func TestExtractLinks_NilFile(t *testing.T) {
+	assert.Nil(t, ExtractLinks(nil))
+}
+
+func TestExtractLinks_RespectsLineOffset(t *testing.T) {
+	source := []byte("---\ntitle: x\n---\nSee [g](g.md).\n")
+	f, err := lint.NewFileFromSource("file.md", source, true)
+	require.NoError(t, err)
+	links := ExtractLinks(f)
+	require.Len(t, links, 1)
+	// Front matter occupies 3 lines; the link's body-relative line is
+	// 1, so the file-relative line is 1 + 3 = 4.
+	assert.Equal(t, 4, links[0].Line)
+}
+
+func TestCollectAnchors(t *testing.T) {
+	f := newFile(t, "# Intro\n\n## Setup\n\n## Setup\n\n##   \n")
+	anchors := CollectAnchors(f)
+	assert.True(t, anchors["intro"])
+	assert.True(t, anchors["setup"])
+	assert.True(t, anchors["setup-1"])
+	assert.False(t, anchors[""], "empty-text headings produce no slug")
+}
+
+func TestCollectAnchors_NilFile(t *testing.T) {
+	got := CollectAnchors(nil)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestNormalizeAnchor(t *testing.T) {
+	assert.Equal(t, "hello-world", NormalizeAnchor("Hello World"))
+	assert.Equal(t, "section", NormalizeAnchor("Section"))
+	// %20 URL-decodes to a space, which slugifies to a dash.
+	assert.Equal(t, "two-words", NormalizeAnchor("Two%20Words"))
+}
+
+// TestExtractLinks_AgreesWithMDS027 confirms the linkgraph extractor
+// reports the same set of links MDS027 sees when validating cross-file
+// references. The agreement is the load-bearing invariant for the
+// `backlinks` subcommand: a target's incoming-link set must mirror
+// the outgoing-link set MDS027 walks.
+func TestExtractLinks_AgreesWithMDS027(t *testing.T) {
+	src := "# Doc\n\nA [one](a.md), [two](b.md#x), [three](#local), and [ref][r].\n\n[r]: r.md\n"
+	f := newFile(t, src)
+	links := ExtractLinks(f)
+
+	// MDS027 sees the same three direct links (one, two, three) and
+	// skips the reference-style link.
+	require.Len(t, links, 3)
+	texts := []string{links[0].Text, links[1].Text, links[2].Text}
+	assert.Equal(t, []string{"one", "two", "three"}, texts)
+}

--- a/internal/mdtext/mdtext.go
+++ b/internal/mdtext/mdtext.go
@@ -107,6 +107,17 @@ func extractText(buf *strings.Builder, node ast.Node, source []byte) {
 		return
 	}
 
+	// For string nodes (emitted by typographer / smart-quote /
+	// auto-link extensions and some paragraph transformers), the
+	// payload lives on the node, not in the source buffer. Without
+	// this branch, ExtractPlainText silently drops them — and any
+	// heading whose text was rewritten by such an extension would
+	// produce a blank slug or an incorrect anchor.
+	if s, ok := node.(*ast.String); ok {
+		buf.Write(s.Value)
+		return
+	}
+
 	// For code spans, extract the text content from children.
 	if _, ok := node.(*ast.CodeSpan); ok {
 		for c := node.FirstChild(); c != nil; c = c.NextSibling() {

--- a/internal/mdtext/mdtext_test.go
+++ b/internal/mdtext/mdtext_test.go
@@ -83,6 +83,19 @@ func TestExtractPlainText_SoftLineBreak(t *testing.T) {
 	assert.Equal(t, "Hello world.", mdtext.ExtractPlainText(para, src))
 }
 
+// TestExtractPlainText_AstString covers heading/paragraph children
+// emitted as *ast.String — the goldmark typographer extension and
+// other inline transformers replace text segments with String nodes
+// whose value lives in the node rather than the source buffer.
+// Without explicit handling, ExtractPlainText drops them, which
+// silently breaks anchor slugs and link-text extraction for any
+// heading or link processed by such an extension.
+func TestExtractPlainText_AstString(t *testing.T) {
+	para := ast.NewParagraph()
+	para.AppendChild(para, ast.NewString([]byte("hello world")))
+	assert.Equal(t, "hello world", mdtext.ExtractPlainText(para, nil))
+}
+
 // --- CountWords tests ---
 
 func TestCountWords_Simple(t *testing.T) {

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jeduden/mdsmith/internal/globpath"
+	"github.com/jeduden/mdsmith/internal/linkgraph"
 	"github.com/jeduden/mdsmith/internal/lint"
-	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
-	"github.com/yuin/goldmark/ast"
 )
 
 func init() {
@@ -50,58 +49,44 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		return []lint.Diagnostic{configDiag(f.Path, r, err)}
 	}
 
-	selfAnchors := collectHeadingAnchors(f)
+	selfAnchors := linkgraph.CollectAnchors(f)
 	anchorCache := map[string]map[string]bool{"self": selfAnchors}
 
 	// Precompute the resolved absolute root once for all link checks.
 	resolvedRoot := resolveAbsRoot(f.RootDir)
 
 	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-
-		linkNode, ok := n.(*ast.Link)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
+	for _, link := range linkgraph.ExtractLinks(f) {
 		diags = append(diags, r.checkLink(
 			f,
-			linkNode,
+			link,
 			r.Include,
 			r.Exclude,
 			selfAnchors,
 			resolvedRoot,
 			anchorCache,
 		)...)
-
-		return ast.WalkContinue, nil
-	})
+	}
 
 	return diags
 }
 
 func (r *Rule) checkLink(
 	f *lint.File,
-	linkNode *ast.Link,
+	link linkgraph.Link,
 	includePatterns []string,
 	excludePatterns []string,
 	selfAnchors map[string]bool,
 	resolvedRoot string,
 	anchorCache map[string]map[string]bool,
 ) []lint.Diagnostic {
-	target, ok := parseTarget(string(linkNode.Destination))
-	if !ok {
-		return nil
-	}
+	target := link.Target
 
 	if placeholders.ContainsBodyToken(target.Raw, r.Placeholders) {
 		return nil
 	}
 
-	line, col := linkPosition(f, linkNode)
+	line, col := link.Line, link.Column
 
 	if target.LocalAnchor {
 		return checkLocalAnchor(f.Path, line, col, r, target, selfAnchors)
@@ -137,16 +122,16 @@ func (r *Rule) checkLink(
 	if err != nil {
 		return []lint.Diagnostic{unreadableTargetDiag(f.Path, line, col, r, target.Raw, err)}
 	}
-	if targetAnchors[normalizeAnchor(target.Anchor)] {
+	if targetAnchors[linkgraph.NormalizeAnchor(target.Anchor)] {
 		return nil
 	}
 	return []lint.Diagnostic{brokenHeadingDiag(f.Path, line, col, r, target.Raw)}
 }
 
 func checkLocalAnchor(
-	path string, line, col int, r *Rule, target linkTarget, selfAnchors map[string]bool,
+	path string, line, col int, r *Rule, target linkgraph.Target, selfAnchors map[string]bool,
 ) []lint.Diagnostic {
-	if selfAnchors[normalizeAnchor(target.Anchor)] {
+	if selfAnchors[linkgraph.NormalizeAnchor(target.Anchor)] {
 		return nil
 	}
 	return []lint.Diagnostic{brokenHeadingDiag(path, line, col, r, target.Raw)}
@@ -259,7 +244,7 @@ func anchorsForFile(target targetFile, cache map[string]map[string]bool) (map[st
 		return nil, err
 	}
 
-	anchors := collectHeadingAnchors(file)
+	anchors := linkgraph.CollectAnchors(file)
 	cache[target.cacheKey] = anchors
 	return anchors, nil
 }
@@ -360,116 +345,9 @@ func resolveTargetOSPath(sourcePath, linkPath string) (string, bool) {
 	return filepath.Clean(filepath.Join(filepath.Dir(sourcePath), linkPath)), true
 }
 
-func collectHeadingAnchors(f *lint.File) map[string]bool {
-	anchors := make(map[string]bool)
-	seen := make(map[string]int)
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-
-		h, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		slug := mdtext.Slugify(extractText(h, f.Source))
-		if slug == "" {
-			return ast.WalkContinue, nil
-		}
-
-		count := seen[slug]
-		anchor := slug
-		if count > 0 {
-			anchor = fmt.Sprintf("%s-%d", slug, count)
-		}
-		seen[slug] = count + 1
-		anchors[anchor] = true
-
-		return ast.WalkContinue, nil
-	})
-
-	return anchors
-}
-
-func extractText(node ast.Node, source []byte) string {
-	var b strings.Builder
-	appendNodeText(&b, node, source)
-	return b.String()
-}
-
-func appendNodeText(b *strings.Builder, node ast.Node, source []byte) {
-	switch n := node.(type) {
-	case *ast.Text:
-		b.Write(n.Segment.Value(source))
-		return
-	case *ast.String:
-		b.Write(n.Value)
-		return
-	}
-
-	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
-		appendNodeText(b, child, source)
-	}
-}
-
-func normalizeAnchor(anchor string) string {
-	decoded, err := url.PathUnescape(anchor)
-	if err == nil {
-		anchor = decoded
-	}
-	return mdtext.Slugify(anchor)
-}
-
 func isMarkdownPath(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
 	return ext == ".md" || ext == ".markdown"
-}
-
-type linkTarget struct {
-	Raw         string
-	Path        string
-	Anchor      string
-	LocalAnchor bool
-}
-
-func parseTarget(dest string) (linkTarget, bool) {
-	dest = strings.TrimSpace(dest)
-	if dest == "" || strings.HasPrefix(dest, "//") {
-		return linkTarget{}, false
-	}
-
-	u, err := url.Parse(dest)
-	if err != nil {
-		return linkTarget{}, false
-	}
-	if u.Scheme != "" || u.Host != "" {
-		return linkTarget{}, false
-	}
-
-	path := u.Path
-	if path == "" && u.Opaque != "" {
-		path = u.Opaque
-	}
-
-	if path == "" && u.Fragment != "" {
-		return linkTarget{
-			Raw:         dest,
-			Anchor:      u.Fragment,
-			LocalAnchor: true,
-		}, true
-	}
-
-	if path == "" {
-		return linkTarget{}, false
-	}
-
-	return linkTarget{
-		Raw:    dest,
-		Path:   path,
-		Anchor: u.Fragment,
-	}, true
 }
 
 func normalizeLinkPath(linkPath string) string {
@@ -516,39 +394,6 @@ func matchesPathFilters(path string, include, exclude []string) bool {
 	}
 
 	return true
-}
-
-func linkPosition(f *lint.File, n ast.Node) (int, int) {
-	offset := firstTextOffset(n)
-	if offset < 0 {
-		return 1, 1
-	}
-	line := f.LineOfOffset(offset)
-	lineStart := 0
-	for i := 0; i < offset && i < len(f.Source); i++ {
-		if f.Source[i] == '\n' {
-			lineStart = i + 1
-		}
-	}
-	return line, offset - lineStart + 1
-}
-
-func firstTextOffset(n ast.Node) int {
-	offset := -1
-	_ = ast.Walk(n, func(cur ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		text, ok := cur.(*ast.Text)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		if offset == -1 || text.Segment.Start < offset {
-			offset = text.Segment.Start
-		}
-		return ast.WalkContinue, nil
-	})
-	return offset
 }
 
 func configDiag(path string, r *Rule, err error) lint.Diagnostic {

--- a/internal/rules/crossfilereferenceintegrity/rule_morecoverage_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_morecoverage_test.go
@@ -5,8 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	gast "github.com/yuin/goldmark/ast"
-
+	"github.com/jeduden/mdsmith/internal/linkgraph"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +17,7 @@ func TestCollectHeadingAnchors_EmptySlug(t *testing.T) {
 	// An empty heading "# " produces an empty slug.
 	f, err := lint.NewFile("test.md", []byte("# \n\nSome text.\n"))
 	require.NoError(t, err)
-	anchors := collectHeadingAnchors(f)
+	anchors := linkgraph.CollectAnchors(f)
 	// Empty slug is skipped, so anchors should be empty.
 	require.Empty(t, anchors)
 }
@@ -28,7 +27,7 @@ func TestCollectHeadingAnchors_EmptySlug(t *testing.T) {
 func TestCollectHeadingAnchors_DuplicateHeadings(t *testing.T) {
 	f, err := lint.NewFile("test.md", []byte("# Intro\n\n## Intro\n"))
 	require.NoError(t, err)
-	anchors := collectHeadingAnchors(f)
+	anchors := linkgraph.CollectAnchors(f)
 	require.True(t, anchors["intro"], "first heading should be 'intro'")
 	require.True(t, anchors["intro-1"], "second heading should be 'intro-1'")
 }
@@ -94,7 +93,7 @@ func TestResolveTargetOSPath_DotSourcePath(t *testing.T) {
 func TestParseTarget_EmptyPathNoFragment(t *testing.T) {
 	// A URL like "?" (query only) has no scheme, host, path, or fragment.
 	// url.Parse("?q=1") => {RawQuery: "q=1"} — path == "", fragment == ""
-	_, ok := parseTarget("?q=1")
+	_, ok := linkgraph.ParseTarget("?q=1")
 	require.False(t, ok, "URL with only query should return false")
 }
 
@@ -185,7 +184,7 @@ func TestCheck_InvalidExcludeGlobReturnsConfigDiag(t *testing.T) {
 // --- parseTarget: plain relative path sets Path, not Opaque ---
 // url.Parse("guide.md") sets Path="guide.md"; Opaque is empty.
 func TestParseTarget_PlainRelativePath(t *testing.T) {
-	target, ok := parseTarget("guide.md")
+	target, ok := linkgraph.ParseTarget("guide.md")
 	require.True(t, ok)
 	require.Equal(t, "guide.md", target.Path)
 	require.Empty(t, target.Anchor)
@@ -216,23 +215,6 @@ func TestMatchesPathFilters_IncludeNoMatch(t *testing.T) {
 	// "other/page.md" doesn't match "docs/**"
 	result := matchesPathFilters("other/page.md", include, nil)
 	require.False(t, result, "path not in include should return false")
-}
-
-// --- linkPosition: offset < 0 (no *ast.Text children in the link) ---
-
-func TestLinkPosition_NoTextChildren(t *testing.T) {
-	// Build a lint.File and a fake ast.Link with no children.
-	// linkPosition calls firstTextOffset, which returns -1 when no ast.Text
-	// nodes are found, causing the "if offset < 0 { return 1, 1 }" branch.
-	f, err := lint.NewFile("test.md", []byte("# Title\n"))
-	require.NoError(t, err)
-
-	linkNode := gast.NewLink()
-	// No children → firstTextOffset returns -1 → offset < 0 → return 1, 1
-
-	line, col := linkPosition(f, linkNode)
-	require.Equal(t, 1, line)
-	require.Equal(t, 1, col)
 }
 
 // --- Collect: compute returns an error path in rank.go ---

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -54,6 +54,34 @@ func TestCheck_MissingHeadingAnchor(t *testing.T) {
 		"message = %q, want to include guide.md#missing", diags[0].Message)
 }
 
+// TestCheck_FrontMatterLineNumbersBodyRelative verifies that MDS027
+// emits body-relative line numbers when the source has front matter.
+// The engine adds f.LineOffset to every diagnostic in CheckRules, so
+// link.Line must NOT already include that offset — otherwise the line
+// is shifted twice and points past the end of the file.
+func TestCheck_FrontMatterLineNumbersBodyRelative(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	// 3 lines of front matter + body. The broken link is on body line 3.
+	source := "---\ntitle: x\n---\n# Doc\n\nSee [missing](missing.md).\n"
+	writeFile(t, sourcePath, source)
+
+	data, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	// Use NewFileFromSource (the same shape the engine uses for files
+	// with front matter): strips the prefix, records LineOffset=3.
+	f, err := lint.NewFileFromSource(sourcePath, data, true)
+	require.NoError(t, err)
+	f.FS = os.DirFS(filepath.Dir(sourcePath))
+
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	// Body-relative: link is on body line 3 ("See [missing]…"), not
+	// file-relative 6. The engine adds LineOffset later.
+	require.Equal(t, 3, diags[0].Line,
+		"diagnostic must use body-relative coordinates; engine adds f.LineOffset")
+}
+
 func TestCheck_ValidRelativeAndLocalAnchors(t *testing.T) {
 	dir := t.TempDir()
 	targetPath := filepath.Join(dir, "guide.md")

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -7,8 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	gast "github.com/yuin/goldmark/ast"
-
+	"github.com/jeduden/mdsmith/internal/linkgraph"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 
@@ -503,7 +502,7 @@ func TestCheck_InvalidIncludeGlobReturnsConfigDiag(t *testing.T) {
 // =====================================================================
 
 func TestParseTarget_AnchorOnly(t *testing.T) {
-	target, ok := parseTarget("#section")
+	target, ok := linkgraph.ParseTarget("#section")
 	require.True(t, ok)
 	require.Equal(t, "#section", target.Raw)
 	require.Equal(t, "section", target.Anchor)
@@ -512,22 +511,22 @@ func TestParseTarget_AnchorOnly(t *testing.T) {
 }
 
 func TestParseTarget_Empty(t *testing.T) {
-	_, ok := parseTarget("")
+	_, ok := linkgraph.ParseTarget("")
 	require.False(t, ok)
 }
 
 func TestParseTarget_ProtocolRelative(t *testing.T) {
-	_, ok := parseTarget("//example.com/path")
+	_, ok := linkgraph.ParseTarget("//example.com/path")
 	require.False(t, ok)
 }
 
 func TestParseTarget_AbsoluteURL(t *testing.T) {
-	_, ok := parseTarget("https://example.com/path")
+	_, ok := linkgraph.ParseTarget("https://example.com/path")
 	require.False(t, ok)
 }
 
 func TestParseTarget_PathWithAnchor(t *testing.T) {
-	target, ok := parseTarget("guide.md#intro")
+	target, ok := linkgraph.ParseTarget("guide.md#intro")
 	require.True(t, ok)
 	require.Equal(t, "guide.md", target.Path)
 	require.Equal(t, "intro", target.Anchor)
@@ -535,7 +534,7 @@ func TestParseTarget_PathWithAnchor(t *testing.T) {
 }
 
 func TestParseTarget_EncodedPath(t *testing.T) {
-	target, ok := parseTarget("my%20file.md")
+	target, ok := linkgraph.ParseTarget("my%20file.md")
 	require.True(t, ok)
 	// url.Parse decodes percent-encoded characters in the path.
 	require.Equal(t, "my file.md", target.Path)
@@ -612,21 +611,6 @@ func TestAnchorsForFile_ReadError(t *testing.T) {
 	_, err := anchorsForFile(tf, cache)
 	require.Error(t, err)
 	require.Equal(t, readErr, err)
-}
-
-// =====================================================================
-// Additional coverage: appendNodeText with *ast.String
-// =====================================================================
-
-// TestAppendNodeText_AstString exercises the *ast.String branch of appendNodeText.
-// ast.String is created by the typographer extension and other paragraph
-// transforms; we construct one directly to keep the test self-contained.
-func TestAppendNodeText_AstString(t *testing.T) {
-	strNode := gast.NewString([]byte("hello"))
-
-	var b strings.Builder
-	appendNodeText(&b, strNode, nil)
-	require.Equal(t, "hello", b.String())
 }
 
 // =====================================================================

--- a/plan/138_backlinks-subcommand.md
+++ b/plan/138_backlinks-subcommand.md
@@ -1,7 +1,7 @@
 ---
 id: 138
 title: "`mdsmith backlinks` subcommand"
-status: "🔲"
+status: "🔳"
 model: sonnet
 summary: >-
   Surface MDS027's link graph as a CLI subcommand.
@@ -158,20 +158,20 @@ trigger.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith backlinks docs/api.md` returns
+- [x] `mdsmith backlinks docs/api.md` returns
       every workspace link to that path, one
       per line, with source path and line.
-- [ ] `mdsmith backlinks docs/api.md#auth`
+- [x] `mdsmith backlinks docs/api.md#auth`
       filters by resolved anchor.
-- [ ] `mdsmith backlinks --format json` emits
+- [x] `mdsmith backlinks --format json` emits
       the documented JSON shape.
-- [ ] `--include GLOB` and `--limit N` scope
+- [x] `--include GLOB` and `--limit N` scope
       the result.
-- [ ] MDS027 and the subcommand share one
+- [x] MDS027 and the subcommand share one
       link-graph builder (no duplicated walk).
-- [ ] A new `docs/reference/cli/backlinks.md`
+- [x] A new `docs/reference/cli/backlinks.md`
       page describes the subcommand with one
       worked example.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues.

--- a/plan/138_backlinks-subcommand.md
+++ b/plan/138_backlinks-subcommand.md
@@ -1,16 +1,16 @@
 ---
 id: 138
-title: "`mdsmith backlinks` subcommand"
+title: "`mdsmith list backlinks` subcommand"
 status: "✅"
 model: sonnet
 summary: >-
   Surface MDS027's link graph as a CLI subcommand.
-  `mdsmith backlinks <file>` lists every workspace
+  `mdsmith list backlinks <file>` lists every workspace
   file with a link to the target, optionally
   scoped by anchor. JSON output for agent / tooling
   consumers.
 ---
-# `mdsmith backlinks` subcommand
+# `mdsmith list backlinks` subcommand
 
 ## Goal
 
@@ -51,7 +51,7 @@ read in reverse.
 ### Invocation
 
 ```bash
-mdsmith backlinks docs/api.md
+mdsmith list backlinks docs/api.md
 ```
 
 Output is one line per incoming link, sorted by
@@ -72,7 +72,7 @@ learn a second shape.
 ### Anchor scoping
 
 ```bash
-mdsmith backlinks docs/api.md#authentication
+mdsmith list backlinks docs/api.md#authentication
 ```
 
 Returns only links whose anchor resolves to the
@@ -82,7 +82,7 @@ MDS027 applies for cross-file anchor checks.
 ### JSON output
 
 ```bash
-mdsmith backlinks --format json docs/api.md
+mdsmith list backlinks --format json docs/api.md
 ```
 
 ```json
@@ -158,12 +158,12 @@ trigger.
 
 ## Acceptance Criteria
 
-- [x] `mdsmith backlinks docs/api.md` returns
+- [x] `mdsmith list backlinks docs/api.md` returns
       every workspace link to that path, one
       per line, with source path and line.
-- [x] `mdsmith backlinks docs/api.md#auth`
+- [x] `mdsmith list backlinks docs/api.md#auth`
       filters by resolved anchor.
-- [x] `mdsmith backlinks --format json` emits
+- [x] `mdsmith list backlinks --format json` emits
       the documented JSON shape.
 - [x] `--include GLOB` and `--limit N` scope
       the result.

--- a/plan/138_backlinks-subcommand.md
+++ b/plan/138_backlinks-subcommand.md
@@ -1,7 +1,7 @@
 ---
 id: 138
 title: "`mdsmith backlinks` subcommand"
-status: "🔳"
+status: "✅"
 model: sonnet
 summary: >-
   Surface MDS027's link graph as a CLI subcommand.

--- a/plan/78_query-command.md
+++ b/plan/78_query-command.md
@@ -2,7 +2,7 @@
 id: 78
 title: "Query subcommand for front-matter filtering"
 status: "✅"
-summary: "Add mdsmith query to select files by CUE expression on front matter"
+summary: "Add mdsmith list query to select files by CUE expression on front matter"
 ---
 # Query subcommand for front-matter filtering
 
@@ -18,7 +18,7 @@ A general `query` subcommand prints matching file paths
 to stdout. Callers compose it with Unix tools:
 
 ```bash
-mdsmith query 'status: "✅"' "plan/[0-9]*.md" \
+mdsmith list query 'status: "✅"' "plan/[0-9]*.md" \
   | xargs git rm
 ```
 
@@ -29,14 +29,14 @@ same mechanism `validateFrontMatterCUE` uses.
 
 ## Goal
 
-Add `mdsmith query` to print paths of Markdown files
+Add `mdsmith list query` to print paths of Markdown files
 whose front matter satisfies a CUE expression, one path
 per line on stdout.
 
 ## Design
 
 ```bash
-mdsmith query [flags] <cue-expr> [files...]
+mdsmith list query [flags] <cue-expr> [files...]
 ```
 
 Flags:
@@ -53,20 +53,20 @@ Examples:
 
 ```bash
 # List completed plans
-mdsmith query 'status: "✅"' "plan/[0-9]*.md"
+mdsmith list query 'status: "✅"' "plan/[0-9]*.md"
 
 # Delete them
-mdsmith query 'status: "✅"' "plan/[0-9]*.md" \
+mdsmith list query 'status: "✅"' "plan/[0-9]*.md" \
   | xargs git rm
 
 # NUL-delimited for paths with spaces
-mdsmith query -0 'status: "✅"' plan/ | xargs -0 rm
+mdsmith list query -0 'status: "✅"' plan/ | xargs -0 rm
 
 # Compound condition
-mdsmith query 'status: "✅", id: >50' plan/
+mdsmith list query 'status: "✅", id: >50' plan/
 
 # All plans not yet started
-mdsmith query 'status: "🔲"' plan/
+mdsmith list query 'status: "🔲"' plan/
 ```
 
 Output goes to stdout (one path per line). Status
@@ -141,7 +141,7 @@ keep numeric types so `id: >50` works.
 
 ## Acceptance Criteria
 
-- [x] `mdsmith query 'status: "✅"' plan/` prints paths
+- [x] `mdsmith list query 'status: "✅"' plan/` prints paths
   of completed plans, one per line
 - [x] Piping into `xargs git rm` deletes them
 - [x] Exit 0 on match, exit 1 on no match

--- a/plan/93_placeholder-grammar.md
+++ b/plan/93_placeholder-grammar.md
@@ -158,7 +158,7 @@ the list comes from config.
       opt-in rule README.
 - [x] `mdsmith help placeholder-grammar` prints the
       concept page summary.
-- [x] `mdsmith query` parses a file with CUE-pattern
+- [x] `mdsmith list query` parses a file with CUE-pattern
       front matter under a placeholder-aware kind
       (covered by test).
 - [x] All tests pass: `go test ./...`


### PR DESCRIPTION
## Summary

Implements the `mdsmith list backlinks` subcommand to query the link graph in reverse, showing every workspace file that links to a given target. This surfaces MDS027's (cross-file-reference-integrity) link-walking logic as a user-facing CLI tool. The selection-style commands now nest under a `list` parent — see the "CLI layout" note below.

## Key Changes

- **New `linkgraph` package** (`internal/linkgraph/`): Extracted shared link and anchor parsing logic from MDS027 into a reusable module
  - `ParseTarget()`: Parses Markdown link destinations into structured targets
  - `ExtractLinks()`: Walks AST to collect all direct (non-reference-style) links with line/column info
  - `CollectAnchors()`: Gathers heading anchors with GitHub-compatible disambiguation (-1, -2, …)
  - `NormalizeAnchor()`: URL-decodes and slugifies anchors for comparison

- **New `list backlinks` subcommand** (`cmd/mdsmith/backlinks.go`):
  - Accepts a target file path with optional anchor (`docs/api.md#section`)
  - Walks all workspace files and collects incoming links matching the target
  - Supports filtering by source path (`--include` glob patterns)
  - Outputs in text (default) or JSON format
  - Respects `--limit` for pagination
  - Exit codes: 0 (matches found), 1 (no matches), 2 (error)

- **CLI layout — `mdsmith list <sub>`**: query and backlinks now nest under a shared `list` parent (`cmd/mdsmith/list.go`). Hard break — `mdsmith query` and `mdsmith backlinks` no longer dispatch. New invocations:
  - `mdsmith list query <cue-expr> [files...]`
  - `mdsmith list backlinks [flags] <target>`

- **Refactored MDS027** (`internal/rules/crossfilereferenceintegrity/`):
  - Replaced local `parseTarget()`, `collectHeadingAnchors()`, `normalizeAnchor()`, and `linkPosition()` with calls to the new `linkgraph` package
  - Updated to use `linkgraph.ExtractLinks()` instead of manual AST walking

- **Intentional MDS027 behavior changes** (carried over with the refactor):
  - **Anchor disambiguation is now globally unique.** The old per-slug counter could produce two headings with the same anchor — e.g. headings `Intro`, `Intro`, `Intro-1` collapsed onto `intro-1` twice. The shared `mdtext.CollectTOCItems` routine increments suffixes until the result is unique, so the third heading now becomes `intro-1-1`. This brings MDS027 in line with the LSP index and TOC directive and fixes a latent broken-anchor false-negative.
  - **Heading text extraction handles `*ast.String` nodes** (e.g. produced by the typographer extension). The fix lives in `mdtext.ExtractPlainText` so every consumer (linkgraph, LSP index, TOC directive) benefits.

- **Comprehensive test coverage**:
  - Unit tests for path normalization, link resolution, output formatting, and the disambiguation/`ast.String` regressions above
  - End-to-end tests validating anchor filtering, include patterns, JSON output, ignore-pattern scope, and malformed-target rejection
  - Linkgraph tests confirming agreement with MDS027's link extraction

- **Documentation**: Added `docs/reference/cli/backlinks.md` and a new `docs/reference/cli/list.md` parent page with usage examples, flags, and output format specifications

## Implementation Details

- The backlinks implementation reuses the exact same link-extraction and anchor-normalization logic MDS027 uses, ensuring the incoming-link set mirrors the outgoing-link set MDS027 validates
- Reference-style links are intentionally excluded (they resolve through the link-reference map, not direct URLs)
- Output is sorted by source path then line number for deterministic pagination
- JSON output guarantees an empty array `[]` (never `null`) for consistency with downstream tooling

https://claude.ai/code/session_01J6nHPTzd4R6rjMecM95e5p