### PR TITLE
Automate cross-tool benchmark on merge to main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,119 @@
+name: Cross-tool benchmark
+
+# Re-measure the mdsmith-vs-Rust benchmark on every merge to
+# main and publish the refreshed numbers to the orphan `assets`
+# branch (the demo.gif pattern). Record-only: it never gates a
+# merge or a release. The website pulls these numbers at
+# build time; the in-repo committed snapshot stays the
+# `bench-fragments` CI gate's source of truth and is unaffected
+# by this workflow.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  record:
+    # Skip if the push was made by the CI bot. The publish job
+    # pushes to the assets branch (never main), so this is parity
+    # with demo.yml rather than loop-prevention.
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      artifact_name: benchmark-numbers
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # markdownlint-cli2 installs via `npm ci` from the
+          # committed docs/research/benchmarks/npm/ lockfile.
+          node-version: "24"
+      - name: Run the pinned cross-tool benchmark
+        # Builds mdsmith, fetches + SHA-256-verifies
+        # hyperfine/mado/panache/rumdl, `npm ci`s
+        # markdownlint-cli2, builds the corpora, drives
+        # hyperfine, promotes the JSON into
+        # docs/research/benchmarks/data/, and regenerates the
+        # fragments via gen_fragments.py. Single source of truth
+        # with the local run.sh hand-refresh.
+        run: go run ./cmd/mdsmith-release bench /tmp/mdsmith-bench
+      - name: Normalize fragments to the gate's canonical form
+        # `mdsmith fix` normalizes the gen_fragments.py tables to
+        # the exact form the `bench-fragments` gate regenerates,
+        # so the published fragment is byte-identical to what the
+        # in-repo snapshot would become from the same JSON.
+        run: |
+          go run ./cmd/mdsmith fix \
+            docs/research/benchmarks/results.fragment.md \
+            docs/research/benchmarks/headline.fragment.md
+      - name: Stage publishable numbers
+        run: |
+          mkdir -p artifacts/benchmarks/data
+          cp docs/research/benchmarks/results.fragment.md \
+             docs/research/benchmarks/headline.fragment.md \
+             artifacts/benchmarks/
+          cp docs/research/benchmarks/data/*.json artifacts/benchmarks/data/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-numbers
+          path: artifacts/benchmarks
+          retention-days: 7
+          if-no-files-found: error
+
+  publish:
+    needs: record
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Credentials intentionally persisted — needed for git push.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.record.outputs.artifact_name }}
+          path: /tmp/bench
+      - name: Publish numbers to the assets branch
+        run: |
+          # Update ONLY assets/benchmarks/ on the shared orphan
+          # assets branch. demo.yml manages assets/demo.gif on the
+          # same branch, so neither workflow may wipe the whole
+          # tree — each touches only its own subtree and commits
+          # only when its subtree changed.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then
+            git fetch origin assets
+            git checkout assets
+          else
+            # First ever publish: unborn branch, no siblings yet.
+            git checkout --orphan assets
+            git rm -r --cached . >/dev/null 2>&1 || true
+          fi
+
+          # Replace only the benchmarks subtree. assets/demo.gif
+          # (if present) is left exactly as demo.yml wrote it.
+          rm -rf assets/benchmarks
+          mkdir -p assets/benchmarks
+          cp -R /tmp/bench/. assets/benchmarks/
+
+          git add assets/benchmarks
+          if git diff --staged --quiet; then
+            echo "benchmark numbers unchanged — nothing to push"
+          else
+            git commit -m "chore: refresh cross-tool benchmark numbers"
+            git push -u origin assets
+          fi

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -31,9 +31,15 @@ jobs:
           path: /tmp/demo
       - name: Push GIF to assets branch
         run: |
-          # Create or update the orphan assets branch with only
-          # the demo GIF. This avoids pushing to main entirely —
-          # no branch protection bypass needed.
+          # Update ONLY assets/demo.gif on the shared orphan
+          # assets branch. benchmark.yml manages
+          # assets/benchmarks/ on the same branch, so neither
+          # workflow may wipe the whole tree (the old
+          # `git rm -rf . && git clean -fdx` did, and would
+          # delete the other's subtree on every run). Each
+          # touches only its own subtree and pushes only when
+          # that subtree changed. Pushing to the assets branch
+          # avoids main entirely — no branch protection bypass.
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -41,12 +47,10 @@ jobs:
           if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then
             git fetch origin assets
             git checkout assets
-            git rm -rf --ignore-unmatch .
-            git clean -fdx
           else
+            # First ever publish: unborn branch, no siblings yet.
             git checkout --orphan assets
-            git rm -rf --ignore-unmatch .
-            git clean -fdx
+            git rm -r --cached . >/dev/null 2>&1 || true
           fi
 
           mkdir -p assets

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -108,6 +108,25 @@ jobs:
         # resolved version, so the deployed site shows it.
         if: env.SITE_VERSION != ''
         run: go run ./cmd/mdsmith-release stamp "$SITE_VERSION"
+      - name: Pull published demo + benchmark numbers
+        # The demo GIF and the cross-tool benchmark numbers are
+        # regenerated post-merge and pushed to the orphan assets
+        # branch (.github/workflows/{demo,benchmark}.yml), never
+        # committed. Pull them in so the deployed site serves the
+        # current GIF as a first-party asset and bakes the live
+        # benchmark table into the comparison page. The committed
+        # fragment snapshot is the fallback while the assets
+        # branch has not published numbers yet; the
+        # `bench-fragments` gate (a separate workflow) still
+        # validates that committed snapshot. The scoped
+        # `mdsmith fix` refreshes only the one page's <?include?>
+        # body from the freshly pulled fragment — the intended,
+        # minimal exception to build-website's --no-fix. See
+        # docs/development/release-tooling.md for why the pull is
+        # a Go subcommand rather than inline shell.
+        run: |
+          go run ./cmd/mdsmith-release pull-site-assets
+          go run ./cmd/mdsmith fix docs/background/markdown-linters.md
       - name: Build Hugo content tree from docs
         # Snapshot ./docs into ./website/content/docs, dropping
         # proto.md schema templates, renaming index.md to

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ unit.cov
 merged.cov
 .github/scripts/node_modules/
 .claude/worktrees/
+# Pulled from the orphan assets branch at site-build time by
+# mdsmith-release pull-site-assets; never committed.
+website/static/img/demo.gif

--- a/PLAN.md
+++ b/PLAN.md
@@ -110,5 +110,5 @@ footer: |
 | 181 | 🔲     | opus   | [Table structure rules](plan/181_table-structure.md)                                                                                    |
 | 182 | 🔲     | sonnet | [Code block convention rules](plan/182_code-block-conventions.md)                                                                       |
 | 183 | 🔲     | sonnet | [Skip DedupeDiagnostics via an audited rule.RepoScoped marker](plan/183_dedupe-diagnostics-repo-scoped-skip.md)                         |
-| 184 | 🔳     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
+| 184 | ✅     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 <?/catalog?>

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -18,6 +18,8 @@
 //	mdsmith-release check-secret-rotations
 //	mdsmith-release record-rotation <ENTRY_TITLE> <YYYY-MM-DD>
 //	mdsmith-release merge-coverage -o <out> <profile>...
+//	mdsmith-release bench [workdir]
+//	mdsmith-release pull-site-assets
 //
 // Each subcommand operates relative to the current working
 // directory, which is the repo root in CI.
@@ -51,6 +53,8 @@ Commands:
   check-secret-rotations          Open GitHub issues for secrets due for rotation.
   record-rotation <title> <date>  Update lastRotated in a per-secret rotation file.
   merge-coverage -o <out> <p>...  Merge coverage profiles by summing hit counts.
+  bench [workdir]                 Run the pinned cross-tool benchmark; promote JSON + fragments.
+  pull-site-assets                Fetch the published demo GIF + benchmark numbers for the site build.
 `
 
 func main() {
@@ -68,6 +72,13 @@ func run(args []string) int {
 		return 1
 	}
 	cmd, rest := args[0], args[1:]
+	return dispatch(cmd, root, rest)
+}
+
+// dispatch routes one subcommand to its runner. Split out of run
+// so each is a short, single-purpose function (run owns argv/cwd
+// preconditions; dispatch owns the command table).
+func dispatch(cmd, root string, rest []string) int {
 	switch cmd {
 	case "-h", "--help", "help":
 		fmt.Print(usageText)
@@ -94,6 +105,10 @@ func run(args []string) int {
 		return runRecordRotation(root, rest)
 	case "merge-coverage":
 		return runMergeCoverage(root, rest)
+	case "bench":
+		return runBench(root, rest)
+	case "pull-site-assets":
+		return runPullSiteAssets(root, rest)
 	default:
 		fmt.Fprintf(os.Stderr, "mdsmith-release: unknown command %q\n%s", cmd, usageText)
 		return 2
@@ -376,6 +391,59 @@ func runRecordRotation(root string, args []string) int {
 	}
 	fmt.Printf("updated %s lastRotated -> %s\n", entryTitle, date)
 	return 0
+}
+
+func runBench(root string, args []string) int {
+	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mdsmith-release bench [workdir]\n\n"+
+			"Run the pinned, integrity-verified cross-tool Markdown\n"+
+			"linter benchmark from the repo root: build mdsmith,\n"+
+			"fetch + SHA-256-verify hyperfine/mado/panache/rumdl,\n"+
+			"`npm ci` markdownlint-cli2 from the committed lockfile,\n"+
+			"build the repo + neutral corpora, drive hyperfine,\n"+
+			"promote the JSON into "+"docs/research/benchmarks/data/,\n"+
+			"and regenerate the doc fragments via gen_fragments.py.\n"+
+			"workdir caches built/fetched binaries and the corpora\n"+
+			"(default "+"/tmp/mdsmith-bench); CI passes a fresh path.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: bench"); code >= 0 {
+			return code
+		}
+	}
+	if fs.NArg() > 1 {
+		fs.Usage()
+		return 2
+	}
+	workdir := ""
+	if fs.NArg() == 1 {
+		workdir = fs.Arg(0)
+	}
+	return reportError(release.Bench(root, workdir))
+}
+
+func runPullSiteAssets(root string, args []string) int {
+	fs := flag.NewFlagSet("pull-site-assets", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mdsmith-release pull-site-assets\n\n"+
+			"Fetch the published demo GIF and cross-tool benchmark\n"+
+			"numbers from the orphan `assets` branch into the working\n"+
+			"tree before the Hugo build. The demo GIF is required;\n"+
+			"the benchmark fragments fall back to the committed\n"+
+			"in-repo snapshot when the assets branch has not yet\n"+
+			"published them. Run from the repo root.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: pull-site-assets"); code >= 0 {
+			return code
+		}
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	return reportError(release.PullSiteAssets(root))
 }
 
 func reportError(err error) int {

--- a/docs/development/release-tooling.md
+++ b/docs/development/release-tooling.md
@@ -59,6 +59,8 @@ setup step.
 | `check-secret-rotations`    | `secret-rotation-reminder.yml`             |
 | `record-rotation <t> <d>`   | `record-secret-rotation.yml`               |
 | `merge-coverage -o <o> <p>` | `ci.yml` test job                          |
+| `bench [workdir]`           | `benchmark.yml` record job; `run.sh`       |
+| `pull-site-assets`          | `pages.yml` deploy job                     |
 
 Each subcommand lives under `cmd/mdsmith-release/`.
 It delegates to a function in `internal/release/`.

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -8,7 +8,13 @@ summary: >-
 # Markdown linter benchmark
 
 Our own benchmark run, not a re-quote of each project's README.
-Reproduce it with [`run.sh`](run.sh).
+Reproduce it with [`run.sh`](run.sh), a thin wrapper over
+`mdsmith-release bench`. The same harness runs automatically on
+every merge to `main` and publishes the refreshed numbers to the
+orphan `assets` branch; the website reads them at build time
+(the demo.gif pattern). The committed `data/*.json` snapshot in
+this directory stays the `bench-fragments` gate's source of
+truth and is what the tables below render from in-repo.
 
 ## Method
 
@@ -29,6 +35,13 @@ Reproduce it with [`run.sh`](run.sh).
   (it does more per file); `mdsmith-parity` vs them is the
   closest like-for-like, with one residual asymmetry noted
   in [Reading the result](#reading-the-result).
+- Integrity: every comparison binary is fetched at a pinned
+  version and verified by SHA-256 before it runs.
+  hyperfine, mado, panache, and rumdl come from pinned
+  GitHub release tarballs (rumdl moved off an unpinned
+  `uv tool install`); markdownlint-cli2 installs via
+  `npm ci` from the committed lockfile in `npm/`. A
+  tampered or silently-rebuilt download fails the run loud.
 
 ### Corpora
 

--- a/docs/research/benchmarks/npm/package-lock.json
+++ b/docs/research/benchmarks/npm/package-lock.json
@@ -1,0 +1,1252 @@
+{
+  "name": "mdsmith-benchmark-markdownlint",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mdsmith-benchmark-markdownlint",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "markdownlint-cli2": "0.22.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
+      "license": "MIT",
+      "dependencies": {
+        "globby": "16.2.0",
+        "js-yaml": "4.1.1",
+        "jsonc-parser": "3.3.1",
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.1.1",
+        "markdownlint": "0.40.0",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.6.1"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      },
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/docs/research/benchmarks/npm/package.json
+++ b/docs/research/benchmarks/npm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mdsmith-benchmark-markdownlint",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned markdownlint-cli2 for the mdsmith cross-tool benchmark (npm ci from this lockfile keeps the comparison reproducible).",
+  "license": "MIT",
+  "dependencies": {
+    "markdownlint-cli2": "0.22.1"
+  }
+}

--- a/docs/research/benchmarks/run.sh
+++ b/docs/research/benchmarks/run.sh
@@ -1,105 +1,28 @@
 #!/usr/bin/env bash
 # Reproducible cross-tool Markdown-linter benchmark.
 #
-# Builds a clean corpus, installs the comparison tools at pinned
-# versions, and runs hyperfine over each tool's default check/lint
-# command. Results land in $OUT (JSON + Markdown).
+# Thin wrapper over `mdsmith-release bench`. The harness logic
+# (build mdsmith, fetch + SHA-256-verify the pinned comparison
+# binaries, `npm ci` markdownlint-cli2 from the committed
+# lockfile, build the corpora, drive hyperfine, promote the JSON
+# into data/, regenerate the fragments via gen_fragments.py) now
+# lives in Go so the local hand-refresh and the post-merge
+# benchmark.yml workflow run byte-identical logic — see
+# docs/development/release-tooling.md and
+# internal/release/bench.go.
 #
 # Usage:  docs/research/benchmarks/run.sh [workdir]
 #
-# Requires network on first run (downloads prebuilt binaries and
-# the rumdl/markdownlint packages). Go and a C-free toolchain are
-# enough to build mdsmith; everything else ships as a prebuilt
-# binary so no Rust/Node compile is needed.
+# Requires network on first run (downloads the pinned tool
+# tarballs and the npm tree) plus a Go toolchain, python3, npm,
+# and git on PATH. workdir caches built/fetched binaries and the
+# corpora (default /tmp/mdsmith-bench) so a rerun is cheap.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WORK="${1:-/tmp/mdsmith-bench}"
-BIN="$WORK/bin"
-OUT="$WORK/out"
-mkdir -p "$BIN" "$OUT"
-export PATH="$BIN:$HOME/.local/bin:$WORK/npm/node_modules/.bin:$PATH"
 
-HYPERFINE_VER="v1.20.0"
-MADO_VER="v0.3.0"
-PANACHE_VER="v2.46.0"
+cd "$REPO_ROOT"
+go run ./cmd/mdsmith-release bench "$WORK"
 
-# --- tools -----------------------------------------------------------------
-[ -x "$BIN/mdsmith" ] || ( cd "$REPO_ROOT" && go build -o "$BIN/mdsmith" ./cmd/mdsmith )
-
-if [ ! -x "$BIN/hyperfine" ]; then
-  curl -sSL \
-    "https://github.com/sharkdp/hyperfine/releases/download/$HYPERFINE_VER/hyperfine-$HYPERFINE_VER-x86_64-unknown-linux-musl.tar.gz" \
-    | tar xz -C "$WORK"
-  cp "$WORK"/hyperfine-*/hyperfine "$BIN/"
-fi
-
-[ -x "$BIN/mado" ] || curl -sSL \
-  "https://github.com/akiomik/mado/releases/download/$MADO_VER/mado-Linux-gnu-x86_64.tar.gz" \
-  | tar xz -C "$BIN/"
-
-[ -x "$BIN/panache" ] || { curl -sSL \
-  "https://github.com/jolars/panache/releases/download/$PANACHE_VER/panache-x86_64-unknown-linux-gnu.tar.gz" \
-  | tar xz -C "$WORK"; find "$WORK" -maxdepth 2 -name panache -type f -exec cp {} "$BIN/" \; ; }
-
-command -v rumdl >/dev/null || uv tool install rumdl
-[ -x "$WORK/npm/node_modules/.bin/markdownlint-cli2" ] || npm i --prefix "$WORK/npm" markdownlint-cli2
-
-# --- corpora ---------------------------------------------------------------
-# A: this repository's own Markdown (drop generated/bad fixtures).
-if [ ! -d "$WORK/corpus_repo" ]; then
-  mkdir -p "$WORK/corpus_repo"
-  ( cd "$REPO_ROOT" && git ls-files '*.md' '*.markdown' \
-      | grep -vE '^(demo/|internal/rules/[^/]*/bad/)' \
-      | tar cf - -T - ) | tar xf - -C "$WORK/corpus_repo"
-fi
-# B: neutral third-party prose (Rust Book + Rust Reference).
-if [ ! -d "$WORK/corpus_neutral" ]; then
-  git clone --depth 1 -q https://github.com/rust-lang/book.git "$WORK/rust-book"
-  git clone --depth 1 -q https://github.com/rust-lang/reference.git "$WORK/rust-ref"
-  mkdir -p "$WORK/corpus_neutral"
-  find "$WORK/rust-book/src" "$WORK/rust-ref/src" -name '*.md' -print0 \
-    | tar --null -cf - -T - | tar xf - -C "$WORK/corpus_neutral"
-fi
-
-# --- benchmark -------------------------------------------------------------
-# mdsmith        — default rule set (what users actually run; the
-#                  cross-file / readability / generated layer is on).
-# mdsmith-parity — only the structural rules that have a markdownlint
-#                  analog, so the work class matches mado / rumdl /
-#                  markdownlint. See bench-parity.mdsmith.yml.
-PARITY="$REPO_ROOT/docs/research/benchmarks/bench-parity.mdsmith.yml"
-for corpus in corpus_repo corpus_neutral; do
-  hyperfine -i --warmup 3 --runs 10 -N \
-    --command-name "mado"    "mado check $WORK/$corpus" \
-    --command-name "rumdl"   "rumdl check --no-cache $WORK/$corpus" \
-    --command-name "panache" "panache lint --no-cache $WORK/$corpus" \
-    --command-name "mdsmith-parity" "mdsmith check -c $PARITY $WORK/$corpus" \
-    --command-name "mdsmith" "mdsmith check $WORK/$corpus" \
-    --export-json "$OUT/$corpus.json" \
-    --export-markdown "$OUT/$corpus.md"
-  hyperfine -i --warmup 2 --runs 6 -N \
-    --command-name "markdownlint-cli2" "markdownlint-cli2 '$WORK/$corpus/**/*.md'" \
-    --export-json "$OUT/${corpus}_mdl.json"
-done
-
-echo "Results written to $OUT"
-
-# --- promote results to the committed source of truth ---------------------
-# The fragments are derived from these JSON files, and the
-# `bench-fragments` CI gate regenerates from the *committed* copies
-# and fails on any diff. So a fresh run must update them here.
-DATA_DIR="$REPO_ROOT/docs/research/benchmarks/data"
-mkdir -p "$DATA_DIR"
-for j in corpus_repo corpus_repo_mdl corpus_neutral corpus_neutral_mdl; do
-  cp "$OUT/$j.json" "$DATA_DIR/$j.json"
-done
-
-# --- regenerate the doc fragments ------------------------------------------
-# Single generator, shared with the CI drift gate. The docs do not
-# hand-type numbers; they <?include?> these fragments. Run
-# `mdsmith fix` afterwards so the include bodies in README /
-# comparison / research docs refresh.
-python3 "$REPO_ROOT/docs/research/benchmarks/gen_fragments.py" \
-  "$DATA_DIR" "$REPO_ROOT/docs/research/benchmarks"
 echo "Now run: mdsmith fix . (refresh <?include?> bodies)"

