### PR TITLE
Multiplex AST walk and parallelize intra-file rules

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -113,10 +113,10 @@ footer: |
 | 184 | ✅     | opus   | [Automate the cross-tool benchmark on merge to main and publish numbers to the assets branch](plan/184_release-benchmark-automation.md) |
 | 185 | 🔲     |        | [Expose extended-syntax parsers and the flavor model in pkg/markdown](plan/185_public-markdown-flavor-library.md)                       |
 | 186 | ✅     |        | [Centralize UTF-16 column helpers in internal/mdtext](plan/186_arch-fix-utf16-centralize.md)                                            |
-| 186 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/186_catalog-run-scoped-readcache.md)                                     |
 | 187 | ✅     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
 | 188 | 🔲     | opus   | [Regex-over-source rules — inventory and AST-resident replacements](plan/188_regex-vs-ast-inventory.md)                                 |
 | 189 | ✅     | opus   | [Finish the multiplex migration for pure per-node rules](plan/189_multiplex-finish.md)                                                  |
 | 190 | ✅     | opus   | [Intra-file rule parallelism for non-NodeChecker rules](plan/190_intra-file-rule-parallelism.md)                                        |
 | 191 | 🔲     | opus   | [Hand-rolled DFA for Punkt's `reAbbr` to skip regex backtracking](plan/191_punkt-reabbr-dfa.md)                                         |
+| 192 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/192_catalog-run-scoped-readcache.md)                                     |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -116,4 +116,6 @@ footer: |
 | 186 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/186_catalog-run-scoped-readcache.md)                                     |
 | 187 | ✅     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
 | 188 | 🔲     | opus   | [Regex-over-source rules — inventory and AST-resident replacements](plan/188_regex-vs-ast-inventory.md)                                 |
+| 189 | 🔳     | opus   | [Finish the multiplex migration for pure per-node rules](plan/189_multiplex-finish.md)                                                  |
+| 190 | 🔳     | opus   | [Intra-file rule parallelism for non-NodeChecker rules](plan/190_intra-file-rule-parallelism.md)                                        |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -118,4 +118,5 @@ footer: |
 | 188 | 🔲     | opus   | [Regex-over-source rules — inventory and AST-resident replacements](plan/188_regex-vs-ast-inventory.md)                                 |
 | 189 | ✅     | opus   | [Finish the multiplex migration for pure per-node rules](plan/189_multiplex-finish.md)                                                  |
 | 190 | ✅     | opus   | [Intra-file rule parallelism for non-NodeChecker rules](plan/190_intra-file-rule-parallelism.md)                                        |
+| 191 | 🔲     | opus   | [Hand-rolled DFA for Punkt's `reAbbr` to skip regex backtracking](plan/191_punkt-reabbr-dfa.md)                                         |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -116,6 +116,6 @@ footer: |
 | 186 | 🔲     | opus   | [Run-scoped read cache for catalog cross-host redundancy](plan/186_catalog-run-scoped-readcache.md)                                     |
 | 187 | ✅     | opus   | [Neutral-corpus engine lever — shared AST walk and Punkt cost](plan/187_neutral-corpus-engine-lever.md)                                 |
 | 188 | 🔲     | opus   | [Regex-over-source rules — inventory and AST-resident replacements](plan/188_regex-vs-ast-inventory.md)                                 |
-| 189 | 🔳     | opus   | [Finish the multiplex migration for pure per-node rules](plan/189_multiplex-finish.md)                                                  |
-| 190 | 🔳     | opus   | [Intra-file rule parallelism for non-NodeChecker rules](plan/190_intra-file-rule-parallelism.md)                                        |
+| 189 | ✅     | opus   | [Finish the multiplex migration for pure per-node rules](plan/189_multiplex-finish.md)                                                  |
+| 190 | ✅     | opus   | [Intra-file rule parallelism for non-NodeChecker rules](plan/190_intra-file-rule-parallelism.md)                                        |
 <?/catalog?>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,16 @@
+codecov:
+  notify:
+    # Wait for every CI workflow to finish before posting status
+    # checks. Without this, the per-file `codecov/changes` gate
+    # fires immediately when ANY coverage upload arrives — but
+    # the test job in ci.yml uploads its coverage report well
+    # after the codecov bot has already evaluated whatever was
+    # in its cache, so codecov/changes can report stale per-file
+    # numbers (and fail) on commits whose fresh coverage actually
+    # improves the gate. wait_for_ci removes the race by holding
+    # the status post until all uploads are in.
+    wait_for_ci: true
+
 coverage:
   status:
     project:

--- a/internal/engine/bench_test.go
+++ b/internal/engine/bench_test.go
@@ -49,6 +49,75 @@ func BenchmarkCheckCorpusLarge(b *testing.B) {
 	benchCheck(b, 600, checkCorpusLines, 12*time.Second)
 }
 
+// BenchmarkCheckCorpusFewFiles exercises the small-file-count path
+// that the intra-file rule parallelism (plan 190) is designed for:
+// a 5-file batch leaves most cores idle for the file-level pool, so
+// the inner pool fills the gap. The budget is generous because the
+// per-file cost dominates (~5 files = 5x the per-file fixed overhead
+// of Small, no scaling beyond that). Not part of the standing
+// budget gate.
+func BenchmarkCheckCorpusFewFiles(b *testing.B) {
+	benchCheck(b, 5, checkCorpusLines, 1*time.Second)
+}
+
+// BenchmarkCheckCorpusFewFilesNoIntraFile is the control variant for
+// the few-files benchmark with intra-file parallelism disabled. Run
+// alongside BenchmarkCheckCorpusFewFiles to measure how much the
+// inner pool saves when the outer pool already has worker headroom.
+// Manual benchmark only; not part of the standing CI gate.
+func BenchmarkCheckCorpusFewFilesNoIntraFile(b *testing.B) {
+	benchCheckCapped(b, 5, checkCorpusLines, 1*time.Second, 1)
+}
+
+func benchCheckCapped(b *testing.B, files, lines int, budget time.Duration, intraCap int) {
+	b.Helper()
+	if testing.Short() {
+		b.Skip("benchmark skipped in -short mode")
+	}
+
+	dir := b.TempDir()
+	paths := make([]string, 0, files)
+	for i := 0; i < files; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("doc%03d.md", i))
+		if err := os.WriteFile(p, []byte(buildCorpusDoc(i, lines, files)), 0o644); err != nil {
+			b.Fatalf("write corpus file: %v", err)
+		}
+		paths = append(paths, p)
+	}
+
+	cfg := config.Defaults()
+	newRunner := func() *engine.Runner {
+		return &engine.Runner{
+			Config:               cfg,
+			Rules:                rule.All(),
+			StripFrontMatter:     true,
+			RootDir:              dir,
+			SkipSourceContext:    true,
+			IntraFileConcurrency: intraCap,
+		}
+	}
+	_ = newRunner().Run(paths)
+
+	samples := make([]time.Duration, 0, b.N)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+		_ = newRunner().Run(paths)
+		samples = append(samples, time.Since(start))
+	}
+	b.StopTimer()
+
+	if len(samples) == 0 {
+		b.Skip("no samples — benchmark needs more iterations")
+	}
+	p95 := percentileDur(samples, 0.95)
+	b.ReportMetric(float64(p95.Milliseconds()), "p95_ms")
+	b.ReportMetric(float64(p95.Microseconds())/float64(files), "us_per_file")
+	if p95 > budget {
+		b.Fatalf("check p95 %v exceeds budget %v for %d-file corpus (cap=%d)", p95, budget, files, intraCap)
+	}
+}
+
 func benchCheck(b *testing.B, files, lines int, budget time.Duration) {
 	b.Helper()
 	if testing.Short() {

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -116,11 +116,14 @@ func checkRulesWithIntraFile(
 	return diags, errs
 }
 
-// classifyRules walks the rules list once, clones and configures each
-// enabled rule, and splits the result into per-rule slots. The slots
-// slice keeps every enabled rule in input order (so the final
-// concatenation is deterministic); the nodeCheckers slice is the
-// subset whose group will be filled by the shared walk.
+// classifyRules walks the rules list once, configures each enabled
+// rule via ConfigureRule (which clones and applies settings only
+// when cfg.Settings is non-nil and the rule is Configurable —
+// otherwise the worker's existing clone is reused as-is), and splits
+// the result into per-rule slots. The slots slice keeps every
+// enabled rule in input order (so the final concatenation is
+// deterministic); the nodeCheckers slice is the subset whose group
+// will be filled by the shared walk.
 func classifyRules(
 	rules []rule.Rule, effective map[string]config.RuleCfg,
 ) (slots []*ruleSlot, nodeCheckers []*ruleSlot, errs []error) {

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -44,53 +45,55 @@ func CheckRules(f *lint.File, rules []rule.Rule, effective map[string]config.Rul
 // and []string windows were the single largest object count on the
 // check gate (~315 MB / 3.8M objects, plan 175 profiling) and are
 // unused when the caller never renders SourceLines (the benchmark, and
-// machine output that omits them).
+// machine output that omits them). Defaults intra-file concurrency to
+// 1 (serial); callers that already resolved the cap use
+// checkRulesWithIntraFile directly.
 func checkRules(
 	f *lint.File,
 	rules []rule.Rule,
 	effective map[string]config.RuleCfg,
 	skipSourceContext bool,
 ) ([]lint.Diagnostic, []error) {
-	var diags []lint.Diagnostic
-	var errs []error
+	return checkRulesWithIntraFile(f, rules, effective, skipSourceContext, 1)
+}
 
-	// Each enabled rule contributes one contiguous diagnostic group,
-	// kept in rules order. Rules implementing rule.NodeChecker have
-	// their group filled by a single shared ast.Walk instead of each
-	// re-walking the whole tree (goldmark walkHelper was ~44%
-	// cumulative). Because every group is still placed in rules order
-	// and a NodeChecker's bucket is fed the identical pre-order node
-	// stream its own Check (rule.WalkNodes) would use, the combined
-	// slice is byte-identical to running every rule's Check
-	// sequentially — order-independent consumers see no change.
-	type ruleSlot struct {
-		nc    rule.NodeChecker
-		diags []lint.Diagnostic
-	}
-	var slots []*ruleSlot
-	var nodeCheckers []*ruleSlot
+// ruleSlot is one rule's diagnostic bucket. NodeCheckers append to
+// it from the shared walk; non-NodeCheckers fill it once via Check.
+// Slots are kept in rules order so the final concatenation reproduces
+// the sequential output exactly.
+type ruleSlot struct {
+	nc       rule.NodeChecker
+	check    rule.Rule // non-nil for non-NodeChecker slots
+	diags    []lint.Diagnostic
+	configed bool // skip filled if false (configure-failed entry)
+}
 
-	for _, rl := range rules {
-		cfg, ok := effective[rl.Name()]
-		if !ok || !cfg.Enabled {
-			continue
-		}
+// checkRulesWithIntraFile is the core implementation that accepts an
+// explicit intra-file concurrency cap. The lintFile path resolves the
+// cap once per Run (via resolveIntraFileWorkers) and passes it in here
+// so the per-file workers do not each query GOMAXPROCS.
+func checkRulesWithIntraFile(
+	f *lint.File,
+	rules []rule.Rule,
+	effective map[string]config.RuleCfg,
+	skipSourceContext bool,
+	intraFileCap int,
+) ([]lint.Diagnostic, []error) {
+	slots, nodeCheckers, errs := classifyRules(rules, effective)
 
-		checkRule, err := ConfigureRule(rl, cfg)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
+	// Run non-NodeChecker rules. With cap=1 the loop stays serial and
+	// matches the legacy code path byte-for-byte. With cap>1, slots
+	// run concurrently into their own buckets; rules order is
+	// preserved because the concatenation step reads `slots` in
+	// index order at the end.
+	runNonNodeCheckers(f, slots, intraFileCap)
 
-		if nc, ok := checkRule.(rule.NodeChecker); ok {
-			s := &ruleSlot{nc: nc}
-			slots = append(slots, s)
-			nodeCheckers = append(nodeCheckers, s)
-			continue
-		}
-		slots = append(slots, &ruleSlot{diags: checkRule.Check(f)})
-	}
-
+	// The shared walk runs after the goroutine workers join, so its
+	// node visitor and the rules running inside it never race for
+	// any per-rule state. NodeCheckers stay internally serial: one
+	// goroutine, one walk, one rule per node — fast enough that
+	// splitting per rule would lose the cache locality the multiplex
+	// just won.
 	if len(nodeCheckers) > 0 {
 		_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 			for _, s := range nodeCheckers {
@@ -100,6 +103,7 @@ func checkRules(
 		})
 	}
 
+	var diags []lint.Diagnostic
 	for _, s := range slots {
 		diags = append(diags, s.diags...)
 	}
@@ -110,6 +114,68 @@ func checkRules(
 		populateSourceContext(f, diags, 2)
 	}
 	return diags, errs
+}
+
+// classifyRules walks the rules list once, clones and configures each
+// enabled rule, and splits the result into per-rule slots. The slots
+// slice keeps every enabled rule in input order (so the final
+// concatenation is deterministic); the nodeCheckers slice is the
+// subset whose group will be filled by the shared walk.
+func classifyRules(
+	rules []rule.Rule, effective map[string]config.RuleCfg,
+) (slots []*ruleSlot, nodeCheckers []*ruleSlot, errs []error) {
+	for _, rl := range rules {
+		cfg, ok := effective[rl.Name()]
+		if !ok || !cfg.Enabled {
+			continue
+		}
+		checkRule, err := ConfigureRule(rl, cfg)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if nc, ok := checkRule.(rule.NodeChecker); ok {
+			s := &ruleSlot{nc: nc, configed: true}
+			slots = append(slots, s)
+			nodeCheckers = append(nodeCheckers, s)
+			continue
+		}
+		slots = append(slots, &ruleSlot{check: checkRule, configed: true})
+	}
+	return slots, nodeCheckers, errs
+}
+
+// runNonNodeCheckers fills the non-NodeChecker slots' diags fields.
+// With cap<=1, runs serially (matches pre-plan-190 behaviour). With
+// cap>1, runs slots concurrently bounded by a semaphore so no more
+// than cap rule.Check calls execute at the same time. Each goroutine
+// writes only to its own slot, so the result needs no lock — slots
+// are concatenated in rules order after the workers join.
+func runNonNodeCheckers(f *lint.File, slots []*ruleSlot, intraFileCap int) {
+	if intraFileCap <= 1 {
+		for _, s := range slots {
+			if s.check == nil {
+				continue
+			}
+			s.diags = s.check.Check(f)
+		}
+		return
+	}
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, intraFileCap)
+	for _, s := range slots {
+		if s.check == nil {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(slot *ruleSlot) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			slot.diags = slot.check.Check(f)
+		}(s)
+	}
+	wg.Wait()
 }
 
 // filterGeneratedDiags removes diagnostics whose line falls within any

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -60,12 +60,12 @@ func checkRules(
 // ruleSlot is one rule's diagnostic bucket. NodeCheckers append to
 // it from the shared walk; non-NodeCheckers fill it once via Check.
 // Slots are kept in rules order so the final concatenation reproduces
-// the sequential output exactly.
+// the sequential output exactly. Configure-failed rules never get a
+// slot — they short-circuit in classifyRules with an entry in errs.
 type ruleSlot struct {
-	nc       rule.NodeChecker
-	check    rule.Rule // non-nil for non-NodeChecker slots
-	diags    []lint.Diagnostic
-	configed bool // skip filled if false (configure-failed entry)
+	nc    rule.NodeChecker
+	check rule.Rule // non-nil for non-NodeChecker slots
+	diags []lint.Diagnostic
 }
 
 // checkRulesWithIntraFile is the core implementation that accepts an
@@ -135,12 +135,12 @@ func classifyRules(
 			continue
 		}
 		if nc, ok := checkRule.(rule.NodeChecker); ok {
-			s := &ruleSlot{nc: nc, configed: true}
+			s := &ruleSlot{nc: nc}
 			slots = append(slots, s)
 			nodeCheckers = append(nodeCheckers, s)
 			continue
 		}
-		slots = append(slots, &ruleSlot{check: checkRule, configed: true})
+		slots = append(slots, &ruleSlot{check: checkRule})
 	}
 	return slots, nodeCheckers, errs
 }

--- a/internal/engine/intrafile_test.go
+++ b/internal/engine/intrafile_test.go
@@ -1,0 +1,263 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slowRule sleeps inside Check so the test can observe concurrency.
+// It also records the maximum observed concurrency via an atomic
+// counter, so the "honors cap" test can verify the cap was not
+// exceeded. emitAtCol differentiates diagnostics from sibling
+// instances so order assertions can match a specific instance.
+type slowRule struct {
+	id, name  string
+	sleep     time.Duration
+	current   *atomic.Int32
+	peak      *atomic.Int32
+	emitAtCol int
+}
+
+func (s *slowRule) ID() string       { return s.id }
+func (s *slowRule) Name() string     { return s.name }
+func (s *slowRule) Category() string { return "test" }
+func (s *slowRule) Check(f *lint.File) []lint.Diagnostic {
+	if s.current != nil {
+		c := s.current.Add(1)
+		for {
+			peak := s.peak.Load()
+			if c <= peak {
+				break
+			}
+			if s.peak.CompareAndSwap(peak, c) {
+				break
+			}
+		}
+		defer s.current.Add(-1)
+	}
+	if s.sleep > 0 {
+		time.Sleep(s.sleep)
+	}
+	col := s.emitAtCol
+	if col == 0 {
+		col = 1
+	}
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     1,
+		Column:   col,
+		RuleID:   s.id,
+		RuleName: s.name,
+		Severity: lint.Warning,
+		Message:  s.name + " says hello",
+	}}
+}
+
+// TestCheckRules_ParallelEqualsSequential pins that running the
+// non-NodeChecker slots concurrently produces a byte-identical
+// diagnostic slice to the serial path.
+func TestCheckRules_ParallelEqualsSequential(t *testing.T) {
+	src := []byte("# Hello\n\nA paragraph.\n")
+	f1, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+	f2, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+
+	rules := []rule.Rule{
+		&mockRule{id: "MDA", name: "rule-a"},
+		&mockRule{id: "MDB", name: "rule-b"},
+		&mockRule{id: "MDC", name: "rule-c"},
+	}
+	eff := map[string]config.RuleCfg{
+		"rule-a": {Enabled: true},
+		"rule-b": {Enabled: true},
+		"rule-c": {Enabled: true},
+	}
+
+	seq, errs1 := checkRulesWithIntraFile(f1, rules, eff, true, 1)
+	par, errs2 := checkRulesWithIntraFile(f2, rules, eff, true, 4)
+
+	require.Empty(t, errs1)
+	require.Empty(t, errs2)
+	assert.Equal(t, seq, par,
+		"parallel intra-file dispatch must be byte-identical to sequential")
+}
+
+// TestCheckRules_ParallelRespectsRulesOrder pins that diagnostic
+// groups emerge in rules order even though the goroutines that fill
+// them complete in arbitrary order. The slow first rule would emit
+// last under any goroutine-finish-order scheme, so passing this test
+// requires the engine to write to a per-slot index and concatenate
+// at the end.
+func TestCheckRules_ParallelRespectsRulesOrder(t *testing.T) {
+	src := []byte("# Hello\n")
+	f, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+
+	slow := &slowRule{id: "MDS", name: "slow", sleep: 30 * time.Millisecond}
+	fast := &mockRule{id: "MDF", name: "fast"}
+	rules := []rule.Rule{slow, fast}
+	eff := map[string]config.RuleCfg{
+		"slow": {Enabled: true},
+		"fast": {Enabled: true},
+	}
+
+	diags, errs := checkRulesWithIntraFile(f, rules, eff, true, 4)
+	require.Empty(t, errs)
+	require.Len(t, diags, 2)
+	assert.Equal(t, "MDS", diags[0].RuleID, "slow rule's group should come first (rules order)")
+	assert.Equal(t, "MDF", diags[1].RuleID, "fast rule's group should come second")
+}
+
+// TestCheckRules_ParallelHonorsCap pins that no more than `cap`
+// rule.Check calls run concurrently at any moment. Each slow rule
+// increments a shared counter on entry and decrements on exit; a
+// shared peak watermark records the maximum it ever held.
+func TestCheckRules_ParallelHonorsCap(t *testing.T) {
+	const limit = 2
+	src := []byte("# Hello\n")
+	f, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+
+	var current, peak atomic.Int32
+	rules := []rule.Rule{
+		&slowRule{id: "S1", name: "s1", sleep: 30 * time.Millisecond, current: &current, peak: &peak, emitAtCol: 1},
+		&slowRule{id: "S2", name: "s2", sleep: 30 * time.Millisecond, current: &current, peak: &peak, emitAtCol: 2},
+		&slowRule{id: "S3", name: "s3", sleep: 30 * time.Millisecond, current: &current, peak: &peak, emitAtCol: 3},
+		&slowRule{id: "S4", name: "s4", sleep: 30 * time.Millisecond, current: &current, peak: &peak, emitAtCol: 4},
+		&slowRule{id: "S5", name: "s5", sleep: 30 * time.Millisecond, current: &current, peak: &peak, emitAtCol: 5},
+	}
+	eff := map[string]config.RuleCfg{
+		"s1": {Enabled: true},
+		"s2": {Enabled: true},
+		"s3": {Enabled: true},
+		"s4": {Enabled: true},
+		"s5": {Enabled: true},
+	}
+
+	diags, errs := checkRulesWithIntraFile(f, rules, eff, true, limit)
+	require.Empty(t, errs)
+	require.Len(t, diags, 5)
+	assert.LessOrEqual(t, int(peak.Load()), limit, "peak concurrency must not exceed cap=%d", limit)
+}
+
+// TestCheckRules_ParallelCapOne forces serial dispatch even when the
+// caller passes cap=1, matching the documented "1 = disabled" knob.
+func TestCheckRules_ParallelCapOne(t *testing.T) {
+	src := []byte("# Hello\n")
+	f, err := lint.NewFile("doc.md", src)
+	require.NoError(t, err)
+
+	var current, peak atomic.Int32
+	rules := []rule.Rule{
+		&slowRule{id: "S1", name: "s1", sleep: 5 * time.Millisecond, current: &current, peak: &peak},
+		&slowRule{id: "S2", name: "s2", sleep: 5 * time.Millisecond, current: &current, peak: &peak},
+		&slowRule{id: "S3", name: "s3", sleep: 5 * time.Millisecond, current: &current, peak: &peak},
+	}
+	eff := map[string]config.RuleCfg{
+		"s1": {Enabled: true},
+		"s2": {Enabled: true},
+		"s3": {Enabled: true},
+	}
+
+	diags, errs := checkRulesWithIntraFile(f, rules, eff, true, 1)
+	require.Empty(t, errs)
+	require.Len(t, diags, 3)
+	assert.Equal(t, int32(1), peak.Load(), "cap=1 must hold concurrency to 1")
+}
+
+// TestResolveIntraFileWorkers covers the auto-cap formula and the
+// explicit-knob overrides.
+func TestResolveIntraFileWorkers(t *testing.T) {
+	cases := []struct {
+		name      string
+		setting   int
+		gomaxproc int
+		fileWk    int
+		want      int
+	}{
+		{"explicit-1-is-off", 1, 16, 4, 1},
+		{"explicit-n-passthrough", 3, 16, 4, 3},
+		{"auto-with-headroom", 0, 16, 4, 4}, // 16/4=4
+		{"auto-no-headroom", 0, 16, 16, 1},  // 16/16=1
+		{"auto-tight", 0, 8, 3, 2},          // 8/3=2 (integer div)
+		{"auto-single-worker", 0, 8, 1, 8},  // 8/1=8
+		{"auto-zero-workers", 0, 8, 0, 8},   // guard against div0
+		{"auto-negative-workers", 0, 8, -1, 8},
+		{"auto-negative-gomaxproc", 0, 0, 4, 1}, // floor at 1
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveIntraFileWorkersFor(tc.setting, tc.gomaxproc, tc.fileWk)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRunner_IntraFileConcurrencyByteIdentical pins that diagnostic
+// output through Runner.Run is identical regardless of the
+// IntraFileConcurrency knob value, over a multi-file corpus that
+// exercises the production rule set. All three runs share one temp
+// dir so the absolute paths in d.File match byte-for-byte.
+func TestRunner_IntraFileConcurrencyByteIdentical(t *testing.T) {
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"## Section",
+		"",
+		"Paragraph one with a link <https://example.com> here.",
+		"",
+		"- item 1",
+		"- item 2",
+		"",
+		"```",
+		"unlanguaged",
+		"```",
+		"",
+	}, "\n")
+
+	files := map[string]string{
+		"a.md": src,
+		"b.md": src + "\n## Extra\n",
+		"c.md": src + "\n\n![](x.png)\n",
+	}
+	cfg := config.Defaults()
+	dir := t.TempDir()
+	var paths []string
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	run := func(intraCap int) []lint.Diagnostic {
+		runner := &Runner{
+			Config:               cfg,
+			Rules:                rule.All(),
+			StripFrontMatter:     true,
+			RootDir:              dir,
+			SkipSourceContext:    true,
+			IntraFileConcurrency: intraCap,
+		}
+		return runner.Run(paths).Diagnostics
+	}
+
+	lint1 := run(0)
+	lint2 := run(1)
+	lint3 := run(4)
+
+	assert.Equal(t, lint1, lint2, "auto vs cap=1 must produce identical diagnostics")
+	assert.Equal(t, lint1, lint3, "auto vs cap=4 must produce identical diagnostics")
+}

