### PR TITLE
Add Claude Code skills, reviewer agent, and autofix hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "name": "Jan-Eric Duden",
     "url": "https://github.com/jeduden"
   },
-  "description": "Markdown linter for Claude Code via LSP",
+  "description": "Markdown linter for Claude Code — LSP diagnostics, slash-command skills, a Markdown reviewer subagent, and a post-edit autofix hook",
   "plugins": [
     {
       "name": "mdsmith-lsp",
@@ -21,6 +21,21 @@
       "name": "mdsmith-audit",
       "source": "./editors/claude-code-audit",
       "description": "Audit and fix Markdown file organization in an mdsmith repository"
+    },
+    {
+      "name": "mdsmith-skills",
+      "source": "./editors/claude-code-skills",
+      "description": "Slash-command skills for mdsmith fix, kinds, and check"
+    },
+    {
+      "name": "mdsmith-reviewer",
+      "source": "./editors/claude-code-reviewer",
+      "description": "Subagent that reviews Markdown PRs and drafts"
+    },
+    {
+      "name": "mdsmith-autofix",
+      "source": "./editors/claude-code-autofix",
+      "description": "Post-edit hook that runs mdsmith fix on .md files"
     }
   ]
 }

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -92,14 +92,14 @@ overrides:
           - urls
       blank-line-around-lists: false
   - glob: [".claude/skills/*/SKILL.md",
-            "editors/claude-code-audit/skills/*/SKILL.md",
+            "editors/claude-code-*/skills/*/SKILL.md",
             ".github/copilot-pr-fixup.md",
             ".github/AGENTS-PR-FIXUP.md"]
     rules:
       max-file-length:
         max: 600
   - glob: [".claude/skills/*/SKILL.md",
-            "editors/claude-code-audit/skills/*/SKILL.md"]
+            "editors/claude-code-*/skills/*/SKILL.md"]
     rules:
       # required-structure.schema for SKILL.md files comes
       # from the `skill` kind; this override only carries
@@ -317,7 +317,7 @@ kinds:
       required-structure:
         schema: internal/rules/directive-proto.md
   skill:
-    path-pattern: "{.claude/skills,editors/claude-code-audit/skills}/{proto.md,*/SKILL.md}"
+    path-pattern: "{.claude/skills,editors/claude-code-*/skills}/{proto.md,*/SKILL.md}"
     rules:
       required-structure:
         schema: .claude/skills/proto.md
@@ -510,7 +510,7 @@ kind-assignment:
            "internal/rules/MDS039-build/README.md"]
     kinds: [directive-rule-readme]
   - glob: [".claude/skills/proto.md", ".claude/skills/*/SKILL.md",
-            "editors/claude-code-audit/skills/*/SKILL.md"]
+            "editors/claude-code-*/skills/*/SKILL.md"]
     kinds: [skill]
   # Each docs/**-targeting assignment also matches the synced
   # website/content/docs/** parallel path so an explicit lint

--- a/PLAN.md
+++ b/PLAN.md
@@ -86,7 +86,7 @@ footer: |
 | 156 | ✅     | opus   | [Composable required-structure schemas across multiple kinds](plan/156_kind-schema-composition.md)                                      |
 | 156 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/156_schema-entry-unification.md)                               |
 | 157 | ✅     | sonnet | [Catalog filter by front matter property](plan/157_catalog-where-filter.md)                                                             |
-| 160 | 🔲     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                                    |
+| 160 | 🔳     | sonnet | [Claude Code plugin extensions — skills, agents, hooks](plan/160_claude-code-skills-agents-hooks.md)                                    |
 | 161 | ✅     | sonnet | [Expose rule maintainability patterns via CLI help and LSP](plan/161_rule-pattern-metadata.md)                                          |
 | 162 | ✅     | sonnet | [Split the overloaded `meta` rule category](plan/162_rule-category-cleanup.md)                                                          |
 | 163 | 🔲     |        | [Extract mdsmith Markdown parse/produce as a public Go library](plan/163_public-markdown-library.md)                                    |

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -207,37 +207,117 @@ See [VS Code Integration](editors/vscode.md) for the
 configuration surface (`mdsmith.path`, `mdsmith.run`,
 `mdsmith.fixOnSave`, `mdsmith.trace.server`).
 
-## Claude Code plugin
+## Claude Code plugins
 
