### PR TITLE
Pin @mdsmith/cli in VS Code extension manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,15 @@ jobs:
           path: ${{ env.bin }}
 
   vscode:
-    needs: [preflight]
+    # `needs: [npm]` is load-bearing, not just for ordering. The
+    # extension's `bun install` step fetches `@mdsmith/cli@<version>`
+    # so build.ts can copy the host-platform binary out of
+    # node_modules/@mdsmith/<plat>/bin/ into dist/bin/ for the
+    # bundled .vsix. That version of @mdsmith/cli does not exist
+    # on npm until the npm job has published it; without this
+    # dependency the install silently no-ops the optionalDep and
+    # the .vsix ships without a binary.
+    needs: [npm]
     runs-on: ubuntu-latest
     # VSCE_PAT and OVSX_PAT are long-lived publisher tokens — see
     # docs/development/release.md for why the `release` environment
@@ -131,6 +139,11 @@ jobs:
       - name: Stamp tracked manifests with the tag
         env:
           VERSION: ${{ env.VERSION }}
+        # Stamp rewrites both the `version` field and the
+        # @mdsmith/cli optionalDependency pin in
+        # editors/vscode/package.json, so the install step below
+        # fetches the freshly-published binary instead of chasing
+        # the 0.0.0-dev sentinel.
         run: go run ./cmd/mdsmith-release stamp "${VERSION#v}"
       - name: Install extension dependencies
         working-directory: editors/vscode
@@ -142,7 +155,14 @@ jobs:
         # radius if a future lockfile update or registry compromise
         # ships a malicious lifecycle script (the TanStack /
         # shai-hulud worm class).
