### PR TITLE
Website: auto-link rule mentions, collapse mobile nav, reorder docs as a journey

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ row: "- [{summary}](../{filename})"
 - [How "flavor" (a property of the renderer), "rule" (a single check), "convention" (a project-wide bundle), and "kind" (a per-file role tag) differ in mdsmith, the cases where they overlap, and how the four concepts compose.](../docs/background/concepts/flavor-rule-convention-kind.md)
 - [How generated sections work — markers, directives, and fix behavior.](../docs/background/concepts/generated-section.md)
 - [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](../docs/background/concepts/placeholder-grammar.md)
+- [The mental model behind mdsmith — how flavor, rule, convention, and kind relate, how generated sections work, the placeholder grammar, and how it compares to other Markdown linters.](../docs/background/index.md)
 - [How mdsmith compares to other Markdown linters.](../docs/background/markdown-linters.md)
 - [Running log of SOLID and clean-architecture findings on origin/main. The solid-architecture skill (audit mode) appends here; blockers are also filed as plans.](../docs/development/architecture-audit.md)
 - [Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.](../docs/development/architecture/audit-checklist.md)
@@ -97,6 +98,7 @@ row: "- [{summary}](../{filename})"
 - [Print the mdsmith build version and exit.](../docs/reference/cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](../docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](../docs/reference/globs.md)
+- [Look up exact CLI commands, config glob and schema syntax, the built-in conventions, and the section-schema grammar.](../docs/reference/index.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](../docs/reference/schema-types.md)
 - [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](../docs/reference/section-schema.md)
 <?/catalog?>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ row: "- [{summary}]({filename})"
 - [How "flavor" (a property of the renderer), "rule" (a single check), "convention" (a project-wide bundle), and "kind" (a per-file role tag) differ in mdsmith, the cases where they overlap, and how the four concepts compose.](docs/background/concepts/flavor-rule-convention-kind.md)
 - [How generated sections work — markers, directives, and fix behavior.](docs/background/concepts/generated-section.md)
 - [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](docs/background/concepts/placeholder-grammar.md)
+- [The mental model behind mdsmith — how flavor, rule, convention, and kind relate, how generated sections work, the placeholder grammar, and how it compares to other Markdown linters.](docs/background/index.md)
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 - [Running log of SOLID and clean-architecture findings on origin/main. The solid-architecture skill (audit mode) appends here; blockers are also filed as plans.](docs/development/architecture-audit.md)
 - [Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.](docs/development/architecture/audit-checklist.md)
@@ -103,6 +104,7 @@ row: "- [{summary}]({filename})"
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
+- [Look up exact CLI commands, config glob and schema syntax, the built-in conventions, and the section-schema grammar.](docs/reference/index.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](docs/reference/schema-types.md)
 - [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](docs/reference/section-schema.md)
 <?/catalog?>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ row: "- [{summary}]({filename})"
 - [How "flavor" (a property of the renderer), "rule" (a single check), "convention" (a project-wide bundle), and "kind" (a per-file role tag) differ in mdsmith, the cases where they overlap, and how the four concepts compose.](docs/background/concepts/flavor-rule-convention-kind.md)
 - [How generated sections work — markers, directives, and fix behavior.](docs/background/concepts/generated-section.md)
 - [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](docs/background/concepts/placeholder-grammar.md)
+- [The mental model behind mdsmith — how flavor, rule, convention, and kind relate, how generated sections work, the placeholder grammar, and how it compares to other Markdown linters.](docs/background/index.md)
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 - [Running log of SOLID and clean-architecture findings on origin/main. The solid-architecture skill (audit mode) appends here; blockers are also filed as plans.](docs/development/architecture-audit.md)
 - [Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.](docs/development/architecture/audit-checklist.md)
@@ -89,6 +90,7 @@ row: "- [{summary}]({filename})"
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
+- [Look up exact CLI commands, config glob and schema syntax, the built-in conventions, and the section-schema grammar.](docs/reference/index.md)
 - [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](docs/reference/schema-types.md)
 - [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](docs/reference/section-schema.md)
 <?/catalog?>

