### PR TITLE
Audit link handling; file follow-up plans (plan 170)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -96,5 +96,8 @@ footer: |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
 | 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |
 | 169 | 🔲     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)         |
-| 170 | 🔲     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                     |
+| 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                     |
+| 171 | 🔲     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                            |
+| 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                         |
+| 173 | 🔲     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                              |
 <?/catalog?>

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ row: "- [{summary}]({filename})"
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 <?/catalog?>
 
+**🔗 Link handling internals.** See:
+<?catalog
+glob:
+  - "docs/research/links/README.md"
+row: "- [{summary}]({filename})"
+?>
+- [Audit of every link surface in mdsmith — the link-aware rules, the linkgraph package, the website rewriter, and the Hugo render-link hook — with a corpus census, a catalogued gap list, a decision per gap, and a sketched shared `links:` config block. Follow-up plans 171–173 cite this doc instead of relitigating the trade-offs.](docs/research/links/README.md)
+<?/catalog?>
+
 ## 📦 Installation
 
 CLI:

--- a/docs/research/links/README.md
+++ b/docs/research/links/README.md
@@ -1,0 +1,331 @@
+---
+summary: >-
+  Audit of every link surface in mdsmith — the link-aware
+  rules, the linkgraph package, the website rewriter, and
+  the Hugo render-link hook — with a corpus census, a
+  catalogued gap list, a decision per gap, and a sketched
+  shared `links:` config block. Follow-up plans 171–173
+  cite this doc instead of relitigating the trade-offs.
+---
+# Link handling audit
+
+This note surveys how mdsmith reads, validates, and
+rewrites Markdown links across the linter, the
+[`linkgraph`](../../../internal/linkgraph/linkgraph.go)
+package, the
+[website rewriter](../../../internal/release/website.go),
+and the
+[Hugo render-link hook](../../../website/layouts/_default/_markup/render-link.html).
+It grounds policy choices in a corpus census, catalogues
+every gap PR #309 surfaced plus the inventory's new ones,
+and records one decision per gap. Implementation is
+deferred to the follow-up plans named in each decision.
+
+## Inventory of link surfaces
+
+One entry per file. "Nodes" lists the goldmark AST node
+kinds the surface walks for links; "URL parts" lists
+which components of the target it inspects.
+
+| Surface                                                                                      | Nodes                                                                      | URL parts                                                                 | What it does                                                                                                                       |
+|----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| MDS012 no-bare-urls (`internal/rules/nobareurls/rule.go`)                                    | `*ast.Text`                                                                | scheme (http/https)                                                       | Flags raw `https?://` in text not already inside a link, autolink, or code; wraps in `<>` on fix.                                  |
+| MDS019 catalog (`internal/rules/catalog/rule.go`)                                            | `<?catalog?>` PI                                                           | none (front-matter fields)                                                | Generates an index list; warns when a templated field value contains a `](` link-injection sequence.                               |
+| MDS021 include (`internal/rules/include/rule.go`)                                            | `<?include?>` PI                                                           | relative file path only                                                   | Resolves the `file:` parameter; rejects absolute paths and `..` escapes; detects cycles.                                           |
+| MDS027 cross-file-reference-integrity (`internal/rules/crossfilereferenceintegrity/rule.go`) | `*ast.Link` with `Reference == nil` only (via `linkgraph.ExtractLinks`)    | relative path, fragment; rejects scheme/host; **short-circuits absolute** | Checks inline link targets exist on disk and that `#anchor` matches a heading.                                                     |
+| MDS032 no-empty-alt-text (`internal/rules/noemptyalttext/rule.go`)                           | `*ast.Image`                                                               | none (alt text only)                                                      | Flags images with empty/whitespace alt text. The **only** rule that walks `*ast.Image`.                                            |
+| MDS035 toc-directive (`internal/rules/tocdirective/rule.go`)                                 | `*ast.Paragraph` text                                                      | none                                                                      | Flags renderer-specific TOC markers (`[TOC]`, `[[toc]]`, `${toc}`).                                                                |
+| MDS037 duplicated-content (`internal/rules/duplicatedcontent/rule.go`)                       | `*ast.Paragraph`                                                           | none                                                                      | Cross-file duplicate-paragraph fingerprinting; skips generated bodies.                                                             |
+| MDS038 toc (`internal/rules/toc/rule.go`)                                                    | headings via `mdtext.CollectTOCItems`                                      | fragment only                                                             | Generates the `<?toc?>` body with GitHub-style `#anchor` links.                                                                    |
+| MDS043 no-reference-style (`internal/rules/noreferencestyle/rule.go`)                        | `*ast.Link`/`*ast.Image` with `Reference != nil`; regex for defs/footnotes | none                                                                      | Flags reference-style links/images and footnote refs.                                                                              |
+| MDS049 no-space-in-link-text (`internal/rules/nospaceinlinktext/rule.go`)                    | `*ast.Link`, `*ast.Image`                                                  | none (bracket whitespace)                                                 | Flags leading/trailing space inside `[...]`.                                                                                       |
+| MDS053 no-unused-link-definitions (`internal/rules/nounusedlinkdefinitions/rule.go`)         | `*ast.Link`/`*ast.Image` with `Reference != nil`; regex for defs           | none                                                                      | Flags unused/duplicate `[label]:` definitions.                                                                                     |
+| MDS054 no-undefined-reference-labels (`internal/rules/noundefinedreferencelabels/rule.go`)   | regex on source (no AST link walk)                                         | none                                                                      | Flags reference links/images whose label has no definition.                                                                        |
+| `linkgraph.ExtractLinks` (`internal/linkgraph/linkgraph.go`)                                 | `*ast.Link` with `Reference == nil` only                                   | path, fragment; rejects scheme/host/`//`                                  | The shared inline-link extractor. **Skips images, autolinks, and reference-style links by design.**                                |
+| `linkgraph.ExtractRefLinks` (`internal/linkgraph/refs.go`)                                   | `*ast.Link` with `Reference != nil`                                        | normalized label only                                                     | Complements `ExtractLinks` for ref-style links; **not consumed by MDS027 today**.                                                  |
+| `astutil` (`internal/rules/astutil/astutil.go`)                                              | block nodes only                                                           | none                                                                      | Heading/paragraph text helpers; no link walking.                                                                                   |
+| Website rewriter (`internal/release/website.go`)                                             | inline `](...)` and `[label]: ...` defs via ~9 regexes                     | path, fragment; **not titles, not images**                                | Sync-time rewrite of repo-relative `.md` paths to site-absolute or GitHub URLs; guarded by `applyOutsideCode`.                     |
+| Hugo render-link hook (`website/layouts/_default/_markup/render-link.html`)                  | all rendered links                                                         | path, fragment, site prefix                                               | Resolves source-relative `.md` via `GetPage`, strips `index.md`/`_index.md`, reattaches fragment, applies non-root baseURL prefix. |
+| `mdsmith list backlinks` (`cmd/mdsmith/backlinks.go`)                                        | `*ast.Link` via `ExtractLinks`                                             | resolved path                                                             | Lists workspace links pointing at a file; inherits all `ExtractLinks` blind spots.                                                 |
+
+The recurring theme: `*ast.Link` (inline only) is the
+well-trodden path. `*ast.Image`, `*ast.AutoLink`,
+reference-style links, absolute paths, and link titles
+are each understood by at most one isolated surface, and
+the shared `linkgraph.ExtractLinks` — the spine of
+MDS027 and backlinks — sees none of them.
+
+## Corpus census
+
+Counts over `docs/` (72 files, research/security excluded
+from this census), `plan/` (82), `internal/rules/MDS*/`
+READMEs (60), and root `README.md`. Approximate, derived
+from ripgrep over each corpus; the point is the
+distribution, not the exact integer.
+
+| Metric                    | Docs | Plan | Rules | README |
+|---------------------------|------|------|-------|--------|
+| Inline links              | 274  | 330  | 159   | 42     |
+| Reference-style uses      | 146  | 99   | 14    | 3      |
+| Reference definitions     | 147  | 51   | 14    | 6      |
+| Relative `../` targets    | 140  | 271  | 103   | 0      |
+| Relative same-dir targets | 59   | 23   | 0     | 0      |
+| Absolute `/root` targets  | 2    | 0    | 0     | 0      |
+| External http(s)          | 16   | 8    | 6     | 1      |
+| Fragment-only (`#x`)      | 3    | 9    | 11    | 0      |
+| `.md#anchor` targets      | 12   | 3    | 3     | 0      |
+| Links with a title        | 0    | 1    | 0     | 0      |
+| Images                    | 0    | 0    | 1     | 1      |
+| Empty alt text            | 0    | 0    | 1     | 0      |
+| Autolinks `<...>`         | 4    | 3    | 1     | 0      |
+| Mailto                    | 0    | 0    | 0     | 0      |
+
+Reading the data:
+
+- **Style is split, not consistent.** `docs/` is ~50%
+  reference-style; `plan/` and rule READMEs are
+  overwhelmingly inline. There is no project-wide
+  relative-vs-absolute or inline-vs-reference
+  convention, and the two styles are mixed within the
+  same doc set.
+- **Internal links are relative.** Absolute-from-root
+  targets are nearly nonexistent in source (2 in all of
+  `docs/`); the site-absolute form only appears *after*
+  the rewriter runs — exactly the form MDS027
+  short-circuits.
+- **Extensionless internal links exist.** 59 same-dir
+  `foo.md`-style targets in `docs/` versus 0 in rule
+  READMEs (which are pure `../`), so an extension policy
+  would not be a no-op.
+- **Titles and images are effectively unused in
+  published source** (0 titled links in `docs/`, 0
+  images in `docs/`/`plan/`). The gaps are real but the
+  blast radius today is small.
+
+## Gap catalogue and decisions
+
+Each gap: the surface, an observed example, what mdsmith
+emits today, what it should emit, the site breakage if
+left open, and the decision — (a) new rule, (b) extend an
+existing rule, (c) rewriter change, (d) render-time
+change, or (e) deliberately not addressed.
+
+### G1 — MDS027 ignores `*ast.Image`
+
+`ExtractLinks` walks only `*ast.Link`, so
+`![diagram](missing.png)` is never resolved. Today:
+silent pass. Should: same broken-target diagnostic as a
+text link. Site breakage: a 404 image ships to
+mdsmith.dev with no lint signal. **Decision: (b)** —
+extend MDS027 via a `validate-images` toggle (default
+on). Images and links share resolution logic; a separate
+rule would duplicate `ParseTarget`. Plan 171.
+
+### G2 — MDS027 short-circuits absolute paths
+
+`[x](/docs/rules/MDS027/)` returns early because
+`ParseTarget` rejects a non-empty path that looks
+rooted. Today: silent pass. Should: resolve against a
+configured site root and verify the page exists.
+Breakage: the rewriter's own output (site-absolute) is
+the one form the synced-tree lint cannot validate — a
+broken rewrite is invisible until a human clicks the
+link. **Decision: (b)** — extend MDS027 with an optional
+`site-root:` so absolute targets resolve to a workspace
+path. Off when unset, preserving today's behavior. Plan
+171.
+
+### G3 — linkgraph skips reference-style links
+
+`ExtractLinks` filters `Reference == nil`, so a broken
+`[a]` whose `[a]: ./gone.md` def points nowhere
+survives. `ExtractRefLinks` exists but nothing wires it
+into MDS027. Today: silent pass. Should: resolve
+ref-style targets like inline ones. Breakage: a broken
+ref-def ships. **Decision: (b)** — feed
+`ExtractRefLinks` results through the same resolver in
+MDS027. Plan 171.
+
+### G4 — Rewriter ignored Hugo baseURL
+
+PR #309's first cut hardcoded `/docs/rules/…`, breaking
+a non-root Pages deploy. **Decision: (e), already
+resolved.** The render-link hook now derives the prefix
+from `site.Home.RelPermalink`. Recorded here so a future
+reader does not refile it; Plan 171 adds a regression
+test asserting the prefix under a subpath baseURL.
+
+### G5 — Source-vs-rendered URL depth
+
+`../reference/globs.md` from `docs/guides/file-kinds.md`
+would resolve one level too shallow if emitted
+literally. **Decision: (e), already resolved.** The
+render-link hook calls Hugo `GetPage`, which returns the
+target's absolute permalink and absorbs the rendering
+depth. The audit confirms the PR #309 split (see G7).
+
+### G6 — Titled links unmatched by rewriter
+
+`[x](../y.md "title")` is not matched by any rewriter
+regex (`\S+` stops at the space before the title), so it
+would ship as a dead repo-relative path. Corpus: 0 in
+`docs/`, 1 in `plan/` (unpublished). Today: passes the
+rewriter unchanged. Should: rewrite path, preserve
+title. **Decision: (c)**, low priority — widen the
+rewriter regexes to capture an optional
+`(\s+"[^"]*")?` tail and re-emit it. Plan 173.
+
+### G7 — index.md / _index.md / trailing slash split
+
+PR #309 splits this: the **rewriter** drops a trailing
+`index.md` to a directory path and keeps synced files
+filesystem-valid for MDS027; the **render-link hook**
+strips `index.md`/`_index.md` and normalizes the
+trailing slash at render time using Hugo's content tree.
+**Decision: (e), confirm the split.** It is correct:
+basename-to-slug transforms depend on Hugo's tree, which
+the regex rewriter cannot see, while MDS027 needs the
+on-disk filename intact. Reversing it would either break
+the synced-tree lint or duplicate Hugo's routing in Go.
+No change; documented so the next PR does not re-derive
+it.
+
+### G8 — No link-style consistency rule
+
+Mixed relative/absolute, `.md`/extensionless, and
+inline/reference within one doc set (census: `docs/` is
+~50% reference-style, rule READMEs ~0%). Today: no
+signal. Should: an opt-in rule flags deviation from a
+per-kind declared style. **Decision: (a)** — new opt-in
+rule `link-style` reading the shared `links:` block
+(below). Plan 172.
+
+### G9 — Heading-anchor stability across renderers
+
+CommonMark, GFM, and goldmark-with-attributes normalize
+heading slugs differently, so an anchor valid under one
+renderer 404s under another. **Decision: (e), not
+addressed.** mdsmith already commits to goldmark as the
+single anchor authority (MDS038 generates GitHub-style
+slugs and MDS027 checks against the same computation).
+Multi-renderer anchor portability has no concrete user
+and would fork the anchor model. Revisit only if a
+convention targets a non-goldmark flavor.
+
+### G10 — Wiki-style `[[target]]` links
+
+Not parsed by goldmark's default extensions; invisible
+to every surface. **Decision: (e), deferred to
+[plan 168](../../../plan/168_obsidian-markdown-support.md).**
+Wikilink validation is in scope for the Obsidian
+convention there (extended MDS027 settings); duplicating
+it here would pre-empt that design.
+
+### G11 — Redirects / aliases for renamed pages
+
+A renamed page breaks inbound links with no mdsmith
+signal. **Decision: (e), out of linter scope.** Hugo
+`aliases` front matter handles published redirects;
+in-repo, this is a rename-refactor concern (LSP rename
+already rewrites workspace links). No rule; recorded so
+it is not refiled as a lint gap.
+
+### G12 — Cross-repo references
+
+`@mdsmith/cli` → another mdsmith-managed repo cannot be
+resolved on the local filesystem. **Decision: (e),
+deferred, no concrete need.** No current doc links
+cross-repo by package name; revisit when a multi-repo
+workspace exists. Listed for completeness.
+
+### G13 — Issue #47 external URL HTTP probing
+
+[Issue #47](https://github.com/jeduden/mdsmith/issues/47)
+proposes HTTP-checking external URLs. **Decision: (a),
+standalone opt-in rule, not the MDS027 family.** MDS027
+is a pure, offline, deterministic filesystem check;
+folding network I/O into it would make every CI run
+network-bound and flaky. A separate off-by-default rule
+(`external-link-check`) with skip patterns, caching, and
+a timeout keeps offline CI fast and the failure modes
+isolated. Tracked by issue #47; Plan 172 carries the
+shared skip-pattern config it depends on, so the rule
+lands on a config foundation rather than inventing its
+own.
+
+## Sketched `links:` config block
+
+Design only — no parser changes in this audit. A shared
+block under `.mdsmith.yml`, deep-merged per kind like
+every other rule config, consumed by MDS027 (G1–G3) and
+the new `link-style` rule (G8), and supplying the skip
+list issue #47's rule (G13) reuses:
+
+```yaml
+links:
+  # G2: resolve absolute targets against this workspace
+  # path; unset preserves today's short-circuit.
+  site-root: ""
+
+  # G1: validate *ast.Image targets like text links.
+  validate-images: true
+
+  # G3: resolve reference-style targets too.
+  validate-reference-style: true
+
+  # G8: preferred styles; flagged only by the opt-in
+  # link-style rule, overridable per kind.
+  style:
+    path: relative        # relative | absolute
+    extension: keep        # keep | strip   (.md suffix)
+    form: any              # any | inline | reference
+
+  # G13: regexes for external URLs the (separate,
+  # opt-in) HTTP-check rule must skip.
+  external-skip:
+    - '^https?://localhost'
+```
+
+Per-kind override example: rule READMEs are pure `../`
+inline, so a `rule-readme` kind could pin
+`style.form: inline`; `docs` could stay `form: any`
+until the corpus is migrated.
+
+## MDS027: extend vs split
+
+**Decision: extend MDS027** for G1 (images), G2
+(absolute-against-site-root), and G3 (ref-style),
+gated by the `links:` toggles. Rationale: all three are
+the same operation — "does this target resolve?" — over
+a wider node set and a configurable root. The gomarklint
+precedent in
+[learn-from-mdbase](../mdbase-vs-mdsmith/learn-from-mdbase.md)
+keeps file-integrity unified rather than fragmenting it
+per node kind; splitting would duplicate `ParseTarget`
+and the heading-set build across three rules and split
+one diagnostic class across three IDs. Network probing
+(G13) is the one piece that does **not** belong in
+MDS027 — it is impure and offline-hostile — so it splits
+out as its own opt-in rule.
+
+## Follow-up plans
+
+Each cites this audit; implementation is deferred to
+them.
+
+- [Plan 171](../../../plan/171_mds027-link-integrity-hardening.md)
+  — MDS027 link-integrity hardening: G1, G2, G3, plus
+  the G4 subpath regression test.
+- [Plan 172](../../../plan/172_link-style-rule-and-config.md)
+  — link-style rule and shared `links:` config: G8 and
+  the `links:` parser, including the `external-skip`
+  list G13's rule consumes.
+- [Plan 173](../../../plan/173_rewriter-titled-links.md)
+  — rewriter tolerates titled links: G6.
+
+G7, G9, G11, G12 are scope decisions (no plan). G10 is
+deferred to
+[plan 168](../../../plan/168_obsidian-markdown-support.md).
+G13 is tracked by
+[issue #47](https://github.com/jeduden/mdsmith/issues/47)
+and depends on Plan 172's config.

--- a/plan/170_link-handling-audit.md
+++ b/plan/170_link-handling-audit.md
@@ -1,7 +1,7 @@
 ---
 id: 170
 title: Audit link handling across mdsmith and the website
-status: 🔲
+status: ✅
 summary: >-
   Survey every place mdsmith touches Markdown links — the
   linter (MDS027 and friends), the website rewriter, the
@@ -143,18 +143,18 @@ of these mid-implementation in another PR.
 
 ## Acceptance Criteria
 
-- [ ] `docs/research/links/README.md` exists, passes
+- [x] `docs/research/links/README.md` exists, passes
       `mdsmith check`, and is in the homepage catalog.
-- [ ] Every gap surfaced by PR #309 review is
+- [x] Every gap surfaced by PR #309 review is
       catalogued with a target surface and a decision.
-- [ ] Inventory of link rules and link-aware code is
+- [x] Inventory of link rules and link-aware code is
       complete (one entry per file).
-- [ ] Corpus audit lists per-form counts for inline
+- [x] Corpus audit lists per-form counts for inline
       vs ref-style, relative vs absolute, with vs
       without `.md`, with vs without fragment.
-- [ ] A shared `links:` config sketch is in the doc
+- [x] A shared `links:` config sketch is in the doc
       (design only — no parser changes here).
-- [ ] At least one follow-up plan file is filed per
+- [x] At least one follow-up plan file is filed per
       "act on this" decision.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no issues.
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no issues.

--- a/plan/171_mds027-link-integrity-hardening.md
+++ b/plan/171_mds027-link-integrity-hardening.md
@@ -9,7 +9,7 @@ summary: >-
   absolute paths against a configured site root, and
   cover reference-style links, gated by a shared
   `links:` config block. Add a subpath-baseURL
-  regression test for the website rewriter.
+  regression test for the Hugo render-link hook.
 ---
 # MDS027 link-integrity hardening
 

--- a/plan/171_mds027-link-integrity-hardening.md
+++ b/plan/171_mds027-link-integrity-hardening.md
@@ -1,0 +1,74 @@
+---
+id: 171
+title: MDS027 link-integrity hardening
+status: "🔲"
+model: opus
+depends-on: [170]
+summary: >-
+  Extend MDS027 to validate image targets, resolve
+  absolute paths against a configured site root, and
+  cover reference-style links, gated by a shared
+  `links:` config block. Add a subpath-baseURL
+  regression test for the website rewriter.
+---
+# MDS027 link-integrity hardening
+
+## Goal
+
+MDS027 passes three link forms silently. Close those
+blind spots. They are gaps G1–G3 in the
+[link handling audit](../docs/research/links/README.md).
+Also lock in the G4 baseURL fix with a regression test.
+
+## Background
+
+The audit lives at
+[docs/research/links/README.md](../docs/research/links/README.md).
+It found that
+[`linkgraph.ExtractLinks`](../internal/linkgraph/linkgraph.go)
+walks only `*ast.Link` with `Reference == nil`. So
+[MDS027](../internal/rules/crossfilereferenceintegrity/rule.go)
+never resolves image targets (G1). It also
+short-circuits absolute paths (G2).
+
+It ignores reference-style links even though
+[`ExtractRefLinks`](../internal/linkgraph/refs.go)
+already exists (G3). The audit decided to extend
+MDS027 rather than split it. The new behavior is gated
+by a shared `links:` block.
+
+## Tasks
+
+1. Add a `links:` config block parser: `site-root`,
+   `validate-images`, `validate-reference-style`.
+   Deep-merge per kind like every other rule config.
+2. G1: walk `*ast.Image` in the MDS027 resolver behind
+   `validate-images` (default on). Red test: a missing
+   `![](x.png)` reports a broken target.
+3. G3: feed `linkgraph.ExtractRefLinks` through the
+   same resolver behind `validate-reference-style`.
+   Red test: a `[a]` with a broken `[a]:` def is
+   flagged.
+4. G2: when `site-root` is set, resolve absolute
+   targets to a workspace path instead of
+   short-circuiting. Red test: `/docs/rules/MDS027/`
+   resolves; a missing one is flagged; unset preserves
+   today's short-circuit.
+5. G4 regression: assert the website render-link hook
+   prefixes site-absolute links with
+   `site.Home.RelPermalink` under a non-root baseURL.
+6. Update MDS027's README and the audit doc's status if
+   any decision changed during implementation.
+
+## Acceptance Criteria
+
+- [ ] A broken `![](x.png)` is flagged by MDS027 with
+  `validate-images` on and silent when off.
+- [ ] A broken reference-style target is flagged with
+  `validate-reference-style` on.
+- [ ] An absolute target resolves against `site-root`
+  when set and short-circuits when unset.
+- [ ] A subpath-baseURL regression test asserts the
+  render-link prefix.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no issues.

--- a/plan/172_link-style-rule-and-config.md
+++ b/plan/172_link-style-rule-and-config.md
@@ -9,7 +9,7 @@ summary: >-
   from a per-kind declared relative/absolute,
   extension, and inline/reference policy, and finish
   the shared `links:` parser including the
-  external-skip list issue #47's rule reuses.
+  external-skip list that issue #47's rule reuses.
 ---
 # Link-style rule and shared links config
 

--- a/plan/172_link-style-rule-and-config.md
+++ b/plan/172_link-style-rule-and-config.md
@@ -1,0 +1,68 @@
+---
+id: 172
+title: Link-style rule and shared links config
+status: "🔲"
+model: opus
+depends-on: [170, 171]
+summary: >-
+  Add an opt-in link-style rule that flags deviation
+  from a per-kind declared relative/absolute,
+  extension, and inline/reference policy, and finish
+  the shared `links:` parser including the
+  external-skip list issue #47's rule reuses.
+---
+# Link-style rule and shared links config
+
+## Goal
+
+Give projects one switch for a consistent link style
+per file kind. This closes gap G8 from the
+[link handling audit](../docs/research/links/README.md).
+Also land the remaining `links:` config keys. The
+proposed external-link rule (issue #47) then has a
+config foundation.
+
+## Background
+
+See the audit's corpus census in
+[docs/research/links/README.md](../docs/research/links/README.md).
+It found `docs/` is ~50% reference-style while rule
+READMEs are ~0%. Relative, absolute, `.md`, and
+extensionless targets are mixed in the same doc set.
+G8's decision is a new opt-in rule that reads a shared
+`links:` block. G13's decision reuses that block's
+`external-skip` list.
+
+Plan 171 introduces the block's resolution keys. This
+plan adds the `style:` and `external-skip:` keys. It
+also adds the rule that consumes `style:`.
+
+## Tasks
+
+1. Extend the `links:` parser from plan 171 with
+   `style: {path, extension, form}` and
+   `external-skip: []`, deep-merged per kind.
+2. Add opt-in rule `link-style` (next free MDS id).
+   Red tests: an absolute target under
+   `style.path: relative`; a `.md` suffix under
+   `extension: strip`; a reference link under
+   `form: inline`.
+3. Per-kind override path: a `rule-readme` kind pinned
+   to `form: inline` flags a ref-style link there while
+   a `docs` kind on `form: any` does not.
+4. Document the rule README and link it from the audit
+   doc and the rule catalog.
+5. Confirm `external-skip` parses and is exposed for
+   the future issue #47 rule (no HTTP code here).
+
+## Acceptance Criteria
+
+- [ ] `link-style` is opt-in (off by default) and
+  flags path/extension/form deviations per kind.
+- [ ] Per-kind override changes the verdict for the
+  same link in two kinds.
+- [ ] `links.external-skip` parses and is readable by
+  rule code.
+- [ ] Rule README exists and is in the rule catalog.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no issues.

--- a/plan/173_rewriter-titled-links.md
+++ b/plan/173_rewriter-titled-links.md
@@ -1,0 +1,53 @@
+---
+id: 173
+title: Website rewriter tolerates titled links
+status: "🔲"
+model: sonnet
+depends-on: [170]
+summary: >-
+  Widen the website rewriter regexes to capture an
+  optional link-title tail so a titled repo-relative
+  link is rewritten and its title preserved instead of
+  shipping as a dead path.
+---
+# Website rewriter tolerates titled links
+
+## Goal
+
+Stop `[x](../y.md "title")` from shipping as a dead
+repo-relative path on the published site, closing gap
+G6 from the
+[link handling audit](../docs/research/links/README.md).
+
+## Background
+
+The audit found every rewrite regex in
+[internal/release/website.go](../internal/release/website.go)
+stops the path capture at whitespace (`\S+`), so a
+Markdown title makes the link fail to match and pass
+through unrewritten. The corpus has 0 titled links in
+`docs/` today, so this is low-priority and pre-emptive,
+but the gap is real and cheap to close.
+
+## Tasks
+
+1. Add a red test: a synced doc containing
+   `[x](../../../docs/a.md "t")` currently keeps the
+   repo-relative path.
+2. Widen the affected regexes to capture an optional
+   `(\s+"[^"]*")?` title tail and re-emit it after the
+   rewritten path. Keep the `applyOutsideCode` guard.
+3. Verify reference-def forms (`[label]: path "t"`) are
+   handled the same way.
+4. Green the test; confirm no existing rewrite
+   regressed.
+
+## Acceptance Criteria
+
+- [ ] A titled inline link is rewritten with its title
+  preserved.
+- [ ] A titled reference definition is rewritten with
+  its title preserved.
+- [ ] Code spans and fences are still untouched.
+- [ ] All tests pass: `go test ./...`.
+- [ ] `go tool golangci-lint run` reports no issues.


### PR DESCRIPTION
Add docs/research/links/README.md: inventory of every
link-aware rule and pipeline surface, a corpus census,
a catalogued gap list (G1–G13) with one decision each,
and a sketched shared links: config block. File
follow-up plans 171 (MDS027 hardening), 172 (link-style
rule + links: config), and 173 (rewriter titled links).
Surface the doc via a README homepage catalog.

https://claude.ai/code/session_01XamKftforWKRM9dj9DCYVM