### PR TITLE
audit: SOLID sweep 2026-05-17 — plan/175 for UTF-16 helper triplicate

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -101,4 +101,5 @@ footer: |
 | 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                         |
 | 173 | 🔲     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                              |
 | 174 | ✅     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)          |
+| 175 | 🔲     |        | [Centralize UTF-16 column helpers in internal/mdtext](plan/175_arch-fix-utf16-centralize.md)                              |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: 7464d27310f722d9bfe203dc66b11bde714d4dd8
+audit-from: b5a6d72302b6a258f4acdb812464d1990388420d
 ---
 # Architecture audit log
 
@@ -252,6 +252,26 @@ Worth a one-sentence package comment
 explaining why it is separate so
 future readers do not read it as a
 separate rule package.
+
+## Audit 2026-05-17 (range: 7464d273..b5a6d72)
+
+Covered: `internal/rename`, `internal/index`
+(relocated), `mdsmith deps`, `mdsmith export`.
+
+### 2026-05-17 tax
+
+`nonNegativeUTF16RuneLen` privately copied in
+three packages:
+
+- `internal/lsp/diagnostics.go:156`
+- `internal/rename/rename.go:532`
+- `cmd/mdsmith/rename.go:380`
+
+Fix: export `NonNegativeUTF16RuneLen` (plus
+`UTF16FromByteOffset` and `UTF16ToByteOffset`)
+from `internal/mdtext`. Remove the three private
+copies. See
+[plan/175](../../plan/175_arch-fix-utf16-centralize.md).
 
 ## Decision 2026-05-17 (plan/174)
 

--- a/plan/175_arch-fix-utf16-centralize.md
+++ b/plan/175_arch-fix-utf16-centralize.md
@@ -1,0 +1,83 @@
+---
+id: 175
+title: Centralize UTF-16 column helpers in internal/mdtext
+status: 🔲
+summary: >-
+  Lift the triplicated nonNegativeUTF16RuneLen /
+  utf16FromByteOffset helpers out of internal/lsp,
+  internal/rename, and cmd/mdsmith into
+  internal/mdtext, removing the three private
+  copies.
+model: ''
+depends-on: []
+---
+# Centralize UTF-16 column helpers in internal/mdtext
+
+## Goal
+
+Export three UTF-16 helpers from
+`internal/mdtext`:
+
+- `NonNegativeUTF16RuneLen`
+- `UTF16FromByteOffset`
+- `UTF16ToByteOffset`
+
+Remove the three private copies in
+`internal/lsp`, `internal/rename`, and
+`cmd/mdsmith`.
+
+## Tasks
+
+1. Add exported functions to
+   `internal/mdtext`:
+
+  - `NonNegativeUTF16RuneLen(r rune) int`
+  - `UTF16FromByteOffset(line []byte, byteOff int) int`
+  - `UTF16ToByteOffset(line []byte, target int) int`
+   Add unit tests for each in
+   `internal/mdtext/utf16_test.go`.
+
+2. Replace `nonNegativeUTF16RuneLen`
+   and `utf16FromByteOffset` in
+   `internal/lsp/diagnostics.go` with
+   calls to the new `mdtext` functions.
+   Update
+   `internal/lsp/server_test.go` to
+   remove its now-stale private test
+   of the helper.
+3. Replace `nonNegativeUTF16RuneLen`
+   and `utf16FromByteOffset` in
+   `internal/rename/rename.go` with
+   calls to the new `mdtext` functions.
+   Remove the private copy and its
+   test in
+   `internal/rename/helpers_test.go`.
+4. Replace `nonNegativeUTF16RuneLen`
+   and `utf16ToByteOffset` in
+   `cmd/mdsmith/rename.go` with calls
+   to `mdtext.NonNegativeUTF16RuneLen`
+   and `mdtext.UTF16ToByteOffset`.
+   Update `rename_unit_test.go` to
+   remove the now-stale private test.
+5. Run `go build ./...` and
+   `go test ./...` to confirm no
+   breakage.
+6. Run `go tool golangci-lint run` to
+   confirm no lint regressions.
+
+## Acceptance Criteria
+
+- [ ] `internal/mdtext` exports
+  `NonNegativeUTF16RuneLen`,
+  `UTF16FromByteOffset`, and
+  `UTF16ToByteOffset`, each with a
+  dedicated unit test.
+- [ ] No private copy of
+  `nonNegativeUTF16RuneLen`,
+  `utf16FromByteOffset`, or
+  `utf16ToByteOffset` remains in
+  `internal/lsp/`, `internal/rename/`,
+  or `cmd/mdsmith/`.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run`
+  reports no issues.

--- a/plan/175_arch-fix-utf16-centralize.md
+++ b/plan/175_arch-fix-utf16-centralize.md
@@ -34,6 +34,7 @@ Remove the three private copies in
   - `NonNegativeUTF16RuneLen(r rune) int`
   - `UTF16FromByteOffset(line []byte, byteOff int) int`
   - `UTF16ToByteOffset(line []byte, target int) int`
+
    Add unit tests for each in
    `internal/mdtext/utf16_test.go`.
 


### PR DESCRIPTION
## Summary

- Ran the SOLID architecture audit over range `7464d273..b5a6d72` (commits landing `internal/rename`, `internal/index` relocation, `mdsmith deps`, `mdsmith export`).
- Found one new **tax** violation: `nonNegativeUTF16RuneLen` privately copied in three packages.
- Appended findings to `docs/development/architecture-audit.md` and updated `audit-from` SHA.
- Created `plan/175_arch-fix-utf16-centralize.md` to track the fix.

## Finding: UTF-16 helper triplicated (tax)

`nonNegativeUTF16RuneLen` (wraps `utf16.RuneLen` to clamp negative values) exists as a private copy in:

- `internal/lsp/diagnostics.go:156`
- `internal/rename/rename.go:532`
- `cmd/mdsmith/rename.go:380`

**Fix** (plan/175): export `NonNegativeUTF16RuneLen`, `UTF16FromByteOffset`, and `UTF16ToByteOffset` from `internal/mdtext`; remove the three private copies.

## No new blockers

All new code (`internal/rename`, `internal/index`, `deps.go`, `export.go`) follows the layering map. No rule package imports another rule package. All new exported functions have dedicated unit tests.

## Test plan

- [x] `mdsmith check .` passes (0 failures)
- [x] All catalogs regenerated via `mdsmith fix .`

https://claude.ai/code/session_01EvNiuNwQ679WM6VT8gJ63B

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvNiuNwQ679WM6VT8gJ63B)_