-The Claude Code plugin runs
-`npx -y -p @mdsmith/cli mdsmith lsp`. The agent
-receives Markdown diagnostics inline after every
-edit. It also gains definition, references,
-symbol search, and call-hierarchy queries across
-the docs. Register the marketplace and install
-the plugin:
+The mdsmith marketplace ships six plugins.
+Register once, then install whichever you need:
 
 ```text
 /plugin marketplace add jeduden/mdsmith
+```
+
+### mdsmith-lsp
+
+Inline diagnostics, quick-fixes, and navigation
+(definition, references, symbol search,
+call-hierarchy) via `mdsmith lsp`. Required by
+most users.
+
+```text
 /plugin install mdsmith-lsp@mdsmith
 /reload-plugins
 ```
 
-`npx` is bundled with npm, which standard Node.js
-installers ship and Claude Code already requires.
-First launch downloads `@mdsmith/cli` and the
-platform binary subpackage from npm; later launches
-reuse the npm cache. No global `mdsmith` install is
-needed. To pin a version, edit the plugin
-manifest's `args` to read `@mdsmith/cli@<ver>` in
-place of `@mdsmith/cli`.
+The plugin runs `npx -y -p @mdsmith/cli mdsmith
+lsp`. `npx` is bundled with npm, which standard
+Node.js installers ship and Claude Code already
+requires. First launch downloads `@mdsmith/cli`
+and the platform binary from npm; later launches
+reuse the cache. No global `mdsmith` install
+needed. To pin a version, edit the manifest
+`args` to `@mdsmith/cli@<ver>`.
 
-If the `/plugin` Errors tab shows `Executable not
-found in $PATH`, `npx` is missing from the shell
-`$PATH` Claude Code sees. Install Node 18 or later
-(20 LTS recommended) — the standard installer
-bundles npm and npx — then run `/reload-plugins`.
+If the `/plugin` Errors tab shows `Executable
+not found in $PATH`, `npx` is missing. Install
+Node 18 or later (20 LTS recommended) and run
+`/reload-plugins`.
 
 See the
 [Claude Code editor README](../../editors/claude-code/README.md)
-for the install commands and troubleshooting steps.
+for troubleshooting steps.
+
+### mdsmith-skills
+
+Three slash-command skills:
+`/mdsmith-fix [path]`, `/mdsmith-kinds [...]`,
+and `/mdsmith-check [path]`. Useful without the
+LSP plugin, or to run a targeted fix from the
+command palette.
+
+```text
+/plugin install mdsmith-skills@mdsmith
+/reload-plugins
+```
+
+Requires `mdsmith` on the `$PATH` Claude Code
+sees (or the mdsmith source tree under
+`./cmd/mdsmith`).
+
+### mdsmith-reviewer
+
+A `markdown-reviewer` subagent that reviews
+Markdown PRs and drafts for structural drift.
+Loads rule-backed patterns from `mdsmith help
+patterns` at review time and checks three
+config-level patterns from a sibling
+`patterns.md`. Proposes config or directive
+snippets; no auto-fix.
+
+```text
+/plugin install mdsmith-reviewer@mdsmith
+/reload-plugins
+```
+
+Requires `mdsmith` on the `$PATH`.
+
+### mdsmith-autofix
+
+A `PostToolUse` hook that runs `mdsmith fix`
+on every `.md` file Claude Code edits. Keeps
+generated sections, whitespace, and table
+alignment in sync automatically.
+
+```text
+/plugin install mdsmith-autofix@mdsmith
+/reload-plugins
+```
+
+Requires `mdsmith` and `jq` on the `$PATH`.
+This plugin is opt-in: if you prefer to run
+`/mdsmith-fix` manually, skip it.
+
+### mdsmith-audit
+
+The `markdown-audit` skill. Audits an mdsmith
+repository for structural problems the built-in
+rules cannot see: hand-maintained indexes,
+similar files without a kind, missing
+`.mdsmith.yml`, and kinds without a
+`path-pattern`.
+
+```text
+/plugin install mdsmith-audit@mdsmith
+/reload-plugins
+```
+
+### mdsmith-dev-lsp
+
+Go and TypeScript LSP servers for mdsmith
+contributors. Installs `gopls` and the
+TypeScript language server alongside
+`mdsmith lsp` for development.
+
+```text
+/plugin install mdsmith-dev-lsp@mdsmith
+/reload-plugins
+```

--- a/editors/claude-code-autofix/.claude-plugin/plugin.json
+++ b/editors/claude-code-autofix/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mdsmith-autofix",
+  "description": "Post-edit hook that runs mdsmith fix on .md files after Edit, Write, or MultiEdit tool calls.",
+  "homepage": "https://github.com/jeduden/mdsmith",
+  "repository": "https://github.com/jeduden/mdsmith",
+  "license": "MIT",
+  "keywords": [
+    "markdown",
+    "hook",
+    "autofix"
+  ]
+}

