### PR TITLE
Rewrite relative non-MDS links in rule READMEs to GitHub URLs

### DIFF
--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -220,19 +220,43 @@ var indexMdLink = regexp.MustCompile(
 var ruleFixtureLink = regexp.MustCompile(
 	`\]\(((?:bad|good|pattern)/\S*)` + linkTitleTail + `\)`)
 
-// ruleSiblingNonMDSLink matches an inline link in a per-rule
-// README whose target is a single-`../`-prefixed sibling under
-// internal/rules/ that is NOT another rule's page — the rule's
-// Go package directory or the shared `proto.md` schema, for
-// example. Sibling MDS rule pages (`../MDS021-include/`) ARE
-// published, so they are excluded by requiring the first
-// character after `../` to be lowercase or a dot (rule names
-// start with uppercase `M`). The path uses `\S*` so it stops at
-// the whitespace before an optional Markdown link title; the
-// trailing linkTitleTail (group 2) then consumes that title and
-// rewriteRuleSibling re-emits it after the GitHub URL (gap G6).
-var ruleSiblingNonMDSLink = regexp.MustCompile(
-	`\]\(\.\./([a-z._]\S*)` + linkTitleTail + `\)`)
+// ruleRelativeNonMDSLink matches an inline link in a per-rule
+// README whose target is a `(?:\.\./)+<non-MDS>` reference into
+// a repo location outside the rule's own directory. The path's
+// first character (the one after the final `../`) is restricted
+// to lowercase or a dot so MDS-prefixed cross-rule references
+// (`../MDS021-include/…`) — which ruleReadmeLink already routes
+// to the site URL — are excluded.
+//
+// Two depths are common in the source:
+//   - depth 1 (`../<x>`): a sibling Go package (../linelength/rule.go),
+//     the shared proto.md (../proto.md), or a sibling test file
+//     (../paragraphstructure/rule_test.go).
+//   - depth 2 (`../../<x>`): a cousin internal/ subdirectory
+//     (../../mdtext/sentence_equivalence_test.go).
+//
+// Depth-3+ references are repo-rooted (../../../docs/,
+// ../../../plan/, ../../../internal/, …) and have already been
+// rewritten by rewriteRuleLinks (repoDocsLink, repoPlanLink,
+// repoNonPublishedLink) by the time transformRulePage applies
+// this regex; rewriteRuleRelativeInline declines depths outside
+// 1–2 so it cannot fight those rewrites.
+//
+// The path uses `\S*` so it stops at the whitespace before an
+// optional Markdown link title; the trailing linkTitleTail (the
+// final captured group) then consumes that title and
+// rewriteRuleRelativeInline re-emits it after the GitHub URL.
+var ruleRelativeNonMDSLink = regexp.MustCompile(
+	`\]\(((?:\.\./)+)([a-z._]\S*)` + linkTitleTail + `\)`)
+
+// ruleRelativeNonMDSRefDef is the reference-style sibling of
+// ruleRelativeNonMDSLink. Multiline flag so `^` and `$` anchor at
+// each line start/end. The leading capture is the `[label]: `
+// prefix, then the `(?:\.\./)+` depth, the non-MDS path, and the
+// optional linkTitleTail — re-emitted by rewriteRuleRelativeRefDef
+// so a titled definition keeps its title.
+var ruleRelativeNonMDSRefDef = regexp.MustCompile(
+	`(?m)^(\[[^\]]+\]: )((?:\.\./)+)([a-z._]\S*)` + linkTitleTail + `$`)
 
 // ruleSourceTreeBase is the GitHub directory (tree) route for a
 // rule's source. Per-rule READMEs carry an
@@ -717,7 +741,8 @@ func transformRulePage(data []byte, ruleName string) []byte {
 		seg = repoPlanLink.ReplaceAll(seg, []byte("]("+githubBlobBase+"plan/$1)"))
 		seg = repoPlanRefDef.ReplaceAll(seg, []byte("${1}"+githubBlobBase+"plan/$2"))
 		seg = rewriteRuleFixtures(seg, ruleSourceFiles, ruleSourceDir)
-		seg = ruleSiblingNonMDSLink.ReplaceAllFunc(seg, rewriteRuleSibling)
+		seg = ruleRelativeNonMDSLink.ReplaceAllFunc(seg, rewriteRuleRelativeInline)
+		seg = ruleRelativeNonMDSRefDef.ReplaceAllFunc(seg, rewriteRuleRelativeRefDef)
 		return seg
 	})
 	data = bytes.ReplaceAll(data,
@@ -742,18 +767,59 @@ func rewriteRuleFixtures(seg []byte, fileBase, dirBase string) []byte {
 	})
 }
 