--- a/docs/background/index.md
+++ b/docs/background/index.md
@@ -1,0 +1,24 @@
+---
+title: Concepts
+weight: 50
+summary: >-
+  The mental model behind mdsmith — how flavor, rule,
+  convention, and kind relate, how generated sections
+  work, the placeholder grammar, and how it compares to
+  other Markdown linters.
+---
+# Concepts
+
+<?catalog
+glob:
+  - "**/*.md"
+  - "!index.md"
+sort: path
+header: ""
+row: "- [{summary}]({filename})"
+?>
+- [How "flavor" (a property of the renderer), "rule" (a single check), "convention" (a project-wide bundle), and "kind" (a per-file role tag) differ in mdsmith, the cases where they overlap, and how the four concepts compose.](concepts/flavor-rule-convention-kind.md)
+- [How generated sections work — markers, directives, and fix behavior.](concepts/generated-section.md)
+- [How the placeholder vocabulary lets rules treat template tokens as opaque rather than flagging them as content violations.](concepts/placeholder-grammar.md)
+- [How mdsmith compares to other Markdown linters.](markdown-linters.md)
+<?/catalog?>

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,5 +1,6 @@
 ---
 title: Development
+weight: 60
 summary: Build commands, project layout, code style, test fixtures, coverage gate, and merge conflicts.
 ---
 

--- a/docs/guides/file-kinds.md
+++ b/docs/guides/file-kinds.md
@@ -1,5 +1,6 @@
 ---
 title: File Kinds
+weight: 20
 summary: >-
   How to declare file kinds, assign files to them, and read
   the merged rule config that results.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,5 +1,6 @@
 ---
 title: Guides
+weight: 20
 summary: >-
   User guides for mdsmith directives, structure
   enforcement, and migration.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installation
+weight: 10
 summary: >-
   Every channel that ships the mdsmith binary, the VS
   Code extension, or the Claude Code plugin — npm,

--- a/docs/guides/metrics-tradeoffs.md
+++ b/docs/guides/metrics-tradeoffs.md
@@ -1,5 +1,6 @@
 ---
 title: Choosing Readability, Conciseness, and Token Budget Metrics
+weight: 40
 summary: Trade-offs and threshold guidance for readability, structure, length, and token budgets.
 ---
 # Choosing Readability, Conciseness, and Token Budget Metrics

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -1,5 +1,6 @@
 ---
 title: Schemas
+weight: 30
 summary: >-
   Declare a document-structure schema inline on a kind
   or in a proto.md file, validate headings and front

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,4 +1,5 @@
 ---
+weight: 10
 summary: CLI commands, flags, exit codes, and output format.
 ---
 # CLI Reference

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -1,4 +1,5 @@
 ---
+weight: 20
 summary: >-
   Built-in Markdown conventions, the rule presets
   each one applies, and how user config layers on

--- a/docs/reference/globs.md
+++ b/docs/reference/globs.md
@@ -1,4 +1,5 @@
 ---
