### PR TITLE
Extract test pyramid guidance to shared docs page

### DIFF
--- a/.claude/skills/solid-architecture/SKILL.md
+++ b/.claude/skills/solid-architecture/SKILL.md
@@ -176,5 +176,6 @@ row: "[{slug}]: {filename}"
 [cross]: ../../../docs/development/architecture/cross-system.md
 [go]: ../../../docs/development/architecture/go.md
 [hub]: ../../../docs/development/architecture/index.md
+[tests]: ../../../docs/development/architecture/tests.md
 [ts]: ../../../docs/development/architecture/typescript.md
 <?/catalog?>

--- a/.claude/skills/solid-architecture/audit-checklist.md
+++ b/.claude/skills/solid-architecture/audit-checklist.md
@@ -133,19 +133,29 @@ e2e. It also sets the rule that
 every function ships with a
 dedicated unit test.
 
-For every function in the touched
-set:
+For every production function in the
+touched set — skip `_test.go`,
+`*.test.ts`, and test-only helper
+files; the audit does not ask for
+"tests for tests":
 
 - Confirm a dedicated unit test
   exists in the matching test file,
   named after the function per the
   language page's binding (e.g.
-  `TestFunctionName` for Go,
-  `describe("name")` for TS).
+  `TestFunctionName` or
+  `TestReceiver_Method` for Go;
+  `describe("name")` containing
+  `test(…)` cases from `bun:test`
+  for TS).
 - If the function is exempt
-  (generated code, trivial
-  accessor), confirm the one-line
-  exemption comment is present.
+  (generated file marker present,
+  or trivial accessor), confirm
+  the one-line exemption comment
+  is present on trivial accessors
+  (generated files need no
+  per-function comment — the
+  file-level marker is enough).
 - If a test exists but lives one
   layer too high (an integration
   test that drives a single

--- a/.claude/skills/solid-architecture/audit-checklist.md
+++ b/.claude/skills/solid-architecture/audit-checklist.md
@@ -134,7 +134,7 @@ every function ships with a
 dedicated unit test.
 
 For every production function in the
-touched set — skip `_test.go`,
+touched set — skip `*_test.go`,
 `*.test.ts`, and test-only helper
 files; the audit does not ask for
 "tests for tests":
@@ -148,14 +148,24 @@ files; the audit does not ask for
   `describe("name")` containing
   `test(…)` cases from `bun:test`
   for TS).
