### PR TITLE
Add parallel file linting with per-worker rule isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /mdsmith
+*.test
+*.prof
 eval/corpus/config.local.yml
 coverage.out
 cover.out

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,100 +14,101 @@ footer: |
 
 ?>
 
-| ID  | Status | Model  | Title                                                                                                                     |
-|-----|--------|--------|---------------------------------------------------------------------------------------------------------------------------|
-| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                |
-| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                              |
-| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                          |
-| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                   |
-| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                           |
-| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                |
-| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                      |
-| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                       |
-| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                         |
-| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                           |
-| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                            |
-| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                    |
-| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                           |
-| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                   |
-| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                          |
-| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                       |
-| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                        |
-| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                             |
-| 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                   |
-| 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                |
-| 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                                            |
-| 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                                    |
-| 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                                                 |
-| 105 | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                                         |
-| 106 | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                                         |
-| 107 | ✅     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                                           |
-| 108 | ✅     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                                           |
-| 109 | ✅     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                                                   |
-| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                                         |
-| 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                                                 |
-| 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                                     |
-| 113 | ✅     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                                    |
-| 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md)                      |
-| 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                        |
-| 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                  |
-| 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                                   |
-| 122 | ✅     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                          |
-| 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                                     |
-| 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                                       |
-| 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                               |
-| 127 | ✅     | sonnet | [Single H1 per file rule](plan/127_single-h1.md)                                                                          |
-| 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                                       |
-| 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)                             |
-| 130 | ✅     | opus   | [Distribute mdsmith binaries via npm, PyPI, and the VS Code marketplaces](plan/130_binary-distribution-and-versioning.md) |
-| 131 | ✅     | opus   | [LSP symbol navigation for agents (Claude)](plan/131_lsp-symbol-navigation.md)                                            |
-| 132 | ✅     | sonnet | [Package mdsmith LSP as a Claude Code plugin](plan/132_claude-code-plugin.md)                                             |
-| 133 | ✅     | sonnet | [LSP hover for rule and directive docs](plan/133_lsp-hover.md)                                                            |
-| 134 | ✅     | sonnet | [LSP completion for anchors, refs, kinds, and directive args](plan/134_lsp-completion.md)                                 |
-| 135 | 🔲     | sonnet | [Schema inheritance via `extends`](plan/135_schema-extends.md)                                                            |
-| 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                   |
-| 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                        |
-| 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                   |
-| 139 | ✅     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                              |
-| 140 | ✅     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                          |
-| 142 | ✅     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                             |
-| 143 | ✅     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                              |
-| 144 | ✅     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                              |
-| 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                      |
-| 146 | ✅     | opus   | [Schema engine — sources, scope tree, per-scope rules](plan/146_inline-schema-in-kinds.md)                                |
-| 147 | ✅     | opus   | [Actionable schema diagnostics for MDS020](plan/147_actionable-schema-diagnostics.md)                                     |
-| 148 | ✅     | sonnet | [Named field-type shortcuts for inline schemas](plan/148_named-field-type-shortcuts.md)                                   |
-| 149 | ✅     | opus   | [Section content schema for non-heading AST nodes](plan/149_section-content-schema.md)                                    |
-| 151 | ✅     | opus   | [LSP rename for headings and link-reference labels](plan/151_lsp-rename.md)                                               |
-| 153 | ✅     | sonnet | [Catalog directive — accept `..` globs within project root](plan/153_catalog-dotdot-globs.md)                             |
-| 153 | ✅     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                     |
-| 154 | ✅     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                       |
-| 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)             |
-| 156 | ✅     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                        |
-| 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
-| 157 | ✅     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
-| 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                      |
-| 161 | ✅     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |
-| 162 | ✅     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                            |
-| 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                      |
-| 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)               |
-| 165 | ✅     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                         |
-| 166 | ✅     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                              |
-| 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                      |
-| 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                               |
-| 169 | ✅     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)         |
-| 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                     |
-| 171 | 🔲     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                            |
-| 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                         |
-| 173 | 🔲     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                              |
-| 174 | ✅     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)          |
-| 175 | 🔳     | opus   | [CI performance gate for mdsmith check, modelled on the LSP latency gate](plan/175_check-performance-gate.md)             |
-| 176 | 🔲     | sonnet | [ATX heading whitespace and indentation rule](plan/176_atx-heading-whitespace.md)                                         |
-| 177 | 🔲     | sonnet | [Blockquote whitespace rule](plan/177_blockquote-whitespace.md)                                                           |
-| 178 | 🔲     | sonnet | [List marker space rule](plan/178_list-marker-space.md)                                                                   |
-| 179 | 🔲     | opus   | [Reversed and empty link rule](plan/179_link-validity.md)                                                                 |
-| 180 | 🔲     | sonnet | [Descriptive link text rule](plan/180_descriptive-link-text.md)                                                           |
-| 181 | 🔲     | opus   | [Table structure rules](plan/181_table-structure.md)                                                                      |
-| 182 | 🔲     | sonnet | [Code block convention rules](plan/182_code-block-conventions.md)                                                         |
-| 183 | 🔲     | sonnet | [Skip DedupeDiagnostics via an audited rule.RepoScoped marker](plan/183_dedupe-diagnostics-repo-scoped-skip.md)           |
+| ID  | Status | Model  | Title                                                                                                                                   |
+|-----|--------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| 52  | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                              |
+| 61  | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                            |
+| 65  | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                        |
+| 78  | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                                 |
+| 83  | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                                         |
+| 84  | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                              |
+| 85  | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                                    |
+| 86  | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                                     |
+| 89  | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                                       |
+| 90  | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                                         |
+| 91  | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                                          |
+| 92  | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                                  |
+| 93  | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                                         |
+| 94  | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                                 |
+| 95  | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                                        |
+| 96  | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                                     |
+| 97  | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                                      |
+| 98  | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                                           |
+| 100 | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                                 |
+| 101 | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                              |
+| 102 | 🔲     | opus   | [Builder interface and mdsmith build subcommand](plan/102_build-subcommand.md)                                                          |
+| 103 | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                                                  |
+| 104 | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                                                               |
+| 105 | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                                                       |
+| 106 | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                                                       |
+| 107 | ✅     | opus   | [No reference-style links rule](plan/107_no-reference-style.md)                                                                         |
+| 108 | ✅     | sonnet | [Horizontal rule style rule](plan/108_horizontal-rule-style.md)                                                                         |
+| 109 | ✅     | sonnet | [List marker style rule](plan/109_list-marker-style.md)                                                                                 |
+| 110 | ✅     | sonnet | [Ordered list numbering rule](plan/110_ordered-list-numbering.md)                                                                       |
+| 111 | ✅     | sonnet | [Ambiguous emphasis rule](plan/111_ambiguous-emphasis.md)                                                                               |
+| 112 | ✅     | opus   | [Markdown convention bundles for MDS034](plan/112_flavor-profiles.md)                                                                   |
+| 113 | ✅     | sonnet | [User-defined Markdown conventions](plan/113_user-defined-profiles.md)                                                                  |
+| 114 | ✅     | sonnet | [MDS034 message clarity and flavor-vs-rule docs](plan/114_mds034-message-and-flavor-vs-rule-docs.md)                                    |
+| 120 | ✅     | sonnet | [Unify glob matcher and field naming across mdsmith](plan/120_glob-unification.md)                                                      |
+| 121 | ✅     | opus   | [Expose mdsmith to VS Code via Language Server Protocol](plan/121_vscode-integration.md)                                                |
+| 121 | ✅     | sonnet | [Review and centralize YAML handling](plan/121_yaml-handling-review.md)                                                                 |
+| 122 | ✅     | sonnet | [VS Code palette commands](plan/122_vscode-hover-and-palette.md)                                                                        |
+| 124 | ✅     | sonnet | [No space inside code spans rule](plan/124_no-space-in-code-spans.md)                                                                   |
+| 125 | ✅     | sonnet | [No space inside link text rule](plan/125_no-space-in-link-text.md)                                                                     |
+| 126 | ✅     | sonnet | [Proper-name capitalization rule](plan/126_proper-names.md)                                                                             |
+| 127 | ✅     | sonnet | [Single H1 per file rule](plan/127_single-h1.md)                                                                                        |
+| 128 | ✅     | sonnet | [Reject undefined reference-link labels](plan/128_no-undefined-reference-labels.md)                                                     |
+| 129 | ✅     | sonnet | [Flag unused or duplicate link reference definitions](plan/129_no-unused-link-definitions.md)                                           |
+| 130 | ✅     | opus   | [Distribute mdsmith binaries via npm, PyPI, and the VS Code marketplaces](plan/130_binary-distribution-and-versioning.md)               |
+| 131 | ✅     | opus   | [LSP symbol navigation for agents (Claude)](plan/131_lsp-symbol-navigation.md)                                                          |
+| 132 | ✅     | sonnet | [Package mdsmith LSP as a Claude Code plugin](plan/132_claude-code-plugin.md)                                                           |
+| 133 | ✅     | sonnet | [LSP hover for rule and directive docs](plan/133_lsp-hover.md)                                                                          |
+| 134 | ✅     | sonnet | [LSP completion for anchors, refs, kinds, and directive args](plan/134_lsp-completion.md)                                               |
+| 135 | 🔲     | sonnet | [Schema inheritance via `extends`](plan/135_schema-extends.md)                                                                          |
+| 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                                 |
+| 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                                      |
+| 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                                 |
+| 139 | ✅     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                                            |
+| 140 | ✅     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                                        |
+| 142 | ✅     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                                           |
+| 143 | ✅     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                                            |
+| 144 | ✅     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                                            |
+| 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                                    |
+| 146 | ✅     | opus   | [Schema engine — sources, scope tree, per-scope rules](plan/146_inline-schema-in-kinds.md)                                              |
+| 147 | ✅     | opus   | [Actionable schema diagnostics for MDS020](plan/147_actionable-schema-diagnostics.md)                                                   |
+| 148 | ✅     | sonnet | [Named field-type shortcuts for inline schemas](plan/148_named-field-type-shortcuts.md)                                                 |
+| 149 | ✅     | opus   | [Section content schema for non-heading AST nodes](plan/149_section-content-schema.md)                                                  |
+| 151 | ✅     | opus   | [LSP rename for headings and link-reference labels](plan/151_lsp-rename.md)                                                             |
+| 153 | ✅     | sonnet | [Catalog directive — accept `..` globs within project root](plan/153_catalog-dotdot-globs.md)                                           |
+| 153 | ✅     | opus   | [Unify linkgraph and the LSP symbol index](plan/153_unify-linkgraph-and-lsp-index.md)                                                   |
+| 154 | ✅     | sonnet | [arch-fix: extract cross-rule helpers](plan/154_arch-fix-rule-helper-extraction.md)                                                     |
+| 155 | ✅     | sonnet | [arch-fix: relocate convention types out of markdownflavor](plan/155_arch-fix-convention-config-ownership.md)                           |
+| 156 | ✅     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                                      |
+| 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                               |
+| 157 | ✅     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                                             |
+| 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                                    |
+| 161 | ✅     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                                          |
+| 162 | ✅     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                                          |
+| 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                                    |
+| 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)                             |
+| 165 | ✅     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                                       |
+| 166 | ✅     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                                            |
+| 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                                    |
+| 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                                             |
+| 169 | ✅     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)                       |
+| 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                                   |
+| 171 | 🔲     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                                          |
+| 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                                       |
+| 173 | 🔲     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                                            |
+| 174 | ✅     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)                        |
+| 175 | 🔳     | opus   | [CI performance gate for mdsmith check, modelled on the LSP latency gate](plan/175_check-performance-gate.md)                           |
+| 176 | 🔲     | sonnet | [ATX heading whitespace and indentation rule](plan/176_atx-heading-whitespace.md)                                                       |
+| 177 | 🔲     | sonnet | [Blockquote whitespace rule](plan/177_blockquote-whitespace.md)                                                                         |
+| 178 | 🔲     | sonnet | [List marker space rule](plan/178_list-marker-space.md)                                                                                 |
+| 179 | 🔲     | opus   | [Reversed and empty link rule](plan/179_link-validity.md)                                                                               |
+| 180 | 🔲     | sonnet | [Descriptive link text rule](plan/180_descriptive-link-text.md)                                                                         |
+| 181 | 🔲     | opus   | [Table structure rules](plan/181_table-structure.md)                                                                                    |
+| 182 | 🔲     | sonnet | [Code block convention rules](plan/182_code-block-conventions.md)                                                                       |
+| 183 | 🔲     | sonnet | [Skip DedupeDiagnostics via an audited rule.RepoScoped marker](plan/183_dedupe-diagnostics-repo-scoped-skip.md)                         |
+| 184 | 🔳     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 <?/catalog?>

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -150,9 +150,6 @@ func ResolveWorkers(concurrency, n int) int {
 	if w > n {
 		w = n
 	}
-	if w < 1 {
-		w = 1
-	}
 	return w
 }
 

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -6,7 +6,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"sync"
+	"sync/atomic"
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/config"
@@ -51,9 +54,29 @@ type Runner struct {
 	// ignores this field and continues to derive FS from filepath.Dir
 	// per file.
 	SourceFS fs.FS
+	// Concurrency controls how many files Run lints in parallel.
+	// Zero or negative means "use runtime.GOMAXPROCS"; 1 forces the
+	// sequential path; n>1 uses n workers. The worker count is
+	// clamped to the file count. Output is merged in input order and
+	// then sorted, so the value never changes observable results —
+	// it only trades CPU for wall time. RunSource (single in-memory
+	// file) ignores this field.
+	Concurrency int
 	// gitignoreCache caches GitignoreMatchers by directory to avoid
-	// re-walking the filesystem for each file.
+	// re-walking the filesystem for each file. gitignoreMu guards it
+	// because Run lints files on multiple goroutines and the
+	// GitignoreFunc closure each file carries reaches back into the
+	// shared cache lazily during rule execution.
 	gitignoreCache map[string]*lint.GitignoreMatcher
+	gitignoreMu    sync.Mutex
+}
+
+// fileOutcome is one file's contribution to a run. Workers fill a
+// pre-sized slice of these by index, so the merge is order-stable and
+// needs no lock on the shared Result.
+type fileOutcome struct {
+	diags []lint.Diagnostic
+	errs  []error
 }
 
 // Result holds the output of a lint run.
