### PR TITLE
audit: SOLID sweep 2026-05-17 + plan/186 UTF-16 helper centralization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -112,5 +112,5 @@ footer: |
 | 183 | ✅     | sonnet | [Skip DedupeDiagnostics via an audited rule.RepoScoped marker](plan/183_dedupe-diagnostics-repo-scoped-skip.md)                         |
 | 184 | ✅     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 | 185 | 🔲     |        | [Expose extended-syntax parsers and the flavor model in pkg/markdown](plan/185_public-markdown-flavor-library.md)                       |
-| 186 | 🔲     |        | [Centralize UTF-16 column helpers in internal/mdtext](plan/186_arch-fix-utf16-centralize.md)                                            |
+| 186 | ✅     |        | [Centralize UTF-16 column helpers in internal/mdtext](plan/186_arch-fix-utf16-centralize.md)                                            |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -112,4 +112,5 @@ footer: |
 | 183 | ✅     | sonnet | [Skip DedupeDiagnostics via an audited rule.RepoScoped marker](plan/183_dedupe-diagnostics-repo-scoped-skip.md)                         |
 | 184 | ✅     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 | 185 | 🔲     |        | [Expose extended-syntax parsers and the flavor model in pkg/markdown](plan/185_public-markdown-flavor-library.md)                       |
+| 186 | 🔲     |        | [Centralize UTF-16 column helpers in internal/mdtext](plan/186_arch-fix-utf16-centralize.md)                                            |
 <?/catalog?>

--- a/cmd/mdsmith/rename.go
+++ b/cmd/mdsmith/rename.go
@@ -8,13 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"unicode/utf16"
-	"unicode/utf8"
 
 	flag "github.com/spf13/pflag"
 
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/rename"
 )
 
@@ -306,8 +305,8 @@ func applyEdits(src []byte, edits []rename.Edit) ([]byte, error) {
 		})
 		buf := append([]byte(nil), row...)
 		for _, e := range es {
-			s := utf16ToByteOffset(row, e.Range.Start.Character)
-			en := utf16ToByteOffset(row, e.Range.End.Character)
+			s := mdtext.UTF16ToByteOffset(row, e.Range.Start.Character)
+			en := mdtext.UTF16ToByteOffset(row, e.Range.End.Character)
 			if s < 0 || en < 0 || s > len(buf) || en > len(buf) || s > en {
 				return nil, fmt.Errorf("edit offset [%d,%d) out of range on line %d", s, en, line+1)
 			}
@@ -350,38 +349,6 @@ func joinLF(segs [][]byte) []byte {
 		out = append(out, s...)
 	}
 	return out
-}
-
-// utf16ToByteOffset returns the byte offset in row at the given
-// UTF-16 code-unit offset, the inverse of the engine's
-// byte→UTF-16 mapping. Offsets past the row's end clamp to len(row)
-// so a defensive guard upstream still sees an in-range value.
-func utf16ToByteOffset(row []byte, target int) int {
-	if target <= 0 {
-		return 0
-	}
-	units := 0
-	for i := 0; i < len(row); {
-		if units >= target {
-			return i
-		}
-		r, size := utf8.DecodeRune(row[i:])
-		units += nonNegativeUTF16RuneLen(r)
-		i += size
-	}
-	return len(row)
-}
-
-// nonNegativeUTF16RuneLen wraps utf16.RuneLen so its negative
-// "invalid code point" return (e.g. a lone surrogate) cannot
-// decrement the running UTF-16 unit count. utf8.DecodeRune maps
-// invalid bytes to RuneError (width 1), so in practice the guard is
-// defensive against an out-of-range rune reaching this path.
-func nonNegativeUTF16RuneLen(r rune) int {
-	if w := utf16.RuneLen(r); w >= 0 {
-		return w
-	}
-	return 1
 }
 
 // writeFilePreservingMode overwrites path with data, keeping the

--- a/cmd/mdsmith/rename_unit_test.go
+++ b/cmd/mdsmith/rename_unit_test.go
@@ -237,26 +237,6 @@ func TestSplitKeepCRAndJoinLF(t *testing.T) {
 	assert.Equal(t, []byte("x\n"), joinLF(splitKeepCR([]byte("x\n"))))
 }
 
