### PR TITLE
Fix website rewriter to preserve Markdown link titles

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -99,7 +99,7 @@ footer: |
 | 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                                   |
 | 171 | ✅     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                                          |
 | 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                                       |
-| 173 | 🔲     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                                            |
+| 173 | ✅     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                                            |
 | 174 | ✅     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)                        |
 | 175 | 🔳     | opus   | [CI performance gate for mdsmith check, modelled on the LSP latency gate](plan/175_check-performance-gate.md)                           |
 | 176 | ✅     | sonnet | [ATX heading whitespace and indentation rule](plan/176_atx-heading-whitespace.md)                                                       |

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -35,11 +35,14 @@ const linkTitleTail = `(\s+"[^"]*")?`
 // `../MDS021-include/#section`) rather than an unpublished
 // `README.md`.
 //
-// A trailing linkTitleTail (group 3) absorbs an optional Markdown
-// link title so `[x](MDS…/README.md "t")` is rewritten with its
-// title kept rather than shipped as a dead path (audit gap G6).
+// The anchor capture excludes whitespace (`#[^)\s]*`, not
+// `#[^)]*`) so it stops at the space before a link title rather
+// than swallowing it; the trailing linkTitleTail (group 3) then
+// cleanly captures the title so `[x](MDS…/README.md "t")` (or
+// `…/README.md#sec "t"`) is rewritten with its title kept rather
+// than shipped as a dead path (audit gap G6).
 var ruleReadmeLink = regexp.MustCompile(
-	`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md(#[^)]*)?` +
+	`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md(#[^)\s]*)?` +
 		linkTitleTail + `\)`)
 
 // ruleRefDefLink matches a Markdown reference-style link definition
@@ -84,11 +87,13 @@ var repoPlanRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )\.\./\.\./\.\./plan/
 // docs link to both forms. Group 2 captures an optional
 // `#anchor` so a deep-link into a rule README's heading
 // (e.g. `MDS020-required-structure/README.md#index-side-output`)
-// preserves the fragment after the slash. Group 3 is the optional
-// linkTitleTail so a titled link keeps its title (gap G6).
+// preserves the fragment after the slash. The anchor capture
+// excludes whitespace (`#[^)\s]*`) so a title is left for the
+// trailing linkTitleTail (group 3) to capture, rather than the
+// anchor swallowing `#sec "t"` as one blob (gap G6).
 var repoRuleLink = regexp.MustCompile(
 	`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/` +
-		`(?:README\.md)?(#[^)]*)?` + linkTitleTail + `\)`)
+		`(?:README\.md)?(#[^)\s]*)?` + linkTitleTail + `\)`)
 
 // repoRuleRefDef matches a reference-style link definition whose
 // target is a repo-relative internal/rules/ path. Multiline flag
@@ -192,11 +197,12 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 //
 // Group 1 captures the path prefix (required: a bare
 // `index.md` link with no parent directory is ambiguous and
-// left alone); group 2 captures an optional `#anchor`; group 3
-// is the optional linkTitleTail so a titled directory link keeps
-// its title (gap G6).
+// left alone); group 2 captures an optional `#anchor` (whitespace
+// excluded so it stops before a title); group 3 is the optional
+// linkTitleTail so a titled directory link keeps its title — even
+// when it also carries a `#fragment` (gap G6).
 var indexMdLink = regexp.MustCompile(
-	`\]\(((?:[^)/]+/)+)index\.md((?:#[^)]*)?)` + linkTitleTail + `\)`)
+	`\]\(((?:[^)/]+/)+)index\.md((?:#[^)\s]*)?)` + linkTitleTail + `\)`)
 
 // ruleFixtureLink matches an inline link in a per-rule README
 // whose target is a fixture path under the rule's own directory:

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -10,6 +10,19 @@ import (
 	"strings"
 )
 
+// linkTitleTail optionally matches a Markdown link title — a
+// double-quoted string preceded by whitespace — that sits between
+// an inline link's URL and its closing `)`, or trails a reference
+// definition. Every inline rewrite regex used to stop the path
+// capture at the first whitespace (`\S+`/`[^)\s]+`) and then
+// demand a literal `)`; a title made that `)` unreachable, so the
+// whole titled link shipped verbatim as a dead repo-relative path
+// (audit gap G6). Appending this group lets each rewrite consume
+// the title and re-emit it after the rewritten path. It is a
+// single capturing group, so it only ever adds one trailing
+// submatch to whatever regex includes it.
+const linkTitleTail = `(\s+"[^"]*")?`
+
 // ruleReadmeLink matches a Markdown link whose target is a rule
 // README relative path and captures the rule directory (with an
 // optional `../` prefix) separately from the `README.md` filename
