### PR TITLE
Add per-kind `path-pattern:` filename validation (plan 140)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -51,7 +51,7 @@ footer: |
 | 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
 | 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                   |
 | 139 | 🔲     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
-| 140 | 🔲     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
+| 140 | 🔳     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |
 | 143 | 🔲     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                              |
 | 144 | 🔲     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                              |

--- a/PLAN.md
+++ b/PLAN.md
@@ -51,7 +51,7 @@ footer: |
 | 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
 | 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                   |
 | 139 | 🔲     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
-| 140 | 🔳     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
+| 140 | ✅     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |
 | 143 | 🔲     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                              |
 | 144 | 🔲     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                              |

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -44,6 +44,51 @@ file of the kind.
 Referencing an undeclared kind name from front matter or
 `kind-assignment:` is a config error.
 
+### Validating the file path
+
+A kind can declare a `path-pattern:` glob that the
+workspace-relative path of every file in the kind must
+match. Use it to enforce filename conventions —
+plan-ID prefixes, RFC numbering, runbook slugs —
+without a custom CI script.
+
+```yaml
+kinds:
+  plan:
+    path-pattern: "plan/[0-9][0-9]*_*.md"
+    rules:
+      required-structure:
+        schema: plan/proto.md
+  rfc:
+    path-pattern: "docs/rfc/RFC-[0-9][0-9][0-9][0-9].md"
+```
+
+A file whose path does not match the kind's pattern
+produces an MDS020 diagnostic anchored to line 1 of the
+file. For `plan/early-draft.md` with the `plan` kind
+above, the diagnostic reads:
+
+```text
+filename: got "plan/early-draft.md", expected
+  glob plan/[0-9][0-9]*_*.md
+schema: kinds[plan] / path-pattern
+```
+
+The pattern uses the same doublestar syntax as
+`overrides:`, `ignore:`, and `kind-assignment:`
+(see [Glob patterns](../reference/globs.md)). Because
+glob syntax has no "exactly digits" character class,
+the pattern is an approximation: `[0-9][0-9]*` enforces a
+two-digit prefix plus any trailing characters, not strict
+integer-only. For tighter constraints, combine
+`path-pattern:` with a `<?require filename:?>` directive
+on the schema — both run, and each emits its own
+diagnostic when violated.
+
+`mdsmith kinds show <name>` prints `path-pattern:`
+alongside the kind's rule settings when it's set, so the
+constraint is auditable from one command.
+
 ## Assigning files to kinds
 
 A file's effective kind list is built from two sources,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,10 +130,18 @@ func (o Override) Patterns() []string {
 // rules.required-structure.schema:). A kind that sets both Schema
 // and rules.required-structure.schema: is a config error; see
 // ValidateKinds.
+//
+// PathPattern, when set, is a glob the workspace-relative path of every
+// file assigned to this kind must match. The pattern uses the same
+// doublestar syntax as overrides:, ignore:, and kind-assignment:. A
+// path mismatch surfaces as an MDS020 diagnostic. PathPattern is the
+// kind-config counterpart to the per-schema `<?require filename:?>`
+// directive; both feed the same matcher and may coexist.
 type KindBody struct {
-	Rules      map[string]RuleCfg `yaml:"rules"`
-	Categories map[string]bool    `yaml:"categories"`
-	Schema     map[string]any     `yaml:"schema,omitempty"`
+	Rules       map[string]RuleCfg `yaml:"rules"`
+	Categories  map[string]bool    `yaml:"categories"`
+	Schema      map[string]any     `yaml:"schema,omitempty"`
+	PathPattern string             `yaml:"path-pattern,omitempty"`
 }
 
 // KindAssignmentEntry assigns one or more kinds to files matching glob

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,12 +131,16 @@ func (o Override) Patterns() []string {
 // and rules.required-structure.schema: is a config error; see
 // ValidateKinds.
 //
-// PathPattern, when set, is a glob the workspace-relative path of every
-// file assigned to this kind must match. The pattern uses the same
-// doublestar syntax as overrides:, ignore:, and kind-assignment:. A
-// path mismatch surfaces as an MDS020 diagnostic. PathPattern is the
-// kind-config counterpart to the per-schema `<?require filename:?>`
-// directive; both feed the same matcher and may coexist.
+// PathPattern, when set, is a glob the workspace-relative path of
+// every file assigned to this kind must match. The pattern uses the
+// doublestar syntax shared by overrides:, ignore:, and
+// kind-assignment:, anchored at the workspace root. A path mismatch
+// surfaces as an MDS020 diagnostic. PathPattern is the kind-config
+// counterpart to the per-schema `<?require filename:?>` directive
+// and the two may coexist on the same kind — each runs through its
+// own matcher (`<?require filename:?>` uses filepath.Match against
+// the basename, PathPattern uses doublestar against the workspace-
+// relative path) and emits a separate diagnostic when violated.
 type KindBody struct {
 	Rules       map[string]RuleCfg `yaml:"rules"`
 	Categories  map[string]bool    `yaml:"categories"`

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -372,6 +372,73 @@ func TestCopyKindsNilSettingsRemainNil(t *testing.T) {
 	assert.Nil(t, copied["plan"].Rules["no-hard-tabs"].Settings)
 }
 
+// --- path-pattern ---
+
+func TestKindsPathPatternParsesFromYAML(t *testing.T) {
+	yml := `
+kinds:
+  plan:
+    path-pattern: "plan/[0-9][0-9]*_*.md"
+  rfc:
+    path-pattern: "docs/rfc/RFC-[0-9][0-9][0-9][0-9].md"
+`
+	cfg := loadFromString(t, yml)
+	require.Contains(t, cfg.Kinds, "plan")
+	assert.Equal(t, "plan/[0-9][0-9]*_*.md", cfg.Kinds["plan"].PathPattern)
+	assert.Equal(t, "docs/rfc/RFC-[0-9][0-9][0-9][0-9].md",
+		cfg.Kinds["rfc"].PathPattern)
+}
+
+func TestEffectiveRules_PathPatternInstallsListSetting(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{
+			"plan": {PathPattern: "plan/[0-9]*_*.md"},
+		},
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
+		},
+	}
+	eff, _, _ := EffectiveAll(cfg, "plan/01_x.md", nil)
+	rs, ok := eff["required-structure"]
+	require.True(t, ok, "required-structure rule should be present")
+	assert.True(t, rs.Enabled)
+	list, ok := rs.Settings["path-patterns"].([]any)
+	require.True(t, ok, "path-patterns should be a list")
+	require.Len(t, list, 1)
+	entry := list[0].(map[string]any)
+	assert.Equal(t, "plan", entry["kind"])
+	assert.Equal(t, "plan/[0-9]*_*.md", entry["pattern"])
+}
+
+func TestEffectiveRules_PathPatternAccumulatesAcrossKinds(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{
+			"plan": {PathPattern: "plan/*.md"},
+			"rfc":  {PathPattern: "docs/rfc/*.md"},
+		},
+	}
+	eff, _, _ := EffectiveAll(cfg, "anywhere.md", []string{"plan", "rfc"})
+	rs := eff["required-structure"]
+	list, _ := rs.Settings["path-patterns"].([]any)
+	require.Len(t, list, 2)
+	assert.Equal(t, "plan", list[0].(map[string]any)["kind"])
+	assert.Equal(t, "rfc", list[1].(map[string]any)["kind"])
+}
+
+func TestEffectiveRules_PathPatternAbsentLeavesRuleAlone(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{
+			"plan": {Rules: map[string]RuleCfg{"line-length": {Enabled: false}}},
+		},
+	}
+	eff, _, _ := EffectiveAll(cfg, "anywhere.md", []string{"plan"})
+	if rs, ok := eff["required-structure"]; ok {
+		_, hasList := rs.Settings["path-patterns"]
+		assert.False(t, hasList,
+			"path-patterns should be absent when no kind declares one")
+	}
+}
+
 // --- helpers ---
 
 func loadFromString(t *testing.T, yml string) *Config {

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -439,6 +439,33 @@ func TestEffectiveRules_PathPatternAbsentLeavesRuleAlone(t *testing.T) {
 	}
 }
 
