### PR TITLE
Restructure markdown-audit checks: split config-level from rule-backed

### DIFF
--- a/.claude/skills/markdown-audit/SKILL.md
+++ b/.claude/skills/markdown-audit/SKILL.md
@@ -109,12 +109,29 @@ command below.
 
 ### 3. Walk the checks
 
-Run the seven checks listed in `## Checks` in
-order. Each summary names the signal, the
-`<?directive?>` or `.mdsmith.yml` knob, and the
-fix recipe. When a sibling `patterns.md` is
-present (project install), read it once at the
-start for deeper heuristics and false positives.
+Load the rule-backed patterns once at the start,
+using the CLI detected in step 2:
+
+```bash
+mdsmith help patterns -f json
+```
+
+Each record is `{id, name, signal, fix,
+for-diagnostic}` for one of the five built-in
+rules that declare a maintainability pattern. Do
+not hard-code these signals or fixes; reading
+them here keeps the audit in sync as rules gain
+or change patterns.
+
+Read `patterns.md` for the three config-level
+checks. It carries their signal, heuristic, false
+positives, severity, and fix recipe. The project
+skill ships it as a sibling file; the marketplace
+plugin appends the same content to this SKILL.md
+under the `Detection patterns` heading at the
+end.
+
+Run all eight checks (see `## Checks`) in order.
 
 For each `<?directive?>` fix, read the rule's
 `pattern/bad/` and `pattern/good/` folders. They
@@ -175,31 +192,46 @@ retune rules the user has already chosen.
 
 ## Checks
 
-Each check has a one-line summary here.  When a
-sibling `patterns.md` is present, it carries the
-full signal, heuristic, false positives, and fix
-recipe per check.
+The audit runs eight checks from two sources.
+
+### Config-level checks
+
+No built-in rule backs these three. `patterns.md`
+(see step 3) carries the full signal, heuristic,
+false positives, severity, and fix recipe.
 
 1. **No `.mdsmith.yml`** — the repo has no
    config; propose `mdsmith init`.
-2. **Hand-maintained indexes** — a list of links
-   to sibling files that should be a
-   `<?catalog?>` directive.
-3. **Similar files, no kind** — a directory of
+2. **Similar files, no kind** — a directory of
    three or more `.md` files with shared front
    matter and no `kind-assignment:` entry.
-4. **Duplicated content** — near-identical
-   sections across files that should use
-   `<?include?>`.
-5. **Kind without `path-pattern`** — a kind whose
+3. **Kind without `path-pattern`** — a kind whose
    files share a naming shape, but the body
    declares no `path-pattern:`.
-6. **Kind without a schema** — a kind whose files
-   share a front matter shape, but the body
-   declares no `required-structure.schema:`.
-7. **File placement violation** — a `.md` file
-   in a directory the file-placement guide
-   rejects.
+
+### Rule-backed checks
+
+Five built-in rules each declare a
+maintainability pattern. `mdsmith help patterns`
+(step 3) supplies the signal and fix wording for
+each; treat that output as the source of truth.
+The list below only maps each rule to its
+check — new rule-backed patterns show up in the
+command output automatically.
+
+- `catalog` (MDS019) — a hand-maintained index
+  of sibling files that should be a `<?catalog?>`
+  directive.
+- `required-structure` (MDS020) — a kind whose
+  files share a shape but declare no
+  `required-structure.schema:`.
+- `include` (MDS021) — near-duplicate sections
+  that drift across files and should use
+  `<?include?>`.
+- `directory-structure` (MDS033) — a `.md` file
+  outside an allowed directory.
+- `duplicated-content` (MDS037) — repeated
+  paragraphs or sections with the same content.
 
 ## Severity
 
@@ -260,11 +292,12 @@ line to the report: `applied → path`.
   otherwise fail.
 - This skill ships in two places. The project
   copy at `.claude/skills/markdown-audit/` is the
