### PR TITLE
arch-fix: move Flavor and convention types to internal/convention

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,7 +4,7 @@
 glob:
   - "plan/*.md"
   - "!plan/proto.md"
-sort: id
+sort: numeric:id
 header: |
 
   | ID  | Status | Model | Title |
@@ -16,6 +16,24 @@ footer: |
 
 | ID  | Status | Model  | Title                                                                                                                     |
 |-----|--------|--------|---------------------------------------------------------------------------------------------------------------------------|
+| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
+| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
+| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
+| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
+| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
+| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
+| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
+| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
+| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
+| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
+| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
+| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
+| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
+| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
 | 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                   |
 | 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                |
 | 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                                            |
@@ -66,22 +84,4 @@ footer: |
 | 153 | 🔲     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
 | 154 | 🔲     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
 | 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
-| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
-| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
-| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
-| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
-| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
-| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
-| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
-| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
-| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
-| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
-| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
-| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
-| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
-| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
-| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
-| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
-| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
-| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,7 +4,7 @@
 glob:
   - "plan/*.md"
   - "!plan/proto.md"
-sort: numeric:id
+sort: id
 header: |
 
   | ID  | Status | Model | Title |
@@ -16,24 +16,6 @@ footer: |
 
 | ID  | Status | Model  | Title                                                                                                                     |
 |-----|--------|--------|---------------------------------------------------------------------------------------------------------------------------|
-| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
-| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
-| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
-| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
-| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
-| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
-| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
-| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
-| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
-| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
-| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
-| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
-| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
-| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
-| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
-| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
-| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
-| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
 | 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                   |
 | 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                |
 | 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                                            |
@@ -83,5 +65,23 @@ footer: |
 | 153 | 🔲     | sonnet | [Catalog directive — accept `..` globs within project root](plan/153_catalog-dotdot-globs.md)                             |
 | 153 | 🔲     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
 | 154 | 🔲     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
