### PR TITLE
Simplify and clarify README feature descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,70 +13,61 @@ cross-file integrity. Written in Go.
 
 ## ✨ Why mdsmith
 
-**🔧 Stop hand-formatting Markdown.**
-Whitespace, heading style, code fences, bare URLs, list
-indentation, table alignment — `mdsmith fix` handles them
-in place. Multi-pass fixing resolves cascading changes so
-you don't run it twice. `mdsmith check` is the read-only
-sibling for CI.
+**🔧 Auto-fix Markdown formatting.**
+`mdsmith fix` rewrites whitespace, headings, code fences,
+bare URLs, list indentation, and table alignment in place;
+multi-pass resolves cascading edits. `mdsmith check` is
+the read-only CI sibling.
 
-**✏️ See lint errors live in your editor.**
-The [VS Code extension][vsc-mp] runs `mdsmith lsp` and
-shows inline squiggles, per-rule quick fixes, and an
-opt-in `source.fixAll.mdsmith` action for fix-on-save
-(set `mdsmith.fixOnSave: true` to enable). Also on
-[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
-Gitpod. Any LSP-aware editor — Neovim, Helix, JetBrains —
-works the same way by pointing at `mdsmith lsp`.
+**✏️ Live diagnostics in every editor.**
+`mdsmith lsp` powers the [VS Code extension][vsc-mp]
+(quick-fixes plus opt-in fix-on-save), [Open VSX][vsc-ovsx]
+for Cursor, VSCodium, Theia, Gitpod, and any LSP client
+(Neovim, Helix, JetBrains). The
+[Claude Code plugin](docs/guides/install.md) adds the same
+diagnostics inside Claude Code, plus definition,
+references, symbol search, and call-hierarchy across docs.
 
-**🔗 Catch broken links before they merge.**
-Refactors silently break Markdown links and anchors.
+**🔗 Cross-file integrity.**
 [`cross-file-reference-integrity`](internal/rules/MDS027-cross-file-reference-integrity/README.md)
-flags every missing file and missing heading anchor in PR
-review. Pair it with
+flags broken links and missing anchors,
 [`required-structure`](internal/rules/MDS020-required-structure/README.md)
-to enforce that each file has the sections it should
-(reusable schemas live in your repo and are referenced by
-path or named via `kinds:`), and
+enforces sections per file via inline schemas or `kinds:`,
+and
 [`directory-structure`](internal/rules/MDS033-directory-structure/README.md)
-to keep Markdown in the folders it belongs.
+keeps Markdown in the folders it belongs.
 
-**🤖 Stop AI from bloating your docs.**
-LLMs produce walls of text. Cap file length with
+**🤖 Guardrails for AI-generated docs.**
+Cap size with
 [`max-file-length`](internal/rules/MDS022-max-file-length/README.md),
-section length with
 [`max-section-length`](internal/rules/MDS036-max-section-length/README.md),
-and tokens with
-[`token-budget`](internal/rules/MDS028-token-budget/README.md).
+and
+[`token-budget`](internal/rules/MDS028-token-budget/README.md);
+hold reading-grade and sentence count with
 [`paragraph-readability`](internal/rules/MDS023-paragraph-readability/README.md)
 and
-[`paragraph-structure`](internal/rules/MDS024-paragraph-structure/README.md)
-hold reading-grade and sentence count in line.
-[`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md)
-flags verbatim repetition across files.
+[`paragraph-structure`](internal/rules/MDS024-paragraph-structure/README.md);
+catch copy-paste with
+[`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md).
 
-**📋 Make tables of contents and indexes maintain themselves.**
-Embed `<?toc?>` for a heading list,
-`<?catalog?>` for a table built from front matter,
-or `<?include?>` to splice in another file. `mdsmith fix`
-regenerates them in place. After a merge conflict in one
-of these blocks, `merge-driver install` registers a Git
-driver that resolves it automatically.
+**📋 Self-maintaining sections.**
+`<?toc?>`, `<?catalog?>`, and `<?include?>` blocks
+regenerate on `mdsmith fix`. `merge-driver install`
+registers a Git driver that resolves merge conflicts
+inside them automatically.
 
 **📊 Gate releases on doc status.**
-`mdsmith list query 'status: "✅"' plan/` lists every plan
-that's done — pipe it to a release script, or fail the
-release if anything is still open.
-`mdsmith metrics rank --by token-estimate --top 10 docs/` is the
-PR-time complement: spot the file an AI just doubled in
-size before it lands.
+`mdsmith list query 'status: "✅"' plan/` lists finished
+plans for a release script;
+`mdsmith metrics rank --by token-estimate --top 10 docs/`
+spots the file an AI just doubled in size.
 
-**📖 Make rule docs readable by AI agents (and humans).**
-`mdsmith help rule [name]` prints the full rule spec —
-settings, examples, diagnostics — straight from the
-binary. No network calls. Drop the output into
-`.cursor/rules`, `AGENTS.md`, or `CLAUDE.md` and your
-agent knows the rules without an extra fetch.
+**📖 Rule docs your agent can read.**
+`mdsmith help rule [name]` prints settings, examples, and
+diagnostics straight from the binary — no network. Drop
+the output into `.cursor/rules`, `AGENTS.md`, or
+`CLAUDE.md` so your agent knows the rules without an extra
+fetch.
 
 **🆚 How does it compare?** See:
 <?catalog

--- a/README.md
+++ b/README.md
@@ -15,59 +15,63 @@ cross-file integrity. Written in Go.
 
 **🔧 Auto-fix Markdown formatting.**
 `mdsmith fix` rewrites whitespace, headings, code fences,
-bare URLs, list indentation, and table alignment in place;
-multi-pass resolves cascading edits. `mdsmith check` is
-the read-only CI sibling.
+bare URLs, list indentation, and table alignment in place,
+re-running until edits settle. `mdsmith check` is the
+read-only CI sibling.
 
-**✏️ Live diagnostics in every editor.**
+**✏️ Live diagnostics wherever you write.**
 `mdsmith lsp` powers the [VS Code extension][vsc-mp]
-(quick-fixes plus opt-in fix-on-save), [Open VSX][vsc-ovsx]
-for Cursor, VSCodium, Theia, Gitpod, and any LSP client
-(Neovim, Helix, JetBrains). The
-[Claude Code plugin](docs/guides/install.md) adds the same
-diagnostics inside Claude Code, plus definition,
-references, symbol search, and call-hierarchy across docs.
+(quick-fixes plus opt-in fix-on-save),
+[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
+Gitpod, and any LSP client (Neovim, Helix, JetBrains).
+The [Claude Code plugin](docs/guides/install.md) loads the
+same server so agents editing Markdown inside Claude Code
+see mdsmith diagnostics and link navigation inline.
 
 **🔗 Cross-file integrity.**
-[`cross-file-reference-integrity`](internal/rules/MDS027-cross-file-reference-integrity/README.md)
-flags broken links and missing anchors,
-[`required-structure`](internal/rules/MDS020-required-structure/README.md)
-enforces sections per file via inline schemas or `kinds:`,
-and
-[`directory-structure`](internal/rules/MDS033-directory-structure/README.md)
-keeps Markdown in the folders it belongs.
+Built-in rules flag broken links and missing anchors
+([`MDS027`](internal/rules/MDS027-cross-file-reference-integrity/README.md)),
+enforce per-file section schemas
+([`MDS020`](internal/rules/MDS020-required-structure/README.md)),
+and keep Markdown in the right folders
+([`MDS033`](internal/rules/MDS033-directory-structure/README.md)).
+Schemas can be inline on a
+[file kind](docs/guides/file-kinds.md) or shared via proto
+files.
 
 **🤖 Guardrails for AI-generated docs.**
-Cap size with
-[`max-file-length`](internal/rules/MDS022-max-file-length/README.md),
-[`max-section-length`](internal/rules/MDS036-max-section-length/README.md),
+Cap [file](internal/rules/MDS022-max-file-length/README.md),
+[section](internal/rules/MDS036-max-section-length/README.md),
 and
-[`token-budget`](internal/rules/MDS028-token-budget/README.md);
-hold reading-grade and sentence count with
-[`paragraph-readability`](internal/rules/MDS023-paragraph-readability/README.md)
-and
-[`paragraph-structure`](internal/rules/MDS024-paragraph-structure/README.md);
-catch copy-paste with
-[`duplicated-content`](internal/rules/MDS037-duplicated-content/README.md).
+[token-budget](internal/rules/MDS028-token-budget/README.md)
+size; enforce
+[reading grade and sentence count](internal/rules/MDS023-paragraph-readability/README.md);
+flag
+[verbatim copy-paste](internal/rules/MDS037-duplicated-content/README.md)
+across files.
 
 **📋 Self-maintaining sections.**
-`<?toc?>`, `<?catalog?>`, and `<?include?>` blocks
-regenerate on `mdsmith fix`. `merge-driver install`
-registers a Git driver that resolves merge conflicts
-inside them automatically.
+On `mdsmith fix`, `<?toc?>` rebuilds a heading
+table-of-contents, `<?catalog?>` assembles a table from
+matching files' front matter, and `<?include?>` splices in
+another file. `merge-driver install` registers a Git
+driver that auto-resolves merge conflicts inside those
+blocks.
 
 **📊 Gate releases on doc status.**
-`mdsmith list query 'status: "✅"' plan/` lists finished
-plans for a release script;
+`mdsmith list query 'status: "✅"' plan/` selects files by
+a [CUE expression](docs/reference/cli/query.md) on front
+matter;
 `mdsmith metrics rank --by token-estimate --top 10 docs/`
-spots the file an AI just doubled in size.
+ranks files by any shared metric — both ready to pipe into
+a release script.
 
 **📖 Rule docs your agent can read.**
 `mdsmith help rule [name]` prints settings, examples, and
 diagnostics straight from the binary — no network. Drop
 the output into `.cursor/rules`, `AGENTS.md`, or
-`CLAUDE.md` so your agent knows the rules without an extra
-fetch.
+`CLAUDE.md` and your agent knows the rules without an
+extra fetch.
 
 **🆚 How does it compare?** See:
 <?catalog

--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ cross-file integrity. Written in Go.
 **🔧 Auto-fix Markdown formatting.**
 `mdsmith fix` rewrites whitespace, headings, code fences,
 bare URLs, list indentation, and table alignment in place,
-re-running up to 10 passes until edits stabilize.
-`mdsmith check` is the read-only CI sibling.
+re-running up to 10 passes and stopping early once edits
+stabilize. `mdsmith check` is the read-only CI sibling.
 
 **✏️ Live diagnostics wherever you write.**
 `mdsmith lsp` emits diagnostics, quick-fixes, and
 navigation (definition, references, symbol search, and a
-call-hierarchy over `<?include?>`/`<?catalog?>` and links).
+call-hierarchy over `<?include?>`/`<?catalog?>` and
+cross-file links).
 The [VS Code extension][vsc-mp] surfaces all of it with
 opt-in fix-on-save (also on [Open VSX][vsc-ovsx] for
-Cursor, VSCodium, Theia, and Gitpod); generic LSP clients
+Cursor, VSCodium, Theia, and Gitpod). Generic LSP clients
 (Neovim, Helix, JetBrains) expose what they support. The
 [Claude Code plugin](docs/guides/install.md#claude-code-plugin)
 feeds diagnostics and navigation to the agent so it sees

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ cross-file integrity. Written in Go.
 **🔧 Auto-fix Markdown formatting.**
 `mdsmith fix` rewrites whitespace, headings, code fences,
 bare URLs, list indentation, and table alignment in place,
-re-running until edits settle. `mdsmith check` is the
-read-only CI sibling.
+re-running up to 10 passes until edits stabilize.
+`mdsmith check` is the read-only CI sibling.
 
 **✏️ Live diagnostics wherever you write.**
 `mdsmith lsp` emits diagnostics, quick-fixes, and
-navigation (definition, references, symbol search,
-call-hierarchy). The [VS Code extension][vsc-mp] surfaces
-all of it with opt-in fix-on-save (also on
-[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
-Gitpod); generic LSP clients (Neovim, Helix, JetBrains)
-expose what they support. The
-[Claude Code plugin](docs/guides/install.md) feeds
-diagnostics and navigation to the agent so it sees mdsmith
-inline while editing Markdown.
+navigation (definition, references, symbol search, and a
+call-hierarchy over `<?include?>`/`<?catalog?>` and links).
+The [VS Code extension][vsc-mp] surfaces all of it with
+opt-in fix-on-save (also on [Open VSX][vsc-ovsx] for
+Cursor, VSCodium, Theia, and Gitpod); generic LSP clients
+(Neovim, Helix, JetBrains) expose what they support. The
+[Claude Code plugin](docs/guides/install.md#claude-code-plugin)
+feeds diagnostics and navigation to the agent so it sees
+mdsmith inline while editing Markdown.
 
 **🔗 Cross-file integrity.**
 Built-in rules flag broken links and missing anchors

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ re-running until edits settle. `mdsmith check` is the
 read-only CI sibling.
 
 **✏️ Live diagnostics wherever you write.**
-`mdsmith lsp` powers the [VS Code extension][vsc-mp]
-(quick-fixes plus opt-in fix-on-save),
-[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
-Gitpod, and any LSP client (Neovim, Helix, JetBrains).
-The [Claude Code plugin](docs/guides/install.md) loads the
-same server so agents editing Markdown inside Claude Code
-see mdsmith diagnostics and link navigation inline.
+`mdsmith lsp` is one server. It powers the
+[VS Code extension][vsc-mp] (also on
+[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, Gitpod),
+any LSP client (Neovim, Helix, JetBrains), and the
+[Claude Code plugin](docs/guides/install.md). Same
+diagnostics, quick-fixes, fix-on-save, and link navigation
+whether you edit in an IDE or with an agent.
 
 **🔗 Cross-file integrity.**
 Built-in rules flag broken links and missing anchors
@@ -52,9 +52,9 @@ across files.
 
 **📋 Self-maintaining sections.**
 On `mdsmith fix`, `<?toc?>` rebuilds a heading
-table-of-contents, `<?catalog?>` assembles a table from
-matching files' front matter, and `<?include?>` splices in
-another file. `merge-driver install` registers a Git
+table-of-contents, `<?catalog?>` builds a table from the
+front matter of files matching a glob, and `<?include?>`
+splices in another file. `merge-driver install` registers a Git
 driver that auto-resolves merge conflicts inside those
 blocks.
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ across files.
 
 **📋 Self-maintaining sections.**
 On `mdsmith fix`, `<?toc?>` rebuilds a heading
-table-of-contents, `<?catalog?>` builds a table from the
-front matter of files matching a glob, and `<?include?>`
-splices in another file. `merge-driver install` registers a Git
+table-of-contents, `<?catalog?>` generates an
+index — list, table, or any row template — from the front
+matter of files matching a glob, and `<?include?>` splices
+in another file. `merge-driver install` registers a Git
 driver that auto-resolves merge conflicts inside those
 blocks.
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ re-running until edits settle. `mdsmith check` is the
 read-only CI sibling.
 
 **✏️ Live diagnostics wherever you write.**
-`mdsmith lsp` is one server. It powers the
-[VS Code extension][vsc-mp] (also on
-[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, Gitpod),
-any LSP client (Neovim, Helix, JetBrains), and the
-[Claude Code plugin](docs/guides/install.md). Same
-diagnostics, quick-fixes, fix-on-save, and link navigation
-whether you edit in an IDE or with an agent.
+`mdsmith lsp` emits diagnostics, quick-fixes, and
+navigation (definition, references, symbol search,
+call-hierarchy). The [VS Code extension][vsc-mp] surfaces
+all of it with opt-in fix-on-save (also on
+[Open VSX][vsc-ovsx] for Cursor, VSCodium, Theia, and
+Gitpod); generic LSP clients (Neovim, Helix, JetBrains)
+expose what they support. The
+[Claude Code plugin](docs/guides/install.md) feeds
+diagnostics and navigation to the agent so it sees mdsmith
+inline while editing Markdown.
 
 **🔗 Cross-file integrity.**
 Built-in rules flag broken links and missing anchors
@@ -45,7 +48,9 @@ Cap [file](internal/rules/MDS022-max-file-length/README.md),
 and
 [token-budget](internal/rules/MDS028-token-budget/README.md)
 size; enforce
-[reading grade and sentence count](internal/rules/MDS023-paragraph-readability/README.md);
+[reading grade](internal/rules/MDS023-paragraph-readability/README.md)
+and
+[sentence count](internal/rules/MDS024-paragraph-structure/README.md);
 flag
 [verbatim copy-paste](internal/rules/MDS037-duplicated-content/README.md)
 across files.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ On `mdsmith fix`, `<?toc?>` rebuilds a heading
 table-of-contents, `<?catalog?>` generates an
 index — list, table, or any row template — from the front
 matter of files matching a glob, and `<?include?>` splices
-in another file. `merge-driver install` registers a Git
-driver that auto-resolves merge conflicts inside those
-blocks.
+in another file. `mdsmith merge-driver install` registers
+a Git driver that auto-resolves merge conflicts inside
+those blocks.
 
 **📊 Gate releases on doc status.**
 `mdsmith list query 'status: "✅"' plan/` selects files by

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ enforce per-file section schemas
 and keep Markdown in the right folders
 ([`MDS033`](internal/rules/MDS033-directory-structure/README.md)).
 Schemas can be inline on a
-[file kind](docs/guides/file-kinds.md) or shared via proto
-files.
+[file kind](docs/guides/file-kinds.md) or shared via
+`proto.md` files.
 
 **🤖 Guardrails for AI-generated docs.**
 Cap [file](internal/rules/MDS022-max-file-length/README.md),

--- a/README.md
+++ b/README.md
@@ -73,13 +73,6 @@ matter;
 ranks files by any shared metric — both ready to pipe into
 a release script.
 
-**📖 Rule docs your agent can read.**
-`mdsmith help rule [name]` prints settings, examples, and
-diagnostics straight from the binary — no network. Drop
-the output into `.cursor/rules`, `AGENTS.md`, or
-`CLAUDE.md` and your agent knows the rules without an
-extra fetch.
-
 **🆚 How does it compare?** See:
 <?catalog
 glob:


### PR DESCRIPTION
Streamline the "Why mdsmith" section of the README to make feature descriptions more concise and direct, while improving clarity for both human readers and AI agents.

## Summary

Rewrote the feature bullets in the README to be shorter, more scannable, and more concrete. Each bullet now leads with the core benefit and uses simpler language. The Claude Code plugin is now surfaced alongside the other LSP clients.

## Key changes

- **Auto-fix Markdown formatting**: Shortened explanation of `mdsmith fix` and `mdsmith check`; documents the 10-pass cap with early exit.
- **Live diagnostics**: Consolidated editor integration details; added Claude Code plugin alongside VS Code, Open VSX, and generic LSP clients. Server-side capabilities (diagnostics, quick-fixes, navigation incl. cross-file call-hierarchy) are named once on the server; each client surface lists what it exposes.
- **Cross-file integrity**: Reorganized to emphasize the three built-in rules (MDS027, MDS020, MDS033) and schema flexibility (inline kind or `proto.md` files).
- **Guardrails for AI-generated docs**: Restructured to list specific rules by their capabilities (file/section/token limits, readability via MDS023, sentence count via MDS024, duplication via MDS037).
- **Self-maintaining sections**: Clarified the three directive types (`<?toc?>`, `<?catalog?>`, `<?include?>`) and `mdsmith merge-driver install`. Catalog is described as generating an index from any row template, not just tables.
- **Gate releases on doc status**: Added reference to CUE query syntax; clarified that `mdsmith metrics rank` works with any shared metric.

**Removed**: The previous "Rule docs your agent can read" bullet about `mdsmith help rule` was dropped — LSP diagnostics and `mdsmith check` already carry rule id and message to the agent, so a separate bullet about pasting `help rule` output into `.cursor/rules`/`AGENTS.md`/`CLAUDE.md` was redundant (and the manual-paste workflow isn't how those files are actually consumed).

All changes maintain the feature set readers actually need to discover while reducing verbosity and improving scannability for both human readers and AI agents that may consume this documentation.

https://claude.ai/code/session_01MiX3q2wdUPWzFpi632yU8F