### PR TITLE
Add markdownlint rule coverage tracking to rule metadata

### DIFF
--- a/internal/rules/MDS001-line-length/README.md
+++ b/internal/rules/MDS001-line-length/README.md
@@ -6,6 +6,9 @@ description: Line exceeds maximum length.
 category: line
 nature: content
 maintainability: null
+markdownlint:
+  - id: MD013
+    name: line-length
 ---
 # MDS001: line-length
 
@@ -251,3 +254,6 @@ This line inside a code block is over 80 characters but within the code-block-ma
 - **Implementation**:
   [source](./)
 - **Category**: line
+- **Markdownlint**: [MD013][mdl-md013] (line-length)
+
+[mdl-md013]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md

--- a/internal/rules/MDS002-heading-style/README.md
+++ b/internal/rules/MDS002-heading-style/README.md
@@ -6,6 +6,9 @@ description: Heading style must be consistent.
 category: heading
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD003
+    name: heading-style
 ---
 # MDS002: heading-style
 
@@ -150,3 +153,6 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD003][mdl-md003] (heading-style)
+
+[mdl-md003]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md003.md

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -6,6 +6,9 @@ description: Heading levels should increment by one. No jumping from `#` to `###
 category: heading
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD001
+    name: heading-increment
 ---
 # MDS003: heading-increment
 
@@ -83,3 +86,6 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD001][mdl-md001] (heading-increment)
+
+[mdl-md001]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -6,6 +6,9 @@ description: First line of the file should be a heading.
 category: heading
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD041
+    name: first-line-h1
 ---
 # MDS004: first-line-heading
 
@@ -116,3 +119,6 @@ Some content here.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD041][mdl-md041] (first-line-h1)
+
+[mdl-md041]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md

--- a/internal/rules/MDS005-no-duplicate-headings/README.md
+++ b/internal/rules/MDS005-no-duplicate-headings/README.md
@@ -6,6 +6,9 @@ description: No two headings should have the same text.
 category: heading
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD024
+    name: no-duplicate-heading
 ---
 # MDS005: no-duplicate-headings
 
@@ -77,3 +80,6 @@ Body two.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD024][mdl-md024] (no-duplicate-heading)
+
+[mdl-md024]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md

--- a/internal/rules/MDS006-no-trailing-spaces/README.md
+++ b/internal/rules/MDS006-no-trailing-spaces/README.md
@@ -6,6 +6,9 @@ description: No trailing whitespace at the end of lines.
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD009
+    name: no-trailing-spaces
 ---
 # MDS006: no-trailing-spaces
 
@@ -73,3 +76,6 @@ code block with language tag
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**: [MD009][mdl-md009] (no-trailing-spaces)
+
+[mdl-md009]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md

--- a/internal/rules/MDS007-no-hard-tabs/README.md
+++ b/internal/rules/MDS007-no-hard-tabs/README.md
@@ -6,6 +6,9 @@ description: No tab characters. Use spaces instead.
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD010
+    name: no-hard-tabs
 ---
 # MDS007: no-hard-tabs
 
@@ -74,3 +77,6 @@ No tabs here.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**: [MD010][mdl-md010] (no-hard-tabs)
+
+[mdl-md010]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md

--- a/internal/rules/MDS008-no-multiple-blanks/README.md
+++ b/internal/rules/MDS008-no-multiple-blanks/README.md
@@ -6,6 +6,9 @@ description: No more than one consecutive blank line.
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD012
+    name: no-multiple-blanks
 ---
 # MDS008: no-multiple-blanks
 
@@ -77,3 +80,6 @@ more code with blank lines above
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**: [MD012][mdl-md012] (no-multiple-blanks)
+
+[mdl-md012]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md

--- a/internal/rules/MDS009-single-trailing-newline/README.md
+++ b/internal/rules/MDS009-single-trailing-newline/README.md
@@ -6,6 +6,9 @@ description: File must end with exactly one newline character.
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD047
+    name: single-trailing-newline
 ---
 # MDS009: single-trailing-newline
 
@@ -77,3 +80,6 @@ is what the rule detects.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**: [MD047][mdl-md047] (single-trailing-newline)
+
+[mdl-md047]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md047.md

--- a/internal/rules/MDS010-fenced-code-style/README.md
+++ b/internal/rules/MDS010-fenced-code-style/README.md
@@ -6,6 +6,9 @@ description: Fenced code blocks must use a consistent delimiter.
 category: code
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD048
+    name: code-fence-style
 ---
 # MDS010: fenced-code-style
 
@@ -122,3 +125,6 @@ fmt.Println("hello")
 - **Implementation**:
   [source](./)
 - **Category**: code
+- **Markdownlint**: [MD048][mdl-md048] (code-fence-style)
+
+[mdl-md048]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md

--- a/internal/rules/MDS011-fenced-code-language/README.md
+++ b/internal/rules/MDS011-fenced-code-language/README.md
@@ -6,6 +6,9 @@ description: Fenced code blocks must specify a language.
 category: code
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD040
+    name: fenced-code-language
 ---
 # MDS011: fenced-code-language
 
@@ -73,3 +76,6 @@ fmt.Println("hello")
 - **Implementation**:
   [source](./)
 - **Category**: code
+- **Markdownlint**: [MD040][mdl-md040] (fenced-code-language)
+
+[mdl-md040]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md

--- a/internal/rules/MDS012-no-bare-urls/README.md
+++ b/internal/rules/MDS012-no-bare-urls/README.md
@@ -6,6 +6,9 @@ description: URLs must be wrapped in angle brackets or as a link, not left bare.
 category: link
 nature: content
 maintainability: null
+markdownlint:
+  - id: MD034
+    name: no-bare-urls
 ---
 # MDS012: no-bare-urls
 
@@ -69,3 +72,6 @@ Visit [example](https://example.com) for more.
 - **Implementation**:
   [source](./)
 - **Category**: link
+- **Markdownlint**: [MD034][mdl-md034] (no-bare-urls)
+
+[mdl-md034]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md

--- a/internal/rules/MDS013-blank-line-around-headings/README.md
+++ b/internal/rules/MDS013-blank-line-around-headings/README.md
@@ -6,6 +6,9 @@ description: Headings must have a blank line before and after.
 category: heading
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD022
+    name: blanks-around-headings
 ---
 # MDS013: blank-line-around-headings
 
@@ -79,3 +82,6 @@ Content here.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD022][mdl-md022] (blanks-around-headings)
+
+[mdl-md022]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md

--- a/internal/rules/MDS014-blank-line-around-lists/README.md
+++ b/internal/rules/MDS014-blank-line-around-lists/README.md
@@ -6,6 +6,9 @@ description: Lists must have a blank line before and after.
 category: list
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD032
+    name: blanks-around-lists
 ---
 # MDS014: blank-line-around-lists
 
@@ -81,3 +84,6 @@ Content here.
 - **Implementation**:
   [source](./)
 - **Category**: list
+- **Markdownlint**: [MD032][mdl-md032] (blanks-around-lists)
+
+[mdl-md032]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md032.md

--- a/internal/rules/MDS015-blank-line-around-fenced-code/README.md
+++ b/internal/rules/MDS015-blank-line-around-fenced-code/README.md
@@ -6,6 +6,9 @@ description: Fenced code blocks must have a blank line before and after.
 category: code
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD031
+    name: blanks-around-fences
 ---
 # MDS015: blank-line-around-fenced-code
 
@@ -83,3 +86,6 @@ Content here.
 - **Implementation**:
   [source](./)
 - **Category**: code
+- **Markdownlint**: [MD031][mdl-md031] (blanks-around-fences)
+
+[mdl-md031]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md

--- a/internal/rules/MDS016-list-indent/README.md
+++ b/internal/rules/MDS016-list-indent/README.md
@@ -6,6 +6,12 @@ description: List items must use consistent indentation.
 category: list
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD005
+    name: list-indent
+    partial: true
+  - id: MD007
+    name: ul-indent
 ---
 # MDS016: list-indent
 
@@ -118,3 +124,9 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: list
+- **Markdownlint**:
+  - [MD005][mdl-md005] (list-indent) (partial)
+  - [MD007][mdl-md007] (ul-indent)
+
+[mdl-md005]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md005.md
+[mdl-md007]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md

--- a/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
+++ b/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
@@ -6,6 +6,9 @@ description: Headings should not end with punctuation.
 category: heading
 nature: content
 maintainability: null
+markdownlint:
+  - id: MD026
+    name: no-trailing-punctuation
 ---
 # MDS017: no-trailing-punctuation-in-heading
 
@@ -73,3 +76,6 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD026][mdl-md026] (no-trailing-punctuation)
+
+[mdl-md026]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -6,6 +6,9 @@ description: Don't use bold or emphasis on a standalone line as a heading substi
 category: heading
 nature: content
 maintainability: null
+markdownlint:
+  - id: MD036
+    name: no-emphasis-as-heading
 ---
 # MDS018: no-emphasis-as-heading
 
@@ -81,3 +84,6 @@ This is a normal paragraph.
 - **Implementation**:
   [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD036][mdl-md036] (no-emphasis-as-heading)
+
+[mdl-md036]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md036.md

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -9,6 +9,7 @@ maintainability:
   signal: a list of links to sibling files in the same directory
   fix: adopt a `<?catalog?>` directive so the list stays in sync
   for-diagnostic: false
+markdownlint: null
 ---
 # MDS019: catalog
 

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -9,11 +9,13 @@ maintainability:
   signal: files of a kind that lack an explicit section schema
   fix: declare `kinds.<name>.schema` inline or point `kinds.<name>.rules.required-structure.schema` at a proto file
   for-diagnostic: false
+markdownlint:
+  - id: MD043
+    name: required-headings
 ---
 # MDS020: required-structure
 
-Document structure and front matter must match its
-schema.
+Document structure and front matter must match its schema.
 
 ## Settings
 
@@ -31,9 +33,8 @@ still warns on misplaced `<?require?>` directives. Use
 overrides or `kinds:` to apply schemas to specific file
 groups.
 
-A kind may declare its schema in either form. The
-config loader rejects a kind that sets both — see
-[file kinds](../../../docs/guides/file-kinds.md).
+A kind may declare its schema in either form. The config loader
+rejects a kind that sets both — see [file kinds](../../../docs/guides/file-kinds.md).
 
 Schema front matter may embed a CUE schema that
 validates document front matter. The rule-readme
@@ -359,3 +360,6 @@ Other shapes get no hint.
 - **Guide**:
   [directive guide](../../../docs/guides/directives/enforcing-structure.md)
 - **Category**: structural
+- **Markdownlint**: [MD043][mdl-md043] (required-headings)
+
+[mdl-md043]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md

--- a/internal/rules/MDS021-include/README.md
+++ b/internal/rules/MDS021-include/README.md
@@ -9,6 +9,7 @@ maintainability:
   signal: near-duplicate sections that drift across files
   fix: adopt `<?include?>` so shared content has one source of truth
   for-diagnostic: false
+markdownlint: null
 ---
 # MDS021: include
 

--- a/internal/rules/MDS022-max-file-length/README.md
+++ b/internal/rules/MDS022-max-file-length/README.md
@@ -6,6 +6,7 @@ description: File must not exceed maximum number of lines.
 category: structural
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS022: max-file-length
 

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -6,6 +6,7 @@ description: Paragraph readability index must not exceed a threshold.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS023: paragraph-readability
 

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -6,6 +6,7 @@ description: Paragraphs must not exceed sentence and word limits.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS024: paragraph-structure
 

--- a/internal/rules/MDS025-table-format/README.md
+++ b/internal/rules/MDS025-table-format/README.md
@@ -6,6 +6,7 @@ description: Tables must have consistent column widths and padding.
 category: table
 nature: style
 maintainability: null
+markdownlint: null
 ---
 # MDS025: table-format
 

--- a/internal/rules/MDS026-table-readability/README.md
+++ b/internal/rules/MDS026-table-readability/README.md
@@ -6,6 +6,7 @@ description: Tables must stay within readability complexity limits.
 category: table
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS026: table-readability
 

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -6,6 +6,9 @@ description: Links to local files and heading anchors must resolve.
 category: link
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD051
+    name: link-fragments
 ---
 # MDS027: cross-file-reference-integrity
 
@@ -158,3 +161,6 @@ See [guide](bad/ref/guide.md#missing-section).
 - **Implementation**:
   [source](./)
 - **Category**: link
+- **Markdownlint**: [MD051][mdl-md051] (link-fragments)
+
+[mdl-md051]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md

--- a/internal/rules/MDS028-token-budget/README.md
+++ b/internal/rules/MDS028-token-budget/README.md
@@ -6,6 +6,7 @@ description: File must not exceed a token budget.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS028: token-budget
 

--- a/internal/rules/MDS029-conciseness-scoring/README.md
+++ b/internal/rules/MDS029-conciseness-scoring/README.md
@@ -6,6 +6,7 @@ description: Paragraph conciseness score must not fall below a threshold.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS029: conciseness-scoring
 

--- a/internal/rules/MDS030-empty-section-body/README.md
+++ b/internal/rules/MDS030-empty-section-body/README.md
@@ -6,6 +6,7 @@ description: Section headings must include meaningful body content.
 category: heading
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS030: empty-section-body
 

--- a/internal/rules/MDS031-unclosed-code-block/README.md
+++ b/internal/rules/MDS031-unclosed-code-block/README.md
@@ -6,6 +6,7 @@ description: Fenced code blocks must have a closing fence delimiter.
 category: code
 nature: structure
 maintainability: null
+markdownlint: null
 ---
 # MDS031: unclosed-code-block
 

--- a/internal/rules/MDS032-no-empty-alt-text/README.md
+++ b/internal/rules/MDS032-no-empty-alt-text/README.md
@@ -6,6 +6,9 @@ description: Images must have non-empty alt text for accessibility.
 category: accessibility
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD045
+    name: no-alt-text
 ---
 # MDS032: no-empty-alt-text
 
@@ -69,3 +72,6 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: accessibility
+- **Markdownlint**: [MD045][mdl-md045] (no-alt-text)
+
+[mdl-md045]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md

--- a/internal/rules/MDS033-directory-structure/README.md
+++ b/internal/rules/MDS033-directory-structure/README.md
@@ -9,6 +9,7 @@ maintainability:
   signal: markdown files that live outside allowed directories
   fix: move the file into an allowed directory or extend `directory-structure.allowed` when the new location is intentional
   for-diagnostic: true
+markdownlint: null
 ---
 # MDS033: directory-structure
 

--- a/internal/rules/MDS034-markdown-flavor/README.md
+++ b/internal/rules/MDS034-markdown-flavor/README.md
@@ -8,6 +8,7 @@ description: >-
 category: structural
 nature: structure
 maintainability: null
+markdownlint: null
 ---
 # MDS034: markdown-flavor
 

--- a/internal/rules/MDS035-toc-directive/README.md
+++ b/internal/rules/MDS035-toc-directive/README.md
@@ -6,6 +6,7 @@ description: Flag renderer-specific TOC directives that render as literal text o
 category: directive
 nature: generator
 maintainability: null
+markdownlint: null
 ---
 # MDS035: toc-directive
 

--- a/internal/rules/MDS036-max-section-length/README.md
+++ b/internal/rules/MDS036-max-section-length/README.md
@@ -6,6 +6,7 @@ description: Section length must not exceed per-level, per-heading, word, or par
 category: heading
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS036: max-section-length
 

--- a/internal/rules/MDS037-duplicated-content/README.md
+++ b/internal/rules/MDS037-duplicated-content/README.md
@@ -9,6 +9,7 @@ maintainability:
   signal: repeated paragraphs or sections with the same content
   fix: extract shared text with `<?include?>` or refactor so one canonical source remains
   for-diagnostic: true
+markdownlint: null
 ---
 # MDS037: duplicated-content
 

--- a/internal/rules/MDS038-toc/README.md
+++ b/internal/rules/MDS038-toc/README.md
@@ -6,6 +6,7 @@ description: Keep toc generated heading lists in sync with document headings.
 category: directive
 nature: directive
 maintainability: null
+markdownlint: null
 ---
 # MDS038: toc
 

--- a/internal/rules/MDS039-build/README.md
+++ b/internal/rules/MDS039-build/README.md
@@ -8,6 +8,7 @@ description: >-
 category: directive
 nature: directive
 maintainability: null
+markdownlint: null
 ---
 # MDS039: build
 

--- a/internal/rules/MDS040-recipe-safety/README.md
+++ b/internal/rules/MDS040-recipe-safety/README.md
@@ -8,6 +8,7 @@ description: >-
 category: directive
 nature: structure
 maintainability: null
+markdownlint: null
 ---
 # MDS040: recipe-safety
 

--- a/internal/rules/MDS041-no-inline-html/README.md
+++ b/internal/rules/MDS041-no-inline-html/README.md
@@ -8,6 +8,9 @@ description: >-
 category: structural
 nature: content
 maintainability: null
+markdownlint:
+  - id: MD033
+    name: no-inline-html
 ---
 # MDS041: no-inline-html
 
@@ -101,3 +104,6 @@ Press <kbd>Enter</kbd> to continue.
 - **Implementation**:
   [source](./)
 - **Category**: structural
+- **Markdownlint**: [MD033][mdl-md033] (no-inline-html)
+
+[mdl-md033]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md

--- a/internal/rules/MDS042-emphasis-style/README.md
+++ b/internal/rules/MDS042-emphasis-style/README.md
@@ -9,6 +9,11 @@ description: >-
 category: prose
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD049
+    name: emphasis-style
+  - id: MD050
+    name: strong-style
 ---
 # MDS042: emphasis-style
 
@@ -125,3 +130,9 @@ The following cases emit diagnostics but are
 - **Implementation**:
   [source](./)
 - **Category**: prose
+- **Markdownlint**:
+  - [MD049][mdl-md049] (emphasis-style)
+  - [MD050][mdl-md050] (strong-style)
+
+[mdl-md049]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md
+[mdl-md050]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md050.md

--- a/internal/rules/MDS043-no-reference-style/README.md
+++ b/internal/rules/MDS043-no-reference-style/README.md
@@ -6,6 +6,7 @@ description: Reference-style links and footnotes require global definition resol
 category: link
 nature: style
 maintainability: null
+markdownlint: null
 ---
 # MDS043: no-reference-style
 

--- a/internal/rules/MDS044-horizontal-rule-style/README.md
+++ b/internal/rules/MDS044-horizontal-rule-style/README.md
@@ -8,6 +8,9 @@ description: >-
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD035
+    name: hr-style
 ---
 # MDS044: horizontal-rule-style
 
@@ -210,3 +213,6 @@ blank lines above and below.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**: [MD035][mdl-md035] (hr-style)
+
+[mdl-md035]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md035.md

--- a/internal/rules/MDS045-list-marker-style/README.md
+++ b/internal/rules/MDS045-list-marker-style/README.md
@@ -6,6 +6,9 @@ description: Unordered list items must use the configured bullet marker characte
 category: list
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD004
+    name: ul-style
 ---
 # MDS045: list-marker-style
 
@@ -145,3 +148,6 @@ Outer uses dash (correct), inner should use asterisk but uses dash.
 - **Implementation**:
   [source](./)
 - **Category**: list
+- **Markdownlint**: [MD004][mdl-md004] (ul-style)
+
+[mdl-md004]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -6,6 +6,9 @@ description: Ordered list items must be numbered in the configured style.
 category: list
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD029
+    name: ol-prefix
 ---
 # MDS046: ordered-list-numbering
 
@@ -154,3 +157,6 @@ that the start fix already covers.
 - **Implementation**:
   [source](./)
 - **Category**: list
+- **Markdownlint**: [MD029][mdl-md029] (ol-prefix)
+
+[mdl-md029]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md029.md

--- a/internal/rules/MDS047-ambiguous-emphasis/README.md
+++ b/internal/rules/MDS047-ambiguous-emphasis/README.md
@@ -6,6 +6,9 @@ description: Forbid emphasis sequences whose meaning a human cannot predict at a
 category: prose
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD037
+    name: no-space-in-emphasis
 ---
 # MDS047: ambiguous-emphasis
 
@@ -214,3 +217,6 @@ __a__b__
 - **Implementation**:
   [source](./)
 - **Category**: prose
+- **Markdownlint**: [MD037][mdl-md037] (no-space-in-emphasis)
+
+[mdl-md037]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md

--- a/internal/rules/MDS048-git-hook-sync/README.md
+++ b/internal/rules/MDS048-git-hook-sync/README.md
@@ -6,6 +6,7 @@ description: Git artifacts must match the canonical glob-based template derived 
 category: structural
 nature: structure
 maintainability: null
+markdownlint: null
 ---
 # MDS048: git-hook-sync
 

--- a/internal/rules/MDS049-no-space-in-link-text/README.md
+++ b/internal/rules/MDS049-no-space-in-link-text/README.md
@@ -6,6 +6,9 @@ description: Link text and image alt text must not have leading or trailing whit
 category: link
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD039
+    name: no-space-in-links
 ---
 # MDS049: no-space-in-link-text
 
@@ -84,3 +87,6 @@ Visit [example](https://example.com) for more.
 - **Implementation**:
   [source](./)
 - **Category**: link
+- **Markdownlint**: [MD039][mdl-md039] (no-space-in-links)
+
+[mdl-md039]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md

--- a/internal/rules/MDS050-proper-names/README.md
+++ b/internal/rules/MDS050-proper-names/README.md
@@ -6,6 +6,9 @@ description: Configured proper names (e.g. JavaScript, GitHub) must appear with 
 category: prose
 nature: content
 maintainability: null
+markdownlint:
+  - id: MD044
+    name: proper-names
 ---
 # MDS050: proper-names
 
@@ -188,3 +191,6 @@ diagnostic is emitted.
 - **Implementation**:
   [source](./)
 - **Category**: prose
+- **Markdownlint**: [MD044][mdl-md044] (proper-names)
+
+[mdl-md044]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md

--- a/internal/rules/MDS051-single-h1/README.md
+++ b/internal/rules/MDS051-single-h1/README.md
@@ -6,6 +6,9 @@ description: At most one H1 heading is allowed per file.
 category: heading
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD025
+    name: single-h1
 ---
 # MDS051: single-h1
 
@@ -100,3 +103,6 @@ title: My Doc
 - **Fixable**: yes — extra H1s are demoted to H2; front-matter conflicts are not auto-fixed
 - **Implementation**: [source](./)
 - **Category**: heading
+- **Markdownlint**: [MD025][mdl-md025] (single-h1)
+
+[mdl-md025]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md

--- a/internal/rules/MDS052-no-space-in-code-spans/README.md
+++ b/internal/rules/MDS052-no-space-in-code-spans/README.md
@@ -6,6 +6,9 @@ description: Inline code spans with leading or trailing whitespace inside the ba
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD038
+    name: no-space-in-code
 ---
 # MDS052: no-space-in-code-spans
 
@@ -129,3 +132,6 @@ Use `foo bar` for multi-word.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**: [MD038][mdl-md038] (no-space-in-code)
+
+[mdl-md038]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md

--- a/internal/rules/MDS053-no-unused-link-definitions/README.md
+++ b/internal/rules/MDS053-no-unused-link-definitions/README.md
@@ -8,6 +8,9 @@ description: >-
 category: link
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD053
+    name: link-image-reference-definitions
 ---
 # MDS053: no-unused-link-definitions
 
@@ -133,3 +136,6 @@ Ignored labels are never removed.
 - **Fixable**: yes
 - **Implementation**: [source](./)
 - **Category**: link
+- **Markdownlint**: [MD053][mdl-md053] (link-image-reference-definitions)
+
+[mdl-md053]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md053.md

--- a/internal/rules/MDS054-no-undefined-reference-labels/README.md
+++ b/internal/rules/MDS054-no-undefined-reference-labels/README.md
@@ -6,6 +6,9 @@ description: Reference-style links and images must have a matching link referenc
 category: link
 nature: structure
 maintainability: null
+markdownlint:
+  - id: MD052
+    name: reference-links-images
 ---
 # MDS054: no-undefined-reference-labels
 
@@ -175,3 +178,6 @@ against `[bar]: url`.
 - **Fixable**: no
 - **Implementation**: [source](./)
 - **Category**: link
+- **Markdownlint**: [MD052][mdl-md052] (reference-links-images)
+
+[mdl-md052]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md

--- a/internal/rules/MDS055-forbidden-paragraph-starts/README.md
+++ b/internal/rules/MDS055-forbidden-paragraph-starts/README.md
@@ -6,6 +6,7 @@ description: Paragraphs must not begin with any configured prefix.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS055: forbidden-paragraph-starts
 

--- a/internal/rules/MDS056-forbidden-text/README.md
+++ b/internal/rules/MDS056-forbidden-text/README.md
@@ -6,6 +6,7 @@ description: Paragraphs must not contain any configured substring.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS056: forbidden-text
 

--- a/internal/rules/MDS057-required-text-patterns/README.md
+++ b/internal/rules/MDS057-required-text-patterns/README.md
@@ -6,6 +6,7 @@ description: Heading-bounded sections must match every configured regex.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS057: required-text-patterns
 

--- a/internal/rules/MDS058-required-mentions/README.md
+++ b/internal/rules/MDS058-required-mentions/README.md
@@ -6,6 +6,7 @@ description: Heading-bounded sections must contain every configured substring.
 category: prose
 nature: content
 maintainability: null
+markdownlint: null
 ---
 # MDS058: required-mentions
 

--- a/internal/rules/MDS059-blockquote-whitespace/README.md
+++ b/internal/rules/MDS059-blockquote-whitespace/README.md
@@ -8,6 +8,11 @@ description: >-
 category: whitespace
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD027
+    name: no-multiple-space-blockquote
+  - id: MD028
+    name: no-blanks-blockquote
 ---
 # MDS059: blockquote-whitespace
 
@@ -118,3 +123,9 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
+- **Markdownlint**:
+  - [MD027][mdl-md027] (no-multiple-space-blockquote)
+  - [MD028][mdl-md028] (no-blanks-blockquote)
+
+[mdl-md027]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md
+[mdl-md028]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md

--- a/internal/rules/MDS061-list-marker-space/README.md
+++ b/internal/rules/MDS061-list-marker-space/README.md
@@ -8,6 +8,9 @@ description: >-
 nature: style
 category: list
 maintainability: null
+markdownlint:
+  - id: MD030
+    name: list-marker-space
 ---
 # MDS061: list-marker-space
 
@@ -145,3 +148,6 @@ Ordered list with two spaces after each marker.
 - **Implementation**:
   [source](./)
 - **Category**: list
+- **Markdownlint**: [MD030][mdl-md030] (list-marker-space)
+
+[mdl-md030]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md030.md

--- a/internal/rules/MDS062-link-validity/README.md
+++ b/internal/rules/MDS062-link-validity/README.md
@@ -9,6 +9,11 @@ description: >-
 nature: structure
 category: link
 maintainability: null
+markdownlint:
+  - id: MD011
+    name: no-reversed-links
+  - id: MD042
+    name: no-empty-links
 ---
 # MDS062: link-validity
 
@@ -152,3 +157,9 @@ The reversed form `(text)[url]` is shown as code, not as a link.
 - **Implementation**:
   [source](../linkvalidity/)
 - **Category**: link
+- **Markdownlint**:
+  - [MD011][mdl-md011] (no-reversed-links)
+  - [MD042][mdl-md042] (no-empty-links)
+
+[mdl-md011]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md
+[mdl-md042]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md

--- a/internal/rules/MDS063-descriptive-link-text/README.md
+++ b/internal/rules/MDS063-descriptive-link-text/README.md
@@ -8,6 +8,9 @@ description: >-
 category: prose
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD059
+    name: descriptive-link-text
 ---
 # MDS063: descriptive-link-text
 
@@ -90,3 +93,6 @@ See [`SomeAPI`](https://example.com/api) for details.
 - **Implementation**:
   [source](../descriptivelinktext/)
 - **Category**: prose
+- **Markdownlint**: [MD059][mdl-md059] (descriptive-link-text)
+
+[mdl-md059]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md

--- a/internal/rules/MDS064-atx-heading-whitespace/README.md
+++ b/internal/rules/MDS064-atx-heading-whitespace/README.md
@@ -6,6 +6,18 @@ description: ATX heading whitespace and indentation.
 category: heading
 nature: style
 maintainability: null
+markdownlint:
+  - id: MD018
+    name: no-missing-space-atx
+  - id: MD019
+    name: no-multiple-space-atx
+  - id: MD020
+    name: no-missing-space-closed-atx
+    partial: true
+  - id: MD021
+    name: no-multiple-space-closed-atx
+  - id: MD023
+    name: heading-start-left
 ---
 # MDS064: atx-heading-whitespace
 
@@ -94,3 +106,15 @@ Tab after opening `#`:
 - **Fixable**: yes
 - **Implementation**: [source](./)
 - **Category**: heading
