### PR TITLE
plan(156): section schema — unify entry shape under heading:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ row: "- [{summary}]({filename})"
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](docs/reference/schema-types.md)
-- [Section-schema reference: the entry-shape vocabulary used in inline `kinds.<name>.schema:` blocks and `proto.md` files. Covers the `heading:` discriminator, the `regex:` matcher with `{n}` and `{field}` preprocessor tokens, the `repeat: {min, max}` cardinality field, and the matching algorithm.](docs/reference/section-schema.md)
+- [Section-schema reference: the entry-shape vocabulary used in inline `kinds.<name>.schema:` blocks and `proto.md` files. Covers the `heading:` discriminator, the `regex:` matcher (a CUE expression with `digits` and `fmvar` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm.](docs/reference/section-schema.md)
 <?/catalog?>
 
 ## Development Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ row: "- [{summary}]({filename})"
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](docs/reference/schema-types.md)
+- [Section-schema reference: the entry-shape vocabulary used in inline `kinds.<name>.schema:` blocks and `proto.md` files. Covers the `heading:` discriminator, the `regex:` matcher with `{n}` and `{field}` preprocessor tokens, the `repeat: {min, max}` cardinality field, and the matching algorithm.](docs/reference/section-schema.md)
 <?/catalog?>
 
 ## Development Workflow

--- a/PLAN.md
+++ b/PLAN.md
@@ -84,4 +84,5 @@ footer: |
 | 153 | ✅     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
 | 154 | 🔲     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
 | 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
+| 156 | 🔲     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
 <?/catalog?>

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -4,9 +4,9 @@ summary: >-
   vocabulary used in inline `kinds.<name>.schema:`
   blocks and `proto.md` files. Covers the
   `heading:` discriminator, the `regex:` matcher
-  with `{n}` and `{field}` preprocessor tokens,
-  the `repeat: {min, max}` cardinality field, and
-  the matching algorithm.
+  (a CUE expression with `digits` and `fmvar`
+  helpers), the `repeat: {min, max}` cardinality
+  field, and the matching algorithm.
 ---
 # Section schema
 
@@ -39,13 +39,13 @@ schema:
     - heading:
         regex: 'Intro|Getting Started'           # disjunction
     - heading:
-        regex: 'Step {n}'                        # numeric pattern
+        regex: 'Step \#(digits)'                 # numeric pattern
         repeat: { min: 1 }                       # one or more
-        sequential: true                         # {n} ordered
+        sequential: true                         # digits ordered
       sections: [...]
       content: [...]
     - heading:
-        regex: '{id}: {name}'                    # frontmatter interpolation
+        regex: '\#(fmvar(id)): \#(fmvar(name))'  # frontmatter interpolation
     - heading:
         regex: '.+'
         repeat: { min: 0 }                       # zero or more (slot)
@@ -107,7 +107,7 @@ exactly one occurrence.
 
 ```yaml
 - heading:
-    regex: 'Step {n}'
+    regex: 'Step \#(digits)'
     repeat: { min: 1, max: 5 }
     sequential: true
 ```
@@ -118,13 +118,20 @@ value is a mapping.
 
 ## The regex matcher
 
-`regex:` is a CUE-compatible regex over the
-heading's rendered plain text.
+`regex:` is a CUE expression evaluating to a
+string. The string is compiled as Go RE2.
 
-**Dialect.** Go RE2, the same dialect CUE's
-`=~` operator uses. No backreferences, no
-lookaround. Plus two mdsmith preprocessor
-tokens described below.
+The YAML value is the body of a CUE
+raw-interpolation string. mdsmith wraps it in
+`#"..."#` before evaluating. Two consequences:
+
+- **Backslash is literal.** Write `\d`, `\w`,
+  `\.`, `\(` directly — no doubling. Plain
+  RE2 patterns work as-is.
+- **Interpolation is `\#(expr)`.** Inside the
+  string, `\#(x)` evaluates `x` in the CUE
+  scope (frontmatter fields plus mdsmith
+  helpers) and substitutes the result.
 
 **Anchoring.** Whole-string. `regex: 'Overview'`
 matches a heading whose text is exactly
@@ -142,51 +149,39 @@ Rendering strips inline emphasis, link wrappers
 **Case.** Sensitive. Use `(?i)` for
 insensitive.
 
-## Preprocessor: `{n}` and `{field}`
+## Helpers
 
