### PR TITLE
Mount synced docs tree at site root, not under /docs

### DIFF
--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -212,21 +212,21 @@ func TestRunBuildWebsiteEndToEnd(t *testing.T) {
 // exercised end-to-end.
 func TestRunVerifyWebsiteLinksHappyPath(t *testing.T) {
 	root := t.TempDir()
-	mq := filepath.Join(root, "docs", "development", "merge-queue", "index.html")
-	aa := filepath.Join(root, "docs", "development", "architecture-audit", "index.html")
-	st := filepath.Join(root, "docs", "reference", "schema-types", "index.html")
-	rule := filepath.Join(root, "docs", "rules", "mds001", "index.html")
+	mq := filepath.Join(root, "development", "merge-queue", "index.html")
+	aa := filepath.Join(root, "development", "architecture-audit", "index.html")
+	st := filepath.Join(root, "reference", "schema-types", "index.html")
+	rule := filepath.Join(root, "rules", "mds001", "index.html")
 	for _, dir := range []string{filepath.Dir(mq), filepath.Dir(aa), filepath.Dir(st), filepath.Dir(rule)} {
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
 	require.NoError(t, os.WriteFile(mq,
-		[]byte(`<a href="/docs/development/pr-fixup-workflow/">x</a>`), 0o644))
+		[]byte(`<a href="/development/pr-fixup-workflow/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(aa,
-		[]byte(`<a href="/docs/development/architecture/">x</a>`), 0o644))
+		[]byte(`<a href="/development/architecture/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(st,
-		[]byte(`<a href="/docs/rules/MDS020-required-structure/">x</a>`), 0o644))
+		[]byte(`<a href="/rules/MDS020-required-structure/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(rule,
-		[]byte(`<a href="/docs/rules/mds021/">x</a>`), 0o644))
+		[]byte(`<a href="/rules/mds021/">x</a>`), 0o644))
 
 	assert.Equal(t, 0, run([]string{"verify-website-links", "--dir", root}))
 }

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -224,7 +224,7 @@ func TestRunVerifyWebsiteLinksHappyPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(aa,
 		[]byte(`<a href="/development/architecture/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(st,
-		[]byte(`<a href="/rules/MDS020-required-structure/">x</a>`), 0o644))
+		[]byte(`<a href="/rules/mds020-required-structure/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(rule,
 		[]byte(`<a href="/rules/mds021/">x</a>`), 0o644))
 

--- a/docs/features/ai-guardrails.md
+++ b/docs/features/ai-guardrails.md
@@ -4,7 +4,7 @@ summary: >-
   Cap file, section, and token-budget size; enforce reading grade and
   sentence count; flag verbatim copy-paste across files.
 icon: bot
-link: "/docs/guides/metrics-tradeoffs/"
+link: "/guides/metrics-tradeoffs/"
 rules: ["MDS022", "MDS028", "MDS037"]
 weight: 4
 ---
@@ -19,7 +19,7 @@ token-budget (`MDS028`) length. Prose rules enforce a reading
 grade (`MDS023`) and a sentence count (`MDS024`). `MDS037` flags
 verbatim copy-paste across files, so a generator cannot pad the
 corpus by repeating itself. The
-[rule directory](/docs/rules/)
+[rule directory](/rules/)
 has the full reference for each.
 
 See the [metrics trade-offs guide](../guides/metrics-tradeoffs.md)

--- a/docs/features/auto-fix.md
+++ b/docs/features/auto-fix.md
@@ -6,7 +6,7 @@ summary: >-
   passes and stopping when edits stabilize. `mdsmith check` is the
   read-only CI sibling.
 icon: wrench
-link: "/docs/reference/cli/fix/"
+link: "/reference/cli/fix/"
 weight: 1
 ---
 # Auto-fix Markdown formatting

--- a/docs/features/build-artifacts.md
+++ b/docs/features/build-artifacts.md
@@ -5,7 +5,7 @@ summary: >-
   `mdsmith fix` keeps the section body in sync with the recipe
   output; `MDS040` shell-safety-checks the recipe without running it.
 icon: blocks
-link: "/docs/guides/directives/build/"
+link: "/guides/directives/build/"
 rules: ["MDS039", "MDS040"]
 weight: 11
 ---

--- a/docs/features/config-transparency.md
+++ b/docs/features/config-transparency.md
@@ -5,7 +5,7 @@ summary: >-
   kinds, then overrides. `--explain` and `mdsmith kinds resolve`
   show which layer set each effective value, per leaf.
 icon: git-compare
-link: "/docs/reference/cli/kinds/"
+link: "/reference/cli/kinds/"
 weight: 13
 ---
 # Config you can explain

--- a/docs/features/cross-file-integrity.md
+++ b/docs/features/cross-file-integrity.md
@@ -5,7 +5,7 @@ summary: >-
   per-file section schemas, and keep Markdown in the right folders.
   Schemas can be inline on a file kind or shared via `proto.md` files.
 icon: link
-link: "/docs/guides/directives/enforcing-structure/"
+link: "/guides/directives/enforcing-structure/"
 rules: ["MDS027", "MDS020", "MDS033"]
 weight: 3
 ---
@@ -19,7 +19,7 @@ resolves links and anchors across the whole workspace.
 enforces a per-file section schema: required headings,
 front-matter fields, and ordering. `MDS033` keeps each Markdown
 file in an allowed folder. The
-[rule directory](/docs/rules/)
+[rule directory](/rules/)
 has the full reference for each.
 
 A schema can be declared inline on a [file

--- a/docs/features/dependency-graph.md
+++ b/docs/features/dependency-graph.md
@@ -7,7 +7,7 @@ summary: >-
   editor.
 icon: network
 weight: 16
-link: "/docs/reference/cli/deps/"
+link: "/reference/cli/deps/"
 ---
 # See the dependency graph
 

--- a/docs/features/editor-agent-integration.md
+++ b/docs/features/editor-agent-integration.md
@@ -5,7 +5,7 @@ summary: >-
   `mdsmith lsp` server, so diagnostics, fix-on-save, and navigation
   reach your editor and your coding agent unchanged.
 icon: plug
-link: "/docs/guides/editors/vscode/"
+link: "/guides/editors/vscode/"
 weight: 14
 ---
 # Editors and agents

--- a/docs/features/file-kinds-schemas.md
+++ b/docs/features/file-kinds-schemas.md
@@ -5,7 +5,7 @@ summary: >-
   matter against a schema declared inline on the kind or shared via a
   `proto.md` template — so a whole directory obeys one contract.
 icon: shapes
-link: "/docs/guides/file-kinds/"
+link: "/guides/file-kinds/"
 rules: ["MDS020"]
 weight: 9
 ---

--- a/docs/features/git-native.md
+++ b/docs/features/git-native.md
@@ -5,7 +5,7 @@ summary: >-
   blocks, and a pre-merge-commit hook re-runs `mdsmith fix` and
   re-stages the result, so generated content never blocks a merge.
 icon: git-merge
-link: "/docs/reference/cli/merge-driver/"
+link: "/reference/cli/merge-driver/"
 weight: 12
 ---
 # Git-native, conflict-free

--- a/docs/features/install-everywhere.md
+++ b/docs/features/install-everywhere.md
@@ -5,7 +5,7 @@ summary: >-
   uvx, mise, asdf, and GitHub Releases — with no postinstall network
   call, so locked-down CI installs offline.
 icon: package
-link: "/docs/guides/install/"
+link: "/guides/install/"
 weight: 15
 ---
 # Installs everywhere

--- a/docs/features/live-diagnostics.md
+++ b/docs/features/live-diagnostics.md
@@ -6,7 +6,7 @@ summary: >-
   `<?include?>`, `<?catalog?>`, and cross-file links — consumed by any
   LSP-aware editor.
 icon: edit-3
-link: "/docs/guides/editors/vscode/"
+link: "/guides/editors/vscode/"
 weight: 2
 ---
 # Live diagnostics wherever you write

--- a/docs/features/markdown-conventions.md
+++ b/docs/features/markdown-conventions.md
@@ -5,7 +5,7 @@ summary: >-
   renderer flavor in one switch. `MDS034` flags syntax the flavor
   will not render; a placeholder vocabulary spares template tokens.
 icon: book-type
-link: "/docs/reference/conventions/"
+link: "/reference/conventions/"
 rules: ["MDS034"]
 weight: 10
 ---

--- a/docs/features/performance.md
+++ b/docs/features/performance.md
@@ -6,7 +6,7 @@ summary: >-
   the hot path — roughly 4x faster than Node markdownlint, with a CI
   gate against regression.
 icon: zap
-link: "/docs/reference/cli/check/"
+link: "/reference/cli/check/"
 weight: 7
 ---
 # Fast on every run

--- a/docs/features/quality.md
+++ b/docs/features/quality.md
@@ -6,7 +6,7 @@ summary: >-
   ships, and a coverage gate blocks any merge that drops below the
   line.
 icon: shield-check
-link: "/docs/development/coverage/"
+link: "/development/coverage/"
 weight: 8
 ---
 # Quality you can verify

--- a/docs/features/release-gating.md
+++ b/docs/features/release-gating.md
@@ -5,7 +5,7 @@ summary: >-
   expression on front matter; `mdsmith metrics rank` ranks files by
   any shared metric — both ready to pipe into a release script.
 icon: gauge
-link: "/docs/reference/cli/query/"
+link: "/reference/cli/query/"
 weight: 6
 ---
 # Gate releases on doc status

--- a/docs/features/rename.md
+++ b/docs/features/rename.md
@@ -7,7 +7,7 @@ summary: >-
   breaking cross-file links.
 icon: replace
 weight: 17
-link: "/docs/reference/cli/lsp/"
+link: "/reference/cli/lsp/"
 ---
 # Rename without breaking links
 

--- a/docs/features/self-maintaining-sections.md
+++ b/docs/features/self-maintaining-sections.md
@@ -6,7 +6,7 @@ summary: >-
   another file. A Git merge driver auto-resolves conflicts inside
   those blocks.
 icon: list-checks
-link: "/docs/guides/directives/generating-content/"
+link: "/guides/directives/generating-content/"
 weight: 5
 ---
 # Self-maintaining sections

--- a/docs/research/links/README.md
+++ b/docs/research/links/README.md
@@ -123,7 +123,7 @@ rule would duplicate `ParseTarget`. Plan 171.
 
 ### G2 — MDS027 short-circuits absolute paths
 
-`[x](/docs/rules/MDS027/)` returns early because
+`[x](/rules/MDS027/)` returns early because
 `ParseTarget` rejects a non-empty path that looks
 rooted. Today: silent pass. Should: resolve against a
 configured site root and verify the page exists.

--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -68,8 +68,10 @@ var siblingLink = regexp.MustCompile(`\]\(([^)\s]+)\)`)
 // Only same-directory and descendant relative targets whose
 // extension is outside syncableExt are rewritten. Five classes
 // are deliberately left untouched: synced `.md`/image targets
-// (still valid relative links), site-absolute targets
-// (`/rules/...`), external URLs (`scheme://`), pure `#anchor`
+// (still valid relative links), any site-absolute target
+// (a leading `/` — `/rules/…`, `/guides/…`, …; the guard is
+// `HasPrefix(target, "/")`, not a `/rules/` check), external
+// URLs (`scheme://`), pure `#anchor`
 // fragments, and `../`-prefixed paths (those are the
 // non-published rewrite's job — repoNonPublishedLink — and
 // double-handling them here would route the same link twice).

