### PR TITLE
feat(kinds): add fields-present selector to kind-assignment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -50,7 +50,7 @@ footer: |
 | 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                   |
 | 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
 | 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                   |
-| 139 | 🔲     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
+| 139 | ✅     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
 | 140 | ✅     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |
 | 143 | ✅     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                              |

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -263,12 +263,12 @@ func readFrontMatter(cfg *config.Config, path string, maxBytes int64) ([]string,
 	if err != nil {
 		return nil, nil, err
 	}
-	if !config.HasFieldsPresentSelector(cfg) {
+	if !config.NeedsFieldsForFile(cfg, path) {
 		return kinds, nil, nil
 	}
 	fields, err := lint.ParseFrontMatterFields(prefix)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("parsing front matter in %q: %w", path, err)
 	}
 	return kinds, fields, nil
 }

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -271,7 +271,7 @@ func readFrontMatter(cfg *config.Config, path string, maxBytes int64) ([]string,
 	}
 	fields, err := lint.ParseFrontMatterFields(prefix)
 	if err != nil {
-		return nil, nil, fmt.Errorf("parsing front matter in %q: %w", path, err)
+		return nil, nil, fmt.Errorf("parsing front matter: %w", err)
 	}
 	return kinds, fields, nil
 }

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -249,8 +249,11 @@ func runKindsPath(stdout io.Writer, args []string) int {
 
 // readFrontMatter reads a file and returns both the parsed kinds list and
 // the full front-matter mapping, the latter feeding the kind-assignment
-// `fields-present:` selector.
-func readFrontMatter(path string, maxBytes int64) ([]string, map[string]any, error) {
+// `fields-present:` selector. The full-mapping decode runs only when at
+// least one kind-assignment entry uses `fields-present:` — without that
+// gate, `kinds resolve` would fail on FM YAML errors that the
+// kinds-only fast path silently ignores.
+func readFrontMatter(cfg *config.Config, path string, maxBytes int64) ([]string, map[string]any, error) {
 	data, err := lint.ReadFileLimited(path, maxBytes)
 	if err != nil {
 		return nil, nil, err
@@ -259,6 +262,9 @@ func readFrontMatter(path string, maxBytes int64) ([]string, map[string]any, err
 	kinds, err := lint.ParseFrontMatterKinds(prefix)
 	if err != nil {
 		return nil, nil, err
+	}
+	if !config.HasFieldsPresentSelector(cfg) {
+		return kinds, nil, nil
 	}
 	fields, err := lint.ParseFrontMatterFields(prefix)
 	if err != nil {
@@ -289,7 +295,7 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 			return nil, nil, 2
 		}
-		fmKinds, fmFields, err = readFrontMatter(path, maxBytes)
+		fmKinds, fmFields, err = readFrontMatter(cfg, path, maxBytes)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
 			return nil, nil, 2

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -249,10 +249,13 @@ func runKindsPath(stdout io.Writer, args []string) int {
 
 // readFrontMatter reads a file and returns both the parsed kinds list and
 // the full front-matter mapping, the latter feeding the kind-assignment
-// `fields-present:` selector. The full-mapping decode runs only when at
-// least one kind-assignment entry uses `fields-present:` — without that
-// gate, `kinds resolve` would fail on FM YAML errors that the
-// kinds-only fast path silently ignores.
+// `fields-present:` selector. The full-mapping decode runs only when
+// `config.NeedsFieldsForFile(cfg, path)` returns true — i.e. when at
+// least one kind-assignment entry with `fields-present:` could match
+// this path (an entry without a glob, or one whose glob matches).
+// Files outside every fields-present scope keep the kinds-only fast
+// path's leniency for FM YAML errors that decode would otherwise
+// surface.
 func readFrontMatter(cfg *config.Config, path string, maxBytes int64) ([]string, map[string]any, error) {
 	data, err := lint.ReadFileLimited(path, maxBytes)
 	if err != nil {

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -247,15 +247,24 @@ func runKindsPath(stdout io.Writer, args []string) int {
 	return 0
 }
 
-// readFrontMatterKinds reads a file and parses its front-matter kinds: list.
-// Returns nil kinds when the file has no front matter or no kinds: field.
-func readFrontMatterKinds(path string, maxBytes int64) ([]string, error) {
+// readFrontMatter reads a file and returns both the parsed kinds list and
+// the full front-matter mapping, the latter feeding the kind-assignment
+// `fields-present:` selector.
+func readFrontMatter(path string, maxBytes int64) ([]string, map[string]any, error) {
 	data, err := lint.ReadFileLimited(path, maxBytes)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	prefix, _ := lint.StripFrontMatter(data)
-	return lint.ParseFrontMatterKinds(prefix)
+	kinds, err := lint.ParseFrontMatterKinds(prefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	fields, err := lint.ParseFrontMatterFields(prefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	return kinds, fields, nil
 }
 
 // resolveFileFromCLI loads config, parses the file's front matter for
@@ -273,13 +282,14 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 	}
 
 	var fmKinds []string
+	var fmFields map[string]any
 	if frontMatterEnabled(cfg) {
 		maxBytes, err := resolveMaxInputBytes(cfg, "")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 			return nil, nil, 2
 		}
-		fmKinds, err = readFrontMatterKinds(path, maxBytes)
+		fmKinds, fmFields, err = readFrontMatter(path, maxBytes)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", path, err)
 			return nil, nil, 2
@@ -304,7 +314,7 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 		}
 	}
 
-	return config.ResolveFile(cfg, path, fmKinds), cfg, 0
+	return config.ResolveFile(cfg, path, fmKinds, fmFields), cfg, 0
 }
 
 // runKindsResolve prints the resolved kind list and merged rule config

--- a/cmd/mdsmith/kinds_e2e_test.go
+++ b/cmd/mdsmith/kinds_e2e_test.go
@@ -317,6 +317,26 @@ kind-assignment:
 	assert.Contains(t, stdout, "plan (from kind-assignment[0]: glob plan/*.md AND fields-present id)")
 }
 
+// When the file front matter cannot be decoded as a mapping AND the
+// config has a fields-present entry that could match this path, the
+// CLI surfaces the parse failure with "parsing front matter" context
+// — not the misleading "reading <path>" prefix the unwrapped error
+// would have produced.
+func TestKinds_ResolveFieldsPresentParseErrorContext(t *testing.T) {
+	cfg := `kinds:
+  task: {}
+kind-assignment:
+  - fields-present: [status]
+    kinds: [task]
+`
+	doc := "---\n- not\n- a\n- mapping\n---\n# Bad\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"bad.md": doc})
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "bad.md")
+	require.Equal(t, 2, code)
+	assert.Contains(t, stderr, "parsing front matter")
+	assert.Contains(t, stderr, "bad.md")
+}
+
 func TestKinds_ResolveMissingFileArg(t *testing.T) {
 	dir := kindsTestDir(t, sampleKindsCfg, nil)
 	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve")

--- a/cmd/mdsmith/kinds_e2e_test.go
+++ b/cmd/mdsmith/kinds_e2e_test.go
@@ -206,7 +206,7 @@ func TestKinds_ResolveTextShowsPerLeafProvenance(t *testing.T) {
 	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "plan/9_big.md")
 	require.Equal(t, 0, code)
 	assert.Contains(t, stdout, "file: plan/9_big.md")
-	assert.Contains(t, stdout, "plan (from kind-assignment[0])")
+	assert.Contains(t, stdout, "plan (from kind-assignment[0]: glob")
 	assert.Contains(t, stdout, "max-file-length")
 	// Override applies to plan/9_big.md, so the winning source for max is overrides[0].
 	assert.Contains(t, stdout, "settings.max")
@@ -270,6 +270,51 @@ rules:
 	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "doc.md")
 	require.Equal(t, 0, code)
 	assert.Contains(t, stdout, "proto (from front-matter)")
+}
+
+func TestKinds_ResolveFromFieldsPresent(t *testing.T) {
+	cfg := `kinds:
+  task: {}
+kind-assignment:
+  - fields-present: [status, priority, assignee]
+    kinds: [task]
+`
+	doc := "---\nstatus: open\npriority: high\nassignee: alice\n---\n# T\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"anywhere/doc.md": doc})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "anywhere/doc.md")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "task (from kind-assignment[0]: fields-present status,priority,assignee)")
+}
+
+func TestKinds_ResolveFromFieldsPresentMissingField(t *testing.T) {
+	cfg := `kinds:
+  task: {}
+kind-assignment:
+  - fields-present: [status, priority, assignee]
+    kinds: [task]
+`
+	// priority missing — entry should not match.
+	doc := "---\nstatus: open\nassignee: alice\n---\n# T\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"anywhere/doc.md": doc})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "anywhere/doc.md")
+	require.Equal(t, 0, code)
+	assert.NotContains(t, stdout, "task (from kind-assignment")
+	assert.Contains(t, stdout, "effective kinds:\n  (none)")
+}
+
+func TestKinds_ResolveGlobAndFieldsPresent(t *testing.T) {
+	cfg := `kinds:
+  plan: {}
+kind-assignment:
+  - glob: ["plan/*.md"]
+    fields-present: [id]
+    kinds: [plan]
+`
+	doc := "---\nid: 132\n---\n# T\n"
+	dir := kindsTestDir(t, cfg, map[string]string{"plan/132_inline.md": doc})
+	stdout, _, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "plan/132_inline.md")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "plan (from kind-assignment[0]: glob plan/*.md AND fields-present id)")
 }
 
 func TestKinds_ResolveMissingFileArg(t *testing.T) {

--- a/cmd/mdsmith/kinds_e2e_test.go
+++ b/cmd/mdsmith/kinds_e2e_test.go
@@ -319,9 +319,9 @@ kind-assignment:
 
 // When the file front matter cannot be decoded as a mapping AND the
 // config has a fields-present entry that could match this path, the
-// CLI surfaces the parse failure with "parsing front matter" context
-// — not the misleading "reading <path>" prefix the unwrapped error
-// would have produced.
+// CLI wraps the failure with "parsing front matter" context so users
+// see the parse failure category (not a bare yaml error) under the
+// caller's "reading <path>:" prefix.
 func TestKinds_ResolveFieldsPresentParseErrorContext(t *testing.T) {
 	cfg := `kinds:
   task: {}

--- a/cmd/mdsmith/kinds_unit_test.go
+++ b/cmd/mdsmith/kinds_unit_test.go
@@ -331,6 +331,74 @@ func TestRunKindsResolve_FrontMatterDisabledDirectoryReportsError(t *testing.T) 
 	assert.Contains(t, got, "reading ")
 }
 
+// TestReadFrontMatter_FieldsPresentParseErrorWraps confirms that when a
+// kind-assignment entry uses fields-present:, a malformed FM mapping
+// produces a parse error wrapped with "parsing front matter:". Without
+// the selector, the same input passes (kinds-only fast path).
+func TestReadFrontMatter_FieldsPresentParseErrorWraps(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "bad.md")
+	require.NoError(t, os.WriteFile(mdPath,
+		[]byte("---\n- not\n- a\n- mapping\n---\n# Bad\n"), 0o644))
+
+	cfgNoSelector := &config.Config{}
+	kinds, fields, err := readFrontMatter(cfgNoSelector, mdPath, 0)
+	require.NoError(t, err, "no fields-present selector → kinds-only path")
+	assert.Nil(t, kinds)
+	assert.Nil(t, fields)
+
+	cfgWithSelector := &config.Config{
+		Kinds: map[string]config.KindBody{"task": {}},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+	_, _, err = readFrontMatter(cfgWithSelector, mdPath, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing front matter")
+}
+
+// TestReadFrontMatter_FieldsPresentReturnsMapping confirms that when the
+// selector is active and the front matter is a valid mapping, the parsed
+// fields are returned alongside the kinds list.
+func TestReadFrontMatter_FieldsPresentReturnsMapping(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "ok.md")
+	require.NoError(t, os.WriteFile(mdPath,
+		[]byte("---\nstatus: open\nid: 7\n---\n# Hi\n"), 0o644))
+
+	cfg := &config.Config{
+		Kinds: map[string]config.KindBody{"task": {}},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+	kinds, fields, err := readFrontMatter(cfg, mdPath, 0)
+	require.NoError(t, err)
+	assert.Nil(t, kinds, "no kinds: key in front matter")
+	assert.Equal(t, "open", fields["status"])
+	assert.Equal(t, 7, fields["id"])
+}
+
+// TestReadFrontMatter_ReadErrorPropagated confirms that a missing file
+// surfaces an error from ReadFileLimited rather than silently returning
+// empty kinds.
+func TestReadFrontMatter_ReadErrorPropagated(t *testing.T) {
+	_, _, err := readFrontMatter(&config.Config{}, "/no/such/file.md", 0)
+	require.Error(t, err)
+}
+
+// TestReadFrontMatter_KindsParseErrorPropagated confirms that an invalid
+// YAML kinds: list surfaces the ParseFrontMatterKinds error.
+func TestReadFrontMatter_KindsParseErrorPropagated(t *testing.T) {
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "bad-kinds.md")
+	require.NoError(t, os.WriteFile(mdPath,
+		[]byte("---\nkinds: [[[invalid\n---\n"), 0o644))
+	_, _, err := readFrontMatter(&config.Config{}, mdPath, 0)
+	require.Error(t, err)
+}
+
 // Compile-time assertion that the failing writers implement io.Writer.
 var (
 	_ io.Writer = alwaysFailingWriter{}

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -98,7 +98,9 @@ concatenated in this order:
    list).
 2. Matching entries in `kind-assignment:`, in the order
    they appear in the config; within an entry, kinds in
-   the order listed.
+   the order listed. An entry can select files by `glob:`
+   and/or `fields-present:` (front-matter keys with
+   non-null values).
 
 Duplicate names are dropped after their first occurrence.
 
@@ -169,6 +171,63 @@ In the example above, `plan/proto.md` matches both
 so its effective kind list is `[proto, plan]`. A regular
 plan file like `plan/96_kinds-adoption-and-docs.md` only
 matches `plan/*.md`, so it resolves to `[plan]`.
+
+### Field-presence assignment
+
+An entry can require that a file's front matter carries a
+configured set of keys, each with a non-null value. Pair
+this with `glob:` when a project identifies a file's role
+by its front-matter shape rather than (or in addition to)
+its location.
+
+```yaml
+kind-assignment:
+  - glob: ["docs/**"]
+    kinds: [doc]
+  - fields-present: [status, priority, assignee]
+    kinds: [task]
+  - glob: ["plan/*.md"]
+    fields-present: [id]
+    kinds: [plan]
+```
+
+Within a single entry, `glob:` and `fields-present:`
+combine with **AND** — every selector that is set must
+match. Across entries, matches union (OR), the same as
+for glob-only entries.
+
+A field is "present" when the key appears in front matter
+with a non-null value. A key set to YAML `null` (e.g.
+`status: null`) does **not** count: the user wrote the
+key but did not fill it.
+
+For the config above, a file at
+`anywhere/important.md` whose front matter is:
+
+```markdown
+---
+status: open
+priority: high
+assignee: alice
+---
+```
+
+resolves to `[task]` because the second entry's
+`fields-present:` selector is satisfied. A file at
+`plan/132_inline.md` with `id: 132` in its front matter
+resolves to `[plan]` — the third entry's `glob:` matches
+the path **and** its `fields-present:` finds a non-null
+`id`.
+
+`mdsmith kinds resolve <file>` names the matching entry
+index and the selectors that fired, so you can confirm
+which rule did the work:
+
+```text
+file: plan/132_inline.md
+effective kinds:
+  - plan (from kind-assignment[2]: glob plan/*.md AND fields-present id)
+```
 
 ## Merge order
 
@@ -249,7 +308,9 @@ against the merge rules above:
 
 1. Read the file's front matter for any `kinds:` field.
 2. Walk `kind-assignment:` top to bottom and collect
-   every entry whose `glob:` matches the file.
+   every entry whose selectors all match the file —
+   `glob:` against the path and `fields-present:`
+   against the file's front matter.
 3. Concatenate the two lists, dropping duplicates after
    first occurrence — that's the effective kind list.
 4. Apply built-in defaults, then the top-level `rules:`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,15 +148,22 @@ type KindBody struct {
 	PathPattern string             `yaml:"path-pattern,omitempty"`
 }
 
-// KindAssignmentEntry assigns one or more kinds to files matching glob
-// patterns. The glob syntax is the same as overrides: and ignore:.
+// KindAssignmentEntry assigns one or more kinds to files matching the
+// configured selectors. Two selectors are available: a glob set
+// (`glob:`) and a front-matter field-presence set (`fields-present:`).
+// Within a single entry the selectors combine with AND — every set
+// selector must match. Across entries the matches union (OR semantics).
 type KindAssignmentEntry struct {
 	// Glob is the canonical field for file patterns (doublestar syntax,
 	// supports **, brace expansion, and !-prefix exclusion).
 	Glob []string `yaml:"glob,omitempty"`
 	// Files is a deprecated alias for Glob. Use Glob in new configs.
 	Files []string `yaml:"files,omitempty"`
-	Kinds []string `yaml:"kinds"`
+	// FieldsPresent lists front-matter keys that must all be present
+	// with a non-null value for this entry to match. An empty list
+	// disables the selector — only glob is considered.
+	FieldsPresent []string `yaml:"fields-present,omitempty"`
+	Kinds         []string `yaml:"kinds"`
 }
 
 // Patterns returns the effective set of glob patterns for the entry.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -429,7 +429,7 @@ func TestMergePreservesIgnoreAndOverrides(t *testing.T) {
 
 func TestEffectiveWithoutOverrides(t *testing.T) {
 	cfg := Defaults()
-	eff := Effective(cfg, "README.md", nil)
+	eff := Effective(cfg, "README.md", nil, nil)
 
 	require.Len(t, eff, len(rule.All()), "expected %d rules, got %d", len(rule.All()), len(eff))
 	for _, r := range rule.All() {
@@ -457,12 +457,12 @@ func TestEffectiveOverrideAppliesPerFile(t *testing.T) {
 	}
 
 	// CHANGELOG.md should have no-duplicate-headings disabled
-	eff := Effective(cfg, "CHANGELOG.md", nil)
+	eff := Effective(cfg, "CHANGELOG.md", nil, nil)
 	assert.False(t, eff["no-duplicate-headings"].Enabled, "no-duplicate-headings should be disabled for CHANGELOG.md")
 	assert.True(t, eff["line-length"].Enabled, "line-length should remain enabled for CHANGELOG.md")
 
 	// README.md should NOT be affected
-	eff2 := Effective(cfg, "README.md", nil)
+	eff2 := Effective(cfg, "README.md", nil, nil)
 	assert.True(t, eff2["no-duplicate-headings"].Enabled, "no-duplicate-headings should remain enabled for README.md")
 }
 
@@ -490,7 +490,7 @@ func TestEffectiveLaterOverridesWin(t *testing.T) {
 	}
 
 	// docs/api/foo.md matches both overrides; second should win
-	eff := Effective(cfg, "docs/api/foo.md", nil)
+	eff := Effective(cfg, "docs/api/foo.md", nil, nil)
 	rc := eff["line-length"]
 	assert.True(t, rc.Enabled, "line-length should be enabled")
 	if rc.Settings["max"] != 200 {
@@ -585,16 +585,16 @@ func TestEffectiveOverrideMatchesBasename(t *testing.T) {
 	}
 
 	// slides.md at root should match.
-	eff := Effective(cfg, "slides.md", nil)
+	eff := Effective(cfg, "slides.md", nil, nil)
 	assert.False(t, eff["first-line-heading"].Enabled, "first-line-heading should be disabled for slides.md")
 
 	// docs/slides.md should also match via basename (issue #40).
-	eff2 := Effective(cfg, "docs/slides.md", nil)
+	eff2 := Effective(cfg, "docs/slides.md", nil, nil)
 	assert.False(t, eff2["first-line-heading"].Enabled,
 		"first-line-heading should be disabled for docs/slides.md via basename match")
 
 	// other.md should NOT match.
-	eff3 := Effective(cfg, "other.md", nil)
+	eff3 := Effective(cfg, "other.md", nil, nil)
 	assert.True(t, eff3["first-line-heading"].Enabled, "first-line-heading should remain enabled for other.md")
 }
 
@@ -609,11 +609,11 @@ func TestEffectiveGlobPatternMatch(t *testing.T) {
 		},
 	}
 
-	eff := Effective(cfg, "vendor/foo/bar.md", nil)
+	eff := Effective(cfg, "vendor/foo/bar.md", nil, nil)
 	assert.False(t, eff["line-length"].Enabled, "line-length should be disabled for vendor/foo/bar.md")
 
 	// Non-matching file
-	eff2 := Effective(cfg, "src/main.md", nil)
+	eff2 := Effective(cfg, "src/main.md", nil, nil)
 	assert.True(t, eff2["line-length"].Enabled, "line-length should remain enabled for src/main.md")
 }
 
@@ -853,7 +853,7 @@ rules:
 	assert.Nil(t, cfg.Categories, "expected nil categories when omitted, got %v", cfg.Categories)
 
 	// EffectiveCategories should default all to true.
-	cats := EffectiveCategories(cfg, "README.md", nil)
+	cats := EffectiveCategories(cfg, "README.md", nil, nil)
 	for _, name := range ValidCategories {
 		assert.True(t, cats[name], "category %q should default to true", name)
 	}
@@ -936,7 +936,7 @@ func TestEffectiveCategoriesTopLevel(t *testing.T) {
 		},
 	}
 
-	cats := EffectiveCategories(cfg, "README.md", nil)
+	cats := EffectiveCategories(cfg, "README.md", nil, nil)
 	if cats["heading"] != false {
 		t.Error("heading should be false")
 	}
@@ -968,13 +968,13 @@ func TestEffectiveCategoriesOverride(t *testing.T) {
 	}
 
 	// CHANGELOG.md should have heading disabled via override.
-	cats := EffectiveCategories(cfg, "CHANGELOG.md", nil)
+	cats := EffectiveCategories(cfg, "CHANGELOG.md", nil, nil)
 	if cats["heading"] != false {
 		t.Error("heading should be false for CHANGELOG.md")
 	}
 
 	// README.md should keep heading enabled.
-	cats2 := EffectiveCategories(cfg, "README.md", nil)
+	cats2 := EffectiveCategories(cfg, "README.md", nil, nil)
 	if cats2["heading"] != true {
 		t.Error("heading should be true for README.md")
 	}
@@ -998,12 +998,12 @@ func TestEffectiveExplicitRulesFromOverrides(t *testing.T) {
 		},
 	}
 
-	explicit := EffectiveExplicitRules(cfg, "docs/guide.md", nil)
+	explicit := EffectiveExplicitRules(cfg, "docs/guide.md", nil, nil)
 	assert.True(t, explicit["line-length"], "line-length should be explicit (from top-level)")
 	assert.True(t, explicit["heading-style"], "heading-style should be explicit (from matching override)")
 
 	// Non-matching file should not get override rules.
-	explicit2 := EffectiveExplicitRules(cfg, "README.md", nil)
+	explicit2 := EffectiveExplicitRules(cfg, "README.md", nil, nil)
 	assert.False(t, explicit2["heading-style"], "heading-style should not be explicit for README.md")
 }
 
@@ -1617,8 +1617,8 @@ overrides:
 	mergedFiles := Merge(defaults, cfgFiles)
 	mergedGlob := Merge(defaults, cfgGlob)
 
-	effFiles := Effective(mergedFiles, "docs/guide.md", nil)
-	effGlob := Effective(mergedGlob, "docs/guide.md", nil)
+	effFiles := Effective(mergedFiles, "docs/guide.md", nil, nil)
+	effGlob := Effective(mergedGlob, "docs/guide.md", nil, nil)
 
 	assert.Equal(t, effFiles["line-length"].Settings["max"],
 		effGlob["line-length"].Settings["max"],

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -94,7 +94,7 @@ func TestEffectiveRules_ConventionIsBaseLayerUnderUserRules(t *testing.T) {
 	}
 	require.NoError(t, applyConvention(cfg))
 
-	got := Effective(cfg, "doc.md", nil)
+	got := Effective(cfg, "doc.md", nil, nil)
 	rc, ok := got["no-inline-html"]
 	require.True(t, ok, "no-inline-html must be present")
 	assert.True(t, rc.Enabled)
@@ -107,7 +107,7 @@ func TestEffectiveRules_ConventionSurvivesWhenUserDoesNotMention(t *testing.T) {
 	cfg := &Config{Convention: "portable"}
 	require.NoError(t, applyConvention(cfg))
 
-	got := Effective(cfg, "doc.md", nil)
+	got := Effective(cfg, "doc.md", nil, nil)
 	rc, ok := got["horizontal-rule-style"]
 	require.True(t, ok, "horizontal-rule-style must be inherited from convention")
 	assert.True(t, rc.Enabled)
@@ -130,7 +130,7 @@ func TestEffectiveRules_UserSettingDeepMergesOverConvention(t *testing.T) {
 	}
 	require.NoError(t, applyConvention(cfg))
 
-	got := Effective(cfg, "doc.md", nil)
+	got := Effective(cfg, "doc.md", nil, nil)
 	rc := got["horizontal-rule-style"]
 	assert.Equal(t, 5, rc.Settings["length"], "user scalar wins")
 	assert.Equal(t, "dash", rc.Settings["style"], "preset sibling preserved")
@@ -141,7 +141,7 @@ func TestProvenance_ConventionLayerVisible(t *testing.T) {
 	cfg := &Config{Convention: "portable"}
 	require.NoError(t, applyConvention(cfg))
 
-	res := ResolveFile(cfg, "doc.md", nil)
+	res := ResolveFile(cfg, "doc.md", nil, nil)
 	rr, ok := res.Rules["horizontal-rule-style"]
 	require.True(t, ok, "rule must appear in resolution")
 	require.NotEmpty(t, rr.Layers)
@@ -178,7 +178,7 @@ func TestProvenance_UserLayerWinsOverConvention(t *testing.T) {
 	}
 	require.NoError(t, applyConvention(cfg))
 
-	res := ResolveFile(cfg, "doc.md", nil)
+	res := ResolveFile(cfg, "doc.md", nil, nil)
 	rr := res.Rules["horizontal-rule-style"]
 	leaf := rr.LeafByPath("settings.length")
 	require.NotNil(t, leaf)
@@ -206,7 +206,7 @@ func TestApplyConvention_DisablingMarkdownFlavorPreservesPresetForOtherRules(t *
 	}
 	cfg.Rules["markdown-flavor"] = RuleCfg{Enabled: false}
 
-	got := Effective(cfg, "doc.md", nil)
+	got := Effective(cfg, "doc.md", nil, nil)
 	rc := got["horizontal-rule-style"]
 	assert.True(t, rc.Enabled,
 		"convention-enabled rule survives MDS034 being disabled")
@@ -345,7 +345,7 @@ func TestConvention_EnablesOptInRuleEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	merged := Merge(Defaults(), loaded)
 
-	got := Effective(merged, "doc.md", nil)
+	got := Effective(merged, "doc.md", nil, nil)
 	mf, ok := got["markdown-flavor"]
 	require.True(t, ok, "markdown-flavor must be present after merge")
 	assert.True(t, mf.Enabled,
@@ -471,7 +471,7 @@ func TestApplyConvention_UserConvention_TopLevelRulesOverride(t *testing.T) {
 	}
 	require.NoError(t, applyConvention(cfg))
 
-	got := Effective(cfg, "doc.md", nil)
+	got := Effective(cfg, "doc.md", nil, nil)
 	es, ok := got["emphasis-style"]
 	require.True(t, ok)
 	assert.True(t, es.Enabled)
@@ -533,7 +533,7 @@ func TestProvenance_UserConventionLayerHasUserSuffix(t *testing.T) {
 	}
 	require.NoError(t, applyConvention(cfg))
 
-	res := ResolveFile(cfg, "doc.md", nil)
+	res := ResolveFile(cfg, "doc.md", nil, nil)
 	rr, ok := res.Rules["markdown-flavor"]
 	require.True(t, ok)
 

--- a/internal/config/deepmerge_test.go
+++ b/internal/config/deepmerge_test.go
@@ -202,7 +202,7 @@ func TestEffectiveTwoKindsContributeDifferentKeys(t *testing.T) {
 			}},
 		},
 	}
-	got := Effective(cfg, "doc.md", []string{"a", "b"})
+	got := Effective(cfg, "doc.md", []string{"a", "b"}, nil)
 	rule := got["first-line-heading"]
 	assert.Equal(t, 2, rule.Settings["level"],
 		"level from kind a should survive deep-merge with kind b")
@@ -224,7 +224,7 @@ func TestEffectiveOverridePreservesEarlierSiblings(t *testing.T) {
 			},
 		},
 	}
-	got := Effective(cfg, "docs/foo.md", nil)
+	got := Effective(cfg, "docs/foo.md", nil, nil)
 	rule := got["line-length"]
 	assert.Equal(t, 120, rule.Settings["max"], "override updates max")
 	assert.Equal(t, 4, rule.Settings["tabs"], "override does not erase sibling tabs")
@@ -255,7 +255,7 @@ func TestEffectivePlaceholdersAppendAcrossLayers(t *testing.T) {
 			},
 		},
 	}
-	got := Effective(cfg, "plan/97.md", []string{"plan"})
+	got := Effective(cfg, "plan/97.md", []string{"plan"}, nil)
 	rule := got["first-line-heading"]
 	assert.Equal(t,
 		[]any{"heading-question", "var-token", "cue-frontmatter"},
@@ -286,7 +286,7 @@ func TestEffectiveListReplaceRemainsTheDefault(t *testing.T) {
 			},
 		},
 	}
-	got := Effective(cfg, "plan/97.md", nil)
+	got := Effective(cfg, "plan/97.md", nil, nil)
 	rule := got["cross-file-reference-integrity"]
 	assert.Equal(t, []any{"plan/**"}, rule.Settings["include"],
 		"replace-mode list (default) should not concatenate")
@@ -305,7 +305,7 @@ func TestEffectiveBoolOnlyLayerPreservesInheritedSettings(t *testing.T) {
 			"back": {Rules: map[string]RuleCfg{"line-length": {Enabled: true}}},
 		},
 	}
-	got := Effective(cfg, "doc.md", []string{"off", "back"})
+	got := Effective(cfg, "doc.md", []string{"off", "back"}, nil)
 	rule := got["line-length"]
 	assert.True(t, rule.Enabled, "later kind re-enables")
 	assert.Equal(t, 80, rule.Settings["max"], "inherited settings survive bool-only layers")
@@ -325,7 +325,7 @@ func TestEffectiveKindAddsRuleNotInDefaults(t *testing.T) {
 			}},
 		},
 	}
-	got := Effective(cfg, "doc.md", []string{"plan"})
+	got := Effective(cfg, "doc.md", []string{"plan"}, nil)
 	assert.True(t, got["line-length"].Enabled)
 	assert.Equal(t, 80, got["line-length"].Settings["max"])
 }
@@ -346,7 +346,7 @@ func TestEffectiveFullyRestatedLayerStillWins(t *testing.T) {
 			},
 		},
 	}
-	got := Effective(cfg, "docs/foo.md", nil)
+	got := Effective(cfg, "docs/foo.md", nil, nil)
 	rule := got["line-length"]
 	assert.Equal(t, 120, rule.Settings["max"])
 	assert.Equal(t, 2, rule.Settings["tabs"])

--- a/internal/config/fieldspresent_test.go
+++ b/internal/config/fieldspresent_test.go
@@ -138,3 +138,22 @@ func TestFieldsPresent_EmptyEntryNeverMatches(t *testing.T) {
 	got := resolveEffectiveKinds(cfg, "doc.md", nil, map[string]any{"status": "open"})
 	assert.Empty(t, got)
 }
+
+// HasFieldsPresentSelector lets callers (engine, fix, lsp) skip the
+// extra FM-mapping decode when no entry uses the selector.
+func TestHasFieldsPresentSelector(t *testing.T) {
+	assert.False(t, HasFieldsPresentSelector(nil), "nil config")
+
+	assert.False(t, HasFieldsPresentSelector(&Config{
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
+		},
+	}), "glob-only entries")
+
+	assert.True(t, HasFieldsPresentSelector(&Config{
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}), "any entry with fields-present")
+}

--- a/internal/config/fieldspresent_test.go
+++ b/internal/config/fieldspresent_test.go
@@ -96,12 +96,17 @@ func TestFieldsPresent_GlobOnlyEntryUnchanged(t *testing.T) {
 }
 
 // Provenance surfaces the matching entry index and selector via the
-// new ResolvedKind.Selector field.
+// new ResolvedKind.Selector field. Includes an entry that does not
+// match so the resolver's skip branch runs alongside the matching
+// path.
 func TestFieldsPresent_ProvenanceCarriesSelector(t *testing.T) {
 	cfg := &Config{
-		Kinds: map[string]KindBody{"task": {}, "plan": {}},
+		Kinds: map[string]KindBody{"task": {}, "plan": {}, "draft": {}},
 		KindAssignment: []KindAssignmentEntry{
 			{FieldsPresent: []string{"status", "assignee"}, Kinds: []string{"task"}},
+			// Second entry asks for a field the file doesn't carry —
+			// the resolver must skip it without contributing a kind.
+			{FieldsPresent: []string{"draft"}, Kinds: []string{"draft"}},
 			{Glob: []string{"plan/*.md"}, FieldsPresent: []string{"id"}, Kinds: []string{"plan"}},
 		},
 	}
@@ -112,16 +117,16 @@ func TestFieldsPresent_ProvenanceCarriesSelector(t *testing.T) {
 		"assignee": "alice",
 	})
 	require := assert.New(t)
-	require.Len(res.Kinds, 2)
+	require.Len(res.Kinds, 2, "non-matching entry should not contribute a kind")
 
 	// First entry: fields-present only.
 	require.Equal("task", res.Kinds[0].Name)
 	require.Equal(KindAssignmentSource("kind-assignment[0]"), res.Kinds[0].Source)
 	require.Equal("fields-present status,assignee", res.Kinds[0].Selector)
 
-	// Second entry: glob AND fields-present.
+	// Third entry matched; second was skipped so the index jumps to 2.
 	require.Equal("plan", res.Kinds[1].Name)
-	require.Equal(KindAssignmentSource("kind-assignment[1]"), res.Kinds[1].Source)
+	require.Equal(KindAssignmentSource("kind-assignment[2]"), res.Kinds[1].Source)
 	require.Equal("glob plan/*.md AND fields-present id", res.Kinds[1].Selector)
 }
 
@@ -156,4 +161,40 @@ func TestHasFieldsPresentSelector(t *testing.T) {
 			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
 		},
 	}), "any entry with fields-present")
+}
+
+// NeedsFieldsForFile gates the FM-mapping decode per file path: it only
+// returns true when a fields-present entry could actually match this
+// file — an entry without a glob always could, an entry with a glob
+// only if the path matches it.
+func TestNeedsFieldsForFile(t *testing.T) {
+	assert.False(t, NeedsFieldsForFile(nil, "any.md"), "nil config")
+
+	assert.False(t, NeedsFieldsForFile(&Config{
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"docs/*.md"}, Kinds: []string{"doc"}},
+		},
+	}, "docs/a.md"), "no fields-present entry → false even when glob matches")
+
+	cfg := &Config{
+		KindAssignment: []KindAssignmentEntry{
+			{
+				Glob:          []string{"plan/*.md"},
+				FieldsPresent: []string{"id"},
+				Kinds:         []string{"plan"},
+			},
+		},
+	}
+	assert.True(t, NeedsFieldsForFile(cfg, "plan/9.md"),
+		"glob+fields entry matches path → needs fields")
+	assert.False(t, NeedsFieldsForFile(cfg, "docs/api.md"),
+		"glob+fields entry does not match path → no need to parse fields")
+
+	cfgUnscoped := &Config{
+		KindAssignment: []KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+	assert.True(t, NeedsFieldsForFile(cfgUnscoped, "anywhere/x.md"),
+		"fields-only entry has no glob, so every path needs the parse")
 }

--- a/internal/config/fieldspresent_test.go
+++ b/internal/config/fieldspresent_test.go
@@ -144,25 +144,6 @@ func TestFieldsPresent_EmptyEntryNeverMatches(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-// HasFieldsPresentSelector lets callers (engine, fix, lsp) skip the
-// extra FM-mapping decode when no entry uses the selector.
-func TestHasFieldsPresentSelector(t *testing.T) {
-	assert.False(t, HasFieldsPresentSelector(nil), "nil config")
-
-	assert.False(t, HasFieldsPresentSelector(&Config{
-		KindAssignment: []KindAssignmentEntry{
-			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
-		},
-	}), "glob-only entries")
-
-	assert.True(t, HasFieldsPresentSelector(&Config{
-		KindAssignment: []KindAssignmentEntry{
-			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
-			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
-		},
-	}), "any entry with fields-present")
-}
-
 // NeedsFieldsForFile gates the FM-mapping decode per file path: it only
 // returns true when a fields-present entry could actually match this
 // file — an entry without a glob always could, an entry with a glob

--- a/internal/config/fieldspresent_test.go
+++ b/internal/config/fieldspresent_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Files satisfying every listed field with a non-null value get the
+// kind. Files missing any field do not.
+func TestFieldsPresent_AllFieldsRequired(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"task": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{FieldsPresent: []string{"status", "priority", "assignee"}, Kinds: []string{"task"}},
+		},
+	}
+
+	full := map[string]any{
+		"status":   "open",
+		"priority": "high",
+		"assignee": "alice",
+	}
+	got := resolveEffectiveKinds(cfg, "anywhere/doc.md", nil, full)
+	assert.Equal(t, []string{"task"}, got, "all three fields present → kind matches")
+
+	missing := map[string]any{
+		"status":   "open",
+		"priority": "high",
+	}
+	got = resolveEffectiveKinds(cfg, "anywhere/doc.md", nil, missing)
+	assert.Empty(t, got, "missing one field → no match")
+}
+
+// A field present with a null value does not count as present. The user
+// wrote the key but did not fill it in.
+func TestFieldsPresent_NullValueDoesNotCount(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"task": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+
+	// `status: null` in YAML decodes to a nil value.
+	withNull := map[string]any{"status": nil}
+	got := resolveEffectiveKinds(cfg, "doc.md", nil, withNull)
+	assert.Empty(t, got, "null value should not count as present")
+
+	withValue := map[string]any{"status": "open"}
+	got = resolveEffectiveKinds(cfg, "doc.md", nil, withValue)
+	assert.Equal(t, []string{"task"}, got)
+}
+
+// An entry combining glob and fields-present matches only files
+// satisfying both selectors.
+func TestFieldsPresent_AndedWithGlob(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"plan": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{
+				Glob:          []string{"plan/*.md"},
+				FieldsPresent: []string{"id"},
+				Kinds:         []string{"plan"},
+			},
+		},
+	}
+
+	withID := map[string]any{"id": 132}
+
+	got := resolveEffectiveKinds(cfg, "plan/132_inline.md", nil, withID)
+	assert.Equal(t, []string{"plan"}, got, "both selectors satisfied")
+
+	got = resolveEffectiveKinds(cfg, "docs/api.md", nil, withID)
+	assert.Empty(t, got, "glob fails → AND fails")
+
+	got = resolveEffectiveKinds(cfg, "plan/132_inline.md", nil, nil)
+	assert.Empty(t, got, "no FM fields → fields-present fails → AND fails")
+}
+
+// Entries with no fields-present keep behaving exactly as before:
+// glob-only matching.
+func TestFieldsPresent_GlobOnlyEntryUnchanged(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"doc": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"docs/**"}, Kinds: []string{"doc"}},
+		},
+	}
+
+	got := resolveEffectiveKinds(cfg, "docs/api.md", nil, map[string]any{"unrelated": 1})
+	assert.Equal(t, []string{"doc"}, got)
+
+	got = resolveEffectiveKinds(cfg, "plan/132.md", nil, nil)
+	assert.Empty(t, got)
+}
+
+// Provenance surfaces the matching entry index and selector via the
+// new ResolvedKind.Selector field.
+func TestFieldsPresent_ProvenanceCarriesSelector(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"task": {}, "plan": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{FieldsPresent: []string{"status", "assignee"}, Kinds: []string{"task"}},
+			{Glob: []string{"plan/*.md"}, FieldsPresent: []string{"id"}, Kinds: []string{"plan"}},
+		},
+	}
+
+	res := ResolveFile(cfg, "plan/9.md", nil, map[string]any{
+		"id":       9,
+		"status":   "open",
+		"assignee": "alice",
+	})
+	require := assert.New(t)
+	require.Len(res.Kinds, 2)
+
+	// First entry: fields-present only.
+	require.Equal("task", res.Kinds[0].Name)
+	require.Equal(KindAssignmentSource("kind-assignment[0]"), res.Kinds[0].Source)
+	require.Equal("fields-present status,assignee", res.Kinds[0].Selector)
+
+	// Second entry: glob AND fields-present.
+	require.Equal("plan", res.Kinds[1].Name)
+	require.Equal(KindAssignmentSource("kind-assignment[1]"), res.Kinds[1].Source)
+	require.Equal("glob plan/*.md AND fields-present id", res.Kinds[1].Selector)
+}
+
+// An entry with neither selector set never matches — an unconditional
+// kind assignment is not supported by design.
+func TestFieldsPresent_EmptyEntryNeverMatches(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"task": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{Kinds: []string{"task"}},
+		},
+	}
+
+	got := resolveEffectiveKinds(cfg, "doc.md", nil, map[string]any{"status": "open"})
+	assert.Empty(t, got)
+}

--- a/internal/config/fieldspresent_test.go
+++ b/internal/config/fieldspresent_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Files satisfying every listed field with a non-null value get the
@@ -116,18 +117,17 @@ func TestFieldsPresent_ProvenanceCarriesSelector(t *testing.T) {
 		"status":   "open",
 		"assignee": "alice",
 	})
-	require := assert.New(t)
-	require.Len(res.Kinds, 2, "non-matching entry should not contribute a kind")
+	require.Len(t, res.Kinds, 2, "non-matching entry should not contribute a kind")
 
 	// First entry: fields-present only.
-	require.Equal("task", res.Kinds[0].Name)
-	require.Equal(KindAssignmentSource("kind-assignment[0]"), res.Kinds[0].Source)
-	require.Equal("fields-present status,assignee", res.Kinds[0].Selector)
+	assert.Equal(t, "task", res.Kinds[0].Name)
+	assert.Equal(t, KindAssignmentSource("kind-assignment[0]"), res.Kinds[0].Source)
+	assert.Equal(t, "fields-present status,assignee", res.Kinds[0].Selector)
 
 	// Third entry matched; second was skipped so the index jumps to 2.
-	require.Equal("plan", res.Kinds[1].Name)
-	require.Equal(KindAssignmentSource("kind-assignment[2]"), res.Kinds[1].Source)
-	require.Equal("glob plan/*.md AND fields-present id", res.Kinds[1].Selector)
+	assert.Equal(t, "plan", res.Kinds[1].Name)
+	assert.Equal(t, KindAssignmentSource("kind-assignment[2]"), res.Kinds[1].Source)
+	assert.Equal(t, "glob plan/*.md AND fields-present id", res.Kinds[1].Selector)
 }
 
 // An entry with neither selector set never matches — an unconditional

--- a/internal/config/kindmatch.go
+++ b/internal/config/kindmatch.go
@@ -79,3 +79,27 @@ func HasFieldsPresentSelector(cfg *Config) bool {
 	}
 	return false
 }
+
+// NeedsFieldsForFile is the per-file refinement of HasFieldsPresentSelector.
+// It returns true when at least one kind-assignment entry could match the
+// given file path under its `fields-present:` selector — either because
+// the entry has no `glob:` (it considers every file) or because its glob
+// matches this path. Callers use this to skip the full FM-mapping YAML
+// decode for files no fields-present entry could ever assign a kind to.
+func NeedsFieldsForFile(cfg *Config, filePath string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, entry := range cfg.KindAssignment {
+		if len(entry.FieldsPresent) == 0 {
+			continue
+		}
+		if len(entry.Patterns()) == 0 {
+			return true
+		}
+		if matchesAny(entry.Patterns(), filePath) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/kindmatch.go
+++ b/internal/config/kindmatch.go
@@ -62,3 +62,20 @@ func formatSelector(entry KindAssignmentEntry) string {
 	}
 	return strings.Join(parts, " AND ")
 }
+
+// HasFieldsPresentSelector reports whether any kind-assignment entry
+// uses the fields-present: selector. Callers that wire front-matter
+// fields into resolution can short-circuit the full-FM YAML decode
+// when this returns false — both saving work and avoiding a parse
+// error mode that the kinds-only path never triggered.
+func HasFieldsPresentSelector(cfg *Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, entry := range cfg.KindAssignment {
+		if len(entry.FieldsPresent) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/kindmatch.go
+++ b/internal/config/kindmatch.go
@@ -1,0 +1,64 @@
+package config
+
+import "strings"
+
+// matchKindAssignmentEntry reports whether a kind-assignment entry
+// matches a given file. An entry's selectors combine with AND:
+// when both `glob:` and `fields-present:` are set, the file must
+// satisfy both. An entry with no selectors never matches — declaring
+// an unconditional kind assignment is not supported by design.
+//
+// fmFields, when nil, means the caller has no front-matter info; an
+// entry with `fields-present:` set won't match in that case, since
+// presence cannot be confirmed.
+//
+// The returned selector string describes which selectors fired and is
+// surfaced through provenance output. For an unmatched entry it is
+// always the empty string.
+func matchKindAssignmentEntry(entry KindAssignmentEntry, filePath string, fmFields map[string]any) (bool, string) {
+	hasGlob := len(entry.Patterns()) > 0
+	hasFields := len(entry.FieldsPresent) > 0
+	if !hasGlob && !hasFields {
+		return false, ""
+	}
+	if hasGlob && !matchesAny(entry.Patterns(), filePath) {
+		return false, ""
+	}
+	if hasFields && !allFieldsPresent(entry.FieldsPresent, fmFields) {
+		return false, ""
+	}
+	return true, formatSelector(entry)
+}
+
+// allFieldsPresent reports whether every required key is set to a
+// non-null value in fmFields. A nil map means no fields were observed
+// — no key can satisfy the predicate.
+func allFieldsPresent(required []string, fmFields map[string]any) bool {
+	if fmFields == nil {
+		return false
+	}
+	for _, key := range required {
+		v, ok := fmFields[key]
+		if !ok {
+			return false
+		}
+		if v == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// formatSelector renders the selectors of a kind-assignment entry
+// in a stable form ("glob a,b AND fields-present x,y"). Used by
+// provenance output to identify which selector(s) matched.
+func formatSelector(entry KindAssignmentEntry) string {
+	parts := make([]string, 0, 2)
+	if pats := entry.Patterns(); len(pats) > 0 {
+		parts = append(parts, "glob "+strings.Join(pats, ","))
+	}
+	if len(entry.FieldsPresent) > 0 {
+		parts = append(parts, "fields-present "+strings.Join(entry.FieldsPresent, ","))
+	}
+	return strings.Join(parts, " AND ")
+}

--- a/internal/config/kindmatch.go
+++ b/internal/config/kindmatch.go
@@ -63,29 +63,12 @@ func formatSelector(entry KindAssignmentEntry) string {
 	return strings.Join(parts, " AND ")
 }
 
-// HasFieldsPresentSelector reports whether any kind-assignment entry
-// uses the fields-present: selector. Callers that wire front-matter
-// fields into resolution can short-circuit the full-FM YAML decode
-// when this returns false — both saving work and avoiding a parse
-// error mode that the kinds-only path never triggered.
-func HasFieldsPresentSelector(cfg *Config) bool {
-	if cfg == nil {
-		return false
-	}
-	for _, entry := range cfg.KindAssignment {
-		if len(entry.FieldsPresent) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// NeedsFieldsForFile is the per-file refinement of HasFieldsPresentSelector.
-// It returns true when at least one kind-assignment entry could match the
-// given file path under its `fields-present:` selector — either because
-// the entry has no `glob:` (it considers every file) or because its glob
-// matches this path. Callers use this to skip the full FM-mapping YAML
-// decode for files no fields-present entry could ever assign a kind to.
+// NeedsFieldsForFile returns true when at least one kind-assignment
+// entry could match the given file path under its `fields-present:`
+// selector — either because the entry has no `glob:` (it considers
+// every file) or because its glob matches this path. Callers use this
+// to skip the full FM-mapping YAML decode for files no fields-present
+// entry could ever assign a kind to.
 func NeedsFieldsForFile(cfg *Config, filePath string) bool {
 	if cfg == nil {
 		return false

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -126,7 +126,7 @@ func TestResolveEffectiveKindsFrontMatterFirst(t *testing.T) {
 			{Files: []string{"*.md"}, Kinds: []string{"b", "c"}},
 		},
 	}
-	got := resolveEffectiveKinds(cfg, "file.md", []string{"a"})
+	got := resolveEffectiveKinds(cfg, "file.md", []string{"a"}, nil)
 	assert.Equal(t, []string{"a", "b", "c"}, got)
 }
 
@@ -141,7 +141,7 @@ func TestResolveEffectiveKindsDeduplicates(t *testing.T) {
 			{Files: []string{"*.md"}, Kinds: []string{"a", "b"}},
 		},
 	}
-	got := resolveEffectiveKinds(cfg, "file.md", []string{"a"})
+	got := resolveEffectiveKinds(cfg, "file.md", []string{"a"}, nil)
 	assert.Equal(t, []string{"a", "b"}, got)
 }
 
@@ -152,7 +152,7 @@ func TestResolveEffectiveKindsNoAssignmentMatch(t *testing.T) {
 			{Files: []string{"docs/*.md"}, Kinds: []string{"a"}},
 		},
 	}
-	got := resolveEffectiveKinds(cfg, "other/file.md", nil)
+	got := resolveEffectiveKinds(cfg, "other/file.md", nil, nil)
 	assert.Empty(t, got)
 }
 
@@ -172,7 +172,7 @@ func TestEffectiveKindOverridesTopLevelRule(t *testing.T) {
 			{Files: []string{"wide/*.md"}, Kinds: []string{"wide"}},
 		},
 	}
-	result := Effective(cfg, "wide/doc.md", nil)
+	result := Effective(cfg, "wide/doc.md", nil, nil)
 	assert.Equal(t, 200, result["line-length"].Settings["max"])
 }
 
@@ -198,7 +198,7 @@ func TestEffectiveGlobOverrideBeatsKind(t *testing.T) {
 			},
 		},
 	}
-	result := Effective(cfg, "wide/special.md", nil)
+	result := Effective(cfg, "wide/special.md", nil, nil)
 	assert.Equal(t, 120, result["line-length"].Settings["max"])
 }
 
@@ -218,7 +218,7 @@ func TestEffectiveTwoKindsMergeInListOrder(t *testing.T) {
 		},
 	}
 	// Front matter: kinds: [a, b] — b comes later and wins on line-length.
-	result := Effective(cfg, "doc.md", []string{"a", "b"})
+	result := Effective(cfg, "doc.md", []string{"a", "b"}, nil)
 	assert.True(t, result["line-length"].Enabled)
 	assert.Equal(t, 200, result["line-length"].Settings["max"])
 }
@@ -238,7 +238,7 @@ func TestEffectiveConflictLaterKindWins(t *testing.T) {
 		},
 	}
 	// kinds: [a, b] — b's config replaces a's entirely.
-	result := Effective(cfg, "doc.md", []string{"a", "b"})
+	result := Effective(cfg, "doc.md", []string{"a", "b"}, nil)
 	assert.Equal(t, 150, result["line-length"].Settings["max"])
 }
 
@@ -252,7 +252,7 @@ func TestEffectiveCategoriesWithKinds(t *testing.T) {
 			{Files: []string{"_partials/*.md"}, Kinds: []string{"fragment"}},
 		},
 	}
-	result := EffectiveCategories(cfg, "_partials/foo.md", nil)
+	result := EffectiveCategories(cfg, "_partials/foo.md", nil, nil)
 	assert.False(t, result["meta"])
 }
 
@@ -291,7 +291,7 @@ func TestEffectiveExplicitRulesIncludesKindRules(t *testing.T) {
 			{Files: []string{"wide/*.md"}, Kinds: []string{"wide"}},
 		},
 	}
-	result := EffectiveExplicitRules(cfg, "wide/doc.md", nil)
+	result := EffectiveExplicitRules(cfg, "wide/doc.md", nil, nil)
 	assert.True(t, result["no-hard-tabs"], "top-level explicit rule should be present")
 	assert.True(t, result["line-length"], "kind rule should be marked explicit")
 }
@@ -304,7 +304,7 @@ func TestEffectiveExplicitRulesFrontMatterKinds(t *testing.T) {
 			}},
 		},
 	}
-	result := EffectiveExplicitRules(cfg, "doc.md", []string{"plan"})
+	result := EffectiveExplicitRules(cfg, "doc.md", []string{"plan"}, nil)
 	assert.True(t, result["paragraph-readability"])
 }
 
@@ -323,7 +323,7 @@ func TestEffectiveIgnoresMissingKindBody(t *testing.T) {
 		},
 	}
 	// Inject a stale kind name via front-matter (bypasses LoadKinds validation).
-	result := Effective(cfg, "doc.md", []string{"nonexistent"})
+	result := Effective(cfg, "doc.md", []string{"nonexistent"}, nil)
 	assert.Equal(t, 80, result["line-length"].Settings["max"], "missing kind body is silently skipped")
 }
 
@@ -332,7 +332,7 @@ func TestEffectiveExplicitRulesIgnoresMissingKindBody(t *testing.T) {
 		ExplicitRules: map[string]bool{"line-length": true},
 		Kinds:         map[string]KindBody{},
 	}
-	result := EffectiveExplicitRules(cfg, "doc.md", []string{"nonexistent"})
+	result := EffectiveExplicitRules(cfg, "doc.md", []string{"nonexistent"}, nil)
 	assert.True(t, result["line-length"])
 	assert.False(t, result["nonexistent"])
 }
@@ -341,7 +341,7 @@ func TestEffectiveCategoriesIgnoresMissingKindBody(t *testing.T) {
 	cfg := &Config{
 		Kinds: map[string]KindBody{},
 	}
-	result := EffectiveCategories(cfg, "doc.md", []string{"nonexistent"})
+	result := EffectiveCategories(cfg, "doc.md", []string{"nonexistent"}, nil)
 	assert.True(t, result["heading"], "default category still enabled")
 }
 

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -398,7 +398,7 @@ func TestEffectiveRules_PathPatternInstallsListSetting(t *testing.T) {
 			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
 		},
 	}
-	eff, _, _ := EffectiveAll(cfg, "plan/01_x.md", nil)
+	eff, _, _ := EffectiveAll(cfg, "plan/01_x.md", nil, nil)
 	rs, ok := eff["required-structure"]
 	require.True(t, ok, "required-structure rule should be present")
 	assert.True(t, rs.Enabled)
@@ -417,7 +417,7 @@ func TestEffectiveRules_PathPatternAccumulatesAcrossKinds(t *testing.T) {
 			"rfc":  {PathPattern: "docs/rfc/*.md"},
 		},
 	}
-	eff, _, _ := EffectiveAll(cfg, "anywhere.md", []string{"plan", "rfc"})
+	eff, _, _ := EffectiveAll(cfg, "anywhere.md", []string{"plan", "rfc"}, nil)
 	rs := eff["required-structure"]
 	list, _ := rs.Settings["path-patterns"].([]any)
 	require.Len(t, list, 2)
@@ -431,7 +431,7 @@ func TestEffectiveRules_PathPatternAbsentLeavesRuleAlone(t *testing.T) {
 			"plan": {Rules: map[string]RuleCfg{"line-length": {Enabled: false}}},
 		},
 	}
-	eff, _, _ := EffectiveAll(cfg, "anywhere.md", []string{"plan"})
+	eff, _, _ := EffectiveAll(cfg, "anywhere.md", []string{"plan"}, nil)
 	if rs, ok := eff["required-structure"]; ok {
 		_, hasList := rs.Settings["path-patterns"]
 		assert.False(t, hasList,

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -181,9 +181,10 @@ func copyKindAssignment(entries []KindAssignmentEntry) []KindAssignmentEntry {
 	result := make([]KindAssignmentEntry, len(entries))
 	for i, e := range entries {
 		result[i] = KindAssignmentEntry{
-			Glob:  copyStrings(e.Glob),
-			Files: copyStrings(e.Files),
-			Kinds: copyStrings(e.Kinds),
+			Glob:          copyStrings(e.Glob),
+			Files:         copyStrings(e.Files),
+			FieldsPresent: copyStrings(e.FieldsPresent),
+			Kinds:         copyStrings(e.Kinds),
 		}
 	}
 	return result
@@ -235,10 +236,14 @@ func mergeCategories(base, override map[string]bool) map[string]bool {
 // outside the config package (e.g. the LSP symbol index) that need
 // effective-kind resolution without re-implementing the merge rules.
 //
-// When cfg is nil there are no kind-assignment globs to apply, so
+// When cfg is nil there are no kind-assignment entries to apply, so
 // the result is just fmKinds with duplicates dropped — preserving
 // the dedup contract callers rely on.
-func EffectiveKinds(cfg *Config, filePath string, fmKinds []string) []string {
+//
+// fmFields, when non-nil, is the file's parsed front matter; it is
+// consumed by entries that set `fields-present:`. Pass nil when the
+// caller has no FM info — such entries simply won't match.
+func EffectiveKinds(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) []string {
 	if cfg == nil {
 		seen := make(map[string]bool, len(fmKinds))
 		out := make([]string, 0, len(fmKinds))
@@ -251,14 +256,14 @@ func EffectiveKinds(cfg *Config, filePath string, fmKinds []string) []string {
 		}
 		return out
 	}
-	return resolveEffectiveKinds(cfg, filePath, fmKinds)
+	return resolveEffectiveKinds(cfg, filePath, fmKinds, fmFields)
 }
 
 // resolveEffectiveKinds builds the ordered, deduplicated effective kind list
 // for a file. fmKinds are the kinds declared in the file's front matter;
 // they come first. kind-assignment matches are appended in config order.
 // Duplicate names are dropped after their first occurrence.
-func resolveEffectiveKinds(cfg *Config, filePath string, fmKinds []string) []string {
+func resolveEffectiveKinds(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) []string {
 	seen := make(map[string]bool)
 	var result []string
 
@@ -273,7 +278,7 @@ func resolveEffectiveKinds(cfg *Config, filePath string, fmKinds []string) []str
 		add(k)
 	}
 	for _, entry := range cfg.KindAssignment {
-		if matchesAny(entry.Patterns(), filePath) {
+		if matched, _ := matchKindAssignmentEntry(entry, filePath, fmFields); matched {
 			for _, k := range entry.Kinds {
 				add(k)
 			}
@@ -286,33 +291,33 @@ func resolveEffectiveKinds(cfg *Config, filePath string, fmKinds []string) []str
 // It starts with the top-level rules, applies kinds in effective-list order
 // (fmKinds from front matter first, then kind-assignment matches), and
 // finally applies glob overrides. Later entries take precedence.
-func Effective(cfg *Config, filePath string, fmKinds []string) map[string]RuleCfg {
-	return effectiveRules(cfg, filePath, resolveEffectiveKinds(cfg, filePath, fmKinds))
+func Effective(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) map[string]RuleCfg {
+	return effectiveRules(cfg, filePath, resolveEffectiveKinds(cfg, filePath, fmKinds, fmFields))
 }
 
 // EffectiveExplicitRules returns the set of rule names that were explicitly
 // configured for a given file path. It includes rules from the top-level
 // ExplicitRules, any rules set by matching kinds, and any rules set by
 // matching overrides.
-func EffectiveExplicitRules(cfg *Config, filePath string, fmKinds []string) map[string]bool {
-	return effectiveExplicit(cfg, filePath, resolveEffectiveKinds(cfg, filePath, fmKinds))
+func EffectiveExplicitRules(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) map[string]bool {
+	return effectiveExplicit(cfg, filePath, resolveEffectiveKinds(cfg, filePath, fmKinds, fmFields))
 }
 
 // EffectiveCategories returns the effective category settings for a given
 // file path. It starts with the top-level categories, applies kinds in
 // effective-list order, and then applies matching overrides. Categories not
 // explicitly set default to true (enabled).
-func EffectiveCategories(cfg *Config, filePath string, fmKinds []string) map[string]bool {
-	return effectiveCats(cfg, filePath, resolveEffectiveKinds(cfg, filePath, fmKinds))
+func EffectiveCategories(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) map[string]bool {
+	return effectiveCats(cfg, filePath, resolveEffectiveKinds(cfg, filePath, fmKinds, fmFields))
 }
 
 // EffectiveAll returns the effective rule config, category settings, and
 // explicit rule set for a file path while resolving effective kinds once and
 // reusing that result across all three computations.
 func EffectiveAll(
-	cfg *Config, filePath string, fmKinds []string,
+	cfg *Config, filePath string, fmKinds []string, fmFields map[string]any,
 ) (map[string]RuleCfg, map[string]bool, map[string]bool) {
-	kinds := resolveEffectiveKinds(cfg, filePath, fmKinds)
+	kinds := resolveEffectiveKinds(cfg, filePath, fmKinds, fmFields)
 	return effectiveRules(cfg, filePath, kinds),
 		effectiveCats(cfg, filePath, kinds),
 		effectiveExplicit(cfg, filePath, kinds)

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -43,9 +43,13 @@ const (
 type KindAssignmentSource string
 
 // ResolvedKind names a kind in the effective list and how it was assigned.
+// Selector, when non-empty, describes the selectors that fired for a
+// kind-assignment match ("glob a,b AND fields-present x"). It is empty
+// for kinds declared via front matter.
 type ResolvedKind struct {
-	Name   string
-	Source KindAssignmentSource
+	Name     string
+	Source   KindAssignmentSource
+	Selector string
 }
 
 // LayerEntry is one applicable merge layer for a single rule. Source
@@ -110,9 +114,11 @@ type FileResolution struct {
 }
 
 // ResolveFile builds the full provenance picture for a single file.
-// fmKinds is the kinds: list parsed from the file's front matter.
-func ResolveFile(cfg *Config, filePath string, fmKinds []string) *FileResolution {
-	kinds := resolveKindsWithSources(cfg, filePath, fmKinds)
+// fmKinds is the kinds: list parsed from the file's front matter;
+// fmFields, when non-nil, is the parsed front matter and feeds the
+// kind-assignment `fields-present:` selector.
+func ResolveFile(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) *FileResolution {
+	kinds := resolveKindsWithSources(cfg, filePath, fmKinds, fmFields)
 	layers := buildLayers(cfg, filePath, kinds)
 
 	names := allRuleNames(layers)
@@ -340,25 +346,27 @@ func leafValue(rc RuleCfg, path string) (any, bool) {
 	return nil, false
 }
 
-func resolveKindsWithSources(cfg *Config, filePath string, fmKinds []string) []ResolvedKind {
+func resolveKindsWithSources(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) []ResolvedKind {
 	seen := make(map[string]bool)
 	var result []ResolvedKind
-	add := func(name string, source KindAssignmentSource) {
+	add := func(name string, source KindAssignmentSource, selector string) {
 		if seen[name] {
 			return
 		}
 		seen[name] = true
-		result = append(result, ResolvedKind{Name: name, Source: source})
+		result = append(result, ResolvedKind{Name: name, Source: source, Selector: selector})
 	}
 	for _, k := range fmKinds {
-		add(k, "front-matter")
+		add(k, "front-matter", "")
 	}
 	for i, entry := range cfg.KindAssignment {
-		if matchesAny(entry.Patterns(), filePath) {
-			src := KindAssignmentSource(fmt.Sprintf("kind-assignment[%d]", i))
-			for _, k := range entry.Kinds {
-				add(k, src)
-			}
+		matched, selector := matchKindAssignmentEntry(entry, filePath, fmFields)
+		if !matched {
+			continue
+		}
+		src := KindAssignmentSource(fmt.Sprintf("kind-assignment[%d]", i))
+		for _, k := range entry.Kinds {
+			add(k, src, selector)
 		}
 	}
 	return result

--- a/internal/config/provenance_edges_test.go
+++ b/internal/config/provenance_edges_test.go
@@ -33,7 +33,7 @@ func TestResolveFile_SkipsUndeclaredKindFromFrontMatter(t *testing.T) {
 		},
 		// no Kinds map: front-matter "ghost" cannot resolve to a body.
 	}
-	res := ResolveFile(cfg, "x.md", []string{"ghost"})
+	res := ResolveFile(cfg, "x.md", []string{"ghost"}, nil)
 	require.NotNil(t, res)
 	// ghost still appears in the kind list (resolveKindsWithSources adds it),
 	// but no kind layer is appended to the merge chain.
@@ -94,7 +94,7 @@ func TestBuildRuleResolution_BoolOnlyLayerPreservesInheritedSettings(t *testing.
 			{Files: []string{"x.md"}, Kinds: []string{"off"}},
 		},
 	}
-	res := ResolveFile(cfg, "x.md", nil)
+	res := ResolveFile(cfg, "x.md", nil, nil)
 	rr := res.Rules["line-length"]
 	require.NotNil(t, rr)
 	assert.False(t, rr.Final.Enabled, "kind layer must toggle Enabled off")
@@ -133,7 +133,7 @@ func TestBuildLeaves_ChainSkipsLayersMissingPath(t *testing.T) {
 			{Files: []string{"x.md"}, Kinds: []string{"size"}},
 		},
 	}
-	res := ResolveFile(cfg, "x.md", nil)
+	res := ResolveFile(cfg, "x.md", nil, nil)
 	rr := res.Rules["line-length"]
 	maxLeaf := rr.LeafByPath("settings.max")
 	require.NotNil(t, maxLeaf)

--- a/internal/config/provenance_test.go
+++ b/internal/config/provenance_test.go
@@ -38,7 +38,7 @@ overrides:
 `
 	cfg := resolveFromYAML(t, yml)
 
-	res := ResolveFile(cfg, "plan/big.md", nil)
+	res := ResolveFile(cfg, "plan/big.md", nil, nil)
 	require.NotNil(t, res)
 
 	require.Len(t, res.Kinds, 1)
@@ -88,7 +88,7 @@ kinds:
         max: 120
 `
 	cfg := resolveFromYAML(t, yml)
-	res := ResolveFile(cfg, "doc.md", []string{"proto"})
+	res := ResolveFile(cfg, "doc.md", []string{"proto"}, nil)
 
 	require.Len(t, res.Kinds, 1)
 	assert.Equal(t, "proto", res.Kinds[0].Name)
@@ -116,7 +116,7 @@ kind-assignment:
     kinds: [proto]
 `
 	cfg := resolveFromYAML(t, yml)
-	res := ResolveFile(cfg, "doc.md", nil)
+	res := ResolveFile(cfg, "doc.md", nil, nil)
 
 	rr := res.Rules["line-length"]
 	require.Len(t, rr.Layers, 2, "user + kinds.proto")
@@ -138,7 +138,7 @@ overrides:
         max: 200
 `
 	cfg := resolveFromYAML(t, yml)
-	res := ResolveFile(cfg, "doc.md", nil)
+	res := ResolveFile(cfg, "doc.md", nil, nil)
 
 	rr := res.Rules["line-length"]
 	// Override does not match doc.md, so only the user layer is in
@@ -160,7 +160,7 @@ kind-assignment:
 `
 	cfg := resolveFromYAML(t, yml)
 	// front-matter declares plan first, then kind-assignment adds proto and (dup) plan.
-	res := ResolveFile(cfg, "doc.md", []string{"plan"})
+	res := ResolveFile(cfg, "doc.md", []string{"plan"}, nil)
 
 	require.Len(t, res.Kinds, 2)
 	assert.Equal(t, "plan", res.Kinds[0].Name)

--- a/internal/config/provenance_test.go
+++ b/internal/config/provenance_test.go
@@ -184,7 +184,7 @@ kind-assignment:
     kinds: [plan]
 `
 	cfg := resolveFromYAML(t, yml)
-	res := ResolveFile(cfg, "plan/140_x.md", nil)
+	res := ResolveFile(cfg, "plan/140_x.md", nil, nil)
 
 	rr, ok := res.Rules["required-structure"]
 	require.True(t, ok,

--- a/internal/config/schema_kinds_test.go
+++ b/internal/config/schema_kinds_test.go
@@ -126,7 +126,7 @@ func TestEffectiveInjectsInlineSchema(t *testing.T) {
 			{Glob: []string{"docs/rfcs/*.md"}, Kinds: []string{"rfc"}},
 		},
 	}
-	effective := Effective(cfg, "docs/rfcs/foo.md", nil)
+	effective := Effective(cfg, "docs/rfcs/foo.md", nil, nil)
 	rs, ok := effective["required-structure"]
 	require.True(t, ok, "required-structure should be in effective config")
 	require.NotNil(t, rs.Settings)
@@ -159,7 +159,7 @@ func TestEffectiveClearsPriorSchemaWhenNewSourceArrives(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"a", "b"}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
 	assert.NotContains(t, rs.Settings, "schema",
 		"prior file-source must be cleared when a later kind installs inline")
@@ -264,7 +264,7 @@ func TestEmptyInlineSchemaDoesNotClearPriorState(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"a", "b"}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
 	assert.Equal(t, "schemas/a.md", rs.Settings["schema"],
 		"empty schema map must not clear prior file-source")
@@ -290,7 +290,7 @@ func TestInlineSchemaMarksRequiredStructureExplicit(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"k"}},
 		},
 	}
-	explicit := EffectiveExplicitRules(cfg, "foo.md", nil)
+	explicit := EffectiveExplicitRules(cfg, "foo.md", nil, nil)
 	assert.True(t, explicit["required-structure"],
 		"an inline kind schema must mark required-structure as explicit")
 }
@@ -321,7 +321,7 @@ func TestBoolOnlyRequiredStructureRuleCfg(t *testing.T) {
 	}
 	require.NoError(t, ValidateKinds(cfg),
 		"bool-only RuleCfg must not crash schema-source validation")
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	assert.NotNil(t, effective["required-structure"],
 		"bool-only kind entry must still resolve")
 }
@@ -340,7 +340,7 @@ func TestClearSchemaState_NoRequiredStructureEntry(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"k"}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs, ok := effective["required-structure"]
 	require.True(t, ok)
 	assert.Contains(t, rs.Settings, "inline-schema")
@@ -363,7 +363,7 @@ func TestClearSchemaState_NilSettings(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"k"}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
 	assert.Contains(t, rs.Settings, "inline-schema")
 }
@@ -394,7 +394,7 @@ func TestKindDeclaresSchemaRecognisesInlineSchemaSetting(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"k"}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
 	assert.NotContains(t, rs.Settings, "schema",
 		"a kind installing inline-schema via rules should clear the file path")
@@ -423,7 +423,7 @@ func TestEffectiveClearsPriorSchemaForOverrideInlineSchema(t *testing.T) {
 			}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
 	assert.NotContains(t, rs.Settings, "schema",
 		"override installing inline-schema should clear prior file source")
@@ -451,7 +451,7 @@ func TestEffectiveClearsInlineWhenFileSourceArrives(t *testing.T) {
 			{Glob: []string{"*.md"}, Kinds: []string{"a", "b"}},
 		},
 	}
-	effective := Effective(cfg, "foo.md", nil)
+	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
 	assert.NotContains(t, rs.Settings, "inline-schema",
 		"prior inline source must be cleared when a later kind installs file path")

--- a/internal/engine/kinds_test.go
+++ b/internal/engine/kinds_test.go
@@ -312,7 +312,7 @@ func TestKindSetsRequiredStructureSchema(t *testing.T) {
 		},
 	}
 
-	effective := config.Effective(cfg, "plan/001_foo.md", nil)
+	effective := config.Effective(cfg, "plan/001_foo.md", nil, nil)
 	got := effective["required-structure"].Settings["schema"]
 	assert.Equal(t, "plan/proto.md", got)
 }

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -312,11 +312,12 @@ func (r *Runner) parseFrontMatterKinds(path string, fm []byte) ([]string, error)
 
 // parseFrontMatterFields parses a file's front-matter block into a
 // top-level map. It feeds the kind-assignment `fields-present:` selector
-// and returns (nil, nil) when no entry uses the selector — skipping the
-// full YAML decode entirely so configs without fields-present keep their
-// kinds-only parse path (and its narrower error surface).
+// and returns (nil, nil) when no entry could match this file — skipping
+// the full YAML decode for files no fields-present entry would ever
+// claim. Files outside every fields-present glob keep the kinds-only
+// parse path (and its narrower error surface).
 func (r *Runner) parseFrontMatterFields(path string, fm []byte) (map[string]any, error) {
-	if !config.HasFieldsPresentSelector(r.Config) {
+	if !config.NeedsFieldsForFile(r.Config, path) {
 		return nil, nil
 	}
 	fields, err := lint.ParseFrontMatterFields(fm)

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -311,8 +311,14 @@ func (r *Runner) parseFrontMatterKinds(path string, fm []byte) ([]string, error)
 }
 
 // parseFrontMatterFields parses a file's front-matter block into a
-// top-level map. It feeds the kind-assignment `fields-present:` selector.
+// top-level map. It feeds the kind-assignment `fields-present:` selector
+// and returns (nil, nil) when no entry uses the selector — skipping the
+// full YAML decode entirely so configs without fields-present keep their
+// kinds-only parse path (and its narrower error surface).
 func (r *Runner) parseFrontMatterFields(path string, fm []byte) (map[string]any, error) {
+	if !config.HasFieldsPresentSelector(r.Config) {
+		return nil, nil
+	}
 	fields, err := lint.ParseFrontMatterFields(fm)
 	if err != nil {
 		return nil, fmt.Errorf("parsing front matter in %q: %w", path, err)

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -109,7 +109,7 @@ func (r *Runner) processFile(path string, res *Result) {
 		return r.cachedGitignore(gd)
 	}
 
-	fmKinds, err := r.parseFrontMatterKinds(path, f.FrontMatter)
+	fmKinds, fmFields, err := r.parseFrontMatter(path, f.FrontMatter)
 	if err != nil {
 		res.Errors = append(res.Errors, err)
 		return
@@ -117,13 +117,13 @@ func (r *Runner) processFile(path string, res *Result) {
 
 	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
 
-	effective := r.effectiveWithCategories(path, fmKinds)
+	effective := r.effectiveWithCategories(path, fmKinds, fmFields)
 	mdRules := r.markdownRules()
 	r.logRules(mdRules, effective)
 
 	diags, errs := CheckRules(f, mdRules, effective)
 	if r.Explain {
-		explain.Attach(diags, r.Config, path, fmKinds)
+		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
 	res.Diagnostics = append(res.Diagnostics, diags...)
 	res.Errors = append(res.Errors, errs...)
@@ -255,7 +255,7 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 		}
 	}
 
-	fmKinds, err := r.parseFrontMatterKinds(path, f.FrontMatter)
+	fmKinds, fmFields, err := r.parseFrontMatter(path, f.FrontMatter)
 	if err != nil {
 		res.Errors = append(res.Errors, err)
 		return res
@@ -263,14 +263,14 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 
 	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
 
-	effective := r.effectiveWithCategories(path, fmKinds)
+	effective := r.effectiveWithCategories(path, fmKinds, fmFields)
 
 	mdRules := r.markdownRules()
 	r.logRules(mdRules, effective)
 
 	diags, errs := CheckRules(f, mdRules, effective)
 	if r.Explain {
-		explain.Attach(diags, r.Config, path, fmKinds)
+		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
 	res.Diagnostics = append(res.Diagnostics, diags...)
 	res.Errors = append(res.Errors, errs...)
@@ -310,10 +310,36 @@ func (r *Runner) parseFrontMatterKinds(path string, fm []byte) ([]string, error)
 	return kinds, nil
 }
 
+// parseFrontMatterFields parses a file's front-matter block into a
+// top-level map. It feeds the kind-assignment `fields-present:` selector.
+func (r *Runner) parseFrontMatterFields(path string, fm []byte) (map[string]any, error) {
+	fields, err := lint.ParseFrontMatterFields(fm)
+	if err != nil {
+		return nil, fmt.Errorf("parsing front matter in %q: %w", path, err)
+	}
+	return fields, nil
+}
+
+// parseFrontMatter is the shared kinds+fields parse used by both Run and
+// RunSource; pulling it out keeps each entry point under the funlen cap.
+func (r *Runner) parseFrontMatter(path string, fm []byte) ([]string, map[string]any, error) {
+	kinds, err := r.parseFrontMatterKinds(path, fm)
+	if err != nil {
+		return nil, nil, err
+	}
+	fields, err := r.parseFrontMatterFields(path, fm)
+	if err != nil {
+		return nil, nil, err
+	}
+	return kinds, fields, nil
+}
+
 // effectiveWithCategories computes the effective rule config for a file
 // path, applying category-based enable/disable on top of per-rule settings.
-func (r *Runner) effectiveWithCategories(path string, fmKinds []string) map[string]config.RuleCfg {
-	effective, categories, explicit := config.EffectiveAll(r.Config, path, fmKinds)
+func (r *Runner) effectiveWithCategories(
+	path string, fmKinds []string, fmFields map[string]any,
+) map[string]config.RuleCfg {
+	effective, categories, explicit := config.EffectiveAll(r.Config, path, fmKinds, fmFields)
 	return config.ApplyCategories(effective, categories, ruleCategoryLookup(r.Rules), explicit)
 }
 
@@ -381,7 +407,7 @@ func (r *Runner) runConfigTargetRules(res *Result) {
 	if r.ConfigPath == "" {
 		return
 	}
-	effective := r.effectiveWithCategories(r.ConfigPath, nil)
+	effective := r.effectiveWithCategories(r.ConfigPath, nil, nil)
 	f, err := lint.NewFile(r.ConfigPath, []byte{})
 	if err != nil {
 		res.Errors = append(res.Errors, fmt.Errorf("creating config lint.File: %w", err))

--- a/internal/engine/runner_fieldspresent_test.go
+++ b/internal/engine/runner_fieldspresent_test.go
@@ -1,0 +1,91 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// When a kind-assignment entry uses fields-present:, the runner decodes
+// the file's full front matter and the entry's kind appears in the
+// effective rule resolution. Without this path being exercised the new
+// parseFrontMatterFields wrapper only ran its short-circuit branch.
+func TestRunner_FieldsPresentSelectorAppliesKind(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "task.md")
+	body := "---\nstatus: open\npriority: high\n---\n# Task\n"
+	require.NoError(t, os.WriteFile(mdFile, []byte(body), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-rule": {Enabled: false},
+		},
+		Kinds: map[string]config.KindBody{
+			"task": {Rules: map[string]config.RuleCfg{
+				"mock-rule": {Enabled: true},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status", "priority"}, Kinds: []string{"task"}},
+		},
+	}
+
+	runner := &Runner{
+		Config:           cfg,
+		Rules:            []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		StripFrontMatter: true,
+	}
+
+	result := runner.Run([]string{mdFile})
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Diagnostics, 1,
+		"task kind selected via fields-present should enable mock-rule")
+}
+
+// A file whose front matter cannot be decoded as a mapping surfaces a
+// parse error only when an entry actually uses the fields-present
+// selector. The first run (no fields-present entry) succeeds; the
+// second run errors.
+func TestRunner_FieldsPresentParseErrorGated(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "bad.md")
+	// Sequence at the top of FM — not a mapping. ParseFrontMatterKinds'
+	// fast path skips it (no "kinds:" substring); ParseFrontMatterFields
+	// rejects it.
+	body := "---\n- not\n- a\n- mapping\n---\n# Bad\n"
+	require.NoError(t, os.WriteFile(mdFile, []byte(body), 0o644))
+
+	cfgNoSelector := &config.Config{
+		Rules: map[string]config.RuleCfg{"mock-rule": {Enabled: true}},
+	}
+	rNo := &Runner{
+		Config:           cfgNoSelector,
+		Rules:            []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		StripFrontMatter: true,
+	}
+	resNo := rNo.Run([]string{mdFile})
+	assert.Empty(t, resNo.Errors,
+		"without fields-present, malformed FM should not be parsed")
+
+	cfgSelector := &config.Config{
+		Rules: map[string]config.RuleCfg{"mock-rule": {Enabled: true}},
+		Kinds: map[string]config.KindBody{"task": {}},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+	rYes := &Runner{
+		Config:           cfgSelector,
+		Rules:            []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+		StripFrontMatter: true,
+	}
+	resYes := rYes.Run([]string{mdFile})
+	require.NotEmpty(t, resYes.Errors,
+		"with fields-present, malformed FM should surface a parse error")
+	assert.Contains(t, resYes.Errors[0].Error(), "parsing front matter")
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -16,11 +16,11 @@ import (
 // Diagnostics whose RuleName is not present in the file's effective
 // rule config are left untouched: the explain trailer is best-effort
 // and never invents provenance for rules that were never resolved.
-func Attach(diags []lint.Diagnostic, cfg *config.Config, path string, fmKinds []string) {
+func Attach(diags []lint.Diagnostic, cfg *config.Config, path string, fmKinds []string, fmFields map[string]any) {
 	if len(diags) == 0 {
 		return
 	}
-	res := config.ResolveFile(cfg, path, fmKinds)
+	res := config.ResolveFile(cfg, path, fmKinds, fmFields)
 	for i := range diags {
 		rr, ok := res.Rules[diags[i].RuleName]
 		if !ok {

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -23,7 +23,7 @@ func TestAttach_PopulatesExplanation(t *testing.T) {
 		Severity: lint.Error, Message: "too long",
 	}}
 
-	Attach(diags, cfg, "x.md", nil)
+	Attach(diags, cfg, "x.md", nil, nil)
 	require.NotNil(t, diags[0].Explanation)
 	assert.Equal(t, "line-length", diags[0].Explanation.Rule)
 
@@ -51,7 +51,7 @@ func TestAttach_SkipsDiagsForUnknownRule(t *testing.T) {
 		File: "x.md", Line: 1, Column: 1,
 		RuleID: "MDS999", RuleName: "phantom-rule",
 	}}
-	Attach(diags, cfg, "x.md", nil)
+	Attach(diags, cfg, "x.md", nil, nil)
 	assert.Nil(t, diags[0].Explanation)
 }
 
@@ -61,8 +61,8 @@ func TestAttach_EmptyDiagsIsNoOp(t *testing.T) {
 	cfg := &config.Config{
 		Rules: map[string]config.RuleCfg{"line-length": {Enabled: true}},
 	}
-	Attach(nil, cfg, "x.md", nil)
-	Attach([]lint.Diagnostic{}, cfg, "x.md", nil)
+	Attach(nil, cfg, "x.md", nil, nil)
+	Attach([]lint.Diagnostic{}, cfg, "x.md", nil, nil)
 	// No panic, no allocation; nothing to assert beyond a successful return.
 }
 
@@ -83,7 +83,7 @@ func TestAttach_FrontMatterKindsApplied(t *testing.T) {
 		File: "x.md", Line: 1, Column: 1,
 		RuleID: "MDS001", RuleName: "line-length",
 	}}
-	Attach(diags, cfg, "x.md", []string{"short"})
+	Attach(diags, cfg, "x.md", []string{"short"}, nil)
 	require.NotNil(t, diags[0].Explanation)
 
 	var sawMax bool

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -319,12 +319,12 @@ func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []st
 }
 
 // parseFieldsForSelector decodes the full front-matter mapping only when
-// the loaded config actually uses the kind-assignment `fields-present:`
-// selector. Skipping the parse when no entry needs it preserves the
-// kinds-only parse path's leniency toward FM YAML errors that
-// ParseFrontMatterKinds' fast path ignores.
+// a kind-assignment entry with `fields-present:` could match this file
+// path. Skipping the parse for files outside every fields-present glob
+// preserves the kinds-only parse path's leniency toward FM YAML errors
+// that ParseFrontMatterKinds' fast path ignores.
 func parseFieldsForSelector(cfg *config.Config, path string, fm []byte) (map[string]any, error) {
-	if !config.HasFieldsPresentSelector(cfg) {
+	if !config.NeedsFieldsForFile(cfg, path) {
 		return nil, nil
 	}
 	fields, err := lint.ParseFrontMatterFields(fm)

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -311,11 +311,27 @@ func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []st
 	if err := config.ValidateFrontMatterKinds(f.Config, path, kinds); err != nil {
 		return nil, nil, nil, nil, err
 	}
-	fields, err := lint.ParseFrontMatterFields(lf.FrontMatter)
+	fields, err := parseFieldsForSelector(f.Config, path, lf.FrontMatter)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("parsing front matter in %q: %w", path, err)
+		return nil, nil, nil, nil, err
 	}
 	return lf, dirFS, kinds, fields, nil
+}
+
+// parseFieldsForSelector decodes the full front-matter mapping only when
+// the loaded config actually uses the kind-assignment `fields-present:`
+// selector. Skipping the parse when no entry needs it preserves the
+// kinds-only parse path's leniency toward FM YAML errors that
+// ParseFrontMatterKinds' fast path ignores.
+func parseFieldsForSelector(cfg *config.Config, path string, fm []byte) (map[string]any, error) {
+	if !config.HasFieldsPresentSelector(cfg) {
+		return nil, nil
+	}
+	fields, err := lint.ParseFrontMatterFields(fm)
+	if err != nil {
+		return nil, fmt.Errorf("parsing front matter in %q: %w", path, err)
+	}
+	return fields, nil
 }
 
 // effectiveWithCategories computes the effective rule config for a file

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -150,12 +150,12 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 		return nil, nil, "", []error{fmt.Errorf("stat %q: %w", path, err)}
 	}
 
-	lf, dirFS, fmKinds, prepErr := f.prepareFile(path, source)
+	lf, dirFS, fmKinds, fmFields, prepErr := f.prepareFile(path, source)
 	if prepErr != nil {
 		return nil, nil, "", []error{prepErr}
 	}
 
-	effective := f.effectiveWithCategories(path, fmKinds)
+	effective := f.effectiveWithCategories(path, fmKinds, fmFields)
 
 	f.logRules(effective)
 
@@ -181,7 +181,7 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
 	if f.Explain {
-		explain.Attach(diags, f.Config, path, fmKinds)
+		explain.Attach(diags, f.Config, path, fmKinds, fmFields)
 	}
 	return beforeDiags, diags, modified, errs
 }
@@ -275,12 +275,13 @@ func (f *Fixer) logRules(effective map[string]config.RuleCfg) {
 }
 
 // prepareFile parses a lint.File from source, configures its FS/RootDir,
-// and resolves the file's front-matter kinds. Returns the file, its dirFS,
-// the validated kind list, and any error.
-func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []string, error) {
+// and resolves the file's front-matter kinds and full FM mapping. Returns
+// the file, its dirFS, the validated kind list, the FM mapping (for the
+// kind-assignment `fields-present:` selector), and any error.
+func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []string, map[string]any, error) {
 	lf, err := lint.NewFileFromSource(path, source, f.StripFrontMatter)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("parsing %q: %w", path, err)
+		return nil, nil, nil, nil, fmt.Errorf("parsing %q: %w", path, err)
 	}
 	lf.MaxInputBytes = f.MaxInputBytes
 	dir := filepath.Dir(path)
@@ -305,18 +306,24 @@ func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []st
 	}
 	kinds, err := lint.ParseFrontMatterKinds(lf.FrontMatter)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("parsing front-matter kinds in %q: %w", path, err)
+		return nil, nil, nil, nil, fmt.Errorf("parsing front-matter kinds in %q: %w", path, err)
 	}
 	if err := config.ValidateFrontMatterKinds(f.Config, path, kinds); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return lf, dirFS, kinds, nil
+	fields, err := lint.ParseFrontMatterFields(lf.FrontMatter)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("parsing front matter in %q: %w", path, err)
+	}
+	return lf, dirFS, kinds, fields, nil
 }
 
 // effectiveWithCategories computes the effective rule config for a file
 // path, applying category-based enable/disable on top of per-rule settings.
-func (f *Fixer) effectiveWithCategories(path string, fmKinds []string) map[string]config.RuleCfg {
-	effective, categories, explicit := config.EffectiveAll(f.Config, path, fmKinds)
+func (f *Fixer) effectiveWithCategories(
+	path string, fmKinds []string, fmFields map[string]any,
+) map[string]config.RuleCfg {
+	effective, categories, explicit := config.EffectiveAll(f.Config, path, fmKinds, fmFields)
 	m := make(map[string]string, len(f.Rules))
 	for _, rl := range f.Rules {
 		m[rl.Name()] = rl.Category()

--- a/internal/fix/fix_fieldspresent_test.go
+++ b/internal/fix/fix_fieldspresent_test.go
@@ -1,0 +1,88 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// When a kind-assignment entry uses fields-present:, prepareFile decodes
+// the file's front matter into a mapping and the matching kind's rules
+// merge into the effective config. The mock rule is disabled at top
+// level and enabled by the kind; if the fields-present path doesn't fire
+// the rule stays disabled and no pre-fix failure is recorded.
+func TestFix_FieldsPresentSelectorAppliesKindRules(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "task.md")
+	body := "---\nstatus: open\npriority: high\n---\n# Title  \n"
+	require.NoError(t, os.WriteFile(mdFile, []byte(body), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-trailing": {Enabled: false},
+		},
+		Kinds: map[string]config.KindBody{
+			"task": {Rules: map[string]config.RuleCfg{
+				"mock-trailing": {Enabled: true},
+			}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status", "priority"}, Kinds: []string{"task"}},
+		},
+	}
+
+	fixer := &Fixer{
+		Config:           cfg,
+		Rules:            []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		StripFrontMatter: true,
+	}
+	result := fixer.Fix([]string{mdFile})
+	require.Empty(t, result.Errors)
+	require.Equal(t, 1, result.Failures,
+		"task kind's fixable rule should fire because fields-present matched")
+}
+
+// Without a fields-present selector, prepareFile keeps the kinds-only
+// parse path: malformed front matter (a YAML sequence) does not
+// generate a parse error. With the selector active the same file
+// surfaces the error from parseFieldsForSelector.
+func TestFix_FieldsPresentParseErrorGated(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "bad.md")
+	body := "---\n- not\n- a\n- mapping\n---\n# Bad\n"
+	require.NoError(t, os.WriteFile(mdFile, []byte(body), 0o644))
+
+	cfgNoSelector := &config.Config{
+		Rules: map[string]config.RuleCfg{"mock-trailing": {Enabled: true}},
+	}
+	fNo := &Fixer{
+		Config:           cfgNoSelector,
+		Rules:            []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		StripFrontMatter: true,
+	}
+	resNo := fNo.Fix([]string{mdFile})
+	assert.Empty(t, resNo.Errors,
+		"without fields-present, malformed FM should not surface a parse error")
+
+	cfgSelector := &config.Config{
+		Rules: map[string]config.RuleCfg{"mock-trailing": {Enabled: true}},
+		Kinds: map[string]config.KindBody{"task": {}},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+	fYes := &Fixer{
+		Config:           cfgSelector,
+		Rules:            []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		StripFrontMatter: true,
+	}
+	resYes := fYes.Fix([]string{mdFile})
+	require.NotEmpty(t, resYes.Errors,
+		"with fields-present, malformed FM should surface a parse error")
+	assert.Contains(t, resYes.Errors[0].Error(), "parsing front matter")
+}

--- a/internal/fix/source.go
+++ b/internal/fix/source.go
@@ -92,11 +92,11 @@ func fixSourceImpl(opts SourceOptions, only []string) ([]byte, error) {
 		MaxInputBytes:    maxBytes,
 		SourceFS:         opts.SourceFS,
 	}
-	lf, dirFS, fmKinds, err := f.prepareFile(opts.Path, opts.Source)
+	lf, dirFS, fmKinds, fmFields, err := f.prepareFile(opts.Path, opts.Source)
 	if err != nil {
 		return nil, err
 	}
-	effective := f.effectiveWithCategories(opts.Path, fmKinds)
+	effective := f.effectiveWithCategories(opts.Path, fmKinds, fmFields)
 	// Surface configuration errors (invalid rule settings, etc.)
 	// instead of silently producing a fix that omits the affected
 	// rules. Callers (LSP / `mdsmith fix`) decide how to render the

--- a/internal/kindsout/kindsout.go
+++ b/internal/kindsout/kindsout.go
@@ -70,10 +70,13 @@ func RuleCfgValue(rc config.RuleCfg) any {
 }
 
 // ResolvedKindJSON names a kind in the effective list and how it was
-// assigned ("front-matter" or "kind-assignment[<i>]").
+// assigned ("front-matter" or "kind-assignment[<i>]"). Selector, when
+// non-empty, describes the selectors that fired on a kind-assignment
+// match ("glob a,b AND fields-present x").
 type ResolvedKindJSON struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
+	Name     string `json:"name"`
+	Source   string `json:"source"`
+	Selector string `json:"selector,omitempty"`
 }
 
 // LeafJSON is one effective leaf with its winning source and the chain
@@ -133,7 +136,7 @@ func FileResolution(res *config.FileResolution) FileResolutionJSON {
 	}
 	for _, k := range res.Kinds {
 		out.Kinds = append(out.Kinds, ResolvedKindJSON{
-			Name: k.Name, Source: string(k.Source),
+			Name: k.Name, Source: string(k.Source), Selector: k.Selector,
 		})
 	}
 	for name, rr := range res.Rules {
@@ -237,8 +240,12 @@ func WriteFileResolutionText(w io.Writer, res *config.FileResolution) error {
 		}
 	} else {
 		for _, k := range res.Kinds {
+			src := sanitizeControl(string(k.Source))
+			if k.Selector != "" {
+				src = src + ": " + sanitizeControl(k.Selector)
+			}
 			if _, err := fmt.Fprintf(w, "  - %s (from %s)\n",
-				sanitizeControl(k.Name), sanitizeControl(string(k.Source))); err != nil {
+				sanitizeControl(k.Name), src); err != nil {
 				return err
 			}
 		}

--- a/internal/kindsout/kindsout_test.go
+++ b/internal/kindsout/kindsout_test.go
@@ -154,7 +154,7 @@ func makeFileResolution(t *testing.T) *config.FileResolution {
 			{Files: []string{"x.md"}, Kinds: []string{"short"}},
 		},
 	}
-	return config.ResolveFile(cfg, "x.md", nil)
+	return config.ResolveFile(cfg, "x.md", nil, nil)
 }
 
 func TestWriteFileResolutionText_Full(t *testing.T) {
@@ -163,7 +163,7 @@ func TestWriteFileResolutionText_Full(t *testing.T) {
 	require.NoError(t, WriteFileResolutionText(&buf, res))
 	out := buf.String()
 	assert.Contains(t, out, "file: x.md")
-	assert.Contains(t, out, "short (from kind-assignment[0])")
+	assert.Contains(t, out, "short (from kind-assignment[0]: glob x.md)")
 	assert.Contains(t, out, "line-length")
 	assert.Contains(t, out, "settings.max = 30")
 	assert.Contains(t, out, "(from kinds.short)")
@@ -173,7 +173,7 @@ func TestWriteFileResolutionText_NoKinds(t *testing.T) {
 	cfg := &config.Config{
 		Rules: map[string]config.RuleCfg{"line-length": {Enabled: true}},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	var buf bytes.Buffer
 	require.NoError(t, WriteFileResolutionText(&buf, res))
 	assert.Contains(t, buf.String(), "(none)")
@@ -204,7 +204,7 @@ func TestWriteRuleResolutionText_FullAndNoOpLayers(t *testing.T) {
 			{Files: []string{"x.md"}, Kinds: []string{"short"}},
 		},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	rr := res.Rules["line-length"]
 	var buf bytes.Buffer
 	require.NoError(t, WriteRuleResolutionText(&buf, "x.md", rr))
@@ -230,7 +230,7 @@ func TestWriteRuleResolutionText_WriteErrorPropagates(t *testing.T) {
 			{Files: []string{"x.md"}, Kinds: []string{"k"}},
 		},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	rr := res.Rules["r"]
 	for after := 0; after < 8; after++ {
 		w := &failingWriter{err: errors.New("io"), after: after}
@@ -308,7 +308,7 @@ func TestRuleResolutionJSON_IncludesNoOpLayers(t *testing.T) {
 			{Files: []string{"x.md"}, Kinds: []string{"short"}},
 		},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	rr := res.Rules["line-length"]
 	out := RuleResolution("x.md", rr)
 	require.Len(t, out.Layers, 2)
@@ -367,7 +367,7 @@ func TestWriteFileResolutionText_NoneWriteError(t *testing.T) {
 	cfg := &config.Config{
 		Rules: map[string]config.RuleCfg{"r": {Enabled: true}},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	w := &failingWriter{err: errors.New("io"), after: 2}
 	err := WriteFileResolutionText(w, res)
 	require.Error(t, err)
@@ -407,7 +407,7 @@ func TestWriteFileResolutionText_SanitizesKindName(t *testing.T) {
 			{Files: []string{"x.md"}, Kinds: []string{"evil\x1bkind"}},
 		},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	var buf bytes.Buffer
 	require.NoError(t, WriteFileResolutionText(&buf, res))
 	assert.NotContains(t, buf.String(), "\x1b")
@@ -422,7 +422,7 @@ func TestWriteRuleResolutionText_SanitizesFields(t *testing.T) {
 			"line\x07length": {Enabled: true, Settings: map[string]any{"max": 80}},
 		},
 	}
-	res := config.ResolveFile(cfg, "evil\x07file.md", nil)
+	res := config.ResolveFile(cfg, "evil\x07file.md", nil, nil)
 	rr := res.Rules["line\x07length"]
 	var buf bytes.Buffer
 	require.NoError(t, WriteRuleResolutionText(&buf, "evil\x07file.md", rr))
@@ -462,7 +462,7 @@ func TestWriteFileResolutionText_ShowsConventionLayer(t *testing.T) {
 			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
 		},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	var buf bytes.Buffer
 	require.NoError(t, WriteFileResolutionText(&buf, res))
 	out := buf.String()
@@ -483,7 +483,7 @@ func TestWriteRuleResolutionText_ShowsConventionLayer(t *testing.T) {
 			"line-length": {Enabled: true, Settings: map[string]any{"max": 80}},
 		},
 	}
-	res := config.ResolveFile(cfg, "x.md", nil)
+	res := config.ResolveFile(cfg, "x.md", nil, nil)
 	rr := res.Rules["line-length"]
 	var buf bytes.Buffer
 	require.NoError(t, WriteRuleResolutionText(&buf, "x.md", rr))

--- a/internal/lint/frontmatter.go
+++ b/internal/lint/frontmatter.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
 
@@ -61,13 +59,12 @@ func ParseFrontMatterKinds(fm []byte) ([]string, error) {
 
 // ParseFrontMatterFields decodes a YAML front-matter block (including its
 // --- delimiters) into a map of top-level keys to raw values. Returns
-// (nil, nil) when fm is empty or whitespace-only, or when the payload
-// decodes to YAML null (yaml.v3 surfaces a null document as a scalar
-// node with no decode error). Returns an error when the payload is a
-// non-null scalar or a sequence — both reject because the
-// field-presence selector requires named keys — or when the YAML is
-// otherwise invalid. Used by the kind-assignment field-presence
-// selector; a field is considered present when its value is non-null.
+// (nil, nil) when fm is empty, whitespace-only, or decodes to YAML null.
+// Returns an error when the payload is a non-null scalar or a sequence
+// — both reject because the field-presence selector requires named
+// keys — or when the YAML is otherwise invalid. Used by the
+// kind-assignment field-presence selector; a field is considered
+// present when its value is non-null.
 func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
 	if len(fm) == 0 {
 		return nil, nil
@@ -78,29 +75,16 @@ func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil, nil
 	}
-	node, err := yamlutil.UnmarshalNodeSafe(body)
-	if err != nil {
+	var raw any
+	if err := yamlutil.UnmarshalSafe(body, &raw); err != nil {
 		return nil, err
 	}
-	if node.Kind == 0 || len(node.Content) == 0 {
+	if raw == nil {
 		return nil, nil
 	}
-	root := node.Content[0]
-	switch root.Kind {
-	case yaml.MappingNode:
-		var parsed map[string]any
-		if err := root.Decode(&parsed); err != nil {
-			return nil, err
-		}
-		return parsed, nil
-	case yaml.ScalarNode:
-		if root.Tag == "!!null" {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("front matter must be a mapping, got scalar")
-	case yaml.SequenceNode:
-		return nil, fmt.Errorf("front matter must be a mapping, got sequence")
-	default:
-		return nil, fmt.Errorf("front matter must be a mapping")
+	parsed, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("front matter must be a mapping, got %T", raw)
 	}
+	return parsed, nil
 }

--- a/internal/lint/frontmatter.go
+++ b/internal/lint/frontmatter.go
@@ -57,10 +57,12 @@ func ParseFrontMatterKinds(fm []byte) ([]string, error) {
 }
 
 // ParseFrontMatterFields decodes a YAML front-matter block (including its
-// --- delimiters) into a map of top-level keys to raw values. Returns nil
-// and nil error when fm is empty or contains no mapping. Used by the
-// kind-assignment field-presence selector — a field is considered present
-// when its value is non-null.
+// --- delimiters) into a map of top-level keys to raw values. Returns
+// (nil, nil) when fm is empty or whitespace-only. Returns an error when
+// the body is non-empty but does not decode into a mapping (sequence or
+// scalar payloads are rejected) or when the YAML is otherwise invalid.
+// Used by the kind-assignment field-presence selector — a field is
+// considered present when its value is non-null.
 func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
 	if len(fm) == 0 {
 		return nil, nil

--- a/internal/lint/frontmatter.go
+++ b/internal/lint/frontmatter.go
@@ -55,3 +55,25 @@ func ParseFrontMatterKinds(fm []byte) ([]string, error) {
 	}
 	return parsed.Kinds, nil
 }
+
+// ParseFrontMatterFields decodes a YAML front-matter block (including its
+// --- delimiters) into a map of top-level keys to raw values. Returns nil
+// and nil error when fm is empty or contains no mapping. Used by the
+// kind-assignment field-presence selector — a field is considered present
+// when its value is non-null.
+func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
+	if len(fm) == 0 {
+		return nil, nil
+	}
+	delim := []byte("---\n")
+	body := bytes.TrimPrefix(fm, delim)
+	body = bytes.TrimSuffix(body, delim)
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, nil
+	}
+	var parsed map[string]any
+	if err := yamlutil.UnmarshalSafe(body, &parsed); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}

--- a/internal/lint/frontmatter.go
+++ b/internal/lint/frontmatter.go
@@ -2,6 +2,9 @@ package lint
 
 import (
 	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
@@ -58,11 +61,13 @@ func ParseFrontMatterKinds(fm []byte) ([]string, error) {
 
 // ParseFrontMatterFields decodes a YAML front-matter block (including its
 // --- delimiters) into a map of top-level keys to raw values. Returns
-// (nil, nil) when fm is empty or whitespace-only. Returns an error when
-// the body is non-empty but does not decode into a mapping (sequence or
-// scalar payloads are rejected) or when the YAML is otherwise invalid.
-// Used by the kind-assignment field-presence selector — a field is
-// considered present when its value is non-null.
+// (nil, nil) when fm is empty or whitespace-only, or when the payload
+// decodes to YAML null (yaml.v3 surfaces a null document as a scalar
+// node with no decode error). Returns an error when the payload is a
+// non-null scalar or a sequence — both reject because the
+// field-presence selector requires named keys — or when the YAML is
+// otherwise invalid. Used by the kind-assignment field-presence
+// selector; a field is considered present when its value is non-null.
 func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
 	if len(fm) == 0 {
 		return nil, nil
@@ -73,9 +78,29 @@ func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil, nil
 	}
-	var parsed map[string]any
-	if err := yamlutil.UnmarshalSafe(body, &parsed); err != nil {
+	node, err := yamlutil.UnmarshalNodeSafe(body)
+	if err != nil {
 		return nil, err
 	}
-	return parsed, nil
+	if node.Kind == 0 || len(node.Content) == 0 {
+		return nil, nil
+	}
+	root := node.Content[0]
+	switch root.Kind {
+	case yaml.MappingNode:
+		var parsed map[string]any
+		if err := root.Decode(&parsed); err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	case yaml.ScalarNode:
+		if root.Tag == "!!null" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("front matter must be a mapping, got scalar")
+	case yaml.SequenceNode:
+		return nil, fmt.Errorf("front matter must be a mapping, got sequence")
+	default:
+		return nil, fmt.Errorf("front matter must be a mapping")
+	}
 }

--- a/internal/lint/frontmatter.go
+++ b/internal/lint/frontmatter.go
@@ -79,12 +79,14 @@ func ParseFrontMatterFields(fm []byte) (map[string]any, error) {
 	if err := yamlutil.UnmarshalSafe(body, &raw); err != nil {
 		return nil, err
 	}
-	if raw == nil {
+	switch v := raw.(type) {
+	case nil:
 		return nil, nil
-	}
-	parsed, ok := raw.(map[string]any)
-	if !ok {
+	case map[string]any:
+		return v, nil
+	case map[any]any:
+		return nil, fmt.Errorf("front matter mapping keys must be strings")
+	default:
 		return nil, fmt.Errorf("front matter must be a mapping, got %T", raw)
 	}
-	return parsed, nil
 }

--- a/internal/lint/frontmatter_test.go
+++ b/internal/lint/frontmatter_test.go
@@ -158,4 +158,25 @@ func TestParseFrontMatterFields(t *testing.T) {
 		_, err := ParseFrontMatterFields([]byte("---\nbase: &a x\nkey: *a\n---\n"))
 		assert.Error(t, err)
 	})
+
+	t.Run("scalar payload rejected", func(t *testing.T) {
+		prefix, _ := StripFrontMatter([]byte("---\nfoo\n---\n"))
+		_, err := ParseFrontMatterFields(prefix)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mapping")
+	})
+
+	t.Run("sequence payload rejected", func(t *testing.T) {
+		prefix, _ := StripFrontMatter([]byte("---\n- a\n- b\n---\n"))
+		_, err := ParseFrontMatterFields(prefix)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mapping")
+	})
+
+	t.Run("explicit null document returns nil", func(t *testing.T) {
+		prefix, _ := StripFrontMatter([]byte("---\nnull\n---\n"))
+		got, err := ParseFrontMatterFields(prefix)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
 }

--- a/internal/lint/frontmatter_test.go
+++ b/internal/lint/frontmatter_test.go
@@ -122,3 +122,40 @@ func TestParseFrontMatterKinds(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFrontMatterFields(t *testing.T) {
+	t.Run("returns parsed mapping", func(t *testing.T) {
+		prefix, _ := StripFrontMatter([]byte("---\nstatus: open\nid: 7\n---\n# H\n"))
+		got, err := ParseFrontMatterFields(prefix)
+		require.NoError(t, err)
+		assert.Equal(t, "open", got["status"])
+		assert.Equal(t, 7, got["id"])
+	})
+
+	t.Run("null value preserved", func(t *testing.T) {
+		prefix, _ := StripFrontMatter([]byte("---\nstatus: null\n---\n"))
+		got, err := ParseFrontMatterFields(prefix)
+		require.NoError(t, err)
+		v, ok := got["status"]
+		require.True(t, ok, "key should be present")
+		assert.Nil(t, v, "null YAML value decodes to nil")
+	})
+
+	t.Run("no front matter returns nil", func(t *testing.T) {
+		got, err := ParseFrontMatterFields(nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("empty front matter returns nil", func(t *testing.T) {
+		prefix, _ := StripFrontMatter([]byte("---\n---\n# H\n"))
+		got, err := ParseFrontMatterFields(prefix)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("yaml aliases rejected", func(t *testing.T) {
+		_, err := ParseFrontMatterFields([]byte("---\nbase: &a x\nkey: *a\n---\n"))
+		assert.Error(t, err)
+	})
+}

--- a/internal/lint/frontmatter_test.go
+++ b/internal/lint/frontmatter_test.go
@@ -141,42 +141,41 @@ func TestParseFrontMatterFields(t *testing.T) {
 		assert.Nil(t, v, "null YAML value decodes to nil")
 	})
 
-	t.Run("no front matter returns nil", func(t *testing.T) {
-		got, err := ParseFrontMatterFields(nil)
-		require.NoError(t, err)
-		assert.Nil(t, got)
+	t.Run("nil-result inputs return nil,nil", func(t *testing.T) {
+		cases := map[string]string{
+			"no front matter":    "",
+			"empty front matter": "---\n---\n# H\n",
+			"explicit null":      "---\nnull\n---\n",
+		}
+		for name, src := range cases {
+			t.Run(name, func(t *testing.T) {
+				prefix, _ := StripFrontMatter([]byte(src))
+				got, err := ParseFrontMatterFields(prefix)
+				require.NoError(t, err)
+				assert.Nil(t, got)
+			})
+		}
 	})
 
-	t.Run("empty front matter returns nil", func(t *testing.T) {
-		prefix, _ := StripFrontMatter([]byte("---\n---\n# H\n"))
-		got, err := ParseFrontMatterFields(prefix)
-		require.NoError(t, err)
-		assert.Nil(t, got)
-	})
-
-	t.Run("yaml aliases rejected", func(t *testing.T) {
-		_, err := ParseFrontMatterFields([]byte("---\nbase: &a x\nkey: *a\n---\n"))
-		assert.Error(t, err)
-	})
-
-	t.Run("scalar payload rejected", func(t *testing.T) {
-		prefix, _ := StripFrontMatter([]byte("---\nfoo\n---\n"))
-		_, err := ParseFrontMatterFields(prefix)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mapping")
-	})
-
-	t.Run("sequence payload rejected", func(t *testing.T) {
-		prefix, _ := StripFrontMatter([]byte("---\n- a\n- b\n---\n"))
-		_, err := ParseFrontMatterFields(prefix)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mapping")
-	})
-
-	t.Run("explicit null document returns nil", func(t *testing.T) {
-		prefix, _ := StripFrontMatter([]byte("---\nnull\n---\n"))
-		got, err := ParseFrontMatterFields(prefix)
-		require.NoError(t, err)
-		assert.Nil(t, got)
+	t.Run("rejects invalid payloads", func(t *testing.T) {
+		cases := map[string]struct {
+			src     string
+			wantMsg string
+		}{
+			"yaml aliases":     {"---\nbase: &a x\nkey: *a\n---\n", ""},
+			"scalar payload":   {"---\nfoo\n---\n", "mapping"},
+			"sequence payload": {"---\n- a\n- b\n---\n", "mapping"},
+			"non-string keys":  {"---\n1: foo\n---\n", "keys must be strings"},
+		}
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				prefix, _ := StripFrontMatter([]byte(tc.src))
+				_, err := ParseFrontMatterFields(prefix)
+				require.Error(t, err)
+				if tc.wantMsg != "" {
+					assert.Contains(t, err.Error(), tc.wantMsg)
+				}
+			})
+		}
 	})
 }

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -105,9 +105,12 @@ func effectiveKindsFor(cfg *config.Config, rel string, source []byte) []string {
 	if scalar, ok := frontMatterScalarKind(fmBytes); ok {
 		fmKinds = append([]string{scalar}, fmKinds...)
 	}
-	fmFields, err := lint.ParseFrontMatterFields(fmBytes)
-	if err != nil {
-		fmFields = nil
+	var fmFields map[string]any
+	if config.HasFieldsPresentSelector(cfg) {
+		fmFields, err = lint.ParseFrontMatterFields(fmBytes)
+		if err != nil {
+			fmFields = nil
+		}
 	}
 	if len(fmKinds) == 0 && cfg == nil {
 		return nil

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -106,7 +106,7 @@ func effectiveKindsFor(cfg *config.Config, rel string, source []byte) []string {
 		fmKinds = append([]string{scalar}, fmKinds...)
 	}
 	var fmFields map[string]any
-	if config.HasFieldsPresentSelector(cfg) {
+	if config.NeedsFieldsForFile(cfg, rel) {
 		fmFields, err = lint.ParseFrontMatterFields(fmBytes)
 		if err != nil {
 			fmFields = nil

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -105,10 +105,14 @@ func effectiveKindsFor(cfg *config.Config, rel string, source []byte) []string {
 	if scalar, ok := frontMatterScalarKind(fmBytes); ok {
 		fmKinds = append([]string{scalar}, fmKinds...)
 	}
+	fmFields, err := lint.ParseFrontMatterFields(fmBytes)
+	if err != nil {
+		fmFields = nil
+	}
 	if len(fmKinds) == 0 && cfg == nil {
 		return nil
 	}
-	return config.EffectiveKinds(cfg, rel, fmKinds)
+	return config.EffectiveKinds(cfg, rel, fmKinds, fmFields)
 }
 
 // frontMatterScalarKind extracts a scalar `kind: <name>` value

--- a/internal/lsp/symbols_paths_test.go
+++ b/internal/lsp/symbols_paths_test.go
@@ -271,6 +271,23 @@ func TestEffectiveKindsForFieldsPresentSelector(t *testing.T) {
 	assert.NotContains(t, got, "task")
 }
 
+// effectiveKindsFor swallows ParseFrontMatterFields errors so a file with
+// malformed front matter (a YAML sequence in this case) still returns the
+// kinds it can resolve — the LSP index never panics or surfaces an error
+// from indexing.
+func TestEffectiveKindsForFieldsPresentParseErrorSwallowed(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Kinds: map[string]config.KindBody{"task": {}},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status"}, Kinds: []string{"task"}},
+		},
+	}
+	got := effectiveKindsFor(cfg, "a.md", []byte("---\n- not\n- a\n- mapping\n---\n# A\n"))
+	assert.NotContains(t, got, "task",
+		"unparseable FM yields no fields, so the entry cannot match")
+}
+
 func TestEffectiveKindsForScalarKind(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()

--- a/internal/lsp/symbols_paths_test.go
+++ b/internal/lsp/symbols_paths_test.go
@@ -251,6 +251,26 @@ func TestEffectiveKindsForNoCfgNoFrontMatterKind(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+func TestEffectiveKindsForFieldsPresentSelector(t *testing.T) {
+	t.Parallel()
+	// A config that uses fields-present: triggers the ParseFrontMatterFields
+	// branch in effectiveKindsFor; the front-matter mapping must satisfy
+	// the entry for the kind to land on the file.
+	cfg := &config.Config{
+		Kinds: map[string]config.KindBody{"task": {}},
+		KindAssignment: []config.KindAssignmentEntry{
+			{FieldsPresent: []string{"status", "priority"}, Kinds: []string{"task"}},
+		},
+	}
+	got := effectiveKindsFor(cfg, "a.md", []byte(
+		"---\nstatus: open\npriority: high\n---\n# A\n"))
+	assert.Contains(t, got, "task")
+
+	// A file missing one of the required fields should not get the kind.
+	got = effectiveKindsFor(cfg, "a.md", []byte("---\nstatus: open\n---\n# A\n"))
+	assert.NotContains(t, got, "task")
+}
+
 func TestEffectiveKindsForScalarKind(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()

--- a/plan/139_field-presence-kind-assignment.md
+++ b/plan/139_field-presence-kind-assignment.md
@@ -1,7 +1,7 @@
 ---
 id: 139
 title: Field-presence kind assignment
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Auto-assign a kind when a file's front matter
@@ -146,23 +146,23 @@ does.
 
 ## Acceptance Criteria
 
-- [ ] A `kind-assignment:` entry with
+- [x] A `kind-assignment:` entry with
       `fields-present: [a, b]` matches files
       whose FM contains both fields with
       non-null values.
-- [ ] An entry combining `glob:` and
+- [x] An entry combining `glob:` and
       `fields-present:` matches only files
       satisfying both.
-- [ ] Existing entries without
+- [x] Existing entries without
       `fields-present:` retain current
       behavior (regression test).
-- [ ] A field present but null does not count
+- [x] A field present but null does not count
       as present (regression test).
-- [ ] `mdsmith kinds resolve <file>` output
+- [x] `mdsmith kinds resolve <file>` output
       names the matching entry and selector.
-- [ ] [`docs/guides/file-kinds.md`](../docs/guides/file-kinds.md)
+- [x] [`docs/guides/file-kinds.md`](../docs/guides/file-kinds.md)
       describes the new selector with one
       worked example.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues.


### PR DESCRIPTION
A kind-assignment entry can now require a set of front-matter keys
with non-null values. Combined with glob: it ANDs with the path
selector. ResolveFile surfaces which entry and which selectors fired
via a new Selector field on ResolvedKind, and the text/JSON output
of `mdsmith kinds resolve` shows it.

Closes plan/139.