### PR TITLE
Enforce terminal Meta-Information and sync bullets from frontmatter (plan 169)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -95,7 +95,7 @@ footer: |
 | 166 | 🔲     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                              |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
 | 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |
-| 169 | 🔲     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)         |
+| 169 | ✅     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)         |
 | 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                     |
 | 171 | 🔲     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                            |
 | 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                         |

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -408,18 +408,24 @@ title placeholder. `## ...` rows mark wildcard slots.
 Front-matter keys map directly to CUE expressions.
 `<?require?>` declares the filename pattern.
 
-MDS020's file-schema check still routes through
-its legacy parser today: `{field}` in a proto.md
-heading row matches a non-empty run rather than
-resolving the document's frontmatter value via
-`fmvar(...)`. The schema package parses proto.md
-into the new Matcher shape (used by tests), and a
-follow-up plan will wire MDS020 through that
-parser. Until then, treat `{field}` in proto.md
-heading rows as a wildcard placeholder, not as a
-frontmatter substitution. The
+MDS020's file-schema check routes through its
+legacy parser: `{field}` in a proto.md heading row
+matches a non-empty run rather than resolving the
+document's frontmatter value via `fmvar(...)`.
+Heading rows are wildcards, not substitutions.
+
+`{field}` in a proto.md **body** is fully wired:
+MDS020 resolves the placeholder against the
+document's front matter and flags any mismatch.
+`mdsmith fix` rewrites stale body lines to the
+current front-matter value. The rule-readme
+`Meta-Information` body uses this to keep `ID`,
+`Name`, `Status`, and `Category` bullets in sync
+with front matter.
+
+The
 [section-schema reference](../reference/section-schema.md#protomd-file-syntax)
-records the eventual mapping.
+records the heading-row wildcard mapping.
 
 ## Choosing a source
 

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -418,10 +418,12 @@ Heading rows are wildcards, not substitutions.
 MDS020 resolves the placeholder against the
 document's front matter and flags any mismatch.
 `mdsmith fix` rewrites stale body lines to the
-current front-matter value. The rule-readme
-`Meta-Information` body uses this to keep `ID`,
-`Name`, `Status`, and `Category` bullets in sync
-with front matter.
+current front-matter value for files that match a
+**single file-based schema source**. Composed or
+multi-source schemas do not get Fix body rewrites.
+The rule-readme `Meta-Information` body uses this
+to keep `ID`, `Name`, `Status`, and `Category`
+bullets in sync with front matter.
 
 The
 [section-schema reference](../reference/section-schema.md#protomd-file-syntax)

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -255,18 +255,18 @@ schema:
 
 ## `proto.md` file syntax
 
-> **Migration status.** MDS020's file-schema
-> check still uses the legacy `parseSchema`
-> pipeline today: `## ?` and `## ...` already
-> behave as wildcards, and `{field}` in a
-> heading row matches a non-empty run rather
-> than resolving the frontmatter value via
-> `fmvar(...)`. The mapping below is what the
-> schema package parses. Tests exercise it so a
-> follow-up cutover plan can wire MDS020
-> through without docs churn. Until then,
-> proto.md authors should treat `{field}` as a
-> wildcard, not a frontmatter substitution.
+> **Heading rows vs body lines.** In proto.md
+> heading rows, `{field}` matches a non-empty
+> run (wildcard) — it is not resolved against
+> the document's frontmatter. The mapping below
+> shows the equivalent inline entry for each
+> row syntax.
+>
+> In **body lines**, `{field}` is fully wired:
+> MDS020 resolves the placeholder against the
+> document's front matter and flags any mismatch.
+> `mdsmith fix` rewrites stale body lines to the
+> current front-matter value.
 
 Proto.md files use a literal-template surface
 distinct from the inline `regex:` form. Heading

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -255,18 +255,16 @@ schema:
 
 ## `proto.md` file syntax
 
-> **Heading rows vs body lines.** In proto.md
-> heading rows, `{field}` matches a non-empty
-> run (wildcard) — it is not resolved against
-> the document's frontmatter. The mapping below
-> shows the equivalent inline entry for each
-> row syntax.
+> **Heading rows vs body lines.** In heading
+> rows, `{field}` is a wildcard — not resolved
+> against front matter. The table below shows
+> the equivalent inline entry for each row.
 >
 > In **body lines**, `{field}` is fully wired:
-> MDS020 resolves the placeholder against the
-> document's front matter and flags any mismatch.
-> `mdsmith fix` rewrites stale body lines to the
-> current front-matter value.
+> MDS020 checks each placeholder against front
+> matter and `mdsmith fix` rewrites stale lines
+> for a **single file-based schema source**.
+> Composed schemas skip the Fix body rewrite.
 
 Proto.md files use a literal-template surface
 distinct from the inline `regex:` form. Heading

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -69,6 +69,10 @@ Body text.
 
 <?/include?>
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS003
@@ -79,7 +83,3 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -102,6 +102,10 @@ Some content here.
 | `first line should be a level {level} heading, found blank line` | First child is a heading but preceded by blank line |
 | `first heading should be level {level}, got {n}`                 | First heading on line 1 has the wrong level         |
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS004
@@ -112,7 +116,3 @@ Some content here.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -67,6 +67,10 @@ This is a normal paragraph.
 
 <?/include?>
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS018
@@ -77,7 +81,3 @@ This is a normal paragraph.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -343,6 +343,11 @@ Hints fire on string disjunctions (Levenshtein ≤ 2 of a valid
 literal) and integer ranges (nearest bound when just outside).
 Other shapes get no hint.
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+- [Schema field types](../../../docs/reference/schema-types.md)
+
 ## Meta-Information
 
 - **ID**: MDS020
@@ -354,8 +359,3 @@ Other shapes get no hint.
 - **Guide**:
   [directive guide](../../../docs/guides/directives/enforcing-structure.md)
 - **Category**: structural
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
-- [Schema field types](../../../docs/reference/schema-types.md)

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -83,6 +83,10 @@ The implementation of concurrent distributed systems requires sophisticated unde
 
 <?/include?>
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS023
@@ -93,7 +97,3 @@ The implementation of concurrent distributed systems requires sophisticated unde
 - **Implementation**:
   [source](./)
 - **Category**: prose
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -79,6 +79,10 @@ Dogs bark. Cats meow. Birds sing. Fish swim. Frogs croak. Snakes hiss. Bees buzz
 | too many sentences | `paragraph has too many sentences (8 > 6)` |
 | sentence too long  | `sentence too long (45 > 40 words)`        |
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS024
@@ -89,7 +93,3 @@ Dogs bark. Cats meow. Birds sing. Fish swim. Frogs croak. Snakes hiss. Bees buzz
 - **Implementation**:
   [source](./)
 - **Category**: prose
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -122,6 +122,10 @@ See [guide](bad/ref/guide.md#missing-section).
 | missing file    | broken link target "x.md" not found                              |
 | missing heading | broken link target "x.md#section" has no matching heading anchor |
 
+## See also
+
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS027
@@ -132,7 +136,3 @@ See [guide](bad/ref/guide.md#missing-section).
 - **Implementation**:
   [source](./)
 - **Category**: link
-
-## See also
-
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/MDS051-single-h1/README.md
+++ b/internal/rules/MDS051-single-h1/README.md
@@ -85,6 +85,12 @@ title: My Doc
 | `extra H1 heading; only one H1 is allowed per file` | A second or later H1 heading exists in the document                                                   |
 | `h1 heading conflicts with front-matter title`      | An H1 heading exists and the front matter contains the configured field with a non-empty string value |
 
+## See also
+
+- [MDS003](../MDS003-heading-increment/) — heading hierarchy (no level skips)
+- [MDS004](../MDS004-first-line-heading/) — first-line heading
+- [MDS005](../MDS005-no-duplicate-headings/) — no duplicate heading text
+
 ## Meta-Information
 
 - **ID**: MDS051
@@ -94,9 +100,3 @@ title: My Doc
 - **Fixable**: yes — extra H1s are demoted to H2; front-matter conflicts are not auto-fixed
 - **Implementation**: [source](./)
 - **Category**: heading
-
-## See also
-
-- [MDS003](../MDS003-heading-increment/) — heading hierarchy (no level skips)
-- [MDS004](../MDS004-first-line-heading/) — first-line heading
-- [MDS005](../MDS005-no-duplicate-headings/) — no duplicate heading text

--- a/internal/rules/MDS053-no-unused-link-definitions/README.md
+++ b/internal/rules/MDS053-no-unused-link-definitions/README.md
@@ -114,16 +114,6 @@ double-blank behind. When only the preceding blank line is present (no
 following blank), it is preserved so adjacent paragraphs remain separated.
 Ignored labels are never removed.
 
-## Meta-Information
-
-- **ID**: MDS053
-- **Name**: `no-unused-link-definitions`
-- **Status**: ready
-- **Default**: enabled, ignored-labels: []
-- **Fixable**: yes
-- **Implementation**: [source](./)
-- **Category**: link
-
 ## See also
 
 - [MDS027 cross-file-reference-integrity][mds027]
@@ -133,3 +123,13 @@ Ignored labels are never removed.
 [mds027]: ../MDS027-cross-file-reference-integrity/README.md
 [plan107]: ../../../plan/107_no-reference-style.md
 [plan128]: ../../../plan/128_no-undefined-reference-labels.md
+
+## Meta-Information
+
+- **ID**: MDS053
+- **Name**: `no-unused-link-definitions`
+- **Status**: ready
+- **Default**: enabled, ignored-labels: []
+- **Fixable**: yes
+- **Implementation**: [source](./)
+- **Category**: link

--- a/internal/rules/MDS054-no-undefined-reference-labels/README.md
+++ b/internal/rules/MDS054-no-undefined-reference-labels/README.md
@@ -159,6 +159,13 @@ Reference labels are CommonMark-normalized before lookup: case-folded,
 inner whitespace collapsed, and ends trimmed. `[Foo Bar][BAR]` resolves
 against `[bar]: url`.
 
+## See also
+
+- [MDS027 cross-file-reference-integrity](../MDS027-cross-file-reference-integrity/README.md)
+- [Plan 107: no-reference-style](../../../plan/107_no-reference-style.md)
+- [Plan 129: no-unused-link-definitions](../../../plan/129_no-unused-link-definitions.md)
+- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)
+
 ## Meta-Information
 
 - **ID**: MDS054
@@ -168,10 +175,3 @@ against `[bar]: url`.
 - **Fixable**: no
 - **Implementation**: [source](./)
 - **Category**: link
-
-## See also
-
-- [MDS027 cross-file-reference-integrity](../MDS027-cross-file-reference-integrity/README.md)
-- [Plan 107: no-reference-style](../../../plan/107_no-reference-style.md)
-- [Plan 129: no-unused-link-definitions](../../../plan/129_no-unused-link-definitions.md)
-- [Placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -98,9 +98,7 @@ rules:
 - **Fixable**: no
 - **Implementation**:
   [source](./)
-- **Category**: CATEGORY
-- **Concept**:
-  [NAME](../../../docs/background/concepts/NAME.md)
+- **Category**: {category}
 
 <!-- Bullets in this order: ID, Name, Status, Default, Fixable,
      Implementation, Category, Concept (if applicable).
@@ -109,7 +107,3 @@ rules:
      of the values in ValidCategories. Pick the narrowest that fits;
      drop any category not in this list.
      Delete Concept bullet if not used. -->
-
-## ...
-
-<?allow-empty-section?>

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -101,9 +101,11 @@ rules:
 - **Category**: {category}
 
 <!-- Bullets in this order: ID, Name, Status, Default, Fixable,
-     Implementation, Category, Concept (if applicable).
+     Implementation, Category, and optionally Concept.
      Default may include key settings: "enabled, max: 80".
      Category must match the `category:` front-matter field and one
      of the values in ValidCategories. Pick the narrowest that fits;
      drop any category not in this list.
-     Delete Concept bullet if not used. -->
+     Add a Concept bullet when the rule has a dedicated concept page:
+       - **Concept**: [NAME](../../../docs/background/concepts/NAME.md)
+     Omit the Concept bullet when no concept page applies. -->

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -694,9 +694,6 @@ func resolveBodySyncLine(
 	}
 	expected := resolveFields(sp.BodyText, docFM)
 	re := buildFieldPattern(sp.BodyText)
-	if re == nil {
-		return patchedLine{}, false
-	}
 	for i := startLine - 1; i < endLine && i < len(work); i++ {
 		trimmed := strings.TrimSpace(string(work[i]))
 		if trimmed == expected {
@@ -713,6 +710,8 @@ func resolveBodySyncLine(
 
 // buildFieldPattern compiles a regex that matches a body line whose
 // {field} placeholders have been replaced by any non-empty run.
+// The pattern is always valid: each part is regexp.QuoteMeta'd and
+// joined with ".+", so regexp.MustCompile never panics here.
 func buildFieldPattern(bodyText string) *regexp.Regexp {
 	parts := fieldinterp.SplitOnFields(bodyText)
 	var patBuf strings.Builder
@@ -724,11 +723,7 @@ func buildFieldPattern(bodyText string) *regexp.Regexp {
 		}
 	}
 	patBuf.WriteString("$")
-	re, err := regexp.Compile(patBuf.String())
-	if err != nil {
-		return nil
-	}
-	return re
+	return regexp.MustCompile(patBuf.String())
 }
 
 // composedSchemaForFix returns the same composed *schema.Schema

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -589,10 +589,11 @@ func (r *Rule) checkSingleInlineSchema(f *lint.File, sch *schema.Schema) []lint.
 	return diags
 }
 
-// Fix implements rule.FixableRule. The rule does not modify the
-// document body — it returns f.Source unchanged — but when any
-// configured inline schema (single-source or composed across
-// kinds) declares an `index:` block, Fix emits the JSON
+// Fix implements rule.FixableRule. For single file-based schemas it
+// rewrites body lines whose {field} template matches but whose value
+// disagrees with the document's front matter (body-sync fix). For
+// any configured inline schema (single-source or composed across
+// kinds) that declares an `index:` block, Fix also emits the JSON
 // side-output next to the source file. `mdsmith check` skips the
 // write, preserving check's read-only contract (plan 143).
 //
@@ -608,7 +609,126 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	if err == nil && sch != nil && !sch.IsEmpty() && sch.Index != nil {
 		_ = schema.WriteIndex(f, sch)
 	}
+	sources := r.effectiveSources()
+	if len(sources) == 1 && sources[0].File != "" && !r.isSchemaFileAt(f, sources[0].File) {
+		schData, schPath, loadErr := r.loadSchemaAt(f, sources[0].File)
+		if loadErr == nil {
+			parsedSch, parseErr := parseSchema(schData, schPath, f.MaxInputBytes)
+			if parseErr == nil {
+				docFMRaw, _ := readDocFrontMatterRaw(f)
+				return fixBodySyncIn(f, parsedSch, docFMRaw)
+			}
+		}
+	}
 	return f.Source
+}
+
+// fixBodySyncIn rewrites body lines whose {field} template matches but
+// whose resolved front-matter value disagrees with the document text.
+// It returns f.Source unchanged when no lines need rewriting.
+func fixBodySyncIn(f *lint.File, sch *parsedSchema, docFM map[string]any) []byte {
+	if len(docFM) == 0 || len(sch.SyncPoints) == 0 {
+		return f.Source
+	}
+	docHeadings := extractHeadings(f)
+	work := make([][]byte, len(f.Lines))
+	copy(work, f.Lines)
+	modified := false
+	docIdx := 0
+	for schIdx, req := range sch.Headings {
+		if isSectionWildcard(req) {
+			continue
+		}
+		syncs := sch.SyncPoints[schIdx]
+		if len(syncs) == 0 {
+			_, docIdx = advanceToMatch(req, docHeadings, docIdx)
+			continue
+		}
+		matchedDoc, newIdx := advanceToMatch(req, docHeadings, docIdx)
+		docIdx = newIdx
+		if matchedDoc < 0 {
+			continue
+		}
+		dh := docHeadings[matchedDoc]
+		startLine := dh.Line + 1
+		endLine := len(f.Lines)
+		if matchedDoc+1 < len(docHeadings) {
+			endLine = docHeadings[matchedDoc+1].Line - 1
+		}
+		for _, sp := range syncs {
+			if patchedLine, ok := resolveBodySyncLine(sp, docFM, work, startLine, endLine); ok {
+				work[patchedLine.idx] = patchedLine.val
+				modified = true
+			}
+		}
+	}
+	if !modified {
+		return f.Source
+	}
+	return bytes.Join(work, []byte("\n"))
+}
+
+// patchedLine carries the index and new value for a line that needs rewriting.
+type patchedLine struct {
+	idx int
+	val []byte
+}
+
+// resolveBodySyncLine returns the line index and replacement bytes for sp
+// if the document contains a stale template-match line in [startLine, endLine).
+// ok is false when sp is not a body sync point, the field is missing, the
+// line already matches, or no template-matching line is found.
+func resolveBodySyncLine(
+	sp syncPoint, docFM map[string]any,
+	work [][]byte, startLine, endLine int,
+) (patchedLine, bool) {
+	if !sp.InBody {
+		return patchedLine{}, false
+	}
+	path := fieldinterp.ParseCUEPath(sp.Field)
+	if path == nil {
+		return patchedLine{}, false
+	}
+	if _, err := fieldinterp.ResolvePath(docFM, path); err != nil {
+		return patchedLine{}, false
+	}
+	expected := resolveFields(sp.BodyText, docFM)
+	re := buildFieldPattern(sp.BodyText)
+	if re == nil {
+		return patchedLine{}, false
+	}
+	for i := startLine - 1; i < endLine && i < len(work); i++ {
+		trimmed := strings.TrimSpace(string(work[i]))
+		if trimmed == expected {
+			return patchedLine{}, false // already correct
+		}
+		if re.MatchString(trimmed) {
+			orig := string(work[i])
+			leadLen := len(orig) - len(strings.TrimLeft(orig, " \t"))
+			return patchedLine{idx: i, val: []byte(orig[:leadLen] + expected)}, true
+		}
+	}
+	return patchedLine{}, false
+}
+
+// buildFieldPattern compiles a regex that matches a body line whose
+// {field} placeholders have been replaced by any non-empty run.
+func buildFieldPattern(bodyText string) *regexp.Regexp {
+	parts := fieldinterp.SplitOnFields(bodyText)
+	var patBuf strings.Builder
+	patBuf.WriteString("^")
+	for i, part := range parts {
+		patBuf.WriteString(regexp.QuoteMeta(part))
+		if i < len(parts)-1 {
+			patBuf.WriteString(".+")
+		}
+	}
+	patBuf.WriteString("$")
+	re, err := regexp.Compile(patBuf.String())
+	if err != nil {
+		return nil
+	}
+	return re
 }
 
 // composedSchemaForFix returns the same composed *schema.Schema

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -700,7 +700,7 @@ func resolveBodySyncLine(
 	for i := startLine - 1; i < endLine && i < len(work); i++ {
 		trimmed := strings.TrimSpace(string(work[i]))
 		if trimmed == expected {
-			return patchedLine{}, false // already correct
+			continue // already correct; keep scanning for stale duplicates
 		}
 		if re.MatchString(trimmed) {
 			orig := string(work[i])

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2198,6 +2198,52 @@ func TestFix_BodySync_MultiSource(t *testing.T) {
 	assert.Equal(t, string(f.Source), string(result))
 }
 
+// TestFix_BodySync_WildcardBeforeSection covers the isSectionWildcard
+// branch in fixBodySyncIn: a schema with ## ... before the sync heading.
+func TestFix_BodySync_WildcardBeforeSection(t *testing.T) {
+	schemaPath := writeSchema(t,
+		"# ?\n\n## ...\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\ncategory: structural\n---\n# My Rule\n\n## Optional\n\n## Meta-Information\n\n- **Category**: WRONG\n")
+	result := r.Fix(f)
+	assert.Contains(t, string(result), "- **Category**: structural")
+}
+
+// TestFix_BodySync_RequiredHeadingAbsent covers the matchedDoc < 0
+// branch in fixBodySyncIn: the schema requires a heading with body
+// sync but the document does not contain that heading.
+func TestFix_BodySync_RequiredHeadingAbsent(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	// Doc has no ## Meta-Information heading.
+	src := "---\ncategory: structural\n---\n# My Rule\n"
+	f := newTestFile(t, "doc.md", src)
+	result := r.Fix(f)
+	assert.Equal(t, string(f.Source), string(result))
+}
+
+// TestFix_BodySync_HeadingFollowedByAnother covers the
+// matchedDoc+1 < len(docHeadings) branch: the matched heading is
+// not the last heading in the document.
+func TestFix_BodySync_HeadingFollowedByAnother(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	// Doc has ## Appendix after ## Meta-Information.
+	f := newTestFile(t, "doc.md",
+		"---\ncategory: structural\n---\n# My Rule\n\n## Meta-Information\n\n- **Category**: WRONG\n\n## Appendix\n")
+	result := r.Fix(f)
+	assert.Contains(t, string(result), "- **Category**: structural")
+}
+
+// TestResolveBodySyncLine_NilPath covers the path == nil branch by
+// calling resolveBodySyncLine directly with an empty-string field.
+func TestResolveBodySyncLine_NilPath(t *testing.T) {
+	sp := syncPoint{Field: "", InBody: true, BodyText: "- **Category**: {category}"}
+	_, ok := resolveBodySyncLine(sp, map[string]any{"category": "structural"}, nil, 1, 1)
+	assert.False(t, ok, "empty field should yield ok=false")
+}
+
 // TestIsLikelyArchetypeName_AllBranches gives the helper direct
 // coverage of every branch. Previously it was only exercised
 // indirectly through ApplySettings, so test churn elsewhere

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2075,6 +2075,45 @@ id: 'int & >=1'
 	expectDiagMsg(t, diags, "expected int >= 1")
 }
 
+// =====================================================================
+// plan 169: Meta-Information ordering and body-sync Fix
+// =====================================================================
+
+// TestCheck_SectionAfterMetaInformation_Fails verifies that a section
+// appearing after ## Meta-Information in a schema with no trailing
+// wildcard is flagged as not declared in schema.
+func TestCheck_SectionAfterMetaInformation_Fails(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n")
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"# My Rule\n\n## Meta-Information\n\n## See also\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`## See also: got <present>, expected not declared in schema`)
+}
+
+// TestFix_BodySync_RewritesStaleLine verifies that Fix replaces a body
+// line whose template matches but whose value disagrees with front matter.
+func TestFix_BodySync_RewritesStaleLine(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md",
+		"---\ncategory: structural\n---\n# My Rule\n\n## Meta-Information\n\n- **Category**: WRONG\n")
+	result := r.Fix(f)
+	assert.Contains(t, string(result), "- **Category**: structural")
+}
+
+// TestFix_BodySync_LeavesCorrectLine verifies that Fix does not touch a
+// body line that already matches its front-matter value.
+func TestFix_BodySync_LeavesCorrectLine(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	src := "---\ncategory: structural\n---\n# My Rule\n\n## Meta-Information\n\n- **Category**: structural\n"
+	f := newTestFile(t, "doc.md", src)
+	result := r.Fix(f)
+	assert.Equal(t, string(f.Source), string(result))
+}
+
 // TestIsLikelyArchetypeName_AllBranches gives the helper direct
 // coverage of every branch. Previously it was only exercised
 // indirectly through ApplySettings, so test churn elsewhere

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2114,6 +2114,90 @@ func TestFix_BodySync_LeavesCorrectLine(t *testing.T) {
 	assert.Equal(t, string(f.Source), string(result))
 }
 
+// TestFix_BodySync_SkipsCorrectAndFixesStale verifies that Fix skips a
+// correct template-matching line and continues scanning to patch the
+// subsequent stale duplicate. (Regresses the early-break fix from
+// Copilot review comment on PR #315.)
+func TestFix_BodySync_SkipsCorrectAndFixesStale(t *testing.T) {
+	schemaPath := writeSchema(t,
+		"# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	// Two bullets that match the template: the first is already correct,
+	// the second is stale. Fix must patch the second one.
+	f := newTestFile(t, "doc.md",
+		"---\ncategory: structural\n---\n# My Rule\n\n## Meta-Information\n\n"+
+			"- **Category**: structural\n- **Category**: WRONG\n")
+	result := r.Fix(f)
+	assert.Equal(t, 2, strings.Count(string(result), "- **Category**: structural"),
+		"both bullets should equal the front-matter value after fix")
+}
+
+// TestFix_BodySync_NoFrontMatter verifies that Fix is a no-op when the
+// document has no front matter (empty docFMRaw path).
+func TestFix_BodySync_NoFrontMatter(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	src := "# My Rule\n\n## Meta-Information\n\n- **Category**: WRONG\n"
+	f := newTestFile(t, "doc.md", src)
+	result := r.Fix(f)
+	assert.Equal(t, string(f.Source), string(result))
+}
+
+// TestFix_BodySync_NonBodySyncPoint verifies that a sync point that is
+// NOT in the body (InBody == false, heading sync) does not cause Fix to
+// rewrite any line.
+func TestFix_BodySync_NonBodySyncPoint(t *testing.T) {
+	// Schema has only a heading sync ({id} in the title), no body sync.
+	schemaPath := writeSchema(t, "# {id}: {name}\n")
+	r := &Rule{Schema: schemaPath}
+	src := "---\nid: MDS001\nname: line-length\n---\n# MDS001: line-length\n"
+	f := newTestFile(t, "doc.md", src)
+	result := r.Fix(f)
+	assert.Equal(t, string(f.Source), string(result))
+}
+
+// TestFix_BodySync_MissingField verifies that Fix skips a body sync
+// point whose field is absent from the document's front matter.
+func TestFix_BodySync_MissingField(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	// front matter has no "category" key
+	src := "---\nid: MDS001\n---\n# My Rule\n\n## Meta-Information\n\n- **Category**: WRONG\n"
+	f := newTestFile(t, "doc.md", src)
+	result := r.Fix(f)
+	assert.Equal(t, string(f.Source), string(result))
+}
+
+// TestFix_BodySync_NoMatchingLine verifies that Fix returns f.Source
+// unchanged when the heading is present but no body line matches the
+// field template pattern (e.g., the bullet is formatted differently).
+func TestFix_BodySync_NoMatchingLine(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	r := &Rule{Schema: schemaPath}
+	// Body has a line that does NOT match "- **Category**: .+"
+	src := "---\ncategory: structural\n---\n# My Rule\n\n## Meta-Information\n\nSomething else entirely.\n"
+	f := newTestFile(t, "doc.md", src)
+	result := r.Fix(f)
+	assert.Equal(t, string(f.Source), string(result))
+}
+
+// TestFix_BodySync_MultiSource verifies that Fix does not rewrite body
+// lines when the rule is configured with multiple schema sources
+// (composed schemas skip the Fix body rewrite path).
+func TestFix_BodySync_MultiSource(t *testing.T) {
+	schemaPath := writeSchema(t, "# ?\n\n## Meta-Information\n\n- **Category**: {category}\n")
+	schemaPath2 := writeSchema(t, "# ?\n")
+	r := &Rule{Sources: []SchemaSource{
+		{File: schemaPath},
+		{File: schemaPath2},
+	}}
+	f := newTestFile(t, "doc.md",
+		"---\ncategory: structural\n---\n# My Rule\n\n## Meta-Information\n\n- **Category**: WRONG\n")
+	result := r.Fix(f)
+	// Multi-source: Fix should NOT rewrite the stale line.
+	assert.Equal(t, string(f.Source), string(result))
+}
+
 // TestIsLikelyArchetypeName_AllBranches gives the helper direct
 // coverage of every branch. Previously it was only exercised
 // indirectly through ApplySettings, so test churn elsewhere

--- a/plan/169_rule-readme-meta-information-sync.md
+++ b/plan/169_rule-readme-meta-information-sync.md
@@ -1,7 +1,7 @@
 ---
 id: 169
 title: 'Enforce terminal Meta-Information and render it from frontmatter'
-status: "🔲"
+status: "✅"
 model: opus
 depends-on: [156]
 summary: >-
@@ -82,15 +82,15 @@ Meta-Information case.
 
 ## Acceptance Criteria
 
-- [ ] A rule README with any section after
+- [x] A rule README with any section after
   `## Meta-Information` fails `mdsmith check`.
-- [ ] A stale `ID`, `Name`, `Status`, or `Category`
+- [x] A stale `ID`, `Name`, `Status`, or `Category`
   bullet is flagged and `mdsmith fix` rewrites it
   from front matter.
-- [ ] [internal/rules/proto.md](../internal/rules/proto.md)
+- [x] [internal/rules/proto.md](../internal/rules/proto.md)
   has no trailing wildcard after Meta-Information
   and no `CATEGORY` literal.
-- [ ] All `internal/rules/MDS*/README.md` pass
+- [x] All `internal/rules/MDS*/README.md` pass
   `mdsmith check .`.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no issues.
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no issues.


### PR DESCRIPTION
- Drop trailing ## ... wildcard from internal/rules/proto.md so any
  section after ## Meta-Information fails mdsmith check
- Replace hand-kept CATEGORY literal with {category} placeholder in
  proto.md Meta-Information body
- Implement fixBodySyncIn in MDS020 Fix path: rewrites body lines
  whose {field} template matches but value disagrees with front matter
- Move ## See also sections before ## Meta-Information in ten rule
  READMEs that had content after the terminal section
- Update docs/guides/schemas.md and docs/reference/section-schema.md
  to document wired frontmatter-body {field} sync

https://claude.ai/code/session_0185djJjm6owY8d9JCwsEJas