-| 155 | 🔲     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
+| 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
+| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
+| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
+| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
+| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
+| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
+| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
+| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
+| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
+| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
+| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
+| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
+| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
+| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
+| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -58,33 +58,29 @@ helper packages (e.g.
 donor and consumer rules. Scheduled by
 [plan/154](../../plan/154_arch-fix-rule-helper-extraction.md).
 
+### resolved by plan/155
+
 Config imports a rule package.
 
 [`internal/config/convention.go`](../../internal/config/convention.go)
-imports `internal/rules/markdownflavor`.
+imported `internal/rules/markdownflavor`
+to use `Convention`, `RulePreset`,
+`ParseFlavor`, `Lookup`, and
+`ConventionNames`.
 
-The imported symbols are:
+[plan/155](../../plan/155_arch-fix-convention-config-ownership.md)
+hoisted those shapes into a new
+[internal/convention package](../../internal/convention/convention.go).
+The markdownflavor rule now imports
+`internal/convention` for the `Flavor`
+type. The config package depends on
+`internal/convention`, not on a rule.
 
-- `Convention`
-- `RulePreset`
-- `ParseFlavor`
-- `Lookup`
-- `ConventionNames`
-
-This violates dependency direction. The
-[layering map](architecture/index.md)
-puts rules at the lowest layer. Config
-is a mid-layer.
-
-Severity: blocker.
-
-Fix by hoisting the convention and flavor
-data shapes into a layer config can own.
-A new `internal/convention` package
-works. The markdownflavor rule then
-consumes those types instead of defining
-them. Scheduled by
-[plan/155](../../plan/155_arch-fix-convention-config-ownership.md).
+`TestConfigDoesNotImportRules` guards
+the new direction. It parses every
+non-test file under `internal/config/`.
+It fails if any import path contains
+`internal/rules/`.
 
 ### tax
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,8 +53,8 @@ type Config struct {
 	// values: "portable", "github", "plain". User-defined
 	// conventions may also be referenced here after being declared
 	// under the top-level `conventions:` key. Empty means no
-	// convention. See internal/rules/markdownflavor/conventions.go
-	// and docs/reference/conventions.md.
+	// convention. See internal/convention/convention.go and
+	// docs/reference/conventions.md.
 	Convention string `yaml:"convention,omitempty"`
 
 	// Conventions holds user-defined convention bundles declared

--- a/internal/config/convention.go
+++ b/internal/config/convention.go
@@ -6,8 +6,8 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/jeduden/mdsmith/internal/convention"
 	"github.com/jeduden/mdsmith/internal/rule"
-	"github.com/jeduden/mdsmith/internal/rules/markdownflavor"
 )
 
 // applyConvention reads the top-level Convention selector from the
@@ -42,7 +42,7 @@ func applyConvention(cfg *Config) error {
 	if cfg.Convention == "" {
 		return nil
 	}
-	convention, err := markdownflavor.Lookup(cfg.Convention, userMap)
+	conv, err := convention.Lookup(cfg.Convention, userMap)
 	if err != nil {
 		return fmt.Errorf("convention: %w", err)
 	}
@@ -53,16 +53,16 @@ func applyConvention(cfg *Config) error {
 		if err != nil {
 			return err
 		}
-		if userFlavor != "" && userFlavor != convention.Flavor.String() {
+		if userFlavor != "" && userFlavor != conv.Flavor.String() {
 			return fmt.Errorf(
 				"rules.markdown-flavor: convention %q requires flavor %q, but flavor is set to %q",
-				convention.Name, convention.Flavor, userFlavor,
+				conv.Name, conv.Flavor, userFlavor,
 			)
 		}
 	}
 
-	preset := make(map[string]RuleCfg, len(convention.Rules))
-	for ruleName, p := range convention.Rules {
+	preset := make(map[string]RuleCfg, len(conv.Rules))
+	for ruleName, p := range conv.Rules {
 		preset[ruleName] = RuleCfg{
 			Enabled:  p.Enabled,
 			Settings: cloneSettings(p.Settings),
@@ -103,7 +103,7 @@ func copyConventionPreset(p map[string]RuleCfg) map[string]RuleCfg {
 }
 
 // buildUserConventionMap validates every entry in cfg.Conventions and
-// returns them as a map[string]markdownflavor.Convention ready for
+// returns them as a map[string]convention.Convention ready for
 // Lookup. Validation checks:
 //   - The name must not be a reserved built-in name.
 //   - The flavor must be a recognised flavor string.
@@ -112,17 +112,17 @@ func copyConventionPreset(p map[string]RuleCfg) map[string]RuleCfg {
 //     check (called on a cloned instance so the registry is unaffected).
 //
 // Returns nil when cfg.Conventions is empty.
-func buildUserConventionMap(cfg *Config) (map[string]markdownflavor.Convention, error) {
+func buildUserConventionMap(cfg *Config) (map[string]convention.Convention, error) {
 	if len(cfg.Conventions) == 0 {
 		return nil, nil
 	}
 
-	reserved := make(map[string]bool, len(markdownflavor.ConventionNames()))
-	for _, name := range markdownflavor.ConventionNames() {
+	reserved := make(map[string]bool, len(convention.Names()))
+	for _, name := range convention.Names() {
 		reserved[name] = true
 	}
 
-	result := make(map[string]markdownflavor.Convention, len(cfg.Conventions))
+	result := make(map[string]convention.Convention, len(cfg.Conventions))
 	for name, uc := range cfg.Conventions {
 		if reserved[name] {
 			return nil, fmt.Errorf(
@@ -131,7 +131,7 @@ func buildUserConventionMap(cfg *Config) (map[string]markdownflavor.Convention, 
 			)
 		}
 
-		fl, ok := markdownflavor.ParseFlavor(uc.Flavor)
+		fl, ok := convention.ParseFlavor(uc.Flavor)
 		if !ok {
 			return nil, fmt.Errorf(
 				"convention %q: unknown flavor %q",
@@ -139,7 +139,7 @@ func buildUserConventionMap(cfg *Config) (map[string]markdownflavor.Convention, 
 			)
 		}
 
-		rules := make(map[string]markdownflavor.RulePreset, len(uc.Rules))
+		rules := make(map[string]convention.RulePreset, len(uc.Rules))
 		for ruleName, rc := range uc.Rules {
 			r := rule.ByName(ruleName)
 			if r == nil {
@@ -153,13 +153,13 @@ func buildUserConventionMap(cfg *Config) (map[string]markdownflavor.Convention, 
 					return nil, err
 				}
 			}
-			rules[ruleName] = markdownflavor.RulePreset{
+			rules[ruleName] = convention.RulePreset{
 				Enabled:  rc.Enabled,
 				Settings: cloneSettings(rc.Settings),
 			}
 		}
 
-		result[name] = markdownflavor.Convention{
+		result[name] = convention.Convention{
 			Name:   name,
 			Flavor: fl,
 			Rules:  rules,

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"go/parser"
+	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +18,30 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/markdownflavor"
 	_ "github.com/jeduden/mdsmith/internal/rules/nohardtabs"
 )
+
+// TestConfigDoesNotImportRules guards the dependency direction
+// recorded in docs/development/architecture/index.md: rules sit at
+// the lowest layer, config sits above them, so config must not
+// import any rule package. The convention and flavor data types
+// live in internal/convention so this constraint can be enforced.
+// Test files are exempt because they need to register rules to
+// exercise rule.ByName lookups.
+func TestConfigDoesNotImportRules(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, parser.ImportsOnly)
+	require.NoError(t, err)
+	for _, pkg := range pkgs {
+		for fname, file := range pkg.Files {
+			for _, imp := range file.Imports {
+				path := strings.Trim(imp.Path.Value, `"`)
+				assert.NotContains(t, path, "internal/rules/",
+					"%s imports a rule package: %s", fname, path)
+			}
+		}
+	}
+}
 
 func TestApplyConvention_NoConventionSet_NoOp(t *testing.T) {
 	cfg := &Config{

--- a/internal/convention/convention.go
+++ b/internal/convention/convention.go
@@ -1,4 +1,4 @@
-package markdownflavor
+package convention
 
 import (
 	"fmt"
@@ -32,8 +32,8 @@ type Convention struct {
 
 // RulePreset is a convention's preset for a single rule. It mirrors
 // the shape of config.RuleCfg without depending on the config
-// package, so the markdownflavor package can declare convention
-// tables without the import cycle that would otherwise result.
+// package, so this package can declare convention tables without the
+// import cycle that would otherwise result.
 type RulePreset struct {
 	Enabled  bool
 	Settings map[string]any
@@ -176,7 +176,7 @@ func Lookup(name string, userConventions map[string]Convention) (Convention, err
 	}
 	c, ok := conventions[name]
 	if !ok {
-		names := conventionNamesWithUser(userConventions)
+		names := namesWithUser(userConventions)
 		return Convention{}, fmt.Errorf(
 			"unknown convention %q (valid: %s)",
 			name, strings.Join(names, ", "),
@@ -185,10 +185,10 @@ func Lookup(name string, userConventions map[string]Convention) (Convention, err
 	return cloneConvention(c), nil
 }
 
-// conventionNamesWithUser returns a sorted list of all available
-// convention names — built-in names plus user-defined names.
-func conventionNamesWithUser(userConventions map[string]Convention) []string {
-	names := ConventionNames()
+// namesWithUser returns a sorted list of all available convention
+// names — built-in names plus user-defined names.
+func namesWithUser(userConventions map[string]Convention) []string {
+	names := Names()
 	for name := range userConventions {
 		names = append(names, name)
 	}
@@ -259,9 +259,8 @@ func cloneValue(v any) any {
 	}
 }
 
-// ConventionNames returns the sorted list of built-in convention
-// names.
-func ConventionNames() []string {
+// Names returns the sorted list of built-in convention names.
+func Names() []string {
 	names := make([]string, 0, len(conventions))
 	for k := range conventions {
 		names = append(names, k)

--- a/internal/convention/convention_test.go
+++ b/internal/convention/convention_test.go
@@ -1,4 +1,4 @@
-package markdownflavor
+package convention
 
 import (
 	"sort"
@@ -177,9 +177,9 @@ func TestLookup_UnknownListsUserAndBuiltin(t *testing.T) {
 	assert.Contains(t, err.Error(), "portable", "error must list built-in name")
 }
 
-func TestConventionNamesSorted(t *testing.T) {
-	names := ConventionNames()
+func TestNamesSorted(t *testing.T) {
+	names := Names()
 	assert.True(t, sort.StringsAreSorted(names),
-		"ConventionNames should return a sorted slice; got %v", names)
+		"Names should return a sorted slice; got %v", names)
 	assert.ElementsMatch(t, []string{"github", "plain", "portable"}, names)
 }

--- a/internal/convention/flavor.go
+++ b/internal/convention/flavor.go
@@ -45,8 +45,12 @@ const (
 )
 
 // IsValid reports whether f names a recognised flavor. The zero
-// value is reserved for "unparsed/unset" and returns false.
-func (f Flavor) IsValid() bool { return f != flavorInvalid }
+// value (reserved for "unparsed/unset") and any out-of-range integer
+// cast to Flavor both return false. Implemented in terms of String
+// so the two stay in lock-step: every recognised flavor has a name,
+// and adding a new constant only requires updating the switch in
+// String.
+func (f Flavor) IsValid() bool { return f.String() != "" }
 
 // String returns the canonical lowercase name of the flavor.
 func (f Flavor) String() string {

--- a/internal/convention/flavor.go
+++ b/internal/convention/flavor.go
@@ -1,0 +1,97 @@
+// Package convention owns the convention and flavor data shapes
+// independent of any rule. A convention pairs a Markdown flavor with
+// a table of rule presets; the config loader consults this package
+// at load time so a top-level `convention:` selection becomes a base
+// layer beneath the user's own rule config. Rule packages (notably
+// internal/rules/markdownflavor) consume these data shapes — they do
+// not own them — which keeps internal/config from importing a rule.
+package convention
+
+// Flavor identifies a target Markdown flavor.
+type Flavor int
+
+// Flavor constants. The zero value is intentionally invalid so that
+// unparsed settings are caught.
+const (
+	flavorInvalid Flavor = iota
+	FlavorCommonMark
+	FlavorGFM
+	FlavorGoldmark
+	// FlavorAny accepts every tracked feature. Useful when the
+	// document is destined for an unknown or permissive renderer and
+	// the user wants to disable flavor reporting without disabling
+	// the rule.
+	FlavorAny
+	// FlavorPandoc is Pandoc's default markdown dialect. Accepts
+	// GFM's four features plus footnotes, definition lists, heading
+	// IDs, superscript, subscript, math block, and inline math;
+	// rejects abbreviations (a non-default Pandoc extension).
+	FlavorPandoc
+	// FlavorPHPExtra is PHP Markdown Extra. Accepts tables,
+	// footnotes, definition lists, heading IDs, and abbreviations;
+	// rejects GFM's task lists, strikethrough, bare-URL autolinks,
+	// and every math / sub/superscript feature.
+	FlavorPHPExtra
+	// FlavorMultiMarkdown extends PHP Markdown Extra with math
+	// block and inline math. Like PHP Extra, rejects GFM task lists,
+	// strikethrough, bare-URL autolinks, and sub/superscript.
+	FlavorMultiMarkdown
+	// FlavorMyST is the MyST flavor used by the Sphinx documentation
+	// toolchain. Accepts tables, strikethrough, footnotes,
+	// definition lists, heading IDs, math block, and inline math;
+	// rejects GFM task lists, bare-URL autolinks, sub/superscript,
+	// and abbreviations.
+	FlavorMyST
+)
+
+// IsValid reports whether f names a recognised flavor. The zero
+// value is reserved for "unparsed/unset" and returns false.
+func (f Flavor) IsValid() bool { return f != flavorInvalid }
+
+// String returns the canonical lowercase name of the flavor.
+func (f Flavor) String() string {
+	switch f {
+	case FlavorCommonMark:
+		return "commonmark"
+	case FlavorGFM:
+		return "gfm"
+	case FlavorGoldmark:
+		return "goldmark"
+	case FlavorAny:
+		return "any"
+	case FlavorPandoc:
+		return "pandoc"
+	case FlavorPHPExtra:
+		return "phpextra"
+	case FlavorMultiMarkdown:
+		return "multimarkdown"
+	case FlavorMyST:
+		return "myst"
+	}
+	return ""
+}
+
+// ParseFlavor converts a config string into a Flavor. The match is
+// case-sensitive to reject typos like "GFM" that would otherwise
+// silently validate against the wrong flavor.
+func ParseFlavor(s string) (Flavor, bool) {
+	switch s {
+	case "commonmark":
+		return FlavorCommonMark, true
+	case "gfm":
+		return FlavorGFM, true
+	case "goldmark":
+		return FlavorGoldmark, true
+	case "any":
+		return FlavorAny, true
+	case "pandoc":
+		return FlavorPandoc, true
+	case "phpextra":
+		return FlavorPHPExtra, true
+	case "multimarkdown":
+		return FlavorMultiMarkdown, true
+	case "myst":
+		return FlavorMyST, true
+	}
+	return 0, false
+}

--- a/internal/convention/flavor_test.go
+++ b/internal/convention/flavor_test.go
@@ -1,0 +1,60 @@
+package convention
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFlavor(t *testing.T) {
+	tests := []struct {
+		in   string
+		want Flavor
+		ok   bool
+	}{
+		{"commonmark", FlavorCommonMark, true},
+		{"gfm", FlavorGFM, true},
+		{"goldmark", FlavorGoldmark, true},
+		{"any", FlavorAny, true},
+		{"pandoc", FlavorPandoc, true},
+		{"phpextra", FlavorPHPExtra, true},
+		{"multimarkdown", FlavorMultiMarkdown, true},
+		{"myst", FlavorMyST, true},
+		{"GFM", 0, false},
+		{"", 0, false},
+		{"markdown", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := ParseFlavor(tc.in)
+			assert.Equal(t, tc.ok, ok)
+			if tc.ok {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestFlavorString(t *testing.T) {
+	assert.Equal(t, "commonmark", FlavorCommonMark.String())
+	assert.Equal(t, "gfm", FlavorGFM.String())
+	assert.Equal(t, "goldmark", FlavorGoldmark.String())
+	assert.Equal(t, "any", FlavorAny.String())
+	assert.Equal(t, "pandoc", FlavorPandoc.String())
+	assert.Equal(t, "phpextra", FlavorPHPExtra.String())
+	assert.Equal(t, "multimarkdown", FlavorMultiMarkdown.String())
+	assert.Equal(t, "myst", FlavorMyST.String())
+}
+
+func TestFlavorStringUnknownIsEmpty(t *testing.T) {
+	var zero Flavor
+	assert.Equal(t, "", zero.String())
+	assert.Equal(t, "", Flavor(999).String())
+}
+
+func TestFlavorIsValid(t *testing.T) {
+	var zero Flavor
+	assert.False(t, zero.IsValid(), "zero value is invalid")
+	assert.True(t, FlavorCommonMark.IsValid())
+	assert.True(t, FlavorAny.IsValid())
+}

--- a/internal/convention/flavor_test.go
+++ b/internal/convention/flavor_test.go
@@ -55,6 +55,8 @@ func TestFlavorStringUnknownIsEmpty(t *testing.T) {
 func TestFlavorIsValid(t *testing.T) {
 	var zero Flavor
 	assert.False(t, zero.IsValid(), "zero value is invalid")
+	assert.False(t, Flavor(999).IsValid(),
+		"out-of-range integer cast to Flavor is invalid")
 	assert.True(t, FlavorCommonMark.IsValid())
 	assert.True(t, FlavorAny.IsValid())
 }

--- a/internal/rules/markdownflavor/features.go
+++ b/internal/rules/markdownflavor/features.go
@@ -1,93 +1,12 @@
 // Package markdownflavor implements MDS034, which validates Markdown
 // against a declared target flavor (commonmark, gfm, goldmark,
 // pandoc, phpextra, multimarkdown, myst, or any) and flags syntax
-// the target renderer will not understand.
+// the target renderer will not understand. The Flavor type itself,
+// along with the convention bundles that select it, lives in
+// internal/convention; this package consumes those data shapes.
 package markdownflavor
 
-// Flavor identifies a target Markdown flavor.
-type Flavor int
-
-// Flavor constants. The zero value is intentionally invalid so that
-// unparsed settings are caught.
-const (
-	flavorInvalid Flavor = iota
-	FlavorCommonMark
-	FlavorGFM
-	FlavorGoldmark
-	// FlavorAny accepts every tracked feature. Useful when the
-	// document is destined for an unknown or permissive renderer and
-	// the user wants to disable flavor reporting without disabling
-	// the rule.
-	FlavorAny
-	// FlavorPandoc is Pandoc's default markdown dialect. Accepts
-	// GFM's four features plus footnotes, definition lists, heading
-	// IDs, superscript, subscript, math block, and inline math;
-	// rejects abbreviations (a non-default Pandoc extension).
-	FlavorPandoc
-	// FlavorPHPExtra is PHP Markdown Extra. Accepts tables,
-	// footnotes, definition lists, heading IDs, and abbreviations;
-	// rejects GFM's task lists, strikethrough, bare-URL autolinks,
-	// and every math / sub/superscript feature.
-	FlavorPHPExtra
-	// FlavorMultiMarkdown extends PHP Markdown Extra with math
-	// block and inline math. Like PHP Extra, rejects GFM task lists,
-	// strikethrough, bare-URL autolinks, and sub/superscript.
-	FlavorMultiMarkdown
-	// FlavorMyST is the MyST flavor used by the Sphinx documentation
-	// toolchain. Accepts tables, strikethrough, footnotes,
-	// definition lists, heading IDs, math block, and inline math;
-	// rejects GFM task lists, bare-URL autolinks, sub/superscript,
-	// and abbreviations.
-	FlavorMyST
-)
-
-// String returns the canonical lowercase name of the flavor.
-func (f Flavor) String() string {
-	switch f {
-	case FlavorCommonMark:
-		return "commonmark"
-	case FlavorGFM:
-		return "gfm"
-	case FlavorGoldmark:
-		return "goldmark"
-	case FlavorAny:
-		return "any"
-	case FlavorPandoc:
-		return "pandoc"
-	case FlavorPHPExtra:
-		return "phpextra"
-	case FlavorMultiMarkdown:
-		return "multimarkdown"
-	case FlavorMyST:
-		return "myst"
-	}
-	return ""
-}
-
-// ParseFlavor converts a config string into a Flavor. The match is
-// case-sensitive to reject typos like "GFM" that would otherwise
-// silently validate against the wrong flavor.
-func ParseFlavor(s string) (Flavor, bool) {
-	switch s {
-	case "commonmark":
-		return FlavorCommonMark, true
-	case "gfm":
-		return FlavorGFM, true
-	case "goldmark":
-		return FlavorGoldmark, true
-	case "any":
-		return FlavorAny, true
-	case "pandoc":
-		return FlavorPandoc, true
-	case "phpextra":
-		return FlavorPHPExtra, true
-	case "multimarkdown":
-		return FlavorMultiMarkdown, true
-	case "myst":
-		return FlavorMyST, true
-	}
-	return 0, false
-}
+import "github.com/jeduden/mdsmith/internal/convention"
 
 // Feature identifies one Markdown syntax feature whose support varies
 // across flavors.
@@ -167,23 +86,23 @@ func (f Feature) Name() string {
 // lists, strikethrough, and bare-URL autolinks. The goldmark flavor
 // further adds heading IDs. Pandoc, PHP Markdown Extra, MultiMarkdown,
 // and MyST each pick a different combination of the optional
-// features; FlavorAny is handled specially in Supports.
-var support = map[Flavor]map[Feature]bool{
-	FlavorGFM: {
+// features; convention.FlavorAny is handled specially in Supports.
+var support = map[convention.Flavor]map[Feature]bool{
+	convention.FlavorGFM: {
 		FeatureTables:           true,
 		FeatureTaskLists:        true,
 		FeatureStrikethrough:    true,
 		FeatureBareURLAutolinks: true,
 		FeatureGitHubAlerts:     true,
 	},
-	FlavorGoldmark: {
+	convention.FlavorGoldmark: {
 		FeatureTables:           true,
 		FeatureTaskLists:        true,
 		FeatureStrikethrough:    true,
 		FeatureBareURLAutolinks: true,
 		FeatureHeadingIDs:       true,
 	},
-	FlavorPandoc: {
+	convention.FlavorPandoc: {
 		FeatureTables:           true,
 		FeatureTaskLists:        true,
 		FeatureStrikethrough:    true,
@@ -196,14 +115,14 @@ var support = map[Flavor]map[Feature]bool{
 		FeatureMathBlock:        true,
 		FeatureMathInline:       true,
 	},
-	FlavorPHPExtra: {
+	convention.FlavorPHPExtra: {
 		FeatureTables:          true,
 		FeatureFootnotes:       true,
 		FeatureDefinitionLists: true,
 		FeatureHeadingIDs:      true,
 		FeatureAbbreviations:   true,
 	},
-	FlavorMultiMarkdown: {
+	convention.FlavorMultiMarkdown: {
 		FeatureTables:          true,
 		FeatureFootnotes:       true,
 		FeatureDefinitionLists: true,
@@ -212,7 +131,7 @@ var support = map[Flavor]map[Feature]bool{
 		FeatureMathBlock:       true,
 		FeatureMathInline:      true,
 	},
-	FlavorMyST: {
+	convention.FlavorMyST: {
 		FeatureTables:          true,
 		FeatureStrikethrough:   true,
 		FeatureFootnotes:       true,
@@ -224,10 +143,10 @@ var support = map[Flavor]map[Feature]bool{
 }
 
 // Supports reports whether the flavor accepts the given feature.
-// FlavorAny accepts every feature; other flavors consult the
-// support table.
-func (f Flavor) Supports(feat Feature) bool {
-	if f == FlavorAny {
+// convention.FlavorAny accepts every feature; other flavors consult
+// the support table.
+func Supports(f convention.Flavor, feat Feature) bool {
+	if f == convention.FlavorAny {
 		return true
 	}
 	return support[f][feat]

--- a/internal/rules/markdownflavor/features_test.go
+++ b/internal/rules/markdownflavor/features_test.go
@@ -5,68 +5,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/convention"
 )
-
-func TestParseFlavor(t *testing.T) {
-	tests := []struct {
-		in   string
-		want Flavor
-		ok   bool
-	}{
-		{"commonmark", FlavorCommonMark, true},
-		{"gfm", FlavorGFM, true},
-		{"goldmark", FlavorGoldmark, true},
-		{"any", FlavorAny, true},
-		{"pandoc", FlavorPandoc, true},
-		{"phpextra", FlavorPHPExtra, true},
-		{"multimarkdown", FlavorMultiMarkdown, true},
-		{"myst", FlavorMyST, true},
-		{"GFM", 0, false},
-		{"", 0, false},
-		{"markdown", 0, false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.in, func(t *testing.T) {
-			got, ok := ParseFlavor(tc.in)
-			assert.Equal(t, tc.ok, ok)
-			if tc.ok {
-				assert.Equal(t, tc.want, got)
-			}
-		})
-	}
-}
-
-func TestFlavorString(t *testing.T) {
-	assert.Equal(t, "commonmark", FlavorCommonMark.String())
-	assert.Equal(t, "gfm", FlavorGFM.String())
-	assert.Equal(t, "goldmark", FlavorGoldmark.String())
-	assert.Equal(t, "any", FlavorAny.String())
-	assert.Equal(t, "pandoc", FlavorPandoc.String())
-	assert.Equal(t, "phpextra", FlavorPHPExtra.String())
-	assert.Equal(t, "multimarkdown", FlavorMultiMarkdown.String())
-	assert.Equal(t, "myst", FlavorMyST.String())
-}
 
 // assertSupports checks every feature in the supported set is
 // accepted by flavor and every feature not in that set is rejected.
-func assertSupports(t *testing.T, f Flavor, supported ...Feature) {
+func assertSupports(t *testing.T, f convention.Flavor, supported ...Feature) {
 	t.Helper()
 	want := map[Feature]bool{}
 	for _, feat := range supported {
 		want[feat] = true
 	}
 	for _, feat := range AllFeatures() {
-		got := f.Supports(feat)
+		got := Supports(f, feat)
 		assert.Equal(t, want[feat], got,
 			"flavor %s feature %s: want=%v got=%v",
 			f.String(), feat.Name(), want[feat], got)
 	}
-}
-
-func TestFlavorStringUnknownIsEmpty(t *testing.T) {
-	var zero Flavor
-	assert.Equal(t, "", zero.String())
-	assert.Equal(t, "", Flavor(999).String())
 }
 
 func TestFeatureNameUnknownIsEmpty(t *testing.T) {
@@ -74,27 +30,27 @@ func TestFeatureNameUnknownIsEmpty(t *testing.T) {
 }
 
 func TestFeatureSupportCommonMark(t *testing.T) {
-	assertSupports(t, FlavorCommonMark)
+	assertSupports(t, convention.FlavorCommonMark)
 }
 
 func TestFeatureSupportGFM(t *testing.T) {
-	assertSupports(t, FlavorGFM,
+	assertSupports(t, convention.FlavorGFM,
 		FeatureTables, FeatureTaskLists, FeatureStrikethrough,
 		FeatureBareURLAutolinks, FeatureGitHubAlerts)
 }
 
 func TestFeatureSupportGoldmark(t *testing.T) {
-	assertSupports(t, FlavorGoldmark,
+	assertSupports(t, convention.FlavorGoldmark,
 		FeatureTables, FeatureTaskLists, FeatureStrikethrough,
 		FeatureBareURLAutolinks, FeatureHeadingIDs)
 }
 
 func TestFeatureSupportAny(t *testing.T) {
-	assertSupports(t, FlavorAny, AllFeatures()...)
+	assertSupports(t, convention.FlavorAny, AllFeatures()...)
 }
 
 func TestFeatureSupportPandoc(t *testing.T) {
-	assertSupports(t, FlavorPandoc,
+	assertSupports(t, convention.FlavorPandoc,
 		FeatureTables, FeatureTaskLists, FeatureStrikethrough,
 		FeatureBareURLAutolinks, FeatureFootnotes, FeatureDefinitionLists,
 		FeatureHeadingIDs, FeatureSuperscript, FeatureSubscript,
@@ -102,20 +58,20 @@ func TestFeatureSupportPandoc(t *testing.T) {
 }
 
 func TestFeatureSupportPHPExtra(t *testing.T) {
-	assertSupports(t, FlavorPHPExtra,
+	assertSupports(t, convention.FlavorPHPExtra,
 		FeatureTables, FeatureFootnotes, FeatureDefinitionLists,
 		FeatureHeadingIDs, FeatureAbbreviations)
 }
 
 func TestFeatureSupportMultiMarkdown(t *testing.T) {
-	assertSupports(t, FlavorMultiMarkdown,
+	assertSupports(t, convention.FlavorMultiMarkdown,
 		FeatureTables, FeatureFootnotes, FeatureDefinitionLists,
 		FeatureHeadingIDs, FeatureAbbreviations,
 		FeatureMathBlock, FeatureMathInline)
 }
 
 func TestFeatureSupportMyST(t *testing.T) {
-	assertSupports(t, FlavorMyST,
+	assertSupports(t, convention.FlavorMyST,
 		FeatureTables, FeatureStrikethrough, FeatureFootnotes,
 		FeatureDefinitionLists, FeatureHeadingIDs,
 		FeatureMathBlock, FeatureMathInline)

--- a/internal/rules/markdownflavor/fix.go
+++ b/internal/rules/markdownflavor/fix.go
@@ -38,7 +38,7 @@ func (r *Rule) fixByteRangeFeatures(f *lint.File) []byte {
 		})
 	}
 
-	if !r.Flavor.Supports(FeatureBareURLAutolinks) {
+	if !Supports(r.Flavor, FeatureBareURLAutolinks) {
 		for _, fin := range detectBareURLs(f) {
 			edits = append(edits, wrapBareURL(f.Source, fin))
 		}
@@ -52,13 +52,14 @@ func (r *Rule) fixByteRangeFeatures(f *lint.File) []byte {
 
 // needsAnyDualFix reports whether any dual-parser fixable feature is
 // unsupported by the configured flavor. Skips the dual re-parse for
-// flavors that accept every dual feature (e.g. FlavorAny, Pandoc).
+// flavors that accept every dual feature (e.g. convention.FlavorAny,
+// convention.FlavorPandoc).
 func (r *Rule) needsAnyDualFix() bool {
 	for _, feat := range []Feature{
 		FeatureHeadingIDs, FeatureStrikethrough, FeatureTaskLists,
 		FeatureSuperscript, FeatureSubscript,
 	} {
-		if !r.Flavor.Supports(feat) {
+		if !Supports(r.Flavor, feat) {
 			return true
 		}
 	}
@@ -71,27 +72,27 @@ func (r *Rule) needsAnyDualFix() bool {
 func (r *Rule) dualNodeEdits(f *lint.File, n ast.Node) []edit {
 	switch node := n.(type) {
 	case *ast.Heading:
-		if r.Flavor.Supports(FeatureHeadingIDs) {
+		if Supports(r.Flavor, FeatureHeadingIDs) {
 			return nil
 		}
 		return headingIDEdits(f, node)
 	case *extast.Strikethrough:
-		if r.Flavor.Supports(FeatureStrikethrough) {
+		if Supports(r.Flavor, FeatureStrikethrough) {
 			return nil
 		}
 		return delimiterPairEdits(node, len("~~"))
 	case *extast.TaskCheckBox:
-		if r.Flavor.Supports(FeatureTaskLists) {
+		if Supports(r.Flavor, FeatureTaskLists) {
 			return nil
 		}
 		return taskCheckBoxEdits(f, node)
 	case *ext.SuperscriptNode:
-		if r.Flavor.Supports(FeatureSuperscript) {
+		if Supports(r.Flavor, FeatureSuperscript) {
 			return nil
 		}
 		return delimiterPairEdits(node, len("^"))
 	case *ext.SubscriptNode:
-		if r.Flavor.Supports(FeatureSubscript) {
+		if Supports(r.Flavor, FeatureSubscript) {
 			return nil
 		}
 		return delimiterPairEdits(node, len("~"))

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yuin/goldmark/ast"
 
+	"github.com/jeduden/mdsmith/internal/convention"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 )
@@ -22,7 +23,7 @@ func init() {
 // other rules' settings) is handled at config load — see
 // internal/config/convention.go.
 type Rule struct {
-	Flavor Flavor
+	Flavor convention.Flavor
 }
 
 // ID implements rule.Rule.
@@ -47,10 +48,10 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 				return fmt.Errorf("markdown-flavor: flavor must be a string, got %T", v)
 			}
 			if s == "" {
-				r.Flavor = flavorInvalid
+				r.Flavor = convention.Flavor(0)
 				continue
 			}
-			fl, ok := ParseFlavor(s)
+			fl, ok := convention.ParseFlavor(s)
 			if !ok {
 				return fmt.Errorf(
 					"markdown-flavor: unknown flavor %q (expected one of: "+
@@ -75,14 +76,14 @@ func (r *Rule) DefaultSettings() map[string]any {
 
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	if r.Flavor == flavorInvalid {
+	if !r.Flavor.IsValid() {
 		return nil
 	}
 	// Only ask detectors about features this flavor rejects. Detectors
 	// like the bare-URL regex scan then skip large files entirely when
 	// the flavor (gfm, goldmark) accepts them.
 	unsupported := func(feat Feature) bool {
-		return !r.Flavor.Supports(feat)
+		return !Supports(r.Flavor, feat)
 	}
 	var diags []lint.Diagnostic
 	for _, found := range DetectFiltered(f, unsupported) {
@@ -109,11 +110,11 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 // alerts are stripped the byte-range pass re-parses the rewritten
 // source so AST offsets match the new bytes.
 func (r *Rule) Fix(f *lint.File) []byte {
-	if r.Flavor == flavorInvalid {
+	if !r.Flavor.IsValid() {
 		return f.Source
 	}
 	current := f
-	if !r.Flavor.Supports(FeatureGitHubAlerts) {
+	if !Supports(r.Flavor, FeatureGitHubAlerts) {
 		stripped := r.fixGitHubAlerts(f)
 		if !bytes.Equal(stripped, f.Source) {
 			reparsed, err := lint.NewFile(f.Path, stripped)

--- a/plan/112_flavor-profiles.md
+++ b/plan/112_flavor-profiles.md
@@ -179,7 +179,7 @@ land in follow-up plans, `plain` gains them and
 diverges from `portable`.
 
 Conventions are declared in the
-[markdownflavor package](../internal/rules/markdownflavor/conventions.go)
+[convention package](../internal/convention/convention.go)
 as a table: name → flavor + rule preset map.
 
 ### How preset application works
@@ -248,7 +248,7 @@ existing ApplySettings handles it normally.
 
 1. [x] Add a Convention type and built-in table in
    the
-   [markdownflavor package](../internal/rules/markdownflavor/conventions.go)
+   [convention package](../internal/convention/convention.go)
    with a `Lookup(name string) (Convention, error)`
    helper.
 2. [x] Add a top-level `Convention string` field on

--- a/plan/155_arch-fix-convention-config-ownership.md
+++ b/plan/155_arch-fix-convention-config-ownership.md
@@ -1,7 +1,7 @@
 ---
 id: 155
 title: 'arch-fix: relocate convention types out of markdownflavor'
-status: "🔲"
+status: "✅"
 summary: >-
   Hoist Convention, RulePreset and ParseFlavor
   out of the markdownflavor rule into a layer
@@ -73,26 +73,26 @@ inverted.
 
 ## Acceptance Criteria
 
-- [ ] `internal/convention/` exists.
+- [x] `internal/convention/` exists.
   Its package comment states it owns
   convention and flavor data shapes
   independent of any rule. (SRP)
-- [ ] Search reports no
+- [x] Search reports no
   `internal/rules/` imports under
   `internal/config/`. (DIP /
   dependency direction)
-- [ ] `internal/rules/markdownflavor`
+- [x] `internal/rules/markdownflavor`
   still compiles. It continues to
   expose its `rule.Rule` impl. It
   consumes the new package for data,
   not the other way round.
-- [ ] All tests pass:
+- [x] All tests pass:
   `go test ./...`.
-- [ ] `go tool golangci-lint run`
+- [x] `go tool golangci-lint run`
   reports no issues.
-- [ ] `mdsmith check .` passes after
+- [x] `mdsmith check .` passes after
   the refactor.
-- [ ] The audit entry for this
+- [x] The audit entry for this
   blocker moves to a "Resolved by
   plan/155" section in
   [the audit log](../docs/development/architecture-audit.md).


### PR DESCRIPTION
Resolves plan/155 by hoisting the `Flavor` type and convention data shapes out of the markdownflavor rule into a new `internal/convention` package. This fixes the dependency direction violation where `internal/config` was importing from `internal/rules`.

## Summary

The convention and flavor data types are now owned by `internal/convention`, a layer that `internal/config` can safely depend on without violating the layering constraint that rules sit below config. The markdownflavor rule continues to implement its rule.Rule interface but now consumes the `Flavor` type from the convention package instead of defining it.

## Key Changes

- **New package**: `internal/convention/` owns `Flavor`, `Convention`, `RulePreset`, `ParseFlavor()`, `Lookup()`, and `Names()` — all convention and flavor data shapes independent of any rule
- **Moved types**: `Flavor` constants and methods (`String()`, `ParseFlavor()`, `IsValid()`) relocated from markdownflavor to convention
- **Moved conventions table**: Built-in convention definitions and lookup logic moved to `internal/convention/convention.go`
- **Updated markdownflavor**: Now imports `internal/convention` for the `Flavor` type; changed `Supports()` from a receiver method to a package function taking `convention.Flavor` as a parameter
- **Updated config**: Now imports `internal/convention` instead of `internal/rules/markdownflavor`
- **New test guard**: `TestConfigDoesNotImportRules` in `internal/config/convention_test.go` parses all non-test files under `internal/config/` and fails if any import path contains `internal/rules/`, enforcing the corrected dependency direction
- **Documentation**: Updated architecture audit to mark plan/155 as resolved; updated references in development guides

## Implementation Details

- The `Flavor.Supports()` receiver method became a package-level `Supports(f convention.Flavor, feat Feature) bool` function in markdownflavor to avoid circular imports
- Added `Flavor.IsValid()` method to convention package to check if a flavor is valid (non-zero)
- All tests updated to use `convention.Flavor*` constants and the new `Supports()` function signature
- Convention tests moved from markdownflavor to the convention package

https://claude.ai/code/session_01SEJY8ZzkXWkinVyUYMiiKB