### PR TITLE
Implement plan 156: unify section schema entry shape

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ row: "- [{summary}](../{filename})"
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](../docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](../docs/reference/globs.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](../docs/reference/schema-types.md)
-- [Section-schema reference: the entry-shape vocabulary used in inline `kinds.<name>.schema:` blocks and `proto.md` files. Covers the `heading:` discriminator, the `regex:` matcher (a CUE expression with `digits` and `fmvar` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm.](../docs/reference/section-schema.md)
+- [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](../docs/reference/section-schema.md)
 <?/catalog?>
 
 ### Development Workflow
@@ -223,6 +223,12 @@ layout](https://go.dev/doc/modules/layout):
 - Error messages should be lowercase, no trailing
   punctuation
 - Prefer returning errors over panicking
+
+#### Defensive Code
+
+Add a defensive branch only when you can drive it
+red/green. Write the failing test first. Then add
+the code that takes the branch.
 
 #### Test Fixtures
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-mdsmith-pinned-version
-      - run: mdsmith check .
+      # Plan 156 reshaped the inline schema vocabulary; the pinned
+      # baseline binary (v0.15.0) cannot parse the new form in
+      # .mdsmith.yml. .mdsmith.pinned.yml restates the inline
+      # schemas in the pre-156 shape so the pinned binary can lint
+      # the tree. Delete this -c flag (and .mdsmith.pinned.yml)
+      # once setup-mdsmith-pinned-version advances past v0.15.0.
+      - run: mdsmith check -c .mdsmith.pinned.yml .
 
   demo:
     uses: ./.github/workflows/record-demo.yml

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -36,6 +36,24 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-mdsmith-pinned-version
+      # The pinned merge driver / pre-merge-commit hook installer
+      # reads .mdsmith.yml to derive merge-driver attribute globs;
+      # the merge driver's `run` step (invoked by git during a
+      # merge) does the same. v0.15.0 cannot parse plan 156's
+      # inline schema vocabulary, so the workflow swaps in
+      # .mdsmith.pinned.yml — a config restated in the pre-156
+      # shape — for the entire job lifetime. `update-index
+      # --skip-worktree` keeps the swap invisible to git so the
+      # later checkout/merge operations performed by
+      # merge-queue-action don't trip "local changes would be
+      # overwritten" or try to restore the new-shape config
+      # mid-merge. Remove this block once
+      # setup-mdsmith-pinned-version advances past v0.15.0 (and
+      # delete .mdsmith.pinned.yml).
+      - name: Use pinned-binary config for merge driver
+        run: |
+          cp .mdsmith.pinned.yml .mdsmith.yml
+          git update-index --skip-worktree .mdsmith.yml
       - name: Install mdsmith merge driver and pre-merge-commit hook
         run: |
           mdsmith merge-driver install

--- a/.mdsmith.pinned.yml
+++ b/.mdsmith.pinned.yml
@@ -1,3 +1,14 @@
+## .mdsmith.pinned.yml — config consumed by the pinned mdsmith
+## binary in the `mdsmith-fixed-version` CI gate and by the
+## merge-queue workflow's `mdsmith merge-driver install` step.
+## Plan 156 reshaped the inline schema vocabulary; v0.15.0
+## (the current pinned baseline) cannot parse the new form, so
+## this file restates each inline `kinds.<name>.schema:` block
+## in the pre-plan-156 shape (`required: false`, `unlisted: true`,
+## `require.filename:`). Everything outside the inline schemas
+## mirrors .mdsmith.yml verbatim — keep the two files in lockstep
+## when editing project-wide config, then delete this file once
+## setup-mdsmith-pinned-version advances past v0.15.0.
 front-matter: true
 
 rules:
@@ -328,9 +339,9 @@ kinds:
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   cli-command:
     schema:
       frontmatter:
@@ -339,9 +350,9 @@ kinds:
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   release-channel:
     schema:
       frontmatter:
@@ -350,19 +361,14 @@ kinds:
         registry: 'string & != ""'
         credential: 'string & != ""'
         job: 'string & != ""'
-        # channelurl + weight drive the homepage "Distributed
-        # via" strip (website/layouts/partials/logos-strip.html),
-        # which ranges these docs instead of a data file.
-        # Not `url`: Hugo treats a front-matter `url` as a page
-        # URL override and rejects an absolute http(s) value.
         channelurl: 'string & =~ "^https?://"'
         weight: 'int & >=1'
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   secret-rotation:
     schema:
       frontmatter:
@@ -378,28 +384,24 @@ kinds:
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   audit-log:
     schema:
       frontmatter:
         title: 'string & != ""'
         "summary?": 'string'
         audit-from: '=~"^[0-9a-f]{7,40}$"'
-      filename: "architecture-audit.md"
+      require:
+        filename: "architecture-audit.md"
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   feature:
-    # Marketing feature pages under docs/features/. The homepage
-    # feature grid (website/layouts/partials/feature-grid.html)
-    # and the README <?include?> both depend on this front
-    # matter, so the schema makes a missing/typo'd field fail
-    # `mdsmith check` instead of silently breaking a card.
     schema:
       frontmatter:
         title: 'string & != ""'
@@ -411,13 +413,10 @@ kinds:
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   feature-index:
-    # docs/features/index.md is the shared "Why mdsmith"
-    # overview, not a card: it carries only title + summary
-    # (no icon/weight), so it gets its own kind.
     schema:
       frontmatter:
         title: 'string & != ""'
@@ -425,9 +424,9 @@ kinds:
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
   website-page:
     # Hugo content pages under website/content/. Scoped to the
     # top level only (no **) so the kind covers hand-authored
@@ -447,19 +446,14 @@ kinds:
       frontmatter:
         title: 'string & != ""'
         summary: 'string & != ""'
-        # The homepage carries its hero copy and install
-        # quickstart in its own front matter (read by
-        # hero.html / install-list.html) instead of a
-        # separate data file. Open structs: Hugo templates
-        # consume the specific keys.
         "hero?": '{...}'
         "install?": '[...{...}]'
       closed: false
       sections:
         - heading: null
+          required: false
         - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+            unlisted: true
     rules:
       first-line-heading: false
       heading-increment: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ row: "- [{summary}]({filename})"
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](docs/reference/schema-types.md)
-- [Section-schema reference: the entry-shape vocabulary used in inline `kinds.<name>.schema:` blocks and `proto.md` files. Covers the `heading:` discriminator, the `regex:` matcher (a CUE expression with `digits` and `fmvar` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm.](docs/reference/section-schema.md)
+- [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](docs/reference/section-schema.md)
 <?/catalog?>
 
 ## Development Workflow
@@ -228,6 +228,12 @@ layout](https://go.dev/doc/modules/layout):
 - Error messages should be lowercase, no trailing
   punctuation
 - Prefer returning errors over panicking
+
+### Defensive Code
+
+Add a defensive branch only when you can drive it
+red/green. Write the failing test first. Then add
+the code that takes the branch.
 
 ### Test Fixtures
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ row: "- [{summary}]({filename})"
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](docs/reference/schema-types.md)
-- [Section-schema reference: the entry-shape vocabulary used in inline `kinds.<name>.schema:` blocks and `proto.md` files. Covers the `heading:` discriminator, the `regex:` matcher (a CUE expression with `digits` and `fmvar` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm.](docs/reference/section-schema.md)
+- [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](docs/reference/section-schema.md)
 <?/catalog?>
 
 ## Development Workflow
@@ -214,6 +214,12 @@ layout](https://go.dev/doc/modules/layout):
 - Error messages should be lowercase, no trailing
   punctuation
 - Prefer returning errors over panicking
+
+### Defensive Code
+
+Add a defensive branch only when you can drive it
+red/green. Write the failing test first. Then add
+the code that takes the branch.
 
 ### Test Fixtures
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -84,7 +84,7 @@ footer: |
 | 154 | ✅     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
 | 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
 | 156 | 🔲     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                        |
-| 156 | 🔲     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
+| 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
 | 157 | 🔳     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
 | 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                      |
 | 161 | 🔲     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -59,6 +59,12 @@ layout](https://go.dev/doc/modules/layout):
   punctuation
 - Prefer returning errors over panicking
 
+## Defensive Code
+
+Add a defensive branch only when you can drive it
+red/green. Write the failing test first. Then add
+the code that takes the branch.
+
 ## Test Fixtures
 
 Rule test fixtures live in

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -15,13 +15,18 @@ they are the canonical place to lock down the shape
 of a recurring document type (plan, RFC, runbook,
 rule README).
 
-mdsmith reads schemas from two sources that share one
-in-memory representation:
+mdsmith reads schemas from two sources:
 
 - **Inline** — a `schema:` block on a kind body in
-  `.mdsmith.yml`.
+  `.mdsmith.yml`. Uses the new matcher engine
+  (`regex:`, `repeat:`, `\#(digits)`, `\#(fmvar(...))`).
 - **File** — a `proto.md` referenced by
-  `rules.required-structure.schema:`.
+  `rules.required-structure.schema:`. MDS020 still
+  validates this source through its legacy parser
+  today; the schema-package parser shipped with plan
+  156 lifts proto.md into the same matcher shape but
+  is exercised only by tests until the cutover
+  follow-up wires MDS020 through.
 
 A kind may use only one source; setting both is a
 config error.
@@ -37,24 +42,20 @@ templated body content.
 kinds:
   rfc:
     schema:
+      filename: "RFC-[0-9][0-9][0-9][0-9].md"
       frontmatter:
         id: '=~"^RFC-[0-9]{4}$"'
         status: '"draft" | "ratified" | "deprecated"'
         authors: '[...string] & len(authors) >= 1'
-      require:
-        filename: "RFC-[0-9][0-9][0-9][0-9].md"
       closed: true
       sections:
         - heading: null
-          required: false
         - heading: "Overview"
-          required: true
         - heading: "Decision"
-          required: true
         - heading:
-            unlisted: true
+            regex: '.+'
+            repeat: { min: 0 }
         - heading: "References"
-          required: true
 ```
 
 The `frontmatter:` mapping reuses CUE expressions per
@@ -68,40 +69,86 @@ the ISO regex; see
 [Schema field types](../reference/schema-types.md)
 for the registered names and how they are matched.
 
-`require.filename:` is a glob the document basename
-must match.
+`filename:` is a glob the document basename must
+match. It sits at the top of the schema block (no
+`require:` wrapper).
 
 `closed: true` makes the scope strict — unlisted
 headings produce a diagnostic. `closed: false` (the
 default) tolerates unlisted headings between listed
-sections.
+sections. `closed:` is only meaningful when the
+schema declares `sections:`; setting it on a
+frontmatter-only kind is a parse error.
 
-### The `heading:` field
+### The `heading:` discriminator
 
 Every section-array entry sets `heading:`. The value
 takes one of three shapes:
 
-- **string** — literal heading text. Example:
-  `heading: "Overview"`. The doc must have a heading
-  whose text equals that string (or an alias).
 - **`null`** — the preamble: content from line 1 up
   to the first heading. Only valid as the first entry
-  in a section list. Carries `required:` /
-  `closed:` / `rules:` for that range; cannot carry
-  `aliases:` or nested `sections:`.
-- **mapping** — typed match. Today only
-  `{unlisted: true}` is accepted, declaring a slot
-  that absorbs zero or more sections the schema did
-  not list by name. The slot is positional, but
-  out-of-order detection still claims a heading whose
-  text matches a later listed scope, so the slot only
-  absorbs truly-unlisted sections. Slots are
-  positional-only — they cannot carry `aliases:`,
-  `sections:`, `rules:`, `closed:`, or `required:`;
-  the parser rejects those keys. Future work can
-  extend the mapping form with shapes like
-  `{any: true}` (match any heading text) or
-  `{pattern: "..."}` (match a placeholder pattern).
+  in a section list. Carries `closed:` / `rules:` /
+  `content:` for that range; rejects `sections:`.
+- **string** — sugar for a literal match. The string
+  is regex-escaped and used as the matcher's pattern,
+  so `heading: "(WIP)"` matches a heading whose text
+  is exactly `(WIP)` with the parens taken literally.
+  Cardinality is one.
+- **mapping** — the full form:
+  `{ regex, repeat?, sequential? }`. `regex:` is
+  required; the body is a Go RE2 pattern that
+  accepts two interpolation references —
+  `\#(digits)` and `\#(fmvar(name))`. `repeat:`
+  bounds the run; `sequential:` (with `digits`)
+  asserts ordering. See the
+  [section-schema reference](../reference/section-schema.md)
+  for the full grammar.
+
+### The matcher mapping
+
+```yaml
+sections:
+  - heading:
+      regex: 'Step \#(digits)'
+      repeat: { min: 1, max: 5 }
+      sequential: true
+    sections: [...]
+    content: [...]
+  - heading:
+      regex: '\#(fmvar(id)): \#(fmvar(name))'
+  - heading:
+      regex: '.+'
+      repeat: { min: 0 }
+```
+
+`regex:` is whole-string anchored against the
+heading's rendered plain text (inline emphasis stripped,
+link wrappers unwrapped, code-span backticks dropped).
+Backslashes pass through to RE2; interpolation uses
+`\#(expr)`. Two helpers are in scope:
+
+- **`digits`** — expands to the named capture
+  `(?P<n>[0-9]+)`. One per pattern. With
+  `sequential: true` the validator asserts the
+  captured numbers are strictly increasing without
+  gaps.
+- **`fmvar(name)`** — looks up the document's
+  frontmatter field `name`, regex-escapes its value,
+  and substitutes it.
+
+`repeat:` bounds how many consecutive matching
+headings the matcher claims. Omitting `repeat:`
+means exactly one; `{ min: 0 }` is zero-or-more;
+`{ min: 0, max: 1 }` is optional; `{ min: 1 }` is
+one-or-more; bounded forms enforce both bounds.
+`repeat: { max: 0 }` and `repeat: { min > max }`
+each parse-error.
+
+The wildcard-slot shape — `regex: '.+'` with
+`repeat: { min: 0 }` — is positional: it absorbs
+zero or more unlisted sections at its slot. A
+heading whose text matches a later listed entry is
+claimed for that entry, not absorbed by the slot.
 
 ### Nested sections
 
@@ -112,29 +159,25 @@ expresses that as:
 
 ```yaml
 sections:
-  - heading: "Symptoms"
-    required: true
-    aliases: ["Indicators"]
+  - heading:
+      regex: 'Symptoms|Indicators'
   - heading: "Diagnosis"
-    required: true
     sections:
       - heading: "Step"
-        required: true
         sections:
           - heading: "Check"
-            required: true
           - heading: "Expected"
-            required: true
-          - heading: "If different"
-            required: false
-  - heading: "References"
-    required: false
+          - heading:
+              regex: 'If different'
+              repeat: { min: 0, max: 1 }
+  - heading:
+      regex: 'References'
+      repeat: { min: 0, max: 1 }
 ```
 
-`aliases:` lets a heading match alternate texts. A
-required scope that lists `aliases: ["Indicators"]`
-matches both `## Symptoms` and `## Indicators` in a
-document.
+A scope that accepts alternate heading texts encodes
+the disjunction in its regex: `regex: 'A|B'` matches
+a heading whose text is `A` or `B`.
 
 ### Section content
 
@@ -179,10 +222,10 @@ ordered/min/max) emit their own diagnostics but
 still consume the slot. Missing required entries
 anchor at the section's heading line.
 
-`content:` is not accepted on slot scopes
-(`heading: {unlisted: true}`) or on the `?`
-wildcard heading — the parser rejects those
-shapes today.
+`content:` is rejected on a slot scope (the
+wildcard-slot shape has no fixed identity to
+constrain). Set `content:` only on entries that
+match named sections.
 
 ### Per-scope rule overrides
 
@@ -197,7 +240,6 @@ document" without scattering glob overrides.
 ```yaml
 sections:
   - heading: "Decision"
-    required: true
     rules:
       paragraph-readability:
         max-index: 12.0
@@ -364,9 +406,20 @@ filename: "MDS*-*.md"
 The `# ?` (or `# {field}: {field}` form) acts as the
 title placeholder. `## ...` rows mark wildcard slots.
 Front-matter keys map directly to CUE expressions.
-`<?require?>` declares the filename pattern. See
-[enforcing document structure](directives/enforcing-structure.md)
-for the full file-based reference.
+`<?require?>` declares the filename pattern.
+
+MDS020's file-schema check still routes through
+its legacy parser today: `{field}` in a proto.md
+heading row matches a non-empty run rather than
+resolving the document's frontmatter value via
+`fmvar(...)`. The schema package parses proto.md
+into the new Matcher shape (used by tests), and a
+follow-up plan will wire MDS020 through that
+parser. Until then, treat `{field}` in proto.md
+heading rows as a wildcard placeholder, not as a
+frontmatter substitution. The
+[section-schema reference](../reference/section-schema.md#protomd-file-syntax)
+records the eventual mapping.
 
 ## Choosing a source
 
@@ -394,6 +447,8 @@ mismatch`, and `out of order` mean.
 
 ## See also
 
+- [Section schema reference](../reference/section-schema.md)
+  — the entry-shape grammar in full.
 - [File kinds](file-kinds.md) — how kinds attach
   schemas (and other rule config) to file groups.
 - [Enforcing document structure with schemas](directives/enforcing-structure.md)

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -1,24 +1,18 @@
 ---
 summary: >-
-  Section-schema reference: the entry-shape
-  vocabulary used in inline `kinds.<name>.schema:`
-  blocks and `proto.md` files. Covers the
+  Section-schema reference for inline
+  `kinds.<name>.schema:` blocks. Covers the
   `heading:` discriminator, the `regex:` matcher
-  (a CUE expression with `digits` and `fmvar`
-  helpers), the `repeat: {min, max}` cardinality
-  field, and the matching algorithm.
+  (a Go RE2 body with `\#(digits)` and
+  `\#(fmvar(...))` helpers), the
+  `repeat: {min, max}` cardinality field, and the
+  matching algorithm. `proto.md` files are
+  parsed into the same shape by the schema
+  package, but MDS020's file-schema check still
+  uses its legacy parser; see the proto.md
+  section below for what is and is not migrated.
 ---
 # Section schema
-
-> **Status: upcoming.** This page documents the
-> shape defined by
-> [plan 156](../../plan/156_schema-entry-unification.md).
-> It is not yet implemented. The current parser
-> accepts the older shape documented in the
-> [schema guide](../guides/schemas.md). When plan
-> 156 lands, this notice is removed and the guide
-> is rewritten to drop every reference to the old
-> shape.
 
 A **section schema** describes the heading
 structure mdsmith expects in a document. It
@@ -118,20 +112,19 @@ value is a mapping.
 
 ## The regex matcher
 
-`regex:` is a CUE expression evaluating to a
-string. The string is compiled as Go RE2.
-
-The YAML value is the body of a CUE
-raw-interpolation string. mdsmith wraps it in
-`#"..."#` before evaluating. Two consequences:
+`regex:` is a Go RE2 pattern body. mdsmith
+recognizes two interpolation references in the
+pattern surface — borrowed from CUE's
+raw-interpolation syntax (`\#(expr)`) — but it
+does not actually evaluate the body as CUE. Two
+consequences:
 
 - **Backslash is literal.** Write `\d`, `\w`,
   `\.`, `\(` directly — no doubling. Plain
   RE2 patterns work as-is.
-- **Interpolation is `\#(expr)`.** Inside the
-  string, `\#(x)` evaluates `x` in the CUE
-  scope (frontmatter fields plus mdsmith
-  helpers) and substitutes the result.
+- **Interpolation is `\#(expr)`.** Only the two
+  helpers below are accepted; any other `expr`
+  parse-errors with "unknown helper".
 
 **Anchoring.** Whole-string. `regex: 'Overview'`
 matches a heading whose text is exactly
@@ -262,13 +255,24 @@ schema:
 
 ## `proto.md` file syntax
 
+> **Migration status.** MDS020's file-schema
+> check still uses the legacy `parseSchema`
+> pipeline today: `## ?` and `## ...` already
+> behave as wildcards, and `{field}` in a
+> heading row matches a non-empty run rather
+> than resolving the frontmatter value via
+> `fmvar(...)`. The mapping below is what the
+> schema package parses. Tests exercise it so a
+> follow-up cutover plan can wire MDS020
+> through without docs churn. Until then,
+> proto.md authors should treat `{field}` as a
+> wildcard, not a frontmatter substitution.
+
 Proto.md files use a literal-template surface
 distinct from the inline `regex:` form. Heading
 rows in the body act as the schema's
 `sections:` list. `{n}` and `{field}` survive
-here as template placeholders; they desugar to
-the same matcher the inline form produces with
-`digits` and `fmvar`.
+here as template placeholders.
 
 | Row syntax        | Equivalent inline entry                        |
 |-------------------|------------------------------------------------|
@@ -294,7 +298,6 @@ the replacement.
 
 | Old shape                          | New shape                                            |
 |------------------------------------|------------------------------------------------------|
-| `aliases: [A, B]`                  | `regex: 'A\|B'`                                      |
 | `required: true`                   | default (omit `repeat:`)                             |
 | `required: false`                  | `repeat: { min: 0, max: 1 }`                         |
 | `heading: { unlisted: true }`      | `heading: { regex: '.+', repeat: { min: 0 } }`       |
@@ -302,3 +305,9 @@ the replacement.
 | Scope-level `min:` / `max:`        | `repeat: { min, max }`                               |
 | `require: { filename: "..." }`     | top-level `filename: "..."`                          |
 | `closed:` on frontmatter-only kind | dropped (no `sections:` → strictness has no meaning) |
+
+`aliases: [A, B]` migrates to a regex
+disjunction. Write `regex: 'A|B'`. The pipe is a
+plain RE2 alternation, not an escape. (Kept out
+of the table because Markdown swallows `\|`
+inside code spans inconsistently.)

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -103,40 +103,36 @@ same in-memory scope tree — and a kind may use only one.
 kinds:
   rfc:
     schema:
+      filename: "RFC-[0-9][0-9][0-9][0-9].md"
       frontmatter:
         id: '=~"^RFC-[0-9]{4}$"'
         status: '"draft" | "ratified" | "deprecated"'
         authors: '[...string] & len(authors) >= 1'
-      require:
-        filename: "RFC-[0-9][0-9][0-9][0-9].md"
       closed: true
       sections:
         - heading: null
-          required: false
         - heading: "Overview"
-          required: true
         - heading: "Decision"
-          required: true
           sections:
             - heading: "Outcome"
-              required: true
         - heading:
-            unlisted: true
+            regex: '.+'
+            repeat: { min: 0 }
         - heading: "References"
-          required: true
 ```
 
 Section keys:
 
-- `heading:` — string (literal), `null` (preamble), or
-  `{unlisted: true}` (positional slot). Level comes from
-  depth (root sections are H2).
-- `required:` — defaults to `true`. Preamble entries
-  typically set `required: false`.
-- `aliases:` — alternate heading texts. Not allowed
-  on preamble or slot entries (no name to alias).
+- `heading:` — discriminator. `null` for the preamble
+  (content before any heading; valid only as the
+  first entry), a string for an exact-match literal
+  (regex-escaped into the matcher), or a mapping
+  `{ regex, repeat?, sequential? }` for the full
+  form. The level for string headings comes from
+  depth in the tree (root sections are H2; nested
+  sections are H3, then H4, …).
 - `sections:` — nested sections one level deeper.
-  Not allowed on preamble entries (the first heading
+  Rejected on preamble entries (the first heading
   terminates the preamble's range).
 - `closed:` — when `true`, unlisted headings inside
   this scope produce a diagnostic. The same flag
@@ -156,17 +152,23 @@ Section keys:
   See
   [the schemas guide](../../../docs/guides/schemas.md#section-content)
   for the entry shape and the per-kind fields.
-  Rejected on slot or `?` wildcard scopes.
+  Rejected on slot scopes.
 
-A slot (`heading: {unlisted: true}`) absorbs zero or more
-unlisted sections at its position. Out-of-order detection
-still claims a heading whose text matches a later listed
-scope, so the slot only absorbs truly-unlisted sections.
-Slots reject `aliases:`, `sections:`, `rules:`, `closed:`,
-and `required:`. The preamble (`heading: null`) accepts
-`required:`, `closed:`, and `rules:` but rejects
-`aliases:` and `sections:`. H1 is owned by
-`first-line-heading`; inline schemas constrain H2 and below.
+The wildcard slot — `{ regex: '.+', repeat: { min: 0 } }` —
+absorbs zero or more unlisted sections at its position.
+Surrounding listed sections keep their order; out-of-order
+detection still claims a heading whose text matches a later
+listed scope. Slots reject `sections:`, `rules:`,
+`closed:`, and `content:`. The preamble (`heading: null`)
+accepts `closed:`, `rules:`, and `content:` for its line
+range but rejects `sections:`.
+
+See the
+[section-schema reference](../../../docs/reference/section-schema.md)
+for the full grammar — `regex:` body, `digits` /
+`fmvar(name)` helpers, and `repeat: { min, max }`. H1 is
+reserved for `first-line-heading`; inline schemas
+constrain H2 and below.
 
 ### Cross-references
 

--- a/internal/rules/MDS020-required-structure/bad/inline-closed-unlisted.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-closed-unlisted.md
@@ -4,9 +4,7 @@ settings:
     closed: true
     sections:
       - heading: "Overview"
-        required: true
       - heading: "Decision"
-        required: true
 diagnostics:
   - line: 7
     column: 1

--- a/internal/rules/MDS020-required-structure/bad/inline-level-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-level-mismatch.md
@@ -3,10 +3,8 @@ settings:
   inline-schema:
     sections:
       - heading: "Diagnosis"
-        required: true
         sections:
           - heading: "Step"
-            required: true
 diagnostics:
   - line: 5
     column: 1

--- a/internal/rules/MDS020-required-structure/bad/inline-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-missing.md
@@ -3,9 +3,7 @@ settings:
   inline-schema:
     sections:
       - heading: "Goal"
-        required: true
       - heading: "Tasks"
-        required: true
 diagnostics:
   - line: 1
     column: 1

--- a/internal/rules/MDS020-required-structure/good/inline-acronyms-scoped.md
+++ b/internal/rules/MDS020-required-structure/good/inline-acronyms-scoped.md
@@ -3,9 +3,9 @@ settings:
   inline-schema:
     sections:
       - heading: "Check"
-        required: true
-      - heading: "Notes"
-        required: false
+      - heading:
+          regex: 'Notes'
+          repeat: { min: 0, max: 1 }
     acronyms:
       scope: ["Check"]
       known-safe: [API]

--- a/internal/rules/MDS020-required-structure/good/inline-flat.md
+++ b/internal/rules/MDS020-required-structure/good/inline-flat.md
@@ -3,9 +3,7 @@ settings:
   inline-schema:
     sections:
       - heading: "Goal"
-        required: true
       - heading: "Tasks"
-        required: true
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/good/inline-runbook.md
+++ b/internal/rules/MDS020-required-structure/good/inline-runbook.md
@@ -2,23 +2,20 @@
 settings:
   inline-schema:
     sections:
-      - heading: "Symptoms"
-        required: true
-        aliases: ["Indicators"]
+      - heading:
+          regex: 'Symptoms|Indicators'
       - heading: "Diagnosis"
-        required: true
         sections:
           - heading: "Step"
-            required: true
             sections:
               - heading: "Check"
-                required: true
               - heading: "Expected"
-                required: true
-              - heading: "If different"
-                required: false
-      - heading: "References"
-        required: false
+              - heading:
+                  regex: 'If different'
+                  repeat: { min: 0, max: 1 }
+      - heading:
+          regex: 'References'
+          repeat: { min: 0, max: 1 }
 ---
 # Runbook
 

--- a/internal/rules/MDS020-required-structure/good/inline-wildcard.md
+++ b/internal/rules/MDS020-required-structure/good/inline-wildcard.md
@@ -4,11 +4,10 @@ settings:
     closed: true
     sections:
       - heading: "Overview"
-        required: true
       - heading:
-          unlisted: true
+          regex: '.+'
+          repeat: { min: 0 }
       - heading: "References"
-        required: true
 ---
 # RFC
 

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -150,7 +150,10 @@ func TestCheck_InlineSchema_WildcardSlot(t *testing.T) {
 		"closed": true,
 		"sections": []any{
 			map[string]any{"heading": "Overview"},
-			map[string]any{"heading": map[string]any{"unlisted": true}},
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 0},
+			}},
 			map[string]any{"heading": "References"},
 		},
 	})}
@@ -167,15 +170,13 @@ func TestCheck_InlineSchema_NestedThreeLevels(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  "Diagnosis",
-				"required": true,
+				"heading": "Diagnosis",
 				"sections": []any{
 					map[string]any{
-						"heading":  "Step",
-						"required": true,
+						"heading": "Step",
 						"sections": []any{
-							map[string]any{"heading": "Check", "required": true},
-							map[string]any{"heading": "Expected", "required": true},
+							map[string]any{"heading": "Check"},
+							map[string]any{"heading": "Expected"},
 						},
 					},
 				},
@@ -206,10 +207,9 @@ func TestCheck_InlineSchema_LevelMismatch(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  "Diagnosis",
-				"required": true,
+				"heading": "Diagnosis",
 				"sections": []any{
-					map[string]any{"heading": "Step", "required": true},
+					map[string]any{"heading": "Step"},
 				},
 			},
 		},
@@ -229,25 +229,22 @@ func TestCheck_InlineSchema_LevelMismatch(t *testing.T) {
 	expectDiagMsg(t, our, "expected h3")
 }
 
-func TestCheck_InlineSchema_AliasMatches(t *testing.T) {
+func TestCheck_InlineSchema_DisjunctionMatches(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading": "Symptoms",
-				"aliases": []any{"Indicators"},
+				"heading": map[string]any{"regex": "Symptoms|Indicators"},
 			},
 		},
 	})}
 	f := newTestFile(t, "doc.md", "# Runbook\n\n## Indicators\n\nx\n")
 	diags := r.Check(f)
-	assert.Empty(t, diags, "alias should match in place of primary heading")
+	assert.Empty(t, diags, "regex disjunction should match the alternate text")
 }
 
 func TestCheck_InlineSchema_FilenamePattern(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
-		"require": map[string]any{
-			"filename": "RFC-[0-9][0-9][0-9][0-9].md",
-		},
+		"filename": "RFC-[0-9][0-9][0-9][0-9].md",
 	})}
 	f := newTestFile(t, "draft.md", "# Draft\n")
 	diags := r.Check(f)
@@ -352,6 +349,95 @@ func TestCheck_InlineSchema_ScopeRuleDoesNotLeakAcrossSiblings(t *testing.T) {
 		"strict override must not extend into the sibling H3 section")
 }
 
+// TestCheck_InlineSchema_RuleOverrideAppliesToEveryRepeatedOccurrence
+// verifies the per-scope rule override path through `Rule.Check`:
+// when a repeated scope (`repeat: { min: 1, max: N }`) carries a
+// `rules:` block, the override must apply inside every matched
+// section, not just the first occurrence. The plan156 acceptance
+// suite covers the structural walker via acronym ranges as a
+// proxy; this integration test exercises the MDS020 rule directly
+// so a regression in `runScopeRules` would surface.
+func TestCheck_InlineSchema_RuleOverrideAppliesToEveryRepeatedOccurrence(t *testing.T) {
+	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Strict",
+					"repeat": map[string]any{"min": 1, "max": 3},
+				},
+				"rules": map[string]any{
+					"line-length": map[string]any{
+						"max":     20,
+						"stern":   true,
+						"exclude": []any{},
+					},
+				},
+			},
+		},
+	})}
+	// Two Strict sections, each with a long line. The override
+	// must fire in both.
+	src := "# Doc\n\n" +
+		"## Strict\n\n" +
+		"First strict body line is well over twenty chars and should fire.\n\n" +
+		"## Strict\n\n" +
+		"Second strict body line is well over twenty chars and should fire.\n"
+	f := newTestFile(t, "doc.md", src)
+	diags := r.Check(f)
+	var lineLength int
+	for _, d := range diags {
+		if d.RuleID == "MDS001" {
+			lineLength++
+		}
+	}
+	assert.GreaterOrEqual(t, lineLength, 2,
+		"the rule override must fire inside every Strict occurrence")
+}
+
+// TestCheck_InlineSchema_BroadRepeatedScopeYieldsToLaterNamed
+// covers the per-scope rule walker's yield path: a broad
+// repeated matcher must hand a heading over to a later named
+// scope so the named scope's rule override fires on its own
+// section. Mirrors the structural validator's claimsLaterLiteral
+// behavior at the walker level.
+func TestCheck_InlineSchema_BroadRepeatedScopeYieldsToLaterNamed(t *testing.T) {
+	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+			map[string]any{
+				"heading": "Strict",
+				"rules": map[string]any{
+					"line-length": map[string]any{
+						"max":     20,
+						"stern":   true,
+						"exclude": []any{},
+					},
+				},
+			},
+		},
+	})}
+	src := "# Doc\n\n" +
+		"## Body\n\nx\n\n" +
+		"## Strict\n\n" +
+		"This strict line is well over twenty chars and should fire.\n"
+	f := newTestFile(t, "doc.md", src)
+	diags := r.Check(f)
+	var lineLength []lint.Diagnostic
+	for _, d := range diags {
+		if d.RuleID == "MDS001" {
+			lineLength = append(lineLength, d)
+		}
+	}
+	require.NotEmpty(t, lineLength,
+		"broad repeated matcher must yield `## Strict` so the "+
+			"named scope's rule override fires inside its range")
+}
+
 // TestApplyScopeRules_NilSchemaShortCircuits covers the defensive
 // guard at the top of applyScopeRules so coverage reflects the
 // fact that nil schemas are handled.
@@ -387,7 +473,7 @@ func TestApplySettings_AllowsEmptySchemaWithInline(t *testing.T) {
 func TestApplyScopeRules_NilSchemaShortCircuits(t *testing.T) {
 	r := &Rule{}
 	f := newTestFile(t, "doc.md", "# T\n\n## Foo\n")
-	diags := r.applyScopeRules(f, nil)
+	diags := r.applyScopeRules(f, nil, nil)
 	assert.Empty(t, diags)
 }
 
@@ -434,8 +520,7 @@ func TestCheck_InlineSchema_PreambleRuleOverride(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  nil,
-				"required": false,
+				"heading": nil,
 				"rules": map[string]any{
 					"line-length": map[string]any{
 						"max":     20,
@@ -560,15 +645,58 @@ func TestCheck_InlineSchema_ScopeRuleNonConfigurableEmptyOverride(t *testing.T) 
 	}
 }
 
+// TestCheck_InlineSchema_ScopeRulesUnderFmvarHeading regresses a
+// Copilot review finding: a per-scope rule override under a
+// `\#(fmvar(...))` heading must apply to the matching doc section.
+// The walker has to resolve the fmvar against the document's
+// frontmatter the same way the structural validator does.
+func TestCheck_InlineSchema_ScopeRulesUnderFmvarHeading(t *testing.T) {
+	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
+		"frontmatter": map[string]any{
+			"id": `string & != ""`,
+		},
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex": `\#(fmvar(id))`,
+				},
+				"rules": map[string]any{
+					"line-length": map[string]any{
+						"max":     20,
+						"stern":   true,
+						"exclude": []any{},
+					},
+				},
+			},
+		},
+	})}
+	src := "---\nid: MDS001\n---\n# Runbook\n\n" +
+		"## MDS001\n\n" +
+		"This step body has a deliberately long line that exceeds twenty.\n"
+	f := newTestFile(t, "doc.md", src)
+	diags := r.Check(f)
+	var lineLength []lint.Diagnostic
+	for _, d := range diags {
+		if d.RuleID == "MDS001" {
+			lineLength = append(lineLength, d)
+		}
+	}
+	require.NotEmpty(t, lineLength,
+		"fmvar-resolved scope heading must claim its match so the rule override fires")
+}
+
 // TestCheck_InlineSchema_ScopeRulesUnderFieldHeading exercises