--- a/internal/engine/multiplex_test.go
+++ b/internal/engine/multiplex_test.go
@@ -211,7 +211,7 @@ var migratedRuleEquivalenceCorpus = []byte(strings.Join([]string{
 	"",
 	"A code span with `  spaces  ` inside.",
 	"",
-	"A heading with trailing period.",
+	"# A heading with trailing period.",
 	"",
 	"#### A jumped heading",
 	"",

--- a/internal/engine/multiplex_test.go
+++ b/internal/engine/multiplex_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/config"
@@ -9,6 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark/ast"
+
+	// Force-load every production rule registration so the
+	// migrated-equivalence test can look rules up by name. The
+	// engine package itself never imports rules — only tests need
+	// this — so the blank import lives here.
+	_ "github.com/jeduden/mdsmith/internal/rules/all"
 )
 
 // mockNodeChecker implements rule.NodeChecker, emitting one
@@ -116,4 +123,136 @@ func TestCheckRules_MultipleNodeCheckersShareOneWalk(t *testing.T) {
 	assert.Equal(t, "AAA", diags[1].RuleID)
 	assert.Equal(t, "BBB", diags[2].RuleID)
 	assert.Equal(t, "BBB", diags[3].RuleID)
+}
+
+// hiddenNodeChecker wraps a real NodeChecker as a plain rule.Rule so
+// the engine cannot fold it into the shared walk; its Check method
+// still runs the rule's full per-node logic via rule.WalkNodes. Used
+// to compute the pre-multiplex reference output for every migrated
+// rule with the exact code path users would hit pre-plan-189.
+type hiddenNodeChecker struct {
+	nc rule.NodeChecker
+}
+
+func (h hiddenNodeChecker) ID() string                           { return h.nc.ID() }
+func (h hiddenNodeChecker) Name() string                         { return h.nc.Name() }
+func (h hiddenNodeChecker) Category() string                     { return h.nc.Category() }
+func (h hiddenNodeChecker) Check(f *lint.File) []lint.Diagnostic { return h.nc.Check(f) }
+
+// TestCheckRules_MigratedRulesEqualSequential pins that every
+// migrated NodeChecker in the production rule set produces a
+// byte-identical diagnostic slice whether routed through the
+// multiplexed walk or the legacy per-rule path. Each rule is tested
+// in isolation so a failure points at exactly one rule.
+func TestCheckRules_MigratedRulesEqualSequential(t *testing.T) {
+	src := []byte(strings.Join([]string{
+		"# A heading",
+		"",
+		"## A sub-heading",
+		"",
+		"Some paragraph with a link to <https://example.com> and **bold**.",
+		"A bare URL: https://bare.example.com appears here.",
+		"",
+		"- item 1",
+		"- item 2",
+		"",
+		"1. one",
+		"2. two",
+		"",
+		"```",
+		"unlanguaged code",
+		"```",
+		"",
+		"```go",
+		"func main() {}",
+		"```",
+		"",
+		"---",
+		"",
+		"![](image.png)",
+		"![alt](img.png)",
+		"",
+		"[click here](https://x.example.com)",
+		"",
+		"<div>html</div>",
+		"",
+		"A code span with `  spaces  ` inside.",
+		"",
+		"A heading with trailing period.",
+		"",
+		"#### A jumped heading",
+		"",
+		"[TOC]",
+		"",
+	}, "\n"))
+
+	cases := []struct {
+		name  string
+		rules []rule.Rule
+	}{
+		{"MDS002", []rule.Rule{newRuleByName(t, "heading-style")}},
+		{"MDS010", []rule.Rule{newRuleByName(t, "fenced-code-style")}},
+		{"MDS011", []rule.Rule{newRuleByName(t, "fenced-code-language")}},
+		{"MDS012", []rule.Rule{newRuleByName(t, "no-bare-urls")}},
+		{"MDS013", []rule.Rule{newRuleByName(t, "blank-line-around-headings")}},
+		{"MDS014", []rule.Rule{newRuleByName(t, "blank-line-around-lists")}},
+		{"MDS015", []rule.Rule{newRuleByName(t, "blank-line-around-fenced-code")}},
+		{"MDS016", []rule.Rule{newRuleByName(t, "list-indent")}},
+		{"MDS017", []rule.Rule{newRuleByName(t, "no-trailing-punctuation-in-heading")}},
+		{"MDS018", []rule.Rule{newRuleByName(t, "no-emphasis-as-heading")}},
+		{"MDS031", []rule.Rule{newRuleByName(t, "unclosed-code-block")}},
+		{"MDS032", []rule.Rule{newRuleByName(t, "no-empty-alt-text")}},
+		{"MDS035", []rule.Rule{newRuleByName(t, "toc-directive")}},
+		{"MDS041", []rule.Rule{newRuleByName(t, "no-inline-html")}},
+		{"MDS042", []rule.Rule{newRuleByName(t, "emphasis-style")}},
+		{"MDS044", []rule.Rule{newRuleByName(t, "horizontal-rule-style")}},
+		{"MDS045", []rule.Rule{newRuleByName(t, "list-marker-style")}},
+		{"MDS046", []rule.Rule{newRuleByName(t, "ordered-list-numbering")}},
+		{"MDS049", []rule.Rule{newRuleByName(t, "no-space-in-link-text")}},
+		{"MDS052", []rule.Rule{newRuleByName(t, "no-space-in-code-spans")}},
+		{"MDS055", []rule.Rule{newRuleByName(t, "forbidden-paragraph-starts")}},
+		{"MDS056", []rule.Rule{newRuleByName(t, "forbidden-text")}},
+		{"MDS061", []rule.Rule{newRuleByName(t, "list-marker-space")}},
+		{"MDS063", []rule.Rule{newRuleByName(t, "descriptive-link-text")}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rl := tc.rules[0]
+			nc, ok := rl.(rule.NodeChecker)
+			require.True(t, ok, "%s expected to implement NodeChecker", rl.Name())
+
+			eff := map[string]config.RuleCfg{
+				rl.Name(): {Enabled: true},
+			}
+
+			f1, err := lint.NewFile("doc.md", src)
+			require.NoError(t, err)
+			f2, err := lint.NewFile("doc.md", src)
+			require.NoError(t, err)
+
+			seq, errs1 := checkRules(f1, []rule.Rule{hiddenNodeChecker{nc}}, eff, true)
+			mux, errs2 := checkRules(f2, []rule.Rule{rl}, eff, true)
+
+			require.Empty(t, errs1)
+			require.Empty(t, errs2)
+			assert.Equal(t, seq, mux,
+				"%s: multiplexed output must equal sequential", rl.Name())
+		})
+	}
+}
+
+// newRuleByName fetches a registered rule by its Name(). Each
+// production registration creates a stateless instance suitable for
+// tests; the cloning the engine does is per-Check, so there is no
+// risk of contaminating other tests.
+func newRuleByName(t *testing.T, name string) rule.Rule {
+	t.Helper()
+	for _, r := range rule.All() {
+		if r.Name() == name {
+			return rule.CloneInstance(r)
+		}
+	}
+	t.Fatalf("rule %q not registered", name)
+	return nil
 }

--- a/internal/engine/multiplex_test.go
+++ b/internal/engine/multiplex_test.go
@@ -139,105 +139,121 @@ func (h hiddenNodeChecker) Name() string                         { return h.nc.N
 func (h hiddenNodeChecker) Category() string                     { return h.nc.Category() }
 func (h hiddenNodeChecker) Check(f *lint.File) []lint.Diagnostic { return h.nc.Check(f) }
 
+// migratedRules lists every plan-189 NodeChecker rule by its
+// registered Name(). The byte-identity table-test below resolves
+// each one through the production registry, so adding a new
+// migration only requires appending a name here.
+var migratedRules = []struct {
+	id, name string
+}{
+	{"MDS002", "heading-style"},
+	{"MDS010", "fenced-code-style"},
+	{"MDS011", "fenced-code-language"},
+	{"MDS012", "no-bare-urls"},
+	{"MDS013", "blank-line-around-headings"},
+	{"MDS014", "blank-line-around-lists"},
+	{"MDS015", "blank-line-around-fenced-code"},
+	{"MDS016", "list-indent"},
+	{"MDS017", "no-trailing-punctuation-in-heading"},
+	{"MDS018", "no-emphasis-as-heading"},
+	{"MDS031", "unclosed-code-block"},
+	{"MDS032", "no-empty-alt-text"},
+	{"MDS035", "toc-directive"},
+	{"MDS041", "no-inline-html"},
+	{"MDS042", "emphasis-style"},
+	{"MDS044", "horizontal-rule-style"},
+	{"MDS045", "list-marker-style"},
+	{"MDS046", "ordered-list-numbering"},
+	{"MDS049", "no-space-in-link-text"},
+	{"MDS052", "no-space-in-code-spans"},
+	{"MDS055", "forbidden-paragraph-starts"},
+	{"MDS056", "forbidden-text"},
+	{"MDS061", "list-marker-space"},
+	{"MDS063", "descriptive-link-text"},
+}
+
+// migratedRuleEquivalenceCorpus is the representative document used
+// to exercise every migrated rule. It includes headings of varying
+// styles, both list flavours, fenced code blocks (with and without
+// languages), an HR, images, an HTML block, a code span with
+// surrounding whitespace, and a `[TOC]` line so the post-migration
+// rules each see at least one match.
+var migratedRuleEquivalenceCorpus = []byte(strings.Join([]string{
+	"# A heading",
+	"",
+	"## A sub-heading",
+	"",
+	"Some paragraph with a link to <https://example.com> and **bold**.",
+	"A bare URL: https://bare.example.com appears here.",
+	"",
+	"- item 1",
+	"- item 2",
+	"",
+	"1. one",
+	"2. two",
+	"",
+	"```",
+	"unlanguaged code",
+	"```",
+	"",
+	"```go",
+	"func main() {}",
+	"```",
+	"",
+	"---",
+	"",
+	"![](image.png)",
+	"![alt](img.png)",
+	"",
+	"[click here](https://x.example.com)",
+	"",
+	"<div>html</div>",
+	"",
+	"A code span with `  spaces  ` inside.",
+	"",
+	"A heading with trailing period.",
+	"",
+	"#### A jumped heading",
+	"",
+	"[TOC]",
+	"",
+}, "\n"))
+
+// assertMigratedRuleEquivalent runs one migrated rule against the
+// corpus twice — once with its NodeChecker capability hidden and
+// once exposed — and asserts byte-identity of the two diagnostic
+// slices.
+func assertMigratedRuleEquivalent(t *testing.T, name string) {
+	t.Helper()
+	rl := newRuleByName(t, name)
+	nc, ok := rl.(rule.NodeChecker)
+	require.True(t, ok, "%s expected to implement NodeChecker", rl.Name())
+
+	eff := map[string]config.RuleCfg{rl.Name(): {Enabled: true}}
+
+	f1, err := lint.NewFile("doc.md", migratedRuleEquivalenceCorpus)
+	require.NoError(t, err)
+	f2, err := lint.NewFile("doc.md", migratedRuleEquivalenceCorpus)
+	require.NoError(t, err)
+
+	seq, errs1 := checkRules(f1, []rule.Rule{hiddenNodeChecker{nc}}, eff, true)
+	mux, errs2 := checkRules(f2, []rule.Rule{rl}, eff, true)
+
+	require.Empty(t, errs1)
+	require.Empty(t, errs2)
+	assert.Equal(t, seq, mux,
+		"%s: multiplexed output must equal sequential", rl.Name())
+}
+
 // TestCheckRules_MigratedRulesEqualSequential pins that every
 // migrated NodeChecker in the production rule set produces a
 // byte-identical diagnostic slice whether routed through the
 // multiplexed walk or the legacy per-rule path. Each rule is tested
 // in isolation so a failure points at exactly one rule.
 func TestCheckRules_MigratedRulesEqualSequential(t *testing.T) {
-	src := []byte(strings.Join([]string{
-		"# A heading",
-		"",
-		"## A sub-heading",
-		"",
-		"Some paragraph with a link to <https://example.com> and **bold**.",
-		"A bare URL: https://bare.example.com appears here.",
-		"",
-		"- item 1",
-		"- item 2",
-		"",
-		"1. one",
-		"2. two",
-		"",
-		"```",
-		"unlanguaged code",
-		"```",
-		"",
-		"```go",
-		"func main() {}",
-		"```",
-		"",
-		"---",
-		"",
-		"![](image.png)",
-		"![alt](img.png)",
-		"",
-		"[click here](https://x.example.com)",
-		"",
-		"<div>html</div>",
-		"",
-		"A code span with `  spaces  ` inside.",
-		"",
-		"A heading with trailing period.",
-		"",
-		"#### A jumped heading",
-		"",
-		"[TOC]",
-		"",
-	}, "\n"))
-
-	cases := []struct {
-		name  string
-		rules []rule.Rule
-	}{
-		{"MDS002", []rule.Rule{newRuleByName(t, "heading-style")}},
-		{"MDS010", []rule.Rule{newRuleByName(t, "fenced-code-style")}},
-		{"MDS011", []rule.Rule{newRuleByName(t, "fenced-code-language")}},
-		{"MDS012", []rule.Rule{newRuleByName(t, "no-bare-urls")}},
-		{"MDS013", []rule.Rule{newRuleByName(t, "blank-line-around-headings")}},
-		{"MDS014", []rule.Rule{newRuleByName(t, "blank-line-around-lists")}},
-		{"MDS015", []rule.Rule{newRuleByName(t, "blank-line-around-fenced-code")}},
-		{"MDS016", []rule.Rule{newRuleByName(t, "list-indent")}},
-		{"MDS017", []rule.Rule{newRuleByName(t, "no-trailing-punctuation-in-heading")}},
-		{"MDS018", []rule.Rule{newRuleByName(t, "no-emphasis-as-heading")}},
-		{"MDS031", []rule.Rule{newRuleByName(t, "unclosed-code-block")}},
-		{"MDS032", []rule.Rule{newRuleByName(t, "no-empty-alt-text")}},
-		{"MDS035", []rule.Rule{newRuleByName(t, "toc-directive")}},
-		{"MDS041", []rule.Rule{newRuleByName(t, "no-inline-html")}},
-		{"MDS042", []rule.Rule{newRuleByName(t, "emphasis-style")}},
-		{"MDS044", []rule.Rule{newRuleByName(t, "horizontal-rule-style")}},
-		{"MDS045", []rule.Rule{newRuleByName(t, "list-marker-style")}},
-		{"MDS046", []rule.Rule{newRuleByName(t, "ordered-list-numbering")}},
-		{"MDS049", []rule.Rule{newRuleByName(t, "no-space-in-link-text")}},
-		{"MDS052", []rule.Rule{newRuleByName(t, "no-space-in-code-spans")}},
-		{"MDS055", []rule.Rule{newRuleByName(t, "forbidden-paragraph-starts")}},
-		{"MDS056", []rule.Rule{newRuleByName(t, "forbidden-text")}},
-		{"MDS061", []rule.Rule{newRuleByName(t, "list-marker-space")}},
-		{"MDS063", []rule.Rule{newRuleByName(t, "descriptive-link-text")}},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			rl := tc.rules[0]
-			nc, ok := rl.(rule.NodeChecker)
-			require.True(t, ok, "%s expected to implement NodeChecker", rl.Name())
-
-			eff := map[string]config.RuleCfg{
-				rl.Name(): {Enabled: true},
-			}
-
-			f1, err := lint.NewFile("doc.md", src)
-			require.NoError(t, err)
-			f2, err := lint.NewFile("doc.md", src)
-			require.NoError(t, err)
-
-			seq, errs1 := checkRules(f1, []rule.Rule{hiddenNodeChecker{nc}}, eff, true)
-			mux, errs2 := checkRules(f2, []rule.Rule{rl}, eff, true)
-
-			require.Empty(t, errs1)
-			require.Empty(t, errs2)
-			assert.Equal(t, seq, mux,
-				"%s: multiplexed output must equal sequential", rl.Name())
+	for _, tc := range migratedRules {
+		t.Run(tc.id, func(t *testing.T) {
+			assertMigratedRuleEquivalent(t, tc.name)
 		})
 	}
 }

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -63,6 +63,17 @@ type Runner struct {
 	// it only trades CPU for wall time. RunSource (single in-memory
 	// file) ignores this field.
 	Concurrency int
+	// IntraFileConcurrency caps how many non-NodeChecker rules run
+	// concurrently inside one file's checkRules call. The default
+	// (0 = auto) computes `max(1, GOMAXPROCS / fileWorkers)` so the
+	// inner pool fills whichever cores the outer file-level pool
+	// leaves idle: 1 when the file pool saturates cores (mdsmith
+	// check on many files), N when the file pool is small (a 5-file
+	// PR check on a 16-core host, mdsmith lsp single-file). A
+	// caller-set 1 forces serial dispatch; n>1 is taken as the
+	// explicit cap. RunSource uses GOMAXPROCS directly because the
+	// file-level pool does not run for single-file in-memory paths.
+	IntraFileConcurrency int
 	// gitignoreCache caches GitignoreMatchers by directory to avoid
 	// re-walking the filesystem for each file. gitignoreMu guards it
 	// because Run lints files on multiple goroutines and the
@@ -163,6 +174,38 @@ func ResolveWorkers(concurrency, n int) int {
 	return w
 }
 
+// resolveIntraFileWorkersFor maps the IntraFileConcurrency knob and
+// the live file-worker count to an effective concurrency cap for
+// non-NodeChecker rules inside one file. The auto path
+// (`setting <= 0`) computes `max(1, gomaxproc / max(1, fileWorkers))`
+// so the inner pool fills whichever cores the outer pool leaves
+// idle. Pulled out as a pure function so the table-test can pin the
+// formula without spinning up a Runner.
+func resolveIntraFileWorkersFor(setting, gomaxproc, fileWorkers int) int {
+	if setting == 1 {
+		return 1
+	}
+	if setting > 1 {
+		return setting
+	}
+	denom := fileWorkers
+	if denom <= 0 {
+		denom = 1
+	}
+	n := gomaxproc / denom
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// resolveIntraFileWorkers reads GOMAXPROCS once and forwards to the
+// pure helper. Callers should use this; the bare helper is exported
+// only for the test that pins the formula.
+func resolveIntraFileWorkers(setting, fileWorkers int) int {
+	return resolveIntraFileWorkersFor(setting, runtime.GOMAXPROCS(0), fileWorkers)
+}
+
 // runFiles lints work into a pre-sized, index-addressed slice. With one
 // worker it stays on the calling goroutine. With more, each worker
 // clones the rule set once (so rules carrying per-Check state — include's
@@ -170,12 +213,19 @@ func ResolveWorkers(concurrency, n int) int {
 // goroutine's instance) and pulls file indices off an atomic counter
 // for even load balancing. No worker writes a slot another reads, so
 // the result needs no lock.
+//
+// The per-file intra-file concurrency cap (see
+// Runner.IntraFileConcurrency) is resolved once here against the
+// outer worker count: when the file pool already saturates cores the
+// inner cap is 1 (no oversubscription); when only a handful of files
+// are linted, the inner cap grows to fill the gap.
 func (r *Runner) runFiles(work []string) []fileOutcome {
 	outcomes := make([]fileOutcome, len(work))
 	workers := ResolveWorkers(r.Concurrency, len(work))
+	intraCap := resolveIntraFileWorkers(r.IntraFileConcurrency, workers)
 	if workers <= 1 {
 		for i, path := range work {
-			outcomes[i] = r.lintFile(path, r.Rules)
+			outcomes[i] = r.lintFile(path, r.Rules, intraCap)
 		}
 		return outcomes
 	}
@@ -191,7 +241,7 @@ func (r *Runner) runFiles(work []string) []fileOutcome {
 				if i >= len(work) {
 					return
 				}
-				outcomes[i] = r.lintFile(work[i], rules)
+				outcomes[i] = r.lintFile(work[i], rules, intraCap)
 			}
 		}()
 	}
@@ -212,8 +262,10 @@ func cloneRules(rules []rule.Rule) []rule.Rule {
 // lintFile reads, parses, and checks a single file with the given rule
 // set (the worker's private clones) and returns its diagnostics and
 // errors. It touches no shared Runner state except the mutex-guarded
-// gitignore cache.
-func (r *Runner) lintFile(path string, rules []rule.Rule) (out fileOutcome) {
+// gitignore cache. intraFileCap controls how many non-NodeChecker
+// rules run concurrently for this one file — see runFiles for how
+// the cap is computed from Runner.IntraFileConcurrency.
+func (r *Runner) lintFile(path string, rules []rule.Rule, intraFileCap int) (out fileOutcome) {
 	// When verbose, log into a per-file buffer instead of the shared
 	// logger; Run flushes these in input order so concurrent workers
 	// don't interleave -v output. The named return + defer attaches
@@ -259,7 +311,7 @@ func (r *Runner) lintFile(path string, rules []rule.Rule) (out fileOutcome) {
 	mdRules := markdownRulesFrom(rules, r.ConfigPath)
 	logRulesTo(flog, mdRules, effective)
 
-	diags, errs := checkRules(f, mdRules, effective, r.SkipSourceContext)
+	diags, errs := checkRulesWithIntraFile(f, mdRules, effective, r.SkipSourceContext, intraFileCap)
 	if r.Explain {
 		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
@@ -398,22 +450,36 @@ func (r *Runner) RunSource(path string, source []byte) *Result {
 		return res
 	}
 
+	r.runSourceCheckRules(res, f, path, fmKinds, fmFields)
+	sortDiagnostics(res.Diagnostics)
+	return res
+}
+
+// runSourceCheckRules wraps the post-parse check pipeline for
+// RunSource: resolve the intra-file concurrency cap, run the rule
+// set, attach explanation provenance, and append diagnostics to res.
+// Split out so RunSource itself stays under the funlen cap.
+func (r *Runner) runSourceCheckRules(
+	res *Result, f *lint.File, path string,
+	fmKinds []string, fmFields map[string]any,
+) {
 	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
-
 	effective := r.effectiveWithCategories(path, fmKinds, fmFields)
-
 	mdRules := r.markdownRules()
 	r.logRules(mdRules, effective)
 
-	diags, errs := checkRules(f, mdRules, effective, r.SkipSourceContext)
+	// RunSource has no file-level pool to compete with, so the
+	// intra-file cap defaults to GOMAXPROCS (auto = pass 0 file
+	// workers, formula picks the full host). The explicit
+	// IntraFileConcurrency knob still overrides — set 1 to keep
+	// the LSP single-threaded for predictability.
+	intraFileCap := resolveIntraFileWorkers(r.IntraFileConcurrency, 0)
+	diags, errs := checkRulesWithIntraFile(f, mdRules, effective, r.SkipSourceContext, intraFileCap)
 	if r.Explain {
 		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
 	res.Diagnostics = append(res.Diagnostics, diags...)
 	res.Errors = append(res.Errors, errs...)
-
-	sortDiagnostics(res.Diagnostics)
-	return res
 }
 
 // markdownRules returns the subset of rules to run against individual Markdown

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -200,8 +200,9 @@ func resolveIntraFileWorkersFor(setting, gomaxproc, fileWorkers int) int {
 }
 
 // resolveIntraFileWorkers reads GOMAXPROCS once and forwards to the
-// pure helper. Callers should use this; the bare helper is exported
-// only for the test that pins the formula.
+// pure helper. Callers should use this; the bare helper is pulled out
+// as a pure function so a table-driven test can pin the formula
+// without faking the runtime.
 func resolveIntraFileWorkers(setting, fileWorkers int) int {
 	return resolveIntraFileWorkersFor(setting, runtime.GOMAXPROCS(0), fileWorkers)
 }

--- a/internal/engine/runner_helpers_test.go
+++ b/internal/engine/runner_helpers_test.go
@@ -126,7 +126,7 @@ func TestRunFiles_SequentialMatchesParallel(t *testing.T) {
 
 func TestLintFile_ReadErrorReturnsErrs(t *testing.T) {
 	r := &Runner{Config: &config.Config{}}
-	out := r.lintFile(filepath.Join(t.TempDir(), "missing.md"), nil)
+	out := r.lintFile(filepath.Join(t.TempDir(), "missing.md"), nil, 1)
 	assert.Empty(t, out.diags)
 	require.Len(t, out.errs, 1)
 	assert.Contains(t, out.errs[0].Error(), "reading")
@@ -140,7 +140,7 @@ func TestLintFile_HappyReturnsDiags(t *testing.T) {
 		Config: &config.Config{Rules: map[string]config.RuleCfg{"mock-rule": {Enabled: true}}},
 		Rules:  []rule.Rule{&mockRule{id: "MDS999", name: "mock-rule"}},
 	}
-	out := r.lintFile(p, r.Rules)
+	out := r.lintFile(p, r.Rules, 1)
 	require.Len(t, out.diags, 1)
 	assert.Empty(t, out.errs)
 	assert.Equal(t, p, out.diags[0].File)

--- a/internal/rule/walk.go
+++ b/internal/rule/walk.go
@@ -28,7 +28,13 @@ type NodeChecker interface {
 // NodeChecker's standalone Check delegates here so direct callers
 // (the LSP, unit tests) get behaviour identical to the engine's
 // multiplexed dispatch, which feeds CheckNode the same node stream.
+// Files with a nil AST short-circuit to no diagnostics; the engine
+// never produces such files, but unit tests construct
+// `&lint.File{}` literals to exercise rule guards.
 func WalkNodes(r NodeChecker, f *lint.File) []lint.Diagnostic {
+	if f == nil || f.AST == nil {
+		return nil
+	}
 	var diags []lint.Diagnostic
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		diags = append(diags, r.CheckNode(n, entering, f)...)

--- a/internal/rule/walk_test.go
+++ b/internal/rule/walk_test.go
@@ -86,3 +86,20 @@ func TestWalkNodes_EqualsManualWalk(t *testing.T) {
 
 	assert.Equal(t, manual, viaHelper)
 }
+
+// TestWalkNodes_NilFileAndNilAST pins the defensive nil guard:
+// unit-test stubs that construct `&lint.File{}` literals must not
+// crash WalkNodes. The engine path never produces such files (NewFile
+// always parses to a Document node), but rule tests build literals to
+// exercise short-circuits and would panic without the guard.
+func TestWalkNodes_NilFileAndNilAST(t *testing.T) {
+	stub := &nodeCheckerStub{}
+
+	// nil *lint.File — should return nil, not panic.
+	assert.Nil(t, WalkNodes(stub, nil))
+	assert.Empty(t, stub.visits, "no nodes visited when file is nil")
+
+	// non-nil File with nil AST — same.
+	assert.Nil(t, WalkNodes(stub, &lint.File{Path: "t.md"}))
+	assert.Empty(t, stub.visits, "no nodes visited when AST is nil")
+}

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -51,7 +51,7 @@ Punkt-segmented sentence. It is not a guess.
 A paragraph like "Dr. Smith met Mr. Jones at 3.14 p.m. on
 Jan. 5." is one sentence, not seven. Naive splitters
 disagree. Punkt is right. The rule reports what Punkt says.
-So `paragraph has too many sentences (5 > 6)` means five
+So `paragraph has too many sentences (8 > 6)` means eight,
 and `sentence too long (45 > 40 words): "..."` quotes the
 real over-long sentence.
 

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -24,7 +24,44 @@ Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 Markdown tables and code blocks are skipped.
 
+## Performance
+
+MDS024 is **opt-in**. It is the single most expensive default
+rule. The diagnostic needs exact sentence boundaries. The
+per-sentence word count and the over-long sentence preview both
+require them. mdsmith uses the trained Punkt sentence segmenter
+(`github.com/neurosnap/sentences`). On prose-heavy input Punkt is
+roughly 20% of mdsmith's wall time. The cost is the trained
+model's regex execution. The hot function is
+`english.MultiPunctWordAnnotation.tokenAnnotation`. It runs
+`reAbbr` and the token-type matchers with backtracking. The pass
+fires on every period-ending token.
+
+The cheap upper-bound guard in [the rule source](./) skips Punkt
+for paragraphs that provably cannot violate either limit. Short
+paragraphs cost zero. The 20% is paid by paragraphs past the
+guard. On prose-heavy input that is most of them.
+
+No faster Go segmenter matches Punkt. See [plan 187][p187]
+for the recorded negative. The harness at
+[`sentence_equivalence_test.go`][harness] gates any future
+candidate.
+
+[p187]: ../../../plan/187_neutral-corpus-engine-lever.md
+[harness]: ../../mdtext/sentence_equivalence_test.go
+
+Enable when you want the diagnostic. Skip when you don't.
+
 ## Config
+
+Enable with default thresholds:
+
+```yaml
+rules:
+  paragraph-structure: true
+```
+
+Enable with custom thresholds:
 
 ```yaml
 rules:
@@ -33,7 +70,7 @@ rules:
     max-words-per-sentence: 40
 ```
 
-Disable:
+Explicitly disable (matches the default):
 
 ```yaml
 rules:
@@ -89,7 +126,8 @@ Dogs bark. Cats meow. Birds sing. Fish swim. Frogs croak. Snakes hiss. Bees buzz
 - **ID**: MDS024
 - **Name**: `paragraph-structure`
 - **Status**: ready
-- **Default**: enabled, max-sentences: 6, max-words-per-sentence: 40
+- **Default**: disabled (opt-in; see Performance above).
+  When enabled: max-sentences: 6, max-words-per-sentence: 40
 - **Fixable**: no
 - **Implementation**:
   [source](./)

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -24,33 +24,105 @@ Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
 Markdown tables and code blocks are skipped.
 
+## How it works
+
+MDS024 has two execution paths. A constant-time
+**cheap-bounds guard** runs first. It proves a paragraph
+cannot violate either limit. If the proof succeeds, the rule
+returns. If not, the **exact path** runs the trained Punkt
+sentence segmenter. The two paths share one invariant. The
+guard skips Punkt only when the exact path would emit zero
+diagnostics. The combined behavior is fast-or-exact, never
+approximate.
+
+### Exact diagnostics
+
+When the rule fires, every number in the message is exact.
+
+The sentence count comes from the trained Punkt segmenter
+([`github.com/neurosnap/sentences`][punkt]). It classifies
+every `.`/`!`/`?` against abbreviation, decimal, ellipsis,
+and initial heuristics. It is not a regex-based count. The
+per-sentence word count is the exact word count of the
+Punkt-segmented sentence. It is not the paragraph total.
+The over-long-sentence preview is a slice of the actual
+Punkt-segmented sentence. It is not a guess.
+
+A paragraph like "Dr. Smith met Mr. Jones at 3.14 p.m. on
+Jan. 5." is one sentence, not seven. Naive splitters
+disagree. Punkt is right. The rule reports what Punkt says.
+So `paragraph has too many sentences (5 > 6)` means five
+and `sentence too long (45 > 40 words): "..."` quotes the
+real over-long sentence.
+
+[punkt]: https://github.com/neurosnap/sentences
+
+### Cheap-bounds guard
+
+The guard runs one allocation-free pass over the paragraph.
+It computes two bounds.
+
+- `sentenceUB = (count of `.`/`!`/`?`) + 1` — an upper
+  bound on Punkt's sentence count. Punkt only places
+  boundaries at `.`/`!`/`?` and always yields at least one
+  sentence. The bound is sound.
+- `paragraphWords` — the exact whitespace-delimited word
+  count for the whole paragraph. No single sentence has
+  more words than the paragraph. The total is an upper
+  bound on every sentence.
+
+When both bounds are within the limits, Punkt cannot
+fire. The rule returns early.
+[`TestCheapBounds_GuardIsSound`][guard-test] pins this
+invariant.
+
+Short paragraphs, single-sentence paragraphs, and
+lightly-punctuated paragraphs all clear the guard with
+zero allocations. They contribute zero Punkt cost.
+
+Placeholder masking runs before the guard. Configured
+placeholder tokens (`{body}`, `{var-token}`, etc.)
+collapse to neutral words. They never trip the cheap
+path.
+
+[guard-test]: ../paragraphstructure/rule_test.go
+
 ## Performance
 
-MDS024 is **opt-in**. It is the single most expensive default
-rule. The diagnostic needs exact sentence boundaries. The
-per-sentence word count and the over-long sentence preview both
-require them. mdsmith uses the trained Punkt sentence segmenter
-(`github.com/neurosnap/sentences`). On prose-heavy input Punkt is
-roughly 20% of mdsmith's wall time. The cost is the trained
-model's regex execution. The hot function is
-`english.MultiPunctWordAnnotation.tokenAnnotation`. It runs
-`reAbbr` and the token-type matchers with backtracking. The pass
-fires on every period-ending token.
+MDS024 is **opt-in** by default. It is the most expensive
+default rule when enabled. The exactness it guarantees
+comes from real segmentation work. The cheap path avoids
+that work. It cannot replace it.
 
-The cheap upper-bound guard in [the rule source](./) skips Punkt
-for paragraphs that provably cannot violate either limit. Short
-paragraphs cost zero. The 20% is paid by paragraphs past the
-guard. On prose-heavy input that is most of them.
+Most paragraphs in prose-heavy input fail the cheap-bounds
+guard. There Punkt is roughly 20% of mdsmith's wall time
+([plan 187][p187] records the CPU profile). The hot frame
+is `english.MultiPunctWordAnnotation.tokenAnnotation`. It
+runs `reAbbr` and the token-type matchers with
+backtracking on every period-ending token.
+`regexp.(*Regexp).tryBacktrack` alone is 13% flat / 24%
+cumulative of the segmenter's CPU.
 
-No faster Go segmenter matches Punkt. See [plan 187][p187]
-for the recorded negative. The harness at
-[`sentence_equivalence_test.go`][harness] gates any future
-candidate.
+No pure-Go Punkt-equivalent faster segmenter exists. The
+negative is recorded in
+[`sentence_equivalence_test.go`][harness]. The harness
+gates any future candidate. A focused optimization
+target — replacing `reAbbr` with a hand-rolled DFA scanner
+— is tracked in [plan 191][p191].
+
+The cheap-bounds guard bounds the cost. Only paragraphs
+that *provably might* violate pay. Documentation,
+code-heavy READMEs, and short-paragraph prose pay close
+to zero. Long prose paragraphs that already trip the
+limits pay full segmentation. That is what produces the
+exact diagnostic the rule promises.
+
+Enable when you want exact prose-structure diagnostics.
+Skip when you don't.
 
 [p187]: ../../../plan/187_neutral-corpus-engine-lever.md
+[p191]: ../../../plan/191_punkt-reabbr-dfa.md
 [harness]: ../../mdtext/sentence_equivalence_test.go
-
-Enable when you want the diagnostic. Skip when you don't.
 
 ## Config
 

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -62,7 +62,7 @@ real over-long sentence.
 The guard runs one allocation-free pass over the paragraph.
 It computes two bounds.
 
-- `sentenceUB = (count of `.`/`!`/`?`) + 1` — an upper
+- ``sentenceUB = (count of `.`/`!`/`?`) + 1`` — an upper
   bound on Punkt's sentence count. Punkt only places
   boundaries at `.`/`!`/`?` and always yields at least one
   sentence. The bound is sound.

--- a/internal/rules/blanklinearoundfencedcode/rule.go
+++ b/internal/rules/blanklinearoundfencedcode/rule.go
@@ -26,65 +26,70 @@ func (r *Rule) Name() string { return "blank-line-around-fenced-code" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "code" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-block logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	fcb, ok := n.(*ast.FencedCodeBlock)
+	if !ok {
+		return nil
+	}
+
+	openStart, openEnd := fencepos.OpenLineRange(f.Source, fcb)
+	closeStart, _ := fencepos.CloseLineRange(f.Source, fcb, openEnd)
+
+	openLine := f.LineOfOffset(openStart)
+	closeLine := f.LineOfOffset(closeStart)
+
 	var diags []lint.Diagnostic
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		fcb, ok := n.(*ast.FencedCodeBlock)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		openStart, openEnd := fencepos.OpenLineRange(f.Source, fcb)
-		closeStart, _ := fencepos.CloseLineRange(f.Source, fcb, openEnd)
-
-		openLine := f.LineOfOffset(openStart)
-		closeLine := f.LineOfOffset(closeStart)
-
-		// Check blank line before opening fence
-		if openLine > 1 {
-			prevLineIdx := openLine - 2 // 0-based index of the line before
-			if prevLineIdx >= 0 && prevLineIdx < len(f.Lines) {
-				if !isBlank(f.Lines[prevLineIdx]) {
-					diags = append(diags, lint.Diagnostic{
-						File:     f.Path,
-						Line:     openLine,
-						Column:   1,
-						RuleID:   r.ID(),
-						RuleName: r.Name(),
-						Severity: lint.Warning,
-						Message:  "fenced code block should be preceded by a blank line",
-					})
-				}
-			}
-		}
-
-		// Check blank line after closing fence
-		closeLineIdx := closeLine - 1 // 0-based index of closing fence line
-		nextLineIdx := closeLineIdx + 1
-		if nextLineIdx < len(f.Lines) {
-			if !isBlank(f.Lines[nextLineIdx]) {
+	// Check blank line before opening fence
+	if openLine > 1 {
+		prevLineIdx := openLine - 2 // 0-based index of the line before
+		if prevLineIdx >= 0 && prevLineIdx < len(f.Lines) {
+			if !isBlank(f.Lines[prevLineIdx]) {
 				diags = append(diags, lint.Diagnostic{
 					File:     f.Path,
-					Line:     closeLine,
+					Line:     openLine,
 					Column:   1,
 					RuleID:   r.ID(),
 					RuleName: r.Name(),
 					Severity: lint.Warning,
-					Message:  "fenced code block should be followed by a blank line",
+					Message:  "fenced code block should be preceded by a blank line",
 				})
 			}
 		}
+	}
 
-		return ast.WalkContinue, nil
-	})
-
+	// Check blank line after closing fence
+	closeLineIdx := closeLine - 1 // 0-based index of closing fence line
+	nextLineIdx := closeLineIdx + 1
+	if nextLineIdx < len(f.Lines) {
+		if !isBlank(f.Lines[nextLineIdx]) {
+			diags = append(diags, lint.Diagnostic{
+				File:     f.Path,
+				Line:     closeLine,
+				Column:   1,
+				RuleID:   r.ID(),
+				RuleName: r.Name(),
+				Severity: lint.Warning,
+				Message:  "fenced code block should be followed by a blank line",
+			})
+		}
+	}
 	return diags
 }
+
+var _ rule.NodeChecker = (*Rule)(nil)
 
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {

--- a/internal/rules/blanklinearoundheadings/rule.go
+++ b/internal/rules/blanklinearoundheadings/rule.go
@@ -25,52 +25,45 @@ func (r *Rule) Name() string { return "blank-line-around-headings" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "heading" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-heading logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker. Code-line lookup runs lazily
+// via lint.CollectCodeBlockLines (cached on f); the rule cannot
+// precompute it once per Check because the engine multiplexes
+// CheckNode calls, but the cache makes it a single walk per file
+// across all callers.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	heading, ok := n.(*ast.Heading)
+	if !ok {
+		return nil
+	}
+
+	line := astutil.HeadingLine(heading, f)
+
+	// Skip headings whose lines overlap with code block regions.
 	codeLines := lint.CollectCodeBlockLines(f)
+	if codeLines[line] {
+		return nil
+	}
+	lastLine := headingLastLine(heading, f)
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		heading, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
+	var diags []lint.Diagnostic
 
-		line := astutil.HeadingLine(heading, f)
-
-		// Skip headings whose lines overlap with code block regions.
-		if codeLines[line] {
-			return ast.WalkContinue, nil
-		}
-		lastLine := headingLastLine(heading, f)
-
-		// Check blank line before (not needed for line 1)
-		if line > 1 {
-			prevLineIdx := line - 2 // 0-based index
-			if prevLineIdx >= 0 && prevLineIdx < len(f.Lines) {
-				prevLine := strings.TrimSpace(string(f.Lines[prevLineIdx]))
-				if prevLine != "" {
-					diags = append(diags, lint.Diagnostic{
-						File:     f.Path,
-						Line:     line,
-						Column:   1,
-						RuleID:   r.ID(),
-						RuleName: r.Name(),
-						Severity: lint.Warning,
-						Message:  "heading should have a blank line before",
-					})
-				}
-			}
-		}
-
-		// Check blank line after (not needed for last line)
-		nextLineIdx := lastLine // 0-based index of line after heading
-		if nextLineIdx < len(f.Lines) {
-			nextLine := strings.TrimSpace(string(f.Lines[nextLineIdx]))
-			if nextLine != "" {
+	// Check blank line before (not needed for line 1)
+	if line > 1 {
+		prevLineIdx := line - 2 // 0-based index
+		if prevLineIdx >= 0 && prevLineIdx < len(f.Lines) {
+			prevLine := strings.TrimSpace(string(f.Lines[prevLineIdx]))
+			if prevLine != "" {
 				diags = append(diags, lint.Diagnostic{
 					File:     f.Path,
 					Line:     line,
@@ -78,14 +71,28 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 					RuleID:   r.ID(),
 					RuleName: r.Name(),
 					Severity: lint.Warning,
-					Message:  "heading should have a blank line after",
+					Message:  "heading should have a blank line before",
 				})
 			}
 		}
+	}
 
-		return ast.WalkContinue, nil
-	})
-
+	// Check blank line after (not needed for last line)
+	nextLineIdx := lastLine // 0-based index of line after heading
+	if nextLineIdx < len(f.Lines) {
+		nextLine := strings.TrimSpace(string(f.Lines[nextLineIdx]))
+		if nextLine != "" {
+			diags = append(diags, lint.Diagnostic{
+				File:     f.Path,
+				Line:     line,
+				Column:   1,
+				RuleID:   r.ID(),
+				RuleName: r.Name(),
+				Severity: lint.Warning,
+				Message:  "heading should have a blank line after",
+			})
+		}
+	}
 	return diags
 }
 
@@ -205,3 +212,4 @@ func isSetextHeading(heading *ast.Heading, source []byte) bool {
 }
 
 var _ rule.FixableRule = (*Rule)(nil)
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/blanklinearoundheadings/rule_test.go
+++ b/internal/rules/blanklinearoundheadings/rule_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 func TestCheck_ProperBlankLines_NoViolation(t *testing.T) {
@@ -127,4 +129,65 @@ func TestFix_HeadingInsideCodeBlock_NoCorruption(t *testing.T) {
 	if string(result) != string(src) {
 		t.Errorf("fix corrupted code block content:\nexpected: %q\ngot:      %q", string(src), string(result))
 	}
+}
+
+// synthCodeAndHeadingFile builds a *lint.File whose AST has a
+// FencedCodeBlock covering one source-line range AND a Heading
+// whose Lines() segment falls inside that same range. Goldmark's
+// parser will never produce this from real Markdown — headings
+// and code blocks are mutually exclusive at the parse-line level
+// — but the defensive `if codeLines[line] { return nil }` guard
+// in CheckNode and collectHeadingBlankLineInsertions exists for
+// AST shapes built directly (this test, or any future parser
+// behaviour change). Drive both branches red/green here.
+func synthCodeAndHeadingFile(t *testing.T) *lint.File {
+	t.Helper()
+	// Source layout (offsets):
+	//   "```\n"        offsets [ 0,  4) line 1
+	//   "code\n"       offsets [ 4,  9) line 2
+	//   "```\n"        offsets [ 9, 13) line 3
+	src := []byte("```\ncode\n```\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+
+	doc := ast.NewDocument()
+	fenced := ast.NewFencedCodeBlock(nil)
+	fenced.Lines().Append(text.NewSegment(4, 8)) // "code" on line 2
+	doc.AppendChild(doc, fenced)
+
+	// Synthetic heading whose segment starts at offset 4 — line 2
+	// — which lint.CollectCodeBlockLines will also report.
+	heading := ast.NewHeading(1)
+	heading.Lines().Append(text.NewSegment(4, 8))
+	doc.AppendChild(doc, heading)
+
+	f.AST = doc
+	return f
+}
+
+// TestCheckNode_HeadingInCodeBlockRegion pins the `if
+// codeLines[line] { return nil }` guard in CheckNode (rule.go
+// line ~54).
+func TestCheckNode_HeadingInCodeBlockRegion(t *testing.T) {
+	f := synthCodeAndHeadingFile(t)
+	var heading *ast.Heading
+	for c := f.AST.FirstChild(); c != nil; c = c.NextSibling() {
+		if h, ok := c.(*ast.Heading); ok {
+			heading = h
+			break
+		}
+	}
+	require.NotNil(t, heading)
+	diags := (&Rule{}).CheckNode(heading, true, f)
+	assert.Nil(t, diags, "heading whose line falls inside a code-block region must be skipped")
+}
+
+// TestFix_HeadingInCodeBlockRegion pins the parallel guard
+// inside collectHeadingBlankLineInsertions (rule.go line ~153):
+// Fix must not insert blank lines around a synthetic heading
+// whose line collides with a code block.
+func TestFix_HeadingInCodeBlockRegion(t *testing.T) {
+	f := synthCodeAndHeadingFile(t)
+	got := (&Rule{}).Fix(f)
+	assert.Equal(t, f.Source, got, "Fix must not touch a heading whose line is inside a code-block region")
 }

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -24,44 +24,46 @@ func (r *Rule) Name() string { return "blank-line-around-lists" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "list" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-list logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	list, ok := n.(*ast.List)
+	if !ok {
+		return nil
+	}
+	if _, isListItem := list.Parent().(*ast.ListItem); isListItem {
+		return nil
+	}
+
+	listStartLine := lineOfNode(f, list)
+	listEndLine := lastLineOfNode(f, list)
+
 	codeLines := lint.CollectCodeBlockLines(f)
+	if codeLines[listStartLine] || codeLines[listEndLine] {
+		return nil
+	}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-
-		list, ok := n.(*ast.List)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		if _, isListItem := list.Parent().(*ast.ListItem); isListItem {
-			return ast.WalkContinue, nil
-		}
-
-		listStartLine := lineOfNode(f, list)
-		listEndLine := lastLineOfNode(f, list)
-
-		if codeLines[listStartLine] || codeLines[listEndLine] {
-			return ast.WalkContinue, nil
-		}
-
-		if d, ok := r.checkAdjacentBlank(f, listStartLine, -1, "list should be preceded by a blank line"); ok {
-			diags = append(diags, d)
-		}
-		if d, ok := r.checkAdjacentBlank(f, listEndLine, +1, "list should be followed by a blank line"); ok {
-			diags = append(diags, d)
-		}
-
-		return ast.WalkContinue, nil
-	})
-
+	var diags []lint.Diagnostic
+	if d, ok := r.checkAdjacentBlank(f, listStartLine, -1, "list should be preceded by a blank line"); ok {
+		diags = append(diags, d)
+	}
+	if d, ok := r.checkAdjacentBlank(f, listEndLine, +1, "list should be followed by a blank line"); ok {
+		diags = append(diags, d)
+	}
 	return diags
 }
+
+var _ rule.NodeChecker = (*Rule)(nil)
 
 // checkAdjacentBlank checks whether the line adjacent to targetLine (offset -1 for before,
 // +1 for after) is non-blank and returns a diagnostic if so.

--- a/internal/rules/descriptivelinktext/rule.go
+++ b/internal/rules/descriptivelinktext/rule.go
@@ -20,6 +20,15 @@ func init() {
 // "click here", "here", "link", or "more".
 type Rule struct {
 	Banned []string
+
+	// bannedSet is the lookup form of Banned. Built lazily on first
+	// CheckNode call to keep the cost off per-node hot paths under the
+	// multiplexed AST walk (was rebuilt per link node, which on
+	// link-heavy docs was an allocation per node). The rule clone is
+	// per-Check on the configured path and per-worker on the
+	// defaults-only path; in both cases Banned is immutable for the
+	// lifetime of this clone, so the cache stays correct.
+	bannedSet map[string]bool
 }
 
 // ID implements rule.Rule.
@@ -83,19 +92,15 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		return nil
 	}
 
-	// Banned-set construction is cheap, but doing it per node is wasteful
-	// when there are many links. The set is per-rule-config (Banned),
-	// so memoise on r.banned only when r.Banned hasn't changed. For
-	// simplicity and correctness — and because rule clones are per
-	// Check (so a fresh slice maps to a fresh check pass) — just build
-	// it inline per call. The work is bounded by len(Banned) ~ <10.
-	bannedSet := make(map[string]bool, len(r.Banned))
-	for _, b := range r.Banned {
-		bannedSet[normalizeText(b)] = true
+	if r.bannedSet == nil {
+		r.bannedSet = make(map[string]bool, len(r.Banned))
+		for _, b := range r.Banned {
+			r.bannedSet[normalizeText(b)] = true
+		}
 	}
 
 	text := collectLinkText(link, f.Source)
-	if !bannedSet[normalizeText(text)] {
+	if !r.bannedSet[normalizeText(text)] {
 		return nil
 	}
 	line := linkLine(link, f)

--- a/internal/rules/descriptivelinktext/rule.go
+++ b/internal/rules/descriptivelinktext/rule.go
@@ -54,6 +54,9 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 				return fmt.Errorf("descriptive-link-text: banned must be a list of strings, got %T", v)
 			}
 			r.Banned = ss
+			// Banned changed; drop the cached lookup so cachedBannedSet
+			// rebuilds from the new slice on the next visit.
+			r.bannedSet = nil
 		default:
 			return fmt.Errorf("descriptive-link-text: unknown setting %q", k)
 		}

--- a/internal/rules/descriptivelinktext/rule.go
+++ b/internal/rules/descriptivelinktext/rule.go
@@ -59,48 +59,55 @@ func (r *Rule) DefaultSettings() map[string]any {
 	}
 }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-link logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
 	if len(r.Banned) == 0 {
 		return nil
 	}
+	link, ok := n.(*ast.Link)
+	if !ok {
+		return nil
+	}
+	if isOnlyImageChild(link) || isOnlyCodeSpanChild(link) {
+		return nil
+	}
 
+	// Banned-set construction is cheap, but doing it per node is wasteful
+	// when there are many links. The set is per-rule-config (Banned),
+	// so memoise on r.banned only when r.Banned hasn't changed. For
+	// simplicity and correctness — and because rule clones are per
+	// Check (so a fresh slice maps to a fresh check pass) — just build
+	// it inline per call. The work is bounded by len(Banned) ~ <10.
 	bannedSet := make(map[string]bool, len(r.Banned))
 	for _, b := range r.Banned {
 		bannedSet[normalizeText(b)] = true
 	}
 
-	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		link, ok := n.(*ast.Link)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		if isOnlyImageChild(link) || isOnlyCodeSpanChild(link) {
-			return ast.WalkContinue, nil
-		}
-
-		text := collectLinkText(link, f.Source)
-		if bannedSet[normalizeText(text)] {
-			line := linkLine(link, f)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  fmt.Sprintf("link text %q is not descriptive", text),
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-	return diags
+	text := collectLinkText(link, f.Source)
+	if !bannedSet[normalizeText(text)] {
+		return nil
+	}
+	line := linkLine(link, f)
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     line,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  fmt.Sprintf("link text %q is not descriptive", text),
+	}}
 }
 
 // normalizeText trims, lowercases, and collapses internal whitespace.
@@ -159,4 +166,5 @@ func linkLine(link *ast.Link, f *lint.File) int {
 var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/descriptivelinktext/rule.go
+++ b/internal/rules/descriptivelinktext/rule.go
@@ -18,17 +18,16 @@ func init() {
 
 // Rule flags links whose visible text is a non-descriptive phrase such as
 // "click here", "here", "link", or "more".
+//
+// The lookup form of Banned is memoised on the per-Check *lint.File
+// via File.Memo (see cachedBannedSet) rather than on the rule
+// instance. Rule instances are shared across concurrent LSP calls
+// (cmd/mdsmith/lsp.go reuses rule.All(), and ConfigureRule does
+// not clone when cfg.Settings is nil), so any mutable state on the
+// rule itself would race; *lint.File is created fresh per Check
+// and File.Memo is sync.Map + sync.Once protected.
 type Rule struct {
 	Banned []string
-
-	// bannedSet is the lookup form of Banned. Built lazily on first
-	// CheckNode call to keep the cost off per-node hot paths under the
-	// multiplexed AST walk (was rebuilt per link node, which on
-	// link-heavy docs was an allocation per node). The rule clone is
-	// per-Check on the configured path and per-worker on the
-	// defaults-only path; in both cases Banned is immutable for the
-	// lifetime of this clone, so the cache stays correct.
-	bannedSet map[string]bool
 }
 
 // ID implements rule.Rule.
@@ -54,9 +53,6 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 				return fmt.Errorf("descriptive-link-text: banned must be a list of strings, got %T", v)
 			}
 			r.Banned = ss
-			// Banned changed; drop the cached lookup so cachedBannedSet
-			// rebuilds from the new slice on the next visit.
-			r.bannedSet = nil
 		default:
 			return fmt.Errorf("descriptive-link-text: unknown setting %q", k)
 		}
@@ -96,7 +92,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	}
 
 	text := collectLinkText(link, f.Source)
-	if !r.cachedBannedSet()[normalizeText(text)] {
+	if !r.cachedBannedSet(f)[normalizeText(text)] {
 		return nil
 	}
 	line := linkLine(link, f)
@@ -111,17 +107,21 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	}}
 }
 
-// cachedBannedSet returns the lazily-built lookup form of r.Banned.
-// Built on first call within this rule-clone's lifetime so the
-// shared-walk hot path stops paying the construction cost per link.
-func (r *Rule) cachedBannedSet() map[string]bool {
-	if r.bannedSet == nil {
-		r.bannedSet = make(map[string]bool, len(r.Banned))
+// cachedBannedSet returns the lookup form of r.Banned, memoised on
+// the per-Check *lint.File. File.Memo is sync.Map + sync.Once
+// protected so the build runs at most once per File even under
+// the LSP's concurrent reader pattern, where the same rule
+// instance is shared across goroutines (config defaults set
+// cfg.Settings=nil, which makes ConfigureRule a no-op).
+func (r *Rule) cachedBannedSet(f *lint.File) map[string]bool {
+	v := f.Memo("MDS063.bannedSet", func() any {
+		m := make(map[string]bool, len(r.Banned))
 		for _, b := range r.Banned {
-			r.bannedSet[normalizeText(b)] = true
+			m[normalizeText(b)] = true
 		}
-	}
-	return r.bannedSet
+		return m
+	})
+	return v.(map[string]bool)
 }
 
 // normalizeText trims, lowercases, and collapses internal whitespace.

--- a/internal/rules/descriptivelinktext/rule.go
+++ b/internal/rules/descriptivelinktext/rule.go
@@ -92,15 +92,8 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		return nil
 	}
 
-	if r.bannedSet == nil {
-		r.bannedSet = make(map[string]bool, len(r.Banned))
-		for _, b := range r.Banned {
-			r.bannedSet[normalizeText(b)] = true
-		}
-	}
-
 	text := collectLinkText(link, f.Source)
-	if !r.bannedSet[normalizeText(text)] {
+	if !r.cachedBannedSet()[normalizeText(text)] {
 		return nil
 	}
 	line := linkLine(link, f)
@@ -113,6 +106,19 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		Severity: lint.Warning,
 		Message:  fmt.Sprintf("link text %q is not descriptive", text),
 	}}
+}
+
+// cachedBannedSet returns the lazily-built lookup form of r.Banned.
+// Built on first call within this rule-clone's lifetime so the
+// shared-walk hot path stops paying the construction cost per link.
+func (r *Rule) cachedBannedSet() map[string]bool {
+	if r.bannedSet == nil {
+		r.bannedSet = make(map[string]bool, len(r.Banned))
+		for _, b := range r.Banned {
+			r.bannedSet[normalizeText(b)] = true
+		}
+	}
+	return r.bannedSet
 }
 
 // normalizeText trims, lowercases, and collapses internal whitespace.

--- a/internal/rules/descriptivelinktext/rule_test.go
+++ b/internal/rules/descriptivelinktext/rule_test.go
@@ -137,49 +137,44 @@ func TestSoftLineBreakInLinkText(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "not descriptive")
 }
 
-// TestCachedBannedSet pins the lazy memoization contract: the first
-// call builds the lookup map from r.Banned, subsequent calls return
-// the SAME map (reference identity, not equal-but-distinct copies).
-// Without this contract the shared-walk hot path would rebuild the
-// map per link node visited.
+// TestCachedBannedSet pins the per-Check memoization contract:
+// subsequent calls on the same *lint.File return the same cached
+// map (reference identity); a fresh *lint.File builds a separate
+// map. Memoising via File.Memo keeps the cache off the shared
+// rule instance (the LSP path reuses rule.All() across goroutines),
+// so this also functions as a regression guard against the
+// previous race-prone rule-level cache.
 func TestCachedBannedSet(t *testing.T) {
 	r := &Rule{Banned: []string{"Click Here", "MORE"}}
+	f, err := lint.NewFile("t.md", []byte("# t\n"))
+	require.NoError(t, err)
 
-	first := r.cachedBannedSet()
+	first := r.cachedBannedSet(f)
 	require.Equal(t, map[string]bool{"click here": true, "more": true}, first,
 		"lookup keys must be the normalised form of r.Banned")
 
-	// Maps are reference types; reflect.ValueOf.Pointer is the
-	// canonical way to compare the underlying map headers.
-	second := r.cachedBannedSet()
+	second := r.cachedBannedSet(f)
 	assert.Equal(t,
 		reflect.ValueOf(first).Pointer(),
 		reflect.ValueOf(second).Pointer(),
-		"subsequent calls must return the same cached map")
+		"subsequent calls on the same File must return the same cached map")
+
+	g, err := lint.NewFile("t.md", []byte("# t\n"))
+	require.NoError(t, err)
+	third := r.cachedBannedSet(g)
+	assert.NotEqual(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(third).Pointer(),
+		"a fresh File must build a separate cached map (memo is per-Check, not shared on the rule)")
 
 	// An empty Banned yields a non-nil empty map; CheckNode short-
 	// circuits on len(r.Banned)==0 before calling cachedBannedSet, so
 	// this branch is purely defensive — pin it so a future refactor
 	// cannot regress it to nil.
 	empty := &Rule{}
-	got := empty.cachedBannedSet()
+	h, err := lint.NewFile("t.md", []byte("# t\n"))
+	require.NoError(t, err)
+	got := empty.cachedBannedSet(h)
 	require.NotNil(t, got)
 	assert.Empty(t, got)
-}
-
-// TestApplySettings_InvalidatesBannedSetCache pins that
-// ApplySettings drops the cached banned set when `banned`
-// changes, so a re-applied configuration does not serve stale
-// keys built from the previous Banned slice.
-func TestApplySettings_InvalidatesBannedSetCache(t *testing.T) {
-	r := &Rule{Banned: []string{"old phrase"}}
-	first := r.cachedBannedSet()
-	require.Contains(t, first, "old phrase")
-
-	err := r.ApplySettings(map[string]any{"banned": []any{"new phrase"}})
-	require.NoError(t, err)
-
-	rebuilt := r.cachedBannedSet()
-	assert.NotContains(t, rebuilt, "old phrase", "stale Banned keys must be dropped")
-	assert.Contains(t, rebuilt, "new phrase", "new Banned keys must appear")
 }

--- a/internal/rules/descriptivelinktext/rule_test.go
+++ b/internal/rules/descriptivelinktext/rule_test.go
@@ -166,3 +166,20 @@ func TestCachedBannedSet(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Empty(t, got)
 }
+
+// TestApplySettings_InvalidatesBannedSetCache pins that
+// ApplySettings drops the cached banned set when `banned`
+// changes, so a re-applied configuration does not serve stale
+// keys built from the previous Banned slice.
+func TestApplySettings_InvalidatesBannedSetCache(t *testing.T) {
+	r := &Rule{Banned: []string{"old phrase"}}
+	first := r.cachedBannedSet()
+	require.Contains(t, first, "old phrase")
+
+	err := r.ApplySettings(map[string]any{"banned": []any{"new phrase"}})
+	require.NoError(t, err)
+
+	rebuilt := r.cachedBannedSet()
+	assert.NotContains(t, rebuilt, "old phrase", "stale Banned keys must be dropped")
+	assert.Contains(t, rebuilt, "new phrase", "new Banned keys must appear")
+}

--- a/internal/rules/descriptivelinktext/rule_test.go
+++ b/internal/rules/descriptivelinktext/rule_test.go
@@ -1,6 +1,7 @@
 package descriptivelinktext
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -134,4 +135,34 @@ func TestSoftLineBreakInLinkText(t *testing.T) {
 	diags := check(t, "# T\n\n[click\nhere](x)\n")
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message, "not descriptive")
+}
+
+// TestCachedBannedSet pins the lazy memoization contract: the first
+// call builds the lookup map from r.Banned, subsequent calls return
+// the SAME map (reference identity, not equal-but-distinct copies).
+// Without this contract the shared-walk hot path would rebuild the
+// map per link node visited.
+func TestCachedBannedSet(t *testing.T) {
+	r := &Rule{Banned: []string{"Click Here", "MORE"}}
+
+	first := r.cachedBannedSet()
+	require.Equal(t, map[string]bool{"click here": true, "more": true}, first,
+		"lookup keys must be the normalised form of r.Banned")
+
+	// Maps are reference types; reflect.ValueOf.Pointer is the
+	// canonical way to compare the underlying map headers.
+	second := r.cachedBannedSet()
+	assert.Equal(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(second).Pointer(),
+		"subsequent calls must return the same cached map")
+
+	// An empty Banned yields a non-nil empty map; CheckNode short-
+	// circuits on len(r.Banned)==0 before calling cachedBannedSet, so
+	// this branch is purely defensive — pin it so a future refactor
+	// cannot regress it to nil.
+	empty := &Rule{}
+	got := empty.cachedBannedSet()
+	require.NotNil(t, got)
+	assert.Empty(t, got)
 }

--- a/internal/rules/emphasisstyle/rule.go
+++ b/internal/rules/emphasisstyle/rule.go
@@ -50,24 +50,27 @@ func (r *Rule) wantChar(level int) byte {
 	return 0
 }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-emphasis logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
 	if r.Bold == "" && r.Italic == "" && !r.ForbidMixedNesting {
 		return nil
 	}
-	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		em, ok := n.(*ast.Emphasis)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		diags = append(diags, r.checkEmphasis(em, f)...)
-		return ast.WalkContinue, nil
-	})
-	return diags
+	em, ok := n.(*ast.Emphasis)
+	if !ok {
+		return nil
+	}
+	return r.checkEmphasis(em, f)
 }
 
 func (r *Rule) checkEmphasis(em *ast.Emphasis, f *lint.File) []lint.Diagnostic {
@@ -373,4 +376,5 @@ var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
 	_ rule.FixableRule  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/fencedcodelanguage/rule.go
+++ b/internal/rules/fencedcodelanguage/rule.go
@@ -23,45 +23,48 @@ func (r *Rule) Name() string { return "fenced-code-language" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "code" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-block logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		fcb, ok := n.(*ast.FencedCodeBlock)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	fcb, ok := n.(*ast.FencedCodeBlock)
+	if !ok {
+		return nil
+	}
 
-		hasLanguage := false
-		if fcb.Info != nil {
-			info := fcb.Info.Segment
-			if info.Stop > info.Start {
-				lang := f.Source[info.Start:info.Stop]
-				if len(lang) > 0 {
-					hasLanguage = true
-				}
+	hasLanguage := false
+	if fcb.Info != nil {
+		info := fcb.Info.Segment
+		if info.Stop > info.Start {
+			lang := f.Source[info.Start:info.Stop]
+			if len(lang) > 0 {
+				hasLanguage = true
 			}
 		}
+	}
 
-		if !hasLanguage {
-			line := fencepos.OpenLine(f, fcb)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  "fenced code block should have a language tag",
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	if !hasLanguage {
+		line := fencepos.OpenLine(f, fcb)
+		return []lint.Diagnostic{{
+			File:     f.Path,
+			Line:     line,
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "fenced code block should have a language tag",
+		}}
+	}
+	return nil
 }
+
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/forbiddenparagraphstarts/rule.go
+++ b/internal/rules/forbiddenparagraphstarts/rule.go
@@ -39,47 +39,50 @@ func (r *Rule) Category() string { return "prose" }
 // 'We'") or for per-section overrides through a schema.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-paragraph logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
 	if f.AST == nil || len(r.Starts) == 0 {
 		return nil
 	}
-	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
+	para, ok := n.(*ast.Paragraph)
+	if !ok {
+		return nil
+	}
+	if astutil.IsTable(para, f) {
+		return nil
+	}
+	text := strings.TrimLeft(mdtext.ExtractPlainText(para, f.Source), " \t")
+	for _, prefix := range r.Starts {
+		if prefix == "" {
+			continue
 		}
-		para, ok := n.(*ast.Paragraph)
-		if !ok {
-			return ast.WalkContinue, nil
+		if strings.HasPrefix(text, prefix) {
+			return []lint.Diagnostic{{
+				File:     f.Path,
+				Line:     astutil.ParagraphLine(para, f),
+				Column:   1,
+				RuleID:   r.ID(),
+				RuleName: r.Name(),
+				Severity: lint.Warning,
+				Message: fmt.Sprintf(
+					"paragraph starts with forbidden prefix %q",
+					prefix,
+				),
+			}}
 		}
-		if astutil.IsTable(para, f) {
-			return ast.WalkContinue, nil
-		}
-		text := strings.TrimLeft(mdtext.ExtractPlainText(para, f.Source), " \t")
-		for _, prefix := range r.Starts {
-			if prefix == "" {
-				continue
-			}
-			if strings.HasPrefix(text, prefix) {
-				diags = append(diags, lint.Diagnostic{
-					File:     f.Path,
-					Line:     astutil.ParagraphLine(para, f),
-					Column:   1,
-					RuleID:   r.ID(),
-					RuleName: r.Name(),
-					Severity: lint.Warning,
-					Message: fmt.Sprintf(
-						"paragraph starts with forbidden prefix %q",
-						prefix,
-					),
-				})
-				break
-			}
-		}
-		return ast.WalkContinue, nil
-	})
-	return diags
+	}
+	return nil
 }
 
 // ApplySettings implements rule.Configurable.
@@ -114,4 +117,5 @@ func (r *Rule) DefaultSettings() map[string]any {
 var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/forbiddentext/rule.go
+++ b/internal/rules/forbiddentext/rule.go
@@ -38,46 +38,51 @@ func (r *Rule) Category() string { return "prose" }
 // EnabledByDefault implements rule.Defaultable.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-paragraph logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
 	if f.AST == nil || len(r.Contains) == 0 {
 		return nil
 	}
+	para, ok := n.(*ast.Paragraph)
+	if !ok {
+		return nil
+	}
+	if astutil.IsTable(para, f) {
+		return nil
+	}
+	text := mdtext.ExtractPlainText(para, f.Source)
+	line := astutil.ParagraphLine(para, f)
 	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
+	for _, sub := range r.Contains {
+		if sub == "" {
+			continue
 		}
-		para, ok := n.(*ast.Paragraph)
-		if !ok {
-			return ast.WalkContinue, nil
+		if !strings.Contains(text, sub) {
+			continue
 		}
-		if astutil.IsTable(para, f) {
-			return ast.WalkContinue, nil
-		}
-		text := mdtext.ExtractPlainText(para, f.Source)
-		line := astutil.ParagraphLine(para, f)
-		for _, sub := range r.Contains {
-			if sub == "" {
-				continue
-			}
-			if !strings.Contains(text, sub) {
-				continue
-			}
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message: fmt.Sprintf(
-					"paragraph contains forbidden text %q", sub,
-				),
-			})
-		}
-		return ast.WalkContinue, nil
-	})
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     line,
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message: fmt.Sprintf(
+				"paragraph contains forbidden text %q", sub,
+			),
+		})
+	}
 	return diags
 }
 
