### PR TITLE
Use list-releases endpoint to find draft releases by tag

### DIFF
--- a/cmd/mdsmith-release/publishrelease_test.go
+++ b/cmd/mdsmith-release/publishrelease_test.go
@@ -16,7 +16,7 @@ func TestRunPublishReleaseFlipsDraft(t *testing.T) {
 			_, _ = w.Write([]byte(`{"id":42,"draft":false}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":42,"draft":true}`))
+		_, _ = w.Write([]byte(`[{"id":42,"draft":true,"tag_name":"v1.2.3"}]`))
 	}))
 	t.Cleanup(srv.Close)
 

--- a/internal/release/publishrelease.go
+++ b/internal/release/publishrelease.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
@@ -101,35 +100,85 @@ func PublishRelease(opts PublishReleaseOptions) error {
 }
 
 type releaseRef struct {
-	ID    int64 `json:"id"`
-	Draft bool  `json:"draft"`
+	ID      int64  `json:"id"`
+	Draft   bool   `json:"draft"`
+	TagName string `json:"tag_name"`
 }
 
+// lookupReleaseRef finds the release whose tag_name matches tag by
+// walking the list-releases endpoint. The by-tag endpoint
+// (GET /releases/tags/{tag}) deliberately omits draft releases, and
+// the `release` job creates the release as a draft so its assets stay
+// mutable until the final publish — so the draft is only reachable
+// through the list endpoint. Pagination is followed via the Link
+// header because drafts are not guaranteed to land on the first page.
 func lookupReleaseRef(client *http.Client, apiBase, repository, tag, token string) (releaseRef, bool, error) {
-	u := apiBase + "/repos/" + repository + "/releases/tags/" + url.PathEscape(tag)
+	next := apiBase + "/repos/" + repository + "/releases?per_page=100"
+	for next != "" {
+		rel, found, link, err := lookupReleasePage(client, next, tag, token)
+		if err != nil {
+			return releaseRef{}, false, err
+		}
+		if found {
+			return rel, true, nil
+		}
+		next = link
+	}
+	return releaseRef{}, false, nil
+}
+
+func lookupReleasePage(client *http.Client, u, tag, token string) (releaseRef, bool, string, error) {
 	req, err := newGitHubRequest(http.MethodGet, u, nil, token)
 	if err != nil {
-		return releaseRef{}, false, err
+		return releaseRef{}, false, "", err
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return releaseRef{}, false, err
+		return releaseRef{}, false, "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var rel releaseRef
-		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-			return releaseRef{}, false, fmt.Errorf("parse %s: %w", u, err)
-		}
-		return rel, true, nil
-	case http.StatusNotFound:
-		return releaseRef{}, false, nil
-	default:
-		return releaseRef{}, false, unexpectedStatus("lookup", u, resp)
+	if resp.StatusCode != http.StatusOK {
+		return releaseRef{}, false, "", unexpectedStatus("lookup", u, resp)
 	}
+
+	var rels []releaseRef
+	if err := json.NewDecoder(resp.Body).Decode(&rels); err != nil {
+		return releaseRef{}, false, "", fmt.Errorf("parse %s: %w", u, err)
+	}
+	for _, rel := range rels {
+		if rel.TagName == tag {
+			return rel, true, "", nil
+		}
+	}
+	return releaseRef{}, false, nextPageURL(resp.Header.Get("Link")), nil
+}
+
+// nextPageURL extracts the rel="next" target from a GitHub Link
+// header, or "" when there is no further page.
+func nextPageURL(link string) string {
+	for _, part := range strings.Split(link, ",") {
+		segs := strings.Split(part, ";")
+		if len(segs) < 2 {
+			continue
+		}
+		isNext := false
+		for _, attr := range segs[1:] {
+			if strings.TrimSpace(attr) == `rel="next"` {
+				isNext = true
+				break
+			}
+		}
+		if !isNext {
+			continue
+		}
+		u := strings.TrimSpace(segs[0])
+		u = strings.TrimPrefix(u, "<")
+		u = strings.TrimSuffix(u, ">")
+		return u
+	}
+	return ""
 }
 
 func patchReleaseDraftFalse(client *http.Client, apiBase, repository string, id int64, token string) error {

--- a/internal/release/publishrelease_test.go
+++ b/internal/release/publishrelease_test.go
@@ -36,13 +36,15 @@ func TestPublishReleaseFlipsDraftToPublished(t *testing.T) {
 		defer mu.Unlock()
 		authHdr = append(authHdr, r.Header.Get("Authorization"))
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/repos/jeduden/mdsmith/releases/tags/v1.2.3":
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/jeduden/mdsmith/releases":
 			gets++
 			if gets == 1 {
-				http.NotFound(w, r)
+				// The draft has not materialized yet: the list
+				// endpoint returns other releases but not this tag.
+				_, _ = fmt.Fprint(w, `[{"id":7,"draft":false,"tag_name":"v1.2.2"}]`)
 				return
 			}
-			_, _ = fmt.Fprint(w, `{"id":42,"draft":true}`)
+			_, _ = fmt.Fprint(w, `[{"id":42,"draft":true,"tag_name":"v1.2.3"}]`)
 		case r.Method == http.MethodPatch && r.URL.Path == "/repos/jeduden/mdsmith/releases/42":
 			patched = true
 			patchID = r.URL.Path
@@ -76,12 +78,55 @@ func TestPublishReleaseFlipsDraftToPublished(t *testing.T) {
 	}
 }
 
+func TestPublishReleaseFollowsPaginationToFindDraft(t *testing.T) {
+	var patched bool
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isList := r.Method == http.MethodGet && r.URL.Path == "/repos/jeduden/mdsmith/releases"
+		page := r.URL.Query().Get("page")
+		switch {
+		case isList && page == "":
+			w.Header().Set("Link",
+				`<`+srv.URL+`/repos/jeduden/mdsmith/releases?page=2>; rel="next", `+
+					`<`+srv.URL+`/repos/jeduden/mdsmith/releases?page=2>; rel="last"`)
+			_, _ = fmt.Fprint(w, `[{"id":1,"draft":false,"tag_name":"v1.2.2"}]`)
+		case isList && page == "2":
+			_, _ = fmt.Fprint(w, `[{"id":99,"draft":true,"tag_name":"v1.2.3"}]`)
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/jeduden/mdsmith/releases/99":
+			patched = true
+			_, _ = fmt.Fprint(w, `{"id":99,"draft":false}`)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected", http.StatusTeapot)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	err := PublishRelease(PublishReleaseOptions{
+		Repository: "jeduden/mdsmith",
+		Tag:        "v1.2.3",
+		Token:      "t",
+		APIBaseURL: srv.URL,
+	})
+	require.NoError(t, err)
+	assert.True(t, patched)
+}
+
+func TestNextPageURL(t *testing.T) {
+	hdr := `<https://api.github.com/repositories/1/releases?page=2>; rel="next", ` +
+		`<https://api.github.com/repositories/1/releases?page=9>; rel="last"`
+	assert.Equal(t, "https://api.github.com/repositories/1/releases?page=2", nextPageURL(hdr))
+
+	assert.Equal(t, "", nextPageURL(""))
+	assert.Equal(t, "", nextPageURL(`<https://x/p?page=9>; rel="last"`))
+}
+
 func TestPublishReleaseAlreadyPublishedIsNoOp(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("already-published release must not be patched, got %s", r.Method)
 		}
