### PR TITLE
Complete plan 157: catalog filter by front matter property

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -85,7 +85,7 @@ footer: |
 | 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
 | 156 | 🔲     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                        |
 | 156 | 🔲     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
-| 157 | 🔳     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
+| 157 | ✅     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
 | 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                      |
 | 161 | 🔲     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |
 | 162 | 🔲     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                            |

--- a/plan/157_catalog-where-filter.md
+++ b/plan/157_catalog-where-filter.md
@@ -1,7 +1,7 @@
 ---
 id: 157
 title: 'Catalog filter by front matter property'
-status: '🔳'
+status: '✅'
 summary: >-
   Extend the catalog directive with a filter that
   selects matched files by a front matter property
@@ -107,17 +107,22 @@ directive so both surfaces stay consistent.
 - [x] An invalid `where:` expression emits an
   MDS019 diagnostic naming the offending token
   and line.
-- [ ] Every rule README carries a `nature` front
+- [x] Every rule README carries a `nature` front
   matter key matching the documented vocabulary.
-- [ ] [internal/rules/index.md](../internal/rules/index.md)
+- [x] [internal/rules/index.md](../internal/rules/index.md)
   has a "Directive rules" section using
-  `where: 'nature == "directive"'` that lists
-  only the four directive rules.
+  `where: 'nature: "directive"'` that lists
+  only the four directive rules. The plan
+  originally wrote `nature == "directive"`; the
+  CUE grammar reused from `mdsmith list query`
+  uses field-pattern (`:`) form, so the
+  implementation drops in the CLI-compatible
+  expression.
 - [x] The
   [generating-content guide](../docs/guides/directives/generating-content.md)
   documents `where:` with a worked example.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no
   issues.
 
 ## ...


### PR DESCRIPTION
Marks plan 157 as complete (✅) after implementing the catalog `where:` filter feature for selecting files by front matter properties.

## Summary

This plan introduced a `where:` filter to the catalog directive that allows filtering matched files by front matter properties using a CUE-based query expression. The implementation is now complete with all acceptance criteria met.

## Changes

- **Plan status**: Updated plan/157_catalog-where-filter.md from 🔳 (in progress) to ✅ (complete)
- **Acceptance criteria**: Marked all remaining checklist items as complete:
  - Every rule README now carries a `nature` front matter key matching the documented vocabulary
  - [internal/rules/index.md](../internal/rules/index.md) has a "Directive rules" section using the `where:` filter with `nature: "directive"` syntax
  - All tests pass (`go test ./...`)
  - `go tool golangci-lint run` reports no issues
- **Syntax clarification**: Added explanatory note that the implementation uses the field-pattern (`:`) form from the CUE grammar reused from `mdsmith list query`, rather than the equality operator (`==`) originally planned. This ensures CLI compatibility.
- **PLAN.md**: Updated the status indicator for plan 157 from 🔳 to ✅ in the main plan index

## Implementation Details

The `where:` filter syntax uses CUE's field-pattern form (`nature: "directive"`) rather than equality comparison (`nature == "directive"`), maintaining consistency with the `mdsmith list query` command's grammar. This design choice prioritizes CLI compatibility and user familiarity with existing query syntax.

https://claude.ai/code/session_01Rz7mozuWh9ZjrEBzurFQa4