### PR TITLE
Memoize catalog entries and front matter per Check

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -113,5 +113,5 @@ footer: |
 | 184 | ✅     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 | 185 | 🔲     |        | [Expose extended-syntax parsers and the flavor model in pkg/markdown](plan/185_public-markdown-flavor-library.md)                       |
 | 186 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/186_catalog-run-scoped-readcache.md)                                     |
-| 187 | 🔳     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
+| 187 | ✅     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -112,4 +112,6 @@ footer: |
 | 183 | ✅     | sonnet | [Skip DedupeDiagnostics via an audited rule.RepoScoped marker](plan/183_dedupe-diagnostics-repo-scoped-skip.md)                         |
 | 184 | ✅     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 | 185 | 🔲     |        | [Expose extended-syntax parsers and the flavor model in pkg/markdown](plan/185_public-markdown-flavor-library.md)                       |
+| 186 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/186_catalog-run-scoped-readcache.md)                                     |
+| 187 | 🔳     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -114,4 +114,5 @@ footer: |
 | 185 | 🔲     |        | [Expose extended-syntax parsers and the flavor model in pkg/markdown](plan/185_public-markdown-flavor-library.md)                       |
 | 186 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/186_catalog-run-scoped-readcache.md)                                     |
 | 187 | ✅     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
+| 188 | 🔲     | opus   | [Regex-over-source rules — inventory and AST-resident replacements](plan/188_regex-vs-ast-inventory.md)                                 |
 <?/catalog?>

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/yuin/goldmark/ast"
 )
 
 // ConfigureRule clones a rule and applies settings from cfg if the rule
@@ -53,6 +54,22 @@ func checkRules(
 	var diags []lint.Diagnostic
 	var errs []error
 
+	// Each enabled rule contributes one contiguous diagnostic group,
+	// kept in rules order. Rules implementing rule.NodeChecker have
+	// their group filled by a single shared ast.Walk instead of each
+	// re-walking the whole tree (goldmark walkHelper was ~44%
+	// cumulative). Because every group is still placed in rules order
+	// and a NodeChecker's bucket is fed the identical pre-order node
+	// stream its own Check (rule.WalkNodes) would use, the combined
+	// slice is byte-identical to running every rule's Check
+	// sequentially — order-independent consumers see no change.
+	type ruleSlot struct {
+		nc    rule.NodeChecker
+		diags []lint.Diagnostic
+	}
+	var slots []*ruleSlot
+	var nodeCheckers []*ruleSlot
+
 	for _, rl := range rules {
 		cfg, ok := effective[rl.Name()]
 		if !ok || !cfg.Enabled {
@@ -65,8 +82,26 @@ func checkRules(
 			continue
 		}
 
-		d := checkRule.Check(f)
-		diags = append(diags, d...)
+		if nc, ok := checkRule.(rule.NodeChecker); ok {
+			s := &ruleSlot{nc: nc}
+			slots = append(slots, s)
+			nodeCheckers = append(nodeCheckers, s)
+			continue
+		}
+		slots = append(slots, &ruleSlot{diags: checkRule.Check(f)})
+	}
+
+	if len(nodeCheckers) > 0 {
+		_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			for _, s := range nodeCheckers {
+				s.diags = append(s.diags, s.nc.CheckNode(n, entering, f)...)
+			}
+			return ast.WalkContinue, nil
+		})
+	}
+
+	for _, s := range slots {
+		diags = append(diags, s.diags...)
 	}
 
 	diags = filterGeneratedDiags(diags, f.GeneratedRanges)

--- a/internal/engine/multiplex_test.go
+++ b/internal/engine/multiplex_test.go
@@ -1,0 +1,119 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+)
+
+// mockNodeChecker implements rule.NodeChecker, emitting one
+// diagnostic per Heading on entering — a pure per-node rule.
+type mockNodeChecker struct {
+	id, name string
+}
+
+func (m *mockNodeChecker) ID() string       { return m.id }
+func (m *mockNodeChecker) Name() string     { return m.name }
+func (m *mockNodeChecker) Category() string { return "test" }
+func (m *mockNodeChecker) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(m, f)
+}
+func (m *mockNodeChecker) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering || n.Kind() != ast.KindHeading {
+		return nil
+	}
+	return []lint.Diagnostic{{
+		File: f.Path, Line: 1, Column: 1,
+		RuleID: m.id, RuleName: m.name,
+		Severity: lint.Warning, Message: "heading seen",
+	}}
+}
+
+// plainView wraps a NodeChecker but exposes ONLY the Rule interface,
+// so checkRules cannot detect the NodeChecker capability and falls
+// back to calling Check sequentially — i.e. the pre-multiplex path.
+type plainView struct{ nc *mockNodeChecker }
+
+func (p plainView) ID() string                           { return p.nc.id }
+func (p plainView) Name() string                         { return p.nc.name }
+func (p plainView) Category() string                     { return "test" }
+func (p plainView) Check(f *lint.File) []lint.Diagnostic { return p.nc.Check(f) }
+
+// TestCheckRules_MultiplexedEqualsSequential pins that routing a
+// NodeChecker through the engine's single shared ast.Walk produces a
+// byte-identical diagnostic slice — same content AND order — to
+// running every rule's Check sequentially. plainView hides the
+// NodeChecker capability to compute the pre-multiplex reference with
+// the exact same code path, so any divergence is the multiplexing
+// itself.
+func TestCheckRules_MultiplexedEqualsSequential(t *testing.T) {
+	src := []byte("# A\n\npara one\n\n## B\n\npara two\n\n### C\n")
+	f1, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+	f2, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+
+	nc := &mockNodeChecker{id: "MDSX02", name: "mux-stub"}
+	eff := map[string]config.RuleCfg{
+		"mock-a":   {Enabled: true},
+		"mux-stub": {Enabled: true},
+		"mock-b":   {Enabled: true},
+	}
+
+	// Sequential reference: NodeChecker hidden behind plainView.
+	seq, errs1 := checkRules(f1, []rule.Rule{
+		&mockRule{id: "MDA", name: "mock-a"},
+		plainView{nc},
+		&mockRule{id: "MDB", name: "mock-b"},
+	}, eff, true)
+
+	// Multiplexed: real NodeChecker, driven by the shared walk.
+	mux, errs2 := checkRules(f2, []rule.Rule{
+		&mockRule{id: "MDA", name: "mock-a"},
+		nc,
+		&mockRule{id: "MDB", name: "mock-b"},
+	}, eff, true)
+
+	require.Empty(t, errs1)
+	require.Empty(t, errs2)
+	assert.Equal(t, seq, mux,
+		"multiplexed dispatch must be byte-identical to sequential Check")
+
+	// The NodeChecker's diagnostics appear exactly once (3 headings),
+	// and grouped between the two mock rules' single diagnostics.
+	require.Len(t, mux, 5)
+	assert.Equal(t, "MDA", mux[0].RuleID)
+	assert.Equal(t, "MDSX02", mux[1].RuleID)
+	assert.Equal(t, "MDSX02", mux[2].RuleID)
+	assert.Equal(t, "MDSX02", mux[3].RuleID)
+	assert.Equal(t, "MDB", mux[4].RuleID)
+}
+
+// TestCheckRules_MultipleNodeCheckersShareOneWalk pins that several
+// NodeCheckers are all fed the same single walk and each still
+// contributes its own contiguous, correctly ordered group.
+func TestCheckRules_MultipleNodeCheckersShareOneWalk(t *testing.T) {
+	f, err := lint.NewFile("doc.md", []byte("# H1\n\ntext\n\n## H2\n"))
+	require.NoError(t, err)
+
+	a := &mockNodeChecker{id: "AAA", name: "nc-a"}
+	b := &mockNodeChecker{id: "BBB", name: "nc-b"}
+	eff := map[string]config.RuleCfg{
+		"nc-a": {Enabled: true},
+		"nc-b": {Enabled: true},
+	}
+
+	diags, errs := checkRules(f, []rule.Rule{a, b}, eff, true)
+	require.Empty(t, errs)
+	require.Len(t, diags, 4, "2 headings x 2 rules")
+	// nc-a's group first (rules order), then nc-b's group.
+	assert.Equal(t, "AAA", diags[0].RuleID)
+	assert.Equal(t, "AAA", diags[1].RuleID)
+	assert.Equal(t, "BBB", diags[2].RuleID)
+	assert.Equal(t, "BBB", diags[3].RuleID)
+}

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -88,6 +88,38 @@ type File struct {
 	parseCtx     parser.Context
 	linkRefs     []Reference
 	linkRefsOnce sync.Once
+
+	// scratch backs Memo: per-Check rule memoization. A *File is
+	// built fresh for each Check and discarded after, so values
+	// cached here never outlive a single Check — no cross-file or
+	// cross-run staleness, the same scope as the cross-file rule's
+	// per-Check cache. sync.Map keeps it safe for the concurrent
+	// readers the LSP may run against one document.
+	scratch sync.Map
+}
+
+// memoEntry guards a single Memo key so build runs exactly once even
+// when several rule passes (or concurrent LSP readers) race for the
+// same key.
+type memoEntry struct {
+	once sync.Once
+	val  any
+}
+
+// Memo returns the value for key, computing it once via build on the
+// first request within this File's lifetime and serving the cached
+// value thereafter. It exists so a rule whose passes would otherwise
+// recompute the same expensive per-Check derivation can share one
+// result: the catalog directive's resolved entries, for example, are
+// otherwise rebuilt by the generate, injection, and case-mismatch
+// passes — three globs and front-matter reads of every matched file
+// per directive. The File is discarded after each Check, so nothing
+// is cached across files or runs.
+func (f *File) Memo(key string, build func() any) any {
+	ei, _ := f.scratch.LoadOrStore(key, &memoEntry{})
+	e := ei.(*memoEntry)
+	e.once.Do(func() { e.val = build() })
+	return e.val
 }
 
 // Reference is a link reference definition discovered during the parse,

--- a/internal/lint/file_test.go
+++ b/internal/lint/file_test.go
@@ -2,6 +2,8 @@ package lint
 
 import (
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -207,4 +209,58 @@ func TestNewFileFromSource_EmptySource(t *testing.T) {
 
 	assert.Equal(t, 0, f.LineOffset)
 	assert.Nil(t, f.FrontMatter)
+}
+
+// TestFile_Memo pins the per-Check memo: build runs once per key, the
+// cached value is served on every later call, and distinct keys are
+// independent. This is the primitive the catalog rule uses so its
+// generate / injection / case-mismatch passes stop recomputing the
+// same directive's resolved entries three times per Check.
+func TestFile_Memo(t *testing.T) {
+	f := &File{Path: "t.md"}
+
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return 42
+	}
+
+	require.Equal(t, 42, f.Memo("k", build))
+	require.Equal(t, 42, f.Memo("k", build))
+	require.Equal(t, 42, f.Memo("k", build))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"build must run exactly once per key")
+
+	var otherCalls int32
+	require.Equal(t, "v2", f.Memo("k2", func() any {
+		atomic.AddInt32(&otherCalls, 1)
+		return "v2"
+	}))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&otherCalls))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"a distinct key must not re-run the first key's build")
+}
+
+// TestFile_Memo_ConcurrentSingleBuild pins that build runs exactly
+// once even under the concurrent readers the LSP can run against a
+// single document.
+func TestFile_Memo_ConcurrentSingleBuild(t *testing.T) {
+	f := &File{Path: "t.md"}
+
+	var calls int32
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v := f.Memo("shared", func() any {
+				atomic.AddInt32(&calls, 1)
+				return "once"
+			})
+			assert.Equal(t, "once", v)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"build must run exactly once under concurrent access")
 }

