### PR TITLE
Implement schema composition across multiple kinds (plan 156)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -95,4 +95,5 @@ footer: |
 | 166 | 🔲     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                              |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
 | 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |
+| 169 | 🔲     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)         |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -83,7 +83,7 @@ footer: |
 | 153 | ✅     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
 | 154 | ✅     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
 | 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
-| 156 | 🔲     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                        |
+| 156 | ✅     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                        |
 | 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
 | 157 | ✅     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
 | 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                      |

--- a/docs/development/architecture/cross-system.md
+++ b/docs/development/architecture/cross-system.md
@@ -106,6 +106,26 @@ not have is a Liskov violation. Push
 the flag down to the binary, or drop it
 from the shim.
 
+## Schema composition across kinds
+
+When a file resolves to several kinds that each
+declare a `required-structure` schema, the
+schemas compose. Three rules apply:
+
+- Frontmatter conjoins. A key required by any
+  kind is required. Shared keys intersect with
+  CUE `&`.
+- Sections merge. Scopes with the same heading
+  text combine their child lists. Other scopes
+  append in input order.
+- The stricter `closed:` wins.
+
+Multiple kinds can layer schemas. For example,
+`directive-rule-readme` builds on top of
+`rule-readme`. See the
+[Schemas guide](../../guides/schemas.md) for a
+worked example.
+
 ## Versioning policy (post-1.0)
 
 Today mdsmith is at major 0; the rules

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -436,6 +436,101 @@ A project can mix sources across kinds — some kinds use
 inline schemas, others use `proto.md` — but a single
 kind must pick one.
 
