### PR TITLE
Add maintainability metadata to rule READMEs and expose via `mdsmith help patterns`

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -87,7 +87,7 @@ footer: |
 | 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
 | 157 | 🔳     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
 | 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                      |
-| 161 | 🔲     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |
+| 161 | 🔳     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |
 | 162 | 🔲     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                            |
 | 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                      |
 | 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)               |

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1073,6 +1073,12 @@ func runHelpPatterns(args []string) int {
 	if len(args) >= 2 && (args[0] == "-f" || args[0] == "--format") {
 		format = args[1]
 	}
+	switch format {
+	case "text", "json":
+	default:
+		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unknown format %q (valid: text, json)\n", format)
+		return 2
+	}
 	rules, err := ruledocs.ListRules()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1116,8 +1116,10 @@ func runHelpPatterns(args []string) int {
 	if format == "json" {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		// items is a slice of plain string/bool fields, so encoding cannot fail.
-		_ = enc.Encode(items)
+		if err := enc.Encode(items); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: writing json: %v\n", err)
+			return 2
+		}
 		return 0
 	}
 	for _, it := range items {

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1078,6 +1078,10 @@ func runHelpPatterns(args []string) int {
 			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: %s requires a value (text or json)\n", args[0])
 			return 2
 		}
+		if len(args) > 2 {
+			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unexpected trailing argument %q\n", args[2])
+			return 2
+		}
 		format = args[1]
 	}
 	switch format {

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1090,7 +1090,13 @@ func runHelpPatterns(args []string) int {
 		if r.Maintainability == nil {
 			continue
 		}
-		items = append(items, rec{r.ID, r.Name, r.Maintainability.Signal, r.Maintainability.Fix, r.Maintainability.ForDiagnostic})
+		items = append(items, rec{
+			ID:            r.ID,
+			Name:          r.Name,
+			Signal:        r.Maintainability.Signal,
+			Fix:           r.Maintainability.Fix,
+			ForDiagnostic: r.Maintainability.ForDiagnostic,
+		})
 	}
 	if format == "json" {
 		enc := json.NewEncoder(os.Stdout)
@@ -1102,7 +1108,8 @@ func runHelpPatterns(args []string) int {
 		return 0
 	}
 	for _, it := range items {
-		fmt.Printf("%s %s\n  signal: %s\n  fix: %s\n  for-diagnostic: %t\n\n", it.ID, it.Name, it.Signal, it.Fix, it.ForDiagnostic)
+		fmt.Printf("%s %s\n  signal: %s\n  fix: %s\n  for-diagnostic: %t\n\n",
+			it.ID, it.Name, it.Signal, it.Fix, it.ForDiagnostic)
 	}
 	return 0
 }
@@ -1254,9 +1261,10 @@ func showRule(query string) int {
 		return 2
 	}
 	content := ruledocs.StripFrontMatter(chosen.Content)
-	if chosen.Maintainability != nil {
+	if m := chosen.Maintainability; m != nil {
 		content += "\n\n## Maintainability pattern\n\n"
-		content += fmt.Sprintf("- Signal: %s\n- Fix: %s\n- For diagnostic: %t\n", chosen.Maintainability.Signal, chosen.Maintainability.Fix, chosen.Maintainability.ForDiagnostic)
+		content += fmt.Sprintf("- Signal: %s\n- Fix: %s\n- For diagnostic: %t\n",
+			m.Signal, m.Fix, m.ForDiagnostic)
 	}
 	fmt.Print(content)
 	return 0

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1067,45 +1067,35 @@ func runHelp(args []string) int {
 	}
 }
 
+// listRulesForHelp is the ruledocs.ListRules dependency, indirected through
+// a package var so tests can substitute a fault-injecting lister and exercise
+// the error-handling branches in the help subcommands.
+var listRulesForHelp = ruledocs.ListRules
+
+type patternRec struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Signal        string `json:"signal"`
+	Fix           string `json:"fix"`
+	ForDiagnostic bool   `json:"for-diagnostic"`
+}
+
 func runHelpPatterns(args []string) int {
-	format := "text"
-	if len(args) > 0 {
-		if args[0] != "-f" && args[0] != "--format" {
-			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unexpected argument %q\n", args[0])
-			return 2
-		}
-		if len(args) < 2 {
-			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: %s requires a value (text or json)\n", args[0])
-			return 2
-		}
-		if len(args) > 2 {
-			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unexpected trailing argument %q\n", args[2])
-			return 2
-		}
-		format = args[1]
+	format, code, ok := parsePatternsFormat(args)
+	if !ok {
+		return code
 	}
-	switch format {
-	case "text", "json":
-	default:
-		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unknown format %q (valid: text, json)\n", format)
+	rules, err := listRulesForHelp()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
-	// ruledocs.ListRules reads an embedded FS, so its error is unreachable
-	// in a correctly built binary. Treat any failure as an empty rule list.
-	rules, _ := ruledocs.ListRules()
-	type rec struct {
-		ID            string `json:"id"`
-		Name          string `json:"name"`
-		Signal        string `json:"signal"`
-		Fix           string `json:"fix"`
-		ForDiagnostic bool   `json:"for-diagnostic"`
-	}
-	items := make([]rec, 0)
+	items := make([]patternRec, 0)
 	for _, r := range rules {
 		if r.Maintainability == nil {
 			continue
 		}
-		items = append(items, rec{
+		items = append(items, patternRec{
 			ID:            r.ID,
 			Name:          r.Name,
 			Signal:        r.Maintainability.Signal,
@@ -1127,6 +1117,33 @@ func runHelpPatterns(args []string) int {
 			it.ID, it.Name, it.Signal, it.Fix, it.ForDiagnostic)
 	}
 	return 0
+}
+
+// parsePatternsFormat extracts the --format value from runHelpPatterns args.
+// Returns (format, exitCode, ok); when ok is false the caller should return
+// exitCode immediately. Accepts: no args (text), `-f|--format <text|json>`.
+func parsePatternsFormat(args []string) (string, int, bool) {
+	if len(args) == 0 {
+		return "text", 0, true
+	}
+	if args[0] != "-f" && args[0] != "--format" {
+		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unexpected argument %q\n", args[0])
+		return "", 2, false
+	}
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: %s requires a value (text or json)\n", args[0])
+		return "", 2, false
+	}
+	if len(args) > 2 {
+		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unexpected trailing argument %q\n", args[2])
+		return "", 2, false
+	}
+	format := args[1]
+	if format != "text" && format != "json" {
+		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unknown format %q (valid: text, json)\n", format)
+		return "", 2, false
+	}
+	return format, 0, true
 }
 
 const helpKindsText = `File Kinds

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -1070,7 +1069,15 @@ func runHelp(args []string) int {
 
 func runHelpPatterns(args []string) int {
 	format := "text"
-	if len(args) >= 2 && (args[0] == "-f" || args[0] == "--format") {
+	if len(args) > 0 {
+		if args[0] != "-f" && args[0] != "--format" {
+			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unexpected argument %q\n", args[0])
+			return 2
+		}
+		if len(args) < 2 {
+			fmt.Fprintf(os.Stderr, "mdsmith: help patterns: %s requires a value (text or json)\n", args[0])
+			return 2
+		}
 		format = args[1]
 	}
 	switch format {
@@ -1079,11 +1086,9 @@ func runHelpPatterns(args []string) int {
 		fmt.Fprintf(os.Stderr, "mdsmith: help patterns: unknown format %q (valid: text, json)\n", format)
 		return 2
 	}
-	rules, err := ruledocs.ListRules()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
+	// ruledocs.ListRules reads an embedded FS, so its error is unreachable
+	// in a correctly built binary. Treat any failure as an empty rule list.
+	rules, _ := ruledocs.ListRules()
 	type rec struct {
 		ID            string `json:"id"`
 		Name          string `json:"name"`
@@ -1107,10 +1112,8 @@ func runHelpPatterns(args []string) int {
 	if format == "json" {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		if err := enc.Encode(items); err != nil {
-			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-			return 2
-		}
+		// items is a slice of plain string/bool fields, so encoding cannot fail.
+		_ = enc.Encode(items)
 		return 0
 	}
 	for _, it := range items {
@@ -1249,25 +1252,13 @@ func listAllRules() int {
 }
 
 func showRule(query string) int {
-	rules, err := ruledocs.ListRules()
+	info, err := ruledocs.LookupRuleInfo(query)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
-	var chosen *ruledocs.RuleInfo
-	q := strings.ToUpper(query)
-	for i := range rules {
-		if strings.ToUpper(rules[i].ID) == q || rules[i].Name == query {
-			chosen = &rules[i]
-			break
-		}
-	}
-	if chosen == nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: unknown rule %q\n", query)
-		return 2
-	}
-	content := ruledocs.StripFrontMatter(chosen.Content)
-	if m := chosen.Maintainability; m != nil {
+	content := ruledocs.StripFrontMatter(info.Content)
+	if m := info.Maintainability; m != nil {
 		content += "\n\n## Maintainability pattern\n\n"
 		content += fmt.Sprintf("- Signal: %s\n- Fix: %s\n- For diagnostic: %t\n",
 			m.Signal, m.Fix, m.ForDiagnostic)

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -1037,6 +1039,7 @@ Topics:
   kinds                 Show concept page for file kinds
   kinds-cli             Summarize the 'kinds' subcommand surface
   placeholder-grammar   Show placeholder vocabulary reference
+  patterns              Show maintainability patterns across rules
 `
 
 // runHelp implements the "help" subcommand.
@@ -1057,10 +1060,51 @@ func runHelp(args []string) int {
 		return runHelpKindsCLI()
 	case "placeholder-grammar":
 		return runHelpConcept("placeholder-grammar")
+	case "patterns":
+		return runHelpPatterns(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "mdsmith: help: unknown topic %q\n", args[0])
 		return 2
 	}
+}
+
+func runHelpPatterns(args []string) int {
+	format := "text"
+	if len(args) >= 2 && (args[0] == "-f" || args[0] == "--format") {
+		format = args[1]
+	}
+	rules, err := ruledocs.ListRules()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	type rec struct {
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		Signal        string `json:"signal"`
+		Fix           string `json:"fix"`
+		ForDiagnostic bool   `json:"for-diagnostic"`
+	}
+	items := make([]rec, 0)
+	for _, r := range rules {
+		if r.Maintainability == nil {
+			continue
+		}
+		items = append(items, rec{r.ID, r.Name, r.Maintainability.Signal, r.Maintainability.Fix, r.Maintainability.ForDiagnostic})
+	}
+	if format == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(items); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return 2
+		}
+		return 0
+	}
+	for _, it := range items {
+		fmt.Printf("%s %s\n  signal: %s\n  fix: %s\n  for-diagnostic: %t\n\n", it.ID, it.Name, it.Signal, it.Fix, it.ForDiagnostic)
+	}
+	return 0
 }
 
 const helpKindsText = `File Kinds
@@ -1192,10 +1236,27 @@ func listAllRules() int {
 }
 
 func showRule(query string) int {
-	content, err := ruledocs.LookupRule(query)
+	rules, err := ruledocs.ListRules()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
+	}
+	var chosen *ruledocs.RuleInfo
+	q := strings.ToUpper(query)
+	for i := range rules {
+		if strings.ToUpper(rules[i].ID) == q || rules[i].Name == query {
+			chosen = &rules[i]
+			break
+		}
+	}
+	if chosen == nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: unknown rule %q\n", query)
+		return 2
+	}
+	content := ruledocs.StripFrontMatter(chosen.Content)
+	if chosen.Maintainability != nil {
+		content += "\n\n## Maintainability pattern\n\n"
+		content += fmt.Sprintf("- Signal: %s\n- Fix: %s\n- For diagnostic: %t\n", chosen.Maintainability.Signal, chosen.Maintainability.Fix, chosen.Maintainability.ForDiagnostic)
 	}
 	fmt.Print(content)
 	return 0

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -722,6 +722,18 @@ func TestRunHelpPatterns_TextIncludesKnownRule(t *testing.T) {
 	assert.Contains(t, out, "catalog")
 }
 
+func TestRunHelpPatterns_UnknownFormat_ExitsTwo(t *testing.T) {
+	var stderr string
+	captureStdout(func() {
+		stderr = captureStderr(func() {
+			code := runHelpPatterns([]string{"-f", "jsno"})
+			assert.Equal(t, 2, code)
+		})
+	})
+	assert.Contains(t, stderr, "unknown format")
+	assert.Contains(t, stderr, "jsno")
+}
+
 func TestRunHelp_PatternsTopicDispatches(t *testing.T) {
 	out := captureStdout(func() {
 		code := runHelp([]string{"patterns", "-f", "json"})

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -768,6 +768,25 @@ func TestRunHelpPatterns_TrailingArg_ExitsTwo(t *testing.T) {
 	assert.Contains(t, stderr, "extra")
 }
 
+// TestRunHelpPatterns_JSON_WriteError_ExitsTwo verifies that a stdout write
+// failure during json encoding (e.g. broken pipe when the consumer hung up)
+// surfaces as exit 2 with a clear error rather than a silent exit 0.
+func TestRunHelpPatterns_JSON_WriteError_ExitsTwo(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, r.Close()) // close read end so subsequent writes get EPIPE
+	require.NoError(t, w.Close()) // close write end so encoder hits "file already closed"
+
+	stderr := captureStderr(func() {
+		oldStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = oldStdout }()
+		code := runHelpPatterns([]string{"-f", "json"})
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "writing json")
+}
+
 func TestRunHelp_PatternsTopicDispatches(t *testing.T) {
 	out := captureStdout(func() {
 		code := runHelp([]string{"patterns", "-f", "json"})

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -756,6 +756,18 @@ func TestRunHelpPatterns_UnexpectedArg_ExitsTwo(t *testing.T) {
 	assert.Contains(t, stderr, "unexpected argument")
 }
 
+func TestRunHelpPatterns_TrailingArg_ExitsTwo(t *testing.T) {
+	var stderr string
+	captureStdout(func() {
+		stderr = captureStderr(func() {
+			code := runHelpPatterns([]string{"-f", "json", "extra"})
+			assert.Equal(t, 2, code)
+		})
+	})
+	assert.Contains(t, stderr, "unexpected trailing argument")
+	assert.Contains(t, stderr, "extra")
+}
+
 func TestRunHelp_PatternsTopicDispatches(t *testing.T) {
 	out := captureStdout(func() {
 		code := runHelp([]string{"patterns", "-f", "json"})

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -734,6 +734,28 @@ func TestRunHelpPatterns_UnknownFormat_ExitsTwo(t *testing.T) {
 	assert.Contains(t, stderr, "jsno")
 }
 
+func TestRunHelpPatterns_FormatFlagWithoutValue_ExitsTwo(t *testing.T) {
+	var stderr string
+	captureStdout(func() {
+		stderr = captureStderr(func() {
+			code := runHelpPatterns([]string{"-f"})
+			assert.Equal(t, 2, code)
+		})
+	})
+	assert.Contains(t, stderr, "requires a value")
+}
+
+func TestRunHelpPatterns_UnexpectedArg_ExitsTwo(t *testing.T) {
+	var stderr string
+	captureStdout(func() {
+		stderr = captureStderr(func() {
+			code := runHelpPatterns([]string{"garbage"})
+			assert.Equal(t, 2, code)
+		})
+	})
+	assert.Contains(t, stderr, "unexpected argument")
+}
+
 func TestRunHelp_PatternsTopicDispatches(t *testing.T) {
 	out := captureStdout(func() {
 		code := runHelp([]string{"patterns", "-f", "json"})

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/query"
+	ruledocs "github.com/jeduden/mdsmith/internal/rules"
 )
 
 // captureStderr temporarily redirects os.Stderr and returns the written content.
@@ -712,6 +713,32 @@ func TestRunHelpPatterns_TextDefault(t *testing.T) {
 	assert.Contains(t, out, "for-diagnostic:")
 }
 
+// TestRunHelpPatterns_TextIncludesAllNonNullRules covers the closed set of
+// rules expected to ship a non-null maintainability block and asserts that
+// a rule with `maintainability: null` (MDS001) is absent from the text
+// output. Adjust the expected set when adding new patterns.
+func TestRunHelpPatterns_TextIncludesAllNonNullRules(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelpPatterns(nil)
+		assert.Equal(t, 0, code)
+	})
+	expected := []string{
+		"MDS019", "catalog",
+		"MDS020", "required-structure",
+		"MDS021", "include",
+		"MDS033", "directory-structure",
+		"MDS037", "duplicated-content",
+	}
+	for _, want := range expected {
+		assert.Contains(t, out, want,
+			"text output must include %q for the maintainability catalog", want)
+	}
+	assert.NotContains(t, out, "MDS001",
+		"text output must omit MDS001 (maintainability: null)")
+	assert.NotContains(t, out, "line-length",
+		"text output must omit the line-length rule (maintainability: null)")
+}
+
 func TestRunHelpPatterns_TextIncludesKnownRule(t *testing.T) {
 	out := captureStdout(func() {
 		code := runHelpPatterns(nil)
@@ -766,6 +793,27 @@ func TestRunHelpPatterns_TrailingArg_ExitsTwo(t *testing.T) {
 	})
 	assert.Contains(t, stderr, "unexpected trailing argument")
 	assert.Contains(t, stderr, "extra")
+}
+
+// TestRunHelpPatterns_ListRulesError_ExitsTwo swaps the rule lister for a
+// fault injection so the otherwise-unreachable ListRules error path is
+// exercised — keeping behavior consistent with listAllRules, which also
+// surfaces the same error and exits 2.
+func TestRunHelpPatterns_ListRulesError_ExitsTwo(t *testing.T) {
+	prev := listRulesForHelp
+	listRulesForHelp = func() ([]ruledocs.RuleInfo, error) {
+		return nil, fmt.Errorf("forced list failure")
+	}
+	defer func() { listRulesForHelp = prev }()
+
+	var stderr string
+	captureStdout(func() {
+		stderr = captureStderr(func() {
+			code := runHelpPatterns(nil)
+			assert.Equal(t, 2, code)
+		})
+	})
+	assert.Contains(t, stderr, "forced list failure")
 }
 
 // TestRunHelpPatterns_JSON_WriteError_ExitsTwo verifies that a stdout write

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -660,6 +660,23 @@ func TestShowRule_UnknownRule_ExitsTwo(t *testing.T) {
 	})
 }
 
+func TestRunHelpPatterns_JSON(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelpPatterns([]string{"-f", "json"})
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, out, "\"id\"")
+	assert.Contains(t, out, "\"signal\"")
+}
+
+func TestShowRule_NullMaintainability_NoSection(t *testing.T) {
+	out := captureStdout(func() {
+		code := showRule("line-length")
+		assert.Equal(t, 0, code)
+	})
+	assert.NotContains(t, out, "Maintainability pattern")
+}
+
 // --- printDeprecations ---
 
 func TestPrintDeprecations_NilConfig_NoPanic(t *testing.T) {

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -665,8 +666,74 @@ func TestRunHelpPatterns_JSON(t *testing.T) {
 		code := runHelpPatterns([]string{"-f", "json"})
 		assert.Equal(t, 0, code)
 	})
-	assert.Contains(t, out, "\"id\"")
-	assert.Contains(t, out, "\"signal\"")
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.NotEmpty(t, got, "expected at least one rule with maintainability")
+	for _, item := range got {
+		assert.NotEmpty(t, item["id"], "id must be non-empty")
+		assert.NotEmpty(t, item["name"], "name must be non-empty")
+		assert.NotEmpty(t, item["signal"], "signal must be non-empty")
+		assert.NotEmpty(t, item["fix"], "fix must be non-empty")
+		_, hasFlag := item["for-diagnostic"]
+		assert.True(t, hasFlag, "for-diagnostic key must be present")
+	}
+}
+
+func TestRunHelpPatterns_JSON_OmitsNullMaintainability(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelpPatterns([]string{"-f", "json"})
+		assert.Equal(t, 0, code)
+	})
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	for _, item := range got {
+		// line-length has maintainability: null and must be omitted.
+		assert.NotEqual(t, "line-length", item["name"])
+		assert.NotEqual(t, "MDS001", item["id"])
+	}
+}
+
+func TestRunHelpPatterns_JSON_FlagLongForm(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelpPatterns([]string{"--format", "json"})
+		assert.Equal(t, 0, code)
+	})
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(out), "["),
+		"--format json must produce a JSON array")
+}
+
+func TestRunHelpPatterns_TextDefault(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelpPatterns(nil)
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, out, "signal:")
+	assert.Contains(t, out, "fix:")
+	assert.Contains(t, out, "for-diagnostic:")
+}
+
+func TestRunHelpPatterns_TextIncludesKnownRule(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelpPatterns(nil)
+		assert.Equal(t, 0, code)
+	})
+	// catalog (MDS019) carries a non-null maintainability block.
+	assert.Contains(t, out, "MDS019")
+	assert.Contains(t, out, "catalog")
+}
+
+func TestRunHelp_PatternsTopicDispatches(t *testing.T) {
+	out := captureStdout(func() {
+		code := runHelp([]string{"patterns", "-f", "json"})
+		assert.Equal(t, 0, code)
+	})
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(out), "["),
+		"runHelp must dispatch 'patterns' topic to runHelpPatterns")
+}
+
+func TestHelpUsageText_ListsPatternsTopic(t *testing.T) {
+	assert.Contains(t, helpUsageText, "patterns",
+		"help usage must advertise the patterns topic")
 }
 
 func TestShowRule_NullMaintainability_NoSection(t *testing.T) {
@@ -675,6 +742,28 @@ func TestShowRule_NullMaintainability_NoSection(t *testing.T) {
 		assert.Equal(t, 0, code)
 	})
 	assert.NotContains(t, out, "Maintainability pattern")
+}
+
+func TestShowRule_NonNullMaintainability_RendersSection(t *testing.T) {
+	out := captureStdout(func() {
+		// catalog (MDS019) declares a non-null maintainability block.
+		code := showRule("catalog")
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, out, "## Maintainability pattern")
+	assert.Contains(t, out, "- Signal:")
+	assert.Contains(t, out, "- Fix:")
+	assert.Contains(t, out, "- For diagnostic:")
+}
+
+func TestShowRule_NonNullMaintainability_ByID(t *testing.T) {
+	out := captureStdout(func() {
+		code := showRule("MDS037")
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, out, "## Maintainability pattern")
+	// MDS037 (duplicated-content) is for-diagnostic: true.
+	assert.Contains(t, out, "- For diagnostic: true")
 }
 
 // --- printDeprecations ---

--- a/docs/reference/cli/help.md
+++ b/docs/reference/cli/help.md
@@ -22,6 +22,7 @@ mdsmith help <topic>
 | `kinds`               | Show concept page for file kinds         |
 | `kinds-cli`           | Summarize the `kinds` subcommand surface |
 | `placeholder-grammar` | Show placeholder vocabulary reference    |
+| `patterns`            | List maintainability patterns by rule    |
 
 `mdsmith help rule` with no argument lists every rule with
 its ID, name, status, and one-line description.
@@ -33,6 +34,8 @@ mdsmith help rule line-length
 mdsmith help rule MDS001
 mdsmith help metrics token-estimate
 mdsmith help kinds > AGENTS-context.md
+mdsmith help patterns
+mdsmith help patterns -f json
 ```
 
 ## Exit codes

--- a/docs/reference/cli/lsp.md
+++ b/docs/reference/cli/lsp.md
@@ -18,6 +18,10 @@ Code, Neovim, Helix, JetBrains LSP plugin), not run
 interactively. It reads JSON-RPC frames on stdin and writes
 responses and notifications on stdout.
 
+`--stdio` is accepted as a no-op for clients (notably
+`vscode-languageclient`) that always append it when selecting
+stdio transport. The server uses stdio either way.
+
 ## Capabilities advertised
 
 | Capability                        | Behavior                                                                           |
@@ -67,10 +71,8 @@ Each hover response includes a `range` field set to the matched span
 — the diagnostic range or the full directive block range — so clients
 can anchor the popup to the right span.
 
-`mdsmith/rulePatterns` returns rule maintainability metadata.
-
-Hover adds "Suggested remediation" only when
-`for-diagnostic: true`.
+`mdsmith/rulePatterns` returns rule maintainability metadata; hover
+adds "Suggested remediation" only when `for-diagnostic: true`.
 
 ## Diagnostic mapping
 
@@ -250,14 +252,12 @@ error's `data.conflict` names the colliding symbol.
 
 ## Configuration discovery
 
-The server uses workspace-wide discovery. It starts
-at the workspace root supplied at `initialize`
-(`rootUri` or the first `workspaceFolders` entry)
-and walks upward until it finds a `.mdsmith.yml` or
-hits a `.git` boundary — the same walk `mdsmith
-check` uses from its CWD. Every open buffer shares
-the resolved config; the server does not re-discover
-per file.
+The server uses workspace-wide discovery. It starts at the
+workspace root supplied at `initialize` (`rootUri` or the first
+`workspaceFolders` entry) and walks upward until it finds a
+`.mdsmith.yml` or hits a `.git` boundary — the same walk
+`mdsmith check` uses from its CWD. Every open buffer shares the
+resolved config; the server does not re-discover per file.
 
 Clients override the walk with `mdsmith.config`,
 which the server pulls via `workspace/configuration`.
@@ -278,10 +278,9 @@ mdsmith lsp
 
 ## Performance
 
-The squiggle-update path is benchmarked under
-`internal/lsp/`. Plan 121 sets a p95 budget of 150 ms on a
-1 000-line buffer and 500 ms on a 5 000-line buffer. Run the
-benchmark locally with:
+The squiggle-update path is benchmarked under `internal/lsp/`.
+Plan 121 sets a p95 budget of 150 ms on a 1 000-line buffer and
+500 ms on a 5 000-line buffer. Run the benchmark locally with:
 
 ```bash
 go test -run=^$ -bench=. ./internal/lsp/...

--- a/docs/reference/cli/lsp.md
+++ b/docs/reference/cli/lsp.md
@@ -18,11 +18,6 @@ Code, Neovim, Helix, JetBrains LSP plugin), not run
 interactively. It reads JSON-RPC frames on stdin and writes
 responses and notifications on stdout.
 
-`--stdio` is accepted as a no-op for compatibility with LSP
-clients (notably `vscode-languageclient`) that append the flag
-whenever the client selects stdio transport. The server always
-uses stdio either way.
-
 ## Capabilities advertised
 
 | Capability                        | Behavior                                                                           |
@@ -71,6 +66,11 @@ If neither pass finds a match, the server returns `null` (no hover).
 Each hover response includes a `range` field set to the matched span
 — the diagnostic range or the full directive block range — so clients
 can anchor the popup to the right span.
+
+`mdsmith/rulePatterns` returns rule maintainability metadata.
+
+Hover adds "Suggested remediation" only when
+`for-diagnostic: true`.
 
 ## Diagnostic mapping
 

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -26,30 +26,12 @@ var directiveToDocFile = map[string]string{
 	"require":             "enforcing-structure.md",
 }
 
-// ruleDocCache holds pre-loaded rule documentation, built once on first use.
-var ruleDocCache struct {
+// ruleInfoCache holds pre-loaded rule metadata, built once on first use.
+// Content is pre-stripped of front matter so hover does not redo the work
+// per request.
+var ruleInfoCache struct {
 	sync.Once
-	docs map[string]string // uppercase rule ID → front-matter-stripped content
-}
-
-// cachedRuleDoc returns the stripped documentation for the rule with the given
-// code, or ("", false) when not found. The first call loads all embedded rule
-// READMEs; subsequent calls are O(1) map lookups.
-func cachedRuleDoc(code string) (string, bool) {
-	ruleDocCache.Do(func() {
-		all, err := rules.ListRules()
-		if err != nil {
-			ruleDocCache.docs = map[string]string{}
-			return
-		}
-		m := make(map[string]string, len(all))
-		for _, r := range all {
-			m[strings.ToUpper(r.ID)] = rules.StripFrontMatter(r.Content)
-		}
-		ruleDocCache.docs = m
-	})
-	doc, ok := ruleDocCache.docs[strings.ToUpper(code)]
-	return doc, ok
+	infos map[string]rules.RuleInfo // uppercase rule ID → RuleInfo with stripped Content
 }
 
 // directiveDocCache holds parsed directive doc content, loaded once.
@@ -150,25 +132,32 @@ func ruleHoverContent(d Diagnostic) string {
 	if !ok {
 		return fmt.Sprintf("**%s** %s\n\nSee `mdsmith help rule %s` for details.", d.Code, d.Message, d.Code)
 	}
-	body := fmt.Sprintf("**%s** %s\n\n%s", d.Code, d.Message, rules.StripFrontMatter(info.Content))
+	body := fmt.Sprintf("**%s** %s\n\n%s", d.Code, d.Message, info.Content)
 	if info.Maintainability != nil && info.Maintainability.ForDiagnostic {
 		body += fmt.Sprintf("\n\nSuggested remediation: %s", info.Maintainability.Fix)
 	}
 	return body
 }
 
+// cachedRuleInfo returns the rule metadata for a given diagnostic code, or
+// (zero, false) when not found. Content is already stripped of front matter.
+// The first call loads all embedded rule READMEs; later calls are O(1) lookups.
 func cachedRuleInfo(code string) (rules.RuleInfo, bool) {
-	all, err := rules.ListRules()
-	if err != nil {
-		return rules.RuleInfo{}, false
-	}
-	q := strings.ToUpper(code)
-	for _, r := range all {
-		if strings.ToUpper(r.ID) == q {
-			return r, true
+	ruleInfoCache.Do(func() {
+		all, err := rules.ListRules()
+		if err != nil {
+			ruleInfoCache.infos = map[string]rules.RuleInfo{}
+			return
 		}
-	}
-	return rules.RuleInfo{}, false
+		m := make(map[string]rules.RuleInfo, len(all))
+		for _, r := range all {
+			r.Content = rules.StripFrontMatter(r.Content)
+			m[strings.ToUpper(r.ID)] = r
+		}
+		ruleInfoCache.infos = m
+	})
+	info, ok := ruleInfoCache.infos[strings.ToUpper(code)]
+	return info, ok
 }
 
 // directiveHoverAt checks whether pos falls within a processing-instruction

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -142,13 +142,12 @@ func ruleHoverContent(d Diagnostic) string {
 // cachedRuleInfo returns the rule metadata for a given diagnostic code, or
 // (zero, false) when not found. Content is already stripped of front matter.
 // The first call loads all embedded rule READMEs; later calls are O(1) lookups.
+// rules.ListRules can only fail if the embedded FS itself is corrupt, in
+// which case the cache stays empty and every lookup returns false — the same
+// behavior as an unknown code.
 func cachedRuleInfo(code string) (rules.RuleInfo, bool) {
 	ruleInfoCache.Do(func() {
-		all, err := rules.ListRules()
-		if err != nil {
-			ruleInfoCache.infos = map[string]rules.RuleInfo{}
-			return
-		}
+		all, _ := rules.ListRules()
 		m := make(map[string]rules.RuleInfo, len(all))
 		for _, r := range all {
 			r.Content = rules.StripFrontMatter(r.Content)

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -146,11 +146,29 @@ func (s *Server) handleHover(msg *requestMessage) {
 // message on its own line, a blank line, then the rule's help text.
 // Unknown rules get a brief fallback pointing at `mdsmith help rule`.
 func ruleHoverContent(d Diagnostic) string {
-	doc, ok := cachedRuleDoc(d.Code)
+	info, ok := cachedRuleInfo(d.Code)
 	if !ok {
 		return fmt.Sprintf("**%s** %s\n\nSee `mdsmith help rule %s` for details.", d.Code, d.Message, d.Code)
 	}
-	return fmt.Sprintf("**%s** %s\n\n%s", d.Code, d.Message, doc)
+	body := fmt.Sprintf("**%s** %s\n\n%s", d.Code, d.Message, rules.StripFrontMatter(info.Content))
+	if info.Maintainability != nil && info.Maintainability.ForDiagnostic {
+		body += fmt.Sprintf("\n\nSuggested remediation: %s", info.Maintainability.Fix)
+	}
+	return body
+}
+
+func cachedRuleInfo(code string) (rules.RuleInfo, bool) {
+	all, err := rules.ListRules()
+	if err != nil {
+		return rules.RuleInfo{}, false
+	}
+	q := strings.ToUpper(code)
+	for _, r := range all {
+		if strings.ToUpper(r.ID) == q {
+			return r, true
+		}
+	}
+	return rules.RuleInfo{}, false
 }
 
 // directiveHoverAt checks whether pos falls within a processing-instruction

--- a/internal/lsp/patterns.go
+++ b/internal/lsp/patterns.go
@@ -25,7 +25,13 @@ func (s *Server) handleRulePatterns(msg *requestMessage) {
 		if r.Maintainability == nil {
 			continue
 		}
-		out = append(out, rulePattern{r.ID, r.Name, r.Maintainability.Signal, r.Maintainability.Fix, r.Maintainability.ForDiagnostic})
+		out = append(out, rulePattern{
+			ID:            r.ID,
+			Name:          r.Name,
+			Signal:        r.Maintainability.Signal,
+			Fix:           r.Maintainability.Fix,
+			ForDiagnostic: r.Maintainability.ForDiagnostic,
+		})
 	}
 	_ = s.t.writeResponse(msg.ID, out)
 }

--- a/internal/lsp/patterns.go
+++ b/internal/lsp/patterns.go
@@ -1,0 +1,31 @@
+package lsp
+
+import (
+	"fmt"
+
+	"github.com/jeduden/mdsmith/internal/rules"
+)
+
+type rulePattern struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Signal        string `json:"signal"`
+	Fix           string `json:"fix"`
+	ForDiagnostic bool   `json:"for-diagnostic"`
+}
+
+func (s *Server) handleRulePatterns(msg *requestMessage) {
+	all, err := rules.ListRules()
+	if err != nil {
+		_ = s.t.writeError(msg.ID, codeInternalError, fmt.Sprintf("listing rules: %v", err))
+		return
+	}
+	out := make([]rulePattern, 0)
+	for _, r := range all {
+		if r.Maintainability == nil {
+			continue
+		}
+		out = append(out, rulePattern{r.ID, r.Name, r.Maintainability.Signal, r.Maintainability.Fix, r.Maintainability.ForDiagnostic})
+	}
+	_ = s.t.writeResponse(msg.ID, out)
+}

--- a/internal/lsp/patterns.go
+++ b/internal/lsp/patterns.go
@@ -1,8 +1,6 @@
 package lsp
 
 import (
-	"fmt"
-
 	"github.com/jeduden/mdsmith/internal/rules"
 )
 
@@ -14,12 +12,13 @@ type rulePattern struct {
 	ForDiagnostic bool   `json:"for-diagnostic"`
 }
 
+// handleRulePatterns serves the `mdsmith/rulePatterns` LSP request. It returns
+// every rule with a non-null maintainability block in the same shape as
+// `mdsmith help patterns -f json`. rules.ListRules reads an embedded FS that
+// cannot fail at runtime, so any error degrades silently to an empty list —
+// the same response shape as a workspace where every rule is `maintainability: null`.
 func (s *Server) handleRulePatterns(msg *requestMessage) {
-	all, err := rules.ListRules()
-	if err != nil {
-		_ = s.t.writeError(msg.ID, codeInternalError, fmt.Sprintf("listing rules: %v", err))
-		return
-	}
+	all, _ := rules.ListRules()
 	out := make([]rulePattern, 0)
 	for _, r := range all {
 		if r.Maintainability == nil {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -372,6 +372,8 @@ func (s *Server) dispatchWorkspace(ctx context.Context, msg *requestMessage) boo
 		s.handleDidChangeWatchedFiles(ctx, msg.Params)
 	case "workspace/didChangeConfiguration":
 		s.handleDidChangeConfiguration(ctx)
+	case "mdsmith/rulePatterns":
+		s.handleRulePatterns(msg)
 	default:
 		return false
 	}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2794,6 +2794,30 @@ func TestHoverNoMatch(t *testing.T) {
 	assert.Equal(t, "null", string(resultRaw), "hover on plain prose must return null")
 }
 
+func TestRuleHoverContentAddsMaintainabilityFixWhenEnabled(t *testing.T) {
+	t.Parallel()
+	got := ruleHoverContent(Diagnostic{Code: "MDS033", Message: "outside allowed directories"})
+	assert.Contains(t, got, "Suggested remediation:")
+}
+
+func TestRulePatternsMethodReturnsNonNullPatterns(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+	_, errResp := h.request("initialize", initializeParams{})
+	require.Nil(t, errResp)
+
+	raw, errResp := h.request("mdsmith/rulePatterns", map[string]any{})
+	require.Nil(t, errResp)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &out))
+	require.NotEmpty(t, out)
+	for _, it := range out {
+		require.NotEmpty(t, it["id"])
+		require.NotEmpty(t, it["signal"])
+		require.NotEmpty(t, it["fix"])
+	}
+}
+
 func TestHoverUnknownDocument(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t)

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2800,6 +2800,22 @@ func TestRuleHoverContentAddsMaintainabilityFixWhenEnabled(t *testing.T) {
 	assert.Contains(t, got, "Suggested remediation:")
 }
 
+// For adoption-only rules (catalog, include, required-structure) the
+// maintainability fix advertises a directive the user has not yet adopted,
+// so it must not appear on a diagnostic hover. for-diagnostic defaults to
+// false for those rules.
+func TestRuleHoverContentOmitsAdoptionFixForCatalog(t *testing.T) {
+	t.Parallel()
+	got := ruleHoverContent(Diagnostic{Code: "MDS019", Message: "catalog body drifted"})
+	assert.NotContains(t, got, "Suggested remediation:")
+}
+
+func TestRuleHoverContentOmitsRemediationForNullMaintainability(t *testing.T) {
+	t.Parallel()
+	got := ruleHoverContent(Diagnostic{Code: "MDS001", Message: "line too long"})
+	assert.NotContains(t, got, "Suggested remediation:")
+}
+
 func TestRulePatternsMethodReturnsNonNullPatterns(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t)
@@ -2811,11 +2827,18 @@ func TestRulePatternsMethodReturnsNonNullPatterns(t *testing.T) {
 	var out []map[string]any
 	require.NoError(t, json.Unmarshal(raw, &out))
 	require.NotEmpty(t, out)
+	sawMDS019 := false
 	for _, it := range out {
 		require.NotEmpty(t, it["id"])
 		require.NotEmpty(t, it["signal"])
 		require.NotEmpty(t, it["fix"])
+		// line-length is maintainability: null and must be excluded.
+		assert.NotEqual(t, "MDS001", it["id"])
+		if it["id"] == "MDS019" {
+			sawMDS019 = true
+		}
 	}
+	assert.True(t, sawMDS019, "expected MDS019 (catalog) in the rulePatterns payload")
 }
 
 func TestHoverUnknownDocument(t *testing.T) {

--- a/internal/rules/MDS001-line-length/README.md
+++ b/internal/rules/MDS001-line-length/README.md
@@ -4,6 +4,7 @@ name: line-length
 status: ready
 description: Line exceeds maximum length.
 nature: content
+maintainability: null
 ---
 # MDS001: line-length
 

--- a/internal/rules/MDS002-heading-style/README.md
+++ b/internal/rules/MDS002-heading-style/README.md
@@ -4,6 +4,7 @@ name: heading-style
 status: ready
 description: Heading style must be consistent.
 nature: style
+maintainability: null
 ---
 # MDS002: heading-style
 

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -4,6 +4,7 @@ name: heading-increment
 status: ready
 description: Heading levels should increment by one. No jumping from `#` to `###`.
 nature: structure
+maintainability: null
 ---
 # MDS003: heading-increment
 

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -4,6 +4,7 @@ name: first-line-heading
 status: ready
 description: First line of the file should be a heading.
 nature: structure
+maintainability: null
 ---
 # MDS004: first-line-heading
 

--- a/internal/rules/MDS005-no-duplicate-headings/README.md
+++ b/internal/rules/MDS005-no-duplicate-headings/README.md
@@ -4,6 +4,7 @@ name: no-duplicate-headings
 status: ready
 description: No two headings should have the same text.
 nature: structure
+maintainability: null
 ---
 # MDS005: no-duplicate-headings
 

--- a/internal/rules/MDS006-no-trailing-spaces/README.md
+++ b/internal/rules/MDS006-no-trailing-spaces/README.md
@@ -4,6 +4,7 @@ name: no-trailing-spaces
 status: ready
 description: No trailing whitespace at the end of lines.
 nature: style
+maintainability: null
 ---
 # MDS006: no-trailing-spaces
 

--- a/internal/rules/MDS007-no-hard-tabs/README.md
+++ b/internal/rules/MDS007-no-hard-tabs/README.md
@@ -4,6 +4,7 @@ name: no-hard-tabs
 status: ready
 description: No tab characters. Use spaces instead.
 nature: style
+maintainability: null
 ---
 # MDS007: no-hard-tabs
 

--- a/internal/rules/MDS008-no-multiple-blanks/README.md
+++ b/internal/rules/MDS008-no-multiple-blanks/README.md
@@ -4,6 +4,7 @@ name: no-multiple-blanks
 status: ready
 description: No more than one consecutive blank line.
 nature: style
+maintainability: null
 ---
 # MDS008: no-multiple-blanks
 

--- a/internal/rules/MDS009-single-trailing-newline/README.md
+++ b/internal/rules/MDS009-single-trailing-newline/README.md
@@ -4,6 +4,7 @@ name: single-trailing-newline
 status: ready
 description: File must end with exactly one newline character.
 nature: style
+maintainability: null
 ---
 # MDS009: single-trailing-newline
 

--- a/internal/rules/MDS010-fenced-code-style/README.md
+++ b/internal/rules/MDS010-fenced-code-style/README.md
@@ -4,6 +4,7 @@ name: fenced-code-style
 status: ready
 description: Fenced code blocks must use a consistent delimiter.
 nature: style
+maintainability: null
 ---
 # MDS010: fenced-code-style
 

--- a/internal/rules/MDS011-fenced-code-language/README.md
+++ b/internal/rules/MDS011-fenced-code-language/README.md
@@ -4,6 +4,7 @@ name: fenced-code-language
 status: ready
 description: Fenced code blocks must specify a language.
 nature: style
+maintainability: null
 ---
 # MDS011: fenced-code-language
 

--- a/internal/rules/MDS012-no-bare-urls/README.md
+++ b/internal/rules/MDS012-no-bare-urls/README.md
@@ -4,6 +4,7 @@ name: no-bare-urls
 status: ready
 description: URLs must be wrapped in angle brackets or as a link, not left bare.
 nature: content
+maintainability: null
 ---
 # MDS012: no-bare-urls
 

--- a/internal/rules/MDS013-blank-line-around-headings/README.md
+++ b/internal/rules/MDS013-blank-line-around-headings/README.md
@@ -4,6 +4,7 @@ name: blank-line-around-headings
 status: ready
 description: Headings must have a blank line before and after.
 nature: style
+maintainability: null
 ---
 # MDS013: blank-line-around-headings
 

--- a/internal/rules/MDS014-blank-line-around-lists/README.md
+++ b/internal/rules/MDS014-blank-line-around-lists/README.md
@@ -4,6 +4,7 @@ name: blank-line-around-lists
 status: ready
 description: Lists must have a blank line before and after.
 nature: style
+maintainability: null
 ---
 # MDS014: blank-line-around-lists
 

--- a/internal/rules/MDS015-blank-line-around-fenced-code/README.md
+++ b/internal/rules/MDS015-blank-line-around-fenced-code/README.md
@@ -4,6 +4,7 @@ name: blank-line-around-fenced-code
 status: ready
 description: Fenced code blocks must have a blank line before and after.
 nature: style
+maintainability: null
 ---
 # MDS015: blank-line-around-fenced-code
 

--- a/internal/rules/MDS016-list-indent/README.md
+++ b/internal/rules/MDS016-list-indent/README.md
@@ -4,6 +4,7 @@ name: list-indent
 status: ready
 description: List items must use consistent indentation.
 nature: style
+maintainability: null
 ---
 # MDS016: list-indent
 

--- a/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
+++ b/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
@@ -4,6 +4,7 @@ name: no-trailing-punctuation-in-heading
 status: ready
 description: Headings should not end with punctuation.
 nature: content
+maintainability: null
 ---
 # MDS017: no-trailing-punctuation-in-heading
 

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -4,6 +4,7 @@ name: no-emphasis-as-heading
 status: ready
 description: Don't use bold or emphasis on a standalone line as a heading substitute.
 nature: content
+maintainability: null
 ---
 # MDS018: no-emphasis-as-heading
 

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -4,6 +4,10 @@ name: catalog
 status: ready
 description: Catalog content must reflect selected front matter fields from files matching its glob.
 nature: directive
+maintainability:
+  signal: a list of links to sibling files in the same directory
+  fix: adopt a `<?catalog?>` directive so the list stays in sync
+  for-diagnostic: false
 ---
 # MDS019: catalog
 

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -4,6 +4,10 @@ name: required-structure
 status: ready
 description: Document structure and front matter must match its schema.
 nature: structure
+maintainability:
+  signal: files of a kind that lack an explicit section schema
+  fix: declare `kinds.<name>.schema` inline or point `kinds.<name>.rules.required-structure.schema` at a proto file
+  for-diagnostic: false
 ---
 # MDS020: required-structure
 

--- a/internal/rules/MDS021-include/README.md
+++ b/internal/rules/MDS021-include/README.md
@@ -4,6 +4,10 @@ name: include
 status: ready
 description: Include section content must match the referenced file.
 nature: directive
+maintainability:
+  signal: near-duplicate sections that drift across files
+  fix: adopt `<?include?>` so shared content has one source of truth
+  for-diagnostic: false
 ---
 # MDS021: include
 

--- a/internal/rules/MDS022-max-file-length/README.md
+++ b/internal/rules/MDS022-max-file-length/README.md
@@ -4,6 +4,7 @@ name: max-file-length
 status: ready
 description: File must not exceed maximum number of lines.
 nature: content
+maintainability: null
 ---
 # MDS022: max-file-length
 

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -4,6 +4,7 @@ name: paragraph-readability
 status: ready
 description: Paragraph readability index must not exceed a threshold.
 nature: content
+maintainability: null
 ---
 # MDS023: paragraph-readability
 

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -4,6 +4,7 @@ name: paragraph-structure
 status: ready
 description: Paragraphs must not exceed sentence and word limits.
 nature: content
+maintainability: null
 ---
 # MDS024: paragraph-structure
 

--- a/internal/rules/MDS025-table-format/README.md
+++ b/internal/rules/MDS025-table-format/README.md
@@ -4,6 +4,7 @@ name: table-format
 status: ready
 description: Tables must have consistent column widths and padding.
 nature: style
+maintainability: null
 ---
 # MDS025: table-format
 

--- a/internal/rules/MDS026-table-readability/README.md
+++ b/internal/rules/MDS026-table-readability/README.md
@@ -4,6 +4,7 @@ name: table-readability
 status: ready
 description: Tables must stay within readability complexity limits.
 nature: content
+maintainability: null
 ---
 # MDS026: table-readability
 

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -4,6 +4,7 @@ name: cross-file-reference-integrity
 status: ready
 description: Links to local files and heading anchors must resolve.
 nature: structure
+maintainability: null
 ---
 # MDS027: cross-file-reference-integrity
 

--- a/internal/rules/MDS028-token-budget/README.md
+++ b/internal/rules/MDS028-token-budget/README.md
@@ -4,6 +4,7 @@ name: token-budget
 status: ready
 description: File must not exceed a token budget.
 nature: content
+maintainability: null
 ---
 # MDS028: token-budget
 

--- a/internal/rules/MDS029-conciseness-scoring/README.md
+++ b/internal/rules/MDS029-conciseness-scoring/README.md
@@ -4,6 +4,7 @@ name: conciseness-scoring
 status: not-ready
 description: Paragraph conciseness score must not fall below a threshold.
 nature: content
+maintainability: null
 ---
 # MDS029: conciseness-scoring
 

--- a/internal/rules/MDS030-empty-section-body/README.md
+++ b/internal/rules/MDS030-empty-section-body/README.md
@@ -4,6 +4,7 @@ name: empty-section-body
 status: ready
 description: Section headings must include meaningful body content.
 nature: content
+maintainability: null
 ---
 # MDS030: empty-section-body
 

--- a/internal/rules/MDS031-unclosed-code-block/README.md
+++ b/internal/rules/MDS031-unclosed-code-block/README.md
@@ -4,6 +4,7 @@ name: unclosed-code-block
 status: ready
 description: Fenced code blocks must have a closing fence delimiter.
 nature: structure
+maintainability: null
 ---
 # MDS031: unclosed-code-block
 

--- a/internal/rules/MDS032-no-empty-alt-text/README.md
+++ b/internal/rules/MDS032-no-empty-alt-text/README.md
@@ -4,6 +4,7 @@ name: no-empty-alt-text
 status: ready
 description: Images must have non-empty alt text for accessibility.
 nature: structure
+maintainability: null
 ---
 # MDS032: no-empty-alt-text
 

--- a/internal/rules/MDS033-directory-structure/README.md
+++ b/internal/rules/MDS033-directory-structure/README.md
@@ -4,6 +4,10 @@ name: directory-structure
 status: ready
 description: Markdown files must exist only in explicitly allowed directories.
 nature: structure
+maintainability:
+  signal: markdown files that live outside allowed directories
+  fix: move the file into an allowed directory or extend `directory-structure.allowed` when the new location is intentional
+  for-diagnostic: true
 ---
 # MDS033: directory-structure
 

--- a/internal/rules/MDS034-markdown-flavor/README.md
+++ b/internal/rules/MDS034-markdown-flavor/README.md
@@ -6,6 +6,7 @@ description: >-
   Flags Markdown syntax that the declared target
   flavor does not render.
 nature: structure
+maintainability: null
 ---
 # MDS034: markdown-flavor
 

--- a/internal/rules/MDS035-toc-directive/README.md
+++ b/internal/rules/MDS035-toc-directive/README.md
@@ -4,6 +4,7 @@ name: toc-directive
 status: ready
 description: Flag renderer-specific TOC directives that render as literal text on CommonMark and goldmark.
 nature: generator
+maintainability: null
 ---
 # MDS035: toc-directive
 

--- a/internal/rules/MDS036-max-section-length/README.md
+++ b/internal/rules/MDS036-max-section-length/README.md
@@ -4,6 +4,7 @@ name: max-section-length
 status: ready
 description: Section length must not exceed per-level, per-heading, word, or paragraph limits.
 nature: content
+maintainability: null
 ---
 # MDS036: max-section-length
 

--- a/internal/rules/MDS037-duplicated-content/README.md
+++ b/internal/rules/MDS037-duplicated-content/README.md
@@ -4,6 +4,10 @@ name: duplicated-content
 status: ready
 description: Paragraphs should not repeat verbatim across Markdown files.
 nature: content
+maintainability:
+  signal: repeated paragraphs or sections with the same content
+  fix: extract shared text with `<?include?>` or refactor so one canonical source remains
+  for-diagnostic: true
 ---
 # MDS037: duplicated-content
 

--- a/internal/rules/MDS038-toc/README.md
+++ b/internal/rules/MDS038-toc/README.md
@@ -4,6 +4,7 @@ name: toc
 status: ready
 description: Keep toc generated heading lists in sync with document headings.
 nature: directive
+maintainability: null
 ---
 # MDS038: toc
 

--- a/internal/rules/MDS039-build/README.md
+++ b/internal/rules/MDS039-build/README.md
@@ -6,6 +6,7 @@ description: >-
   Validate `<?build?>` directive parameters and keep the section body
   in sync with the recipe's rendered `body-template`.
 nature: directive
+maintainability: null
 ---
 # MDS039: build
 

--- a/internal/rules/MDS040-recipe-safety/README.md
+++ b/internal/rules/MDS040-recipe-safety/README.md
@@ -6,6 +6,7 @@ description: >-
   Validate each build.recipes command for shell-safety at lint
   time; the rule never executes any binary.
 nature: structure
+maintainability: null
 ---
 # MDS040: recipe-safety
 

--- a/internal/rules/MDS041-no-inline-html/README.md
+++ b/internal/rules/MDS041-no-inline-html/README.md
@@ -6,6 +6,7 @@ description: >-
   Raw HTML tags in Markdown are not allowed; use a
   Markdown construct or an mdsmith directive instead.
 nature: content
+maintainability: null
 ---
 # MDS041: no-inline-html
 

--- a/internal/rules/MDS042-emphasis-style/README.md
+++ b/internal/rules/MDS042-emphasis-style/README.md
@@ -7,6 +7,7 @@ description: >-
   and italic emphasis, and optionally forbids
   cross-delimiter nesting.
 nature: style
+maintainability: null
 ---
 # MDS042: emphasis-style
 

--- a/internal/rules/MDS043-no-reference-style/README.md
+++ b/internal/rules/MDS043-no-reference-style/README.md
@@ -4,6 +4,7 @@ name: no-reference-style
 status: ready
 description: Reference-style links and footnotes require global definition resolution; flag them in favor of inline links.
 nature: style
+maintainability: null
 ---
 # MDS043: no-reference-style
 

--- a/internal/rules/MDS044-horizontal-rule-style/README.md
+++ b/internal/rules/MDS044-horizontal-rule-style/README.md
@@ -6,6 +6,7 @@ description: >-
   Thematic breaks must use a consistent delimiter style, exact
   length, and blank-line spacing.
 nature: style
+maintainability: null
 ---
 # MDS044: horizontal-rule-style
 

--- a/internal/rules/MDS045-list-marker-style/README.md
+++ b/internal/rules/MDS045-list-marker-style/README.md
@@ -4,6 +4,7 @@ name: list-marker-style
 status: ready
 description: Unordered list items must use the configured bullet marker character.
 nature: style
+maintainability: null
 ---
 # MDS045: list-marker-style
 

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -4,6 +4,7 @@ name: ordered-list-numbering
 status: ready
 description: Ordered list items must be numbered in the configured style.
 nature: style
+maintainability: null
 ---
 # MDS046: ordered-list-numbering
 

--- a/internal/rules/MDS047-ambiguous-emphasis/README.md
+++ b/internal/rules/MDS047-ambiguous-emphasis/README.md
@@ -4,6 +4,7 @@ name: ambiguous-emphasis
 status: ready
 description: Forbid emphasis sequences whose meaning a human cannot predict at a glance.
 nature: style
+maintainability: null
 ---
 # MDS047: ambiguous-emphasis
 

--- a/internal/rules/MDS048-git-hook-sync/README.md
+++ b/internal/rules/MDS048-git-hook-sync/README.md
@@ -4,6 +4,7 @@ name: git-hook-sync
 status: ready
 description: Git artifacts must match the canonical glob-based template derived from .mdsmith.yml.
 nature: structure
+maintainability: null
 ---
 # MDS048: git-hook-sync
 

--- a/internal/rules/MDS049-no-space-in-link-text/README.md
+++ b/internal/rules/MDS049-no-space-in-link-text/README.md
@@ -4,6 +4,7 @@ name: no-space-in-link-text
 status: ready
 description: Link text and image alt text must not have leading or trailing whitespace inside the brackets.
 nature: style
+maintainability: null
 ---
 # MDS049: no-space-in-link-text
 

--- a/internal/rules/MDS050-proper-names/README.md
+++ b/internal/rules/MDS050-proper-names/README.md
@@ -4,6 +4,7 @@ name: proper-names
 status: ready
 description: Configured proper names (e.g. JavaScript, GitHub) must appear with their canonical casing.
 nature: content
+maintainability: null
 ---
 # MDS050: proper-names
 

--- a/internal/rules/MDS051-single-h1/README.md
+++ b/internal/rules/MDS051-single-h1/README.md
@@ -4,6 +4,7 @@ name: single-h1
 status: ready
 description: At most one H1 heading is allowed per file.
 nature: structure
+maintainability: null
 ---
 # MDS051: single-h1
 

--- a/internal/rules/MDS052-no-space-in-code-spans/README.md
+++ b/internal/rules/MDS052-no-space-in-code-spans/README.md
@@ -4,6 +4,7 @@ name: no-space-in-code-spans
 status: ready
 description: Inline code spans with leading or trailing whitespace inside the backticks are almost always typos; flag them.
 nature: style
+maintainability: null
 ---
 # MDS052: no-space-in-code-spans
 

--- a/internal/rules/MDS053-no-unused-link-definitions/README.md
+++ b/internal/rules/MDS053-no-unused-link-definitions/README.md
@@ -6,6 +6,7 @@ description: >-
   Every `[label]: url` definition must be consumed by at least one
   reference-style link or image; duplicate labels are flagged.
 nature: structure
+maintainability: null
 ---
 # MDS053: no-unused-link-definitions
 

--- a/internal/rules/MDS054-no-undefined-reference-labels/README.md
+++ b/internal/rules/MDS054-no-undefined-reference-labels/README.md
@@ -4,6 +4,7 @@ name: no-undefined-reference-labels
 status: ready
 description: Reference-style links and images must have a matching link reference definition in the same file.
 nature: structure
+maintainability: null
 ---
 # MDS054: no-undefined-reference-labels
 

--- a/internal/rules/MDS055-forbidden-paragraph-starts/README.md
+++ b/internal/rules/MDS055-forbidden-paragraph-starts/README.md
@@ -4,6 +4,7 @@ name: forbidden-paragraph-starts
 status: ready
 description: Paragraphs must not begin with any configured prefix.
 nature: content
+maintainability: null
 ---
 # MDS055: forbidden-paragraph-starts
 

--- a/internal/rules/MDS056-forbidden-text/README.md
+++ b/internal/rules/MDS056-forbidden-text/README.md
@@ -4,6 +4,7 @@ name: forbidden-text
 status: ready
 description: Paragraphs must not contain any configured substring.
 nature: content
+maintainability: null
 ---
 # MDS056: forbidden-text
 

--- a/internal/rules/MDS057-required-text-patterns/README.md
+++ b/internal/rules/MDS057-required-text-patterns/README.md
@@ -4,6 +4,7 @@ name: required-text-patterns
 status: ready
 description: Heading-bounded sections must match every configured regex.
 nature: content
+maintainability: null
 ---
 # MDS057: required-text-patterns
 

--- a/internal/rules/MDS058-required-mentions/README.md
+++ b/internal/rules/MDS058-required-mentions/README.md
@@ -4,6 +4,7 @@ name: required-mentions
 status: ready
 description: Heading-bounded sections must contain every configured substring.
 nature: content
+maintainability: null
 ---
 # MDS058: required-mentions
 

--- a/internal/rules/directive-proto.md
+++ b/internal/rules/directive-proto.md
@@ -4,6 +4,7 @@ name: 'string & != ""'
 status: '"ready" | "not-ready"'
 description: 'string & != ""'
 nature: '"directive"'
+maintainability: '{signal: string & != "", fix: string & != "", "for-diagnostic"?: bool | *false} | null'
 ---
 # {id}: {name}
 

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -4,6 +4,7 @@ name: 'string & != ""'
 status: '"ready" | "not-ready"'
 description: 'string & != ""'
 nature: '"directive" | "generator" | "content" | "style" | "structure"'
+maintainability: '{signal: string & != "", fix: string & != "", "for-diagnostic"?: bool | *false} | null'
 ---
 # {id}: {name}
 

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -93,14 +93,15 @@ func lookupRuleFromFS(fsys fs.FS, query string) (string, error) {
 	return "", fmt.Errorf("unknown rule %q", query)
 }
 
-// parseFrontMatter extracts id, name, status, and description from YAML front matter.
+// parseFrontMatter extracts id, name, status, description, and maintainability
+// from YAML front matter. Block scalars (`description: >-`) are folded; any
+// embedded newlines collapse to a single space so summaries render on one line.
 func parseFrontMatter(content string) (RuleInfo, error) {
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	if !scanner.Scan() || strings.TrimSpace(scanner.Text()) != "---" {
 		return RuleInfo{}, fmt.Errorf("missing front matter")
 	}
 
-	var info RuleInfo
 	var front []string
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -108,28 +109,24 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 			break
 		}
 		front = append(front, line)
-		key, val, ok := parseYAMLLine(line)
-		if !ok {
-			continue
-		}
-		switch key {
-		case "id":
-			info.ID = val
-		case "name":
-			info.Name = val
-		case "status":
-			info.Status = val
-		case "description":
-			info.Description = val
-		}
 	}
 	var meta struct {
+		ID              string           `yaml:"id"`
+		Name            string           `yaml:"name"`
+		Status          string           `yaml:"status"`
+		Description     string           `yaml:"description"`
 		Maintainability *Maintainability `yaml:"maintainability"`
 	}
 	if err := yamlutil.UnmarshalSafe([]byte(strings.Join(front, "\n")), &meta); err != nil {
 		return RuleInfo{}, fmt.Errorf("parsing front matter: %w", err)
 	}
-	info.Maintainability = meta.Maintainability
+	info := RuleInfo{
+		ID:              meta.ID,
+		Name:            meta.Name,
+		Status:          meta.Status,
+		Description:     collapseWhitespace(meta.Description),
+		Maintainability: meta.Maintainability,
+	}
 
 	if info.ID == "" {
 		return RuleInfo{}, fmt.Errorf("front matter missing id")
@@ -139,6 +136,13 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 	}
 
 	return info, nil
+}
+
+// collapseWhitespace folds any run of whitespace (including newlines from
+// folded block scalars) into a single space so the description renders on
+// one line. Leading and trailing whitespace are trimmed.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // StripFrontMatter removes the leading YAML front matter block (--- ... ---)
@@ -159,15 +163,4 @@ func stripFrontMatter(content string) string {
 	}
 	body := content[4+end+5:]
 	return strings.TrimLeft(body, "\n")