-  canonical source and includes a sibling
-  `patterns.md` with deeper recipes; it is used by
-  mdsmith contributors on this repo. The
-  marketplace plugin `mdsmith-audit` mirrors the
-  SKILL body via `<?include?>` so end users get
-  the same workflow without the optional
-  reference. Edit this file and run `mdsmith fix`
-  to keep the plugin copy in sync.
+  canonical source for both the SKILL body and
+  `patterns.md`. The marketplace plugin
+  `mdsmith-audit` mirrors the SKILL body and
+  appends `patterns.md` via `<?include?>`, so end
+  users get the same workflow and config-level
+  recipes in a single file. Edit the canonical
+  `SKILL.md` or `patterns.md` and run
+  `mdsmith fix` to regenerate the plugin
+  SKILL.md.

--- a/.claude/skills/markdown-audit/patterns.md
+++ b/.claude/skills/markdown-audit/patterns.md
@@ -2,15 +2,24 @@
 title: Detection patterns
 summary: >-
   Detection heuristics, false positives, and fix
-  recipes for each of the seven checks the
-  `markdown-audit` skill runs.
+  recipes for the three config-level checks the
+  `markdown-audit` skill runs that no built-in
+  rule backs.
 ---
 # Detection patterns
 
-Each section covers one numbered check from the
-sibling `SKILL.md` workflow. Per check: the
-signal, the heuristic, false positives to skip,
-the severity bucket, and the fix recipe.
+These three checks have no backing rule, so their
+signal and fix live here rather than in a rule
+README. Each section covers one numbered
+config-level check from the sibling `SKILL.md`
+workflow: the signal, the heuristic, false
+positives to skip, the severity bucket, and the
+fix recipe.
+
+The other five checks live elsewhere. A built-in
+rule backs each one. Load its signal and fix from
+`mdsmith help patterns`. `SKILL.md` step 3 has
+the call.
 
 ## Check 1 — No `.mdsmith.yml`
 
@@ -25,53 +34,10 @@ Severity: blocker when the repo has five or more
 `.md` files. Nice-to-have otherwise.
 
 Fix: run `mdsmith init` to create a default
-config. Then walk checks 2 through 7 to populate
-kinds, overrides, and assignments.
+config. Then walk the remaining audit checks to
+populate kinds, overrides, and assignments.
 
-## Check 2 — Hand-maintained indexes
-
-Signal: a `.md` file lists links to sibling files
-that follow a pattern. Examples include an index of
-every plan in `plan/`, every rule in
-`internal/rules/`, every guide in `docs/guides/`.
-
-Heuristic: walk every `.md` file
-(`git ls-files '*.md'`). In each file, scan for a
-contiguous block of three or more bullet-list lines
-whose only content is a Markdown link
-(`grep -n '^[[:space:]]*- \[' <file>`). The block
-is a candidate when the linked paths share a
-directory prefix, the block is not already inside
-`<?catalog ... ?>` markers, and the linked files
-exist on disk.
-
-False positives:
-
-- Lists of two items. Too small to count as an
-  index.
-- Lists mixing repo paths and external links. A
-  catalog would lose the external links.
-- "See also" lists with hand-picked entries.
-  Sometimes the selection is the point.
-
-Severity: tax.
-
-Fix: use a `<?catalog?>` directive on the shared
-directory. Read the canonical before/after pair
-from the rule's own pattern folders:
-
-- before (hand-maintained list): `internal/rules/MDS019-catalog/pattern/bad/`
-- after (catalog directive): `internal/rules/MDS019-catalog/pattern/good/`
-
-These folders are the single source of truth. The
-rule's README `## Pattern` section pulls from
-them. A directive-rule integration test fails
-when they go missing.
-
-Run `mdsmith fix <file>` and confirm the same
-items reappear in the regenerated body.
-
-## Check 3 — Similar files, no kind
+## Check 2 — Similar files, no kind
 
 Signal: a directory holds three or more `.md`
 files with a similar front matter shape. The
@@ -119,45 +85,7 @@ right now. Do not over-engineer. After applying,
 run `mdsmith kinds resolve runbooks/example.md` to
 confirm the file picks up the new kind.
 