-// rewriteRuleSibling rewrites a single-`../`-prefixed sibling
-// reference that is NOT another MDS rule page (a sibling Go
-// package, the shared proto.md, …) to its GitHub URL under
-// internal/rules/. The non-MDS guard in ruleSiblingNonMDSLink
-// preserves cross-rule links like `../MDS021-include/`;
-// directory vs file route is decided by trailing slash. m[2] is
-// the optional link title, re-emitted so a titled link keeps it.
-func rewriteRuleSibling(match []byte) []byte {
-	m := ruleSiblingNonMDSLink.FindSubmatch(match)
+// rewriteRuleRelativeInline rewrites a `(?:\.\./)+<non-MDS>`
+// inline link from a rule README to its GitHub URL. Depth maps
+// to the repo-rooted prefix that the `../` walk lands on from
+// internal/rules/<rule>/ (1 → internal/rules/, 2 → internal/).
+// Higher depths are declined — those are repo-rooted links that
+// the earlier rewriteRuleLinks pass already handled, and matching
+// them here would either double-rewrite a URL the earlier pass
+// emitted or wrongly map a `../../../<x>` repo-root reference
+// into an internal/-rooted GitHub URL. The trailing linkTitleTail
+// (m[3]) is re-emitted so a titled link keeps its title.
+func rewriteRuleRelativeInline(match []byte) []byte {
+	m := ruleRelativeNonMDSLink.FindSubmatch(match)
+	prefix, ok := repoPrefixForRuleRelativeDepth(m[1])
+	if !ok {
+		return match
+	}
 	return []byte("](" +
-		githubURLForPath([]byte("internal/rules/"+string(m[1]))) +
-		string(m[2]) + ")")
+		githubURLForPath([]byte(prefix+string(m[2]))) +
+		string(m[3]) + ")")
+}
+
+// rewriteRuleRelativeRefDef is the reference-style sibling of
+// rewriteRuleRelativeInline. m[1] is the `[label]: ` prefix, m[2]
+// the `(?:\.\./)+` depth capture, m[3] the non-MDS path, and m[4]
+// the optional title re-emitted so the definition keeps it.
+func rewriteRuleRelativeRefDef(match []byte) []byte {
+	m := ruleRelativeNonMDSRefDef.FindSubmatch(match)
+	prefix, ok := repoPrefixForRuleRelativeDepth(m[2])
+	if !ok {
+		return match
+	}
+	return []byte(string(m[1]) +
+		githubURLForPath([]byte(prefix+string(m[3]))) +
+		string(m[4]))
+}
+
+// repoPrefixForRuleRelativeDepth maps a `(?:\.\./)+` capture to
+// the repo-rooted directory it lands on when walked up from
+// internal/rules/<rule>/. The two-level structure makes only
+// depths 1 and 2 well-defined within this rewriter; depth 3+
+// reaches the repo root and is the territory of the earlier
+// rewriters (repoDocsLink, repoPlanLink, repoNonPublishedLink).
+// Returns ok=false outside that range so the caller can leave the
+// match untouched.
+func repoPrefixForRuleRelativeDepth(dotdot []byte) (string, bool) {
+	switch bytes.Count(dotdot, []byte("../")) {
+	case 1:
+		return "internal/rules/", true
+	case 2:
+		return "internal/", true
+	default:
+		return "", false
+	}
 }
 
 // injectFMField inserts a YAML field block into a document's front

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -3,6 +3,7 @@ package release
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -648,4 +649,121 @@ func TestTransformRulePage_AnchoredTitledReadmeLink(t *testing.T) {
 		"anchored+titled sibling README link must keep both #fragment and title")
 	assert.NotContains(t, got, "README.md",
 		"no unpublished README.md target may survive")