-`{n}` and `{field}` are mdsmith preprocessor
-tokens. They rewrite the `regex:` string before
-RE2 compilation. The same tokens work in
-`proto.md` heading rows.
+Two helpers are in the `regex:` evaluation
+scope alongside the document's frontmatter
+fields.
 
-### `{n}` — numeric placeholder
+**`digits`** — string constant
+`(?P<n>[0-9]+)`. A named numeric capture group
+on `n`. Use it for sequenced headings like
+`## Step 1` / `## Step 2`. Limit: one `digits`
+per pattern.
 
-`{n}` expands to `(?P<n>[0-9]+)` — a named
-numeric capture. Use it for headings like
-`## Step 1`, `## Step 2`. Limit: one `{n}` per
-pattern.
+**`fmvar(name)`** — looks up the frontmatter
+field `name`, regex-escapes its value, and
+returns it. Use it whenever the heading text
+must equal a frontmatter value. The escape is
+needed because field values can contain RE2
+metacharacters.
 
 ```yaml
 - heading:
-    regex: 'Step {n}'
+    regex: 'Step \#(digits)'
     repeat: { min: 1 }
     sequential: true
-```
-
-### `{field}` — frontmatter interpolation
-
-`{field}` expands at validate-time. The
-document's frontmatter value for `field` is
-regex-escaped and inserted in place. Use it when
-the heading text must equal a frontmatter value:
-
-```yaml
 - heading:
-    regex: '{id}: {name}'
+    regex: '\#(fmvar(id)): \#(fmvar(name))'
 ```
-
-If `id: "MDS001"` and `name: "first-line"`, the
-schema matches `## MDS001: first-line`.
-
-### `sequential:` — ordering check
 
 `sequential: true` is a sibling field on the
-heading entry. Only meaningful when `regex:`
-contains `{n}`. Asserts that captured numeric
-values across matched headings are in
-increasing order with no gaps.
-
-`sequential: true` without `{n}` parse-errors.
+entry. Only meaningful with `digits` in the
+regex; asserts the captured `n` values are
+increasing with no gaps. Without `digits` it
+parse-errors.
 
 ## The repeat field
 
@@ -242,7 +237,6 @@ Each entry can carry:
   scope produces a diagnostic. Default
   `false`. Express positional flex by listing
   a wildcard slot instead.
-- `sequential:` — described above.
 
 ## Schema-level fields
 
@@ -268,25 +262,29 @@ schema:
 
 ## `proto.md` file syntax
 
-Proto.md files remain a literal-template
-surface. Heading rows in the body act as the
-schema's `sections:` list.
+Proto.md files use a literal-template surface
+distinct from the inline `regex:` form. Heading
+rows in the body act as the schema's
+`sections:` list. `{n}` and `{field}` survive
+here as template placeholders; they desugar to
+the same matcher the inline form produces with
+`digits` and `fmvar`.
 
 | Row syntax        | Equivalent inline entry                        |
 |-------------------|------------------------------------------------|
 | `## Literal text` | `heading: "Literal text"`                      |
 | `## ?`            | `heading: { regex: '.+' }`                     |
 | `## ...`          | `heading: { regex: '.+', repeat: { min: 0 } }` |
-| `## Step {n}`     | `heading: { regex: 'Step {n}' }`               |
-| `## {id}`         | `heading: { regex: '{id}' }`                   |
+| `## Step {n}`     | `heading: { regex: 'Step \#(digits)' }`        |
+| `## {id}`         | `heading: { regex: '\#(fmvar(id))' }`          |
 
 Proto.md cannot express `repeat: { min, max }`
 or `sequential:`. Callers needing those switch
 to the inline-YAML form on a kind in
 `.mdsmith.yml`.
 