--- a/editors/claude-code-autofix/README.md
+++ b/editors/claude-code-autofix/README.md
@@ -1,0 +1,59 @@
+---
+title: mdsmith autofix plugin
+summary: >-
+  Marketplace plugin that installs a PostToolUse
+  hook running `mdsmith fix` on every `.md` file
+  Claude Code edits.
+---
+# mdsmith autofix plugin
+
+A Claude Code hook that runs `mdsmith fix`
+automatically after every `Edit`, `Write`, or
+`MultiEdit` tool call on a `.md` or `.markdown`
+file.
+
+The hook keeps generated sections (catalog,
+include, toc, build), whitespace, headings, and
+table alignment in sync as the agent edits.
+Without this plugin, `mdsmith fix` must be run
+manually or via `/mdsmith-fix`.
+
+## Install
+
+```text
+/plugin marketplace add jeduden/mdsmith
+/plugin install mdsmith-autofix@mdsmith
+/reload-plugins
+```
+
+## Prerequisites
+
+`mdsmith` and `jq` must both be on the `$PATH`
+that Claude Code sees.
+
+Install `mdsmith`:
+
+```text
+npm install -g @mdsmith/cli
+```
+
+Install `jq` via your OS package manager (e.g.
+`brew install jq`, `apt install jq`).
+
+## Opt-out
+
+This plugin is opt-in. If you prefer to run
+`mdsmith fix` manually or via `/mdsmith-fix`,
+simply do not install `mdsmith-autofix`.
+
+## Hook details
+
+The hook fires on `PostToolUse` for
+`Edit|Write|MultiEdit`. It reads the edited
+file path from `.tool_input.file_path`, strips
+the workspace prefix so relative globs match,
+and calls `mdsmith fix -- <relative-path>`.
+
+Non-Markdown files are skipped silently. A
+`mdsmith fix` failure does not fail the hook —
+it exits 0 so the agent is not blocked.

--- a/editors/claude-code-autofix/hooks/hooks.json
+++ b/editors/claude-code-autofix/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(jq -re '.tool_input.file_path // empty') || { echo 'hook: jq missing or no file_path' >&2; exit 1; }; case \"$FILE\" in *.md|*.markdown) mdsmith fix -- \"${FILE#\"$PWD/\"}\" || true;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/editors/claude-code-reviewer/.claude-plugin/plugin.json
+++ b/editors/claude-code-reviewer/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mdsmith-reviewer",
+  "description": "Subagent that reviews Markdown PRs and drafts — checks rule-backed patterns via mdsmith help and surfaces three config-level checks from patterns.md.",
+  "homepage": "https://github.com/jeduden/mdsmith",
+  "repository": "https://github.com/jeduden/mdsmith",
+  "license": "MIT",
+  "keywords": [
+    "markdown",
+    "review",
+    "agent"
+  ]
+}

--- a/editors/claude-code-reviewer/README.md
+++ b/editors/claude-code-reviewer/README.md
@@ -1,0 +1,72 @@
+---
+title: mdsmith reviewer plugin
+summary: >-
+  Marketplace plugin that ships the
+  `markdown-reviewer` subagent for reviewing
+  Markdown PRs and drafts in an mdsmith
+  repository.
+---
+# mdsmith reviewer plugin
+
+A Claude Code subagent that reviews Markdown
+files for structural and organizational problems
+beyond what `mdsmith check` enforces inline.
+
+The agent loads rule-backed patterns from
+`mdsmith help patterns` at review time — new
+rules appear automatically without plugin
+updates. It also checks three config-level
+patterns from sibling `patterns.md`: missing
+`.mdsmith.yml`, similar files without a kind,
+and a kind without `path-pattern`. No auto-fix;
+the agent proposes the config or directive to
+adopt.
+
+## Install
+
+```text
+/plugin marketplace add jeduden/mdsmith
+/plugin install mdsmith-reviewer@mdsmith
+/reload-plugins
+```
+
+## Prerequisites
+
+`mdsmith` must be on the `$PATH` that Claude
+Code sees. Install it via:
+
+```text
+npm install -g @mdsmith/cli
+```
+
+or any other channel from the
+[install guide](../../docs/guides/install.md).
+
+Alternatively, the agent falls back to
+`go run ./cmd/mdsmith` when the workspace
+contains the mdsmith source tree.
+
+## Usage
+
+Invoke by name from any mdsmith-aware
+repository:
+
+```text
+Review the Markdown changes in PR 42.
+```
+
+```text
+Audit the docs/ directory for structural drift.
+```
+
+The agent produces a severity-grouped report
+(blockers, tax, nice-to-have) with fix
+snippets.
+
+## What it checks
+
+See
+[`agents/markdown-reviewer.md`](agents/markdown-reviewer.md)
+for the full workflow and
+[`patterns.md`](patterns.md)
+for the three config-level check recipes.

