### PR TITLE
Add `mdsmith export` command for portable Markdown output

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,6 +80,7 @@ row: "- [{summary}](../{filename})"
 - [CLI commands, flags, exit codes, and output format.](../docs/reference/cli.md)
 - [List workspace links that point at a file.](../docs/reference/cli/backlinks.md)
 - [Lint Markdown files for style issues.](../docs/reference/cli/check.md)
+- [Write a portable, directive-free copy of a Markdown file.](../docs/reference/cli/export.md)
 - [Auto-fix lint issues in Markdown files in place.](../docs/reference/cli/fix.md)
 - [Show built-in documentation for rules, metrics, and concept pages.](../docs/reference/cli/help.md)
 - [Generate a default `.mdsmith.yml` config in the current directory.](../docs/reference/cli/init.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ row: "- [{summary}]({filename})"
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)
 - [List workspace links that point at a file.](docs/reference/cli/backlinks.md)
 - [Lint Markdown files for style issues.](docs/reference/cli/check.md)
+- [Write a portable, directive-free copy of a Markdown file.](docs/reference/cli/export.md)
 - [Auto-fix lint issues in Markdown files in place.](docs/reference/cli/fix.md)
 - [Show built-in documentation for rules, metrics, and concept pages.](docs/reference/cli/help.md)
 - [Generate a default `.mdsmith.yml` config in the current directory.](docs/reference/cli/init.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ row: "- [{summary}]({filename})"
 - [CLI commands, flags, exit codes, and output format.](docs/reference/cli.md)
 - [List workspace links that point at a file.](docs/reference/cli/backlinks.md)
 - [Lint Markdown files for style issues.](docs/reference/cli/check.md)
+- [Write a portable, directive-free copy of a Markdown file.](docs/reference/cli/export.md)
 - [Auto-fix lint issues in Markdown files in place.](docs/reference/cli/fix.md)
 - [Show built-in documentation for rules, metrics, and concept pages.](docs/reference/cli/help.md)
 - [Generate a default `.mdsmith.yml` config in the current directory.](docs/reference/cli/init.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -91,7 +91,7 @@ footer: |
 | 162 | ✅     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                            |
 | 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                      |
 | 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)               |
-| 165 | 🔳     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                         |
+| 165 | ✅     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                         |
 | 166 | 🔲     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                              |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
 | 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |

--- a/PLAN.md
+++ b/PLAN.md
@@ -91,7 +91,7 @@ footer: |
 | 162 | ✅     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                            |
 | 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                      |
 | 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)               |
-| 165 | 🔲     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                         |
+| 165 | 🔳     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                         |
 | 166 | 🔲     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                              |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
 | 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 | Command                                                      | Description                                                                          |
 |--------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | [`check`](docs/reference/cli/check.md)                       | Lint Markdown files for style issues.                                                |
+| [`export`](docs/reference/cli/export.md)                     | Write a portable, directive-free copy of a Markdown file.                            |
 | [`fix`](docs/reference/cli/fix.md)                           | Auto-fix lint issues in Markdown files in place.                                     |
 | [`help`](docs/reference/cli/help.md)                         | Show built-in documentation for rules, metrics, and concept pages.                   |
 | [`init`](docs/reference/cli/init.md)                         | Generate a default `.mdsmith.yml` config in the current directory.                   |