-## Check 4 — Duplicated content
-
-Signal: two or more files contain near-identical
-sections. One common case is a "Development"
-block copied between `README.md` and
-`docs/development/index.md`. Another is an
-"Install" block copied across plugin READMEs.
-
-Heuristic: hash every second-level section
-(`##`-bounded) in every `.md` file. A matching
-hash across files is a strong duplicate signal. A
-weaker signal is an identical first non-blank
-paragraph under a same-named heading.
-
-False positives:
-
-- Generated sections. A `<?catalog?>` body may
-  look identical across files by design.
-- Boilerplate (license footer, security contact)
-  too small to warrant an include.
-
-Severity: tax.
-
-Fix: extract the shared body into one canonical
-snippet. Replace each copy with `<?include?>`.
-Read the canonical before/after pair from the
-rule's own pattern folders:
-
-- before: `internal/rules/MDS021-include/pattern/bad/`
-  (section duplicated across two files)
-- after: `internal/rules/MDS021-include/pattern/good/`
-  (one snippet plus include directives)
-
-Use `heading-level: "absolute"` when the host file
-needs the included headings to nest under an
-existing heading. Run `mdsmith fix` and confirm
-both files regenerate the same body.
-
-## Check 5 — Kind without `path-pattern`
+## Check 3 — Kind without `path-pattern`
 
 Signal: a declared kind whose files share an
 obvious naming convention, but the kind body has
@@ -189,113 +117,3 @@ constraints, combine `path-pattern:` with a
 `<?require filename:?>` directive on the kind's
 schema. Re-run `mdsmith check .` to confirm no
 existing file fails the new pattern.
-
-## Check 6 — Kind without a schema
-
-Signal: a kind whose files share a front matter
-schema or top-level heading sequence, but the
-kind has no `required-structure.schema:`.
-
-Heuristic: walk the files of the kind. The kind is
-a candidate when 70% share the same required
-front matter keys. It is a strong candidate when
-70% also share the same top-level heading
-sequence.
-
-False positives: a kind with fewer than three
-files. Wait until there is enough shape to lock
-in.
-
-Severity: nice-to-have.
-
-Fix: pick the schema flavor that fits the kind,
-then wire it in `.mdsmith.yml`.
-
-Inline schema vs `proto.md` — when to use which:
-
-- Inline schema in `.mdsmith.yml` when the shape
-  is small (one or two required sections, no
-  nested headings) or the kind exists only in
-  this repo. One source file holds everything.
-- A `proto.md` file when the schema runs more
-  than a screen, the required sections nest, the
-  schema is shared across kinds via
-  `<?include?>`, or the prose around each
-  required field is itself useful documentation.
-  The proto file is itself a lintable Markdown
-  document.
-
-Both flavors satisfy `required-structure`. Do not
-mix the two for a single kind — pick one.
-
-The rule's example folder holds canonical samples
-of each flavor under
-`internal/rules/MDS020-required-structure/good/`.
-Read them before authoring:
-
-- `inline-flat.md` — inline schema with flat
-  required sections.
-- `inline-runbook.md` — inline schema with nested
-  sections and heading aliases.
-- `default.md` plus `data/tmpl.md` — proto file
-  referenced via the `schema:` setting.
-- `schema-compose.md` — proto file composed from
-  shared fragments via `<?include?>`.
-
-Wire-up for inline schema:
-
-```yaml
-kinds:
-  plan:
-    schema:
-      sections:
-        - heading: "Goal"
-          required: true
-        - heading: "Tasks"
-          required: true
-```
-
-Wire-up for proto.md:
-
-```yaml
-kinds:
-  plan:
-    rules:
-      required-structure:
-        schema: plan/proto.md
-```
-
-After wiring, run `mdsmith check .` and confirm
-every existing file passes. When a file fails,
-relax the schema — do not break the files.
-
-## Check 7 — File placement violation
-
-Signal: a `.md` file lives in a directory the
-repo's file-placement guide rejects.
-
-Heuristic: when the repo has
-`docs/development/file-placement.md`, read its
-decision list — that is the source of truth.
-Otherwise fall back to the mdsmith default
-layout: repo root well-known files, `plan/`,
-`docs/`, `internal/`, `.claude/skills/`,
-`.github/`, and `editors/`.
-
-False positives:
-
-- A monorepo subpackage with its own `README.md`
-  or `CHANGELOG.md`.
-- A file the user listed under `ignore:` on
-  purpose.
-
-Severity: tax when the misplaced file hurts
-navigation. Nice-to-have otherwise.
-
-Fix: move the file to the directory the guide
-points to. Cross-references update automatically
-when `mdsmith fix .` runs — the
-`cross-file-reference-integrity` rule rewrites
-links to the moved file. After moving, run
-`mdsmith kinds resolve <new-path>` to confirm the
-file picks up the right kind at its new home.