--- a/editors/claude-code-reviewer/agents/markdown-reviewer.md
+++ b/editors/claude-code-reviewer/agents/markdown-reviewer.md
@@ -1,0 +1,151 @@
+---
+name: markdown-reviewer
+description: >-
+  Review Markdown files in a PR or workspace for
+  structural and organizational problems beyond
+  what `mdsmith check` enforces inline. Loads
+  rule-backed patterns from `mdsmith help
+  patterns -f json`; checks config-level patterns
+  from sibling `patterns.md`. Proposes the rule,
+  directive, or kind config to adopt so the
+  pattern stops drifting — content nits stay with
+  `mdsmith check`. No auto-fix; review only.
+tools:
+  - Read
+  - Grep
+  - Bash
+  - mcp__github__pull_request_read
+  - mcp__github__get_file_contents
+  - mcp__github__list_pull_requests
+---
+# markdown-reviewer
+
+Review Markdown files for structural and
+organizational patterns that `mdsmith check`
+cannot enforce without declared structure.
+
+## Capabilities
+
+- Load rule-backed patterns at review time via
+  `mdsmith help patterns -f json`; never
+  hard-code the signal or fix wording.
+- Check three config-level patterns from sibling
+  `patterns.md` (no `.mdsmith.yml`, similar files
+  without a kind, kind without `path-pattern`).
+- Surface findings grouped by severity (blocker,
+  tax, nice-to-have) with the directive or config
+  snippet to adopt.
+- Read GitHub PR diff and file list when a PR
+  number is given.
+
+## When to invoke
+
+Invoke this agent when a user asks to review a
+Markdown PR, audit a draft, or check a directory
+for structural drift. Skip when the user only
+wants content nits (spelling, wording) — those
+belong to `mdsmith check`.
+
+## Workflow
+
+### 1. Locate the workspace
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Use the printed path for every subsequent
+command.
+
+### 2. Detect the mdsmith CLI
+
+```bash
+mdsmith version
+```
+
+If that fails:
+
+```bash
+go run ./cmd/mdsmith version
+```
+
+Substitute `go run ./cmd/mdsmith` for `mdsmith`
+in every command below when the first form
+fails.
+
+### 3. Load rule-backed patterns
+
+```bash
+mdsmith help patterns -f json
+```
+
+Each record is `{id, name, signal, fix,
+for-diagnostic}`. Use the `signal` and `fix`
+fields as-is. Do not paraphrase them.
+
+### 4. Load config-level patterns
+
+Read `patterns.md` from the plugin root
+(sibling of `agents/`). It describes three
+config-level checks with signal, heuristic,
+severity, and fix recipe.
+
+### 5. Collect files under review
+
+For a PR: read the changed files from the GitHub
+MCP tool (`mcp__github__pull_request_read`).
+
+For a directory argument: list `.md` files with
+`find <dir> -name '*.md'`.
+
+For a single file: use it directly.
+
+### 6. Run checks
+
+Run all checks from step 3 and step 4 against
+the collected files.
+
+Also run:
+
+```bash
+mdsmith check -f json -- <path>
+```
+
+to surface any inline diagnostics the agent
+should flag.
+
+```bash
+mdsmith kinds resolve -- <file>
+```
+
+on sampled files to confirm kind assignment.
+
+### 7. Emit the review
+
+Group findings by severity. For each finding,
+include:
+
+- The file path.
+- The pattern name and signal.
+- The directive, kind config, or `mdsmith init`
+  call that resolves it.
+
+Format:
+
+```markdown
+## Review YYYY-MM-DD
+
+### Blockers
+- `path`: signal — fix snippet.
+
+### Tax
+- `path`: signal — fix snippet.
+
+### Nice-to-have
+- `path`: signal — fix snippet.
+
+Summary: N blockers, N tax, N nice-to-have.
+```
+
+Do not propose auto-fix. The user acts on the
+report.

