### PR TITLE
Implement actionable schema diagnostics for MDS020 (plan 147)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -75,7 +75,7 @@ footer: |
 | 144 | ✅     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                              |
 | 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                      |
 | 146 | ✅     | opus   | [Schema engine — sources, scope tree, per-scope rules](plan/146_inline-schema-in-kinds.md)                                |
-| 147 | 🔲     | opus   | [Actionable schema diagnostics for MDS020](plan/147_actionable-schema-diagnostics.md)                                     |
+| 147 | ✅     | opus   | [Actionable schema diagnostics for MDS020](plan/147_actionable-schema-diagnostics.md)                                     |
 | 148 | ✅     | sonnet | [Named field-type shortcuts for inline schemas](plan/148_named-field-type-shortcuts.md)                                   |
 | 149 | ✅     | opus   | [Section content schema for non-heading AST nodes](plan/149_section-content-schema.md)                                    |
 | 151 | ✅     | opus   | [LSP rename for headings and link-reference labels](plan/151_lsp-rename.md)                                               |

--- a/internal/engine/kinds_test.go
+++ b/internal/engine/kinds_test.go
@@ -261,7 +261,7 @@ func TestKindPathPattern_MismatchEmitsMDS020(t *testing.T) {
 	require.Len(t, result.Diagnostics, 1)
 	d := result.Diagnostics[0]
 	assert.Equal(t, "MDS020", d.RuleID)
-	assert.Contains(t, d.Message, `filename: got "plan/early-draft.md"`)
+	assert.Contains(t, d.Message, `path: got "plan/early-draft.md"`)
 	assert.Contains(t, d.Message, "kinds[plan] / path-pattern")
 }
 

--- a/internal/lint/frontmatter.go
+++ b/internal/lint/frontmatter.go
@@ -11,17 +11,36 @@ import (
 // from the beginning of source. It returns the front matter block
 // (including delimiters) and the remaining content. If no front
 // matter is found, prefix is nil and content equals source.
+//
+// The closing fence is recognised only at the start of a line:
+// either as the first bytes after the opening fence (empty FM
+// body) or preceded by a newline. A naive bytes.Index search
+// would otherwise truncate the front matter early when a YAML
+// block-scalar value legitimately contains the literal `---\n`
+// sequence (e.g. a `notes: |` value whose body includes an
+// em-dash row).
 func StripFrontMatter(source []byte) (prefix, content []byte) {
 	delim := []byte("---\n")
 	if !bytes.HasPrefix(source, delim) {
 		return nil, source
 	}
 	rest := source[len(delim):]
-	idx := bytes.Index(rest, delim)
+	// Empty front matter: closing fence sits right after the
+	// opening fence, no body lines between them.
+	if bytes.HasPrefix(rest, delim) {
+		end := len(delim) + len(delim)
+		return source[:end], source[end:]
+	}
+	// Non-empty body: the closing fence is preceded by the
+	// last body line's "\n". Search for "\n---\n" so a
+	// fence-shaped substring inside a block scalar (e.g.
+	// "  ---\n") cannot be mistaken for the actual fence.
+	needle := []byte("\n---\n")
+	idx := bytes.Index(rest, needle)
 	if idx < 0 {
 		return nil, source
 	}
-	end := len(delim) + idx + len(delim)
+	end := len(delim) + idx + len(needle)
 	return source[:end], source[end:]
 }
 

--- a/internal/lint/frontmatter_test.go
+++ b/internal/lint/frontmatter_test.go
@@ -61,6 +61,33 @@ func TestStripFrontMatter(t *testing.T) {
 	}
 }
 
