### PR TITLE
Gate broken-link checks to PRs via build-content job

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -86,11 +86,15 @@ jobs:
     # docs/, then run `mdsmith check` against it with the
     # build-output config (link integrity on, style rules off).
     # Catches broken-link regressions on PR rather than only on
-    # the post-merge deploy. The deploy job re-runs the same
-    # sync and lint inside its own steps as a safety net (a
-    # workflow_dispatch from a maintainer hits deploy directly,
-    # and the second pass also covers the version-stamp +
-    # site-assets pulls that PRs skip).
+    # the post-merge deploy. deploy `needs: build-content`, so
+    # push / workflow_dispatch / workflow_call runs all gate on
+    # this lint before publishing.
+    #
+    # deploy re-runs the same sync and lint after the
+    # version-stamp + site-assets pulls (which mutate docs/
+    # before the second sync), so the deploy's second pass
+    # also covers anything those steps could break — work that
+    # build-content deliberately skips on PR.
     #
     # No Pages permissions — this job never touches the Pages
     # API; deploy carries those separately.
@@ -232,11 +236,13 @@ jobs:
         # we publish. --no-gitignore is needed because
         # website/content/docs/ is .gitignore'd. See
         # website/build-output.mdsmith.yml for the rule set and
-        # the rationale for each disabled rule. Re-runs here as a
-        # safety net (build-content already gated PR merges on
-        # this same check, but a workflow_dispatch deploy from a
-        # branch other than main can reach this job without going
-        # through build-content's needs chain).
+        # the rationale for each disabled rule. Re-runs here as
+        # defense-in-depth: build-content already ran the same
+        # check, but deploy's own sync above happens AFTER the
+        # version-stamp and `mdsmith fix
+        # docs/background/markdown-linters.md` steps that mutate
+        # the docs/ tree, so this pass is the only one that
+        # covers the post-mutation result.
         run: |
           go run ./cmd/mdsmith check \
             --config ./website/build-output.mdsmith.yml \

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,13 +70,6 @@ on:
 permissions:
   contents: read
 
-# Serialize deploys so two runs cannot race the Pages API. Do not
-# cancel an in-flight deploy: a half-applied Pages publish would
-# leave the live site inconsistent.
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   mdsmith-check:
     uses: ./.github/workflows/mdsmith-check.yml
@@ -147,6 +140,15 @@ jobs:
     # above is the only thing the PR sees.
     if: github.repository == 'jeduden/mdsmith' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Serialize deploys so two runs cannot race the Pages API.
+    # cancel-in-progress: false because a half-applied Pages
+    # publish would leave the live site inconsistent. Scoped to
+    # this job (not the whole workflow) so PR runs of
+    # build-content, which never touch the Pages API, don't queue
+    # behind an in-flight deploy or behind each other.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,12 @@ name: Deploy mdsmith.dev
 # passing the release version so the published site shows it. The
 # site is pure HTML built from docs/**/*.md and the homepage data
 # files, so it never needs the registry-publish credentials.
+#
+# The `build-content` job (synced-tree lint) runs on push to main
+# AND on every pull_request that touches the same paths, so a
+# broken-link regression fails the PR rather than only surfacing
+# after merge. The `deploy` job is gated to main, so PR runs stop
+# at the lint and never publish.
 on:
   push:
     branches: [main]
@@ -28,6 +34,19 @@ on:
       # workflow only ran on docs/website edits, so trigger
       # the deploy (which runs the synced-tree lint) on any
       # change to the generator too.
+      - "cmd/mdsmith-release/**"
+      - "internal/release/**"
+      - ".github/workflows/pages.yml"
+  # Run the synced-tree lint on every PR that touches a path that
+  # could break it. The deploy job is main-only (see its `if:`
+  # guard) so PRs stop at the lint and never publish.
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "website/**"
+      - "internal/rules/index.md"
+      - "internal/rules/MDS*/**"
       - "cmd/mdsmith-release/**"
       - "internal/release/**"
       - ".github/workflows/pages.yml"
@@ -62,9 +81,57 @@ jobs:
   mdsmith-check:
     uses: ./.github/workflows/mdsmith-check.yml
 