-func TestUtf16ToByteOffset(t *testing.T) {
-	assert.Equal(t, 0, utf16ToByteOffset([]byte("abc"), 0))
-	assert.Equal(t, 0, utf16ToByteOffset([]byte("abc"), -1))
-	assert.Equal(t, 2, utf16ToByteOffset([]byte("abc"), 2))
-	assert.Equal(t, 3, utf16ToByteOffset([]byte("abc"), 9)) // clamp past end
-	// "é" is one UTF-16 unit but two UTF-8 bytes; "𝄞" is a surrogate
-	// pair (two UTF-16 units, four bytes).
-	row := []byte("é𝄞z")
-	assert.Equal(t, 2, utf16ToByteOffset(row, 1)) // past "é"
-	assert.Equal(t, 6, utf16ToByteOffset(row, 3)) // past the surrogate pair
-}
-
-func TestNonNegativeUTF16RuneLen(t *testing.T) {
-	assert.Equal(t, 1, nonNegativeUTF16RuneLen('a'))
-	assert.Equal(t, 2, nonNegativeUTF16RuneLen('𝄞'))
-	// A lone surrogate is an invalid scalar: utf16.RuneLen returns
-	// -1, and the guard floors it at 1.
-	assert.Equal(t, 1, nonNegativeUTF16RuneLen(rune(0xD800)))
-}
-
 func TestRunRename_FlagParseError(t *testing.T) {
 	renameWorkspace(t)
 	// An unknown flag is a non-help parse error → exit 2.

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: 7464d27310f722d9bfe203dc66b11bde714d4dd8
+audit-from: b5a6d72302b6a258f4acdb812464d1990388420d
 ---
 # Architecture audit log
 
@@ -252,6 +252,26 @@ Worth a one-sentence package comment
 explaining why it is separate so
 future readers do not read it as a
 separate rule package.
+
+## Audit 2026-05-17 (range: 7464d273..b5a6d72)
+
+Covered: `internal/rename`, `internal/index`
+(relocated), `mdsmith deps`, `mdsmith export`.
+
+### 2026-05-17 tax
+
+`nonNegativeUTF16RuneLen` privately copied in
+three packages:
+
+- `internal/lsp/diagnostics.go:156`
+- `internal/rename/rename.go:532`
+- `cmd/mdsmith/rename.go:380`
+
+Fix: export `NonNegativeUTF16RuneLen` (plus
+`UTF16FromByteOffset` and `UTF16ToByteOffset`)
+from `internal/mdtext`. Remove the three private
+copies. See
+[plan/186](../../plan/186_arch-fix-utf16-centralize.md).
 
 ## Decision 2026-05-17 (plan/174)
 

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -2,10 +2,10 @@ package lsp
 
 import (
 	"bytes"
-	"unicode/utf16"
 	"unicode/utf8"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdtext"
 )
 
 // toLSP converts an mdsmith diagnostic to the LSP wire shape.
@@ -25,7 +25,7 @@ import (
 // offset would misplace the squiggle by N-1 positions for every
 // preceding rune that takes N>1 bytes.
 //
-// Both startCol and endCol come from utf16FromByteOffset/utf16Length
+// Both startCol and endCol come from mdtext.UTF16FromByteOffset/utf16Length
 // on the same line, which clamps every input to [0, line's UTF-16
 // length], so endCol is always >= startCol — no end-before-start
 // guard is needed.
@@ -35,7 +35,7 @@ func toLSP(d lint.Diagnostic, lines [][]byte) Diagnostic {
 		startLine = 0
 	}
 	line := currentLineBytes(lines, d.Line)
-	startCol := utf16FromByteOffset(line, d.Column-1)
+	startCol := mdtext.UTF16FromByteOffset(line, d.Column-1)
 	endCol := utf16Length(line)
 	return Diagnostic{
 		Range: Range{
@@ -116,48 +116,11 @@ func currentLineBytes(lines [][]byte, n int) []byte {
 }
 
 // utf16Length returns the total UTF-16 code-unit length of line.
-// Equivalent to utf16FromByteOffset(line, len(line)) but spelled out
-// for readability at call sites that just want "end of line".
+// Equivalent to mdtext.UTF16FromByteOffset(line, len(line)) but
+// spelled out for readability at call sites that just want "end of
+// line".
 func utf16Length(line []byte) int {
-	return utf16FromByteOffset(line, len(line))
-}
-
-// utf16FromByteOffset returns the UTF-16 code-unit offset that
-// corresponds to UTF-8 byte offset `byteOff` within `line`. The
-// result is clamped to [0, utf16Length(line)] so callers cannot
-// receive a negative or past-end position even when given a
-// malformed mdsmith column. See nonNegativeUTF16RuneLen for the
-// width contract — every counted rune contributes >= 0 units, so
-// the running total never drops below zero on the wire.
-func utf16FromByteOffset(line []byte, byteOff int) int {
-	if byteOff <= 0 {
-		return 0
-	}
-	if byteOff > len(line) {
-		byteOff = len(line)
-	}
-	units := 0
-	for i := 0; i < byteOff; {
-		r, size := utf8.DecodeRune(line[i:])
-		units += nonNegativeUTF16RuneLen(r)
-		i += size
-	}
-	return units
-}
-
-// nonNegativeUTF16RuneLen wraps utf16.RuneLen so its negative
-// "invalid code point" return cannot decrement the caller's
-// running total. utf8.DecodeRune already maps invalid bytes to
-// RuneError (U+FFFD, width 1), so in practice w is always >= 0;
-// the guard is defensive against a future Go change that weakens
-// that invariant. A negative width means the rune is outside
-// [0, MaxRune] or is a surrogate, both of which are 1 UTF-16 unit
-// when serialized as RuneError.
-func nonNegativeUTF16RuneLen(r rune) int {
-	if w := utf16.RuneLen(r); w >= 0 {
-		return w
-	}
-	return 1
+	return mdtext.UTF16FromByteOffset(line, len(line))
 }
 
 // byteOffsetFromUTF16 maps a UTF-16 column position (LSP wire form)
@@ -165,11 +128,15 @@ func nonNegativeUTF16RuneLen(r rune) int {
 // clamped to [0, len(line)] so a malformed or past-end LSP position
 // stays within the slice.
 //
-// This is the inverse of utf16FromByteOffset. The navigation surface
-// uses it to convert `Position.Character` (UTF-16) to a byte column
-// before calling the Locator, which works in 1-based byte columns.
-// Without it, every cursor on a non-ASCII line would mis-locate by
-// the number of multi-byte runes between byte 0 and the cursor.
+// This is the inverse of mdtext.UTF16FromByteOffset. The navigation
+// surface uses it to convert `Position.Character` (UTF-16) to a byte
+// column before calling the Locator, which works in 1-based byte
+// columns. Without it, every cursor on a non-ASCII line would
+// mis-locate by the number of multi-byte runes between byte 0 and
+// the cursor. Distinct from mdtext.UTF16ToByteOffset: when utf16Off
+// lands inside a surrogate pair, this rounds down to the rune's
+// starting byte (LSP cursor semantics), whereas UTF16ToByteOffset
+// rounds up to the next codepoint boundary.
 func byteOffsetFromUTF16(line []byte, utf16Off int) int {
 	if utf16Off <= 0 {
 		return 0
@@ -177,7 +144,7 @@ func byteOffsetFromUTF16(line []byte, utf16Off int) int {
 	units := 0
 	for i := 0; i < len(line); {
 		r, size := utf8.DecodeRune(line[i:])
-		w := nonNegativeUTF16RuneLen(r)
+		w := mdtext.NonNegativeUTF16RuneLen(r)
 		if units+w > utf16Off {
 			return i
 		}

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/jeduden/mdsmith/internal/index"
+	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/rename"
 	"github.com/yuin/goldmark/util"
 )
@@ -102,8 +103,8 @@ func headingPrepareRange(source []byte, line int, name string) (prepareRenameRes
 		// text against indented setext underlines.
 		startCol, endCol = trimmedRange(row)
 	}
-	startCh := utf16FromByteOffset(row, startCol)
-	endCh := utf16FromByteOffset(row, endCol)
+	startCh := mdtext.UTF16FromByteOffset(row, startCol)
+	endCh := mdtext.UTF16FromByteOffset(row, endCol)
 	return prepareRenameResult{
 		Range: Range{
 			Start: Position{Line: line - 1, Character: startCh},
@@ -227,8 +228,8 @@ func refDefPrepareRange(source []byte, line int, _ string) (prepareRenameResult,
 	if m == nil {
 		return prepareRenameResult{}, false
 	}
-	startCh := utf16FromByteOffset(row, m[0])
-	endCh := utf16FromByteOffset(row, m[1])
+	startCh := mdtext.UTF16FromByteOffset(row, m[0])
+	endCh := mdtext.UTF16FromByteOffset(row, m[1])
 	return prepareRenameResult{
 		Range: Range{
 			Start: Position{Line: line - 1, Character: startCh},
@@ -285,8 +286,8 @@ func refUsePrepareRange(source []byte, line, col int, label string) (prepareRena
 	if !ok {
 		return prepareRenameResult{}, false
 	}
-	startCh := utf16FromByteOffset(row, startByte)
-	endCh := utf16FromByteOffset(row, endByte)
+	startCh := mdtext.UTF16FromByteOffset(row, startByte)
+	endCh := mdtext.UTF16FromByteOffset(row, endByte)
 	return prepareRenameResult{
 		Range: Range{
 			Start: Position{Line: line - 1, Character: startCh},

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -992,31 +992,6 @@ func TestToLSPEmptyLineProducesZeroWidthRange(t *testing.T) {
 		"empty line should produce a zero-width range, not extend past the line")
 }
 
-func TestUtf16FromByteOffsetInvalidRunes(t *testing.T) {
-	t.Parallel()
-	// `string([]rune{0xD800, 'a'})` produces a UTF-8 sequence
-	// containing utf8.RuneError; the helper must keep counting and
-	// must not drop below zero even when utf16.RuneLen returns -1
-	// for the offending rune.
-	line := []byte(string([]rune{0xD800, 'a'}))
-	got := utf16FromByteOffset(line, len(line))
-	assert.Positive(t, got, "utf16FromByteOffset must stay non-negative on invalid runes")
-}
-
-// nonNegativeUTF16RuneLen exists to defend the running offset
-// total against a (currently impossible) negative utf16.RuneLen
-// return. Verify both branches: a normal BMP rune passes through
-// at width 1, and a surrogate code point (which utf16.RuneLen
-// reports as -1) clamps to 1.
-func TestNonNegativeUTF16RuneLen(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, 1, nonNegativeUTF16RuneLen('a'))
-	assert.Equal(t, 2, nonNegativeUTF16RuneLen('😀'))
-	// 0xD800 is a high-surrogate code point; utf16.RuneLen returns
-	// -1 for it and the helper clamps to 1.
-	assert.Equal(t, 1, nonNegativeUTF16RuneLen(rune(0xD800)))
-}
-
 func TestDispatchRawInvalidJSONRespondsWithParseError(t *testing.T) {
 	t.Parallel()
 	var buf safeBuffer
@@ -2002,24 +1977,6 @@ func TestSplitLines(t *testing.T) {
 		splitLines([]byte("a\nb\n")))
 	// CRLF endings strip per-line CR.
 	assert.Equal(t, [][]byte{[]byte("a"), []byte("b")}, splitLines([]byte("a\r\nb")))
-}
-
-func TestUtf16FromByteOffsetSurrogatePair(t *testing.T) {
-	t.Parallel()
-	// A non-BMP rune (\U0001F600 — 😀) is encoded as 4 UTF-8 bytes
-	// and 2 UTF-16 code units. The trailing 'x' is one of each.
-	line := []byte("😀x")
-	assert.Equal(t, 0, utf16FromByteOffset(line, 0))
-	assert.Equal(t, 2, utf16FromByteOffset(line, 4)) // after the emoji
-	assert.Equal(t, 3, utf16FromByteOffset(line, 5)) // after the 'x'
-	// Out-of-range byte offsets clamp to the line's UTF-16 length
-	// rather than overflowing.
-	assert.Equal(t, 3, utf16FromByteOffset(line, 999))
-}
-
-func TestUtf16FromByteOffsetClampsNegative(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, 0, utf16FromByteOffset([]byte("hello"), -1))
 }
 
 // TestToLSPMultiByteRuneBeforeColumn pins the byte-vs-rune fix for

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/linkgraph"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
 
@@ -679,7 +680,7 @@ func rangeAt(line, col int, source []byte) Range {
 	startCh := 0
 	endCh := 0
 	if line-1 < len(lines) {
-		startCh = utf16FromByteOffset(lines[line-1], col-1)
+		startCh = mdtext.UTF16FromByteOffset(lines[line-1], col-1)
 		endCh = utf16Length(lines[line-1])
 	}
 	return Range{

--- a/internal/mdtext/utf16.go
+++ b/internal/mdtext/utf16.go
@@ -1,0 +1,64 @@
+package mdtext
+
+import (
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// NonNegativeUTF16RuneLen wraps utf16.RuneLen so its negative
+// "invalid code point" return cannot decrement a caller's
+// running UTF-16 unit total. utf8.DecodeRune already maps
+// invalid bytes to RuneError (U+FFFD, width 1), so in practice
+// utf16.RuneLen never returns a negative for runes decoded from
+// real input; the guard is defensive against a future Go change
+// that weakens that invariant. A negative width means the rune
+// is outside [0, MaxRune] or is a surrogate, both of which take
+// one UTF-16 unit when serialized as RuneError.
+func NonNegativeUTF16RuneLen(r rune) int {
+	if w := utf16.RuneLen(r); w >= 0 {
+		return w
+	}
+	return 1
+}
+
+// UTF16FromByteOffset returns the UTF-16 code-unit offset that
+// corresponds to UTF-8 byte offset byteOff within line. The
+// result is clamped to [0, total UTF-16 length of line] so
+// callers cannot receive a negative or past-end position even
+// when given a malformed byte column.
+func UTF16FromByteOffset(line []byte, byteOff int) int {
+	if byteOff <= 0 {
+		return 0
+	}
+	if byteOff > len(line) {
+		byteOff = len(line)
+	}
+	units := 0
+	for i := 0; i < byteOff; {
+		r, size := utf8.DecodeRune(line[i:])
+		units += NonNegativeUTF16RuneLen(r)
+		i += size
+	}
+	return units
+}
+
+// UTF16ToByteOffset returns the byte offset in line at the given
+// UTF-16 code-unit count. Offsets past the line's end clamp to
+// len(line) so a defensive guard upstream still sees an in-range
+// value. A target that lands inside a surrogate pair rounds up
+// to the next codepoint boundary.
+func UTF16ToByteOffset(line []byte, target int) int {
+	if target <= 0 {
+		return 0
+	}
+	units := 0
+	for i := 0; i < len(line); {
+		if units >= target {
+			return i
+		}
+		r, size := utf8.DecodeRune(line[i:])
+		units += NonNegativeUTF16RuneLen(r)
+		i += size
+	}
+	return len(line)
+}

--- a/internal/mdtext/utf16_test.go
+++ b/internal/mdtext/utf16_test.go
@@ -1,0 +1,52 @@
+package mdtext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNonNegativeUTF16RuneLen(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 1, NonNegativeUTF16RuneLen('a'))
+	assert.Equal(t, 2, NonNegativeUTF16RuneLen('😀'))
+	// A lone surrogate is an invalid scalar value: utf16.RuneLen
+	// returns -1, and the guard floors that at 1.
+	assert.Equal(t, 1, NonNegativeUTF16RuneLen(rune(0xD800)))
+}
+
+func TestUTF16FromByteOffset(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, UTF16FromByteOffset([]byte("abc"), 0), "zero offset")
+	assert.Equal(t, 0, UTF16FromByteOffset([]byte("abc"), -3), "negative clamps to 0")
+	assert.Equal(t, 3, UTF16FromByteOffset([]byte("abc"), 99), "past end clamps to length")
+	// A non-BMP rune (\U0001F600 — 😀) is encoded as 4 UTF-8 bytes
+	// and 2 UTF-16 code units. The trailing 'x' is one of each.
+	line := []byte("😀x")
+	assert.Equal(t, 0, UTF16FromByteOffset(line, 0))
+	assert.Equal(t, 2, UTF16FromByteOffset(line, 4)) // after the emoji
+	assert.Equal(t, 3, UTF16FromByteOffset(line, 5)) // after the 'x'
+}
+
+func TestUTF16FromByteOffsetInvalidRunes(t *testing.T) {
+	t.Parallel()
+	// `string([]rune{0xD800, 'a'})` produces a UTF-8 sequence
+	// containing utf8.RuneError; the running total must stay
+	// non-negative even when utf16.RuneLen returns -1 for the
+	// offending rune.
+	line := []byte(string([]rune{0xD800, 'a'}))
+	assert.Positive(t, UTF16FromByteOffset(line, len(line)))
+}
+
+func TestUTF16ToByteOffset(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, UTF16ToByteOffset([]byte("abc"), 0))
+	assert.Equal(t, 0, UTF16ToByteOffset([]byte("abc"), -1))
+	assert.Equal(t, 2, UTF16ToByteOffset([]byte("abc"), 2))
+	assert.Equal(t, 3, UTF16ToByteOffset([]byte("abc"), 9)) // clamp past end
+	// "é" is one UTF-16 unit but two UTF-8 bytes; "𝄞" is a surrogate
+	// pair (two UTF-16 units, four bytes).
+	row := []byte("é𝄞z")
+	assert.Equal(t, 2, UTF16ToByteOffset(row, 1)) // past "é"
+	assert.Equal(t, 6, UTF16ToByteOffset(row, 3)) // past the surrogate pair
+}

--- a/internal/rename/heading.go
+++ b/internal/rename/heading.go
@@ -314,8 +314,8 @@ func headingTextEdit(source []byte, line int, newName string) (Edit, bool) {
 	if !ok {
 		startByte, endByte = trimmedRange(row)
 	}
-	startCh := utf16FromByteOffset(row, startByte)
-	endCh := utf16FromByteOffset(row, endByte)
+	startCh := mdtext.UTF16FromByteOffset(row, startByte)
+	endCh := mdtext.UTF16FromByteOffset(row, endByte)
 	return Edit{
 		Range: Range{
 			Start: Position{Line: line - 1, Character: startCh},
@@ -459,8 +459,8 @@ func anchorEditForEdge(ws Workspace, e index.Edge, oldSlug, newSlug string) (str
 	if !ok {
 		return "", Edit{}, false
 	}
-	startCh := utf16FromByteOffset(row, startByte)
-	endCh := utf16FromByteOffset(row, endByte)
+	startCh := mdtext.UTF16FromByteOffset(row, startByte)
+	endCh := mdtext.UTF16FromByteOffset(row, endByte)
 	return key, Edit{
 		Range: Range{
 			Start: Position{Line: e.SourceLine - 1, Character: startCh},
@@ -675,8 +675,8 @@ func refDefDestEditForMatch(
 		hashIdx++
 	}
 	fragEnd := fragmentEnd(row, hashIdx+1, destEnd)
-	startCh := utf16FromByteOffset(row, hashIdx+1)
-	endCh := utf16FromByteOffset(row, fragEnd)
+	startCh := mdtext.UTF16FromByteOffset(row, hashIdx+1)
+	endCh := mdtext.UTF16FromByteOffset(row, fragEnd)
 	return Edit{
 		Range: Range{
 			Start: Position{Line: fileLine - 1, Character: startCh},

--- a/internal/rename/helpers_test.go
+++ b/internal/rename/helpers_test.go
@@ -111,22 +111,6 @@ func TestSplitLines(t *testing.T) {
 	assert.Equal(t, "b", string(got[1]))
 }
 
-func TestUTF16FromByteOffset(t *testing.T) {
-	assert.Equal(t, 0, utf16FromByteOffset([]byte("abc"), 0), "zero offset")
-	assert.Equal(t, 0, utf16FromByteOffset([]byte("abc"), -3), "negative clamps to 0")
-	assert.Equal(t, 3, utf16FromByteOffset([]byte("abc"), 99), "past end clamps to length")
-	// "𝄞" (U+1D11E) is one rune, two UTF-16 code units, four bytes.
-	assert.Equal(t, 2, utf16FromByteOffset([]byte("𝄞"), 4))
-}
-
-func TestNonNegativeUTF16RuneLen(t *testing.T) {
-	assert.Equal(t, 1, nonNegativeUTF16RuneLen('a'))
-	assert.Equal(t, 2, nonNegativeUTF16RuneLen('𝄞'))
-	// A lone surrogate is an invalid scalar: utf16.RuneLen returns
-	// -1, and the guard maps it to one unit.
-	assert.Equal(t, 1, nonNegativeUTF16RuneLen(rune(0xD800)))
-}
-
 func TestRefDefEditsInBody_SkipsNonMatchingAndOutOfRange(t *testing.T) {
 	// One real def for "a" and one for "other"; renaming "a" only
 	// touches the "a" def. Exercises the normLabel-mismatch skip.

--- a/internal/rename/rename.go
+++ b/internal/rename/rename.go
@@ -10,11 +10,10 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"unicode/utf16"
-	"unicode/utf8"
 
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
@@ -248,8 +247,8 @@ func refDefEditsInBody(
 		}
 		row := lines[fileLine-1]
 		bracket := refDefBracketBytes(row)
-		startCh := utf16FromByteOffset(row, bracket[0])
-		endCh := utf16FromByteOffset(row, bracket[1])
+		startCh := mdtext.UTF16FromByteOffset(row, bracket[0])
+		endCh := mdtext.UTF16FromByteOffset(row, bracket[1])
 		out = append(out, Edit{
 			Range: Range{
 				Start: Position{Line: fileLine - 1, Character: startCh},
@@ -305,8 +304,8 @@ func refUseEdit(
 	endLine := bodyIdx.lineOfOffset(labelEnd) + fmOffset
 	startCol := labelStart - bodyIdx.lineStart(startLine-fmOffset)
 	endCol := labelEnd - bodyIdx.lineStart(endLine-fmOffset)
-	startCh := utf16FromByteOffset(lines[startLine-1], startCol)
-	endCh := utf16FromByteOffset(lines[endLine-1], endCol)
+	startCh := mdtext.UTF16FromByteOffset(lines[startLine-1], startCol)
+	endCh := mdtext.UTF16FromByteOffset(lines[endLine-1], endCol)
 	return Edit{
 		Range: Range{
 			Start: Position{Line: startLine - 1, Character: startCh},
@@ -502,36 +501,4 @@ func splitLines(source []byte) [][]byte {
 		}
 	}
 	return parts
-}
-
-// utf16FromByteOffset returns the UTF-16 code-unit offset for UTF-8
-// byte offset byteOff within line, clamped to
-// [0, utf16 length(line)]. Ported verbatim from the LSP server so
-// delegated renames produce identical wire coordinates.
-func utf16FromByteOffset(line []byte, byteOff int) int {
-	if byteOff <= 0 {
-		return 0
-	}
-	if byteOff > len(line) {
-		byteOff = len(line)
-	}
-	units := 0
-	for i := 0; i < byteOff; {
-		r, size := utf8.DecodeRune(line[i:])
-		units += nonNegativeUTF16RuneLen(r)
-		i += size
-	}
-	return units
-}
-
-// nonNegativeUTF16RuneLen wraps utf16.RuneLen so its negative
-// "invalid code point" return cannot decrement the running total.
-// utf8.DecodeRune maps invalid bytes to RuneError (width 1), so in
-// practice w is always >= 0; the guard is defensive against a future
-// stdlib change.
-func nonNegativeUTF16RuneLen(r rune) int {
-	if w := utf16.RuneLen(r); w >= 0 {
-		return w
-	}
-	return 1
 }

--- a/plan/186_arch-fix-utf16-centralize.md
+++ b/plan/186_arch-fix-utf16-centralize.md
@@ -1,7 +1,7 @@
 ---
 id: 186
 title: Centralize UTF-16 column helpers in internal/mdtext
-status: 🔲
+status: ✅
 summary: >-
   Lift the triplicated nonNegativeUTF16RuneLen /
   utf16FromByteOffset helpers out of internal/lsp,
@@ -68,17 +68,17 @@ Remove the three private copies in
 
 ## Acceptance Criteria
 
-- [ ] `internal/mdtext` exports
+- [x] `internal/mdtext` exports
   `NonNegativeUTF16RuneLen`,
   `UTF16FromByteOffset`, and
   `UTF16ToByteOffset`, each with a
   dedicated unit test.
-- [ ] No private copy of
+- [x] No private copy of
   `nonNegativeUTF16RuneLen`,
   `utf16FromByteOffset`, or
   `utf16ToByteOffset` remains in
   `internal/lsp/`, `internal/rename/`,
   or `cmd/mdsmith/`.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run`
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run`
   reports no issues.

--- a/plan/186_arch-fix-utf16-centralize.md
+++ b/plan/186_arch-fix-utf16-centralize.md
@@ -1,0 +1,84 @@
+---
+id: 186
+title: Centralize UTF-16 column helpers in internal/mdtext
+status: 🔲
+summary: >-
+  Lift the triplicated nonNegativeUTF16RuneLen /
+  utf16FromByteOffset helpers out of internal/lsp,
+  internal/rename, and cmd/mdsmith into
+  internal/mdtext, removing the three private
+  copies.
+model: ''
+depends-on: []
+---
+# Centralize UTF-16 column helpers in internal/mdtext
+
+## Goal
+
+Export three UTF-16 helpers from
+`internal/mdtext`:
+
+- `NonNegativeUTF16RuneLen`
+- `UTF16FromByteOffset`
+- `UTF16ToByteOffset`
+
+Remove the three private copies in
+`internal/lsp`, `internal/rename`, and
+`cmd/mdsmith`.
+
+## Tasks
+
+1. Add exported functions to
+   `internal/mdtext`:
+
+  - `NonNegativeUTF16RuneLen(r rune) int`
+  - `UTF16FromByteOffset(line []byte, byteOff int) int`
+  - `UTF16ToByteOffset(line []byte, target int) int`
+
+   Add unit tests for each in
+   `internal/mdtext/utf16_test.go`.
+
+2. Replace `nonNegativeUTF16RuneLen`
+   and `utf16FromByteOffset` in
+   `internal/lsp/diagnostics.go` with
+   calls to the new `mdtext` functions.
+   Update
+   `internal/lsp/server_test.go` to
+   remove its now-stale private test
+   of the helper.
+3. Replace `nonNegativeUTF16RuneLen`
+   and `utf16FromByteOffset` in
+   `internal/rename/rename.go` with
+   calls to the new `mdtext` functions.
+   Remove the private copy and its
+   test in
+   `internal/rename/helpers_test.go`.
+4. Replace `nonNegativeUTF16RuneLen`
+   and `utf16ToByteOffset` in
+   `cmd/mdsmith/rename.go` with calls
+   to `mdtext.NonNegativeUTF16RuneLen`
+   and `mdtext.UTF16ToByteOffset`.
+   Update `rename_unit_test.go` to
+   remove the now-stale private test.
+5. Run `go build ./...` and
+   `go test ./...` to confirm no
+   breakage.
+6. Run `go tool golangci-lint run` to
+   confirm no lint regressions.
+
+## Acceptance Criteria
+
+- [ ] `internal/mdtext` exports
+  `NonNegativeUTF16RuneLen`,
+  `UTF16FromByteOffset`, and
+  `UTF16ToByteOffset`, each with a
+  dedicated unit test.
+- [ ] No private copy of
+  `nonNegativeUTF16RuneLen`,
+  `utf16FromByteOffset`, or
+  `utf16ToByteOffset` remains in
+  `internal/lsp/`, `internal/rename/`,
+  or `cmd/mdsmith/`.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run`
+  reports no issues.


### PR DESCRIPTION
Supersedes #326, which was based on an older main and had a plan-ID collision (its plan/175 conflicts with main's `175_check-performance-gate.md`). This branch rebases the audit + plan on top of current main, renumbers the plan to **186**, and adds the implementation in one go.

## Summary

- Ran the SOLID architecture audit over range `7464d273..b5a6d72` (commits landing `internal/rename`, `internal/index` relocation, `mdsmith deps`, `mdsmith export`).
- Found one new **tax** violation: `nonNegativeUTF16RuneLen` privately copied in three packages.
- Appended findings to `docs/development/architecture-audit.md` and updated `audit-from` SHA to `b5a6d72`.
- Created `plan/186_arch-fix-utf16-centralize.md` (renumbered from 175).
- Implemented the plan in the same PR.

## Finding: UTF-16 helper triplicated (tax)

`nonNegativeUTF16RuneLen` (wraps `utf16.RuneLen` to clamp negative values) was a private copy in:

- `internal/lsp/diagnostics.go`
- `internal/rename/rename.go`
- `cmd/mdsmith/rename.go`

## Implementation (plan/186)

Exported from `internal/mdtext` with dedicated unit tests:

- `NonNegativeUTF16RuneLen(r rune) int`
- `UTF16FromByteOffset(line []byte, byteOff int) int`
- `UTF16ToByteOffset(line []byte, target int) int`

Removed the three private copies and rewired callers in `internal/lsp/{diagnostics,rename,symbols}.go`, `internal/rename/{rename,heading}.go`, and `cmd/mdsmith/rename.go`. Dropped the now-redundant tests in `internal/lsp/server_test.go`, `internal/rename/helpers_test.go`, and `cmd/mdsmith/rename_unit_test.go`.

`internal/lsp/byteOffsetFromUTF16` stays put — its surrogate-pair rounding (round down to the rune's starting byte, for LSP cursor semantics) differs from `UTF16ToByteOffset` (round up to the next codepoint boundary). The comment now documents the distinction so a future reader does not collapse them.

## Test plan

- [x] `go test ./...` passes
- [x] `go tool golangci-lint run` reports 0 issues
- [x] `mdsmith check .` passes (325 files, 0 failures)
- [x] All catalogs regenerated via `mdsmith fix`

https://claude.ai/code/session_01EvNiuNwQ679WM6VT8gJ63B


---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ2TkFNp6LUdzHoyZoevCy)_