### PR TITLE
Add publish-release command to flip draft releases to published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,13 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: false
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           merge-multiple: true
@@ -412,17 +419,34 @@ jobs:
           cosign sign-blob \
             --bundle checksums.txt.bundle \
             checksums.txt
-      - name: Create release
+      - name: Upload assets to draft release
+        # Always create/update the release as a draft so every asset
+        # uploads while the release is still mutable. With immutable
+        # releases enforced, uploading to an already-published
+        # release is rejected — the publish must be the final step.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
-          draft: ${{ needs.trigger-guard.outputs.create_release_is_draft == 'true' }}
+          draft: true
           generate_release_notes: true
           files: |
             mdsmith-*
             checksums.txt
             checksums.txt.bundle
+      - name: Publish release
+        # Path A (tag push): create_release_is_draft == 'false', so
+        # flip the fully-populated draft to published as the final
+        # atomic step — the result is an immutable release. Path B
+        # (maintainer's UI-created draft): create_release_is_draft ==
+        # 'true', so the release is left as a draft for manual
+        # review and publish. Runtime logic lives in mdsmith-release
+        # per docs/development/release-tooling.md.
+        if: needs.trigger-guard.outputs.create_release_is_draft == 'false'
+        env:
+          RELEASE_TAG: ${{ env.VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./cmd/mdsmith-release publish-release
 
   smoke-test:
     # Wait until every channel is on the new version before checking
@@ -501,9 +525,18 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:
+      # The mise channel resolves the binary off the public GitHub
+      # release (ubi backend). On the UI-draft path the release is
+      # left as a draft, so its assets are not publicly downloadable
+      # and mise cannot resolve them — skip mise there. npm/pip are
+      # registry-backed and unaffected by the GitHub release state.
       - name: Install
+        if: &smoke_channel_active >-
+          matrix.channel != 'mise' ||
+          needs.trigger-guard.outputs.create_release_is_draft == 'false'
         run: ${{ matrix.install }}
       - name: Verify version
+        if: *smoke_channel_active
         run: |
           got=$(${{ matrix.run }})
           want="mdsmith ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,8 +500,6 @@ jobs:
               mdsmith version
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
-    env:
-      VERSION: ${{ env.VERSION }}
     steps:
       - name: Install
         run: ${{ matrix.install }}
@@ -544,11 +542,6 @@ jobs:
       # it expects the binary already on PATH — so no pin lives
       # there.)
       HUGO_VERSION: "0.161.1"
-      # The release tag drives the version Hugo renders in
-      # ``.Site.Params.version`` and the on-disk pin in
-      # website/hugo.toml. Stamp validates that the value has
-      # no leading "v" before rewriting, so strip it here.
-      VERSION: ${{ env.VERSION }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -14,6 +14,7 @@
 //	mdsmith-release sync-docs <src-dir> <dst-dir>
 //	mdsmith-release build-website [--no-fix] [src-dir] [dst-dir]
 //	mdsmith-release check-release-trigger
+//	mdsmith-release publish-release
 //	mdsmith-release check-secret-rotations
 //	mdsmith-release record-rotation <ENTRY_TITLE> <YYYY-MM-DD>
 //
@@ -44,6 +45,7 @@ Commands:
   build-website [--no-fix] [src] [dst]
                                   mdsmith fix (unless --no-fix) + sync-docs.
   check-release-trigger           Emit release trigger guard outputs.
+  publish-release                 Flip the tag's draft release to published.
   check-secret-rotations          Open GitHub issues for secrets due for rotation.
   record-rotation <title> <date>  Update lastRotated in a per-secret rotation file.
 `
@@ -81,6 +83,8 @@ func run(args []string) int {
 		return runBuildWebsite(root, rest)
 	case "check-release-trigger":
 		return runCheckReleaseTrigger(root, rest)
+	case "publish-release":
+		return runPublishRelease(root, rest)
 	case "check-secret-rotations":
 		return runCheckSecretRotations(root, rest)
 	case "record-rotation":

--- a/cmd/mdsmith-release/publishrelease.go
+++ b/cmd/mdsmith-release/publishrelease.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/jeduden/mdsmith/internal/release"
+)
+
+func runPublishRelease(_ string, args []string) int {
+	fs := flag.NewFlagSet("publish-release", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mdsmith-release publish-release\n\n"+
+			"Flip the draft GitHub release for the current tag to a\n"+
+			"published release. The `release` job uploads every asset\n"+
+			"to a draft (still mutable); this is the final atomic step\n"+
+			"that publishes it, yielding an immutable release. Reads\n"+
+			"GITHUB_REPOSITORY, RELEASE_TAG, GITHUB_TOKEN, and\n"+
+			"GITHUB_API_URL from the environment. Idempotent.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: publish-release"); code >= 0 {
+			return code
+		}
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+
+	return reportError(release.PublishRelease(release.PublishReleaseOptions{
+		Repository: os.Getenv("GITHUB_REPOSITORY"),
+		Tag:        os.Getenv("RELEASE_TAG"),
+		Token:      os.Getenv("GITHUB_TOKEN"),
+		APIBaseURL: os.Getenv("GITHUB_API_URL"),
+	}))
+}

--- a/cmd/mdsmith-release/publishrelease_test.go
+++ b/cmd/mdsmith-release/publishrelease_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunPublishReleaseFlipsDraft(t *testing.T) {
+	var patched bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patched = true
+			_, _ = w.Write([]byte(`{"id":42,"draft":false}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":42,"draft":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("GITHUB_REPOSITORY", "jeduden/mdsmith")
+	t.Setenv("RELEASE_TAG", "v1.2.3")
+	t.Setenv("GITHUB_TOKEN", "test-token")
+	t.Setenv("GITHUB_API_URL", srv.URL)
+
+	assert.Equal(t, 0, run([]string{"publish-release"}))
+	assert.True(t, patched)
+}
+
+// TestRunPublishReleaseReportsError covers the reportError branch
+// when PublishRelease fails (here: no token in the environment).
+func TestRunPublishReleaseReportsError(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "jeduden/mdsmith")
+	t.Setenv("RELEASE_TAG", "v1.2.3")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	assert.Equal(t, 1, run([]string{"publish-release"}))
+}
+
+// TestRunPublishReleaseFlagParseError covers the
+// reportFlagParseErr branch for an unknown flag.
+func TestRunPublishReleaseFlagParseError(t *testing.T) {
+	assert.Equal(t, 2, run([]string{"publish-release", "--bogus"}))
+}
+
+// TestRunPublishReleaseRejectsPositionalArgs covers the
+// fs.NArg() != 0 usage branch.
+func TestRunPublishReleaseRejectsPositionalArgs(t *testing.T) {
+	assert.Equal(t, 2, run([]string{"publish-release", "extra"}))
+}

--- a/docs/development/release-tooling.md
+++ b/docs/development/release-tooling.md
@@ -51,6 +51,7 @@ setup step.
 |----------------------------|--------------------------------|
 | `stamp <version>`          | `release.yml` publishing jobs  |
 | `check-release-trigger`    | `release.yml` trigger-guard    |
+| `publish-release`          | `release.yml` release job      |
 | `check`                    | `ci.yml` version-guard         |
 | `build-npm <art> <out>`    | `release.yml` npm job          |
 | `build-wheels <art> <out>` | `release.yml` pypi job         |

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -64,11 +64,22 @@ the `create` preflight sees no draft release yet.
 `pull_request_target`, `workflow_run`, and
 `release`. Those triggers can mint OIDC tokens or
 reach the PATs from a non-tag context. The `release`
-event would also still miss draft creation. When
-the run started from `create`, the final GitHub
-Release upload keeps the release in draft state. A
-normal tag push keeps the current
-published-release behavior.
+event would also still miss draft creation.
+
+The `release` job always uploads every asset to a
+**draft** release first. It then publishes the
+release as a separate final step via
+`mdsmith-release publish-release`. Uploading to a
+published release is rejected once immutable
+releases are on. So the publish must be the last
+action.
+
+A normal tag push
+(`create_release_is_draft == 'false'`) auto-publishes
+the full draft. The result is an immutable release.
+A maintainer's UI-created draft
+(`create_release_is_draft == 'true'`) is left as a
+draft for manual review and publish.
 
 `concurrency: { group: release, cancel-in-progress: false }`
 still serializes real releases tag-agnostically.

--- a/internal/release/publishrelease.go
+++ b/internal/release/publishrelease.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -108,11 +107,10 @@ type releaseRef struct {
 
 func lookupReleaseRef(client *http.Client, apiBase, repository, tag, token string) (releaseRef, bool, error) {
 	u := apiBase + "/repos/" + repository + "/releases/tags/" + url.PathEscape(tag)
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+	req, err := newGitHubRequest(http.MethodGet, u, nil, token)
 	if err != nil {
 		return releaseRef{}, false, err
 	}
-	setGitHubHeaders(req, token)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -130,22 +128,16 @@ func lookupReleaseRef(client *http.Client, apiBase, repository, tag, token strin
 	case http.StatusNotFound:
 		return releaseRef{}, false, nil
 	default:
-		return releaseRef{}, false, unexpectedStatus(u, resp)
+		return releaseRef{}, false, unexpectedStatus("lookup", u, resp)
 	}
 }
 
 func patchReleaseDraftFalse(client *http.Client, apiBase, repository string, id int64, token string) error {
 	u := fmt.Sprintf("%s/repos/%s/releases/%d", apiBase, repository, id)
-	body, err := json.Marshal(map[string]bool{"draft": false})
+	req, err := newGitHubRequest(http.MethodPatch, u, strings.NewReader(`{"draft":false}`), token)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodPatch, u, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	setGitHubHeaders(req, token)
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -154,23 +146,32 @@ func patchReleaseDraftFalse(client *http.Client, apiBase, repository string, id 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return unexpectedStatus(u, resp)
+		return unexpectedStatus("publish", u, resp)
 	}
 	return nil
 }
 
-func setGitHubHeaders(req *http.Request, token string) {
+func newGitHubRequest(method, u string, body io.Reader, token string) (*http.Request, error) {
+	req, err := http.NewRequest(method, u, body)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
 }
 
-func unexpectedStatus(u string, resp *http.Response) error {
+func unexpectedStatus(op, u string, resp *http.Response) error {
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 	if err != nil {
 		return err
 	}
 	return &releaseLookupError{
+		Op:         op,
 		URL:        u,
 		StatusCode: resp.StatusCode,
 		Body:       string(body),

--- a/internal/release/publishrelease.go
+++ b/internal/release/publishrelease.go
@@ -1,0 +1,178 @@
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultPublishReleaseRetryAttempts is how many times
+	// PublishRelease retries the by-tag lookup before concluding the
+	// draft release the `release` job just created is not visible yet.
+	DefaultPublishReleaseRetryAttempts = 3
+	// DefaultPublishReleaseRetryDelay is the pause between by-tag
+	// lookup retries while GitHub finishes materializing the release.
+	DefaultPublishReleaseRetryDelay = 2 * time.Second
+)
+
+// PublishReleaseOptions describes the GitHub release to flip from
+// draft to published and the HTTP settings to reach the API.
+type PublishReleaseOptions struct {
+	Repository string
+	Tag        string
+	Token      string
+
+	APIBaseURL    string
+	RetryAttempts int
+	RetryDelay    time.Duration
+	Client        *http.Client
+	Sleep         func(time.Duration)
+}
+
+// PublishRelease flips the draft GitHub release for opts.Tag to a
+// published release. The release is created by the `release` job's
+// softprops/action-gh-release step as a draft so that every asset
+// uploads while the release is still mutable; this call publishes it
+// as the final, atomic step so the result is an immutable release.
+//
+// Idempotent: a release that is already published is left untouched.
+func PublishRelease(opts PublishReleaseOptions) error {
+	if opts.Repository == "" {
+		return errors.New("publish-release requires repository")
+	}
+	if opts.Tag == "" {
+		return errors.New("publish-release requires tag")
+	}
+	if opts.Token == "" {
+		return errors.New("publish-release requires token")
+	}
+
+	attempts := opts.RetryAttempts
+	if attempts < 1 {
+		attempts = DefaultPublishReleaseRetryAttempts
+	}
+	delay := opts.RetryDelay
+	if delay <= 0 {
+		delay = DefaultPublishReleaseRetryDelay
+	}
+	sleep := opts.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	apiBase := strings.TrimRight(opts.APIBaseURL, "/")
+	if apiBase == "" {
+		apiBase = "https://api.github.com"
+	}
+
+	var (
+		rel   releaseRef
+		found bool
+	)
+	for attempt := 1; attempt <= attempts; attempt++ {
+		var err error
+		rel, found, err = lookupReleaseRef(client, apiBase, opts.Repository, opts.Tag, opts.Token)
+		if err != nil {
+			return err
+		}
+		if found {
+			break
+		}
+		if attempt < attempts {
+			sleep(delay)
+		}
+	}
+	if !found {
+		return fmt.Errorf("no GitHub release found for tag %s in %s", opts.Tag, opts.Repository)
+	}
+	if !rel.Draft {
+		return nil
+	}
+	return patchReleaseDraftFalse(client, apiBase, opts.Repository, rel.ID, opts.Token)
+}
+
+type releaseRef struct {
+	ID    int64 `json:"id"`
+	Draft bool  `json:"draft"`
+}
+
+func lookupReleaseRef(client *http.Client, apiBase, repository, tag, token string) (releaseRef, bool, error) {
+	u := apiBase + "/repos/" + repository + "/releases/tags/" + url.PathEscape(tag)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return releaseRef{}, false, err
+	}
+	setGitHubHeaders(req, token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return releaseRef{}, false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var rel releaseRef
+		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+			return releaseRef{}, false, fmt.Errorf("parse %s: %w", u, err)
+		}
+		return rel, true, nil
+	case http.StatusNotFound:
+		return releaseRef{}, false, nil
+	default:
+		return releaseRef{}, false, unexpectedStatus(u, resp)
+	}
+}
+
+func patchReleaseDraftFalse(client *http.Client, apiBase, repository string, id int64, token string) error {
+	u := fmt.Sprintf("%s/repos/%s/releases/%d", apiBase, repository, id)
+	body, err := json.Marshal(map[string]bool{"draft": false})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPatch, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	setGitHubHeaders(req, token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return unexpectedStatus(u, resp)
+	}
+	return nil
+}
+
+func setGitHubHeaders(req *http.Request, token string) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+}
+
+func unexpectedStatus(u string, resp *http.Response) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return err
+	}
+	return &releaseLookupError{
+		URL:        u,
+		StatusCode: resp.StatusCode,
+		Body:       string(body),
+	}
+}