+  build-content:
+    # The synced-tree lint: build the Hugo content tree from
+    # docs/, then run `mdsmith check` against it with the
+    # build-output config (link integrity on, style rules off).
+    # Catches broken-link regressions on PR rather than only on
+    # the post-merge deploy. The deploy job re-runs the same
+    # sync and lint inside its own steps as a safety net (a
+    # workflow_dispatch from a maintainer hits deploy directly,
+    # and the second pass also covers the version-stamp +
+    # site-assets pulls that PRs skip).
+    #
+    # No Pages permissions — this job never touches the Pages
+    # API; deploy carries those separately.
+    name: Build and lint website content tree
+    needs: mdsmith-check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Build Hugo content tree from docs
+        # Snapshot ./docs into ./website/content/docs with the
+        # docs→Hugo transforms (proto.md drop, index.md →
+        # _index.md rename, link rewrites, shortcode escape).
+        # --no-fix because docs/ is already lint-clean on main
+        # (the check workflow gates that) and PRs must not have
+        # CI mutate the tree.
+        run: go run ./cmd/mdsmith-release build-website --no-fix ./docs ./website/content/docs
+      - name: Lint built docs tree for broken links
+        # The cross-file-reference-integrity rule (MDS027) runs
+        # over the synced tree so any post-sync broken link or
+        # missing anchor fails CI before merge. --no-gitignore
+        # is needed because website/content/docs/ is
+        # .gitignore'd. See website/build-output.mdsmith.yml
+        # for the rule set and the rationale for each disabled
+        # rule.
+        run: |
+          go run ./cmd/mdsmith check \
+            --config ./website/build-output.mdsmith.yml \
+            --no-gitignore \
+            ./website/content/docs
+
   deploy:
     name: Deploy mdsmith.dev to GitHub Pages
-    needs: mdsmith-check
+    needs: build-content
     # Guard fork clones and stray refs: only the canonical repo
     # deploys, and only from `main`. workflow_dispatch lets a
     # maintainer select any branch in the Run-workflow UI; without
@@ -72,6 +139,8 @@ jobs:
     # that branch's content to production. push is already main-only
     # and the release-driven workflow_call runs from `main` (the
     # `release` environment restricts release dispatches to it).
+    # pull_request runs are silently skipped here so the lint job
+    # above is the only thing the PR sees.
     if: github.repository == 'jeduden/mdsmith' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -163,7 +232,11 @@ jobs:
         # we publish. --no-gitignore is needed because
         # website/content/docs/ is .gitignore'd. See
         # website/build-output.mdsmith.yml for the rule set and
-        # the rationale for each disabled rule.
+        # the rationale for each disabled rule. Re-runs here as a
+        # safety net (build-content already gated PR merges on
+        # this same check, but a workflow_dispatch deploy from a
+        # branch other than main can reach this job without going
+        # through build-content's needs chain).
         run: |
           go run ./cmd/mdsmith check \
             --config ./website/build-output.mdsmith.yml \