+// TestKindLayerRules_MergesPathPatternWithExistingRules verifies
+// that the provenance helper preserves a kind's existing body.Rules
+// settings while injecting the synthetic `path-patterns` entry on
+// top of them. Without this, a kind that both disables a rule and
+// declares a `path-pattern:` would have its `body.Rules` ignored in
+// `kinds resolve` / `--explain` output.
+func TestKindLayerRules_MergesPathPatternWithExistingRules(t *testing.T) {
+	body := KindBody{
+		PathPattern: "plan/*.md",
+		Rules: map[string]RuleCfg{
+			"line-length": {Enabled: false},
+			"required-structure": {Enabled: true,
+				Settings: map[string]any{"schema": "plan/proto.md"}},
+		},
+	}
+	out := kindLayerRules("plan", body)
+	require.Contains(t, out, "line-length")
+	assert.False(t, out["line-length"].Enabled)
+	rs := out["required-structure"]
+	assert.True(t, rs.Enabled)
+	assert.Equal(t, "plan/proto.md", rs.Settings["schema"],
+		"existing required-structure settings must be preserved")
+	list := rs.Settings["path-patterns"].([]any)
+	require.Len(t, list, 1)
+	assert.Equal(t, "plan", list[0].(map[string]any)["kind"])
+}
+
 // --- helpers ---
 
 func loadFromString(t *testing.T, yml string) *Config {

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -493,6 +493,36 @@ func TestKindLayerRules_MergesPathPatternWithExistingRules(t *testing.T) {
 	assert.Equal(t, "plan", list[0].(map[string]any)["kind"])
 }
 
+// TestKindLayerRules_MirrorsInlineSchemaAndPathPattern verifies
+// that a kind declaring both `schema:` (an inline schema map) and
+// `path-pattern:` lands BOTH synthetic settings in the provenance
+// layer chain — without this, `kinds resolve` / `--explain` would
+// drop the inline-schema leaf even though effectiveRules applies
+// it.
+func TestKindLayerRules_MirrorsInlineSchemaAndPathPattern(t *testing.T) {
+	body := KindBody{
+		PathPattern: "plan/*.md",
+		Schema: map[string]any{
+			"sections": []any{
+				map[string]any{"heading": "Goal"},
+			},
+		},
+	}
+	out := kindLayerRules("plan", body)
+	rs := out["required-structure"]
+	assert.True(t, rs.Enabled)
+
+	schema, ok := rs.Settings["inline-schema"].(map[string]any)
+	require.True(t, ok, "inline-schema must be injected as a map")
+	assert.Contains(t, schema, "sections")
+
+	list, ok := rs.Settings["path-patterns"].([]any)
+	require.True(t, ok)
+	require.Len(t, list, 1)
+	assert.Equal(t, "plan/*.md",
+		list[0].(map[string]any)["pattern"])
+}
+
 // --- helpers ---
 
 func loadFromString(t *testing.T, yml string) *Config {

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -439,6 +439,33 @@ func TestEffectiveRules_PathPatternAbsentLeavesRuleAlone(t *testing.T) {
 	}
 }
 
+// TestValidateKinds_RejectsInvalidPathPattern verifies that
+// ValidateKinds rejects a kind whose top-level `path-pattern:`
+// is not a valid doublestar glob. Without this, commands that
+// load config but do not run the required-structure rule
+// (e.g. `mdsmith kinds show`) would silently accept and display
+// a malformed pattern.
+func TestValidateKinds_RejectsInvalidPathPattern(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{
+			"plan": {PathPattern: "[unclosed"},
+		},
+	}
+	err := ValidateKinds(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path-pattern")
+	assert.Contains(t, err.Error(), "plan")
+}
+
+func TestValidateKinds_AcceptsValidPathPattern(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{
+			"plan": {PathPattern: "plan/[0-9][0-9]*_*.md"},
+		},
+	}
+	assert.NoError(t, ValidateKinds(cfg))
+}
+
 // TestKindLayerRules_MergesPathPatternWithExistingRules verifies
 // that the provenance helper preserves a kind's existing body.Rules
 // settings while injecting the synthetic `path-patterns` entry on

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -156,9 +156,10 @@ func copyKinds(kinds map[string]KindBody) map[string]KindBody {
 			rules[k] = copyRuleCfg(v)
 		}
 		result[name] = KindBody{
-			Rules:      rules,
-			Categories: copyCategories(body.Categories),
-			Schema:     cloneSettings(body.Schema),
+			Rules:       rules,
+			Categories:  copyCategories(body.Categories),
+			Schema:      cloneSettings(body.Schema),
+			PathPattern: body.PathPattern,
 		}
 	}
 	return result
@@ -368,6 +369,9 @@ func effectiveRules(cfg *Config, filePath string, kinds []string) map[string]Rul
 		if len(body.Schema) > 0 {
 			applyInlineSchema(result, body.Schema)
 		}
+		if body.PathPattern != "" {
+			applyPathPattern(result, kindName, body.PathPattern)
+		}
 		for k, v := range body.Rules {
 			apply(k, v)
 		}
@@ -442,6 +446,27 @@ func clearSchemaState(result map[string]RuleCfg) {
 	result["required-structure"] = rs
 }
 