--- a/cmd/mdsmith/e2e_export_test.go
+++ b/cmd/mdsmith/e2e_export_test.go
@@ -1,0 +1,263 @@
+package main_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// freshTOCFile is a Markdown source whose TOC body matches what the
+// engine would generate, so default-mode export accepts it.
+const freshTOCFile = `# Title
+
+<?toc?>
+
+- [Section](#section)
+
+<?/toc?>
+
+## Section
+
+Body content.
+`
+
+// staleTOCFile points to a heading that doesn't exist; default-mode
+// export must refuse and Fix mode must regenerate.
+const staleTOCFile = `# Title
+
+<?toc?>
+
+- [Wrong](#wrong)
+
+<?/toc?>
+
+## Section
+
+Body content.
+`
+
+func TestE2E_Export_DefaultMode_Fresh(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", freshTOCFile)
+
+	stdout, stderr, code := runBinary(t, "", "export", path)
+	require.Equal(t, 0, code, "expected exit 0, got %d (stderr=%s)", code, stderr)
+	assert.NotContains(t, stdout, "<?toc")
+	assert.NotContains(t, stdout, "<?/toc")
+	assert.Contains(t, stdout, "- [Section](#section)")
+	assert.Contains(t, stdout, "## Section")
+}
+
+func TestE2E_Export_DefaultMode_StaleBody_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", staleTOCFile)
+
+	stdout, stderr, code := runBinary(t, "", "export", path)
+	assert.Equal(t, 1, code, "expected exit 1, got %d", code)
+	assert.Empty(t, stdout, "stale body must emit no output")
+	assert.Contains(t, stderr, "out of date",
+		"diagnostic should describe the stale body, got: %s", stderr)
+	assert.Contains(t, stderr, "MDS038",
+		"diagnostic should name the toc rule, got: %s", stderr)
+
+	// Source file must not be modified.
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, staleTOCFile, string(bytes),
+		"source file must be unchanged after a refused export")
+}
+
+func TestE2E_Export_FixMode_RegeneratesStaleBody(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", staleTOCFile)
+
+	stdout, stderr, code := runBinary(t, "", "export", "--fix", path)
+	require.Equal(t, 0, code, "expected exit 0, got %d (stderr=%s)", code, stderr)
+	assert.NotContains(t, stdout, "<?toc")
+	// Regenerated body links to the real heading.
+	assert.Contains(t, stdout, "- [Section](#section)")
+	assert.NotContains(t, stdout, "Wrong")
+
+	// Source file is still the stale original — fix mode is in-memory.
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, staleTOCFile, string(bytes),
+		"source file must be unchanged in --fix mode")
+}
+
+func TestE2E_Export_NoCheckMode_StaleBody_ExportsAsIs(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", staleTOCFile)
+
+	stdout, stderr, code := runBinary(t, "", "export", "--no-check", path)
+	require.Equal(t, 0, code, "expected exit 0, got %d (stderr=%s)", code, stderr)
+	assert.NotContains(t, stdout, "<?toc")
+	// On-disk body kept verbatim, even though it's stale.
+	assert.Contains(t, stdout, "- [Wrong](#wrong)")
+}
+
+func TestE2E_Export_FixAndNoCheck_Conflict(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", freshTOCFile)
+
+	_, stderr, code := runBinary(t, "", "export", "--fix", "--no-check", path)
+	assert.Equal(t, 2, code, "passing both flags should exit 2")
+	assert.Contains(t, stderr, "mutually exclusive")
+}
+
+func TestE2E_Export_OutputFlag_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	src := writeFixture(t, dir, "doc.md", freshTOCFile)
+	dst := filepath.Join(dir, "out.md")
+
+	stdout, stderr, code := runBinary(t, "", "export", "-o", dst, src)
+	require.Equal(t, 0, code, "expected exit 0, got %d (stderr=%s)", code, stderr)
+	assert.Empty(t, stdout, "stdout should be empty when -o is given")
+
+	written, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.NotContains(t, string(written), "<?toc")
+	assert.Contains(t, string(written), "- [Section](#section)")
+}
+
+func TestE2E_Export_NoArgs_ExitsTwo(t *testing.T) {
+	_, stderr, code := runBinary(t, "", "export")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "requires a file argument")
+}
+
+func TestE2E_Export_MultipleArgs_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	a := writeFixture(t, dir, "a.md", freshTOCFile)
+	b := writeFixture(t, dir, "b.md", freshTOCFile)
+
+	_, stderr, code := runBinary(t, "", "export", a, b)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "single file argument")
+}
+
+func TestE2E_Export_MissingFile_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	_, stderr, code := runBinary(t, "", "export", filepath.Join(dir, "nope.md"))
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "no such file")
+}
+
+func TestE2E_Export_NoDirectiveFile_Noop(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	src := "# Title\n\nNo directives here at all.\n"
+	path := writeFixture(t, dir, "doc.md", src)
+
+	stdout, _, code := runBinary(t, "", "export", path)
+	require.Equal(t, 0, code)
+	assert.Equal(t, src, stdout)
+}
+
+func TestE2E_Export_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", freshTOCFile)
+
+	first, _, code := runBinary(t, "", "export", path)
+	require.Equal(t, 0, code)
+
+	// Save the first output and export it again.
+	roundTrip := writeFixture(t, dir, "round.md", first)
+	second, _, code := runBinary(t, "", "export", roundTrip)
+	require.Equal(t, 0, code)
+
+	assert.Equal(t, first, second,
+		"export should be idempotent: exporting an exported file is a no-op")
+}
+
+func TestE2E_Export_FreshOutputPassesCheck(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	path := writeFixture(t, dir, "doc.md", staleTOCFile)
+
+	out, stderr, code := runBinary(t, "", "export", "--fix", path)
+	require.Equal(t, 0, code, "export --fix should succeed: %s", stderr)
+	exported := writeFixture(t, dir, "exported.md", out)
+
+	// The exported file should pass `mdsmith check`.
+	_, stderr, code = runBinary(t, "", "check", exported)
+	require.Equal(t, 0, code,
+		"exported file should pass `mdsmith check`, but got exit %d: %s",
+		code, stderr)
+
+	// And exporting it again should be a clean no-op.
+	out2, _, code := runBinary(t, "", "export", exported)
+	require.Equal(t, 0, code)
+	assert.Equal(t, out, out2,
+		"idempotence: a second export should produce identical bytes")
+}
+
+func TestE2E_Export_IncludeDirective_BodyInlined(t *testing.T) {
+	// Include resolution joins path.Dir(filePath) with the directive's
+	// `file:` value; with RootFS set, the joined path is consulted on
+	// the project-root DirFS, so the run has to happen with the file's
+	// directory as CWD (and as the config root) for "snippet.md" to
+	// resolve.
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "snippet.md", "snippet body line one\nsnippet body line two\n")
+	src := `# Title
+
+<?include
+file: snippet.md
+?>
+snippet body line one
+snippet body line two
+<?/include?>
+
+After.
+`
+	writeFixture(t, dir, "doc.md", src)
+
+	stdout, stderr, code := runBinaryInDir(t, dir, "", "export", "doc.md")
+	require.Equal(t, 0, code, "expected exit 0, got %d (stderr=%s)", code, stderr)
+	assert.NotContains(t, stdout, "<?include")
+	assert.NotContains(t, stdout, "<?/include")
+	assert.Contains(t, stdout, "snippet body line one")
+	assert.Contains(t, stdout, "snippet body line two")
+	assert.Contains(t, stdout, "After.")
+}
+
+func TestE2E_Export_MarkerlessRequire_RemovedFromFrontmatterDoc(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	src := `---
+id: 1
+title: Plan
+---
+<?require
+filename: "[0-9]*.md"
+?>
+
+# Plan
+
+Body.
+`
+	path := writeFixture(t, dir, "doc.md", src)
+	stdout, stderr, code := runBinary(t, "", "export", path)
+	require.Equal(t, 0, code, "expected exit 0, got %d (stderr=%s)", code, stderr)
+	assert.NotContains(t, stdout, "<?require")
+	// Front matter is preserved.
+	assert.True(t, strings.HasPrefix(stdout, "---\nid: 1\ntitle: Plan\n---\n"),
+		"front matter should be preserved verbatim, got: %q", stdout)
+	assert.Contains(t, stdout, "# Plan")
+	assert.Contains(t, stdout, "Body.")
+}

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/jeduden/mdsmith/internal/export"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+type exportFlags struct {
+	configPath, output, maxInputSize string
+	fixStale, noCheck                bool
+}
+
+// runExport implements the "export" subcommand: write a portable,
+// directive-free copy of a Markdown file. Markers are stripped,
+// generated bodies are kept, and `<?include?>` content is inlined.
+//
+// The source file is never modified. By default, a stale directive
+// body refuses the export with an error. `--fix` regenerates stale
+// bodies in memory before stripping; `--no-check` skips the check
+// and emits on-disk bytes verbatim; passing both is a usage error.
+func runExport(args []string) int {
+	flags, posArgs, code := parseExportFlags(args)
+	if code >= 0 {
+		return code
+	}
+	if flags.fixStale && flags.noCheck {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: export: --fix and --no-check are mutually exclusive\n")
+		return 2
+	}
+	if len(posArgs) == 0 {
+		fmt.Fprintf(os.Stderr, "mdsmith: export requires a file argument\n")
+		return 2
+	}
+	if len(posArgs) > 1 {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: export takes a single file argument (got %d)\n", len(posArgs))
+		return 2
+	}
+	return doExport(posArgs[0], flags)
+}
+
+// parseExportFlags binds the flagset and parses args. Returns
+// (flags, positional, code) — when code is non-negative the caller
+// should return it directly.
+func parseExportFlags(args []string) (exportFlags, []string, int) {
+	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+	var flags exportFlags
+	fs.StringVarP(&flags.configPath, "config", "c", "", "Override config file path")
+	fs.StringVarP(&flags.output, "output", "o", "",
+		"Write output to <path> instead of stdout")
+	fs.StringVar(&flags.maxInputSize, "max-input-size", "",
+		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
+	fs.BoolVar(&flags.fixStale, "fix", false,
+		"Regenerate stale directive bodies in memory before stripping")
+	fs.BoolVar(&flags.noCheck, "no-check", false,
+		"Skip the staleness check; export on-disk bytes as-is")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			"Usage: mdsmith export [flags] <file>\n\n"+
+				"Write a portable, directive-free copy of a Markdown file.\n"+
+				"Generated section markers are removed; bodies are kept "+
+				"and `<?include?>` content is inlined.\n\n"+
+				"The source file is never modified.\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: export"); code >= 0 {
+			return flags, nil, code
+		}
+	}
+	return flags, fs.Args(), -1
+}
+
+// doExport loads the file, hydrates a *lint.File, runs export.Export,
+// and writes the result.
+func doExport(path string, flags exportFlags) int {
+	cfg, cfgPath, err := loadConfig(flags.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	maxBytes, err := resolveMaxInputBytes(cfg, flags.maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
+	data, err := lint.ReadFileLimited(path, maxBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	f, err := lint.NewFileFromSource(path, data, frontMatterEnabled(cfg))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: parsing %s: %v\n", path, err)
+		return 2
+	}
+	f.MaxInputBytes = maxBytes
+	f.FS = os.DirFS(filepath.Dir(path))
+	if root := rootDirFromConfig(cfgPath); root != "" {
+		f.SetRootDir(root)
+	}
+
+	out, diags := export.Export(f, exportMode(flags))
+	if len(diags) > 0 {
+		if code := formatDiagnostics(diags, "text", false); code != 0 {
+			return code
+		}
+		return 1
+	}
+	if err := writeExportOutput(flags.output, out); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+	return 0
+}
+
+// exportMode maps the parsed CLI flags onto the staleness mode the
+// export package understands.
+func exportMode(flags exportFlags) export.Mode {
+	switch {
+	case flags.fixStale:
+		return export.Fix
+	case flags.noCheck:
+		return export.NoCheck
+	default:
+		return export.Check
+	}
+}
+
+// writeExportOutput writes data to a file at path, or to stdout when
+// path is empty.
+func writeExportOutput(path string, data []byte) error {
+	if path == "" {
+		if _, err := os.Stdout.Write(data); err != nil {
+			return fmt.Errorf("writing output: %w", err)
+		}
+		return nil
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -8,8 +8,11 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/engine"
 	"github.com/jeduden/mdsmith/internal/export"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
 )
 
 type exportFlags struct {
@@ -100,22 +103,14 @@ func doExport(path string, flags exportFlags) int {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
-	f, err := lint.NewFileFromSource(path, data, frontMatterEnabled(cfg))
+
+	f, rules, err := prepareExportFile(path, data, cfg, cfgPath, maxBytes)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: parsing %s: %v\n", path, err)
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
-	f.MaxInputBytes = maxBytes
-	f.FS = os.DirFS(filepath.Dir(path))
-	if root := rootDirFromConfig(cfgPath); root != "" {
-		f.SetRootDir(root)
-	}
-	// Match the engine.Runner setup so staleness diagnostics
-	// inside an outer include/catalog body are suppressed: the
-	// host file is not responsible for those bytes.
-	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
 
-	out, diags := export.Export(f, exportMode(flags))
+	out, diags := export.Export(f, exportMode(flags), rules)
 	if len(diags) > 0 {
 		if code := formatDiagnostics(diags, "text", false); code != 0 {
 			return code
@@ -127,6 +122,119 @@ func doExport(path string, flags exportFlags) int {
 		return 2
 	}
 	return 0
+}
+
+// prepareExportFile mirrors fix.Fixer.prepareFile + fixableRules: it
+// parses the file, wires FS / RootDir / MaxInputBytes / GitignoreFunc,
+// resolves the effective rule config from .mdsmith.yml kinds and
+// overrides (and any front-matter `kinds:`), then returns the set of
+// directive rules to consult for staleness/regeneration. Each
+// returned rule is a clone with its per-file settings applied via
+// engine.ConfigureRule, and disabled rules are excluded — matching
+// `mdsmith check`/`fix` so a directive turned off in `.mdsmith.yml`
+// neither flags a stale body nor gets regenerated on `--fix`.
+func prepareExportFile(
+	path string, source []byte,
+	cfg *config.Config, cfgPath string, maxBytes int64,
+) (*lint.File, []rule.Rule, error) {
+	f, err := lint.NewFileFromSource(path, source, frontMatterEnabled(cfg))
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	f.MaxInputBytes = maxBytes
+	dir := filepath.Dir(path)
+	f.FS = os.DirFS(dir)
+	gitignoreDir := dir
+	if root := rootDirFromConfig(cfgPath); root != "" {
+		f.SetRootDir(root)
+		gitignoreDir = root
+	}
+	gd := gitignoreDir
+	f.GitignoreFunc = func() *lint.GitignoreMatcher {
+		return lint.NewGitignoreMatcher(gd)
+	}
+	// Match engine.Runner.processFile so staleness diagnostics inside
+	// an outer include/catalog body are suppressed: the host file is
+	// not responsible for those bytes.
+	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
+
+	all := rule.All()
+	effective, err := effectiveExportConfig(cfg, path, f.FrontMatter, all)
+	if err != nil {
+		return nil, nil, err
+	}
+	rules, err := configuredEnabledRules(all, effective)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, rules, nil
+}
+
+// effectiveExportConfig parses front-matter kinds/fields (with the
+// same leniency `fix.Fixer` uses) and resolves the file's effective
+// rule config including category overrides.
+func effectiveExportConfig(
+	cfg *config.Config, path string, fm []byte, all []rule.Rule,
+) (map[string]config.RuleCfg, error) {
+	fmKinds, err := lint.ParseFrontMatterKinds(fm)
+	if err != nil {
+		return nil, fmt.Errorf("parsing front-matter kinds in %s: %w", path, err)
+	}
+	if err := config.ValidateFrontMatterKinds(cfg, path, fmKinds); err != nil {
+		return nil, err
+	}
+	fmFields, err := exportFrontMatterFields(cfg, path, fm)
+	if err != nil {
+		return nil, err
+	}
+	effective, categories, explicit := config.EffectiveAll(cfg, path, fmKinds, fmFields)
+	categoryFor := make(map[string]string, len(all))
+	for _, rl := range all {
+		categoryFor[rl.Name()] = rl.Category()
+	}
+	return config.ApplyCategories(
+		effective, categories,
+		func(name string) string { return categoryFor[name] },
+		explicit,
+	), nil
+}
+
+// exportFrontMatterFields decodes the full front-matter mapping only
+// when a kind-assignment entry's `fields-present:` selector could
+// match this file path, mirroring fix.parseFieldsForSelector.
+func exportFrontMatterFields(
+	cfg *config.Config, path string, fm []byte,
+) (map[string]any, error) {
+	if !config.NeedsFieldsForFile(cfg, path) {
+		return nil, nil
+	}
+	fields, err := lint.ParseFrontMatterFields(fm)
+	if err != nil {
+		return nil, fmt.Errorf("parsing front matter in %s: %w", path, err)
+	}
+	return fields, nil
+}
+
+// configuredEnabledRules clones+configures every enabled rule via
+// engine.ConfigureRule, the same path fix.Fixer.fixableRules uses.
+// A settings-apply error short-circuits the export with a clear
+// message rather than silently dropping the rule.
+func configuredEnabledRules(
+	all []rule.Rule, effective map[string]config.RuleCfg,
+) ([]rule.Rule, error) {
+	var out []rule.Rule
+	for _, rl := range all {
+		cfg, ok := effective[rl.Name()]
+		if !ok || !cfg.Enabled {
+			continue
+		}
+		configured, err := engine.ConfigureRule(rl, cfg)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, configured)
+	}
+	return out, nil
 }
 
 // exportMode maps the parsed CLI flags onto the staleness mode the

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -111,7 +111,9 @@ func doExport(path string, flags exportFlags) int {
 
 	out, diags := export.Export(f, exportMode(flags), rules)
 	if len(diags) > 0 {
-		_ = formatDiagnostics(diags, "text", false)
+		if code := formatDiagnostics(diags, "text", false); code != 0 {
+			return code
+		}
 		return 1
 	}
 	if err := writeExportOutput(flags.output, out); err != nil {

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -7,6 +7,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
+	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/export"
 	"github.com/jeduden/mdsmith/internal/lint"
 )
@@ -109,6 +110,10 @@ func doExport(path string, flags exportFlags) int {
 	if root := rootDirFromConfig(cfgPath); root != "" {
 		f.SetRootDir(root)
 	}
+	// Match the engine.Runner setup so staleness diagnostics
+	// inside an outer include/catalog body are suppressed: the
+	// host file is not responsible for those bytes.
+	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
 
 	out, diags := export.Export(f, exportMode(flags))
 	if len(diags) > 0 {

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -140,9 +140,11 @@ func prepareExportFile(
 ) (*lint.File, []rule.Rule, error) {
 	f, _ := lint.NewFileFromSource(path, source, frontMatterEnabled(cfg)) // never errors today
 	f.MaxInputBytes = maxBytes
-	f.FS = os.DirFS(filepath.Dir(path))
-	gitignoreDir := filepath.Dir(path)
-	if root := rootDirFromConfig(cfgPath); root != "" {
+	dir := filepath.Dir(path)
+	f.FS = os.DirFS(dir)
+	gitignoreDir := dir
+	root := rootDirFromConfig(cfgPath)
+	if root != "" {
 		f.SetRootDir(root)
 		gitignoreDir = root
 	}
@@ -221,7 +223,10 @@ func configuredEnabledRules(
 	var out []rule.Rule
 	for _, rl := range all {
 		cfg, ok := effective[rl.Name()]
-		if !ok || !cfg.Enabled {
+		if !ok {
+			continue
+		}
+		if !cfg.Enabled {
 			continue
 		}
 		configured, err := engine.ConfigureRule(rl, cfg)

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -38,16 +38,17 @@ func runExport(args []string) int {
 			"mdsmith: export: --fix and --no-check are mutually exclusive\n")
 		return 2
 	}
-	if len(posArgs) == 0 {
+	switch len(posArgs) {
+	case 0:
 		fmt.Fprintf(os.Stderr, "mdsmith: export requires a file argument\n")
 		return 2
-	}
-	if len(posArgs) > 1 {
+	case 1:
+		return doExport(posArgs[0], flags)
+	default:
 		fmt.Fprintf(os.Stderr,
 			"mdsmith: export takes a single file argument (got %d)\n", len(posArgs))
 		return 2
 	}
-	return doExport(posArgs[0], flags)
 }
 
 // parseExportFlags binds the flagset and parses args. Returns
@@ -77,9 +78,7 @@ func parseExportFlags(args []string) (exportFlags, []string, int) {
 	}
 
 	if err := fs.Parse(args); err != nil {
-		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: export"); code >= 0 {
-			return flags, nil, code
-		}
+		return flags, nil, reportFlagParseErr(err, os.Stderr, "mdsmith: export")
 	}
 	return flags, fs.Args(), -1
 }
@@ -112,9 +111,7 @@ func doExport(path string, flags exportFlags) int {
 
 	out, diags := export.Export(f, exportMode(flags), rules)
 	if len(diags) > 0 {
-		if code := formatDiagnostics(diags, "text", false); code != 0 {
-			return code
-		}
+		_ = formatDiagnostics(diags, "text", false)
 		return 1
 	}
 	if err := writeExportOutput(flags.output, out); err != nil {
@@ -133,25 +130,24 @@ func doExport(path string, flags exportFlags) int {
 // engine.ConfigureRule, and disabled rules are excluded — matching
 // `mdsmith check`/`fix` so a directive turned off in `.mdsmith.yml`
 // neither flags a stale body nor gets regenerated on `--fix`.
+//
+// lint.NewFileFromSource never errors with the current goldmark
+// configuration (same invariant fix.Fixer.buildPostFixFile relies
+// on), so the parse is unchecked.
 func prepareExportFile(
 	path string, source []byte,
 	cfg *config.Config, cfgPath string, maxBytes int64,
 ) (*lint.File, []rule.Rule, error) {
-	f, err := lint.NewFileFromSource(path, source, frontMatterEnabled(cfg))
-	if err != nil {
-		return nil, nil, fmt.Errorf("parsing %s: %w", path, err)
-	}
+	f, _ := lint.NewFileFromSource(path, source, frontMatterEnabled(cfg)) // never errors today
 	f.MaxInputBytes = maxBytes
-	dir := filepath.Dir(path)
-	f.FS = os.DirFS(dir)
-	gitignoreDir := dir
+	f.FS = os.DirFS(filepath.Dir(path))
+	gitignoreDir := filepath.Dir(path)
 	if root := rootDirFromConfig(cfgPath); root != "" {
 		f.SetRootDir(root)
 		gitignoreDir = root
 	}
-	gd := gitignoreDir
 	f.GitignoreFunc = func() *lint.GitignoreMatcher {
-		return lint.NewGitignoreMatcher(gd)
+		return lint.NewGitignoreMatcher(gitignoreDir)
 	}
 	// Match engine.Runner.processFile so staleness diagnostics inside
 	// an outer include/catalog body are suppressed: the host file is
@@ -251,13 +247,13 @@ func exportMode(flags exportFlags) export.Mode {
 }
 
 // writeExportOutput writes data to a file at path, or to stdout when
-// path is empty.
+// path is empty. A stdout write failure is treated as fatal because
+// the caller has no other channel to surface it; an os.Stdout.Write
+// failure is theoretical and not exercised by tests.
 func writeExportOutput(path string, data []byte) error {
 	if path == "" {
-		if _, err := os.Stdout.Write(data); err != nil {
-			return fmt.Errorf("writing output: %w", err)
-		}
-		return nil
+		_, err := os.Stdout.Write(data)
+		return err
 	}
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)

--- a/cmd/mdsmith/export_unit_test.go
+++ b/cmd/mdsmith/export_unit_test.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/export"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+
+	// Make sure the production directive rules are registered for
+	// prepareExportFile / configuredEnabledRules to find.
+	_ "github.com/jeduden/mdsmith/internal/rules/all"
+)
+
+func TestExportMode_Mapping(t *testing.T) {
+	assert.Equal(t, export.Check, exportMode(exportFlags{}))
+	assert.Equal(t, export.Fix, exportMode(exportFlags{fixStale: true}))
+	assert.Equal(t, export.NoCheck, exportMode(exportFlags{noCheck: true}))
+	// `fixStale` wins when both are set; the CLI rejects that
+	// combination earlier, so exportMode only ever sees the legal
+	// inputs — this asserts the precedence anyway.
+	assert.Equal(t, export.Fix, exportMode(exportFlags{fixStale: true, noCheck: true}))
+}
+
+func TestParseExportFlags_AllFlags(t *testing.T) {
+	flags, posArgs, code := parseExportFlags([]string{
+		"-c", "custom.yml",
+		"--output", "out.md",
+		"--max-input-size", "1MB",
+		"--fix",
+		"doc.md",
+	})
+	assert.Equal(t, -1, code, "good flag set should produce -1 (continue)")
+	assert.Equal(t, "custom.yml", flags.configPath)
+	assert.Equal(t, "out.md", flags.output)
+	assert.Equal(t, "1MB", flags.maxInputSize)
+	assert.True(t, flags.fixStale)
+	assert.False(t, flags.noCheck)
+	assert.Equal(t, []string{"doc.md"}, posArgs)
+}
+
+func TestParseExportFlags_NoCheckShortFormDisallowed(t *testing.T) {
+	// --no-check is the long form; the short -n isn't registered.
+	stderr := captureStderr(func() {
+		_, _, code := parseExportFlags([]string{"-n"})
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "mdsmith: export")
+}
+
+func TestParseExportFlags_HelpExitsZero(t *testing.T) {
+	stderr := captureStderr(func() {
+		_, _, code := parseExportFlags([]string{"--help"})
+		assert.Equal(t, 0, code)
+	})
+	// `--help` prints the Usage callback we wired in parseExportFlags.
+	assert.Contains(t, stderr, "mdsmith export")
+}
+
+func TestRunExport_FixAndNoCheck_Mutex(t *testing.T) {
+	stderr := captureStderr(func() {
+		code := runExport([]string{"--fix", "--no-check", "ignored.md"})
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "mutually exclusive")
+}
+
+func TestRunExport_MissingPositional(t *testing.T) {
+	stderr := captureStderr(func() {
+		code := runExport(nil)
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "requires a file argument")
+}
+
+func TestRunExport_TooManyPositionals(t *testing.T) {
+	stderr := captureStderr(func() {
+		code := runExport([]string{"a.md", "b.md"})
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "single file argument")
+}
+
+func TestWriteExportOutput_File(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "out.md")
+
+	require.NoError(t, writeExportOutput(dst, []byte("hello\n")))
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", string(got))
+}
+
+func TestWriteExportOutput_FileWriteError_BubblesUp(t *testing.T) {
+	// A path inside a non-existent directory must surface a clear
+	// error, not a panic; the doExport caller maps the error to
+	// stderr + exit 2.
+	err := writeExportOutput(filepath.Join(t.TempDir(), "missing-subdir", "out.md"), []byte("x"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out.md")
+}
+
+func TestWriteExportOutput_Stdout(t *testing.T) {
+	stdout := captureStdout(func() {
+		require.NoError(t, writeExportOutput("", []byte("via stdout\n")))
+	})
+	assert.Equal(t, "via stdout\n", stdout)
+}
+
+// minimalConfig builds a config.Config with frontMatter enabled and
+// the named ignore patterns, suitable for prepareExportFile.
+func minimalConfig() *config.Config {
+	cfg := config.Merge(config.Defaults(), nil)
+	return cfg
+}
+
+func TestPrepareExportFile_BasicWiring(t *testing.T) {
+	dir := t.TempDir()
+	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	path := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0644))
+
+	f, rules, err := prepareExportFile(path, []byte(src), minimalConfig(), "", lint.DefaultMaxInputBytes)
+	require.NoError(t, err)
+
+	require.NotNil(t, f.FS, "FS should be wired so include/catalog can read siblings")
+	require.NotNil(t, f.GitignoreFunc, "GitignoreFunc should be wired so catalog respects .gitignore")
+	// GeneratedRanges is computed from FindAllGeneratedRanges, which
+	// returns nil for files with no include/catalog content. Verify
+	// the call was made by checking the field is set on the
+	// hydrated *lint.File — even an empty slice signals "computed".
+	assert.NotPanics(t, func() {
+		_ = len(f.GeneratedRanges)
+	})
+
+	require.NotEmpty(t, rules,
+		"with defaults loaded, configuredEnabledRules should return the directive rules")
+
+	// Sanity: the toc rule lives in the slice (so Fix mode would
+	// recognise it). The slice is configured+enabled.
+	found := false
+	for _, r := range rules {
+		if r.Name() == "toc" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "toc must be in the enabled rules slice")
+}
+
+func TestPrepareExportFile_InvalidFrontMatterKinds_ReturnsError(t *testing.T) {
+	// front-matter `kinds:` must be a list of strings; a malformed
+	// entry surfaces as a parse error so the CLI exits 2 with a clear
+	// message instead of silently treating the file as kindless.
+	src := "---\nkinds: 42\n---\n# Title\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0644))
+
+	_, _, err := prepareExportFile(path, []byte(src), minimalConfig(), "", lint.DefaultMaxInputBytes)
+	require.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "kinds") ||
+			strings.Contains(err.Error(), "front-matter"),
+		"error should mention kinds / front-matter, got %v", err)
+}
+
+func TestConfiguredEnabledRules_FiltersDisabled(t *testing.T) {
+	// Build an effective map that disables `toc` and leaves the rest
+	// enabled. configuredEnabledRules must drop toc but keep
+	// everything else.
+	all := rule.All()
+	effective := map[string]config.RuleCfg{}
+	for _, r := range all {
+		effective[r.Name()] = config.RuleCfg{Enabled: r.Name() != "toc"}
+	}
+
+	out, err := configuredEnabledRules(all, effective)
+	require.NoError(t, err)
+
+	for _, r := range out {
+		assert.NotEqual(t, "toc", r.Name(),
+			"toc was disabled in effective config but appeared in the output")
+	}
+}
+
+func TestConfiguredEnabledRules_OmitsRulesAbsentFromEffective(t *testing.T) {
+	// An empty effective map means no rule has been resolved → no
+	// rules come back. This guards the "ok" branch in
+	// configuredEnabledRules.
+	out, err := configuredEnabledRules(rule.All(), map[string]config.RuleCfg{})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestDoExport_ReadError_ExitsTwo(t *testing.T) {
+	// doExport is called via runExport; the file does not exist, so
+	// lint.ReadFileLimited fails and the CLI exits 2 with a message
+	// on stderr.
+	missing := filepath.Join(t.TempDir(), "nope.md")
+	stderr := captureStderr(func() {
+		code := runExport([]string{missing})
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "nope.md")
+}
+
+func TestDoExport_FreshFile_StdoutSuccess(t *testing.T) {
+	// End-to-end through doExport (not the subprocess binary): a
+	// fresh file goes through the default check mode, prints to
+	// stdout, and exits 0. Captures stdout via the test helper.
+	dir := t.TempDir()
+	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	path := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0644))
+
+	var code int
+	stdout := captureStdout(func() {
+		code = runExport([]string{path})
+	})
+	assert.Equal(t, 0, code)
+	assert.NotContains(t, stdout, "<?toc")
+	assert.Contains(t, stdout, "- [Section](#section)")
+}
+
+func TestDoExport_StaleFile_DefaultMode_ExitsOne(t *testing.T) {
+	dir := t.TempDir()
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	path := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0644))
+
+	var code int
+	stderr := captureStderr(func() {
+		code = runExport([]string{path})
+	})
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "out of date")
+}
+
+func TestExportFrontMatterFields_NoSelector_ReturnsNil(t *testing.T) {
+	cfg := minimalConfig()
+	// Default config has no fields-present kind-assignment entry; the
+	// helper short-circuits and returns nil without parsing.
+	out, err := exportFrontMatterFields(cfg, "doc.md", []byte("---\nbroken: [yaml\n---\n"))
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+// configWithFieldsPresent returns a config whose KindAssignment has a
+// single fields-present entry, forcing NeedsFieldsForFile to return
+// true so the front-matter decode runs.
+func configWithFieldsPresent() *config.Config {
+	cfg := minimalConfig()
+	cfg.KindAssignment = append(cfg.KindAssignment, config.KindAssignmentEntry{
+		FieldsPresent: []string{"id"},
+		Kinds:         []string{},
+	})
+	return cfg
+}
+
+func TestExportFrontMatterFields_SelectorTriggersDecode(t *testing.T) {
+	cfg := configWithFieldsPresent()
+	out, err := exportFrontMatterFields(cfg, "doc.md", []byte("---\nid: 7\ntitle: t\n---\n"))
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, 7, out["id"])
+	assert.Equal(t, "t", out["title"])
+}
+
+func TestExportFrontMatterFields_SelectorPropagatesParseError(t *testing.T) {
+	cfg := configWithFieldsPresent()
+	_, err := exportFrontMatterFields(cfg, "doc.md", []byte("---\nbroken: [yaml\n---\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing front matter")
+}
+
+func TestEffectiveExportConfig_NoFrontMatter_DefaultsRule(t *testing.T) {
+	cfg := minimalConfig()
+	out, err := effectiveExportConfig(cfg, "doc.md", nil, rule.All())
+	require.NoError(t, err)
+	// At least the toc rule should be present in the effective map
+	// with its default-enabled state.
+	tocCfg, ok := out["toc"]
+	require.True(t, ok, "toc should appear in the effective config")
+	assert.True(t, tocCfg.Enabled, "toc should be enabled by default")
+}
+
+func TestEffectiveExportConfig_InvalidFrontmatterKindsName_Surfaces(t *testing.T) {
+	// A front-matter `kinds:` entry naming an undeclared kind is a
+	// validation error.
+	cfg := minimalConfig()
+	src := []byte("---\nkinds: [no-such-kind]\n---\n")
+	_, err := effectiveExportConfig(cfg, "doc.md", src, rule.All())
+	require.Error(t, err)
+}
+
+func TestRunExport_OutputFlag_RoundTripsThroughTempFile(t *testing.T) {
+	// Drive runExport with the --output flag set; the file should
+	// be written and stdout stays empty.
+	dir := t.TempDir()
+	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte(src), 0644))
+	dstPath := filepath.Join(dir, "out.md")
+
+	var code int
+	stdout := captureStdout(func() {
+		code = runExport([]string{"-o", dstPath, srcPath})
+	})
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stdout, "with -o, stdout stays empty")
+
+	data, err := os.ReadFile(dstPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "<?toc")
+	assert.Contains(t, string(data), "- [Section](#section)")
+}
+
+func TestRunExport_OutputFlag_WriteFailure_ExitsTwo(t *testing.T) {
+	// Writing to a path inside a non-existent directory should
+	// surface as exit 2 with a clear error.
+	dir := t.TempDir()
+	src := "# Title\n\nNo directives.\n"
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte(src), 0644))
+	dstPath := filepath.Join(dir, "missing-sub", "out.md")
+
+	var code int
+	stderr := captureStderr(func() {
+		code = runExport([]string{"-o", dstPath, srcPath})
+	})
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "out.md")
+}
+
+func TestDoExport_InvalidConfig_ExitsTwo(t *testing.T) {
+	// Pass a config path that does not parse — doExport surfaces
+	// the loadConfig error as exit 2.
+	dir := t.TempDir()
+	badCfg := filepath.Join(dir, "bad.yml")
+	require.NoError(t, os.WriteFile(badCfg, []byte("rules: [not a map]\n"), 0644))
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte("# Hi\n"), 0644))
+
+	var code int
+	stderr := captureStderr(func() {
+		code = runExport([]string{"-c", badCfg, srcPath})
+	})
+	assert.Equal(t, 2, code)
+	assert.NotEmpty(t, stderr)
+}
+
+func TestDoExport_BadMaxInputSize_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte("# Hi\n"), 0644))
+
+	var code int
+	stderr := captureStderr(func() {
+		code = runExport([]string{"--max-input-size", "not-a-size", srcPath})
+	})
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "max-input-size")
+}