+## Composition across kinds
+
+A file resolved by multiple kinds that each declare a
+`required-structure` schema gets the composition of all
+of them — not just the last one. The merge layer
+accumulates each kind's `schema:` or `inline-schema:`
+into a `schema-sources` list, and MDS020 loads every
+source and composes them at check time.
+
+The composition rules are:
+
+- **Frontmatter** keys union across schemas. A key
+  required by any input is required. Two schemas
+  constraining the same key get the intersection of
+  their CUE expressions (joined with `&`).
+- **Sections** merge by literal heading text. Scopes
+  that share the same heading combine their child
+  lists recursively. Scopes that differ — including
+  wildcard slots (`{unlisted: true}`), the preamble
+  (`null`), and the bare `?` wildcard — append in
+  input order.
+- **`closed:`** is OR-ed across inputs. Any scope that
+  was strict in any input is strict in the composed
+  scope.
+- **`require.filename`** picks the first non-empty
+  pattern. Conflicting patterns are a config error.
+
+### Worked example: directive-rule-readme + rule-readme
+
+The four directive READMEs in this repository
+(`MDS019-catalog`, `MDS021-include`, `MDS038-toc`,
+`MDS039-build`) resolve to both `rule-readme` and
+`directive-rule-readme`. The first kind contributes
+the common rule-README structure (`Config`,
+`Examples`, `Meta-Information`); the second only adds
+a required `Pattern` section.
+
+```yaml
+kinds:
+  rule-readme:
+    rules:
+      required-structure:
+        schema: internal/rules/proto.md
+  directive-rule-readme:
+    rules:
+      required-structure:
+        schema: internal/rules/directive-proto.md
+
+kind-assignment:
+  - glob: ["internal/rules/MDS*/README.md"]
+    kinds: [rule-readme]
+  - glob: ["internal/rules/MDS019-catalog/README.md", …]
+    kinds: [directive-rule-readme]
+```
+
+`directive-proto.md` declares only what's specific to
+directive rules:
+
+```markdown
+---
+nature: '"directive"'
+---
+# {id}: {name}
+
+## ...
+
+## Pattern
+
+### Without the directive
+### With the directive
+
+## ...
+```
+
+The composed schema requires the union of both
+sections lists. `rule-readme`'s `nature` is
+`"directive" | "generator" | "content" | "style" |
+"structure"`; `directive-rule-readme`'s narrower
+`"directive"` intersects to require exactly
+`"directive"` on every file resolving to both kinds.
+
+### Picking an input order
+
+The composed section list is the concatenation of each
+schema's sections (with same-heading scopes merged).
+Order matters for the "last required section" — if the
+later schema's required sections must appear before
+the earlier schema's required sections in the document,
+either reorder the kinds in `kind-assignment` or rewrite
+the document so the sections fall in composed order.
+The directive READMEs put `Pattern` after
+`Meta-Information` precisely so the composed ordering
+(`rule-readme` first, `directive-rule-readme` appended)
+matches the document layout.
+
 ## Diagnostics
 
 Schema diagnostics surface through

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -471,7 +471,9 @@ func TestValidateKinds_AcceptsValidPathPattern(t *testing.T) {
 // settings while injecting the synthetic `path-patterns` entry on
 // top of them. Without this, a kind that both disables a rule and
 // declares a `path-pattern:` would have its `body.Rules` ignored in
-// `kinds resolve` / `--explain` output.
+// `kinds resolve` / `--explain` output. The `schema:` setting is
+// translated to a `schema-sources` entry so the provenance chain
+// reflects the deep-merged form rather than the raw user input.
 func TestKindLayerRules_MergesPathPatternWithExistingRules(t *testing.T) {
 	body := KindBody{
 		PathPattern: "plan/*.md",
@@ -486,7 +488,11 @@ func TestKindLayerRules_MergesPathPatternWithExistingRules(t *testing.T) {
 	assert.False(t, out["line-length"].Enabled)
 	rs := out["required-structure"]
 	assert.True(t, rs.Enabled)
-	assert.Equal(t, "plan/proto.md", rs.Settings["schema"],
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must accumulate body.Rules schema source")
+	require.Len(t, sources, 1)
+	assert.Equal(t, "plan/proto.md",
+		sources[0].(map[string]any)["file"],
 		"existing required-structure settings must be preserved")
 	list := rs.Settings["path-patterns"].([]any)
 	require.Len(t, list, 1)
@@ -497,8 +503,7 @@ func TestKindLayerRules_MergesPathPatternWithExistingRules(t *testing.T) {
 // that a kind declaring both `schema:` (an inline schema map) and
 // `path-pattern:` lands BOTH synthetic settings in the provenance
 // layer chain — without this, `kinds resolve` / `--explain` would
-// drop the inline-schema leaf even though effectiveRules applies
-// it.
+// drop the schema source leaf even though effectiveRules applies it.
 func TestKindLayerRules_MirrorsInlineSchemaAndPathPattern(t *testing.T) {
 	body := KindBody{
 		PathPattern: "plan/*.md",
@@ -512,15 +517,98 @@ func TestKindLayerRules_MirrorsInlineSchemaAndPathPattern(t *testing.T) {
 	rs := out["required-structure"]
 	assert.True(t, rs.Enabled)
 
-	schema, ok := rs.Settings["inline-schema"].(map[string]any)
-	require.True(t, ok, "inline-schema must be injected as a map")
-	assert.Contains(t, schema, "sections")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must be injected as a list")
+	require.Len(t, sources, 1)
+	entry := sources[0].(map[string]any)
+	inlineMap, ok := entry["inline"].(map[string]any)
+	require.True(t, ok, "inline entry must wrap the schema map")
+	assert.Contains(t, inlineMap, "sections")
 
 	list, ok := rs.Settings["path-patterns"].([]any)
 	require.True(t, ok)
 	require.Len(t, list, 1)
 	assert.Equal(t, "plan/*.md",
 		list[0].(map[string]any)["pattern"])
+}
+
+// TestKindLayerRules_TranslatesBodyRulesSchema covers the provenance
+// translation of body.Rules' legacy `schema:` setting when the kind
+// has neither `KindBody.Schema` (inline map) nor `path-pattern:`.
+// The provenance chain must surface `schema-sources` for that case
+// too, so explainers don't show a stale `schema:` key.
+func TestKindLayerRules_TranslatesBodyRulesSchema(t *testing.T) {
+	body := KindBody{
+		Rules: map[string]RuleCfg{
+			"required-structure": {
+				Enabled: true,
+				Settings: map[string]any{
+					"schema": "plan/proto.md",
+				},
+			},
+		},
+	}
+	out := kindLayerRules("plan", body)
+	rs := out["required-structure"]
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	assert.Equal(t, "plan/proto.md", sources[0].(map[string]any)["file"])
+	assert.NotContains(t, rs.Settings, "schema",
+		"legacy schema key should be stripped after translation")
+}
+
+// TestKindLayerRules_NoTranslationNeededReturnsSameMap exercises the
+// fast path: a body whose required-structure entry has no schema
+// keys should not allocate a new rules map.
+func TestKindLayerRules_NoTranslationNeededReturnsSameMap(t *testing.T) {
+	body := KindBody{
+		Rules: map[string]RuleCfg{
+			"required-structure": {
+				Enabled: true,
+				Settings: map[string]any{
+					"placeholders": []any{"cue-frontmatter"},
+				},
+			},
+		},
+	}
+	out := kindLayerRules("plan", body)
+	// The function returns body.Rules directly in this path because
+	// neither body.Schema nor body.PathPattern is set, and the
+	// required-structure entry has no schema source to translate.
+	assert.Equal(t, body.Rules["required-structure"].Settings["placeholders"],
+		out["required-structure"].Settings["placeholders"])
+	assert.NotContains(t, out["required-structure"].Settings, "schema-sources")
+}
+
+// TestKindLayerRules_BodyRulesInlineSchemaTranslated covers the
+// `inline-schema:` translation in body.Rules (parallel to the
+// file-path translation above).
+func TestKindLayerRules_BodyRulesInlineSchemaTranslated(t *testing.T) {
+	body := KindBody{
+		Rules: map[string]RuleCfg{
+			"required-structure": {
+				Enabled: true,
+				Settings: map[string]any{
+					"inline-schema": map[string]any{
+						"sections": []any{
+							map[string]any{"heading": "Goal"},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := kindLayerRules("plan", body)
+	rs := out["required-structure"]
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	inlineMap, ok := sources[0].(map[string]any)["inline"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, inlineMap, "sections")
+	assert.NotContains(t, rs.Settings, "inline-schema",
+		"legacy inline-schema key should be stripped after translation")
 }
 
 // --- helpers ---

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/jeduden/mdsmith/internal/rule"
+
 // Merge merges a loaded config on top of defaults. The loaded config's rules
 // override the defaults; any rule not mentioned in loaded keeps its default
 // value. Ignore and Overrides come from the loaded config only.
@@ -338,13 +340,21 @@ func effectiveRules(cfg *Config, filePath string, kinds []string) map[string]Rul
 	// the split, the default's `Enabled: false` would land on top of
 	// the convention's `Enabled: true` and silently disable the rule
 	// the user just asked the convention to enable.
+	//
+	// Some rules rewrite a layer's settings before deep-merge by
+	// implementing rule.SettingsTranslator (required-structure
+	// collapses `schema:` / `inline-schema:` into an append-mode
+	// `schema-sources` list so multiple kinds compose, plan 156).
+	// translateLayerSettings consults the rule registry, so this
+	// merge code carries no rule-name special cases.
 	result := make(map[string]RuleCfg, len(cfg.Rules))
 	for k, v := range cfg.Rules {
 		if !cfg.ExplicitRules[k] {
-			result[k] = copyRuleCfg(v)
+			result[k] = copyRuleCfg(translateLayerSettings(k, v))
 		}
 	}
 	apply := func(name string, layer RuleCfg) {
+		layer = translateLayerSettings(name, layer)
 		if existing, ok := result[name]; ok {
 			result[name] = mergeRuleCfg(name, existing, layer)
 			return
@@ -364,15 +374,8 @@ func effectiveRules(cfg *Config, filePath string, kinds []string) map[string]Rul
 		if !ok {
 			continue
 		}
-		// When a kind sets either schema source, treat it as a
-		// fresh schema declaration: clear any prior schema state
-		// on required-structure so the last source wins
-		// unambiguously across mixed kinds.
-		if kindDeclaresSchema(body) {
-			clearSchemaState(result)
-		}
 		if len(body.Schema) > 0 {
-			applyInlineSchema(result, body.Schema)
+			applyInlineSchemaSource(result, body.Schema)
 		}
 		if body.PathPattern != "" {
 			applyPathPattern(result, kindName, body.PathPattern)
@@ -383,9 +386,6 @@ func effectiveRules(cfg *Config, filePath string, kinds []string) map[string]Rul
 	}
 	for _, o := range cfg.Overrides {
 		if matchesAny(o.Patterns(), filePath) {
-			if overrideDeclaresSchema(o) {
-				clearSchemaState(result)
-			}
 			for k, v := range o.Rules {
 				apply(k, v)
 			}
@@ -394,61 +394,32 @@ func effectiveRules(cfg *Config, filePath string, kinds []string) map[string]Rul
 	return result
 }
 
-// kindDeclaresSchema reports whether a kind body declares a schema
-// source — either inline (KindBody.Schema) or via the
-// rules.required-structure.{schema,inline-schema} settings.
-func kindDeclaresSchema(body KindBody) bool {
-	if len(body.Schema) > 0 {
-		return true
+// translateLayerSettings applies a rule's rule.SettingsTranslator
+// (when it implements one) to a single config layer's settings
+// before deep-merge. Rules without the interface — or rules not
+// registered in this binary — pass through unchanged, matching the
+// existing rule.ByName-driven ListMerger lookup in deepmerge.go.
+//
+// The merge code calls this for every layer keyed only by rule
+// name, so it carries no rule-specific behaviour itself: a rule
+// that needs its settings rewritten (e.g. required-structure
+// collapsing `schema:`/`inline-schema:` into `schema-sources`)
+// declares that by implementing the interface.
+func translateLayerSettings(ruleName string, rc RuleCfg) RuleCfg {
+	if rc.Settings == nil {
+		return rc
 	}
-	return rulesDeclareSchema(body.Rules)
-}
-
-// overrideDeclaresSchema reports whether a glob override sets a
-// schema source on required-structure. Both schema sources count —
-// without this, an inline schema installed by an override would
-// leave a prior file-schema path intact and "last source wins"
-// could yield ambiguous configs.
-func overrideDeclaresSchema(o Override) bool {
-	return rulesDeclareSchema(o.Rules)
-}
-
-// rulesDeclareSchema reports whether a per-layer rules map sets
-// either schema source on required-structure. A bool-only entry
-// (`required-structure: true/false`) leaves Settings nil; bail
-// before the lookups to keep the contract explicit.
-func rulesDeclareSchema(rules map[string]RuleCfg) bool {
-	rs, ok := rules["required-structure"]
+	r := rule.ByName(ruleName)
+	if r == nil {
+		return rc
+	}
+	t, ok := r.(rule.SettingsTranslator)
 	if !ok {
-		return false
+		return rc
 	}
-	if rs.Settings == nil {
-		return false
-	}
-	if path, ok := rs.Settings["schema"].(string); ok && path != "" {
-		return true
-	}
-	if m, ok := rs.Settings["inline-schema"].(map[string]any); ok && len(m) > 0 {
-		return true
-	}
-	return false
-}
-
-// clearSchemaState removes any prior schema source from the
-// accumulated effective config for required-structure. Both the
-// inline-schema map and the file-schema path are cleared so the
-// incoming layer can install its own source unambiguously.
-func clearSchemaState(result map[string]RuleCfg) {
-	rs, ok := result["required-structure"]
-	if !ok {
-		return
-	}
-	if rs.Settings == nil {
-		return
-	}
-	delete(rs.Settings, "schema")
-	delete(rs.Settings, "inline-schema")
-	result["required-structure"] = rs
+	out := rc
+	out.Settings = t.TranslateLayerSettings(rc.Settings)
+	return out
 }
 
 // applyPathPattern appends a {kind, pattern} entry to the
@@ -472,10 +443,10 @@ func applyPathPattern(result map[string]RuleCfg, kindName, pattern string) {
 	result["required-structure"] = rs
 }
 
-// applyInlineSchema installs an inline schema (a YAML map) as the
-// `inline-schema` setting on required-structure, creating the rule
-// entry if missing.
-func applyInlineSchema(result map[string]RuleCfg, schema map[string]any) {
+// applyInlineSchemaSource appends a KindBody.Schema (inline schema
+// map) as a `schema-sources` entry. Multiple kinds with inline
+// schemas thus accumulate rather than overwrite.
+func applyInlineSchemaSource(result map[string]RuleCfg, schema map[string]any) {
 	rs, ok := result["required-structure"]
 	if !ok {
 		rs = RuleCfg{Enabled: true}
@@ -483,7 +454,9 @@ func applyInlineSchema(result map[string]RuleCfg, schema map[string]any) {
 	if rs.Settings == nil {
 		rs.Settings = map[string]any{}
 	}
-	rs.Settings["inline-schema"] = cloneSettings(schema)
+	entry := map[string]any{"inline": cloneSettings(schema)}
+	existing, _ := rs.Settings["schema-sources"].([]any)
+	rs.Settings["schema-sources"] = append(existing, entry)
 	rs.Enabled = true
 	result["required-structure"] = rs
 }

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -155,7 +155,10 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 	defaults, user := splitRulesByExplicit(cfg)
 
 	if len(defaults) > 0 {
-		layers = append(layers, layerInfo{Source: layerSourceDefault, Rules: defaults})
+		layers = append(layers, layerInfo{
+			Source: layerSourceDefault,
+			Rules:  translateLayerRules(defaults),
+		})
 	}
 	if cfg.Convention != "" && len(cfg.ConventionPreset) > 0 {
 		source := "convention." + cfg.Convention
@@ -164,11 +167,14 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 		}
 		layers = append(layers, layerInfo{
 			Source: source,
-			Rules:  cfg.ConventionPreset,
+			Rules:  translateLayerRules(cfg.ConventionPreset),
 		})
 	}
 	if len(user) > 0 {
-		layers = append(layers, layerInfo{Source: layerSourceUser, Rules: user})
+		layers = append(layers, layerInfo{
+			Source: layerSourceUser,
+			Rules:  translateLayerRules(user),
+		})
 	}
 	for _, k := range kinds {
 		body, ok := cfg.Kinds[k.Name]
@@ -184,7 +190,7 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 		if matchesAny(o.Patterns(), filePath) {
 			layers = append(layers, layerInfo{
 				Source: fmt.Sprintf("overrides[%d]", i),
-				Rules:  o.Rules,
+				Rules:  translateLayerRules(o.Rules),
 			})
 		}
 	}
@@ -197,18 +203,19 @@ func buildLayers(cfg *Config, filePath string, kinds []ResolvedKind) []layerInfo
 // required-structure outside body.Rules via two top-level fields
 // on KindBody — `schema:` (an inline schema map) and
 // `path-pattern:` — and the engine's merge layer translates each
-// into a setting on the rule (`inline-schema` and `path-patterns`
-// respectively). Without mirroring those injections here,
-// `mdsmith kinds resolve` and `--explain` output drop the
-// winning source for either synthetic setting and diverge from
-// the rule config the engine actually applied.
+// into a setting on the rule (`schema-sources` and `path-patterns`
+// respectively). The body.Rules side also gets translated so user-
+// written `schema:` / `inline-schema:` keys land in
+// `schema-sources` ahead of the deep-merge. Without these mirrored
+// translations, `mdsmith kinds resolve` and `--explain` output
+// diverges from the rule config the engine actually applied.
 func kindLayerRules(kindName string, body KindBody) map[string]RuleCfg {
 	if len(body.Schema) == 0 && body.PathPattern == "" {
-		return body.Rules
+		return translateLayerRules(body.Rules)
 	}
 	out := make(map[string]RuleCfg, len(body.Rules)+1)
 	for k, v := range body.Rules {
-		out[k] = v
+		out[k] = translateLayerSettings(k, v)
 	}
 	rs := out["required-structure"]
 	rs.Enabled = true
@@ -218,7 +225,9 @@ func kindLayerRules(kindName string, body KindBody) map[string]RuleCfg {
 		rs.Settings = cloneSettings(rs.Settings)
 	}
 	if len(body.Schema) > 0 {
-		rs.Settings["inline-schema"] = cloneSettings(body.Schema)
+		entry := map[string]any{"inline": cloneSettings(body.Schema)}
+		existing, _ := rs.Settings["schema-sources"].([]any)
+		rs.Settings["schema-sources"] = append(existing, entry)
 	}
 	if body.PathPattern != "" {
 		entry := map[string]any{"kind": kindName, "pattern": body.PathPattern}
@@ -226,6 +235,20 @@ func kindLayerRules(kindName string, body KindBody) map[string]RuleCfg {
 		rs.Settings["path-patterns"] = append(existing, entry)
 	}
 	out["required-structure"] = rs
+	return out
+}
+
+// translateLayerRules applies each rule's rule.SettingsTranslator
+// (via translateLayerSettings) across a whole rules map so the
+// provenance layer chain shows the same setting keys the engine
+// merges on. Rules without a translator pass through unchanged.
+// Provenance is not a hot path, so this always returns a fresh
+// map rather than threading an allocation-free fast path.
+func translateLayerRules(rules map[string]RuleCfg) map[string]RuleCfg {
+	out := make(map[string]RuleCfg, len(rules))
+	for k, v := range rules {
+		out[k] = translateLayerSettings(k, v)
+	}
 	return out
 }
 

--- a/internal/config/schema_kinds_test.go
+++ b/internal/config/schema_kinds_test.go
@@ -105,10 +105,9 @@ kinds:
 
 // TestEffectiveInjectsInlineSchema verifies that a kind's inline
 // schema reaches required-structure via the effective rule config:
-// the merge layer translates KindBody.Schema into
-// rules.required-structure.Settings["inline-schema"] so the rule
-// receives it through ApplySettings without any rule-specific wiring
-// at the call site.
+// the merge layer translates KindBody.Schema into a `schema-sources`
+// list entry so the rule receives it through ApplySettings without
+// any rule-specific wiring at the call site.
 func TestEffectiveInjectsInlineSchema(t *testing.T) {
 	inline := map[string]any{
 		"sections": []any{
@@ -130,17 +129,21 @@ func TestEffectiveInjectsInlineSchema(t *testing.T) {
 	rs, ok := effective["required-structure"]
 	require.True(t, ok, "required-structure should be in effective config")
 	require.NotNil(t, rs.Settings)
-	got, ok := rs.Settings["inline-schema"].(map[string]any)
-	require.True(t, ok, "inline-schema must be injected as a map")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must be a list")
+	require.Len(t, sources, 1)
+	entry, ok := sources[0].(map[string]any)
+	require.True(t, ok)
+	got, ok := entry["inline"].(map[string]any)
+	require.True(t, ok, "inline-schema entry must wrap the kind's inline map")
 	require.Contains(t, got, "sections")
 }
 
-// TestEffectiveClearsPriorSchemaWhenNewSourceArrives covers the
-// "last source wins" rule the merge layer enforces. When kind A
-// supplies a file path and kind B supplies an inline schema, the
-// resulting required-structure has only the inline source — the
-// file path is cleared.
-func TestEffectiveClearsPriorSchemaWhenNewSourceArrives(t *testing.T) {
+// TestEffectiveComposesSchemaSourcesAcrossKinds covers plan 156: when
+// kind A supplies a file-path schema and kind B supplies an inline
+// schema, both end up in the composed schema-sources list rather
+// than the last one winning.
+func TestEffectiveComposesSchemaSourcesAcrossKinds(t *testing.T) {
 	cfg := &Config{
 		Rules: map[string]RuleCfg{
 			"required-structure": {Enabled: true},
@@ -161,10 +164,17 @@ func TestEffectiveClearsPriorSchemaWhenNewSourceArrives(t *testing.T) {
 	}
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must accumulate across kinds")
+	require.Len(t, sources, 2, "both kinds should contribute a source")
+	first := sources[0].(map[string]any)
+	assert.Equal(t, "schemas/a.md", first["file"])
+	second := sources[1].(map[string]any)
+	assert.Contains(t, second, "inline")
 	assert.NotContains(t, rs.Settings, "schema",
-		"prior file-source must be cleared when a later kind installs inline")
-	assert.Contains(t, rs.Settings, "inline-schema",
-		"later inline source should be present")
+		"legacy schema key must be stripped after translation")
+	assert.NotContains(t, rs.Settings, "inline-schema",
+		"legacy inline-schema key must be stripped after translation")
 }
 
 // TestValidateKindAllowsInlineWithoutFileSchemaSetting covers
@@ -242,11 +252,136 @@ func TestEmptyInlineSchemaDoesNotTriggerMutex(t *testing.T) {
 		"empty inline schema map must not count as a declared source")
 }
 
-// TestEmptyInlineSchemaDoesNotClearPriorState ensures the merge
-// layer doesn't wipe a file-schema path when a later kind has
-// `schema: {}`. An empty map is "no source", so prior state
-// survives unchanged.
-func TestEmptyInlineSchemaDoesNotClearPriorState(t *testing.T) {
+// TestEffectiveKinds_NilCfg covers the cfg == nil fast-path:
+// without a Config the function returns the deduplicated fmKinds
+// list straight through.
+func TestEffectiveKinds_NilCfg(t *testing.T) {
+	got := EffectiveKinds(nil, "doc.md", []string{"a", "b", "a"}, nil)
+	assert.Equal(t, []string{"a", "b"}, got,
+		"nil cfg path must dedupe fmKinds in input order")
+}
+
+// TestEffectiveKinds_CfgDelegatesToResolver verifies the non-nil
+// cfg branch forwards to resolveEffectiveKinds.
+func TestEffectiveKinds_CfgDelegatesToResolver(t *testing.T) {
+	cfg := &Config{
+		Kinds: map[string]KindBody{"plan": {}},
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
+		},
+	}
+	got := EffectiveKinds(cfg, "plan/foo.md", nil, nil)
+	assert.Equal(t, []string{"plan"}, got)
+}
+
+// TestTranslateLayerSettings_NonStringSchemaKey covers a layer
+// whose `schema:` is a non-string value: the rule's translator
+// still strips the legacy key but adds no schema-sources entry.
+func TestTranslateLayerSettings_NonStringSchemaKey(t *testing.T) {
+	out := translateLayerSettings("required-structure", RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"schema": 42},
+	})
+	assert.NotContains(t, out.Settings, "schema")
+	assert.NotContains(t, out.Settings, "schema-sources")
+}
+
+// TestTranslateLayerSettings_NonMapInlineKey covers a non-map
+// `inline-schema` value: treated as empty, key stripped, no
+// source added.
+func TestTranslateLayerSettings_NonMapInlineKey(t *testing.T) {
+	out := translateLayerSettings("required-structure", RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"inline-schema": "not-a-map"},
+	})
+	assert.NotContains(t, out.Settings, "inline-schema")
+	assert.NotContains(t, out.Settings, "schema-sources")
+}
+
+// TestTranslateLayerSettings_UnknownRulePassthrough covers the
+// rule-not-registered / no-translator branches: a rule with no
+// SettingsTranslator (or an unknown name) returns its settings
+// untouched.
+func TestTranslateLayerSettings_UnknownRulePassthrough(t *testing.T) {
+	in := RuleCfg{Enabled: true, Settings: map[string]any{"schema": "x.md"}}
+	out := translateLayerSettings("definitely-not-a-rule", in)
+	assert.Equal(t, "x.md", out.Settings["schema"],
+		"unknown rule must not have its settings rewritten")
+}
+
+// TestTranslateLayerSettings_NilSettingsPassthrough covers the
+// rc.Settings == nil early return.
+func TestTranslateLayerSettings_NilSettingsPassthrough(t *testing.T) {
+	out := translateLayerSettings("required-structure",
+		RuleCfg{Enabled: true})
+	assert.Nil(t, out.Settings)
+}
+
+// TestKindLayerRules_InlineSchemaWithoutPathPattern covers the
+// `body.PathPattern != ""` false branch in kindLayerRules: when
+// a kind body has an inline Schema map but no path-pattern, the
+// path-patterns inject is skipped while the schema source still
+// lands in schema-sources.
+func TestKindLayerRules_InlineSchemaWithoutPathPattern(t *testing.T) {
+	body := KindBody{
+		Schema: map[string]any{
+			"sections": []any{map[string]any{"heading": "X"}},
+		},
+		// PathPattern intentionally empty.
+	}
+	out := kindLayerRules("k", body)
+	rs := out["required-structure"]
+	assert.True(t, rs.Enabled)
+	assert.NotContains(t, rs.Settings, "path-patterns",
+		"empty PathPattern must not inject a path-patterns entry")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	assert.Contains(t, sources[0].(map[string]any), "inline")
+}
+
+// TestTranslateLayerSettings_StripsLegacyKeyWithoutAddingSource
+// covers the empty-value path: a layer with `schema: ""` (the
+// rule's DefaultSettings placeholder) is stripped of the legacy
+// key without contributing a schema-sources entry, and unrelated
+// settings survive.
+func TestTranslateLayerSettings_StripsLegacyKeyWithoutAddingSource(t *testing.T) {
+	out := translateLayerSettings("required-structure", RuleCfg{
+		Enabled: true,
+		Settings: map[string]any{
+			"schema":       "",
+			"placeholders": []string{"cue-frontmatter"},
+		},
+	})
+	assert.NotContains(t, out.Settings, "schema",
+		"legacy schema key must be stripped even when value is empty")
+	assert.NotContains(t, out.Settings, "schema-sources",
+		"empty schema value must NOT add a schema-sources entry")
+	assert.Contains(t, out.Settings, "placeholders",
+		"unrelated settings must survive translation")
+}
+
+// TestTranslateLayerSettings_BothEmptyValuesStripped covers a
+// layer carrying both legacy keys with empty values: both keys
+// are stripped, no source is added.
+func TestTranslateLayerSettings_BothEmptyValuesStripped(t *testing.T) {
+	out := translateLayerSettings("required-structure", RuleCfg{
+		Enabled: true,
+		Settings: map[string]any{
+			"schema":        "",
+			"inline-schema": map[string]any{},
+		},
+	})
+	assert.NotContains(t, out.Settings, "schema")
+	assert.NotContains(t, out.Settings, "inline-schema")
+	assert.NotContains(t, out.Settings, "schema-sources")
+}
+
+// TestEmptyInlineSchemaIsNoOp ensures the merge layer doesn't add a
+// source entry when a kind has `schema: {}`. An empty map is "no
+// source", so the composed schema-sources list contains only the
+// prior kind's file source.
+func TestEmptyInlineSchemaIsNoOp(t *testing.T) {
 	cfg := &Config{
 		Rules: map[string]RuleCfg{
 			"required-structure": {Enabled: true},
@@ -266,10 +401,11 @@ func TestEmptyInlineSchemaDoesNotClearPriorState(t *testing.T) {
 	}
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
-	assert.Equal(t, "schemas/a.md", rs.Settings["schema"],
-		"empty schema map must not clear prior file-source")
-	assert.NotContains(t, rs.Settings, "inline-schema",
-		"empty schema map must not install an inline-schema entry")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1, "empty schema map must not add a source entry")
+	first := sources[0].(map[string]any)
+	assert.Equal(t, "schemas/a.md", first["file"])
 }
 
 // TestInlineSchemaMarksRequiredStructureExplicit regresses a
@@ -326,9 +462,10 @@ func TestBoolOnlyRequiredStructureRuleCfg(t *testing.T) {
 		"bool-only kind entry must still resolve")
 }
 
-func TestClearSchemaState_NoRequiredStructureEntry(t *testing.T) {
-	// clearSchemaState should be a no-op when result has no
-	// required-structure entry. Cover the early-return branch.
+func TestEffectiveInlineSchemaInjectsSourceEntryWithoutPriorRule(t *testing.T) {
+	// A kind with an inline schema reaches the effective config even
+	// when no required-structure rule entry exists yet — the merge
+	// layer creates the rule entry and installs the source.
 	cfg := &Config{
 		Rules: map[string]RuleCfg{"line-length": {Enabled: true}},
 		Kinds: map[string]KindBody{
@@ -343,12 +480,17 @@ func TestClearSchemaState_NoRequiredStructureEntry(t *testing.T) {
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs, ok := effective["required-structure"]
 	require.True(t, ok)
-	assert.Contains(t, rs.Settings, "inline-schema")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	entry := sources[0].(map[string]any)
+	assert.Contains(t, entry, "inline")
 }
 
-func TestClearSchemaState_NilSettings(t *testing.T) {
-	// clearSchemaState with required-structure present but Settings
-	// nil — early return on settings-nil branch.
+func TestEffectiveInlineSchemaSourceSurvivesNilSettings(t *testing.T) {
+	// required-structure may be present with nil Settings before the
+	// kind runs (bool-only enable). Installing the kind's inline
+	// source must allocate Settings rather than panicking.
 	cfg := &Config{
 		Rules: map[string]RuleCfg{
 			"required-structure": {Enabled: true},
@@ -365,13 +507,15 @@ func TestClearSchemaState_NilSettings(t *testing.T) {
 	}
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
-	assert.Contains(t, rs.Settings, "inline-schema")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1)
 }
 
-func TestKindDeclaresSchemaRecognisesInlineSchemaSetting(t *testing.T) {
-	// A kind that supplies `inline-schema` via the rules map (not
-	// via KindBody.Schema) still counts as a schema source so the
-	// merge clears prior state.
+func TestEffectiveComposesInlineSchemaFromRulesWithBaseFile(t *testing.T) {
+	// A kind that supplies `inline-schema` via the rules map composes
+	// with a top-level `schema:` set on the base required-structure
+	// rule. Both sources end up in schema-sources.
 	cfg := &Config{
 		Rules: map[string]RuleCfg{
 			"required-structure": {Enabled: true, Settings: map[string]any{
@@ -396,16 +540,18 @@ func TestKindDeclaresSchemaRecognisesInlineSchemaSetting(t *testing.T) {
 	}
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
-	assert.NotContains(t, rs.Settings, "schema",
-		"a kind installing inline-schema via rules should clear the file path")
-	assert.Contains(t, rs.Settings, "inline-schema")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must accumulate base + kind sources")
+	require.Len(t, sources, 2)
+	assert.Equal(t, "schemas/base.md", sources[0].(map[string]any)["file"])
+	assert.Contains(t, sources[1].(map[string]any), "inline")
 }
 
-// TestEffectiveClearsPriorSchemaForOverrideInlineSchema covers the
-// path where an override (not a kind) installs an inline-schema:
-// the helper rulesDeclareSchema must recognise inline-schema as a
-// source so the prior file-schema path gets cleared.
-func TestEffectiveClearsPriorSchemaForOverrideInlineSchema(t *testing.T) {
+// TestEffectiveComposesOverrideInlineWithBaseFile covers the path
+// where an override (not a kind) installs an inline-schema: the
+// override and the base file source compose into a two-entry list
+// rather than the override clearing the base.
+func TestEffectiveComposesOverrideInlineWithBaseFile(t *testing.T) {
 	cfg := &Config{
 		Rules: map[string]RuleCfg{
 			"required-structure": {Enabled: true, Settings: map[string]any{
@@ -425,14 +571,17 @@ func TestEffectiveClearsPriorSchemaForOverrideInlineSchema(t *testing.T) {
 	}
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
-	assert.NotContains(t, rs.Settings, "schema",
-		"override installing inline-schema should clear prior file source")
-	assert.Contains(t, rs.Settings, "inline-schema")
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must compose base + override")
+	require.Len(t, sources, 2)
+	assert.Equal(t, "schemas/base.md", sources[0].(map[string]any)["file"])
+	assert.Contains(t, sources[1].(map[string]any), "inline")
 }
 
-// TestEffectiveClearsInlineWhenFileSourceArrives is the symmetric
-// case: inline first, file second. The later file source wins.
-func TestEffectiveClearsInlineWhenFileSourceArrives(t *testing.T) {
+// TestEffectiveComposesInlineThenFileSources is the symmetric case
+// to TestEffectiveComposesSchemaSourcesAcrossKinds: kind A has the
+// inline schema and kind B the file. Both compose, in declared order.
+func TestEffectiveComposesInlineThenFileSources(t *testing.T) {
 	cfg := &Config{
 		Rules: map[string]RuleCfg{
 			"required-structure": {Enabled: true},
@@ -453,7 +602,9 @@ func TestEffectiveClearsInlineWhenFileSourceArrives(t *testing.T) {
 	}
 	effective := Effective(cfg, "foo.md", nil, nil)
 	rs := effective["required-structure"]
-	assert.NotContains(t, rs.Settings, "inline-schema",
-		"prior inline source must be cleared when a later kind installs file path")
-	assert.Equal(t, "schemas/b.md", rs.Settings["schema"])
+	sources, ok := rs.Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 2)
+	assert.Contains(t, sources[0].(map[string]any), "inline")
+	assert.Equal(t, "schemas/b.md", sources[1].(map[string]any)["file"])
 }

--- a/internal/config/schema_kinds_test.go
+++ b/internal/config/schema_kinds_test.go
@@ -274,6 +274,54 @@ func TestEffectiveKinds_CfgDelegatesToResolver(t *testing.T) {
 	assert.Equal(t, []string{"plan"}, got)
 }
 
+// TestEffectiveKinds_AllBranches pins every branch of the public
+// helper with direct cases so its coverage no longer depends on
+// indirect call sites (the recurring codecov/changes signal).
+func TestEffectiveKinds_AllBranches(t *testing.T) {
+	t.Run("nil cfg, empty fmKinds -> empty", func(t *testing.T) {
+		got := EffectiveKinds(nil, "doc.md", nil, nil)
+		assert.Empty(t, got)
+	})
+	t.Run("nil cfg, no duplicates -> order preserved", func(t *testing.T) {
+		got := EffectiveKinds(nil, "doc.md", []string{"a", "b", "c"}, nil)
+		assert.Equal(t, []string{"a", "b", "c"}, got)
+	})
+	t.Run("nil cfg, duplicates -> deduped first-wins", func(t *testing.T) {
+		got := EffectiveKinds(nil, "doc.md",
+			[]string{"a", "b", "a", "c", "b"}, nil)
+		assert.Equal(t, []string{"a", "b", "c"}, got,
+			"seen-true branch must skip later duplicates")
+	})
+	t.Run("non-nil cfg delegates and merges fm + assignment", func(t *testing.T) {
+		cfg := &Config{
+			Kinds: map[string]KindBody{"plan": {}, "proto": {}},
+			KindAssignment: []KindAssignmentEntry{
+				{Glob: []string{"plan/*.md"}, Kinds: []string{"plan"}},
+			},
+		}
+		got := EffectiveKinds(cfg, "plan/foo.md",
+			[]string{"proto"}, nil)
+		// front-matter kinds first, then kind-assignment matches.
+		assert.Equal(t, []string{"proto", "plan"}, got)
+	})
+	t.Run("non-nil cfg, fields-present selector via fmFields", func(t *testing.T) {
+		cfg := &Config{
+			Kinds: map[string]KindBody{"rfc": {}},
+			KindAssignment: []KindAssignmentEntry{
+				{Glob: []string{"**/*.md"}, FieldsPresent: []string{"rfc-id"},
+					Kinds: []string{"rfc"}},
+			},
+		}
+		with := EffectiveKinds(cfg, "x.md", nil,
+			map[string]any{"rfc-id": "RFC-1"})
+		assert.Equal(t, []string{"rfc"}, with,
+			"fmFields must feed the fields-present selector")
+		without := EffectiveKinds(cfg, "x.md", nil, nil)
+		assert.Empty(t, without,
+			"no fmFields -> fields-present entry must not match")
+	})
+}
+
 // TestTranslateLayerSettings_NonStringSchemaKey covers a layer
 // whose `schema:` is a non-string value: the rule's translator
 // still strips the legacy key but adds no schema-sources entry.

--- a/internal/engine/kinds_test.go
+++ b/internal/engine/kinds_test.go
@@ -297,7 +297,8 @@ func TestKindPathPattern_MatchEmitsNoDiagnostic(t *testing.T) {
 
 // TestKindSetsRequiredStructureSchema verifies that a kind setting
 // required-structure.schema is reflected in the effective rule config for
-// files assigned to that kind.
+// files assigned to that kind. The merge layer translates the kind's
+// `schema:` setting into a `schema-sources` list entry (plan 156).
 func TestKindSetsRequiredStructureSchema(t *testing.T) {
 	cfg := &config.Config{
 		Rules: map[string]config.RuleCfg{
@@ -314,8 +315,11 @@ func TestKindSetsRequiredStructureSchema(t *testing.T) {
 	}
 
 	effective := config.Effective(cfg, "plan/001_foo.md", nil, nil)
-	got := effective["required-structure"].Settings["schema"]
-	assert.Equal(t, "plan/proto.md", got)
+	sources, ok := effective["required-structure"].Settings["schema-sources"].([]any)
+	require.True(t, ok, "schema-sources must be set")
+	require.Len(t, sources, 1)
+	assert.Equal(t, "plan/proto.md",
+		sources[0].(map[string]any)["file"])
 }
 
 // TestKindRuleReadme_NoInlineHTMLFires guards the .mdsmith.yml change that

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -49,6 +49,25 @@ type ListMerger interface {
 	SettingMergeMode(key string) MergeMode
 }
 
+// SettingsTranslator is implemented by Configurable rules that
+// rewrite one config layer's settings map before the deep-merge
+// runs. The config merge layer calls TranslateLayerSettings on
+// every layer that configures the rule, so merge logic stays free
+// of rule-name special cases.
+//
+// required-structure implements this to collapse the user-facing
+// `schema:` / `inline-schema:` keys into an append-mode
+// `schema-sources` list, letting multiple kinds compose their
+// schemas instead of overwriting (plan 156).
+type SettingsTranslator interface {
+	// TranslateLayerSettings returns the settings the merge layer
+	// should use for one layer. Implementations must treat the
+	// input as read-only and return a new map when they change
+	// anything; returning the input unchanged signals "no
+	// translation applies".
+	TranslateLayerSettings(settings map[string]any) map[string]any
+}
+
 // ConfigTarget is implemented by rules that validate the project
 // config file (.mdsmith.yml) rather than individual Markdown files.
 // The engine runner runs these rules once against a synthetic lint.File

--- a/internal/rules/requiredstructure/compose_test.go
+++ b/internal/rules/requiredstructure/compose_test.go
@@ -1,0 +1,1018 @@
+package requiredstructure
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplySettings_SchemaSourcesList exercises plan 156's primary
+// new input: a `schema-sources` list installed by the merge layer.
+// The rule loads each entry into Sources and reflects the first
+// entry into Schema / InlineSchema only when the list has exactly
+// one element.
+// TestTranslateLayerSettings_FileSource covers the rule's
+// rule.SettingsTranslator implementation: a `schema:` file path
+// becomes a one-entry schema-sources list and the legacy key is
+// stripped.
+func TestTranslateLayerSettings_FileSource(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{
+		"schema":       "internal/rules/proto.md",
+		"placeholders": []any{"cue-frontmatter"},
+	})
+	assert.NotContains(t, out, "schema")
+	srcs, ok := out["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, srcs, 1)
+	assert.Equal(t, "internal/rules/proto.md",
+		srcs[0].(map[string]any)["file"])
+	assert.Contains(t, out, "placeholders",
+		"unrelated keys must survive translation")
+}
+
+// TestTranslateLayerSettings_InlineSource covers the inline-schema
+// branch of the translator.
+func TestTranslateLayerSettings_InlineSource(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{
+		"inline-schema": map[string]any{
+			"sections": []any{map[string]any{"heading": "Goal"}},
+		},
+	})
+	assert.NotContains(t, out, "inline-schema")
+	srcs, ok := out["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, srcs, 1)
+	inl, ok := srcs[0].(map[string]any)["inline"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, inl, "sections")
+}
+
+// TestTranslateLayerSettings_NoSchemaKeyPassesThrough covers the
+// "no translation applies" path: a settings map with no schema
+// keys is returned unchanged (same map identity), so the merge
+// layer's no-translation fast path holds.
+func TestTranslateLayerSettings_NoSchemaKeyPassesThrough(t *testing.T) {
+	r := &Rule{}
+	in := map[string]any{"placeholders": []any{"x"}}
+	out := r.TranslateLayerSettings(in)
+	assert.Equal(t, in["placeholders"], out["placeholders"])
+	assert.NotContains(t, out, "schema-sources")
+}
+
+// TestTranslateLayerSettings_EmptyValuesStripped covers the
+// hadKey-but-no-source path: empty `schema: ""` and empty
+// `inline-schema: {}` are stripped without adding a source.
+func TestTranslateLayerSettings_EmptyValuesStripped(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{
+		"schema":        "",
+		"inline-schema": map[string]any{},
+	})
+	assert.NotContains(t, out, "schema")
+	assert.NotContains(t, out, "inline-schema")
+	assert.NotContains(t, out, "schema-sources")
+}
+
+// TestTranslateLayerSettings_AccumulatesOntoExistingList covers the
+// branch where a layer already carries a schema-sources list (e.g.
+// a prior translator pass): the new entry appends rather than
+// replacing.
+func TestTranslateLayerSettings_AccumulatesOntoExistingList(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{
+		"schema": "b.md",
+		"schema-sources": []any{
+			map[string]any{"file": "a.md"},
+		},
+	})
+	srcs, ok := out["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, srcs, 2)
+	assert.Equal(t, "a.md", srcs[0].(map[string]any)["file"])
+	assert.Equal(t, "b.md", srcs[1].(map[string]any)["file"])
+}
+
+// TestTranslateLayerSettings_NonStringSchema covers the non-string
+// `schema:` value branch of extractSchemaSourceFromSettings.
+func TestTranslateLayerSettings_NonStringSchema(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{"schema": 42})
+	assert.NotContains(t, out, "schema")
+	assert.NotContains(t, out, "schema-sources")
+}
+
+// TestTranslateLayerSettings_NonMapInline covers the non-map
+// `inline-schema:` value branch.
+func TestTranslateLayerSettings_NonMapInline(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{"inline-schema": 7})
+	assert.NotContains(t, out, "inline-schema")
+	assert.NotContains(t, out, "schema-sources")
+}
+
+// TestTranslateLayerSettings_DeepClonesNestedValues verifies the
+// translator does not alias the caller's nested maps/slices, so a
+// later mutation of the input cannot corrupt the merged config.
+func TestTranslateLayerSettings_DeepClonesNestedValues(t *testing.T) {
+	r := &Rule{}
+	inline := map[string]any{
+		"sections": []any{map[string]any{"heading": "Goal"}},
+	}
+	out := r.TranslateLayerSettings(map[string]any{"inline-schema": inline})
+	// Mutate the original nested structures.
+	inline["sections"].([]any)[0].(map[string]any)["heading"] = "MUTATED"
+	srcs := out["schema-sources"].([]any)
+	got := srcs[0].(map[string]any)["inline"].(map[string]any)
+	sec := got["sections"].([]any)[0].(map[string]any)
+	assert.Equal(t, "Goal", sec["heading"],
+		"translator must deep-clone inline schema, not alias it")
+}
+
+// TestCloneSettingsDeep_NilAndScalarTypes covers cloneSettingsDeep's
+// nil short-circuit and cloneSettingsValue's []string / []int /
+// nested-map clone branches. These value shapes appear in
+// programmatically-built RuleCfg.Settings (YAML decodes lists as
+// []any, but config code and tests construct typed slices).
+func TestCloneSettingsDeep_NilAndScalarTypes(t *testing.T) {
+	assert.Nil(t, cloneSettingsDeep(nil))
+
+	in := map[string]any{
+		"strs":   []string{"a", "b"},
+		"ints":   []int{1, 2},
+		"nested": map[string]any{"k": []any{"v"}},
+		"scalar": 7,
+	}
+	out := cloneSettingsDeep(in)
+	// Mutating the originals must not affect the clone.
+	in["strs"].([]string)[0] = "X"
+	in["ints"].([]int)[0] = 99
+	in["nested"].(map[string]any)["k"] = "changed"
+	assert.Equal(t, []string{"a", "b"}, out["strs"])
+	assert.Equal(t, []int{1, 2}, out["ints"])
+	assert.Equal(t, []any{"v"},
+		out["nested"].(map[string]any)["k"])
+	assert.Equal(t, 7, out["scalar"])
+}
+
+// TestRule_ImplementsSettingsTranslator is a compile-time-ish
+// guard that the rule satisfies the interface the merge layer
+// type-asserts on.
+func TestRule_ImplementsSettingsTranslator(t *testing.T) {
+	var _ rule.SettingsTranslator = (*Rule)(nil)
+	r := rule.ByName("required-structure")
+	require.NotNil(t, r)
+	_, ok := r.(rule.SettingsTranslator)
+	assert.True(t, ok,
+		"required-structure must be discoverable as a SettingsTranslator via the registry")
+}
+
+func TestApplySettings_SchemaSourcesList(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"file": "schemas/a.md"},
+			map[string]any{"inline": map[string]any{
+				"sections": []any{map[string]any{"heading": "Goal"}},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.Sources, 2)
+	assert.Equal(t, "schemas/a.md", r.Sources[0].File)
+	assert.NotNil(t, r.Sources[1].Inline)
+	// Multi-source: the single-source fields are not authoritative.
+	assert.Empty(t, r.Schema, "Schema must be empty for multi-source configs")
+	assert.Nil(t, r.InlineSchema, "InlineSchema must be empty for multi-source configs")
+}
+
+func TestApplySettings_SchemaSourcesSingleEntryReflectsLegacyFields(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"file": "schemas/a.md"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.Sources, 1)
+	assert.Equal(t, "schemas/a.md", r.Schema,
+		"single file source must reflect into r.Schema for legacy callers")
+}
+
+func TestApplySettings_SchemaSourcesSingleInlineReflectsLegacyFields(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"inline": map[string]any{
+				"sections": []any{map[string]any{"heading": "Goal"}},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.Sources, 1)
+	require.NotNil(t, r.InlineSchema,
+		"single inline source must reflect into r.InlineSchema")
+	assert.Empty(t, r.Schema,
+		"single inline source must clear r.Schema")
+}
+
+func TestApplySettings_SchemaSourcesRejectsBothKeys(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{
+				"file":   "x.md",
+				"inline": map[string]any{"sections": []any{}},
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "may set only one")
+}
+
+func TestApplySettings_SchemaSourcesRejectsEmptyEntry(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set `file` or `inline`")
+}
+
+func TestApplySettings_SchemaSourcesRejectsNonList(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": "not-a-list",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema-sources must be a list")
+}
+
+// TestCheck_ComposedSchemasRequireBothSets is acceptance criterion
+// #1 of plan 156: a file resolved by two kinds with disjoint
+// required sections must fail until both sets are present.
+func TestCheck_ComposedSchemasRequireBothSets(t *testing.T) {
+	schA := mustInline(t, map[string]any{
+		"sections": []any{map[string]any{"heading": "Goal"}},
+	})
+	schB := mustInline(t, map[string]any{
+		"sections": []any{map[string]any{"heading": "Risks"}},
+	})
+
+	r := &Rule{Sources: []SchemaSource{{Inline: schA}, {Inline: schB}}}
+
+	// Missing Risks.
+	f := newTestFile(t, "doc.md", "# Plan\n\n## Goal\n\nx\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `## Risks: got <missing>`)
+
+	// Missing Goal.
+	f2 := newTestFile(t, "doc.md", "# Plan\n\n## Risks\n\nx\n")
+	diags = r.Check(f2)
+	expectDiagMsg(t, diags, `## Goal: got <missing>`)
+
+	// Both present — clean.
+	f3 := newTestFile(t, "doc.md",
+		"# Plan\n\n## Goal\n\nx\n\n## Risks\n\ny\n")
+	diags = r.Check(f3)
+	assert.Empty(t, diags,
+		"file satisfying both kinds' required sections must validate cleanly")
+}
+
+// TestCheck_ComposedSchemasComposeFrontmatter is acceptance
+// criterion #2: a file resolving to two kinds with disjoint
+// required frontmatter keys must fail until both sets are present.
+func TestCheck_ComposedSchemasComposeFrontmatter(t *testing.T) {
+	schA := mustInline(t, map[string]any{
+		"frontmatter": map[string]any{
+			"id": `=~"^A-[0-9]+$"`,
+		},
+	})
+	schB := mustInline(t, map[string]any{
+		"frontmatter": map[string]any{
+			"category": `"alpha" | "beta"`,
+		},
+	})
+	r := &Rule{Sources: []SchemaSource{{Inline: schA}, {Inline: schB}}}
+
+	// Missing category.
+	doc := "---\nid: A-1\n---\n# T\n"
+	f := newTestFile(t, "doc.md", doc)
+	diags := r.Check(f)
+	require.NotEmpty(t, diags)
+	expectDiagMsg(t, diags, `category: got <missing>`)
+
+	// Has both — clean.
+	doc = "---\nid: A-1\ncategory: alpha\n---\n# T\n"
+	f = newTestFile(t, "doc.md", doc)
+	diags = r.Check(f)
+	assert.Empty(t, diags,
+		"frontmatter that satisfies both schemas must validate cleanly")
+}
+
+// TestCheck_ComposedSchemasMergeSameHeading covers the merge-by-text
+// rule: two schemas that share a literal heading combine their
+// child sections.
+func TestCheck_ComposedSchemasMergeSameHeading(t *testing.T) {
+	schA := mustInline(t, map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Meta-Information",
+				"sections": []any{
+					map[string]any{"heading": "ID"},
+				},
+			},
+		},
+	})
+	schB := mustInline(t, map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Meta-Information",
+				"sections": []any{
+					map[string]any{"heading": "Owner"},
+				},
+			},
+		},
+	})
+	r := &Rule{Sources: []SchemaSource{{Inline: schA}, {Inline: schB}}}
+
+	// Missing Owner under Meta-Information.
+	doc := "# T\n\n## Meta-Information\n\n### ID\n\nx\n"
+	f := newTestFile(t, "doc.md", doc)
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `### Owner: got <missing>`)
+
+	// Both children present.
+	doc = "# T\n\n## Meta-Information\n\n### ID\n\nx\n\n### Owner\n\ny\n"
+	f = newTestFile(t, "doc.md", doc)
+	diags = r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func mustInline(t *testing.T, m map[string]any) *schema.Schema {
+	t.Helper()
+	sch, err := schema.ParseInline(m, "test")
+	require.NoError(t, err)
+	return sch
+}
+
+// TestApplySettings_InlineSchemaEmptyMap covers the empty-map
+// short-circuit in applyInlineSchemaSetting. An empty
+// inline-schema is the merge-clear-then-empty state; it must not
+// install a SchemaSource and must not error.
+func TestApplySettings_InlineSchemaEmptyMap(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{
+		"inline-schema": map[string]any{},
+	}))
+	assert.Nil(t, r.InlineSchema)
+	assert.Empty(t, r.Sources)
+}
+
+// TestParseSchemaSources_EntryNotMap covers the non-map entry
+// rejection in parseSchemaSources.
+func TestParseSchemaSources_EntryNotMap(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{"not-a-map"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a map")
+}
+
+// TestParseSchemaSources_FileEntryWrongType covers the non-string
+// `file` value rejection.
+func TestParseSchemaSources_FileEntryWrongType(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"file": 42},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file must be a non-empty string")
+}
+
+// TestParseSchemaSources_FileEntryEmpty covers the empty-string
+// `file` value rejection.
+func TestParseSchemaSources_FileEntryEmpty(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"file": ""},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file must be a non-empty string")
+}
+
+// TestParseSchemaSources_InlineEntryWrongType covers the non-map
+// `inline` value rejection.
+func TestParseSchemaSources_InlineEntryWrongType(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"inline": "not-a-map"},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inline must be a non-empty mapping")
+}
+
+// TestParseSchemaSources_InlineEntryEmpty covers the empty-map
+// `inline` rejection.
+func TestParseSchemaSources_InlineEntryEmpty(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"inline": map[string]any{}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inline must be a non-empty mapping")
+}
+
+// TestParseSchemaSources_InlineParseError covers the
+// schema.ParseInline error path: an inline-schema with an
+// unsupported key surfaces as a wrapped error.
+func TestParseSchemaSources_InlineParseError(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"inline": map[string]any{
+				"bogus-key": "value",
+			}},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown schema key")
+}
+
+// TestSettingMergeMode_SchemaSources covers the new MergeAppend
+// declaration for the `schema-sources` setting.
+func TestSettingMergeMode_SchemaSources(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, rule.MergeAppend,
+		r.SettingMergeMode("schema-sources"))
+}
+
+// TestIsAnySchemaFile_InlineSourceSkipped covers the
+// `src.File == ""` continue branch in isAnySchemaFile: an inline
+// source has no file path to match, so the loop moves on without
+// claiming the file as a schema.
+func TestIsAnySchemaFile_InlineSourceSkipped(t *testing.T) {
+	r := &Rule{Sources: []SchemaSource{
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{"heading": "X"}},
+		})},
+	}}
+	f := newTestFile(t, "doc.md", "# T\n")
+	assert.False(t, r.isAnySchemaFile(f),
+		"inline-only sources cannot make the doc its own schema")
+}
+
+// TestCheckComposedSources_EmptyInlineSourceSkipped covers the
+// `src.Inline.IsEmpty()` continue branch in checkComposedSources:
+// an inline source set to an empty schema should not contribute a
+// composed entry. The companion non-empty entry still validates.
+func TestCheckComposedSources_EmptyInlineSourceSkipped(t *testing.T) {
+	r := &Rule{Sources: []SchemaSource{
+		{Inline: &schema.Schema{}}, // empty
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{
+				"heading": "Goal",
+			}},
+		})},
+	}}
+	f := newTestFile(t, "doc.md", "# T\n\n## NotGoal\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `## Goal: got <missing>`)
+}
+
+// TestCheckComposedSources_EmptyFileSourceSkipped covers the
+// `src.File == ""` branch when iterating sources: a zero-value
+// file source is silently skipped.
+func TestCheckComposedSources_EmptyFileSourceSkipped(t *testing.T) {
+	r := &Rule{Sources: []SchemaSource{
+		{File: ""},
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{
+				"heading": "Goal",
+			}},
+		})},
+	}}
+	f := newTestFile(t, "doc.md", "# T\n\n## NotGoal\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, `## Goal: got <missing>`)
+}
+
+// TestCheckComposedSources_AllEmptySchemas covers the
+// `len(parsed) == 0` early-return branch in checkComposedSources:
+// every source is empty / self-referential, so the composed schema
+// is nothing and no validation diagnostics fire.
+func TestCheckComposedSources_AllEmptySchemas(t *testing.T) {
+	r := &Rule{Sources: []SchemaSource{
+		{Inline: &schema.Schema{}},
+		{Inline: &schema.Schema{}},
+	}}
+	f := newTestFile(t, "doc.md", "# T\n")
+	diags := r.Check(f)
+	assert.Empty(t, diags,
+		"all-empty composed schemas must produce no diagnostics")
+}
+
+// TestCheckComposedSources_ComposeError covers the
+// schema.Compose error branch: two inline schemas with conflicting
+// filename patterns surface as a "composing schemas" diagnostic.
+func TestCheckComposedSources_ComposeError(t *testing.T) {
+	a := mustInline(t, map[string]any{"filename": "AAA*.md"})
+	b := mustInline(t, map[string]any{"filename": "BBB*.md"})
+	r := &Rule{Sources: []SchemaSource{{Inline: a}, {Inline: b}}}
+	f := newTestFile(t, "doc.md", "# T\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "composing schemas")
+}
+
+// TestBodySyncDiagnostics_LoadError covers the readSchemaFile
+// error branch in bodySyncDiagnostics: a non-existent schema file
+// surfaces as a "cannot read schema" diagnostic when the doc has
+// frontmatter (otherwise the function short-circuits earlier).
+func TestBodySyncDiagnostics_LoadError(t *testing.T) {
+	dir := t.TempDir()
+	doc := "---\nid: X\nname: y\n---\n# X: y\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "missing.md"},
+		// Second source so the rule takes the multi-source path
+		// and exercises bodySyncDiagnostics for the first source.
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{"heading": "Goal"}},
+		})},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "cannot read schema")
+}
+
+// TestBodySyncDiagnostics_ParseError covers the parseSchema error
+// branch: a schema with invalid CUE frontmatter surfaces from the
+// compose path as a load error, while bodySyncDiagnostics silently
+// drops its own duplicated diagnostic.
+func TestBodySyncDiagnostics_ParseError(t *testing.T) {
+	dir := t.TempDir()
+	// Schema with invalid CUE in frontmatter — parseSchema rejects
+	// it, so bodySyncDiagnostics swallows the duplicate while
+	// parseFileSchemaForCompose also rejects (one diag total).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.md"),
+		[]byte("---\nname: 'not (closed string\n---\n# ?\n"), 0o644))
+
+	doc := "---\nid: X\nname: y\n---\n# T\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "bad.md"},
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{"heading": "Goal"}},
+		})},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	// The compose-path reports the parse failure; the
+	// body-sync path swallows it (the swallowed branch is what
+	// this test covers).
+	var msgs []string
+	for _, d := range diags {
+		msgs = append(msgs, d.Message)
+	}
+	assert.NotEmpty(t, msgs)
+}
+
+// TestCheck_ComposedFileSchemas covers the directive-rule-readme +
+// rule-readme shape: two file-based proto.md schemas resolve through
+// the Sources list, get parsed via schema.ParseFile, and compose at
+// check time. Without coverage of this path, the file-source half of
+// the merge layer's translation goes unexercised at the rule level.
+func TestCheck_ComposedFileSchemas(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto-a.md"),
+		[]byte("# {id}: {name}\n\n## Config\n\n## ...\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto-b.md"),
+		[]byte("# {id}: {name}\n\n## Pattern\n"), 0o644))
+
+	doc := "---\nid: X\nname: y\n---\n# X: y\n\n## Config\n\nx\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "proto-a.md"},
+		{File: "proto-b.md"},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	// proto-b requires `## Pattern`, which the doc is missing —
+	// composition must surface that diagnostic.
+	expectDiagMsg(t, diags, `## Pattern: got <missing>`)
+}
+
+// TestCheck_ComposedFileSchemas_BodySyncFires regresses the
+// per-source body-sync path. Each file source still runs its legacy
+// heading- and body-sync check independently so proto.md
+// `# {id}: {name}` + Meta-Information body lines still fire on
+// composed configs.
+func TestCheck_ComposedFileSchemas_BodySyncFires(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto-a.md"),
+		[]byte("# {id}: {name}\n\n## Config\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto-b.md"),
+		[]byte("# {id}: {name}\n\n## Pattern\n"), 0o644))
+
+	// The doc's H1 has the right shape (matches the regex pattern
+	// for `{id}: {name}`) but the values don't match the
+	// frontmatter — legacy body-sync should flag the mismatch
+	// once the H1 has been claimed by the composed schema.
+	doc := "---\nid: X\nname: y\n---\n# wrong: title\n\n" +
+		"## Config\n\nx\n\n## Pattern\n\np\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "proto-a.md"},
+		{File: "proto-b.md"},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "heading does not match frontmatter")
+}
+
+// TestCheck_ComposedFileSchemas_SchemaFileSelfSkipped verifies the
+// self-validation guard: when the file being linted is itself one
+// of the configured file sources, that source contributes no
+// composed entry (so the schema doesn't validate against itself).
+func TestCheck_ComposedFileSchemas_SchemaFileSelfSkipped(t *testing.T) {
+	dir := t.TempDir()
+	// H2-rooted schemas (no H1 wrapper) so both sources agree on
+	// RootLevel and the validator doesn't get stuck on an
+	// unmatched H1 before reaching the section under test.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto-a.md"),
+		[]byte("## Config\n"), 0o644))
+	// The file being linted IS proto-b.md.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto-b.md"),
+		[]byte("## Pattern\n"), 0o644))
+
+	docPath := filepath.Join(dir, "proto-b.md")
+	src, err := os.ReadFile(docPath)
+	require.NoError(t, err)
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "proto-a.md"},
+		{File: "proto-b.md"}, // self-reference; should be skipped
+	}}
+	f, err := lint.NewFileFromSource(docPath, src, true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	// proto-b.md is skipped (self-validation). proto-a requires
+	// Config and the doc (proto-b's body) has only `## Pattern`,
+	// so the missing-Config diagnostic must surface — proving
+	// proto-a still validated while proto-b did not validate
+	// against itself.
+	expectDiagMsg(t, diags, `## Config: got <missing>`)
+}
+
+// TestComposedSchemaForFix_FileSource exercises the file-source
+// branch of composedSchemaForFix. Multi-source configs that mix
+// inline and file sources must produce a composed schema that
+// carries the inline source's Index block. Both sources must
+// agree on RootLevel — the file uses an H2-rooted proto.md
+// (no `# ?` H1 wrapper) so it matches the inline default of 2.
+func TestComposedSchemaForFix_FileSource(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto.md"),
+		[]byte("## Goal\n"), 0o644))
+
+	doc := "# T\n\n## Goal\n\nx\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{"file": "proto.md"},
+			map[string]any{"inline": map[string]any{
+				"index": map[string]any{
+					"output":  "out.json",
+					"include": []any{"headings"},
+				},
+			}},
+		},
+	}))
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	r.Fix(f)
+	_, err = os.Stat(filepath.Join(dir, "out.json"))
+	require.NoError(t, err, "composed Index from inline source must write")
+}
+
+// TestComposedSchemaForFix_NoSources covers the no-source short
+// circuit in composedSchemaForFix.
+func TestComposedSchemaForFix_NoSources(t *testing.T) {
+	r := &Rule{}
+	f := newTestFile(t, "doc.md", "# T\n")
+	sch, err := r.composedSchemaForFix(f)
+	require.NoError(t, err)
+	assert.Nil(t, sch, "no sources should return nil")
+}
+
+// TestComposedSchemaForFix_AllEmpty covers the empty-input branch:
+// every inline source is empty, file source is empty string.
+func TestComposedSchemaForFix_AllEmpty(t *testing.T) {
+	r := &Rule{Sources: []SchemaSource{
+		{Inline: &schema.Schema{}},
+		{File: ""},
+	}}
+	f := newTestFile(t, "doc.md", "# T\n")
+	sch, err := r.composedSchemaForFix(f)
+	require.NoError(t, err)
+	assert.Nil(t, sch,
+		"empty-only sources should produce no composed schema")
+}
+
+// TestComposedSchemaForFix_SelfReferentialFile covers the
+// self-validation skip path in composedSchemaForFix: when a file
+// source points at the file currently being fixed, the source is
+// skipped (parseFileSchemaForCompose returns nil).
+func TestComposedSchemaForFix_SelfReferentialFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "proto.md"),
+		[]byte("# ?\n\n## Goal\n"), 0o644))
+	f, err := lint.NewFileFromSource(filepath.Join(dir, "proto.md"),
+		[]byte("# ?\n\n## Goal\n"), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+
+	r := &Rule{Sources: []SchemaSource{{File: "proto.md"}}}
+	sch, err := r.composedSchemaForFix(f)
+	require.NoError(t, err)
+	assert.Nil(t, sch,
+		"a single self-referential file source should produce no schema")
+}
+
+// TestReflectSingleSource_NoSources covers the early-return when
+// Sources is empty (the default path that does nothing).
+func TestReflectSingleSource_NoSources(t *testing.T) {
+	r := &Rule{Schema: "original.md"}
+	r.reflectSingleSource()
+	assert.Equal(t, "original.md", r.Schema,
+		"empty Sources must not touch Schema")
+}
+
+// TestReflectSingleSource_MultipleSources verifies the no-op branch
+// when more than one source is configured: Schema and InlineSchema
+// stay at their previous values rather than collapsing to the
+// first entry.
+func TestReflectSingleSource_MultipleSources(t *testing.T) {
+	r := &Rule{
+		Schema:       "kept",
+		InlineSchema: mustInline(t, map[string]any{"sections": []any{}}),
+		Sources: []SchemaSource{
+			{File: "a.md"},
+			{File: "b.md"},
+		},
+	}
+	prevInline := r.InlineSchema
+	r.reflectSingleSource()
+	assert.Equal(t, "kept", r.Schema)
+	assert.Same(t, prevInline, r.InlineSchema)
+}
+
+// TestEffectiveSources_EmptyInlineSchemaIgnored covers the
+// `r.InlineSchema.IsEmpty() == true` branch in effectiveSources:
+// an InlineSchema that's set but empty falls through to the file
+// path, then to nil.
+func TestEffectiveSources_EmptyInlineSchemaIgnored(t *testing.T) {
+	r := &Rule{InlineSchema: &schema.Schema{}}
+	assert.Empty(t, r.effectiveSources(),
+		"empty InlineSchema must not produce a source")
+}
+
+// TestFix_NoOpOnErrorOrNil exercises the three "do nothing" exits
+// of Fix: an error from composedSchemaForFix, a nil composed
+// schema (no sources), and a composed schema with no Index.
+func TestFix_NoOpOnErrorOrNil(t *testing.T) {
+	doc := []byte("# T\n")
+	// (a) error path: a non-existent file source surfaces an error.
+	t.Run("error_from_compose", func(t *testing.T) {
+		dir := t.TempDir()
+		f, err := lint.NewFileFromSource(filepath.Join(dir, "doc.md"), doc, true)
+		require.NoError(t, err)
+		f.SetRootDir(dir)
+		r := &Rule{Sources: []SchemaSource{
+			{File: "missing.md"},
+			{Inline: mustInline(t, map[string]any{
+				"sections": []any{map[string]any{"heading": "Goal"}},
+			})},
+		}}
+		out := r.Fix(f)
+		assert.Equal(t, doc, out)
+	})
+	// (b) nil schema path: no sources at all.
+	t.Run("nil_schema", func(t *testing.T) {
+		f, err := lint.NewFileFromSource("doc.md", doc, true)
+		require.NoError(t, err)
+		r := &Rule{}
+		out := r.Fix(f)
+		assert.Equal(t, doc, out)
+	})
+	// (c) no Index: composed schema has no Index block.
+	t.Run("no_index_in_composed", func(t *testing.T) {
+		f, err := lint.NewFileFromSource("doc.md", doc, true)
+		require.NoError(t, err)
+		r := &Rule{Sources: []SchemaSource{
+			{Inline: mustInline(t, map[string]any{
+				"sections": []any{map[string]any{"heading": "Goal"}},
+			})},
+			{Inline: mustInline(t, map[string]any{
+				"sections": []any{map[string]any{"heading": "Risks"}},
+			})},
+		}}
+		out := r.Fix(f)
+		assert.Equal(t, doc, out)
+	})
+	// (d) empty composed schema: parses to nothing.
+	t.Run("empty_composed", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.md"), []byte(""), 0o644))
+		f, err := lint.NewFileFromSource(filepath.Join(dir, "doc.md"), doc, true)
+		require.NoError(t, err)
+		f.SetRootDir(dir)
+		r := &Rule{Sources: []SchemaSource{{File: "empty.md"}}}
+		out := r.Fix(f)
+		assert.Equal(t, doc, out)
+	})
+}
+
+// TestApplySettings_RejectsBothNonEmpty covers the alternate
+// arm of the dual-source rejection: path is set and inline is
+// EMPTY map. That should NOT error (it's the merge-clear-then-
+// reapply state), exercising the false branch of
+// `len(inline) == 0` short-circuit.
+func TestApplySettings_PathPlusEmptyInlineAllowed(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{
+		"schema":        "schemas/x.md",
+		"inline-schema": map[string]any{},
+	}))
+	assert.Equal(t, "schemas/x.md", r.Schema)
+}
+
+// TestReflectSingleSource_ZeroValueSource covers the case where
+// Sources has exactly one zero-value entry — both switch arms
+// evaluate to false, the function falls through, and Schema /
+// InlineSchema stay at their prior values.
+func TestReflectSingleSource_ZeroValueSource(t *testing.T) {
+	r := &Rule{
+		Schema:       "kept",
+		InlineSchema: mustInline(t, map[string]any{"sections": []any{}}),
+		Sources:      []SchemaSource{{}}, // zero-value
+	}
+	prevInline := r.InlineSchema
+	r.reflectSingleSource()
+	assert.Equal(t, "kept", r.Schema,
+		"zero-value source must not overwrite Schema")
+	assert.Same(t, prevInline, r.InlineSchema,
+		"zero-value source must not overwrite InlineSchema")
+}
+
+// TestReflectSingleSource_SingleFileSourceClearsInline covers the
+// `r.Sources[0].Inline != nil` false branch in the reflect
+// switch — when the single source is a FILE, the Inline arm is
+// not chosen.
+func TestReflectSingleSource_SingleFileSourceClearsInline(t *testing.T) {
+	r := &Rule{
+		InlineSchema: mustInline(t, map[string]any{"sections": []any{}}),
+		Sources:      []SchemaSource{{File: "x.md"}},
+	}
+	r.reflectSingleSource()
+	assert.Equal(t, "x.md", r.Schema)
+	assert.Nil(t, r.InlineSchema,
+		"single file source must clear InlineSchema")
+}
+
+// TestCheck_ZeroValueSingleSourceShortCircuits covers the
+// fall-through case in Check where Sources has exactly one entry
+// but both File and Inline are zero-valued (a defensive guard).
+func TestCheck_ZeroValueSingleSourceShortCircuits(t *testing.T) {
+	r := &Rule{Sources: []SchemaSource{{}}}
+	f := newTestFile(t, "doc.md", "# T\n")
+	diags := r.Check(f)
+	assert.Empty(t, diags,
+		"a zero-value single source must produce no diagnostics")
+}
+
+// TestIsSchemaFileAt_EmptyPath covers the empty-path early-return
+// in isSchemaFileAt.
+func TestIsSchemaFileAt_EmptyPath(t *testing.T) {
+	r := &Rule{}
+	f := newTestFile(t, "doc.md", "# T\n")
+	assert.False(t, r.isSchemaFileAt(f, ""))
+}
+
+// TestComposedSchemaForFix_ParseFileError covers the error
+// propagation from parseFileSchemaForCompose during Fix: a schema
+// file that fails to parse surfaces as an error from
+// composedSchemaForFix. The Fix implementation swallows it, so we
+// call the helper directly to confirm the error path.
+func TestComposedSchemaForFix_ParseFileError(t *testing.T) {
+	dir := t.TempDir()
+	// Frontmatter with an unknown shortcut name rejects in
+	// schema.ParseFile via frontmatterExpr → resolveBareName.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.md"),
+		[]byte("---\nname: notashortcut\n---\n# ?\n"), 0o644))
+
+	doc := "# T\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "bad.md"},
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{"heading": "Goal"}},
+		})},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	_, err = r.composedSchemaForFix(f)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot load schema")
+}
+
+// TestCheckComposedSources_EmptyComposedSchemaSkipsValidate covers
+// the `composed == nil || composed.IsEmpty()` early-return: when
+// every file source parses to an empty schema (e.g. proto files
+// with no frontmatter or sections), the composed schema is empty
+// and validation is skipped.
+func TestCheckComposedSources_EmptyComposedSchemaSkipsValidate(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty-a.md"),
+		[]byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty-b.md"),
+		[]byte(""), 0o644))
+
+	doc := "# T\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "empty-a.md"},
+		{File: "empty-b.md"},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	assert.Empty(t, diags,
+		"empty composed schema must skip validation")
+}
+
+// TestParseFileSchemaForCompose_LoadError covers the schema.ParseFile
+// error branch in composedSchemaForFix / checkComposedSources.
+func TestParseFileSchemaForCompose_LoadError(t *testing.T) {
+	dir := t.TempDir()
+	doc := "# T\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(doc), 0o644))
+
+	r := &Rule{Sources: []SchemaSource{
+		{File: "missing-proto.md"},
+		{Inline: mustInline(t, map[string]any{
+			"sections": []any{map[string]any{"heading": "Goal"}},
+		})},
+	}}
+	f, err := lint.NewFileFromSource(docPath, []byte(doc), true)
+	require.NoError(t, err)
+	f.SetRootDir(dir)
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "cannot load schema")
+}

