### PR TITLE
Add manual workflow_dispatch trigger to website deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,11 +2,14 @@ name: Deploy mdsmith.dev
 
 # The website deploy is independent of the tool release. A docs or
 # website change on main ships the site with no tool release and no
-# `release`-environment approval. A tool release also ships the site
-# by calling this workflow (see release.yml's `pages` job), passing
-# the release version so the published site shows it. The site is
-# pure HTML built from docs/**/*.md and the homepage data files, so
-# it never needs the registry-publish credentials.
+# `release`-environment approval. A maintainer can also ship the
+# site on demand via the Actions "Run workflow" UI
+# (workflow_dispatch), optionally stamping a specific version. A
+# tool release also ships the site by calling this workflow (see
+# release.yml's `pages` job, which gates on the frozen release),
+# passing the release version so the published site shows it. The
+# site is pure HTML built from docs/**/*.md and the homepage data
+# files, so it never needs the registry-publish credentials.
 on:
   push:
     branches: [main]
@@ -28,6 +31,16 @@ on:
       - "cmd/mdsmith-release/**"
       - "internal/release/**"
       - ".github/workflows/pages.yml"
+  # Manual trigger from the Actions "Run workflow" UI. The optional
+  # version input is read through the same `inputs.version` context
+  # as workflow_call (the "Resolve site version" step below), so a
+  # blank input falls back to the latest v* tag.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to stamp into the site (defaults to the latest v* tag)"
+        required: false
+        type: string
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,13 +549,16 @@ jobs:
 
   # A tool release also ships the website. The deploy itself lives
   # in pages.yml (its own workflow, also triggered by docs-only
-  # pushes to main); this job just calls it with the release
-  # version so the published site shows the new version. Gated on
-  # `build` so a release whose binaries do not compile never
-  # deploys docs; deliberately NOT gated on the registry-publish
-  # jobs so a flaky registry publish cannot block the docs deploy.
+  # pushes to main and by manual workflow_dispatch); this job just
+  # calls it with the release version so the published site shows
+  # the new version. Gated on `release` so the site is deployed
+  # only after the release has been frozen — the draft is published
+  # and immutable — so mdsmith.dev never advertises a version whose
+  # GitHub release does not yet exist. `release` does not depend on
+  # the npm/pypi registry-publish jobs, so a flaky registry publish
+  # still cannot block the docs deploy.
   pages:
-    needs: [build]
+    needs: [release]
     if: *release_repo_trigger_ok
     permissions:
       contents: read

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -96,17 +96,15 @@ The website deploy is a **separate workflow**,
 `.github/workflows/pages.yml`. It builds
 [mdsmith.dev](https://mdsmith.dev/) from `website/`
 and deploys it to GitHub Pages. It runs on every push
-to `main` that touches `docs/**` or `website/**`, so a
-docs change ships the site with no tool release and no
-`release`-environment approval. A tool release also
-ships the site: `release.yml`'s `pages` job calls
-`pages.yml` (passing the release version) and gates on
-`build`, so a release whose binaries do not compile
-never deploys docs. The publish is asymmetric — a tool
-release implies a website deploy, but a website deploy
-does not imply a tool release. `pages.yml` sits in the
-`github-pages` environment, GitHub's built-in Pages
-protection boundary, not the `release` environment.
+to `main` under `docs/**` or `website/**`, so a docs
+change ships the site with no tool release. A
+maintainer can also deploy on demand: the
+`workflow_dispatch` trigger appears as **Run
+workflow** in the Actions tab. A tool release ships
+it too: `release.yml`'s `pages` job gates on the
+`release` job, so the site deploys only after the
+release is frozen. `pages.yml` runs in the
+`github-pages` environment, not the `release` one.
 
 `pages.yml` calls `mdsmith-release build-website
 --no-fix ./docs ./website/content/docs`. That snapshots


### PR DESCRIPTION
## Summary

Enable maintainers to manually trigger website deployments on demand via the GitHub Actions "Run workflow" UI, with optional version stamping. This complements the existing automatic deployments on docs/website changes and tool releases.

## Changes

- **pages.yml**: Added `workflow_dispatch` trigger with optional `version` input parameter, allowing manual site deploys from the Actions tab
- **pages.yml**: Updated workflow documentation to explain the new manual trigger capability alongside existing automatic triggers
- **release.yml**: Changed `pages` job dependency from `build` to `release`, ensuring the website only deploys after a release is frozen (draft published and immutable), preventing premature version advertisement
- **release.yml**: Updated job documentation to clarify the gating strategy and explain why the site deploy is decoupled from registry-publish jobs
- **docs/development/release.md**: Updated release workflow documentation to describe the new manual dispatch capability and clarify the asymmetric relationship between tool releases and website deploys

## Implementation Details

The `workflow_dispatch` input uses the same `inputs.version` context as `workflow_call`, so a blank input automatically falls back to the latest v* tag. This maintains consistency with the release workflow's version resolution logic.

The `pages` job now gates on the `release` job (not `build`) to ensure mdsmith.dev never advertises a version before its GitHub release exists, improving the user experience during release cycles.

https://claude.ai/code/session_017M1WycZD1LjWDaZrLwLtoM