-- If the function is exempt
-  (generated file marker present,
-  or trivial accessor), confirm
-  the one-line exemption comment
-  is present on trivial accessors
-  (generated files need no
-  per-function comment — the
-  file-level marker is enough).
+- If the function lives in a
+  generated file (`*_gen.go`,
+  `*.d.ts`, anything emitted under
+  `dist/`, or any file beginning
+  with a `// Code generated…`
+  header), the file-level marker
+  is enough — do not flag and do
+  not require a per-function
+  exemption comment.
+- If the function is a trivial
+  accessor with no branch (a
+  one-line getter or
+  `String()`-style format method),
+  confirm a one-line exemption
+  comment is present so the audit
+  can distinguish "no test by
+  design" from "no test,
+  forgotten".
 - If a test exists but lives one
   layer too high (an integration
   test that drives a single

--- a/.claude/skills/solid-architecture/audit-checklist.md
+++ b/.claude/skills/solid-architecture/audit-checklist.md
@@ -101,13 +101,15 @@ shape the docs reject.
 - `.go` files → the project's Go
   architecture page (commonly
   `docs/development/architecture/go.md`).
-  Walk every SOLID section and the
-  "Common violations to flag" list.
+  Walk every SOLID section, the
+  "Tests" section, and the "Common
+  violations to flag" list.
 - `.ts` / `.tsx` files → the project's
   TypeScript architecture page. Walk
   every SOLID section, the wiring
-  section, and the "Common violations
-  to flag" list.
+  section, the "Tests" section, and
+  the "Common violations to flag"
+  list.
 - Files touching wire protocols, CLI
   flags, config schemas, generated
   markers, plugin manifests, shims, or
@@ -118,6 +120,45 @@ shape the docs reject.
 
 For every flagged shape, record the
 section that justifies the flag.
+
+### Test pyramid sub-walk
+
+The language pages include a
+canonical "Test pyramid" partial.
+It commonly lives at
+`docs/development/architecture/tests.md`.
+The partial defines four layers:
+unit, contract, integration, and
+e2e. It also sets the rule that
+every function ships with a
+dedicated unit test.
+
+For every function in the touched
+set:
+
+- Confirm a dedicated unit test
+  exists in the matching test file,
+  named after the function per the
+  language page's binding (e.g.
+  `TestFunctionName` for Go,
+  `describe("name")` for TS).
+- If the function is exempt
+  (generated code, trivial
+  accessor), confirm the one-line
+  exemption comment is present.
+- If a test exists but lives one
+  layer too high (an integration
+  test that drives a single
+  function, an e2e test that
+  duplicates integration), record
+  an inverted-pyramid finding.
+
+Record missing tests as findings.
+Use the severity rule the project
+sets. See its architecture
+audit-checklist page for the
+project's "Severity for missing
+unit test" entry.
 
 ## Step 3: severity rubric
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ row: "- [{summary}](../{filename})"
 - [External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.](../docs/development/architecture/cross-system.md)
 - [Go-specific SOLID and clean architecture patterns for mdsmith's cmd/ and internal/ packages.](../docs/development/architecture/go.md)
 - [SOLID and clean-architecture rules for mdsmith's Go core, TypeScript extension, and cross-system surfaces. Canonical home for the solid-architecture skill.](../docs/development/architecture/index.md)
+- [Four-layer test pyramid (unit, contract, integration, e2e) and the rule that every function ships with a dedicated unit test. Included from the Go and TypeScript architecture pages.](../docs/development/architecture/tests.md)
 - [SOLID and clean architecture patterns for the mdsmith VS Code extension at editors/vscode/.](../docs/development/architecture/typescript.md)
 - [Codecov coverage gate and CI status checks.](../docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](../docs/development/file-placement.md)

--- a/.mdsmith.pinned.yml
+++ b/.mdsmith.pinned.yml
@@ -342,6 +342,9 @@ kinds:
           required: false
         - heading:
             unlisted: true
+    rules:
+      max-file-length:
+        max: 500
   cli-command:
     schema:
       frontmatter:

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -333,6 +333,9 @@ kinds:
         - heading:
             regex: '.+'
             repeat: { min: 0 }
+    rules:
+      max-file-length:
+        max: 500
   cli-command:
     schema:
       frontmatter:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ row: "- [{summary}]({filename})"
 - [External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.](docs/development/architecture/cross-system.md)
 - [Go-specific SOLID and clean architecture patterns for mdsmith's cmd/ and internal/ packages.](docs/development/architecture/go.md)
 - [SOLID and clean-architecture rules for mdsmith's Go core, TypeScript extension, and cross-system surfaces. Canonical home for the solid-architecture skill.](docs/development/architecture/index.md)
+- [Four-layer test pyramid (unit, contract, integration, e2e) and the rule that every function ships with a dedicated unit test. Included from the Go and TypeScript architecture pages.](docs/development/architecture/tests.md)
 - [SOLID and clean architecture patterns for the mdsmith VS Code extension at editors/vscode/.](docs/development/architecture/typescript.md)
 - [Codecov coverage gate and CI status checks.](docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](docs/development/file-placement.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ row: "- [{summary}]({filename})"
 - [External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.](docs/development/architecture/cross-system.md)
 - [Go-specific SOLID and clean architecture patterns for mdsmith's cmd/ and internal/ packages.](docs/development/architecture/go.md)
 - [SOLID and clean-architecture rules for mdsmith's Go core, TypeScript extension, and cross-system surfaces. Canonical home for the solid-architecture skill.](docs/development/architecture/index.md)
+- [Four-layer test pyramid (unit, contract, integration, e2e) and the rule that every function ships with a dedicated unit test. Included from the Go and TypeScript architecture pages.](docs/development/architecture/tests.md)
 - [SOLID and clean architecture patterns for the mdsmith VS Code extension at editors/vscode/.](docs/development/architecture/typescript.md)
 - [Codecov coverage gate and CI status checks.](docs/development/coverage.md)
 - [Where to place Markdown files and documentation types.](docs/development/file-placement.md)

--- a/docs/development/architecture/audit-checklist.md
+++ b/docs/development/architecture/audit-checklist.md
@@ -141,20 +141,29 @@ the audit needs are below.
   `xxx.test.ts` next to `xxx.ts` for
   the VS Code extension.
 - **Function-coverage rule**: every
-  Go and TypeScript function — both
-  exported and unexported — has a
-  dedicated test by name (`TestFoo`
-  for Go `func Foo`; a
+  Go and TypeScript production
+  function — both exported and
+  unexported — has a dedicated test
+  by name (`TestFoo` for Go package
+  `func Foo`, `TestReceiver_Foo`
+  for a method on `Receiver`; a
   `describe("foo")` block with one
-  or more `it(…)` cases for TS
-  `foo`). Generated files
-  (`*_gen.go`, `*.d.ts`, `dist/`)
-  and trivial accessors with no
-  branch are exempt; see
+  or more `test(…)` cases imported
+  from `bun:test` for TS `foo`).
+  Test files (`*_test.go`,
+  `*.test.ts`) and test-only
+  helpers are out of scope — the
+  audit walks production sources
+  only. Generated files (`*_gen.go`,
+  `*.d.ts`, `dist/`) and trivial
+  accessors with no branch are
+  exempt; see
   [Test pyramid §"Exemptions"](tests.md#exemptions).
-- **Contract tests** for Go live
-  alongside the port-package they
-  pin. Examples:
+- **Contract tests** for Go in this
+  repo live under
+  `internal/integration/` rather
+  than alongside the port-package
+  they pin. Examples:
   `internal/integration/rule_boundaries_test.go`,
   `internal/integration/directive_examples_test.go`.
 - **Integration test location**:

--- a/docs/development/architecture/audit-checklist.md
+++ b/docs/development/architecture/audit-checklist.md
@@ -171,15 +171,22 @@ the audit needs are below.
   TypeScript integration tests sit
   next to the command module they
   exercise.
-- **E2E test location**:
-  `cmd/mdsmith/` for Go, using
-  either an `e2e_*_test.go` prefix
-  (e.g. `e2e_test.go`,
-  `e2e_backlinks_test.go`) or an
-  `*_e2e_test.go` suffix (e.g.
-  `kinds_e2e_test.go`,
+- **E2E test location**: under
+  `cmd/mdsmith/` for Go, defined
+  by behaviour (the test spawns
+  the built binary and drives it
+  over stdio, exit code, or
+  signals). Three filename shapes
+  appear in the repo, all e2e:
+  `e2e_` prefix (`e2e_test.go`,
+  `e2e_backlinks_test.go`),
+  `_e2e_` suffix
+  (`kinds_e2e_test.go`,
   `list_e2e_test.go`,
-  `explain_e2e_test.go`); demo
+  `explain_e2e_test.go`), and
+  topic-named LSP subprocess
+  tests (`lsp_test.go`,
+  `lsp_hover_test.go`, …). Demo
   tapes under `demo/` are also
   e2e. The VS Code extension host
   runs are e2e for the TypeScript
@@ -242,13 +249,15 @@ explicit mention here:
   pyramid is inverted; push the
   assertion down to a unit test in
   the function's own package.
-- **An e2e test (`e2e_*_test.go`
-  prefix or `*_e2e_test.go`
-  suffix) added where a unit or
-  integration test would suffice**
-  — e2e tests build and run the
-  binary; reserve them for
-  behaviour that needs the full
+- **A test that spawns the
+  `mdsmith` binary as a
+  subprocess to assert behaviour
+  reachable without it** —
+  pyramid is inverted regardless
+  of the filename shape; e2e
+  tests build and run the binary,
+  reserve them for behaviour that
+  needs the full
   process boundary.
 
 ## Common skip cases in this repo

--- a/docs/development/architecture/audit-checklist.md
+++ b/docs/development/architecture/audit-checklist.md
@@ -172,10 +172,18 @@ the audit needs are below.
   next to the command module they
   exercise.
 - **E2E test location**:
-  `cmd/mdsmith/e2e_*_test.go` for
-  Go; demo tapes under `demo/`. The
-  VS Code extension host runs are
-  e2e for the TypeScript side.
+  `cmd/mdsmith/` for Go, using
+  either an `e2e_*_test.go` prefix
+  (e.g. `e2e_test.go`,
+  `e2e_backlinks_test.go`) or an
+  `*_e2e_test.go` suffix (e.g.
+  `kinds_e2e_test.go`,
+  `list_e2e_test.go`,
+  `explain_e2e_test.go`); demo
+  tapes under `demo/` are also
+  e2e. The VS Code extension host
+  runs are e2e for the TypeScript
+  side.
 - **Severity for missing unit
   test**: `tax` by default;
   `blocker` if the function is on a
@@ -213,10 +221,14 @@ explicit mention here:
   `internal/engine` to test a rule** —
   push it to a fixture under the
   rule's `good/` or `bad/` directory.
-- **A Go function with no
-  `TestFunctionName` symbol in a
-  sibling `_test.go`** — test debt.
-  Severity per the rule above.
+- **A Go function with no matching
+  test symbol in a sibling
+  `*_test.go`** — `TestFoo` for a
+  package function `func Foo`,
+  `TestReceiver_Foo` (or
+  `TestReceiver_Foo_Variant`) for a
+  method on `Receiver`. Test debt;
+  severity per the rule above.
 - **A TypeScript function not
   covered by a `describe("name",
   () => { test(…) })` block (with
@@ -230,10 +242,12 @@ explicit mention here:
   pyramid is inverted; push the
   assertion down to a unit test in
   the function's own package.
-- **An `e2e_*_test.go` added where
-  a unit or integration test would
-  suffice** — e2e tests build and
-  run the binary; reserve them for
+- **An e2e test (`e2e_*_test.go`
+  prefix or `*_e2e_test.go`
+  suffix) added where a unit or
+  integration test would suffice**
+  — e2e tests build and run the
+  binary; reserve them for
   behaviour that needs the full
   process boundary.
 

--- a/docs/development/architecture/audit-checklist.md
+++ b/docs/development/architecture/audit-checklist.md
@@ -218,8 +218,10 @@ explicit mention here:
   sibling `_test.go`** — test debt.
   Severity per the rule above.
 - **A TypeScript function not
-  covered by a `describe` /
-  `it` block in a sibling
+  covered by a `describe("name",
+  () => { test(…) })` block (with
+  `describe`/`test` imported from
+  `bun:test`) in a sibling
   `*.test.ts`** — same rule for the
   extension.
 - **A test under

--- a/docs/development/architecture/audit-checklist.md
+++ b/docs/development/architecture/audit-checklist.md
@@ -125,6 +125,56 @@ generic workflow:
 7. Tell the user what was found and
    what was scheduled.
 
+## Test audit bindings
+
+Architecture audits also check test
+coverage. The
+[Test pyramid](tests.md) doc is the
+source of truth; the language pages
+([Go](go.md), [TypeScript](typescript.md))
+include it and add file-pattern
+bindings. The mdsmith-specific knobs
+the audit needs are below.
+
+- **Unit-test location**: `xxx_test.go`
+  next to `xxx.go` for Go;
+  `xxx.test.ts` next to `xxx.ts` for
+  the VS Code extension.
+- **Function-coverage rule**: every
+  Go and TypeScript function — both
+  exported and unexported — has a
+  dedicated test by name (`TestFoo`
+  for Go `func Foo`; a
+  `describe("foo")` block with one
+  or more `it(…)` cases for TS
+  `foo`). Generated files
+  (`*_gen.go`, `*.d.ts`, `dist/`)
+  and trivial accessors with no
+  branch are exempt; see
+  [Test pyramid §"Exemptions"](tests.md#exemptions).
+- **Contract tests** for Go live
+  alongside the port-package they
+  pin. Examples:
+  `internal/integration/rule_boundaries_test.go`,
+  `internal/integration/directive_examples_test.go`.
+- **Integration test location**:
+  `internal/integration/` for Go.
+  TypeScript integration tests sit
+  next to the command module they
+  exercise.
+- **E2E test location**:
+  `cmd/mdsmith/e2e_*_test.go` for
+  Go; demo tapes under `demo/`. The
+  VS Code extension host runs are
+  e2e for the TypeScript side.
+- **Severity for missing unit
+  test**: `tax` by default;
+  `blocker` if the function is on a
+  public surface (a `rule.Rule`
+  method, an LSP capability handler,
+  a CLI subcommand entry, an
+  exported VS Code command).
+
 ## mdsmith-specific checks worth flagging
 
 These show up enough that they deserve
@@ -154,6 +204,27 @@ explicit mention here:
   `internal/engine` to test a rule** —
   push it to a fixture under the
   rule's `good/` or `bad/` directory.
+- **A Go function with no
+  `TestFunctionName` symbol in a
+  sibling `_test.go`** — test debt.
+  Severity per the rule above.
+- **A TypeScript function not
+  covered by a `describe` /
+  `it` block in a sibling
+  `*.test.ts`** — same rule for the
+  extension.
+- **A test under
+  `internal/integration/` that
+  exercises a single function** —
+  pyramid is inverted; push the
+  assertion down to a unit test in
+  the function's own package.
+- **An `e2e_*_test.go` added where
+  a unit or integration test would
+  suffice** — e2e tests build and
+  run the binary; reserve them for
+  behaviour that needs the full
+  process boundary.
 
 ## Common skip cases in this repo
 

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -325,27 +325,25 @@ packaged-artifact tests.
 - **Unit tests** in `xxx_test.go`
   next to `xxx.go`. The dedicated
   test for a package function
-  `func Foo` is `TestFoo`. For a
-  method `func (r *Receiver) Foo`,
-  the dedicated test is
-  `TestReceiver_Foo`. Sub-behaviours
-  may live as subtests via
-  `t.Run("case", …)` under that
-  parent (see
-  `internal/lint/frontmatter_test.go`'s
-  `TestParseFrontMatterFields`) or
-  as additional top-level functions
-  named `TestReceiver_Foo_Variant`
-  (see
-  `internal/archetype/gensection/`
-  `engine_test.go`'s
-  `TestEngine_Check_*` family).
+  `func Foo` is `TestFoo`; for a
+  method `func (r *Receiver) Foo`
+  it is `TestReceiver_Foo`.
+  Sub-behaviours may live as
+  `t.Run("case", …)` subtests
+  under that parent (e.g.
+  `TestParseFrontMatterFields` in
+  `internal/lint/frontmatter_test.go`)
+  or as additional top-level
+  functions
+  `TestReceiver_Foo_Variant` (e.g.
+  the `TestEngine_Check_*` family
+  in
+  `internal/archetype/gensection/engine_test.go`).
   Either form satisfies the
-  "dedicated test by name" rule;
-  pick subtests when behaviours
-  share setup, separate top-level
-  tests when each variant stands
-  alone.
+  dedicated-test rule — subtests
+  when behaviours share setup,
+  separate top-level when each
+  variant stands alone.
 - **Contract tests** in this repo:
   `internal/integration/rule_boundaries_test.go`
   pins the rule import graph;
@@ -363,17 +361,25 @@ packaged-artifact tests.
   `internal/integration/`. The rule
   fixture runner (`rules_test.go`)
   is the canonical example.
-- **E2E tests** are named with
-  either an `e2e_*_test.go` prefix
-  (e.g. `cmd/mdsmith/e2e_test.go`,
-  `e2e_backlinks_test.go`) or an
-  `*_e2e_test.go` suffix (e.g.
-  `kinds_e2e_test.go`,
-  `list_e2e_test.go`,
-  `explain_e2e_test.go`). Both
-  patterns count; the demo tape
-  harness under `demo/` is also
-  e2e.
+- **E2E tests** live under
+  `cmd/mdsmith/` and are defined
+  by behaviour — the test spawns
+  the built `mdsmith` binary and
+  drives it over stdio, exit
+  code, or signals. Audit by what
+  the test does, not the
+  filename; three name shapes
+  appear in the repo: `e2e_`
+  prefix (`e2e_test.go`,
+  `e2e_backlinks_test.go`),
+  `_e2e_` suffix
+  (`kinds_e2e_test.go`,
+  `list_e2e_test.go`), and
+  topic-named LSP subprocess
+  tests (`lsp_test.go`,
+  `lsp_hover_test.go`, …). The
+  demo tape harness under `demo/`
+  is also e2e.
 - Rule fixtures live in
   `internal/rules/MDS###-<rule-name>/`:
   `good/` must lint clean against
@@ -458,13 +464,16 @@ checklist can pattern-match.
   Pyramid is inverted; push the
   assertion down to a unit test in
   the function's own package.
-- **An e2e test (`e2e_*_test.go`
-  prefix or `*_e2e_test.go`
-  suffix) added where a unit test
-  would suffice.** E2E tests build
-  and run the binary; reserve them
-  for behaviour that needs the
-  full process boundary.
+- **A test that spawns the
+  `mdsmith` binary as a
+  subprocess to assert behaviour
+  reachable without it.** Pyramid
+  is inverted regardless of
+  filename — any of the three
+  e2e shapes above counts.
+  Reserve e2e for behaviour that
+  needs the full process
+  boundary.
 
 ## Refactor moves we have used
 

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -253,37 +253,47 @@ its dedicated unit test by name.
 Sub-behaviours of the same function
 go in subtests under that parent.
 The rule applies to exported and
-unexported functions alike. The
-audit flags every function in the
-touched set that lacks a matching
-test.
+unexported functions alike — in
+production code. Test files
+(`*_test.go`, `*.test.ts`) and
+test-only helpers are out of scope:
+the audit walks production sources
+only and never asks for "tests for
+tests". The audit flags every
+production function in the touched
+set that lacks a matching test.
 
 The language-specific page binds
 this rule to concrete file and
 symbol patterns. For Go, that is
-`TestFunctionName`. For TypeScript,
-that is a `describe("name")` block
-with one or more `it("case")` cases.
+`TestFunctionName` for package
+functions and `TestReceiver_Method`
+for methods. For TypeScript, that
+is a `describe("name")` block with
+one or more `test("case")` cases
+imported from `bun:test`.
 
 #### Exemptions
 
-A function may skip its dedicated
-test only if one of these holds:
+A production function may skip its
+dedicated test only if one of these
+holds:
 
 - It is generated code (file begins
   with a `// Code generated…` header,
   matches a generator file pattern
   such as `*_gen.go`, is a `*.d.ts`
   declaration, or is emitted under
-  `dist/`).
+  `dist/`). The file-level marker is
+  sufficient — no per-function
+  comment is required.
 - It is a trivial accessor with no
   branch — a one-line getter or a
   `String()`-style format method.
-
-Add a one-line comment on the
-function in either case so the audit
-can distinguish "no test by design"
-from "no test, forgotten".
+  Add a one-line comment on the
+  function so the audit can
+  distinguish "no test by design"
+  from "no test, forgotten".
 
 #### Push down by default
 
@@ -314,8 +324,15 @@ packaged-artifact tests.
 
 - **Unit tests** in `xxx_test.go`
   next to `xxx.go`. The dedicated
-  test for `func Foo` is `TestFoo`;
-  sub-behaviours go in subtests via
+  test for a package function
+  `func Foo` is `TestFoo`. For a
+  method `func (r *Receiver) Foo`,
+  the dedicated test is
+  `TestReceiver_Foo` (see e.g.
+  `internal/archetype/gensection/`
+  `engine_test.go`'s
+  `TestEngine_Check_*` family).
+  Sub-behaviours go in subtests via
   `t.Run("case", …)`.
 - **Contract tests** in this repo:
   `internal/integration/rule_boundaries_test.go`

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -350,18 +350,30 @@ packaged-artifact tests.
   `internal/integration/rule_boundaries_test.go`
   pins the rule import graph;
   `internal/integration/directive_examples_test.go`
-  pins the directive grammar. Add a
-  new contract test whenever a new
-  interface in `internal/rule/` or a
-  new external surface shape lands.
+  pins the example-folder contract
+  every directive rule must ship
+  (good/bad/fixed and pattern/
+  pairs, plus the registered rule
+  ID surfaced by the directive).
+  Add a new contract test whenever
+  a new interface in
+  `internal/rule/` or a new
+  external surface shape lands.
 - **Integration tests** live under
   `internal/integration/`. The rule
   fixture runner (`rules_test.go`)
   is the canonical example.
-- **E2E tests** are named
-  `cmd/mdsmith/e2e_*_test.go`; the
-  demo tape harness under `demo/`
-  is also e2e.
+- **E2E tests** are named with
+  either an `e2e_*_test.go` prefix
+  (e.g. `cmd/mdsmith/e2e_test.go`,
+  `e2e_backlinks_test.go`) or an
+  `*_e2e_test.go` suffix (e.g.
+  `kinds_e2e_test.go`,
+  `list_e2e_test.go`,
+  `explain_e2e_test.go`). Both
+  patterns count; the demo tape
+  harness under `demo/` is also
+  e2e.
 - Rule fixtures live in
   `internal/rules/MDS###-<rule-name>/`:
   `good/` must lint clean against
@@ -426,9 +438,13 @@ checklist can pattern-match.
 - **A `Helper`, `Util`, or `Misc` symbol
   anywhere.** The name is the problem;
   rename until it answers a question.
-- **A Go function with no
-  `TestFunctionName` symbol in a
-  sibling `_test.go`.** Test debt.
+- **A Go function with no matching
+  test symbol in a sibling
+  `*_test.go`** — `TestFoo` for a
+  package function `func Foo`,
+  `TestReceiver_Foo` (or
+  `TestReceiver_Foo_Variant`) for a
+  method on `Receiver`. Test debt.
   Severity `tax` by default,
   `blocker` if the function is on a
   public surface (a `rule.Rule`
@@ -442,11 +458,13 @@ checklist can pattern-match.
   Pyramid is inverted; push the
   assertion down to a unit test in
   the function's own package.
-- **An `e2e_*_test.go` added where
-  a unit test would suffice.** E2E
-  tests build and run the binary;
-  reserve them for behaviour that
-  needs the full process boundary.
+- **An e2e test (`e2e_*_test.go`
+  prefix or `*_e2e_test.go`
+  suffix) added where a unit test
+  would suffice.** E2E tests build
+  and run the binary; reserve them
+  for behaviour that needs the
+  full process boundary.
 
 ## Refactor moves we have used
 

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -328,12 +328,24 @@ packaged-artifact tests.
   `func Foo` is `TestFoo`. For a
   method `func (r *Receiver) Foo`,
   the dedicated test is
-  `TestReceiver_Foo` (see e.g.
+  `TestReceiver_Foo`. Sub-behaviours
+  may live as subtests via
+  `t.Run("case", …)` under that
+  parent (see
+  `internal/lint/frontmatter_test.go`'s
+  `TestParseFrontMatterFields`) or
+  as additional top-level functions
+  named `TestReceiver_Foo_Variant`
+  (see
   `internal/archetype/gensection/`
   `engine_test.go`'s
   `TestEngine_Check_*` family).
-  Sub-behaviours go in subtests via
-  `t.Run("case", …)`.
+  Either form satisfies the
+  "dedicated test by name" rule;
+  pick subtests when behaviours
+  share setup, separate top-level
+  tests when each variant stands
+  alone.
 - **Contract tests** in this repo:
   `internal/integration/rule_boundaries_test.go`
   pins the rule import graph;

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -213,24 +213,147 @@ handler in `cmd/mdsmith` longer than
 
 ## Tests
 
-- Unit tests next to the package
-  (`xxx_test.go`).
-- Cross-package tests in
-  `internal/integration/`.
+<?include
+file: tests.md
+strip-frontmatter: "true"
+heading-level: "absolute"
+?>
+### Test pyramid
+
+mdsmith follows a four-layer test
+pyramid. Each layer answers a
+different question and sits in a
+different place in the tree:
+
+- **Unit** — one function or method
+  per test. Lives next to source.
+  No file I/O beyond inline string
+  fixtures. Runs in milliseconds.
+- **Contract** — locks a port-package
+  interface or external surface
+  shape. A contract test must fail
+  loudly when the shape it pins
+  drifts.
+- **Integration** — multiple packages
+  composed together against real
+  Markdown fixtures.
+- **E2E** — the built binary (or the
+  packaged extension) against a
+  fixture workspace.
+
+The pyramid shape — many unit, fewer
+contract, fewer integration, fewest
+e2e — keeps the suite fast and the
+feedback loop tight.
+
+#### Every function has a dedicated unit test
+
+A new function lands together with
+its dedicated unit test by name.
+Sub-behaviours of the same function
+go in subtests under that parent.
+The rule applies to exported and
+unexported functions alike. The
+audit flags every function in the
+touched set that lacks a matching
+test.
+
+The language-specific page binds
+this rule to concrete file and
+symbol patterns. For Go, that is
+`TestFunctionName`. For TypeScript,
+that is a `describe("name")` block
+with one or more `it("case")` cases.
+
+#### Exemptions
+
+A function may skip its dedicated
+test only if one of these holds:
+
+- It is generated code (file begins
+  with a `// Code generated…` header,
+  matches a generator file pattern
+  such as `*_gen.go`, is a `*.d.ts`
+  declaration, or is emitted under
+  `dist/`).
+- It is a trivial accessor with no
+  branch — a one-line getter or a
+  `String()`-style format method.
+
+Add a one-line comment on the
+function in either case so the audit
+can distinguish "no test by design"
+from "no test, forgotten".
+
+#### Push down by default
+
+A unit test on the same behaviour
+is faster than the equivalent
+integration test. It stays focused
+on one function. It also survives
+refactors better. The audit pushes
+back on inverted pyramids:
+
+- An integration test that exercises
+  one function should move down to
+  that function's own package as a
+  unit test.
+- An e2e test that exercises
+  behaviour reachable through the
+  integration layer should move down
+  to integration.
+
+Save e2e for the full process
+boundary. Use it for exit codes.
+Use it for signals. Use it for
+subprocess lifecycle. Use it for
+packaged-artifact tests.
+<?/include?>
+
+### Go-specific bindings
+
+- **Unit tests** in `xxx_test.go`
+  next to `xxx.go`. The dedicated
+  test for `func Foo` is `TestFoo`;
+  sub-behaviours go in subtests via
+  `t.Run("case", …)`.
+- **Contract tests** in this repo:
+  `internal/integration/rule_boundaries_test.go`
+  pins the rule import graph;
+  `internal/integration/directive_examples_test.go`
+  pins the directive grammar. Add a
+  new contract test whenever a new
+  interface in `internal/rule/` or a
+  new external surface shape lands.
+- **Integration tests** live under
+  `internal/integration/`. The rule
+  fixture runner (`rules_test.go`)
+  is the canonical example.
+- **E2E tests** are named
+  `cmd/mdsmith/e2e_*_test.go`; the
+  demo tape harness under `demo/`
+  is also e2e.
 - Rule fixtures live in
   `internal/rules/MDS###-<rule-name>/`:
-  `good/` must lint clean against every
-  default-enabled rule, `bad/` is
-  excluded via `.mdsmith.yml`.
+  `good/` must lint clean against
+  every default-enabled rule, `bad/`
+  is excluded via `.mdsmith.yml`.
 - Use `testify/require` for
   preconditions that abort the test;
   `testify/assert` for soft checks.
 - Use `Same`/`NotSame` for pointer
   identity.
-- Don't mock at the `rule.Rule` boundary
-  — feed real Markdown via fixtures. A
-  mock there is the smell of a too-wide
-  contract.
+- Don't mock at the `rule.Rule`
+  boundary — feed real Markdown via
+  fixtures. A mock there is the
+  smell of a too-wide contract.
+
+Severity for missing unit tests:
+`tax` by default. Promote to
+`blocker` if the function sits on
+a public surface — a `rule.Rule`
+method, an LSP capability handler,
+or a CLI subcommand entry.
 
 ## Common violations to flag
 
@@ -274,6 +397,27 @@ checklist can pattern-match.
 - **A `Helper`, `Util`, or `Misc` symbol
   anywhere.** The name is the problem;
   rename until it answers a question.
+- **A Go function with no
+  `TestFunctionName` symbol in a
+  sibling `_test.go`.** Test debt.
+  Severity `tax` by default,
+  `blocker` if the function is on a
+  public surface (a `rule.Rule`
+  method, an LSP capability handler,
+  a CLI subcommand entry). Generated
+  files and trivial getters are
+  exempt; see §"Tests / Exemptions".
+- **A test under
+  `internal/integration/` that
+  exercises a single function.**
+  Pyramid is inverted; push the
+  assertion down to a unit test in
+  the function's own package.
+- **An `e2e_*_test.go` added where
+  a unit test would suffice.** E2E
+  tests build and run the binary;
+  reserve them for behaviour that
+  needs the full process boundary.
 
 ## Refactor moves we have used
 

--- a/docs/development/architecture/index.md
+++ b/docs/development/architecture/index.md
@@ -127,6 +127,18 @@ at the very edge. They are public APIs
 under stricter compatibility rules. See
 [cross-system contracts](cross-system.md).
 
+## Test pyramid
+
+Tests are part of the architecture.
+mdsmith follows a four-layer pyramid
+(unit, contract, integration, e2e)
+and every function — exported and
+unexported — ships with a dedicated
+unit test. The canonical home is
+[Test pyramid](tests.md); the
+language pages bind the rule to
+concrete file and symbol patterns.
+
 ## Anti-patterns we have actually hit
 
 These are the patterns mdsmith audits have
@@ -172,6 +184,21 @@ caught and the reasons we reject them:
   one rule** — move it to `internal/rule`
   or `internal/mdtext`. Engine grows
   unbounded otherwise.
+- **A new function landing without a
+  dedicated unit test.** Either the
+  function is too coupled to test in
+  isolation (push it down to a port
+  package so it can be tested) or the
+  test was forgotten (write it). The
+  audit flags uncovered functions as
+  test debt.
+- **An e2e test added where a unit
+  test would do the same work.** E2E
+  tests run the built binary; they
+  are far slower than unit tests.
+  Reserve them for full-binary
+  behaviour the unit layer cannot
+  reach.
 
 ## Sub-pages
 
@@ -185,12 +212,13 @@ header: |
   |------|-------------|
 row: "| [{title}]({filename}) | {summary} |"
 ?>
-| Page                                               | Description                                                                                                                                    |
-|----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Architecture audit checklist](audit-checklist.md) | Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files. |
-| [Cross-system contracts](cross-system.md)          | External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.                       |
-| [Go architecture patterns](go.md)                  | Go-specific SOLID and clean architecture patterns for mdsmith's cmd/ and internal/ packages.                                                   |
-| [TypeScript architecture patterns](typescript.md)  | SOLID and clean architecture patterns for the mdsmith VS Code extension at editors/vscode/.                                                    |
+| Page                                               | Description                                                                                                                                                                           |
+|----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Architecture audit checklist](audit-checklist.md) | Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.                                        |
+| [Cross-system contracts](cross-system.md)          | External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.                                                              |
+| [Go architecture patterns](go.md)                  | Go-specific SOLID and clean architecture patterns for mdsmith's cmd/ and internal/ packages.                                                                                          |
+| [Test pyramid](tests.md)                           | Four-layer test pyramid (unit, contract, integration, e2e) and the rule that every function ships with a dedicated unit test. Included from the Go and TypeScript architecture pages. |
+| [TypeScript architecture patterns](typescript.md)  | SOLID and clean architecture patterns for the mdsmith VS Code extension at editors/vscode/.                                                                                           |
 <?/catalog?>
 
 ## When to consult this hub

--- a/docs/development/architecture/tests.md
+++ b/docs/development/architecture/tests.md
@@ -44,37 +44,47 @@ its dedicated unit test by name.
 Sub-behaviours of the same function
 go in subtests under that parent.
 The rule applies to exported and
-unexported functions alike. The
-audit flags every function in the
-touched set that lacks a matching
-test.
+unexported functions alike — in
+production code. Test files
+(`*_test.go`, `*.test.ts`) and
+test-only helpers are out of scope:
+the audit walks production sources
+only and never asks for "tests for
+tests". The audit flags every
+production function in the touched
+set that lacks a matching test.
 
 The language-specific page binds
 this rule to concrete file and
 symbol patterns. For Go, that is
-`TestFunctionName`. For TypeScript,
-that is a `describe("name")` block
-with one or more `it("case")` cases.
+`TestFunctionName` for package
+functions and `TestReceiver_Method`
+for methods. For TypeScript, that
+is a `describe("name")` block with
+one or more `test("case")` cases
+imported from `bun:test`.
 
 ## Exemptions
 
-A function may skip its dedicated
-test only if one of these holds:
+A production function may skip its
+dedicated test only if one of these
+holds:
 
 - It is generated code (file begins
   with a `// Code generated…` header,
   matches a generator file pattern
   such as `*_gen.go`, is a `*.d.ts`
   declaration, or is emitted under
-  `dist/`).
+  `dist/`). The file-level marker is
+  sufficient — no per-function
+  comment is required.
 - It is a trivial accessor with no
   branch — a one-line getter or a
   `String()`-style format method.
-
-Add a one-line comment on the
-function in either case so the audit
-can distinguish "no test by design"
-from "no test, forgotten".
+  Add a one-line comment on the
+  function so the audit can
+  distinguish "no test by design"
+  from "no test, forgotten".
 
 ## Push down by default
 

--- a/docs/development/architecture/tests.md
+++ b/docs/development/architecture/tests.md
@@ -1,0 +1,101 @@
+---
+title: Test pyramid
+slug: tests
+summary: >-
+  Four-layer test pyramid (unit,
+  contract, integration, e2e) and the
+  rule that every function ships with
+  a dedicated unit test. Included from
+  the Go and TypeScript architecture
+  pages.
+---
+# Test pyramid
+
+mdsmith follows a four-layer test
+pyramid. Each layer answers a
+different question and sits in a
+different place in the tree:
+
+- **Unit** — one function or method
+  per test. Lives next to source.
+  No file I/O beyond inline string
+  fixtures. Runs in milliseconds.
+- **Contract** — locks a port-package
+  interface or external surface
+  shape. A contract test must fail
+  loudly when the shape it pins
+  drifts.
+- **Integration** — multiple packages
+  composed together against real
+  Markdown fixtures.
+- **E2E** — the built binary (or the
+  packaged extension) against a
+  fixture workspace.
+
+The pyramid shape — many unit, fewer
+contract, fewer integration, fewest
+e2e — keeps the suite fast and the
+feedback loop tight.
+
+## Every function has a dedicated unit test
+
+A new function lands together with
+its dedicated unit test by name.
+Sub-behaviours of the same function
+go in subtests under that parent.
+The rule applies to exported and
+unexported functions alike. The
+audit flags every function in the
+touched set that lacks a matching
+test.
+
+The language-specific page binds
+this rule to concrete file and
+symbol patterns. For Go, that is
+`TestFunctionName`. For TypeScript,
+that is a `describe("name")` block
+with one or more `it("case")` cases.
+
+## Exemptions
+
+A function may skip its dedicated
+test only if one of these holds:
+
+- It is generated code (file begins
+  with a `// Code generated…` header,
+  matches a generator file pattern
+  such as `*_gen.go`, is a `*.d.ts`
+  declaration, or is emitted under
+  `dist/`).
+- It is a trivial accessor with no
+  branch — a one-line getter or a
+  `String()`-style format method.
+
+Add a one-line comment on the
+function in either case so the audit
+can distinguish "no test by design"
+from "no test, forgotten".
+
+## Push down by default
+
+A unit test on the same behaviour
+is faster than the equivalent
+integration test. It stays focused
+on one function. It also survives
+refactors better. The audit pushes
+back on inverted pyramids:
+
+- An integration test that exercises
+  one function should move down to
+  that function's own package as a
+  unit test.
+- An e2e test that exercises
+  behaviour reachable through the
+  integration layer should move down
+  to integration.
+
+Save e2e for the full process
+boundary. Use it for exit codes.
+Use it for signals. Use it for
+subprocess lifecycle. Use it for
+packaged-artifact tests.

--- a/docs/development/architecture/typescript.md
+++ b/docs/development/architecture/typescript.md
@@ -223,37 +223,47 @@ its dedicated unit test by name.
 Sub-behaviours of the same function
 go in subtests under that parent.
 The rule applies to exported and
-unexported functions alike. The
-audit flags every function in the
-touched set that lacks a matching
-test.
+unexported functions alike — in
+production code. Test files
+(`*_test.go`, `*.test.ts`) and
+test-only helpers are out of scope:
+the audit walks production sources
+only and never asks for "tests for
+tests". The audit flags every
+production function in the touched
+set that lacks a matching test.
 
 The language-specific page binds
 this rule to concrete file and
 symbol patterns. For Go, that is
-`TestFunctionName`. For TypeScript,
-that is a `describe("name")` block
-with one or more `it("case")` cases.
+`TestFunctionName` for package
+functions and `TestReceiver_Method`
+for methods. For TypeScript, that
+is a `describe("name")` block with
+one or more `test("case")` cases
+imported from `bun:test`.
 
 #### Exemptions
 
-A function may skip its dedicated
-test only if one of these holds:
+A production function may skip its
+dedicated test only if one of these
+holds:
 
 - It is generated code (file begins
   with a `// Code generated…` header,
   matches a generator file pattern
   such as `*_gen.go`, is a `*.d.ts`
   declaration, or is emitted under
-  `dist/`).
+  `dist/`). The file-level marker is
+  sufficient — no per-function
+  comment is required.
 - It is a trivial accessor with no
   branch — a one-line getter or a
   `String()`-style format method.
-
-Add a one-line comment on the
-function in either case so the audit
-can distinguish "no test by design"
-from "no test, forgotten".
+  Add a one-line comment on the
+  function so the audit can
+  distinguish "no test by design"
+  from "no test, forgotten".
 
 #### Push down by default
 
@@ -283,11 +293,13 @@ packaged-artifact tests.
 ### TypeScript-specific bindings
 
 - **Unit tests** in `xxx.test.ts`
-  next to `xxx.ts`. The dedicated
+  next to `xxx.ts`, importing
+  `describe`, `test`, and `expect`
+  from `bun:test`. The dedicated
   test for `function foo` (or a
   method `foo`) is a
   `describe("foo", () => { … })`
-  block; one or more `it("case",
+  block; one or more `test("case",
   …)` cases enumerate behaviours.
   Extract pure functions out of
   command bodies and unit-test
@@ -340,6 +352,33 @@ or a binary-boundary parser.
 These are the mdsmith-specific shapes
 the audit flags:
 
+- **A TypeScript function with no
+  matching `describe("name", () =>
+  { test(…) })` block in a sibling
+  `*.test.ts`.** Test debt.
+  Severity `tax` by default,
+  `blocker` if the function is on a
+  public surface (an exported
+  command registration, a
+  `contributes`-backed entry point,
+  a binary-boundary parser).
+  Test files and test-only helpers
+  are out of scope; see §"Tests /
+  Exemptions".
+- **A `*.test.ts` under
+  `editors/vscode/test-fixtures/`
+  or an integration-style test that
+  drives a single pure function.**
+  Pyramid is inverted; extract the
+  function and push the assertion
+  down to a unit test next to it.
+- **A VS Code extension-host e2e
+  test added where a unit test on
+  an extracted pure function would
+  suffice.** E2E is for activation,
+  command palette wiring, and
+  `onSave` lifecycle — not for
+  logic reachable by direct call.
 - **A command that imports another
   command.** Share state through
   `wiring.ts` instead.

--- a/docs/development/architecture/typescript.md
+++ b/docs/development/architecture/typescript.md
@@ -183,25 +183,157 @@ violations list flags new additions to
 
 ## Tests
 
-- Pure unit tests for each module
-  using the project's configured test
-  runner (see
-  `editors/vscode/package.json` →
-  `scripts.test`).
-- Extract pure functions out of
-  command bodies and unit-test those
-  instead of mocking `vscode`. Mock
-  the `vscode` API only when
-  unavoidable.
-- For the binary boundary, prefer
-  running the real binary against a
-  fixture workspace over mocking
-  subprocess calls.
+<?include
+file: tests.md
+strip-frontmatter: "true"
+heading-level: "absolute"
+?>
+### Test pyramid
+
+mdsmith follows a four-layer test
+pyramid. Each layer answers a
+different question and sits in a
+different place in the tree:
+
+- **Unit** — one function or method
+  per test. Lives next to source.
+  No file I/O beyond inline string
+  fixtures. Runs in milliseconds.
+- **Contract** — locks a port-package
+  interface or external surface
+  shape. A contract test must fail
+  loudly when the shape it pins
+  drifts.
+- **Integration** — multiple packages
+  composed together against real
+  Markdown fixtures.
+- **E2E** — the built binary (or the
+  packaged extension) against a
+  fixture workspace.
+
+The pyramid shape — many unit, fewer
+contract, fewer integration, fewest
+e2e — keeps the suite fast and the
+feedback loop tight.
+
+#### Every function has a dedicated unit test
+
+A new function lands together with
+its dedicated unit test by name.
+Sub-behaviours of the same function
+go in subtests under that parent.
+The rule applies to exported and
+unexported functions alike. The
+audit flags every function in the
+touched set that lacks a matching
+test.
+
+The language-specific page binds
+this rule to concrete file and
+symbol patterns. For Go, that is
+`TestFunctionName`. For TypeScript,
+that is a `describe("name")` block
+with one or more `it("case")` cases.
+
+#### Exemptions
+
+A function may skip its dedicated
+test only if one of these holds:
+
+- It is generated code (file begins
+  with a `// Code generated…` header,
+  matches a generator file pattern
+  such as `*_gen.go`, is a `*.d.ts`
+  declaration, or is emitted under
+  `dist/`).
+- It is a trivial accessor with no
+  branch — a one-line getter or a
+  `String()`-style format method.
+
+Add a one-line comment on the
+function in either case so the audit
+can distinguish "no test by design"
+from "no test, forgotten".
+
+#### Push down by default
+
+A unit test on the same behaviour
+is faster than the equivalent
+integration test. It stays focused
+on one function. It also survives
+refactors better. The audit pushes
+back on inverted pyramids:
+
+- An integration test that exercises
+  one function should move down to
+  that function's own package as a
+  unit test.
+- An e2e test that exercises
+  behaviour reachable through the
+  integration layer should move down
+  to integration.
+
+Save e2e for the full process
+boundary. Use it for exit codes.
+Use it for signals. Use it for
+subprocess lifecycle. Use it for
+packaged-artifact tests.
+<?/include?>
+
+### TypeScript-specific bindings
+
+- **Unit tests** in `xxx.test.ts`
+  next to `xxx.ts`. The dedicated
+  test for `function foo` (or a
+  method `foo`) is a
+  `describe("foo", () => { … })`
+  block; one or more `it("case",
+  …)` cases enumerate behaviours.
+  Extract pure functions out of
+  command bodies and unit-test
+  those instead of mocking
+  `vscode`.
+- **Contract tests** pin the shape
+  of the binary boundary — the JSON
+  envelopes parsed in
+  `commands/runner.ts` — the
+  `contributes` section of
+  `package.json`, and the LSP
+  capability set the extension opts
+  into. They live next to the
+  module that owns the contract.
+- **Integration tests** drive the
+  real `mdsmith` binary against
+  fixture workspaces rather than
+  mocking subprocess calls. They
+  live next to the command module
+  they exercise.
+- **E2E tests** spin up the VS Code
+  extension host against a fixture
+  workspace. Reserve them for
+  behaviour that cannot be checked
+  at the lower layers (activation
+  order, command palette wiring,
+  `onSave` handlers).
+- Mock the `vscode` API only when
+  unavoidable. If a function is
+  hard to test without `vscode`,
+  the function probably contains
+  pure logic that should be
+  extracted.
 - Place test fixtures under
-  `editors/vscode/test-fixtures/` or
-  alongside the test that uses them.
-  Do not import fixture data across
-  command modules.
+  `editors/vscode/test-fixtures/`
+  or alongside the test that uses
+  them. Do not import fixture data
+  across command modules.
+
+Severity for missing unit tests:
+`tax` by default. Promote to
+`blocker` if the function sits on
+a public surface — an exported
+command registration, a
+`contributes`-backed entry point,
+or a binary-boundary parser.
 
 ## Common violations to flag
 


### PR DESCRIPTION
## Summary

Consolidates the test pyramid and unit-test coverage rules into a shared documentation page (`docs/development/architecture/tests.md`) that is included in both the Go and TypeScript architecture pages. This eliminates duplication while making the canonical test guidance more discoverable and maintainable.

## Key changes

- **New shared page**: Created `docs/development/architecture/tests.md` containing the four-layer test pyramid (unit, contract, integration, e2e), the rule that every function ships with a dedicated unit test, exemptions for generated code and trivial accessors, and guidance to push tests down by default.

- **Updated Go architecture page** (`docs/development/architecture/go.md`):
  - Replaced inline test guidance with an include directive pointing to `tests.md`
  - Added Go-specific bindings section that maps the pyramid layers to concrete file patterns (`xxx_test.go`, `internal/integration/`, `cmd/mdsmith/e2e_*_test.go`)
  - Expanded "Common violations to flag" section with specific checks for missing unit tests and inverted pyramids

- **Updated TypeScript architecture page** (`docs/development/architecture/typescript.md`):
  - Replaced inline test guidance with an include directive pointing to `tests.md`
  - Added TypeScript-specific bindings section that maps the pyramid layers to concrete file patterns (`xxx.test.ts`, contract tests, integration tests, E2E tests)
  - Expanded "Common violations to flag" section with specific checks for missing unit tests and inverted pyramids

- **Updated audit checklist** (`docs/development/architecture/audit-checklist.md`):
  - Added "Test audit bindings" section documenting how the audit checks test coverage
  - Expanded "mdsmith-specific checks worth flagging" with test-related violations

- **Updated architecture index** (`docs/development/architecture/index.md`):
  - Added "Test pyramid" section linking to the new shared page
  - Added anti-patterns for missing unit tests and misplaced e2e tests

- **Updated audit skill documentation** (`.claude/skills/solid-architecture/`):
  - Added test pyramid sub-walk procedure to the audit checklist
  - Updated language-page walk instructions to include the Tests section

- **Updated mdsmith config** (`.mdsmith.yml`):
  - Added `max-file-length: 500` rule to the new `tests.md` file kind to keep it focused

- **Updated reference catalogs** (AGENTS.md, CLAUDE.md, copilot-instructions.md):
  - Added entries for the new tests.md page

## Implementation details

The shared `tests.md` page uses frontmatter metadata (`slug: tests`) to enable inclusion via the `<?include?>` directive with `strip-frontmatter: "true"` and `heading-level: "absolute"` options. This allows the same content to be included in multiple architecture pages while maintaining proper heading hierarchy and avoiding duplicate frontmatter.

The language-specific pages now follow a consistent structure: include the shared pyramid guidance, then add language-specific file-pattern bindings and severity rules for violations.

https://claude.ai/code/session_01NQsgBNszQ13SJCnkZuxFEV