### PR TITLE
Rewrite repo-relative links in synced docs for published site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -149,88 +149,40 @@ jobs:
         # (website/layouts/_default/_markup/render-link.html) does
         # the source-relative → permalink resolution, baseURL
         # prefixing, and scheme sanitization. None of that is
-        # visible to the synced-tree mdsmith check (it operates on
-        # markdown filesystem, pre-render). Probe the rendered
-        # HTML for representative cases so a regression in the
-        # hook breaks CI here rather than silently shipping a
-        # site full of 404s. Each grep is wrapped in its own
-        # if-block so the failing case prints a clear message;
-        # `set -euo pipefail` ensures the first failure aborts.
-        #
-        # The expected href prefix is derived from BASE_URL so
-        # this works equally on a root deploy (prefix empty,
-        # hrefs are `/docs/…/`) and a project-pages deploy
-        # (prefix `/<repo>`, hrefs are `/<repo>/docs/…/`). The
-        # render-link hook runs absolute paths through relURL,
-        # which prepends whatever prefix Hugo was built with.
-        working-directory: website
+        # visible to the synced-tree mdsmith check (it operates
+        # on the markdown filesystem, pre-render). Probe the
+        # rendered HTML for representative cases via a Go
+        # subcommand so a regression breaks CI here rather than
+        # silently shipping a site full of 404s. The probes
+        # (and their regexes that tolerate both quoted and
+        # minified href forms) live in
+        # internal/release/verifylinks.go with unit-test
+        # coverage rather than as inline YAML shell, per the
+        # convention in docs/development/release-tooling.md.
         env:
           BASE_URL: ${{ steps.pages.outputs.base_url }}
         run: |
-          set -euo pipefail
-
-          # Strip scheme + host and trailing slash to leave just
-          # the path portion. Root deploys collapse to "";
-          # project-pages deploys leave "/<repo>".
-          prefix="$(printf '%s' "$BASE_URL" | sed -E 's|^https?://[^/]+||; s|/$||')"
-
-          # 1. A sibling `.md` link from a leaf-page source
-          #    resolves to the target page's permalink, not a
-          #    literal `.md` path under the source's URL.
-          if ! grep -q "href=${prefix}/docs/development/pr-fixup-workflow/" \
-              public/docs/development/merge-queue/index.html; then
-            echo "::error::render-link: sibling .md not resolved to permalink (prefix=${prefix})" >&2
-            exit 1
-          fi
-
-          # 2. The rewriter's `architecture/index.md` →
-          #    `architecture/` drop resolves through GetPage to
-          #    the section permalink rather than nesting under
-          #    the leaf page (the source-vs-rendered-depth bug).
-          if ! grep -q "href=${prefix}/docs/development/architecture/" \
-              public/docs/development/architecture-audit/index.html; then
-            echo "::error::render-link: index.md drop misresolved on leaf page (prefix=${prefix})" >&2
-            exit 1
-          fi
-
-          # 3. Cross-rule references survive as the published
-          #    rule-page URL, not the unpublished README.md. No
-          #    prefix needed — this asserts absence.
-          if grep -rq 'href=[^"]*README\.md' public/docs/rules/; then
-            echo "::error::render-link: README.md target leaked into a rule page" >&2
-            exit 1
-          fi
-
-          # 4. javascript: and data: hrefs must be neutralized
-          #    by Go's html/template auto-escape. The hook drops
-          #    safeURL exactly so these cannot pass through.
-          if grep -rq 'href=javascript:' public/; then
-            echo "::error::render-link: javascript: href reached rendered HTML" >&2
-            exit 1
-          fi
-          if grep -rq 'href=data:' public/; then
-            echo "::error::render-link: data: href reached rendered HTML" >&2
-            exit 1
-          fi
+          go run ./cmd/mdsmith-release verify-website-links \
+            --dir ./website/public --base-url "$BASE_URL"
       - name: Verify baseURL prefix on absolute hrefs
         # The rewriter emits site-absolute `/docs/...` URLs into
         # the synced markdown. The render-link hook runs them
         # through relURL so a non-root --baseURL deploy
         # (Pages served from a subpath) gets the configured
         # prefix. Build a second copy with a fake subpath
-        # baseURL and assert at least one rewritten link picks
-        # up the prefix. The build output goes to a throwaway
-        # destination so it does not displace the real artifact.
+        # baseURL and re-run the same Go probe against it; the
+        # subcommand uses the supplied baseURL's path component
+        # as the expected prefix. The build output goes to a
+        # throwaway destination so it does not displace the
+        # real artifact.
         working-directory: website
         run: |
-          set -euo pipefail
           hugo --minify --baseURL "https://example.com/mdsmith/" \
             --destination /tmp/baseurl-probe
-          if ! grep -rq 'href=/mdsmith/docs/rules/' \
-              /tmp/baseurl-probe/docs/rules/; then
-            echo "::error::render-link: baseURL prefix not applied to /docs/rules/ hrefs" >&2
-            exit 1
-          fi
+          cd ..
+          go run ./cmd/mdsmith-release verify-website-links \
+            --dir /tmp/baseurl-probe \
+            --base-url "https://example.com/mdsmith/"
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/public

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -144,6 +144,78 @@ jobs:
           # template-expansion vulnerability).
           BASE_URL: ${{ steps.pages.outputs.base_url }}
         run: hugo --minify --baseURL "${BASE_URL}/"
+      - name: Verify render-link hook output
+        # The render-link hook
+        # (website/layouts/_default/_markup/render-link.html) does
+        # the source-relative → permalink resolution, baseURL
+        # prefixing, and scheme sanitization. None of that is
+        # visible to the synced-tree mdsmith check (it operates on
+        # markdown filesystem, pre-render). Probe the rendered
+        # HTML for representative cases so a regression in the
+        # hook breaks CI here rather than silently shipping a
+        # site full of 404s. Each grep is wrapped in its own
+        # if-block so the failing case prints a clear message;
+        # `set -euo pipefail` ensures the first failure aborts.
+        working-directory: website
+        run: |
+          set -euo pipefail
+
+          # 1. A sibling `.md` link from a leaf-page source
+          #    resolves to the target page's permalink, not a
+          #    literal `.md` path under the source's URL.
+          if ! grep -q 'href=/docs/development/pr-fixup-workflow/' \
+              public/docs/development/merge-queue/index.html; then
+            echo "::error::render-link: sibling .md not resolved to permalink" >&2
+            exit 1
+          fi
+
+          # 2. The rewriter's `architecture/index.md` →
+          #    `architecture/` drop resolves through GetPage to
+          #    the section permalink rather than nesting under
+          #    the leaf page (the source-vs-rendered-depth bug).
+          if ! grep -q 'href=/docs/development/architecture/' \
+              public/docs/development/architecture-audit/index.html; then
+            echo "::error::render-link: index.md drop misresolved on leaf page" >&2
+            exit 1
+          fi
+
+          # 3. Cross-rule references survive as the published
+          #    rule-page URL, not the unpublished README.md.
+          if grep -rq 'href=[^"]*README\.md' public/docs/rules/; then
+            echo "::error::render-link: README.md target leaked into a rule page" >&2
+            exit 1
+          fi
+
+          # 4. javascript: and data: hrefs must be neutralized
+          #    by Go's html/template auto-escape. The hook drops
+          #    safeURL exactly so these cannot pass through.
+          if grep -rq 'href=javascript:' public/; then
+            echo "::error::render-link: javascript: href reached rendered HTML" >&2
+            exit 1
+          fi
+          if grep -rq 'href=data:' public/; then
+            echo "::error::render-link: data: href reached rendered HTML" >&2
+            exit 1
+          fi
+      - name: Verify baseURL prefix on absolute hrefs
+        # The rewriter emits site-absolute `/docs/...` URLs into
+        # the synced markdown. The render-link hook runs them
+        # through relURL so a non-root --baseURL deploy
+        # (Pages served from a subpath) gets the configured
+        # prefix. Build a second copy with a fake subpath
+        # baseURL and assert at least one rewritten link picks
+        # up the prefix. The build output goes to a throwaway
+        # destination so it does not displace the real artifact.
+        working-directory: website
+        run: |
+          set -euo pipefail
+          hugo --minify --baseURL "https://example.com/mdsmith/" \
+            --destination /tmp/baseurl-probe
+          if ! grep -rq 'href=/mdsmith/docs/rules/' \
+              /tmp/baseurl-probe/docs/rules/; then
+            echo "::error::render-link: baseURL prefix not applied to /docs/rules/ hrefs" >&2
+            exit 1
+          fi
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/public

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -109,6 +109,19 @@ jobs:
         # docs/development/release-tooling.md for why this lives
         # in the release-tooling Go CLI rather than inline shell.
         run: go run ./cmd/mdsmith-release build-website --no-fix ./docs ./website/content/docs
+      - name: Lint built docs tree for broken links
+        # Run mdsmith over the synced tree with its own config
+        # (style/structure rules off, link integrity on) so any
+        # post-sync broken link or missing target fails CI before
+        # we publish. --no-gitignore is needed because
+        # website/content/docs/ is .gitignore'd. See
+        # website/build-output.mdsmith.yml for the rule set and
+        # the rationale for each disabled rule.
+        run: |
+          go run ./cmd/mdsmith check \
+            --config ./website/build-output.mdsmith.yml \
+            --no-gitignore \
+            ./website/content/docs
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         id: pages
       - name: Build site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -156,16 +156,30 @@ jobs:
         # site full of 404s. Each grep is wrapped in its own
         # if-block so the failing case prints a clear message;
         # `set -euo pipefail` ensures the first failure aborts.
+        #
+        # The expected href prefix is derived from BASE_URL so
+        # this works equally on a root deploy (prefix empty,
+        # hrefs are `/docs/…/`) and a project-pages deploy
+        # (prefix `/<repo>`, hrefs are `/<repo>/docs/…/`). The
+        # render-link hook runs absolute paths through relURL,
+        # which prepends whatever prefix Hugo was built with.
         working-directory: website
+        env:
+          BASE_URL: ${{ steps.pages.outputs.base_url }}
         run: |
           set -euo pipefail
+
+          # Strip scheme + host and trailing slash to leave just
+          # the path portion. Root deploys collapse to "";
+          # project-pages deploys leave "/<repo>".
+          prefix="$(printf '%s' "$BASE_URL" | sed -E 's|^https?://[^/]+||; s|/$||')"
 
           # 1. A sibling `.md` link from a leaf-page source
           #    resolves to the target page's permalink, not a
           #    literal `.md` path under the source's URL.
-          if ! grep -q 'href=/docs/development/pr-fixup-workflow/' \
+          if ! grep -q "href=${prefix}/docs/development/pr-fixup-workflow/" \
               public/docs/development/merge-queue/index.html; then
-            echo "::error::render-link: sibling .md not resolved to permalink" >&2
+            echo "::error::render-link: sibling .md not resolved to permalink (prefix=${prefix})" >&2
             exit 1
           fi
 
@@ -173,14 +187,15 @@ jobs:
           #    `architecture/` drop resolves through GetPage to
           #    the section permalink rather than nesting under
           #    the leaf page (the source-vs-rendered-depth bug).
-          if ! grep -q 'href=/docs/development/architecture/' \
+          if ! grep -q "href=${prefix}/docs/development/architecture/" \
               public/docs/development/architecture-audit/index.html; then
-            echo "::error::render-link: index.md drop misresolved on leaf page" >&2
+            echo "::error::render-link: index.md drop misresolved on leaf page (prefix=${prefix})" >&2
             exit 1
           fi
 
           # 3. Cross-rule references survive as the published
-          #    rule-page URL, not the unpublished README.md.
+          #    rule-page URL, not the unpublished README.md. No
+          #    prefix needed — this asserts absence.
           if grep -rq 'href=[^"]*README\.md' public/docs/rules/; then
             echo "::error::render-link: README.md target leaked into a rule page" >&2
             exit 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,15 @@ on:
       # those files must redeploy the site too.
       - "internal/rules/index.md"
       - "internal/rules/MDS*/**"
+      # The link-rewrite and sync logic that generates the
+      # site lives under cmd/mdsmith-release and
+      # internal/release. A regression in those packages
+      # would corrupt the published tree silently if the
+      # workflow only ran on docs/website edits, so trigger
+      # the deploy (which runs the synced-tree lint) on any
+      # change to the generator too.
+      - "cmd/mdsmith-release/**"
+      - "internal/release/**"
       - ".github/workflows/pages.yml"
   workflow_call:
     inputs:

--- a/PLAN.md
+++ b/PLAN.md
@@ -96,4 +96,5 @@ footer: |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
 | 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |
 | 169 | 🔲     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)         |
+| 170 | 🔲     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                     |
 <?/catalog?>

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -13,6 +13,7 @@
 //	mdsmith-release build-wheels <artifacts-dir> <out-dir>
 //	mdsmith-release sync-docs <src-dir> <dst-dir>
 //	mdsmith-release build-website [--no-fix] [src-dir] [dst-dir]
+//	mdsmith-release verify-website-links --dir <html-dir> [--base-url <url>]
 //	mdsmith-release publish-release
 //	mdsmith-release check-secret-rotations
 //	mdsmith-release record-rotation <ENTRY_TITLE> <YYYY-MM-DD>
@@ -43,6 +44,8 @@ Commands:
   sync-docs <src> <dst>           Snapshot docs/ into a Hugo content tree.
   build-website [--no-fix] [src] [dst]
                                   mdsmith fix (unless --no-fix) + sync-docs.
+  verify-website-links --dir <dir> [--base-url <url>]
+                                  Probe rendered HTML for render-link regressions.
   publish-release                 Flip the tag's draft release to published.
   check-secret-rotations          Open GitHub issues for secrets due for rotation.
   record-rotation <title> <date>  Update lastRotated in a per-secret rotation file.