--- a/editors/claude-code-reviewer/patterns.md
+++ b/editors/claude-code-reviewer/patterns.md
@@ -1,0 +1,118 @@
+---
+title: Detection patterns
+summary: >-
+  Detection heuristics, false positives, and fix
+  recipes for the three config-level checks the
+  `markdown-reviewer` agent runs that no built-in
+  rule backs.
+---
+# Detection patterns
+
+These three checks have no backing rule, so their
+signal and fix live here rather than in a rule
+README. Each section covers one numbered
+config-level check from the sibling agent
+workflow: the signal, the heuristic, false
+positives to skip, the severity bucket, and the
+fix recipe.
+
+The other checks come from built-in rules. Load
+their signal and fix from `mdsmith help patterns
+-f json`. The agent workflow step 3 has the call.
+
+## Check 1 — No `.mdsmith.yml`
+
+Signal: `.mdsmith.yml` does not exist at the repo
+root (`test -f .mdsmith.yml`).
+
+False positives: a repo with one or two top-level
+Markdown files and nothing else. Skip with a
+one-line note.
+
+Severity: blocker when the repo has five or more
+`.md` files. Nice-to-have otherwise.
+
+Fix: run `mdsmith init` to create a default
+config. Then walk the remaining checks to
+populate kinds, overrides, and assignments.
+
+## Check 2 — Similar files, no kind
+
+Signal: a directory holds three or more `.md`
+files with a similar front matter shape. The
+files share the same required keys. No
+`kind-assignment:` entry covers the directory.
+
+Heuristic: list directories with three or more
+`.md` files
+(`git ls-files '*.md' | xargs -n1 dirname | sort | uniq -c`).
+For each candidate, sample every file's front
+matter. The directory is a kind candidate when 70%
+of files share the same key set, and no glob in
+`.mdsmith.yml` already covers it.
+
+False positives:
+
+- A directory of one-off Markdown without shared
+  front matter (research spikes, ad-hoc notes).
+- A directory already covered by a glob in
+  `kind-assignment:`, even when the kind body is
+  empty. The assignment alone counts.
+- Bad fixtures inside `internal/rules/*/bad/`,
+  intentionally malformed and under `ignore:`.
+
+Severity: tax. Drop to nice-to-have when the
+shared shape is small.
+
+Fix: add an entry to `kinds:` plus a matching
+`kind-assignment:` glob.
+
+```yaml
+kinds:
+  runbook:
+    rules:
+      max-file-length:
+        max: 400
+
+kind-assignment:
+  - glob: ["runbooks/*.md"]
+    kinds: [runbook]
+```
+
+Start with the settings the files actually share
+right now. Do not over-engineer. After applying,
+run `mdsmith kinds resolve runbooks/example.md` to
+confirm the file picks up the new kind.
+
+## Check 3 — Kind without `path-pattern`
+
+Signal: a declared kind whose files share an
+obvious naming convention, but the kind body has
+no `path-pattern:`.
+
+Heuristic: read `kinds:` and `kind-assignment:`
+from `.mdsmith.yml`. For each kind, walk the files
+that resolve to it. The kind is a candidate when
+80% of those files share a regex-shaped filename.
+Examples: `\d+_[a-z-]+\.md`, `RFC-\d{4}\.md`.
+
+False positives: a kind with intentionally
+heterogeneous membership — a "doc" kind covering
+README, index, and topic pages qualifies.
+
+Severity: nice-to-have.
+
+Fix: add `path-pattern:` to the kind body.
+
+```yaml
+kinds:
+  plan:
+    path-pattern: "plan/[0-9][0-9]*_*.md"
+```
+
+Glob syntax has no "exactly digits" class, so the
+pattern is an approximation. For tighter
+constraints, combine `path-pattern:` with a
+`<?require filename:?>` directive on the kind's
+schema. Re-run `mdsmith check .` to confirm no
+existing file fails the new pattern.

--- a/editors/claude-code-skills/.claude-plugin/plugin.json
+++ b/editors/claude-code-skills/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mdsmith-skills",
+  "description": "Slash-command skills for mdsmith fix, kinds, and check — run lint, inspect file-kind resolution, and auto-fix Markdown from Claude Code.",
+  "homepage": "https://github.com/jeduden/mdsmith",
+  "repository": "https://github.com/jeduden/mdsmith",
+  "license": "MIT",
+  "keywords": [
+    "markdown",
+    "skills",
+    "mdsmith"
+  ]
+}