--- a/cmd/mdsmith/export_unit_test.go
+++ b/cmd/mdsmith/export_unit_test.go
@@ -88,6 +88,28 @@ func TestRunExport_TooManyPositionals(t *testing.T) {
 	assert.Contains(t, stderr, "single file argument")
 }
 
+func TestRunExport_HelpExitsZero(t *testing.T) {
+	// --help drives parseExportFlags to ErrHelp, which
+	// reportFlagParseErr maps to exit 0; the runExport `code >= 0`
+	// branch returns it directly.
+	stderr := captureStderr(func() {
+		code := runExport([]string{"--help"})
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, stderr, "mdsmith export")
+}
+
+func TestRunExport_UnknownFlag_ExitsTwo(t *testing.T) {
+	// An unknown flag drives parseExportFlags to a non-help parse
+	// error → reportFlagParseErr returns 2 with a stderr message →
+	// runExport's `code >= 0` branch returns it.
+	stderr := captureStderr(func() {
+		code := runExport([]string{"--no-such-flag"})
+		assert.Equal(t, 2, code)
+	})
+	assert.Contains(t, stderr, "mdsmith: export")
+}
+
 func TestWriteExportOutput_File(t *testing.T) {
 	dir := t.TempDir()
 	dst := filepath.Join(dir, "out.md")
@@ -190,6 +212,48 @@ func TestConfiguredEnabledRules_FiltersDisabled(t *testing.T) {
 		assert.NotEqual(t, "toc", r.Name(),
 			"toc was disabled in effective config but appeared in the output")
 	}
+}
+
+func TestConfiguredEnabledRules_PropagatesConfigureRuleError(t *testing.T) {
+	// emphasis-style.ApplySettings rejects non-string `bold`. An
+	// effective map with that bad setting drives ConfigureRule into
+	// an error, which configuredEnabledRules surfaces unchanged so
+	// the export refuses with a clear message instead of running
+	// against partially-configured rules.
+	all := rule.All()
+	effective := map[string]config.RuleCfg{
+		"emphasis-style": {
+			Enabled:  true,
+			Settings: map[string]any{"bold": 42}, // wrong type → error
+		},
+	}
+
+	_, err := configuredEnabledRules(all, effective)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "emphasis-style")
+}
+
+func TestPrepareExportFile_ConfigureRuleError_BubblesUp(t *testing.T) {
+	// A config that disables every rule except a deliberately
+	// misconfigured one drives prepareExportFile → effectiveExportConfig
+	// →  configuredEnabledRules → ConfigureRule error. The error
+	// surfaces from prepareExportFile so doExport can map it to
+	// exit 2.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(
+		"rules:\n  emphasis-style:\n    bold: 42\n"), 0644))
+
+	cfg, _, err := loadConfig(cfgPath)
+	require.NoError(t, err)
+
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte("# Hi\n"), 0644))
+	src := []byte("# Hi\n")
+
+	_, _, err = prepareExportFile(srcPath, src, cfg, cfgPath, lint.DefaultMaxInputBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "emphasis-style")
 }
 
 func TestConfiguredEnabledRules_OmitsRulesAbsentFromEffective(t *testing.T) {
@@ -356,6 +420,84 @@ func TestDoExport_InvalidConfig_ExitsTwo(t *testing.T) {
 	})
 	assert.Equal(t, 2, code)
 	assert.NotEmpty(t, stderr)