+// applyPathPattern appends a {kind, pattern} entry to the
+// `path-patterns` list setting on required-structure, creating the
+// rule entry if missing. Each kind in the file's effective kind list
+// that declares a `path-pattern:` contributes one entry, so the rule
+// can validate the workspace-relative path against every applicable
+// pattern and emit one diagnostic per failure.
+func applyPathPattern(result map[string]RuleCfg, kindName, pattern string) {
+	rs, ok := result["required-structure"]
+	if !ok {
+		rs = RuleCfg{Enabled: true}
+	}
+	if rs.Settings == nil {
+		rs.Settings = map[string]any{}
+	}
+	entry := map[string]any{"kind": kindName, "pattern": pattern}
+	existing, _ := rs.Settings["path-patterns"].([]any)
+	rs.Settings["path-patterns"] = append(existing, entry)
+	rs.Enabled = true
+	result["required-structure"] = rs
+}
+
 // applyInlineSchema installs an inline schema (a YAML map) as the
 // `inline-schema` setting on required-structure, creating the rule
 // entry if missing.
@@ -476,8 +501,9 @@ func effectiveExplicit(cfg *Config, filePath string, kinds []string) map[string]
 		// outside body.Rules. Without this, a `meta` category
 		// disable would silently wipe an inline-schema kind's
 		// effect — inconsistent with the file-source path that
-		// lives under body.Rules.
-		if len(body.Schema) > 0 {
+		// lives under body.Rules. The same reasoning applies to
+		// `path-pattern:`.
+		if len(body.Schema) > 0 || body.PathPattern != "" {
 			result["required-structure"] = true
 		}
 	}

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -188,15 +188,16 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 // kindLayerRules returns the per-kind rules map seen by the
 // provenance layer chain, mirroring the synthetic injections
 // effectiveRules performs in merge.go. A kind body can configure
-// required-structure outside body.Rules — via the top-level
-// `path-pattern:` field on KindBody — and the engine's merge layer
-// translates that into a `path-patterns` setting on the rule. Without
-// mirroring the same injection here, `mdsmith kinds resolve` and
-// `--explain` output omit the winning source for the synthetic
-// setting and diverge from the rule config the engine actually
-// applied.
+// required-structure outside body.Rules via two top-level fields
+// on KindBody — `schema:` (an inline schema map) and
+// `path-pattern:` — and the engine's merge layer translates each
+// into a setting on the rule (`inline-schema` and `path-patterns`
+// respectively). Without mirroring those injections here,
+// `mdsmith kinds resolve` and `--explain` output drop the
+// winning source for either synthetic setting and diverge from
+// the rule config the engine actually applied.
 func kindLayerRules(kindName string, body KindBody) map[string]RuleCfg {
-	if body.PathPattern == "" {
+	if len(body.Schema) == 0 && body.PathPattern == "" {
 		return body.Rules
 	}
 	out := make(map[string]RuleCfg, len(body.Rules)+1)
@@ -210,9 +211,14 @@ func kindLayerRules(kindName string, body KindBody) map[string]RuleCfg {
 	} else {
 		rs.Settings = cloneSettings(rs.Settings)
 	}
-	entry := map[string]any{"kind": kindName, "pattern": body.PathPattern}
-	existing, _ := rs.Settings["path-patterns"].([]any)
-	rs.Settings["path-patterns"] = append(existing, entry)
+	if len(body.Schema) > 0 {
+		rs.Settings["inline-schema"] = cloneSettings(body.Schema)
+	}
+	if body.PathPattern != "" {
+		entry := map[string]any{"kind": kindName, "pattern": body.PathPattern}
+		existing, _ := rs.Settings["path-patterns"].([]any)
+		rs.Settings["path-patterns"] = append(existing, entry)
+	}
 	out["required-structure"] = rs
 	return out
 }

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -171,7 +171,7 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 		}
 		layers = append(layers, layerInfo{
 			Source: "kinds." + k.Name,
-			Rules:  body.Rules,
+			Rules:  kindLayerRules(k.Name, body),
 		})
 	}
 	for i, o := range cfg.Overrides {
@@ -183,6 +183,38 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 		}
 	}
 	return layers
+}
+
+// kindLayerRules returns the per-kind rules map seen by the
+// provenance layer chain, mirroring the synthetic injections
+// effectiveRules performs in merge.go. A kind body can configure
+// required-structure outside body.Rules — via the top-level
+// `path-pattern:` field on KindBody — and the engine's merge layer
+// translates that into a `path-patterns` setting on the rule. Without
+// mirroring the same injection here, `mdsmith kinds resolve` and
+// `--explain` output omit the winning source for the synthetic
+// setting and diverge from the rule config the engine actually
+// applied.
+func kindLayerRules(kindName string, body KindBody) map[string]RuleCfg {
+	if body.PathPattern == "" {
+		return body.Rules
+	}
+	out := make(map[string]RuleCfg, len(body.Rules)+1)
+	for k, v := range body.Rules {
+		out[k] = v
+	}
+	rs := out["required-structure"]
+	rs.Enabled = true
+	if rs.Settings == nil {
+		rs.Settings = map[string]any{}
+	} else {
+		rs.Settings = cloneSettings(rs.Settings)
+	}
+	entry := map[string]any{"kind": kindName, "pattern": body.PathPattern}
+	existing, _ := rs.Settings["path-patterns"].([]any)
+	rs.Settings["path-patterns"] = append(existing, entry)
+	out["required-structure"] = rs
+	return out
 }
 
 // splitRulesByExplicit divides cfg.Rules into two maps using

--- a/internal/config/provenance_test.go
+++ b/internal/config/provenance_test.go
@@ -168,3 +168,35 @@ kind-assignment:
 	assert.Equal(t, "proto", res.Kinds[1].Name)
 	assert.Equal(t, KindAssignmentSource("kind-assignment[0]"), res.Kinds[1].Source)
 }
