### PR TITLE
Plan 137: `mdsmith fix --dry-run`

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -66,7 +66,7 @@ footer: |
 | 134 | ✅     | sonnet | [LSP completion for anchors, refs, kinds, and directive args](plan/134_lsp-completion.md)                                               |
 | 135 | 🔲     | sonnet | [Schema inheritance via `extends`](plan/135_schema-extends.md)                                                                          |
 | 136 | 🔲     | sonnet | [Field deprecation flag in schemas](plan/136_field-deprecation-flag.md)                                                                 |
-| 137 | 🔲     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                                      |
+| 137 | ✅     | sonnet | [`mdsmith fix --dry-run`](plan/137_fix-dry-run.md)                                                                                      |
 | 138 | ✅     | sonnet | [`mdsmith list backlinks` subcommand](plan/138_backlinks-subcommand.md)                                                                 |
 | 139 | ✅     | sonnet | [Field-presence kind assignment](plan/139_field-presence-kind-assignment.md)                                                            |
 | 140 | ✅     | sonnet | [Per-kind `path-pattern` for filename validation](plan/140_kind-path-pattern.md)                                                        |

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -533,6 +533,134 @@ func TestE2E_Fix_PrintsStatsWithUnfixedFailures(t *testing.T) {
 		"expected failures >= unfixed, got failures=%d unfixed=%d", failures, unfixed)
 }
 
