### PR TITLE
arch: audit 2026-05-19 — six tax plans and one nice-to-have

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -124,4 +124,11 @@ footer: |
 | 195 | 🔳     | opus   | [Enforce the ≤ 10 allocs/op per-rule budget across every registered rule](plan/195_per-rule-alloc-budget.md)                            |
 | 196 | 🔲     | opus   | [Lazy SectionParagraph text — defer ExtractPlainText until a caller asks](plan/196_lazy-section-paragraph-text.md)                      |
 | 197 | 🔲     | opus   | [PoC — review goldmark's allocation architecture, then pool the best lever](plan/197_fork-goldmark-for-allocs.md)                       |
+| 200 | 🔲     |        | [Move docs/ embed out of internal/lsp/hover.go](plan/200_arch-fix-hover-embed.md)                                                       |
+| 201 | 🔲     |        | [Rename internal/testutil to internal/testsymlink](plan/201_arch-fix-testutil-rename.md)                                                |
+| 202 | 🔲     |        | [Split cmd/mdsmith/main.go into per-subcommand files](plan/202_arch-fix-main-split.md)                                                  |
+| 203 | 🔲     |        | [Split internal/lsp/server.go and symbols.go](plan/203_arch-fix-lsp-server-split.md)                                                    |
+| 204 | 🔲     |        | [Fix internal/fix importing internal/engine](plan/204_arch-fix-fix-engine-inversion.md)                                                 |
+| 205 | 🔲     |        | [Move extension.ts concerns to wiring.ts](plan/205_arch-fix-extension-ts-srp.md)                                                        |
+| 206 | 🔲     |        | [Document cue/ in architecture layering map](plan/206_arch-fix-cue-types-docs.md)                                                       |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: b5a6d72302b6a258f4acdb812464d1990388420d
+audit-from: 41e61a5e08279bb37230cdb2e7ae33119b26077a
 ---
 # Architecture audit log
 
@@ -255,22 +255,10 @@ separate rule package.
 
 ## Audit 2026-05-17 (range: 7464d273..b5a6d72)
 
-Covered: `internal/rename`, `internal/index`
-(relocated), `mdsmith deps`, `mdsmith export`.
-
-### 2026-05-17 tax
-
-`nonNegativeUTF16RuneLen` privately copied in
-three packages:
-
-- `internal/lsp/diagnostics.go:156`
-- `internal/rename/rename.go:532`
-- `cmd/mdsmith/rename.go:380`
-
-Fix: export `NonNegativeUTF16RuneLen` (plus
-`UTF16FromByteOffset` and `UTF16ToByteOffset`)
-from `internal/mdtext`. Remove the three private
-copies. See
+Covered `internal/rename`, `internal/index`,
+`mdsmith deps`, `mdsmith export`. Tax:
+`nonNegativeUTF16RuneLen` copied privately in
+three packages; export from `internal/mdtext` —
 [plan/186](../../plan/186_arch-fix-utf16-centralize.md).
 
 ## Decision 2026-05-17 (plan/174)
@@ -295,3 +283,27 @@ map forbids `cmd/mdsmith` →
 `internal/lsp`. A peer package removes
 the conflict. `internal/index` must
 never import `internal/lsp`.
+
+## Audit 2026-05-19 (range: 7464d273..41e61a5)
+
+131 Go files. Plans 154, 155, 174 green.
+
+### tax (2026-05-19)
+
+- `server.go` (1 536) and `symbols.go` (1 385)
+  exceed 1 000 lines — [plan/203][203].
+- Five items from 2026-05-13 now scheduled:
+  [hover][200], [testutil][201], [main.go][202],
+  [fix→engine][204], [extension.ts][205].
+
+[200]: ../../plan/200_arch-fix-hover-embed.md
+[201]: ../../plan/201_arch-fix-testutil-rename.md
+[202]: ../../plan/202_arch-fix-main-split.md
+[203]: ../../plan/203_arch-fix-lsp-server-split.md
+[204]: ../../plan/204_arch-fix-fix-engine-inversion.md
+[205]: ../../plan/205_arch-fix-extension-ts-srp.md
+[206]: ../../plan/206_arch-fix-cue-types-docs.md
+
+### nice-to-have (2026-05-19)
+
+`cue/types` not in layering map — [plan/206][206].

--- a/plan/200_arch-fix-hover-embed.md
+++ b/plan/200_arch-fix-hover-embed.md
@@ -1,0 +1,51 @@
+---
+id: 200
+title: Move docs/ embed out of internal/lsp/hover.go
+status: "🔲"
+summary: >-
+  Fix the DIP violation where internal/lsp/hover.go
+  imports a Go package from docs/guides/directives.
+  Move the embed to internal/directives so the
+  docs tree contains only documentation.
+model: ""
+depends-on: []
+---
+# Move docs/ embed out of internal/lsp/hover.go
+
+## Goal
+
+[internal/lsp/hover.go](../internal/lsp/hover.go) imports
+[docs/guides/directives](../docs/guides/directives) as an `embed.FS`.
+A Go package inside `docs/` blurs source
+vs. documentation. It also violates the
+layering map: no `docs/` layer sits
+between helpers and [internal/lsp](../internal/lsp).
+Moving the embed to `internal/directives`
+follows the `internal/concepts` pattern.
+
+## Tasks
+
+1. Create `internal/directives/` with a
+   `directives.go` file that embeds the
+   content from `docs/guides/directives/`.
+2. Replace the import in
+   `internal/lsp/hover.go` to
+   `internal/directives`.
+3. Remove the Go package files from
+   `docs/guides/directives/` (keep the
+   Markdown docs there).
+4. Add `TestDirectivesSource` in
+   `internal/directives/directives_test.go`.
+5. Run `go build ./...` and
+   `go test ./...`.
+6. Run `go run ./cmd/mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] `grep -r 'docs/guides/directives' internal/`
+  returns no Go imports.
+- [ ] `internal/directives/` has the
+  embed and a passing unit test.
+- [ ] `go build ./...` clean.
+- [ ] `go test ./...` passes.
+- [ ] `go tool golangci-lint run` clean.

--- a/plan/201_arch-fix-testutil-rename.md
+++ b/plan/201_arch-fix-testutil-rename.md
@@ -1,0 +1,45 @@
+---
+id: 201
+title: Rename internal/testutil to internal/testsymlink
+status: "🔲"
+summary: >-
+  Fix the anti-pattern package name. internal/testutil
+  answers "a grab bag"; rename it to
+  internal/testsymlink, which names the question
+  its single symlink.go file answers.
+model: ""
+depends-on: []
+---
+# Rename internal/testutil to internal/testsymlink
+
+## Goal
+
+[internal/testutil](../internal/testutil) violates the SRP
+naming rule from the architecture hub.
+A package named `util` attracts unrelated
+code. The package has one non-test file,
+[symlink.go](../internal/testutil/symlink.go), that creates temporary
+symlinks for tests. Renaming to
+`internal/testsymlink` signals the
+narrow scope.
+
+## Tasks
+
+1. Create `internal/testsymlink/`.
+2. Move `symlink.go` and update its
+   `package` declaration.
+3. Update all imports referencing
+   `internal/testutil`.
+4. Delete `internal/testutil/`.
+5. Run `go build ./...` and
+   `go test ./...`.
+
+## Acceptance Criteria
+
+- [ ] `internal/testutil/` is gone.
+- [ ] `internal/testsymlink/` exists.
+- [ ] `grep -r --include='*.go' 'internal/testutil'`
+  returns no results.
+- [ ] `go build ./...` clean.
+- [ ] `go test ./...` passes.
+- [ ] `go tool golangci-lint run` clean.

--- a/plan/202_arch-fix-main-split.md
+++ b/plan/202_arch-fix-main-split.md
@@ -1,0 +1,51 @@
+---
+id: 202
+title: Split cmd/mdsmith/main.go into per-subcommand files
+status: "🔲"
+summary: >-
+  main.go is 1 306 lines with six handlers over
+  50 lines. Move each oversized handler to its own
+  per-subcommand file, following the pattern used
+  by kinds.go, metrics.go, and backlinks.go.
+model: ""
+depends-on: []
+---
+# Split cmd/mdsmith/main.go into per-subcommand files
+
+## Goal
+
+[cmd/mdsmith/main.go](../cmd/mdsmith/main.go) is 1 306 lines.
+Six handlers exceed ~50 lines: `runHelp`
+(81), `runFix` (71), `fixDiscovered`
+(68), `runCheck` (62), `checkStdin`
+(61), `run` (57). The per-subcommand
+file pattern is already used by
+[kinds.go](../cmd/mdsmith/kinds.go),
+[metrics.go](../cmd/mdsmith/metrics.go),
+[backlinks.go](../cmd/mdsmith/backlinks.go),
+and [mergedriver.go](../cmd/mdsmith/mergedriver.go).
+
+## Tasks
+
+1. Create `cmd/mdsmith/check.go`; move
+   `runCheck`, `checkStdin`, and helpers.
+2. Create `cmd/mdsmith/fix.go`; move
+   `runFix`, `fixDiscovered`, and helpers.
+3. Create `cmd/mdsmith/help.go`; move
+   `runHelp` and helpers.
+4. Remove the moved functions from
+   `main.go`; verify it drops below
+   700 lines.
+5. Run `go build ./...` and
+   `go test ./...`.
+
+## Acceptance Criteria
+
+- [ ] `cmd/mdsmith/main.go` is under
+  700 lines.
+- [ ] No handler body exceeds ~50 lines.
+- [ ] `check.go`, `fix.go`, `help.go`
+  exist under `cmd/mdsmith/`.
+- [ ] `go build ./...` clean.
+- [ ] `go test ./...` passes.
+- [ ] `go tool golangci-lint run` clean.

--- a/plan/203_arch-fix-lsp-server-split.md
+++ b/plan/203_arch-fix-lsp-server-split.md
@@ -1,0 +1,52 @@
+---
+id: 203
+title: Split internal/lsp/server.go and symbols.go
+status: "🔲"
+summary: >-
+  server.go (1 536 lines) and symbols.go (1 385
+  lines) both exceed the 1 000-line threshold.
+  Split each file along its natural dispatch
+  group boundaries.
+model: ""
+depends-on: []
+---
+# Split internal/lsp/server.go and symbols.go
+
+## Goal
+
+[internal/lsp/server.go](../internal/lsp/server.go) is 1 536 lines.
+[internal/lsp/symbols.go](../internal/lsp/symbols.go) is 1 385 lines.
+Both exceed the 1 000-line ceiling from
+the audit checklist. Both contain LSP
+capability handlers that can live in
+their own files. The pattern already
+exists: [rename.go](../internal/lsp/rename.go) and
+[completion.go](../internal/lsp/completion.go)
+each own a dispatch group.
+
+## Tasks
+
+1. Identify the dispatch groups in
+   `server.go` (lifecycle, doc-sync,
+   code-action, diagnostics push).
+2. Move each group to a new file
+   (`server_lifecycle.go`, etc.).
+3. Identify the dispatch groups in
+   `symbols.go` (document symbols,
+   workspace symbols, call hierarchy).
+4. Move each group to a new file
+   (`symbols_document.go`, etc.).
+5. Verify no file in `internal/lsp/`
+   exceeds 1 000 lines.
+6. Run `go build ./...` and
+   `go test ./...`.
+
+## Acceptance Criteria
+
+- [ ] No non-test production file under
+  `internal/lsp/` exceeds 1 000 lines
+  (`*_test.go` files are out of scope).
+- [ ] `go build ./...` clean.
+- [ ] `go test ./...` passes (LSP
+  integration tests included).
+- [ ] `go tool golangci-lint run` clean.

--- a/plan/204_arch-fix-fix-engine-inversion.md
+++ b/plan/204_arch-fix-fix-engine-inversion.md
@@ -1,0 +1,51 @@
+---
+id: 204
+title: Fix internal/fix importing internal/engine
+status: "🔲"
+summary: >-
+  internal/fix/fix.go imports internal/engine for
+  CheckRules, ConfigureRule, and DedupeDiagnostics.
+  The layering map places engine above fix. Move
+  the three functions to a lower shared package.
+model: ""
+depends-on: []
+---
+# Fix internal/fix importing internal/engine
+
+## Goal
+
+[internal/fix/fix.go](../internal/fix/fix.go) imports
+[internal/engine](../internal/engine) for three functions.
+The layering map places engine above fix.
+The import inverts that arrow. Moving
+the three functions to a package both
+engine and fix can import restores the
+intended direction.
+
+## Tasks
+
+1. Read `CheckRules`, `ConfigureRule`,
+   and `DedupeDiagnostics` and identify
+   their dependencies.
+2. Choose the target package (`internal/lint`,
+   `internal/rule`, or a new package).
+   Document the choice here.
+3. Move the three functions.
+4. Update all callers in `internal/engine`
+   and `internal/fix`.
+5. Verify `internal/fix` no longer
+   imports `internal/engine`.
+6. Add a contract test in
+   `internal/integration/` that fails if
+   `internal/fix` imports `internal/engine`.
+7. Run `go build ./...` and
+   `go test ./...`.
+
+## Acceptance Criteria
+
+- [ ] `grep -r --include='*.go' '".*internal/engine"' internal/fix/`
+  returns nothing.
+- [ ] A contract test guards the boundary.
+- [ ] `go build ./...` clean.
+- [ ] `go test ./...` passes.
+- [ ] `go tool golangci-lint run` clean.

--- a/plan/205_arch-fix-extension-ts-srp.md
+++ b/plan/205_arch-fix-extension-ts-srp.md
@@ -1,0 +1,54 @@
+---
+id: 205
+title: Move extension.ts concerns to wiring.ts
+status: "🔲"
+summary: >-
+  extension.ts is 509 lines and owns the LSP client
+  lifecycle, config-file watcher, error handler, and
+  command registrations. Move those concerns to
+  wiring.ts per the TypeScript architecture doc.
+model: ""
+depends-on: []
+---
+# Move extension.ts concerns to wiring.ts
+
+## Goal
+
+[editors/vscode/src/extension.ts](../editors/vscode/src/extension.ts) is
+509 lines and violates SRP. It runs the
+LSP client, watches `.mdsmith.yml`,
+handles errors, and registers commands.
+The TypeScript architecture doc says
+[extension.ts](../editors/vscode/src/extension.ts) should activate, construct
+the wiring object, and hand control to
+[wiring.ts](../editors/vscode/src/wiring.ts). Everything else moves.
+
+## Tasks
+
+1. Move `LanguageClient` lifecycle into
+   `wiring.ts`.
+2. Move the `WorkspaceFileSystemWatcher`
+   for `.mdsmith.yml` into `wiring.ts`.
+3. Move the `ErrorHandler` class into
+   `wiring.ts` or `commands/error-handler.ts`.
+4. Move `registerPaletteCommands` and all
+   `registerCommand` calls into `wiring.ts`.
+5. Reduce `extension.ts` to: import,
+   construct wiring, hand over.
+6. Extend the existing `wiring.test.ts`
+   with coverage for the moved concerns:
+   LSP client lifecycle, config watcher,
+   and command registration.
+7. Run `bun test` and the extension-host
+   e2e suite.
+
+## Acceptance Criteria
+
+- [ ] `extension.ts` is under 60 lines.
+- [ ] No `registerCommand` calls remain
+  in `extension.ts`.
+- [ ] `wiring.test.ts` covers the moved
+  LSP lifecycle, watcher, and command
+  registration. All tests pass.
+- [ ] The extension-host e2e suite passes.
+- [ ] `bun run lint` reports no issues.

--- a/plan/206_arch-fix-cue-types-docs.md
+++ b/plan/206_arch-fix-cue-types-docs.md
@@ -1,0 +1,51 @@
+---
+id: 206
+title: Document cue/ in architecture layering map
+status: "🔲"
+summary: >-
+  cue/types was added as a public Go package outside
+  internal/ and pkg/, but is not in the layering map.
+  Also add the required exemption comment to
+  cue/types.Source().
+model: ""
+depends-on: []
+---
+# Document cue/ in architecture layering map
+
+## Goal
+
+[cue/types/types.go](../cue/types/types.go) was added and is
+imported by [internal/schema/shortcuts.go](../internal/schema/shortcuts.go).
+It sits outside both `internal/` and
+`pkg/`, analogous to [pkg/markdown](../pkg/markdown) but
+for CUE consumers. Two gaps need fixing:
+
+1. `cue/` is absent from the layering
+   diagram in
+   `docs/development/architecture/index.md`.
+2. `Source()` is a trivial accessor that
+   qualifies for the test exemption but
+   lacks the required comment.
+
+## Tasks
+
+1. Update the layering diagram in
+   `docs/development/architecture/index.md`
+   to show `cue/types` at the bottom
+   layer alongside `pkg/markdown`.
+2. Add one sentence in the layering
+   prose explaining `cue/types`.
+3. Add the comment
+   `// no test by design: trivial embed accessor`
+   to `func Source()` in `cue/types/types.go`.
+4. Run `go run ./cmd/mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] The layering diagram in
+  `docs/development/architecture/index.md`
+  shows `cue/types`.
+- [ ] `Source()` has a "no test by design"
+  comment.
+- [ ] `go run ./cmd/mdsmith check .`
+  reports no issues.


### PR DESCRIPTION
## Summary

- Ran a SOLID/clean-architecture audit over `origin/main` range `7464d273..41e61a5` (131 Go files changed since the 2026-05-13 sweep).
- Verified plans 154, 155, and 174 are resolved on main.
- Appended the 2026-05-19 audit entry to `docs/development/architecture-audit.md` and advanced `audit-from` to `41e61a5`.
- Filed seven new plan files (200–206) for architectural items that were logged but never scheduled.

### Plans filed

| # | Title | Severity |
|---|-------|----------|
| 200 | Move `hover.go` embed from `docs/` to `internal/directives` (DIP) | tax |
| 201 | Rename `internal/testutil` → `internal/testsymlink` | tax |
| 202 | Split `cmd/mdsmith/main.go` into per-subcommand files (1 306 lines) | tax |
| 203 | Split `internal/lsp/server.go` (1 536) and `symbols.go` (1 385) | tax |
| 204 | Fix `internal/fix` → `internal/engine` layering inversion | tax |
| 205 | Move `extension.ts` concerns to `wiring.ts` (TypeScript SRP) | tax |
| 206 | Document `cue/` in layering map; add `Source()` exemption comment | nice-to-have |

Plans 200–205 are tax; plan 206 is nice-to-have (documentation gap, not active technical debt).

Note: plan IDs 186–199 were already taken by work merged into main while this PR was open; these plans use 200–206.

## Test plan

- [x] `go run ./cmd/mdsmith check .` passes (0 failures)
- [x] All new plan files pass `mdsmith check plan/`
- [x] `PLAN.md` catalog regenerated

https://claude.ai/code/session_019LRrfkRrVZNsAK5jM1a3sA