@@ -113,4 +118,5 @@ func (r *Rule) DefaultSettings() map[string]any {
 var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/horizontalrulestyle/rule.go
+++ b/internal/rules/horizontalrulestyle/rule.go
@@ -38,24 +38,25 @@ func (r *Rule) Category() string { return "whitespace" }
 // EnabledByDefault implements rule.Defaultable.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-thematic-break logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		tb, ok := n.(*ast.ThematicBreak)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		line := thematicBreakLine(tb, f)
-		diags = append(diags, r.checkHR(f, line)...)
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	tb, ok := n.(*ast.ThematicBreak)
+	if !ok {
+		return nil
+	}
+	line := thematicBreakLine(tb, f)
+	return r.checkHR(f, line)
 }
 
 func (r *Rule) checkHR(f *lint.File, line int) []lint.Diagnostic {
@@ -349,3 +350,4 @@ func (r *Rule) DefaultSettings() map[string]any {
 var _ rule.FixableRule = (*Rule)(nil)
 var _ rule.Configurable = (*Rule)(nil)
 var _ rule.Defaultable = (*Rule)(nil)
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/listindent/rule.go
+++ b/internal/rules/listindent/rule.go
@@ -29,52 +29,49 @@ func (r *Rule) Name() string { return "list-indent" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "list" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-list-item logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	listItem, ok := n.(*ast.ListItem)
+	if !ok {
+		return nil
+	}
 	spaces := r.Spaces
 	if spaces <= 0 {
 		spaces = 2
 	}
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-
-		listItem, ok := n.(*ast.ListItem)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		level := nestingLevel(listItem)
-		if level == 0 {
-			return ast.WalkContinue, nil
-		}
-
-		expectedIndent := level * spaces
-		line := firstLineOfListItem(f, listItem)
-		if line < 1 || line > len(f.Lines) {
-			return ast.WalkContinue, nil
-		}
-
-		actualIndent := countLeadingSpaces(f.Lines[line-1])
-		if actualIndent != expectedIndent {
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  "list indent should be " + itoa(expectedIndent) + " spaces, found " + itoa(actualIndent),
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	level := nestingLevel(listItem)
+	if level == 0 {
+		return nil
+	}
+	expectedIndent := level * spaces
+	line := firstLineOfListItem(f, listItem)
+	if line < 1 || line > len(f.Lines) {
+		return nil
+	}
+	actualIndent := countLeadingSpaces(f.Lines[line-1])
+	if actualIndent == expectedIndent {
+		return nil
+	}
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     line,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  "list indent should be " + itoa(expectedIndent) + " spaces, found " + itoa(actualIndent),
+	}}
 }
 
 // nestingLevel returns the nesting depth of a ListItem. A top-level list item
@@ -282,3 +279,4 @@ func toIntSetting(v any) (int, bool) {
 }
 
 var _ rule.Configurable = (*Rule)(nil)
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/listindent/rule_test.go
+++ b/internal/rules/listindent/rule_test.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 func TestCheck_CorrectIndent2Spaces(t *testing.T) {
@@ -156,4 +159,72 @@ func TestCategory(t *testing.T) {
 	if r.Category() == "" {
 		t.Error("expected non-empty category")
 	}
+}
+
+// TestFirstLineOfListItem_LinesPath pins the
+// `li.Lines().Len() > 0` branch. Goldmark's parser does not
+// populate Lines() on ListItem nodes in normal source — content
+// lives in child Paragraph nodes — but the helper handles the
+// case in case future goldmark versions or programmatic AST
+// construction set Lines() directly. Construct the segment
+// manually and pin that the helper returns the line for that
+// segment's start offset.
+func TestFirstLineOfListItem_LinesPath(t *testing.T) {
+	src := []byte("alpha\nbeta\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+	li := ast.NewListItem(0)
+	li.Lines().Append(text.NewSegment(6, 10)) // "beta" starts at offset 6 (line 2)
+	assert.Equal(t, 2, firstLineOfListItem(f, li))
+}
+
+// TestFirstLineOfListItem_Empty_ReturnsZero pins the final
+// `return 0` defensive branch: a ListItem with no Lines() and
+// no children that yield a positive line falls through to zero.
+// Goldmark won't produce this in normal source, but the helper
+// must not crash on a directly-constructed empty ListItem (the
+// CheckNode bounds guard relies on this contract).
+func TestFirstLineOfListItem_Empty_ReturnsZero(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("\n"))
+	require.NoError(t, err)
+	li := ast.NewListItem(0)
+	assert.Equal(t, 0, firstLineOfListItem(f, li))
+}
+
+// TestCheckNode_EmptyNestedListItem_GuardSkips pins CheckNode's
+// `line < 1 || line > len(f.Lines)` bounds check: a nested empty
+// ListItem has nestingLevel > 0 (passes the early return) but
+// firstLineOfListItem returns 0, so the bounds check fires and
+// CheckNode returns nil instead of indexing f.Lines[-1].
+func TestCheckNode_EmptyNestedListItem_GuardSkips(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("\n"))
+	require.NoError(t, err)
+	parent := ast.NewListItem(0)
+	nested := ast.NewListItem(0)
+	parent.AppendChild(parent, nested)
+	r := &Rule{Spaces: 2}
+	diags := r.CheckNode(nested, true, f)
+	assert.Nil(t, diags, "empty nested ListItem must hit the bounds guard, not panic")
+}
+
+// TestFix_EmptyNestedListItem_NoAdjustment pins
+// collectIndentAdjustments's parallel bounds check (rule.go
+// line ~230). Use the same empty-nested-ListItem shape as the
+// CheckNode test; Fix must return the source unchanged.
+func TestFix_EmptyNestedListItem_NoAdjustment(t *testing.T) {
+	src := []byte("\n")
+	f, err := lint.NewFile("t.md", src)
+	require.NoError(t, err)
+	doc := ast.NewDocument()
+	outer := ast.NewList('-')
+	outerItem := ast.NewListItem(0)
+	innerList := ast.NewList('-')
+	innerItem := ast.NewListItem(0) // empty; firstLineOfListItem returns 0
+	innerList.AppendChild(innerList, innerItem)
+	outerItem.AppendChild(outerItem, innerList)
+	outer.AppendChild(outer, outerItem)
+	doc.AppendChild(doc, outer)
+	f.AST = doc
+	got := (&Rule{Spaces: 2}).Fix(f)
+	assert.Equal(t, src, got, "empty nested ListItem must hit the Fix bounds guard")
 }

--- a/internal/rules/listmarkerspace/rule.go
+++ b/internal/rules/listmarkerspace/rule.go
@@ -34,21 +34,24 @@ func (r *Rule) Name() string { return "list-marker-space" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "list" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-list logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		list, ok := n.(*ast.List)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		diags = append(diags, r.checkList(f, list)...)
-		return ast.WalkContinue, nil
-	})
-	return diags
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	list, ok := n.(*ast.List)
+	if !ok {
+		return nil
+	}
+	return r.checkList(f, list)
 }
 
 func (r *Rule) checkList(f *lint.File, list *ast.List) []lint.Diagnostic {
@@ -260,4 +263,5 @@ func pluralSpace(n int) string {
 var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.FixableRule  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/listmarkerstyle/rule.go
+++ b/internal/rules/listmarkerstyle/rule.go
@@ -43,23 +43,24 @@ func (r *Rule) Category() string { return "list" }
 // users pick a project convention and turn the rule on.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-list logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		list, ok := n.(*ast.List)
-		if !ok || list.IsOrdered() {
-			return ast.WalkContinue, nil
-		}
-		diags = append(diags, r.checkList(f, list)...)
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	list, ok := n.(*ast.List)
+	if !ok || list.IsOrdered() {
+		return nil
+	}
+	return r.checkList(f, list)
 }
 
 // checkList emits diagnostics when any list item's marker does not match
@@ -354,4 +355,5 @@ var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.FixableRule  = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/nobareurls/rule.go
+++ b/internal/rules/nobareurls/rule.go
@@ -28,59 +28,65 @@ func (r *Rule) Name() string { return "no-bare-urls" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "link" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-text-node logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	textNode, ok := n.(*ast.Text)
+	if !ok {
+		return nil
+	}
+	// Skip text nodes inside links.
+	if isInsideNonBareContext(n) {
+		return nil
+	}
+
+	seg := textNode.Segment
+	content := seg.Value(f.Source)
+	matches := urlPattern.FindAllIndex(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
 	var diags []lint.Diagnostic
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-
-		textNode, ok := n.(*ast.Text)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		// Skip text nodes inside links.
-		if isInsideNonBareContext(n) {
-			return ast.WalkContinue, nil
-		}
-
-		seg := textNode.Segment
-		content := seg.Value(f.Source)
-		matches := urlPattern.FindAllIndex(content, -1)
-		for _, m := range matches {
-			offset := seg.Start + m[0]
-			line := f.LineOfOffset(offset)
-			// Compute column: find the start of this line.
-			lineStart := 0
-			count := 1
-			for i := 0; i < offset && i < len(f.Source); i++ {
-				if f.Source[i] == '\n' {
-					lineStart = i + 1
-					count++
-					_ = count
-				}
+	for _, m := range matches {
+		offset := seg.Start + m[0]
+		line := f.LineOfOffset(offset)
+		// Compute column: find the start of this line.
+		lineStart := 0
+		count := 1
+		for i := 0; i < offset && i < len(f.Source); i++ {
+			if f.Source[i] == '\n' {
+				lineStart = i + 1
+				count++
+				_ = count
 			}
-			col := offset - lineStart + 1
-
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   col,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  "bare URL found; use angle brackets or a link",
-			})
 		}
+		col := offset - lineStart + 1
 
-		return ast.WalkContinue, nil
-	})
-
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     line,
+			Column:   col,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "bare URL found; use angle brackets or a link",
+		})
+	}
 	return diags
 }
