### PR TITLE
docs: clarify LSP client support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ stabilize. `mdsmith check` is the read-only CI sibling.
 `mdsmith lsp` emits diagnostics, quick-fixes, and
 navigation (definition, references, symbol search, and a
 call-hierarchy over `<?include?>`/`<?catalog?>` and
-cross-file links).
+cross-file links) — consumed by any LSP-aware editor,
+including Neovim, Helix, and JetBrains.
 The [VS Code extension][vsc-mp] surfaces all of it with
 opt-in fix-on-save (also on [Open VSX][vsc-ovsx] for
-Cursor, VSCodium, Theia, and Gitpod). Generic LSP clients
-(Neovim, Helix, JetBrains) expose what they support. The
+Cursor, VSCodium, Theia, and Gitpod). The
 [Claude Code plugin](docs/guides/install.md#claude-code-plugin)
 feeds diagnostics and navigation to the agent so it sees
 mdsmith inline while editing Markdown.


### PR DESCRIPTION
## Summary

Updated the README to clarify which LSP clients are supported by mdsmith and how they consume the LSP server's capabilities.

## Changes

- Moved mention of generic LSP clients (Neovim, Helix, JetBrains) from a separate sentence into the main description of `mdsmith lsp` output, making it clear that these editors consume the LSP diagnostics and navigation features
- Removed redundant text about generic LSP clients exposing "what they support" since this is implicit in how LSP works
- Simplified the flow by consolidating information about editor support into a more cohesive narrative

## Details

The change improves clarity by:
1. Establishing upfront that the LSP server output is consumed by any LSP-aware editor, with specific examples
2. Distinguishing between the VS Code extension (which has opt-in fix-on-save) and generic LSP clients (which expose native LSP capabilities)
3. Reducing redundancy while maintaining all key information about supported editors

https://claude.ai/code/session_01MiX3q2wdUPWzFpi632yU8F