-The `<?require filename: "..."?>` directive
-in proto.md bodies is unchanged.
+The `<?require filename: "..."?>` directive in
+proto.md bodies is unchanged.
 
 ## Migration from the old shape
 

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -1,0 +1,306 @@
+---
+summary: >-
+  Section-schema reference: the entry-shape
+  vocabulary used in inline `kinds.<name>.schema:`
+  blocks and `proto.md` files. Covers the
+  `heading:` discriminator, the `regex:` matcher
+  with `{n}` and `{field}` preprocessor tokens,
+  the `repeat: {min, max}` cardinality field, and
+  the matching algorithm.
+---
+# Section schema
+
+> **Status: upcoming.** This page documents the
+> shape defined by
+> [plan 156](../../plan/156_schema-entry-unification.md).
+> It is not yet implemented. The current parser
+> accepts the older shape documented in the
+> [schema guide](../guides/schemas.md). When plan
+> 156 lands, this notice is removed and the guide
+> is rewritten to drop every reference to the old
+> shape.
+
+A **section schema** describes the heading
+structure mdsmith expects in a document. It
+pairs with frontmatter and filename constraints
+to form a kind's required-structure schema.
+
+## At a glance
+
+```yaml
+schema:
+  filename: "RFC-[0-9][0-9][0-9][0-9].md"
+  frontmatter:
+    id: '=~"^RFC-[0-9]{4}$"'
+    status: '"draft" | "ratified"'
+  sections:
+    - heading: null                              # preamble
+    - heading: "Overview"                        # exact-match
+    - heading:
+        regex: 'Intro|Getting Started'           # disjunction
+    - heading:
+        regex: 'Step {n}'                        # numeric pattern
+        repeat: { min: 1 }                       # one or more
+        sequential: true                         # {n} ordered
+      sections: [...]
+      content: [...]
+    - heading:
+        regex: '{id}: {name}'                    # frontmatter interpolation
+    - heading:
+        regex: '.+'
+        repeat: { min: 0 }                       # zero or more (slot)
+    - heading: "References"
+```
+
+Three orthogonal axes describe each entry:
+
+- **Discriminator** — what kind of section it
+  is (`heading:` value).
+- **Matcher** — what text it accepts
+  (`regex:`).
+- **Cardinality** — how many headings it claims
+  (`repeat:`).
+
+## Entry shapes
+
+Every entry in `sections:` sets exactly one
+`heading:` key. Its value's YAML type
+discriminates the form.
+
+### `heading: null` — no-heading section
+
+```yaml
+- heading: null
+```
+
+Represents the preamble. At the top level, the
+preamble is the content before any heading. In a
+nested `sections:`, it is the content between
+the parent heading and the first child.
+
+Only valid as the first entry of its `sections:`
+list. Any later position parse-errors.
+
+A null entry accepts `content:` and `rules:`. It
+rejects `regex:` and `repeat:` — those live
+inside the `heading:` mapping form.
+
+### `heading: <string>` — exact-match sugar
+
+```yaml
+- heading: "Overview"
+```
+
+Sugar for the mapping form with the string
+regex-escaped into `regex:`. Equivalent to:
+
+```yaml
+- heading:
+    regex: 'Overview'
+```
+
+The bare string is the most common form. Use it
+when the heading text is fixed and you want
+exactly one occurrence.
+
+### `heading: { regex, repeat?, sequential? }` — full form
+
+```yaml
+- heading:
+    regex: 'Step {n}'
+    repeat: { min: 1, max: 5 }
+    sequential: true
+```
+
+The full form makes regex, cardinality, and
+ordering explicit. `regex:` is required when the
+value is a mapping.
+
+## The regex matcher
+
+`regex:` is a CUE-compatible regex over the
+heading's rendered plain text.
+
+**Dialect.** Go RE2, the same dialect CUE's
+`=~` operator uses. No backreferences, no
+lookaround. Plus two mdsmith preprocessor
+tokens described below.
+
+**Anchoring.** Whole-string. `regex: 'Overview'`
+matches a heading whose text is exactly
+`Overview`. The bare-string sugar behaves the
+same way. For a substring, write
+`regex: '.*Overview.*'`.
+
+**Match target.** The regex sees the heading's
+rendered plain text, not the raw source.
+Rendering strips inline emphasis, link wrappers
+(keeping link text), code-span backticks
+(keeping contents), heading attribute lists
+(`{#id}`), and trailing ATX `#`s.
+
+**Case.** Sensitive. Use `(?i)` for
+insensitive.
+
+## Preprocessor: `{n}` and `{field}`
+
+`{n}` and `{field}` are mdsmith preprocessor
+tokens. They rewrite the `regex:` string before
+RE2 compilation. The same tokens work in
+`proto.md` heading rows.
+
+### `{n}` — numeric placeholder
+
+`{n}` expands to `(?P<n>[0-9]+)` — a named
+numeric capture. Use it for headings like
+`## Step 1`, `## Step 2`. Limit: one `{n}` per
+pattern.
+
+```yaml
+- heading:
+    regex: 'Step {n}'
+    repeat: { min: 1 }
+    sequential: true
+```
+
+### `{field}` — frontmatter interpolation
+
+`{field}` expands at validate-time. The
+document's frontmatter value for `field` is
+regex-escaped and inserted in place. Use it when
+the heading text must equal a frontmatter value:
+
+```yaml
+- heading:
+    regex: '{id}: {name}'
+```
+
+If `id: "MDS001"` and `name: "first-line"`, the
+schema matches `## MDS001: first-line`.
+
+### `sequential:` — ordering check
+
+`sequential: true` is a sibling field on the
+heading entry. Only meaningful when `regex:`
+contains `{n}`. Asserts that captured numeric
+values across matched headings are in
+increasing order with no gaps.
+
+`sequential: true` without `{n}` parse-errors.
+
+## The repeat field
+
+`repeat: { min: int, max: int }` bounds how
+many consecutive headings the entry claims.
+Both fields are optional within the mapping;
+both must be ≥ 0.
+
+### Defaults
+
+| `repeat:`            | Meaning           |
+|----------------------|-------------------|
+| absent               | exactly one       |
+| `{ min: 0 }`         | zero or more      |
+| `{ min: 1 }`         | one or more       |
+| `{ min: 0, max: 1 }` | optional (0 or 1) |
+| `{ min: N, max: M }` | bounded N..M      |
+
+`min:` omitted (when `repeat:` is set) defaults
+to 0. `max:` omitted defaults to unbounded.
+
+Parse-time rejection: `repeat: {}` (empty),
+`max: 0`, `min > max` (both set).
+`repeat:` on a `heading: null` entry is
+structurally impossible — `repeat:` is a key
+inside the `heading:` mapping, not a sibling.
+
+## Matching
+
+Entries match the document's heading sequence
+as a positional quantified regex. Each entry
+consumes a contiguous run, sized within its
+`repeat:` bounds. The walker is greedy by
+default and backtracks if a later literal entry
+would otherwise be starved.
+
+A heading whose text matches a later literal
+entry's `regex:` is claimed for that entry, not
+by an earlier wildcard slot. Mirrors plan 146's
+slot semantics.
+
+## Sibling fields
+
+Each entry can carry:
+
+- `sections:` — nested entries one heading
+  level deeper. Recursive.
+- `content:` — AST-node constraints inside the
+  section body. See plan 149.
+- `rules:` — per-scope rule-config overrides.
+- `closed:` — strictness shorthand. When
+  `true`, an unlisted heading inside this
+  scope produces a diagnostic. Default
+  `false`. Express positional flex by listing
+  a wildcard slot instead.
+- `sequential:` — described above.
+
+## Schema-level fields
+
+```yaml
+schema:
+  filename: "<glob>"
+  frontmatter:
+    <key>: <cue-expression>
+    "<key>?": <cue-expression>
+  sections: [...]
+  closed: <bool>
+```
+
+- `filename:` — a glob the document basename
+  must match. Top-level; no `require:` wrapper.
+- `frontmatter:` — per-key CUE constraints.
+  Trailing `?` on a key marks it optional.
+- `sections:` — the top-level section list.
+- `closed:` — strictness for the root scope.
+  Valid only on schemas that declare
+  `sections:`. A frontmatter-only kind that
+  sets `closed:` parse-errors.
+
+## `proto.md` file syntax
+
+Proto.md files remain a literal-template
+surface. Heading rows in the body act as the
+schema's `sections:` list.
+
+| Row syntax        | Equivalent inline entry                        |
+|-------------------|------------------------------------------------|
+| `## Literal text` | `heading: "Literal text"`                      |
+| `## ?`            | `heading: { regex: '.+' }`                     |
+| `## ...`          | `heading: { regex: '.+', repeat: { min: 0 } }` |
+| `## Step {n}`     | `heading: { regex: 'Step {n}' }`               |
+| `## {id}`         | `heading: { regex: '{id}' }`                   |
+
+Proto.md cannot express `repeat: { min, max }`
+or `sequential:`. Callers needing those switch
+to the inline-YAML form on a kind in
+`.mdsmith.yml`.
+
+The `<?require filename: "..."?>` directive
+in proto.md bodies is unchanged.
+
+## Migration from the old shape
+
+Hard cutover. Old-shape keys parse-error with
+a "removed; see plan 156" diagnostic naming
+the replacement.
+
+| Old shape                          | New shape                                            |
+|------------------------------------|------------------------------------------------------|
+| `aliases: [A, B]`                  | `regex: 'A\|B'`                                      |
+| `required: true`                   | default (omit `repeat:`)                             |
+| `required: false`                  | `repeat: { min: 0, max: 1 }`                         |
+| `heading: { unlisted: true }`      | `heading: { regex: '.+', repeat: { min: 0 } }`       |
+| Scope-level `repeats: true`        | `repeat: { min: 1 }`                                 |
+| Scope-level `min:` / `max:`        | `repeat: { min, max }`                               |
+| `require: { filename: "..." }`     | top-level `filename: "..."`                          |
+| `closed:` on frontmatter-only kind | dropped (no `sections:` → strictness has no meaning) |

