### PR TITLE
Add numeric sort mode for catalog directive

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,7 +4,7 @@
 glob:
   - "plan/*.md"
   - "!plan/proto.md"
-sort: id
+sort: numeric:id
 header: |
 
   | ID  | Status | Model | Title |
@@ -16,6 +16,24 @@ footer: |
 
 | ID  | Status | Model  | Title                                                                                                                     |
 |-----|--------|--------|---------------------------------------------------------------------------------------------------------------------------|
+| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
+| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
+| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
+| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
+| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
+| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
+| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
+| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
+| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
+| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
+| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
+| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
+| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
+| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
 | 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                   |
 | 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                |
 | 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                                            |
@@ -54,7 +72,7 @@ footer: |
 | 140 | ✅     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
 | 142 | 🔲     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |
 | 143 | ✅     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                              |
-| 144 | 🔲     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                              |
+| 144 | ✅     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                              |
 | 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                      |
 | 146 | ✅     | opus   | [Schema engine — sources, scope tree, per-scope rules](plan/146_inline-schema-in-kinds.md)                                |
 | 147 | 🔲     | opus   | [Actionable schema diagnostics for MDS020](plan/147_actionable-schema-diagnostics.md)                                     |
@@ -66,22 +84,4 @@ footer: |
 | 153 | 🔲     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
 | 154 | 🔲     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
 | 155 | 🔲     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
-| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
-| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
-| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
-| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
-| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
-| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
-| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
-| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
-| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
-| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
-| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
-| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
-| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
-| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
-| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
-| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
-| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
-| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
 <?/catalog?>

--- a/docs/guides/directives/generating-content.md
+++ b/docs/guides/directives/generating-content.md
@@ -109,10 +109,30 @@ gitignore: "false"
 
 ### Sorting
 
-Format: `[-]KEY`. A `-` prefix means descending.
-Built-in keys: `path`, `filename`. Any other key is
-looked up in front matter. Missing values sort as
-empty string.
+Format: `[-][numeric:]KEY`. A `-` prefix means
+descending. Built-in keys: `path`, `filename`. Any
+other key is looked up in front matter. Missing
+values sort as empty string.
+
+The optional `numeric:` prefix opts a field into
+integer comparison. Use it for ID-shaped fields
+where mixed 2-digit and 3-digit values would
+otherwise collate lexicographically (`100` before
+`52`):
+
+```markdown
+<?catalog
+glob: "plan/*.md"
+sort: numeric:id
+row: "| {id} | [{title}]({filename}) |"
+?>
+```
+
+If any matched file's value fails to parse as an
+integer, the directive falls back to string
+compare for all entries — no error is raised, so a
+field that is sometimes numeric stays usable.
+`-numeric:id` reverses the order.
 
 ### What happens when no files match
 

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -18,6 +19,11 @@ import (
 	"github.com/jeduden/mdsmith/internal/rules/tableformat"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
+
+// numericSortPrefix marks a sort spec whose key value should be
+// parsed as an integer before comparison. The prefix follows any
+// leading "-" descending marker — `-numeric:id`, not `numeric:-id`.
+const numericSortPrefix = "numeric:"
 
 func init() {
 	rule.Register(&Rule{})
@@ -233,6 +239,7 @@ func validateSort(filePath string, line int, sortVal string) []lint.Diagnostic {
 			`generated section directive has empty "sort" value`)}
 	}
 	key := strings.TrimPrefix(sortVal, "-")