+- **Markdownlint**:
+  - [MD018][mdl-md018] (no-missing-space-atx)
+  - [MD019][mdl-md019] (no-multiple-space-atx)
+  - [MD020][mdl-md020] (no-missing-space-closed-atx) (partial)
+  - [MD021][mdl-md021] (no-multiple-space-closed-atx)
+  - [MD023][mdl-md023] (heading-start-left)
+
+[mdl-md018]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md018.md
+[mdl-md019]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md019.md
+[mdl-md020]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md020.md
+[mdl-md021]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md021.md
+[mdl-md023]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md023.md

--- a/internal/rules/directive-proto.md
+++ b/internal/rules/directive-proto.md
@@ -5,6 +5,7 @@ status: '"ready" | "not-ready"'
 description: 'string & != ""'
 nature: '"directive"'
 maintainability: '{signal: string & != "", fix: string & != "", "for-diagnostic"?: bool | *false} | null'
+markdownlint: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial?: bool | *false}] | null'
 category: '"directive"'
 ---
 # {id}: {name}

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -5,6 +5,7 @@ status: '"ready" | "not-ready"'
 description: 'string & != ""'
 nature: '"directive" | "generator" | "content" | "style" | "structure"'
 maintainability: '{signal: string & != "", fix: string & != "", "for-diagnostic"?: bool | *false} | null'