+}
+
+// --- non-MDS relative-link rewrite ------------------------------
+//
+// MDS024's README references its rule_test.go sibling as a
+// reference-style def (`[guard-test]: ../paragraphstructure/rule_test.go`)
+// and its mdtext cousin as a 2-up def
+// (`[harness]: ../../mdtext/sentence_equivalence_test.go`). Both
+// shipped verbatim into the synced rule page and were flagged
+// MDS027 by the deploy's mdsmith check pass. The four tests
+// below pin the rewrite for the four shapes — inline vs ref-def,
+// 1-up sibling vs 2-up cousin — that a rule README can author
+// when pointing at unpublished Go sources or test files.
+
+func TestTransformRulePage_SiblingNonMDSRefDef(t *testing.T) {
+	in := "[guard-test]: ../paragraphstructure/rule_test.go\n"
+	got := string(transformRulePage([]byte(in), "MDS024-paragraph-structure"))
+	assert.Contains(t, got,
+		"[guard-test]: https://github.com/jeduden/mdsmith/blob/main/"+
+			"internal/rules/paragraphstructure/rule_test.go",
+		"reference-style 1-up sibling non-MDS link must become a GitHub blob URL")
+	assert.NotContains(t, got, "../paragraphstructure/",
+		"no repo-relative sibling path may survive")
+}
+
+func TestTransformRulePage_CousinNonMDSInline(t *testing.T) {
+	in := "See [harness](../../mdtext/sentence_equivalence_test.go).\n"
+	got := string(transformRulePage([]byte(in), "MDS024-paragraph-structure"))
+	assert.Contains(t, got,
+		"[harness](https://github.com/jeduden/mdsmith/blob/main/"+
+			"internal/mdtext/sentence_equivalence_test.go)",
+		"inline 2-up cousin non-MDS link must become a GitHub blob URL")
+	assert.NotContains(t, got, "../../mdtext/",
+		"no repo-relative cousin path may survive")
+}
+
+func TestTransformRulePage_CousinNonMDSRefDef(t *testing.T) {
+	in := "[harness]: ../../mdtext/sentence_equivalence_test.go\n"
+	got := string(transformRulePage([]byte(in), "MDS024-paragraph-structure"))
+	assert.Contains(t, got,
+		"[harness]: https://github.com/jeduden/mdsmith/blob/main/"+
+			"internal/mdtext/sentence_equivalence_test.go",
+		"reference-style 2-up cousin non-MDS link must become a GitHub blob URL")
+	assert.NotContains(t, got, "../../mdtext/",
+		"no repo-relative cousin path may survive")
+}
+
+func TestTransformRulePage_TitledRelativeNonMDSKeepsTitle(t *testing.T) {
+	in := "Inline: [g](../../mdtext/x.go \"H\").\n" +
+		"[r]: ../../mdtext/x.go \"H\"\n" +
+		"[s]: ../paragraphstructure/rule_test.go \"G\"\n"
+	got := string(transformRulePage([]byte(in), "MDS024-paragraph-structure"))
+	assert.Contains(t, got,
+		`[g](https://github.com/jeduden/mdsmith/blob/main/internal/mdtext/x.go "H")`,
+		"titled 2-up cousin inline must keep its title")
+	assert.Contains(t, got,
+		`[r]: https://github.com/jeduden/mdsmith/blob/main/internal/mdtext/x.go "H"`,
+		"titled 2-up cousin ref-def must keep its title")
+	assert.Contains(t, got,
+		`[s]: https://github.com/jeduden/mdsmith/blob/main/internal/rules/`+
+			`paragraphstructure/rule_test.go "G"`,
+		"titled 1-up sibling ref-def must keep its title")
+}
+
+// TestRulePageTransforms_NoLeftoverRelativeNonMDSLinks is the
+// repo-wide regression for the deploy failure: every rule
+// README that links at a `(?:\.\./)+<non-MDS>` repo path must
+// have that path rewritten before it lands on the published
+// site, since the synced rule pages live at
+// website/content/docs/rules/MDS…/ and unrewritten relative
+// targets resolve to nothing under that tree.
+//
+// The check walks the actual internal/rules/MDS…/README.md
+// files, runs transformMarkdown then transformRulePage (the
+// same composition syncRulePages uses), and scans each rule's
+// transformed body — outside code regions — for any leftover
+// `\]\(\.\./[a-z._]` or `^\[…\]:\s+\.\./[a-z._]` pattern.
+// Lowercase first-char excludes the legitimate `../MDSyyy/`
+// cross-rule site references that survive untouched.
+func TestRulePageTransforms_NoLeftoverRelativeNonMDSLinks(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	rulesDir := filepath.Join(repoRoot, "internal", "rules")
+	entries, err := os.ReadDir(rulesDir)
+	require.NoError(t, err)
+
+	leftoverInline := regexp.MustCompile(`\]\(\.\./[a-z._]\S*\)`)
+	leftoverRefDef := regexp.MustCompile(`(?m)^\[[^\]]+\]:\s+\.\./[a-z._]\S+`)
+
+	for _, e := range entries {
+		if !e.IsDir() || !ruleDirName.MatchString(e.Name()) {
+			continue
+		}
+		ruleName := e.Name()
+		t.Run(ruleName, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(rulesDir, ruleName, "README.md"))
+			if os.IsNotExist(err) {
+				t.Skip("rule has no README.md")
+			}
+			require.NoError(t, err)
+			transformed := transformRulePage(transformMarkdown(data), ruleName)
+			var inlineHit, refDefHit string
+			applyOutsideCode(transformed, func(seg []byte) []byte {
+				if loc := leftoverInline.FindIndex(seg); loc != nil && inlineHit == "" {
+					inlineHit = string(seg[loc[0]:loc[1]])
+				}
+				if loc := leftoverRefDef.FindIndex(seg); loc != nil && refDefHit == "" {
+					refDefHit = string(seg[loc[0]:loc[1]])
+				}
+				return seg
+			})
+			assert.Empty(t, inlineHit,
+				"inline non-MDS relative link survived rule-page transforms")
+			assert.Empty(t, refDefHit,
+				"ref-def non-MDS relative link survived rule-page transforms")
+		})
+	}
 }

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -713,6 +713,28 @@ func TestTransformRulePage_TitledRelativeNonMDSKeepsTitle(t *testing.T) {
 		"titled 1-up sibling ref-def must keep its title")
 }
 
