### PR TITLE
feat: lift the heading rename engine into internal/rename

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,7 @@ row: "- [{summary}](../{filename})"
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](../docs/reference/cli/metrics.md)
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](../docs/reference/cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](../docs/reference/cli/query.md)
+- [Rename a heading or link-reference label and rewrite every dependent edit.](../docs/reference/cli/rename.md)
 - [Print the mdsmith build version and exit.](../docs/reference/cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](../docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](../docs/reference/globs.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ row: "- [{summary}]({filename})"
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](docs/reference/cli/metrics.md)
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](docs/reference/cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](docs/reference/cli/query.md)
+- [Rename a heading or link-reference label and rewrite every dependent edit.](docs/reference/cli/rename.md)
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ row: "- [{summary}]({filename})"
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](docs/reference/cli/metrics.md)
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](docs/reference/cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](docs/reference/cli/query.md)
+- [Rename a heading or link-reference label and rewrite every dependent edit.](docs/reference/cli/rename.md)
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -100,5 +100,5 @@ footer: |
 | 171 | 🔲     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                            |
 | 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                         |
 | 173 | 🔲     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                              |
-| 174 | 🔳     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)          |
+| 174 | ✅     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)          |
 <?/catalog?>

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 | [`merge-driver`](docs/reference/cli/merge-driver.md)         | Git merge driver that resolves conflicts inside generated sections.                  |
 | [`metrics`](docs/reference/cli/metrics.md)                   | List and rank shared Markdown metrics (file length, token estimate, readability, …). |
 | [`pre-merge-commit`](docs/reference/cli/pre-merge-commit.md) | Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.      |
+| [`rename`](docs/reference/cli/rename.md)                     | Rename a heading or link-reference label and rewrite every dependent edit.           |
 | [`version`](docs/reference/cli/version.md)                   | Print the mdsmith build version and exit.                                            |
 <?/catalog?>
 

--- a/cmd/mdsmith/e2e_rename_test.go
+++ b/cmd/mdsmith/e2e_rename_test.go
@@ -1,0 +1,61 @@
+package main_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRenameWorkspace builds a workspace where b.md links to a
+// heading in a.md by anchor and by a ref-def destination, so a
+// heading rename has cross-file edits to make.
+func setupRenameWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	wf := func(rel, body string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, rel)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644))
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	wf(".mdsmith.yml", "files:\n  - \"**/*.md\"\nrules:\n  cross-file-reference-integrity: false\n")
+	wf("a.md", "# Setup\n\nBody.\n")
+	wf("b.md", "See [go](a.md#setup) and [the docs][docs].\n\n[docs]: https://x.example\n")
+	return dir
+}
+
+func TestE2E_Rename_Heading_RewritesWorkspace(t *testing.T) {
+	dir := setupRenameWorkspace(t)
+	stdout, _, code := runBinaryInDir(t, dir, "", "rename", "a.md", "--heading", "Setup", "Install")
+	require.Equal(t, 0, code, "stdout=%q", stdout)
+	assert.Contains(t, stdout, "a.md: 1 edit(s)")
+	assert.Contains(t, stdout, "b.md: 1 edit(s)")
+
+	a, _ := os.ReadFile(filepath.Join(dir, "a.md"))
+	assert.Contains(t, string(a), "# Install")
+	b, _ := os.ReadFile(filepath.Join(dir, "b.md"))
+	assert.Contains(t, string(b), "[go](a.md#install)")
+}
+
+func TestE2E_Rename_LinkRef_JSON(t *testing.T) {
+	dir := setupRenameWorkspace(t)
+	stdout, _, code := runBinaryInDir(t, dir, "", "rename",
+		"b.md", "--link-ref", "--format", "json", "docs", "rfc")
+	require.Equal(t, 0, code, "stdout=%q", stdout)
+	assert.Contains(t, stdout, `"file": "b.md"`)
+	b, _ := os.ReadFile(filepath.Join(dir, "b.md"))
+	assert.Contains(t, string(b), "[the docs][rfc]")
+	assert.Contains(t, string(b), "[rfc]: https://x.example")
+}
+
+func TestE2E_Rename_ExitCodes(t *testing.T) {
+	dir := setupRenameWorkspace(t)
+	// No matching heading → exit 1.
+	_, _, code := runBinaryInDir(t, dir, "", "rename", "a.md", "--heading", "Ghost", "X")
+	assert.Equal(t, 1, code)
+	// Missing mode flag → exit 2.
+	_, _, code = runBinaryInDir(t, dir, "", "rename", "a.md", "Setup", "Install")
+	assert.Equal(t, 2, code)
+}

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -46,6 +46,7 @@ Commands:
   extract           Emit a kind-conformant file as a JSON/YAML/msgpack data tree
   list              Walk the workspace and emit matches (files or link records)
   deps              Show a file's dependency-graph edges (includes, links, …)
+  rename            Rename a heading or link-ref label and rewrite dependents
   help              Show help for rules and topics
   metrics           Show and rank shared Markdown metrics
   merge-driver      Git merge driver for regenerable sections
@@ -77,34 +78,41 @@ func run() int {
 	}
 
 	// Dispatch to subcommand.
-	first := os.Args[1]
+	return dispatch(os.Args[1], os.Args[2:])
+}
+
+// dispatch routes a subcommand name to its handler. Split out of run
+// so run stays under the statement-count limit as commands are added.
+func dispatch(first string, args []string) int {
 	switch first {
 	case "check":
-		return runCheck(os.Args[2:])
+		return runCheck(args)
 	case "fix":
-		return runFix(os.Args[2:])
+		return runFix(args)
 	case "export":
-		return runExport(os.Args[2:])
+		return runExport(args)
 	case "extract":
-		return runExtract(os.Args[2:])
+		return runExtract(args)
 	case "list":
-		return runList(os.Args[2:])
+		return runList(args)
 	case "deps":
-		return runDeps(os.Args[2:])
+		return runDeps(args)
+	case "rename":
+		return runRename(args)
 	case "help":
-		return runHelp(os.Args[2:])
+		return runHelp(args)
 	case "metrics":
-		return runMetrics(os.Args[2:])
+		return runMetrics(args)
 	case "merge-driver":
-		return runMergeDriver(os.Args[2:])
+		return runMergeDriver(args)
 	case "pre-merge-commit":
-		return runPreMergeCommit(os.Args[2:])
+		return runPreMergeCommit(args)
 	case "kinds":
-		return runKinds(os.Args[2:])
+		return runKinds(args)
 	case "init":
-		return runInit(os.Args[2:])
+		return runInit(args)
 	case "lsp":
-		return runLSP(os.Args[2:])
+		return runLSP(args)
 	case "version":
 		printVersion()
 		return 0

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -898,3 +898,14 @@ func TestPrintDeprecations_EmitsEachMessageAndClears(t *testing.T) {
 	stderr2 := captureStderr(func() { printDeprecations(cfg) })
 	assert.Empty(t, stderr2, "second call on the same cfg emits nothing")
 }
+
+// TestDispatch covers the subcommand router's terminal arms: the
+// in-process "version" command and the unknown-command fallback. The
+// run* delegations are exercised through each command's own e2e
+// suite, which drives the real binary through dispatch.
+func TestDispatch(t *testing.T) {
+	assert.Equal(t, 0, dispatch("version", nil))
+	var code int
+	_ = captureStderr(func() { code = dispatch("totally-unknown", nil) })
+	assert.Equal(t, 2, code)
+}

--- a/cmd/mdsmith/rename.go
+++ b/cmd/mdsmith/rename.go
@@ -1,0 +1,395 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/jeduden/mdsmith/internal/index"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rename"
+)
+
+// renameOptions bundles the parsed CLI flags for `rename`.
+type renameOptions struct {
+	configPath   string
+	format       string
+	maxInputSize string
+	heading      bool
+	linkRef      bool
+	walk         walkCLI
+}
+
+// renameSummary is one rewritten file's record for `--format json`.
+type renameSummary struct {
+	File  string `json:"file"`
+	Edits int    `json:"edits"`
+}
+
+// cliRenameWorkspace backs the rename engine's Workspace seam with a
+// transient index over the discovered files plus on-disk reads,
+// mirroring how `deps` builds its graph. The key a file's edits group
+// under is its workspace-relative path — the same string the CLI
+// writes back to disk.
+type cliRenameWorkspace struct {
+	idx      *index.Index
+	relToAbs map[string]string
+	rootDir  string
+	maxBytes int64
+}
+
+// Trivial index pass-through; no dedicated test by design (covered
+// by the heading-rename behavioral tests via the engine).
+func (w cliRenameWorkspace) IncomingAnchorEdges(file, slug string) []index.Edge {
+	return w.idx.IncomingEdges(file, slug)
+}
+
+// Trivial index pass-through; no dedicated test by design.
+func (w cliRenameWorkspace) Files() []string { return w.idx.Files() }
+
+func (w cliRenameWorkspace) Resolve(file string) (string, []byte, bool) {
+	rel := index.NormalizePath(file)
+	abs, ok := w.relToAbs[rel]
+	if !ok {
+		abs = filepath.Join(w.rootDir, filepath.FromSlash(rel))
+	}
+	src, err := lint.ReadFileLimited(abs, w.maxBytes)
+	if err != nil {
+		return "", nil, false
+	}
+	return rel, src, true
+}
+
+// parseRenameFlags parses `mdsmith rename` flags and returns the
+// options plus the remaining positional arguments.
+func parseRenameFlags(args []string) (renameOptions, []string, error) {
+	fs := flag.NewFlagSet("rename", flag.ContinueOnError)
+	var (
+		opts                        renameOptions
+		noGitignore, followSymlinks bool
+	)
+	fs.StringVarP(&opts.configPath, "config", "c", "", "Override config file path")
+	fs.StringVarP(&opts.format, "format", "f", "text", "Output format: text, json")
+	fs.BoolVar(&opts.heading, "heading", false, "Rename a heading and every workspace anchor that targets it")
+	fs.BoolVar(&opts.linkRef, "link-ref", false, "Rename a link-reference label: the def and every use in the file")
+	fs.BoolVar(&noGitignore, "no-gitignore", false, "Disable .gitignore filtering when walking directories")
+	fs.BoolVar(&followSymlinks, "follow-symlinks", false,
+		"Follow symlinks; omitted defers to follow-symlinks config (default skip); "+
+			"=false forces skip over any config opt-in")
+	fs.StringVar(&opts.maxInputSize, "max-input-size", "",
+		"Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, "Usage: mdsmith rename [flags] <file> <old> <new>\n\n"+
+			"Rename a heading or a link-reference label, rewriting every\n"+
+			"dependent edit across the workspace in place. Exactly one of\n"+
+			"--heading or --link-ref is required.\n\n"+
+			"  mdsmith rename docs/a.md --heading \"Old Title\" \"New Title\"\n"+
+			"  mdsmith rename docs/a.md --link-ref oldlabel newlabel\n\n"+
+			"Exit codes: 0 rewritten, 1 no match, 2 error or conflict\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return opts, nil, err
+	}
+	opts.walk = walkCLI{
+		noGitignore:    noGitignore,
+		followSymlinks: followSymlinksOverride(fs, followSymlinks),
+	}
+	return opts, fs.Args(), nil
+}
+
+// runRename implements the "rename" subcommand: rename a heading or a
+// link-reference label and rewrite every dependent edit in place.
+func runRename(args []string) int {
+	opts, posArgs, err := parseRenameFlags(args)
+	if err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: rename"); code >= 0 {
+			return code
+		}
+	}
+	if opts.heading == opts.linkRef {
+		fmt.Fprint(os.Stderr, "mdsmith: rename requires exactly one of --heading or --link-ref\n")
+		return 2
+	}
+	if len(posArgs) != 3 {
+		fmt.Fprint(os.Stderr, "mdsmith: rename requires <file> <old> <new>\n")
+		return 2
+	}
+	target := normalizeWorkspacePath(posArgs[0])
+	if !isWorkspaceRelativeTarget(target) {
+		fmt.Fprintf(os.Stderr, "mdsmith: target %q must be workspace-relative\n", target)
+		return 2
+	}
+	oldName, newName := posArgs[1], posArgs[2]
+
+	ws, src, code := buildRenameWorkspace(opts, target)
+	if code >= 0 {
+		return code
+	}
+
+	changes, code := computeRenameChanges(ws, target, src, oldName, newName, opts.heading)
+	if code >= 0 {
+		return code
+	}
+	return applyAndReport(os.Stdout, ws, changes, opts.format)
+}
+
+// buildRenameWorkspace discovers the workspace, builds the transient
+// index, and reads the target file's bytes. A non-negative return
+// code means stop (0 = empty workspace, 2 = error); src is the target
+// source on the success path.
+func buildRenameWorkspace(opts renameOptions, target string) (cliRenameWorkspace, []byte, int) {
+	cfg, cfgPath, _, files, code := discoverFiles(opts.configPath, false, opts.walk)
+	if code >= 0 {
+		if code == 0 {
+			fmt.Fprint(os.Stderr, "mdsmith: no Markdown files in workspace\n")
+			return cliRenameWorkspace{}, nil, 1
+		}
+		return cliRenameWorkspace{}, nil, code
+	}
+	maxBytes, err := resolveMaxInputBytes(cfg, opts.maxInputSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return cliRenameWorkspace{}, nil, 2
+	}
+	rootDir := rootDirFromConfig(cfgPath)
+	relToAbs := make(map[string]string, len(files))
+	rels := make([]string, 0, len(files))
+	for _, srcPath := range files {
+		rel := index.NormalizePath(workspaceRelativePath(srcPath, rootDir))
+		relToAbs[rel] = srcPath
+		rels = append(rels, rel)
+	}
+	idx := index.New(rootDir)
+	idx.BuildSerial(rels, func(rel string) ([]byte, error) {
+		return lint.ReadFileLimited(relToAbs[rel], maxBytes)
+	})
+	ws := cliRenameWorkspace{idx: idx, relToAbs: relToAbs, rootDir: rootDir, maxBytes: maxBytes}
+	_, src, ok := ws.Resolve(target)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "mdsmith: cannot read %q\n", target)
+		return cliRenameWorkspace{}, nil, 2
+	}
+	return ws, src, -1
+}
+
+// computeRenameChanges runs the rename engine for the requested mode
+// and maps a typed engine error to the CLI exit contract: 1 when
+// nothing matched, 2 on a conflict or invalid input.
+func computeRenameChanges(
+	ws cliRenameWorkspace, target string, src []byte,
+	oldName, newName string, isHeading bool,
+) (map[string][]rename.Edit, int) {
+	if isHeading {
+		line, ok := rename.FindHeadingLine(src, oldName)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "mdsmith: no heading %q in %s\n", oldName, target)
+			return nil, 1
+		}
+		changes, err := rename.Heading(ws, target, target, src, line, oldName, newName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+			return nil, 2
+		}
+		if len(changes) == 0 {
+			fmt.Fprintf(os.Stderr, "mdsmith: nothing to rename for heading %q\n", oldName)
+			return nil, 1
+		}
+		return changes, -1
+	}
+	edits, err := rename.LinkRef(src, rename.NormalizeLabel(oldName), newName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, 2
+	}
+	if len(edits) == 0 {
+		fmt.Fprintf(os.Stderr, "mdsmith: no link reference %q in %s\n", oldName, target)
+		return nil, 1
+	}
+	return map[string][]rename.Edit{target: edits}, -1
+}
+
+// applyAndReport writes every change to disk and prints the per-file
+// summary. Returns 0 on success, 2 on a write or render failure.
+func applyAndReport(
+	w io.Writer, ws cliRenameWorkspace,
+	changes map[string][]rename.Edit, format string,
+) int {
+	summaries := make([]renameSummary, 0, len(changes))
+	for rel, edits := range changes {
+		_, src, ok := ws.Resolve(rel)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "mdsmith: cannot read %q to apply edits\n", rel)
+			return 2
+		}
+		out, err := applyEdits(src, edits)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: %s: %v\n", rel, err)
+			return 2
+		}
+		abs, ok := ws.relToAbs[rel]
+		if !ok {
+			abs = filepath.Join(ws.rootDir, filepath.FromSlash(rel))
+		}
+		if err := writeFilePreservingMode(abs, out); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: writing %s: %v\n", rel, err)
+			return 2
+		}
+		summaries = append(summaries, renameSummary{File: rel, Edits: len(edits)})
+	}
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].File < summaries[j].File })
+	return emitRenameSummary(w, summaries, format)
+}
+
+// emitRenameSummary renders the rewritten-file list. Exit code: 0 on
+// success, 2 on unknown format or write error.
+func emitRenameSummary(w io.Writer, summaries []renameSummary, format string) int {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(summaries); err != nil {
+			fmt.Fprintf(os.Stderr, "mdsmith: writing json: %v\n", err)
+			return 2
+		}
+	case "text", "":
+		for _, s := range summaries {
+			if _, err := fmt.Fprintf(w, "%s: %d edit(s)\n", s.File, s.Edits); err != nil {
+				fmt.Fprintf(os.Stderr, "mdsmith: writing output: %v\n", err)
+				return 2
+			}
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "mdsmith: unknown --format %q (want text or json)\n", format)
+		return 2
+	}
+	return 0
+}
+
+// applyEdits splices every edit into src and returns the rewritten
+// bytes. Each edit is single-line (heading text, label, or fragment).
+// Edits on the same line are applied right-to-left so a left edit's
+// byte offsets — computed against the original row — stay valid while
+// the bytes to its right are rewritten. A trailing `\r` is preserved
+// so CRLF files round-trip.
+func applyEdits(src []byte, edits []rename.Edit) ([]byte, error) {
+	segs := splitKeepCR(src)
+	byLine := map[int][]rename.Edit{}
+	for _, e := range edits {
+		if e.Range.Start.Line != e.Range.End.Line {
+			return nil, errors.New("multi-line edit is not supported")
+		}
+		byLine[e.Range.Start.Line] = append(byLine[e.Range.Start.Line], e)
+	}
+	for line, es := range byLine {
+		if line < 0 || line >= len(segs) {
+			return nil, fmt.Errorf("edit line %d out of range", line+1)
+		}
+		seg := segs[line]
+		cr := len(seg) > 0 && seg[len(seg)-1] == '\r'
+		row := seg
+		if cr {
+			row = seg[:len(seg)-1]
+		}
+		sort.SliceStable(es, func(i, j int) bool {
+			return es[i].Range.Start.Character > es[j].Range.Start.Character
+		})
+		buf := append([]byte(nil), row...)
+		for _, e := range es {
+			s := utf16ToByteOffset(row, e.Range.Start.Character)
+			en := utf16ToByteOffset(row, e.Range.End.Character)
+			if s < 0 || en < 0 || s > len(buf) || en > len(buf) || s > en {
+				return nil, fmt.Errorf("edit offset [%d,%d) out of range on line %d", s, en, line+1)
+			}
+			next := make([]byte, 0, len(buf)-(en-s)+len(e.NewText))
+			next = append(next, buf[:s]...)
+			next = append(next, e.NewText...)
+			next = append(next, buf[en:]...)
+			buf = next
+		}
+		if cr {
+			buf = append(buf, '\r')
+		}
+		segs[line] = buf
+	}
+	return joinLF(segs), nil
+}
+
+// splitKeepCR splits src on `\n`, keeping any trailing `\r` on each
+// segment so CRLF endings survive a round-trip.
+func splitKeepCR(src []byte) [][]byte {
+	var segs [][]byte
+	start := 0
+	for i := 0; i < len(src); i++ {
+		if src[i] == '\n' {
+			segs = append(segs, src[start:i])
+			start = i + 1
+		}
+	}
+	segs = append(segs, src[start:])
+	return segs
+}
+
+// joinLF rejoins segments with `\n`, the inverse of splitKeepCR.
+func joinLF(segs [][]byte) []byte {
+	var out []byte
+	for i, s := range segs {
+		if i > 0 {
+			out = append(out, '\n')
+		}
+		out = append(out, s...)
+	}
+	return out
+}
+
+// utf16ToByteOffset returns the byte offset in row at the given
+// UTF-16 code-unit offset, the inverse of the engine's
+// byte→UTF-16 mapping. Offsets past the row's end clamp to len(row)
+// so a defensive guard upstream still sees an in-range value.
+func utf16ToByteOffset(row []byte, target int) int {
+	if target <= 0 {
+		return 0
+	}
+	units := 0
+	for i := 0; i < len(row); {
+		if units >= target {
+			return i
+		}
+		r, size := utf8.DecodeRune(row[i:])
+		units += nonNegativeUTF16RuneLen(r)
+		i += size
+	}
+	return len(row)
+}
+
+// nonNegativeUTF16RuneLen wraps utf16.RuneLen so its negative
+// "invalid code point" return (e.g. a lone surrogate) cannot
+// decrement the running UTF-16 unit count. utf8.DecodeRune maps
+// invalid bytes to RuneError (width 1), so in practice the guard is
+// defensive against an out-of-range rune reaching this path.
+func nonNegativeUTF16RuneLen(r rune) int {
+	if w := utf16.RuneLen(r); w >= 0 {
+		return w
+	}
+	return 1
+}
+
+// writeFilePreservingMode overwrites path with data, keeping the
+// file's existing permission bits.
+func writeFilePreservingMode(path string, data []byte) error {
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	return os.WriteFile(path, data, mode)
+}