+
+var _ rule.NodeChecker = (*Rule)(nil)
 
 // isInsideNonBareContext checks if a node is a descendant of an ast.Link,
 // ast.AutoLink, or ast.CodeSpan (where URLs should not be flagged).

--- a/internal/rules/nobareurls/rule.go
+++ b/internal/rules/nobareurls/rule.go
@@ -60,20 +60,10 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	var diags []lint.Diagnostic
 	for _, m := range matches {
 		offset := seg.Start + m[0]
-		line := f.LineOfOffset(offset)
-		// Compute column: find the start of this line.
-		lineStart := 0
-		for i := 0; i < offset && i < len(f.Source); i++ {
-			if f.Source[i] == '\n' {
-				lineStart = i + 1
-			}
-		}
-		col := offset - lineStart + 1
-
 		diags = append(diags, lint.Diagnostic{
 			File:     f.Path,
-			Line:     line,
-			Column:   col,
+			Line:     f.LineOfOffset(offset),
+			Column:   f.ColumnOfOffset(offset),
 			RuleID:   r.ID(),
 			RuleName: r.Name(),
 			Severity: lint.Warning,

--- a/internal/rules/nobareurls/rule.go
+++ b/internal/rules/nobareurls/rule.go
@@ -63,12 +63,9 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		line := f.LineOfOffset(offset)
 		// Compute column: find the start of this line.
 		lineStart := 0
-		count := 1
 		for i := 0; i < offset && i < len(f.Source); i++ {
 			if f.Source[i] == '\n' {
 				lineStart = i + 1
-				count++
-				_ = count
 			}
 		}
 		col := offset - lineStart + 1

--- a/internal/rules/noemptyalttext/rule.go
+++ b/internal/rules/noemptyalttext/rule.go
@@ -24,38 +24,40 @@ func (r *Rule) Name() string { return "no-empty-alt-text" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "accessibility" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-image logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		img, ok := n.(*ast.Image)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		alt := imageAltText(img, f)
-		if strings.TrimSpace(alt) == "" {
-			line := imageLine(img, f)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  "image has empty alt text",
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	return rule.WalkNodes(r, f)
 }
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	img, ok := n.(*ast.Image)
+	if !ok {
+		return nil
+	}
+	alt := imageAltText(img, f)
+	if strings.TrimSpace(alt) != "" {
+		return nil
+	}
+	line := imageLine(img, f)
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     line,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  "image has empty alt text",
+	}}
+}
+
+var _ rule.NodeChecker = (*Rule)(nil)
 
 func imageAltText(img *ast.Image, f *lint.File) string {
 	var b strings.Builder

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -14,7 +14,12 @@ import (
 )
 
 func init() {
-	rule.Register(&Rule{})
+	// Register with AllowComments=true so that enabling the rule with
+	// the bare boolean form (`no-inline-html: true`) matches what
+	// DefaultSettings documents. ConfigureRule does not clone or apply
+	// settings when cfg.Settings is nil, so the registered instance
+	// must already reflect the documented default.
+	rule.Register(&Rule{AllowComments: true})
 }
 
 // Rule implements MDS041, flagging raw HTML in Markdown documents.
@@ -58,6 +63,9 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 				return fmt.Errorf("no-inline-html: allow must be a list of strings, got %T", v)
 			}
 			r.Allow = tags
+			// Allow changed; drop the cached lookup so cachedAllowSet
+			// rebuilds from the new slice on the next visit.
+			r.allowSetCache = nil
 		case "allow-comments":
 			b, ok := v.(bool)
 			if !ok {

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -21,6 +21,11 @@ func init() {
 type Rule struct {
 	Allow         []string
 	AllowComments bool
+
+	// allowSetCache memoizes allowSet() for the lifetime of one
+	// rule-clone (one Check on one File, in practice). Built only when
+	// an HTML node is actually visited — most documents have none.
+	allowSetCache map[string]bool
 }
 
 // ID implements rule.Rule.
@@ -79,7 +84,10 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	if !entering {
 		return nil
 	}
-	allowed := r.allowSet()
+	// Build the allow-set lazily and only when we actually see an HTML
+	// node. Most documents have many AST nodes and very few HTML ones,
+	// so computing it unconditionally allocated a map per visit under
+	// the multiplexed walk.
 	switch node := n.(type) {
 	case *ast.HTMLBlock:
 		seg := node.Lines().At(0)
@@ -88,13 +96,13 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		if i := bytes.IndexByte(raw, '<'); i >= 0 {
 			offset += i
 		}
-		if d, ok := r.checkRaw(f, allowed, raw, offset); ok {
+		if d, ok := r.checkRaw(f, r.cachedAllowSet(), raw, offset); ok {
 			return []lint.Diagnostic{d}
 		}
 	case *ast.RawHTML:
 		seg := node.Segments.At(0)
 		raw := rawHTMLBytes(node, f.Source)
-		if d, ok := r.checkRaw(f, allowed, raw, seg.Start); ok {
+		if d, ok := r.checkRaw(f, r.cachedAllowSet(), raw, seg.Start); ok {
 			return []lint.Diagnostic{d}
 		}
 	}
@@ -130,6 +138,15 @@ func (r *Rule) allowSet() map[string]bool {
 		m[strings.ToLower(t)] = true
 	}
 	return m
+}
+
+// cachedAllowSet returns the lazily-built lookup form of r.Allow.
+// Builds it on first call within this rule-clone's lifetime.
+func (r *Rule) cachedAllowSet() map[string]bool {
+	if r.allowSetCache == nil {
+		r.allowSetCache = r.allowSet()
+	}
+	return r.allowSetCache
 }
 
 func (r *Rule) diag(f *lint.File, offset int, display string) lint.Diagnostic {

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -66,40 +66,39 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 	return nil
 }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-HTML-node logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
 	allowed := r.allowSet()
-	var diags []lint.Diagnostic
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
+	switch node := n.(type) {
+	case *ast.HTMLBlock:
+		seg := node.Lines().At(0)
+		raw := seg.Value(f.Source)
+		offset := seg.Start
+		if i := bytes.IndexByte(raw, '<'); i >= 0 {
+			offset += i
 		}
-
-		switch node := n.(type) {
-		case *ast.HTMLBlock:
-			seg := node.Lines().At(0)
-			raw := seg.Value(f.Source)
-			offset := seg.Start
-			if i := bytes.IndexByte(raw, '<'); i >= 0 {
-				offset += i
-			}
-			if d, ok := r.checkRaw(f, allowed, raw, offset); ok {
-				diags = append(diags, d)
-			}
-
-		case *ast.RawHTML:
-			seg := node.Segments.At(0)
-			raw := rawHTMLBytes(node, f.Source)
-			if d, ok := r.checkRaw(f, allowed, raw, seg.Start); ok {
-				diags = append(diags, d)
-			}
+		if d, ok := r.checkRaw(f, allowed, raw, offset); ok {
+			return []lint.Diagnostic{d}
 		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	case *ast.RawHTML:
+		seg := node.Segments.At(0)
+		raw := rawHTMLBytes(node, f.Source)
+		if d, ok := r.checkRaw(f, allowed, raw, seg.Start); ok {
+			return []lint.Diagnostic{d}
+		}
+	}
+	return nil
 }
 
 // checkRaw inspects raw HTML bytes and returns a diagnostic if the HTML
@@ -196,4 +195,5 @@ func rawHTMLBytes(n *ast.RawHTML, source []byte) []byte {
 var (
 	_ rule.Defaultable  = (*Rule)(nil)
 	_ rule.Configurable = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -23,18 +23,17 @@ func init() {
 }
 
 // Rule implements MDS041, flagging raw HTML in Markdown documents.
+//
+// The lookup form of Allow is memoised on the per-Check *lint.File
+// via File.Memo (see cachedAllowSet) rather than on the rule
+// instance. Rule instances are shared across concurrent LSP calls
+// (cmd/mdsmith/lsp.go reuses rule.All(), and ConfigureRule does
+// not clone when cfg.Settings is nil), so any mutable state on the
+// rule itself would race; *lint.File is created fresh per Check
+// and File.Memo is sync.Map + sync.Once protected.
 type Rule struct {
 	Allow         []string
 	AllowComments bool
-
-	// allowSetCache memoizes allowSet() for the lifetime of this
-	// rule instance. The instance is per-Check when ConfigureRule
-	// clones (cfg.Settings non-nil for a Configurable rule), and
-	// per-worker otherwise (defaults-only path reuses the runner's
-	// worker clone across files). Either way Allow is immutable for
-	// the cache's lifetime — ApplySettings drops the cache when it
-	// rewrites Allow — so the memoised map stays correct.
-	allowSetCache map[string]bool
 }
 
 // ID implements rule.Rule.
@@ -67,9 +66,6 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 				return fmt.Errorf("no-inline-html: allow must be a list of strings, got %T", v)
 			}
 			r.Allow = tags
-			// Allow changed; drop the cached lookup so cachedAllowSet
-			// rebuilds from the new slice on the next visit.
-			r.allowSetCache = nil
 		case "allow-comments":
 			b, ok := v.(bool)
 			if !ok {
@@ -108,13 +104,13 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		if i := bytes.IndexByte(raw, '<'); i >= 0 {
 			offset += i
 		}
-		if d, ok := r.checkRaw(f, r.cachedAllowSet(), raw, offset); ok {
+		if d, ok := r.checkRaw(f, r.cachedAllowSet(f), raw, offset); ok {
 			return []lint.Diagnostic{d}
 		}
 	case *ast.RawHTML:
 		seg := node.Segments.At(0)
 		raw := rawHTMLBytes(node, f.Source)
-		if d, ok := r.checkRaw(f, r.cachedAllowSet(), raw, seg.Start); ok {
+		if d, ok := r.checkRaw(f, r.cachedAllowSet(f), raw, seg.Start); ok {
 			return []lint.Diagnostic{d}
 		}
 	}
@@ -152,13 +148,15 @@ func (r *Rule) allowSet() map[string]bool {
 	return m
 }
 
-// cachedAllowSet returns the lazily-built lookup form of r.Allow.
-// Builds it on first call within this rule-clone's lifetime.
-func (r *Rule) cachedAllowSet() map[string]bool {
-	if r.allowSetCache == nil {
-		r.allowSetCache = r.allowSet()
-	}
-	return r.allowSetCache
+// cachedAllowSet returns the lookup form of r.Allow, memoised on
+// the per-Check *lint.File. File.Memo is sync.Map + sync.Once
+// protected so the build runs at most once per File even under
+// the LSP's concurrent reader pattern, where the same rule
+// instance is shared across goroutines (config defaults set
+// cfg.Settings=nil, which makes ConfigureRule a no-op).
+func (r *Rule) cachedAllowSet(f *lint.File) map[string]bool {
+	v := f.Memo("MDS041.allowSet", func() any { return r.allowSet() })
+	return v.(map[string]bool)
 }
 
 func (r *Rule) diag(f *lint.File, offset int, display string) lint.Diagnostic {

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -27,9 +27,13 @@ type Rule struct {
 	Allow         []string
 	AllowComments bool
 
-	// allowSetCache memoizes allowSet() for the lifetime of one
-	// rule-clone (one Check on one File, in practice). Built only when
-	// an HTML node is actually visited — most documents have none.
+	// allowSetCache memoizes allowSet() for the lifetime of this
+	// rule instance. The instance is per-Check when ConfigureRule
+	// clones (cfg.Settings non-nil for a Configurable rule), and
+	// per-worker otherwise (defaults-only path reuses the runner's
+	// worker clone across files). Either way Allow is immutable for
+	// the cache's lifetime — ApplySettings drops the cache when it
+	// rewrites Allow — so the memoised map stays correct.
 	allowSetCache map[string]bool
 }
 

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -248,4 +249,36 @@ func TestCachedAllowSet(t *testing.T) {
 	got := empty.cachedAllowSet()
 	require.NotNil(t, got, "empty Allow must still return a non-nil map")
 	assert.Empty(t, got)
+}
+
+// TestApplySettings_InvalidatesAllowSetCache pins that
+// ApplySettings drops the cached allow set when `allow` changes,
+// so a re-applied configuration does not serve stale keys built
+// from the previous Allow slice.
+func TestApplySettings_InvalidatesAllowSetCache(t *testing.T) {
+	r := &Rule{Allow: []string{"old-tag"}}
+	first := r.cachedAllowSet()
+	require.Contains(t, first, "old-tag")
+
+	err := r.ApplySettings(map[string]any{"allow": []any{"new-tag"}})
+	require.NoError(t, err)
+
+	rebuilt := r.cachedAllowSet()
+	assert.NotContains(t, rebuilt, "old-tag", "stale Allow keys must be dropped")
+	assert.Contains(t, rebuilt, "new-tag", "new Allow keys must appear")
+}
+
+// TestRegisteredDefault_AllowCommentsTrue pins that the
+// init()-registered rule instance carries AllowComments=true so
+// that enabling the rule via the bare boolean form
+// (`no-inline-html: true`) matches DefaultSettings's documented
+// allow-comments default. ConfigureRule short-circuits when
+// cfg.Settings is nil, so the registered instance is what runs.
+func TestRegisteredDefault_AllowCommentsTrue(t *testing.T) {
+	r := rule.ByID("MDS041")
+	require.NotNil(t, r, "MDS041 must be registered")
+	hr, ok := r.(*Rule)
+	require.True(t, ok)
+	assert.True(t, hr.AllowComments,
+		"registered MDS041 must have AllowComments=true to match DefaultSettings")
 }

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -223,49 +223,43 @@ func TestApplySettings_AllowCommentsBadType(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestCachedAllowSet pins the lazy memoization contract: the first
-// call builds the lookup map from r.Allow, subsequent calls return the
-// SAME map (reference identity, not equal-but-distinct copies).
-// Without this contract the shared-walk hot path would allocate a new
-// map per AST node visited.
+// TestCachedAllowSet pins the per-Check memoization contract:
+// subsequent calls on the same *lint.File return the same cached
+// map (reference identity); a fresh *lint.File builds a separate
+// map. Memoising via File.Memo keeps the cache off the shared
+// rule instance (the LSP path reuses rule.All() across goroutines),
+// so this also functions as a regression guard against the
+// previous race-prone rule-level cache.
 func TestCachedAllowSet(t *testing.T) {
 	r := &Rule{Allow: []string{"Span", "div", "STRONG"}}
+	f, err := lint.NewFile("t.md", []byte("# t\n"))
+	require.NoError(t, err)
 
-	first := r.cachedAllowSet()
+	first := r.cachedAllowSet(f)
 	require.Equal(t, map[string]bool{"span": true, "div": true, "strong": true}, first,
 		"lookup keys must be lowercase normalisations of r.Allow")
 
-	// Maps are reference types; reflect.ValueOf.Pointer is the
-	// canonical way to compare the underlying map headers.
-	second := r.cachedAllowSet()
+	second := r.cachedAllowSet(f)
 	assert.Equal(t,
 		reflect.ValueOf(first).Pointer(),
 		reflect.ValueOf(second).Pointer(),
-		"subsequent calls must return the same cached map")
+		"subsequent calls on the same File must return the same cached map")
 
-	// An empty Allow yields a non-nil empty map, so a nil check is
-	// usable as the "not yet built" sentinel.
+	g, err := lint.NewFile("t.md", []byte("# t\n"))
+	require.NoError(t, err)
+	third := r.cachedAllowSet(g)
+	assert.NotEqual(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(third).Pointer(),
+		"a fresh File must build a separate cached map (memo is per-Check, not shared on the rule)")
+
+	// An empty Allow yields a non-nil empty map.
 	empty := &Rule{}
-	got := empty.cachedAllowSet()
+	h, err := lint.NewFile("t.md", []byte("# t\n"))
+	require.NoError(t, err)
+	got := empty.cachedAllowSet(h)
 	require.NotNil(t, got, "empty Allow must still return a non-nil map")
 	assert.Empty(t, got)
-}
-
-// TestApplySettings_InvalidatesAllowSetCache pins that
-// ApplySettings drops the cached allow set when `allow` changes,
-// so a re-applied configuration does not serve stale keys built
-// from the previous Allow slice.
-func TestApplySettings_InvalidatesAllowSetCache(t *testing.T) {
-	r := &Rule{Allow: []string{"old-tag"}}
-	first := r.cachedAllowSet()
-	require.Contains(t, first, "old-tag")
-
-	err := r.ApplySettings(map[string]any{"allow": []any{"new-tag"}})
-	require.NoError(t, err)
-
-	rebuilt := r.cachedAllowSet()
-	assert.NotContains(t, rebuilt, "old-tag", "stale Allow keys must be dropped")
-	assert.Contains(t, rebuilt, "new-tag", "new Allow keys must appear")
 }
 
 // TestRegisteredDefault_AllowCommentsTrue pins that the

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -1,6 +1,7 @@
 package noinlinehtml
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -219,4 +220,32 @@ func TestApplySettings_AllowCommentsBadType(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{"allow-comments": "yes"})
 	require.Error(t, err)
+}
+
+// TestCachedAllowSet pins the lazy memoization contract: the first
+// call builds the lookup map from r.Allow, subsequent calls return the
+// SAME map (reference identity, not equal-but-distinct copies).
+// Without this contract the shared-walk hot path would allocate a new
+// map per AST node visited.
+func TestCachedAllowSet(t *testing.T) {
+	r := &Rule{Allow: []string{"Span", "div", "STRONG"}}
+
+	first := r.cachedAllowSet()
+	require.Equal(t, map[string]bool{"span": true, "div": true, "strong": true}, first,
+		"lookup keys must be lowercase normalisations of r.Allow")
+
+	// Maps are reference types; reflect.ValueOf.Pointer is the
+	// canonical way to compare the underlying map headers.
+	second := r.cachedAllowSet()
+	assert.Equal(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(second).Pointer(),
+		"subsequent calls must return the same cached map")
+
+	// An empty Allow yields a non-nil empty map, so a nil check is
+	// usable as the "not yet built" sentinel.
+	empty := &Rule{}
+	got := empty.cachedAllowSet()
+	require.NotNil(t, got, "empty Allow must still return a non-nil map")
+	assert.Empty(t, got)
 }

--- a/internal/rules/nospaceincodespans/rule.go
+++ b/internal/rules/nospaceincodespans/rule.go
@@ -42,56 +42,60 @@ const (
 // when both sides have one and the content is not all spaces). Inspecting
 // the post-trim segment avoids false positives on spans like “ `  x ` “
 // where only one leading space remains visible after CommonMark strips one
-// from each side.
+// from each side. The per-span logic is pure and stateless, so it is
+// expressed as CheckNode and the engine can fold this rule into one
+// shared AST walk; a direct call still works via rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		cs, ok := n.(*ast.CodeSpan)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		first, last, ok2 := spanBounds(cs)
-		if !ok2 || last == first {
-			return ast.WalkContinue, nil
-		}
-		seg := f.Source[first:last]
-		if !isASCIIWhitespace(seg[0]) && !isASCIIWhitespace(seg[len(seg)-1]) {
-			return ast.WalkContinue, nil
-		}
-		btStart := openingBacktickOffset(cs, f.Source)
-		line := f.LineOfOffset(btStart)
-		if inGeneratedSection(f, line) {
-			return ast.WalkContinue, nil
-		}
-		col := f.ColumnOfOffset(btStart)
+	return rule.WalkNodes(r, f)
+}
 
-		if isASCIIWhitespace(seg[0]) {
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   col,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  msgLeading,
-			})
-		}
-		if isASCIIWhitespace(seg[len(seg)-1]) {
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   col,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  msgTrailing,
-			})
-		}
-		return ast.WalkContinue, nil
-	})
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	cs, ok := n.(*ast.CodeSpan)
+	if !ok {
+		return nil
+	}
+	first, last, ok2 := spanBounds(cs)
+	if !ok2 || last == first {
+		return nil
+	}
+	seg := f.Source[first:last]
+	if !isASCIIWhitespace(seg[0]) && !isASCIIWhitespace(seg[len(seg)-1]) {
+		return nil
+	}
+	btStart := openingBacktickOffset(cs, f.Source)
+	line := f.LineOfOffset(btStart)
+	if inGeneratedSection(f, line) {
+		return nil
+	}
+	col := f.ColumnOfOffset(btStart)
+
+	var diags []lint.Diagnostic
+	if isASCIIWhitespace(seg[0]) {
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     line,
+			Column:   col,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  msgLeading,
+		})
+	}
+	if isASCIIWhitespace(seg[len(seg)-1]) {
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     line,
+			Column:   col,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  msgTrailing,
+		})
+	}
 	return diags
 }
 
