### PR TITLE
Configure Codecov to handle fork PR uploads gracefully

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,15 +8,28 @@ coverage:
         # mean). patch stays at 0%, so undertested new
         # code still fails.
         threshold: 0.2%
+        # Fork PRs skip the Codecov upload (see ci.yml's
+        # upload steps gated on head.repo.full_name).
+        # Without these, the required status check would
+        # never post on a fork PR and branch protection
+        # would block the merge. `success` posts a passing
+        # status when no report arrives or no base report
+        # exists — same-repo PRs still gate on real numbers.
+        if_no_uploads: success
+        if_not_found: success
     patch:
       default:
         target: auto
         threshold: 0%
+        if_no_uploads: success
+        if_not_found: success
     # Per-file gate: fail the status check if any
     # file's coverage decreased vs the base commit.
     changes:
       default:
         enabled: true
+        if_no_uploads: success
+        if_not_found: success
 
 # Coverage is uploaded with a flag per language so each report
 # only contains the files it actually measured. Without flags,


### PR DESCRIPTION
## Summary

Updates `codecov.yml` to configure Codecov status checks to pass when coverage reports are unavailable, which occurs on fork PRs where the upload step is skipped for security reasons.

## Changes

- Added `if_no_uploads: success` and `if_not_found: success` to the `coverage.precision` section to allow the required status check to pass when no report is uploaded
- Added the same configuration to the `patch.default` section for patch coverage checks
- Added the same configuration to the `changes.default` section for per-file coverage change detection
- Added explanatory comments documenting why fork PRs skip Codecov uploads and how these settings prevent branch protection from blocking merges on fork PRs

## Details

Fork PRs skip the Codecov upload step (gated in CI configuration) to avoid exposing credentials. Without these settings, the required Codecov status check would never post on a fork PR, causing branch protection rules to block the merge. By setting both `if_no_uploads` and `if_not_found` to `success`, the status check will post a passing result when no report arrives or no base report exists, while same-repo PRs continue to gate on actual coverage numbers.

https://claude.ai/code/session_01MaHBkhMJKk3jGJe1b6zuSR