@@ -22,15 +35,12 @@ import (
 // `../MDS021-include/#section`) rather than an unpublished
 // `README.md`.
 //
-// Markdown link titles (`[x](url "title")`) are not matched —
-// no source doc in the repo uses them, and the rewriter is
-// regex-based rather than AST-aware. The same scope decision
-// applies to every other link-rewrite pattern in this file
-// (repoRuleLink, repoNonPublishedLink, indexMdLink, …). If a
-// titled link is ever added to docs, that one link will keep
-// its source target post-sync and the regex will need to grow.
+// A trailing linkTitleTail (group 3) absorbs an optional Markdown
+// link title so `[x](MDS…/README.md "t")` is rewritten with its
+// title kept rather than shipped as a dead path (audit gap G6).
 var ruleReadmeLink = regexp.MustCompile(
-	`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md(#[^)]*)?\)`)
+	`\]\(((?:\.\./)?MDS[0-9A-Za-z._-]+)/README\.md(#[^)]*)?` +
+		linkTitleTail + `\)`)
 
 // ruleRefDefLink matches a Markdown reference-style link definition
 // whose target is a rule README path (with an optional `../`
@@ -74,17 +84,24 @@ var repoPlanRefDef = regexp.MustCompile(`(?m)^(\[[^\]]+\]: )\.\./\.\./\.\./plan/
 // docs link to both forms. Group 2 captures an optional
 // `#anchor` so a deep-link into a rule README's heading
 // (e.g. `MDS020-required-structure/README.md#index-side-output`)
-// preserves the fragment after the slash.
-var repoRuleLink = regexp.MustCompile(`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#[^)]*)?\)`)
+// preserves the fragment after the slash. Group 3 is the optional
+// linkTitleTail so a titled link keeps its title (gap G6).
+var repoRuleLink = regexp.MustCompile(
+	`\]\((?:\.\./)+internal/rules/(MDS[0-9A-Za-z._-]+)/` +
+		`(?:README\.md)?(#[^)]*)?` + linkTitleTail + `\)`)
 
 // repoRuleRefDef matches a reference-style link definition whose
 // target is a repo-relative internal/rules/ path. Multiline flag
 // so `^` anchors at each line start. Mirrors repoRuleLink — any
 // `../` depth, optional README.md suffix, optional anchor.
 // Example: [mds020]: ../../internal/rules/MDS020-required-structure/README.md
+// Group 4 is the optional linkTitleTail, captured before the `$`
+// so a titled definition keeps its title (gap G6) — without it the
+// `$` could never match past the title and the def shipped raw.
 var repoRuleRefDef = regexp.MustCompile(
 	`(?m)^(\[[^\]]+\]: )(?:\.\./)+internal/rules/` +
-		`(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#\S+)?$`)
+		`(MDS[0-9A-Za-z._-]+)/(?:README\.md)?(#\S+)?` +
+		linkTitleTail + `$`)
 
 // rulePageURLBase is the site-absolute URL prefix every rule page
 // lives under. Hugo serves website/content/docs/rules/<dir>/index.md
@@ -119,13 +136,11 @@ const rulePageURLBase = "/rules/"
 // directory, so a `(?:\.\./)+` prefix is the only signal that
 // the link target is repo-relative rather than sibling.
 //
-// Each path uses `\S+` rather than `[^)]+`. A Markdown link
-// title (`[x](target "title")`) is whitespace-separated from
-// the target, so `\S+` stops before it and the regex's
-// trailing `\)` then fails to match — the titled link is
-// left alone rather than rewritten with the title text
-// glued into the GitHub URL. No source doc carries a titled
-// link today, but the pattern stays correct if one is added.
+// Each path uses `\S+` rather than `[^)]+` so the target stops
+// at the whitespace before an optional Markdown link title; the
+// trailing linkTitleTail (group 2) then consumes that title and
+// rewriteNonPublishedInline re-emits it after the GitHub URL,
+// instead of the whole titled link shipping unrewritten (G6).
 var repoNonPublishedLink = regexp.MustCompile(
 	`\]\((?:\.\./)+(` +
 		`plan/\S+|` +
@@ -139,7 +154,7 @@ var repoNonPublishedLink = regexp.MustCompile(
 		`\.github/\S+|` +
 		`internal/\S+|` +
 		`PLAN\.md|README\.md|LICENSE|SECURITY\.md|CLAUDE\.md|AGENTS\.md` +
-		`)\)`)
+		`)` + linkTitleTail + `\)`)
 
 // repoNonPublishedRefDef is the reference-style sibling of
 // repoNonPublishedLink for definitions like