--- a/internal/release/bench.go
+++ b/internal/release/bench.go
@@ -1,0 +1,522 @@
+// Package release: the cross-tool benchmark harness.
+//
+// This file ports docs/research/benchmarks/run.sh into the
+// mdsmith-release Go CLI so the local hand-refresh and the
+// post-merge `benchmark.yml` workflow run byte-identical logic
+// (see docs/development/release-tooling.md: workflow runtime
+// logic goes through this binary, not inline shell).
+//
+// What Go owns now that the shell script delegated or skipped:
+//
+//   - Integrity. Every comparison binary is fetched at a pinned
+//     version and verified by SHA-256 before it runs. run.sh
+//     pinned hyperfine/mado/panache by release tag but never
+//     checksummed them, and pulled rumdl (uv) and
+//     markdownlint-cli2 (npm) unpinned. A tampered or
+//     silently-rebuilt tarball now fails the run loudly.
+//   - markdownlint-cli2 installs from a committed lockfile via
+//     `npm ci` (docs/research/benchmarks/npm/), not an unpinned
+//     `npm i`.
+//
+// What is unchanged on purpose: the corpora construction, the
+// exact hyperfine flags/commands, the JSON promoted into
+// docs/research/benchmarks/data/, and the fragment regeneration
+// — the last still shells out to the existing gen_fragments.py
+// so the `bench-fragments` drift gate keeps validating the
+// committed snapshot against the committed JSON with one
+// generator.
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// benchDirRel is the benchmark harness directory relative to the
+// repo root. The committed JSON snapshot, the fragment files, the
+// parity config, the npm lockfile, and gen_fragments.py all live
+// under it.
+const benchDirRel = "docs/research/benchmarks"
+
+// defaultBenchWorkdir is where the harness caches the built
+// mdsmith binary, the fetched tool binaries, the corpora, and the
+// raw hyperfine output. Matches run.sh's historical default so a
+// local rerun reuses the same cache.
+const defaultBenchWorkdir = "/tmp/mdsmith-bench"
+
+// benchTool is one pinned, integrity-verified comparison binary
+// fetched from a GitHub release tarball. Name is BOTH the
+// hyperfine `--command-name` and the executable's basename inside
+// the archive — true for all four tools (hyperfine, mado,
+// panache, rumdl), whose tarballs differ only in directory
+// nesting. URL embeds the version tag so a version bump that
+// forgets to refresh the pin trips validateBenchManifest. SHA256
+// is the lowercase-hex digest of the downloaded `.tar.gz`.
+type benchTool struct {
+	Name    string
+	Version string
+	URL     string
+	SHA256  string
+}
+
+// benchTools is the pinned manifest. rumdl moved here from
+// run.sh's unpinned `uv tool install rumdl`: its GitHub release
+// ships a linux-gnu tarball with a companion `.sha256`, so it
+// joins the same fetch+verify path as the other three rather
+// than needing a separate uv install with no integrity. The
+// digests were recorded by downloading each tarball once;
+// rumdl's was cross-checked against the publisher's `.sha256`.
+// markdownlint-cli2 is intentionally absent — it installs from a
+// committed npm lockfile via `npm ci`, not a tarball.
+func benchTools() []benchTool {
+	return []benchTool{
+		{
+			Name:    "hyperfine",
+			Version: "v1.20.0",
+			URL: "https://github.com/sharkdp/hyperfine/releases/download/" +
+				"v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-musl.tar.gz",
+			SHA256: "3285ec7959285288137043dd81dce0dde056227018a8277532d9a364b4f03c2b",
+		},
+		{
+			Name:    "mado",
+			Version: "v0.3.0",
+			URL: "https://github.com/akiomik/mado/releases/download/" +
+				"v0.3.0/mado-Linux-gnu-x86_64.tar.gz",
+			SHA256: "aad845cd23c8c0417cdf87b8376b75e131c38e1cb890124790567735306de6d7",
+		},
+		{
+			Name:    "panache",
+			Version: "v2.46.0",
+			URL: "https://github.com/jolars/panache/releases/download/" +
+				"v2.46.0/panache-x86_64-unknown-linux-gnu.tar.gz",
+			SHA256: "898d5cc90df921745cca2c9e058bc2b99aeebeac9e16a1a9a5f8bd1b7fb655b5",
+		},
+		{
+			Name:    "rumdl",
+			Version: "v0.1.93",
+			URL: "https://github.com/rvben/rumdl/releases/download/" +
+				"v0.1.93/rumdl-v0.1.93-x86_64-unknown-linux-gnu.tar.gz",
+			SHA256: "033f48f4601b6533dfcc48112621defc6097a6f5609d187fa8149f94789d3f59",
+		},
+	}
+}
+
+// benchJSONNames are the four hyperfine JSON exports the harness
+// promotes into docs/research/benchmarks/data/. gen_fragments.py
+// reads exactly these names; the `bench-fragments` gate diffs the
+// fragments regenerated from the committed copies.
+var benchJSONNames = []string{
+	"corpus_repo",
+	"corpus_repo_mdl",
+	"corpus_neutral",
+	"corpus_neutral_mdl",
+}
+
+// sha256Hex matches a lowercase 64-hex-character SHA-256 digest.
+var sha256Hex = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// validateBenchManifest enforces the invariants every pinned
+// entry must hold so a future edit cannot land a half-specified
+// or unpinned tool. It is covered by a unit test and also runs at
+// the top of Bench so a bad manifest fails before any download.
+func validateBenchManifest(tools []benchTool) error {
+	if len(tools) == 0 {
+		return fmt.Errorf("bench manifest is empty")
+	}
+	seen := make(map[string]struct{}, len(tools))
+	for _, t := range tools {
+		switch {
+		case t.Name == "":
+			return fmt.Errorf("bench manifest entry has empty name")
+		case t.Version == "":
+			return fmt.Errorf("%s: empty version", t.Name)
+		case t.URL == "":
+			return fmt.Errorf("%s: empty url", t.Name)
+		case t.SHA256 == "":
+			return fmt.Errorf("%s: empty sha256", t.Name)
+		}
+		if _, dup := seen[t.Name]; dup {
+			return fmt.Errorf("%s: duplicate manifest entry", t.Name)
+		}
+		seen[t.Name] = struct{}{}
+		if !strings.HasPrefix(t.URL, "https://github.com/") {
+			return fmt.Errorf("%s: url is not a github.com release URL: %s", t.Name, t.URL)
+		}
+		if !strings.HasSuffix(t.URL, ".tar.gz") {
+			return fmt.Errorf("%s: url is not a .tar.gz: %s", t.Name, t.URL)
+		}
+		// The release tag segment must carry the pinned version,
+		// so bumping Version without re-pinning the URL (or vice
+		// versa) is a loud failure rather than a silent
+		// version/integrity skew.
+		if !strings.Contains(t.URL, "/download/"+t.Version+"/") {
+			return fmt.Errorf("%s: url does not pin version %s: %s", t.Name, t.Version, t.URL)
+		}
+		if !sha256Hex.MatchString(t.SHA256) {
+			return fmt.Errorf("%s: sha256 is not 64 lowercase hex chars: %q", t.Name, t.SHA256)
+		}
+	}
+	return nil
+}
+
+// verifyChecksum reports whether data hashes to the pinned
+// lowercase-hex SHA-256 want. A mismatch returns an error naming
+// both digests so a tampered or silently-rebuilt download fails
+// the run loudly (and legibly in CI logs). Pure and unit-tested.
+func verifyChecksum(data []byte, want string) error {
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if got != strings.ToLower(want) {
+		return fmt.Errorf("checksum mismatch: got %s, want %s", got, want)
+	}
+	return nil
+}
+
+// extractTarGzBinary pulls the single executable named binName
+// out of a gzip-compressed tar archive and writes it to dstPath
+// with 0o755. The four tool tarballs nest the binary differently
+// (hyperfine under a versioned dir, panache under "./", mado and
+// rumdl at the root), so the match is on path.Base of a regular
+// file rather than a hardcoded member path — the same robustness
+// run.sh got from `find -name <tool> -type f`.
+func extractTarGzBinary(r io.Reader, binName, dstPath string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("open gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("binary %q not found in archive", binName)
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg || path.Base(hdr.Name) != binName {
+			continue
+		}
+		//nolint:gosec // CI-only; dstPath is harness-controlled
+		out, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+		if err != nil {
+			return fmt.Errorf("create %s: %w", dstPath, err)
+		}
+		// Cap the copy so a crafted archive member cannot fill
+		// the runner disk. 64 MiB dwarfs every real binary here
+		// (the largest tarball is ~5 MB compressed).
+		if _, err := io.CopyN(out, tr, 64<<20); err != nil && err != io.EOF {
+			_ = out.Close()
+			return fmt.Errorf("extract %s: %w", binName, err)
+		}
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", dstPath, err)
+		}
+		return nil
+	}
+}
+
+// promoteBenchJSON copies the four hyperfine JSON exports from the
+// raw output directory into docs/research/benchmarks/data/, the
+// committed source of truth gen_fragments.py reads. A missing
+// export is a hard error (the run did not produce what the
+// fragments depend on) rather than a silent stale promote.
+func (t *Toolkit) promoteBenchJSON(outDir, dataDir string) error {
+	if err := t.fs.MkdirAll(dataDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dataDir, err)
+	}
+	for _, name := range benchJSONNames {
+		src := filepath.Join(outDir, name+".json")
+		data, err := t.fs.ReadFile(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("benchmark output %s.json not found in %s", name, outDir)
+			}
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		dst := filepath.Join(dataDir, name+".json")
+		if err := t.fs.WriteFile(dst, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
+	}
+	return nil
+}
+
+// Bench runs the full cross-tool benchmark from the repo root:
+// build mdsmith, fetch + integrity-verify the pinned comparison
+// binaries, build the two corpora, drive hyperfine, promote the
+// JSON into the committed data dir, and regenerate the doc
+// fragments via gen_fragments.py. workdir caches every heavy
+// artifact (built binaries, corpora) so a local rerun is cheap;
+// CI passes a fresh /tmp path so every run is cold.
+//
+// It deliberately does NOT run `mdsmith fix` to refresh the
+// <?include?> bodies — run.sh never did either, and the
+// benchmark.yml workflow owns that normalization before
+// publishing to the assets branch.
+func (t *Toolkit) Bench(root, workdir string) error {
+	if err := validateBenchManifest(benchTools()); err != nil {
+		return fmt.Errorf("bench manifest: %w", err)
+	}
+	if workdir == "" {
+		workdir = defaultBenchWorkdir
+	}
+	binDir := filepath.Join(workdir, "bin")
+	outDir := filepath.Join(workdir, "out")
+	for _, d := range []string{binDir, outDir} {
+		if err := t.fs.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", d, err)
+		}
+	}
+
+	mdsmithBin := filepath.Join(binDir, "mdsmith")
+	if !t.exists(mdsmithBin) {
+		fmt.Println("bench: building mdsmith")
+		if err := t.runner.RunCommand(root, "go", "build", "-o", mdsmithBin, "./cmd/mdsmith"); err != nil {
+			return fmt.Errorf("build mdsmith: %w", err)
+		}
+	}
+
+	for _, tool := range benchTools() {
+		dst := filepath.Join(binDir, tool.Name)
+		if t.exists(dst) {
+			continue
+		}
+		if err := t.fetchTool(tool, dst); err != nil {
+			return err
+		}
+	}
+
+	mdlBin, err := t.installMarkdownlint(root, workdir)
+	if err != nil {
+		return err
+	}
+
+	if err := t.buildCorpora(root, workdir); err != nil {
+		return err
+	}
+
+	if err := t.runHyperfine(binDir, outDir, workdir, mdsmithBin, mdlBin, root); err != nil {
+		return err
+	}
+
+	dataDir := filepath.Join(root, benchDirRel, "data")
+	if err := t.promoteBenchJSON(outDir, dataDir); err != nil {
+		return err
+	}
+
+	fmt.Println("bench: regenerating fragments via gen_fragments.py")
+	gen := filepath.Join(root, benchDirRel, "gen_fragments.py")
+	if err := t.runner.RunCommand(root, "python3", gen, dataDir, filepath.Join(root, benchDirRel)); err != nil {
+		return fmt.Errorf("gen_fragments.py: %w", err)
+	}
+	return nil
+}
+
+// exists reports whether name is present (file or dir). Used for
+// the skip-if-cached checks that make a local rerun cheap.
+func (t *Toolkit) exists(name string) bool {
+	_, err := t.fs.Stat(name)
+	return err == nil
+}
+
+// fetchTool downloads one pinned tarball, fails loudly on a
+// SHA-256 mismatch, and extracts its binary to dst.
+func (t *Toolkit) fetchTool(tool benchTool, dst string) error {
+	fmt.Printf("bench: fetching %s %s\n", tool.Name, tool.Version)
+	status, body, err := t.http.Get(tool.URL)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", tool.Name, err)
+	}
+	if status != 200 {
+		return fmt.Errorf("download %s: %s returned HTTP %d", tool.Name, tool.URL, status)
+	}
+	if err := verifyChecksum(body, tool.SHA256); err != nil {
+		return fmt.Errorf("%s: %w", tool.Name, err)
+	}
+	if err := extractTarGzBinary(bytes.NewReader(body), tool.Name, dst); err != nil {
+		return fmt.Errorf("%s: %w", tool.Name, err)
+	}
+	return nil
+}
+
+// installMarkdownlint stages the committed npm lockfile into the
+// workdir and runs `npm ci`, returning the path to the resolved
+// markdownlint-cli2 binary. `npm ci` (not `npm i`) installs the
+// exact tree the committed package-lock.json pins, so the
+// benchmark sees the same markdownlint-cli2 every run.
+func (t *Toolkit) installMarkdownlint(root, workdir string) (string, error) {
+	npmDir := filepath.Join(workdir, "npm")
+	if err := t.fs.MkdirAll(npmDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", npmDir, err)
+	}
+	srcDir := filepath.Join(root, benchDirRel, "npm")
+	for _, f := range []string{"package.json", "package-lock.json"} {
+		data, err := t.fs.ReadFile(filepath.Join(srcDir, f))
+		if err != nil {
+			return "", fmt.Errorf("read pinned %s: %w", f, err)
+		}
+		if err := t.fs.WriteFile(filepath.Join(npmDir, f), data, 0o644); err != nil {
+			return "", fmt.Errorf("stage %s: %w", f, err)
+		}
+	}
+	bin := filepath.Join(npmDir, "node_modules", ".bin", "markdownlint-cli2")
+	if t.exists(bin) {
+		return bin, nil
+	}
+	fmt.Println("bench: npm ci markdownlint-cli2")
+	if err := t.runner.RunCommand(npmDir, "npm", "ci"); err != nil {
+		return "", fmt.Errorf("npm ci: %w", err)
+	}
+	return bin, nil
+}
+
+// repoCorpusSkip drops generated/bad fixtures from corpus A so the
+// repo corpus is the Markdown a user would actually lint. Matches
+// run.sh's `grep -vE '^(demo/|internal/rules/[^/]*/bad/)'`.
+var repoCorpusSkip = regexp.MustCompile(`^(demo/|internal/rules/[^/]*/bad/)`)
+
+// buildCorpora materializes the two benchmark corpora under
+// workdir, skipping each if already present (cheap local rerun):
+//
+//   - corpus_repo: this repo's own tracked Markdown, fixtures
+//     dropped (git ls-files, filtered).
+//   - corpus_neutral: third-party prose — the Rust Book and Rust
+//     Reference `src/` trees, shallow-cloned.
+func (t *Toolkit) buildCorpora(root, workdir string) error {
+	repoCorpus := filepath.Join(workdir, "corpus_repo")
+	if !t.exists(repoCorpus) {
+		fmt.Println("bench: building corpus_repo")
+		lsArgs := []string{"-C", root, "ls-files", "*.md", "*.markdown"}
+		out, err := exec.Command("git", lsArgs...).Output() //nolint:gosec // CI-only; args constant
+		if err != nil {
+			return fmt.Errorf("git ls-files: %w", err)
+		}
+		for _, rel := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if rel == "" || repoCorpusSkip.MatchString(rel) {
+				continue
+			}
+			if err := t.copyInto(filepath.Join(root, rel), filepath.Join(repoCorpus, rel)); err != nil {
+				return err
+			}
+		}
+	}
+
+	neutralCorpus := filepath.Join(workdir, "corpus_neutral")
+	if !t.exists(neutralCorpus) {
+		fmt.Println("bench: building corpus_neutral (cloning Rust Book + Reference)")
+		clones := []struct{ url, dir string }{
+			{"https://github.com/rust-lang/book.git", "rust-book"},
+			{"https://github.com/rust-lang/reference.git", "rust-ref"},
+		}
+		for _, c := range clones {
+			dir := filepath.Join(workdir, c.dir)
+			if t.exists(dir) {
+				continue
+			}
+			if err := t.runner.RunCommand(workdir, "git", "clone", "--depth", "1", "-q", c.url, c.dir); err != nil {
+				return fmt.Errorf("clone %s: %w", c.url, err)
+			}
+		}
+		for _, src := range []string{
+			filepath.Join(workdir, "rust-book", "src"),
+			filepath.Join(workdir, "rust-ref", "src"),
+		} {
+			if err := t.copyMarkdownTree(src, neutralCorpus); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// copyInto copies one file, creating parent directories. Used for
+// the repo corpus where each path is reproduced verbatim under
+// corpus_repo/.
+func (t *Toolkit) copyInto(src, dst string) error {
+	data, err := t.fs.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+	if err := t.fs.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+	}
+	if err := t.fs.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}
+
+// copyMarkdownTree walks srcRoot and copies every *.md file into
+// dstRoot, reproducing the source path under it (leading
+// separator stripped) — the same layout run.sh's
+// `find … | tar … | tar -x` produced, so hyperfine walks an
+// identical corpus.
+func (t *Toolkit) copyMarkdownTree(srcRoot, dstRoot string) error {
+	return filepath.WalkDir(srcRoot, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(p, ".md") {
+			return nil
+		}
+		rel := strings.TrimPrefix(filepath.ToSlash(p), "/")
+		return t.copyInto(p, filepath.Join(dstRoot, filepath.FromSlash(rel)))
+	})
+}
+
+// runHyperfine drives the two benchmark passes per corpus with
+// the exact flags run.sh used. The comparison command strings use
+// absolute binary paths rather than bare names: with `-N`
+// hyperfine tokenizes the string itself (no PATH-providing
+// shell), and the JSON `command` field is the `--command-name`,
+// not the executable path, so the promoted JSON — and therefore
+// every regenerated fragment — is identical to run.sh's.
+func (t *Toolkit) runHyperfine(binDir, outDir, workdir, mdsmithBin, mdlBin, root string) error {
+	hyperfine := filepath.Join(binDir, "hyperfine")
+	parity := filepath.Join(root, benchDirRel, "bench-parity.mdsmith.yml")
+	mado := filepath.Join(binDir, "mado")
+	rumdl := filepath.Join(binDir, "rumdl")
+	panache := filepath.Join(binDir, "panache")
+	for _, corpus := range []string{"corpus_repo", "corpus_neutral"} {
+		cpath := filepath.Join(workdir, corpus)
+		fmt.Printf("bench: hyperfine over %s\n", corpus)
+		if err := t.runner.RunCommand("", hyperfine,
+			"-i", "--warmup", "3", "--runs", "10", "-N",
+			"--command-name", "mado", mado+" check "+cpath,
+			"--command-name", "rumdl", rumdl+" check --no-cache "+cpath,
+			"--command-name", "panache", panache+" lint --no-cache "+cpath,
+			"--command-name", "mdsmith-parity", mdsmithBin+" check -c "+parity+" "+cpath,
+			"--command-name", "mdsmith", mdsmithBin+" check "+cpath,
+			"--export-json", filepath.Join(outDir, corpus+".json"),
+			"--export-markdown", filepath.Join(outDir, corpus+".md"),
+		); err != nil {
+			return fmt.Errorf("hyperfine %s: %w", corpus, err)
+		}
+		if err := t.runner.RunCommand("", hyperfine,
+			"-i", "--warmup", "2", "--runs", "6", "-N",
+			"--command-name", "markdownlint-cli2", mdlBin+" '"+cpath+"/**/*.md'",
+			"--export-json", filepath.Join(outDir, corpus+"_mdl.json"),
+		); err != nil {
+			return fmt.Errorf("hyperfine %s markdownlint: %w", corpus, err)
+		}
+	}
+	return nil
+}
+
+// Bench delegates to a default-OS Toolkit (see Stamp).
+func Bench(root, workdir string) error {
+	return New().Bench(root, workdir)
+}

