### PR TITLE
Add Obsidian Flavored Markdown support (plan 168)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -94,7 +94,7 @@ footer: |
 | 165 | ✅     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                                       |
 | 166 | ✅     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                                            |
 | 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                                    |
-| 168 | 🔲     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                                             |
+| 168 | ✅     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                                             |
 | 169 | ✅     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)                       |
 | 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                                   |
 | 171 | ✅     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                                          |

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -21,22 +21,27 @@ import (
 
 // backlinkRecord is one incoming link to the queried target.
 //
-// Kind distinguishes a standard Markdown link ("link") from an
-// Obsidian-style wikilink ("wikilink"). JSON consumers can filter
-// on this field; the text formatter renders both shapes inline.
+// Kind is set to "wikilink" only when the record came from an
+// Obsidian-style `[[Page]]` link; for ordinary Markdown links Kind
+// stays empty and is omitted from JSON, so the historical
+// {source, line, text, target} shape every existing consumer reads
+// is preserved unchanged.
 //
 // Alias and Embed are only meaningful when Kind == "wikilink":
 //   - Alias is the `|alias` half of `[[Page|alias]]`, empty when
-//     the source had no alias. omitempty keeps standard-link
-//     records' JSON shape unchanged.
+//     the source had no alias.
 //   - Embed is true when the source used `![[...]]` rather than
 //     `[[...]]`.
+//
+// All three of Kind, Alias, and Embed are omitempty so a JSON
+// document of standard-link records is byte-for-byte the same as
+// before the wikilink fields were added.
 type backlinkRecord struct {
 	Source string `json:"source"`
 	Line   int    `json:"line"`
 	Text   string `json:"text"`
 	Target string `json:"target"`
-	Kind   string `json:"kind"`
+	Kind   string `json:"kind,omitempty"`
 	Alias  string `json:"alias,omitempty"`
 	Embed  bool   `json:"embed,omitempty"`
 }
@@ -327,7 +332,6 @@ func extractBacklinksFromSource(
 			Line:   link.Line + f.LineOffset,
 			Text:   link.Text,
 			Target: t.Raw,
-			Kind:   "link",
 		})
 	}
 	out = appendWikilinkBacklinks(out, f, srcRel, wantTarget, wantAnchorSlug)

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -20,11 +20,16 @@ import (
 )
 
 // backlinkRecord is one incoming link to the queried target.
+//
+// Kind distinguishes a standard Markdown link ("link") from an
+// Obsidian-style wikilink ("wikilink"). JSON consumers can filter
+// on this field; the text formatter renders both shapes inline.
 type backlinkRecord struct {
 	Source string `json:"source"`
 	Line   int    `json:"line"`
 	Text   string `json:"text"`
 	Target string `json:"target"`
+	Kind   string `json:"kind"`
 }
 
 // backlinksOptions bundles the parsed CLI flags for `backlinks`.