@@ -177,8 +192,11 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 //
 // Group 1 captures the path prefix (required: a bare
 // `index.md` link with no parent directory is ambiguous and
-// left alone); group 2 captures an optional `#anchor`.
-var indexMdLink = regexp.MustCompile(`\]\(((?:[^)/]+/)+)index\.md((?:#[^)]*)?)\)`)
+// left alone); group 2 captures an optional `#anchor`; group 3
+// is the optional linkTitleTail so a titled directory link keeps
+// its title (gap G6).
+var indexMdLink = regexp.MustCompile(
+	`\]\(((?:[^)/]+/)+)index\.md((?:#[^)]*)?)` + linkTitleTail + `\)`)
 
 // ruleFixtureLink matches an inline link in a per-rule README
 // whose target is a fixture path under the rule's own directory:
@@ -189,11 +207,12 @@ var indexMdLink = regexp.MustCompile(`\]\(((?:[^)/]+/)+)index\.md((?:#[^)]*)?)\)
 // repo-relative link 404s. Rewrite to the rule's GitHub source
 // tree URL so the example file is still reachable.
 //
-// `\S*` (not `[^)]*`) rejects whitespace inside the target so
-// a titled link `[x](good/default.md "title")` is left alone
-// rather than rewritten with the title text glued into the
-// GitHub URL.
-var ruleFixtureLink = regexp.MustCompile(`\]\(((?:bad|good|pattern)/\S*)\)`)
+// `\S*` (not `[^)]*`) stops the target at the whitespace before
+// an optional Markdown link title; the trailing linkTitleTail
+// (group 2) then consumes that title and rewriteRuleFixtures
+// re-emits it after the GitHub URL (gap G6).
+var ruleFixtureLink = regexp.MustCompile(
+	`\]\(((?:bad|good|pattern)/\S*)` + linkTitleTail + `\)`)
 
 // ruleSiblingNonMDSLink matches an inline link in a per-rule
 // README whose target is a single-`../`-prefixed sibling under
@@ -202,10 +221,12 @@ var ruleFixtureLink = regexp.MustCompile(`\]\(((?:bad|good|pattern)/\S*)\)`)
 // example. Sibling MDS rule pages (`../MDS021-include/`) ARE
 // published, so they are excluded by requiring the first
 // character after `../` to be lowercase or a dot (rule names
-// start with uppercase `M`). The tail uses `\S*` rather than
-// `[^)]*` so a titled link is left alone instead of having
-// the title text consumed into the GitHub URL.
-var ruleSiblingNonMDSLink = regexp.MustCompile(`\]\(\.\./([a-z._]\S*)\)`)
+// start with uppercase `M`). The path uses `\S*` so it stops at
+// the whitespace before an optional Markdown link title; the
+// trailing linkTitleTail (group 2) then consumes that title and
+// rewriteRuleSibling re-emits it after the GitHub URL (gap G6).
+var ruleSiblingNonMDSLink = regexp.MustCompile(
+	`\]\(\.\./([a-z._]\S*)` + linkTitleTail + `\)`)
 
 // ruleSourceTreeBase is the GitHub directory (tree) route for a
 // rule's source. Per-rule READMEs carry an
@@ -290,7 +311,7 @@ func rewriteRuleLinks(b []byte) []byte {
 		// `/<path>/_index.md` or `/<path>/index.md`. Keeping
 		// either filename in the markdown produces a 404 on
 		// the live site.
-		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}$2)"))
+		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}${2}${3})"))
 		return seg
 	})
 }
@@ -299,23 +320,27 @@ func rewriteRuleLinks(b []byte) []byte {
 // internal/rules/MDS…/ to its site-absolute rule-page URL. The
 // rule-directory capture (m[1]) is lowercased — Hugo case-folds
 // path-derived URLs, so the served page is /rules/mds…/ — while
-// the optional `#anchor` capture (m[2]) passes through unchanged.
-// ReplaceAllFunc (not a ReplaceAll template) is required because
-// $1 cannot be lowercased inside a replacement template.
+// the optional `#anchor` capture (m[2]) and the optional link
+// title (m[3]) pass through unchanged. ReplaceAllFunc (not a
+// ReplaceAll template) is required because $1 cannot be
+// lowercased inside a replacement template.
 func rewriteRepoRuleInline(match []byte) []byte {
 	m := repoRuleLink.FindSubmatch(match)
 	return []byte("](" + rulePageURLBase +
-		strings.ToLower(string(m[1])) + "/" + string(m[2]) + ")")
+		strings.ToLower(string(m[1])) + "/" +
+		string(m[2]) + string(m[3]) + ")")
 }
 
 // rewriteRepoRuleRefDef is the reference-style sibling of
 // rewriteRepoRuleInline. m[1] is the `[label]: ` prefix, m[2] the
 // rule directory (lowercased to match Hugo's served URL), m[3] an
