### PR TITLE
Restrict production deploys to main branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,8 +65,14 @@ jobs:
   deploy:
     name: Deploy mdsmith.dev to GitHub Pages
     needs: mdsmith-check
-    # Guard fork clones: only the canonical repo deploys the site.
-    if: github.repository == 'jeduden/mdsmith'
+    # Guard fork clones and stray refs: only the canonical repo
+    # deploys, and only from `main`. workflow_dispatch lets a
+    # maintainer select any branch in the Run-workflow UI; without
+    # the ref check a manual run from a feature branch would publish
+    # that branch's content to production. push is already main-only
+    # and the release-driven workflow_call runs from `main` (the
+    # `release` environment restricts release dispatches to it).
+    if: github.repository == 'jeduden/mdsmith' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,9 +554,11 @@ jobs:
   # the new version. Gated on `release` so the site is deployed
   # only after the release has been frozen — the draft is published
   # and immutable — so mdsmith.dev never advertises a version whose
-  # GitHub release does not yet exist. `release` does not depend on
-  # the npm/pypi registry-publish jobs, so a flaky registry publish
-  # still cannot block the docs deploy.
+  # GitHub release does not yet exist. `release` transitively
+  # depends on `npm` (release -> vscode -> npm), so a failed npm
+  # publish also blocks this deploy. That is intentional: with no
+  # frozen release there is no version to ship the site for. `pypi`
+  # is not in the release chain, so a PyPI outage does not block it.
   pages:
     needs: [release]
     if: *release_repo_trigger_ok


### PR DESCRIPTION
## Summary

Hardens the GitHub Pages deployment workflow to prevent accidental publication of feature branch content to production when using `workflow_dispatch` (manual runs).

## Changes

- **pages.yml**: Added `github.ref == 'refs/heads/main'` guard to the deploy job condition
  - Prevents manual workflow runs from feature branches from deploying to production
  - `push` events are already main-only, and `workflow_call` runs from main via the release workflow
  - Expanded condition comment to explain the rationale and interaction with `workflow_dispatch`

- **release.yml**: Clarified documentation of the `pages` job's dependency chain
  - Updated comments to reflect that `pages` transitively depends on `npm` (via release → vscode → npm)
  - Documented that a failed npm publish blocks the docs deploy (intentional, as there's no frozen release to ship)
  - Noted that PyPI is not in the release chain, so PyPI outages don't block the site deploy

## Implementation Details

The ref check uses the standard GitHub Actions variable `github.ref`, which contains the full ref path (e.g., `refs/heads/main`). This ensures that only pushes and dispatches from the main branch trigger production deployment, while still allowing maintainers to manually trigger the workflow from the UI (they just won't be able to deploy from feature branches).

https://claude.ai/code/session_017M1WycZD1LjWDaZrLwLtoM