### PR TITLE
Rewrite sibling non-published links to GitHub blob URLs

### DIFF
--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -72,9 +72,12 @@ var siblingLink = regexp.MustCompile(`\]\(([^)\s]+)\)`)
 // fragments, and `../`-prefixed paths (those are the
 // non-published rewrite's job — repoNonPublishedLink — and
 // double-handling them here would route the same link twice).
-// Image targets (`.svg`/`.png`/…) are in syncableExt, so the
-// extension filter already leaves them — and any `![alt](…)`
-// image link — untouched.
+// Common image extensions (`.svg`/`.png`/…) are in syncableExt,
+// so the extension filter leaves an `![alt](pic.png)` image link
+// untouched. An image whose extension is outside syncableExt
+// (e.g. `![x](chart.pdf)`) would still be rewritten — acceptable
+// because no such doc image exists and MDS027 never walks image
+// nodes anyway.
 //
 // Runs under applyOutsideCode so a `[x](run.sh)` example inside
 // a code span or fenced block stays verbatim documentation.
@@ -153,6 +156,14 @@ func (t *Toolkit) SyncDocs(srcDir, dstDir string) error {
 	if err := t.fs.MkdirAll(dstDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir dst %s: %w", dstDir, err)
 	}
+	// repoDir is the docs tree's name relative to the repo root,
+	// used to anchor sibling-link GitHub URLs (see
+	// rewriteSiblingNonPublished). The basename of srcDir IS that
+	// segment because BuildWebsite is run from the repo root with
+	// srcDir = ./docs — the same root-relative assumption the
+	// rulesDir derivation makes. A srcDir whose basename is not
+	// the real repo-relative docs path would mis-anchor those
+	// URLs (silently — they would 404 on GitHub, not error here).
 	repoDir := filepath.Base(filepath.Clean(srcDir))
 	if _, err := t.syncDocsDir(srcDir, dstDir, repoDir); err != nil {
 		return fmt.Errorf("sync %s -> %s: %w", srcDir, dstDir, err)

--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -42,6 +43,63 @@ var syncableExt = map[string]struct{}{
 	".jpeg": {},
 	".gif":  {},
 	".webp": {},
+}
+
+// siblingLink matches the `](target)` tail of an inline
+// Markdown link, capturing the target in group 1. Matching only
+// the tail (not the `[label]` head) is deliberate and matches
+// every other rewriter in this package: applyOutsideCode splits
+// the byte stream at inline code spans, so a real-doc link whose
+// label is a code span — “ [`run.sh`](run.sh) “ — reaches the
+// rewrite as a bare `](run.sh)` fragment with the label in a
+// separate piece. `[^)\s]+` stops the target before a
+// whitespace-separated link title so a titled link is left
+// alone.
+var siblingLink = regexp.MustCompile(`\]\(([^)\s]+)\)`)
+
+// rewriteSiblingNonPublished routes a relative link whose target
+// SyncDocs prunes from the Hugo tree to the file's canonical
+// GitHub blob/tree URL. repoDir is the doc's repo-relative
+// directory (e.g. "docs/research/benchmarks"), so a same-
+// directory `run.sh` or a subdirectory `data/repo.json` resolves
+// to the right source path.
+//
+// Only same-directory and descendant relative targets whose
+// extension is outside syncableExt are rewritten. Five classes
+// are deliberately left untouched: synced `.md`/image targets
+// (still valid relative links), site-absolute targets
+// (`/docs/...`), external URLs (`scheme://`), pure `#anchor`
+// fragments, and `../`-prefixed paths (those are the
+// non-published rewrite's job — repoNonPublishedLink — and
+// double-handling them here would route the same link twice).
+// Image targets (`.svg`/`.png`/…) are in syncableExt, so the
+// extension filter already leaves them — and any `![alt](…)`
+// image link — untouched.
+//
+// Runs under applyOutsideCode so a `[x](run.sh)` example inside
+// a code span or fenced block stays verbatim documentation.
+func rewriteSiblingNonPublished(b []byte, repoDir string) []byte {
+	return applyOutsideCode(b, func(seg []byte) []byte {
+		return siblingLink.ReplaceAllFunc(seg, func(m []byte) []byte {
+			target := string(siblingLink.FindSubmatch(m)[1])
+			if strings.HasPrefix(target, "#") ||
+				strings.HasPrefix(target, "/") ||
+				strings.HasPrefix(target, "../") ||
+				strings.Contains(target, "://") {
+				return m
+			}
+			pathPart, frag := target, ""
+			if i := strings.IndexByte(target, '#'); i >= 0 {
+				pathPart, frag = target[:i], target[i:]
+			}
+			ext := strings.ToLower(filepath.Ext(pathPart))
+			if _, ok := syncableExt[ext]; ok || ext == "" {
+				return m
+			}
+			url := githubURLForPath([]byte(path.Join(repoDir, pathPart)))
+			return []byte("](" + url + frag + ")")
+		})
+	})
 }
 
 // SyncDocs snapshots srcDir into dstDir for a Hugo build. The
@@ -95,7 +153,8 @@ func (t *Toolkit) SyncDocs(srcDir, dstDir string) error {
 	if err := t.fs.MkdirAll(dstDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir dst %s: %w", dstDir, err)
 	}
-	if _, err := t.syncDocsDir(srcDir, dstDir); err != nil {
+	repoDir := filepath.Base(filepath.Clean(srcDir))
+	if _, err := t.syncDocsDir(srcDir, dstDir, repoDir); err != nil {
 		return fmt.Errorf("sync %s -> %s: %w", srcDir, dstDir, err)
 	}
 	return nil
@@ -157,7 +216,7 @@ func SyncDocs(srcDir, dstDir string) error {
 // file ended up under dst. An empty dst is removed so the rendered
 // tree doesn't expose hollow directories from upstream pruning
 // (a docs/ subdir containing only a proto.md, say).
-func (t *Toolkit) syncDocsDir(src, dst string) (bool, error) {
+func (t *Toolkit) syncDocsDir(src, dst, repoDir string) (bool, error) {
 	entries, err := t.fs.ReadDir(src)
 	if err != nil {
 		return false, fmt.Errorf("read dir %s: %w", src, err)
@@ -187,9 +246,9 @@ func (t *Toolkit) syncDocsDir(src, dst string) (bool, error) {
 		srcPath := filepath.Join(src, e.Name())
 		var entryWrote bool
 		if e.IsDir() {
-			entryWrote, err = t.syncDocsSubdir(srcPath, dst, e.Name(), mdSiblings)
+			entryWrote, err = t.syncDocsSubdir(srcPath, dst, e.Name(), mdSiblings, repoDir)
 		} else {
-			entryWrote, err = t.syncDocsFile(srcPath, dst, e.Name())
+			entryWrote, err = t.syncDocsFile(srcPath, dst, e.Name(), repoDir)
 		}
 		if err != nil {
 			return wrote, err
@@ -209,12 +268,12 @@ func (t *Toolkit) syncDocsDir(src, dst string) (bool, error) {
 // syncDocsSubdir recurses into one subdirectory, then
 // synthesizes a section _index.md when the subtree produced
 // content. It returns whether anything was written under dst.
-func (t *Toolkit) syncDocsSubdir(src, dst, name string, siblings map[string]struct{}) (bool, error) {
+func (t *Toolkit) syncDocsSubdir(src, dst, name string, siblings map[string]struct{}, repoDir string) (bool, error) {
 	childDst := filepath.Join(dst, name)
 	if err := t.fs.MkdirAll(childDst, 0o755); err != nil {
 		return false, fmt.Errorf("mkdir %s: %w", childDst, err)
 	}
-	childWrote, err := t.syncDocsDir(src, childDst)
+	childWrote, err := t.syncDocsDir(src, childDst, path.Join(repoDir, name))
 	if err != nil {
 		return childWrote, err
 	}
@@ -232,7 +291,7 @@ func (t *Toolkit) syncDocsSubdir(src, dst, name string, siblings map[string]stru
 // non-content extensions are skipped (returns false, nil);
 // index.md is renamed to _index.md. It returns whether a file
 // was written.
-func (t *Toolkit) syncDocsFile(src, dst, name string) (bool, error) {
+func (t *Toolkit) syncDocsFile(src, dst, name, repoDir string) (bool, error) {
 	if name == "proto.md" {
 		return false, nil
 	}
@@ -249,7 +308,7 @@ func (t *Toolkit) syncDocsFile(src, dst, name string) (bool, error) {
 		return false, fmt.Errorf("read %s: %w", src, err)
 	}
 	if ext == ".md" {
-		data = transformMarkdown(data)
+		data = rewriteSiblingNonPublished(transformMarkdown(data), repoDir)
 	}
 	dstPath := filepath.Join(dst, dstName)
 	if err := t.fs.WriteFile(dstPath, data, 0o644); err != nil {

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -817,6 +817,62 @@ func TestTransformMarkdown_SkipsFencedExamples(t *testing.T) {
 	})
 }
 
+// TestRewriteSiblingNonPublished: a relative link to a
+// same-directory or subdirectory file whose extension is not
+// synced into the Hugo tree (a `.sh` script, a `.yml` config,
+// `.json` data) must rewrite to a GitHub blob URL anchored at
+// the doc's repo-relative directory. Markdown and image links
+// (synced), site-absolute targets, external URLs, pure
+// anchors, and `../`-prefixed paths (handled by the
+// non-published rewrite) are left untouched.
+func TestRewriteSiblingNonPublished(t *testing.T) {
+	const rd = "docs/research/benchmarks"
+	blob := ghBlob + rd + "/"
+	cases := []struct{ name, in, want string }{
+		{"same-dir script", "[`r`](run.sh)\n", "[`r`](" + blob + "run.sh)\n"},
+		{"yml config", "[c](bench.mdsmith.yml)\n", "[c](" + blob + "bench.mdsmith.yml)\n"},
+		{"subdir data", "[j](data/r.json)\n", "[j](" + blob + "data/r.json)\n"},
+		{"anchor kept", "[x](run.sh#L3)\n", "[x](" + blob + "run.sh#L3)\n"},
+		{"markdown untouched", "[f](res.md)\n", "[f](res.md)\n"},
+		{"image untouched", "![d](d.svg)\n", "![d](d.svg)\n"},
+		{"pure anchor untouched", "[r](#sec)\n", "[r](#sec)\n"},
+		{"external url untouched", "[c](https://x.io/run.sh)\n", "[c](https://x.io/run.sh)\n"},
+		{"site-absolute untouched", "[a](/docs/rules/MDS027/)\n", "[a](/docs/rules/MDS027/)\n"},
+		{"parent-relative untouched", "[p](../b/run.sh)\n", "[p](../b/run.sh)\n"},
+		{"code span untouched", "use `[x](run.sh)` lit\n", "use `[x](run.sh)` lit\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want,
+				string(rewriteSiblingNonPublished([]byte(tc.in), rd)))
+		})
+	}
+}
+
+// TestSyncDocs_RewritesSiblingNonPublishedLinks pins the
+// benchmarks-README fix end to end: research docs link to
+// sibling `run.sh` / `bench-parity.mdsmith.yml` plumbing that
+// SyncDocs prunes, so the synced page must point those links at
+// GitHub instead of a dead relative path that MDS027 flags.
+func TestSyncDocs_RewritesSiblingNonPublishedLinks(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "docs")
+	dst := t.TempDir()
+	writeFile(t, filepath.Join(src, "research", "benchmarks", "README.md"),
+		"# Bench\n\nRun [`run.sh`](run.sh) with "+
+			"[cfg](bench-parity.mdsmith.yml).\n")
+
+	require.NoError(t, SyncDocs(src, dst))
+
+	got, err := os.ReadFile(
+		filepath.Join(dst, "research", "benchmarks", "README.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got),
+		"["+"`run.sh`"+"]("+ghBlob+"docs/research/benchmarks/run.sh)")
+	assert.Contains(t, string(got),
+		"[cfg]("+ghBlob+"docs/research/benchmarks/bench-parity.mdsmith.yml)")
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))


### PR DESCRIPTION
## Summary

When SyncDocs prunes non-content files (scripts, configs, data files) from the Hugo tree, relative links to those files become broken. This change rewrites same-directory and descendant relative links to non-synced file extensions as GitHub blob URLs anchored at the doc's repo-relative directory.

## Changes

- **Added `rewriteSiblingNonPublished` function**: Rewrites relative links to non-synced files (`.sh`, `.yml`, `.json`, etc.) as GitHub blob URLs. The rewrite:
  - Only targets same-directory and descendant paths (leaves `../` paths to the existing non-published rewrite)
  - Preserves synced `.md` and image files, site-absolute paths, external URLs, and pure anchors
  - Respects code spans and fenced blocks (runs under `applyOutsideCode`)
  - Preserves anchor fragments when present

- **Added `siblingLink` regex**: Matches the `](target)` tail of Markdown links to capture the target, handling the case where inline code spans split the link across pieces

- **Updated function signatures**: Threaded `repoDir` parameter through the sync pipeline:
  - `SyncDocs` extracts the repo-relative directory from the source path
  - `syncDocsDir`, `syncDocsSubdir`, and `syncDocsFile` now accept and propagate `repoDir`
  - `syncDocsFile` applies the rewrite to transformed Markdown

- **Added comprehensive tests**: 
  - `TestRewriteSiblingNonPublished` validates the rewrite logic with 11 test cases covering scripts, configs, data files, anchors, and untouched categories
  - `TestSyncDocs_RewritesSiblingNonPublishedLinks` pins the end-to-end behavior for the benchmarks-README use case

## Implementation Details

The rewrite integrates into the existing Markdown transformation pipeline, running after `transformMarkdown` so it operates on already-processed content. It uses `path.Join` to construct repo-relative paths and `githubURLForPath` to generate the canonical GitHub blob URL, maintaining consistency with other link rewrites in the package.

https://claude.ai/code/session_012pfjHCKFVUuCPJSdoEFVUv