-// optional `#anchor` left as authored.
+// optional `#anchor` left as authored, m[4] the optional link
+// title re-emitted so the definition keeps it.
 func rewriteRepoRuleRefDef(match []byte) []byte {
 	m := repoRuleRefDef.FindSubmatch(match)
 	return []byte(string(m[1]) + rulePageURLBase +
-		strings.ToLower(string(m[2])) + "/" + string(m[3]))
+		strings.ToLower(string(m[2])) + "/" +
+		string(m[3]) + string(m[4]))
 }
 
 // rewriteNonPublishedInline applies repoNonPublishedLink's
@@ -324,10 +349,11 @@ func rewriteRepoRuleRefDef(match []byte) []byte {
 // ReplaceAll with a template) because the URL prefix depends on
 // the captured path's trailing slash — directory links must use
 // /tree/ on GitHub and file links must use /blob/, and a
-// template cannot branch on the capture.
+// template cannot branch on the capture. m[2] is the optional
+// link title, re-emitted after the URL so a titled link keeps it.
 func rewriteNonPublishedInline(match []byte) []byte {
 	m := repoNonPublishedLink.FindSubmatch(match)
-	return []byte("](" + githubURLForPath(m[1]) + ")")
+	return []byte("](" + githubURLForPath(m[1]) + string(m[2]) + ")")
 }
 
 // rewriteNonPublishedRefDef is the reference-style sibling of
@@ -594,7 +620,7 @@ func (t *Toolkit) syncRuleIndex(rulesDir, dstDir string) error {
 	// Skip code regions so a documented `MDS…/README.md` example
 	// stays verbatim.
 	data = applyOutsideCode(data, func(seg []byte) []byte {
-		return ruleReadmeLink.ReplaceAll(seg, []byte("]($1/$2)"))
+		return ruleReadmeLink.ReplaceAll(seg, []byte("]($1/${2}${3})"))
 	})
 	// Cascade the `rule` layout type to all child pages so Hugo
 	// picks up the per-rule template for category/status display.
@@ -679,7 +705,7 @@ func transformRulePage(data []byte, ruleName string) []byte {
 	ruleSourceFiles := githubBlobBase + "internal/rules/" + ruleName + "/"
 	ruleSourceDir := ruleSourceTreeBase + ruleName + "/"
 	data = applyOutsideCode(data, func(seg []byte) []byte {
-		seg = ruleReadmeLink.ReplaceAll(seg, []byte("]($1/$2)"))
+		seg = ruleReadmeLink.ReplaceAll(seg, []byte("]($1/${2}${3})"))
 		seg = ruleRefDefLink.ReplaceAll(seg, []byte("$1/$3"))
 		seg = repoDocsLink.ReplaceAll(seg, []byte("](/$1/$2)"))
 		seg = repoPlanLink.ReplaceAll(seg, []byte("]("+githubBlobBase+"plan/$1)"))
@@ -706,7 +732,7 @@ func rewriteRuleFixtures(seg []byte, fileBase, dirBase string) []byte {
 		if bytes.HasSuffix(m[1], []byte("/")) {
 			base = dirBase
 		}
-		return []byte("](" + base + string(m[1]) + ")")
+		return []byte("](" + base + string(m[1]) + string(m[2]) + ")")
 	})
 }
 
@@ -715,10 +741,13 @@ func rewriteRuleFixtures(seg []byte, fileBase, dirBase string) []byte {
 // package, the shared proto.md, …) to its GitHub URL under
 // internal/rules/. The non-MDS guard in ruleSiblingNonMDSLink
 // preserves cross-rule links like `../MDS021-include/`;
-// directory vs file route is decided by trailing slash.
+// directory vs file route is decided by trailing slash. m[2] is
+// the optional link title, re-emitted so a titled link keeps it.
 func rewriteRuleSibling(match []byte) []byte {
 	m := ruleSiblingNonMDSLink.FindSubmatch(match)
-	return []byte("](" + githubURLForPath([]byte("internal/rules/"+string(m[1]))) + ")")
+	return []byte("](" +
+		githubURLForPath([]byte("internal/rules/"+string(m[1]))) +
+		string(m[2]) + ")")
 }
 
 // injectFMField inserts a YAML field block into a document's front

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -615,3 +615,37 @@ func TestRewriteRuleLinks_UntitledStillRewrites(t *testing.T) {
 		`[x](https://github.com/jeduden/mdsmith/blob/main/plan/107_no-reference-style.md)`,
 		"an untitled link must still rewrite exactly as before")
 }
+
+// A link that carries BOTH a `#fragment` and a title is the case
+// the anchor-capture tightening (`#[^)\s]*`, not `#[^)]*`) exists
+// for: the anchor must stop at the space so linkTitleTail keeps
+// the title in its own group and the rewritten destination has no
+// embedded space. These pin that anchor and title stay cleanly
+// separated across every regex that has both.
+
+func TestRewriteRuleLinks_AnchoredTitledRuleInlineAndRefDef(t *testing.T) {
+	in := "Deep: [MDS020](../../../internal/rules/" +
+		"MDS020-required-structure/README.md#sec \"Req\").\n\n" +
+		"[r]: ../../internal/rules/MDS020-required-structure/README.md#sec \"Req\"\n"
+	got := string(rewriteRuleLinks([]byte(in)))
+	assert.Contains(t, got, `[MDS020](/rules/mds020-required-structure/#sec "Req")`,
+		"anchored+titled rule link must keep both #fragment and title, no embedded space")
+	assert.Contains(t, got, `[r]: /rules/mds020-required-structure/#sec "Req"`,
+		"anchored+titled rule reference-def must keep both #fragment and title")
+}
+
+func TestRewriteRuleLinks_AnchoredTitledIndexMdLink(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`See [d](development/index.md#x "Dev").` + "\n")))
+	assert.Contains(t, got, `[d](development/#x "Dev")`,
+		"anchored+titled index.md link must keep both #fragment and title")
+}
+
+func TestTransformRulePage_AnchoredTitledReadmeLink(t *testing.T) {
+	in := "Anchor: [MDS021 a](../MDS021-include/README.md#syntax \"Inc\").\n"
+	got := string(transformRulePage([]byte(in), "MDS001-line-length"))
+	assert.Contains(t, got, `[MDS021 a](../MDS021-include/#syntax "Inc")`,
+		"anchored+titled sibling README link must keep both #fragment and title")
+	assert.NotContains(t, got, "README.md",
+		"no unpublished README.md target may survive")
+}

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -531,3 +531,87 @@ func TestBuildWebsite_SyncErrorNotDoubleWrapped(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(err.Error(), "sync "),
 		"the sync prefix must appear exactly once")
 }