@@ -65,7 +88,10 @@ type Result struct {
 }
 
 // Run lints the files at the given paths and returns a Result containing
-// all diagnostics (sorted by file, line, column, message) and any errors encountered.
+// all diagnostics (sorted by file, line, column, message) and any errors
+// encountered. Files are linted concurrently (see Runner.Concurrency);
+// per-file results are merged in input order before dedupe and sort, so
+// the output is identical to a sequential run regardless of scheduling.
 func (r *Runner) Run(paths []string) *Result {
 	res := &Result{}
 
@@ -74,12 +100,12 @@ func (r *Runner) Run(paths []string) *Result {
 	// the project config rather than individual Markdown files.
 	r.runConfigTargetRules(res)
 
-	for _, path := range paths {
-		if config.IsIgnored(r.Config.Ignore, path) {
-			continue
-		}
-		res.FilesChecked++
-		r.processFile(path, res)
+	work := r.filterIgnored(paths)
+	res.FilesChecked = len(work)
+
+	for _, o := range r.runFiles(work) {
+		res.Diagnostics = append(res.Diagnostics, o.diags...)
+		res.Errors = append(res.Errors, o.errs...)
 	}
 
 	res.Diagnostics = DedupeDiagnostics(res.Diagnostics)
@@ -87,20 +113,102 @@ func (r *Runner) Run(paths []string) *Result {
 	return res
 }
 
-// processFile reads, parses, and checks a single file, appending results to res.
-func (r *Runner) processFile(path string, res *Result) {
+// filterIgnored drops paths matched by the config ignore list, keeping
+// input order.
+func (r *Runner) filterIgnored(paths []string) []string {
+	work := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if config.IsIgnored(r.Config.Ignore, path) {
+			continue
+		}
+		work = append(work, path)
+	}
+	return work
+}
+
+// ResolveWorkers maps the Runner.Concurrency knob to an actual worker
+// count for a run over n files. concurrency <= 0 means "use
+// runtime.GOMAXPROCS"; a positive value is taken literally. The result
+// is clamped to n (never more workers than files) and is 0 when there
+// is nothing to do.
+func ResolveWorkers(concurrency, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	w := concurrency
+	if w <= 0 {
+		w = runtime.GOMAXPROCS(0)
+	}
+	if w > n {
+		w = n
+	}
+	if w < 1 {
+		w = 1
+	}
+	return w
+}
+
+// runFiles lints work into a pre-sized, index-addressed slice. With one
+// worker it stays on the calling goroutine. With more, each worker
+// clones the rule set once (so rules carrying per-Check state — include's
+// visited/chain, the directive engines — never touch another
+// goroutine's instance) and pulls file indices off an atomic counter
+// for even load balancing. No worker writes a slot another reads, so
+// the result needs no lock.
+func (r *Runner) runFiles(work []string) []fileOutcome {
+	outcomes := make([]fileOutcome, len(work))
+	workers := ResolveWorkers(r.Concurrency, len(work))
+	if workers <= 1 {
+		for i, path := range work {
+			outcomes[i] = r.lintFile(path, r.Rules)
+		}
+		return outcomes
+	}
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rules := cloneRules(r.Rules)
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= len(work) {
+					return
+				}
+				outcomes[i] = r.lintFile(work[i], rules)
+			}
+		}()
+	}
+	wg.Wait()
+	return outcomes
+}
+
+// cloneRules returns an independent copy of rules for one worker so
+// concurrent Check calls never share a rule instance's mutable state.
+func cloneRules(rules []rule.Rule) []rule.Rule {
+	out := make([]rule.Rule, len(rules))
+	for i, rl := range rules {
+		out[i] = rule.CloneInstance(rl)
+	}
+	return out
+}
+
+// lintFile reads, parses, and checks a single file with the given rule
+// set (the worker's private clones) and returns its diagnostics and
+// errors. It touches no shared Runner state except the mutex-guarded
+// gitignore cache.
+func (r *Runner) lintFile(path string, rules []rule.Rule) fileOutcome {
 	r.log().Printf("file: %s", path)
 
 	source, err := lint.ReadFileLimited(path, r.MaxInputBytes)
 	if err != nil {
-		res.Errors = append(res.Errors, fmt.Errorf("reading %q: %w", path, err))
-		return
+		return fileOutcome{errs: []error{fmt.Errorf("reading %q: %w", path, err)}}
 	}
 
 	f, err := lint.NewFileFromSource(path, source, r.StripFrontMatter)
 	if err != nil {
-		res.Errors = append(res.Errors, fmt.Errorf("parsing %q: %w", path, err))
-		return
+		return fileOutcome{errs: []error{fmt.Errorf("parsing %q: %w", path, err)}}
 	}
 	f.MaxInputBytes = r.MaxInputBytes
 	dir := filepath.Dir(path)
@@ -117,22 +225,20 @@ func (r *Runner) processFile(path string, res *Result) {
 
 	fmKinds, fmFields, err := r.parseFrontMatter(path, f.FrontMatter)
 	if err != nil {
-		res.Errors = append(res.Errors, err)
-		return
+		return fileOutcome{errs: []error{err}}
 	}
 
 	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
 
 	effective := r.effectiveWithCategories(path, fmKinds, fmFields)
-	mdRules := r.markdownRules()
+	mdRules := markdownRulesFrom(rules, r.ConfigPath)
 	r.logRules(mdRules, effective)
 
 	diags, errs := checkRules(f, mdRules, effective, r.SkipSourceContext)
 	if r.Explain {
 		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
-	res.Diagnostics = append(res.Diagnostics, diags...)
-	res.Errors = append(res.Errors, errs...)
+	return fileOutcome{diags: diags, errs: errs}
 }
 
 // DedupeDiagnostics returns a new slice with duplicate (file, line,
@@ -290,11 +396,19 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 // have already run once (via runConfigTargetRules) and their Check method
 // returns nil for any non-config path anyway.
 func (r *Runner) markdownRules() []rule.Rule {
-	if r.ConfigPath == "" {
-		return r.Rules
+	return markdownRulesFrom(r.Rules, r.ConfigPath)
+}
+
+// markdownRulesFrom filters config-target rules out of rules when a
+// config path is set (they ran once via runConfigTargetRules and their
+// Check returns nil for non-config paths anyway). It operates on the
+// passed slice so each worker filters its own clones.
+func markdownRulesFrom(rules []rule.Rule, configPath string) []rule.Rule {
+	if configPath == "" {
+		return rules
 	}
-	filtered := make([]rule.Rule, 0, len(r.Rules))
-	for _, rl := range r.Rules {
+	filtered := make([]rule.Rule, 0, len(rules))
+	for _, rl := range rules {
 		if ct, ok := rl.(rule.ConfigTarget); ok && ct.IsConfigFileRule() {
 			continue
 		}
@@ -361,6 +475,8 @@ func (r *Runner) effectiveWithCategories(
 // The cache key is normalized to an absolute path so equivalent paths
 // (e.g. "sub" vs "./sub") share the same entry.
 func (r *Runner) cachedGitignore(dir string) *lint.GitignoreMatcher {
+	r.gitignoreMu.Lock()
+	defer r.gitignoreMu.Unlock()
 	if r.gitignoreCache == nil {
 		r.gitignoreCache = make(map[string]*lint.GitignoreMatcher)
 	}

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"math"
@@ -73,10 +74,13 @@ type Runner struct {
 
 // fileOutcome is one file's contribution to a run. Workers fill a
 // pre-sized slice of these by index, so the merge is order-stable and
-// needs no lock on the shared Result.
+// needs no lock on the shared Result. log holds the file's verbose
+// lines (empty unless the logger is enabled); Run flushes them in
+// input order so -v output is deterministic regardless of scheduling.
 type fileOutcome struct {
 	diags []lint.Diagnostic
 	errs  []error
+	log   []byte
 }
 
 // Result holds the output of a lint run.
@@ -103,7 +107,11 @@ func (r *Runner) Run(paths []string) *Result {
 	work := r.filterIgnored(paths)
 	res.FilesChecked = len(work)
 
+	sink := r.log()
 	for _, o := range r.runFiles(work) {
+		if len(o.log) > 0 && sink.W != nil {
+			_, _ = sink.W.Write(o.log)
+		}
 		res.Diagnostics = append(res.Diagnostics, o.diags...)
 		res.Errors = append(res.Errors, o.errs...)
 	}
@@ -198,8 +206,18 @@ func cloneRules(rules []rule.Rule) []rule.Rule {
 // set (the worker's private clones) and returns its diagnostics and
 // errors. It touches no shared Runner state except the mutex-guarded
 // gitignore cache.
-func (r *Runner) lintFile(path string, rules []rule.Rule) fileOutcome {
-	r.log().Printf("file: %s", path)
+func (r *Runner) lintFile(path string, rules []rule.Rule) (out fileOutcome) {
+	// When verbose, log into a per-file buffer instead of the shared
+	// logger; Run flushes these in input order so concurrent workers
+	// don't interleave -v output. The named return + defer attaches
+	// the buffer no matter which early return fires.
+	flog := r.log()
+	if flog.Enabled {
+		var buf bytes.Buffer
+		flog = &vlog.Logger{Enabled: true, W: &buf}
+		defer func() { out.log = bytes.Clone(buf.Bytes()) }()
+	}
+	flog.Printf("file: %s", path)
 
 	source, err := lint.ReadFileLimited(path, r.MaxInputBytes)
 	if err != nil {
@@ -232,7 +250,7 @@ func (r *Runner) lintFile(path string, rules []rule.Rule) fileOutcome {
 
 	effective := r.effectiveWithCategories(path, fmKinds, fmFields)
 	mdRules := markdownRulesFrom(rules, r.ConfigPath)
-	r.logRules(mdRules, effective)
+	logRulesTo(flog, mdRules, effective)
 
 	diags, errs := checkRules(f, mdRules, effective, r.SkipSourceContext)
 	if r.Explain {
@@ -503,7 +521,13 @@ func (r *Runner) log() *vlog.Logger {
 
 // logRules logs each enabled rule in the effective config from the provided slice.
 func (r *Runner) logRules(rules []rule.Rule, effective map[string]config.RuleCfg) {
-	l := r.log()
+	logRulesTo(r.log(), rules, effective)
+}
+
+// logRulesTo logs each enabled rule to l. Split from logRules so the
+// per-file buffered logger in lintFile can reuse the same formatting
+// without going through the shared Runner logger.
+func logRulesTo(l *vlog.Logger, rules []rule.Rule, effective map[string]config.RuleCfg) {
 	if !l.Enabled {
 		return
 	}

--- a/internal/engine/runner_helpers_test.go
+++ b/internal/engine/runner_helpers_test.go
@@ -1,0 +1,147 @@
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	vlog "github.com/jeduden/mdsmith/internal/log"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configTargetMock implements rule.Rule and rule.ConfigTarget so the
+// markdownRulesFrom filter branch can be exercised both ways.
+type configTargetMock struct {
+	id, name string
+	isCfg    bool
+}
+
+func (r *configTargetMock) ID() string                           { return r.id }
+func (r *configTargetMock) Name() string                         { return r.name }
+func (r *configTargetMock) Category() string                     { return "test" }
+func (r *configTargetMock) Check(_ *lint.File) []lint.Diagnostic { return nil }
+func (r *configTargetMock) IsConfigFileRule() bool               { return r.isCfg }
+
+func TestFilterIgnored(t *testing.T) {
+	r := &Runner{Config: &config.Config{Ignore: []string{"vendor/**", "**/skip.md"}}}
+	in := []string{"a.md", "vendor/lib.md", "b.md", "x/skip.md", "c.md"}
+	assert.Equal(t, []string{"a.md", "b.md", "c.md"}, r.filterIgnored(in),
+		"ignored paths dropped, input order preserved")
+}
+
+func TestFilterIgnored_NoPatternsKeepsAll(t *testing.T) {
+	r := &Runner{Config: &config.Config{}}
+	in := []string{"a.md", "b.md"}
+	assert.Equal(t, in, r.filterIgnored(in))
+}
+
+func TestCloneRules_IndependentInstances(t *testing.T) {
+	orig := []rule.Rule{
+		&mockRule{id: "MDS1", name: "m1"},
+		&silentRule{id: "MDS2", name: "s2"},
+	}
+	cl := cloneRules(orig)
+	require.Len(t, cl, len(orig))
+	for i := range orig {
+		assert.NotSame(t, orig[i], cl[i], "clone %d must be a distinct pointer", i)
+		assert.Equal(t, orig[i].ID(), cl[i].ID())
+		assert.Equal(t, orig[i].Name(), cl[i].Name())
+	}
+}
+
+func TestCloneRules_Empty(t *testing.T) {
+	assert.Empty(t, cloneRules(nil))
+}
+
+func TestMarkdownRulesFrom_NoConfigPathReturnsAll(t *testing.T) {
+	rules := []rule.Rule{
+		&mockRule{id: "A", name: "a"},
+		&configTargetMock{id: "C", name: "c", isCfg: true},
+	}
+	assert.Equal(t, rules, markdownRulesFrom(rules, ""),
+		"with no config path every rule is kept")
+}
+
+func TestMarkdownRulesFrom_FiltersConfigFileRules(t *testing.T) {
+	md := &mockRule{id: "A", name: "a"}
+	cfgRule := &configTargetMock{id: "C", name: "c", isCfg: true}
+	nonCfg := &configTargetMock{id: "D", name: "d", isCfg: false}
+	got := markdownRulesFrom([]rule.Rule{md, cfgRule, nonCfg}, "/x/.mdsmith.yml")
+	assert.Equal(t, []rule.Rule{md, nonCfg}, got,
+		"only IsConfigFileRule()==true rules are filtered out")
+}
+
+func TestLogRulesTo_DisabledLoggerNoOutput(t *testing.T) {
+	var buf bytes.Buffer
+	logRulesTo(&vlog.Logger{Enabled: false, W: &buf},
+		[]rule.Rule{&mockRule{id: "M1", name: "m1"}},
+		map[string]config.RuleCfg{"m1": {Enabled: true}})
+	assert.Empty(t, buf.String(), "disabled logger writes nothing")
+}
+
+func TestLogRulesTo_LogsOnlyEnabledRules(t *testing.T) {
+	var buf bytes.Buffer
+	rules := []rule.Rule{
+		&mockRule{id: "M1", name: "m1"}, // enabled  -> logged
+		&mockRule{id: "M2", name: "m2"}, // disabled -> skipped
+		&mockRule{id: "M3", name: "m3"}, // absent   -> skipped
+	}
+	eff := map[string]config.RuleCfg{"m1": {Enabled: true}, "m2": {Enabled: false}}
+	logRulesTo(&vlog.Logger{Enabled: true, W: &buf}, rules, eff)
+	assert.Equal(t, "rule: M1 m1\n", buf.String())
+}
+
+func TestRunFiles_SequentialMatchesParallel(t *testing.T) {
+	dir := t.TempDir()
+	var work []string
+	for i := 0; i < 6; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("f%d.md", i))
+		require.NoError(t, os.WriteFile(p, []byte("# H\n"), 0o644))
+		work = append(work, p)
+	}
+	cfg := &config.Config{Rules: map[string]config.RuleCfg{"mock-rule": {Enabled: true}}}
+	mk := func(c int) *Runner {
+		return &Runner{
+			Config:      cfg,
+			Rules:       []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+			Concurrency: c,
+		}
+	}
+	seq := mk(1).runFiles(work) // workers<=1 branch
+	par := mk(4).runFiles(work) // parallel + cloneRules branch
+	require.Len(t, seq, len(work))
+	require.Len(t, par, len(work))
+	for i := range work {
+		require.Len(t, seq[i].diags, 1)
+		assert.Equal(t, seq[i].diags, par[i].diags, "outcome %d differs seq vs parallel", i)
+		assert.Equal(t, work[i], seq[i].diags[0].File, "index must map to its own file")
+	}
+}
+
+func TestLintFile_ReadErrorReturnsErrs(t *testing.T) {
+	r := &Runner{Config: &config.Config{}}
+	out := r.lintFile(filepath.Join(t.TempDir(), "missing.md"), nil)
+	assert.Empty(t, out.diags)
+	require.Len(t, out.errs, 1)
+	assert.Contains(t, out.errs[0].Error(), "reading")
+}
+
+func TestLintFile_HappyReturnsDiags(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.md")
+	require.NoError(t, os.WriteFile(p, []byte("# H\n"), 0o644))
+	r := &Runner{
+		Config: &config.Config{Rules: map[string]config.RuleCfg{"mock-rule": {Enabled: true}}},
+		Rules:  []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
+	}
+	out := r.lintFile(p, r.Rules)
+	require.Len(t, out.diags, 1)
+	assert.Empty(t, out.errs)
+	assert.Equal(t, p, out.diags[0].File)
+}

--- a/internal/engine/runner_parallel_test.go
+++ b/internal/engine/runner_parallel_test.go
@@ -1,0 +1,162 @@
+package engine_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/engine"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Production rule set so the equivalence test exercises the
+	// real stateful rules (include, catalog, …), not a stub subset.
+	_ "github.com/jeduden/mdsmith/internal/rules/all"
+)
+
+// statefulRule writes f.Path to a per-instance field during Check and
+// reads it back into the diagnostic message. If a single instance is
+// shared across goroutines running Check concurrently, the field is
+// clobbered between the write and the read and the message no longer
+// equals the file path (and `go test -race` flags the access). Correct
+// per-worker rule isolation keeps every Check on a given instance
+// sequential, so message == path always.
+type statefulRule struct {
+	tmp string
+}
+
+func (r *statefulRule) ID() string       { return "MDS900" }
+func (r *statefulRule) Name() string     { return "stateful-mock" }
+func (r *statefulRule) Category() string { return "test" }
+
+func (r *statefulRule) Check(f *lint.File) []lint.Diagnostic {
+	r.tmp = f.Path
+	runtime.Gosched() // widen the race window if the instance is shared
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     1,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  r.tmp,
+	}}
+}
+
+func writeCorpus(t *testing.T, n int) (string, []string) {
+	t.Helper()
+	dir := t.TempDir()
+	paths := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("doc%03d.md", i))
+		body := fmt.Sprintf("# Document %d\n\nProse line one for document %d.\n\n"+
+			"## Section\n\nSee [next](doc%03d.md) for more.\n\n"+
+			"```go\nfunc f() int { return 0 }\n```\n", i, i, (i+1)%n)
+		require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+		paths = append(paths, p)
+	}
+	return dir, paths
+}
+
+func TestResolveWorkers(t *testing.T) {
+	gomax := runtime.GOMAXPROCS(0)
+	cases := []struct {
+		name        string
+		concurrency int
+		n           int
+		want        int
+	}{
+		{"auto clamps to file count", 0, 3, min(gomax, 3)},
+		{"auto uses gomaxprocs", 0, 10_000, gomax},
+		{"explicit one is sequential", 1, 50, 1},
+		{"explicit n honored", 4, 50, 4},
+		{"explicit clamps to files", 8, 3, 3},
+		{"negative means auto", -1, 10_000, gomax},
+		{"zero files yields zero", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, engine.ResolveWorkers(tc.concurrency, tc.n))
+		})
+	}
+}
+
+func TestRunner_ParallelEquivalenceFullRuleSet(t *testing.T) {
+	dir, paths := writeCorpus(t, 40)
+	cfg := config.Defaults()
+	newRunner := func(c int) *engine.Runner {
+		return &engine.Runner{
+			Config:           cfg,
+			Rules:            rule.All(),
+			StripFrontMatter: true,
+			RootDir:          dir,
+			Concurrency:      c,
+		}
+	}
+
+	seq := newRunner(1).Run(paths)
+	for _, c := range []int{0, 2, 8, 16} {
+		par := newRunner(c).Run(paths)
+		require.Equal(t, seq.FilesChecked, par.FilesChecked,
+			"FilesChecked mismatch at concurrency=%d", c)
+		require.Equal(t, len(seq.Errors), len(par.Errors),
+			"error count mismatch at concurrency=%d: %v vs %v", c, seq.Errors, par.Errors)
+		require.Equal(t, len(seq.Diagnostics), len(par.Diagnostics),
+			"diagnostic count mismatch at concurrency=%d", c)
+		for i := range seq.Diagnostics {
+			assert.Equal(t, seq.Diagnostics[i], par.Diagnostics[i],
+				"diagnostic %d differs at concurrency=%d", i, c)
+		}
+	}
+}
+
+func TestRunner_ParallelStatefulRuleIsolated(t *testing.T) {
+	_, paths := writeCorpus(t, 64)
+	runner := &engine.Runner{
+		Config: &config.Config{
+			Rules: map[string]config.RuleCfg{"stateful-mock": {Enabled: true}},
+		},
+		Rules:       []rule.Rule{&statefulRule{}},
+		Concurrency: 8,
+	}
+	res := runner.Run(paths)
+	require.Empty(t, res.Errors)
+	require.Len(t, res.Diagnostics, len(paths))
+	// Each diagnostic's message must equal its own file path; a shared
+	// instance under concurrent Check would cross-contaminate them.
+	for _, d := range res.Diagnostics {
+		assert.Equal(t, d.File, d.Message,
+			"stateful rule leaked state across goroutines")
+	}
+}
+
+// TestRunner_ParallelGitignoreCacheNoRace hammers the shared
+// gitignore cache from many workers: a pre-fix lazy-init data race on
+// Runner.gitignoreCache shows up here under `go test -race`.
+func TestRunner_ParallelGitignoreCacheNoRace(t *testing.T) {
+	dir, paths := writeCorpus(t, 64)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"),
+		[]byte("ignored/\n"), 0o644))
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runner := &engine.Runner{
+				Config:           config.Defaults(),
+				Rules:            rule.All(),
+				StripFrontMatter: true,
+				RootDir:          dir,
+				Concurrency:      8,
+			}
+			_ = runner.Run(paths)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/engine/runner_parallel_test.go
+++ b/internal/engine/runner_parallel_test.go
@@ -1,16 +1,19 @@
 package engine_test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/engine"
 	"github.com/jeduden/mdsmith/internal/lint"
+	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -134,6 +137,61 @@ func TestRunner_ParallelStatefulRuleIsolated(t *testing.T) {
 		assert.Equal(t, d.File, d.Message,
 			"stateful rule leaked state across goroutines")
 	}
+}
+
+// TestRunner_ParallelVerboseLogIsOrdered checks that a parallel run
+// with an enabled logger emits each file's verbose block in input
+// order with no cross-file interleaving — the buffered-then-merged
+// path makes -v output deterministic despite the worker scheduling.
+// Run under -race it also covers the enabled-logger concurrent path.
+func TestRunner_ParallelVerboseLogIsOrdered(t *testing.T) {
+	_, paths := writeCorpus(t, 24)
+	var buf bytes.Buffer
+	runner := &engine.Runner{
+		Config:           config.Defaults(),
+		Rules:            rule.All(),
+		StripFrontMatter: true,
+		RootDir:          filepath.Dir(paths[0]),
+		Concurrency:      8,
+		Logger:           &vlog.Logger{Enabled: true, W: &buf},
+	}
+
+	res := runner.Run(paths)
+	require.Equal(t, len(paths), res.FilesChecked)
+
+	// The sequence of "file:" lines must exactly match input order.
+	var gotFiles []string
+	for _, ln := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if rest, ok := strings.CutPrefix(ln, "file: "); ok {
+			gotFiles = append(gotFiles, rest)
+		}
+	}
+	require.Equal(t, paths, gotFiles,
+		"verbose file: lines must appear in input order, no interleaving")
+
+	// And every rule line must sit inside its own file's block: between
+	// two consecutive file: markers there are only that file's lines.
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	curFileIdx := -1
+	for _, ln := range lines {
+		if rest, ok := strings.CutPrefix(ln, "file: "); ok {
+			idx := indexOf(paths, rest)
+			require.Equal(t, curFileIdx+1, idx, "file blocks out of order at %q", ln)
+			curFileIdx = idx
+			continue
+		}
+		assert.True(t, strings.HasPrefix(ln, "rule: "),
+			"unexpected verbose line %q", ln)
+	}
+}
+
+func indexOf(ss []string, s string) int {
+	for i, v := range ss {
+		if v == s {
+			return i
+		}
+	}
+	return -1
 }
 
 // TestRunner_ParallelGitignoreCacheNoRace hammers the shared

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -3,13 +3,21 @@ package log
 import (
 	"fmt"
 	"io"
+	"sync"
 )
 
 // Logger writes verbose diagnostic messages when Enabled is true.
 // Output goes to the configured writer (typically stderr).
+//
+// Printf is safe for concurrent use: the parallel lint pipeline can
+// reach a shared logger from many goroutines, and not every io.Writer
+// (e.g. bytes.Buffer) is itself thread-safe. mu serializes the format
+// + write so lines are never torn or dropped. Always use *Logger;
+// copying a Logger value would copy the mutex.
 type Logger struct {
 	Enabled bool
 	W       io.Writer
+	mu      sync.Mutex
 }
 
 // Printf writes a formatted message to W when Enabled is true.
@@ -18,5 +26,7 @@ func (l *Logger) Printf(format string, args ...any) {
 	if !l.Enabled {
 		return
 	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	_, _ = fmt.Fprintf(l.W, format+"\n", args...)
 }

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"bytes"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +37,34 @@ func TestPrintf_MultipleMessages(t *testing.T) {
 
 	want := "file: README.md\nrule: MDS001 line-length\n"
 	assert.Equal(t, want, buf.String())
+}
+
+// TestPrintf_ConcurrentWritesAreSerialized hammers Printf from many
+// goroutines into one buffer. Without internal locking this is a data
+// race on the unsynchronized writer (caught by `go test -race`) and
+// can tear or drop lines; with the lock every line is intact and the
+// count is exact.
+func TestPrintf_ConcurrentWritesAreSerialized(t *testing.T) {
+	var buf bytes.Buffer
+	l := &Logger{Enabled: true, W: &buf}
+
+	const goroutines = 16
+	const perG = 64
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				l.Printf("g%02d-%03d", id, i)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Len(t, lines, goroutines*perG, "every Printf must produce exactly one line")
+	for _, ln := range lines {
+		assert.Regexp(t, `^g\d{2}-\d{3}$`, ln, "torn or interleaved write")
+	}
 }

--- a/internal/rule/clone.go
+++ b/internal/rule/clone.go
@@ -31,3 +31,31 @@ func CloneRule(r Rule) Rule {
 	// Value type — already a copy.
 	return r
 }
+
+// CloneInstance returns an independent copy of r that preserves its
+// identity and current state. Unlike CloneRule — which, for a
+// Configurable rule, builds a zero value and applies DefaultSettings —
+// CloneInstance is a faithful shallow copy of the same rule: every
+// field, including a rule's struct-stored name/ID and any
+// already-applied config, carries over, and the result is a distinct
+// pointer. It exists so each Run worker can hold its own rule set:
+// the per-file effective-config lookup is keyed by Name(), so a clone
+// that zeroed Name() would silently skip the rule.
+//
+// An embedded sync.Mutex (or similar) is copied while unlocked —
+// clones are taken from pristine, idle rule instances before any
+// Check runs — so the copy is a valid, independent lock. The shallow
+// copy shares slice/map backing with the source; that is safe because
+// the engine clones again per file via ConfigureRule before applying
+// per-file settings, and rules do not mutate their own config during
+// Check.
+func CloneInstance(r Rule) Rule {
+	rv := reflect.ValueOf(r)
+	if rv.Kind() != reflect.Ptr {
+		// Value-type rule: the interface already holds a copy.
+		return r
+	}
+	newPtr := reflect.New(rv.Elem().Type())
+	newPtr.Elem().Set(rv.Elem())
+	return newPtr.Interface().(Rule)
+}

--- a/internal/rule/clone_test.go
+++ b/internal/rule/clone_test.go
@@ -72,6 +72,37 @@ func TestCloneRule_NonConfigurable_IndependentCopy(t *testing.T) {
 	assert.Equal(t, "stub", clone.Name())
 }
 
+func TestCloneInstance_Configurable_PreservesIdentityAndState(t *testing.T) {
+	original := &configurableStub{id: "MDS001", name: "line-length", Max: 120, Style: "custom"}
+
+	clone := CloneInstance(original)
+
+	assert.NotSame(t, original, clone, "CloneInstance must return a new instance")
+	// Unlike CloneRule (zero value + DefaultSettings), CloneInstance is
+	// an independent copy of *this* rule: a worker clones before the
+	// effective-config name lookup, so losing Name() would make the
+	// lookup miss and silently skip the rule.
+	assert.Equal(t, "MDS001", clone.ID())
+	assert.Equal(t, "line-length", clone.Name())
+	cs, ok := clone.(*configurableStub)
+	require.True(t, ok, "expected *configurableStub, got %T", clone)
+	assert.Equal(t, 120, cs.Max, "CloneInstance must preserve current state, not reset to defaults")
+	assert.Equal(t, "custom", cs.Style)
+
+	cs.Max = 999
+	assert.Equal(t, 120, original.Max, "mutating clone affected original")
+}
+
+func TestCloneInstance_NonConfigurable_IndependentCopy(t *testing.T) {
+	original := &stubRule{id: "MDS999", name: "stub"}
+
+	clone := CloneInstance(original)
+
+	assert.NotSame(t, original, clone, "CloneInstance must return a new instance")
+	assert.Equal(t, "MDS999", clone.ID())
+	assert.Equal(t, "stub", clone.Name())
+}
+
 func TestCloneRule_ApplySettingsOnClone(t *testing.T) {
 	original := &configurableStub{id: "MDS001", name: "test", Max: 80, Style: "default"}
 

--- a/internal/rule/clone_test.go
+++ b/internal/rule/clone_test.go
@@ -103,6 +103,29 @@ func TestCloneInstance_NonConfigurable_IndependentCopy(t *testing.T) {
 	assert.Equal(t, "stub", clone.Name())
 }
 
+// valueRule satisfies Rule with value receivers, so an interface
+// holding it is not a pointer — exercising CloneInstance's value-type
+// branch (the interface already carries a copy).
+type valueRule struct {
+	id   string
+	name string
+}
+
+func (r valueRule) ID() string                           { return r.id }
+func (r valueRule) Name() string                         { return r.name }
+func (r valueRule) Category() string                     { return "test" }
+func (r valueRule) Check(_ *lint.File) []lint.Diagnostic { return nil }
+
+func TestCloneInstance_ValueType_ReturnsCopy(t *testing.T) {
+	var original Rule = valueRule{id: "MDS900", name: "value-rule"}
+
+	clone := CloneInstance(original)
+
+	require.IsType(t, valueRule{}, clone)
+	assert.Equal(t, "MDS900", clone.ID())
+	assert.Equal(t, "value-rule", clone.Name())
+}
+
 func TestCloneRule_ApplySettingsOnClone(t *testing.T) {
 	original := &configurableStub{id: "MDS001", name: "test", Max: 80, Style: "default"}
 

--- a/internal/rules/directorystructure/rule.go
+++ b/internal/rules/directorystructure/rule.go
@@ -63,12 +63,15 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// When configured but no allowed patterns provided, emit a config
 	// warning once per process. sync.Once survives the per-file cloning
 	// that the engine performs (CloneRule creates a fresh struct but
-	// the package-level configWarned is shared).
+	// the package-level configWarned is shared). Anchor it to RootDir,
+	// a per-run constant: under the parallel runner any worker can win
+	// the Once, so keying the diagnostic to the triggering file would
+	// make the sorted output nondeterministic across runs.
 	if len(r.Allowed) == 0 {
 		var diags []lint.Diagnostic
 		configWarned.Do(func() {
 			diags = []lint.Diagnostic{{
-				File:     f.Path,
+				File:     f.RootDir,
 				Line:     1,
 				Column:   1,
 				RuleID:   r.ID(),

--- a/internal/rules/directorystructure/rule_test.go
+++ b/internal/rules/directorystructure/rule_test.go
@@ -123,6 +123,26 @@ func TestCheck_EmptyAllowed_ClonedRuleWarnsOnce(t *testing.T) {
 	assert.Empty(t, diags2, "second clone should not repeat the warning")
 }
 
+// TestCheck_EmptyAllowed_WarningAnchoredToRootDir pins the config
+// warning to the per-run RootDir, not the file that happened to
+// trigger the sync.Once. Under the parallel runner any worker can win
+// that race; anchoring to a run-constant keeps the emitted diagnostic
+// (and therefore the sorted output) deterministic.
+func TestCheck_EmptyAllowed_WarningAnchoredToRootDir(t *testing.T) {
+	resetConfigWarned()
+	r := newRule(t, []string{})
+	f, err := lint.NewFile("docs/deep/guide.md", []byte("# T\n"))
+	require.NoError(t, err)
+	f.SetRootDir("/project/root")
+
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "expected the config warning")
+	assert.Contains(t, diags[0].Message, "no \"allowed\" patterns configured")
+	assert.Equal(t, "/project/root", diags[0].File,
+		"warning must anchor to RootDir, not the triggering file path")
+	assert.NotEqual(t, "docs/deep/guide.md", diags[0].File)
+}
+
 func TestCheck_MultiplePatterns(t *testing.T) {
 	r := newRule(t, []string{"docs/**", "plan/**", "."})
 	tests := []struct {

--- a/plan/184_release-benchmark-automation.md
+++ b/plan/184_release-benchmark-automation.md
@@ -16,19 +16,21 @@ summary: >-
 
 ## Goal
 
-The mdsmith-vs-Rust comparison
-([benchmark research doc](../docs/research/benchmarks/README.md))
-is a hand-refreshed artifact: `run.sh` installs the tools,
-runs hyperfine, promotes JSON, regenerates fragments. CI
-(`bench-fragments`) only checks the committed fragments
-match the committed JSON — it never re-measures. So the
-table drifts stale after every engine change (it is stale
-right now: it predates plan 175's single-core work *and*
-the Run parallelization).
+The mdsmith-vs-Rust comparison is a hand-refreshed
+artifact. See the
+[benchmark research doc](../docs/research/benchmarks/README.md).
+`run.sh` installs the tools, runs hyperfine, promotes
+JSON, and regenerates fragments by hand.
 
-Automate it the way `demo.gif` is automated: on merge to
-`main`, measure, and push the result to the orphan
-`assets` branch; the website pulls from there.
+CI (`bench-fragments`) only checks that the committed
+fragments match the committed JSON. It never re-measures.
+So the table goes stale after every engine change. It is
+stale now. It predates both plan 175's single-core work
+and the Run parallelization.
+
+Fix this the way `demo.gif` is built. On merge to `main`,
+measure. Push the result to the orphan `assets` branch.
+The website pulls from there.
 
 ## Background
 

--- a/plan/184_release-benchmark-automation.md
+++ b/plan/184_release-benchmark-automation.md
@@ -1,0 +1,111 @@
+---
+id: 184
+title: Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch
+status: "🔳"
+model: opus
+depends-on: []
+summary: >-
+  Fold docs/research/benchmarks/run.sh into a pinned,
+  integrity-verified `mdsmith-release bench` subcommand;
+  run it on every merge to main and publish the refreshed
+  JSON + fragments to the orphan `assets` branch (the
+  demo.gif pattern) so the website serves current
+  cross-tool numbers without a maintainer hand-refresh.
+---
+# Automate the cross-tool benchmark and publish to the assets branch
+
+## Goal
+
+The mdsmith-vs-Rust comparison
+([benchmark research doc](../docs/research/benchmarks/README.md))
+is a hand-refreshed artifact: `run.sh` installs the tools,
+runs hyperfine, promotes JSON, regenerates fragments. CI
+(`bench-fragments`) only checks the committed fragments
+match the committed JSON — it never re-measures. So the
+table drifts stale after every engine change (it is stale
+right now: it predates plan 175's single-core work *and*
+the Run parallelization).
+
+Automate it the way `demo.gif` is automated: on merge to
+`main`, measure, and push the result to the orphan
+`assets` branch; the website pulls from there.
+
+## Background
+
+- `demo.yml` → `record-demo.yml`: on `push: main` (skip the
+  bot to avoid loops) record the artifact, then a `publish`
+  job force-updates the orphan `assets` branch with only
+  that artifact, committing **only if it changed**.
+  `website/layouts/partials/hero.html` pulls
+  `raw.githubusercontent.com/<repo>/assets/assets/demo.gif`.
+- `docs/development/release-tooling.md`: workflow runtime
+  logic goes through `go run ./cmd/mdsmith-release <sub>`,
+  not inline scripts. So the harness becomes a subcommand.
+- `run.sh` already version-pins hyperfine/mado/panache via
+  release tarballs but **without checksums**; `rumdl`
+  (`uv tool install rumdl`) and `markdownlint-cli2`
+  (`npm i`) are unpinned entirely.
+
+## Decisions (locked)
+
+1. Trigger: on merge to `main`, publish to the existing
+   orphan `assets` branch under `assets/benchmarks/`
+   (reuse, don't proliferate branches). Record-only —
+   never gates a merge or a release.
+2. Harness lives in `mdsmith-release bench` (Go owns
+   install + integrity + hyperfine + promote + fragment
+   regen); `run.sh` becomes a thin wrapper that calls it
+   so local hand-refresh and CI run identical logic.
+3. Pin **version + integrity**: every tool fetch is a
+   pinned version verified by SHA-256; `markdownlint-cli2`
+   via a committed lockfile + `npm ci`.
+4. Lands on PR #330 (this branch).
+
+## Tasks
+
+1. [x] Create this plan.
+2. [ ] `internal/release` benchmark core + `mdsmith-release
+   bench` subcommand: pinned-tool manifest
+   `{tool,version,url,sha256}`, fail-loud SHA-256
+   verifier, corpus build, hyperfine orchestration, JSON
+   promote into `docs/research/benchmarks/data/`, fragment
+   regen via the existing `gen_fragments.py`. Unit-test
+   the pure parts (manifest invariants, verifier
+   ok/mismatch, promote copy/missing-source).
+3. [ ] Choose + pin `rumdl` and `markdownlint-cli2`
+   versions; record real SHA-256s for all five tools;
+   commit `markdownlint-cli2` lockfile, install via
+   `npm ci`.
+4. [ ] Rewrite `run.sh` as a wrapper over
+   `go run ./cmd/mdsmith-release bench` (no behaviour
+   change for the local hand-refresh; keeps the
+   `bench-fragments` drift gate intact).
+5. [ ] `benchmark.yml`: `push: main`, skip
+   `github-actions[bot]`; `record` runs the subcommand;
+   `publish` force-updates `assets` branch under
+   `assets/benchmarks/` (JSON + fragments), commit only
+   on change. Model on `demo.yml`.
+6. [ ] Website + docs: serve headline/results from the
+   `assets` branch like `demo.gif`; keep `bench-fragments`
+   coherent (it still validates committed fragments vs
+   committed JSON as the in-repo snapshot).
+7. [ ] Gates: `go build`, `go test ./...`,
+   `golangci-lint`, `mdsmith check .`. End-to-end
+   (`benchmark.yml`) is only exercisable on merge to main —
+   note this explicitly; it cannot be validated on the PR.
+
+## Acceptance Criteria
+
+- [ ] `mdsmith-release bench` reproduces the four
+      `data/*.json` files and the fragments byte-for-byte
+      vs the current `run.sh` on the same inputs.
+- [ ] A tampered download (wrong SHA-256) fails the run
+      loudly; covered by a unit test.
+- [ ] `run.sh` delegates to the subcommand and the
+      `bench-fragments` drift gate stays green.
+- [ ] `benchmark.yml` pushes to `assets/benchmarks/` only
+      when numbers change and never to `main`.
+- [ ] Website renders numbers fetched from the `assets`
+      branch.
+- [ ] `go test ./...`, `golangci-lint`, `mdsmith check .`
+      all pass.


### PR DESCRIPTION
## Summary

Implement concurrent file linting in the `Runner` with configurable worker count, ensuring deterministic output and thread-safe rule execution. Each worker gets its own rule instance clone to prevent state corruption from concurrent `Check` calls, and verbose logging is buffered per-file then merged in input order for deterministic `-v` output.

## Key Changes

- **Parallel execution**: Add `Runner.Concurrency` field to control worker count (0/negative = auto-detect via `GOMAXPROCS`, 1 = sequential, n>1 = n workers). Implement `ResolveWorkers()` to map the knob to actual worker count, clamped to file count.

- **Per-worker rule isolation**: Introduce `CloneInstance()` in `rule/clone.go` to create faithful shallow copies of rule instances that preserve identity and current state (unlike `CloneRule` which resets to defaults). Each worker clones the rule set once before processing files, preventing concurrent `Check` calls from corrupting shared mutable state.

- **Deterministic output**: Refactor `Run()` to collect per-file outcomes (diagnostics, errors, verbose logs) into a pre-sized, index-addressed slice. Merge results in input order before deduplication and sort, guaranteeing identical output regardless of worker scheduling.

- **Thread-safe verbose logging**: Add `sync.Mutex` to `Logger` to serialize concurrent `Printf` calls. When verbose mode is enabled, each worker logs to a per-file buffer instead of the shared logger; `Run()` flushes these buffers in input order so `-v` output is deterministic and never interleaved.

- **Thread-safe gitignore cache**: Guard `Runner.gitignoreCache` with `sync.Mutex` since workers reach it lazily during rule execution via the `GitignoreFunc` closure.

- **Refactored file processing**: Extract `lintFile()` to process a single file with a given rule set (worker's private clones), returning a `fileOutcome` struct. Move `markdownRules()` logic into `markdownRulesFrom()` so each worker filters its own rule clones. Split `logRules()` into `logRulesTo()` to support per-file buffered logging.

## Notable Implementation Details

- Work distribution uses an atomic counter for even load balancing across workers; no worker writes a slot another reads, so no lock is needed on the outcomes slice.

- The `fileOutcome` struct holds per-file diagnostics, errors, and verbose log bytes; `Run()` appends these in input order before final deduplication and sort.

- Verbose logging defers flushing the per-file buffer to the named return, ensuring it captures logs regardless of which early return fires (read error, parse error, etc.).

- `directorystructure` rule's config warning is anchored to `RootDir` (a per-run constant) instead of the triggering file, so the diagnostic is deterministic under parallel execution where any worker can win the `sync.Once` race.

- Added comprehensive tests: `TestRunner_ParallelEquivalenceFullRuleSet` verifies identical results across concurrency levels, `TestRunner_ParallelStatefulRuleIsolated` confirms per-worker isolation via a mock stateful rule, `TestRunner_ParallelVerboseLogIsOrdered` checks deterministic `-v` output, and `TestRunner_ParallelGitignoreCacheNoRace` exercises the shared cache under concurrent access.

- Logger concurrency test added to `log/logger_test.go` to verify serialization of concurrent writes.

https://claude.ai/code/session_012pboYfnxzyZQLHYE7VS4of