+markdownlint: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial?: bool | *false}] | null'
 category: '"accessibility" | "code" | "directive" | "heading" | "line" | "link" | "list" | "prose" | "structural" | "table" | "whitespace"'
 ---
 # {id}: {name}
@@ -17,6 +18,11 @@ category: '"accessibility" | "code" | "directive" | "heading" | "line" | "link" 
      by mdsmith check against the literal CUE union in this file's
      `category:` front matter, which is hand-kept in sync with
      config.ValidCategories.
+     The `markdownlint:` key lists every active markdownlint rule
+     the mdsmith rule covers. Each entry has `id:` and `name:`;
+     `partial: true` marks an incomplete cover. Source of truth is
+     docs/research/markdownlint-coverage/README.md. Set
+     `markdownlint: null` for mdsmith-only rules.
      Repeat the description verbatim. Use prescriptive voice,
      present tense: "Headings must ..." not "Checks that ...".
      The `nature` key labels the rule's kind. Exactly one of:
@@ -99,13 +105,22 @@ rules:
 - **Implementation**:
   [source](./)
 - **Category**: {category}
+- **Markdownlint**: [MDxxx][mdl-mdxxx] (name)
+
+[mdl-mdxxx]: https://github.com/DavidAnson/markdownlint/blob/main/doc/mdxxx.md
 
 <!-- Bullets in this order: ID, Name, Status, Default, Fixable,