--- a/internal/rules/requiredstructure/compose_test.go
+++ b/internal/rules/requiredstructure/compose_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestApplySettings_SchemaSourcesList exercises plan 156's primary
-// new input: a `schema-sources` list installed by the merge layer.
-// The rule loads each entry into Sources and reflects the first
-// entry into Schema / InlineSchema only when the list has exactly
-// one element.
 // TestTranslateLayerSettings_FileSource covers the rule's
 // rule.SettingsTranslator implementation: a `schema:` file path
 // becomes a one-entry schema-sources list and the legacy key is
@@ -174,6 +169,11 @@ func TestRule_ImplementsSettingsTranslator(t *testing.T) {
 		"required-structure must be discoverable as a SettingsTranslator via the registry")
 }
 
+// TestApplySettings_SchemaSourcesList exercises plan 156's primary
+// new input: a `schema-sources` list installed by the merge layer.
+// The rule loads each entry into Sources and reflects the first
+// entry into Schema / InlineSchema only when the list has exactly
+// one element.
 func TestApplySettings_SchemaSourcesList(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{

--- a/internal/rules/requiredstructure/index_fix_test.go
+++ b/internal/rules/requiredstructure/index_fix_test.go
@@ -47,6 +47,56 @@ func TestFix_WritesIndexSideOutput(t *testing.T) {
 	assert.Equal(t, "title", got["headings"][0].Slug)
 }
 
+// TestFix_WritesComposedIndexSideOutput regresses Copilot's review
+// finding on PR #288: when the rule's effective config carries
+// multiple Sources, the legacy r.InlineSchema field stays nil and
+// Fix used to no-op. checkComposedSources still validates an
+// `index:` block on the composed schema, so users would see a
+// "missing index" diagnostic that Fix couldn't resolve. Fix must
+// therefore compose the same way Check does and write the
+// side-output when the composed schema declares one.
+func TestFix_WritesComposedIndexSideOutput(t *testing.T) {
+	dir := t.TempDir()
+	src := "# Title\n\n## Goal\n\n## Tasks\n"
+	docPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(docPath, []byte(src), 0o644))
+
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			// Kind A: structure only (no index).
+			map[string]any{"inline": map[string]any{
+				"sections": []any{
+					map[string]any{"heading": "Goal"},
+				},
+			}},
+			// Kind B: declares the index side-output.
+			map[string]any{"inline": map[string]any{
+				"index": map[string]any{
+					"output":  "doc-index.json",
+					"include": []any{"headings"},
+				},
+			}},
+		},
+	}))
+	require.Len(t, r.Sources, 2,
+		"multi-source config must keep both entries")
+	require.Nil(t, r.InlineSchema,
+		"multi-source must leave the single-source mirror nil")
+
+	f, err := lint.NewFile(docPath, []byte(src))
+	require.NoError(t, err)
+	out := r.Fix(f)
+	assert.Equal(t, src, string(out), "Fix must return source unchanged")
+
+	idxData, err := os.ReadFile(filepath.Join(dir, "doc-index.json"))
+	require.NoError(t, err,
+		"composed index must be written from the multi-source schema")
+	var got map[string][]schema.IndexHeading
+	require.NoError(t, json.Unmarshal(idxData, &got))
+	require.Len(t, got["headings"], 3)
+}
+
 // TestCheck_ReportsStaleIndex verifies the read-only contract for
 // `mdsmith check`: when the index is missing the rule emits a
 // diagnostic so `mdsmith fix` is triggered, but Check itself does

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -456,6 +456,48 @@ func TestApplySettings_RejectsBothSources(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot set both")
 }
 