+}
+
+func TestDoExport_InvalidFrontMatterKinds_ExitsTwo(t *testing.T) {
+	// A file with malformed `kinds:` front matter makes
+	// prepareExportFile return an error. doExport must map that to
+	// exit 2 with a clear stderr message.
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte("---\nkinds: 42\n---\n# Hi\n"), 0644))
+
+	var code int
+	stderr := captureStderr(func() {
+		code = runExport([]string{srcPath})
+	})
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "mdsmith:")
+}
+
+func TestDoExport_StaleFile_PrintsDiagnostics(t *testing.T) {
+	// Stale-body refusal in Check mode goes through formatDiagnostics
+	// and exits 1 with the diagnostic on stderr.
+	dir := t.TempDir()
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	srcPath := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte(src), 0644))
+
+	var code int
+	stderr := captureStderr(func() {
+		code = runExport([]string{srcPath})
+	})
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "out of date")
+	assert.Contains(t, stderr, "MDS038")
+}
+
+func TestPrepareExportFile_NoCfgPath_UsesDocDirForGitignore(t *testing.T) {
+	// When cfgPath is empty, the gitignore matcher should still be
+	// wired (against the doc's parent directory). Triggering
+	// GetGitignore must not panic and should return a non-nil
+	// matcher — exercises the closure body.
+	dir := t.TempDir()
+	src := "# Title\n\nNo directives.\n"
+	path := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0644))
+
+	f, _, err := prepareExportFile(path, []byte(src), minimalConfig(), "", lint.DefaultMaxInputBytes)
+	require.NoError(t, err)
+	// Calling GetGitignore should invoke the closure on line 153-155
+	// and return a matcher anchored at the doc's parent dir.
+	matcher := f.GetGitignore()
+	require.NotNil(t, matcher)
+}
+
+func TestPrepareExportFile_WithCfgPath_UsesProjectRootForGitignore(t *testing.T) {
+	// With cfgPath set, the matcher should be anchored at the
+	// project root (parent of cfgPath), exercising the
+	// rootDirFromConfig branch in prepareExportFile.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("rules: {}\n"), 0644))
+
+	src := "# Title\n\nNo directives.\n"
+	path := filepath.Join(dir, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0644))
+
+	f, _, err := prepareExportFile(path, []byte(src), minimalConfig(), cfgPath, lint.DefaultMaxInputBytes)
+	require.NoError(t, err)
+	matcher := f.GetGitignore()
+	require.NotNil(t, matcher)
+}
+
+func TestEffectiveExportConfig_FieldsPresentBranch_PropagatesError(t *testing.T) {
+	// Front-matter parse error from exportFrontMatterFields should
+	// flow through effectiveExportConfig.
+	cfg := configWithFieldsPresent()
+	_, err := effectiveExportConfig(cfg, "doc.md", []byte("---\nbroken: [yaml\n---\n"), rule.All())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "front matter")
 }
 
 func TestDoExport_BadMaxInputSize_ExitsTwo(t *testing.T) {

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -42,6 +42,7 @@ const usageText = `Usage: mdsmith <command> [flags] [files...]
 Commands:
   check             Lint Markdown files (default when given file arguments)
   fix               Auto-fix lint issues in place
+  export            Write a portable, directive-free copy of a Markdown file
   list              Walk the workspace and emit matches (files or link records)
   help              Show help for rules and topics
   metrics           Show and rank shared Markdown metrics
@@ -88,6 +89,8 @@ func run() int {
 		return runCheck(os.Args[2:])
 	case "fix":
 		return runFix(os.Args[2:])
+	case "export":
+		return runExport(os.Args[2:])
 	case "list":
 		return runList(os.Args[2:])
 	case "help":

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 | Command                                       | Description                                                                          |
 |-----------------------------------------------|--------------------------------------------------------------------------------------|
 | [`check`](cli/check.md)                       | Lint Markdown files for style issues.                                                |
+| [`export`](cli/export.md)                     | Write a portable, directive-free copy of a Markdown file.                            |
 | [`fix`](cli/fix.md)                           | Auto-fix lint issues in Markdown files in place.                                     |
 | [`help`](cli/help.md)                         | Show built-in documentation for rules, metrics, and concept pages.                   |
 | [`init`](cli/init.md)                         | Generate a default `.mdsmith.yml` config in the current directory.                   |

--- a/docs/reference/cli/export.md
+++ b/docs/reference/cli/export.md
@@ -1,0 +1,94 @@
+---
+command: export
+summary: Write a portable, directive-free copy of a Markdown file.
+---
+# `mdsmith export`
+
+Write a portable, directive-free copy of a Markdown file
+to stdout. Generated section markers are stripped and
+the bodies stay as plain Markdown. `<?include?>` content
+is inlined recursively. The result renders on any
+Markdown tool with no mdsmith knowledge.
+
+```text
+mdsmith export [flags] <file>
+```
+
+Takes a single file argument. The source file is never
+modified in any mode.
+
+## Flags
+
+| Flag               | Default | Description                                                  |
+|--------------------|---------|--------------------------------------------------------------|
+| `-c`, `--config`   | auto    | Override config path (auto-discovers)                        |
+| `-o`, `--output`   | stdout  | Write output to `<path>` instead of stdout                   |
+| `--max-input-size` | `2MB`   | Max file size (e.g. `2MB`, `0`=none)                         |
+| `--fix`            | false   | Regenerate stale directive bodies in memory before stripping |
+| `--no-check`       | false   | Skip the staleness check; export on-disk bytes as-is         |
+
+`--fix` and `--no-check` are mutually exclusive — one
+regenerates, the other trusts the file as-is. Passing
+both is a usage error.
+
+## Staleness modes
+
+By default `export` is **faithful**: it strips markers
+only after verifying each directive body equals what the
+engine would generate.
+
+| Mode         | Behavior                                                                        |
+|--------------|---------------------------------------------------------------------------------|
+| (default)    | Refuse on any stale body; exit non-zero with a diagnostic naming the directive. |
+| `--fix`      | Regenerate stale bodies in memory, then strip markers.                          |
+| `--no-check` | Skip the check; emit on-disk bytes verbatim.                                    |
+
+The default never silently masks drift between a
+directive and its rendered body. `--fix` is the opt-in
+convenience for a one-shot fresh export; `--no-check`
+trusts callers who already know the file is fresh.
+
+## What gets stripped
+
+- Opening and closing markers of every paired directive
+  (`<?catalog?>`, `<?include?>`, `<?toc?>`, `<?build?>`).
+  The body between them is kept verbatim — or
+  regenerated first under `--fix`.
+- Markerless directives with no body (for example
+  `<?allow-empty-section?>` and `<?require?>`) are
+  removed outright.
+- Marker-like text the engine treats as literal content
+  — for example inner same-type markers nested inside an
+  outer directive — is left in place.
+
+After stripping, blank lines around the removed markers
+are normalised so the output is stable and passes
+`mdsmith check`. Front matter is kept as-is.
+
+Exporting an already directive-free file is a no-op:
+`export` is idempotent.
+
+## Examples
+
+```bash
+mdsmith export PLAN.md             # write portable copy to stdout
+mdsmith export PLAN.md -o PLAN.export.md
+mdsmith export --fix README.md     # regenerate stale bodies first
+mdsmith export --no-check README.md > README.snapshot.md
+```
+
+## Exit codes
+
+| Code | Meaning                                                                                        |
+|------|------------------------------------------------------------------------------------------------|
+| 0    | Export succeeded                                                                               |
+| 1    | Refused: a directive body was stale in default mode                                            |
+| 2    | Runtime or configuration error (missing file, conflict between `--fix` and `--no-check`, etc.) |
+
+## See also
+
+- [`mdsmith fix`](fix.md) — the same regeneration engine
+  applied in place on disk.
+- [`mdsmith check`](check.md) — read-only sibling that
+  surfaces the same "out of date" diagnostic without
+  attempting to export.

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -9,7 +9,6 @@ package export
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -36,6 +35,19 @@ const (
 
 // Export returns a portable, directive-free copy of f's source.
 //
+// rules carries the caller's effective ruleset (already cloned and
+// configured via engine.ConfigureRule, and filtered to enabled rules
+// only — like fix.Fixer.fixableRules). Staleness checks (Check mode)
+// and regeneration (Fix mode) only consult rules in this slice, so a
+// directive disabled in `.mdsmith.yml` neither produces a stale-body
+// refusal nor gets regenerated on `--fix`.
+//
+// Marker stripping is independent of `rules`: every directive
+// registered in the global rule registry has its start/end markers
+// stripped from the output, so a disabled directive's markers still
+// disappear even though its body is untouched. Callers that want
+// stripping but no staleness behavior can pass a nil rules slice.
+//
 // Generated section markers are removed, generated bodies stay as
 // plain Markdown, and `<?include?>` content is inlined (recursively,
 // when the body is fresh or has been regenerated).
@@ -43,34 +55,32 @@ const (
 // Exactly one of the returned values is populated:
 //   - on success, the exported bytes (non-nil) and a nil diagnostic
 //     slice — including the no-op case of a directive-free file
-//   - on refusal, nil bytes and a non-empty diagnostic slice naming
-//     the offending directive(s); the caller should exit non-zero
-func Export(f *lint.File, mode Mode) ([]byte, []lint.Diagnostic) {
-	directives := selectDirectives(rule.All())
+//   - on Check-mode refusal, nil bytes and a non-empty diagnostic
+//     slice naming the offending directive(s); the caller should
+//     exit non-zero
+func Export(f *lint.File, mode Mode, rules []rule.Rule) ([]byte, []lint.Diagnostic) {
+	active := selectDirectives(rules)
+	stripDirs := allDirectiveNames()
 
 	working := f
 	switch mode {
 	case Fix:
-		regenerated, diags := regenerate(f, directives)
-		if len(diags) > 0 {
-			return nil, diags
-		}
-		working = regenerated
+		working = regenerate(f, active)
 	case Check:
-		if diags := checkStaleness(f, directives); len(diags) > 0 {
+		if diags := checkStaleness(f, active); len(diags) > 0 {
 			return nil, diags
 		}
 	case NoCheck:
 		// Skip staleness handling; strip uses the on-disk body verbatim.
 	}
 
-	body := stripDirectives(working, directives)
+	body := stripDirectives(working, stripDirs)
 	return working.FullSource(body), nil
 }
 
 // directiveRule pairs a fixable rule with its gensection.Directive
 // view so we can call both Fix (for regeneration) and the
-// directive-level Validate/Generate (for staleness checks).
+// directive-level Check (for staleness).
 type directiveRule struct {
 	rule      rule.FixableRule
 	directive gensection.Directive
@@ -78,7 +88,7 @@ type directiveRule struct {
 
 // selectDirectives picks the rules that implement gensection.Directive
 // AND rule.FixableRule, and orders them by directive name so behavior
-// is deterministic across calls.
+// is deterministic across calls. Returns nil for a nil/empty input.
 func selectDirectives(rules []rule.Rule) []directiveRule {
 	var out []directiveRule
 	for _, r := range rules {
@@ -98,21 +108,61 @@ func selectDirectives(rules []rule.Rule) []directiveRule {
 	return out
 }
 
-// regenerate runs each directive rule's Fix in memory until the source
-// stops changing, then returns a freshly parsed *lint.File that
-// downstream phases can walk. The input is not mutated.
-func regenerate(orig *lint.File, directives []directiveRule) (*lint.File, []lint.Diagnostic) {
+// directiveStrip carries the minimal context Export needs to remove a
+// directive's start/end markers and locate its body range. It is
+// populated from the unconfigured registry so stripping recognises a
+// directive even when its rule is disabled in `.mdsmith.yml`.
+type directiveStrip struct {
+	name     string
+	ruleID   string
+	ruleName string
+}
+
+// allDirectiveNames returns the strip-only descriptor for every
+// directive registered at package-init time. Stripping is independent
+// of the file's effective config — a disabled rule's markers should
+// still vanish — so this list comes straight from `rule.All()` without
+// any kind/override merge.
+func allDirectiveNames() []directiveStrip {
+	all := rule.All()
+	var out []directiveStrip
+	for _, r := range all {
+		d, ok := r.(gensection.Directive)
+		if !ok {
+			continue
+		}
+		out = append(out, directiveStrip{
+			name:     d.Name(),
+			ruleID:   d.RuleID(),
+			ruleName: d.RuleName(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	return out
+}
+
+// regenerate runs each directive rule's Fix in memory until the
+// source stops changing, then returns a freshly parsed *lint.File
+// that downstream phases can walk. The input is not mutated.
+//
+// Mirrors fix.Fixer.applyFixPasses: each rule's Fix only runs when
+// its Check fires — so up-to-date directives aren't regenerated
+// gratuitously. lint.NewFile never errors with the current goldmark
+// configuration (same invariant fix.Fixer relies on at
+// buildPostFixFile), so re-parses here cannot fail.
+func regenerate(orig *lint.File, directives []directiveRule) *lint.File {
 	current := append([]byte(nil), orig.Source...)
 
 	const maxPasses = 10
 	for pass := 0; pass < maxPasses; pass++ {
 		before := current
 		for _, d := range directives {
-			parsed, err := lint.NewFile(orig.Path, current)
-			if err != nil {
+			parsed, _ := lint.NewFile(orig.Path, current) // never errors today
+			hydrate(parsed, orig)
+
+			if len(d.rule.Check(parsed)) == 0 {
 				continue
 			}
-			hydrate(parsed, orig)
 			current = d.rule.Fix(parsed)
 		}
 		if bytes.Equal(before, current) {
@@ -120,21 +170,12 @@ func regenerate(orig *lint.File, directives []directiveRule) (*lint.File, []lint
 		}
 	}
 
-	working, err := lint.NewFile(orig.Path, current)
-	if err != nil {
-		return nil, []lint.Diagnostic{{
-			File:     orig.Path,
-			Line:     1,
-			Column:   1,
-			Severity: lint.Error,
-			Message:  fmt.Sprintf("re-parsing regenerated source: %v", err),
-		}}
-	}
+	working, _ := lint.NewFile(orig.Path, current) // never errors today
 	hydrate(working, orig)
 	working.FrontMatter = orig.FrontMatter
 	working.LineOffset = orig.LineOffset
 	working.StripFrontMatter = orig.StripFrontMatter
-	return working, nil
+	return working
 }
 
 // hydrate copies the per-file context the directive engines rely on
@@ -199,13 +240,12 @@ func inGeneratedRange(line int, ranges []lint.LineRange) bool {
 // inner same-type markers nested in an outer directive — survives,
 // because such PIs sit inside a pair's body range and are skipped
 // here.
-func stripDirectives(f *lint.File, directives []directiveRule) []byte {
+func stripDirectives(f *lint.File, directives []directiveStrip) []byte {
 	stripLines := map[int]bool{}
 	bodyLines := map[int]bool{}
 
 	for _, d := range directives {
-		pairs, _ := gensection.FindMarkerPairs(f, d.directive.Name(),
-			d.directive.RuleID(), d.directive.RuleName())
+		pairs, _ := gensection.FindMarkerPairs(f, d.name, d.ruleID, d.ruleName)
 		for _, p := range pairs {
 			for line := p.StartLine; line < p.ContentFrom; line++ {
 				stripLines[line] = true

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -154,16 +154,40 @@ func hydrate(parsed, orig *lint.File) {
 // invalid YAML, missing include file) cause a refusal while
 // non-blocking hints (catalog case-mismatch, injection warnings)
 // don't.
+//
+// Diagnostics whose line falls inside the host file's
+// GeneratedRanges (i.e. inside an outer include/catalog body) are
+// dropped: the host file is not responsible for content pulled in
+// by another directive, matching the suppression `engine.CheckRules`
+// applies on the regular check path.
+//
+// Returned diagnostics carry file-relative line numbers (front
+// matter included) so the CLI prints positions a user can navigate
+// to directly.
 func checkStaleness(f *lint.File, directives []directiveRule) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for _, d := range directives {
 		for _, rd := range d.rule.Check(f) {
-			if rd.Severity == lint.Error {
-				diags = append(diags, rd)
+			if rd.Severity != lint.Error {
+				continue
 			}
+			if inGeneratedRange(rd.Line, f.GeneratedRanges) {
+				continue
+			}
+			diags = append(diags, rd)
 		}
 	}
+	f.AdjustDiagnostics(diags)
 	return diags
+}
+
+func inGeneratedRange(line int, ranges []lint.LineRange) bool {
+	for _, r := range ranges {
+		if r.Contains(line) {
+			return true
+		}
+	}
+	return false
 }
 
 // stripDirectives removes every line that the engine recognises as a

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -298,17 +298,21 @@ func stripDirectives(f *lint.File, directives []directiveStrip) []byte {
 
 // piLineRange returns the 1-based start and end source-line numbers
 // of a processing-instruction block (including the closing ?>).
+// Markerless PIs come in two shapes the goldmark PI parser can
+// produce: a single-line PI (`<?name?>`) where the closure is on the
+// opening line, and a multi-line PI where the closure sits on its
+// own line; the latter is the only shape that extends `end` past
+// `start`.
 func piLineRange(pi *lint.ProcessingInstruction, f *lint.File) (int, int) {
 	first := pi.Lines().At(0)
 	start := f.LineOfOffset(first.Start)
-	end := start
-	if pi.HasClosure() && pi.ClosureLine.Start != first.Start {
-		end = f.LineOfOffset(pi.ClosureLine.Start)
-	} else if pi.Lines().Len() > 1 {
-		last := pi.Lines().At(pi.Lines().Len() - 1)
-		end = f.LineOfOffset(last.Start)
+	if !pi.HasClosure() {
+		return start, start
 	}
-	return start, end
+	if pi.ClosureLine.Start == first.Start {
+		return start, start
+	}
+	return start, f.LineOfOffset(pi.ClosureLine.Start)
 }
 
 func overlapsAny(from, to int, set map[int]bool) bool {
@@ -349,7 +353,9 @@ func normalizeBlankLines(src []byte, codeBlockLines map[int]bool) []byte {
 		return src
 	}
 	rawLines := strings.Split(string(src), "\n")
-	if len(rawLines) > 0 && rawLines[len(rawLines)-1] == "" {
+	// strings.Split on a non-empty input always returns at least one
+	// element, so the guard reduces to a check on the final element.
+	if rawLines[len(rawLines)-1] == "" {
 		rawLines = rawLines[:len(rawLines)-1]
 	}
 

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -234,7 +234,9 @@ func inGeneratedRange(line int, ranges []lint.LineRange) bool {
 // stripDirectives removes every line that the engine recognises as a
 // real directive start or end marker, plus every markerless PI
 // (e.g. <?allow-empty-section?>, <?require?>), and normalises blank
-// lines around the holes left behind.
+// lines around the holes left behind. A directive-free file is
+// returned byte-for-byte unchanged — `export` is a no-op when there
+// are no markers to remove.
 //
 // Marker-like text the engine treats as literal content — for example
 // inner same-type markers nested in an outer directive — survives,
@@ -277,8 +279,21 @@ func stripDirectives(f *lint.File, directives []directiveStrip) []byte {
 		}
 	}
 
+	// No directive markers found — pass the source through verbatim
+	// so the plan's "export of a directive-free file equals the input"
+	// promise holds and code-block blank lines aren't disturbed.
+	if len(stripLines) == 0 {
+		return f.Source
+	}
+
 	out := emitLines(f.Lines, stripLines)
-	return normalizeBlankLines(out)
+	// Re-parse so the code-block line set lines up with `out`'s
+	// (shifted) line numbers. Without this the normalisation pass
+	// would still see code-block lines at their pre-strip positions
+	// and could collapse intentional blank lines inside fenced/
+	// indented code blocks.
+	parsed, _ := lint.NewFile(f.Path, out) // never errors today
+	return normalizeBlankLines(out, lint.CollectCodeBlockLines(parsed))
 }
 
 // piLineRange returns the 1-based start and end source-line numbers
@@ -323,33 +338,53 @@ func emitLines(srcLines [][]byte, strip map[int]bool) []byte {
 // normalizeBlankLines collapses runs of consecutive blank lines to a
 // single blank line, drops leading/trailing blanks, and ensures the
 // output ends with exactly one newline (unless the result is empty).
-func normalizeBlankLines(src []byte) []byte {
+//
+// Lines whose 1-based index appears in codeBlockLines are treated as
+// non-blank: they pass through unchanged, end any run of collapsing,
+// and anchor leading/trailing trims. That preserves intentional
+// blank lines inside fenced and indented code blocks, matching how
+// MDS008 (blank-line rule) leaves code-block whitespace alone.
+func normalizeBlankLines(src []byte, codeBlockLines map[int]bool) []byte {
 	if len(src) == 0 {
 		return src
 	}
-	lines := strings.Split(string(src), "\n")
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
-		lines = lines[:len(lines)-1]
+	rawLines := strings.Split(string(src), "\n")
+	if len(rawLines) > 0 && rawLines[len(rawLines)-1] == "" {
+		rawLines = rawLines[:len(rawLines)-1]
 	}
-	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+
+	type srcLine struct {
+		text   string
+		inCode bool
+	}
+	lines := make([]srcLine, len(rawLines))
+	for i, l := range rawLines {
+		lines[i] = srcLine{text: l, inCode: codeBlockLines[i+1]}
+	}
+
+	isBlank := func(l srcLine) bool {
+		return !l.inCode && strings.TrimSpace(l.text) == ""
+	}
+
+	for len(lines) > 0 && isBlank(lines[0]) {
 		lines = lines[1:]
 	}
-	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+	for len(lines) > 0 && isBlank(lines[len(lines)-1]) {
 		lines = lines[:len(lines)-1]
 	}
 
 	var out []string
 	blank := false
 	for _, l := range lines {
-		if strings.TrimSpace(l) == "" {
+		if isBlank(l) {
 			if !blank {
 				out = append(out, "")
 			}
 			blank = true
-		} else {
-			out = append(out, l)
-			blank = false
+			continue
 		}
+		out = append(out, l.text)
+		blank = false
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,295 @@
+// Package export implements the source-to-source transform behind
+// `mdsmith export`. It strips every directive start/end marker from a
+// Markdown file while keeping the directive bodies as plain Markdown,
+// so the result renders on any tool without mdsmith knowledge.
+//
+// The package operates purely on an in-memory *lint.File. File reads
+// and disk writes are the CLI layer's responsibility.
+package export
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/archetype/gensection"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+// Mode controls how Export handles directive staleness.
+type Mode int
+
+const (
+	// Check is the default mode. A directive body that disagrees with
+	// the engine's regenerated output is a refusal — Export returns nil
+	// bytes and a diagnostic naming the stale directive.
+	Check Mode = iota
+	// Fix regenerates stale bodies in memory before stripping. The
+	// source file is never written.
+	Fix
+	// NoCheck skips the staleness check entirely. Bodies are exported
+	// exactly as they appear on disk.
+	NoCheck
+)
+
+// Export returns a portable, directive-free copy of f's source.
+//
+// Generated section markers are removed, generated bodies stay as
+// plain Markdown, and `<?include?>` content is inlined (recursively,
+// when the body is fresh or has been regenerated).
+//
+// Exactly one of the returned values is populated:
+//   - on success, the exported bytes (non-nil) and a nil diagnostic
+//     slice — including the no-op case of a directive-free file
+//   - on refusal, nil bytes and a non-empty diagnostic slice naming
+//     the offending directive(s); the caller should exit non-zero
+func Export(f *lint.File, mode Mode) ([]byte, []lint.Diagnostic) {
+	directives := selectDirectives(rule.All())
+
+	working := f
+	switch mode {
+	case Fix:
+		regenerated, diags := regenerate(f, directives)
+		if len(diags) > 0 {
+			return nil, diags
+		}
+		working = regenerated
+	case Check:
+		if diags := checkStaleness(f, directives); len(diags) > 0 {
+			return nil, diags
+		}
+	case NoCheck:
+		// Skip staleness handling; strip uses the on-disk body verbatim.
+	}
+
+	body := stripDirectives(working, directives)
+	return working.FullSource(body), nil
+}
+
+// directiveRule pairs a fixable rule with its gensection.Directive
+// view so we can call both Fix (for regeneration) and the
+// directive-level Validate/Generate (for staleness checks).
+type directiveRule struct {
+	rule      rule.FixableRule
+	directive gensection.Directive
+}
+
+// selectDirectives picks the rules that implement gensection.Directive
+// AND rule.FixableRule, and orders them by directive name so behavior
+// is deterministic across calls.
+func selectDirectives(rules []rule.Rule) []directiveRule {
+	var out []directiveRule
+	for _, r := range rules {
+		fr, fok := r.(rule.FixableRule)
+		if !fok {
+			continue
+		}
+		d, dok := r.(gensection.Directive)
+		if !dok {
+			continue
+		}
+		out = append(out, directiveRule{rule: fr, directive: d})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].directive.Name() < out[j].directive.Name()
+	})
+	return out
+}
+
+// regenerate runs each directive rule's Fix in memory until the source
+// stops changing, then returns a freshly parsed *lint.File that
+// downstream phases can walk. The input is not mutated.
+func regenerate(orig *lint.File, directives []directiveRule) (*lint.File, []lint.Diagnostic) {
+	current := append([]byte(nil), orig.Source...)
+
+	const maxPasses = 10
+	for pass := 0; pass < maxPasses; pass++ {
+		before := current
+		for _, d := range directives {
+			parsed, err := lint.NewFile(orig.Path, current)
+			if err != nil {
+				continue
+			}
+			hydrate(parsed, orig)
+			current = d.rule.Fix(parsed)
+		}
+		if bytes.Equal(before, current) {
+			break
+		}
+	}
+
+	working, err := lint.NewFile(orig.Path, current)
+	if err != nil {
+		return nil, []lint.Diagnostic{{
+			File:     orig.Path,
+			Line:     1,
+			Column:   1,
+			Severity: lint.Error,
+			Message:  fmt.Sprintf("re-parsing regenerated source: %v", err),
+		}}
+	}
+	hydrate(working, orig)
+	working.FrontMatter = orig.FrontMatter
+	working.LineOffset = orig.LineOffset
+	working.StripFrontMatter = orig.StripFrontMatter
+	return working, nil
+}
+
+// hydrate copies the per-file context the directive engines rely on
+// (FS, RootFS/RootDir, MaxInputBytes, gitignore factory) from orig
+// onto parsed so a freshly parsed buffer behaves like the original.
+func hydrate(parsed, orig *lint.File) {
+	parsed.FS = orig.FS
+	parsed.RootFS = orig.RootFS
+	parsed.RootDir = orig.RootDir
+	parsed.MaxInputBytes = orig.MaxInputBytes
+	parsed.GitignoreFunc = orig.GitignoreFunc
+	parsed.GeneratedRanges = gensection.FindAllGeneratedRanges(parsed)
+}
+
+// checkStaleness runs each directive's rule.Check and keeps only
+// error-severity diagnostics, so blocking problems (stale body,
+// invalid YAML, missing include file) cause a refusal while
+// non-blocking hints (catalog case-mismatch, injection warnings)
+// don't.
+func checkStaleness(f *lint.File, directives []directiveRule) []lint.Diagnostic {
+	var diags []lint.Diagnostic
+	for _, d := range directives {
+		for _, rd := range d.rule.Check(f) {
+			if rd.Severity == lint.Error {
+				diags = append(diags, rd)
+			}
+		}
+	}
+	return diags
+}
+
+// stripDirectives removes every line that the engine recognises as a
+// real directive start or end marker, plus every markerless PI
+// (e.g. <?allow-empty-section?>, <?require?>), and normalises blank
+// lines around the holes left behind.
+//
+// Marker-like text the engine treats as literal content — for example
+// inner same-type markers nested in an outer directive — survives,
+// because such PIs sit inside a pair's body range and are skipped
+// here.
+func stripDirectives(f *lint.File, directives []directiveRule) []byte {
+	stripLines := map[int]bool{}
+	bodyLines := map[int]bool{}
+
+	for _, d := range directives {
+		pairs, _ := gensection.FindMarkerPairs(f, d.directive.Name(),
+			d.directive.RuleID(), d.directive.RuleName())
+		for _, p := range pairs {
+			for line := p.StartLine; line < p.ContentFrom; line++ {
+				stripLines[line] = true
+			}
+			stripLines[p.EndLine] = true
+			for line := p.ContentFrom; line <= p.ContentTo; line++ {
+				bodyLines[line] = true
+			}
+		}
+	}
+
+	// Markerless directives: every top-level PI whose lines fall
+	// outside a known pair's strip range and body range.
+	for n := f.AST.FirstChild(); n != nil; n = n.NextSibling() {
+		pi, ok := n.(*lint.ProcessingInstruction)
+		if !ok {
+			continue
+		}
+		startLine, endLine := piLineRange(pi, f)
+
+		if overlapsAny(startLine, endLine, stripLines) {
+			continue
+		}
+		if overlapsAny(startLine, endLine, bodyLines) {
+			continue
+		}
+		for line := startLine; line <= endLine; line++ {
+			stripLines[line] = true
+		}
+	}
+
+	out := emitLines(f.Lines, stripLines)
+	return normalizeBlankLines(out)
+}
+
+// piLineRange returns the 1-based start and end source-line numbers
+// of a processing-instruction block (including the closing ?>).
+func piLineRange(pi *lint.ProcessingInstruction, f *lint.File) (int, int) {
+	first := pi.Lines().At(0)
+	start := f.LineOfOffset(first.Start)
+	end := start
+	if pi.HasClosure() && pi.ClosureLine.Start != first.Start {
+		end = f.LineOfOffset(pi.ClosureLine.Start)
+	} else if pi.Lines().Len() > 1 {
+		last := pi.Lines().At(pi.Lines().Len() - 1)
+		end = f.LineOfOffset(last.Start)
+	}
+	return start, end
+}
+
+func overlapsAny(from, to int, set map[int]bool) bool {
+	for line := from; line <= to; line++ {
+		if set[line] {
+			return true
+		}
+	}
+	return false
+}
+
+func emitLines(srcLines [][]byte, strip map[int]bool) []byte {
+	var b bytes.Buffer
+	for i, line := range srcLines {
+		lineNum := i + 1
+		if strip[lineNum] {
+			continue
+		}
+		b.Write(line)
+		if i < len(srcLines)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.Bytes()
+}
+
+// normalizeBlankLines collapses runs of consecutive blank lines to a
+// single blank line, drops leading/trailing blanks, and ensures the
+// output ends with exactly one newline (unless the result is empty).
+func normalizeBlankLines(src []byte) []byte {
+	if len(src) == 0 {
+		return src
+	}
+	lines := strings.Split(string(src), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	var out []string
+	blank := false
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			if !blank {
+				out = append(out, "")
+			}
+			blank = true
+		} else {
+			out = append(out, l)
+			blank = false
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	result := strings.Join(out, "\n") + "\n"
+	return []byte(result)
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/export"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
 
 	// Register the production directive rules (toc, catalog, include,
-	// build, …) so export.Export sees them via rule.All().
+	// build, …) so allRules() picks them up via rule.All().
 	_ "github.com/jeduden/mdsmith/internal/rules/all"
 
 	"github.com/stretchr/testify/assert"
@@ -25,11 +26,35 @@ func newFile(t *testing.T, path, src string) *lint.File {
 	return f
 }
 
+// allRules returns the registered ruleset unmodified — equivalent to
+// what the CLI would pass when no settings narrow it. Tests that want
+// to simulate a disabled rule build their own slice.
+func allRules() []rule.Rule { return rule.All() }
+
+// rulesExcept returns rule.All() with the directives named in skip
+// removed, simulating an effective config where those rules are
+// disabled.
+func rulesExcept(skip ...string) []rule.Rule {
+	out := rule.All()
+	skipSet := map[string]bool{}
+	for _, n := range skip {
+		skipSet[n] = true
+	}
+	filtered := out[:0]
+	for _, r := range out {
+		if skipSet[r.Name()] {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered
+}
+
 func TestExport_NoDirectives_Noop(t *testing.T) {
 	src := "# Title\n\nSome content.\n\n## Section\n\nMore content.\n"
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	assert.Equal(t, src, string(out))
 }
@@ -38,7 +63,7 @@ func TestExport_TOCMarkers_BodyKept(t *testing.T) {
 	src := "# Title\n\n<?toc?>\n\n- [Title](#title)\n- [Two](#two)\n\n<?/toc?>\n\n## Two\n\nbody\n"
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	assert.NotContains(t, got, "<?toc")
@@ -52,7 +77,7 @@ func TestExport_MarkerlessRequire_Removed(t *testing.T) {
 	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
 	require.NoError(t, err)
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	assert.NotContains(t, got, "<?require")
@@ -65,7 +90,7 @@ func TestExport_MarkerlessAllowEmptySection_Removed(t *testing.T) {
 	src := "# Title\n\n## Stub\n\n<?allow-empty-section?>\n\n## Real\n\nbody\n"
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	assert.NotContains(t, got, "<?allow-empty-section?>")
@@ -81,7 +106,7 @@ func TestExport_Include_BodyKeptInline(t *testing.T) {
 		"snippet.md": &fstest.MapFile{Data: []byte("snippet body\n")},
 	}
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	assert.NotContains(t, got, "<?include")
@@ -112,7 +137,7 @@ func TestExport_NestedSameTypeMarkers_LiteralContentSurvives(t *testing.T) {
 	}, "\n")
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	// Outer markers gone.
@@ -129,11 +154,11 @@ func TestExport_Idempotent(t *testing.T) {
 	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
 	f := newFile(t, "doc.md", src)
 
-	first, diags := export.Export(f, export.NoCheck)
+	first, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 
 	f2 := newFile(t, "doc.md", string(first))
-	second, diags := export.Export(f2, export.NoCheck)
+	second, diags := export.Export(f2, export.NoCheck, allRules())
 	require.Empty(t, diags)
 
 	assert.Equal(t, string(first), string(second))
@@ -144,7 +169,7 @@ func TestExport_CheckMode_StaleBody_Refuses(t *testing.T) {
 	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.Check)
+	out, diags := export.Export(f, export.Check, allRules())
 	assert.Nil(t, out, "stale body must produce nil bytes")
 	require.NotEmpty(t, diags)
 	// Diagnostic mentions the offending directive and its location.
@@ -158,11 +183,42 @@ func TestExport_CheckMode_StaleBody_Refuses(t *testing.T) {
 	assert.True(t, found, "expected an 'out of date' diagnostic for toc, got %+v", diags)
 }
 
+func TestExport_CheckMode_DisabledDirective_NotFlaggedButStripped(t *testing.T) {
+	// A stale <?toc?> body that would normally refuse the export is
+	// silently allowed when the toc rule is excluded from the
+	// effective config — but the markers still vanish, because
+	// stripping is independent of which rules the caller passes.
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.Check, rulesExcept("toc"))
+	require.Empty(t, diags, "disabled toc must not produce a stale-body refusal")
+	got := string(out)
+	assert.NotContains(t, got, "<?toc", "markers strip regardless of enabled state")
+	// On-disk body kept verbatim — the wrong link survives, but no diag.
+	assert.Contains(t, got, "- [Wrong](#wrong)")
+}
+
+func TestExport_FixMode_DisabledDirective_NotRegenerated(t *testing.T) {
+	// In Fix mode with toc disabled, the stale body should NOT be
+	// regenerated (the rule isn't in the active set), but its markers
+	// still get stripped on the way out.
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.Fix, rulesExcept("toc"))
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?toc")
+	// Stale body survives because Fix didn't touch it.
+	assert.Contains(t, got, "- [Wrong](#wrong)")
+}
+
 func TestExport_FixMode_StaleBody_Regenerates(t *testing.T) {
 	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.Fix)
+	out, diags := export.Export(f, export.Fix, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	assert.NotContains(t, got, "<?toc")
@@ -175,7 +231,7 @@ func TestExport_NoCheckMode_StaleBody_ExportsAsIs(t *testing.T) {
 	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.NoCheck)
+	out, diags := export.Export(f, export.NoCheck, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	assert.NotContains(t, got, "<?toc")
@@ -208,7 +264,7 @@ func TestExport_Catalog_MarkersRemoved_BodyKept(t *testing.T) {
 		"beta.md":  &fstest.MapFile{Data: []byte("---\ntitle: Beta\n---\n# Beta\n")},
 	}
 
-	out, diags := export.Export(f, export.Check)
+	out, diags := export.Export(f, export.Check, allRules())
 	require.Empty(t, diags, "fresh catalog should pass Check")
 	got := string(out)
 	assert.NotContains(t, got, "<?catalog")
@@ -223,7 +279,7 @@ func TestExport_FullSourceIncludesFrontMatter(t *testing.T) {
 	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
 	require.NoError(t, err)
 
-	out, diags := export.Export(f, export.Check)
+	out, diags := export.Export(f, export.Check, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	// Front matter is preserved exactly.
@@ -253,7 +309,7 @@ func TestExport_FreshOutputPassesCheck(t *testing.T) {
 	}, "\n")
 	f := newFile(t, "doc.md", src)
 
-	out, diags := export.Export(f, export.Fix)
+	out, diags := export.Export(f, export.Fix, allRules())
 	require.Empty(t, diags)
 	got := string(out)
 	// No directive markers.
@@ -271,7 +327,7 @@ func TestExport_NoDirectives_FullSource(t *testing.T) {
 	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
 	require.NoError(t, err)
 
-	out, diags := export.Export(f, export.Check)
+	out, diags := export.Export(f, export.Check, allRules())
 	require.Empty(t, diags)
 	assert.Equal(t, src, string(out),
 		"export of a directive-free file should equal the input")
@@ -285,7 +341,7 @@ func TestExport_CheckMode_StaleBody_DiagnosticLine_IncludesFrontmatterOffset(t *
 	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
 	require.NoError(t, err)
 
-	out, diags := export.Export(f, export.Check)
+	out, diags := export.Export(f, export.Check, allRules())
 	assert.Nil(t, out)
 	require.NotEmpty(t, diags)
 	assert.Equal(t, 6, diags[0].Line,
@@ -320,7 +376,7 @@ func TestExport_CheckMode_SuppressesDiagnosticsInsideGeneratedRange(t *testing.T
 	// not responsible for staleness within that range.
 	f.GeneratedRanges = []lint.LineRange{{From: 6, To: 10}}
 
-	out, diags := export.Export(f, export.Check)
+	out, diags := export.Export(f, export.Check, allRules())
 	// Outer include itself is stale (its body should be `snippet
 	// body\n`), so the export still refuses — but the diagnostic
 	// points at the include marker, not at the suppressed inner toc.
@@ -330,4 +386,95 @@ func TestExport_CheckMode_SuppressesDiagnosticsInsideGeneratedRange(t *testing.T
 		assert.NotEqual(t, "toc", d.RuleName,
 			"diagnostics inside a GeneratedRange should be suppressed: %+v", d)
 	}
+}
+
+func TestExport_FixMode_FreshFile_DoesNotInvokeFix(t *testing.T) {
+	// In Fix mode, when every directive is already fresh, the
+	// underlying rule.Fix should NOT be called — the gate is "only
+	// call Fix when Check fires". countingFixable wraps a real
+	// directive rule to count Fix invocations.
+	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	wrappers := wrapDirectives(allRules())
+	out, diags := export.Export(f, export.Fix, wrappers.rules)
+	require.Empty(t, diags)
+	require.NotNil(t, out)
+
+	tocFixCount := wrappers.fixCalls("toc")
+	assert.Equal(t, 0, tocFixCount,
+		"a fresh toc body must not invoke Fix (got %d calls)", tocFixCount)
+}
+
+func TestExport_OnlyDirectives_OutputCollapsesToEmpty(t *testing.T) {
+	// A file containing only markerless directives — and nothing else
+	// once they're stripped — exercises the empty-output branch of
+	// normalizeBlankLines so it does not insert a stray "\n" on output.
+	src := "<?allow-empty-section?>\n\n<?require\nfilename: \"*.md\"\n?>\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	assert.Empty(t, out, "all-directive file should normalise to empty output, got %q", string(out))
+}
+
+func TestExport_NormalizeBlankLines_EmptyInput(t *testing.T) {
+	// A file that is empty bytes returns empty bytes unchanged —
+	// guards normalizeBlankLines' fast-path.
+	src := ""
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	assert.Empty(t, string(out))
+}
+
+func TestExport_CheckMode_WarningSeverity_DoesNotRefuse(t *testing.T) {
+	// checkStaleness only treats Error-severity diagnostics as
+	// blocking. A Warning (e.g. catalog case-mismatch / injection
+	// hints) must not turn into a refusal. The countingDirective
+	// here returns a fresh body PLUS a warning, simulating that
+	// non-blocking case.
+	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	rules := wrapDirectives(allRules())
+	tocWrapper := rules.wrappers["toc"]
+	require.NotNil(t, tocWrapper)
+	tocWrapper.injectWarning = true
+
+	out, diags := export.Export(f, export.Check, rules.rules)
+	require.Empty(t, diags, "a Warning-severity diagnostic must not refuse")
+	require.NotNil(t, out)
+	assert.NotContains(t, string(out), "<?toc")
+}
+
+func TestExport_FixMode_StaleBody_InvokesFixForThatDirectiveOnly(t *testing.T) {
+	// Same gate, opposite direction: when toc is stale, its Fix must
+	// run; an unrelated, fresh directive's Fix must not.
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"<?toc?>",
+		"",
+		"- [Wrong](#wrong)",
+		"",
+		"<?/toc?>",
+		"",
+		"<?allow-empty-section?>",
+		"",
+		"## Section",
+		"",
+		"body",
+		"",
+	}, "\n")
+	f := newFile(t, "doc.md", src)
+
+	wrappers := wrapDirectives(allRules())
+	out, diags := export.Export(f, export.Fix, wrappers.rules)
+	require.Empty(t, diags)
+	require.NotNil(t, out)
+
+	assert.GreaterOrEqual(t, wrappers.fixCalls("toc"), 1,
+		"stale toc must invoke Fix at least once")
 }

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -182,3 +182,97 @@ func TestExport_NoCheckMode_StaleBody_ExportsAsIs(t *testing.T) {
 	// On-disk body kept verbatim — wrong link survives.
 	assert.Contains(t, got, "- [Wrong](#wrong)")
 }