-// matchesScopeText against a placeholder-bearing heading — the
-// walker should still pair the scope with the matching doc heading
-// so its `rules:` block applies inside the right line range.
+// the per-scope walker's matching path for a `\#(digits)`
+// heading. The walker must still pair the scope with the
+// matching doc heading so its `rules:` block applies inside
+// the right line range.
 func TestCheck_InlineSchema_ScopeRulesUnderFieldHeading(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading": "Step {n}",
+				"heading": map[string]any{
+					"regex": `Step \#(digits)`,
+				},
 				"rules": map[string]any{
 					"line-length": map[string]any{
 						"max":     20,

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -274,9 +274,9 @@ func (r *Rule) checkInlineSchema(f *lint.File) []lint.Diagnostic {
 	diags = append(diags, fmDiags...)
 	fmIsCUE := placeholders.HasCUEFrontmatter(r.Placeholders)
 	diags = append(diags, schema.Validate(f, r.InlineSchema, docFMRaw, fmIsCUE, makeDiag)...)
-	diags = append(diags, r.applyScopeRules(f, r.InlineSchema)...)
+	diags = append(diags, r.applyScopeRules(f, r.InlineSchema, docFMRaw)...)
 	diags = append(diags, schema.ValidateCrossReferences(f, r.InlineSchema, makeDiag)...)
-	diags = append(diags, schema.ValidateAcronyms(f, r.InlineSchema, makeDiag)...)
+	diags = append(diags, schema.ValidateAcronyms(f, r.InlineSchema, docFMRaw, makeDiag)...)
 	diags = append(diags, schema.ValidateIndex(f, r.InlineSchema, makeDiag)...)
 	return diags
 }

--- a/internal/rules/requiredstructure/scope_rules.go
+++ b/internal/rules/requiredstructure/scope_rules.go
@@ -19,7 +19,9 @@ import (
 // effective config. The fixture for this feature (same prose in two
 // sections, one with a stricter override) is met by this baseline;
 // the full file→scope merge is a follow-up.
-func (r *Rule) applyScopeRules(f *lint.File, sch *schema.Schema) []lint.Diagnostic {
+func (r *Rule) applyScopeRules(
+	f *lint.File, sch *schema.Schema, docFM map[string]any,
+) []lint.Diagnostic {
 	if sch == nil {
 		return nil
 	}
@@ -28,7 +30,7 @@ func (r *Rule) applyScopeRules(f *lint.File, sch *schema.Schema) []lint.Diagnost
 	body := skipBelow(heads, rootLevel)
 	var diags []lint.Diagnostic
 	claimed := make(map[int]bool, len(body))
-	walkScopes(sch.Sections, body, rootLevel, 1, len(f.Lines)+1, claimed,
+	walkScopes(sch.Sections, body, rootLevel, 1, len(f.Lines)+1, claimed, docFM,
 		func(sc schema.Scope, startLine, endLine int) {
 			if len(sc.Rules) == 0 {
 				return
@@ -68,10 +70,10 @@ func skipBelow(heads []schema.DocHeading, rootLevel int) []schema.DocHeading {
 func walkScopes(
 	scopes []schema.Scope, heads []schema.DocHeading,
 	expectedLevel, parentStart, parentEnd int,
-	claimed map[int]bool,
+	claimed map[int]bool, docFM map[string]any,
 	visit func(sc schema.Scope, startLine, endLine int),
 ) {
-	for _, sc := range scopes {
+	for i, sc := range scopes {
 		if sc.Preamble {
 			// Preamble range: [parentStart, first heading at this
 			// level in the window). Empty if the very first doc
@@ -82,73 +84,30 @@ func walkScopes(
 			visit(sc, parentStart, end)
 			continue
 		}
-		if sc.Wildcard {
+		if isSlotScope(sc) {
 			continue
 		}
-		matched := findMatchingHead(sc, heads, expectedLevel, parentStart, parentEnd, claimed)
-		if matched < 0 {
-			continue
-		}
-		claimed[matched] = true
-		dh := heads[matched]
-		// The section's end boundary follows the doc heading's real
-		// level, not the schema's expectedLevel. When the two
-		// differ (level-mismatch fallback), basing the end on
-		// expectedLevel would let sibling sections at the doc's
-		// level leak into the scope (deeper doc level) or truncate
-		// the section short (shallower doc level).
-		end := scopeEndLine(heads, matched, dh.Level, parentEnd)
-		visit(sc, dh.Line, end)
-		if len(sc.Sections) > 0 {
-			walkScopes(sc.Sections, heads,
-				expectedLevel+1, dh.Line, end, claimed, visit)
+		// schema.ScopeRunIndices applies the structural validator's
+		// run + yield semantics: contiguous matches only, with
+		// broad-and-after-min yielding to later named scopes.
+		for _, matched := range schema.ScopeRunIndices(
+			scopes, i, heads, expectedLevel, parentStart, parentEnd, claimed, docFM) {
+			dh := heads[matched]
+			claimed[matched] = true
+			// The section's end boundary follows the doc heading's
+			// real level, not the schema's expectedLevel. When the
+			// two differ (level-mismatch fallback), basing the end
+			// on expectedLevel would let sibling sections at the
+			// doc's level leak into the scope (deeper doc level)
+			// or truncate the section short (shallower doc level).
+			end := scopeEndLine(heads, matched, dh.Level, parentEnd)
+			visit(sc, dh.Line, end)
+			if len(sc.Sections) > 0 {
+				walkScopes(sc.Sections, heads,
+					expectedLevel+1, dh.Line, end, claimed, docFM, visit)
+			}
 		}
 	}
-}
-
-// findMatchingHead returns the earliest unclaimed heading index in
-// heads whose level matches expectedLevel and whose text matches
-// sc, restricted to the [parentStart, parentEnd) line window. When
-// no in-window heading at the expected level matches, it falls back
-// to an in-window heading at any level — the same level-mismatch
-// case the validator's matchScope claims. The fallback stays inside
-// the parent window so the walker never pairs a scope with a
-// heading the validator could not have claimed.
-func findMatchingHead(
-	sc schema.Scope, heads []schema.DocHeading,
-	expectedLevel, parentStart, parentEnd int,
-	claimed map[int]bool,
-) int {
-	if idx := scanHeads(sc, heads, parentStart, parentEnd, claimed, expectedLevel); idx >= 0 {
-		return idx
-	}
-	return scanHeads(sc, heads, parentStart, parentEnd, claimed, -1)
-}
-
-// scanHeads returns the first unclaimed heading in heads whose line
-// is in [parentStart, parentEnd) and whose level equals
-// requireLevel (or any level when requireLevel < 0), and whose text
-// matches sc.
-func scanHeads(
-	sc schema.Scope, heads []schema.DocHeading,
-	parentStart, parentEnd int, claimed map[int]bool,
-	requireLevel int,
-) int {
-	for j, dh := range heads {
-		if claimed[j] {
-			continue
-		}
-		if dh.Line < parentStart || dh.Line >= parentEnd {
-			continue
-		}
-		if requireLevel >= 0 && dh.Level != requireLevel {
-			continue
-		}
-		if schema.MatchesHeading(sc, dh) {
-			return j
-		}
-	}
-	return -1
 }
 
 // scopeEndLine returns the exclusive end-line of the section
@@ -188,6 +147,24 @@ func firstHeadingLine(
 		}
 	}
 	return parentEnd
+}
+
+// isSlotScope reports whether sc is the wildcard-slot shape (plan
+// 156: `regex: '.+', repeat: { min: 0 }`). The per-scope walker
+// skips slots because they have no fixed identity to attach rule
+// overrides to.
+func isSlotScope(sc schema.Scope) bool {
+	m := sc.Matcher
+	if m == nil {
+		return false
+	}
+	if m.Regex != ".+" {
+		return false
+	}
+	if !m.Repeat.Set || m.Repeat.Min != 0 || m.Repeat.Max != 0 {
+		return false
+	}
+	return true
 }
 
 // runScopeRules executes each rule named in sc.Rules and returns

--- a/internal/rules/requiredstructure/scope_rules_test.go
+++ b/internal/rules/requiredstructure/scope_rules_test.go
@@ -1,0 +1,52 @@
+package requiredstructure
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestScopeEndLine_BreaksAtParentEnd covers the
+// `heads[j].Line >= parentEnd` branch: when the next heading
+// after `matched` falls outside the parent window, the scan
+// stops at parentEnd rather than reporting that heading's line
+// (which would belong to a sibling scope).
+func TestScopeEndLine_BreaksAtParentEnd(t *testing.T) {
+	heads := []schema.DocHeading{
+		{Level: 2, Text: "Matched", Line: 10},
+		{Level: 3, Text: "Inside", Line: 15},
+		// 25 is past parentEnd=20 — must not be reported.
+		{Level: 2, Text: "Outside", Line: 25},
+	}
+	got := scopeEndLine(heads, 0, 2, 20)
+	assert.Equal(t, 20, got,
+		"a heading past parentEnd must not close the scope; the "+
+			"function must fall through to the parentEnd return")
+}
+
+// TestFirstHeadingLine_SkipsOutOfRange covers the range skip and
+// the no-match fallthrough: a heading before parentStart or at
+// or past parentEnd is ignored, and when no heading inside the
+// window matches expectedLevel the function returns parentEnd.
+func TestFirstHeadingLine_SkipsOutOfRange(t *testing.T) {
+	heads := []schema.DocHeading{
+		// Before parentStart=5 — skipped.
+		{Level: 2, Text: "Early", Line: 1},
+		// In window but wrong level — skipped by the
+		// `h.Level == expectedLevel` filter.
+		{Level: 3, Text: "Deep", Line: 7},
+		// At or past parentEnd=10 — skipped.
+		{Level: 2, Text: "Late", Line: 10},
+	}
+	got := firstHeadingLine(heads, 2, 5, 10)
+	assert.Equal(t, 10, got,
+		"no in-window heading at expectedLevel → return parentEnd")
+}
+
+// TestIsSlotScope_NilMatcher covers isSlotScope's defensive nil
+// branch: a preamble-shaped scope (no matcher) is not a slot.
+func TestIsSlotScope_NilMatcher(t *testing.T) {
+	assert.False(t, isSlotScope(schema.Scope{Preamble: true}),
+		"a preamble scope has no matcher and is not a slot")
+}

--- a/internal/schema/acronyms.go
+++ b/internal/schema/acronyms.go
@@ -30,7 +30,7 @@ var acronymToken = regexp.MustCompile(`\b[A-Z][A-Z0-9]{1,5}\b`)
 // of OIDC when the body that follows immediately spells out the
 // expansion.
 func ValidateAcronyms(
-	f *lint.File, sch *Schema, mkDiag MakeDiag,
+	f *lint.File, sch *Schema, docFM map[string]any, mkDiag MakeDiag,
 ) []lint.Diagnostic {
 	if sch == nil || sch.Acronyms == nil {
 		return nil
@@ -39,7 +39,7 @@ func ValidateAcronyms(
 	known := buildKnownSet(a.KnownSafe)
 
 	headingLines := documentHeadingLines(f)
-	ranges := acronymRanges(f, sch, a.Scope)
+	ranges := acronymRanges(f, sch, a.Scope, docFM)
 	var diags []lint.Diagnostic
 	for _, rng := range ranges {
 		diags = append(diags, checkAcronymsInRange(f, rng, known, headingLines, mkDiag)...)
@@ -77,14 +77,12 @@ type lineRange struct {
 
 // acronymRanges returns the line windows the acronym check should
 // scan. An empty scope list applies to the whole document.
-// Otherwise the schema scope tree is walked and each schema scope
-// claims the first matching document heading at its level; if the
-// document repeats a heading text under the same schema scope,
-// only the first occurrence is included today. This matches the
-// validator's claim semantics; widening to multi-match would
-// require schema repeats support (currently rejected by the
-// parser) and is tracked as a follow-up.
-func acronymRanges(f *lint.File, sch *Schema, scope []string) []lineRange {
+// Otherwise the schema scope tree is walked and one line range is
+// emitted per occurrence: a repeated scope (`repeat.max > 1` or
+// unbounded) contributes a range for each matched heading, so a
+// scope name like "Diagnosis" applied to two `## Diagnosis`
+// sections scans both bodies for first-use acronyms.
+func acronymRanges(f *lint.File, sch *Schema, scope []string, docFM map[string]any) []lineRange {
 	if len(scope) == 0 {
 		return []lineRange{{Start: 1, End: len(f.Lines) + 1}}
 	}
@@ -98,67 +96,65 @@ func acronymRanges(f *lint.File, sch *Schema, scope []string) []lineRange {
 	}
 
 	var out []lineRange
-	walkRanges(sch.Sections, body, rootLevel, 1, len(f.Lines)+1,
-		func(sc Scope, start, end int) {
-			// walkRanges already skips preamble and wildcard scopes,
-			// so any sc reaching here has a literal Heading text.
-			if matchSet[sc.Heading] {
+	walkRanges(sch.Sections, body, rootLevel, 1, len(f.Lines)+1, docFM,
+		func(sc Scope, headingText string, start, end int) {
+			// walkRanges already skips preamble and slot scopes, so
+			// any sc reaching here has a literal Matcher. Match the
+			// scope-name allowlist against (a) the actual matched
+			// heading text and (b) the schema label. The
+			// heading-text match keeps disjunctive regexes like
+			// `Symptoms|Indicators` aligned with intuitive
+			// `acronyms.scope: ["Indicators"]` config; plan 156
+			// dropped the scope-level `aliases:` field, so without
+			// (a) users would have to mirror the regex body
+			// verbatim. The `Matcher.Regex` branch is intentionally
+			// not checked separately — the parser sets
+			// `sc.Heading == sc.Matcher.Regex` for mapping-form
+			// entries, so (b) already covers it.
+			if matchSet[headingText] {
 				out = append(out, lineRange{Start: start, End: end})
 				return
 			}
-			for _, a := range sc.Aliases {
-				if matchSet[a] {
-					out = append(out, lineRange{Start: start, End: end})
-					return
-				}
+			if matchSet[sc.Heading] {
+				out = append(out, lineRange{Start: start, End: end})
+				return
 			}
 		})
 	return out
 }
 
-// walkRanges pairs each non-wildcard, non-preamble scope with the
-// line range covered by its first matching doc heading, recursing
-// into nested sections. It mirrors the validator's claim semantics
-// (text-equality matching, aliases honoured) but is simpler — no
-// out-of-order detection — because per-scope acronym detection
-// applies wherever a section appears.
+// walkRanges pairs each non-slot, non-preamble scope with the line
+// ranges covered by its matching doc headings, recursing into
+// nested sections. Repeated scopes contribute one range per
+// occurrence so per-scope checks fire on every matched section,
+// not just the first. The walker mirrors the structural
+// validator's claim semantics (regex matching) but is simpler —
+// no out-of-order detection.
 func walkRanges(
 	scopes []Scope, heads []DocHeading,
 	expectedLevel, parentStart, parentEnd int,
-	visit func(sc Scope, start, end int),
+	docFM map[string]any,
+	visit func(sc Scope, headingText string, start, end int),
 ) {
-	for _, sc := range scopes {
-		if sc.Wildcard || sc.Preamble {
+	claimed := make(map[int]bool, len(heads))
+	for i, sc := range scopes {
+		if sc.Preamble || isSlotMatcher(sc.Matcher) {
 			continue
 		}
-		idx := findHead(sc, heads, expectedLevel, parentStart, parentEnd)
-		if idx < 0 {
-			continue
-		}
-		start := heads[idx].Line
-		end := nextSectionLine(heads, idx, heads[idx].Level, parentEnd)
-		visit(sc, start, end)
-		if len(sc.Sections) > 0 {
-			walkRanges(sc.Sections, heads, expectedLevel+1, start, end, visit)
+		// ScopeRunIndices applies the structural validator's
+		// run + yield semantics: contiguous matches only, with
+		// broad-and-after-min yielding to later named scopes.
+		for _, idx := range ScopeRunIndices(
+			scopes, i, heads, expectedLevel, parentStart, parentEnd, claimed, docFM) {
+			claimed[idx] = true
+			start := heads[idx].Line
+			end := nextSectionLine(heads, idx, heads[idx].Level, parentEnd)
+			visit(sc, heads[idx].Text, start, end)
+			if len(sc.Sections) > 0 {
+				walkRanges(sc.Sections, heads, expectedLevel+1, start, end, docFM, visit)
+			}
 		}
 	}
-}
-
-func findHead(
-	sc Scope, heads []DocHeading, expectedLevel, parentStart, parentEnd int,
-) int {
-	for i, h := range heads {
-		if h.Line < parentStart || h.Line >= parentEnd {
-			continue
-		}
-		if h.Level != expectedLevel {
-			continue
-		}
-		if scopeMatchesHeading(sc, h) {
-			return i
-		}
-	}
-	return -1
 }
 
 func nextSectionLine(heads []DocHeading, idx, level, parentEnd int) int {

--- a/internal/schema/coverage_test.go
+++ b/internal/schema/coverage_test.go
@@ -15,43 +15,10 @@ import (
 
 // ---- ParseInline edge cases ----
 
-// TestParseInline_RejectsRepeatingPatternKeys covers the parse-
-// time rejection of `repeats`, `sequential`, `min`, and `max` —
-// the validator does not enforce them yet, so accepting them would
-// give users a false sense of constraint.
-func TestParseInline_RejectsRepeatingPatternKeys(t *testing.T) {
-	cases := []struct {
-		name string
-		key  string
-		val  any
-	}{
-		{"repeats", "repeats", true},
-		{"sequential", "sequential", true},
-		{"min", "min", 1},
-		{"max", "max", 3},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			raw := map[string]any{
-				"sections": []any{
-					map[string]any{
-						"heading": "Step",
-						tc.key:    tc.val,
-					},
-				},
-			}
-			_, err := ParseInline(raw, "kind x")
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "repeating-pattern keys")
-			assert.Contains(t, err.Error(), "not enforced")
-		})
-	}
-}
-
 func TestParseInline_RejectsMissingHeadingKey(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"required": true},
+			map[string]any{"closed": true},
 		},
 	}
 	_, err := ParseInline(raw, "kind x")
@@ -62,12 +29,12 @@ func TestParseInline_RejectsMissingHeadingKey(t *testing.T) {
 func TestParseInline_RejectsBlankHeading(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "   ", "required": true},
+			map[string]any{"heading": "   "},
 		},
 	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "non-empty heading")
+	assert.Contains(t, err.Error(), "empty string")
 }
 
 func TestParseInline_AcceptsScopeRulesMapping(t *testing.T) {
@@ -140,29 +107,23 @@ func TestParseInline_RejectsBadFrontmatterType(t *testing.T) {
 	assert.Contains(t, err.Error(), "frontmatter must be a mapping")
 }
 
-func TestParseInline_RejectsBadRequireType(t *testing.T) {
-	raw := map[string]any{"require": "not-a-map"}
+func TestParseInline_RejectsLegacyRequireKey(t *testing.T) {
+	// Plan 156 removed the `require:` wrapper; the parser rejects
+	// the key with a migration-pointing diagnostic.
+	raw := map[string]any{
+		"require": map[string]any{"filename": "RFC-*.md"},
+	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "require must be a mapping")
+	assert.Contains(t, err.Error(), "`require:` removed")
+	assert.Contains(t, err.Error(), "filename:")
 }
 
-func TestParseInline_RejectsBadRequireFilename(t *testing.T) {
-	raw := map[string]any{
-		"require": map[string]any{"filename": 42},
-	}
+func TestParseInline_RejectsBadFilenameType(t *testing.T) {
+	raw := map[string]any{"filename": 42}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "filename must be a string")
-}
-
-func TestParseInline_RejectsUnknownRequireKey(t *testing.T) {
-	raw := map[string]any{
-		"require": map[string]any{"unknown": "v"},
-	}
-	_, err := ParseInline(raw, "kind x")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown schema.require key")
 }
 
 func TestParseInline_RejectsBadClosedType(t *testing.T) {
@@ -181,37 +142,59 @@ func TestParseInline_RejectsBadHeadingType(t *testing.T) {
 	assert.Contains(t, err.Error(), "heading must be a string")
 }
 
-func TestParseInline_RejectsBadRequiredType(t *testing.T) {
+func TestParseInline_RejectsLegacyRequiredKey(t *testing.T) {
+	// Plan 156 removed `required:`; the rejection diagnostic
+	// points at the `repeat:` replacement.
 	raw := map[string]any{
 		"sections": []any{map[string]any{
-			"heading": "X", "required": "yes",
+			"heading": "X", "required": false,
 		}},
 	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "required must be a boolean")
+	assert.Contains(t, err.Error(), "`required:` removed")
+	assert.Contains(t, err.Error(), "repeat:")
 }
 
-func TestParseInline_RejectsBadAliasesType(t *testing.T) {
+func TestParseInline_RejectsLegacyAliasesKey(t *testing.T) {
+	// Plan 156 removed `aliases:`; encode disjunction in the regex.
 	raw := map[string]any{
 		"sections": []any{map[string]any{
-			"heading": "X", "aliases": "not-a-list",
+			"heading": "X", "aliases": []any{"Y"},
 		}},
 	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "aliases must be a list")
+	assert.Contains(t, err.Error(), "`aliases:` removed")
+	assert.Contains(t, err.Error(), "regex:")
 }
 
-func TestParseInline_RejectsBadAliasItemType(t *testing.T) {
-	raw := map[string]any{
-		"sections": []any{map[string]any{
-			"heading": "X", "aliases": []any{42},
-		}},
+func TestParseInline_RejectsLegacyRepeatingPatternKeys(t *testing.T) {
+	// Plan 156 removed the scope-level `repeats:` / `sequential:`
+	// / `min:` / `max:` keys; each one carries its own pointer
+	// at the replacement.
+	cases := []struct {
+		key string
+		val any
+	}{
+		{"repeats", true},
+		{"sequential", true},
+		{"min", 1},
+		{"max", 5},
 	}
-	_, err := ParseInline(raw, "kind x")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "aliases[0] must be a string")
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			raw := map[string]any{
+				"sections": []any{map[string]any{
+					"heading": "X", tc.key: tc.val,
+				}},
+			}
+			_, err := ParseInline(raw, "kind x")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.key)
+			assert.Contains(t, err.Error(), "removed; see plan 156")
+		})
+	}
 }
 
 func TestParseInline_RejectsBadRulesType(t *testing.T) {
@@ -346,7 +329,7 @@ func TestParseFile_RequireSingleLine(t *testing.T) {
 		"<?require filename: \"plan-*.md\" ?>\n\n# ?\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "plan-*.md", sch.Require.Filename)
+	assert.Equal(t, "plan-*.md", sch.Filename)
 }
 
 func TestParseFile_RequireMalformedYAML(t *testing.T) {
@@ -383,7 +366,7 @@ func TestParseFile_IncludeFragmentWithFilename(t *testing.T) {
 		"# ?\n\n<?include\nfile: frag.md\n?>\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "frag-*.md", sch.Require.Filename,
+	assert.Equal(t, "frag-*.md", sch.Filename,
 		"fragment's filename pattern should win when host has none")
 }
 
@@ -400,7 +383,7 @@ func TestParseFile_HostFilenameBeatsIncludeFilename(t *testing.T) {
 		"<?require\nfilename: \"plan-*.md\"\n?>\n\n# ?\n\n<?include\nfile: frag.md\n?>\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "plan-*.md", sch.Require.Filename)
+	assert.Equal(t, "plan-*.md", sch.Filename)
 }
 
 func TestParseFile_HeadingWithCodeSpan(t *testing.T) {
@@ -445,7 +428,7 @@ func TestSchema_IsEmpty(t *testing.T) {
 	assert.True(t, (*Schema)(nil).IsEmpty())
 	assert.True(t, (&Schema{}).IsEmpty())
 	assert.False(t, (&Schema{Sections: []Scope{{Heading: "X"}}}).IsEmpty())
-	assert.False(t, (&Schema{Require: Require{Filename: "*.md"}}).IsEmpty())
+	assert.False(t, (&Schema{Filename: "*.md"}).IsEmpty())
 	assert.False(t, (&Schema{Frontmatter: map[string]string{"id": "string"}}).IsEmpty())
 }
 
@@ -497,15 +480,18 @@ func TestValidateFrontmatterSyntax_RejectsInvalidCUE(t *testing.T) {
 
 func TestValidate_FieldInterpolatedHeadingMatches(t *testing.T) {
 	// `# {id}: {name}` against `# MDS001: line-length` should match
-	// via the regex path inside matchesText.
+	// once the document's front matter supplies the field values
+	// the fmvar() helper resolves against.
 	dir := t.TempDir()
 	p := writeFile(t, dir, "proto.md", "# {id}: {name}\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
 	doc := newDocFile(t, "doc.md", "# MDS001: line-length\n")
-	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	diags := Validate(doc, sch,
+		map[string]any{"id": "MDS001", "name": "line-length"},
+		false, makeDiagForTest)
 	assert.Empty(t, diags,
-		"field-interpolated H1 pattern should match a concrete title")
+		"field-interpolated H1 pattern should match the concrete title")
 }
 
 func TestValidate_FieldInterpolatedHeadingMismatch(t *testing.T) {
@@ -559,25 +545,36 @@ func TestParseInline_FrontmatterEmptyString(t *testing.T) {
 
 func TestMatchesHeading_Exported(t *testing.T) {
 	// Exported wrapper used by the per-scope-rule walker.
-	sc := Scope{Heading: "Goal"}
-	assert.True(t, MatchesHeading(sc, DocHeading{Text: "Goal", Level: 2}))
-	assert.False(t, MatchesHeading(sc, DocHeading{Text: "Other", Level: 2}))
-	// Wildcard scopes never match a specific heading.
-	assert.False(t, MatchesHeading(Scope{Wildcard: true}, DocHeading{Text: "Anything"}))
-	// "?" matches any text.
-	assert.True(t, MatchesHeading(Scope{Heading: "?"}, DocHeading{Text: "Anything"}))
-	// Aliases match.
-	sc2 := Scope{Heading: "Symptoms", Aliases: []string{"Indicators"}}
-	assert.True(t, MatchesHeading(sc2, DocHeading{Text: "Indicators"}))
+	sc := literalScope("Goal")
+	assert.True(t, MatchesHeading(sc, DocHeading{Text: "Goal", Level: 2}, nil))
+	assert.False(t, MatchesHeading(sc, DocHeading{Text: "Other", Level: 2}, nil))
+	// Slot scopes never match a specific heading.
+	assert.False(t, MatchesHeading(slotScope(), DocHeading{Text: "Anything"}, nil))
+	// A `.+` matcher (one-or-more wildcard) matches any text.
+	wild := Scope{Heading: ".+", Matcher: &Matcher{Regex: ".+"}}
+	assert.True(t, MatchesHeading(wild, DocHeading{Text: "Anything"}, nil))
+	// Disjunction inside the regex replaces the old aliases field.
+	sc2 := Scope{Heading: "Symptoms|Indicators",
+		Matcher: &Matcher{Regex: "Symptoms|Indicators"}}
+	assert.True(t, MatchesHeading(sc2, DocHeading{Text: "Indicators"}, nil))
+	// fmvar() patterns now resolve against the supplied frontmatter
+	// when the caller passes it in.
+	sc3 := Scope{Heading: "fmvar",
+		Matcher: &Matcher{Regex: `\#(fmvar(id))`}}
+	assert.True(t, MatchesHeading(sc3, DocHeading{Text: "X-42"},
+		map[string]any{"id": "X-42"}))
+	assert.False(t, MatchesHeading(sc3, DocHeading{Text: "X-42"}, nil),
+		"fmvar with nil FM must not match a non-empty heading text")
 }
 
-func TestPatternRegexCache_ReusesCompiled(t *testing.T) {
+func TestMatcherCache_ReusesCompiled(t *testing.T) {
 	// Two calls with the same pattern must hit the cache the second
 	// time. Cover both the cache-miss and cache-hit branches.
-	pattern := "Step {n}"
-	first := patternRegex(pattern)
-	require.NotNil(t, first)
-	second := patternRegex(pattern)
+	m := &Matcher{Regex: `Step \#(digits)`}
+	first, err := cachedMatcher(m, nil)
+	require.NoError(t, err)
+	second, err := cachedMatcher(m, nil)
+	require.NoError(t, err)
 	assert.Same(t, first, second,
 		"second call must return the cached compiled regex")
 }
@@ -646,8 +643,7 @@ func TestValidate_ShallowLevelMismatchClaimedByText(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  "Diagnosis",
-				"required": true,
+				"heading": "Diagnosis",
 				"sections": []any{
 					map[string]any{"heading": "Step"},
 				},
@@ -695,7 +691,7 @@ func TestValidate_InvalidFilenamePattern(t *testing.T) {
 	// A pattern that filepath.Match rejects (e.g., unmatched
 	// bracket) surfaces as a diagnostic at the document level.
 	raw := map[string]any{
-		"require": map[string]any{"filename": "[unterminated"},
+		"filename": "[unterminated",
 	}
 	sch, err := ParseInline(raw, "kind x")
 	require.NoError(t, err)
@@ -857,11 +853,9 @@ func TestIsCUEIdent_EmptyAndDigitFirst(t *testing.T) {
 	assert.True(t, isCUEIdent("foo123"))
 }
 
-// TestValidate_OutOfOrderHonoursPlaceholderHeadings regresses
-// the fallback that lets out-of-order detection see scopes whose
-// heading carries a placeholder. requiredByText keys only literal
-// scopes; the field-interpolated scope is found via
-// scopeMatchesHeading instead.
+// TestValidate_OutOfOrderHonoursPlaceholderHeadings: out-of-order
+// detection sees scopes whose matcher uses fmvar() interpolation
+// once the document supplies the fields.
 func TestValidate_OutOfOrderHonoursPlaceholderHeadings(t *testing.T) {
 	dir := t.TempDir()
 	// File-based schema with two scopes: literal "Goal" and
@@ -872,7 +866,9 @@ func TestValidate_OutOfOrderHonoursPlaceholderHeadings(t *testing.T) {
 	require.NoError(t, err)
 	doc := newDocFile(t, "doc.md",
 		"# T\n\n## MDS001: line-length\n\nx\n\n## Goal\n\ny\n")
-	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	diags := Validate(doc, sch,
+		map[string]any{"id": "MDS001", "name": "line-length"},
+		false, makeDiagForTest)
 	var oo bool
 	var missing bool
 	for _, d := range diags {
@@ -899,15 +895,17 @@ func TestValidate_OutOfOrderHonoursPlaceholderHeadings(t *testing.T) {
 func TestValidate_LateListedScopeRecursesIntoChildren(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "A", "required": true},
+			map[string]any{"heading": "A"},
 			map[string]any{
-				"heading":  "B",
-				"required": false,
+				"heading": map[string]any{
+					"regex":  "B",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
 				"sections": []any{
-					map[string]any{"heading": "B-child", "required": true},
+					map[string]any{"heading": "B-child"},
 				},
 			},
-			map[string]any{"heading": "C", "required": true},
+			map[string]any{"heading": "C"},
 		},
 	}
 	sch, err := ParseInline(raw, "kind x")
@@ -932,10 +930,10 @@ func TestValidate_LateListedScopeRecursesIntoChildren(t *testing.T) {
 }
 
 // TestParseInline_RejectsWildcardAsHeadingText regresses a
-// confusing-input case: a mapping-form scope with `heading: "..."`
-// would silently be treated as a literal section named "...".
-// Reject it at parse time so the only inline path to a slot is
-// `heading: {unlisted: true}` (the mapping form).
+// confusing-input case: a bare-string `heading: "..."` would
+// silently be treated as a literal section named "...". Reject it
+// at parse time so the only path to a slot is the mapping form
+// (`heading: { regex: '.+', repeat: { min: 0 } }`).
 func TestParseInline_RejectsWildcardAsHeadingText(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
@@ -945,22 +943,7 @@ func TestParseInline_RejectsWildcardAsHeadingText(t *testing.T) {
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"..."`)
-	assert.Contains(t, err.Error(), "heading: {unlisted: true}")
-}
-
-func TestParseInline_RejectsWildcardAsAlias(t *testing.T) {
-	raw := map[string]any{
-		"sections": []any{
-			map[string]any{
-				"heading": "Overview",
-				"aliases": []any{"..."},
-			},
-		},
-	}
-	_, err := ParseInline(raw, "kind x")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(),
-		`alias "..."`)
+	assert.Contains(t, err.Error(), "regex: '.+'")
 }
 
 // ---- Unified heading: grammar (string / null / mapping) ----
@@ -974,13 +957,15 @@ func TestParseInline_HeadingString(t *testing.T) {
 	require.Len(t, sch.Sections, 1)
 	assert.Equal(t, "Goal", sch.Sections[0].Heading)
 	assert.False(t, sch.Sections[0].Preamble)
-	assert.False(t, sch.Sections[0].Wildcard)
+	require.NotNil(t, sch.Sections[0].Matcher)
+	assert.Equal(t, "Goal", sch.Sections[0].Matcher.Regex,
+		"bare-string sugar populates Matcher.Regex with the literal text")
 }
 
 func TestParseInline_HeadingNullIsPreamble(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": nil, "required": false},
+			map[string]any{"heading": nil},
 			map[string]any{"heading": "Goal"},
 		},
 	}
@@ -991,17 +976,22 @@ func TestParseInline_HeadingNullIsPreamble(t *testing.T) {
 	assert.Equal(t, "Goal", sch.Sections[1].Heading)
 }
 
-func TestParseInline_HeadingMappingUnlisted(t *testing.T) {
+func TestParseInline_HeadingMappingSlot(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{"heading": "Overview"},
-			map[string]any{"heading": map[string]any{"unlisted": true}},
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 0},
+			}},
 		},
 	}
 	sch, err := ParseInline(raw, "kind x")
 	require.NoError(t, err)
 	require.Len(t, sch.Sections, 2)
-	assert.True(t, sch.Sections[1].Wildcard)
+	require.NotNil(t, sch.Sections[1].Matcher)
+	assert.True(t, isSlotMatcher(sch.Sections[1].Matcher),
+		"the mapping form `.+` plus `repeat: {min: 0}` desugars to a slot")
 }
 
 func TestParseInline_RejectsPreambleAfterFirst(t *testing.T) {
@@ -1014,17 +1004,6 @@ func TestParseInline_RejectsPreambleAfterFirst(t *testing.T) {
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be the first entry")
-}
-
-func TestParseInline_RejectsAliasesOnPreamble(t *testing.T) {
-	raw := map[string]any{
-		"sections": []any{
-			map[string]any{"heading": nil, "aliases": []any{"Intro"}},
-		},
-	}
-	_, err := ParseInline(raw, "kind x")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "`aliases:` is not allowed")
 }
 
 func TestParseInline_RejectsSectionsOnPreamble(t *testing.T) {
@@ -1042,25 +1021,10 @@ func TestParseInline_RejectsSectionsOnPreamble(t *testing.T) {
 	assert.Contains(t, err.Error(), "sections")
 }
 
-func TestParseInline_RejectsAliasesOnSlot(t *testing.T) {
-	raw := map[string]any{
-		"sections": []any{
-			map[string]any{
-				"heading": map[string]any{"unlisted": true},
-				"aliases": []any{"Anything"},
-			},
-		},
-	}
-	_, err := ParseInline(raw, "kind x")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "`aliases:` is not allowed")
-}
-
-// TestParseInline_RejectsSlotForbiddenKeys regresses the round-3
-// review: a slot's `sections:` / `rules:` / `closed:` / `required:`
-// fields used to parse silently because validateScopes skips
-// wildcard scopes. Reject them by key presence at parse time so
-// authors see the misconfiguration immediately.
+// TestParseInline_RejectsSlotForbiddenKeys: a slot's `sections:` /
+// `rules:` / `closed:` / `content:` fields are not honoured by the
+// validator. Reject them at parse time so authors see the
+// misconfiguration immediately.
 func TestParseInline_RejectsSlotForbiddenKeys(t *testing.T) {
 	cases := []struct {
 		key string
@@ -1071,15 +1035,18 @@ func TestParseInline_RejectsSlotForbiddenKeys(t *testing.T) {
 			"paragraph-readability": map[string]any{"max-index": 12.0},
 		}},
 		{"closed", true},
-		{"required", false},
+		{"content", []any{map[string]any{"kind": "paragraph"}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.key, func(t *testing.T) {
 			raw := map[string]any{
 				"sections": []any{
 					map[string]any{
-						"heading": map[string]any{"unlisted": true},
-						tc.key:    tc.val,
+						"heading": map[string]any{
+							"regex":  ".+",
+							"repeat": map[string]any{"min": 0},
+						},
+						tc.key: tc.val,
 					},
 				},
 			}
@@ -1091,36 +1058,6 @@ func TestParseInline_RejectsSlotForbiddenKeys(t *testing.T) {
 	}
 }
 
-func TestParseInline_SlotClearsRequiredDefault(t *testing.T) {
-	// Slots inherit the parseInlineScopeEntry default Required=true,
-	// but the heading mapping flips it back to false so the
-	// in-memory shape matches the file-based parser.
-	raw := map[string]any{
-		"sections": []any{
-			map[string]any{"heading": map[string]any{"unlisted": true}},
-		},
-	}
-	sch, err := ParseInline(raw, "kind x")
-	require.NoError(t, err)
-	require.Len(t, sch.Sections, 1)
-	assert.False(t, sch.Sections[0].Required,
-		"slot scopes must report Required=false")
-}
-
-func TestParseInline_PreambleClearsRequiredDefault(t *testing.T) {
-	raw := map[string]any{
-		"sections": []any{
-			map[string]any{"heading": nil},
-			map[string]any{"heading": "Goal"},
-		},
-	}
-	sch, err := ParseInline(raw, "kind x")
-	require.NoError(t, err)
-	require.Len(t, sch.Sections, 2)
-	assert.False(t, sch.Sections[0].Required,
-		"preamble scopes must report Required=false")
-}
-
 func TestParseInline_RejectsEmptyHeadingMapping(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{map[string]any{"heading": map[string]any{}}},
@@ -1128,6 +1065,31 @@ func TestParseInline_RejectsEmptyHeadingMapping(t *testing.T) {
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty mapping")
+}
+
+func TestParseInline_RejectsMappingMissingRegex(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"repeat": map[string]any{"min": 1},
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "`regex:` is required")
+}
+
+func TestParseInline_RejectsLegacyUnlistedKey(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{"unlisted": true}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "`heading.unlisted:` removed")
+	assert.Contains(t, err.Error(), "regex: '.+'")
 }
 
 func TestParseInline_RejectsUnknownHeadingKind(t *testing.T) {
@@ -1138,29 +1100,89 @@ func TestParseInline_RejectsUnknownHeadingKind(t *testing.T) {
 	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown heading-kind key")
+	assert.Contains(t, err.Error(), "unknown heading-mapping key")
 }
 
-func TestParseInline_RejectsUnlistedFalse(t *testing.T) {
+func TestParseInline_RejectsEmptyRepeatMapping(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": map[string]any{"unlisted": false}},
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{},
+			}},
 		},
 	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be `true`")
+	assert.Contains(t, err.Error(), "empty mapping")
 }
 
-func TestParseInline_RejectsUnlistedNonBool(t *testing.T) {
+func TestParseInline_RejectsMaxZero(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": map[string]any{"unlisted": "yes"}},
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"max": 0},
+			}},
 		},
 	}
 	_, err := ParseInline(raw, "kind x")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be a boolean")
+	assert.Contains(t, err.Error(), "max:")
+	assert.Contains(t, err.Error(), "greater than 0")
+}
+
+func TestParseInline_RejectsMinGreaterThanMax(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 5, "max": 2},
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "min=5 is greater than max=2")
+}
+
+func TestParseInline_RejectsSequentialWithoutDigits(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":      "Step",
+				"sequential": true,
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sequential")
+	assert.Contains(t, err.Error(), "digits")
+}
+
+func TestParseInline_RejectsInvalidRegex(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex": "[unterminated",
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regex")
+}
+
+func TestParseInline_RejectsClosedOnFrontmatterOnly(t *testing.T) {
+	raw := map[string]any{
+		"frontmatter": map[string]any{"id": "string"},
+		"closed":      true,
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema.closed")
+	assert.Contains(t, err.Error(), "sections")
 }
 
 // TestHeadingLine_FallbackTo1 covers the empty-Lines path of
@@ -1177,20 +1199,19 @@ func TestHeadingLine_FallbackTo1(t *testing.T) {
 }
 
 // TestValidate_WildcardHeadingParticipatesInOutOfOrder regresses
-// the "?" wildcard fallback: a later listed scope whose Heading is
-// "?" must still be claimable via out-of-order detection, because
-// "?" can't appear in the literal-text map but scopeMatchesHeading
-// treats it as matching any heading.
+// the `.+` mapping fallback: a later listed scope whose Matcher
+// accepts any text must still be claimable via out-of-order
+// detection.
 func TestValidate_WildcardHeadingParticipatesInOutOfOrder(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "A", "required": true},
-			map[string]any{"heading": "?", "required": true},
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{"regex": ".+"}},
 		},
 	}
 	sch, err := ParseInline(raw, "kind x")
 	require.NoError(t, err)
-	// Doc: B first (matches the "?" wildcard), then A.
+	// Doc: B first (matches the `.+` mapping), then A.
 	doc := newDocFile(t, "doc.md",
 		"# T\n\n## B\n\nx\n\n## A\n\ny\n")
 	diags := Validate(doc, sch, nil, false, makeDiagForTest)
@@ -1201,26 +1222,29 @@ func TestValidate_WildcardHeadingParticipatesInOutOfOrder(t *testing.T) {
 			oo = true
 		}
 		assert.NotContains(t, d.Message, "expected section to be present",
-			"the ? wildcard must claim B via out-of-order, not stay missing")
+			"the `.+` mapping must claim B via out-of-order, not stay missing")
 		assert.NotContains(t, d.Message, "<present>",
-			"B should not surface as unexpected when ? can claim it")
+			"B should not surface as unexpected when `.+` can claim it")
 	}
 	assert.True(t, oo,
-		"`?` wildcard heading must participate in out-of-order detection")
+		"a `.+` matcher must participate in out-of-order detection")
 }
 
-// TestValidate_PlaceholderAliasParticipatesInOutOfOrder regresses
-// the buildRequiredByText + findOutOfOrderIdx fix: a scope with a
-// literal heading and a placeholder alias must still be detected
-// as a later listed match via the fallback scan.
-func TestValidate_PlaceholderAliasParticipatesInOutOfOrder(t *testing.T) {
+// TestValidate_PlaceholderRegexParticipatesInOutOfOrder verifies
+// out-of-order detection works for a scope whose regex uses
+// fmvar() interpolation.
+func TestValidate_PlaceholderRegexParticipatesInOutOfOrder(t *testing.T) {
 	raw := map[string]any{
+		"frontmatter": map[string]any{
+			"user": `string & != ""`,
+			"role": `string & != ""`,
+		},
 		"sections": []any{
-			map[string]any{"heading": "A", "required": true},
+			map[string]any{"heading": "A"},
 			map[string]any{
-				"heading":  "Profile",
-				"required": true,
-				"aliases":  []any{"{user}: {role}"},
+				"heading": map[string]any{
+					"regex": `\#(fmvar(user)): \#(fmvar(role))`,
+				},
 			},
 		},
 	}
@@ -1228,7 +1252,9 @@ func TestValidate_PlaceholderAliasParticipatesInOutOfOrder(t *testing.T) {
 	require.NoError(t, err)
 	doc := newDocFile(t, "doc.md",
 		"# T\n\n## alice: admin\n\nx\n\n## A\n\ny\n")
-	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	diags := Validate(doc, sch,
+		map[string]any{"user": "alice", "role": "admin"},
+		false, makeDiagForTest)
 	var oo bool
 	for _, d := range diags {
 		if strings.Contains(d.Message, `## alice: admin: got <out of order>`) &&
@@ -1236,10 +1262,10 @@ func TestValidate_PlaceholderAliasParticipatesInOutOfOrder(t *testing.T) {
 			oo = true
 		}
 		assert.NotContains(t, d.Message, "expected section to be present",
-			"placeholder alias must claim the heading, not leave Profile missing")
+			"fmvar regex must claim the heading, not leave the scope missing")
 	}
 	assert.True(t, oo,
-		"placeholder alias must participate in out-of-order detection")
+		"fmvar regex must participate in out-of-order detection")
 }
 
 // TestParseFile_DefaultMaxBytesCapped regresses the FileReader
@@ -1267,8 +1293,8 @@ func TestParseFile_DefaultMaxBytesCapped(t *testing.T) {
 func TestValidate_StrayShallowerHeadingDoesNotTerminate(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "Overview", "required": true},
-			map[string]any{"heading": "Decision", "required": true},
+			map[string]any{"heading": "Overview"},
+			map[string]any{"heading": "Decision"},
 		},
 	}
 	sch, err := ParseInline(raw, "kind rfc")
@@ -1290,9 +1316,12 @@ func TestValidate_StrayShallowerHeadingDoesNotTerminate(t *testing.T) {
 func TestValidate_OpenScopeFlagsLateListedScope(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "A", "required": true},
-			map[string]any{"heading": "B", "required": false},
-			map[string]any{"heading": "C", "required": true},
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{
+				"regex":  "B",
+				"repeat": map[string]any{"min": 0, "max": 1},
+			}},
+			map[string]any{"heading": "C"},
 		},
 	}
 	sch, err := ParseInline(raw, "kind x")
@@ -1320,8 +1349,14 @@ func TestValidate_OpenScopeFlagsLateListedScope(t *testing.T) {
 func TestValidate_OptionalScopeNotOutOfOrder(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "A", "required": false},
-			map[string]any{"heading": "B", "required": false},
+			map[string]any{"heading": map[string]any{
+				"regex":  "A",
+				"repeat": map[string]any{"min": 0, "max": 1},
+			}},
+			map[string]any{"heading": map[string]any{
+				"regex":  "B",
+				"repeat": map[string]any{"min": 0, "max": 1},
+			}},
 		},
 	}
 	sch, err := ParseInline(raw, "kind x")
@@ -1340,8 +1375,8 @@ func TestValidate_OptionalScopeNotOutOfOrder(t *testing.T) {
 func TestValidate_RequiredScopeStillFlagsOutOfOrder(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": "A", "required": true},
-			map[string]any{"heading": "B", "required": true},
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": "B"},
 		},
 	}
 	sch, err := ParseInline(raw, "kind x")
@@ -1392,15 +1427,13 @@ func TestValidate_ShallowNonMatchEndsScopeList(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  "Parent",
-				"required": true,
+				"heading": "Parent",
 				"sections": []any{
 					map[string]any{"heading": "Child"},
 				},
 			},
 			map[string]any{
-				"heading":  "Sibling",
-				"required": true,
+				"heading": "Sibling",
 			},
 		},
 	}
@@ -1442,13 +1475,12 @@ func TestValidate_DeeperHeadingConsumedAsOrphan(t *testing.T) {
 
 func TestParseInline_ScopeLevelClosed(t *testing.T) {
 	// `closed:` on a scope (not the root) — covers the
-	// applyScopeFields "closed" branch at parse_inline.go:228.
+	// applyScopeFields "closed" branch.
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  "Parent",
-				"required": true,
-				"closed":   true,
+				"heading": "Parent",
+				"closed":  true,
 				"sections": []any{
 					map[string]any{"heading": "Child"},
 				},
@@ -1477,20 +1509,10 @@ func TestSetScopeSections_RejectsNonList(t *testing.T) {
 	assert.Contains(t, err.Error(), "sections must be a list")
 }
 
-func TestPatternRegex_SentinelCacheHit(t *testing.T) {
-	// First call caches the compile-failed sentinel for a
-	// compile-failing pattern; the second call hits the sentinel
-	// branch and returns nil.
-	pattern := "{x} bad ( pattern"
-	patternRegexCache.Store(pattern, patternCompileFailed)
-	got := patternRegex(pattern)
-	assert.Nil(t, got, "cache-hit on sentinel should return nil")
-}
-
 func TestValidate_FilenameMatchesPattern(t *testing.T) {
 	// The "matched" return branch of validateFilename.
 	raw := map[string]any{
-		"require": map[string]any{"filename": "doc.md"},
+		"filename": "doc.md",
 	}
 	sch, err := ParseInline(raw, "kind x")
 	require.NoError(t, err)
@@ -1499,14 +1521,14 @@ func TestValidate_FilenameMatchesPattern(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
-func TestPatternRegex_SentinelOnCompileError(t *testing.T) {
-	// Stuff the compile-failed sentinel into the cache and ensure
-	// matchesText handles the nil return without panicking. Using
-	// a unique pattern avoids contention with other tests.
-	pattern := "{n} (broken ["
-	patternRegexCache.Store(pattern, patternCompileFailed)
-	assert.False(t, matchesText(pattern, "anything"),
-		"matchesText should return false when the cache stores the failed sentinel")
+func TestCompileMatcher_RejectsInvalidRegex(t *testing.T) {
+	// Patterns that don't compile as RE2 surface as compileMatcher
+	// errors; the validator falls back to "no match" so a malformed
+	// pattern still produces a missing-required diagnostic rather
+	// than panicking.
+	m := &Matcher{Regex: "[unterminated"}
+	_, err := compileMatcher(m, nil)
+	require.Error(t, err)
 }
 
 // ---- Validate frontmatter CUE-placeholder skip ----

--- a/internal/schema/extras_test.go
+++ b/internal/schema/extras_test.go
@@ -71,13 +71,13 @@ OIDC (OpenID Connect) is set up here.
 	sch := &Schema{Source: "test", RootLevel: 2,
 		Acronyms: &AcronymRule{},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	assert.Empty(t, diags, "heading line must not flag OIDC as first use")
 
 	// Scoped.
-	sch.Sections = []Scope{{Heading: "OIDC configuration", Required: true}}
+	sch.Sections = []Scope{literalScope("OIDC configuration")}
 	sch.Acronyms.Scope = []string{"OIDC configuration"}
-	diags = ValidateAcronyms(f, sch, makeDiagForTest)
+	diags = ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	assert.Empty(t, diags, "scoped pass also excludes the heading line")
 }
 
@@ -87,7 +87,7 @@ func TestAcronyms_FirstUseFlagged(t *testing.T) {
 	sch := &Schema{Source: "test", RootLevel: 2, Acronyms: &AcronymRule{
 		KnownSafe: []string{"API"},
 	}}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message, "OIDC")
 }
@@ -98,7 +98,7 @@ func TestAcronyms_KnownSafePasses(t *testing.T) {
 	sch := &Schema{Source: "test", RootLevel: 2, Acronyms: &AcronymRule{
 		KnownSafe: []string{"API", "HTTP"},
 	}}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	assert.Empty(t, diags)
 }
 
@@ -106,7 +106,7 @@ func TestAcronyms_ExpansionPasses(t *testing.T) {
 	src := "# Doc\n\nOIDC (OpenID Connect) is configured.\n"
 	f := newDocFile(t, "doc.md", src)
 	sch := &Schema{Source: "test", RootLevel: 2, Acronyms: &AcronymRule{}}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	assert.Empty(t, diags)
 }
 
@@ -126,12 +126,12 @@ OIDC outside scope — should not flag.
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Heading: "Check", Required: true},
-			{Heading: "Notes", Required: false},
+			literalScope("Check"),
+			optionalScope("Notes"),
 		},
 		Acronyms: &AcronymRule{Scope: []string{"Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1, "exactly one diagnostic, inside Check")
 	assert.Contains(t, diags[0].Message, "OIDC")
 	assert.Equal(t, 5, diags[0].Line)
@@ -646,7 +646,7 @@ func TestAcronyms_AppliesWithEmptyScope(t *testing.T) {
 	sch := &Schema{Source: "test", RootLevel: 2,
 		Acronyms: &AcronymRule{Scope: []string{}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1, "empty scope applies document-wide")
 }
 
@@ -668,11 +668,11 @@ OIDC again, separate scope pass.
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Heading: "Check", Required: true},
+			literalScope("Check"),
 		},
 		Acronyms: &AcronymRule{Scope: []string{"Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	// walker only matches one "Check" today (no repeats), so we
 	// just check that at least the first OIDC is flagged.
 	require.NotEmpty(t, diags)
@@ -694,12 +694,15 @@ OIDC also here.
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Heading: "Probe", Required: true, Aliases: []string{"Check"}},
-			{Heading: "Outside", Required: false},
+			{
+				Heading: "Probe|Check",
+				Matcher: &Matcher{Regex: "Probe|Check"},
+			},
+			optionalScope("Outside"),
 		},
-		Acronyms: &AcronymRule{Scope: []string{"Check"}},
+		Acronyms: &AcronymRule{Scope: []string{"Probe|Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1)
 	assert.Equal(t, 5, diags[0].Line)
 }
@@ -759,13 +762,13 @@ OIDC needs an expansion.
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Preamble: true},
-			{Wildcard: true},
-			{Heading: "Check", Required: true},
+			preambleScope(),
+			slotScope(),
+			literalScope("Check"),
 		},
 		Acronyms: &AcronymRule{Scope: []string{"Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1)
 }
 
@@ -785,15 +788,13 @@ OIDC inside nested scope.
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Heading: "Diagnosis", Required: true, Sections: []Scope{
-				{Heading: "Step", Required: true, Sections: []Scope{
-					{Heading: "Check", Required: true},
-				}},
-			}},
+			nested("Diagnosis",
+				nested("Step",
+					literalScope("Check"))),
 		},
 		Acronyms: &AcronymRule{Scope: []string{"Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message, "OIDC")
 }
@@ -821,14 +822,12 @@ OIDC in second tree — but acronyms-scope is per-walker first-match.
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Heading: "Diagnosis", Required: true, Sections: []Scope{
-				{Heading: "Check", Required: true},
-			}},
-			{Heading: "Other", Required: false},
+			nested("Diagnosis", literalScope("Check")),
+			optionalScope("Other"),
 		},
 		Acronyms: &AcronymRule{Scope: []string{"Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	require.Len(t, diags, 1)
 	assert.Equal(t, 7, diags[0].Line)
 }
@@ -901,11 +900,11 @@ func TestAcronyms_ScopeWithNoMatchingHeadingIsSilent(t *testing.T) {
 		Source:    "test",
 		RootLevel: 2,
 		Sections: []Scope{
-			{Heading: "Check", Required: true},
+			literalScope("Check"),
 		},
 		Acronyms: &AcronymRule{Scope: []string{"Check"}},
 	}
-	diags := ValidateAcronyms(f, sch, makeDiagForTest)
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
 	assert.Empty(t, diags)
 }
 
@@ -918,9 +917,9 @@ func TestValidators_NoOpWhenSchemaAbsent(t *testing.T) {
 		&Schema{Source: "test", RootLevel: 2}, makeDiagForTest))
 
 	// ValidateAcronyms: same contract.
-	assert.Empty(t, ValidateAcronyms(f, nil, makeDiagForTest))
+	assert.Empty(t, ValidateAcronyms(f, nil, nil, makeDiagForTest))
 	assert.Empty(t, ValidateAcronyms(f,
-		&Schema{Source: "test", RootLevel: 2}, makeDiagForTest))
+		&Schema{Source: "test", RootLevel: 2}, nil, makeDiagForTest))
 
 	// ValidateIndex: nil schema and no-index schema return no diags.
 	assert.Empty(t, ValidateIndex(f, nil, makeDiagForTest))

--- a/internal/schema/matcher.go
+++ b/internal/schema/matcher.go
@@ -1,0 +1,463 @@
+package schema
+
+import (
+	"fmt"
+	"regexp"
+	"regexp/syntax"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/jeduden/mdsmith/internal/fieldinterp"
+)
+
+// digitsCaptureName is the named group used by the `digits` helper.
+// One per matcher; the validator inspects this group when
+// `sequential: true` is set.
+const digitsCaptureName = "n"
+
+// digitsCaptureExpr is the literal string the `digits` helper
+// substitutes into a `regex:` pattern.
+const digitsCaptureExpr = `(?P<` + digitsCaptureName + `>[0-9]+)`
+
+// interpMarker is the two-byte opener for a `\#(...)` interpolation
+// reference inside a `regex:` body. mdsmith resolves the two
+// supported expressions itself (`digits` and `fmvar(name)`) rather
+// than going through the CUE evaluator for every pattern.
+const interpMarker = `\#(`
+
+// parseFmvarCall parses an `fmvar(<name>)` helper invocation
+// inside an already-trimmed interpolation body. The argument is
+// returned with surrounding whitespace stripped. The parser
+// honours double-quoted segments so a CUE label whose key
+// contains a literal `)` — written as `fmvar("release)date")` —
+// reaches fmvarLookup intact instead of being truncated at the
+// first close paren.
+//
+// Returns (name, true) on a syntactically valid invocation,
+// or ("", false) when expr is not an fmvar call at all.
+func parseFmvarCall(expr string) (string, bool) {
+	rest := strings.TrimSpace(expr)
+	if !strings.HasPrefix(rest, "fmvar") {
+		return "", false
+	}
+	rest = strings.TrimSpace(rest[len("fmvar"):])
+	if !strings.HasPrefix(rest, "(") {
+		return "", false
+	}
+	rest = rest[1:]
+	end := findCallArgEnd(rest)
+	if end < 0 {
+		return "", false
+	}
+	arg := strings.TrimSpace(rest[:end])
+	tail := strings.TrimSpace(rest[end+1:])
+	if tail != "" {
+		return "", false
+	}
+	return arg, true
+}
+
+// findCallArgEnd returns the index of the closing `)` that ends
+// the fmvar argument, scanning past double-quoted segments so
+// embedded `)` characters do not terminate early. Returns -1
+// when no close paren is found.
+func findCallArgEnd(s string) int {
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '"':
+			i = skipQuotedSegment(s, i)
+		case ')':
+			return i
+		default:
+			i++
+		}
+	}
+	return -1
+}
+
+// scanInterps walks pattern, calling visit on each `\#(expr)`
+// reference with the inner expression and the [start, end) byte
+// offsets of the full reference. Nested parens inside expr are
+// balanced; callers can replace the spans atomically.
+func scanInterps(pattern string, visit func(expr string, start, end int) error) error {
+	for i := 0; i < len(pattern); {
+		idx := strings.Index(pattern[i:], interpMarker)
+		if idx < 0 {
+			return nil
+		}
+		start := i + idx
+		exprStart := start + len(interpMarker)
+		j, ok := findInterpEnd(pattern, exprStart)
+		if !ok {
+			return fmt.Errorf("unterminated interpolation in pattern")
+		}
+		expr := pattern[exprStart:j]
+		if err := visit(expr, start, j+1); err != nil {
+			return err
+		}
+		i = j + 1
+	}
+	return nil
+}
+
+// findInterpEnd walks pattern starting at exprStart (the byte
+// after the opening `\#(`) and returns the index of the matching
+// `)` plus true. It tracks paren depth across the body and skips
+// over double-quoted segments so a quoted CUE path like
+// `fmvar("release)date")` survives intact. Returns (0, false)
+// when the interpolation is unterminated.
+func findInterpEnd(pattern string, exprStart int) (int, bool) {
+	depth := 1
+	j := exprStart
+	for j < len(pattern) && depth > 0 {
+		c := pattern[j]
+		if c == '"' {
+			j = skipQuotedSegment(pattern, j)
+			continue
+		}
+		switch c {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		if depth == 0 {
+			return j, true
+		}
+		j++
+	}
+	return 0, false
+}
+
+// skipQuotedSegment advances past a double-quoted segment whose
+// opening quote is at pattern[i]. Returns the index of the
+// character after the closing quote (or len(pattern) when the
+// segment is unterminated). Backslash escapes inside the segment
+// consume the next byte verbatim so an escaped quote (`\"`) does
+// not close the segment.
+func skipQuotedSegment(pattern string, i int) int {
+	i++ // step past the opening quote
+	for i < len(pattern) {
+		if pattern[i] == '\\' && i+1 < len(pattern) {
+			i += 2
+			continue
+		}
+		if pattern[i] == '"' {
+			return i + 1
+		}
+		i++
+	}
+	return i
+}
+
+// resolvePattern substitutes the two supported `\#(expr)` helpers
+// in a matcher's `regex:` body and returns the resulting RE2 source
+// (anchored by callers with `^(?:...)$`). Frontmatter lookups use
+// fm; a missing `fmvar` field returns an error so matchHeading
+// turns it into a non-match instead of substituting an empty
+// regex fragment that would otherwise let a degenerate heading
+// match the literal-only remainder of the pattern.
+//
+// Returns (resolved, err) where err is non-nil when the input
+// references an unknown helper or an unresolved `fmvar` field.
+func resolvePattern(pattern string, fm map[string]any) (string, error) {
+	return rewriteInterps(pattern, func(expr string) (string, error) {
+		expr = strings.TrimSpace(expr)
+		if expr == "digits" {
+			return digitsCaptureExpr, nil
+		}
+		if name, ok := parseFmvarCall(expr); ok {
+			val, found := fmvarLookup(fm, name)
+			if !found {
+				// Missing frontmatter value: fail the match
+				// rather than substituting an empty regex
+				// fragment, which would otherwise let a
+				// heading like `## Topic ` match
+				// `regex: 'Topic \#(fmvar(id))'` even with
+				// `id` absent. matchHeading turns the error
+				// into a non-match, surfacing the section as
+				// missing instead of silently passing.
+				return "", fmt.Errorf(
+					"`fmvar(%s)`: frontmatter value missing", name)
+			}
+			return regexp.QuoteMeta(val), nil
+		}
+		return "", fmt.Errorf("unknown helper %q in `regex:` pattern", expr)
+	})
+}
+
+// resolvePatternForCheck substitutes helpers using a sentinel for
+// frontmatter lookups so the result is syntactically valid even
+// when no document is in hand. Used at parse time to catch invalid
+// RE2 in `regex:` early. Returns an error when the pattern uses an
+// unsupported helper, an unterminated `\#(` reference, or an
+// `fmvar(name)` whose argument is not a valid CUE path — turning
+// a schema typo into a parse-time diagnostic instead of a
+// confusing missing-section diagnostic at validate-time.
+func resolvePatternForCheck(pattern string) (string, error) {
+	return rewriteInterps(pattern, func(expr string) (string, error) {
+		expr = strings.TrimSpace(expr)
+		if expr == "digits" {
+			return digitsCaptureExpr, nil
+		}
+		if name, ok := parseFmvarCall(expr); ok {
+			if fieldinterp.ParseCUEPath(name) == nil {
+				return "", fmt.Errorf(
+					"`fmvar(%s)`: invalid frontmatter path "+
+						"(non-identifier keys must be quoted, "+
+						"e.g. `fmvar(\"my-key\")`)", name)
+			}
+			// Use a literal placeholder so the compiled regex is
+			// syntactically valid. The validator will re-resolve
+			// against the real frontmatter at validate-time.
+			return "PROBE", nil
+		}
+		return "", fmt.Errorf("unknown helper %q in `regex:` pattern", expr)
+	})
+}
+
+// rewriteInterps walks pattern and replaces each `\#(expr)`
+// reference with the result of replace(expr).
+func rewriteInterps(pattern string, replace func(expr string) (string, error)) (string, error) {
+	var b strings.Builder
+	cursor := 0
+	err := scanInterps(pattern, func(expr string, start, end int) error {
+		b.WriteString(pattern[cursor:start])
+		rep, err := replace(expr)
+		if err != nil {
+			return err
+		}
+		b.WriteString(rep)
+		cursor = end
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	b.WriteString(pattern[cursor:])
+	return b.String(), nil
+}
+
+// fmvarLookup resolves a CUE-style field path against fm. The
+// second return is true when the path resolves to a concrete
+// value (including the empty string) and false when fm is nil,
+// the path is unparseable, or the field is absent. resolvePattern
+// uses the ok signal to fail the match for unresolved fmvar
+// references, so a missing frontmatter field surfaces the
+// section as missing rather than letting a partial regex match a
+// degenerate heading.
+func fmvarLookup(fm map[string]any, name string) (string, bool) {
+	path := fieldinterp.ParseCUEPath(name)
+	if len(path) == 0 || fm == nil {
+		return "", false
+	}
+	val, err := fieldinterp.ResolvePath(fm, path)
+	if err != nil {
+		return "", false
+	}
+	return val, true
+}
+
+// patternHasDigits reports whether pattern references the `digits`
+// helper via the `\#(digits)` interpolation. Used to validate
+// `sequential: true` at parse time.
+func patternHasDigits(pattern string) bool {
+	return countDigitsHelpers(pattern) > 0
+}
+
+// hasNamedCapture reports whether pattern contains a named
+// capture group with the given name. The check parses the regex
+// via regexp/syntax so escape sequences (`\(\?P<n>`) and
+// character-class contents that happen to spell `(?P<n>` are
+// correctly excluded. A pattern that fails to parse is treated
+// as having no captures — compileMatcher will surface the parse
+// error later with full diagnostic context.
+func hasNamedCapture(pattern, name string) bool {
+	re, err := syntax.Parse(pattern, syntax.Perl)
+	if err != nil {
+		return false
+	}
+	return regexpHasNamedCapture(re, name)
+}
+
+// regexpHasNamedCapture walks the parsed regex AST looking for a
+// capture group whose Name equals the target. Recurses into every
+// sub-expression — alternations, concatenations, repeats, all
+// nest captures inside their Sub slice.
+func regexpHasNamedCapture(re *syntax.Regexp, name string) bool {
+	if re == nil {
+		return false
+	}
+	if re.Op == syntax.OpCapture && re.Name == name {
+		return true
+	}
+	for _, sub := range re.Sub {
+		if regexpHasNamedCapture(sub, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// countDigitsHelpers returns the number of `\#(digits)` references
+// in pattern. The matcher runtime only reads the first `n` capture,
+// so the parser rejects patterns with more than one helper.
+func countDigitsHelpers(pattern string) int {
+	count := 0
+	_ = scanInterps(pattern, func(expr string, _, _ int) error {
+		if strings.TrimSpace(expr) == "digits" {
+			count++
+		}
+		return nil
+	})
+	return count
+}
+
+// compiledMatcher carries a compiled RE2 pattern plus the index of
+// the `digits` named capture (-1 when absent) so the validator can
+// pull captured numbers out without scanning SubexpNames per match.
+type compiledMatcher struct {
+	re        *regexp.Regexp
+	digitsIdx int
+}
+
+// compileMatcher resolves m's pattern against fm and compiles it as
+// an anchored RE2 expression. The pattern is wrapped in `^(?:...)$`
+// so callers do not have to anchor explicitly; the original body is
+// what the docs and proto.md tables show.
+func compileMatcher(m *Matcher, fm map[string]any) (*compiledMatcher, error) {
+	if m == nil {
+		return nil, fmt.Errorf("nil matcher")
+	}
+	resolved, err := resolvePattern(m.Regex, fm)
+	if err != nil {
+		return nil, err
+	}
+	re, err := regexp.Compile("^(?:" + resolved + ")$")
+	if err != nil {
+		return nil, err
+	}
+	digitsIdx := -1
+	for i, name := range re.SubexpNames() {
+		if name == digitsCaptureName {
+			digitsIdx = i
+			break
+		}
+	}
+	return &compiledMatcher{re: re, digitsIdx: digitsIdx}, nil
+}
+
+// matcherCacheCap bounds the per-process compiled-matcher cache.
+// A long-running LSP session edits front matter often, and each
+// distinct `fmvar(...)` value produces a fresh cache key — without
+// a bound the cache grows unboundedly. 1024 entries covers a busy
+// workspace while keeping the working-set predictable; once full,
+// the cache resets so old entries do not pin compiled regexps for
+// the lifetime of the process.
+const matcherCacheCap = 1024
+
+// matcherCache memoises compiled matchers keyed on the raw pattern
+// plus a serialised frontmatter fingerprint. Hot loops (one
+// validator pass walks every heading × every scope) re-use the
+// compiled regexp instead of recompiling per heading. The cache
+// is sized-bounded by matcherCacheCap; see matcherCacheReset.
+var (
+	matcherCacheMu  sync.Mutex
+	matcherCache    map[matcherCacheKey]*compiledMatcher = make(map[matcherCacheKey]*compiledMatcher, matcherCacheCap)
+	matcherCacheLen int
+)
+
+type matcherCacheKey struct {
+	regex string
+	fmKey string
+}
+
+// cachedMatcher returns the compiled matcher for m under fm,
+// compiling on cache miss. nil + err on a malformed pattern; the
+// caller decides whether to surface that as a diagnostic.
+//
+// When the cache reaches matcherCacheCap, the entire map is
+// dropped before inserting the new entry. A simple reset beats
+// per-entry LRU bookkeeping for workloads where hot patterns are
+// re-encountered on the next validator pass anyway.
+func cachedMatcher(m *Matcher, fm map[string]any) (*compiledMatcher, error) {
+	if m == nil {
+		return nil, fmt.Errorf("nil matcher")
+	}
+	key := matcherCacheKey{regex: m.Regex, fmKey: fmFingerprint(m.Regex, fm)}
+	matcherCacheMu.Lock()
+	if v, ok := matcherCache[key]; ok {
+		matcherCacheMu.Unlock()
+		return v, nil
+	}
+	matcherCacheMu.Unlock()
+	cm, err := compileMatcher(m, fm)
+	if err != nil {
+		return nil, err
+	}
+	matcherCacheMu.Lock()
+	if matcherCacheLen >= matcherCacheCap {
+		matcherCache = make(map[matcherCacheKey]*compiledMatcher, matcherCacheCap)
+		matcherCacheLen = 0
+	}
+	if _, exists := matcherCache[key]; !exists {
+		matcherCacheLen++
+	}
+	matcherCache[key] = cm
+	matcherCacheMu.Unlock()
+	return cm, nil
+}
+
+// fmFingerprint joins the fmvar values referenced by pattern into a
+// stable cache key. Patterns that don't use `fmvar(...)` get an
+// empty fingerprint so they share a cache entry across documents.
+//
+// Names and values are written through strconv.Quote so a value
+// that contains a separator character (`;`, `=`) cannot collide
+// with another field's name=value pair. Two documents whose
+// `fmvar(...)` substitutions differ always produce different
+// fingerprints.
+func fmFingerprint(pattern string, fm map[string]any) string {
+	var b strings.Builder
+	_ = scanInterps(pattern, func(expr string, _, _ int) error {
+		expr = strings.TrimSpace(expr)
+		name, isCall := parseFmvarCall(expr)
+		if !isCall {
+			return nil
+		}
+		val, ok := fmvarLookup(fm, name)
+		b.WriteString(strconv.Quote(name))
+		b.WriteByte('=')
+		if ok {
+			b.WriteString(strconv.Quote(val))
+		} else {
+			b.WriteString("<missing>")
+		}
+		b.WriteByte('\n')
+		return nil
+	})
+	return b.String()
+}
+
+// matchHeading reports whether dh.Text matches m's pattern, and if
+// so returns the captured `digits` value (when present) as the
+// second return.
+func matchHeading(m *Matcher, dh DocHeading, fm map[string]any) (bool, string) {
+	if m == nil {
+		return false, ""
+	}
+	cm, err := cachedMatcher(m, fm)
+	if err != nil {
+		return false, ""
+	}
+	sub := cm.re.FindStringSubmatch(dh.Text)
+	if sub == nil {
+		return false, ""
+	}
+	if cm.digitsIdx <= 0 || cm.digitsIdx >= len(sub) {
+		return true, ""
+	}
+	return true, sub[cm.digitsIdx]
+}

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/jeduden/mdsmith/internal/fieldinterp"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 	"github.com/yuin/goldmark/ast"
@@ -30,6 +32,21 @@ type FileReader struct {
 // File-based schemas default to Closed=true at the root so the
 // historical heading-template behaviour (extras flagged) survives the
 // migration. Inline schemas opt back to open scopes per plan 146.
+//
+// Plan 156 maps the proto.md heading-row tokens to the new Matcher
+// shape: `## ?` → `{regex: '.+'}`, `## ...` → `{regex: '.+',
+// repeat: {min: 0}}`, `## Step {n}` → `{regex: 'Step \#(digits)'}`,
+// `## {id}` → `{regex: '\#(fmvar(id))'}`. The `<?require?>`
+// directive in proto.md bodies is unchanged.
+//
+// Note: MDS020's file-schema path (internal/rules/requiredstructure)
+// still routes through its legacy `parseSchema` / `parsedSchema`
+// pipeline, not this `ParseFile`. The new shape parses correctly
+// here and is exercised by the schema-package tests, but proto.md
+// authors won't benefit from the new Matcher / fmvar / digits
+// semantics until that path is migrated (a follow-up plan tracks
+// the cutover so the `{field}` heading/body sync feature survives
+// the move).
 func ParseFile(r *FileReader, path string) (*Schema, error) {
 	if r == nil {
 		r = &FileReader{}
@@ -65,18 +82,21 @@ func parseFileBytes(
 		return nil, err
 	}
 	if fp != "" {
-		sch.Require.Filename = fp
+		sch.Filename = fp
 	}
 
 	headings, fp2, err := collectFileHeadings(f, r, path, visited, chain)
 	if err != nil {
 		return nil, err
 	}
-	if sch.Require.Filename == "" && fp2 != "" {
-		sch.Require.Filename = fp2
+	if sch.Filename == "" && fp2 != "" {
+		sch.Filename = fp2
 	}
 
-	sch.Sections, sch.RootLevel = headingsToScopes(headings)
+	sch.Sections, sch.RootLevel, err = headingsToScopes(headings)
+	if err != nil {
+		return nil, err
+	}
 	return sch, nil
 }
 
@@ -340,8 +360,10 @@ func (r *FileReader) readPath(path string) ([]byte, error) {
 // the same level produce diagnostics unless a "..." wildcard slot
 // relaxes the position.
 //
-// The "..." text marks a wildcard scope at its position.
-func headingsToScopes(heads []FileHeading) ([]Scope, int) {
+// The "..." text marks a slot scope at its position; the helper
+// desugars it to the canonical wildcard matcher (`regex: '.+',
+// repeat: { min: 0 }`).
+func headingsToScopes(heads []FileHeading) ([]Scope, int, error) {
 	rootLevel := 0
 	for _, h := range heads {
 		if rootLevel == 0 || h.Level < rootLevel {
@@ -349,7 +371,7 @@ func headingsToScopes(heads []FileHeading) ([]Scope, int) {
 		}
 	}
 	if rootLevel == 0 {
-		return nil, 2
+		return nil, 2, nil
 	}
 
 	type frame struct {
@@ -370,7 +392,10 @@ func headingsToScopes(heads []FileHeading) ([]Scope, int) {
 			stack = stack[:len(stack)-1]
 		}
 		parent := stack[len(stack)-1]
-		sc := buildScopeFromHeading(h.Text)
+		sc, err := buildScopeFromHeading(h.Text)
+		if err != nil {
+			return nil, 0, err
+		}
 		parent.scopes = append(parent.scopes, sc)
 		stack = append(stack, &frame{level: h.Level})
 	}
@@ -380,14 +405,80 @@ func headingsToScopes(heads []FileHeading) ([]Scope, int) {
 		parent.scopes[len(parent.scopes)-1].Sections = top.scopes
 		stack = stack[:len(stack)-1]
 	}
-	return root.scopes, rootLevel
+	return root.scopes, rootLevel, nil
 }
 
-func buildScopeFromHeading(text string) Scope {
-	if strings.TrimSpace(text) == SectionWildcard {
-		return Scope{Wildcard: true}
+// buildScopeFromHeading translates a proto.md heading-row text into
+// a Scope, desugaring the four template tokens listed in the
+// section-schema reference.
+func buildScopeFromHeading(text string) (Scope, error) {
+	switch strings.TrimSpace(text) {
+	case SectionWildcard:
+		// `## ...` — any text, zero or more headings.
+		return Scope{
+			Heading: text,
+			Matcher: &Matcher{
+				Regex:  ".+",
+				Repeat: Repeat{Set: true, Min: 0, Max: 0},
+			},
+			Closed: true,
+		}, nil
+	case "?":
+		// `# ?` / `## ?` — any text, exactly one heading.
+		return Scope{
+			Heading: text,
+			Matcher: &Matcher{Regex: ".+"},
+			Closed:  true,
+		}, nil
 	}
-	return Scope{Heading: text, Required: true, Closed: true}
+	if fieldinterp.ContainsField(text) {
+		regex := protoTokenRegex(text)
+		if countDigitsHelpers(regex) > 1 {
+			return Scope{}, fmt.Errorf(
+				"heading %q: `{n}` may appear at most once "+
+					"(the matcher reads a single named `n` capture)",
+				text)
+		}
+		return Scope{
+			Heading: text,
+			Matcher: &Matcher{Regex: regex},
+			Closed:  true,
+		}, nil
+	}
+	return Scope{
+		Heading: text,
+		Matcher: &Matcher{Regex: regexp.QuoteMeta(text)},
+		Closed:  true,
+	}, nil
+}
+
+// protoTokenRegex desugars a heading-row text containing `{...}`
+// tokens into a `regex:` body using the section-schema's helpers:
+// `{n}` → `\#(digits)` (numeric capture) and `{field}` →
+// `\#(fmvar(field))` (frontmatter lookup). The function preserves
+// literal text in between via regexp.QuoteMeta so backslashes and
+// regex metacharacters survive the round-trip.
+func protoTokenRegex(text string) string {
+	parts := fieldinterp.SplitOnFields(text)
+	fields := fieldinterp.Fields(text)
+	if len(parts) == 0 {
+		return regexp.QuoteMeta(text)
+	}
+	var b strings.Builder
+	for i, part := range parts {
+		b.WriteString(regexp.QuoteMeta(part))
+		if i < len(fields) {
+			name := fields[i]
+			if name == "n" {
+				b.WriteString(`\#(digits)`)
+			} else {
+				b.WriteString(`\#(fmvar(`)
+				b.WriteString(name)
+				b.WriteString(`))`)
+			}
+		}
+	}
+	return b.String()
 }
 
 // headingText extracts the plain text content of a heading node.

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,6 +21,14 @@ import (
 // Inline schemas default to open scopes (Closed: false) per plan 146.
 // The validator's open-scope semantics still enforce required sections
 // and listed-section ordering; only unlisted headings are tolerated.
+//
+// Plan 156 collapses the section-entry vocabulary: each entry sets
+// exactly one `heading:` key (null, string, or mapping) and the
+// mapping carries `regex:`, `repeat:`, and `sequential:`. The
+// `aliases:`, `required:`, scope-level `repeats:`/`sequential:`/
+// `min:`/`max:`, `{unlisted: true}` mapping, and schema-level
+// `require:` shapes are gone; the parser rejects them with a
+// "removed; see plan 156" diagnostic naming the replacement.
 func ParseInline(raw map[string]any, source string) (*Schema, error) {
 	if raw == nil {
 		return &Schema{Source: source, RootLevel: 2}, nil
@@ -30,7 +39,11 @@ func ParseInline(raw map[string]any, source string) (*Schema, error) {
 	if err := parseInlineFrontmatter(raw, sch); err != nil {
 		return nil, err
 	}
-	if err := parseInlineRequire(raw, sch); err != nil {
+	if err := rejectRemovedTopKey(raw, "require",
+		"`require:` removed; see plan 156 (use top-level `filename:`)"); err != nil {
+		return nil, err
+	}
+	if err := parseInlineFilename(raw, sch); err != nil {
 		return nil, err
 	}
 	if err := parseInlineRootClosed(raw, sch); err != nil {
@@ -49,6 +62,19 @@ func ParseInline(raw map[string]any, source string) (*Schema, error) {
 		return nil, err
 	}
 
+	// schema-level `closed:` only makes sense when the schema also
+	// declares a non-empty `sections:` list — strictness has no
+	// scope to apply to when the kind only constrains front matter
+	// / filename, and `Schema.IsEmpty` ignores `Closed`, so an
+	// empty-sections closed schema would be skipped by Validate
+	// entirely. Plan 156 surfaces the mismatch at parse time.
+	if _, hasClosed := raw["closed"]; hasClosed && len(sch.Sections) == 0 {
+		return nil, fmt.Errorf(
+			"schema.closed: only valid on schemas that declare " +
+				"a non-empty `sections:` list — drop the key on a " +
+				"frontmatter-only kind or add at least one section")
+	}
+
 	if err := rejectUnknownTopKeys(raw); err != nil {
 		return nil, err
 	}
@@ -58,7 +84,7 @@ func ParseInline(raw map[string]any, source string) (*Schema, error) {
 
 var inlineTopKeys = map[string]bool{
 	"frontmatter":      true,
-	"require":          true,
+	"filename":         true,
 	"closed":           true,
 	"sections":         true,
 	"cross-references": true,
@@ -78,6 +104,13 @@ func rejectUnknownTopKeys(raw map[string]any) error {
 		if !inlineTopKeys[k] {
 			return fmt.Errorf("unknown schema key %q", k)
 		}
+	}
+	return nil
+}
+
+func rejectRemovedTopKey(raw map[string]any, key, msg string) error {
+	if _, ok := raw[key]; ok {
+		return fmt.Errorf("schema.%s: %s", key, msg)
 	}
 	return nil
 }
@@ -130,10 +163,11 @@ func frontmatterExpr(v any) (string, error) {
 		}
 		return expr, nil
 	case bool, int, int64, float64, nil:
-		b, err := json.Marshal(x)
-		if err != nil {
-			return "", err
-		}
+		// json.Marshal cannot fail on these primitive types, so
+		// the error from the marshal call is intentionally
+		// discarded — keeping the err check would land on a
+		// permanently unreachable branch.
+		b, _ := json.Marshal(x)
 		return string(b), nil
 	case []any, map[string]any:
 		b, err := json.Marshal(x)
@@ -146,28 +180,16 @@ func frontmatterExpr(v any) (string, error) {
 	}
 }
 
-func parseInlineRequire(raw map[string]any, sch *Schema) error {
-	v, ok := raw["require"]
+func parseInlineFilename(raw map[string]any, sch *Schema) error {
+	v, ok := raw["filename"]
 	if !ok {
 		return nil
 	}
-	m, ok := v.(map[string]any)
+	s, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("schema.require must be a mapping, got %T", v)
+		return fmt.Errorf("schema.filename must be a string, got %T", v)
 	}
-	for k, vv := range m {
-		switch k {
-		case "filename":
-			s, ok := vv.(string)
-			if !ok {
-				return fmt.Errorf(
-					"schema.require.filename must be a string, got %T", vv)
-			}
-			sch.Require.Filename = s
-		default:
-			return fmt.Errorf("unknown schema.require key %q", k)
-		}
-	}
+	sch.Filename = s
 	return nil
 }
 
@@ -219,49 +241,65 @@ func parseInlineScopeList(list []any, path string) ([]Scope, error) {
 	return scopes, nil
 }
 
+// removedScopeKeys lists the per-entry keys plan 156 removed. The
+// parser rejects each one by presence with a "removed; see plan 156"
+// diagnostic naming the replacement so authors migrating from the
+// old shape see the fix inline rather than the validator silently
+// dropping the constraint.
+// removedScopeKeyOrder pins the iteration order of
+// removedScopeKeys. The map alone would be enough to surface a
+// diagnostic, but Go randomises map iteration on every range —
+// so a legacy entry that still carries two removed keys would
+// report a different one on each run. The order chosen here
+// matches the plan-156 changelog so users read the entries in
+// the same sequence the migration table presents them.
+var removedScopeKeyOrder = []string{
+	"required", "aliases", "repeats", "sequential", "min", "max",
+}
+
+var removedScopeKeys = map[string]string{
+	"required": "`required:` removed; see plan 156 " +
+		"(use `repeat: { min: 0, max: 1 }` for optional, or omit for required)",
+	"aliases": "`aliases:` removed; see plan 156 " +
+		"(encode disjunction in `regex:`, e.g. `regex: 'A|B'`)",
+	"repeats": "scope-level `repeats:` removed; see plan 156 " +
+		"(use `heading.repeat: { min: 1 }`)",
+	"sequential": "scope-level `sequential:` removed; see plan 156 " +
+		"(set `sequential:` inside the `heading:` mapping)",
+	"min": "scope-level `min:` removed; see plan 156 " +
+		"(use `heading.repeat.min`)",
+	"max": "scope-level `max:` removed; see plan 156 " +
+		"(use `heading.repeat.max`)",
+}
+
 func parseInlineScopeEntry(entry any, path string) (Scope, error) {
 	m, ok := entry.(map[string]any)
 	if !ok {
 		return Scope{}, fmt.Errorf(
 			"%s: scope must be a mapping, got %T", path, entry)
 	}
-	if k, found := firstRepeatingPatternKey(m); found {
-		return Scope{}, fmt.Errorf(
-			"%s: scope sets %q, but the repeating-pattern keys "+
-				"(`repeats`, `sequential`, `min`, `max`) are parsed "+
-				"into the Scope struct yet not enforced by any "+
-				"validator today; remove them until a future plan "+
-				"lifts the rejection so the schema does not appear "+
-				"to constrain counts it ignores",
-			path, k)
+	// Walk a fixed key order so the first surfaced migration
+	// diagnostic stays deterministic when an entry carries more
+	// than one removed key — Go's map iteration is randomised
+	// per range, which would otherwise swap which key gets
+	// reported run-to-run.
+	for _, k := range removedScopeKeyOrder {
+		if _, present := m[k]; present {
+			return Scope{}, fmt.Errorf("%s: %s", path, removedScopeKeys[k])
+		}
 	}
 	if _, hasHeading := m["heading"]; !hasHeading {
 		return Scope{}, fmt.Errorf(
 			"%s: scope must set a `heading:` key — use a string "+
 				"(literal heading text), `null` (preamble), or "+
-				"`{unlisted: true}` (slot)", path)
+				"a mapping `{ regex, repeat?, sequential? }`", path)
 	}
-	sc := Scope{Required: true}
+	sc := Scope{}
 	if err := applyScopeFields(m, &sc, path); err != nil {
 		return Scope{}, err
 	}
 	if err := validateScopeShape(sc, m, path); err != nil {
 		return Scope{}, err
-	}
-	// Required defaults to true for literal scopes (matches the
-	// file-based parser). Preamble and slot scopes have no heading
-	// to require — both parsers should produce Required=false for
-	// them. Slots reject `required:` outright; preambles accept
-	// it. Apply the default deterministically here, after fields
-	// have settled, so map-iteration order in applyScopeFields
-	// cannot leave Required at the parseInlineScopeEntry default
-	// for non-literal scopes.
-	if sc.Wildcard {
-		sc.Required = false
-	} else if sc.Preamble {
-		if _, explicit := m["required"]; !explicit {
-			sc.Required = false
-		}
 	}
 	return sc, nil
 }
@@ -271,52 +309,61 @@ func parseInlineScopeEntry(entry any, path string) (Scope, error) {
 // and field values) and at the raw map (so a forbidden key is
 // caught by its presence, not its post-parsed value).
 func validateScopeShape(sc Scope, m map[string]any, path string) error {
-	if !sc.Wildcard && !sc.Preamble && strings.TrimSpace(sc.Heading) == "" {
-		return fmt.Errorf(
-			"%s: literal scope must set a non-empty heading", path)
-	}
-	if strings.TrimSpace(sc.Heading) == SectionWildcard {
-		return fmt.Errorf(
-			"%s: `heading: \"%s\"` is not a valid heading text — "+
-				"use `heading: {unlisted: true}` to declare a slot",
-			path, SectionWildcard)
-	}
-	for _, a := range sc.Aliases {
-		if strings.TrimSpace(a) == SectionWildcard {
-			return fmt.Errorf(
-				"%s: alias %q is not a valid alias text — "+
-					"declare a separate `heading: {unlisted: true}` "+
-					"entry if you need a slot at that position",
-				path, SectionWildcard)
-		}
-	}
-	if sc.Wildcard {
-		return rejectKeys(m, path, "slot (`heading: {unlisted: true}`)",
-			"required", "aliases", "closed", "sections", "rules", "content")
-	}
 	if sc.Preamble {
 		return rejectKeys(m, path, "preamble (`heading: null`)",
-			"aliases", "sections")
+			"sections")
 	}
-	if strings.TrimSpace(sc.Heading) == "?" {
-		return rejectKeys(m, path,
-			"`?` wildcard heading", "content")
+	// After applyScopeFields succeeds, either Preamble is true
+	// (handled above) or Matcher is set by setScopeHeading; a
+	// missing `heading:` key is rejected upstream by
+	// parseInlineScopeEntry. There is no reachable path where
+	// sc.Matcher is nil here, so no defensive nil-check fires.
+	// A regex of '.+' is the wildcard-slot shape; rule overrides,
+	// nested sections, and per-section content do not make sense
+	// there because the slot has no fixed identity. Plan 156
+	// makes that explicit.
+	if isSlotMatcher(sc.Matcher) {
+		return rejectKeys(m, path, "slot (`regex: '.+', repeat: { min: 0 }`)",
+			"sections", "rules", "content", "closed")
 	}
 	return nil
+}
+
+// isSlotMatcher reports whether m is the canonical wildcard-slot
+// shape: a `.+` regex with `repeat: { min: 0 }` (unbounded max).
+// The shape collapses what the old grammar spelled
+// `heading: { unlisted: true }`.
+func isSlotMatcher(m *Matcher) bool {
+	if m == nil {
+		return false
+	}
+	if m.Regex != ".+" {
+		return false
+	}
+	if !m.Repeat.Set || m.Repeat.Min != 0 || m.Repeat.Max != 0 {
+		return false
+	}
+	return true
+}
+
+// isBroadMatcher reports whether m's regex matches "anything" —
+// the `.+` body, regardless of repeat bounds. Used by the
+// yield-to-later helpers so a broad scope never claims a heading
+// that a more-specific later scope would have matched. Slot
+// matchers are a subset of broad matchers.
+func isBroadMatcher(m *Matcher) bool {
+	return m != nil && m.Regex == ".+"
 }
 
 // rejectKeys errors if any forbidden key is present in m. The
 // shape label and key list go into the error so the user sees
 // which field is incompatible and why. Forbidden keys are checked
-// by presence (zero-value or false still rejects), matching the
-// repeating-pattern rejection's contract.
+// by presence (zero-value or false still rejects).
 func rejectKeys(m map[string]any, path, shape string, keys ...string) error {
 	for _, k := range keys {
 		if _, ok := m[k]; ok {
 			return fmt.Errorf(
 				"%s: `%s:` is not allowed on a %s scope — "+
-					"the validator would ignore it, so the "+
-					"parser surfaces it as a config error; "+
 					"remove the key",
 				path, k, shape)
 		}
@@ -324,37 +371,15 @@ func rejectKeys(m map[string]any, path, shape string, keys ...string) error {
 	return nil
 }
 
-// firstRepeatingPatternKey returns the first repeating-pattern key
-// present in m (in a stable order), so the parse rejection fires
-// based on key PRESENCE rather than the post-parsed value. Schemas
-// that explicitly write `repeats: false` or `min: 0` are still
-// rejected — the key being there at all signals an intent the
-// validator does not yet honour.
-func firstRepeatingPatternKey(m map[string]any) (string, bool) {
-	for _, k := range []string{"repeats", "sequential", "min", "max"} {
-		if _, ok := m[k]; ok {
-			return k, true
-		}
-	}
-	return "", false
-}
-
-// applyScopeFields walks the scope mapping and populates sc. The
-// repeating-pattern keys (repeats, sequential, min, max) are
-// intentionally absent here: parseInlineScopeEntry rejects them
-// upfront via firstRepeatingPatternKey, so this loop never sees
-// them. A future plan that ships repeating-pattern enforcement
-// will lift the rejection and restore the cases.
+// applyScopeFields walks the scope mapping and populates sc. Each
+// supported per-entry key has its own setter; unknown keys
+// parse-error.
 func applyScopeFields(m map[string]any, sc *Scope, path string) error {
 	for k, vv := range m {
 		var err error
 		switch k {
 		case "heading":
 			err = setScopeHeading(sc, vv, path)
-		case "required":
-			err = setScopeBool(&sc.Required, vv, path, k)
-		case "aliases":
-			err = setScopeAliases(sc, vv, path)
 		case "closed":
 			err = setScopeBool(&sc.Closed, vv, path, k)
 		case "sections":
@@ -375,18 +400,15 @@ func applyScopeFields(m map[string]any, sc *Scope, path string) error {
 
 // setScopeHeading reads the unified `heading:` field. The value is
 // a string (literal text — the common case), `null` (preamble:
-// content before the first heading), or a mapping that types a
-// non-literal match. Only `{unlisted: true}` is accepted in the
-// mapping form today; future work can extend it with shapes such
-// as `{any: true}` and `{pattern: "..."}`.
+// content before the first heading), or a mapping that types the
+// match (`{ regex, repeat?, sequential? }`).
 func setScopeHeading(sc *Scope, v any, path string) error {
 	switch x := v.(type) {
 	case nil:
 		sc.Preamble = true
 		return nil
 	case string:
-		sc.Heading = x
-		return nil
+		return setBareStringHeading(sc, x, path)
 	case map[string]any:
 		return applyHeadingMapping(sc, x, path)
 	default:
@@ -396,31 +418,196 @@ func setScopeHeading(sc *Scope, v any, path string) error {
 	}
 }
 
+func setBareStringHeading(sc *Scope, s, path string) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf(
+			"%s.heading: empty string — use `null` for a preamble", path)
+	}
+	if strings.TrimSpace(s) == SectionWildcard {
+		return fmt.Errorf(
+			"%s.heading: %q is not a valid heading text — "+
+				"use `heading: { regex: '.+', repeat: { min: 0 } }` for a slot",
+			path, SectionWildcard)
+	}
+	sc.Heading = s
+	sc.Matcher = &Matcher{Regex: regexp.QuoteMeta(s)}
+	return nil
+}
+
+// removedHeadingKeys lists the heading-mapping keys plan 156
+// dropped. The parser rejects each one by presence so authors see
+// the migration path inline.
+var removedHeadingKeys = map[string]string{
+	"unlisted": "`heading.unlisted:` removed; see plan 156 (use `regex: '.+', repeat: { min: 0 }`)",
+}
+
 func applyHeadingMapping(sc *Scope, m map[string]any, path string) error {
 	if len(m) == 0 {
 		return fmt.Errorf(
-			"%s.heading: empty mapping — use `{unlisted: true}` for a slot",
+			"%s.heading: empty mapping — use `{ regex: '.+', repeat: { min: 0 } }` for a slot",
 			path)
 	}
+	for k, msg := range removedHeadingKeys {
+		if _, present := m[k]; present {
+			return fmt.Errorf("%s.heading: %s", path, msg)
+		}
+	}
+	matcher := &Matcher{}
 	for k, v := range m {
+		var err error
 		switch k {
-		case "unlisted":
-			b, ok := v.(bool)
-			if !ok {
-				return fmt.Errorf(
-					"%s.heading.unlisted must be a boolean, got %T", path, v)
-			}
-			if !b {
-				return fmt.Errorf(
-					"%s.heading.unlisted must be `true` "+
-						"(set the value or omit the entry)", path)
-			}
-			sc.Wildcard = true
+		case "regex":
+			err = setMatcherRegex(matcher, v, path)
+		case "repeat":
+			err = setMatcherRepeat(matcher, v, path)
+		case "sequential":
+			err = setScopeBool(&matcher.Sequential, v, path+".heading", k)
 		default:
 			return fmt.Errorf(
-				"%s.heading.%s: unknown heading-kind key (today only "+
-					"`unlisted: true` is accepted)", path, k)
+				"%s.heading.%s: unknown heading-mapping key", path, k)
 		}
+		if err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(matcher.Regex) == "" {
+		return fmt.Errorf(
+			"%s.heading: `regex:` is required when `heading:` is a mapping",
+			path)
+	}
+	if n := countDigitsHelpers(matcher.Regex); n > 1 {
+		return fmt.Errorf(
+			"%s.heading.regex: `\\#(digits)` may appear at most once "+
+				"(the matcher reads a single named `n` capture)",
+			path)
+	}
+	// The `n` named-capture group is reserved by the `digits` helper.
+	// Parse the regex source to find actual named captures rather
+	// than substring-matching `(?P<n>` — the literal text can also
+	// appear inside a character class or as `\(\?P<n>` escape
+	// sequence that does not introduce a real capture group.
+	if hasNamedCapture(matcher.Regex, "n") {
+		return fmt.Errorf(
+			"%s.heading.regex: the `n` named capture is reserved by "+
+				"`\\#(digits)`; rename the user capture or remove the "+
+				"`(?P<n>...)` group",
+			path)
+	}
+	if matcher.Sequential && !patternHasDigits(matcher.Regex) {
+		return fmt.Errorf(
+			"%s.heading.sequential: requires a `\\#(digits)` capture in `regex:`",
+			path)
+	}
+	sc.Heading = matcher.Regex
+	sc.Matcher = matcher
+	return nil
+}
+
+func setMatcherRegex(m *Matcher, v any, path string) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("%s.heading.regex must be a string, got %T", path, v)
+	}
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("%s.heading.regex: empty pattern", path)
+	}
+	// Compile the resolved pattern (with helpers substituted by a
+	// dummy frontmatter) to surface invalid RE2 syntax at parse
+	// time. The validator re-resolves the pattern per-document so
+	// `fmvar(name)` picks up the real value. Unsupported helpers
+	// and unterminated `\#(` references fail here instead of
+	// degrading into a missing-section diagnostic at runtime.
+	probe, err := resolvePatternForCheck(s)
+	if err != nil {
+		return fmt.Errorf("%s.heading.regex: %v", path, err)
+	}
+	if _, err := regexp.Compile("^(?:" + probe + ")$"); err != nil {
+		return fmt.Errorf("%s.heading.regex: %v", path, err)
+	}
+	m.Regex = s
+	return nil
+}
+
+func setMatcherRepeat(m *Matcher, v any, path string) error {
+	rm, ok := v.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s.heading.repeat must be a mapping, got %T", path, v)
+	}
+	if len(rm) == 0 {
+		return fmt.Errorf(
+			"%s.heading.repeat: empty mapping — set `min:`, `max:`, or both",
+			path)
+	}
+	r := Repeat{Set: true}
+	var minSet, maxSet bool
+	for k, vv := range rm {
+		switch k {
+		case "min":
+			minSet = true
+			if err := readIntBound(&r.Min, vv, path+".heading.repeat", k); err != nil {
+				return err
+			}
+		case "max":
+			maxSet = true
+			if err := readIntBound(&r.Max, vv, path+".heading.repeat", k); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf(
+				"%s.heading.repeat.%s: unknown key (valid: min, max)", path, k)
+		}
+	}
+	if maxSet && r.Max == 0 {
+		return fmt.Errorf(
+			"%s.heading.repeat.max: must be greater than 0 (0 is unbounded; "+
+				"omit `max:` instead)", path)
+	}
+	if minSet && maxSet && r.Min > r.Max {
+		return fmt.Errorf(
+			"%s.heading.repeat: min=%d is greater than max=%d",
+			path, r.Min, r.Max)
+	}
+	m.Repeat = r
+	return nil
+}
+
+// readIntBound parses a non-negative integer from v. YAML decoders
+// can deliver ints as int, int64, or float64; the helper handles
+// all three with the same overflow / non-integer guards used for
+// content list bounds.
+func readIntBound(dst *int, v any, path, key string) error {
+	switch x := v.(type) {
+	case int:
+		if x < 0 {
+			return fmt.Errorf("%s.%s must be non-negative, got %d", path, key, x)
+		}
+		*dst = x
+	case int64:
+		if x < 0 {
+			return fmt.Errorf("%s.%s must be non-negative, got %d", path, key, x)
+		}
+		*dst = int(x)
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return fmt.Errorf(
+				"%s.%s must be a finite integer, got %v", path, key, x)
+		}
+		if x < 0 {
+			return fmt.Errorf(
+				"%s.%s must be non-negative, got %v", path, key, x)
+		}
+		if math.Trunc(x) != x {
+			return fmt.Errorf(
+				"%s.%s must be a non-negative integer, got %v", path, key, x)
+		}
+		if x > float64(math.MaxInt) {
+			return fmt.Errorf(
+				"%s.%s value %v exceeds int range on this platform",
+				path, key, x)
+		}
+		*dst = int(x)
+	default:
+		return fmt.Errorf("%s.%s must be an integer, got %T", path, key, v)
 	}
 	return nil
 }
@@ -431,23 +618,6 @@ func setScopeBool(dst *bool, v any, path, key string) error {
 		return fmt.Errorf("%s.%s must be a boolean, got %T", path, key, v)
 	}
 	*dst = b
-	return nil
-}
-
-func setScopeAliases(sc *Scope, v any, path string) error {
-	list, ok := v.([]any)
-	if !ok {
-		return fmt.Errorf("%s.aliases must be a list, got %T", path, v)
-	}
-	sc.Aliases = make([]string, 0, len(list))
-	for j, a := range list {
-		as, ok := a.(string)
-		if !ok {
-			return fmt.Errorf(
-				"%s.aliases[%d] must be a string, got %T", path, j, a)
-		}
-		sc.Aliases = append(sc.Aliases, as)
-	}
 	return nil
 }
 
@@ -841,46 +1011,7 @@ func setContentItemBound(dst *int, v any, path, key, kind string) error {
 		return fmt.Errorf(
 			"%s.%s: only valid on `kind: list`", path, key)
 	}
-	switch x := v.(type) {
-	case int:
-		if x < 0 {
-			return fmt.Errorf("%s.%s must be non-negative, got %d", path, key, x)
-		}
-		*dst = x
-	case int64:
-		if x < 0 {
-			return fmt.Errorf("%s.%s must be non-negative, got %d", path, key, x)
-		}
-		if x > int64(math.MaxInt) {
-			return fmt.Errorf(
-				"%s.%s value %d exceeds int range on this platform", path, key, x)
-		}
-		*dst = int(x)
-	case float64:
-		if math.IsNaN(x) || math.IsInf(x, 0) {
-			return fmt.Errorf(
-				"%s.%s must be a finite integer, got %v", path, key, x)
-		}
-		if x < 0 {
-			return fmt.Errorf(
-				"%s.%s must be non-negative, got %v", path, key, x)
-		}
-		// Reject non-integers before any int conversion. math.Trunc
-		// stays in the float domain, so a huge or fractional value
-		// never reaches the implementation-defined float->int cast.
-		if math.Trunc(x) != x {
-			return fmt.Errorf(
-				"%s.%s must be a non-negative integer, got %v", path, key, x)
-		}
-		if x > float64(math.MaxInt) {
-			return fmt.Errorf(
-				"%s.%s value %v exceeds int range on this platform", path, key, x)
-		}
-		*dst = int(x)
-	default:
-		return fmt.Errorf("%s.%s must be an integer, got %T", path, key, v)
-	}
-	return nil
+	return readIntBound(dst, v, path, key)
 }
 
 func isCUEIdent(s string) bool {

--- a/internal/schema/plan156_acceptance_test.go
+++ b/internal/schema/plan156_acceptance_test.go
@@ -1,0 +1,1486 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlan156_RegexMatchesRenderedPlainText covers the acceptance
+// criterion: regex matching is whole-string anchored against
+// rendered plain text. `## **Overview**` strips the emphasis
+// before matching `regex: 'Overview'`.
+func TestPlan156_RegexMatchesRenderedPlainText(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{"regex": "Overview"}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n\n## **Overview**\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	assert.Empty(t, diags, "emphasis around the heading text should not affect matching")
+}
+
+// TestPlan156_DigitsCaptureSequential covers `digits` plus
+// `sequential: true`: out-of-order numeric headings emit a
+// diagnostic.
+func TestPlan156_DigitsCaptureSequential(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":      `Step \#(digits)`,
+					"repeat":     map[string]any{"min": 1},
+					"sequential": true,
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step 1\n\nx\n\n## Step 3\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "sequential") ||
+			strings.Contains(d.Message, "out of order") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a sequential-violation diagnostic")
+}
+
+// TestPlan156_FmvarInterpolates covers `\#(fmvar(name))`
+// substitution from the document's frontmatter.
+func TestPlan156_FmvarInterpolates(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex": `\#(fmvar(id)): \#(fmvar(name))`,
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n\n## MDS001: line-length\n\nx\n")
+	diags := Validate(doc, sch,
+		map[string]any{"id": "MDS001", "name": "line-length"},
+		false, makeDiagForTest)
+	assert.Empty(t, diags, "fmvar should resolve and match the doc heading")
+}
+
+// TestPlan156_RepeatBoundsEnforced covers cardinality bounds.
+func TestPlan156_RepeatBoundsEnforced(t *testing.T) {
+	// `repeat: { min: 2, max: 3 }` requires 2-3 matches.
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  `Step \#(digits)`,
+					"repeat": map[string]any{"min": 2, "max": 3},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Only one Step heading present — falls below min.
+	doc := newDocFile(t, "doc.md", "# T\n\n## Step 1\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	require.NotEmpty(t, diags, "min=2 with one match should flag missing")
+}
+
+// TestPlan156_RepeatMaxEnforcedInOpenSchema regresses a Copilot
+// review finding: `repeat: { max: 1 }` must enforce its upper
+// bound regardless of `closed:`. In an open schema, extra matches
+// beyond max would otherwise pass through the trailing-leftover
+// loop silently.
+func TestPlan156_RepeatMaxEnforcedInOpenSchema(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  `Step \#(digits)`,
+					"repeat": map[string]any{"max": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step 1\n\nx\n\n## Step 2\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var exceeds bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "Step 2") &&
+			strings.Contains(d.Message, "at most") {
+			exceeds = true
+		}
+	}
+	assert.True(t, exceeds,
+		"repeat: {max: 1} with 2 matches should flag the second as exceeding max")
+}
+
+// TestPlan156_RejectsUnknownInterpHelperAtParseTime regresses a
+// Copilot review finding: `resolvePatternForCheck` used to swallow
+// errors and accept any non-`digits` interpolation as a probe
+// placeholder. Unsupported helpers and unterminated `\#(` must
+// fail at parse time.
+func TestPlan156_RejectsUnknownInterpHelperAtParseTime(t *testing.T) {
+	cases := []struct {
+		name, regex, want string
+	}{
+		{
+			name:  "unknown helper",
+			regex: `\#(bogus)`,
+			want:  `unknown helper "bogus"`,
+		},
+		{
+			name:  "unterminated reference",
+			regex: `prefix \#(fmvar(id`,
+			want:  "unterminated",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]any{
+				"sections": []any{
+					map[string]any{"heading": map[string]any{"regex": tc.regex}},
+				},
+			}
+			_, err := ParseInline(raw, "kind x")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestPlan156_RepeatYieldsToOptionalLaterScope regresses a Copilot
+// finding: a bounded greedy matcher must yield to any later listed
+// scope (required or optional) that the heading text matches,
+// instead of flagging that heading as exceeding `max`. Before the
+// fix, claimsLaterLiteral skipped optional scopes, so a greedy
+// `.+` matcher with `max: 2` followed by an optional listed entry
+// would emit a spurious "matched N times, allowed at most 2" on
+// the optional heading.
+func TestPlan156_RepeatYieldsToOptionalLaterScope(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 1, "max": 2},
+				},
+			},
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Optional",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## A\n\nx\n\n## B\n\ny\n\n## Optional\n\nz\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "Optional",
+			"the optional scope must claim its heading; "+
+				"the greedy matcher must not flag it as exceeding max")
+	}
+}
+
+// TestPlan156_SequentialDiagOnPartialRun regresses a Copilot
+// finding: matchScope used to skip the sequential-numbering check
+// when the run terminated by hitting a non-matching heading (not
+// by EOF or max). `Step 1, Step 3, Summary` must still emit a
+// sequential violation.
+func TestPlan156_SequentialDiagOnPartialRun(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":      `Step \#(digits)`,
+					"repeat":     map[string]any{"min": 1},
+					"sequential": true,
+				},
+			},
+			map[string]any{"heading": "Summary"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step 1\n\nx\n\n## Step 3\n\ny\n\n## Summary\n\nz\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "sequential") ||
+			strings.Contains(d.Message, "out of order") {
+			found = true
+		}
+	}
+	assert.True(t, found,
+		"sequential gap must be diagnosed even when the run ends before EOF/max")
+}
+
+// TestPlan156_FmFingerprintCollisionGuard regresses a Copilot
+// review concern: a naive `name=value;` join can collide when
+// values contain `;` or `=name=`. Two distinct frontmatter values
+// must produce distinct fingerprints so the cache returns the
+// right compiled regex.
+func TestPlan156_FmFingerprintCollisionGuard(t *testing.T) {
+	pattern := `\#(fmvar(a)): \#(fmvar(b))`
+	// Two FMs whose naive concatenation `a=x;b=y;b=z;` could
+	// match: the values themselves contain the separator chars.
+	first := fmFingerprint(pattern, map[string]any{
+		"a": "x;b=y",
+		"b": "z",
+	})
+	second := fmFingerprint(pattern, map[string]any{
+		"a": "x",
+		"b": "y;b=z",
+	})
+	assert.NotEqual(t, first, second,
+		"fmFingerprint must distinguish values that contain `;` or `=`")
+}
+
+// TestPlan156_RepeatSpansDeeperHeadings regresses a Copilot
+// review finding: a repeat run must skip deeper-than-expected
+// headings instead of terminating on them. Without this, a
+// repeated section with nested children (e.g. `## Step 1`
+// followed by `### Details` and then `## Step 2`) only counts
+// the first step.
+func TestPlan156_RepeatSpansDeeperHeadings(t *testing.T) {
+	raw := map[string]any{
+		"closed": true,
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":      `Step \#(digits)`,
+					"repeat":     map[string]any{"min": 1, "max": 5},
+					"sequential": true,
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// A nested H3 between two H2 repeats. Step 2 must be counted
+	// by the run (not surface as unexpected) and the sequential
+	// check must see [1, 2] (not just [1]).
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step 1\n\n### Details\n\nx\n\n## Step 2\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, `unexpected section "## Step 2"`,
+			"## Step 2 must not surface as unexpected; the run "+
+				"must skip the deeper `### Details` heading")
+	}
+}
+
+// TestPlan156_FlagExtrasBeyondMaxSkipsDeeper regresses a Copilot
+// finding: the max-extras scan must skip headings deeper than the
+// expected level instead of treating them as the boundary. A
+// repeated section with `### Detail` between the max'd run and a
+// later same-level extra would otherwise let the extra through
+// silently in an open schema.
+func TestPlan156_FlagExtrasBeyondMaxSkipsDeeper(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Step",
+					"repeat": map[string]any{"max": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step\n\n### Detail\n\nx\n\n## Step\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var exceeds bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "allowed at most") {
+			exceeds = true
+		}
+	}
+	assert.True(t, exceeds,
+		"second Step must be flagged even when a deeper heading "+
+			"separates it from the first occurrence")
+}
+
+// TestPlan156_RejectsMultipleDigitsInline regresses a Copilot
+// finding: the matcher runtime reads only the first `n` capture,
+// so multiple `\#(digits)` helpers in one pattern make later
+// numbers silently ignored. The parser must reject this.
+func TestPlan156_RejectsMultipleDigitsInline(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex": `Step \#(digits) of \#(digits)`,
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "digits")
+	assert.Contains(t, err.Error(), "once")
+}
+
+// TestPlan156_OptionalSpecificClaimsOwnSlot regresses a Copilot
+// finding: a heading that matches an earlier optional specific
+// matcher must claim that scope, not yield to a later broad
+// (`.+`) matcher. The previous fix made claimsLaterLiteral
+// include optional scopes — necessary for the wildcard-slot
+// case — but the yield should only fire when the later
+// matcher is *narrower* than the current one (i.e. not a
+// broad `.+` regex).
+func TestPlan156_OptionalSpecificClaimsOwnSlot(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Overview",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
+				"content": []any{
+					map[string]any{"kind": "code-block", "lang": "yaml"},
+				},
+			},
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Overview is present but missing its required code block.
+	// If the broad `.+` matcher claims the heading first, the
+	// content check is silenced. We want the missing-content
+	// diagnostic to fire.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Overview\n\nNo code block here.\n\n## Body\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var contentMissing bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "missing required content") &&
+			strings.Contains(d.Message, "Overview") {
+			contentMissing = true
+		}
+	}
+	assert.True(t, contentMissing,
+		"the optional specific scope must claim its own heading; "+
+			"a broad `.+` matcher must not absorb it")
+}
+
+// TestPlan156_FlagsExtrasMatchingClaimedScope regresses a
+// Copilot finding: when an out-of-order claim takes one
+// occurrence of a scope and another doc heading matches the
+// same scope, the late-claim path used to flag the second as a
+// generic "unexpected" (or silently accept it in open
+// schemas). The trailing loop now emits a specific
+// "exceeds scope's allowed occurrences" diagnostic so the user
+// sees which scope was over-filled.
+func TestPlan156_FlagsExtrasMatchingClaimedScope(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{
+				"regex":  "B",
+				"repeat": map[string]any{"max": 1},
+			}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc: B (claimed late by out-of-order claim against A),
+	// A, B again. The second B is the extra occurrence; the
+	// late-claim path absorbed only the first B.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## B\n\nx\n\n## A\n\ny\n\n## B\n\nz\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var exceeded bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "exceeds scope") &&
+			strings.Contains(d.Message, "B") {
+			exceeded = true
+		}
+	}
+	assert.True(t, exceeded,
+		"the second B must surface as exceeding the late-claimed "+
+			"scope, not as a generic unexpected section")
+}
+
+// TestPlan156_OutOfOrderSequentialDiagFires regresses a Copilot
+// finding: when a scope with `sequential: true` is claimed
+// out-of-order, the run-style sequential check can't be
+// retraced. claimOutOfOrder now emits a dedicated diagnostic
+// pointing the author at the in-order schema position.
+func TestPlan156_OutOfOrderSequentialDiagFires(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{
+				"regex":      `Step \#(digits)`,
+				"sequential": true,
+			}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Step appears before A — out of order, sequential set.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step 1\n\nx\n\n## A\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var seq bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "sequential ordering is not enforced") {
+			seq = true
+		}
+	}
+	assert.True(t, seq,
+		"out-of-order claim of a sequential scope must surface "+
+			"the unenforced-sequential diagnostic")
+}
+
+// TestPlan156_OverlappingMatcherDoesNotInflateClaimCount
+// regresses a Copilot finding: an earlier `regex: 'A|B'` scope
+// that yields a `B` heading to a later named `B` scope used to
+// have that yielded heading counted toward its own claim total
+// because the trailing pass re-scanned by regex. Now the count
+// tracks actual claims, so the early scope's `max` isn't
+// over-counted.
+func TestPlan156_OverlappingMatcherDoesNotInflateClaimCount(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "A|B",
+					"repeat": map[string]any{"min": 1, "max": 2},
+				},
+			},
+			map[string]any{"heading": "B"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc: A, B, A. The first scope claims A (counted = 1),
+	// yields B to the named B scope, then sees the second A.
+	// The trailing A should be its 2nd claim — within max=2.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## A\n\nx\n\n## B\n\ny\n\n## A\n\nz\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "exceeds scope",
+			"yielded headings must not inflate the first scope's claim count")
+	}
+}
+
+// TestPlan156_BoundedMaxExceededOutOfOrder regresses a Copilot
+// finding: the recovery path used to skip already-claimed
+// scopes with `max > 1`, so a `repeat: { max: 2 }` scope
+// claimed out of order could silently absorb three or more
+// occurrences in open schemas. The trailing pass now counts
+// same-level matches in the parent window and flags the
+// excess (only) when count > max.
+func TestPlan156_BoundedMaxExceededOutOfOrder(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{
+				"regex":  "B",
+				"repeat": map[string]any{"max": 2},
+			}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc: B (out of order), A, B, B. Three Bs total; max=2.
+	// The third B must be flagged.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## B\n\nx\n\n## A\n\ny\n\n## B\n\nz\n\n## B\n\nw\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var exceededCount int
+	for _, d := range diags {
+		if strings.Contains(d.Message, "exceeds scope") {
+			exceededCount++
+		}
+	}
+	assert.Equal(t, 1, exceededCount,
+		"only the third B should be flagged as exceeding max=2 "+
+			"(the first two are within bounds)")
+}
+
+// TestPlan156_RejectsUserNamedCaptureN regresses a Copilot
+// finding: the matcher runtime reads the named capture `n` for
+// sequential ordering, but `regex:` is raw RE2 and a user
+// could write their own `(?P<n>...)` group that would collide.
+// Reject the reserved capture name at parse time.
+func TestPlan156_RejectsUserNamedCaptureN(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex": `(?P<n>[a-z]+) Step \#(digits)`,
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved by")
+	assert.Contains(t, err.Error(), "`\\#(digits)`")
+}
+
+// TestPlan156_NonBroadRunYieldsAfterMin regresses a Copilot
+// finding: the per-scope walkers used to yield only broad
+// matchers, but matchScope yields any matcher (broad or not)
+// to a later named scope once `min` is satisfied. A scope like
+// `regex: 'A|B', repeat: { min: 1 }` followed by a `B` scope
+// must let `## B` belong to the named B scope so that scope's
+// content / rule / acronym checks fire on its body.
+func TestPlan156_NonBroadRunYieldsAfterMin(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "A|B",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+			map[string]any{
+				"heading": "B",
+				"content": []any{
+					map[string]any{"kind": "code-block", "lang": "yaml"},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc: A, B. The first run claims A (min=1 satisfied) then
+	// yields B to the named scope; B is missing its required
+	// code block, so the content check fires.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## A\n\nx\n\n## B\n\nno code here\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var contentMissing bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "missing required content") &&
+			strings.Contains(d.Message, "B") {
+			contentMissing = true
+		}
+	}
+	assert.True(t, contentMissing,
+		"the named B scope must claim its heading and run its "+
+			"content check once the earlier run has satisfied min")
+}
+
+// TestPlan156_OptionalYieldsToBroadFollower regresses a Copilot
+// finding: when an optional scope (`repeat: { min: 0 }`) does
+// not match the current heading, the step path used to skip
+// the heading if no non-broad later scope claimed it. That
+// consumed headings a later broad matcher needed, so a schema
+// like [A optional, .+ min=1] against doc [Body] reported the
+// broad scope as missing. The unmatched-optional yield check
+// must include broad matchers.
+func TestPlan156_OptionalYieldsToBroadFollower(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "A",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
+			},
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md", "# T\n\n## Body\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "missing required",
+			"the broad matcher must claim Body; optional A "+
+				"yields to it instead of consuming Body silently")
+	}
+}
+
+// TestPlan156_ScopeRunStopsAtBoundary regresses a Copilot
+// finding: per-scope walkers (content, rules, acronyms) used
+// to scan the whole parent window for matches, so a repeated
+// `Step` scope would silently apply its content / rule
+// overrides to a `## Step` that appeared AFTER a `## Summary`
+// boundary, even though the structural validator stopped the
+// run at Summary. The walkers now use ScopeRunIndices which
+// mirrors matchScope's contiguous-run semantics.
+func TestPlan156_ScopeRunStopsAtBoundary(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Step",
+					"repeat": map[string]any{"min": 1},
+				},
+				"content": []any{
+					map[string]any{"kind": "code-block", "lang": "yaml"},
+				},
+			},
+			map[string]any{"heading": "Summary"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Two Step sections (each with the required code block),
+	// then Summary, then a third Step WITHOUT the code block.
+	// The third Step is not part of the run — its missing
+	// code-block should NOT be flagged.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n"+
+			"## Step\n\n```yaml\nfoo: bar\n```\n\n"+
+			"## Step\n\n```yaml\nbaz: qux\n```\n\n"+
+			"## Summary\n\nsummary text\n\n"+
+			"## Step\n\nno code block here\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "missing required content",
+			"the third Step is outside the structural run; "+
+				"its content constraint must not fire")
+	}
+}
+
+// TestPlan156_FlagsExtrasInIterationStream regresses a Copilot
+// finding: when a doc has [B, B, A] against schema [A, B], the
+// second B used to be silently consumed by handleNonMatch
+// (findOutOfOrderIdx skips claimed scopes, open schema → no
+// diag). The handler now consults claimedScopeMatches and
+// emits "exceeds allowed occurrences" for the duplicate.
+func TestPlan156_FlagsExtrasInIterationStream(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": "B"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## B\n\nx\n\n## B\n\ny\n\n## A\n\nz\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var exceeded bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "exceeds scope") {
+			exceeded = true
+		}
+	}
+	assert.True(t, exceeded,
+		"the second B must be flagged as exceeding scope B's "+
+			"allowed occurrences, not silently consumed")
+}
+
+// TestPlan156_UnboundedRepeatDoesNotFlagAsExceeded regresses a
+// Copilot finding: claimedScopeMatches used to fire for any
+// claimed scope, including unbounded matchers (`max == 0`). A
+// later non-contiguous occurrence of a `repeat: { min: 1 }`
+// scope must NOT surface as "exceeds allowed occurrences" —
+// the matcher has no upper bound.
+func TestPlan156_UnboundedRepeatDoesNotFlagAsExceeded(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Step",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+			map[string]any{"heading": "Summary"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Two Step sections sandwiching Summary. The second Step
+	// is non-contiguous; the unbounded matcher has no max to
+	// exceed.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step\n\nx\n\n## Summary\n\ny\n\n## Step\n\nz\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "exceeds scope",
+			"an unbounded repeat must not produce a max-exceeded "+
+				"diagnostic on a non-contiguous occurrence")
+	}
+}
+
+// TestPlan156_BroadMatcherYieldsBeforeMin regresses a Copilot
+// finding: a broad matcher (`.+`) with `repeat: { min: 2 }`
+// used to consume a later named scope's heading to satisfy its
+// own min, leaving the named scope flagged as missing. The
+// yield check must fire for broad matchers regardless of
+// consumed/min so a heading the user named separately always
+// claims its named scope.
+func TestPlan156_BroadMatcherYieldsBeforeMin(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 2},
+				},
+			},
+			map[string]any{"heading": "Named"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Body\n\nx\n\n## Named\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, `missing required section "## Named"`,
+			"the named scope must claim its own heading; "+
+				"a broad min=2 matcher must not steal it")
+	}
+}
+
+// TestPlan156_LateClaimFlagsRepeatMin regresses a Copilot
+// finding: when a repeated scope (`repeat.min > 1`) appears
+// out-of-order with only one occurrence, the late-claim
+// recovery path must still surface a "required at least N"
+// diagnostic so the cardinality contract is enforced.
+func TestPlan156_LateClaimFlagsRepeatMin(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{
+				"regex":  "B",
+				"repeat": map[string]any{"min": 2},
+			}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// B appears once before A — out of order, and only one
+	// occurrence so the repeat.min is not satisfied.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## B\n\nx\n\n## A\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var card bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "required at least 2") {
+			card = true
+		}
+	}
+	assert.True(t, card,
+		"the late-claim path must flag the repeat.min shortfall")
+}
+
+// TestPlan156_WrongLevelMatchCountsTowardRepeat regresses a
+// Copilot finding: a wrong-level match used to go through a
+// claimRun helper that did not update consumed/digits, so a
+// repeated matcher could be silently satisfied by a single
+// wrong-level occurrence without `repeat.min` or `sequential`
+// enforcement. The path now routes through claimMatch so the
+// run accounting still fires.
+func TestPlan156_WrongLevelMatchCountsTowardRepeat(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "Outer", "sections": []any{
+				map[string]any{
+					"heading": map[string]any{
+						"regex":  "Inner",
+						"repeat": map[string]any{"min": 2},
+					},
+				},
+			}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Outer at H2; only one Inner at H2 (wrong level — expected
+	// H3). The wrong-level match counts as one occurrence, so the
+	// run accounting must emit "matched 1 times, required at
+	// least 2".
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Outer\n\n## Inner\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var shortRun bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "required at least 2") {
+			shortRun = true
+		}
+	}
+	assert.True(t, shortRun,
+		"wrong-level match must contribute to the run's count "+
+			"so repeat.min still fires")
+}
+
+// TestPlan156_RejectsInvalidFmvarPath regresses a Copilot
+// finding: `fmvar(name)` accepted any argument string at parse
+// time, so a typo like `fmvar(my-key)` (unquoted hyphenated key)
+// only surfaced as a confusing missing-section diagnostic at
+// validate-time. Parse-time validation now applies the same CUE
+// path rules as the runtime lookup.
+func TestPlan156_RejectsInvalidFmvarPath(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex": `\#(fmvar(my-key))`,
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fmvar(my-key)")
+	assert.Contains(t, err.Error(), "non-identifier keys must be quoted")
+}
+
+// TestPlan156_OptionalMatcherSkipsTolerated regresses a Copilot
+// low-confidence finding: an optional matcher (`repeat.min == 0`)
+// stopped at the first non-matching heading and left later
+// in-order occurrences to be flagged as out-of-order by the
+// leftover pass. The matcher should scan past tolerated extras
+// in open schemas the same way a required matcher does, only
+// terminating once it has actually started a run.
+func TestPlan156_OptionalMatcherSkipsTolerated(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "X",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc has a tolerated extra before X. The open-schema walk
+	// should silently consume Other and then claim X normally.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Other\n\nx\n\n## X\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "out of order",
+			"optional X must claim itself even after a tolerated extra")
+	}
+}
+
+// TestPlan156_BroadRepeatYieldsAcronymScope covers the acronym
+// walker's broad-matcher yield: an acronym-scoped named section
+// after a broad repeated matcher must still get its body
+// scanned, not have the broad matcher absorb its heading.
+func TestPlan156_BroadRepeatYieldsAcronymScope(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+			map[string]any{"heading": "Diagnosis"},
+		},
+		"acronyms": map[string]any{
+			"scope":      []any{"Diagnosis"},
+			"known-safe": []any{},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Body\n\nIgnored.\n\n## Diagnosis\n\nOIDC undefined.\n")
+	diags := ValidateAcronyms(doc, sch, nil, makeDiagForTest)
+	require.Len(t, diags, 1,
+		"acronym scan must reach the named Diagnosis section")
+	assert.Contains(t, diags[0].Message, "OIDC")
+}
+
+// TestPlan156_BroadRepeatYieldsToLaterScopeInPerScopeWalkers
+// regresses a Copilot finding: the per-scope walkers (rules,
+// content, acronyms) must yield to later named scopes the same
+// way the structural validator does, otherwise a broad repeated
+// matcher silently consumes headings the user named separately.
+func TestPlan156_BroadRepeatYieldsToLaterScopeInPerScopeWalkers(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 1},
+				},
+			},
+			map[string]any{
+				"heading": "Diagnosis",
+				"content": []any{
+					map[string]any{"kind": "code-block", "lang": "yaml"},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc has Body + Diagnosis. The broad matcher must yield
+	// "Diagnosis" so the content check fires there.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Body\n\nx\n\n## Diagnosis\n\nNo code block.\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var missing bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "missing required content") &&
+			strings.Contains(d.Message, "Diagnosis") {
+			missing = true
+		}
+	}
+	assert.True(t, missing,
+		"named Diagnosis scope must claim its heading; "+
+			"a broad repeated matcher must not absorb it")
+}
+
+// TestPlan156_RejectsMultipleNTokensProto regresses the same
+// constraint for proto.md heading rows. `## Step {n} of {n}`
+// would expand to two `\#(digits)` helpers; the file parser
+// must surface the same rejection as the inline form.
+func TestPlan156_RejectsMultipleNTokensProto(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "proto.md", "## Step {n} of {n}\n")
+	_, err := ParseFile(&FileReader{}, p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "{n}")
+	assert.Contains(t, err.Error(), "at most once")
+}
+
+// TestPlan156_AcronymScopeOnRepeatedScope regresses a Copilot
+// review finding: a repeated scope with an acronym-scope name
+// must scan every occurrence's range, not just the first.
+func TestPlan156_AcronymScopeOnRepeatedScope(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Diagnosis",
+					"repeat": map[string]any{"min": 1, "max": 5},
+				},
+			},
+		},
+		"acronyms": map[string]any{
+			"scope":      []any{"Diagnosis"},
+			"known-safe": []any{},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Diagnosis\n\nOIDC first.\n\n## Diagnosis\n\nLDAP second.\n")
+	diags := ValidateAcronyms(doc, sch, nil, makeDiagForTest)
+	var seenOIDC, seenLDAP bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "OIDC") {
+			seenOIDC = true
+		}
+		if strings.Contains(d.Message, "LDAP") {
+			seenLDAP = true
+		}
+	}
+	assert.True(t, seenOIDC, "first Diagnosis range should report OIDC")
+	assert.True(t, seenLDAP,
+		"second Diagnosis range must also be scanned for first-use acronyms")
+}
+
+// TestPlan156_ContentOnRepeatedScope regresses a Copilot review
+// finding: content constraints on a repeated scope must fire for
+// every occurrence, not just the first.
+func TestPlan156_ContentOnRepeatedScope(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Step",
+					"repeat": map[string]any{"min": 1, "max": 5},
+				},
+				"content": []any{
+					map[string]any{"kind": "code-block", "lang": "yaml"},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Two Step sections; only the first has a code block.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step\n\n```yaml\nfoo: bar\n```\n\n## Step\n\nNo code block here.\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var contentMisses int
+	for _, d := range diags {
+		if strings.Contains(d.Message, "missing required content") {
+			contentMisses++
+		}
+	}
+	assert.Equal(t, 1, contentMisses,
+		"the second Step's missing code-block must be flagged "+
+			"even though the first occurrence satisfied the constraint")
+}
+
+// TestPlan156_RulesOnRepeatedScope regresses a Copilot review
+// finding: per-scope rule overrides on a repeated scope must
+// apply to every occurrence.
+func TestPlan156_RulesOnRepeatedScope(t *testing.T) {
+	// Build the rule directly so the test stays inside the
+	// schema package — the override fires when the per-scope
+	// walker visits more than one occurrence. We can't invoke
+	// the MDS020 rule engine from here, but we can observe the
+	// walker visits via the acronym range count, which mirrors
+	// the per-scope walker's visit-count semantics.
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Diagnosis",
+					"repeat": map[string]any{"min": 1, "max": 5},
+				},
+			},
+		},
+		"acronyms": map[string]any{
+			"scope":      []any{"Diagnosis"},
+			"known-safe": []any{},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Diagnosis\n\nOIDC first.\n\n## Diagnosis\n\nSAML second.\n")
+	diags := ValidateAcronyms(doc, sch, nil, makeDiagForTest)
+	// Each range produces its own first-use diagnostic; two
+	// occurrences => two diagnostics.
+	assert.Len(t, diags, 2,
+		"each repeated occurrence must contribute its own range "+
+			"so per-scope checks fire on every occurrence")
+}
+
+// TestPlan156_AcronymScopeMatchesByHeadingText regresses a
+// Copilot review finding: a disjunctive matcher like
+// `regex: 'Symptoms|Indicators'` paired with
+// `acronyms.scope: ["Indicators"]` must scan the matched
+// `## Indicators` body. Plan 156 dropped the scope-level
+// `aliases:` field, so the walker must compare the configured
+// scope name against the actual matched heading text (not just
+// the schema label or the raw regex body).
+func TestPlan156_AcronymScopeMatchesByHeadingText(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{"regex": "Symptoms|Indicators"},
+			},
+		},
+		"acronyms": map[string]any{
+			"scope":      []any{"Indicators"},
+			"known-safe": []any{},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Indicators\n\nOIDC first.\n")
+	diags := ValidateAcronyms(doc, sch, nil, makeDiagForTest)
+	var seenOIDC bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "OIDC") {
+			seenOIDC = true
+		}
+	}
+	assert.True(t, seenOIDC,
+		"acronyms.scope must match the actual matched heading text, "+
+			"not just the schema label or the raw regex body")
+}
+
+// TestPlan156_OutOfOrderRunCountsAvailableMatches regresses a
+// Copilot review finding: when an out-of-order recovery occurs on
+// a scope with `repeat.min > 1`, the diagnostic must count the
+// available run of consecutive matches rather than always
+// emitting "matched 1 times". Otherwise a document that contains
+// enough occurrences of B (just before A) gets a spurious
+// "matched 1 times, required at least 2" diagnostic on top of
+// the legitimate out-of-order message.
+func TestPlan156_OutOfOrderRunCountsAvailableMatches(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "B",
+					"repeat": map[string]any{"min": 2, "max": 5},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Two B's before the expected A — B's min cardinality is
+	// satisfied by the run, only the ordering is wrong.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## B\n\n## B\n\n## A\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var outOfOrder, falseMin int
+	for _, d := range diags {
+		if strings.Contains(d.Message, "out of order") {
+			outOfOrder++
+		}
+		if strings.Contains(d.Message, "matched 1 times") {
+			falseMin++
+		}
+	}
+	assert.GreaterOrEqual(t, outOfOrder, 1,
+		"the out-of-order condition must still be reported")
+	assert.Zero(t, falseMin,
+		"a contiguous B-run that satisfies min must not get a "+
+			"`matched 1 times, required at least 2` diagnostic")
+}
+
+// TestPlan156_NonContiguousClaimedScopeFlagged regresses a
+// Copilot review finding: a heading that matches an already-
+// claimed scope is silently absorbed when it stays within
+// `max`. With schema `[A (repeat 1..2), B]` and document
+// `A, B, A`, the trailing A is non-contiguous with A's earlier
+// run — matcher runs are consecutive, so the open schema
+// should still emit a diagnostic instead of letting the
+// trailing occurrence pass.
+func TestPlan156_NonContiguousClaimedScopeFlagged(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "A",
+					"repeat": map[string]any{"min": 1, "max": 2},
+				},
+			},
+			map[string]any{"heading": "B"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## A\n\n## B\n\n## A\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var orderingDiag bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "out of order") &&
+			strings.Contains(d.Message, "contiguous") {
+			orderingDiag = true
+		}
+	}
+	assert.True(t, orderingDiag,
+		"a trailing same-scope match after the run closed must be "+
+			"flagged as non-contiguous, even within max")
+}
+
+// TestPlan156_LateClaimChildRecursionStopsAtParentLevel
+// regresses a Copilot review finding: claimLateScope hands
+// validateScopes the full remaining doc-heading slice when it
+// recurses into the late scope's children. The leftover pass
+// inside that child window must break at the first shallower-
+// than-child heading so a same-level sibling that follows the
+// late section is still visible to the parent's leftover loop.
+// Otherwise the trailing duplicate `## A` here would be
+// silently absorbed by the child walker instead of getting an
+// "exceeds allowed occurrences" diagnostic on the parent A
+// scope.
+func TestPlan156_LateClaimChildRecursionStopsAtParentLevel(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "B",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
+				"sections": []any{
+					map[string]any{"heading": "Detail"},
+				},
+			},
+			map[string]any{"heading": "C"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## A\n\n## C\n\n## B\n\n### Detail\n\n## A\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var lateB, trailingA bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, `## B: got <out of order>`) &&
+			strings.Contains(d.Message, `expected before this position`) {
+			lateB = true
+		}
+		if strings.Contains(d.Message,
+			`"## A"`) &&
+			(strings.Contains(d.Message, "exceeds") ||
+				strings.Contains(d.Message, "out of order")) {
+			trailingA = true
+		}
+	}
+	assert.True(t, lateB,
+		"late B must still be flagged by claimLateScope")
+	assert.True(t, trailingA,
+		"trailing ## A at parent level must surface; child "+
+			"recursion under B must not consume it")
+}
+
+// TestPlan156_CountMatchingRunStopsAtShallowerHeading regresses
+// countMatchingRun's early-return on a heading shallower than
+// the expected child level. When a nested out-of-order match is
+// immediately followed by a parent-level heading, the run-length
+// scan must stop at the shallower boundary rather than walking
+// past it.
+func TestPlan156_CountMatchingRunStopsAtShallowerHeading(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Parent",
+				"sections": []any{
+					map[string]any{"heading": "A"},
+					map[string]any{"heading": "B"},
+				},
+			},
+			map[string]any{"heading": "Sibling"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Parent\n\n### B\n\n## Sibling\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var sawOO bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, `### B`) &&
+			strings.Contains(d.Message, "out of order") {
+			sawOO = true
+		}
+	}
+	assert.True(t, sawOO,
+		"### B inside Parent must be flagged as out-of-order "+
+			"under A; the run-count must not walk past ## Sibling")
+}
+
+// TestPlan156_RunContinuationRecursesChildren regresses a Copilot
+// review finding: when claimedScopeMatches absorbs a contiguous
+// run-continuation heading (idx >= s.idx, within max), the walker
+// must still recurse into the scope's children so every
+// occurrence of a repeated scope with required nested sections
+// gets its child contract enforced — not just the first one.
+func TestPlan156_RunContinuationRecursesChildren(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "Anchor"},
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "Step",
+					"repeat": map[string]any{"min": 1, "max": 5},
+				},
+				"sections": []any{
+					map[string]any{"heading": "Detail"},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Two Step occurrences before the listed Anchor — second
+	// Step lacks its required Detail child. The first Step is
+	// claimed via claimOutOfOrder (and recurses into Detail);
+	// the second Step is absorbed as a run continuation and
+	// must also recurse so the missing Detail surfaces.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Step\n\n### Detail\n\n## Step\n\n## Anchor\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var missing int
+	for _, d := range diags {
+		if strings.Contains(d.Message, `### Detail`) &&
+			strings.Contains(d.Message, "section to be present") {
+			missing++
+		}
+	}
+	assert.GreaterOrEqual(t, missing, 1,
+		"the second Step occurrence's missing Detail must surface; "+
+			"the run-continuation absorb path must recurse into "+
+			"children just like claimMatch does")
+}
+
+// TestPlan156_MissingFmvarFailsMatch regresses a Copilot review
+// finding: an unresolved `fmvar(name)` used to substitute an
+// empty regex fragment, so `regex: 'Topic \#(fmvar(id))'` with
+// missing `id` would match a degenerate `## Topic ` heading.
+// resolvePattern now errors on a missing fmvar, surfacing the
+// section as missing rather than silently matching a partial
+// heading.
+func TestPlan156_MissingFmvarFailsMatch(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex": `Topic \#(fmvar(id))`,
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Heading text matches the literal-only remainder of the
+	// pattern. With the old behavior this passed silently; the
+	// new behavior fails the match because `id` is absent.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Topic \n\nbody\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var sawMissing bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "section to be present") {
+			sawMissing = true
+		}
+	}
+	assert.True(t, sawMissing,
+		"a heading with unresolved fmvar must not match a "+
+			"degenerate literal heading; the scope must surface "+
+			"as missing instead")
+}
+
+// TestPlan156_BroadMatcherIgnoresParentLevelSibling regresses a
+// Copilot review finding: when a nested broad matcher
+// (`regex: '.+'`) runs out of child headings, it must NOT
+// salvage the next parent-level heading via the
+// shallower-heading recovery. Otherwise the parent walker's
+// next sibling is consumed under the wrong scope and reported
+// as a level mismatch.
+func TestPlan156_BroadMatcherIgnoresParentLevelSibling(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Parent",
+				"sections": []any{
+					map[string]any{
+						"heading": map[string]any{
+							"regex":  ".+",
+							"repeat": map[string]any{"min": 0},
+						},
+					},
+				},
+			},
+			map[string]any{"heading": "Sibling"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Parent\n\n## Sibling\n\nbody\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var sawLevel bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "Sibling") &&
+			strings.Contains(d.Message, "got h2") {
+			sawLevel = true
+		}
+	}
+	assert.False(t, sawLevel,
+		"the nested broad matcher must not salvage `## Sibling` "+
+			"as an h3 level-mismatch; the parent walker owns it")
+}
+
+// TestPlan156_ScanInterpsHandlesQuotedParens regresses a
+// Copilot review finding: scanInterps used to count every `)`
+// as closing the interpolation even inside a quoted CUE path
+// like `fmvar("release)date")`, truncating the helper. The
+// scanner now skips parens inside double-quoted segments.
+func TestPlan156_ScanInterpsHandlesQuotedParens(t *testing.T) {
+	pattern := `prefix \#(fmvar("release)date")) suffix`
+	var seen string
+	err := scanInterps(pattern, func(expr string, _, _ int) error {
+		seen = expr
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `fmvar("release)date")`, seen,
+		"the parser must keep the quoted argument intact even when "+
+			"it contains a literal `)`")
+}
+
+// TestPlan156_FmvarAcceptsQuotedCloseParen regresses a Copilot
+// review finding: the `fmvar(...)` argument parser used to stop
+// at the first `)`, breaking a valid CUE label like
+// `fmvar("release)date")` even though scanInterps respected the
+// quoted segment. parseFmvarCall now scans past quoted regions
+// so the full argument reaches fmvarLookup.
+func TestPlan156_FmvarAcceptsQuotedCloseParen(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex": `\#(fmvar("release)date"))`,
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err,
+		"a quoted CUE label containing `)` must parse cleanly")
+	require.Len(t, sch.Sections, 1)
+	assert.Equal(t, `\#(fmvar("release)date"))`,
+		sch.Sections[0].Matcher.Regex)
+}
+
+// TestPlan156_RejectsRealUserNCaptureNotLiteral regresses a
+// Copilot review finding: the `(?P<n>...)` reservation used to
+// substring-match the literal text, which would reject valid
+// regexes that merely contained `(?P<n>` as escaped/character-
+// class content. The check now parses the regex via
+// regexp/syntax and looks for an actual named capture, so a
+// regex like `\(\?P<n>` (a literal-text match of that exact
+// string) is now accepted.
+func TestPlan156_RejectsRealUserNCaptureNotLiteral(t *testing.T) {
+	// A real `(?P<n>...)` collides with the reserved capture and
+	// must still be rejected.
+	bad := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex": `(?P<n>[A-Z]+)`,
+				},
+			},
+		},
+	}
+	_, err := ParseInline(bad, "kind x")
+	require.Error(t, err, "real `(?P<n>...)` capture must be rejected")
+	assert.Contains(t, err.Error(), "reserved")
+
+	// An escaped literal `(?P<n>` is not a capture group and
+	// must be accepted.
+	good := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex": `\(\?P<n>doc\)`,
+				},
+			},
+		},
+	}
+	_, err = ParseInline(good, "kind x")
+	assert.NoError(t, err,
+		"an escaped literal `(?P<n>` text is not a capture and "+
+			"must not trip the reservation check")
+}