@@ -79,6 +82,8 @@ func run(args []string) int {
 		return runSyncDocs(root, rest)
 	case "build-website":
 		return runBuildWebsite(root, rest)
+	case "verify-website-links":
+		return runVerifyWebsiteLinks(root, rest)
 	case "publish-release":
 		return runPublishRelease(root, rest)
 	case "check-secret-rotations":
@@ -237,6 +242,35 @@ func runBuildWebsite(_ string, args []string) int {
 		dst = fs.Arg(1)
 	}
 	return reportError(release.BuildWebsite(src, dst, !*noFix))
+}
+
+func runVerifyWebsiteLinks(_ string, args []string) int {
+	fs := flag.NewFlagSet("verify-website-links", flag.ContinueOnError)
+	dir := fs.String("dir", "",
+		"path to the Hugo output directory (usually website/public)")
+	baseURL := fs.String("base-url", "",
+		"baseURL Hugo was built with — its path component is the expected prefix on site-absolute hrefs")
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			"Usage: mdsmith-release verify-website-links --dir <dir> [--base-url <url>]\n\n"+
+				"Probe the rendered HTML in <dir> for the rewrites the\n"+
+				"render-link hook is responsible for: sibling `.md` →\n"+
+				"page permalink, `index.md` drop → section URL, no\n"+
+				"unpublished `README.md` hrefs in rule pages,\n"+
+				"javascript:/data: hrefs neutralized, and the configured\n"+
+				"baseURL prefix on site-absolute hrefs. Exits non-zero on\n"+
+				"the first failed probe.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: verify-website-links"); code >= 0 {
+			return code
+		}
+	}
+	if *dir == "" {
+		fs.Usage()
+		return 2
+	}
+	return reportError(release.VerifyWebsiteLinks(*dir, *baseURL))
 }
 
 // reportFlagParseErr mirrors the helper in cmd/mdsmith/main.go:

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -214,14 +214,17 @@ func TestRunVerifyWebsiteLinksHappyPath(t *testing.T) {
 	root := t.TempDir()
 	mq := filepath.Join(root, "docs", "development", "merge-queue", "index.html")
 	aa := filepath.Join(root, "docs", "development", "architecture-audit", "index.html")
+	st := filepath.Join(root, "docs", "reference", "schema-types", "index.html")
 	rule := filepath.Join(root, "docs", "rules", "mds001", "index.html")
-	for _, dir := range []string{filepath.Dir(mq), filepath.Dir(aa), filepath.Dir(rule)} {
+	for _, dir := range []string{filepath.Dir(mq), filepath.Dir(aa), filepath.Dir(st), filepath.Dir(rule)} {
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
 	require.NoError(t, os.WriteFile(mq,
 		[]byte(`<a href="/docs/development/pr-fixup-workflow/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(aa,
 		[]byte(`<a href="/docs/development/architecture/">x</a>`), 0o644))
+	require.NoError(t, os.WriteFile(st,
+		[]byte(`<a href="/docs/rules/MDS020-required-structure/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(rule,
 		[]byte(`<a href="/docs/rules/mds021/">x</a>`), 0o644))
 

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -97,7 +97,7 @@ func TestReportFlagParseErrNilReturnsContinue(t *testing.T) {
 func TestSubcommandHelpExitsZero(t *testing.T) {
 	for _, sub := range []string{
 		"stamp", "check", "build-npm", "build-wheels",
-		"sync-docs", "build-website",
+		"sync-docs", "build-website", "verify-website-links",
 	} {
 		assert.Equal(t, 0, run([]string{sub, "--help"}), "%s --help", sub)
 	}
@@ -108,7 +108,7 @@ func TestSubcommandHelpExitsZero(t *testing.T) {
 func TestSubcommandRejectsUnknownFlag(t *testing.T) {
 	for _, sub := range []string{
 		"stamp", "check", "build-npm", "build-wheels",
-		"sync-docs", "build-website",
+		"sync-docs", "build-website", "verify-website-links",
 	} {
 		assert.Equal(t, 2, run([]string{sub, "--bogus"}), "%s --bogus", sub)
 	}
@@ -203,6 +203,45 @@ func TestRunBuildWebsiteEndToEnd(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(dst, "top.md"))
 	require.NoError(t, err)
 	assert.Equal(t, "top body\n", string(got))
+}
+
+// TestRunVerifyWebsiteLinksHappyPath dispatches through
+// `run verify-website-links --dir <dir>` against a
+// minimal Hugo-output fixture so the subcommand wiring
+// (required-flag check, baseURL default, reportError) is
+// exercised end-to-end.
+func TestRunVerifyWebsiteLinksHappyPath(t *testing.T) {
+	root := t.TempDir()
+	mq := filepath.Join(root, "docs", "development", "merge-queue", "index.html")
+	aa := filepath.Join(root, "docs", "development", "architecture-audit", "index.html")
+	rule := filepath.Join(root, "docs", "rules", "mds001", "index.html")
+	for _, dir := range []string{filepath.Dir(mq), filepath.Dir(aa), filepath.Dir(rule)} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	require.NoError(t, os.WriteFile(mq,
+		[]byte(`<a href="/docs/development/pr-fixup-workflow/">x</a>`), 0o644))
+	require.NoError(t, os.WriteFile(aa,
+		[]byte(`<a href="/docs/development/architecture/">x</a>`), 0o644))
+	require.NoError(t, os.WriteFile(rule,
+		[]byte(`<a href="/docs/rules/mds021/">x</a>`), 0o644))
+
+	assert.Equal(t, 0, run([]string{"verify-website-links", "--dir", root}))
+}
+
+// TestRunVerifyWebsiteLinksMissingDir drives the
+// required-flag branch: omitting --dir prints usage and
+// returns exit code 2 without touching the filesystem.
+func TestRunVerifyWebsiteLinksMissingDir(t *testing.T) {
+	assert.Equal(t, 2, run([]string{"verify-website-links"}))
+}
+
+// TestRunVerifyWebsiteLinksReportsError drives the
+// reportError non-nil branch: pointing at an empty
+// directory makes the first probe fail with
+// "rendered HTML not found", so runVerifyWebsiteLinks
+// must surface exit code 1.
+func TestRunVerifyWebsiteLinksReportsError(t *testing.T) {
+	assert.Equal(t, 1, run([]string{"verify-website-links", "--dir", t.TempDir()}))
 }
 
 // TestRunBuildWebsiteReportsError drives the reportError

--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -312,9 +312,17 @@ func humanizeDirName(name string) string {
 // parse drives both the body-H1 → front-matter title lift
 // and the <?…?> directive-marker strip (see
 // reconcileDocForHugo), then literal shortcode patterns are
-// escaped so documentation about Hugo renders verbatim.
+// escaped so documentation about Hugo renders verbatim,
+// and finally any repo-relative `internal/rules/MDS…/[README.md]`
+// link is rewritten to its published `/docs/rules/MDS…/` URL.
+// The rule-link rewrite runs at this layer rather than in
+// website.go's rule-specific syncs because plain docs (e.g.
+// docs/background/concepts/generated-section.md) link into
+// internal/rules/ too; without the rewrite those links resolve
+// to a non-existent path on the site even though they work on
+// GitHub.
 func transformMarkdown(b []byte) []byte {
-	return escapeHugoShortcodes(reconcileDocForHugo(b))
+	return rewriteRuleLinks(escapeHugoShortcodes(reconcileDocForHugo(b)))
 }
 
 // splitDocFrontMatter separates a leading "---\n…\n---\n" block

--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -308,19 +308,28 @@ func humanizeDirName(name string) string {
 }
 
 // transformMarkdown applies the docs/-tree → Hugo content
-// reconciliations to one markdown file: a single goldmark
-// parse drives both the body-H1 → front-matter title lift
-// and the <?…?> directive-marker strip (see
-// reconcileDocForHugo), then literal shortcode patterns are
-// escaped so documentation about Hugo renders verbatim,
-// and finally any repo-relative `internal/rules/MDS…/[README.md]`
-// link is rewritten to its published `/docs/rules/MDS…/` URL.
-// The rule-link rewrite runs at this layer rather than in
-// website.go's rule-specific syncs because plain docs (e.g.
-// docs/background/concepts/generated-section.md) link into
-// internal/rules/ too; without the rewrite those links resolve
-// to a non-existent path on the site even though they work on
-// GitHub.
+// reconciliations to one markdown file in three layered passes:
+//
+//   - reconcileDocForHugo: one goldmark parse lifts the first
+//     body H1 to front-matter title and strips <?…?> directive
+//     markers.
+//   - escapeHugoShortcodes: literal `{{< … >}}` / `{{% … %}}`
+//     patterns are rewritten to their Hugo escape forms so
+//     documentation about Hugo renders verbatim.
+//   - rewriteRuleLinks: every repo-relative Markdown link is
+//     routed for the published site — `internal/rules/MDS…/`
+//     becomes `/docs/rules/MDS…/`, every other non-published
+//     path (plan/, internal/ Go packages, .claude/, root files,
+//     …) becomes a GitHub blob/tree URL, and a sibling
+//     `<path>/index.md` reference drops to `<path>/` so Hugo's
+//     section URL resolves. All three rewrites run under
+//     applyOutsideCode so documented examples inside fenced or
+//     inline code spans pass through verbatim.
+//
+// rewriteRuleLinks runs here (not only in website.go's
+// rule-specific syncs) because plain docs link into the same
+// non-published trees; without the rewrite their targets resolve
+// on GitHub but 404 on the site.
 func transformMarkdown(b []byte) []byte {
 	return rewriteRuleLinks(escapeHugoShortcodes(reconcileDocForHugo(b)))
 }

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -615,7 +615,6 @@ const (
 	ghBlob    = "https://github.com/jeduden/mdsmith/blob/main/"
 	ghTree    = "https://github.com/jeduden/mdsmith/tree/main/"
 	rulesBase = "/docs/rules/"
-	docsBase  = "/docs/"
 )
 
 // transformCase pairs an input markdown body with the expected

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -781,6 +781,21 @@ func TestTransformMarkdown_SkipsFencedExamples(t *testing.T) {
 			in:   "Doc `[p](../../plan/x.md)` real [p](../../plan/y.md).\n",
 			want: "Doc `[p](../../plan/x.md)` real [p](" + ghBlob + "plan/y.md).\n",
 		},
+		{
+			name: "single backtick run is not a fence — rewrite continues",
+			in:   "Prose with one `tick` and [p](../../plan/y.md).\n",
+			want: "Prose with one `tick` and [p](" + ghBlob + "plan/y.md).\n",
+		},
+		{
+			name: "line starting with one backtick does not open a fence",
+			in:   "`code line`\n\n[p](../../plan/y.md)\n",
+			want: "`code line`\n\n[p](" + ghBlob + "plan/y.md)\n",
+		},
+		{
+			name: "closing fence with leading spaces still ends fence",
+			in:   "```markdown\n[r](../../plan/a.md)\n   ```\n\nReal [p](../../plan/b.md).\n",
+			want: "```markdown\n[r](../../plan/a.md)\n   ```\n\nReal [p](" + ghBlob + "plan/b.md).\n",
+		},
 	})
 }
 

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -646,6 +646,46 @@ func TestTransformMarkdown_RewritesRuleLinks(t *testing.T) {
 			in:   "See [MDS019](/docs/rules/MDS019-catalog/).\n",
 			want: "See [MDS019](/docs/rules/MDS019-catalog/).\n",
 		},
+		{
+			name: "deep rule link preserves anchor",
+			in:   "See [MDS020 anchor](../../../internal/rules/MDS020-required-structure/README.md#index-side-output).\n",
+			want: "See [MDS020 anchor](/docs/rules/MDS020-required-structure/#index-side-output).\n",
+		},
+		{
+			name: "plan link to GitHub blob URL",
+			in:   "See [plan 154](../../plan/154_arch-fix-rule-helper-extraction.md).\n",
+			want: "See [plan 154](https://github.com/jeduden/mdsmith/blob/main/plan/154_arch-fix-rule-helper-extraction.md).\n",
+		},
+		{
+			name: "internal Go source to GitHub blob URL",
+			in:   "See [convention loader](../../internal/config/convention.go).\n",
+			want: "See [convention loader](https://github.com/jeduden/mdsmith/blob/main/internal/config/convention.go).\n",
+		},
+		{
+			name: "claude skill to GitHub blob URL",
+			in:   "See [skill](../../../.claude/skills/solid-architecture/SKILL.md).\n",
+			want: "See [skill](https://github.com/jeduden/mdsmith/blob/main/.claude/skills/solid-architecture/SKILL.md).\n",
+		},
+		{
+			name: "repo root PLAN.md to GitHub blob URL",
+			in:   "See [PLAN](../../PLAN.md).\n",
+			want: "See [PLAN](https://github.com/jeduden/mdsmith/blob/main/PLAN.md).\n",
+		},
+		{
+			name: "sibling index.md renamed to _index.md",
+			in:   "See [arch](architecture/index.md).\n",
+			want: "See [arch](architecture/_index.md).\n",
+		},
+		{
+			name: "sibling index.md with anchor renamed",
+			in:   "See [arch deep](architecture/index.md#section).\n",
+			want: "See [arch deep](architecture/_index.md#section).\n",
+		},
+		{
+			name: "non-published reference-style def to GitHub",
+			in:   "[plan154]: ../../plan/154_arch.md\n",
+			want: "[plan154]: https://github.com/jeduden/mdsmith/blob/main/plan/154_arch.md\n",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -608,6 +608,52 @@ func TestReconcileDocForHugo_StripNoOp(t *testing.T) {
 	}
 }
 
+// TestTransformMarkdown_RewritesRuleLinks: docs that link into
+// internal/rules/ (any `../` depth, with or without README.md,
+// inline or reference-style) must come out pointing at the
+// published /docs/rules/<dir>/ URL. The same link works on
+// GitHub because the source tree still has internal/rules/, but
+// that directory is not published on the site — without the
+// rewrite the link 404s.
+func TestTransformMarkdown_RewritesRuleLinks(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "deep inline no readme",
+			in:   "See [MDS019 catalog](../../../../internal/rules/MDS019-catalog/).\n",
+			want: "See [MDS019 catalog](/docs/rules/MDS019-catalog/).\n",
+		},
+		{
+			name: "shallow inline with readme",
+			in:   "See [MDS020](../../internal/rules/MDS020-required-structure/README.md).\n",
+			want: "See [MDS020](/docs/rules/MDS020-required-structure/).\n",
+		},
+		{
+			name: "reference-style def with readme",
+			in:   "[mds027]: ../../../internal/rules/MDS027-cross-file-reference-integrity/README.md\n",
+			want: "[mds027]: /docs/rules/MDS027-cross-file-reference-integrity/\n",
+		},
+		{
+			name: "reference-style def no readme",
+			in:   "[mds019]: ../../../../internal/rules/MDS019-catalog/\n",
+			want: "[mds019]: /docs/rules/MDS019-catalog/\n",
+		},
+		{
+			name: "already-rewritten path is unchanged",
+			in:   "See [MDS019](/docs/rules/MDS019-catalog/).\n",
+			want: "See [MDS019](/docs/rules/MDS019-catalog/).\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, string(transformMarkdown([]byte(tc.in))))
+		})
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -724,21 +724,29 @@ func TestTransformMarkdown_RewritesNonPublishedLinks(t *testing.T) {
 	})
 }
 
-// TestTransformMarkdown_RenamesIndexMd: a relative link that
-// keeps the docs/-tree convention `index.md` filename must be
-// rewritten to `_index.md` to match SyncDocs' rename, so MDS027
-// resolves the synced target. Anchor is preserved.
-func TestTransformMarkdown_RenamesIndexMd(t *testing.T) {
+// TestTransformMarkdown_DropsIndexMdFilename: Hugo serves a
+// section's _index.md at the directory URL (no filename), so a
+// relative `<path>/index.md` link in a docs body must be
+// rewritten to `<path>/` to render correctly on the site. The
+// anchor passes through; a bare `index.md` with no parent
+// directory is left alone because the resulting empty target
+// would be ambiguous.
+func TestTransformMarkdown_DropsIndexMdFilename(t *testing.T) {
 	runTransformCases(t, []transformCase{
 		{
-			name: "sibling index.md renamed",
+			name: "sibling index.md becomes section URL",
 			in:   "See [x](architecture/index.md).\n",
-			want: "See [x](architecture/_index.md).\n",
+			want: "See [x](architecture/).\n",
 		},
 		{
 			name: "sibling index.md with anchor",
 			in:   "See [x](architecture/index.md#section).\n",
-			want: "See [x](architecture/_index.md#section).\n",
+			want: "See [x](architecture/#section).\n",
+		},
+		{
+			name: "bare index.md with no parent dir is unchanged",
+			in:   "See [x](index.md).\n",
+			want: "See [x](index.md).\n",
 		},
 	})
 }

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -608,9 +608,10 @@ func TestReconcileDocForHugo_StripNoOp(t *testing.T) {
 	}
 }
 
-// shortGH is the GitHub base URL split for readability under
-// the lll line-length cap; tests below build the full /blob/ or
-// /tree/ form by appending the path.
+// ghBlob / ghTree / rulesBase short-name the URL prefixes that
+// would otherwise blow past the lll line-length cap in every
+// expected-output literal below. Tests append the rest of the
+// path inline.
 const (
 	ghBlob    = "https://github.com/jeduden/mdsmith/blob/main/"
 	ghTree    = "https://github.com/jeduden/mdsmith/tree/main/"

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -608,6 +608,34 @@ func TestReconcileDocForHugo_StripNoOp(t *testing.T) {
 	}
 }
 
+// shortGH is the GitHub base URL split for readability under
+// the lll line-length cap; tests below build the full /blob/ or
+// /tree/ form by appending the path.
+const (
+	ghBlob    = "https://github.com/jeduden/mdsmith/blob/main/"
+	ghTree    = "https://github.com/jeduden/mdsmith/tree/main/"
+	rulesBase = "/docs/rules/"
+	docsBase  = "/docs/"
+)
+
+// transformCase pairs an input markdown body with the expected
+// transformMarkdown output so every test below can share the
+// same runTransformCases driver.
+type transformCase struct {
+	name string
+	in   string
+	want string
+}
+
+func runTransformCases(t *testing.T, cases []transformCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, string(transformMarkdown([]byte(tc.in))))
+		})
+	}
+}
+
 // TestTransformMarkdown_RewritesRuleLinks: docs that link into
 // internal/rules/ (any `../` depth, with or without README.md,
 // inline or reference-style) must come out pointing at the