--- a/plan/156_schema-entry-unification.md
+++ b/plan/156_schema-entry-unification.md
@@ -9,9 +9,12 @@ depends-on: [146]
 summary: >-
   Collapse the section-entry vocabulary to one
   discriminator (`heading:` — null, string, or
-  mapping). Match with `regex:`. Quantify with
-  `repeat: {min, max}`. `{n}` and `{field}`
-  survive as regex preprocessor tokens.
+  mapping). Match with `regex:`, a CUE
+  expression evaluated as a raw-interpolation
+  string. Two helpers in scope: `digits` (named
+  numeric capture) and `fmvar(name)`
+  (frontmatter variable, regex-escaped).
+  Quantify with `repeat: {min, max}`.
   `sequential:` survives as a sibling. Drop
   `aliases:`, `required:`, the
   `{unlisted: true}` mapping, scope-level
@@ -68,8 +71,13 @@ Three axes describe each entry:
 - **Discriminator** — `heading:` value
   (`null`, string, or mapping).
 - **Matcher** — `regex:` inside the mapping
-  form, CUE-compatible RE2 plus `{n}` and
-  `{field}` preprocessor tokens.
+  form. The YAML value is the body of a CUE
+  raw-interpolation string (`#"..."#`).
+  Backslashes pass through to RE2.
+  Interpolation uses `\#(expr)`. Two helpers
+  in scope: `digits` (named numeric capture
+  `(?P<n>[0-9]+)`) and `fmvar(name)`
+  (frontmatter lookup + regex-escape).
 - **Cardinality** — `repeat: { min, max }`
   inside the mapping form.
 