+// TestStripFrontMatter_BlockScalarFenceSequence regresses a
+// Copilot review observation: a YAML block-scalar value (e.g.
+// `notes: |`) can contain the literal `---\n` sequence inside
+// its body. The closing fence must still be matched at the
+// start of a line, not at the first `---\n` substring anywhere
+// in the YAML body.
+func TestStripFrontMatter_BlockScalarFenceSequence(t *testing.T) {
+	src := "---\n" +
+		"id: 1\n" +
+		"notes: |\n" +
+		"  ---\n" +
+		"  more text\n" +
+		"status: open\n" +
+		"---\n" +
+		"# Body\n"
+	wantPrefix := "---\n" +
+		"id: 1\n" +
+		"notes: |\n" +
+		"  ---\n" +
+		"  more text\n" +
+		"status: open\n" +
+		"---\n"
+	prefix, content := StripFrontMatter([]byte(src))
+	assert.Equal(t, wantPrefix, string(prefix))
+	assert.Equal(t, "# Body\n", string(content))
+}
+
 func TestParseFrontMatterKinds(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -128,12 +128,9 @@ kinds:
 
 Section keys:
 
-- `heading:` — string (literal text), `null` (the
-  preamble: content before any heading), or mapping
-  (typed match — today only `{unlisted: true}` for a
-  slot). The level for string headings comes from
-  depth in the tree (root sections are H2; nested
-  sections are H3, then H4, …).
+- `heading:` — string (literal), `null` (preamble), or
+  `{unlisted: true}` (positional slot). Level comes from
+  depth (root sections are H2).
 - `required:` — defaults to `true`. Preamble entries
   typically set `required: false`.
 - `aliases:` — alternate heading texts. Not allowed
@@ -161,34 +158,23 @@ Section keys:
   for the entry shape and the per-kind fields.
   Rejected on slot or `?` wildcard scopes.
 
-A slot entry (`heading: {unlisted: true}`) absorbs
-zero or more unlisted sections at that position.
-Surrounding listed sections still keep their order.
-Out-of-order detection still claims a heading whose
-text matches a later listed scope, so the slot only
-absorbs truly-unlisted sections.
-
-Slots are positional-only: the parser rejects
-`aliases:`, `sections:`, `rules:`, `closed:`, and
-`required:` on a slot scope. The preamble
-(`heading: null`) accepts `required:`, `closed:`,
-and `rules:` for its line range; it rejects
-`aliases:` and `sections:`.
-
-The document's H1 is reserved for the title and is
-validated by `first-line-heading`; inline schemas
-constrain H2 and below.
+A slot (`heading: {unlisted: true}`) absorbs zero or more
+unlisted sections at its position. Out-of-order detection
+still claims a heading whose text matches a later listed
+scope, so the slot only absorbs truly-unlisted sections.
+Slots reject `aliases:`, `sections:`, `rules:`, `closed:`,
+and `required:`. The preamble (`heading: null`) accepts
+`required:`, `closed:`, and `rules:` but rejects
+`aliases:` and `sections:`. H1 is owned by
+`first-line-heading`; inline schemas constrain H2 and below.
 
 ### Cross-references
 
 A `cross-references:` block names text patterns whose
-matches must resolve to a real heading in the document.
-Each entry walks the document's inline text once and
-fills numeric (`{n}`, `{1}`, `{2}`, …) or named
-captures from the regex into the `must-match:` template;
-the result is slugified and looked up in the heading
-slug set. Unresolved references produce a diagnostic at
-the match's source line.
+matches must resolve to a real heading. Each entry fills
+numeric (`{n}`, `{1}`, …) or named captures from the
+regex into `must-match:`; the result is slugified and
+looked up in the heading slug set.
 
 ```yaml
 schema:
@@ -198,21 +184,17 @@ schema:
       skip-lines-matching: "^> "
 ```
 
-`skip-lines-matching:` is a regex; raw source lines
-that match it are exempt from the resolution check.
-The intended use is blockquoted stale text and version-
-history notes that mention old step numbers.
+`skip-lines-matching:` (regex) exempts blockquoted stale
+text and version-history notes from the check.
 
 ### Acronyms
 
-An `acronyms:` block flags all-caps tokens (length
-2-6, leading letter, alphanumeric) on their first use
-inside a configured scope when they appear without a
-parenthesised expansion. `known-safe:` lists tokens
-allowed without expansion; `scope:` restricts the
-check to sections whose heading text matches one of
-the listed names. Omitting `scope:` applies the check
-document-wide. First-use state is per-scope.
+An `acronyms:` block flags all-caps tokens (length 2-6,
+leading letter, alphanumeric) on first use inside a
+configured scope when they appear without a parenthesised
+expansion. `known-safe:` lists exempt tokens; `scope:`
+restricts the check to matching sections (omit it for
+document-wide). First-use state is per-scope.
 
 ```yaml
 schema:
@@ -224,11 +206,10 @@ schema:
 ### Index side-output
 
 An `index:` block asks `mdsmith fix` to write a JSON
-side-output next to the source file. `mdsmith check`
-does not write the file (read-only contract). The
-output path is resolved relative to the document's
-directory; absolute paths and `..` traversal are
-rejected.
+side-output next to the source file. `mdsmith check` is
+read-only (no write). Output paths are resolved relative
+to the document's directory; absolute paths and `..`
+traversal are rejected.
 
 ```yaml
 schema:
@@ -242,11 +223,7 @@ schema:
 - `step-map` — `{section-slug: [child-slugs]}`
 - `cross-ref-graph` — `{ref-text: target-slug}`
 - `word-counts` — `{section-slug: int}`
-- `headings` — flat list of
-  `{level, text, slug, line}`
-
-The set is closed so downstream tooling can parse the
-file without a schema reference.
+- `headings` — flat list of `{level, text, slug, line}`
 
 ## Config
 
@@ -314,23 +291,50 @@ Describe the goal here.
 
 ## Diagnostics
 
-| Condition            | Message                                                                       |
-|----------------------|-------------------------------------------------------------------------------|
-| section missing      | missing required section "## Settings"                                        |
-| wrong level          | heading level mismatch for "Settings": expected h2, got h3                    |
-| extra section        | unexpected section "## Extra" (expected "## Settings")                        |
-| out of order         | section "## Tasks" out of order: expected after "## Goal"                     |
-| heading sync         | heading does not match frontmatter: expected "MDS001" (from id), got "MDS002" |
-| body sync            | body does not match frontmatter field "description": expected "..."           |
-| front matter schema  | front matter does not satisfy schema CUE constraints: ...                     |
-| filename mismatch    | filename "foo.md" does not match required pattern "[0-9]*_*.md"               |
-| misplaced require    | <?require?> is only recognized in schema files; this directive has no effect  |
-| schema include loop  | cyclic include: a.md -> b.md -> a.md                                          |
-| content missing      | missing required content "code-block lang=yaml" inside ## Examples            |
-| content unexpected   | unexpected content "table" inside ## Examples (expected "paragraph")          |
-| content out of order | content "table" out of order: expected after "code-block lang=yaml"           |
-| code block lang      | code block language "json" does not match required "yaml"                     |
-| table columns        | table headers [Key Value] do not match required [Setting Default]             |
+Every schema diagnostic names the field, the value, the
+constraint, and (when it can) a hint:
+
+```text
+status: got "draf", expected one of: "draft", "open", "done"
+  (did you mean "draft"?)
+schema: plan/proto.md:4
+```
+
+The trailing `schema: <ref>` line points at the source; for
+proto.md schemas it includes the constraint's line number.
+
+| Condition            | Message                                                               |
+|----------------------|-----------------------------------------------------------------------|
+| section missing      | `## Settings: got <missing>, expected section to be present`          |
+| wrong level          | `Settings: got h3, expected h2`                                       |
+| extra section        | `## Extra: got <present>, expected not declared in schema`            |
+| out of order         | `## Tasks: got <out of order>, expected in declared order`            |
+| heading sync         | `heading does not match frontmatter: expected "X" (from id), …`       |
+| body sync            | `body does not match frontmatter field "description": expected …`     |
+| front matter schema  | `status: got "draf", expected one of: "draft", "open", "done" …`      |
+| filename mismatch    | `filename: got "foo.md", expected filename matching glob [0-9]*_*.md` |
+| misplaced require    | `<?require?> is only recognized in schema files; …`                   |
+| schema include loop  | `cyclic include: a.md -> b.md -> a.md`                                |
+| content missing      | missing required content "code-block lang=yaml" inside ## Examples    |
+| content unexpected   | unexpected content "table" inside ## Examples (expected "paragraph")  |
+| content out of order | content "table" out of order: expected after "code-block lang=yaml"   |
+| code block lang      | code block language "json" does not match required "yaml"             |
+| table columns        | table headers [Key Value] do not match required [Setting Default]     |
+
+CUE constraints render in user vocabulary:
+
+| CUE shape            | Rendered as                      |
+|----------------------|----------------------------------|
+| `"a" \| "b" \| "c"`  | `one of: "a", "b", "c"`          |
+| `=~"^FOO-[0-9]{4}$"` | `string matching ^FOO-[0-9]{4}$` |
+| `int & >=1 & <=5`    | `int between 1 and 5`            |
+| `string & != ""`     | `non-empty string`               |
+| `bool`               | `true or false`                  |
+| anything else        | the raw CUE expression           |
+
+Hints fire on string disjunctions (Levenshtein ≤ 2 of a valid
+literal) and integer ranges (nearest bound when just outside).
+Other shapes get no hint.
 
 ## Meta-Information
 

--- a/internal/rules/MDS020-required-structure/bad/default.md
+++ b/internal/rules/MDS020-required-structure/bad/default.md
@@ -4,7 +4,9 @@ settings:
 diagnostics:
   - line: 1
     column: 1
-    message: 'missing required section "## Tasks"'
+    message: |-
+      ## Tasks: got <missing>, expected section to be present
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/extra-section.md
+++ b/internal/rules/MDS020-required-structure/bad/extra-section.md
@@ -4,7 +4,10 @@ settings:
 diagnostics:
   - line: 3
     column: 1
-    message: 'unexpected section "## Extra" (expected "## Goal")'
+    message: |-
+      ## Extra: got <present>, expected not declared in schema
+        (expected "## Goal" here instead)
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/filename-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/filename-mismatch.md
@@ -4,6 +4,8 @@ settings:
 diagnostics:
   - line: 1
     column: 1
-    message: 'filename "filename-mismatch.md" does not match required pattern "[0-9]*_*.md"'
+    message: |-
+      filename: got "filename-mismatch.md", expected filename matching glob [0-9]*_*.md
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/filename-tmpl.md
 ---
 # My Doc

--- a/internal/rules/MDS020-required-structure/bad/inline-closed-unlisted.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-closed-unlisted.md
@@ -10,7 +10,10 @@ settings:
 diagnostics:
   - line: 7
     column: 1
-    message: 'unexpected section "## Notes" (expected "## Decision")'
+    message: |-
+      ## Notes: got <present>, expected not declared in schema
+        (expected "## Decision" here instead)
+      schema: inline kind schema
 ---
 # RFC
 

--- a/internal/rules/MDS020-required-structure/bad/inline-level-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-level-mismatch.md
@@ -10,7 +10,9 @@ settings:
 diagnostics:
   - line: 5
     column: 1
-    message: 'heading level mismatch for "Step": expected h3, got h2'
+    message: |-
+      Step: got h2, expected h3
+      schema: inline kind schema
 ---
 # Runbook
 

--- a/internal/rules/MDS020-required-structure/bad/inline-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-missing.md
@@ -9,7 +9,9 @@ settings:
 diagnostics:
   - line: 1
     column: 1
-    message: 'missing required section "## Tasks"'
+    message: |-
+      ## Tasks: got <missing>, expected section to be present
+      schema: inline kind schema
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/multi-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/multi-missing.md
@@ -4,9 +4,13 @@ settings:
 diagnostics:
   - line: 1
     column: 1
-    message: 'missing required section "## Goal"'
+    message: |-
+      ## Goal: got <missing>, expected section to be present
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
   - line: 1
     column: 1
-    message: 'missing required section "## Tasks"'
+    message: |-
+      ## Tasks: got <missing>, expected section to be present
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # Title Only

--- a/internal/rules/MDS020-required-structure/bad/nature-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/nature-missing.md
@@ -6,7 +6,9 @@ settings:
 diagnostics:
   - line: 1
     column: 1
-    message: 'front matter does not satisfy schema CUE constraints: nature: incomplete value "directive" | "generator" | "content" | "style" | "structure"'
+    message: |-
+      nature: got <missing>, expected one of: "directive", "generator", "content", "style", "structure"
+      schema: inline kind schema
 ---
 # MDS999: example-rule
 

--- a/internal/rules/MDS020-required-structure/bad/out-of-order.md
+++ b/internal/rules/MDS020-required-structure/bad/out-of-order.md
@@ -4,7 +4,10 @@ settings:
 diagnostics:
   - line: 3
     column: 1
-    message: 'section "## Tasks" out of order: expected after "## Goal"'
+    message: |-
+      ## Tasks: got <out of order>, expected in declared order
+        (expected after "## Goal")
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/path-pattern-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/path-pattern-mismatch.md
@@ -7,8 +7,7 @@ diagnostics:
   - line: 1
     column: 1
     message: |-
-      filename: got "path-pattern-mismatch.md", expected
-        glob [0-9]*_*.md
+      path: got "path-pattern-mismatch.md", expected path matching glob [0-9]*_*.md
       schema: kinds[plan] / path-pattern
 ---
 # Plan body whose path does not match the kind's path-pattern

--- a/internal/rules/MDS020-required-structure/bad/wildcard-level.md
+++ b/internal/rules/MDS020-required-structure/bad/wildcard-level.md
@@ -4,6 +4,8 @@ settings:
 diagnostics:
   - line: 1
     column: 1
-    message: 'heading level mismatch for "Title": expected h1, got h2'
+    message: |-
+      Title: got h2, expected h1
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/wildcard-tmpl.md
 ---
 ## Title

--- a/internal/rules/MDS020-required-structure/bad/wrong-level.md
+++ b/internal/rules/MDS020-required-structure/bad/wrong-level.md
@@ -4,7 +4,9 @@ settings:
 diagnostics:
   - line: 3
     column: 1
-    message: 'heading level mismatch for "Goal": expected h2, got h3'
+    message: |-
+      Goal: got h3, expected h2
+      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -79,7 +79,7 @@ func TestCheck_InlineSchema_MissingSection(t *testing.T) {
 	})}
 	f := newTestFile(t, "doc.md", "# My Plan\n\n## Goal\n\nGoal text.\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `missing required section "## Tasks"`)
+	expectDiagMsg(t, diags, `## Tasks: got <missing>, expected section to be present`)
 }
 
 func TestCheck_InlineSchema_ParityWithFileSchema(t *testing.T) {
@@ -102,7 +102,17 @@ func TestCheck_InlineSchema_ParityWithFileSchema(t *testing.T) {
 	inlineDiags := rInline.Check(fInline)
 	require.Len(t, fileDiags, 1)
 	require.Len(t, inlineDiags, 1)
-	assert.Equal(t, fileDiags[0].Message, inlineDiags[0].Message)
+	// The two paths emit identical violation bodies (field /
+	// actual / expected); only the trailing schema-reference
+	// line differs because one points at a file path and the
+	// other at the kind label.
+	firstLine := func(s string) string {
+		if i := strings.Index(s, "\n"); i >= 0 {
+			return s[:i]
+		}
+		return s
+	}
+	assert.Equal(t, firstLine(fileDiags[0].Message), firstLine(inlineDiags[0].Message))
 }
 
 func TestCheck_InlineSchema_OpenByDefault(t *testing.T) {
@@ -132,7 +142,7 @@ func TestCheck_InlineSchema_ClosedFlagsUnlisted(t *testing.T) {
 		"# Runbook\n\n## Symptoms\n\nx\n\n## Notes\n\ny\n\n## Diagnosis\n\nz\n")
 	diags := r.Check(f)
 	require.NotEmpty(t, diags)
-	expectDiagMsg(t, diags, `unexpected section "## Notes"`)
+	expectDiagMsg(t, diags, `## Notes: got <present>, expected not declared in schema`)
 }
 
 func TestCheck_InlineSchema_WildcardSlot(t *testing.T) {
@@ -215,8 +225,8 @@ func TestCheck_InlineSchema_LevelMismatch(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, our)
-	expectDiagMsg(t, our, "heading level mismatch")
-	expectDiagMsg(t, our, "expected h3, got h2")
+	expectDiagMsg(t, our, "Step: got h2")
+	expectDiagMsg(t, our, "expected h3")
 }
 
 func TestCheck_InlineSchema_AliasMatches(t *testing.T) {
@@ -242,7 +252,7 @@ func TestCheck_InlineSchema_FilenamePattern(t *testing.T) {
 	f := newTestFile(t, "draft.md", "# Draft\n")
 	diags := r.Check(f)
 	require.Len(t, diags, 1)
-	expectDiagMsg(t, diags, `filename "draft.md" does not match required pattern`)
+	expectDiagMsg(t, diags, `filename: got "draft.md"`)
 }
 
 func TestCheck_InlineSchema_FrontmatterCUE(t *testing.T) {
@@ -256,8 +266,8 @@ func TestCheck_InlineSchema_FrontmatterCUE(t *testing.T) {
 		"---\nid: NOT-AN-RFC\n---\n# Doc\n")
 	diags := r.Check(f)
 	require.NotEmpty(t, diags)
-	expectDiagMsg(t, diags,
-		"front matter does not satisfy schema CUE constraints")
+	expectDiagMsg(t, diags, `id: got "NOT-AN-RFC"`)
+	expectDiagMsg(t, diags, `string matching ^RFC-[0-9]{4}$`)
 }
 
 // TestCheck_InlineSchema_ScopeRuleDeterministicOrdering exercises

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1,6 +1,7 @@
 package requiredstructure
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -327,19 +328,21 @@ func (r *Rule) checkFileSchema(f *lint.File) []lint.Diagnostic {
 	diags = append(diags, fmDiags...)
 
 	// Check filename pattern.
-	diags = append(diags, checkFilenamePattern(f, sch)...)
+	diags = append(diags, checkFilenamePattern(f, sch, r.Schema)...)
 
 	// Check structure: required headings present and in order.
-	diags = append(diags, checkStructure(f, sch, docHeadings)...)
+	diags = append(diags, checkStructure(f, sch, docHeadings, r.Schema)...)
 
 	// Validate document front matter against schema-embedded CUE constraints,
 	// unless the cue-frontmatter placeholder token is configured (which marks
 	// the front-matter values as CUE expressions rather than concrete data).
 	if !placeholders.HasCUEFrontmatter(r.Placeholders) {
-		if err := validateFrontMatterCUE(sch.Config.FrontMatterCUE, docFMRaw); err != nil {
-			diags = append(diags, makeDiag(f.Path, 1,
-				fmt.Sprintf("front matter does not satisfy schema CUE constraints: %v", err)))
+		fmSch := &schema.Schema{
+			Frontmatter:      sch.Config.Frontmatter,
+			FrontmatterLines: sch.Config.FrontmatterLines,
+			Source:           r.Schema,
 		}
+		diags = append(diags, schema.ValidateFrontmatterDiags(f, fmSch, docFMRaw, makeDiag)...)
 	}
 
 	// Check frontmatter-body sync using raw map for nested access.
@@ -401,6 +404,19 @@ var (
 type schemaConfig struct {
 	FrontMatterCUE  string
 	FilenamePattern string // glob pattern the document basename must match
+
+	// Frontmatter carries the per-key constraint expression
+	// strings. Populated alongside FrontMatterCUE so the
+	// SchemaDiagnostic emitter can render one diagnostic per CUE
+	// error path with the source expression available for
+	// "expected" extraction.
+	Frontmatter map[string]string
+
+	// FrontmatterLines records the 1-based line number of each
+	// front-matter key in the schema source, when known. The
+	// yaml.Node based parser populates this; the legacy
+	// yaml.Unmarshal path leaves it empty.
+	FrontmatterLines map[string]int
 }
 
 // schemaHeading represents a required heading from the schema.
@@ -436,13 +452,21 @@ func parseSchemaFrontMatter(prefix []byte) (schemaConfig, error) {
 		return cfg, nil
 	}
 	yamlBytes := extractYAML(prefix)
-	derivedSchema, err := deriveFrontMatterCUE(yamlBytes)
+	derivedSchema, perKey, err := deriveFrontMatterCUE(yamlBytes)
 	if err != nil {
 		return cfg, err
 	}
 	cfg.FrontMatterCUE = derivedSchema
+	cfg.Frontmatter = perKey
 	if err := validateCUESchemaSyntax(cfg.FrontMatterCUE); err != nil {
 		return cfg, err
+	}
+	// Capture per-key source lines. The YAML body sits after the
+	// opening "---\n" fence in the schema file, so line numbers
+	// from yaml.Node are off by 1 relative to the schema source.
+	node, nodeErr := yamlutil.UnmarshalNodeSafe(yamlBytes)
+	if nodeErr == nil {
+		cfg.FrontmatterLines = yamlutil.TopLevelMappingLines(&node, 1)
 	}
 	return cfg, nil
 }
@@ -494,20 +518,28 @@ func extractRequireDirective(f *lint.File) (string, error) {
 	return filenamePattern, nil
 }
 
-func deriveFrontMatterCUE(yamlBytes []byte) (string, error) {
+func deriveFrontMatterCUE(yamlBytes []byte) (string, map[string]string, error) {
 	var raw map[string]any
 	if err := yamlutil.UnmarshalSafe(yamlBytes, &raw); err != nil {
-		return "", fmt.Errorf("parsing schema frontmatter: %w", err)
+		return "", nil, fmt.Errorf("parsing schema frontmatter: %w", err)
 	}
 	if len(raw) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 
 	expr, err := cueExprForMap(raw)
 	if err != nil {
-		return "", fmt.Errorf("parsing schema frontmatter constraints: %w", err)
+		return "", nil, fmt.Errorf("parsing schema frontmatter constraints: %w", err)
 	}
-	return "close(" + expr + ")", nil
+	perKey := make(map[string]string, len(raw))
+	for k, v := range raw {
+		ke, err := cueExprForValue(v)
+		if err != nil {
+			continue
+		}
+		perKey[k] = ke
+	}
+	return "close(" + expr + ")", perKey, nil
 }
 
 func cueExprForMap(m map[string]any) (string, error) {
@@ -898,26 +930,48 @@ func checkStructure(
 	f *lint.File,
 	sch *parsedSchema,
 	docHeadings []docHeading,
+	schemaSource string,
 ) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	ref := buildSchemaRefForLegacy(schemaSource)
+	requiredByText := buildRequiredByTextLegacy(sch.Headings)
 
-	// Map each literal required heading text to its schema indices,
-	// so that a doc heading seen at the "wrong" position can be
-	// recognized as an out-of-order required section rather than
-	// double-counted as both "unexpected" and "missing".
-	// Wildcard, `?` and field-interpolated headings are excluded
-	// because their match depends on context.
-	requiredByText := map[string][]int{}
-	for i, req := range sch.Headings {
+	diags, docIdx, allowExtra := walkRequiredHeadings(
+		f, sch, docHeadings, requiredByText, ref,
+	)
+	if !allowExtra {
+		diags = append(diags, flagTrailingExtras(f, docHeadings, docIdx, ref)...)
+	}
+	return diags
+}
+
+// buildRequiredByTextLegacy maps each literal required heading text
+// to its schema indices, so a doc heading seen at the "wrong"
+// position can be recognized as an out-of-order required section
+// rather than double-counted as both "unexpected" and "missing".
+// Wildcard, `?`, and field-interpolated headings are excluded
+// because their match depends on context.
+func buildRequiredByTextLegacy(headings []schemaHeading) map[string][]int {
+	out := map[string][]int{}
+	for i, req := range headings {
 		if isSectionWildcard(req) || req.Text == "?" {
 			continue
 		}
 		if fieldinterp.ContainsField(req.Text) {
 			continue
 		}
-		requiredByText[req.Text] = append(requiredByText[req.Text], i)
+		out[req.Text] = append(out[req.Text], i)
 	}
+	return out
+}
 
+// walkRequiredHeadings iterates the schema's heading list, matching
+// each required entry against the document and emitting
+// missing/unexpected/out-of-order diagnostics as it goes.
+func walkRequiredHeadings(
+	f *lint.File, sch *parsedSchema, docHeadings []docHeading,
+	requiredByText map[string][]int, ref string,
+) ([]lint.Diagnostic, int, bool) {
+	var diags []lint.Diagnostic
 	claimed := make(map[int]bool)
 	docIdx := 0
 	allowExtra := false
@@ -929,9 +983,9 @@ func checkStructure(
 		if claimed[schIdx] {
 			continue
 		}
-
 		reqDiags, newIdx, found := matchRequired(
-			f, sch, docHeadings, docIdx, schIdx, requiredByText, claimed, allowExtra,
+			f, sch, docHeadings, docIdx, schIdx,
+			requiredByText, claimed, allowExtra, ref,
 		)
 		diags = append(diags, reqDiags...)
 		docIdx = newIdx
@@ -939,25 +993,55 @@ func checkStructure(
 			allowExtra = false
 		}
 		if !found && !claimed[schIdx] {
-			diags = append(diags, makeDiag(f.Path, 1,
-				fmt.Sprintf("missing required section %q",
-					formatHeading(req.Level, req.Text))))
+			diags = append(diags, missingSectionDiagLegacy(f, req, ref))
 		}
 	}
+	return diags, docIdx, allowExtra
+}
 
-	// Check remaining doc headings for extra sections when no wildcard
-	// allows trailing extras.
-	if !allowExtra {
-		for docIdx < len(docHeadings) {
-			dh := docHeadings[docIdx]
-			diags = append(diags, makeDiag(f.Path, dh.Line,
-				fmt.Sprintf("unexpected section %q",
-					formatHeading(dh.Level, dh.Text))))
-			docIdx++
+// flagTrailingExtras emits one diagnostic per leftover document
+// heading when no wildcard allows trailing extras.
+func flagTrailingExtras(
+	f *lint.File, docHeadings []docHeading, docIdx int, ref string,
+) []lint.Diagnostic {
+	var diags []lint.Diagnostic
+	for docIdx < len(docHeadings) {
+		dh := docHeadings[docIdx]
+		d := schema.SchemaDiagnostic{
+			Field:     formatHeading(dh.Level, dh.Text),
+			Actual:    "<present>",
+			Expected:  "not declared in schema",
+			SchemaRef: ref,
 		}
+		diags = append(diags, makeDiag(f.Path, dh.Line, d.Format()))
+		docIdx++
 	}
-
 	return diags
+}
+
+// missingSectionDiagLegacy builds the SchemaDiagnostic for a
+// required heading that the document lacks.
+func missingSectionDiagLegacy(
+	f *lint.File, req schemaHeading, ref string,
+) lint.Diagnostic {
+	d := schema.SchemaDiagnostic{
+		Field:     formatHeading(req.Level, req.Text),
+		Actual:    "<missing>",
+		Expected:  "section to be present",
+		SchemaRef: ref,
+	}
+	return makeDiag(f.Path, 1, d.Format())
+}
+
+// buildSchemaRefForLegacy returns the schema reference string
+// used by SchemaDiagnostic in the file-schema (proto.md) code
+// path. An empty source falls back to the generic "schema"
+// label so every diagnostic still carries a reference suffix.
+func buildSchemaRefForLegacy(source string) string {
+	if source == "" {
+		return "schema"
+	}
+	return source
 }
 
 // matchRequired advances docIdx to find a doc heading matching req.
@@ -973,6 +1057,7 @@ func matchRequired(
 	requiredByText map[string][]int,
 	claimed map[int]bool,
 	allowExtra bool,
+	schemaRef string,
 ) ([]lint.Diagnostic, int, bool) {
 	var diags []lint.Diagnostic
 	req := sch.Headings[schIdx]
@@ -980,29 +1065,37 @@ func matchRequired(
 		dh := docHeadings[docIdx]
 		if matchesSchema(req, dh) {
 			if dh.Level != req.Level {
-				diags = append(diags, levelMismatchDiag(f, dh, req))
+				diags = append(diags, levelMismatchDiag(f, dh, req, schemaRef))
 			}
 			claimed[schIdx] = true
 			return diags, docIdx + 1, true
 		}
 		if ooIdx := nextUnclaimed(requiredByText[dh.Text], claimed, schIdx+1); ooIdx >= 0 {
 			other := sch.Headings[ooIdx]
-			diags = append(diags, makeDiag(f.Path, dh.Line,
-				fmt.Sprintf("section %q out of order: expected after %q",
-					formatHeading(dh.Level, dh.Text),
-					formatHeading(req.Level, req.Text))))
+			ooDiag := schema.SchemaDiagnostic{
+				Field:     formatHeading(dh.Level, dh.Text),
+				Actual:    "<out of order>",
+				Expected:  "in declared order",
+				Hint:      fmt.Sprintf("expected after %q", formatHeading(req.Level, req.Text)),
+				SchemaRef: schemaRef,
+			}
+			diags = append(diags, makeDiag(f.Path, dh.Line, ooDiag.Format()))
 			if dh.Level != other.Level {
-				diags = append(diags, levelMismatchDiag(f, dh, other))
+				diags = append(diags, levelMismatchDiag(f, dh, other, schemaRef))
 			}
 			claimed[ooIdx] = true
 			docIdx++
 			continue
 		}
 		if !allowExtra {
-			diags = append(diags, makeDiag(f.Path, dh.Line,
-				fmt.Sprintf("unexpected section %q (expected %q)",
-					formatHeading(dh.Level, dh.Text),
-					formatHeading(req.Level, req.Text))))
+			unexpDiag := schema.SchemaDiagnostic{
+				Field:     formatHeading(dh.Level, dh.Text),
+				Actual:    "<present>",
+				Expected:  "not declared in schema",
+				Hint:      fmt.Sprintf("expected %q here instead", formatHeading(req.Level, req.Text)),
+				SchemaRef: schemaRef,
+			}
+			diags = append(diags, makeDiag(f.Path, dh.Line, unexpDiag.Format()))
 		}
 		docIdx++
 	}
@@ -1012,11 +1105,15 @@ func matchRequired(
 // levelMismatchDiag builds a heading level-mismatch diagnostic that
 // names the offending heading so readers can locate it quickly.
 func levelMismatchDiag(
-	f *lint.File, dh docHeading, req schemaHeading,
+	f *lint.File, dh docHeading, req schemaHeading, schemaRef string,
 ) lint.Diagnostic {
-	return makeDiag(f.Path, dh.Line,
-		fmt.Sprintf("heading level mismatch for %q: expected h%d, got h%d",
-			dh.Text, req.Level, dh.Level))
+	d := schema.SchemaDiagnostic{
+		Field:     dh.Text,
+		Actual:    fmt.Sprintf("h%d", dh.Level),
+		Expected:  fmt.Sprintf("h%d", req.Level),
+		SchemaRef: schemaRef,
+	}
+	return makeDiag(f.Path, dh.Line, d.Format())
 }
 
 // nextUnclaimed returns the first index in candidates that is >= minIdx
@@ -1276,18 +1373,22 @@ func readDocFrontMatterRaw(f *lint.File) (map[string]any, []lint.Diagnostic) {
 }
 
 // extractYAML extracts the YAML content between --- delimiters.
+// The closing fence is removed via TrimSuffix on the canonical
+// `---\n` (or bare `---` for blocks that omit the trailing
+// newline) rather than a strings.Index scan, so a YAML block
+// scalar value (e.g. `notes: |\n  ---\n`) that legitimately
+// contains the same sequence inside its body cannot truncate
+// the YAML early. A block that carries no recognisable fence at
+// all returns nil so the caller short-circuits on bad input.
 func extractYAML(fmBlock []byte) []byte {
-	s := string(fmBlock)
-	s = strings.TrimPrefix(s, "---\n")
-	idx := strings.Index(s, "---\n")
-	if idx < 0 {
-		// Try without trailing newline.
-		idx = strings.Index(s, "---")
-		if idx < 0 {
-			return nil
-		}
+	body := bytes.TrimPrefix(fmBlock, []byte("---\n"))
+	switch {
+	case bytes.HasSuffix(body, []byte("---\n")):
+		return body[:len(body)-len("---\n")]
+	case bytes.HasSuffix(body, []byte("---")):
+		return body[:len(body)-len("---")]
 	}
-	return []byte(s[:idx])
+	return nil
 }
 
 // findRequireDirectiveLine returns the 1-based line number of the first
@@ -1345,9 +1446,17 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 		if err == nil && ok {
 			continue
 		}
-		diags = append(diags, makeDiag(f.Path, 1, fmt.Sprintf(
-			"filename: got %q, expected\n  glob %s\nschema: kinds[%s] / path-pattern",
-			rel, pp.Pattern, pp.Kind)))
+		// path-pattern checks the workspace-relative path (which may
+		// include directories), so the field label is "path" rather
+		// than "filename". The latter is reserved for basename-only
+		// checks emitted by validateFilename / checkFilenamePattern.
+		d := schema.SchemaDiagnostic{
+			Field:     "path",
+			Actual:    fmt.Sprintf("%q", rel),
+			Expected:  fmt.Sprintf("path matching glob %s", pp.Pattern),
+			SchemaRef: fmt.Sprintf("kinds[%s] / path-pattern", pp.Kind),
+		}
+		diags = append(diags, makeDiag(f.Path, 1, d.Format()))
 	}
 	return diags
 }
@@ -1378,7 +1487,7 @@ func workspaceRelPath(f *lint.File) string {
 // checkFilenamePattern checks that the document basename matches the
 // schema's filename glob pattern (if configured).
 func checkFilenamePattern(
-	f *lint.File, sch *parsedSchema,
+	f *lint.File, sch *parsedSchema, schemaSource string,
 ) []lint.Diagnostic {
 	pattern := sch.Config.FilenamePattern
 	if pattern == "" {
@@ -1387,15 +1496,29 @@ func checkFilenamePattern(
 	base := filepath.Base(f.Path)
 	matched, err := filepath.Match(pattern, base)
 	if err != nil {
-		return []lint.Diagnostic{makeDiag(f.Path, 1,
-			fmt.Sprintf("invalid filename pattern %q: %v",
-				pattern, err))}
+		// Malformed glob in the schema. Surface it via the same
+		// SchemaDiagnostic shape so the message carries the
+		// schema reference and the user can jump to the
+		// offending pattern.
+		d := schema.SchemaDiagnostic{
+			Field:     "filename pattern",
+			Actual:    fmt.Sprintf("%q", pattern),
+			Expected:  "valid glob",
+			Hint:      err.Error(),
+			SchemaRef: buildSchemaRefForLegacy(schemaSource),
+		}
+		return []lint.Diagnostic{makeDiag(f.Path, 1, d.Format())}
 	}
 	if !matched {
-		return []lint.Diagnostic{makeDiag(f.Path, 1,
-			fmt.Sprintf(
-				"filename %q does not match required pattern %q",
-				base, pattern))}
+		// `glob` keeps the wording aligned with schema.validateFilename
+		// and the path-pattern diagnostic; see the rationale there.
+		d := schema.SchemaDiagnostic{
+			Field:     "filename",
+			Actual:    fmt.Sprintf("%q", base),
+			Expected:  fmt.Sprintf("filename matching glob %s", pattern),
+			SchemaRef: buildSchemaRefForLegacy(schemaSource),
+		}
+		return []lint.Diagnostic{makeDiag(f.Path, 1, d.Format())}
 	}
 	return nil
 }

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1030,7 +1030,11 @@ func missingSectionDiagLegacy(
 		Expected:  "section to be present",
 		SchemaRef: ref,
 	}
-	return makeDiag(f.Path, 1, d.Format())
+	// Missing sections have no body line to point at; use the
+	// non-body anchor so the engine's filterGeneratedDiags can't
+	// drop the diagnostic when body line 1 sits inside a
+	// generated section.
+	return makeDiag(f.Path, schema.NonBodyDiagLine(f), d.Format())
 }
 
 // buildSchemaRefForLegacy returns the schema reference string
@@ -1361,12 +1365,12 @@ func readDocFrontMatterRaw(f *lint.File) (map[string]any, []lint.Diagnostic) {
 	}
 
 	if err := yamlutil.RejectYAMLAliases(yamlBytes); err != nil {
-		return nil, []lint.Diagnostic{makeDiag(f.Path, 1,
+		return nil, []lint.Diagnostic{makeDiag(f.Path, schema.NonBodyDiagLine(f),
 			fmt.Sprintf("front matter: %v", err))}
 	}
 	var raw map[string]any
 	if err := yaml.Unmarshal(yamlBytes, &raw); err != nil {
-		return nil, []lint.Diagnostic{makeDiag(f.Path, 1,
+		return nil, []lint.Diagnostic{makeDiag(f.Path, schema.NonBodyDiagLine(f),
 			fmt.Sprintf("front matter: invalid YAML: %v", err))}
 	}
 	return raw, nil
@@ -1456,7 +1460,7 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 			Expected:  fmt.Sprintf("path matching glob %s", pp.Pattern),
 			SchemaRef: fmt.Sprintf("kinds[%s] / path-pattern", pp.Kind),
 		}
-		diags = append(diags, makeDiag(f.Path, 1, d.Format()))
+		diags = append(diags, makeDiag(f.Path, schema.NonBodyDiagLine(f), d.Format()))
 	}
 	return diags
 }
@@ -1493,6 +1497,11 @@ func checkFilenamePattern(
 	if pattern == "" {
 		return nil
 	}
+	// Filename diagnostics describe the document as a whole;
+	// use the non-body anchor so filterGeneratedDiags can't
+	// drop them when body line 1 sits inside a generated
+	// section.
+	anchor := schema.NonBodyDiagLine(f)
 	base := filepath.Base(f.Path)
 	matched, err := filepath.Match(pattern, base)
 	if err != nil {
@@ -1507,7 +1516,7 @@ func checkFilenamePattern(
 			Hint:      err.Error(),
 			SchemaRef: buildSchemaRefForLegacy(schemaSource),
 		}
-		return []lint.Diagnostic{makeDiag(f.Path, 1, d.Format())}
+		return []lint.Diagnostic{makeDiag(f.Path, anchor, d.Format())}
 	}
 	if !matched {
 		// `glob` keeps the wording aligned with schema.validateFilename
@@ -1518,7 +1527,7 @@ func checkFilenamePattern(
 			Expected:  fmt.Sprintf("filename matching glob %s", pattern),
 			SchemaRef: buildSchemaRefForLegacy(schemaSource),
 		}
-		return []lint.Diagnostic{makeDiag(f.Path, 1, d.Format())}
+		return []lint.Diagnostic{makeDiag(f.Path, anchor, d.Format())}
 	}
 	return nil
 }

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -298,7 +298,7 @@ func TestCheck_MissingHeading(t *testing.T) {
 	r := &Rule{Schema: schemaPath}
 	f := newTestFile(t, "doc.md", "# My Rule\n\n## Examples\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `missing required section "## Settings"`)
+	expectDiagMsg(t, diags, `## Settings: got <missing>, expected section to be present`)
 }
 
 func TestCheck_ExtraSectionForbidden(t *testing.T) {
@@ -307,7 +307,7 @@ func TestCheck_ExtraSectionForbidden(t *testing.T) {
 	f := newTestFile(t, "doc.md",
 		"# My Plan\n\n## Prerequisites\n\n## Goal\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `unexpected section "## Prerequisites"`)
+	expectDiagMsg(t, diags, `## Prerequisites: got <present>, expected not declared in schema`)
 }
 
 func TestCheck_SectionWildcardAllowsExtras(t *testing.T) {
@@ -334,7 +334,7 @@ func TestCheck_WrongLevel(t *testing.T) {
 	f := newTestFile(t, "doc.md",
 		"# My Rule\n\n### Settings\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, "heading level mismatch")
+	expectDiagMsg(t, diags, "expected h2")
 }
 
 // Level-mismatch diagnostics must name the offending heading so
@@ -345,8 +345,8 @@ func TestCheck_WrongLevel_NamesHeading(t *testing.T) {
 	f := newTestFile(t, "doc.md",
 		"# My Rule\n\n### Settings\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `"Settings"`)
-	expectDiagMsg(t, diags, "expected h2, got h3")
+	expectDiagMsg(t, diags, "Settings:")
+	expectDiagMsg(t, diags, "got h3, expected h2")
 }
 
 // Unexpected-section diagnostics should tell the author which
@@ -357,7 +357,7 @@ func TestCheck_ExtraSection_NamesExpected(t *testing.T) {
 	f := newTestFile(t, "doc.md",
 		"# My Plan\n\n## Prerequisites\n\n## Goal\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `unexpected section "## Prerequisites"`)
+	expectDiagMsg(t, diags, `## Prerequisites: got <present>, expected not declared in schema`)
 	expectDiagMsg(t, diags, `expected "## Goal"`)
 }
 
@@ -370,7 +370,7 @@ func TestCheck_ExtraSection_TrailingNoExpected(t *testing.T) {
 	f := newTestFile(t, "doc.md",
 		"# My Plan\n\n## Goal\n\n## Trailing\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `unexpected section "## Trailing"`)
+	expectDiagMsg(t, diags, `## Trailing: got <present>, expected not declared in schema`)
 }
 
 // When a required section appears but in the wrong order, the
@@ -555,8 +555,8 @@ status: '"🔲" | "🔳" | "✅"'
 	f := newTestFile(t, "doc.md",
 		"---\nid: 40\n---\n# Any title\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags,
-		"front matter does not satisfy schema CUE constraints")
+	expectDiagMsg(t, diags, `status: `)
+	expectDiagMsg(t, diags, `expected one of: "🔲", "🔳", "✅"`)
 }
 
 func TestCheck_FrontMatterCUESchemaInvalidStatus(t *testing.T) {
@@ -570,8 +570,8 @@ status: '"🔲" | "🔳" | "✅"'
 	f := newTestFile(t, "doc.md",
 		"---\nid: 40\nstatus: in-progress\n---\n# Any title\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags,
-		"front matter does not satisfy schema CUE constraints")
+	expectDiagMsg(t, diags, `status: got "in-progress"`)
+	expectDiagMsg(t, diags, `expected one of: "🔲", "🔳", "✅"`)
 }
 
 func TestCheck_FrontMatterCUESchemaRejectsExtraFields(t *testing.T) {
@@ -585,8 +585,8 @@ status: '"🔲" | "🔳" | "✅"'
 	f := newTestFile(t, "doc.md",
 		"---\nid: 40\nstatus: \"✅\"\nextra: true\n---\n# Any title\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags,
-		"front matter does not satisfy schema CUE constraints")
+	expectDiagMsg(t, diags, `extra:`)
+	expectDiagMsg(t, diags, `not declared in schema`)
 }
 
 func TestCheck_InvalidSchemaFrontMatterCUE(t *testing.T) {
@@ -658,8 +658,8 @@ name: 'string & != ""'
 	f := newTestFile(t, "doc.md",
 		"---\nname: my-skill\nunknown: true\n---\n# My Skill\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags,
-		"front matter does not satisfy schema CUE constraints")
+	expectDiagMsg(t, diags, `unknown:`)
+	expectDiagMsg(t, diags, `not declared in schema`)
 }
 
 func TestCheck_OptionalFieldInvalidType(t *testing.T) {
@@ -673,8 +673,7 @@ name: 'string & != ""'
 	f := newTestFile(t, "doc.md",
 		"---\nname: my-skill\nuser-invocable: not-a-bool\n---\n# My Skill\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags,
-		"front matter does not satisfy schema CUE constraints")
+	expectDiagMsg(t, diags, `user-invocable`)
 }
 
 // =====================================================================
@@ -703,7 +702,7 @@ filename: "[0-9]*_*.md"
 	f := newTestFile(t, "my-plan.md", "# My Plan\n")
 	diags := r.Check(f)
 	expectDiagMsg(t, diags,
-		`filename "my-plan.md" does not match required pattern`)
+		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
 }
 
 func TestCheck_FilenamePatternSingleLinePI(t *testing.T) {
@@ -714,7 +713,7 @@ func TestCheck_FilenamePatternSingleLinePI(t *testing.T) {
 	f := newTestFile(t, "my-plan.md", "# My Plan\n")
 	diags := r.Check(f)
 	expectDiagMsg(t, diags,
-		`filename "my-plan.md" does not match required pattern`)
+		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
 }
 
 func TestCheck_FilenamePatternPIWithTrailingContent(t *testing.T) {
@@ -723,7 +722,7 @@ func TestCheck_FilenamePatternPIWithTrailingContent(t *testing.T) {
 	f := newTestFile(t, "my-plan.md", "# My Plan\n")
 	diags := r.Check(f)
 	expectDiagMsg(t, diags,
-		`filename "my-plan.md" does not match required pattern`)
+		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
 }
 
 func TestCheck_FilenamePatternIndentedPI(t *testing.T) {
@@ -734,7 +733,7 @@ func TestCheck_FilenamePatternIndentedPI(t *testing.T) {
 	f := newTestFile(t, "my-plan.md", "# My Plan\n")
 	diags := r.Check(f)
 	expectDiagMsg(t, diags,
-		`filename "my-plan.md" does not match required pattern`)
+		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
 }
 
 func TestCheck_FilenamePatternNotSet(t *testing.T) {
@@ -782,8 +781,11 @@ func TestCheck_PathPattern_Mismatch(t *testing.T) {
 	}}
 	diags := r.Check(f)
 	expectDiags(t, diags, 1)
+	// path-pattern checks the workspace-relative path, so the
+	// field label is "path" (distinct from the "filename" field
+	// used for basename-only checks).
 	assert.Contains(t, diags[0].Message,
-		`filename: got "plan/early-draft.md"`)
+		`path: got "plan/early-draft.md"`)
 	assert.Contains(t, diags[0].Message,
 		`glob plan/[0-9][0-9]*_*.md`)
 	assert.Contains(t, diags[0].Message,
@@ -926,7 +928,7 @@ filename: "[0-9]*_*.md"
 	}
 	diags := r.Check(f)
 	expectDiagMsg(t, diags,
-		`filename "my-plan.md" does not match required pattern`)
+		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
 	expectDiagMsg(t, diags, "kinds[plan] / path-pattern")
 }
 
@@ -1143,7 +1145,7 @@ func TestCheck_FrontMatterAnchorRejected(t *testing.T) {
 
 func TestDeriveFrontMatterCUE_AnchorRejected(t *testing.T) {
 	yml := []byte("base: &base\n  id: 1\n")
-	_, err := deriveFrontMatterCUE(yml)
+	_, _, err := deriveFrontMatterCUE(yml)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "anchors/aliases are not permitted")
 }
@@ -1365,6 +1367,26 @@ func TestExtractYAML_UnclosedFrontMatter(t *testing.T) {
 	assert.Nil(t, got, "unclosed front matter should return nil")
 }
 
+// TestExtractYAML_BlockScalarFenceSequence regresses a Copilot
+// review observation: a YAML block-scalar value (e.g. `notes:
+// |`) can contain the literal `---\n` sequence inside its body.
+// The earlier strings.Index search would truncate at the first
+// match; TrimSuffix on the canonical closing fence keeps the
+// full body intact.
+func TestExtractYAML_BlockScalarFenceSequence(t *testing.T) {
+	input := []byte(
+		"---\n" +
+			"id: 1\n" +
+			"notes: |\n" +
+			"  ---\n" +
+			"  more text\n" +
+			"status: open\n" +
+			"---\n")
+	got := extractYAML(input)
+	want := "id: 1\nnotes: |\n  ---\n  more text\nstatus: open\n"
+	assert.Equal(t, want, string(got))
+}
+
 // =====================================================================
 // Phase 4 coverage: writeNodeText via headingText (CodeSpan branch)
 // =====================================================================
@@ -1430,7 +1452,7 @@ func TestCheck_WildcardHeadingLevelMismatch(t *testing.T) {
 	r := &Rule{Schema: schemaPath}
 	f := newTestFile(t, "doc.md", "## Title\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `heading level mismatch for "Title": expected h1, got h2`)
+	expectDiagMsg(t, diags, `Title: got h2, expected h1`)
 }
 
 // Soft-wrapped body paragraph (multiple lines joined by space) must
@@ -1476,7 +1498,7 @@ func TestCheck_SyncNotFiredForMissingHeading(t *testing.T) {
 	diags := r.Check(f)
 	// Exactly one diagnostic: missing required section, no sync error.
 	require.Len(t, diags, 1)
-	expectDiagMsg(t, diags, "missing required section")
+	expectDiagMsg(t, diags, "expected section to be present")
 	for _, d := range diags {
 		assert.NotContains(t, d.Message, "sync")
 	}
@@ -1490,9 +1512,9 @@ func TestCheck_MultipleMissingSections(t *testing.T) {
 	r := &Rule{Schema: schemaPath}
 	f := newTestFile(t, "doc.md", "# Title\n")
 	diags := r.Check(f)
-	expectDiagMsg(t, diags, `missing required section "## Goal"`)
-	expectDiagMsg(t, diags, `missing required section "## Tasks"`)
-	expectDiagMsg(t, diags, `missing required section "## Acceptance Criteria"`)
+	expectDiagMsg(t, diags, `## Goal: got <missing>`)
+	expectDiagMsg(t, diags, `## Tasks: got <missing>`)
+	expectDiagMsg(t, diags, `## Acceptance Criteria: got <missing>`)
 }
 
 // A section that is both out of order AND at the wrong level must
@@ -1506,7 +1528,7 @@ func TestCheck_OutOfOrderAlsoReportsLevelMismatch(t *testing.T) {
 		"# Title\n\n## Tasks\n\n### Goal\n")
 	diags := r.Check(f)
 	expectDiagMsg(t, diags, `out of order`)
-	expectDiagMsg(t, diags, `heading level mismatch`)
+	expectDiagMsg(t, diags, `Goal: got h3, expected h2`)
 }
 
 // =====================================================================
@@ -1516,7 +1538,7 @@ func TestCheck_OutOfOrderAlsoReportsLevelMismatch(t *testing.T) {
 // deriveFrontMatterCUE: empty map → return "", nil
 func TestDeriveFrontMatterCUE_EmptyMap(t *testing.T) {
 	// "{}" unmarshals to an empty map → len(raw)==0 branch.
-	result, err := deriveFrontMatterCUE([]byte("{}\n"))
+	result, _, err := deriveFrontMatterCUE([]byte("{}\n"))
 	require.NoError(t, err)
 	assert.Equal(t, "", result)
 }
@@ -1524,7 +1546,7 @@ func TestDeriveFrontMatterCUE_EmptyMap(t *testing.T) {
 // deriveFrontMatterCUE: cueExprForMap error via null YAML value
 func TestDeriveFrontMatterCUE_NullValueError(t *testing.T) {
 	// YAML null (represented as nil in Go) is not a supported schema type.
-	_, err := deriveFrontMatterCUE([]byte("key: ~\n"))
+	_, _, err := deriveFrontMatterCUE([]byte("key: ~\n"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing schema frontmatter constraints")
 }
@@ -1731,7 +1753,8 @@ func TestCheck_FilenamePatternInvalidGlob(t *testing.T) {
 	f := newTestFile(t, "doc.md", "# Title\n")
 	diags := r.Check(f)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, "invalid filename pattern")
+	assert.Contains(t, diags[0].Message, "filename pattern:")
+	assert.Contains(t, diags[0].Message, "expected valid glob")
 }
 
 // checkSync: isSectionWildcard continue branch
@@ -1758,7 +1781,7 @@ func TestCheck_SyncHeadingNotFoundInDoc(t *testing.T) {
 	diags := r.Check(f)
 	// Should report missing required section, not panic.
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, "missing required section")
+	assert.Contains(t, diags[0].Message, "expected section to be present")
 }
 
 // checkSyncPoint: invalid CUE path (call directly since the fieldPattern
@@ -1843,7 +1866,8 @@ status: '"🔲" | "🔳" | "✅"'
 	diags := r.Check(f)
 	var hasCUEDiag bool
 	for _, d := range diags {
-		if strings.Contains(d.Message, "CUE constraints") {
+		if strings.Contains(d.Message, "id:") &&
+			strings.Contains(d.Message, "schema:") {
 			hasCUEDiag = true
 		}
 	}
@@ -1883,4 +1907,170 @@ func TestSettingMergeMode_RequiredStructure(t *testing.T) {
 	assert.Equal(t, rule.MergeAppend, r.SettingMergeMode("placeholders"))
 	assert.Equal(t, rule.MergeReplace, r.SettingMergeMode("schema"))
 	assert.Equal(t, rule.MergeReplace, r.SettingMergeMode("unknown"))
+}
+
+// =====================================================================
+// Plan 147: actionable schema diagnostics
+// =====================================================================
+
+// TestCheck_FrontMatter_Hint covers acceptance criterion 3: a
+// short-disjunction violation with a typo close to a valid literal
+// produces a "did you mean" hint pointing at the nearest match.
+func TestCheck_FrontMatter_Hint(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+status: '"draft" | "open" | "done"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\nstatus: draf\n---\n# Any title\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `status: got "draf"`)
+	expectDiagMsg(t, diags, `expected one of: "draft", "open", "done"`)
+	expectDiagMsg(t, diags, `did you mean "draft"?`)
+}
+
+// TestCheck_FrontMatter_IntRange covers acceptance criterion 4: a
+// numeric-range violation is rendered with the user-facing
+// `int between N and M` form, not raw CUE syntax.
+func TestCheck_FrontMatter_IntRange(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+priority: 'int & >=1 & <=5'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\npriority: 9\n---\n# Any title\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `priority: got 9`)
+	expectDiagMsg(t, diags, `expected int between 1 and 5`)
+	expectDiagMsg(t, diags, `try 5`)
+}
+
+// TestCheck_FrontMatter_Regex covers acceptance criterion 5: a
+// regex violation renders as `string matching <pattern>`, with
+// the pattern body unquoted so the user sees what to type.
+func TestCheck_FrontMatter_Regex(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+id: '=~"^FOO-[0-9]{4}$"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\nid: BAR-0001\n---\n# Any title\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `id: got "BAR-0001"`)
+	expectDiagMsg(t, diags, `expected string matching ^FOO-[0-9]{4}$`)
+}
+
+// TestCheck_FrontMatter_OneDiagnosticPerField covers acceptance
+// criterion 2: three failed FM constraints produce three
+// diagnostics rather than collapsing into one.
+func TestCheck_FrontMatter_OneDiagnosticPerField(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+a: '"x" | "y"'
+b: 'int & >=1'
+c: '=~"^Z"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\na: wrong\nb: 0\nc: nope\n---\n# Any title\n")
+	diags := r.Check(f)
+	// Filter to MDS020 only (other rules don't run with the
+	// minimal schema).
+	var our []lint.Diagnostic
+	for _, d := range diags {
+		if d.RuleID == "MDS020" {
+			our = append(our, d)
+		}
+	}
+	require.Len(t, our, 3,
+		"three FM violations should produce three separate diagnostics")
+	fieldSeen := map[string]bool{}
+	for _, d := range our {
+		for _, f := range []string{"a:", "b:", "c:"} {
+			if strings.HasPrefix(d.Message, f) {
+				fieldSeen[f] = true
+			}
+		}
+	}
+	for _, f := range []string{"a:", "b:", "c:"} {
+		assert.True(t, fieldSeen[f], "expected a diagnostic for field %s", f)
+	}
+}
+
+// TestCheck_FrontMatter_SchemaRefIncludesLine covers acceptance
+// criterion 8 for file-based schemas: the trailing schema
+// reference points at the constraint's line in proto.md so users
+// jump straight to the rule they violated.
+func TestCheck_FrontMatter_SchemaRefIncludesLine(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+id: 'int & >=1'
+status: '"open" | "done"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\nstatus: bogus\n---\n# Any title\n")
+	diags := r.Check(f)
+	// status is on line 3 of the schema (line 1 is "---",
+	// line 2 is "id:", line 3 is "status:").
+	expectDiagMsg(t, diags, "schema:")
+	expectDiagMsg(t, diags, ":3")
+}
+
+// TestCheck_FrontMatter_DiagnosticLineAtKey regresses the
+// Copilot review comment: a FM violation should anchor its
+// diagnostic at the offending key's line, not at the start of
+// the body. The rule emits a body-coord line; the file's
+// LineOffset shift (applied by lint.File.AdjustDiagnostics)
+// turns it back into the absolute file line for the key.
+func TestCheck_FrontMatter_DiagnosticLineAtKey(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+status: '"open" | "done"'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	// Build the file through NewFileFromSource so f.FrontMatter
+	// and f.LineOffset land in the same shape they do under the
+	// LSP / CLI lint path. The doc's status key sits on file
+	// line 2; we expect the diagnostic to anchor there after
+	// AdjustDiagnostics shifts the rule's body-coord output.
+	src := []byte("---\nstatus: bogus\n---\n# Any title\n")
+	f, err := lint.NewFileFromSource("doc.md", src, true)
+	require.NoError(t, err)
+	diags := r.Check(f)
+	f.AdjustDiagnostics(diags)
+	var statusLine int
+	for _, d := range diags {
+		if strings.HasPrefix(d.Message, "status:") {
+			statusLine = d.Line
+		}
+	}
+	assert.Equal(t, 2, statusLine,
+		"FM diagnostic should anchor at the offending key's file line")
+}
+
+// TestCheck_FrontMatter_MissingFieldShowsMissing regresses the
+// Copilot review comment: a required FM field absent from the
+// document should render with `<missing>` in the actual slot so
+// the diagnostic format stays consistent.
+func TestCheck_FrontMatter_MissingFieldShowsMissing(t *testing.T) {
+	schemaPath := writeSchema(t, `---
+id: 'int & >=1'
+---
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md", "# Any title\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "id: got <missing>")
+	expectDiagMsg(t, diags, "expected int >= 1")
 }

--- a/internal/schema/coverage_test.go
+++ b/internal/schema/coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -614,7 +615,8 @@ func TestValidate_OutOfOrderWithNestedSections(t *testing.T) {
 	// Expect the out-of-order diagnostic but no "missing Step A".
 	var found bool
 	for _, d := range diags {
-		if d.Message == `section "## Tasks" out of order: expected after "## Goal"` {
+		if strings.Contains(d.Message, `## Tasks: got <out of order>`) &&
+			strings.Contains(d.Message, `expected after "## Goal"`) {
 			found = true
 		}
 		assert.NotContains(t, d.Message, "Step A",
@@ -660,10 +662,10 @@ func TestValidate_ShallowLevelMismatchClaimedByText(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var levelDiag bool
 	for _, d := range diags {
-		if d.Message == `heading level mismatch for "Step": expected h3, got h2` {
+		if strings.Contains(d.Message, `Step: got h2, expected h3`) {
 			levelDiag = true
 		}
-		assert.NotContains(t, d.Message, "missing required",
+		assert.NotContains(t, d.Message, "expected section to be present",
 			"shallow-match should claim the scope, not leave it missing")
 	}
 	assert.True(t, levelDiag,
@@ -700,7 +702,8 @@ func TestValidate_InvalidFilenamePattern(t *testing.T) {
 	doc := newDocFile(t, "doc.md", "# T\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, "invalid filename pattern")
+	assert.Contains(t, diags[0].Message, "filename pattern:")
+	assert.Contains(t, diags[0].Message, "expected valid glob")
 }
 
 func TestValidateFrontmatter_HandlesNilFM(t *testing.T) {
@@ -757,6 +760,25 @@ func TestStripDelimiters_HappyPath(t *testing.T) {
 	// lint.StripFrontMatter feeds it.
 	got := stripDelimiters([]byte("---\nfoo: 1\n---\n"))
 	assert.Equal(t, "foo: 1\n", string(got))
+}
+
+// TestStripDelimiters_BlockScalarFenceSequence regresses a
+// Copilot review observation: a YAML block-scalar value can
+// contain the literal `---\n` sequence inside its body. The
+// earlier strings.Index search truncated at the first match;
+// TrimSuffix on the canonical closing fence preserves the
+// entire body.
+func TestStripDelimiters_BlockScalarFenceSequence(t *testing.T) {
+	in := []byte(
+		"---\n" +
+			"id: 1\n" +
+			"notes: |\n" +
+			"  ---\n" +
+			"  more text\n" +
+			"status: open\n" +
+			"---\n")
+	want := "id: 1\nnotes: |\n  ---\n  more text\nstatus: open\n"
+	assert.Equal(t, want, string(stripDelimiters(in)))
 }
 
 func TestParseFile_FrontmatterEmptyBody(t *testing.T) {
@@ -854,10 +876,11 @@ func TestValidate_OutOfOrderHonoursPlaceholderHeadings(t *testing.T) {
 	var oo bool
 	var missing bool
 	for _, d := range diags {
-		if d.Message == `section "## MDS001: line-length" out of order: expected after "## Goal"` {
+		if strings.Contains(d.Message, `## MDS001: line-length: got <out of order>`) &&
+			strings.Contains(d.Message, `expected after "## Goal"`) {
 			oo = true
 		}
-		if d.Message == `missing required section "## {id}: {name}"` {
+		if strings.Contains(d.Message, `## {id}: {name}: got <missing>`) {
 			missing = true
 		}
 	}
@@ -895,10 +918,11 @@ func TestValidate_LateListedScopeRecursesIntoChildren(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var oo, missing bool
 	for _, d := range diags {
-		if d.Message == `section "## B" out of order: expected before this position` {
+		if strings.Contains(d.Message, `## B: got <out of order>`) &&
+			strings.Contains(d.Message, "expected before this position") {
 			oo = true
 		}
-		if d.Message == `missing required section "### B-child"` {
+		if strings.Contains(d.Message, `### B-child: got <missing>`) {
 			missing = true
 		}
 	}
@@ -1172,12 +1196,13 @@ func TestValidate_WildcardHeadingParticipatesInOutOfOrder(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var oo bool
 	for _, d := range diags {
-		if d.Message == `section "## B" out of order: expected after "## A"` {
+		if strings.Contains(d.Message, `## B: got <out of order>`) &&
+			strings.Contains(d.Message, `expected after "## A"`) {
 			oo = true
 		}
-		assert.NotContains(t, d.Message, "missing required",
+		assert.NotContains(t, d.Message, "expected section to be present",
 			"the ? wildcard must claim B via out-of-order, not stay missing")
-		assert.NotContains(t, d.Message, "unexpected",
+		assert.NotContains(t, d.Message, "<present>",
 			"B should not surface as unexpected when ? can claim it")
 	}
 	assert.True(t, oo,
@@ -1206,10 +1231,11 @@ func TestValidate_PlaceholderAliasParticipatesInOutOfOrder(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var oo bool
 	for _, d := range diags {
-		if d.Message == `section "## alice: admin" out of order: expected after "## A"` {
+		if strings.Contains(d.Message, `## alice: admin: got <out of order>`) &&
+			strings.Contains(d.Message, `expected after "## A"`) {
 			oo = true
 		}
-		assert.NotContains(t, d.Message, "missing required",
+		assert.NotContains(t, d.Message, "expected section to be present",
 			"placeholder alias must claim the heading, not leave Profile missing")
 	}
 	assert.True(t, oo,
@@ -1276,7 +1302,8 @@ func TestValidate_OpenScopeFlagsLateListedScope(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var found bool
 	for _, d := range diags {
-		if d.Message == `section "## B" out of order: expected before this position` {
+		if strings.Contains(d.Message, `## B: got <out of order>`) &&
+			strings.Contains(d.Message, "expected before this position") {
 			found = true
 		}
 	}
@@ -1323,7 +1350,8 @@ func TestValidate_RequiredScopeStillFlagsOutOfOrder(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var ooFound bool
 	for _, d := range diags {
-		if d.Message == `section "## B" out of order: expected after "## A"` {
+		if strings.Contains(d.Message, `## B: got <out of order>`) &&
+			strings.Contains(d.Message, `expected after "## A"`) {
 			ooFound = true
 		}
 	}
@@ -1347,7 +1375,8 @@ func TestValidate_ClosedTrailingExtra(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var trailing bool
 	for _, d := range diags {
-		if d.Message == `unexpected section "## Trailing"` {
+		if strings.Contains(d.Message, `## Trailing: got <present>`) &&
+			strings.Contains(d.Message, "not declared in schema") {
 			trailing = true
 		}
 	}
@@ -1384,7 +1413,7 @@ func TestValidate_ShallowNonMatchEndsScopeList(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	var missing bool
 	for _, d := range diags {
-		if d.Message == `missing required section "### Child"` {
+		if strings.Contains(d.Message, `### Child: got <missing>`) {
 			missing = true
 		}
 	}

--- a/internal/schema/diagnostic.go
+++ b/internal/schema/diagnostic.go
@@ -1,0 +1,117 @@
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// SchemaDiagnostic is the structured form of an MDS020 violation.
+// Every CUE-error, structure-mismatch, filename-mismatch, and
+// require-directive failure flows through this type so the
+// rendered message names the field, shows the value, names the
+// constraint, and (when applicable) suggests a fix.
+//
+// The type lives in the schema package because schema.Validate is
+// the producer; internal/rules/requiredstructure is the sole
+// consumer and would import this from anywhere else. Keeping the
+// formatter alongside the producer avoids duplicating extractor
+// logic across the two packages and sidesteps the import cycle
+// that would result from defining it under internal/rules/.
+//
+// The `Schema` prefix on the name disambiguates from lint.Diagnostic
+// at import sites where both packages are visible — plan 147 names
+// the type explicitly, and renaming to schema.Diagnostic would
+// require touching every caller for purely cosmetic reasons.
+//
+//nolint:revive // intentional name; see comment above.
+type SchemaDiagnostic struct {
+	// Field names the offending input. For front-matter CUE errors
+	// it is the top-level key (or dotted path for nested values).
+	// For structure failures it is the formatted heading
+	// (e.g. "## Goal"). For filename failures it is "filename".
+	Field string
+
+	// Actual is the value the user wrote, rendered for display:
+	// strings appear quoted, scalars raw. Empty when the user
+	// supplied nothing concrete (e.g. a missing required section).
+	Actual string
+
+	// Expected describes the constraint in user vocabulary
+	// (e.g. `one of: "open", "in-progress", "done"`). Empty when
+	// the expectation is implied by Field — for instance, a
+	// "missing required section" diagnostic does not repeat the
+	// section name as the expected value.
+	Expected string
+
+	// Hint, when non-empty, points the reader at a likely fix
+	// (typically the nearest valid literal or numeric bound).
+	// Hints are best-effort; a noisy hint is worse than none, so
+	// the extractor only fires on a small set of shapes.
+	Hint string
+
+	// SchemaRef names the schema source and (when known) the line
+	// of the constraint, so the reader can locate the rule
+	// without parsing the message. Examples: "plan/proto.md:4",
+	// "inline kind schema".
+	SchemaRef string
+}
+
+// Format renders the diagnostic as the two-line message described
+// in plan 147: the first line carries field/actual/expected, an
+// optional hint follows in parentheses on its own indented line,
+// and the schema reference appears on a trailing line so it stays
+// greppable without parsing the message body.
+func (d SchemaDiagnostic) Format() string {
+	var b strings.Builder
+	b.WriteString(d.Field)
+	if d.Actual != "" {
+		b.WriteString(": got ")
+		b.WriteString(d.Actual)
+	}
+	if d.Expected != "" {
+		if d.Actual == "" {
+			b.WriteString(": expected ")
+		} else {
+			b.WriteString(", expected ")
+		}
+		b.WriteString(d.Expected)
+	}
+	if d.Hint != "" {
+		b.WriteString("\n  (")
+		b.WriteString(d.Hint)
+		b.WriteString(")")
+	}
+	if d.SchemaRef != "" {
+		b.WriteString("\nschema: ")
+		b.WriteString(d.SchemaRef)
+	}
+	return b.String()
+}
+
+// formatActual renders a JSON-decoded front-matter value for the
+// "got" segment of the diagnostic. Strings are quoted with %q so
+// the rendered message is unambiguous; numbers and bools pass
+// through Sprintf's default formatting. An explicit YAML/JSON
+// null surfaces as the literal `null` so callers can distinguish
+// "field present but null" from "field absent" — the latter sets
+// Actual to "<missing>" at the call site (see lookupFM's
+// hasActual contract). Complex shapes (maps, slices) round-trip
+// through json.Marshal so the rendered output is deterministic
+// (Go's default map formatting iterates keys in undefined order,
+// which would make the diagnostic message non-stable and break
+// the deduplication key the caller derives from Actual).
+func formatActual(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "null"
+	case string:
+		return fmt.Sprintf("%q", x)
+	case bool, int, int64, float64:
+		return fmt.Sprintf("%v", x)
+	}
+	if b, err := json.Marshal(v); err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/internal/schema/diagnostic_test.go
+++ b/internal/schema/diagnostic_test.go
@@ -1,0 +1,451 @@
+package schema
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaDiagnostic_Format_AllFields covers the full
+// SchemaDiagnostic render with field, actual, expected, hint, and
+// schema reference present. The output is a two-block message: the
+// violation summary first, then the trailing schema-ref line so it
+// stays greppable.
+func TestSchemaDiagnostic_Format_AllFields(t *testing.T) {
+	d := SchemaDiagnostic{
+		Field:     "status",
+		Actual:    `"draft"`,
+		Expected:  `one of: "open", "in-progress", "done"`,
+		Hint:      `did you mean "open"?`,
+		SchemaRef: "plan/proto.md:4",
+	}
+	got := d.Format()
+	want := "status: got \"draft\", expected one of: \"open\", \"in-progress\", \"done\"\n" +
+		"  (did you mean \"open\"?)\n" +
+		"schema: plan/proto.md:4"
+	assert.Equal(t, want, got)
+}
+
+// TestSchemaDiagnostic_Format_NoHint covers the no-hint branch:
+// when the extractor cannot suggest a fix, the message ends at the
+// expected line and goes straight to the schema reference.
+func TestSchemaDiagnostic_Format_NoHint(t *testing.T) {
+	d := SchemaDiagnostic{
+		Field:     "id",
+		Actual:    `"BAD"`,
+		Expected:  "string matching ^RFC-[0-9]{4}$",
+		SchemaRef: "kind rfc",
+	}
+	got := d.Format()
+	want := "id: got \"BAD\", expected string matching ^RFC-[0-9]{4}$\n" +
+		"schema: kind rfc"
+	assert.Equal(t, want, got)
+}
+
+// TestRenderExpected_ShapeTable exercises every shape listed in the
+// plan 147 expected-value table; the fallback "raw expression"
+// branch is covered by the unknown-shape case.
+func TestRenderExpected_ShapeTable(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			name: "string-disjunction",
+			expr: `"a" | "b" | "c"`,
+			want: `one of: "a", "b", "c"`,
+		},
+		{
+			name: "regex",
+			expr: `=~"^FOO-[0-9]{4}$"`,
+			want: `string matching ^FOO-[0-9]{4}$`,
+		},
+		{
+			name: "regex-with-string-prefix",
+			expr: `string & =~"^A$"`,
+			want: `string matching ^A$`,
+		},
+		{
+			name: "int-range-inclusive",
+			expr: `int & >=1 & <=5`,
+			want: `int between 1 and 5`,
+		},
+		{
+			name: "int-range-exclusive",
+			expr: `int & >0 & <10`,
+			want: `int between 1 and 9`,
+		},
+		{
+			name: "int-lower-only",
+			expr: `int & >=1`,
+			want: `int >= 1`,
+		},
+		{
+			name: "non-empty-string",
+			expr: `string & != ""`,
+			want: `non-empty string`,
+		},
+		{
+			name: "bool",
+			expr: `bool`,
+			want: `true or false`,
+		},
+		{
+			name: "fallback-raw",
+			expr: `[...string]`,
+			want: `[...string]`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, RenderExpected(tc.expr))
+		})
+	}
+}
+
+// TestParseFMBlockKeyLines_BlockScalarWithFenceSequence
+// regresses a Copilot review observation: the closing front-
+// matter fence was previously located via bytes.Index, which
+// would truncate early if a YAML block scalar value contained
+// the literal `---\n` sequence (e.g. a `notes: |` block whose
+// body included an em-dash row). TrimSuffix on the canonical
+// closing fence is both safer and simpler.
+func TestParseFMBlockKeyLines_BlockScalarWithFenceSequence(t *testing.T) {
+	// `notes:` is a block scalar whose value contains "---\n"
+	// inside the body. The closing `---\n` fence sits at the
+	// end. The walker must still see both top-level keys and
+	// place each on its source line.
+	fm := []byte(
+		"---\n" +
+			"id: 1\n" +
+			"notes: |\n" +
+			"  ---\n" +
+			"  some literal text\n" +
+			"status: open\n" +
+			"---\n")
+	lines := parseFMBlockKeyLines(fm)
+	require.NotNil(t, lines)
+	assert.Equal(t, 2, lines["id"])
+	assert.Equal(t, 3, lines["notes"])
+	assert.Equal(t, 6, lines["status"])
+}
+
+// TestValidateFrontmatterDiags_CompileFailureCarriesSchemaRef
+// regresses the Copilot review observation that early-return
+// diagnostics for unrecoverable CUE/JSON failures used to drop
+// the trailing `schema: ...` line. Every diagnostic the
+// validator emits now uses SchemaDiagnostic so the source is
+// always present.
+func TestValidateFrontmatterDiags_CompileFailureCarriesSchemaRef(t *testing.T) {
+	sch := &Schema{
+		Source: "kind broken",
+		Frontmatter: map[string]string{
+			// Deliberately malformed CUE expression so
+			// CompileString fails on the schema itself.
+			"id": `int &`,
+		},
+	}
+	doc := newDocFile(t, "doc.md", "# T\n")
+	diags := ValidateFrontmatterDiags(doc, sch, map[string]any{"id": 1}, makeDiagForTest)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "schema:")
+	assert.Contains(t, diags[0].Message, "kind broken")
+}
+
+// TestRenderExpected_IntRangeOverflowGuard regresses two
+// Copilot review observations:
+//
+//   - `int & >MaxInt` would previously do `MaxInt + 1` and
+//     silently wrap to MinInt, producing a meaningless inclusive
+//     bound.
+//   - Converting it to `int >= MaxInt` is also wrong: the
+//     original constraint `int > MaxInt` is unsatisfiable, but
+//     `int >= MaxInt` accepts MaxInt itself.
+//
+// The renderer now keeps the exclusive form when the bound
+// can't be converted without overflow, so the rendered message
+// preserves the original semantics.
+func TestRenderExpected_IntRangeOverflowGuard(t *testing.T) {
+	maxStr := strconv.Itoa(math.MaxInt)
+	minStr := strconv.Itoa(math.MinInt)
+
+	// >MaxInt: cannot become >=MaxInt+1, so render `int > MaxInt`
+	// (exclusive) rather than the misleading inclusive form.
+	rendered := RenderExpected("int & >" + maxStr)
+	assert.Equal(t, "int > "+maxStr, rendered,
+		"upper-overflow guard should keep the exclusive form")
+
+	// <MinInt: mirror case for the upper bound.
+	rendered = RenderExpected("int & <" + minStr)
+	assert.Equal(t, "int < "+minStr, rendered,
+		"lower-overflow guard should keep the exclusive form")
+}
+
+// TestRenderHint_StringDisjunctionTypo covers the Levenshtein
+// path: an actual within distance 2 of a literal alternative gets
+// suggested.
+func TestRenderHint_StringDisjunctionTypo(t *testing.T) {
+	expr := `"draft" | "open" | "done"`
+	assert.Equal(t, `did you mean "draft"?`, RenderHint(expr, "draf"))
+	assert.Equal(t, `did you mean "open"?`, RenderHint(expr, "ope"))
+}
+
+// TestRenderHint_StringDisjunctionTooFar exercises the silent
+// branch: an actual far from any literal returns no hint so the
+// message doesn't add noise.
+func TestRenderHint_StringDisjunctionTooFar(t *testing.T) {
+	expr := `"draft" | "open" | "done"`
+	assert.Empty(t, RenderHint(expr, "completely-different"))
+}
+
+// TestRenderHint_IntRange covers the numeric-range suggestion:
+// a value just outside the range is hinted with the nearest bound.
+func TestRenderHint_IntRange(t *testing.T) {
+	expr := `int & >=1 & <=5`
+	assert.Equal(t, "try 1", RenderHint(expr, float64(0)))
+	assert.Equal(t, "try 5", RenderHint(expr, float64(6)))
+	// In-range values get no hint.
+	assert.Empty(t, RenderHint(expr, float64(3)))
+}
+
+// TestRenderHint_HugeActualSkipsLev regresses the Copilot review
+// finding that levenshtein previously materialised a full rune
+// slice before consulting maxLevInput. A multi-megabyte actual
+// value should short-circuit without allocating its rune
+// representation, and the returned hint should still be empty
+// because the input is too dissimilar from any literal.
+func TestRenderHint_HugeActualSkipsLev(t *testing.T) {
+	expr := `"open" | "done"`
+	huge := strings.Repeat("a", 1<<20) // 1 MiB
+	assert.Empty(t, RenderHint(expr, huge),
+		"oversized actual should not produce a hint")
+}
+
+// TestValidateFrontmatterDiags_OnePerError covers acceptance
+// criterion 2: three FM violations produce three diagnostics, each
+// anchored to its own field.
+func TestValidateFrontmatterDiags_OnePerError(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"a": `"x" | "y"`,
+			"b": `int & >=1`,
+			"c": `=~"^Z"`,
+		},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n")
+	docFM := map[string]any{
+		"a": "wrong",
+		"b": float64(0),
+		"c": "nope",
+	}
+	diags := ValidateFrontmatterDiags(doc, sch, docFM, makeDiagForTest)
+	require.Len(t, diags, 3)
+	fields := map[string]bool{}
+	for _, d := range diags {
+		// The first segment of each message is the field name
+		// followed by ": got ...".
+		fields[firstField(d.Message)] = true
+	}
+	assert.True(t, fields["a"], "missing diagnostic for field a")
+	assert.True(t, fields["b"], "missing diagnostic for field b")
+	assert.True(t, fields["c"], "missing diagnostic for field c")
+}
+
+func firstField(msg string) string {
+	for i := 0; i < len(msg); i++ {
+		if msg[i] == ':' {
+			return msg[:i]
+		}
+	}
+	return msg
+}
+
+// TestValidateFrontmatterDiags_PopulatesRuleIDAndName regresses
+// acceptance criterion 7: every emitted diagnostic carries
+// MDS020/required-structure so the LSP can map them to Source and
+// Code on the wire.
+func TestValidateFrontmatterDiags_PopulatesRuleIDAndName(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"id": `int & >=1`,
+		},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n")
+	docFM := map[string]any{"id": "not-an-int"}
+	mkDiag := func(file string, line int, msg string) lint.Diagnostic {
+		return lint.Diagnostic{
+			File:     file,
+			Line:     line,
+			RuleID:   "MDS020",
+			RuleName: "required-structure",
+			Message:  msg,
+		}
+	}
+	diags := ValidateFrontmatterDiags(doc, sch, docFM, mkDiag)
+	require.NotEmpty(t, diags)
+	for _, d := range diags {
+		assert.Equal(t, "MDS020", d.RuleID)
+		assert.Equal(t, "required-structure", d.RuleName)
+	}
+}
+
+// TestSchemaRef_FileWithLine covers the proto.md schema-ref form:
+// when the schema parser captured the per-key line in
+// FrontmatterLines, the rendered ref appends ":<line>" so users
+// jump straight to the constraint.
+func TestSchemaRef_FileWithLine(t *testing.T) {
+	sch := &Schema{
+		Source: "plan/proto.md",
+		Frontmatter: map[string]string{
+			"status": `"open" | "done"`,
+		},
+		FrontmatterLines: map[string]int{
+			"status": 4,
+		},
+	}
+	assert.Equal(t, "plan/proto.md:4", FormatSchemaRef(sch, "status"))
+}
+
+// TestSchemaRef_WithoutLine covers the fallback branch: an inline
+// schema (no per-key lines) emits just the source label.
+func TestSchemaRef_WithoutLine(t *testing.T) {
+	sch := &Schema{Source: "kind rfc"}
+	assert.Equal(t, "kind rfc", FormatSchemaRef(sch, "status"))
+}
+
+// TestValidateFrontmatterDiags_MissingRequiredFieldShowsMissing
+// regresses a Copilot review comment: a required field absent
+// from the document should surface as `<missing>` in the actual
+// slot rather than dropping that segment entirely, so every
+// diagnostic answers field / got / expected.
+func TestValidateFrontmatterDiags_MissingRequiredFieldShowsMissing(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"id": `int & >=1`,
+		},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n")
+	diags := ValidateFrontmatterDiags(doc, sch, nil, makeDiagForTest)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "id: got <missing>")
+	assert.Contains(t, diags[0].Message, "expected int >= 1")
+}
+
+// TestValidateFrontmatterDiags_AnchorsAtKeyLine regresses the
+// Copilot finding that FM diagnostics were anchored at line 1
+// regardless of where the offending key lived. With doc FM
+// parsing we now point at the key's actual source line so the
+// editor squiggle lands on the right row.
+func TestValidateFrontmatterDiags_AnchorsAtKeyLine(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"id":     `int & >=1`,
+			"status": `"open" | "done"`,
+		},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	// status sits on file line 3: line 1 = "---", line 2 = id,
+	// line 3 = status, line 4 = "---", line 5 = body.
+	doc := newDocFile(t, "doc.md",
+		"---\nid: 1\nstatus: bogus\n---\n# Body\n")
+	docFM := map[string]any{"id": float64(1), "status": "bogus"}
+	diags := ValidateFrontmatterDiags(doc, sch, docFM, makeDiagForTest)
+	require.NotEmpty(t, diags)
+	var statusLine int
+	for _, d := range diags {
+		if strings.HasPrefix(d.Message, "status:") {
+			statusLine = d.Line
+		}
+	}
+	assert.Equal(t, 3, statusLine,
+		"status diagnostic should be anchored at the key's source line")
+}
+
+// TestFormatActual_DeterministicMap regresses the comment/behavior
+// mismatch noted in code review: map values now JSON-marshal so
+// the rendered output is stable across runs.
+func TestFormatActual_DeterministicMap(t *testing.T) {
+	v := map[string]any{"b": 2, "a": 1, "c": 3}
+	// Two renders must match — Go's default map formatter does not
+	// guarantee key order, but JSON marshalling does.
+	got1 := formatActual(v)
+	got2 := formatActual(v)
+	assert.Equal(t, got1, got2)
+	assert.Equal(t, `{"a":1,"b":2,"c":3}`, got1)
+}
+
+// TestLookupFM_HandlesListIndices regresses a Copilot review
+// finding: a CUE error path that includes a list index (e.g.
+// `tags.1`) used to bottom out at the slice step because
+// lookupFM only descended through map[string]any. The diagnostic
+// then claimed `<missing>` for a value that was actually
+// present. lookupFM now parses numeric segments as list indices
+// and returns the leaf value.
+func TestLookupFM_HandlesListIndices(t *testing.T) {
+	fm := map[string]any{
+		"tags": []any{"alpha", "beta", "gamma"},
+		"nested": map[string]any{
+			"items": []any{
+				map[string]any{"id": "x"},
+				map[string]any{"id": "y"},
+			},
+		},
+	}
+	v, ok := lookupFM(fm, []string{"tags", "1"})
+	require.True(t, ok)
+	assert.Equal(t, "beta", v)
+
+	v, ok = lookupFM(fm, []string{"nested", "items", "1", "id"})
+	require.True(t, ok)
+	assert.Equal(t, "y", v)
+
+	// Out-of-range index reports absent.
+	_, ok = lookupFM(fm, []string{"tags", "99"})
+	assert.False(t, ok)
+
+	// Non-numeric segment on a list reports absent.
+	_, ok = lookupFM(fm, []string{"tags", "name"})
+	assert.False(t, ok)
+}
+
+// TestValidateFrontmatterDiags_NullDistinctFromMissing regresses
+// the Copilot review observation that an explicit YAML null was
+// rendering as `<missing>`, conflating "field present but null"
+// with "field absent". The two cases should now produce distinct
+// "got" values so users can tell which problem they have.
+func TestValidateFrontmatterDiags_NullDistinctFromMissing(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"id": `int & >=1`,
+		},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n")
+
+	// Explicit null: docFM has the key set to nil.
+	nullDiags := ValidateFrontmatterDiags(doc, sch, map[string]any{"id": nil}, makeDiagForTest)
+	require.NotEmpty(t, nullDiags)
+	assert.Contains(t, nullDiags[0].Message, "id: got null")
+	assert.NotContains(t, nullDiags[0].Message, "<missing>")
+
+	// Absent: docFM does not carry the key at all.
+	missingDiags := ValidateFrontmatterDiags(doc, sch, map[string]any{}, makeDiagForTest)
+	require.NotEmpty(t, missingDiags)
+	assert.Contains(t, missingDiags[0].Message, "id: got <missing>")
+	assert.NotContains(t, missingDiags[0].Message, "got null")
+}

--- a/internal/schema/diagnostic_test.go
+++ b/internal/schema/diagnostic_test.go
@@ -32,6 +32,42 @@ func TestSchemaDiagnostic_Format_AllFields(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+// TestSchemaDiagnostic_Format_NoActual covers the branch
+// where Field and Expected are set but Actual is empty: the
+// rendered message uses ": expected ..." rather than the
+// "got X, expected Y" form, so absent-but-known constraints
+// (e.g. a wildcard-text scope) read cleanly.
+func TestSchemaDiagnostic_Format_NoActual(t *testing.T) {
+	d := SchemaDiagnostic{
+		Field:     "## Goal",
+		Expected:  "section to be present",
+		SchemaRef: "kind plan",
+	}
+	want := "## Goal: expected section to be present\nschema: kind plan"
+	assert.Equal(t, want, d.Format())
+}
+
+// TestSchemaDiagnostic_Format_FieldOnly covers the very
+// minimal render: just a field name with no actual,
+// expected, hint, or schema ref. The renderer should still
+// produce a non-empty string.
+func TestSchemaDiagnostic_Format_FieldOnly(t *testing.T) {
+	d := SchemaDiagnostic{Field: "field"}
+	assert.Equal(t, "field", d.Format())
+}
+
+// TestFormatActual_FallbackOnMarshalError exercises the
+// final fmt.Sprintf("%v", v) fallback. json.Marshal fails
+// on channels, functions, and complex values; the helper
+// degrades to the default formatter so the caller still
+// gets a printable string.
+func TestFormatActual_FallbackOnMarshalError(t *testing.T) {
+	// Channels can't be JSON-marshalled; the helper falls
+	// through to %v which produces a pointer-shaped string.
+	got := formatActual(make(chan int))
+	assert.NotEmpty(t, got)
+}
+
 // TestSchemaDiagnostic_Format_NoHint covers the no-hint branch:
 // when the extractor cannot suggest a fix, the message ends at the
 // expected line and goes straight to the schema reference.

--- a/internal/schema/expected.go
+++ b/internal/schema/expected.go
@@ -1,0 +1,261 @@
+package schema
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+// RenderExpected converts a raw CUE constraint expression into a
+// user-facing "expected" string. It recognises the common shapes
+// listed in plan 147 — string disjunctions, regex matchers,
+// numeric ranges, non-empty strings, and bool — and falls back to
+// the verbatim expression when nothing matches. The fallback is
+// deliberately the raw CUE so the user can still copy/paste into
+// the schema; an over-eager translation that drops type
+// information would be worse than the literal expression.
+func RenderExpected(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return expr
+	}
+	if rendered, ok := renderStringDisjunction(expr); ok {
+		return rendered
+	}
+	if rendered, ok := renderRegex(expr); ok {
+		return rendered
+	}
+	if rendered, ok := renderIntRange(expr); ok {
+		return rendered
+	}
+	if rendered, ok := renderNonEmptyString(expr); ok {
+		return rendered
+	}
+	if expr == "bool" {
+		return "true or false"
+	}
+	return expr
+}
+
+// renderStringDisjunction matches `"a" | "b" | "c"` and renders
+// it as `one of: "a", "b", "c"`. Disjunctions mixing strings with
+// other types fall through to the raw expression so the user is
+// not misled into thinking only the string branches are allowed.
+func renderStringDisjunction(expr string) (string, bool) {
+	parts := splitTopLevel(expr, '|')
+	if len(parts) < 2 {
+		return "", false
+	}
+	literals := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		// Strip a leading `*` (CUE default marker) before checking
+		// for a string literal; the default is a UX hint, not a
+		// new shape.
+		s = strings.TrimPrefix(s, "*")
+		if !isQuotedString(s) {
+			return "", false
+		}
+		literals = append(literals, s)
+	}
+	return "one of: " + strings.Join(literals, ", "), true
+}
+
+// renderRegex matches `=~"<pattern>"` (with optional surrounding
+// `string &`) and renders it as `string matching <pattern>`.
+// Bare regex matchers without a `string &` cover the common
+// proto.md shape; constraints that further restrict the type
+// fall through to the raw expression.
+func renderRegex(expr string) (string, bool) {
+	body := expr
+	body = strings.TrimSpace(body)
+	body = strings.TrimPrefix(body, "string &")
+	body = strings.TrimSpace(body)
+	if !strings.HasPrefix(body, "=~") {
+		return "", false
+	}
+	pattern := strings.TrimSpace(strings.TrimPrefix(body, "=~"))
+	if !isQuotedString(pattern) {
+		return "", false
+	}
+	unquoted, err := strconv.Unquote(pattern)
+	if err != nil {
+		return "", false
+	}
+	return "string matching " + unquoted, true
+}
+
+// intRangeBounds captures the parsed lower/upper bounds of an
+// `int & ...` constraint, along with whether each remains
+// exclusive after the overflow-safe `+1`/`-1` inclusive shift.
+type intRangeBounds struct {
+	lo, hi                   string
+	loExclusive, hiExclusive bool
+}
+
+// renderIntRange matches `int & >=N & <=M`, `int & >N & <M`, or
+// any combination of the two operators in either order and
+// renders it as `int between N and M`. Half-open ranges
+// (`int & >=N`) render as `int >= N` so the reader sees the
+// bound; fully unbounded ints fall through to the raw expression.
+func renderIntRange(expr string) (string, bool) {
+	parts := splitTopLevel(expr, '&')
+	if len(parts) < 2 {
+		return "", false
+	}
+	bounds, hasInt, ok := parseIntRangeBounds(parts)
+	if !ok || !hasInt {
+		return "", false
+	}
+	bounds.tryConvertExclusive()
+	return bounds.render()
+}
+
+// parseIntRangeBounds walks the &-separated parts and pulls out
+// the `int` marker plus any `>`, `>=`, `<`, `<=` bounds. A part
+// that doesn't fit the small grammar aborts the rendering by
+// returning ok=false so the caller falls back to the raw CUE
+// expression rather than rendering a partial constraint.
+func parseIntRangeBounds(parts []string) (intRangeBounds, bool, bool) {
+	var b intRangeBounds
+	hasInt := false
+	loInclusive, hiInclusive := false, false
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		switch {
+		case s == "int":
+			hasInt = true
+		case strings.HasPrefix(s, ">="):
+			b.lo = strings.TrimSpace(strings.TrimPrefix(s, ">="))
+			loInclusive = true
+		case strings.HasPrefix(s, ">"):
+			b.lo = strings.TrimSpace(strings.TrimPrefix(s, ">"))
+		case strings.HasPrefix(s, "<="):
+			b.hi = strings.TrimSpace(strings.TrimPrefix(s, "<="))
+			hiInclusive = true
+		case strings.HasPrefix(s, "<"):
+			b.hi = strings.TrimSpace(strings.TrimPrefix(s, "<"))
+		default:
+			return intRangeBounds{}, false, false
+		}
+	}
+	b.loExclusive = !loInclusive && b.lo != ""
+	b.hiExclusive = !hiInclusive && b.hi != ""
+	return b, hasInt, true
+}
+
+// tryConvertExclusive turns `> N` into `>= N+1` (and `< N` into
+// `<= N-1`) when N is an integer literal and the increment stays
+// inside int's range. Bounds that would overflow keep their
+// exclusive form so the rendered message preserves the original
+// semantics — `int & >MaxInt` is unsatisfiable, but rendering it
+// as `int >= MaxInt` would suggest MaxInt itself satisfied the
+// constraint. CUE permits non-integer comparison targets, but
+// our schemas almost always use integer literals.
+func (b *intRangeBounds) tryConvertExclusive() {
+	if b.loExclusive {
+		if n, err := strconv.Atoi(b.lo); err == nil && n < math.MaxInt {
+			b.lo = strconv.Itoa(n + 1)
+			b.loExclusive = false
+		}
+	}
+	if b.hiExclusive {
+		if n, err := strconv.Atoi(b.hi); err == nil && n > math.MinInt {
+			b.hi = strconv.Itoa(n - 1)
+			b.hiExclusive = false
+		}
+	}
+}
+
+// render produces the final user-facing string from the parsed
+// bounds: `int between N and M` for closed two-sided ranges,
+// `int > N and <= M` (or similar) when one side stays exclusive,
+// and `int >= N` / `int <= N` for half-open ranges.
+func (b *intRangeBounds) render() (string, bool) {
+	switch {
+	case b.lo != "" && b.hi != "" && !b.loExclusive && !b.hiExclusive:
+		return "int between " + b.lo + " and " + b.hi, true
+	case b.lo != "" && b.hi != "":
+		return "int " + lowerOp(b.loExclusive) + " " + b.lo +
+			" and " + upperOp(b.hiExclusive) + " " + b.hi, true
+	case b.lo != "":
+		return "int " + lowerOp(b.loExclusive) + " " + b.lo, true
+	case b.hi != "":
+		return "int " + upperOp(b.hiExclusive) + " " + b.hi, true
+	}
+	return "", false
+}
+
+func lowerOp(exclusive bool) string {
+	if exclusive {
+		return ">"
+	}
+	return ">="
+}
+
+func upperOp(exclusive bool) string {
+	if exclusive {
+		return "<"
+	}
+	return "<="
+}
+
+// renderNonEmptyString matches `string & != ""` (in either
+// operand order) and renders it as `non-empty string`.
+func renderNonEmptyString(expr string) (string, bool) {
+	parts := splitTopLevel(expr, '&')
+	if len(parts) != 2 {
+		return "", false
+	}
+	hasString, hasNonEmpty := false, false
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		switch s {
+		case "string":
+			hasString = true
+		case `!= ""`, `!=""`:
+			hasNonEmpty = true
+		}
+	}
+	if hasString && hasNonEmpty {
+		return "non-empty string", true
+	}
+	return "", false
+}
+
+// splitTopLevel splits expr on every occurrence of sep that is
+// not inside double quotes or parentheses. CUE expressions
+// occasionally embed `|` inside a regex string or a parenthesised
+// subexpression; a naive strings.Split would mangle those.
+func splitTopLevel(expr string, sep byte) []string {
+	var out []string
+	depth := 0
+	inString := false
+	start := 0
+	for i := 0; i < len(expr); i++ {
+		c := expr[i]
+		switch {
+		case c == '\\' && i+1 < len(expr):
+			i++ // skip escaped char
+		case c == '"':
+			inString = !inString
+		case !inString && (c == '(' || c == '['):
+			depth++
+		case !inString && (c == ')' || c == ']'):
+			depth--
+		case !inString && depth == 0 && c == sep:
+			out = append(out, expr[start:i])
+			start = i + 1
+		}
+	}
+	out = append(out, expr[start:])
+	return out
+}
+
+// isQuotedString reports whether s begins and ends with `"`.
+// CUE single-quote string literals are rare in our schemas; we
+// accept only the canonical double-quoted form so the extractor
+// is unambiguous.
+func isQuotedString(s string) bool {
+	return len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"'
+}

--- a/internal/schema/expected.go
+++ b/internal/schema/expected.go
@@ -61,15 +61,25 @@ func renderStringDisjunction(expr string) (string, bool) {
 	return "one of: " + strings.Join(literals, ", "), true
 }
 
-// renderRegex matches `=~"<pattern>"` (with optional surrounding
-// `string &`) and renders it as `string matching <pattern>`.
-// Bare regex matchers without a `string &` cover the common
-// proto.md shape; constraints that further restrict the type
-// fall through to the raw expression.
+// renderRegex matches `=~"<pattern>"` (with an optional
+// surrounding `string &`) and renders it as `string matching
+// <pattern>`. Bare regex matchers without a `string &` cover
+// the common proto.md shape; constraints that further restrict
+// the type fall through to the raw expression.
+//
+// CUE doesn't require whitespace around `&`, so both
+// `string & =~"^A$"` and `string&=~"^A$"` are valid input.
+// We normalise by splitting on the `=~` token directly rather
+// than the whitespace-sensitive `string &` prefix, so format
+// drift on the input side doesn't lose the rendered shape.
 func renderRegex(expr string) (string, bool) {
-	body := expr
+	body := strings.TrimSpace(expr)
+	// Strip an optional `string` prefix and any `&` (with or
+	// without surrounding whitespace) so we land directly on
+	// the `=~` token.
+	body = strings.TrimPrefix(body, "string")
 	body = strings.TrimSpace(body)
-	body = strings.TrimPrefix(body, "string &")
+	body = strings.TrimPrefix(body, "&")
 	body = strings.TrimSpace(body)
 	if !strings.HasPrefix(body, "=~") {
 		return "", false

--- a/internal/schema/expected_coverage_test.go
+++ b/internal/schema/expected_coverage_test.go
@@ -78,3 +78,36 @@ func TestRenderExpected_IntRangeUnknownOperand(t *testing.T) {
 	got := RenderExpected("int & some-other & >=1")
 	assert.Equal(t, "int & some-other & >=1", got)
 }
+
+// TestRenderExpected_RegexNoWhitespace regresses a Copilot
+// review observation: `string&=~"^A$"` (no spaces around `&`)
+// is semantically equivalent to `string & =~"^A$"`. Both now
+// render as `string matching <pattern>` instead of falling
+// through to the raw expression.
+func TestRenderExpected_RegexNoWhitespace(t *testing.T) {
+	cases := map[string]string{
+		`string&=~"^A$"`:  "string matching ^A$",
+		`string &=~"^B$"`: "string matching ^B$",
+		`string& =~"^C$"`: "string matching ^C$",
+		`=~"^D$"`:         "string matching ^D$",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, RenderExpected(in), "input: %q", in)
+	}
+}
+
+// TestRenderExpected_RegexUnquoteFailure covers the
+// strconv.Unquote error branch in renderRegex: a pattern
+// with a malformed escape sequence (e.g. `\q` which Go does
+// not recognise) is rejected after isQuotedString accepts
+// the outer quotes.
+func TestRenderExpected_RegexUnquoteFailure(t *testing.T) {
+	assert.Equal(t, `=~"\q"`, RenderExpected(`=~"\q"`))
+}
+
+// TestRenderExpected_IntRangeUpperHalfOpen covers the
+// half-open upper-bound render branch (`int <= N`) that the
+// other tests miss when the lower bound is unspecified.
+func TestRenderExpected_IntRangeUpperHalfOpen(t *testing.T) {
+	assert.Equal(t, "int <= 5", RenderExpected("int & <=5"))
+}

--- a/internal/schema/expected_coverage_test.go
+++ b/internal/schema/expected_coverage_test.go
@@ -1,0 +1,80 @@
+package schema
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderExpected_Edges exercises the early-return branches
+// in RenderExpected and renderStringDisjunction / renderRegex /
+// renderNonEmptyString that previously had no test coverage.
+func TestRenderExpected_Edges(t *testing.T) {
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.Equal(t, "", RenderExpected(""))
+		// Whitespace-only is trimmed to "" before any shape
+		// matches; the renderer returns the trimmed value.
+		assert.Equal(t, "", RenderExpected("   "))
+	})
+
+	t.Run("disjunction with non-quoted alternative falls back", func(t *testing.T) {
+		// `int | "x"` has a non-string-literal alternative; the
+		// renderer should fall back to the raw expression
+		// rather than misreport.
+		assert.Equal(t, `int | "x"`, RenderExpected(`int | "x"`))
+	})
+
+	t.Run("regex with bad unquote falls back", func(t *testing.T) {
+		// A regex pattern that uses single-quote delimiters
+		// (CUE accepts double-quoted only) can't be unquoted;
+		// the renderer falls through to the raw form.
+		assert.Equal(t, `=~'foo'`, RenderExpected(`=~'foo'`))
+	})
+
+	t.Run("regex without quoted pattern falls back", func(t *testing.T) {
+		assert.Equal(t, `=~foo`, RenderExpected(`=~foo`))
+	})
+}
+
+// TestRenderExpected_IntRangeMixed covers the mixed-exclusive
+// render branch: when one bound can be converted to inclusive
+// (`<= N-1`) but the other can't (`>MaxInt`), the renderer
+// emits both with explicit comparison operators so the
+// asymmetry stays visible.
+func TestRenderExpected_IntRangeMixed(t *testing.T) {
+	maxStr := strconv.Itoa(math.MaxInt)
+	got := RenderExpected("int & >" + maxStr + " & <=10")
+	assert.Contains(t, got, "int > "+maxStr)
+	assert.Contains(t, got, "and <= 10")
+}
+
+// TestRenderExpected_IntRangeOnlyExclusiveUpper exercises the
+// half-open upper-bound rendering with an exclusive `<` form
+// that the overflow guard preserves intact.
+func TestRenderExpected_IntRangeOnlyExclusiveUpper(t *testing.T) {
+	minStr := strconv.Itoa(math.MinInt)
+	got := RenderExpected("int & <" + minStr)
+	assert.Equal(t, "int < "+minStr, got)
+}
+
+// TestRenderExpected_IntRangeNoIntKeyword regresses the early
+// false return when the `int` keyword is missing from the
+// constraint (e.g. `>=1 & <=5` without `int &`). The
+// constraint isn't recognised as an int range, so the renderer
+// falls back to the raw expression.
+func TestRenderExpected_IntRangeNoIntKeyword(t *testing.T) {
+	got := RenderExpected(">=1 & <=5")
+	assert.Equal(t, ">=1 & <=5", got)
+}
+
+// TestRenderExpected_IntRangeUnknownOperand exercises the
+// fallback when a `&`-joined part doesn't fit the small
+// grammar (int / >=, >, <=, <). The renderer aborts and falls
+// back to the raw expression so a partial constraint never
+// reaches the user.
+func TestRenderExpected_IntRangeUnknownOperand(t *testing.T) {
+	got := RenderExpected("int & some-other & >=1")
+	assert.Equal(t, "int & some-other & >=1", got)
+}

--- a/internal/schema/expected_coverage_test.go
+++ b/internal/schema/expected_coverage_test.go
@@ -111,3 +111,12 @@ func TestRenderExpected_RegexUnquoteFailure(t *testing.T) {
 func TestRenderExpected_IntRangeUpperHalfOpen(t *testing.T) {
 	assert.Equal(t, "int <= 5", RenderExpected("int & <=5"))
 }
+
+// TestRenderIntRange_NoBoundsFallsThrough exercises the
+// final fallback inside (*intRangeBounds).render: an
+// `int & int` constraint has the int keyword twice but no
+// bounds on either side, so render returns ("", false) and
+// RenderExpected falls back to the raw expression.
+func TestRenderIntRange_NoBoundsFallsThrough(t *testing.T) {
+	assert.Equal(t, "int & int", RenderExpected("int & int"))
+}

--- a/internal/schema/hint.go
+++ b/internal/schema/hint.go
@@ -1,0 +1,277 @@
+package schema
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// RenderHint returns a best-effort suggestion for fixing the
+// violation. It only fires on a small set of shapes:
+//
+//   - String disjunctions: when the actual value is within
+//     Levenshtein distance 2 of one of the literal alternatives,
+//     suggest that literal.
+//   - Integer ranges: when the actual value is just outside the
+//     declared bounds, suggest the nearest bound.
+//
+// All other shapes return the empty string. A noisy hint (for
+// instance, a regex pattern naïvely echoed at the user) is worse
+// than no hint, so the extractor errs on the side of silence.
+//
+// actual is the raw front-matter value as decoded from JSON;
+// numbers arrive as float64 from json.Unmarshal.
+func RenderHint(expr string, actual any) string {
+	expr = strings.TrimSpace(expr)
+	if h := hintForStringDisjunction(expr, actual); h != "" {
+		return h
+	}
+	if h := hintForIntRange(expr, actual); h != "" {
+		return h
+	}
+	return ""
+}
+
+func hintForStringDisjunction(expr string, actual any) string {
+	s, ok := actual.(string)
+	if !ok {
+		return ""
+	}
+	parts := splitTopLevel(expr, '|')
+	if len(parts) < 2 {
+		return ""
+	}
+	literals := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		t = strings.TrimPrefix(t, "*")
+		if !isQuotedString(t) {
+			return ""
+		}
+		unq, err := strconv.Unquote(t)
+		if err != nil {
+			return ""
+		}
+		literals = append(literals, unq)
+	}
+	best := ""
+	bestDist := -1
+	for _, lit := range literals {
+		d := levenshtein(s, lit)
+		if d == 0 {
+			// Exact match — should not happen on a violation, but
+			// returning a hint that says "did you mean X?" when X
+			// equals the actual value would be confusing.
+			return ""
+		}
+		if d > 2 {
+			continue
+		}
+		if bestDist == -1 || d < bestDist {
+			best = lit
+			bestDist = d
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	// %q safely quotes the candidate so a literal containing a
+	// double quote cannot break out of the surrounding quotes in
+	// the rendered message (CodeQL go/unsafe-quoting).
+	return fmt.Sprintf("did you mean %q?", best)
+}
+
+func hintForIntRange(expr string, actual any) string {
+	rendered, ok := renderIntRange(expr)
+	if !ok {
+		return ""
+	}
+	n, ok := toFloat64(actual)
+	if !ok {
+		return ""
+	}
+	// Re-derive the bounds from the rendered form: parseBounds
+	// extracts (lo, hi) from "int between N and M" / "int >= N" /
+	// "int <= N". This keeps the bound source in one place
+	// (renderIntRange) and avoids duplicating the parser here.
+	lo, hi, hasLo, hasHi := parseRenderedBounds(rendered)
+	switch {
+	case hasLo && n < float64(lo):
+		return "try " + strconv.Itoa(lo)
+	case hasHi && n > float64(hi):
+		return "try " + strconv.Itoa(hi)
+	}
+	return ""
+}
+
+func parseRenderedBounds(rendered string) (lo, hi int, hasLo, hasHi bool) {
+	switch {
+	case strings.HasPrefix(rendered, "int between "):
+		body := strings.TrimPrefix(rendered, "int between ")
+		idx := strings.Index(body, " and ")
+		if idx < 0 {
+			return 0, 0, false, false
+		}
+		var err error
+		lo, err = strconv.Atoi(body[:idx])
+		if err != nil {
+			return 0, 0, false, false
+		}
+		hi, err = strconv.Atoi(body[idx+len(" and "):])
+		if err != nil {
+			return 0, 0, false, false
+		}
+		return lo, hi, true, true
+	case strings.HasPrefix(rendered, "int >= "):
+		n, err := strconv.Atoi(strings.TrimPrefix(rendered, "int >= "))
+		if err != nil {
+			return 0, 0, false, false
+		}
+		return n, 0, true, false
+	case strings.HasPrefix(rendered, "int <= "):
+		n, err := strconv.Atoi(strings.TrimPrefix(rendered, "int <= "))
+		if err != nil {
+			return 0, 0, false, false
+		}
+		return 0, n, false, true
+	}
+	return 0, 0, false, false
+}
+
+func toFloat64(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	}
+	return 0, false
+}
+
+// levenshtein returns the edit distance between a and b. The
+// implementation is the textbook two-row DP; the hint extractor
+// only calls it on short strings (front-matter enum literals),
+// so the O(len(a)*len(b)) cost is negligible. Unicode is handled
+// by comparing runes, not bytes, so a typo in a multi-byte rune
+// still counts as one edit.
+//
+// Inputs longer than maxLevInput runes short-circuit to a
+// length-based upper bound. The hint extractor only uses
+// distance ≤ 2 to suggest a literal, so any value beyond the
+// guard is far too dissimilar to produce a hint anyway. The cap
+// also satisfies CodeQL's go/allocation-size-overflow finding
+// for the `len(rb)+1` row allocations: bounded inputs cannot
+// overflow `int` arithmetic.
+//
+// The length guard runs before allocating rune slices for a or
+// b: a multi-megabyte front-matter string would otherwise
+// materialise into a rune slice the size of the input before we
+// got a chance to short-circuit, defeating the protection the
+// guard is meant to provide.
+const maxLevInput = 1024
+
+func levenshtein(a, b string) int {
+	if tooLongForLevInput(a) || tooLongForLevInput(b) {
+		// At least one operand exceeds the cap; return the
+		// longer rune count capped at maxLevInput+1. The capped
+		// value is still an upper bound on the true distance,
+		// and that's all callers need — the hint extractor only
+		// suggests literals within distance 2, so anything >= 3
+		// (the cap is much larger) already kills the hint. The
+		// `for range` walk inside runeCountAtMost iterates runes
+		// without allocating, so a multi-megabyte operand never
+		// materialises into a `[]rune` here.
+		ca := runeCountAtMost(a, maxLevInput+1)
+		cb := runeCountAtMost(b, maxLevInput+1)
+		if ca > cb {
+			return ca
+		}
+		return cb
+	}
+	ra := []rune(a)
+	rb := []rune(b)
+	// Belt-and-braces bound CodeQL can prove locally:
+	// tooLongForLevInput above already returns early for any
+	// over-cap input, but the static analyser cannot follow
+	// the bound through the helper, so it kept flagging the
+	// `len(rb)+1` allocation. The inline guard here pins the
+	// length to a constant CodeQL can see, mirroring the
+	// length-based fallback above without changing behaviour.
+	if len(ra) > maxLevInput || len(rb) > maxLevInput {
+		if len(ra) > len(rb) {
+			return len(ra)
+		}
+		return len(rb)
+	}
+	if len(ra) == 0 {
+		return len(rb)
+	}
+	if len(rb) == 0 {
+		return len(ra)
+	}
+	rows := len(rb) + 1
+	prev := make([]int, rows)
+	curr := make([]int, rows)
+	for j := 0; j < rows; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j < rows; j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = minInt(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}
+
+func minInt(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// tooLongForLevInput reports whether s has more than maxLevInput
+// runes. It iterates via `for range` so no `[]rune` slice is
+// allocated and returns as soon as the threshold is crossed —
+// the caller only needs the yes/no answer.
+func tooLongForLevInput(s string) bool {
+	n := 0
+	for range s {
+		n++
+		if n > maxLevInput {
+			return true
+		}
+	}
+	return false
+}
+
+// runeCountAtMost returns the rune count of s capped at limit.
+// Used in the levenshtein over-cap branch to compute the length
+// upper bound without materialising the full rune slice for very
+// long inputs.
+func runeCountAtMost(s string, limit int) int {
+	n := 0
+	for range s {
+		if n >= limit {
+			return n
+		}
+		n++
+	}
+	return n
+}

--- a/internal/schema/hint.go
+++ b/internal/schema/hint.go
@@ -192,34 +192,26 @@ func levenshtein(a, b string) int {
 	}
 	ra := []rune(a)
 	rb := []rune(b)
-	// Belt-and-braces bound CodeQL can prove locally:
-	// tooLongForLevInput above already returns early for any
-	// over-cap input, but the static analyser cannot follow
-	// the bound through the helper, so it kept flagging the
-	// `len(rb)+1` allocation. The inline guard here pins the
-	// length to a constant CodeQL can see, mirroring the
-	// length-based fallback above without changing behaviour.
-	if len(ra) > maxLevInput || len(rb) > maxLevInput {
-		if len(ra) > len(rb) {
-			return len(ra)
-		}
-		return len(rb)
-	}
 	if len(ra) == 0 {
 		return len(rb)
 	}
 	if len(rb) == 0 {
 		return len(ra)
 	}
-	rows := len(rb) + 1
-	prev := make([]int, rows)
-	curr := make([]int, rows)
-	for j := 0; j < rows; j++ {
+	// CodeQL flagged the previous `make([]int, len(rb)+1)`
+	// allocation because the static analyser couldn't follow
+	// the maxLevInput bound through the tooLongForLevInput
+	// helper above. Use the compile-time constant size
+	// directly so the analyser sees a bounded allocation, and
+	// only iterate the columns inside the bound.
+	const rows = maxLevInput + 1
+	var prev, curr [rows]int
+	for j := 0; j <= len(rb); j++ {
 		prev[j] = j
 	}
 	for i := 1; i <= len(ra); i++ {
 		curr[0] = i
-		for j := 1; j < rows; j++ {
+		for j := 1; j <= len(rb); j++ {
 			cost := 1
 			if ra[i-1] == rb[j-1] {
 				cost = 0

--- a/internal/schema/hint_coverage_test.go
+++ b/internal/schema/hint_coverage_test.go
@@ -38,9 +38,11 @@ func TestRenderHint_NonQuotedAlternative(t *testing.T) {
 // error branch: a malformed escape inside a string literal
 // prevents the literal from being decoded, so no hint fires.
 func TestRenderHint_UnquoteFailure(t *testing.T) {
-	// Two alternatives so len(parts) >= 2; the bad escape
-	// breaks Unquote on the second literal.
-	assert.Empty(t, RenderHint(`"ok" | "\xff"`, "ok-typo"))
+	// `"\q"` uses an invalid Go escape sequence (`\q` is
+	// not a recognised letter). isQuotedString accepts it
+	// (it starts and ends with `"`), but strconv.Unquote
+	// fails, exercising the error branch.
+	assert.Empty(t, RenderHint(`"ok" | "\q"`, "qq"))
 }
 
 // TestRenderHint_ExactMatchSkipped covers the d==0 branch:
@@ -118,6 +120,17 @@ func TestParseRenderedBounds_Edges(t *testing.T) {
 		_, _, hasLo, hasHi := parseRenderedBounds("string")
 		assert.False(t, hasLo)
 		assert.False(t, hasHi)
+	})
+
+	t.Run("half-open upper bound parses cleanly", func(t *testing.T) {
+		// `int <= 5` is the upper half-open form; the helper
+		// returns (0, 5, false, true). The other tests use
+		// `int >= N` which already covers the lower-half
+		// branch.
+		_, hi, hasLo, hasHi := parseRenderedBounds("int <= 5")
+		assert.False(t, hasLo)
+		assert.True(t, hasHi)
+		assert.Equal(t, 5, hi)
 	})
 }
 

--- a/internal/schema/hint_coverage_test.go
+++ b/internal/schema/hint_coverage_test.go
@@ -1,0 +1,200 @@
+package schema
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderHint_NonStringActualDisjunction exercises the
+// `actual` non-string branch in hintForStringDisjunction: a
+// numeric actual against a string-disjunction constraint
+// produces no hint (the disjunction path only fires for
+// string actuals).
+func TestRenderHint_NonStringActualDisjunction(t *testing.T) {
+	expr := `"a" | "b"`
+	assert.Empty(t, RenderHint(expr, 42))
+	assert.Empty(t, RenderHint(expr, float64(3.14)))
+}
+
+// TestRenderHint_SinglePartDisjunction covers the "not a
+// disjunction" early return (len(parts) < 2): a bare `"x"`
+// constraint cannot produce a "did you mean" hint.
+func TestRenderHint_SinglePartDisjunction(t *testing.T) {
+	assert.Empty(t, RenderHint(`"x"`, "y"))
+}
+
+// TestRenderHint_NonQuotedAlternative covers the
+// isQuotedString=false branch: when one of the disjunction
+// alternatives isn't a string literal (e.g. `int | "x"`), the
+// extractor backs off rather than misreporting.
+func TestRenderHint_NonQuotedAlternative(t *testing.T) {
+	assert.Empty(t, RenderHint(`int | "x"`, "y"))
+}
+
+// TestRenderHint_UnquoteFailure covers the strconv.Unquote
+// error branch: a malformed escape inside a string literal
+// prevents the literal from being decoded, so no hint fires.
+func TestRenderHint_UnquoteFailure(t *testing.T) {
+	// Two alternatives so len(parts) >= 2; the bad escape
+	// breaks Unquote on the second literal.
+	assert.Empty(t, RenderHint(`"ok" | "\xff"`, "ok-typo"))
+}
+
+// TestRenderHint_ExactMatchSkipped covers the d==0 branch:
+// the actual exactly equals one of the literals, so no hint
+// fires (a "did you mean X?" message when X equals the actual
+// would be confusing).
+func TestRenderHint_ExactMatchSkipped(t *testing.T) {
+	// The CUE constraint validator never calls RenderHint on
+	// a value that satisfies the constraint, but the
+	// disjunction extractor still guards against the case
+	// defensively. Pass an exact match to exercise the
+	// guard.
+	assert.Empty(t, RenderHint(`"foo" | "bar"`, "foo"))
+}
+
+// TestRenderHint_IntRangeNonNumericActual exercises the
+// toFloat64=false branch: a string actual against an int
+// range produces no hint.
+func TestRenderHint_IntRangeNonNumericActual(t *testing.T) {
+	assert.Empty(t, RenderHint("int & >=1 & <=5", "not-a-number"))
+}
+
+// TestRenderHint_IntRangeWithIntActual exercises the int /
+// int64 paths of toFloat64 that the float64 default missed.
+func TestRenderHint_IntRangeWithIntActual(t *testing.T) {
+	assert.Equal(t, "try 1", RenderHint("int & >=1 & <=5", int(0)))
+	assert.Equal(t, "try 5", RenderHint("int & >=1 & <=5", int64(6)))
+}
+
+// TestRenderHint_IntRangeNoBoundCrossed covers the no-hint
+// branch when neither bound is exceeded but the actual is
+// still in range (in-range actuals already exit before hint
+// rendering, but the guard inside hintForIntRange covers
+// boundary-equal cases).
+func TestRenderHint_IntRangeNoBoundCrossed(t *testing.T) {
+	// Value equal to a bound — within range, no hint.
+	assert.Empty(t, RenderHint("int & >=1 & <=5", float64(1)))
+	assert.Empty(t, RenderHint("int & >=1 & <=5", float64(5)))
+}
+
+// TestParseRenderedBounds_Edges exercises the error branches
+// in parseRenderedBounds. These fire when the rendered string
+// is malformed; in practice renderIntRange produces a
+// well-formed string, so hintForIntRange short-circuits on
+// the renderIntRange ok=false path. Direct calls cover the
+// defensive branches for future callers.
+func TestParseRenderedBounds_Edges(t *testing.T) {
+	t.Run("malformed between drops the and separator", func(t *testing.T) {
+		_, _, hasLo, hasHi := parseRenderedBounds("int between 1 5")
+		assert.False(t, hasLo)
+		assert.False(t, hasHi)
+	})
+
+	t.Run("non-integer lower bound", func(t *testing.T) {
+		_, _, hasLo, _ := parseRenderedBounds("int between abc and 5")
+		assert.False(t, hasLo)
+	})
+
+	t.Run("non-integer upper bound", func(t *testing.T) {
+		_, _, _, hasHi := parseRenderedBounds("int between 1 and zzz")
+		assert.False(t, hasHi)
+	})
+
+	t.Run("non-integer half-open lower", func(t *testing.T) {
+		_, _, hasLo, _ := parseRenderedBounds("int >= xyz")
+		assert.False(t, hasLo)
+	})
+
+	t.Run("non-integer half-open upper", func(t *testing.T) {
+		_, _, _, hasHi := parseRenderedBounds("int <= xyz")
+		assert.False(t, hasHi)
+	})
+
+	t.Run("unknown rendered form", func(t *testing.T) {
+		_, _, hasLo, hasHi := parseRenderedBounds("string")
+		assert.False(t, hasLo)
+		assert.False(t, hasHi)
+	})
+}
+
+// TestLevenshtein_InlineGuardKicksIn exercises the
+// CodeQL-visible inline guard path inside levenshtein() that
+// the over-cap helper would normally short-circuit before.
+// The test calls levenshtein directly with strings sized at
+// the cap to confirm the inner branch path is reached.
+func TestLevenshtein_InlineGuardKicksIn(t *testing.T) {
+	// Inputs at maxLevInput rune count stay inside the DP
+	// branch; smaller of the two governs the row size.
+	short := strings.Repeat("a", maxLevInput)
+	tiny := "abc"
+	// short ↔ tiny: 1024 - 3 = 1021 deletions, 0 substitutions
+	// from the 3-char overlap, so distance ~ 1021.
+	got := levenshtein(short, tiny)
+	assert.Greater(t, got, 1000)
+}
+
+// TestLevenshtein_OneEmpty exercises the early-return branches
+// for empty operands that the typo tests don't hit.
+func TestLevenshtein_OneEmpty(t *testing.T) {
+	assert.Equal(t, 4, levenshtein("", "abcd"))
+	assert.Equal(t, 4, levenshtein("abcd", ""))
+}
+
+// TestLevenshtein_BothOverCapReturnsLonger exercises both
+// branches of the over-cap fallback: when b is longer than a,
+// the helper returns len(b)'s capped count; when a is
+// longer, it returns len(a). The first call below covers
+// the `return cb` branch the typo tests miss.
+func TestLevenshtein_BothOverCapReturnsLonger(t *testing.T) {
+	short := strings.Repeat("a", maxLevInput+5)
+	longer := strings.Repeat("a", maxLevInput+50)
+	// b longer → returns cb (= maxLevInput+1).
+	got := levenshtein(short, longer)
+	assert.Equal(t, maxLevInput+1, got)
+	// a longer → returns ca.
+	got = levenshtein(longer, short)
+	assert.Equal(t, maxLevInput+1, got)
+}
+
+// TestRuneCountAtMost_Cap exercises the early-exit branch of
+// runeCountAtMost: a string longer than the cap returns
+// exactly the cap, not the true rune count.
+func TestRuneCountAtMost_Cap(t *testing.T) {
+	s := strings.Repeat("a", maxLevInput+10)
+	got := runeCountAtMost(s, maxLevInput)
+	assert.Equal(t, maxLevInput, got)
+}
+
+// TestTooLongForLevInput_Bound exercises the boundary branch:
+// exactly maxLevInput runes is not "too long", maxLevInput+1
+// is.
+func TestTooLongForLevInput_Bound(t *testing.T) {
+	exact := strings.Repeat("a", maxLevInput)
+	tooLong := strings.Repeat("a", maxLevInput+1)
+	assert.False(t, tooLongForLevInput(exact))
+	assert.True(t, tooLongForLevInput(tooLong))
+}
+
+// TestRenderHint_IntRangeOverflowFalsePositive guards the
+// hint extractor against suggesting the rendered exclusive
+// form's bound (`int > MaxInt`) for an in-range value. With
+// the inclusive shift skipped, parseRenderedBounds doesn't
+// match the rendered form, so hintForIntRange returns no
+// hint.
+func TestRenderHint_IntRangeOverflowFalsePositive(t *testing.T) {
+	maxStr := math.MaxInt
+	assert.Empty(t, RenderHint("int & >"+itoa(maxStr), float64(0)))
+}
+
+// itoa is a tiny wrapper so the test reads naturally without
+// importing strconv at the call site.
+func itoa(n int) string {
+	if n == math.MaxInt {
+		return "9223372036854775807"
+	}
+	return ""
+}

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -108,20 +109,31 @@ func parseFileFrontmatter(prefix []byte, sch *Schema) error {
 		}
 		sch.Frontmatter[k] = expr
 	}
+	// Capture per-key source lines so MDS020 diagnostics can point
+	// the reader at the exact constraint. yaml.Node line numbers
+	// are 1-based within the stripped YAML body; the body starts
+	// on the schema file's line 2 (line 1 is the opening "---"
+	// fence), so we add 1 to translate into file-relative lines.
+	node, err := yamlutil.UnmarshalNodeSafe(body)
+	if err == nil {
+		sch.FrontmatterLines = yamlutil.TopLevelMappingLines(&node, 1)
+	}
 	return nil
 }
 
 // stripDelimiters returns the YAML body between a front-matter
 // block's "---\n" delimiters. The caller (parseFileFrontmatter)
 // receives prefix bytes produced by lint.StripFrontMatter, which
-// only matches blocks bracketed by "---\n" on both ends, so the
-// helper only has to look for that exact closing fence.
+// guarantees the block is bracketed by "---\n" on both ends.
+//
+// The closing fence is removed via TrimSuffix rather than a
+// strings.Index scan: searching for the first "---\n" anywhere
+// in the body would truncate the YAML early if a block-scalar
+// value (e.g. `notes: |`) legitimately contained the same
+// sequence on one of its indented lines.
 func stripDelimiters(fm []byte) []byte {
-	s := strings.TrimPrefix(string(fm), "---\n")
-	if idx := strings.Index(s, "---\n"); idx >= 0 {
-		return []byte(s[:idx])
-	}
-	return []byte(s)
+	s := bytes.TrimPrefix(fm, []byte("---\n"))
+	return bytes.TrimSuffix(s, []byte("---\n"))
 }
 
 // extractRequireFilename walks the schema AST for a <?require?> PI

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -35,6 +35,16 @@ type Schema struct {
 	// including any trailing "?" optional-field marker.
 	Frontmatter map[string]string
 
+	// FrontmatterLines maps each front-matter key to the 1-based
+	// line of its constraint in the schema source, when known. The
+	// file-based parser populates this from the proto.md
+	// frontmatter via yaml.Node line metadata; the inline parser
+	// does not (the config loader unmarshals into typed values
+	// before this code sees it). Lookup is by the same key form
+	// stored in Frontmatter (with the optional "?" suffix
+	// preserved).
+	FrontmatterLines map[string]int
+
 	// Require carries constraints that apply to the document as a
 	// whole (filename pattern, etc.).
 	Require Require

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -172,7 +172,8 @@ func TestValidate_MissingSection(t *testing.T) {
 	doc := newDocFile(t, "doc.md", "# My Plan\n\n## Goal\n\nGoal text.\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Equal(t, `missing required section "## Tasks"`, diags[0].Message)
+	assert.Contains(t, diags[0].Message,
+		`## Tasks: got <missing>, expected section to be present`)
 }
 
 func TestValidate_ExtraSectionFlagged(t *testing.T) {
@@ -184,7 +185,8 @@ func TestValidate_ExtraSectionFlagged(t *testing.T) {
 		"# My Plan\n\n## Extra\n\nx\n\n## Goal\n\ny\n\n## Tasks\n\nz\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, `unexpected section "## Extra"`)
+	assert.Contains(t, diags[0].Message,
+		`## Extra: got <present>, expected not declared in schema`)
 }
 
 func TestValidate_OutOfOrder(t *testing.T) {
@@ -196,9 +198,9 @@ func TestValidate_OutOfOrder(t *testing.T) {
 		"# My Plan\n\n## Tasks\n\nx\n\n## Goal\n\ny\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Equal(t,
-		`section "## Tasks" out of order: expected after "## Goal"`,
-		diags[0].Message)
+	assert.Contains(t, diags[0].Message,
+		`## Tasks: got <out of order>, expected in declared order`)
+	assert.Contains(t, diags[0].Message, `expected after "## Goal"`)
 }
 
 func TestValidate_WildcardH1LevelMismatch(t *testing.T) {
@@ -209,9 +211,7 @@ func TestValidate_WildcardH1LevelMismatch(t *testing.T) {
 	doc := newDocFile(t, "doc.md", "## Title\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Equal(t,
-		`heading level mismatch for "Title": expected h1, got h2`,
-		diags[0].Message)
+	assert.Contains(t, diags[0].Message, `Title: got h2, expected h1`)
 }
 
 func TestValidate_FilenameMismatch(t *testing.T) {
@@ -224,7 +224,7 @@ func TestValidate_FilenameMismatch(t *testing.T) {
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message,
-		`filename "filename-mismatch.md" does not match required pattern "[0-9]*_*.md"`)
+		`filename: got "filename-mismatch.md", expected filename matching glob [0-9]*_*.md`)
 }
 
 // ---- Validate (inline schemas) ----
@@ -259,7 +259,8 @@ func TestValidate_Inline_ClosedRejectsUnlisted(t *testing.T) {
 		"# Title\n\n## Overview\n\nx\n\n## Notes\n\ny\n\n## Decision\n\nz\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, `unexpected section "## Notes"`)
+	assert.Contains(t, diags[0].Message,
+		`## Notes: got <present>, expected not declared in schema`)
 }
 
 func TestValidate_Inline_WildcardSlotTolerates(t *testing.T) {
@@ -335,7 +336,8 @@ func TestValidate_Inline_FrontmatterCUE(t *testing.T) {
 	// Document FM has the wrong shape.
 	diags := Validate(doc, sch, map[string]any{"id": "BAD"}, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, "front matter does not satisfy schema")
+	assert.Contains(t, diags[0].Message, `id: got "BAD"`)
+	assert.Contains(t, diags[0].Message, `string matching ^RFC-[0-9]{4}$`)
 }
 
 // ---- ParseInline (content:) ----

--- a/internal/schema/shortcuts_test.go
+++ b/internal/schema/shortcuts_test.go
@@ -200,8 +200,8 @@ func TestValidate_Inline_ShortcutAcceptsAndRejects(t *testing.T) {
 	diags = Validate(doc, sch,
 		map[string]any{"created": "2024-5-1"}, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message,
-		"front matter does not satisfy schema")
+	assert.Contains(t, diags[0].Message, `created: got "2024-5-1"`)
+	assert.Contains(t, diags[0].Message, "string matching")
 }
 
 // TestValidate_File_ShortcutWorksOffline covers the
@@ -237,8 +237,8 @@ func TestValidate_File_ShortcutWorksOffline(t *testing.T) {
 		"homepage": "ftp://example.com",
 	}, false, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message,
-		"front matter does not satisfy schema")
+	assert.Contains(t, diags[0].Message, `homepage: got "ftp://example.com"`)
+	assert.Contains(t, diags[0].Message, "string matching")
 }
 
 // TestShortcutRegistry_MatchesEmbeddedCUE is the

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -1,17 +1,21 @@
 package schema
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/errors"
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/yamlutil"
 	"github.com/yuin/goldmark/ast"
 )
 
@@ -94,24 +98,356 @@ func Validate(
 	diags = append(diags, validateFilename(f, sch, mkDiag)...)
 
 	if !fmIsCUE {
-		if err := ValidateFrontmatter(sch, docFM); err != nil {
-			diags = append(diags, mkDiag(f.Path, 1,
-				fmt.Sprintf(
-					"front matter does not satisfy schema CUE constraints: %v",
-					err)))
-		}
+		diags = append(diags, validateFrontmatterDiags(f, sch, docFM, mkDiag)...)
 	}
 
 	rootLevel := sch.EffectiveRootLevel()
 	heads := ExtractDocHeadings(f)
 	body := skipBelow(heads, rootLevel)
 
-	_, sd := validateScopes(f, sch.Sections, sch.Closed, body, 0, rootLevel, mkDiag)
+	_, sd := validateScopes(f, sch, sch.Sections, sch.Closed, body, 0, rootLevel, mkDiag)
 	diags = append(diags, sd...)
 
 	diags = append(diags, ValidateContent(f, sch, mkDiag)...)
 
 	return diags
+}
+
+// validateFrontmatterDiags compiles the schema's CUE expression,
+// unifies it with the document front matter, and emits one
+// diagnostic per resulting CUE error (rather than collapsing all
+// of them into a single line). Each diagnostic is a
+// SchemaDiagnostic rendered through Format(): the field that
+// failed, the value the user wrote, the constraint they
+// violated, and — when applicable — a hint.
+//
+// A schema-side compile or marshal failure surfaces as a single
+// fallback diagnostic at line 1 so users still see a signal
+// without needing to chase the underlying CUE error. The
+// formerly-flat "front matter does not satisfy schema CUE
+// constraints" message is intentionally retired; see plan 147.
+func validateFrontmatterDiags(
+	f *lint.File, sch *Schema, docFM map[string]any, mkDiag MakeDiag,
+) []lint.Diagnostic {
+	expr := sch.FrontmatterCUE()
+	if strings.TrimSpace(expr) == "" {
+		return nil
+	}
+	ctx := cuecontext.New()
+	schemaVal := ctx.CompileString(expr)
+	if err := schemaVal.Err(); err != nil {
+		return []lint.Diagnostic{mkDiag(f.Path, 1,
+			compileFailureDiag(sch, "schema", "valid schema CUE", err).Format())}
+	}
+	if docFM == nil {
+		docFM = map[string]any{}
+	}
+	data, err := json.Marshal(docFM)
+	if err != nil {
+		return []lint.Diagnostic{mkDiag(f.Path, 1,
+			compileFailureDiag(sch, "front matter", "JSON-marshalable front matter", err).Format())}
+	}
+	dataVal := ctx.CompileBytes(data)
+	if err := dataVal.Err(); err != nil {
+		return []lint.Diagnostic{mkDiag(f.Path, 1,
+			compileFailureDiag(sch, "front matter", "valid front matter", err).Format())}
+	}
+	merged := schemaVal.Unify(dataVal)
+	verr := merged.Validate(cue.Concrete(true))
+	if verr == nil {
+		return nil
+	}
+	cueErrs := errors.Errors(verr)
+	if len(cueErrs) == 0 {
+		return []lint.Diagnostic{mkDiag(f.Path, 1,
+			SchemaDiagnostic{
+				Field:     "front matter",
+				Actual:    fmt.Sprintf("%v", verr),
+				Expected:  "valid CUE",
+				SchemaRef: schemaRef(sch, ""),
+			}.Format())}
+	}
+	keyLines := docFrontmatterKeyLines(f)
+	out := make([]lint.Diagnostic, 0, len(cueErrs))
+	// A struct dedup key avoids accidental collisions when one of
+	// the components (notably the raw-CUE-expression Expected
+	// fallback and a placeholder-bearing Field) legitimately
+	// contains the same delimiter we would have used in a flat
+	// string key.
+	type dedupKey struct{ field, actual, expected string }
+	seen := make(map[dedupKey]bool, len(cueErrs))
+	for _, ce := range cueErrs {
+		d := schemaDiagFromCUEError(sch, docFM, ce)
+		key := dedupKey{field: d.Field, actual: d.Actual, expected: d.Expected}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, mkDiag(f.Path, fmDiagLine(f, ce.Path(), keyLines), d.Format()))
+	}
+	return out
+}
+
+// fmDiagLine returns the line to anchor a front-matter diagnostic
+// at, expressed in the body-line coordinate system the engine
+// uses before lint.File.AdjustDiagnostics fires. When the doc's
+// FM has a tracked source line for the offending key, the line
+// is the file-relative line of that key minus f.LineOffset; the
+// engine's AdjustDiagnostics shift then lands the diagnostic on
+// the absolute file line of the key.
+//
+// In front-matter-stripped mode (f.LineOffset > 0) the body-
+// coordinate value is non-positive for keys inside the FM block.
+// That is intentional: AdjustDiagnostics adds LineOffset back to
+// reach the absolute line, which is positive. Callers that
+// consume Diagnostic.Line without running it through the engine
+// must normalise the value first (see ValidateFrontmatterDiags
+// for the contract). In unstripped mode (LineOffset == 0) the
+// returned value already equals the absolute file line.
+//
+// When no per-key line is known the function falls back to line
+// 1 — the conventional "start of file" anchor, which the engine
+// also shifts to the first body line.
+func fmDiagLine(f *lint.File, path []string, keyLines map[string]int) int {
+	if len(path) == 0 || len(keyLines) == 0 {
+		return 1
+	}
+	line, ok := keyLines[path[0]]
+	if !ok {
+		// Top-level path may carry an optional-key suffix in the
+		// schema; the doc itself never does, so a miss here means
+		// the key was absent from the document (and therefore has
+		// no source line to point at).
+		return 1
+	}
+	return line - f.LineOffset
+}
+
+// docFrontmatterKeyLines parses the document's front matter and
+// returns the file-relative line of each top-level key. Works in
+// both front-matter-stripped mode (FM lives in f.FrontMatter) and
+// unstripped mode (FM still at the top of f.Source) so the same
+// helper serves the LSP / CLI path and the rule's unit-test
+// callers that build files via lint.NewFile directly.
+func docFrontmatterKeyLines(f *lint.File) map[string]int {
+	if fm := f.FrontMatter; len(fm) > 0 {
+		return parseFMBlockKeyLines(fm)
+	}
+	if bytes.HasPrefix(f.Source, []byte("---\n")) {
+		if fm, _ := lint.StripFrontMatter(f.Source); fm != nil {
+			return parseFMBlockKeyLines(fm)
+		}
+	}
+	return nil
+}
+
+// parseFMBlockKeyLines extracts top-level key lines from a YAML
+// front-matter block that includes its `---` delimiters. yaml.Node
+// line numbers are 1-based within the body between the fences; the
+// file-relative line is one more (the opening `---` occupies the
+// first source line).
+//
+// The closing fence is removed via TrimSuffix rather than a
+// bytes.Index scan: callers feed us a block returned by
+// lint.StripFrontMatter which always ends with `---\n`, and a
+// scan-for-first-match would truncate the body early if a YAML
+// block scalar legitimately contained the `---\n` sequence as a
+// value.
+func parseFMBlockKeyLines(fm []byte) map[string]int {
+	body := bytes.TrimPrefix(fm, []byte("---\n"))
+	body = bytes.TrimSuffix(body, []byte("---\n"))
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	node, err := yamlutil.UnmarshalNodeSafe(body)
+	if err != nil {
+		return nil
+	}
+	return yamlutil.TopLevelMappingLines(&node, 1)
+}
+
+// schemaDiagFromCUEError converts one CUE-error leaf into a
+// SchemaDiagnostic. The CUE error's Path() names the offending
+// field; we look up the raw constraint expression on the schema
+// to render an "expected" string in user vocabulary, and pull
+// the actual value out of docFM so the message shows exactly
+// what the user wrote.
+func schemaDiagFromCUEError(
+	sch *Schema, docFM map[string]any, ce errors.Error,
+) SchemaDiagnostic {
+	path := ce.Path()
+	field := "front matter"
+	if len(path) > 0 {
+		field = strings.Join(path, ".")
+	}
+	d := SchemaDiagnostic{
+		Field:     field,
+		SchemaRef: schemaRef(sch, schemaKeyForPath(sch, path)),
+	}
+	actualVal, hasActual := lookupFM(docFM, path)
+	if hasActual {
+		d.Actual = formatActual(actualVal)
+	}
+	if expr := lookupConstraint(sch, path); expr != "" {
+		d.Expected = RenderExpected(expr)
+		if hasActual {
+			d.Hint = RenderHint(expr, actualVal)
+		} else {
+			// A required field that the document omitted. Show
+			// the same <missing> sentinel structure diagnostics
+			// use so every diagnostic answers the same three
+			// questions: which field, what value, what's
+			// expected.
+			d.Actual = "<missing>"
+		}
+	} else {
+		// Extra field: close() rejected a key that is not in the
+		// schema's frontmatter map. There is no per-field
+		// constraint to render, and the schema source already
+		// names the declared set; the diagnostic body says so
+		// explicitly so the reader can compare against the
+		// schema file. <extra field> is the actual-slot sentinel
+		// for the (rare) case where the key has no value to show
+		// (e.g. an empty mapping entry).
+		if !hasActual {
+			d.Actual = "<extra field>"
+		}
+		d.Expected = "not declared in schema"
+	}
+	return d
+}
+
+// schemaKeyForPath finds the Frontmatter map key (with the
+// optional "?" suffix preserved) that owns the given CUE error
+// path. The required-key form "x" and optional-key form "x?"
+// produce identical CUE paths, so we accept either when looking
+// up the constraint and the source line.
+func schemaKeyForPath(sch *Schema, path []string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	first := path[0]
+	if _, ok := sch.Frontmatter[first]; ok {
+		return first
+	}
+	if _, ok := sch.Frontmatter[first+"?"]; ok {
+		return first + "?"
+	}
+	return ""
+}
+
+func lookupConstraint(sch *Schema, path []string) string {
+	if key := schemaKeyForPath(sch, path); key != "" {
+		return sch.Frontmatter[key]
+	}
+	return ""
+}
+
+// lookupFM walks docFM along path and returns the leaf value.
+// The boolean reports whether the path resolved; a present-but-
+// nil value still reports true so the diagnostic can show
+// "null" rather than "<missing>".
+//
+// path segments come from CUE's error.Path() and may be mixed
+// map keys and numeric list indices (e.g. "tags", "1" for a
+// failing element of a list-shaped field). lookupFM understands
+// both: it descends through `map[string]any` by key and through
+// `[]any` by parsing the segment as a non-negative integer.
+// Falling back to <missing> on a list-shaped path would
+// misreport "field present but a particular index failed" as
+// "field absent" — see the Copilot review comment on PR #284.
+func lookupFM(docFM map[string]any, path []string) (any, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+	cur := any(docFM)
+	for _, p := range path {
+		switch typed := cur.(type) {
+		case map[string]any:
+			v, ok := typed[p]
+			if !ok {
+				return nil, false
+			}
+			cur = v
+		case []any:
+			idx, err := strconv.Atoi(p)
+			if err != nil || idx < 0 || idx >= len(typed) {
+				return nil, false
+			}
+			cur = typed[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// schemaRef builds the `schema: ...` suffix from the schema's
+// Source label and (when known) the line of the named key. An
+// unknown source falls back to a generic "schema" label so
+// every diagnostic still carries a reference field.
+func schemaRef(sch *Schema, key string) string {
+	src := sch.Source
+	if src == "" {
+		src = "schema"
+	}
+	if key != "" {
+		if line, ok := sch.FrontmatterLines[key]; ok && line > 0 {
+			return fmt.Sprintf("%s:%d", src, line)
+		}
+	}
+	return src
+}
+
+// compileFailureDiag builds a SchemaDiagnostic for the
+// early-return CUE / JSON failure paths in
+// validateFrontmatterDiags. The `Field` names what failed to
+// process ("schema", "front matter"), `expected` carries the
+// shape-specific contract (e.g. "valid schema CUE",
+// "JSON-marshalable front matter"), the `Actual` carries the
+// underlying error message, and the schema reference points the
+// reader at the source so the diagnostic stays consistent with
+// the rest of MDS020's output. Threading `expected` through the
+// helper keeps each early-return path's message accurate —
+// using a single generic phrase would have made the
+// json.Marshal failure path read as "Expected: compilable CUE"
+// even though CUE isn't involved at that step.
+func compileFailureDiag(sch *Schema, field, expected string, err error) SchemaDiagnostic {
+	return SchemaDiagnostic{
+		Field:     field,
+		Actual:    fmt.Sprintf("%v", err),
+		Expected:  expected,
+		SchemaRef: schemaRef(sch, ""),
+	}
+}
+
+// ValidateFrontmatterDiags exposes the per-error CUE-diagnostic
+// walker to callers outside the validator (notably the
+// requiredstructure rule's legacy file-schema path, which has
+// its own heading-template parser but reuses the schema
+// package's actionable front-matter diagnostics).
+//
+// Line numbers on returned diagnostics are in the engine's
+// body-coordinate system: they are the absolute file line of
+// the offending front-matter key minus f.LineOffset. In
+// front-matter-stripped mode (f.LineOffset > 0) the body-
+// coordinate value is non-positive for keys inside the FM
+// block; lint.File.AdjustDiagnostics then shifts it back into
+// the absolute file line. Callers that bypass the engine — for
+// instance unit tests inspecting the raw slice — must either
+// run the result through f.AdjustDiagnostics or normalise the
+// values themselves before treating them as 1-based positions.
+func ValidateFrontmatterDiags(
+	f *lint.File, sch *Schema, docFM map[string]any, mkDiag MakeDiag,
+) []lint.Diagnostic {
+	return validateFrontmatterDiags(f, sch, docFM, mkDiag)
+}
+
+// FormatSchemaRef builds the "source:line" suffix used by every
+// SchemaDiagnostic so callers outside the schema package emit
+// the same shape. An unknown source falls back to "schema".
+func FormatSchemaRef(sch *Schema, key string) string {
+	return schemaRef(sch, key)
 }
 
 // skipBelow returns a filtered slice that omits every heading
@@ -142,7 +478,7 @@ func skipBelow(heads []DocHeading, rootLevel int) []DocHeading {
 // tolerated. A wildcard scope ("...") always tolerates unlisted
 // headings at its position.
 func validateScopes(
-	f *lint.File, scopes []Scope, closed bool, docHeads []DocHeading,
+	f *lint.File, sch *Schema, scopes []Scope, closed bool, docHeads []DocHeading,
 	docIdx int, expectedLevel int, mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
 	var diags []lint.Diagnostic
@@ -168,7 +504,7 @@ func validateScopes(
 			continue
 		}
 		newIdx, scDiags, found := matchScope(
-			f, scopes, i, expectedLevel, docHeads, docIdx,
+			f, sch, scopes, i, expectedLevel, docHeads, docIdx,
 			requiredByText, claimed, allowExtra, closed, mkDiag)
 		diags = append(diags, scDiags...)
 		docIdx = newIdx
@@ -176,16 +512,80 @@ func validateScopes(
 			allowExtra = false
 		} else if !claimed[i] && sc.Required && !sc.Repeats {
 			diags = append(diags, mkDiag(f.Path, 1,
-				fmt.Sprintf("missing required section %q",
-					formatHeading(expectedLevel, sc.Heading))))
+				missingSectionDiag(formatHeading(expectedLevel, sc.Heading), sch).Format()))
 		}
 	}
 
 	newIdx, leftoverDiags := handleLeftoverHeadings(
-		f, scopes, claimed, docHeads, docIdx, expectedLevel,
+		f, sch, scopes, claimed, docHeads, docIdx, expectedLevel,
 		closed, allowExtra, mkDiag)
 	diags = append(diags, leftoverDiags...)
 	return newIdx, diags
+}
+
+// missingSectionDiag builds a SchemaDiagnostic for a required
+// section that is absent from the document. The field carries
+// the heading marker form (`## Goal`) so the reader can grep for
+// the exact text; the actual is "<missing>" and the schema
+// reference points back at the schema source.
+func missingSectionDiag(heading string, sch *Schema) SchemaDiagnostic {
+	return SchemaDiagnostic{
+		Field:     heading,
+		Actual:    "<missing>",
+		Expected:  "section to be present",
+		SchemaRef: schemaRef(sch, ""),
+	}
+}
+
+// unexpectedSectionDiag builds a SchemaDiagnostic for a heading
+// that appears in the document but is not declared in the
+// schema. expected, when non-empty, names the section the
+// validator was looking for at that position; the message
+// surfaces it as a hint so the reader can decide whether they
+// added the wrong heading or omitted a different one.
+func unexpectedSectionDiag(heading, expected string, sch *Schema) SchemaDiagnostic {
+	d := SchemaDiagnostic{
+		Field:     heading,
+		Actual:    "<present>",
+		Expected:  "not declared in schema",
+		SchemaRef: schemaRef(sch, ""),
+	}
+	if expected != "" {
+		d.Hint = fmt.Sprintf("expected %q here instead", expected)
+	}
+	return d
+}
+
+// outOfOrderDiag builds a SchemaDiagnostic for a heading whose
+// text matches a declared section but appears at the wrong
+// position relative to its siblings. expectedAfter, when
+// non-empty, names the section it should follow.
+func outOfOrderDiag(heading, expectedAfter string, sch *Schema) SchemaDiagnostic {
+	d := SchemaDiagnostic{
+		Field:     heading,
+		Actual:    "<out of order>",
+		Expected:  "in declared order",
+		SchemaRef: schemaRef(sch, ""),
+	}
+	if expectedAfter != "" {
+		d.Hint = fmt.Sprintf("expected after %q", expectedAfter)
+	} else {
+		d.Hint = "expected before this position"
+	}
+	return d
+}
+
+// levelMismatchSchemaDiag builds a SchemaDiagnostic for a
+// heading whose text matches a declared section but appears at
+// the wrong heading level (e.g. `## Step` where the schema
+// declared `### Step`).
+func levelMismatchSchemaDiag(text string, expectedLevel, actualLevel int, sch *Schema) SchemaDiagnostic {
+	return SchemaDiagnostic{
+		Field:     text,
+		Actual:    fmt.Sprintf("h%d", actualLevel),
+		Expected:  fmt.Sprintf("h%d", expectedLevel),
+		SchemaRef: schemaRef(sch, ""),
+	}
 }
 
 // handleLeftoverHeadings processes doc headings that survived the
@@ -197,7 +597,7 @@ func validateScopes(
 // closed: flagged as unexpected in closed scopes, silently
 // consumed in open ones.
 func handleLeftoverHeadings(
-	f *lint.File, scopes []Scope, claimed map[int]bool,
+	f *lint.File, sch *Schema, scopes []Scope, claimed map[int]bool,
 	docHeads []DocHeading, docIdx, expectedLevel int,
 	closed, allowExtra bool, mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
@@ -213,15 +613,14 @@ func handleLeftoverHeadings(
 		}
 		if idx := unclaimedListedScope(scopes, dh, claimed); idx >= 0 {
 			newIdx, claimDiags := claimLateScope(
-				f, scopes, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag)
+				f, sch, scopes, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag)
 			diags = append(diags, claimDiags...)
 			docIdx = newIdx
 			continue
 		}
 		if !allowExtra && closed {
 			diags = append(diags, mkDiag(f.Path, dh.Line,
-				fmt.Sprintf("unexpected section %q",
-					formatHeading(dh.Level, dh.Text))))
+				unexpectedSectionDiag(formatHeading(dh.Level, dh.Text), "", sch).Format()))
 		}
 		docIdx++
 	}
@@ -233,20 +632,18 @@ func handleLeftoverHeadings(
 // nested children so missing-required-section diagnostics still
 // surface beneath a late parent.
 func claimLateScope(
-	f *lint.File, scopes []Scope, idx, expectedLevel int,
+	f *lint.File, sch *Schema, scopes []Scope, idx, expectedLevel int,
 	docHeads []DocHeading, docIdx int, claimed map[int]bool,
 	mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
 	dh := docHeads[docIdx]
 	diags := []lint.Diagnostic{mkDiag(f.Path, dh.Line,
-		fmt.Sprintf(
-			"section %q out of order: expected before this position",
-			formatHeading(dh.Level, dh.Text)))}
+		outOfOrderDiag(formatHeading(dh.Level, dh.Text), "", sch).Format())}
 	claimed[idx] = true
 	docIdx++
 	if len(scopes[idx].Sections) > 0 {
 		newIdx, childDiags := validateScopes(
-			f, scopes[idx].Sections, scopes[idx].Closed,
+			f, sch, scopes[idx].Sections, scopes[idx].Closed,
 			docHeads, docIdx, expectedLevel+1, mkDiag)
 		diags = append(diags, childDiags...)
 		docIdx = newIdx
@@ -314,7 +711,7 @@ func indexableLiteral(text string) bool {
 // subtree. Returns the new docIdx, diagnostics, and whether the
 // scope was matched.
 func matchScope(
-	f *lint.File, scopes []Scope, idx, expectedLevel int,
+	f *lint.File, sch *Schema, scopes []Scope, idx, expectedLevel int,
 	docHeads []DocHeading, docIdx int,
 	requiredByText map[string][]int, claimed map[int]bool,
 	allowExtra, closed bool, mkDiag MakeDiag,
@@ -331,12 +728,12 @@ func matchScope(
 		// "unexpected" (when the caller revisits it).
 		if dh.Level < expectedLevel {
 			if scopeMatchesHeading(sc, dh) {
-				return claimMatch(f, sc, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag, diags)
+				return claimMatch(f, sch, sc, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag, diags)
 			}
 			return docIdx, diags, false
 		}
 		if scopeMatchesHeading(sc, dh) {
-			return claimMatch(f, sc, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag, diags)
+			return claimMatch(f, sch, sc, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag, diags)
 		}
 		if ooIdx := findOutOfOrderIdx(scopes, dh, requiredByText, claimed, idx+1); ooIdx >= 0 {
 			if !sc.Required {
@@ -348,7 +745,7 @@ func matchScope(
 				return docIdx, diags, false
 			}
 			newIdx, ooDiags := claimOutOfOrder(
-				f, scopes, idx, ooIdx, expectedLevel, docHeads, docIdx, claimed, mkDiag)
+				f, sch, scopes, idx, ooIdx, expectedLevel, docHeads, docIdx, claimed, mkDiag)
 			diags = append(diags, ooDiags...)
 			docIdx = newIdx
 			continue
@@ -363,9 +760,10 @@ func matchScope(
 		}
 		if !allowExtra && closed {
 			diags = append(diags, mkDiag(f.Path, dh.Line,
-				fmt.Sprintf("unexpected section %q (expected %q)",
+				unexpectedSectionDiag(
 					formatHeading(dh.Level, dh.Text),
-					formatHeading(expectedLevel, sc.Heading))))
+					formatHeading(expectedLevel, sc.Heading),
+					sch).Format()))
 		}
 		docIdx++
 	}
@@ -373,14 +771,13 @@ func matchScope(
 }
 
 func levelDiagIfNeeded(
-	f *lint.File, dh DocHeading, expectedLevel int, mkDiag MakeDiag,
+	f *lint.File, sch *Schema, dh DocHeading, expectedLevel int, mkDiag MakeDiag,
 ) []lint.Diagnostic {
 	if dh.Level == expectedLevel {
 		return nil
 	}
 	return []lint.Diagnostic{mkDiag(f.Path, dh.Line,
-		fmt.Sprintf("heading level mismatch for %q: expected h%d, got h%d",
-			dh.Text, expectedLevel, dh.Level))}
+		levelMismatchSchemaDiag(dh.Text, expectedLevel, dh.Level, sch).Format())}
 }
 
 // claimMatch marks scopes[idx] as matched against docHeads[docIdx],
@@ -388,16 +785,16 @@ func levelDiagIfNeeded(
 // recursing into the scope's child sections. Returns the advanced
 // docIdx, combined diagnostics, and true.
 func claimMatch(
-	f *lint.File, sc Scope, idx, expectedLevel int,
+	f *lint.File, sch *Schema, sc Scope, idx, expectedLevel int,
 	docHeads []DocHeading, docIdx int, claimed map[int]bool,
 	mkDiag MakeDiag, prior []lint.Diagnostic,
 ) (int, []lint.Diagnostic, bool) {
-	diags := append(prior, levelDiagIfNeeded(f, docHeads[docIdx], expectedLevel, mkDiag)...)
+	diags := append(prior, levelDiagIfNeeded(f, sch, docHeads[docIdx], expectedLevel, mkDiag)...)
 	claimed[idx] = true
 	docIdx++
 	if len(sc.Sections) > 0 {
 		newIdx, childDiags := validateScopes(
-			f, sc.Sections, sc.Closed, docHeads, docIdx,
+			f, sch, sc.Sections, sc.Closed, docHeads, docIdx,
 			expectedLevel+1, mkDiag)
 		diags = append(diags, childDiags...)
 		docIdx = newIdx
@@ -409,7 +806,7 @@ func claimMatch(
 // (a later listed scope), emits the out-of-order diagnostic, and
 // recurses into the matched scope's child sections.
 func claimOutOfOrder(
-	f *lint.File, scopes []Scope, idx, ooIdx, expectedLevel int,
+	f *lint.File, sch *Schema, scopes []Scope, idx, ooIdx, expectedLevel int,
 	docHeads []DocHeading, docIdx int, claimed map[int]bool,
 	mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
@@ -417,15 +814,16 @@ func claimOutOfOrder(
 	ooSc := scopes[ooIdx]
 	dh := docHeads[docIdx]
 	diags := []lint.Diagnostic{mkDiag(f.Path, dh.Line,
-		fmt.Sprintf("section %q out of order: expected after %q",
+		outOfOrderDiag(
 			formatHeading(dh.Level, dh.Text),
-			formatHeading(expectedLevel, sc.Heading)))}
-	diags = append(diags, levelDiagIfNeeded(f, dh, expectedLevel, mkDiag)...)
+			formatHeading(expectedLevel, sc.Heading),
+			sch).Format())}
+	diags = append(diags, levelDiagIfNeeded(f, sch, dh, expectedLevel, mkDiag)...)
 	claimed[ooIdx] = true
 	docIdx++
 	if len(ooSc.Sections) > 0 {
 		newIdx, childDiags := validateScopes(
-			f, ooSc.Sections, ooSc.Closed, docHeads, docIdx,
+			f, sch, ooSc.Sections, ooSc.Closed, docHeads, docIdx,
 			expectedLevel+1, mkDiag)
 		diags = append(diags, childDiags...)
 		docIdx = newIdx
@@ -582,7 +980,12 @@ func formatHeading(level int, text string) string {
 }
 
 // validateFilename checks that the document basename matches the
-// schema's filename pattern (if configured).
+// schema's filename pattern (if configured). A mismatched
+// basename surfaces as a SchemaDiagnostic so the message mirrors
+// the front-matter and path-pattern diagnostics: the "field" is
+// "filename", the "actual" is the basename the user wrote, and
+// the "expected" is the glob spelled out as a pattern-matching
+// constraint.
 func validateFilename(
 	f *lint.File, sch *Schema, mkDiag MakeDiag,
 ) []lint.Diagnostic {
@@ -593,13 +996,33 @@ func validateFilename(
 	base := filepath.Base(f.Path)
 	matched, err := filepath.Match(pattern, base)
 	if err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, 1,
-			fmt.Sprintf("invalid filename pattern %q: %v", pattern, err))}
+		// Malformed glob in the schema. Surface it via the same
+		// SchemaDiagnostic shape so the message carries a
+		// schema reference and the user can jump to the
+		// offending pattern.
+		d := SchemaDiagnostic{
+			Field:     "filename pattern",
+			Actual:    fmt.Sprintf("%q", pattern),
+			Expected:  "valid glob",
+			Hint:      err.Error(),
+			SchemaRef: schemaRef(sch, ""),
+		}
+		return []lint.Diagnostic{mkDiag(f.Path, 1, d.Format())}
 	}
 	if !matched {
-		return []lint.Diagnostic{mkDiag(f.Path, 1,
-			fmt.Sprintf("filename %q does not match required pattern %q",
-				base, pattern))}
+		// `glob` makes the constraint syntax explicit: users
+		// occasionally read `string matching <pattern>` as a regex
+		// requirement, which filepath.Match does not accept. The
+		// wording also lines up with the kind-level `path-pattern`
+		// diagnostic ("path matching glob ...") so the user
+		// vocabulary is consistent across both surfaces.
+		d := SchemaDiagnostic{
+			Field:     "filename",
+			Actual:    fmt.Sprintf("%q", base),
+			Expected:  fmt.Sprintf("filename matching glob %s", pattern),
+			SchemaRef: schemaRef(sch, ""),
+		}
+		return []lint.Diagnostic{mkDiag(f.Path, 1, d.Format())}
 	}
 	return nil
 }

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -134,9 +134,10 @@ func validateFrontmatterDiags(
 		return nil
 	}
 	ctx := cuecontext.New()
+	anchor := nonBodyDiagLine(f)
 	schemaVal := ctx.CompileString(expr)
 	if err := schemaVal.Err(); err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, 1,
+		return []lint.Diagnostic{mkDiag(f.Path, anchor,
 			compileFailureDiag(sch, "schema", "valid schema CUE", err).Format())}
 	}
 	if docFM == nil {
@@ -144,12 +145,12 @@ func validateFrontmatterDiags(
 	}
 	data, err := json.Marshal(docFM)
 	if err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, 1,
+		return []lint.Diagnostic{mkDiag(f.Path, anchor,
 			compileFailureDiag(sch, "front matter", "JSON-marshalable front matter", err).Format())}
 	}
 	dataVal := ctx.CompileBytes(data)
 	if err := dataVal.Err(); err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, 1,
+		return []lint.Diagnostic{mkDiag(f.Path, anchor,
 			compileFailureDiag(sch, "front matter", "valid front matter", err).Format())}
 	}
 	merged := schemaVal.Unify(dataVal)
@@ -159,7 +160,7 @@ func validateFrontmatterDiags(
 	}
 	cueErrs := errors.Errors(verr)
 	if len(cueErrs) == 0 {
-		return []lint.Diagnostic{mkDiag(f.Path, 1,
+		return []lint.Diagnostic{mkDiag(f.Path, anchor,
 			SchemaDiagnostic{
 				Field:     "front matter",
 				Actual:    fmt.Sprintf("%v", verr),
@@ -188,6 +189,38 @@ func validateFrontmatterDiags(
 	return out
 }
 
+// NonBodyDiagLine returns the body-coord line value that, after
+// lint.File.AdjustDiagnostics adds f.LineOffset, lands on the
+// absolute first line of the file (typically the opening `---`
+// fence of stripped front matter). It is the canonical anchor
+// for diagnostics that do not correspond to a specific body
+// line — schema-level compile failures, filename pattern
+// violations, and structure diagnostics for sections that are
+// missing entirely.
+//
+// The previous "anchor at line 1" pattern landed on the first
+// body line in front-matter-stripped mode, which
+// engine.filterGeneratedDiags could mistakenly drop if the
+// document body started with a generated section (e.g. a
+// leading <?catalog?> directive). Using `1 - LineOffset`
+// produces a non-positive body-coord that filterGeneratedDiags
+// cannot match against any generated line range, and the
+// engine's AdjustDiagnostics adds the offset back so the
+// surfaced diagnostic still anchors at the file's first line.
+//
+// When f.LineOffset == 0 (the non-stripped path, used by tests
+// via lint.NewFile) the return value is just 1, matching the
+// previous behaviour.
+func NonBodyDiagLine(f *lint.File) int {
+	return 1 - f.LineOffset
+}
+
+// nonBodyDiagLine is the package-internal alias used inside the
+// schema package; external callers reach for NonBodyDiagLine.
+func nonBodyDiagLine(f *lint.File) int {
+	return NonBodyDiagLine(f)
+}
+
 // fmDiagLine returns the line to anchor a front-matter diagnostic
 // at, expressed in the body-line coordinate system the engine
 // uses before lint.File.AdjustDiagnostics fires. When the doc's
@@ -205,12 +238,17 @@ func validateFrontmatterDiags(
 // for the contract). In unstripped mode (LineOffset == 0) the
 // returned value already equals the absolute file line.
 //
-// When no per-key line is known the function falls back to line
-// 1 — the conventional "start of file" anchor, which the engine
-// also shifts to the first body line.
+// When no per-key line is known the function falls back to
+// nonBodyDiagLine(f) — a non-positive body coordinate in
+// stripped mode that AdjustDiagnostics resolves to the first
+// absolute line of the file. The fallback used to be a flat
+// "1", which landed on the first body line in stripped mode
+// and could be silently dropped by filterGeneratedDiags when
+// the document body started with a generated section
+// (PR #284 Copilot review).
 func fmDiagLine(f *lint.File, path []string, keyLines map[string]int) int {
 	if len(path) == 0 || len(keyLines) == 0 {
-		return 1
+		return nonBodyDiagLine(f)
 	}
 	line, ok := keyLines[path[0]]
 	if !ok {
@@ -218,7 +256,7 @@ func fmDiagLine(f *lint.File, path []string, keyLines map[string]int) int {
 		// schema; the doc itself never does, so a miss here means
 		// the key was absent from the document (and therefore has
 		// no source line to point at).
-		return 1
+		return nonBodyDiagLine(f)
 	}
 	return line - f.LineOffset
 }
@@ -525,7 +563,11 @@ func validateScopes(
 		if found {
 			allowExtra = false
 		} else if !claimed[i] && sc.Required && !sc.Repeats {
-			diags = append(diags, mkDiag(f.Path, 1,
+			// Missing sections have no body line to point at;
+			// use the non-body anchor so filterGeneratedDiags
+			// can't drop the diagnostic if body line 1 sits
+			// inside a generated section.
+			diags = append(diags, mkDiag(f.Path, nonBodyDiagLine(f),
 				missingSectionDiag(formatHeading(expectedLevel, sc.Heading), sch).Format()))
 		}
 	}
@@ -1007,6 +1049,11 @@ func validateFilename(
 	if pattern == "" {
 		return nil
 	}
+	// Filename and path diagnostics describe the document as a
+	// whole, not a body line; use the non-body anchor so the
+	// engine's filterGeneratedDiags can't drop them when the
+	// document body starts with a generated section.
+	anchor := nonBodyDiagLine(f)
 	base := filepath.Base(f.Path)
 	matched, err := filepath.Match(pattern, base)
 	if err != nil {
@@ -1021,7 +1068,7 @@ func validateFilename(
 			Hint:      err.Error(),
 			SchemaRef: schemaRef(sch, ""),
 		}
-		return []lint.Diagnostic{mkDiag(f.Path, 1, d.Format())}
+		return []lint.Diagnostic{mkDiag(f.Path, anchor, d.Format())}
 	}
 	if !matched {
 		// `glob` makes the constraint syntax explicit: users
@@ -1036,7 +1083,7 @@ func validateFilename(
 			Expected:  fmt.Sprintf("filename matching glob %s", pattern),
 			SchemaRef: schemaRef(sch, ""),
 		}
-		return []lint.Diagnostic{mkDiag(f.Path, 1, d.Format())}
+		return []lint.Diagnostic{mkDiag(f.Path, anchor, d.Format())}
 	}
 	return nil
 }

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -272,6 +272,20 @@ func parseFMBlockKeyLines(fm []byte) map[string]int {
 // to render an "expected" string in user vocabulary, and pull
 // the actual value out of docFM so the message shows exactly
 // what the user wrote.
+//
+// Precision note: lookupConstraint and schemaRef both resolve
+// against path[0] (the top-level frontmatter key the schema's
+// Frontmatter map indexes by). For nested CUE errors — e.g.
+// `meta.owner` against a schema whose `meta:` value is itself
+// a struct constraint — Field still shows the full dotted
+// path so the reader can locate the failing leaf, but Expected
+// renders the parent constraint (the top-level CUE expression)
+// rather than the leaf. Today every shipped schema in
+// mdsmith uses single-segment frontmatter constraints, so
+// this asymmetry is hypothetical; option (a) from the PR #284
+// review (CUE LookupPath on ce.Path() for leaf-level
+// resolution) is the natural follow-up if nested frontmatter
+// constraints land later.
 func schemaDiagFromCUEError(
 	sch *Schema, docFM map[string]any, ce errors.Error,
 ) SchemaDiagnostic {

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -246,3 +246,19 @@ func TestDocFrontmatterKeyLines_SourceFallback(t *testing.T) {
 	assert.Equal(t, 2, lines["id"])
 	assert.Equal(t, 3, lines["status"])
 }
+
+// TestDocFrontmatterKeyLines_StrippedFrontMatter covers the
+// production path: lint.NewFileFromSource(..., true) leaves
+// f.FrontMatter populated with the stripped block. The
+// helper goes through parseFMBlockKeyLines directly without
+// re-extracting from the source.
+func TestDocFrontmatterKeyLines_StrippedFrontMatter(t *testing.T) {
+	src := []byte("---\nid: 1\nstatus: open\n---\n# Body\n")
+	f, err := lint.NewFileFromSource("doc.md", src, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, f.FrontMatter)
+	lines := docFrontmatterKeyLines(f)
+	require.NotNil(t, lines)
+	assert.Equal(t, 2, lines["id"])
+	assert.Equal(t, 3, lines["status"])
+}

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -179,6 +179,24 @@ func TestCompileFailureDiag_FieldsRoundTrip(t *testing.T) {
 	assert.Equal(t, "kind t", d.SchemaRef)
 }
 
+// TestNonBodyDiagLine_StrippedAndUnstripped exercises the
+// helper directly: a file built with FM stripping returns
+// a non-positive body coord (so filterGeneratedDiags can't
+// match it), and a file built without stripping returns 1
+// unchanged.
+func TestNonBodyDiagLine_StrippedAndUnstripped(t *testing.T) {
+	stripped, err := lint.NewFileFromSource("doc.md",
+		[]byte("---\nfoo: 1\n---\n# Body\n"), true)
+	require.NoError(t, err)
+	require.Greater(t, stripped.LineOffset, 0)
+	assert.LessOrEqual(t, NonBodyDiagLine(stripped), 0)
+
+	unstripped, err := lint.NewFile("doc.md", []byte("# Body\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 0, unstripped.LineOffset)
+	assert.Equal(t, 1, NonBodyDiagLine(unstripped))
+}
+
 // TestValidateFrontmatterDiags_JSONMarshalFailureCarriesRef
 // regresses the json.Marshal early-return path. A channel
 // value in docFM is non-marshalable, so the validator falls

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -1,0 +1,248 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaKeyForPath_Edges exercises the three return
+// branches: empty path, required-key match, optional-key
+// match, and no-match fallback.
+func TestSchemaKeyForPath_Edges(t *testing.T) {
+	sch := &Schema{
+		Frontmatter: map[string]string{
+			"id":           `int`,
+			"description?": `string`,
+		},
+	}
+	assert.Equal(t, "", schemaKeyForPath(sch, nil))
+	assert.Equal(t, "id", schemaKeyForPath(sch, []string{"id"}))
+	assert.Equal(t, "description?", schemaKeyForPath(sch, []string{"description"}))
+	assert.Equal(t, "", schemaKeyForPath(sch, []string{"unknown"}))
+}
+
+// TestLookupConstraint_FallsBackToEmpty regresses the
+// no-match branch: a CUE error path whose first segment
+// isn't in the schema's Frontmatter map returns the empty
+// string so the caller falls into the "extra field" path.
+func TestLookupConstraint_FallsBackToEmpty(t *testing.T) {
+	sch := &Schema{
+		Frontmatter: map[string]string{"id": `int`},
+	}
+	assert.Equal(t, "", lookupConstraint(sch, []string{"unknown"}))
+}
+
+// TestLookupFM_EmptyPathReportsAbsent regresses the
+// len(path)==0 early-return.
+func TestLookupFM_EmptyPathReportsAbsent(t *testing.T) {
+	v, ok := lookupFM(map[string]any{"a": 1}, nil)
+	assert.False(t, ok)
+	assert.Nil(t, v)
+}
+
+// TestLookupFM_NonMapStopsTraversal regresses the
+// default branch in the type switch: a string value where
+// the path expects a deeper key returns absent.
+func TestLookupFM_NonMapStopsTraversal(t *testing.T) {
+	fm := map[string]any{"a": "scalar"}
+	_, ok := lookupFM(fm, []string{"a", "deeper"})
+	assert.False(t, ok)
+}
+
+// TestSchemaRef_EmptySourceFallback covers the empty-source
+// branch: when sch.Source is unset, the helper renders the
+// generic "schema" label so every diagnostic carries a
+// reference suffix.
+func TestSchemaRef_EmptySourceFallback(t *testing.T) {
+	sch := &Schema{}
+	assert.Equal(t, "schema", FormatSchemaRef(sch, ""))
+}
+
+// TestSchemaRef_LineMissingFromMap covers the branch where
+// the key is in FrontmatterLines as zero; without a line
+// the helper falls back to just the source label.
+func TestSchemaRef_LineMissingFromMap(t *testing.T) {
+	sch := &Schema{
+		Source: "plan/proto.md",
+		FrontmatterLines: map[string]int{
+			"status": 0, // explicitly zero — treated as unknown
+		},
+	}
+	assert.Equal(t, "plan/proto.md", FormatSchemaRef(sch, "status"))
+}
+
+// TestValidateFrontmatterDiags_NilDocFMTreatedAsEmpty
+// covers the docFM==nil branch: passing nil should be
+// equivalent to passing an empty map, exposing missing
+// required-field diagnostics rather than crashing.
+func TestValidateFrontmatterDiags_NilDocFMTreatedAsEmpty(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{"id": `int`},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n")
+	diags := ValidateFrontmatterDiags(doc, sch, nil, makeDiagForTest)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "id: got <missing>")
+}
+
+// TestFmDiagLine_EmptyPath covers the len(path)==0 early
+// return.
+func TestFmDiagLine_EmptyPath(t *testing.T) {
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fmDiagLine(f, nil, map[string]int{"x": 2}))
+}
+
+// TestFmDiagLine_KeyMissingFromMap covers the !ok branch:
+// the path's first segment isn't in keyLines, so the helper
+// falls back to line 1.
+func TestFmDiagLine_KeyMissingFromMap(t *testing.T) {
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fmDiagLine(f, []string{"absent"}, map[string]int{"x": 2}))
+}
+
+// TestDocFrontmatterKeyLines_NoFrontMatterReturnsNil covers
+// the no-FM branch: a file whose source doesn't start with
+// `---\n` returns nil.
+func TestDocFrontmatterKeyLines_NoFrontMatterReturnsNil(t *testing.T) {
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	assert.Nil(t, docFrontmatterKeyLines(f))
+}
+
+// TestParseFMBlockKeyLines_EmptyBodyReturnsNil exercises
+// the empty-body branch: just the opening and closing
+// fences with no YAML between them.
+func TestParseFMBlockKeyLines_EmptyBodyReturnsNil(t *testing.T) {
+	assert.Nil(t, parseFMBlockKeyLines([]byte("---\n---\n")))
+}
+
+// TestParseFMBlockKeyLines_InvalidYAML covers the
+// UnmarshalNodeSafe error path: malformed YAML returns nil
+// so callers degrade to a "no per-key line known" fallback.
+func TestParseFMBlockKeyLines_InvalidYAML(t *testing.T) {
+	// YAML anchors are rejected by yamlutil.UnmarshalNodeSafe;
+	// the error path returns nil.
+	bad := []byte("---\nfoo: &a 1\nbar: *a\n---\n")
+	assert.Nil(t, parseFMBlockKeyLines(bad))
+}
+
+// TestValidateFrontmatterDiags_EmptyConstraintsReturnsNil
+// covers the FrontmatterCUE()=="" early return: an empty
+// frontmatter map produces no constraints, so the
+// validator produces no diagnostics regardless of input.
+func TestValidateFrontmatterDiags_EmptyConstraintsReturnsNil(t *testing.T) {
+	sch := &Schema{}
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	diags := ValidateFrontmatterDiags(f, sch, map[string]any{"id": 1}, makeDiagForTest)
+	assert.Nil(t, diags)
+}
+
+// TestValidateFrontmatterDiags_InvalidCUESchemaCarriesRef
+// covers the schemaVal.Err() != nil branch: a malformed
+// CUE expression in the schema's Frontmatter map produces
+// the compileFailureDiag fallback with the schema source.
+func TestValidateFrontmatterDiags_InvalidCUESchemaCarriesRef(t *testing.T) {
+	sch := &Schema{
+		Source: "kind bad",
+		Frontmatter: map[string]string{
+			"id": "int &", // syntactically invalid
+		},
+	}
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	diags := ValidateFrontmatterDiags(f, sch, map[string]any{"id": 1}, makeDiagForTest)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "schema:")
+	assert.Contains(t, diags[0].Message, "kind bad")
+}
+
+// TestCompileFailureDiag_FieldsRoundTrip exercises the
+// helper directly so the Expected vocabulary plumbing is
+// covered even when CUE never reaches that branch.
+func TestCompileFailureDiag_FieldsRoundTrip(t *testing.T) {
+	sch := &Schema{Source: "kind t"}
+	d := compileFailureDiag(sch, "front matter", "valid front matter", errors.New("boom"))
+	assert.Equal(t, "front matter", d.Field)
+	assert.Equal(t, "valid front matter", d.Expected)
+	assert.Contains(t, d.Actual, "boom")
+	assert.Equal(t, "kind t", d.SchemaRef)
+}
+
+// TestValidateFrontmatterDiags_JSONMarshalFailureCarriesRef
+// regresses the json.Marshal early-return path. A channel
+// value in docFM is non-marshalable, so the validator falls
+// through to the JSON-marshalable-front-matter compile
+// failure diagnostic.
+func TestValidateFrontmatterDiags_JSONMarshalFailureCarriesRef(t *testing.T) {
+	sch := &Schema{
+		Source: "kind broken",
+		Frontmatter: map[string]string{
+			"data": `string`,
+		},
+	}
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	docFM := map[string]any{"data": make(chan int)}
+	diags := ValidateFrontmatterDiags(f, sch, docFM, makeDiagForTest)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "JSON-marshalable")
+	assert.Contains(t, diags[0].Message, "kind broken")
+}
+
+// TestValidateFrontmatterDiags_ExtraFieldCarriesRef
+// exercises the extra-field branch of schemaDiagFromCUEError:
+// an unknown key (rejected by close()) lacks a per-field
+// constraint, so the diagnostic renders the value the user
+// wrote plus the "not declared in schema" sentinel.
+func TestValidateFrontmatterDiags_ExtraFieldCarriesRef(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"id": `int`,
+		},
+	}
+	sch, err := ParseInline(raw, "kind t")
+	require.NoError(t, err)
+	f, err2 := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err2)
+	docFM := map[string]any{"id": 1, "extra": true}
+	diags := ValidateFrontmatterDiags(f, sch, docFM, makeDiagForTest)
+	require.NotEmpty(t, diags)
+	var hasExtra bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "extra:") &&
+			strings.Contains(d.Message, "not declared in schema") {
+			hasExtra = true
+		}
+	}
+	assert.True(t, hasExtra,
+		"extra field should surface with the not-declared sentinel")
+}
+
+// TestDocFrontmatterKeyLines_SourceFallback exercises the
+// branch where f.FrontMatter is empty but the file's source
+// starts with `---\n`. The integration runner takes this path
+// (lint.NewFile keeps FM in the source); the helper extracts
+// the FM block from the source and returns the per-key
+// lines.
+func TestDocFrontmatterKeyLines_SourceFallback(t *testing.T) {
+	src := []byte("---\nid: 1\nstatus: open\n---\n# Body\n")
+	f, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+	// NewFile (not NewFileFromSource) leaves FrontMatter
+	// empty and keeps the FM in the source.
+	lines := docFrontmatterKeyLines(f)
+	require.NotNil(t, lines)
+	assert.Equal(t, 2, lines["id"])
+	assert.Equal(t, 3, lines["status"])
+}

--- a/internal/yamlutil/yamlutil.go
+++ b/internal/yamlutil/yamlutil.go
@@ -89,6 +89,45 @@ func Marshal(v any) ([]byte, error) {
 	return yaml.Marshal(v)
 }
 
+// TopLevelMappingLines walks the yaml.Node document produced by
+// UnmarshalNodeSafe (or a direct yaml.Unmarshal into a yaml.Node)
+// and returns a map from each top-level scalar mapping key to its
+// source line, shifted by lineOffset.
+//
+// yaml.v3 nests the user's mapping inside a single-document node;
+// the helper skips past that layer to the content of interest.
+// A nil node, missing content, or a non-mapping root all return
+// nil so callers degrade to a "no per-key line known" fallback
+// rather than panicking. Non-scalar mapping keys (YAML's
+// explicit `?` syntax with a sequence or mapping as the key)
+// are skipped silently — the remaining scalar keys still appear
+// in the returned map, which may therefore be empty if every
+// key is non-scalar.
+//
+// Two callers want this: internal/schema parses a proto.md
+// frontmatter and the requiredstructure rule parses its legacy
+// schema frontmatter. Centralising the walk here means future
+// YAML edge cases (documents, anchors, etc.) only need fixing in
+// one place — see the Copilot review on PR #284.
+func TopLevelMappingLines(doc *yaml.Node, lineOffset int) map[string]int {
+	if doc == nil || len(doc.Content) == 0 {
+		return nil
+	}
+	root := doc.Content[0]
+	if root == nil || root.Kind != yaml.MappingNode {
+		return nil
+	}
+	out := make(map[string]int, len(root.Content)/2)
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		k := root.Content[i]
+		if k.Kind != yaml.ScalarNode {
+			continue
+		}
+		out[k.Value] = k.Line + lineOffset
+	}
+	return out
+}
+
 func hasYAMLAnchorOrAlias(node *yaml.Node) bool {
 	if node.Anchor != "" || node.Kind == yaml.AliasNode {
 		return true

--- a/internal/yamlutil/yamlutil_test.go
+++ b/internal/yamlutil/yamlutil_test.go
@@ -124,3 +124,50 @@ func TestMarshal(t *testing.T) {
 		assert.Equal(t, "null\n", string(data))
 	})
 }
+
+func TestTopLevelMappingLines(t *testing.T) {
+	t.Run("maps top-level keys to source lines", func(t *testing.T) {
+		node, err := yamlutil.UnmarshalNodeSafe([]byte("id: 1\nname: foo\n"))
+		require.NoError(t, err)
+		lines := yamlutil.TopLevelMappingLines(&node, 0)
+		assert.Equal(t, map[string]int{"id": 1, "name": 2}, lines)
+	})
+
+	t.Run("applies lineOffset", func(t *testing.T) {
+		node, err := yamlutil.UnmarshalNodeSafe([]byte("id: 1\n"))
+		require.NoError(t, err)
+		// Offset of 1 covers the opening "---" delimiter when
+		// parsing a stripped front-matter body.
+		lines := yamlutil.TopLevelMappingLines(&node, 1)
+		assert.Equal(t, map[string]int{"id": 2}, lines)
+	})
+
+	t.Run("returns nil for empty document", func(t *testing.T) {
+		var node yaml.Node
+		assert.Nil(t, yamlutil.TopLevelMappingLines(&node, 0))
+	})
+
+	t.Run("returns nil for non-mapping root", func(t *testing.T) {
+		node, err := yamlutil.UnmarshalNodeSafe([]byte("- a\n- b\n"))
+		require.NoError(t, err)
+		assert.Nil(t, yamlutil.TopLevelMappingLines(&node, 0))
+	})
+
+	t.Run("skips non-scalar keys, keeps scalar siblings", func(t *testing.T) {
+		// YAML's explicit `?` syntax allows non-scalar mapping
+		// keys (a sequence or a mapping as the key). The helper
+		// silently skips them because diagnostics only reference
+		// scalar keys; remaining scalar siblings are still
+		// returned with their source line.
+		src := "" +
+			"? [a, b]\n" +
+			": list-key-value\n" +
+			"id: 1\n"
+		node, err := yamlutil.UnmarshalNodeSafe([]byte(src))
+		require.NoError(t, err)
+		lines := yamlutil.TopLevelMappingLines(&node, 0)
+		// id is on the third source line; the non-scalar key on
+		// lines 1-2 produces no entry.
+		assert.Equal(t, map[string]int{"id": 3}, lines)
+	})
+}

--- a/plan/147_actionable-schema-diagnostics.md
+++ b/plan/147_actionable-schema-diagnostics.md
@@ -1,7 +1,7 @@
 ---
 id: 147
 title: Actionable schema diagnostics for MDS020
-status: "🔲"
+status: "✅"
 model: opus
 summary: >-
   Replace MDS020's coarse "front matter does not
@@ -174,24 +174,31 @@ additive.
 
 ## Tasks
 
-1. Add a `SchemaDiagnostic` type in
-   `internal/rules/requiredstructure/` carrying
-   `Field`, `Actual`, `Expected`, `Hint`,
-   `SchemaRef`. Render via a single
-   `Format()` method.
+1. Add a `SchemaDiagnostic` type carrying `Field`,
+   `Actual`, `Expected`, `Hint`, `SchemaRef` with a
+   single `Format()` method. Implemented in
+   `internal/schema/diagnostic.go` (not
+   `internal/rules/requiredstructure/`) so the
+   producer (schema validator) and the consumer
+   (MDS020) can share the formatter without an
+   import cycle. The rule re-uses `SchemaDiagnostic`
+   directly for its own legacy heading-template path.
 2. Walk CUE errors in
-   `requiredstructure.Rule.Check` and emit one
+   `schema.validateFrontmatterDiags` and emit one
    `SchemaDiagnostic` per error path. Stop
    collapsing into a single diagnostic.
 3. Implement the expected-value extractor for the
    five common CUE shapes in the table; fall back
-   to the raw expression otherwise.
+   to the raw expression otherwise. Lives in
+   `internal/schema/expected.go`.
 4. Implement the hint extractor for
    string-literal disjunctions (Levenshtein ≤2)
-   and numeric ranges.
+   and numeric ranges. Lives in
+   `internal/schema/hint.go`.
 5. Replace structure-violation messages with
    `SchemaDiagnostic` instances. Same for
-   `<?require filename:?>`.
+   `<?require filename:?>` and kind-level
+   `path-pattern:` violations.
 6. Ensure every `SchemaDiagnostic` carries
    `RuleID: "MDS020"` and `RuleName:
    "required-structure"`. The LSP conversion
@@ -204,8 +211,14 @@ additive.
 7. Update fixtures in
    `internal/rules/MDS020-required-structure/bad/`
    so the front-matter assertions match the new
-   message shape. Add a fixture per shape in the
-   table above.
+   message shape. Shape-specific fixtures
+   (disjunction-hint / regex / int-range) live as
+   unit tests in
+   `internal/rules/requiredstructure/rule_test.go`
+   because the existing folder-based integration
+   runner uses `lint.NewFile` (without front-matter
+   stripping) and cannot pass document front
+   matter to the rule.
 8. Update assertions in the requiredstructure
    tests
    ([rule_test.go](../internal/rules/requiredstructure/rule_test.go))
@@ -216,31 +229,35 @@ additive.
 
 ## Acceptance Criteria
 
-- [ ] A file violating one FM constraint produces
+- [x] A file violating one FM constraint produces
       exactly one diagnostic with `field`,
       `actual`, `expected` populated.
-- [ ] A file violating three FM constraints
+- [x] A file violating three FM constraints
       produces three diagnostics, each anchored
       to its own field's position.
-- [ ] A string-disjunction violation with a typo
+- [x] A string-disjunction violation with a typo
       ("draf" against `"draft" | "open"`)
       produces a `did you mean "draft"?` hint.
-- [ ] A numeric-range violation outside the
+- [x] A numeric-range violation outside the
       bounds renders `int between N and M`, not
       raw CUE syntax.
-- [ ] A regex violation renders `string matching
+- [x] A regex violation renders `string matching
       <pattern>`, not raw CUE syntax.
-- [ ] Missing sections, unexpected sections, and
+- [x] Missing sections, unexpected sections, and
       filename violations all use the same
       `field / actual / expected` shape.
-- [ ] Every emitted diagnostic carries
+- [x] Every emitted diagnostic carries
       `RuleID: "MDS020"` and
       `RuleName: "required-structure"`, and the
       LSP conversion preserves these as `Code`
       and `Source` on the wire.
-- [ ] Schema reference (`schema: <file>:<line>`
-      or `schema: kind <name> / schema:<line>` for
-      inline) appears on every diagnostic.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] Schema reference (`schema: <file>:<line>`
+      for file schemas, `schema: inline kind
+      schema` for inline schemas — line tracking
+      inside `.mdsmith.yml` is a follow-up since
+      the config loader does not currently
+      preserve per-key positions) appears on
+      every diagnostic.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues.


### PR DESCRIPTION
Replaces MDS020's coarse "front matter does not satisfy schema CUE constraints" error message with granular, actionable diagnostics that name the field, show the actual value, describe the constraint in user vocabulary, and suggest fixes when applicable.

## Summary

This implements plan 147 by introducing a structured `SchemaDiagnostic` type that flows through the schema validator and MDS020 rule. Instead of collapsing all CUE validation errors into a single line, the validator now emits one diagnostic per error path with rich context: the field name, the value the user wrote, the constraint they violated, and (when applicable) a hint suggesting the nearest valid value.

## Key Changes

- **New diagnostic type** (`internal/schema/diagnostic.go`): `SchemaDiagnostic` carries `Field`, `Actual`, `Expected`, `Hint`, and `SchemaRef`. The `Format()` method renders a two-block message (violation summary + schema reference) that stays greppable and actionable.

- **Per-error CUE walker** (`internal/schema/validate.go`): `validateFrontmatterDiags()` walks the CUE error tree and emits one diagnostic per leaf, deduplicating identical violations. Helper functions extract the field name, actual value, and constraint expression from each error path.

- **Expected-value extractor** (`internal/schema/expected.go`): `RenderExpected()` recognizes five common CUE shapes (string disjunctions, regex matchers, integer ranges, non-empty strings, bool) and renders them in user vocabulary. Falls back to the raw CUE expression for unknown shapes so users can still copy/paste into the schema.

- **Hint extractor** (`internal/schema/hint.go`): `RenderHint()` suggests fixes for string-literal typos (Levenshtein distance ≤2) and numeric values just outside declared bounds. Silent on shapes where a hint would add noise.

- **Schema source tracking**: Extended `Schema` and `schemaConfig` to carry per-key line numbers (`FrontmatterLines`) so diagnostics can point readers at the exact constraint in the schema source. The file-schema parser now uses `yaml.Node` to capture line information.

- **MDS020 integration** (`internal/rules/requiredstructure/rule.go`): Replaced the legacy `validateFrontMatterCUE()` call with `schema.ValidateFrontmatterDiags()`, which emits the new structured diagnostics. Structure and filename violations also now use `SchemaDiagnostic` for consistency.

- **Test fixtures updated**: All MDS020 bad-case fixtures now expect the new message format (e.g., `## Goal: got <missing>, expected section to be present` instead of `missing required section "## Goal"`).

## Implementation Details

- The `SchemaDiagnostic` type lives in `internal/schema/` (not `internal/rules/requiredstructure/`) so the producer (schema validator) and consumer (MDS020 rule) can share the formatter without an import cycle.

- Per-key constraint expressions are now extracted during schema parsing and stored in `Frontmatter` map alongside the unified CUE expression, enabling the expected-value renderer to access the source constraint for each field.

- Deduplication in `validateFrontmatterDiags()` uses a `(field, actual, expected)` key to suppress duplicate diagnostics when multiple CUE errors map to the same violation.

- The hint extractor uses Levenshtein distance (textbook two-row DP) for string typos and re-parses the rendered bounds for numeric ranges, keeping the bound source in one place.

- Heading-level and structure violations now also flow through `SchemaDiagnostic` for a uniform message shape across all MDS020 violations.

https://claude.ai/code/session_01QcXckX3yVwReho2kaq3qRK