### PR TITLE
Refactor release-channel kind to use proto.md schema

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@ glob:
   - "docs/**/*.md"
   - "!docs/research/**"
   - "!docs/security/**"
+  - "!**/proto.md"
 sort: path
 header: ""
 row: "- [{summary}](../{filename})"

--- a/.mdsmith.pinned.yml
+++ b/.mdsmith.pinned.yml
@@ -357,7 +357,7 @@ kinds:
         - heading:
             unlisted: true
   release-channel:
-    path-pattern: "docs/development/release-channels/{proto.md,*.md}"
+    path-pattern: "{docs,website/content/docs}/development/release-channels/{proto.md,*.md}"
     rules:
       required-structure:
         schema: docs/development/release-channels/proto.md

--- a/.mdsmith.pinned.yml
+++ b/.mdsmith.pinned.yml
@@ -357,21 +357,10 @@ kinds:
         - heading:
             unlisted: true
   release-channel:
-    schema:
-      frontmatter:
-        title: 'string & != ""'
-        summary: 'string & != ""'
-        registry: 'string & != ""'
-        credential: 'string & != ""'
-        job: 'string & != ""'
-        channelurl: 'string & =~ "^https?://"'
-        weight: 'int & >=1'
-      closed: false
-      sections:
-        - heading: null
-          required: false
-        - heading:
-            unlisted: true
+    path-pattern: "docs/development/release-channels/{proto.md,*.md}"
+    rules:
+      required-structure:
+        schema: docs/development/release-channels/proto.md
   secret-rotation:
     schema:
       frontmatter:

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -348,7 +348,7 @@ kinds:
             regex: '.+'
             repeat: { min: 0 }
   release-channel:
-    path-pattern: "docs/development/release-channels/{proto.md,*.md}"
+    path-pattern: "{docs,website/content/docs}/development/release-channels/{proto.md,*.md}"
     rules:
       required-structure:
         schema: docs/development/release-channels/proto.md

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -348,26 +348,10 @@ kinds:
             regex: '.+'
             repeat: { min: 0 }
   release-channel:
-    schema:
-      frontmatter:
-        title: 'string & != ""'
-        summary: 'string & != ""'
-        registry: 'string & != ""'
-        credential: 'string & != ""'
-        job: 'string & != ""'
-        # channelurl + weight drive the homepage "Distributed
-        # via" strip (website/layouts/partials/logos-strip.html),
-        # which ranges these docs instead of a data file.
-        # Not `url`: Hugo treats a front-matter `url` as a page
-        # URL override and rejects an absolute http(s) value.
-        channelurl: 'string & =~ "^https?://"'
-        weight: 'int & >=1'
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
+    path-pattern: "docs/development/release-channels/{proto.md,*.md}"
+    rules:
+      required-structure:
+        schema: docs/development/release-channels/proto.md
   secret-rotation:
     schema:
       frontmatter:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ glob:
   - "docs/**/*.md"
   - "!docs/research/**"
   - "!docs/security/**"
+  - "!**/proto.md"
 sort: path
 header: ""
 row: "- [{summary}]({filename})"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ glob:
   - "docs/**/*.md"
   - "!docs/research/**"
   - "!docs/security/**"
+  - "!**/proto.md"
 sort: path
 header: ""
 row: "- [{summary}]({filename})"

--- a/docs/development/release-channels/github-releases.md
+++ b/docs/development/release-channels/github-releases.md
@@ -12,6 +12,8 @@ weight: 5
 ---
 # GitHub Releases
 
+Release page: <https://github.com/jeduden/mdsmith/releases>
+
 The GitHub Releases channel attaches every artifact
 the build matrix produced to a release named after
 the tag:

--- a/docs/development/release-channels/npm.md
+++ b/docs/development/release-channels/npm.md
@@ -12,6 +12,8 @@ weight: 1
 ---
 # npm
 
+Release page: <https://www.npmjs.com/package/@mdsmith/cli>
+
 The npm channel publishes the root plus one
 platform-specific subpackage per host. This page
 holds the canonical list. Other docs link here

--- a/docs/development/release-channels/open-vsx.md
+++ b/docs/development/release-channels/open-vsx.md
@@ -12,6 +12,8 @@ weight: 4
 ---
 # Open VSX
 
+Release page: <https://open-vsx.org/extension/jeduden/mdsmith>
+
 Open VSX is the registry VSCodium, Cursor, Theia,
 and Gitpod query. Publishing the same `.vsix` to
 both Marketplace and Open VSX lets every IDE in

--- a/docs/development/release-channels/proto.md
+++ b/docs/development/release-channels/proto.md
@@ -1,0 +1,16 @@
+---
+title: 'string & != ""'
+summary: 'string & != ""'
+registry: 'string & != ""'
+credential: 'string & != ""'
+job: 'string & != ""'
+channelurl: 'string & =~ "^https?://"'
+weight: 'int & >=1'
+---
+# {title}
+
+Release page: <{channelurl}>
+
+## ...
+
+<?allow-empty-section?>