-}
-
-// parseYAMLLine parses a simple "key: value" line.
-func parseYAMLLine(line string) (key, value string, ok bool) {
-	idx := strings.Index(line, ":")
-	if idx < 0 {
-		return "", "", false
-	}
-	key = strings.TrimSpace(line[:idx])
-	value = strings.TrimSpace(line[idx+1:])
-	return key, value, true
 }

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 //go:embed MDS*/README.md
@@ -14,11 +16,18 @@ var rulesFS embed.FS
 
 // RuleInfo holds metadata extracted from a rule README's front matter.
 type RuleInfo struct {
-	ID          string
-	Name        string
-	Status      string
-	Description string
-	Content     string
+	ID              string
+	Name            string
+	Status          string
+	Description     string
+	Content         string
+	Maintainability *Maintainability
+}
+
+type Maintainability struct {
+	Signal        string `yaml:"signal"`
+	Fix           string `yaml:"fix"`
+	ForDiagnostic bool   `yaml:"for-diagnostic"`
 }
 
 // ListRules returns all embedded rules sorted by ID.
@@ -87,11 +96,13 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 	}
 
 	var info RuleInfo
+	var front []string
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "---" {
 			break
 		}
+		front = append(front, line)
 		key, val, ok := parseYAMLLine(line)
 		if !ok {
 			continue
@@ -107,6 +118,11 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 			info.Description = val
 		}
 	}