--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -69,7 +69,7 @@ var siblingLink = regexp.MustCompile(`\]\(([^)\s]+)\)`)
 // extension is outside syncableExt are rewritten. Five classes
 // are deliberately left untouched: synced `.md`/image targets
 // (still valid relative links), site-absolute targets
-// (`/docs/...`), external URLs (`scheme://`), pure `#anchor`
+// (`/rules/...`), external URLs (`scheme://`), pure `#anchor`
 // fragments, and `../`-prefixed paths (those are the
 // non-published rewrite's job — repoNonPublishedLink — and
 // double-handling them here would route the same link twice).
@@ -333,7 +333,7 @@ func (t *Toolkit) syncDocsFile(src, dst, name, repoDir string) (bool, error) {
 // _index.md into a synced subdirectory that has content but no
 // section landing page of its own. Without it Hugo renders no
 // page for the directory and the nav link 404s (the GitHub
-// Pages symptom for /docs/reference/, /docs/background/, …).
+// Pages symptom for /reference/, /background/, …).
 //
 // It is a no-op when the directory already has an _index.md
 // (e.g. an index.md the sibling rename produced) or when the
@@ -389,7 +389,7 @@ func humanizeDirName(name string) string {
 //     documentation about Hugo renders verbatim.
 //   - rewriteRuleLinks: every repo-relative Markdown link is
 //     routed for the published site — `internal/rules/MDS…/`
-//     becomes `/docs/rules/MDS…/`, every other non-published
+//     becomes `/rules/MDS…/`, every other non-published
 //     path (plan/, internal/ Go packages, .claude/, root files,
 //     …) becomes a GitHub blob/tree URL, and a sibling
 //     `<path>/index.md` reference drops to `<path>/` so Hugo's

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -615,7 +615,7 @@ func TestReconcileDocForHugo_StripNoOp(t *testing.T) {
 const (
 	ghBlob    = "https://github.com/jeduden/mdsmith/blob/main/"
 	ghTree    = "https://github.com/jeduden/mdsmith/tree/main/"
-	rulesBase = "/docs/rules/"
+	rulesBase = "/rules/"
 )
 
 // transformCase pairs an input markdown body with the expected
@@ -837,7 +837,7 @@ func TestRewriteSiblingNonPublished(t *testing.T) {
 		{"image untouched", "![d](d.svg)\n", "![d](d.svg)\n"},
 		{"pure anchor untouched", "[r](#sec)\n", "[r](#sec)\n"},
 		{"external url untouched", "[c](https://x.io/run.sh)\n", "[c](https://x.io/run.sh)\n"},
-		{"site-absolute untouched", "[a](/docs/rules/MDS027/)\n", "[a](/docs/rules/MDS027/)\n"},
+		{"site-absolute untouched", "[a](/rules/MDS027/)\n", "[a](/rules/MDS027/)\n"},
 		{"parent-relative untouched", "[p](../b/run.sh)\n", "[p](../b/run.sh)\n"},
 		{"code span untouched", "use `[x](run.sh)` lit\n", "use `[x](run.sh)` lit\n"},
 	}

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -639,8 +639,9 @@ func runTransformCases(t *testing.T, cases []transformCase) {
 // TestTransformMarkdown_RewritesRuleLinks: docs that link into
 // internal/rules/ (any `../` depth, with or without README.md,
 // inline or reference-style) must come out pointing at the
-// published /docs/rules/<dir>/ URL. The same link works on
-// GitHub because the source tree still has internal/rules/, but
+// published /rules/<dir>/ URL, with <dir> lowercased to match
+// Hugo's case-folded page URL. The same link works on GitHub
+// because the source tree still has internal/rules/MDS…/, but
 // that directory is not published on the site — without the
 // rewrite the link 404s.
 func TestTransformMarkdown_RewritesRuleLinks(t *testing.T) {
@@ -648,32 +649,32 @@ func TestTransformMarkdown_RewritesRuleLinks(t *testing.T) {
 		{
 			name: "deep inline no readme",
 			in:   "See [x](../../../../internal/rules/MDS019-catalog/).\n",
-			want: "See [x](" + rulesBase + "MDS019-catalog/).\n",
+			want: "See [x](" + rulesBase + "mds019-catalog/).\n",
 		},
 		{
 			name: "shallow inline with readme",
 			in:   "See [x](../../internal/rules/MDS020-required-structure/README.md).\n",
-			want: "See [x](" + rulesBase + "MDS020-required-structure/).\n",
+			want: "See [x](" + rulesBase + "mds020-required-structure/).\n",
 		},
 		{
 			name: "reference-style def with readme",
 			in:   "[mds]: ../../../internal/rules/MDS027-cross-file-reference-integrity/README.md\n",
-			want: "[mds]: " + rulesBase + "MDS027-cross-file-reference-integrity/\n",
+			want: "[mds]: " + rulesBase + "mds027-cross-file-reference-integrity/\n",
 		},
 		{
 			name: "reference-style def no readme",
 			in:   "[mds]: ../../../../internal/rules/MDS019-catalog/\n",
-			want: "[mds]: " + rulesBase + "MDS019-catalog/\n",
+			want: "[mds]: " + rulesBase + "mds019-catalog/\n",
 		},
 		{
 			name: "already-rewritten path is unchanged",
-			in:   "See [x](" + rulesBase + "MDS019-catalog/).\n",
-			want: "See [x](" + rulesBase + "MDS019-catalog/).\n",
+			in:   "See [x](" + rulesBase + "mds019-catalog/).\n",
+			want: "See [x](" + rulesBase + "mds019-catalog/).\n",
 		},
 		{
 			name: "deep rule link preserves anchor",
 			in:   "See [x](../../../internal/rules/MDS020-required-structure/README.md#out).\n",
-			want: "See [x](" + rulesBase + "MDS020-required-structure/#out).\n",
+			want: "See [x](" + rulesBase + "mds020-required-structure/#out).\n",
 		},
 	})
 }

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -99,7 +99,11 @@ func websiteLinkProbes(prefix string) []linkProbe {
 			// hook manually prefixes those with
 			// site.Home.RelPermalink so the rendered href carries
 			// the baseURL's path component (empty on root
-			// deploys, `/<repo>` on project-pages). A recursive
+			// deploys, `/<repo>` on project-pages). The id is
+			// lowercased to match Hugo's case-folded page URL
+			// (the source dir is MDS…; the served page is mds…),
+			// so the probe asserts the lowercased form — an
+			// uppercase regression would fail it. A recursive
 			// wantAnyMatch keeps the probe robust to legitimate
 			// docs edits — any rendered page that carries one
 			// such href satisfies the assertion, so removing a
@@ -107,7 +111,7 @@ func websiteLinkProbes(prefix string) []linkProbe {
 			name: "site-absolute /rules/ href carries baseURL prefix",
 			path: ".",
 			wantAnyMatch: regexp.MustCompile(
-				hrefEq + q(prefix) + `/rules/MDS[0-9A-Za-z._-]+/`),
+				hrefEq + q(prefix) + `/rules/mds[0-9a-z._-]+/`),
 			recursive: true,
 		},
 		{

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -81,20 +81,22 @@ func websiteLinkProbes(prefix string) []linkProbe {
 	return []linkProbe{
 		{
 			name: "sibling .md resolves to target permalink",
-			path: "docs/development/merge-queue/index.html",
+			path: "development/merge-queue/index.html",
 			wantMatch: regexp.MustCompile(
-				hrefEq + q(prefix) + `/docs/development/pr-fixup-workflow/`),
+				hrefEq + q(prefix) + `/development/pr-fixup-workflow/`),
 		},
 		{
 			name: "index.md drop resolves to section URL on leaf page",
-			path: "docs/development/architecture-audit/index.html",
+			path: "development/architecture-audit/index.html",
 			wantMatch: regexp.MustCompile(
-				hrefEq + q(prefix) + `/docs/development/architecture/`),
+				hrefEq + q(prefix) + `/development/architecture/`),
 		},
 		{
-			// The rewriter emits site-absolute `/docs/rules/<id>/`
-			// targets for every cross-rule and docs-to-rule link.
-			// The render-link hook manually prefixes those with
+			// The rewriter emits site-absolute `/rules/<id>/`
+			// targets for every cross-rule and docs-to-rule link
+			// (the synced docs tree is mounted at the site root,
+			// so there is no `/docs` segment). The render-link
+			// hook manually prefixes those with
 			// site.Home.RelPermalink so the rendered href carries
 			// the baseURL's path component (empty on root
 			// deploys, `/<repo>` on project-pages). A recursive
@@ -102,15 +104,15 @@ func websiteLinkProbes(prefix string) []linkProbe {
 			// docs edits — any rendered page that carries one
 			// such href satisfies the assertion, so removing a
 			// single content reference does not block the deploy.
-			name: "site-absolute /docs/rules/ href carries baseURL prefix",
-			path: "docs",
+			name: "site-absolute /rules/ href carries baseURL prefix",
+			path: ".",
 			wantAnyMatch: regexp.MustCompile(
-				hrefEq + q(prefix) + `/docs/rules/MDS[0-9A-Za-z._-]+/`),
+				hrefEq + q(prefix) + `/rules/MDS[0-9A-Za-z._-]+/`),
 			recursive: true,
 		},
 		{
 			name: "no README.md hrefs leaked into rule pages",
-			path: "docs/rules",
+			path: "rules",
 			wantNoMatch: regexp.MustCompile(
 				`href=(?:"[^"]*README\.md|[^ ">]*README\.md)`),
 			recursive: true,
@@ -234,7 +236,7 @@ func readHTMLFile(path string) ([]byte, error) {
 
 // pathPrefixFromBaseURL returns the URL path component of
 // baseURL, with a trailing slash trimmed so the caller can
-// concatenate `/docs/...` without producing `//docs/...`.
+// concatenate `/rules/...` without producing `//rules/...`.
 // An empty baseURL or a root-deploy baseURL
 // (`https://example.com/`) yields "". A project-pages
 // baseURL (`https://example.com/repo/`) yields `/repo`.

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -24,7 +24,7 @@ func goodSite(t *testing.T, prefix string) string {
 	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
 		`<a href="`+prefix+`/development/architecture/">arch</a>`)
 	writeFile(t, filepath.Join(root, "reference", "schema-types", "index.html"),
-		`<a href="`+prefix+`/rules/MDS020-required-structure/">rule</a>`)
+		`<a href="`+prefix+`/rules/mds020-required-structure/">rule</a>`)
 	writeFile(t, filepath.Join(root, "rules", "mds001", "index.html"),
 		`<a href="`+prefix+`/rules/mds021/">sibling rule</a>`)
 	writeFile(t, filepath.Join(root, "index.html"), `<p>home</p>`)
@@ -53,7 +53,7 @@ func TestVerifyWebsiteLinks_AcceptsUnquotedHref(t *testing.T) {
 	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
 		`<a href=/development/architecture/>arch</a>`)
 	writeFile(t, filepath.Join(root, "reference", "schema-types", "index.html"),
-		`<a href=/rules/MDS020-required-structure/>rule</a>`)
+		`<a href=/rules/mds020-required-structure/>rule</a>`)
 	writeFile(t, filepath.Join(root, "rules", "mds001", "index.html"),
 		`<a href=/rules/mds021/>sibling</a>`)
 	require.NoError(t, VerifyWebsiteLinks(root, ""))
@@ -125,11 +125,11 @@ func TestVerifyWebsiteLinks_FailsOnMixedCaseJavascript(t *testing.T) {
 
 // TestVerifyWebsiteLinks_FailsOnMissingSiteAbsolute exercises
 // walkAndRequireAny's no-match path: the good fixture has the
-// /rules/MDSxxx/ link, but stripping the prefix expectation
+// /rules/mdsxxx/ link, but stripping the prefix expectation
 // means nothing matches under subpath baseURL.
 func TestVerifyWebsiteLinks_FailsOnMissingSiteAbsolute(t *testing.T) {
 	// Build a tree that has every required href except the
-	// site-absolute /rules/MDSxxx/ form.
+	// site-absolute /rules/mdsxxx/ form.
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "development", "merge-queue", "index.html"),
 		`<a href="/mdsmith/development/pr-fixup-workflow/">x</a>`)
@@ -188,7 +188,7 @@ func TestVerifyWebsiteLinks_MissingRecursiveRootWraps(t *testing.T) {
 	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
 		`<a href="/development/architecture/">x</a>`)
 	writeFile(t, filepath.Join(root, "reference", "schema-types", "index.html"),
-		`<a href="/rules/MDS020-required-structure/">x</a>`)
+		`<a href="/rules/mds020-required-structure/">x</a>`)
 	// rules/ is absent.
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -13,18 +13,20 @@ import (
 // every assertion VerifyWebsiteLinks runs. Each test below
 // starts from this corpus and mutates one file to break a
 // single probe, so each failing case is isolated to the
-// regex it targets.
+// regex it targets. The synced docs tree is mounted at the
+// site root, so pages render at `/<section>/...` with no
+// `/docs` segment.
 func goodSite(t *testing.T, prefix string) string {
 	t.Helper()
 	root := t.TempDir()
-	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
-		`<a href="`+prefix+`/docs/development/pr-fixup-workflow/">pr fixup</a>`)
-	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
-		`<a href="`+prefix+`/docs/development/architecture/">arch</a>`)
-	writeFile(t, filepath.Join(root, "docs", "reference", "schema-types", "index.html"),
-		`<a href="`+prefix+`/docs/rules/MDS020-required-structure/">rule</a>`)
-	writeFile(t, filepath.Join(root, "docs", "rules", "mds001", "index.html"),
-		`<a href="`+prefix+`/docs/rules/mds021/">sibling rule</a>`)
+	writeFile(t, filepath.Join(root, "development", "merge-queue", "index.html"),
+		`<a href="`+prefix+`/development/pr-fixup-workflow/">pr fixup</a>`)
+	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
+		`<a href="`+prefix+`/development/architecture/">arch</a>`)
+	writeFile(t, filepath.Join(root, "reference", "schema-types", "index.html"),
+		`<a href="`+prefix+`/rules/MDS020-required-structure/">rule</a>`)
+	writeFile(t, filepath.Join(root, "rules", "mds001", "index.html"),
+		`<a href="`+prefix+`/rules/mds021/">sibling rule</a>`)
 	writeFile(t, filepath.Join(root, "index.html"), `<p>home</p>`)
 	return root
 }
@@ -46,20 +48,20 @@ func TestVerifyWebsiteLinks_SubpathDeployPasses(t *testing.T) {
 // match `href=value` as well as `href="value"`.
 func TestVerifyWebsiteLinks_AcceptsUnquotedHref(t *testing.T) {
 	root := t.TempDir()
-	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
-		`<a href=/docs/development/pr-fixup-workflow/>pr fixup</a>`)
-	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
-		`<a href=/docs/development/architecture/>arch</a>`)
-	writeFile(t, filepath.Join(root, "docs", "reference", "schema-types", "index.html"),
-		`<a href=/docs/rules/MDS020-required-structure/>rule</a>`)
-	writeFile(t, filepath.Join(root, "docs", "rules", "mds001", "index.html"),
-		`<a href=/docs/rules/mds021/>sibling</a>`)
+	writeFile(t, filepath.Join(root, "development", "merge-queue", "index.html"),
+		`<a href=/development/pr-fixup-workflow/>pr fixup</a>`)
+	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
+		`<a href=/development/architecture/>arch</a>`)
+	writeFile(t, filepath.Join(root, "reference", "schema-types", "index.html"),
+		`<a href=/rules/MDS020-required-structure/>rule</a>`)
+	writeFile(t, filepath.Join(root, "rules", "mds001", "index.html"),
+		`<a href=/rules/mds021/>sibling</a>`)
 	require.NoError(t, VerifyWebsiteLinks(root, ""))
 }
 
 func TestVerifyWebsiteLinks_FailsOnMissingSiblingMD(t *testing.T) {
 	root := goodSite(t, "")
-	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
+	writeFile(t, filepath.Join(root, "development", "merge-queue", "index.html"),
 		`<a href="pr-fixup-workflow.md">stale .md ref</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -70,7 +72,7 @@ func TestVerifyWebsiteLinks_FailsOnIndexMDMisresolved(t *testing.T) {
 	root := goodSite(t, "")
 	// Simulate the bug PR #309 fixed: relative target stayed
 	// relative, browser resolves below the leaf page.
-	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
+	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
 		`<a href="architecture/">stale relative</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -79,7 +81,7 @@ func TestVerifyWebsiteLinks_FailsOnIndexMDMisresolved(t *testing.T) {
 
 func TestVerifyWebsiteLinks_FailsOnLeakedREADMEHref(t *testing.T) {
 	root := goodSite(t, "")
-	writeFile(t, filepath.Join(root, "docs", "rules", "mds999", "index.html"),
+	writeFile(t, filepath.Join(root, "rules", "mds999", "index.html"),
 		`<a href="../MDS021-include/README.md">leaked</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -91,7 +93,7 @@ func TestVerifyWebsiteLinks_FailsOnQuotedREADMEHref(t *testing.T) {
 	// inline-shell regex (`href=[^"]*README\.md`) could not
 	// cross the opening quote.
 	root := goodSite(t, "")
-	writeFile(t, filepath.Join(root, "docs", "rules", "mds999", "index.html"),
+	writeFile(t, filepath.Join(root, "rules", "mds999", "index.html"),
 		`<a href="../README.md">quoted leak</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -100,7 +102,7 @@ func TestVerifyWebsiteLinks_FailsOnQuotedREADMEHref(t *testing.T) {
 
 func TestVerifyWebsiteLinks_FailsOnJavascriptScheme(t *testing.T) {
 	root := goodSite(t, "")
-	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),
+	writeFile(t, filepath.Join(root, "evil", "index.html"),
 		`<a href="javascript:alert(1)">click</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -114,7 +116,7 @@ func TestVerifyWebsiteLinks_FailsOnJavascriptScheme(t *testing.T) {
 // must reject it too.
 func TestVerifyWebsiteLinks_FailsOnMixedCaseJavascript(t *testing.T) {
 	root := goodSite(t, "")
-	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),
+	writeFile(t, filepath.Join(root, "evil", "index.html"),
 		`<a href="JavaScript:alert(1)">click</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -123,25 +125,25 @@ func TestVerifyWebsiteLinks_FailsOnMixedCaseJavascript(t *testing.T) {
 
 // TestVerifyWebsiteLinks_FailsOnMissingSiteAbsolute exercises
 // walkAndRequireAny's no-match path: the good fixture has the
-// /docs/rules/MDSxxx/ link, but stripping the prefix
-// expectation means nothing matches under subpath baseURL.
+// /rules/MDSxxx/ link, but stripping the prefix expectation
+// means nothing matches under subpath baseURL.
 func TestVerifyWebsiteLinks_FailsOnMissingSiteAbsolute(t *testing.T) {
 	// Build a tree that has every required href except the
-	// site-absolute /docs/rules/MDSxxx/ form.
+	// site-absolute /rules/MDSxxx/ form.
 	root := t.TempDir()
-	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
-		`<a href="/mdsmith/docs/development/pr-fixup-workflow/">x</a>`)
-	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
-		`<a href="/mdsmith/docs/development/architecture/">x</a>`)
-	// docs/ has no MDS-rule href under any subpath.
+	writeFile(t, filepath.Join(root, "development", "merge-queue", "index.html"),
+		`<a href="/mdsmith/development/pr-fixup-workflow/">x</a>`)
+	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
+		`<a href="/mdsmith/development/architecture/">x</a>`)
+	// No MDS-rule href under any subpath.
 	err := VerifyWebsiteLinks(root, "https://example.com/mdsmith/")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "/mdsmith/docs/rules/")
+	assert.Contains(t, err.Error(), "/mdsmith/rules/")
 }
 
 func TestVerifyWebsiteLinks_FailsOnDataScheme(t *testing.T) {
 	root := goodSite(t, "")
-	writeFile(t, filepath.Join(root, "docs", "evil", "index.html"),
+	writeFile(t, filepath.Join(root, "evil", "index.html"),
 		`<a href="data:text/html,<script>1</script>">click</a>`)
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
@@ -174,19 +176,20 @@ func TestVerifyWebsiteLinks_InvalidBaseURLWraps(t *testing.T) {
 
 // TestVerifyWebsiteLinks_MissingRecursiveRootWraps drives
 // the WalkDir-callback error branch in walkAndReject: the
-// recursive probe root (docs/rules) does not exist, so
-// WalkDir calls the callback with a stat error.
+// recursive probe root (rules) does not exist, so WalkDir
+// calls the callback with a stat error.
 func TestVerifyWebsiteLinks_MissingRecursiveRootWraps(t *testing.T) {
 	root := t.TempDir()
-	// Materialize only the non-recursive probe targets so we
-	// reach the recursive `no README.md leak` probe.
-	writeFile(t, filepath.Join(root, "docs", "development", "merge-queue", "index.html"),
-		`<a href="/docs/development/pr-fixup-workflow/">x</a>`)
-	writeFile(t, filepath.Join(root, "docs", "development", "architecture-audit", "index.html"),
-		`<a href="/docs/development/architecture/">x</a>`)
-	writeFile(t, filepath.Join(root, "docs", "reference", "schema-types", "index.html"),
-		`<a href="/docs/rules/MDS020-required-structure/">x</a>`)
-	// docs/rules is absent.
+	// Materialize only the non-recursive probe targets plus a
+	// page carrying the site-absolute rule href, so we reach
+	// the recursive `no README.md leak` probe.
+	writeFile(t, filepath.Join(root, "development", "merge-queue", "index.html"),
+		`<a href="/development/pr-fixup-workflow/">x</a>`)
+	writeFile(t, filepath.Join(root, "development", "architecture-audit", "index.html"),
+		`<a href="/development/architecture/">x</a>`)
+	writeFile(t, filepath.Join(root, "reference", "schema-types", "index.html"),
+		`<a href="/rules/MDS020-required-structure/">x</a>`)
+	// rules/ is absent.
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "walk")

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -247,7 +247,14 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // rewriteRuleLinks rewrites every repo-relative link in a synced
 // markdown body so it resolves on the published site. The three
 // classes are applied in order: (1) links into internal/rules/MDS…/
-// become /rules/<dir>/<#anchor> site URLs; (2) links into any
+// become /rules/<dir>/<#anchor> site URLs, with <dir> lowercased
+// because Hugo case-folds path-derived URLs by default
+// (disablePathToLower is off), so the synced
+// content/docs/rules/MDS001-line-length/ page is served at
+// /rules/mds001-line-length/. The repo-relative source dir keeps
+// its MDS… case (MDS027 stats it on disk; absolute targets are
+// short-circuited so the lowercased URL is not filesystem-checked);
+// (2) links into any
 // other non-published repo path — plan/, cmd/, editors/, website/,
 // .claude/, internal/ (other than the rule pages already handled
 // in step 1), and root-level files — become absolute GitHub URLs,
@@ -274,8 +281,8 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // second pass is a no-op.
 func rewriteRuleLinks(b []byte) []byte {
 	return applyOutsideCode(b, func(seg []byte) []byte {
-		seg = repoRuleLink.ReplaceAll(seg, []byte("]("+rulePageURLBase+"$1/$2)"))
-		seg = repoRuleRefDef.ReplaceAll(seg, []byte("${1}"+rulePageURLBase+"$2/$3"))
+		seg = repoRuleLink.ReplaceAllFunc(seg, rewriteRepoRuleInline)
+		seg = repoRuleRefDef.ReplaceAllFunc(seg, rewriteRepoRuleRefDef)
 		seg = repoNonPublishedLink.ReplaceAllFunc(seg, rewriteNonPublishedInline)
 		seg = repoNonPublishedRefDef.ReplaceAllFunc(seg, rewriteNonPublishedRefDef)
 		// Drop the `index.md` filename — Hugo serves the
@@ -286,6 +293,29 @@ func rewriteRuleLinks(b []byte) []byte {
 		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}$2)"))
 		return seg
 	})
+}
+
+// rewriteRepoRuleInline rewrites an inline link into
+// internal/rules/MDS…/ to its site-absolute rule-page URL. The
+// rule-directory capture (m[1]) is lowercased — Hugo case-folds
+// path-derived URLs, so the served page is /rules/mds…/ — while
+// the optional `#anchor` capture (m[2]) passes through unchanged.
+// ReplaceAllFunc (not a ReplaceAll template) is required because
+// $1 cannot be lowercased inside a replacement template.
+func rewriteRepoRuleInline(match []byte) []byte {
+	m := repoRuleLink.FindSubmatch(match)
+	return []byte("](" + rulePageURLBase +
+		strings.ToLower(string(m[1])) + "/" + string(m[2]) + ")")
+}
+
+// rewriteRepoRuleRefDef is the reference-style sibling of
+// rewriteRepoRuleInline. m[1] is the `[label]: ` prefix, m[2] the
+// rule directory (lowercased to match Hugo's served URL), m[3] an
+// optional `#anchor` left as authored.
+func rewriteRepoRuleRefDef(match []byte) []byte {
+	m := repoRuleRefDef.FindSubmatch(match)
+	return []byte(string(m[1]) + rulePageURLBase +
+		strings.ToLower(string(m[2])) + "/" + string(m[3]))
 }
 
 // rewriteNonPublishedInline applies repoNonPublishedLink's

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -45,8 +45,9 @@ var ruleRefDefLink = regexp.MustCompile(
 
 // repoDocsLink matches an inline link from a rule README into the
 // docs/ tree (`../../../docs/path/file.md`). The docs tree IS
-// published on the site (under /docs/), but Hugo serves each page
-// at `/docs/path/file/` (no `.md`), so the raw relative path
+// published on the site (the synced content/docs/ tree is mounted
+// at the site root), but Hugo serves each page at `/path/file/`
+// (no `docs` segment, no `.md`), so the raw relative path
 // resolves to a 404. Group 1 captures the path without `.md`;
 // group 2 captures an optional `#anchor` fragment.
 var repoDocsLink = regexp.MustCompile(`\]\(\.\./\.\./\.\./docs/([^)#]*)\.md([^)]*)\)`)
@@ -87,9 +88,11 @@ var repoRuleRefDef = regexp.MustCompile(
 
 // rulePageURLBase is the site-absolute URL prefix every rule page
 // lives under. Hugo serves website/content/docs/rules/<dir>/index.md
-// at /docs/rules/<dir>/, so repo-relative `internal/rules/<dir>/`
-// links from any docs page must rewrite to this prefix to resolve.
-const rulePageURLBase = "/docs/rules/"
+// at /rules/<dir>/ (content/docs/ is mounted at the site root, so
+// there is no `docs` URL segment), so repo-relative
+// `internal/rules/<dir>/` links from any docs page must rewrite to
+// this prefix to resolve.
+const rulePageURLBase = "/rules/"
 
 // repoNonPublishedLink matches an inline link whose target is a
 // repo-relative path that the website does NOT publish — every
@@ -244,7 +247,7 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // rewriteRuleLinks rewrites every repo-relative link in a synced
 // markdown body so it resolves on the published site. The three
 // classes are applied in order: (1) links into internal/rules/MDS…/
-// become /docs/rules/<dir>/<#anchor> site URLs; (2) links into any
+// become /rules/<dir>/<#anchor> site URLs; (2) links into any
 // other non-published repo path — plan/, cmd/, editors/, website/,
 // .claude/, internal/ (other than the rule pages already handled
 // in step 1), and root-level files — become absolute GitHub URLs,
@@ -266,7 +269,7 @@ var ruleDirName = regexp.MustCompile(`^MDS[0-9]`)
 // match `internal/rules/MDS…`, and only the first leaves the
 // link on-site rather than routing it to GitHub.
 //
-// Idempotent: already-rewritten paths (a leading `/docs/`,
+// Idempotent: already-rewritten paths (a leading `/rules/`,
 // `https://`, or `_index.md`) do not match any regex, so a
 // second pass is a no-op.
 func rewriteRuleLinks(b []byte) []byte {
@@ -648,7 +651,7 @@ func transformRulePage(data []byte, ruleName string) []byte {
 	data = applyOutsideCode(data, func(seg []byte) []byte {
 		seg = ruleReadmeLink.ReplaceAll(seg, []byte("]($1/$2)"))
 		seg = ruleRefDefLink.ReplaceAll(seg, []byte("$1/$3"))
-		seg = repoDocsLink.ReplaceAll(seg, []byte("](/docs/$1/$2)"))
+		seg = repoDocsLink.ReplaceAll(seg, []byte("](/$1/$2)"))
 		seg = repoPlanLink.ReplaceAll(seg, []byte("]("+githubBlobBase+"plan/$1)"))
 		seg = repoPlanRefDef.ReplaceAll(seg, []byte("${1}"+githubBlobBase+"plan/$2"))
 		seg = rewriteRuleFixtures(seg, ruleSourceFiles, ruleSourceDir)

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -215,8 +215,8 @@ func TestBuildWebsite_PublishesRulePages_DocsAndPlanLinks(t *testing.T) {
 func TestBuildWebsite_PublishesRulePages_FixtureAndSibling(t *testing.T) {
 	body := buildRulePageBody(t)
 	// Deep MDS rule link with anchor → site URL with anchor preserved.
-	assert.Contains(t, body, "(/rules/MDS020-required-structure/#index-side-output)",
-		"deep rule link must rewrite to site URL with anchor preserved")
+	assert.Contains(t, body, "(/rules/mds020-required-structure/#index-side-output)",
+		"deep rule link must rewrite to lowercased site URL with anchor preserved")
 	// Fixture file links (good/, bad/) → rule's GitHub /blob/ URL.
 	assert.Contains(t, body,
 		"](https://github.com/jeduden/mdsmith/blob/main/internal/rules/MDS001-line-length/good/default.md)",

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -37,7 +37,7 @@ func TestRenderLinkHook_SubpathBaseURL(t *testing.T) {
 		"site-absolute branch must derive prefix from site.Home.RelPermalink")
 	// The trailing slash of RelPermalink must be stripped before
 	// concatenation so root deploys get "/" not "//" and sub-path
-	// deploys get "/mdsmith/docs/…" not "/mdsmith//docs/…".
+	// deploys get "/mdsmith/rules/…" not "/mdsmith//rules/…".
 	assert.Contains(t, hook, `strings.TrimSuffix "/" site.Home.RelPermalink`,
 		"trailing slash of site.Home.RelPermalink must be stripped before concatenation")
 }
@@ -196,9 +196,9 @@ func TestBuildWebsite_PublishesRulePages_SiblingLinks(t *testing.T) {
 
 func TestBuildWebsite_PublishesRulePages_DocsAndPlanLinks(t *testing.T) {
 	body := buildRulePageBody(t)
-	assert.Contains(t, body, "](/docs/background/concepts/placeholder-grammar/)",
+	assert.Contains(t, body, "](/background/concepts/placeholder-grammar/)",
 		"docs link must become site-absolute path (no .md extension)")
-	assert.Contains(t, body, "](/docs/guides/schemas/#section-content)",
+	assert.Contains(t, body, "](/guides/schemas/#section-content)",
 		"docs link with anchor must preserve the anchor after the trailing slash")
 	assert.NotContains(t, body, "../../../docs/",
 		"no repo-relative docs/ link may remain on the published page")
@@ -215,7 +215,7 @@ func TestBuildWebsite_PublishesRulePages_DocsAndPlanLinks(t *testing.T) {
 func TestBuildWebsite_PublishesRulePages_FixtureAndSibling(t *testing.T) {
 	body := buildRulePageBody(t)
 	// Deep MDS rule link with anchor → site URL with anchor preserved.
-	assert.Contains(t, body, "(/docs/rules/MDS020-required-structure/#index-side-output)",
+	assert.Contains(t, body, "(/rules/MDS020-required-structure/#index-side-output)",
 		"deep rule link must rewrite to site URL with anchor preserved")
 	// Fixture file links (good/, bad/) → rule's GitHub /blob/ URL.
 	assert.Contains(t, body,

--- a/website/README.md
+++ b/website/README.md
@@ -117,7 +117,7 @@ Feature copy lives once, as Markdown, in
 - `index.md` is the shared "Why mdsmith" overview. The
   repository `README.md` splices it in with `<?include?>`,
   and the website renders the same file as the
-  `/docs/features/` landing page — so the README and the
+  `/features/` landing page — so the README and the
   site cannot drift.
 - One page per feature (`auto-fix.md`, `performance.md`,
   `quality.md`, …) carries a short `summary:` plus an
@@ -144,7 +144,7 @@ A push to `main` also deploys, via the path filter in
 `docs/**`, `website/**`, the workflow itself, and
 `internal/rules/index.md`. The rule index is on the
 list because `build-website` publishes it as the
-`/docs/rules/` section. Editing a rule README and
+`/rules/` section. Editing a rule README and
 running `mdsmith fix` regenerates the tracked
 `internal/rules/index.md` catalog. That regenerated
 file is the change that triggers the deploy.

--- a/website/build-output.mdsmith.yml
+++ b/website/build-output.mdsmith.yml
@@ -23,8 +23,8 @@
 # - Code-block contents: a `[…](…)`-shaped sequence inside
 #   a fenced or inline span parses as code text, not a
 #   Link node.
-# - Site-absolute targets (`/docs/rules/<id>/`,
-#   `/docs/<page>/`): MDS027 short-circuits absolute paths.
+# - Site-absolute targets (`/rules/<id>/`,
+#   `/<page>/`): MDS027 short-circuits absolute paths.
 #
 # The rewriter emits each rewritten URL form with unit-test
 # coverage (internal/release/syncdocs_test.go,

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -14,9 +14,23 @@ enableGitInfo = false
 # literal shortcode patterns, dropping proto.md schema
 # templates, and renaming index.md to _index.md.
 # content/docs/ is .gitignore'd.
+#
+# The synced tree lives on disk under content/docs/ (so the
+# .mdsmith.yml / build-output.mdsmith.yml lint globs that
+# target website/content/docs/** keep matching), but it is
+# mounted at the content root rather than under a `docs`
+# segment: every doc page is served at `/<section>/...`, not
+# `/docs/<section>/...`. The only index is the homepage
+# (content/_index.md, served at `/`). The first mount excludes
+# `docs/**` so content/docs/ is not also exposed under `/docs/`;
+# the second mount re-roots it.
 [module]
   [[module.mounts]]
     source = "content"
+    target = "content"
+    excludeFiles = "docs/**"
+  [[module.mounts]]
+    source = "content/docs"
     target = "content"
   [[module.mounts]]
     source = "static"

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -5,15 +5,15 @@
        Source docs link sibling pages by relative path
        (`[CLI](../reference/cli.md)`) so the markdown stays
        filesystem-valid for MDS027. The site's URL layout
-       is one level deeper than the source: a markdown file
-       at `docs/guides/foo.md` renders at
-       `/docs/guides/foo/`. A relative href resolved from
-       that rendered URL therefore lands one directory
-       below where the source intended — for example
-       `../reference/globs.md` from `docs/guides/file-kinds.md`
-       would resolve to `/docs/guides/reference/globs/`
-       instead of `/docs/reference/globs/`. Stripping `.md`
-       alone does not fix that mismatch.
+       differs from the source path: a markdown file at
+       `docs/guides/foo.md` renders at `/guides/foo/`. A
+       relative href resolved from that rendered URL
+       therefore lands one directory below where the source
+       intended — for example `../reference/globs.md` from
+       `docs/guides/file-kinds.md` would resolve to
+       `/guides/reference/globs/` instead of
+       `/reference/globs/`. Stripping `.md` alone does not
+       fix that mismatch.
 
        Hugo's `.Page.GetPage` resolves a source-relative
        path to a Page and returns its absolute
@@ -29,7 +29,7 @@
        renders sensibly.
 
        For site-absolute hrefs (the rewriter emits
-       `/docs/rules/<id>/` for cross-rule and docs-to-rule
+       `/rules/<id>/` for cross-rule and docs-to-rule
        references), we run them through `relURL` so a
        deploy with a non-root `--baseURL`
        (e.g. https://example.com/mdsmith/) gets the
@@ -70,7 +70,7 @@
          `site.Home.RelPermalink` (which IS the baseURL
          path with a trailing slash — `/` for root,
          `/mdsmith/` for project-pages). Trim its trailing
-         slash so concatenation does not produce `//docs`. */ -}}
+         slash so concatenation does not produce `//rules`. */ -}}
   {{- $parts := split $url "#" -}}
   {{- $path := index $parts 0 -}}
   {{- $frag := "" -}}

--- a/website/layouts/_default/list.html
+++ b/website/layouts/_default/list.html
@@ -35,7 +35,13 @@
                   <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                   {{ with .Params.summary }}<p class="docs-index-summary">{{ . }}</p>{{ end }}
                   <ul class="docs-index-list">
-                    {{ range .Pages.ByWeight }}
+                    {{- /* .RegularPages, not .Pages: Hugo's .Pages
+                           is the union of .RegularPages and
+                           .Sections, so iterating .Pages here and
+                           .Sections just below would list every
+                           subsection twice (once as a page row,
+                           once as the "— more pages" row). */ -}}
+                    {{ range .RegularPages.ByWeight }}
                       <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>{{ with .Params.summary }} <span class="docs-index-desc">— {{ . }}</span>{{ end }}</li>
                     {{ end }}
                     {{ range .Sections.ByWeight }}
@@ -47,7 +53,14 @@
             </div>
           {{ end }}
 
-          {{ with .Pages.ByWeight }}
+          {{- /* Loose pages with no subsection: .RegularPages,
+                 not .Pages. .Pages includes .Sections, so on a
+                 section whose children are all subsections (the
+                 docs root) .Pages here would re-list every group
+                 already rendered as a card above. .RegularPages
+                 is empty there, so the flat list correctly
+                 collapses to nothing. */ -}}
+          {{ with .RegularPages.ByWeight }}
             <ul class="docs-index-list docs-index-flat">
               {{ range . }}
                 <li><a href="{{ .RelPermalink }}">{{ .Title }}</a>{{ with .Params.summary }} <span class="docs-index-desc">— {{ . }}</span>{{ end }}</li>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -13,7 +13,7 @@
     <div class="container">
       <div class="section-eyebrow">Install</div>
       <h2 class="section-title">Install for your toolchain.</h2>
-      <p class="section-lead">Find your package manager below and copy the one line you need. The <a href="{{ "/docs/guides/install/" | relURL }}">install guide</a> covers npx, mise, asdf, and the rest.</p>
+      <p class="section-lead">Find your package manager below and copy the one line you need. The <a href="{{ "/guides/install/" | relURL }}">install guide</a> covers npx, mise, asdf, and the rest.</p>
       {{ partial "install-list.html" . }}
     </div>
   </section>

--- a/website/layouts/partials/docs-sidebar.html
+++ b/website/layouts/partials/docs-sidebar.html
@@ -37,12 +37,17 @@
   {{ range $ordered }}
     <div class="docs-side-group">
       <a class="docs-side-title{{ if eq .RelPermalink $current }} is-active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a>
-      {{ range .Pages.ByWeight }}
+      {{- /* .RegularPages, not .Pages: .Pages is the union of
+             .RegularPages and .Sections, so pairing .Pages with
+             the .Sections loop below would render every
+             subsection twice — once as a flat link, once as the
+             "›" sub-group header. */ -}}
+      {{ range .RegularPages.ByWeight }}
         <a class="docs-side-link{{ if eq .RelPermalink $current }} is-active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a>
       {{ end }}
       {{ range .Sections.ByWeight }}
         <a class="docs-side-link docs-side-sub{{ if eq .RelPermalink $current }} is-active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }} ›</a>
-        {{ range .Pages.ByWeight }}
+        {{ range .RegularPages.ByWeight }}
           <a class="docs-side-link docs-side-nested{{ if eq .RelPermalink $current }} is-active{{ end }}" href="{{ .RelPermalink }}">{{ .Title }}</a>
         {{ end }}
       {{ end }}

--- a/website/layouts/partials/docs-sidebar.html
+++ b/website/layouts/partials/docs-sidebar.html
@@ -1,5 +1,9 @@
 {{ $current := .RelPermalink }}
-{{ $docs := .Site.GetPage "/docs" }}
+{{- /* The synced docs tree is mounted at the site root, so
+       there is no "/docs" section page. The doc groups are the
+       homepage's top-level sections; the "All docs" link points
+       at the homepage (the only index). */ -}}
+{{ $root := site.Home }}
 {{- /* Explicit narrative order for the docs groups: the
        sidebar reads as a user journey (why → how → look up →
        rule catalog → mental model → contribute) rather than
@@ -22,7 +26,7 @@
   <i data-lucide="chevron-down" width="16" height="16" aria-hidden="true"></i>
 </button>
 <nav class="docs-side-nav" id="docs-nav">
-{{ with $docs }}
+{{ with $root }}
   {{ $secs := .Sections }}
   {{ $ordered := slice }}
   {{ range $name := $order }}

--- a/website/layouts/partials/feature-grid.html
+++ b/website/layouts/partials/feature-grid.html
@@ -1,11 +1,11 @@
 {{- /* Feature cards are driven by the shared Markdown in
-       docs/features/ (synced to /docs/features/ by
+       docs/features/ (synced and served at /features/ by
        `mdsmith-release build-website`). The repository README
        includes the same source via <?include?>, so the card
        copy and the README cannot drift. The card links to the
        full feature page, which carries the longer write-up the
        site's layout has room for. */ -}}
-{{- $features := site.GetPage "/docs/features" -}}
+{{- $features := site.GetPage "/features" -}}
 <div class="feature-grid">
   {{- with $features }}
     {{ range .Pages.ByWeight }}

--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -9,17 +9,16 @@
       </div>
       <div class="footer-col">
         <h4>Product</h4>
-        <a href="{{ "/docs/guides/install/" | relURL }}">Install</a>
-        <a href="{{ "/docs/reference/cli/" | relURL }}">CLI reference</a>
-        <a href="{{ "/docs/guides/editors/vscode/" | relURL }}">VS Code extension</a>
-        <a href="{{ "/docs/background/markdown-linters/" | relURL }}">vs other linters</a>
+        <a href="{{ "/guides/install/" | relURL }}">Install</a>
+        <a href="{{ "/reference/cli/" | relURL }}">CLI reference</a>
+        <a href="{{ "/guides/editors/vscode/" | relURL }}">VS Code extension</a>
+        <a href="{{ "/background/markdown-linters/" | relURL }}">vs other linters</a>
       </div>
       <div class="footer-col">
         <h4>Resources</h4>
-        <a href="{{ "/docs/" | relURL }}">Documentation</a>
-        <a href="{{ "/docs/guides/" | relURL }}">Guides</a>
-        <a href="{{ "/docs/reference/conventions/" | relURL }}">Conventions</a>
-        <a href="{{ "/docs/development/" | relURL }}">Development</a>
+        <a href="{{ "/guides/" | relURL }}">Guides</a>
+        <a href="{{ "/reference/conventions/" | relURL }}">Conventions</a>
+        <a href="{{ "/development/" | relURL }}">Development</a>
       </div>
       <div class="footer-col">
         <h4>Community</h4>

--- a/website/layouts/partials/hero.html
+++ b/website/layouts/partials/hero.html
@@ -10,11 +10,11 @@
         <h1>{{ .headline_pre }}<em>{{ .headline_em }}</em>{{ .headline_post }}</h1>
         <p class="hero-lead">{{ .lead }}</p>
         <div class="hero-cta">
-          <a class="btn btn-primary btn-lg" href="{{ "/docs/guides/install/" | relURL }}">
+          <a class="btn btn-primary btn-lg" href="{{ "/guides/install/" | relURL }}">
             <i data-lucide="download" width="16" height="16" aria-hidden="true"></i>
             Install mdsmith
           </a>
-          <a class="btn btn-secondary btn-lg" href="{{ "/docs/" | relURL }}">
+          <a class="btn btn-secondary btn-lg" href="{{ "/guides/" | relURL }}">
             <i data-lucide="book-open" width="16" height="16" aria-hidden="true"></i>
             Read the docs
           </a>

--- a/website/layouts/partials/logos-strip.html
+++ b/website/layouts/partials/logos-strip.html
@@ -3,11 +3,11 @@
     <div class="logos-strip">
       <span class="logos-label">Distributed via</span>
       {{- /* Sourced from the release-channel docs
-             (docs/development/release-channels/*.md), synced to
-             /docs/development/release-channels/. Each carries a
-             canonical `channelurl` and an ordering `weight` in
+             (docs/development/release-channels/*.md), synced and
+             served at /development/release-channels/. Each carries
+             a canonical `channelurl` and an ordering `weight` in
              front matter — no separate data file. */ -}}
-      {{ with site.GetPage "/docs/development/release-channels" }}
+      {{ with site.GetPage "/development/release-channels" }}
         {{ range .Pages.ByWeight }}
           {{ $c := . }}
           {{ with .Params.channelurl }}

--- a/website/layouts/partials/rule-index.html
+++ b/website/layouts/partials/rule-index.html
@@ -8,10 +8,10 @@
        "cannot drift" guarantee.
 
        The map is empty when a docs tree is built without
-       internal/rules/index.md (no /docs/rules/ section): the
+       internal/rules/index.md (no /rules/ section): the
        caller then renders the code span unchanged. */ -}}
 {{- $m := dict -}}
-{{- with site.GetPage "/docs/rules" -}}
+{{- with site.GetPage "/rules" -}}
   {{- range .Pages -}}
     {{- $id := .Params.id -}}
     {{- $name := .Params.name -}}

--- a/website/layouts/partials/topnav.html
+++ b/website/layouts/partials/topnav.html
@@ -5,26 +5,27 @@
     </a>
     {{- /* Active-state prefixes pass through relURL so they
            respect --baseURL. Direct comparisons against literal
-           "/docs" would never match when the site is served from
-           a subpath (e.g. <user>.github.io/<repo>/), because
-           .RelPermalink includes the subpath. */ -}}
-    {{- $docsPrefix := relURL "/docs/" -}}
-    {{- $guidesPrefix := relURL "/docs/guides/" -}}
-    {{- $refPrefix := relURL "/docs/reference/" -}}
-    {{- $rulesPrefix := relURL "/docs/rules/" -}}
+           "/guides" would never match when the site is served
+           from a subpath (e.g. <user>.github.io/<repo>/), because
+           .RelPermalink includes the subpath. The synced docs
+           tree is mounted at the site root, so there is no
+           "/docs" landing page or nav entry — the only index is
+           the homepage. */ -}}
+    {{- $guidesPrefix := relURL "/guides/" -}}
+    {{- $refPrefix := relURL "/reference/" -}}
+    {{- $rulesPrefix := relURL "/rules/" -}}
     <nav class="topnav-links">
-      <a class="topnav-link{{ if and (hasPrefix .RelPermalink $docsPrefix) (not (hasPrefix .RelPermalink $guidesPrefix)) (not (hasPrefix .RelPermalink $refPrefix)) (not (hasPrefix .RelPermalink $rulesPrefix)) }} is-active{{ end }}" href="{{ "/docs/" | relURL }}">Docs</a>
-      <a class="topnav-link{{ if hasPrefix .RelPermalink $guidesPrefix }} is-active{{ end }}" href="{{ "/docs/guides/" | relURL }}">Guides</a>
-      <a class="topnav-link{{ if hasPrefix .RelPermalink $refPrefix }} is-active{{ end }}" href="{{ "/docs/reference/" | relURL }}">Reference</a>
+      <a class="topnav-link{{ if hasPrefix .RelPermalink $guidesPrefix }} is-active{{ end }}" href="{{ "/guides/" | relURL }}">Guides</a>
+      <a class="topnav-link{{ if hasPrefix .RelPermalink $refPrefix }} is-active{{ end }}" href="{{ "/reference/" | relURL }}">Reference</a>
       {{- /* Only show Rules when the section exists: a docs
              tree with no internal/rules/index.md publishes no
-             /docs/rules/, so an unconditional link would 404. */ -}}
-      {{ if site.GetPage "/docs/rules" }}
-      <a class="topnav-link{{ if hasPrefix .RelPermalink $rulesPrefix }} is-active{{ end }}" href="{{ "/docs/rules/" | relURL }}">Rules</a>
+             /rules/, so an unconditional link would 404. */ -}}
+      {{ if site.GetPage "/rules" }}
+      <a class="topnav-link{{ if hasPrefix .RelPermalink $rulesPrefix }} is-active{{ end }}" href="{{ "/rules/" | relURL }}">Rules</a>
       {{ end }}
     </nav>
     <div class="topnav-right">
-      <a class="topnav-version" href="https://github.com/{{ .Site.Params.githubRepo }}/releases" rel="noopener" title="Release notes on GitHub">v{{ .Site.Params.version }}</a>
+      <a class="topnav-version" href="{{ "/guides/install/" | relURL }}" title="Install mdsmith">v{{ .Site.Params.version }}</a>
       <a class="topnav-gh" href="https://github.com/{{ .Site.Params.githubRepo }}" rel="noopener" aria-label="mdsmith on GitHub">
         {{ partial "github-mark.html" (dict "size" 15) }}
         GitHub


### PR DESCRIPTION
## Summary

Restructures the website's content hierarchy so the synced documentation tree is mounted at the site root (`/<section>/...`) rather than under a `/docs` segment (`/docs/<section>/...`). This simplifies URLs, removes the redundant "docs" landing page, and consolidates the navigation structure around the homepage as the single index.

## Key Changes

**Hugo Configuration & Content Mounting**
- Updated `hugo.toml` to mount `content/docs/` at the content root instead of under a `docs` segment
- Added `excludeFiles` directive to prevent double-mounting of the docs tree
- Removed the separate `/docs/` landing page; the homepage is now the only index

**URL Rewrites Throughout**
- Updated all link targets from `/docs/<section>/...` to `/<section>/...` across:
  - Test fixtures in `verifylinks_test.go` and `website_test.go`
  - Link rewriting logic in `website.go` and `syncdocs.go`
  - Feature front matter in `docs/features/*.md`
  - Research documentation in `docs/research/links/README.md`

**Navigation & Layout Updates**
- Removed the "Docs" nav entry from `topnav.html` (no longer a separate section)
- Updated `docs-sidebar.html` to reference `site.Home` instead of a `/docs` section page
- Fixed `list.html` to use `.RegularPages` instead of `.Pages` to avoid double-listing subsections
- Updated footer links to remove `/docs` prefix
- Changed version link in topnav to point to `/guides/install/` instead of GitHub releases

**Template & Partial Fixes**
- Corrected `render-link.html` comments to reflect new URL structure
- Updated `feature-grid.html` and `logos-strip.html` comments and page references
- Fixed `rule-index.html` to look for `/rules` instead of `/docs/rules`
- Updated `hero.html` and other partials with new link paths

**Test & Documentation Updates**
- Updated all test file paths to remove `docs/` directory segment
- Updated comments in test files and source code to reflect the new structure
- Fixed comments in `website.go` explaining the URL rewriting logic

## Notable Implementation Details

- The change maintains backward compatibility for link resolution through Hugo's `relURL` filter, which respects the `--baseURL` for subpath deployments
- `.RegularPages` is now used instead of `.Pages` in list templates to prevent subsections from being rendered twice (once as a page row, once as a section header)
- The synced docs tree still lives on disk under `content/docs/` for build-system compatibility, but is re-rooted at the content level via Hugo's module mounts
- All site-absolute link probes in the link verification system were updated to expect the new URL structure without the `/docs` segment

https://claude.ai/code/session_017G4bNoDi6MdtFGHmsB14m1