--- a/editors/claude-code-skills/README.md
+++ b/editors/claude-code-skills/README.md
@@ -1,0 +1,49 @@
+---
+title: mdsmith skills plugin
+summary: >-
+  Marketplace plugin that ships slash-command
+  skills for `mdsmith fix`, `mdsmith kinds`, and
+  `mdsmith check`.
+---
+# mdsmith skills plugin
+
+Three Claude Code slash-command skills that run
+`mdsmith` subcommands from the agent.
+
+## Install
+
+```text
+/plugin marketplace add jeduden/mdsmith
+/plugin install mdsmith-skills@mdsmith
+/reload-plugins
+```
+
+## Prerequisites
+
+`mdsmith` must be on the `$PATH` that Claude
+Code sees. Install it via:
+
+```text
+npm install -g @mdsmith/cli
+```
+
+or any other channel from the
+[install guide](../../docs/guides/install.md).
+
+Alternatively, the skills fall back to
+`go run ./cmd/mdsmith` when the workspace
+contains the mdsmith source tree.
+
+## Skills
+
+| Slash command                             | What it runs    |
+|-------------------------------------------|-----------------|
+| `/mdsmith-fix [path]`                     | `mdsmith fix`   |
+| `/mdsmith-kinds [resolve <file> \| list]` | `mdsmith kinds` |
+| `/mdsmith-check [path]`                   | `mdsmith check` |
+
+All three default to `.` (workspace root) when
+no argument is given.
+
+See each `SKILL.md` under `skills/` for the
+full workflow.

--- a/editors/claude-code-skills/skills/mdsmith-check/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-check/SKILL.md
@@ -10,7 +10,10 @@ description: >-
   lint errors".
 user-invocable: true
 argument-hint: "[path | .]"
-allowed-tools: "Bash(mdsmith:*)"
+allowed-tools: >-
+  Bash(mdsmith:*),
+  Bash(git rev-parse:*),
+  Bash(go run ./cmd/mdsmith:*)
 ---
 # mdsmith check
 

--- a/editors/claude-code-skills/skills/mdsmith-check/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-check/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: mdsmith-check
+description: >-
+  Run `mdsmith check` on Markdown files in the
+  current workspace and surface lint diagnostics.
+  Useful without the `mdsmith-lsp` plugin — gives
+  the same findings in a text report. Trigger when
+  the user asks to "check my markdown", "run
+  mdsmith check", "lint these files", or "show
+  lint errors".
+user-invocable: true
+argument-hint: "[path | .]"
+allowed-tools: "Bash(mdsmith:*)"
+---
+# mdsmith check
+
+Run `mdsmith check` on the argument, defaulting
+to `.` (entire workspace) when no argument is
+given.
+
+## Steps
+
+1. Locate the workspace root:
+
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+
+   Run every subsequent command from that path.
+   Without `git`, use the current directory.
+
+2. Detect the mdsmith CLI. Try, in order:
+
+   ```bash
+   mdsmith version
+   ```
+
+   ```bash
+   go run ./cmd/mdsmith version
+   ```
+
+   If only the second succeeds, substitute
+   `go run ./cmd/mdsmith` for `mdsmith` below.
+
+3. Run the check:
+
+   ```bash
+   mdsmith check -- <path>
+   ```
+
+   where `<path>` is the skill argument, or `.`
+   when none was given.
+
+4. Surface the full stdout. If the command exits
+   non-zero, also show stderr and end with a
+   summary line: `N diagnostic(s) found`.
+
+## Notes
+
+`mdsmith check` exits 0 when all files pass,
+1 when diagnostics are found, and 2 on a fatal
+error (bad config, binary missing, etc.). Only
+exit code 2 means the CLI itself failed.

--- a/editors/claude-code-skills/skills/mdsmith-fix/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-fix/SKILL.md
@@ -12,7 +12,10 @@ description: >-
   "regenerate sections".
 user-invocable: true
 argument-hint: "[path | .]"
-allowed-tools: "Bash(mdsmith:*)"
+allowed-tools: >-
+  Bash(mdsmith:*),
+  Bash(git rev-parse:*),
+  Bash(go run ./cmd/mdsmith:*)
 ---
 # mdsmith fix
 

--- a/editors/claude-code-skills/skills/mdsmith-fix/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-fix/SKILL.md
@@ -59,9 +59,9 @@ given.
 4. If the command exits non-zero, surface the
    full stderr to the user.
 