--- a/cmd/mdsmith/rename_unit_test.go
+++ b/cmd/mdsmith/rename_unit_test.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/rename"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renameWorkspace creates a minimal project (.git + .mdsmith.yml +
+// linked docs) and chdirs into it so runRename's discovery resolves
+// against it, mirroring depsWorkspace.
+func renameWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	wf := func(rel, body string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, rel)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644))
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	wf(".mdsmith.yml", "files:\n  - \"**/*.md\"\nrules:\n  cross-file-reference-integrity: false\n")
+	wf("a.md", "# Setup\n\nBody.\n")
+	wf("b.md", "See [go](a.md#setup) and [the docs][docs].\n\n[docs]: https://x.example\n")
+	t.Chdir(dir)
+	return dir
+}
+
+func TestParseRenameFlags(t *testing.T) {
+	opts, pos, err := parseRenameFlags([]string{"--heading", "a.md", "Old", "New"})
+	require.NoError(t, err)
+	assert.True(t, opts.heading)
+	assert.Equal(t, []string{"a.md", "Old", "New"}, pos)
+
+	_, _, err = parseRenameFlags([]string{"--unknown"})
+	require.Error(t, err)
+}
+
+func TestRunRename_FlagAndArgValidation(t *testing.T) {
+	renameWorkspace(t)
+	// --help is a pflag ErrHelp: reportFlagParseErr returns 0.
+	assert.Equal(t, 0, runRename([]string{"--help"}))
+	// Neither mode flag.
+	assert.Equal(t, 2, runRename([]string{"a.md", "Old", "New"}))
+	// Both mode flags.
+	assert.Equal(t, 2, runRename([]string{"--heading", "--link-ref", "a.md", "O", "N"}))
+	// Wrong positional count.
+	assert.Equal(t, 2, runRename([]string{"--heading", "a.md", "Old"}))
+	// Not workspace-relative.
+	assert.Equal(t, 2, runRename([]string{"--heading", "/abs/a.md", "Old", "New"}))
+}
+
+func TestRunRename_HeadingSuccess(t *testing.T) {
+	dir := renameWorkspace(t)
+	code := runRename([]string{"--heading", "a.md", "Setup", "Install"})
+	assert.Equal(t, 0, code)
+	a, _ := os.ReadFile(filepath.Join(dir, "a.md"))
+	assert.Contains(t, string(a), "# Install")
+	b, _ := os.ReadFile(filepath.Join(dir, "b.md"))
+	assert.Contains(t, string(b), "a.md#install")
+}
+
+func TestRunRename_LinkRefSuccess(t *testing.T) {
+	dir := renameWorkspace(t)
+	code := runRename([]string{"--link-ref", "b.md", "docs", "rfc"})
+	assert.Equal(t, 0, code)
+	b, _ := os.ReadFile(filepath.Join(dir, "b.md"))
+	assert.Contains(t, string(b), "[the docs][rfc]")
+	assert.Contains(t, string(b), "[rfc]: https://x.example")
+}
+
+func TestRunRename_NoMatchAndConflict(t *testing.T) {
+	dir := renameWorkspace(t)
+	// Heading text not present → exit 1.
+	assert.Equal(t, 1, runRename([]string{"--heading", "a.md", "Ghost", "X"}))
+	// Link-ref label not present → exit 1.
+	assert.Equal(t, 1, runRename([]string{"--link-ref", "a.md", "ghost", "x"}))
+	// Heading collision → exit 2.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.md"),
+		[]byte("# Alpha\n\n## Beta\n"), 0o644))
+	assert.Equal(t, 2, runRename([]string{"--heading", "c.md", "Alpha", "Beta"}))
+	// Heading no-op (same text) → empty changes → exit 1.
+	assert.Equal(t, 1, runRename([]string{"--heading", "a.md", "Setup", "Setup"}))
+	// Link-ref invalid rune → exit 2.
+	assert.Equal(t, 2, runRename([]string{"--link-ref", "b.md", "docs", "bad]label"}))
+}
+
+func TestRunRename_JSONFormat(t *testing.T) {
+	renameWorkspace(t)
+	var code int
+	out := captureStdout(func() {
+		code = runRename([]string{"--heading", "--format", "json", "a.md", "Setup", "Install"})
+	})
+	assert.Equal(t, 0, code)
+	assert.Contains(t, out, `"file": "a.md"`)
+	assert.Contains(t, out, `"edits": 1`)
+}
+
+func TestBuildRenameWorkspace_DiscoveryPaths(t *testing.T) {
+	t.Run("missing config exits 2", func(t *testing.T) {
+		renameWorkspace(t)
+		opts := renameOptions{configPath: "/no/such/.mdsmith.yml"}
+		_, _, code := buildRenameWorkspace(opts, "a.md")
+		assert.Equal(t, 2, code)
+	})
+	t.Run("empty workspace exits 1", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+			[]byte("files:\n  - \"nope/*.md\"\n"), 0o644))
+		t.Chdir(dir)
+		_, _, code := buildRenameWorkspace(renameOptions{}, "a.md")
+		assert.Equal(t, 1, code)
+	})
+	t.Run("bad max-input-size exits 2", func(t *testing.T) {
+		renameWorkspace(t)
+		_, _, code := buildRenameWorkspace(renameOptions{maxInputSize: "notabytes"}, "a.md")
+		assert.Equal(t, 2, code)
+	})
+	t.Run("unreadable target exits 2", func(t *testing.T) {
+		renameWorkspace(t)
+		_, _, code := buildRenameWorkspace(renameOptions{}, "missing.md")
+		assert.Equal(t, 2, code)
+	})
+}
+
+func TestComputeRenameChanges(t *testing.T) {
+	renameWorkspace(t)
+	ws, src, code := buildRenameWorkspace(renameOptions{}, "a.md")
+	require.Equal(t, -1, code)
+
+	changes, c := computeRenameChanges(ws, "a.md", src, "Setup", "Install", true)
+	assert.Equal(t, -1, c)
+	assert.Contains(t, changes, "a.md")
+
+	_, c = computeRenameChanges(ws, "a.md", src, "Ghost", "X", true)
+	assert.Equal(t, 1, c)
+}
+
+func TestApplyAndReport_Errors(t *testing.T) {
+	renameWorkspace(t)
+	ws, _, code := buildRenameWorkspace(renameOptions{}, "a.md")
+	require.Equal(t, -1, code)
+
+	// A change keyed at an unreadable path → exit 2.
+	got := applyAndReport(&bytes.Buffer{}, ws,
+		map[string][]rename.Edit{"missing.md": {{NewText: "x"}}}, "text")
+	assert.Equal(t, 2, got)
+
+	// applyEdits fails on an out-of-range line → exit 2.
+	bad := map[string][]rename.Edit{"a.md": {{
+		Range:   rename.Range{Start: rename.Position{Line: 99}, End: rename.Position{Line: 99}},
+		NewText: "x",
+	}}}
+	assert.Equal(t, 2, applyAndReport(&bytes.Buffer{}, ws, bad, "text"))
+}
+
+func TestEmitRenameSummary(t *testing.T) {
+	sums := []renameSummary{{File: "a.md", Edits: 2}}
+
+	var buf bytes.Buffer
+	assert.Equal(t, 0, emitRenameSummary(&buf, sums, "text"))
+	assert.Contains(t, buf.String(), "a.md: 2 edit(s)")
+
+	buf.Reset()
+	assert.Equal(t, 0, emitRenameSummary(&buf, sums, "json"))
+	assert.Contains(t, buf.String(), `"edits": 2`)
+
+	assert.Equal(t, 2, emitRenameSummary(&buf, sums, "yaml"))
+
+	// A writer that always errors drives the json and text write-error
+	// arms.
+	ew := &errWriter{err: errors.New("boom")}
+	assert.Equal(t, 2, emitRenameSummary(ew, sums, "json"))
+	assert.Equal(t, 2, emitRenameSummary(ew, sums, "text"))
+}
+
+// mkEdit builds a single-line rename.Edit, keeping the table-style
+// test cases below readable.
+func mkEdit(line, startCh, endCh int, text string) rename.Edit {
+	return rename.Edit{
+		Range: rename.Range{
+			Start: rename.Position{Line: line, Character: startCh},
+			End:   rename.Position{Line: line, Character: endCh},
+		},
+		NewText: text,
+	}
+}
+
+func TestApplyEdits(t *testing.T) {
+	t.Run("single edit", func(t *testing.T) {
+		out, err := applyEdits([]byte("# Setup\n"), []rename.Edit{mkEdit(0, 2, 7, "Install")})
+		require.NoError(t, err)
+		assert.Equal(t, "# Install\n", string(out))
+	})
+	t.Run("two edits same line apply right-to-left", func(t *testing.T) {
+		// `[a](#x) [b](#y)` → rewrite both fragments.
+		out, err := applyEdits([]byte("[a](#x) [b](#y)\n"), []rename.Edit{
+			mkEdit(0, 5, 6, "X"),
+			mkEdit(0, 13, 14, "Y"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "[a](#X) [b](#Y)\n", string(out))
+	})
+	t.Run("CRLF preserved", func(t *testing.T) {
+		out, err := applyEdits([]byte("# Setup\r\n"), []rename.Edit{mkEdit(0, 2, 7, "X")})
+		require.NoError(t, err)
+		assert.Equal(t, "# X\r\n", string(out))
+	})
+	t.Run("multi-line edit rejected", func(t *testing.T) {
+		_, err := applyEdits([]byte("a\nb\n"), []rename.Edit{{
+			Range: rename.Range{Start: rename.Position{Line: 0}, End: rename.Position{Line: 1}},
+		}})
+		require.Error(t, err)
+	})
+	t.Run("line out of range", func(t *testing.T) {
+		_, err := applyEdits([]byte("a\n"), []rename.Edit{mkEdit(9, 0, 0, "")})
+		require.Error(t, err)
+	})
+	t.Run("offset out of range", func(t *testing.T) {
+		// Start past End after mapping → the s>en guard fires.
+		_, err := applyEdits([]byte("abcd\n"), []rename.Edit{mkEdit(0, 3, 1, "x")})
+		require.Error(t, err)
+	})
+}
+
+func TestSplitKeepCRAndJoinLF(t *testing.T) {
+	src := []byte("a\r\nb\nc")
+	segs := splitKeepCR(src)
+	assert.Equal(t, [][]byte{[]byte("a\r"), []byte("b"), []byte("c")}, segs)
+	assert.Equal(t, src, joinLF(segs))
+	// Trailing newline yields a trailing empty segment that round-trips.
+	assert.Equal(t, []byte("x\n"), joinLF(splitKeepCR([]byte("x\n"))))
+}
+
+func TestUtf16ToByteOffset(t *testing.T) {
+	assert.Equal(t, 0, utf16ToByteOffset([]byte("abc"), 0))
+	assert.Equal(t, 0, utf16ToByteOffset([]byte("abc"), -1))
+	assert.Equal(t, 2, utf16ToByteOffset([]byte("abc"), 2))
+	assert.Equal(t, 3, utf16ToByteOffset([]byte("abc"), 9)) // clamp past end
+	// "é" is one UTF-16 unit but two UTF-8 bytes; "𝄞" is a surrogate
+	// pair (two UTF-16 units, four bytes).
+	row := []byte("é𝄞z")
+	assert.Equal(t, 2, utf16ToByteOffset(row, 1)) // past "é"
+	assert.Equal(t, 6, utf16ToByteOffset(row, 3)) // past the surrogate pair
+}
+
+func TestNonNegativeUTF16RuneLen(t *testing.T) {
+	assert.Equal(t, 1, nonNegativeUTF16RuneLen('a'))
+	assert.Equal(t, 2, nonNegativeUTF16RuneLen('𝄞'))
+	// A lone surrogate is an invalid scalar: utf16.RuneLen returns
+	// -1, and the guard floors it at 1.
+	assert.Equal(t, 1, nonNegativeUTF16RuneLen(rune(0xD800)))
+}
+
+func TestRunRename_FlagParseError(t *testing.T) {
+	renameWorkspace(t)
+	// An unknown flag is a non-help parse error → exit 2.
+	assert.Equal(t, 2, runRename([]string{"--bogus", "a.md", "O", "N"}))
+}
+
+func TestRunRename_WorkspaceBuildFailure(t *testing.T) {
+	renameWorkspace(t)
+	// A missing config makes buildRenameWorkspace return 2, which
+	// runRename propagates.
+	assert.Equal(t, 2, runRename([]string{
+		"--heading", "--config", "/no/such/.mdsmith.yml", "a.md", "Setup", "Install",
+	}))
+}
+
+func TestApplyAndReport_WriteErrorAndFallback(t *testing.T) {
+	dir := t.TempDir()
+	rel := "a.md"
+	abs := filepath.Join(dir, rel)
+	require.NoError(t, os.WriteFile(abs, []byte("# Setup\n"), 0o644))
+
+	// relToAbs is empty so Resolve + applyAndReport take the
+	// rootDir-join fallback; the edit applies and the file is
+	// rewritten.
+	ws := cliRenameWorkspace{relToAbs: map[string]string{}, rootDir: dir}
+	edit := rename.Edit{
+		Range: rename.Range{
+			Start: rename.Position{Line: 0, Character: 2},
+			End:   rename.Position{Line: 0, Character: 7},
+		},
+		NewText: "Install",
+	}
+	var buf bytes.Buffer
+	require.Equal(t, 0, applyAndReport(&buf, ws,
+		map[string][]rename.Edit{rel: {edit}}, "text"))
+	got, _ := os.ReadFile(abs)
+	assert.Contains(t, string(got), "# Install")
+
+	// Resolve normalizes "./sub" → "sub" and reads the mapped file
+	// (ok), but applyAndReport's raw-key lookup misses and falls back
+	// to rootDir/sub — a directory — so writeFilePreservingMode fails
+	// → exit 2. This drives the write-error arm without relying on
+	// permission bits (the test runs as root).
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0o755))
+	ws2 := cliRenameWorkspace{relToAbs: map[string]string{"sub": abs}, rootDir: dir}
+	code := applyAndReport(&bytes.Buffer{}, ws2,
+		map[string][]rename.Edit{"./sub": {edit}}, "text")
+	assert.Equal(t, 2, code)
+}
+
+func TestWriteFilePreservingMode(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.md")
+	require.NoError(t, os.WriteFile(p, []byte("old"), 0o640))
+	require.NoError(t, writeFilePreservingMode(p, []byte("new")))
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+
+	// Non-existent file: stat fails, default mode, write succeeds.
+	np := filepath.Join(dir, "new.md")
+	require.NoError(t, writeFilePreservingMode(np, []byte("x")))
+
+	// Writing to a directory path fails.
+	require.Error(t, writeFilePreservingMode(dir, []byte("x")))
+}
+
+func TestCliRenameWorkspace_Resolve(t *testing.T) {
+	dir := t.TempDir()
+	abs := filepath.Join(dir, "a.md")
+	require.NoError(t, os.WriteFile(abs, []byte("# A\n"), 0o644))
+	ws := cliRenameWorkspace{
+		relToAbs: map[string]string{"a.md": abs},
+		rootDir:  dir,
+		maxBytes: 0,
+	}
+	key, src, ok := ws.Resolve("a.md")
+	require.True(t, ok)
+	assert.Equal(t, "a.md", key)
+	assert.Equal(t, "# A\n", string(src))
+
+	// Path not in relToAbs falls back to rootDir join.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.md"), []byte("# B\n"), 0o644))
+	_, _, ok = ws.Resolve("b.md")
+	assert.True(t, ok)
+
+	// Unreadable file → ok=false.
+	_, _, ok = ws.Resolve("missing.md")
+	assert.False(t, ok)
+}

--- a/docs/features/rename.md
+++ b/docs/features/rename.md
@@ -37,7 +37,26 @@ that collides with another definition fails the same way.
 Text that slugifies to nothing, or that contains a newline
 or a stray bracket, is rejected before any edit applies.
 
-Today this is the LSP `rename` capability: any LSP-aware
-editor, and the Claude Code agent, can drive it. See the
+Any LSP-aware editor, and the Claude Code agent, can
+drive this over the wire. See the
 [LSP reference](../reference/cli/lsp.md) for the
 prepare-range table and the collision-error contract.
+
+## From the command line
+
+The same rename engine has a CLI surface, so a script or
+an agent with no editor reaches it too:
+
+```bash
+mdsmith rename docs/guide.md --heading "Old Title" "New Title"
+mdsmith rename docs/guide.md --link-ref oldlabel newlabel
+```
+
+`--heading` matches the heading's current visible text;
+`--link-ref` matches the label. The command rewrites
+every dependent edit in place and prints a per-file
+summary (`--format text|json`). A collision, an empty or
+bracket-bearing name, or a missing target exits non-zero
+and names the conflict, exactly like the editor path. See
+the [`mdsmith rename` reference](../reference/cli/rename.md)
+for flags, output, and exit codes.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 | [`merge-driver`](cli/merge-driver.md)         | Git merge driver that resolves conflicts inside generated sections.                  |
 | [`metrics`](cli/metrics.md)                   | List and rank shared Markdown metrics (file length, token estimate, readability, …). |
 | [`pre-merge-commit`](cli/pre-merge-commit.md) | Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.      |
+| [`rename`](cli/rename.md)                     | Rename a heading or link-reference label and rewrite every dependent edit.           |
 | [`version`](cli/version.md)                   | Print the mdsmith build version and exit.                                            |
 <?/catalog?>
 

--- a/docs/reference/cli/rename.md
+++ b/docs/reference/cli/rename.md
@@ -1,0 +1,117 @@
+---
+command: rename
+summary: Rename a heading or link-reference label and rewrite every dependent edit.
+---
+# `mdsmith rename`
+
+Rename a heading or a link-reference label and rewrite
+every dependent edit across the workspace in place. This
+is the CLI surface for the same rename engine the LSP
+server drives, so a script or agent with no editor reaches
+it too.
+
+```text
+mdsmith rename [flags] <file> <old> <new>
+```
+
+`<file>` is workspace-relative. Absolute paths and
+parent-traversal entries (`../foo.md`) are rejected with
+exit code 2. Exactly one of `--heading` or `--link-ref`
+is required.
+
+With `--heading`, `<old>` is the heading's current visible
+text. mdsmith rewrites the heading line. It also rewrites
+every workspace `](file.md#slug)` anchor and every
+`[label]: file.md#slug` ref-def whose target resolved to
+it. Same-file `(#slug)` references are included. A
+duplicate-name disambiguator that shifts as a result is
+updated too.
+
+With `--link-ref`, `<old>` is the label. It is matched
+after the lowercase / whitespace-collapse normalization
+links already use. The `[label]: url` definition moves
+with every `[text][label]` and shortcut `[label]` use in
+the file.
+
+The rename refuses to corrupt the workspace. It fails when
+the new heading slug collides with another heading. It
+fails when the label collides with another definition. It
+fails when the text slugifies to nothing, or carries a
+newline or a stray bracket. Each failure exits 2 and names
+the conflict. No partial edit is written.
+
+## Flags
+
+| Flag                | Default | Description                                |
+|---------------------|---------|--------------------------------------------|
+| `--heading`         | false   | Rename a heading and its workspace anchors |
+| `--link-ref`        | false   | Rename a link-ref label: def + uses        |
+| `-c`, `--config`    | auto    | Override config path                       |
+| `-f`, `--format`    | `text`  | Output format: `text` or `json`            |
+| `--no-gitignore`    | false   | Disable `.gitignore` filtering during walk |
+| `--follow-symlinks` | config  | Follow symlinks; tri-state — see below     |
+| `--max-input-size`  | `2MB`   | Max file size (e.g. `2MB`, `0`=none)       |
+
+`--follow-symlinks` semantics match
+[`mdsmith check`](check.md#flags). File discovery follows
+the `files:` patterns in `.mdsmith.yml` and the same
+`ignore:` rules `check` and `fix` use.
+
+## Output
+
+A summary of the rewritten files, one per line.
+
+**text** (default):
+
+```text
+docs/guide.md: 1 edit(s)
+docs/index.md: 2 edit(s)
+```
+
+**json**:
+
+```json
+[
+  {
+    "file": "docs/guide.md",
+    "edits": 1
+  }
+]
+```
+
+Rows are sorted by path. Keys are stable.
+
+## Examples
+
+Rename a heading and fix every link that pointed at it:
+
+```bash
+mdsmith rename docs/guide.md --heading "Old Title" "New Title"
+```
+
+Rename a link-reference label:
+
+```bash
+mdsmith rename docs/guide.md --link-ref oldlabel newlabel
+```
+
+JSON summary for a release script:
+
+```bash
+mdsmith rename --format json docs/guide.md --heading "Setup" "Install"
+```
+
+## Exit codes
+
+| Code | Meaning                        |
+|------|--------------------------------|
+| 0    | Rewritten                      |
+| 1    | No matching heading or label   |
+| 2    | Conflict, invalid input, error |
+
+## See also
+
+- [`mdsmith deps`](deps.md) — the dependency edges the
+  rename walks to find dependent anchors.
+- [`mdsmith lsp`](lsp.md) — the editor surface for the
+  same rename engine (prepare-range, collision data).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -32,6 +32,7 @@ row: "- [{summary}]({filename})"
 - [List and rank shared Markdown metrics (file length, token estimate, readability, …).](cli/metrics.md)
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](cli/query.md)
+- [Rename a heading or link-reference label and rewrite every dependent edit.](cli/rename.md)
 - [Print the mdsmith build version and exit.](cli/version.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](conventions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](globs.md)

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -2,18 +2,11 @@ package lsp
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/url"
+	"errors"
 	"sort"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/index"
-	"github.com/jeduden/mdsmith/internal/linkgraph"
-	"github.com/jeduden/mdsmith/internal/lint"
-	"github.com/jeduden/mdsmith/internal/mdtext"
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/text"
+	"github.com/jeduden/mdsmith/internal/rename"
 	"github.com/yuin/goldmark/util"
 )
 
@@ -75,16 +68,18 @@ func (s *Server) prepareRenameAt(source []byte, rel string, pos Position) (prepa
 }
 
 // isValidRefDefLine reports whether a 1-based source line holds a
-// real reference definition (one goldmark accepted), translating
-// the source-coordinate line into body coordinates so the
-// validRefDefBodyLines lookup matches.
+// real reference definition (one goldmark accepted), translating the
+// source-coordinate line into body coordinates so the
+// rename.ValidRefDefBodyLines lookup matches. The validation logic
+// lives in internal/rename so the LSP prepare-rename gate and the
+// rename engine agree on what counts as a real def.
 func isValidRefDefLine(source []byte, line int) bool {
-	body, fmOffset := bodyAndFMOffset(source)
+	body, fmOffset := rename.BodyAndFMOffset(source)
 	bodyLine := line - fmOffset
 	if bodyLine < 1 {
 		return false
 	}
-	return validRefDefBodyLines(body)[bodyLine]
+	return rename.ValidRefDefBodyLines(body)[bodyLine]
 }
 
 // headingPrepareRange builds the rename range for an ATX or setext
@@ -255,21 +250,21 @@ func refDefBracketBytes(row []byte) []int {
 		return nil
 	}
 	open := i + 1
-	close := -1
+	closeIdx := -1
 	for j := open; j < len(row); j++ {
 		if row[j] == ']' {
-			close = j
+			closeIdx = j
 			break
 		}
 	}