--- a/internal/release/bench_test.go
+++ b/internal/release/bench_test.go
@@ -1,0 +1,272 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBenchManifestInvariants pins the contract every manifest
+// entry must hold so a future edit cannot land a half-specified
+// or unpinned tool. The shipped manifest must pass; each
+// individually-broken clone must fail with a message naming the
+// offending field.
+func TestBenchManifestInvariants(t *testing.T) {
+	require.NoError(t, validateBenchManifest(benchTools()),
+		"the shipped pinned manifest must satisfy its own invariants")
+
+	tools := benchTools()
+	require.NotEmpty(t, tools)
+	assert.GreaterOrEqual(t, len(tools), 4,
+		"hyperfine, mado, panache, rumdl are all pinned")
+
+	assert.Error(t, validateBenchManifest(nil), "empty manifest")
+
+	cases := []struct {
+		name   string
+		mutate func(bt *benchTool)
+		want   string
+	}{
+		{"empty name", func(b *benchTool) { b.Name = "" }, "empty name"},
+		{"empty version", func(b *benchTool) { b.Version = "" }, "empty version"},
+		{"empty url", func(b *benchTool) { b.URL = "" }, "empty url"},
+		{"empty sha", func(b *benchTool) { b.SHA256 = "" }, "empty sha256"},
+		{"non-github", func(b *benchTool) {
+			b.URL = "https://example.com/download/" + b.Version + "/x.tar.gz"
+		}, "not a github.com release URL"},
+		{"not tarball", func(b *benchTool) {
+			b.URL = "https://github.com/o/r/releases/download/" + b.Version + "/x.zip"
+		}, "not a .tar.gz"},
+		{"version not pinned in url", func(b *benchTool) {
+			b.URL = "https://github.com/o/r/releases/download/v9.9.9/x.tar.gz"
+		}, "does not pin version"},
+		{"sha not hex", func(b *benchTool) { b.SHA256 = "NOTHEX" }, "64 lowercase hex"},
+		{"sha uppercase", func(b *benchTool) {
+			b.SHA256 = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+		}, "64 lowercase hex"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			one := benchTools()[:1]
+			one[0] = benchTools()[0]
+			c.mutate(&one[0])
+			err := validateBenchManifest(one)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.want)
+		})
+	}
+
+	t.Run("duplicate name", func(t *testing.T) {
+		dup := []benchTool{benchTools()[0], benchTools()[0]}
+		err := validateBenchManifest(dup)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate manifest entry")
+	})
+}
+
+// TestVerifyChecksum covers the integrity gate the acceptance
+// criteria call out: a tampered download (wrong SHA-256) must
+// fail loudly, and the message must name both digests.
+func TestVerifyChecksum(t *testing.T) {
+	data := []byte("the quick brown fox\n")
+	sum := sha256.Sum256(data)
+	good := hex.EncodeToString(sum[:])
+
+	require.NoError(t, verifyChecksum(data, good))
+
+	err := verifyChecksum(data, "0000000000000000000000000000000000000000000000000000000000000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+	assert.Contains(t, err.Error(), good, "message names the actual digest")
+
+	// A single flipped byte must not pass.
+	tampered := append([]byte{}, data...)
+	tampered[0] ^= 0xff
+	assert.Error(t, verifyChecksum(tampered, good))
+}
+
+// makeTarGz builds an in-memory gzip-compressed tar with the
+// given members. Mirrors the three nesting shapes the real tool
+// tarballs use (root, "./"-prefixed, versioned subdir).
+func makeTarGz(t *testing.T, members map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, body := range members {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg,
+		}))
+		_, err := tw.Write([]byte(body))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}
+
+func TestExtractTarGzBinary(t *testing.T) {
+	t.Run("nested member is extracted 0755", func(t *testing.T) {
+		archive := makeTarGz(t, map[string]string{
+			"hyperfine-v1.20.0-x86_64-unknown-linux-musl/README.md": "docs",
+			"hyperfine-v1.20.0-x86_64-unknown-linux-musl/hyperfine": "#!/bin/sh\necho hi\n",
+		})
+		dst := filepath.Join(t.TempDir(), "hyperfine")
+		require.NoError(t, extractTarGzBinary(bytes.NewReader(archive), "hyperfine", dst))
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, "#!/bin/sh\necho hi\n", string(got))
+		info, err := os.Stat(dst)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	})
+
+	t.Run("dot-slash prefixed member (panache shape)", func(t *testing.T) {
+		archive := makeTarGz(t, map[string]string{"./panache": "PANACHE"})
+		dst := filepath.Join(t.TempDir(), "panache")
+		require.NoError(t, extractTarGzBinary(bytes.NewReader(archive), "panache", dst))
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, "PANACHE", string(got))
+	})
+
+	t.Run("missing binary errors", func(t *testing.T) {
+		archive := makeTarGz(t, map[string]string{"README.md": "x"})
+		dst := filepath.Join(t.TempDir(), "mado")
+		err := extractTarGzBinary(bytes.NewReader(archive), "mado", dst)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"mado" not found`)
+	})
+
+	t.Run("not gzip errors", func(t *testing.T) {
+		err := extractTarGzBinary(bytes.NewReader([]byte("not a gzip stream")), "x", filepath.Join(t.TempDir(), "x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "open gzip")
+	})
+}
+
+// TestPromoteBenchJSON covers the copy and the missing-source
+// failure: a run that did not produce one of the four exports
+// must error (naming it) rather than silently promote stale JSON.
+func TestPromoteBenchJSON(t *testing.T) {
+	t.Run("copies all four", func(t *testing.T) {
+		root := t.TempDir()
+		out := filepath.Join(root, "out")
+		require.NoError(t, os.MkdirAll(out, 0o755))
+		for _, n := range benchJSONNames {
+			require.NoError(t, os.WriteFile(filepath.Join(out, n+".json"),
+				[]byte(`{"results":[{"command":"`+n+`"}]}`), 0o644))
+		}
+		data := filepath.Join(root, benchDirRel, "data")
+		require.NoError(t, New().promoteBenchJSON(out, data))
+		for _, n := range benchJSONNames {
+			b, err := os.ReadFile(filepath.Join(data, n+".json"))
+			require.NoError(t, err, "%s promoted", n)
+			assert.Contains(t, string(b), n)
+		}
+	})
+
+	t.Run("missing source errors and names it", func(t *testing.T) {
+		root := t.TempDir()
+		out := filepath.Join(root, "out")
+		require.NoError(t, os.MkdirAll(out, 0o755))
+		// Only the first three exist; corpus_neutral_mdl is absent.
+		for _, n := range benchJSONNames[:3] {
+			require.NoError(t, os.WriteFile(filepath.Join(out, n+".json"), []byte("{}"), 0o644))
+		}
+		err := New().promoteBenchJSON(out, filepath.Join(root, "data"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "corpus_neutral_mdl.json not found")
+	})
+}
+
+// fakeGetter is an in-memory HTTPGetter keyed by URL.
+type fakeGetter struct {
+	resp map[string]struct {
+		status int
+		body   []byte
+		err    error
+	}
+	calls []string
+}
+
+func (f *fakeGetter) Get(url string) (int, []byte, error) {
+	f.calls = append(f.calls, url)
+	r, ok := f.resp[url]
+	if !ok {
+		return 404, []byte("not found"), nil
+	}
+	return r.status, r.body, r.err
+}
+
+func TestPullSiteAssets(t *testing.T) {
+	t.Run("200 writes every destination", func(t *testing.T) {
+		root := t.TempDir()
+		g := &fakeGetter{resp: map[string]struct {
+			status int
+			body   []byte
+			err    error
+		}{
+			rawAssetsBase + "benchmarks/results.fragment.md":  {200, []byte("RESULTS-TABLE"), nil},
+			rawAssetsBase + "benchmarks/headline.fragment.md": {200, []byte("HEADLINE"), nil},
+			rawAssetsBase + "demo.gif":                        {200, []byte("GIF89a-bytes"), nil},
+		}}
+		require.NoError(t, NewWithHTTP(osFS{}, g).PullSiteAssets(root))
+
+		res, err := os.ReadFile(filepath.Join(root, benchDirRel, "results.fragment.md"))
+		require.NoError(t, err)
+		assert.Equal(t, "RESULTS-TABLE", string(res))
+		gif, err := os.ReadFile(filepath.Join(root, "website", "static", "img", "demo.gif"))
+		require.NoError(t, err)
+		assert.Equal(t, "GIF89a-bytes", string(gif))
+	})
+
+	t.Run("missing benchmark fragments keep the committed snapshot", func(t *testing.T) {
+		root := t.TempDir()
+		// Pre-seed a committed snapshot the deploy must not lose.
+		snap := filepath.Join(root, benchDirRel, "results.fragment.md")
+		require.NoError(t, os.MkdirAll(filepath.Dir(snap), 0o755))
+		require.NoError(t, os.WriteFile(snap, []byte("COMMITTED-SNAPSHOT"), 0o644))
+
+		g := &fakeGetter{resp: map[string]struct {
+			status int
+			body   []byte
+			err    error
+		}{
+			// benchmarks/* absent (404 default); only the demo GIF
+			// is published.
+			rawAssetsBase + "demo.gif": {200, []byte("GIF"), nil},
+		}}
+		require.NoError(t, NewWithHTTP(osFS{}, g).PullSiteAssets(root))
+
+		kept, err := os.ReadFile(snap)
+		require.NoError(t, err)
+		assert.Equal(t, "COMMITTED-SNAPSHOT", string(kept),
+			"a non-required miss must not overwrite the committed fragment")
+	})
+
+	t.Run("required demo gif miss fails the deploy", func(t *testing.T) {
+		root := t.TempDir()
+		g := &fakeGetter{resp: map[string]struct {
+			status int
+			body   []byte
+			err    error
+		}{
+			rawAssetsBase + "benchmarks/results.fragment.md":  {200, []byte("R"), nil},
+			rawAssetsBase + "benchmarks/headline.fragment.md": {200, []byte("H"), nil},
+			rawAssetsBase + "demo.gif":                        {404, []byte("nope"), nil},
+		}}
+		err := NewWithHTTP(osFS{}, g).PullSiteAssets(root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "demo.gif")
+		assert.Contains(t, err.Error(), "HTTP 404")
+	})
+}

--- a/internal/release/fs.go
+++ b/internal/release/fs.go
@@ -1,9 +1,13 @@
 package release
 
 import (
+	"fmt"
+	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
+	"time"
 )
 
 // FS is the small filesystem surface the release toolkit uses.
@@ -85,26 +89,77 @@ func (osRunner) RunCommand(dir, name string, args ...string) error {
 	return cmd.Run()
 }
 
-// Toolkit owns a configured FS and Runner and exposes the release
-// helpers (Stamp, Check, BuildNpmPlatforms, BuildWheels) as
-// methods. `New()` returns a Toolkit backed by the real OS for
-// both; tests can use `NewWithFS(fakeFS)` or `NewWithDeps` to
-// drive error paths that the OS does not expose.
+// HTTPGetter is the one-call HTTP surface the release toolkit
+// uses to fetch pinned benchmark tool tarballs and the published
+// benchmark numbers / demo GIF from the orphan `assets` branch.
+// Production uses osHTTPGetter (net/http); tests inject a fake so
+// the assets-pull and download-integrity branches run without a
+// network.
+type HTTPGetter interface {
+	// Get fetches url and returns the HTTP status code and the
+	// fully-read body. A transport-level failure (DNS, refused,
+	// timeout) returns a non-nil error with status 0; an HTTP
+	// error response (404, 500, …) returns the status and the
+	// body with a nil error, so callers decide per-asset whether
+	// a miss is fatal or a keep-the-committed-copy fallback.
+	Get(url string) (status int, body []byte, err error)
+}
+
+// osHTTPGetter is the production HTTPGetter. The client carries a
+// generous timeout: the benchmark tool tarballs are a few MB and
+// CI runners are occasionally slow, but an unbounded wait would
+// hang a stuck publish/deploy indefinitely.
+type osHTTPGetter struct{}
+
+func (osHTTPGetter) Get(url string) (int, []byte, error) {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Get(url) //nolint:gosec // CI-only fetch of a constant-derived URL
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("read body: %w", err)
+	}
+	return resp.StatusCode, body, nil
+}
+
+// Toolkit owns a configured FS, Runner, and HTTPGetter and exposes
+// the release helpers (Stamp, Check, BuildNpmPlatforms,
+// BuildWheels, Bench, PullSiteAssets) as methods. `New()` returns
+// a Toolkit backed by the real OS for all three; tests can use
+// `NewWithFS(fakeFS)`, `NewWithDeps`, or `NewWithHTTP` to drive
+// error paths that the OS does not expose.
 type Toolkit struct {
 	fs     FS
 	runner Runner
+	http   HTTPGetter
 }
 
-// New returns a Toolkit backed by the real OS filesystem and
-// command runner.
-func New() *Toolkit { return &Toolkit{fs: osFS{}, runner: osRunner{}} }
+// New returns a Toolkit backed by the real OS filesystem, command
+// runner, and HTTP client.
+func New() *Toolkit {
+	return &Toolkit{fs: osFS{}, runner: osRunner{}, http: osHTTPGetter{}}
+}
 
 // NewWithFS returns a Toolkit with a custom FS and the OS-backed
-// Runner. Convenience helper for tests that only need IO faults.
-func NewWithFS(fsys FS) *Toolkit { return &Toolkit{fs: fsys, runner: osRunner{}} }
+// Runner/HTTPGetter. Convenience helper for tests that only need
+// IO faults.
+func NewWithFS(fsys FS) *Toolkit {
+	return &Toolkit{fs: fsys, runner: osRunner{}, http: osHTTPGetter{}}
+}
 
-// NewWithDeps returns a Toolkit with custom FS and Runner. Used
-// by tests that exercise both IO and command-execution faults.
+// NewWithDeps returns a Toolkit with custom FS and Runner and the
+// OS-backed HTTPGetter. Used by tests that exercise both IO and
+// command-execution faults.
 func NewWithDeps(fsys FS, runner Runner) *Toolkit {
-	return &Toolkit{fs: fsys, runner: runner}
+	return &Toolkit{fs: fsys, runner: runner, http: osHTTPGetter{}}
+}
+
+// NewWithHTTP returns a Toolkit with a custom FS and HTTPGetter and
+// the OS-backed Runner. Used by the PullSiteAssets tests to drive
+// the build-time assets fetch without a network.
+func NewWithHTTP(fsys FS, getter HTTPGetter) *Toolkit {
+	return &Toolkit{fs: fsys, runner: osRunner{}, http: getter}
 }

--- a/internal/release/siteassets.go
+++ b/internal/release/siteassets.go
@@ -1,0 +1,114 @@
+// Package release: build-time fetch of the published assets.
+//
+// The demo GIF and the cross-tool benchmark numbers are not
+// committed to the repo — they are regenerated post-merge and
+// pushed to the orphan `assets` branch (the demo.gif pattern;
+// see .github/workflows/{demo,benchmark}.yml). This file pulls
+// them into the working tree at site-build time so the deployed
+// site serves the current artifacts:
+//
+//   - the demo GIF lands in website/static/ and is served as a
+//     first-party asset (was a runtime raw.githubusercontent
+//     <img> hotlink);
+//   - the benchmark fragments overwrite the committed in-repo
+//     snapshot so the next `mdsmith fix` bakes the live numbers
+//     into the published page.
+//
+// The committed fragment snapshot stays the floor: a miss
+// (assets branch not yet carrying benchmarks/, or a transient
+// fetch failure) keeps it rather than failing the deploy. The
+// `bench-fragments` CI gate is a separate workflow that never
+// calls this, so it keeps validating the committed snapshot
+// against the committed JSON.
+package release
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// rawAssetsBase is the raw-content root of the orphan `assets`
+// branch. The branch layout is assets/<path>, so demo.gif is at
+// assets/demo.gif and the benchmark fragments under
+// assets/benchmarks/ — the same URL shape the hero <img>
+// previously hotlinked at runtime.
+const rawAssetsBase = "https://raw.githubusercontent.com/jeduden/mdsmith/assets/assets/"
+
+// siteAsset is one published artifact pulled at build time.
+// required marks an artifact whose absence is a real regression
+// worth failing the deploy (the demo GIF has been published for
+// many releases and the hero hard-depends on it); a non-required
+// miss falls back to the committed copy.
+type siteAsset struct {
+	url      string
+	dst      string
+	required bool
+}
+
+// siteAssets maps each published artifact to its working-tree
+// destination, resolved against the repo root.
+//
+// The benchmark fragments are not required: before benchmark.yml
+// first runs, assets/benchmarks/ does not exist, and the
+// committed snapshot is correct in the meantime. The demo GIF is
+// required: it is reliably published and the site has no
+// committed fallback for it.
+func siteAssets(root string) []siteAsset {
+	return []siteAsset{
+		{
+			url:      rawAssetsBase + "benchmarks/results.fragment.md",
+			dst:      filepath.Join(root, benchDirRel, "results.fragment.md"),
+			required: false,
+		},
+		{
+			url:      rawAssetsBase + "benchmarks/headline.fragment.md",
+			dst:      filepath.Join(root, benchDirRel, "headline.fragment.md"),
+			required: false,
+		},
+		{
+			url:      rawAssetsBase + "demo.gif",
+			dst:      filepath.Join(root, "website", "static", "img", "demo.gif"),
+			required: true,
+		},
+	}
+}
+
+// PullSiteAssets fetches every published artifact into the
+// working tree before the Hugo build. Per-asset policy: a 200
+// overwrites the destination; a transport error or non-200 on a
+// required asset fails the deploy loudly; the same miss on a
+// non-required asset logs and keeps the committed copy.
+func (t *Toolkit) PullSiteAssets(root string) error {
+	for _, a := range siteAssets(root) {
+		status, body, err := t.http.Get(a.url)
+		if err != nil {
+			if a.required {
+				return fmt.Errorf("fetch %s: %w", a.url, err)
+			}
+			fmt.Printf("pull-site-assets: %s unreachable (%v); keeping committed %s\n",
+				a.url, err, a.dst)
+			continue
+		}
+		if status != 200 {
+			if a.required {
+				return fmt.Errorf("fetch %s: HTTP %d", a.url, status)
+			}
+			fmt.Printf("pull-site-assets: %s HTTP %d; keeping committed %s\n",
+				a.url, status, a.dst)
+			continue
+		}
+		if err := t.fs.MkdirAll(filepath.Dir(a.dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(a.dst), err)
+		}
+		if err := t.fs.WriteFile(a.dst, body, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", a.dst, err)
+		}
+		fmt.Printf("pull-site-assets: pulled %s -> %s\n", a.url, a.dst)
+	}
+	return nil
+}
+
+// PullSiteAssets delegates to a default-OS Toolkit (see Stamp).
+func PullSiteAssets(root string) error {
+	return New().PullSiteAssets(root)
+}

--- a/plan/184_release-benchmark-automation.md
+++ b/plan/184_release-benchmark-automation.md
@@ -1,7 +1,7 @@
 ---
 id: 184
 title: Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: []
 summary: >-
@@ -66,48 +66,90 @@ The website pulls from there.
 ## Tasks
 
 1. [x] Create this plan.
-2. [ ] `internal/release` benchmark core + `mdsmith-release
+2. [x] `internal/release` benchmark core + `mdsmith-release
    bench` subcommand: pinned-tool manifest
-   `{tool,version,url,sha256}`, fail-loud SHA-256
-   verifier, corpus build, hyperfine orchestration, JSON
-   promote into `docs/research/benchmarks/data/`, fragment
-   regen via the existing `gen_fragments.py`. Unit-test
-   the pure parts (manifest invariants, verifier
-   ok/mismatch, promote copy/missing-source).
-3. [ ] Choose + pin `rumdl` and `markdownlint-cli2`
-   versions; record real SHA-256s for all five tools;
-   commit `markdownlint-cli2` lockfile, install via
-   `npm ci`.
-4. [ ] Rewrite `run.sh` as a wrapper over
-   `go run ./cmd/mdsmith-release bench` (no behaviour
-   change for the local hand-refresh; keeps the
-   `bench-fragments` drift gate intact).
-5. [ ] `benchmark.yml`: `push: main`, skip
-   `github-actions[bot]`; `record` runs the subcommand;
-   `publish` force-updates `assets` branch under
-   `assets/benchmarks/` (JSON + fragments), commit only
-   on change. Model on `demo.yml`.
-6. [ ] Website + docs: serve headline/results from the
-   `assets` branch like `demo.gif`; keep `bench-fragments`
-   coherent (it still validates committed fragments vs
-   committed JSON as the in-repo snapshot).
-7. [ ] Gates: `go build`, `go test ./...`,
+   `{tool,version,url,sha256}` (`benchTools()` in
+   `internal/release/bench.go`), fail-loud SHA-256
+   verifier (`verifyChecksum`), corpus build, hyperfine
+   orchestration, JSON promote into
+   `docs/research/benchmarks/data/` (`promoteBenchJSON`),
+   fragment regen via the existing `gen_fragments.py`.
+   Unit-tested the pure parts in `bench_test.go`
+   (manifest invariants, verifier ok/mismatch, promote
+   copy/missing-source, tar extraction).
+3. [x] Pinned `rumdl` 0.1.93 and `markdownlint-cli2`
+   0.22.1. Recorded real SHA-256s for the four binary
+   tools (hyperfine/mado/panache/rumdl); rumdl moved from
+   the unpinned `uv tool install` to its pinned GitHub
+   release tarball so it shares the verify path. The
+   fifth tool, `markdownlint-cli2`, is pinned by the
+   committed `docs/research/benchmarks/npm/`
+   package.json + package-lock.json and installs via
+   `npm ci` (npm's lockfile integrity is its SHA).
+4. [x] Rewrote `run.sh` as a thin wrapper over
+   `go run ./cmd/mdsmith-release bench`. The
+   `bench-fragments` drift gate is untouched.
+5. [x] `benchmark.yml`: `push: main`, skip
+   `github-actions[bot]`; `record` runs the subcommand +
+   normalizes fragments; `publish` updates the `assets`
+   branch under `assets/benchmarks/` (JSON + fragments),
+   commit only on change. Modelled on `demo.yml`. Both
+   workflows are now subtree-scoped so they coexist on
+   the shared branch (see Deviations).
+6. [x] Build-time fetch (chosen over the runtime model):
+   `mdsmith-release pull-site-assets` pulls the published
+   fragments + demo GIF into the tree during `pages.yml`;
+   a scoped `mdsmith fix` rebakes the comparison page's
+   `<?include?>` body. The demo GIF now ships as a
+   first-party static asset (was a runtime
+   `raw.githubusercontent` hotlink). `bench-fragments`
+   stays coherent: it is a separate workflow that never
+   calls the pull and still validates the committed
+   snapshot vs committed JSON.
+7. [x] Gates pass: `go build ./...`, `go test ./...`,
    `golangci-lint`, `mdsmith check .`. End-to-end
-   (`benchmark.yml`) is only exercisable on merge to main —
-   note this explicitly; it cannot be validated on the PR.
+   (`benchmark.yml`, the assets-branch push, and the
+   site build-time fetch) is only exercisable on merge
+   to main and cannot be validated on the PR.
+
+## Deviations
+
+- Website mechanism: user chose **build-time fetch** over
+  the runtime `demo.gif`-style fetch, and asked that
+  `demo.gif` move to build-time too. Implemented as
+  `pull-site-assets` in `pages.yml`; `hero.html` now
+  serves a local `img/demo.gif` (`.gitignore`d).
+- `demo.yml` publish made subtree-safe (dropped the
+  `git rm -rf . && git clean -fdx` whole-tree wipe). Both
+  it and `benchmark.yml` now touch only their own subtree
+  on the shared orphan `assets` branch, so neither erases
+  the other's output.
+- `rumdl` is pinned via its GitHub release tarball + a
+  SHA-256 (cross-checked against the publisher `.sha256`)
+  rather than `uv`, so all four binary tools share one
+  fetch+verify path.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith-release bench` reproduces the four
+- [x] `mdsmith-release bench` runs the identical
+      commands/flags/corpora as the old `run.sh` and
+      reuses `gen_fragments.py`, so it reproduces the four
       `data/*.json` files and the fragments byte-for-byte
-      vs the current `run.sh` on the same inputs.
-- [ ] A tampered download (wrong SHA-256) fails the run
-      loudly; covered by a unit test.
-- [ ] `run.sh` delegates to the subcommand and the
-      `bench-fragments` drift gate stays green.
-- [ ] `benchmark.yml` pushes to `assets/benchmarks/` only
-      when numbers change and never to `main`.
-- [ ] Website renders numbers fetched from the `assets`
-      branch.
-- [ ] `go test ./...`, `golangci-lint`, `mdsmith check .`
+      on the same inputs. (The timing values are
+      non-deterministic; the format/pipeline is
+      identical. Full e2e only on merge to main.)
+- [x] A tampered download (wrong SHA-256) fails the run
+      loudly; covered by `TestVerifyChecksum` /
+      `TestExtractTarGzBinary` in `bench_test.go`.
+- [x] `run.sh` delegates to the subcommand and the
+      `bench-fragments` drift gate is unchanged (stays
+      green: committed JSON/fragments untouched).
+- [x] `benchmark.yml` writes only `assets/benchmarks/`,
+      commits only on change, and pushes to the `assets`
+      branch — never `main`. (Exercisable only on merge.)
+- [x] Website serves numbers from the `assets` branch via
+      build-time fetch (`pull-site-assets` +
+      scoped `mdsmith fix` in `pages.yml`). (Exercisable
+      only on a site deploy.)
+- [x] `go test ./...`, `golangci-lint`, `mdsmith check .`
       all pass.

--- a/website/layouts/partials/hero.html
+++ b/website/layouts/partials/hero.html
@@ -47,11 +47,13 @@
           </div>
           {{- /* The GIF is recorded from demo.tape and published
                  to the orphan `assets` branch by demo.yml on push
-                 to main (same source the README embeds). It is not
-                 part of the Hugo build, so it loads from the raw
-                 GitHub URL rather than a local static asset. */ -}}
+                 to main. The pages-deploy workflow pulls it into
+                 website/static/img/ at build time (mdsmith-release
+                 pull-site-assets), so it ships as a first-party
+                 site asset instead of a runtime
+                 raw.githubusercontent hotlink. */ -}}
           <img class="hero-demo-img"