-     Implementation, Category, and optionally Concept.
+     Implementation, Category, Markdownlint, and optionally Concept.
      Default may include key settings: "enabled, max: 80".
      Category must match the `category:` front-matter field and one
      of the values in ValidCategories. Pick the narrowest that fits;
      drop any category not in this list.
+     The Markdownlint bullet mirrors the `markdownlint:` front-matter
+     list. One entry per markdownlint rule the mdsmith rule covers,
+     joined with commas; "(partial)" suffixes a partial cover. The
+     matching link-reference definition follows the bullet block.
+     Omit the Markdownlint bullet (and the link refs) for mdsmith-only
+     rules with `markdownlint: null` in front matter.
      Add a Concept bullet when the rule has a dedicated concept page:
        - **Concept**: [NAME](../../../docs/background/concepts/NAME.md)
      Omit the Concept bullet when no concept page applies. -->

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -22,6 +22,25 @@ type RuleInfo struct {
 	Description     string
 	Content         string
 	Maintainability *Maintainability
+	Markdownlint    []MarkdownlintRule
+}
+
+// MarkdownlintRule names a markdownlint rule that the mdsmith rule covers.
+// Partial is true when the mdsmith rule implements only part of the
+// corresponding markdownlint check; the coverage matrix at
+// docs/research/markdownlint-coverage/README.md is the source of truth.
+type MarkdownlintRule struct {
+	ID      string `yaml:"id"`
+	Name    string `yaml:"name"`
+	Partial bool   `yaml:"partial"`
+}
+
+// URL returns the canonical markdownlint documentation URL for this rule.
+// Markdownlint hosts per-rule docs at a stable per-ID path keyed on the
+// lowercase ID, so the URL is derivable from ID alone.
+func (r MarkdownlintRule) URL() string {
+	return "https://github.com/DavidAnson/markdownlint/blob/main/doc/" +
+		strings.ToLower(r.ID) + ".md"
 }
 
 // Maintainability captures a rule's adoption pattern: the structural shape a