-	if close < 0 || close == open {
+	if closeIdx < 0 || closeIdx == open {
 		return nil
 	}
 	// After `]` we need `:` to qualify as a definition.
-	if close+1 >= len(row) || row[close+1] != ':' {
+	if closeIdx+1 >= len(row) || row[closeIdx+1] != ':' {
 		return nil
 	}
-	return []int{open, close}
+	return []int{open, closeIdx}
 }
 
 // refUsePrepareRange builds the rename range for a reference-style
@@ -379,1171 +374,6 @@ func normalizedLabel(b []byte) string {
 	return string(util.ToLinkReference(b))
 }
 
-// firstControlRune returns the first newline / carriage return in
-// s, or 0 when the string is a single line. Used to keep
-// single-line surfaces (heading text, link-ref labels) from being
-// rewritten into multi-line garbage.
-func firstControlRune(s string) rune {
-	for _, r := range s {
-		if r == '\n' || r == '\r' {
-			return r
-		}
-	}
-	return 0
-}
-
-// invalidLinkRefRune returns the first rune in s that would make
-// the resulting `[label]: …` line unparsable, or 0 when s is safe.
-//
-// Newlines force the label run onto a second line where the def
-// no longer parses. `]` ends the label early, leaving the rest
-// as paragraph text. `[` is technically permitted via escape
-// (`\[`), but emitting a raw `[` here would still confuse most
-// CommonMark renderers and our own ref-def regex, so we forbid
-// both bracket forms outright rather than auto-escaping the user's
-// typed text.
-func invalidLinkRefRune(s string) rune {
-	for _, r := range s {
-		switch r {
-		case '\n', '\r', '[', ']':
-			return r
-		}
-	}
-	return 0
-}
-
-// handleRename answers textDocument/rename. The reply is a
-// WorkspaceEdit that covers every affected file. Heading rename
-// rewrites incoming anchor links across the workspace; link-ref
-// label rename rewrites the def and every use in the same file.
-// Collisions return InvalidParams with renameCollisionData so the
-// client can show a meaningful error instead of partially applying
-// an edit.
-func (s *Server) handleRename(msg *requestMessage) {
-	var p renameParams
-	if err := json.Unmarshal(msg.Params, &p); err != nil {
-		_ = s.t.writeError(msg.ID, codeInvalidParams, "invalid rename params")
-		return
-	}
-	source, rel, ok := s.docTextOrFile(p.TextDocument.URI)
-	if !ok {
-		_ = s.t.writeResponse(msg.ID, nil)
-		return
-	}
-	line := p.Position.Line + 1
-	col := lspPositionToByteColumn(source, line, p.Position.Character)
-	res := index.Locator{Path: rel}.Locate(source, line, col)
-	switch res.Tag {
-	case index.TokenHeading:
-		s.renameHeading(msg, p, source, rel, line, res, p.NewName)
-	case index.TokenRefDef:
-		// Mirror prepareRename's gate: a `[label]: url`-shaped
-		// line inside a fenced code block or PI body isn't a
-		// real def, so refuse the rename rather than producing
-		// empty / off-target edits.
-		if !isValidRefDefLine(source, line) {
-			_ = s.t.writeError(msg.ID, codeInvalidParams, "rename not supported at this position")
-			return
-		}
-		s.renameLinkRef(msg, p, source, res.Label, p.NewName)
-	case index.TokenRefUse:
-		s.renameLinkRef(msg, p, source, res.Label, p.NewName)
-	default:
-		_ = s.t.writeError(msg.ID, codeInvalidParams, "rename not supported at this position")
-	}
-}
-
-// renameHeading rewrites a heading and every workspace anchor link
-// pointing at it.
-//
-// Algorithm:
-//  1. Recompute the file's heading slug map under the new heading
-//     text. The pass mirrors mdtext.CollectTOCItems' disambiguator
-//     logic via assignSlugs, but walks every heading (including
-//     empty-slug ones CollectTOCItems would skip) so the slug
-//     map stays aligned with the rename's heading walk.
-//  2. Reject the rename when its new bare slug collides with another
-//     heading's bare slug (a *new* duplicate would force the
-//     disambiguator to shift in surprising ways; cross-file links
-//     would silently break).
-//  3. Compare old and new slug maps to identify shifted headings.
-//  4. Build TextEdits: replace the heading text on the source line
-//     and rewrite every incoming anchor link for each (file,
-//     oldSlug → newSlug) pair.
-func (s *Server) renameHeading(
-	msg *requestMessage, p renameParams,
-	source []byte, rel string, line int, res index.LocateResult, newName string,
-) {
-	idx := s.ensureIndex()
-	oldText := res.Name
-	if strings.TrimSpace(newName) == strings.TrimSpace(oldText) {
-		_ = s.t.writeResponse(msg.ID, &workspaceEdit{Changes: map[string][]textEdit{}})
-		return
-	}
-	// Reject newName values that would corrupt the heading line.
-	// A `\n` or `\r` turns a single-line heading into a multi-line
-	// insertion, splitting the document at the source location.
-	if r := firstControlRune(newName); r != 0 {
-		_ = s.t.writeError(msg.ID, codeInvalidParams,
-			fmt.Sprintf("heading text cannot contain %q", r))
-		return
-	}
-	// Reject a new heading text that slugifies to nothing (e.g.
-	// punctuation-only). The renamed heading would have no
-	// addressable anchor — CollectTOCItems and the index's heading
-	// walk both skip empty slugs — so cross-file links would have
-	// nowhere to land. The check is unconditional so the behavior
-	// matches the docs: any rename to an empty-slug name fails,
-	// regardless of whether the old heading had a slug.
-	if mdtext.Slugify(newName) == "" {
-		_ = s.t.writeError(msg.ID, codeInvalidParams,
-			"new heading text has no addressable slug; pick text containing letters or digits")
-		return
-	}
-	oldSlugs, newSlugs, conflict := computeSlugRemap(source, line, newName)
-	if conflict != "" {
-		_ = s.t.writeErrorWithData(msg.ID, codeInvalidParams,
-			"rename would collide with heading "+conflict,
-			renameCollisionData{Conflict: conflict})
-		return
-	}
-	// headingTextEdit is reachable only when the cursor's line
-	// is inside the source — the locator would have returned
-	// TokenNone otherwise — so the false branch is unreachable
-	// here.
-	headingEdit, _ := headingTextEdit(source, line, newName)
-	changes := map[string][]textEdit{p.TextDocument.URI: {headingEdit}}
-	for old, new := range slugRemapPairs(oldSlugs, newSlugs) {
-		// slugRemapPairs already filters empty and unchanged
-		// slugs, so no redundant guard is needed here.
-		s.appendAnchorEditsForHeading(changes, idx, rel, old, new)
-		// Ref-def destinations like `[label]: ./a.md#slug` aren't
-		// recorded as edges in the index (defs are symbols, not
-		// edges; only their uses become EdgeRefLink). Walk every
-		// workspace file once per shifted slug to find ref-defs
-		// whose destination resolves to the renamed heading.
-		s.appendRefDefDestEditsForHeading(changes, idx, rel, old, new)
-	}
-	stableSortEdits(changes)
-	_ = s.t.writeResponse(msg.ID, &workspaceEdit{Changes: changes})
-}
-
-// computeSlugRemap returns the file's old slug list, its new slug
-// list (after substituting newText for the heading on `line`), and a
-// non-empty `conflict` heading name when the rename would create a
-// new duplicate base slug. The returned slices share index ordering:
-// oldSlugs[i] is the slug of the i-th heading before rename and
-// newSlugs[i] is its slug after.
-//
-// The walk includes every heading, including ones whose slug is
-// empty (punctuation-only text). Skipping them — as
-// mdtext.CollectTOCItems does — would desynchronize the per-heading
-// indices from the heading-line walk and mis-identify the renamed
-// heading on files with empty-slug headings before the cursor's
-// line. It would also block the case of renaming an empty-slug
-// heading to a real one (which can shift later disambiguators).
-func computeSlugRemap(source []byte, line int, newText string) ([]string, []string, string) {
-	body, fmOffset := bodyAndFMOffset(source)
-	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
-	headings := walkAllHeadings(root, body)
-	bodyLine := line - fmOffset
-	target := -1
-	for i, h := range headings {
-		if h.bodyLine == bodyLine {
-			target = i
-			break
-		}
-	}
-	if target < 0 {
-		return nil, nil, ""
-	}
-	texts := make([]string, len(headings))
-	for i, h := range headings {
-		texts[i] = h.text
-	}
-	oldBase := mdtext.Slugify(headings[target].text)
-	texts[target] = newText
-	// Collision check: any other heading shares the new bare slug?
-	// Skip the check when the rename keeps the same base slug —
-	// a non-semantic edit (case, punctuation) inside an existing
-	// duplicate-name group doesn't *introduce* a new collision,
-	// so blocking it would surprise the user.
-	newBase := mdtext.Slugify(newText)
-	if newBase != "" && newBase != oldBase {
-		for i, t := range texts {
-			if i == target {
-				continue
-			}
-			if mdtext.Slugify(t) == newBase {
-				return nil, nil, headings[i].text
-			}
-		}
-	}
-	oldSlugs := assignSlugs(slicesOfText(headings))
-	newSlugs := assignSlugs(texts)
-	return oldSlugs, newSlugs, ""
-}
-
-// headingWalk records the body-line and visible text of one heading
-// node. Carries no slug — the slug is computed in lockstep with the
-// rename so empty-slug headings don't get silently dropped.
-type headingWalk struct {
-	bodyLine int
-	text     string
-}
-
-// walkAllHeadings returns every heading in document order, including
-// ones whose slugified text is empty.
-func walkAllHeadings(root ast.Node, body []byte) []headingWalk {
-	var out []headingWalk
-	_ = ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		h, ok := n.(*ast.Heading)
-		if !ok || h.Lines().Len() == 0 {
-			return ast.WalkContinue, nil
-		}
-		out = append(out, headingWalk{
-			bodyLine: lineOfBodyOffset(body, h.Lines().At(0).Start),
-			text:     mdtext.ExtractPlainText(h, body),
-		})
-		return ast.WalkContinue, nil
-	})
-	return out
-}
-
-func slicesOfText(walks []headingWalk) []string {
-	out := make([]string, len(walks))
-	for i, w := range walks {
-		out[i] = w.text
-	}
-	return out
-}
-
-// assignSlugs runs the same disambiguator pass mdtext.CollectTOCItems
-// uses, but operates on a parallel slice of texts so callers can
-// substitute a renamed heading's text in place without losing
-// alignment with the heading walk. Headings whose base slug is
-// empty stay at "" — those have no anchor and never participate in
-// link rewrites.
-func assignSlugs(texts []string) []string {
-	used := map[string]bool{}
-	counts := map[string]int{}
-	out := make([]string, len(texts))
-	for i, t := range texts {
-		base := mdtext.Slugify(t)
-		if base == "" {
-			out[i] = ""
-			continue
-		}
-		anchor := base
-		if used[anchor] {
-			c := counts[base]
-			for {
-				c++
-				anchor = fmt.Sprintf("%s-%d", base, c)
-				if !used[anchor] {
-					break
-				}
-			}
-			counts[base] = c
-		}
-		used[anchor] = true
-		out[i] = anchor
-	}
-	return out
-}
-
-// slugRemapPairs returns a map from old slug to new slug for every
-// heading whose slug changed. Skips entries whose old slug is empty
-// (headings with no slug, e.g. punctuation-only).
-func slugRemapPairs(oldSlugs, newSlugs []string) map[string]string {
-	out := map[string]string{}
-	for i := range oldSlugs {
-		if oldSlugs[i] == "" || oldSlugs[i] == newSlugs[i] {
-			continue
-		}
-		// First wins when two old slugs map to the same new slug —
-		// shouldn't happen in practice because the disambiguator
-		// keeps slugs unique, but the guard prevents an inflated
-		// rewrite from a corrupted index.
-		if _, exists := out[oldSlugs[i]]; !exists {
-			out[oldSlugs[i]] = newSlugs[i]
-		}
-	}
-	return out
-}
-
-// headingTextEdit replaces the heading text on the source line with
-// newName. Returns false when the line is not recognized as a
-// heading line.
-func headingTextEdit(source []byte, line int, newName string) (textEdit, bool) {
-	lines := splitLines(source)
-	if line-1 >= len(lines) {
-		return textEdit{}, false
-	}
-	row := lines[line-1]
-	startByte, endByte, ok := atxHeadingTextByteRange(row)
-	if !ok {
-		startByte, endByte = trimmedRange(row)
-	}
-	startCh := utf16FromByteOffset(row, startByte)
-	endCh := utf16FromByteOffset(row, endByte)
-	return textEdit{
-		Range: Range{
-			Start: Position{Line: line - 1, Character: startCh},
-			End:   Position{Line: line - 1, Character: endCh},
-		},
-		NewText: newName,
-	}, true
-}
-
-// appendRefDefDestEditsForHeading rewrites `[label]: url`
-// definitions whose destination URL points at the renamed
-// heading. The index treats ref-defs as symbols rather than
-// edges, so appendAnchorEditsForHeading skips them — without
-// this companion pass a heading rename would leave def lines
-// like `[setup]: ./a.md#setup` stranded on the old slug while
-// every `[t][setup]` use still resolved correctly through the
-// def to a now-stale anchor.
-//
-// The pass iterates every file the index knows about, reads
-// each through resolveURIAndSource so unsaved buffers win
-// over disk, and emits one edit per def whose destination
-// URL fragment slugifies to oldSlug AND whose path resolves
-// to headingFile (or is the same file when the def is anchor-
-// only).
-func (s *Server) appendRefDefDestEditsForHeading(
-	changes map[string][]textEdit, idx *index.Index,
-	headingFile, oldSlug, newSlug string,
-) {
-	headingFile = index.NormalizePath(headingFile)
-	for _, rel := range idx.Files() {
-		uri, source, ok := s.resolveURIAndSource(rel)
-		if !ok {
-			continue
-		}
-		body, fmOffset := bodyAndFMOffset(source)
-		fileLines := splitLines(source)
-		// Route through validRefDefMatches so `[label]:` lines
-		// goldmark refused (code blocks, paragraph continuations)
-		// don't get rewritten as if they were real defs.
-		for _, m := range validRefDefMatches(body) {
-			edit, ok := refDefDestEditForMatch(
-				body, fileLines, fmOffset, m.matchIdx,
-				rel, headingFile, oldSlug, newSlug,
-			)
-			if !ok {
-				continue
-			}
-			changes[uri] = append(changes[uri], edit)
-		}
-	}
-}
-
-// refDefDestEditForMatch turns one regex match for a
-// `[label]: url` line into a TextEdit on the URL's slug
-// portion, or returns ok=false when the destination doesn't
-// point at the renamed heading.
-//
-// The URL portion is everything after `]:` on the line,
-// trimmed of surrounding whitespace and an optional quoted
-// title. We don't need to be perfect about the title syntax
-// — we just need to locate the `#slug` substring inside the
-// destination part, the same way anchorFragmentBytes locates
-// it inside an inline link.
-func refDefDestEditForMatch(
-	body []byte, fileLines [][]byte, fmOffset int, m []int,
-	defFile, headingFile, oldSlug, newSlug string,
-) (textEdit, bool) {
-	bodyLine := lineOfBodyOffset(body, m[2])
-	fileLine := bodyLine + fmOffset
-	if fileLine-1 >= len(fileLines) {
-		return textEdit{}, false
-	}
-	row := fileLines[fileLine-1]
-	colonOff := refDefColonOffset(row)
-	if colonOff < 0 {
-		return textEdit{}, false
-	}
-	destStart, destEnd := refDefDestRange(row, colonOff+1)
-	if destStart >= destEnd {
-		return textEdit{}, false
-	}
-	dest := row[destStart:destEnd]
-	if !refDefDestPointsAt(dest, defFile, headingFile, oldSlug) {
-		return textEdit{}, false
-	}
-	// refDefDestPointsAt already confirmed the destination
-	// contains `#oldSlug` (oldSlug is non-empty when the rename
-	// reaches this path), so `#` always exists in dest.
-	hashIdx := destStart
-	for hashIdx < destEnd && row[hashIdx] != '#' {
-		hashIdx++
-	}
-	fragEnd := fragmentEnd(row, hashIdx+1, destEnd)
-	startCh := utf16FromByteOffset(row, hashIdx+1)
-	endCh := utf16FromByteOffset(row, fragEnd)
-	return textEdit{
-		Range: Range{
-			Start: Position{Line: fileLine - 1, Character: startCh},
-			End:   Position{Line: fileLine - 1, Character: endCh},
-		},
-		NewText: newSlug,
-	}, true
-}
-
-// refDefColonOffset returns the byte offset of the `:` that
-// follows the `[label]` in a ref-def line, or -1 when the
-// shape doesn't match. Mirrors the regex's expectation: ≤3
-// leading spaces, then `[label]:` where label has no `]`.
-func refDefColonOffset(row []byte) int {
-	i := 0
-	for i < len(row) && i < 3 && row[i] == ' ' {
-		i++
-	}
-	if i >= len(row) || row[i] != '[' {
-		return -1
-	}
-	close := -1
-	for j := i + 1; j < len(row); j++ {
-		if row[j] == ']' {
-			close = j
-			break
-		}
-	}
-	if close < 0 || close+1 >= len(row) || row[close+1] != ':' {
-		return -1
-	}
-	return close + 1
-}
-
-// refDefDestRange returns the byte range of the destination
-// URL portion of a ref-def line, given the offset just past
-// the `:`. Skips leading whitespace, then handles both forms:
-//
-//   - Angle-bracketed: `[label]: <url>`. The returned range
-//     covers the bytes *inside* the angle brackets, so a slug
-//     edit replaces only the fragment text and leaves `<` / `>`
-//     intact.
-//   - Bare: `[label]: url`. The range runs from the first
-//     non-whitespace byte to the next whitespace.
-//
-// Quoted titles after the URL are excluded either way.
-func refDefDestRange(row []byte, from int) (int, int) {
-	i := from
-	for i < len(row) && (row[i] == ' ' || row[i] == '\t') {
-		i++
-	}
-	if i < len(row) && row[i] == '<' {
-		open := i + 1
-		for j := open; j < len(row); j++ {
-			if row[j] == '\\' && j+1 < len(row) {
-				j++
-				continue
-			}
-			if row[j] == '>' {
-				return open, j
-			}
-		}
-		// Unterminated `<…` — fall through to the bare reader
-		// from the original `<` position so a malformed line
-		// doesn't masquerade as an angle-bracketed dest.
-	}
-	start := i
-	for i < len(row) && row[i] != ' ' && row[i] != '\t' {
-		i++
-	}
-	return start, i
-}
-
-// refDefDestPointsAt reports whether the dest bytes (URL
-// portion of a ref-def in defFile) resolve to (headingFile,
-// oldSlug). The check mirrors the index's edge collector:
-// percent-decode the fragment, run through mdtext.Slugify,
-// and compare against oldSlug; resolve the path against
-// defFile's directory and compare against headingFile.
-func refDefDestPointsAt(dest []byte, defFile, headingFile, oldSlug string) bool {
-	t, ok := refDefParseTarget(string(dest))
-	if !ok {
-		return false
-	}
-	// url.Parse already produced t.fragment in decoded form, but
-	// re-running PathUnescape mirrors the index's `decodeAnchor`
-	// helper so corner-case escapes can't drift between the two.
-	// Errors are impossible at this point: url.Parse would have
-	// rejected the dest if it had a malformed `%xx` sequence.
-	decoded, _ := url.PathUnescape(t.fragment)
-	if mdtext.Slugify(decoded) != oldSlug {
-		return false
-	}
-	if t.localAnchor {
-		return index.NormalizePath(defFile) == headingFile
-	}
-	resolved := linkgraph.ResolveRelTarget(defFile, t.path)
-	return resolved == headingFile
-}
-
-// refDefDestTarget is the parsed shape of a ref-def URL.
-// Kept private to this file — the index has its own
-// `linkTarget` helper and we don't want to leak two slightly
-// different parsers through one type.
-type refDefDestTarget struct {
-	path        string
-	fragment    string
-	localAnchor bool
-}
-
-func refDefParseTarget(dest string) (refDefDestTarget, bool) {
-	dest = strings.TrimSpace(dest)
-	if dest == "" || strings.HasPrefix(dest, "//") {
-		return refDefDestTarget{}, false
-	}
-	u, err := url.Parse(dest)
-	if err != nil {
-		return refDefDestTarget{}, false
-	}
-	if u.Scheme != "" || u.Host != "" {
-		return refDefDestTarget{}, false
-	}
-	if u.Path == "" && u.Fragment != "" {
-		return refDefDestTarget{fragment: u.Fragment, localAnchor: true}, true
-	}
-	if u.Path == "" {
-		return refDefDestTarget{}, false
-	}
-	return refDefDestTarget{path: u.Path, fragment: u.Fragment}, true
-}
-
-// appendAnchorEditsForHeading records one TextEdit per workspace
-// anchor link pointing at (headingFile, oldSlug). The new slug is
-// substituted into each link destination's fragment portion; the
-// path component is left unchanged so relative includes (`./other.md`
-// etc.) keep their source form.
-func (s *Server) appendAnchorEditsForHeading(
-	changes map[string][]textEdit, idx *index.Index,
-	headingFile, oldSlug, newSlug string,
-) {
-	edges := idx.IncomingEdges(headingFile, oldSlug)
-	for _, e := range edges {
-		uri, edit, ok := s.anchorEditForEdge(e, oldSlug, newSlug)
-		if !ok {
-			continue
-		}
-		changes[uri] = append(changes[uri], edit)
-	}
-}
-
-// resolveURIAndSource returns the URI string and source bytes for
-// a workspace-relative path. It scans open documents first and
-// returns the client-provided URI verbatim when the file is held
-// as a buffer; only when no open buffer matches does it fall back
-// to the canonical workspaceURI + on-disk read.
-//
-// Without this, a rename's WorkspaceEdit could split same-file
-// edits across two URI strings (e.g. the client's exact URI and
-// the server's canonicalized form) — clients keying open buffers
-// on the original URI would then apply only one side of the split
-// and leave the buffer in a torn state.
-func (s *Server) resolveURIAndSource(rel string) (string, []byte, bool) {
-	rel = index.NormalizePath(rel)
-	_, _, root := s.snapshotConfig()
-	for _, openURI := range s.docs.openURIs() {
-		// Combine the lookup and the path check into one
-		// short-circuit so a concurrent didClose between
-		// openURIs() and get() can't nil-deref doc, without
-		// a separate uncoverable `if !found` branch.
-		if doc, ok := s.docs.get(openURI); ok &&
-			index.NormalizePath(workspaceRelative(root, doc.path)) == rel {
-			return openURI, doc.text, true
-		}
-	}
-	uri := s.workspaceURI(rel)
-	if uri == "" {
-		return "", nil, false
-	}
-	source, _, ok := s.docTextOrFile(uri)
-	if !ok {
-		return "", nil, false
-	}
-	return uri, source, true
-}
-
-// anchorEditForEdge converts one incoming-edge record into a
-// concrete TextEdit on the source file. Returns false when the
-// source file isn't readable (out of workspace, deleted) or when
-// the edge's link can't be located in the source — the rename
-// silently skips those rather than failing the whole request, since
-// the alternative would block a user from renaming a heading because
-// of an unrelated stale edge.
-func (s *Server) anchorEditForEdge(e index.Edge, oldSlug, newSlug string) (string, textEdit, bool) {
-	uri, source, ok := s.resolveURIAndSource(e.SourceFile)
-	if !ok {
-		// Edge points at a file the LSP can no longer read (closed
-		// buffer + on-disk delete, or workspace boundary moved).
-		// Skip rather than fail the whole rename.
-		return "", textEdit{}, false
-	}
-	lines := splitLines(source)
-	// SourceLine bounds check: the index can hold stale entries
-	// after a closed-buffer edit or a watcher event we haven't
-	// processed yet. Indexing past EOF would panic the rename.
-	if e.SourceLine < 1 || e.SourceLine > len(lines) {
-		return "", textEdit{}, false
-	}
-	row := lines[e.SourceLine-1]
-	startByte, endByte, ok := anchorFragmentBytes(row, e.SourceCol-1, oldSlug)
-	if !ok {
-		return "", textEdit{}, false
-	}
-	startCh := utf16FromByteOffset(row, startByte)
-	endCh := utf16FromByteOffset(row, endByte)
-	return uri, textEdit{
-		Range: Range{
-			Start: Position{Line: e.SourceLine - 1, Character: startCh},
-			End:   Position{Line: e.SourceLine - 1, Character: endCh},
-		},
-		NewText: newSlug,
-	}, true
-}
-
-// anchorFragmentBytes locates the byte range of the fragment slug
-// inside a link destination on row, starting from the link's
-// text-start column. Returns the range of the raw fragment text
-// (excluding the leading `#`) so callers can replace it with the
-// new slug.
-//
-// The match is normalized: the raw fragment is URL-unescaped and
-// run through mdtext.Slugify, mirroring the way the index keys
-// incoming edges. That way `(#Setup)` and `(#Docs%20API)` both
-// participate in a rename even though their literal byte
-// sequences differ from `setup` / `docs-api`.
-func anchorFragmentBytes(row []byte, textStart int, oldSlug string) (int, int, bool) {
-	bracketStart := textStart
-	if bracketStart < 0 {
-		bracketStart = 0
-	}
-	if bracketStart >= len(row) {
-		return 0, 0, false
-	}
-	open, close, ok := destBounds(row, bracketStart)
-	if !ok {
-		return 0, 0, false
-	}
-	hash := indexOfHash(row, open, close)
-	if hash < 0 {
-		return 0, 0, false
-	}
-	fragEnd := fragmentEnd(row, hash+1, close)
-	rawFrag := row[hash+1 : fragEnd]
-	if !fragmentMatchesSlug(rawFrag, oldSlug) {
-		return 0, 0, false
-	}
-	return hash + 1, fragEnd, true
-}
-
-// destBounds returns the byte offsets of the destination *content*
-// — the byte just after `(` and the byte at the matching `)` — for
-// a link starting at or after `from` on row. Callers slice
-// row[open:close] to get the destination text. Nested parens are
-// matched depth-aware, and backslash-escaped parens are treated as
-// literal bytes (CommonMark allows `\(` / `\)` inside the
-// destination), so a link like `[t](foo\(bar\)#sec)` resolves to
-// the outer parens, not the escaped inner ones.
-func destBounds(row []byte, from int) (int, int, bool) {
-	open := -1
-	for i := from; i < len(row)-1; i++ {
-		// Skip backslash-escaped bytes so a literal `\]` inside the
-		// text portion (CommonMark allows it) doesn't fool the
-		// `](` lookahead into thinking the destination starts
-		// earlier than it does.
-		if row[i] == '\\' && i+1 < len(row) {
-			i++
-			continue
-		}
-		if row[i] == ']' && row[i+1] == '(' {
-			open = i + 2
-			break
-		}
-	}
-	if open < 0 {
-		return 0, 0, false
-	}
-	close := -1
-	depth := 1
-	for j := open; j < len(row) && close < 0; j++ {
-		if isBackslashEscaped(row, j) {
-			continue
-		}
-		switch row[j] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 {
-				close = j
-			}
-		}
-	}
-	if close < 0 {
-		return 0, 0, false
-	}
-	return open, close, true
-}
-
-// isBackslashEscaped reports whether row[i] is preceded by an odd
-// number of backslashes — the CommonMark escape signal.
-func isBackslashEscaped(row []byte, i int) bool {
-	n := 0
-	for k := i - 1; k >= 0 && row[k] == '\\'; k-- {
-		n++
-	}
-	return n%2 == 1
-}
-
-// indexOfHash returns the offset of the first `#` in row[open:close],
-// or -1 when the destination has no fragment. The first `#` wins
-// because URL fragments by definition start at the first `#`.
-func indexOfHash(row []byte, open, close int) int {
-	for i := open; i < close; i++ {
-		if row[i] == '#' {
-			return i
-		}
-	}
-	return -1
-}
-
-// fragmentEnd returns the byte offset where a fragment ends within
-// row[start:close]. CommonMark inline-link destinations don't carry
-// query strings (the `(url "title")` title form is parsed by
-// goldmark separately), so the fragment runs from `start` to the
-// first whitespace, the first `>` (CommonMark's angle-bracketed
-// destination form `<url>`), or to `close`. Without the `>` guard,
-// `[t](<#sec>)` would slugify `sec>` as `sec` and the rename would
-// then overwrite the closing bracket.
-func fragmentEnd(row []byte, start, close int) int {
-	for i := start; i < close; i++ {
-		if row[i] == ' ' || row[i] == '\t' || row[i] == '>' {
-			return i
-		}
-	}
-	return close
-}
-
-// fragmentMatchesSlug reports whether the raw bytes of a link
-// fragment slugify to oldSlug. URL-unescape mirrors decodeAnchor
-// in the index so `%20` and friends decode the same way before
-// the slug pass.
-func fragmentMatchesSlug(rawFrag []byte, oldSlug string) bool {
-	decoded, err := url.PathUnescape(string(rawFrag))
-	if err != nil {
-		decoded = string(rawFrag)
-	}
-	return mdtext.Slugify(decoded) == oldSlug
-}
-
-// stableSortEdits sorts each file's TextEdit slice in reverse
-// document order so a client that applies edits sequentially in
-// array order ends up with the right buffer state. The LSP spec
-// only forbids overlap; it does not pin down application order,
-// and naive clients walk the array top-to-bottom. Emitting
-// bottom-up means earlier (later-positioned) edits don't shift
-// the offsets the next edit relies on — particularly when two
-// edits share a line.
-func stableSortEdits(changes map[string][]textEdit) {
-	for uri, edits := range changes {
-		sort.SliceStable(edits, func(i, j int) bool {
-			a, b := edits[i].Range.Start, edits[j].Range.Start
-			if a.Line != b.Line {
-				return a.Line > b.Line
-			}
-			return a.Character > b.Character
-		})
-		changes[uri] = edits
-	}
-}
-
-// renameLinkRef rewrites a link-reference def and every use of the
-// label in the same file.
-//
-// Collision handling: a new label that matches another existing def
-// in the file fails with InvalidParams — MDS053 / MDS054 would
-// surface the breakage on the next lint pass anyway, but the LSP
-// error catches it before the edit applies.
-func (s *Server) renameLinkRef(
-	msg *requestMessage, p renameParams,
-	source []byte, oldLabel, newName string,
-) {
-	if strings.TrimSpace(newName) == "" {
-		_ = s.t.writeError(msg.ID, codeInvalidParams, "label cannot be empty")
-		return
-	}
-	// Reject labels that would break the on-disk syntax. A bare
-	// `]` would close the bracket pair early, producing an
-	// unparsable `[label]:` line; a newline or `[` similarly
-	// destroys the def. CommonMark allows escapes (`\]`), but
-	// emitting an escaped form here would silently rewrite the
-	// user's typed text — forcing the user to pick a valid label
-	// is the safer path.
-	if invalid := invalidLinkRefRune(newName); invalid != 0 {
-		_ = s.t.writeError(msg.ID, codeInvalidParams,
-			fmt.Sprintf("label cannot contain %q", invalid))
-		return
-	}
-	// Don't early-return when the normalized label is unchanged.
-	// A rename from `docs api` to `Docs API` keeps the same
-	// normalized form but changes the visible spelling; users can
-	// legitimately ask for that to refresh casing or whitespace
-	// across the def and every use. labelConflict still uses the
-	// normalized form for collision matching so a same-normal-form
-	// rename can never trip the collision check against itself.
-	newLabel := normalizedLabel([]byte(newName))
-	if conflict := labelConflict(source, oldLabel, newLabel); conflict != "" {
-		_ = s.t.writeErrorWithData(msg.ID, codeInvalidParams,
-			"rename would collide with link reference ["+conflict+"]",
-			renameCollisionData{Conflict: conflict})
-		return
-	}
-	// linkRefEdits is guaranteed to produce at least one edit:
-	// the cursor was tagged TokenRefDef or TokenRefUse, so a
-	// matching def or use exists in the buffer.
-	changes := map[string][]textEdit{p.TextDocument.URI: linkRefEdits(source, oldLabel, newName)}
-	stableSortEdits(changes)
-	_ = s.t.writeResponse(msg.ID, &workspaceEdit{Changes: changes})
-}
-
-// labelConflict returns the conflicting label name (preserving the
-// original casing) when newLabel matches a link-reference
-// definition in the file other than the one being renamed. Empty
-// string means "no conflict".
-//
-// The scan filters regex matches through goldmark's parser context
-// (validRefDefMatches) so a `[label]: url`-looking line inside a
-// fenced code block or PI body doesn't count as a real def — both
-// shapes parse as content, not as references, and the rename must
-// not flag a phantom collision against them.
-func labelConflict(source []byte, oldLabel, newLabel string) string {
-	body, _ := bodyAndFMOffset(source)
-	for _, m := range validRefDefMatches(body) {
-		if m.normLabel == oldLabel {
-			// Defs that match the rename's source label are the
-			// ones being rewritten — they don't count as collisions.
-			continue
-		}
-		if m.normLabel == newLabel {
-			return m.rawLabel
-		}
-	}
-	return ""
-}
-
-// validRefDefMatch is one source-validated reference definition
-// position. Validation goes through goldmark's parser context so
-// matches inside code/PI blocks (which goldmark refuses as
-// references) drop out before reaching the rename.
-type validRefDefMatch struct {
-	bodyLine  int    // 1-based line within body
-	rawLabel  string // bytes between `[` and `]`, unmodified
-	normLabel string // util.ToLinkReference normalized form
-	matchIdx  []int  // refDefRegexpMatches indices for further use
-}
-
-// validRefDefMatches returns the ref-def regex matches that
-// fall outside any AST node. Real reference definitions
-// never appear in the AST (they're consumed into the parser
-// context), so the inverse — "regex hit on a line goldmark
-// didn't tuck into a block" — is the set of real defs. This
-// drops paragraph-continuation lookalikes, code-block
-// content, and PI bodies in one pass without needing a
-// label-keyed wanted set.
-func validRefDefMatches(body []byte) []validRefDefMatch {
-	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
-	consumed := contentBlockLines(root, body)
-	var out []validRefDefMatch
-	for _, m := range index.RefDefRegexpMatches(body) {
-		bodyLine := lineOfBodyOffset(body, m[2])
-		if consumed[bodyLine] {
-			continue
-		}
-		raw := body[m[2]:m[3]]
-		norm := normalizedLabel(raw)
-		out = append(out, validRefDefMatch{
-			bodyLine:  bodyLine,
-			rawLabel:  string(raw),
-			normLabel: norm,
-			matchIdx:  m,
-		})
-	}
-	return out
-}
-
-// contentBlockLines returns the set of body-line numbers that
-// goldmark consumed into any AST node. Real reference
-// definitions never appear in the AST — they live in
-// parser.Context.References — so any line covered by an AST
-// node is by definition not a def. Walking every node
-// (paragraphs, code blocks, headings, list items, blockquotes,
-// HTML blocks, PIs) means the rename surface doesn't need to
-// enumerate block types; it just trusts the AST.
-//
-// The root *ast.Document is skipped: its Lines() span the
-// whole buffer, which would mask every line and break the
-// "real def" detection entirely.
-func contentBlockLines(root ast.Node, body []byte) map[int]bool {
-	out := map[int]bool{}
-	_ = ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		// Only block-level nodes have Lines(); calling it on
-		// inline nodes panics. Skip the Document root too —
-		// its Lines() span the whole buffer and would mask
-		// every line — and LinkReferenceDefinition because
-		// real defs ARE the lines we want regex hits to
-		// survive on. Including them would defeat the
-		// detection.
-		if n.Type() != ast.TypeBlock {
-			return ast.WalkContinue, nil
-		}
-		switch n.(type) {
-		case *ast.Document, *ast.LinkReferenceDefinition:
-			return ast.WalkContinue, nil
-		}
-		ls := n.Lines()
-		for i := 0; i < ls.Len(); i++ {
-			seg := ls.At(i)
-			out[lineOfBodyOffset(body, seg.Start)] = true
-		}
-		return ast.WalkContinue, nil
-	})
-	return out
-}
-
-// validRefDefBodyLines reports body-line indices that hold a real
-// reference definition (one goldmark accepted, not a code-block
-// look-alike). prepareRenameAt uses it to suppress the rename UI
-// on lines the parser doesn't treat as defs.
-func validRefDefBodyLines(body []byte) map[int]bool {
-	out := map[int]bool{}
-	for _, m := range validRefDefMatches(body) {
-		out[m.bodyLine] = true
-	}
-	return out
-}
-
-// linkRefEdits walks the source for the def line and every
-// reference-style use of oldLabel (full and shortcut), returning
-// one TextEdit per match. The def is rewritten via refDefBracketBytes;
-// uses are rewritten via the link AST walk so the precise label
-// brackets are targeted regardless of whether the link is full,
-// shortcut, or collapsed.
-func linkRefEdits(source []byte, oldLabel, newName string) []textEdit {
-	body, fmOffset := bodyAndFMOffset(source)
-	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
-	lines := splitLines(source)
-	var out []textEdit
-	out = append(out, refDefEditsInBody(body, lines, fmOffset, oldLabel, newName)...)
-	out = append(out, refUseEditsInBody(root, body, lines, fmOffset, oldLabel, newName)...)
-	return out
-}
-
-// refDefEditsInBody finds the `[label]: url` line(s) for oldLabel
-// and emits one TextEdit per match. Goldmark only resolves the first
-// definition for a given label, but the file may legally carry
-// duplicate def lines (the rest are unused). We rewrite all of them
-// so the file ends up internally consistent.
-//
-// Filtering goes through validRefDefMatches so a `[label]: url`-
-// looking line inside a fenced code block or PI body does not get
-// rewritten — those parse as content, and overwriting them would
-// corrupt examples in the docs.
-func refDefEditsInBody(
-	body []byte, lines [][]byte, fmOffset int,
-	oldLabel, newName string,
-) []textEdit {
-	var out []textEdit
-	for _, m := range validRefDefMatches(body) {
-		if m.normLabel != oldLabel {
-			continue
-		}
-		fileLine := m.bodyLine + fmOffset
-		if fileLine-1 >= len(lines) {
-			continue
-		}
-		row := lines[fileLine-1]
-		// refDefBracketBytes always finds the `[…]` here: the
-		// regex already confirmed the def shape on this line,
-		// and validRefDefMatches confirmed goldmark accepted it.
-		bracket := refDefBracketBytes(row)
-		startCh := utf16FromByteOffset(row, bracket[0])
-		endCh := utf16FromByteOffset(row, bracket[1])
-		out = append(out, textEdit{
-			Range: Range{
-				Start: Position{Line: fileLine - 1, Character: startCh},
-				End:   Position{Line: fileLine - 1, Character: endCh},
-			},
-			NewText: newName,
-		})
-	}
-	return out
-}
-
-// refUseEditsInBody walks the AST for ast.Link nodes whose
-// Reference matches oldLabel and emits one TextEdit per use.
-// Full `[text][label]` rewrites the second pair of brackets;
-// shortcut `[label]` rewrites the only pair; collapsed `[text][]`
-// keeps the empty `[]` and rewrites the first (text) pair, since
-// the text doubles as the label.
-func refUseEditsInBody(
-	root ast.Node, body []byte, lines [][]byte, fmOffset int,
-	oldLabel, newName string,
-) []textEdit {
-	// Build the line-offset table once. Without this, refUseEdit's
-	// per-link line lookups would be O(n) each; on a file with N
-	// reference uses the cost grew to O(N·n).
-	idx := newBodyLineIndex(body)
-	var out []textEdit
-	_ = ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		l, ok := n.(*ast.Link)
-		if !ok || l.Reference == nil {
-			return ast.WalkContinue, nil
-		}
-		if normalizedLabel(l.Reference.Value) != oldLabel {
-			return ast.WalkContinue, nil
-		}
-		edit, ok := refUseEdit(l, body, lines, fmOffset, newName, idx)
-		if ok {
-			out = append(out, edit)
-		}
-		return ast.WalkContinue, nil
-	})
-	return out
-}
-
-// refUseEdit converts one link node into a TextEdit. Returns false
-// when the source position can't be recovered (e.g. nested in an
-// unsupported block) so the caller can skip the use rather than
-// emit a corrupt edit.
-//
-// Goldmark guarantees a parsed reference link has at least one
-// text segment, so linkTextBounds always returns a valid offset
-// pair — the textStart-from-AST → bodyLine → lineStart chain
-// stays inside the table by construction.
-func refUseEdit(
-	l *ast.Link, body []byte, lines [][]byte, fmOffset int, newName string,
-	bodyIdx bodyLineIndex,
-) (textEdit, bool) {
-	textStart, textEnd := linkTextBounds(l, body)
-	labelStart, labelEnd, ok := labelBoundsInBody(body, textStart, textEnd, l.Reference.Type)
-	if !ok {
-		// Empty-text references (`[][id]`) and other shapes
-		// linkTextBounds can't anchor leave us without a way
-		// to locate the label in the source. Skip rather than
-		// emit a corrupt edit.
-		return textEdit{}, false
-	}
-	// labelStart/End are byte offsets in body, so the line
-	// lookups stay inside the source's line table by
-	// construction: lines is splitLines(source) which spans
-	// front matter + body, and fmOffset is the same line shift
-	// the body parse used.
-	startLine := bodyIdx.LineOfOffset(labelStart) + fmOffset
-	endLine := bodyIdx.LineOfOffset(labelEnd) + fmOffset
-	startCol := labelStart - bodyIdx.LineStart(startLine-fmOffset)
-	endCol := labelEnd - bodyIdx.LineStart(endLine-fmOffset)
-	startCh := utf16FromByteOffset(lines[startLine-1], startCol)
-	endCh := utf16FromByteOffset(lines[endLine-1], endCol)
-	return textEdit{
-		Range: Range{
-			Start: Position{Line: startLine - 1, Character: startCh},
-			End:   Position{Line: endLine - 1, Character: endCh},
-		},
-		NewText: newName,
-	}, true
-}
-
-// labelBoundsInBody returns the body-byte offsets of the label
-// inside a reference-style link, given the link's text-segment
-// bounds and the goldmark Reference type. For full `[text][label]`
-// the range covers the label content (between the inner `[` and
-// `]`). For shortcut `[label]` and collapsed `[label][]` the
-// range covers the text bracket's content (the text IS the
-// label). Returns ok=false when the surrounding bracket structure
-// doesn't match what the type implies — guarding against unusual
-// goldmark output without dropping multi-line uses, where the
-// label still sits between intact byte offsets even when the
-// text spans newlines.
-func labelBoundsInBody(body []byte, textStart, textEnd int, refType ast.ReferenceLinkType) (int, int, bool) {
-	// Empty-text refs like `[][id]` or `![][id]` parse with no
-	// text segments, so linkTextBounds returns (-1, -1). The
-	// label still exists in the source but we can't locate it
-	// without the text bracket as an anchor — skip the use to
-	// avoid a body[-1] panic. The same trade-off lives in
-	// internal/rules/noreferencestyle.
-	if textStart < 0 || textEnd < 0 {
-		return 0, 0, false
-	}
-	if refType == ast.ReferenceLinkFull {
-		// `[text][label]`: the text closes at body[textEnd] with
-		// `]`, then `[` opens the label.
-		if textEnd >= len(body) || body[textEnd] != ']' {
-			return 0, 0, false
-		}
-		if textEnd+1 >= len(body) || body[textEnd+1] != '[' {
-			return 0, 0, false
-		}
-		labelOpen := textEnd + 2
-		// Scan for the closing `]`, honoring backslash escapes.
-		for i := labelOpen; i < len(body); i++ {
-			if body[i] == '\\' && i+1 < len(body) {
-				i++
-				continue
-			}
-			if body[i] == ']' {
-				return labelOpen, i, true
-			}
-		}
-		return 0, 0, false
-	}
-	// Shortcut / collapsed: the label IS the text bracket.
-	if textStart <= 0 || body[textStart-1] != '[' {
-		return 0, 0, false
-	}
-	if textEnd >= len(body) || body[textEnd] != ']' {
-		return 0, 0, false
-	}
-	return textStart, textEnd, true
-}
-
-// linkTextBounds returns the [start, end) absolute byte offsets of
-// the link's display-text run inside body. End is one past the last
-// character of the visible text (i.e. the position of the closing
-// `]`). Returns (-1, -1) when the link has no parsed text segment.
-func linkTextBounds(l *ast.Link, body []byte) (int, int) {
-	start, end := -1, -1
-	_ = ast.Walk(l, func(cur ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		t, ok := cur.(*ast.Text)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		if start < 0 || t.Segment.Start < start {
-			start = t.Segment.Start
-		}
-		if t.Segment.Stop > end {
-			end = t.Segment.Stop
-		}
-		return ast.WalkContinue, nil
-	})
-	return start, end
-}
-
 // bracketPairs returns every top-level `[` / `]` pair on row, in
 // left-to-right order. The walker is depth-aware: a `[` opens a new
 // nesting level and a `]` closes the innermost open `[`, so a