--- a/PLAN.md
+++ b/PLAN.md
@@ -87,7 +87,7 @@ footer: |
 | 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                 |
 | 157 | ✅     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                               |
 | 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                      |
-| 161 | 🔳     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |
+| 161 | ✅     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                            |
 | 162 | ✅     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                            |
 | 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                      |
 | 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)               |

--- a/editors/claude-code-audit/skills/markdown-audit/SKILL.md
+++ b/editors/claude-code-audit/skills/markdown-audit/SKILL.md
@@ -113,12 +113,29 @@ command below.
 
 ### 3. Walk the checks
 
-Run the seven checks listed in `## Checks` in
-order. Each summary names the signal, the
-`<?directive?>` or `.mdsmith.yml` knob, and the
-fix recipe. When a sibling `patterns.md` is
-present (project install), read it once at the
-start for deeper heuristics and false positives.
+Load the rule-backed patterns once at the start,
+using the CLI detected in step 2:
+
+```bash
+mdsmith help patterns -f json
+```
+
+Each record is `{id, name, signal, fix,
+for-diagnostic}` for one of the five built-in
+rules that declare a maintainability pattern. Do
+not hard-code these signals or fixes; reading
+them here keeps the audit in sync as rules gain
+or change patterns.
+
+Read `patterns.md` for the three config-level
+checks. It carries their signal, heuristic, false
+positives, severity, and fix recipe. The project
+skill ships it as a sibling file; the marketplace
+plugin appends the same content to this SKILL.md
+under the `Detection patterns` heading at the
+end.
+
+Run all eight checks (see `## Checks`) in order.
 
 For each `<?directive?>` fix, read the rule's
 `pattern/bad/` and `pattern/good/` folders. They
@@ -180,31 +197,46 @@ retune rules the user has already chosen.
 
 ## Checks
 
-Each check has a one-line summary here.  When a
-sibling `patterns.md` is present, it carries the
-full signal, heuristic, false positives, and fix
-recipe per check.
+The audit runs eight checks from two sources.
+
+### Config-level checks
+
+No built-in rule backs these three. `patterns.md`
+(see step 3) carries the full signal, heuristic,
+false positives, severity, and fix recipe.
 
 1. **No `.mdsmith.yml`** — the repo has no
    config; propose `mdsmith init`.
-2. **Hand-maintained indexes** — a list of links
-   to sibling files that should be a
-   `<?catalog?>` directive.
-3. **Similar files, no kind** — a directory of
+2. **Similar files, no kind** — a directory of
    three or more `.md` files with shared front
    matter and no `kind-assignment:` entry.
-4. **Duplicated content** — near-identical
-   sections across files that should use
-   `<?include?>`.
-5. **Kind without `path-pattern`** — a kind whose
+3. **Kind without `path-pattern`** — a kind whose
    files share a naming shape, but the body
    declares no `path-pattern:`.
-6. **Kind without a schema** — a kind whose files
-   share a front matter shape, but the body
-   declares no `required-structure.schema:`.
-7. **File placement violation** — a `.md` file
-   in a directory the file-placement guide
-   rejects.
+
+### Rule-backed checks
+
+Five built-in rules each declare a
+maintainability pattern. `mdsmith help patterns`
+(step 3) supplies the signal and fix wording for
+each; treat that output as the source of truth.
+The list below only maps each rule to its
+check — new rule-backed patterns show up in the
+command output automatically.
+
+- `catalog` (MDS019) — a hand-maintained index
+  of sibling files that should be a `<?catalog?>`
+  directive.
+- `required-structure` (MDS020) — a kind whose
+  files share a shape but declare no
+  `required-structure.schema:`.
+- `include` (MDS021) — near-duplicate sections
+  that drift across files and should use
+  `<?include?>`.
+- `directory-structure` (MDS033) — a `.md` file
+  outside an allowed directory.
+- `duplicated-content` (MDS037) — repeated
+  paragraphs or sections with the same content.
 
 ## Severity
 