--- a/internal/release/publishrelease_test.go
+++ b/internal/release/publishrelease_test.go
@@ -161,6 +161,21 @@ func TestPublishReleasePatchUnexpectedStatusErrors(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected GitHub API status 422")
+	// A PATCH (publish) failure must not be mislabeled "lookup".
+	assert.Contains(t, err.Error(), "publish ")
+	assert.NotContains(t, err.Error(), "lookup ")
+}
+
+func TestLookupReleaseRefRequestBuildError(t *testing.T) {
+	// A control character in the URL makes http.NewRequest fail,
+	// exercising newGitHubRequest's error path via the GET caller.
+	_, _, err := lookupReleaseRef(&http.Client{}, "http://\x7f", "jeduden/mdsmith", "v1", "t")
+	require.Error(t, err)
+}
+
+func TestPatchReleaseDraftFalseRequestBuildError(t *testing.T) {
+	err := patchReleaseDraftFalse(&http.Client{}, "http://\x7f", "jeduden/mdsmith", 42, "t")
+	require.Error(t, err)
 }
 
 func TestPublishReleaseUsesDefaultAPIBase(t *testing.T) {

--- a/internal/release/publishrelease_test.go
+++ b/internal/release/publishrelease_test.go
@@ -198,6 +198,52 @@ func TestPublishReleaseClientDoError(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 }
 
+func TestPublishReleasePatchTransportError(t *testing.T) {
+	sentinel := errors.New("patch boom")
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodPatch {
+			return nil, sentinel
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":5,"draft":true}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: "https://api.example.com",
+		Client:     client,
+	})
+	require.ErrorIs(t, err, sentinel)
+}
+
+type errBody struct{}
+
+func (errBody) Read([]byte) (int, error) { return 0, errors.New("read boom") }
+func (errBody) Close() error             { return nil }
+
+func TestPublishReleaseUnexpectedStatusBodyReadError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errBody{},
+			Header:     make(http.Header),
+		}, nil
+	})}
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: "https://api.example.com",
+		Client:     client,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read boom")
+}
+
 func TestPublishReleaseInvalidJSONErrors(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, `{not json`)