-        run: bun install --frozen-lockfile --ignore-scripts
+        #
+        # No `--frozen-lockfile` here: the Stamp step above just
+        # rewrote the @mdsmith/cli optionalDependency to the
+        # version this run is publishing, so bun.lock is
+        # intentionally out-of-date for that one entry.
+        # `--ignore-scripts` still guards the lifecycle-hook
+        # surface that the shai-hulud / TanStack worm relies on.
+        run: bun install --ignore-scripts
       - name: Run extension unit tests
         working-directory: editors/vscode
         run: bun test

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -320,7 +320,10 @@ func writeFixture(t *testing.T, root string) {
 	files := map[string]string{
 		"editors/vscode/package.json": `{
   "name": "mdsmith",
-  "version": "0.0.0-dev"
+  "version": "0.0.0-dev",
+  "optionalDependencies": {
+    "@mdsmith/cli": "0.0.0-dev"
+  }
 }
 `,
 		"npm/mdsmith/package.json": `{

--- a/docs/development/release-channels/visual-studio-marketplace.md
+++ b/docs/development/release-channels/visual-studio-marketplace.md
@@ -36,3 +36,10 @@ The `vscode` job in `release.yml` calls
 same `.vsix` Open VSX and the GitHub release
 attach. All three artifacts have identical SHA-256
 sums.
+
+The job depends on the `npm` job: the `.vsix`
+bundles the host-platform binary by `bun install`-
+ing `@mdsmith/cli` at the release version, so the
+npm platform packages must publish first. See the
+[release pipeline doc](../release.md#job-topology)
+for the full dependency chain.

--- a/docs/development/release-channels/visual-studio-marketplace.md
+++ b/docs/development/release-channels/visual-studio-marketplace.md
@@ -38,8 +38,9 @@ attach. All three artifacts have identical SHA-256
 sums.
 
 The job depends on the `npm` job: the `.vsix`
-bundles the host-platform binary by `bun install`-
-ing `@mdsmith/cli` at the release version, so the
-npm platform packages must publish first. See the
-[release pipeline doc](../release.md#job-topology)
-for the full dependency chain.
+bundles the host-platform binary by running
+`bun install` against `@mdsmith/cli` at the release
+version, so the npm platform packages must publish
+first. See the [release pipeline
+doc](../release.md#job-topology) for the full
+dependency chain.

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -84,13 +84,13 @@ packages from the root.
 
 ## Job Topology
 
-`build` produces per-platform binaries that fan out
-to `vscode`, `npm`, `pypi`, and `release`. The
-`release` job runs `smoke-test` against the freshly
-published `npm`, `pypi`, and `mise` channels. Every
-job that holds a credential is also gated by
-`if: github.repository == 'jeduden/mdsmith'` and
-runs in the `release` GitHub environment.
+`build` feeds binaries to `npm`, `pypi`, and
+`release`. `vscode` chains off `npm` (the `.vsix`
+bundles the just-published binary). `release` runs
+`smoke-test` against the fresh `npm`, `pypi`, and
+`mise` channels. Every credential-bearing job is
+gated by `if: github.repository == 'jeduden/mdsmith'`
+and runs in the `release` GitHub environment.
 
 The website deploy is a **separate workflow**,
 `.github/workflows/pages.yml`. It builds

--- a/internal/release/version.go
+++ b/internal/release/version.go
@@ -47,12 +47,15 @@ const (
 	ManifestTOML
 )
 
-// Manifest is one tracked file. OptionalDeps marks the npm root
-// — only that file carries @mdsmith/* pins.
+// Manifest is one tracked file. RequiredMdsmithPins lists the
+// @mdsmith/* dependency keys this manifest must declare at the
+// dev sentinel. When non-empty, Stamp rewrites every @mdsmith/*
+// pin found in the file (so a future extra entry stays in sync)
+// and Check verifies each listed key is present at DevSentinel.
 type Manifest struct {
-	Path         string
-	Kind         ManifestKind
-	OptionalDeps bool
+	Path                string
+	Kind                ManifestKind
+	RequiredMdsmithPins []string
 }
 
 // TrackedManifests returns the set of manifests Stamp rewrites
@@ -64,27 +67,34 @@ type Manifest struct {
 // previous local Stamp+BuildNpmPlatforms invocation, a custom
 // staging step) is stamped here too; if the directory is
 // absent the helper just returns the four checked-in manifests.
+//
+// The VS Code extension manifest pins @mdsmith/cli as an
+// optionalDependency so the release-time `bun install` pulls
+// the just-published binary into node_modules and build.ts
+// bundles it into the .vsix. Stamp keeps that pin in lockstep
+// with the release version; without the rewrite, bun would
+// still chase the 0.0.0-dev sentinel and silently skip it.
 func (t *Toolkit) TrackedManifests(root string) []Manifest {
 	out := []Manifest{
-		{filepath.Join(root, "editors", "vscode", "package.json"), ManifestJSON, false},
-		{filepath.Join(root, "npm", "mdsmith", "package.json"), ManifestJSON, true},
+		{filepath.Join(root, "editors", "vscode", "package.json"), ManifestJSON, []string{"@mdsmith/cli"}},
+		{filepath.Join(root, "npm", "mdsmith", "package.json"), ManifestJSON, PlatformPackages},
 	}
 	platformsDir := filepath.Join(root, "npm", "platforms")
 	if entries, err := t.fs.ReadDir(platformsDir); err == nil {
 		for _, e := range entries {
 			p := filepath.Join(platformsDir, e.Name(), "package.json")
 			if _, err := t.fs.Stat(p); err == nil {
-				out = append(out, Manifest{p, ManifestJSON, false})
+				out = append(out, Manifest{p, ManifestJSON, nil})
 			}
 		}
 	}
-	out = append(out, Manifest{filepath.Join(root, "python", "pyproject.toml"), ManifestTOML, false})
+	out = append(out, Manifest{filepath.Join(root, "python", "pyproject.toml"), ManifestTOML, nil})
 	// website/hugo.toml carries the version the deployed
 	// mdsmith.dev site renders in topnav and elsewhere. The
 	// pages-deploy workflow re-runs Stamp before `hugo --minify`
 	// so the site always reflects the release tag rather than
 	// the dev sentinel.
-	out = append(out, Manifest{filepath.Join(root, "website", "hugo.toml"), ManifestTOML, false})
+	out = append(out, Manifest{filepath.Join(root, "website", "hugo.toml"), ManifestTOML, nil})
 	return out
 }
 
@@ -130,8 +140,9 @@ func ValidateSemver(v string) error {
 // Stamp rewrites every tracked manifest under root from the dev
 // sentinel to version. Idempotent: running with the same version
 // twice produces no further change. A required manifest that's
-// missing a version field — or, for the npm root, missing the
-// @mdsmith/* optionalDependencies block — is a hard error.
+// missing a version field — or missing the @mdsmith/*
+// optionalDependencies block on a manifest that declares any
+// RequiredMdsmithPins — is a hard error.
 func (t *Toolkit) Stamp(root, version string) error {
 	if err := ValidateSemver(version); err != nil {
 		return err
@@ -162,7 +173,7 @@ func (t *Toolkit) stampManifest(m Manifest, version string) error {
 	if err != nil {
 		return fmt.Errorf("%s: %w", m.Path, err)
 	}
-	if m.OptionalDeps {
+	if len(m.RequiredMdsmithPins) > 0 {
 		if !jsonOptDepRE.Match(out) {
 			return fmt.Errorf("%s: no @mdsmith/* optionalDependencies pins found", m.Path)
 		}
@@ -229,18 +240,16 @@ func (t *Toolkit) checkManifest(m Manifest, note func(string)) {
 	if string(sub[2]) != DevSentinel {
 		note(fmt.Sprintf("%s: version is %q, want %q", m.Path, sub[2], DevSentinel))
 	}
-	if m.OptionalDeps {
-		for _, key := range PlatformPackages {
-			keyRE := regexp.MustCompile(`(?m)^[ \t]*"` + regexp.QuoteMeta(key) +
-				`"[ \t]*:[ \t]*"([^"]+)"`)
-			kSub := keyRE.FindSubmatch(body)
-			if kSub == nil {
-				note(fmt.Sprintf("%s: optionalDependencies missing key %s", m.Path, key))
-				continue
-			}
-			if string(kSub[1]) != DevSentinel {
-				note(fmt.Sprintf("%s: %s pin %q, want %q", m.Path, key, kSub[1], DevSentinel))
-			}
+	for _, key := range m.RequiredMdsmithPins {
+		keyRE := regexp.MustCompile(`(?m)^[ \t]*"` + regexp.QuoteMeta(key) +
+			`"[ \t]*:[ \t]*"([^"]+)"`)
+		kSub := keyRE.FindSubmatch(body)
+		if kSub == nil {
+			note(fmt.Sprintf("%s: optionalDependencies missing key %s", m.Path, key))
+			continue
+		}
+		if string(kSub[1]) != DevSentinel {
+			note(fmt.Sprintf("%s: %s pin %q, want %q", m.Path, key, kSub[1], DevSentinel))
 		}
 	}
 }