@@ -140,11 +159,12 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 		return RuleInfo{}, fmt.Errorf("unterminated front matter")
 	}
 	var meta struct {
-		ID              string           `yaml:"id"`
-		Name            string           `yaml:"name"`
-		Status          string           `yaml:"status"`
-		Description     string           `yaml:"description"`
-		Maintainability *Maintainability `yaml:"maintainability"`
+		ID              string             `yaml:"id"`
+		Name            string             `yaml:"name"`
+		Status          string             `yaml:"status"`
+		Description     string             `yaml:"description"`
+		Maintainability *Maintainability   `yaml:"maintainability"`
+		Markdownlint    []MarkdownlintRule `yaml:"markdownlint"`
 	}
 	if err := yamlutil.UnmarshalSafe([]byte(strings.Join(front, "\n")), &meta); err != nil {
 		return RuleInfo{}, fmt.Errorf("parsing front matter: %w", err)
@@ -155,6 +175,7 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 		Status:          meta.Status,
 		Description:     collapseWhitespace(meta.Description),
 		Maintainability: meta.Maintainability,
+		Markdownlint:    meta.Markdownlint,
 	}
 
 	if info.ID == "" {

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -365,23 +365,38 @@ func TestParseFrontMatter_MarkdownlintBlock(t *testing.T) {
 	assert.True(t, info.Markdownlint[1].Partial)
 }
 
-// TestParseFrontMatter_NullMarkdownlint verifies that an explicit `null` for
-// markdownlint (or its absence) yields a nil slice rather than an error.
+// TestParseFrontMatter_NullMarkdownlint verifies that an explicit `null`
+// for markdownlint, or omitting the key entirely, both yield a nil slice
+// rather than an error. Front matter that already conformed to the older
+// schema (no `markdownlint:` key at all) must keep parsing cleanly.
 func TestParseFrontMatter_NullMarkdownlint(t *testing.T) {
-	content := "---\n" +
-		"id: MDS999\n" +
-		"name: example\n" +
-		"status: ready\n" +
-		"description: Example.\n" +
-		"markdownlint: null\n" +
-		"---\n# Body\n"
-	info, err := parseFrontMatter(content)
-	require.NoError(t, err)
-	assert.Nil(t, info.Markdownlint)
+	cases := map[string]string{
+		"explicit-null": "---\n" +
+			"id: MDS999\n" +
+			"name: example\n" +
+			"status: ready\n" +
+			"description: Example.\n" +
+			"markdownlint: null\n" +
+			"---\n# Body\n",
+		"key-absent": "---\n" +
+			"id: MDS999\n" +
+			"name: example\n" +
+			"status: ready\n" +
+			"description: Example.\n" +
+			"---\n# Body\n",
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			info, err := parseFrontMatter(content)
+			require.NoError(t, err)
+			assert.Nil(t, info.Markdownlint)
+		})
+	}
 }
 