--- a/internal/release/publishrelease_test.go
+++ b/internal/release/publishrelease_test.go
@@ -1,0 +1,215 @@
+package release
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishReleaseFlipsDraftToPublished(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gets    int
+		patched bool
+		patchID string
+		gotBody map[string]bool
+		authHdr []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		authHdr = append(authHdr, r.Header.Get("Authorization"))
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/jeduden/mdsmith/releases/tags/v1.2.3":
+			gets++
+			if gets == 1 {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = fmt.Fprint(w, `{"id":42,"draft":true}`)
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/jeduden/mdsmith/releases/42":
+			patched = true
+			patchID = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = fmt.Fprint(w, `{"id":42,"draft":false}`)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusTeapot)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var sleeps int
+	err := PublishRelease(PublishReleaseOptions{
+		Repository:    "jeduden/mdsmith",
+		Tag:           "v1.2.3",
+		Token:         "test-token",
+		APIBaseURL:    srv.URL,
+		RetryAttempts: 3,
+		RetryDelay:    time.Millisecond,
+		Sleep:         func(time.Duration) { sleeps++ },
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, gets)
+	assert.Equal(t, 1, sleeps)
+	assert.True(t, patched)
+	assert.Equal(t, "/repos/jeduden/mdsmith/releases/42", patchID)
+	assert.Equal(t, map[string]bool{"draft": false}, gotBody)
+	for _, h := range authHdr {
+		assert.Equal(t, "Bearer test-token", h)
+	}
+}
+
+func TestPublishReleaseAlreadyPublishedIsNoOp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("already-published release must not be patched, got %s", r.Method)
+		}
+		_, _ = fmt.Fprint(w, `{"id":7,"draft":false}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "test-token",
+		APIBaseURL: srv.URL,
+	})
+	require.NoError(t, err)
+}
+
+func TestPublishReleaseMissingAfterRetriesErrors(t *testing.T) {
+	var calls, sleeps int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := PublishRelease(PublishReleaseOptions{
+		Repository:    "jeduden/mdsmith",
+		Tag:           "v9.9.9",
+		Token:         "t",
+		APIBaseURL:    srv.URL,
+		RetryAttempts: 2,
+		RetryDelay:    time.Millisecond,
+		Sleep:         func(time.Duration) { sleeps++ },
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no GitHub release found for tag v9.9.9")
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, 1, sleeps)
+}
+
+func TestPublishReleaseRequiresRepositoryTagToken(t *testing.T) {
+	err := PublishRelease(PublishReleaseOptions{Tag: "v1", Token: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository")
+
+	err = PublishRelease(PublishReleaseOptions{Repository: "r", Token: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag")
+
+	err = PublishRelease(PublishReleaseOptions{Repository: "r", Tag: "v1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestPublishReleaseLookupUnexpectedStatusErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"message":"boom"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: srv.URL,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected GitHub API status 500")
+}
+
+func TestPublishReleasePatchUnexpectedStatusErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = fmt.Fprint(w, `{"id":3,"draft":true}`)
+			return
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"message":"immutable"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: srv.URL,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected GitHub API status 422")
+}
+
+func TestPublishReleaseUsesDefaultAPIBase(t *testing.T) {
+	var gotURL string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotURL = r.URL.String()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id":1,"draft":false}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		Client:     client,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.github.com/repos/jeduden/mdsmith/releases/tags/v1.2.3", gotURL)
+}
+
+func TestPublishReleaseClientDoError(t *testing.T) {
+	sentinel := errors.New("transport boom")
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, sentinel
+	})}
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: "https://api.example.com",
+		Client:     client,
+	})
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestPublishReleaseInvalidJSONErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{not json`)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: srv.URL,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse ")
+}