+// TestRewriteRuleRelative_Depth3PlusDeclined pins that
+// depth-3+ relative non-MDS links are NOT rewritten by the
+// rule-page rewriter. The earlier rewriteRuleLinks pass owns
+// every repo-rooted path it can name (plan/, cmd/, internal/,
+// docs/, plan/, root files, …); a path outside that
+// alternative list (e.g. `../../../demo/foo.go`) reaches
+// rewriteRuleRelativeInline at depth 3 and must stay as
+// authored, because depth 3 from internal/rules/<rule>/ is the
+// repo root and the per-rule rewriter cannot guess a prefix
+// that would produce a correct GitHub URL. A visible relative
+// link the synced-tree lint will flag is the safe outcome —
+// silently mapping three-up to a fabricated internal/<x> URL
+// would be worse.
+func TestRewriteRuleRelative_Depth3PlusDeclined(t *testing.T) {
+	in := "Inline: [d](../../../demo/foo.go).\n[r]: ../../../demo/foo.go\n"
+	got := string(transformRulePage([]byte(in), "MDS001-line-length"))
+	assert.Contains(t, got, "[d](../../../demo/foo.go)",
+		"depth-3+ inline link must remain unchanged")
+	assert.Contains(t, got, "[r]: ../../../demo/foo.go",
+		"depth-3+ ref-def must remain unchanged")
+}
+
 // TestRulePageTransforms_NoLeftoverRelativeNonMDSLinks is the
 // repo-wide regression for the deploy failure: every rule
 // README that links at a `(?:\.\./)+<non-MDS>` repo path must