@@ -239,4 +243,5 @@ func isASCIIWhitespace(b byte) bool {
 var (
 	_ rule.FixableRule = (*Rule)(nil)
 	_ rule.Defaultable = (*Rule)(nil)
+	_ rule.NodeChecker = (*Rule)(nil)
 )

--- a/internal/rules/nospaceincodespans/rule_test.go
+++ b/internal/rules/nospaceincodespans/rule_test.go
@@ -31,6 +31,18 @@ func TestCheck_NoSpaces_NoDiagnostic(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+// TestCheck_EmptyCodeSpan_NoDiagnostic pins the empty-span guard:
+// goldmark accepts paired backticks with nothing between them as an
+// (empty) CodeSpan. The rule's span-bounds helper returns
+// last==first for these; CheckNode must short-circuit rather than
+// index into a zero-length slice. This pins the branch at
+// rule.go: `!ok2 || last == first`.
+func TestCheck_EmptyCodeSpan_NoDiagnostic(t *testing.T) {
+	f := newFile(t, "Use `` here.\n")
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags, "empty code span must produce no diagnostic")
+}
+
 func TestCheck_BalancedSingleSpace_NoDiagnostic(t *testing.T) {
 	// CommonMark trims one space from each side when both sides have one.
 	f := newFile(t, "Use ` x ` here.\n")

--- a/internal/rules/nospaceincodespans/rule_test.go
+++ b/internal/rules/nospaceincodespans/rule_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -299,4 +300,79 @@ func TestFix_SkipsGeneratedRange(t *testing.T) {
 	f := newFileWithGeneratedRanges(t, src, []lint.LineRange{{From: 3, To: 3}})
 	got := string((&Rule{}).Fix(f))
 	assert.Equal(t, src, got)
+}
+
+// TestCheckNode_EmptyCodeSpan_NoDiagnostic pins the spanBounds
+// empty-span short-circuit in CheckNode. Goldmark's parser does
+// not produce a CodeSpan with no Text children in normal source,
+// but the guard exists to defend against future parser behaviour
+// and direct AST construction. Build the empty CodeSpan
+// programmatically and pin that CheckNode returns nil.
+func TestCheckNode_EmptyCodeSpan_NoDiagnostic(t *testing.T) {
+	f := newFile(t, "`x`\n")
+	cs := ast.NewCodeSpan() // no Text children -> spanBounds returns ok=false
+	diags := (&Rule{}).CheckNode(cs, true, f)
+	assert.Nil(t, diags, "an empty CodeSpan must not emit a diagnostic")
+}
+
+// TestFix_EmptyCodeSpan_NoChange pins the parallel guard inside
+// the Fix-path walk (rule.go's `if !ok2 || last == first { return
+// ast.WalkContinue }`). Inject an empty CodeSpan into the AST so
+// the walk visits it; Fix must return the source unchanged.
+func TestFix_EmptyCodeSpan_NoChange(t *testing.T) {
+	src := []byte("`x`\n")
+	f := newFile(t, string(src))
+	doc := ast.NewDocument()
+	p := ast.NewParagraph()
+	p.AppendChild(p, ast.NewCodeSpan()) // empty
+	doc.AppendChild(doc, p)
+	f.AST = doc
+	got := (&Rule{}).Fix(f)
+	assert.Equal(t, src, got, "an empty CodeSpan must not trigger a Fix rewrite")
+}
+
+// TestFix_WhitespaceOnlyCodeSpan_NoChange pins the
+// `len(trimmed) == 0` branch in Fix: when a code span contains
+// only spaces, bytes.Trim drops everything, and Fix returns
+// without modifying the source. Three spaces avoid CommonMark's
+// single-space trim (which only fires when content is non-empty
+// after the strip), so goldmark exposes all three to spanBounds.
+func TestFix_WhitespaceOnlyCodeSpan_NoChange(t *testing.T) {
+	src := "Use `   ` here.\n"
+	f := newFile(t, src)
+	got := string((&Rule{}).Fix(f))
+	assert.Equal(t, src, got, "whitespace-only span must not be rewritten")
+}
+
+// TestFix_TrimmedEqualsRaw_NoChange pins the
+// `bytes.Equal(trimmed, raw)` branch in Fix: when bytes.Trim
+// removes the outer whitespace and the surviving content has
+// backticks at one or both ends, Fix re-wraps it with one space
+// per side so CommonMark's trim renders it correctly. If the
+// re-wrapped form happens to equal the raw bytes, no rewrite is
+// needed — return without modifying. Goldmark's parser does not
+// expose a span shaped like this from real Markdown (the
+// CommonMark trim normalises it earlier); construct the CodeSpan
+// directly so the branch is exercised. Source layout:
+//
+//	X `x` Y          // offsets 0..6
+//	  ^^^^^          // span text at [1, 6)
+//
+// Recover does not extend (source[0]=='X', not '`'), so
+// raw == seg == " `x` "; trim → "`x`"; append spaces →
+// " `x` " == raw; branch fires.
+func TestFix_TrimmedEqualsRaw_NoChange(t *testing.T) {
+	src := []byte("X `x` Y\n")
+	f := newFile(t, string(src))
+
+	cs := ast.NewCodeSpan()
+	cs.AppendChild(cs, ast.NewTextSegment(text.NewSegment(1, 6)))
+	doc := ast.NewDocument()
+	p := ast.NewParagraph()
+	p.AppendChild(p, cs)
+	doc.AppendChild(doc, p)
+	f.AST = doc
+
+	got := (&Rule{}).Fix(f)
+	assert.Equal(t, src, got, "trimmed==raw must skip the rewrite")
 }

--- a/internal/rules/nospaceinlinktext/rule.go
+++ b/internal/rules/nospaceinlinktext/rule.go
@@ -271,43 +271,91 @@ func (r *Rule) collectSpans(f *lint.File) []span {
 	return spans
 }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-link/image logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	return rule.WalkNodes(r, f)
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	s, ok := r.spanForNode(n, f)
+	if !ok {
+		return nil
+	}
+	return diagsForSpan(s, f, r.ID(), r.Name())
+}
+
+// spanForNode returns the bracket span for a Link or Image node, or
+// false if the node should be skipped (not a Link/Image, images
+// disabled, undetectable bracket position, or located in a generated
+// section).
+func (r *Rule) spanForNode(n ast.Node, f *lint.File) (span, bool) {
+	switch n.(type) {
+	case *ast.Link, *ast.Image:
+	default:
+		return span{}, false
+	}
+	img := isImage(n)
+	if img && !r.CheckImages {
+		return span{}, false
+	}
+	open, close := bracketSpan(n, f.Source)
+	if open == -1 {
+		return span{}, false
+	}
+	line := f.LineOfOffset(open)
+	for _, gr := range f.GeneratedRanges {
+		if gr.Contains(line) {
+			return span{}, false
+		}
+	}
+	return span{open: open, close: close, img: img}, true
+}
+
+// diagsForSpan returns the leading/trailing-whitespace diagnostics
+// for a single bracket span. Returns nil when neither end is flagged.
+func diagsForSpan(s span, f *lint.File, ruleID, ruleName string) []lint.Diagnostic {
+	inner := f.Source[s.open+1 : s.close]
+	if s.img && len(bytes.TrimSpace(inner)) == 0 {
+		return nil // whitespace-only image alt; leave to MDS032
+	}
+	if len(inner) == 0 {
+		return nil
+	}
+	role := "link text"
+	if s.img {
+		role = "image alt text"
+	}
+	first := inner[0]
+	last := inner[len(inner)-1]
 	var diags []lint.Diagnostic
-	for _, s := range r.collectSpans(f) {
-		inner := f.Source[s.open+1 : s.close]
-		if s.img && len(bytes.TrimSpace(inner)) == 0 {
-			continue // whitespace-only image alt; leave to MDS032 (no-empty-alt-text)
-		}
-		role := "link text"
-		if s.img {
-			role = "image alt text"
-		}
-		first := inner[0]
-		last := inner[len(inner)-1]
-		// Only flag space/tab, not newlines.
-		if first == ' ' || first == '\t' {
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     f.LineOfOffset(s.open + 1),
-				Column:   f.ColumnOfOffset(s.open + 1),
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  role + " has leading whitespace",
-			})
-		}
-		if last == ' ' || last == '\t' {
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     f.LineOfOffset(s.close - 1),
-				Column:   f.ColumnOfOffset(s.close - 1),
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  role + " has trailing whitespace",
-			})
-		}
+	if first == ' ' || first == '\t' {
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     f.LineOfOffset(s.open + 1),
+			Column:   f.ColumnOfOffset(s.open + 1),
+			RuleID:   ruleID,
+			RuleName: ruleName,
+			Severity: lint.Warning,
+			Message:  role + " has leading whitespace",
+		})
+	}
+	if last == ' ' || last == '\t' {
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     f.LineOfOffset(s.close - 1),
+			Column:   f.ColumnOfOffset(s.close - 1),
+			RuleID:   ruleID,
+			RuleName: ruleName,
+			Severity: lint.Warning,
+			Message:  role + " has trailing whitespace",
+		})
 	}
 	return diags
 }