--- a/internal/mdtext/sentence_equivalence_test.go
+++ b/internal/mdtext/sentence_equivalence_test.go
@@ -1,0 +1,187 @@
+package mdtext_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/mdtext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Plan 187 task 4: sentence-segmenter equivalence harness.
+//
+// SplitSentences wraps the trained Punkt tokenizer
+// (github.com/neurosnap/sentences). It is the single biggest
+// neutral-corpus cost (~20% CPU, heavy regexp backtracking). MDS024
+// (paragraph-structure) is its only production caller and its
+// diagnostics depend on the EXACT segmentation: the sentence count,
+// each sentence's word count, and the over-long-sentence preview
+// string. So a faster segmenter is only adoptable if it is
+// byte-for-byte identical to Punkt on real prose.
+//
+// This harness makes that check reusable: assertSegmenterEquivalent
+// runs a candidate against Punkt over a representative corpus and
+// fails on the first divergence. A future faster candidate is
+// adopted only if it passes here.
+//
+// Evidence-backed negative recorded for this task (see plan 187):
+//
+//   - The "per-call regexp.MustCompile in IsNonPunct" hypothesis is
+//     false. IsNonPunct has no call site anywhere in the neurosnap
+//     module or its english subpackage, and no regexp.MustCompile
+//     frame appears in the neutral CPU profile. Precompiling it
+//     would change nothing.
+//   - The real cost is intrinsic trained-Punkt regexp *execution*:
+//     english.(*MultiPunctWordAnnotation).tokenAnnotation (~140 ms
+//     cum on the neutral corpus) running package-level regexps
+//     (reAbbr and the token-type matchers) with backtracking. That
+//     is the trained model's algorithm, not a fixable recompile.
+//   - A naive [.!?] splitter is provably NOT equivalent (TestNaive*
+//     below): it diverges on abbreviations, decimals, ellipses, and
+//     initials — exactly what Punkt is trained to handle. No pure-Go
+//     Punkt-compatible faster segmenter exists.
+//
+// Conclusion: keep Punkt. The neutral lever is the structural one
+// (plan 187 task 3 / 5), not a segmenter swap. This harness stays as
+// the cheap gate for any future candidate.
+
+// equivalenceCorpus is representative prose that exercises the cases
+// where trained Punkt and naive splitting disagree: plain
+// multi-sentence text, abbreviations, honorifics, decimals,
+// ellipses, initials, and Rust-Book-style technical prose (the
+// neutral benchmark corpus' shape).
+var equivalenceCorpus = []string{
+	"Hello world. How are you? I am fine!",
+	"Dr. Smith met Mr. Jones at 3.14 p.m. on Jan. 5.",
+	"The value is 3.14 today. It was 2.71 yesterday.",
+	"Wait... what happened here? Nothing, apparently.",
+	"J. R. R. Tolkien wrote it. Many people read it.",
+	"Use e.g. this form, i.e. the short one. Then stop.",
+	"The U.S. and U.K. signed it. The E.U. did not.",
+	"A trait bound restricts the generic types a function accepts. " +
+		"It is written after a colon. The compiler enforces it at " +
+		"every call site. Errors point at the unsatisfied bound.",
+	"Ownership moves by default. Borrowing lends a reference instead. " +
+		"A mutable borrow is exclusive. The borrow checker proves this " +
+		"at compile time, so no runtime cost is added.",
+	"See section 1.2.3 for details. The API is stable. Version 2.0 " +
+		"dropped the old path. Migrate before then.",
+	"",
+	"No terminal punctuation here just a long clause that runs on",
+}
+
+// firstDivergence returns the index and detail of the first corpus
+// sample where candidate's segmentation differs from Punkt's, or
+// ok==true when the candidate is byte-for-byte equivalent across the
+// whole corpus. This is the reusable gate any future faster
+// candidate must pass (ok==true) to be adoptable.
+func firstDivergence(candidate func(string) []string) (idx int, detail string, ok bool) {
+	for i, sample := range equivalenceCorpus {
+		want := mdtext.SplitSentences(sample)
+		got := candidate(sample)
+		if !slicesEqual(want, got) {
+			return i, fmt.Sprintf(
+				"corpus[%d]=%q\n  Punkt:     %#v\n  candidate: %#v",
+				i, sample, want, got), false
+		}
+	}
+	return 0, "", true
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// assertSegmenterEquivalent fails the test unless candidate is
+// byte-for-byte equivalent to Punkt across the whole corpus.
+func assertSegmenterEquivalent(
+	t *testing.T, name string, candidate func(string) []string,
+) {
+	t.Helper()
+	idx, detail, ok := firstDivergence(candidate)
+	require.Truef(t, ok,
+		"%s must be byte-for-byte equivalent to Punkt; diverged at %s",
+		name, detail)
+	_ = idx
+}
+
+// TestSplitSentences_IsItsOwnReference sanity-checks the harness:
+// Punkt is trivially equivalent to itself across the whole corpus,
+// so a real candidate that passes is genuinely byte-identical.
+func TestSplitSentences_IsItsOwnReference(t *testing.T) {
+	assertSegmenterEquivalent(t, "Punkt", mdtext.SplitSentences)
+}
+
+// naiveSplit is the obvious "fast" alternative: split on a terminal
+// punctuation run followed by whitespace or end of text, trim, drop
+// empties — mirroring SplitSentences' post-processing so only the
+// boundary logic differs.
+var naiveBoundary = regexp.MustCompile(`[.!?]+(\s+|$)`)
+
+func naiveSplit(text string) []string {
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	var out []string
+	start := 0
+	for _, m := range naiveBoundary.FindAllStringIndex(text, -1) {
+		seg := strings.TrimSpace(text[start:m[1]])
+		if seg != "" {
+			out = append(out, seg)
+		}
+		start = m[1]
+	}
+	if start < len(text) {
+		if seg := strings.TrimSpace(text[start:]); seg != "" {
+			out = append(out, seg)
+		}
+	}
+	return out
+}
+
+// TestNaiveSplit_IsNotPunktEquivalent records the negative with a
+// concrete divergence: naive splitting breaks "Dr. Smith met Mr.
+// Jones at 3.14 p.m. on Jan. 5." into many fragments where trained
+// Punkt keeps one sentence. This is why MDS024 needs Punkt and why
+// no naive faster segmenter is adoptable.
+func TestNaiveSplit_IsNotPunktEquivalent(t *testing.T) {
+	const sample = "Dr. Smith met Mr. Jones at 3.14 p.m. on Jan. 5."
+
+	punkt := mdtext.SplitSentences(sample)
+	naive := naiveSplit(sample)
+
+	require.Len(t, punkt, 1,
+		"trained Punkt keeps the abbreviation-laden clause as one sentence")
+	assert.Greater(t, len(naive), len(punkt),
+		"naive splitting over-segments on abbreviations and decimals")
+
+	// And it fails the reusable gate, so it cannot be adopted: the
+	// harness must reject any non-Punkt-equivalent candidate.
+	_, detail, ok := firstDivergence(naiveSplit)
+	assert.Falsef(t, ok,
+		"the equivalence harness must reject naiveSplit, but it passed")
+	t.Logf("recorded negative — naiveSplit diverges from Punkt at %s", detail)
+}
+
+// BenchmarkSplitSentences pins the Punkt cost over the equivalence
+// corpus so any future candidate has a comparison baseline and a
+// regression in the tokenizer path is visible.
+func BenchmarkSplitSentences(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, s := range equivalenceCorpus {
+			_ = mdtext.SplitSentences(s)
+		}
+	}
+}

--- a/internal/mdtext/sentence_equivalence_test.go
+++ b/internal/mdtext/sentence_equivalence_test.go
@@ -73,22 +73,23 @@ var equivalenceCorpus = []string{
 	"No terminal punctuation here just a long clause that runs on",
 }
 
-// firstDivergence returns the index and detail of the first corpus
+// firstDivergence returns a human-readable detail of the first corpus
 // sample where candidate's segmentation differs from Punkt's, or
 // ok==true when the candidate is byte-for-byte equivalent across the
-// whole corpus. This is the reusable gate any future faster
+// whole corpus. The detail embeds the corpus index, so callers do not
+// need it separately. This is the reusable gate any future faster
 // candidate must pass (ok==true) to be adoptable.