--- a/internal/schema/plan156_coverage_test.go
+++ b/internal/schema/plan156_coverage_test.go
@@ -1,0 +1,832 @@
+package schema
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// TestClaimsLaterLiteral_Branches covers the four branches of
+// claimsLaterLiteral so an ambiguous matcher run (e.g. `regex: '.+'`
+// with `repeat: { min: 1 }`) yields to a later literal entry only
+// when one is actually present.
+func TestClaimsLaterLiteral_Branches(t *testing.T) {
+	scopes := []Scope{
+		// idx 0: preamble — never claims headings (no matcher)
+		{Preamble: true},
+		// idx 1: slot — never claims (broad `.+` matcher is
+		// filtered out by claimsLaterLiteral so it never
+		// reserves a heading from an earlier scope)
+		slotScope(),
+		// idx 2: optional literal — eligible to claim its own
+		// text "Optional"; ignored here because the test heading
+		// is "References", not "Optional"
+		optionalScope("Optional"),
+		// idx 3: required literal that matches the heading
+		literalScope("References"),
+	}
+	claimed := map[int]bool{}
+	dh := DocHeading{Text: "References", Level: 2}
+	assert.True(t,
+		claimsLaterLiteral(scopes, 0, dh, claimed, nil),
+		"a heading whose text matches a later required literal must reserve for that literal")
+
+	// dh that doesn't match any later literal — no claim.
+	other := DocHeading{Text: "Trailing", Level: 2}
+	assert.False(t,
+		claimsLaterLiteral(scopes, 0, other, claimed, nil),
+		"a heading that matches no later required literal does not reserve")
+
+	// startIdx past the literal — none ahead, no claim.
+	assert.False(t,
+		claimsLaterLiteral(scopes, 4, dh, claimed, nil),
+		"no scopes at or after startIdx => no claim")
+
+	// Already-claimed literal — not eligible.
+	claimed[3] = true
+	assert.False(t,
+		claimsLaterLiteral(scopes, 0, dh, claimed, nil),
+		"a claimed later literal must not reserve again")
+}
+
+// TestDisplayHeading_Branches covers all three return paths.
+func TestDisplayHeading_Branches(t *testing.T) {
+	// Heading set — bare-string sugar path.
+	assert.Equal(t, "Overview", displayHeading(literalScope("Overview")))
+	// Heading empty, Matcher set — mapping-form fallback.
+	sc := Scope{Matcher: &Matcher{Regex: ".+"}}
+	assert.Equal(t, ".+", displayHeading(sc))
+	// Neither set — preamble label.
+	assert.Equal(t, "", displayHeading(Scope{Preamble: true}))
+}
+
+// TestWrongLevelMatch_RecursesIntoChildren covers the branch of
+// claimMatch reached via the shallower-than-expected heading
+// path: a scope whose nested children must still be validated
+// even when the outer heading appeared at the wrong level.
+func TestWrongLevelMatch_RecursesIntoChildren(t *testing.T) {
+	// Schema: Outer at H3 (because of an outer wrapper), Inner at
+	// H4. Doc emits Outer at H2 (shallower than expected H3).
+	// claimMatch recurses into Inner's checks; the missing-Inner
+	// diagnostic surfaces from the nested validateScopes call.
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Top",
+				"sections": []any{
+					map[string]any{
+						"heading": "Outer",
+						"sections": []any{
+							map[string]any{"heading": "Inner"},
+						},
+					},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc has Top at H2; Outer at H2 (wrong level — expected H3);
+	// no Inner. The nested validateScopes from claimRun should
+	// emit a missing-Inner diagnostic.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Top\n\n## Outer\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var missingInner bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, `#### Inner: got <missing>`) &&
+			strings.Contains(d.Message, `expected section to be present`) {
+			missingInner = true
+		}
+	}
+	assert.True(t, missingInner,
+		"the children-recurse branch must validate nested sections")
+}
+
+// TestWrongLevelMatch_EmitsLevelDiag covers the wrong-level
+// match path: matchScope sees a shallower-than-expected heading
+// that still matches the matcher, claimMatch emits the
+// level-mismatch diagnostic, and the consumed/digits state is
+// updated so repeat.min / sequential still apply.
+func TestWrongLevelMatch_EmitsLevelDiag(t *testing.T) {
+	// Nested schema: outer expects H2, inner expects H3. The doc
+	// emits the inner heading at H2 (shallower than expected).
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Outer",
+				"sections": []any{
+					map[string]any{"heading": "Inner"},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Outer\n\n## Inner\n\nx\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var level bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, `Inner: got h2, expected h3`) {
+			level = true
+		}
+	}
+	assert.True(t, level,
+		"the wrong-level match path must emit the level-mismatch diagnostic")
+}
+
+// TestSequentialDiagMessage_NonInteger covers the parse-error path
+// inside sequentialDiagMessage. The `digits` helper always matches
+// `[0-9]+` so this never trips in normal usage; exercising it
+// directly keeps the safety branch covered.
+func TestSequentialDiagMessage_NonInteger(t *testing.T) {
+	got := sequentialDiagMessage([]string{"abc"})
+	assert.Contains(t, got, "must be integers")
+}
+
+// TestSequentialDiagMessage_OK returns empty when the sequence is
+// strictly increasing.
+func TestSequentialDiagMessage_OK(t *testing.T) {
+	assert.Empty(t, sequentialDiagMessage([]string{"1", "2", "3"}))
+}
+
+// TestCachedMatcher_NilAndInvalid covers the two early-error
+// branches of cachedMatcher.
+func TestCachedMatcher_NilAndInvalid(t *testing.T) {
+	_, err := cachedMatcher(nil, nil)
+	require.Error(t, err)
+
+	_, err = cachedMatcher(&Matcher{Regex: "[unterminated"}, nil)
+	require.Error(t, err)
+}
+
+// TestMatchHeading_NilMatcher covers the early-return for a nil
+// matcher (the preamble's shape).
+func TestMatchHeading_NilMatcher(t *testing.T) {
+	matched, captured := matchHeading(nil, DocHeading{Text: "x"}, nil)
+	assert.False(t, matched)
+	assert.Empty(t, captured)
+}
+
+// TestMatchHeading_DigitsCapture verifies the captured group is
+// returned alongside the match.
+func TestMatchHeading_DigitsCapture(t *testing.T) {
+	m := &Matcher{Regex: `Step \#(digits)`}
+	matched, captured := matchHeading(m, DocHeading{Text: "Step 42"}, nil)
+	assert.True(t, matched)
+	assert.Equal(t, "42", captured)
+}
+
+// TestFmvarLookup_MissingField signals a missing value via the
+// second return so resolvePattern can fail the match instead of
+// substituting an empty regex fragment that would otherwise let
+// a degenerate heading match the literal-only remainder of the
+// pattern.
+func TestFmvarLookup_MissingField(t *testing.T) {
+	_, ok := fmvarLookup(nil, "id")
+	assert.False(t, ok)
+	_, ok = fmvarLookup(map[string]any{}, "id")
+	assert.False(t, ok)
+	_, ok = fmvarLookup(map[string]any{"id": "X"}, "")
+	assert.False(t, ok)
+}
+
+// TestFirstWrongLevelMatch_SkipsClaimedAndOutOfRange exercises the
+// three early-continue branches of firstWrongLevelMatch:
+// already-claimed entries, headings outside the parent window, and
+// same-level headings (which the same-level run owns). The result
+// is the index of the wrong-level match that does pass all three
+// filters.
+func TestFirstWrongLevelMatch_SkipsClaimedAndOutOfRange(t *testing.T) {
+	heads := []DocHeading{
+		{Level: 3, Text: "Step", Line: 5},  // 0: would match, claimed
+		{Level: 3, Text: "Step", Line: 1},  // 1: before parentStart
+		{Level: 2, Text: "Step", Line: 12}, // 2: same level, skip
+		{Level: 3, Text: "Step", Line: 15}, // 3: the wrong-level match
+	}
+	sc := Scope{Heading: "Step", Matcher: &Matcher{Regex: "Step"}}
+	claimed := map[int]bool{0: true}
+	idx := firstWrongLevelMatch(sc, heads, 2, 3, 100, claimed, nil)
+	assert.Equal(t, 3, idx,
+		"claimed heads, out-of-range heads, and same-level heads "+
+			"must all be skipped before the wrong-level match wins")
+}
+
+// TestHeadingLine_EmptyAtxFallback exercises headingLine's
+// fallback path for ATX headings whose Lines() slice is empty
+// (a goldmark quirk that fires when an ATX consumes its line via
+// an inline extension). We synthesize the state by handing
+// ExtractDocHeadings a parser that yields such a heading,
+// asserting the descendant-text scan still returns a positive
+// line number. The body uses link-reference defs which goldmark
+// strips before AST construction, leaving the heading with only
+// inline children.
+func TestHeadingLine_EmptyAtxFallback(t *testing.T) {
+	src := []byte("# T\n\n## body\n\nbody\n")
+	f, err := lint.NewFileFromSource("doc.md", src, false)
+	require.NoError(t, err)
+	// Construct a synthetic ATX heading whose Lines() slice is
+	// empty but which carries a *ast.Text descendant — exactly
+	// the shape goldmark produces on the rare paths described
+	// in headingLine's doc comment. Prepend a non-Text inline
+	// child (an Emphasis) so the walker also exercises the
+	// `_, ok := n.(*ast.Text)` non-Text continue branch before
+	// reaching the Text segment.
+	h := ast.NewHeading(2)
+	h.AppendChild(h, ast.NewEmphasis(1))
+	tn := ast.NewTextSegment(text.NewSegment(2, 6))
+	h.AppendChild(h, tn)
+	got := headingLine(h, f)
+	assert.Greater(t, got, 0,
+		"the descendant-Text fallback must yield a positive line "+
+			"when Lines() is empty")
+}
+
+// TestFrontmatterExpr_MarshalErrorSliceMap covers the
+// json.Marshal error return for the []any / map[string]any
+// branch by passing a map that contains an unmarshalable value
+// (a Go channel — channels have no JSON representation, so
+// encoding/json returns *json.UnsupportedTypeError). The same
+// shape can reach frontmatterExpr through nested user input
+// (highly unusual but defensively handled), and the test pins
+// the error path so the diagnostic surfaces rather than
+// returning an empty string.
+func TestFrontmatterExpr_MarshalErrorSliceMap(t *testing.T) {
+	m := map[string]any{"ch": make(chan int)}
+	_, err := frontmatterExpr(m)
+	require.Error(t, err,
+		"a map containing an unmarshalable value must surface "+
+			"the json error rather than silently returning")
+}
+
+// TestHeadingLine_EmptyEverywhereFallback covers the trailing
+// `return line` default when an ATX heading has neither a
+// populated Lines() slice nor an inline *ast.Text descendant.
+func TestHeadingLine_EmptyEverywhereFallback(t *testing.T) {
+	src := []byte("# T\n")
+	f, err := lint.NewFileFromSource("doc.md", src, false)
+	require.NoError(t, err)
+	h := ast.NewHeading(2)
+	got := headingLine(h, f)
+	assert.Equal(t, 1, got,
+		"a heading with no Lines and no Text descendant defaults to line 1")
+}
+
+// TestHeadingLine_InlineFallback covers headingLine's fallback
+// branch: goldmark occasionally produces ATX headings with an
+// empty Lines() slice (the leading marker is consumed by an
+// inline construct like a code span), in which case we walk
+// inline descendants to recover the source line. Constructing
+// the empty-Lines case directly is awkward, so the test goes
+// through the regular parser with a heading whose body is
+// purely inline content and asserts that headingLine still
+// returns a positive line via the descendant-text path when
+// the primary path returns no data.
+func TestHeadingLine_InlineFallback(t *testing.T) {
+	// Build an ATX heading whose body is just an inline code
+	// span. Goldmark may or may not populate Lines() for this
+	// shape depending on parser internals; the assertion below
+	// only checks that ExtractDocHeadings returns a non-zero
+	// line for the heading either way, exercising both branches
+	// of headingLine across the run.
+	src := "# Title\n\n## `code-span`\n\nbody\n"
+	doc := newDocFile(t, "doc.md", src)
+	heads := ExtractDocHeadings(doc)
+	require.NotEmpty(t, heads, "parser must yield at least one heading")
+	for _, h := range heads {
+		assert.Greater(t, h.Line, 0,
+			"every heading must resolve to a positive line, "+
+				"including the inline-content fallback path")
+	}
+}
+
+// TestParseFmvarCall_NegativeForms covers the early-return
+// branches of parseFmvarCall — expressions that aren't fmvar
+// calls, calls missing the opening paren, calls without a
+// closing paren, and calls with trailing garbage after the
+// close. Each must return (_, false) so the resolver falls
+// through to the "unknown helper" diagnostic.
+func TestParseFmvarCall_NegativeForms(t *testing.T) {
+	cases := []string{
+		"digits",               // not an fmvar prefix
+		"fmvarX",               // prefix without `(`
+		"fmvar(unterminated",   // no closing `)`
+		"fmvar(name) trailing", // garbage after close
+	}
+	for _, expr := range cases {
+		_, ok := parseFmvarCall(expr)
+		assert.False(t, ok, "expr %q must not parse as a valid fmvar call", expr)
+	}
+}
+
+// TestHasNamedCapture_RejectsInvalidPattern covers the parse-
+// error branch in hasNamedCapture: an unparseable regex returns
+// false so a downstream caller still reaches compileMatcher,
+// which surfaces the actual parse error with diagnostic context.
+func TestHasNamedCapture_RejectsInvalidPattern(t *testing.T) {
+	// An unbalanced paren makes regexp/syntax.Parse return an
+	// error. The helper must report no captures.
+	assert.False(t, hasNamedCapture(`(?P<n>`, "n"),
+		"an unparseable pattern must report no captures")
+}
+
+// TestRegexpHasNamedCapture_NilSafe covers regexpHasNamedCapture's
+// defensive nil check: a nil sub-expression yields no captures
+// without panicking, which keeps the recursion safe for future
+// callers that might pass a constructed AST with sparse children.
+func TestRegexpHasNamedCapture_NilSafe(t *testing.T) {
+	assert.False(t, regexpHasNamedCapture(nil, "n"),
+		"nil regex node must not match any capture name")
+}
+
+// TestSkipQuotedSegment_UnterminatedReturnsEnd exercises the
+// end-of-pattern fallthrough when a `\#(fmvar("...))` has no
+// closing quote. scanInterps then surfaces the failure as an
+// "unterminated interpolation" diagnostic via findInterpEnd's
+// false return.
+func TestSkipQuotedSegment_UnterminatedReturnsEnd(t *testing.T) {
+	pattern := `\#(fmvar("unterminated`
+	err := scanInterps(pattern, func(string, int, int) error { return nil })
+	require.Error(t, err,
+		"an unterminated quoted segment must surface as a parse error")
+	assert.Contains(t, err.Error(), "unterminated interpolation")
+}
+
+// TestScanInterps_QuotedEscapeAdvances covers scanInterps'
+// escape-inside-quote branch: a `\"` inside the quoted segment
+// must advance past the quoted quote without ending the
+// segment, so the scanner doesn't reopen paren-counting
+// prematurely on a CUE-style key like `fmvar("a\"b")`.
+func TestScanInterps_QuotedEscapeAdvances(t *testing.T) {
+	pattern := `\#(fmvar("a\"b"))`
+	var seen string
+	err := scanInterps(pattern, func(expr string, _, _ int) error {
+		seen = expr
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `fmvar("a\"b")`, seen,
+		"an escaped quote must not close the quoted segment "+
+			"prematurely")
+}
+
+// TestFirstWrongLevelMatch_BroadMatcherReturnsMinusOne covers
+// the broad-matcher early-return: a `.+` matcher must not pair
+// with any wrong-level heading, since the slot has no fixed
+// identity and would otherwise consume arbitrary parent-level
+// siblings.
+func TestFirstWrongLevelMatch_BroadMatcherReturnsMinusOne(t *testing.T) {
+	heads := []DocHeading{
+		{Level: 2, Text: "Whatever", Line: 5},
+	}
+	sc := Scope{
+		Heading: ".+",
+		Matcher: &Matcher{
+			Regex:  ".+",
+			Repeat: Repeat{Set: true, Min: 0},
+		},
+	}
+	idx := firstWrongLevelMatch(sc, heads, 3, 1, 100, map[int]bool{}, nil)
+	assert.Equal(t, -1, idx,
+		"a broad matcher must not salvage a wrong-level heading")
+}
+
+// TestAnyLaterScopeClaims_SkipsAlreadyClaimed covers the
+// claimed-scope skip in anyLaterScopeClaims. A heading whose
+// text matches a later already-claimed scope must not be
+// reported as a yield target — the claimed-skip is what lets
+// step's optional-yield decision ignore scopes whose runs have
+// already closed.
+func TestAnyLaterScopeClaims_SkipsAlreadyClaimed(t *testing.T) {
+	scopes := []Scope{
+		{Heading: "A", Matcher: &Matcher{Regex: "A"}},
+		{Heading: "B", Matcher: &Matcher{Regex: "B"}},
+	}
+	dh := DocHeading{Level: 2, Text: "B", Line: 5}
+	claimed := map[int]bool{1: true}
+	assert.False(t, anyLaterScopeClaims(scopes, 0, dh, claimed, nil),
+		"a claimed scope must not register as a yield target")
+}
+
+// TestScanScopeRunAtLevel_BreaksOnShallowAfterStart covers the
+// `h.Level < expectedLevel && started` early break: once a run
+// has consumed at least one match, a heading shallower than
+// expectedLevel ends the scan instead of being silently skipped,
+// matching matchScope's contiguous-run boundary.
+func TestScanScopeRunAtLevel_BreaksOnShallowAfterStart(t *testing.T) {
+	heads := []DocHeading{
+		{Level: 3, Text: "Step", Line: 5},  // 0: matches, starts run
+		{Level: 2, Text: "Done", Line: 10}, // 1: shallower → break
+		{Level: 3, Text: "Step", Line: 15}, // 2: same level — but
+		// the break above stops the scan before reaching us.
+	}
+	sc := Scope{
+		Heading: "Step",
+		Matcher: &Matcher{
+			Regex:  "Step",
+			Repeat: Repeat{Set: true, Min: 1, Max: 5},
+		},
+	}
+	out := scanScopeRunAtLevel(
+		[]Scope{sc}, 0, heads, 3, 1, 100,
+		map[int]bool{}, nil)
+	assert.Equal(t, []int{0}, out,
+		"the run must close at the shallower heading; index 2 "+
+			"must not be claimed even though its text matches")
+}
+
+// TestResolvePattern_PassesThroughLiterals leaves a pattern without
+// interpolations untouched.
+func TestResolvePattern_PassesThroughLiterals(t *testing.T) {
+	got, err := resolvePattern(`Step [0-9]+`, nil)
+	require.NoError(t, err)
+	assert.Equal(t, `Step [0-9]+`, got)
+}
+
+// TestResolvePattern_RejectsUnknownHelper surfaces the validator's
+// runtime-side guard (parse-time is covered separately via
+// resolvePatternForCheck).
+func TestResolvePattern_RejectsUnknownHelper(t *testing.T) {
+	_, err := resolvePattern(`\#(bogus)`, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown helper")
+}
+
+// TestCompileMatcher_NilRejected protects against a nil-pointer
+// crash if a caller accidentally invokes the helper without a
+// matcher.
+func TestCompileMatcher_NilRejected(t *testing.T) {
+	_, err := compileMatcher(nil, nil)
+	require.Error(t, err)
+}
+
+// TestSetMatcherRegex_EmptyRejected covers the trim/empty guard.
+func TestSetMatcherRegex_EmptyRejected(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{"regex": "   "}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty pattern")
+}
+
+// TestSetMatcherRegex_NonStringRejected covers the type guard.
+func TestSetMatcherRegex_NonStringRejected(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{"regex": 42}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a string")
+}
+
+// TestSetMatcherRepeat_NotAMapping covers the type guard.
+func TestSetMatcherRepeat_NotAMapping(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":  "X",
+				"repeat": "nope",
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a mapping")
+}
+
+// TestSetMatcherRepeat_UnknownKey covers the unknown-key guard.
+func TestSetMatcherRepeat_UnknownKey(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":  "X",
+				"repeat": map[string]any{"bogus": 1},
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown key")
+}
+
+// TestSetMatcherRepeat_NegativeMin covers the bound-validation
+// path inside readIntBound.
+func TestSetMatcherRepeat_NegativeMin(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":  "X",
+				"repeat": map[string]any{"min": -1},
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-negative")
+}
+
+// TestScopeMatchesHeading_NilScope returns false rather than
+// panicking on the nil-matcher branch.
+func TestScopeMatchesHeading_NilScope(t *testing.T) {
+	assert.False(t, scopeMatchesHeading(Scope{}, DocHeading{Text: "x"}, nil))
+}
+
+// TestCountSameLevelMatches_SkipsDeeperHeadings covers the
+// level filter inside countSameLevelMatches via the trailing
+// max-exceeded path: a deeper heading between matching same-
+// level occurrences must not count toward the scope's max.
+func TestCountSameLevelMatches_SkipsDeeperHeadings(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A"},
+			map[string]any{"heading": map[string]any{
+				"regex":  "B",
+				"repeat": map[string]any{"max": 2},
+			}},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// Doc: B (out of order), nested ### Detail, A, B, B.
+	// Three Bs at level 2, with a deeper Detail mixed in. Only
+	// the third B (4th match attempt) should be flagged.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## B\n\n### Detail\n\nx\n\n## A\n\ny\n\n## B\n\nz\n\n## B\n\nw\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var exceeded int
+	for _, d := range diags {
+		if strings.Contains(d.Message, "exceeds scope") {
+			exceeded++
+		}
+	}
+	assert.Equal(t, 1, exceeded,
+		"deeper Detail heading must not count toward B's max")
+}
+
+// TestScopeRunIndices_NilMatcherReturnsNil covers the early
+// return for a nil-matcher scope (preamble-shaped scope routed
+// through the helper directly).
+func TestScopeRunIndices_NilMatcherReturnsNil(t *testing.T) {
+	scopes := []Scope{{Preamble: true}}
+	got := ScopeRunIndices(scopes, 0,
+		[]DocHeading{{Level: 2, Text: "X", Line: 1}},
+		2, 1, 100, map[int]bool{}, nil)
+	assert.Nil(t, got)
+}
+
+// TestLaterScopeMatches_SkipsBroadMatcher covers
+// laterScopeMatches' broad-matcher skip — a later `.+` scope
+// must not count as "more specific" when deciding to yield.
+func TestLaterScopeMatches_SkipsBroadMatcher(t *testing.T) {
+	scopes := []Scope{
+		// Position 0 — the "current" scope (caller pretends).
+		{Heading: ".+", Matcher: &Matcher{Regex: ".+"}},
+		// Position 1 — broad matcher, should be skipped by
+		// laterScopeMatches as "not more specific".
+		{Heading: ".+", Matcher: &Matcher{Regex: ".+"}},
+	}
+	dh := DocHeading{Level: 2, Text: "Anything", Line: 1}
+	assert.False(t, laterScopeMatches(scopes, 1, dh, nil),
+		"a later broad `.+` matcher must not block yielding")
+}
+
+// TestAcronymRanges_MatchesByRegex covers the acronym walker's
+// `sc.Matcher.Regex` match branch — when a scope is constructed
+// without a separate `Heading` label, the regex itself is the
+// scope name the `acronyms.scope:` list compares against.
+func TestAcronymRanges_MatchesByRegex(t *testing.T) {
+	src := "# Doc\n\n## Check\n\nOIDC undefined.\n"
+	f := newDocFile(t, "doc.md", src)
+	sch := &Schema{
+		Source:    "test",
+		RootLevel: 2,
+		// Scope built directly so the regex IS the only label —
+		// no separate Heading. The acronyms.scope match falls
+		// through to the regex.
+		Sections: []Scope{
+			{Matcher: &Matcher{Regex: "Check"}},
+		},
+		Acronyms: &AcronymRule{Scope: []string{"Check"}},
+	}
+	diags := ValidateAcronyms(f, sch, nil, makeDiagForTest)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "OIDC")
+}
+
+// TestHandleLeftoverHeadings_SkipsDeeperLevel covers
+// handleLeftoverHeadings's `dh.Level != expectedLevel` branch.
+// Triggered by a schema with only a preamble entry so the
+// matchScope path never runs and the leftover loop processes
+// every doc heading itself, including nested ones.
+func TestHandleLeftoverHeadings_SkipsDeeperLevel(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": nil},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## A\n\n### Nested\n\nx\n")
+	// We don't assert specific diagnostics — the test exercises
+	// the branch without panicking and produces the expected
+	// open-scope silence.
+	_ = Validate(doc, sch, nil, false, makeDiagForTest)
+}
+
+// TestStep_RequiredMatcherSkipsDeeperBeforeMatch covers
+// handleNonMatch's `dh.Level > expectedLevel` branch: a
+// required matcher with `consumed == 0 < min` scans past a
+// deeper-than-expected heading (e.g. a stray ### before the
+// expected ## section) without emitting anything.
+func TestStep_RequiredMatcherSkipsDeeperBeforeMatch(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "Goal"},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	// `### Stray` is deeper than the expected H2; matchScope's
+	// required-matcher path advances past it silently.
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n### Stray\n\nx\n\n## Goal\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "Stray",
+			"the deeper Stray heading must be skipped silently")
+		assert.NotContains(t, d.Message, "missing required",
+			"the required Goal must still be claimed")
+	}
+}
+
+// TestStep_OptionalMatcherFlagsToleratedExtraInClosed covers
+// the closed-schema branch where an optional matcher (min=0)
+// hasn't yet matched and the current heading is a tolerated
+// extra. In a closed schema this emits an "unexpected section"
+// diagnostic; the open-schema variant skips silently.
+func TestStep_OptionalMatcherFlagsToleratedExtraInClosed(t *testing.T) {
+	raw := map[string]any{
+		"closed": true,
+		"sections": []any{
+			map[string]any{
+				"heading": map[string]any{
+					"regex":  "X",
+					"repeat": map[string]any{"min": 0, "max": 1},
+				},
+			},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	doc := newDocFile(t, "doc.md",
+		"# T\n\n## Other\n\nx\n\n## X\n\ny\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	var unexpected bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, `## Other: got <present>`) &&
+			strings.Contains(d.Message, `not declared in schema`) &&
+			strings.Contains(d.Message, `## X`) {
+			unexpected = true
+		}
+	}
+	assert.True(t, unexpected,
+		"closed schema must flag the tolerated-extra heading "+
+			"when an optional matcher hasn't started")
+}
+
+// TestSetMatcherRepeat_NegativeMax covers the max-bound branch
+// inside setMatcherRepeat / readIntBound: a negative `max:` value
+// rejects with a clear message.
+func TestSetMatcherRepeat_NegativeMax(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":  "X",
+				"repeat": map[string]any{"max": -1},
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-negative")
+}
+
+// TestSetScopeBool_NonBoolSequential covers setScopeBool's type
+// guard via the `sequential:` field inside a heading mapping.
+func TestSetScopeBool_NonBoolSequential(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": map[string]any{
+				"regex":      "X",
+				"sequential": "yes",
+			}},
+		},
+	}
+	_, err := ParseInline(raw, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a boolean")
+}
+
+// TestMatcherCache_BoundsGrowth regresses a Copilot review
+// concern: the global matcher cache must not grow without bound
+// when an LSP session emits a stream of unique `fmvar(...)`
+// values. After matcherCacheCap inserts the cache resets so
+// memory stays predictable.
+func TestMatcherCache_BoundsGrowth(t *testing.T) {
+	matcherCacheMu.Lock()
+	matcherCache = make(map[matcherCacheKey]*compiledMatcher, matcherCacheCap)
+	matcherCacheLen = 0
+	matcherCacheMu.Unlock()
+
+	m := &Matcher{Regex: `\#(fmvar(id))`}
+	// Fill past the cap with distinct fmvar values so each entry
+	// is a fresh cache key.
+	for i := 0; i < matcherCacheCap+5; i++ {
+		_, err := cachedMatcher(m, map[string]any{
+			"id": "id-" + strconv.Itoa(i),
+		})
+		require.NoError(t, err)
+	}
+	matcherCacheMu.Lock()
+	size := matcherCacheLen
+	matcherCacheMu.Unlock()
+	assert.LessOrEqual(t, size, matcherCacheCap,
+		"matcher cache must stay within the configured cap")
+}
+
+// TestIsBroadMatcher covers the helper's three branches.
+func TestIsBroadMatcher(t *testing.T) {
+	assert.False(t, isBroadMatcher(nil))
+	assert.False(t, isBroadMatcher(&Matcher{Regex: "Specific"}))
+	assert.True(t, isBroadMatcher(&Matcher{Regex: ".+"}))
+	// A bounded-max `.+` is still broad; the helper is
+	// intentionally repeat-agnostic.
+	assert.True(t, isBroadMatcher(&Matcher{
+		Regex:  ".+",
+		Repeat: Repeat{Set: true, Min: 1, Max: 2},
+	}))
+}
+
+// TestScope_Required covers the three branches of Scope.Required.
+func TestScope_Required(t *testing.T) {
+	// Preamble is never required.
+	assert.False(t, Scope{Preamble: true}.Required())
+	// Matcher absent → not required.
+	assert.False(t, Scope{}.Required())
+	// Optional matcher (min=0) → not required.
+	opt := Scope{Matcher: &Matcher{
+		Regex:  "X",
+		Repeat: Repeat{Set: true, Min: 0, Max: 1},
+	}}
+	assert.False(t, opt.Required())
+	// Default cardinality (1..1) → required.
+	assert.True(t, literalScope("X").Required())
+	// Min=2 → required.
+	bounded := Scope{Matcher: &Matcher{
+		Regex:  "X",
+		Repeat: Repeat{Set: true, Min: 2, Max: 5},
+	}}
+	assert.True(t, bounded.Required())
+}
+
+// TestRepeatBounds covers Repeat.Bounds and Repeat.Optional defaults.
+func TestRepeatBounds(t *testing.T) {
+	// Unset → (1, 1).
+	min, max := Repeat{}.Bounds()
+	assert.Equal(t, 1, min)
+	assert.Equal(t, 1, max)
+	assert.False(t, Repeat{}.Optional())
+	// Set with min=0 → optional.
+	r := Repeat{Set: true, Min: 0, Max: 0}
+	min, max = r.Bounds()
+	assert.Equal(t, 0, min)
+	assert.Equal(t, 0, max)
+	assert.True(t, r.Optional())
+}
+
+// TestProtoTokenRegex_AllTokens exercises the four desugaring
+// branches the proto.md parser uses.
+func TestProtoTokenRegex_AllTokens(t *testing.T) {
+	// Literal text — regex-escape only.
+	assert.Equal(t, `Step \(One\)`, protoTokenRegex(`Step (One)`))
+	// `{n}` → digits helper.
+	assert.Equal(t, `Step \#(digits)`, protoTokenRegex(`Step {n}`))
+	// `{field}` → fmvar helper.
+	assert.Equal(t, `\#(fmvar(id))`, protoTokenRegex(`{id}`))
+	// Mixed literal + fmvar.
+	assert.Equal(t, `\#(fmvar(id)): \#(fmvar(name))`,
+		protoTokenRegex(`{id}: {name}`))
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -15,15 +15,18 @@
 // tree, emitting diagnostics through the lint.Diagnostic shape.
 //
 // See plan/146_inline-schema-in-kinds.md for the design context.
+// Plan 156 collapses each section entry to one discriminator
+// (`heading:` — null, string, or mapping) with a single matcher
+// (`regex:`) and a cardinality field (`repeat: {min, max}`); see
+// docs/reference/section-schema.md for the full grammar.
 package schema
 
 // SectionWildcard is the literal text the file-based parser
 // recognises in a proto.md heading row (`## ...`) as a positional
-// slot — the on-disk surface for what the inline grammar spells
-// `heading: {unlisted: true}`. The inline parser rejects this
-// string when it appears as `heading:` or `aliases:` text;
-// authors must use the mapping form. The constant lives here so
-// the two parsers agree on the same on-disk token.
+// slot — a heading run that matches any text zero or more times.
+// The inline parser rejects this string when it appears as
+// `heading:` text; authors must use the mapping form
+// (`heading: { regex: '.+', repeat: { min: 0 } }`).
 const SectionWildcard = "..."
 
 // Schema is the parsed representation of a single document schema.
@@ -45,9 +48,11 @@ type Schema struct {
 	// preserved).
 	FrontmatterLines map[string]int
 
-	// Require carries constraints that apply to the document as a
-	// whole (filename pattern, etc.).
-	Require Require
+	// Filename is a glob the document basename must match. Empty
+	// means no filename constraint. Authors set it as a top-level
+	// `filename:` key on the schema (plan 156 dropped the
+	// `require.filename:` nesting).
+	Filename string
 
 	// Sections holds the top-level section list at RootLevel; each
 	// Scope may itself nest further sections one heading level
@@ -136,80 +141,52 @@ const (
 	IndexIncludeHeadingsFlat = "headings"
 )
 
-// Require captures the schema-level constraints that apply to the
-// document as a whole.
-type Require struct {
-	// Filename is a glob the document basename must match. Empty
-	// means no filename constraint.
-	Filename string
-}
-
 // Scope binds an AST subtree (a section) to a set of constraints and
 // per-rule config overrides. The root scope's children are the
 // top-level (H2) section list; their children are H3, and so on.
 // Levels come from depth in the tree.
+//
+// Plan 156 collapses the section-entry vocabulary to three
+// orthogonal axes:
+//
+//   - Discriminator — `heading:` value (`null`, string, or mapping).
+//   - Matcher — `regex:` inside the mapping form.
+//   - Cardinality — `repeat: { min, max }` inside the mapping form.
+//
+// The legacy `aliases:`, `required:`, scope-level
+// `repeats:`/`sequential:`/`min:`/`max:`, and `{unlisted: true}`
+// shapes are gone; the parser rejects them with a "removed; see
+// plan 156" diagnostic naming the replacement.
 type Scope struct {
-	// Heading is the heading text to match. No "#" markers; the
-	// level comes from depth in the tree. The single-character
-	// "?" matches any text. Headings (and aliases) containing
-	// `{field}` interpolation are matched as anchored regex
-	// patterns, with each placeholder consuming one or more
-	// characters of the doc heading text. Empty when Wildcard is
-	// true.
+	// Heading is the diagnostic-friendly label for this scope —
+	// the bare-string literal for the sugar form, the regex body
+	// for the mapping form, or empty for the preamble. The
+	// validator does not match on this field; Matcher drives all
+	// heading claims.
 	Heading string
 
-	// Required reports whether a matching heading must appear in
-	// the document. Literal scopes default to true. Slot scopes
-	// (`heading: {unlisted: true}`) always parse to Required=false
-	// because the parser rejects an explicit `required:` key on
-	// them. Preamble scopes (`heading: null`) default to false but
-	// accept an explicit `required:` value; the inline validator
-	// does not yet act on it (a future plan that adds preamble-
-	// content checks will).
-	Required bool
-
-	// Aliases lists alternate heading texts that match this scope.
-	// An empty list means only Heading matches.
-	Aliases []string
+	// Matcher, when non-nil, describes how this scope claims one or
+	// more headings. Preamble scopes leave Matcher nil because they
+	// have no heading text to compare against — their range is
+	// `[parent-start, first-child-heading)`.
+	Matcher *Matcher
 
 	// Sections is the recursive list of nested sections (one level
 	// deeper in the document tree).
 	Sections []Scope
 
-	// Repeats reports whether Heading is a pattern (with placeholder
-	// tokens) that may match zero or more sections.
-	Repeats bool
-
-	// Sequential, on a repeating scope, asserts no gaps and no
-	// duplicates in the {n} placeholder values.
-	Sequential bool
-
-	// Min and Max bound the match count of a repeating scope. Zero
-	// means unbounded.
-	Min int
-	Max int
-
-	// Closed reports whether this scope is strict: when true,
-	// unlisted child headings produce a diagnostic; when false, they
-	// are tolerated between listed sub-sections.
-	Closed bool
-
-	// Wildcard reports whether this scope is a slot that matches
-	// zero or more sections the schema did not list by name. Authors
-	// write it inline as `heading: {unlisted: true}` (or as a `## ...`
-	// row in a file-based proto.md). Out-of-order detection still
-	// claims a heading whose text matches a later listed scope, so
-	// the slot only absorbs truly-unlisted sections.
-	Wildcard bool
-
 	// Preamble reports whether this scope describes the implicit
 	// section before any heading — the document's lead-in content.
 	// Authors write it inline as `heading: null`. A preamble scope
 	// has no heading text to match; its range is [parent-start,
-	// first-child-heading). Plan 146 limits the preamble to
-	// carrying `rules:` overrides for that range; `content:` (plan
-	// 149) extends it to AST-node constraints.
+	// first-child-heading). Only valid as the first entry of its
+	// section list.
 	Preamble bool
+
+	// Closed reports whether this scope is strict: when true,
+	// unlisted child headings produce a diagnostic; when false,
+	// they are tolerated between listed sub-sections.
+	Closed bool
 
 	// Rules carries per-scope rule-config overrides. Each entry maps
 	// a rule name to a settings map. The MDS020 walker re-runs each
@@ -228,6 +205,79 @@ type Scope struct {
 	// follow the same out-of-order + unlisted-slot semantics the
 	// heading-tree validator uses.
 	Content []ContentEntry
+}
+
+// Matcher describes how a Scope claims one or more consecutive
+// headings. Authors set it inline as the mapping form
+// (`heading: { regex, repeat?, sequential? }`); the bare-string
+// sugar (`heading: "Overview"`) and the proto.md heading-row
+// tokens (`## ?`, `## ...`, `## Step {n}`, `## {id}`) desugar to
+// the same shape.
+type Matcher struct {
+	// Regex is the body of a CUE raw-interpolation string
+	// (`#"..."#`). The validator compiles it as Go RE2 after
+	// substituting the two helpers in scope: `digits` (the literal
+	// string `(?P<n>[0-9]+)`) and `fmvar(name)` (the front-matter
+	// field `name`, regex-escaped). Backslash passes through to RE2
+	// without doubling; interpolation uses `\#(expr)` inside the
+	// pattern.
+	Regex string
+
+	// Repeat bounds how many consecutive matching headings this
+	// matcher claims. The zero value (Repeat{Set: false}) means
+	// "exactly one"; see Repeat.Bounds for the canonical (min, max)
+	// pair the validator consumes.
+	Repeat Repeat
+
+	// Sequential, with a `digits` named capture in Regex, asserts
+	// the captured `n` values are strictly increasing without gaps.
+	// Without a `digits` capture in the pattern the parser rejects
+	// `sequential: true`.
+	Sequential bool
+}
+
+// Repeat bounds the cardinality of a Matcher's heading run.
+type Repeat struct {
+	// Set reports whether the `repeat:` key was present in the YAML
+	// mapping. When false, Bounds() returns (1, 1) — the matcher
+	// claims exactly one heading. When true, an omitted `min:`
+	// defaults to 0 and an omitted `max:` to unbounded (Max == 0).
+	Set bool
+
+	// Min is the minimum match count. Ignored when Set is false.
+	Min int
+
+	// Max is the maximum match count, with 0 meaning unbounded.
+	// Ignored when Set is false. The parser rejects `repeat: {
+	// max: 0 }` so Max == 0 unambiguously signals "unbounded".
+	Max int
+}
+
+// Bounds returns the canonical (min, max) pair the validator
+// consumes. Max == 0 in the returned pair means unbounded. A
+// matcher with Set=false claims exactly one heading.
+func (r Repeat) Bounds() (int, int) {
+	if !r.Set {
+		return 1, 1
+	}
+	return r.Min, r.Max
+}
+
+// Optional reports whether the matcher's run can be empty
+// (min == 0). The validator treats Optional matchers as
+// non-required: a missing match does not flag a diagnostic.
+func (r Repeat) Optional() bool {
+	min, _ := r.Bounds()
+	return min == 0
+}
+
+// Required reports whether the scope claims at least one heading
+// (Repeat.Min >= 1). Preamble scopes are never Required.
+func (sc Scope) Required() bool {
+	if sc.Preamble || sc.Matcher == nil {
+		return false
+	}
+	return !sc.Matcher.Repeat.Optional()
 }
 
 // Content-entry kind discriminators. The on-disk YAML carries one of
@@ -286,7 +336,7 @@ func (s *Schema) IsEmpty() bool {
 		return true
 	}
 	return len(s.Frontmatter) == 0 &&
-		s.Require.Filename == "" &&
+		s.Filename == "" &&
 		len(s.Sections) == 0 &&
 		len(s.CrossReferences) == 0 &&
 		s.Acronyms == nil &&

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -73,7 +73,8 @@ func TestParseFile_NoH1(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, sch.RootLevel)
 	require.Len(t, sch.Sections, 1)
-	assert.True(t, sch.Sections[0].Wildcard)
+	assert.True(t, isSlotMatcher(sch.Sections[0].Matcher),
+		"a `## ...` heading row desugars to a slot matcher")
 }
 
 func TestParseFile_FrontmatterCUE(t *testing.T) {
@@ -90,7 +91,7 @@ func TestParseFile_RequireFilename(t *testing.T) {
 		"<?require\nfilename: \"foo-*.md\"\n?>\n# ?\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "foo-*.md", sch.Require.Filename)
+	assert.Equal(t, "foo-*.md", sch.Filename)
 }
 
 // ---- ParseInline ----
@@ -109,36 +110,33 @@ func TestParseInline_FrontmatterAndSections(t *testing.T) {
 			"id":     `=~"^RFC-[0-9]{4}$"`,
 			"title?": `string`,
 		},
-		"require": map[string]any{
-			"filename": "RFC-[0-9][0-9][0-9][0-9].md",
-		},
-		"closed": true,
+		"filename": "RFC-[0-9][0-9][0-9][0-9].md",
+		"closed":   true,
 		"sections": []any{
+			map[string]any{"heading": "Overview"},
 			map[string]any{
-				"heading":  "Overview",
-				"required": true,
-			},
-			map[string]any{
-				"heading":  "Decision",
-				"required": true,
+				"heading":  map[string]any{"regex": "Decision|Resolution"},
 				"sections": []any{map[string]any{"heading": "Outcome"}},
-				"aliases":  []any{"Resolution"},
 			},
 			map[string]any{
-				"heading": map[string]any{"unlisted": true},
+				"heading": map[string]any{
+					"regex":  ".+",
+					"repeat": map[string]any{"min": 0},
+				},
 			},
 		},
 	}
 	sch, err := ParseInline(raw, "kind rfc")
 	require.NoError(t, err)
 	assert.True(t, sch.Closed)
-	assert.Equal(t, "RFC-[0-9][0-9][0-9][0-9].md", sch.Require.Filename)
+	assert.Equal(t, "RFC-[0-9][0-9][0-9][0-9].md", sch.Filename)
 	require.Len(t, sch.Sections, 3)
 	assert.Equal(t, "Overview", sch.Sections[0].Heading)
-	assert.Equal(t, []string{"Resolution"}, sch.Sections[1].Aliases)
+	require.NotNil(t, sch.Sections[1].Matcher)
+	assert.Equal(t, "Decision|Resolution", sch.Sections[1].Matcher.Regex)
 	require.Len(t, sch.Sections[1].Sections, 1)
 	assert.Equal(t, "Outcome", sch.Sections[1].Sections[0].Heading)
-	assert.True(t, sch.Sections[2].Wildcard)
+	assert.True(t, isSlotMatcher(sch.Sections[2].Matcher))
 
 	assert.Contains(t, sch.FrontmatterCUE(), `id: =~"^RFC-[0-9]{4}$"`)
 	assert.Contains(t, sch.FrontmatterCUE(), `title?: string`)
@@ -268,7 +266,10 @@ func TestValidate_Inline_WildcardSlotTolerates(t *testing.T) {
 		"closed": true,
 		"sections": []any{
 			map[string]any{"heading": "Overview"},
-			map[string]any{"heading": map[string]any{"unlisted": true}},
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 0},
+			}},
 			map[string]any{"heading": "References"},
 		},
 	}
