### PR TITLE
Include website/ paths in non-published link rewrites

### DIFF
--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -680,10 +680,10 @@ func TestTransformMarkdown_RewritesRuleLinks(t *testing.T) {
 
 // TestTransformMarkdown_RewritesNonPublishedLinks: every
 // repo-relative link to a path outside the published trees
-// (plan/, cmd/, internal/ non-rules, .claude/, root files)
-// must rewrite to a GitHub URL. The /blob/ vs /tree/ route is
-// decided by trailing slash: files go to /blob/, directories to
-// /tree/. The reference-style sibling shares the rewrite logic.
+// (plan/, cmd/, internal/ non-rules, website/, .claude/, root
+// files) must rewrite to a GitHub URL. The /blob/ vs /tree/ route
+// is decided by trailing slash: files go to /blob/, directories
+// to /tree/. The reference-style sibling shares the rewrite logic.
 func TestTransformMarkdown_RewritesNonPublishedLinks(t *testing.T) {
 	runTransformCases(t, []transformCase{
 		{

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -721,6 +721,16 @@ func TestTransformMarkdown_RewritesNonPublishedLinks(t *testing.T) {
 			in:   "[lint]: ../../internal/lint/\n",
 			want: "[lint]: " + ghTree + "internal/lint/\n",
 		},
+		{
+			name: "website layout file → GitHub blob",
+			in:   "See [x](../../../website/layouts/_default/_markup/render-link.html).\n",
+			want: "See [x](" + ghBlob + "website/layouts/_default/_markup/render-link.html).\n",
+		},
+		{
+			name: "website reference-style def → GitHub blob",
+			in:   "[hook]: ../../../website/layouts/_default/_markup/render-link.html\n",
+			want: "[hook]: " + ghBlob + "website/layouts/_default/_markup/render-link.html\n",
+		},
 	})
 }
 

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -245,15 +245,15 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // markdown body so it resolves on the published site. The three
 // classes are applied in order: (1) links into internal/rules/MDS…/
 // become /docs/rules/<dir>/<#anchor> site URLs; (2) links into any
-// other non-published repo path — plan/, cmd/, editors/, .claude/,
-// internal/ (other than the rule pages already handled in step 1),
-// and root-level files — become absolute GitHub URLs, /blob/ for
-// file targets and /tree/ for directory targets; (3) sibling
-// links to `<path>/index.md` drop the `index.md` filename so the
-// target becomes the directory itself (`<path>/`). Hugo serves
-// `_index.md` (the rename SyncDocs applies) at that directory
-// URL, and MDS027 stats the directory as an existing path, so
-// the rendered link works and the lint still resolves.
+// other non-published repo path — plan/, cmd/, editors/, website/,
+// .claude/, internal/ (other than the rule pages already handled
+// in step 1), and root-level files — become absolute GitHub URLs,
+// /blob/ for file targets and /tree/ for directory targets;
+// (3) sibling links to `<path>/index.md` drop the `index.md`
+// filename so the target becomes the directory itself (`<path>/`).
+// Hugo serves `_index.md` (the rename SyncDocs applies) at that
+// directory URL, and MDS027 stats the directory as an existing
+// path, so the rendered link works and the lint still resolves.
 //
 // The whole pass runs under applyOutsideCode so a Markdown
 // example inside a fenced code block OR an inline code span

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -131,6 +131,7 @@ var repoNonPublishedLink = regexp.MustCompile(
 		`cue/\S+|` +
 		`npm/\S+|` +
 		`python/\S+|` +
+		`website/\S+|` +
 		`\.claude/\S+|` +
 		`\.github/\S+|` +
 		`internal/\S+|` +
@@ -150,6 +151,7 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 		`cue/\S+|` +
 		`npm/\S+|` +
 		`python/\S+|` +
+		`website/\S+|` +
 		`\.claude/\S+|` +
 		`\.github/\S+|` +
 		`internal/\S+|` +


### PR DESCRIPTION
## Summary

Extend the markdown documentation link rewriting logic to handle `website/` directory paths, converting them to GitHub blob URLs when syncing docs for release.

## Changes

- Added `website/\S+|` pattern to `repoNonPublishedLink` regex to match inline markdown links pointing to website files
- Added `website/\S+|` pattern to `repoNonPublishedRefDef` regex to match reference-style link definitions pointing to website files
- Added test cases validating that relative paths to `website/layouts/` files are correctly rewritten to GitHub blob URLs in both inline and reference-style link formats

## Details

The `website/` directory was missing from the set of repository paths that get rewritten during documentation synchronization. This meant links to website layout files and other website assets would not be properly converted to GitHub URLs when publishing release documentation. The fix brings `website/` into parity with other non-published directories like `internal/`, `cue/`, `npm/`, and `python/`.

https://claude.ai/code/session_01ECYDouaQydssUoKBRvuqyc