@@ -361,4 +409,5 @@ var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
 	_ rule.FixableRule  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/nospaceinlinktext/rule_test.go
+++ b/internal/rules/nospaceinlinktext/rule_test.go
@@ -86,6 +86,18 @@ func TestCheckImagesDisabled(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+// TestFixImagesDisabled_LeavesImageAltUntouched pins the
+// CheckImages=false branch on the Fix path (collectSpans): images
+// must be skipped so their alt text is not stripped of intentional
+// padding. The Check path is already covered by
+// TestCheckImagesDisabled; this exercises the same predicate in
+// the collectSpans loop used by Fix.
+func TestFixImagesDisabled_LeavesImageAltUntouched(t *testing.T) {
+	src := "# T\n\n![ alt ](img.png)\n"
+	result := fix(t, src, false)
+	assert.Equal(t, src, result, "Fix must leave image alt untouched when CheckImages=false")
+}
+
 func TestNewlineInLinkTextNotFlagged(t *testing.T) {
 	// Newline between words inside brackets must not be flagged.
 	diags := check(t, "# T\n\n[long text that\nwraps](url)\n", true)

--- a/internal/rules/nospaceinlinktext/rule_test.go
+++ b/internal/rules/nospaceinlinktext/rule_test.go
@@ -98,6 +98,17 @@ func TestFixImagesDisabled_LeavesImageAltUntouched(t *testing.T) {
 	assert.Equal(t, src, result, "Fix must leave image alt untouched when CheckImages=false")
 }
 
+// TestEmptyLinkText_NoDiagnostic pins the `len(inner) == 0`
+// short-circuit in diagsForSpan: a link with empty brackets
+// `[](url)` has zero inner bytes, so neither leading- nor
+// trailing-space checks make sense — return without flagging.
+// MDS049 leaves empty link text to MDS063 (descriptive-link-text)
+// since "empty" is a content concern, not a whitespace concern.
+func TestEmptyLinkText_NoDiagnostic(t *testing.T) {
+	diags := check(t, "# T\n\n[](https://example.com)\n", true)
+	assert.Empty(t, diags, "empty link text must not trigger a leading/trailing-space diagnostic")
+}
+
 func TestNewlineInLinkTextNotFlagged(t *testing.T) {
 	// Newline between words inside brackets must not be flagged.
 	diags := check(t, "# T\n\n[long text that\nwraps](url)\n", true)

--- a/internal/rules/nospaceinlinktext/rule_test.go
+++ b/internal/rules/nospaceinlinktext/rule_test.go
@@ -109,6 +109,21 @@ func TestEmptyLinkText_NoDiagnostic(t *testing.T) {
 	assert.Empty(t, diags, "empty link text must not trigger a leading/trailing-space diagnostic")
 }
 
+// TestDiagsForSpan_EmptyInner pins diagsForSpan's empty-inner
+// branch at the helper level. spanForNode usually rejects empty
+// spans earlier via bracketSpan, but the helper is also reached
+// from the Fix path through collectSpans; pin the contract that
+// an empty span never emits a whitespace diagnostic regardless of
+// which caller constructed it.
+func TestDiagsForSpan_EmptyInner(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("[](u)\n"))
+	require.NoError(t, err)
+	// [ at 0, ] at 1, inner = source[1:1] = "".
+	s := span{open: 0, close: 1, img: false}
+	diags := diagsForSpan(s, f, "MDS049", "no-space-in-link-text")
+	assert.Nil(t, diags, "empty inner span must not flag whitespace")
+}
+
 func TestNewlineInLinkTextNotFlagged(t *testing.T) {
 	// Newline between words inside brackets must not be flagged.
 	diags := check(t, "# T\n\n[long text that\nwraps](url)\n", true)

--- a/internal/rules/notrailingpunctuation/rule.go
+++ b/internal/rules/notrailingpunctuation/rule.go
@@ -30,45 +30,48 @@ func (r *Rule) Category() string { return "heading" }
 // at the end of a heading.
 const flaggedPunctuation = ".,;:!"
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-heading logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		heading, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		text := astutil.HeadingText(heading, f.Source)
-		text = strings.TrimSpace(text)
-		if len(text) == 0 {
-			return ast.WalkContinue, nil
-		}
-		if text == "..." {
-			// Reserved wildcard marker for required-structure prototypes.
-			return ast.WalkContinue, nil
-		}
-
-		lastChar := text[len(text)-1]
-		if strings.ContainsRune(flaggedPunctuation, rune(lastChar)) {
-			line := astutil.HeadingLine(heading, f)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     line,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  fmt.Sprintf("heading should not end with punctuation %q", string(lastChar)),
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	return rule.WalkNodes(r, f)
 }
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	heading, ok := n.(*ast.Heading)
+	if !ok {
+		return nil
+	}
+
+	text := astutil.HeadingText(heading, f.Source)
+	text = strings.TrimSpace(text)
+	if len(text) == 0 {
+		return nil
+	}
+	if text == "..." {
+		// Reserved wildcard marker for required-structure prototypes.
+		return nil
+	}
+
+	lastChar := text[len(text)-1]
+	if strings.ContainsRune(flaggedPunctuation, rune(lastChar)) {
+		line := astutil.HeadingLine(heading, f)
+		return []lint.Diagnostic{{
+			File:     f.Path,
+			Line:     line,
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  fmt.Sprintf("heading should not end with punctuation %q", string(lastChar)),
+		}}
+	}
+	return nil
+}
+
+var _ rule.NodeChecker = (*Rule)(nil)

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -46,23 +46,24 @@ func (r *Rule) Category() string { return "list" }
 // users pick a project convention and turn the rule on.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-list logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
+	return rule.WalkNodes(r, f)
+}
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		list, ok := n.(*ast.List)
-		if !ok || !list.IsOrdered() {
-			return ast.WalkContinue, nil
-		}
-		diags = append(diags, r.checkList(f, list)...)
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	list, ok := n.(*ast.List)
+	if !ok || !list.IsOrdered() {
+		return nil
+	}
+	return r.checkList(f, list)
 }
 
 // checkList emits diagnostics for one ordered list. Nested ordered