-5. Report how many files were rewritten (parse
-   the last line of stdout, which reads
-   `N file(s) fixed`).
+5. Report the fix summary from the last line of
+   stderr, which reads:
+   `stats: checked=N fixed=N failures=N unfixed=N`.
 
 ## Notes
 

--- a/editors/claude-code-skills/skills/mdsmith-fix/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-fix/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: mdsmith-fix
+description: >-
+  Run `mdsmith fix` on Markdown files in the
+  current workspace. Auto-fixes whitespace,
+  headings, code fences, bare URLs, list
+  indentation, table alignment, and generated
+  sections (catalog, include, toc, build) in
+  place, looping until edits stabilize. Trigger
+  when the user asks to "fix my markdown",
+  "run mdsmith fix", "clean up lint", or
+  "regenerate sections".
+user-invocable: true
+argument-hint: "[path | .]"
+allowed-tools: "Bash(mdsmith:*)"
+---
+# mdsmith fix
+
+Run `mdsmith fix` on the argument, defaulting
+to `.` (entire workspace) when no argument is
+given.
+
+## Steps
+
+1. Locate the workspace root:
+
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+
+   Run every subsequent command from that path.
+   Without `git`, use the current directory.
+
+2. Detect the mdsmith CLI. Try, in order:
+
+   ```bash
+   mdsmith version
+   ```
+
+   ```bash
+   go run ./cmd/mdsmith version
+   ```
+
+   If only the second succeeds, substitute
+   `go run ./cmd/mdsmith` for `mdsmith` below.
+
+3. Run the fix:
+
+   ```bash
+   mdsmith fix -- <path>
+   ```
+
+   where `<path>` is the skill argument, or `.`
+   when none was given.
+
+4. If the command exits non-zero, surface the
+   full stderr to the user.
+
+5. Report how many files were rewritten (parse
+   the last line of stdout, which reads
+   `N file(s) fixed`).
+
+## Notes
+
+`mdsmith fix` loops up to 10 passes. It exits
+0 even when files change — a non-zero exit
+means the CLI itself failed (binary missing,
+config parse error, etc.).

--- a/editors/claude-code-skills/skills/mdsmith-kinds/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-kinds/SKILL.md
@@ -10,7 +10,10 @@ description: >-
   or "resolve this file's config".
 user-invocable: true
 argument-hint: "[resolve <file> | list]"
-allowed-tools: "Bash(mdsmith:*)"
+allowed-tools: >-
+  Bash(mdsmith:*),
+  Bash(git rev-parse:*),
+  Bash(go run ./cmd/mdsmith:*)
 ---
 # mdsmith kinds
 

--- a/editors/claude-code-skills/skills/mdsmith-kinds/SKILL.md
+++ b/editors/claude-code-skills/skills/mdsmith-kinds/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mdsmith-kinds
+description: >-
+  Inspect how mdsmith resolves file kinds in the
+  current workspace. `resolve` shows the effective
+  kind and merged rule config for one file;
+  `list` enumerates all declared kinds. Trigger
+  when the user asks "what kind is this file",
+  "which rules apply here", "show me the kinds",
+  or "resolve this file's config".
+user-invocable: true
+argument-hint: "[resolve <file> | list]"
+allowed-tools: "Bash(mdsmith:*)"
+---
+# mdsmith kinds
+
+Inspect file-kind resolution and the effective
+rule config that results.
+
+## Subcommands
+
+Pass the subcommand as the skill argument.
+
+- **`resolve <file>`** — print the kind(s)
+  assigned to `<file>` and the merged rule
+  config. Required when the user asks about a
+  specific file.
+- **`list`** — enumerate all declared kinds in
+  the workspace config.
+
+When no argument is given, default to `list`.
+
+## Steps
+
+1. Locate the workspace root:
+
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+
+   Run every subsequent command from that path.
+   Without `git`, use the current directory.
+
+2. Detect the mdsmith CLI. Try, in order:
+
+   ```bash
+   mdsmith version
+   ```
+
+   ```bash
+   go run ./cmd/mdsmith version
+   ```
+
+   If only the second succeeds, substitute
+   `go run ./cmd/mdsmith` for `mdsmith` below.
+
+3. Run the subcommand:
+
+   For `resolve <file>`:
+
+   ```bash
+   mdsmith kinds resolve -- <file>
+   ```
+
+   For `list`:
+
+   ```bash
+   mdsmith kinds list
+   ```
+
+4. Surface the full stdout. If the command exits
+   non-zero, surface stderr as well.