--- a/plan/156_schema-entry-unification.md
+++ b/plan/156_schema-entry-unification.md
@@ -1,0 +1,218 @@
+---
+id: 156
+title: >-
+  Section schema — unify entry shape under
+  `heading:` discriminator
+status: "🔲"
+model: opus
+depends-on: [146]
+summary: >-
+  Collapse the section-entry vocabulary to one
+  discriminator (`heading:` — null, string, or
+  mapping). Match with `regex:`. Quantify with
+  `repeat: {min, max}`. `{n}` and `{field}`
+  survive as regex preprocessor tokens.
+  `sequential:` survives as a sibling. Drop
+  `aliases:`, `required:`, the
+  `{unlisted: true}` mapping, scope-level
+  `repeats:`/`min:`/`max:`, and
+  `require.filename:` (which flattens to
+  top-level `filename:`). Hard cutover; rewrite
+  in-repo callers in the same PR.
+---
+# Section schema — unify entry shape under `heading:` discriminator
+
+## Goal
+
+Make a section schema read as a quantified
+regex over the document's heading sequence.
+One discriminator. One matcher. One
+cardinality field. The old shape had six
+sibling fields plus three forms of `heading:`.
+
+## Background
+
+Plan 146 shipped the engine. The vocabulary
+accreted around it: `required:`, `aliases:`,
+`{unlisted: true}`, `repeats:`, `sequential:`,
+scope-level `min:`/`max:`. Each addressed a
+real need but read as ad-hoc knobs.
+
+In-repo usage is small. Five inline kinds in
+`.mdsmith.yml` lines 303–371 use `heading:
+null` plus `heading: {unlisted: true}` plus
+`required:`. One fixture uses `aliases:`. The
+repeat-pattern keys are unused outside
+research files. Narrowing now beats narrowing
+later.
+
+## Non-Goals
+
+- Migration tool. Hand-rewrite in this PR.
+- Backwards-compat shim. Hard cutover.
+- `content:` redesign (plan 149).
+- Per-scope rule-override stacking.
+- Renaming the `<?require filename: ?>`
+  directive in proto.md bodies.
+
+## Design
+
+Full specification:
+[Section schema reference](../docs/reference/section-schema.md).
+The page is committed alongside this plan with
+an **upcoming** notice. The notice comes off
+when implementation lands.
+
+Three axes describe each entry:
+
+- **Discriminator** — `heading:` value
+  (`null`, string, or mapping).
+- **Matcher** — `regex:` inside the mapping
+  form, CUE-compatible RE2 plus `{n}` and
+  `{field}` preprocessor tokens.
+- **Cardinality** — `repeat: { min, max }`
+  inside the mapping form.
+
+Plus three migration-only changes:
+
+- `require.filename:` flattens to top-level
+  `filename:`.
+- Frontmatter-only kinds reject schema-level
+  `closed:`.
+- Every removed key
+  (`aliases:` / `required:` / `unlisted:` /
+  scope-level `repeats:` / `sequential:` /
+  `min:` / `max:` / `require:`) parse-errors
+  with a "removed; see plan 156" diagnostic
+  naming the replacement.
+
+Diagnostics follow the existing
+`parse_inline.go` style: path prefix,
+lowercase message, no trailing punctuation.
+Final wording refined in code review.
+
+### Migration surface
+
+Files rewritten as part of implementation:
+
+- `.mdsmith.yml` — 5 kinds, lines 303–371.
+- The runbook fixture under
+  `internal/rules/MDS020-required-structure/good/`
+  (uses `aliases:`).
+- `docs/guides/schemas.md` — rewrite to
+  describe only the new shape.
+- The MDS020 README — same.
+- `docs/reference/section-schema.md` —
+  remove the "upcoming" notice.
+- A "superseded" note on plan 146's
+  entry-shape section.
+
+## Tasks
+
+1. Update `Scope` in `internal/schema/schema.go`.
+   Drop `Aliases`, `Required`, `Repeats`,
+   `Sequential` (top-level), `Min`/`Max`,
+   `Wildcard`. Add a `Matcher` sub-struct
+   (`Regex`, `Repeat`, `Sequential`). Keep
+   `Preamble` as a derived flag.
+2. Rewrite the heading-mapping parser in
+   `internal/schema/parse_inline.go` to
+   accept `{ regex, repeat?, sequential? }`.
+   Reject every removed key by name with a
+   "removed; see plan 156" diagnostic naming
+   the replacement.
+3. In the same parser, flatten
+   `require.filename:` to top-level
+   `filename:`. Reject schema-level `closed:`
+   on kinds without `sections:`.
+4. Update `internal/schema/parse_file.go` so
+   `## ?` and `## ...` map to the new
+   `Matcher` (`regex: '.+'`, plus
+   `repeat: { min: 0 }` for `...`). Keep
+   `{n}` and `{field}` token expansion in
+   heading rows.
+5. Rewrite the validator in
+   `internal/schema/validate.go` to match
+   the heading sequence as a positional
+   quantified regex. Each `Matcher` consumes
+   between `repeat.min` and `repeat.max`
+   consecutive headings whose text matches
+   `regex:`. Diagnostics point at the
+   entry's source location.
+6. Update fixtures and tests under
+   `internal/schema/` and
+   `internal/rules/MDS020-required-structure/`.
+   Add one fixture per new parse-time
+   diagnostic.
+7. Rewrite the 5 inline kinds in
+   `.mdsmith.yml` and the affected fixture
+   to the new shape. Run `mdsmith check .`
+   and `mdsmith fix .`.
+8. Rewrite `docs/guides/schemas.md` and the
+   MDS020 README to describe only the new
+   shape. Every reference to `aliases:`,
+   `required:`, `unlisted:`, scope-level
+   `repeats:`/`sequential:`/`min:`/`max:`, and
+   `require:` is removed; one worked example
+   of the new shape replaces the old one.
+9. Remove the "upcoming" notice from
+   `docs/reference/section-schema.md`.
+   Run `mdsmith fix CLAUDE.md` so the catalog
+   line for the page survives any title /
+   summary edits.
+10. Add a "superseded" note to plan 146's
+    entry-shape section pointing at this plan
+    and the reference page.
+
+## Acceptance Criteria
+
+- [ ] A section entry uses exactly one of
+      three shapes: `heading: null`,
+      `heading: <string>`, or `heading: {
+      regex, repeat?, sequential? }`.
+- [ ] `repeat:` omitted → exactly one;
+      `repeat: { min: 0 }` → zero or more;
+      `repeat: { min: 0, max: 1 }` →
+      optional; bounded forms enforce the
+      bounds.
+- [ ] Regex matching is whole-string
+      anchored against rendered plain text
+      (fixture: `## **Overview**` matches
+      `regex: 'Overview'`).
+- [ ] `{n}` expands to a numeric capture;
+      `sequential: true` flags out-of-order
+      or gapped numbers.
+- [ ] `{field}` interpolates the document's
+      frontmatter value at validate-time.
+- [ ] `heading: null` outside index 0
+      parse-errors.
+- [ ] `heading:` mapping without `regex:`
+      parse-errors.
+- [ ] `repeat: {}`, `repeat: { max: 0 }`,
+      `min > max` each parse-error.
+- [ ] `sequential: true` without `{n}`
+      parse-errors.
+- [ ] Invalid regex parse-errors with the
+      RE2 message and field path.
+- [ ] Removed keys each parse-error with a
+      "removed; see plan 156" message
+      naming the replacement.
+- [ ] The 5 rewritten inline kinds and the
+      rewritten fixture emit the same MDS020
+      diagnostics they did before the
+      cutover (where the constraint is
+      preserved).
+- [ ] `docs/guides/schemas.md` and the
+      MDS020 README describe only the new
+      shape — `grep -E 'aliases:|required:|unlisted:|repeats:|^require:'`
+      against either file returns no matches
+      in prose.
+- [ ] `docs/reference/section-schema.md`
+      reads as a current spec — its
+      "upcoming" notice is removed and the
+      page links from `docs/guides/schemas.md`.
+- [ ] `mdsmith check .` reports no
+      diagnostics.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports
+      no issues.