@@ -281,12 +282,12 @@ func TestValidate_Inline_WildcardSlotTolerates(t *testing.T) {
 		"wildcard slot should tolerate unlisted sections at that position")
 }
 
-func TestValidate_Inline_AliasMatches(t *testing.T) {
+func TestValidate_Inline_DisjunctionMatches(t *testing.T) {
+	// Aliases are gone; encode the disjunction in the regex.
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading": "Symptoms",
-				"aliases": []any{"Indicators"},
+				"heading": map[string]any{"regex": "Symptoms|Indicators"},
 			},
 		},
 	}
@@ -301,12 +302,10 @@ func TestValidate_Inline_NestedThreeLevels(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  "Diagnosis",
-				"required": true,
+				"heading": "Diagnosis",
 				"sections": []any{
 					map[string]any{
-						"heading":  "Step",
-						"required": true,
+						"heading": "Step",
 						"sections": []any{
 							map[string]any{"heading": "Check"},
 							map[string]any{"heading": "Expected"},
@@ -406,7 +405,7 @@ func TestParseInline_ContentRequiredOnUnlistedRejected(t *testing.T) {
 		"sections": []any{map[string]any{
 			"heading": "Examples",
 			"content": []any{map[string]any{
-				"kind": "unlisted", "required": true,
+				"kind": "unlisted", "required": true, // tests rejection
 			}},
 		}},
 	}, "kind x")
@@ -418,25 +417,16 @@ func TestParseInline_ContentRequiredOnUnlistedRejected(t *testing.T) {
 func TestParseInline_ContentRejectedOnWildcard(t *testing.T) {
 	_, err := ParseInline(map[string]any{
 		"sections": []any{map[string]any{
-			"heading": map[string]any{"unlisted": true},
+			"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 0},
+			},
 			"content": []any{map[string]any{"kind": "paragraph"}},
 		}},
 	}, "kind x")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(),
 		"not allowed on a slot")
-}
-
-func TestParseInline_ContentRejectedOnQuestionMarkHeading(t *testing.T) {
-	_, err := ParseInline(map[string]any{
-		"sections": []any{map[string]any{
-			"heading": "?",
-			"content": []any{map[string]any{"kind": "paragraph"}},
-		}},
-	}, "kind x")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(),
-		"not allowed on a `?` wildcard heading")
 }
 
 // ---- Validate (content:) ----
@@ -1049,11 +1039,13 @@ func TestValidate_Content_NestedSectionRecurses(t *testing.T) {
 
 func TestValidate_Content_WildcardSiblingSkipped(t *testing.T) {
 	// A slot scope sibling to a content-bearing scope must be skipped
-	// by walkContentScopes without panicking — exercises the
-	// sc.Wildcard branch.
+	// by walkContentScopes without panicking.
 	raw := map[string]any{
 		"sections": []any{
-			map[string]any{"heading": map[string]any{"unlisted": true}},
+			map[string]any{"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 0},
+			}},
 			map[string]any{
 				"heading": "Body",
 				"content": []any{map[string]any{"kind": "paragraph"}},
@@ -1234,8 +1226,10 @@ var describeNodeCases = []describeNodeCase{
 func TestValidate_Content_ScopeWithoutMatchingHeading(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{map[string]any{
-			"heading":  "Missing",
-			"required": false,
+			"heading": map[string]any{
+				"regex":  "Missing",
+				"repeat": map[string]any{"min": 0, "max": 1},
+			},
 			"content": []any{
 				map[string]any{"kind": "code-block", "lang": "yaml"},
 			},
@@ -1696,8 +1690,7 @@ func TestValidate_Content_PreambleAtEndOfDocument(t *testing.T) {
 	raw := map[string]any{
 		"sections": []any{
 			map[string]any{
-				"heading":  nil,
-				"required": true,
+				"heading": nil,
 				"content": []any{
 					map[string]any{"kind": "code-block", "lang": "yaml"},
 				},

--- a/internal/schema/test_helpers_test.go
+++ b/internal/schema/test_helpers_test.go
@@ -1,0 +1,54 @@
+package schema
+
+// Test helpers for constructing Scope and Matcher values without
+// going through the parser. Used by unit tests that exercise the
+// validator's branches directly.
+
+// literalScope returns a required-once scope whose Matcher.Regex
+// is the input text verbatim. Test inputs use plain alphanumeric
+// heading text where regex metacharacters and the source string
+// coincide; tests that need a real regex should construct the
+// `Scope{Matcher: &Matcher{...}}` literal directly so the intent
+// is obvious at the call site.
+func literalScope(text string) Scope {
+	return Scope{
+		Heading: text,
+		Matcher: &Matcher{Regex: text},
+	}
+}
+
+// optionalScope is the literal scope counterpart with
+// `repeat: { min: 0, max: 1 }` — an optional once-or-not match.
+func optionalScope(text string) Scope {
+	return Scope{
+		Heading: text,
+		Matcher: &Matcher{
+			Regex:  text,
+			Repeat: Repeat{Set: true, Min: 0, Max: 1},
+		},
+	}
+}
+
+// slotScope returns the canonical wildcard-slot scope —
+// `regex: '.+', repeat: { min: 0 }`.
+func slotScope() Scope {
+	return Scope{
+		Matcher: &Matcher{
+			Regex:  ".+",
+			Repeat: Repeat{Set: true, Min: 0, Max: 0},
+		},
+	}
+}
+
+// preambleScope returns a preamble entry.
+func preambleScope() Scope {
+	return Scope{Preamble: true}
+}
+
+// nested wraps inner scopes under a literal parent. Used by tests
+// that build small nested trees without going through the parser.
+func nested(parent string, children ...Scope) Scope {
+	sc := literalScope(parent)
+	sc.Sections = children
+	return sc
+}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -5,15 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/errors"
-	"github.com/jeduden/mdsmith/internal/fieldinterp"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 	"github.com/yuin/goldmark/ast"
@@ -105,10 +102,10 @@ func Validate(
 	heads := ExtractDocHeadings(f)
 	body := skipBelow(heads, rootLevel)
 
-	_, sd := validateScopes(f, sch, sch.Sections, sch.Closed, body, 0, rootLevel, mkDiag)
+	_, sd := validateScopes(f, sch, sch.Sections, sch.Closed, body, 0, rootLevel, docFM, mkDiag)
 	diags = append(diags, sd...)
 
-	diags = append(diags, ValidateContent(f, sch, mkDiag)...)
+	diags = append(diags, ValidateContent(f, sch, docFM, mkDiag)...)
 
 	return diags
 }
@@ -527,54 +524,55 @@ func skipBelow(heads []DocHeading, rootLevel int) []DocHeading {
 //
 // closed controls handling of unlisted headings at this level: when
 // true, an unlisted heading flags a diagnostic; when false, it is
-// tolerated. A wildcard scope ("...") always tolerates unlisted
-// headings at its position.
+// tolerated. A slot scope (`regex: '.+', repeat: {min: 0}`) always
+// tolerates unlisted headings at its position.
 func validateScopes(
 	f *lint.File, sch *Schema, scopes []Scope, closed bool, docHeads []DocHeading,
-	docIdx int, expectedLevel int, mkDiag MakeDiag,
+	docIdx int, expectedLevel int, docFM map[string]any,
+	mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
 	var diags []lint.Diagnostic
-	requiredByText := buildRequiredByText(scopes)
 	claimed := make(map[int]bool)
+	claimCounts := make(map[int]int)
 	allowExtra := false
 
 	for i, sc := range scopes {
 		if sc.Preamble {
 			// The preamble has no heading to match. Its rules: are
 			// applied by the per-scope walker in MDS020 against the
-			// [parent-start, first-child-heading) line range. The
-			// validator itself only needs to mark the entry as
-			// processed; plan 149 adds content-shape checks.
+			// [parent-start, first-child-heading) line range.
 			claimed[i] = true
 			continue
 		}
-		if sc.Wildcard {
+		if isSlotMatcher(sc.Matcher) {
 			allowExtra = true
+			claimed[i] = true
 			continue
 		}
 		if claimed[i] {
 			continue
 		}
-		newIdx, scDiags, found := matchScope(
+		newIdx, scDiags, claimedThis := matchScope(
 			f, sch, scopes, i, expectedLevel, docHeads, docIdx,
-			requiredByText, claimed, allowExtra, closed, mkDiag)
+			claimed, claimCounts, allowExtra, closed, docFM, mkDiag)
 		diags = append(diags, scDiags...)
 		docIdx = newIdx
-		if found {
+		if claimedThis {
 			allowExtra = false
-		} else if !claimed[i] && sc.Required && !sc.Repeats {
+		} else if !claimed[i] && sc.Required() {
 			// Missing sections have no body line to point at;
 			// use the non-body anchor so filterGeneratedDiags
 			// can't drop the diagnostic if body line 1 sits
 			// inside a generated section.
 			diags = append(diags, mkDiag(f.Path, nonBodyDiagLine(f),
-				missingSectionDiag(formatHeading(expectedLevel, sc.Heading), sch).Format()))
+				missingSectionDiag(
+					formatHeading(expectedLevel, displayHeading(sc)), sch).Format()))
 		}
 	}
 
 	newIdx, leftoverDiags := handleLeftoverHeadings(
-		f, sch, scopes, claimed, docHeads, docIdx, expectedLevel,
-		closed, allowExtra, mkDiag)
+		f, sch, scopes, claimed, claimCounts, docHeads, docIdx, expectedLevel,
+		closed, allowExtra, docFM, mkDiag)
 	diags = append(diags, leftoverDiags...)
 	return newIdx, diags
 }
@@ -653,9 +651,9 @@ func levelMismatchSchemaDiag(text string, expectedLevel, actualLevel int, sch *S
 // closed: flagged as unexpected in closed scopes, silently
 // consumed in open ones.
 func handleLeftoverHeadings(
-	f *lint.File, sch *Schema, scopes []Scope, claimed map[int]bool,
+	f *lint.File, sch *Schema, scopes []Scope, claimed map[int]bool, claimCounts map[int]int,
 	docHeads []DocHeading, docIdx, expectedLevel int,
-	closed, allowExtra bool, mkDiag MakeDiag,
+	closed, allowExtra bool, docFM map[string]any, mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
 	var diags []lint.Diagnostic
 	for docIdx < len(docHeads) {
@@ -667,11 +665,39 @@ func handleLeftoverHeadings(
 			docIdx++
 			continue
 		}
-		if idx := unclaimedListedScope(scopes, dh, claimed); idx >= 0 {
+		if idx := unclaimedListedScope(scopes, dh, claimed, docFM); idx >= 0 {
 			newIdx, claimDiags := claimLateScope(
-				f, sch, scopes, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag)
+				f, sch, scopes, idx, expectedLevel, docHeads, docIdx,
+				claimed, claimCounts, docFM, mkDiag)
 			diags = append(diags, claimDiags...)
 			docIdx = newIdx
+			continue
+		}
+		// A heading that matches an already-claimed scope is an
+		// extra occurrence after the scope's run has closed. The
+		// trailing pass runs after every in-order matchScope has
+		// returned, so every claimed scope here is finalised:
+		// either the heading pushes the scope past its `max`
+		// ("exceeds allowed occurrences") or it appears outside
+		// the contiguous run ("out of order"). Both shapes are
+		// surfaced explicitly rather than letting an open schema
+		// absorb the heading silently.
+		if idx, exceeded := claimedScopeMatches(
+			scopes, dh, claimed, claimCounts, docFM); idx >= 0 {
+			sc := scopes[idx]
+			msg := fmt.Sprintf(
+				"section %q out of order: matcher runs must be "+
+					"contiguous with scope %q's earlier run",
+				formatHeading(dh.Level, dh.Text),
+				formatHeading(expectedLevel, displayHeading(sc)))
+			if exceeded {
+				msg = fmt.Sprintf(
+					"section %q exceeds scope %q's allowed occurrences",
+					formatHeading(dh.Level, dh.Text),
+					formatHeading(expectedLevel, displayHeading(sc)))
+			}
+			diags = append(diags, mkDiag(f.Path, dh.Line, msg))
+			docIdx++
 			continue
 		}
 		if !allowExtra && closed {
@@ -683,24 +709,76 @@ func handleLeftoverHeadings(
 	return docIdx, diags
 }
 
+// claimedScopeMatches reports the first already-claimed non-slot,
+// non-preamble scope whose matcher accepts dh, increments that
+// scope's claim count, and returns whether the new count pushes
+// the scope past its `max`. Returns (-1, false) when no claimed
+// scope matches.
+//
+// Callers decide the diagnostic wording: an `exceeded == true`
+// match is a max-exceeded extra ("exceeds allowed occurrences"),
+// while a within-max match is a non-contiguous extra ("out of
+// order: matcher runs must be contiguous") that the caller may
+// still need to suppress when it represents a contiguous
+// continuation of a run still being assembled (see
+// matchRun.handleNonMatch).
+//
+// Unbounded matchers (`max == 0`) never exceed; they return
+// `(idx, false)` so callers can still detect non-contiguity.
+func claimedScopeMatches(
+	scopes []Scope, dh DocHeading, claimed map[int]bool,
+	claimCounts map[int]int, docFM map[string]any,
+) (int, bool) {
+	for i, sc := range scopes {
+		if !claimed[i] {
+			continue
+		}
+		if sc.Preamble || isSlotMatcher(sc.Matcher) {
+			continue
+		}
+		if !scopeMatchesHeading(sc, dh, docFM) {
+			continue
+		}
+		_, max := sc.Matcher.Repeat.Bounds()
+		claimCounts[i]++
+		return i, max > 0 && claimCounts[i] > max
+	}
+	return -1, false
+}
+
 // claimLateScope marks a late-arriving listed scope as claimed,
 // emits its out-of-order diagnostic, and recurses into the scope's
 // nested children so missing-required-section diagnostics still
 // surface beneath a late parent.
+//
+// Known limitation: this path consumes one heading per call.
+// `repeat.max` exceeded by a subsequent same-text heading is
+// flagged separately by handleLeftoverHeadings via
+// claimedScopeMatches. A `repeat.min > 1` shortfall on a
+// late-claimed scope is structurally unreachable here — the
+// only paths that can leave a repeated scope unclaimed are
+// already covered by matchScope's finishRun (in-order) or
+// claimOutOfOrder's min check (out-of-order during iteration).
+// Sequential ordering is not enforced for recovery paths; the
+// in-order matchScope path is the canonical enforcement
+// surface.
 func claimLateScope(
 	f *lint.File, sch *Schema, scopes []Scope, idx, expectedLevel int,
-	docHeads []DocHeading, docIdx int, claimed map[int]bool,
-	mkDiag MakeDiag,
+	docHeads []DocHeading, docIdx int,
+	claimed map[int]bool, claimCounts map[int]int,
+	docFM map[string]any, mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
+	sc := scopes[idx]
 	dh := docHeads[docIdx]
 	diags := []lint.Diagnostic{mkDiag(f.Path, dh.Line,
 		outOfOrderDiag(formatHeading(dh.Level, dh.Text), "", sch).Format())}
 	claimed[idx] = true
+	claimCounts[idx]++
 	docIdx++
-	if len(scopes[idx].Sections) > 0 {
+	if len(sc.Sections) > 0 {
 		newIdx, childDiags := validateScopes(
-			f, sch, scopes[idx].Sections, scopes[idx].Closed,
-			docHeads, docIdx, expectedLevel+1, mkDiag)
+			f, sch, sc.Sections, sc.Closed,
+			docHeads, docIdx, expectedLevel+1, docFM, mkDiag)
 		diags = append(diags, childDiags...)
 		docIdx = newIdx
 	}
@@ -708,122 +786,418 @@ func claimLateScope(
 }
 
 // unclaimedListedScope returns the index of the first unclaimed
-// non-wildcard scope whose text matches dh, or -1 when no listed
-// scope is a candidate.
+// non-slot, non-preamble scope whose matcher accepts dh, or -1
+// when no listed scope is a candidate.
 func unclaimedListedScope(
 	scopes []Scope, dh DocHeading, claimed map[int]bool,
+	docFM map[string]any,
 ) int {
 	for i, sc := range scopes {
-		if claimed[i] || sc.Wildcard {
+		if claimed[i] || sc.Preamble || isSlotMatcher(sc.Matcher) {
 			continue
 		}
-		if scopeMatchesHeading(sc, dh) {
+		if scopeMatchesHeading(sc, dh, docFM) {
 			return i
 		}
 	}
 	return -1
 }
 
-func buildRequiredByText(scopes []Scope) map[string][]int {
-	out := map[string][]int{}
-	for i, sc := range scopes {
-		if sc.Wildcard || sc.Preamble {
-			// Preambles have no heading text; wildcards by design.
-			continue
-		}
-		// Skip the "?" wildcard and placeholder patterns — neither
-		// can sit in a literal-text map; the findOutOfOrderIdx
-		// fallback handles them via scopeMatchesHeading.
-		if !indexableLiteral(sc.Heading) {
-			// no-op
-		} else {
-			out[sc.Heading] = append(out[sc.Heading], i)
-		}
-		for _, a := range sc.Aliases {
-			if !indexableLiteral(a) {
-				continue
-			}
-			out[a] = append(out[a], i)
-		}
-	}
-	return out
-}
-
-// indexableLiteral reports whether text is a fully-literal heading
-// that can be used as a map key. "?" and patterns containing
-// placeholders match many doc texts and cannot be pre-indexed; the
-// fallback scan handles those.
-func indexableLiteral(text string) bool {
-	if text == "?" {
-		return false
-	}
-	return !fieldinterp.ContainsField(text)
-}
-
-// matchScope advances docIdx looking for a heading matching the
-// scope at scopes[idx]. Intervening doc headings either belong to a
-// later listed scope (out-of-order), are unexpected (closed + no
-// wildcard), or are descended into as part of an earlier scope's
-// subtree. Returns the new docIdx, diagnostics, and whether the
-// scope was matched.
+// matchScope advances docIdx looking for a run of headings that
+// matches scopes[idx]'s matcher. Intervening doc headings either
+// belong to a later listed scope (out-of-order), are unexpected
+// (closed + no wildcard), or are descended into as part of an
+// earlier scope's subtree. Returns the new docIdx, diagnostics,
+// and whether the scope was claimed at least once.
 func matchScope(
 	f *lint.File, sch *Schema, scopes []Scope, idx, expectedLevel int,
 	docHeads []DocHeading, docIdx int,
-	requiredByText map[string][]int, claimed map[int]bool,
-	allowExtra, closed bool, mkDiag MakeDiag,
+	claimed map[int]bool, claimCounts map[int]int,
+	allowExtra, closed bool,
+	docFM map[string]any, mkDiag MakeDiag,
 ) (int, []lint.Diagnostic, bool) {
-	sc := scopes[idx]
-	var diags []lint.Diagnostic
+	state := matchRun{
+		f: f, sch: sch, scopes: scopes, idx: idx, expectedLevel: expectedLevel,
+		claimed: claimed, claimCounts: claimCounts,
+		allowExtra: allowExtra, closed: closed,
+		docFM: docFM, mkDiag: mkDiag,
+	}
+	state.min, state.max = scopes[idx].Matcher.Repeat.Bounds()
 
+	for docIdx < len(docHeads) && (state.max == 0 || state.consumed < state.max) {
+		done, next, ok := state.step(docHeads, docIdx)
+		docIdx = next
+		if done {
+			state.finishRun()
+			return docIdx, state.diags, ok
+		}
+	}
+
+	state.finishRun()
+	// A run that hit its max while more matching headings remain
+	// must flag the extras. Without this loop, the trailing-leftover
+	// pass only flags them in closed schemas — silently accepting
+	// `repeat: { max: N }` violations under the default open scope.
+	docIdx = state.flagExtrasBeyondMax(docHeads, docIdx)
+	return docIdx, state.diags, state.consumed > 0
+}
+
+// finishRun emits the per-run diagnostics that depend on the
+// final consumed/digitsSeen state — `sequential:` ordering and
+// the "matched N times, required at least M" guard. Called from
+// every matchScope return path so a run that terminates on a
+// non-matching heading (not just EOF or max) still gets these
+// checks.
+func (s *matchRun) finishRun() {
+	sc := s.scopes[s.idx]
+	if sc.Matcher.Sequential && len(s.digitsSeen) > 0 {
+		if msg := sequentialDiagMessage(s.digitsSeen); msg != "" {
+			s.diags = append(s.diags, s.mkDiag(s.f.Path, 1, msg))
+		}
+	}
+	// A run that consumed fewer than min matches falls short of
+	// the matcher's cardinality contract. The outer loop's
+	// missing-required check only fires when `claimed[idx]` is
+	// false; a partially-claimed run needs its own diagnostic.
+	if s.consumed > 0 && s.consumed < s.min {
+		s.diags = append(s.diags, s.mkDiag(s.f.Path, 1,
+			fmt.Sprintf("section %q matched %d times, required at least %d",
+				formatHeading(s.expectedLevel, displayHeading(sc)),
+				s.consumed, s.min)))
+	}
+}
+
+// flagExtrasBeyondMax walks doc headings still ahead of docIdx at
+// the scope's expected level and emits a diagnostic for each one
+// that matches the current matcher and isn't claimable by a later
+// listed scope. The walk stops at the first heading that doesn't
+// match the matcher so the caller sees the next "real" boundary.
+// Returns the advanced docIdx (past any flagged extras).
+func (s *matchRun) flagExtrasBeyondMax(docHeads []DocHeading, docIdx int) int {
+	if s.max == 0 || s.consumed < s.max {
+		return docIdx
+	}
+	sc := s.scopes[s.idx]
 	for docIdx < len(docHeads) {
 		dh := docHeads[docIdx]
-		// Shallower than us belongs to an ancestor — unless the text
-		// still matches, in which case we claim it here with a
-		// level-mismatch diagnostic. Without this branch a wrong-level
-		// match would surface as both "missing required" (here) and
-		// "unexpected" (when the caller revisits it).
-		if dh.Level < expectedLevel {
-			if scopeMatchesHeading(sc, dh) {
-				return claimMatch(f, sch, sc, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag, diags)
-			}
-			return docIdx, diags, false
+		// Shallower headings belong to a parent scope — let the
+		// outer walker decide. Deeper headings are body content of
+		// a section we've already claimed; skip them so a later
+		// same-level extra isn't hidden behind a nested heading.
+		if dh.Level < s.expectedLevel {
+			return docIdx
 		}
-		if scopeMatchesHeading(sc, dh) {
-			return claimMatch(f, sch, sc, idx, expectedLevel, docHeads, docIdx, claimed, mkDiag, diags)
-		}
-		if ooIdx := findOutOfOrderIdx(scopes, dh, requiredByText, claimed, idx+1); ooIdx >= 0 {
-			if !sc.Required {
-				// The current scope is optional — its absence is not
-				// a violation, so dh matching a later listed scope is
-				// not "out of order". Return without claiming so the
-				// outer loop advances to the matching scope, which
-				// will pair dh on its own iteration.
-				return docIdx, diags, false
-			}
-			newIdx, ooDiags := claimOutOfOrder(
-				f, sch, scopes, idx, ooIdx, expectedLevel, docHeads, docIdx, claimed, mkDiag)
-			diags = append(diags, ooDiags...)
-			docIdx = newIdx
-			continue
-		}
-		// dh did not match this scope or any later listed scope by
-		// text. Deeper than expected: orphan child of some unmatched
-		// parent — consume silently. Same level: treat as unexpected
-		// when closed and no wildcard has opened the door.
-		if dh.Level > expectedLevel {
+		if dh.Level > s.expectedLevel {
 			docIdx++
 			continue
 		}
-		if !allowExtra && closed {
-			diags = append(diags, mkDiag(f.Path, dh.Line,
-				unexpectedSectionDiag(
-					formatHeading(dh.Level, dh.Text),
-					formatHeading(expectedLevel, sc.Heading),
-					sch).Format()))
+		matched, _ := matchHeading(sc.Matcher, dh, s.docFM)
+		if !matched {
+			return docIdx
 		}
+		if claimsLaterLiteral(s.scopes, s.idx+1, dh, s.claimed, s.docFM) {
+			return docIdx
+		}
+		s.diags = append(s.diags, s.mkDiag(s.f.Path, dh.Line,
+			fmt.Sprintf("section %q matched %d times, allowed at most %d",
+				formatHeading(dh.Level, dh.Text),
+				s.consumed+1, s.max)))
+		s.consumed++
 		docIdx++
 	}
-	return docIdx, diags, false
+	return docIdx
+}
+
+// matchRun threads the per-iteration state of matchScope through
+// helper methods so the top-level loop reads as a straight pipe of
+// "advance, claim, or break" decisions.
+type matchRun struct {
+	f             *lint.File
+	sch           *Schema
+	scopes        []Scope
+	idx           int
+	expectedLevel int
+	claimed       map[int]bool
+	claimCounts   map[int]int
+	allowExtra    bool
+	closed        bool
+	docFM         map[string]any
+	mkDiag        MakeDiag
+	min, max      int
+	consumed      int
+	digitsSeen    []string
+	diags         []lint.Diagnostic
+}
+
+// step processes one doc heading. Returns (done, newDocIdx, ok)
+// where done==true exits the outer loop early.
+func (s *matchRun) step(docHeads []DocHeading, docIdx int) (bool, int, bool) {
+	sc := s.scopes[s.idx]
+	dh := docHeads[docIdx]
+	if dh.Level < s.expectedLevel {
+		// Broad matchers (`.+`) match everything, including
+		// parent-level siblings. Claiming such a heading here
+		// would consume the parent walker's next sibling and
+		// flag it as a level mismatch even though it never
+		// belonged to this nested run. Restrict the
+		// shallower-heading recovery to non-broad matchers so
+		// only an authored wrong-level heading (e.g. an `## X`
+		// where the schema wanted `### X`) is salvaged.
+		if matched, captured := matchHeading(sc.Matcher, dh, s.docFM); matched &&
+			!isBroadMatcher(sc.Matcher) {
+			// A shallower-than-expected heading that still matches
+			// the matcher counts toward the run's consumed/digits
+			// state — claimMatch emits the level-mismatch
+			// diagnostic on its own. Returning done=false lets the
+			// outer loop continue scanning for additional matches.
+			return false, s.claimMatch(docHeads, docIdx, captured), false
+		}
+		return true, docIdx, s.consumed > 0
+	}
+	matched, captured := matchHeading(sc.Matcher, dh, s.docFM)
+	if matched {
+		// Yield to a later specific scope whenever the current
+		// matcher is broad (`.+`) — even before reaching its min.
+		// A broad matcher's job is to absorb leftovers; stealing
+		// a heading the user named separately would either flag
+		// that section as missing or hide its content/rules. The
+		// repeat.min shortfall surfaces in finishRun if the
+		// broad matcher couldn't collect enough leftovers. For
+		// non-broad matchers, only yield once min is satisfied,
+		// so a required specific scope still claims its first
+		// occurrence even when the heading text overlaps a later
+		// literal entry.
+		if (isBroadMatcher(sc.Matcher) || s.consumed >= s.min) &&
+			claimsLaterLiteral(s.scopes, s.idx+1, dh, s.claimed, s.docFM) {
+			return true, docIdx, s.consumed > 0
+		}
+		return false, s.claimMatch(docHeads, docIdx, captured), false
+	}
+	// A deeper-than-expected heading is part of an earlier claimed
+	// scope's body, not a sibling boundary — skip it so the run
+	// keeps scanning for the next same-level match.
+	if dh.Level > s.expectedLevel {
+		return false, docIdx + 1, false
+	}
+	if s.consumed > 0 {
+		// An active run is contiguous; the first same-level
+		// non-match closes it.
+		return true, docIdx, true
+	}
+	if s.consumed >= s.min {
+		// Optional matcher (min=0) hasn't started yet. Yield to a
+		// later scope when the heading would claim it — including
+		// a later broad matcher, since the broad matcher is the
+		// natural absorber for a heading the optional scope did
+		// not match. Without yielding to broad here, the broad
+		// scope would later report "missing required" because the
+		// optional scope already advanced past its heading.
+		if anyLaterScopeClaims(s.scopes, s.idx+1, dh, s.claimed, s.docFM) {
+			return true, docIdx, false
+		}
+		if !s.allowExtra && s.closed {
+			s.diags = append(s.diags, s.mkDiag(s.f.Path, dh.Line,
+				unexpectedSectionDiag(
+					formatHeading(dh.Level, dh.Text),
+					formatHeading(s.expectedLevel, displayHeading(sc)),
+					s.sch).Format()))
+		}
+		return false, docIdx + 1, false
+	}
+	return s.handleNonMatch(docHeads, docIdx)
+}
+
+func (s *matchRun) claimMatch(docHeads []DocHeading, docIdx int, captured string) int {
+	sc := s.scopes[s.idx]
+	dh := docHeads[docIdx]
+	s.diags = append(s.diags, levelDiagIfNeeded(s.f, s.sch, dh, s.expectedLevel, s.mkDiag)...)
+	s.claimed[s.idx] = true
+	s.claimCounts[s.idx]++
+	if len(sc.Sections) > 0 {
+		newIdx, childDiags := validateScopes(
+			s.f, s.sch, sc.Sections, sc.Closed, docHeads, docIdx+1,
+			s.expectedLevel+1, s.docFM, s.mkDiag)
+		s.diags = append(s.diags, childDiags...)
+		docIdx = newIdx
+	} else {
+		docIdx++
+	}
+	s.consumed++
+	if captured != "" {
+		s.digitsSeen = append(s.digitsSeen, captured)
+	}
+	return docIdx
+}
+
+// handleNonMatch processes a heading that didn't match the current
+// matcher and that the run hasn't yet satisfied its `min` for. The
+// caller (step) has already filtered out deeper-than-expected
+// headings, so dh is always at the expected level here.
+func (s *matchRun) handleNonMatch(docHeads []DocHeading, docIdx int) (bool, int, bool) {
+	dh := docHeads[docIdx]
+	if ooIdx := findOutOfOrderIdx(s.scopes, dh, s.claimed, s.idx+1, s.docFM); ooIdx >= 0 {
+		newIdx, ooDiags := claimOutOfOrder(
+			s.f, s.sch, s.scopes, s.idx, ooIdx, s.expectedLevel, docHeads, docIdx,
+			s.claimed, s.claimCounts, s.docFM, s.mkDiag)
+		s.diags = append(s.diags, ooDiags...)
+		return false, newIdx, false
+	}
+	// A heading that matches an already-claimed scope falls into
+	// one of three buckets:
+	//   1. Contiguous continuation of a run still being assembled
+	//      in this very iteration (e.g. [A, B] with doc [B, B, A]
+	//      where claimOutOfOrder opened B's run; the second B
+	//      belongs to that same run). idx >= s.idx and the new
+	//      count is within max — silently absorb.
+	//   2. Past `max`: emit "exceeds allowed occurrences".
+	//   3. Non-contiguous extra: the scope's run was closed by an
+	//      earlier scope iteration (idx < s.idx) and the new
+	//      heading is within max. Emit "out of order: matcher
+	//      runs must be contiguous" so the user sees the ordering
+	//      violation even in an open schema.
+	if idx, exceeded := claimedScopeMatches(
+		s.scopes, dh, s.claimed, s.claimCounts, s.docFM); idx >= 0 {
+		if !exceeded && idx >= s.idx {
+			// Contiguous continuation of a run still being
+			// assembled. Recurse into the scope's children so
+			// nested required sections still surface for every
+			// occurrence of the run, matching claimMatch's
+			// in-order behavior — otherwise a repeated scope
+			// with required children would only validate the
+			// first occurrence's subtree.
+			contSc := s.scopes[idx]
+			if len(contSc.Sections) > 0 {
+				newIdx, childDiags := validateScopes(
+					s.f, s.sch, contSc.Sections, contSc.Closed,
+					docHeads, docIdx+1, s.expectedLevel+1,
+					s.docFM, s.mkDiag)
+				s.diags = append(s.diags, childDiags...)
+				return false, newIdx, false
+			}
+			return false, docIdx + 1, false
+		}
+		sc := s.scopes[idx]
+		msg := fmt.Sprintf(
+			"section %q out of order: matcher runs must be "+
+				"contiguous with scope %q's earlier run",
+			formatHeading(dh.Level, dh.Text),
+			formatHeading(s.expectedLevel, displayHeading(sc)))
+		if exceeded {
+			msg = fmt.Sprintf(
+				"section %q exceeds scope %q's allowed occurrences",
+				formatHeading(dh.Level, dh.Text),
+				formatHeading(s.expectedLevel, displayHeading(sc)))
+		}
+		s.diags = append(s.diags, s.mkDiag(s.f.Path, dh.Line, msg))
+		return false, docIdx + 1, false
+	}
+	if !s.allowExtra && s.closed {
+		sc := s.scopes[s.idx]
+		s.diags = append(s.diags, s.mkDiag(s.f.Path, dh.Line,
+			unexpectedSectionDiag(
+				formatHeading(dh.Level, dh.Text),
+				formatHeading(s.expectedLevel, displayHeading(sc)),
+				s.sch).Format()))
+	}
+	return false, docIdx + 1, false
+}
+
+// laterScopeMatches reports whether dh matches any later scope in
+// the same parent window that is more specific than a broad
+// matcher. Used by the per-scope walkers (rules, content,
+// acronyms) so a broad repeated matcher does not consume a
+// heading that a later named scope would claim. The walker
+// version does not need a scope-index `claimed` map because each
+// walker iterates scopes in declared order and acts immediately.
+func laterScopeMatches(
+	scopes []Scope, startIdx int, dh DocHeading,
+	docFM map[string]any,
+) bool {
+	for i := startIdx; i < len(scopes); i++ {
+		sc := scopes[i]
+		if sc.Preamble ||
+			isSlotMatcher(sc.Matcher) || isBroadMatcher(sc.Matcher) {
+			continue
+		}
+		if scopeMatchesHeading(sc, dh, docFM) {
+			return true
+		}
+	}
+	return false
+}
+
+// anyLaterScopeClaims reports whether dh matches any unclaimed
+// non-slot, non-preamble later scope — including broad
+// matchers. Used by the unmatched-optional yield path so an
+// optional scope that doesn't match the current heading still
+// yields to a broad matcher waiting to absorb leftovers
+// (e.g. an `A optional` + `.+ min=1` pair against a `## Body`
+// heading). Differs from `claimsLaterLiteral` only in that it
+// keeps broad matchers in the search.
+func anyLaterScopeClaims(
+	scopes []Scope, startIdx int, dh DocHeading,
+	claimed map[int]bool, docFM map[string]any,
+) bool {
+	for i := startIdx; i < len(scopes); i++ {
+		sc := scopes[i]
+		if claimed[i] || sc.Preamble || isSlotMatcher(sc.Matcher) {
+			continue
+		}
+		if scopeMatchesHeading(sc, dh, docFM) {
+			return true
+		}
+	}
+	return false
+}
+
+// claimsLaterLiteral reports whether dh matches any unclaimed
+// later scope that is more specific than a broad/slot matcher.
+// Used so a slot or repeat-run does not absorb a heading the
+// user named separately further down the list. Optional scopes
+// participate (a `regex: 'A'` with `repeat: { min: 0, max: 1 }`
+// still wants the heading), but later scopes with a broad `.+`
+// regex are skipped — yielding to them would let a generic
+// catch-all steal a heading from a specific predecessor.
+func claimsLaterLiteral(
+	scopes []Scope, startIdx int, dh DocHeading,
+	claimed map[int]bool, docFM map[string]any,
+) bool {
+	for i := startIdx; i < len(scopes); i++ {
+		sc := scopes[i]
+		if claimed[i] || sc.Preamble ||
+			isSlotMatcher(sc.Matcher) || isBroadMatcher(sc.Matcher) {
+			continue
+		}
+		if scopeMatchesHeading(sc, dh, docFM) {
+			return true
+		}
+	}
+	return false
+}
+
+// sequentialDiagMessage scans captured digit strings for ordering
+// violations: each number must be strictly greater than its
+// predecessor, no gaps allowed.
+func sequentialDiagMessage(captured []string) string {
+	prev := -1
+	for _, s := range captured {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Sprintf(
+				"sequential captures must be integers; got %q", s)
+		}
+		if prev < 0 {
+			prev = n
+			continue
+		}
+		if n != prev+1 {
+			return fmt.Sprintf(
+				"sequential numbering out of order: expected %d, got %d",
+				prev+1, n)
+		}
+		prev = n
+	}
+	return ""
 }
 
 func levelDiagIfNeeded(
@@ -836,35 +1210,14 @@ func levelDiagIfNeeded(
 		levelMismatchSchemaDiag(dh.Text, expectedLevel, dh.Level, sch).Format())}
 }
 
-// claimMatch marks scopes[idx] as matched against docHeads[docIdx],
-// appending the level-mismatch diagnostic when applicable and
-// recursing into the scope's child sections. Returns the advanced
-// docIdx, combined diagnostics, and true.
-func claimMatch(
-	f *lint.File, sch *Schema, sc Scope, idx, expectedLevel int,
-	docHeads []DocHeading, docIdx int, claimed map[int]bool,
-	mkDiag MakeDiag, prior []lint.Diagnostic,
-) (int, []lint.Diagnostic, bool) {
-	diags := append(prior, levelDiagIfNeeded(f, sch, docHeads[docIdx], expectedLevel, mkDiag)...)
-	claimed[idx] = true
-	docIdx++
-	if len(sc.Sections) > 0 {
-		newIdx, childDiags := validateScopes(
-			f, sch, sc.Sections, sc.Closed, docHeads, docIdx,
-			expectedLevel+1, mkDiag)
-		diags = append(diags, childDiags...)
-		docIdx = newIdx
-	}
-	return docIdx, diags, true
-}
-
 // claimOutOfOrder records that docHeads[docIdx] matches scopes[ooIdx]
 // (a later listed scope), emits the out-of-order diagnostic, and
 // recurses into the matched scope's child sections.
 func claimOutOfOrder(
 	f *lint.File, sch *Schema, scopes []Scope, idx, ooIdx, expectedLevel int,
-	docHeads []DocHeading, docIdx int, claimed map[int]bool,
-	mkDiag MakeDiag,
+	docHeads []DocHeading, docIdx int,
+	claimed map[int]bool, claimCounts map[int]int,
+	docFM map[string]any, mkDiag MakeDiag,
 ) (int, []lint.Diagnostic) {
 	sc := scopes[idx]
 	ooSc := scopes[ooIdx]
@@ -872,163 +1225,253 @@ func claimOutOfOrder(
 	diags := []lint.Diagnostic{mkDiag(f.Path, dh.Line,
 		outOfOrderDiag(
 			formatHeading(dh.Level, dh.Text),
-			formatHeading(expectedLevel, sc.Heading),
+			formatHeading(expectedLevel, displayHeading(sc)),
 			sch).Format())}
 	diags = append(diags, levelDiagIfNeeded(f, sch, dh, expectedLevel, mkDiag)...)
+	// Count the contiguous run of same-level headings starting at
+	// docIdx that match ooSc. The recovery path still claims only
+	// the leading occurrence (so child recursion has a single
+	// anchor), but counting the full run avoids reporting a false
+	// `repeat.min` shortfall when the document does contain enough
+	// occurrences — they are simply in the wrong position, which
+	// the out-of-order diagnostic already calls out.
+	runLen := countMatchingRun(ooSc, docHeads, docIdx, expectedLevel, docFM)
+	if ooSc.Matcher != nil && runLen < ooSc.Matcher.Repeat.Min {
+		diags = append(diags, mkDiag(f.Path, dh.Line,
+			fmt.Sprintf(
+				"section %q matched %d times, required at least %d",
+				formatHeading(expectedLevel, displayHeading(ooSc)),
+				runLen, ooSc.Matcher.Repeat.Min)))
+	}
+	if ooSc.Matcher != nil && ooSc.Matcher.Sequential {
+		diags = append(diags, mkDiag(f.Path, dh.Line,
+			fmt.Sprintf(
+				"section %q sequential ordering is not enforced "+
+					"on out-of-order claims; move the scope to its "+
+					"natural position for sequential checks",
+				formatHeading(expectedLevel, displayHeading(ooSc)))))
+	}
 	claimed[ooIdx] = true
+	claimCounts[ooIdx]++
 	docIdx++
 	if len(ooSc.Sections) > 0 {
 		newIdx, childDiags := validateScopes(
 			f, sch, ooSc.Sections, ooSc.Closed, docHeads, docIdx,
-			expectedLevel+1, mkDiag)
+			expectedLevel+1, docFM, mkDiag)
 		diags = append(diags, childDiags...)
 		docIdx = newIdx
 	}
 	return docIdx, diags
 }
 
-func nextUnclaimed(cands []int, claimed map[int]bool, minIdx int) int {
-	for _, i := range cands {
-		if i >= minIdx && !claimed[i] {
-			return i
+// countMatchingRun returns the number of contiguous same-level
+// headings starting at docIdx that match sc's matcher. Deeper
+// headings (level > expectedLevel) are skipped as body content of
+// an already-matched section, mirroring matchScope's run
+// semantics. The walk stops at the first same-level non-match or
+// the first shallower-than-expected heading.
+func countMatchingRun(
+	sc Scope, docHeads []DocHeading, docIdx, expectedLevel int,
+	docFM map[string]any,
+) int {
+	run := 0
+	for i := docIdx; i < len(docHeads); i++ {
+		dh := docHeads[i]
+		if dh.Level < expectedLevel {
+			return run
 		}
+		if dh.Level > expectedLevel {
+			continue
+		}
+		if matched, _ := matchHeading(sc.Matcher, dh, docFM); matched {
+			run++
+			continue
+		}
+		return run
 	}
-	return -1
+	return run
 }
 
 // findOutOfOrderIdx returns the first unclaimed scope at index >=
-// minIdx that matches dh, scanning placeholder-bearing scopes too.
-// requiredByText keys only fully-literal heading/alias text; a
-// scope with placeholder interpolation in either its Heading or
-// any of its Aliases falls through to the scopeMatchesHeading
-// scan, so out-of-order detection still picks it up.
+// minIdx that matches dh.
 func findOutOfOrderIdx(
 	scopes []Scope, dh DocHeading,
-	requiredByText map[string][]int, claimed map[int]bool, minIdx int,
+	claimed map[int]bool, minIdx int, docFM map[string]any,
 ) int {
-	if i := nextUnclaimed(requiredByText[dh.Text], claimed, minIdx); i >= 0 {
-		return i
-	}
 	for i := minIdx; i < len(scopes); i++ {
 		sc := scopes[i]
-		if claimed[i] || sc.Wildcard {
+		if claimed[i] || sc.Preamble || isSlotMatcher(sc.Matcher) {
 			continue
 		}
-		if !scopeNeedsMatchScan(sc) {
-			// Fully-literal scopes are already indexed in
-			// requiredByText; nothing the fallback can find.
-			continue
-		}
-		if scopeMatchesHeading(sc, dh) {
+		if scopeMatchesHeading(sc, dh, docFM) {
 			return i
 		}
 	}
 	return -1
 }
 
-// scopeNeedsMatchScan reports whether scopeMatchesHeading must be
-// invoked to decide if a scope claims a heading. Fully-literal
-// scopes are pre-indexed in requiredByText and don't need the
-// fallback; scopes with placeholder interpolation in either
-// Heading or Aliases do — and so does the "?" wildcard, which
-// matches any text but can't appear in a literal-text map.
-func scopeNeedsMatchScan(sc Scope) bool {
-	if sc.Heading == "?" || fieldinterp.ContainsField(sc.Heading) {
-		return true
-	}
-	for _, a := range sc.Aliases {
-		if a == "?" || fieldinterp.ContainsField(a) {
-			return true
-		}
-	}
-	return false
-}
-
-// MatchesHeading reports whether sc matches the heading text in dh.
-// Exported so callers outside the validator (notably the per-scope
-// rule walker in internal/rules/requiredstructure) reuse the same
-// matching semantics — anchored regex for field-interpolated
-// patterns, exact text otherwise, plus aliases and the "?"
-// wildcard.
-func MatchesHeading(sc Scope, dh DocHeading) bool {
-	return scopeMatchesHeading(sc, dh)
-}
-
-func scopeMatchesHeading(sc Scope, dh DocHeading) bool {
-	if sc.Wildcard || sc.Preamble {
-		// Wildcards never match a specific heading directly; the
-		// preamble has no heading text to compare against.
-		return false
-	}
-	if sc.Heading == "?" {
-		return true
-	}
-	if matchesText(sc.Heading, dh.Text) {
-		return true
-	}
-	for _, a := range sc.Aliases {
-		if matchesText(a, dh.Text) {
-			return true
-		}
-	}
-	return false
-}
-
-// patternRegexCache memoises compiled regexes for field-interpolated
-// heading patterns. Recompiling per-call would be O(scopes ×
-// headings) on every validation pass; caching by pattern string
-// keeps the hot loop allocation-free after warm-up.
+// ScopeRunIndices returns the doc-heading indices that
+// scopes[currentIdx] would claim inside the
+// [parentStart, parentEnd) window, following the same
+// contiguous-run semantics matchScope uses: scan forward from
+// the first match for additional same-level matches, but stop at
+// the first same-level heading that does not match (deeper
+// headings inside the matched section are skipped silently).
 //
-// Stored values are *regexp.Regexp. A compile error is signalled
-// by storing the patternCompileFailed sentinel — a dedicated
-// non-nil pointer that the loader distinguishes from a successful
-// entry by identity, avoiding the typed-nil-interface trap that
-// would make `v == nil` silently fail.
-var patternRegexCache sync.Map
-
-// patternCompileFailed is the sentinel value stored in
-// patternRegexCache when regexp.Compile failed. A separate value
-// (instead of a typed-nil *regexp.Regexp) lets the loader
-// distinguish "never tried" from "tried and failed" via a regular
-// type assertion.
-var patternCompileFailed = &regexp.Regexp{}
-
-func matchesText(pattern, text string) bool {
-	if !fieldinterp.ContainsField(pattern) {
-		return pattern == text
-	}
-	re := patternRegex(pattern)
-	if re == nil {
-		return false
-	}
-	return re.MatchString(text)
-}
-
-func patternRegex(pattern string) *regexp.Regexp {
-	if v, ok := patternRegexCache.Load(pattern); ok {
-		re, ok := v.(*regexp.Regexp)
-		if !ok || re == patternCompileFailed {
-			return nil
-		}
-		return re
-	}
-	parts := fieldinterp.SplitOnFields(pattern)
-	var b strings.Builder
-	b.WriteString("^")
-	for i, p := range parts {
-		b.WriteString(regexp.QuoteMeta(p))
-		if i < len(parts)-1 {
-			b.WriteString(".+")
-		}
-	}
-	b.WriteString("$")
-	re, err := regexp.Compile(b.String())
-	if err != nil {
-		patternRegexCache.Store(pattern, patternCompileFailed)
+// The helper also mirrors matchScope's yield rules so per-scope
+// walkers stay in step with structural validation:
+//   - A broad matcher (`regex: '.+'`) yields to any later named
+//     scope whose matcher would claim the heading.
+//   - A non-broad matcher yields to a later named scope only
+//     after its `repeat.min` has been satisfied.
+//
+// When no in-level match is found the helper falls back to the
+// first wrong-level match in the window. Used by the per-scope
+// walkers (acronyms, content, rules) so they only visit
+// occurrences the structural validator would also have claimed
+// as part of the same run.
+func ScopeRunIndices(
+	scopes []Scope, currentIdx int, heads []DocHeading,
+	expectedLevel, parentStart, parentEnd int,
+	claimed map[int]bool, docFM map[string]any,
+) []int {
+	sc := scopes[currentIdx]
+	if sc.Matcher == nil {
 		return nil
 	}
-	patternRegexCache.Store(pattern, re)
-	return re
+	out := scanScopeRunAtLevel(
+		scopes, currentIdx, heads, expectedLevel, parentStart, parentEnd,
+		claimed, docFM)
+	if len(out) > 0 {
+		return out
+	}
+	// No in-level match — fall back to the first wrong-level
+	// match. Wrong-level matches never form a run (the heading
+	// already deviates from the schema's level expectation).
+	if idx := firstWrongLevelMatch(
+		sc, heads, expectedLevel, parentStart, parentEnd, claimed, docFM); idx >= 0 {
+		return []int{idx}
+	}
+	return nil
+}
+
+// scanScopeRunAtLevel scans heads in source order for contiguous
+// matches of scopes[currentIdx] at expectedLevel. The run ends
+// when its bounds are exhausted, when a same-level non-match
+// closes the run, or when a heading would be claimed by a more
+// specific later scope (broad matchers yield from the start;
+// non-broad yield only after `repeat.min` is satisfied).
+func scanScopeRunAtLevel(
+	scopes []Scope, currentIdx int, heads []DocHeading,
+	expectedLevel, parentStart, parentEnd int,
+	claimed map[int]bool, docFM map[string]any,
+) []int {
+	sc := scopes[currentIdx]
+	min, max := sc.Matcher.Repeat.Bounds()
+	isBroad := isBroadMatcher(sc.Matcher)
+	var out []int
+	started := false
+	for i, h := range heads {
+		if claimed[i] {
+			continue
+		}
+		if h.Line < parentStart || h.Line >= parentEnd {
+			continue
+		}
+		if h.Level != expectedLevel {
+			if h.Level < expectedLevel && started {
+				break
+			}
+			continue
+		}
+		if scopeMatchesHeading(sc, h, docFM) {
+			if (isBroad || len(out) >= min) &&
+				laterScopeMatches(scopes, currentIdx+1, h, docFM) {
+				break
+			}
+			out = append(out, i)
+			started = true
+			if max == 1 || (max > 0 && len(out) >= max) {
+				break
+			}
+			continue
+		}
+		if started {
+			break
+		}
+	}
+	return out
+}
+
+// firstWrongLevelMatch returns the index of the first heading in
+// the window that matches sc at any level other than
+// expectedLevel, or -1 when none exists. The walker uses this
+// fallback so a section authored at the wrong heading depth still
+// gets its per-scope checks applied. Broad matchers (`.+`) are
+// skipped — they would otherwise pair the slot with any sibling
+// in the parent window, making per-scope rule/content/acronym
+// checks fire against the wrong section.
+func firstWrongLevelMatch(
+	sc Scope, heads []DocHeading,
+	expectedLevel, parentStart, parentEnd int,
+	claimed map[int]bool, docFM map[string]any,
+) int {
+	if isBroadMatcher(sc.Matcher) {
+		return -1
+	}
+	for i, h := range heads {
+		if claimed[i] {
+			continue
+		}
+		if h.Line < parentStart || h.Line >= parentEnd {
+			continue
+		}
+		if h.Level == expectedLevel {
+			continue
+		}
+		if scopeMatchesHeading(sc, h, docFM) {
+			return i
+		}
+	}
+	return -1
+}
+
+// MatchesHeading reports whether sc matches dh's heading text.
+// Exported so callers outside the validator (notably the per-scope
+// rule walker in internal/rules/requiredstructure) reuse the same
+// matching semantics. fm is the document's parsed front matter and
+// must be supplied so `\#(fmvar(...))` patterns resolve correctly;
+// pass nil only when the schema is known to use literal-only
+// matchers.
+func MatchesHeading(sc Scope, dh DocHeading, fm map[string]any) bool {
+	return scopeMatchesHeading(sc, dh, fm)
+}
+
+func scopeMatchesHeading(sc Scope, dh DocHeading, fm map[string]any) bool {
+	if sc.Preamble || sc.Matcher == nil {
+		return false
+	}
+	if isSlotMatcher(sc.Matcher) {
+		// Slots are positional placeholders, not identity claimants;
+		// callers that want to know whether a heading falls inside
+		// a slot use the walker's logic instead.
+		return false
+	}
+	matched, _ := matchHeading(sc.Matcher, dh, fm)
+	return matched
+}
+
+// displayHeading renders a scope's label for diagnostics. The bare
+// heading text is preferred when it survives parsing; otherwise
+// the matcher's regex body stands in.
+func displayHeading(sc Scope) string {
+	if sc.Heading != "" {
+		return sc.Heading
+	}
+	if sc.Matcher != nil {
+		return sc.Matcher.Regex
+	}
+	return ""
 }
 
 func formatHeading(level int, text string) string {
@@ -1045,7 +1488,7 @@ func formatHeading(level int, text string) string {
 func validateFilename(
 	f *lint.File, sch *Schema, mkDiag MakeDiag,
 ) []lint.Diagnostic {
-	pattern := sch.Require.Filename
+	pattern := sch.Filename
 	if pattern == "" {
 		return nil
 	}

--- a/internal/schema/validate_content.go
+++ b/internal/schema/validate_content.go
@@ -21,12 +21,16 @@ import (
 // the matched section's body. Diagnostics surface alongside the
 // heading-tree results emitted by Validate.
 //
+// docFM is the document's parsed front matter; it threads through
+// to the per-scope walker so `\#(fmvar(...))` matchers resolve when
+// pairing a scope with its heading.
+//
 // The function does its own document parse with the table extension
 // enabled — lint.NewFile's parser is CommonMark-only, so GFM tables
 // would otherwise appear as paragraphs. The parse is skipped when
 // the schema declares no content entries anywhere.
 func ValidateContent(
-	f *lint.File, sch *Schema, mkDiag MakeDiag,
+	f *lint.File, sch *Schema, docFM map[string]any, mkDiag MakeDiag,
 ) []lint.Diagnostic {
 	if sch == nil || !anyScopeHasContent(sch.Sections) {
 		return nil
@@ -40,7 +44,7 @@ func ValidateContent(
 	claimed := make(map[int]bool)
 	walkContentScopes(
 		f, sch.Sections, heads, rootLevel, 1, len(f.Lines)+1,
-		claimed, blocks, mkDiag, &diags,
+		claimed, blocks, docFM, mkDiag, &diags,
 	)
 	return diags
 }
@@ -217,10 +221,10 @@ func walkContentScopes(
 	f *lint.File, scopes []Scope, heads []DocHeading,
 	expectedLevel, parentStart, parentEnd int,
 	claimed map[int]bool, blocks []contentBlock,
-	mkDiag MakeDiag, diags *[]lint.Diagnostic,
+	docFM map[string]any, mkDiag MakeDiag, diags *[]lint.Diagnostic,
 ) {
-	for _, sc := range scopes {
-		if sc.Wildcard {
+	for i, sc := range scopes {
+		if isSlotMatcher(sc.Matcher) {
 			continue
 		}
 		if sc.Preamble {
@@ -234,19 +238,21 @@ func walkContentScopes(
 			runContent(f, sc, parentStart, expectedLevel, parentStart, end, blocks, mkDiag, diags)
 			continue
 		}
-		matched := findContentMatchingHead(sc, heads, expectedLevel, parentStart, parentEnd, claimed)
-		if matched < 0 {
-			continue
-		}
-		claimed[matched] = true
-		dh := heads[matched]
-		end := contentScopeEndLine(heads, matched, dh.Level, parentEnd)
-		runContent(f, sc, dh.Line, dh.Level, dh.Line+1, end, blocks, mkDiag, diags)
-		if len(sc.Sections) > 0 {
-			walkContentScopes(
-				f, sc.Sections, heads, expectedLevel+1, dh.Line, end,
-				claimed, blocks, mkDiag, diags,
-			)
+		// ScopeRunIndices applies the structural validator's
+		// run + yield semantics: contiguous matches only, with
+		// broad-and-after-min yielding to later named scopes.
+		for _, matched := range ScopeRunIndices(
+			scopes, i, heads, expectedLevel, parentStart, parentEnd, claimed, docFM) {
+			dh := heads[matched]
+			claimed[matched] = true
+			end := contentScopeEndLine(heads, matched, dh.Level, parentEnd)
+			runContent(f, sc, dh.Line, dh.Level, dh.Line+1, end, blocks, mkDiag, diags)
+			if len(sc.Sections) > 0 {
+				walkContentScopes(
+					f, sc.Sections, heads, expectedLevel+1, dh.Line, end,
+					claimed, blocks, docFM, mkDiag, diags,
+				)
+			}
 		}
 	}
 }
@@ -283,44 +289,6 @@ func blocksInRange(blocks []contentBlock, startLine, endLine int) []contentBlock
 		out = append(out, b)
 	}
 	return out
-}
-
-// findContentMatchingHead picks the earliest unclaimed heading at the
-// expected level whose text matches sc, restricted to the parent
-// window. Falls back to a heading at any in-window level so a level-
-// mismatched section still pairs (the heading walker emits the
-// level-mismatch diagnostic separately).
-func findContentMatchingHead(
-	sc Scope, heads []DocHeading,
-	expectedLevel, parentStart, parentEnd int,
-	claimed map[int]bool,
-) int {
-	if idx := scanContentHeads(sc, heads, parentStart, parentEnd, claimed, expectedLevel); idx >= 0 {
-		return idx
-	}
-	return scanContentHeads(sc, heads, parentStart, parentEnd, claimed, -1)
-}
-
-func scanContentHeads(
-	sc Scope, heads []DocHeading,
-	parentStart, parentEnd int, claimed map[int]bool,
-	requireLevel int,
-) int {
-	for j, dh := range heads {
-		if claimed[j] {
-			continue
-		}
-		if dh.Line < parentStart || dh.Line >= parentEnd {
-			continue
-		}
-		if requireLevel >= 0 && dh.Level != requireLevel {
-			continue
-		}
-		if MatchesHeading(sc, dh) {
-			return j
-		}
-	}
-	return -1
 }
 
 // contentScopeEndLine returns the exclusive end-line of a section

--- a/plan/146_inline-schema-in-kinds.md
+++ b/plan/146_inline-schema-in-kinds.md
@@ -162,6 +162,11 @@ diagnostic.
 permissive subsections sets `closed: true` at
 the root and omits it on each child.
 
+> **Entry shape superseded by plan 156.** The
+> grammar below is historical; the current shape
+> lives in the
+> [section-schema reference](../docs/reference/section-schema.md).
+
 Every section-array entry sets `heading:`. The
 value is a string (literal heading text), `null`
 (the preamble — content before any heading),

--- a/plan/156_schema-entry-unification.md
+++ b/plan/156_schema-entry-unification.md
@@ -3,7 +3,7 @@ id: 156
 title: >-
   Section schema — unify entry shape under
   `heading:` discriminator
-status: "🔲"
+status: "✅"
 model: opus
 depends-on: [146]
 summary: >-
@@ -117,29 +117,35 @@ Files rewritten as part of implementation:
 
 ## Tasks
 
-1. Update `Scope` in `internal/schema/schema.go`.
+1. [x] Update `Scope` in `internal/schema/schema.go`.
    Drop `Aliases`, `Required`, `Repeats`,
    `Sequential` (top-level), `Min`/`Max`,
    `Wildcard`. Add a `Matcher` sub-struct
    (`Regex`, `Repeat`, `Sequential`). Keep
    `Preamble` as a derived flag.
-2. Rewrite the heading-mapping parser in
+2. [x] Rewrite the heading-mapping parser in
    `internal/schema/parse_inline.go` to
    accept `{ regex, repeat?, sequential? }`.
    Reject every removed key by name with a
    "removed; see plan 156" diagnostic naming
    the replacement.
-3. In the same parser, flatten
+3. [x] In the same parser, flatten
    `require.filename:` to top-level
    `filename:`. Reject schema-level `closed:`
    on kinds without `sections:`.
-4. Update `internal/schema/parse_file.go` so
+4. [x] Update `internal/schema/parse_file.go` so
    `## ?` and `## ...` map to the new
    `Matcher` (`regex: '.+'`, plus
    `repeat: { min: 0 }` for `...`). Keep
    `{n}` and `{field}` token expansion in
-   heading rows.
-5. Rewrite the validator in
+   heading rows. (Scope note: MDS020's file-
+   schema check still routes through its
+   legacy `parseSchema`/`parsedSchema` pipeline
+   so the `{field}` heading/body sync feature
+   survives; this parser is exercised by the
+   schema-package tests and prepares the
+   ground for the cutover in a follow-up plan.)
+5. [x] Rewrite the validator in
    `internal/schema/validate.go` to match
    the heading sequence as a positional
    quantified regex. Each `Matcher` consumes
@@ -147,80 +153,80 @@ Files rewritten as part of implementation:
    consecutive headings whose text matches
    `regex:`. Diagnostics point at the
    entry's source location.
-6. Update fixtures and tests under
+6. [x] Update fixtures and tests under
    `internal/schema/` and
    `internal/rules/MDS020-required-structure/`.
    Add one fixture per new parse-time
    diagnostic.
-7. Rewrite the 5 inline kinds in
+7. [x] Rewrite the 5 inline kinds in
    `.mdsmith.yml` and the affected fixture
    to the new shape. Run `mdsmith check .`
    and `mdsmith fix .`.
-8. Rewrite `docs/guides/schemas.md` and the
+8. [x] Rewrite `docs/guides/schemas.md` and the
    MDS020 README to describe only the new
    shape. Every reference to `aliases:`,
    `required:`, `unlisted:`, scope-level
    `repeats:`/`sequential:`/`min:`/`max:`, and
    `require:` is removed; one worked example
    of the new shape replaces the old one.
-9. Remove the "upcoming" notice from
+9. [x] Remove the "upcoming" notice from
    `docs/reference/section-schema.md`.
    Run `mdsmith fix CLAUDE.md` so the catalog
    line for the page survives any title /
    summary edits.
-10. Add a "superseded" note to plan 146's
+10. [x] Add a "superseded" note to plan 146's
     entry-shape section pointing at this plan
     and the reference page.
 
 ## Acceptance Criteria
 
-- [ ] A section entry uses exactly one of
+- [x] A section entry uses exactly one of
       three shapes: `heading: null`,
       `heading: <string>`, or `heading: {
       regex, repeat?, sequential? }`.
-- [ ] `repeat:` omitted → exactly one;
+- [x] `repeat:` omitted → exactly one;
       `repeat: { min: 0 }` → zero or more;
       `repeat: { min: 0, max: 1 }` →
       optional; bounded forms enforce the
       bounds.
-- [ ] Regex matching is whole-string
+- [x] Regex matching is whole-string
       anchored against rendered plain text
       (fixture: `## **Overview**` matches
       `regex: 'Overview'`).
-- [ ] `{n}` expands to a numeric capture;
+- [x] `{n}` expands to a numeric capture;
       `sequential: true` flags out-of-order
       or gapped numbers.
-- [ ] `{field}` interpolates the document's
+- [x] `{field}` interpolates the document's
       frontmatter value at validate-time.
-- [ ] `heading: null` outside index 0
+- [x] `heading: null` outside index 0
       parse-errors.
-- [ ] `heading:` mapping without `regex:`
+- [x] `heading:` mapping without `regex:`
       parse-errors.
-- [ ] `repeat: {}`, `repeat: { max: 0 }`,
+- [x] `repeat: {}`, `repeat: { max: 0 }`,
       `min > max` each parse-error.
-- [ ] `sequential: true` without `{n}`
+- [x] `sequential: true` without `{n}`
       parse-errors.
-- [ ] Invalid regex parse-errors with the
+- [x] Invalid regex parse-errors with the
       RE2 message and field path.
-- [ ] Removed keys each parse-error with a
+- [x] Removed keys each parse-error with a
       "removed; see plan 156" message
       naming the replacement.
-- [ ] The 5 rewritten inline kinds and the
+- [x] The 5 rewritten inline kinds and the
       rewritten fixture emit the same MDS020
       diagnostics they did before the
       cutover (where the constraint is
       preserved).
-- [ ] `docs/guides/schemas.md` and the
+- [x] `docs/guides/schemas.md` and the
       MDS020 README describe only the new
       shape — `grep -E 'aliases:|required:|unlisted:|repeats:|^require:'`
       against either file returns no matches
       in prose.
-- [ ] `docs/reference/section-schema.md`
+- [x] `docs/reference/section-schema.md`
       reads as a current spec — its
       "upcoming" notice is removed and the
       page links from `docs/guides/schemas.md`.
-- [ ] `mdsmith check .` reports no
+- [x] `mdsmith check .` reports no
       diagnostics.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports
       no issues.


### PR DESCRIPTION
Implements [plan 156](plan/156_schema-entry-unification.md), which collapses the section-entry vocabulary to a single `heading:` discriminator with a unified `Matcher` shape.

## Summary

This change restructures how document schemas define section entries. Instead of separate keys for `required`, `aliases`, `repeats`, `sequential`, `min`, and `max` scattered across the entry and scope levels, all matching logic now flows through a single `Matcher` struct containing `Regex`, `Repeat` (with `Min`/`Max` bounds), and `Sequential` fields. The schema-level `require.filename:` nesting is flattened to a top-level `filename:` key.

## Key Changes

**Schema structure (`internal/schema/schema.go`)**
- Replaced `Scope` fields: removed `Aliases`, `Required`, `Repeats`, `Sequential` (top-level), `Min`/`Max`, `Wildcard`
- Added `Matcher` sub-struct with `Regex`, `Repeat`, and `Sequential` fields
- Flattened `Schema.Require` struct to a single `Schema.Filename` string field
- `Preamble` remains as a derived flag (when `Heading` is `null`)

**Inline parser (`internal/schema/parse_inline.go`)**
- Rewrote heading-mapping parser to accept `{ regex, repeat?, sequential? }` shape
- Rejects all removed keys (`required`, `aliases`, `repeats`, `sequential`, `min`, `max`) with "removed; see plan 156" diagnostics naming the replacement
- Flattened `require:` wrapper; now parses top-level `filename:` directly
- Added validation that `closed:` only appears on schemas with `sections:`

**Matcher implementation (`internal/schema/matcher.go`, new file)**
- Implements regex pattern resolution with support for `\#(digits)` and `\#(fmvar(name))` interpolations
- `digits` captures numeric sequences for sequential validation
- `fmvar()` resolves frontmatter field values into the pattern
- Provides `scanInterps`, `resolvePattern`, and helper functions for pattern compilation

**Validator (`internal/schema/validate.go`)**
- Refactored `validateScopes` to thread `docFM` (document frontmatter) through the call stack
- Replaced `buildRequiredByText` map with direct matcher-based matching via `matchHeading`
- Introduced `matchRun` state machine to handle cardinality constraints (`min`/`max` repetitions)
- Added sequential validation: detects out-of-order numeric headings when `sequential: true`
- Updated `scopeMatchesHeading` to accept frontmatter for field interpolation resolution

**File parser (`internal/schema/parse_file.go`)**
- Maps proto.md heading-row tokens to new `Matcher` shape:
  - `## ?` → `{regex: '.+'}`
  - `## ...` → `{regex: '.+', repeat: {min: 0}}`
  - `## Step {n}` → `{regex: 'Step \#(digits)'}`
  - `## {id}` → `{regex: '\#(fmvar(id))'}`

**Test updates**
- Removed tests for rejected keys; added tests verifying rejection with migration diagnostics
- Updated all test fixtures to use new shape (removed `required:`, `aliases:`, etc.)
- Added `plan156_acceptance_test.go` covering regex matching, digit capture, and sequential validation
- Added `test_helpers_test.go` with `literalScope`, `optionalScope`, `slotScope` constructors

**Documentation**
- Updated `docs/guides/schemas.md` with new entry shape examples
- Updated `docs/reference/section-schema.md` to reflect current grammar
- Updated plan 156 status to ✅ (complete)
- Updated `.mdsmith.yml` and example schemas to use new shape

## Notable Implementation Details

- **Regex anchoring**: Patterns are anchored with `^(?:...)$` to match whole heading text
- **Frontmatter interpolation**: The

https://claude.ai/code/session_012GGH62fZUzLuzP8T4ocGkJ