--- a/internal/release/version_test.go
+++ b/internal/release/version_test.go
@@ -24,7 +24,10 @@ func fixtureManifests(t *testing.T, root string) {
 	write("editors/vscode/package.json", `{
   "name": "mdsmith",
   "version": "0.0.0-dev",
-  "publisher": "jeduden"
+  "publisher": "jeduden",
+  "optionalDependencies": {
+    "@mdsmith/cli": "0.0.0-dev"
+  }
 }
 `)
 	write("npm/mdsmith/package.json", `{
@@ -75,6 +78,7 @@ func TestStampRewritesEveryManifest(t *testing.T) {
 		want string
 	}{
 		{"editors/vscode/package.json", `"version": "1.2.3"`},
+		{"editors/vscode/package.json", `"@mdsmith/cli": "1.2.3"`},
 		{"npm/mdsmith/package.json", `"version": "1.2.3"`},
 		{"npm/mdsmith/package.json", `"@mdsmith/linux-x64": "1.2.3"`},
 		{"npm/mdsmith/package.json", `"@mdsmith/win32-x64": "1.2.3"`},
@@ -194,6 +198,25 @@ func TestStampFailsWhenManifestMissing(t *testing.T) {
 	assert.Contains(t, err.Error(), "required manifest missing")
 }
 
+func TestStampFailsWhenVscodeMdsmithCliPinMissing(t *testing.T) {
+	root := t.TempDir()
+	fixtureManifests(t, root)
+	// Drop the optionalDependencies block so the @mdsmith/cli pin
+	// disappears. build.ts bundles the host platform binary via this
+	// pin; without it the .vsix would ship empty.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "editors/vscode/package.json"), []byte(`{
+  "name": "mdsmith",
+  "version": "0.0.0-dev",
+  "publisher": "jeduden"
+}
+`), 0o644))
+
+	err := Stamp(root, "1.2.3")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no @mdsmith/* optionalDependencies")
+}
+
 func TestCheckAcceptsDevSentinel(t *testing.T) {
 	root := t.TempDir()
 	fixtureManifests(t, root)
@@ -209,7 +232,10 @@ func TestCheckRejectsHandEdit(t *testing.T) {
 		filepath.Join(root, "editors/vscode/package.json"), []byte(`{
   "name": "mdsmith",
   "version": "0.1.2",
-  "publisher": "jeduden"
+  "publisher": "jeduden",
+  "optionalDependencies": {
+    "@mdsmith/cli": "0.0.0-dev"
+  }
 }
 `), 0o644))
 
@@ -239,6 +265,47 @@ func TestCheckRejectsOptionalDepDrift(t *testing.T) {
 	err := Check(root)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `@mdsmith/linux-x64 pin "1.2.3"`)
+}
+
+func TestCheckRejectsMissingMdsmithCliPin(t *testing.T) {
+	root := t.TempDir()
+	fixtureManifests(t, root)
+	// editors/vscode/package.json with the @mdsmith/cli pin removed
+	// must fail Check — the release-time bun install relies on this
+	// pin to fetch the bundled binary.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "editors/vscode/package.json"), []byte(`{
+  "name": "mdsmith",
+  "version": "0.0.0-dev",
+  "publisher": "jeduden"
+}
+`), 0o644))
+
+	err := Check(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "@mdsmith/cli")
+}
+
+func TestCheckRejectsDriftedMdsmithCliPin(t *testing.T) {
+	root := t.TempDir()
+	fixtureManifests(t, root)
+	// editors/vscode/package.json carries the dev sentinel on
+	// `version` but a real release on @mdsmith/cli. The version-guard
+	// CI job must surface that mismatch.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "editors/vscode/package.json"), []byte(`{
+  "name": "mdsmith",
+  "version": "0.0.0-dev",
+  "publisher": "jeduden",
+  "optionalDependencies": {
+    "@mdsmith/cli": "1.2.3"
+  }
+}
+`), 0o644))
+
+	err := Check(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `@mdsmith/cli pin "1.2.3"`)
 }
 
 func TestCheckRejectsMissingOptionalDepKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends the release pipeline to track and enforce the `@mdsmith/cli` dependency pin in the VS Code extension's `package.json`. This ensures the extension bundles the correct host-platform binary during the release build.

## Changes

- **Manifest tracking**: Refactored `Manifest` struct to use `RequiredMdsmithPins` (a list of dependency keys) instead of a boolean `OptionalDeps` flag. This allows different manifests to declare which `@mdsmith/*` pins they must maintain.
  - VS Code extension now requires `@mdsmith/cli` pin
  - npm root continues to require all platform packages (`@mdsmith/linux-x64`, etc.)
  - Other manifests (Python, website, platform packages) require no pins

- **Stamp validation**: Updated `stampManifest()` to verify that any manifest declaring `RequiredMdsmithPins` has an `optionalDependencies` block, preventing silent failures where the binary would be missing from the `.vsix`.

- **Check validation**: Updated `checkManifest()` to verify each required pin is present at the dev sentinel (`0.0.0-dev`), catching version drift between the main version field and dependency pins.

- **Test fixtures**: Added `@mdsmith/cli` pin to VS Code extension fixture in both test files, and added three new test cases:
  - `TestStampFailsWhenVscodeMdsmithCliPinMissing`: Ensures Stamp fails if the pin is absent
  - `TestCheckRejectsMissingMdsmithCliPin`: Ensures Check fails if the pin is absent
  - `TestCheckRejectsDriftedMdsmithCliPin`: Ensures Check fails if the pin drifts from dev sentinel

- **Release workflow**: Updated `release.yml` to make the `vscode` job depend on `npm` (not just `preflight`), ensuring platform packages publish before the extension build attempts to `bun install @mdsmith/cli`. Removed `--frozen-lockfile` from the install step since Stamp intentionally rewrites the pin.

- **Documentation**: Updated release pipeline docs to explain the job dependency chain and why the `.vsix` must wait for npm publishing.

## Implementation Details

The refactoring maintains backward compatibility with existing manifest types while enabling per-manifest pin requirements. The `PlatformPackages` constant is now used directly in `TrackedManifests()` rather than being embedded in the manifest definition, making the dependency list explicit and testable.

https://claude.ai/code/session_01KNWawqcSBLqvHYzxp2pFBK