### PR TITLE
Fix install panel contrast: clear leaked code-element styling

### DIFF
--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -319,6 +319,10 @@ main {
   font-size: 13.5px;
   white-space: nowrap;
   overflow-x: auto;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  border-radius: 0;
 }
 .install-body {
   padding: 18px 20px;


### PR DESCRIPTION
## Summary
Fix a contrast bug on the homepage install list where each command was
rendered with a cream rectangle behind it on the dark steel-900 panel,
making the light terminal text near-invisible.

## Cause
`website/layouts/partials/install-list.html` wraps each command in
`<code class="install-cmd">`. The global `code` selector in
`website/static/css/colors_and_type.css:281` sets `background:
var(--code-bg)` (cream), a light border, and small padding. The
`.install-row .install-cmd` rule at `website/static/css/app.css:315`
only sized the flex box and did not reset the background, so those
inline-code "chip" defaults leaked through.

The light terminal text colors (`--term-fg: #E6E1D6`) are designed for
the dark `--steel-900` panel — printing them onto the leaked cream
chip produced ~1.16:1 contrast on the args, ~3:1 on the dim `$` prompt.
The shortcode form at `website/layouts/shortcodes/install-cmd.html`
isn't affected because it uses `<div>`.

## Fix
Set `background: transparent; border: 0; padding: 0; border-radius: 0;`
on `.install-row .install-cmd` so the command text sits on the
intended dark panel. Contrast on `--steel-900` is now ~14.8:1 for
args, ~6.7:1 for the labels, ~5.7:1 for the prompt — all pass AA.

## Test plan
- [ ] Visual check of the homepage install list on mdsmith.dev once
      the Pages deploy runs.
- [ ] Confirm `mdsmith check .` still passes (it does — no Markdown
      files touched).

https://claude.ai/code/session_01Peq7vGyvntGAFGDm1WoKun