@@ -725,8 +747,14 @@ func TestTransformRulePage_TitledRelativeNonMDSKeepsTitle(t *testing.T) {
 // files, runs transformMarkdown then transformRulePage (the
 // same composition syncRulePages uses), and scans each rule's
 // transformed body — outside code regions — for any leftover
-// `\]\(\.\./[a-z._]` or `^\[…\]:\s+\.\./[a-z._]` pattern.
-// Lowercase first-char excludes the legitimate `../MDSyyy/`
+// inline `\]\((?:\.\./)+[a-z._]` or reference-style
+// `^\[…\]:\s+(?:\.\./)+[a-z._]` pattern. The `(?:\.\./)+`
+// matches any depth (1 sibling, 2 cousin, 3+ repo-rooted)
+// and the lead-in–only match catches a titled link too — the
+// production regex's `\S*` would stop at the space before
+// a `"title"` and the closing `\)` would never reach, leaving
+// a titled leftover invisible to a path-anchored scan. The
+// lowercase first-char excludes legitimate `../MDSyyy/`
 // cross-rule site references that survive untouched.
 func TestRulePageTransforms_NoLeftoverRelativeNonMDSLinks(t *testing.T) {
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
@@ -735,8 +763,8 @@ func TestRulePageTransforms_NoLeftoverRelativeNonMDSLinks(t *testing.T) {
 	entries, err := os.ReadDir(rulesDir)
 	require.NoError(t, err)
 
-	leftoverInline := regexp.MustCompile(`\]\(\.\./[a-z._]\S*\)`)
-	leftoverRefDef := regexp.MustCompile(`(?m)^\[[^\]]+\]:\s+\.\./[a-z._]\S+`)
+	leftoverInline := regexp.MustCompile(`\]\((?:\.\./)+[a-z._][^)\n]*\)?`)
+	leftoverRefDef := regexp.MustCompile(`(?m)^\[[^\]]+\]:\s+(?:\.\./)+[a-z._][^\n]*`)
 
 	for _, e := range entries {
 		if !e.IsDir() || !ruleDirName.MatchString(e.Name()) {


### PR DESCRIPTION
## Summary

Extends the rule README link rewriting logic to handle relative references to non-MDS files at both depth-1 (sibling packages, test files) and depth-2 (cousin internal/ subdirectories). Previously only depth-1 inline links were rewritten; this change adds support for reference-style definitions and both depths, preventing broken links when rule pages are synced to the published website.

## Changes

- **Regex expansion**: Replaced `ruleSiblingNonMDSLink` (depth-1 inline only) with `ruleRelativeNonMDSLink` (depth-1 and depth-2 inline) and added `ruleRelativeNonMDSRefDef` (depth-1 and depth-2 reference-style definitions)
  - Both regexes capture the `(?:\.\./)+` depth prefix and restrict the first path character to lowercase/dot to exclude MDS cross-rule references
  - Preserve optional Markdown link titles through the rewrite

- **Rewriter functions**: Split `rewriteRuleSibling` into two depth-aware functions:
  - `rewriteRuleRelativeInline`: handles inline links
  - `rewriteRuleRelativeRefDef`: handles reference-style definitions
  - Both delegate depth mapping to `repoPrefixForRuleRelativeDepth`, which maps `../` count to repo-rooted prefixes (depth 1 → `internal/rules/`, depth 2 → `internal/`)
  - Decline depths outside 1–2 to avoid conflicts with earlier repo-rooted rewrites

- **Comprehensive test coverage**: Added four unit tests covering the four link shapes (inline/ref-def × sibling/cousin) plus a repo-wide regression test that walks all rule READMEs, applies the full transform pipeline, and scans for leftover relative non-MDS patterns outside code blocks

## Implementation Details

The rewrite happens in `transformRulePage` after earlier passes handle repo-rooted links (docs/, plan/, etc.), so depth-3+ references are already converted and this pass only handles the well-defined depth-1 and depth-2 cases. The regex patterns use `\S*` to stop at whitespace before optional titles, and `linkTitleTail` is re-emitted to preserve titled links. The regression test uses `applyOutsideCode` to exclude code blocks from the leftover-link scan, matching the actual transform behavior.

https://claude.ai/code/session_01FCBrmiPJUg3XWNYFn66QNY