-// MarkdownlintURL returns the canonical doc URL for a markdownlint rule ID
-// (e.g. "MD013" -> "https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md").
+// TestMarkdownlintRule_URL verifies that MarkdownlintRule.URL builds the
+// canonical doc URL by lowercasing the rule ID and appending it to the
+// markdownlint doc path.
 func TestMarkdownlintRule_URL(t *testing.T) {
 	r := MarkdownlintRule{ID: "MD013", Name: "line-length"}
 	assert.Equal(t,

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -338,6 +338,57 @@ func TestParseFrontMatter_UnterminatedFrontMatter(t *testing.T) {
 	assert.Contains(t, err.Error(), "unterminated front matter")
 }
 
+// TestParseFrontMatter_MarkdownlintBlock verifies that a list of markdownlint
+// equivalents in front matter is parsed into the Markdownlint field, including
+// the optional `partial` flag.
+func TestParseFrontMatter_MarkdownlintBlock(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"description: Example.\n" +
+		"markdownlint:\n" +
+		"  - id: MD013\n" +
+		"    name: line-length\n" +
+		"  - id: MD020\n" +
+		"    name: no-missing-space-closed-atx\n" +
+		"    partial: true\n" +
+		"---\n# Body\n"
+	info, err := parseFrontMatter(content)
+	require.NoError(t, err)
+	require.Len(t, info.Markdownlint, 2)
+	assert.Equal(t, "MD013", info.Markdownlint[0].ID)
+	assert.Equal(t, "line-length", info.Markdownlint[0].Name)
+	assert.False(t, info.Markdownlint[0].Partial)
+	assert.Equal(t, "MD020", info.Markdownlint[1].ID)
+	assert.Equal(t, "no-missing-space-closed-atx", info.Markdownlint[1].Name)
+	assert.True(t, info.Markdownlint[1].Partial)
+}
+
+// TestParseFrontMatter_NullMarkdownlint verifies that an explicit `null` for
+// markdownlint (or its absence) yields a nil slice rather than an error.
+func TestParseFrontMatter_NullMarkdownlint(t *testing.T) {
+	content := "---\n" +
+		"id: MDS999\n" +
+		"name: example\n" +
+		"status: ready\n" +
+		"description: Example.\n" +
+		"markdownlint: null\n" +
+		"---\n# Body\n"
+	info, err := parseFrontMatter(content)
+	require.NoError(t, err)
+	assert.Nil(t, info.Markdownlint)
+}
+
+// MarkdownlintURL returns the canonical doc URL for a markdownlint rule ID
+// (e.g. "MD013" -> "https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md").
+func TestMarkdownlintRule_URL(t *testing.T) {
+	r := MarkdownlintRule{ID: "MD013", Name: "line-length"}
+	assert.Equal(t,
+		"https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md",
+		r.URL())
+}
+
 // TestParseFrontMatter_RejectsYAMLAliases verifies that the safe-YAML wrapper
 // rejects anchor/alias usage in rule README front matter rather than silently
 // expanding aliases.

--- a/website/layouts/rule/single.html
+++ b/website/layouts/rule/single.html
@@ -31,7 +31,11 @@
           {{ end }}
         </div>
         <h1>{{ .Title }}</h1>
-        {{ with .Params.description }}<p class="lead">{{ . }}</p>{{ end }}
+        {{/* `.Params.description` is not rendered here: each rule
+             README's body opens with the same description sentence
+             (proto.md requires it for the CLI `help rule` view),
+             so emitting it from front matter would duplicate the
+             first body paragraph on the page. */}}
         {{ partial "link-rules.html" . }}
         {{ with .Params.github_source }}
           <div class="rule-source-link">


### PR DESCRIPTION
## Summary

This change adds support for tracking which markdownlint rules each mdsmith rule covers. The `markdownlint` field in rule README front matter now documents the equivalent markdownlint checks, with an optional `partial` flag to indicate incomplete coverage.

## Key Changes

- **Core metadata structure**: Added `MarkdownlintRule` type with `ID`, `Name`, and `Partial` fields to `internal/rules/ruledocs.go`
- **URL generation**: Implemented `MarkdownlintRule.URL()` method to derive canonical markdownlint documentation URLs from rule IDs
- **Front matter parsing**: Extended `parseFrontMatter()` to parse the `markdownlint` YAML block into the `RuleInfo` struct
- **Test coverage**: Added three new tests:
  - `TestParseFrontMatter_MarkdownlintBlock`: Verifies parsing of markdownlint lists with optional `partial` flag
  - `TestParseFrontMatter_NullMarkdownlint`: Confirms that `null` or absent markdownlint fields yield nil slices
  - `TestMarkdownlintRule_URL`: Validates URL generation from rule IDs
- **Schema documentation**: Updated `proto.md` and `directive-proto.md` to document the new `markdownlint` field schema
- **Rule documentation**: Added markdownlint equivalents to 30+ rule README files with front matter entries and reference links in the metadata section

## Implementation Details

- The `markdownlint` field accepts either a list of rule objects or `null` (for mdsmith-only rules)
- Each rule object requires `id` and `name`; `partial` defaults to `false`
- URLs are generated deterministically: `https://github.com/DavidAnson/markdownlint/blob/main/doc/{lowercase-id}.md`
- The website layout was updated to avoid duplicating the description (which already appears in rule body text)
- All mdsmith-only rules explicitly set `markdownlint: null` to distinguish them from rules awaiting documentation

https://claude.ai/code/session_01AWsGxLSLKAgyg9kcKJePUR