--- a/internal/release/syncdocs_test.go
+++ b/internal/release/syncdocs_test.go
@@ -739,9 +739,10 @@ func TestTransformMarkdown_RewritesNonPublishedLinks(t *testing.T) {
 // section's _index.md at the directory URL (no filename), so a
 // relative `<path>/index.md` link in a docs body must be
 // rewritten to `<path>/` to render correctly on the site. The
-// anchor passes through; a bare `index.md` with no parent
-// directory is left alone because the resulting empty target
-// would be ambiguous.
+// anchor passes through; a bare `index.md` (a sibling reference
+// from another page in the same directory) becomes `./` so the
+// stripped target stays a directory reference instead of
+// collapsing to a same-file `#anchor`.
 func TestTransformMarkdown_DropsIndexMdFilename(t *testing.T) {
 	runTransformCases(t, []transformCase{
 		{
@@ -755,9 +756,14 @@ func TestTransformMarkdown_DropsIndexMdFilename(t *testing.T) {
 			want: "See [x](architecture/#section).\n",
 		},
 		{
-			name: "bare index.md with no parent dir is unchanged",
+			name: "bare index.md with no parent dir becomes ./",
 			in:   "See [x](index.md).\n",
-			want: "See [x](index.md).\n",
+			want: "See [x](./).\n",
+		},
+		{
+			name: "bare index.md with anchor becomes ./#anchor",
+			in:   "See [x](index.md#section).\n",
+			want: "See [x](./#section).\n",
 		},
 	})
 }

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -195,14 +195,18 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 // source-vs-rendered-URL depth mismatch that a bare relative
 // directory link would otherwise have on leaf pages.
 //
-// Group 1 captures the path prefix (required: a bare
-// `index.md` link with no parent directory is ambiguous and
-// left alone); group 2 captures an optional `#anchor` (whitespace
-// excluded so it stops before a title); group 3 is the optional
-// linkTitleTail so a titled directory link keeps its title — even
-// when it also carries a `#fragment` (gap G6).
+// Group 1 captures the path prefix (may be empty for a bare
+// `index.md` sibling reference like `docs/development/foo.md`
+// linking back to `docs/development/index.md`); group 2 captures
+// an optional `#anchor` (whitespace excluded so it stops before
+// a title); group 3 is the optional linkTitleTail so a titled
+// directory link keeps its title — even when it also carries a
+// `#fragment` (gap G6). When group 1 is empty rewriteIndexMd
+// substitutes `./` so the rewritten target stays a directory
+// reference (a bare `#anchor` would silently flip semantics to
+// a same-file local-anchor link).
 var indexMdLink = regexp.MustCompile(
-	`\]\(((?:[^)/]+/)+)index\.md((?:#[^)\s]*)?)` + linkTitleTail + `\)`)
+	`\]\(((?:[^)/]+/)*)index\.md((?:#[^)\s]*)?)` + linkTitleTail + `\)`)
 
 // ruleFixtureLink matches an inline link in a per-rule README
 // whose target is a fixture path under the rule's own directory:
@@ -341,9 +345,27 @@ func rewriteRuleLinks(b []byte) []byte {
 		// `/<path>/_index.md` or `/<path>/index.md`. Keeping
 		// either filename in the markdown produces a 404 on
 		// the live site.
-		seg = indexMdLink.ReplaceAll(seg, []byte("](${1}${2}${3})"))
+		seg = indexMdLink.ReplaceAllFunc(seg, rewriteIndexMdLink)
 		return seg
 	})
+}
+
+// rewriteIndexMdLink emits the `index.md`-stripped target.
+// indexMdLink's group 1 is the path prefix; group 2 is the
+// optional `#anchor`; group 3 is the optional linkTitleTail.
+// A non-empty prefix passes through (so `dir/index.md` → `dir/`);
+// an empty prefix is replaced with `./` so a bare `index.md`
+// link rewrites to `./` instead of collapsing to a bare
+// `#anchor` (which would be a same-file local-anchor reference,
+// a semantic change MDS027 would silently accept against the
+// wrong file).
+func rewriteIndexMdLink(match []byte) []byte {
+	m := indexMdLink.FindSubmatch(match)
+	prefix := m[1]
+	if len(prefix) == 0 {
+		prefix = []byte("./")
+	}
+	return []byte("](" + string(prefix) + string(m[2]) + string(m[3]) + ")")
 }
 
 // rewriteRepoRuleInline rewrites an inline link into

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -201,10 +201,10 @@ var repoNonPublishedRefDef = regexp.MustCompile(
 // an optional `#anchor` (whitespace excluded so it stops before
 // a title); group 3 is the optional linkTitleTail so a titled
 // directory link keeps its title — even when it also carries a
-// `#fragment` (gap G6). When group 1 is empty rewriteIndexMd
-// substitutes `./` so the rewritten target stays a directory
-// reference (a bare `#anchor` would silently flip semantics to
-// a same-file local-anchor link).
+// `#fragment` (gap G6). When group 1 is empty
+// rewriteIndexMdLink substitutes `./` so the rewritten target
+// stays a directory reference (a bare `#anchor` would silently
+// flip semantics to a same-file local-anchor link).
 var indexMdLink = regexp.MustCompile(
 	`\]\(((?:[^)/]+/)*)index\.md((?:#[^)\s]*)?)` + linkTitleTail + `\)`)
 

--- a/internal/release/website_test.go
+++ b/internal/release/website_test.go
@@ -642,6 +642,38 @@ func TestRewriteRuleLinks_AnchoredTitledIndexMdLink(t *testing.T) {
 		"anchored+titled index.md link must keep both #fragment and title")
 }
 