@@ -265,12 +297,130 @@ line to the report: `applied → path`.
   otherwise fail.
 - This skill ships in two places. The project
   copy at `.claude/skills/markdown-audit/` is the
-  canonical source and includes a sibling
-  `patterns.md` with deeper recipes; it is used by
-  mdsmith contributors on this repo. The
-  marketplace plugin `mdsmith-audit` mirrors the
-  SKILL body via `<?include?>` so end users get
-  the same workflow without the optional
-  reference. Edit this file and run `mdsmith fix`
-  to keep the plugin copy in sync.
+  canonical source for both the SKILL body and
+  `patterns.md`. The marketplace plugin
+  `mdsmith-audit` mirrors the SKILL body and
+  appends `patterns.md` via `<?include?>`, so end
+  users get the same workflow and config-level
+  recipes in a single file. Edit the canonical
+  `SKILL.md` or `patterns.md` and run
+  `mdsmith fix` to regenerate the plugin
+  SKILL.md.
+<?/include?>
+
+<?include
+file: ../../../../.claude/skills/markdown-audit/patterns.md
+strip-frontmatter: "true"
+?>
+# Detection patterns
+
+These three checks have no backing rule, so their
+signal and fix live here rather than in a rule
+README. Each section covers one numbered
+config-level check from the sibling `SKILL.md`
+workflow: the signal, the heuristic, false
+positives to skip, the severity bucket, and the
+fix recipe.
+
+The other five checks live elsewhere. A built-in
+rule backs each one. Load its signal and fix from
+`mdsmith help patterns`. `SKILL.md` step 3 has
+the call.
+
+## Check 1 — No `.mdsmith.yml`
+
+Signal: `.mdsmith.yml` does not exist at the repo
+root (`test -f .mdsmith.yml`).
+
+False positives: a repo with one or two top-level
+Markdown files and nothing else. Skip with a
+one-line note.
+
+Severity: blocker when the repo has five or more
+`.md` files. Nice-to-have otherwise.
+
+Fix: run `mdsmith init` to create a default
+config. Then walk the remaining audit checks to
+populate kinds, overrides, and assignments.
+
+## Check 2 — Similar files, no kind
+
+Signal: a directory holds three or more `.md`
+files with a similar front matter shape. The
+files share the same required keys. No
+`kind-assignment:` entry covers the directory.
+
+Heuristic: list directories with three or more
+`.md` files
+(`git ls-files '*.md' | xargs -n1 dirname | sort | uniq -c`).
+For each candidate, sample every file's front
+matter. The directory is a kind candidate when 70%
+of files share the same key set, and no glob in
+`.mdsmith.yml` already covers it.
+
+False positives:
+
+- A directory of one-off Markdown without shared
+  front matter (research spikes, ad-hoc notes).
+- A directory already covered by a glob in
+  `kind-assignment:`, even when the kind body is
+  empty. The assignment alone counts.
+- Bad fixtures inside `internal/rules/*/bad/`,
+  intentionally malformed and under `ignore:`.
+
+Severity: tax. Drop to nice-to-have when the
+shared shape is small.
+
+Fix: add an entry to `kinds:` plus a matching
+`kind-assignment:` glob.
+
+```yaml
+kinds:
+  runbook:
+    rules:
+      max-file-length:
+        max: 400
+
+kind-assignment:
+  - glob: ["runbooks/*.md"]
+    kinds: [runbook]
+```
+
+Start with the settings the files actually share
+right now. Do not over-engineer. After applying,
+run `mdsmith kinds resolve runbooks/example.md` to
+confirm the file picks up the new kind.
+
+## Check 3 — Kind without `path-pattern`
+
+Signal: a declared kind whose files share an
+obvious naming convention, but the kind body has
+no `path-pattern:`.
+
+Heuristic: read `kinds:` and `kind-assignment:`
+from `.mdsmith.yml`. For each kind, walk the files
+that resolve to it. The kind is a candidate when
+80% of those files share a regex-shaped filename.
+Examples: `\d+_[a-z-]+\.md`, `RFC-\d{4}\.md`.
+
+False positives: a kind with intentionally
+heterogeneous membership — a "doc" kind covering
+README, index, and topic pages qualifies.
+
+Severity: nice-to-have.
+
+Fix: add `path-pattern:` to the kind body.
+
+```yaml
+kinds:
+  plan:
+    path-pattern: "plan/[0-9][0-9]*_*.md"
+```
+
+Glob syntax has no "exactly digits" class, so the
+pattern is an approximation. For tighter
+constraints, combine `path-pattern:` with a
+`<?require filename:?>` directive on the kind's
+schema. Re-run `mdsmith check .` to confirm no
+existing file fails the new pattern.
 <?/include?>