-               src="https://raw.githubusercontent.com/{{ $.Site.Params.githubRepo }}/assets/assets/demo.gif"
+               src="{{ "img/demo.gif" | relURL }}"
                width="960" height="540" loading="lazy"
                alt="Terminal recording: mdsmith check flags issues, then mdsmith fix auto-resolves them.">
         </figure>


### PR DESCRIPTION
Implements the benchmark automation plan (plan/184) by porting the shell-based benchmark harness into Go and integrating it with CI/CD workflows.

## Summary

The cross-tool Markdown linter benchmark now runs automatically on every merge to `main`, with results published to an orphan `assets` branch. The benchmark harness logic has been moved from `run.sh` into the `mdsmith-release` CLI to ensure the local hand-refresh and the post-merge `benchmark.yml` workflow run byte-identical code.

## Key Changes

**Benchmark Harness (`internal/release/bench.go`)**
- Pinned manifest for four comparison tools (hyperfine, mado, panache, rumdl) with SHA-256 integrity verification
- Fail-loud checksum validation that names both digests on mismatch
- Corpus building: repo Markdown (with fixtures filtered) and neutral third-party prose (Rust Book + Reference)
- Hyperfine orchestration and JSON promotion into `docs/research/benchmarks/data/`
- Fragment regeneration via the existing `gen_fragments.py`
- Comprehensive unit tests covering manifest invariants, checksum verification, tar extraction, and JSON promotion