@@ -441,4 +442,5 @@ var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.FixableRule  = (*Rule)(nil)
 	_ rule.Defaultable  = (*Rule)(nil)
+	_ rule.NodeChecker  = (*Rule)(nil)
 )

--- a/internal/rules/paragraphstructure/rule.go
+++ b/internal/rules/paragraphstructure/rule.go
@@ -32,6 +32,22 @@ func (r *Rule) Name() string { return "paragraph-structure" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "prose" }
 
+// EnabledByDefault implements rule.Defaultable. MDS024 is opt-in
+// because exact sentence counting and per-sentence word counting
+// require the trained Punkt segmenter
+// (github.com/neurosnap/sentences), which the neutral CPU profile
+// recorded in [plan 187](../../../plan/187_neutral-corpus-engine-lever.md)
+// attributes ~20% of mdsmith's wall time to on prose-heavy input.
+// Punkt's cost is the trained model's regex execution
+// (english.MultiPunctWordAnnotation.tokenAnnotation runs reAbbr
+// and the token-type matchers with backtracking on every period-
+// ending token), and there is no Punkt-equivalent faster pure-Go
+// segmenter — [plan 187](../../../plan/187_neutral-corpus-engine-lever.md)
+// records the negative with a reusable equivalence harness. Users
+// who want the diagnostic enable it explicitly; the default check
+// path stops paying the ~20%.
+func (r *Rule) EnabledByDefault() bool { return false }
+
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
@@ -195,4 +211,5 @@ func (r *Rule) SettingMergeMode(key string) rule.MergeMode {
 var (
 	_ rule.Configurable = (*Rule)(nil)
 	_ rule.ListMerger   = (*Rule)(nil)
+	_ rule.Defaultable  = (*Rule)(nil)
 )

--- a/internal/rules/paragraphstructure/rule.go
+++ b/internal/rules/paragraphstructure/rule.go
@@ -36,16 +36,21 @@ func (r *Rule) Category() string { return "prose" }
 // because exact sentence counting and per-sentence word counting
 // require the trained Punkt segmenter
 // (github.com/neurosnap/sentences), which the neutral CPU profile
-// recorded in [plan 187](../../../plan/187_neutral-corpus-engine-lever.md)
-// attributes ~20% of mdsmith's wall time to on prose-heavy input.
-// Punkt's cost is the trained model's regex execution
-// (english.MultiPunctWordAnnotation.tokenAnnotation runs reAbbr
-// and the token-type matchers with backtracking on every period-
-// ending token), and there is no Punkt-equivalent faster pure-Go
-// segmenter — [plan 187](../../../plan/187_neutral-corpus-engine-lever.md)
-// records the negative with a reusable equivalence harness. Users
-// who want the diagnostic enable it explicitly; the default check
-// path stops paying the ~20%.
+// recorded in plan 187 attributes ~20% of mdsmith's wall time on
+// prose-heavy input. Punkt's cost is the trained model's regex
+// execution (english.MultiPunctWordAnnotation.tokenAnnotation
+// runs reAbbr and the token-type matchers with backtracking on
+// every period-ending token), and no pure-Go Punkt-equivalent
+// faster segmenter exists — plan 187 records the negative with a
+// reusable equivalence harness. Users who want the diagnostic
+// enable it explicitly; the default check path stops paying the
+// ~20%.
+//
+// NOTE: This is a behaviour change. Before this rule implemented
+// rule.Defaultable, MDS024 ran on every default check. Existing
+// .mdsmith.yml configs that did not pin paragraph-structure will
+// no longer emit prose-structure diagnostics until they opt in
+// via `rules: { paragraph-structure: true }`.
 func (r *Rule) EnabledByDefault() bool { return false }
 
 // Check implements rule.Rule.

--- a/internal/rules/paragraphstructure/rule_test.go
+++ b/internal/rules/paragraphstructure/rule_test.go
@@ -354,3 +354,15 @@ func TestSettingMergeMode_ParagraphStructure(t *testing.T) {
 	assert.Equal(t, rule.MergeReplace, r.SettingMergeMode("max-sentences"))
 	assert.Equal(t, rule.MergeReplace, r.SettingMergeMode("unknown"))
 }
+
+// TestEnabledByDefault pins MDS024 as opt-in. Punkt-based exact
+// sentence counting and per-sentence word counting cost ~20% of
+// mdsmith's wall time on prose-heavy input (plan 187 profile); the
+// rule's value is the precise diagnostic, so users who want it
+// enable it explicitly rather than every default check paying the
+// segmenter cost.
+func TestEnabledByDefault(t *testing.T) {
+	r := &Rule{}
+	assert.False(t, r.EnabledByDefault(),
+		"MDS024 must be opt-in — see EnabledByDefault godoc for cost rationale")
+}

--- a/internal/rules/tocdirective/rule.go
+++ b/internal/rules/tocdirective/rule.go
@@ -90,9 +90,9 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	if !entering {
 		return nil
 	}
-	if f == nil || f.AST == nil {
-		return nil
-	}
+	// The engine path never calls CheckNode with a nil File or AST,
+	// and rule.WalkNodes (the standalone Check path) short-circuits
+	// nil ASTs before invoking the walk. No duplicate guard here.
 	para, ok := n.(*ast.Paragraph)
 	if !ok {
 		return nil

--- a/internal/rules/tocdirective/rule.go
+++ b/internal/rules/tocdirective/rule.go
@@ -56,50 +56,76 @@ func (r *Rule) Category() string { return "directive" }
 // EnabledByDefault implements rule.Defaultable.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-paragraph logic is pure and
+// stateless once the `hasTOCRef` lookup is shared via File.Memo; the
+// engine can fold this rule into one shared AST walk and a direct
+// call still works via rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	if f == nil || f.AST == nil {
 		return nil
 	}
+	return rule.WalkNodes(r, f)
+}
 
-	hasTOCRef := hasTOCLinkReference(f.Source)
+// memoKey scopes the once-per-File hasTOCLinkReference cache. The
+// File.Memo store is per-Check (so the value is recomputed for each
+// new file) and rule-namespaced (so it can never collide with another
+// rule's key).
+const memoKey = "mds035:hasTOCLinkReference"
 
-	var diags []lint.Diagnostic
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		para, ok := n.(*ast.Paragraph)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-		lines := para.Lines()
-		for i := 0; i < lines.Len(); i++ {
-			seg := lines.At(i)
-			lineText := strings.TrimRight(
-				string(seg.Value(f.Source)), "\r\n",
-			)
-			v, matched := matchVariant(lineText)
-			if !matched {
-				continue
-			}
-			if v.isLinkRefCandidate && hasTOCRef {
-				continue
-			}
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     f.LineOfOffset(seg.Start),
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Warning,
-				Message:  buildMessage(v.token),
-			})
-		}
-		return ast.WalkContinue, nil
+// hasTOCRefMemoized returns the once-per-File hasTOCLinkReference
+// result. The lookup walks the document with goldmark's parser and is
+// not cheap enough to repeat for every paragraph node, so it is
+// memoised on f.
+func hasTOCRefMemoized(f *lint.File) bool {
+	v := f.Memo(memoKey, func() any {
+		return hasTOCLinkReference(f.Source)
 	})
+	got, _ := v.(bool)
+	return got
+}
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	if f == nil || f.AST == nil {
+		return nil
+	}
+	para, ok := n.(*ast.Paragraph)
+	if !ok {
+		return nil
+	}
+	hasTOCRef := hasTOCRefMemoized(f)
+	var diags []lint.Diagnostic
+	lines := para.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		seg := lines.At(i)
+		lineText := strings.TrimRight(
+			string(seg.Value(f.Source)), "\r\n",
+		)
+		v, matched := matchVariant(lineText)
+		if !matched {
+			continue
+		}
+		if v.isLinkRefCandidate && hasTOCRef {
+			continue
+		}
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     f.LineOfOffset(seg.Start),
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  buildMessage(v.token),
+		})
+	}
 	return diags
 }
+
+var _ rule.NodeChecker = (*Rule)(nil)
 
 func matchVariant(line string) (tocVariant, bool) {
 	for _, v := range variants {

--- a/internal/rules/tocdirective/rule_test.go
+++ b/internal/rules/tocdirective/rule_test.go
@@ -241,3 +241,21 @@ func TestFix_CodeBlocks_Untouched(t *testing.T) {
 	// But not replaced with <?toc?>.
 	assert.NotContains(t, fixed, "<?toc?>")
 }
+
+// TestHasTOCLinkReference covers the helper's three branches.
+// The empty-source short-circuit avoids spinning up a fresh parser
+// for a no-op case (hot when CheckNode is called on every node of
+// a small document); without an explicit test the branch shows up
+// as uncovered patch coverage.
+func TestHasTOCLinkReference(t *testing.T) {
+	t.Run("empty source returns false without parsing", func(t *testing.T) {
+		assert.False(t, hasTOCLinkReference(nil))
+		assert.False(t, hasTOCLinkReference([]byte{}))
+	})
+	t.Run("source with TOC reference returns true", func(t *testing.T) {
+		assert.True(t, hasTOCLinkReference([]byte("[TOC]: #\n")))
+	})
+	t.Run("source without TOC reference returns false", func(t *testing.T) {
+		assert.False(t, hasTOCLinkReference([]byte("# Title\n\nbody\n")))
+	})
+}

--- a/internal/rules/unclosedcodeblock/rule.go
+++ b/internal/rules/unclosedcodeblock/rule.go
@@ -25,37 +25,39 @@ func (r *Rule) Name() string { return "unclosed-code-block" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "code" }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The per-block logic is pure and
+// stateless, so it is expressed as CheckNode and the engine can fold
+// this rule into one shared AST walk; a direct call still works via
+// rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	var diags []lint.Diagnostic
-
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		fcb, ok := n.(*ast.FencedCodeBlock)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
-		if !hasClosingFence(f, fcb) {
-			openLine := fencepos.OpenLine(f, fcb)
-			diags = append(diags, lint.Diagnostic{
-				File:     f.Path,
-				Line:     openLine,
-				Column:   1,
-				RuleID:   r.ID(),
-				RuleName: r.Name(),
-				Severity: lint.Error,
-				Message:  "unclosed fenced code block",
-			})
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	return diags
+	return rule.WalkNodes(r, f)
 }
+
+// CheckNode implements rule.NodeChecker.
+func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if !entering {
+		return nil
+	}
+	fcb, ok := n.(*ast.FencedCodeBlock)
+	if !ok {
+		return nil
+	}
+	if hasClosingFence(f, fcb) {
+		return nil
+	}
+	openLine := fencepos.OpenLine(f, fcb)
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     openLine,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Error,
+		Message:  "unclosed fenced code block",
+	}}
+}
+
+var _ rule.NodeChecker = (*Rule)(nil)
 
 // hasClosingFence checks whether a fenced code block has a proper closing
 // fence line after its content.

--- a/plan/189_multiplex-finish.md
+++ b/plan/189_multiplex-finish.md
@@ -1,0 +1,123 @@
+---
+id: 189
+title: Finish the multiplex migration for pure per-node rules
+status: "🔳"
+model: opus
+depends-on: [187]
+summary: >-
+  Migrate every default rule whose Check is a pure per-node, stateless
+  pass to rule.NodeChecker so the engine drives them from one shared
+  ast.Walk. Reverses plan 187's task 3 deferral after a follow-up review
+  judged the compound impact of multiple sub-10% improvements is the
+  way to close the gap to faster Rust linters.
+---
+# Finish the multiplex migration for pure per-node rules
+
+## Goal
+
+Migrate every default rule whose Check is a pure per-node, stateless
+pass to the rule.NodeChecker interface. The engine then runs one
+shared ast.Walk over the AST instead of N per-rule walks. Three rules
+were already migrated as a prototype in plan 187 task 3 (MDS002,
+MDS010, MDS018); this finishes the sweep across the rest.
+
+## Background
+
+[Plan 187](187_neutral-corpus-engine-lever.md) prototyped the
+multiplexed walk. It concluded the full migration was "not worth the
+cross-rule churn". The per-document walk flat cost was about 6%, far
+smaller than the 44% cumulative goldmark walkHelper showed.
+
+A follow-up review judged differently. The compound impact of
+multiple sub-10% improvements is how mdsmith closes the gap to
+faster Rust linters. A 6% trim is worth taking when it stacks on
+the next one. This plan reverses the deferral.
+
+A rule is migratable when:
+
+- Its Check does only `ast.Walk(f.AST, ...)` plus trivial setup
+  (precomputed maps shared across nodes, e.g. `CollectCodeBlockLines`).
+- Each visited node is inspected independently — no state is carried
+  across nodes.
+- It does not rely on `ast.WalkSkipChildren` or `ast.WalkStop` on the
+  top-level walk for correctness (using them as optimisations on
+  child walks inside helper functions is fine).
+
+Stateful rules keep their per-rule walks. The full list lives under
+"Not migrated" below.
+
+## Tasks
+
+1. [x] Write this plan.
+2. [x] Migrate the heading batch: MDS013 blank-line-around-headings,
+   MDS017 no-trailing-punctuation-in-heading.
+3. [x] Migrate the list batch: MDS014 blank-line-around-lists, MDS016
+   list-indent, MDS045 list-marker-style, MDS046 ordered-list-numbering,
+   MDS061 list-marker-space.
+4. [x] Migrate the code batch: MDS011 fenced-code-language, MDS015
+   blank-line-around-fenced-code, MDS031 unclosed-code-block, MDS052
+   no-space-in-code-spans.
+5. [x] Migrate the prose / link batch: MDS012 no-bare-urls, MDS032
+   no-empty-alt-text, MDS035 toc-directive, MDS041 no-inline-html, MDS042
+   emphasis-style, MDS044 horizontal-rule-style, MDS049 no-space-in-link-text,
+   MDS055 forbidden-paragraph-starts, MDS056 forbidden-text, MDS063
+   descriptive-link-text.
+6. [x] Extend `TestCheckRules_MultiplexedEqualsSequential` (or add a
+   per-rule equivalence test) so it pins every migrated rule's
+   diagnostic output as byte-identical to the pre-migration Check.
+
+## Acceptance Criteria
+
+- [x] All migratable rules implement `rule.NodeChecker`; their `Check`
+      delegates to `rule.WalkNodes(r, f)`.
+- [x] The list of "Not migrated — reason" is recorded at the bottom of
+      this file.
+- [x] `go test ./...` passes.
+- [x] `mdsmith check .` passes (generated sections in sync).
+- [x] `go tool golangci-lint run` reports no issues.
+- [x] The existing byte-identity test in
+      [internal/engine/multiplex_test.go](../internal/engine/multiplex_test.go)
+      still pins multiplexed output to sequential.
+
+## Not migrated — reason
+
+- **MDS003 heading-increment**: tracks `prevLevel` across headings.
+- **MDS005 no-duplicate-headings**: builds a `seen` map across headings.
+- **MDS051 single-h1**: collects all H1s before emitting diagnostics.
+- **MDS036 max-section-length**: collects all headings to compute
+  per-section bounds.
+- **MDS037 duplicated-content**: collects paragraphs to compare against
+  one another.
+- **MDS050 proper-names**: uses `WalkSkipChildren` for correctness on
+  code spans / HTML blocks, then post-sorts and deduplicates matches.
+- **MDS020 required-structure**: collects headings into an ordered list
+  before validating against the schema.
+- **MDS043 no-reference-style**: multi-pass — needs to know whether
+  any reference-style link exists before reporting unused-definition
+  diagnostics.
+- **MDS029 conciseness-scoring**: opt-in; one-time scorer load
+  failure is reported by `errReportedOnce` outside the walk; not
+  worth complicating the engine path for an opt-in rule.
+- **MDS024 paragraph-structure**, **paragraph-readability**: already
+  share a memoized paragraph collector (plan 187 task 2) and never
+  walked `f.AST` directly.
+- **MDS034 markdown-flavor**: does not walk f.AST; uses its own
+  `DetectFiltered` line-and-AST scan.
+- **MDS027 cross-file-reference-integrity**, **MDS021 include**,
+  **MDS019 catalog**, **MDS038 toc**, **MDS039 build**, **MDS048
+  git-hook-sync**: cross-file or directive engines; their Check
+  bodies do not walk the host AST node-by-node.
+- **MDS001 line-length**, **MDS006 no-trailing-spaces**, **MDS007
+  no-hard-tabs**, **MDS008 no-multiple-blanks**, **MDS009 single-
+  trailing-newline**, **MDS022 max-file-length**, **MDS025 table-
+  format**, **MDS026 table-readability**, **MDS028 token-budget**,
+  **MDS033 directory-structure**, **MDS040 recipe-safety**, **MDS047
+  ambiguous-emphasis**, **MDS053 no-unused-link-definitions**, **MDS054
+  no-undefined-reference-labels**, **MDS057 required-text-patterns**,
+  **MDS058 required-mentions**, **MDS059 blockquote-whitespace**,
+  **MDS064 atx-heading-whitespace**: do not walk f.AST in Check at
+  all (line-level scans, table extractors, file-level checks).
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/189_multiplex-finish.md
+++ b/plan/189_multiplex-finish.md
@@ -1,7 +1,7 @@
 ---
 id: 189
 title: Finish the multiplex migration for pure per-node rules
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: [187]
 summary: >-

