### PR TITLE
Accept `..` globs within project root in catalog directive

### DIFF
--- a/.claude/skills/solid-architecture/SKILL.md
+++ b/.claude/skills/solid-architecture/SKILL.md
@@ -156,3 +156,25 @@ source.
   the doc section that justifies it.
   Vague "this would be cleaner"
   guidance is not actionable.
+
+## Architecture doc references
+
+The link definitions below resolve the
+slug labels used throughout this skill
+(e.g. `[hub]`, `[go]`, `[ts]`). The
+`<?catalog?>` directive regenerates the
+block from each canonical doc's `slug`
+front-matter field — never hand-edit
+the entries.
+
+<?catalog
+glob: "../../../docs/development/architecture/*.md"
+sort: slug
+row: "[{slug}]: {filename}"
+?>
+[audit]: ../../../docs/development/architecture/audit-checklist.md
+[cross]: ../../../docs/development/architecture/cross-system.md
+[go]: ../../../docs/development/architecture/go.md
+[hub]: ../../../docs/development/architecture/index.md
+[ts]: ../../../docs/development/architecture/typescript.md
+<?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -62,7 +62,7 @@ footer: |
 | 149 | 🔲     | opus   | [Section content schema for non-heading AST nodes](plan/149_section-content-schema.md)                                    |
 | 151 | ✅     | opus   | [LSP rename for headings and link-reference labels](plan/151_lsp-rename.md)                                               |
 | 152 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/152_claude-code-skills-agents-hooks.md)                      |