+weight: 30
 summary: >-
   Glob pattern syntax across mdsmith config, directives,
   and CLI argument expansion, with the supported

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,39 @@
+---
+title: Reference
+weight: 30
+summary: >-
+  Look up exact CLI commands, config glob and schema
+  syntax, the built-in conventions, and the section-schema
+  grammar.
+---
+# Reference
+
+<?catalog
+glob:
+  - "**/*.md"
+  - "!index.md"
+sort: path
+header: ""
+row: "- [{summary}]({filename})"
+?>
+- [CLI commands, flags, exit codes, and output format.](cli.md)
+- [List workspace links that point at a file.](cli/backlinks.md)
+- [Lint Markdown files for style issues.](cli/check.md)
+- [Write a portable, directive-free copy of a Markdown file.](cli/export.md)
+- [Emit a schema-conformant Markdown file as a JSON/YAML/msgpack data tree.](cli/extract.md)
+- [Auto-fix lint issues in Markdown files in place.](cli/fix.md)
+- [Show built-in documentation for rules, metrics, and concept pages.](cli/help.md)
+- [Generate a default `.mdsmith.yml` config in the current directory.](cli/init.md)
+- [Inspect declared file kinds and resolve effective rule config per file.](cli/kinds.md)
+- [Selection-style commands that walk the workspace and emit matches.](cli/list.md)
+- [Run a Language Server Protocol server on stdio for editor integrations.](cli/lsp.md)
+- [Git merge driver that resolves conflicts inside generated sections.](cli/merge-driver.md)
+- [List and rank shared Markdown metrics (file length, token estimate, readability, …).](cli/metrics.md)
+- [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](cli/pre-merge-commit.md)
+- [Select Markdown files by a CUE expression on front matter.](cli/query.md)
+- [Print the mdsmith build version and exit.](cli/version.md)
+- [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](conventions.md)
+- [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](globs.md)
+- [Named field-type shortcuts for inline schema frontmatter values — the registered names, the canonical CUE each one resolves to, and example usage.](schema-types.md)
+- [Section-schema reference for inline `kinds.<name>.schema:` blocks. Covers the `heading:` discriminator, the `regex:` matcher (a Go RE2 body with `\#(digits)` and `\#(fmvar(...))` helpers), the `repeat: {min, max}` cardinality field, and the matching algorithm. `proto.md` files are parsed into the same shape by the schema package, but MDS020's file-schema check still uses its legacy parser; see the proto.md section below for what is and is not migrated.](section-schema.md)
+<?/catalog?>

--- a/docs/reference/schema-types.md
+++ b/docs/reference/schema-types.md
@@ -1,4 +1,5 @@
 ---
+weight: 40
 summary: >-
   Named field-type shortcuts for inline schema
   frontmatter values — the registered names, the

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -1,4 +1,5 @@
 ---
+weight: 50
 summary: >-
   Section-schema reference for inline
   `kinds.<name>.schema:` blocks. Covers the

--- a/internal/rules/index.md
+++ b/internal/rules/index.md
@@ -1,5 +1,6 @@
 ---
 title: Rule Directory
+weight: 40
 summary: >-
   Complete list of all mdsmith rules with category, status, and
   description, generated from rule READMEs.

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -13,6 +13,12 @@
          because the kind schema standardizes on `summary`. */ -}}
   <meta name="description" content="{{ with .Description }}{{ . }}{{ else with .Params.summary }}{{ . }}{{ else with .Params.description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   <link rel="icon" type="image/svg+xml" href="{{ "img/logo-mark.svg" | relURL }}">
+  {{- /* Mark the document as JS-capable before CSS applies so
+         the mobile docs-nav collapse is scoped to `html.js`.
+         With JS off this class never lands, the nav stays
+         visible, and the (inert) toggle button stays hidden —
+         the navigation is reachable without scripting. */ -}}
+  <script>document.documentElement.classList.add("js")</script>
   <link rel="stylesheet" href="{{ "css/colors_and_type.css" | relURL }}">
   <link rel="stylesheet" href="{{ "css/app.css" | relURL }}">
   <script src="{{ "js/lucide.min.js" | relURL }}" defer></script>

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -34,6 +34,14 @@
         document.addEventListener("scroll", onScroll, { passive: true });
         onScroll();
       }
