### PR TITLE
Fix release workflow to use input version instead of git ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -543,4 +543,4 @@ jobs:
       id-token: write
     uses: ./.github/workflows/pages.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary

Updates the GitHub Actions release workflow to pass the workflow input `version` parameter to the pages deployment job, instead of using the git reference name (`github.ref_name`).

## Changes

- Modified `.github/workflows/release.yml` to use `${{ inputs.version }}` instead of `${{ github.ref_name }}` when invoking the pages workflow
- This ensures the pages deployment uses the explicitly provided version input rather than deriving it from the git tag/branch name

## Details

The release workflow now correctly propagates the `version` input parameter through to the pages deployment job. This change aligns with the workflow's input-driven design and ensures version consistency across all deployment steps, particularly important for the website deployment documented in [docs/development/release.md](docs/development/release.md).

https://claude.ai/code/session_01AYvLiLN1S4XG4RgJWUkJXa