+// TestTranslateLayerSettings_DualSourcePreservesGuard regresses
+// the Copilot review on PR #288: when one config layer sets both
+// a non-empty `schema:` and a non-empty `inline-schema:`, the
+// translator must NOT strip the keys (which would silently drop
+// the inline source). It passes the layer through unchanged so
+// the keys survive deep-merge and ApplySettings' dual-source
+// guard still surfaces the original config error.
+func TestTranslateLayerSettings_DualSourcePreservesGuard(t *testing.T) {
+	r := &Rule{}
+	dual := map[string]any{
+		"schema": "schemas/rfc.md",
+		"inline-schema": map[string]any{
+			"sections": []any{map[string]any{"heading": "X"}},
+		},
+	}
+	out := r.TranslateLayerSettings(dual)
+	// Untouched: both legacy keys survive, no schema-sources added.
+	assert.Equal(t, "schemas/rfc.md", out["schema"],
+		"dual-source layer must pass through with `schema` intact")
+	assert.Contains(t, out, "inline-schema",
+		"dual-source layer must pass through with `inline-schema` intact")
+	assert.NotContains(t, out, "schema-sources",
+		"dual-source layer must not be translated to schema-sources")
+	// The surviving keys still trip the rule's guard.
+	err := r.ApplySettings(out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot set both")
+}
+
+// TestTranslateLayerSettings_SingleSourcesStillTranslate confirms
+// the dual-source guard does not regress the normal single-source
+// translation (only one of the two keys, non-empty).
+func TestTranslateLayerSettings_SingleSourcesStillTranslate(t *testing.T) {
+	r := &Rule{}
+	out := r.TranslateLayerSettings(map[string]any{"schema": "x.md"})
+	srcs, ok := out["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, srcs, 1)
+	assert.Equal(t, "x.md", srcs[0].(map[string]any)["file"])
+	assert.NotContains(t, out, "schema")
+}
+
 func TestApplySettings_AllowsEmptySchemaWithInline(t *testing.T) {
 	// An empty `schema:""` next to a real `inline-schema` is the
 	// merge-clears-prior-state state; the rule must still accept it.

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -31,17 +31,35 @@ func init() {
 
 // Rule checks that a document's heading structure matches a schema.
 //
-// A rule instance holds at most one schema source: a path to a
-// proto.md file (Schema) or an already-parsed inline schema
-// (InlineSchema). The kind-level loader rejects configurations that
-// set both on the same kind; the merge logic in internal/config
-// clears the other source whenever a later layer installs a new one,
-// so the rule never has to disambiguate at runtime.
+// A rule instance carries an ordered list of schema sources (Sources)
+// — one per layer (kind, override, or top-level rule entry) that
+// declared a `schema:` (file) or `inline-schema:` (inline map). The
+// rule loads each source at Check time and composes them via
+// schema.Compose; a file resolving to multiple kinds therefore layers
+// each kind's constraints rather than letting the last one win.
+//
+// Schema and InlineSchema mirror the first source's parsed form when
+// exactly one source is present. They support tests that drive the
+// rule directly through ApplySettings with the legacy single-source
+// keys; the kind-level loader still rejects configurations that set
+// both keys on the same layer.
 type Rule struct {
-	Schema       string         // path to schema file
-	InlineSchema *schema.Schema // parsed inline schema (when set)
+	Schema       string         // first source's file path (single-source convenience)
+	InlineSchema *schema.Schema // first source's parsed inline schema
+	Sources      []SchemaSource // ordered list of schema sources (canonical)
 	Placeholders []string       // placeholder tokens to treat as opaque
 	PathPatterns []PathPattern  // kind-level path-pattern entries
+}
+
+// SchemaSource is one entry in the rule's schema-sources list. Either
+// File or Inline is set, never both. Inline schemas are pre-parsed at
+// ApplySettings time so a malformed schema surfaces as a config-load
+// error rather than a per-file diagnostic at Check time. File sources
+// stay as paths because the rule reads them through the lint.File's
+// RootFS at Check time.
+type SchemaSource struct {
+	File   string
+	Inline *schema.Schema
 }
 
 // PathPattern records a kind's `path-pattern:` constraint: the kind
@@ -63,63 +81,188 @@ func (r *Rule) Name() string { return "required-structure" }
 func (r *Rule) Category() string { return "structural" }
 
 // ApplySettings implements rule.Configurable.
+//
+// Three input shapes are accepted, all collapsed into Sources:
+//
+//   - `schema-sources` (canonical, set by the merge layer): a list of
+//     {file: path} / {inline: map} entries in source order.
+//   - `schema` (legacy single-source): a file path; equivalent to a
+//     one-entry schema-sources list.
+//   - `inline-schema` (legacy single-source): a YAML map; equivalent
+//     to a one-entry inline schema-sources list.
+//
+// When called via the merge layer the rule sees only schema-sources;
+// the legacy keys are retained for tests and direct callers. Mixing
+// `schema` and `inline-schema` in the same settings call is rejected
+// as before — the merge layer only produces schema-sources, so the
+// guard fires only on hand-authored configs.
 func (r *Rule) ApplySettings(settings map[string]any) error {
 	if err := rejectDualSchemaSettings(settings); err != nil {
 		return err
 	}
+	r.Sources = nil
 	for k, v := range settings {
-		switch k {
-		case "schema":
-			s, ok := v.(string)
-			if !ok {
-				return fmt.Errorf("required-structure: schema must be a string, got %T", v)
-			}
-			if isLikelyArchetypeName(s) {
-				return fmt.Errorf(
-					"required-structure: schema %q looks like a bare name; "+
-						"name-based lookup has been removed — set `schema:` to "+
-						"an explicit path (e.g. schemas/%s.md), or declare a "+
-						"kind under `kinds:` — see docs/guides/file-kinds.md", s, s)
-			}
-			r.Schema = s
-		case "inline-schema":
-			m, ok := v.(map[string]any)
-			if !ok {
-				return fmt.Errorf(
-					"required-structure: inline-schema must be a mapping, got %T", v)
-			}
-			sch, err := schema.ParseInline(m, "inline kind schema")
-			if err != nil {
-				return fmt.Errorf("required-structure: invalid inline-schema: %w", err)
-			}
-			r.InlineSchema = sch
-		case "placeholders":
-			toks, ok := rulesettings.ToStringSlice(v)
-			if !ok {
-				return fmt.Errorf(
-					"required-structure: placeholders must be a list of strings, got %T", v,
-				)
-			}
-			if err := placeholders.Validate(toks); err != nil {
-				return fmt.Errorf("required-structure: %w", err)
-			}
-			r.Placeholders = toks
-		case "path-patterns":
-			pp, err := parsePathPatterns(v)
-			if err != nil {
-				return fmt.Errorf("required-structure: %w", err)
-			}
-			r.PathPatterns = pp
-		case "archetype", "archetype-roots":
-			return fmt.Errorf(
-				"required-structure: setting %q has been removed; "+
-					"use `schema:` with an explicit path, or declare a kind "+
-					"under `kinds:` — see docs/guides/file-kinds.md", k)
-		default:
-			return fmt.Errorf("required-structure: unknown setting %q", k)
+		if err := r.applySetting(k, v); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (r *Rule) applySetting(key string, value any) error {
+	switch key {
+	case "schema":
+		return r.applySchemaSetting(value)
+	case "inline-schema":
+		return r.applyInlineSchemaSetting(value)
+	case "schema-sources":
+		return r.applySchemaSourcesSetting(value)
+	case "placeholders":
+		return r.applyPlaceholdersSetting(value)
+	case "path-patterns":
+		pp, err := parsePathPatterns(value)
+		if err != nil {
+			return fmt.Errorf("required-structure: %w", err)
+		}
+		r.PathPatterns = pp
+		return nil
+	case "archetype", "archetype-roots":
+		return fmt.Errorf(
+			"required-structure: setting %q has been removed; "+
+				"use `schema:` with an explicit path, or declare a kind "+
+				"under `kinds:` — see docs/guides/file-kinds.md", key)
+	default:
+		return fmt.Errorf("required-structure: unknown setting %q", key)
+	}
+}
+
+func (r *Rule) applySchemaSetting(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("required-structure: schema must be a string, got %T", v)
+	}
+	if s == "" {
+		return nil
+	}
+	if isLikelyArchetypeName(s) {
+		return fmt.Errorf(
+			"required-structure: schema %q looks like a bare name; "+
+				"name-based lookup has been removed — set `schema:` to "+
+				"an explicit path (e.g. schemas/%s.md), or declare a "+
+				"kind under `kinds:` — see docs/guides/file-kinds.md", s, s)
+	}
+	r.Schema = s
+	r.Sources = append(r.Sources, SchemaSource{File: s})
+	return nil
+}
+
+func (r *Rule) applyInlineSchemaSetting(v any) error {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return fmt.Errorf(
+			"required-structure: inline-schema must be a mapping, got %T", v)
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	sch, err := schema.ParseInline(m, "inline kind schema")
+	if err != nil {
+		return fmt.Errorf("required-structure: invalid inline-schema: %w", err)
+	}
+	r.InlineSchema = sch
+	r.Sources = append(r.Sources, SchemaSource{Inline: sch})
+	return nil
+}
+
+func (r *Rule) applySchemaSourcesSetting(v any) error {
+	sources, err := parseSchemaSources(v)
+	if err != nil {
+		return fmt.Errorf("required-structure: %w", err)
+	}
+	r.Sources = append(r.Sources, sources...)
+	r.reflectSingleSource()
+	return nil
+}
+
+func (r *Rule) applyPlaceholdersSetting(v any) error {
+	toks, ok := rulesettings.ToStringSlice(v)
+	if !ok {
+		return fmt.Errorf(
+			"required-structure: placeholders must be a list of strings, got %T", v,
+		)
+	}
+	if err := placeholders.Validate(toks); err != nil {
+		return fmt.Errorf("required-structure: %w", err)
+	}
+	r.Placeholders = toks
+	return nil
+}
+
+// reflectSingleSource keeps Schema and InlineSchema in sync with
+// Sources when exactly one source is configured. Multi-source
+// configs leave both as their previous values — callers must read
+// Sources to enumerate the list.
+func (r *Rule) reflectSingleSource() {
+	if len(r.Sources) != 1 {
+		return
+	}
+	switch {
+	case r.Sources[0].File != "":
+		r.Schema = r.Sources[0].File
+		r.InlineSchema = nil
+	case r.Sources[0].Inline != nil:
+		r.InlineSchema = r.Sources[0].Inline
+		r.Schema = ""
+	}
+}
+
+// parseSchemaSources reads the `schema-sources` rule setting: a list
+// of `{file: path}` / `{inline: map}` entries installed by the merge
+// layer. Inline maps are parsed eagerly so a malformed schema fails
+// at config-load time rather than per file at Check time.
+func parseSchemaSources(v any) ([]SchemaSource, error) {
+	list, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf(
+			"schema-sources must be a list of {file|inline} entries, got %T", v)
+	}
+	out := make([]SchemaSource, 0, len(list))
+	for i, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("schema-sources[%d]: entry must be a map, got %T", i, item)
+		}
+		filePath, hasFile := m["file"]
+		inlineV, hasInline := m["inline"]
+		if hasFile && hasInline {
+			return nil, fmt.Errorf(
+				"schema-sources[%d]: entry may set only one of `file` or `inline`", i)
+		}
+		switch {
+		case hasFile:
+			fp, ok := filePath.(string)
+			if !ok || fp == "" {
+				return nil, fmt.Errorf(
+					"schema-sources[%d].file must be a non-empty string, got %T", i, filePath)
+			}
+			out = append(out, SchemaSource{File: fp})
+		case hasInline:
+			im, ok := inlineV.(map[string]any)
+			if !ok || len(im) == 0 {
+				return nil, fmt.Errorf(
+					"schema-sources[%d].inline must be a non-empty mapping, got %T", i, inlineV)
+			}
+			sch, err := schema.ParseInline(im, "inline kind schema")
+			if err != nil {
+				return nil, fmt.Errorf("schema-sources[%d].inline: %w", i, err)
+			}
+			out = append(out, SchemaSource{Inline: sch})
+		default:
+			return nil, fmt.Errorf(
+				"schema-sources[%d]: entry must set `file` or `inline`", i)
+		}
+	}
+	return out, nil
 }
 
 // rejectDualSchemaSettings refuses a settings map that supplies both
@@ -152,12 +295,12 @@ func (r *Rule) DefaultSettings() map[string]any {
 	}
 }
 
-// hasInlineSchema reports whether the rule has a non-empty inline
-// schema attached. The inline source takes precedence over the file
-// source — the kind validator and the effective-config merge prevent
-// them from coexisting, but this is the runtime safeguard.
-func (r *Rule) hasInlineSchema() bool {
-	return r.InlineSchema != nil && !r.InlineSchema.IsEmpty()
+// isSchemaFile reports whether f is the rule's configured schema
+// file. The compose code path uses isSchemaFileAt against an
+// explicit path; this helper preserves the original single-source
+// convenience for callers and tests.
+func (r *Rule) isSchemaFile(f *lint.File) bool {
+	return r.isSchemaFileAt(f, r.Schema)
 }
 
 // isLikelyArchetypeName reports whether s looks like a bare archetype
@@ -182,7 +325,105 @@ func (r *Rule) SettingMergeMode(key string) rule.MergeMode {
 	if key == "path-patterns" {
 		return rule.MergeAppend
 	}
+	if key == "schema-sources" {
+		return rule.MergeAppend
+	}
 	return rule.MergeReplace
+}
+
+// TranslateLayerSettings implements rule.SettingsTranslator. It
+// collapses one config layer's user-facing `schema:` (file path)
+// or `inline-schema:` (map) keys into a single-entry
+// `schema-sources` list and strips the legacy keys. Because the
+// rule declares `schema-sources` as MergeAppend, layers that pass
+// through deep-merge then accumulate their sources instead of
+// scalar-replacing the previous layer — which is what lets a file
+// resolving to several kinds compose every kind's schema
+// (plan 156).
+//
+// Empty values (`schema: ""`, `inline-schema: {}`) are stripped
+// without contributing a source, so the rule's own DefaultSettings
+// `schema: ""` placeholder never pollutes the composed list. The
+// input map is treated as read-only; a new map is returned only
+// when a legacy key is present.
+func (r *Rule) TranslateLayerSettings(settings map[string]any) map[string]any {
+	source, hadKey := extractSchemaSourceFromSettings(settings)
+	if !hadKey {
+		return settings
+	}
+	out := cloneSettingsDeep(settings)
+	delete(out, "schema")
+	delete(out, "inline-schema")
+	if source != nil {
+		existing, _ := out["schema-sources"].([]any)
+		out["schema-sources"] = append(existing, source)
+	}
+	return out
+}
+
+// extractSchemaSourceFromSettings inspects a settings map for a
+// schema-source declaration. It returns (source, true) when either
+// legacy key is present — even if the value is empty / no-op — so
+// the caller strips the key; (nil, false) means no schema key
+// appears at all and the settings pass through untouched.
+func extractSchemaSourceFromSettings(s map[string]any) (any, bool) {
+	hadKey := false
+	if v, ok := s["schema"]; ok {
+		hadKey = true
+		if path, ok := v.(string); ok && path != "" {
+			return map[string]any{"file": path}, true
+		}
+	}
+	if v, ok := s["inline-schema"]; ok {
+		hadKey = true
+		if m, ok := v.(map[string]any); ok && len(m) > 0 {
+			return map[string]any{"inline": cloneSettingsDeep(m)}, true
+		}
+	}
+	if !hadKey {
+		return nil, false
+	}
+	return nil, true
+}
+
+// cloneSettingsDeep deep-copies a settings map so a translated
+// layer never aliases the caller's nested maps or slices.
+func cloneSettingsDeep(s map[string]any) map[string]any {
+	if s == nil {
+		return nil
+	}
+	out := make(map[string]any, len(s))
+	for k, v := range s {
+		out[k] = cloneSettingsValue(v)
+	}
+	return out
+}
+
+func cloneSettingsValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = cloneSettingsValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = cloneSettingsValue(e)
+		}
+		return out
+	case []string:
+		out := make([]string, len(x))
+		copy(out, x)
+		return out
+	case []int:
+		out := make([]int, len(x))
+		copy(out, x)
+		return out
+	default:
+		return v
+	}
 }
 
 // parsePathPatterns reads the `path-patterns` rule setting: a list of