+      const sideToggle = document.querySelector(".docs-side-toggle");
+      const sideNav = document.getElementById("docs-nav");
+      if (sideToggle && sideNav) {
+        sideToggle.addEventListener("click", () => {
+          const open = sideNav.classList.toggle("is-open");
+          sideToggle.setAttribute("aria-expanded", open ? "true" : "false");
+        });
+      }
       document.querySelectorAll("[data-copy]").forEach(btn => {
         btn.addEventListener("click", async () => {
           const text = btn.getAttribute("data-copy");

--- a/website/layouts/_default/list.html
+++ b/website/layouts/_default/list.html
@@ -18,7 +18,7 @@
       <div class="docs-prose">
         <h1>{{ .Title }}</h1>
         {{ with .Params.summary }}<p class="lead">{{ . }}</p>{{ end }}
-        {{ .Content }}
+        {{ partial "link-rules.html" . }}
 
         {{- /* Auto-rendered section index: only emitted when the
                page body is empty (e.g. a synthesized stub

--- a/website/layouts/_default/single.html
+++ b/website/layouts/_default/single.html
@@ -18,7 +18,7 @@
       <div class="docs-prose">
         <h1>{{ .Title }}</h1>
         {{ with .Params.summary }}<p class="lead">{{ . }}</p>{{ end }}
-        {{ .Content }}
+        {{ partial "link-rules.html" . }}
       </div>
     </article>
   </div>

--- a/website/layouts/partials/docs-sidebar.html
+++ b/website/layouts/partials/docs-sidebar.html
@@ -3,13 +3,19 @@
 {{- /* Explicit narrative order for the docs groups: the
        sidebar reads as a user journey (why → how → look up →
        rule catalog → mental model → contribute) rather than
-       Hugo's default title sort. Section weights set in each
-       _index.md front matter would do this too, but the
-       feature-index kind schema is closed and rejects a
-       `weight` key, so the order lives here. Any section not
-       named in $order is appended afterwards by weight, so a
-       new docs section still renders without a template
-       change. */ -}}
+       Hugo's default title sort. Per-section weights in each
+       _index.md front matter would do this too, but
+       docs/features/index.md is the feature-index kind, whose
+       schema declares a frontmatter struct of only title +
+       summary. mdsmith validates that struct as closed
+       regardless of the schema-level `closed: false` (which
+       governs the section list, not front matter), so a
+       `weight` key fails MDS020 (verified: "weight: ...
+       not declared in schema"). Rather than widen .mdsmith.yml
+       (needs maintainer consent), the order lives here. Any
+       section not named in $order is appended afterwards by
+       weight, so a new docs section still renders without a
+       template change. */ -}}
 {{ $order := slice "features" "guides" "reference" "rules" "background" "development" }}
 <button class="docs-side-toggle" type="button" aria-expanded="false" aria-controls="docs-nav">
   <span class="docs-side-toggle-label">Documentation</span>

--- a/website/layouts/partials/docs-sidebar.html
+++ b/website/layouts/partials/docs-sidebar.html
@@ -1,8 +1,34 @@
 {{ $current := .RelPermalink }}
 {{ $docs := .Site.GetPage "/docs" }}
+{{- /* Explicit narrative order for the docs groups: the
+       sidebar reads as a user journey (why → how → look up →
+       rule catalog → mental model → contribute) rather than
+       Hugo's default title sort. Section weights set in each
+       _index.md front matter would do this too, but the
+       feature-index kind schema is closed and rejects a
+       `weight` key, so the order lives here. Any section not
+       named in $order is appended afterwards by weight, so a
+       new docs section still renders without a template
+       change. */ -}}
+{{ $order := slice "features" "guides" "reference" "rules" "background" "development" }}
+<button class="docs-side-toggle" type="button" aria-expanded="false" aria-controls="docs-nav">
+  <span class="docs-side-toggle-label">Documentation</span>
+  <i data-lucide="chevron-down" width="16" height="16" aria-hidden="true"></i>
+</button>
+<nav class="docs-side-nav" id="docs-nav">
 {{ with $docs }}
+  {{ $secs := .Sections }}
+  {{ $ordered := slice }}
+  {{ range $name := $order }}
+    {{ range $secs }}
+      {{ if eq (path.Base .RelPermalink) $name }}{{ $ordered = $ordered | append . }}{{ end }}
+    {{ end }}
+  {{ end }}
+  {{ range $secs.ByWeight }}
+    {{ if not (in $ordered .) }}{{ $ordered = $ordered | append . }}{{ end }}
+  {{ end }}
   <a class="docs-side-home{{ if eq .RelPermalink $current }} is-active{{ end }}" href="{{ .RelPermalink }}">All docs</a>
-  {{ range .Sections.ByWeight }}
+  {{ range $ordered }}
     <div class="docs-side-group">
       <a class="docs-side-title{{ if eq .RelPermalink $current }} is-active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a>
       {{ range .Pages.ByWeight }}
@@ -17,3 +43,4 @@
     </div>
   {{ end }}
 {{ end }}
+</nav>

--- a/website/layouts/partials/link-rules.html
+++ b/website/layouts/partials/link-rules.html
@@ -12,15 +12,19 @@
        instead. Only `<code>…</code>` spans match, so rule
        codes in prose, headings, links, or tables are left
        alone (the user asked for backticked mentions only).
-       Rule-shaped tokens with no published page (a docs tree
-       built without internal/rules/index.md → empty map) are
-       left as plain code. A rule page does not self-link. */ -}}
+       Each token is matched exactly against the rule-index
+       map keys (bare id and exact page slug), so a typo'd
+       suffix like `MDS001-lenght` is NOT linked — it would
+       otherwise silently point at the wrong rule. Tokens with
+       no published page (a docs tree built without
+       internal/rules/index.md → empty map) are left as plain
+       code. A rule page does not self-link. */ -}}
 {{- $content := .Content -}}
 {{- $self := .RelPermalink -}}
 {{- $rules := partialCached "rule-index.html" . -}}
-{{- range $id, $url := $rules -}}
+{{- range $token, $url := $rules -}}
   {{- if ne $url $self -}}