--- a/docs/development/release-channels/pypi.md
+++ b/docs/development/release-channels/pypi.md
@@ -11,6 +11,8 @@ weight: 2
 ---
 # PyPI
 
+Release page: <https://pypi.org/project/mdsmith/>
+
 The PyPI channel publishes one wheel per supported
 host. Platform tags:
 

--- a/docs/development/release-channels/visual-studio-marketplace.md
+++ b/docs/development/release-channels/visual-studio-marketplace.md
@@ -11,6 +11,9 @@ weight: 3
 ---
 # Visual Studio Marketplace
 
+Release page:
+<https://marketplace.visualstudio.com/items?itemName=jeduden.mdsmith>
+
 The Marketplace channel publishes the mdsmith VS
 Code extension to
 [marketplace.visualstudio.com](https://marketplace.visualstudio.com).

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -21,7 +21,7 @@ Each channel has its own file under
 `mdsmith fix`.
 
 <?catalog
-glob: "release-channels/*.md"
+glob: ["release-channels/*.md", "!release-channels/proto.md"]
 sort: title
 header: |
   | Channel | Release page | Credential |

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -24,17 +24,17 @@ Each channel has its own file under
 glob: "release-channels/*.md"
 sort: title
 header: |
-  | Channel | Credential |
-  |---------|------------|
-row: "| [{title}]({filename}) | {credential} |"
+  | Channel | Release page | Credential |
+  |---------|--------------|------------|
+row: "| [{title}]({filename}) | <{channelurl}> | {credential} |"
 ?>
-| Channel                                                                    | Credential              |
-|----------------------------------------------------------------------------|-------------------------|
-| [GitHub Releases](release-channels/github-releases.md)                     | GITHUB_TOKEN + OIDC     |
-| [npm](release-channels/npm.md)                                             | OIDC Trusted Publishing |
-| [Open VSX](release-channels/open-vsx.md)                                   | OVSX_PAT                |
-| [PyPI](release-channels/pypi.md)                                           | OIDC Trusted Publishing |
-| [Visual Studio Marketplace](release-channels/visual-studio-marketplace.md) | VSCE_PAT                |
+| Channel                                                                    | Release page                                                          | Credential              |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------|-------------------------|
+| [GitHub Releases](release-channels/github-releases.md)                     | <https://github.com/jeduden/mdsmith/releases>                         | GITHUB_TOKEN + OIDC     |
+| [npm](release-channels/npm.md)                                             | <https://www.npmjs.com/package/@mdsmith/cli>                          | OIDC Trusted Publishing |
+| [Open VSX](release-channels/open-vsx.md)                                   | <https://open-vsx.org/extension/jeduden/mdsmith>                      | OVSX_PAT                |
+| [PyPI](release-channels/pypi.md)                                           | <https://pypi.org/project/mdsmith/>                                   | OIDC Trusted Publishing |
+| [Visual Studio Marketplace](release-channels/visual-studio-marketplace.md) | <https://marketplace.visualstudio.com/items?itemName=jeduden.mdsmith> | VSCE_PAT                |
 <?/catalog?>
 
 ## Triggering a Release


### PR DESCRIPTION
## Summary

Refactored the `release-channel` kind configuration to use a shared `proto.md` schema file instead of inline schema definitions. This follows mdsmith's pattern for enforcing consistent file contracts across a directory.

## Key Changes

- **Created `docs/development/release-channels/proto.md`**: New schema template defining the frontmatter contract (title, summary, registry, credential, job, channelurl, weight) and document structure for all release-channel files.

- **Updated `.mdsmith.yml` and `.mdsmith.pinned.yml`**: Replaced inline `schema` definitions with `path-pattern` and `rules` that reference the new proto.md file, reducing duplication and centralizing the schema.

- **Added release page URLs to all channel files**: Updated each release-channel document (GitHub Releases, npm, Open VSX, PyPI, Visual Studio Marketplace) to include a "Release page:" section with the `channelurl` frontmatter value.

- **Updated release.md catalog**: Modified the `<?catalog?>` directive to:
  - Exclude `proto.md` from the generated table
  - Add a "Release page" column displaying the `channelurl` frontmatter field
  - Updated the rendered table to show release URLs for each channel

- **Excluded proto.md from documentation catalogs**: Added `!**/proto.md` glob exclusion to `.github/copilot-instructions.md`, `AGENTS.md`, and `CLAUDE.md` to prevent the schema template from appearing in documentation indexes.

## Implementation Details

The refactoring consolidates schema validation logic into a single source of truth while making release page URLs visible both in the frontmatter and in the generated documentation table. This improves maintainability and ensures all release channels follow the same structural contract.

https://claude.ai/code/session_01RJK9bZ7FyedKviv1fqz2c2