@@ -616,82 +644,144 @@ func TestReconcileDocForHugo_StripNoOp(t *testing.T) {
 // that directory is not published on the site — without the
 // rewrite the link 404s.
 func TestTransformMarkdown_RewritesRuleLinks(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want string
-	}{
+	runTransformCases(t, []transformCase{
 		{
 			name: "deep inline no readme",
-			in:   "See [MDS019 catalog](../../../../internal/rules/MDS019-catalog/).\n",
-			want: "See [MDS019 catalog](/docs/rules/MDS019-catalog/).\n",
+			in:   "See [x](../../../../internal/rules/MDS019-catalog/).\n",
+			want: "See [x](" + rulesBase + "MDS019-catalog/).\n",
 		},
 		{
 			name: "shallow inline with readme",
-			in:   "See [MDS020](../../internal/rules/MDS020-required-structure/README.md).\n",
-			want: "See [MDS020](/docs/rules/MDS020-required-structure/).\n",
+			in:   "See [x](../../internal/rules/MDS020-required-structure/README.md).\n",
+			want: "See [x](" + rulesBase + "MDS020-required-structure/).\n",
 		},
 		{
 			name: "reference-style def with readme",
-			in:   "[mds027]: ../../../internal/rules/MDS027-cross-file-reference-integrity/README.md\n",
-			want: "[mds027]: /docs/rules/MDS027-cross-file-reference-integrity/\n",
+			in:   "[mds]: ../../../internal/rules/MDS027-cross-file-reference-integrity/README.md\n",
+			want: "[mds]: " + rulesBase + "MDS027-cross-file-reference-integrity/\n",
 		},
 		{
 			name: "reference-style def no readme",
-			in:   "[mds019]: ../../../../internal/rules/MDS019-catalog/\n",
-			want: "[mds019]: /docs/rules/MDS019-catalog/\n",
+			in:   "[mds]: ../../../../internal/rules/MDS019-catalog/\n",
+			want: "[mds]: " + rulesBase + "MDS019-catalog/\n",
 		},
 		{
 			name: "already-rewritten path is unchanged",
-			in:   "See [MDS019](/docs/rules/MDS019-catalog/).\n",
-			want: "See [MDS019](/docs/rules/MDS019-catalog/).\n",
+			in:   "See [x](" + rulesBase + "MDS019-catalog/).\n",
+			want: "See [x](" + rulesBase + "MDS019-catalog/).\n",
 		},
 		{
 			name: "deep rule link preserves anchor",
-			in:   "See [MDS020 anchor](../../../internal/rules/MDS020-required-structure/README.md#index-side-output).\n",
-			want: "See [MDS020 anchor](/docs/rules/MDS020-required-structure/#index-side-output).\n",
+			in:   "See [x](../../../internal/rules/MDS020-required-structure/README.md#out).\n",
+			want: "See [x](" + rulesBase + "MDS020-required-structure/#out).\n",
+		},
+	})
+}
+
+// TestTransformMarkdown_RewritesNonPublishedLinks: every
+// repo-relative link to a path outside the published trees
+// (plan/, cmd/, internal/ non-rules, .claude/, root files)
+// must rewrite to a GitHub URL. The /blob/ vs /tree/ route is
+// decided by trailing slash: files go to /blob/, directories to
+// /tree/. The reference-style sibling shares the rewrite logic.
+func TestTransformMarkdown_RewritesNonPublishedLinks(t *testing.T) {
+	runTransformCases(t, []transformCase{
+		{
+			name: "plan link → GitHub blob",
+			in:   "See [x](../../plan/154_arch.md).\n",
+			want: "See [x](" + ghBlob + "plan/154_arch.md).\n",
 		},
 		{
-			name: "plan link to GitHub blob URL",
-			in:   "See [plan 154](../../plan/154_arch-fix-rule-helper-extraction.md).\n",
-			want: "See [plan 154](https://github.com/jeduden/mdsmith/blob/main/plan/154_arch-fix-rule-helper-extraction.md).\n",
+			name: "internal Go source → GitHub blob",
+			in:   "See [x](../../internal/config/convention.go).\n",
+			want: "See [x](" + ghBlob + "internal/config/convention.go).\n",
 		},
 		{
-			name: "internal Go source to GitHub blob URL",
-			in:   "See [convention loader](../../internal/config/convention.go).\n",
-			want: "See [convention loader](https://github.com/jeduden/mdsmith/blob/main/internal/config/convention.go).\n",
+			name: "claude skill → GitHub blob",
+			in:   "See [x](../../../.claude/skills/foo/SKILL.md).\n",
+			want: "See [x](" + ghBlob + ".claude/skills/foo/SKILL.md).\n",
 		},
 		{
-			name: "claude skill to GitHub blob URL",
-			in:   "See [skill](../../../.claude/skills/solid-architecture/SKILL.md).\n",
-			want: "See [skill](https://github.com/jeduden/mdsmith/blob/main/.claude/skills/solid-architecture/SKILL.md).\n",
+			name: "repo root PLAN.md → GitHub blob",
+			in:   "See [x](../../PLAN.md).\n",
+			want: "See [x](" + ghBlob + "PLAN.md).\n",
 		},
 		{
-			name: "repo root PLAN.md to GitHub blob URL",
-			in:   "See [PLAN](../../PLAN.md).\n",
-			want: "See [PLAN](https://github.com/jeduden/mdsmith/blob/main/PLAN.md).\n",
+			name: "internal directory → GitHub tree",
+			in:   "See [x](../../internal/lint/).\n",
+			want: "See [x](" + ghTree + "internal/lint/).\n",
 		},
 		{
-			name: "sibling index.md renamed to _index.md",
-			in:   "See [arch](architecture/index.md).\n",
-			want: "See [arch](architecture/_index.md).\n",
+			name: "reference-style def → GitHub blob",
+			in:   "[plan]: ../../plan/154_arch.md\n",
+			want: "[plan]: " + ghBlob + "plan/154_arch.md\n",
 		},
 		{
-			name: "sibling index.md with anchor renamed",
-			in:   "See [arch deep](architecture/index.md#section).\n",
-			want: "See [arch deep](architecture/_index.md#section).\n",
+			name: "reference-style def directory → GitHub tree",
+			in:   "[lint]: ../../internal/lint/\n",
+			want: "[lint]: " + ghTree + "internal/lint/\n",
+		},
+	})
+}
+
+// TestTransformMarkdown_RenamesIndexMd: a relative link that
+// keeps the docs/-tree convention `index.md` filename must be
+// rewritten to `_index.md` to match SyncDocs' rename, so MDS027
+// resolves the synced target. Anchor is preserved.
+func TestTransformMarkdown_RenamesIndexMd(t *testing.T) {
+	runTransformCases(t, []transformCase{
+		{
+			name: "sibling index.md renamed",
+			in:   "See [x](architecture/index.md).\n",
+			want: "See [x](architecture/_index.md).\n",
 		},
 		{
-			name: "non-published reference-style def to GitHub",
-			in:   "[plan154]: ../../plan/154_arch.md\n",
-			want: "[plan154]: https://github.com/jeduden/mdsmith/blob/main/plan/154_arch.md\n",
+			name: "sibling index.md with anchor",
+			in:   "See [x](architecture/index.md#section).\n",
+			want: "See [x](architecture/_index.md#section).\n",
 		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, string(transformMarkdown([]byte(tc.in))))
-		})
-	}
+	})
+}
+
+// TestTransformMarkdown_SkipsFencedExamples: fenced code blocks
+// contain Markdown examples (rule READMEs demoing what a
+// directive rewrites, catalog-output snippets in the directive
+// guide) whose link patterns are documentation, not real
+// targets. transformMarkdown's rewrites must leave those lines
+// verbatim or the published docs misrepresent the tool.
+func TestTransformMarkdown_SkipsFencedExamples(t *testing.T) {
+	runTransformCases(t, []transformCase{
+		{
+			name: "backtick fence preserves rule-link example",
+			in:   "```markdown\nSee [r](../../internal/rules/MDS019-catalog/).\n```\n",
+			want: "```markdown\nSee [r](../../internal/rules/MDS019-catalog/).\n```\n",
+		},
+		{
+			name: "backtick fence preserves index.md example",
+			in:   "```markdown\n- [i](development/index.md)\n```\n",
+			want: "```markdown\n- [i](development/index.md)\n```\n",
+		},
+		{
+			name: "tilde fence preserves plan example",
+			in:   "~~~markdown\nSee [p](../../plan/x.md).\n~~~\n",
+			want: "~~~markdown\nSee [p](../../plan/x.md).\n~~~\n",
+		},
+		{
+			name: "fence followed by real link still rewrites the real link",
+			in:   "```markdown\n[r](../../plan/x.md)\n```\n\nSee [p](../../plan/y.md).\n",
+			want: "```markdown\n[r](../../plan/x.md)\n```\n\nSee [p](" + ghBlob + "plan/y.md).\n",
+		},
+		{
+			name: "inline code span preserves rule-link example",
+			in:   "Sample: `[r](../../internal/rules/MDS019-catalog/)` is doc.\n",
+			want: "Sample: `[r](../../internal/rules/MDS019-catalog/)` is doc.\n",
+		},
+		{
+			name: "inline code span and real link on same line",
+			in:   "Doc `[p](../../plan/x.md)` real [p](../../plan/y.md).\n",
+			want: "Doc `[p](../../plan/x.md)` real [p](" + ghBlob + "plan/y.md).\n",
+		},
+	})
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -609,9 +609,9 @@ func TestReconcileDocForHugo_StripNoOp(t *testing.T) {
 }
 
 // ghBlob / ghTree / rulesBase short-name the URL prefixes that
-// would otherwise blow past the lll line-length cap in every
-// expected-output literal below. Tests append the rest of the
-// path inline.
+// would otherwise blow past the golangci-lint `lll` (line-length)
+// cap in every expected-output literal below. Tests append the
+// rest of the path inline.
 const (
 	ghBlob    = "https://github.com/jeduden/mdsmith/blob/main/"
 	ghTree    = "https://github.com/jeduden/mdsmith/tree/main/"

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -1,0 +1,181 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// VerifyWebsiteLinks runs a fixed set of probes against the
+// rendered HTML produced by `hugo --minify ...`. Each probe
+// targets a behavior the render-link hook is responsible for:
+// `.md` → permalink resolution, `index.md` → section URL,
+// no `README.md` hrefs in rule pages, javascript:/data:
+// hrefs neutralized by html/template, and the baseURL prefix
+// appearing on site-absolute hrefs when one was supplied at
+// build time. None of these are visible to the synced-tree
+// mdsmith check (it walks the markdown filesystem
+// pre-render), so without these probes a regression in the
+// render-link hook ships silently.
+//
+// htmlDir is the Hugo output root (`public/` under
+// website/). baseURL is the URL Hugo was built with; the
+// path portion (e.g. `/mdsmith` for project-pages, empty
+// for root deploys) is treated as the expected path prefix
+// on every site-absolute href. Each probe's regex accepts
+// both `href="value"` (Hugo's default) and `href=value`
+// (--minify), so the function is robust whether or not the
+// caller passed `--minify`.
+//
+// Probes fail closed with a single returned error naming
+// the probe and the file that failed; subsequent probes
+// are not run.
+func VerifyWebsiteLinks(htmlDir, baseURL string) error {
+	prefix, err := pathPrefixFromBaseURL(baseURL)
+	if err != nil {
+		return fmt.Errorf("parse base url: %w", err)
+	}
+	for _, p := range websiteLinkProbes(prefix) {
+		if err := runWebsiteLinkProbe(htmlDir, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// linkProbe describes one rendered-HTML assertion. Either
+// wantMatch or wantNoMatch is set, never both; whichever is
+// non-nil drives the check at that path. recursive=true
+// scans every .html file under path; recursive=false reads
+// the single file at path.
+type linkProbe struct {
+	name        string
+	path        string
+	wantMatch   *regexp.Regexp
+	wantNoMatch *regexp.Regexp
+	recursive   bool
+}
+
+// websiteLinkProbes returns the probes that VerifyWebsiteLinks
+// runs against the rendered output. Built fresh per call so
+// the captured prefix lands in each regex; prefix is the
+// site-path component of the build's baseURL (`/mdsmith`
+// for a project-pages deploy, "" for a root deploy).
+func websiteLinkProbes(prefix string) []linkProbe {
+	q := regexp.QuoteMeta
+	hrefEq := `href="?` // allow both quoted (default) and unquoted (minified) emission
+	return []linkProbe{
+		{
+			name: "sibling .md resolves to target permalink",
+			path: "docs/development/merge-queue/index.html",
+			wantMatch: regexp.MustCompile(
+				hrefEq + q(prefix) + `/docs/development/pr-fixup-workflow/`),
+		},
+		{
+			name: "index.md drop resolves to section URL on leaf page",
+			path: "docs/development/architecture-audit/index.html",
+			wantMatch: regexp.MustCompile(
+				hrefEq + q(prefix) + `/docs/development/architecture/`),
+		},
+		{
+			name: "no README.md hrefs leaked into rule pages",
+			path: "docs/rules",
+			wantNoMatch: regexp.MustCompile(
+				`href=(?:"[^"]*README\.md|[^ ">]*README\.md)`),
+			recursive: true,
+		},
+		{
+			name:        "no javascript: hrefs reached rendered HTML",
+			path:        ".",
+			wantNoMatch: regexp.MustCompile(`href=(?:"javascript:|javascript:)`),
+			recursive:   true,
+		},
+		{
+			name:        "no data: hrefs reached rendered HTML",
+			path:        ".",
+			wantNoMatch: regexp.MustCompile(`href=(?:"data:|data:)`),
+			recursive:   true,
+		},
+	}
+}
+
+// runWebsiteLinkProbe evaluates one probe. For
+// non-recursive probes it reads a single file. For
+// recursive probes it walks the subtree and either reports
+// the first file matching wantNoMatch or aggregates all
+// files; wantMatch is not used with recursive=true today.
+func runWebsiteLinkProbe(root string, p linkProbe) error {
+	target := filepath.Join(root, p.path)
+	if !p.recursive {
+		data, err := readHTMLFile(target)
+		if err != nil {
+			return fmt.Errorf("verify %q: %w", p.name, err)
+		}
+		if p.wantMatch != nil && !p.wantMatch.Match(data) {
+			return fmt.Errorf("verify %q: no match for %s in %s",
+				p.name, p.wantMatch, target)
+		}
+		if p.wantNoMatch != nil && p.wantNoMatch.Match(data) {
+			return fmt.Errorf("verify %q: unwanted match for %s in %s",
+				p.name, p.wantNoMatch, target)
+		}
+		return nil
+	}
+	if p.wantNoMatch == nil {
+		return fmt.Errorf("verify %q: recursive probe needs wantNoMatch", p.name)
+	}
+	return filepath.WalkDir(target, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		data, err := readHTMLFile(path)
+		if err != nil {
+			return err
+		}
+		if p.wantNoMatch.Match(data) {
+			return fmt.Errorf("verify %q: unwanted match for %s in %s",
+				p.name, p.wantNoMatch, path)
+		}
+		return nil
+	})
+}
+
+// readHTMLFile reads an HTML file via the package's fs seam
+// for symmetry with the other release subcommands.
+// filepath.WalkDir bypasses the seam, so this routes through
+// it consistently for unit-test injection points.
+func readHTMLFile(path string) ([]byte, error) {
+	t := New()
+	data, err := t.fs.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("rendered HTML not found: %s", path)
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return data, nil
+}
+
+// pathPrefixFromBaseURL returns the URL path component of
+// baseURL, with a trailing slash trimmed so the caller can
+// concatenate `/docs/...` without producing `//docs/...`.
+// An empty baseURL or a root-deploy baseURL
+// (`https://example.com/`) yields "". A project-pages
+// baseURL (`https://example.com/repo/`) yields `/repo`.
+func pathPrefixFromBaseURL(baseURL string) (string, error) {
+	if baseURL == "" {
+		return "", nil
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(u.Path, "/"), nil
+}

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -82,6 +83,19 @@ func websiteLinkProbes(prefix string) []linkProbe {
 				hrefEq + q(prefix) + `/docs/development/architecture/`),
 		},
 		{
+			// The rewriter emits site-absolute `/docs/rules/<id>/`
+			// targets for every cross-rule and docs-to-rule link.
+			// The render-link hook routes those through relURL so
+			// the rendered href carries the baseURL's path prefix
+			// (empty for root deploys). Without this probe a
+			// regression in relURL would slip past the two probes
+			// above, which exercise only the GetPage branch.
+			name: "site-absolute /docs/rules/ href carries baseURL prefix",
+			path: "docs/reference/schema-types/index.html",
+			wantMatch: regexp.MustCompile(
+				hrefEq + q(prefix) + `/docs/rules/MDS020-required-structure/`),
+		},
+		{
 			name: "no README.md hrefs leaked into rule pages",
 			path: "docs/rules",
 			wantNoMatch: regexp.MustCompile(
@@ -154,8 +168,11 @@ func walkAndReject(target string, p linkProbe) error {
 // readHTMLFile reads an HTML file and wraps a missing-file
 // error with a clearer message so the probe failure points
 // at the rendered tree rather than a generic open error.
+// Reads through os.ReadFile directly — VerifyWebsiteLinks
+// runs only against a real Hugo output tree on disk, so
+// there is no Toolkit fs seam to thread through here.
 func readHTMLFile(path string) ([]byte, error) {
-	data, err := New().fs.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("rendered HTML not found: %s", path)
 	}

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -48,17 +48,26 @@ func VerifyWebsiteLinks(htmlDir, baseURL string) error {
 	return nil
 }
 
-// linkProbe describes one rendered-HTML assertion. Either
-// wantMatch or wantNoMatch is set, never both; whichever is
-// non-nil drives the check at that path. recursive=true
-// scans every .html file under path; recursive=false reads
-// the single file at path.
+// linkProbe describes one rendered-HTML assertion. Exactly
+// one of wantMatch, wantNoMatch, or wantAnyMatch is set:
+//
+//   - wantMatch (non-recursive): the single file at path
+//     must contain a regex match.
+//   - wantNoMatch (recursive): no file under path may
+//     match — used for absence checks (no leaked README.md
+//     hrefs, no javascript: schemes, …).
+//   - wantAnyMatch (recursive): at least one file under
+//     path must match — used to assert a render-link
+//     behavior is reachable in the rendered output without
+//     tying the probe to one specific docs page that a
+//     legitimate edit could remove.
 type linkProbe struct {
-	name        string
-	path        string
-	wantMatch   *regexp.Regexp
-	wantNoMatch *regexp.Regexp
-	recursive   bool
+	name         string
+	path         string
+	wantMatch    *regexp.Regexp
+	wantNoMatch  *regexp.Regexp
+	wantAnyMatch *regexp.Regexp
+	recursive    bool
 }
 
 // websiteLinkProbes returns the probes that VerifyWebsiteLinks
@@ -85,15 +94,19 @@ func websiteLinkProbes(prefix string) []linkProbe {
 		{
 			// The rewriter emits site-absolute `/docs/rules/<id>/`
 			// targets for every cross-rule and docs-to-rule link.
-			// The render-link hook routes those through relURL so
-			// the rendered href carries the baseURL's path prefix
-			// (empty for root deploys). Without this probe a
-			// regression in relURL would slip past the two probes
-			// above, which exercise only the GetPage branch.
+			// The render-link hook manually prefixes those with
+			// site.Home.RelPermalink so the rendered href carries
+			// the baseURL's path component (empty on root
+			// deploys, `/<repo>` on project-pages). A recursive
+			// wantAnyMatch keeps the probe robust to legitimate
+			// docs edits — any rendered page that carries one
+			// such href satisfies the assertion, so removing a
+			// single content reference does not block the deploy.
 			name: "site-absolute /docs/rules/ href carries baseURL prefix",
-			path: "docs/reference/schema-types/index.html",
-			wantMatch: regexp.MustCompile(
-				hrefEq + q(prefix) + `/docs/rules/MDS020-required-structure/`),
+			path: "docs",
+			wantAnyMatch: regexp.MustCompile(
+				hrefEq + q(prefix) + `/docs/rules/MDS[0-9A-Za-z._-]+/`),
+			recursive: true,
 		},
 		{
 			name: "no README.md hrefs leaked into rule pages",
@@ -103,30 +116,37 @@ func websiteLinkProbes(prefix string) []linkProbe {
 			recursive: true,
 		},
 		{
+			// URL schemes are case-insensitive per RFC 3986 — a
+			// rendered `href="JavaScript:..."` is just as
+			// dangerous as the lowercase form. `(?i)` makes the
+			// regex case-fold so the probe catches both.
 			name:        "no javascript: hrefs reached rendered HTML",
 			path:        ".",
-			wantNoMatch: regexp.MustCompile(`href=(?:"javascript:|javascript:)`),
+			wantNoMatch: regexp.MustCompile(`(?i)href=(?:"javascript:|javascript:)`),
 			recursive:   true,
 		},
 		{
 			name:        "no data: hrefs reached rendered HTML",
 			path:        ".",
-			wantNoMatch: regexp.MustCompile(`href=(?:"data:|data:)`),
+			wantNoMatch: regexp.MustCompile(`(?i)href=(?:"data:|data:)`),
 			recursive:   true,
 		},
 	}
 }
 
 // runWebsiteLinkProbe evaluates one probe. Recursive probes
-// walk the subtree at p.path looking for any file that
-// matches p.wantNoMatch (every recursive probe today is an
-// absence check). Non-recursive probes read the single file
+// walk the subtree at p.path looking for either a forbidden
+// match (wantNoMatch) or at least one allowed match
+// (wantAnyMatch). Non-recursive probes read the single file
 // at p.path and require it to match p.wantMatch. Splitting
-// the two modes keeps each branch reachable from at least
-// one test.
+// the modes keeps each branch reachable from at least one
+// test.
 func runWebsiteLinkProbe(root string, p linkProbe) error {
 	target := filepath.Join(root, p.path)
 	if p.recursive {
+		if p.wantAnyMatch != nil {
+			return walkAndRequireAny(target, p)
+		}
 		return walkAndReject(target, p)
 	}
 	data, err := readHTMLFile(target)
@@ -163,6 +183,39 @@ func walkAndReject(target string, p linkProbe) error {
 		}
 		return nil
 	})
+}
+
+// walkAndRequireAny walks every .html file under target and
+// returns nil as soon as one matches p.wantAnyMatch. If no
+// file matches, returns a single error naming the regex and
+// the searched root. Walk errors propagate with the same
+// wrapping walkAndReject uses.
+func walkAndRequireAny(target string, p linkProbe) error {
+	var matched bool
+	walkErr := filepath.WalkDir(target, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("verify %q: walk %s: %w", p.name, path, err)
+		}
+		if matched || d.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		data, readErr := readHTMLFile(path)
+		if readErr != nil {
+			return fmt.Errorf("verify %q: %w", p.name, readErr)
+		}
+		if p.wantAnyMatch.Match(data) {
+			matched = true
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+	if !matched {
+		return fmt.Errorf("verify %q: no file under %s matched %s",
+			p.name, target, p.wantAnyMatch)
+	}
+	return nil
 }
 
 // readHTMLFile reads an HTML file and wraps a missing-file

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -103,41 +103,45 @@ func websiteLinkProbes(prefix string) []linkProbe {
 	}
 }
 
-// runWebsiteLinkProbe evaluates one probe. For
-// non-recursive probes it reads a single file. For
-// recursive probes it walks the subtree and either reports
-// the first file matching wantNoMatch or aggregates all
-// files; wantMatch is not used with recursive=true today.
+// runWebsiteLinkProbe evaluates one probe. Recursive probes
+// walk the subtree at p.path looking for any file that
+// matches p.wantNoMatch (every recursive probe today is an
+// absence check). Non-recursive probes read the single file
+// at p.path and require it to match p.wantMatch. Splitting
+// the two modes keeps each branch reachable from at least
+// one test.
 func runWebsiteLinkProbe(root string, p linkProbe) error {
 	target := filepath.Join(root, p.path)
-	if !p.recursive {
-		data, err := readHTMLFile(target)
-		if err != nil {
-			return fmt.Errorf("verify %q: %w", p.name, err)
-		}
-		if p.wantMatch != nil && !p.wantMatch.Match(data) {
-			return fmt.Errorf("verify %q: no match for %s in %s",
-				p.name, p.wantMatch, target)
-		}
-		if p.wantNoMatch != nil && p.wantNoMatch.Match(data) {
-			return fmt.Errorf("verify %q: unwanted match for %s in %s",
-				p.name, p.wantNoMatch, target)
-		}
-		return nil
+	if p.recursive {
+		return walkAndReject(target, p)
 	}
-	if p.wantNoMatch == nil {
-		return fmt.Errorf("verify %q: recursive probe needs wantNoMatch", p.name)
+	data, err := readHTMLFile(target)
+	if err != nil {
+		return fmt.Errorf("verify %q: %w", p.name, err)
 	}
-	return filepath.WalkDir(target, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	if !p.wantMatch.Match(data) {
+		return fmt.Errorf("verify %q: no match for %s in %s",
+			p.name, p.wantMatch, target)
+	}
+	return nil
+}
+
+// walkAndReject walks every .html file under target and
+// returns an error on the first match of p.wantNoMatch. The
+// WalkDir-supplied err is propagated so a broken symlink or
+// a missing target root surfaces with the same wrapping
+// readHTMLFile would produce on a single-file probe.
+func walkAndReject(target string, p linkProbe) error {
+	return filepath.WalkDir(target, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("verify %q: walk %s: %w", p.name, path, walkErr)
 		}
 		if d.IsDir() || filepath.Ext(path) != ".html" {
 			return nil
 		}
 		data, err := readHTMLFile(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("verify %q: %w", p.name, err)
 		}
 		if p.wantNoMatch.Match(data) {
 			return fmt.Errorf("verify %q: unwanted match for %s in %s",
@@ -147,20 +151,15 @@ func runWebsiteLinkProbe(root string, p linkProbe) error {
 	})
 }
 
-// readHTMLFile reads an HTML file via the package's fs seam
-// for symmetry with the other release subcommands.
-// filepath.WalkDir bypasses the seam, so this routes through
-// it consistently for unit-test injection points.
+// readHTMLFile reads an HTML file and wraps a missing-file
+// error with a clearer message so the probe failure points
+// at the rendered tree rather than a generic open error.
 func readHTMLFile(path string) ([]byte, error) {
-	t := New()
-	data, err := t.fs.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("rendered HTML not found: %s", path)
-		}
-		return nil, fmt.Errorf("read %s: %w", path, err)
+	data, err := New().fs.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("rendered HTML not found: %s", path)
 	}
-	return data, nil
+	return data, err
 }
 
 // pathPrefixFromBaseURL returns the URL path component of

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -1,0 +1,158 @@
+package release
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goodSite materializes a minimal Hugo output tree matching
+// every assertion VerifyWebsiteLinks runs. Each test below
+// starts from this corpus and mutates one file to break a
+// single probe, so each failing case is isolated to the
+// regex it targets.
+func goodSite(t *testing.T, prefix string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
+		`<a href="`+prefix+`/docs/development/pr-fixup-workflow/">pr fixup</a>`)
+	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
+		`<a href="`+prefix+`/docs/development/architecture/">arch</a>`)
+	writeFile(t, filepath.Join(root, "docs", "rules", "mds001", "index.html"),
+		`<a href="`+prefix+`/docs/rules/mds021/">sibling rule</a>`)
+	writeFile(t, filepath.Join(root, "index.html"), `<p>home</p>`)
+	return root
+}
+
+func TestVerifyWebsiteLinks_RootDeployPasses(t *testing.T) {
+	root := goodSite(t, "")
+	require.NoError(t, VerifyWebsiteLinks(root, ""))
+}
+
+func TestVerifyWebsiteLinks_SubpathDeployPasses(t *testing.T) {
+	root := goodSite(t, "/mdsmith")
+	require.NoError(t, VerifyWebsiteLinks(root, "https://example.com/mdsmith/"))
+}
+
+// TestVerifyWebsiteLinks_AcceptsUnquotedHref pins the bug
+// fix from PR #309 review: `hugo --minify` drops the
+// double-quote around href values when the URL contains no
+// characters that require quoting. The probe regexes must
+// match `href=value` as well as `href="value"`.
+func TestVerifyWebsiteLinks_AcceptsUnquotedHref(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
+		`<a href=/docs/development/pr-fixup-workflow/>pr fixup</a>`)
+	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
+		`<a href=/docs/development/architecture/>arch</a>`)
+	writeFile(t, filepath.Join(root, "docs", "rules", "mds001", "index.html"),
+		`<a href=/docs/rules/mds021/>sibling</a>`)
+	require.NoError(t, VerifyWebsiteLinks(root, ""))
+}
+
+func TestVerifyWebsiteLinks_FailsOnMissingSiblingMD(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
+		`<a href="pr-fixup-workflow.md">stale .md ref</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sibling .md")
+}
+
+func TestVerifyWebsiteLinks_FailsOnIndexMDMisresolved(t *testing.T) {
+	root := goodSite(t, "")
+	// Simulate the bug PR #309 fixed: relative target stayed
+	// relative, browser resolves below the leaf page.
+	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
+		`<a href="architecture/">stale relative</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "index.md drop")
+}
+
+func TestVerifyWebsiteLinks_FailsOnLeakedREADMEHref(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "docs", "rules", "mds999", "index.html"),
+		`<a href="../MDS021-include/README.md">leaked</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "README.md")
+}
+
+func TestVerifyWebsiteLinks_FailsOnQuotedREADMEHref(t *testing.T) {
+	// The quoted form must be caught too — the original
+	// inline-shell regex (`href=[^"]*README\.md`) could not
+	// cross the opening quote.
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "docs", "rules", "mds999", "index.html"),
+		`<a href="../README.md">quoted leak</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "README.md")
+}
+
+func TestVerifyWebsiteLinks_FailsOnJavascriptScheme(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),
+		`<a href="javascript:alert(1)">click</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "javascript:")
+}
+
+func TestVerifyWebsiteLinks_FailsOnDataScheme(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),
+		`<a href="data:text/html,<script>1</script>">click</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "data:")
+}
+
+func TestVerifyWebsiteLinks_FailsOnMissingPrefix(t *testing.T) {
+	root := goodSite(t, "") // built without prefix
+	err := VerifyWebsiteLinks(root, "https://example.com/mdsmith/")
+	require.Error(t, err)
+	// The probe should mention the prefix it expected.
+	assert.Contains(t, err.Error(), "/mdsmith/")
+}
+
+func TestVerifyWebsiteLinks_MissingTargetFileWraps(t *testing.T) {
+	root := t.TempDir() // no merge-queue file
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rendered HTML not found")
+}
+
+func TestPathPrefixFromBaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"root no slash", "https://example.com", ""},
+		{"root with slash", "https://example.com/", ""},
+		{"project pages", "https://example.com/mdsmith/", "/mdsmith"},
+		{"project pages no slash", "https://example.com/mdsmith", "/mdsmith"},
+		{"nested", "https://example.com/foo/bar/", "/foo/bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pathPrefixFromBaseURL(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPathPrefixFromBaseURL_InvalidURL(t *testing.T) {
+	_, err := pathPrefixFromBaseURL("://invalid")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "missing protocol") ||
+		strings.Contains(err.Error(), "parse"),
+		"err = %v", err)
+}

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -107,6 +107,38 @@ func TestVerifyWebsiteLinks_FailsOnJavascriptScheme(t *testing.T) {
 	assert.Contains(t, err.Error(), "javascript:")
 }
 
+// TestVerifyWebsiteLinks_FailsOnMixedCaseJavascript pins
+// the case-insensitive scheme guard: URL schemes are
+// case-insensitive per RFC 3986, so `JavaScript:` is the
+// same dangerous scheme as `javascript:` and the probe
+// must reject it too.
+func TestVerifyWebsiteLinks_FailsOnMixedCaseJavascript(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),
+		`<a href="JavaScript:alert(1)">click</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "javascript:")
+}
+
+// TestVerifyWebsiteLinks_FailsOnMissingSiteAbsolute exercises
+// walkAndRequireAny's no-match path: the good fixture has the
+// /docs/rules/MDSxxx/ link, but stripping the prefix
+// expectation means nothing matches under subpath baseURL.
+func TestVerifyWebsiteLinks_FailsOnMissingSiteAbsolute(t *testing.T) {
+	// Build a tree that has every required href except the
+	// site-absolute /docs/rules/MDSxxx/ form.
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
+		`<a href="/mdsmith/docs/development/pr-fixup-workflow/">x</a>`)
+	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
+		`<a href="/mdsmith/docs/development/architecture/">x</a>`)
+	// docs/ has no MDS-rule href under any subpath.
+	err := VerifyWebsiteLinks(root, "https://example.com/mdsmith/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "/mdsmith/docs/rules/")
+}
+
 func TestVerifyWebsiteLinks_FailsOnDataScheme(t *testing.T) {
 	root := goodSite(t, "")
 	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -127,6 +127,33 @@ func TestVerifyWebsiteLinks_MissingTargetFileWraps(t *testing.T) {
 	assert.Contains(t, err.Error(), "rendered HTML not found")
 }
 
+// TestVerifyWebsiteLinks_InvalidBaseURLWraps drives the
+// pathPrefixFromBaseURL error path. A URL with an unparsable
+// scheme returns an error before the probes run.
+func TestVerifyWebsiteLinks_InvalidBaseURLWraps(t *testing.T) {
+	err := VerifyWebsiteLinks(t.TempDir(), "://invalid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse base url")
+}
+
+// TestVerifyWebsiteLinks_MissingRecursiveRootWraps drives
+// the WalkDir-callback error branch in walkAndReject: the
+// recursive probe root (docs/rules) does not exist, so
+// WalkDir calls the callback with a stat error.
+func TestVerifyWebsiteLinks_MissingRecursiveRootWraps(t *testing.T) {
+	root := t.TempDir()
+	// Materialize only the non-recursive probe targets so we
+	// reach the recursive `no README.md leak` probe.
+	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
+		`<a href="/docs/development/pr-fixup-workflow/">x</a>`)
+	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
+		`<a href="/docs/development/architecture/">x</a>`)
+	// docs/rules is absent.
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "walk")
+}
+
 func TestPathPrefixFromBaseURL(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -21,6 +21,8 @@ func goodSite(t *testing.T, prefix string) string {
 		`<a href="`+prefix+`/docs/development/pr-fixup-workflow/">pr fixup</a>`)
 	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
 		`<a href="`+prefix+`/docs/development/architecture/">arch</a>`)