-    {{- $re := printf `<code>(%s(?:-[a-z0-9-]+)?)</code>` $id -}}
+    {{- $re := printf `<code>(%s)</code>` $token -}}
     {{- $repl := printf `<a class="rule-ref" href="%s"><code>$1</code></a>` $url -}}
     {{- $content = replaceRE $re $repl $content -}}
   {{- end -}}

--- a/website/layouts/partials/link-rules.html
+++ b/website/layouts/partials/link-rules.html
@@ -1,0 +1,28 @@
+{{- /* Structurally auto-link rule mentions. Any inline-code
+       token that is exactly a rule id (`MDS027`) or the
+       id-with-name page-directory form
+       (`MDS027-cross-file-reference-integrity`) is rewritten
+       to a link to that rule's page. Authors write nothing
+       special — putting a rule code in a code span is enough —
+       so the link cannot drift and no wiki-link syntax has to
+       be remembered.
+
+       Hugo has no inline-code render hook, so this runs as a
+       post-process over the already-rendered `.Content`
+       instead. Only `<code>…</code>` spans match, so rule
+       codes in prose, headings, links, or tables are left
+       alone (the user asked for backticked mentions only).
+       Rule-shaped tokens with no published page (a docs tree
+       built without internal/rules/index.md → empty map) are
+       left as plain code. A rule page does not self-link. */ -}}
+{{- $content := .Content -}}
+{{- $self := .RelPermalink -}}
+{{- $rules := partialCached "rule-index.html" . -}}
+{{- range $id, $url := $rules -}}
+  {{- if ne $url $self -}}
+    {{- $re := printf `<code>(%s(?:-[a-z0-9-]+)?)</code>` $id -}}
+    {{- $repl := printf `<a class="rule-ref" href="%s"><code>$1</code></a>` $url -}}
+    {{- $content = replaceRE $re $repl $content -}}
+  {{- end -}}
+{{- end -}}
+{{- $content | safeHTML -}}

--- a/website/layouts/partials/link-rules.html
+++ b/website/layouts/partials/link-rules.html
@@ -8,25 +8,40 @@
        be remembered.
 
        Hugo has no inline-code render hook, so this runs as a
-       post-process over the already-rendered `.Content`
-       instead. Only `<code>…</code>` spans match, so rule
-       codes in prose, headings, links, or tables are left
-       alone (the user asked for backticked mentions only).
-       Each token is matched exactly against the rule-index
-       map keys (bare id and exact page slug), so a typo'd
-       suffix like `MDS001-lenght` is NOT linked — it would
-       otherwise silently point at the wrong rule. Tokens with
-       no published page (a docs tree built without
-       internal/rules/index.md → empty map) are left as plain
-       code. A rule page does not self-link. */ -}}
+       post-process over the already-rendered `.Content`. The
+       needle is the literal `<code>TOKEN</code>` string, so:
+       - Only code spans are touched. A rule code in plain
+         prose, a heading's plain text, or a link's href is
+         NOT a `<code>` span and is left alone.
+       - A rule code in a `<code>` span IS linked wherever the
+         span sits — body paragraph, list item, table cell, or
+         a heading written as `# `+"`MDS027`". That is the
+         intended behaviour: the span is the opt-in marker.
+       - It assumes docs never wrap a bare rule code in a link
+         label (`[`+"`MDS027`"+`](url)`); none do, and putting
+         one there would nest <a> tags. Match exactly against
+         the rule-index keys (bare id and exact page slug) so a
+         typo'd suffix like `MDS001-lenght` is left as plain
+         code instead of pointing at the wrong rule.
+
+       Tokens with no published page (a docs tree built
+       without internal/rules/index.md → empty map) are left
+       as plain code. A rule page does not self-link.
+
+       `replace` (literal) not `replaceRE`: the needle is a
+       fixed string, so a regex would be wasted work per page
+       and would mis-handle a rule name with a regex
+       metacharacter. `partialCached … site` keys the rule map
+       once site-wide — the partial only reads `site.GetPage`,
+       never the passed context. */ -}}
 {{- $content := .Content -}}
 {{- $self := .RelPermalink -}}
-{{- $rules := partialCached "rule-index.html" . -}}
+{{- $rules := partialCached "rule-index.html" site -}}
 {{- range $token, $url := $rules -}}
   {{- if ne $url $self -}}