+
+// TestResolveFile_PathPatternAppearsInProvenance verifies that a
+// kind's top-level `path-pattern:` field — which the engine merges
+// into required-structure via a synthetic `path-patterns` setting —
+// shows up in `kinds resolve` / `--explain` provenance under its
+// kind layer, instead of being dropped by buildLayers.
+func TestResolveFile_PathPatternAppearsInProvenance(t *testing.T) {
+	yml := `
+kinds:
+  plan:
+    path-pattern: "plan/[0-9][0-9]*_*.md"
+kind-assignment:
+  - files: ["plan/*.md"]
+    kinds: [plan]
+`
+	cfg := resolveFromYAML(t, yml)
+	res := ResolveFile(cfg, "plan/140_x.md", nil)
+
+	rr, ok := res.Rules["required-structure"]
+	require.True(t, ok,
+		"required-structure must appear in rules when path-pattern is set")
+	leaf := rr.LeafByPath("settings.path-patterns")
+	require.NotNil(t, leaf,
+		"path-patterns leaf must be present in provenance")
+	assert.Equal(t, "kinds.plan", leaf.Source())
+	list, ok := leaf.Value.([]any)
+	require.True(t, ok)
+	require.Len(t, list, 1)
+	entry := list[0].(map[string]any)
+	assert.Equal(t, "plan", entry["kind"])
+	assert.Equal(t, "plan/[0-9][0-9]*_*.md", entry["pattern"])
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,6 +1,11 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
 
 // ValidateKinds returns an error if any kind named in a kind-assignment
 // entry is not declared in cfg.Kinds, or if any declared kind sets a
@@ -15,6 +20,9 @@ func ValidateKinds(cfg *Config) error {
 		if err := validateKindSchemaSources(name, body); err != nil {
 			return err
 		}
+		if err := validateKindPathPattern(name, body); err != nil {
+			return err
+		}
 	}
 	for i, entry := range cfg.KindAssignment {
 		for _, name := range entry.Kinds {
@@ -24,6 +32,27 @@ func ValidateKinds(cfg *Config) error {
 				)
 			}
 		}
+	}
+	return nil
+}
+
+// validateKindPathPattern rejects a kind whose top-level
+// `path-pattern:` is not a valid doublestar glob. Without this
+// check, commands that load config but do not run the
+// required-structure rule (e.g. `mdsmith kinds show`) would
+// silently accept and display a malformed pattern, and the
+// problem would only surface as a per-file rule-configuration
+// error at lint time. The matcher is shared with overrides:,
+// ignore:, and kind-assignment:; mirroring their syntax keeps
+// the user-facing config surface uniform.
+func validateKindPathPattern(name string, body KindBody) error {
+	if body.PathPattern == "" {
+		return nil
+	}
+	if !doublestar.ValidatePattern(filepath.ToSlash(body.PathPattern)) {
+		return fmt.Errorf(
+			"kind %q: path-pattern %q is not a valid doublestar glob",
+			name, body.PathPattern)
 	}
 	return nil
 }

--- a/internal/engine/kinds_test.go
+++ b/internal/engine/kinds_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	_ "github.com/jeduden/mdsmith/internal/rules/requiredstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -228,6 +229,69 @@ func TestRunSource_FrontMatterKinds_InvalidYAMLIsError(t *testing.T) {
 	result := runner.RunSource("doc.md", src)
 	require.Len(t, result.Errors, 1)
 	assert.Contains(t, result.Errors[0].Error(), "parsing front-matter kinds")
+}
+
+// TestKindPathPattern_MismatchEmitsMDS020 verifies that a kind with a
+// `path-pattern:` causes the required-structure rule to emit an MDS020
+// diagnostic for files whose workspace-relative path does not match
+// the glob.
+func TestKindPathPattern_MismatchEmitsMDS020(t *testing.T) {
+	dir := t.TempDir()
+	planFile := filepath.Join(dir, "plan", "early-draft.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(planFile), 0o755))
+	require.NoError(t, os.WriteFile(planFile, []byte("# Draft\n"), 0o644))
+
+	cfg := &config.Config{
+		Kinds: map[string]config.KindBody{
+			"plan": {PathPattern: "plan/[0-9][0-9]*_*.md"},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"**/plan/*.md"}, Kinds: []string{"plan"}},
+		},
+	}
+
+	runner := &Runner{
+		Config:  cfg,
+		Rules:   []rule.Rule{rule.ByName("required-structure")},
+		RootDir: dir,
+	}
+
+	result := runner.Run([]string{planFile})
+	require.Empty(t, result.Errors)
+	require.Len(t, result.Diagnostics, 1)
+	d := result.Diagnostics[0]
+	assert.Equal(t, "MDS020", d.RuleID)
+	assert.Contains(t, d.Message, `filename: got "plan/early-draft.md"`)
+	assert.Contains(t, d.Message, "kinds[plan] / path-pattern")
+}
+
+// TestKindPathPattern_MatchEmitsNoDiagnostic is the green half of the
+// previous test: a file whose path satisfies the kind's pattern produces
+// no MDS020 path-pattern diagnostic.
+func TestKindPathPattern_MatchEmitsNoDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	planFile := filepath.Join(dir, "plan", "140_x.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(planFile), 0o755))
+	require.NoError(t, os.WriteFile(planFile, []byte("# Plan\n"), 0o644))
+
+	cfg := &config.Config{
+		Kinds: map[string]config.KindBody{
+			"plan": {PathPattern: "plan/[0-9][0-9]*_*.md"},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"**/plan/*.md"}, Kinds: []string{"plan"}},
+		},
+	}
+
+	runner := &Runner{
+		Config:  cfg,
+		Rules:   []rule.Rule{rule.ByName("required-structure")},
+		RootDir: dir,
+	}
+
+	result := runner.Run([]string{planFile})
+	require.Empty(t, result.Errors)
+	assert.Empty(t, result.Diagnostics)
 }
 
 // TestKindSetsRequiredStructureSchema verifies that a kind setting

--- a/internal/kindsout/kindsout.go
+++ b/internal/kindsout/kindsout.go
@@ -20,9 +20,10 @@ import (
 // BodyJSON is the JSON form of a kind body, used by `kinds list` and
 // `kinds show`.
 type BodyJSON struct {
-	Name       string                 `json:"name"`
-	Rules      map[string]RuleCfgJSON `json:"rules"`
-	Categories map[string]bool        `json:"categories,omitempty"`
+	Name        string                 `json:"name"`
+	Rules       map[string]RuleCfgJSON `json:"rules"`
+	Categories  map[string]bool        `json:"categories,omitempty"`
+	PathPattern string                 `json:"path-pattern,omitempty"`
 }
 
 // RuleCfgJSON serializes a config.RuleCfg using its YAML union form:
@@ -43,9 +44,10 @@ func MakeBodyJSON(name string, body config.KindBody) BodyJSON {
 		rules[k] = RuleCfgJSON{v: RuleCfgValue(v)}
 	}
 	return BodyJSON{
-		Name:       name,
-		Rules:      rules,
-		Categories: body.Categories,
+		Name:        name,
+		Rules:       rules,
+		Categories:  body.Categories,
+		PathPattern: body.PathPattern,
 	}
 }
 