+
+func TestExport_Catalog_MarkersRemoved_BodyKept(t *testing.T) {
+	// A fresh catalog body is kept as-is once the markers are
+	// stripped. The catalog directive needs an FS to discover files
+	// for its glob, so wire a fake one.
+	src := strings.Join([]string{
+		"# Index",
+		"",
+		"<?catalog",
+		"glob:",
+		"  - \"*.md\"",
+		"  - \"!index.md\"",
+		"sort: filename",
+		"row: \"- [{title}]({filename})\"",
+		"?>",
+		"- [Alpha](alpha.md)",
+		"- [Beta](beta.md)",
+		"<?/catalog?>",
+		"",
+	}, "\n")
+	f := newFile(t, "index.md", src)
+	f.FS = fstest.MapFS{
+		"alpha.md": &fstest.MapFile{Data: []byte("---\ntitle: Alpha\n---\n# Alpha\n")},
+		"beta.md":  &fstest.MapFile{Data: []byte("---\ntitle: Beta\n---\n# Beta\n")},
+	}
+
+	out, diags := export.Export(f, export.Check)
+	require.Empty(t, diags, "fresh catalog should pass Check")
+	got := string(out)
+	assert.NotContains(t, got, "<?catalog")
+	assert.NotContains(t, got, "<?/catalog")
+	assert.Contains(t, got, "- [Alpha](alpha.md)")
+	assert.Contains(t, got, "- [Beta](beta.md)")
+	assert.Contains(t, got, "# Index")
+}
+
+func TestExport_FullSourceIncludesFrontMatter(t *testing.T) {
+	src := "---\ntitle: Doc\n---\n# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
+	require.NoError(t, err)
+
+	out, diags := export.Export(f, export.Check)
+	require.Empty(t, diags)
+	got := string(out)
+	// Front matter is preserved exactly.
+	assert.True(t, strings.HasPrefix(got, "---\ntitle: Doc\n---\n"),
+		"expected front matter prefix, got: %q", got[:30])
+	assert.NotContains(t, got, "<?toc")
+	assert.Contains(t, got, "- [Section](#section)")
+}
+
+func TestExport_FreshOutputPassesCheck(t *testing.T) {
+	// After Fix-mode export, the bytes should not contain any
+	// directive markers, and the result should be a clean Markdown
+	// document with no MDS003/MDS010 stitching artifacts.
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"<?toc?>",
+		"",
+		"- [Wrong](#wrong)",
+		"",
+		"<?/toc?>",
+		"",
+		"## Section",
+		"",
+		"body",
+		"",
+	}, "\n")
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.Fix)
+	require.Empty(t, diags)
+	got := string(out)
+	// No directive markers.
+	assert.NotContains(t, got, "<?")
+	// No 2+ consecutive blank lines.
+	assert.NotContains(t, got, "\n\n\n",
+		"output should not contain runs of multiple blank lines")
+	// Ends with exactly one newline.
+	assert.True(t, strings.HasSuffix(got, "\n"))
+	assert.False(t, strings.HasSuffix(got, "\n\n"))
+}
+
+func TestExport_NoDirectives_FullSource(t *testing.T) {
+	src := "---\nid: 1\n---\n# Hello\n\nNo directives here.\n"
+	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
+	require.NoError(t, err)
+
+	out, diags := export.Export(f, export.Check)
+	require.Empty(t, diags)
+	assert.Equal(t, src, string(out),
+		"export of a directive-free file should equal the input")
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -276,3 +276,58 @@ func TestExport_NoDirectives_FullSource(t *testing.T) {
 	assert.Equal(t, src, string(out),
 		"export of a directive-free file should equal the input")
 }
+
+func TestExport_CheckMode_StaleBody_DiagnosticLine_IncludesFrontmatterOffset(t *testing.T) {
+	// Front matter occupies lines 1-3; the stale <?toc?> sits at
+	// file-relative line 6. The returned diagnostic must point at
+	// the file-relative line so the CLI prints a navigable location.
+	src := "---\nid: 1\n---\n# Hello\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
+	require.NoError(t, err)
+
+	out, diags := export.Export(f, export.Check)
+	assert.Nil(t, out)
+	require.NotEmpty(t, diags)
+	assert.Equal(t, 6, diags[0].Line,
+		"diagnostic line should be file-relative (include the 3-line front matter)")
+}
+
+func TestExport_CheckMode_SuppressesDiagnosticsInsideGeneratedRange(t *testing.T) {
+	// An inner toc body inside an outer include's body is not the
+	// host file's responsibility: the host file's GeneratedRanges
+	// cover the include body, and any directive diagnostic anchored
+	// there must be suppressed (matching `mdsmith check`).
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"<?include",
+		"file: snippet.md",
+		"?>",
+		"<?toc?>",
+		"",
+		"- [Wrong](#wrong)",
+		"",
+		"<?/toc?>",
+		"<?/include?>",
+		"",
+	}, "\n")
+	f := newFile(t, "doc.md", src)
+	f.FS = fstest.MapFS{
+		"snippet.md": &fstest.MapFile{Data: []byte("snippet body\n")},
+	}
+	// Pretend the include body covers lines 6-10 (the lines that hold
+	// the stale inner <?toc?> ... <?/toc?> markers); the host file is
+	// not responsible for staleness within that range.
+	f.GeneratedRanges = []lint.LineRange{{From: 6, To: 10}}
+
+	out, diags := export.Export(f, export.Check)
+	// Outer include itself is stale (its body should be `snippet
+	// body\n`), so the export still refuses — but the diagnostic
+	// points at the include marker, not at the suppressed inner toc.
+	require.NotEmpty(t, diags)
+	assert.Nil(t, out)
+	for _, d := range diags {
+		assert.NotEqual(t, "toc", d.RuleName,
+			"diagnostics inside a GeneratedRange should be suppressed: %+v", d)
+	}
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -441,6 +441,24 @@ func TestExport_SingleMarkerlessPI_FullyStripped(t *testing.T) {
 	assert.Empty(t, string(out))
 }
 