+
+// --- G6: titled-link rewrite (plan/173) -------------------------
+//
+// Every inline rewrite regex used to stop the path capture at the
+// first whitespace and then require a literal `)`, so a Markdown
+// link title (`[x](../y.md "t")`) made the close fail and the
+// titled link shipped verbatim as a dead repo-relative path. The
+// `$`-anchored rule reference-def had the same gap. These tests
+// pin the fix: the path is rewritten and the title re-emitted.
+
+func TestRewriteRuleLinks_TitledNonPublishedInline(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`See [x](../../plan/107_no-reference-style.md "Plan 107").` + "\n")))
+	assert.Contains(t, got,
+		`[x](https://github.com/jeduden/mdsmith/blob/main/plan/107_no-reference-style.md "Plan 107")`,
+		"titled non-published inline link must be rewritten with its title preserved")
+	assert.NotContains(t, got, "../../plan/",
+		"no repo-relative path may survive the rewrite")
+}
+
+func TestRewriteRuleLinks_TitledNonPublishedRefDef(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`[p]: ../../plan/107_no-reference-style.md "Plan 107"` + "\n")))
+	assert.Contains(t, got,
+		`[p]: https://github.com/jeduden/mdsmith/blob/main/plan/107_no-reference-style.md "Plan 107"`,
+		"titled non-published reference definition must be rewritten with its title preserved")
+}
+
+func TestRewriteRuleLinks_TitledRuleInlineAndRefDef(t *testing.T) {
+	in := "Deep: [MDS020](../../../internal/rules/" +
+		"MDS020-required-structure/README.md \"Req\").\n\n" +
+		"[r]: ../../internal/rules/MDS020-required-structure/README.md \"Req\"\n"
+	got := string(rewriteRuleLinks([]byte(in)))
+	assert.Contains(t, got, `[MDS020](/rules/mds020-required-structure/ "Req")`,
+		"titled deep rule link must rewrite to the site URL with its title kept")
+	assert.Contains(t, got, `[r]: /rules/mds020-required-structure/ "Req"`,
+		"titled rule reference-def (the $-anchored regex) must keep its title")
+	assert.NotContains(t, got, "internal/rules/MDS020",
+		"no repo-relative rule path may survive the rewrite")
+}
+
+func TestRewriteRuleLinks_TitledIndexMdLink(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`See [d](development/index.md "Dev").` + "\n")))
+	assert.Contains(t, got, `[d](development/ "Dev")`,
+		"titled index.md link must drop the filename and keep its title")
+}
+
+func TestTransformRulePage_TitledReadmeFixtureAndSibling(t *testing.T) {
+	in := "Sibling: [MDS021](../MDS021-include/README.md \"Inc\").\n" +
+		"Fixture: [good](good/default.md \"Good\").\n" +
+		"Pkg: [pkg](../linelength/rule.go \"Pkg\").\n"
+	got := string(transformRulePage([]byte(in), "MDS001-line-length"))
+	assert.Contains(t, got, `[MDS021](../MDS021-include/ "Inc")`,
+		"titled sibling-rule README link must drop README.md and keep its title")
+	assert.Contains(t, got,
+		`[good](https://github.com/jeduden/mdsmith/blob/main/internal/rules/`+
+			`MDS001-line-length/good/default.md "Good")`,
+		"titled fixture link must become the GitHub blob URL with its title kept")
+	assert.Contains(t, got,
+		`[pkg](https://github.com/jeduden/mdsmith/blob/main/internal/rules/`+
+			`linelength/rule.go "Pkg")`,
+		"titled sibling non-MDS link must become the GitHub blob URL with its title kept")
+	assert.NotContains(t, got, "README.md",
+		"no unpublished README.md target may survive")
+}
+
+func TestRewriteRuleLinks_TitledLinkInCodeUntouched(t *testing.T) {
+	in := "Inline `[x](../../plan/a.md \"t\")` span.\n\n" +
+		"```md\n[y](../../plan/b.md \"t\")\n```\n"
+	got := string(rewriteRuleLinks([]byte(in)))
+	assert.Contains(t, got, "`[x](../../plan/a.md \"t\")`",
+		"a titled link inside an inline code span must stay verbatim")
+	assert.Contains(t, got, "[y](../../plan/b.md \"t\")",
+		"a titled link inside a fenced block must stay verbatim")
+}
+
+func TestRewriteRuleLinks_UntitledStillRewrites(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`See [x](../../plan/107_no-reference-style.md).` + "\n")))
+	assert.Contains(t, got,
+		`[x](https://github.com/jeduden/mdsmith/blob/main/plan/107_no-reference-style.md)`,
+		"an untitled link must still rewrite exactly as before")
+}