@@ -196,11 +198,13 @@ func WriteBodyText(w io.Writer, name string, body config.KindBody) error {
 		return err
 	}
 	wrap := struct {
-		Rules      map[string]config.RuleCfg `yaml:"rules,omitempty"`
-		Categories map[string]bool           `yaml:"categories,omitempty"`
+		Rules       map[string]config.RuleCfg `yaml:"rules,omitempty"`
+		Categories  map[string]bool           `yaml:"categories,omitempty"`
+		PathPattern string                    `yaml:"path-pattern,omitempty"`
 	}{
-		Rules:      body.Rules,
-		Categories: body.Categories,
+		Rules:       body.Rules,
+		Categories:  body.Categories,
+		PathPattern: body.PathPattern,
 	}
 	data, err := yamlutil.Marshal(wrap)
 	if err != nil {

--- a/internal/kindsout/kindsout_test.go
+++ b/internal/kindsout/kindsout_test.go
@@ -89,6 +89,24 @@ func TestWriteBodyText_RendersYAMLBody(t *testing.T) {
 	assert.Contains(t, out, "max: 30")
 }
 
+func TestWriteBodyText_RendersPathPattern(t *testing.T) {
+	body := config.KindBody{
+		PathPattern: "plan/[0-9][0-9]*_*.md",
+	}
+	var buf bytes.Buffer
+	require.NoError(t, WriteBodyText(&buf, "plan", body))
+	out := buf.String()
+	assert.Contains(t, out, "plan:")
+	assert.Contains(t, out, "path-pattern: plan/[0-9][0-9]*_*.md")
+}
+
+func TestMakeBodyJSON_IncludesPathPattern(t *testing.T) {
+	body := config.KindBody{PathPattern: "plan/*.md"}
+	enc, err := json.Marshal(MakeBodyJSON("plan", body))
+	require.NoError(t, err)
+	assert.Contains(t, string(enc), `"path-pattern":"plan/*.md"`)
+}
+
 func TestWriteBodyText_EmptyBodyRendersPlaceholder(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, WriteBodyText(&buf, "ghost", config.KindBody{}))

--- a/internal/rules/MDS020-required-structure/bad/path-pattern-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/path-pattern-mismatch.md
@@ -1,0 +1,14 @@
+---
+settings:
+  path-patterns:
+    - kind: plan
+      pattern: "[0-9]*_*.md"
+diagnostics:
+  - line: 1
+    column: 1
+    message: |-
+      filename: got "path-pattern-mismatch.md", expected
+        glob [0-9]*_*.md
+      schema: kinds[plan] / path-pattern
+---
+# Plan body whose path does not match the kind's path-pattern

--- a/internal/rules/MDS020-required-structure/good/path-pattern-match.md
+++ b/internal/rules/MDS020-required-structure/good/path-pattern-match.md
@@ -1,0 +1,7 @@
+---
+settings:
+  path-patterns:
+    - kind: plan
+      pattern: "path-*.md"
+---
+# Plan body satisfies the kind's path-pattern

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -218,6 +218,15 @@ func parsePathPatterns(v any) ([]PathPattern, error) {
 			return nil, fmt.Errorf(
 				"path-patterns[%d].pattern must be a non-empty string, got %T", i, patV)
 		}
+		// Validate the pattern as a doublestar glob at config time
+		// so an unmatched bracket or other syntax error surfaces as
+		// a config error instead of an MDS020 diagnostic on every
+		// file assigned to the kind.
+		if !doublestar.ValidatePattern(filepath.ToSlash(pat)) {
+			return nil, fmt.Errorf(
+				"path-patterns[%d].pattern %q is not a valid doublestar glob",
+				i, pat)
+		}
 		out = append(out, PathPattern{Kind: kind, Pattern: pat})
 	}
 	return out, nil

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1321,16 +1321,20 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 // resolved through filepath.Abs first so the relative computation
 // works when the CLI was invoked with a relative `--config` path
 // (e.g. `--config sub/.mdsmith.yml` makes RootDir relative).
+//
+// filepath.Abs / filepath.Rel only fail when os.Getwd fails or the
+// two paths cannot be expressed relative to one another (different
+// volumes on Windows). Both are pre-conditions the engine has
+// already satisfied for every other rule before this point, so any
+// error here would already have blocked the lint at file discovery;
+// the fallback returns f.Path so the diagnostic still names a path.
 func workspaceRelPath(f *lint.File) string {
 	if f.RootDir == "" {
 		return filepath.ToSlash(f.Path)
 	}
-	absRoot, err := filepath.Abs(f.RootDir)
-	if err != nil {
-		return filepath.ToSlash(f.Path)
-	}
-	absPath, err := filepath.Abs(f.Path)
-	if err != nil {
+	absRoot, errRoot := filepath.Abs(f.RootDir)
+	absPath, errPath := filepath.Abs(f.Path)
+	if errRoot != nil || errPath != nil {
 		return filepath.ToSlash(f.Path)
 	}
 	rel, err := filepath.Rel(absRoot, absPath)

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -13,6 +13,7 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
+	"github.com/jeduden/mdsmith/internal/globpath"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -39,6 +40,16 @@ type Rule struct {
 	Schema       string         // path to schema file
 	InlineSchema *schema.Schema // parsed inline schema (when set)
 	Placeholders []string       // placeholder tokens to treat as opaque
+	PathPatterns []PathPattern  // kind-level path-pattern entries
+}
+
+// PathPattern records a kind's `path-pattern:` constraint: the kind
+// that declared it and the glob the workspace-relative path of every
+// file in the kind must match. Populated by the config merge layer
+// from KindBody.PathPattern.
+type PathPattern struct {
+	Kind    string
+	Pattern string
 }
 
 // ID implements rule.Rule.
@@ -92,6 +103,12 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 				return fmt.Errorf("required-structure: %w", err)
 			}
 			r.Placeholders = toks
+		case "path-patterns":
+			pp, err := parsePathPatterns(v)
+			if err != nil {
+				return fmt.Errorf("required-structure: %w", err)
+			}
+			r.PathPatterns = pp
 		case "archetype", "archetype-roots":
 			return fmt.Errorf(
 				"required-structure: setting %q has been removed; "+
@@ -161,7 +178,49 @@ func (r *Rule) SettingMergeMode(key string) rule.MergeMode {
 	if key == "placeholders" {
 		return rule.MergeAppend
 	}
+	if key == "path-patterns" {
+		return rule.MergeAppend
+	}
 	return rule.MergeReplace
+}
+
+// parsePathPatterns reads the `path-patterns` rule setting: a list of
+// {kind, pattern} maps installed by the config merge layer from each
+// kind's `path-pattern:` field. The merge layer is the only documented
+// producer; the parser still validates shape so a hand-written rule
+// override fails loudly instead of silently dropping entries.
+func parsePathPatterns(v any) ([]PathPattern, error) {
+	list, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf(
+			"path-patterns must be a list of {kind, pattern} maps, got %T", v)
+	}
+	out := make([]PathPattern, 0, len(list))
+	for i, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf(
+				"path-patterns[%d] must be a map, got %T", i, item)
+		}
+		kindV, hasKind := m["kind"]
+		patV, hasPat := m["pattern"]
+		if !hasKind || !hasPat {
+			return nil, fmt.Errorf(
+				"path-patterns[%d] must set both `kind` and `pattern`", i)
+		}
+		kind, ok := kindV.(string)
+		if !ok || kind == "" {
+			return nil, fmt.Errorf(
+				"path-patterns[%d].kind must be a non-empty string, got %T", i, kindV)
+		}
+		pat, ok := patV.(string)
+		if !ok || pat == "" {
+			return nil, fmt.Errorf(
+				"path-patterns[%d].pattern must be a non-empty string, got %T", i, patV)
+		}
+		out = append(out, PathPattern{Kind: kind, Pattern: pat})
+	}
+	return out, nil
 }
 
 // Check implements rule.Rule.