--- a/plan/160_claude-code-skills-agents-hooks.md
+++ b/plan/160_claude-code-skills-agents-hooks.md
@@ -1,7 +1,7 @@
 ---
 id: 160
 title: Claude Code plugin extensions — skills, agents, hooks
-status: "🔲"
+status: "🔳"
 model: sonnet
 depends-on: [161]
 summary: >-
@@ -301,9 +301,9 @@ without auto-installing.
       new manifest; `mdsmith kinds resolve`
       reports `skill` for audit and
       `mdsmith-skills` SKILL.md files.
-- [ ] The [install guide][install-guide]
+- [x] The [install guide][install-guide]
       documents all six plugins.
-- [ ] `go test ./...` and `mdsmith check .`
+- [x] `go test ./...` and `mdsmith check .`
       pass.
 
 ## Open Questions


### PR DESCRIPTION
Completes the Claude Code plugin ecosystem by shipping three new plugins alongside the existing LSP and audit tools.

## Summary

This change adds three new Claude Code marketplace plugins that extend mdsmith integration:

1. **mdsmith-skills** — Three slash-command skills (`/mdsmith-fix`, `/mdsmith-kinds`, `/mdsmith-check`) that let users run mdsmith subcommands from the agent without the LSP plugin.

2. **mdsmith-reviewer** — A `markdown-reviewer` subagent that audits Markdown PRs and drafts for structural drift. Loads rule-backed patterns from `mdsmith help patterns` at review time and checks three config-level patterns (missing `.mdsmith.yml`, similar files without a kind, kinds without `path-pattern`) from a sibling `patterns.md` file. Proposes config or directive snippets; no auto-fix.

3. **mdsmith-autofix** — A `PostToolUse` hook that runs `mdsmith fix` automatically on every `.md` file Claude Code edits, keeping generated sections, whitespace, and table alignment in sync without manual intervention.

## Key changes

- **`editors/claude-code-skills/`** — New plugin with three skills:
  - `skills/mdsmith-fix/SKILL.md` — Run `mdsmith fix` on a path or workspace
  - `skills/mdsmith-kinds/SKILL.md` — Inspect file-kind resolution and effective rule config
  - `skills/mdsmith-check/SKILL.md` — Run `mdsmith check` and surface lint diagnostics
  - `README.md` — Plugin overview and install instructions
  - `.claude-plugin/plugin.json` — Plugin manifest

- **`editors/claude-code-reviewer/`** — New plugin with a subagent:
  - `agents/markdown-reviewer.md` — Full workflow for the `markdown-reviewer` subagent
  - `patterns.md` — Detection heuristics and fix recipes for three config-level checks
  - `README.md` — Plugin overview and usage guide
  - `.claude-plugin/plugin.json` — Plugin manifest

- **`editors/claude-code-autofix/`** — New plugin with a hook:
  - `hooks/hooks.json` — `PostToolUse` hook that runs `mdsmith fix` on `.md` files after edits
  - `README.md` — Plugin overview and prerequisites
  - `.claude-plugin/plugin.json` — Plugin manifest

- **`.claude-plugin/marketplace.json`** — Updated to register all three new plugins and expanded the marketplace description to reflect the full plugin suite.

- **`docs/guides/install.md`** — Expanded Claude Code section to document all six plugins (LSP, skills, reviewer, autofix, audit, dev-lsp) with separate subsections for each, install commands, and prerequisites.

- **`.mdsmith.yml`** — Updated glob pattern for SKILL.md files to cover all `claude-code-*` subdirectories, not just audit.

- **`plan/160_claude-code-skills-agents-hooks.md`** — Marked as complete (status changed from `🔲` to `🔳`).

## Implementation details

- The skills (`mdsmith-fix`, `mdsmith-kinds`, `mdsmith-check`) and the reviewer agent try `mdsmith` on `$PATH` first, then fall back to `go run ./cmd/mdsmith` when the workspace contains the mdsmith source tree.
- The autofix hook (`mdsmith-autofix`) requires a pre-installed `mdsmith` binary on `$PATH`. A `go run` fallback is intentionally omitted — it would impose compilation overhead on every `.md` edit. The README documents `mdsmith` and `jq` as hard prerequisites.
- The reviewer agent loads rule-backed patterns dynamically via `mdsmith help patterns -f json`, so new rules appear automatically without plugin updates.
- The autofix hook uses `jq` to extract the edited file path and runs `mdsmith fix` with a relative path so globs match correctly.
- All skills and the reviewer agent default to `.` (workspace root) when no argument is given.

https://claude.ai/code/session_01VKHYR9fgkjXzseTkGCNzhD