+	writeFile(t, filepath.Join(root, "docs", "reference", "schema-types", "index.html"),
+		`<a href="`+prefix+`/docs/rules/MDS020-required-structure/">rule</a>`)
 	writeFile(t, filepath.Join(root, "docs", "rules", "mds001", "index.html"),
 		`<a href="`+prefix+`/docs/rules/mds021/">sibling rule</a>`)
 	writeFile(t, filepath.Join(root, "index.html"), `<p>home</p>`)
@@ -48,6 +50,8 @@ func TestVerifyWebsiteLinks_AcceptsUnquotedHref(t *testing.T) {
 		`<a href=/docs/development/pr-fixup-workflow/>pr fixup</a>`)
 	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
 		`<a href=/docs/development/architecture/>arch</a>`)
+	writeFile(t, filepath.Join(root, "docs", "reference", "schema-types", "index.html"),
+		`<a href=/docs/rules/MDS020-required-structure/>rule</a>`)
 	writeFile(t, filepath.Join(root, "docs", "rules", "mds001", "index.html"),
 		`<a href=/docs/rules/mds021/>sibling</a>`)
 	require.NoError(t, VerifyWebsiteLinks(root, ""))
@@ -148,6 +152,8 @@ func TestVerifyWebsiteLinks_MissingRecursiveRootWraps(t *testing.T) {
 		`<a href="/docs/development/pr-fixup-workflow/">x</a>`)
 	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
 		`<a href="/docs/development/architecture/">x</a>`)
+	writeFile(t, filepath.Join(root, "docs", "reference", "schema-types", "index.html"),
+		`<a href="/docs/rules/MDS020-required-structure/">x</a>`)
 	// docs/rules is absent.
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -142,13 +142,18 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 
 // indexMdLink matches an inline link whose target ends in
 // `<path>/index.md` (the docs/-tree convention for a directory
-// overview). Hugo serves a section's `_index.md` at the
-// directory URL (`/section/`) with no filename suffix — it does
-// not publish `_index.md` (or `index.md`) as a URL — so the
-// rewrite drops the filename entirely and resolves to
-// `<path>/`. The synced filesystem still has `_index.md` at
-// that directory thanks to SyncDocs' rename, so directory
-// targets continue to resolve in MDS027's filesystem check too.
+// overview). The rewrite drops the `index.md` filename so the
+// target becomes `<path>/`. Hugo serves a section's _index.md
+// at the directory URL with no filename; the synced filesystem
+// still has `_index.md` at that directory thanks to SyncDocs'
+// rename, so MDS027 stats the directory target as a regular
+// existing path. The render-link hook
+// (website/layouts/_default/_markup/render-link.html) then
+// resolves the directory target to the section's absolute
+// permalink at HTML-render time, which is what fixes the
+// source-vs-rendered-URL depth mismatch that a bare relative
+// directory link would otherwise have on leaf pages.
+//
 // Group 1 captures the path prefix (required: a bare
 // `index.md` link with no parent directory is ambiguous and
 // left alone); group 2 captures an optional `#anchor`.

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -47,6 +47,31 @@ var repoPlanLink = regexp.MustCompile(`\]\(\.\./\.\./\.\./plan/([^)]+)\)`)
 // Example: [plan107]: ../../../plan/107_no-reference-style.md
 var repoPlanRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )\.\./\.\./\.\./plan/(\S+)`)
 
+// repoRuleLink matches an inline link from any docs/ page into
+// the internal/rules/ tree (`../…/internal/rules/MDS001-line-length/`
+// or `../…/internal/rules/MDS001-line-length/README.md`). Unlike
+// ruleReadmeLink (which only matches the bare or single-`../`
+// prefix used inside rule pages themselves), this regex accepts
+// any depth of `../` segments so plain docs deep in the tree
+// (e.g. docs/background/concepts/generated-section.md, 4 levels
+// up) get their rule links rewritten too. Group 1 captures the
+// rule directory name. The trailing `README.md` is optional —
+// docs link to both forms.
+var repoRuleLink = regexp.MustCompile(`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?\)`)
+
+// repoRuleRefDef matches a reference-style link definition whose
+// target is a repo-relative internal/rules/ path. Multiline flag
+// so `^` anchors at each line start. Mirrors repoRuleLink — any
+// `../` depth, optional README.md suffix.
+// Example: [mds020]: ../../internal/rules/MDS020-required-structure/README.md
+var repoRuleRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )(?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?$`)
+
+// rulePageURLBase is the site-absolute URL prefix every rule page
+// lives under. Hugo serves website/content/docs/rules/<dir>/index.md
+// at /docs/rules/<dir>/, so repo-relative `internal/rules/<dir>/`
+// links from any docs page must rewrite to this prefix to resolve.
+const rulePageURLBase = "/docs/rules/"
+
 // ruleSourceTreeBase is the GitHub directory (tree) route for a
 // rule's source. Per-rule READMEs carry an
 // `Implementation: [source](./)` link that points at the rule's
@@ -64,6 +89,19 @@ const githubBlobBase = "https://github.com/jeduden/mdsmith/blob/main/"
 // stops syncRulePages from copying non-rule directories (fixtures,
 // helper files, …) into the Hugo content tree.
 var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
+
+// rewriteRuleLinks rewrites every repo-relative link from a docs
+// page into internal/rules/ to its published site URL
+// (/docs/rules/<dir>/). Both inline and reference-style forms are
+// handled, with or without a trailing README.md. Idempotent:
+// already-rewritten /docs/rules/ paths do not match the regexes
+// (they have no `../` prefix and no `internal/rules/` segment),
+// so a second pass is a no-op.
+func rewriteRuleLinks(b []byte) []byte {
+	b = repoRuleLink.ReplaceAll(b, []byte("]("+rulePageURLBase+"$1/)"))
+	b = repoRuleRefDef.ReplaceAll(b, []byte("${1}"+rulePageURLBase+"$2/"))
+	return b
+}
 
 // BuildWebsite prepares the Hugo content tree: optionally runs
 // `mdsmith fix` against srcDir so every <?catalog?>/<?include?>

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -252,9 +252,6 @@ func rewriteRuleLinks(b []byte) []byte {
 // template cannot branch on the capture.
 func rewriteNonPublishedInline(match []byte) []byte {
 	m := repoNonPublishedLink.FindSubmatch(match)
-	if len(m) < 2 {
-		return match
-	}
 	return []byte("](" + githubURLForPath(m[1]) + ")")
 }
 
@@ -263,9 +260,6 @@ func rewriteNonPublishedInline(match []byte) []byte {
 // is preserved so the definition keeps its `[label]: ` form.
 func rewriteNonPublishedRefDef(match []byte) []byte {
 	m := repoNonPublishedRefDef.FindSubmatch(match)
-	if len(m) < 3 {
-		return match
-	}
 	return []byte(string(m[1]) + githubURLForPath(m[2]))
 }
 
@@ -630,9 +624,6 @@ func transformRulePage(data []byte, ruleName string) []byte {
 func rewriteRuleFixtures(seg []byte, fileBase, dirBase string) []byte {
 	return ruleFixtureLink.ReplaceAllFunc(seg, func(match []byte) []byte {
 		m := ruleFixtureLink.FindSubmatch(match)
-		if len(m) < 2 {
-			return match
-		}
 		base := fileBase
 		if bytes.HasSuffix(m[1], []byte("/")) {
 			base = dirBase
@@ -649,9 +640,6 @@ func rewriteRuleFixtures(seg []byte, fileBase, dirBase string) []byte {
 // directory vs file route is decided by trailing slash.
 func rewriteRuleSibling(match []byte) []byte {
 	m := ruleSiblingNonMDSLink.FindSubmatch(match)
-	if len(m) < 2 {
-		return match
-	}
 	return []byte("](" + githubURLForPath([]byte("internal/rules/"+string(m[1]))) + ")")
 }
 

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -56,21 +56,112 @@ var repoPlanRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )\.\./\.\./\.\./plan/
 // (e.g. docs/background/concepts/generated-section.md, 4 levels
 // up) get their rule links rewritten too. Group 1 captures the
 // rule directory name. The trailing `README.md` is optional —
-// docs link to both forms.
-var repoRuleLink = regexp.MustCompile(`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?\)`)
+// docs link to both forms. Group 2 captures an optional
+// `#anchor` so a deep-link into a rule README's heading
+// (e.g. `MDS020-required-structure/README.md#index-side-output`)
+// preserves the fragment after the slash.
+var repoRuleLink = regexp.MustCompile(`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#[^)]*)?\)`)
 
 // repoRuleRefDef matches a reference-style link definition whose
 // target is a repo-relative internal/rules/ path. Multiline flag
 // so `^` anchors at each line start. Mirrors repoRuleLink — any
-// `../` depth, optional README.md suffix.
+// `../` depth, optional README.md suffix, optional anchor.
 // Example: [mds020]: ../../internal/rules/MDS020-required-structure/README.md
-var repoRuleRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )(?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?$`)
+var repoRuleRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )(?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#\S+)?$`)
 
 // rulePageURLBase is the site-absolute URL prefix every rule page
 // lives under. Hugo serves website/content/docs/rules/<dir>/index.md
 // at /docs/rules/<dir>/, so repo-relative `internal/rules/<dir>/`
 // links from any docs page must rewrite to this prefix to resolve.
 const rulePageURLBase = "/docs/rules/"
+
+// repoNonPublishedLink matches an inline link whose target is a
+// repo-relative path that the website does NOT publish — every
+// tree under the repo that lives outside docs/ and outside
+// internal/rules/MDS*/ falls here. On the source tree the link
+// resolves to a real file (so mdsmith fix and humans reading the
+// source see it fine); on the synced Hugo tree there is no such
+// path, so the link 404s. Rewriting to an absolute GitHub blob
+// URL keeps the reference clickable on the live site while still
+// pointing at the canonical source on github.com.
+//
+// Group 1 captures the repo-relative path (everything past the
+// last `../`). The alternative order matters: every `internal/…`
+// prefix that is NOT `internal/rules/MDS…/` falls here, but
+// `internal/rules/MDS…/` itself is already rewritten by
+// rewriteRuleLinks (run first) and never reaches this regex.
+// The `internal/rules/<non-MDS>/` case (e.g.
+// `internal/rules/markdownflavor/`) is intentionally caught
+// here because only MDS-prefixed directories carry a published
+// README.
+//
+// Root-level files (PLAN.md, README.md, LICENSE, …) are listed
+// explicitly. They live at the repo root with no enclosing
+// directory, so a `(?:\.\./)+` prefix is the only signal that
+// the link target is repo-relative rather than sibling.
+var repoNonPublishedLink = regexp.MustCompile(
+	`\]\((?:\.\./)+(` +
+		`plan/[^)]+|` +
+		`cmd/[^)]+|` +
+		`editors/[^)]+|` +
+		`cue/[^)]+|` +
+		`npm/[^)]+|` +
+		`python/[^)]+|` +
+		`\.claude/[^)]+|` +
+		`\.github/[^)]+|` +
+		`internal/[^)]+|` +
+		`PLAN\.md|README\.md|LICENSE|SECURITY\.md|CLAUDE\.md|AGENTS\.md` +
+		`)\)`)
+
+// repoNonPublishedRefDef is the reference-style sibling of
+// repoNonPublishedLink for definitions like
+// `[plan107]: ../../../plan/107.md`. Multiline anchor; `\S+`
+// captures the target so trailing whitespace or comments after
+// the URL are not eaten.
+var repoNonPublishedRefDef = regexp.MustCompile(
+	`(?m)^(\[[^\]]+\]: )(?:\.\./)+(` +
+		`plan/\S+|` +
+		`cmd/\S+|` +
+		`editors/\S+|` +
+		`cue/\S+|` +
+		`npm/\S+|` +
+		`python/\S+|` +
+		`\.claude/\S+|` +
+		`\.github/\S+|` +
+		`internal/\S+|` +
+		`PLAN\.md|README\.md|LICENSE|SECURITY\.md|CLAUDE\.md|AGENTS\.md` +
+		`)`)
+
+// indexMdLink matches a sibling-style inline link whose target
+// is `index.md` (the docs/-tree convention for a directory
+// overview). syncDocsFile renames every `index.md` to
+// `_index.md` when copying into the Hugo tree, so a link that
+// kept the source name resolves to nothing on the synced
+// filesystem (and MDS027 flags it). Rewrite `index.md` in the
+// link target to `_index.md` to follow the rename. Group 1
+// captures the path prefix (e.g. `architecture/`); group 2
+// captures an optional `#anchor` fragment.
+var indexMdLink = regexp.MustCompile(`\]\(((?:[^)/]+/)*)index\.md((?:#[^)]*)?)\)`)
+
+// ruleFixtureLink matches an inline link in a per-rule README
+// whose target is a fixture path under the rule's own directory:
+// `[good/default.md](good/default.md)`, `[bad/x.md](bad/x.md)`,
+// or the `pattern/bad/` / `pattern/good/` directives-rule case.
+// Fixtures live in the source tree but are intentionally not
+// republished on the site (no Hugo page for raw test data), so a
+// repo-relative link 404s. Rewrite to the rule's GitHub source
+// tree URL so the example file is still reachable.
+var ruleFixtureLink = regexp.MustCompile(`\]\(((?:bad|good|pattern)/[^)]*)\)`)
+
+// ruleSiblingNonMDSLink matches an inline link in a per-rule
+// README whose target is a single-`../`-prefixed sibling under
+// internal/rules/ that is NOT another rule's page — the rule's
+// Go package directory or the shared `proto.md` schema, for
+// example. Sibling MDS rule pages (`../MDS021-include/`) ARE
+// published, so they are excluded by requiring the first
+// character after `../` to be lowercase or a dot (rule names
+// start with uppercase `M`).
+var ruleSiblingNonMDSLink = regexp.MustCompile(`\]\(\.\./([a-z._][^)]*)\)`)
 
 // ruleSourceTreeBase is the GitHub directory (tree) route for a
 // rule's source. Per-rule READMEs carry an
@@ -90,16 +181,34 @@ const githubBlobBase = "https://github.com/jeduden/mdsmith/blob/main/"
 // helper files, …) into the Hugo content tree.
 var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 
-// rewriteRuleLinks rewrites every repo-relative link from a docs
-// page into internal/rules/ to its published site URL
-// (/docs/rules/<dir>/). Both inline and reference-style forms are
-// handled, with or without a trailing README.md. Idempotent:
-// already-rewritten /docs/rules/ paths do not match the regexes
-// (they have no `../` prefix and no `internal/rules/` segment),
-// so a second pass is a no-op.
+// rewriteRuleLinks rewrites every repo-relative link in a synced
+// markdown body so it resolves on the published site. The three
+// classes are applied in order: (1) links into internal/rules/MDS…/
+// become /docs/rules/<dir>/<#anchor> site URLs; (2) links into any
+// other non-published repo path — plan/, cmd/, editors/, .claude/,
+// internal/ (other than the rule pages already handled in step 1),
+// and root-level files — become absolute GitHub blob URLs;
+// (3) sibling links to `index.md` get the `_index.md` rename
+// SyncDocs applied to the file itself, so MDS027 still resolves
+// the target on the synced filesystem.
+//
+// The ordering matters because the rule rewrite is the only one
+// that has a site-local target — the non-published rewrite would
+// otherwise consume `internal/rules/MDS…` and send it to GitHub.
+//
+// Idempotent: already-rewritten paths (a leading `/docs/`,
+// `https://`, or `_index.md`) do not match any of the three
+// regexes, so a second pass is a no-op.
 func rewriteRuleLinks(b []byte) []byte {
-	b = repoRuleLink.ReplaceAll(b, []byte("]("+rulePageURLBase+"$1/)"))
-	b = repoRuleRefDef.ReplaceAll(b, []byte("${1}"+rulePageURLBase+"$2/"))
+	b = repoRuleLink.ReplaceAll(b, []byte("]("+rulePageURLBase+"$1/$2)"))
+	b = repoRuleRefDef.ReplaceAll(b, []byte("${1}"+rulePageURLBase+"$2/$3"))
+	b = repoNonPublishedLink.ReplaceAll(b, []byte("]("+githubBlobBase+"$1)"))
+	b = repoNonPublishedRefDef.ReplaceAll(b, []byte("${1}"+githubBlobBase+"$2"))
+	// `${1}` (braced form) is required: `$1_index.md` would parse
+	// as a variable named `1_index` to Go's regexp expander, so
+	// the captured directory prefix would silently vanish (and
+	// every link become `.md`).
+	b = indexMdLink.ReplaceAll(b, []byte("](${1}_index.md$2)"))
 	return b
 }
 
@@ -278,12 +387,26 @@ func (t *Toolkit) syncRulePages(rulesDir, dstDir string) error {
 		// otherwise parse "$1https" as a single group name, leaving the
 		// expansion empty.
 		data = repoPlanRefDef.ReplaceAll(data, []byte("${1}"+githubBlobBase+"plan/$2"))
+		// Rewrite fixture references (`good/default.md`,
+		// `bad/x.md`, `pattern/good/`) to the rule's GitHub source
+		// tree URL. Fixtures live under the rule's source
+		// directory but are not republished on the site.
+		ruleSourceURL := ruleSourceTreeBase + e.Name() + "/"
+		data = ruleFixtureLink.ReplaceAll(data, []byte("]("+ruleSourceURL+"$1)"))
+		// Rewrite single-`../`-prefixed sibling references that
+		// are NOT MDS rule pages (a sibling Go package, the
+		// shared `proto.md`, etc.) to GitHub blob URLs under
+		// internal/rules/. The non-MDS guard in the regex
+		// preserves working cross-rule links like
+		// `../MDS021-include/`.
+		data = ruleSiblingNonMDSLink.ReplaceAll(data,
+			[]byte("]("+githubBlobBase+"internal/rules/$1)"))
 		// The `Implementation: [source](./)` meta line self-links the
 		// generated page on the site; repoint it at the rule's
 		// GitHub source directory.
 		data = bytes.ReplaceAll(data,
 			[]byte("[source](./)"),
-			[]byte("[source]("+ruleSourceTreeBase+e.Name()+"/)"))
+			[]byte("[source]("+ruleSourceURL+")"))
 		// Inject the repo-relative source path so the layout can
 		// render a "View source on GitHub" link without hard-coding
 		// the repo URL in the Go layer.

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -134,16 +134,19 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 		`PLAN\.md|README\.md|LICENSE|SECURITY\.md|CLAUDE\.md|AGENTS\.md` +
 		`)`)
 
-// indexMdLink matches a sibling-style inline link whose target
-// is `index.md` (the docs/-tree convention for a directory
-// overview). syncDocsFile renames every `index.md` to
-// `_index.md` when copying into the Hugo tree, so a link that
-// kept the source name resolves to nothing on the synced
-// filesystem (and MDS027 flags it). Rewrite `index.md` in the
-// link target to `_index.md` to follow the rename. Group 1
-// captures the path prefix (e.g. `architecture/`); group 2
-// captures an optional `#anchor` fragment.
-var indexMdLink = regexp.MustCompile(`\]\(((?:[^)/]+/)*)index\.md((?:#[^)]*)?)\)`)
+// indexMdLink matches an inline link whose target ends in
+// `<path>/index.md` (the docs/-tree convention for a directory
+// overview). Hugo serves a section's `_index.md` at the
+// directory URL (`/section/`) with no filename suffix — it does
+// not publish `_index.md` (or `index.md`) as a URL — so the
+// rewrite drops the filename entirely and resolves to
+// `<path>/`. The synced filesystem still has `_index.md` at
+// that directory thanks to SyncDocs' rename, so directory
+// targets continue to resolve in MDS027's filesystem check too.
+// Group 1 captures the path prefix (required: a bare
+// `index.md` link with no parent directory is ambiguous and
+// left alone); group 2 captures an optional `#anchor`.
+var indexMdLink = regexp.MustCompile(`\]\(((?:[^)/]+/)+)index\.md((?:#[^)]*)?)\)`)
 
 // ruleFixtureLink matches an inline link in a per-rule README
 // whose target is a fixture path under the rule's own directory:
@@ -234,11 +237,12 @@ func rewriteRuleLinks(b []byte) []byte {
 		seg = repoRuleRefDef.ReplaceAll(seg, []byte("${1}"+rulePageURLBase+"$2/$3"))
 		seg = repoNonPublishedLink.ReplaceAllFunc(seg, rewriteNonPublishedInline)
 		seg = repoNonPublishedRefDef.ReplaceAllFunc(seg, rewriteNonPublishedRefDef)
-		// `${1}` (braced form) is required: `$1_index.md` would
-		// parse as a variable named `1_index` to Go's regexp
-		// expander, so the captured directory prefix would
-		// silently vanish (and every link become `.md`).
-		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}_index.md$2)"))
+		// Drop the `index.md` filename — Hugo serves the
+		// directory's _index.md at `/<path>/`, not at
+		// `/<path>/_index.md` or `/<path>/index.md`. Keeping
+		// either filename in the markdown produces a 404 on
+		// the live site.
+		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}$2)"))
 		return seg
 	})
 }

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -115,17 +115,25 @@ const rulePageURLBase = "/docs/rules/"
 // explicitly. They live at the repo root with no enclosing
 // directory, so a `(?:\.\./)+` prefix is the only signal that
 // the link target is repo-relative rather than sibling.