@@ -239,7 +480,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 
 	// Warn when <?require?> appears in a non-schema file.
 	if reqLine := findRequireDirectiveLine(f); reqLine > 0 {
-		if !r.isSchemaFile(f) {
+		if !r.isAnySchemaFile(f) {
 			d := makeDiag(f.Path, reqLine,
 				"<?require?> is only recognized in schema files; this directive has no effect here")
 			d.Severity = lint.Warning
@@ -253,61 +494,149 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// on top of a `<?require filename:?>` directive.
 	diags = append(diags, r.checkPathPatterns(f)...)
 
-	if r.hasInlineSchema() {
-		return append(diags, r.checkInlineSchema(f)...)
-	}
-
-	if r.Schema == "" {
+	sources := r.effectiveSources()
+	if len(sources) == 0 {
 		return diags
 	}
 
-	return append(diags, r.checkFileSchema(f)...)
+	// Single-source: use the legacy paths so file schemas keep their
+	// heading- and body-sync features (`# {id}: {name}`, body lines
+	// under Meta-Information). Composition is irrelevant when only
+	// one source is configured.
+	if len(sources) == 1 {
+		src := sources[0]
+		if src.Inline != nil {
+			return append(diags, r.checkSingleInlineSchema(f, src.Inline)...)
+		}
+		if src.File != "" {
+			return append(diags, r.checkSingleFileSchema(f, src.File)...)
+		}
+		return diags
+	}
+
+	return append(diags, r.checkComposedSources(f, sources)...)
 }
 
-// checkInlineSchema runs the validator against the rule's parsed
-// inline schema. Inline schemas do not support frontmatter-body
-// {field} sync (no source body content) so the legacy syncPoints
-// code path is skipped.
-func (r *Rule) checkInlineSchema(f *lint.File) []lint.Diagnostic {
+// effectiveSources returns the rule's sources list, falling back to
+// a single-entry list built from the legacy Schema / InlineSchema
+// fields when Sources is empty. This lets tests drive the rule
+// directly with the older fields while still routing through the
+// new multi-source code path.
+func (r *Rule) effectiveSources() []SchemaSource {
+	if len(r.Sources) > 0 {
+		return r.Sources
+	}
+	if r.InlineSchema != nil && !r.InlineSchema.IsEmpty() {
+		return []SchemaSource{{Inline: r.InlineSchema}}
+	}
+	if r.Schema != "" {
+		return []SchemaSource{{File: r.Schema}}
+	}
+	return nil
+}
+
+// isAnySchemaFile reports whether f matches any of the configured
+// file sources. When a file plays the role of its own schema (e.g.
+// rule-readme's proto.md), the warning-on-misplaced-<?require?>
+// check must skip it.
+func (r *Rule) isAnySchemaFile(f *lint.File) bool {
+	for _, src := range r.effectiveSources() {
+		if src.File == "" {
+			continue
+		}
+		if r.isSchemaFileAt(f, src.File) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkSingleInlineSchema runs the validator against a single inline
+// schema. Inline schemas do not support frontmatter-body {field}
+// sync (no source body content) so the legacy syncPoints code path
+// is skipped.
+func (r *Rule) checkSingleInlineSchema(f *lint.File, sch *schema.Schema) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	docFMRaw, fmDiags := readDocFrontMatterRaw(f)
 	diags = append(diags, fmDiags...)
 	fmIsCUE := placeholders.HasCUEFrontmatter(r.Placeholders)
-	diags = append(diags, schema.Validate(f, r.InlineSchema, docFMRaw, fmIsCUE, makeDiag)...)
-	diags = append(diags, r.applyScopeRules(f, r.InlineSchema, docFMRaw)...)
-	diags = append(diags, schema.ValidateCrossReferences(f, r.InlineSchema, makeDiag)...)
-	diags = append(diags, schema.ValidateAcronyms(f, r.InlineSchema, docFMRaw, makeDiag)...)
-	diags = append(diags, schema.ValidateIndex(f, r.InlineSchema, makeDiag)...)
+	diags = append(diags, schema.Validate(f, sch, docFMRaw, fmIsCUE, makeDiag)...)
+	diags = append(diags, r.applyScopeRules(f, sch, docFMRaw)...)
+	diags = append(diags, schema.ValidateCrossReferences(f, sch, makeDiag)...)
+	diags = append(diags, schema.ValidateAcronyms(f, sch, docFMRaw, makeDiag)...)
+	diags = append(diags, schema.ValidateIndex(f, sch, makeDiag)...)
 	return diags
 }
 
 // Fix implements rule.FixableRule. The rule does not modify the
-// document body — it returns f.Source unchanged — but when the
-// inline schema declares an `index:` block, Fix emits the JSON
+// document body — it returns f.Source unchanged — but when any
+// configured inline schema (single-source or composed across
+// kinds) declares an `index:` block, Fix emits the JSON
 // side-output next to the source file. `mdsmith check` skips the
 // write, preserving check's read-only contract (plan 143).
 //
-// Fix swallows the WriteIndex error because Fix returns bytes, not
-// diagnostics. WriteIndex itself records any failure in the
-// package-level cache keyed by f.Path; the next Check reads that
-// cache and surfaces the underlying I/O error in place of the
-// generic "missing / out of date" message, so users are not
-// trapped in a fix loop without signal.
+// Fix swallows errors (composition and WriteIndex both). WriteIndex
+// itself records any I/O failure in the package-level cache keyed
+// by f.Path; the next Check reads that cache and surfaces the
+// underlying error in place of the generic "missing / out of date"
+// message, so users are not trapped in a fix loop without signal.
+// Composition errors are similarly swallowed — they re-surface on
+// the next Check pass through the same checkComposedSources path.
 func (r *Rule) Fix(f *lint.File) []byte {
-	if r.hasInlineSchema() && r.InlineSchema.Index != nil {
-		_ = schema.WriteIndex(f, r.InlineSchema)
+	sch, err := r.composedSchemaForFix(f)
+	if err == nil && sch != nil && !sch.IsEmpty() && sch.Index != nil {
+		_ = schema.WriteIndex(f, sch)
 	}
 	return f.Source
 }
 
-// checkFileSchema retains the legacy proto.md heading-template
+// composedSchemaForFix returns the same composed *schema.Schema
+// that checkComposedSources validates against — but without
+// running validation or body-sync (Fix doesn't need either).
+// Returns nil with no error when the rule has no schema source or
+// every source is empty / self-referential. A file source pointing
+// at the file currently being fixed is skipped so a schema
+// doesn't drive its own index side-output.
+func (r *Rule) composedSchemaForFix(f *lint.File) (*schema.Schema, error) {
+	sources := r.effectiveSources()
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	parsed := make([]*schema.Schema, 0, len(sources))
+	for _, src := range sources {
+		if src.Inline != nil {
+			if src.Inline.IsEmpty() {
+				continue
+			}
+			parsed = append(parsed, src.Inline)
+			continue
+		}
+		if src.File == "" {
+			continue
+		}
+		sch, err := r.parseFileSchemaForCompose(f, src.File)
+		if err != nil {
+			return nil, err
+		}
+		if sch == nil {
+			continue
+		}
+		parsed = append(parsed, sch)
+	}
+	if len(parsed) == 0 {
+		return nil, nil
+	}
+	return schema.Compose(parsed...)
+}
+
+// checkSingleFileSchema retains the legacy proto.md heading-template
 // validation path. It supports {field} sync points in headings and
 // body content; these features are tied to the source body of the
 // schema markdown and have no inline counterpart.
-func (r *Rule) checkFileSchema(f *lint.File) []lint.Diagnostic {
+func (r *Rule) checkSingleFileSchema(f *lint.File, schemaPath string) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 
-	schData, schPath, err := r.loadSchema(f)
+	schData, schPath, err := r.loadSchemaAt(f, schemaPath)
 	if err != nil {
 		return append(diags, r.diag(f.Path, 1, err.Error()))
 	}
@@ -315,11 +644,11 @@ func (r *Rule) checkFileSchema(f *lint.File) []lint.Diagnostic {
 	sch, err := parseSchema(schData, schPath, f.MaxInputBytes)
 	if err != nil {
 		return append(diags, r.diag(f.Path, 1,
-			fmt.Sprintf("invalid schema %q: %v", r.Schema, err)))
+			fmt.Sprintf("invalid schema %q: %v", schemaPath, err)))
 	}
 
 	// Skip the schema file itself when schemas come from disk.
-	if r.isSchemaFile(f) {
+	if r.isSchemaFileAt(f, schemaPath) {
 		return diags
 	}
 
@@ -351,24 +680,139 @@ func (r *Rule) checkFileSchema(f *lint.File) []lint.Diagnostic {
 	return diags
 }
 
-// loadSchema returns the schema bytes and resolution path.
-func (r *Rule) loadSchema(f *lint.File) ([]byte, string, error) {
-	data, err := readSchemaFile(f, r.Schema)
-	if err != nil {
-		return nil, "", fmt.Errorf("cannot read schema %q: %v", r.Schema, err)
+// checkComposedSources loads every source, composes them via
+// schema.Compose, and validates the document against the composed
+// schema. Each FILE source ALSO runs the legacy heading- and
+// body-sync check (proto.md `# {id}: {name}` and Meta-Information
+// body lines) — composition cannot express those checks today, so
+// per-source legacy validation preserves them. Sources that name a
+// file the rule is currently linting are skipped (self-validation).
+func (r *Rule) checkComposedSources(f *lint.File, sources []SchemaSource) []lint.Diagnostic {
+	var diags []lint.Diagnostic
+	docFMRaw, fmDiags := readDocFrontMatterRaw(f)
+	diags = append(diags, fmDiags...)
+
+	parsed := make([]*schema.Schema, 0, len(sources))
+	for _, src := range sources {
+		if src.Inline != nil {
+			if src.Inline.IsEmpty() {
+				continue
+			}
+			parsed = append(parsed, src.Inline)
+			continue
+		}
+		if src.File == "" {
+			continue
+		}
+		// Per-source legacy body-sync. Loads via the legacy parser so
+		// proto.md-style {field} interpolation and Meta-Information
+		// body sync still fire for each file source.
+		if !r.isSchemaFileAt(f, src.File) {
+			diags = append(diags, r.bodySyncDiagnostics(f, src.File, docFMRaw)...)
+		}
+		sch, err := r.parseFileSchemaForCompose(f, src.File)
+		if err != nil {
+			diags = append(diags, r.diag(f.Path, 1, err.Error()))
+			continue
+		}
+		if sch == nil {
+			// f was the schema itself — skip its composition entry.
+			continue
+		}
+		parsed = append(parsed, sch)
 	}
-	return data, r.Schema, nil
+
+	if len(parsed) == 0 {
+		return diags
+	}
+
+	composed, err := schema.Compose(parsed...)
+	if err != nil {
+		return append(diags, r.diag(f.Path, 1,
+			fmt.Sprintf("composing schemas: %v", err)))
+	}
+	// composed is non-nil here: parsed contains at least one
+	// non-nil schema (the empty-source filter above guarantees it),
+	// and schema.Compose returns its single input unchanged when
+	// len(parsed) == 1. IsEmpty() can still hold when every parsed
+	// schema was itself empty (e.g. a proto.md with no headings).
+	if composed.IsEmpty() {
+		return diags
+	}
+
+	fmIsCUE := placeholders.HasCUEFrontmatter(r.Placeholders)
+	diags = append(diags, schema.Validate(f, composed, docFMRaw, fmIsCUE, makeDiag)...)
+	diags = append(diags, r.applyScopeRules(f, composed, docFMRaw)...)
+	diags = append(diags, schema.ValidateCrossReferences(f, composed, makeDiag)...)
+	diags = append(diags, schema.ValidateAcronyms(f, composed, docFMRaw, makeDiag)...)
+	diags = append(diags, schema.ValidateIndex(f, composed, makeDiag)...)
+	return diags
 }
 
-// isSchemaFile reports whether f is the configured schema file. It
-// normalizes f.Path against f.RootDir so the check still succeeds when
-// mdsmith runs from a subdirectory while `schema:` paths remain
-// project-root-relative.
-func (r *Rule) isSchemaFile(f *lint.File) bool {
-	if r.Schema == "" {
+// parseFileSchemaForCompose loads a proto.md file source via the
+// unified schema.ParseFile parser so the result composes with inline
+// schemas. Returns (nil, nil) when f is the schema file itself —
+// the caller skips that entry so a schema doesn't validate against
+// itself.
+func (r *Rule) parseFileSchemaForCompose(f *lint.File, schemaPath string) (*schema.Schema, error) {
+	if r.isSchemaFileAt(f, schemaPath) {
+		return nil, nil
+	}
+	reader := &schema.FileReader{
+		RootFS:   f.RootFS,
+		RootDir:  f.RootDir,
+		MaxBytes: f.MaxInputBytes,
+	}
+	sch, err := schema.ParseFile(reader, schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load schema %q: %v", schemaPath, err)
+	}
+	return sch, nil
+}
+
+// bodySyncDiagnostics runs only the heading- and body-sync portion
+// of the legacy file-schema check for a single file source. The
+// composed structure validation runs separately; calling
+// checkSingleFileSchema here would double-report missing-section
+// and frontmatter-CUE diagnostics.
+func (r *Rule) bodySyncDiagnostics(f *lint.File, schemaPath string, docFMRaw map[string]any) []lint.Diagnostic {
+	var diags []lint.Diagnostic
+	if len(docFMRaw) == 0 {
+		return diags
+	}
+	data, _, err := r.loadSchemaAt(f, schemaPath)
+	if err != nil {
+		return append(diags, r.diag(f.Path, 1, err.Error()))
+	}
+	sch, err := parseSchema(data, schemaPath, f.MaxInputBytes)
+	if err != nil {
+		// The compose path reports schema-parse errors separately;
+		// avoid duplicating them here.
+		return diags
+	}
+	docHeadings := extractHeadings(f)
+	return append(diags, checkSync(f, sch, docHeadings, docFMRaw)...)
+}
+
+// loadSchemaAt reads the named schema file using the file's RootFS
+// when configured, falling back to the OS filesystem.
+func (r *Rule) loadSchemaAt(f *lint.File, schemaPath string) ([]byte, string, error) {
+	data, err := readSchemaFile(f, schemaPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot read schema %q: %v", schemaPath, err)
+	}
+	return data, schemaPath, nil
+}
+
+// isSchemaFileAt reports whether f is the schema file at the named
+// path. It normalizes f.Path against f.RootDir so the check still
+// succeeds when mdsmith runs from a subdirectory while `schema:`
+// paths remain project-root-relative.
+func (r *Rule) isSchemaFileAt(f *lint.File, schemaPath string) bool {
+	if schemaPath == "" {
 		return false
 	}
-	if isSchemaFile(f.Path, r.Schema) {
+	if isSchemaFile(f.Path, schemaPath) {
 		return true
 	}
 	if f.RootDir == "" {
@@ -379,7 +823,7 @@ func (r *Rule) isSchemaFile(f *lint.File) bool {
 	if err != nil {
 		return false
 	}
-	return isSchemaFile(rel, r.Schema)
+	return isSchemaFile(rel, schemaPath)
 }
 
 func (r *Rule) diag(file string, line int, msg string) lint.Diagnostic {
@@ -395,9 +839,10 @@ func (r *Rule) diag(file string, line int, msg string) lint.Diagnostic {
 }
 
 var (
-	_ rule.Configurable = (*Rule)(nil)
-	_ rule.ListMerger   = (*Rule)(nil)
-	_ rule.FixableRule  = (*Rule)(nil)
+	_ rule.Configurable       = (*Rule)(nil)
+	_ rule.ListMerger         = (*Rule)(nil)
+	_ rule.FixableRule        = (*Rule)(nil)
+	_ rule.SettingsTranslator = (*Rule)(nil)
 )
 
 // schemaConfig holds the parsed schema frontmatter.

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -347,6 +347,16 @@ func (r *Rule) SettingMergeMode(key string) rule.MergeMode {
 // input map is treated as read-only; a new map is returned only
 // when a legacy key is present.
 func (r *Rule) TranslateLayerSettings(settings map[string]any) map[string]any {
+	// A single layer that sets BOTH a non-empty `schema:` and a
+	// non-empty `inline-schema:` is a config error. Pass the layer
+	// through untouched so the keys survive deep-merge and the
+	// rule's own rejectDualSchemaSettings (run from ApplySettings)
+	// still surfaces the original error — stripping them here would
+	// silently drop the inline source. Cross-layer composition is
+	// unaffected: this only fires when one map carries both.
+	if hasDualSchemaSource(settings) {
+		return settings
+	}
 	source, hadKey := extractSchemaSourceFromSettings(settings)
 	if !hadKey {
 		return settings
@@ -359,6 +369,17 @@ func (r *Rule) TranslateLayerSettings(settings map[string]any) map[string]any {
 		out["schema-sources"] = append(existing, source)
 	}
 	return out
+}
+
+// hasDualSchemaSource reports whether one settings map sets both a
+// non-empty `schema:` path and a non-empty `inline-schema:` map.
+// It mirrors rejectDualSchemaSettings' non-empty semantics so the
+// translator and the rule's guard agree on what counts as a
+// dual-source layer.
+func hasDualSchemaSource(s map[string]any) bool {
+	path, _ := s["schema"].(string)
+	inline, _ := s["inline-schema"].(map[string]any)
+	return path != "" && len(inline) > 0
 }
 
 // extractSchemaSourceFromSettings inspects a settings map for a

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2074,3 +2074,87 @@ id: 'int & >=1'
 	expectDiagMsg(t, diags, "id: got <missing>")
 	expectDiagMsg(t, diags, "expected int >= 1")
 }
+
+// TestIsLikelyArchetypeName_AllBranches gives the helper direct
+// coverage of every branch. Previously it was only exercised
+// indirectly through ApplySettings, so test churn elsewhere
+// silently dropped its coverage (the recurring codecov/changes
+// signal). A dedicated table keeps it pinned.
+func TestIsLikelyArchetypeName_AllBranches(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"forward slash path", "schemas/story.md", false},
+		{"forward slash, no ext", "schemas/story", false},
+		{"backslash path", `schemas\story`, false},
+		{"has extension", "story.md", false},
+		{"dotfile-style extension", "story.proto.md", false},
+		{"bare name no ext no slash", "story", true},
+		{"bare name with dash", "rule-readme", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isLikelyArchetypeName(tc.in))
+		})
+	}
+}
+
+// TestExtractSchemaSourceFromSettings_AllBranches replaces the
+// removed rulesDeclareSchema's branch coverage. The schema-source
+// detection logic moved here during the SettingsTranslator
+// refactor; this table exercises every return path directly
+// instead of relying on TranslateLayerSettings call sites.
+func TestExtractSchemaSourceFromSettings_AllBranches(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      map[string]any
+		wantSrc any
+		wantKey bool
+	}{
+		{"no schema keys", map[string]any{"placeholders": []any{"x"}}, nil, false},
+		{"empty settings", map[string]any{}, nil, false},
+		{"schema non-empty string", map[string]any{"schema": "schemas/a.md"},
+			map[string]any{"file": "schemas/a.md"}, true},
+		{"schema empty string", map[string]any{"schema": ""}, nil, true},
+		{"schema wrong type", map[string]any{"schema": 42}, nil, true},
+		{"inline-schema non-empty map", map[string]any{"inline-schema": map[string]any{
+			"sections": []any{map[string]any{"heading": "X"}},
+		}}, map[string]any{"inline": map[string]any{
+			"sections": []any{map[string]any{"heading": "X"}},
+		}}, true},
+		{"inline-schema empty map",
+			map[string]any{"inline-schema": map[string]any{}}, nil, true},
+		{"inline-schema wrong type",
+			map[string]any{"inline-schema": "not-a-map"}, nil, true},
+		{"schema wins over inline (file first)", map[string]any{
+			"schema":        "a.md",
+			"inline-schema": map[string]any{"sections": []any{}},
+		}, map[string]any{"file": "a.md"}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src, hadKey := extractSchemaSourceFromSettings(tc.in)
+			assert.Equal(t, tc.wantSrc, src)
+			assert.Equal(t, tc.wantKey, hadKey)
+		})
+	}
+}
+
+// TestExtractSchemaSourceFromSettings_InlineDeepCopied verifies the
+// extracted inline source does not alias the caller's nested maps,
+// so a later layer mutation cannot reach the captured schema.
+func TestExtractSchemaSourceFromSettings_InlineDeepCopied(t *testing.T) {
+	inline := map[string]any{"sections": []any{
+		map[string]any{"heading": "Goal"},
+	}}
+	src, _ := extractSchemaSourceFromSettings(
+		map[string]any{"inline-schema": inline})
+	got := src.(map[string]any)["inline"].(map[string]any)
+	inline["sections"].([]any)[0].(map[string]any)["heading"] = "MUT"
+	sec := got["sections"].([]any)[0].(map[string]any)
+	assert.Equal(t, "Goal", sec["heading"],
+		"extracted inline source must not alias the input map")
+}

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -1,0 +1,439 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Compose merges multiple schemas into one. The composed schema's
+// frontmatter constraints are the union of each input's keys; for keys
+// declared in more than one input, the CUE expressions are conjoined
+// with `&` so a value must satisfy every constraint. Sections are
+// merged so that scopes sharing the same heading label combine their
+// child sections recursively; remaining scopes append in input order.
+// The stricter `closed:` wins (any input that sets Closed=true makes
+// the composed scope closed) and the stricter cardinality wins (a
+// section required by any input is required in the result). Filename
+// uses the first non-empty value; conflicting patterns cause an error
+// so the caller surfaces a clear diagnostic rather than silently
+// ignoring one constraint. Acronyms, CrossReferences, and Index slots
+// are joined from inputs that declare them; conflicts on Index.Output
+// return an error.
+//
+// Compose returns nil when given no inputs. With a single non-nil
+// input it returns that input unchanged.
+func Compose(schemas ...*Schema) (*Schema, error) {
+	nonNil := make([]*Schema, 0, len(schemas))
+	for _, s := range schemas {
+		if s == nil {
+			continue
+		}
+		nonNil = append(nonNil, s)
+	}
+	if len(nonNil) == 0 {
+		return nil, nil
+	}
+	if len(nonNil) == 1 {
+		return nonNil[0], nil
+	}
+
+	rootLevel, err := composedRootLevel(nonNil)
+	if err != nil {
+		return nil, err
+	}
+	out := &Schema{
+		Source:    composedSourceLabel(nonNil),
+		RootLevel: rootLevel,
+	}
+
+	composeFrontmatter(out, nonNil)
+	if err := composeFilename(out, nonNil); err != nil {
+		return nil, err
+	}
+	composeRootClosed(out, nonNil)
+	out.Sections = composeSectionLists(extractRootSections(nonNil))
+	out.CrossReferences = composeCrossRefs(nonNil)
+	composeAcronyms(out, nonNil)
+	if err := composeIndex(out, nonNil); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// composedRootLevel reports the heading level the composed
+// section list should sit at. Every input must agree on the
+// effective root level — mixing an inline schema (RootLevel=2,
+// H1 owned by the title) with a file-based proto.md that wraps
+// its sections in an H1 wildcard (RootLevel=1) would cause the
+// validator's section walk to start at the wrong depth for one
+// of the inputs. Surface the conflict as a config error so the
+// caller sees a clear message instead of silently mis-validated
+// headings.
+func composedRootLevel(schemas []*Schema) (int, error) {
+	root := schemas[0].EffectiveRootLevel()
+	for _, s := range schemas[1:] {
+		if s.EffectiveRootLevel() != root {
+			return 0, fmt.Errorf(
+				"composed schemas disagree on root heading level: "+
+					"%q starts at h%d, %q starts at h%d — every source "+
+					"must declare the same root level (typically the "+
+					"H1 wildcard `# ?` for file-based schemas, H2 for "+
+					"inline)",
+				schemas[0].Source, root,
+				s.Source, s.EffectiveRootLevel())
+		}
+	}
+	return root, nil
+}
+
+func composedSourceLabel(schemas []*Schema) string {
+	parts := make([]string, 0, len(schemas))
+	for _, s := range schemas {
+		if s.Source == "" {
+			continue
+		}
+		parts = append(parts, s.Source)
+	}
+	if len(parts) == 0 {
+		return "composed"
+	}
+	return "composed(" + strings.Join(parts, ", ") + ")"
+}
+
+func composeFrontmatter(out *Schema, schemas []*Schema) {
+	for _, s := range schemas {
+		for k, expr := range s.Frontmatter {
+			if out.Frontmatter == nil {
+				out.Frontmatter = map[string]string{}
+			}
+			existing, ok := out.Frontmatter[k]
+			if !ok {
+				out.Frontmatter[k] = expr
+				continue
+			}
+			if existing == expr {
+				continue
+			}
+			out.Frontmatter[k] = "(" + existing + ") & (" + expr + ")"
+		}
+	}
+}
+
+func composeFilename(out *Schema, schemas []*Schema) error {
+	for _, s := range schemas {
+		if s.Filename == "" {
+			continue
+		}
+		if out.Filename == "" {
+			out.Filename = s.Filename
+			continue
+		}
+		if out.Filename != s.Filename {
+			return fmt.Errorf(
+				"conflicting filename patterns across "+
+					"composed schemas: %q and %q",
+				out.Filename, s.Filename)
+		}
+	}
+	return nil
+}
+
+func composeRootClosed(out *Schema, schemas []*Schema) {
+	for _, s := range schemas {
+		if s.Closed {
+			out.Closed = true
+			return
+		}
+	}
+}
+
+func extractRootSections(schemas []*Schema) [][]Scope {
+	out := make([][]Scope, 0, len(schemas))
+	for _, s := range schemas {
+		out = append(out, s.Sections)
+	}
+	return out
+}
+
+// composeSectionLists merges multiple parallel section lists into
+// one. Scopes that share a heading label (canMergeByHeading) are
+// merged recursively — their child sections compose. The
+// no-identity shapes (the `## ...` wildcard slot, the bare `?`
+// matcher, the preamble) append in input order so each stays
+// distinct. A field-interpolated label like `{id}: {name}` is a
+// stable identity and DOES merge, so two proto.md sources that
+// each wrap their sections in the same H1 yield one combined H1
+// scope rather than requiring two H1s in the document.
+func composeSectionLists(lists [][]Scope) []Scope {
+	var out []Scope
+	indexByHeading := map[string]int{}
+	for _, list := range lists {
+		seenPreambleInList := false
+		for _, sc := range list {
+			if sc.Preamble {
+				if seenPreambleInList {
+					// A list can have at most one preamble at index
+					// 0; defensively skip duplicates.
+					continue
+				}
+				seenPreambleInList = true
+				if existing := findPreambleIndex(out); existing >= 0 {
+					out[existing] = mergeScopes(out[existing], sc)
+					continue
+				}
+				// Preamble must be first in any list. Prepend on the
+				// composed list so the invariant survives.
+				out = append([]Scope{sc}, out...)
+				// Shift existing heading indices.
+				for k, v := range indexByHeading {
+					indexByHeading[k] = v + 1
+				}
+				continue
+			}
+			if !canMergeByHeading(sc) {
+				out = append(out, cloneScope(sc))
+				continue
+			}
+			if idx, ok := indexByHeading[sc.Heading]; ok {
+				out[idx] = mergeScopes(out[idx], sc)
+				continue
+			}
+			indexByHeading[sc.Heading] = len(out)
+			out = append(out, cloneScope(sc))
+		}
+	}
+	return out
+}
+
+func findPreambleIndex(list []Scope) int {
+	for i, sc := range list {
+		if sc.Preamble {
+			return i
+		}
+	}
+	return -1
+}
+
+// canMergeByHeading reports whether a scope has a stable identity
+// that supports merging across composed inputs. Scopes merge by
+// their heading label (including field-interpolated patterns: two
+// schemas that both wrap their sections in `# {id}: {name}`
+// describe the same H1, so the validator must see one combined
+// scope). The no-identity shapes — the `## ...` wildcard slot, the
+// bare `?` any-heading matcher, and the preamble — never merge:
+// each must stay distinct so it independently absorbs the
+// surrounding content the author intended.
+func canMergeByHeading(sc Scope) bool {
+	if sc.Preamble {
+		return false
+	}
+	h := strings.TrimSpace(sc.Heading)
+	if h == "" || h == "?" || h == SectionWildcard {
+		return false
+	}
+	return true
+}
+
+// mergeScopes combines two scopes that share a heading label. The
+// result keeps the first scope's heading label; Closed takes the
+// stricter value (true wins) and the Matcher's cardinality takes
+// the stricter value (a section required by either input is
+// required in the result). Child sections and per-scope rule
+// overrides compose by the same rules as the root; positional
+// Content constraints concatenate in input order.
+func mergeScopes(a, b Scope) Scope {
+	out := cloneScope(a)
+	if b.Closed {
+		out.Closed = true
+	}
+	out.Matcher = mergeMatcher(a.Matcher, b.Matcher)
+	out.Sections = composeSectionLists([][]Scope{a.Sections, b.Sections})
+	// Rules: union by rule name; later input wins on key collisions.
+	// The schema-rule walker is the only consumer, and its semantics
+	// are already "later overrides earlier" within a single scope.
+	out.Rules = mergeScopeRules(a.Rules, b.Rules)
+	out.Content = append(cloneContent(a.Content), cloneContent(b.Content)...)
+	return out
+}
+
+// mergeMatcher combines two matchers for scopes that share a
+// heading label. In practice both matchers derive from the same
+// heading text, so their Regex bodies are identical; the function
+// keeps the first scope's Regex and folds the stricter cardinality
+// in. "Stricter" means a section required by either input is
+// required in the result (the larger minimum), and the run length
+// is the more permissive of the two maxima so composition never
+// makes a satisfiable document impossible. Sequential is OR-ed.
+func mergeMatcher(a, b *Matcher) *Matcher {
+	if a == nil {
+		return cloneMatcher(b)
+	}
+	if b == nil {
+		return cloneMatcher(a)
+	}
+	out := *a
+	out.Sequential = a.Sequential || b.Sequential
+	aMin, aMax := a.Repeat.Bounds()
+	bMin, bMax := b.Repeat.Bounds()
+	min := aMin
+	if bMin > min {
+		min = bMin
+	}
+	var max int // 0 == unbounded
+	if aMax != 0 && bMax != 0 {
+		max = aMax
+		if bMax > max {
+			max = bMax
+		}
+	}
+	if min == 1 && max == 1 {
+		out.Repeat = Repeat{}
+	} else {
+		out.Repeat = Repeat{Set: true, Min: min, Max: max}
+	}
+	return &out
+}
+
+func cloneMatcher(m *Matcher) *Matcher {
+	if m == nil {
+		return nil
+	}
+	c := *m
+	return &c
+}
+
+func cloneContent(c []ContentEntry) []ContentEntry {
+	if len(c) == 0 {
+		return nil
+	}
+	out := make([]ContentEntry, len(c))
+	for i, e := range c {
+		out[i] = e
+		if e.Columns != nil {
+			out[i].Columns = append([]string(nil), e.Columns...)
+		}
+	}
+	return out
+}
+
+func unionStrings(a, b []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(a)+len(b))
+	for _, list := range [][]string{a, b} {
+		for _, s := range list {
+			if seen[s] {
+				continue
+			}
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mergeScopeRules(
+	a, b map[string]map[string]any,
+) map[string]map[string]any {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]any, len(a)+len(b))
+	for k, v := range a {
+		out[k] = cloneSettingsMap(v)
+	}
+	for k, v := range b {
+		out[k] = cloneSettingsMap(v)
+	}
+	return out
+}
+
+func cloneScope(sc Scope) Scope {
+	out := sc
+	out.Matcher = cloneMatcher(sc.Matcher)
+	if sc.Sections != nil {
+		out.Sections = make([]Scope, len(sc.Sections))
+		for i, child := range sc.Sections {
+			out.Sections[i] = cloneScope(child)
+		}
+	}
+	if sc.Rules != nil {
+		out.Rules = make(map[string]map[string]any, len(sc.Rules))
+		for k, v := range sc.Rules {
+			out.Rules[k] = cloneSettingsMap(v)
+		}
+	}
+	out.Content = cloneContent(sc.Content)
+	return out
+}
+
+func cloneSettingsMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func composeCrossRefs(schemas []*Schema) []CrossRef {
+	var out []CrossRef
+	for _, s := range schemas {
+		out = append(out, s.CrossReferences...)
+	}
+	return out
+}
+
+// composeAcronyms unions KnownSafe entries across inputs. Scope
+// follows the inverse rule: an empty Scope means "document-wide",
+// so once any input declares Acronyms with no Scope restriction
+// the composed Scope becomes nil (document-wide) — narrowing it
+// to another input's restricted list would silently weaken the
+// document-wide check the first input asked for. Two restricted
+// inputs union their Scope lists.
+func composeAcronyms(out *Schema, schemas []*Schema) {
+	scopeWidened := false
+	for _, s := range schemas {
+		if s.Acronyms == nil {
+			continue
+		}
+		if out.Acronyms == nil {
+			out.Acronyms = &AcronymRule{}
+		}
+		out.Acronyms.KnownSafe = unionStrings(out.Acronyms.KnownSafe, s.Acronyms.KnownSafe)
+		if scopeWidened {
+			continue
+		}
+		if len(s.Acronyms.Scope) == 0 {
+			scopeWidened = true
+			out.Acronyms.Scope = nil
+			continue
+		}
+		out.Acronyms.Scope = unionStrings(out.Acronyms.Scope, s.Acronyms.Scope)
+	}
+}
+
+func composeIndex(out *Schema, schemas []*Schema) error {
+	for _, s := range schemas {
+		if s.Index == nil {
+			continue
+		}
+		if out.Index == nil {
+			out.Index = &IndexSpec{Output: s.Index.Output}
+			out.Index.Include = append([]string(nil), s.Index.Include...)
+			continue
+		}
+		if out.Index.Output != s.Index.Output {
+			return fmt.Errorf(
+				"conflicting schema.index.output values across "+
+					"composed schemas: %q and %q",
+				out.Index.Output, s.Index.Output)
+		}
+		out.Index.Include = unionStrings(out.Index.Include, s.Index.Include)
+	}
+	return nil
+}

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -12,11 +12,12 @@ import (
 // merged so that scopes sharing the same heading label combine their
 // child sections recursively; remaining scopes append in input order.
 // The stricter `closed:` wins (any input that sets Closed=true makes
-// the composed scope closed) and the stricter cardinality wins (a
-// section required by any input is required in the result). Filename
-// uses the first non-empty value; conflicting patterns cause an error
-// so the caller surfaces a clear diagnostic rather than silently
-// ignoring one constraint. Acronyms, CrossReferences, and Index slots
+// the composed scope closed) and the cardinality intersects (the
+// composed run length must satisfy every input; disjoint ranges have
+// an empty intersection and return an error). Filename uses the first
+// non-empty value; conflicting patterns cause an error so the caller
+// surfaces a clear diagnostic rather than silently ignoring one
+// constraint. Acronyms, CrossReferences, and Index slots
 // are joined from inputs that declare them; conflicts on Index.Output
 // return an error.
 //
@@ -51,7 +52,10 @@ func Compose(schemas ...*Schema) (*Schema, error) {
 		return nil, err
 	}
 	composeRootClosed(out, nonNil)
-	out.Sections = composeSectionLists(extractRootSections(nonNil))
+	out.Sections, err = composeSectionLists(extractRootSections(nonNil))
+	if err != nil {
+		return nil, err
+	}
 	out.CrossReferences = composeCrossRefs(nonNil)
 	composeAcronyms(out, nonNil)
 	if err := composeIndex(out, nonNil); err != nil {
@@ -164,45 +168,77 @@ func extractRootSections(schemas []*Schema) [][]Scope {
 // stable identity and DOES merge, so two proto.md sources that
 // each wrap their sections in the same H1 yield one combined H1
 // scope rather than requiring two H1s in the document.
-func composeSectionLists(lists [][]Scope) []Scope {
-	var out []Scope
-	indexByHeading := map[string]int{}
+func composeSectionLists(lists [][]Scope) ([]Scope, error) {
+	acc := &sectionAcc{indexByHeading: map[string]int{}}
 	for _, list := range lists {
-		seenPreambleInList := false
+		seenPreamble := false
 		for _, sc := range list {
-			if sc.Preamble {
-				if seenPreambleInList {
-					// A list can have at most one preamble at index
-					// 0; defensively skip duplicates.
-					continue
-				}
-				seenPreambleInList = true
-				if existing := findPreambleIndex(out); existing >= 0 {
-					out[existing] = mergeScopes(out[existing], sc)
-					continue
-				}
-				// Preamble must be first in any list. Prepend on the
-				// composed list so the invariant survives.
-				out = append([]Scope{sc}, out...)
-				// Shift existing heading indices.
-				for k, v := range indexByHeading {
-					indexByHeading[k] = v + 1
-				}
+			switch {
+			case sc.Preamble && seenPreamble:
+				// A list can have at most one preamble at index 0;
+				// defensively skip duplicates.
 				continue
+			case sc.Preamble:
+				seenPreamble = true
+				if err := acc.addPreamble(sc); err != nil {
+					return nil, err
+				}
+			default:
+				if err := acc.addNamed(sc); err != nil {
+					return nil, err
+				}
 			}
-			if !canMergeByHeading(sc) {
-				out = append(out, cloneScope(sc))
-				continue
-			}
-			if idx, ok := indexByHeading[sc.Heading]; ok {
-				out[idx] = mergeScopes(out[idx], sc)
-				continue
-			}
-			indexByHeading[sc.Heading] = len(out)
-			out = append(out, cloneScope(sc))
 		}
 	}
-	return out
+	return acc.out, nil
+}
+
+// sectionAcc accumulates composed scopes while tracking where each
+// mergeable heading landed, so a later input's same-heading scope
+// folds into the earlier one instead of duplicating.
+type sectionAcc struct {
+	out            []Scope
+	indexByHeading map[string]int
+}
+
+// addPreamble folds a preamble into the existing one or prepends it.
+// A preamble must lead the composed list, so prepending shifts every
+// recorded heading index by one to keep them valid.
+func (a *sectionAcc) addPreamble(sc Scope) error {
+	if existing := findPreambleIndex(a.out); existing >= 0 {
+		return a.mergeAt(existing, sc)
+	}
+	a.out = append([]Scope{sc}, a.out...)
+	for k, v := range a.indexByHeading {
+		a.indexByHeading[k] = v + 1
+	}
+	return nil
+}
+
+// addNamed appends a no-identity scope verbatim, merges a repeated
+// stable heading into its first occurrence, or records a new one.
+func (a *sectionAcc) addNamed(sc Scope) error {
+	if !canMergeByHeading(sc) {
+		a.out = append(a.out, cloneScope(sc))
+		return nil
+	}
+	if idx, ok := a.indexByHeading[sc.Heading]; ok {
+		return a.mergeAt(idx, sc)
+	}
+	a.indexByHeading[sc.Heading] = len(a.out)
+	a.out = append(a.out, cloneScope(sc))
+	return nil
+}
+
+// mergeAt merges sc into a.out[idx] in place, propagating any
+// composition error.
+func (a *sectionAcc) mergeAt(idx int, sc Scope) error {
+	merged, err := mergeScopes(a.out[idx], sc)
+	if err != nil {
+		return err
+	}
+	a.out[idx] = merged
+	return nil
 }
 
 func findPreambleIndex(list []Scope) int {
@@ -236,40 +272,51 @@ func canMergeByHeading(sc Scope) bool {
 
 // mergeScopes combines two scopes that share a heading label. The
 // result keeps the first scope's heading label; Closed takes the
-// stricter value (true wins) and the Matcher's cardinality takes
-// the stricter value (a section required by either input is
-// required in the result). Child sections and per-scope rule
-// overrides compose by the same rules as the root; positional
-// Content constraints concatenate in input order.
-func mergeScopes(a, b Scope) Scope {
+// stricter value (true wins) and the Matcher's cardinality is the
+// intersection of both inputs' run-length ranges (disjoint ranges
+// return an error). Child sections and per-scope rule overrides
+// compose by the same rules as the root; positional Content
+// constraints concatenate in input order.
+func mergeScopes(a, b Scope) (Scope, error) {
 	out := cloneScope(a)
 	if b.Closed {
 		out.Closed = true
 	}
-	out.Matcher = mergeMatcher(a.Matcher, b.Matcher)
-	out.Sections = composeSectionLists([][]Scope{a.Sections, b.Sections})
+	m, err := mergeMatcher(a.Matcher, b.Matcher)
+	if err != nil {
+		return Scope{}, err
+	}
+	out.Matcher = m
+	out.Sections, err = composeSectionLists([][]Scope{a.Sections, b.Sections})
+	if err != nil {
+		return Scope{}, err
+	}
 	// Rules: union by rule name; later input wins on key collisions.
 	// The schema-rule walker is the only consumer, and its semantics
 	// are already "later overrides earlier" within a single scope.
 	out.Rules = mergeScopeRules(a.Rules, b.Rules)
 	out.Content = append(cloneContent(a.Content), cloneContent(b.Content)...)
-	return out
+	return out, nil
 }
 
 // mergeMatcher combines two matchers for scopes that share a
 // heading label. In practice both matchers derive from the same
 // heading text, so their Regex bodies are identical; the function
-// keeps the first scope's Regex and folds the stricter cardinality
-// in. "Stricter" means a section required by either input is
-// required in the result (the larger minimum), and the run length
-// is the more permissive of the two maxima so composition never
-// makes a satisfiable document impossible. Sequential is OR-ed.
-func mergeMatcher(a, b *Matcher) *Matcher {
+// keeps the first scope's Regex and intersects the cardinality so
+// the composed run length satisfies every input. The minimum is
+// the larger of the two (a section required by either input is
+// required in the result) and the maximum is the smaller of the
+// two, treating 0 as unbounded so an unbounded side never loosens
+// a bounded one. Disjoint ranges (e.g. 1..3 and 5..10) have an
+// empty intersection: no document can satisfy both, so they return
+// an error, mirroring how conflicting filename patterns surface
+// rather than silently honoring one input. Sequential is OR-ed.
+func mergeMatcher(a, b *Matcher) (*Matcher, error) {
 	if a == nil {
-		return cloneMatcher(b)
+		return cloneMatcher(b), nil
 	}
 	if b == nil {
-		return cloneMatcher(a)
+		return cloneMatcher(a), nil
 	}
 	out := *a
 	out.Sequential = a.Sequential || b.Sequential
@@ -279,19 +326,46 @@ func mergeMatcher(a, b *Matcher) *Matcher {
 	if bMin > min {
 		min = bMin
 	}
-	var max int // 0 == unbounded
-	if aMax != 0 && bMax != 0 {
-		max = aMax
-		if bMax > max {
-			max = bMax
-		}
+	max := intersectMax(aMax, bMax)
+	if max != 0 && min > max {
+		return nil, fmt.Errorf(
+			"composed schemas declare disjoint cardinality for a "+
+				"section: one input allows %s, another allows %s — "+
+				"the intersection is empty so no document satisfies "+
+				"both",
+			boundsLabel(aMin, aMax), boundsLabel(bMin, bMax))
 	}
 	if min == 1 && max == 1 {
 		out.Repeat = Repeat{}
 	} else {
 		out.Repeat = Repeat{Set: true, Min: min, Max: max}
 	}
-	return &out
+	return &out, nil
+}
+
+// intersectMax returns the stricter (smaller) of two run-length
+// maxima, where 0 means unbounded. An unbounded side yields the
+// other's bound so it never loosens a bounded constraint.
+func intersectMax(a, b int) int {
+	switch {
+	case a == 0:
+		return b
+	case b == 0:
+		return a
+	case a < b:
+		return a
+	default:
+		return b
+	}
+}
+
+// boundsLabel renders a (min, max) cardinality pair for error
+// messages; a 0 max prints as "unbounded".
+func boundsLabel(min, max int) string {
+	if max == 0 {
+		return fmt.Sprintf("%d..unbounded", min)
+	}
+	return fmt.Sprintf("%d..%d", min, max)
 }
 
 func cloneMatcher(m *Matcher) *Matcher {

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -1,0 +1,607 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lit builds a literal exact-match scope (the `heading: "X"` sugar):
+// a matcher whose regex is the text and whose cardinality is exactly
+// one — i.e. a required section.
+func lit(text string) Scope {
+	return Scope{Heading: text, Matcher: &Matcher{Regex: text}}
+}
+
+// slot builds a `## ...` wildcard scope: any heading, zero or more.
+func slot() Scope {
+	return Scope{
+		Heading: SectionWildcard,
+		Matcher: &Matcher{Regex: ".+", Repeat: Repeat{Set: true, Min: 0}},
+	}
+}
+
+func TestCompose_NilInputs(t *testing.T) {
+	out, err := Compose()
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = Compose(nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestCompose_SingleInputReturnedUnchanged(t *testing.T) {
+	in := &Schema{Source: "a", Sections: []Scope{lit("Goal")}}
+	out, err := Compose(in)
+	require.NoError(t, err)
+	assert.Same(t, in, out)
+}
+
+// TestCompose_DisjointRequiredSections is acceptance criterion #1: a
+// file resolving to two kinds with disjoint required sections must
+// require both. Kind A requires Goal; kind B requires Risks.
+func TestCompose_DisjointRequiredSections(t *testing.T) {
+	a := &Schema{Sections: []Scope{lit("Goal")}}
+	b := &Schema{Sections: []Scope{lit("Risks")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 2)
+	assert.Equal(t, "Goal", out.Sections[0].Heading)
+	assert.True(t, out.Sections[0].Required())
+	assert.Equal(t, "Risks", out.Sections[1].Heading)
+	assert.True(t, out.Sections[1].Required())
+}
+
+// TestCompose_DisjointFrontmatterKeys is acceptance criterion #2: a
+// file resolving to two kinds with disjoint required frontmatter
+// keys must require both.
+func TestCompose_DisjointFrontmatterKeys(t *testing.T) {
+	a := &Schema{Frontmatter: map[string]string{
+		"id": `=~"^A-[0-9]+$"`,
+	}}
+	b := &Schema{Frontmatter: map[string]string{
+		"category": `"alpha" | "beta"`,
+	}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Contains(t, out.Frontmatter, "id")
+	require.Contains(t, out.Frontmatter, "category")
+	assert.Equal(t, `=~"^A-[0-9]+$"`, out.Frontmatter["id"])
+	assert.Equal(t, `"alpha" | "beta"`, out.Frontmatter["category"])
+}
+
+// TestCompose_SharedFrontmatterKeyConjoins exercises CUE conjunction:
+// when two schemas constrain the same key, the composed expression
+// is the conjunction of both.
+func TestCompose_SharedFrontmatterKeyConjoins(t *testing.T) {
+	a := &Schema{Frontmatter: map[string]string{
+		"status": `"draft" | "ratified"`,
+	}}
+	b := &Schema{Frontmatter: map[string]string{
+		"status": `"ratified" | "deprecated"`,
+	}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Contains(t, out.Frontmatter, "status")
+	assert.Contains(t, out.Frontmatter["status"], "draft")
+	assert.Contains(t, out.Frontmatter["status"], "deprecated")
+	assert.Contains(t, out.Frontmatter["status"], "&")
+}
+
+// TestCompose_SharedFrontmatterIdenticalExprStaysVerbatim verifies a
+// shared constraint that's identical in both inputs is not wrapped in
+// redundant parens.
+func TestCompose_SharedFrontmatterIdenticalExprStaysVerbatim(t *testing.T) {
+	expr := `string & != ""`
+	a := &Schema{Frontmatter: map[string]string{"title": expr}}
+	b := &Schema{Frontmatter: map[string]string{"title": expr}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, expr, out.Frontmatter["title"])
+}
+
+// TestCompose_MergesSameHeadingScopes covers the rule-readme +
+// directive-rule-readme shape: each schema wraps its required
+// sections in a shared `{id}: {name}` H1. After composition the
+// H1 wrapper must appear once and its child sections include both
+// inputs' children — without this, a file resolving to both kinds
+// would be required to have two H1 headings, only one of which can
+// exist in the same document.
+func TestCompose_MergesSameHeadingScopes(t *testing.T) {
+	wrap := func(child Scope) Scope {
+		return Scope{
+			Heading:  "{id}: {name}",
+			Matcher:  &Matcher{Regex: `\#(fmvar(id)): \#(fmvar(name))`},
+			Sections: []Scope{child},
+		}
+	}
+	a := &Schema{RootLevel: 1, Sections: []Scope{wrap(lit("Goal"))}}
+	b := &Schema{RootLevel: 1, Sections: []Scope{wrap(lit("Risks"))}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	root := out.Sections[0]
+	assert.Equal(t, "{id}: {name}", root.Heading)
+	require.Len(t, root.Sections, 2)
+	assert.Equal(t, "Goal", root.Sections[0].Heading)
+	assert.Equal(t, "Risks", root.Sections[1].Heading)
+}
+
+// TestCompose_MergesLiteralHeadingScopes covers the case where two
+// schemas share a literal heading. Their child sections combine.
+func TestCompose_MergesLiteralHeadingScopes(t *testing.T) {
+	mk := func(child Scope) *Schema {
+		return &Schema{Sections: []Scope{{
+			Heading:  "Meta-Information",
+			Matcher:  &Matcher{Regex: "Meta-Information"},
+			Sections: []Scope{child},
+		}}}
+	}
+	out, err := Compose(mk(lit("ID")), mk(lit("Owner")))
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.Equal(t, "Meta-Information", out.Sections[0].Heading)
+	require.Len(t, out.Sections[0].Sections, 2)
+	headings := []string{
+		out.Sections[0].Sections[0].Heading,
+		out.Sections[0].Sections[1].Heading,
+	}
+	assert.Contains(t, headings, "ID")
+	assert.Contains(t, headings, "Owner")
+}
+
+// TestCompose_PreservesWildcardSlots covers the rule-readme proto.md
+// shape: each schema's sections are interleaved with wildcard slots
+// (`## ...`). Composition must keep the slots distinct so each one
+// still tolerates extras at its position.
+func TestCompose_PreservesWildcardSlots(t *testing.T) {
+	a := &Schema{Sections: []Scope{slot(), lit("Config"), slot()}}
+	b := &Schema{Sections: []Scope{slot(), lit("Pattern"), slot()}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	// 4 wildcard slots (none merge) + 2 unique headings.
+	require.Len(t, out.Sections, 6)
+}
+
+// TestCompose_StrictClosedWins checks the closed-flag rule: if any
+// composed scope's input was closed, the merged scope is closed.
+func TestCompose_StrictClosedWins(t *testing.T) {
+	a := &Schema{Sections: []Scope{{
+		Heading: "Meta", Matcher: &Matcher{Regex: "Meta"}, Closed: true,
+	}}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Meta", Matcher: &Matcher{Regex: "Meta"}, Closed: false,
+	}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.True(t, out.Sections[0].Closed,
+		"any closed=true input must close the merged scope")
+}
+
+// TestCompose_RootClosedStricterWins exercises the root-level
+// closed flag the same way the scope-level test does.
+func TestCompose_RootClosedStricterWins(t *testing.T) {
+	a := &Schema{Closed: true}
+	b := &Schema{Closed: false}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.True(t, out.Closed)
+}
+
+// TestCompose_RootLevelMismatchErrors regresses the Copilot
+// review on PR #288: composing schemas with different
+// EffectiveRootLevel values would silently mis-validate the
+// second input's sections (validate.go positions the section
+// walk at the composed RootLevel). The composer must surface
+// the mismatch as a config error.
+func TestCompose_RootLevelMismatchErrors(t *testing.T) {
+	a := &Schema{
+		Source: "proto.md", RootLevel: 1,
+		Sections: []Scope{{Heading: "?", Matcher: &Matcher{Regex: ".+"}}},
+	}
+	b := &Schema{
+		Source: "kind <inline>", RootLevel: 2,
+		Sections: []Scope{lit("Goal")},
+	}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root heading level")
+}
+
+// TestCompose_RootLevelMatchOK confirms two schemas that agree
+// on RootLevel compose without error.
+func TestCompose_RootLevelMatchOK(t *testing.T) {
+	a := &Schema{RootLevel: 2, Sections: []Scope{lit("Goal")}}
+	b := &Schema{RootLevel: 2, Sections: []Scope{lit("Risks")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, 2, out.RootLevel)
+}
+
+// TestCompose_RequiredWinsAcrossInputs verifies the stricter
+// cardinality wins: a section that is optional (`repeat: {min:0}`)
+// in one input but required (exactly one) in another ends up
+// required in the composed scope.
+func TestCompose_RequiredWinsAcrossInputs(t *testing.T) {
+	optional := &Schema{Sections: []Scope{{
+		Heading: "Meta",
+		Matcher: &Matcher{Regex: "Meta", Repeat: Repeat{Set: true, Min: 0, Max: 1}},
+	}}}
+	required := &Schema{Sections: []Scope{lit("Meta")}}
+	out, err := Compose(optional, required)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.True(t, out.Sections[0].Required(),
+		"a section required by any input must be required in the result")
+}
+
+// TestComposeAcronyms_DocumentWideOverridesScope regresses the
+// Copilot review on PR #288: when one input declares acronyms
+// document-wide (empty Scope) and another restricts to specific
+// sections, composing would previously silently narrow the
+// document-wide check. Document-wide must win.
+func TestComposeAcronyms_DocumentWideOverridesScope(t *testing.T) {
+	a := &Schema{Acronyms: &AcronymRule{KnownSafe: []string{"API"}}}
+	b := &Schema{Acronyms: &AcronymRule{
+		KnownSafe: []string{"HTTP"}, Scope: []string{"Check"},
+	}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Acronyms)
+	assert.Empty(t, out.Acronyms.Scope,
+		"document-wide acronym check must survive composition with a restricted input")
+	assert.ElementsMatch(t, []string{"API", "HTTP"}, out.Acronyms.KnownSafe)
+}
+
+// TestComposeAcronyms_DocumentWideOverridesScopeReverseOrder
+// verifies the order-independence of the document-wide rule:
+// even when the document-wide input arrives second, it widens
+// the prior restriction.
+func TestComposeAcronyms_DocumentWideOverridesScopeReverseOrder(t *testing.T) {
+	a := &Schema{Acronyms: &AcronymRule{
+		KnownSafe: []string{"HTTP"}, Scope: []string{"Check"},
+	}}
+	b := &Schema{Acronyms: &AcronymRule{KnownSafe: []string{"API"}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Acronyms)
+	assert.Empty(t, out.Acronyms.Scope,
+		"document-wide acronym check arriving second must widen the prior restriction")
+}
+
+// TestComposeAcronyms_BothRestricted_UnionsScope verifies the
+// scope union still applies when neither input is document-wide.
+func TestComposeAcronyms_BothRestricted_UnionsScope(t *testing.T) {
+	a := &Schema{Acronyms: &AcronymRule{Scope: []string{"Check"}}}
+	b := &Schema{Acronyms: &AcronymRule{Scope: []string{"Expected"}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Acronyms)
+	assert.ElementsMatch(t,
+		[]string{"Check", "Expected"}, out.Acronyms.Scope)
+}
+
+// TestCompose_FilenameIdenticalNotConflict covers the
+// `out.Filename != s.Filename` false branch: two schemas declaring
+// the same non-empty filename pattern must NOT error.
+func TestCompose_FilenameIdenticalNotConflict(t *testing.T) {
+	a := &Schema{Filename: "[0-9]*.md"}
+	b := &Schema{Filename: "[0-9]*.md"}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, "[0-9]*.md", out.Filename)
+}
+
+// TestCompose_MergeScopeRulesOneSideEmpty covers the
+// `len(b) == 0` false branch in mergeScopeRules — exercised
+// when a side has rules and the other doesn't.
+func TestCompose_MergeScopeRulesOneSideEmpty(t *testing.T) {
+	a := &Schema{Sections: []Scope{lit("Loose")}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Loose",
+		Matcher: &Matcher{Regex: "Loose"},
+		Rules:   map[string]map[string]any{"line-length": {"max": 80}},
+	}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	require.NotNil(t, out.Sections[0].Rules)
+	assert.Contains(t, out.Sections[0].Rules, "line-length")
+}
+
+// TestCanMergeByHeading_PreambleDirect targets the `sc.Preamble`
+// guard of canMergeByHeading. The caller short-circuits preambles
+// before reaching the helper, but the safety branch must still
+// hold so a hand-authored caller doesn't silently merge preambles.
+func TestCanMergeByHeading_PreambleDirect(t *testing.T) {
+	assert.False(t, canMergeByHeading(Scope{Preamble: true, Heading: "stale"}))
+}
+
+// TestCompose_FilenameFirstNonEmpty picks the first non-empty
+// filename pattern; conflicting patterns are an error.
+func TestCompose_FilenameFirstNonEmpty(t *testing.T) {
+	a := &Schema{Filename: ""}
+	b := &Schema{Filename: "[0-9]*.md"}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, "[0-9]*.md", out.Filename)
+}
+
+func TestCompose_FilenameConflictErrors(t *testing.T) {
+	a := &Schema{Filename: "AAA*.md"}
+	b := &Schema{Filename: "BBB*.md"}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filename")
+}
+
+// TestCompose_StrictClosedWinsFromSecondInput regresses the
+// branch where the SECOND merged scope (b) carries Closed=true
+// while the first didn't — `out.Closed = true` must still fire.
+func TestCompose_StrictClosedWinsFromSecondInput(t *testing.T) {
+	a := &Schema{Sections: []Scope{{
+		Heading: "Meta", Matcher: &Matcher{Regex: "Meta"}, Closed: false,
+	}}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Meta", Matcher: &Matcher{Regex: "Meta"}, Closed: true,
+	}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.True(t, out.Sections[0].Closed,
+		"the second input's Closed=true must propagate to the merged scope")
+}
+
+// TestCompose_PreamblePrependedShiftsIndices covers the
+// index-shift branch in composeSectionLists: when the composed
+// list already has named scopes and a later input starts with a
+// preamble, the preamble is prepended and the indexByHeading
+// entries must shift by one.
+func TestCompose_PreamblePrependedShiftsIndices(t *testing.T) {
+	a := &Schema{Sections: []Scope{lit("Goal"), lit("Risks")}}
+	b := &Schema{Sections: []Scope{
+		{Preamble: true},
+		// Same heading as a's first entry — must still merge
+		// after the indexByHeading entries shift.
+		{Heading: "Goal", Matcher: &Matcher{Regex: "Goal"},
+			Sections: []Scope{lit("Why")}},
+	}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	// Expected order: preamble, Goal (merged), Risks.
+	require.Len(t, out.Sections, 3)
+	assert.True(t, out.Sections[0].Preamble,
+		"preamble must land at index 0 after shift")
+	assert.Equal(t, "Goal", out.Sections[1].Heading,
+		"Goal scope must be findable by its shifted index")
+	require.Len(t, out.Sections[1].Sections, 1,
+		"Goal's child sections must come from the merged input")
+	assert.Equal(t, "Why", out.Sections[1].Sections[0].Heading)
+	assert.Equal(t, "Risks", out.Sections[2].Heading)
+}
+
+func TestCompose_PreambleAtStart(t *testing.T) {
+	a := &Schema{Sections: []Scope{{Preamble: true}, lit("Goal")}}
+	b := &Schema{Sections: []Scope{{Preamble: true}, lit("Risks")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Sections)
+	assert.True(t, out.Sections[0].Preamble, "preamble must remain at index 0")
+}
+
+func TestCompose_IndexOutputConflictErrors(t *testing.T) {
+	a := &Schema{Index: &IndexSpec{Output: "a.json", Include: []string{IndexIncludeHeadingsFlat}}}
+	b := &Schema{Index: &IndexSpec{Output: "b.json", Include: []string{IndexIncludeWordCounts}}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema.index.output")
+}
+
+func TestCompose_IndexMergesIncludes(t *testing.T) {
+	a := &Schema{Index: &IndexSpec{Output: "x.json", Include: []string{IndexIncludeHeadingsFlat}}}
+	b := &Schema{Index: &IndexSpec{Output: "x.json", Include: []string{IndexIncludeWordCounts}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Index)
+	assert.Equal(t, "x.json", out.Index.Output)
+	assert.ElementsMatch(t,
+		[]string{IndexIncludeHeadingsFlat, IndexIncludeWordCounts},
+		out.Index.Include)
+}
+
+func TestCompose_CrossRefsConcat(t *testing.T) {
+	a := &Schema{CrossReferences: []CrossRef{{Pattern: "A", MustMatch: "a"}}}
+	b := &Schema{CrossReferences: []CrossRef{{Pattern: "B", MustMatch: "b"}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.CrossReferences, 2)
+}
+
+// TestCompose_MergesScopeRules covers the per-scope rule-overrides
+// merge: when two schemas attach `rules:` to a scope sharing the
+// same heading, the merged scope inherits both override sets. Later
+// inputs win on key collisions.
+func TestCompose_MergesScopeRules(t *testing.T) {
+	a := &Schema{Sections: []Scope{{
+		Heading: "Loose", Matcher: &Matcher{Regex: "Loose"},
+		Rules: map[string]map[string]any{"line-length": {"max": 80}},
+	}}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Loose", Matcher: &Matcher{Regex: "Loose"},
+		Rules: map[string]map[string]any{
+			"line-length":  {"max": 120}, // overrides a's max
+			"no-bare-urls": {},
+		},
+	}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	rules := out.Sections[0].Rules
+	require.NotNil(t, rules)
+	assert.Equal(t, 120, rules["line-length"]["max"],
+		"later scope rule should override earlier on key collision")
+	assert.Contains(t, rules, "no-bare-urls",
+		"distinct rule entries should union")
+}
+
+// TestCompose_CloneScopeDeepCopies ensures cloneScope copies nested
+// slices and maps so mutating the composed schema's scopes can't
+// leak back into the inputs.
+func TestCompose_CloneScopeDeepCopies(t *testing.T) {
+	original := &Schema{Sections: []Scope{{
+		Heading:  "Loose",
+		Matcher:  &Matcher{Regex: "Loose"},
+		Rules:    map[string]map[string]any{"line-length": {"max": 80}},
+		Sections: []Scope{lit("Child")},
+		Content:  []ContentEntry{{Kind: ContentKindCodeBlock, Lang: "go"}},
+	}}}
+	another := &Schema{Sections: []Scope{lit("Other")}}
+	out, err := Compose(original, another)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 2)
+	merged := out.Sections[0]
+	merged.Rules["line-length"]["max"] = 999
+	merged.Sections[0].Heading = "changed"
+	merged.Matcher.Regex = "mutated"
+	assert.Equal(t, 80, original.Sections[0].Rules["line-length"]["max"],
+		"cloneScope must deep-copy rules")
+	assert.Equal(t, "Child", original.Sections[0].Sections[0].Heading,
+		"cloneScope must deep-copy nested sections")
+	assert.Equal(t, "Loose", original.Sections[0].Matcher.Regex,
+		"cloneScope must deep-copy the matcher")
+}
+
+// TestCompose_BareQuestionHeadingNotMerged covers the `?` branch in
+// canMergeByHeading: two `# ?` scopes at the same root level don't
+// merge (they're any-heading matchers, not literal identifiers).
+func TestCompose_BareQuestionHeadingNotMerged(t *testing.T) {
+	a := &Schema{Sections: []Scope{{Heading: "?", Matcher: &Matcher{Regex: ".+"}}}}
+	b := &Schema{Sections: []Scope{{Heading: "?", Matcher: &Matcher{Regex: ".+"}}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 2)
+}
+
+// TestCompose_EmptyHeadingNotMerged covers the empty-string branch
+// in canMergeByHeading.
+func TestCompose_EmptyHeadingNotMerged(t *testing.T) {
+	a := &Schema{Sections: []Scope{{Heading: "", Matcher: &Matcher{Regex: ".+"}}}}
+	b := &Schema{Sections: []Scope{{Heading: "", Matcher: &Matcher{Regex: ".+"}}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 2)
+}
+
+// TestCompose_CloneSettingsMapNil exercises the nil branch in
+// cloneSettingsMap by composing two scopes with the same heading and
+// a nil scope-rules entry.
+func TestCompose_CloneSettingsMapNil(t *testing.T) {
+	a := &Schema{Sections: []Scope{{
+		Heading: "Loose", Matcher: &Matcher{Regex: "Loose"},
+		Rules: map[string]map[string]any{"line-length": nil},
+	}}}
+	b := &Schema{Sections: []Scope{lit("Other")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 2)
+	require.NotNil(t, out.Sections[0].Rules)
+	assert.Contains(t, out.Sections[0].Rules, "line-length")
+}
+
+// TestCompose_SourceLabelFromInputs verifies the composed label
+// concatenates the inputs' Source values when any are set.
+func TestCompose_SourceLabelFromInputs(t *testing.T) {
+	a := &Schema{Source: "proto-a.md"}
+	b := &Schema{Source: "proto-b.md"}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Contains(t, out.Source, "proto-a.md")
+	assert.Contains(t, out.Source, "proto-b.md")
+}
+
+// TestCompose_SourceLabelDefault exercises the fallback when every
+// input has an empty Source.
+func TestCompose_SourceLabelDefault(t *testing.T) {
+	a := &Schema{Source: ""}
+	b := &Schema{Source: ""}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, "composed", out.Source)
+}
+
+// TestCompose_PreambleDuplicateInOneListSkipped covers the
+// `seenPreambleInList` defensive skip: a hand-built list with two
+// preambles in the same input keeps only the first.
+func TestCompose_PreambleDuplicateInOneListSkipped(t *testing.T) {
+	a := &Schema{Sections: []Scope{
+		{Preamble: true},
+		{Preamble: true}, // duplicate; should be skipped
+		lit("Goal"),
+	}}
+	b := &Schema{Sections: []Scope{lit("Risks")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	preambles := 0
+	for _, sc := range out.Sections {
+		if sc.Preamble {
+			preambles++
+		}
+	}
+	assert.Equal(t, 1, preambles,
+		"duplicate preambles in a single input list must collapse")
+}
+
+// TestCompose_PreambleSecondInputMerges covers the existing-preamble
+// merge path: when a later input has a preamble and the composed
+// list already has one, they merge rather than appending a second.
+func TestCompose_PreambleSecondInputMerges(t *testing.T) {
+	a := &Schema{Sections: []Scope{{Preamble: true}, lit("Goal")}}
+	b := &Schema{Sections: []Scope{{Preamble: true}, lit("Risks")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	preambles := 0
+	for _, sc := range out.Sections {
+		if sc.Preamble {
+			preambles++
+		}
+	}
+	assert.Equal(t, 1, preambles,
+		"two input preambles should merge into one composed preamble")
+}
+
+func TestCompose_AcronymsMerge(t *testing.T) {
+	a := &Schema{Acronyms: &AcronymRule{
+		KnownSafe: []string{"API", "HTTP"}, Scope: []string{"Check"},
+	}}
+	b := &Schema{Acronyms: &AcronymRule{
+		KnownSafe: []string{"HTTP", "TLS"}, Scope: []string{"Expected"},
+	}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Acronyms)
+	assert.ElementsMatch(t, []string{"API", "HTTP", "TLS"}, out.Acronyms.KnownSafe)
+	assert.ElementsMatch(t, []string{"Check", "Expected"}, out.Acronyms.Scope)
+}
+
+// TestCompose_ContentConcatenatesOnMerge verifies positional
+// Content constraints concatenate when two same-heading scopes
+// merge (earlier input first).
+func TestCompose_ContentConcatenatesOnMerge(t *testing.T) {
+	a := &Schema{Sections: []Scope{{
+		Heading: "Examples", Matcher: &Matcher{Regex: "Examples"},
+		Content: []ContentEntry{{Kind: ContentKindCodeBlock, Lang: "go"}},
+	}}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Examples", Matcher: &Matcher{Regex: "Examples"},
+		Content: []ContentEntry{{Kind: ContentKindTable}},
+	}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	require.Len(t, out.Sections[0].Content, 2)
+	assert.Equal(t, ContentKindCodeBlock, out.Sections[0].Content[0].Kind)
+	assert.Equal(t, ContentKindTable, out.Sections[0].Content[1].Kind)
+}

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -338,6 +338,67 @@ func TestCompose_FilenameConflictErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "filename")
 }
 
+// TestCompose_DisjointCardinalityErrors drives the empty-intersection
+// guard through the public Compose path: two root schemas declare the
+// same Step heading with disjoint run lengths (1..3 vs 5..10). The
+// error must propagate through composeSectionLists and mergeScopes
+// rather than silently honoring one input.
+func TestCompose_DisjointCardinalityErrors(t *testing.T) {
+	a := &Schema{Sections: []Scope{{
+		Heading: "Step",
+		Matcher: &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 3}},
+	}}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Step",
+		Matcher: &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 5, Max: 10}},
+	}}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disjoint cardinality")
+}
+
+// TestCompose_NestedDisjointCardinalityErrors covers mergeScopes'
+// recursive composeSectionLists error arm: a shared Goal parent
+// merges fine, but its Step child has disjoint cardinality, so the
+// error surfaces from the nested composition.
+func TestCompose_NestedDisjointCardinalityErrors(t *testing.T) {
+	child := func(min, max int) Scope {
+		return Scope{
+			Heading: "Goal", Matcher: &Matcher{Regex: "Goal"},
+			Sections: []Scope{{
+				Heading: "Step",
+				Matcher: &Matcher{Regex: "Step",
+					Repeat: Repeat{Set: true, Min: min, Max: max}},
+			}},
+		}
+	}
+	a := &Schema{Sections: []Scope{child(1, 3)}}
+	b := &Schema{Sections: []Scope{child(5, 10)}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disjoint cardinality")
+}
+
+// TestComposeSectionLists_PreambleMergeError white-box-covers the
+// preamble error-return arm: two lists each lead with a preamble
+// whose matcher carries a disjoint run length, so merging the
+// second into the first must surface the composition error.
+func TestComposeSectionLists_PreambleMergeError(t *testing.T) {
+	pre := func(min, max int) Scope {
+		return Scope{
+			Preamble: true,
+			Matcher: &Matcher{Regex: "x",
+				Repeat: Repeat{Set: true, Min: min, Max: max}},
+		}
+	}
+	_, err := composeSectionLists([][]Scope{
+		{pre(1, 3)},
+		{pre(5, 10)},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disjoint cardinality")
+}
+
 // TestCompose_StrictClosedWinsFromSecondInput regresses the
 // branch where the SECOND merged scope (b) carries Closed=true
 // while the first didn't — `out.Closed = true` must still fire.
@@ -611,7 +672,8 @@ func TestCompose_ContentConcatenatesOnMerge(t *testing.T) {
 // input's matcher.
 func TestMergeMatcher_BNil(t *testing.T) {
 	a := &Matcher{Regex: "Meta"}
-	got := mergeMatcher(a, nil)
+	got, err := mergeMatcher(a, nil)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "Meta", got.Regex)
 	assert.NotSame(t, a, got, "result must be a clone, not the input pointer")
@@ -620,24 +682,26 @@ func TestMergeMatcher_BNil(t *testing.T) {
 // TestMergeMatcher_ANil covers the symmetric `a == nil` arm.
 func TestMergeMatcher_ANil(t *testing.T) {
 	b := &Matcher{Regex: "Meta"}
-	got := mergeMatcher(nil, b)
+	got, err := mergeMatcher(nil, b)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "Meta", got.Regex)
 	assert.NotSame(t, b, got)
 }
 
-// TestMergeMatcher_WiderMaxAndRepeatSet covers two branches: the
-// `bMax > max` widening (b's bounded max is larger than a's) and
-// the non-(1,1) `else` that sets an explicit Repeat. a allows
-// 1..2, b allows 1..5 -> merged is 1..5.
-func TestMergeMatcher_WiderMaxAndRepeatSet(t *testing.T) {
+// TestMergeMatcher_StricterMaxAndRepeatSet covers two branches: the
+// `a < b` arm of intersectMax (a's bounded max is smaller, so it
+// wins) and the non-(1,1) `else` that sets an explicit Repeat. a
+// allows 1..2, b allows 1..5 -> the intersection is 1..2.
+func TestMergeMatcher_StricterMaxAndRepeatSet(t *testing.T) {
 	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 2}}
 	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 5}}
-	got := mergeMatcher(a, b)
+	got, err := mergeMatcher(a, b)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	gotMin, gotMax := got.Repeat.Bounds()
 	assert.Equal(t, 1, gotMin)
-	assert.Equal(t, 5, gotMax, "the wider max must win")
+	assert.Equal(t, 2, gotMax, "the stricter (smaller) max must win")
 	assert.True(t, got.Repeat.Set, "non-(1,1) bounds must set Repeat explicitly")
 }
 
@@ -647,7 +711,8 @@ func TestMergeMatcher_WiderMaxAndRepeatSet(t *testing.T) {
 func TestMergeMatcher_RequiredWinsOverOptional(t *testing.T) {
 	optional := &Matcher{Regex: "Meta", Repeat: Repeat{Set: true, Min: 0, Max: 1}}
 	required := &Matcher{Regex: "Meta"} // exactly one
-	got := mergeMatcher(optional, required)
+	got, err := mergeMatcher(optional, required)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	gotMin, _ := got.Repeat.Bounds()
 	assert.Equal(t, 1, gotMin, "required (min 1) must win over optional (min 0)")
@@ -690,12 +755,13 @@ func TestMergeMatcher_SequentialOredAndUnbounded(t *testing.T) {
 		Regex:  "Step",
 		Repeat: Repeat{Set: true, Min: 1, Max: 0},
 	}
-	got := mergeMatcher(a, b)
+	got, err := mergeMatcher(a, b)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.True(t, got.Sequential, "Sequential must OR across inputs")
 	gotMin, gotMax := got.Repeat.Bounds()
 	assert.Equal(t, 1, gotMin)
-	assert.Equal(t, 0, gotMax, "unbounded max stays unbounded")
+	assert.Equal(t, 0, gotMax, "unbounded ∩ unbounded stays unbounded")
 }
 
 // TestMergeMatcher_SequentialFromBOnly covers the right operand of
@@ -703,7 +769,8 @@ func TestMergeMatcher_SequentialOredAndUnbounded(t *testing.T) {
 func TestMergeMatcher_SequentialFromBOnly(t *testing.T) {
 	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}}
 	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}, Sequential: true}
-	got := mergeMatcher(a, b)
+	got, err := mergeMatcher(a, b)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.True(t, got.Sequential)
 }
@@ -714,22 +781,66 @@ func TestMergeMatcher_SequentialFromBOnly(t *testing.T) {
 func TestMergeMatcher_OptionalBothSides(t *testing.T) {
 	a := &Matcher{Regex: "Notes", Repeat: Repeat{Set: true, Min: 0, Max: 1}}
 	b := &Matcher{Regex: "Notes", Repeat: Repeat{Set: true, Min: 0, Max: 1}}
-	got := mergeMatcher(a, b)
+	got, err := mergeMatcher(a, b)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	gotMin, _ := got.Repeat.Bounds()
 	assert.Equal(t, 0, gotMin, "two optional runs stay optional")
 	assert.True(t, got.Repeat.Optional())
 }
 
-// TestMergeMatcher_BoundedAThenUnboundedB covers the `bMax != 0`
-// false arm: a is bounded (max 3), b is unbounded (max 0). Either
-// side unbounded makes the merged run unbounded.
+// TestMergeMatcher_BoundedAThenUnboundedB covers intersectMax's
+// `b == 0` arm: a is bounded (max 3), b is unbounded (max 0). The
+// intersection keeps the bounded side so the unbounded input never
+// loosens it.
 func TestMergeMatcher_BoundedAThenUnboundedB(t *testing.T) {
 	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 3}}
 	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}}
-	got := mergeMatcher(a, b)
+	got, err := mergeMatcher(a, b)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	_, gotMax := got.Repeat.Bounds()
-	assert.Equal(t, 0, gotMax,
-		"a bounded max merged with an unbounded one yields unbounded")
+	assert.Equal(t, 3, gotMax,
+		"a bounded max intersected with an unbounded one stays bounded")
+}
+
+// TestMergeMatcher_UnboundedAThenBoundedB covers intersectMax's
+// `a == 0` arm: a is unbounded, b is bounded (max 4). The bounded
+// side wins.
+func TestMergeMatcher_UnboundedAThenBoundedB(t *testing.T) {
+	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}}
+	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 4}}
+	got, err := mergeMatcher(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	_, gotMax := got.Repeat.Bounds()
+	assert.Equal(t, 4, gotMax,
+		"an unbounded max intersected with a bounded one stays bounded")
+}
+
+// TestMergeMatcher_DisjointRangesError covers the empty-intersection
+// guard: 1..3 and 5..10 share no satisfiable run length, so compose
+// surfaces a config error instead of silently honoring one input.
+func TestMergeMatcher_DisjointRangesError(t *testing.T) {
+	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 3}}
+	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 5, Max: 10}}
+	got, err := mergeMatcher(a, b)
+	assert.Nil(t, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disjoint cardinality")
+	assert.Contains(t, err.Error(), "1..3")
+	assert.Contains(t, err.Error(), "5..10")
+}
+
+// TestMergeMatcher_DisjointWithUnboundedError covers the
+// boundsLabel "unbounded" branch: a requires 5..unbounded, b caps
+// at 1..2 — disjoint, and the error names the unbounded side.
+func TestMergeMatcher_DisjointWithUnboundedError(t *testing.T) {
+	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 5, Max: 0}}
+	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 2}}
+	got, err := mergeMatcher(a, b)
+	assert.Nil(t, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "5..unbounded")
+	assert.Contains(t, err.Error(), "1..2")
 }

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -605,3 +605,131 @@ func TestCompose_ContentConcatenatesOnMerge(t *testing.T) {
 	assert.Equal(t, ContentKindCodeBlock, out.Sections[0].Content[0].Kind)
 	assert.Equal(t, ContentKindTable, out.Sections[0].Content[1].Kind)
 }
+
+// TestMergeMatcher_BNil covers the `b == nil` arm: a same-heading
+// scope whose Matcher is nil in the later input keeps the earlier
+// input's matcher.
+func TestMergeMatcher_BNil(t *testing.T) {
+	a := &Matcher{Regex: "Meta"}
+	got := mergeMatcher(a, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, "Meta", got.Regex)
+	assert.NotSame(t, a, got, "result must be a clone, not the input pointer")
+}
+
+// TestMergeMatcher_ANil covers the symmetric `a == nil` arm.
+func TestMergeMatcher_ANil(t *testing.T) {
+	b := &Matcher{Regex: "Meta"}
+	got := mergeMatcher(nil, b)
+	require.NotNil(t, got)
+	assert.Equal(t, "Meta", got.Regex)
+	assert.NotSame(t, b, got)
+}
+
+// TestMergeMatcher_WiderMaxAndRepeatSet covers two branches: the
+// `bMax > max` widening (b's bounded max is larger than a's) and
+// the non-(1,1) `else` that sets an explicit Repeat. a allows
+// 1..2, b allows 1..5 -> merged is 1..5.
+func TestMergeMatcher_WiderMaxAndRepeatSet(t *testing.T) {
+	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 2}}
+	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 5}}
+	got := mergeMatcher(a, b)
+	require.NotNil(t, got)
+	gotMin, gotMax := got.Repeat.Bounds()
+	assert.Equal(t, 1, gotMin)
+	assert.Equal(t, 5, gotMax, "the wider max must win")
+	assert.True(t, got.Repeat.Set, "non-(1,1) bounds must set Repeat explicitly")
+}
+
+// TestMergeMatcher_RequiredWinsOverOptional covers the min-widening
+// branch plus the explicit-Repeat else: an optional run (min 0)
+// merged with a required single (1,1) yields a required matcher.
+func TestMergeMatcher_RequiredWinsOverOptional(t *testing.T) {
+	optional := &Matcher{Regex: "Meta", Repeat: Repeat{Set: true, Min: 0, Max: 1}}
+	required := &Matcher{Regex: "Meta"} // exactly one
+	got := mergeMatcher(optional, required)
+	require.NotNil(t, got)
+	gotMin, _ := got.Repeat.Bounds()
+	assert.Equal(t, 1, gotMin, "required (min 1) must win over optional (min 0)")
+}
+
+// TestCloneContent_CopiesColumns covers the `e.Columns != nil`
+// deep-copy branch: a table ContentEntry's Columns slice must be
+// cloned, not aliased, when two same-heading scopes merge.
+func TestCloneContent_CopiesColumns(t *testing.T) {
+	cols := []string{"Name", "Type"}
+	a := &Schema{Sections: []Scope{{
+		Heading: "Schema", Matcher: &Matcher{Regex: "Schema"},
+		Content: []ContentEntry{{Kind: ContentKindTable, Columns: cols}},
+	}}}
+	b := &Schema{Sections: []Scope{{
+		Heading: "Schema", Matcher: &Matcher{Regex: "Schema"},
+	}}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	require.Len(t, out.Sections[0].Content, 1)
+	got := out.Sections[0].Content[0].Columns
+	require.Equal(t, []string{"Name", "Type"}, got)
+	cols[0] = "MUTATED"
+	assert.Equal(t, "Name", out.Sections[0].Content[0].Columns[0],
+		"cloneContent must deep-copy Columns, not alias the input slice")
+}
+
+// TestMergeMatcher_SequentialOredAndUnbounded covers the
+// `a.Sequential || b.Sequential` true arms and the unbounded-max
+// path (aMax/bMax == 0): merging an unbounded sequential run with
+// an unbounded plain run keeps Sequential and stays unbounded.
+func TestMergeMatcher_SequentialOredAndUnbounded(t *testing.T) {
+	a := &Matcher{
+		Regex:      "Step",
+		Repeat:     Repeat{Set: true, Min: 1, Max: 0}, // 1..unbounded
+		Sequential: true,
+	}
+	b := &Matcher{
+		Regex:  "Step",
+		Repeat: Repeat{Set: true, Min: 1, Max: 0},
+	}
+	got := mergeMatcher(a, b)
+	require.NotNil(t, got)
+	assert.True(t, got.Sequential, "Sequential must OR across inputs")
+	gotMin, gotMax := got.Repeat.Bounds()
+	assert.Equal(t, 1, gotMin)
+	assert.Equal(t, 0, gotMax, "unbounded max stays unbounded")
+}
+
+// TestMergeMatcher_SequentialFromBOnly covers the right operand of
+// the `||` (a.Sequential false, b.Sequential true).
+func TestMergeMatcher_SequentialFromBOnly(t *testing.T) {
+	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}}
+	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}, Sequential: true}
+	got := mergeMatcher(a, b)
+	require.NotNil(t, got)
+	assert.True(t, got.Sequential)
+}
+
+// TestMergeMatcher_OptionalBothSides covers the `min == 1` false
+// branch: two optional (min 0) runs merge to an optional run, so
+// the explicit-Repeat else fires with min 0.
+func TestMergeMatcher_OptionalBothSides(t *testing.T) {
+	a := &Matcher{Regex: "Notes", Repeat: Repeat{Set: true, Min: 0, Max: 1}}
+	b := &Matcher{Regex: "Notes", Repeat: Repeat{Set: true, Min: 0, Max: 1}}
+	got := mergeMatcher(a, b)
+	require.NotNil(t, got)
+	gotMin, _ := got.Repeat.Bounds()
+	assert.Equal(t, 0, gotMin, "two optional runs stay optional")
+	assert.True(t, got.Repeat.Optional())
+}
+
+// TestMergeMatcher_BoundedAThenUnboundedB covers the `bMax != 0`
+// false arm: a is bounded (max 3), b is unbounded (max 0). Either
+// side unbounded makes the merged run unbounded.
+func TestMergeMatcher_BoundedAThenUnboundedB(t *testing.T) {
+	a := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 3}}
+	b := &Matcher{Regex: "Step", Repeat: Repeat{Set: true, Min: 1, Max: 0}}
+	got := mergeMatcher(a, b)
+	require.NotNil(t, got)
+	_, gotMax := got.Repeat.Bounds()
+	assert.Equal(t, 0, gotMax,
+		"a bounded max merged with an unbounded one yields unbounded")
+}

--- a/plan/156_kind-schema-composition.md
+++ b/plan/156_kind-schema-composition.md
@@ -1,7 +1,7 @@
 ---
 id: 156
 title: 'Composable required-structure schemas across multiple kinds'
-status: '🔲'
+status: '✅'
 summary: >-
   Two kinds whose required-structure schemas
   differ overwrite each other under deep-merge.
@@ -58,55 +58,57 @@ drops the other. Neither path composes.
 
 ## Tasks
 
-1. Document the current behaviour. Add a short
-   note to the [cross-system
-   doc](../docs/development/architecture/cross-system.md)
-   stating that conflicting required-structure
-   schemas across kinds pick the last applied.
-   That is the baseline this plan moves off of.
+1. ✅ Baseline note landed in the
+   [cross-system doc](../docs/development/architecture/cross-system.md).
+   It describes the new composition rule. The
+   note doubles as the public contract.
 
-2. Decide the composition rule. Three candidates:
+2. ✅ Chose composition rule option 1.
 
-  - Concatenate sections; intersect frontmatter
-    types. Sections from earlier kinds run first.
-    Later kinds append. A key required by any kind
-    is required. The stricter `closed:` wins.
-  - Schema-include. The later kind's schema gets a
-    synthetic `<?include?>` of the earlier kind's
-    schema at the top. Composition piggy-backs on
-    the schema-include feature in
-    [MDS020](../internal/rules/MDS020-required-structure/README.md).
-  - Explicit extends. Each kind declares
-    `extends: <kind-name>` in its schema body. The
-    merge resolver walks the chain. Mirrors
-    [plan/135_schema-extends.md](135_schema-extends.md)
-    at the kind level.
+  - Sections concatenate.
+  - Same-heading scopes merge.
+  - Frontmatter conjoins via CUE `&`.
+  - Stricter `closed:` wins.
+  - `Require.Filename` picks the first
+    non-empty pattern.
+  - Conflicting patterns error.
+  - Acceptance test:
+    [compose_test.go](../internal/schema/compose_test.go).
 
-  Acceptance test for the decision. Write a YAML
-  doc with two kinds A and B. A requires `## Goal`.
-  B requires `## Risks`. After composition a file
-  resolving to `[A, B]` must require both.
+3. ✅ Merge layer accumulates a
+   `schema-sources` list across layers. Each
+   layer that sets `schema:` or `inline-schema:`
+   contributes one entry. The rule loads the
+   list and calls
+   [`schema.Compose`](../internal/schema/compose.go)
+   at check time.
 
-3. Implement the chosen rule in the merge layer.
-   Special-case `required-structure.schema` and
-   `required-structure.inline-schema`. They run
-   the composition procedure. Other paths keep
-   the default scalar replacement. Add a test in
-   `internal/config/` covering two kinds with
-   disjoint required headings.
+   Tests in
+   [schema_kinds_test.go](../internal/config/schema_kinds_test.go)
+   cover disjoint sections, disjoint frontmatter,
+   and the kind-plus-override path.
+   [compose_test.go](../internal/rules/requiredstructure/compose_test.go)
+   exercises the end-to-end Check path.
 
-4. Validate directive-rule-readme + rule-readme.
-   Reassign the four directive READMEs through
-   both kinds in [.mdsmith.yml](../.mdsmith.yml).
-   Confirm `mdsmith check .` enforces both header
-   sets. Remove the duplicated headings from
-   `internal/rules/directive-proto.md` so it
-   declares only Pattern additions.
+4. ✅ The four directive READMEs now resolve to
+   both `rule-readme` and `directive-rule-readme`
+   in [.mdsmith.yml](../.mdsmith.yml). The
+   [directive-proto.md](../internal/rules/directive-proto.md)
+   schema lost the duplicated headings. It now
+   declares only the `Pattern` section. The
+   `nature` frontmatter narrows to
+   `"directive"`. Each directive README moved
+   `Pattern` to the end so the composed section
+   order matches: `rule-readme` first, then
+   `directive-rule-readme`.
 
-5. Document the composition rule. Update the
+5. ✅ Composition rule lives in
+   [schemas.md](../docs/guides/schemas.md) with
+   the worked
+   `rule-readme + directive-rule-readme`
+   example. The
    [MDS020 README](../internal/rules/MDS020-required-structure/README.md)
-   and [docs/guides/schemas.md](../docs/guides/schemas.md).
-   Include a worked two-kind example.
+   points at the guide.
 
 ## ...
 
@@ -114,21 +116,21 @@ drops the other. Neither path composes.
 
 ## Acceptance Criteria
 
-- [ ] A file resolving to two kinds with disjoint
+- [x] A file resolving to two kinds with disjoint
   required sections fails `mdsmith check` until
   both sets are present.
-- [ ] A file resolving to two kinds with disjoint
+- [x] A file resolving to two kinds with disjoint
   required front-matter keys fails `mdsmith check`
   until both sets are present.
-- [ ] `internal/rules/directive-proto.md` no
+- [x] `internal/rules/directive-proto.md` no
   longer duplicates rule-readme's `Config`,
   `Examples`, and `Meta-Information` headings; it
   declares only Pattern additions.
-- [ ] [docs/guides/schemas.md](../docs/guides/schemas.md)
+- [x] [docs/guides/schemas.md](../docs/guides/schemas.md)
   documents the composition rule with a two-kind
   worked example.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no
   issues.
 
 ## ...

--- a/plan/169_rule-readme-meta-information-sync.md
+++ b/plan/169_rule-readme-meta-information-sync.md
@@ -1,0 +1,96 @@
+---
+id: 169
+title: 'Enforce terminal Meta-Information and render it from frontmatter'
+status: "🔲"
+model: opus
+depends-on: [156]
+summary: >-
+  The rule-readme schema allows sections after
+  Meta-Information and its bullets are hand-typed.
+  Make the schema reject any later section and sync
+  the bullets from frontmatter via {field}.
+---
+# Rule-README Meta-Information ordering and sync
+
+## Goal
+
+Every rule README must end with its
+`## Meta-Information` section. That section's
+bullets must come from the README front matter, not
+hand-typed values. The rule-readme schema enforces
+both. A section after Meta-Information fails
+`mdsmith check`. A bullet that disagrees with front
+matter is flagged and fixed.
+
+## Background
+
+The rule-readme kind loads its required-structure
+schema from
+[internal/rules/proto.md](../internal/rules/proto.md).
+That schema ends with a trailing `## ...` wildcard
+after `## Meta-Information`. So a README may add
+sections after it and still pass. The schema does
+not enforce Meta-Information as the last section.
+
+The Meta-Information body is hand-authored. Its
+`ID`, `Name`, `Status`, and `Category` bullets
+restate the `id`, `name`, `status`, and `category`
+front-matter keys. Nothing checks that they agree.
+
+[docs/guides/schemas.md](../docs/guides/schemas.md)
+notes that MDS020's file-schema check still uses
+its legacy parser. A `{field}` token in a
+`proto.md` body is treated as a wildcard, not
+resolved against front matter. Frontmatter-body
+`{field}` sync is listed there as an unwired
+follow-up. This plan wires it for the
+Meta-Information case.
+
+## Tasks
+
+1. Drop the trailing `## ...` wildcard in
+   [internal/rules/proto.md](../internal/rules/proto.md).
+   The parsed schema then treats Meta-Information as
+   the last scope. Add a test that a later section
+   reports `got <present>, expected not declared in
+   schema`.
+
+2. Wire MDS020's file-schema path so a `{field}`
+   token in the Meta-Information body resolves the
+   document front-matter value. Reuse the
+   `fmvar(...)` resolution the heading matcher
+   already uses. `mdsmith fix` rewrites a stale
+   bullet to the front-matter value.
+
+3. Update
+   [internal/rules/proto.md](../internal/rules/proto.md)
+   so the bullets use `{id}`, `{name}`, `{status}`,
+   `{category}`. Drop the hand-kept `CATEGORY`
+   literal.
+
+4. Revalidate every `internal/rules/MDS*/README.md`.
+   Move any content after Meta-Information ahead of
+   it. Reconcile bullet values with front matter so
+   `mdsmith check .` passes.
+
+5. Update
+   [docs/guides/schemas.md](../docs/guides/schemas.md)
+   and the
+   [section-schema reference](../docs/reference/section-schema.md).
+   Record that frontmatter-body `{field}` sync is
+   now wired for file schemas.
+
+## Acceptance Criteria
+
+- [ ] A rule README with any section after
+  `## Meta-Information` fails `mdsmith check`.
+- [ ] A stale `ID`, `Name`, `Status`, or `Category`
+  bullet is flagged and `mdsmith fix` rewrites it
+  from front matter.
+- [ ] [internal/rules/proto.md](../internal/rules/proto.md)
+  has no trailing wildcard after Meta-Information
+  and no `CATEGORY` literal.
+- [ ] All `internal/rules/MDS*/README.md` pass
+  `mdsmith check .`.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no issues.


### PR DESCRIPTION
## Summary

Implements plan 156: when a file resolves to multiple kinds that each declare a `required-structure` schema, the schemas now compose instead of the last one winning. The merge layer accumulates schema sources into a `schema-sources` list, and the rule loads and composes them at check time.

## Key Changes

**Core composition logic** (`internal/schema/compose.go`, new):
- `Compose()` merges multiple schemas by unioning frontmatter keys (with CUE conjunction `&` for shared keys), merging sections by literal heading text, OR-ing the `closed:` flag, and picking the first non-empty `require.filename` pattern
- Sections with identical headings combine recursively; wildcard slots and preambles remain distinct
- Comprehensive test coverage in `compose_test.go` validates all composition rules

**Rule refactoring** (`internal/rules/requiredstructure/rule.go`):
- New `SchemaSource` struct holds either a file path or pre-parsed inline schema
- `Rule.Sources` field (canonical) replaces single-source logic; `Schema` and `InlineSchema` now mirror the first source for backward compatibility
- `ApplySettings()` refactored into focused helpers (`applySchemaSetting`, `applyInlineSchemaSetting`, `applySchemaSourcesSetting`)
- New `parseSchemaSources()` parses the `schema-sources` list installed by the merge layer
- `reflectSingleSource()` keeps legacy fields in sync when exactly one source is configured
- `SettingMergeMode()` returns `MergeAppend` for `schema-sources` so layers accumulate

**Merge layer** (`internal/config/merge.go`):
- New `translateSchemaSource()` converts legacy `schema:` and `inline-schema:` settings into single-entry `schema-sources` lists
- `effectiveRules()` applies translation to all layers (defaults, convention, user, kinds, overrides)
- Removed `clearSchemaState()` and related "last source wins" logic; sources now accumulate
- `SettingMergeMode()` updated to append `schema-sources` across layers

**Check-time composition** (`internal/rules/requiredstructure/rule.go`):
- `Check()` loads all sources and calls `schema.Compose()` to merge them before validation
- Handles both file and inline sources; file sources read through `lint.File.RootFS`
- Maintains backward compatibility: single-source configs work unchanged

**Config tests** (`internal/config/schema_kinds_test.go`):
- Updated `TestEffectiveInjectsInlineSchema` to verify `schema-sources` list structure
- Renamed `TestEffectiveClearsPriorSchemaWhenNewSourceArrives` to `TestEffectiveComposesSchemaSourcesAcrossKinds`; now verifies both sources accumulate instead of the last winning

**Rule tests** (`internal/rules/requiredstructure/compose_test.go`, new):
- `TestApplySettings_SchemaSourcesList` validates multi-source parsing
- `TestCheck_ComposedSchemasRequireBothSets` (acceptance criterion #1): file resolving to two kinds with disjoint required sections must require both
- `TestCheck_ComposedSchemasComposeFrontmatter` (acceptance criterion #2): disjoint frontmatter keys compose

**Documentation and examples**:
- Updated `docs/guides/schemas.md` with composition rules and worked example (directive-rule-readme + rule-readme)
- Updated `docs/development/architecture/cross-system.md` with schema composition contract
- Simplified `internal/rules/directive-proto.md` to declare only Pattern-specific constraints; common rule-README structure now comes from `proto.md` via composition
- Moved Meta-Information sections in four directive READMEs (MDS019, MDS021, MDS038, MDS039) to appear before Pattern (composition order)
- Updated `.mdsmith.yml` to assign all four directive READMEs to both `rule-readme` and `directive-rule-readme` kinds

## Notable Implementation Details

- Inline schemas are pre

https://claude.ai/code/session_01C4XwUp4AkhzqjrvSSHMMZS