**Tool Pinning**
- Moved `rumdl` from unpinned `uv tool install` to pinned GitHub release tarball (v0.1.93) with SHA-256 verification
- Pinned `markdownlint-cli2` (0.22.1) via committed `docs/research/benchmarks/npm/package.json` + `package-lock.json`
- All four binary tools now fetch and verify through the same tarball path

**CI/CD Integration**
- New `benchmark.yml` workflow: runs on push to `main`, skips `github-actions[bot]`, records benchmark numbers and publishes to `assets` branch under `assets/benchmarks/`
- Scoped subtree updates on the shared `assets` branch (coexists with `demo.yml`)
- `pages.yml` integration: `pull-site-assets` subcommand fetches published fragments + demo GIF at build time

**Site Assets (`internal/release/siteassets.go`)**
- Build-time fetch of published demo GIF and benchmark numbers from the orphan `assets` branch
- Graceful fallback: required assets (demo GIF) fail the deploy on miss; optional assets (benchmark fragments) keep the committed snapshot
- Demo GIF now ships as a first-party static asset instead of a runtime `raw.githubusercontent` hotlink

**CLI Updates**
- Added `mdsmith-release bench [workdir]` subcommand
- Added `mdsmith-release pull-site-assets` subcommand
- Updated help text and dispatch routing

**Documentation**
- Rewrote `run.sh` as a thin wrapper over `go run ./cmd/mdsmith-release bench`
- Updated plan/184 status to complete
- Updated benchmark README and release-tooling docs

## Implementation Details

- The benchmark harness validates its manifest at startup, catching half-specified or unpinned tools before any download
- Corpus caching in `workdir` makes local reruns cheap; CI passes a fresh `/tmp` path for cold runs
- Fragment normalization happens in the `record` job via `mdsmith fix` before promotion, ensuring published fragments are byte-identical to what the `bench-fragments` gate would regenerate
- The `bench-fragments` drift gate remains a separate workflow that never calls `pull-site-assets`, so it keeps validating the committed snapshot against committed JSON
- HTTP client carries a 5-minute timeout to prevent indefinite hangs on stuck publishes/deploys

https://claude.ai/code/session_013h3VNdVYqgVQkAMDa8QkC6