+//
+// Each path uses `\S+` rather than `[^)]+`. A Markdown link
+// title (`[x](target "title")`) is whitespace-separated from
+// the target, so `\S+` stops before it and the regex's
+// trailing `\)` then fails to match — the titled link is
+// left alone rather than rewritten with the title text
+// glued into the GitHub URL. No source doc carries a titled
+// link today, but the pattern stays correct if one is added.
 var repoNonPublishedLink = regexp.MustCompile(
 	`\]\((?:\.\./)+(` +
-		`plan/[^)]+|` +
-		`cmd/[^)]+|` +
-		`editors/[^)]+|` +
-		`cue/[^)]+|` +
-		`npm/[^)]+|` +
-		`python/[^)]+|` +
-		`\.claude/[^)]+|` +
-		`\.github/[^)]+|` +
-		`internal/[^)]+|` +
+		`plan/\S+|` +
+		`cmd/\S+|` +
+		`editors/\S+|` +
+		`cue/\S+|` +
+		`npm/\S+|` +
+		`python/\S+|` +
+		`\.claude/\S+|` +
+		`\.github/\S+|` +
+		`internal/\S+|` +
 		`PLAN\.md|README\.md|LICENSE|SECURITY\.md|CLAUDE\.md|AGENTS\.md` +
 		`)\)`)
 