-		_, _ = fmt.Fprint(w, `{"id":7,"draft":false}`)
+		_, _ = fmt.Fprint(w, `[{"id":7,"draft":false,"tag_name":"v1.2.3"}]`)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -96,9 +141,10 @@ func TestPublishReleaseAlreadyPublishedIsNoOp(t *testing.T) {
 
 func TestPublishReleaseMissingAfterRetriesErrors(t *testing.T) {
 	var calls, sleeps int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		calls++
-		http.NotFound(w, r)
+		// The draft for v9.9.9 never appears in the list.
+		_, _ = fmt.Fprint(w, `[{"id":1,"draft":false,"tag_name":"v9.9.8"}]`)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -151,7 +197,7 @@ func TestPublishReleaseLookupUnexpectedStatusErrors(t *testing.T) {
 func TestPublishReleasePatchUnexpectedStatusErrors(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			_, _ = fmt.Fprint(w, `{"id":3,"draft":true}`)
+			_, _ = fmt.Fprint(w, `[{"id":3,"draft":true,"tag_name":"v1.2.3"}]`)
 			return
 		}
 		w.WriteHeader(http.StatusUnprocessableEntity)
@@ -200,7 +246,7 @@ func TestPublishReleaseUsesDefaultAPIBase(t *testing.T) {
 		gotURL = r.URL.String()
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"id":1,"draft":false}`)),
+			Body:       io.NopCloser(strings.NewReader(`[{"id":1,"draft":false,"tag_name":"v1.2.3"}]`)),
 			Header:     make(http.Header),
 		}, nil
 	})}
@@ -211,7 +257,7 @@ func TestPublishReleaseUsesDefaultAPIBase(t *testing.T) {
 		Client:     client,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://api.github.com/repos/jeduden/mdsmith/releases/tags/v1.2.3", gotURL)
+	assert.Equal(t, "https://api.github.com/repos/jeduden/mdsmith/releases?per_page=100", gotURL)
 }
 
 func TestPublishReleaseClientDoError(t *testing.T) {
@@ -237,7 +283,7 @@ func TestPublishReleasePatchTransportError(t *testing.T) {
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{"id":5,"draft":true}`)),
+			Body:       io.NopCloser(strings.NewReader(`[{"id":5,"draft":true,"tag_name":"v1.2.3"}]`)),
 			Header:     make(http.Header),
 		}, nil
 	})}


### PR DESCRIPTION
## Summary

Changes the release lookup logic to use the GitHub list-releases endpoint instead of the by-tag endpoint. This is necessary because the by-tag endpoint deliberately omits draft releases, but the release job creates releases as drafts to keep assets mutable until final publication.

## Key Changes

- **Removed direct by-tag lookup**: Replaced the single GET `/releases/tags/{tag}` request with pagination through the list-releases endpoint
- **Added pagination support**: Implemented `nextPageURL()` helper to parse GitHub's Link header and follow pagination to find draft releases that may not appear on the first page
- **Split lookup logic**: Extracted `lookupReleasePage()` to handle individual page requests and tag matching
- **Updated releaseRef struct**: Added `TagName` field to support matching releases by tag name when iterating through paginated results
- **Removed net/url import**: No longer needed since we're not using `url.PathEscape()`

## Implementation Details

- The `lookupReleaseRef()` function now loops through paginated results, calling `lookupReleasePage()` for each page
- `lookupReleasePage()` decodes a list of releases and searches for a matching tag name, returning the next page URL from the Link header
- `nextPageURL()` parses the RFC 5988 Link header format to extract the `rel="next"` URL for pagination
- All tests updated to reflect the new list-based response format and pagination behavior
- Added `TestPublishReleaseFollowsPaginationToFindDraft()` to verify pagination works correctly
- Added `TestNextPageURL()` to unit test the Link header parsing logic

https://claude.ai/code/session_01F3gFEBvZLjWfAuoqcMNoSZ