--- a/plan/161_rule-pattern-metadata.md
+++ b/plan/161_rule-pattern-metadata.md
@@ -1,7 +1,7 @@
 ---
 id: 161
 title: Expose rule maintainability patterns via CLI help and LSP
-status: "🔳"
+status: "✅"
 model: sonnet
 depends-on: []
 summary: >-
@@ -303,13 +303,13 @@ automatically.
       and
       [`docs/reference/cli/lsp.md`](../docs/reference/cli/lsp.md)
       document the new topic and LSP method.
-- [ ] Both the local `markdown-audit` skill
+- [x] Both the local `markdown-audit` skill
       and the installed `mdsmith-audit` plugin
       surface all five rule-backed patterns
       (from `mdsmith help patterns`) plus the
-      three trimmed config-level checks. Deferred
-      to a follow-up; this PR ships the data
-      source the skill consumes.
+      three trimmed config-level checks (sibling
+      `patterns.md` locally; inlined into the
+      plugin SKILL.md via `<?include?>`).
 - [x] `go test ./...` passes.
 - [x] `mdsmith check .` passes.
 


### PR DESCRIPTION
## Summary

Restructure the `markdown-audit` skill to clearly separate the three config-level checks (which have no backing rule) from five rule-backed checks (which are surfaced via `mdsmith help patterns`). This makes the audit maintainable as rule patterns evolve and clarifies which checks live where.

## Key Changes

- **Refactored check inventory**: Reduced the documented checks from 7 to 3 config-level checks in `patterns.md` and `SKILL.md`. The other 5 checks are now sourced dynamically from `mdsmith help patterns -f json` at audit time.

- **Updated `patterns.md`**: Removed detailed sections for checks 2, 4, 6, and 7 (now rule-backed: `catalog`, `include`, `required-structure`, `directory-structure`, `duplicated-content`). Kept only the three config-level checks (No `.mdsmith.yml`, Similar files no kind, Kind without `path-pattern`).

- **Updated `SKILL.md` (both copies)**: 
  - Step 3 now instructs auditors to load rule-backed patterns via `mdsmith help patterns -f json` at the start.
  - The `## Checks` section now splits into "Config-level checks" (3 items) and "Rule-backed checks" (5 items mapped to their rule IDs).
  - Clarified that rule signals and fixes are sourced from the CLI, not hard-coded, so the audit stays in sync as rules change.

- **Plugin integration**: The marketplace `mdsmith-audit` plugin now appends `patterns.md` content via `<?include?>` into its SKILL.md, so end users get both the workflow and config-level recipes in one file.

- **Plan status**: Marked plan 161 as complete (✅) since both the local skill and plugin now surface all five rule-backed patterns plus the three config-level checks.

## Implementation Details

- The three config-level checks remain in `patterns.md` because they are not backed by built-in rules and require custom heuristics and fix recipes specific to the audit workflow.
- Rule-backed checks are now sourced dynamically via CLI, eliminating the need to maintain their descriptions in two places and ensuring the audit automatically picks up new patterns as rules are added or modified.
- The canonical source is the project copy at `.claude/skills/markdown-audit/`; the plugin mirrors it via `<?include?>` directives.

https://claude.ai/code/session_017hdEbKFPJH66sLTrTw87WE