-func firstDivergence(candidate func(string) []string) (idx int, detail string, ok bool) {
+func firstDivergence(candidate func(string) []string) (detail string, ok bool) {
 	for i, sample := range equivalenceCorpus {
 		want := mdtext.SplitSentences(sample)
 		got := candidate(sample)
 		if !slicesEqual(want, got) {
-			return i, fmt.Sprintf(
+			return fmt.Sprintf(
 				"corpus[%d]=%q\n  Punkt:     %#v\n  candidate: %#v",
 				i, sample, want, got), false
 		}
 	}
-	return 0, "", true
+	return "", true
 }
 
 func slicesEqual(a, b []string) bool {
@@ -109,11 +110,10 @@ func assertSegmenterEquivalent(
 	t *testing.T, name string, candidate func(string) []string,
 ) {
 	t.Helper()
-	idx, detail, ok := firstDivergence(candidate)
+	detail, ok := firstDivergence(candidate)
 	require.Truef(t, ok,
 		"%s must be byte-for-byte equivalent to Punkt; diverged at %s",
 		name, detail)
-	_ = idx
 }
 
 // TestSplitSentences_IsItsOwnReference sanity-checks the harness:
@@ -168,7 +168,7 @@ func TestNaiveSplit_IsNotPunktEquivalent(t *testing.T) {
 
 	// And it fails the reusable gate, so it cannot be adopted: the
 	// harness must reject any non-Punkt-equivalent candidate.
-	_, detail, ok := firstDivergence(naiveSplit)
+	detail, ok := firstDivergence(naiveSplit)
 	assert.Falsef(t, ok,
 		"the equivalence harness must reject naiveSplit, but it passed")
 	t.Logf("recorded negative — naiveSplit diverges from Punkt at %s", detail)

--- a/internal/rule/walk.go
+++ b/internal/rule/walk.go
@@ -1,0 +1,38 @@
+package rule
+
+import (
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/yuin/goldmark/ast"
+)
+
+// NodeChecker is an optional capability for a rule whose Check is a
+// pure per-node pass: it inspects each AST node independently, keeps
+// no state across nodes, and does not depend on skipping a subtree or
+// stopping the walk for correctness. The engine drives ONE shared
+// ast.Walk for every enabled NodeChecker instead of each rule
+// re-walking the whole tree (goldmark walkHelper was ~44% cumulative
+// with N per-rule walks). The engine still appends each rule's
+// diagnostics as one contiguous group in rule order, so the result
+// is byte-identical to running each rule's Check sequentially.
+type NodeChecker interface {
+	Rule
+	// CheckNode is invoked for every node, once entering and (for
+	// container nodes) once leaving, in the exact pre-order
+	// goldmark ast.Walk uses. It must return precisely the
+	// diagnostics the rule's own ast.Walk Check would, and must not
+	// rely on ast.WalkSkipChildren or ast.WalkStop.
+	CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic
+}
+
+// WalkNodes runs r.CheckNode over a single ast.Walk of f. A
+// NodeChecker's standalone Check delegates here so direct callers
+// (the LSP, unit tests) get behaviour identical to the engine's
+// multiplexed dispatch, which feeds CheckNode the same node stream.
+func WalkNodes(r NodeChecker, f *lint.File) []lint.Diagnostic {
+	var diags []lint.Diagnostic
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		diags = append(diags, r.CheckNode(n, entering, f)...)
+		return ast.WalkContinue, nil
+	})
+	return diags
+}

--- a/internal/rule/walk_test.go
+++ b/internal/rule/walk_test.go
@@ -1,0 +1,88 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+)
+
+// nodeCheckerStub emits one diagnostic per Heading node on entering,
+// and records every (kind, entering) it is shown so the test can
+// assert WalkNodes feeds the full pre-order node stream.
+type nodeCheckerStub struct {
+	visits []string
+}
+
+func (s *nodeCheckerStub) ID() string       { return "MDSX01" }
+func (s *nodeCheckerStub) Name() string     { return "stub" }
+func (s *nodeCheckerStub) Category() string { return "test" }
+
+func (s *nodeCheckerStub) Check(f *lint.File) []lint.Diagnostic {
+	return WalkNodes(s, f)
+}
+
+func (s *nodeCheckerStub) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	verb := "exit"
+	if entering {
+		verb = "enter"
+	}
+	s.visits = append(s.visits, verb+":"+n.Kind().String())
+	if entering && n.Kind() == ast.KindHeading {
+		return []lint.Diagnostic{{RuleID: s.ID(), Message: "heading seen"}}
+	}
+	return nil
+}
+
+var _ NodeChecker = (*nodeCheckerStub)(nil)
+
+// TestWalkNodes_FeedsFullPreorderStreamAndConcatenates pins that
+// WalkNodes drives one ast.Walk, shows CheckNode every node entering
+// then leaving, and concatenates per-node diagnostics in document
+// order. This is the contract the engine's multiplexed dispatch and
+// a NodeChecker's standalone Check both rely on.
+func TestWalkNodes_FeedsFullPreorderStreamAndConcatenates(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("# A\n\ntext\n\n## B\n"))
+	require.NoError(t, err)
+
+	s := &nodeCheckerStub{}
+	diags := WalkNodes(s, f)
+
+	require.Len(t, diags, 2, "one diagnostic per heading, in document order")
+	assert.Equal(t, "heading seen", diags[0].Message)
+
+	// Document root is entered first and left last; both headings are
+	// shown entering.
+	require.NotEmpty(t, s.visits)
+	assert.Equal(t, "enter:Document", s.visits[0])
+	assert.Equal(t, "exit:Document", s.visits[len(s.visits)-1])
+	enterHeadings := 0
+	for _, v := range s.visits {
+		if v == "enter:Heading" {
+			enterHeadings++
+		}
+	}
+	assert.Equal(t, 2, enterHeadings)
+}
+
+// TestWalkNodes_EqualsManualWalk pins that WalkNodes is exactly a
+// single ast.Walk over CheckNode — the equivalence the engine relies
+// on so a multiplexed dispatch cannot change a rule's output.
+func TestWalkNodes_EqualsManualWalk(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("# H\n\np\n\n### Deep\n\n- a\n"))
+	require.NoError(t, err)
+
+	s := &nodeCheckerStub{}
+	viaHelper := WalkNodes(s, f)
+
+	var manual []lint.Diagnostic
+	ref := &nodeCheckerStub{}
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		manual = append(manual, ref.CheckNode(n, entering, f)...)
+		return ast.WalkContinue, nil
+	})
+
+	assert.Equal(t, manual, viaHelper)
+}

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -56,25 +56,37 @@ func CollectSectionHeadings(f *lint.File) []SectionHeading {
 // tables as paragraphs when the table extension is absent; those are
 // filtered so cell text does not pollute section bodies.
 func CollectSectionParagraphs(f *lint.File) []SectionParagraph {
-	var out []SectionParagraph
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
+	// Memoized per File: this walks the whole AST and runs
+	// ExtractPlainText on every paragraph. On prose-heavy input the
+	// two hot default rules (MDS024 paragraph-structure and
+	// paragraph-readability) plus the required-* rules each called
+	// it, so the walk and per-paragraph extraction ran several times
+	// per file. The result is a pure function of the immutable AST
+	// and Source; the memo lives on the per-Check File, so nothing
+	// is cached across files or runs — the same scope and staleness
+	// guarantees as the per-File code-block-line cache. Callers
+	// treat the slice as read-only.
+	return f.Memo("astutil.sectionParagraphs", func() any {
+		var out []SectionParagraph
+		_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			p, ok := n.(*ast.Paragraph)
+			if !ok {
+				return ast.WalkContinue, nil
+			}
+			if IsTable(p, f) {
+				return ast.WalkContinue, nil
+			}
+			out = append(out, SectionParagraph{
+				Line: ParagraphLine(p, f),
+				Text: mdtext.ExtractPlainText(p, f.Source),
+			})
 			return ast.WalkContinue, nil
-		}
-		p, ok := n.(*ast.Paragraph)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		if IsTable(p, f) {
-			return ast.WalkContinue, nil
-		}
-		out = append(out, SectionParagraph{
-			Line: ParagraphLine(p, f),
-			Text: mdtext.ExtractPlainText(p, f.Source),
 		})
-		return ast.WalkContinue, nil
-	})
-	return out
+		return out
+	}).([]SectionParagraph)
 }
 
 // SectionEnd returns the exclusive end line of the section starting

--- a/internal/rules/astutil/astutil_test.go
+++ b/internal/rules/astutil/astutil_test.go
@@ -416,3 +416,33 @@ func TestSectionBody_EmptyWhenNoParagraphsInRange(t *testing.T) {
 	paras := []SectionParagraph{{Line: 100, Text: "out"}}
 	assert.Equal(t, "", SectionBody(paras, 1, 10))
 }
+
+// TestCollectSectionParagraphs_MemoizedPerFile pins that the
+// AST-walking, ExtractPlainText-running collector runs once per File
+// and serves a cached result thereafter. On prose-heavy corpora
+// (the neutral Rust Book benchmark) the two hot default rules —
+// MDS024 paragraph-structure and paragraph-readability — both walk
+// every paragraph and extract its plain text; sharing one memoized
+// walk removes the duplicate. Reference identity of the returned
+// slice proves a later call did not re-walk.
+func TestCollectSectionParagraphs_MemoizedPerFile(t *testing.T) {
+	src := []byte("# H\n\nFirst paragraph here.\n\nSecond paragraph too.\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+
+	p1 := CollectSectionParagraphs(f)
+	p2 := CollectSectionParagraphs(f)
+
+	require.Len(t, p1, 2)
+	require.Len(t, p2, 2)
+	assert.Same(t, &p1[0], &p2[0],
+		"repeated calls must return the cached slice, not a fresh walk")
+
+	// A different File computes independently (the memo is per-File,
+	// discarded with it — no cross-file or cross-run staleness).
+	f2, err := lint.NewFile("other.md", []byte("Different.\n"))
+	require.NoError(t, err)
+	o := CollectSectionParagraphs(f2)
+	require.Len(t, o, 1)
+	assert.Equal(t, "Different.", o[0].Text)
+}

--- a/internal/rules/catalog/memo_test.go
+++ b/internal/rules/catalog/memo_test.go
@@ -1,0 +1,106 @@
+package catalog
+
+import (
+	"io/fs"
+	"sync"
+	"testing"
+	"testing/fstest"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingFS wraps an fstest.MapFS and counts how many times each path
+// is read (via ReadFile, the path lint.ReadFSFileLimited and the YAML
+// front-matter reader take when MaxInputBytes is unset). doublestar's
+// glob walk uses ReadDir/Stat, not ReadFile, so a matched markdown
+// file's count reflects only the rule passes that re-read its content.
+type countingFS struct {
+	inner fstest.MapFS
+	mu    sync.Mutex
+	reads map[string]int
+}
+
+func newCountingFS(inner fstest.MapFS) *countingFS {
+	return &countingFS{inner: inner, reads: map[string]int{}}
+}
+
+func (c *countingFS) bump(name string) {
+	c.mu.Lock()
+	c.reads[name]++
+	c.mu.Unlock()
+}
+
+func (c *countingFS) count(name string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reads[name]
+}
+
+func (c *countingFS) Open(name string) (fs.File, error) {
+	c.bump(name)
+	return c.inner.Open(name)
+}
+
+func (c *countingFS) ReadFile(name string) ([]byte, error) {
+	c.bump(name)
+	return c.inner.ReadFile(name)
+}
+
+func (c *countingFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return c.inner.ReadDir(name)
+}
+
+func (c *countingFS) Stat(name string) (fs.FileInfo, error) {
+	return c.inner.Stat(name)
+}
+
+func (c *countingFS) Glob(pattern string) ([]string, error) {
+	return c.inner.Glob(pattern)
+}
+
+// TestCheck_DoesNotRebuildCatalogEntriesPerPass pins that one Check of
+// a file with a single catalog directive reads each matched file's
+// content a bounded number of times. Before the per-Check entry memo,
+// buildCatalogEntries ran three times per directive — once for the
+// generate (out-of-date) pass, once for injection, once for
+// case-mismatch — so every matched file's front matter was read three
+// times, plus once more for the include-cycle scan: four reads per
+// matched file. The memo collapses the three entry builds to one, so a
+// matched file is read at most twice (front matter once, cycle scan
+// once). On the directive-dense repo corpus this is ~24% of the whole
+// `mdsmith check` run; the neutral corpus has no directives and never
+// paid it, which is the repo-vs-neutral gap.
+func TestCheck_DoesNotRebuildCatalogEntriesPerPass(t *testing.T) {
+	src := `<?catalog
+glob: "docs/*.md"
+row: "- [{title}]({filename})"
+?>
+- [Alpha](docs/a.md)
+- [Beta](docs/b.md)
+<?/catalog?>
+`
+	inner := fstest.MapFS{
+		"docs/a.md": {Data: []byte("---\ntitle: Alpha\n---\n# A\n")},
+		"docs/b.md": {Data: []byte("---\ntitle: Beta\n---\n# B\n")},
+	}
+	cfs := newCountingFS(inner)
+
+	f, err := lint.NewFile("index.md", []byte(src))
+	require.NoError(t, err)
+	f.FS = cfs
+
+	r := &Rule{}
+	diags := r.Check(f)
+	require.Empty(t, diags, "fixture is well-formed; optimization must not change correctness")
+
+	for _, p := range []string{"docs/a.md", "docs/b.md"} {
+		assert.LessOrEqualf(t, cfs.count(p), 2,
+			"matched file %s should be read at most twice per Check "+
+				"(front matter once + cycle scan once), got %d — the "+
+				"generate/injection/case-mismatch passes are rebuilding entries",
+			p, cfs.count(p))
+	}
+}

--- a/internal/rules/catalog/memo_test.go
+++ b/internal/rules/catalog/memo_test.go
@@ -104,3 +104,101 @@ row: "- [{title}]({filename})"
 			p, cfs.count(p))
 	}
 }