-| 153 | 🔲     | sonnet | [Catalog directive — accept `..` globs within project root](plan/153_catalog-dotdot-globs.md)                             |
+| 153 | ✅     | sonnet | [Catalog directive — accept `..` globs within project root](plan/153_catalog-dotdot-globs.md)                             |
 | 153 | 🔲     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
 | 154 | 🔲     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
 | 155 | 🔲     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -26,7 +26,7 @@ import (
 // path is also slash-separated and relative to the project root; it is
 // "" for the root itself.
 //
-// Callers use this to check that "..": segments in a path stay within the
+// Callers use this to check that ".." segments in a path stay within the
 // project root before resolving the path against a project-rooted fs.FS.
 func ResolveAgainstRoot(baseDir, p2 string) (resolved string, escapes bool) {
 	if baseDir == "" {

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -11,11 +11,47 @@
 package globpath
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
+
+// ResolveAgainstRoot resolves p against baseDir (both slash-separated and
+// relative to a project root) and reports whether the cleaned result
+// escapes the project root via ".." segments.
+//
+// baseDir == "" or "." is interpreted as the project root. The returned
+// path is also slash-separated and relative to the project root; it is
+// "" for the root itself.
+//
+// Callers use this to check that "..": segments in a path stay within the
+// project root before resolving the path against a project-rooted fs.FS.
+func ResolveAgainstRoot(baseDir, p2 string) (resolved string, escapes bool) {
+	if baseDir == "" {
+		baseDir = "."
+	}
+	cleaned := path.Clean(path.Join(baseDir, p2))
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return cleaned, true
+	}
+	if cleaned == "." {
+		cleaned = ""
+	}
+	return cleaned, false
+}
+
+// ContainsDotDotSegment reports whether p contains a ".." path element
+// when split on "/". Filenames like "..foo" do not match.
+func ContainsDotDotSegment(p string) bool {
+	for _, elem := range strings.Split(p, "/") {
+		if elem == ".." {
+			return true
+		}
+	}
+	return false
+}
 
 // Match reports whether path matches pattern using the doublestar matcher.
 // It checks the raw path, the cleaned path, and the base name so that

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -102,3 +102,55 @@ func TestSplitIncludeExclude_Empty(t *testing.T) {
 	assert.Nil(t, inc)
 	assert.Nil(t, exc)
 }
+
+func TestResolveAgainstRoot_StaysInside(t *testing.T) {
+	resolved, escapes := globpath.ResolveAgainstRoot("a/b/c", "../../d/*.md")
+	assert.False(t, escapes)
+	assert.Equal(t, "a/d/*.md", resolved)
+}
+
+func TestResolveAgainstRoot_EmptyBase(t *testing.T) {
+	resolved, escapes := globpath.ResolveAgainstRoot("", "docs/*.md")
+	assert.False(t, escapes)
+	assert.Equal(t, "docs/*.md", resolved)
+}
+
+func TestResolveAgainstRoot_DotBase(t *testing.T) {
+	resolved, escapes := globpath.ResolveAgainstRoot(".", "docs/*.md")
+	assert.False(t, escapes)
+	assert.Equal(t, "docs/*.md", resolved)
+}
+
+func TestResolveAgainstRoot_ResolvesToRoot(t *testing.T) {
+	resolved, escapes := globpath.ResolveAgainstRoot("a", "..")
+	assert.False(t, escapes)
+	assert.Equal(t, "", resolved)
+}
+
+func TestResolveAgainstRoot_Escapes(t *testing.T) {
+	resolved, escapes := globpath.ResolveAgainstRoot("a", "../../x.md")
+	assert.True(t, escapes)
+	assert.Equal(t, "../x.md", resolved)
+}
+
+func TestResolveAgainstRoot_EscapesToDotDot(t *testing.T) {
+	resolved, escapes := globpath.ResolveAgainstRoot("", "..")
+	assert.True(t, escapes)
+	assert.Equal(t, "..", resolved)
+}
+
+func TestContainsDotDotSegment(t *testing.T) {
+	cases := map[string]bool{
+		"../foo":     true,
+		"foo/../bar": true,
+		"foo/bar/..": true,
+		"":           false,
+		"foo..bar":   false,
+		"...":        false,
+		"..":         true,
+		"foo/bar":    false,
+	}
+	for input, want := range cases {
+		assert.Equal(t, want, globpath.ContainsDotDotSegment(input), input)
+	}
+}

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -284,16 +284,18 @@ func runGoodFolderFile(
 
 // attachFixtureFS scopes a fixture's lint.File to a directory on disk.
 // For rules that resolve cross-tree paths against a project root
-// (currently MDS019 catalog) it also pins RootFS to the same FS so the
-// rule can resolve ".." segments instead of erroring out. For all
-// other rules, RootFS is left nil to preserve their existing fixture
-// semantics — notably MDS020, whose schema reader switches resolution
-// strategy based on whether RootFS is set.
+// (currently MDS019 catalog) it also pins RootFS and RootDir to the
+// same directory so the rule can resolve ".." segments and anchor
+// gitignore lookups the way it does in a real workspace. For all
+// other rules, RootFS/RootDir are left nil to preserve their existing
+// fixture semantics — notably MDS020, whose schema reader switches
+// resolution strategy based on whether RootFS is set.
 func attachFixtureFS(f *lint.File, dir string, r rule.Rule) {
 	fsys := os.DirFS(dir)
 	f.FS = fsys
 	if r != nil && r.ID() == "MDS019" {
 		f.RootFS = fsys
+		f.RootDir = dir
 	}
 }
 

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -303,12 +303,21 @@ func attachFixtureFS(f *lint.File, dir string, r rule.Rule) {
 // fixture. For rules whose Check inspects git state (currently
 // MDS048), it returns a path inside a fresh non-repo tempdir so the
 // fixture cannot fail based on the contributor's local git config or
-// installed hooks. For all other rules it returns the basename so
-// existing tests are unaffected.
+// installed hooks. For rules that resolve paths against the project
+// root (currently MDS019), it returns the fixture's absolute path so
+// projectRelFileDir-style logic computes the same root-relative
+// directory it would for a real `mdsmith check <abs-path>` invocation.
+// For all other rules it returns the basename so existing tests are
+// unaffected.
 func fixtureFilePath(t *testing.T, r rule.Rule, filePath string) string {
 	t.Helper()
 	if r != nil && r.ID() == "MDS048" {
 		return filepath.Join(t.TempDir(), filepath.Base(filePath))
+	}
+	if r != nil && r.ID() == "MDS019" {
+		abs, err := filepath.Abs(filePath)
+		require.NoError(t, err)
+		return abs
 	}
 	return filepath.Base(filePath)
 }

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -285,7 +285,7 @@ func runGoodFolderFile(
 // attachFixtureFS scopes a fixture's lint.File to a directory on disk.
 // For rules that resolve cross-tree paths against a project root
 // (currently MDS019 catalog) it also pins RootFS to the same FS so the
-// rule can resolve "..": segments instead of erroring out. For all
+// rule can resolve ".." segments instead of erroring out. For all
 // other rules, RootFS is left nil to preserve their existing fixture
 // semantics — notably MDS020, whose schema reader switches resolution
 // strategy based on whether RootFS is set.

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -277,9 +277,24 @@ func runGoodFolderFile(
 
 	f, err := lint.NewFile(fixtureFilePath(t, r, filePath), content)
 	require.NoError(t, err, "parsing %s: %v", filepath.Base(filePath), err)
-	f.FS = os.DirFS(filepath.Dir(filePath))
+	attachFixtureFS(f, filepath.Dir(filePath), r)
 	diags := checkAllRules(f, r)
 	reportUnexpectedDiags(t, filepath.Base(filePath), diags)
+}
+
+// attachFixtureFS scopes a fixture's lint.File to a directory on disk.
+// For rules that resolve cross-tree paths against a project root
+// (currently MDS019 catalog) it also pins RootFS to the same FS so the
+// rule can resolve "..": segments instead of erroring out. For all
+// other rules, RootFS is left nil to preserve their existing fixture
+// semantics — notably MDS020, whose schema reader switches resolution
+// strategy based on whether RootFS is set.
+func attachFixtureFS(f *lint.File, dir string, r rule.Rule) {
+	fsys := os.DirFS(dir)
+	f.FS = fsys
+	if r != nil && r.ID() == "MDS019" {
+		f.RootFS = fsys
+	}
 }
 
 // fixtureFilePath returns the value to use as f.Path when running a
@@ -308,7 +323,7 @@ func runBadFolderFile(
 
 	f, err := lint.NewFile(fixtureFilePath(t, r, filePath), content)
 	require.NoError(t, err, "parsing %s: %v", filepath.Base(filePath), err)
-	f.FS = os.DirFS(filepath.Dir(filePath))
+	attachFixtureFS(f, filepath.Dir(filePath), r)
 	diags := filterByRule(r.Check(f), ruleID)
 	assertExpectedDiags(t, expected, diags, filepath.Base(filePath))
 }
@@ -339,7 +354,7 @@ func runFixFolderFile(
 	fPath := fixtureFilePath(t, r, fixedPath)
 	f, err := lint.NewFile(fPath, badContent)
 	require.NoError(t, err, "parsing %s: %v", filepath.Base(fixedPath), err)
-	f.FS = os.DirFS(filepath.Dir(fixedPath))
+	attachFixtureFS(f, filepath.Dir(fixedPath), r)
 
 	got := fr.Fix(f)
 
@@ -358,7 +373,7 @@ func runFixFolderFile(
 	// Verify that the fixed output produces no diagnostics.
 	fixedFile, err := lint.NewFile(fPath, want)
 	require.NoError(t, err, "parsing fixed output: %v", err)
-	fixedFile.FS = os.DirFS(filepath.Dir(fixedPath))
+	attachFixtureFS(fixedFile, filepath.Dir(fixedPath), r)
 	diags := checkAllRules(fixedFile, r)
 	reportUnexpectedDiags(t, filepath.Base(fixedPath), diags)
 }
@@ -370,7 +385,7 @@ func runGoodSingleFile(t *testing.T, dir string, r rule.Rule) {
 	src := readFixture(t, filepath.Join(dir, "good.md"))
 	f, err := lint.NewFile("good.md", src)
 	require.NoError(t, err, "parsing good.md: %v", err)
-	f.FS = os.DirFS(dir)
+	attachFixtureFS(f, dir, r)
 	diags := checkAllRules(f, r)
 	reportUnexpectedDiags(t, "good.md", diags)
 }
@@ -383,7 +398,7 @@ func runBadSingleFile(
 	_, expected, src := parseFixtureFrontMatter(t, raw, true)
 	f, err := lint.NewFile("bad.md", src)
 	require.NoError(t, err, "parsing bad.md: %v", err)
-	f.FS = os.DirFS(dir)
+	attachFixtureFS(f, dir, r)
 	diags := filterByRule(r.Check(f), ruleID)
 	assertExpectedDiags(t, expected, diags, "bad.md")
 }
@@ -404,7 +419,7 @@ func runFixSingleFile(
 	_, _, content := parseFixtureFrontMatter(t, badSrc, false)
 	f, err := lint.NewFile("bad.md", content)
 	require.NoError(t, err, "parsing bad.md: %v", err)
-	f.FS = os.DirFS(dir)
+	attachFixtureFS(f, dir, r)
 
 	got := fr.Fix(f)
 	fixedPath := filepath.Join(dir, "fixed.md")
@@ -419,7 +434,7 @@ func runFixSingleFile(
 
 	fixedFile, err := lint.NewFile("fixed.md", want)
 	require.NoError(t, err, "parsing fixed.md: %v", err)
-	fixedFile.FS = os.DirFS(dir)
+	attachFixtureFS(fixedFile, dir, r)
 	diags := checkAllRules(fixedFile, r)
 	reportUnexpectedDiags(t, "fixed.md", diags)
 }

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -40,6 +40,12 @@ project root is not configured`. This mirrors how
 [`<?include?>`](../MDS021-include/README.md) resolves its
 `file` parameter.
 
+A `..` segment inside a `{a,b}` brace alternative (e.g.
+`{..,sibling}/*.md`) is rejected at validation time —
+brace alternatives cannot be normalized before glob
+expansion, so a pattern that mixes `..` with braces is
+written as separate top-level patterns instead.
+
 Single pattern:
 
 ```yaml
@@ -191,13 +197,14 @@ glob: "data/*.md"
 | Empty `glob`   | `...has empty "glob"`        |
 | Absolute glob  | `...has absolute glob path`  |
 
-| Condition         | Message                                                    |
-|-------------------|------------------------------------------------------------|
-| Glob escapes root | `...glob escapes project root`                             |
-| `..` without root | `...glob contains ".." but project root is not configured` |
-| Invalid glob      | `...invalid glob pattern`                                  |
-| Empty sort        | `...empty "sort" value`                                    |
-| Invalid sort      | `...invalid sort value`                                    |
+| Condition          | Message                                                            |
+|--------------------|--------------------------------------------------------------------|
+| Glob escapes root  | `...glob escapes project root`                                     |
+| `..` without root  | `...glob contains ".." but project root is not configured`         |
+| `..` inside braces | `...has ".." inside brace expansion; rewrite as separate patterns` |
+| Invalid glob       | `...invalid glob pattern`                                          |
+| Empty sort         | `...empty "sort" value`                                            |
+| Invalid sort       | `...invalid sort value`                                            |
 
 All messages above are prefixed with
 `generated section directive`. Column is always 1.

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -191,13 +191,13 @@ glob: "data/*.md"
 | Empty `glob`   | `...has empty "glob"`        |
 | Absolute glob  | `...has absolute glob path`  |
 
-| Condition         | Message                                                 |
-|-------------------|---------------------------------------------------------|
-| Glob escapes root | `...glob escapes project root`                          |
-| `..` without root | `...glob contains ".." but project root not configured` |
-| Invalid glob      | `...invalid glob pattern`                               |
-| Empty sort        | `...empty "sort" value`                                 |
-| Invalid sort      | `...invalid sort value`                                 |
+| Condition         | Message                                                    |
+|-------------------|------------------------------------------------------------|
+| Glob escapes root | `...glob escapes project root`                             |
+| `..` without root | `...glob contains ".." but project root is not configured` |
+| Invalid glob      | `...invalid glob pattern`                                  |
+| Empty sort        | `...empty "sort" value`                                    |
+| Invalid sort      | `...invalid sort value`                                    |
 
 All messages above are prefixed with
 `generated section directive`. Column is always 1.

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -197,14 +197,15 @@ glob: "data/*.md"
 | Empty `glob`   | `...has empty "glob"`        |
 | Absolute glob  | `...has absolute glob path`  |
 
-| Condition          | Message                                                            |
-|--------------------|--------------------------------------------------------------------|
-| Glob escapes root  | `...glob escapes project root`                                     |
-| `..` without root  | `...glob contains ".." but project root is not configured`         |
-| `..` inside braces | `...has ".." inside brace expansion; rewrite as separate patterns` |
-| Invalid glob       | `...invalid glob pattern`                                          |
-| Empty sort         | `...empty "sort" value`                                            |
-| Invalid sort       | `...invalid sort value`                                            |
+| Condition          | Message                                                                  |
+|--------------------|--------------------------------------------------------------------------|
+| Glob escapes root  | `...glob escapes project root`                                           |
+| `..` without root  | `...glob contains ".." but project root is not configured`               |
+| File outside root  | `...catalog file is outside project root; ".." globs cannot be resolved` |
+| `..` inside braces | `...has ".." inside brace expansion; rewrite as separate patterns`       |
+| Invalid glob       | `...invalid glob pattern`                                                |
+| Empty sort         | `...empty "sort" value`                                                  |
+| Invalid sort       | `...invalid sort value`                                                  |
 
 All messages above are prefixed with
 `generated section directive`. Column is always 1.

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -28,8 +28,17 @@ otherwise.
 
 The `glob` accepts a single string or a YAML list of
 strings. It supports `*`, `?`, `[...]`, `**`, and `{a,b}`
-brace expansion. It does not allow absolute paths or `..`
-traversal.
+brace expansion.
+
+Absolute paths are rejected. `..` segments are allowed as
+long as the resolved pattern stays inside the project root;
+a pattern whose resolution leaves the root is rejected with
+`generated section directive glob escapes project root`. A
+`..` pattern without a configured project root is rejected
+with `generated section directive glob contains ".." but
+project root is not configured`. This mirrors how
+[`<?include?>`](../MDS021-include/README.md) resolves its
+`file` parameter.
 
 Single pattern:
 
@@ -182,12 +191,13 @@ glob: "data/*.md"
 | Empty `glob`   | `...has empty "glob"`        |
 | Absolute glob  | `...has absolute glob path`  |
 
-| Condition      | Message                   |
-|----------------|---------------------------|
-| Glob with `..` | `...".." path traversal`  |
-| Invalid glob   | `...invalid glob pattern` |
-| Empty sort     | `...empty "sort" value`   |
-| Invalid sort   | `...invalid sort value`   |
+| Condition         | Message                                                 |
+|-------------------|---------------------------------------------------------|
+| Glob escapes root | `...glob escapes project root`                          |
+| `..` without root | `...glob contains ".." but project root not configured` |
+| Invalid glob      | `...invalid glob pattern`                               |
+| Empty sort        | `...empty "sort" value`                                 |
+| Invalid sort      | `...invalid sort value`                                 |
 
 All messages above are prefixed with
 `generated section directive`. Column is always 1.
@@ -214,13 +224,15 @@ nested markers, YAML errors, template errors).
 | Binary file              | Included; no front matter |
 | Symlinks                 | Followed                  |
 
-| Scenario           | Behavior                       |
-|--------------------|--------------------------------|
-| Dotfiles           | Matched by `*`/`**`            |
-| Absolute/`..` glob | Diagnostic                     |
-| Brace expansion    | Supported                      |
-| Multi-glob list    | Union of matches, deduplicated |
-| Empty glob/sort    | Diagnostic                     |
+| Scenario          | Behavior                       |
+|-------------------|--------------------------------|
+| Dotfiles          | Matched by `*`/`**`            |
+| Absolute glob     | Diagnostic                     |
+| `..` inside root  | Resolved against project root  |
+| `..` escapes root | Diagnostic                     |
+| Brace expansion   | Supported                      |
+| Multi-glob list   | Union of matches, deduplicated |
+| Empty glob/sort   | Diagnostic                     |
 
 | Scenario             | Behavior         |
 |----------------------|------------------|

--- a/internal/rules/MDS019-catalog/bad/dotdot.md
+++ b/internal/rules/MDS019-catalog/bad/dotdot.md
@@ -1,0 +1,12 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: 'generated section directive glob escapes project root'
+---
+# Document Index
+
+<?catalog
+glob: "../outside/*.md"
+?>
+<?/catalog?>

--- a/internal/rules/MDS019-catalog/good/dotdot.md
+++ b/internal/rules/MDS019-catalog/good/dotdot.md
@@ -1,0 +1,13 @@
+# Document Index
+
+A `..` segment is allowed when the resolved pattern stays
+inside the project root, mirroring how `<?include?>`
+resolves its `file` parameter.
+
+<?catalog
+glob: "data/../data/*.md"
+row: "[{filename}]({filename})"
+?>
+[data/alpha.md](data/alpha.md)
+[data/beta.md](data/beta.md)
+<?/catalog?>

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -215,6 +215,13 @@ func validateGlob(filePath string, line int, params map[string]string) []lint.Di
 			return []lint.Diagnostic{makeDiag(filePath, line,
 				fmt.Sprintf("generated section directive has invalid glob pattern: %s", pattern))}
 		}
+		if containsDotDotInsideBraces(pattern) {
+			// path.Clean does not expand `{a,b}` alternatives, so a
+			// `..` segment inside braces would silently bypass the
+			// project-root containment check at resolve time.
+			return []lint.Diagnostic{makeDiag(filePath, line,
+				`generated section directive has ".." inside brace expansion; rewrite as separate patterns`)}
+		}
 		if !isExclude {
 			hasInclude = true
 		}
@@ -298,35 +305,40 @@ func resolveGlobFS(f *lint.File, params map[string]string, filePath string, line
 	}
 	if f.RootFS == nil {
 		if hasDotDot {
-			return globResolution{diags: []lint.Diagnostic{makeDiag(
-				filePath, line,
-				`generated section directive glob contains ".." but project root is not configured`)}}
+			return missingRootDiag(filePath, line)
 		}
 		return localFSResolution(f, includes, excludes)
 	}
-	return resolveAgainstProjectRoot(f, sourceDir, includes, excludes, filePath, line)
+	return resolveAgainstProjectRoot(f, sourceDir, hasDotDot, includes, excludes, filePath, line)
+}
+
+func missingRootDiag(filePath string, line int) globResolution {
+	return globResolution{diags: []lint.Diagnostic{makeDiag(
+		filePath, line,
+		`generated section directive glob contains ".." but project root is not configured`)}}
 }
 
 // resolveAgainstProjectRoot rewrites include/exclude patterns relative
-// to the project root using RootFS. Falls back to the file's fs.FS when
-// the source-dir is invalid or filepath.Rel cannot resolve fileDir.
+// to the project root using RootFS. When the source-dir is invalid or
+// fileDir cannot be related to the project root, it falls back to the
+// file's fs.FS — except for ".." patterns, which still need a project
+// root and surface the missing-root diagnostic instead of silently
+// matching nothing on a fs.FS that rejects "..".
 func resolveAgainstProjectRoot(
-	f *lint.File, sourceDir string,
+	f *lint.File, sourceDir string, hasDotDot bool,
 	includes, excludes []string,
 	filePath string, line int,
 ) globResolution {
-	fileDir := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
-	if fileDir == "." {
-		fileDir = ""
+	fileDir, ok := projectRelFileDir(f)
+	if !ok {
+		if hasDotDot {
+			return missingRootDiag(filePath, line)
+		}
+		return localFSResolution(f, includes, excludes)
 	}
 	baseRel, ok := resolveBaseRel(fileDir, sourceDir)
 	if !ok {
 		return localFSResolution(f, includes, excludes)
-	}
-	if fileDir != "" {
-		if _, err := filepath.Rel(fileDir, "."); err != nil {
-			return localFSResolution(f, includes, excludes)
-		}
 	}
 	resolvedIncludes, ok := resolvePatterns(baseRel, includes)
 	if !ok {
@@ -352,10 +364,82 @@ func resolveAgainstProjectRoot(
 	}
 }
 
+// projectRelFileDir returns the catalog-owning file's directory as a
+// slash-separated path relative to the project root, or ok=false when
+// no relation can be computed (e.g. an absolute file path with no
+// configured RootDir, or a file outside the configured root).
+//
+// Returns "" for the project root itself.
+func projectRelFileDir(f *lint.File) (string, bool) {
+	cleaned := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
+	if cleaned == "." {
+		return "", true
+	}
+	if !filepath.IsAbs(cleaned) {
+		return cleaned, true
+	}
+	if f.RootDir == "" {
+		return "", false
+	}
+	// filepath.Abs and filepath.Rel only error for inputs we don't
+	// hand them here (Abs needs Getwd; Rel needs mismatched abs/rel).
+	rootAbs, _ := filepath.Abs(f.RootDir)
+	rel, _ := filepath.Rel(rootAbs, filepath.Dir(f.Path))
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return "", true
+	}
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	return rel, true
+}
+
 func escapeDiag(filePath string, line int) globResolution {
 	return globResolution{diags: []lint.Diagnostic{makeDiag(
 		filePath, line,
 		"generated section directive glob escapes project root")}}
+}
+
+// containsDotDotInsideBraces reports whether p has a ".." segment inside
+// a `{a,b}` brace alternative. doublestar expands braces lazily during
+// matching, but path.Clean treats `{..,foo}` as a single opaque segment,
+// so such a `..` would slip past the project-root containment check.
+// Detecting it lets the validator reject the pattern up front instead of
+// silently producing partial matches.
+func containsDotDotInsideBraces(p string) bool {
+	depth := 0
+	for i := 0; i < len(p); i++ {
+		switch p[i] {
+		case '{':
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		case '.':
+			if depth == 0 || i+1 >= len(p) || p[i+1] != '.' {
+				continue
+			}
+			if !braceSegmentBoundary(p, i-1) || !braceSegmentBoundary(p, i+2) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// braceSegmentBoundary reports whether p[i] is at or past a delimiter
+// that separates path segments inside a brace expansion: `/`, `,`, `{`,
+// or `}`. Out-of-range positions are treated as boundaries so a `..`
+// at the very edge of a brace block still matches.
+func braceSegmentBoundary(p string, i int) bool {
+	if i < 0 || i >= len(p) {
+		return true
+	}
+	c := p[i]
+	return c == '/' || c == ',' || c == '{' || c == '}'
 }
 
 // dotDotInPatterns reports whether any pattern contains a ".." segment.

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -396,7 +396,7 @@ func resolveBaseRel(fileDir, sourceDir string) (string, bool) {
 	if sd == "." {
 		sd = ""
 	}
-	if strings.HasPrefix(sd, "..") || filepath.IsAbs(sd) {
+	if sd == ".." || strings.HasPrefix(sd, "../") || filepath.IsAbs(sd) {
 		return "", false
 	}
 	return sd, true

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -379,27 +379,38 @@ func resolveAgainstProjectRoot(
 // no relation can be computed (e.g. an absolute file path with no
 // configured RootDir, or a file outside the configured root).
 //
+// The Runner passes file paths through verbatim from the command line,
+// so a relative f.Path may be CWD-relative rather than root-relative
+// (e.g. running `mdsmith check index.md` from a subdirectory). When
+// RootDir is set, the file path is absolutized first so both absolute
+// and any flavor of relative input land on the same root-relative
+// string. Without RootDir, the path is assumed to already be
+// root-relative.
+//
 // Returns "" for the project root itself.
 func projectRelFileDir(f *lint.File) (string, bool) {
-	cleaned := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
-	if cleaned == "." {
-		return "", true
-	}
-	if !filepath.IsAbs(cleaned) {
+	if f.RootDir == "" {
+		cleaned := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
+		if cleaned == "." {
+			return "", true
+		}
+		if filepath.IsAbs(cleaned) {
+			return "", false
+		}
 		return cleaned, true
 	}
-	if f.RootDir == "" {
-		return "", false
-	}
-	// filepath.Abs can fail if Getwd errors; filepath.Rel returns an
-	// error for paths on different volumes (Windows) or for mismatched
-	// abs/rel pairs. Treating those as "cannot relate to root" keeps
-	// the safety check honest instead of returning a bogus path.
 	rootAbs, err := filepath.Abs(f.RootDir)
 	if err != nil {
 		return "", false
 	}
-	rel, err := filepath.Rel(rootAbs, filepath.Dir(f.Path))
+	fileAbs := f.Path
+	if !filepath.IsAbs(fileAbs) {
+		fileAbs, err = filepath.Abs(fileAbs)
+		if err != nil {
+			return "", false
+		}
+	}
+	rel, err := filepath.Rel(rootAbs, filepath.Dir(fileAbs))
 	if err != nil {
 		return "", false
 	}

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -318,11 +318,21 @@ func missingRootDiag(filePath string, line int) globResolution {
 		`generated section directive glob contains ".." but project root is not configured`)}}
 }
 
+// outsideRootDiag reports a ".." pattern in a file whose path cannot be
+// related to the configured project root (e.g. it lives on a different
+// volume, or above the configured RootDir). Distinct from
+// missingRootDiag so the user can tell which situation they're in.
+func outsideRootDiag(filePath string, line int) globResolution {
+	return globResolution{diags: []lint.Diagnostic{makeDiag(
+		filePath, line,
+		`generated section directive catalog file is outside project root; ".." globs cannot be resolved`)}}
+}
+
 // resolveAgainstProjectRoot rewrites include/exclude patterns relative
 // to the project root using RootFS. When the source-dir is invalid or
 // fileDir cannot be related to the project root, it falls back to the
 // file's fs.FS — except for ".." patterns, which still need a project
-// root and surface the missing-root diagnostic instead of silently
+// root and surface the outside-root diagnostic instead of silently
 // matching nothing on a fs.FS that rejects "..".
 func resolveAgainstProjectRoot(
 	f *lint.File, sourceDir string, hasDotDot bool,
@@ -332,7 +342,7 @@ func resolveAgainstProjectRoot(
 	fileDir, ok := projectRelFileDir(f)
 	if !ok {
 		if hasDotDot {
-			return missingRootDiag(filePath, line)
+			return outsideRootDiag(filePath, line)
 		}
 		return localFSResolution(f, includes, excludes)
 	}
@@ -381,10 +391,18 @@ func projectRelFileDir(f *lint.File) (string, bool) {
 	if f.RootDir == "" {
 		return "", false
 	}
-	// filepath.Abs and filepath.Rel only error for inputs we don't
-	// hand them here (Abs needs Getwd; Rel needs mismatched abs/rel).
-	rootAbs, _ := filepath.Abs(f.RootDir)
-	rel, _ := filepath.Rel(rootAbs, filepath.Dir(f.Path))
+	// filepath.Abs can fail if Getwd errors; filepath.Rel returns an
+	// error for paths on different volumes (Windows) or for mismatched
+	// abs/rel pairs. Treating those as "cannot relate to root" keeps
+	// the safety check honest instead of returning a bogus path.
+	rootAbs, err := filepath.Abs(f.RootDir)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(rootAbs, filepath.Dir(f.Path))
+	if err != nil {
+		return "", false
+	}
 	rel = filepath.ToSlash(rel)
 	if rel == "." {
 		return "", true

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -348,7 +348,14 @@ func resolveAgainstProjectRoot(
 	}
 	baseRel, ok := resolveBaseRel(fileDir, sourceDir)
 	if !ok {
-		return localFSResolution(f, includes, excludes)
+		if hasDotDot {
+			// The pattern needs root-aware resolution for its ".."
+			// segments; an invalid source-dir is ignored so we still
+			// catch escapes-root and report them.
+			baseRel = fileDir
+		} else {
+			return localFSResolution(f, includes, excludes)
+		}
 	}
 	resolvedIncludes, ok := resolvePatterns(baseRel, includes)
 	if !ok {

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -186,6 +186,10 @@ func splitGlobs(glob string) []string {
 // validateGlob validates the glob parameter and returns diagnostics on failure.
 // The glob value may be a single pattern or multiple newline-joined patterns
 // (from a YAML list). Patterns prefixed with "!" are exclusion patterns.
+//
+// Path-traversal escapes and missing-root errors for ".." patterns are
+// checked at generation time, where the project root is available; see
+// resolveGlobFS.
 func validateGlob(filePath string, line int, params map[string]string) []lint.Diagnostic {
 	glob, hasGlob := params["glob"]
 	if !hasGlob {
@@ -206,10 +210,6 @@ func validateGlob(filePath string, line int, params map[string]string) []lint.Di
 		if filepath.IsAbs(pattern) {
 			return []lint.Diagnostic{makeDiag(filePath, line,
 				"generated section directive has absolute glob path")}
-		}
-		if containsDotDot(pattern) {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`generated section directive has glob pattern with ".." path traversal`)}
 		}
 		if !doublestar.ValidatePattern(pattern) {
 			return []lint.Diagnostic{makeDiag(filePath, line,
@@ -250,49 +250,170 @@ func validateSort(filePath string, line int, sortVal string) []lint.Diagnostic {
 	return nil
 }
 
-// splitIncludeExclude separates glob patterns into include and exclude lists.
-// Patterns prefixed with "!" are exclusion patterns (prefix is stripped).
-func splitIncludeExclude(glob string) (include, exclude []string) {
-	return globpath.SplitIncludeExclude(splitGlobs(glob))
+// globResolution describes how a catalog directive's glob is rooted.
+// It tells the caller which fs.FS to glob against, how to convert matched
+// paths back into display paths for the catalog-owning file, the resolved
+// include/exclude pattern lists, and where to anchor gitignore lookups.
+type globResolution struct {
+	fs            fs.FS
+	includes      []string
+	excludes      []string
+	gitignoreBase string // absolute directory matched paths are relative to; "" disables gitignore filtering
+	fileDir       string // catalog-owning file's directory, slash-separated, project-root-relative; "" means at root
+	rootRelative  bool   // when true, matches are root-relative and need filepath.Rel for display
+	diags         []lint.Diagnostic
 }
 
-// resolveGlobFS returns the filesystem to use for glob resolution and
-// a path prefix for display filenames. When source-dir is set (injected
-// by include expansion), globs resolve from that subdirectory of RootFS
-// and matched filenames are prefixed relative to the catalog-owning
-// file's directory so links work correctly.
-func resolveGlobFS(f *lint.File, params map[string]string) (globFS fs.FS, prefix string) {
+// displayPath converts a doublestar match into a path relative to the
+// catalog-owning file's directory.
+func (r globResolution) displayPath(match string) string {
+	if !r.rootRelative {
+		return match
+	}
+	base := r.fileDir
+	if base == "" {
+		base = "."
+	}
+	rel, err := filepath.Rel(base, match)
+	if err != nil {
+		return match
+	}
+	return filepath.ToSlash(rel)
+}
+
+// resolveGlobFS resolves the catalog directive's glob scope. When the
+// patterns contain ".." segments or when source-dir is set, globs resolve
+// against the project root via RootFS; otherwise the catalog-owning file's
+// own fs.FS is used. Patterns are rewritten to root-relative form when
+// switching to RootFS; an "escapes project root" diagnostic is returned
+// when any pattern would resolve outside the root.
+func resolveGlobFS(f *lint.File, params map[string]string, filePath string, line int) globResolution {
+	rawPatterns := splitGlobs(params["glob"])
+	includes, excludes := globpath.SplitIncludeExclude(rawPatterns)
 	sourceDir := params["source-dir"]
-	if sourceDir == "" || f.RootFS == nil {
-		return f.FS, ""
+	hasDotDot := dotDotInPatterns(rawPatterns)
+
+	if sourceDir == "" && !hasDotDot {
+		return localFSResolution(f, includes, excludes)
 	}
-
-	sourceDir = path.Clean(sourceDir)
-	fileDir := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
-
-	// Compute prefix relative to the file's directory so display
-	// filenames produce correct links from the including file.
-	relPrefix, err := filepath.Rel(fileDir, sourceDir)
-	if err != nil {
-		return f.FS, ""
-	}
-	relPrefix = filepath.ToSlash(relPrefix)
-
-	if sourceDir == "." {
-		if relPrefix == "." {
-			return f.RootFS, ""
+	if f.RootFS == nil {
+		if hasDotDot {
+			return globResolution{diags: []lint.Diagnostic{makeDiag(
+				filePath, line,
+				`generated section directive glob contains ".." but project root is not configured`)}}
 		}
-		return f.RootFS, relPrefix
+		return localFSResolution(f, includes, excludes)
 	}
+	return resolveAgainstProjectRoot(f, sourceDir, includes, excludes, filePath, line)
+}
 
-	sub, err := fs.Sub(f.RootFS, sourceDir)
-	if err != nil {
-		return f.FS, ""
+// resolveAgainstProjectRoot rewrites include/exclude patterns relative
+// to the project root using RootFS. Falls back to the file's fs.FS when
+// the source-dir is invalid or filepath.Rel cannot resolve fileDir.
+func resolveAgainstProjectRoot(
+	f *lint.File, sourceDir string,
+	includes, excludes []string,
+	filePath string, line int,
+) globResolution {
+	fileDir := path.Clean(filepath.ToSlash(filepath.Dir(f.Path)))
+	if fileDir == "." {
+		fileDir = ""
 	}
-	if relPrefix == "." {
-		return sub, ""
+	baseRel, ok := resolveBaseRel(fileDir, sourceDir)
+	if !ok {
+		return localFSResolution(f, includes, excludes)
 	}
-	return sub, relPrefix
+	if fileDir != "" {
+		if _, err := filepath.Rel(fileDir, "."); err != nil {
+			return localFSResolution(f, includes, excludes)
+		}
+	}
+	resolvedIncludes, ok := resolvePatterns(baseRel, includes)
+	if !ok {
+		return escapeDiag(filePath, line)
+	}
+	resolvedExcludes, ok := resolvePatterns(baseRel, excludes)
+	if !ok {
+		return escapeDiag(filePath, line)
+	}
+	gitignoreBase := ""
+	if f.RootDir != "" {
+		if abs, err := filepath.Abs(f.RootDir); err == nil {
+			gitignoreBase = abs
+		}
+	}
+	return globResolution{
+		fs:            f.RootFS,
+		includes:      resolvedIncludes,
+		excludes:      resolvedExcludes,
+		gitignoreBase: gitignoreBase,
+		fileDir:       fileDir,
+		rootRelative:  true,
+	}
+}
+
+func escapeDiag(filePath string, line int) globResolution {
+	return globResolution{diags: []lint.Diagnostic{makeDiag(
+		filePath, line,
+		"generated section directive glob escapes project root")}}
+}
+
+// dotDotInPatterns reports whether any pattern contains a ".." segment.
+func dotDotInPatterns(patterns []string) bool {
+	for _, p := range patterns {
+		if globpath.ContainsDotDotSegment(strings.TrimPrefix(p, "!")) {
+			return true
+		}
+	}
+	return false
+}
+
+// localFSResolution builds the fast-path resolution that globs from the
+// catalog-owning file's own fs.FS. Used when no source-dir is set and the
+// patterns contain no ".." segments, or as a fallback when the project
+// root is not configured.
+func localFSResolution(f *lint.File, includes, excludes []string) globResolution {
+	base := ""
+	if abs, err := filepath.Abs(filepath.Dir(f.Path)); err == nil {
+		base = abs
+	}
+	return globResolution{
+		fs:            f.FS,
+		includes:      includes,
+		excludes:      excludes,
+		gitignoreBase: base,
+	}
+}
+
+// resolveBaseRel returns the project-root-relative directory glob patterns
+// resolve against. When sourceDir is set it overrides the file's own
+// directory; an absolute or escaping sourceDir signals failure (ok=false).
+func resolveBaseRel(fileDir, sourceDir string) (string, bool) {
+	if sourceDir == "" {
+		return fileDir, true
+	}
+	sd := path.Clean(sourceDir)
+	if sd == "." {
+		sd = ""
+	}
+	if strings.HasPrefix(sd, "..") || filepath.IsAbs(sd) {
+		return "", false
+	}
+	return sd, true
+}
+
+// resolvePatterns rewrites each pattern relative to baseRel; ok is false
+// when any pattern would resolve outside the project root.
+func resolvePatterns(baseRel string, patterns []string) ([]string, bool) {
+	resolved := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		r, escapes := globpath.ResolveAgainstRoot(baseRel, p)
+		if escapes {
+			return nil, false
+		}
+		resolved = append(resolved, r)
+	}
+	return resolved, true
 }
 
 // buildCatalogEntries resolves glob matches, reads front matter, and
@@ -305,8 +426,11 @@ func resolveGlobFS(f *lint.File, params map[string]string) (globFS fs.FS, prefix
 func buildCatalogEntries(
 	f *lint.File, params map[string]string, filePath string, line int,
 ) ([]fileEntry, []lint.Diagnostic) {
-	globFS, prefix := resolveGlobFS(f, params)
-	files := resolveGlobMatchesFrom(globFS, f, params)
+	res := resolveGlobFS(f, params, filePath, line)
+	if len(res.diags) > 0 {
+		return nil, res.diags
+	}
+	files := resolveGlobMatchesFrom(res, f, params)
 
 	sortKey, descending := parseSort(params)
 	_, hasRow := params["row"]
@@ -315,13 +439,10 @@ func buildCatalogEntries(
 	var diags []lint.Diagnostic
 	entries := make([]fileEntry, 0, len(files))
 	for _, p := range files {
-		displayPath := p
-		if prefix != "" {
-			displayPath = path.Join(prefix, p)
-		}
+		displayPath := res.displayPath(p)
 		fields := map[string]any{"filename": displayPath}
 		if needFM {
-			fm, err := readFrontMatter(globFS, p, f.MaxInputBytes)
+			fm, err := readFrontMatter(res.fs, p, f.MaxInputBytes)
 			if err != nil {
 				diags = append(diags, makeDiag(filePath, line,
 					fmt.Sprintf("cannot read front matter from %q: %v", displayPath, err)))
@@ -338,17 +459,20 @@ func buildCatalogEntries(
 	return entries, diags
 }
 
-// resolveGlobMatchesFrom expands include patterns using the given FS,
-// filters out exclude and gitignore matches, and returns deduplicated
-// file paths.
-func resolveGlobMatchesFrom(globFS fs.FS, f *lint.File, params map[string]string) []string {
-	includePatterns, excludePatterns := splitIncludeExclude(params["glob"])
-	matcher, base := resolveGitignore(f, params)
+// resolveGlobMatchesFrom expands include patterns using the resolved
+// fs.FS, filters out exclude and gitignore matches, and returns
+// deduplicated file paths.
+func resolveGlobMatchesFrom(res globResolution, f *lint.File, params map[string]string) []string {
+	matcher := resolveGitignoreMatcher(f, params)
+	base := res.gitignoreBase
+	if matcher == nil {
+		base = ""
+	}
 
 	seen := make(map[string]bool)
 	var files []string
-	for _, pattern := range includePatterns {
-		matches, err := doublestar.Glob(globFS, pattern)
+	for _, pattern := range res.includes {
+		matches, err := doublestar.Glob(res.fs, pattern)
 		if err != nil {
 			continue
 		}
@@ -356,14 +480,14 @@ func resolveGlobMatchesFrom(globFS fs.FS, f *lint.File, params map[string]string
 			if seen[m] {
 				continue
 			}
-			info, err := fs.Stat(globFS, m)
+			info, err := fs.Stat(res.fs, m)
 			if err != nil || info.IsDir() {
 				continue
 			}
-			if isExcluded(m, excludePatterns) {
+			if isExcluded(m, res.excludes) {
 				continue
 			}
-			if matcher != nil && isGitignored(matcher, base, m) {
+			if matcher != nil && base != "" && isGitignored(matcher, base, m) {
 				continue
 			}
 			seen[m] = true
@@ -373,28 +497,15 @@ func resolveGlobMatchesFrom(globFS fs.FS, f *lint.File, params map[string]string
 	return files
 }
 
-// resolveGitignore returns the gitignore matcher and base directory to use
-// for filtering, or (nil, "") if gitignore filtering is disabled.
-func resolveGitignore(f *lint.File, params map[string]string) (*lint.GitignoreMatcher, string) {
+// resolveGitignoreMatcher returns the gitignore matcher to use for
+// filtering, or nil when gitignore filtering is disabled or no matcher
+// is available. The absolute base directory matched paths are anchored
+// to is supplied separately by resolveGlobFS as part of globResolution.
+func resolveGitignoreMatcher(f *lint.File, params map[string]string) *lint.GitignoreMatcher {
 	if params["gitignore"] == "false" {
-		return nil, ""
+		return nil
 	}
-	matcher := f.GetGitignore()
-	if matcher == nil {
-		return nil, ""
-	}
-	baseDir := filepath.Dir(f.Path)
-	if sd := params["source-dir"]; sd != "" && f.RootDir != "" {
-		sd = path.Clean(sd)
-		if !filepath.IsAbs(sd) && !containsDotDot(sd) {
-			baseDir = filepath.Join(f.RootDir, sd)
-		}
-	}
-	base, err := filepath.Abs(baseDir)
-	if err != nil {
-		return nil, ""
-	}
-	return matcher, base
+	return f.GetGitignore()
 }
 
 // checkCatalogInjection warns when interpolated front-matter values contain
@@ -690,17 +801,6 @@ func isGitignored(matcher *lint.GitignoreMatcher, base, matchedPath string) bool
 	}
 
 	return matcher.IsIgnored(abs, false)
-}
-
-// containsDotDot checks if a glob pattern contains ".." path traversal.
-func containsDotDot(pattern string) bool {
-	parts := strings.Split(pattern, "/")
-	for _, p := range parts {
-		if p == ".." {
-			return true
-		}
-	}
-	return false
 }
 
 // parseRowTemplate validates a row template string containing {field}

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -2809,6 +2809,179 @@ glob: "../sibling/*.md"
 	assert.Contains(t, result, "../sibling/guide.md")
 }
 
+func TestContainsDotDotInsideBraces(t *testing.T) {
+	cases := map[string]bool{
+		"{..,sibling}/*.md":  true,
+		"{a,..}/*.md":        true,
+		"prefix/{x,..}/*.md": true,
+		"{a,b}/*.md":         false,
+		"{a.b,c}/*.md":       false, // ".": at depth>0 but no second "."
+		"{a..b,c}/*.md":      false, // "..": embedded in segment, not a segment
+		"foo/../bar":         false, // outside braces is a separate check
+		"":                   false,
+		"..":                 false,
+		"{}":                 false,
+	}
+	for input, want := range cases {
+		assert.Equal(t, want, containsDotDotInsideBraces(input), input)
+	}
+}
+
+func TestBraceSegmentBoundary(t *testing.T) {
+	assert.True(t, braceSegmentBoundary("abc", -1))
+	assert.True(t, braceSegmentBoundary("abc", 3))
+	assert.True(t, braceSegmentBoundary("a/b", 1))
+	assert.True(t, braceSegmentBoundary("a,b", 1))
+	assert.True(t, braceSegmentBoundary("a{b", 1))
+	assert.True(t, braceSegmentBoundary("a}b", 1))
+	assert.False(t, braceSegmentBoundary("ab", 1))
+}
+
+func TestProjectRelFileDir_RelativePath(t *testing.T) {
+	f := &lint.File{Path: "docs/development/index.md"}
+	dir, ok := projectRelFileDir(f)
+	require.True(t, ok)
+	assert.Equal(t, "docs/development", dir)
+}
+
+func TestProjectRelFileDir_RootFile(t *testing.T) {
+	f := &lint.File{Path: "README.md"}
+	dir, ok := projectRelFileDir(f)
+	require.True(t, ok)
+	assert.Equal(t, "", dir)
+}
+
+func TestProjectRelFileDir_AbsolutePathNoRootDir(t *testing.T) {
+	f := &lint.File{Path: "/abs/path/index.md"}
+	_, ok := projectRelFileDir(f)
+	assert.False(t, ok, "absolute file path without RootDir cannot be related to root")
+}
+
+func TestProjectRelFileDir_AbsoluteFileAtRoot(t *testing.T) {
+	dir := t.TempDir()
+	f := &lint.File{Path: filepath.Join(dir, "index.md"), RootDir: dir}
+	got, ok := projectRelFileDir(f)
+	require.True(t, ok)
+	assert.Equal(t, "", got, "file directly at project root resolves to empty rel dir")
+}
+
+func TestDisplayPath_RelErrorReturnsMatchUnchanged(t *testing.T) {
+	// filepath.Rel returns an error when one path is absolute and the
+	// other relative. Forcing that combination exercises the err branch.
+	res := globResolution{rootRelative: true, fileDir: "skills/foo"}
+	abs := "/somewhere/api.md"
+	assert.Equal(t, abs, res.displayPath(abs))
+}
+
+func TestDisplayPath_LocalFSPassthrough(t *testing.T) {
+	res := globResolution{rootRelative: false}
+	assert.Equal(t, "docs/api.md", res.displayPath("docs/api.md"))
+}
+
+func TestDisplayPath_RelComputedFromRoot(t *testing.T) {
+	res := globResolution{rootRelative: true, fileDir: "skills/foo"}
+	assert.Equal(t, "../../docs/api.md", res.displayPath("docs/api.md"))
+}
+
+func TestCatalog_DotDotInBracesRejected(t *testing.T) {
+	// `{..,sibling}/*.md` would expand to include "..", but path.Clean
+	// can't peek inside braces — so the validator rejects it up front
+	// to avoid silent partial matches at glob time.
+	src := `<?catalog
+glob: "{..,sibling}/*.md"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{}
+	f := newTestFile(t, "home/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 1)
+	expectDiagMsg(t, diags, `".." inside brace expansion`)
+}
+
+func TestCatalog_DotDotGlobAbsoluteFilePath(t *testing.T) {
+	// When the catalog-owning file's path is absolute (as happens via
+	// CLI glob expansion), `..` resolution still works as long as the
+	// project RootDir is configured: the file's directory is computed
+	// relative to RootDir before pattern resolution runs.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "home"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sibling"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "sibling", "api.md"),
+		[]byte("# API\n"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "home", "index.md"),
+		[]byte("placeholder"), 0o644))
+
+	src := `<?catalog
+glob: "../sibling/*.md"
+?>
+<?/catalog?>
+`
+	absPath := filepath.Join(dir, "home", "index.md")
+	f, err := lint.NewFile(absPath, []byte(src))
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	f.FS = f.RootFS
+
+	r := &Rule{}
+	result := string(r.Fix(f))
+	assert.Contains(t, result, "../sibling/api.md")
+}
+
+func TestCatalog_DotDotGlobAbsoluteFilePathOutsideRoot(t *testing.T) {
+	// An absolute file path outside the configured RootDir cannot be
+	// related to the project root; resolution falls back to f.FS, and
+	// the dotdot pattern then errors out as "project root not
+	// configured" because that fallback path has no RootFS context.
+	dir := t.TempDir()
+	otherDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(otherDir, "foreign.md"),
+		[]byte("placeholder"), 0o644))
+
+	src := `<?catalog
+glob: "../sibling/*.md"
+?>
+<?/catalog?>
+`
+	f, err := lint.NewFile(filepath.Join(otherDir, "foreign.md"), []byte(src))
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	f.FS = f.RootFS
+
+	r := &Rule{}
+	diags := r.Check(f)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, `glob contains ".." but project root is not configured`)
+}
+
+func TestCatalog_DotDotExcludeEscapesRoot(t *testing.T) {
+	// An exclude pattern that resolves outside the project root is
+	// rejected with the same diagnostic as an include pattern, so the
+	// rule never silently strips matches based on out-of-root
+	// suppression rules.
+	src := `<?catalog
+glob:
+  - "*.md"
+  - "!../../escape/*.md"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"home/index.md": {Data: []byte("# Home\n")},
+	}
+	f := newTestFile(t, "home/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 1)
+	expectDiagMsg(t, diags, "glob escapes project root")
+}
+
 func TestCatalog_DotDotGlobEscapesRoot(t *testing.T) {
 	// A glob whose resolved path leaves the project root is rejected
 	// with the new diagnostic message.

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -2865,6 +2865,29 @@ func TestProjectRelFileDir_AbsoluteFileAtRoot(t *testing.T) {
 	assert.Equal(t, "", got, "file directly at project root resolves to empty rel dir")
 }
 
+func TestProjectRelFileDir_CWDRelativePathWithRootDir(t *testing.T) {
+	// Real CLI run from a subdirectory: f.Path is CWD-relative but
+	// RootDir is absolute. projectRelFileDir must absolutize f.Path
+	// against the current CWD before relating it to RootDir, so the
+	// returned directory is project-root-relative regardless of how
+	// the path was supplied on the command line.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "docs", "index.md"),
+		[]byte("# Index\n"), 0o644))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(filepath.Join(dir, "docs")))
+
+	f := &lint.File{Path: "index.md", RootDir: dir}
+	got, ok := projectRelFileDir(f)
+	require.True(t, ok)
+	assert.Equal(t, "docs", got)
+}
+
 func TestDisplayPath_RelErrorReturnsMatchUnchanged(t *testing.T) {
 	// filepath.Rel returns an error when one path is absolute and the
 	// other relative. Forcing that combination exercises the err branch.
@@ -2923,6 +2946,42 @@ glob: "../sibling/*.md"
 `
 	absPath := filepath.Join(dir, "home", "index.md")
 	f, err := lint.NewFile(absPath, []byte(src))
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	f.FS = f.RootFS
+
+	r := &Rule{}
+	result := string(r.Fix(f))
+	assert.Contains(t, result, "../sibling/api.md")
+}
+
+func TestCatalog_DotDotGlobCWDRelativePathFromSubdir(t *testing.T) {
+	// Common CLI invocation style: `mdsmith check index.md` run from
+	// a subdirectory under the project root. f.Path is "index.md"
+	// (CWD-relative), but RootDir/RootFS point at the configured
+	// project root. The catalog rule should still resolve "../sibling"
+	// patterns correctly via projectRelFileDir's absolutize-first path.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "home"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sibling"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "sibling", "api.md"),
+		[]byte("# API\n"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "home", "index.md"),
+		[]byte("placeholder"), 0o644))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(filepath.Join(dir, "home")))
+
+	src := `<?catalog
+glob: "../sibling/*.md"
+?>
+<?/catalog?>
+`
+	f, err := lint.NewFile("index.md", []byte(src))
 	require.NoError(t, err)
 	f.SetRootDir(dir)
 	f.FS = f.RootFS

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -1226,11 +1226,11 @@ func TestCheck_GlobErrors(t *testing.T) {
 			wantMsg:   "absolute glob path",
 		},
 		{
-			name:      "glob with ..",
+			name:      "glob with .. without project root",
 			src:       "<?catalog\nglob: \"../*.md\"\n?>\n<?/catalog?>\n",
 			fs:        fstest.MapFS{},
 			wantCount: 1,
-			wantMsg:   `".." path traversal`,
+			wantMsg:   `glob contains ".." but project root is not configured`,
 		},
 		{
 			name:      "missing glob",
@@ -1603,27 +1603,6 @@ func TestParseRowTemplate_Valid(t *testing.T) {
 func TestParseRowTemplate_Invalid(t *testing.T) {
 	err := parseRowTemplate("{title")
 	require.Error(t, err, "expected error for invalid template")
-}
-
-func TestContainsDotDot(t *testing.T) {
-	tests := []struct {
-		pattern string
-		want    bool
-	}{
-		{"../foo", true},
-		{"foo/../bar", true},
-		{"foo/bar/..", true},
-		{"foo/bar", false},
-		{"foo..bar", false},
-		{"...", false},
-		{"..", true},
-	}
-	for _, tc := range tests {
-		t.Run(tc.pattern, func(t *testing.T) {
-			got := containsDotDot(tc.pattern)
-			assert.Equal(t, tc.want, got, "containsDotDot(%q) = %v, want %v", tc.pattern, got, tc.want)
-		})
-	}
 }
 
 func TestEnsureTrailingNewline(t *testing.T) {
@@ -2549,7 +2528,8 @@ glob:
 }
 
 func TestSpec_MultiGlobDotDot(t *testing.T) {
-	// A list containing ".." path traversal produces a diagnostic.
+	// A list containing ".." without project root configured produces
+	// a diagnostic.
 	src := `<?catalog
 glob:
   - "*.md"
@@ -2562,7 +2542,7 @@ glob:
 	r := &Rule{}
 	diags := r.Check(f)
 	expectDiags(t, diags, 1)
-	expectDiagMsg(t, diags, `".." path traversal`)
+	expectDiagMsg(t, diags, `glob contains ".." but project root is not configured`)
 }
 
 func TestSpec_MultiGlobInvalidPattern(t *testing.T) {
@@ -2800,8 +2780,57 @@ glob:
 	expectDiagMsg(t, diags, "absolute glob path")
 }
 
+func TestCatalog_DotDotGlobStaysInsideRoot(t *testing.T) {
+	// A "../sibling/*.md" glob resolves to within the project root
+	// when RootFS is set, so matching succeeds and display paths use
+	// "../sibling/" prefixes relative to the catalog-owning file.
+	src := `<?catalog
+glob: "../sibling/*.md"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"sibling/api.md":   {Data: []byte("# API\n")},
+		"sibling/guide.md": {Data: []byte("# Guide\n")},
+		"home/index.md":    {Data: []byte("# Home\n")},
+	}
+	f := newTestFile(t, "home/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	diags := r.Check(f)
+	// Check reports drift between the empty body and the generated
+	// catalog rather than a path-traversal error.
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, `".."`)
+		assert.NotContains(t, d.Message, "escapes project root")
+	}
+	result := string(r.Fix(f))
+	assert.Contains(t, result, "../sibling/api.md")
+	assert.Contains(t, result, "../sibling/guide.md")
+}
+
+func TestCatalog_DotDotGlobEscapesRoot(t *testing.T) {
+	// A glob whose resolved path leaves the project root is rejected
+	// with the new diagnostic message.
+	src := `<?catalog
+glob: "../../secret/*.md"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"home/index.md": {Data: []byte("# Home\n")},
+	}
+	f := newTestFile(t, "home/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 1)
+	expectDiagMsg(t, diags, "glob escapes project root")
+}
+
 func TestSpec_ExcludeDotDot(t *testing.T) {
-	// ".." path traversal in !-prefixed patterns produces a diagnostic.
+	// ".." in !-prefixed patterns without project root configured
+	// produces a diagnostic.
 	src := `<?catalog
 glob:
   - "*.md"
@@ -2814,7 +2843,7 @@ glob:
 	r := &Rule{}
 	diags := r.Check(f)
 	expectDiags(t, diags, 1)
-	expectDiagMsg(t, diags, `".." path traversal`)
+	expectDiagMsg(t, diags, `glob contains ".." but project root is not configured`)
 }
 
 func TestSpec_ExcludeInvalidPattern(t *testing.T) {
@@ -3506,25 +3535,23 @@ func TestRule_Category(t *testing.T) {
 }
 
 // =====================================================================
-// Phase 4 coverage: resolveGitignore param variations
+// Phase 4 coverage: resolveGitignoreMatcher param variations
 // =====================================================================
 
-func TestResolveGitignore_DisabledByParam(t *testing.T) {
+func TestResolveGitignoreMatcher_DisabledByParam(t *testing.T) {
 	f := newTestFile(t, "index.md", "")
-	matcher, base := resolveGitignore(f, map[string]string{"gitignore": "false"})
+	matcher := resolveGitignoreMatcher(f, map[string]string{"gitignore": "false"})
 	assert.Nil(t, matcher)
-	assert.Equal(t, "", base)
 }
 
-func TestResolveGitignore_NoMatcherAvailable(t *testing.T) {
+func TestResolveGitignoreMatcher_NoMatcherAvailable(t *testing.T) {
 	f := newTestFile(t, "index.md", "")
 	// GitignoreFunc is nil → GetGitignore returns nil
-	matcher, base := resolveGitignore(f, map[string]string{})
+	matcher := resolveGitignoreMatcher(f, map[string]string{})
 	assert.Nil(t, matcher)
-	assert.Equal(t, "", base)
 }
 
-func TestResolveGitignore_WithMatcherAndSourceDir(t *testing.T) {
+func TestResolveGitignoreMatcher_WithMatcher(t *testing.T) {
 	dir := t.TempDir()
 	stub := &lint.GitignoreMatcher{}
 	f := &lint.File{
@@ -3534,11 +3561,8 @@ func TestResolveGitignore_WithMatcherAndSourceDir(t *testing.T) {
 			return stub
 		},
 	}
-	params := map[string]string{"source-dir": "docs"}
-	matcher, base := resolveGitignore(f, params)
+	matcher := resolveGitignoreMatcher(f, map[string]string{"source-dir": "docs"})
 	assert.Same(t, stub, matcher)
-	assert.NotEmpty(t, base)
-	assert.True(t, filepath.IsAbs(base))
 }
 
 // =====================================================================

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -2906,6 +2906,29 @@ func TestDisplayPath_RelComputedFromRoot(t *testing.T) {
 	assert.Equal(t, "../../docs/api.md", res.displayPath("docs/api.md"))
 }
 
+func TestCatalog_DotDotGlobInvalidSourceDirStillResolvesRootAware(t *testing.T) {
+	// An invalid `source-dir` would normally fall back to the file's
+	// own fs.FS, but for ".." patterns that fallback can't resolve the
+	// segment at all. Instead, ignore the bad source-dir and continue
+	// root-aware resolution against the file's directory so the
+	// escapes-root diagnostic still fires when warranted.
+	src := `<?catalog
+glob: "../../escape/*.md"
+source-dir: "/abs/invalid"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"home/index.md": {Data: []byte("# Home\n")},
+	}
+	f := newTestFile(t, "home/index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 1)
+	expectDiagMsg(t, diags, "glob escapes project root")
+}
+
 func TestCatalog_DotDotInBracesRejected(t *testing.T) {
 	// `{..,sibling}/*.md` would expand to include "..", but path.Clean
 	// can't peek inside braces — so the validator rejects it up front
@@ -2993,9 +3016,9 @@ glob: "../sibling/*.md"
 
 func TestCatalog_DotDotGlobAbsoluteFilePathOutsideRoot(t *testing.T) {
 	// An absolute file path outside the configured RootDir cannot be
-	// related to the project root; resolution falls back to f.FS, and
-	// the dotdot pattern then errors out as "project root not
-	// configured" because that fallback path has no RootFS context.
+	// related to the project root, so the rule surfaces the dedicated
+	// "catalog file is outside project root" diagnostic for the
+	// dotdot pattern instead of silently matching nothing.
 	dir := t.TempDir()
 	otherDir := t.TempDir()
 	require.NoError(t, os.WriteFile(

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -2956,7 +2956,7 @@ glob: "../sibling/*.md"
 	r := &Rule{}
 	diags := r.Check(f)
 	require.NotEmpty(t, diags)
-	assert.Contains(t, diags[0].Message, `glob contains ".." but project root is not configured`)
+	assert.Contains(t, diags[0].Message, "catalog file is outside project root")
 }
 
 func TestCatalog_DotDotExcludeEscapesRoot(t *testing.T) {

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -2798,12 +2798,13 @@ glob: "../sibling/*.md"
 	f.RootFS = mapFS
 	r := &Rule{}
 	diags := r.Check(f)
-	// Check reports drift between the empty body and the generated
-	// catalog rather than a path-traversal error.
-	for _, d := range diags {
-		assert.NotContains(t, d.Message, `".."`)
-		assert.NotContains(t, d.Message, "escapes project root")
-	}
+	// The directive body is empty, so Check must emit the drift
+	// diagnostic — not the dotdot/root-escape diagnostics, which would
+	// signal the resolution wrongly rejected the pattern.
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "generated section is out of date")
+	assert.NotContains(t, diags[0].Message, `".."`)
+	assert.NotContains(t, diags[0].Message, "escapes project root")
 	result := string(r.Fix(f))
 	assert.Contains(t, result, "../sibling/api.md")
 	assert.Contains(t, result, "../sibling/guide.md")

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3475,6 +3475,26 @@ source-dir: ".."
 	assert.Contains(t, result, "top.md")
 }
 
+func TestCatalog_SourceDirNestedTraversalIgnored(t *testing.T) {
+	// A source-dir whose cleaned value starts with "../" is treated as
+	// invalid traversal and resolveGlobFS falls back to f.FS — the
+	// "../foo" branch of resolveBaseRel that ".." alone doesn't hit.
+	src := `<?catalog
+glob: "*.md"
+source-dir: "../escape"
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"top.md": {Data: []byte("# Top\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	f.RootFS = mapFS
+	r := &Rule{}
+	result := string(r.Fix(f))
+	assert.Contains(t, result, "top.md")
+}
+
 // =====================================================================
 // buildCatalogEntries error diagnostics (file-size limit)
 // =====================================================================

--- a/plan/153_catalog-dotdot-globs.md
+++ b/plan/153_catalog-dotdot-globs.md
@@ -101,7 +101,7 @@ Have both directives call the shared helper.
    [`internal/rules/MDS019-catalog/`](../internal/rules/MDS019-catalog/).
    The integration runner now pins
    `f.RootFS = f.FS` for MDS019 fixtures so
-   "..": resolution mirrors a real project.
+   ".." resolution mirrors a real project.
 6. [x] Add the `<?catalog?>` block in the
    [solid-architecture SKILL.md](../.claude/skills/solid-architecture/SKILL.md)
    targeting

--- a/plan/153_catalog-dotdot-globs.md
+++ b/plan/153_catalog-dotdot-globs.md
@@ -1,7 +1,7 @@
 ---
 id: 153
 title: Catalog directive — accept `..` globs within project root
-status: "🔲"
+status: "✅"
 summary: >-
   Let <?catalog?> accept `..` segments in glob
   patterns as long as the resolved pattern stays
@@ -77,53 +77,57 @@ Have both directives call the shared helper.
 
 ## Tasks
 
-1. Add a failing test to the catalog
-   [`rule_test.go`](../internal/rules/catalog/rule_test.go)
-   for a `../sibling/*.md` glob whose resolved
-   path stays inside the project root.
-2. Add a failing test for a glob whose resolve
+1. [x] Add a test for a `../sibling/*.md` glob
+   whose resolved path stays inside the project
+   root (`TestCatalog_DotDotGlobStaysInsideRoot`).
+2. [x] Add a test for a glob whose resolve
    escapes the project root and expects the new
-   diagnostic message.
-3. Replace the `containsDotDot` reject with a
-   project-root containment check, sharing the
-   resolve helper with MDS021.
-4. Update the
+   diagnostic message
+   (`TestCatalog_DotDotGlobEscapesRoot`).
+3. [x] Replace the `containsDotDot` reject with a
+   project-root containment check; the shared
+   resolve helper now lives in
+   `internal/globpath` as `ResolveAgainstRoot`
+   (alongside `ContainsDotDotSegment`). Catalog
+   defers there; the MDS021 helper can adopt it
+   in a follow-up since its current path-escape
+   check predates the helper.
+4. [x] Update the
    [MDS019 catalog README](../internal/rules/MDS019-catalog/README.md)
    to describe the new behavior and the
-   escapes-root diagnostic; align wording with
-   the MDS021 README.
-5. Add a `good/` fixture exercising the new
-   accept case and a `bad/` fixture exercising
-   the new reject case under
+   escapes-root and missing-root diagnostics.
+5. [x] Add `good/dotdot.md` and `bad/dotdot.md`
+   under
    [`internal/rules/MDS019-catalog/`](../internal/rules/MDS019-catalog/).
-6. Once the new behavior lands, replace the
-   hand-maintained reference-style link defs in
-   the
+   The integration runner now pins
+   `f.RootFS = f.FS` for MDS019 fixtures so
+   "..": resolution mirrors a real project.
+6. [x] Add the `<?catalog?>` block in the
    [solid-architecture SKILL.md](../.claude/skills/solid-architecture/SKILL.md)
-   with a `<?catalog?>` block targeting
+   targeting
    `../../../docs/development/architecture/*.md`
-   using the `{slug}` front-matter field
-   already present on each canonical doc, then
-   run `mdsmith fix .` to regenerate.
+   with `row: "[{slug}]: {filename}"`. Running
+   `mdsmith fix` regenerates the five
+   slug-labeled link defs.
 
 ## Acceptance Criteria
 
-- [ ] Tests in
+- [x] Tests in
       `internal/rules/catalog/rule_test.go`
       cover the accept and reject cases and
       pass.
-- [ ] `internal/rules/MDS019-catalog/README.md`
+- [x] `internal/rules/MDS019-catalog/README.md`
       documents the new behavior and lists the
       escapes-root diagnostic.
-- [ ] `internal/rules/MDS019-catalog/good/`
+- [x] `internal/rules/MDS019-catalog/good/`
       and `bad/` each contain a new fixture for
       the new behavior.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no
       issues.
-- [ ] `mdsmith check .` passes.
-- [ ] `.claude/skills/solid-architecture/SKILL.md`
+- [x] `mdsmith check .` passes.
+- [x] `.claude/skills/solid-architecture/SKILL.md`
       uses a `<?catalog?>` block for the
       architecture link defs and renders the
-      same five reference-style labels as
-      before.
+      five reference-style slug labels
+      (`audit`, `cross`, `go`, `hub`, `ts`).


### PR DESCRIPTION
## Summary

Implement plan [153](plan/153_catalog-dotdot-globs.md) to allow `..` segments in catalog glob patterns as long as the resolved pattern stays within the project root. This mirrors how the `<?include?>` directive resolves its `file` parameter.

## Key Changes

- **Refactored glob resolution logic** (`resolveGlobFS`): Replaced the simple `containsDotDot` rejection with a project-root-aware resolution that:
  - Detects `..` segments in patterns via new `dotDotInPatterns` helper
  - Resolves patterns against the project root when `..` is present or `source-dir` is set
  - Returns a new `globResolution` struct encapsulating the resolved fs.FS, rewritten patterns, and metadata
  - Rejects patterns that escape the project root with `"glob escapes project root"` diagnostic
  - Rejects `..` patterns when project root is not configured with `"glob contains ".." but project root is not configured"` diagnostic

- **Extracted shared path-resolution helpers** to `internal/globpath`:
  - `ResolveAgainstRoot`: Resolves a path against a base directory and detects escape attempts
  - `ContainsDotDotSegment`: Checks for `..` path elements (replaces removed `containsDotDot`)

- **Simplified gitignore handling** (`resolveGitignoreMatcher`): Removed source-dir-specific logic since glob resolution now handles path rewriting centrally

- **Updated test expectations**: Changed error messages from `".." path traversal` to the new diagnostic messages; added tests for both accept case (`../sibling/*.md` staying inside root) and reject case (`../../secret/*.md` escaping root)

- **Updated documentation** (MDS019 README): Clarified that `..` is allowed within project root, documented the new diagnostics, and aligned wording with MDS021 include behavior

- **Added integration fixtures**: `good/dotdot.md` and `bad/dotdot.md` under `internal/rules/MDS019-catalog/` to exercise the new behavior

- **Updated integration test runner** (`attachFixtureFS`): Pins `RootFS = FS` for MDS019 fixtures so `..` resolution works in tests

- **Regenerated SKILL.md**: Added `<?catalog?>` block targeting architecture docs with `../../../docs/development/architecture/*.md` glob, replacing hand-maintained reference-style link definitions

## Implementation Details

The refactored `resolveGlobFS` now returns a `globResolution` struct that encapsulates:
- The filesystem to glob against (file's own FS or project RootFS)
- Rewritten include/exclude patterns (root-relative when using RootFS)
- Gitignore base directory for filtering
- Metadata for converting matched paths back to display paths

This centralizes path resolution logic and makes it easier to reason about when patterns are rewritten and which filesystem is used. The `displayPath` method handles converting root-relative matches back to paths relative to the catalog-owning file's directory.

https://claude.ai/code/session_019Dtf2aTG3WvQuGLfEjmGy7