@@ -175,7 +183,12 @@ var indexMdLink = regexp.MustCompile(`\]\(((?:[^)/]+/)+)index\.md((?:#[^)]*)?)\)
 // republished on the site (no Hugo page for raw test data), so a
 // repo-relative link 404s. Rewrite to the rule's GitHub source
 // tree URL so the example file is still reachable.
-var ruleFixtureLink = regexp.MustCompile(`\]\(((?:bad|good|pattern)/[^)]*)\)`)
+//
+// `\S*` (not `[^)]*`) rejects whitespace inside the target so
+// a titled link `[x](good/default.md "title")` is left alone
+// rather than rewritten with the title text glued into the
+// GitHub URL.
+var ruleFixtureLink = regexp.MustCompile(`\]\(((?:bad|good|pattern)/\S*)\)`)
 
 // ruleSiblingNonMDSLink matches an inline link in a per-rule
 // README whose target is a single-`../`-prefixed sibling under
@@ -184,8 +197,10 @@ var ruleFixtureLink = regexp.MustCompile(`\]\(((?:bad|good|pattern)/[^)]*)\)`)
 // example. Sibling MDS rule pages (`../MDS021-include/`) ARE
 // published, so they are excluded by requiring the first
 // character after `../` to be lowercase or a dot (rule names
-// start with uppercase `M`).
-var ruleSiblingNonMDSLink = regexp.MustCompile(`\]\(\.\./([a-z._][^)]*)\)`)
+// start with uppercase `M`). The tail uses `\S*` rather than
+// `[^)]*` so a titled link is left alone instead of having
+// the title text consumed into the GitHub URL.
+var ruleSiblingNonMDSLink = regexp.MustCompile(`\]\(\.\./([a-z._]\S*)\)`)
 
 // ruleSourceTreeBase is the GitHub directory (tree) route for a
 // rule's source. Per-rule READMEs carry an

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -232,9 +232,11 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // internal/ (other than the rule pages already handled in step 1),
 // and root-level files — become absolute GitHub URLs, /blob/ for
 // file targets and /tree/ for directory targets; (3) sibling
-// links to `index.md` get the `_index.md` rename SyncDocs applied
-// to the file itself, so MDS027 still resolves the target on the
-// synced filesystem.
+// links to `<path>/index.md` drop the `index.md` filename so the
+// target becomes the directory itself (`<path>/`). Hugo serves
+// `_index.md` (the rename SyncDocs applies) at that directory
+// URL, and MDS027 stats the directory as an existing path, so
+// the rendered link works and the lint still resolves.
 //
 // The whole pass runs under applyOutsideCode so a Markdown
 // example inside a fenced code block OR an inline code span
@@ -370,9 +372,12 @@ func applyOutsideFences(src []byte, fn func([]byte) []byte) []byte {
 }
 
 // inlineCodeSpan matches a single-backtick code span on one
-// line: `text`. Multi-backtick spans and multi-line spans are
-// not matched. The non-greedy body and the line-end guard keep
-// the regex from spanning adjacent code spans on the same line.
+// line: `text`. The body uses a negated character class that
+// excludes the backtick and newline, so the match cannot cross
+// either — that is what keeps the regex from spanning adjacent
+// code spans on the same line or running into a following line.
+// Multi-backtick spans (the doubled or tripled opener forms)
+// and multi-line spans are not matched.
 var inlineCodeSpan = regexp.MustCompile("`[^`\n]+`")
 
 // applyOutsideInlineCode calls fn on every maximal substring of

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -12,22 +12,28 @@ import (
 
 // ruleReadmeLink matches a Markdown link whose target is a rule
 // README relative path and captures the rule directory (with an
-// optional `../` prefix) separately from the `README.md` filename.
-// It covers both link forms in play: the bare
-// `MDS001-line-length/README.md` used by the rule index, and the
-// sibling `../MDS021-include/README.md` used between per-rule
-// READMEs. Rewriting drops `README.md` so the link resolves to the
+// optional `../` prefix) separately from the `README.md` filename
+// and an optional `#anchor` fragment. It covers both link forms
+// in play: the bare `MDS001-line-length/README.md` used by the
+// rule index, and the sibling `../MDS021-include/README.md` used
+// between per-rule READMEs. Rewriting drops `README.md` and
+// keeps the captured anchor so the link resolves to the
 // published page directory (`MDS001-line-length/`,
-// `../MDS021-include/`) rather than an unpublished `README.md`.
-var ruleReadmeLink = regexp.MustCompile(`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md\)`)
+// `../MDS021-include/#section`) rather than an unpublished
+// `README.md`.
+var ruleReadmeLink = regexp.MustCompile(
+	`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md(#[^)]*)?\)`)
 
 // ruleRefDefLink matches a Markdown reference-style link definition
 // whose target is a rule README path (with an optional `../`
-// prefix). The multiline flag makes `^` match at each line start.
-// Example: [mds027]: ../MDS027-cross-file-reference-integrity/README.md
-// Rewriting drops `/README.md` and adds a trailing slash so the
-// reference resolves to the published rule page directory.
-var ruleRefDefLink = regexp.MustCompile(`(?m)^(\[[^\]]+\]: (?:\.\./)?(MDS[0-9A-Za-z._-]+))/README\.md`)
+// prefix and an optional `#anchor` fragment). The multiline flag
+// makes `^` match at each line start.
+// Example: [mds027]: ../MDS027-cross-file-reference-integrity/README.md#index
+// Rewriting drops `/README.md`, adds a trailing slash, and keeps
+// the anchor so the reference resolves to the published rule
+// page directory.
+var ruleRefDefLink = regexp.MustCompile(
+	`(?m)^(\[[^\]]+\]: (?:\.\./)?(MDS[0-9A-Za-z._-]+))/README\.md(#\S+)?`)
 
 // repoDocsLink matches an inline link from a rule README into the
 // docs/ tree (`../../../docs/path/file.md`). The docs tree IS
@@ -520,7 +526,7 @@ func (t *Toolkit) syncRuleIndex(rulesDir, dstDir string) error {
 	// Skip code regions so a documented `MDS…/README.md` example
 	// stays verbatim.
 	data = applyOutsideCode(data, func(seg []byte) []byte {
-		return ruleReadmeLink.ReplaceAll(seg, []byte("]($1/)"))
+		return ruleReadmeLink.ReplaceAll(seg, []byte("]($1/$2)"))
 	})
 	// Cascade the `rule` layout type to all child pages so Hugo
 	// picks up the per-rule template for category/status display.
@@ -605,8 +611,8 @@ func transformRulePage(data []byte, ruleName string) []byte {
 	ruleSourceFiles := githubBlobBase + "internal/rules/" + ruleName + "/"
 	ruleSourceDir := ruleSourceTreeBase + ruleName + "/"
 	data = applyOutsideCode(data, func(seg []byte) []byte {
-		seg = ruleReadmeLink.ReplaceAll(seg, []byte("]($1/)"))
-		seg = ruleRefDefLink.ReplaceAll(seg, []byte("$1/"))
+		seg = ruleReadmeLink.ReplaceAll(seg, []byte("]($1/$2)"))
+		seg = ruleRefDefLink.ReplaceAll(seg, []byte("$1/$3"))
 		seg = repoDocsLink.ReplaceAll(seg, []byte("](/docs/$1/$2)"))
 		seg = repoPlanLink.ReplaceAll(seg, []byte("]("+githubBlobBase+"plan/$1)"))
 		seg = repoPlanRefDef.ReplaceAll(seg, []byte("${1}"+githubBlobBase+"plan/$2"))

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -67,7 +67,9 @@ var repoRuleLink = regexp.MustCompile(`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za
 // so `^` anchors at each line start. Mirrors repoRuleLink — any
 // `../` depth, optional README.md suffix, optional anchor.
 // Example: [mds020]: ../../internal/rules/MDS020-required-structure/README.md
-var repoRuleRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )(?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#\S+)?$`)
+var repoRuleRefDef = regexp.MustCompile(
+	`(?m)^(\[[^\]]+\]: )(?:\.\./)+internal/rules/` +
+		`(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#\S+)?$`)
 
 // rulePageURLBase is the site-absolute URL prefix every rule page
 // lives under. Hugo serves website/content/docs/rules/<dir>/index.md
@@ -171,9 +173,28 @@ var ruleSiblingNonMDSLink = regexp.MustCompile(`\]\(\.\./([a-z._][^)]*)\)`)
 // GitHub tree URL. `/tree/` (not `/blob/`) is the directory route.
 const ruleSourceTreeBase = "https://github.com/jeduden/mdsmith/tree/main/internal/rules/"
 
-// githubBlobBase is the GitHub blob (file) URL prefix for files in
-// the repository that are not published on the site (plan/, etc.).
-const githubBlobBase = "https://github.com/jeduden/mdsmith/blob/main/"
+// githubBlobBase / githubTreeBase are GitHub's file vs directory
+// URL prefixes. A repo-relative link whose target ends with `/`
+// must go to /tree/ (GitHub renders a directory listing there);
+// any other target — a `.md`, `.go`, an extension-less script —
+// must go to /blob/, which is the file route. Using the wrong
+// one is not just a stylistic difference: /tree/ on a file 404s
+// and /blob/ on a directory 404s, both silently.
+const (
+	githubBlobBase = "https://github.com/jeduden/mdsmith/blob/main/"
+	githubTreeBase = "https://github.com/jeduden/mdsmith/tree/main/"
+)
+
+// githubURLForPath returns the GitHub URL for a repo-relative
+// path, selecting /tree/ for directory targets (trailing slash)
+// and /blob/ for file targets. Centralized so every rewrite that
+// emits a GitHub URL picks the right route.
+func githubURLForPath(path []byte) string {
+	if bytes.HasSuffix(path, []byte("/")) {
+		return githubTreeBase + string(path)
+	}
+	return githubBlobBase + string(path)
+}
 
 // ruleDirName matches the MDS-prefixed directory names used for
 // per-rule subdirectories under internal/rules/. The prefix guard
@@ -187,29 +208,218 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // become /docs/rules/<dir>/<#anchor> site URLs; (2) links into any
 // other non-published repo path — plan/, cmd/, editors/, .claude/,
 // internal/ (other than the rule pages already handled in step 1),
-// and root-level files — become absolute GitHub blob URLs;
-// (3) sibling links to `index.md` get the `_index.md` rename
-// SyncDocs applied to the file itself, so MDS027 still resolves
-// the target on the synced filesystem.
+// and root-level files — become absolute GitHub URLs, /blob/ for
+// file targets and /tree/ for directory targets; (3) sibling
+// links to `index.md` get the `_index.md` rename SyncDocs applied
+// to the file itself, so MDS027 still resolves the target on the
+// synced filesystem.
 //
-// The ordering matters because the rule rewrite is the only one
-// that has a site-local target — the non-published rewrite would
-// otherwise consume `internal/rules/MDS…` and send it to GitHub.
+// The whole pass runs under applyOutsideCode so a Markdown
+// example inside a fenced code block OR an inline code span
+// (an MDS021 README demoing `[rules](../internal/rules/)`, or
+// a catalog-output snippet showing `[index.md](development/index.md)`
+// in a fenced block) is left verbatim — those examples are
+// documentation, not real link targets.
+//
+// Rule rewrites must precede the non-published rewrite: both
+// match `internal/rules/MDS…`, and only the first leaves the
+// link on-site rather than routing it to GitHub.
 //
 // Idempotent: already-rewritten paths (a leading `/docs/`,
-// `https://`, or `_index.md`) do not match any of the three
-// regexes, so a second pass is a no-op.
+// `https://`, or `_index.md`) do not match any regex, so a
+// second pass is a no-op.
 func rewriteRuleLinks(b []byte) []byte {
-	b = repoRuleLink.ReplaceAll(b, []byte("]("+rulePageURLBase+"$1/$2)"))
-	b = repoRuleRefDef.ReplaceAll(b, []byte("${1}"+rulePageURLBase+"$2/$3"))
-	b = repoNonPublishedLink.ReplaceAll(b, []byte("]("+githubBlobBase+"$1)"))
-	b = repoNonPublishedRefDef.ReplaceAll(b, []byte("${1}"+githubBlobBase+"$2"))
-	// `${1}` (braced form) is required: `$1_index.md` would parse
-	// as a variable named `1_index` to Go's regexp expander, so
-	// the captured directory prefix would silently vanish (and
-	// every link become `.md`).
-	b = indexMdLink.ReplaceAll(b, []byte("](${1}_index.md$2)"))
-	return b
+	return applyOutsideCode(b, func(seg []byte) []byte {
+		seg = repoRuleLink.ReplaceAll(seg, []byte("]("+rulePageURLBase+"$1/$2)"))
+		seg = repoRuleRefDef.ReplaceAll(seg, []byte("${1}"+rulePageURLBase+"$2/$3"))
+		seg = repoNonPublishedLink.ReplaceAllFunc(seg, rewriteNonPublishedInline)
+		seg = repoNonPublishedRefDef.ReplaceAllFunc(seg, rewriteNonPublishedRefDef)
+		// `${1}` (braced form) is required: `$1_index.md` would
+		// parse as a variable named `1_index` to Go's regexp
+		// expander, so the captured directory prefix would
+		// silently vanish (and every link become `.md`).
+		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}_index.md$2)"))
+		return seg
+	})
+}
+
+// rewriteNonPublishedInline applies repoNonPublishedLink's
+// match, routing the captured path to /tree/ or /blob/ per
+// githubURLForPath. ReplaceAllFunc is used (rather than
+// ReplaceAll with a template) because the URL prefix depends on
+// the captured path's trailing slash — directory links must use
+// /tree/ on GitHub and file links must use /blob/, and a
+// template cannot branch on the capture.
+func rewriteNonPublishedInline(match []byte) []byte {
+	m := repoNonPublishedLink.FindSubmatch(match)
+	if len(m) < 2 {
+		return match
+	}
+	return []byte("](" + githubURLForPath(m[1]) + ")")
+}
+
+// rewriteNonPublishedRefDef is the reference-style sibling of
+// rewriteNonPublishedInline. The captured label prefix (m[1])
+// is preserved so the definition keeps its `[label]: ` form.
+func rewriteNonPublishedRefDef(match []byte) []byte {
+	m := repoNonPublishedRefDef.FindSubmatch(match)
+	if len(m) < 3 {
+		return match
+	}
+	return []byte(string(m[1]) + githubURLForPath(m[2]))
+}
+
+// applyOutsideCode calls fn on each maximal substring of src
+// that lies OUTSIDE Markdown code regions and passes code
+// regions through unchanged. Two constructs are skipped:
+//
+//   - Fenced code blocks: a line beginning (after up to three
+//     leading spaces, per CommonMark) with three or more
+//     backticks or tildes opens a fence, and the matching run
+//     on its own line closes it. The opener, body, and closer
+//     all pass through verbatim.
+//   - Inline code spans: a backtick-delimited region on a
+//     single line (`code`). Multi-backtick spans (the doubled
+//     or tripled forms) and multi-line spans fall through as
+//     plain text — they are rare in mdsmith's authored docs.
+//
+// Without these guards the link rewrites would corrupt
+// documentation examples that show what a directive PRODUCES:
+// MDS021 demoing `[rules](../internal/rules/)` inside an inline
+// code span; the generating-content guide demoing
+// `[i](development/index.md)` inside a fenced markdown block.
+// Indented code blocks and raw HTML blocks are not detected
+// because no observed corruption hits them; switching to a
+// goldmark-AST walk would handle those at the cost of more
+// complexity than the current bug surface justifies.
+func applyOutsideCode(src []byte, fn func([]byte) []byte) []byte {
+	return applyOutsideFences(src, func(seg []byte) []byte {
+		return applyOutsideInlineCode(seg, fn)
+	})
+}
+
+// applyOutsideFences is the fenced-block half of applyOutsideCode.
+// Exposed for the corner case where a caller has already
+// stripped inline code spans and only needs the fence guard.
+func applyOutsideFences(src []byte, fn func([]byte) []byte) []byte {
+	var out bytes.Buffer
+	var nonCode bytes.Buffer
+	flush := func() {
+		if nonCode.Len() == 0 {
+			return
+		}
+		out.Write(fn(nonCode.Bytes()))
+		nonCode.Reset()
+	}
+
+	inFence := false
+	var fenceChar byte
+	var fenceLen int
+
+	start := 0
+	for i := 0; i <= len(src); i++ {
+		if i < len(src) && src[i] != '\n' {
+			continue
+		}
+		line := src[start:i]
+		thisChar, thisLen := fenceMarker(line)
+		var transition bool
+		if !inFence {
+			if thisLen >= 3 {
+				inFence = true
+				fenceChar = thisChar
+				fenceLen = thisLen
+				transition = true
+			}
+		} else if thisChar == fenceChar && thisLen >= fenceLen && fenceLineEmptyAfter(line, thisLen) {
+			inFence = false
+			transition = true
+		}
+
+		dst := &nonCode
+		if inFence || transition {
+			flush()
+			dst = &out
+		}
+		dst.Write(line)
+		if i < len(src) {
+			dst.WriteByte('\n')
+		}
+		start = i + 1
+	}
+
+	flush()
+	return out.Bytes()
+}
+
+// inlineCodeSpan matches a single-backtick code span on one
+// line: `text`. Multi-backtick spans and multi-line spans are
+// not matched. The non-greedy body and the line-end guard keep
+// the regex from spanning adjacent code spans on the same line.
+var inlineCodeSpan = regexp.MustCompile("`[^`\n]+`")
+
+// applyOutsideInlineCode calls fn on every maximal substring of
+// b that lies outside an inline code span. The spans themselves
+// pass through verbatim. Used inside applyOutsideCode to gate a
+// regex rewrite from corrupting a code-spanned example like
+// MDS021's `[rules](../internal/rules/)` that documents the
+// include directive's output.
+func applyOutsideInlineCode(b []byte, fn func([]byte) []byte) []byte {
+	matches := inlineCodeSpan.FindAllIndex(b, -1)
+	if len(matches) == 0 {
+		return fn(b)
+	}
+	var out bytes.Buffer
+	last := 0
+	for _, m := range matches {
+		out.Write(fn(b[last:m[0]]))
+		out.Write(b[m[0]:m[1]])
+		last = m[1]
+	}
+	out.Write(fn(b[last:]))
+	return out.Bytes()
+}
+
+// fenceMarker reports the fence char (backtick or tilde) and
+// run length at the start of line after up to three leading
+// spaces, or (0, 0) if the line is not a fence candidate — i.e.
+// the first non-space char is not a backtick or tilde, or the
+// run length is less than three.
+func fenceMarker(line []byte) (byte, int) {
+	i := 0
+	for i < len(line) && i < 3 && line[i] == ' ' {
+		i++
+	}
+	if i >= len(line) {
+		return 0, 0
+	}
+	c := line[i]
+	if c != '`' && c != '~' {
+		return 0, 0
+	}
+	count := 0
+	for i+count < len(line) && line[i+count] == c {
+		count++
+	}
+	if count < 3 {
+		return 0, 0
+	}
+	return c, count
+}
+
+// fenceLineEmptyAfter reports whether the part of line that
+// follows the fence run (skipping up to three leading spaces
+// plus runLen marker chars) is blank. CommonMark allows an info
+// string after an opener but requires a closer to be followed
+// only by spaces — this guard keeps a code line that happens
+// to start with a backtick run inside a fence from prematurely
+// closing it.
+func fenceLineEmptyAfter(line []byte, runLen int) bool {
+	i := 0
+	for i < len(line) && i < 3 && line[i] == ' ' {
+		i++
+	}
+	return len(bytes.TrimSpace(line[i+runLen:])) == 0
 }
 
 // BuildWebsite prepares the Hugo content tree: optionally runs
@@ -309,7 +519,11 @@ func (t *Toolkit) syncRuleIndex(rulesDir, dstDir string) error {
 	data = transformMarkdown(data)
 	// Rewrite `MDS001-line-length/README.md` → `MDS001-line-length/`
 	// so links stay on-site rather than pointing at GitHub.
-	data = ruleReadmeLink.ReplaceAll(data, []byte("]($1/)"))
+	// Skip code regions so a documented `MDS…/README.md` example
+	// stays verbatim.
+	data = applyOutsideCode(data, func(seg []byte) []byte {
+		return ruleReadmeLink.ReplaceAll(seg, []byte("]($1/)"))
+	})
 	// Cascade the `rule` layout type to all child pages so Hugo
 	// picks up the per-rule template for category/status display.
 	data = injectFMField(data, "cascade:\n  type: rule")
@@ -365,54 +579,9 @@ func (t *Toolkit) syncRulePages(rulesDir, dstDir string) error {
 			}
 			return fmt.Errorf("read rule README %s: %w", readmeSrc, err)
 		}
-		data = transformMarkdown(data)
-		// Rewrite inline cross-rule links (`../MDS021-include/README.md` →
-		// `../MDS021-include/`) so they resolve to the sibling rule's
-		// published page rather than an unpublished README.md.
-		data = ruleReadmeLink.ReplaceAll(data, []byte("]($1/)"))
-		// Rewrite reference-style link definitions to sibling rule
-		// directories (e.g. `[mds027]: ../MDS027-.../README.md`) so the
-		// definition URL resolves to the published page, not a raw README.
-		data = ruleRefDefLink.ReplaceAll(data, []byte("$1/"))
-		// Rewrite inline links to the docs/ tree to site-absolute paths.
-		// Hugo serves each doc at /docs/path/ (no .md); the raw relative
-		// ../../../docs/path/file.md would resolve to a 404 on the site.
-		// An optional #anchor fragment is preserved after the trailing slash.
-		data = repoDocsLink.ReplaceAll(data, []byte("](/docs/$1/$2)"))
-		// Rewrite inline links to the plan/ tree (not published on the
-		// site) to absolute GitHub blob URLs.
-		data = repoPlanLink.ReplaceAll(data, []byte("]("+githubBlobBase+"plan/$1)"))
-		// Rewrite reference-style link definitions to plan/ files.
-		// ${1} (braced form) is required: Go's template engine would
-		// otherwise parse "$1https" as a single group name, leaving the
-		// expansion empty.
-		data = repoPlanRefDef.ReplaceAll(data, []byte("${1}"+githubBlobBase+"plan/$2"))
-		// Rewrite fixture references (`good/default.md`,
-		// `bad/x.md`, `pattern/good/`) to the rule's GitHub source
-		// tree URL. Fixtures live under the rule's source
-		// directory but are not republished on the site.
-		ruleSourceURL := ruleSourceTreeBase + e.Name() + "/"
-		data = ruleFixtureLink.ReplaceAll(data, []byte("]("+ruleSourceURL+"$1)"))
-		// Rewrite single-`../`-prefixed sibling references that
-		// are NOT MDS rule pages (a sibling Go package, the
-		// shared `proto.md`, etc.) to GitHub blob URLs under
-		// internal/rules/. The non-MDS guard in the regex
-		// preserves working cross-rule links like
-		// `../MDS021-include/`.
-		data = ruleSiblingNonMDSLink.ReplaceAll(data,
-			[]byte("]("+githubBlobBase+"internal/rules/$1)"))
-		// The `Implementation: [source](./)` meta line self-links the
-		// generated page on the site; repoint it at the rule's
-		// GitHub source directory.
-		data = bytes.ReplaceAll(data,
-			[]byte("[source](./)"),
-			[]byte("[source]("+ruleSourceURL+")"))
-		// Inject the repo-relative source path so the layout can
-		// render a "View source on GitHub" link without hard-coding
-		// the repo URL in the Go layer.
-		sourcePath := "internal/rules/" + e.Name() + "/"
-		data = injectFMField(data, "github_source: "+sourcePath)
-		ruleDst := filepath.Join(dstRulesDir, e.Name())
+		ruleName := e.Name()
+		data = transformRulePage(transformMarkdown(data), ruleName)
+		ruleDst := filepath.Join(dstRulesDir, ruleName)
 		if err := t.fs.MkdirAll(ruleDst, 0o755); err != nil {
 			return fmt.Errorf("mkdir %s: %w", ruleDst, err)
 		}
@@ -422,6 +591,68 @@ func (t *Toolkit) syncRulePages(rulesDir, dstDir string) error {
 		}
 	}
 	return nil
+}
+
+// transformRulePage applies all rule-page link rewrites to data,
+// which is a single rule README's content (already through
+// transformMarkdown). The pass runs under applyOutsideCode so
+// code regions in rule READMEs — MDS021 demoing
+// `[rules](../internal/rules/)` in an inline code span, MDS027
+// demoing `[guide](good/guide.md)` in a fenced block, etc. —
+// pass through as documentation text rather than being
+// rewritten alongside real link targets. It also rewrites the
+// `[source](./)` self-link and injects the `github_source`
+// front-matter field.
+func transformRulePage(data []byte, ruleName string) []byte {
+	ruleSourceFiles := githubBlobBase + "internal/rules/" + ruleName + "/"
+	ruleSourceDir := ruleSourceTreeBase + ruleName + "/"
+	data = applyOutsideCode(data, func(seg []byte) []byte {
+		seg = ruleReadmeLink.ReplaceAll(seg, []byte("]($1/)"))
+		seg = ruleRefDefLink.ReplaceAll(seg, []byte("$1/"))
+		seg = repoDocsLink.ReplaceAll(seg, []byte("](/docs/$1/$2)"))
+		seg = repoPlanLink.ReplaceAll(seg, []byte("]("+githubBlobBase+"plan/$1)"))
+		seg = repoPlanRefDef.ReplaceAll(seg, []byte("${1}"+githubBlobBase+"plan/$2"))
+		seg = rewriteRuleFixtures(seg, ruleSourceFiles, ruleSourceDir)
+		seg = ruleSiblingNonMDSLink.ReplaceAllFunc(seg, rewriteRuleSibling)
+		return seg
+	})
+	data = bytes.ReplaceAll(data,
+		[]byte("[source](./)"),
+		[]byte("[source]("+ruleSourceDir+")"))
+	return injectFMField(data, "github_source: internal/rules/"+ruleName+"/")
+}
+
+// rewriteRuleFixtures rewrites fixture references
+// (good/default.md, bad/x.md, pattern/good/) to the rule's
+// GitHub URL: /blob/ for file targets, /tree/ for directory
+// targets. Fixtures are not republished on the site, so a
+// repo-relative link 404s.
+func rewriteRuleFixtures(seg []byte, fileBase, dirBase string) []byte {
+	return ruleFixtureLink.ReplaceAllFunc(seg, func(match []byte) []byte {
+		m := ruleFixtureLink.FindSubmatch(match)
+		if len(m) < 2 {
+			return match
+		}
+		base := fileBase
+		if bytes.HasSuffix(m[1], []byte("/")) {
+			base = dirBase
+		}
+		return []byte("](" + base + string(m[1]) + ")")
+	})
+}
+
+// rewriteRuleSibling rewrites a single-`../`-prefixed sibling
+// reference that is NOT another MDS rule page (a sibling Go
+// package, the shared proto.md, …) to its GitHub URL under
+// internal/rules/. The non-MDS guard in ruleSiblingNonMDSLink
+// preserves cross-rule links like `../MDS021-include/`;
+// directory vs file route is decided by trailing slash.
+func rewriteRuleSibling(match []byte) []byte {
+	m := ruleSiblingNonMDSLink.FindSubmatch(match)
+	if len(m) < 2 {
+		return match
+	}
+	return []byte("](" + githubURLForPath([]byte("internal/rules/"+string(m[1]))) + ")")
 }
 
 // injectFMField inserts a YAML field block into a document's front

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -21,6 +21,14 @@ import (
 // published page directory (`MDS001-line-length/`,
 // `../MDS021-include/#section`) rather than an unpublished
 // `README.md`.
+//
+// Markdown link titles (`[x](url "title")`) are not matched —
+// no source doc in the repo uses them, and the rewriter is
+// regex-based rather than AST-aware. The same scope decision
+// applies to every other link-rewrite pattern in this file
+// (repoRuleLink, repoNonPublishedLink, indexMdLink, …). If a
+// titled link is ever added to docs, that one link will keep
+// its source target post-sync and the regex will need to grow.
 var ruleReadmeLink = regexp.MustCompile(
 	`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md(#[^)]*)?\)`)
 

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -46,11 +46,16 @@ Line exceeds maximum length.
 | ` + "`max`" + ` | int | 80 | Maximum line length |
 
 See also [MDS021](../MDS021-include/README.md) and [MDS027][mds027].
+Linkable sibling without README suffix: [MDS020 anchor](../../../internal/rules/MDS020-required-structure/README.md#index-side-output).
 
 See the [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
 and the [schemas guide](../../../docs/guides/schemas.md#section-content).
 
 See [Plan 107](../../../plan/107_no-reference-style.md) for background.
+
+Fixture examples: [good/default.md](good/default.md) and [bad/x.md](bad/x.md).
+Sibling Go package: [linelength rule](../linelength/rule.go).
+Schema schema: [proto.md](../proto.md).
 
 ## Meta-Information
 
@@ -160,6 +165,33 @@ func TestBuildWebsite_PublishesRulePages(t *testing.T) {
 		"plan reference-style definition must become a GitHub blob URL")
 	assert.NotContains(t, body, "../../../plan/",
 		"no repo-relative plan/ link may remain on the published page")
+
+	// Deep `internal/rules/MDS…/README.md#anchor` → site URL with
+	// anchor preserved. transformMarkdown handles this for any
+	// docs body (rewriteRuleLinks runs before the rule-specific
+	// transforms layered on top in syncRulePages).
+	assert.Contains(t, body, "(/docs/rules/MDS020-required-structure/#index-side-output)",
+		"deep rule link must rewrite to site URL with anchor preserved")
+
+	// Rule fixture references (good/, bad/, pattern/) → rule's
+	// GitHub source tree URL: fixtures are not republished on
+	// the site, so a repo-relative link would 404.
+	assert.Contains(t, body,
+		"](https://github.com/jeduden/mdsmith/tree/main/internal/rules/MDS001-line-length/good/default.md)",
+		"good/ fixture link must become rule's GitHub tree URL")
+	assert.Contains(t, body,
+		"](https://github.com/jeduden/mdsmith/tree/main/internal/rules/MDS001-line-length/bad/x.md)",
+		"bad/ fixture link must become rule's GitHub tree URL")
+
+	// Sibling non-MDS references (Go package, proto.md) →
+	// GitHub blob URL under internal/rules/. Cross-rule sibling
+	// links (../MDS021-include/) must NOT match this pattern.
+	assert.Contains(t, body,
+		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/linelength/rule.go)",
+		"sibling Go package link must become a GitHub blob URL")
+	assert.Contains(t, body,
+		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/proto.md)",
+		"sibling proto.md link must become a GitHub blob URL")
 }
 
 func TestBuildWebsite_NoRuleDirectoryIsNotAnError(t *testing.T) {

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -57,7 +57,7 @@ See [Plan 107](../../../plan/107_no-reference-style.md) for background.
 Fixture examples: [good/default.md](good/default.md) and [bad/x.md](bad/x.md).
 Pattern directory: [pattern/good/](pattern/good/).
 Sibling Go package: [linelength rule](../linelength/rule.go).
-Schema schema: [proto.md](../proto.md).
+Schema: [proto.md](../proto.md).
 
 ## Meta-Information
 

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -54,6 +54,7 @@ and the [schemas guide](../../../docs/guides/schemas.md#section-content).
 See [Plan 107](../../../plan/107_no-reference-style.md) for background.
 
 Fixture examples: [good/default.md](good/default.md) and [bad/x.md](bad/x.md).
+Pattern directory: [pattern/good/](pattern/good/).
 Sibling Go package: [linelength rule](../linelength/rule.go).
 Schema schema: [proto.md](../proto.md).
 
@@ -188,6 +189,10 @@ func TestBuildWebsite_PublishesRulePages_FixtureAndSibling(t *testing.T) {
 	assert.Contains(t, body,
 		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/MDS001-line-length/bad/x.md)",
 		"bad/ fixture file link must become rule's GitHub blob URL")
+	// Fixture directory link (pattern/good/) → rule's GitHub /tree/ URL.
+	assert.Contains(t, body,
+		"](https://github.com/jeduden/mdsmith/tree/main/internal/rules/MDS001-line-length/pattern/good/)",
+		"pattern/ fixture directory link must become rule's GitHub tree URL")
 	// Sibling non-MDS references (Go package, proto.md) → GitHub
 	// /blob/ URL; cross-rule (../MDS021-include/) must NOT match.
 	assert.Contains(t, body,

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -46,6 +46,7 @@ Line exceeds maximum length.
 | ` + "`max`" + ` | int | 80 | Maximum line length |
 
 See also [MDS021](../MDS021-include/README.md) and [MDS027][mds027].
+Sibling rule with anchor: [MDS021 anchor](../MDS021-include/README.md#syntax).
 Anchor link: [MDS020 anchor](../../../internal/rules/MDS020-required-structure/README.md#index-side-output).
 
 See the [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
@@ -146,6 +147,8 @@ func TestBuildWebsite_PublishesRulePages_SiblingLinks(t *testing.T) {
 	body := buildRulePageBody(t)
 	assert.Contains(t, body, "[MDS021](../MDS021-include/)",
 		"sibling rule links must drop the README.md target")
+	assert.Contains(t, body, "[MDS021 anchor](../MDS021-include/#syntax)",
+		"sibling rule links with anchors must drop README.md and keep the anchor")
 	assert.NotContains(t, body, "../MDS021-include/README.md",
 		"no unpublished README.md link target may remain")
 	assert.Contains(t, body,

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -46,7 +46,7 @@ Line exceeds maximum length.
 | ` + "`max`" + ` | int | 80 | Maximum line length |
 
 See also [MDS021](../MDS021-include/README.md) and [MDS027][mds027].
-Linkable sibling without README suffix: [MDS020 anchor](../../../internal/rules/MDS020-required-structure/README.md#index-side-output).
+Anchor link: [MDS020 anchor](../../../internal/rules/MDS020-required-structure/README.md#index-side-output).
 
 See the [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
 and the [schemas guide](../../../docs/guides/schemas.md#section-content).
@@ -113,25 +113,36 @@ func TestBuildWebsite_PublishesRuleDirectory(t *testing.T) {
 	assert.Contains(t, body, "type: rule", "cascade must set layout type to rule")
 }
 
-func TestBuildWebsite_PublishesRulePages(t *testing.T) {
+// buildRulePageBody runs BuildWebsite over a single-rule
+// fixture and returns the synced rule page body so each of the
+// per-rewrite tests below can assert against it without
+// duplicating the setup.
+func buildRulePageBody(t *testing.T) string {
+	t.Helper()
 	parent := t.TempDir()
 	src := filepath.Join(parent, "docs")
 	dst := filepath.Join(t.TempDir(), "out")
 	writeFile(t, filepath.Join(src, "top.md"), "top body\n")
 	ruleIndexAt(t, parent)
 	ruleReadmeAt(t, parent, "MDS001-line-length")
-
 	require.NoError(t, NewWithDeps(osFS{}, &recordingRunner{}).BuildWebsite(src, dst, false))
-
 	got, err := os.ReadFile(filepath.Join(dst, "rules", "MDS001-line-length", "index.md"))
 	require.NoError(t, err, "per-rule page must be written at rules/<dir>/index.md")
-	body := string(got)
+	return string(got)
+}
+
+func TestBuildWebsite_PublishesRulePages_FrontMatter(t *testing.T) {
+	body := buildRulePageBody(t)
 	assert.Contains(t, body, `title: "MDS001: line-length"`,
 		"rule H1 must be lifted to front-matter title")
 	assert.Contains(t, body, "github_source: internal/rules/MDS001-line-length/",
 		"github_source field must be injected for source link")
 	assert.NotContains(t, body, "# MDS001: line-length",
 		"body H1 must be stripped after promotion")
+}
+
+func TestBuildWebsite_PublishesRulePages_SiblingLinks(t *testing.T) {
+	body := buildRulePageBody(t)
 	assert.Contains(t, body, "[MDS021](../MDS021-include/)",
 		"sibling rule links must drop the README.md target")
 	assert.NotContains(t, body, "../MDS021-include/README.md",
@@ -141,22 +152,20 @@ func TestBuildWebsite_PublishesRulePages(t *testing.T) {
 		"[source](./) self-link must be repointed at the GitHub tree URL")
 	assert.NotContains(t, body, "[source](./)",
 		"the on-site self-link must not survive")
-
-	// Reference-style link definition to a sibling rule.
 	assert.Contains(t, body, "[mds027]: ../MDS027-cross-file-reference-integrity/",
 		"reference-style rule link definitions must drop README.md")
 	assert.NotContains(t, body, "[mds027]: ../MDS027-cross-file-reference-integrity/README.md",
 		"raw reference def README.md target must not survive")
+}
 
-	// Inline links to the docs/ tree → site-absolute paths.
+func TestBuildWebsite_PublishesRulePages_DocsAndPlanLinks(t *testing.T) {
+	body := buildRulePageBody(t)
 	assert.Contains(t, body, "](/docs/background/concepts/placeholder-grammar/)",
 		"docs link must become site-absolute path (no .md extension)")
 	assert.Contains(t, body, "](/docs/guides/schemas/#section-content)",
 		"docs link with anchor must preserve the anchor after the trailing slash")
 	assert.NotContains(t, body, "../../../docs/",
 		"no repo-relative docs/ link may remain on the published page")
-
-	// Inline and reference-style links to plan/ → GitHub blob URLs.
 	assert.Contains(t, body,
 		"](https://github.com/jeduden/mdsmith/blob/main/plan/107_no-reference-style.md)",
 		"plan inline link must become a GitHub blob URL")
@@ -165,27 +174,22 @@ func TestBuildWebsite_PublishesRulePages(t *testing.T) {
 		"plan reference-style definition must become a GitHub blob URL")
 	assert.NotContains(t, body, "../../../plan/",
 		"no repo-relative plan/ link may remain on the published page")
+}
 
-	// Deep `internal/rules/MDS…/README.md#anchor` → site URL with
-	// anchor preserved. transformMarkdown handles this for any
-	// docs body (rewriteRuleLinks runs before the rule-specific
-	// transforms layered on top in syncRulePages).
+func TestBuildWebsite_PublishesRulePages_FixtureAndSibling(t *testing.T) {
+	body := buildRulePageBody(t)
+	// Deep MDS rule link with anchor → site URL with anchor preserved.
 	assert.Contains(t, body, "(/docs/rules/MDS020-required-structure/#index-side-output)",
 		"deep rule link must rewrite to site URL with anchor preserved")
-
-	// Rule fixture references (good/, bad/, pattern/) → rule's
-	// GitHub source tree URL: fixtures are not republished on
-	// the site, so a repo-relative link would 404.
+	// Fixture file links (good/, bad/) → rule's GitHub /blob/ URL.
 	assert.Contains(t, body,
-		"](https://github.com/jeduden/mdsmith/tree/main/internal/rules/MDS001-line-length/good/default.md)",
-		"good/ fixture link must become rule's GitHub tree URL")
+		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/MDS001-line-length/good/default.md)",
+		"good/ fixture file link must become rule's GitHub blob URL")
 	assert.Contains(t, body,
-		"](https://github.com/jeduden/mdsmith/tree/main/internal/rules/MDS001-line-length/bad/x.md)",
-		"bad/ fixture link must become rule's GitHub tree URL")
-
-	// Sibling non-MDS references (Go package, proto.md) →
-	// GitHub blob URL under internal/rules/. Cross-rule sibling
-	// links (../MDS021-include/) must NOT match this pattern.
+		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/MDS001-line-length/bad/x.md)",
+		"bad/ fixture file link must become rule's GitHub blob URL")
+	// Sibling non-MDS references (Go package, proto.md) → GitHub
+	// /blob/ URL; cross-rule (../MDS021-include/) must NOT match.
 	assert.Contains(t, body,
 		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/linelength/rule.go)",
 		"sibling Go package link must become a GitHub blob URL")

--- a/plan/170_link-handling-audit.md
+++ b/plan/170_link-handling-audit.md
@@ -1,0 +1,160 @@
+---
+id: 170
+title: Audit link handling across mdsmith and the website
+status: 🔲
+summary: >-
+  Survey every place mdsmith touches Markdown links — the
+  linter (MDS027 and friends), the website rewriter, the
+  Hugo render-link hook, and adjacent rule surfaces — and
+  decide which gaps to close as concrete rules or
+  pipeline fixes. PR #309 surfaced enough issues
+  (subpath baseURL handling, `*ast.Image` blind spots,
+  absolute targets, source-vs-rendered-URL depth) to
+  justify a single sweep rather than another point fix.
+model: opus
+---
+# Audit link handling across mdsmith and the website
+
+## Goal
+
+Catalog every link concern across mdsmith today. Rank
+by user impact. Decide which ones become new rules,
+rewriter changes, or scope decisions. The output is a
+research doc at `docs/research/links/`. Follow-up plans
+cite the doc instead of relitigating the trade-offs.
+
+## Background
+
+PR #309 (rule pages and synced-tree lint) surfaced
+multiple link issues in close succession:
+
+- MDS027 walks only `*ast.Link`, never `*ast.Image`, so
+  broken image targets slip past the cross-file check.
+- MDS027 short-circuits absolute paths
+  (`/docs/rules/<id>/`), so the very URLs the website
+  rewriter emits are not validated by the synced-tree
+  lint.
+- linkgraph's `ExtractLinks` intentionally skips
+  reference-style links (`[label]: target`), so a
+  broken ref-style def survives the check.
+- The website rewriter hardcoded `/docs/rules/…` paths
+  that ignored Hugo's configured `baseURL`; the
+  render-link hook had to grow `relURL` support.
+- Source-file relative paths resolve one directory
+  level shallower than the rendered-URL would
+  (`../reference/globs.md` from `docs/guides/file-kinds.md`
+  becomes `/docs/guides/reference/globs/` if rendered
+  literally instead of `/docs/reference/globs/`).
+- `Markdown` titled links (`[x](url "title")`) are not
+  matched by any rewriter regex; no source doc uses
+  them today, but the gap is real.
+- Issue [#47](https://github.com/jeduden/mdsmith/issues/47)
+  proposes external-URL HTTP checking — a separate
+  network-bound concern.
+
+Several other concerns sit alongside these without a
+home:
+
+- Link style consistency inside a doc set
+  (relative-vs-absolute, `.md`-vs-extensionless,
+  inline-vs-reference). Mixed styles are common in
+  mdsmith's own docs and reduce readability.
+- Heading-anchor stability when renderers normalize
+  differently (CommonMark vs GFM vs goldmark with
+  attribute extensions).
+- Wiki-style `[[target]]` links from Obsidian-flavored
+  Markdown (see [plan
+  168](168_obsidian-markdown-support.md)).
+- Redirects / aliases for renamed pages.
+- Cross-repo references (`@mdsmith/cli` → another
+  mdsmith-managed repo).
+
+A single research pass is cheaper than discovering each
+of these mid-implementation in another PR.
+
+## Tasks
+
+1. Inventory every link surface in the codebase: list
+   each rule that reads links (MDS012, MDS019, MDS021,
+   MDS027, MDS035, MDS037, MDS049, MDS053, MDS054, and
+   the directive-validating rules), the linkgraph
+   package, the website rewriter regexes
+   ([internal/release/website.go](../internal/release/website.go)),
+   the Hugo render-link hook at
+   [website/layouts/_default/_markup/](../website/layouts/_default/_markup/),
+   and any CLI subcommand that surfaces link data
+   ([mdsmith list backlinks](../docs/reference/cli/backlinks.md)).
+   Note which node kinds each one walks
+   (`*ast.Link`, `*ast.Image`, `*ast.AutoLink`,
+   reference defs, autolinks-from-text) and which
+   parts of the URL each one understands (scheme,
+   absolute, relative, fragment, title).
+2. Audit a sample corpus — `docs/`, `plan/`,
+   `internal/rules/MDS*/README.md`, the synced
+   `website/content/docs/` tree, and the README — for
+   each link form actually in use. Record counts per
+   form (inline vs ref, relative vs absolute, with vs
+   without `.md` suffix, with vs without fragment,
+   with vs without title) and per kind. This grounds
+   later policy choices in real data.
+3. Catalog every gap surfaced above plus any new ones
+   the inventory turns up. For each gap, record:
+   target rule / surface, observed example, the
+   diagnostic mdsmith would emit today, the
+   diagnostic it should emit, and the breakage on the
+   published site if the gap stays open.
+4. For each gap, decide one of: (a) new rule with an
+   MDS id, (b) extension to an existing rule, (c)
+   build-time rewriter change, (d) Hugo render-time
+   change, or (e) deliberately not addressed (scope
+   decision). Capture the reasoning in one paragraph
+   each.
+5. Sketch a minimal API for a shared "link policy"
+   config block under `.mdsmith.yml` — at minimum:
+   preferred relative-vs-absolute style per kind,
+   preferred extension policy, allow-list of
+   external-URL skip patterns, image-target
+   validation toggle. This is design only; the
+   implementation cost lands in the follow-up plans.
+6. Decide whether MDS027 should grow image-target
+   validation, absolute-path resolution against a
+   configured site root, and ref-style coverage —
+   versus splitting those into new rules. Look at the
+   gomarklint precedent
+   ([docs/research/mdbase-vs-mdsmith/](../docs/research/mdbase-vs-mdsmith/))
+   for prior art.
+7. Decide whether `index.md` / `_index.md` /
+   trailing-slash conventions belong in a rewriter
+   layer, a render-link layer, or both (the current
+   PR #309 design splits them; the audit confirms or
+   reverses that split).
+8. Decide whether issue #47 (external URL HTTP
+   probing) lands as part of the same rule family or
+   as a standalone opt-in rule. Note the trade-off
+   with offline CI runs.
+9. Write the research doc at
+   `docs/research/links/README.md` (front matter, a
+   `summary:`, sections for each gap and the
+   decision). Link it from the docs catalog so
+   `mdsmith fix` picks it up.
+10. File one follow-up plan per "act on this" decision
+    from step 4. Each follow-up cites this audit.
+    Defer implementation to those plans.
+
+## Acceptance Criteria
+
+- [ ] `docs/research/links/README.md` exists, passes
+      `mdsmith check`, and is in the homepage catalog.
+- [ ] Every gap surfaced by PR #309 review is
+      catalogued with a target surface and a decision.
+- [ ] Inventory of link rules and link-aware code is
+      complete (one entry per file).
+- [ ] Corpus audit lists per-form counts for inline
+      vs ref-style, relative vs absolute, with vs
+      without `.md`, with vs without fragment.
+- [ ] A shared `links:` config sketch is in the doc
+      (design only — no parser changes here).
+- [ ] At least one follow-up plan file is filed per
+      "act on this" decision.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no issues.

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -8,17 +8,28 @@
 # rename) legitimately reshape files in ways that violate
 # the stylistic rules the source tree passes.
 #
-# Scope of validation: this config catches every
-# **relative-path** broken link in the rewritten output —
-# sibling-relative refs left by the rewriter, missing
-# `_index.md` renames, links to docs/ pages that no longer
-# exist. It does NOT validate site-absolute targets
-# (`/docs/rules/<id>/`, `/docs/guides/<page>/`) because
-# MDS027 short-circuits on absolute paths. The rewriter
-# emits those targets with unit-test coverage
-# (internal/release/syncdocs_test.go: rule-link rewrites);
-# Hugo's build step is the second guard. A follow-up could
-# add a Hugo-aware link check for those URLs.
+# Scope of validation: MDS027 only walks the goldmark AST
+# Link nodes that the parser actually produces, so this
+# config catches broken **inline** Markdown links and image
+# targets in the rewritten output — e.g. a docs page that
+# kept a relative `.md` reference the rewriter missed, or a
+# rewritten `_index.md`/`index.md` rename that points at a
+# directory the sync did not produce. Three classes of
+# breakage are NOT covered:
+#
+# - Reference-style links (`[label]: target`): linkgraph
+#   skips them so the per-link walk never sees them.
+# - Code-block contents: a `[…](…)`-shaped sequence inside
+#   a fenced or inline span parses as code text, not a
+#   Link node.
+# - Site-absolute targets (`/docs/rules/<id>/`,
+#   `/docs/<page>/`): MDS027 short-circuits absolute paths.
+#
+# The rewriter emits each rewritten URL form with unit-test
+# coverage (internal/release/syncdocs_test.go,
+# website_test.go); Hugo's build step is the second guard.
+# A follow-up could add a Hugo-aware end-to-end link check
+# for the gaps above.
 #
 # Used from CI via `mdsmith check --config
 # website/build-output.mdsmith.yml --no-gitignore

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -1,0 +1,66 @@
+# Lint config for the Hugo content tree under
+# website/content/docs/, produced by `mdsmith-release
+# build-website`. That tree is gitignored and regenerated
+# on every build, so it carries its own config rather than
+# inheriting the strict project config at the repo root —
+# sync transforms (H1 → front-matter title lift, directive-
+# marker strip, link rewrites, `index.md` → `_index.md`
+# rename) legitimately reshape files in ways that violate
+# the stylistic rules the source tree passes.
+#
+# This config keeps the integrity checks active and turns
+# off every style/structure rule whose source-shape
+# assumption no longer holds after sync. The remaining
+# active rules catch the one class of breakage the source
+# config cannot see: broken links in the rewritten output.
+#
+# Used from CI via `mdsmith check --config
+# website/build-output.mdsmith.yml --no-gitignore
+# website/content/docs/`.
+
+front-matter: true
+
+rules:
+  # Cross-file integrity: this is the entire point of
+  # running the lint over the synced tree. strict: true so
+  # non-Markdown link targets (image files, scripts, …)
+  # are also checked.
+  cross-file-reference-integrity:
+    strict: true
+
+  # Disabled — sync transforms break the rule's assumptions
+  # rather than producing real diagnostics:
+  #
+  # - first-line-heading / heading-increment: the source
+  #   H1 is lifted to front-matter `title:` by
+  #   reconcileDocForHugo, so the body's first heading is
+  #   level 2 (or there is no body heading at all on a
+  #   stub _index.md).
+  # - no-multiple-blanks: stripping <?include?> /
+  #   <?catalog?> markers can leave adjacent blank lines
+  #   that no longer separate a marker from its body.
+  # - single-trailing-newline: synthesizeSectionIndex
+  #   writes a minimal stub without a final newline.
+  # - line-length / max-file-length / paragraph-structure /
+  #   table-format / table-readability: catalog and
+  #   include outputs in the synced tree can have row
+  #   widths and paragraph shapes the source-side limits
+  #   were not tuned for.
+  # - required-structure: schemas target the
+  #   docs/-tree shape (paths, filenames, front matter);
+  #   the synced tree has different paths
+  #   (website/content/docs/...) and different filenames
+  #   (_index.md), so every schema mismatches.
+  first-line-heading: false
+  heading-increment: false
+  no-multiple-blanks: false
+  single-trailing-newline: false
+  line-length: false
+  max-file-length: false
+  paragraph-structure: false
+  paragraph-readability: false
+  table-format: false
+  table-readability: false
+  required-structure: false
+  no-emphasis-as-heading: false
+  token-budget: false

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -9,14 +9,15 @@
 # the stylistic rules the source tree passes.
 #
 # Scope of validation: MDS027 only walks the goldmark AST
-# Link nodes that the parser actually produces, so this
-# config catches broken **inline** Markdown links and image
-# targets in the rewritten output — e.g. a docs page that
-# kept a relative `.md` reference the rewriter missed, or a
-# rewritten `_index.md`/`index.md` rename that points at a
-# directory the sync did not produce. Three classes of
-# breakage are NOT covered:
+# Link nodes that linkgraph.ExtractLinks exposes, so this
+# config catches broken **inline** Markdown link targets in
+# the rewritten output — e.g. a docs page that kept a
+# relative `.md` reference the rewriter missed, or an
+# `index.md` rename that points at a directory the sync did
+# not produce. Four classes of breakage are NOT covered:
 #
+# - Image targets (`![alt](target)`): linkgraph walks only
+#   *ast.Link, not *ast.Image.
 # - Reference-style links (`[label]: target`): linkgraph
 #   skips them so the per-link walk never sees them.
 # - Code-block contents: a `[…](…)`-shaped sequence inside

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -29,8 +29,14 @@
 # The rewriter emits each rewritten URL form with unit-test
 # coverage (internal/release/syncdocs_test.go,
 # website_test.go); Hugo's build step is the second guard.
-# A follow-up could add a Hugo-aware end-to-end link check
-# for the gaps above.
+# A render-link hook
+# (website/layouts/_default/_markup/render-link.html) strips
+# the `.md` (and `_index.md`/`index.md`) suffix from every
+# relative href so the synced markdown stays
+# filesystem-valid for this check while the rendered HTML
+# uses Hugo's extensionless directory URLs. A follow-up
+# could add a Hugo-aware end-to-end link check for the
+# absolute-target gap above.
 #
 # Used from CI via `mdsmith check --config
 # website/build-output.mdsmith.yml --no-gitignore

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -40,18 +40,26 @@ rules:
   # - first-line-heading / heading-increment: the source
   #   H1 is lifted to front-matter `title:` by
   #   reconcileDocForHugo, so the body's first heading is
-  #   level 2 (or there is no body heading at all on a
-  #   stub _index.md).
+  #   level 2. Synthesized stub _index.md files have only
+  #   front matter and no body heading at all, which both
+  #   rules flag.
   # - no-multiple-blanks: stripping <?include?> /
   #   <?catalog?> markers can leave adjacent blank lines
   #   that no longer separate a marker from its body.
-  # - single-trailing-newline: synthesizeSectionIndex
-  #   writes a minimal stub without a final newline.
+  # - single-trailing-newline: front-matter: true strips
+  #   the YAML block before rules see the body. A
+  #   synthesized stub _index.md has only front matter, so
+  #   the post-strip body is empty and MDS009 reports an
+  #   empty file. The source stub itself is well-formed.
   # - line-length / max-file-length / paragraph-structure /
-  #   table-format / table-readability: catalog and
-  #   include outputs in the synced tree can have row
-  #   widths and paragraph shapes the source-side limits
+  #   paragraph-readability / token-budget / table-format /
+  #   table-readability: catalog and include outputs in
+  #   the synced tree can have row widths, paragraph
+  #   shapes, and section lengths the source-side limits
   #   were not tuned for.
+  # - no-emphasis-as-heading: catalog-generated bold table
+  #   labels and feature-card headers can trip the
+  #   emphasis-as-heading detector on the rendered output.
   # - required-structure: schemas target the
   #   docs/-tree shape (paths, filenames, front matter);
   #   the synced tree has different paths

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -8,11 +8,17 @@
 # rename) legitimately reshape files in ways that violate
 # the stylistic rules the source tree passes.
 #
-# This config keeps the integrity checks active and turns
-# off every style/structure rule whose source-shape
-# assumption no longer holds after sync. The remaining
-# active rules catch the one class of breakage the source
-# config cannot see: broken links in the rewritten output.
+# Scope of validation: this config catches every
+# **relative-path** broken link in the rewritten output —
+# sibling-relative refs left by the rewriter, missing
+# `_index.md` renames, links to docs/ pages that no longer
+# exist. It does NOT validate site-absolute targets
+# (`/docs/rules/<id>/`, `/docs/guides/<page>/`) because
+# MDS027 short-circuits on absolute paths. The rewriter
+# emits those targets with unit-test coverage
+# (internal/release/syncdocs_test.go: rule-link rewrites);
+# Hugo's build step is the second guard. A follow-up could
+# add a Hugo-aware link check for those URLs.
 #
 # Used from CI via `mdsmith check --config
 # website/build-output.mdsmith.yml --no-gitignore

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -1,5 +1,6 @@
 {{- /* Render-link hook: rewrite repo-relative hrefs to
-       Hugo's resolved page URLs.
+       Hugo's resolved page URLs, and adjust site-absolute
+       hrefs to honour the configured baseURL.
 
        Source docs link sibling pages by relative path
        (`[CLI](../reference/cli.md)`) so the markdown stays
@@ -27,9 +28,25 @@
        non-Page target (e.g. a resource file) still
        renders sensibly.
 
-       External URLs (http(s), mailto), fragment-only
-       links, and site-absolute paths bypass the lookup —
-       they are already in the right form. */ -}}
+       For site-absolute hrefs (the rewriter emits
+       `/docs/rules/<id>/` for cross-rule and docs-to-rule
+       references), we run them through `relURL` so a
+       deploy with a non-root `--baseURL`
+       (e.g. https://example.com/mdsmith/) gets the
+       configured prefix. Without this, Pages served from a
+       subpath would 404 on every rewritten link.
+       Fragments pass through unchanged. External URLs
+       (http(s), mailto) and fragment-only links bypass
+       both branches — they are already in the right form
+       or page-local.
+
+       `safeURL` would mark the URL as pre-sanitized and
+       skip Go html/template's built-in escaping, which
+       would let a `javascript:` or `data:` href in the
+       source markdown pass straight through. Without it,
+       Go neutralizes unknown schemes (rewriting them to
+       `#ZgotmplZ`) while still preserving legitimate path
+       characters in clean URLs — the right default. */ -}}
 
 {{- $url := .Destination -}}
 {{- $external := or
@@ -39,7 +56,15 @@
 {{- $anchorOnly := strings.HasPrefix $url "#" -}}
 {{- $absolute := strings.HasPrefix $url "/" -}}
 
-{{- if not (or $external $anchorOnly $absolute) -}}
+{{- if $absolute -}}
+  {{- $parts := split $url "#" -}}
+  {{- $path := index $parts 0 -}}
+  {{- $frag := "" -}}
+  {{- if gt (len $parts) 1 -}}
+    {{- $frag = printf "#%s" (delimit (after 1 $parts) "#") -}}
+  {{- end -}}
+  {{- $url = printf "%s%s" (relURL $path) $frag -}}
+{{- else if not (or $external $anchorOnly) -}}
   {{- $parts := split $url "#" -}}
   {{- $path := index $parts 0 -}}
   {{- $frag := "" -}}
@@ -64,11 +89,4 @@
     {{- $url = printf "%s/%s" (strings.TrimSuffix ".md" $path) $frag -}}
   {{- end -}}
 {{- end -}}
-{{- /* `safeURL` would mark the URL as pre-sanitized and skip
-       Go html/template's built-in escaping, which would let a
-       `javascript:` or `data:` href in the source markdown
-       pass straight through to the rendered anchor. Without
-       it, Go neutralizes unknown schemes (rewriting them to
-       `#ZgotmplZ`) while still preserving legitimate path
-       characters in clean URLs — which is the right default. */ -}}
 <a href="{{ $url }}"{{ with .Title }} title="{{ . | safeHTML }}"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -64,4 +64,11 @@
     {{- $url = printf "%s/%s" (strings.TrimSuffix ".md" $path) $frag -}}
   {{- end -}}
 {{- end -}}
-<a href="{{ $url | safeURL }}"{{ with .Title }} title="{{ . | safeHTML }}"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /* `safeURL` would mark the URL as pre-sanitized and skip
+       Go html/template's built-in escaping, which would let a
+       `javascript:` or `data:` href in the source markdown
+       pass straight through to the rendered anchor. Without
+       it, Go neutralizes unknown schemes (rewriting them to
+       `#ZgotmplZ`) while still preserving legitimate path
+       characters in clean URLs — which is the right default. */ -}}
+<a href="{{ $url }}"{{ with .Title }} title="{{ . | safeHTML }}"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -1,22 +1,35 @@
-{{- /* Render-link hook: rewrite repo-relative `.md` hrefs to
-       Hugo's extensionless directory URLs.
+{{- /* Render-link hook: rewrite repo-relative hrefs to
+       Hugo's resolved page URLs.
 
-       Source docs link sibling pages with the .md suffix
-       (`[CLI](../reference/cli.md)`) because the markdown
-       must also be valid on the local filesystem so MDS027
-       can resolve it. Hugo, on the other hand, serves
-       `reference/cli.md` at `/docs/reference/cli/` — no
-       extension, trailing slash. Without this hook the
-       rendered `<a href="reference/cli.md">` would 404 on
-       the live site.
+       Source docs link sibling pages by relative path
+       (`[CLI](../reference/cli.md)`) so the markdown stays
+       filesystem-valid for MDS027. The site's URL layout
+       is one level deeper than the source: a markdown file
+       at `docs/guides/foo.md` renders at
+       `/docs/guides/foo/`. A relative href resolved from
+       that rendered URL therefore lands one directory
+       below where the source intended — for example
+       `../reference/globs.md` from `docs/guides/file-kinds.md`
+       would resolve to `/docs/guides/reference/globs/`
+       instead of `/docs/reference/globs/`. Stripping `.md`
+       alone does not fix that mismatch.
 
-       The hook passes external URLs (http(s)/mailto),
-       fragment-only links, and site-absolute paths through
-       unchanged — those are already in the right form. For
-       any other target the fragment is split off, a
-       trailing `/index.md` or `/_index.md` collapses to the
-       directory URL, and a trailing `.md` becomes `/`. The
-       fragment is reattached after the transform. */ -}}
+       Hugo's `.Page.GetPage` resolves a source-relative
+       path to a Page and returns its absolute
+       `.RelPermalink`, which already accounts for the
+       deeper rendering URL. We try GetPage first for any
+       relative target. If it succeeds (typically every
+       link into another docs page, including section
+       indexes), we use the page's permalink and append any
+       fragment. GetPage misses fall back to a path-only
+       fix-up (strip a trailing `.md`, collapse
+       `index.md`/`_index.md` to the directory) so a stray
+       non-Page target (e.g. a resource file) still
+       renders sensibly.
+
+       External URLs (http(s), mailto), fragment-only
+       links, and site-absolute paths bypass the lookup —
+       they are already in the right form. */ -}}
 
 {{- $url := .Destination -}}
 {{- $external := or
@@ -25,6 +38,7 @@
   (strings.HasPrefix $url "mailto:") -}}
 {{- $anchorOnly := strings.HasPrefix $url "#" -}}
 {{- $absolute := strings.HasPrefix $url "/" -}}
+
 {{- if not (or $external $anchorOnly $absolute) -}}
   {{- $parts := split $url "#" -}}
   {{- $path := index $parts 0 -}}
@@ -32,15 +46,22 @@
   {{- if gt (len $parts) 1 -}}
     {{- $frag = printf "#%s" (delimit (after 1 $parts) "#") -}}
   {{- end -}}
-  {{- if strings.HasSuffix $path "/index.md" -}}
-    {{- $path = strings.TrimSuffix "index.md" $path -}}
-  {{- else if strings.HasSuffix $path "/_index.md" -}}
-    {{- $path = strings.TrimSuffix "_index.md" $path -}}
-  {{- else if or (eq $path "index.md") (eq $path "_index.md") -}}
-    {{- $path = "./" -}}
-  {{- else if strings.HasSuffix $path ".md" -}}
-    {{- $path = printf "%s/" (strings.TrimSuffix ".md" $path) -}}
+
+  {{- $resolved := "" -}}
+  {{- with .Page.GetPage $path -}}
+    {{- $resolved = .RelPermalink -}}
   {{- end -}}
-  {{- $url = printf "%s%s" $path $frag -}}
+
+  {{- if $resolved -}}
+    {{- $url = printf "%s%s" $resolved $frag -}}
+  {{- else if strings.HasSuffix $path "/index.md" -}}
+    {{- $url = printf "%s%s" (strings.TrimSuffix "index.md" $path) $frag -}}
+  {{- else if strings.HasSuffix $path "/_index.md" -}}
+    {{- $url = printf "%s%s" (strings.TrimSuffix "_index.md" $path) $frag -}}
+  {{- else if or (eq $path "index.md") (eq $path "_index.md") -}}
+    {{- $url = printf "./%s" $frag -}}
+  {{- else if strings.HasSuffix $path ".md" -}}
+    {{- $url = printf "%s/%s" (strings.TrimSuffix ".md" $path) $frag -}}
+  {{- end -}}
 {{- end -}}
 <a href="{{ $url | safeURL }}"{{ with .Title }} title="{{ . | safeHTML }}"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -89,4 +89,14 @@
     {{- $url = printf "%s/%s" (strings.TrimSuffix ".md" $path) $frag -}}
   {{- end -}}
 {{- end -}}
-<a href="{{ $url }}"{{ with .Title }} title="{{ . | safeHTML }}"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /* .Title is the Markdown link title — raw text that has
+       not been through Hugo's contextual escaper. Emitting it
+       with `safeHTML` would bypass the attribute escaper and
+       let a `"`/`>` in the title break out of the href's
+       sibling attribute. Letting Go's html/template see the
+       string in `attr="…"` context produces the right
+       per-context escaping. (.Text stays on safeHTML because
+       it already arrives as rendered HTML from Hugo — the
+       renderer applies any inline emphasis or code spans in
+       the link text before this hook fires.) */ -}}
+<a href="{{ $url }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -52,9 +52,16 @@
 {{- $external := or
   (strings.HasPrefix $url "http://")
   (strings.HasPrefix $url "https://")
-  (strings.HasPrefix $url "mailto:") -}}
+  (strings.HasPrefix $url "mailto:")
+  (strings.HasPrefix $url "//") -}}
+{{- /* `//example.com/path` is a protocol-relative external URL,
+       not a site-absolute path. Treating it as $absolute would
+       prefix it with `site.Home.RelPermalink` and emit
+       `/mdsmith//example.com/path`, corrupting the link. The
+       protocol-relative check sits in $external so the value
+       passes through unchanged. */ -}}
 {{- $anchorOnly := strings.HasPrefix $url "#" -}}
-{{- $absolute := strings.HasPrefix $url "/" -}}
+{{- $absolute := and (strings.HasPrefix $url "/") (not $external) -}}
 
 {{- if $absolute -}}
   {{- /* Hugo's `relURL` returns absolute paths unchanged

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -1,0 +1,46 @@
+{{- /* Render-link hook: rewrite repo-relative `.md` hrefs to
+       Hugo's extensionless directory URLs.
+
+       Source docs link sibling pages with the .md suffix
+       (`[CLI](../reference/cli.md)`) because the markdown
+       must also be valid on the local filesystem so MDS027
+       can resolve it. Hugo, on the other hand, serves
+       `reference/cli.md` at `/docs/reference/cli/` — no
+       extension, trailing slash. Without this hook the
+       rendered `<a href="reference/cli.md">` would 404 on
+       the live site.
+
+       The hook passes external URLs (http(s)/mailto),
+       fragment-only links, and site-absolute paths through
+       unchanged — those are already in the right form. For
+       any other target the fragment is split off, a
+       trailing `/index.md` or `/_index.md` collapses to the
+       directory URL, and a trailing `.md` becomes `/`. The
+       fragment is reattached after the transform. */ -}}
+
+{{- $url := .Destination -}}
+{{- $external := or
+  (strings.HasPrefix $url "http://")
+  (strings.HasPrefix $url "https://")
+  (strings.HasPrefix $url "mailto:") -}}
+{{- $anchorOnly := strings.HasPrefix $url "#" -}}
+{{- $absolute := strings.HasPrefix $url "/" -}}
+{{- if not (or $external $anchorOnly $absolute) -}}
+  {{- $parts := split $url "#" -}}
+  {{- $path := index $parts 0 -}}
+  {{- $frag := "" -}}
+  {{- if gt (len $parts) 1 -}}
+    {{- $frag = printf "#%s" (delimit (after 1 $parts) "#") -}}
+  {{- end -}}
+  {{- if strings.HasSuffix $path "/index.md" -}}
+    {{- $path = strings.TrimSuffix "index.md" $path -}}
+  {{- else if strings.HasSuffix $path "/_index.md" -}}
+    {{- $path = strings.TrimSuffix "_index.md" $path -}}
+  {{- else if or (eq $path "index.md") (eq $path "_index.md") -}}
+    {{- $path = "./" -}}
+  {{- else if strings.HasSuffix $path ".md" -}}
+    {{- $path = printf "%s/" (strings.TrimSuffix ".md" $path) -}}
+  {{- end -}}
+  {{- $url = printf "%s%s" $path $frag -}}
+{{- end -}}
+<a href="{{ $url | safeURL }}"{{ with .Title }} title="{{ . | safeHTML }}"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -57,13 +57,21 @@
 {{- $absolute := strings.HasPrefix $url "/" -}}
 
 {{- if $absolute -}}
+  {{- /* Hugo's `relURL` returns absolute paths unchanged
+         even under a non-root --baseURL, so the rewriter's
+         site-absolute targets need a manual prefix from
+         `site.Home.RelPermalink` (which IS the baseURL
+         path with a trailing slash — `/` for root,
+         `/mdsmith/` for project-pages). Trim its trailing
+         slash so concatenation does not produce `//docs`. */ -}}
   {{- $parts := split $url "#" -}}
   {{- $path := index $parts 0 -}}
   {{- $frag := "" -}}
   {{- if gt (len $parts) 1 -}}
     {{- $frag = printf "#%s" (delimit (after 1 $parts) "#") -}}
   {{- end -}}
-  {{- $url = printf "%s%s" (relURL $path) $frag -}}
+  {{- $sitePrefix := strings.TrimSuffix "/" site.Home.RelPermalink -}}
+  {{- $url = printf "%s%s%s" $sitePrefix $path $frag -}}
 {{- else if not (or $external $anchorOnly) -}}
   {{- $parts := split $url "#" -}}
   {{- $path := index $parts 0 -}}

--- a/website/layouts/_default/list.html
+++ b/website/layouts/_default/list.html
@@ -20,36 +20,40 @@
         {{ with .Params.summary }}<p class="lead">{{ . }}</p>{{ end }}
         {{ .Content }}
 
-        {{- /* Section index: list child subsections as grouped
-               cards (each with its pages) plus any direct pages.
-               Replaces the old flat <ul> that ignored
-               subsections, which is why /docs/ looked
-               unstructured and Background never showed. */ -}}
-        {{ with .Sections.ByWeight }}
-          <div class="docs-index">
-            {{ range . }}
-              <section class="docs-index-group">
-                <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-                {{ with .Params.summary }}<p class="docs-index-summary">{{ . }}</p>{{ end }}
-                <ul class="docs-index-list">
-                  {{ range .Pages.ByWeight }}
-                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>{{ with .Params.summary }} <span class="docs-index-desc">— {{ . }}</span>{{ end }}</li>
-                  {{ end }}
-                  {{ range .Sections.ByWeight }}
-                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> <span class="docs-index-desc">— more pages</span></li>
-                  {{ end }}
-                </ul>
-              </section>
-            {{ end }}
-          </div>
-        {{ end }}
+        {{- /* Auto-rendered section index: only emitted when the
+               page body is empty (e.g. a synthesized stub
+               _index.md). Pages whose source carries its own
+               listing — a `<?catalog?>` table or hand-written
+               links — already render that listing inside
+               .Content above, so adding section cards or a flat
+               <ul> below would duplicate it. */ -}}
+        {{ if not .Content }}
+          {{ with .Sections.ByWeight }}
+            <div class="docs-index">
+              {{ range . }}
+                <section class="docs-index-group">
+                  <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+                  {{ with .Params.summary }}<p class="docs-index-summary">{{ . }}</p>{{ end }}
+                  <ul class="docs-index-list">
+                    {{ range .Pages.ByWeight }}
+                      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>{{ with .Params.summary }} <span class="docs-index-desc">— {{ . }}</span>{{ end }}</li>
+                    {{ end }}
+                    {{ range .Sections.ByWeight }}
+                      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> <span class="docs-index-desc">— more pages</span></li>
+                    {{ end }}
+                  </ul>
+                </section>
+              {{ end }}
+            </div>
+          {{ end }}
 
-        {{ with .Pages.ByWeight }}
-          <ul class="docs-index-list docs-index-flat">
-            {{ range . }}
-              <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>{{ with .Params.summary }} <span class="docs-index-desc">— {{ . }}</span>{{ end }}</li>
-            {{ end }}
-          </ul>
+          {{ with .Pages.ByWeight }}
+            <ul class="docs-index-list docs-index-flat">
+              {{ range . }}
+                <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>{{ with .Params.summary }} <span class="docs-index-desc">— {{ . }}</span>{{ end }}</li>
+              {{ end }}
+            </ul>
+          {{ end }}
         {{ end }}
       </div>
     </article>


### PR DESCRIPTION
## Summary

When syncing the docs tree to Hugo for publication, repo-relative links that point into unpublished directories (like `internal/rules/`, `plan/`, or source code) break on the live site. This change rewrites those links to either published site URLs (for rule pages) or GitHub blob URLs (for source files), ensuring all cross-references remain clickable after sync.

## Key Changes

- **New link rewriting logic** (`rewriteRuleLinks` function): Transforms repo-relative links in three passes:
  1. `internal/rules/MDS…/` links → `/docs/rules/<dir>/` site URLs (preserving anchors)
  2. Non-published paths (`plan/`, `cmd/`, `internal/`, root files) → GitHub blob URLs
  3. `index.md` sibling links → `_index.md` (matching the rename applied during sync)

- **Six new regex patterns** to match different link classes:
  - `repoRuleLink` / `repoRuleRefDef`: Inline and reference-style rule links (any `../` depth, optional `README.md`, optional anchors)
  - `repoNonPublishedLink` / `repoNonPublishedRefDef`: Links to unpublished repo paths
  - `indexMdLink`: Sibling `index.md` references
  - `ruleFixtureLink` / `ruleSiblingNonMDSLink`: Rule-specific fixture and sibling links

- **Rule page sync enhancements** (`syncRulePages`):
  - Fixture references (`good/`, `bad/`, `pattern/`) → rule's GitHub source tree URL
  - Sibling non-MDS references (Go packages, `proto.md`) → GitHub blob URLs under `internal/rules/`
  - Reuses computed `ruleSourceURL` to avoid duplication

- **Hugo template fix** (`website/layouts/_default/list.html`): Only render auto-generated section index when page body is empty, preventing duplication with hand-written or `<?catalog?>` listings

- **New lint config** (`website/build-output.mdsmith.yml`): Dedicated mdsmith config for the synced tree with link-integrity checks enabled and style/structure rules disabled (since sync transforms legitimately reshape files)

- **CI integration** (`pages.yml`): Added `mdsmith check` step over the synced tree to catch broken links before publishing

- **Comprehensive test coverage**: 13 test cases covering deep/shallow links, inline/reference-style, anchors, fixture paths, and sibling references

## Implementation Details

- **Idempotent rewrites**: Already-rewritten paths (leading `/docs/`, `https://`, or `_index.md`) don't match any regex, so multiple passes are safe
- **Ordering matters**: Rule rewrite runs first so `internal/rules/MDS…/` paths don't get consumed by the non-published rewrite
- **Braced group syntax**: Uses `${1}` (not `$1`) in replacements to avoid Go regexp parser ambiguity with variable names like `1_index`
- **Anchor preservation**: Rule links capture optional `#anchor` fragments and preserve them in the rewritten site URL
- **Reference-style support**: Both inline `[text](url)` and reference-style `[label]: url` definitions are rewritten consistently

https://claude.ai/code/session_0118XVEN78p3ijBMLix3Nuvf