+
+// TestCheck_DoesNotRescanIncludesPerDirective pins that the
+// include-cycle scan parses each matched file once per Check, not once
+// per catalog directive. The two minimal (glob-only, no row) catalog
+// directives below match the same files and read no front matter, so
+// the only reads of a matched file come from the include-cycle scan
+// (checkCatalogIncludeCycle -> scanIncludesForTarget -> a full
+// lint.NewFile parse). Before the per-Check adjacency memo that scan
+// re-read and re-parsed every matched file once per directive; files
+// like CLAUDE.md carry three catalogs over an overlapping docs/**
+// glob, so the same docs tree was parsed three times. With the memo a
+// matched file is read once for the whole Check.
+func TestCheck_DoesNotRescanIncludesPerDirective(t *testing.T) {
+	src := `<?catalog
+glob: "docs/*.md"
+?>
+- [a.md](docs/a.md)
+- [b.md](docs/b.md)
+<?/catalog?>
+
+<?catalog
+glob: "docs/*.md"
+?>
+- [a.md](docs/a.md)
+- [b.md](docs/b.md)
+<?/catalog?>
+`
+	inner := fstest.MapFS{
+		"docs/a.md": {Data: []byte("# A\n")},
+		"docs/b.md": {Data: []byte("# B\n")},
+	}
+	cfs := newCountingFS(inner)
+
+	f, err := lint.NewFile("index.md", []byte(src))
+	require.NoError(t, err)
+	f.FS = cfs
+
+	r := &Rule{}
+	diags := r.Check(f)
+	require.Empty(t, diags, "fixture is well-formed; optimization must not change correctness")
+
+	for _, p := range []string{"docs/a.md", "docs/b.md"} {
+		assert.LessOrEqualf(t, cfs.count(p), 1,
+			"matched file %s should be parsed once per Check for the "+
+				"include-cycle scan, not once per directive, got %d",
+			p, cfs.count(p))
+	}
+}
+
+// TestCheck_DoesNotReReadFrontMatterPerDirective pins that a matched
+// file's front matter is read once per Check, not once per catalog
+// directive that globs it. The two directives below carry distinct
+// (path, line) keys so their entry builds are not shared, yet they
+// match the same files; without a per-path front-matter memo each
+// matched file's YAML was read once per directive. Files that carry
+// several catalogs over an overlapping glob — CLAUDE.md has three on
+// docs/** — paid this per directive. Combined with the cycle-scan
+// memo, a matched file is now read at most twice for the whole Check
+// (front matter once + cycle scan once) regardless of directive count.
+func TestCheck_DoesNotReReadFrontMatterPerDirective(t *testing.T) {
+	src := `<?catalog
+glob: "docs/*.md"
+row: "- [{title}]({filename})"
+?>
+- [Alpha](docs/a.md)
+- [Beta](docs/b.md)
+<?/catalog?>
+
+<?catalog
+glob: "docs/*.md"
+row: "- [{title}]({filename})"
+?>
+- [Alpha](docs/a.md)
+- [Beta](docs/b.md)
+<?/catalog?>
+`
+	inner := fstest.MapFS{
+		"docs/a.md": {Data: []byte("---\ntitle: Alpha\n---\n# A\n")},
+		"docs/b.md": {Data: []byte("---\ntitle: Beta\n---\n# B\n")},
+	}
+	cfs := newCountingFS(inner)
+
+	f, err := lint.NewFile("index.md", []byte(src))
+	require.NoError(t, err)
+	f.FS = cfs
+
+	r := &Rule{}
+	diags := r.Check(f)
+	require.Empty(t, diags, "fixture is well-formed; optimization must not change correctness")
+
+	for _, p := range []string{"docs/a.md", "docs/b.md"} {
+		assert.LessOrEqualf(t, cfs.count(p), 2,
+			"matched file %s should be read at most twice per Check "+
+				"(front matter once + cycle scan once) no matter how "+
+				"many directives glob it, got %d",
+			p, cfs.count(p))
+	}
+}

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -104,7 +104,7 @@ func (r *Rule) Generate(f *lint.File, filePath string, line int,
 	// Read errors (e.g. "file too large") are fatal for generation:
 	// a partially-rendered catalog would silently hide missing rows,
 	// which is worse than failing loudly with a clear diagnostic.
-	entries, entryDiags := buildCatalogEntries(f, params, filePath, line)
+	entries, entryDiags := cachedCatalogEntries(f, params, filePath, line)
 	if len(entryDiags) > 0 {
 		return "", entryDiags
 	}
@@ -550,13 +550,43 @@ func resolvePatterns(baseRel string, patterns []string) ([]string, bool) {
 	return resolved, true
 }
 
+// catalogEntries holds one buildCatalogEntries result so f.Memo can
+// cache the (entries, diags) pair behind a single key.
+type catalogEntries struct {
+	entries []fileEntry
+	diags   []lint.Diagnostic
+}
+
+// cachedCatalogEntries returns buildCatalogEntries' result, computed
+// once per directive per Check. A directive is identified by its file
+// and start line, which the generate, injection, and case-mismatch
+// passes all pass identically for the same marker pair, so without
+// this memo every matched file's glob + front-matter read ran three
+// times per directive. The result is read-only for every caller
+// (entries are already sorted by buildCatalogEntries). The memo lives
+// on the per-Check *lint.File, so nothing is cached across files or
+// runs.
+func cachedCatalogEntries(
+	f *lint.File, params map[string]string, filePath string, line int,
+) ([]fileEntry, []lint.Diagnostic) {
+	key := fmt.Sprintf("catalog.entries:%s#%d", filePath, line)
+	v := f.Memo(key, func() any {
+		e, d := buildCatalogEntries(f, params, filePath, line)
+		return catalogEntries{entries: e, diags: d}
+	})
+	r := v.(catalogEntries)
+	return r.entries, r.diags
+}
+
 // buildCatalogEntries resolves glob matches, reads front matter, and
 // returns sorted file entries for the catalog directive. Read errors
 // (notably "file too large") are returned as diagnostics attached to
 // the directive's file+line. Callers in the Generate path treat any
 // returned diagnostic as fatal to avoid producing an incomplete catalog;
 // check-only callers (checkInjection, checkCaseMismatches) discard the
-// diagnostics because Generate already surfaces them.
+// diagnostics because Generate already surfaces them. Callers reached
+// during Check go through cachedCatalogEntries so the three passes do
+// not each rebuild the same directive's entries.
 func buildCatalogEntries(
 	f *lint.File, params map[string]string, filePath string, line int,
 ) ([]fileEntry, []lint.Diagnostic) {
@@ -727,7 +757,7 @@ func (r *Rule) checkInjection(f *lint.File) []lint.Diagnostic {
 			continue
 		}
 		// Ignore entry diagnostics here; Generate surfaces them.
-		entries, _ := buildCatalogEntries(f, dir.Params, f.Path, mp.StartLine)
+		entries, _ := cachedCatalogEntries(f, dir.Params, f.Path, mp.StartLine)
 		diags = append(diags, checkCatalogInjection(f.Path, mp.StartLine, entries)...)
 	}
 	return diags
@@ -1040,7 +1070,7 @@ func (r *Rule) checkCaseMismatches(f *lint.File) []lint.Diagnostic {
 			continue
 		}
 		// Ignore entry diagnostics here; Generate surfaces them.
-		entries, _ := buildCatalogEntries(f, dir.Params, f.Path, mp.StartLine)
+		entries, _ := cachedCatalogEntries(f, dir.Params, f.Path, mp.StartLine)
 		diags = append(diags, checkFieldCaseMismatches(f.Path, mp.StartLine, row, entries)...)
 	}
 	return diags

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -621,7 +621,7 @@ func buildCatalogEntries(
 		var fm map[string]any
 		if needFM {
 			var err error
-			fm, err = readFrontMatter(res.fs, p, f.MaxInputBytes)
+			fm, err = cachedFrontMatter(f, res.fs, p, f.MaxInputBytes)
 			if err != nil {
 				diags = append(diags, makeDiag(filePath, line,
 					fmt.Sprintf("cannot read front matter from %q: %v", displayPath, err)))
@@ -876,12 +876,41 @@ func sortValue(entry fileEntry, key string) string {
 	}
 }
 
+// frontMatterResult holds one readFrontMatter result so f.Memo can
+// cache the (map, error) pair behind a single key.
+type frontMatterResult struct {
+	fm  map[string]any
+	err error
+}
+
+// cachedFrontMatter returns readFrontMatter's result, computed once
+// per matched path per Check. Several catalog directives in one file
+// can glob overlapping sets — CLAUDE.md carries three over docs/** —
+// and each directive's entry build otherwise re-read and re-parsed the
+// same matched file's YAML. The result is a pure function of the
+// matched file's bytes; the memo lives on the per-Check *lint.File, so
+// nothing is cached across files or runs. Keyed by path, matching the
+// include-cycle adjacency memo's resolution assumption (all catalog
+// globs in one host file resolve against that file's tree).
+func cachedFrontMatter(
+	f *lint.File, fsys fs.FS, path string, maxBytes int64,
+) (map[string]any, error) {
+	v := f.Memo("catalog.fm:"+path, func() any {
+		fm, err := readFrontMatter(fsys, path, maxBytes)
+		return frontMatterResult{fm: fm, err: err}
+	})
+	r := v.(frontMatterResult)
+	return r.fm, r.err
+}
+
 // readFrontMatter reads a file's YAML front matter and returns it as
 // a map preserving nested structure for CUE path resolution.
 // Returns (nil, nil) if no front matter is found or content is
 // malformed. Returns (nil, err) when the file itself cannot be read —
 // notably when it exceeds the configured max-input-size — so callers
 // can surface the failure instead of treating it as "no front matter".
+// Reached during Check via cachedFrontMatter so directives that glob
+// overlapping sets do not each re-read the same matched file.
 func readFrontMatter(fsys fs.FS, path string, maxBytes int64) (map[string]any, error) {
 	data, err := lint.ReadFSFileLimited(fsys, path, maxBytes)
 	if err != nil {
@@ -926,7 +955,7 @@ func checkCatalogIncludeCycle(
 	catalogFile := filepath.Base(filePath)
 	for _, entry := range entries {
 		matchedPath := fieldinterp.Stringify(entry.fields["filename"])
-		if fileIncludesTarget(f.FS, matchedPath, catalogFile, f.MaxInputBytes) {
+		if fileIncludesTarget(f, f.FS, matchedPath, catalogFile, f.MaxInputBytes) {
 			return []lint.Diagnostic{makeDiag(filePath, line,
 				fmt.Sprintf(
 					"catalog includes %q which includes %q via <?include?>, creating a cycle",
@@ -938,46 +967,70 @@ func checkCatalogIncludeCycle(
 
 // fileIncludesTarget checks whether the file at filePath contains
 // include directives that (directly or indirectly) reference the
-// target file. Uses a visited set to avoid infinite recursion.
+// target file. Uses a visited set to avoid infinite recursion. cf is
+// the file being checked; it carries the per-Check memo the include
+// adjacency is cached on.
 func fileIncludesTarget(
-	fsys fs.FS, filePath, target string, maxBytes int64,
+	cf *lint.File, fsys fs.FS, filePath, target string, maxBytes int64,
 ) bool {
 	visited := map[string]bool{filePath: true}
-	return scanIncludesForTarget(fsys, filePath, target, visited, 0, maxBytes)
+	return scanIncludesForTarget(cf, fsys, filePath, target, visited, 0, maxBytes)
 }
 
 // maxIncludeDepth mirrors the include rule's depth limit for consistency.
 const maxIncludeDepth = 10
 
+// includeTargetsOf returns the resolved paths every <?include?> in
+// filePath points at. Reading and fully parsing filePath is the
+// include-cycle scan's only expensive step, so the result is memoized
+// per Check on cf: a file carrying several catalog directives over an
+// overlapping glob (CLAUDE.md has three on docs/**) otherwise re-read
+// and re-parsed every matched file once per directive. The adjacency
+// is a pure function of the matched file's bytes — independent of the
+// cycle target and the DFS visited set — so it is safe to share across
+// every directive and recursion within one Check.
+func includeTargetsOf(
+	cf *lint.File, fsys fs.FS, filePath string, maxBytes int64,
+) []string {
+	v := cf.Memo("catalog.includes:"+filePath, func() any {
+		data, err := lint.ReadFSFileLimited(fsys, filePath, maxBytes)
+		if err != nil {
+			return []string(nil)
+		}
+		_, content := lint.StripFrontMatter(data)
+		pf, err := lint.NewFile(filePath, content)
+		if err != nil {
+			return []string(nil)
+		}
+		pairs, _ := gensection.FindMarkerPairs(
+			pf, "include", "MDS021", "include")
+		var targets []string
+		for _, mp := range pairs {
+			dir, diags := gensection.ParseDirective(
+				filePath, mp, "MDS021", "include")
+			if dir == nil || len(diags) > 0 {
+				continue
+			}
+			file := dir.Params["file"]
+			if file == "" {
+				continue
+			}
+			targets = append(targets,
+				path.Clean(path.Join(path.Dir(filePath), file)))
+		}
+		return targets
+	})
+	return v.([]string)
+}
+
 func scanIncludesForTarget(
-	fsys fs.FS, filePath, target string,
+	cf *lint.File, fsys fs.FS, filePath, target string,
 	visited map[string]bool, depth int, maxBytes int64,
 ) bool {
 	if depth > maxIncludeDepth {
 		return false
 	}
-	data, err := lint.ReadFSFileLimited(fsys, filePath, maxBytes)
-	if err != nil {
-		return false
-	}
-	_, content := lint.StripFrontMatter(data)
-	f, err := lint.NewFile(filePath, content)
-	if err != nil {
-		return false
-	}
-	pairs, _ := gensection.FindMarkerPairs(
-		f, "include", "MDS021", "include")
-	for _, mp := range pairs {
-		dir, diags := gensection.ParseDirective(
-			filePath, mp, "MDS021", "include")
-		if dir == nil || len(diags) > 0 {
-			continue
-		}
-		file := dir.Params["file"]
-		if file == "" {
-			continue
-		}
-		resolved := path.Clean(path.Join(path.Dir(filePath), file))
+	for _, resolved := range includeTargetsOf(cf, fsys, filePath, maxBytes) {
 		if resolved == target {
 			return true
 		}
@@ -985,7 +1038,7 @@ func scanIncludesForTarget(
 			continue
 		}
 		visited[resolved] = true
-		found := scanIncludesForTarget(fsys, resolved, target, visited, depth+1, maxBytes)
+		found := scanIncludesForTarget(cf, fsys, resolved, target, visited, depth+1, maxBytes)
 		delete(visited, resolved)
 		if found {
 			return true

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3983,7 +3983,7 @@ func TestScanIncludesForTarget_MaxDepthExceeded(t *testing.T) {
 		"a.md": &fstest.MapFile{Data: []byte("# A\n")},
 	}
 	visited := map[string]bool{}
-	result := scanIncludesForTarget(fsys, "a.md", "target.md", visited, maxIncludeDepth+1, 1000)
+	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, maxIncludeDepth+1, 1000)
 	assert.False(t, result)
 }
 
@@ -3991,7 +3991,7 @@ func TestScanIncludesForTarget_FileReadError(t *testing.T) {
 	// File does not exist in FS → read error → returns false.
 	fsys := fstest.MapFS{}
 	visited := map[string]bool{}
-	result := scanIncludesForTarget(fsys, "nonexistent.md", "target.md", visited, 0, 1000)
+	result := scanIncludesForTarget(&lint.File{}, fsys, "nonexistent.md", "target.md", visited, 0, 1000)
 	assert.False(t, result)
 }
 
@@ -4001,7 +4001,7 @@ func TestScanIncludesForTarget_NoIncludes(t *testing.T) {
 		"a.md": &fstest.MapFile{Data: []byte("# A\n\nNo includes here.\n")},
 	}
 	visited := map[string]bool{}
-	result := scanIncludesForTarget(fsys, "a.md", "target.md", visited, 0, 1000)
+	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.False(t, result)
 }
 
@@ -4013,7 +4013,7 @@ func TestScanIncludesForTarget_DirectMatch(t *testing.T) {
 		},
 	}
 	visited := map[string]bool{"a.md": true}
-	result := scanIncludesForTarget(fsys, "a.md", "target.md", visited, 0, 1000)
+	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.True(t, result)
 }
 
@@ -4026,7 +4026,7 @@ func TestScanIncludesForTarget_VisitedCycleSkipped(t *testing.T) {
 	}
 	// Mark b.md as already visited to prevent recursion.
 	visited := map[string]bool{"a.md": true, "b.md": true}
-	result := scanIncludesForTarget(fsys, "a.md", "target.md", visited, 0, 1000)
+	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.False(t, result)
 }
 
@@ -4076,7 +4076,7 @@ func TestScanIncludesForTarget_IndirectMatch(t *testing.T) {
 		},
 	}
 	visited := map[string]bool{"a.md": true}
-	result := scanIncludesForTarget(fsys, "a.md", "target.md", visited, 0, 1000)
+	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.True(t, result)
 }
 

--- a/internal/rules/fencedcodestyle/rule.go
+++ b/internal/rules/fencedcodestyle/rule.go
@@ -28,47 +28,46 @@ func (r *Rule) Name() string { return "fenced-code-style" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "code" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-block logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		fcb, ok := n.(*ast.FencedCodeBlock)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	fcb, ok := n.(*ast.FencedCodeBlock)
+	if !ok {
+		return nil
+	}
 
-		openStart, _ := fencepos.OpenLineRange(f.Source, fcb)
-		if openStart >= len(f.Source) {
-			return ast.WalkContinue, nil
-		}
+	openStart, _ := fencepos.OpenLineRange(f.Source, fcb)
+	if openStart >= len(f.Source) {
+		return nil
+	}
 
-		fenceChar := fencepos.CharAt(f.Source, openStart)
-		if fenceChar == 0 {
-			return ast.WalkContinue, nil
-		}
+	fenceChar := fencepos.CharAt(f.Source, openStart)
+	if fenceChar == 0 {
+		return nil
+	}
 
-		wantChar := r.wantChar()
-		if fenceChar != wantChar {
-			line := f.LineOfOffset(openStart)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  "fenced code block should use " + r.Style + " style",
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	if fenceChar != r.wantChar() {
+		return []lint.Diagnostic{{
+			File:     f.Path,
+			Line:     f.LineOfOffset(openStart),
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "fenced code block should use " + r.Style + " style",
+		}}
+	}
+	return nil
 }
 
 // Fix implements rule.FixableRule.
@@ -181,3 +180,4 @@ func (r *Rule) DefaultSettings() map[string]any {
 }
 
 var _ rule.Configurable = (*Rule)(nil)
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/headingstyle/rule.go
+++ b/internal/rules/headingstyle/rule.go
@@ -29,56 +29,54 @@ func (r *Rule) Name() string { return "heading-style" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "heading" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-heading logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	heading, ok := n.(*ast.Heading)
+	if !ok {
+		return nil
+	}
+
 	style := r.Style
 	if style == "" {
 		style = "atx"
 	}
+	isATX := isATXHeading(heading, f.Source)
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		heading, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		isATX := isATXHeading(heading, f.Source)
-
-		if style == "atx" && !isATX {
-			line := headingLine(heading, f)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  "heading style should be atx",
-			})
-		} else if style == "setext" && isATX {
-			// setext only supports levels 1 and 2; levels 3-6 must use atx
-			if heading.Level <= 2 {
-				line := headingLine(heading, f)
-				diags = append(diags, lint.Diagnostic{
-					File:     f.Path,
-					Line:     line,
-					Column:   1,
-					RuleID:   r.ID(),
-					RuleName: r.Name(),
-					Severity: lint.Warning,
-					Message:  "heading style should be setext",
-				})
-			}
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	if style == "atx" && !isATX {
+		return []lint.Diagnostic{{
+			File:     f.Path,
+			Line:     headingLine(heading, f),
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "heading style should be atx",
+		}}
+	}
+	// setext only supports levels 1 and 2; levels 3-6 must use atx.
+	if style == "setext" && isATX && heading.Level <= 2 {
+		return []lint.Diagnostic{{
+			File:     f.Path,
+			Line:     headingLine(heading, f),
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "heading style should be setext",
+		}}
+	}
+	return nil
 }
 
 type replacement struct {
@@ -325,3 +323,4 @@ func (r *Rule) DefaultSettings() map[string]any {
 
 var _ rule.FixableRule = (*Rule)(nil)
 var _ rule.Configurable = (*Rule)(nil)
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/noemphasisasheading/rule.go
+++ b/internal/rules/noemphasisasheading/rule.go
@@ -32,56 +32,49 @@ func (r *Rule) Name() string { return "no-emphasis-as-heading" }
 func (r *Rule) Category() string { return "heading" }
 
 // Check implements rule.Rule.
+// Check implements rule.Rule. The per-paragraph logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		para, ok := n.(*ast.Paragraph)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	para, ok := n.(*ast.Paragraph)
+	if !ok {
+		return nil
+	}
 
-		// Check if the paragraph has exactly one child that is emphasis or strong
-		firstChild := para.FirstChild()
-		if firstChild == nil {
-			return ast.WalkContinue, nil
-		}
+	// The paragraph must have exactly one child, and it must be
+	// emphasis (a lone *emphasised line* masquerading as a heading).
+	firstChild := para.FirstChild()
+	if firstChild == nil || firstChild.NextSibling() != nil {
+		return nil
+	}
+	if _, isEmphasis := firstChild.(*ast.Emphasis); !isEmphasis {
+		return nil
+	}
 
-		// Must be the only child
-		if firstChild.NextSibling() != nil {
-			return ast.WalkContinue, nil
-		}
+	// If the emphasis text contains a configured placeholder token,
+	// treat it as opaque and suppress the diagnostic.
+	if emphasisContainsPlaceholder(firstChild, f.Source, r.Placeholders) {
+		return nil
+	}
 
-		// Check if it's emphasis or strong emphasis
-		_, isEmphasis := firstChild.(*ast.Emphasis)
-		if !isEmphasis {
-			return ast.WalkContinue, nil
-		}
-
-		// If the emphasis text contains a configured placeholder token,
-		// treat it as opaque and suppress the diagnostic.
-		if emphasisContainsPlaceholder(firstChild, f.Source, r.Placeholders) {
-			return ast.WalkContinue, nil
-		}
-
-		line := astutil.ParagraphLine(para, f)
-		diags = append(diags, lint.Diagnostic{
-			File:     f.Path,
-			Line:     line,
-			Column:   1,
-			RuleID:   r.ID(),
-			RuleName: r.Name(),
-			Severity: lint.Warning,
-			Message:  "emphasis used instead of a heading",
-		})
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     astutil.ParagraphLine(para, f),
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  "emphasis used instead of a heading",
+	}}
 }
 
 func emphasisContainsPlaceholder(n ast.Node, src []byte, toks []string) bool {
@@ -144,4 +137,5 @@ func (r *Rule) SettingMergeMode(key string) rule.MergeMode {
 var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.ListMerger   = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/paragraphreadability/rule.go
+++ b/internal/rules/paragraphreadability/rule.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
-	"github.com/yuin/goldmark/ast"
 )
 
 func init() {
@@ -50,46 +49,33 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		index = ARI
 	}
 
-	_ = ast.Walk(
-		f.AST,
-		func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-			if !entering {
-				return ast.WalkContinue, nil
-			}
-			para, ok := n.(*ast.Paragraph)
-			if !ok {
-				return ast.WalkContinue, nil
-			}
-			if astutil.IsTable(para, f) {
-				return ast.WalkContinue, nil
-			}
+	// Iterate the per-File memoized non-table paragraph collection so
+	// the AST walk and per-paragraph ExtractPlainText are shared with
+	// MDS024 instead of re-run here — the two are the hot default
+	// rules on prose-heavy input.
+	for _, p := range astutil.CollectSectionParagraphs(f) {
+		text := p.Text
+		if len(r.Placeholders) > 0 {
+			text = placeholders.MaskBodyTokens(text, r.Placeholders)
+		}
+		words := mdtext.CountWords(text)
+		if words < minWords {
+			continue
+		}
 
-			text := mdtext.ExtractPlainText(para, f.Source)
-			if len(r.Placeholders) > 0 {
-				text = placeholders.MaskBodyTokens(text, r.Placeholders)
-			}
-			words := mdtext.CountWords(text)
-			if words < minWords {
-				return ast.WalkContinue, nil
-			}
-
-			score := index(text)
-			if score > maxIndex {
-				line := astutil.ParagraphLine(para, f)
-				diags = append(diags, lint.Diagnostic{
-					File:     f.Path,
-					Line:     line,
-					Column:   1,
-					RuleID:   r.ID(),
-					RuleName: r.Name(),
-					Severity: lint.Warning,
-					Message:  readabilityMessage(score, maxIndex, words, text),
-				})
-			}
-
-			return ast.WalkContinue, nil
-		},
-	)
+		score := index(text)
+		if score > maxIndex {
+			diags = append(diags, lint.Diagnostic{
+				File:     f.Path,
+				Line:     p.Line,
+				Column:   1,
+				RuleID:   r.ID(),
+				RuleName: r.Name(),
+				Severity: lint.Warning,
+				Message:  readabilityMessage(score, maxIndex, words, text),
+			})
+		}
+	}
 
 	return diags
 }

--- a/internal/rules/paragraphstructure/rule.go
+++ b/internal/rules/paragraphstructure/rule.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
-	"github.com/yuin/goldmark/ast"
 )
 
 func init() {
@@ -36,24 +35,22 @@ func (r *Rule) Category() string { return "prose" }
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		para, ok := n.(*ast.Paragraph)
-		if !ok || astutil.IsTable(para, f) {
-			return ast.WalkContinue, nil
-		}
-		diags = append(diags, r.checkParagraph(para, f)...)
-		return ast.WalkContinue, nil
-	})
+	// Iterate the per-File memoized non-table paragraph collection so
+	// the AST walk and per-paragraph ExtractPlainText are shared with
+	// the other prose rules instead of re-run here (the two hot
+	// default rules on prose-heavy input).
+	for _, p := range astutil.CollectSectionParagraphs(f) {
+		diags = append(diags, r.checkParagraph(p.Text, p.Line, f.Path)...)
+	}
 	return diags
 }
 
 // checkParagraph evaluates one paragraph against the sentence-count
-// and per-sentence word limits.
-func (r *Rule) checkParagraph(para *ast.Paragraph, f *lint.File) []lint.Diagnostic {
-	text := mdtext.ExtractPlainText(para, f.Source)
+// and per-sentence word limits. text is the raw extracted plain
+// text; line is its 1-based source line; both come from the shared
+// collector. Placeholder masking stays per-rule so the shared text
+// is not coupled to one rule's config.
+func (r *Rule) checkParagraph(text string, line int, filePath string) []lint.Diagnostic {
 	if len(r.Placeholders) > 0 {
 		text = placeholders.MaskBodyTokens(text, r.Placeholders)
 	}
@@ -70,12 +67,11 @@ func (r *Rule) checkParagraph(para *ast.Paragraph, f *lint.File) []lint.Diagnost
 	}
 
 	sentences := mdtext.SplitSentences(text)
-	line := astutil.ParagraphLine(para, f)
 	var diags []lint.Diagnostic
 
 	if len(sentences) > r.MaxSentences {
 		diags = append(diags, lint.Diagnostic{
-			File:     f.Path,
+			File:     filePath,
 			Line:     line,
 			Column:   1,
 			RuleID:   r.ID(),
@@ -92,7 +88,7 @@ func (r *Rule) checkParagraph(para *ast.Paragraph, f *lint.File) []lint.Diagnost
 		wc := mdtext.CountWords(sent)
 		if wc > r.MaxWords {
 			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
+				File:     filePath,
 				Line:     line,
 				Column:   1,
 				RuleID:   r.ID(),

--- a/internal/rules/paragraphstructure/rule_test.go
+++ b/internal/rules/paragraphstructure/rule_test.go
@@ -6,47 +6,42 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/goldmark/ast"
 )
 
-func firstParagraph(t *testing.T, body string) (*ast.Paragraph, *lint.File) {
+// firstParagraph parses body and returns the first non-table
+// paragraph's extracted text, 1-based line, and path — exactly what
+// the shared collector now feeds checkParagraph in production.
+func firstParagraph(t *testing.T, body string) (text string, line int, path string) {
 	t.Helper()
 	f, err := lint.NewFile("t.md", []byte(body+"\n"))
 	require.NoError(t, err)
-	var p *ast.Paragraph
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if entering && p == nil {
-			if pp, ok := n.(*ast.Paragraph); ok {
-				p = pp
-			}
-		}
-		return ast.WalkContinue, nil
-	})
-	require.NotNil(t, p, "no paragraph parsed from %q", body)
-	return p, f
+	paras := astutil.CollectSectionParagraphs(f)
+	require.NotEmpty(t, paras, "no paragraph parsed from %q", body)
+	return paras[0].Text, paras[0].Line, f.Path
 }
 
 func TestRule_checkParagraph(t *testing.T) {
 	r := &Rule{MaxSentences: 6, MaxWords: 40}
 
 	t.Run("guard short-circuits clean paragraph", func(t *testing.T) {
-		p, f := firstParagraph(t, "Short and safe.")
-		assert.Nil(t, r.checkParagraph(p, f))
+		text, line, path := firstParagraph(t, "Short and safe.")
+		assert.Nil(t, r.checkParagraph(text, line, path))
 	})
 
 	t.Run("too many sentences", func(t *testing.T) {
-		p, f := firstParagraph(t,
+		text, line, path := firstParagraph(t,
 			"One. Two. Three. Four. Five. Six. Seven. Eight.")
-		d := r.checkParagraph(p, f)
+		d := r.checkParagraph(text, line, path)
 		require.Len(t, d, 1)
 		assert.Contains(t, d[0].Message, "too many sentences")
 	})
 
 	t.Run("sentence too long", func(t *testing.T) {
-		p, f := firstParagraph(t, strings.Repeat("word ", 45)+".")
-		d := r.checkParagraph(p, f)
+		text, line, path := firstParagraph(t, strings.Repeat("word ", 45)+".")
+		d := r.checkParagraph(text, line, path)
 		require.Len(t, d, 1)
 		assert.Contains(t, d[0].Message, "sentence too long")
 	})

--- a/plan/186_catalog-run-scoped-readcache.md
+++ b/plan/186_catalog-run-scoped-readcache.md
@@ -1,0 +1,84 @@
+---
+id: 186
+title: Run-scoped read cache for catalog cross-host redundancy
+status: "🔲"
+model: opus
+depends-on: []
+summary: >-
+  The per-Check catalog memo collapsed the three-times-per-directive
+  rebuild, but different host files whose catalogs glob the same docs
+  tree still re-read and re-parse those targets once per host-file
+  Check. Add a run-scoped read/parse cache (front matter + include
+  adjacency) keyed by path, invalidated per LSP document change, so
+  the repo corpus stops paying O(host-files x shared-targets).
+---
+# Run-scoped read cache for catalog cross-host redundancy
+
+## Goal
+
+The catalog rule re-reads and re-parses each matched target once
+per host file whose catalog globs it. Cut that to once per run. On
+the repo corpus, `CLAUDE.md`, `PLAN.md`, and ~30 `docs/**/index.md`
+files carry catalogs over the same `docs/**` tree. Each target's
+front matter and include list is recomputed once per host-file
+Check.
+
+## Background
+
+A per-Check memo already shipped on this branch. It added
+`File.Memo`, `cachedCatalogEntries`, `includeTargetsOf`, and
+`cachedFrontMatter`. It removed the three-builds-per-directive
+redundancy inside one Check. The catalog rule fell from ~280 ms to
+~140 ms cumulative on the 569-file repo corpus.
+
+That memo lives on the per-Check `*lint.File`. It is discarded with
+the file. So it does not dedupe across host files. File A's catalog
+over `docs/**` and file B's catalog over `docs/**` still each read
+`docs/X.md`.
+
+Closing that needs a cache that lives for the whole `mdsmith check`
+run. The hazard is the LSP. A long-lived server must not serve a
+stale target after the user edits it.
+
+The cross-file-reference rule hits the same tension. It uses a
+per-Check local cache. A run cache instead needs an explicit
+invalidation seam. The LSP calls that seam on `didChange` or
+`didSave`.
+
+A one-shot `mdsmith check` sees an immutable corpus, so the cache
+is trivially safe there. Only the LSP path needs the hook.
+
+## Tasks
+
+1. [ ] Create this plan.
+2. [ ] Add a run-scoped cache type (path -> parsed front matter,
+   path -> resolved include adjacency) owned by the engine
+   `Runner` and threaded to rules via a context value or a field
+   on `*lint.File` that points at the shared cache (not a package
+   global — testability and LSP isolation).
+3. [ ] Route `cachedFrontMatter` and `includeTargetsOf` through
+   the run cache when present, falling back to the per-Check memo
+   when absent (struct-literal `*lint.File` in unit tests).
+4. [ ] Add an `Invalidate(path)` seam; call it from the LSP
+   document-sync path so an edited file's cached read is dropped.
+   Unit-test that a second Check after Invalidate re-reads.
+5. [ ] Benchmark the repo corpus before/after with the existing
+   interleaved-median harness; record the delta here. Confirm the
+   neutral corpus (no directives) is unchanged and
+   `BenchmarkCheckCorpus{Small,Large}` stays within budget.
+6. [ ] Confirm `mdsmith check .` and the full suite stay green;
+   verify race-cleanliness under `-race` (the cache is read by the
+   parallel worker pool and the LSP's concurrent readers).
+
+## Acceptance Criteria
+
+- [ ] A target file globbed by N host-file catalogs is read and
+      parsed once per `mdsmith check` run, not N times (pinned by
+      a counting-FS test over a multi-host fixture).
+- [ ] The LSP re-reads a target after it is edited (pinned by an
+      Invalidate test); no stale catalog body is served.
+- [ ] Repo-corpus wall time improves and the repo-vs-neutral gap
+      narrows further; neutral is unchanged; the check gate stays
+      within budget.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/186_catalog-run-scoped-readcache.md
+++ b/plan/186_catalog-run-scoped-readcache.md
@@ -50,7 +50,7 @@ is trivially safe there. Only the LSP path needs the hook.
 
 ## Tasks
 
-1. [ ] Create this plan.
+1. [x] Create this plan.
 2. [ ] Add a run-scoped cache type (path -> parsed front matter,
    path -> resolved include adjacency) owned by the engine
    `Runner` and threaded to rules via a context value or a field

--- a/plan/187_neutral-corpus-engine-lever.md
+++ b/plan/187_neutral-corpus-engine-lever.md
@@ -60,18 +60,19 @@ are structural. Each is scoped work, not a one-line guard:
 
 ## Tasks
 
-1. [ ] Create this plan.
-2. [ ] Memoize `astutil.CollectSectionParagraphs` on the per-Check
+1. [x] Create this plan.
+2. [x] Memoize `astutil.CollectSectionParagraphs` on the per-Check
    `*lint.File` (the `File.Memo` primitive) and migrate the two hot
    default prose rules (MDS024 paragraph-structure,
    paragraph-readability) to consume it instead of each running
    their own `ast.Walk` + per-paragraph `ExtractPlainText`.
-   Behaviour-preserving (integration fixtures unchanged); the
-   foundation the multiplexed walk generalises. Honest measured
-   note: wall time on the neutral corpus is flat here because the
+   Behaviour-preserving: the full integration fixture suite,
+   `go test ./...`, and `mdsmith check .` are unchanged. This is
+   the foundation the multiplexed walk generalises. Honest
+   measured note: neutral-corpus wall time is flat here because the
    residual cost is intrinsic Punkt, not this duplicate walk — the
    value is the removed redundant CPU work and the shared seam, not
-   a neutral speedup.
+   a neutral speedup. The next two tasks hold the real levers.
 3. [ ] Prototype the multiplexed walk: a single `ast.Walk` driver
    that fans out to registered per-rule visitors, migrate a scoped
    batch of the default node-walking rules, and measure the
@@ -87,7 +88,7 @@ are structural. Each is scoped work, not a one-line guard:
 
 ## Acceptance Criteria
 
-- [ ] `astutil.CollectSectionParagraphs` runs once per File;
+- [x] `astutil.CollectSectionParagraphs` runs once per File;
       MDS024 and paragraph-readability share it (pinned by a
       reference-identity test); integration fixtures unchanged.
 - [ ] The multiplexed walk reduces `goldmark walkHelper`

--- a/plan/187_neutral-corpus-engine-lever.md
+++ b/plan/187_neutral-corpus-engine-lever.md
@@ -78,11 +78,20 @@ are structural. Each is scoped work, not a one-line guard:
    batch of the default node-walking rules, and measure the
    `walkHelper` cumulative drop on both corpora. Gate behind the
    existing `BenchmarkCheckCorpus{Small,Large}` budgets.
-4. [ ] Evaluate faster sentence segmentation for MDS024: build an
-   exhaustive equivalence harness (Punkt vs candidate over the
-   neutral corpus and the rule fixtures) and adopt a candidate only
-   if diagnostics are byte-for-byte identical; otherwise record the
-   negative result here and keep Punkt.
+4. [x] Evaluate faster sentence segmentation for MDS024. Built a
+   reusable equivalence harness and benchmark in
+   [the mdtext segmenter test](../internal/mdtext/sentence_equivalence_test.go).
+   Recorded negative, evidence-backed: the inferred bottleneck (a
+   per-call `regexp.MustCompile` in neurosnap `IsNonPunct`) does not
+   exist. `IsNonPunct` has no call site in the library, and no
+   `MustCompile` frame appears in the neutral profile. The real cost
+   is intrinsic trained-Punkt regexp execution in
+   `MultiPunctWordAnnotation.tokenAnnotation` (~140 ms cum), not a
+   fixable recompile. A naive `[.!?]` splitter is provably not
+   equivalent (it over-segments abbreviations, decimals, ellipses,
+   initials), and no pure-Go Punkt-compatible faster segmenter
+   exists. Keep Punkt; the harness stays as the cheap gate for any
+   future candidate.
 5. [ ] Re-promote cross-tool benchmark JSON on the optimized binary
    and update the gate baselines if they move.
 
@@ -95,9 +104,10 @@ are structural. Each is scoped work, not a one-line guard:
       cumulative on both corpora with no diagnostic changes across
       the full fixture suite, or is recorded here as not worth the
       cross-rule churn with the measured evidence.
-- [ ] Any sentence-segmenter change is byte-for-byte
+- [x] Any sentence-segmenter change is byte-for-byte
       diagnostic-equivalent to Punkt over the neutral corpus and
-      the rule fixtures, or the negative result is recorded.
+      the rule fixtures, or the negative result is recorded. Negative
+      recorded with a reusable equivalence harness; Punkt kept.
 - [ ] `BenchmarkCheckCorpus{Small,Large}` stay within budget;
       neutral-corpus wall time improves once a structural lever
       lands.

--- a/plan/187_neutral-corpus-engine-lever.md
+++ b/plan/187_neutral-corpus-engine-lever.md
@@ -1,7 +1,7 @@
 ---
 id: 187
 title: Neutral-corpus engine lever — shared AST walk and Punkt cost
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: []
 summary: >-
@@ -73,44 +73,69 @@ are structural. Each is scoped work, not a one-line guard:
    residual cost is intrinsic Punkt, not this duplicate walk — the
    value is the removed redundant CPU work and the shared seam, not
    a neutral speedup. The next two tasks hold the real levers.
-3. [ ] Prototype the multiplexed walk: a single `ast.Walk` driver
-   that fans out to registered per-rule visitors, migrate a scoped
-   batch of the default node-walking rules, and measure the
-   `walkHelper` cumulative drop on both corpora. Gate behind the
-   existing `BenchmarkCheckCorpus{Small,Large}` budgets.
-4. [x] Evaluate faster sentence segmentation for MDS024. Built a
-   reusable equivalence harness and benchmark in
+3. [x] Prototyped the multiplexed walk.
+
+   Added the opt-in `rule.NodeChecker` and `rule.WalkNodes`. The
+   engine runs one shared walk for all of them. Each rule's
+   diagnostics stay grouped in rules order. A test proves the
+   output is byte-identical to sequential `Check`.
+
+   Migrated a verified batch of three pure per-node default rules
+   (MDS002, MDS010, MDS009). Fixtures, the suite, and the gate are
+   unchanged.
+
+   The measured result is no gain. Neutral held at 280 ms. Repo
+   held at 410 ms. Both deltas are noise.
+
+   The profile explains why. The shared-walk cumulative cost fell a
+   lot. Its flat cost did not move (~6%). So that 44% was per-node
+   rule work counted under the walk. It was never redundant
+   traversal.
+
+   Only the small flat cost is removable. Removing it would touch
+   nearly every walking rule. That is a big churn for a tiny gain.
+
+   So keep the primitive and the batch. Skip the full migration.
+   This confirms the plan 175 task 11 deferral with numbers.
+4. [x] Evaluated faster sentence segmentation for MDS024.
+
+   Built a reusable equivalence harness and a cost benchmark in
    [the mdtext segmenter test](../internal/mdtext/sentence_equivalence_test.go).
-   Recorded negative, evidence-backed: the inferred bottleneck (a
-   per-call `regexp.MustCompile` in neurosnap `IsNonPunct`) does not
-   exist. `IsNonPunct` has no call site in the library, and no
-   `MustCompile` frame appears in the neutral profile. The real cost
-   is intrinsic trained-Punkt regexp execution in
-   `MultiPunctWordAnnotation.tokenAnnotation` (~140 ms cum), not a
-   fixable recompile. A naive `[.!?]` splitter is provably not
-   equivalent (it over-segments abbreviations, decimals, ellipses,
-   initials), and no pure-Go Punkt-compatible faster segmenter
-   exists. Keep Punkt; the harness stays as the cheap gate for any
-   future candidate.
-5. [ ] Re-promote cross-tool benchmark JSON on the optimized binary
-   and update the gate baselines if they move.
+
+   Recorded an evidence-backed negative. The guessed bottleneck was
+   a per-call regexp recompile in the tokenizer. It does not exist.
+   That function has no caller, and no compile frame shows in the
+   profile.
+
+   The real cost is the trained-model regexp run over tokens. That
+   is its algorithm, not a fixable recompile. A naive splitter is
+   not equivalent: it breaks abbreviations and decimals. No pure-Go
+   Punkt-compatible faster segmenter exists.
+
+   Keep Punkt. The harness stays as the cheap gate for any future
+   candidate.
+5. [x] Re-promote cross-tool benchmark JSON only if numbers move.
+   They did not: the multiplex is flat and the segmenter is
+   unchanged. Nothing to promote; gate baselines unchanged.
 
 ## Acceptance Criteria
 
 - [x] `astutil.CollectSectionParagraphs` runs once per File;
       MDS024 and paragraph-readability share it (pinned by a
       reference-identity test); integration fixtures unchanged.
-- [ ] The multiplexed walk reduces `goldmark walkHelper`
+- [x] The multiplexed walk reduces `goldmark walkHelper`
       cumulative on both corpora with no diagnostic changes across
       the full fixture suite, or is recorded here as not worth the
-      cross-rule churn with the measured evidence.
+      cross-rule churn with the measured evidence. Recorded: cum
+      fell but flat (~6%) did not; full migration not worth it.
 - [x] Any sentence-segmenter change is byte-for-byte
       diagnostic-equivalent to Punkt over the neutral corpus and
       the rule fixtures, or the negative result is recorded. Negative
       recorded with a reusable equivalence harness; Punkt kept.
-- [ ] `BenchmarkCheckCorpus{Small,Large}` stay within budget;
-      neutral-corpus wall time improves once a structural lever
-      lands.
-- [ ] `mdsmith check .` passes (generated sections in sync).
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] `BenchmarkCheckCorpus{Small,Large}` stay within budget
+      (Small p95 27 ms / 2 s, Large p95 189 ms / 12 s). No
+      structural lever paid off, so neutral wall time is unchanged;
+      that negative is the recorded outcome of tasks 3 and 4.
+- [x] `mdsmith check .` passes (generated sections in sync).
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues

--- a/plan/187_neutral-corpus-engine-lever.md
+++ b/plan/187_neutral-corpus-engine-lever.md
@@ -1,0 +1,105 @@
+---
+id: 187
+title: Neutral-corpus engine lever — shared AST walk and Punkt cost
+status: "🔳"
+model: opus
+depends-on: []
+summary: >-
+  Profiling the neutral Rust Book corpus shows its cost is intrinsic,
+  not redundant: per-rule AST re-walks (goldmark walkHelper ~44% cum)
+  and the trained Punkt sentence tokenizer behind MDS024 (~20% cum,
+  the sound cheap guard already maxed). No cheap behaviour-preserving
+  guard remains. Land the safe shared-paragraph-walk increment, then
+  scope the two real levers: a multiplexed AST walk and a
+  vetted-equivalent faster sentence segmenter.
+---
+# Neutral-corpus engine lever — shared AST walk and Punkt cost
+
+## Goal
+
+Cut `mdsmith check` wall time on prose-heavy third-party input.
+The target is the 234-file neutral Rust Book and Reference
+benchmark corpus. Once the catalog redundancy is removed, mdsmith
+trails the per-file Rust linters there by more than on its own
+directive-dense repo corpus.
+
+## Background
+
+A deep CPU profile of the full default rule set over the neutral
+corpus ran via the env hook on this branch. It attributes the cost
+to intrinsic, non-redundant work. This confirms the deferred
+verdict in [plan 175](175_check-performance-gate.md) task 11, now
+for the neutral corpus:
+
+- `goldmark/ast.walkHelper` ~370 ms / ~44% cumulative: every
+  default rule runs its own `ast.Walk` over the whole document.
+- `paragraph-structure` (MDS024) ~210 ms / ~25% cumulative, almost
+  all in `mdtext.SplitSentences` and its trained `neurosnap` Punkt
+  tokenizer (~170 ms / ~20%, heavy `regexp` backtracking). The
+  allocation-free `cheapBounds` guard already skips Punkt when a
+  paragraph provably cannot violate a limit. Rust Book paragraphs
+  exceed 40 words and run many sentences, so they cannot be skipped.
+- `paragraph-readability` ~90 ms and per-file full-source regexp
+  scans (`nounusedlinkdefinitions` ~70 ms) round out the profile.
+  None is redundant on the check path.
+
+The word check needs exact Punkt boundaries for its message. Punkt
+only ever merges naive `[.!?]`-segments; it never splits more. So
+no cheap split gives a sound upper bound on the longest sentence.
+The whole-paragraph word count the guard already uses is the only
+sound bound.
+
+No cheap behaviour-preserving guard remains. The two real levers
+are structural. Each is scoped work, not a one-line guard:
+
+1. A multiplexed AST walk: one traversal that dispatches every
+   rule's node visitor, instead of N full walks per file.
+2. A faster sentence segmenter for MDS024, adopted only behind an
+   exhaustive equivalence test against the current Punkt output so
+   diagnostics (counts, previews) stay byte-for-byte identical.
+
+## Tasks
+
+1. [ ] Create this plan.
+2. [ ] Memoize `astutil.CollectSectionParagraphs` on the per-Check
+   `*lint.File` (the `File.Memo` primitive) and migrate the two hot
+   default prose rules (MDS024 paragraph-structure,
+   paragraph-readability) to consume it instead of each running
+   their own `ast.Walk` + per-paragraph `ExtractPlainText`.
+   Behaviour-preserving (integration fixtures unchanged); the
+   foundation the multiplexed walk generalises. Honest measured
+   note: wall time on the neutral corpus is flat here because the
+   residual cost is intrinsic Punkt, not this duplicate walk — the
+   value is the removed redundant CPU work and the shared seam, not
+   a neutral speedup.
+3. [ ] Prototype the multiplexed walk: a single `ast.Walk` driver
+   that fans out to registered per-rule visitors, migrate a scoped
+   batch of the default node-walking rules, and measure the
+   `walkHelper` cumulative drop on both corpora. Gate behind the
+   existing `BenchmarkCheckCorpus{Small,Large}` budgets.
+4. [ ] Evaluate faster sentence segmentation for MDS024: build an
+   exhaustive equivalence harness (Punkt vs candidate over the
+   neutral corpus and the rule fixtures) and adopt a candidate only
+   if diagnostics are byte-for-byte identical; otherwise record the
+   negative result here and keep Punkt.
+5. [ ] Re-promote cross-tool benchmark JSON on the optimized binary
+   and update the gate baselines if they move.
+
+## Acceptance Criteria
+
+- [ ] `astutil.CollectSectionParagraphs` runs once per File;
+      MDS024 and paragraph-readability share it (pinned by a
+      reference-identity test); integration fixtures unchanged.
+- [ ] The multiplexed walk reduces `goldmark walkHelper`
+      cumulative on both corpora with no diagnostic changes across
+      the full fixture suite, or is recorded here as not worth the
+      cross-rule churn with the measured evidence.
+- [ ] Any sentence-segmenter change is byte-for-byte
+      diagnostic-equivalent to Punkt over the neutral corpus and
+      the rule fixtures, or the negative result is recorded.
+- [ ] `BenchmarkCheckCorpus{Small,Large}` stay within budget;
+      neutral-corpus wall time improves once a structural lever
+      lands.
+- [ ] `mdsmith check .` passes (generated sections in sync).
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/188_regex-vs-ast-inventory.md
+++ b/plan/188_regex-vs-ast-inventory.md
@@ -1,0 +1,119 @@
+---
+id: 188
+title: Regex-over-source rules — inventory and AST-resident replacements
+status: "🔲"
+model: opus
+depends-on: []
+summary: >-
+  Plan 187 named "per-file regexp scans (nounusedlinkdefinitions ~70 ms)
+  and per-file full-source regexp scans" as intrinsic without enumerating
+  them. This plan inventories every rule that compiles or runs a regex
+  over `f.Source`, identifies which have an AST-resident equivalent
+  already produced during goldmark's canonical parse, and schedules the
+  conversions. The lever is compounding: many small wins (5–10% each on
+  prose-heavy or link-heavy input) the existing land-and-skip framing
+  rejected one-by-one.
+---
+# Regex-over-source rules — inventory and AST-resident replacements
+
+## Goal
+
+Replace every per-file regex pass over `f.Source` with an
+AST-resident lookup. The condition: the same information must
+already be produced by goldmark's canonical parse. The shipped
+`File.Memo` and `f.LinkReferences()` cache prove the pattern.
+MDS053 and MDS054 already use it. Extend the pattern across the
+regex-heavy tail plan 187's CPU profile names.
+
+## Background
+
+Plan 187's neutral CPU profile attributes ~70 ms of the 280 ms
+neutral-corpus check time to `nounusedlinkdefinitions`'s
+full-source regex scan. It also notes "per-file full-source
+regexp scans" more generally without enumerating them. The plan
+calls the cost "intrinsic" and stops there. The premise is wrong
+on two counts:
+
+1. **AST already carries most of what these regexes look for**.
+   goldmark's parser produces typed nodes for headings, code
+   fences, link references, list markers, blockquotes, and tables.
+   A regex scanning `f.Source` for `^#{1,6} ` is reproducing the
+   work the parser already did and discarded.
+2. **The work isn't always pure**. `regexp.MustCompile` is cheap
+   on the first call, free thereafter. But matching against
+   `f.Source` per rule per file is N rules × M files × |Source|
+   bytes. One parse is already shared across all rules.
+
+[Plan 175](175_check-performance-gate.md) added
+`f.LinkReferences()` to read goldmark's parse context once.
+MDS053 and MDS054 stopped each re-parsing the document. The
+template here is the same. Identify regex-only rules. Find the
+AST node type each regex is approximating. Route through a
+memoized per-File accessor — existing or new.
+
+## Tasks
+
+1. [ ] Create this plan.
+2. [ ] Inventory every rule whose `Check` (or helpers called only
+   from `Check`) calls `regexp.MatchString`, `regexp.FindAll*`, or
+   compiles a package-level regex against `f.Source`. List the
+   rule ID, the regex pattern, the AST node type that carries the
+   same information (or "no AST equivalent — true regex"), and
+   estimated cumulative cost from a fresh `pprof` over the neutral
+   corpus. Record under `## Inventory` below.
+3. [ ] For each rule with an AST equivalent, write the failing
+   conversion test: feed a fixture that the regex catches, switch
+   the rule to walk the AST node type (via a memoized
+   `astutil`-level accessor if shared with other rules), and pin
+   byte-identical diagnostics against the regex implementation.
+4. [ ] Land conversions in batches keyed by AST node type
+   (heading-based rules together, code-fence-based rules together,
+   etc.) so each batch shares one new `astutil` accessor when
+   useful.
+5. [ ] After each batch, re-profile and record the new
+   `BenchmarkCheckCorpus{Small,Large}` numbers. Reject any batch
+   that regresses either benchmark beyond noise.
+6. [ ] For rules with no AST equivalent (true regex work — e.g.
+   placeholder grammar checks, content-pattern rules like
+   `proper-names`, `forbidden-text`), record them as "kept regex"
+   with the reason. They are not the lever.
+
+## Inventory
+
+To be filled in by task 2. Initial suspects from plan 187 and from
+file grep:
+
+- `nounusedlinkdefinitions` — plan 187 names it explicitly at ~70 ms.
+  Definitions are in `f.LinkReferences()` already; usages are in
+  the AST as `*ast.Link` / `*ast.Image` with `ReferenceLink: true`.
+  **Likely conversion: route through `f.LinkReferences()` +
+  AST walk for usages.**
+- `noundefinedreferencelabels` — symmetric to the above.
+- `nobareurls` — currently scans `f.Source` for URL patterns.
+  AST equivalent: `*ast.AutoLink` and `*ast.Text` segments.
+  Conversion is less clean (bare URLs are exactly the case the
+  parser does NOT pick up), so this likely stays regex.
+- `noinlinehtml` — could use `*ast.RawHTML` and `*ast.HTMLBlock`
+  rather than scan source.
+- `notrailingpunctuation` — operates on heading text; AST already
+  exposes heading children.
+- `linelength` — pure line-based, no AST equivalent, stays as-is.
+
+The above is unverified; task 2 produces the authoritative list
+with patterns and cost numbers.
+
+## Acceptance Criteria
+
+- [ ] The inventory section names every regex-over-source rule, its
+      pattern, the AST equivalent (or "kept regex" with reason), and
+      the measured cumulative CPU cost per rule on the neutral corpus.
+- [ ] Each converted rule has a byte-identity test pinning its
+      diagnostics against the previous regex implementation on a
+      representative fixture corpus.
+- [ ] `BenchmarkCheckCorpus{Small,Large}` improve in net (gain ≥
+      cumulative cost of converted rules from the profile) and stay
+      within the existing budget (Small p95 27 ms / 2 s, Large p95
+      189 ms / 12 s).
+- [ ] `mdsmith check .` passes; the full fixture suite is unchanged.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

Eliminate redundant catalog entry rebuilds and front-matter reads within a single `Check` by memoizing results on the per-Check `*lint.File`. The catalog rule's generate, injection, and case-mismatch passes previously each rebuilt the same directive's entries, and each directive's entry build re-read matched files' front matter. This change collapses those redundant passes to single computations per directive and per matched file per Check.

## Key Changes

- **Add `File.Memo` primitive** (`internal/lint/file.go`): A per-Check memoization cache on `*lint.File` backed by `sync.Map` for thread-safe concurrent access. Callers provide a key and a build function; the result is computed once and cached for the lifetime of the File.

- **Memoize catalog entries** (`internal/rules/catalog/rule.go`): Introduce `cachedCatalogEntries` to cache the (entries, diags) pair behind a directive's (filePath, line) key. The three passes (generate, injection, case-mismatch) now share one entry build per directive instead of rebuilding three times.

- **Memoize front matter reads** (`internal/rules/catalog/rule.go`): Introduce `cachedFrontMatter` to cache parsed YAML front matter by matched file path. Multiple directives in one host file that glob overlapping sets no longer re-read and re-parse the same targets.

- **Memoize paragraph collection** (`internal/rules/astutil/astutil.go`): Cache `CollectSectionParagraphs` result per File so the AST walk and per-paragraph `ExtractPlainText` are shared across prose rules (MDS024 paragraph-structure and paragraph-readability) instead of re-run.

- **Add `rule.NodeChecker` interface and `rule.WalkNodes`** (`internal/rule/walk.go`): Enable rules whose Check is a pure per-node pass to opt into a shared AST walk. The engine dispatches one walk for all enabled NodeCheckers instead of each rule re-walking the tree.

- **Migrate three rules to NodeChecker** (`internal/rules/headingstyle/rule.go`, `internal/rules/noemphasisasheading/rule.go`, `internal/rules/fencedcodestyle/rule.go`): Convert pure per-node rules to implement `CheckNode` so they participate in the shared walk.

- **Implement multiplexed dispatch** (`internal/engine/check.go`): Route enabled NodeCheckers through a single shared `ast.Walk` instead of sequential `Check` calls. Diagnostics are grouped by rule in order, producing byte-identical output to sequential execution.

- **Add comprehensive test coverage**:
  - `TestCheck_DoesNotRebuildCatalogEntriesPerPass`: Pins that matched files are read at most twice per Check (front matter + cycle scan).
  - `TestCheck_DoesNotRescanIncludesPerDirective`: Pins that include-cycle scan parses each matched file once per Check, not per directive.
  - `TestCheck_DoesNotReReadFrontMatterPerDirective`: Pins that front matter is read once per Check across all directives.
  - `TestCheckRules_MultiplexedEqualsSequential`: Pins that multiplexed dispatch is byte-identical to sequential Check.
  - `TestFile_Memo`: Pins the per-Check memo contract.
  - `TestWalkNodes_*`: Pins the NodeChecker walk contract.

- **Add plan documents** (`plan/186_catalog-run-scoped-readcache.md`, `plan/187_neutral-corpus-engine-lever.md`): Document the optimization strategy, profiling findings, and future work (run-scoped cache for cross-host deduplication, multiplexed AST walk, faster sentence segmenter).

## Implementation Details

- The memo lives on the per-Check `*lint.File`, so nothing is cached across files or runs — the same scope and staleness guarantees as existing per-File caches.
- `sync.Map` and `sync.Once` ensure thread-safe single-build semantics even under concurrent LSP readers.
- The multiplexed walk preserv

https://claude.ai/code/session_01WErVWM36Szt4A2bRjc4RYW