### PR DESCRIPTION
## Summary

Introduces plan 156 and its reference documentation, which redesigns the section-schema vocabulary to unify entry shapes under a single `heading:` discriminator. This is a specification commit that establishes the design before implementation.

## Changes

- **plan/156_schema-entry-unification.md** — New plan document specifying the redesign:
  - Collapses section-entry vocabulary to three `heading:` forms: `null`, string, or mapping
  - Replaces six sibling fields (`aliases:`, `required:`, `unlisted:`, scope-level `repeats:`/`min:`/`max:`) with unified `repeat: {min, max}` cardinality
  - Introduces `regex:` as the sole matcher (with `{n}` and `{field}` preprocessor tokens)
  - Keeps `sequential:` as a sibling field for ordered numeric patterns
  - Flattens `require.filename:` to top-level `filename:`
  - Specifies hard cutover with parse-time diagnostics for removed keys
  - Lists 10 implementation tasks and acceptance criteria

- **docs/reference/section-schema.md** — New reference page documenting the unified schema:
  - "At a glance" example showing all three `heading:` forms
  - Three orthogonal axes: discriminator, matcher, cardinality
  - Detailed entry shapes with examples
  - Regex dialect (Go RE2), anchoring, and rendering behavior
  - `{n}` numeric placeholder and `{field}` frontmatter interpolation
  - `sequential:` ordering semantics
  - `repeat:` bounds and defaults table
  - Matching algorithm (greedy with backtracking for literals)
  - Sibling fields (`sections:`, `content:`, `rules:`, `closed:`)
  - Schema-level fields (`filename:`, `frontmatter:`, `sections:`, `closed:`)
  - Proto.md file syntax mapping
  - Migration table from old shape to new shape
  - Marked as "upcoming" status pending implementation

- **CLAUDE.md** — Updated catalog to include the new reference page

- **PLAN.md** — Updated plan index to include plan 156

## Implementation Status

This is a specification-only commit. The reference page carries an "upcoming" notice that will be removed when plan 156 is implemented. No parser, validator, or schema-handling code changes are included; those will follow in a separate implementation PR that also rewrites in-repo callers (5 inline kinds in `.mdsmith.yml` and one fixture).

https://claude.ai/code/session_017E5oirVXVq87CRz3cKgnCD