--- a/plan/190_intra-file-rule-parallelism.md
+++ b/plan/190_intra-file-rule-parallelism.md
@@ -1,0 +1,87 @@
+---
+id: 190
+title: Intra-file rule parallelism for non-NodeChecker rules
+status: "🔳"
+model: opus
+depends-on: [187, 189]
+summary: >-
+  Run the non-NodeChecker subset of a file's rules concurrently within
+  one file when the file-level worker pool has not saturated the
+  available cores. Reverses plan 187's task 5 deferral — small-file
+  LSP / PR runs leave most cores idle, so this is a free win on the
+  exact paths users feel most.
+---
+# Intra-file rule parallelism for non-NodeChecker rules
+
+## Goal
+
+Parallelize the non-NodeChecker subset of a single file's rules when
+the file-level worker pool leaves cores idle. Examples include
+`mdsmith lsp` linting one file, or a 5-file PR check on a 16-core
+host. Each rule's Check is independent: rule clones are per-call, the
+File is read-only, and `File.Memo` is `sync.Map`-safe. Diagnostics
+remain byte-identical to the sequential path because slots are
+concatenated in rules order after the workers join.
+
+## Background
+
+[Plan 187](187_neutral-corpus-engine-lever.md) task 5 deferred this
+work because the multiplex experiment was flat. A follow-up review
+judged the compound impact of small wins is the way to close the
+gap to faster Rust linters. An intra-file boost on the small-file
+LSP path lands directly on user-visible latency, not on batch wall
+time alone.
+
+Concurrency model:
+
+- The file-level pool (`Runner.runFiles`) decides its worker count
+  in `ResolveWorkers`. Pass that count into `checkRules` via a new
+  parameter so the inner pool can decide how many cores remain.
+- Each non-NodeChecker rule's `Check(f)` writes to its own slot only;
+  results merge in rules order after the workers join, so output is
+  byte-identical to serial.
+- `Runner.IntraFileConcurrency` gates the behaviour: 0 = auto, 1 =
+  disabled, n>1 = explicit cap. Auto picks
+  `max(1, GOMAXPROCS / max(1, fileWorkers))`.
+- `RunSource` (LSP single-file path) uses `GOMAXPROCS` directly —
+  there is no file-level pool to compete with.
+
+## Tasks
+
+1. [x] Write this plan.
+2. [x] Add `Runner.IntraFileConcurrency` (int, default 0 = auto). Thread
+   the file-worker count from `runFiles` into `lintFile` and
+   `checkRules`. Compute the auto cap once per Run.
+3. [x] Refactor `checkRules` to run non-NodeChecker slots concurrently
+   when the cap > 1, preserving slot order at the end. Keep the
+   NodeChecker multiplex unchanged (a single shared walk is already
+   internally serial).
+4. [x] Add tests in `internal/engine/intrafile_test.go`:
+       `TestCheckRules_ParallelEqualsSequential` mirroring the
+       multiplex byte-identity test; `TestCheckRules_ParallelRespectsRulesOrder`
+       to pin slot order; `TestCheckRules_ParallelHonorsCap` using an
+       atomic concurrency counter inside a stub rule.
+5. [x] Run `go test -race ./internal/engine/...` to confirm
+       race-cleanness.
+6. [x] Extend `BenchmarkCheckCorpusSmall`/`Large` numbers or add a
+       small-file-count variant that exercises the intra-file path
+       (few files, many cores). Record before/after in the plan.
+
+## Acceptance Criteria
+
+- [x] `Runner.IntraFileConcurrency` field exists with the documented
+      semantics (0=auto, 1=off, n>1 explicit cap).
+- [x] Auto cap formula in code:
+      `max(1, GOMAXPROCS / max(1, fileWorkers))` for `Run`, and
+      `GOMAXPROCS` for `RunSource`.
+- [x] Diagnostic output remains byte-identical to the sequential
+      path on every existing fixture.
+- [x] New tests pass under both `go test ./internal/engine/...` and
+      `go test -race ./internal/engine/...`.
+- [x] `mdsmith check .` passes and `go tool golangci-lint run` reports
+      no issues.
+- [x] `BenchmarkCheckCorpus{Small,Large}` stays within budget.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/190_intra-file-rule-parallelism.md
+++ b/plan/190_intra-file-rule-parallelism.md
@@ -1,7 +1,7 @@
 ---
 id: 190
 title: Intra-file rule parallelism for non-NodeChecker rules
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: [187, 189]
 summary: >-
@@ -63,9 +63,26 @@ Concurrency model:
        atomic concurrency counter inside a stub rule.
 5. [x] Run `go test -race ./internal/engine/...` to confirm
        race-cleanness.
-6. [x] Extend `BenchmarkCheckCorpusSmall`/`Large` numbers or add a
-       small-file-count variant that exercises the intra-file path
-       (few files, many cores). Record before/after in the plan.
+6. [x] Add `BenchmarkCheckCorpusFewFiles` plus a control variant
+       `BenchmarkCheckCorpusFewFilesNoIntraFile`. Record numbers
+       below.
+
+## Benchmark deltas
+
+Measured on the 4-vCPU sandbox; intra-file cap auto vs cap=1, same
+workload, 50 samples each:
+
+- `BenchmarkCheckCorpusFewFiles`: p95 ~3 ms with intra-file auto.
+- `BenchmarkCheckCorpusFewFilesNoIntraFile`: p95 ~5 ms with cap=1.
+- Standing budgets unchanged: `BenchmarkCheckCorpusSmall` p95 ~29
+  ms (budget 2 s); `BenchmarkCheckCorpusLarge` p95 ~187 ms (budget
+  12 s).
+
+The small/large numbers are flat because the file-level pool
+already saturates the four cores there. The few-files variant
+exercises the path this plan targets — the intra-file pool reclaims
+the cores left idle when the outer pool has nothing to do — and
+shows a ~40% latency drop.
 
 ## Acceptance Criteria
 

--- a/plan/191_punkt-reabbr-dfa.md
+++ b/plan/191_punkt-reabbr-dfa.md
@@ -1,0 +1,176 @@
+---
+id: 191
+title: Hand-rolled DFA for Punkt's `reAbbr` to skip regex backtracking
+status: "🔲"
+model: opus
+depends-on: []
+summary: >-
+  Punkt's English-pass abbreviation classifier runs the regex
+  `((?:[\w]\.)+[\w]*\.)` on every period-ending token. A focused
+  profile of `SplitSentences` over a representative corpus shows
+  `regexp.(*Regexp).tryBacktrack` at 13% flat / 24% cumulative of
+  CPU — the largest single attributable cost inside the segmenter.
+  Replace `reAbbr.FindAllString` with a hand-rolled DFA scanner
+  that returns a byte-identical answer with no backtracking
+  engine. The existing equivalence harness in `internal/mdtext`
+  gates the change against `SplitSentences` drift.
+---
+# Hand-rolled DFA for Punkt's `reAbbr` to skip regex backtracking
+
+## Goal
+
+Cut MDS024's runtime without changing its diagnostic.
+Target a 10–15% drop in `mdtext.SplitSentences` wall time
+on prose-heavy input. Remove the `regexp` engine from the
+hottest abbreviation classifier inside the trained Punkt
+pipeline.
+
+## Background
+
+The cost is concrete and measured.
+[`BenchmarkSplitSentences`][bench] runs at ~176 µs/op,
+593 allocs/op. The CPU profile attributes the time as:
+
+- `regexp.(*Regexp).tryBacktrack` — 13% flat, 24% cum.
+  The NFA backtracking loop.
+- `regexp.(*Regexp).doExecute` — 37% cum.
+- `english.MultiPunctWordAnnotation.tokenAnnotation` —
+  39% cum. It runs `reAbbr.FindAllString(tok, 1)` on
+  every period-ending token.
+
+[bench]: ../internal/mdtext/sentence_equivalence_test.go
+
+`reAbbr` is defined at [`english/main.go:15`][upstream]
+as `((?:[\w]\.)+[\w]*\.)`. It matches tokens with
+multiple internal periods. Patterns like `U.S.`, `p.m.`,
+`e.g.`, `i.e.`, and initials like `J.R.R.` match. These
+are exactly the patterns where Punkt must demote a
+tentative sentence boundary to "this is an abbreviation,
+not a terminator".
+
+[upstream]: https://github.com/neurosnap/sentences/blob/v1.1.2/english/main.go
+
+The `(?:...)+` repetition drives `tryBacktrack`. Go's
+`regexp` engine falls back to backtracking for patterns
+it cannot run on the one-pass DFA path. This one does.
+The cost scales with period-ending tokens per file.
+That is the dominant token class on prose-heavy input.
+
+`reAbbr` has a small, regular structure. A hand-rolled
+DFA scanner over runes can decide membership in one
+linear pass. No allocations. No backtracking. The
+[equivalence harness][bench] already pins
+`SplitSentences` output to be byte-identical to upstream
+across a representative corpus. Drift is caught at the
+next test run.
+
+The change stays local to mdsmith. No fork.
+
+The upstream library exposes the needed types:
+
+- `AnnotateTokens` — the interface.
+- `Storage` and `PunctStrings` — carry trained data.
+- `MultiPunctWordAnnotation`'s component fields — all
+  exported.
+
+mdsmith builds its own tokenizer with three annotators:
+
+- `TypeBasedAnnotation` — upstream, unchanged.
+- `TokenBasedAnnotation` — upstream, unchanged.
+- `FastMultiPunctWordAnnotation` — new. Only the
+  abbreviation matcher differs from upstream.
+
+## Tasks
+
+1. [ ] Create this plan.
+2. [ ] Add a `BenchmarkSplitSentences_Subset` that isolates the
+   hot pattern (a corpus of abbreviation-heavy short paragraphs)
+   so the optimization's effect is visible without being diluted
+   by the rest of the equivalence corpus.
+3. [ ] Implement `matchAbbrPattern(tok string) bool` in a new
+   `internal/mdtext/abbr.go`. The function must return
+   `true` if and only if `reAbbr.FindAllString(tok, 1)` would
+   return a non-empty slice on the same input. Write the failing
+   unit test first: a table of inputs the regex matches (`U.S.`,
+   `p.m.`, `J.R.R.`, `a.b.c.`, `e.g.`) and inputs it does not
+   (`Mr.`, `hello.`, `3.14`, `a..b`, `.`, empty string), with the
+   reference being `reAbbr.FindAllString(tok, 1)` itself.
+4. [ ] Build a `FastMultiPunctWordAnnotation` (in
+   `internal/mdtext/fastpunct.go`) that mirrors upstream
+   `english.MultiPunctWordAnnotation` line-for-line except the
+   `reAbbr.FindAllString(tokOne.Tok, 1)` call is replaced by
+   `matchAbbrPattern(tokOne.Tok)`. The annotator embeds the same
+   `*Storage`, `PunctStrings`, `TokenExistential`, `TokenParser`,
+   `TokenGrouper`, and `Ortho` fields the upstream type uses, so
+   no further behavioural drift is possible.
+5. [ ] Switch `initTokenizer` in
+   [`internal/mdtext/mdtext.go`](../internal/mdtext/mdtext.go) to
+   construct the tokenizer manually with annotators
+   `[TypeBasedAnnotation, TokenBasedAnnotation,
+   FastMultiPunctWordAnnotation]`. Keep the previous
+   `english.NewSentenceTokenizer(nil)` path behind a build tag
+   `mdtext_punkt_upstream` for A/B verification.
+6. [ ] Run the existing [`TestSplitSentences_IsItsOwnReference`][bench]
+   and the `english/main_test.go` golden-rules corpus through
+   the fast path. Both must be byte-for-byte identical to the
+   upstream output. If either drifts, the hand-rolled matcher
+   is wrong — fix it.
+7. [ ] Profile and record the new
+   `BenchmarkSplitSentences` and `BenchmarkSplitSentences_Subset`
+   numbers in this plan's `## Results` section. Confirm
+   `BenchmarkCheckCorpus{Small,Large}` stay within budget
+   (Small p95 27 ms / 2 s, Large p95 189 ms / 12 s) and that the
+   abbreviation-heavy `BenchmarkSplitSentences_Subset` drops by
+   at least 10% — if it does not, the lever was smaller than the
+   profile suggested and the change is rejected.
+8. [ ] If the change ships, document the fast-path annotator in
+   the MDS024 README under "How it works" so the optimization is
+   visible to anyone reading the rule docs.
+
+## Results
+
+To be filled in by task 7. Initial baseline (recorded today):
+
+```text
+BenchmarkSplitSentences-4    13256    176457 ns/op    29747 B/op    593 allocs/op
+```
+
+CPU profile attribution (regex-heavy frames):
+
+- `regexp.(*Regexp).tryBacktrack`: 13.02% flat / 23.64% cum
+- `regexp.(*Regexp).doExecute`: 0.65% flat / 37.09% cum
+- `english.MultiPunctWordAnnotation.tokenAnnotation`: 1.52% flat / 39.05% cum
+
+## Risk
+
+The hand-rolled matcher must be byte-equivalent to the regex on
+every conceivable token shape Punkt feeds it. The equivalence
+harness covers a representative corpus but is not exhaustive over
+the rune space. Task 3's unit test must use
+`reAbbr.FindAllString(tok, 1)` directly as the reference, so a
+property-style table of inputs hits every branch of the DFA
+against the regex's own answer.
+
+If the upstream library updates `reAbbr` in a future
+neurosnap/sentences release, the local fast path silently
+diverges. The equivalence harness catches that on the next test
+run. To make the drift visible without running tests, the build
+tag `mdtext_punkt_upstream` (task 5) lets a developer flip back
+to upstream and verify.
+
+## Acceptance Criteria
+
+- [ ] `matchAbbrPattern` returns the same boolean as
+      `reAbbr.FindAllString(tok, 1) != nil` for every input in
+      the abbreviation-equivalence table (task 3); the test
+      explicitly cross-checks against the regex.
+- [ ] `TestSplitSentences_IsItsOwnReference` passes — the fast
+      path is byte-identical to upstream over the equivalence
+      corpus.
+- [ ] `BenchmarkSplitSentences_Subset` (abbreviation-heavy)
+      improves by ≥10% on the 4-vCPU sandbox; absolute number
+      recorded in `## Results`.
+- [ ] `BenchmarkCheckCorpus{Small,Large}` remain within budget.
+- [ ] `mdsmith check .` passes.
+- [ ] `go test ./...` and `go test -race ./...` pass.
+- [ ] `go tool golangci-lint run` reports no issues.

--- a/plan/191_punkt-reabbr-dfa.md
+++ b/plan/191_punkt-reabbr-dfa.md
@@ -82,12 +82,11 @@ mdsmith builds its own tokenizer with three annotators:
 
 ## Tasks
 
-1. [ ] Create this plan.
-2. [ ] Add a `BenchmarkSplitSentences_Subset` that isolates the
+1. [ ] Add a `BenchmarkSplitSentences_Subset` that isolates the
    hot pattern (a corpus of abbreviation-heavy short paragraphs)
    so the optimization's effect is visible without being diluted
    by the rest of the equivalence corpus.
-3. [ ] Implement `matchAbbrPattern(tok string) bool` in a new
+2. [ ] Implement `matchAbbrPattern(tok string) bool` in a new
    `internal/mdtext/abbr.go`. The function must return
    `true` if and only if `reAbbr.FindAllString(tok, 1)` would
    return a non-empty slice on the same input. Write the failing
@@ -95,7 +94,7 @@ mdsmith builds its own tokenizer with three annotators:
    `p.m.`, `J.R.R.`, `a.b.c.`, `e.g.`) and inputs it does not
    (`Mr.`, `hello.`, `3.14`, `a..b`, `.`, empty string), with the
    reference being `reAbbr.FindAllString(tok, 1)` itself.
-4. [ ] Build a `FastMultiPunctWordAnnotation` (in
+3. [ ] Build a `FastMultiPunctWordAnnotation` (in
    `internal/mdtext/fastpunct.go`) that mirrors upstream
    `english.MultiPunctWordAnnotation` line-for-line except the
    `reAbbr.FindAllString(tokOne.Tok, 1)` call is replaced by
@@ -103,19 +102,19 @@ mdsmith builds its own tokenizer with three annotators:
    `*Storage`, `PunctStrings`, `TokenExistential`, `TokenParser`,
    `TokenGrouper`, and `Ortho` fields the upstream type uses, so
    no further behavioural drift is possible.
-5. [ ] Switch `initTokenizer` in
+4. [ ] Switch `initTokenizer` in
    [`internal/mdtext/mdtext.go`](../internal/mdtext/mdtext.go) to
    construct the tokenizer manually with annotators
    `[TypeBasedAnnotation, TokenBasedAnnotation,
    FastMultiPunctWordAnnotation]`. Keep the previous
    `english.NewSentenceTokenizer(nil)` path behind a build tag
    `mdtext_punkt_upstream` for A/B verification.
-6. [ ] Run the existing [`TestSplitSentences_IsItsOwnReference`][bench]
+5. [ ] Run the existing [`TestSplitSentences_IsItsOwnReference`][bench]
    and the `english/main_test.go` golden-rules corpus through
    the fast path. Both must be byte-for-byte identical to the
    upstream output. If either drifts, the hand-rolled matcher
    is wrong — fix it.
-7. [ ] Profile and record the new
+6. [ ] Profile and record the new
    `BenchmarkSplitSentences` and `BenchmarkSplitSentences_Subset`
    numbers in this plan's `## Results` section. Confirm
    `BenchmarkCheckCorpus{Small,Large}` stay within budget
@@ -123,7 +122,7 @@ mdsmith builds its own tokenizer with three annotators:
    abbreviation-heavy `BenchmarkSplitSentences_Subset` drops by
    at least 10% — if it does not, the lever was smaller than the
    profile suggested and the change is rejected.
-8. [ ] If the change ships, document the fast-path annotator in
+7. [ ] If the change ships, document the fast-path annotator in
    the MDS024 README under "How it works" so the optimization is
    visible to anyone reading the rule docs.
 

--- a/plan/192_catalog-run-scoped-readcache.md
+++ b/plan/192_catalog-run-scoped-readcache.md
@@ -1,5 +1,5 @@
 ---
-id: 186
+id: 192
 title: Run-scoped read cache for catalog cross-host redundancy
 status: "🔲"
 model: opus

--- a/plan/192_catalog-run-scoped-readcache.md
+++ b/plan/192_catalog-run-scoped-readcache.md
@@ -50,23 +50,22 @@ is trivially safe there. Only the LSP path needs the hook.
 
 ## Tasks
 
-1. [x] Create this plan.
-2. [ ] Add a run-scoped cache type (path -> parsed front matter,
+1. [ ] Add a run-scoped cache type (path -> parsed front matter,
    path -> resolved include adjacency) owned by the engine
    `Runner` and threaded to rules via a context value or a field
    on `*lint.File` that points at the shared cache (not a package
    global — testability and LSP isolation).
-3. [ ] Route `cachedFrontMatter` and `includeTargetsOf` through
+2. [ ] Route `cachedFrontMatter` and `includeTargetsOf` through
    the run cache when present, falling back to the per-Check memo
    when absent (struct-literal `*lint.File` in unit tests).
-4. [ ] Add an `Invalidate(path)` seam; call it from the LSP
+3. [ ] Add an `Invalidate(path)` seam; call it from the LSP
    document-sync path so an edited file's cached read is dropped.
    Unit-test that a second Check after Invalidate re-reads.
-5. [ ] Benchmark the repo corpus before/after with the existing
+4. [ ] Benchmark the repo corpus before/after with the existing
    interleaved-median harness; record the delta here. Confirm the
    neutral corpus (no directives) is unchanged and
    `BenchmarkCheckCorpus{Small,Large}` stays within budget.
-6. [ ] Confirm `mdsmith check .` and the full suite stay green;
+5. [ ] Confirm `mdsmith check .` and the full suite stay green;
    verify race-cleanliness under `-race` (the cache is read by the
    parallel worker pool and the LSP's concurrent readers).
 


### PR DESCRIPTION
## Summary

Implements engine-level performance optimizations from plans 187, 189, 190, and 191. Disables MDS024 paragraph-structure by default (breaking change — see below).

## Key Changes

- **Shared AST walk (plan 187/189)**: Introduced `rule.NodeChecker` interface for pure per-node rules. The engine now drives one shared `ast.Walk` for all enabled NodeCheckers instead of each rule re-walking the document. Migrated 20+ default rules to NodeChecker (heading-style, blank-line-around-headings, no-bare-urls, fenced-code-language, list-indent, etc.).

- **Intra-file rule parallelism (plan 190)**: Non-NodeChecker rules now run concurrently within a single file when the file-level worker pool leaves cores idle. Diagnostics remain byte-identical to sequential execution via per-slot buffering and rules-order concatenation. Added `IntraFileConcurrency` field to `Runner` with auto-tuning: `max(1, GOMAXPROCS / fileWorkers)`. Few-files benchmark (5 files / 4 cores) drops 40% (~5 ms → ~3 ms); large benchmarks unchanged (file pool already saturates cores).

- **MDS024 disabled by default (BREAKING)**: `paragraph-structure` now implements `rule.Defaultable` and returns `false`. The diagnostic requires the trained Punkt sentence segmenter, which is ~20% of `mdsmith check` wall time on prose-heavy input. Users who want the diagnostic enable it explicitly via `rules: { paragraph-structure: true }`. **Existing configs that did not pin the rule will no longer emit MDS024 diagnostics after upgrading.** See the new "How it works" and "Performance" sections in `internal/rules/MDS024-paragraph-structure/README.md` for the exactness contract, the cheap-bounds soundness invariant, and the cost rationale.

- **Plan 191 (Punkt reAbbr DFA)**: Documents the focused optimization for the next round — hand-roll a DFA scanner for `((?:[\w]\.)+[\w]*\.)` to bypass `regexp.tryBacktrack` (13% flat / 24% cum of segmenter CPU). Gated by the existing equivalence harness.

- **Lazy caches on hot-path rules**: `descriptive-link-text` (banned set) and `no-inline-html` (allow set) now build their lookup maps lazily on first `CheckNode` call instead of per node, restoring the per-Check cost the multiplex aims at.

- **File.Memo primitive**: Per-Check memoization on `*lint.File` (backed by `sync.Map`). Used by catalog entries and `CollectSectionParagraphs`.

## Implementation Details

- `checkRulesWithIntraFile` replaces the sequential loop with a two-phase dispatch: NodeCheckers feed one shared walk, non-NodeCheckers run in parallel slots (or serially if cap=1).
- Slots are kept in rules order so final concatenation reproduces sequential output exactly — verified by `TestCheckRules_MultiplexedEqualsSequential` and `TestCheckRules_ParallelEqualsSequential`.
- Per the test pyramid, new methods (`cachedAllowSet`, `cachedBannedSet`, the `WalkNodes` nil guard) ship with dedicated unit tests pinning identity via `reflect.ValueOf(m).Pointer()`.
- Adds plan documents (189, 190, 191) detailing the lever strategy, cost analysis, and future work.

https://claude.ai/code/session_011yEKAjEGfViXBGUvwc8st3