@@ -243,7 +248,7 @@ func collectBacklinks(
 			continue
 		}
 		rs, err := extractBacklinksFromSource(
-			src, srcRel, wantTarget, wantAnchorSlug,
+			src, srcRel, rootDir, wantTarget, wantAnchorSlug,
 			maxBytes, stripFrontMatter,
 		)
 		if err != nil {
@@ -266,7 +271,7 @@ func collectBacklinks(
 // that resolve to wantTarget. wantAnchorSlug is the already-slugified
 // anchor query, or "" to match any anchor.
 func extractBacklinksFromSource(
-	src, srcRel, wantTarget, wantAnchorSlug string,
+	src, srcRel, rootDir, wantTarget, wantAnchorSlug string,
 	maxBytes int64, stripFrontMatter bool,
 ) ([]backlinkRecord, error) {
 	data, err := lint.ReadFileLimited(src, maxBytes)
@@ -280,6 +285,14 @@ func extractBacklinksFromSource(
 	f, err := lint.NewFileFromSource(src, data, stripFrontMatter)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", srcRel, err)
+	}
+	// Wikilink resolution needs the workspace root: ResolveWikiLink
+	// walks the fs.FS to find candidates. Standard Markdown link
+	// resolution operates on the source-relative path and never reads
+	// f.RootFS, so this is a wikilink-only requirement.
+	if rootDir != "" {
+		f.RootDir = rootDir
+		f.RootFS = os.DirFS(rootDir)
 	}
 	var out []backlinkRecord
 	for _, link := range linkgraph.ExtractLinks(f) {
@@ -305,9 +318,64 @@ func extractBacklinksFromSource(
 			Line:   link.Line + f.LineOffset,
 			Text:   link.Text,
 			Target: t.Raw,
+			Kind:   "link",
 		})
 	}
+	out = appendWikilinkBacklinks(out, f, srcRel, wantTarget, wantAnchorSlug)
 	return out, nil
+}
+
+// appendWikilinkBacklinks scans f for Obsidian-style wikilinks whose
+// resolved workspace-relative target matches wantTarget. Resolution
+// uses the same shortest-path algorithm MDS027 applies, sandboxed to
+// the file's root. Wikilinks are extracted unconditionally — the
+// scan is cheap and the user querying backlinks already opted in by
+// running the command.
+func appendWikilinkBacklinks(
+	out []backlinkRecord,
+	f *lint.File,
+	srcRel, wantTarget, wantAnchorSlug string,
+) []backlinkRecord {
+	wikilinks := linkgraph.ExtractWikiLinks(f)
+	if len(wikilinks) == 0 {
+		return out
+	}
+	root := f.RootFS
+	if root == nil {
+		return out
+	}
+	for _, wl := range wikilinks {
+		resolved, ok := linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+		if !ok || resolved != wantTarget {
+			continue
+		}
+		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(wl.Anchor) != wantAnchorSlug {
+			continue
+		}
+		text := wl.Alias
+		if text == "" {
+			text = wl.Target
+		}
+		out = append(out, backlinkRecord{
+			Source: srcRel,
+			Line:   wl.Line + f.LineOffset,
+			Text:   text,
+			Target: wikilinkTargetString(wl),
+			Kind:   "wikilink",
+		})
+	}
+	return out
+}
+
+// wikilinkTargetString renders just the target+anchor of wl as it
+// appeared in the source — the destination half a Markdown link's
+// Target field would carry. Alias and embed prefix are dropped so
+// the field reflects "where does this point", not "how does it look".
+func wikilinkTargetString(wl linkgraph.WikiLink) string {
+	if wl.Anchor == "" {
+		return wl.Target
+	}
+	return wl.Target + "#" + wl.Anchor
 }
 
 // workspaceRelativePath returns p relative to rootDir using forward
@@ -396,6 +464,22 @@ func sourceMatches(src string, includePatterns []string) bool {
 	return false
 }
 
+// formatBacklinkTextLine renders one record for the human text
+// format. Standard links use the `[text](target)` shape; wikilinks
+// use the source-form `[[target]]` (or `[[target|alias]]`,
+// `![[target]]` for embeds) so a user scanning output can see at a
+// glance which records came from each link kind.
+func formatBacklinkTextLine(r backlinkRecord) string {
+	if r.Kind == "wikilink" {
+		alias := ""
+		if r.Text != "" && r.Text != r.Target {
+			alias = "|" + r.Text
+		}
+		return fmt.Sprintf("%s:%d: [[%s%s]]", r.Source, r.Line, r.Target, alias)
+	}
+	return fmt.Sprintf("%s:%d: [%s](%s)", r.Source, r.Line, r.Text, r.Target)
+}
+
 // emitBacklinks writes records to w using format. limit caps the
 // output; 0 means no cap. Exit code: 0 when records were emitted,
 // 1 when none were found, 2 on write error.
@@ -419,7 +503,8 @@ func emitBacklinks(w io.Writer, records []backlinkRecord, format string, limit i
 		}
 	case "text", "":
 		for _, r := range records {
-			if _, err := fmt.Fprintf(w, "%s:%d: [%s](%s)\n", r.Source, r.Line, r.Text, r.Target); err != nil {
+			line := formatBacklinkTextLine(r)
+			if _, err := fmt.Fprintln(w, line); err != nil {
 				fmt.Fprintf(os.Stderr, "mdsmith: writing output: %v\n", err)
 				return 2
 			}

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -376,9 +376,15 @@ func appendWikilinkBacklinks(
 		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(wl.Anchor) != wantAnchorSlug {
 			continue
 		}
+		// Visible text mirrors what a reader would see: the alias
+		// when one is present; otherwise the target-as-written
+		// (target + "#anchor" if the source carried a fragment).
+		// Using wl.Target alone would drop the anchor portion from
+		// the JSON `text` field for `[[page#Section]]` and break
+		// downstream round-tripping.
 		text := wl.Alias
 		if text == "" {
-			text = wl.Target
+			text = wikilinkTargetString(wl)
 		}
 		out = append(out, backlinkRecord{
 			Source: srcRel,

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -308,10 +308,11 @@ func extractBacklinksFromSource(
 	// in records match what users see in editors. Mirror the config's
 	// frontMatter setting so backlinks stays aligned with MDS027 when
 	// stripping is turned off.
-	f, err := lint.NewFileFromSource(src, data, stripFrontMatter)
-	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", srcRel, err)
-	}
+	//
+	// NewFileFromSource only errors when NewFile errors, and NewFile
+	// never errors — goldmark always returns an AST. The discard keeps
+	// the linter happy without preserving an unreachable branch.
+	f, _ := lint.NewFileFromSource(src, data, stripFrontMatter) //nolint:errcheck
 	// Wikilink resolution needs the workspace root: ResolveWikiLink
 	// walks the fs.FS to find candidates. Standard Markdown link
 	// resolution operates on the source-relative path and never reads

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -252,10 +252,14 @@ func collectBacklinks(
 
 	// Build the workspace wikilink index once per collectBacklinks
 	// call so a corpus with N source files × M distinct wikilink
-	// targets does one fs.WalkDir instead of N×M. Skipped when
-	// rootDir is empty (e.g. unit-test calls with files in the
-	// current directory) — extractBacklinksFromSource then falls
-	// back to per-call walks via ResolveWikiLink.
+	// targets does one fs.WalkDir instead of N×M.
+	//
+	// When rootDir is empty (e.g. unit-test calls with files in
+	// the current directory and no resolved workspace root),
+	// wikilink resolution is skipped entirely:
+	// extractBacklinksFromSource leaves f.RootFS unset, and
+	// appendWikilinkBacklinks returns early without producing
+	// any wikilink rows. Standard Markdown links still surface.
 	var index *linkgraph.WikilinkIndex
 	if rootDir != "" {
 		index = linkgraph.NewWikilinkIndex(os.DirFS(rootDir))

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -252,7 +252,9 @@ func collectBacklinks(
 
 	// Build the workspace wikilink index once per collectBacklinks
 	// call so a corpus with N source files × M distinct wikilink
-	// targets does one fs.WalkDir instead of N×M.
+	// targets does one fs.WalkDir instead of N×M. Both this
+	// command and MDS027 route through linkgraph.WikilinkIndexFor
+	// so the build/cache semantics live in one place.
 	//
 	// When rootDir is empty (e.g. unit-test calls with files in
 	// the current directory and no resolved workspace root),
@@ -262,7 +264,7 @@ func collectBacklinks(
 	// any wikilink rows. Standard Markdown links still surface.
 	var index *linkgraph.WikilinkIndex
 	if rootDir != "" {
-		index = linkgraph.NewWikilinkIndex(os.DirFS(rootDir))
+		index = linkgraph.WikilinkIndexFor(nil, "", os.DirFS(rootDir))
 	}
 
 	var records []backlinkRecord

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -250,6 +250,17 @@ func collectBacklinks(
 		wantAnchorSlug = linkgraph.NormalizeAnchor(wantAnchor)
 	}
 
+	// Build the workspace wikilink index once per collectBacklinks
+	// call so a corpus with N source files × M distinct wikilink
+	// targets does one fs.WalkDir instead of N×M. Skipped when
+	// rootDir is empty (e.g. unit-test calls with files in the
+	// current directory) — extractBacklinksFromSource then falls
+	// back to per-call walks via ResolveWikiLink.
+	var index *linkgraph.WikilinkIndex
+	if rootDir != "" {
+		index = linkgraph.NewWikilinkIndex(os.DirFS(rootDir))
+	}
+
 	var records []backlinkRecord
 	var errs []error
 	for _, src := range files {
@@ -263,7 +274,7 @@ func collectBacklinks(
 		}
 		rs, err := extractBacklinksFromSource(
 			src, srcRel, rootDir, wantTarget, wantAnchorSlug,
-			maxBytes, stripFrontMatter,
+			maxBytes, stripFrontMatter, index,
 		)
 		if err != nil {
 			errs = append(errs, err)
@@ -287,6 +298,7 @@ func collectBacklinks(
 func extractBacklinksFromSource(
 	src, srcRel, rootDir, wantTarget, wantAnchorSlug string,
 	maxBytes int64, stripFrontMatter bool,
+	index *linkgraph.WikilinkIndex,
 ) ([]backlinkRecord, error) {
 	data, err := lint.ReadFileLimited(src, maxBytes)
 	if err != nil {
@@ -334,7 +346,7 @@ func extractBacklinksFromSource(
 			Target: t.Raw,
 		})
 	}
-	out = appendWikilinkBacklinks(out, f, srcRel, wantTarget, wantAnchorSlug)
+	out = appendWikilinkBacklinks(out, f, srcRel, wantTarget, wantAnchorSlug, index)
 	return out, nil
 }
 
@@ -343,20 +355,23 @@ func extractBacklinksFromSource(
 // uses the same shortest-path algorithm MDS027 applies, sandboxed to
 // the file's root. Wikilinks are extracted unconditionally — the
 // scan is cheap and the user querying backlinks already opted in by
-// running the command. Resolution results are cached per (target)
-// across one file's wikilinks so a doc with N references to the same
-// page does N=1 fs walks.
+// running the command.
+//
+// When a prebuilt index is supplied, every wikilink resolves via
+// O(1) map lookups; otherwise resolution falls back to per-call
+// fs.WalkDir, memoized per target within this file.
 func appendWikilinkBacklinks(
 	out []backlinkRecord,
 	f *lint.File,
 	srcRel, wantTarget, wantAnchorSlug string,
+	index *linkgraph.WikilinkIndex,
 ) []backlinkRecord {
 	wikilinks := linkgraph.ExtractWikiLinks(f)
 	if len(wikilinks) == 0 {
 		return out
 	}
 	root := f.RootFS
-	if root == nil {
+	if root == nil && index == nil {
 		return out
 	}
 	type resolveResult struct {
@@ -367,7 +382,11 @@ func appendWikilinkBacklinks(
 	for _, wl := range wikilinks {
 		r, cached := cache[wl.Target]
 		if !cached {
-			r.path, r.ok = linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+			if index != nil {
+				r.path, r.ok = index.Resolve(wl.Target)
+			} else {
+				r.path, r.ok = linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+			}
 			cache[wl.Target] = r
 		}
 		if !r.ok || r.path != wantTarget {

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -24,12 +24,21 @@ import (
 // Kind distinguishes a standard Markdown link ("link") from an
 // Obsidian-style wikilink ("wikilink"). JSON consumers can filter
 // on this field; the text formatter renders both shapes inline.
+//
+// Alias and Embed are only meaningful when Kind == "wikilink":
+//   - Alias is the `|alias` half of `[[Page|alias]]`, empty when
+//     the source had no alias. omitempty keeps standard-link
+//     records' JSON shape unchanged.
+//   - Embed is true when the source used `![[...]]` rather than
+//     `[[...]]`.
 type backlinkRecord struct {
 	Source string `json:"source"`
 	Line   int    `json:"line"`
 	Text   string `json:"text"`
 	Target string `json:"target"`
 	Kind   string `json:"kind"`
+	Alias  string `json:"alias,omitempty"`
+	Embed  bool   `json:"embed,omitempty"`
 }
 
 // backlinksOptions bundles the parsed CLI flags for `backlinks`.
@@ -330,7 +339,9 @@ func extractBacklinksFromSource(
 // uses the same shortest-path algorithm MDS027 applies, sandboxed to
 // the file's root. Wikilinks are extracted unconditionally — the
 // scan is cheap and the user querying backlinks already opted in by
-// running the command.
+// running the command. Resolution results are cached per (target)
+// across one file's wikilinks so a doc with N references to the same
+// page does N=1 fs walks.
 func appendWikilinkBacklinks(
 	out []backlinkRecord,
 	f *lint.File,
@@ -344,9 +355,18 @@ func appendWikilinkBacklinks(
 	if root == nil {
 		return out
 	}
+	type resolveResult struct {
+		path string
+		ok   bool
+	}
+	cache := map[string]resolveResult{}
 	for _, wl := range wikilinks {
-		resolved, ok := linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
-		if !ok || resolved != wantTarget {
+		r, cached := cache[wl.Target]
+		if !cached {
+			r.path, r.ok = linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+			cache[wl.Target] = r
+		}
+		if !r.ok || r.path != wantTarget {
 			continue
 		}
 		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(wl.Anchor) != wantAnchorSlug {
@@ -362,6 +382,8 @@ func appendWikilinkBacklinks(
 			Text:   text,
 			Target: wikilinkTargetString(wl),
 			Kind:   "wikilink",
+			Alias:  wl.Alias,
+			Embed:  wl.Embed,
 		})
 	}
 	return out
@@ -468,14 +490,21 @@ func sourceMatches(src string, includePatterns []string) bool {
 // format. Standard links use the `[text](target)` shape; wikilinks
 // use the source-form `[[target]]` (or `[[target|alias]]`,
 // `![[target]]` for embeds) so a user scanning output can see at a
-// glance which records came from each link kind.
+// glance which records came from each link kind. The alias half is
+// emitted only when the source itself carried one — the heuristic
+// "Text != Target means alias" would misclassify `[[page#Section]]`
+// because Target ("page#Section") differs from Text ("page").
 func formatBacklinkTextLine(r backlinkRecord) string {
 	if r.Kind == "wikilink" {
-		alias := ""
-		if r.Text != "" && r.Text != r.Target {
-			alias = "|" + r.Text
+		prefix := ""
+		if r.Embed {
+			prefix = "!"
 		}
-		return fmt.Sprintf("%s:%d: [[%s%s]]", r.Source, r.Line, r.Target, alias)
+		alias := ""
+		if r.Alias != "" {
+			alias = "|" + r.Alias
+		}
+		return fmt.Sprintf("%s:%d: %s[[%s%s]]", r.Source, r.Line, prefix, r.Target, alias)
 	}
 	return fmt.Sprintf("%s:%d: [%s](%s)", r.Source, r.Line, r.Text, r.Target)
 }

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -364,6 +364,33 @@ func TestCollectBacklinks_Wikilinks(t *testing.T) {
 	})
 }
 
+func TestAppendWikilinkBacklinks_NoRootFS(t *testing.T) {
+	// extractBacklinksFromSource leaves f.RootFS nil whenever
+	// rootDir == "" — appendWikilinkBacklinks then has no workspace
+	// to walk and must return the input slice untouched.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"),
+		[]byte("# S\n\n[[page]]\n"), 0o644))
+	files := []string{filepath.Join(root, "src.md")}
+	got, errs := collectBacklinks(files, "", "page.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	assert.Empty(t, got)
+}
+
+func TestAppendWikilinkBacklinks_UnrelatedTargetSkipped(t *testing.T) {
+	// A wikilink that resolves to a different file than wantTarget
+	// exercises the `r.path != wantTarget` continue branch.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "other.md"),
+		[]byte("# Other\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"),
+		[]byte("# S\n\n[[other]]\n"), 0o644))
+	files := []string{filepath.Join(root, "src.md")}
+	got, errs := collectBacklinks(files, root, "page.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	assert.Empty(t, got)
+}
+
 func TestFormatBacklinkTextLine_Wikilink(t *testing.T) {
 	bare := backlinkRecord{
 		Source: "from.md", Line: 4, Text: "page", Target: "page", Kind: "wikilink",

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -418,7 +418,7 @@ func TestFormatBacklinkTextLine_Wikilink(t *testing.T) {
 	assert.Equal(t, "from.md:4: ![[img.png]]", formatBacklinkTextLine(embed))
 
 	std := backlinkRecord{
-		Source: "from.md", Line: 1, Text: "ref", Target: "x.md", Kind: "link",
+		Source: "from.md", Line: 1, Text: "ref", Target: "x.md",
 	}
 	assert.Equal(t, "from.md:1: [ref](x.md)", formatBacklinkTextLine(std))
 }

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -361,6 +361,11 @@ func TestCollectBacklinks_Wikilinks(t *testing.T) {
 		assert.Equal(t, "anchored.md", got[0].Source)
 		assert.Equal(t, "wikilink", got[0].Kind)
 		assert.Equal(t, "page#Section", got[0].Target)
+		// `text` is the visible link text — for anchor-only wikilinks
+		// the full target-as-written, not the bare stem. Setting
+		// Text=wl.Target alone would drop the `#Section` half and
+		// break JSON round-tripping.
+		assert.Equal(t, "page#Section", got[0].Text)
 	})
 }
 

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -330,3 +330,53 @@ func TestEmitBacklinks_JSONWriteError(t *testing.T) {
 	code := emitBacklinks(failingWriter{}, []backlinkRecord{{Source: "a.md", Line: 1}}, "json", 0)
 	assert.Equal(t, 2, code)
 }
+
+func TestCollectBacklinks_Wikilinks(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "page.md"), []byte("# Page\n\n## Section\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "other.md"),
+		[]byte("# Other\n\nSee [[page]] and [[page|alias]].\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "anchored.md"),
+		[]byte("# Anchored\n\n[[page#Section]]\n"), 0o644))
+	files := []string{
+		filepath.Join(root, "anchored.md"),
+		filepath.Join(root, "other.md"),
+		filepath.Join(root, "page.md"),
+	}
+
+	t.Run("matches both wikilink shapes", func(t *testing.T) {
+		got, errs := collectBacklinks(files, root, "page.md", "", nil, nil, 0, true)
+		require.Empty(t, errs)
+		// Expect three wikilink hits — two on other.md, one on anchored.md.
+		require.Len(t, got, 3)
+		for _, r := range got {
+			assert.Equal(t, "wikilink", r.Kind, "all wikilink hits must carry kind=wikilink")
+		}
+	})
+
+	t.Run("anchor scoping", func(t *testing.T) {
+		got, errs := collectBacklinks(files, root, "page.md", "section", nil, nil, 0, true)
+		require.Empty(t, errs)
+		require.Len(t, got, 1)
+		assert.Equal(t, "anchored.md", got[0].Source)
+		assert.Equal(t, "wikilink", got[0].Kind)
+		assert.Equal(t, "page#Section", got[0].Target)
+	})
+}
+
+func TestFormatBacklinkTextLine_Wikilink(t *testing.T) {
+	bare := backlinkRecord{
+		Source: "from.md", Line: 4, Text: "page", Target: "page", Kind: "wikilink",
+	}
+	assert.Equal(t, "from.md:4: [[page]]", formatBacklinkTextLine(bare))
+
+	alias := backlinkRecord{
+		Source: "from.md", Line: 4, Text: "Display", Target: "page", Kind: "wikilink",
+	}
+	assert.Equal(t, "from.md:4: [[page|Display]]", formatBacklinkTextLine(alias))
+
+	std := backlinkRecord{
+		Source: "from.md", Line: 1, Text: "ref", Target: "x.md", Kind: "link",
+	}
+	assert.Equal(t, "from.md:1: [ref](x.md)", formatBacklinkTextLine(std))
+}

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -371,9 +371,24 @@ func TestFormatBacklinkTextLine_Wikilink(t *testing.T) {
 	assert.Equal(t, "from.md:4: [[page]]", formatBacklinkTextLine(bare))
 
 	alias := backlinkRecord{
-		Source: "from.md", Line: 4, Text: "Display", Target: "page", Kind: "wikilink",
+		Source: "from.md", Line: 4, Text: "Display", Target: "page",
+		Kind: "wikilink", Alias: "Display",
 	}
 	assert.Equal(t, "from.md:4: [[page|Display]]", formatBacklinkTextLine(alias))
+
+	anchorNoAlias := backlinkRecord{
+		Source: "from.md", Line: 4, Text: "page",
+		Target: "page#Section", Kind: "wikilink",
+	}
+	// Anchor-only refs must not be rewritten as `|page` aliases; the
+	// alias half is empty so the format emits only the target.
+	assert.Equal(t, "from.md:4: [[page#Section]]", formatBacklinkTextLine(anchorNoAlias))
+
+	embed := backlinkRecord{
+		Source: "from.md", Line: 4, Text: "img.png",
+		Target: "img.png", Kind: "wikilink", Embed: true,
+	}
+	assert.Equal(t, "from.md:4: ![[img.png]]", formatBacklinkTextLine(embed))
 
 	std := backlinkRecord{
 		Source: "from.md", Line: 1, Text: "ref", Target: "x.md", Kind: "link",

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/lint"
 )
 
 func TestResolveLinkTarget(t *testing.T) {
@@ -367,6 +369,29 @@ func TestCollectBacklinks_Wikilinks(t *testing.T) {
 		// break JSON round-tripping.
 		assert.Equal(t, "page#Section", got[0].Text)
 	})
+}
+
+func TestAppendWikilinkBacklinks_FallbackToPerCallWalk(t *testing.T) {
+	// The collectBacklinks public path always pairs index with
+	// RootFS; calling appendWikilinkBacklinks directly with a nil
+	// index but a populated RootFS exercises the per-call
+	// fs.WalkDir fallback, which would otherwise rot if the
+	// helper API ever gets reused without the index.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "page.md"), []byte("# P\n"), 0o644))
+	srcPath := filepath.Join(root, "src.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte("# S\n\n[[page]]\n"), 0o644))
+	data, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	f, err := lint.NewFileFromSource(srcPath, data, true)
+	require.NoError(t, err)
+	f.RootFS = os.DirFS(root)
+	got := appendWikilinkBacklinks(nil, f, "src.md", "page.md", "", nil)
+	require.Len(t, got, 1)
+	// Target on a wikilink record is the source-form `[[target]]`,
+	// not the resolved filename; resolution matches "page" against
+	// "page.md" but the record carries the bare stem.
+	assert.Equal(t, "page", got[0].Target)
 }
 
 func TestAppendWikilinkBacklinks_NoRootFS(t *testing.T) {

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -218,17 +218,23 @@ the same `.md` files.
 |--------------------|-----------------------------------|--------------------------------------|
 | Purpose            | Note-taking editor                | Linter / fixer                       |
 | Linting            | Community plugin only             | Built-in, CI-ready                   |
-| Wikilinks          | Native (`[[Page]]`)               | Treated as text; no validation       |
-| Callouts           | Native (`> [!note]`)              | Treated as blockquotes               |
+| Wikilinks          | Native (`[[Page]]`)               | Validated by [MDS027][mds027]        |
+| Callouts           | Native (`> [!note]`)              | Validated by [MDS067][mds067]        |
 | Front matter       | YAML or Dataview inline (`key::`) | YAML only (inline not recognized)    |
 | Agent friendliness | Editor-centric, manual saves      | Direct file access, no editor needed |
 
-mdsmith can lint the Markdown subset that Obsidian and
-standard parsers share. Wikilinks and callouts pass
-through without errors (they look like valid Markdown
-to CommonMark parsers). Dataview inline fields are not
-front matter and will not be read by mdsmith's
-`require`/`schema` directives.
+Pin `convention: obsidian` (see the
+[conventions reference][conventions]) to enable both
+checks with one config line.
+
+The wikilink check resolves `[[Page]]` against every
+workspace file by stem. Matching is case-insensitive
+with a shortest-path tie-break.
+
+The callout check accepts the 13 base Obsidian types
+and their aliases out of the box. Dataview inline
+fields (`key:: value`) are still not front matter.
+The `require`/`schema` directives do not read them.
 
 ### [mdbase][]
 
@@ -823,6 +829,7 @@ you need a stable rule set while these land.
 [mds024]: ../../internal/rules/MDS024-paragraph-structure/README.md
 [mds025]: ../../internal/rules/MDS025-table-format/README.md
 [mds027]: ../../internal/rules/MDS027-cross-file-reference-integrity/README.md
+[mds067]: ../../internal/rules/MDS067-callout-type/README.md
 [mds028]: ../../internal/rules/MDS028-token-budget/README.md
 [mds029]: ../../internal/rules/MDS029-conciseness-scoring/README.md
 [mds030]: ../../internal/rules/MDS030-empty-section-body/README.md

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -231,7 +231,7 @@ The wikilink check resolves `[[Page]]` against every
 workspace file by stem. Matching is case-insensitive
 with a shortest-path tie-break.
 
-The callout check accepts the 13 base Obsidian types
+The callout check accepts the 12 base Obsidian types
 and their aliases out of the box. Dataview inline
 fields (`key:: value`) are still not front matter.
 The `require`/`schema` directives do not read them.

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -71,11 +71,31 @@ then line, so `--limit` paginates deterministically.
     "line": 8,
     "text": "api",
     "target": "../docs/api.md"
+  },
+  {
+    "source": "vault/notes.md",
+    "line": 3,
+    "text": "API reference",
+    "target": "api",
+    "kind": "wikilink",
+    "alias": "API reference"
   }
 ]
 ```
 
-Keys are stable. Empty results emit `[]`, not `null`.
+Four base keys are always present. They are `source`,
+`line`, `text`, and `target`. Three more appear only
+on Obsidian-style wikilink records:
+
+| Key     | Type   | Set when                                            |
+|---------|--------|-----------------------------------------------------|
+| `kind`  | string | `"wikilink"`; standard links omit the key entirely. |
+| `alias` | string | Source carried a `\|alias` half; otherwise omitted. |
+| `embed` | bool   | `true` for `![[…]]` embeds; otherwise omitted.      |
+
+Existing consumers that read only the four base keys
+see the same shape as before. Empty results emit
+`[]`, not `null`.
 
 ## Examples
 
@@ -100,11 +120,18 @@ mdsmith list backlinks --include "plan/**" --limit 10 docs/api.md
 ## Scope
 
 The command resolves the same direct Markdown links
-MDS027 sees. The graph covers `[text](path)` and
-`[text](path#anchor)`. Reference-style links
-(`[text][label]`), wiki-style links (`[[page]]`), and
-external URLs are out of scope. They would only join
-the result set once the matching parser support lands.
+MDS027 sees: `[text](path)` and `[text](path#anchor)`.
+
+It also resolves Obsidian-style wikilinks
+(`[[page]]`, `[[page#anchor]]`, `[[page|alias]]`,
+`![[file.png]]`) by walking the workspace for a
+shortest-path match. The wikilink rows carry
+`"kind": "wikilink"` in JSON output. Text output
+renders them as `[[target]]` (or `[[target|alias]]`,
+`![[target]]`).
+
+Reference-style links (`[text][label]`) and external
+URLs are still out of scope.
 
 ## Exit codes
 

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -39,8 +39,8 @@ config key, sibling to `rules:`, `kinds:`, and
 `overrides:`. Setting an unknown name is a config
 error at load time.
 
-Built-in values: `portable`, `github`, `plain`. The
-key is optional; omit it for no convention.
+Built-in values: `portable`, `github`, `obsidian`,
+`plain`. The key is optional; omit it for no convention.
 
 You may also set `flavor:` inside `markdown-flavor`
 alongside `convention:`. If both are set, they must
@@ -82,6 +82,24 @@ rules stay off.
 | `no-inline-html`    | `allow: [details, summary]`            |
 | `emphasis-style`    | `bold: asterisk`, `italic: underscore` |
 | `list-marker-style` | `style: dash`                          |
+
+### `obsidian`
+
+Markdown written in an Obsidian vault. Selects
+`flavor: gfm` and turns on the Obsidian-specific
+validations — MDS027 resolves `[[Page]]` wikilink
+targets workspace-wide, and MDS067 checks every
+`[!type]` callout against the Obsidian type set.
+
+| Rule                             | Setting                                       |
+|----------------------------------|-----------------------------------------------|
+| `markdown-flavor`                | `flavor: gfm`                                 |
+| `cross-file-reference-integrity` | `wikilinks: true`, `wikilink-style: obsidian` |
+| `callout-type`                   | enabled (12 base Obsidian types and aliases)  |
+
+Standard style rules stay at their defaults so an
+Obsidian vault behaves like a GFM project unless the
+team layers more rules on top.
 
 ### `plain`
 

--- a/internal/convention/convention.go
+++ b/internal/convention/convention.go
@@ -113,6 +113,24 @@ var conventions = map[string]Convention{
 			},
 		},
 	},
+	"obsidian": {
+		Name:   "obsidian",
+		Flavor: FlavorGFM,
+		Rules: map[string]RulePreset{
+			"markdown-flavor": {
+				Enabled:  true,
+				Settings: map[string]any{"flavor": "gfm"},
+			},
+			"cross-file-reference-integrity": {
+				Enabled: true,
+				Settings: map[string]any{
+					"wikilinks":      true,
+					"wikilink-style": "obsidian",
+				},
+			},
+			"callout-type": {Enabled: true},
+		},
+	},
 	"plain": {
 		Name:   "plain",
 		Flavor: FlavorCommonMark,

--- a/internal/convention/convention_test.go
+++ b/internal/convention/convention_test.go
@@ -60,6 +60,24 @@ func TestLookup_Unknown(t *testing.T) {
 	assert.Contains(t, err.Error(), "github")
 	assert.Contains(t, err.Error(), "plain")
 	assert.Contains(t, err.Error(), "portable")
+	assert.Contains(t, err.Error(), "obsidian")
+}
+
+func TestLookup_Obsidian(t *testing.T) {
+	c, err := Lookup("obsidian", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "obsidian", c.Name)
+	assert.Equal(t, FlavorGFM, c.Flavor)
+
+	xref, ok := c.Rules["cross-file-reference-integrity"]
+	require.True(t, ok)
+	assert.True(t, xref.Enabled)
+	assert.Equal(t, true, xref.Settings["wikilinks"])
+	assert.Equal(t, "obsidian", xref.Settings["wikilink-style"])
+
+	co, ok := c.Rules["callout-type"]
+	require.True(t, ok)
+	assert.True(t, co.Enabled)
 }
 
 func TestCloneValue_TypedSlices(t *testing.T) {
@@ -181,5 +199,5 @@ func TestNamesSorted(t *testing.T) {
 	names := Names()
 	assert.True(t, sort.StringsAreSorted(names),
 		"Names should return a sorted slice; got %v", names)
-	assert.ElementsMatch(t, []string{"github", "plain", "portable"}, names)
+	assert.ElementsMatch(t, []string{"github", "obsidian", "plain", "portable"}, names)
 }

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/blanklinearoundlists"
 	_ "github.com/jeduden/mdsmith/internal/rules/blockquotewhitespace"
 	_ "github.com/jeduden/mdsmith/internal/rules/build"
+	_ "github.com/jeduden/mdsmith/internal/rules/callouttype"
 	_ "github.com/jeduden/mdsmith/internal/rules/catalog"
 	_ "github.com/jeduden/mdsmith/internal/rules/concisenessscoring"
 	_ "github.com/jeduden/mdsmith/internal/rules/crossfilereferenceintegrity"

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -172,6 +172,12 @@ func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
 	if target == "" {
 		return "", false
 	}
+	// Reject Windows-style absolute forms (drive-letter, UNC) before
+	// path.Clean — those would otherwise pass the POSIX guards below
+	// and be searched as workspace-relative names on POSIX hosts.
+	if isDriveOrUNC(target) {
+		return "", false
+	}
 	cleaned := path.Clean(path.Clean(filepath.ToSlash(target)))
 	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
 		return "", false

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -1,0 +1,244 @@
+package linkgraph
+
+import (
+	"io/fs"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// WikiLink is one parsed Obsidian-style wikilink occurrence.
+//
+// Target is the destination filename or stem (without alias or
+// anchor). Anchor and Alias are the optional fragment and display
+// label. Embed reports whether the source used `![[...]]` rather
+// than `[[...]]`.
+//
+// Line and Column are body-relative — same convention as Link.
+type WikiLink struct {
+	Target string
+	Anchor string
+	Alias  string
+	Embed  bool
+	Line   int
+	Column int
+}
+
+// wikilinkRE matches Obsidian-style wikilinks.
+// Group 1: leading "!" (embed marker)
+// Group 2: target stem or filename (no anchor or alias)
+// Group 3: optional anchor (text after "#")
+// Group 4: optional alias (text after "|")
+var wikilinkRE = regexp.MustCompile(
+	`(!?)\[\[([^\[\]\n|#]+)(?:#([^\[\]\n|]+))?(?:\|([^\[\]\n]+))?\]\]`,
+)
+
+// ExtractWikiLinks scans f.Source for Obsidian-style wikilinks
+// (`[[Page]]`, `[[Page#anchor]]`, `[[Page|alias]]`, `![[file.png]]`).
+// Matches inside fenced/indented code blocks, code spans, and
+// `<?...?>` processing-instruction blocks are skipped — the same
+// guards MDS054 applies to its bracket scanner.
+//
+// Lines are body-relative (post front-matter strip).
+func ExtractWikiLinks(f *lint.File) []WikiLink {
+	if f == nil || len(f.Source) == 0 {
+		return nil
+	}
+	codeLines := lint.CollectCodeBlockLines(f)
+	piLines := lint.CollectPIBlockLines(f)
+	codeSpans := collectCodeSpanRanges(f)
+
+	source := f.Source
+	var out []WikiLink
+	for _, m := range wikilinkRE.FindAllSubmatchIndex(source, -1) {
+		start := m[0]
+		line := f.LineOfOffset(start)
+		if codeLines[line] || piLines[line] {
+			continue
+		}
+		if inCodeSpan(codeSpans, start) {
+			continue
+		}
+		embed := m[3] > m[2]
+		bracketStart := m[0]
+		if embed {
+			bracketStart++
+		}
+		col := f.ColumnOfOffset(bracketStart)
+		wl := WikiLink{
+			Target: strings.TrimSpace(string(source[m[4]:m[5]])),
+			Embed:  embed,
+			Line:   line,
+			Column: col,
+		}
+		if m[6] >= 0 {
+			wl.Anchor = strings.TrimSpace(string(source[m[6]:m[7]]))
+		}
+		if m[8] >= 0 {
+			wl.Alias = strings.TrimSpace(string(source[m[8]:m[9]]))
+		}
+		out = append(out, wl)
+	}
+	return out
+}
+
+// byteRange is a half-open [start, end) byte range.
+type byteRange struct{ start, end int }
+
+func collectCodeSpanRanges(f *lint.File) []byteRange {
+	var out []byteRange
+	source := f.Source
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if _, ok := n.(*ast.CodeSpan); !ok {
+			return ast.WalkContinue, nil
+		}
+		first, last := codeSpanTextBounds(n)
+		if first < 0 {
+			return ast.WalkContinue, nil
+		}
+		start := first
+		for start > 0 && source[start-1] == '`' {
+			start--
+		}
+		end := last
+		for end < len(source) && source[end] == '`' {
+			end++
+		}
+		out = append(out, byteRange{start, end})
+		return ast.WalkContinue, nil
+	})
+	return out
+}
+
+func codeSpanTextBounds(n ast.Node) (first, last int) {
+	first = -1
+	last = -1
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		t, ok := c.(*ast.Text)
+		if !ok {
+			continue
+		}
+		if first < 0 {
+			first = t.Segment.Start
+		}
+		last = t.Segment.Stop
+	}
+	return first, last
+}
+
+func inCodeSpan(spans []byteRange, offset int) bool {
+	for _, r := range spans {
+		if offset >= r.start && offset < r.end {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveWikiLink resolves an Obsidian-style wikilink target against
+// root, returning the workspace-relative path of the resolved file.
+//
+// Resolution rules:
+//
+//   - When target has no extension or ends in `.md`/`.markdown`, the
+//     search matches files whose stem (filename minus extension)
+//     equals target, case-insensitive. The target itself is also
+//     considered a stem when it lacks an extension.
+//   - When target has any other extension (an embed like `image.png`),
+//     the search matches files by exact filename, case-insensitive.
+//   - Ties are broken by the shortest path (fewest separators); then
+//     alphabetically. Two matches at the same depth never both win.
+//   - The walk is sandboxed to root: paths that would escape via `..`
+//     are rejected before the walk starts.
+//
+// from is the workspace-relative path of the source file. It is
+// reserved for future per-directory resolution preference; today it
+// only blocks empty targets the same way `ParseTarget` does for
+// regular links.
+func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
+	if root == nil || target == "" {
+		return "", false
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", false
+	}
+	if strings.Contains(target, "..") {
+		return "", false
+	}
+	cleaned := path.Clean(target)
+	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
+		return "", false
+	}
+
+	wantName, wantStem, stemMode := wikilinkSearchKey(target)
+	_ = from
+
+	var matches []string
+	walkErr := fs.WalkDir(root, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		base := path.Base(p)
+		if stemMode {
+			stem := strings.TrimSuffix(base, path.Ext(base))
+			if strings.EqualFold(stem, wantStem) && isMarkdownName(base) {
+				matches = append(matches, p)
+			}
+			return nil
+		}
+		if strings.EqualFold(base, wantName) {
+			matches = append(matches, p)
+		}
+		return nil
+	})
+	if walkErr != nil || len(matches) == 0 {
+		return "", false
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		di := strings.Count(matches[i], "/")
+		dj := strings.Count(matches[j], "/")
+		if di != dj {
+			return di < dj
+		}
+		return matches[i] < matches[j]
+	})
+	return matches[0], true
+}
+
+// wikilinkSearchKey splits target into the lookup parameters
+// ResolveWikiLink walks the FS with.
+//
+// stemMode true means "match by filename stem against .md/.markdown
+// files only" — the bare-page case (`[[Notes]]` or
+// `[[Notes.md]]`). stemMode false means "match by exact filename"
+// — the typed-extension case (`![[diagram.png]]`).
+func wikilinkSearchKey(target string) (wantName, wantStem string, stemMode bool) {
+	target = filepath.ToSlash(target)
+	base := path.Base(target)
+	ext := strings.ToLower(path.Ext(base))
+	switch ext {
+	case "", ".md", ".markdown":
+		stem := strings.TrimSuffix(base, path.Ext(base))
+		return "", stem, true
+	default:
+		return base, "", false
+	}
+}
+
+func isMarkdownName(name string) bool {
+	ext := strings.ToLower(path.Ext(name))
+	return ext == ".md" || ext == ".markdown"
+}

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -3,7 +3,6 @@ package linkgraph
 import (
 	"io/fs"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -45,9 +44,12 @@ var wikilinkRE = regexp.MustCompile(
 // `<?...?>` processing-instruction blocks are skipped — the same
 // guards MDS054 applies to its bracket scanner.
 //
-// Lines are body-relative (post front-matter strip).
+// Lines are body-relative (post front-matter strip). Returns nil
+// for files without a parsed AST (struct-literal *lint.File
+// instances): the code-block / code-span guards below walk the
+// tree, so a missing AST would otherwise panic.
 func ExtractWikiLinks(f *lint.File) []WikiLink {
-	if f == nil || len(f.Source) == 0 {
+	if f == nil || len(f.Source) == 0 || f.AST == nil {
 		return nil
 	}
 	codeLines := lint.CollectCodeBlockLines(f)
@@ -178,7 +180,13 @@ func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
 	if isDriveOrUNC(target) {
 		return "", false
 	}
-	cleaned := path.Clean(path.Clean(filepath.ToSlash(target)))
+	// Normalize backslashes manually: filepath.ToSlash is OS-dependent
+	// (no-op on POSIX), so a Windows-authored `[[sub\page]]` would
+	// otherwise stay as a single literal segment on Linux CI and
+	// never resolve. Match the strings.ReplaceAll pattern
+	// ResolveRelTarget uses for the same reason.
+	target = strings.ReplaceAll(target, `\`, `/`)
+	cleaned := path.Clean(target)
 	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
 		return "", false
 	}
@@ -236,7 +244,10 @@ func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
 // `[[Notes.md]]`). stemMode false means "match by exact filename"
 // — the typed-extension case (`![[diagram.png]]`).
 func wikilinkSearchKey(target string) (wantName, wantStem string, stemMode bool) {
-	target = filepath.ToSlash(target)
+	// Match the host-independent normalisation ResolveWikiLink uses
+	// up front so a Windows-authored `[[sub\page]]` reaches this
+	// helper as `sub/page`.
+	target = strings.ReplaceAll(target, `\`, `/`)
 	base := path.Base(target)
 	ext := strings.ToLower(path.Ext(base))
 	switch ext {

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -146,6 +146,26 @@ func inCodeSpan(spans []byteRange, offset int) bool {
 	return false
 }
 
+// WikilinkIndexFor returns a *WikilinkIndex for root, memoized on
+// cache under rootKey when cache is non-nil. With cache=nil the
+// helper falls through to a direct NewWikilinkIndex call —
+// callers without a long-lived cache (one-shot CLI commands)
+// still share the same API.
+//
+// This is the canonical entry point both MDS027 and
+// `mdsmith list backlinks` route through; rewriting it once
+// keeps the workspace walk semantics in one place.
+func WikilinkIndexFor(cache *lint.RunCache, rootKey string, root fs.FS) *WikilinkIndex {
+	if cache == nil || rootKey == "" {
+		return NewWikilinkIndex(root)
+	}
+	v := cache.Wikilinks(rootKey, func() any {
+		return NewWikilinkIndex(root)
+	})
+	idx, _ := v.(*WikilinkIndex)
+	return idx
+}
+
 // WikilinkIndex is a pre-built directory of every file under one
 // workspace root, keyed for the two lookup shapes ResolveWikiLink
 // uses: stem (.md/.markdown filename minus extension) and exact

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -164,7 +164,11 @@ type WikilinkIndex struct {
 
 // NewWikilinkIndex walks root once and returns a lookup table that
 // future ResolveWikiLink-style queries can serve from memory.
-// Returns nil when root is nil.
+// Returns nil when root is nil or the workspace walk itself fails
+// (e.g. Open(".") on root returns an error). A nil return lets the
+// caller fall back to per-call walks via ResolveWikiLink rather
+// than serving an empty index that would silently report every
+// target as "not found".
 func NewWikilinkIndex(root fs.FS) *WikilinkIndex {
 	if root == nil {
 		return nil
@@ -173,8 +177,20 @@ func NewWikilinkIndex(root fs.FS) *WikilinkIndex {
 		stems: map[string][]string{},
 		names: map[string][]string{},
 	}
-	_ = fs.WalkDir(root, ".", func(p string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+	if err := fs.WalkDir(root, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Root-level read failures (e.g. ReadDir(".") returns an
+			// error) mean the index would otherwise be silently empty.
+			// Propagate so NewWikilinkIndex can return nil and the
+			// resolver falls back to per-call walks. Sub-tree failures
+			// stay local — one rejected directory should not poison
+			// resolution against unrelated sibling subtrees.
+			if p == "." {
+				return err
+			}
+			return nil
+		}
+		if d.IsDir() {
 			return nil
 		}
 		base := path.Base(p)
@@ -186,7 +202,9 @@ func NewWikilinkIndex(root fs.FS) *WikilinkIndex {
 			idx.stems[lcStem] = append(idx.stems[lcStem], p)
 		}
 		return nil
-	})
+	}); err != nil {
+		return nil
+	}
 	for k, v := range idx.stems {
 		sortByDepthThenName(v)
 		idx.stems[k] = v

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -211,7 +211,7 @@ func NewWikilinkIndex(root fs.FS) *WikilinkIndex {
 			return nil
 		}
 		if d.IsDir() {
-			return nil
+			return skipHeavyDirs(p)
 		}
 		base := path.Base(p)
 		lcName := strings.ToLower(base)
@@ -265,6 +265,23 @@ func (idx *WikilinkIndex) Resolve(target string) (string, bool) {
 		return matches[0], true
 	}
 	return "", false
+}
+
+// skipHeavyDirs returns fs.SkipDir for known-heavy subtrees that
+// never carry wikilink targets users want resolved (`.git`,
+// `node_modules`). Used as a fs.WalkDirFunc verdict for directory
+// entries — file entries pass through unchanged. Mirrors the
+// pattern walkDirDecision uses in duplicatedcontent so the same
+// names stay pruned across every rule that walks the workspace.
+func skipHeavyDirs(p string) error {
+	if p == "." {
+		return nil
+	}
+	switch path.Base(p) {
+	case ".git", "node_modules":
+		return fs.SkipDir
+	}
+	return nil
 }
 
 func sortByDepthThenName(paths []string) {
@@ -339,7 +356,7 @@ func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
 			return nil
 		}
 		if d.IsDir() {
-			return nil
+			return skipHeavyDirs(p)
 		}
 		base := path.Base(p)
 		if stemMode {

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -146,6 +146,100 @@ func inCodeSpan(spans []byteRange, offset int) bool {
 	return false
 }
 
+// WikilinkIndex is a pre-built directory of every file under one
+// workspace root, keyed for the two lookup shapes ResolveWikiLink
+// uses: stem (.md/.markdown filename minus extension) and exact
+// filename. Each key holds the matching paths in shortest-then-
+// alphabetical order, the same order ResolveWikiLink would
+// otherwise sort on every call.
+//
+// Build the index once per (run, root) — e.g. via
+// `lint.RunCache.Wikilinks` — and call Resolve for each wikilink
+// target. Lookups are then O(stems + matches) instead of O(files
+// in workspace) per target.
+type WikilinkIndex struct {
+	stems map[string][]string // lowercased stem → sorted .md paths
+	names map[string][]string // lowercased filename → sorted any-ext paths
+}
+
+// NewWikilinkIndex walks root once and returns a lookup table that
+// future ResolveWikiLink-style queries can serve from memory.
+// Returns nil when root is nil.
+func NewWikilinkIndex(root fs.FS) *WikilinkIndex {
+	if root == nil {
+		return nil
+	}
+	idx := &WikilinkIndex{
+		stems: map[string][]string{},
+		names: map[string][]string{},
+	}
+	_ = fs.WalkDir(root, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		base := path.Base(p)
+		lcName := strings.ToLower(base)
+		idx.names[lcName] = append(idx.names[lcName], p)
+		if isMarkdownName(base) {
+			stem := strings.TrimSuffix(base, path.Ext(base))
+			lcStem := strings.ToLower(stem)
+			idx.stems[lcStem] = append(idx.stems[lcStem], p)
+		}
+		return nil
+	})
+	for k, v := range idx.stems {
+		sortByDepthThenName(v)
+		idx.stems[k] = v
+	}
+	for k, v := range idx.names {
+		sortByDepthThenName(v)
+		idx.names[k] = v
+	}
+	return idx
+}
+
+// Resolve answers the same question as ResolveWikiLink but serves
+// it from the prebuilt index — no filesystem walk per call.
+func (idx *WikilinkIndex) Resolve(target string) (string, bool) {
+	if idx == nil || target == "" {
+		return "", false
+	}
+	target = strings.TrimSpace(target)
+	if target == "" || isDriveOrUNC(target) {
+		return "", false
+	}
+	target = strings.ReplaceAll(target, `\`, `/`)
+	cleaned := path.Clean(target)
+	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
+		return "", false
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", false
+	}
+	wantName, wantStem, stemMode := wikilinkSearchKey(target)
+	if stemMode {
+		if matches, ok := idx.stems[strings.ToLower(wantStem)]; ok && len(matches) > 0 {
+			return matches[0], true
+		}
+		return "", false
+	}
+	if matches, ok := idx.names[strings.ToLower(wantName)]; ok && len(matches) > 0 {
+		return matches[0], true
+	}
+	return "", false
+}
+
+func sortByDepthThenName(paths []string) {
+	sort.Slice(paths, func(i, j int) bool {
+		di := strings.Count(paths[i], "/")
+		dj := strings.Count(paths[j], "/")
+		if di != dj {
+			return di < dj
+		}
+		return paths[i] < paths[j]
+	})
+}
+
 // ResolveWikiLink resolves an Obsidian-style wikilink target against
 // root, returning the workspace-relative path of the resolved file.
 //

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -172,11 +172,15 @@ func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
 	if target == "" {
 		return "", false
 	}
-	if strings.Contains(target, "..") {
+	cleaned := path.Clean(path.Clean(filepath.ToSlash(target)))
+	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
 		return "", false
 	}
-	cleaned := path.Clean(target)
-	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
+	// path.Clean reduces "../x" to "../x", "../../x" to "../../x", and
+	// "a/../b" to "b" — so the only escape forms left after Clean are a
+	// leading ".." segment or the bare "..". A name like "v1..v2" never
+	// produces either; this rejects only real parent-directory traversal.
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return "", false
 	}
 

--- a/internal/linkgraph/wikilinks_bench_test.go
+++ b/internal/linkgraph/wikilinks_bench_test.go
@@ -1,0 +1,62 @@
+package linkgraph
+
+import (
+	"fmt"
+	"testing"
+	"testing/fstest"
+)
+
+// buildBenchFS returns a synthetic workspace of n .md files spread
+// across a depth-2 directory tree, with one matching target stem
+// `target`.
+func buildBenchFS(n int, target string) fstest.MapFS {
+	mfs := fstest.MapFS{}
+	for i := 0; i < n; i++ {
+		mfs[fmt.Sprintf("dir%d/sub/file%d.md", i%8, i)] = &fstest.MapFile{Data: []byte{}}
+	}
+	mfs["dir0/sub/"+target+".md"] = &fstest.MapFile{Data: []byte{}}
+	return mfs
+}
+
+// BenchmarkResolveWikiLink_PerCall measures the cost of one
+// ResolveWikiLink call against a 200-file workspace — the baseline
+// for the per-call walk path used when no run-wide index is cached.
+func BenchmarkResolveWikiLink_PerCall(b *testing.B) {
+	mfs := buildBenchFS(200, "page")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, ok := ResolveWikiLink(mfs, "from.md", "page"); !ok {
+			b.Fatal("expected page to resolve")
+		}
+	}
+}
+
+// BenchmarkWikilinkIndex_Resolve measures one lookup against a
+// prebuilt index of the same 200-file workspace — the steady-state
+// cost MDS027 and `mdsmith list backlinks` see once the per-run
+// cache is warm. Construction is outside the timer; the benchmark
+// reflects what every call after the first pays.
+func BenchmarkWikilinkIndex_Resolve(b *testing.B) {
+	mfs := buildBenchFS(200, "page")
+	idx := NewWikilinkIndex(mfs)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, ok := idx.Resolve("page"); !ok {
+			b.Fatal("expected page to resolve")
+		}
+	}
+}
+
+// BenchmarkNewWikilinkIndex measures one-time index construction:
+// the fs.WalkDir + sort that the per-run cache amortises across
+// every wikilink in every host file.
+func BenchmarkNewWikilinkIndex(b *testing.B) {
+	mfs := buildBenchFS(200, "page")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if NewWikilinkIndex(mfs) == nil {
+			b.Fatal("index nil")
+		}
+	}
+}

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -72,6 +72,17 @@ func TestExtractWikiLinks_SkipsCodeSpan(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestExtractWikiLinks_EmptyCodeSpan(t *testing.T) {
+	// Empty backticks (`` `` ``) parse as a CodeSpan with no Text
+	// children — codeSpanTextBounds returns first<0 and the range
+	// is dropped from the span list, so the extractor must not
+	// panic and must still find the wikilink that follows.
+	f := newFile(t, "A `` `` literal, then [[Page]].\n")
+	got := ExtractWikiLinks(f)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Page", got[0].Target)
+}
+
 func TestExtractWikiLinks_SkipsFencedCode(t *testing.T) {
 	src := "```\n[[InFence]]\n```\n"
 	f := newFile(t, src)
@@ -223,6 +234,48 @@ func TestResolveWikiLink_NilFS(t *testing.T) {
 	_, ok := ResolveWikiLink(nil, "from.md", "page")
 	assert.False(t, ok)
 }
+
+func TestResolveWikiLink_WalkDirCallbackError(t *testing.T) {
+	// fs.WalkDir invokes the callback with err != nil when ReadDir
+	// on a child directory fails. ResolveWikiLink must swallow the
+	// error and keep walking the rest of the tree. erroringFS
+	// rejects ReadDir("broken") while serving every other path
+	// normally; resolution finds page.md in the sibling subtree.
+	mfs := &erroringFS{
+		inner: fstest.MapFS{
+			"broken":        &fstest.MapFile{Mode: fs.ModeDir},
+			"other/page.md": &fstest.MapFile{Data: []byte{}},
+		},
+		failDir: "broken",
+	}
+	got, ok := ResolveWikiLink(mfs, "from.md", "page")
+	require.True(t, ok)
+	assert.Equal(t, "other/page.md", got)
+}
+
+// erroringFS rejects ReadDir on a specific subdirectory while
+// serving Open and other paths normally. fs.WalkDir then invokes
+// its callback with err != nil for the rejected directory — the
+// exact branch ResolveWikiLink swallows.
+type erroringFS struct {
+	inner   fs.FS
+	failDir string
+}
+
+func (e *erroringFS) Open(name string) (fs.File, error) {
+	return e.inner.Open(name)
+}
+
+func (e *erroringFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == e.failDir {
+		return nil, &fsErr{name: name}
+	}
+	return fs.ReadDir(e.inner, name)
+}
+
+type fsErr struct{ name string }
+
+func (e *fsErr) Error() string { return "synthetic read failure on " + e.name }
 
 func TestResolveWikiLink_OnDiskFS(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -1,0 +1,205 @@
+package linkgraph
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractWikiLinks_BarePage(t *testing.T) {
+	f := newFile(t, "# Doc\n\nSee [[Page]] for context.\n")
+	got := ExtractWikiLinks(f)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Page", got[0].Target)
+	assert.Empty(t, got[0].Anchor)
+	assert.Empty(t, got[0].Alias)
+	assert.False(t, got[0].Embed)
+	assert.Equal(t, 3, got[0].Line)
+	assert.Equal(t, 5, got[0].Column)
+}
+
+func TestExtractWikiLinks_AnchorAndAlias(t *testing.T) {
+	f := newFile(t, "Refer to [[Notes#Heading|the notes]].\n")
+	got := ExtractWikiLinks(f)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Notes", got[0].Target)
+	assert.Equal(t, "Heading", got[0].Anchor)
+	assert.Equal(t, "the notes", got[0].Alias)
+}
+
+func TestExtractWikiLinks_AliasOnly(t *testing.T) {
+	f := newFile(t, "See [[Page|Display]].\n")
+	got := ExtractWikiLinks(f)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Page", got[0].Target)
+	assert.Equal(t, "Display", got[0].Alias)
+	assert.Empty(t, got[0].Anchor)
+}
+
+func TestExtractWikiLinks_Embed(t *testing.T) {
+	f := newFile(t, "Inline ![[image.png]] embed.\n")
+	got := ExtractWikiLinks(f)
+	require.Len(t, got, 1)
+	assert.Equal(t, "image.png", got[0].Target)
+	assert.True(t, got[0].Embed)
+	// Column points at the leading '[', not the '!'.
+	assert.Equal(t, 9, got[0].Column)
+}
+
+func TestExtractWikiLinks_SkipsCodeSpan(t *testing.T) {
+	f := newFile(t, "Inline `[[NotALink]]` should be ignored.\n")
+	got := ExtractWikiLinks(f)
+	assert.Empty(t, got)
+}
+
+func TestExtractWikiLinks_SkipsFencedCode(t *testing.T) {
+	src := "```\n[[InFence]]\n```\n"
+	f := newFile(t, src)
+	got := ExtractWikiLinks(f)
+	assert.Empty(t, got)
+}
+
+func TestExtractWikiLinks_SkipsPIBlock(t *testing.T) {
+	// A wikilink on a directive marker line is skipped — every line
+	// goldmark reports inside the `<?...?>` block (open, body, close)
+	// counts as PI content, the same exclusion MDS054's scanner uses.
+	src := "<?some-directive\n[[InPI]]\n?>\n"
+	f := newFile(t, src)
+	got := ExtractWikiLinks(f)
+	assert.Empty(t, got)
+}
+
+func TestExtractWikiLinks_Multiple(t *testing.T) {
+	src := "See [[One]] and [[Two|x]] and [[Three#frag]].\n"
+	f := newFile(t, src)
+	got := ExtractWikiLinks(f)
+	require.Len(t, got, 3)
+	assert.Equal(t, "One", got[0].Target)
+	assert.Equal(t, "Two", got[1].Target)
+	assert.Equal(t, "Three", got[2].Target)
+	assert.Equal(t, "frag", got[2].Anchor)
+}
+
+func TestExtractWikiLinks_NoNewlinesInsideBrackets(t *testing.T) {
+	// A "wikilink" split across a newline is not a wikilink; the regex
+	// rejects internal newlines so this paragraph yields zero matches.
+	src := "See [[Page\nname]].\n"
+	f := newFile(t, src)
+	got := ExtractWikiLinks(f)
+	assert.Empty(t, got)
+}
+
+func TestResolveWikiLink_ExactStem(t *testing.T) {
+	mfs := fstest.MapFS{
+		"notes.md": &fstest.MapFile{Data: []byte("# Notes\n")},
+	}
+	path, ok := ResolveWikiLink(mfs, "from.md", "notes")
+	require.True(t, ok)
+	assert.Equal(t, "notes.md", path)
+}
+
+func TestResolveWikiLink_CaseInsensitive(t *testing.T) {
+	mfs := fstest.MapFS{
+		"Notes.md": &fstest.MapFile{Data: []byte("# Notes\n")},
+	}
+	path, ok := ResolveWikiLink(mfs, "from.md", "notes")
+	require.True(t, ok)
+	assert.Equal(t, "Notes.md", path)
+}
+
+func TestResolveWikiLink_ShortestPathWins(t *testing.T) {
+	mfs := fstest.MapFS{
+		"deep/sub/notes.md": &fstest.MapFile{Data: []byte{}},
+		"notes.md":          &fstest.MapFile{Data: []byte{}},
+		"other/notes.md":    &fstest.MapFile{Data: []byte{}},
+	}
+	path, ok := ResolveWikiLink(mfs, "from.md", "notes")
+	require.True(t, ok)
+	assert.Equal(t, "notes.md", path)
+}
+
+func TestResolveWikiLink_AlphabeticalTieBreak(t *testing.T) {
+	mfs := fstest.MapFS{
+		"a/notes.md": &fstest.MapFile{Data: []byte{}},
+		"b/notes.md": &fstest.MapFile{Data: []byte{}},
+	}
+	path, ok := ResolveWikiLink(mfs, "from.md", "notes")
+	require.True(t, ok)
+	assert.Equal(t, "a/notes.md", path)
+}
+
+func TestResolveWikiLink_NotFound(t *testing.T) {
+	mfs := fstest.MapFS{
+		"other.md": &fstest.MapFile{Data: []byte{}},
+	}
+	_, ok := ResolveWikiLink(mfs, "from.md", "missing")
+	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_EmbedExactName(t *testing.T) {
+	mfs := fstest.MapFS{
+		"assets/diagram.png": &fstest.MapFile{Data: []byte{}},
+		"diagram.md":         &fstest.MapFile{Data: []byte{}},
+	}
+	path, ok := ResolveWikiLink(mfs, "from.md", "diagram.png")
+	require.True(t, ok)
+	assert.Equal(t, "assets/diagram.png", path)
+}
+
+func TestResolveWikiLink_EmbedNotFound(t *testing.T) {
+	mfs := fstest.MapFS{
+		"other.png": &fstest.MapFile{Data: []byte{}},
+	}
+	_, ok := ResolveWikiLink(mfs, "from.md", "missing.png")
+	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_RejectsRootEscape(t *testing.T) {
+	mfs := fstest.MapFS{
+		"notes.md": &fstest.MapFile{Data: []byte{}},
+	}
+	_, ok := ResolveWikiLink(mfs, "from.md", "../etc/passwd")
+	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_RejectsAbsolutePath(t *testing.T) {
+	mfs := fstest.MapFS{
+		"notes.md": &fstest.MapFile{Data: []byte{}},
+	}
+	_, ok := ResolveWikiLink(mfs, "from.md", "/notes.md")
+	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_EmptyTarget(t *testing.T) {
+	mfs := fstest.MapFS{}
+	_, ok := ResolveWikiLink(mfs, "from.md", "")
+	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_NilFS(t *testing.T) {
+	_, ok := ResolveWikiLink(nil, "from.md", "page")
+	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_OnDiskFS(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "page.md"), []byte("#h\n"), 0o644))
+	root, err := openDirFS(dir)
+	require.NoError(t, err)
+	path, ok := ResolveWikiLink(root, "from.md", "page")
+	require.True(t, ok)
+	assert.Equal(t, "sub/page.md", path)
+}
+
+// openDirFS is a tiny wrapper so the helper above can return an error
+// alongside the FS, without leaking os.DirFS internals into the test
+// body.
+func openDirFS(dir string) (fs.FS, error) {
+	return os.DirFS(dir), nil
+}

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractWikiLinks_NilFileReturnsNil(t *testing.T) {
+	assert.Nil(t, ExtractWikiLinks(nil))
+}
+
+func TestExtractWikiLinks_EmptySource(t *testing.T) {
+	f := newFile(t, "")
+	assert.Nil(t, ExtractWikiLinks(f))
+}
+
+func TestResolveWikiLink_WhitespaceTarget(t *testing.T) {
+	mfs := fstest.MapFS{"page.md": &fstest.MapFile{Data: []byte{}}}
+	_, ok := ResolveWikiLink(mfs, "from.md", "   ")
+	assert.False(t, ok)
+}
+
 func TestExtractWikiLinks_BarePage(t *testing.T) {
 	f := newFile(t, "# Doc\n\nSee [[Page]] for context.\n")
 	got := ExtractWikiLinks(f)

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -224,6 +224,24 @@ func TestResolveWikiLink_RejectsAbsolutePath(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestResolveWikiLink_RejectsWindowsAbsoluteForms(t *testing.T) {
+	// On POSIX hosts a Windows drive-letter or UNC path would
+	// otherwise pass the leading-slash check and be searched as a
+	// workspace-relative stem. The drive/UNC guard matches the one
+	// linkgraph.ResolveRelTarget uses for the same reason.
+	mfs := fstest.MapFS{
+		"system.md": &fstest.MapFile{Data: []byte{}},
+	}
+	for _, target := range []string{
+		"C:/Windows/system.md",
+		"c:/Windows/system.md",
+		"//host/share/system.md",
+	} {
+		_, ok := ResolveWikiLink(mfs, "from.md", target)
+		assert.Falsef(t, ok, "Windows-absolute %q must be rejected", target)
+	}
+}
+
 func TestResolveWikiLink_EmptyTarget(t *testing.T) {
 	mfs := fstest.MapFS{}
 	_, ok := ResolveWikiLink(mfs, "from.md", "")

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,48 @@ func TestExtractWikiLinks_NilASTReturnsNilNoPanic(t *testing.T) {
 func TestNewWikilinkIndex_NilRoot(t *testing.T) {
 	assert.Nil(t, NewWikilinkIndex(nil))
 }
+
+func TestNewWikilinkIndex_RootWalkErrorReturnsNil(t *testing.T) {
+	// When fs.WalkDir cannot read the root (e.g. ReadDir(".")
+	// fails), NewWikilinkIndex returns nil so the resolver can
+	// fall back to per-call walks instead of an empty index that
+	// would silently report every target as "not found".
+	root := &rootFailFS{}
+	assert.Nil(t, NewWikilinkIndex(root))
+}
+
+// rootFailFS rejects the root ReadDir but accepts every other
+// call. fs.WalkDir starts with Stat(".") which goes through
+// Open(".") on the fallback path, then calls ReadDirFile on the
+// returned file. Returning a Stat-only file forces WalkDir to
+// fall back to ReadDir(".") on the fsys, which we reject.
+type rootFailFS struct{}
+
+func (rootFailFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return &rootStubDir{}, nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (rootFailFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return nil, fs.ErrPermission
+}
+
+type rootStubDir struct{}
+
+func (rootStubDir) Stat() (fs.FileInfo, error) { return rootStubInfo{}, nil }
+func (rootStubDir) Read([]byte) (int, error)   { return 0, fs.ErrInvalid }
+func (rootStubDir) Close() error               { return nil }
+
+type rootStubInfo struct{}
+
+func (rootStubInfo) Name() string       { return "." }
+func (rootStubInfo) Size() int64        { return 0 }
+func (rootStubInfo) Mode() fs.FileMode  { return fs.ModeDir }
+func (rootStubInfo) ModTime() time.Time { return time.Time{} }
+func (rootStubInfo) IsDir() bool        { return true }
+func (rootStubInfo) Sys() any           { return nil }
 
 func TestWikilinkIndex_ResolveSemantics(t *testing.T) {
 	// One index should serve every shape ResolveWikiLink supports:

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 )
@@ -346,6 +348,118 @@ func TestResolveWikiLink_WalkDirCallbackError(t *testing.T) {
 	got, ok := ResolveWikiLink(mfs, "from.md", "page")
 	require.True(t, ok)
 	assert.Equal(t, "other/page.md", got)
+}
+
+func TestWikilinkSearchKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		target   string
+		wantName string
+		wantStem string
+		stemMode bool
+	}{
+		{"no extension → stem mode", "Notes", "", "Notes", true},
+		{"md extension → stem mode", "Notes.md", "", "Notes", true},
+		{"markdown extension → stem mode", "Notes.markdown", "", "Notes", true},
+		{"PNG embed → exact name", "image.png", "image.png", "", false},
+		{"backslash normalised", `sub\page`, "", "page", true},
+		{"nested path → basename only", "deep/sub/page", "", "page", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, s, mode := wikilinkSearchKey(tc.target)
+			assert.Equal(t, tc.wantName, n, "wantName")
+			assert.Equal(t, tc.wantStem, s, "wantStem")
+			assert.Equal(t, tc.stemMode, mode, "stemMode")
+		})
+	}
+}
+
+func TestIsMarkdownName(t *testing.T) {
+	assert.True(t, isMarkdownName("page.md"))
+	assert.True(t, isMarkdownName("page.MD"))
+	assert.True(t, isMarkdownName("page.markdown"))
+	assert.False(t, isMarkdownName("page.txt"))
+	assert.False(t, isMarkdownName("page"))
+}
+
+func TestSortByDepthThenName(t *testing.T) {
+	// Mixed depths and matching depths exercise both keys of the
+	// sort: shorter paths come first, ties break alphabetically.
+	paths := []string{
+		"b/page.md",
+		"a/page.md",
+		"page.md",
+		"a/sub/page.md",
+	}
+	sortByDepthThenName(paths)
+	assert.Equal(t, []string{
+		"page.md",
+		"a/page.md",
+		"b/page.md",
+		"a/sub/page.md",
+	}, paths)
+}
+
+func TestCodeSpanTextBounds(t *testing.T) {
+	// One Text child → bounds equal that text's segment. A non-Text
+	// child is skipped (continue). Two Text children expand the
+	// range. Zero Text children → -1, -1.
+	src := []byte("`abc`")
+	cs := ast.NewCodeSpan()
+	t1 := ast.NewTextSegment(text.NewSegment(1, 3))
+	cs.AppendChild(cs, t1)
+	first, last := codeSpanTextBounds(cs)
+	assert.Equal(t, 1, first)
+	assert.Equal(t, 3, last)
+
+	csNoText := ast.NewCodeSpan()
+	first, last = codeSpanTextBounds(csNoText)
+	assert.Equal(t, -1, first)
+	assert.Equal(t, -1, last)
+
+	csMixed := ast.NewCodeSpan()
+	csMixed.AppendChild(csMixed, ast.NewAutoLink(ast.AutoLinkURL, ast.NewTextSegment(text.NewSegment(0, 0))))
+	csMixed.AppendChild(csMixed, ast.NewTextSegment(text.NewSegment(2, 4)))
+	first, last = codeSpanTextBounds(csMixed)
+	assert.Equal(t, 2, first)
+	assert.Equal(t, 4, last)
+	_ = src
+}
+
+func TestInCodeSpan(t *testing.T) {
+	spans := []byteRange{{start: 5, end: 10}, {start: 20, end: 25}}
+	assert.True(t, inCodeSpan(spans, 5))
+	assert.True(t, inCodeSpan(spans, 9))
+	assert.False(t, inCodeSpan(spans, 10), "end is exclusive")
+	assert.False(t, inCodeSpan(spans, 4))
+	assert.False(t, inCodeSpan(spans, 100))
+	assert.False(t, inCodeSpan(nil, 0))
+}
+
+func TestCollectCodeSpanRanges_EmptyCodeSpan(t *testing.T) {
+	// Drive the `first < 0` early return in collectCodeSpanRanges by
+	// handing it an AST with a CodeSpan that has no Text children.
+	// goldmark won't usually emit one, but a struct-literal node
+	// proves the guard works without relying on parser quirks.
+	f := newFile(t, "ignored\n")
+	root := ast.NewDocument()
+	root.AppendChild(root, ast.NewCodeSpan())
+	f.AST = root
+	got := collectCodeSpanRanges(f)
+	assert.Empty(t, got, "empty CodeSpan must yield no range")
+}
+
+func TestWikilinkIndex_Resolve_EmbedNotFound(t *testing.T) {
+	// An embed lookup (exact-name) that misses falls through to the
+	// final `return "", false`. The stem case already hits its own
+	// "", false path via TestWikilinkIndex_ResolveSemantics.
+	mfs := fstest.MapFS{
+		"img.png": &fstest.MapFile{Data: []byte{}},
+	}
+	idx := NewWikilinkIndex(mfs)
+	_, ok := idx.Resolve("missing.png")
+	assert.False(t, ok)
 }
 
 // erroringFS rejects ReadDir on a specific subdirectory while

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/lint"
 )
 
 func TestExtractWikiLinks_NilFileReturnsNil(t *testing.T) {
@@ -18,6 +20,17 @@ func TestExtractWikiLinks_NilFileReturnsNil(t *testing.T) {
 func TestExtractWikiLinks_EmptySource(t *testing.T) {
 	f := newFile(t, "")
 	assert.Nil(t, ExtractWikiLinks(f))
+}
+
+func TestExtractWikiLinks_NilASTReturnsNilNoPanic(t *testing.T) {
+	// lint.File explicitly supports the struct-literal construction
+	// path where AST is never populated. The extractor walks the
+	// AST via CollectCodeBlockLines / CollectPIBlockLines, so it
+	// must short-circuit instead of panicking on a nil tree.
+	f := &lint.File{Source: []byte("[[Page]]\n")}
+	assert.NotPanics(t, func() {
+		assert.Nil(t, ExtractWikiLinks(f))
+	})
 }
 
 func TestResolveWikiLink_WhitespaceTarget(t *testing.T) {
@@ -214,6 +227,19 @@ func TestResolveWikiLink_RejectsCollapsedTraversal(t *testing.T) {
 	}
 	_, ok := ResolveWikiLink(mfs, "from.md", "a/../../etc/passwd")
 	assert.False(t, ok)
+}
+
+func TestResolveWikiLink_NormalizesBackslashSegments(t *testing.T) {
+	// A Windows-authored wikilink like `[[sub\page]]` arrives on
+	// Linux CI as the literal string "sub\page" — filepath.ToSlash
+	// is a no-op on POSIX. The resolver must collapse backslashes
+	// to slashes itself so cross-host vaults still resolve.
+	mfs := fstest.MapFS{
+		"sub/page.md": &fstest.MapFile{Data: []byte{}},
+	}
+	got, ok := ResolveWikiLink(mfs, "from.md", `sub\page`)
+	require.True(t, ok)
+	assert.Equal(t, "sub/page.md", got)
 }
 
 func TestResolveWikiLink_RejectsAbsolutePath(t *testing.T) {

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -167,6 +167,29 @@ func TestResolveWikiLink_RejectsRootEscape(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestResolveWikiLink_AcceptsDoubleDotInName(t *testing.T) {
+	// A bare ".." in the middle of a stem must not be confused with a
+	// parent-dir traversal. The wikilink writes the full filename
+	// (`v1..v2.md`) so path.Ext can identify ".md" as the extension and
+	// the search falls into stem mode against the matching file.
+	mfs := fstest.MapFS{
+		"v1..v2.md": &fstest.MapFile{Data: []byte{}},
+	}
+	got, ok := ResolveWikiLink(mfs, "from.md", "v1..v2.md")
+	require.True(t, ok)
+	assert.Equal(t, "v1..v2.md", got)
+}
+
+func TestResolveWikiLink_RejectsCollapsedTraversal(t *testing.T) {
+	// path.Clean reduces "a/../../etc" to "../etc" — the check must
+	// catch traversal hidden behind a leading legitimate segment.
+	mfs := fstest.MapFS{
+		"notes.md": &fstest.MapFile{Data: []byte{}},
+	}
+	_, ok := ResolveWikiLink(mfs, "from.md", "a/../../etc/passwd")
+	assert.False(t, ok)
+}
+
 func TestResolveWikiLink_RejectsAbsolutePath(t *testing.T) {
 	mfs := fstest.MapFS{
 		"notes.md": &fstest.MapFile{Data: []byte{}},

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -33,6 +33,57 @@ func TestExtractWikiLinks_NilASTReturnsNilNoPanic(t *testing.T) {
 	})
 }
 
+func TestNewWikilinkIndex_NilRoot(t *testing.T) {
+	assert.Nil(t, NewWikilinkIndex(nil))
+}
+
+func TestWikilinkIndex_ResolveSemantics(t *testing.T) {
+	// One index should serve every shape ResolveWikiLink supports:
+	// stem (.md), embed (any extension), case-insensitive match,
+	// shortest-path tie-break, traversal rejection, drive-letter
+	// rejection, backslash normalisation.
+	mfs := fstest.MapFS{
+		"notes.md":          &fstest.MapFile{Data: []byte{}},
+		"deep/sub/notes.md": &fstest.MapFile{Data: []byte{}},
+		"assets/img.png":    &fstest.MapFile{Data: []byte{}},
+		"sub/page.md":       &fstest.MapFile{Data: []byte{}},
+	}
+	idx := NewWikilinkIndex(mfs)
+	require.NotNil(t, idx)
+
+	cases := []struct {
+		name   string
+		target string
+		want   string
+		wantOK bool
+	}{
+		{"stem case-insensitive", "Notes", "notes.md", true},
+		{"shortest path", "notes", "notes.md", true},
+		{"embed exact name", "img.png", "assets/img.png", true},
+		{"backslash normalised", `sub\page`, "sub/page.md", true},
+		{"missing", "absent", "", false},
+		{"traversal rejected", "../etc/passwd", "", false},
+		{"drive rejected", "C:/Windows/notes.md", "", false},
+		{"UNC rejected", "//host/share/notes.md", "", false},
+		{"absolute rejected", "/notes.md", "", false},
+		{"empty rejected", "", "", false},
+		{"nil index", "notes", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := idx
+			if tc.name == "nil index" {
+				target = nil
+			}
+			got, ok := target.Resolve(tc.target)
+			assert.Equal(t, tc.wantOK, ok)
+			if ok {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
 func TestResolveWikiLink_WhitespaceTarget(t *testing.T) {
 	mfs := fstest.MapFS{"page.md": &fstest.MapFile{Data: []byte{}}}
 	_, ok := ResolveWikiLink(mfs, "from.md", "   ")

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -67,6 +67,48 @@ func linkgraphWikilinkIndexFor(cache *lint.RunCache, key string, root fs.FS) *Wi
 	return WikilinkIndexFor(cache, key, root)
 }
 
+func TestSkipHeavyDirs(t *testing.T) {
+	assert.Nil(t, skipHeavyDirs("."))
+	assert.Nil(t, skipHeavyDirs("docs"))
+	assert.Nil(t, skipHeavyDirs("plan/sub"))
+	assert.Equal(t, fs.SkipDir, skipHeavyDirs(".git"))
+	assert.Equal(t, fs.SkipDir, skipHeavyDirs("vendor/dep/node_modules"))
+	assert.Equal(t, fs.SkipDir, skipHeavyDirs("sub/.git"))
+}
+
+func TestNewWikilinkIndex_PrunesHeavyDirs(t *testing.T) {
+	// A wikilink target that lives under .git/ or node_modules/
+	// must not show up in the index — both directories carry no
+	// content users intend to wikilink against, and skipping them
+	// keeps the workspace walk bounded on real repos.
+	mfs := fstest.MapFS{
+		"page.md":                                &fstest.MapFile{Data: []byte{}},
+		".git/HEAD":                              &fstest.MapFile{Data: []byte{}},
+		".git/sub/page.md":                       &fstest.MapFile{Data: []byte{}},
+		"node_modules/lib/page.md":               &fstest.MapFile{Data: []byte{}},
+		"vendor/dep/node_modules/inside/page.md": &fstest.MapFile{Data: []byte{}},
+	}
+	idx := NewWikilinkIndex(mfs)
+	require.NotNil(t, idx)
+	got, ok := idx.Resolve("page")
+	require.True(t, ok)
+	assert.Equal(t, "page.md", got,
+		"only the top-level page.md should survive pruning")
+}
+
+func TestResolveWikiLink_PrunesHeavyDirs(t *testing.T) {
+	// The fallback per-call walk must apply the same pruning so
+	// a vault without a cached index does not pay for walking
+	// node_modules.
+	mfs := fstest.MapFS{
+		"page.md":                  &fstest.MapFile{Data: []byte{}},
+		"node_modules/lib/page.md": &fstest.MapFile{Data: []byte{}},
+	}
+	got, ok := ResolveWikiLink(mfs, "from.md", "page")
+	require.True(t, ok)
+	assert.Equal(t, "page.md", got)
+}
+
 func TestNewWikilinkIndex_NilRoot(t *testing.T) {
 	assert.Nil(t, NewWikilinkIndex(nil))
 }

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -36,6 +36,37 @@ func TestExtractWikiLinks_NilASTReturnsNilNoPanic(t *testing.T) {
 	})
 }
 
+func TestWikilinkIndexFor_NilCacheBuildsDirectly(t *testing.T) {
+	// A nil cache (or empty key) falls through to NewWikilinkIndex
+	// — used by `mdsmith list backlinks` which has no engine-wide
+	// RunCache. Two calls then walk twice; the cache path is what
+	// turns the second call into an O(1) lookup.
+	mfs := fstest.MapFS{"page.md": &fstest.MapFile{Data: []byte{}}}
+	idx := linkgraphWikilinkIndexFor(nil, "", mfs)
+	require.NotNil(t, idx)
+	got, ok := idx.Resolve("page")
+	require.True(t, ok)
+	assert.Equal(t, "page.md", got)
+}
+
+func TestWikilinkIndexFor_CachedAcrossCallers(t *testing.T) {
+	// With a shared cache + key, two callers see the same index.
+	// MDS027 takes this branch via the engine's RunCache so a
+	// workspace walked for host file A serves host file B too.
+	mfs := fstest.MapFS{"page.md": &fstest.MapFile{Data: []byte{}}}
+	cache := lint.NewRunCache()
+	a := linkgraphWikilinkIndexFor(cache, "/root", mfs)
+	b := linkgraphWikilinkIndexFor(cache, "/root", mfs)
+	require.NotNil(t, a)
+	assert.Same(t, a, b, "cache must hand out the same *WikilinkIndex per key")
+}
+
+// linkgraphWikilinkIndexFor is a thin alias so the test reads
+// naturally as a unit test of the package-local helper.
+func linkgraphWikilinkIndexFor(cache *lint.RunCache, key string, root fs.FS) *WikilinkIndex {
+	return WikilinkIndexFor(cache, key, root)
+}
+
 func TestNewWikilinkIndex_NilRoot(t *testing.T) {
 	assert.Nil(t, NewWikilinkIndex(nil))
 }

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -19,6 +19,7 @@ type RunCache struct {
 	frontMatter sync.Map // string (absPath) -> *runCacheEntry
 	includes    sync.Map // string (absPath) -> *runCacheEntry
 	anchors     sync.Map // string (absPath) -> *anchorEntry
+	wikilinks   sync.Map // string (root key) -> *runCacheEntry
 }
 
 // runCacheEntry guards a single cache slot so build runs exactly once
@@ -94,14 +95,41 @@ type anchorEntry struct {
 	anchors map[string]bool
 }
 
+// Wikilinks returns build's result keyed by rootKey, computed at
+// most once per rootKey in this cache's lifetime. Concurrent
+// callers with the same key block on the same once and observe
+// the same value.
+//
+// The value carries dynamic type any — MDS027 and `mdsmith list
+// backlinks` install a *linkgraph.WikilinkIndex so a workspace
+// walked for one host file serves every other file in the run.
+func (c *RunCache) Wikilinks(rootKey string, build func() any) any {
+	return load(&c.wikilinks, rootKey, build)
+}
+
 // Invalidate drops the front-matter, include, and anchor entries
 // for absPath. The LSP calls this from didChange / didSave /
 // didChangeWatchedFiles so the next Check that crosses absPath
 // re-reads from disk.
+//
+// Wikilink indices are NOT invalidated per absPath because a file
+// rename or creation could change the resolution of any wikilink in
+// the workspace; the LSP must InvalidateWikilinks (or build a
+// fresh RunCache) when the filesystem layout changes.
 func (c *RunCache) Invalidate(absPath string) {
 	c.frontMatter.Delete(absPath)
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
+}
+
+// InvalidateWikilinks clears every cached wikilink index. The LSP
+// calls this when the workspace tree changes (file create/delete/
+// rename) so the next resolution walks afresh.
+func (c *RunCache) InvalidateWikilinks() {
+	c.wikilinks.Range(func(k, _ any) bool {
+		c.wikilinks.Delete(k)
+		return true
+	})
 }
 
 // load is the shared LoadOrStore + sync.Once primitive for both maps.

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -100,9 +100,14 @@ type anchorEntry struct {
 // callers with the same key block on the same once and observe
 // the same value.
 //
-// The value carries dynamic type any — MDS027 and `mdsmith list
-// backlinks` install a *linkgraph.WikilinkIndex so a workspace
-// walked for one host file serves every other file in the run.
+// The value carries dynamic type any — the canonical caller is
+// linkgraph.WikilinkIndexFor, which stores a
+// *linkgraph.WikilinkIndex so a workspace walked for one host
+// file serves every later file in the run. MDS027 routes
+// through that helper via the engine's RunCache; `mdsmith list
+// backlinks` calls the helper directly without a cache because
+// it is one-shot. Either way the build/cache contract sits in
+// one place.
 func (c *RunCache) Wikilinks(rootKey string, build func() any) any {
 	return load(&c.wikilinks, rootKey, build)
 }

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -236,3 +236,52 @@ func TestRunCache_AnchorsConcurrentSingleBuild(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
 		"Anchors build must run exactly once under concurrent access")
 }
+
+func TestRunCache_WikilinksBuildsOnce(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return "index-instance"
+	}
+	for i := 0; i < 4; i++ {
+		got := c.Wikilinks("/root/a", build)
+		require.Equal(t, "index-instance", got)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"Wikilinks must build exactly once per root key")
+}
+
+func TestRunCache_WikilinksConcurrent(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return "idx"
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.Wikilinks("/root/a", build)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"concurrent callers must share one build")
+}
+
+func TestRunCache_InvalidateWikilinks(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return "v"
+	}
+	_ = c.Wikilinks("/root/a", build)
+	c.InvalidateWikilinks()
+	_ = c.Wikilinks("/root/a", build)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"InvalidateWikilinks must let the next call rebuild")
+}

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -268,6 +268,14 @@ type fileEvent struct {
 	Type int    `json:"type"`
 }
 
+// LSP FileChangeType enum values (spec §
+// workspace.didChangeWatchedFiles). Used as fileEvent.Type.
+const (
+	fileChangeCreated = 1
+	fileChangeChanged = 2
+	fileChangeDeleted = 3
+)
+
 type configurationParams struct {
 	Items []configurationItem `json:"items"`
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -584,6 +584,17 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 			configChanged = true
 			continue
 		}
+		// The wikilink index indexes every file under the workspace
+		// — not just markdown — because embeds like `![[image.png]]`
+		// resolve to any extension. A create or delete of any
+		// non-config file therefore changes the candidate set; the
+		// flag is set before the markdown filter so an image add or
+		// a rename to a binary asset still rebuilds the index.
+		// Per LSP spec: 1=Created, 2=Changed, 3=Deleted. A rename
+		// is reported as a Deleted+Created pair.
+		if c.Type == fileChangeCreated || c.Type == fileChangeDeleted {
+			treeChanged = true
+		}
 		// Use isMarkdownExt for case-insensitive extension match
 		// — the rest of the navigation surface (docTextOrFile,
 		// indexReloadFromDisk) treats `.MD` / `.Markdown` as
@@ -592,13 +603,6 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 		// the index.
 		if isMarkdownExt(path) {
 			mdChanges = append(mdChanges, path)
-			// Per LSP spec: 1=Created, 2=Changed, 3=Deleted. A
-			// rename is reported as a Deleted+Created pair. The
-			// workspace-wide wikilink index keys off the file set,
-			// so any create or delete invalidates it.
-			if c.Type == fileChangeCreated || c.Type == fileChangeDeleted {
-				treeChanged = true
-			}
 		}
 	}
 	if configChanged {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -576,6 +576,7 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 		return
 	}
 	configChanged := false
+	treeChanged := false
 	mdChanges := make([]string, 0, len(p.Changes))
 	for _, c := range p.Changes {
 		path := uriToPath(c.URI)
@@ -591,6 +592,13 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 		// the index.
 		if isMarkdownExt(path) {
 			mdChanges = append(mdChanges, path)
+			// Per LSP spec: 1=Created, 2=Changed, 3=Deleted. A
+			// rename is reported as a Deleted+Created pair. The
+			// workspace-wide wikilink index keys off the file set,
+			// so any create or delete invalidates it.
+			if c.Type == fileChangeCreated || c.Type == fileChangeDeleted {
+				treeChanged = true
+			}
 		}
 	}
 	if configChanged {
@@ -602,6 +610,14 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 			s.scheduleLint(uri, lintTriggerConfig)
 		}
 		return
+	}
+	if treeChanged && s.runCache != nil {
+		// File create / delete / rename changes the candidate set
+		// the WikilinkIndex keys off, so the next Check must rebuild
+		// the index from scratch — otherwise MDS027 would resolve
+		// `[[NewPage]]` against the pre-create set and report it
+		// missing (or keep resolving `[[OldName]]` after a delete).
+		s.runCache.InvalidateWikilinks()
 	}
 	openPaths := s.openDocPaths()
 	for _, path := range mdChanges {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2433,6 +2433,60 @@ func TestHandleDidChangeWatchedFilesInvalidJSON(t *testing.T) {
 	s.handleDidChangeWatchedFiles(context.Background(), json.RawMessage("oops"))
 }
 
+func TestHandleDidChangeWatchedFiles_InvalidatesWikilinkIndex(t *testing.T) {
+	t.Parallel()
+	// A markdown file create/delete reported via the workspace
+	// watcher must clear the wikilink index — otherwise the next
+	// MDS027 Check would resolve `[[NewPage]]` against the
+	// pre-create candidate set and emit a false-positive
+	// not-found diagnostic.
+	cases := []struct {
+		name       string
+		changeType int
+		want       bool
+	}{
+		{"create invalidates", fileChangeCreated, true},
+		{"delete invalidates", fileChangeDeleted, true},
+		{"changed does not invalidate", fileChangeChanged, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+			rc := lint.NewRunCache()
+			s.runCache = rc
+			// Seed the cache so we can detect whether the handler
+			// cleared it.
+			var built int
+			rc.Wikilinks("/root", func() any {
+				built++
+				return "v1"
+			})
+			require.Equal(t, 1, built)
+
+			body, err := json.Marshal(didChangeWatchedFilesParams{
+				Changes: []fileEvent{
+					{URI: "file:///tmp/new.md", Type: tc.changeType},
+				},
+			})
+			require.NoError(t, err)
+			s.handleDidChangeWatchedFiles(context.Background(), body)
+
+			rc.Wikilinks("/root", func() any {
+				built++
+				return "v2"
+			})
+			if tc.want {
+				assert.Equal(t, 2, built,
+					"wikilink cache must rebuild after %s", tc.name)
+			} else {
+				assert.Equal(t, 1, built,
+					"%s must not invalidate the wikilink cache", tc.name)
+			}
+		})
+	}
+}
+
 func TestDocumentStoreGetMissing(t *testing.T) {
 	t.Parallel()
 	s := newDocumentStore()

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2442,12 +2442,20 @@ func TestHandleDidChangeWatchedFiles_InvalidatesWikilinkIndex(t *testing.T) {
 	// not-found diagnostic.
 	cases := []struct {
 		name       string
+		uri        string
 		changeType int
 		want       bool
 	}{
-		{"create invalidates", fileChangeCreated, true},
-		{"delete invalidates", fileChangeDeleted, true},
-		{"changed does not invalidate", fileChangeChanged, false},
+		{"markdown create invalidates", "file:///tmp/new.md", fileChangeCreated, true},
+		{"markdown delete invalidates", "file:///tmp/new.md", fileChangeDeleted, true},
+		{"markdown changed does not invalidate", "file:///tmp/new.md", fileChangeChanged, false},
+		// Non-markdown create/delete must also invalidate: embeds
+		// like `![[image.png]]` resolve against any extension via
+		// the WikilinkIndex.names map, so a binary asset rename
+		// shifts the candidate set just as a markdown rename does.
+		{"image create invalidates", "file:///tmp/diagram.png", fileChangeCreated, true},
+		{"image delete invalidates", "file:///tmp/diagram.png", fileChangeDeleted, true},
+		{"image changed does not invalidate", "file:///tmp/diagram.png", fileChangeChanged, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2465,9 +2473,7 @@ func TestHandleDidChangeWatchedFiles_InvalidatesWikilinkIndex(t *testing.T) {
 			require.Equal(t, 1, built)
 
 			body, err := json.Marshal(didChangeWatchedFilesParams{
-				Changes: []fileEvent{
-					{URI: "file:///tmp/new.md", Type: tc.changeType},
-				},
+				Changes: []fileEvent{{URI: tc.uri, Type: tc.changeType}},
 			})
 			require.NoError(t, err)
 			s.handleDidChangeWatchedFiles(context.Background(), body)

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -16,12 +16,14 @@ Links to local files and heading anchors must resolve.
 
 ## Settings
 
-| Setting        | Type | Default | Description                                                                                                                |
-|----------------|------|---------|----------------------------------------------------------------------------------------------------------------------------|
-| `include`      | list | `[]`    | glob patterns to include                                                                                                   |
-| `exclude`      | list | `[]`    | glob patterns to skip                                                                                                      |
-| `strict`       | bool | `false` | check non-Markdown file links                                                                                              |
-| `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
+| Setting          | Type   | Default      | Description                                                                                                                  |
+|------------------|--------|--------------|------------------------------------------------------------------------------------------------------------------------------|
+| `include`        | list   | `[]`         | glob patterns to include                                                                                                     |
+| `exclude`        | list   | `[]`         | glob patterns to skip                                                                                                        |
+| `strict`         | bool   | `false`      | check non-Markdown file links                                                                                                |
+| `placeholders`   | list   | `[]`         | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md)   |
+| `wikilinks`      | bool   | `false`      | Validate Obsidian-style `[[Page]]`, `[[Page#anchor]]`, `[[Page\|alias]]`, and `![[file.png]]` targets against the workspace. |
+| `wikilink-style` | string | `"obsidian"` | Resolution style for wikilinks. Only `obsidian` ships today; other values are rejected at config load.                       |
 
 Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
 
@@ -44,6 +46,29 @@ pre-hardening behavior where images were silently skipped.
 
 When `links.site-root` is unset, absolute-path links (`/foo/bar`)
 are silently skipped (the behavior before this setting was added).
+
+### Wikilinks
+
+`wikilinks: true` resolves every Obsidian-style wikilink
+in the source against the workspace root.
+
+Resolution is by file stem (case-insensitive) for
+`.md`/`.markdown` targets. Other extensions match by
+exact filename. The shortest matching path wins; ties
+break alphabetically.
+
+Unresolved targets, missing heading anchors, and
+unreadable targets each emit one diagnostic.
+
+Wikilinks inside fenced code blocks, code spans, and
+`<?...?>` directive markers are never flagged. The
+`placeholders` filter applies to wikilink targets the
+same way it applies to standard Markdown link
+destinations.
+
+The `obsidian` convention turns this on with
+`wikilink-style: obsidian` in one switch — see the
+[conventions reference](../../../docs/reference/conventions.md).
 
 ## Config
 

--- a/internal/rules/MDS027-cross-file-reference-integrity/bad/wikilink-missing.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/bad/wikilink-missing.md
@@ -1,0 +1,11 @@
+---
+settings:
+  wikilinks: true
+diagnostics:
+  - line: 3
+    column: 5
+    message: 'wikilink target "Missing Page" not found in workspace'
+---
+# Broken Wikilink
+
+See [[Missing Page]].

--- a/internal/rules/MDS027-cross-file-reference-integrity/good/wikilink-resolved.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/good/wikilink-resolved.md
@@ -1,0 +1,7 @@
+---
+settings:
+  wikilinks: true
+---
+# Wikilink Resolves
+
+See [[guide]] for context.

--- a/internal/rules/MDS067-callout-type/README.md
+++ b/internal/rules/MDS067-callout-type/README.md
@@ -1,0 +1,137 @@
+---
+id: MDS067
+name: callout-type
+status: ready
+description: Validate Obsidian callout types against an allowed set.
+category: structural
+nature: structure
+maintainability: null
+markdownlint: null
+---
+# MDS067: callout-type
+
+Validate Obsidian callout types against an allowed set.
+
+A blockquote whose first paragraph begins with
+`[!type]` is an Obsidian callout. MDS067 flags the
+callout when `type` is not in the effective allow
+set. Matching is case-insensitive. Custom types are
+opt-in via the `allow` setting; the rule turns off
+entirely under `allow-unknown: true`.
+
+Disabled by default. Set `convention: obsidian` (or
+toggle the rule on directly) to enable it.
+
+## Settings
+
+| Setting         | Type | Default | Description                                                    |
+|-----------------|------|---------|----------------------------------------------------------------|
+| `allow`         | list | `[]`    | Extra callout-type names to permit alongside the built-in set. |
+| `allow-unknown` | bool | `false` | When `true`, accept any `[!name]` token without validation.    |
+
+The built-in vocabulary is the Obsidian base set:
+
+- `note`
+- `abstract` (aliases `summary`, `tldr`)
+- `info` (alias `todo`)
+- `tip` (aliases `hint`, `important`)
+- `success` (aliases `check`, `done`)
+- `question` (aliases `help`, `faq`)
+- `warning` (aliases `caution`, `attention`)
+- `failure` (aliases `fail`, `missing`)
+- `danger` (alias `error`)
+- `bug`
+- `example`
+- `quote` (alias `cite`)
+
+`allow` uses `append` merge semantics. A kind or
+override that adds a custom type preserves entries
+from earlier layers.
+
+## Config
+
+Enable:
+
+```yaml
+rules:
+  callout-type: true
+```
+
+Disable:
+
+```yaml
+rules:
+  callout-type: false
+```
+
+Extend the allowed set:
+
+```yaml
+rules:
+  callout-type:
+    allow:
+      - review
+      - decision
+```
+
+Accept any type:
+
+```yaml
+rules:
+  callout-type:
+    allow-unknown: true
+```
+
+## Examples
+
+### Good
+
+<?include
+file: good/default.md
+wrap: markdown
+?>
+
+```markdown
+# Standard Callouts
+
+> [!note]
+> A note callout.
+
+Some prose between callouts.
+
+> [!warning]
+> A warning callout.
+
+More prose between callouts.
+
+> [!tip]
+> A tip callout.
+```
+
+<?/include?>
+
+### Bad
+
+<?include
+file: bad/unknown.md
+wrap: markdown
+?>
+
+```markdown
+# Bad Callout
+
+> [!REVIEW]
+> Unknown type.
+```
+
+<?/include?>
+
+## Meta-Information
+
+- **ID**: MDS067
+- **Name**: `callout-type`
+- **Status**: ready
+- **Default**: disabled
+- **Fixable**: no
+- **Implementation**: [source](./)
+- **Category**: structural

--- a/internal/rules/MDS067-callout-type/bad/unknown.md
+++ b/internal/rules/MDS067-callout-type/bad/unknown.md
@@ -1,0 +1,10 @@
+---
+diagnostics:
+  - line: 3
+    column: 3
+    message: 'unknown callout type "REVIEW"; valid types: note, abstract, info, tip, success, question, warning, failure, danger, bug, example, quote (or configure allow-unknown: true)'
+---
+# Bad Callout
+
+> [!REVIEW]
+> Unknown type.

--- a/internal/rules/MDS067-callout-type/bad/unknown.md
+++ b/internal/rules/MDS067-callout-type/bad/unknown.md
@@ -2,7 +2,7 @@
 diagnostics:
   - line: 3
     column: 3
-    message: 'unknown callout type "REVIEW"; valid types: note, abstract, info, tip, success, question, warning, failure, danger, bug, example, quote (or configure allow-unknown: true)'
+    message: 'unknown callout type "REVIEW"; valid base types: note, abstract, info, tip, success, question, warning, failure, danger, bug, example, quote (aliases such as summary, tldr, todo also resolve; or configure allow-unknown: true)'
 ---
 # Bad Callout
 

--- a/internal/rules/MDS067-callout-type/good/allow-list.md
+++ b/internal/rules/MDS067-callout-type/good/allow-list.md
@@ -1,0 +1,9 @@
+---
+settings:
+  allow:
+    - custom
+---
+# Allow Custom
+
+> [!custom]
+> A user-permitted type.

--- a/internal/rules/MDS067-callout-type/good/allow-unknown.md
+++ b/internal/rules/MDS067-callout-type/good/allow-unknown.md
@@ -1,0 +1,13 @@
+---
+settings:
+  allow-unknown: true
+---
+# Allow Anything
+
+> [!review]
+> Custom type allowed.
+
+Some prose to separate callouts.
+
+> [!whatever]
+> Another custom type.

--- a/internal/rules/MDS067-callout-type/good/default.md
+++ b/internal/rules/MDS067-callout-type/good/default.md
@@ -1,0 +1,14 @@
+# Standard Callouts
+
+> [!note]
+> A note callout.
+
+Some prose between callouts.
+
+> [!warning]
+> A warning callout.
+
+More prose between callouts.
+
+> [!tip]
+> A tip callout.

--- a/internal/rules/all/all.go
+++ b/internal/rules/all/all.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/blanklinearoundlists"        // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/blockquotewhitespace"        // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/build"                       // registers rule
+	_ "github.com/jeduden/mdsmith/internal/rules/callouttype"                 // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/catalog"                     // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/concisenessscoring"          // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/crossfilereferenceintegrity" // registers rule

--- a/internal/rules/callouttype/rule.go
+++ b/internal/rules/callouttype/rule.go
@@ -1,0 +1,225 @@
+// Package callouttype implements MDS067, which validates the
+// `[!type]` token at the start of an Obsidian callout blockquote
+// against the convention's allowed type set.
+package callouttype
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/settings"
+)
+
+func init() {
+	rule.Register(&Rule{})
+}
+
+// Rule flags blockquote callouts whose `[!type]` token is not in the
+// effective allow set. The set is the Obsidian-flavor base types plus
+// any user-configured `allow:` entries; `allow-unknown: true` turns
+// validation off entirely.
+type Rule struct {
+	Allow        []string
+	AllowUnknown bool
+}
+
+// ID implements rule.Rule.
+func (r *Rule) ID() string { return "MDS067" }
+
+// Name implements rule.Rule.
+func (r *Rule) Name() string { return "callout-type" }
+
+// Category implements rule.Rule.
+func (r *Rule) Category() string { return "structural" }
+
+// EnabledByDefault implements rule.Defaultable. Disabled by default
+// so non-Obsidian projects do not see diagnostics for blockquote
+// lines that happen to start with `[!something]`.
+func (r *Rule) EnabledByDefault() bool { return false }
+
+// builtInTypes lists every base Obsidian callout type and its
+// aliases. Lowercased; lookup uses strings.ToLower on the captured
+// token. Keep alphabetised so the diagnostic's "valid types" list
+// has a stable order across runs.
+var builtInTypes = map[string]bool{
+	"note":      true,
+	"abstract":  true,
+	"summary":   true,
+	"tldr":      true,
+	"info":      true,
+	"todo":      true,
+	"tip":       true,
+	"hint":      true,
+	"important": true,
+	"success":   true,
+	"check":     true,
+	"done":      true,
+	"question":  true,
+	"help":      true,
+	"faq":       true,
+	"warning":   true,
+	"caution":   true,
+	"attention": true,
+	"failure":   true,
+	"fail":      true,
+	"missing":   true,
+	"danger":    true,
+	"error":     true,
+	"bug":       true,
+	"example":   true,
+	"quote":     true,
+	"cite":      true,
+}
+
+// validTypeOrder is the message-facing list of base type names. The
+// order matches the convention's documented vocabulary so users
+// quoting the diagnostic see the official names first; aliases stay
+// out of the message to keep it readable.
+var validTypeOrder = []string{
+	"note", "abstract", "info", "tip", "success", "question",
+	"warning", "failure", "danger", "bug", "example", "quote",
+}
+
+// calloutRE matches the `[!type]` token at the start of a callout
+// line. The capture group is the type body (letters, digits, dash,
+// underscore).
+var calloutRE = regexp.MustCompile(`^\[!([A-Za-z0-9_-]+)\]`)
+
+// Check implements rule.Rule.
+func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	if r.AllowUnknown {
+		return nil
+	}
+	allowed := r.effectiveAllowSet()
+	var diags []lint.Diagnostic
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		bq, ok := n.(*ast.Blockquote)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		token, line, col, ok := calloutToken(bq, f)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		if allowed[strings.ToLower(token)] {
+			return ast.WalkContinue, nil
+		}
+		diags = append(diags, r.unknownTypeDiag(f.Path, line, col, token))
+		return ast.WalkContinue, nil
+	})
+	return diags
+}
+
+// effectiveAllowSet returns the union of the built-in Obsidian types
+// (lowercased) and the user-configured `allow` entries. Returned map
+// is private to one Check call.
+func (r *Rule) effectiveAllowSet() map[string]bool {
+	out := make(map[string]bool, len(builtInTypes)+len(r.Allow))
+	for k := range builtInTypes {
+		out[k] = true
+	}
+	for _, name := range r.Allow {
+		out[strings.ToLower(name)] = true
+	}
+	return out
+}
+
+// calloutToken returns the `[!type]` token, body-relative line, and
+// column of the bq blockquote when its first paragraph begins with
+// the Obsidian callout marker. ok=false means the blockquote is not
+// a callout.
+func calloutToken(bq *ast.Blockquote, f *lint.File) (token string, line, col int, ok bool) {
+	para, ok := bq.FirstChild().(*ast.Paragraph)
+	if !ok || para.Lines().Len() == 0 {
+		return "", 0, 0, false
+	}
+	seg := para.Lines().At(0)
+	firstLine := bytes.TrimRight(f.Source[seg.Start:seg.Stop], "\r\n")
+	m := calloutRE.FindSubmatchIndex(firstLine)
+	if m == nil {
+		return "", 0, 0, false
+	}
+	startOffset := seg.Start + m[0]
+	return string(firstLine[m[2]:m[3]]), f.LineOfOffset(startOffset), f.ColumnOfOffset(startOffset), true
+}
+
+func (r *Rule) unknownTypeDiag(path string, line, col int, token string) lint.Diagnostic {
+	valid := strings.Join(validTypeOrder, ", ")
+	extra := ""
+	if len(r.Allow) > 0 {
+		extras := make([]string, len(r.Allow))
+		copy(extras, r.Allow)
+		sort.Strings(extras)
+		extra = " (plus " + strings.Join(extras, ", ") + ")"
+	}
+	msg := fmt.Sprintf(
+		"unknown callout type %q; valid types: %s%s (or configure allow-unknown: true)",
+		token, valid, extra,
+	)
+	return lint.Diagnostic{
+		File:     path,
+		Line:     line,
+		Column:   col,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  msg,
+	}
+}
+
+// ApplySettings implements rule.Configurable.
+func (r *Rule) ApplySettings(s map[string]any) error {
+	for k, v := range s {
+		switch k {
+		case "allow":
+			list, ok := settings.ToStringSlice(v)
+			if !ok {
+				return fmt.Errorf("callout-type: allow must be a list of strings, got %T", v)
+			}
+			r.Allow = list
+		case "allow-unknown":
+			b, ok := v.(bool)
+			if !ok {
+				return fmt.Errorf("callout-type: allow-unknown must be a bool, got %T", v)
+			}
+			r.AllowUnknown = b
+		default:
+			return fmt.Errorf("callout-type: unknown setting %q", k)
+		}
+	}
+	return nil
+}
+
+// DefaultSettings implements rule.Configurable.
+func (r *Rule) DefaultSettings() map[string]any {
+	return map[string]any{
+		"allow":         []string{},
+		"allow-unknown": false,
+	}
+}
+
+// SettingMergeMode implements rule.ListMerger. `allow` appends across
+// layers so a user override can extend (not replace) a convention's
+// list of custom callout names.
+func (r *Rule) SettingMergeMode(key string) rule.MergeMode {
+	if key == "allow" {
+		return rule.MergeAppend
+	}
+	return rule.MergeReplace
+}
+
+var (
+	_ rule.Configurable = (*Rule)(nil)
+	_ rule.ListMerger   = (*Rule)(nil)
+	_ rule.Defaultable  = (*Rule)(nil)
+)

--- a/internal/rules/callouttype/rule.go
+++ b/internal/rules/callouttype/rule.go
@@ -46,8 +46,10 @@ func (r *Rule) EnabledByDefault() bool { return false }
 
 // builtInTypes lists every base Obsidian callout type and its
 // aliases. Lowercased; lookup uses strings.ToLower on the captured
-// token. Keep alphabetised so the diagnostic's "valid types" list
-// has a stable order across runs.
+// token. Keep this map in sync with Obsidian's published
+// vocabulary; the diagnostic message orders names via
+// validTypeOrder below, so map iteration order does not affect
+// output stability.
 var builtInTypes = map[string]bool{
 	"note":      true,
 	"abstract":  true,

--- a/internal/rules/callouttype/rule.go
+++ b/internal/rules/callouttype/rule.go
@@ -99,6 +99,9 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	if r.AllowUnknown {
 		return nil
 	}
+	if f == nil || f.AST == nil {
+		return nil
+	}
 	allowed := r.effectiveAllowSet()
 	var diags []lint.Diagnostic
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {

--- a/internal/rules/callouttype/rule.go
+++ b/internal/rules/callouttype/rule.go
@@ -165,7 +165,9 @@ func (r *Rule) unknownTypeDiag(path string, line, col int, token string) lint.Di
 		extra = " (plus " + strings.Join(extras, ", ") + ")"
 	}
 	msg := fmt.Sprintf(
-		"unknown callout type %q; valid types: %s%s (or configure allow-unknown: true)",
+		"unknown callout type %q; valid base types: %s%s "+
+			"(aliases such as summary, tldr, todo also resolve; "+
+			"or configure allow-unknown: true)",
 		token, valid, extra,
 	)
 	return lint.Diagnostic{

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -135,3 +135,23 @@ func TestSettingMergeMode(t *testing.T) {
 	r := &Rule{}
 	assert.NotEqual(t, r.SettingMergeMode("allow"), r.SettingMergeMode("allow-unknown"))
 }
+
+func TestCheck_BlockquoteWithoutParagraph(t *testing.T) {
+	// A blockquote whose first child is a list, code block, or another
+	// blockquote (not a paragraph) cannot carry a callout marker. The
+	// rule must skip it without panicking on the type assertion.
+	f := newFile(t, "> - item 1\n> - item 2\n")
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestUnknownTypeDiag_AllowListExtras(t *testing.T) {
+	// When the rule has user-configured types in Allow, the diagnostic
+	// message lists them after the built-in vocabulary so the user
+	// sees both sets when they triage a violation.
+	f := newFile(t, "> [!REVIEW]\n> body\n")
+	r := &Rule{Allow: []string{"decision", "custom"}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "(plus custom, decision)")
+}

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -1,0 +1,137 @@
+package callouttype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+func newFile(t *testing.T, src string) *lint.File {
+	t.Helper()
+	f, err := lint.NewFile("test.md", []byte(src))
+	require.NoError(t, err)
+	return f
+}
+
+func TestRuleMetadata(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "MDS067", r.ID())
+	assert.Equal(t, "callout-type", r.Name())
+	assert.Equal(t, "structural", r.Category())
+	assert.False(t, r.EnabledByDefault())
+}
+
+func TestCheck_BaseTypeAllowed(t *testing.T) {
+	r := &Rule{}
+	for _, ty := range []string{
+		"note", "abstract", "summary", "tldr",
+		"info", "todo",
+		"tip", "hint", "important",
+		"success", "check", "done",
+		"question", "help", "faq",
+		"warning", "caution", "attention",
+		"failure", "fail", "missing",
+		"danger", "error",
+		"bug", "example",
+		"quote", "cite",
+	} {
+		src := "> [!" + ty + "]\n> body\n"
+		f := newFile(t, src)
+		diags := r.Check(f)
+		assert.Emptyf(t, diags, "type %q should be allowed", ty)
+	}
+}
+
+func TestCheck_CaseInsensitive(t *testing.T) {
+	f := newFile(t, "> [!NOTE]\n> body\n")
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_UnknownType(t *testing.T) {
+	f := newFile(t, "> [!REVIEW]\n> body\n")
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "MDS067", diags[0].RuleID)
+	assert.Contains(t, diags[0].Message, "REVIEW")
+	assert.Contains(t, diags[0].Message, "note")
+	assert.Contains(t, diags[0].Message, "allow-unknown")
+}
+
+func TestCheck_AllowList(t *testing.T) {
+	f := newFile(t, "> [!custom]\n> body\n")
+	r := &Rule{Allow: []string{"custom"}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_AllowUnknownDisablesValidation(t *testing.T) {
+	f := newFile(t, "> [!anything]\n> body\n")
+	r := &Rule{AllowUnknown: true}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_PlainBlockquoteIgnored(t *testing.T) {
+	f := newFile(t, "> just a quote\n> no callout marker here\n")
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_ReportsLineAndColumn(t *testing.T) {
+	f := newFile(t, "# Heading\n\n> [!REVIEW]\n> body\n")
+	diags := (&Rule{}).Check(f)
+	require.Len(t, diags, 1)
+	assert.Equal(t, 3, diags[0].Line)
+	// The "[" sits after "> " on the line, so col 3.
+	assert.Equal(t, 3, diags[0].Column)
+}
+
+func TestCheck_NestedBlockquote(t *testing.T) {
+	// A blockquote whose first paragraph does not start with `[!type]`
+	// is not a callout — even if a deeper child contains the token.
+	f := newFile(t, "> not a callout\n>\n> > [!REVIEW]\n> > body\n")
+	diags := (&Rule{}).Check(f)
+	// The inner blockquote is itself walked; if its first paragraph
+	// holds the unknown token it still triggers.
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "REVIEW")
+}
+
+func TestApplySettings_AllowList(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"allow": []any{"custom", "other"}}))
+	assert.Equal(t, []string{"custom", "other"}, r.Allow)
+}
+
+func TestApplySettings_AllowUnknown(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"allow-unknown": true}))
+	assert.True(t, r.AllowUnknown)
+}
+
+func TestApplySettings_BadTypes(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{"allow": "string-not-list"})
+	require.Error(t, err)
+
+	err = r.ApplySettings(map[string]any{"allow-unknown": "yes"})
+	require.Error(t, err)
+
+	err = r.ApplySettings(map[string]any{"unknown-key": true})
+	require.Error(t, err)
+}
+
+func TestDefaultSettings(t *testing.T) {
+	ds := (&Rule{}).DefaultSettings()
+	assert.Equal(t, []string{}, ds["allow"])
+	assert.Equal(t, false, ds["allow-unknown"])
+}
+
+func TestSettingMergeMode(t *testing.T) {
+	r := &Rule{}
+	assert.NotEqual(t, r.SettingMergeMode("allow"), r.SettingMergeMode("allow-unknown"))
+}

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -141,6 +141,16 @@ func TestSettingMergeMode(t *testing.T) {
 	assert.NotEqual(t, r.SettingMergeMode("allow"), r.SettingMergeMode("allow-unknown"))
 }
 
+func TestCheck_NilFileAndNilASTReturnNil(t *testing.T) {
+	// lint.File explicitly supports the struct-literal construction
+	// path where AST is never populated. Rule.Check walks f.AST, so
+	// it must short-circuit instead of panicking on a nil tree —
+	// and gracefully accept a nil *lint.File the same way.
+	r := &Rule{}
+	assert.NotPanics(t, func() { assert.Nil(t, r.Check(nil)) })
+	assert.NotPanics(t, func() { assert.Nil(t, r.Check(&lint.File{})) })
+}
+
 func TestCheck_BlockquoteWithoutParagraph(t *testing.T) {
 	// A blockquote whose first child is a list, code block, or another
 	// blockquote (not a paragraph) cannot carry a callout marker. The

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -59,6 +59,11 @@ func TestCheck_UnknownType(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "REVIEW")
 	assert.Contains(t, diags[0].Message, "note")
 	assert.Contains(t, diags[0].Message, "allow-unknown")
+	// The wording must call out base-type vs alias so a user
+	// reading the message does not assume "summary" or "tldr" are
+	// rejected just because they aren't in the printed list.
+	assert.Contains(t, diags[0].Message, "valid base types")
+	assert.Contains(t, diags[0].Message, "aliases")
 }
 
 func TestCheck_AllowList(t *testing.T) {

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -250,10 +250,12 @@ func wikilinkAnchorsForTarget(
 // relative (e.g. a struct-literal test File without RootDir) it
 // returns the original path with separators normalised.
 //
-// filepath.Abs only errors when os.Getwd() fails (an OS-level
-// catastrophe); filepath.Rel only errors on Windows cross-volume
-// pairs. On Linux, where mdsmith ships, the call chain below never
-// errors once f.RootDir is non-empty.
+// filepath.Abs only errors when os.Getwd() fails; filepath.Rel only
+// errors when the two paths cannot share a base (cross-volume on
+// Windows, otherwise impossible here because both arguments are
+// made absolute first). Real workspaces under one RootDir do not
+// hit either branch; the discarded errors degrade gracefully to a
+// best-effort path on the rare cases that do.
 func workspaceRelativeSource(f *lint.File) string {
 	if f.RootDir == "" {
 		return filepath.ToSlash(f.Path)

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -117,10 +117,10 @@ func (r *Rule) checkWikilinks(
 	f *lint.File,
 	anchorCache map[string]map[string]bool,
 ) []lint.Diagnostic {
+	// f.FS is guaranteed non-nil by the caller (r.Check returns early
+	// otherwise), and wikilinkRoot's last fallback returns f.FS, so
+	// root is always populated here.
 	root := wikilinkRoot(f)
-	if root == nil {
-		return nil
-	}
 	resolver := newWikilinkResolver(root, workspaceRelativeSource(f), r.effectiveWikilinkStyle())
 
 	var diags []lint.Diagnostic
@@ -249,22 +249,18 @@ func wikilinkAnchorsForTarget(
 // project root, using forward slashes. When the path cannot be made
 // relative (e.g. a struct-literal test File without RootDir) it
 // returns the original path with separators normalised.
+//
+// filepath.Abs only errors when os.Getwd() fails (an OS-level
+// catastrophe); filepath.Rel only errors on Windows cross-volume
+// pairs. On Linux, where mdsmith ships, the call chain below never
+// errors once f.RootDir is non-empty.
 func workspaceRelativeSource(f *lint.File) string {
 	if f.RootDir == "" {
 		return filepath.ToSlash(f.Path)
 	}
-	abs, err := filepath.Abs(f.Path)
-	if err != nil {
-		return filepath.ToSlash(f.Path)
-	}
-	absRoot, err := filepath.Abs(f.RootDir)
-	if err != nil {
-		return filepath.ToSlash(f.Path)
-	}
-	rel, err := filepath.Rel(absRoot, abs)
-	if err != nil {
-		return filepath.ToSlash(f.Path)
-	}
+	abs, _ := filepath.Abs(f.Path)        //nolint:errcheck
+	absRoot, _ := filepath.Abs(f.RootDir) //nolint:errcheck
+	rel, _ := filepath.Rel(absRoot, abs)  //nolint:errcheck
 	return filepath.ToSlash(rel)
 }
 

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -31,11 +32,13 @@ type LinksConfig struct {
 // Rule checks Markdown links for missing target files and missing heading
 // anchors in linked Markdown files.
 type Rule struct {
-	Include      []string
-	Exclude      []string
-	Strict       bool
-	Placeholders []string // placeholder tokens to treat as opaque
-	Links        LinksConfig
+	Include       []string
+	Exclude       []string
+	Strict        bool
+	Placeholders  []string // placeholder tokens to treat as opaque
+	Wikilinks     bool     // when true, validate Obsidian-style [[...]] targets
+	WikilinkStyle string   // resolution style; only "obsidian" ships today
+	Links         LinksConfig
 }
 
 // ID implements rule.Rule.
@@ -94,8 +97,176 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			)...)
 		}
 	}
+	if r.Wikilinks {
+		diags = append(diags, r.checkWikilinks(f, anchorCache)...)
+	}
 
 	return diags
+}
+
+// checkWikilinks resolves every Obsidian-style wikilink against the
+// project root and emits one diagnostic per unresolved target or
+// missing heading anchor. Wikilink targets pass through the same
+// placeholder filter the standard link check uses.
+func (r *Rule) checkWikilinks(
+	f *lint.File,
+	anchorCache map[string]map[string]bool,
+) []lint.Diagnostic {
+	root := f.RootFS
+	if root == nil && f.RootDir != "" {
+		root = os.DirFS(f.RootDir)
+	}
+	if root == nil {
+		root = f.FS
+	}
+	if root == nil {
+		return nil
+	}
+
+	srcRel := workspaceRelativeSource(f)
+
+	var diags []lint.Diagnostic
+	for _, wl := range linkgraph.ExtractWikiLinks(f) {
+		raw := wikilinkRaw(wl)
+		if placeholders.ContainsBodyToken(wl.Target, r.Placeholders) ||
+			placeholders.ContainsBodyToken(raw, r.Placeholders) {
+			continue
+		}
+		resolved, ok := linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+		if !ok {
+			diags = append(diags, wikilinkBrokenTargetDiag(f.Path, wl, r))
+			continue
+		}
+		if wl.Anchor == "" || !isMarkdownPath(resolved) {
+			continue
+		}
+		anchors, err := wikilinkAnchorsForTarget(f, root, resolved, anchorCache)
+		if err != nil {
+			diags = append(diags, wikilinkUnreadableTargetDiag(f.Path, wl, resolved, err, r))
+			continue
+		}
+		if anchors[linkgraph.NormalizeAnchor(wl.Anchor)] {
+			continue
+		}
+		diags = append(diags, wikilinkBrokenAnchorDiag(f.Path, wl, resolved, r))
+	}
+	return diags
+}
+
+// wikilinkAnchorsForTarget memoizes anchor lookup per workspace-relative
+// target path so two wikilinks pointing at the same file share one parse.
+func wikilinkAnchorsForTarget(
+	f *lint.File,
+	root fs.FS,
+	resolved string,
+	cache map[string]map[string]bool,
+) (map[string]bool, error) {
+	key := "wikilink:" + resolved
+	if anchors, ok := cache[key]; ok {
+		return anchors, nil
+	}
+	data, err := lint.ReadFSFileLimited(root, resolved, f.MaxInputBytes)
+	if err != nil {
+		return nil, err
+	}
+	target, _ := lint.NewFileFromSource(resolved, data, true) //nolint:errcheck
+	anchors := linkgraph.CollectAnchors(target)
+	cache[key] = anchors
+	return anchors, nil
+}
+
+// workspaceRelativeSource returns f.Path expressed relative to its
+// project root, using forward slashes. When the path cannot be made
+// relative (e.g. a struct-literal test File without RootDir) it
+// returns the original path with separators normalised.
+func workspaceRelativeSource(f *lint.File) string {
+	if f.RootDir == "" {
+		return filepath.ToSlash(f.Path)
+	}
+	abs, err := filepath.Abs(f.Path)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
+	absRoot, err := filepath.Abs(f.RootDir)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
+	rel, err := filepath.Rel(absRoot, abs)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+// wikilinkRaw renders wl back to its source form so placeholders that
+// look at the full bracket span (e.g. matching a `{var}` token in the
+// alias) can fire the same way they would for a Markdown link's raw
+// target.
+func wikilinkRaw(wl linkgraph.WikiLink) string {
+	var sb strings.Builder
+	if wl.Embed {
+		sb.WriteByte('!')
+	}
+	sb.WriteString("[[")
+	sb.WriteString(wl.Target)
+	if wl.Anchor != "" {
+		sb.WriteByte('#')
+		sb.WriteString(wl.Anchor)
+	}
+	if wl.Alias != "" {
+		sb.WriteByte('|')
+		sb.WriteString(wl.Alias)
+	}
+	sb.WriteString("]]")
+	return sb.String()
+}
+
+func wikilinkBrokenTargetDiag(
+	path string, wl linkgraph.WikiLink, r *Rule,
+) lint.Diagnostic {
+	return lint.Diagnostic{
+		File:     path,
+		Line:     wl.Line,
+		Column:   wl.Column,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  fmt.Sprintf("wikilink target %q not found in workspace", wl.Target),
+	}
+}
+
+func wikilinkBrokenAnchorDiag(
+	path string, wl linkgraph.WikiLink, resolved string, r *Rule,
+) lint.Diagnostic {
+	return lint.Diagnostic{
+		File:     path,
+		Line:     wl.Line,
+		Column:   wl.Column,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message: fmt.Sprintf(
+			"wikilink %q: anchor %q not found in %s",
+			wikilinkRaw(wl), wl.Anchor, resolved,
+		),
+	}
+}
+
+func wikilinkUnreadableTargetDiag(
+	path string, wl linkgraph.WikiLink, resolved string, err error, r *Rule,
+) lint.Diagnostic {
+	return lint.Diagnostic{
+		File:     path,
+		Line:     wl.Line,
+		Column:   wl.Column,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message: fmt.Sprintf(
+			"cannot read wikilink target %q (%s): %v",
+			wl.Target, resolved, err,
+		),
+	}
 }
 
 func (r *Rule) checkLink(
@@ -214,65 +385,97 @@ func (r *Rule) checkSiteAbsoluteLink(
 // ApplySettings implements rule.Configurable.
 func (r *Rule) ApplySettings(settings map[string]any) error {
 	for k, v := range settings {
-		switch k {
-		case "include":
-			list, ok := toStringSlice(v)
-			if !ok {
-				return fmt.Errorf(
-					"cross-file-reference-integrity: include must be a list of strings, got %T",
-					v,
-				)
-			}
-			r.Include = list
-		case "exclude":
-			list, ok := toStringSlice(v)
-			if !ok {
-				return fmt.Errorf(
-					"cross-file-reference-integrity: exclude must be a list of strings, got %T",
-					v,
-				)
-			}
-			r.Exclude = list
-		case "strict":
-			b, ok := v.(bool)
-			if !ok {
-				return fmt.Errorf(
-					"cross-file-reference-integrity: strict must be a bool, got %T",
-					v,
-				)
-			}
-			r.Strict = b
-		case "placeholders":
-			toks, ok := toStringSlice(v)
-			if !ok {
-				return fmt.Errorf(
-					"cross-file-reference-integrity: placeholders must be a list of strings, got %T",
-					v,
-				)
-			}
-			if err := placeholders.Validate(toks); err != nil {
-				return fmt.Errorf("cross-file-reference-integrity: %w", err)
-			}
-			r.Placeholders = toks
-		case "links":
-			linksMap, ok := v.(map[string]any)
-			if !ok {
-				return fmt.Errorf(
-					"cross-file-reference-integrity: links must be a map, got %T",
-					v,
-				)
-			}
-			if err := r.applyLinksSettings(linksMap); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf(
-				"cross-file-reference-integrity: unknown setting %q",
-				k,
-			)
+		if err := r.applyOneSetting(k, v); err != nil {
+			return err
 		}
 	}
 	return r.validateGlobSettings()
+}
+
+func (r *Rule) applyOneSetting(key string, v any) error {
+	switch key {
+	case "include":
+		return r.applyListSetting(&r.Include, "include", v)
+	case "exclude":
+		return r.applyListSetting(&r.Exclude, "exclude", v)
+	case "strict":
+		b, ok := v.(bool)
+		if !ok {
+			return fmt.Errorf(
+				"cross-file-reference-integrity: strict must be a bool, got %T",
+				v,
+			)
+		}
+		r.Strict = b
+		return nil
+	case "placeholders":
+		toks, ok := toStringSlice(v)
+		if !ok {
+			return fmt.Errorf(
+				"cross-file-reference-integrity: placeholders must be a list of strings, got %T",
+				v,
+			)
+		}
+		if err := placeholders.Validate(toks); err != nil {
+			return fmt.Errorf("cross-file-reference-integrity: %w", err)
+		}
+		r.Placeholders = toks
+		return nil
+	case "links":
+		linksMap, ok := v.(map[string]any)
+		if !ok {
+			return fmt.Errorf(
+				"cross-file-reference-integrity: links must be a map, got %T",
+				v,
+			)
+		}
+		return r.applyLinksSettings(linksMap)
+	case "wikilinks", "wikilink-style":
+		return r.applyWikilinkSetting(key, v)
+	}
+	return fmt.Errorf("cross-file-reference-integrity: unknown setting %q", key)
+}
+
+func (r *Rule) applyListSetting(target *[]string, name string, v any) error {
+	list, ok := toStringSlice(v)
+	if !ok {
+		return fmt.Errorf(
+			"cross-file-reference-integrity: %s must be a list of strings, got %T",
+			name, v,
+		)
+	}
+	*target = list
+	return nil
+}
+
+func (r *Rule) applyWikilinkSetting(key string, v any) error {
+	switch key {
+	case "wikilinks":
+		b, ok := v.(bool)
+		if !ok {
+			return fmt.Errorf(
+				"cross-file-reference-integrity: wikilinks must be a bool, got %T",
+				v,
+			)
+		}
+		r.Wikilinks = b
+	case "wikilink-style":
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf(
+				"cross-file-reference-integrity: wikilink-style must be a string, got %T",
+				v,
+			)
+		}
+		if s != "" && s != "obsidian" {
+			return fmt.Errorf(
+				"cross-file-reference-integrity: wikilink-style %q not supported; only \"obsidian\" ships today",
+				s,
+			)
+		}
+		r.WikilinkStyle = s
+	}
+	return nil
 }
 
 func (r *Rule) applyLinksSettings(m map[string]any) error {
@@ -334,10 +537,12 @@ func (r *Rule) validateGlobSettings() error {
 // DefaultSettings implements rule.Configurable.
 func (r *Rule) DefaultSettings() map[string]any {
 	return map[string]any{
-		"include":      []string{},
-		"exclude":      []string{},
-		"strict":       false,
-		"placeholders": []string{},
+		"include":        []string{},
+		"exclude":        []string{},
+		"strict":         false,
+		"placeholders":   []string{},
+		"wikilinks":      false,
+		"wikilink-style": "obsidian",
 		"links": map[string]any{
 			"site-root":                "",
 			"validate-images":          true,

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -189,6 +189,9 @@ func (r *Rule) effectiveWikilinkStyle() string {
 // by every later host file in the same run. Returns nil when no
 // RunCache is installed (struct-literal Files in unit tests) so the
 // resolver falls back to the per-Check fs walk.
+//
+// Delegates to linkgraph.WikilinkIndexFor so MDS027 and `mdsmith
+// list backlinks` share one build/cache implementation.
 func wikilinkIndexForRoot(f *lint.File, root fs.FS) *linkgraph.WikilinkIndex {
 	if f.RunCache == nil || root == nil {
 		return nil
@@ -197,11 +200,7 @@ func wikilinkIndexForRoot(f *lint.File, root fs.FS) *linkgraph.WikilinkIndex {
 	if key == "" {
 		return nil
 	}
-	v := f.RunCache.Wikilinks(key, func() any {
-		return linkgraph.NewWikilinkIndex(root)
-	})
-	idx, _ := v.(*linkgraph.WikilinkIndex)
-	return idx
+	return linkgraph.WikilinkIndexFor(f.RunCache, key, root)
 }
 
 // wikilinkCacheKey returns the per-root cache key for the wikilink

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -121,7 +121,10 @@ func (r *Rule) checkWikilinks(
 	// otherwise), and wikilinkRoot's last fallback returns f.FS, so
 	// root is always populated here.
 	root := wikilinkRoot(f)
-	resolver := newWikilinkResolver(root, workspaceRelativeSource(f), r.effectiveWikilinkStyle())
+	resolver := newWikilinkResolver(
+		root, workspaceRelativeSource(f), r.effectiveWikilinkStyle(),
+		wikilinkIndexForRoot(f, root),
+	)
 
 	var diags []lint.Diagnostic
 	for _, wl := range linkgraph.ExtractWikiLinks(f) {
@@ -180,6 +183,41 @@ func (r *Rule) effectiveWikilinkStyle() string {
 	return r.WikilinkStyle
 }
 
+// wikilinkIndexForRoot returns a *linkgraph.WikilinkIndex cached on
+// f.RunCache, keyed by the workspace's absolute root directory. The
+// index is built lazily by the first Check that needs it and shared
+// by every later host file in the same run. Returns nil when no
+// RunCache is installed (struct-literal Files in unit tests) so the
+// resolver falls back to the per-Check fs walk.
+func wikilinkIndexForRoot(f *lint.File, root fs.FS) *linkgraph.WikilinkIndex {
+	if f.RunCache == nil || root == nil {
+		return nil
+	}
+	key := wikilinkCacheKey(f)
+	if key == "" {
+		return nil
+	}
+	v := f.RunCache.Wikilinks(key, func() any {
+		return linkgraph.NewWikilinkIndex(root)
+	})
+	idx, _ := v.(*linkgraph.WikilinkIndex)
+	return idx
+}
+
+// wikilinkCacheKey returns the per-root cache key for the wikilink
+// index. RootDir's absolute form is preferred so two host files at
+// different relative paths under the same root share one index.
+func wikilinkCacheKey(f *lint.File) string {
+	if f.RootDir == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(f.RootDir)
+	if err != nil {
+		return f.RootDir
+	}
+	return abs
+}
+
 func wikilinkRoot(f *lint.File) fs.FS {
 	if f.RootFS != nil {
 		return f.RootFS
@@ -192,10 +230,15 @@ func wikilinkRoot(f *lint.File) fs.FS {
 
 // wikilinkResolver caches workspace-walk results so a doc with many
 // references to the same target does a single fs walk per target.
+// When a per-run WikilinkIndex is available (built once and shared
+// via f.RunCache), the resolver serves every lookup from that
+// index — turning N files × M targets × workspace-walk into one
+// walk per workspace.
 type wikilinkResolver struct {
 	root   fs.FS
 	from   string
 	style  string
+	index  *linkgraph.WikilinkIndex
 	memory map[string]wikilinkResolveResult
 }
 
@@ -204,11 +247,12 @@ type wikilinkResolveResult struct {
 	ok   bool
 }
 
-func newWikilinkResolver(root fs.FS, from, style string) *wikilinkResolver {
+func newWikilinkResolver(root fs.FS, from, style string, index *linkgraph.WikilinkIndex) *wikilinkResolver {
 	return &wikilinkResolver{
 		root:   root,
 		from:   from,
 		style:  style,
+		index:  index,
 		memory: map[string]wikilinkResolveResult{},
 	}
 }
@@ -220,7 +264,11 @@ func (rv *wikilinkResolver) resolve(target string) (string, bool) {
 	var out wikilinkResolveResult
 	switch rv.style {
 	case "obsidian":
-		out.path, out.ok = linkgraph.ResolveWikiLink(rv.root, rv.from, target)
+		if rv.index != nil {
+			out.path, out.ok = rv.index.Resolve(target)
+		} else {
+			out.path, out.ok = linkgraph.ResolveWikiLink(rv.root, rv.from, target)
+		}
 	default:
 		// Settings parsing already rejects unsupported values; this
 		// branch is a defensive no-op so a manually-constructed Rule
@@ -273,10 +321,11 @@ func workspaceRelativeSource(f *lint.File) string {
 	return filepath.ToSlash(rel)
 }
 
-// wikilinkRaw renders wl back to its source form so placeholders that
-// look at the full bracket span (e.g. matching a `{var}` token in the
-// alias) can fire the same way they would for a Markdown link's raw
-// target.
+// wikilinkRaw renders wl back to its source form for diagnostic
+// messages — broken-anchor diagnostics quote the full bracket span
+// (target + #anchor + |alias) so the user can grep the source for
+// the exact token. Placeholder suppression does NOT call this; see
+// wikilinkSuppressed for the destination-only check.
 func wikilinkRaw(wl linkgraph.WikiLink) string {
 	var sb strings.Builder
 	if wl.Embed {

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -162,8 +162,15 @@ func (r *Rule) wikilinkSuppressed(wl linkgraph.WikiLink) bool {
 	if len(r.Placeholders) == 0 {
 		return false
 	}
-	return placeholders.ContainsBodyToken(wl.Target, r.Placeholders) ||
-		placeholders.ContainsBodyToken(wikilinkRaw(wl), r.Placeholders)
+	// MDS027's placeholder filter only applies to link destinations,
+	// not link text. For a wikilink the destination is target plus
+	// optional "#anchor"; the alias is display text and must not be
+	// scanned for placeholder tokens.
+	dest := wl.Target
+	if wl.Anchor != "" {
+		dest += "#" + wl.Anchor
+	}
+	return placeholders.ContainsBodyToken(dest, r.Placeholders)
 }
 
 func (r *Rule) effectiveWikilinkStyle() string {

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -108,49 +108,119 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 // project root and emits one diagnostic per unresolved target or
 // missing heading anchor. Wikilink targets pass through the same
 // placeholder filter the standard link check uses.
+//
+// Resolution is cached per (style, target) within one Check: two
+// wikilinks pointing at the same page share a single fs walk, so
+// runtime stays linear in distinct targets rather than total
+// wikilinks.
 func (r *Rule) checkWikilinks(
 	f *lint.File,
 	anchorCache map[string]map[string]bool,
 ) []lint.Diagnostic {
-	root := f.RootFS
-	if root == nil && f.RootDir != "" {
-		root = os.DirFS(f.RootDir)
-	}
-	if root == nil {
-		root = f.FS
-	}
+	root := wikilinkRoot(f)
 	if root == nil {
 		return nil
 	}
-
-	srcRel := workspaceRelativeSource(f)
+	resolver := newWikilinkResolver(root, workspaceRelativeSource(f), r.effectiveWikilinkStyle())
 
 	var diags []lint.Diagnostic
 	for _, wl := range linkgraph.ExtractWikiLinks(f) {
-		raw := wikilinkRaw(wl)
-		if placeholders.ContainsBodyToken(wl.Target, r.Placeholders) ||
-			placeholders.ContainsBodyToken(raw, r.Placeholders) {
+		if r.wikilinkSuppressed(wl) {
 			continue
 		}
-		resolved, ok := linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+		resolved, ok := resolver.resolve(wl.Target)
 		if !ok {
 			diags = append(diags, wikilinkBrokenTargetDiag(f.Path, wl, r))
 			continue
 		}
-		if wl.Anchor == "" || !isMarkdownPath(resolved) {
-			continue
-		}
-		anchors, err := wikilinkAnchorsForTarget(f, root, resolved, anchorCache)
-		if err != nil {
-			diags = append(diags, wikilinkUnreadableTargetDiag(f.Path, wl, resolved, err, r))
-			continue
-		}
-		if anchors[linkgraph.NormalizeAnchor(wl.Anchor)] {
-			continue
-		}
-		diags = append(diags, wikilinkBrokenAnchorDiag(f.Path, wl, resolved, r))
+		diags = append(diags, r.checkWikilinkAnchor(f, wl, resolved, root, anchorCache)...)
 	}
 	return diags
+}
+
+func (r *Rule) checkWikilinkAnchor(
+	f *lint.File,
+	wl linkgraph.WikiLink,
+	resolved string,
+	root fs.FS,
+	anchorCache map[string]map[string]bool,
+) []lint.Diagnostic {
+	if wl.Anchor == "" || !isMarkdownPath(resolved) {
+		return nil
+	}
+	anchors, err := wikilinkAnchorsForTarget(f, root, resolved, anchorCache)
+	if err != nil {
+		return []lint.Diagnostic{wikilinkUnreadableTargetDiag(f.Path, wl, resolved, err, r)}
+	}
+	if anchors[linkgraph.NormalizeAnchor(wl.Anchor)] {
+		return nil
+	}
+	return []lint.Diagnostic{wikilinkBrokenAnchorDiag(f.Path, wl, resolved, r)}
+}
+
+func (r *Rule) wikilinkSuppressed(wl linkgraph.WikiLink) bool {
+	if len(r.Placeholders) == 0 {
+		return false
+	}
+	return placeholders.ContainsBodyToken(wl.Target, r.Placeholders) ||
+		placeholders.ContainsBodyToken(wikilinkRaw(wl), r.Placeholders)
+}
+
+func (r *Rule) effectiveWikilinkStyle() string {
+	if r.WikilinkStyle == "" {
+		return "obsidian"
+	}
+	return r.WikilinkStyle
+}
+
+func wikilinkRoot(f *lint.File) fs.FS {
+	if f.RootFS != nil {
+		return f.RootFS
+	}
+	if f.RootDir != "" {
+		return os.DirFS(f.RootDir)
+	}
+	return f.FS
+}
+
+// wikilinkResolver caches workspace-walk results so a doc with many
+// references to the same target does a single fs walk per target.
+type wikilinkResolver struct {
+	root   fs.FS
+	from   string
+	style  string
+	memory map[string]wikilinkResolveResult
+}
+
+type wikilinkResolveResult struct {
+	path string
+	ok   bool
+}
+
+func newWikilinkResolver(root fs.FS, from, style string) *wikilinkResolver {
+	return &wikilinkResolver{
+		root:   root,
+		from:   from,
+		style:  style,
+		memory: map[string]wikilinkResolveResult{},
+	}
+}
+
+func (rv *wikilinkResolver) resolve(target string) (string, bool) {
+	if cached, ok := rv.memory[target]; ok {
+		return cached.path, cached.ok
+	}
+	var out wikilinkResolveResult
+	switch rv.style {
+	case "obsidian":
+		out.path, out.ok = linkgraph.ResolveWikiLink(rv.root, rv.from, target)
+	default:
+		// Settings parsing already rejects unsupported values; this
+		// branch is a defensive no-op so a manually-constructed Rule
+		// with a non-empty unknown style cannot silently fall back.
+	}
+	rv.memory[target] = out
+	return out.path, out.ok
 }
 
 // wikilinkAnchorsForTarget memoizes anchor lookup per workspace-relative

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -302,23 +302,30 @@ func wikilinkAnchorsForTarget(
 }
 
 // workspaceRelativeSource returns f.Path expressed relative to its
-// project root, using forward slashes. When the path cannot be made
-// relative (e.g. a struct-literal test File without RootDir) it
-// returns the original path with separators normalised.
+// project root, using forward slashes. The LSP and the CLI hand the
+// rule different shapes of f.Path — the CLI walks files by their
+// absolute path, the LSP threads the workspace-relative form — so
+// the helper has to anchor a relative f.Path to RootDir before
+// re-relativising, or filepath.Abs would land it under the process
+// cwd instead.
 //
-// filepath.Abs only errors when os.Getwd() fails; filepath.Rel only
-// errors when the two paths cannot share a base (cross-volume on
-// Windows, otherwise impossible here because both arguments are
-// made absolute first). Real workspaces under one RootDir do not
-// hit either branch; the discarded errors degrade gracefully to a
-// best-effort path on the rare cases that do.
+// When the path cannot be made relative (a struct-literal test
+// File without RootDir, or a cross-volume pair on Windows) it
+// returns the original path with separators normalised.
 func workspaceRelativeSource(f *lint.File) string {
 	if f.RootDir == "" {
 		return filepath.ToSlash(f.Path)
 	}
-	abs, _ := filepath.Abs(f.Path)        //nolint:errcheck
+	sourcePath := f.Path
+	if !filepath.IsAbs(sourcePath) {
+		sourcePath = filepath.Join(f.RootDir, sourcePath)
+	}
+	abs, _ := filepath.Abs(sourcePath)    //nolint:errcheck
 	absRoot, _ := filepath.Abs(f.RootDir) //nolint:errcheck
-	rel, _ := filepath.Rel(absRoot, abs)  //nolint:errcheck
+	rel, err := filepath.Rel(absRoot, abs)
+	if err != nil {
+		return filepath.ToSlash(f.Path)
+	}
 	return filepath.ToSlash(rel)
 }
 

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -207,14 +207,15 @@ func wikilinkIndexForRoot(f *lint.File, root fs.FS) *linkgraph.WikilinkIndex {
 // wikilinkCacheKey returns the per-root cache key for the wikilink
 // index. RootDir's absolute form is preferred so two host files at
 // different relative paths under the same root share one index.
+//
+// filepath.Abs only errors when os.Getwd fails — an OS-level
+// catastrophe the rest of the linter does not survive either —
+// so the rare error is swallowed in favour of the raw RootDir.
 func wikilinkCacheKey(f *lint.File) string {
 	if f.RootDir == "" {
 		return ""
 	}
-	abs, err := filepath.Abs(f.RootDir)
-	if err != nil {
-		return f.RootDir
-	}
+	abs, _ := filepath.Abs(f.RootDir) //nolint:errcheck
 	return abs
 }
 

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1238,6 +1238,107 @@ func newLintFileWithRoot(t *testing.T, path, root string) *lint.File {
 	return f
 }
 
+func TestWikilinkRaw_Variants(t *testing.T) {
+	cases := map[string]struct {
+		wl   linkgraph.WikiLink
+		want string
+	}{
+		"bare":         {linkgraph.WikiLink{Target: "Page"}, "[[Page]]"},
+		"anchor":       {linkgraph.WikiLink{Target: "Page", Anchor: "Sec"}, "[[Page#Sec]]"},
+		"alias":        {linkgraph.WikiLink{Target: "Page", Alias: "X"}, "[[Page|X]]"},
+		"embed":        {linkgraph.WikiLink{Target: "img.png", Embed: true}, "![[img.png]]"},
+		"anchor+alias": {linkgraph.WikiLink{Target: "Page", Anchor: "S", Alias: "X"}, "[[Page#S|X]]"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, wikilinkRaw(tc.wl))
+		})
+	}
+}
+
+func TestEffectiveWikilinkStyle(t *testing.T) {
+	assert.Equal(t, "obsidian", (&Rule{}).effectiveWikilinkStyle())
+	assert.Equal(t, "obsidian", (&Rule{WikilinkStyle: "obsidian"}).effectiveWikilinkStyle())
+	// Set non-default via direct field write — ApplySettings rejects
+	// unknown values, but the helper must still mirror whatever is
+	// configured.
+	assert.Equal(t, "custom", (&Rule{WikilinkStyle: "custom"}).effectiveWikilinkStyle())
+}
+
+func TestWikilinkRoot_Fallbacks(t *testing.T) {
+	dir := t.TempDir()
+	f := &lint.File{}
+	assert.Nil(t, wikilinkRoot(f))
+
+	f.RootDir = dir
+	require.NotNil(t, wikilinkRoot(f))
+
+	mfs := os.DirFS(dir)
+	f.RootFS = mfs
+	assert.Equal(t, fs.FS(mfs), wikilinkRoot(f))
+
+	f.RootFS = nil
+	f.RootDir = ""
+	f.FS = mfs
+	assert.Equal(t, fs.FS(mfs), wikilinkRoot(f))
+}
+
+func TestCheck_Wikilinks_RootMissing(t *testing.T) {
+	// f.FS is nil → the rule short-circuits before calling
+	// checkWikilinks; verify the top-level Check has the early return.
+	f := &lint.File{Source: []byte("[[X]]\n")}
+	diags := (&Rule{Wikilinks: true}).Check(f)
+	assert.Nil(t, diags)
+}
+
+func TestResolver_UnknownStyleNoop(t *testing.T) {
+	// A Rule constructed with an unknown style bypasses ApplySettings'
+	// validation. The resolver must treat it as "no resolution" rather
+	// than silently falling back to the Obsidian algorithm.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "page.md"), []byte{}, 0o644))
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\n[[page]]\n")
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true, WikilinkStyle: "foam-not-supported"}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	require.Contains(t, diags[0].Message, "not found in workspace")
+}
+
+func TestCheck_Wikilinks_UnreadableTarget(t *testing.T) {
+	// MaxInputBytes set to a value below the target file's size makes
+	// the anchor read fail; the rule must surface a unreadable-target
+	// diagnostic rather than crash.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.md"),
+		[]byte("# Notes\n\n## A\n## B\n## C\n"), 0o644))
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\n[[Notes#A]]\n")
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	f.MaxInputBytes = 5
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "cannot read wikilink target")
+}
+
+func TestWikilinkAnchorsForTarget_CacheHit(t *testing.T) {
+	cache := map[string]map[string]bool{
+		"wikilink:notes.md": {"x": true},
+	}
+	f := &lint.File{}
+	got, err := wikilinkAnchorsForTarget(f, nil, "notes.md", cache)
+	require.NoError(t, err)
+	assert.True(t, got["x"])
+}
+
+func TestWorkspaceRelativeSource_NoRootDir(t *testing.T) {
+	f := &lint.File{Path: "/abs/path/doc.md"}
+	got := workspaceRelativeSource(f)
+	assert.Equal(t, "/abs/path/doc.md", got)
+}
+
 func TestCheck_Wikilinks_ResolutionCachedPerTarget(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "page.md"), []byte("# P\n"), 0o644))

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1228,6 +1228,13 @@ func TestApplySettings_WikilinkStyle(t *testing.T) {
 	err := r.ApplySettings(map[string]any{"wikilink-style": "foam"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not supported")
+
+	// Non-string types are rejected before the value check runs;
+	// reaching the "must be a string" branch keeps the error
+	// taxonomy honest.
+	err = r.ApplySettings(map[string]any{"wikilink-style": 123})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be a string")
 }
 
 func newLintFileWithRoot(t *testing.T, path, root string) *lint.File {

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1092,3 +1092,147 @@ func TestDefaultSettings_Links(t *testing.T) {
 	require.Equal(t, true, links["validate-images"])
 	require.Equal(t, true, links["validate-reference-style"])
 }
+
+func TestDefaultSettings_Wikilinks(t *testing.T) {
+	ds := (&Rule{}).DefaultSettings()
+	require.Equal(t, false, ds["wikilinks"])
+	require.Equal(t, "obsidian", ds["wikilink-style"])
+}
+
+func TestCheck_Wikilinks_DisabledByDefault(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Missing]].\n")
+
+	f := newLintFile(t, sourcePath)
+	diags := (&Rule{}).Check(f)
+	require.Empty(t, diags, "wikilinks must not be flagged when wikilinks=false")
+}
+
+func TestCheck_Wikilinks_UnresolvedTarget(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Missing Page]].\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	require.Contains(t, diags[0].Message, "Missing Page")
+	require.Contains(t, diags[0].Message, "not found in workspace")
+}
+
+func TestCheck_Wikilinks_ResolvedTarget(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, filepath.Join(dir, "present.md"), "# Present\n")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Present]].\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Empty(t, diags, "wikilinks to existing files must not be flagged")
+}
+
+func TestCheck_Wikilinks_BrokenAnchor(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, filepath.Join(dir, "notes.md"), "# Notes\n\n## Current Heading\n")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Notes#Old Heading]].\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	require.Contains(t, diags[0].Message, "Old Heading")
+	require.Contains(t, diags[0].Message, "notes.md")
+}
+
+func TestCheck_Wikilinks_ResolvedAnchor(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, filepath.Join(dir, "notes.md"), "# Notes\n\n## Existing\n")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Notes#Existing]].\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Empty(t, diags, "matching wikilink anchors must not be flagged")
+}
+
+func TestCheck_Wikilinks_AliasIgnoredForResolution(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, filepath.Join(dir, "page.md"), "# Page\n")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Page|Alias]].\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Empty(t, diags, "alias must not affect resolution of the target stem")
+}
+
+func TestCheck_Wikilinks_EmbedAnyFileType(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "image.png"), []byte("\x89PNG\r\n"), 0o644))
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\nLook ![[image.png]].\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Empty(t, diags, "embed must resolve any extension")
+}
+
+func TestCheck_Wikilinks_PlaceholderSuppresses(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[{topic}]] for context.\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{
+		Wikilinks:    true,
+		Placeholders: []string{"var-token"},
+	}
+	diags := r.Check(f)
+	require.Empty(t, diags, "placeholder targets must be skipped")
+}
+
+func TestCheck_Wikilinks_CodeBlockSkipped(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\n```\n[[Missing]]\n```\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Empty(t, diags, "wikilinks inside fenced code must not be flagged")
+}
+
+func TestApplySettings_Wikilinks(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"wikilinks": true}))
+	require.True(t, r.Wikilinks)
+
+	err := r.ApplySettings(map[string]any{"wikilinks": "yes"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wikilinks must be a bool")
+}
+
+func TestApplySettings_WikilinkStyle(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"wikilink-style": "obsidian"}))
+	require.Equal(t, "obsidian", r.WikilinkStyle)
+
+	err := r.ApplySettings(map[string]any{"wikilink-style": "foam"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
+}
+
+func newLintFileWithRoot(t *testing.T, path, root string) *lint.File {
+	t.Helper()
+	f := newLintFile(t, path)
+	f.RootDir = root
+	f.RootFS = os.DirFS(root)
+	return f
+}

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1335,7 +1335,7 @@ func TestResolver_UnknownStyleNoop(t *testing.T) {
 
 func TestCheck_Wikilinks_UnreadableTarget(t *testing.T) {
 	// MaxInputBytes set to a value below the target file's size makes
-	// the anchor read fail; the rule must surface a unreadable-target
+	// the anchor read fail; the rule must surface an unreadable-target
 	// diagnostic rather than crash.
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.md"),

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1444,6 +1444,34 @@ func TestWorkspaceRelativeSource_NoRootDir(t *testing.T) {
 	assert.Equal(t, "/abs/path/doc.md", got)
 }
 
+func TestWorkspaceRelativeSource_RelativePathAnchoredToRoot(t *testing.T) {
+	// The LSP passes workspace-relative f.Path values (e.g.
+	// "docs/notes.md"). Without explicit anchoring, filepath.Abs
+	// would join against the process cwd — producing a path
+	// outside RootDir that filepath.Rel would either reject or
+	// turn into "../../<cwd>/docs/notes.md". The helper anchors
+	// to RootDir first so the returned value is always the
+	// expected workspace-relative form.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs"), 0o755))
+	f := &lint.File{Path: "docs/notes.md", RootDir: dir}
+	got := workspaceRelativeSource(f)
+	assert.Equal(t, "docs/notes.md", got)
+}
+
+func TestWorkspaceRelativeSource_AbsolutePathUnderRoot(t *testing.T) {
+	// CLI callers pass absolute paths. Those must collapse to
+	// the workspace-relative form too.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs"), 0o755))
+	f := &lint.File{
+		Path:    filepath.Join(dir, "docs", "notes.md"),
+		RootDir: dir,
+	}
+	got := workspaceRelativeSource(f)
+	assert.Equal(t, "docs/notes.md", got)
+}
+
 func TestCheck_Wikilinks_ResolutionCachedPerTarget(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "page.md"), []byte("# P\n"), 0o644))

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1199,6 +1199,26 @@ func TestCheck_Wikilinks_PlaceholderSuppresses(t *testing.T) {
 	require.Empty(t, diags, "placeholder targets must be skipped")
 }
 
+func TestCheck_Wikilinks_PlaceholderInAliasDoesNotSuppress(t *testing.T) {
+	// MDS027's placeholder filter applies to link destinations, not
+	// link text. A wikilink whose alias contains a placeholder must
+	// still resolve the underlying target — a missing target stays
+	// a diagnostic. Mirrors the standard-link behaviour where only
+	// the URL half is checked for placeholder tokens.
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[MissingPage|{topic}]] alias.\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{
+		Wikilinks:    true,
+		Placeholders: []string{"var-token"},
+	}
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "alias-only placeholder must not mask a missing target")
+	require.Contains(t, diags[0].Message, "MissingPage")
+}
+
 func TestCheck_Wikilinks_CodeBlockSkipped(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "doc.md")

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1226,6 +1226,33 @@ func TestCheck_Wikilinks_RunCacheSharedIndex(t *testing.T) {
 	}
 }
 
+func TestWikilinkIndexForRoot_EmptyKeyReturnsNil(t *testing.T) {
+	// A file with RootFS set but RootDir empty hits the
+	// wikilinkCacheKey == "" branch and short-circuits without
+	// touching the RunCache. The resolver then falls back to the
+	// per-Check walk.
+	dir := t.TempDir()
+	f := &lint.File{
+		RootFS:   os.DirFS(dir),
+		RunCache: lint.NewRunCache(),
+	}
+	got := wikilinkIndexForRoot(f, f.RootFS)
+	assert.Nil(t, got)
+}
+
+func TestWikilinkIndexForRoot_NilRunCacheReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	f := &lint.File{RootDir: dir, RootFS: os.DirFS(dir)}
+	assert.Nil(t, wikilinkIndexForRoot(f, f.RootFS),
+		"no RunCache → no per-run index")
+}
+
+func TestWikilinkIndexForRoot_NilRootReturnsNil(t *testing.T) {
+	f := &lint.File{RootDir: "/tmp/x", RunCache: lint.NewRunCache()}
+	assert.Nil(t, wikilinkIndexForRoot(f, nil),
+		"nil root → no per-run index")
+}
+
 func TestWikilinkCacheKey_FallbackOnUnknownDir(t *testing.T) {
 	// filepath.Abs only errors when os.Getwd fails — unreachable in
 	// the test harness — so this asserts the empty-RootDir branch

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -2,6 +2,7 @@ package crossfilereferenceintegrity
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1235,4 +1236,45 @@ func newLintFileWithRoot(t *testing.T, path, root string) *lint.File {
 	f.RootDir = root
 	f.RootFS = os.DirFS(root)
 	return f
+}
+
+func TestCheck_Wikilinks_ResolutionCachedPerTarget(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "page.md"), []byte("# P\n"), 0o644))
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\n[[page]] [[page]] [[page]] [[page]] [[page]]\n")
+
+	counting := &walkCountingFS{inner: os.DirFS(dir)}
+
+	f := newLintFile(t, sourcePath)
+	f.RootDir = dir
+	f.RootFS = counting
+
+	r := &Rule{Wikilinks: true}
+	diags := r.Check(f)
+	require.Empty(t, diags)
+	// One workspace walk does an Open(".") for Stat and again for the
+	// recursion entry — two opens per walk. Five identical wikilinks
+	// without caching would walk five times (10 opens); with the cache
+	// they collapse to one walk (≤ 2 opens). Bound by the no-cache
+	// floor to prove the cache is consulted.
+	require.LessOrEqual(t, counting.rootOpens, 2,
+		"resolver must memoize per target; got %d Open(\".\") calls", counting.rootOpens)
+}
+
+// walkCountingFS wraps an fs.FS and tallies Open(".") calls — the
+// entry point fs.WalkDir uses for the root. Each ResolveWikiLink call
+// triggers exactly two such opens (one for Stat, one for the walk).
+// The test below uses this to prove the per-target cache reduces N
+// repeated wikilinks down to a single walk.
+type walkCountingFS struct {
+	inner     fs.FS
+	rootOpens int
+}
+
+func (w *walkCountingFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		w.rootOpens++
+	}
+	return w.inner.Open(name)
 }

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1185,6 +1185,57 @@ func TestCheck_Wikilinks_EmbedAnyFileType(t *testing.T) {
 	require.Empty(t, diags, "embed must resolve any extension")
 }
 
+func TestCheck_Wikilinks_PlaceholderAppliesToAnchor(t *testing.T) {
+	// wikilinkSuppressed builds "target#anchor" before testing the
+	// placeholder set, so a placeholder hit in the anchor must
+	// suppress the diagnostic the same way a hit in the target
+	// would. Covers the `wl.Anchor != ""` branch of the helper.
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "doc.md")
+	writeFile(t, sourcePath, "# Doc\n\nSee [[Page#{topic}]] there.\n")
+
+	f := newLintFileWithRoot(t, sourcePath, dir)
+	r := &Rule{Wikilinks: true, Placeholders: []string{"var-token"}}
+	diags := r.Check(f)
+	require.Empty(t, diags, "placeholder anchor must suppress the diagnostic")
+}
+
+func TestCheck_Wikilinks_RunCacheSharedIndex(t *testing.T) {
+	// f.RunCache makes wikilinkIndexForRoot build a shared
+	// WikilinkIndex; the resolver then takes the index branch
+	// instead of per-call fs.WalkDir. Asserting "two Check calls
+	// on different host files emit the same diagnostic" exercises
+	// wikilinkIndexForRoot, wikilinkCacheKey, and the index path
+	// in the resolver.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "present.md"), []byte("# P\n"), 0o644))
+	docA := filepath.Join(dir, "a.md")
+	docB := filepath.Join(dir, "b.md")
+	writeFile(t, docA, "# A\n\n[[present]] [[missing]]\n")
+	writeFile(t, docB, "# B\n\n[[present]] [[missing]]\n")
+
+	cache := lint.NewRunCache()
+	r := &Rule{Wikilinks: true}
+
+	for _, p := range []string{docA, docB} {
+		f := newLintFileWithRoot(t, p, dir)
+		f.RunCache = cache
+		diags := r.Check(f)
+		require.Len(t, diags, 1, "missing wikilink must surface once per host file")
+		require.Contains(t, diags[0].Message, "missing")
+	}
+}
+
+func TestWikilinkCacheKey_FallbackOnUnknownDir(t *testing.T) {
+	// filepath.Abs only errors when os.Getwd fails — unreachable in
+	// the test harness — so this asserts the empty-RootDir branch
+	// and the happy path. The error fallback stays defensive code.
+	assert.Equal(t, "", wikilinkCacheKey(&lint.File{}))
+	dir := t.TempDir()
+	got := wikilinkCacheKey(&lint.File{RootDir: dir})
+	assert.NotEmpty(t, got, "RootDir must produce a non-empty cache key")
+}
+
 func TestCheck_Wikilinks_PlaceholderSuppresses(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "doc.md")

--- a/internal/rules/index.md
+++ b/internal/rules/index.md
@@ -83,6 +83,7 @@ row: "| [{id}]({filename}) | `{name}` | {category} | {status} | {description} |"
 | [MDS062](MDS062-link-validity/README.md)                      | `link-validity`                      | link          | ready     | Links must not use the reversed `(text)[url]` form, and every link or image must have a non-empty destination; a link must also have visible text. |
 | [MDS063](MDS063-descriptive-link-text/README.md)              | `descriptive-link-text`              | prose         | ready     | Link text must be descriptive. Non-descriptive phrases like "click here", "here", "link", and "more" fail screen readers and link-list navigation. |
 | [MDS064](MDS064-atx-heading-whitespace/README.md)             | `atx-heading-whitespace`             | heading       | ready     | ATX heading whitespace and indentation.                                                                                                            |
+| [MDS067](MDS067-callout-type/README.md)                       | `callout-type`                       | structural    | ready     | Validate Obsidian callout types against an allowed set.                                                                                            |
 <?/catalog?>
 
 ## Directive rules

--- a/plan/168_obsidian-markdown-support.md
+++ b/plan/168_obsidian-markdown-support.md
@@ -1,7 +1,7 @@
 ---
 id: 168
 title: Obsidian Flavored Markdown support
-status: "🔲"
+status: "✅"
 summary: >-
   Add an `obsidian` convention that validates wikilinks
   (`[[Page]]`) via extended MDS027 settings, checks callout
@@ -242,35 +242,36 @@ comparison table rows for wikilinks and callouts change from
 
 ## Acceptance Criteria
 
-- [ ] `[[Missing]]` with `wikilinks: true` emits one
+- [x] `[[Missing]]` with `wikilinks: true` emits one
       diagnostic naming the unresolved target.
-- [ ] `[[Present]]` where `present.md` exists emits no
+- [x] `[[Present]]` where `present.md` exists emits no
       diagnostic.
-- [ ] `[[Notes#Old Heading]]` with a missing anchor emits
+- [x] `[[Notes#Old Heading]]` with a missing anchor emits
       one anchor-not-found diagnostic.
-- [ ] `[[Page|Alias]]` resolves `Page`, not `Alias`.
-- [ ] `![[image.png]]` resolves as an embed (any file type).
-- [ ] Wikilinks inside fenced code, code spans, and PI
+- [x] `[[Page|Alias]]` resolves `Page`, not `Alias`.
+- [x] `![[image.png]]` resolves as an embed (any file type).
+- [x] Wikilinks inside fenced code, code spans, and PI
       blocks are never flagged.
-- [ ] A wikilink target in `placeholders` is never flagged.
-- [ ] `wikilinks: false` (default) emits no wikilink
+- [x] A wikilink target in `placeholders` is never flagged.
+- [x] `wikilinks: false` (default) emits no wikilink
       diagnostics.
-- [ ] `> [!note]` (and all 13 base types + aliases)
-      emits no diagnostic from MDS067 with default settings.
-- [ ] `> [!REVIEW]` (unknown type) emits one diagnostic
+- [x] `> [!note]` (and all 12 base types + aliases listed
+      in this plan) emits no diagnostic from MDS067 with
+      default settings.
+- [x] `> [!REVIEW]` (unknown type) emits one diagnostic
       naming the type and listing valid options.
-- [ ] `> [!custom]` with `allow: [custom]` emits no
+- [x] `> [!custom]` with `allow: [custom]` emits no
       diagnostic.
-- [ ] `> [!anything]` with `allow-unknown: true` emits no
+- [x] `> [!anything]` with `allow-unknown: true` emits no
       diagnostic.
-- [ ] MDS067 is disabled by default.
-- [ ] `convention: obsidian` activates both rules with no
+- [x] MDS067 is disabled by default.
+- [x] `convention: obsidian` activates both rules with no
       other config.
-- [ ] `mdsmith list backlinks docs/page.md` lists files
+- [x] `mdsmith list backlinks docs/page.md` lists files
       with `[[page]]` wikilinks pointing at `page.md`.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
-- [ ] `mdsmith check .` passes on the repo.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues
+- [x] `mdsmith check .` passes on the repo.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

Implements [plan 168](plan/168_obsidian-markdown-support.md) — three new pieces of Obsidian-Flavored Markdown support:

- **Wikilink validation.** `internal/linkgraph/wikilinks.go` extracts `[[Page]]`, `[[Page#anchor]]`, `[[Page|alias]]`, and `[[file.png]]` from source, skipping code spans / fenced code / PI markers (same guards as MDS054). `ResolveWikiLink` walks the workspace `fs.FS` and returns the shortest-path match by stem (case-insensitive); ties break alphabetically. Targets that try to escape root are rejected.
- **MDS027 extension.** New `wikilinks` (bool, default `false`) and `wikilink-style` (`"obsidian"` only) settings on `cross-file-reference-integrity`. When `wikilinks: true`, MDS027 emits one diagnostic per unresolved target, missing heading anchor, or unreadable target. The existing `placeholders` filter applies to wikilink targets.
- **MDS067 `callout-type`.** New rule (disabled by default) that walks blockquote nodes and flags `[!type]` tokens not in the 12 base Obsidian types and their aliases. `allow:` adds custom types (append-merged across config layers); `allow-unknown: true` disables validation.
- **`obsidian` convention.** One new built-in: GFM flavor plus the two rule presets above.
- **`mdsmith list backlinks`.** Now extracts wikilinks unconditionally; records carry `kind: "wikilink"` in JSON and render as `[[target]]` / `[[target|alias]]` in text.
- **Docs.** `docs/reference/conventions.md` gains an `obsidian` section; `docs/background/markdown-linters.md` updates the Obsidian comparison table to cite MDS027 and MDS067.

Every acceptance criterion in the plan is checked off.

## Test plan

- [x] `go test ./...` — all packages pass, including new `linkgraph/wikilinks_test.go`, `callouttype/rule_test.go`, wikilink tests on MDS027, wikilink-backlinks tests on the CLI, and the `obsidian` convention test.
- [x] `go tool golangci-lint run` — 0 issues.
- [x] `go run ./cmd/mdsmith check .` — 0 failures.
- [x] Fixture coverage: `MDS027-cross-file-reference-integrity/{good/wikilink-resolved.md, bad/wikilink-missing.md}` and `MDS067-callout-type/{good/default.md, good/allow-unknown.md, good/allow-list.md, bad/unknown.md}` exercised by the integration `TestRuleFixtures` harness.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCKZhXDspDU4ucPxfhtsXJ)_