-    {{- $re := printf `<code>(%s)</code>` $token -}}
-    {{- $repl := printf `<a class="rule-ref" href="%s"><code>$1</code></a>` $url -}}
-    {{- $content = replaceRE $re $repl $content -}}
+    {{- $needle := printf `<code>%s</code>` $token -}}
+    {{- $repl := printf `<a class="rule-ref" href="%s"><code>%s</code></a>` $url $token -}}
+    {{- $content = replace $content $needle $repl -}}
   {{- end -}}
 {{- end -}}
 {{- $content | safeHTML -}}

--- a/website/layouts/partials/rule-index.html
+++ b/website/layouts/partials/rule-index.html
@@ -1,17 +1,25 @@
-{{- /* Build a once-cached map of rule id -> published rule
-       page permalink. Consumed by the render-codespan hook so
-       any `MDSxxx` inline-code token auto-links to its rule
-       page with zero author markup. Keyed off `.Params.id`
-       (e.g. "MDS001") set in each rule README's front matter.
+{{- /* Build a once-cached map of every linkable rule token
+       -> published rule page permalink. Two keys per rule:
+       the bare id (`MDS001`) and the exact page-directory
+       form (`MDS001-line-length`, id + `-` + name). Only
+       these exact tokens are linked, so a typo'd suffix like
+       `MDS001-lenght` is left as plain code instead of
+       silently linking to the wrong rule — keeping the
+       "cannot drift" guarantee.
+
        The map is empty when a docs tree is built without
        internal/rules/index.md (no /docs/rules/ section): the
-       caller then renders a plain <code> span. */ -}}
+       caller then renders the code span unchanged. */ -}}
 {{- $m := dict -}}
 {{- with site.GetPage "/docs/rules" -}}
   {{- range .Pages -}}
     {{- $id := .Params.id -}}
+    {{- $name := .Params.name -}}
     {{- if $id -}}
       {{- $m = merge $m (dict $id .RelPermalink) -}}