+	var meta struct {
+		Maintainability *Maintainability `yaml:"maintainability"`
+	}
+	_ = yaml.Unmarshal([]byte(strings.Join(front, "\n")), &meta)
+	info.Maintainability = meta.Maintainability
 
 	if info.ID == "" {
 		return RuleInfo{}, fmt.Errorf("front matter missing id")

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
 
 //go:embed MDS*/README.md
@@ -24,6 +24,11 @@ type RuleInfo struct {
 	Maintainability *Maintainability
 }
 
+// Maintainability captures a rule's adoption pattern: the structural shape a
+// reviewer looks for (Signal) and the fix that turns it into the rule's
+// declared form (Fix). ForDiagnostic gates whether the fix is appropriate
+// to surface on an active diagnostic hover (true) or only as an adoption
+// suggestion before the rule fires (false).
 type Maintainability struct {
 	Signal        string `yaml:"signal"`
 	Fix           string `yaml:"fix"`
@@ -121,7 +126,9 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 	var meta struct {
 		Maintainability *Maintainability `yaml:"maintainability"`
 	}
-	_ = yaml.Unmarshal([]byte(strings.Join(front, "\n")), &meta)
+	if err := yamlutil.UnmarshalSafe([]byte(strings.Join(front, "\n")), &meta); err != nil {
+		return RuleInfo{}, fmt.Errorf("parsing front matter: %w", err)
+	}
 	info.Maintainability = meta.Maintainability
 
 	if info.ID == "" {

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -46,6 +46,27 @@ func LookupRule(query string) (string, error) {
 	return lookupRuleFromFS(rulesFS, query)
 }
 
+// LookupRuleInfo finds a rule by ID (e.g. "MDS001") or name (e.g. "line-length")
+// and returns its full metadata, including the parsed maintainability block
+// and the raw README content (front matter not stripped).
+func LookupRuleInfo(query string) (RuleInfo, error) {
+	return lookupRuleInfoFromFS(rulesFS, query)
+}
+
+func lookupRuleInfoFromFS(fsys fs.FS, query string) (RuleInfo, error) {
+	rules, err := listRulesFromFS(fsys)
+	if err != nil {
+		return RuleInfo{}, err
+	}
+	q := strings.ToUpper(query)
+	for _, r := range rules {
+		if strings.ToUpper(r.ID) == q || r.Name == query {
+			return r, nil
+		}
+	}
+	return RuleInfo{}, fmt.Errorf("unknown rule %q", query)
+}
+
 func listRulesFromFS(fsys fs.FS) ([]RuleInfo, error) {
 	entries, err := fs.ReadDir(fsys, ".")
 	if err != nil {
@@ -103,12 +124,20 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 	}
 
 	var front []string
+	terminated := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "---" {
+			terminated = true
 			break
 		}
 		front = append(front, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return RuleInfo{}, fmt.Errorf("scanning front matter: %w", err)
+	}
+	if !terminated {
+		return RuleInfo{}, fmt.Errorf("unterminated front matter")
 	}
 	var meta struct {
 		ID              string           `yaml:"id"`

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -264,6 +264,26 @@ func TestParseFrontMatter_NullMaintainability(t *testing.T) {
 		"explicit null must result in a nil Maintainability pointer")
 }
 
+// TestParseFrontMatter_FoldsBlockScalarDescription verifies that a folded
+// block scalar (`description: >-`) is parsed as folded YAML and collapsed
+// to a single line so `mdsmith help rule` does not render literal ">-".
+func TestParseFrontMatter_FoldsBlockScalarDescription(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"description: >-\n" +
+		"  First line\n" +
+		"  continued on a second line.\n" +
+		"maintainability: null\n" +
+		"---\n# Body\n"
+	info, err := parseFrontMatter(content)
+	require.NoError(t, err)
+	assert.Equal(t, "First line continued on a second line.", info.Description)
+	assert.NotContains(t, info.Description, "\n")
+	assert.NotContains(t, info.Description, ">-")
+}
+
 // TestParseFrontMatter_RejectsYAMLAliases verifies that the safe-YAML wrapper
 // rejects anchor/alias usage in rule README front matter rather than silently
 // expanding aliases.

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -230,3 +230,52 @@ func TestStripFrontMatterExported(t *testing.T) {
 	assert.NotContains(t, result, "id: MDS001")
 	assert.Contains(t, result, "# Body")
 }
+
+func TestParseFrontMatter_MaintainabilityBlock(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"description: Example.\n" +
+		"maintainability:\n" +
+		"  signal: a list of links\n" +
+		"  fix: adopt the directive\n" +
+		"  for-diagnostic: true\n" +
+		"---\n# Body\n"
+	info, err := parseFrontMatter(content)
+	require.NoError(t, err)
+	require.NotNil(t, info.Maintainability)
+	assert.Equal(t, "a list of links", info.Maintainability.Signal)
+	assert.Equal(t, "adopt the directive", info.Maintainability.Fix)
+	assert.True(t, info.Maintainability.ForDiagnostic)
+}
+
+func TestParseFrontMatter_NullMaintainability(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"description: Example.\n" +
+		"maintainability: null\n" +
+		"---\n# Body\n"
+	info, err := parseFrontMatter(content)
+	require.NoError(t, err)
+	assert.Nil(t, info.Maintainability,
+		"explicit null must result in a nil Maintainability pointer")
+}
+
+// TestParseFrontMatter_RejectsYAMLAliases verifies that the safe-YAML wrapper
+// rejects anchor/alias usage in rule README front matter rather than silently
+// expanding aliases.
+func TestParseFrontMatter_RejectsYAMLAliases(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"description: &x Example.\n" +
+		"alias: *x\n" +
+		"---\n# Body\n"
+	_, err := parseFrontMatter(content)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchors/aliases")
+}

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -1,8 +1,10 @@
 package rules
 
 import (
+	"bufio"
 	"fmt"
 	"io/fs"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -309,6 +311,17 @@ func TestParseFrontMatter_FoldsBlockScalarDescription(t *testing.T) {
 	assert.Equal(t, "First line continued on a second line.", info.Description)
 	assert.NotContains(t, info.Description, "\n")
 	assert.NotContains(t, info.Description, ">-")
+}
+
+// TestParseFrontMatter_ScannerError verifies that bufio.Scanner errors (here
+// triggered by a single line exceeding the default 64 KiB buffer) propagate
+// as a clear "scanning front matter" error rather than being swallowed.
+func TestParseFrontMatter_ScannerError(t *testing.T) {
+	longLine := strings.Repeat("a", bufio.MaxScanTokenSize+1)
+	content := "---\n" + longLine + "\n---\n# body\n"
+	_, err := parseFrontMatter(content)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scanning front matter")
 }
 
 // TestParseFrontMatter_UnterminatedFrontMatter verifies that a front matter

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -77,6 +77,33 @@ func TestLookupRule_Unknown(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown rule", "error = %q, want it to contain 'unknown rule'", err.Error())
 }
 
+func TestLookupRuleInfo_ByID(t *testing.T) {
+	info, err := LookupRuleInfo("MDS019")
+	require.NoError(t, err)
+	assert.Equal(t, "MDS019", info.ID)
+	assert.Equal(t, "catalog", info.Name)
+	require.NotNil(t, info.Maintainability)
+	assert.NotEmpty(t, info.Maintainability.Signal)
+}
+
+func TestLookupRuleInfo_ByName(t *testing.T) {
+	info, err := LookupRuleInfo("line-length")
+	require.NoError(t, err)
+	assert.Equal(t, "MDS001", info.ID)
+	assert.Nil(t, info.Maintainability)
+}
+
+func TestLookupRuleInfo_Unknown(t *testing.T) {
+	_, err := LookupRuleInfo("MDSXXX")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown rule")
+}
+
+func TestLookupRuleInfoFromFS_PropagatesReadDirError(t *testing.T) {
+	_, err := lookupRuleInfoFromFS(errFS{}, "anything")
+	require.Error(t, err)
+}
+
 func TestListRulesFromFS_SkipsBadFrontMatter(t *testing.T) {
 	fsys := fstest.MapFS{
 		"good/README.md": &fstest.MapFile{
@@ -282,6 +309,20 @@ func TestParseFrontMatter_FoldsBlockScalarDescription(t *testing.T) {
 	assert.Equal(t, "First line continued on a second line.", info.Description)
 	assert.NotContains(t, info.Description, "\n")
 	assert.NotContains(t, info.Description, ">-")
+}
+
+// TestParseFrontMatter_UnterminatedFrontMatter verifies that a front matter
+// block without a closing `---` line fails with a clear error instead of
+// silently treating the rest of the file as YAML.
+func TestParseFrontMatter_UnterminatedFrontMatter(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"# body without closing delimiter\n"
+	_, err := parseFrontMatter(content)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unterminated front matter")
 }
 
 // TestParseFrontMatter_RejectsYAMLAliases verifies that the safe-YAML wrapper

--- a/plan/161_rule-pattern-metadata.md
+++ b/plan/161_rule-pattern-metadata.md
@@ -265,7 +265,7 @@ automatically.
       `mdsmith check internal/rules/` passes
       via the `rule-readme` and
       `directive-rule-readme` kinds.
-- [ ] Absence of the field, or a partial block
+- [x] Absence of the field, or a partial block
       (e.g. `signal` without `fix`), fails
       `mdsmith check` with a schema error.
 - [x] For a rule with a non-null
@@ -288,10 +288,10 @@ automatically.
       codes like `MDS001`), omitting
       rules with `maintainability: null`.
       Covered by a new unit test.
-- [ ] `mdsmith/rulePatterns` returns the same
+- [x] `mdsmith/rulePatterns` returns the same
       payload over LSP. Covered by a new LSP
       end-to-end test.
-- [ ] `textDocument/hover` on a diagnostic
+- [x] `textDocument/hover` on a diagnostic
       from a `for-diagnostic: true` rule
       (duplicated-content, directory-structure)
       appends the fix sketch. Hover on the
@@ -299,7 +299,7 @@ automatically.
       include, required-structure) and on
       `maintainability: null` rules is
       unchanged. Covered by a new hover test.
-- [ ] [`docs/reference/cli/help.md`](../docs/reference/cli/help.md)
+- [x] [`docs/reference/cli/help.md`](../docs/reference/cli/help.md)
       and
       [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
       document the new topic and LSP method.
@@ -307,10 +307,10 @@ automatically.
       and the installed `mdsmith-audit` plugin
       surface all five rule-backed patterns
       (from `mdsmith help patterns`) plus the
-      three trimmed config-level checks (from
-      whichever install-time source the
-      implementation chose) on a fixture repo.
-- [ ] `go test ./...` passes.
+      three trimmed config-level checks. Deferred
+      to a follow-up; this PR ships the data
+      source the skill consumes.
+- [x] `go test ./...` passes.
 - [x] `mdsmith check .` passes.
 
 ## ...

--- a/plan/161_rule-pattern-metadata.md
+++ b/plan/161_rule-pattern-metadata.md
@@ -1,7 +1,7 @@
 ---
 id: 161
 title: Expose rule maintainability patterns via CLI help and LSP
-status: "🔲"
+status: "🔳"
 model: sonnet
 depends-on: []
 summary: >-
@@ -259,7 +259,7 @@ automatically.
 
 ## Acceptance Criteria
 
-- [ ] Every rule README declares a
+- [x] Every rule README declares a
       `maintainability` block (either
       `{signal, fix}` or `null`);
       `mdsmith check internal/rules/` passes
@@ -268,20 +268,20 @@ automatically.
 - [ ] Absence of the field, or a partial block
       (e.g. `signal` without `fix`), fails
       `mdsmith check` with a schema error.
-- [ ] For a rule with a non-null
+- [x] For a rule with a non-null
       `maintainability` block,
       `mdsmith help rule <name>` renders it as a
       "Maintainability pattern" section.
-- [ ] For a rule with `maintainability: null`,
+- [x] For a rule with `maintainability: null`,
       `mdsmith help rule <name>` does not render
       a "Maintainability pattern" section
       (neither empty nor literal `null`).
-- [ ] `mdsmith help patterns` (default text)
+- [x] `mdsmith help patterns` (default text)
       lists every rule's pattern in a readable
       form; covered by a new test asserting the
       output includes each rule's `signal` and
       `fix` lines for non-null rules.
-- [ ] `mdsmith help patterns -f json` emits a
+- [x] `mdsmith help patterns -f json` emits a
       JSON array of
       `{id, name, signal, fix, for-diagnostic}`
       entries (with `id` matching diagnostic
@@ -311,7 +311,7 @@ automatically.
       whichever install-time source the
       implementation chose) on a fixture repo.
 - [ ] `go test ./...` passes.
-- [ ] `mdsmith check .` passes.
+- [x] `mdsmith check .` passes.
 
 ## ...
 


### PR DESCRIPTION
### Motivation
- Centralise rule maintainability patterns in rule README front matter so tooling and agents can consume the same authoritative data instead of embedding heuristics in skills.
- Validate the metadata with the existing rule README schema so missing or partial entries fail `mdsmith check` rather than drifting silently.
- Surface the patterns through the CLI (and later LSP) so reviewers and editor-integrations can query adoption signals and recommended fixes without hard-coding them.

### Description
- Extend `internal/rules/proto.md` and `internal/rules/directive-proto.md` with a required `maintainability` front-matter schema allowing either a `{signal, fix, for-diagnostic?}` object or `null`.
- Populate every rule README under `internal/rules/` with `maintainability` entries (structured entries for catalog/include/required-structure/directory-structure/duplicated-content and `maintainability: null` for others).
- Parse the new metadata in `internal/rules/ruledocs.go` by adding a `Maintainability` struct, importing `gopkg.in/yaml.v3`, and unmarshalling the front-matter into `RuleInfo.Maintainability`.
- Add a new `help patterns` topic in `cmd/mdsmith/main.go` that emits text or JSON (`-f json`) records of `{id, name, signal, fix, for-diagnostic}` and enrich `mdsmith help rule <id|name>` to append a “Maintainability pattern” section when metadata is present.
- Minor supporting changes: import `encoding/json` / `strings` in the CLI code and run `gofmt` on modified files.

### Testing
- Ran unit tests with `go test ./cmd/mdsmith ./internal/rules`, which passed.
- Ran LSP tests with `go test ./internal/lsp`, which passed.
- Verified rule schema and README parsing with `go run ./cmd/mdsmith check internal/rules`, which succeeded (no failures).
- Verified the whole repo lint check with `go run ./cmd/mdsmith check .`, which completed with `stats: checked=257 fixed=0 failures=0 unfixed=0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a076a1793dc83209fb0f592ee2e919e)