+func TestExport_UnclosedMarkerlessPI_PreservedAsLiteral(t *testing.T) {
+	// An unclosed PI (`<?foo` without `?>`) is parsed by goldmark
+	// as a PI with HasClosure()==false. piLineRange's no-closure
+	// branch returns start==end. stripDirectives won't pair it
+	// with any directive, so its line passes through to the output
+	// — proving the path is reachable without changing observable
+	// behavior.
+	src := "# Title\n\n<?weird\n\nbody after blank\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	got := string(out)
+	// The "weird" PI line survives (no matching directive in the
+	// registry, no closing marker, so stripDirectives leaves it).
+	assert.Contains(t, got, "body after blank")
+}
+
 func TestExport_TrailingBlankLines_Collapsed(t *testing.T) {
 	// After stripping markers, trailing blank lines beyond the
 	// directive block should be trimmed by normalizeBlankLines'

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -429,6 +429,113 @@ func TestExport_NormalizeBlankLines_EmptyInput(t *testing.T) {
 	assert.Empty(t, string(out))
 }
 
+func TestExport_SingleMarkerlessPI_FullyStripped(t *testing.T) {
+	// A file whose only content is one markerless directive — after
+	// stripping, emitLines produces nil bytes, exercising
+	// normalizeBlankLines' empty-input fast path.
+	src := "<?allow-empty-section?>\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	assert.Empty(t, string(out))
+}
+
+func TestExport_TrailingBlankLines_Collapsed(t *testing.T) {
+	// After stripping markers, trailing blank lines beyond the
+	// directive block should be trimmed by normalizeBlankLines'
+	// trailing-blank loop.
+	src := "<?toc?>\n- foo\n<?/toc?>\n\n\n\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	got := string(out)
+	assert.True(t, strings.HasSuffix(got, "\n"),
+		"output should end with exactly one newline, got %q", got)
+	assert.False(t, strings.HasSuffix(got, "\n\n"),
+		"trailing blank lines should be trimmed, got %q", got)
+}
+
+func TestExport_DirectiveFreeFile_PassesThroughVerbatim(t *testing.T) {
+	// The plan promises that exporting a directive-free file is a
+	// no-op. Quirky whitespace — multiple consecutive blank lines,
+	// no trailing newline — must survive unchanged.
+	src := "# Title\n\n\n\nbody\n\n\n## Section\n\nmore"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	assert.Equal(t, src, string(out),
+		"directive-free files must round-trip byte-for-byte")
+}
+
+func TestExport_PreservesBlankLinesInFencedCodeBlock(t *testing.T) {
+	// A fenced code block with intentional consecutive blank lines
+	// must survive stripping. The Markdown rule MDS008 already
+	// leaves code-block blanks alone; normalizeBlankLines is
+	// expected to behave the same.
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"<?toc?>",
+		"",
+		"- [Section](#section)",
+		"",
+		"<?/toc?>",
+		"",
+		"## Section",
+		"",
+		"```",
+		"line 1",
+		"",
+		"",
+		"line 4 after two blank lines",
+		"```",
+		"",
+	}, "\n")
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	got := string(out)
+	// Markers gone.
+	assert.NotContains(t, got, "<?toc")
+	// Two consecutive blank lines inside the fenced block survive.
+	assert.Contains(t, got, "line 1\n\n\nline 4 after two blank lines",
+		"blank lines inside a fenced code block must not be collapsed; got:\n%s", got)
+}
+
+func TestExport_PreservesBlankLinesInIndentedCodeBlock(t *testing.T) {
+	// Same guarantee for indented code blocks: blank lines that are
+	// part of the block — leading-tab/4-space — should pass through.
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"<?toc?>",
+		"",
+		"- [Section](#section)",
+		"",
+		"<?/toc?>",
+		"",
+		"## Section",
+		"",
+		"prose",
+		"",
+		"    indented line",
+		"",
+		"    still indented after blank",
+		"",
+	}, "\n")
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck, allRules())
+	require.Empty(t, diags)
+	got := string(out)
+	assert.Contains(t, got, "indented line")
+	assert.Contains(t, got, "still indented after blank")
+}
+
 func TestExport_CheckMode_WarningSeverity_DoesNotRefuse(t *testing.T) {
 	// checkStaleness only treats Error-severity diagnostics as
 	// blocking. A Warning (e.g. catalog case-mismatch / injection

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,184 @@
+package export_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/jeduden/mdsmith/internal/export"
+	"github.com/jeduden/mdsmith/internal/lint"
+
+	// Register the production directive rules (toc, catalog, include,
+	// build, …) so export.Export sees them via rule.All().
+	_ "github.com/jeduden/mdsmith/internal/rules/all"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFile builds a *lint.File from a source string for tests that
+// don't need front-matter stripping or a real filesystem.
+func newFile(t *testing.T, path, src string) *lint.File {
+	t.Helper()
+	f, err := lint.NewFile(path, []byte(src))
+	require.NoError(t, err)
+	return f
+}
+
+func TestExport_NoDirectives_Noop(t *testing.T) {
+	src := "# Title\n\nSome content.\n\n## Section\n\nMore content.\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	assert.Equal(t, src, string(out))
+}
+
+func TestExport_TOCMarkers_BodyKept(t *testing.T) {
+	src := "# Title\n\n<?toc?>\n\n- [Title](#title)\n- [Two](#two)\n\n<?/toc?>\n\n## Two\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?toc")
+	assert.NotContains(t, got, "<?/toc")
+	assert.Contains(t, got, "- [Title](#title)")
+	assert.Contains(t, got, "- [Two](#two)")
+}
+
+func TestExport_MarkerlessRequire_Removed(t *testing.T) {
+	src := "---\nid: 1\n---\n<?require\nfilename: \"[0-9]*.md\"\n?>\n\n# Hello\n\nBody.\n"
+	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
+	require.NoError(t, err)
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?require")
+	assert.Contains(t, got, "---\nid: 1\n---")
+	assert.Contains(t, got, "# Hello")
+	assert.Contains(t, got, "Body.")
+}
+
+func TestExport_MarkerlessAllowEmptySection_Removed(t *testing.T) {
+	src := "# Title\n\n## Stub\n\n<?allow-empty-section?>\n\n## Real\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?allow-empty-section?>")
+	assert.Contains(t, got, "## Stub")
+	assert.Contains(t, got, "## Real")
+}
+
+func TestExport_Include_BodyKeptInline(t *testing.T) {
+	// Fresh include body — when stripped, the inlined content remains.
+	src := "# Title\n\n<?include\nfile: snippet.md\n?>\n\nsnippet body\n\n<?/include?>\n\nAfter.\n"
+	f := newFile(t, "doc.md", src)
+	f.FS = fstest.MapFS{
+		"snippet.md": &fstest.MapFile{Data: []byte("snippet body\n")},
+	}
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?include")
+	assert.NotContains(t, got, "<?/include")
+	assert.Contains(t, got, "snippet body")
+	assert.Contains(t, got, "After.")
+}
+
+func TestExport_NestedSameTypeMarkers_LiteralContentSurvives(t *testing.T) {
+	// A balanced inner <?toc?>...<?/toc?> inside an outer <?toc?>
+	// pair is treated by the engine as literal content; only the
+	// outermost markers are removed.
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"<?toc",
+		"min-level: \"2\"",
+		"?>",
+		"- a",
+		"<?toc?>",
+		"- nested literal",
+		"<?/toc?>",
+		"- b",
+		"<?/toc?>",
+		"",
+		"## Section",
+		"",
+	}, "\n")
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	got := string(out)
+	// Outer markers gone.
+	lines := strings.Split(got, "\n")
+	leading := strings.Join(lines[:6], "\n")
+	assert.NotContains(t, leading, "<?toc\nmin-level")
+	// Inner same-type markers preserved as literal content.
+	assert.Contains(t, got, "<?toc?>")
+	assert.Contains(t, got, "<?/toc?>")
+	assert.Contains(t, got, "- nested literal")
+}
+
+func TestExport_Idempotent(t *testing.T) {
+	src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	first, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+
+	f2 := newFile(t, "doc.md", string(first))
+	second, diags := export.Export(f2, export.NoCheck)
+	require.Empty(t, diags)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestExport_CheckMode_StaleBody_Refuses(t *testing.T) {
+	// TOC body should be `- [Section](#section)` but file has wrong text.
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.Check)
+	assert.Nil(t, out, "stale body must produce nil bytes")
+	require.NotEmpty(t, diags)
+	// Diagnostic mentions the offending directive and its location.
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "out of date") && d.RuleName == "toc" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected an 'out of date' diagnostic for toc, got %+v", diags)
+}
+
+func TestExport_FixMode_StaleBody_Regenerates(t *testing.T) {
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.Fix)
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?toc")
+	// Regenerated body links to the actual heading.
+	assert.Contains(t, got, "- [Section](#section)")
+	assert.NotContains(t, got, "Wrong")
+}
+
+func TestExport_NoCheckMode_StaleBody_ExportsAsIs(t *testing.T) {
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	f := newFile(t, "doc.md", src)
+
+	out, diags := export.Export(f, export.NoCheck)
+	require.Empty(t, diags)
+	got := string(out)
+	assert.NotContains(t, got, "<?toc")
+	// On-disk body kept verbatim — wrong link survives.
+	assert.Contains(t, got, "- [Wrong](#wrong)")
+}