--- a/plan/173_rewriter-titled-links.md
+++ b/plan/173_rewriter-titled-links.md
@@ -1,7 +1,7 @@
 ---
 id: 173
 title: Website rewriter tolerates titled links
-status: "🔲"
+status: "✅"
 model: sonnet
 depends-on: [170]
 summary: >-
@@ -31,23 +31,34 @@ but the gap is real and cheap to close.
 
 ## Tasks
 
-1. Add a red test: a synced doc containing
-   `[x](../../../docs/a.md "t")` currently keeps the
-   repo-relative path.
-2. Widen the affected regexes to capture an optional
-   `(\s+"[^"]*")?` title tail and re-emit it after the
-   rewritten path. Keep the `applyOutsideCode` guard.
-3. Verify reference-def forms (`[label]: path "t"`) are
-   handled the same way.
-4. Green the test; confirm no existing rewrite
-   regressed.
+1. [x] Add red tests for a titled link shipping a dead
+   repo-relative path. Note: the original example
+   `[x](../../../docs/a.md "t")` does not go red —
+   `repoDocsLink`'s `([^)]*)` group already absorbs the
+   title. The genuine G6 dead-path cases are the regexes
+   that terminate with `\)` after a `\S+`/anchor capture
+   (`repoNonPublishedLink`, `repoRuleLink`,
+   `ruleReadmeLink`, `indexMdLink`, `ruleFixtureLink`,
+   `ruleSiblingNonMDSLink`) and the `$`-anchored
+   `repoRuleRefDef`; the tests cover those.
+2. [x] Added a shared `linkTitleTail` (`(\s+"[^"]*")?`)
+   appended to each affected regex and re-emitted by its
+   replacement func/template. The `applyOutsideCode`
+   guard is unchanged.
+3. [x] Verified reference-def forms: the no-`$`
+   definitions (`repoNonPublishedRefDef`,
+   `repoPlanRefDef`, `ruleRefDefLink`) already let the
+   title trail untouched; the `$`-anchored
+   `repoRuleRefDef` was widened so it no longer breaks.
+4. [x] Tests green; untitled-link and code-region
+   regression guards still pass.
 
 ## Acceptance Criteria
 