--- a/internal/release/triggerguard.go
+++ b/internal/release/triggerguard.go
@@ -106,13 +106,21 @@ type releaseLookupPayload struct {
 }
 
 type releaseLookupError struct {
+	// Op labels the failing operation in the error message. Empty
+	// defaults to "lookup" so existing GET-by-tag callers are
+	// unaffected; PATCH callers pass "publish".
+	Op         string
 	URL        string
 	StatusCode int
 	Body       string
 }
 
 func (e *releaseLookupError) Error() string {
-	msg := fmt.Sprintf("lookup %s: unexpected GitHub API status %d", e.URL, e.StatusCode)
+	op := e.Op
+	if op == "" {
+		op = "lookup"
+	}
+	msg := fmt.Sprintf("%s %s: unexpected GitHub API status %d", op, e.URL, e.StatusCode)
 	body := strings.TrimSpace(e.Body)
 	if body == "" {
 		return msg


### PR DESCRIPTION
## Summary

Adds a new `mdsmith-release publish-release` command that flips GitHub draft releases to published state. This enables the release workflow to upload all assets to a mutable draft release first, then atomically publish it as the final step — required for GitHub's immutable releases enforcement.

## Changes

- **New `internal/release` package** with `PublishRelease()` function that:
  - Looks up a release by tag with configurable retry logic (handles GitHub's eventual consistency)
  - Checks if the release is already published (idempotent)
  - Patches the release to set `draft: false` if needed
  - Uses proper GitHub API headers (Bearer token auth, API version pinning)

- **New `cmd/mdsmith-release/publishrelease.go` subcommand** that:
  - Reads `GITHUB_REPOSITORY`, `RELEASE_TAG`, `GITHUB_TOKEN`, and `GITHUB_API_URL` from environment
  - Delegates to the `PublishRelease()` function
  - Integrates with existing mdsmith-release CLI structure

- **Updated `.github/workflows/release.yml`**:
  - Changed `softprops/action-gh-release` to always create releases as drafts (`draft: true`)
  - Added checkout and Go setup steps to the publish job
  - Added new "Publish release" step that runs `go run ./cmd/mdsmith-release publish-release` only on tag pushes (not UI-created drafts)
  - Updated smoke-test to skip mise channel on UI-draft path (assets not publicly downloadable until published)

- **Comprehensive test coverage** (`internal/release/publishrelease_test.go`):
  - Happy path: draft → published with retries
  - Already-published releases are no-op
  - Retry exhaustion errors appropriately
  - Validation of required options
  - HTTP error handling (unexpected status codes, JSON parse errors, transport errors)
  - Default API base URL behavior
  - Custom HTTP client support

- **Documentation updates** in `docs/development/release.md` and `docs/development/release-tooling.md` explaining the two-phase release strategy (draft upload + atomic publish).

## Implementation Details

- Retry logic with configurable attempts and delay handles GitHub's eventual consistency when looking up newly-created releases
- Idempotent design: already-published releases are left untouched
- Proper HTTP client lifecycle management with request/response cleanup
- GitHub API v2022-11-28 with Bearer token authentication
- Separates draft creation (always happens) from publishing (conditional on tag push vs. UI draft)

https://claude.ai/code/session_014crGVw5Bwiv3nv4EoBimbz