--- a/internal/export/wrap_directives_test.go
+++ b/internal/export/wrap_directives_test.go
@@ -1,0 +1,110 @@
+package export_test
+
+import (
+	"github.com/jeduden/mdsmith/internal/archetype/gensection"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+// directiveWrappers couples a real directive rule with call counters
+// so tests can assert that Export gates Fix on Check results without
+// reaching for goroutine-shared state at the package level.
+type directiveWrappers struct {
+	rules     []rule.Rule
+	wrappers  map[string]*countingDirective
+	byOrigPtr map[rule.Rule]*countingDirective
+}
+
+func (w *directiveWrappers) fixCalls(name string) int {
+	c, ok := w.wrappers[name]
+	if !ok {
+		return -1
+	}
+	return c.fixCount
+}
+
+// wrapDirectives replaces every directive rule in src with a
+// countingDirective that delegates to the original implementation
+// while recording Check/Fix invocations.
+func wrapDirectives(src []rule.Rule) *directiveWrappers {
+	w := &directiveWrappers{
+		wrappers:  map[string]*countingDirective{},
+		byOrigPtr: map[rule.Rule]*countingDirective{},
+	}
+	for _, r := range src {
+		fr, fok := r.(rule.FixableRule)
+		d, dok := r.(gensection.Directive)
+		if !fok || !dok {
+			w.rules = append(w.rules, r)
+			continue
+		}
+		cd := &countingDirective{wrapped: r, fix: fr, dir: d}
+		w.wrappers[d.Name()] = cd
+		w.byOrigPtr[r] = cd
+		w.rules = append(w.rules, cd)
+	}
+	return w
+}
+
+// countingDirective forwards every Rule/FixableRule/Directive method
+// to the wrapped implementation while incrementing call counters.
+//
+// The CLI/Export contract treats a wrapper that satisfies both
+// rule.FixableRule and gensection.Directive identically to the rule
+// it wraps, so we can swap one in without registering it.
+type countingDirective struct {
+	wrapped    rule.Rule
+	fix        rule.FixableRule
+	dir        gensection.Directive
+	checkCount int
+	fixCount   int
+	// injectWarning, when true, appends a Warning-severity diagnostic
+	// to whatever the wrapped Check returns. Lets tests assert that
+	// Export's Check mode only refuses on Error severity.
+	injectWarning bool
+}
+
+func (c *countingDirective) ID() string       { return c.wrapped.ID() }
+func (c *countingDirective) Name() string     { return c.wrapped.Name() }
+func (c *countingDirective) Category() string { return c.wrapped.Category() }
+
+func (c *countingDirective) Check(f *lint.File) []lint.Diagnostic {
+	c.checkCount++
+	d := c.wrapped.Check(f)
+	if c.injectWarning {
+		d = append(d, lint.Diagnostic{
+			File:     f.Path,
+			Line:     1,
+			Column:   1,
+			Severity: lint.Warning,
+			RuleID:   c.dir.RuleID(),
+			RuleName: c.dir.RuleName(),
+			Message:  "synthetic warning from countingDirective",
+		})
+	}
+	return d
+}
+
+func (c *countingDirective) Fix(f *lint.File) []byte {
+	c.fixCount++
+	return c.fix.Fix(f)
+}
+
+// gensection.Directive shims.
+
+func (c *countingDirective) RuleID() string   { return c.dir.RuleID() }
+func (c *countingDirective) RuleName() string { return c.dir.RuleName() }
+
+func (c *countingDirective) Validate(
+	filePath string, line int, params map[string]string,
+	columns map[string]gensection.ColumnConfig,
+) []lint.Diagnostic {
+	return c.dir.Validate(filePath, line, params, columns)
+}
+
+func (c *countingDirective) Generate(
+	f *lint.File, filePath string, line int,
+	params map[string]string, columns map[string]gensection.ColumnConfig,
+) (string, []lint.Diagnostic) {
+	return c.dir.Generate(f, filePath, line, params, columns)
+}

--- a/plan/165_portable-markdown-export.md
+++ b/plan/165_portable-markdown-export.md
@@ -1,7 +1,7 @@
 ---
 id: 165
 title: Portable Markdown export (mdsmith export)
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: []
 summary: >-
@@ -151,29 +151,29 @@ modified.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith export <file>` removes every line the
+- [x] `mdsmith export <file>` removes every line the
       engine recognizes as a real directive start/end
       marker, keeps generated bodies, and inlines
       `<?include?>` content. Marker-like text treated as
       literal content is left in place.
-- [ ] The source file is never modified in any mode.
-- [ ] Default mode: a stale directive body makes
+- [x] The source file is never modified in any mode.
+- [x] Default mode: a stale directive body makes
       `export` exit non-zero with a diagnostic naming the
       directive and writes no output.
-- [ ] `--fix` regenerates stale bodies in memory before
+- [x] `--fix` regenerates stale bodies in memory before
       stripping; `--no-check` exports on-disk bytes as-is;
       passing both is a usage error.
-- [ ] Nested same-type literal-content markers are
+- [x] Nested same-type literal-content markers are
       preserved.
-- [ ] Output is idempotent and (when fresh) passes
+- [x] Output is idempotent and (when fresh) passes
       `mdsmith check`.
-- [ ] `-o <path>` writes to a file; stdout is the
+- [x] `-o <path>` writes to a file; stdout is the
       default.
-- [ ] A parse error or missing file exits non-zero with
+- [x] A parse error or missing file exits non-zero with
       a clear message.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
-- [ ] `mdsmith check .` passes
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues
+- [x] `mdsmith check .` passes
 
 ## Decisions
 

--- a/plan/165_portable-markdown-export.md
+++ b/plan/165_portable-markdown-export.md
@@ -1,7 +1,7 @@
 ---
 id: 165
 title: Portable Markdown export (mdsmith export)
-status: "🔲"
+status: "🔳"
 model: opus
 depends-on: []
 summary: >-


### PR DESCRIPTION
Implements the `mdsmith export` subcommand to generate portable, directive-free copies of Markdown files. This fulfills plan #165.

## Summary

The export command strips all mdsmith directive markers (`<?...?>`) from a file while preserving the generated bodies as plain Markdown, making the output renderable by any standard Markdown tool. The source file is never modified.

## Key Changes

- **`internal/export/export.go`**: Core export engine with three staleness modes:
  - `Check` (default): Refuses export if any directive body is stale, returning a diagnostic
  - `Fix`: Regenerates stale bodies in memory before stripping markers
  - `NoCheck`: Skips staleness validation and exports on-disk bytes verbatim
  
- **`cmd/mdsmith/export.go`**: CLI command handler with flags:
  - `-o/--output`: Write to file instead of stdout
  - `--fix`: Regenerate stale bodies before export
  - `--no-check`: Skip staleness check
  - `--config`, `--max-input-size`: Standard mdsmith options

- **Marker stripping logic**:
  - Removes opening/closing markers of paired directives (`<?toc?>`, `<?include?>`, `<?catalog?>`, `<?build?>`)
  - Removes markerless directives (`<?allow-empty-section?>`, `<?require?>`)
  - Preserves marker-like text treated as literal content (e.g., nested same-type markers)
  - Normalizes blank lines and ensures single trailing newline

- **Include inlining**: `<?include?>` bodies are kept verbatim (or regenerated under `--fix`), effectively inlining the included content

- **Front matter handling**: Preserved exactly as-is; line numbers in diagnostics account for front matter offset

- **Generated range suppression**: Diagnostics for directives inside outer `<?include?>` or `<?catalog?>` bodies are suppressed, matching the behavior of `mdsmith check`

## Testing

- **Unit tests** (`internal/export/export_test.go`): 20 test cases covering:
  - No-op on directive-free files
  - Marker removal with body preservation
  - Staleness detection and refusal in Check mode
  - Regeneration in Fix mode
  - Idempotence (exporting an exported file is a no-op)
  - Nested markers and literal content survival
  - Front matter preservation and line offset correctness
  - Generated range suppression

- **E2E tests** (`cmd/mdsmith/e2e_export_test.go`): 13 integration tests covering:
  - CLI flag parsing and mutual exclusivity
  - File I/O and output redirection
  - Staleness modes end-to-end
  - Include directive inlining
  - Idempotence and freshness validation

## Documentation

- **`docs/reference/cli/export.md`**: Complete command reference with staleness modes, examples, and exit codes
- **Plan status**: Marked #165 as complete (✅)
- **CLI help**: Registered `export` command in main help text and catalog

## Notable Implementation Details

- Export is **idempotent**: running it twice on the same file produces identical output
- **Faithful by default**: the Check mode never silently masks drift between a directive and its rendered body
- **Regeneration loop**: Fix mode runs up to 10 passes of directive regeneration until the source stabilizes
- **Blank line normalization**: Collapses consecutive blank lines and ensures stable output that passes `mdsmith check`
- **Diagnostic suppression**: Errors inside GeneratedRanges (outer include/catalog bodies) are suppressed so the host file is only responsible for its own directives

https://claude.ai/code/session_014ykB7MqqiySoWqVKJw4TfT