-- [ ] A titled inline link is rewritten with its title
+- [x] A titled inline link is rewritten with its title
   preserved.
-- [ ] A titled reference definition is rewritten with
+- [x] A titled reference definition is rewritten with
   its title preserved.
-- [ ] Code spans and fences are still untouched.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no issues.
+- [x] Code spans and fences are still untouched.
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no issues.


### PR DESCRIPTION
## Summary

Closes plan/173. The website rewriter now preserves Markdown link titles (e.g., `[text](url "title")`) when rewriting repo-relative paths to published URLs. Previously, titled links would fail to match the rewrite regexes and ship verbatim as dead paths.

## Changes

- **Added `linkTitleTail` constant**: A shared regex pattern `(\s+"[^"]*")?` that optionally matches a Markdown link title. This pattern is appended to all affected rewrite regexes so titles are captured and re-emitted after the rewritten path.

- **Updated rewrite regexes**: Modified 7 regexes to include `linkTitleTail`:
  - `ruleReadmeLink` (group 3)
  - `repoRuleLink` (group 3)
  - `repoRuleRefDef` (group 4, before `$` anchor)
  - `repoNonPublishedLink` (group 2)
  - `indexMdLink` (group 3)
  - `ruleFixtureLink` (group 2)
  - `ruleSiblingNonMDSLink` (group 2)

- **Updated replacement functions**: Modified 6 replacement functions to re-emit the captured title:
  - `rewriteRepoRuleInline()` — appends `m[3]`
  - `rewriteRepoRuleRefDef()` — appends `m[4]`
  - `rewriteNonPublishedInline()` — appends `m[2]`
  - `rewriteRuleFixtures()` — appends `m[2]`
  - `rewriteRuleSibling()` — appends `m[2]`
  - Template replacements in `rewriteRuleLinks()` and `transformRulePage()` — updated placeholders to include title groups

- **Added comprehensive tests**: 7 new test cases covering:
  - Titled non-published inline links and reference definitions
  - Titled rule links (inline and reference-def forms)
  - Titled index.md links
  - Titled fixture and sibling links
  - Titled links inside code spans/fences (must remain untouched)
  - Untitled links (regression guard)

## Implementation Details

The fix leverages the existing `applyOutsideCode()` guard, so titled links inside code regions remain untouched. The `linkTitleTail` pattern is optional (`?`), so untitled links continue to work exactly as before. Reference-definition regexes without `$` anchors (`repoNonPublishedRefDef`, `repoPlanRefDef`, `ruleRefDefLink`) already let titles trail untouched; only the `$`-anchored `repoRuleRefDef` needed widening to prevent the anchor from breaking past the title.

All acceptance criteria met; all tests pass.

https://claude.ai/code/session_01JHq14bbX1bUG25MWYJjPna