+      {{- if $name -}}
+        {{- $m = merge $m (dict (printf "%s-%s" $id $name) .RelPermalink) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/website/layouts/partials/rule-index.html
+++ b/website/layouts/partials/rule-index.html
@@ -1,0 +1,18 @@
+{{- /* Build a once-cached map of rule id -> published rule
+       page permalink. Consumed by the render-codespan hook so
+       any `MDSxxx` inline-code token auto-links to its rule
+       page with zero author markup. Keyed off `.Params.id`
+       (e.g. "MDS001") set in each rule README's front matter.
+       The map is empty when a docs tree is built without
+       internal/rules/index.md (no /docs/rules/ section): the
+       caller then renders a plain <code> span. */ -}}
+{{- $m := dict -}}
+{{- with site.GetPage "/docs/rules" -}}
+  {{- range .Pages -}}
+    {{- $id := .Params.id -}}
+    {{- if $id -}}
+      {{- $m = merge $m (dict $id .RelPermalink) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $m -}}

--- a/website/layouts/rule/single.html
+++ b/website/layouts/rule/single.html
@@ -32,7 +32,7 @@
         </div>
         <h1>{{ .Title }}</h1>
         {{ with .Params.description }}<p class="lead">{{ . }}</p>{{ end }}
-        {{ .Content }}
+        {{ partial "link-rules.html" . }}
         {{ with .Params.github_source }}
           <div class="rule-source-link">
             <a href="https://github.com/{{ $.Site.Params.githubRepo }}/tree/main/{{ . }}" rel="noopener">

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -857,8 +857,12 @@ a.rule-ref:hover code { text-decoration: underline; }
     max-height: none;
     overflow: visible;
   }
+  /* Progressive enhancement: the collapse is JS-only. Without
+     the `html.js` flag (script disabled or failed) the toggle
+     stays hidden and the nav stays visible, so docs navigation
+     is always reachable. */
   .docs-side-toggle {
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: space-between;
     width: 100%;
@@ -875,10 +879,12 @@ a.rule-ref:hover code { text-decoration: underline; }
     border-radius: 4px;
     cursor: pointer;
   }
+  html.js .docs-side-toggle { display: flex; }
   .docs-side-toggle i { transition: transform 0.15s ease; }
   .docs-side-toggle[aria-expanded="true"] i { transform: rotate(180deg); }
-  .docs-side-nav { display: none; padding: 14px 0 4px; }
-  .docs-side-nav.is-open { display: block; }
+  .docs-side-nav { display: block; padding: 14px 0 4px; }
+  html.js .docs-side-nav { display: none; }
+  html.js .docs-side-nav.is-open { display: block; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
   .pg { grid-template-columns: 1fr; height: auto; }
   .pg-pane + .pg-pane { border-left: 0; border-top: 1px solid var(--border); }

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -880,8 +880,13 @@ a.rule-ref:hover code { text-decoration: underline; }
     cursor: pointer;
   }
   html.js .docs-side-toggle { display: flex; }
-  .docs-side-toggle i { transition: transform 0.15s ease; }
-  .docs-side-toggle[aria-expanded="true"] i { transform: rotate(180deg); }
+  /* Lucide's createIcons() swaps the <i data-lucide> for an
+     inline <svg>, so target both: the <i> covers the brief
+     pre-script paint, the <svg> the rendered state. */
+  .docs-side-toggle i,
+  .docs-side-toggle svg { transition: transform 0.15s ease; }
+  .docs-side-toggle[aria-expanded="true"] i,
+  .docs-side-toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
   .docs-side-nav { display: block; padding: 14px 0 4px; }
   html.js .docs-side-nav { display: none; }
   html.js .docs-side-nav.is-open { display: block; }

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -463,6 +463,11 @@ main {
   max-height: calc(100vh - 100px);
   overflow-y: auto;
 }
+/* The collapse toggle is a mobile-only affordance: on desktop
+   the sidebar is always shown, so the button stays hidden and
+   the nav renders unconditionally. */
+.docs-side-toggle { display: none; }
+.docs-side-nav { display: block; }
 .docs-side-group { margin-bottom: 22px; }
 .docs-side-title {
   font-family: var(--font-mono);
@@ -821,6 +826,17 @@ a.docs-side-title:hover, a.docs-side-title.is-active { color: var(--accent); tex
 .chip.cat-accessibility { background: #DDF0E5; border-color: #2A8E5A; color: #1f5e3e; }
 .chip.cat-line       { background: var(--steel-50);  border-color: var(--steel-300); color: var(--steel-700); }
 
+/* Auto-linked rule references (render-codespan hook). Keep the
+   code-span look; add a subtle accent + underline so it reads
+   as a link without losing the monospace token styling. */
+a.rule-ref { text-decoration: none; }
+a.rule-ref code {
+  color: var(--accent);
+  border-color: var(--forge-200);
+  cursor: pointer;
+}
+a.rule-ref:hover code { text-decoration: underline; }
+
 /* ========== UTIL ========== */
 .muted { color: var(--fg-muted); }
 .subtle { color: var(--fg-subtle); }
@@ -831,8 +847,38 @@ a.docs-side-title:hover, a.docs-side-title.is-active { color: var(--accent); tex
   .hero h1 { font-size: 44px; }
   .feature-grid { grid-template-columns: 1fr; }
   .docs-index { grid-template-columns: 1fr; }
-  .docs-grid { grid-template-columns: 1fr; }
-  .docs-side { position: static; max-height: none; }
+  .docs-grid { grid-template-columns: 1fr; gap: 20px; }
+  /* Standard mobile pattern: the long docs nav collapses
+     behind a disclosure so page content sits directly under
+     the breadcrumb instead of below the entire tree. The
+     aside shrinks to just the toggle until expanded. */
+  .docs-side {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
+  .docs-side-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 8px;
+    padding: 10px 14px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--fg-subtle);
+    background: var(--steel-50);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .docs-side-toggle i { transition: transform 0.15s ease; }
+  .docs-side-toggle[aria-expanded="true"] i { transform: rotate(180deg); }
+  .docs-side-nav { display: none; padding: 14px 0 4px; }
+  .docs-side-nav.is-open { display: block; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
   .pg { grid-template-columns: 1fr; height: auto; }
   .pg-pane + .pg-pane { border-left: 0; border-top: 1px solid var(--border); }


### PR DESCRIPTION
- Structurally link any `MDSxxx`/`MDSxxx-name` inline-code token to
  its rule page via a content post-process (Hugo has no inline-code
  render hook); rule pages do not self-link.
- Collapse the long docs sidebar behind a disclosure toggle below
  880px so page content sits directly under the breadcrumb instead
  of below the entire tree.
- Order the sidebar groups and the Guides/Reference pages as a user
  journey (Why -> Guides -> Reference -> Rules -> Concepts ->
  Development); add Reference and Concepts section landing pages.

https://claude.ai/code/session_014n4DeKnwT7qnAnwJPsMsoE