+// A bare `index.md` link with no parent directory is the in-tree
+// sibling form: `docs/development/high-performance-go.md` linking
+// back to `docs/development/index.md`. The source path is
+// filesystem-valid (so the source-tree MDS027 check passes) but
+// post-sync `index.md` no longer exists in the directory — Hugo
+// renamed it to `_index.md` — so the synced-tree lint would fail
+// on the original `(index.md…)` form. Rewriting bare `index.md`
+// to `./` mirrors Hugo's own render-link hook (which collapses a
+// bare `index.md` href to `./`) and lets MDS027 short-circuit
+// the dot-only path as valid.
+func TestRewriteRuleLinks_BareIndexMdLink(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`See [a](index.md#allocation-budget) — top.` + "\n")))
+	assert.Contains(t, got, `[a](./#allocation-budget)`,
+		"bare index.md#anchor must drop the filename and resolve to the current directory")
+	assert.NotContains(t, got, "index.md",
+		"no bare index.md target may survive the rewrite")
+}
+
+func TestRewriteRuleLinks_BareIndexMdNoAnchor(t *testing.T) {
+	got := string(rewriteRuleLinks([]byte(`Up: [home](index.md).` + "\n")))
+	assert.Contains(t, got, `[home](./)`,
+		"bare index.md with no anchor must rewrite to ./")
+}
+
+func TestRewriteRuleLinks_BareIndexMdTitled(t *testing.T) {
+	got := string(rewriteRuleLinks(
+		[]byte(`See [a](index.md#anchor "Title").` + "\n")))
+	assert.Contains(t, got, `[a](./#anchor "Title")`,
+		"bare index.md with anchor and title must rewrite to ./ while keeping both")
+}
+
 func TestTransformRulePage_AnchoredTitledReadmeLink(t *testing.T) {
 	in := "Anchor: [MDS021 a](../MDS021-include/README.md#syntax \"Inc\").\n"
 	got := string(transformRulePage([]byte(in), "MDS001-line-length"))


### PR DESCRIPTION
## Summary

Add a new `build-content` CI job that runs on every pull request touching documentation paths, catching broken-link regressions before merge. The job syncs the docs tree to Hugo's content structure and runs `mdsmith check` with link-integrity rules enabled, mirroring what the `deploy` job does but gated to PRs only.

## Key Changes

- **Workflow trigger**: Add `pull_request` trigger to `.github/workflows/pages.yml` with the same path filters as the `push` trigger, so PRs touching docs, website, or rules run the lint
- **New `build-content` job**: 
  - Builds the Hugo content tree from `docs/` using `mdsmith-release build-website`
  - Runs `mdsmith check` with `build-output.mdsmith.yml` config (link integrity on, style rules off)
  - Depends on `mdsmith-check` to ensure baseline linting passes first
  - Has no Pages permissions since it never publishes
- **Updated `deploy` job**: Change `needs` from `mdsmith-check` to `build-content`, and add a comment explaining that `pull_request` runs are silently skipped by the `if:` guard so only the lint job runs on PRs
- **Link rewriting fix**: Handle bare `index.md` links (sibling references like `docs/development/foo.md` → `docs/development/index.md`) by rewriting them to `./` instead of leaving them unchanged
  - Update `indexMdLink` regex to allow empty path prefix: `((?:[^)/]+/)*)`
  - Replace simple `ReplaceAll` with `ReplaceAllFunc` calling new `rewriteIndexMdLink` helper
  - The helper substitutes `./` when the path prefix is empty, preserving anchors and titles
  - Add three new test cases covering bare `index.md` with and without anchors/titles

## Notable Details

- The `build-content` job re-runs the same sync and lint that `deploy` performs, serving as a safety net for `workflow_dispatch` runs that bypass the PR chain
- Bare `index.md` links are filesystem-valid in the source tree (so source-tree MDS027 passes) but break post-sync when Hugo renames `index.md` to `_index.md`; rewriting to `./` mirrors Hugo's own render-link hook behavior
- PR runs stop at the lint job and never reach `deploy` due to its `if: github.ref == 'refs/heads/main'` guard

https://claude.ai/code/session_01XYet6BNTe757VutetWQfsb