+// --- fix --dry-run tests ---
+
+func TestE2E_Fix_DryRun_LeavesFileByteIdentical(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	original := "# Title\n\nHello   \nworld  \n"
+	path := writeFixture(t, dir, "preview.md", original)
+
+	stdout, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"fix", "--dry-run", "--no-color", "preview.md")
+	require.Equal(t, 0, exitCode,
+		"expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got),
+		"dry-run modified the file; before=%q after=%q", original, string(got))
+
+	assert.Contains(t, stderr, "preview.md: would fix",
+		"expected dry-run preview line on stderr; got: %s", stderr)
+	assert.Empty(t, stdout, "text dry-run must not write to stdout; got: %s", stdout)
+}
+
+func TestE2E_Fix_DryRun_StatsLineHasWouldFix(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "dirty.md", "# Title\n\nHello   \nworld  \n")
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"fix", "--dry-run", "--no-color", "dirty.md")
+	require.Equal(t, 0, exitCode,
+		"expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+
+	re := regexp.MustCompile(
+		`stats: checked=(\d+) fixed=(\d+) failures=(\d+) unfixed=(\d+) would-fix=(\d+)`)
+	m := re.FindStringSubmatch(stderr)
+	require.Len(t, m, 6,
+		"expected dry-run stats line with would-fix field; got: %s", stderr)
+	assert.Equal(t, "0", m[2],
+		"dry-run must report fixed=0; got fixed=%s", m[2])
+	wouldFix, _ := strconv.Atoi(m[5])
+	assert.GreaterOrEqual(t, wouldFix, 1,
+		"expected would-fix >= 1 for a dirty file; got %d", wouldFix)
+}
+
+func TestE2E_Fix_DryRun_MatchesRealRunExitCode(t *testing.T) {
+	// Same content, two locations: --dry-run and a real fix must
+	// return the same exit code on identical input.
+	for _, tc := range []struct {
+		name     string
+		content  string
+		wantCode int
+	}{
+		{
+			name:     "all-fixable",
+			content:  "# Title\n\nHello   \n",
+			wantCode: 0,
+		},
+		{
+			name:     "partial-fixable",
+			content:  "# Title!\n\nHello   \n",
+			wantCode: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dryDir := t.TempDir()
+			isolateDir(t, dryDir)
+			writeFixture(t, dryDir, "f.md", tc.content)
+
+			wetDir := t.TempDir()
+			isolateDir(t, wetDir)
+			writeFixture(t, wetDir, "f.md", tc.content)
+
+			_, _, dryCode := runBinaryInDir(t, dryDir, "",
+				"fix", "--dry-run", "--no-color", "f.md")
+			_, _, wetCode := runBinaryInDir(t, wetDir, "",
+				"fix", "--no-color", "f.md")
+
+			assert.Equal(t, tc.wantCode, dryCode,
+				"dry-run exit code mismatch")
+			assert.Equal(t, wetCode, dryCode,
+				"dry-run exit code (%d) must match real-run (%d)",
+				dryCode, wetCode)
+		})
+	}
+}
+
+func TestE2E_Fix_DryRun_JSON_PerFileRecords(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "dirty.md", "# Title\n\nHello   \nworld  \n")
+
+	stdout, _, exitCode := runBinaryInDir(t, dir, "",
+		"fix", "--dry-run", "--format", "json", "dirty.md")
+	require.Equal(t, 0, exitCode, "expected exit code 0")
+
+	var records []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &records),
+		"json output must parse; got: %s", stdout)
+	require.Len(t, records, 1)
+
+	rec := records[0]
+	assert.Equal(t, "dirty.md", rec["path"])
+	wf, ok := rec["would_fix"].(float64)
+	require.True(t, ok, "would_fix must be a number; got %T", rec["would_fix"])
+	assert.GreaterOrEqual(t, int(wf), 1,
+		"expected would_fix >= 1 for a dirty file")
+	rules, ok := rec["rules"].([]any)
+	require.True(t, ok, "rules must be a JSON array")
+	assert.NotEmpty(t, rules, "rules array must list at least one rule ID")
+}
+
+func TestE2E_Fix_DryRun_CleanFileOmitted(t *testing.T) {
+	dir := t.TempDir()
+	isolateDir(t, dir)
+	writeFixture(t, dir, "clean.md", "# Title\n\nClean content here.\n")
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "",
+		"fix", "--dry-run", "--no-color", "clean.md")
+	require.Equal(t, 0, exitCode,
+		"expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+
+	assert.NotContains(t, stderr, "would fix",
+		"clean files must not appear in the preview; got: %s", stderr)
+	assert.Contains(t, stderr, "would-fix=0",
+		"expected would-fix=0 in stats; got: %s", stderr)
+}
+
 // --- Init subcommand tests ---
 
 func TestE2E_Init_CreatesConfig(t *testing.T) {

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -630,12 +630,11 @@ func TestE2E_Fix_DryRun_JSON_PerFileRecords(t *testing.T) {
 	require.Equal(t, 0, exitCode, "expected exit code 0")
 	assert.Empty(t, stdout, "dry-run JSON must go to stderr, not stdout")
 
-	// stderr is the JSON payload followed by the stats summary line.
-	jsonEnd := strings.LastIndex(stderr, "]")
-	require.GreaterOrEqual(t, jsonEnd, 0,
-		"stderr must contain JSON payload; got: %s", stderr)
+	// In JSON mode stats are suppressed, so stderr is just the
+	// encoded array. Trim is defensive against future trailing
+	// output.
 	var records []map[string]any
-	require.NoError(t, json.Unmarshal([]byte(stderr[:jsonEnd+1]), &records),
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(stderr)), &records),
 		"json output must parse; got: %s", stderr)
 	require.Len(t, records, 1)
 

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -625,13 +625,18 @@ func TestE2E_Fix_DryRun_JSON_PerFileRecords(t *testing.T) {
 	isolateDir(t, dir)
 	writeFixture(t, dir, "dirty.md", "# Title\n\nHello   \nworld  \n")
 
-	stdout, _, exitCode := runBinaryInDir(t, dir, "",
+	stdout, stderr, exitCode := runBinaryInDir(t, dir, "",
 		"fix", "--dry-run", "--format", "json", "dirty.md")
 	require.Equal(t, 0, exitCode, "expected exit code 0")
+	assert.Empty(t, stdout, "dry-run JSON must go to stderr, not stdout")
 
+	// stderr is the JSON payload followed by the stats summary line.
+	jsonEnd := strings.LastIndex(stderr, "]")
+	require.GreaterOrEqual(t, jsonEnd, 0,
+		"stderr must contain JSON payload; got: %s", stderr)
 	var records []map[string]any
-	require.NoError(t, json.Unmarshal([]byte(stdout), &records),
-		"json output must parse; got: %s", stdout)
+	require.NoError(t, json.Unmarshal([]byte(stderr[:jsonEnd+1]), &records),
+		"json output must parse; got: %s", stderr)
 	require.Len(t, records, 1)
 
 	rec := records[0]

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -207,10 +208,31 @@ func runCheck(args []string) int {
 
 // runFix implements the "fix" subcommand: auto-fix lint issues in place.
 func runFix(args []string) int {
+	opts, fileArgs, hasStdin, code := parseFixFlags(args)
+	if code >= 0 {
+		return code
+	}
+	if hasStdin {
+		fmt.Fprintf(os.Stderr, "mdsmith: cannot fix stdin in place\n")
+		return 2
+	}
+	if len(fileArgs) > 0 {
+		return fixFiles(fileArgs, opts)
+	}
+	// No file args: discover files from config.
+	return fixDiscovered(opts)
+}
+
+// parseFixFlags configures the `fix` flag set, parses args, and
+// returns the resolved opts plus positional arguments. The bool
+// `hasStdin` is true when the caller passed `-` as a positional
+// arg. A non-negative `code` means the caller should return that
+// exit code immediately (e.g. --help or a parse error).
+func parseFixFlags(args []string) (fixCLIOpts, []string, bool, int) {
 	fs := flag.NewFlagSet("fix", flag.ContinueOnError)
 	var (
-		configPath, format, maxInputSize                              string
-		noColor, quiet, verbose, noGitignore, followSymlinks, explain bool
+		configPath, format, maxInputSize                                      string
+		noColor, quiet, verbose, noGitignore, followSymlinks, explain, dryRun bool
 	)
 
 	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
@@ -224,6 +246,9 @@ func runFix(args []string) int {
 			"=false forces skip over any config opt-in")
 	fs.StringVar(&maxInputSize, "max-input-size", "", "Maximum file size to process (e.g. 2MB, 500KB, 0=unlimited)")
 	fs.BoolVar(&explain, "explain", false, "Attach per-leaf rule provenance to each remaining diagnostic")
+	fs.BoolVar(&dryRun, "dry-run", false,
+		"Preview which files would change without writing; "+
+			"per-file output lists the rules that would fire and their counts")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: mdsmith fix [flags] [files...]\n\n"+
@@ -237,7 +262,7 @@ func runFix(args []string) int {
 
 	if err := fs.Parse(args); err != nil {
 		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: fix"); code >= 0 {
-			return code
+			return fixCLIOpts{}, nil, false, code
 		}
 	}
 
@@ -246,27 +271,38 @@ func runFix(args []string) int {
 		verbose = false
 	}
 
-	walk := walkCLI{
-		noGitignore:    noGitignore,
-		followSymlinks: followSymlinksOverride(fs, followSymlinks),
-	}
+	hasStdin, fileArgs := splitStdinArg(fs.Args())
 
-	allArgs := fs.Args()
+	return fixCLIOpts{
+		configPath: configPath,
+		format:     format,
+		noColor:    noColor,
+		quiet:      quiet,
+		verbose:    verbose,
+		walk: walkCLI{
+			noGitignore:    noGitignore,
+			followSymlinks: followSymlinksOverride(fs, followSymlinks),
+		},
+		maxInputSize: maxInputSize,
+		explain:      explain,
+		dryRun:       dryRun,
+	}, fileArgs, hasStdin, -1
+}
 
-	// Check for explicit stdin argument "-".
-	hasStdin, fileArgs := splitStdinArg(allArgs)
-
-	if hasStdin {
-		fmt.Fprintf(os.Stderr, "mdsmith: cannot fix stdin in place\n")
-		return 2
-	}
-
-	if len(fileArgs) > 0 {
-		return fixFiles(fileArgs, configPath, format, noColor, quiet, verbose, walk, maxInputSize, explain)
-	}
-
-	// No file args: discover files from config.
-	return fixDiscovered(configPath, format, noColor, quiet, verbose, walk, maxInputSize, explain)
+// fixCLIOpts bundles the runtime knobs threaded through the fix
+// command path. Grouped because runFix splits between explicit-file
+// and config-discovery entry points and the same nine values flow
+// to both.
+type fixCLIOpts struct {
+	configPath   string
+	format       string
+	noColor      bool
+	quiet        bool
+	verbose      bool
+	walk         walkCLI
+	maxInputSize string
+	explain      bool
+	dryRun       bool
 }
 
 // runQuery implements the "query" subcommand: select files by CUE
@@ -462,6 +498,113 @@ func runInit(args []string) int {
 	return 0
 }
 
+// printDryRunPreview writes one line per file that would change.
+// Files where some diagnostics would be resolved get a
+// "would fix N violations (MDS001 ×2, MDS006)" line; files whose
+// bytes would change without any diagnostic count decreasing get a
+// "would update generated content" line so a dry-run still surfaces
+// directive regeneration. No-op when the preview is empty. Write
+// errors on the destination are ignored — the diagnostic output
+// path swallows them too, and a half-written preview is not worth
+// halting the run for.
+func printDryRunPreview(w io.Writer, fixResult *fixpkg.Result) {
+	for _, wf := range fixResult.WouldFixFiles {
+		if wf.Count == 0 {
+			_, _ = fmt.Fprintf(w, "%s: would update generated content\n", wf.Path)
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "%s: would fix %s\n", wf.Path, formatWouldFixSummary(wf))
+	}
+}
+
+// formatWouldFixSummary renders "N violations (MDS001 ×2, MDS006)"
+// for one file's would-fix entry. Single-count rules are printed
+// without a multiplier so the common case stays compact.
+func formatWouldFixSummary(wf fixpkg.WouldFixFile) string {
+	parts := make([]string, 0, len(wf.Rules))
+	for _, r := range wf.Rules {
+		if r.Count == 1 {
+			parts = append(parts, r.RuleID)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s ×%d", r.RuleID, r.Count))
+	}
+	noun := "violations"
+	if wf.Count == 1 {
+		noun = "violation"
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d %s", wf.Count, noun)
+	}
+	return fmt.Sprintf("%d %s (%s)", wf.Count, noun, strings.Join(parts, ", "))
+}
+
+// dryRunJSONFile is the per-file JSON shape produced by
+// `mdsmith fix --dry-run --format json`. One record per file
+// whose bytes or diagnostic counts would change.
+type dryRunJSONFile struct {
+	Path        string     `json:"path"`
+	WouldFix    int        `json:"would_fix"`
+	Rules       []string   `json:"rules"`
+	Diagnostics []jsonDiag `json:"diagnostics"`
+}
+
+// jsonDiag mirrors the diagnostic shape JSONFormatter writes today
+// so dry-run JSON records carry the same per-diagnostic fields.
+type jsonDiag struct {
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Rule     string `json:"rule"`
+	Name     string `json:"name"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+// writeDryRunJSON emits the per-file dry-run JSON payload on w as a
+// JSON array of dryRunJSONFile records. Files in WouldFixFiles drive
+// the record list; per-file remaining diagnostics come from
+// fixResult.Diagnostics. Returns a non-zero exit code on write error.
+func writeDryRunJSON(w io.Writer, fixResult *fixpkg.Result) int {
+	diagsByFile := make(map[string][]lint.Diagnostic)
+	for _, d := range fixResult.Diagnostics {
+		diagsByFile[d.File] = append(diagsByFile[d.File], d)
+	}
+	records := make([]dryRunJSONFile, 0, len(fixResult.WouldFixFiles))
+	for _, wf := range fixResult.WouldFixFiles {
+		rules := make([]string, 0, len(wf.Rules))
+		for _, r := range wf.Rules {
+			rules = append(rules, r.RuleID)
+		}
+		diags := diagsByFile[wf.Path]
+		jsonDiags := make([]jsonDiag, 0, len(diags))
+		for _, d := range diags {
+			jsonDiags = append(jsonDiags, jsonDiag{
+				File:     d.File,
+				Line:     d.Line,
+				Column:   d.Column,
+				Rule:     d.RuleID,
+				Name:     d.RuleName,
+				Severity: string(d.Severity),
+				Message:  d.Message,
+			})
+		}
+		records = append(records, dryRunJSONFile{
+			Path:        wf.Path,
+			WouldFix:    wf.Count,
+			Rules:       rules,
+			Diagnostics: jsonDiags,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(records); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: error writing dry-run output: %v\n", err)
+		return 2
+	}
+	return 0
+}
+
 // formatDiagnosticsTo writes diagnostics to w using the specified format.
 // Returns a non-zero exit code on write error, or 0 on success.
 func formatDiagnosticsTo(w io.Writer, diags []lint.Diagnostic, format string, noColor bool) int {
@@ -496,10 +639,29 @@ type runStats struct {
 	Fixed    int
 	Failures int
 	Unfixed  int
+	// WouldFix is the total diagnostics a dry-run preview would
+	// have fixed. Rendered only when DryRun is true.
+	WouldFix int
+	// DryRun signals that the run was a `fix --dry-run`. When true,
+	// the stats line appends a `would-fix=N` field; the existing
+	// `fixed=` field reads zero because nothing was written.
+	DryRun bool
 }
 
 func printRunStats(format string, quiet bool, stats runStats) {
 	if quiet || format == "json" {
+		return
+	}
+	if stats.DryRun {
+		fmt.Fprintf(
+			os.Stderr,
+			"stats: checked=%d fixed=%d failures=%d unfixed=%d would-fix=%d\n",
+			stats.Checked,
+			stats.Fixed,
+			stats.Failures,
+			stats.Unfixed,
+			stats.WouldFix,
+		)
 		return
 	}
 	fmt.Fprintf(
@@ -561,13 +723,9 @@ func checkFiles(
 }
 
 // fixFiles fixes lint issues in the given file paths.
-func fixFiles(
-	fileArgs []string, configPath, format string,
-	noColor, quiet, verbose bool, walk walkCLI,
-	maxInputSize string, explain bool,
-) int {
+func fixFiles(fileArgs []string, opts fixCLIOpts) int {
 	cfg, cfgPath, logger, files, maxBytes, code := loadAndResolve(
-		fileArgs, configPath, verbose, walk, maxInputSize,
+		fileArgs, opts.configPath, opts.verbose, opts.walk, opts.maxInputSize,
 	)
 	if code >= 0 {
 		return code
@@ -580,31 +738,11 @@ func fixFiles(
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
-		Explain:          explain,
+		Explain:          opts.explain,
+		DryRun:           opts.dryRun,
 	}
 	fixResult := fixer.Fix(files)
-	printErrors(fixResult.Errors)
-
-	if !quiet && len(fixResult.Diagnostics) > 0 {
-		if code := formatDiagnostics(fixResult.Diagnostics, format, noColor); code != 0 {
-			return code
-		}
-	}
-	printRunStats(format, quiet, runStats{
-		Checked:  fixResult.FilesChecked,
-		Fixed:    len(fixResult.Modified),
-		Failures: fixResult.Failures,
-		Unfixed:  len(fixResult.Diagnostics),
-	})
-	logger.Printf("checked %d files, %d issues found", fixResult.FilesChecked, len(fixResult.Diagnostics))
-
-	if len(fixResult.Errors) > 0 && len(fixResult.Diagnostics) == 0 {
-		return 2
-	}
-	if len(fixResult.Diagnostics) > 0 {
-		return 1
-	}
-	return 0
+	return reportFixResult(opts, fixResult, logger)
 }
 
 // readStdinLimited reads stdin with an optional size limit.
@@ -830,17 +968,13 @@ func checkDiscovered(
 
 // fixDiscovered loads config, discovers files from config patterns,
 // and fixes them. Returns the appropriate exit code.
-func fixDiscovered(
-	configPath, format string,
-	noColor, quiet, verbose bool, walk walkCLI,
-	maxInputSize string, explain bool,
-) int {
-	cfg, cfgPath, logger, files, code := discoverFiles(configPath, verbose, walk)
+func fixDiscovered(opts fixCLIOpts) int {
+	cfg, cfgPath, logger, files, code := discoverFiles(opts.configPath, opts.verbose, opts.walk)
 	if code >= 0 {
 		return code
 	}
 
-	maxBytes, err := resolveMaxInputBytes(cfg, maxInputSize)
+	maxBytes, err := resolveMaxInputBytes(cfg, opts.maxInputSize)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
@@ -853,21 +987,41 @@ func fixDiscovered(
 		Logger:           logger,
 		RootDir:          rootDirFromConfig(cfgPath),
 		MaxInputBytes:    maxBytes,
-		Explain:          explain,
+		Explain:          opts.explain,
+		DryRun:           opts.dryRun,
 	}
 	fixResult := fixer.Fix(files)
+	return reportFixResult(opts, fixResult, logger)
+}
+
+// reportFixResult writes the fix run's output and computes the exit
+// code. Shared by fixFiles and fixDiscovered so the dry-run preview,
+// stats summary, and exit-code logic stay in one place.
+func reportFixResult(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.Logger) int {
 	printErrors(fixResult.Errors)
 
-	if !quiet && len(fixResult.Diagnostics) > 0 {
-		if code := formatDiagnostics(fixResult.Diagnostics, format, noColor); code != 0 {
+	if opts.dryRun && opts.format == "json" {
+		if code := writeDryRunJSON(os.Stdout, fixResult); code != 0 {
 			return code
 		}
+	} else {
+		if opts.dryRun && !opts.quiet {
+			printDryRunPreview(os.Stderr, fixResult)
+		}
+		if !opts.quiet && len(fixResult.Diagnostics) > 0 {
+			if code := formatDiagnostics(fixResult.Diagnostics, opts.format, opts.noColor); code != 0 {
+				return code
+			}
+		}
 	}
-	printRunStats(format, quiet, runStats{
+
+	printRunStats(opts.format, opts.quiet, runStats{
 		Checked:  fixResult.FilesChecked,
 		Fixed:    len(fixResult.Modified),
 		Failures: fixResult.Failures,
 		Unfixed:  len(fixResult.Diagnostics),
+		WouldFix: fixResult.WouldFix,
+		DryRun:   opts.dryRun,
 	})
 	logger.Printf("checked %d files, %d issues found", fixResult.FilesChecked, len(fixResult.Diagnostics))
 

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -505,9 +505,10 @@ func runInit(args []string) int {
 // bytes would change without any diagnostic count decreasing get a
 // "would update generated content" line so a dry-run still surfaces
 // directive regeneration. No-op when the preview is empty. Write
-// errors on the destination are ignored — the diagnostic output
-// path swallows them too, and a half-written preview is not worth
-// halting the run for.
+// errors on the destination are intentionally ignored: the preview
+// is supplemental context, not the primary signal (exit code and
+// diagnostic output drive CI), and a half-written preview is not
+// worth halting the run for.
 func printDryRunPreview(w io.Writer, fixResult *fixpkg.Result) {
 	for _, wf := range fixResult.WouldFixFiles {
 		if wf.Count == 0 {

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -688,8 +688,16 @@ func formatDiagnostics(diags []lint.Diagnostic, format string, noColor bool) int
 
 // printErrors writes runtime errors to stderr.
 func printErrors(errs []error) {
+	printErrorsTo(os.Stderr, errs)
+}
+
+// printErrorsTo writes runtime errors to the supplied writer.
+// Write errors are intentionally swallowed; the run itself has
+// already produced its diagnostic content and a partial stderr
+// notice is not worth stopping the process for.
+func printErrorsTo(w io.Writer, errs []error) {
 	for _, e := range errs {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", e)
+		_, _ = fmt.Fprintf(w, "mdsmith: %v\n", e)
 	}
 }
 
@@ -708,12 +716,18 @@ type runStats struct {
 }
 
 func printRunStats(format string, quiet bool, stats runStats) {
+	printRunStatsTo(os.Stderr, format, quiet, stats)
+}
+
+// printRunStatsTo writes the stats line to the supplied writer.
+func printRunStatsTo(w io.Writer, format string, quiet bool, stats runStats) {
 	if quiet || format == "json" {
 		return
 	}
 	if stats.DryRun {
-		fmt.Fprintf(
-			os.Stderr,
+		// Write errors swallowed: see printErrorsTo rationale.
+		_, _ = fmt.Fprintf(
+			w,
 			"stats: checked=%d fixed=%d failures=%d unfixed=%d would-fix=%d\n",
 			stats.Checked,
 			stats.Fixed,
@@ -723,8 +737,8 @@ func printRunStats(format string, quiet bool, stats runStats) {
 		)
 		return
 	}
-	fmt.Fprintf(
-		os.Stderr,
+	_, _ = fmt.Fprintf(
+		w,
 		"stats: checked=%d fixed=%d failures=%d unfixed=%d\n",
 		stats.Checked,
 		stats.Fixed,
@@ -1057,13 +1071,14 @@ func fixDiscovered(opts fixCLIOpts) int {
 // code. Shared by fixFiles and fixDiscovered so the dry-run preview,
 // stats summary, and exit-code logic stay in one place.
 func reportFixResult(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.Logger) int {
-	return reportFixResultTo(opts, fixResult, logger, os.Stdout, os.Stderr)
+	return reportFixResultTo(opts, fixResult, logger, os.Stderr)
 }
 
 // reportFixResultTo is the injectable form of reportFixResult. Tests
-// pass alternate writers to exercise the write-error branches.
-func reportFixResultTo(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.Logger, stdoutW, stderrW io.Writer) int {
-	printErrors(fixResult.Errors)
+// pass an alternate stderr writer to exercise the write-error
+// branches without leaking to the real stderr.
+func reportFixResultTo(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.Logger, stderrW io.Writer) int {
+	printErrorsTo(stderrW, fixResult.Errors)
 
 	if opts.dryRun && opts.format == "json" && !opts.quiet {
 		// Match `check --format json` and `fix --format json`: lint
@@ -1082,7 +1097,7 @@ func reportFixResultTo(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.L
 		}
 	}
 
-	printRunStats(opts.format, opts.quiet, runStats{
+	printRunStatsTo(stderrW, opts.format, opts.quiet, runStats{
 		Checked:  fixResult.FilesChecked,
 		Fixed:    len(fixResult.Modified),
 		Failures: fixResult.Failures,

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -550,15 +550,34 @@ type dryRunJSONFile struct {
 }
 
 // jsonDiag mirrors the diagnostic shape JSONFormatter writes today
-// so dry-run JSON records carry the same per-diagnostic fields.
+// so dry-run JSON records carry the same per-diagnostic fields,
+// including the optional source-context and explanation trailers.
 type jsonDiag struct {
-	File     string `json:"file"`
-	Line     int    `json:"line"`
-	Column   int    `json:"column"`
-	Rule     string `json:"rule"`
-	Name     string `json:"name"`
-	Severity string `json:"severity"`
-	Message  string `json:"message"`
+	File            string       `json:"file"`
+	Line            int          `json:"line"`
+	Column          int          `json:"column"`
+	Rule            string       `json:"rule"`
+	Name            string       `json:"name"`
+	Severity        string       `json:"severity"`
+	Message         string       `json:"message"`
+	SourceLines     []string     `json:"source_lines,omitempty"`
+	SourceStartLine int          `json:"source_start_line,omitempty"`
+	Explanation     *jsonDiagExp `json:"explanation,omitempty"`
+}
+
+// jsonDiagExp is the explanation trailer shape, matching
+// output.jsonExplanation so dry-run JSON is schema-compatible with
+// check --format json.
+type jsonDiagExp struct {
+	Rule   string         `json:"rule"`
+	Leaves []jsonDiagLeaf `json:"leaves"`
+}
+
+// jsonDiagLeaf is one leaf entry inside a jsonDiagExp.
+type jsonDiagLeaf struct {
+	Path   string `json:"path"`
+	Value  any    `json:"value"`
+	Source string `json:"source"`
 }
 
 // writeDryRunJSON emits the per-file dry-run JSON payload on w as a
@@ -579,14 +598,25 @@ func writeDryRunJSON(w io.Writer, fixResult *fixpkg.Result) int {
 		diags := diagsByFile[wf.Path]
 		jsonDiags := make([]jsonDiag, 0, len(diags))
 		for _, d := range diags {
+			var exp *jsonDiagExp
+			if d.Explanation != nil {
+				leaves := make([]jsonDiagLeaf, 0, len(d.Explanation.Leaves))
+				for _, l := range d.Explanation.Leaves {
+					leaves = append(leaves, jsonDiagLeaf{Path: l.Path, Value: l.Value, Source: l.Source})
+				}
+				exp = &jsonDiagExp{Rule: d.Explanation.Rule, Leaves: leaves}
+			}
 			jsonDiags = append(jsonDiags, jsonDiag{
-				File:     d.File,
-				Line:     d.Line,
-				Column:   d.Column,
-				Rule:     d.RuleID,
-				Name:     d.RuleName,
-				Severity: string(d.Severity),
-				Message:  d.Message,
+				File:            d.File,
+				Line:            d.Line,
+				Column:          d.Column,
+				Rule:            d.RuleID,
+				Name:            d.RuleName,
+				Severity:        string(d.Severity),
+				Message:         d.Message,
+				SourceLines:     d.SourceLines,
+				SourceStartLine: d.SourceStartLine,
+				Explanation:     exp,
 			})
 		}
 		records = append(records, dryRunJSONFile{
@@ -998,18 +1028,24 @@ func fixDiscovered(opts fixCLIOpts) int {
 // code. Shared by fixFiles and fixDiscovered so the dry-run preview,
 // stats summary, and exit-code logic stay in one place.
 func reportFixResult(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.Logger) int {
+	return reportFixResultTo(opts, fixResult, logger, os.Stdout, os.Stderr)
+}
+
+// reportFixResultTo is the injectable form of reportFixResult. Tests
+// pass alternate writers to exercise the write-error branches.
+func reportFixResultTo(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.Logger, stdoutW, stderrW io.Writer) int {
 	printErrors(fixResult.Errors)
 
-	if opts.dryRun && opts.format == "json" {
-		if code := writeDryRunJSON(os.Stdout, fixResult); code != 0 {
+	if opts.dryRun && opts.format == "json" && !opts.quiet {
+		if code := writeDryRunJSON(stdoutW, fixResult); code != 0 {
 			return code
 		}
 	} else {
 		if opts.dryRun && !opts.quiet {
-			printDryRunPreview(os.Stderr, fixResult)
+			printDryRunPreview(stderrW, fixResult)
 		}
 		if !opts.quiet && len(fixResult.Diagnostics) > 0 {
-			if code := formatDiagnostics(fixResult.Diagnostics, opts.format, opts.noColor); code != 0 {
+			if code := formatDiagnosticsTo(stderrW, fixResult.Diagnostics, opts.format, opts.noColor); code != 0 {
 				return code
 			}
 		}

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -541,7 +542,7 @@ func formatWouldFixSummary(wf fixpkg.WouldFixFile) string {
 
 // dryRunJSONFile is the per-file JSON shape produced by
 // `mdsmith fix --dry-run --format json`. One record per file
-// whose bytes or diagnostic counts would change.
+// with fixable violations or remaining unfixable diagnostics.
 type dryRunJSONFile struct {
 	Path        string     `json:"path"`
 	WouldFix    int        `json:"would_fix"`
@@ -580,50 +581,73 @@ type jsonDiagLeaf struct {
 	Source string `json:"source"`
 }
 
+// diagsToJSONDiags converts lint diagnostics to the JSON shape used by
+// dry-run output.
+func diagsToJSONDiags(diags []lint.Diagnostic) []jsonDiag {
+	jsonDiags := make([]jsonDiag, 0, len(diags))
+	for _, d := range diags {
+		var exp *jsonDiagExp
+		if d.Explanation != nil {
+			leaves := make([]jsonDiagLeaf, 0, len(d.Explanation.Leaves))
+			for _, l := range d.Explanation.Leaves {
+				leaves = append(leaves, jsonDiagLeaf{Path: l.Path, Value: l.Value, Source: l.Source})
+			}
+			exp = &jsonDiagExp{Rule: d.Explanation.Rule, Leaves: leaves}
+		}
+		jsonDiags = append(jsonDiags, jsonDiag{
+			File:            d.File,
+			Line:            d.Line,
+			Column:          d.Column,
+			Rule:            d.RuleID,
+			Name:            d.RuleName,
+			Severity:        string(d.Severity),
+			Message:         d.Message,
+			SourceLines:     d.SourceLines,
+			SourceStartLine: d.SourceStartLine,
+			Explanation:     exp,
+		})
+	}
+	return jsonDiags
+}
+
 // writeDryRunJSON emits the per-file dry-run JSON payload on w as a
-// JSON array of dryRunJSONFile records. Files in WouldFixFiles drive
-// the record list; per-file remaining diagnostics come from
-// fixResult.Diagnostics. Returns a non-zero exit code on write error.
+// JSON array of dryRunJSONFile records. Records are emitted for every
+// file in WouldFixFiles plus any file that has remaining diagnostics
+// not already covered. Returns a non-zero exit code on write error.
 func writeDryRunJSON(w io.Writer, fixResult *fixpkg.Result) int {
 	diagsByFile := make(map[string][]lint.Diagnostic)
 	for _, d := range fixResult.Diagnostics {
 		diagsByFile[d.File] = append(diagsByFile[d.File], d)
 	}
+	seen := make(map[string]struct{}, len(fixResult.WouldFixFiles))
 	records := make([]dryRunJSONFile, 0, len(fixResult.WouldFixFiles))
 	for _, wf := range fixResult.WouldFixFiles {
+		seen[wf.Path] = struct{}{}
 		rules := make([]string, 0, len(wf.Rules))
 		for _, r := range wf.Rules {
 			rules = append(rules, r.RuleID)
-		}
-		diags := diagsByFile[wf.Path]
-		jsonDiags := make([]jsonDiag, 0, len(diags))
-		for _, d := range diags {
-			var exp *jsonDiagExp
-			if d.Explanation != nil {
-				leaves := make([]jsonDiagLeaf, 0, len(d.Explanation.Leaves))
-				for _, l := range d.Explanation.Leaves {
-					leaves = append(leaves, jsonDiagLeaf{Path: l.Path, Value: l.Value, Source: l.Source})
-				}
-				exp = &jsonDiagExp{Rule: d.Explanation.Rule, Leaves: leaves}
-			}
-			jsonDiags = append(jsonDiags, jsonDiag{
-				File:            d.File,
-				Line:            d.Line,
-				Column:          d.Column,
-				Rule:            d.RuleID,
-				Name:            d.RuleName,
-				Severity:        string(d.Severity),
-				Message:         d.Message,
-				SourceLines:     d.SourceLines,
-				SourceStartLine: d.SourceStartLine,
-				Explanation:     exp,
-			})
 		}
 		records = append(records, dryRunJSONFile{
 			Path:        wf.Path,
 			WouldFix:    wf.Count,
 			Rules:       rules,
-			Diagnostics: jsonDiags,
+			Diagnostics: diagsToJSONDiags(diagsByFile[wf.Path]),
+		})
+	}
+	// Include files with only unfixable diagnostics (not in WouldFixFiles).
+	unfixable := make([]string, 0, len(diagsByFile))
+	for path := range diagsByFile {
+		if _, ok := seen[path]; !ok {
+			unfixable = append(unfixable, path)
+		}
+	}
+	sort.Strings(unfixable)
+	for _, path := range unfixable {
+		records = append(records, dryRunJSONFile{
+			Path:        path,
+			WouldFix:    0,
+			Rules:       []string{},
+			Diagnostics: diagsToJSONDiags(diagsByFile[path]),
 		})
 	}
 	enc := json.NewEncoder(w)

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -614,7 +614,9 @@ func diagsToJSONDiags(diags []lint.Diagnostic) []jsonDiag {
 // writeDryRunJSON emits the per-file dry-run JSON payload on w as a
 // JSON array of dryRunJSONFile records. Records are emitted for every
 // file in WouldFixFiles plus any file that has remaining diagnostics
-// not already covered. Returns a non-zero exit code on write error.
+// not already covered. Callers route w to stderr to match the
+// existing lint-output contract documented in
+// docs/reference/cli.md. Returns a non-zero exit code on write error.
 func writeDryRunJSON(w io.Writer, fixResult *fixpkg.Result) int {
 	diagsByFile := make(map[string][]lint.Diagnostic)
 	for _, d := range fixResult.Diagnostics {
@@ -1062,7 +1064,9 @@ func reportFixResultTo(opts fixCLIOpts, fixResult *fixpkg.Result, logger *vlog.L
 	printErrors(fixResult.Errors)
 
 	if opts.dryRun && opts.format == "json" && !opts.quiet {
-		if code := writeDryRunJSON(stdoutW, fixResult); code != 0 {
+		// Match `check --format json` and `fix --format json`: lint
+		// output goes to stderr (see docs/reference/cli.md "Output").
+		if code := writeDryRunJSON(stderrW, fixResult); code != 0 {
 			return code
 		}
 	} else {

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -543,7 +543,9 @@ func formatWouldFixSummary(wf fixpkg.WouldFixFile) string {
 
 // dryRunJSONFile is the per-file JSON shape produced by
 // `mdsmith fix --dry-run --format json`. One record per file
-// with fixable violations or remaining unfixable diagnostics.
+// whose bytes or diagnostic counts would change — fixable
+// violations, remaining unfixable diagnostics, or
+// generated-section regeneration (would_fix=0, rules=[]).
 type dryRunJSONFile struct {
 	Path        string     `json:"path"`
 	WouldFix    int        `json:"would_fix"`

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/jeduden/mdsmith/internal/config"
+	fixpkg "github.com/jeduden/mdsmith/internal/fix"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/query"
 	ruledocs "github.com/jeduden/mdsmith/internal/rules"
@@ -238,6 +239,146 @@ func TestPrintRunStats_ZeroValues(t *testing.T) {
 	assert.Contains(t, got, "fixed=0")
 	assert.Contains(t, got, "failures=0")
 	assert.Contains(t, got, "unfixed=0")
+}
+
+func TestPrintRunStats_DryRunIncludesWouldFix(t *testing.T) {
+	got := captureStderr(func() {
+		printRunStats("text", false, runStats{
+			Checked:  12,
+			Fixed:    0,
+			Failures: 4,
+			Unfixed:  0,
+			WouldFix: 8,
+			DryRun:   true,
+		})
+	})
+	assert.Contains(t, got, "checked=12")
+	assert.Contains(t, got, "fixed=0")
+	assert.Contains(t, got, "failures=4")
+	assert.Contains(t, got, "unfixed=0")
+	assert.Contains(t, got, "would-fix=8")
+}
+
+func TestPrintRunStats_NonDryRunOmitsWouldFix(t *testing.T) {
+	got := captureStderr(func() {
+		printRunStats("text", false, runStats{
+			Checked: 1, Fixed: 1, Failures: 1, Unfixed: 0,
+		})
+	})
+	assert.NotContains(t, got, "would-fix",
+		"would-fix field must be hidden on non-dry-run; got: %s", got)
+}
+
+// --- formatWouldFixSummary / printDryRunPreview / writeDryRunJSON ---
+
+func TestFormatWouldFixSummary_SingleRuleSingleCount(t *testing.T) {
+	got := formatWouldFixSummary(fixpkg.WouldFixFile{
+		Path:  "a.md",
+		Count: 1,
+		Rules: []fixpkg.RuleFixCount{{RuleID: "MDS006", Count: 1}},
+	})
+	assert.Equal(t, "1 violation (MDS006)", got)
+}
+
+func TestFormatWouldFixSummary_MultipleRulesWithCounts(t *testing.T) {
+	got := formatWouldFixSummary(fixpkg.WouldFixFile{
+		Path:  "a.md",
+		Count: 3,
+		Rules: []fixpkg.RuleFixCount{
+			{RuleID: "MDS001", Count: 2},
+			{RuleID: "MDS006", Count: 1},
+		},
+	})
+	assert.Equal(t, "3 violations (MDS001 ×2, MDS006)", got)
+}
+
+func TestFormatWouldFixSummary_EmptyRulesPrintsCountOnly(t *testing.T) {
+	got := formatWouldFixSummary(fixpkg.WouldFixFile{
+		Path:  "a.md",
+		Count: 2,
+		Rules: nil,
+	})
+	assert.Equal(t, "2 violations", got)
+}
+
+func TestPrintDryRunPreview_BytesOnlyChangeReportsRegeneration(t *testing.T) {
+	var buf bytes.Buffer
+	printDryRunPreview(&buf, &fixpkg.Result{
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{Path: "docs/index.md", Count: 0, Rules: nil},
+		},
+	})
+	assert.Equal(t, "docs/index.md: would update generated content\n", buf.String())
+}
+
+func TestPrintDryRunPreview_MultipleFiles(t *testing.T) {
+	var buf bytes.Buffer
+	printDryRunPreview(&buf, &fixpkg.Result{
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{
+				Path:  "a.md",
+				Count: 2,
+				Rules: []fixpkg.RuleFixCount{
+					{RuleID: "MDS006", Count: 2},
+				},
+			},
+			{
+				Path:  "b.md",
+				Count: 1,
+				Rules: []fixpkg.RuleFixCount{
+					{RuleID: "MDS001", Count: 1},
+				},
+			},
+		},
+	})
+	out := buf.String()
+	assert.Contains(t, out, "a.md: would fix 2 violations (MDS006 ×2)\n")
+	assert.Contains(t, out, "b.md: would fix 1 violation (MDS001)\n")
+}
+
+func TestWriteDryRunJSON_EmitsPerFileRecords(t *testing.T) {
+	var buf bytes.Buffer
+	code := writeDryRunJSON(&buf, &fixpkg.Result{
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{
+				Path:  "a.md",
+				Count: 3,
+				Rules: []fixpkg.RuleFixCount{
+					{RuleID: "MDS001", Count: 2},
+					{RuleID: "MDS006", Count: 1},
+				},
+			},
+		},
+		Diagnostics: []lint.Diagnostic{
+			{File: "a.md", Line: 7, Column: 1, RuleID: "MDS017",
+				RuleName: "no-trailing-punctuation-in-heading",
+				Severity: lint.Warning, Message: "trailing punctuation"},
+		},
+	})
+	assert.Equal(t, 0, code)
+
+	var records []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &records),
+		"output must be valid JSON; got: %s", buf.String())
+	require.Len(t, records, 1)
+
+	rec := records[0]
+	assert.Equal(t, "a.md", rec["path"])
+	assert.EqualValues(t, 3, rec["would_fix"])
+	assert.Equal(t, []any{"MDS001", "MDS006"}, rec["rules"])
+
+	diags, ok := rec["diagnostics"].([]any)
+	require.True(t, ok, "diagnostics must be a JSON array")
+	require.Len(t, diags, 1)
+	diag := diags[0].(map[string]any)
+	assert.Equal(t, "MDS017", diag["rule"])
+}
+
+func TestWriteDryRunJSON_EmptyResultEmitsEmptyArray(t *testing.T) {
+	var buf bytes.Buffer
+	code := writeDryRunJSON(&buf, &fixpkg.Result{})
+	assert.Equal(t, 0, code)
+	assert.Equal(t, "[]\n", buf.String())
 }
 
 // --- printErrors ---

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -499,14 +499,19 @@ func TestReportFixResult_DryRunJSONOutput(t *testing.T) {
 	}
 	var code int
 	var stdout string
-	captureStderr(func() {
+	stderr := captureStderr(func() {
 		stdout = captureStdout(func() {
 			code = reportFixResult(opts, result, &vlog.Logger{})
 		})
 	})
 	assert.Equal(t, 0, code)
+	assert.NotContains(t, stdout, "[", "dry-run JSON must go to stderr, not stdout")
+
+	// Strip the trailing stats line so the rest is parseable JSON.
+	jsonEnd := strings.LastIndex(stderr, "]")
+	require.GreaterOrEqual(t, jsonEnd, 0, "stderr must contain JSON payload; got: %s", stderr)
 	var records []map[string]any
-	require.NoError(t, json.Unmarshal([]byte(stdout), &records))
+	require.NoError(t, json.Unmarshal([]byte(stderr[:jsonEnd+1]), &records))
 	require.Len(t, records, 1)
 	assert.Equal(t, "f.md", records[0]["path"])
 }
@@ -521,13 +526,14 @@ func TestReportFixResult_DryRunJSONQuietSuppressesOutput(t *testing.T) {
 	}
 	var code int
 	var stdout string
-	captureStderr(func() {
+	stderr := captureStderr(func() {
 		stdout = captureStdout(func() {
 			code = reportFixResult(opts, result, &vlog.Logger{})
 		})
 	})
 	assert.Equal(t, 0, code)
 	assert.Empty(t, stdout)
+	assert.NotContains(t, stderr, "{", "--quiet must suppress dry-run JSON on stderr too")
 }
 
 func TestReportFixResult_DiagnosticsReturnsCode1(t *testing.T) {
@@ -568,7 +574,8 @@ func TestReportFixResultTo_DryRunJSONWriteErrorReturns2(t *testing.T) {
 	}
 	var code int
 	captureStderr(func() {
-		code = reportFixResultTo(opts, result, &vlog.Logger{}, &alwaysErrorWriter{}, io.Discard)
+		// Dry-run JSON goes to stderr; route the error writer there.
+		code = reportFixResultTo(opts, result, &vlog.Logger{}, io.Discard, &alwaysErrorWriter{})
 	})
 	assert.Equal(t, 2, code)
 }

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -439,6 +439,34 @@ func TestWriteDryRunJSON_PopulatesSourceLinesAndExplanation(t *testing.T) {
 	assert.Equal(t, "MDS017", exp["rule"])
 }
 
+func TestWriteDryRunJSON_IncludesUnfixableDiagFiles(t *testing.T) {
+	var buf bytes.Buffer
+	code := writeDryRunJSON(&buf, &fixpkg.Result{
+		WouldFixFiles: []fixpkg.WouldFixFile{},
+		Diagnostics: []lint.Diagnostic{
+			{File: "b.md", Line: 3, Column: 1, RuleID: "MDS099",
+				RuleName: "unfixable-rule", Severity: lint.Error, Message: "unfixable"},
+		},
+	})
+	assert.Equal(t, 0, code)
+
+	var records []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &records),
+		"output must be valid JSON; got: %s", buf.String())
+	require.Len(t, records, 1, "unfixable-diag file must appear in output")
+
+	rec := records[0]
+	assert.Equal(t, "b.md", rec["path"])
+	assert.EqualValues(t, 0, rec["would_fix"])
+	assert.Equal(t, []any{}, rec["rules"])
+
+	diags, ok := rec["diagnostics"].([]any)
+	require.True(t, ok, "diagnostics must be a JSON array")
+	require.Len(t, diags, 1)
+	diag := diags[0].(map[string]any)
+	assert.Equal(t, "MDS099", diag["rule"])
+}
+
 // --- reportFixResult ---
 
 func TestReportFixResult_DryRunTextPreview(t *testing.T) {

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -570,11 +570,7 @@ func TestReportFixResultTo_DryRunJSONWriteErrorReturns2(t *testing.T) {
 	result := &fixpkg.Result{
 		WouldFixFiles: []fixpkg.WouldFixFile{{Path: "f.md", Count: 1}},
 	}
-	var code int
-	captureStderr(func() {
-		// Dry-run JSON goes to stderr; route the error writer there.
-		code = reportFixResultTo(opts, result, &vlog.Logger{}, io.Discard, &alwaysErrorWriter{})
-	})
+	code := reportFixResultTo(opts, result, &vlog.Logger{}, &alwaysErrorWriter{})
 	assert.Equal(t, 2, code)
 }
 
@@ -588,10 +584,7 @@ func TestReportFixResultTo_DiagWriteErrorReturns2(t *testing.T) {
 				RuleName: "test-rule", Severity: lint.Warning, Message: "issue"},
 		},
 	}
-	var code int
-	captureStderr(func() {
-		code = reportFixResultTo(opts, result, &vlog.Logger{}, io.Discard, &alwaysErrorWriter{})
-	})
+	code := reportFixResultTo(opts, result, &vlog.Logger{}, &alwaysErrorWriter{})
 	assert.Equal(t, 2, code)
 }
 

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/config"
 	fixpkg "github.com/jeduden/mdsmith/internal/fix"
 	"github.com/jeduden/mdsmith/internal/lint"
+	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/query"
 	ruledocs "github.com/jeduden/mdsmith/internal/rules"
 )
@@ -379,6 +380,186 @@ func TestWriteDryRunJSON_EmptyResultEmitsEmptyArray(t *testing.T) {
 	code := writeDryRunJSON(&buf, &fixpkg.Result{})
 	assert.Equal(t, 0, code)
 	assert.Equal(t, "[]\n", buf.String())
+}
+
+// alwaysErrorWriter rejects all writes, used to drive error paths.
+type alwaysErrorWriter struct{}
+
+func (w *alwaysErrorWriter) Write(_ []byte) (int, error) {
+	return 0, fmt.Errorf("write failed")
+}
+
+func TestWriteDryRunJSON_WriteErrorReturns2(t *testing.T) {
+	var code int
+	captureStderr(func() {
+		code = writeDryRunJSON(&alwaysErrorWriter{}, &fixpkg.Result{
+			WouldFixFiles: []fixpkg.WouldFixFile{{Path: "f.md", Count: 1}},
+		})
+	})
+	assert.Equal(t, 2, code)
+}
+
+func TestWriteDryRunJSON_PopulatesSourceLinesAndExplanation(t *testing.T) {
+	var buf bytes.Buffer
+	code := writeDryRunJSON(&buf, &fixpkg.Result{
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{Path: "a.md", Count: 1, Rules: []fixpkg.RuleFixCount{{RuleID: "MDS001", Count: 1}}},
+		},
+		Diagnostics: []lint.Diagnostic{
+			{
+				File: "a.md", Line: 5, Column: 1,
+				RuleID: "MDS017", RuleName: "no-trailing-punct",
+				Severity: lint.Warning, Message: "trailing punct",
+				SourceLines:     []string{"## Heading."},
+				SourceStartLine: 5,
+				Explanation: &lint.Explanation{
+					Rule: "MDS017",
+					Leaves: []lint.ExplanationLeaf{
+						{Path: "rules.no-trailing-punct.enabled", Value: true, Source: "default"},
+					},
+				},
+			},
+		},
+	})
+	require.Equal(t, 0, code)
+
+	var records []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &records))
+	require.Len(t, records, 1)
+	diags, ok := records[0]["diagnostics"].([]any)
+	require.True(t, ok)
+	require.Len(t, diags, 1)
+	d := diags[0].(map[string]any)
+	srcLines, ok := d["source_lines"].([]any)
+	require.True(t, ok, "source_lines must be present")
+	assert.Equal(t, []any{"## Heading."}, srcLines)
+	assert.EqualValues(t, 5, d["source_start_line"])
+	exp, ok := d["explanation"].(map[string]any)
+	require.True(t, ok, "explanation must be present")
+	assert.Equal(t, "MDS017", exp["rule"])
+}
+
+// --- reportFixResult ---
+
+func TestReportFixResult_DryRunTextPreview(t *testing.T) {
+	opts := fixCLIOpts{dryRun: true, format: "text"}
+	result := &fixpkg.Result{
+		FilesChecked: 2,
+		Failures:     1,
+		WouldFix:     1,
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{Path: "f.md", Count: 1, Rules: []fixpkg.RuleFixCount{{RuleID: "MDS001", Count: 1}}},
+		},
+	}
+	var code int
+	stderr := captureStderr(func() {
+		code = reportFixResult(opts, result, &vlog.Logger{})
+	})
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stderr, "f.md: would fix 1 violation")
+	assert.Contains(t, stderr, "would-fix=1")
+}
+
+func TestReportFixResult_DryRunJSONOutput(t *testing.T) {
+	opts := fixCLIOpts{dryRun: true, format: "json"}
+	result := &fixpkg.Result{
+		FilesChecked: 1,
+		WouldFix:     1,
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{Path: "f.md", Count: 1, Rules: []fixpkg.RuleFixCount{{RuleID: "MDS001", Count: 1}}},
+		},
+	}
+	var code int
+	var stdout string
+	captureStderr(func() {
+		stdout = captureStdout(func() {
+			code = reportFixResult(opts, result, &vlog.Logger{})
+		})
+	})
+	assert.Equal(t, 0, code)
+	var records []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &records))
+	require.Len(t, records, 1)
+	assert.Equal(t, "f.md", records[0]["path"])
+}
+
+func TestReportFixResult_DryRunJSONQuietSuppressesOutput(t *testing.T) {
+	opts := fixCLIOpts{dryRun: true, format: "json", quiet: true}
+	result := &fixpkg.Result{
+		WouldFix: 1,
+		WouldFixFiles: []fixpkg.WouldFixFile{
+			{Path: "f.md", Count: 1},
+		},
+	}
+	var code int
+	var stdout string
+	captureStderr(func() {
+		stdout = captureStdout(func() {
+			code = reportFixResult(opts, result, &vlog.Logger{})
+		})
+	})
+	assert.Equal(t, 0, code)
+	assert.Empty(t, stdout)
+}
+
+func TestReportFixResult_DiagnosticsReturnsCode1(t *testing.T) {
+	opts := fixCLIOpts{format: "text"}
+	result := &fixpkg.Result{
+		FilesChecked: 1,
+		Failures:     1,
+		Diagnostics: []lint.Diagnostic{
+			{File: "f.md", Line: 1, Column: 1, RuleID: "MDS001",
+				RuleName: "test-rule", Severity: lint.Warning, Message: "issue"},
+		},
+	}
+	var code int
+	captureStderr(func() {
+		code = reportFixResult(opts, result, &vlog.Logger{})
+	})
+	assert.Equal(t, 1, code)
+}
+
+func TestReportFixResult_ErrorsOnlyReturnsCode2(t *testing.T) {
+	opts := fixCLIOpts{format: "text"}
+	result := &fixpkg.Result{
+		FilesChecked: 1,
+		Errors:       []error{fmt.Errorf("disk error")},
+	}
+	var code int
+	stderr := captureStderr(func() {
+		code = reportFixResult(opts, result, &vlog.Logger{})
+	})
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "disk error")
+}
+
+func TestReportFixResultTo_DryRunJSONWriteErrorReturns2(t *testing.T) {
+	opts := fixCLIOpts{dryRun: true, format: "json"}
+	result := &fixpkg.Result{
+		WouldFixFiles: []fixpkg.WouldFixFile{{Path: "f.md", Count: 1}},
+	}
+	var code int
+	captureStderr(func() {
+		code = reportFixResultTo(opts, result, &vlog.Logger{}, &alwaysErrorWriter{}, io.Discard)
+	})
+	assert.Equal(t, 2, code)
+}
+
+func TestReportFixResultTo_DiagWriteErrorReturns2(t *testing.T) {
+	opts := fixCLIOpts{format: "text"}
+	result := &fixpkg.Result{
+		FilesChecked: 1,
+		Failures:     1,
+		Diagnostics: []lint.Diagnostic{
+			{File: "f.md", Line: 1, Column: 1, RuleID: "MDS001",
+				RuleName: "test-rule", Severity: lint.Warning, Message: "issue"},
+		},
+	}
+	var code int
+	captureStderr(func() {
+		code = reportFixResultTo(opts, result, &vlog.Logger{}, io.Discard, &alwaysErrorWriter{})
+	})
+	assert.Equal(t, 2, code)
 }
 
 // --- printErrors ---

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -507,11 +507,9 @@ func TestReportFixResult_DryRunJSONOutput(t *testing.T) {
 	assert.Equal(t, 0, code)
 	assert.NotContains(t, stdout, "[", "dry-run JSON must go to stderr, not stdout")
 
-	// Strip the trailing stats line so the rest is parseable JSON.
-	jsonEnd := strings.LastIndex(stderr, "]")
-	require.GreaterOrEqual(t, jsonEnd, 0, "stderr must contain JSON payload; got: %s", stderr)
+	// Stats are suppressed in JSON mode; stderr is just the array.
 	var records []map[string]any
-	require.NoError(t, json.Unmarshal([]byte(stderr[:jsonEnd+1]), &records))
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(stderr)), &records))
 	require.Len(t, records, 1)
 	assert.Equal(t, "f.md", records[0]["path"])
 }

--- a/docs/reference/cli/fix.md
+++ b/docs/reference/cli/fix.md
@@ -29,6 +29,7 @@ files are discovered from `.mdsmith.yml` `files:` patterns.
 | `-q`, `--quiet`     | false   | Suppress non-error output              |
 | `-v`, `--verbose`   | false   | Show config, files, and rules          |
 | `--explain`         | false   | Attach per-leaf rule provenance        |
+| `--dry-run`         | false   | Preview changes; write nothing         |
 
 `--follow-symlinks` semantics match
 [`mdsmith check`](check.md#flags).
@@ -39,7 +40,50 @@ files are discovered from `.mdsmith.yml` `files:` patterns.
 mdsmith fix README.md            # fix a single file
 mdsmith fix docs/                # fix a tree
 mdsmith fix --explain plan/      # show provenance for unfixed leftovers
+mdsmith fix --dry-run docs/      # preview without writing
 ```
+
+## `--dry-run`
+
+`mdsmith fix --dry-run` runs the full fix pipeline but
+writes nothing back to disk. Use it to preview which files
+would change and which rules would fire, then gate a CI
+step on the resulting exit code.
+
+```text
+$ mdsmith fix --dry-run docs/
+docs/api.md: would fix 3 violations (MDS001 ×2, MDS006)
+stats: checked=12 fixed=0 failures=3 unfixed=0 would-fix=3
+```
+
+The summary keeps the `checked=` / `fixed=` /
+`failures=` / `unfixed=` fields machine-parsable.
+`fixed=` is always `0` on a dry run (nothing was
+written); the additive `would-fix=N` field counts the
+violations a real run would have auto-fixed. The exit
+code matches what `mdsmith fix` would have returned on
+the same input:
+
+- `0` — every diagnostic is fixable; a real run would
+  leave the worktree clean.
+- non-zero — at least one unfixable diagnostic remains.
+
+`--format json` emits one record per file whose bytes
+or diagnostic counts would change:
+
+```json
+[
+  {
+    "path": "docs/api.md",
+    "would_fix": 3,
+    "rules": ["MDS001", "MDS006"],
+    "diagnostics": []
+  }
+]
+```
+
+The `diagnostics` array carries the same per-diagnostic
+fields `check --format json` returns.
 
 ## Pre-commit
 

--- a/docs/reference/cli/fix.md
+++ b/docs/reference/cli/fix.md
@@ -84,8 +84,10 @@ or diagnostic counts would change:
 
 The `diagnostics` array carries the same per-diagnostic
 fields `check --format json` returns. Like every other
-lint output, the JSON goes to **stderr**; the stats
-summary line follows on stderr too.
+lint output, the JSON goes to **stderr**. The text-mode
+`stats:` summary is suppressed in JSON mode; the
+machine-readable counts live inside each record's
+`would_fix` field.
 
 Some rules fix by writing a sibling file rather than
 the markdown itself. MDS048 `git-hook-sync` is the

--- a/docs/reference/cli/fix.md
+++ b/docs/reference/cli/fix.md
@@ -93,9 +93,10 @@ Some rules fix by writing a sibling file rather than
 the markdown itself. MDS048 `git-hook-sync` is the
 example today: it regenerates `.gitattributes`. On
 `--dry-run` these rules return early to honor the
-no-disk-writes contract. The diff-based preview will
-not list them under `would-fix`, even though a real
-run would clear the underlying drift.
+no-disk-writes contract and instead declare which
+diagnostics a real run would have cleared (via the
+`DryRunPredictor` rule interface), so the dry-run
+exit code still matches a real run.
 
 ## Pre-commit
 

--- a/docs/reference/cli/fix.md
+++ b/docs/reference/cli/fix.md
@@ -83,7 +83,17 @@ or diagnostic counts would change:
 ```
 
 The `diagnostics` array carries the same per-diagnostic
-fields `check --format json` returns.
+fields `check --format json` returns. Like every other
+lint output, the JSON goes to **stderr**; the stats
+summary line follows on stderr too.
+
+Some rules fix by writing a sibling file rather than
+the markdown itself. MDS048 `git-hook-sync` is the
+example today: it regenerates `.gitattributes`. On
+`--dry-run` these rules return early to honor the
+no-disk-writes contract. The diff-based preview will
+not list them under `would-fix`, even though a real
+run would clear the underlying drift.
 
 ## Pre-commit
 

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -33,6 +33,12 @@ type Fixer struct {
 	// remaining diagnostic so output formatters can render an
 	// explanation trailer.
 	Explain bool
+	// DryRun, when true, runs the full fix pipeline but skips the
+	// write back to disk. Modified is left empty (nothing was
+	// written); the per-rule would-fix tally is recorded on the
+	// Result's WouldFix and WouldFixFiles fields so callers can
+	// preview what a real run would change.
+	DryRun bool
 	// SourceFS, when non-nil, overrides the per-file dirFS that
 	// prepareFile would otherwise derive from filepath.Dir(path).
 	// Used by Source / SourceWithRules so callers can pass a
@@ -85,10 +91,42 @@ type Result struct {
 	// Diagnostics contains remaining diagnostics after fixing (from non-fixable
 	// rules and any violations that could not be auto-fixed).
 	Diagnostics []lint.Diagnostic
-	// Modified lists file paths that were written back to disk.
+	// Modified lists file paths that were written back to disk. Always
+	// empty when Fixer.DryRun is true.
 	Modified []string
+	// WouldFix is the total number of diagnostics across all files
+	// that would be resolved by a real fix run. Equals the sum of
+	// WouldFixFiles[i].Count. Populated only when Fixer.DryRun is
+	// true.
+	WouldFix int
+	// WouldFixFiles is the per-file preview produced by a dry run.
+	// Each entry corresponds to one file whose diagnostic count
+	// would decrease or whose bytes would change. Populated only
+	// when Fixer.DryRun is true.
+	WouldFixFiles []WouldFixFile
 	// Errors contains any errors encountered during the fix process.
 	Errors []error
+}
+
+// WouldFixFile is a per-file preview entry returned by a dry run.
+type WouldFixFile struct {
+	// Path is the file path the preview was computed for.
+	Path string
+	// Count is the total number of diagnostics that would be
+	// resolved by a real fix run. May be zero when the file's bytes
+	// would change without any rule's diagnostic count decreasing
+	// (e.g. a generated section regenerating without firing a
+	// diagnostic before).
+	Count int
+	// Rules lists per-rule fix tallies, sorted by RuleID.
+	Rules []RuleFixCount
+}
+
+// RuleFixCount records one rule's would-fix tally inside a
+// WouldFixFile.
+type RuleFixCount struct {
+	RuleID string
+	Count  int
 }
 
 // Fix applies auto-fixes to the files at the given paths and returns a Result
@@ -109,11 +147,15 @@ func (f *Fixer) Fix(paths []string) *Result {
 		}
 		res.FilesChecked++
 		f.log().Printf("file: %s", path)
-		beforeDiags, remainingDiags, modified, errs := f.fixFile(path)
+		beforeDiags, remainingDiags, modified, wouldFix, errs := f.fixFile(path)
 		allBefore = append(allBefore, beforeDiags...)
 		res.Diagnostics = append(res.Diagnostics, remainingDiags...)
 		if modified != "" {
 			res.Modified = append(res.Modified, modified)
+		}
+		if wouldFix != nil {
+			res.WouldFixFiles = append(res.WouldFixFiles, *wouldFix)
+			res.WouldFix += wouldFix.Count
 		}
 		res.Errors = append(res.Errors, errs...)
 	}
@@ -135,24 +177,26 @@ func (f *Fixer) Fix(paths []string) *Result {
 }
 
 // fixFile applies auto-fixes to a single file and returns diagnostics before
-// fixing, remaining diagnostics after fixing, the path if modified, and any
-// errors encountered.
-func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, string, []error) {
+// fixing, remaining diagnostics after fixing, the path if modified, an
+// optional dry-run preview, and any errors encountered.
+func (f *Fixer) fixFile(path string) (
+	[]lint.Diagnostic, []lint.Diagnostic, string, *WouldFixFile, []error,
+) {
 	var errs []error
 
 	source, err := lint.ReadFileLimited(path, f.MaxInputBytes)
 	if err != nil {
-		return nil, nil, "", []error{fmt.Errorf("reading %q: %w", path, err)}
+		return nil, nil, "", nil, []error{fmt.Errorf("reading %q: %w", path, err)}
 	}
 
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, nil, "", []error{fmt.Errorf("stat %q: %w", path, err)}
+		return nil, nil, "", nil, []error{fmt.Errorf("stat %q: %w", path, err)}
 	}
 
 	lf, dirFS, fmKinds, fmFields, prepErr := f.prepareFile(path, source)
 	if prepErr != nil {
-		return nil, nil, "", []error{prepErr}
+		return nil, nil, "", nil, []error{prepErr}
 	}
 
 	effective := f.effectiveWithCategories(path, fmKinds, fmFields)
@@ -166,12 +210,13 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 
 	current := f.applyFixPasses(path, lf.Source, fixable, lf, dirFS, &errs)
 
+	bytesChanged := !bytes.Equal(lf.Source, current)
 	var modified string
-	if !bytes.Equal(lf.Source, current) {
+	if bytesChanged && !f.DryRun {
 		out := lf.FullSource(current)
 		if err := atomicWriteFile(path, out, info.Mode()); err != nil {
 			errs = append(errs, fmt.Errorf("writing %q: %w", path, err))
-			return beforeDiags, beforeDiags, "", errs
+			return beforeDiags, beforeDiags, "", nil, errs
 		}
 		modified = path
 	}
@@ -183,7 +228,50 @@ func (f *Fixer) fixFile(path string) ([]lint.Diagnostic, []lint.Diagnostic, stri
 	if f.Explain {
 		explain.Attach(diags, f.Config, path, fmKinds, fmFields)
 	}
-	return beforeDiags, diags, modified, errs
+	var wouldFix *WouldFixFile
+	if f.DryRun {
+		wouldFix = computeWouldFix(path, beforeDiags, diags, bytesChanged)
+	}
+	return beforeDiags, diags, modified, wouldFix, errs
+}
+
+// computeWouldFix diffs pre-fix and post-fix diagnostics by RuleID
+// and returns a preview entry for the file. Returns nil when no
+// diagnostic counts decreased and bytes did not change, so callers
+// can skip clean files.
+func computeWouldFix(
+	path string, before, after []lint.Diagnostic, bytesChanged bool,
+) *WouldFixFile {
+	beforeCounts := countByRule(before)
+	afterCounts := countByRule(after)
+
+	var rules []RuleFixCount
+	total := 0
+	for ruleID, beforeCount := range beforeCounts {
+		fixed := beforeCount - afterCounts[ruleID]
+		if fixed > 0 {
+			rules = append(rules, RuleFixCount{RuleID: ruleID, Count: fixed})
+			total += fixed
+		}
+	}
+	if total == 0 && !bytesChanged {
+		return nil
+	}
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].RuleID < rules[j].RuleID
+	})
+	return &WouldFixFile{Path: path, Count: total, Rules: rules}
+}
+
+func countByRule(diags []lint.Diagnostic) map[string]int {
+	if len(diags) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(diags))
+	for _, d := range diags {
+		out[d.RuleID]++
+	}
+	return out
 }
 
 // hydrateLintFile copies onto a freshly-parsed *lint.File the parse-

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -134,28 +134,33 @@ type RuleFixCount struct {
 func (f *Fixer) Fix(paths []string) *Result {
 	res := &Result{}
 
-	// Aggregate `before` diagnostics across files so the Failures
-	// count can be deduped after the loop. Repo-level rules
-	// (notably MDS048 git-hook-sync) anchor a single warning to a
-	// repository artifact for every linted file in the repo, so
-	// raw len(beforeDiags) summed per file would inflate Failures
-	// to N when only one underlying issue exists.
-	var allBefore []lint.Diagnostic
+	// Aggregate `before` and `after` diagnostics across files so the
+	// Failures count and (on dry-run) the WouldFix accounting can be
+	// deduped after the loop. Repo-level rules (notably MDS048
+	// git-hook-sync) anchor a single warning to a repository
+	// artifact for every linted file in the repo; raw per-file
+	// sums would inflate Failures and WouldFix to N when only one
+	// underlying issue exists.
+	var allBefore, allAfter []lint.Diagnostic
+	var bytesChangedByPath map[string]bool
+	if f.DryRun {
+		bytesChangedByPath = make(map[string]bool)
+	}
 	for _, path := range paths {
 		if config.IsIgnored(f.Config.Ignore, path) {
 			continue
 		}
 		res.FilesChecked++
 		f.log().Printf("file: %s", path)
-		beforeDiags, remainingDiags, modified, wouldFix, errs := f.fixFile(path)
+		beforeDiags, remainingDiags, modified, bytesChanged, errs := f.fixFile(path)
 		allBefore = append(allBefore, beforeDiags...)
+		allAfter = append(allAfter, remainingDiags...)
 		res.Diagnostics = append(res.Diagnostics, remainingDiags...)
 		if modified != "" {
 			res.Modified = append(res.Modified, modified)
 		}
-		if wouldFix != nil {
-			res.WouldFixFiles = append(res.WouldFixFiles, *wouldFix)
-			res.WouldFix += wouldFix.Count
+		if f.DryRun && bytesChanged {
+			bytesChangedByPath[path] = true
 		}
 		res.Errors = append(res.Errors, errs...)
 	}
@@ -173,30 +178,36 @@ func (f *Fixer) Fix(paths []string) *Result {
 		return di.Column < dj.Column
 	})
 
+	if f.DryRun {
+		res.WouldFixFiles, res.WouldFix = computeWouldFixAggregated(
+			allBefore, allAfter, bytesChangedByPath,
+		)
+	}
+
 	return res
 }
 
 // fixFile applies auto-fixes to a single file and returns diagnostics before
-// fixing, remaining diagnostics after fixing, the path if modified, an
-// optional dry-run preview, and any errors encountered.
+// fixing, remaining diagnostics after fixing, the path if modified, whether
+// the in-memory bytes changed (true even on dry-run), and any errors.
 func (f *Fixer) fixFile(path string) (
-	[]lint.Diagnostic, []lint.Diagnostic, string, *WouldFixFile, []error,
+	[]lint.Diagnostic, []lint.Diagnostic, string, bool, []error,
 ) {
 	var errs []error
 
 	source, err := lint.ReadFileLimited(path, f.MaxInputBytes)
 	if err != nil {
-		return nil, nil, "", nil, []error{fmt.Errorf("reading %q: %w", path, err)}
+		return nil, nil, "", false, []error{fmt.Errorf("reading %q: %w", path, err)}
 	}
 
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, nil, "", nil, []error{fmt.Errorf("stat %q: %w", path, err)}
+		return nil, nil, "", false, []error{fmt.Errorf("stat %q: %w", path, err)}
 	}
 
 	lf, dirFS, fmKinds, fmFields, prepErr := f.prepareFile(path, source)
 	if prepErr != nil {
-		return nil, nil, "", nil, []error{prepErr}
+		return nil, nil, "", false, []error{prepErr}
 	}
 
 	effective := f.effectiveWithCategories(path, fmKinds, fmFields)
@@ -216,7 +227,7 @@ func (f *Fixer) fixFile(path string) (
 		out := lf.FullSource(current)
 		if err := writeFile(path, out, info.Mode()); err != nil {
 			errs = append(errs, fmt.Errorf("writing %q: %w", path, err))
-			return beforeDiags, beforeDiags, "", nil, errs
+			return beforeDiags, beforeDiags, "", bytesChanged, errs
 		}
 		modified = path
 	}
@@ -228,11 +239,64 @@ func (f *Fixer) fixFile(path string) (
 	if f.Explain {
 		explain.Attach(diags, f.Config, path, fmKinds, fmFields)
 	}
-	var wouldFix *WouldFixFile
-	if f.DryRun {
-		wouldFix = computeWouldFix(path, beforeDiags, diags, bytesChanged)
+	return beforeDiags, diags, modified, bytesChanged, errs
+}
+
+// computeWouldFixAggregated dedupes pre-fix and post-fix diagnostics
+// across the whole run, groups them by diagnostic.File, and emits one
+// preview entry per affected file. Files in bytesChangedByPath (host
+// markdown files whose bytes would change without any diagnostic-count
+// decrease, e.g. directive regeneration) also receive a preview entry
+// so dry-run still surfaces them. Dedupe keeps repo-scoped rules
+// (notably MDS048 anchoring to .gitattributes) from inflating the
+// WouldFix total by the number of files in the repo.
+func computeWouldFixAggregated(
+	allBefore, allAfter []lint.Diagnostic,
+	bytesChangedByPath map[string]bool,
+) ([]WouldFixFile, int) {
+	beforeByFile := groupDiagsByFile(engine.DedupeDiagnostics(allBefore))
+	afterByFile := groupDiagsByFile(engine.DedupeDiagnostics(allAfter))
+
+	files := make(map[string]struct{}, len(beforeByFile)+len(bytesChangedByPath))
+	for path := range beforeByFile {
+		files[path] = struct{}{}
 	}
-	return beforeDiags, diags, modified, wouldFix, errs
+	for path := range afterByFile {
+		files[path] = struct{}{}
+	}
+	for path := range bytesChangedByPath {
+		files[path] = struct{}{}
+	}
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	result := make([]WouldFixFile, 0, len(paths))
+	total := 0
+	for _, p := range paths {
+		wf := computeWouldFix(p, beforeByFile[p], afterByFile[p], bytesChangedByPath[p])
+		if wf == nil {
+			continue
+		}
+		result = append(result, *wf)
+		total += wf.Count
+	}
+	return result, total
+}
+
+// groupDiagsByFile buckets diagnostics by their File field so per-file
+// fix counts can be computed from the deduped global diagnostic set.
+func groupDiagsByFile(diags []lint.Diagnostic) map[string][]lint.Diagnostic {
+	if len(diags) == 0 {
+		return nil
+	}
+	out := make(map[string][]lint.Diagnostic)
+	for _, d := range diags {
+		out[d.File] = append(out[d.File], d)
+	}
+	return out
 }
 
 // computeWouldFix diffs pre-fix and post-fix diagnostics by RuleID
@@ -372,6 +436,7 @@ func (f *Fixer) prepareFile(path string, source []byte) (*lint.File, fs.FS, []st
 		return nil, nil, nil, nil, fmt.Errorf("parsing %q: %w", path, err)
 	}
 	lf.MaxInputBytes = f.MaxInputBytes
+	lf.DryRun = f.DryRun
 	dir := filepath.Dir(path)
 	var dirFS fs.FS
 	if f.SourceFS != nil {

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -49,6 +49,12 @@ type Fixer struct {
 	// absolute path.
 	SourceFS fs.FS
 
+	// WriteFile, when non-nil, replaces atomicWriteFile for the
+	// final on-disk write step. Tests inject an error-returning
+	// function to exercise write-failure branches without OS-level
+	// read-only tricks. Production callers leave it nil.
+	WriteFile func(path string, data []byte, perm os.FileMode) error
+
 	// gitignoreCache caches GitignoreMatchers by directory so the
 	// matcher tree is walked once per directory across a fix run,
 	// matching the engine.Runner cache contract that catalog and
@@ -225,7 +231,11 @@ func (f *Fixer) fixFile(path string) (
 	var modified string
 	if bytesChanged && !f.DryRun {
 		out := lf.FullSource(current)
-		if err := writeFile(path, out, info.Mode()); err != nil {
+		writeFn := f.WriteFile
+		if writeFn == nil {
+			writeFn = atomicWriteFile
+		}
+		if err := writeFn(path, out, info.Mode()); err != nil {
 			errs = append(errs, fmt.Errorf("writing %q: %w", path, err))
 			return beforeDiags, beforeDiags, "", bytesChanged, errs
 		}
@@ -236,10 +246,62 @@ func (f *Fixer) fixFile(path string) (
 
 	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
+	if f.DryRun {
+		diags = subtractPredictedDryRunFixes(diags, fixable, finalFile)
+	}
 	if f.Explain {
 		explain.Attach(diags, f.Config, path, fmKinds, fmFields)
 	}
 	return beforeDiags, diags, modified, bytesChanged, errs
+}
+
+// subtractPredictedDryRunFixes removes from diags every diagnostic
+// that a DryRunPredictor among fixable would have cleared in a
+// real run. This restores dry-run exit-code parity with a real
+// `mdsmith fix` for side-effect-only fixers (e.g. MDS048
+// git-hook-sync) whose Fix returns the markdown source unchanged
+// but mutates a sibling file. Without this subtraction, the
+// post-fix Check would still report the drift and the dry-run
+// would exit non-zero where a real run would exit 0.
+func subtractPredictedDryRunFixes(
+	diags []lint.Diagnostic, fixable []rule.FixableRule, finalFile *lint.File,
+) []lint.Diagnostic {
+	predicted := make(map[diagKey]struct{})
+	for _, fr := range fixable {
+		p, ok := fr.(rule.DryRunPredictor)
+		if !ok {
+			continue
+		}
+		for _, d := range p.PredictDryRunFix(finalFile) {
+			predicted[keyOf(d)] = struct{}{}
+		}
+	}
+	if len(predicted) == 0 {
+		return diags
+	}
+	out := diags[:0]
+	for _, d := range diags {
+		if _, hit := predicted[keyOf(d)]; hit {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// diagKey is the dedupe identity of a diagnostic, matching
+// engine.DedupeDiagnostics' tuple so subtraction is consistent
+// with how repo-scoped diagnostics are merged elsewhere.
+type diagKey struct {
+	File    string
+	Line    int
+	Column  int
+	RuleID  string
+	Message string
+}
+
+func keyOf(d lint.Diagnostic) diagKey {
+	return diagKey{File: d.File, Line: d.Line, Column: d.Column, RuleID: d.RuleID, Message: d.Message}
 }
 
 // computeWouldFixAggregated dedupes pre-fix and post-fix diagnostics
@@ -502,10 +564,6 @@ func (f *Fixer) effectiveWithCategories(
 	}
 	return config.ApplyCategories(effective, categories, func(name string) string { return m[name] }, explicit)
 }
-
-// writeFile is the package-level write hook. Tests can swap it out to
-// inject a write error without needing a real read-only filesystem.
-var writeFile = atomicWriteFile
 
 // atomicWriteFile writes data to path using a temp-file-then-rename strategy
 // to reduce the risk of partial writes on crash. Directory fsync is omitted

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -214,7 +214,7 @@ func (f *Fixer) fixFile(path string) (
 	var modified string
 	if bytesChanged && !f.DryRun {
 		out := lf.FullSource(current)
-		if err := atomicWriteFile(path, out, info.Mode()); err != nil {
+		if err := writeFile(path, out, info.Mode()); err != nil {
 			errs = append(errs, fmt.Errorf("writing %q: %w", path, err))
 			return beforeDiags, beforeDiags, "", nil, errs
 		}
@@ -434,6 +434,10 @@ func (f *Fixer) effectiveWithCategories(
 	}
 	return config.ApplyCategories(effective, categories, func(name string) string { return m[name] }, explicit)
 }
+
+// writeFile is the package-level write hook. Tests can swap it out to
+// inject a write error without needing a real read-only filesystem.
+var writeFile = atomicWriteFile
 
 // atomicWriteFile writes data to path using a temp-file-then-rename strategy
 // to reduce the risk of partial writes on crash. Directory fsync is omitted

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -341,14 +341,16 @@ func countByRule(diags []lint.Diagnostic) map[string]int {
 // hydrateLintFile copies onto a freshly-parsed *lint.File the parse-
 // time and resolution context that the engine.Runner sets per-file
 // (see runner.go ~line 90-108): FS, RootFS/RootDir, FrontMatter,
-// LineOffset, StripFrontMatter, MaxInputBytes, GitignoreFunc, and
-// GeneratedRanges (recomputed for the parsed bytes). Used by both
+// LineOffset, StripFrontMatter, MaxInputBytes, DryRun, GitignoreFunc,
+// and GeneratedRanges (recomputed for the parsed bytes). Used by both
 // the post-fix CheckRules call and the parsedFile inside each
 // applyFixPasses iteration so rules see the same File regardless of
 // which Fixer phase invokes them. Without this, fixable rules like
 // catalog (consults GetGitignore for glob filtering) and include
 // (consults MaxInputBytes for secondary reads) silently produce
-// different post-fix bytes than `mdsmith check` would have validated.
+// different post-fix bytes than `mdsmith check` would have validated,
+// and side-effect-only fixers (e.g. MDS048 checking DryRun) would see
+// DryRun=false on re-parsed files and ignore the contract.
 func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS) {
 	parsed.FS = dirFS
 	parsed.RootFS = lf.RootFS
@@ -357,6 +359,7 @@ func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS) {
 	parsed.LineOffset = lf.LineOffset
 	parsed.StripFrontMatter = lf.StripFrontMatter
 	parsed.MaxInputBytes = lf.MaxInputBytes
+	parsed.DryRun = lf.DryRun
 	parsed.GitignoreFunc = lf.GitignoreFunc
 	parsed.GeneratedRanges = gensection.FindAllGeneratedRanges(parsed)
 }

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1026,3 +1026,128 @@ func TestFix_MaxPassesBoundary(t *testing.T) {
 	const maxPasses = 10
 	assert.Equal(t, string(initial)+strings.Repeat("X", maxPasses), string(got))
 }
+
+// --- dry-run ---
+
+func TestFix_DryRun_LeavesFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "test.md")
+	original := []byte("# Hello  \nworld  \n")
+	require.NoError(t, os.WriteFile(mdFile, original, 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-trailing": {Enabled: true},
+		},
+	}
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		DryRun: true,
+	}
+
+	result := fixer.Fix([]string{mdFile})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	// File on disk is byte-identical.
+	got, err := os.ReadFile(mdFile)
+	require.NoError(t, err)
+	assert.Equal(t, original, got, "dry-run must not modify the file")
+
+	// Nothing in Modified: nothing was written.
+	assert.Empty(t, result.Modified, "dry-run must not populate Modified")
+}
+
+func TestFix_DryRun_ReportsWouldFixCounts(t *testing.T) {
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "test.md")
+	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello  \nworld  \n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-trailing": {Enabled: true},
+		},
+	}
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		DryRun: true,
+	}
+
+	result := fixer.Fix([]string{mdFile})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	// Two trailing-spaces violations on two lines.
+	assert.Equal(t, 2, result.WouldFix, "expected 2 would-fix violations")
+	require.Len(t, result.WouldFixFiles, 1)
+	wf := result.WouldFixFiles[0]
+	assert.Equal(t, mdFile, wf.Path)
+	assert.Equal(t, 2, wf.Count)
+	require.Len(t, wf.Rules, 1)
+	assert.Equal(t, "MDS100", wf.Rules[0].RuleID)
+	assert.Equal(t, 2, wf.Rules[0].Count)
+}
+
+func TestFix_DryRun_MatchesRealFixCount(t *testing.T) {
+	// dry-run reports the same fix count a real run would apply.
+	dir := t.TempDir()
+	dryFile := filepath.Join(dir, "dry.md")
+	wetFile := filepath.Join(dir, "wet.md")
+	content := []byte("# Hello  \nworld  \nthird line  \n")
+	require.NoError(t, os.WriteFile(dryFile, content, 0o644))
+	require.NoError(t, os.WriteFile(wetFile, content, 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-trailing": {Enabled: true},
+		},
+	}
+
+	dryFixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		DryRun: true,
+	}
+	dryResult := dryFixer.Fix([]string{dryFile})
+
+	wetFixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+	}
+	wetResult := wetFixer.Fix([]string{wetFile})
+
+	assert.Equal(t, wetResult.Failures, dryResult.Failures,
+		"failure counts must match between dry-run and real run")
+	assert.Equal(t, wetResult.Failures, dryResult.WouldFix,
+		"would-fix count must equal the real-run pre-fix violation count")
+
+	// Real run modified the file; dry run did not.
+	require.Len(t, wetResult.Modified, 1)
+	require.Empty(t, dryResult.Modified)
+
+	dryContent, err := os.ReadFile(dryFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, dryContent, "dry-run must leave bytes identical")
+}
+
+func TestFix_DryRun_OmitsFilesWithNoFixes(t *testing.T) {
+	dir := t.TempDir()
+	cleanFile := filepath.Join(dir, "clean.md")
+	require.NoError(t, os.WriteFile(cleanFile, []byte("# Clean\n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-trailing": {Enabled: true},
+		},
+	}
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		DryRun: true,
+	}
+
+	result := fixer.Fix([]string{cleanFile})
+	require.Empty(t, result.Errors)
+	assert.Equal(t, 0, result.WouldFix)
+	assert.Empty(t, result.WouldFixFiles, "clean files must not appear in WouldFixFiles")
+}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -93,6 +93,35 @@ func (r *mockNonFixableRule) Check(f *lint.File) []lint.Diagnostic {
 	}
 }
 
+// mockSideEffectRule simulates MDS048: Check always returns a
+// drift diagnostic, Fix returns f.Source unchanged (no markdown
+// bytes change), and PredictDryRunFix returns the Check set so
+// the dry-run engine subtracts it from remaining diagnostics —
+// exit-code parity with a real run.
+type mockSideEffectRule struct {
+	id   string
+	name string
+}
+
+func (r *mockSideEffectRule) ID() string       { return r.id }
+func (r *mockSideEffectRule) Name() string     { return r.name }
+func (r *mockSideEffectRule) Category() string { return "test" }
+func (r *mockSideEffectRule) Check(f *lint.File) []lint.Diagnostic {
+	return []lint.Diagnostic{{
+		File: f.Path, Line: 1, Column: 1,
+		RuleID: r.id, RuleName: r.name,
+		Severity: lint.Warning,
+		Message:  "side-effect drift",
+	}}
+}
+func (r *mockSideEffectRule) Fix(f *lint.File) []byte                         { return f.Source }
+func (r *mockSideEffectRule) PredictDryRunFix(f *lint.File) []lint.Diagnostic { return r.Check(f) }
+
+var (
+	_ rule.FixableRule     = (*mockSideEffectRule)(nil)
+	_ rule.DryRunPredictor = (*mockSideEffectRule)(nil)
+)
+
 // mockFixableRuleB replaces tabs with spaces (second fixable rule for ordering tests).
 type mockFixableRuleB struct {
 	id   string
@@ -1132,14 +1161,7 @@ func TestFix_DryRun_MatchesRealFixCount(t *testing.T) {
 }
 
 func TestFix_WriteErrorPopulatesErrors(t *testing.T) {
-	// Inject a write failure via the package-level hook so the test
-	// works regardless of OS permissions (e.g. when running as root).
-	origWrite := writeFile
-	writeFile = func(_ string, _ []byte, _ os.FileMode) error {
-		return fmt.Errorf("injected write error")
-	}
-	defer func() { writeFile = origWrite }()
-
+	t.Parallel()
 	dir := t.TempDir()
 	mdFile := filepath.Join(dir, "fixable.md")
 	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello  \n"), 0o644))
@@ -1149,9 +1171,14 @@ func TestFix_WriteErrorPopulatesErrors(t *testing.T) {
 			"mock-trailing": {Enabled: true},
 		},
 	}
+	// Inject the write failure on this Fixer so the test stays
+	// isolated when other tests in the package run in parallel.
 	fixer := &Fixer{
 		Config: cfg,
 		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+		WriteFile: func(_ string, _ []byte, _ os.FileMode) error {
+			return fmt.Errorf("injected write error")
+		},
 	}
 
 	result := fixer.Fix([]string{mdFile})
@@ -1173,6 +1200,41 @@ func TestComputeWouldFix_SortsRulesByID(t *testing.T) {
 	require.Len(t, wf.Rules, 2)
 	assert.Equal(t, "MDS001", wf.Rules[0].RuleID, "rules must be sorted ascending by ID")
 	assert.Equal(t, "MDS010", wf.Rules[1].RuleID)
+}
+
+func TestFix_DryRun_PredictedDiagnosticsSubtracted(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "f.md")
+	require.NoError(t, os.WriteFile(mdFile, []byte("# Hi\n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"side-effect": {Enabled: true},
+		},
+	}
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockSideEffectRule{id: "MDS900", name: "side-effect"}},
+		DryRun: true,
+	}
+	result := fixer.Fix([]string{mdFile})
+
+	assert.Empty(t, result.Diagnostics,
+		"DryRunPredictor diagnostics must be subtracted from remaining set")
+	assert.Equal(t, 1, result.WouldFix,
+		"diff after subtraction must count the predicted fix")
+}
+
+func TestSubtractPredictedDryRunFixes_NoPredictorIsNoop(t *testing.T) {
+	t.Parallel()
+	// Non-DryRunPredictor fixable rule: subtract leaves diags untouched.
+	diags := []lint.Diagnostic{
+		{File: "f.md", Line: 1, Column: 1, RuleID: "MDS001", Message: "x"},
+	}
+	fixable := []rule.FixableRule{&mockFixableRule{id: "MDS001", name: "trim"}}
+	got := subtractPredictedDryRunFixes(diags, fixable, &lint.File{Path: "f.md"})
+	assert.Equal(t, diags, got)
 }
 
 func TestComputeWouldFixAggregated_DedupesByDiagnosticFile(t *testing.T) {

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -2,6 +2,7 @@ package fix
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1128,6 +1129,50 @@ func TestFix_DryRun_MatchesRealFixCount(t *testing.T) {
 	dryContent, err := os.ReadFile(dryFile)
 	require.NoError(t, err)
 	assert.Equal(t, content, dryContent, "dry-run must leave bytes identical")
+}
+
+func TestFix_WriteErrorPopulatesErrors(t *testing.T) {
+	// Inject a write failure via the package-level hook so the test
+	// works regardless of OS permissions (e.g. when running as root).
+	origWrite := writeFile
+	writeFile = func(_ string, _ []byte, _ os.FileMode) error {
+		return fmt.Errorf("injected write error")
+	}
+	defer func() { writeFile = origWrite }()
+
+	dir := t.TempDir()
+	mdFile := filepath.Join(dir, "fixable.md")
+	require.NoError(t, os.WriteFile(mdFile, []byte("# Hello  \n"), 0o644))
+
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"mock-trailing": {Enabled: true},
+		},
+	}
+	fixer := &Fixer{
+		Config: cfg,
+		Rules:  []rule.Rule{&mockFixableRule{id: "MDS100", name: "mock-trailing"}},
+	}
+
+	result := fixer.Fix([]string{mdFile})
+	require.Len(t, result.Errors, 1, "expected exactly one write error")
+	assert.Contains(t, result.Errors[0].Error(), "injected write error")
+}
+
+func TestComputeWouldFix_SortsRulesByID(t *testing.T) {
+	// Two rules fire; rules must come back sorted by ID regardless of map iteration
+	// order, which exercises the sort.Slice less function.
+	before := []lint.Diagnostic{
+		{File: "f.md", RuleID: "MDS010", RuleName: "rule-b"},
+		{File: "f.md", RuleID: "MDS001", RuleName: "rule-a"},
+	}
+	after := []lint.Diagnostic{} // both fixed
+	wf := computeWouldFix("f.md", before, after, true)
+	require.NotNil(t, wf)
+	assert.Equal(t, 2, wf.Count)
+	require.Len(t, wf.Rules, 2)
+	assert.Equal(t, "MDS001", wf.Rules[0].RuleID, "rules must be sorted ascending by ID")
+	assert.Equal(t, "MDS010", wf.Rules[1].RuleID)
 }
 
 func TestFix_DryRun_OmitsFilesWithNoFixes(t *testing.T) {

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1175,6 +1175,45 @@ func TestComputeWouldFix_SortsRulesByID(t *testing.T) {
 	assert.Equal(t, "MDS010", wf.Rules[1].RuleID)
 }
 
+func TestComputeWouldFixAggregated_DedupesByDiagnosticFile(t *testing.T) {
+	// Simulate a repo-scoped rule (e.g. MDS048) that fires once per
+	// linted markdown file but anchors its diagnostic to a shared
+	// repo artifact (.gitattributes). After dedupe, the WouldFix
+	// entry is keyed by the diagnostic's File, and the count is not
+	// inflated by the number of host markdown files.
+	hostA := "a.md"
+	hostB := "b.md"
+	target := ".gitattributes"
+	allBefore := []lint.Diagnostic{
+		{File: target, Line: 1, Column: 1, RuleID: "MDS048", RuleName: "git-hook-sync", Message: "drift"},
+		{File: target, Line: 1, Column: 1, RuleID: "MDS048", RuleName: "git-hook-sync", Message: "drift"},
+	}
+	allAfter := []lint.Diagnostic{} // fixed across the run
+	bytesChangedByPath := map[string]bool{hostA: true, hostB: false}
+
+	files, total := computeWouldFixAggregated(allBefore, allAfter, bytesChangedByPath)
+	require.Equal(t, 1, total, "deduped MDS048 must contribute exactly 1 to WouldFix")
+
+	// Files are sorted by path. .gitattributes < a.md alphabetically.
+	require.Len(t, files, 2)
+	assert.Equal(t, target, files[0].Path)
+	assert.Equal(t, 1, files[0].Count)
+	require.Len(t, files[0].Rules, 1)
+	assert.Equal(t, "MDS048", files[0].Rules[0].RuleID)
+
+	// a.md gets a "would update generated content" entry (Count=0, Rules empty).
+	assert.Equal(t, hostA, files[1].Path)
+	assert.Equal(t, 0, files[1].Count)
+	assert.Empty(t, files[1].Rules)
+}
+
+func TestComputeWouldFixAggregated_NoChanges(t *testing.T) {
+	// No before/after diff and no bytesChanged anywhere → no entries.
+	files, total := computeWouldFixAggregated(nil, nil, nil)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, files)
+}
+
 func TestFix_DryRun_OmitsFilesWithNoFixes(t *testing.T) {
 	dir := t.TempDir()
 	cleanFile := filepath.Join(dir, "clean.md")

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -32,6 +32,13 @@ type File struct {
 	// same coordinate system as the current file.
 	StripFrontMatter bool
 
+	// DryRun, when true, signals that the surrounding fix run must
+	// not touch the filesystem or the git index. Fixable rules whose
+	// Fix method has side effects beyond returning the new file
+	// bytes (e.g. writing a sibling repo file, staging via git)
+	// must check this flag and skip the side effect.
+	DryRun bool
+
 	// MaxInputBytes is the maximum file size in bytes that rules
 	// should enforce when reading secondary files (includes, schemas,
 	// cross-references). Zero or negative means unlimited.

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -16,6 +16,19 @@ type FixableRule interface {
 	Fix(f *lint.File) []byte
 }
 
+// DryRunPredictor is implemented by FixableRules whose Fix performs
+// side effects (e.g. writing a sibling file, staging a git index
+// entry) rather than rewriting the markdown source itself. During
+// `mdsmith fix --dry-run`, Fix returns the markdown unchanged to
+// honor the no-disk-writes contract, but the post-fix Check would
+// still observe the unfixed drift. PredictDryRunFix lets the rule
+// declare which diagnostics a real Fix would have cleared so the
+// fix engine subtracts them from the remaining-diagnostic set,
+// keeping the dry-run exit code matching a real run.
+type DryRunPredictor interface {
+	PredictDryRunFix(f *lint.File) []lint.Diagnostic
+}
+
 // Configurable is implemented by rules that have user-tunable settings.
 type Configurable interface {
 	ApplySettings(settings map[string]any) error

--- a/internal/rules/githooksync/rule.go
+++ b/internal/rules/githooksync/rule.go
@@ -332,6 +332,13 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return f.Source
 	}
 
+	// A dry-run must not touch .gitattributes or the git index.
+	// The diagnostic still fires from Check so the would-fix
+	// preview counts this rule, but the side effect is skipped.
+	if f.DryRun {
+		return f.Source
+	}
+
 	repoRoot, err := r.resolveRepoRoot(filepath.Dir(f.Path))
 	if err != nil {
 		return f.Source

--- a/internal/rules/githooksync/rule.go
+++ b/internal/rules/githooksync/rule.go
@@ -333,12 +333,9 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	}
 
 	// A dry-run must not touch .gitattributes or the git index.
-	// Trade-off: skipping the write means the post-fix Check still
-	// observes drift, so the diff-based would-fix preview will not
-	// count this rule even though a real run would fix it. A
-	// dedicated "would-fix" hook for side-effect-only fixers could
-	// close that gap; for now the contract (no disk/index writes)
-	// takes precedence over the preview count.
+	// The fix engine instead asks PredictDryRunFix below for the
+	// diagnostics a real run would have cleared, so the dry-run
+	// exit code still matches a real run.
 	if f.DryRun {
 		return f.Source
 	}
@@ -402,6 +399,16 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	// Return original file content unchanged (the fix is in
 	// .gitattributes, not in the markdown file being linted).
 	return f.Source
+}
+
+// PredictDryRunFix implements rule.DryRunPredictor. A real-run Fix
+// would write .gitattributes and stage it, clearing every drift and
+// stale-staging diagnostic Check currently reports. Re-running Check
+// on the same file returns exactly that set, so the fix engine can
+// subtract those diagnostics from the dry-run remaining set without
+// performing the underlying side effect.
+func (r *Rule) PredictDryRunFix(f *lint.File) []lint.Diagnostic {
+	return r.Check(f)
 }
 
 // stage attempts to stage .gitattributes and records the outcome in
@@ -487,8 +494,9 @@ func (r *Rule) DefaultSettings() map[string]any {
 }
 
 var (
-	_ rule.Configurable = (*Rule)(nil)
-	_ rule.Defaultable  = (*Rule)(nil)
-	_ rule.FixableRule  = (*Rule)(nil)
-	_ rule.RepoScoped   = (*Rule)(nil)
+	_ rule.Configurable    = (*Rule)(nil)
+	_ rule.Defaultable     = (*Rule)(nil)
+	_ rule.FixableRule     = (*Rule)(nil)
+	_ rule.DryRunPredictor = (*Rule)(nil)
+	_ rule.RepoScoped      = (*Rule)(nil)
 )

--- a/internal/rules/githooksync/rule.go
+++ b/internal/rules/githooksync/rule.go
@@ -333,8 +333,12 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	}
 
 	// A dry-run must not touch .gitattributes or the git index.
-	// The diagnostic still fires from Check so the would-fix
-	// preview counts this rule, but the side effect is skipped.
+	// Trade-off: skipping the write means the post-fix Check still
+	// observes drift, so the diff-based would-fix preview will not
+	// count this rule even though a real run would fix it. A
+	// dedicated "would-fix" hook for side-effect-only fixers could
+	// close that gap; for now the contract (no disk/index writes)
+	// takes precedence over the preview count.
 	if f.DryRun {
 		return f.Source
 	}

--- a/internal/rules/githooksync/rule_test.go
+++ b/internal/rules/githooksync/rule_test.go
@@ -513,6 +513,35 @@ func TestRule_Fix_RegeneratesGitattributes(t *testing.T) {
 	assert.Equal(t, canonicalManagedBlock(), string(content))
 }
 
+func TestRule_Fix_DryRunSkipsGitattributesWrite(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithDriver(t, dir)
+
+	mdFile := filepath.Join(dir, "test.md")
+	require.NoError(t, os.WriteFile(mdFile, []byte("# Test\n"), 0o644))
+
+	attrPath := filepath.Join(dir, ".gitattributes")
+	initial := "# BEGIN mdsmith merge-driver\nold.md merge=mdsmith\n# END mdsmith merge-driver\n"
+	require.NoError(t, os.WriteFile(attrPath, []byte(initial), 0o644))
+
+	r := &Rule{}
+	f := &lint.File{
+		FS:            os.DirFS(dir),
+		Path:          mdFile,
+		Source:        []byte("# Test\n"),
+		MaxInputBytes: 10000,
+		DryRun:        true,
+	}
+
+	assert.Equal(t, f.Source, r.Fix(f),
+		"Fix returns the markdown source unchanged in dry-run too")
+
+	content, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+	assert.Equal(t, initial, string(content),
+		".gitattributes must be untouched during dry-run")
+}
+
 func TestRule_Fix_EncodesConfigIgnoreAsExcludes(t *testing.T) {
 	dir := t.TempDir()
 	initRepoWithDriver(t, dir)

--- a/plan/137_fix-dry-run.md
+++ b/plan/137_fix-dry-run.md
@@ -1,7 +1,7 @@
 ---
 id: 137
 title: "`mdsmith fix --dry-run`"
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Add `--dry-run` to `mdsmith fix` so agents and CI
@@ -115,23 +115,23 @@ unchanged. The new line in the summary
 
 ## Tasks
 
-1. Add `--dry-run` to the `fix` subcommand flag
+1. [x] Add `--dry-run` to the `fix` subcommand flag
    set in
    [`runFix` in `cmd/mdsmith/main.go`](../cmd/mdsmith/main.go).
-2. Gate the write step in the fix pipeline:
+2. [x] Gate the write step in the fix pipeline:
    build the fixed buffer as today, but on
    `--dry-run` skip the write and record the
    would-fix count per rule.
-3. Update the per-file output formatter to emit
+3. [x] Update the per-file output formatter to emit
    "would fix N violations" lines and the
    trailing `would-fix=N` summary stat.
-4. Extend the JSON output struct with
+4. [x] Extend the JSON output struct with
    `would_fix` and `rules` fields when
    `--dry-run` is set.
-5. Document the flag in
+5. [x] Document the flag in
    [`docs/reference/cli/fix.md`](../docs/reference/cli/fix.md)
    with one worked example.
-6. Tests:
+6. [x] Tests:
 
   - dry-run reports the same fix count a real
     run would apply (regression compares both),
@@ -143,24 +143,24 @@ unchanged. The new line in the summary
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith fix --dry-run` writes nothing to
+- [x] `mdsmith fix --dry-run` writes nothing to
       disk (regression test asserts every
       candidate file is byte-identical after
       the run).
-- [ ] The per-file output names each rule that
+- [x] The per-file output names each rule that
       would fire and how many times.
-- [ ] The summary line includes
+- [x] The summary line includes
       `would-fix=N`. The existing
       `checked=` / `fixed=` / `failures=` /
       `unfixed=` fields are present on the
       same line; `fixed=` reads `0` since
       nothing was written.
-- [ ] `--format json` exposes `would_fix` and
+- [x] `--format json` exposes `would_fix` and
       `rules` per file.
-- [ ] Exit code matches the real-run exit code
+- [x] Exit code matches the real-run exit code
       on identical input.
-- [ ] [`docs/reference/cli/fix.md`](../docs/reference/cli/fix.md)
+- [x] [`docs/reference/cli/fix.md`](../docs/reference/cli/fix.md)
       documents the flag with an example.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues.


### PR DESCRIPTION
## Summary

Implements [plan 137](plan/137_fix-dry-run.md): add `--dry-run` to
`mdsmith fix` so agents and CI scripts can preview which files
would change before any bytes touch disk.

- The fix pipeline still runs end-to-end (so the post-fix diagnostic set is computed against the in-memory fixed buffer), but `atomicWriteFile` is skipped when `--dry-run` is set.
- `fixpkg.Result` grows `WouldFix int` and `WouldFixFiles []WouldFixFile`, populated only on a dry run. The per-file entry lists each rule whose diagnostic count would decrease, with a count, sorted by rule ID.
- The text output prints one line per file:
  ```
  docs/api.md: would fix 3 violations (MDS001 ×2, MDS006)
  ```
  Files whose bytes would change without a diagnostic-count decrease (catalog/include regenerating) get a `would update generated content` line so a dry-run still surfaces directive output.
- The stats summary gains an additive `would-fix=N` field; `fixed=` stays literal-zero on dry runs so existing CI parsers see no surprise apply.
- `--format json` emits one record per file with `path`, `would_fix`, `rules`, and `diagnostics`. The diagnostics array keeps the same shape `check --format json` produces.
- Exit code matches what a real `fix` run would return on the same input (0 if every diagnostic is fixable, non-zero otherwise).

The branch name is leftover from the prior session task; this PR is plan 137.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `go tool golangci-lint run` — clean
- [x] `mdsmith check .` — clean
- [x] Manual smoke test: `mdsmith fix --dry-run` and `mdsmith fix --dry-run --format json` on a dirty file confirm bytes unchanged after both runs.

https://claude.ai/code/session_01UW7fzxeY9bMXfUSBSDqC5C

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW7fzxeY9bMXfUSBSDqC5C)_