+	key = strings.TrimPrefix(key, numericSortPrefix)
 	if key == "" {
 		return []lint.Diagnostic{makeDiag(filePath, line,
 			fmt.Sprintf("generated section directive has invalid sort value %q", sortVal))}
@@ -308,7 +315,7 @@ func buildCatalogEntries(
 	globFS, prefix := resolveGlobFS(f, params)
 	files := resolveGlobMatchesFrom(globFS, f, params)
 
-	sortKey, descending := parseSort(params)
+	sortKey, descending, numeric := parseSort(params)
 	_, hasRow := params["row"]
 	needFM := hasRow || (sortKey != "path" && sortKey != "filename")
 
@@ -334,7 +341,7 @@ func buildCatalogEntries(
 		entries = append(entries, fileEntry{fields: fields})
 	}
 
-	sortEntries(entries, sortKey, descending)
+	sortEntries(entries, sortKey, descending, numeric)
 	return entries, diags
 }
 
@@ -484,26 +491,53 @@ func renderCatalogContent(
 	return renderTemplate(params, entries, cols)
 }
 
-// parseSort parses the sort value from params, returning the key and direction.
-func parseSort(params map[string]string) (key string, descending bool) {
+// parseSort parses the sort value from params, returning the key,
+// direction, and whether the value should be compared numerically.
+// The `numeric:` prefix opts into integer comparison and may follow
+// the descending `-` marker, e.g. `-numeric:id`.
+func parseSort(params map[string]string) (key string, descending, numeric bool) {
 	sortVal, ok := params["sort"]
 	if !ok || sortVal == "" {
-		return "path", false
+		return "path", false, false
 	}
 
 	if strings.HasPrefix(sortVal, "-") {
-		return sortVal[1:], true
+		descending = true
+		sortVal = sortVal[1:]
 	}
-	return sortVal, false
+	if strings.HasPrefix(sortVal, numericSortPrefix) {
+		numeric = true
+		sortVal = sortVal[len(numericSortPrefix):]
+	}
+	return sortVal, descending, numeric
 }
 
-// sortEntries sorts file entries by the given key.
-func sortEntries(entries []fileEntry, key string, descending bool) {
-	sort.SliceStable(entries, func(i, j int) bool {
-		vi := sortValue(entries[i], key)
-		vj := sortValue(entries[j], key)
+// sortEntries sorts file entries by the given key. When numeric is
+// true and every entry's value parses as an int, entries are ordered
+// by the integer value; any parse failure falls back to string
+// compare for the whole sort so behavior stays predictable when one
+// entry's field is missing or malformed.
+func sortEntries(entries []fileEntry, key string, descending, numeric bool) {
+	useInts := numeric && allParseAsInt(entries, key)
 
-		cmp := strings.Compare(strings.ToLower(vi), strings.ToLower(vj))
+	sort.SliceStable(entries, func(i, j int) bool {
+		var cmp int
+		if useInts {
+			// Re-parse from the current entry rather than a fixed
+			// index — SliceStable reorders the slice during sort.
+			ni, _ := parseSortInt(entries[i], key)
+			nj, _ := parseSortInt(entries[j], key)
+			switch {
+			case ni < nj:
+				cmp = -1
+			case ni > nj:
+				cmp = 1
+			}
+		} else {
+			vi := sortValue(entries[i], key)
+			vj := sortValue(entries[j], key)
+			cmp = strings.Compare(strings.ToLower(vi), strings.ToLower(vj))
+		}
 		if cmp == 0 {
 			// Tiebreaker: path ascending, case-insensitive.
 			pi := strings.ToLower(fieldinterp.Stringify(entries[i].fields["filename"]))
@@ -516,6 +550,24 @@ func sortEntries(entries []fileEntry, key string, descending bool) {
 		}
 		return cmp < 0
 	})
+}
+
+// allParseAsInt reports whether every entry's value for key parses
+// as an integer. Used to decide whether numeric mode applies before
+// sorting begins.
+func allParseAsInt(entries []fileEntry, key string) bool {
+	for _, e := range entries {
+		if _, err := parseSortInt(e, key); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// parseSortInt extracts the entry's sort key as a trimmed string
+// and parses it via strconv.Atoi.
+func parseSortInt(entry fileEntry, key string) (int, error) {
+	return strconv.Atoi(strings.TrimSpace(sortValue(entry, key)))
 }
 
 // sortValue returns the sort value for a file entry given a key.

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -1538,6 +1538,53 @@ func TestSort_FrontMatterKey(t *testing.T) {
 	})
 }
 
+func TestSort_Numeric(t *testing.T) {
+	mixedDigitIDs := fstest.MapFS{
+		"52.md":  {Data: []byte("---\nid: 52\ntitle: Fifty-two\n---\n")},
+		"100.md": {Data: []byte("---\nid: 100\ntitle: One hundred\n---\n")},
+		"132.md": {Data: []byte("---\nid: 132\ntitle: One thirty-two\n---\n")},
+	}
+	runSortScenarios(t, []sortScenario{
+		{
+			name: "numeric ascending interleaves 2- and 3-digit ids",
+			src: "<?catalog\nglob: \"*.md\"\n" +
+				"sort: numeric:id\nrow: \"- {id} [{title}]({filename})\"\n?>\n" +
+				"- 52 [Fifty-two](52.md)\n" +
+				"- 100 [One hundred](100.md)\n" +
+				"- 132 [One thirty-two](132.md)\n<?/catalog?>\n",
+			fs: mixedDigitIDs,
+		},
+		{
+			name: "numeric descending reverses",
+			src: "<?catalog\nglob: \"*.md\"\n" +
+				"sort: -numeric:id\nrow: \"- {id} [{title}]({filename})\"\n?>\n" +
+				"- 132 [One thirty-two](132.md)\n" +
+				"- 100 [One hundred](100.md)\n" +
+				"- 52 [Fifty-two](52.md)\n<?/catalog?>\n",
+			fs: mixedDigitIDs,
+		},
+		{
+			name: "numeric on non-numeric field falls back to string compare",
+			src: "<?catalog\nglob: \"*.md\"\n" +
+				"sort: numeric:title\nrow: \"- [{title}]({filename})\"\n?>\n" +
+				"- [Alpha](b.md)\n- [Zulu](a.md)\n<?/catalog?>\n",
+			fs: fstest.MapFS{
+				"a.md": {Data: []byte("---\ntitle: Zulu\n---\n")},
+				"b.md": {Data: []byte("---\ntitle: Alpha\n---\n")},
+			},
+		},
+		{
+			name: "existing lexicographic sort: id still puts 100 before 52 (regression)",
+			src: "<?catalog\nglob: \"*.md\"\n" +
+				"sort: id\nrow: \"- {id} [{title}]({filename})\"\n?>\n" +
+				"- 100 [One hundred](100.md)\n" +
+				"- 132 [One thirty-two](132.md)\n" +
+				"- 52 [Fifty-two](52.md)\n<?/catalog?>\n",
+			fs: mixedDigitIDs,
+		},
+	})
+}
+
 func TestSort_TiebreakerAndCaseInsensitive(t *testing.T) {
 	runSortScenarios(t, []sortScenario{
 		{
@@ -1568,30 +1615,44 @@ func TestSort_TiebreakerAndCaseInsensitive(t *testing.T) {
 // =====================================================================
 
 func TestParseSort_Default(t *testing.T) {
-	key, desc := parseSort(map[string]string{})
-	if key != "path" || desc {
-		t.Errorf("expected (path, false), got (%s, %v)", key, desc)
+	key, desc, num := parseSort(map[string]string{})
+	if key != "path" || desc || num {
+		t.Errorf("expected (path, false, false), got (%s, %v, %v)", key, desc, num)
 	}
 }
 
 func TestParseSort_Ascending(t *testing.T) {
-	key, desc := parseSort(map[string]string{"sort": "title"})
-	if key != "title" || desc {
-		t.Errorf("expected (title, false), got (%s, %v)", key, desc)
+	key, desc, num := parseSort(map[string]string{"sort": "title"})
+	if key != "title" || desc || num {
+		t.Errorf("expected (title, false, false), got (%s, %v, %v)", key, desc, num)
 	}
 }
 
 func TestParseSort_Descending(t *testing.T) {
-	key, desc := parseSort(map[string]string{"sort": "-title"})
-	if key != "title" || !desc {
-		t.Errorf("expected (title, true), got (%s, %v)", key, desc)
+	key, desc, num := parseSort(map[string]string{"sort": "-title"})
+	if key != "title" || !desc || num {
+		t.Errorf("expected (title, true, false), got (%s, %v, %v)", key, desc, num)
 	}
 }
 
 func TestParseSort_EmptyValue(t *testing.T) {
-	key, desc := parseSort(map[string]string{"sort": ""})
-	if key != "path" || desc {
-		t.Errorf("expected (path, false) for empty, got (%s, %v)", key, desc)
+	key, desc, num := parseSort(map[string]string{"sort": ""})
+	if key != "path" || desc || num {
+		t.Errorf("expected (path, false, false) for empty, got (%s, %v, %v)", key, desc, num)
+	}
+}
+
+func TestParseSort_NumericAscending(t *testing.T) {
+	key, desc, num := parseSort(map[string]string{"sort": "numeric:id"})
+	if key != "id" || desc || !num {
+		t.Errorf("expected (id, false, true), got (%s, %v, %v)", key, desc, num)
+	}
+}
+
+func TestParseSort_NumericDescending(t *testing.T) {
+	key, desc, num := parseSort(map[string]string{"sort": "-numeric:id"})
+	if key != "id" || !desc || !num {
+		t.Errorf("expected (id, true, true), got (%s, %v, %v)", key, desc, num)
 	}
 }
 
@@ -1778,7 +1839,7 @@ func TestSortEntries_PathAscending(t *testing.T) {
 		{fields: map[string]any{"filename": "a.md"}},
 		{fields: map[string]any{"filename": "b.md"}},
 	}
-	sortEntries(entries, "path", false)
+	sortEntries(entries, "path", false, false)
 	if entries[0].fields["filename"] != "a.md" {
 		t.Errorf("expected first entry a.md, got %s", entries[0].fields["filename"])
 	}
@@ -1793,7 +1854,7 @@ func TestSortEntries_PathDescending(t *testing.T) {
 		{fields: map[string]any{"filename": "c.md"}},
 		{fields: map[string]any{"filename": "b.md"}},
 	}
-	sortEntries(entries, "path", true)
+	sortEntries(entries, "path", true, false)
 	if entries[0].fields["filename"] != "c.md" {
 		t.Errorf("expected first entry c.md, got %s", entries[0].fields["filename"])
 	}
@@ -1807,7 +1868,7 @@ func TestSortEntries_FrontMatterKey(t *testing.T) {
 		{fields: map[string]any{"filename": "a.md", "title": "Zulu"}},
 		{fields: map[string]any{"filename": "b.md", "title": "Alpha"}},
 	}
-	sortEntries(entries, "title", false)
+	sortEntries(entries, "title", false, false)
 	if entries[0].fields["title"] != "Alpha" {
 		t.Errorf("expected Alpha first, got %s", entries[0].fields["title"])
 	}
@@ -1818,7 +1879,7 @@ func TestSortEntries_Tiebreaker(t *testing.T) {
 		{fields: map[string]any{"filename": "b.md", "title": "Same"}},
 		{fields: map[string]any{"filename": "a.md", "title": "Same"}},
 	}
-	sortEntries(entries, "title", false)
+	sortEntries(entries, "title", false, false)
 	if entries[0].fields["filename"] != "a.md" {
 		t.Errorf("expected a.md first (tiebreaker), got %s", entries[0].fields["filename"])
 	}
@@ -1830,7 +1891,7 @@ func TestSortEntries_TiebreakerDescending(t *testing.T) {
 		{fields: map[string]any{"filename": "b.md", "title": "Same"}},
 		{fields: map[string]any{"filename": "a.md", "title": "Same"}},
 	}
-	sortEntries(entries, "title", true)
+	sortEntries(entries, "title", true, false)
 	if entries[0].fields["filename"] != "a.md" {
 		t.Errorf("expected a.md first (tiebreaker ascending), got %s", entries[0].fields["filename"])
 	}
@@ -1841,9 +1902,80 @@ func TestSortEntries_FilenameDescending(t *testing.T) {
 		{fields: map[string]any{"filename": "a/alpha.md"}},
 		{fields: map[string]any{"filename": "z/zulu.md"}},
 	}
-	sortEntries(entries, "filename", true)
+	sortEntries(entries, "filename", true, false)
 	if entries[0].fields["filename"] != "z/zulu.md" {
 		t.Errorf("expected z/zulu.md first (filename descending), got %s", entries[0].fields["filename"])
+	}
+}
+
+func TestSortEntries_NumericAscending(t *testing.T) {
+	entries := []fileEntry{
+		{fields: map[string]any{"filename": "132.md", "id": 132}},
+		{fields: map[string]any{"filename": "52.md", "id": 52}},
+		{fields: map[string]any{"filename": "100.md", "id": 100}},
+	}
+	sortEntries(entries, "id", false, true)
+	want := []string{"52.md", "100.md", "132.md"}
+	for i, w := range want {
+		if got := entries[i].fields["filename"]; got != w {
+			t.Errorf("entries[%d]: want filename %s, got %v", i, w, got)
+		}
+	}
+}
+
+func TestSortEntries_NumericDescending(t *testing.T) {
+	entries := []fileEntry{
+		{fields: map[string]any{"filename": "52.md", "id": 52}},
+		{fields: map[string]any{"filename": "132.md", "id": 132}},
+		{fields: map[string]any{"filename": "100.md", "id": 100}},
+	}
+	sortEntries(entries, "id", true, true)
+	want := []string{"132.md", "100.md", "52.md"}
+	for i, w := range want {
+		if got := entries[i].fields["filename"]; got != w {
+			t.Errorf("entries[%d]: want filename %s, got %v", i, w, got)
+		}
+	}
+}
+
+func TestSortEntries_NumericFallsBackOnNonInt(t *testing.T) {
+	// One entry's id is non-numeric; fall back to lexicographic compare.
+	entries := []fileEntry{
+		{fields: map[string]any{"filename": "b.md", "id": "alpha"}},
+		{fields: map[string]any{"filename": "a.md", "id": 10}},
+		{fields: map[string]any{"filename": "c.md", "id": 2}},
+	}
+	sortEntries(entries, "id", false, true)
+	// String compare on "10", "2", "alpha" => "10", "2", "alpha".
+	want := []string{"a.md", "c.md", "b.md"}
+	for i, w := range want {
+		if got := entries[i].fields["filename"]; got != w {
+			t.Errorf("entries[%d]: want filename %s, got %v", i, w, got)
+		}
+	}
+}
+
+func TestSortEntries_NumericWithIntegerStrings(t *testing.T) {
+	// Front-matter integers parsed by YAML as strings still sort numerically.
+	entries := []fileEntry{
+		{fields: map[string]any{"filename": "p100.md", "id": "100"}},
+		{fields: map[string]any{"filename": "p52.md", "id": "52"}},
+	}
+	sortEntries(entries, "id", false, true)
+	if entries[0].fields["filename"] != "p52.md" {
+		t.Errorf("expected p52.md first, got %v", entries[0].fields["filename"])
+	}
+}
+
+func TestSortEntries_NumericTiebreaker(t *testing.T) {
+	// Same numeric id → fall back to path ascending tiebreaker.
+	entries := []fileEntry{
+		{fields: map[string]any{"filename": "b.md", "id": 121}},
+		{fields: map[string]any{"filename": "a.md", "id": 121}},
+	}
+	sortEntries(entries, "id", false, true)
+	if entries[0].fields["filename"] != "a.md" {
+		t.Errorf("expected a.md first (path tiebreaker), got %v", entries[0].fields["filename"])
 	}
 }
 

--- a/plan/144_catalog-numeric-sort.md
+++ b/plan/144_catalog-numeric-sort.md
@@ -1,7 +1,7 @@
 ---
 id: 144
 title: Numeric sort for `<?catalog?>` directive
-status: "🔲"
+status: "✅"
 model: sonnet
 depends-on: []
 summary: >-
@@ -133,23 +133,23 @@ except for the row order.
 
 ## Acceptance Criteria
 
-- [ ] `sort: numeric:id` orders entries by the
+- [x] `sort: numeric:id` orders entries by the
       integer value of the `id` field; mixed
       2-digit and 3-digit IDs interleave
       correctly (52 before 100, 100 before
       132).
-- [ ] `-numeric:id` reverses the order.
-- [ ] A non-parseable value with `numeric:`
+- [x] `-numeric:id` reverses the order.
+- [x] A non-parseable value with `numeric:`
       falls back to string compare; no error.
-- [ ] PLAN.md's catalog uses
+- [x] PLAN.md's catalog uses
       `sort: numeric:id` and renders 52 before
       100.
-- [ ] The
+- [x] The
       [generating content](../docs/guides/directives/generating-content.md)
       guide documents the mode with one
       example.
-- [ ] Existing `sort: id` behavior is
+- [x] Existing `sort: id` behavior is
       unchanged (regression test).
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues.


### PR DESCRIPTION
Implements numeric sorting for the `<?catalog?>` directive, allowing ID-shaped fields with mixed digit counts to sort correctly (52 before 100 before 132) instead of lexicographically.

## Summary

Adds a `numeric:` prefix to the sort parameter that opts fields into integer comparison. When enabled, values are parsed as integers before comparison; if any value fails to parse, the directive falls back to string comparison for all entries without raising an error.

## Key Changes

- **parseSort()** now returns a third value (`numeric bool`) and parses the `numeric:` prefix from sort specs (e.g., `numeric:id` or `-numeric:id`)
- **sortEntries()** accepts a `numeric` parameter and uses integer comparison when all values parse as ints; falls back to string compare if any parse fails
- Added helper functions:
  - `allParseAsInt()` — checks if all entries' values for a key parse as integers
  - `parseSortInt()` — extracts and parses a sort value via `strconv.Atoi`
- Updated validation in `validateSort()` to strip the `numeric:` prefix before checking key validity
- Updated all call sites to pass the new `numeric` parameter

## Tests & Documentation

- Added `TestSort_Numeric()` with four scenarios: ascending, descending, fallback to string compare, and regression test for existing lexicographic behavior
- Added `TestParseSort_NumericAscending()` and `TestParseSort_NumericDescending()` to verify parsing
- Added five new `TestSortEntries_Numeric*()` tests covering ascending, descending, non-int fallback, string integers, and tiebreaker behavior
- Updated all existing sort tests to pass `false` for the new `numeric` parameter
- Updated `docs/guides/directives/generating-content.md` with usage example and fallback behavior documentation
- Updated `PLAN.md` to use `sort: numeric:id` and marked plan item 144 as complete (✅)
- Updated `plan/144_catalog-numeric-sort.md` status to complete with all acceptance criteria checked

## Implementation Notes

- The `numeric:` prefix is parsed after the descending `-` marker, so `-numeric:id` is valid but `numeric:-id` is not
- Tiebreaker for equal numeric values remains path ascending (case-insensitive), consistent with string sort behavior
- No error is raised when numeric mode encounters non-parseable values; the entire sort silently falls back to string comparison for predictability

https://claude.ai/code/session_01JpY7sfVD2bzsuVa6vJRa13