@@ -177,6 +236,12 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			diags = append(diags, d)
 		}
 	}
+
+	// Kind-level path-pattern constraints run independently of the
+	// schema source: a kind may declare `path-pattern:` without an
+	// attached schema, and a schema-bearing kind may add a pattern
+	// on top of a `<?require filename:?>` directive.
+	diags = append(diags, r.checkPathPatterns(f)...)
 
 	if r.hasInlineSchema() {
 		return append(diags, r.checkInlineSchema(f)...)
@@ -1224,6 +1289,48 @@ func isSchemaFile(docPath, schemaPath string) bool {
 // formatHeading returns a markdown-style heading string.
 func formatHeading(level int, text string) string {
 	return strings.Repeat("#", level) + " " + text
+}
+
+// checkPathPatterns validates the workspace-relative path of f
+// against every kind-level `path-pattern:` configured on the rule.
+// One diagnostic is emitted per failing pattern; a kind whose pattern
+// matches contributes no diagnostic. Matching uses the same doublestar
+// syntax as overrides:, ignore:, and kind-assignment:, anchored at the
+// workspace root.
+func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
+	if len(r.PathPatterns) == 0 {
+		return nil
+	}
+	rel := workspaceRelPath(f)
+	var diags []lint.Diagnostic
+	for _, pp := range r.PathPatterns {
+		if globpath.Match(pp.Pattern, rel) {
+			continue
+		}
+		diags = append(diags, makeDiag(f.Path, 1, fmt.Sprintf(
+			"filename: got %q, expected\n  glob %s\nschema: kinds[%s] / path-pattern",
+			rel, pp.Pattern, pp.Kind)))
+	}
+	return diags
+}
+
+// workspaceRelPath returns the file path relative to the workspace
+// root when RootDir is set, falling back to the file's own Path. The
+// returned path is slash-normalized so glob patterns written with
+// forward slashes match on every platform.
+func workspaceRelPath(f *lint.File) string {
+	if f.RootDir == "" {
+		return filepath.ToSlash(f.Path)
+	}
+	abs, err := filepath.Abs(f.Path)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
+	rel, err := filepath.Rel(f.RootDir, abs)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
+	return filepath.ToSlash(rel)
 }
 
 // checkFilenamePattern checks that the document basename matches the

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -12,8 +12,8 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
-	"github.com/jeduden/mdsmith/internal/globpath"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -1301,10 +1301,16 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 	if len(r.PathPatterns) == 0 {
 		return nil
 	}
-	rel := workspaceRelPath(f)
+	rel := filepath.ToSlash(workspaceRelPath(f))
 	var diags []lint.Diagnostic
 	for _, pp := range r.PathPatterns {
-		if globpath.Match(pp.Pattern, rel) {
+		// Match the full workspace-relative path with doublestar
+		// directly. Going through globpath.Match would also try the
+		// basename, which would let `path-pattern: README.md` pass
+		// for `docs/README.md` — defeating the documented root-
+		// anchored semantics.
+		ok, err := doublestar.Match(filepath.ToSlash(pp.Pattern), rel)
+		if err == nil && ok {
 			continue
 		}
 		diags = append(diags, makeDiag(f.Path, 1, fmt.Sprintf(

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1320,23 +1320,16 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 // forward slashes match on every platform. Both RootDir and Path are
 // resolved through filepath.Abs first so the relative computation
 // works when the CLI was invoked with a relative `--config` path
-// (e.g. `--config sub/.mdsmith.yml` makes RootDir relative).
-//
-// filepath.Abs / filepath.Rel only fail when os.Getwd fails or the
-// two paths cannot be expressed relative to one another (different
-// volumes on Windows). Both are pre-conditions the engine has
-// already satisfied for every other rule before this point, so any
-// error here would already have blocked the lint at file discovery;
-// the fallback returns f.Path so the diagnostic still names a path.
+// (e.g. `--config sub/.mdsmith.yml` makes RootDir relative). The
+// `_ :=` discards mirror isSchemaFile's pattern above: filepath.Abs
+// only fails when os.Getwd fails, which the engine would already
+// have surfaced during file discovery.
 func workspaceRelPath(f *lint.File) string {
 	if f.RootDir == "" {
 		return filepath.ToSlash(f.Path)
 	}
-	absRoot, errRoot := filepath.Abs(f.RootDir)
-	absPath, errPath := filepath.Abs(f.Path)
-	if errRoot != nil || errPath != nil {
-		return filepath.ToSlash(f.Path)
-	}
+	absRoot, _ := filepath.Abs(f.RootDir)
+	absPath, _ := filepath.Abs(f.Path)
 	rel, err := filepath.Rel(absRoot, absPath)
 	if err != nil {
 		return filepath.ToSlash(f.Path)

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1317,16 +1317,23 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 // workspaceRelPath returns the file path relative to the workspace
 // root when RootDir is set, falling back to the file's own Path. The
 // returned path is slash-normalized so glob patterns written with
-// forward slashes match on every platform.
+// forward slashes match on every platform. Both RootDir and Path are
+// resolved through filepath.Abs first so the relative computation
+// works when the CLI was invoked with a relative `--config` path
+// (e.g. `--config sub/.mdsmith.yml` makes RootDir relative).
 func workspaceRelPath(f *lint.File) string {
 	if f.RootDir == "" {
 		return filepath.ToSlash(f.Path)
 	}
-	abs, err := filepath.Abs(f.Path)
+	absRoot, err := filepath.Abs(f.RootDir)
 	if err != nil {
 		return filepath.ToSlash(f.Path)
 	}
-	rel, err := filepath.Rel(f.RootDir, abs)
+	absPath, err := filepath.Abs(f.Path)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
 	if err != nil {
 		return filepath.ToSlash(f.Path)
 	}

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -956,6 +956,8 @@ func TestApplySettings_PathPatternsRejectsBadShape(t *testing.T) {
 		{"missing kind", []any{map[string]any{"pattern": "plan/*.md"}}},
 		{"empty kind", []any{map[string]any{"kind": "", "pattern": "x"}}},
 		{"empty pattern", []any{map[string]any{"kind": "x", "pattern": ""}}},
+		{"malformed glob",
+			[]any{map[string]any{"kind": "x", "pattern": "[unclosed"}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -819,6 +819,20 @@ func TestCheck_PathPattern_RelativeRootDir(t *testing.T) {
 	expectDiags(t, diags, 0)
 }
 
+// TestCheck_PathPattern_EmptyRootDirFallsBackToPath covers the
+// `f.RootDir == ""` branch of workspaceRelPath: with no workspace
+// root configured, the glob compares against f.Path verbatim.
+func TestCheck_PathPattern_EmptyRootDirFallsBackToPath(t *testing.T) {
+	f, err := lint.NewFileFromSource(
+		"plan/140_x.md", []byte("# x\n"), true)
+	require.NoError(t, err)
+	r := &Rule{PathPatterns: []PathPattern{
+		{Kind: "plan", Pattern: "plan/[0-9][0-9]*_*.md"},
+	}}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
 func TestCheck_PathPattern_NoPatternsIsNoOp(t *testing.T) {
 	root := t.TempDir()
 	f := newRootedFile(t, root, "anywhere/anything.md", "# Hi\n")

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -746,6 +746,138 @@ func TestCheck_FilenamePatternNotSet(t *testing.T) {
 }
 
 // =====================================================================
+// Kind-level path-pattern validation
+// =====================================================================
+
+// newRootedFile builds a *lint.File anchored at a workspace root so
+// path-pattern matching has a workspace-relative path to compare
+// against. The file is written under root/path so its absolute Path
+// resolves correctly through filepath.Rel inside the rule.
+func newRootedFile(t *testing.T, root, path, source string) *lint.File {
+	t.Helper()
+	abs := filepath.Join(root, path)
+	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+	require.NoError(t, os.WriteFile(abs, []byte(source), 0o644))
+	f, err := lint.NewFileFromSource(abs, []byte(source), true)
+	require.NoError(t, err)
+	f.SetRootDir(root)
+	return f
+}
+
+func TestCheck_PathPattern_Match(t *testing.T) {
+	root := t.TempDir()
+	f := newRootedFile(t, root, "plan/140_my-plan.md", "# My Plan\n")
+	r := &Rule{PathPatterns: []PathPattern{
+		{Kind: "plan", Pattern: "plan/[0-9][0-9]*_*.md"},
+	}}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestCheck_PathPattern_Mismatch(t *testing.T) {
+	root := t.TempDir()
+	f := newRootedFile(t, root, "plan/early-draft.md", "# Draft\n")
+	r := &Rule{PathPatterns: []PathPattern{
+		{Kind: "plan", Pattern: "plan/[0-9][0-9]*_*.md"},
+	}}
+	diags := r.Check(f)
+	expectDiags(t, diags, 1)
+	assert.Contains(t, diags[0].Message,
+		`filename: got "plan/early-draft.md"`)
+	assert.Contains(t, diags[0].Message,
+		`glob plan/[0-9][0-9]*_*.md`)
+	assert.Contains(t, diags[0].Message,
+		`schema: kinds[plan] / path-pattern`)
+	assert.Equal(t, "MDS020", diags[0].RuleID)
+	assert.Equal(t, "required-structure", diags[0].RuleName)
+	assert.Equal(t, 1, diags[0].Line)
+}
+
+func TestCheck_PathPattern_NoPatternsIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	f := newRootedFile(t, root, "anywhere/anything.md", "# Hi\n")
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestCheck_PathPattern_MultipleKindsBothFail(t *testing.T) {
+	root := t.TempDir()
+	f := newRootedFile(t, root, "docs/notes.md", "# Notes\n")
+	r := &Rule{PathPatterns: []PathPattern{
+		{Kind: "plan", Pattern: "plan/[0-9]*_*.md"},
+		{Kind: "rfc", Pattern: "docs/rfc/RFC-*.md"},
+	}}
+	diags := r.Check(f)
+	expectDiags(t, diags, 2)
+	expectDiagMsg(t, diags, "kinds[plan] / path-pattern")
+	expectDiagMsg(t, diags, "kinds[rfc] / path-pattern")
+}
+
+func TestCheck_PathPattern_PlusRequireFilenameBothEmit(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "proto.md"),
+		[]byte(`<?require
+filename: "[0-9]*_*.md"
+?>
+# ?
+`), 0o644))
+	f := newRootedFile(t, root, "plan/my-plan.md", "# My Plan\n")
+	r := &Rule{
+		Schema: "proto.md",
+		PathPatterns: []PathPattern{
+			{Kind: "plan", Pattern: "plan/[0-9][0-9]*_*.md"},
+		},
+	}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`filename "my-plan.md" does not match required pattern`)
+	expectDiagMsg(t, diags, "kinds[plan] / path-pattern")
+}
+
+func TestApplySettings_PathPatternsParsesList(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"path-patterns": []any{
+			map[string]any{"kind": "plan", "pattern": "plan/*.md"},
+			map[string]any{"kind": "rfc", "pattern": "docs/rfc/*.md"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.PathPatterns, 2)
+	assert.Equal(t, "plan", r.PathPatterns[0].Kind)
+	assert.Equal(t, "plan/*.md", r.PathPatterns[0].Pattern)
+	assert.Equal(t, "rfc", r.PathPatterns[1].Kind)
+}
+
+func TestApplySettings_PathPatternsRejectsBadShape(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"not a list", "plan/*.md"},
+		{"entry not a map", []any{"plan/*.md"}},
+		{"missing pattern", []any{map[string]any{"kind": "plan"}}},
+		{"missing kind", []any{map[string]any{"pattern": "plan/*.md"}}},
+		{"empty kind", []any{map[string]any{"kind": "", "pattern": "x"}}},
+		{"empty pattern", []any{map[string]any{"kind": "x", "pattern": ""}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (&Rule{}).ApplySettings(map[string]any{
+				"path-patterns": tc.v,
+			})
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestSettingMergeMode_PathPatternsIsAppend(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, rule.MergeAppend, r.SettingMergeMode("path-patterns"))
+}
+
+// =====================================================================
 // Schema file skipping
 // =====================================================================
 

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -793,6 +793,32 @@ func TestCheck_PathPattern_Mismatch(t *testing.T) {
 	assert.Equal(t, 1, diags[0].Line)
 }
 
+// TestCheck_PathPattern_RelativeRootDir verifies that a relative
+// f.RootDir (produced when the CLI is invoked with a relative
+// --config path like `--config sub/.mdsmith.yml`) still yields a
+// correct workspace-relative path for glob matching, instead of
+// failing filepath.Rel and falling back to f.Path.
+func TestCheck_PathPattern_RelativeRootDir(t *testing.T) {
+	root := t.TempDir()
+	abs := filepath.Join(root, "plan", "140_x.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+	require.NoError(t, os.WriteFile(abs, []byte("# x\n"), 0o644))
+	// Restore cwd after the test to keep parallel tests independent.
+	origCwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+	require.NoError(t, os.Chdir(root))
+
+	f, err := lint.NewFileFromSource(abs, []byte("# x\n"), true)
+	require.NoError(t, err)
+	f.RootDir = "." // intentionally relative
+	r := &Rule{PathPatterns: []PathPattern{
+		{Kind: "plan", Pattern: "plan/[0-9][0-9]*_*.md"},
+	}}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
 func TestCheck_PathPattern_NoPatternsIsNoOp(t *testing.T) {
 	root := t.TempDir()
 	f := newRootedFile(t, root, "anywhere/anything.md", "# Hi\n")

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -793,27 +793,82 @@ func TestCheck_PathPattern_Mismatch(t *testing.T) {
 	assert.Equal(t, 1, diags[0].Line)
 }
 
-// TestCheck_PathPattern_RelativeRootDir verifies that a relative
-// f.RootDir (produced when the CLI is invoked with a relative
-// --config path like `--config sub/.mdsmith.yml`) still yields a
-// correct workspace-relative path for glob matching, instead of
-// failing filepath.Rel and falling back to f.Path.
-func TestCheck_PathPattern_RelativeRootDir(t *testing.T) {
-	root := t.TempDir()
-	abs := filepath.Join(root, "plan", "140_x.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
-	require.NoError(t, os.WriteFile(abs, []byte("# x\n"), 0o644))
-	// Restore cwd after the test to keep parallel tests independent.
-	origCwd, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chdir(origCwd) })
-	require.NoError(t, os.Chdir(root))
+// TestWorkspaceRelPath_RelativeRootDirResolvesViaAbs verifies that
+// workspaceRelPath handles a relative f.RootDir (produced when the
+// CLI is invoked with `--config sub/.mdsmith.yml`) by resolving
+// both sides through filepath.Abs first. Without this, filepath.Rel
+// would fail and the function would fall back to f.Path, producing
+// false MDS020 path-pattern mismatches. The test asserts the
+// returned relative path directly so it does not depend on the
+// process working directory.
+func TestWorkspaceRelPath_RelativeRootDirResolvesViaAbs(t *testing.T) {
+	cases := []struct {
+		name    string
+		rootDir string
+		path    string
+		want    string
+	}{
+		{
+			name:    "both relative",
+			rootDir: ".",
+			path:    "plan/140_x.md",
+			want:    "plan/140_x.md",
+		},
+		{
+			name:    "relative root, absolute file",
+			rootDir: ".",
+			path:    filepath.Join(mustAbs(t, "."), "plan", "140_x.md"),
+			want:    "plan/140_x.md",
+		},
+		{
+			name:    "empty root falls back to path",
+			rootDir: "",
+			path:    "plan/early-draft.md",
+			want:    "plan/early-draft.md",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &lint.File{Path: tc.path, RootDir: tc.rootDir}
+			assert.Equal(t, tc.want, workspaceRelPath(f))
+		})
+	}
+}
 
-	f, err := lint.NewFileFromSource(abs, []byte("# x\n"), true)
+// mustAbs is a tiny helper for tests that need a known-absolute
+// path without inlining error handling.
+func mustAbs(t *testing.T, p string) string {
+	t.Helper()
+	abs, err := filepath.Abs(p)
 	require.NoError(t, err)
-	f.RootDir = "." // intentionally relative
+	return abs
+}
+
+// TestCheck_PathPattern_RootAnchoredNotBasenameOnly verifies that
+// a root-anchored pattern like `README.md` is matched against the
+// full workspace-relative path, not its basename. Without this,
+// `docs/README.md` would pass `path-pattern: README.md`, defeating
+// the documented "workspace-relative path must match" semantics.
+func TestCheck_PathPattern_RootAnchoredNotBasenameOnly(t *testing.T) {
+	root := t.TempDir()
+	f := newRootedFile(t, root, "docs/README.md", "# Docs\n")
 	r := &Rule{PathPatterns: []PathPattern{
-		{Kind: "plan", Pattern: "plan/[0-9][0-9]*_*.md"},
+		{Kind: "readme", Pattern: "README.md"},
+	}}
+	diags := r.Check(f)
+	expectDiags(t, diags, 1)
+	assert.Contains(t, diags[0].Message, `got "docs/README.md"`)
+}
+
+// TestCheck_PathPattern_DoublestarWildcardMatchesNested verifies
+// the doublestar-specific `**` wildcard works against the full
+// workspace-relative path so a pattern like `**/README.md` still
+// matches a nested file.
+func TestCheck_PathPattern_DoublestarWildcardMatchesNested(t *testing.T) {
+	root := t.TempDir()
+	f := newRootedFile(t, root, "docs/sub/README.md", "# Sub\n")
+	r := &Rule{PathPatterns: []PathPattern{
+		{Kind: "readme", Pattern: "**/README.md"},
 	}}
 	diags := r.Check(f)
 	expectDiags(t, diags, 0)

--- a/plan/140_kind-path-pattern.md
+++ b/plan/140_kind-path-pattern.md
@@ -1,7 +1,7 @@
 ---
 id: 140
 title: "Per-kind `path-pattern` for filename validation"
-status: "🔲"
+status: "🔳"
 model: sonnet
 depends-on: [147]
 summary: >-
@@ -169,22 +169,22 @@ command.
 
 ## Acceptance Criteria
 
-- [ ] A kind with `path-pattern:` validates
+- [x] A kind with `path-pattern:` validates
       the workspace-relative path of every
       file assigned to that kind.
-- [ ] A path mismatch produces an MDS020
+- [x] A path mismatch produces an MDS020
       diagnostic in the plan 147 shape with
       `field: filename`.
-- [ ] A kind with both `path-pattern:` and a
+- [x] A kind with both `path-pattern:` and a
       schema `<?require filename:?>` emits
       one diagnostic per failing constraint.
-- [ ] Kinds without `path-pattern:` retain
+- [x] Kinds without `path-pattern:` retain
       current behavior (regression test).
-- [ ] `mdsmith kinds show <name>` shows
+- [x] `mdsmith kinds show <name>` shows
       `path-pattern:` when set.
-- [ ] [`docs/guides/file-kinds.md`](../docs/guides/file-kinds.md)
+- [x] [`docs/guides/file-kinds.md`](../docs/guides/file-kinds.md)
       documents the new field with one worked
       example.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues.

--- a/plan/140_kind-path-pattern.md
+++ b/plan/140_kind-path-pattern.md
@@ -1,7 +1,7 @@
 ---
 id: 140
 title: "Per-kind `path-pattern` for filename validation"
-status: "🔳"
+status: "✅"
 model: sonnet
 depends-on: [147]
 summary: >-


### PR DESCRIPTION
A kind can now declare `path-pattern:` next to its schema and rule
overrides; every file assigned to the kind must have a workspace-
relative path matching the glob, otherwise MDS020 fires with the
new actionable shape. Replaces hand-rolled CI scripts that enforce
plan-ID, RFC numbering, or runbook-slug conventions, and surfaces
the constraint in `mdsmith kinds show <name>`. Composes with
`<?require filename:?>` — both run, each emits its own diagnostic.

https://claude.ai/code/session_01QzmyKr4usEEyBtYzuSXh8H