@@ -1583,101 +413,213 @@ func bracketPairs(row []byte) []bracketPair {
 	return pairs
 }
 
-// lineOfBodyOffset returns the 1-based line of byte offset off
-// within body. The two callers (computeSlugRemap and
-// refDefEditsInBody) each invoke it once per heading or def, so
-// the linear scan is bounded; tight per-edit loops use
-// bodyLineIndex instead to avoid quadratic behavior.
-func lineOfBodyOffset(body []byte, off int) int {
-	if off < 0 {
-		return 1
+// handleRename answers textDocument/rename. The reply is a
+// WorkspaceEdit that covers every affected file. Heading rename
+// rewrites incoming anchor links across the workspace; link-ref
+// label rename rewrites the def and every use in the same file. The
+// edit computation lives in internal/rename — this handler resolves
+// the cursor, delegates, and adapts the neutral edits / typed errors
+// to LSP wire types. Collisions return InvalidParams with
+// renameCollisionData so the client can show a meaningful error
+// instead of partially applying an edit.
+func (s *Server) handleRename(msg *requestMessage) {
+	var p renameParams
+	if err := json.Unmarshal(msg.Params, &p); err != nil {
+		_ = s.t.writeError(msg.ID, codeInvalidParams, "invalid rename params")
+		return
 	}
-	if off > len(body) {
-		off = len(body)
+	source, rel, ok := s.docTextOrFile(p.TextDocument.URI)
+	if !ok {
+		_ = s.t.writeResponse(msg.ID, nil)
+		return
 	}
-	line := 1
-	for i := 0; i < off; i++ {
-		if body[i] == '\n' {
-			line++
+	line := p.Position.Line + 1
+	col := lspPositionToByteColumn(source, line, p.Position.Character)
+	res := index.Locator{Path: rel}.Locate(source, line, col)
+	switch res.Tag {
+	case index.TokenHeading:
+		s.renameHeading(msg, p, source, rel, line, res, p.NewName)
+	case index.TokenRefDef:
+		// Mirror prepareRename's gate: a `[label]: url`-shaped
+		// line inside a fenced code block or PI body isn't a
+		// real def, so refuse the rename rather than producing
+		// empty / off-target edits.
+		if !isValidRefDefLine(source, line) {
+			_ = s.t.writeError(msg.ID, codeInvalidParams, "rename not supported at this position")
+			return
+		}
+		s.renameLinkRef(msg, p, source, res.Label, p.NewName)
+	case index.TokenRefUse:
+		s.renameLinkRef(msg, p, source, res.Label, p.NewName)
+	default:
+		_ = s.t.writeError(msg.ID, codeInvalidParams, "rename not supported at this position")
+	}
+}
+
+// lspRenameWorkspace backs the rename engine's Workspace seam with
+// the server's warm index plus open buffers. The index supplies the
+// edge graph; resolveURIAndSource supplies the per-file bytes and
+// the URI the file's edits group under (the client URI for open
+// buffers, the canonical workspace URI otherwise).
+type lspRenameWorkspace struct {
+	s   *Server
+	idx *index.Index
+}
+
+// Trivial index pass-through; no dedicated test by design (the
+// rename engine's behavioral tests exercise it through Heading).
+func (w lspRenameWorkspace) IncomingAnchorEdges(file, slug string) []index.Edge {
+	return w.idx.IncomingEdges(file, slug)
+}
+
+// Trivial index pass-through; no dedicated test by design.
+func (w lspRenameWorkspace) Files() []string { return w.idx.Files() }
+
+// Trivial pass-through to resolveURIAndSource; no dedicated test by
+// design (covered via resolveURIAndSource's own tests and the
+// rename behavioral suite).
+func (w lspRenameWorkspace) Resolve(file string) (string, []byte, bool) {
+	return w.s.resolveURIAndSource(file)
+}
+
+// renameHeading adapts rename.Heading to the LSP wire: it delegates
+// the slug-remap / anchor / ref-def-destination computation to the
+// shared engine, then maps the neutral per-key Edit set to a
+// WorkspaceEdit. A no-op rename yields an empty (but non-nil)
+// Changes map, matching the pre-delegation behavior.
+func (s *Server) renameHeading(
+	msg *requestMessage, p renameParams,
+	source []byte, rel string, line int, res index.LocateResult, newName string,
+) {
+	ws := lspRenameWorkspace{s: s, idx: s.ensureIndex()}
+	changes, err := rename.Heading(ws, p.TextDocument.URI, rel, source, line, res.Name, newName)
+	if err != nil {
+		s.writeRenameError(msg.ID, err)
+		return
+	}
+	_ = s.t.writeResponse(msg.ID, &workspaceEdit{Changes: toLSPChanges(changes)})
+}
+
+// renameLinkRef adapts rename.LinkRef to the LSP wire. The engine
+// returns the def + use edits unordered; the handler sorts them
+// bottom-up so a naive client applying them array-order leaves the
+// buffer correct, exactly as the pre-delegation code did.
+func (s *Server) renameLinkRef(
+	msg *requestMessage, p renameParams,
+	source []byte, oldLabel, newName string,
+) {
+	edits, err := rename.LinkRef(source, oldLabel, newName)
+	if err != nil {
+		s.writeRenameError(msg.ID, err)
+		return
+	}
+	te := toTextEdits(edits)
+	sortTextEditsBottomUp(te)
+	_ = s.t.writeResponse(msg.ID, &workspaceEdit{
+		Changes: map[string][]textEdit{p.TextDocument.URI: te},
+	})
+}
+
+// writeRenameError maps a rename engine error to an LSP error
+// response. Collision errors carry the conflicting name in
+// renameCollisionData so the client can render it; every other
+// typed error (empty / control rune / invalid label rune / empty
+// slug) surfaces its message verbatim — the engine's Error() text
+// is the same string the handler emitted before delegation.
+func (s *Server) writeRenameError(id json.RawMessage, err error) {
+	var hce rename.HeadingCollisionError
+	if errors.As(err, &hce) {
+		_ = s.t.writeErrorWithData(id, codeInvalidParams,
+			hce.Error(), renameCollisionData{Conflict: hce.Conflict})
+		return
+	}
+	var lce rename.LabelConflictError
+	if errors.As(err, &lce) {
+		_ = s.t.writeErrorWithData(id, codeInvalidParams,
+			lce.Error(), renameCollisionData{Conflict: lce.Conflict})
+		return
+	}
+	_ = s.t.writeError(id, codeInvalidParams, err.Error())
+}
+
+// toLSPChanges converts the engine's per-key Edit map to the LSP
+// WorkspaceEdit shape. The map is always allocated (never nil) so a
+// no-op rename serializes as `"changes": {}` rather than `null`,
+// matching the pre-delegation reply.
+func toLSPChanges(changes map[string][]rename.Edit) map[string][]textEdit {
+	out := make(map[string][]textEdit, len(changes))
+	for key, edits := range changes {
+		out[key] = toTextEdits(edits)
+	}
+	return out
+}
+
+// toTextEdits copies neutral rename.Edit values into LSP textEdits.
+// rename.Edit's Range is line + UTF-16 character, the same shape as
+// the LSP textEdit, so the conversion is a field copy and the wire
+// coordinates cannot drift.
+func toTextEdits(edits []rename.Edit) []textEdit {
+	out := make([]textEdit, len(edits))
+	for i, e := range edits {
+		out[i] = textEdit{
+			Range: Range{
+				Start: Position{Line: e.Range.Start.Line, Character: e.Range.Start.Character},
+				End:   Position{Line: e.Range.End.Line, Character: e.Range.End.Character},
+			},
+			NewText: e.NewText,
 		}
 	}
-	return line
+	return out
 }
 
-// bodyLineIndex precomputes the byte offset of every line start in
-// a body so lookups for line→offset and offset→line run in O(log n)
-// instead of O(n) per call. Use it when a single rename emits many
-// per-link edits; without it, refUseEdit's per-edit scans were
-// quadratic in the number of reference uses.
-type bodyLineIndex struct {
-	starts []int
+// sortTextEditsBottomUp orders edits in reverse document order so a
+// client applying them sequentially in array order doesn't shift
+// the offsets a later edit relies on. The LSP spec only forbids
+// overlap; it doesn't pin application order, and naive clients walk
+// the array top-to-bottom. rename.Heading already sorts its result
+// this way internally; link-ref edits are sorted here so both paths
+// emit the same bottom-up order.
+func sortTextEditsBottomUp(edits []textEdit) {
+	sort.SliceStable(edits, func(i, j int) bool {
+		a, b := edits[i].Range.Start, edits[j].Range.Start
+		if a.Line != b.Line {
+			return a.Line > b.Line
+		}
+		return a.Character > b.Character
+	})
 }
 
-// newBodyLineIndex builds a line-start table for body. The first
-// entry is always 0 (start of line 1); each `\n` advances to the
-// next line's start.
-func newBodyLineIndex(body []byte) bodyLineIndex {
-	starts := make([]int, 1, 1+bodyNewlineCount(body))
-	for i, b := range body {
-		if b == '\n' {
-			starts = append(starts, i+1)
+// resolveURIAndSource returns the URI string and source bytes for
+// a workspace-relative path. It scans open documents first and
+// returns the client-provided URI verbatim when the file is held
+// as a buffer; only when no open buffer matches does it fall back
+// to the canonical workspaceURI + on-disk read.
+//
+// Without this, a rename's WorkspaceEdit could split same-file
+// edits across two URI strings (e.g. the client's exact URI and
+// the server's canonicalized form) — clients keying open buffers
+// on the original URI would then apply only one side of the split
+// and leave the buffer in a torn state.
+func (s *Server) resolveURIAndSource(rel string) (string, []byte, bool) {
+	rel = index.NormalizePath(rel)
+	_, _, root := s.snapshotConfig()
+	for _, openURI := range s.docs.openURIs() {
+		// Combine the lookup and the path check into one
+		// short-circuit so a concurrent didClose between
+		// openURIs() and get() can't nil-deref doc, without
+		// a separate uncoverable `if !found` branch.
+		if doc, ok := s.docs.get(openURI); ok &&
+			index.NormalizePath(workspaceRelative(root, doc.path)) == rel {
+			return openURI, doc.text, true
 		}
 	}
-	return bodyLineIndex{starts: starts}
-}
-
-// bodyNewlineCount returns the count of `\n` bytes in body. Used to
-// presize the line-start slice without an extra alloc cycle.
-func bodyNewlineCount(body []byte) int {
-	n := 0
-	for _, b := range body {
-		if b == '\n' {
-			n++
-		}
+	uri := s.workspaceURI(rel)
+	if uri == "" {
+		return "", nil, false
 	}
-	return n
-}
-
-// LineOfOffset returns the 1-based line number containing byte off.
-// Out-of-range offsets clamp to the boundary line.
-func (b bodyLineIndex) LineOfOffset(off int) int {
-	if off < 0 {
-		return 1
+	source, _, ok := s.docTextOrFile(uri)
+	if !ok {
+		return "", nil, false
 	}
-	lo, hi := 0, len(b.starts)-1
-	for lo < hi {
-		mid := (lo + hi + 1) / 2
-		if b.starts[mid] <= off {
-			lo = mid
-		} else {
-			hi = mid - 1
-		}
-	}
-	return lo + 1
-}
-
-// LineStart returns the byte offset of the start of 1-based line n,
-// or -1 when n falls outside the table.
-func (b bodyLineIndex) LineStart(n int) int {
-	if n < 1 || n > len(b.starts) {
-		return -1
-	}
-	return b.starts[n-1]
-}
-
-// bodyAndFMOffset splits source into body and the line offset the
-// front matter contributed. Mirrors the slicing the index does so
-// renames work consistently against files with or without front
-// matter.
-func bodyAndFMOffset(source []byte) ([]byte, int) {
-	fm, body := lint.StripFrontMatter(source)
-	off := 0
-	if len(fm) > 0 {
-		for _, b := range fm {
-			if b == '\n' {
-				off++
-			}
-		}
-	}
-	return body, off
+	return uri, source, true
 }

--- a/internal/lsp/rename_adapter_test.go
+++ b/internal/lsp/rename_adapter_test.go
@@ -1,0 +1,87 @@
+package lsp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/rename"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToTextEdits(t *testing.T) {
+	t.Parallel()
+	got := toTextEdits([]rename.Edit{
+		{Range: rename.Range{
+			Start: rename.Position{Line: 1, Character: 2},
+			End:   rename.Position{Line: 1, Character: 7},
+		}, NewText: "x"},
+	})
+	require.Len(t, got, 1)
+	assert.Equal(t, textEdit{
+		Range:   Range{Start: Position{Line: 1, Character: 2}, End: Position{Line: 1, Character: 7}},
+		NewText: "x",
+	}, got[0])
+}
+
+func TestToLSPChanges(t *testing.T) {
+	t.Parallel()
+	// An empty engine map still yields a non-nil map so the reply
+	// serializes as `"changes": {}` rather than `null`.
+	got := toLSPChanges(map[string][]rename.Edit{})
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+
+	got = toLSPChanges(map[string][]rename.Edit{
+		"file:///a.md": {{NewText: "n"}},
+	})
+	require.Len(t, got["file:///a.md"], 1)
+	assert.Equal(t, "n", got["file:///a.md"][0].NewText)
+}
+
+func TestSortTextEditsBottomUp(t *testing.T) {
+	t.Parallel()
+	edits := []textEdit{
+		{Range: Range{Start: Position{Line: 1, Character: 0}}},
+		{Range: Range{Start: Position{Line: 5, Character: 1}}},
+		{Range: Range{Start: Position{Line: 5, Character: 4}}},
+	}
+	sortTextEditsBottomUp(edits)
+	assert.Equal(t, 5, edits[0].Range.Start.Line)
+	assert.Equal(t, 4, edits[0].Range.Start.Character)
+	assert.Equal(t, 5, edits[1].Range.Start.Line)
+	assert.Equal(t, 1, edits[2].Range.Start.Line)
+}
+
+func TestServer_writeRenameError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("heading collision carries conflict data", func(t *testing.T) {
+		var buf safeBuffer
+		s := New(Options{Reader: nil, Writer: &buf})
+		s.writeRenameError(json.RawMessage(`1`), rename.HeadingCollisionError{Conflict: "Intro"})
+		out := buf.String()
+		assert.Contains(t, out, `"code":-32602`)
+		assert.Contains(t, out, `rename would collide with heading Intro`)
+		assert.Contains(t, out, `"conflict":"Intro"`)
+	})
+
+	t.Run("label collision carries conflict data", func(t *testing.T) {
+		var buf safeBuffer
+		s := New(Options{Reader: nil, Writer: &buf})
+		s.writeRenameError(json.RawMessage(`1`), rename.LabelConflictError{Conflict: "Docs"})
+		out := buf.String()
+		assert.Contains(t, out, `"code":-32602`)
+		assert.Contains(t, out, `rename would collide with link reference [Docs]`)
+		assert.Contains(t, out, `"conflict":"Docs"`)
+	})
+
+	t.Run("plain typed error surfaces its message", func(t *testing.T) {
+		var buf safeBuffer
+		s := New(Options{Reader: nil, Writer: &buf})
+		s.writeRenameError(json.RawMessage(`1`), rename.ErrEmptyHeadingSlug)
+		out := buf.String()
+		assert.Contains(t, out, `"code":-32602`)
+		assert.Contains(t, out, rename.ErrEmptyHeadingSlug.Error())
+	})
+}

--- a/internal/lsp/rename_coverage_test.go
+++ b/internal/lsp/rename_coverage_test.go
@@ -7,9 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/goldmark/ast"
-
-	"github.com/jeduden/mdsmith/internal/index"
 )
 
 // TestHandlePrepareRenameOnUnknownDocument verifies the
@@ -88,8 +85,7 @@ func TestPrepareRenameOnAnchorLinkReturnsNull(t *testing.T) {
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
 	raw, errResp := h.request("textDocument/prepareRename", textDocumentPositionParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor inside `[s](#sec)` on line 3.
-		Position: Position{Line: 2, Character: 8},
+		Position:     Position{Line: 2, Character: 8},
 	})
 	require.Nil(t, errResp)
 	assert.Equal(t, "null", string(raw))
@@ -213,19 +209,15 @@ func TestRefDefBracketBytesEdgeCases(t *testing.T) {
 func TestRefUseLabelBytesShapes(t *testing.T) {
 	t.Parallel()
 	row := []byte("See [text][docs] and [docs] and [Docs API][]")
-	// Cursor inside the trailing `[docs]` label of the full ref.
 	start, end, ok := refUseLabelBytes(row, 11, "docs")
 	require.True(t, ok)
 	assert.Equal(t, "docs", string(row[start:end]))
-	// Cursor inside `text` of the full ref — should resolve to label.
 	start, end, ok = refUseLabelBytes(row, 5, "docs")
 	require.True(t, ok)
 	assert.Equal(t, "docs", string(row[start:end]))
-	// Cursor on the shortcut `[docs]`.
 	start, end, ok = refUseLabelBytes(row, 22, "docs")
 	require.True(t, ok)
 	assert.Equal(t, "docs", string(row[start:end]))
-	// Cursor on the leading `Docs API` of a collapsed ref.
 	start, end, ok = refUseLabelBytes(row, 35, "docs api")
 	require.True(t, ok)
 	assert.Equal(t, "Docs API", string(row[start:end]))
@@ -234,70 +226,20 @@ func TestRefUseLabelBytesShapes(t *testing.T) {
 // TestAssignSlugsDisambiguator exercises the slug-uniqueness
 // pass directly: duplicate base slugs gain `-1`, `-2`, … suffixes
 // in document order.
-func TestAssignSlugsDisambiguator(t *testing.T) {
-	t.Parallel()
-	got := assignSlugs([]string{"Setup", "Setup", "Other", "Setup"})
-	assert.Equal(t, []string{"setup", "setup-1", "other", "setup-2"}, got)
-}
-
 // TestAssignSlugsEmpty ensures empty-slug entries pass through
 // as "" instead of stealing the first base.
-func TestAssignSlugsEmpty(t *testing.T) {
-	t.Parallel()
-	got := assignSlugs([]string{"!!!", "Foo", "..."})
-	assert.Equal(t, []string{"", "foo", ""}, got)
-}
-
 // TestSlugRemapPairsSkipsUnchanged keeps the helper's contract
 // in coverage — only entries whose slug changed appear.
-func TestSlugRemapPairsSkipsUnchanged(t *testing.T) {
-	t.Parallel()
-	pairs := slugRemapPairs(
-		[]string{"a", "b", "c"},
-		[]string{"a", "x", "c"},
-	)
-	assert.Equal(t, map[string]string{"b": "x"}, pairs)
-}
-
 // TestAnchorFragmentBytesNoHash covers the destination without a
 // fragment — the helper returns false instead of misclassifying.
-func TestAnchorFragmentBytesNoHash(t *testing.T) {
-	t.Parallel()
-	row := []byte("see [t](./other.md)")
-	_, _, ok := anchorFragmentBytes(row, 4, "anything")
-	assert.False(t, ok)
-}
-
 // TestAnchorFragmentBytesNoDestination covers the path where the
 // `]` is not followed by `(` (e.g. a reference-style link), so
 // destBounds returns false.
-func TestAnchorFragmentBytesNoDestination(t *testing.T) {
-	t.Parallel()
-	row := []byte("[t][label]")
-	_, _, ok := anchorFragmentBytes(row, 0, "anything")
-	assert.False(t, ok)
-}
-
 // TestDestBoundsHandlesEscapedParens verifies the CommonMark
 // escape rule: `\(` and `\)` inside a destination don't shift
 // the depth counter, so the outer `)` still closes the link.
-func TestDestBoundsHandlesEscapedParens(t *testing.T) {
-	t.Parallel()
-	row := []byte(`[t](foo\(bar\)#sec)`)
-	open, close, ok := destBounds(row, 0)
-	require.True(t, ok)
-	assert.Equal(t, "foo\\(bar\\)#sec", string(row[open:close]))
-}
-
 // TestIsBackslashEscaped exercises the helper directly: even
 // counts of backslashes mean the byte is unescaped.
-func TestIsBackslashEscaped(t *testing.T) {
-	t.Parallel()
-	row := []byte(`a\)b\\)c`)
-	assert.True(t, isBackslashEscaped(row, 2), `position 2 is escaped \)`)
-	assert.False(t, isBackslashEscaped(row, 6), `position 6 follows \\, even count`)
-}
-
 // TestBracketPairsHandlesEscape verifies the bracket walker
 // honors `\]`.
 func TestBracketPairsHandlesEscape(t *testing.T) {
@@ -311,41 +253,11 @@ func TestBracketPairsHandlesEscape(t *testing.T) {
 
 // TestBodyAndFMOffsetWithFrontMatter exercises both branches of
 // the helper.
-func TestBodyAndFMOffsetWithFrontMatter(t *testing.T) {
-	t.Parallel()
-	body, off := bodyAndFMOffset([]byte("---\ntitle: T\n---\n# H\n"))
-	assert.Equal(t, "# H\n", string(body))
-	assert.Equal(t, 3, off)
-
-	body, off = bodyAndFMOffset([]byte("# H\n"))
-	assert.Equal(t, "# H\n", string(body))
-	assert.Equal(t, 0, off)
-}
-
 // TestBodyLineIndexEdgeCases covers the boundaries: empty body,
 // out-of-range line, last-line offsets.
-func TestBodyLineIndexEdgeCases(t *testing.T) {
-	t.Parallel()
-	// Empty body has just one line start at 0.
-	idx := newBodyLineIndex(nil)
-	assert.Equal(t, 0, idx.LineStart(1))
-	assert.Equal(t, -1, idx.LineStart(2))
-	// Negative offsets clamp to line 1.
-	assert.Equal(t, 1, idx.LineOfOffset(-1))
-}
-
 // TestComputeSlugRemapTargetNotFound covers the path where the
 // cursor's body line doesn't match any heading — the helper
 // returns nil slices instead of indexing past the array.
-func TestComputeSlugRemapTargetNotFound(t *testing.T) {
-	t.Parallel()
-	source := []byte("# Top\n\nparagraph\n")
-	old, new, conflict := computeSlugRemap(source, 99, "Other")
-	assert.Nil(t, old)
-	assert.Nil(t, new)
-	assert.Empty(t, conflict)
-}
-
 // TestRenameHeadingOnUnknownLineReturnsError covers the
 // renameHeading path where the cursor matches no heading
 // (e.g. body trimmed away) — it should reject with InvalidParams
@@ -359,9 +271,6 @@ func TestRenameHeadingOnUnknownLineReturnsError(t *testing.T) {
 		TextDocument: textDocumentItem{URI: uri, LanguageID: "markdown", Version: 1, Text: src},
 	})
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
-	// Cursor on the heading; rename to identical text should be
-	// the no-op path (covered elsewhere). Here we exercise an
-	// out-of-buffer position to hit the unsupported branch.
 	_, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
 		Position:     Position{Line: 99, Character: 0},
@@ -412,8 +321,7 @@ func TestPrepareRenameSetextHeading(t *testing.T) {
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
 	raw, errResp := h.request("textDocument/prepareRename", textDocumentPositionParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `Setup` (line 4, 1-based) → LSP line 3.
-		Position: Position{Line: 3, Character: 1},
+		Position:     Position{Line: 3, Character: 1},
 	})
 	require.Nil(t, errResp)
 	var res prepareRenameResult
@@ -423,12 +331,6 @@ func TestPrepareRenameSetextHeading(t *testing.T) {
 
 // TestHeadingTextEditOutOfRange verifies the defensive return
 // when the source has fewer lines than `line` requests.
-func TestHeadingTextEditOutOfRange(t *testing.T) {
-	t.Parallel()
-	_, ok := headingTextEdit([]byte("only one line\n"), 99, "x")
-	assert.False(t, ok)
-}
-
 // TestHeadingPrepareRangeOutOfRange and friends cover the
 // out-of-range branches of every prepareRange variant.
 func TestHeadingPrepareRangeOutOfRange(t *testing.T) {
@@ -481,48 +383,12 @@ func TestBracketPairsUnclosedBracket(t *testing.T) {
 // TestAnchorFragmentBytesEdgeCases covers the defensive returns:
 // negative textStart, textStart at end of row, fragment that
 // starts past the destination's `)`.
-func TestAnchorFragmentBytesEdgeCases(t *testing.T) {
-	t.Parallel()
-	row := []byte("see [t](#sec)")
-	// Negative textStart clamps to 0.
-	start, end, ok := anchorFragmentBytes(row, -10, "sec")
-	require.True(t, ok)
-	assert.Equal(t, "sec", string(row[start:end]))
-	// textStart past EOL.
-	_, _, ok = anchorFragmentBytes(row, 999, "sec")
-	assert.False(t, ok)
-}
-
 // TestDestBoundsEdgeCases covers the unclosed-paren branch.
-func TestDestBoundsEdgeCases(t *testing.T) {
-	t.Parallel()
-	_, _, ok := destBounds([]byte(`[t](unclosed`), 0)
-	assert.False(t, ok)
-	_, _, ok = destBounds([]byte(`plain text`), 0)
-	assert.False(t, ok)
-}
-
 // TestFragmentMatchesSlugInvalidEscape verifies the helper falls
 // back to the raw bytes when URL-unescaping fails (malformed
 // percent escape).
-func TestFragmentMatchesSlugInvalidEscape(t *testing.T) {
-	t.Parallel()
-	// `%zz` is an invalid percent escape; PathUnescape errors out
-	// and the helper uses the raw bytes for slugify.
-	got := fragmentMatchesSlug([]byte("%zz"), "zz")
-	assert.True(t, got)
-}
-
 // TestLineOfBodyOffsetEdges covers the negative-offset and
 // past-EOF clamps.
-func TestLineOfBodyOffsetEdges(t *testing.T) {
-	t.Parallel()
-	body := []byte("a\nb\nc")
-	assert.Equal(t, 1, lineOfBodyOffset(body, -5))
-	// past EOF clamps to last line
-	assert.Equal(t, 3, lineOfBodyOffset(body, 1000))
-}
-
 // TestRenameLinkRefAfterDidChangeRewritesLiveBuffer verifies the
 // rename uses the buffer the editor most recently sent rather
 // than the on-disk content. After a didChange that keeps the
@@ -569,11 +435,8 @@ func TestRenameHeadingAllowsSameBaseSlugRefresh(t *testing.T) {
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// First `## Setup` (line 3, 1-based) → LSP line 2.
-		Position: Position{Line: 2, Character: 4},
-		// Same base slug ("setup") — this is a non-semantic refresh,
-		// not a collision.
-		NewName: "Setup!",
+		Position:     Position{Line: 2, Character: 4},
+		NewName:      "Setup!",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
@@ -627,14 +490,6 @@ func TestRenameHeadingRejectsNewline(t *testing.T) {
 
 // TestDestBoundsEscapedClosingInText verifies the `\]` escape
 // inside link text is honored by destBounds.
-func TestDestBoundsEscapedClosingInText(t *testing.T) {
-	t.Parallel()
-	row := []byte(`[a\](b)](#sec)`)
-	open, close, ok := destBounds(row, 0)
-	require.True(t, ok)
-	assert.Equal(t, "#sec", string(row[open:close]))
-}
-
 // TestHandleRenameOnRefUseRewritesViaUse covers handleRename's
 // TokenRefUse case — the cursor on `[text][label]` instead of
 // the def line.
@@ -673,22 +528,6 @@ func TestResolveURIAndSourceMissingOnDisk(t *testing.T) {
 // TestAnchorEditForEdgeStalePaths covers anchorEditForEdge's
 // defensive branches: unresolvable source file, SourceLine out
 // of range, and a fragment that doesn't match.
-func TestAnchorEditForEdgeStalePaths(t *testing.T) {
-	t.Parallel()
-	h, _, rootURI := rootedHarness(t, map[string]string{"a.md": "# A\n\n[t](#sec)\n"})
-	uri := rootURI + "/a.md"
-	h.notify("textDocument/didOpen", didOpenTextDocumentParams{
-		TextDocument: textDocumentItem{URI: uri, LanguageID: "markdown", Version: 1, Text: "# A\n\n[t](#sec)\n"},
-	})
-	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
-	_, _, ok := h.srv.anchorEditForEdge(index.Edge{SourceFile: "gone.md", SourceLine: 1, SourceCol: 1}, "sec", "new")
-	assert.False(t, ok)
-	_, _, ok = h.srv.anchorEditForEdge(index.Edge{SourceFile: "a.md", SourceLine: 999, SourceCol: 1}, "sec", "new")
-	assert.False(t, ok)
-	_, _, ok = h.srv.anchorEditForEdge(index.Edge{SourceFile: "a.md", SourceLine: 3, SourceCol: 1}, "missing", "new")
-	assert.False(t, ok)
-}
-
 // TestRefUseEditsInBodyIgnoresOtherLabels covers the
 // `Reference.Value != oldLabel` continue branch.
 func TestRefUseEditsInBodyIgnoresOtherLabels(t *testing.T) {
@@ -746,145 +585,25 @@ func TestBracketPairsStrayClosingBracket(t *testing.T) {
 // TestRefDefHelperShapes drives every branch of the ref-def
 // destination helpers added for the heading-rename companion
 // pass.
-func TestRefDefHelperShapes(t *testing.T) {
-	t.Parallel()
-	// refDefColonOffset
-	assert.Equal(t, 5, refDefColonOffset([]byte(`[abc]: url`)))
-	assert.Equal(t, 7, refDefColonOffset([]byte(`  [abc]: url`)))
-	assert.Equal(t, -1, refDefColonOffset([]byte(`plain text`)))
-	assert.Equal(t, -1, refDefColonOffset([]byte(`[no-close`)))
-	assert.Equal(t, -1, refDefColonOffset([]byte(`[abc] no colon`)))
-	assert.Equal(t, -1, refDefColonOffset([]byte(`    [over]: x`)))
-
-	// refDefDestRange — skip leading whitespace, stop at next space.
-	start, end := refDefDestRange([]byte(`[a]:   url more`), 4)
-	assert.Equal(t, "url", string([]byte(`[a]:   url more`)[start:end]))
-	// All-whitespace tail returns empty range at end.
-	start, end = refDefDestRange([]byte(`[a]:   `), 4)
-	assert.Equal(t, start, end)
-
-	// refDefParseTarget happy + error cases.
-	tgt, ok := refDefParseTarget("./b.md#sec")
-	require.True(t, ok)
-	assert.Equal(t, "./b.md", tgt.path)
-	assert.Equal(t, "sec", tgt.fragment)
-	tgt, ok = refDefParseTarget("#sec")
-	require.True(t, ok)
-	assert.True(t, tgt.localAnchor)
-	_, ok = refDefParseTarget("")
-	assert.False(t, ok)
-	_, ok = refDefParseTarget("//host/x")
-	assert.False(t, ok)
-	_, ok = refDefParseTarget("https://example.com")
-	assert.False(t, ok)
-	_, ok = refDefParseTarget("%")
-	assert.False(t, ok)
-	_, ok = refDefParseTarget("   ")
-	assert.False(t, ok)
-	// Empty path AND empty fragment.
-	_, ok = refDefParseTarget("?q=v")
-	assert.False(t, ok)
-
-	// refDefDestPointsAt happy + mismatches.
-	assert.True(t, refDefDestPointsAt(
-		[]byte(`./a.md#setup`), "b.md", "a.md", "setup"))
-	assert.False(t, refDefDestPointsAt(
-		[]byte(`./a.md#other`), "b.md", "a.md", "setup"))
-	assert.False(t, refDefDestPointsAt(
-		[]byte(`./other.md#setup`), "b.md", "a.md", "setup"))
-	// Local anchor in a def whose host file matches headingFile.
-	assert.True(t, refDefDestPointsAt(
-		[]byte(`#setup`), "a.md", "a.md", "setup"))
-	// Local anchor in the wrong host file.
-	assert.False(t, refDefDestPointsAt(
-		[]byte(`#setup`), "b.md", "a.md", "setup"))
-	// Garbage destination.
-	assert.False(t, refDefDestPointsAt(
-		[]byte(`%`), "b.md", "a.md", "setup"))
-	// Percent-escaped anchor still matches the slugified form.
-	assert.True(t, refDefDestPointsAt(
-		[]byte(`./a.md#Docs%20API`), "b.md", "a.md", "docs-api"))
-}
-
 // TestRefDefDestEditForMatchSkipsBadInputs covers
 // refDefDestEditForMatch's defensive returns: out-of-range
 // fileLine, malformed bracket shape, empty dest, and the
 // no-`#` fragment path.
-func TestRefDefDestEditForMatchSkipsBadInputs(t *testing.T) {
-	t.Parallel()
-	body := []byte(`[a]: ./b.md#sec`)
-	// Out-of-range fileLine (lines slice has 1 entry but match
-	// points past it).
-	short := [][]byte{[]byte("# h")}
-	_, ok := refDefDestEditForMatch(body, short, 10, []int{0, len(body), 1, 2},
-		"a.md", "b.md", "sec", "new")
-	assert.False(t, ok)
-	// Row that the regex matched but doesn't contain a valid
-	// `[label]:` (synthetic mismatch).
-	lines := [][]byte{[]byte("plain")}
-	_, ok = refDefDestEditForMatch(body, lines, 0, []int{0, 5, 1, 2},
-		"a.md", "b.md", "sec", "new")
-	assert.False(t, ok)
-	// Empty destination after `:`.
-	lines = [][]byte{[]byte("[a]:   ")}
-	_, ok = refDefDestEditForMatch([]byte("[a]:   "), lines, 0,
-		[]int{0, 7, 1, 2}, "a.md", "b.md", "sec", "new")
-	assert.False(t, ok)
-	// Destination has no `#` (so no fragment to rewrite).
-	lines = [][]byte{[]byte("[a]: ./b.md")}
-	_, ok = refDefDestEditForMatch([]byte("[a]: ./b.md"), lines, 0,
-		[]int{0, 11, 1, 2}, "a.md", "b.md", "sec", "new")
-	assert.False(t, ok)
-}
-
 // TestAppendRefDefDestEditsForHeadingSkipsUnresolvable covers
 // the resolveURIAndSource fail branch by planting a synthetic
 // index entry for a file the server can't read.
-func TestAppendRefDefDestEditsForHeadingSkipsUnresolvable(t *testing.T) {
-	t.Parallel()
-	h, _, _ := rootedHarness(t, map[string]string{})
-	idx := h.srv.ensureIndex()
-	idx.UpdateWithKinds("ghost.md", []byte("[setup]: ./a.md#setup\n"), nil)
-	changes := map[string][]textEdit{}
-	h.srv.appendRefDefDestEditsForHeading(changes, idx, "a.md", "setup", "config")
-	assert.Empty(t, changes)
-}
-
 // TestValidRefDefMatchesSkipsRegexHitGoldmarkRefused covers the
 // `!wanted[norm]` continue arm. The first `[unaccepted]: url`
 // line is paragraph continuation in CommonMark, so the regex
 // matches it but goldmark never registers a def for that label;
 // the helper must drop it while still emitting the real
 // `[accepted]: url` def.
-func TestValidRefDefMatchesSkipsRegexHitGoldmarkRefused(t *testing.T) {
-	t.Parallel()
-	body := []byte("para line\n[unaccepted]: url\n\n[accepted]: url\n")
-	matches := validRefDefMatches(body)
-	require.Len(t, matches, 1)
-	assert.Equal(t, "accepted", matches[0].rawLabel)
-}
-
 // TestAppendAnchorEditsForHeadingDropsUnresolvableEdge plants a
 // synthetic edge in the index that points at a file the server
 // can't read, then verifies appendAnchorEditsForHeading skips it
 // rather than producing a phantom edit. This drives the
 // `if !ok { continue }` arm that the rename's natural flow
 // rarely reaches.
-func TestAppendAnchorEditsForHeadingDropsUnresolvableEdge(t *testing.T) {
-	t.Parallel()
-	h, _, _ := rootedHarness(t, map[string]string{
-		"present.md": "# Real\n",
-	})
-	idx := h.srv.ensureIndex()
-	// `ghost.md` has no on-disk file and no open buffer, so
-	// resolveURIAndSource will fail; but the index entry below
-	// makes IncomingEdges return an edge for (ghost.md, sec).
-	idx.UpdateWithKinds("ghost.md", []byte("# Sec\n[t](#sec)\n"), nil)
-	changes := map[string][]textEdit{}
-	h.srv.appendAnchorEditsForHeading(changes, idx, "ghost.md", "sec", "newsec")
-	assert.Empty(t, changes)
-}
-
 // TestRenameLinkRefSkipsEmptyTextReference verifies that an
 // empty-text reference link `[][docs]` doesn't panic the
 // rename. linkTextBounds returns (-1, -1) for these — without
@@ -946,33 +665,8 @@ func TestRenameHeadingRewritesAngleBracketRefDef(t *testing.T) {
 // TestRefDefDestRangeAngleBracket exercises the new
 // angle-bracket arm of refDefDestRange plus its
 // fall-through on an unterminated `<…`.
-func TestRefDefDestRangeAngleBracket(t *testing.T) {
-	t.Parallel()
-	row := []byte(`[a]: <./b.md#sec>`)
-	start, end := refDefDestRange(row, 4)
-	assert.Equal(t, "./b.md#sec", string(row[start:end]))
-	// Unterminated angle: fall back to bare reader from the `<`.
-	row = []byte(`[a]: <./b.md#sec`)
-	start, end = refDefDestRange(row, 4)
-	assert.Equal(t, "<./b.md#sec", string(row[start:end]))
-	// Angle dest containing an escaped `\>` doesn't terminate
-	// the URL early.
-	row = []byte(`[a]: <./b.md\>x#sec>`)
-	start, end = refDefDestRange(row, 4)
-	assert.Equal(t, `./b.md\>x#sec`, string(row[start:end]))
-}
-
 // TestLabelBoundsInBodyEmptyText covers the negative-offset
 // guard added for empty-text references.
-func TestLabelBoundsInBodyEmptyText(t *testing.T) {
-	t.Parallel()
-	body := []byte(`[][docs]`)
-	_, _, ok := labelBoundsInBody(body, -1, -1, ast.ReferenceLinkFull)
-	assert.False(t, ok)
-	_, _, ok = labelBoundsInBody(body, -1, -1, ast.ReferenceLinkShortcut)
-	assert.False(t, ok)
-}
-
 // TestRenameHeadingSkipsRefDefInCodeBlock verifies that a
 // `[label]: …#oldSlug` line inside a fenced code block is not
 // rewritten when the heading is renamed. Without routing
@@ -1000,12 +694,7 @@ func TestRenameHeadingSkipsRefDefInCodeBlock(t *testing.T) {
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uriB)
-	// Only the real `[real]: ./a.md#setup` def rewrites. The
-	// fake one inside the fenced code block stays put.
 	require.Len(t, edit.Changes[uriB], 1)
-	// The fence opens on b.md line 5 (1-based) → LSP line 4;
-	// the fake def is on line 6 → LSP line 5. No edit should
-	// land there.
 	assert.NotEqual(t, 5, edit.Changes[uriB][0].Range.Start.Line)
 }
 
@@ -1015,15 +704,6 @@ func TestRenameHeadingSkipsRefDefInCodeBlock(t *testing.T) {
 // a real `[docs]: url` def appears later in the file. The
 // label-only filter from before would accept both regex hits;
 // the AST paragraph-line filter drops the continuation.
-func TestValidRefDefMatchesExcludesParagraphContinuation(t *testing.T) {
-	t.Parallel()
-	body := []byte("para line\n[docs]: bogus\n\n[docs]: https://real\n")
-	matches := validRefDefMatches(body)
-	require.Len(t, matches, 1)
-	// The surviving match is the real def on body-line 4.
-	assert.Equal(t, 4, matches[0].bodyLine)
-}
-
 // TestRenameHeadingRewritesRefDefDestinations verifies the
 // ref-def-destination companion pass. A `[setup]: ./a.md#setup`
 // def in b.md isn't recorded as an edge in the index (refs are
@@ -1052,9 +732,6 @@ func TestRenameHeadingRewritesRefDefDestinations(t *testing.T) {
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uriB)
-	// b.md's `[setup]: ./a.md#setup` def rewrites to
-	// `#configuration`; the `[local]: #setup` def points at the
-	// non-renamed file b.md so it stays untouched.
 	bEdits := edit.Changes[uriB]
 	require.Len(t, bEdits, 1)
 	assert.Equal(t, "configuration", bEdits[0].NewText)
@@ -1084,7 +761,6 @@ func TestRenameLinkRefMultiLineUseRewritesLabel(t *testing.T) {
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uri)
-	// Def + multi-line full ref + single-line shortcut = 3 edits.
 	require.Len(t, edit.Changes[uri], 3)
 	for _, e := range edit.Changes[uri] {
 		assert.Equal(t, "manual", e.NewText)
@@ -1096,49 +772,6 @@ func TestRenameLinkRefMultiLineUseRewritesLabel(t *testing.T) {
 // `]` after text, missing `[` after `]`, unterminated label,
 // shortcut/collapsed with valid bracketing, and shortcut/
 // collapsed where the leading `[` isn't right before textStart.
-func TestLabelBoundsInBodyShapes(t *testing.T) {
-	t.Parallel()
-	// Full ref `[t][docs]`: text "t" at offset 1, textEnd=2.
-	body := []byte(`[t][docs]`)
-	start, end, ok := labelBoundsInBody(body, 1, 2, ast.ReferenceLinkFull)
-	require.True(t, ok)
-	assert.Equal(t, "docs", string(body[start:end]))
-	// Full but trailing `[` missing.
-	body = []byte(`[t] docs`)
-	_, _, ok = labelBoundsInBody(body, 1, 2, ast.ReferenceLinkFull)
-	assert.False(t, ok)
-	// Full but unterminated label.
-	body = []byte(`[t][docs`)
-	_, _, ok = labelBoundsInBody(body, 1, 2, ast.ReferenceLinkFull)
-	assert.False(t, ok)
-	// Full but the byte at textEnd isn't `]`.
-	body = []byte(`[t (docs)`)
-	_, _, ok = labelBoundsInBody(body, 1, 2, ast.ReferenceLinkFull)
-	assert.False(t, ok)
-	// Shortcut `[docs]`: text "docs" at offset 1, textEnd=5.
-	body = []byte(`[docs]`)
-	start, end, ok = labelBoundsInBody(body, 1, 5, ast.ReferenceLinkShortcut)
-	require.True(t, ok)
-	assert.Equal(t, "docs", string(body[start:end]))
-	// Shortcut with textStart at byte 0 (no leading `[`).
-	body = []byte(`docs]`)
-	_, _, ok = labelBoundsInBody(body, 0, 4, ast.ReferenceLinkShortcut)
-	assert.False(t, ok)
-	// Shortcut where the leading byte isn't `[`.
-	body = []byte(`(docs]`)
-	_, _, ok = labelBoundsInBody(body, 1, 5, ast.ReferenceLinkShortcut)
-	assert.False(t, ok)
-	// Shortcut where the byte at textEnd isn't `]`.
-	body = []byte(`[docs `)
-	_, _, ok = labelBoundsInBody(body, 1, 5, ast.ReferenceLinkShortcut)
-	assert.False(t, ok)
-	// Full ref label with `\]` escape inside the label.
-	body = []byte(`[t][doc\]s]`)
-	start, end, ok = labelBoundsInBody(body, 1, 2, ast.ReferenceLinkFull)
-	require.True(t, ok)
-	assert.Equal(t, `doc\]s`, string(body[start:end]))
-}
-
 // TestBracketPairsHandlesNestedBrackets verifies that the
 // bracket walker pairs the outer `]` with the outer `[` for
 // CommonMark text containing balanced inner brackets (e.g.
@@ -1161,7 +794,6 @@ func TestBracketPairsHandlesNestedBrackets(t *testing.T) {
 func TestRefUseLabelBytesNestedBrackets(t *testing.T) {
 	t.Parallel()
 	row := []byte(`See [a [b]][label] inline`)
-	// Cursor on `b` (offset 8). Label is "label".
 	start, end, ok := refUseLabelBytes(row, 8, "label")
 	require.True(t, ok)
 	assert.Equal(t, "label", string(row[start:end]))
@@ -1174,8 +806,6 @@ func TestRefUseLabelBytesNestedBrackets(t *testing.T) {
 func TestIsValidRefDefLineBodyLineUnderflow(t *testing.T) {
 	t.Parallel()
 	src := []byte("---\ntitle: T\n---\n[a]: x\n")
-	// line=1 sits inside the front matter; subtracting fmOffset (3)
-	// pushes bodyLine to -2, so the helper short-circuits to false.
 	assert.False(t, isValidRefDefLine(src, 1))
 }
 
@@ -1206,8 +836,7 @@ func TestPrepareRenameSkipsCodeBlockDefLookalike(t *testing.T) {
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
 	raw, errResp := h.request("textDocument/prepareRename", textDocumentPositionParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor inside `[fake]: https://x` (line 4, 1-based).
-		Position: Position{Line: 3, Character: 2},
+		Position:     Position{Line: 3, Character: 2},
 	})
 	require.Nil(t, errResp)
 	assert.Equal(t, "null", string(raw))
@@ -1228,19 +857,15 @@ func TestRenameLinkRefIgnoresCodeBlockLookalike(t *testing.T) {
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on the real def line `[docs]: https://right` (line 9, 1-based).
-		Position: Position{Line: 8, Character: 2},
-		NewName:  "manual",
+		Position:     Position{Line: 8, Character: 2},
+		NewName:      "manual",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uri)
-	// Two edits: the real def + the `[t][docs]` use.
 	require.Len(t, edit.Changes[uri], 2)
 	for _, e := range edit.Changes[uri] {
-		// Code-block line is line 6 (0-based 5); ensure no edit
-		// targets it.
 		assert.NotEqual(t, 5, e.Range.Start.Line, "edit must not target code-block line")
 	}
 }
@@ -1265,25 +890,12 @@ func TestResolveURIAndSourceFallbackToDisk(t *testing.T) {
 	uri, source, ok := h.srv.resolveURIAndSource("closed.md")
 	require.True(t, ok)
 	assert.Equal(t, "# closed\n", string(source))
-	// Fallback uses the canonical workspaceURI form, which mirrors
-	// the openURI's prefix (file://...).
 	assert.Equal(t, rootURI+"/closed.md", uri)
 }
 
 // TestRefDefEditsInBodyIgnoresOtherLabels verifies the
 // `normalizedLabel != oldLabel` continue branch — defs for other
 // labels in the same buffer are skipped.
-func TestRefDefEditsInBodyIgnoresOtherLabels(t *testing.T) {
-	t.Parallel()
-	body := []byte("[a]: x\n[b]: y\n[a]: z\n")
-	lines := [][]byte{[]byte("[a]: x"), []byte("[b]: y"), []byte("[a]: z")}
-	out := refDefEditsInBody(body, lines, 0, "a", "renamed")
-	require.Len(t, out, 2)
-	for _, e := range out {
-		assert.Equal(t, "renamed", e.NewText)
-	}
-}
-
 // TestAppendAnchorEditsForHeadingSkipsStaleEdge covers the
 // continue branch in appendAnchorEditsForHeading: an edge whose
 // link doesn't actually contain the old slug at the recorded
@@ -1291,7 +903,6 @@ func TestRefDefEditsInBodyIgnoresOtherLabels(t *testing.T) {
 // than failing the rename.
 func TestAppendAnchorEditsForHeadingSkipsStaleEdge(t *testing.T) {
 	t.Parallel()
-	// Build a real harness, then fabricate an out-of-date edge.
 	src := "# Top\n\n[link](#elsewhere)\n"
 	h, _, rootURI := rootedHarness(t, map[string]string{"a.md": src})
 	uri := rootURI + "/a.md"
@@ -1299,10 +910,7 @@ func TestAppendAnchorEditsForHeadingSkipsStaleEdge(t *testing.T) {
 		TextDocument: textDocumentItem{URI: uri, LanguageID: "markdown", Version: 1, Text: src},
 	})
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
-	// Trigger index build.
 	_ = h.srv.ensureIndex()
-	// Rename "Top" to "Other"; the edge for `[link](#elsewhere)`
-	// is unrelated to the heading and stays untouched.
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
 		Position:     Position{Line: 0, Character: 3},
@@ -1312,7 +920,6 @@ func TestAppendAnchorEditsForHeadingSkipsStaleEdge(t *testing.T) {
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uri)
-	// One edit total (heading line); no stale anchor edit slipped in.
 	require.Len(t, edit.Changes[uri], 1)
 }
 
@@ -1339,8 +946,6 @@ func TestRenameHeadingSelfLinkSharesURI(t *testing.T) {
 	require.Nil(t, errResp)
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
-	// Both the heading text and the self-anchor link must land
-	// under the same URI key.
 	require.Len(t, edit.Changes, 1, "expected one URI key, got %v", keys(edit.Changes))
 	require.Contains(t, edit.Changes, uri)
 	require.Len(t, edit.Changes[uri], 2)
@@ -1363,7 +968,6 @@ func TestTrimmedRangeStripsLeadingAndTrailing(t *testing.T) {
 	start, end := trimmedRange([]byte("  text\t"))
 	assert.Equal(t, 2, start)
 	assert.Equal(t, 6, end)
-	// All-whitespace input collapses to start==end.
 	start, end = trimmedRange([]byte("   "))
 	assert.Equal(t, start, end)
 }
@@ -1399,25 +1003,4 @@ func TestRefUseLabelBytesReturnsFalseWhenCursorOutside(t *testing.T) {
 	row := []byte(`[a][b]`)
 	_, _, ok := refUseLabelBytes(row, 99, "a")
 	assert.False(t, ok)
-}
-
-// TestDestBoundsUnclosedReturnsFalse covers the depth>0
-// fallthrough branch when the destination has an unclosed `(`.
-func TestDestBoundsUnclosedReturnsFalse(t *testing.T) {
-	t.Parallel()
-	_, _, ok := destBounds([]byte(`[t](inner(unclosed`), 0)
-	assert.False(t, ok)
-}
-
-// TestRefDefEditsInBodyOutOfRangeFileLine covers the defensive
-// `fileLine-1 >= len(lines)` branch by feeding a body whose
-// regex match points at a line index past `lines`.
-func TestRefDefEditsInBodyOutOfRangeFileLine(t *testing.T) {
-	t.Parallel()
-	// Two `[label]: url` matches in body but lines slice has
-	// only one — the second match is silently skipped.
-	body := []byte("[a]: x\n[a]: x\n")
-	lines := [][]byte{[]byte("[a]: x")}
-	out := refDefEditsInBody(body, lines, 0, "a", "b")
-	require.Len(t, out, 1)
 }

--- a/internal/lsp/rename_test.go
+++ b/internal/lsp/rename_test.go
@@ -47,7 +47,6 @@ func TestPrepareRenameHeadingReturnsTextRange(t *testing.T) {
 	var res prepareRenameResult
 	require.NoError(t, json.Unmarshal(raw, &res))
 	assert.Equal(t, "Setup", res.Placeholder)
-	// "## Setup" — `S` is at byte column 3 (UTF-16 col 3), end col 8.
 	assert.Equal(t, Position{Line: 2, Character: 3}, res.Range.Start)
 	assert.Equal(t, Position{Line: 2, Character: 8}, res.Range.End)
 }
@@ -109,9 +108,7 @@ func TestRenameHeadingRewritesCrossFileAnchors(t *testing.T) {
 	assert.Len(t, edit.Changes[uriA], 1, "heading line edit")
 	assert.Len(t, edit.Changes[uriB], 1, "one anchor link in b.md")
 	assert.Len(t, edit.Changes[uriC], 2, "two anchor links in c.md")
-	// The replacement on a.md is the new heading text.
 	assert.Equal(t, "Configuration", edit.Changes[uriA][0].NewText)
-	// Anchor edits replace just the slug portion (no leading `#`).
 	for _, e := range edit.Changes[uriB] {
 		assert.Equal(t, "configuration", e.NewText)
 	}
@@ -146,17 +143,14 @@ func TestRenameHeadingShiftDetection(t *testing.T) {
 	}
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uriA},
-		// Position on the FIRST `## Setup` (line 3, 1-based) → LSP line 2.
-		Position: Position{Line: 2, Character: 4},
-		NewName:  "Configuration",
+		Position:     Position{Line: 2, Character: 4},
+		NewName:      "Configuration",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uriB)
 	require.Len(t, edit.Changes[uriB], 1)
-	// `setup-1` shifted to `setup`; b.md's link must now point at
-	// `#setup`.
 	assert.Equal(t, "setup", edit.Changes[uriB][0].NewText)
 }
 
@@ -175,9 +169,8 @@ func TestRenameHeadingCollisionReturnsInvalidParams(t *testing.T) {
 
 	_, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `## Bar` (line 5, 1-based) → LSP line 4.
-		Position: Position{Line: 4, Character: 4},
-		NewName:  "Foo",
+		Position:     Position{Line: 4, Character: 4},
+		NewName:      "Foo",
 	})
 	require.NotNil(t, errResp, "expected InvalidParams")
 	assert.Equal(t, codeInvalidParams, errResp.Code)
@@ -202,15 +195,13 @@ func TestRenameLinkRefLabel(t *testing.T) {
 
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `[docs]: …` (line 5, 1-based) → LSP line 4.
-		Position: Position{Line: 4, Character: 2},
-		NewName:  "manual",
+		Position:     Position{Line: 4, Character: 2},
+		NewName:      "manual",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uri)
-	// One def + two uses (full + shortcut) = 3 edits.
 	assert.Len(t, edit.Changes[uri], 3)
 	for _, e := range edit.Changes[uri] {
 		assert.Equal(t, "manual", e.NewText)
@@ -232,9 +223,8 @@ func TestRenameLinkRefLabelCollision(t *testing.T) {
 
 	_, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `[docs]: …` (line 5, 1-based).
-		Position: Position{Line: 4, Character: 2},
-		NewName:  "manual",
+		Position:     Position{Line: 4, Character: 2},
+		NewName:      "manual",
 	})
 	require.NotNil(t, errResp)
 	assert.Equal(t, codeInvalidParams, errResp.Code)
@@ -258,9 +248,8 @@ func TestRenameLinkRefRefreshesCasing(t *testing.T) {
 
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `[docs api]: …` (line 5, 1-based) → LSP line 4.
-		Position: Position{Line: 4, Character: 2},
-		NewName:  "Docs API",
+		Position:     Position{Line: 4, Character: 2},
+		NewName:      "Docs API",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
@@ -290,9 +279,8 @@ func TestRenameLinkRefDetectsDuplicateDefCollision(t *testing.T) {
 
 	_, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `[docs]: …` (line 5, 1-based) → LSP line 4.
-		Position: Position{Line: 4, Character: 2},
-		NewName:  "manual",
+		Position:     Position{Line: 4, Character: 2},
+		NewName:      "manual",
 	})
 	require.NotNil(t, errResp)
 	assert.Equal(t, codeInvalidParams, errResp.Code)
@@ -315,9 +303,8 @@ func TestRenameHeadingRejectsEmptySlugNewName(t *testing.T) {
 
 	_, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `## Setup` (line 3, 1-based) → LSP line 2.
-		Position: Position{Line: 2, Character: 4},
-		NewName:  "!!!",
+		Position:     Position{Line: 2, Character: 4},
+		NewName:      "!!!",
 	})
 	require.NotNil(t, errResp)
 	assert.Equal(t, codeInvalidParams, errResp.Code)
@@ -385,9 +372,7 @@ func TestPrepareRenameOnRefUseReturnsLabelRange(t *testing.T) {
 
 	raw, errResp := h.request("textDocument/prepareRename", textDocumentPositionParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor inside `[look][docs]` — line 3 (0-based: 2),
-		// char 12 lands inside the second bracket pair.
-		Position: Position{Line: 2, Character: 12},
+		Position:     Position{Line: 2, Character: 12},
 	})
 	require.Nil(t, errResp)
 	var res prepareRenameResult
@@ -400,7 +385,6 @@ func TestPrepareRenameOnRefUseReturnsLabelRange(t *testing.T) {
 // edit replaces that line and leaves the underline intact.
 func TestRenameSetextHeading(t *testing.T) {
 	t.Parallel()
-	// Setext H2: "Setup" with `-----` underline on next line.
 	src := "Top\n===\n\nSetup\n-----\n\nbody\n"
 	h, _, rootURI := rootedHarness(t, map[string]string{"a.md": src})
 	uri := rootURI + "/a.md"
@@ -411,9 +395,8 @@ func TestRenameSetextHeading(t *testing.T) {
 
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `Setup` (line 4, 1-based) → LSP line 3.
-		Position: Position{Line: 3, Character: 2},
-		NewName:  "Configuration",
+		Position:     Position{Line: 3, Character: 2},
+		NewName:      "Configuration",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
@@ -442,8 +425,7 @@ func TestPrepareRenameLabelPlaceholderPreservesCase(t *testing.T) {
 
 	raw, errResp := h.request("textDocument/prepareRename", textDocumentPositionParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `[Docs API]:` (line 5, 1-based) → LSP line 4.
-		Position: Position{Line: 4, Character: 2},
+		Position:     Position{Line: 4, Character: 2},
 	})
 	require.Nil(t, errResp)
 	var res prepareRenameResult
@@ -458,9 +440,6 @@ func TestPrepareRenameLabelPlaceholderPreservesCase(t *testing.T) {
 // renamed heading on its actual line.
 func TestRenameHeadingHandlesEmptySlugSibling(t *testing.T) {
 	t.Parallel()
-	// First heading slugifies to "" (only punctuation), so a naive
-	// implementation would mis-identify which heading the cursor
-	// lands on.
 	src := "# !!!\n\n## Setup\n\nbody\n"
 	h, _, rootURI := rootedHarness(t, map[string]string{"a.md": src})
 	uri := rootURI + "/a.md"
@@ -471,17 +450,14 @@ func TestRenameHeadingHandlesEmptySlugSibling(t *testing.T) {
 
 	raw, errResp := h.request("textDocument/rename", renameParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
-		// Cursor on `## Setup` (line 3, 1-based) → LSP line 2.
-		Position: Position{Line: 2, Character: 4},
-		NewName:  "Configuration",
+		Position:     Position{Line: 2, Character: 4},
+		NewName:      "Configuration",
 	})
 	require.Nil(t, errResp)
 	var edit workspaceEdit
 	require.NoError(t, json.Unmarshal(raw, &edit))
 	require.Contains(t, edit.Changes, uri)
 	require.Len(t, edit.Changes[uri], 1)
-	// The edit must target the `## Setup` line (LSP line 2), not
-	// the `# !!!` line (LSP line 0).
 	assert.Equal(t, 2, edit.Changes[uri][0].Range.Start.Line)
 	assert.Equal(t, "Configuration", edit.Changes[uri][0].NewText)
 }
@@ -520,89 +496,25 @@ func TestAtxHeadingTextByteRange(t *testing.T) {
 // TestAnchorFragmentBytes verifies the helper that finds the slug
 // portion inside a link destination on a line. The returned range
 // is what the rename's TextEdit uses to swap in the new slug.
-func TestAnchorFragmentBytes(t *testing.T) {
-	t.Parallel()
-	row := []byte("text [a](./b.md#sec) more [c](#sec) end")
-	// First link: `[a](./b.md#sec)` — text starts at byte 5 (`[`).
-	startA, endA, ok := anchorFragmentBytes(row, 6, "sec")
-	require.True(t, ok)
-	assert.Equal(t, "sec", string(row[startA:endA]))
-	// Second link: `[c](#sec)` — text starts at byte 26 (`[`).
-	startB, endB, ok := anchorFragmentBytes(row, 27, "sec")
-	require.True(t, ok)
-	assert.Equal(t, "sec", string(row[startB:endB]))
-	// Slug not present on this link.
-	_, _, ok = anchorFragmentBytes(row, 6, "missing")
-	assert.False(t, ok)
-}
-
 // TestAnchorFragmentBytesRejectsPrefixMatch guards against
 // `#foo` rewriting `#foobar`. The destination ends at `)`, so
 // the fragment boundary must agree.
-func TestAnchorFragmentBytesRejectsPrefixMatch(t *testing.T) {
-	t.Parallel()
-	row := []byte("see [t](#foobar)")
-	_, _, ok := anchorFragmentBytes(row, 4, "foo")
-	assert.False(t, ok)
-}
-
 // TestAnchorFragmentBytesNormalizesCase verifies that a raw
 // fragment whose case differs from the slug still matches —
 // the index keys edges by mdtext.Slugify(decoded), which is
 // lowercase, so `#Setup` participates in a rename of the
 // `setup` slug.
-func TestAnchorFragmentBytesNormalizesCase(t *testing.T) {
-	t.Parallel()
-	row := []byte("see [t](#Setup)")
-	start, end, ok := anchorFragmentBytes(row, 4, "setup")
-	require.True(t, ok)
-	assert.Equal(t, "Setup", string(row[start:end]))
-}
-
 // TestAnchorFragmentBytesURLDecodesPercentEscape verifies that
 // `#Docs%20API` (a real GitHub anchor when the heading is
 // "Docs API") matches the indexed slug `docs-api`.
-func TestAnchorFragmentBytesURLDecodesPercentEscape(t *testing.T) {
-	t.Parallel()
-	row := []byte("see [t](#Docs%20API)")
-	start, end, ok := anchorFragmentBytes(row, 4, "docs-api")
-	require.True(t, ok)
-	assert.Equal(t, "Docs%20API", string(row[start:end]))
-}
-
 // TestAnchorFragmentBytesAngleBracketDestination verifies that
 // a destination of the form `<#sec>` returns a fragment range
 // that excludes the closing `>`. Without that boundary the
 // rename would overwrite the `>` and corrupt the link.
-func TestAnchorFragmentBytesAngleBracketDestination(t *testing.T) {
-	t.Parallel()
-	row := []byte(`see [t](<#sec>) end`)
-	start, end, ok := anchorFragmentBytes(row, 4, "sec")
-	require.True(t, ok)
-	assert.Equal(t, "sec", string(row[start:end]))
-	// Confirm the `>` lives outside the returned range.
-	assert.Equal(t, byte('>'), row[end])
-}
-
 // TestBodyLineIndexLookups exercises the precomputed line-offset
 // table. The fast path replaced an O(n) scan that ran per
 // reference-use edit; correctness is the bar this test enforces,
 // not throughput.
-func TestBodyLineIndexLookups(t *testing.T) {
-	t.Parallel()
-	body := []byte("alpha\nbeta\ngamma\n")
-	idx := newBodyLineIndex(body)
-	assert.Equal(t, 0, idx.LineStart(1))
-	assert.Equal(t, 6, idx.LineStart(2))
-	assert.Equal(t, 11, idx.LineStart(3))
-	assert.Equal(t, -1, idx.LineStart(99))
-	// Offset 0 → line 1; offset 6 (start of "beta") → line 2;
-	// offset 12 (mid-"gamma") → line 3.
-	assert.Equal(t, 1, idx.LineOfOffset(0))
-	assert.Equal(t, 2, idx.LineOfOffset(6))
-	assert.Equal(t, 3, idx.LineOfOffset(12))
-}
-
 // TestRefUseLabelBytesCollapsedTrailingEmptyBrackets verifies
 // that the cursor on the trailing `[]` of a collapsed reference
 // resolves to the leading bracket pair, not nil. The Locator
@@ -612,7 +524,6 @@ func TestBodyLineIndexLookups(t *testing.T) {
 func TestRefUseLabelBytesCollapsedTrailingEmptyBrackets(t *testing.T) {
 	t.Parallel()
 	row := []byte(`See [Docs API][] elsewhere`)
-	// Cursor inside the trailing `[]` (byte offset 14 = `[`).
 	start, end, ok := refUseLabelBytes(row, 14, "docs api")
 	require.True(t, ok, "expected match for cursor inside trailing []")
 	assert.Equal(t, "Docs API", string(row[start:end]))

--- a/internal/rename/heading.go
+++ b/internal/rename/heading.go
@@ -1,0 +1,788 @@
+package rename
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/index"
+	"github.com/jeduden/mdsmith/internal/linkgraph"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdtext"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// Workspace is the seam the heading rename needs. A heading rename
+// reaches beyond the edited file: every incoming `[t](other.md#slug)`
+// anchor and every `[label]: other.md#slug` ref-def whose destination
+// resolves to the renamed heading must be rewritten too. The engine
+// asks the Workspace three questions and stays surface-neutral:
+//
+//   - which edges point at (file, slug)?
+//   - what files exist?
+//   - what key + bytes back a workspace-relative path?
+//
+// The LSP server backs it with its warm index plus open buffers; the
+// `mdsmith rename` CLI with a transient index plus disk reads. The
+// returned key groups edits per output target (an LSP document URI,
+// or a CLI file path) without the engine knowing which.
+type Workspace interface {
+	// IncomingAnchorEdges returns every workspace edge whose target
+	// is (file, slug). file is workspace-relative.
+	IncomingAnchorEdges(file, slug string) []index.Edge
+	// Files lists every workspace-relative file path the workspace
+	// knows about.
+	Files() []string
+	// Resolve maps a workspace-relative path to the opaque key its
+	// edits group under and the file's current bytes (open-buffer
+	// text when the surface has one, else disk). ok is false when
+	// the file is unreadable.
+	Resolve(file string) (key string, source []byte, ok bool)
+}
+
+// ErrEmptyHeadingSlug is returned when the new heading text slugifies
+// to nothing (punctuation-only): the renamed heading would have no
+// addressable anchor, so cross-file links would have nowhere to land.
+var ErrEmptyHeadingSlug = errors.New(
+	"new heading text has no addressable slug; pick text containing letters or digits")
+
+// InvalidHeadingRuneError reports the first newline / carriage return
+// in the new heading text. A control rune would split the single-line
+// heading into a multi-line insertion. Its Error() is byte-identical
+// to the message the LSP server emitted before the refactor so the
+// adapter can surface it verbatim.
+type InvalidHeadingRuneError struct{ Rune rune }
+
+func (e InvalidHeadingRuneError) Error() string {
+	return fmt.Sprintf("heading text cannot contain %q", e.Rune)
+}
+
+// HeadingCollisionError reports that the new heading's bare slug
+// collides with another heading in the same file. Conflict carries
+// the colliding heading's visible text. Its Error() matches the
+// pre-refactor LSP message verbatim.
+type HeadingCollisionError struct{ Conflict string }
+
+func (e HeadingCollisionError) Error() string {
+	return "rename would collide with heading " + e.Conflict
+}
+
+// Heading rewrites a heading and every workspace anchor link / ref-def
+// destination pointing at it. fileKey is the key the heading file's
+// own edits group under (the LSP document URI, or the CLI file path);
+// file is its workspace-relative path; source its current bytes; line
+// the 1-based source line of the heading; oldName the heading's
+// current visible text; newName the requested text.
+//
+// Returns an empty (non-nil) map with no error when the rename is a
+// no-op (newName equals oldName after trimming). Returns a typed
+// error — InvalidHeadingRuneError, ErrEmptyHeadingSlug, or
+// HeadingCollisionError — without producing any edit when the rename
+// is unsafe, so callers surface the failure before applying anything.
+//
+// Algorithm (unchanged from the LSP original):
+//  1. Recompute the file's heading slug map under the new text.
+//  2. Reject a new bare-slug collision with another heading.
+//  3. Diff old vs new slug maps to find shifted headings.
+//  4. Emit the heading-line edit plus, per shifted slug, every
+//     incoming anchor edit and every ref-def-destination edit.
+func Heading(
+	ws Workspace, fileKey, file string, source []byte,
+	line int, oldName, newName string,
+) (map[string][]Edit, error) {
+	if strings.TrimSpace(newName) == strings.TrimSpace(oldName) {
+		return map[string][]Edit{}, nil
+	}
+	if r := firstControlRune(newName); r != 0 {
+		return nil, InvalidHeadingRuneError{Rune: r}
+	}
+	if mdtext.Slugify(newName) == "" {
+		return nil, ErrEmptyHeadingSlug
+	}
+	oldSlugs, newSlugs, conflict := computeSlugRemap(source, line, newName)
+	if conflict != "" {
+		return nil, HeadingCollisionError{Conflict: conflict}
+	}
+	// headingTextEdit's false branch is unreachable here: the caller
+	// resolved `line` to a heading line, so the row is a heading.
+	headingEdit, _ := headingTextEdit(source, line, newName)
+	changes := map[string][]Edit{fileKey: {headingEdit}}
+	for old, neu := range slugRemapPairs(oldSlugs, newSlugs) {
+		appendAnchorEditsForHeading(changes, ws, file, old, neu)
+		appendRefDefDestEditsForHeading(changes, ws, file, old, neu)
+	}
+	stableSortEdits(changes)
+	return changes, nil
+}
+
+// firstControlRune returns the first newline / carriage return in s,
+// or 0 when s is a single line. Heading text and link-ref labels are
+// single-line surfaces; a control rune would rewrite them into
+// multi-line garbage.
+func firstControlRune(s string) rune {
+	for _, r := range s {
+		if r == '\n' || r == '\r' {
+			return r
+		}
+	}
+	return 0
+}
+
+// computeSlugRemap returns the file's old slug list, its new slug list
+// (after substituting newText for the heading on `line`), and a
+// non-empty `conflict` heading text when the rename would create a new
+// duplicate base slug. The slices share index ordering: oldSlugs[i] /
+// newSlugs[i] are the i-th heading's slug before / after.
+//
+// The walk includes every heading, even ones whose slug is empty
+// (punctuation-only). Skipping them — as mdtext.CollectTOCItems does —
+// would desynchronize the per-heading indices from the heading-line
+// walk and mis-identify the renamed heading on files with empty-slug
+// headings before the cursor's line. It would also block renaming an
+// empty-slug heading into a real one (which can shift disambiguators).
+func computeSlugRemap(source []byte, line int, newText string) ([]string, []string, string) {
+	body, fmOffset := bodyAndFMOffset(source)
+	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
+	headings := walkAllHeadings(root, body)
+	bodyLine := line - fmOffset
+	target := -1
+	for i, h := range headings {
+		if h.bodyLine == bodyLine {
+			target = i
+			break
+		}
+	}
+	if target < 0 {
+		return nil, nil, ""
+	}
+	texts := make([]string, len(headings))
+	for i, h := range headings {
+		texts[i] = h.text
+	}
+	oldBase := mdtext.Slugify(headings[target].text)
+	texts[target] = newText
+	// Collision check: any other heading shares the new bare slug?
+	// Skip it when the rename keeps the same base slug — a
+	// non-semantic edit (case, punctuation) inside an existing
+	// duplicate-name group doesn't introduce a new collision, so
+	// blocking it would surprise the user.
+	newBase := mdtext.Slugify(newText)
+	if newBase != "" && newBase != oldBase {
+		for i, t := range texts {
+			if i == target {
+				continue
+			}
+			if mdtext.Slugify(t) == newBase {
+				return nil, nil, headings[i].text
+			}
+		}
+	}
+	oldSlugs := assignSlugs(slicesOfText(headings))
+	newSlugs := assignSlugs(texts)
+	return oldSlugs, newSlugs, ""
+}
+
+// headingWalk records the body-line and visible text of one heading
+// node. It carries no slug — the slug is computed in lockstep with
+// the rename so empty-slug headings aren't silently dropped.
+type headingWalk struct {
+	bodyLine int
+	text     string
+}
+
+// walkAllHeadings returns every heading in document order, including
+// ones whose slugified text is empty.
+func walkAllHeadings(root ast.Node, body []byte) []headingWalk {
+	var out []headingWalk
+	_ = ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok || h.Lines().Len() == 0 {
+			return ast.WalkContinue, nil
+		}
+		out = append(out, headingWalk{
+			bodyLine: lineOfBodyOffset(body, h.Lines().At(0).Start),
+			text:     mdtext.ExtractPlainText(h, body),
+		})
+		return ast.WalkContinue, nil
+	})
+	return out
+}
+
+func slicesOfText(walks []headingWalk) []string {
+	out := make([]string, len(walks))
+	for i, w := range walks {
+		out[i] = w.text
+	}
+	return out
+}
+
+// assignSlugs runs the same disambiguator pass
+// mdtext.CollectTOCItems uses, but over a parallel slice of texts so
+// callers can substitute a renamed heading's text in place without
+// losing alignment with the heading walk. Empty-base-slug headings
+// stay at "" — those have no anchor and never participate in link
+// rewrites.
+func assignSlugs(texts []string) []string {
+	used := map[string]bool{}
+	counts := map[string]int{}
+	out := make([]string, len(texts))
+	for i, t := range texts {
+		base := mdtext.Slugify(t)
+		if base == "" {
+			out[i] = ""
+			continue
+		}
+		anchor := base
+		if used[anchor] {
+			c := counts[base]
+			for {
+				c++
+				anchor = fmt.Sprintf("%s-%d", base, c)
+				if !used[anchor] {
+					break
+				}
+			}
+			counts[base] = c
+		}
+		used[anchor] = true
+		out[i] = anchor
+	}
+	return out
+}
+
+// slugRemapPairs maps old slug → new slug for every heading whose slug
+// changed. It skips entries whose old slug is empty (no anchor).
+func slugRemapPairs(oldSlugs, newSlugs []string) map[string]string {
+	out := map[string]string{}
+	for i := range oldSlugs {
+		if oldSlugs[i] == "" || oldSlugs[i] == newSlugs[i] {
+			continue
+		}
+		// First wins when two old slugs map to one new slug — the
+		// disambiguator keeps slugs unique so this shouldn't happen,
+		// but the guard prevents an inflated rewrite from a corrupt
+		// index.
+		if _, exists := out[oldSlugs[i]]; !exists {
+			out[oldSlugs[i]] = newSlugs[i]
+		}
+	}
+	return out
+}
+
+// headingTextEdit replaces the heading text on the source line with
+// newName. Returns false when the line is not a recognized heading
+// line.
+func headingTextEdit(source []byte, line int, newName string) (Edit, bool) {
+	lines := splitLines(source)
+	if line-1 >= len(lines) {
+		return Edit{}, false
+	}
+	row := lines[line-1]
+	startByte, endByte, ok := atxHeadingTextByteRange(row)
+	if !ok {
+		startByte, endByte = trimmedRange(row)
+	}
+	startCh := utf16FromByteOffset(row, startByte)
+	endCh := utf16FromByteOffset(row, endByte)
+	return Edit{
+		Range: Range{
+			Start: Position{Line: line - 1, Character: startCh},
+			End:   Position{Line: line - 1, Character: endCh},
+		},
+		NewText: newName,
+	}, true
+}
+
+// atxHeadingTextByteRange returns the byte offsets of the heading text
+// inside an ATX heading line — the run between the opening `#`s (and
+// required following space) and any trailing closing `#` run. Returns
+// false when row is not an ATX heading line.
+//
+// Trailing markers are recognized only when a CommonMark-significant
+// space precedes the run, mirroring goldmark's ATX parsing. A heading
+// line with no text (`### `) returns a zero-width range where text
+// would begin so the editor inserts there rather than rejecting the
+// rename.
+func atxHeadingTextByteRange(row []byte) (int, int, bool) {
+	textStart, ok := atxHeadingTextStart(row)
+	if !ok {
+		return 0, 0, false
+	}
+	end := trimRightSpace(row, textStart, len(row))
+	end = trimTrailingHashRun(row, textStart, end)
+	return textStart, end, true
+}
+
+// atxHeadingTextStart returns the byte offset where a heading's text
+// run begins, or false when row is not an ATX heading line.
+func atxHeadingTextStart(row []byte) (int, bool) {
+	i := skipLeadingSpaces(row, 3)
+	if i >= len(row) || row[i] != '#' {
+		return 0, false
+	}
+	hashStart := i
+	for i < len(row) && row[i] == '#' {
+		i++
+	}
+	level := i - hashStart
+	if level < 1 || level > 6 {
+		return 0, false
+	}
+	// CommonMark requires a space (or end of line) after the markers.
+	// `##foo` is paragraph content even though it starts with `#`.
+	if i < len(row) && row[i] != ' ' && row[i] != '\t' {
+		return 0, false
+	}
+	for i < len(row) && (row[i] == ' ' || row[i] == '\t') {
+		i++
+	}
+	return i, true
+}
+
+// trimTrailingHashRun strips a trailing `#` run preceded by whitespace
+// — the optional ATX closing markers. A `#` run with no preceding
+// whitespace is part of the heading text (e.g. `# foo#bar`).
+func trimTrailingHashRun(row []byte, start, end int) int {
+	if end <= start || row[end-1] != '#' {
+		return end
+	}
+	k := end
+	for k > start && row[k-1] == '#' {
+		k--
+	}
+	if k <= start || (row[k-1] != ' ' && row[k-1] != '\t') {
+		return end
+	}
+	return trimRightSpace(row, start, k-1)
+}
+
+// skipLeadingSpaces advances past up to max leading space bytes.
+func skipLeadingSpaces(row []byte, max int) int {
+	i := 0
+	for i < len(row) && i < max && row[i] == ' ' {
+		i++
+	}
+	return i
+}
+
+// trimRightSpace returns end shrunk past trailing space/tab bytes in
+// row[start:end].
+func trimRightSpace(row []byte, start, end int) int {
+	for end > start && (row[end-1] == ' ' || row[end-1] == '\t') {
+		end--
+	}
+	return end
+}
+
+// trimmedRange returns the byte offsets of row stripped of leading and
+// trailing horizontal whitespace.
+func trimmedRange(row []byte) (int, int) {
+	start, end := 0, len(row)
+	for start < end && (row[start] == ' ' || row[start] == '\t') {
+		start++
+	}
+	for end > start && (row[end-1] == ' ' || row[end-1] == '\t') {
+		end--
+	}
+	return start, end
+}
+
+// appendAnchorEditsForHeading records one Edit per workspace anchor
+// link pointing at (headingFile, oldSlug). The new slug is
+// substituted into each link destination's fragment; the path
+// component is left unchanged so relative includes keep their source
+// form.
+func appendAnchorEditsForHeading(
+	changes map[string][]Edit, ws Workspace,
+	headingFile, oldSlug, newSlug string,
+) {
+	for _, e := range ws.IncomingAnchorEdges(headingFile, oldSlug) {
+		key, edit, ok := anchorEditForEdge(ws, e, oldSlug, newSlug)
+		if !ok {
+			continue
+		}
+		changes[key] = append(changes[key], edit)
+	}
+}
+
+// anchorEditForEdge converts one incoming-edge record into a concrete
+// Edit. Returns false when the source file isn't readable (out of
+// workspace, deleted) or the edge's link can't be located — the
+// rename skips those rather than failing the whole request, since the
+// alternative would block a heading rename over an unrelated stale
+// edge.
+func anchorEditForEdge(ws Workspace, e index.Edge, oldSlug, newSlug string) (string, Edit, bool) {
+	key, source, ok := ws.Resolve(e.SourceFile)
+	if !ok {
+		return "", Edit{}, false
+	}
+	lines := splitLines(source)
+	// The index can hold stale entries after a closed-buffer edit or
+	// an unprocessed watcher event. Indexing past EOF would panic.
+	if e.SourceLine < 1 || e.SourceLine > len(lines) {
+		return "", Edit{}, false
+	}
+	row := lines[e.SourceLine-1]
+	startByte, endByte, ok := anchorFragmentBytes(row, e.SourceCol-1, oldSlug)
+	if !ok {
+		return "", Edit{}, false
+	}
+	startCh := utf16FromByteOffset(row, startByte)
+	endCh := utf16FromByteOffset(row, endByte)
+	return key, Edit{
+		Range: Range{
+			Start: Position{Line: e.SourceLine - 1, Character: startCh},
+			End:   Position{Line: e.SourceLine - 1, Character: endCh},
+		},
+		NewText: newSlug,
+	}, true
+}
+
+// anchorFragmentBytes locates the byte range of the fragment slug
+// inside a link destination on row, starting from the link's
+// text-start column. Returns the raw fragment range (excluding the
+// leading `#`).
+//
+// The match is normalized: the raw fragment is URL-unescaped and run
+// through mdtext.Slugify, mirroring how the index keys incoming
+// edges, so `(#Setup)` and `(#Docs%20API)` both participate in a
+// rename even though their literal bytes differ from `setup` /
+// `docs-api`.
+func anchorFragmentBytes(row []byte, textStart int, oldSlug string) (int, int, bool) {
+	bracketStart := textStart
+	if bracketStart < 0 {
+		bracketStart = 0
+	}
+	if bracketStart >= len(row) {
+		return 0, 0, false
+	}
+	open, closeIdx, ok := destBounds(row, bracketStart)
+	if !ok {
+		return 0, 0, false
+	}
+	hash := indexOfHash(row, open, closeIdx)
+	if hash < 0 {
+		return 0, 0, false
+	}
+	fragEnd := fragmentEnd(row, hash+1, closeIdx)
+	rawFrag := row[hash+1 : fragEnd]
+	if !fragmentMatchesSlug(rawFrag, oldSlug) {
+		return 0, 0, false
+	}
+	return hash + 1, fragEnd, true
+}
+
+// destBounds returns the byte offsets of the destination content —
+// the byte just after `(` and the byte at the matching `)` — for a
+// link starting at or after `from`. Nested parens are matched
+// depth-aware and backslash-escaped parens are literal, so
+// `[t](foo\(bar\)#sec)` resolves to the outer parens.
+func destBounds(row []byte, from int) (int, int, bool) {
+	open := -1
+	for i := from; i < len(row)-1; i++ {
+		// Skip backslash-escaped bytes so a literal `\]` in the text
+		// portion doesn't fool the `](` lookahead.
+		if row[i] == '\\' && i+1 < len(row) {
+			i++
+			continue
+		}
+		if row[i] == ']' && row[i+1] == '(' {
+			open = i + 2
+			break
+		}
+	}
+	if open < 0 {
+		return 0, 0, false
+	}
+	closeIdx := -1
+	depth := 1
+	for j := open; j < len(row) && closeIdx < 0; j++ {
+		if isBackslashEscaped(row, j) {
+			continue
+		}
+		switch row[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				closeIdx = j
+			}
+		}
+	}
+	if closeIdx < 0 {
+		return 0, 0, false
+	}
+	return open, closeIdx, true
+}
+
+// isBackslashEscaped reports whether row[i] is preceded by an odd
+// number of backslashes — the CommonMark escape signal.
+func isBackslashEscaped(row []byte, i int) bool {
+	n := 0
+	for k := i - 1; k >= 0 && row[k] == '\\'; k-- {
+		n++
+	}
+	return n%2 == 1
+}
+
+// indexOfHash returns the offset of the first `#` in row[open:close],
+// or -1 when the destination has no fragment.
+func indexOfHash(row []byte, open, closeIdx int) int {
+	for i := open; i < closeIdx; i++ {
+		if row[i] == '#' {
+			return i
+		}
+	}
+	return -1
+}
+
+// fragmentEnd returns the byte offset where a fragment ends within
+// row[start:close]. Inline-link destinations carry no query strings,
+// so the fragment runs to the first whitespace, the first `>`
+// (angle-bracketed `<url>` form), or to close. Without the `>` guard,
+// `[t](<#sec>)` would slugify `sec>` and overwrite the closing
+// bracket.
+func fragmentEnd(row []byte, start, closeIdx int) int {
+	for i := start; i < closeIdx; i++ {
+		if row[i] == ' ' || row[i] == '\t' || row[i] == '>' {
+			return i
+		}
+	}
+	return closeIdx
+}
+
+// fragmentMatchesSlug reports whether the raw fragment bytes slugify
+// to oldSlug. URL-unescape mirrors the index's decodeAnchor so `%20`
+// decodes the same way before the slug pass.
+func fragmentMatchesSlug(rawFrag []byte, oldSlug string) bool {
+	decoded, err := url.PathUnescape(string(rawFrag))
+	if err != nil {
+		decoded = string(rawFrag)
+	}
+	return mdtext.Slugify(decoded) == oldSlug
+}
+
+// appendRefDefDestEditsForHeading rewrites `[label]: url` definitions
+// whose destination points at the renamed heading. The index treats
+// ref-defs as symbols, not edges, so the anchor-edge pass skips them;
+// without this companion pass a heading rename would strand def lines
+// like `[setup]: ./a.md#setup` on the old slug while every
+// `[t][setup]` use still resolved through the def to a stale anchor.
+//
+// It walks every workspace file, reads each through ws.Resolve so
+// unsaved buffers win over disk, and emits one edit per def whose
+// destination fragment slugifies to oldSlug AND whose path resolves
+// to headingFile (or is the same file when the def is anchor-only).
+func appendRefDefDestEditsForHeading(
+	changes map[string][]Edit, ws Workspace,
+	headingFile, oldSlug, newSlug string,
+) {
+	headingFile = index.NormalizePath(headingFile)
+	for _, rel := range ws.Files() {
+		key, source, ok := ws.Resolve(rel)
+		if !ok {
+			continue
+		}
+		body, fmOffset := bodyAndFMOffset(source)
+		fileLines := splitLines(source)
+		// Route through validRefDefMatches so `[label]:` lines
+		// goldmark refused (code blocks, paragraph continuations)
+		// aren't rewritten as if they were real defs.
+		for _, m := range validRefDefMatches(body) {
+			edit, ok := refDefDestEditForMatch(
+				body, fileLines, fmOffset, m.matchIdx,
+				rel, headingFile, oldSlug, newSlug,
+			)
+			if !ok {
+				continue
+			}
+			changes[key] = append(changes[key], edit)
+		}
+	}
+}
+
+// refDefDestEditForMatch turns one regex match for a `[label]: url`
+// line into an Edit on the URL's slug portion, or ok=false when the
+// destination doesn't point at the renamed heading.
+func refDefDestEditForMatch(
+	body []byte, fileLines [][]byte, fmOffset int, m []int,
+	defFile, headingFile, oldSlug, newSlug string,
+) (Edit, bool) {
+	bodyLine := lineOfBodyOffset(body, m[2])
+	fileLine := bodyLine + fmOffset
+	if fileLine-1 >= len(fileLines) {
+		return Edit{}, false
+	}
+	row := fileLines[fileLine-1]
+	colonOff := refDefColonOffset(row)
+	if colonOff < 0 {
+		return Edit{}, false
+	}
+	destStart, destEnd := refDefDestRange(row, colonOff+1)
+	if destStart >= destEnd {
+		return Edit{}, false
+	}
+	dest := row[destStart:destEnd]
+	if !refDefDestPointsAt(dest, defFile, headingFile, oldSlug) {
+		return Edit{}, false
+	}
+	// refDefDestPointsAt already confirmed dest contains `#oldSlug`
+	// (oldSlug is non-empty on this path), so `#` always exists.
+	hashIdx := destStart
+	for hashIdx < destEnd && row[hashIdx] != '#' {
+		hashIdx++
+	}
+	fragEnd := fragmentEnd(row, hashIdx+1, destEnd)
+	startCh := utf16FromByteOffset(row, hashIdx+1)
+	endCh := utf16FromByteOffset(row, fragEnd)
+	return Edit{
+		Range: Range{
+			Start: Position{Line: fileLine - 1, Character: startCh},
+			End:   Position{Line: fileLine - 1, Character: endCh},
+		},
+		NewText: newSlug,
+	}, true
+}
+
+// refDefColonOffset returns the byte offset of the `:` that follows
+// `[label]` in a ref-def line, or -1 when the shape doesn't match:
+// ≤3 leading spaces, then `[label]:` where label has no `]`.
+func refDefColonOffset(row []byte) int {
+	i := 0
+	for i < len(row) && i < 3 && row[i] == ' ' {
+		i++
+	}
+	if i >= len(row) || row[i] != '[' {
+		return -1
+	}
+	closeIdx := -1
+	for j := i + 1; j < len(row); j++ {
+		if row[j] == ']' {
+			closeIdx = j
+			break
+		}
+	}
+	if closeIdx < 0 || closeIdx+1 >= len(row) || row[closeIdx+1] != ':' {
+		return -1
+	}
+	return closeIdx + 1
+}
+
+// refDefDestRange returns the byte range of the destination URL
+// portion of a ref-def line, given the offset just past the `:`.
+// Skips leading whitespace, then handles both forms:
+//
+//   - Angle-bracketed `[label]: <url>`: the range covers the bytes
+//     inside the angle brackets, so a slug edit leaves `<` / `>`
+//     intact.
+//   - Bare `[label]: url`: from the first non-whitespace byte to the
+//     next whitespace.
+//
+// Quoted titles after the URL are excluded either way.
+func refDefDestRange(row []byte, from int) (int, int) {
+	i := from
+	for i < len(row) && (row[i] == ' ' || row[i] == '\t') {
+		i++
+	}
+	if i < len(row) && row[i] == '<' {
+		open := i + 1
+		for j := open; j < len(row); j++ {
+			if row[j] == '\\' && j+1 < len(row) {
+				j++
+				continue
+			}
+			if row[j] == '>' {
+				return open, j
+			}
+		}
+		// Unterminated `<…` — fall through to the bare reader from
+		// the original `<` position so a malformed line doesn't
+		// masquerade as an angle-bracketed dest.
+	}
+	start := i
+	for i < len(row) && row[i] != ' ' && row[i] != '\t' {
+		i++
+	}
+	return start, i
+}
+
+// refDefDestPointsAt reports whether dest (the URL portion of a
+// ref-def in defFile) resolves to (headingFile, oldSlug). It mirrors
+// the index's edge collector: percent-decode the fragment, slugify,
+// compare to oldSlug; resolve the path against defFile's directory
+// and compare to headingFile.
+func refDefDestPointsAt(dest []byte, defFile, headingFile, oldSlug string) bool {
+	t, ok := refDefParseTarget(string(dest))
+	if !ok {
+		return false
+	}
+	// url.Parse already decoded t.fragment, but re-running
+	// PathUnescape mirrors the index's decodeAnchor so corner-case
+	// escapes can't drift. The error is impossible here: url.Parse
+	// would have rejected a malformed `%xx`.
+	decoded, _ := url.PathUnescape(t.fragment)
+	if mdtext.Slugify(decoded) != oldSlug {
+		return false
+	}
+	if t.localAnchor {
+		return index.NormalizePath(defFile) == headingFile
+	}
+	resolved := linkgraph.ResolveRelTarget(defFile, t.path)
+	return resolved == headingFile
+}
+
+// refDefDestTarget is the parsed shape of a ref-def URL. Kept private
+// — the index has its own linkTarget helper and leaking two slightly
+// different parsers through one type would invite drift.
+type refDefDestTarget struct {
+	path        string
+	fragment    string
+	localAnchor bool
+}
+
+func refDefParseTarget(dest string) (refDefDestTarget, bool) {
+	dest = strings.TrimSpace(dest)
+	if dest == "" || strings.HasPrefix(dest, "//") {
+		return refDefDestTarget{}, false
+	}
+	u, err := url.Parse(dest)
+	if err != nil {
+		return refDefDestTarget{}, false
+	}
+	if u.Scheme != "" || u.Host != "" {
+		return refDefDestTarget{}, false
+	}
+	if u.Path == "" && u.Fragment != "" {
+		return refDefDestTarget{fragment: u.Fragment, localAnchor: true}, true
+	}
+	if u.Path == "" {
+		return refDefDestTarget{}, false
+	}
+	return refDefDestTarget{path: u.Path, fragment: u.Fragment}, true
+}
+
+// stableSortEdits sorts each key's Edit slice in reverse document
+// order so a consumer applying edits sequentially ends up with the
+// right buffer state: earlier (later-positioned) edits don't shift
+// the offsets the next edit relies on, particularly when two edits
+// share a line.
+func stableSortEdits(changes map[string][]Edit) {
+	for key, edits := range changes {
+		sort.SliceStable(edits, func(i, j int) bool {
+			a, b := edits[i].Range.Start, edits[j].Range.Start
+			if a.Line != b.Line {
+				return a.Line > b.Line
+			}
+			return a.Character > b.Character
+		})
+		changes[key] = edits
+	}
+}

--- a/internal/rename/heading.go
+++ b/internal/rename/heading.go
@@ -119,6 +119,31 @@ func Heading(
 	return changes, nil
 }
 
+// FindHeadingLine returns the 1-based source line of the first
+// heading whose visible text equals headingText, or ok=false when no
+// heading matches. The CLI uses it to turn `--heading "Old"` into the
+// line coordinate the rename engine expects; it parses the same way
+// the engine does so the line it finds is the line Heading rewrites.
+func FindHeadingLine(source []byte, headingText string) (int, bool) {
+	body, fmOffset := bodyAndFMOffset(source)
+	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
+	for _, h := range walkAllHeadings(root, body) {
+		if h.text == headingText {
+			return h.bodyLine + fmOffset, true
+		}
+	}
+	return 0, false
+}
+
+// NormalizeLabel collapses a link-reference label to its canonical
+// matching form (lowercased, whitespace-collapsed), the same
+// normalization LinkRef expects its oldLabel argument in. The CLI
+// normalizes `--link-ref oldlabel` through this before calling
+// LinkRef.
+func NormalizeLabel(s string) string {
+	return normalizedLabel([]byte(s))
+}
+
 // firstControlRune returns the first newline / carriage return in s,
 // or 0 when s is a single line. Heading text and link-ref labels are
 // single-line surfaces; a control rune would rewrite them into

--- a/internal/rename/heading_test.go
+++ b/internal/rename/heading_test.go
@@ -208,6 +208,21 @@ func TestHeading_RefDefInCodeBlockNotRewritten(t *testing.T) {
 
 // --- direct helper coverage for branches Heading can't easily drive --
 
+func TestFindHeadingLine(t *testing.T) {
+	src := []byte("---\ntitle: x\n---\n# Intro\n\n## Setup\n")
+	line, ok := FindHeadingLine(src, "Setup")
+	require.True(t, ok)
+	assert.Equal(t, 6, line) // 3 front-matter lines + body line 3
+
+	_, ok = FindHeadingLine(src, "Missing")
+	assert.False(t, ok)
+}
+
+func TestNormalizeLabel(t *testing.T) {
+	assert.Equal(t, "docs api", NormalizeLabel("Docs  API"))
+	assert.Equal(t, "x", NormalizeLabel("X"))
+}
+
 func TestFirstControlRune(t *testing.T) {
 	assert.Equal(t, '\r', firstControlRune("a\rb"))
 	assert.Equal(t, rune(0), firstControlRune("clean"))

--- a/internal/rename/heading_test.go
+++ b/internal/rename/heading_test.go
@@ -1,0 +1,585 @@
+package rename
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/index"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// memWorkspace is a concrete Workspace backed by a real index over an
+// in-memory file set. It is not a mock — the edge graph is the
+// production index.New + BuildSerial, the same path the LSP server and
+// the CLI use; only the byte source is a map instead of disk.
+type memWorkspace struct {
+	idx   *index.Index
+	files map[string][]byte
+}
+
+func newMemWorkspace(files map[string]string) *memWorkspace {
+	bytesMap := make(map[string][]byte, len(files))
+	rels := make([]string, 0, len(files))
+	for rel, body := range files {
+		n := index.NormalizePath(rel)
+		bytesMap[n] = []byte(body)
+		rels = append(rels, n)
+	}
+	idx := index.New(".")
+	idx.BuildSerial(rels, func(rel string) ([]byte, error) {
+		return bytesMap[rel], nil
+	})
+	return &memWorkspace{idx: idx, files: bytesMap}
+}
+
+func (w *memWorkspace) IncomingAnchorEdges(file, slug string) []index.Edge {
+	return w.idx.IncomingEdges(file, slug)
+}
+
+func (w *memWorkspace) Files() []string { return w.idx.Files() }
+
+func (w *memWorkspace) Resolve(file string) (string, []byte, bool) {
+	n := index.NormalizePath(file)
+	b, ok := w.files[n]
+	return n, b, ok
+}
+
+func TestHeading_RewritesCrossFileAnchorsAndRefDef(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n\nBody.\n\n## Config\n\ntext\n",
+		"b.md": "See [setup](a.md#setup) and [cfg](a.md#config).\n\n[ref]: a.md#setup\n",
+	})
+	src := ws.files["a.md"]
+	changes, err := Heading(ws, "a.md", "a.md", src, 1, "Setup", "Install")
+	require.NoError(t, err)
+
+	// a.md: just the heading-text edit.
+	aEdits := changes["a.md"]
+	require.Len(t, aEdits, 1)
+	assert.Equal(t, "Install", aEdits[0].NewText)
+	assert.Equal(t, 0, aEdits[0].Range.Start.Line)
+
+	// b.md: the anchor link fragment + the ref-def destination, both
+	// rewritten setup → install.
+	bEdits := changes["b.md"]
+	require.Len(t, bEdits, 2)
+	for _, e := range bEdits {
+		assert.Equal(t, "install", e.NewText)
+	}
+}
+
+func TestHeading_SameFileAnchorSharesKey(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Top\n\nJump to [here](#top).\n",
+	})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Top", "Start")
+	require.NoError(t, err)
+	// Heading edit + same-file anchor edit both land under "a.md".
+	require.Len(t, changes, 1)
+	require.Len(t, changes["a.md"], 2)
+}
+
+func TestHeading_NoOpWhenUnchanged(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{"a.md": "# Title\n"})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Title", "  Title  ")
+	require.NoError(t, err)
+	assert.Empty(t, changes)
+	assert.NotNil(t, changes)
+}
+
+func TestHeading_ControlRuneRejected(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{"a.md": "# Title\n"})
+	_, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Title", "two\nlines")
+	var ire InvalidHeadingRuneError
+	require.True(t, errors.As(err, &ire))
+	assert.Equal(t, '\n', ire.Rune)
+	assert.Equal(t, `heading text cannot contain '\n'`, ire.Error())
+}
+
+func TestHeading_EmptySlugRejected(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{"a.md": "# Title\n"})
+	_, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Title", "...")
+	assert.ErrorIs(t, err, ErrEmptyHeadingSlug)
+}
+
+func TestHeading_CollisionNamesConflict(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Alpha\n\n## Beta\n",
+	})
+	_, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Alpha", "Beta")
+	var hce HeadingCollisionError
+	require.True(t, errors.As(err, &hce))
+	assert.Equal(t, "Beta", hce.Conflict)
+	assert.Equal(t, "rename would collide with heading Beta", hce.Error())
+}
+
+func TestHeading_SameBaseSlugRefreshAllowed(t *testing.T) {
+	// "Title" → "title" keeps the same bare slug; the collision check
+	// is skipped and the heading edit still emits.
+	ws := newMemWorkspace(map[string]string{"a.md": "# Title\n"})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Title", "title")
+	require.NoError(t, err)
+	require.Len(t, changes["a.md"], 1)
+}
+
+func TestHeading_SetextHeadingLine(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{"a.md": "Title\n=====\n"})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Title", "Renamed")
+	require.NoError(t, err)
+	require.Len(t, changes["a.md"], 1)
+	assert.Equal(t, "Renamed", changes["a.md"][0].NewText)
+}
+
+func TestHeading_TargetLineNotAHeading(t *testing.T) {
+	// computeSlugRemap returns no remap when the line isn't a heading;
+	// only the (degenerate) heading-line edit is produced.
+	ws := newMemWorkspace(map[string]string{"a.md": "# Real\n\nprose\n"})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 3, "prose", "other")
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+}
+
+func TestHeading_DisambiguatorShift(t *testing.T) {
+	// Two "Dup" headings; renaming the first away frees the bare slug
+	// so the second's `dup-2` collapses to `dup`. An incoming link to
+	// `dup-2` is rewritten to `dup`.
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Dup\n\n## Dup\n",
+		"b.md": "[x](a.md#dup-1)\n",
+	})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Dup", "Unique")
+	require.NoError(t, err)
+	require.Len(t, changes["b.md"], 1)
+	assert.Equal(t, "dup", changes["b.md"][0].NewText)
+}
+
+func TestHeading_StaleEdgeSkipped(t *testing.T) {
+	// An incoming edge whose source file the workspace can't resolve
+	// is skipped rather than failing the whole rename.
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n",
+		"b.md": "[x](a.md#setup)\n",
+	})
+	delete(ws.files, "b.md") // edge survives in idx; bytes vanish
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Setup", "Install")
+	require.NoError(t, err)
+	require.Len(t, changes["a.md"], 1)
+	assert.Empty(t, changes["b.md"])
+}
+
+func TestHeading_AngleBracketRefDefDestination(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n",
+		"b.md": "[ref]: <a.md#setup>\n",
+	})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Setup", "Install")
+	require.NoError(t, err)
+	require.Len(t, changes["b.md"], 1)
+	e := changes["b.md"][0]
+	assert.Equal(t, "install", e.NewText)
+	// The edit stays inside the angle brackets.
+	assert.Equal(t, e.Range.Start.Line, e.Range.End.Line)
+}
+
+func TestHeading_LocalAnchorRefDefDestination(t *testing.T) {
+	// `[ref]: #setup` is an anchor-only def in the heading's own file.
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n\n[ref]: #setup\n",
+	})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Setup", "Install")
+	require.NoError(t, err)
+	// Heading line + the local ref-def destination.
+	require.Len(t, changes["a.md"], 2)
+}
+
+func TestHeading_RefDefInCodeBlockNotRewritten(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n",
+		"b.md": "```\n[ref]: a.md#setup\n```\n",
+	})
+	changes, err := Heading(ws, "a.md", "a.md", ws.files["a.md"], 1, "Setup", "Install")
+	require.NoError(t, err)
+	assert.Empty(t, changes["b.md"])
+}
+
+// --- direct helper coverage for branches Heading can't easily drive --
+
+func TestFirstControlRune(t *testing.T) {
+	assert.Equal(t, '\r', firstControlRune("a\rb"))
+	assert.Equal(t, rune(0), firstControlRune("clean"))
+}
+
+func TestHeadingTextEdit_OutOfRange(t *testing.T) {
+	_, ok := headingTextEdit([]byte("# H\n"), 9, "X")
+	assert.False(t, ok)
+}
+
+func TestAtxHeadingTextByteRange(t *testing.T) {
+	t.Run("trailing hash run", func(t *testing.T) {
+		s, e, ok := atxHeadingTextByteRange([]byte("## Title ##"))
+		require.True(t, ok)
+		assert.Equal(t, "Title", string([]byte("## Title ##")[s:e]))
+	})
+	t.Run("not atx", func(t *testing.T) {
+		_, _, ok := atxHeadingTextByteRange([]byte("plain text"))
+		assert.False(t, ok)
+	})
+	t.Run("empty heading", func(t *testing.T) {
+		s, e, ok := atxHeadingTextByteRange([]byte("### "))
+		require.True(t, ok)
+		assert.Equal(t, s, e)
+	})
+	t.Run("hash#text not closing", func(t *testing.T) {
+		s, e, ok := atxHeadingTextByteRange([]byte("# foo#bar"))
+		require.True(t, ok)
+		assert.Equal(t, "foo#bar", string([]byte("# foo#bar")[s:e]))
+	})
+}
+
+func TestAtxHeadingTextStart(t *testing.T) {
+	_, ok := atxHeadingTextStart([]byte("    # x")) // >3 leading spaces
+	assert.False(t, ok)
+	_, ok = atxHeadingTextStart([]byte("####### x")) // level 7
+	assert.False(t, ok)
+	_, ok = atxHeadingTextStart([]byte("##foo")) // no space after markers
+	assert.False(t, ok)
+	i, ok := atxHeadingTextStart([]byte("#\tx")) // tab separator
+	require.True(t, ok)
+	assert.Equal(t, 2, i)
+	_, ok = atxHeadingTextStart([]byte("no hash"))
+	assert.False(t, ok)
+}
+
+func TestTrimTrailingHashRun(t *testing.T) {
+	assert.Equal(t, 0, trimTrailingHashRun([]byte(""), 0, 0)) // end<=start
+	row := []byte("# abc")
+	assert.Equal(t, 5, trimTrailingHashRun(row, 2, 5)) // no trailing #
+	row = []byte("# a#")
+	assert.Equal(t, 4, trimTrailingHashRun(row, 2, 4)) // # not preceded by space
+	row = []byte("#  ###")
+	assert.Equal(t, 1, trimTrailingHashRun(row, 1, 6)) // k<=start after run
+}
+
+func TestTrimmedRange(t *testing.T) {
+	s, e := trimmedRange([]byte("  hi  "))
+	assert.Equal(t, "hi", string([]byte("  hi  ")[s:e]))
+}
+
+func TestSlugRemapPairs(t *testing.T) {
+	got := slugRemapPairs(
+		[]string{"a", "", "b", "b"},
+		[]string{"a", "x", "c", "z"},
+	)
+	// "a"→"a" unchanged skipped; ""→"x" skipped; "b" first-wins → "c".
+	assert.Equal(t, map[string]string{"b": "c"}, got)
+}
+
+func TestAssignSlugs(t *testing.T) {
+	got := assignSlugs([]string{"Dup", "...", "Dup", "Dup"})
+	assert.Equal(t, []string{"dup", "", "dup-1", "dup-2"}, got)
+}
+
+func TestDestBounds(t *testing.T) {
+	t.Run("escaped parens", func(t *testing.T) {
+		row := []byte(`[t](foo\(bar\)#sec)`)
+		o, c, ok := destBounds(row, 0)
+		require.True(t, ok)
+		assert.Equal(t, `foo\(bar\)#sec`, string(row[o:c]))
+	})
+	t.Run("no destination", func(t *testing.T) {
+		_, _, ok := destBounds([]byte("[t] no paren"), 0)
+		assert.False(t, ok)
+	})
+	t.Run("unclosed", func(t *testing.T) {
+		_, _, ok := destBounds([]byte("[t](unclosed"), 0)
+		assert.False(t, ok)
+	})
+	t.Run("escaped bracket in text", func(t *testing.T) {
+		row := []byte(`[a\]b](u#s)`)
+		o, c, ok := destBounds(row, 0)
+		require.True(t, ok)
+		assert.Equal(t, "u#s", string(row[o:c]))
+	})
+}
+
+func TestIsBackslashEscaped(t *testing.T) {
+	row := []byte(`a\)b`)
+	assert.True(t, isBackslashEscaped(row, 2))
+	row = []byte(`a\\)b`)
+	assert.False(t, isBackslashEscaped(row, 3))
+}
+
+func TestIndexOfHash(t *testing.T) {
+	assert.Equal(t, 3, indexOfHash([]byte("abc#frag"), 0, 8))
+	assert.Equal(t, -1, indexOfHash([]byte("nohash"), 0, 6))
+}
+
+func TestFragmentEnd(t *testing.T) {
+	row := []byte("abc#frag>x")
+	assert.Equal(t, 8, fragmentEnd(row, 4, len(row)))     // stops at '>'
+	assert.Equal(t, 2, fragmentEnd([]byte("ab x"), 0, 4)) // stops at space
+	assert.Equal(t, 3, fragmentEnd([]byte("abc"), 0, 3))  // runs to close
+}
+
+func TestComputeSlugRemap(t *testing.T) {
+	old, neu, conflict := computeSlugRemap([]byte("# A\n\n## B\n"), 1, "C")
+	assert.Empty(t, conflict)
+	assert.Equal(t, []string{"a", "b"}, old)
+	assert.Equal(t, []string{"c", "b"}, neu)
+
+	_, _, conflict = computeSlugRemap([]byte("# A\n\n## B\n"), 1, "B")
+	assert.Equal(t, "B", conflict)
+
+	old, neu, conflict = computeSlugRemap([]byte("# A\n"), 99, "X")
+	assert.Nil(t, old)
+	assert.Nil(t, neu)
+	assert.Empty(t, conflict)
+}
+
+func TestWalkAllHeadings(t *testing.T) {
+	body := []byte("# A\n\nprose\n\n## B\n")
+	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
+	hs := walkAllHeadings(root, body)
+	require.Len(t, hs, 2)
+	assert.Equal(t, "A", hs[0].text)
+	assert.Equal(t, "B", hs[1].text)
+}
+
+func TestSlicesOfText(t *testing.T) {
+	got := slicesOfText([]headingWalk{{text: "x"}, {text: "y"}})
+	assert.Equal(t, []string{"x", "y"}, got)
+}
+
+func TestSkipLeadingSpaces(t *testing.T) {
+	assert.Equal(t, 2, skipLeadingSpaces([]byte("  x"), 3))
+	assert.Equal(t, 3, skipLeadingSpaces([]byte("     x"), 3)) // capped at max
+	assert.Equal(t, 0, skipLeadingSpaces([]byte("x"), 3))
+}
+
+func TestTrimRightSpace(t *testing.T) {
+	row := []byte("ab \t ")
+	assert.Equal(t, 2, trimRightSpace(row, 0, len(row)))
+	assert.Equal(t, 0, trimRightSpace([]byte("   "), 0, 3))
+}
+
+func TestInvalidHeadingRuneError_Error(t *testing.T) {
+	assert.Equal(t, `heading text cannot contain '\n'`,
+		InvalidHeadingRuneError{Rune: '\n'}.Error())
+}
+
+func TestHeadingCollisionError_Error(t *testing.T) {
+	assert.Equal(t, "rename would collide with heading Intro",
+		HeadingCollisionError{Conflict: "Intro"}.Error())
+}
+
+func TestAppendAnchorEditsForHeading(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n",
+		"b.md": "[x](a.md#setup)\n",
+	})
+	changes := map[string][]Edit{}
+	appendAnchorEditsForHeading(changes, ws, "a.md", "setup", "install")
+	require.Len(t, changes["b.md"], 1)
+	assert.Equal(t, "install", changes["b.md"][0].NewText)
+
+	// An edge whose source can't be resolved is skipped.
+	delete(ws.files, "b.md")
+	changes = map[string][]Edit{}
+	appendAnchorEditsForHeading(changes, ws, "a.md", "setup", "install")
+	assert.Empty(t, changes)
+}
+
+func TestFragmentMatchesSlug(t *testing.T) {
+	assert.True(t, fragmentMatchesSlug([]byte("Docs%20API"), "docs-api"))
+	assert.True(t, fragmentMatchesSlug([]byte("bad%zz"), "badzz")) // invalid escape → raw
+	assert.False(t, fragmentMatchesSlug([]byte("other"), "setup"))
+}
+
+func TestAnchorFragmentBytes(t *testing.T) {
+	t.Run("negative textStart clamps", func(t *testing.T) {
+		row := []byte("[t](#setup)")
+		s, e, ok := anchorFragmentBytes(row, -5, "setup")
+		require.True(t, ok)
+		assert.Equal(t, "setup", string(row[s:e]))
+	})
+	t.Run("textStart past row", func(t *testing.T) {
+		_, _, ok := anchorFragmentBytes([]byte("[t](#s)"), 99, "s")
+		assert.False(t, ok)
+	})
+	t.Run("no hash", func(t *testing.T) {
+		_, _, ok := anchorFragmentBytes([]byte("[t](file.md)"), 0, "x")
+		assert.False(t, ok)
+	})
+	t.Run("slug mismatch", func(t *testing.T) {
+		_, _, ok := anchorFragmentBytes([]byte("[t](#other)"), 0, "setup")
+		assert.False(t, ok)
+	})
+}
+
+func TestRefDefColonOffset(t *testing.T) {
+	assert.Equal(t, 4, refDefColonOffset([]byte("[ab]: u")))
+	assert.Equal(t, 6, refDefColonOffset([]byte("  [ab]: u"))) // ≤3 leading spaces
+	assert.Equal(t, -1, refDefColonOffset([]byte("no bracket")))
+	assert.Equal(t, -1, refDefColonOffset([]byte("[ab no close")))
+	assert.Equal(t, -1, refDefColonOffset([]byte("[ab] no colon")))
+	assert.Equal(t, -1, refDefColonOffset([]byte("[ab]"))) // `]` is last byte
+}
+
+func TestAnchorEditForEdge_SkipPaths(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{"b.md": "[x](a.md#setup)\n"})
+	// Source file the workspace can't resolve.
+	_, _, ok := anchorEditForEdge(ws, index.Edge{SourceFile: "gone.md", SourceLine: 1, SourceCol: 1}, "setup", "x")
+	assert.False(t, ok)
+	// SourceLine past EOF.
+	_, _, ok = anchorEditForEdge(ws, index.Edge{SourceFile: "b.md", SourceLine: 99, SourceCol: 1}, "setup", "x")
+	assert.False(t, ok)
+	// Fragment can't be located on the line.
+	ws2 := newMemWorkspace(map[string]string{"b.md": "no link here\n"})
+	_, _, ok = anchorEditForEdge(ws2, index.Edge{SourceFile: "b.md", SourceLine: 1, SourceCol: 1}, "setup", "x")
+	assert.False(t, ok)
+}
+
+func TestAnchorFragmentBytes_NoDestination(t *testing.T) {
+	_, _, ok := anchorFragmentBytes([]byte("plain text no link"), 0, "x")
+	assert.False(t, ok)
+}
+
+func TestDestBounds_NestedUnescapedParens(t *testing.T) {
+	row := []byte("[t](a(b)#s)")
+	o, c, ok := destBounds(row, 0)
+	require.True(t, ok)
+	assert.Equal(t, "a(b)#s", string(row[o:c]))
+}
+
+func TestAppendRefDefDestEditsForHeading_SkipsUnresolvable(t *testing.T) {
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n",
+		"b.md": "[ref]: a.md#setup\n",
+	})
+	delete(ws.files, "b.md") // still in idx.Files(), bytes gone
+	changes := map[string][]Edit{}
+	appendRefDefDestEditsForHeading(changes, ws, "a.md", "setup", "install")
+	assert.Empty(t, changes)
+}
+
+func TestRefDefDestEditForMatch_ColonAndEmptyDest(t *testing.T) {
+	// m is only read as m[2] (a body offset → line). A zero offset
+	// maps to the single fixture line, isolating the colon / empty-
+	// destination guards from regex-shape concerns.
+	m := []int{0, 0, 0, 0}
+
+	// No `[label]:` colon on the line.
+	_, ok := refDefDestEditForMatch(
+		[]byte("plain text"), [][]byte{[]byte("plain text")},
+		0, m, "b.md", "a.md", "setup", "x")
+	assert.False(t, ok)
+
+	// Colon present but nothing after it — empty destination.
+	_, ok = refDefDestEditForMatch(
+		[]byte("[a]:"), [][]byte{[]byte("[a]:")},
+		0, m, "b.md", "a.md", "setup", "x")
+	assert.False(t, ok)
+}
+
+func TestAppendRefDefDestEditsForHeading_NonMatchingDefSkipped(t *testing.T) {
+	// b.md has a real ref-def, but its destination points at a
+	// different anchor, so refDefDestEditForMatch returns false and
+	// the inner skip fires.
+	ws := newMemWorkspace(map[string]string{
+		"a.md": "# Setup\n",
+		"b.md": "[ref]: a.md#other\n",
+	})
+	changes := map[string][]Edit{}
+	appendRefDefDestEditsForHeading(changes, ws, "a.md", "setup", "install")
+	assert.Empty(t, changes)
+}
+
+func TestRefDefDestRange(t *testing.T) {
+	t.Run("bare", func(t *testing.T) {
+		row := []byte(`[a]: url "title"`)
+		s, e := refDefDestRange(row, 4)
+		assert.Equal(t, "url", string(row[s:e]))
+	})
+	t.Run("angle bracket", func(t *testing.T) {
+		row := []byte(`[a]: <u#s>`)
+		s, e := refDefDestRange(row, 4)
+		assert.Equal(t, "u#s", string(row[s:e]))
+	})
+	t.Run("escaped inside angle", func(t *testing.T) {
+		row := []byte(`[a]: <u\>v>`)
+		s, e := refDefDestRange(row, 4)
+		assert.Equal(t, `u\>v`, string(row[s:e]))
+	})
+	t.Run("unterminated angle falls back to bare", func(t *testing.T) {
+		row := []byte(`[a]: <unterminated`)
+		s, e := refDefDestRange(row, 4)
+		assert.Equal(t, "<unterminated", string(row[s:e]))
+	})
+}
+
+func TestRefDefParseTarget(t *testing.T) {
+	_, ok := refDefParseTarget("")
+	assert.False(t, ok)
+	_, ok = refDefParseTarget("//proto-relative")
+	assert.False(t, ok)
+	_, ok = refDefParseTarget("ht\ttp://x\n")
+	assert.False(t, ok) // url.Parse error on control char
+	_, ok = refDefParseTarget("https://example.com")
+	assert.False(t, ok) // scheme/host set
+	tg, ok := refDefParseTarget("#frag")
+	require.True(t, ok)
+	assert.True(t, tg.localAnchor)
+	_, ok = refDefParseTarget("?onlyquery")
+	assert.False(t, ok) // empty path, no fragment
+	tg, ok = refDefParseTarget("a.md#s")
+	require.True(t, ok)
+	assert.Equal(t, "a.md", tg.path)
+}
+
+func TestRefDefDestPointsAt(t *testing.T) {
+	assert.False(t, refDefDestPointsAt([]byte("https://x"), "b.md", "a.md", "s"))
+	assert.False(t, refDefDestPointsAt([]byte("a.md#other"), "b.md", "a.md", "setup"))
+	assert.True(t, refDefDestPointsAt([]byte("#setup"), "a.md", "a.md", "setup"))
+	assert.False(t, refDefDestPointsAt([]byte("#setup"), "b.md", "a.md", "setup"))
+}
+
+func TestStableSortEdits(t *testing.T) {
+	changes := map[string][]Edit{
+		"f": {
+			{Range: Range{Start: Position{Line: 1, Character: 0}}},
+			{Range: Range{Start: Position{Line: 5, Character: 2}}},
+			{Range: Range{Start: Position{Line: 5, Character: 0}}},
+		},
+	}
+	stableSortEdits(changes)
+	got := changes["f"]
+	assert.Equal(t, 5, got[0].Range.Start.Line)
+	assert.Equal(t, 2, got[0].Range.Start.Character)
+	assert.Equal(t, 5, got[1].Range.Start.Line)
+	assert.Equal(t, 1, got[2].Range.Start.Line)
+}
+
+func TestRefDefDestEditForMatch_BadInputs(t *testing.T) {
+	body := []byte("[a]: a.md#setup\n")
+	lines := splitLines(body)
+	matches := index.RefDefRegexpMatches(body)
+	require.NotEmpty(t, matches)
+	m := matches[0]
+
+	// fileLine past the line table.
+	_, ok := refDefDestEditForMatch(body, [][]byte{}, 0, m, "b.md", "a.md", "setup", "x")
+	assert.False(t, ok)
+
+	// Destination doesn't point at the heading.
+	_, ok = refDefDestEditForMatch(body, lines, 0, m, "b.md", "z.md", "setup", "x")
+	assert.False(t, ok)
+
+	// Happy path.
+	e, ok := refDefDestEditForMatch(body, lines, 0, m, "b.md", "a.md", "setup", "install")
+	require.True(t, ok)
+	assert.Equal(t, "install", e.NewText)
+}

--- a/plan/174_expose-rename-and-deps-cli.md
+++ b/plan/174_expose-rename-and-deps-cli.md
@@ -146,9 +146,16 @@ over discovered files and queries `OutgoingEdges` /
    index + disk. Behavior-tested at **100%** statement
    coverage with a real index-backed workspace (no mocks);
    every production function has a dedicated unit test.
-5. [ ] Refactor `internal/lsp/rename.go` to delegate to
-   `internal/rename`; delete duplicated computation. Plans
-   151/131 + `cmd/mdsmith/lsp_rename_test.go` stay green.
+5. [x] Refactor `internal/lsp/rename.go` to delegate to
+   `internal/rename`; duplicated computation deleted.
+   `handleRename` resolves the cursor and calls
+   `rename.Heading` / `rename.LinkRef`; a thin adapter maps
+   the neutral `Edit` set to `workspaceEdit` and the typed
+   errors to `InvalidParams` + `renameCollisionData`. The
+   editor-only prepare-range / cursor-disambiguation code
+   stays; `isValidRefDefLine` now calls
+   `rename.ValidRefDefBodyLines`. Plans 151/131 +
+   `cmd/mdsmith/lsp_rename_test.go` stay green byte-for-byte.
 6. [ ] TDD `cmd/mdsmith/rename.go` (unit + e2e), register in
    `main.go` dispatch + `usageText`.
 7. [x] TDD `cmd/mdsmith/deps.go` (unit + e2e); register
@@ -175,7 +182,7 @@ over discovered files and queries `OutgoingEdges` /
 - [x] `internal/rename` returns plain edits and typed errors,
       imports neither `internal/lsp` nor any LSP wire type
       (DIP — surfaces depend on the core).
-- [ ] `internal/lsp/rename.go` contains no slug / edit
+- [x] `internal/lsp/rename.go` contains no slug / edit
       computation; it delegates to `internal/rename` (no
       duplicated logic across surfaces — `cross-system.md`).
 - [x] Plans 131/151 LSP test suites and
@@ -233,28 +240,30 @@ a path→bytes resolver. `rename.Heading` returns a
 per-key `Edit` set. An unsafe rename returns a typed
 error instead.
 
-The LSP package still carries its own copy. Slice B
-deletes that copy. Behavior tests cover same-file
-anchors, cross-file anchors, the disambiguator
-shift, and each guard at 100%, no mocks.
+Behavior tests cover same-file anchors, cross-file
+anchors, the disambiguator shift, and each guard at
+100%, no mocks.
 
-### Slice B — LSP delegates to the core
+### Slice B — LSP delegates to the core (done)
 
-- `handleRename` resolves the cursor (unchanged), then
-  calls `rename.Heading` / `rename.LinkRef`
-- map the `Edit` set → `workspaceEdit`; map typed
-  errors → `InvalidParams` + `renameCollisionData`
-- delete the now-duplicated engine from the LSP
-  package
-- keep the prepare-range / cursor-disambiguation code
-  (editor-only); `isValidRefDefLine` calls
-  `rename.ValidRefDefBodyLines`
-- regression gate, byte-for-byte: the plan-131/151
-  suites in [internal/lsp](../internal/lsp/) plus
-  [cmd/mdsmith/lsp_rename_test.go](../cmd/mdsmith/lsp_rename_test.go)
-- the neutral `Edit` is line + UTF-16 char, the same
-  shape as the LSP `textEdit`, so the adapter is a
-  field copy — the wire output cannot drift
+`handleRename` resolves the cursor. Then it calls
+`rename.Heading` or `rename.LinkRef`. A thin
+adapter maps the neutral `Edit` set to
+`workspaceEdit`. It maps the typed errors to
+`InvalidParams` plus `renameCollisionData`. The
+duplicated engine was deleted from the LSP package.
+
+The editor-only prepare-range and
+cursor-disambiguation code stays. `isValidRefDefLine`
+now calls `rename.ValidRefDefBodyLines`.
+
+The neutral `Edit` is line + UTF-16 char. That is
+the same shape as the LSP `textEdit`. The adapter is
+a field copy, so the wire output cannot drift. The
+plan-131/151 suites in
+[internal/lsp](../internal/lsp/) plus
+[cmd/mdsmith/lsp_rename_test.go](../cmd/mdsmith/lsp_rename_test.go)
+stay green byte-for-byte.
 
 ### Slice C — the `mdsmith rename` CLI
 

--- a/plan/174_expose-rename-and-deps-cli.md
+++ b/plan/174_expose-rename-and-deps-cli.md
@@ -1,7 +1,7 @@
 ---
 id: 174
 title: Expose rename and dependency-graph as CLI subcommands and feature docs
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: [131, 151, 153]
 summary: >-
@@ -156,8 +156,18 @@ over discovered files and queries `OutgoingEdges` /
    stays; `isValidRefDefLine` now calls
    `rename.ValidRefDefBodyLines`. Plans 151/131 +
    `cmd/mdsmith/lsp_rename_test.go` stay green byte-for-byte.
-6. [ ] TDD `cmd/mdsmith/rename.go` (unit + e2e), register in
-   `main.go` dispatch + `usageText`.
+6. [x] TDD `cmd/mdsmith/rename.go` (unit + e2e), registered
+   in `main.go` dispatch + `usageText`. Name-based:
+   `--heading <old> <new>` resolves the heading line via
+   `rename.FindHeadingLine`; `--link-ref` normalizes the
+   label via `rename.NormalizeLabel`. A `cliRenameWorkspace`
+   backs the engine's `Workspace` over a transient
+   `internal/index` + disk reads. Edits are spliced back by
+   converting each UTF-16 range to bytes. Exit 0 rewritten,
+   1 no match, 2 conflict/error. `rename.go` is 100%
+   covered (unit) with an e2e suite for the process
+   boundary; the `run` dispatch was split into `dispatch`
+   to stay under the statement limit.
 7. [x] TDD `cmd/mdsmith/deps.go` (unit + e2e); register
    in `main.go`. The LSP call-hierarchy and `deps` both
    consult `internal/index` for the edge graph, so the
@@ -169,9 +179,10 @@ over discovered files and queries `OutgoingEdges` /
    `cross-system.md` left as-is: the CLI-surface row
    already covers subcommands generically, and "adding a
    flag/command is minor" is stated there.
-9. [ ] Final gate + flip status to ✅; push. **Remaining
-   before ✅: tasks 4–6 (the `internal/rename` core, the
-   LSP delegation, and the `mdsmith rename` CLI).**
+9. [x] Final gate + flip status to ✅; push. All slices
+   landed: the `internal/rename` core, the LSP delegation,
+   and the `mdsmith rename` CLI. `go test ./...`,
+   `golangci-lint`, and `mdsmith check .` all clean.
 
 ## Acceptance Criteria
 
@@ -189,15 +200,15 @@ over discovered files and queries `OutgoingEdges` /
       `cmd/mdsmith/lsp_rename_test.go` pass unchanged
       (Liskov — the relocation is behavior-preserving; the
       delegation refactor in task 5 must keep them green).
-- [ ] `mdsmith rename f.md --heading "A" "B"` rewrites the
+- [x] `mdsmith rename f.md --heading "A" "B"` rewrites the
       heading and every workspace anchor link; `--link-ref`
       rewrites def + uses; collisions exit 2 naming the
       conflict.
 - [x] `mdsmith deps f.md` and `--incoming` emit the
       dependency edges in text and json.
-- [ ] CLI rename + deps contracts locked by e2e tests in
-      `cmd/mdsmith/` (cross-system contract test). deps
-      done (`e2e_deps_test.go`); rename pending task 6.
+- [x] CLI rename + deps contracts locked by e2e tests in
+      `cmd/mdsmith/` (cross-system contract test):
+      `e2e_deps_test.go` and `e2e_rename_test.go`.
 - [x] Every new production function has a dedicated unit
       test (`TestFoo` / `TestReceiver_Foo`). Holds for the
       shipped `deps` code; re-verify when the rename core
@@ -218,83 +229,22 @@ over discovered files and queries `OutgoingEdges` /
   Easy to rename before the contract test locks if a
   reviewer prefers otherwise.
 
-## Remaining work
+## Outcome
 
-Task 4 is complete:
-[internal/rename](../internal/rename/rename.go) holds
-the link-reference engine and
-[heading.go](../internal/rename/heading.go) the
-heading engine, both 100% covered. Two slices remain,
-each its own green commit.
+All three slices landed as their own green
+commits:
 
-### Slice A — move the heading engine (done)
-
-The heading half of
-[internal/lsp/rename.go](../internal/lsp/rename.go)
-moved into
-[internal/rename/heading.go](../internal/rename/heading.go).
-It covers the slug map, the anchor edits, the
-ref-def edits, and the stable sort. A `Workspace`
-seam feeds it the incoming edges, the file list, and
-a path→bytes resolver. `rename.Heading` returns a
-per-key `Edit` set. An unsafe rename returns a typed
-error instead.
-
-Behavior tests cover same-file anchors, cross-file
-anchors, the disambiguator shift, and each guard at
-100%, no mocks.
-
-### Slice B — LSP delegates to the core (done)
-
-`handleRename` resolves the cursor. Then it calls
-`rename.Heading` or `rename.LinkRef`. A thin
-adapter maps the neutral `Edit` set to
-`workspaceEdit`. It maps the typed errors to
-`InvalidParams` plus `renameCollisionData`. The
-duplicated engine was deleted from the LSP package.
-
-The editor-only prepare-range and
-cursor-disambiguation code stays. `isValidRefDefLine`
-now calls `rename.ValidRefDefBodyLines`.
-
-The neutral `Edit` is line + UTF-16 char. That is
-the same shape as the LSP `textEdit`. The adapter is
-a field copy, so the wire output cannot drift. The
-plan-131/151 suites in
-[internal/lsp](../internal/lsp/) plus
-[cmd/mdsmith/lsp_rename_test.go](../cmd/mdsmith/lsp_rename_test.go)
-stay green byte-for-byte.
-
-### Slice C — the `mdsmith rename` CLI
-
-Add `cmd/mdsmith/rename.go`, name-based:
-
-```bash
-mdsmith rename <file> --heading "Old" "New"
-mdsmith rename <file> --link-ref oldlabel newlabel
-```
-
-- `--heading` finds the heading line whose text is
-  `Old`; `--link-ref` normalizes `oldlabel`
-- build a `Workspace` over a transient
-  `internal/index` + disk, mirroring
-  [cmd/mdsmith/deps.go](../cmd/mdsmith/deps.go)
-- apply each `Edit`: per line, convert the UTF-16
-  range back to bytes, then splice
-- register `rename` in
-  [cmd/mdsmith/main.go](../cmd/mdsmith/main.go)
-  dispatch + usage text
-- exit codes: `0` rewritten, `1` no match, `2` error
-  or conflict
-- unit + e2e tests, 100% coverage
-
-Then the task-8 follow-ups:
-
-- add a CLI section to
-  [docs/features/rename.md](../docs/features/rename.md)
-- add a `docs/reference/cli/rename.md` page
-- run `mdsmith fix .` to regenerate the catalogs
-- flip this plan's status to ✅
+- `internal/rename` holds the link-reference
+  engine ([rename.go](../internal/rename/rename.go))
+  and the heading engine
+  ([heading.go](../internal/rename/heading.go)),
+  both 100% covered behind a `Workspace` seam.
+- `internal/lsp/rename.go` is a thin adapter; the
+  duplicated engine is gone and the plan-131/151
+  suites stay green byte-for-byte.
+- [cmd/mdsmith/rename.go](../cmd/mdsmith/rename.go)
+  is the name-based CLI, 100% unit-covered with an
+  e2e suite, plus feature and reference docs.
 
 ## ...
 

--- a/plan/174_expose-rename-and-deps-cli.md
+++ b/plan/174_expose-rename-and-deps-cli.md
@@ -134,19 +134,18 @@ over discovered files and queries `OutgoingEdges` /
    supersession to the audit log. (`cross-system.md`
    boundaries/versioning deferred to task 8 with the CLI
    surface.)
-4. [ ] TDD `internal/rename` core. **In progress —**
-   **done:** the
-   link-reference engine plus the shared body/offset
-   helpers are lifted out of `internal/lsp/rename.go` into
+4. [x] TDD `internal/rename` core. The link-reference
+   engine and the heading engine are both lifted into
    `internal/rename` (neutral `Edit`/`Position`/`Range`,
    typed `ErrEmptyLabel` / `InvalidLabelRuneError` /
-   `LabelConflictError`), behavior-tested at **100%**
-   statement coverage, building and linting clean.
-   **Remaining:** the heading engine (`computeSlugRemap`,
-   `assignSlugs`, anchor/ref-def-dest edits) still lives in
-   `internal/lsp/rename.go` because the heading and
-   link-ref paths share helpers now in `internal/rename`;
-   moving it is the next slice of this task.
+   `LabelConflictError` / `InvalidHeadingRuneError` /
+   `ErrEmptyHeadingSlug` / `HeadingCollisionError`). The
+   heading path takes a `Workspace` seam (incoming anchor
+   edges, file list, path→bytes) so LSP can back it with
+   the warm index + buffers and the CLI with a transient
+   index + disk. Behavior-tested at **100%** statement
+   coverage with a real index-backed workspace (no mocks);
+   every production function has a dedicated unit test.
 5. [ ] Refactor `internal/lsp/rename.go` to delegate to
    `internal/rename`; delete duplicated computation. Plans
    151/131 + `cmd/mdsmith/lsp_rename_test.go` stay green.
@@ -173,7 +172,7 @@ over discovered files and queries `OutgoingEdges` /
       `internal/lsp/index`; `grep -r internal/lsp/index`
       finds nothing (SRP / DIP — package answers one
       question, CLI no longer reaches the editor layer).
-- [ ] `internal/rename` returns plain edits and typed errors,
+- [x] `internal/rename` returns plain edits and typed errors,
       imports neither `internal/lsp` nor any LSP wire type
       (DIP — surfaces depend on the core).
 - [ ] `internal/lsp/rename.go` contains no slug / edit
@@ -214,43 +213,30 @@ over discovered files and queries `OutgoingEdges` /
 
 ## Remaining work
 
-Task 4's first slice landed:
+Task 4 is complete:
 [internal/rename](../internal/rename/rename.go) holds
-the link-reference engine and the shared body/offset
-helpers, 100% covered. Three slices remain, each its
-own green commit.
+the link-reference engine and
+[heading.go](../internal/rename/heading.go) the
+heading engine, both 100% covered. Two slices remain,
+each its own green commit.
 
-### Slice A — move the heading engine
+### Slice A — move the heading engine (done)
 
-Lift the heading half of
+The heading half of
 [internal/lsp/rename.go](../internal/lsp/rename.go)
-into [internal/rename](../internal/rename/rename.go).
+moved into
+[internal/rename/heading.go](../internal/rename/heading.go).
+It covers the slug map, the anchor edits, the
+ref-def edits, and the stable sort. A `Workspace`
+seam feeds it the incoming edges, the file list, and
+a path→bytes resolver. `rename.Heading` returns a
+per-key `Edit` set. An unsafe rename returns a typed
+error instead.
 
-- slug map: `computeSlugRemap`, `walkAllHeadings`,
-  `assignSlugs`, `slugRemapPairs`, `headingTextEdit`
-- anchor edits: `anchorEditForEdge`,
-  `anchorFragmentBytes`, `destBounds`, `indexOfHash`,
-  `fragmentEnd`, `fragmentMatchesSlug`,
-  `isBackslashEscaped`
-- ref-def destinations: `refDefDestEditForMatch`,
-  `refDefColonOffset`, `refDefDestRange`,
-  `refDefDestPointsAt`, `refDefParseTarget`
-- ordering: `stableSortEdits`
-- guards to add: reject a control rune, an empty
-  slug, and a slug that collides with another heading
-
-`Workspace` seam the heading path needs:
-
-- list the incoming anchor edges for a `(file, slug)`
-- resolve a workspace path to its bytes
-- LSP backs it with the warm index + open buffers;
-  CLI with a transient index + disk reads
-
-API: `rename.Heading(ws, file, line, newName)` →
-per-file `Edit` set, or `CollisionError` naming the
-clash. Behavior tests: same-file anchors, cross-file
-anchors, disambiguator shift, each guard. 100%
-coverage, no mocks.
+The LSP package still carries its own copy. Slice B
+deletes that copy. Behavior tests cover same-file
+anchors, cross-file anchors, the disambiguator
+shift, and each guard at 100%, no mocks.
 
 ### Slice B — LSP delegates to the core
 


### PR DESCRIPTION
Slice A of plan 174: the heading half of internal/lsp/rename.go
(slug remap, anchor-link edits, ref-def-destination edits, stable
ordering) moves into internal/rename/heading.go behind a Workspace
seam so the LSP server and the future `mdsmith rename` CLI share one
engine. Returns neutral Edit values and typed errors
(InvalidHeadingRuneError / ErrEmptyHeadingSlug /
HeadingCollisionError); no LSP wire types. 100% statement coverage
with a real index-backed workspace, a dedicated unit test per
production function. The LSP package keeps its own copy until
Slice B deletes it.

https://claude.ai/code/session_01CdBMT52zf2GAGVcYYAoQxd