### PR TITLE
Plan 195 task 15: cache parsed schema + compiled CUE in RunCache

### DIFF
--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -32,6 +32,18 @@ type RunCache struct {
 	// slots populate; the LSP's didChange path on a fragment then
 	// transitively invalidates every schema that reached it.
 	schemaDependents sync.Map // string (fragmentPath) -> *sync.Map
+
+	// schemaIncludes / schemaCUESources mirror ParsedSchemaMetadata
+	// into dedicated sync.Maps so Invalidate reads metadata without
+	// peeking at runCacheEntry.val — that would race with the slot's
+	// sync.Once during a first-time build. The slots are written
+	// AFTER ParsedSchema's load returns (so after the once completes)
+	// and read by Invalidate via sync.Map.Load, which gives the
+	// happens-before guarantee. A missing entry just means no
+	// metadata is registered yet; eviction degrades to a no-op rather
+	// than races on a partial value.
+	schemaIncludes   sync.Map // string (absPath) -> []string
+	schemaCUESources sync.Map // string (absPath) -> []string
 }
 
 // runCacheEntry guards a single cache slot so build runs exactly once
@@ -174,9 +186,23 @@ func (c *RunCache) Wikilinks(rootKey string, build func() any) any {
 func (c *RunCache) ParsedSchema(absPath string, build func() any) any {
 	v := load(&c.parsedSchema, absPath, build)
 	if meta, ok := v.(ParsedSchemaMetadata); ok {
-		c.registerSchemaIncludes(absPath, meta.SchemaIncludes())
+		c.registerSchemaMetadata(absPath, meta)
 	}
 	return v
+}
+
+// registerSchemaMetadata captures the parsed schema's includes and
+// CUE sources into dedicated sync.Maps (so Invalidate can read them
+// race-free) and adds absPath as a dependent of every include
+// fragment on the reverse-include index. Idempotent under concurrent
+// ParsedSchema calls for the same absPath: the inner sync.Map's
+// LoadOrStore re-uses the existing set and a re-Store of the same
+// metadata slice is a benign overwrite.
+func (c *RunCache) registerSchemaMetadata(absPath string, meta ParsedSchemaMetadata) {
+	includes := meta.SchemaIncludes()
+	c.schemaIncludes.Store(absPath, includes)
+	c.schemaCUESources.Store(absPath, meta.SchemaCUESources())
+	c.registerSchemaIncludes(absPath, includes)
 }
 
 // registerSchemaIncludes adds schemaPath as a dependent of every
@@ -248,17 +274,19 @@ func (c *RunCache) Invalidate(absPath string) {
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
 
-	// Read the parsed-schema slot's metadata before deleting it so
-	// downstream eviction sees the includes/cueSources captured at
-	// the last build. A miss (slot never populated, or already
-	// dropped by a sibling Invalidate via the dependents walk)
-	// leaves meta nil and the rest of the eviction is a no-op.
-	var meta ParsedSchemaMetadata
-	if ei, ok := c.parsedSchema.Load(absPath); ok {
-		e := ei.(*runCacheEntry)
-		if m, mok := e.val.(ParsedSchemaMetadata); mok {
-			meta = m
-		}
+	// Read the schema's includes + cueSources from the dedicated
+	// sync.Maps. Both are written AFTER ParsedSchema's load returns
+	// (post-sync.Once) and read here via sync.Map.Load, so there is
+	// no race with an in-flight build. A miss (slot never populated,
+	// or already dropped by a sibling Invalidate via the dependents
+	// walk) leaves the slices nil and the rest of the eviction is a
+	// no-op.
+	var includes, cueSources []string
+	if v, ok := c.schemaIncludes.Load(absPath); ok {
+		includes, _ = v.([]string)
+	}
+	if v, ok := c.schemaCUESources.Load(absPath); ok {
+		cueSources, _ = v.([]string)
 	}
 
 	// Drop every CompiledCUE entry the parsed schema produced. The
@@ -266,10 +294,8 @@ func (c *RunCache) Invalidate(absPath string) {
 	// front matter share one slot — invalidating absPath drops the
 	// slot for both, and the sibling recompiles on its next lookup
 	// (one CUE compile per surviving schema is the worst case).
-	if meta != nil {
-		for _, src := range meta.SchemaCUESources() {
-			c.compiledCUE.Delete(src)
-		}
+	for _, src := range cueSources {
+		c.compiledCUE.Delete(src)
 	}
 
 	// Walk the reverse-include index: every schema that included
@@ -293,8 +319,10 @@ func (c *RunCache) Invalidate(absPath string) {
 		c.schemaDependents.Delete(absPath)
 	}
 
-	// Drop the parsed-schema slot itself.
+	// Drop the parsed-schema slot and its mirrored metadata.
 	c.parsedSchema.Delete(absPath)
+	c.schemaIncludes.Delete(absPath)
+	c.schemaCUESources.Delete(absPath)
 
 	// Drop the reverse-index edges where absPath appears as a
 	// dependent — for each fragment in absPath's includes, remove
@@ -302,14 +330,12 @@ func (c *RunCache) Invalidate(absPath string) {
 	// fragment's own slot intact (it is a sibling document, not the
 	// invalidated one); only the back-pointer to absPath is
 	// removed.
-	if meta != nil {
-		for _, frag := range meta.SchemaIncludes() {
-			if frag == "" {
-				continue
-			}
-			if setI, ok := c.schemaDependents.Load(frag); ok {
-				setI.(*sync.Map).Delete(absPath)
-			}
+	for _, frag := range includes {
+		if frag == "" {
+			continue
+		}
+		if setI, ok := c.schemaDependents.Load(frag); ok {
+			setI.(*sync.Map).Delete(absPath)
 		}
 	}
 }

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -270,6 +270,23 @@ func (c *RunCache) CompiledCUE(source string, build func() any) any {
 // the workspace; the LSP must InvalidateWikilinks (or build a
 // fresh RunCache) when the filesystem layout changes.
 func (c *RunCache) Invalidate(absPath string) {
+	c.invalidate(absPath, map[string]bool{})
+}
+
+// invalidate is the recursive worker for Invalidate. The visited set
+// tracks every path the current top-level call has already touched
+// so a cyclic reverse-include graph (legal mid-edit LSP state — a
+// schema whose <?include?> chain self-references via a partial-parse
+// register on the cycle-error path) terminates on the second
+// encounter. The set is per-call (allocated by the public
+// Invalidate entry point) so independent Invalidate calls do not
+// share visited state.
+func (c *RunCache) invalidate(absPath string, visited map[string]bool) {
+	if visited[absPath] {
+		return
+	}
+	visited[absPath] = true
+
 	c.frontMatter.Delete(absPath)
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
@@ -300,12 +317,14 @@ func (c *RunCache) Invalidate(absPath string) {
 
 	// Walk the reverse-include index: every schema that included
 	// absPath as a fragment must be invalidated transitively. Drain
-	// the set into a slice first so the recursive Invalidate calls
+	// the set into a slice first so the recursive invalidate calls
 	// (which also touch schemaDependents during their own
 	// fragment-edge cleanup) cannot race with this iteration. The
 	// reverse-index entry for absPath is dropped after the walk so
 	// a re-populated schema's next register re-creates the set with
-	// only the live dependents.
+	// only the live dependents. The visited set carried through the
+	// recursion is the cycle guard — a dependent that has already
+	// been invalidated in this top-level call is skipped.
 	if setI, ok := c.schemaDependents.Load(absPath); ok {
 		set := setI.(*sync.Map)
 		var deps []string
@@ -314,7 +333,7 @@ func (c *RunCache) Invalidate(absPath string) {
 			return true
 		})
 		for _, dep := range deps {
-			c.Invalidate(dep)
+			c.invalidate(dep, visited)
 		}
 		c.schemaDependents.Delete(absPath)
 	}
@@ -329,13 +348,31 @@ func (c *RunCache) Invalidate(absPath string) {
 	// absPath from that fragment's dependent set. Leaves the
 	// fragment's own slot intact (it is a sibling document, not the
 	// invalidated one); only the back-pointer to absPath is
-	// removed.
+	// removed. When that removal empties the set, CompareAndDelete
+	// drops the schemaDependents entry too so long-lived LSP
+	// sessions do not accumulate empty *sync.Maps. CompareAndDelete
+	// is the race-safe primitive: if a concurrent
+	// registerSchemaMetadata re-Stored a dependent between our
+	// Range and the delete, the value in schemaDependents now
+	// differs from setI and the delete is skipped, preserving the
+	// new entry.
 	for _, frag := range includes {
 		if frag == "" {
 			continue
 		}
-		if setI, ok := c.schemaDependents.Load(frag); ok {
-			setI.(*sync.Map).Delete(absPath)
+		setI, ok := c.schemaDependents.Load(frag)
+		if !ok {
+			continue
+		}
+		set := setI.(*sync.Map)
+		set.Delete(absPath)
+		empty := true
+		set.Range(func(_, _ any) bool {
+			empty = false
+			return false
+		})
+		if empty {
+			c.schemaDependents.CompareAndDelete(frag, setI)
 		}
 	}
 }

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -31,6 +31,28 @@ type runCacheEntry struct {
 	val  any
 }
 
+// ParsedSchemaMetadata is the optional interface a parsed-schema
+// cache value (whatever its concrete type) implements so RunCache.
+// Invalidate can drop downstream entries that depend on the
+// invalidated schema. The rule package's schemaParseResult satisfies
+// it; the lint package only sees the surface.
+//
+//   - SchemaIncludes returns absolute paths of every fragment the
+//     schema's <?include?> directives reached. Invalidate(fragment)
+//     uses the reverse of this set (built lazily as ParsedSchema slots
+//     populate) to evict every schema that includes fragment.
+//   - SchemaCUESources returns every distinct CUE source string the
+//     schema's frontmatter produced. Invalidate(schemaPath) drops the
+//     matching CompiledCUE entries so an LSP edit that retypes a
+//     frontmatter constraint does not leak compiled values forever.
+//
+// Both methods may return nil for a parsed schema that pulled in no
+// fragments or has no frontmatter CUE source.
+type ParsedSchemaMetadata interface {
+	SchemaIncludes() []string
+	SchemaCUESources() []string
+}
+
 // NewRunCache returns an empty cache ready to be installed on
 // engine.Runner.RunCache.
 func NewRunCache() *RunCache {

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -22,6 +22,16 @@ type RunCache struct {
 	wikilinks    sync.Map // string (root key) -> *runCacheEntry
 	parsedSchema sync.Map // string (absPath) -> *runCacheEntry
 	compiledCUE  sync.Map // string (CUE source) -> *runCacheEntry
+
+	// schemaDependents maps a fragment path to the set of schema
+	// paths whose ParsedSchema slot reached it via <?include?>.
+	// Invalidate(fragment) walks this set so dependent schemas are
+	// evicted alongside the fragment. The inner *sync.Map acts as a
+	// concurrent string-set: keys are dependent schemaPaths, values
+	// are an empty struct sentinel. Built lazily as ParsedSchema
+	// slots populate; the LSP's didChange path on a fragment then
+	// transitively invalidates every schema that reached it.
+	schemaDependents sync.Map // string (fragmentPath) -> *sync.Map
 }
 
 // runCacheEntry guards a single cache slot so build runs exactly once
@@ -150,13 +160,39 @@ func (c *RunCache) Wikilinks(rootKey string, build func() any) any {
 // map hit. The LSP must call Invalidate(schemaPath) when the user
 // edits the schema so the next Check re-parses it.
 //
+// When build's return value satisfies ParsedSchemaMetadata, the
+// cache also registers absPath as a dependent of every path in
+// SchemaIncludes() on the reverse-include index. Invalidate(fragment)
+// then evicts every schema that reached fragment, closing the
+// stale-fragment gap the LSP would otherwise observe.
+//
 // MDS020 reaches this slot via f.RunCache; on a corpus where N
 // host files all reference one schema, the per-Check parseSchema
 // chain (schema markdown parse, AST walk, frontmatter CUE-derive)
 // collapses from N runs to 1 — closing the parity-gap profile
 // that plan 195 documents as the biggest default-rule hot spot.
 func (c *RunCache) ParsedSchema(absPath string, build func() any) any {
-	return load(&c.parsedSchema, absPath, build)
+	v := load(&c.parsedSchema, absPath, build)
+	if meta, ok := v.(ParsedSchemaMetadata); ok {
+		c.registerSchemaIncludes(absPath, meta.SchemaIncludes())
+	}
+	return v
+}
+
+// registerSchemaIncludes adds schemaPath as a dependent of every
+// fragment in includes on the reverse-include index. Idempotent
+// under concurrent ParsedSchema calls for the same schemaPath: the
+// inner sync.Map's LoadOrStore re-uses the existing set, and
+// re-adding the same dependent key is a no-op.
+func (c *RunCache) registerSchemaIncludes(schemaPath string, includes []string) {
+	for _, frag := range includes {
+		if frag == "" {
+			continue
+		}
+		setI, _ := c.schemaDependents.LoadOrStore(frag, &sync.Map{})
+		set := setI.(*sync.Map)
+		set.Store(schemaPath, struct{}{})
+	}
 }
 
 // CompiledCUE returns build's result for source — the CUE source
@@ -182,22 +218,100 @@ func (c *RunCache) CompiledCUE(source string, build func() any) any {
 // didChange / didSave / didChangeWatchedFiles so the next Check
 // that crosses absPath re-reads from disk.
 //
+// Schema dependency invalidation: when absPath's ParsedSchema slot
+// carries ParsedSchemaMetadata,
+//
+//   - every CUE source string in SchemaCUESources() is dropped from
+//     the compiledCUE slot (conservatively — a sibling schema with
+//     the same CUE source will recompile on its next lookup, which
+//     is cheap), and
+//   - every schema in schemaDependents[absPath] is recursively
+//     Invalidated (their cached parses depended on absPath as a
+//     fragment, so a fragment edit must propagate). Recursion is
+//     bounded by the schema-include depth cap the producer enforces
+//     and by the finite set of registered schemas; the include
+//     parser's no-cycle guarantee carries through.
+//
+// The reverse-index edges that name absPath as a dependent (i.e.
+// the entry on each include path's set) are dropped after the
+// recursion so the absPath's metadata can still be read first. The
+// recursion-then-delete order is load-bearing: Invalidate reads the
+// parsed-schema slot for its dependency metadata before dropping
+// it.
+//
 // Wikilink indices are NOT invalidated per absPath because a file
 // rename or creation could change the resolution of any wikilink in
 // the workspace; the LSP must InvalidateWikilinks (or build a
 // fresh RunCache) when the filesystem layout changes.
-//
-// The CompiledCUE slot is NOT invalidated either: its key is the
-// CUE source string, not a file path, so editing a schema file
-// changes its parsed-schema entry but the resulting CUE source —
-// if unchanged — still maps to the same valid cached value. The
-// LSP installs a fresh RunCache on workspace reload, which clears
-// it then.
 func (c *RunCache) Invalidate(absPath string) {
 	c.frontMatter.Delete(absPath)
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
+
+	// Read the parsed-schema slot's metadata before deleting it so
+	// downstream eviction sees the includes/cueSources captured at
+	// the last build. A miss (slot never populated, or already
+	// dropped by a sibling Invalidate via the dependents walk)
+	// leaves meta nil and the rest of the eviction is a no-op.
+	var meta ParsedSchemaMetadata
+	if ei, ok := c.parsedSchema.Load(absPath); ok {
+		e := ei.(*runCacheEntry)
+		if m, mok := e.val.(ParsedSchemaMetadata); mok {
+			meta = m
+		}
+	}
+
+	// Drop every CompiledCUE entry the parsed schema produced. The
+	// CUE source is the cache key, so two schemas with identical
+	// front matter share one slot — invalidating absPath drops the
+	// slot for both, and the sibling recompiles on its next lookup
+	// (one CUE compile per surviving schema is the worst case).
+	if meta != nil {
+		for _, src := range meta.SchemaCUESources() {
+			c.compiledCUE.Delete(src)
+		}
+	}
+
+	// Walk the reverse-include index: every schema that included
+	// absPath as a fragment must be invalidated transitively. Drain
+	// the set into a slice first so the recursive Invalidate calls
+	// (which also touch schemaDependents during their own
+	// fragment-edge cleanup) cannot race with this iteration. The
+	// reverse-index entry for absPath is dropped after the walk so
+	// a re-populated schema's next register re-creates the set with
+	// only the live dependents.
+	if setI, ok := c.schemaDependents.Load(absPath); ok {
+		set := setI.(*sync.Map)
+		var deps []string
+		set.Range(func(k, _ any) bool {
+			deps = append(deps, k.(string))
+			return true
+		})
+		for _, dep := range deps {
+			c.Invalidate(dep)
+		}
+		c.schemaDependents.Delete(absPath)
+	}
+
+	// Drop the parsed-schema slot itself.
 	c.parsedSchema.Delete(absPath)
+
+	// Drop the reverse-index edges where absPath appears as a
+	// dependent — for each fragment in absPath's includes, remove
+	// absPath from that fragment's dependent set. Leaves the
+	// fragment's own slot intact (it is a sibling document, not the
+	// invalidated one); only the back-pointer to absPath is
+	// removed.
+	if meta != nil {
+		for _, frag := range meta.SchemaIncludes() {
+			if frag == "" {
+				continue
+			}
+			if setI, ok := c.schemaDependents.Load(frag); ok {
+				setI.(*sync.Map).Delete(absPath)
+			}
+		}
+	}
 }
 
 // InvalidateWikilinks clears every cached wikilink index. The LSP

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -278,10 +278,15 @@ func (c *RunCache) CompiledCUE(source string, build func() any) any {
 //     is cheap), and
 //   - every schema in schemaDependents[absPath] is recursively
 //     Invalidated (their cached parses depended on absPath as a
-//     fragment, so a fragment edit must propagate). Recursion is
-//     bounded by the schema-include depth cap the producer enforces
-//     and by the finite set of registered schemas; the include
-//     parser's no-cycle guarantee carries through.
+//     fragment, so a fragment edit must propagate). The reverse-
+//     include graph CAN contain cycles — extractSchemaHeadings
+//     surfaces both edges of an include cycle on its error path so
+//     a legal LSP mid-edit state (schemaA <?include B?> with
+//     schemaB <?include A?>) registers both edges. Recursion is
+//     made finite by the per-call visited set the public Invalidate
+//     entry point seeds and the recursive invalidate worker
+//     consults; each path is invalidated at most once per top-level
+//     call.
 //
 // The reverse-index edges that name absPath as a dependent (i.e.
 // the entry on each include path's set) are dropped after the

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -16,10 +16,12 @@ import "sync"
 // lifetime and calls Invalidate when a document edit could change
 // what the next Check would read from disk.
 type RunCache struct {
-	frontMatter sync.Map // string (absPath) -> *runCacheEntry
-	includes    sync.Map // string (absPath) -> *runCacheEntry
-	anchors     sync.Map // string (absPath) -> *anchorEntry
-	wikilinks   sync.Map // string (root key) -> *runCacheEntry
+	frontMatter  sync.Map // string (absPath) -> *runCacheEntry
+	includes     sync.Map // string (absPath) -> *runCacheEntry
+	anchors      sync.Map // string (absPath) -> *anchorEntry
+	wikilinks    sync.Map // string (root key) -> *runCacheEntry
+	parsedSchema sync.Map // string (absPath) -> *runCacheEntry
+	compiledCUE  sync.Map // string (CUE source) -> *runCacheEntry
 }
 
 // runCacheEntry guards a single cache slot so build runs exactly once
@@ -112,19 +114,68 @@ func (c *RunCache) Wikilinks(rootKey string, build func() any) any {
 	return load(&c.wikilinks, rootKey, build)
 }
 
-// Invalidate drops the front-matter, include, and anchor entries
-// for absPath. The LSP calls this from didChange / didSave /
-// didChangeWatchedFiles so the next Check that crosses absPath
-// re-reads from disk.
+// ParsedSchema returns build's result for absPath, computed at most
+// once per absPath in this cache's lifetime. The value carries
+// dynamic type any so the requiredstructure rule (MDS020) can store
+// its package-private *parsedSchema (or a (parsedSchema, error) tuple)
+// without leaking the type into the lint package. Concurrent callers
+// with the same key block on the same once and observe the same
+// value.
+//
+// Build errors are cached intentionally: a malformed schema must
+// not be re-parsed on every host file that references it. Callers
+// store an error in the returned `any` so the next lookup is a
+// map hit. The LSP must call Invalidate(schemaPath) when the user
+// edits the schema so the next Check re-parses it.
+//
+// MDS020 reaches this slot via f.RunCache; on a corpus where N
+// host files all reference one schema, the per-Check parseSchema
+// chain (schema markdown parse, AST walk, frontmatter CUE-derive)
+// collapses from N runs to 1 — closing the parity-gap profile
+// that plan 195 documents as the biggest default-rule hot spot.
+func (c *RunCache) ParsedSchema(absPath string, build func() any) any {
+	return load(&c.parsedSchema, absPath, build)
+}
+
+// CompiledCUE returns build's result for source — the CUE source
+// string itself, not a file path. The same expression can come
+// from a schema file or from an inline `schema:` block; using the
+// source as the key collapses both into one compile per Run.
+//
+// The cached value carries dynamic type any so the caller can
+// store a wrapper that pairs the produced cue.Value with the
+// cue.Context that produced it (cue values are tied to their
+// context and must not cross contexts).
+//
+// MDS020's validateCUESchemaSyntax / validateFrontMatterCUE call
+// `cuecontext.New().CompileString(schema)` on every Check; with
+// this slot the compile runs once per unique CUE source per Run,
+// regardless of how many host files share the schema.
+func (c *RunCache) CompiledCUE(source string, build func() any) any {
+	return load(&c.compiledCUE, source, build)
+}
+
+// Invalidate drops the front-matter, include, anchor, and
+// parsed-schema entries for absPath. The LSP calls this from
+// didChange / didSave / didChangeWatchedFiles so the next Check
+// that crosses absPath re-reads from disk.
 //
 // Wikilink indices are NOT invalidated per absPath because a file
 // rename or creation could change the resolution of any wikilink in
 // the workspace; the LSP must InvalidateWikilinks (or build a
 // fresh RunCache) when the filesystem layout changes.
+//
+// The CompiledCUE slot is NOT invalidated either: its key is the
+// CUE source string, not a file path, so editing a schema file
+// changes its parsed-schema entry but the resulting CUE source —
+// if unchanged — still maps to the same valid cached value. The
+// LSP installs a fresh RunCache on workspace reload, which clears
+// it then.
 func (c *RunCache) Invalidate(absPath string) {
 	c.frontMatter.Delete(absPath)
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
+	c.parsedSchema.Delete(absPath)
 }
 
 // InvalidateWikilinks clears every cached wikilink index. The LSP

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -210,14 +210,39 @@ func (c *RunCache) registerSchemaMetadata(absPath string, meta ParsedSchemaMetad
 // under concurrent ParsedSchema calls for the same schemaPath: the
 // inner sync.Map's LoadOrStore re-uses the existing set, and
 // re-adding the same dependent key is a no-op.
+//
+// The verify-and-retry loop closes a race with Invalidate's
+// empty-set cleanup: Invalidate's CompareAndDelete on the outer
+// schemaDependents map only compares the outer-value pointer,
+// which stays the same even when a concurrent register adds to
+// the inner *sync.Map. Without the retry, this sequence loses
+// the new dependent:
+//
+//  1. T1 register: LoadOrStore("frag") → setI (existing)
+//  2. T2 invalidate: empty-check on setI → empty → CompareAndDelete
+//     drops the outer entry
+//  3. T1 register: set.Store(schemaPath) → lands on the orphaned
+//     setI, never reachable from schemaDependents again
+//
+// The retry detects step 3's orphaning by re-Loading the outer
+// entry after Store and confirming it still points at setI.
+// On mismatch, the loop re-issues LoadOrStore, which creates a
+// fresh set and re-registers. The retry cap (8) is well above
+// any plausible race depth — register-vs-invalidate is bounded
+// by LSP edit rate.
 func (c *RunCache) registerSchemaIncludes(schemaPath string, includes []string) {
 	for _, frag := range includes {
 		if frag == "" {
 			continue
 		}
-		setI, _ := c.schemaDependents.LoadOrStore(frag, &sync.Map{})
-		set := setI.(*sync.Map)
-		set.Store(schemaPath, struct{}{})
+		for retry := 0; retry < 8; retry++ {
+			setI, _ := c.schemaDependents.LoadOrStore(frag, &sync.Map{})
+			set := setI.(*sync.Map)
+			set.Store(schemaPath, struct{}{})
+			if current, ok := c.schemaDependents.Load(frag); ok && current == setI {
+				break
+			}
+		}
 	}
 }
 

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -659,6 +659,39 @@ func TestRunCache_InvalidateSchemaDropsBackpointers(t *testing.T) {
 			"rebuild is the cumulative second call")
 }
 
+// TestRunCache_InvalidateDoesNotRaceParsedSchemaBuild pins the race
+// fix for Copilot thread `PRRT_kwDORLpjqs6EXfF6` on PR #377: Invalidate
+// must not read runCacheEntry.val (which is set under the slot's
+// sync.Once) while a concurrent ParsedSchema build is in flight. The
+// fix stores metadata in dedicated sync.Maps (schemaIncludes /
+// schemaCUESources) and Invalidate reads from those — race-free.
+// Under `go test -race`, the old code would flag a data race; this
+// test pounds the path so any future regression fails the gate.
+func TestRunCache_InvalidateDoesNotRaceParsedSchemaBuild(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/schemaA.md"
+	const fragmentB = "/abs/fragmentB.md"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = c.ParsedSchema(schemaA, func() any {
+				return testSchemaMeta{
+					includes:   []string{fragmentB},
+					cueSources: []string{`{x: string}`},
+				}
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			c.Invalidate(schemaA)
+		}()
+	}
+	wg.Wait()
+}
+
 // TestRunCache_EmptyFragmentSkippedBothDirections pins the empty-string
 // guard on both reverse-index sides. A schema whose include list
 // carries an empty entry (e.g. a parse path that produced a blank

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -743,6 +743,73 @@ func TestRunCache_InvalidateTerminatesOnCyclicReverseIncludes(t *testing.T) {
 			"via the partial-includes-on-error register)")
 }
 
+// TestRunCache_RegisterInvalidateRaceDoesNotLoseDependents pins the
+// fix for Copilot thread PRRT_kwDORLpjqs6EXwfS: Invalidate's
+// CompareAndDelete on schemaDependents only compares the outer
+// pointer, which a concurrent register-into-inner-set does not
+// change. Without the retry on register, this sequence would lose
+// the new dependent. The test pounds register and Invalidate on the
+// same key in parallel and asserts every "live" dependent the last
+// register left in place is still reachable via schemaDependents.
+func TestRunCache_RegisterInvalidateRaceDoesNotLoseDependents(t *testing.T) {
+	c := NewRunCache()
+	const fragment = "/abs/fragment.md"
+
+	// Two pools of schema paths. Half are repeatedly invalidated;
+	// half are continuously re-registered and must remain
+	// discoverable through schemaDependents[fragment].
+	const liveSchemas = 8
+	const churnIters = 200
+
+	live := make([]string, liveSchemas)
+	for i := range live {
+		live[i] = "/abs/schema-live-" + string(rune('0'+i)) + ".md"
+	}
+	churn := "/abs/schema-churn.md"
+
+	var wg sync.WaitGroup
+
+	// Continuously register the live set against fragment.
+	for _, s := range live {
+		s := s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < churnIters; i++ {
+				c.registerSchemaIncludes(s, []string{fragment})
+			}
+		}()
+	}
+
+	// Concurrently register-then-invalidate the churn schema —
+	// each Invalidate may empty fragment's set and trip the
+	// CompareAndDelete.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < churnIters; i++ {
+			c.registerSchemaIncludes(churn, []string{fragment})
+			c.Invalidate(churn)
+		}
+	}()
+	wg.Wait()
+
+	// Every live schema must still be a dependent of fragment.
+	setI, ok := c.schemaDependents.Load(fragment)
+	require.True(t, ok,
+		"after all live registers, fragment must still have a "+
+			"dependent set — the retry-and-verify loop in "+
+			"registerSchemaIncludes is what prevents the outer "+
+			"entry from being lost under churn")
+	set := setI.(*sync.Map)
+	for _, s := range live {
+		_, hit := set.Load(s)
+		assert.True(t, hit,
+			"live dependent %s must survive the register/invalidate "+
+				"race against the churn schema", s)
+	}
+}
+
 // TestRunCache_InvalidateDropsEmptyDependentSets pins the empty-set
 // cleanup added for Copilot thread PRRT_kwDORLpjqs6EXnIf. When a
 // schema's last dependent is removed, the *sync.Map entry in

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -658,3 +658,39 @@ func TestRunCache_InvalidateSchemaDropsBackpointers(t *testing.T) {
 			"dependent set must be gone; the second ParsedSchema(schemaA) "+
 			"rebuild is the cumulative second call")
 }
+
+// TestRunCache_EmptyFragmentSkippedBothDirections pins the empty-string
+// guard on both reverse-index sides. A schema whose include list
+// carries an empty entry (e.g. a parse path that produced a blank
+// before normalisation) must not register a back-pointer under the
+// empty key, and Invalidate must skip the same empty entry when tearing
+// back-pointers down. Without the guard, the schemaDependents map
+// would grow a "" key and Invalidate("") would later evict everything.
+func TestRunCache_EmptyFragmentSkippedBothDirections(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/schemaA.md"
+	const fragmentB = "/abs/fragmentB.md"
+
+	_ = c.ParsedSchema(schemaA, func() any {
+		return testSchemaMeta{includes: []string{"", fragmentB}}
+	})
+
+	// Invalidate("") must NOT find schemaA in any dependent set —
+	// the empty include was skipped on registration, so no
+	// back-pointer exists. A rebuild on schemaA proves Invalidate("")
+	// did not evict it.
+	c.Invalidate("")
+	var rebuilds int32
+	_ = c.ParsedSchema(schemaA, func() any {
+		atomic.AddInt32(&rebuilds, 1)
+		return testSchemaMeta{includes: []string{"", fragmentB}}
+	})
+	assert.Equal(t, int32(0), atomic.LoadInt32(&rebuilds),
+		"Invalidate(\"\") must be a no-op: the empty include never "+
+			"registered a back-pointer in the first place")
+
+	// Invalidate(schemaA) walks meta.SchemaIncludes() — including
+	// the "" entry — and must skip it cleanly. No panic, fragmentB's
+	// back-pointer is removed.
+	c.Invalidate(schemaA)
+}

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -285,3 +285,148 @@ func TestRunCache_InvalidateWikilinks(t *testing.T) {
 	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
 		"InvalidateWikilinks must let the next call rebuild")
 }
+
+// TestRunCache_ParsedSchemaBuildsOnce pins that the parsed-schema cache
+// closes MDS020's per-host-file re-parse hot spot: a schema file
+// referenced by N host files is parsed exactly once per run, matching
+// the FrontMatter / Includes single-build guarantee.
+func TestRunCache_ParsedSchemaBuildsOnce(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return "parsed-schema-instance"
+	}
+	for i := 0; i < 3; i++ {
+		got := c.ParsedSchema("/abs/schema.md", build)
+		require.Equal(t, "parsed-schema-instance", got)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"ParsedSchema build must run exactly once per absPath")
+}
+
+// TestRunCache_ParsedSchemaCachesErrors pins that ParsedSchema caches
+// the build result wholesale, including parse errors. A malformed
+// schema file must not be re-read on every host file that references
+// it; the cached value carries the error so the next caller's lookup
+// is a map hit.
+func TestRunCache_ParsedSchemaCachesErrors(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return assert.AnError
+	}
+	for i := 0; i < 3; i++ {
+		got := c.ParsedSchema("/abs/broken.md", build)
+		require.ErrorIs(t, got.(error), assert.AnError)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"ParsedSchema must cache build results including errors")
+}
+
+// TestRunCache_ParsedSchemaInvalidateForcesRebuild pins that
+// Invalidate drops the parsed-schema slot alongside FrontMatter,
+// Includes, and Anchors. Without this, an LSP edit to the schema
+// file would not refresh MDS020's view of it.
+func TestRunCache_ParsedSchemaInvalidateForcesRebuild(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	c.ParsedSchema("/abs/schema.md", func() any {
+		atomic.AddInt32(&calls, 1)
+		return "v1"
+	})
+	c.Invalidate("/abs/schema.md")
+	got := c.ParsedSchema("/abs/schema.md", func() any {
+		atomic.AddInt32(&calls, 1)
+		return "v2"
+	})
+	assert.Equal(t, "v2", got, "Invalidate must clear the parsed-schema slot")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"ParsedSchema build must run again after Invalidate")
+}
+
+// TestRunCache_ParsedSchemaConcurrentSingleBuild pins the per-key
+// once: the parallel file worker pool may race for the same schema
+// path; the build must still run exactly once.
+func TestRunCache_ParsedSchemaConcurrentSingleBuild(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v := c.ParsedSchema("/abs/shared.md", func() any {
+				atomic.AddInt32(&calls, 1)
+				return "once"
+			})
+			assert.Equal(t, "once", v)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"ParsedSchema build must run exactly once under concurrent access")
+}
+
+// TestRunCache_CompiledCUEBuildsOnce pins that compiling the same CUE
+// source string twice returns the cached value: the schema-frontmatter
+// CUE expression is shared across every host file referencing the
+// schema, so compiling it once per Run closes the second half of
+// MDS020's parity gap.
+//
+// The key is the source string itself, not a path, so an inline
+// `schema:` block and a schema file that produce the same CUE share
+// the slot.
+func TestRunCache_CompiledCUEBuildsOnce(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return "compiled-value"
+	}
+	const src = `close({id: string, status: "✅" | "🔳"})`
+	for i := 0; i < 4; i++ {
+		got := c.CompiledCUE(src, build)
+		require.Equal(t, "compiled-value", got)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"CompiledCUE build must run exactly once per source string")
+}
+
+// TestRunCache_CompiledCUEDistinctSourcesDoNotShare pins that two
+// different CUE sources keep independent slots: caching one must
+// not silently serve the other.
+func TestRunCache_CompiledCUEDistinctSourcesDoNotShare(t *testing.T) {
+	c := NewRunCache()
+	c.CompiledCUE(`{a: string}`, func() any { return "a-val" })
+	c.CompiledCUE(`{b: string}`, func() any { return "b-val" })
+	assert.Equal(t, "a-val", c.CompiledCUE(`{a: string}`,
+		func() any { return "different" }))
+	assert.Equal(t, "b-val", c.CompiledCUE(`{b: string}`,
+		func() any { return "different" }))
+}
+
+// TestRunCache_CompiledCUEConcurrentSingleBuild pins the per-key
+// once: many goroutines compiling the same CUE source must observe
+// exactly one build.
+func TestRunCache_CompiledCUEConcurrentSingleBuild(t *testing.T) {
+	c := NewRunCache()
+	var calls int32
+	var wg sync.WaitGroup
+	const src = `{x: int}`
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v := c.CompiledCUE(src, func() any {
+				atomic.AddInt32(&calls, 1)
+				return "once"
+			})
+			assert.Equal(t, "once", v)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"CompiledCUE build must run exactly once under concurrent access")
+}

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -430,3 +430,231 @@ func TestRunCache_CompiledCUEConcurrentSingleBuild(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
 		"CompiledCUE build must run exactly once under concurrent access")
 }
+
+// testSchemaMeta is a minimal ParsedSchemaMetadata implementation
+// used to drive the include + CUE-source eviction tests below
+// without depending on the requiredstructure package's concrete
+// schemaParseResult. The fields mirror the rule package's surface
+// exactly so the tests pin the contract from the lint side.
+type testSchemaMeta struct {
+	includes   []string
+	cueSources []string
+}
+
+func (m testSchemaMeta) SchemaIncludes() []string   { return m.includes }
+func (m testSchemaMeta) SchemaCUESources() []string { return m.cueSources }
+
+// TestRunCache_InvalidateFragmentEvictsDependentSchema pins thread 1
+// (PR #377): a ParsedSchema slot whose build returned
+// ParsedSchemaMetadata reporting fragmentB as an include must be
+// evicted when Invalidate(fragmentB) fires. Without this, the LSP
+// edits a schema include fragment and MDS020 keeps serving stale
+// headings until the parent schema itself is invalidated.
+func TestRunCache_InvalidateFragmentEvictsDependentSchema(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/schema.md"
+	const fragmentB = "/abs/fragment.md"
+
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return testSchemaMeta{includes: []string{fragmentB}}
+	}
+	got := c.ParsedSchema(schemaA, build)
+	require.Equal(t, testSchemaMeta{includes: []string{fragmentB}}, got)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	c.Invalidate(fragmentB)
+
+	build2 := func() any {
+		atomic.AddInt32(&calls, 1)
+		return testSchemaMeta{includes: []string{fragmentB}}
+	}
+	_ = c.ParsedSchema(schemaA, build2)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"Invalidate(fragment) must evict every schema whose ParsedSchema slot "+
+			"reached fragment via <?include?>")
+}
+
+// TestRunCache_InvalidateFragmentEvictsTransitively pins the
+// transitive case: schemaA includes fragmentB; fragmentB itself is
+// modelled as a schema with an include on fragmentC.
+// Invalidate(fragmentC) must drop both A and B's parsed-schema
+// slots because A's parse depends on B's parse which depends on
+// fragmentC.
+func TestRunCache_InvalidateFragmentEvictsTransitively(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/a.md"
+	const fragmentB = "/abs/b.md"
+	const fragmentC = "/abs/c.md"
+
+	var aCalls, bCalls int32
+	_ = c.ParsedSchema(schemaA, func() any {
+		atomic.AddInt32(&aCalls, 1)
+		return testSchemaMeta{includes: []string{fragmentB}}
+	})
+	_ = c.ParsedSchema(fragmentB, func() any {
+		atomic.AddInt32(&bCalls, 1)
+		return testSchemaMeta{includes: []string{fragmentC}}
+	})
+	require.Equal(t, int32(1), atomic.LoadInt32(&aCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&bCalls))
+
+	c.Invalidate(fragmentC)
+
+	_ = c.ParsedSchema(schemaA, func() any {
+		atomic.AddInt32(&aCalls, 1)
+		return testSchemaMeta{includes: []string{fragmentB}}
+	})
+	_ = c.ParsedSchema(fragmentB, func() any {
+		atomic.AddInt32(&bCalls, 1)
+		return testSchemaMeta{includes: []string{fragmentC}}
+	})
+	assert.Equal(t, int32(2), atomic.LoadInt32(&aCalls),
+		"transitive: schemaA depends on fragmentB depends on fragmentC; "+
+			"Invalidate(fragmentC) must evict A")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&bCalls),
+		"transitive: Invalidate(fragmentC) must evict B")
+}
+
+// TestRunCache_InvalidateSchemaDropsCompiledCUE pins thread 2
+// (PR #377): editing a schema's frontmatter produces a new CUE
+// source. Without per-schema CompiledCUE eviction the cache leaks
+// the old source's compiled value forever in long-lived LSP
+// sessions. Invalidate(schemaPath) must drop every CompiledCUE
+// entry the parsed schema produced.
+func TestRunCache_InvalidateSchemaDropsCompiledCUE(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/schema.md"
+	const cueSrc = `close({x: string})`
+
+	// Populate the parsed-schema slot with metadata that names cueSrc.
+	_ = c.ParsedSchema(schemaA, func() any {
+		return testSchemaMeta{cueSources: []string{cueSrc}}
+	})
+	// Populate the matching CompiledCUE slot.
+	var compileCalls int32
+	_ = c.CompiledCUE(cueSrc, func() any {
+		atomic.AddInt32(&compileCalls, 1)
+		return "compiled-v1"
+	})
+	require.Equal(t, int32(1), atomic.LoadInt32(&compileCalls))
+
+	c.Invalidate(schemaA)
+
+	_ = c.CompiledCUE(cueSrc, func() any {
+		atomic.AddInt32(&compileCalls, 1)
+		return "compiled-v2"
+	})
+	assert.Equal(t, int32(2), atomic.LoadInt32(&compileCalls),
+		"Invalidate(schemaPath) must drop CompiledCUE entries the parsed "+
+			"schema produced so an LSP frontmatter edit does not leak compiled "+
+			"values")
+}
+
+// TestRunCache_InvalidateSharedCUESourceIsConservative documents
+// the design choice for shared CUE sources: two schemas declaring
+// the same `{x: string}` source share one CompiledCUE slot;
+// invalidating one schema drops the slot for both. The sibling
+// recompiles on its next ValidateFrontmatterDiags lookup — a one-
+// time cost that is the safe default. The alternative
+// (refcounting CUE sources) is heavier infrastructure for a cheap
+// recompile.
+func TestRunCache_InvalidateSharedCUESourceIsConservative(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/a.md"
+	const schemaB = "/abs/b.md"
+	const cueSrc = `{x: string}`
+
+	_ = c.ParsedSchema(schemaA, func() any {
+		return testSchemaMeta{cueSources: []string{cueSrc}}
+	})
+	_ = c.ParsedSchema(schemaB, func() any {
+		return testSchemaMeta{cueSources: []string{cueSrc}}
+	})
+	var compileCalls int32
+	_ = c.CompiledCUE(cueSrc, func() any {
+		atomic.AddInt32(&compileCalls, 1)
+		return "v1"
+	})
+	require.Equal(t, int32(1), atomic.LoadInt32(&compileCalls))
+
+	// Invalidate one of the two schemas. The CompiledCUE slot is
+	// dropped — the sibling schema's next lookup recompiles. This
+	// is the documented conservative behavior; a refcount-based
+	// strategy would keep the slot alive for schemaB but adds
+	// machinery for a sub-millisecond recompile.
+	c.Invalidate(schemaA)
+	_ = c.CompiledCUE(cueSrc, func() any {
+		atomic.AddInt32(&compileCalls, 1)
+		return "v2"
+	})
+	assert.Equal(t, int32(2), atomic.LoadInt32(&compileCalls),
+		"Invalidate(schemaA) must drop the shared CUE slot — schemaB recompiles "+
+			"on its next lookup; cheap and removes the leak risk")
+}
+
+// TestRunCache_InvalidateNonSchemaPathIsNoop pins that Invalidate
+// on a path that was never registered as a schema (no
+// ParsedSchema slot, no fragment-of-anything) does not panic and
+// does not affect CompiledCUE entries on the cache.
+func TestRunCache_InvalidateNonSchemaPathIsNoop(t *testing.T) {
+	c := NewRunCache()
+	const cueSrc = `{kept: string}`
+	var compileCalls int32
+	_ = c.CompiledCUE(cueSrc, func() any {
+		atomic.AddInt32(&compileCalls, 1)
+		return "kept"
+	})
+	require.Equal(t, int32(1), atomic.LoadInt32(&compileCalls))
+
+	require.NotPanics(t, func() { c.Invalidate("/abs/random-doc.md") })
+
+	got := c.CompiledCUE(cueSrc, func() any {
+		atomic.AddInt32(&compileCalls, 1)
+		return "rebuilt"
+	})
+	assert.Equal(t, "kept", got,
+		"Invalidate on a non-schema path must not evict unrelated CompiledCUE entries")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&compileCalls),
+		"CompiledCUE build must not run again after a no-op Invalidate")
+}
+
+// TestRunCache_InvalidateSchemaDropsBackpointers pins that
+// Invalidate(schemaA) tears down the reverse-include edges where
+// schemaA appears as a dependent. A subsequent Invalidate on the
+// fragment must not re-evict schemaA (it is already gone), proving
+// the dependent set was cleaned up.
+func TestRunCache_InvalidateSchemaDropsBackpointers(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/a.md"
+	const fragmentB = "/abs/b.md"
+
+	var aCalls int32
+	_ = c.ParsedSchema(schemaA, func() any {
+		atomic.AddInt32(&aCalls, 1)
+		return testSchemaMeta{includes: []string{fragmentB}}
+	})
+
+	// Invalidate the schema first — this must remove the
+	// fragmentB → schemaA edge.
+	c.Invalidate(schemaA)
+
+	// Now invalidate the fragment. Because the back-pointer was
+	// dropped, Invalidate(fragmentB) finds no dependent. If the
+	// back-pointer survived, this call would try to re-evict
+	// schemaA (a no-op against an already-empty slot — but the
+	// schemaDependents Range would still walk it). We assert the
+	// invariant by rebuilding schemaA and observing its slot is
+	// fresh.
+	c.Invalidate(fragmentB)
+
+	_ = c.ParsedSchema(schemaA, func() any {
+		atomic.AddInt32(&aCalls, 1)
+		return testSchemaMeta{includes: []string{fragmentB}}
+	})
+	assert.Equal(t, int32(2), atomic.LoadInt32(&aCalls),
+		"after Invalidate(schemaA) the back-pointer to schemaA on fragmentB's "+
+			"dependent set must be gone; the second ParsedSchema(schemaA) "+
+			"rebuild is the cumulative second call")
+}

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -690,6 +691,87 @@ func TestRunCache_InvalidateDoesNotRaceParsedSchemaBuild(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestRunCache_InvalidateTerminatesOnCyclicReverseIncludes pins the
+// cycle guard added for Copilot thread PRRT_kwDORLpjqs6EXqUJ. After
+// plan 195 task 15's partial-includes-on-error fix, a cyclic include
+// (schemaA → schemaB → schemaA — a real LSP mid-edit state) registers
+// a cycle in the reverse-include graph: schemaDependents[A] contains
+// B, schemaDependents[B] contains A. Without a visited guard,
+// Invalidate(A) → invalidate(B) → invalidate(A) → ... stack-overflows.
+// The fix carries a per-call visited set; this test pins that
+// Invalidate terminates and evicts both slots.
+func TestRunCache_InvalidateTerminatesOnCyclicReverseIncludes(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/schemaA.md"
+	const schemaB = "/abs/schemaB.md"
+
+	_ = c.ParsedSchema(schemaA, func() any {
+		return testSchemaMeta{includes: []string{schemaB}}
+	})
+	_ = c.ParsedSchema(schemaB, func() any {
+		return testSchemaMeta{includes: []string{schemaA}}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		c.Invalidate(schemaA)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Invalidate did not terminate on a cyclic reverse-include " +
+			"graph within 2s — the cycle guard is missing or broken")
+	}
+
+	// Both schemas' slots must be gone.
+	var rebuildsA, rebuildsB int32
+	_ = c.ParsedSchema(schemaA, func() any {
+		atomic.AddInt32(&rebuildsA, 1)
+		return testSchemaMeta{}
+	})
+	_ = c.ParsedSchema(schemaB, func() any {
+		atomic.AddInt32(&rebuildsB, 1)
+		return testSchemaMeta{}
+	})
+	assert.Equal(t, int32(1), atomic.LoadInt32(&rebuildsA),
+		"schemaA's slot must be evicted by Invalidate(schemaA)")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&rebuildsB),
+		"schemaB's slot must be evicted transitively (B depended on A "+
+			"via the partial-includes-on-error register)")
+}
+
+// TestRunCache_InvalidateDropsEmptyDependentSets pins the empty-set
+// cleanup added for Copilot thread PRRT_kwDORLpjqs6EXnIf. When a
+// schema's last dependent is removed, the *sync.Map entry in
+// schemaDependents must be deleted via CompareAndDelete so a
+// long-lived LSP session does not accumulate one empty *sync.Map per
+// fragment ever included.
+func TestRunCache_InvalidateDropsEmptyDependentSets(t *testing.T) {
+	c := NewRunCache()
+	const schemaA = "/abs/schemaA.md"
+	const fragmentB = "/abs/fragmentB.md"
+
+	_ = c.ParsedSchema(schemaA, func() any {
+		return testSchemaMeta{includes: []string{fragmentB}}
+	})
+
+	// Sanity: fragmentB's dependent set holds schemaA.
+	_, presentBefore := c.schemaDependents.Load(fragmentB)
+	require.True(t, presentBefore,
+		"baseline: fragmentB's dependent set must exist after register")
+
+	c.Invalidate(schemaA)
+
+	// fragmentB's set was emptied; the schemaDependents entry must
+	// be gone too.
+	_, presentAfter := c.schemaDependents.Load(fragmentB)
+	assert.False(t, presentAfter,
+		"after Invalidate(schemaA) removes the last dependent from "+
+			"fragmentB's set, the schemaDependents entry for fragmentB "+
+			"must be CompareAndDelete'd so the *sync.Map does not leak")
 }
 
 // TestRunCache_EmptyFragmentSkippedBothDirections pins the empty-string

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1364,7 +1364,14 @@ func parseSchemaWithCache(
 	// Extract <?require?> directive from schema body.
 	filenamePattern, err := extractRequireDirective(f)
 	if err != nil {
-		return nil, nil, err
+		// cfg.FrontMatterCUE was already compiled (and cached
+		// via RunCache.CompiledCUE) before extractRequireDirective
+		// ran, so surface a partial *parsedSchema so the cache
+		// wrapper can record cueSources. Without this, an LSP
+		// mid-edit state where <?require?> is malformed leaves
+		// the CompiledCUE entry uncoupled from any schemaPath
+		// and Invalidate(schemaPath) cannot evict it.
+		return &parsedSchema{Config: cfg}, nil, err
 	}
 	cfg.FilenamePattern = filenamePattern
 

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1378,7 +1378,15 @@ func parseSchemaWithCache(
 		var fp string
 		headings, fp, includes, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes)
 		if err != nil {
-			return nil, nil, err
+			// Surface a partial *parsedSchema (carrying the
+			// frontmatter CUE source the cache will track via
+			// schemaCUESources) AND the partial include set the
+			// walk reached before erroring. The rule's caller
+			// discards the partial schema on err, but the cache
+			// wrapper records both pieces so a later
+			// Invalidate(fragment) on a fixed include still
+			// evicts the schema's failed-parse slot.
+			return &parsedSchema{Config: cfg}, includes, err
 		}
 		if fp != "" && cfg.FilenamePattern == "" {
 			cfg.FilenamePattern = fp
@@ -1410,13 +1418,17 @@ func parseSchemaWithCache(
 // expanding <?include?> PIs by splicing in the included file's headings.
 // It uses a visited set for cycle detection.
 //
-// The returned includes slice carries the resolved absolute path of
-// every fragment reached during the walk — both direct includes and
-// transitively-included ones. Order is source order at the current
-// level, with each fragment's transitive set appended after the
-// fragment's own path. The cache wrapper feeds this into RunCache's
-// reverse-include index so a fragment edit invalidates every schema
-// that reached it.
+// The returned includes slice carries the resolved path of every
+// fragment reached during the walk — both direct includes and
+// transitively-included ones. Paths are in the SAME coordinate
+// system as schemaPath: resolveSchemaIncludePath joins each include
+// onto filepath.Dir(schemaPath), so a project-relative schemaPath
+// produces project-relative include entries (and an absolute
+// schemaPath produces absolute ones). cachedParseSchemaWith later
+// anchors them onto absRoot via absoluteIncludes before storing on
+// schemaParseResult, so RunCache.Invalidate's absolute keys match.
+// Order is source order at the current level, with each fragment's
+// transitive set appended after the fragment's own path.
 func extractSchemaHeadings(
 	schemaFile *lint.File, schemaPath string,
 	visited map[string]bool, chain []string, maxBytes int64,
@@ -1443,6 +1455,20 @@ func extractSchemaHeadings(
 			fragHeadings, fp, fragIncluded, subIncludes, walkErr := expandSchemaInclude(
 				node, schemaFile.Source, schemaPath, visited, chain, maxBytes)
 			if walkErr != nil {
+				// Record the broken-but-known fragment plus any
+				// transitive sub-includes the recursive walk
+				// reached before erroring. The outer
+				// extractSchemaHeadings surfaces this partial
+				// `includes` slice up to parseSchemaWithCache so
+				// the cache wrapper's reverse-include index covers
+				// the full dependency footprint, broken edges
+				// included. Without this, Invalidate(fragment) on
+				// a fix would not evict the schema's failed-parse
+				// slot.
+				if fragIncluded != "" {
+					includes = append(includes, fragIncluded)
+				}
+				includes = append(includes, subIncludes...)
 				return ast.WalkStop, walkErr
 			}
 			if fp != "" && filenamePattern == "" {
@@ -1458,7 +1484,13 @@ func extractSchemaHeadings(
 		return ast.WalkContinue, nil
 	})
 	if err != nil {
-		return nil, "", nil, err
+		// Surface the partial include set so the cache wrapper can
+		// still register dependents on fragments the walk reached
+		// before erroring. A schema that fails to parse because of
+		// a downstream <?include?> issue must still let
+		// Invalidate(brokenFragment) evict the schema's failed-parse
+		// slot when the fragment is fixed.
+		return nil, "", includes, err
 	}
 
 	return headings, filenamePattern, includes, nil
@@ -1493,11 +1525,12 @@ func resolveSchemaIncludePath(
 
 // expandSchemaInclude resolves and recursively expands a schema
 // include PI. It returns the fragment's headings, any filename
-// pattern declared on the fragment, the resolved absolute path of
-// the fragment itself, the fragment's transitive include set, and
-// an error. The path-plus-subIncludes pair lets the caller record
-// the full dependency footprint on RunCache's reverse-include
-// index.
+// pattern declared on the fragment, the fragment's resolved path
+// (in the same coordinate system as schemaPath — typically
+// project-relative; cachedParseSchemaWith anchors it onto absRoot
+// before storing), the fragment's transitive include set, and an
+// error. The path-plus-subIncludes pair lets the caller record the
+// full dependency footprint on RunCache's reverse-include index.
 func expandSchemaInclude(
 	pi *lint.ProcessingInstruction, source []byte,
 	schemaPath string, visited map[string]bool, chain []string, maxBytes int64,
@@ -1507,21 +1540,27 @@ func expandSchemaInclude(
 		return nil, "", "", nil, err
 	}
 
+	// Surface includedPath on every error past this point so the
+	// caller can register the broken-but-known fragment in
+	// RunCache's reverse-include index. When the user fixes the
+	// fragment (creates the missing file, breaks the cycle, raises
+	// the depth limit), Invalidate(fragmentAbs) then evicts this
+	// schema's failed-parse slot and the next Check re-parses.
 	if len(chain) > maxSchemaIncludeDepth {
-		return nil, "", "", nil, fmt.Errorf(
+		return nil, "", includedPath, nil, fmt.Errorf(
 			"schema include depth exceeds maximum (%d)", maxSchemaIncludeDepth)
 	}
 	if visited[includedPath] {
 		chainCopy := make([]string, len(chain))
 		copy(chainCopy, chain)
 		chainCopy = append(chainCopy, includedPath)
-		return nil, "", "", nil, fmt.Errorf(
+		return nil, "", includedPath, nil, fmt.Errorf(
 			"cyclic include: %s", strings.Join(chainCopy, " -> "))
 	}
 
 	fragData, err := lint.ReadFileLimited(includedPath, maxBytes)
 	if err != nil {
-		return nil, "", "", nil, fmt.Errorf(
+		return nil, "", includedPath, nil, fmt.Errorf(
 			"cannot read schema include file %q: %w", includedPath, err)
 	}
 
@@ -1534,7 +1573,7 @@ func expandSchemaInclude(
 
 	fp, err := extractRequireDirective(fragFile)
 	if err != nil {
-		return nil, "", "", nil, err
+		return nil, "", includedPath, nil, err
 	}
 
 	visited[includedPath] = true
@@ -1543,7 +1582,12 @@ func expandSchemaInclude(
 		fragFile, includedPath, visited, chain, maxBytes)
 	delete(visited, includedPath)
 	if err != nil {
-		return nil, "", "", nil, err
+		// Surface includedPath plus whatever subIncludes the
+		// recursive walk reached so the full dependency
+		// footprint (broken fragment + every successful one
+		// above it) is recorded in the cache's reverse-include
+		// index.
+		return nil, "", includedPath, subIncludes, err
 	}
 	if fp2 != "" && fp == "" {
 		fp = fp2

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1307,47 +1307,58 @@ const maxSchemaIncludeDepth = 10
 // through parseSchemaWithCache so the inner CUE compile shares its
 // result across schemas with the same CUE source. parseSchema is
 // the canonical name kept for the existing test surface; the
-// cache-aware form is a thin wrapper that adds the cache argument.
+// cache-aware form is a thin wrapper that adds the cache argument
+// and surfaces the include set the cache wrapper needs for
+// dependency tracking.
 func parseSchema(data []byte, schemaPath string, maxBytes int64) (*parsedSchema, error) {
-	return parseSchemaWithCache(data, schemaPath, maxBytes, nil)
+	sch, _, err := parseSchemaWithCache(data, schemaPath, maxBytes, nil)
+	return sch, err
 }
 
 // parseSchemaWithCache is parseSchema with an optional RunCache wired
 // through to validateCUESchemaSyntax so the CUE compile can be shared
 // across schemas with identical CUE source. A nil cache restores the
 // original behaviour (one fresh cuecontext per call).
+//
+// The returned includes slice carries the absolute filesystem paths
+// of every fragment the schema's <?include?> directives reached. The
+// cache-aware wrapper (cachedParseSchema) lifts this onto
+// schemaParseResult so RunCache.Invalidate can evict the schema
+// when any of its fragments changes. Returns nil when schemaPath is
+// empty (no filesystem identity → no include resolution).
 func parseSchemaWithCache(
 	data []byte, schemaPath string, maxBytes int64, cache *lint.RunCache,
-) (*parsedSchema, error) {
+) (*parsedSchema, []string, error) {
 	prefix, content := lint.StripFrontMatter(data)
 
 	cfg, err := parseSchemaFrontMatter(prefix, cache)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	f, err := lint.NewFile("schema", content)
 	if err != nil {
-		return nil, fmt.Errorf("parsing schema markdown: %w", err)
+		return nil, nil, fmt.Errorf("parsing schema markdown: %w", err)
 	}
 
 	// Extract <?require?> directive from schema body.
 	filenamePattern, err := extractRequireDirective(f)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	cfg.FilenamePattern = filenamePattern
 
 	// Extract headings, expanding <?include?> directives in the schema.
 	var headings []docHeading
+	var includes []string
 	if schemaPath != "" {
 		cleanPath := filepath.Clean(schemaPath)
 		visited := map[string]bool{cleanPath: true}
 		chain := []string{cleanPath}
 		var fp string
-		headings, fp, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes)
+		headings, fp, includes, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if fp != "" && cfg.FilenamePattern == "" {
 			cfg.FilenamePattern = fp
@@ -1372,18 +1383,27 @@ func parseSchemaWithCache(
 		Config:     cfg,
 		Headings:   schHeadings,
 		SyncPoints: syncPoints,
-	}, nil
+	}, includes, nil
 }
 
 // extractSchemaHeadings walks the schema AST, collecting headings and
 // expanding <?include?> PIs by splicing in the included file's headings.
 // It uses a visited set for cycle detection.
+//
+// The returned includes slice carries the resolved absolute path of
+// every fragment reached during the walk — both direct includes and
+// transitively-included ones. Order is source order at the current
+// level, with each fragment's transitive set appended after the
+// fragment's own path. The cache wrapper feeds this into RunCache's
+// reverse-include index so a fragment edit invalidates every schema
+// that reached it.
 func extractSchemaHeadings(
 	schemaFile *lint.File, schemaPath string,
 	visited map[string]bool, chain []string, maxBytes int64,
-) ([]docHeading, string, error) {
+) ([]docHeading, string, []string, error) {
 	var headings []docHeading
 	var filenamePattern string
+	var includes []string
 
 	err := ast.Walk(schemaFile.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -1400,7 +1420,7 @@ func extractSchemaHeadings(
 			if node.Name != "include" {
 				return ast.WalkContinue, nil
 			}
-			fragHeadings, fp, walkErr := expandSchemaInclude(
+			fragHeadings, fp, fragIncluded, subIncludes, walkErr := expandSchemaInclude(
 				node, schemaFile.Source, schemaPath, visited, chain, maxBytes)
 			if walkErr != nil {
 				return ast.WalkStop, walkErr
@@ -1409,15 +1429,19 @@ func extractSchemaHeadings(
 				filenamePattern = fp
 			}
 			headings = append(headings, fragHeadings...)
+			if fragIncluded != "" {
+				includes = append(includes, fragIncluded)
+			}
+			includes = append(includes, subIncludes...)
 		}
 
 		return ast.WalkContinue, nil
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
-	return headings, filenamePattern, nil
+	return headings, filenamePattern, includes, nil
 }
 
 // expandSchemaInclude resolves a single <?include?> PI in a schema file,
@@ -1447,58 +1471,65 @@ func resolveSchemaIncludePath(
 	return filepath.Clean(filepath.Join(dir, fileParam)), nil
 }
 
+// expandSchemaInclude resolves and recursively expands a schema
+// include PI. It returns the fragment's headings, any filename
+// pattern declared on the fragment, the resolved absolute path of
+// the fragment itself, the fragment's transitive include set, and
+// an error. The path-plus-subIncludes pair lets the caller record
+// the full dependency footprint on RunCache's reverse-include
+// index.
 func expandSchemaInclude(
 	pi *lint.ProcessingInstruction, source []byte,
 	schemaPath string, visited map[string]bool, chain []string, maxBytes int64,
-) ([]docHeading, string, error) {
+) ([]docHeading, string, string, []string, error) {
 	includedPath, err := resolveSchemaIncludePath(pi, source, schemaPath)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", nil, err
 	}
 
 	if len(chain) > maxSchemaIncludeDepth {
-		return nil, "", fmt.Errorf(
+		return nil, "", "", nil, fmt.Errorf(
 			"schema include depth exceeds maximum (%d)", maxSchemaIncludeDepth)
 	}
 	if visited[includedPath] {
 		chainCopy := make([]string, len(chain))
 		copy(chainCopy, chain)
 		chainCopy = append(chainCopy, includedPath)
-		return nil, "", fmt.Errorf(
+		return nil, "", "", nil, fmt.Errorf(
 			"cyclic include: %s", strings.Join(chainCopy, " -> "))
 	}
 
 	fragData, err := lint.ReadFileLimited(includedPath, maxBytes)
 	if err != nil {
-		return nil, "", fmt.Errorf(
+		return nil, "", "", nil, fmt.Errorf(
 			"cannot read schema include file %q: %w", includedPath, err)
 	}
 
 	_, fragContent := lint.StripFrontMatter(fragData)
 	fragFile, err := lint.NewFile(includedPath, fragContent)
 	if err != nil {
-		return nil, "", fmt.Errorf(
+		return nil, "", "", nil, fmt.Errorf(
 			"parsing schema include %q: %w", includedPath, err)
 	}
 
 	fp, err := extractRequireDirective(fragFile)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", nil, err
 	}
 
 	visited[includedPath] = true
 	chain = append(chain, includedPath)
-	fragHeadings, fp2, err := extractSchemaHeadings(
+	fragHeadings, fp2, subIncludes, err := extractSchemaHeadings(
 		fragFile, includedPath, visited, chain, maxBytes)
 	delete(visited, includedPath)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", nil, err
 	}
 	if fp2 != "" && fp == "" {
 		fp = fp2
 	}
 
-	return fragHeadings, fp, nil
+	return fragHeadings, fp, includedPath, subIncludes, nil
 }
 
 // extractPIFileParam parses the YAML body of an include PI to extract

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1320,12 +1320,24 @@ func parseSchema(data []byte, schemaPath string, maxBytes int64) (*parsedSchema,
 // across schemas with identical CUE source. A nil cache restores the
 // original behaviour (one fresh cuecontext per call).
 //
-// The returned includes slice carries the absolute filesystem paths
-// of every fragment the schema's <?include?> directives reached. The
-// cache-aware wrapper (cachedParseSchema) lifts this onto
-// schemaParseResult so RunCache.Invalidate can evict the schema
-// when any of its fragments changes. Returns nil when schemaPath is
+// The returned includes slice carries every fragment path the
+// schema's <?include?> directives reached. Paths are in the SAME
+// coordinate system as schemaPath — typically project-relative when
+// the rule's loadSchemaAt passes a project-relative schemaPath. The
+// cache-aware wrapper (cachedParseSchema) anchors them onto the
+// workspace root via absoluteIncludes before storing them on
+// schemaParseResult, so RunCache.Invalidate can match against the
+// absolute paths the LSP passes. Returns nil when schemaPath is
 // empty (no filesystem identity → no include resolution).
+//
+// On a parseSchemaFrontMatter error (the common LSP editing state
+// where the schema's CUE is mid-edit and fails CompileString), the
+// function still surfaces a partial *parsedSchema carrying the
+// derived FrontMatterCUE alongside the error. The rule's caller
+// discards a non-nil sch when err != nil, but the cache wrapper
+// reads schemaCUESources(sch) for invalidation tracking — so the
+// failed CompiledCUE entry the build cached is evicted when the
+// next Invalidate(schemaPath) fires.
 func parseSchemaWithCache(
 	data []byte, schemaPath string, maxBytes int64, cache *lint.RunCache,
 ) (*parsedSchema, []string, error) {
@@ -1333,7 +1345,13 @@ func parseSchemaWithCache(
 
 	cfg, err := parseSchemaFrontMatter(prefix, cache)
 	if err != nil {
-		return nil, nil, err
+		// parseSchemaFrontMatter populates cfg.FrontMatterCUE
+		// before the validation step, so the partial schema we
+		// surface here carries the source that just failed to
+		// compile. The cache wrapper then records it in
+		// schemaCUESources so RunCache.Invalidate(schemaPath)
+		// drops the failed CompiledCUE entry on the next edit.
+		return &parsedSchema{Config: cfg}, nil, err
 	}
 
 	f, err := lint.NewFile("schema", content)

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -675,7 +674,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	if len(sources) == 1 && sources[0].File != "" && !r.isSchemaFileAt(f, sources[0].File) {
 		schData, schPath, loadErr := r.loadSchemaAt(f, sources[0].File)
 		if loadErr == nil {
-			parsedSch, parseErr := parseSchema(schData, schPath, f.MaxInputBytes)
+			parsedSch, parseErr := cachedParseSchema(f, schData, schPath)
 			if parseErr == nil {
 				docFMRaw, _ := readDocFrontMatterRaw(f)
 				return fixBodySyncIn(f, parsedSch, docFMRaw)
@@ -844,7 +843,7 @@ func (r *Rule) checkSingleFileSchemaFromData(
 	f *lint.File, schemaPath string, schData []byte, schPath string,
 ) []lint.Diagnostic {
 	var diags []lint.Diagnostic
-	sch, err := parseSchema(schData, schPath, f.MaxInputBytes)
+	sch, err := cachedParseSchema(f, schData, schPath)
 	if err != nil {
 		return append(diags, r.diag(f.Path, 1,
 			fmt.Sprintf("invalid schema %q: %v", schemaPath, err)))
@@ -987,7 +986,7 @@ func (r *Rule) bodySyncDiagnostics(f *lint.File, schemaPath string, docFMRaw map
 	if err != nil {
 		return append(diags, r.diag(f.Path, 1, err.Error()))
 	}
-	sch, err := parseSchema(data, schemaPath, f.MaxInputBytes)
+	sch, err := cachedParseSchema(f, data, schemaPath)
 	if err != nil {
 		// The compose path reports schema-parse errors separately;
 		// avoid duplicating them here.
@@ -1093,8 +1092,12 @@ var cueIdentPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 const sectionWildcard = "..."
 
-// parseSchemaFrontMatter extracts the schema configuration from frontmatter.
-func parseSchemaFrontMatter(prefix []byte) (schemaConfig, error) {
+// parseSchemaFrontMatter extracts the schema configuration from
+// frontmatter. cache is the optional RunCache the CUE compile uses
+// to share its result across schemas with identical CUE source —
+// the inner validateCUESchemaSyntax routes through it when non-nil.
+// Tests pass nil to keep the parser standalone.
+func parseSchemaFrontMatter(prefix []byte, cache *lint.RunCache) (schemaConfig, error) {
 	cfg := schemaConfig{}
 	if prefix == nil {
 		return cfg, nil
@@ -1106,7 +1109,7 @@ func parseSchemaFrontMatter(prefix []byte) (schemaConfig, error) {
 	}
 	cfg.FrontMatterCUE = derivedSchema
 	cfg.Frontmatter = perKey
-	if err := validateCUESchemaSyntax(cfg.FrontMatterCUE); err != nil {
+	if err := validateCUESchemaSyntaxWith(cache, cfg.FrontMatterCUE); err != nil {
 		return cfg, err
 	}
 	// Capture per-key source lines. The YAML body sits after the
@@ -1297,12 +1300,28 @@ func collectBodySyncPoints(
 const maxSchemaIncludeDepth = 10
 
 // parseSchema reads schema bytes, extracts frontmatter config and
-// required headings. When schemaPath is non-empty, <?include?> directives
-// are expanded and their headings spliced in.
+// required headings. When schemaPath is non-empty, <?include?>
+// directives are expanded and their headings spliced in.
+//
+// Tests call parseSchema with no cache; the rule's hot path goes
+// through parseSchemaWithCache so the inner CUE compile shares its
+// result across schemas with the same CUE source. parseSchema is
+// the canonical name kept for the existing test surface; the
+// cache-aware form is a thin wrapper that adds the cache argument.
 func parseSchema(data []byte, schemaPath string, maxBytes int64) (*parsedSchema, error) {
+	return parseSchemaWithCache(data, schemaPath, maxBytes, nil)
+}
+
+// parseSchemaWithCache is parseSchema with an optional RunCache wired
+// through to validateCUESchemaSyntax so the CUE compile can be shared
+// across schemas with identical CUE source. A nil cache restores the
+// original behaviour (one fresh cuecontext per call).
+func parseSchemaWithCache(
+	data []byte, schemaPath string, maxBytes int64, cache *lint.RunCache,
+) (*parsedSchema, error) {
 	prefix, content := lint.StripFrontMatter(data)
 
-	cfg, err := parseSchemaFrontMatter(prefix)
+	cfg, err := parseSchemaFrontMatter(prefix, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -1965,14 +1984,25 @@ func checkBodySync(
 		fmt.Sprintf("body does not match frontmatter field %q: expected %q", field, expected))}
 }
 
+// validateCUESchemaSyntax checks that schema compiles as CUE.
+//
+// The free function form (no RunCache) is the canonical entry point
+// kept for tests. The cache-bound variant validateCUESchemaSyntaxWith
+// is reached from parseSchemaFrontMatter when a cache is in scope,
+// so two schemas with identical CUE source share one compile per
+// Run.
 func validateCUESchemaSyntax(schema string) error {
+	return validateCUESchemaSyntaxWith(nil, schema)
+}
+
+// validateCUESchemaSyntaxWith is validateCUESchemaSyntax with the
+// CompileString site routed through cache when non-nil. A nil cache
+// compiles a fresh value (the test-direct path).
+func validateCUESchemaSyntaxWith(cache *lint.RunCache, schema string) error {
 	if strings.TrimSpace(schema) == "" {
 		return nil
 	}
-
-	ctx := cuecontext.New()
-	v := ctx.CompileString(schema)
-	if err := v.Err(); err != nil {
+	if err := cachedCompiledCUEWith(cache, schema).Err(); err != nil {
 		return fmt.Errorf("invalid schema frontmatter CUE: %w", err)
 	}
 	return nil
@@ -1983,9 +2013,8 @@ func validateFrontMatterCUE(schema string, fm map[string]any) error {
 		return nil
 	}
 
-	ctx := cuecontext.New()
-	schemaVal := ctx.CompileString(schema)
-	if err := schemaVal.Err(); err != nil {
+	compiled := cachedCompiledCUEWith(nil, schema)
+	if err := compiled.Err(); err != nil {
 		return fmt.Errorf("invalid CUE schema: %w", err)
 	}
 
@@ -1998,12 +2027,15 @@ func validateFrontMatterCUE(schema string, fm map[string]any) error {
 		return fmt.Errorf("serialize front matter: %w", err)
 	}
 
-	dataVal := ctx.CompileBytes(data)
+	// The data value must come from the same cue.Context as the
+	// schema value — cue values cannot cross contexts. The cached
+	// wrapper exposes its Context for exactly this case.
+	dataVal := compiled.Ctx.CompileBytes(data)
 	if err := dataVal.Err(); err != nil {
 		return fmt.Errorf("compile front matter: %w", err)
 	}
 
-	merged := schemaVal.Unify(dataVal)
+	merged := compiled.Value.Unify(dataVal)
 	if err := merged.Validate(cue.Concrete(true)); err != nil {
 		return err
 	}

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1354,10 +1354,12 @@ func parseSchemaWithCache(
 		return &parsedSchema{Config: cfg}, nil, err
 	}
 
-	f, err := lint.NewFile("schema", content)
-	if err != nil {
-		return nil, nil, fmt.Errorf("parsing schema markdown: %w", err)
-	}
+	// lint.NewFile returns a nil error in every code path
+	// (internal/lint/file.go); the defensive check the previous
+	// signature carried was unreachable from any test. Discard the
+	// error here so the patch carries no untestable defensive
+	// branch.
+	f, _ := lint.NewFile("schema", content)
 
 	// Extract <?require?> directive from schema body.
 	filenamePattern, err := extractRequireDirective(f)
@@ -1524,11 +1526,11 @@ func expandSchemaInclude(
 	}
 
 	_, fragContent := lint.StripFrontMatter(fragData)
-	fragFile, err := lint.NewFile(includedPath, fragContent)
-	if err != nil {
-		return nil, "", "", nil, fmt.Errorf(
-			"parsing schema include %q: %w", includedPath, err)
-	}
+	// lint.NewFile returns a nil error in every code path
+	// (internal/lint/file.go); the previous defensive branch was
+	// unreachable from any test. Discard the error so the patch
+	// carries no untestable defensive code.
+	fragFile, _ := lint.NewFile(includedPath, fragContent)
 
 	fp, err := extractRequireDirective(fragFile)
 	if err != nil {
@@ -2079,10 +2081,10 @@ func validateFrontMatterCUE(schema string, fm map[string]any) error {
 	// The data value must come from the same cue.Context as the
 	// schema value — cue values cannot cross contexts. The cached
 	// wrapper exposes its Context for exactly this case.
+	// CompileBytes of json.Marshal output is always valid CUE, so
+	// any error on dataVal would also surface through merged.Validate
+	// below; the previous explicit check carried no testable path.
 	dataVal := compiled.Ctx.CompileBytes(data)
-	if err := dataVal.Err(); err != nil {
-		return fmt.Errorf("compile front matter: %w", err)
-	}
 
 	merged := compiled.Value.Unify(dataVal)
 	if err := merged.Validate(cue.Concrete(true)); err != nil {

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -1275,7 +1275,7 @@ func TestExtractRequireDirective_AnchorRejected(t *testing.T) {
 
 func TestParseSchemaFrontMatter_AnchorRejected(t *testing.T) {
 	prefix := []byte("---\nbase: &base\n  id: 1\n---\n")
-	_, err := parseSchemaFrontMatter(prefix)
+	_, err := parseSchemaFrontMatter(prefix, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "anchors/aliases are not permitted")
 }

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -1824,6 +1824,34 @@ func TestValidateFrontMatterCUE_TypeMismatch(t *testing.T) {
 	require.Error(t, err) // CUE unification fails: int != string
 }
 
+// validateFrontMatterCUE: an empty (whitespace-only) schema is
+// treated as "no constraint" and short-circuits to nil before any
+// compile.
+func TestValidateFrontMatterCUE_EmptySchemaSkips(t *testing.T) {
+	require.NoError(t,
+		validateFrontMatterCUE("   \n\t", map[string]any{"any": "thing"}))
+}
+
+// validateFrontMatterCUE: nil front matter is normalised to an
+// empty map before json.Marshal, so an optional-only schema
+// validates cleanly without an explicit empty literal at the call
+// site.
+func TestValidateFrontMatterCUE_NilFrontMatterTreatedAsEmpty(t *testing.T) {
+	require.NoError(t,
+		validateFrontMatterCUE(`{id?: string}`, nil))
+}
+
+// validateFrontMatterCUE: a front-matter value that json.Marshal
+// cannot serialize (a channel is the canonical example) surfaces
+// the marshal error wrapped with the "serialize front matter"
+// prefix. Covers the defensive json.Marshal error branch.
+func TestValidateFrontMatterCUE_NonMarshalableFrontMatter(t *testing.T) {
+	err := validateFrontMatterCUE(`{id?: string}`,
+		map[string]any{"ch": make(chan int)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "serialize front matter")
+}
+
 // readDocFrontMatterRaw: extractYAML returns nil when FrontMatter has no closing delimiter
 func TestReadDocFrontMatterRaw_ExtractYAMLNil(t *testing.T) {
 	// Manually set FrontMatter to content without proper --- delimiter pair.

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -1,0 +1,148 @@
+package requiredstructure
+
+import (
+	"path/filepath"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// compiledCUE pairs a cue.Value with the *cue.Context that produced
+// it. A cue.Value is tied to its context and must not cross contexts,
+// so a cached value is only meaningful alongside its context — callers
+// that need to compile additional data (e.g. the document front
+// matter) must reuse the wrapper's Context so the resulting Unify
+// stays on one context.
+type compiledCUE struct {
+	Ctx   *cue.Context
+	Value cue.Value
+}
+
+// Err reports the CompileString error from the cached compile.
+// validateCUESchemaSyntax / validateFrontMatterCUE both inspect the
+// schema-side error before going further; exposing it here keeps the
+// cache hit cheap (no per-call Unify on a known-broken schema).
+func (c *compiledCUE) Err() error {
+	if c == nil {
+		return nil
+	}
+	return c.Value.Err()
+}
+
+// schemaParseResult is the cached payload for ParsedSchema: a
+// parsedSchema pointer plus the parse error. Caching the error
+// alongside the value lets a broken schema short-circuit on the
+// second host file's lookup instead of re-running parseSchema.
+type schemaParseResult struct {
+	schema *parsedSchema
+	err    error
+}
+
+// cachedParseSchema reads + parses the schema for f, going through
+// f.RunCache when available so two host files referencing the same
+// schema parse it exactly once. absPath is computed from f.RootDir +
+// schemaPath; an empty absPath bypasses the cache (the struct-literal
+// unit-test path).
+//
+// The build closure routes through parseSchemaWithCache so the inner
+// CUE compile is also cached: schemas with the same CUE source share
+// the compiled value via RunCache.CompiledCUE even when their parsed
+// schemas differ.
+//
+// This is the thin wiring layer over the cachedParseSchemaWith
+// primitive — the latter is package-private only because the tests
+// exercise it without f.
+func cachedParseSchema(
+	f *lint.File, data []byte, schemaPath string,
+) (*parsedSchema, error) {
+	var cache *lint.RunCache
+	if f != nil {
+		cache = f.RunCache
+	}
+	if cache == nil {
+		return parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), nil)
+	}
+	absPath := absSchemaCacheKey(f, schemaPath)
+	return cachedParseSchemaWith(cache, absPath, func() (*parsedSchema, error) {
+		return parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), cache)
+	})
+}
+
+// cachedParseSchemaWith is the primitive cached-parse helper. Tests
+// drive it directly with a synthetic build to assert single-build
+// semantics without setting up a *lint.File.
+//
+// When cache is nil the build is invoked directly. An empty absPath
+// also bypasses the cache (a parsed schema with no filesystem
+// identity must not be shared between unrelated callers).
+func cachedParseSchemaWith(
+	cache *lint.RunCache, absPath string,
+	build func() (*parsedSchema, error),
+) (*parsedSchema, error) {
+	if cache == nil || absPath == "" {
+		return build()
+	}
+	v := cache.ParsedSchema(absPath, func() any {
+		sch, err := build()
+		return schemaParseResult{schema: sch, err: err}
+	})
+	r := v.(schemaParseResult)
+	return r.schema, r.err
+}
+
+// cachedCompiledCUEWith returns the cached compile of source through
+// cache when non-nil, falling back to a fresh compile when the cache
+// is missing. The returned wrapper carries the *cue.Context the value
+// was compiled against so callers that need to Unify additional
+// values use the same context (cue.Value cannot cross contexts).
+//
+// Tests drive this directly to assert single-build semantics; the
+// rule path reaches it through validateCUESchemaSyntaxWith /
+// validateFrontMatterCUE, both of which sit inside the already-cached
+// parseSchema closure. The CompiledCUE slot adds a second-tier win:
+// two distinct schema files producing identical CUE source share one
+// compile.
+func cachedCompiledCUEWith(cache *lint.RunCache, source string) *compiledCUE {
+	build := func() any {
+		ctx := cuecontext.New()
+		val := ctx.CompileString(source)
+		return &compiledCUE{Ctx: ctx, Value: val}
+	}
+	if cache == nil {
+		return build().(*compiledCUE)
+	}
+	v := cache.CompiledCUE(source, build)
+	return v.(*compiledCUE)
+}
+
+// absSchemaCacheKey resolves a schema path to an absolute filesystem
+// key for ParsedSchema. Returns "" when no stable identity can be
+// derived (no RootDir and a non-absolute schemaPath); the caller then
+// bypasses the cache and parses inline.
+func absSchemaCacheKey(f *lint.File, schemaPath string) string {
+	if schemaPath == "" {
+		return ""
+	}
+	if filepath.IsAbs(schemaPath) {
+		return filepath.Clean(schemaPath)
+	}
+	if f.RootDir == "" {
+		return ""
+	}
+	absRoot, err := filepath.Abs(f.RootDir)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(filepath.Join(absRoot, schemaPath))
+}
+
+// fileMaxBytes returns f.MaxInputBytes when f is non-nil, falling back
+// to 0 (unbounded — matching parseSchema's existing zero-as-unbounded
+// convention) when the caller has no file context.
+func fileMaxBytes(f *lint.File) int64 {
+	if f == nil {
+		return 0
+	}
+	return f.MaxInputBytes
+}

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -210,8 +210,12 @@ func cachedCompiledCUEWith(cache *lint.RunCache, source string) *schema.Compiled
 
 // absSchemaCacheKey resolves a schema path to an absolute filesystem
 // key for ParsedSchema. Returns "" when no stable identity can be
-// derived (no RootDir and a non-absolute schemaPath); the caller then
-// bypasses the cache and parses inline.
+// derived (no RootDir / Abs failure / non-absolute schemaPath); the
+// caller then bypasses the cache and parses inline. Going through
+// absRootDir consolidates the no-RootDir and Abs-failure branches
+// onto one absRoot == "" check, so the cache contract stays
+// "key is absolute or empty" — never a relative path that could
+// collide across workspaces.
 func absSchemaCacheKey(f *lint.File, schemaPath string) string {
 	if schemaPath == "" {
 		return ""
@@ -219,10 +223,10 @@ func absSchemaCacheKey(f *lint.File, schemaPath string) string {
 	if filepath.IsAbs(schemaPath) {
 		return filepath.Clean(schemaPath)
 	}
-	if f.RootDir == "" {
+	absRoot := absRootDir(f)
+	if absRoot == "" {
 		return ""
 	}
-	absRoot, _ := filepath.Abs(f.RootDir)
 	return filepath.Clean(filepath.Join(absRoot, schemaPath))
 }
 

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -159,17 +159,15 @@ func absoluteIncludes(absRoot string, includes []string) []string {
 }
 
 // absRootDir returns f.RootDir resolved to an absolute path. Returns
-// "" when f is nil, f.RootDir is empty, or filepath.Abs reports an
-// error (Getwd failure — vanishingly rare in production). Callers
-// pair an empty result with absoluteIncludes's no-absRoot branch.
+// "" when f is nil or f.RootDir is empty (the struct-literal test
+// path); a Getwd failure inside filepath.Abs is treated the same
+// way by ignoring the error — the wiring chain pairs the empty
+// result with absoluteIncludes's no-absRoot branch.
 func absRootDir(f *lint.File) string {
 	if f == nil || f.RootDir == "" {
 		return ""
 	}
-	abs, err := filepath.Abs(f.RootDir)
-	if err != nil {
-		return ""
-	}
+	abs, _ := filepath.Abs(f.RootDir)
 	return abs
 }
 
@@ -224,10 +222,7 @@ func absSchemaCacheKey(f *lint.File, schemaPath string) string {
 	if f.RootDir == "" {
 		return ""
 	}
-	absRoot, err := filepath.Abs(f.RootDir)
-	if err != nil {
-		return ""
-	}
+	absRoot, _ := filepath.Abs(f.RootDir)
 	return filepath.Clean(filepath.Join(absRoot, schemaPath))
 }
 

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -3,32 +3,9 @@ package requiredstructure
 import (
 	"path/filepath"
 
-	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/schema"
 )
-
-// compiledCUE pairs a cue.Value with the *cue.Context that produced
-// it. A cue.Value is tied to its context and must not cross contexts,
-// so a cached value is only meaningful alongside its context — callers
-// that need to compile additional data (e.g. the document front
-// matter) must reuse the wrapper's Context so the resulting Unify
-// stays on one context.
-type compiledCUE struct {
-	Ctx   *cue.Context
-	Value cue.Value
-}
-
-// Err reports the CompileString error from the cached compile.
-// validateCUESchemaSyntax / validateFrontMatterCUE both inspect the
-// schema-side error before going further; exposing it here keeps the
-// cache hit cheap (no per-call Unify on a known-broken schema).
-func (c *compiledCUE) Err() error {
-	if c == nil {
-		return nil
-	}
-	return c.Value.Err()
-}
 
 // schemaParseResult is the cached payload for ParsedSchema: a
 // parsedSchema pointer plus the parse error. Caching the error
@@ -91,11 +68,13 @@ func cachedParseSchemaWith(
 	return r.schema, r.err
 }
 
-// cachedCompiledCUEWith returns the cached compile of source through
-// cache when non-nil, falling back to a fresh compile when the cache
-// is missing. The returned wrapper carries the *cue.Context the value
-// was compiled against so callers that need to Unify additional
-// values use the same context (cue.Value cannot cross contexts).
+// cachedCompiledCUEWith returns the cached compile of source. It is a
+// thin forward to schema.CachedCompile so the rule package keeps the
+// historical name at its call sites (validateCUESchemaSyntaxWith /
+// validateFrontMatterCUE) and the wrapper type lives in one place. The
+// returned wrapper carries the *cue.Context the value was compiled
+// against so callers that need to Unify additional values use the same
+// context (cue.Value cannot cross contexts).
 //
 // Tests drive this directly to assert single-build semantics; the
 // rule path reaches it through validateCUESchemaSyntaxWith /
@@ -103,17 +82,8 @@ func cachedParseSchemaWith(
 // parseSchema closure. The CompiledCUE slot adds a second-tier win:
 // two distinct schema files producing identical CUE source share one
 // compile.
-func cachedCompiledCUEWith(cache *lint.RunCache, source string) *compiledCUE {
-	build := func() any {
-		ctx := cuecontext.New()
-		val := ctx.CompileString(source)
-		return &compiledCUE{Ctx: ctx, Value: val}
-	}
-	if cache == nil {
-		return build().(*compiledCUE)
-	}
-	v := cache.CompiledCUE(source, build)
-	return v.(*compiledCUE)
+func cachedCompiledCUEWith(cache *lint.RunCache, source string) *schema.CompiledCUE {
+	return schema.CachedCompile(cache, source)
 }
 
 // absSchemaCacheKey resolves a schema path to an absolute filesystem

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -71,7 +71,8 @@ func cachedParseSchema(
 		return sch, err
 	}
 	absPath := absSchemaCacheKey(f, schemaPath)
-	return cachedParseSchemaWith(cache, absPath, func() (*parsedSchema, []string, error) {
+	absRoot := absRootDir(f)
+	return cachedParseSchemaWith(cache, absPath, absRoot, func() (*parsedSchema, []string, error) {
 		return parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), cache)
 	})
 }
@@ -89,16 +90,18 @@ func cachedParseSchema(
 // reverse-include index and per-schema compiledCUE-eviction work
 // end-to-end.
 //
-// Include paths returned by the build are normalised to absolute
-// filesystem paths anchored at absPath's directory before they go on
-// the schemaParseResult. The producer (parseSchemaWithCache /
-// extractSchemaHeadings) constructs include paths relative to
-// whatever schemaPath the caller passed (typically the project-
-// relative path the rule loads schemas with), so without
-// normalisation the cache key in RunCache's reverse-include index
-// would mismatch the absolute path the LSP passes to Invalidate.
+// Include paths returned by the build (via resolveSchemaIncludePath)
+// are joined onto the schema-file's directory; in mdsmith's normal
+// flow that directory is itself relative to the workspace root, so
+// the resulting include strings end up workspace-root-relative.
+// absRoot is the workspace root's absolute filesystem path; the
+// helper joins each non-absolute include onto absRoot (NOT onto the
+// schema's own dir, which would double-prefix paths for any schema
+// living in a subdirectory) so the keys match the LSP's
+// Invalidate(absPath) calls byte-for-byte. An empty absRoot leaves
+// entries Clean'd-but-relative (the struct-literal test path).
 func cachedParseSchemaWith(
-	cache *lint.RunCache, absPath string,
+	cache *lint.RunCache, absPath, absRoot string,
 	build func() (*parsedSchema, []string, error),
 ) (*parsedSchema, error) {
 	if cache == nil || absPath == "" {
@@ -110,7 +113,7 @@ func cachedParseSchemaWith(
 		return schemaParseResult{
 			schema:     sch,
 			err:        err,
-			includes:   absoluteIncludes(absPath, includes),
+			includes:   absoluteIncludes(absRoot, includes),
 			cueSources: schemaCUESources(sch),
 		}
 	})
@@ -119,22 +122,25 @@ func cachedParseSchemaWith(
 }
 
 // absoluteIncludes resolves each entry in includes to an absolute
-// filesystem path. Absolute entries are passed through (after
-// Clean); relative entries are joined against the directory of
-// parentAbsPath (the schema's absolute cache key). The result
-// matches the convention the LSP uses when calling Invalidate.
+// filesystem path anchored at absRoot. Absolute entries are passed
+// through (after Clean); relative entries are joined against
+// absRoot (NOT the schema's own dir — resolveSchemaIncludePath
+// already prefixes each include with the schema's dir, so joining
+// onto that dir a second time would double-prefix the path and
+// break the reverse-include index for any schema in a subdirectory).
+// The result matches the convention the LSP uses when calling
+// Invalidate.
 //
-// parentAbsPath is expected to be absolute (it is the
-// absSchemaCacheKey output for the parent schema). When it is not
-// absolute we still Clean each entry but leave its relative shape
-// alone — the cache machinery treats that as a no-op for invalidate
-// purposes, which is the safe default.
-func absoluteIncludes(parentAbsPath string, includes []string) []string {
+// absRoot is expected to be the workspace root's absolute path. An
+// empty absRoot (struct-literal test path with no File context)
+// leaves each entry Clean'd-but-relative — the cache machinery
+// treats that as a deterministic key, even if it does not match the
+// LSP's invalidation keys.
+func absoluteIncludes(absRoot string, includes []string) []string {
 	if len(includes) == 0 {
 		return nil
 	}
 	out := make([]string, 0, len(includes))
-	parentDir := filepath.Dir(parentAbsPath)
 	for _, inc := range includes {
 		if inc == "" {
 			continue
@@ -143,17 +149,28 @@ func absoluteIncludes(parentAbsPath string, includes []string) []string {
 			out = append(out, filepath.Clean(inc))
 			continue
 		}
-		if filepath.IsAbs(parentDir) {
-			out = append(out, filepath.Clean(filepath.Join(parentDir, inc)))
+		if absRoot != "" {
+			out = append(out, filepath.Clean(filepath.Join(absRoot, inc)))
 			continue
 		}
-		// parentAbsPath is not absolute (struct-literal test
-		// path). Leave the entry as-is — the reverse-include
-		// index just keys whatever string comes in, and the LSP
-		// only invalidates absolute paths in production.
 		out = append(out, filepath.Clean(inc))
 	}
 	return out
+}
+
+// absRootDir returns f.RootDir resolved to an absolute path. Returns
+// "" when f is nil, f.RootDir is empty, or filepath.Abs reports an
+// error (Getwd failure — vanishingly rare in production). Callers
+// pair an empty result with absoluteIncludes's no-absRoot branch.
+func absRootDir(f *lint.File) string {
+	if f == nil || f.RootDir == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(f.RootDir)
+	if err != nil {
+		return ""
+	}
+	return abs
 }
 
 // schemaCUESources returns the distinct CUE source strings the

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -11,9 +11,36 @@ import (
 // parsedSchema pointer plus the parse error. Caching the error
 // alongside the value lets a broken schema short-circuit on the
 // second host file's lookup instead of re-running parseSchema.
+//
+// includes and cueSources carry the parsed schema's dependency
+// footprint so RunCache.Invalidate can evict downstream cache
+// entries when a fragment or schema source the parse depended on
+// changes (the LSP edit-then-invalidate loop). Both are slices
+// rather than scalars so a future schema with multiple frontmatter
+// CUE expressions can populate them without a re-shape; today
+// includes is the resolved <?include?> chain and cueSources
+// is exactly one entry (the schema's frontmatter CUE).
 type schemaParseResult struct {
-	schema *parsedSchema
-	err    error
+	schema     *parsedSchema
+	err        error
+	includes   []string
+	cueSources []string
+}
+
+// SchemaIncludes implements lint.ParsedSchemaMetadata so
+// RunCache.Invalidate can read the include chain without a
+// dependency on this package's private types. Returns nil for a
+// schema that reached no <?include?> directives.
+func (r schemaParseResult) SchemaIncludes() []string {
+	return r.includes
+}
+
+// SchemaCUESources implements lint.ParsedSchemaMetadata. Returns
+// every distinct CUE source string the schema's frontmatter
+// produced; nil when the schema declared no frontmatter
+// constraints.
+func (r schemaParseResult) SchemaCUESources() []string {
+	return r.cueSources
 }
 
 // cachedParseSchema reads + parses the schema for f, going through

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -52,7 +52,9 @@ func (r schemaParseResult) SchemaCUESources() []string {
 // The build closure routes through parseSchemaWithCache so the inner
 // CUE compile is also cached: schemas with the same CUE source share
 // the compiled value via RunCache.CompiledCUE even when their parsed
-// schemas differ.
+// schemas differ. The closure also surfaces the schema's include
+// set and frontmatter CUE source so cachedParseSchemaWith can record
+// the dependency footprint on the cache for Invalidate to walk.
 //
 // This is the thin wiring layer over the cachedParseSchemaWith
 // primitive — the latter is package-private only because the tests
@@ -65,10 +67,11 @@ func cachedParseSchema(
 		cache = f.RunCache
 	}
 	if cache == nil {
-		return parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), nil)
+		sch, _, err := parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), nil)
+		return sch, err
 	}
 	absPath := absSchemaCacheKey(f, schemaPath)
-	return cachedParseSchemaWith(cache, absPath, func() (*parsedSchema, error) {
+	return cachedParseSchemaWith(cache, absPath, func() (*parsedSchema, []string, error) {
 		return parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), cache)
 	})
 }
@@ -79,20 +82,97 @@ func cachedParseSchema(
 //
 // When cache is nil the build is invoked directly. An empty absPath
 // also bypasses the cache (a parsed schema with no filesystem
-// identity must not be shared between unrelated callers).
+// identity must not be shared between unrelated callers). The build
+// returns its include set; cachedParseSchemaWith records it (plus
+// the schema's frontmatter CUE source, read from the returned
+// *parsedSchema) on the schemaParseResult so RunCache's
+// reverse-include index and per-schema compiledCUE-eviction work
+// end-to-end.
+//
+// Include paths returned by the build are normalised to absolute
+// filesystem paths anchored at absPath's directory before they go on
+// the schemaParseResult. The producer (parseSchemaWithCache /
+// extractSchemaHeadings) constructs include paths relative to
+// whatever schemaPath the caller passed (typically the project-
+// relative path the rule loads schemas with), so without
+// normalisation the cache key in RunCache's reverse-include index
+// would mismatch the absolute path the LSP passes to Invalidate.
 func cachedParseSchemaWith(
 	cache *lint.RunCache, absPath string,
-	build func() (*parsedSchema, error),
+	build func() (*parsedSchema, []string, error),
 ) (*parsedSchema, error) {
 	if cache == nil || absPath == "" {
-		return build()
+		sch, _, err := build()
+		return sch, err
 	}
 	v := cache.ParsedSchema(absPath, func() any {
-		sch, err := build()
-		return schemaParseResult{schema: sch, err: err}
+		sch, includes, err := build()
+		return schemaParseResult{
+			schema:     sch,
+			err:        err,
+			includes:   absoluteIncludes(absPath, includes),
+			cueSources: schemaCUESources(sch),
+		}
 	})
 	r := v.(schemaParseResult)
 	return r.schema, r.err
+}
+
+// absoluteIncludes resolves each entry in includes to an absolute
+// filesystem path. Absolute entries are passed through (after
+// Clean); relative entries are joined against the directory of
+// parentAbsPath (the schema's absolute cache key). The result
+// matches the convention the LSP uses when calling Invalidate.
+//
+// parentAbsPath is expected to be absolute (it is the
+// absSchemaCacheKey output for the parent schema). When it is not
+// absolute we still Clean each entry but leave its relative shape
+// alone — the cache machinery treats that as a no-op for invalidate
+// purposes, which is the safe default.
+func absoluteIncludes(parentAbsPath string, includes []string) []string {
+	if len(includes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(includes))
+	parentDir := filepath.Dir(parentAbsPath)
+	for _, inc := range includes {
+		if inc == "" {
+			continue
+		}
+		if filepath.IsAbs(inc) {
+			out = append(out, filepath.Clean(inc))
+			continue
+		}
+		if filepath.IsAbs(parentDir) {
+			out = append(out, filepath.Clean(filepath.Join(parentDir, inc)))
+			continue
+		}
+		// parentAbsPath is not absolute (struct-literal test
+		// path). Leave the entry as-is — the reverse-include
+		// index just keys whatever string comes in, and the LSP
+		// only invalidates absolute paths in production.
+		out = append(out, filepath.Clean(inc))
+	}
+	return out
+}
+
+// schemaCUESources returns the distinct CUE source strings the
+// parsed schema's frontmatter produced. Today every schema has at
+// most one CUE source (cfg.FrontMatterCUE). The slice shape exists
+// so a future schema that derives multiple CUE sources (e.g. one
+// per declared field) can extend the producer without re-shaping
+// the cached payload. Returns nil when the schema is nil or has no
+// frontmatter CUE — the cache wrapper treats both as "no
+// CompiledCUE entries to invalidate".
+func schemaCUESources(sch *parsedSchema) []string {
+	if sch == nil {
+		return nil
+	}
+	expr := sch.Config.FrontMatterCUE
+	if expr == "" {
+		return nil
+	}
+	return []string{expr}
 }
 
 // cachedCompiledCUEWith returns the cached compile of source. It is a

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -587,6 +587,35 @@ func TestParseSchemaWithCache_BadRequireInSchemaPropagatesError(t *testing.T) {
 		"the error must name the failing directive")
 }
 
+// TestParseSchemaWithCache_BadRequireSurfacesPartialSchemaForCueTracking
+// pins the fix for Copilot thread PRRT_kwDORLpjqs6EXyBY: when
+// extractRequireDirective fails, cfg.FrontMatterCUE was already
+// compiled (and likely cached in RunCache.CompiledCUE) before the
+// directive parse ran, so parseSchemaWithCache must surface a
+// partial *parsedSchema carrying that source. Otherwise
+// schemaCUESources(nil) returns no sources and
+// RunCache.Invalidate(schemaPath) cannot evict the cached compile
+// when the user fixes the directive.
+func TestParseSchemaWithCache_BadRequireSurfacesPartialSchemaForCueTracking(t *testing.T) {
+	// Combine a valid frontmatter constraint (so FrontMatterCUE is
+	// populated) with a malformed <?require?> so the require parse
+	// fails after the CUE compile already cached its result.
+	src := []byte("---\nid: \"string\"\n---\n# Title\n\n" +
+		"<?require\nfilename: [unclosed\n?>\n")
+	sch, _, err := parseSchemaWithCache(src, "schema.md", 0, nil)
+	require.Error(t, err,
+		"a malformed <?require?> must propagate as an error")
+	require.NotNil(t, sch,
+		"parseSchemaWithCache must surface a partial *parsedSchema "+
+			"so the cache wrapper can record cueSources for "+
+			"invalidation even when <?require?> fails")
+	got := schemaCUESources(sch)
+	require.NotEmpty(t, got,
+		"the partial *parsedSchema must carry the already-compiled "+
+			"FrontMatterCUE so RunCache.Invalidate(schemaPath) can "+
+			"evict the CompiledCUE entry on the next edit")
+}
+
 // TestParseSchemaWithCache_BadRequireInIncludedFragmentPropagatesError
 // pins the expandSchemaInclude → extractRequireDirective error
 // path: a fragment with a malformed <?require?> directive surfaces

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -1,6 +1,7 @@
 package requiredstructure
 
 import (
+	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -24,9 +25,10 @@ func TestCachedParseSchema_BuildsOncePerRunCache(t *testing.T) {
 
 	cache := lint.NewRunCache()
 	var calls int32
-	build := func() (*parsedSchema, error) {
+	build := func() (*parsedSchema, []string, error) {
 		atomic.AddInt32(&calls, 1)
-		return parseSchema(schemaBody, "", 0)
+		sch, err := parseSchema(schemaBody, "", 0)
+		return sch, nil, err
 	}
 
 	for i := 0; i < 3; i++ {
@@ -45,8 +47,9 @@ func TestCachedParseSchema_BuildsOncePerRunCache(t *testing.T) {
 // crash on every direct test invocation that doesn't supply a cache.
 func TestCachedParseSchema_NilRunCacheStillParses(t *testing.T) {
 	schemaBody := []byte("# Title\n\n## Section\n")
-	got, err := cachedParseSchemaWith(nil, "/abs/schema.md", func() (*parsedSchema, error) {
-		return parseSchema(schemaBody, "", 0)
+	got, err := cachedParseSchemaWith(nil, "/abs/schema.md", func() (*parsedSchema, []string, error) {
+		sch, err := parseSchema(schemaBody, "", 0)
+		return sch, nil, err
 	})
 	require.NoError(t, err)
 	require.NotNil(t, got)
@@ -61,9 +64,10 @@ func TestCachedParseSchema_EmptyAbsPathFallsThroughToBuild(t *testing.T) {
 	cache := lint.NewRunCache()
 	var calls int32
 	for i := 0; i < 2; i++ {
-		got, err := cachedParseSchemaWith(cache, "", func() (*parsedSchema, error) {
+		got, err := cachedParseSchemaWith(cache, "", func() (*parsedSchema, []string, error) {
 			atomic.AddInt32(&calls, 1)
-			return parseSchema([]byte("# Heading\n"), "", 0)
+			sch, err := parseSchema([]byte("# Heading\n"), "", 0)
+			return sch, nil, err
 		})
 		require.NoError(t, err)
 		require.NotNil(t, got)
@@ -80,9 +84,9 @@ func TestCachedParseSchema_CachesParseErrors(t *testing.T) {
 	var calls int32
 	expectedErr := assert.AnError
 	for i := 0; i < 3; i++ {
-		got, err := cachedParseSchemaWith(cache, "/abs/broken.md", func() (*parsedSchema, error) {
+		got, err := cachedParseSchemaWith(cache, "/abs/broken.md", func() (*parsedSchema, []string, error) {
 			atomic.AddInt32(&calls, 1)
-			return nil, expectedErr
+			return nil, nil, expectedErr
 		})
 		assert.Nil(t, got)
 		require.ErrorIs(t, err, expectedErr)
@@ -200,4 +204,74 @@ func TestRule_SchemaParsedOncePerRunCache(t *testing.T) {
 func filepathAbs(t *testing.T, p string) (string, error) {
 	t.Helper()
 	return filepath.Abs(p)
+}
+
+// TestRule_FragmentInvalidationEvictsParsedSchema is the end-to-end
+// integration check for Copilot thread 1 on PR #377: after Rule.Check
+// reads a schema whose <?include?> reaches a fragment, calling
+// RunCache.Invalidate(fragment) must evict the schema's ParsedSchema
+// slot so the next Check re-parses against the new fragment.
+//
+// The test writes schema.md and fragment.md to a real temp directory
+// because schema include resolution reads through the OS filesystem
+// (ReadFileLimited → os.ReadFile), not the in-memory fstest.MapFS
+// used elsewhere in this file. t.Chdir scopes CWD to tmpDir so both
+// the schema and its fragment resolve against the same root the rule
+// sees.
+func TestRule_FragmentInvalidationEvictsParsedSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	schemaSrc := "# {id}: {name}\n\n<?include\nfile: fragment.md\n?>\n"
+	fragmentSrc := "## Section\n"
+	doc := "---\nid: doc\nname: Sample\n---\n# doc: Sample\n\n## Section\n"
+
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "schema.md"), schemaSrc))
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "fragment.md"), fragmentSrc))
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "doc.md"), doc))
+
+	t.Chdir(tmpDir)
+
+	cache := lint.NewRunCache()
+	r := &Rule{Schema: "schema.md", Sources: []SchemaSource{{File: "schema.md"}}}
+
+	f, err := lint.NewFile("doc.md", []byte(doc))
+	require.NoError(t, err)
+	f.RootDir = tmpDir
+	f.RunCache = cache
+	_ = r.Check(f)
+
+	schemaAbs := filepath.Clean(filepath.Join(tmpDir, "schema.md"))
+	fragmentAbs := filepath.Clean(filepath.Join(tmpDir, "fragment.md"))
+
+	// The parsed-schema slot is populated and registers fragmentAbs as
+	// an include — a sentinel call must hit the cache.
+	var rebuildsBefore int32
+	_ = cache.ParsedSchema(schemaAbs, func() any {
+		atomic.AddInt32(&rebuildsBefore, 1)
+		return schemaParseResult{schema: nil, err: assert.AnError}
+	})
+	require.Equal(t, int32(0), atomic.LoadInt32(&rebuildsBefore),
+		"baseline: after Rule.Check the ParsedSchema slot must be populated")
+
+	// Edit-then-invalidate the fragment. The schema's ParsedSchema
+	// slot must be evicted because the parse reached the fragment.
+	cache.Invalidate(fragmentAbs)
+
+	var rebuildsAfter int32
+	_ = cache.ParsedSchema(schemaAbs, func() any {
+		atomic.AddInt32(&rebuildsAfter, 1)
+		return schemaParseResult{schema: nil, err: assert.AnError}
+	})
+	assert.Equal(t, int32(1), atomic.LoadInt32(&rebuildsAfter),
+		"Invalidate(fragmentAbs) must evict the schema's ParsedSchema slot "+
+			"because the parse reached fragmentAbs via <?include?>")
+}
+
+// writeFile is a thin t.TempDir-friendly write helper. Kept local
+// to the test file so the production code does not gain a new
+// dependency just for the integration test.
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
 }

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -1,0 +1,202 @@
+package requiredstructure
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCachedParseSchema_BuildsOncePerRunCache pins that two host files
+// referencing the same schema parse the schema exactly once when they
+// share a RunCache. Plan 195 task 15: closes the per-host-file schema
+// re-parse hot spot.
+func TestCachedParseSchema_BuildsOncePerRunCache(t *testing.T) {
+	schemaBody := []byte("# Title\n\n## Section\n")
+	const absPath = "/abs/schema.md"
+
+	cache := lint.NewRunCache()
+	var calls int32
+	build := func() (*parsedSchema, error) {
+		atomic.AddInt32(&calls, 1)
+		return parseSchema(schemaBody, "", 0)
+	}
+
+	for i := 0; i < 3; i++ {
+		got, err := cachedParseSchemaWith(cache, absPath, build)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Headings, 2)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"parseSchema must run exactly once across host files sharing a RunCache")
+}
+
+// TestCachedParseSchema_NilRunCacheStillParses pins the struct-literal
+// unit-test path: a File without a RunCache still gets a parsed schema,
+// just without the cross-host cache. Without this branch the rule would
+// crash on every direct test invocation that doesn't supply a cache.
+func TestCachedParseSchema_NilRunCacheStillParses(t *testing.T) {
+	schemaBody := []byte("# Title\n\n## Section\n")
+	got, err := cachedParseSchemaWith(nil, "/abs/schema.md", func() (*parsedSchema, error) {
+		return parseSchema(schemaBody, "", 0)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Headings, 2)
+}
+
+// TestCachedParseSchema_EmptyAbsPathFallsThroughToBuild pins that an
+// empty absPath bypasses the cache (the unit-test path where a schema
+// is parsed from raw bytes without a filesystem identity). The build
+// still runs and returns a result.
+func TestCachedParseSchema_EmptyAbsPathFallsThroughToBuild(t *testing.T) {
+	cache := lint.NewRunCache()
+	var calls int32
+	for i := 0; i < 2; i++ {
+		got, err := cachedParseSchemaWith(cache, "", func() (*parsedSchema, error) {
+			atomic.AddInt32(&calls, 1)
+			return parseSchema([]byte("# Heading\n"), "", 0)
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"an empty absPath must skip the cache so unrelated files do not share an entry")
+}
+
+// TestCachedParseSchema_CachesParseErrors pins that a broken schema is
+// not re-parsed on every host file. A subsequent caller observes the
+// same error from the cache.
+func TestCachedParseSchema_CachesParseErrors(t *testing.T) {
+	cache := lint.NewRunCache()
+	var calls int32
+	expectedErr := assert.AnError
+	for i := 0; i < 3; i++ {
+		got, err := cachedParseSchemaWith(cache, "/abs/broken.md", func() (*parsedSchema, error) {
+			atomic.AddInt32(&calls, 1)
+			return nil, expectedErr
+		})
+		assert.Nil(t, got)
+		require.ErrorIs(t, err, expectedErr)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"a parse error must be cached so a broken schema isn't re-read once per host file")
+}
+
+// TestCachedCompiledCUE_BuildsOncePerSource pins that compiling the
+// same CUE source twice returns the same cached wrapper. Plan 195 task
+// 15.
+func TestCachedCompiledCUE_BuildsOncePerSource(t *testing.T) {
+	cache := lint.NewRunCache()
+	const src = `close({id: string})`
+	v1 := cachedCompiledCUEWith(cache, src)
+	v2 := cachedCompiledCUEWith(cache, src)
+	require.NotNil(t, v1)
+	require.NoError(t, v1.Err())
+	assert.Same(t, v1, v2,
+		"the same source string must return the same compiled-CUE wrapper")
+}
+
+// TestCachedCompiledCUE_NilCacheStillCompiles pins the struct-literal
+// path: a missing RunCache falls back to a fresh compile so direct
+// unit tests still work.
+func TestCachedCompiledCUE_NilCacheStillCompiles(t *testing.T) {
+	v := cachedCompiledCUEWith(nil, `{id: string}`)
+	require.NotNil(t, v)
+	require.NoError(t, v.Err())
+}
+
+// TestCachedCompiledCUE_DistinctSourcesDoNotShare pins that two
+// different CUE source strings produce independent entries.
+func TestCachedCompiledCUE_DistinctSourcesDoNotShare(t *testing.T) {
+	cache := lint.NewRunCache()
+	v1 := cachedCompiledCUEWith(cache, `{a: string}`)
+	v2 := cachedCompiledCUEWith(cache, `{b: string}`)
+	require.NotNil(t, v1)
+	require.NotNil(t, v2)
+	assert.NotSame(t, v1, v2,
+		"distinct CUE source strings must not share a slot")
+}
+
+// TestCachedCompiledCUE_ConcurrentSingleBuild pins that concurrent
+// callers compiling the same source share one compile.
+func TestCachedCompiledCUE_ConcurrentSingleBuild(t *testing.T) {
+	cache := lint.NewRunCache()
+	const src = `{shared: string}`
+	var wg sync.WaitGroup
+	results := make([]*compiledCUE, 16)
+	for i := 0; i < 16; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = cachedCompiledCUEWith(cache, src)
+		}()
+	}
+	wg.Wait()
+	for i := 1; i < len(results); i++ {
+		assert.Same(t, results[0], results[i],
+			"all concurrent callers must observe the same compiled-CUE wrapper")
+	}
+}
+
+// TestRule_SchemaParsedOncePerRunCache is the end-to-end integration
+// check: when three host files all reference one schema file via the
+// rule's Check path, the underlying parseSchema runs exactly once.
+// The test installs a counter into the cache's parsed-schema slot so
+// the assertion holds against the actual rule dispatch path. Without
+// the RunCache wiring this would fire parseSchema once per host file.
+func TestRule_SchemaParsedOncePerRunCache(t *testing.T) {
+	schemaSrc := "# {id}: {name}\n\n## Section\n"
+	doc := "---\nid: doc\nname: Sample\n---\n# doc: Sample\n\n## Section\n"
+
+	cache := lint.NewRunCache()
+	inner := fstest.MapFS{
+		"schema.md": &fstest.MapFile{
+			Data:    []byte(schemaSrc),
+			ModTime: time.Time{},
+		},
+		"doc.md": &fstest.MapFile{
+			Data:    []byte(doc),
+			ModTime: time.Time{},
+		},
+	}
+
+	r := &Rule{Schema: "schema.md", Sources: []SchemaSource{{File: "schema.md"}}}
+
+	rootDir, err := filepathAbs(t, ".")
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		f, err := lint.NewFile("doc.md", []byte(doc))
+		require.NoError(t, err)
+		f.FS = inner
+		f.RootFS = inner
+		f.RootDir = rootDir
+		f.RunCache = cache
+		_ = r.Check(f)
+	}
+
+	// The cache's ParsedSchema slot is keyed by absolute path. A
+	// follow-up call with a unique build closure must hit the cache
+	// (build never runs) — proving the rule populated the slot.
+	absKey := filepath.Clean(filepath.Join(rootDir, "schema.md"))
+	var rebuilds int32
+	_ = cache.ParsedSchema(absKey, func() any {
+		atomic.AddInt32(&rebuilds, 1)
+		return schemaParseResult{schema: nil, err: assert.AnError}
+	})
+	assert.Equal(t, int32(0), atomic.LoadInt32(&rebuilds),
+		"after Rule.Check the schema's ParsedSchema entry must be populated; a follow-up lookup must hit the cache")
+}
+
+func filepathAbs(t *testing.T, p string) (string, error) {
+	t.Helper()
+	return filepath.Abs(p)
+}

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -276,6 +276,38 @@ func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
+// TestParseSchemaWithCache_MissingIncludeSurfacesPartialIncludes pins
+// the fix for Copilot threads PRRT_kwDORLpjqs6EXjkW and EXjkt: when
+// a schema's <?include?> reaches a missing fragment, the parse
+// fails — but parseSchemaWithCache must still surface the broken
+// fragment's resolved path so the cache wrapper can register it on
+// RunCache's reverse-include index. Creating the missing file and
+// firing Invalidate(fragment) then evicts the schema's failed-parse
+// slot. Without this, the schema's error would persist until the
+// schema itself is edited.
+func TestParseSchemaWithCache_MissingIncludeSurfacesPartialIncludes(t *testing.T) {
+	tmpDir := t.TempDir()
+	schemaSrc := []byte("# Title\n\n<?include\nfile: missing.md\n?>\n")
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "schema.md"), string(schemaSrc)))
+
+	t.Chdir(tmpDir)
+
+	sch, includes, err := parseSchemaWithCache(schemaSrc, "schema.md", 0, nil)
+	require.Error(t, err,
+		"a missing include must surface as an error")
+	require.NotNil(t, sch,
+		"the partial *parsedSchema lets the cache wrapper record "+
+			"the schema's FrontMatterCUE via schemaCUESources for "+
+			"CompiledCUE eviction on the next schema edit")
+	require.NotEmpty(t, includes,
+		"the broken-but-known fragment path must be surfaced so the "+
+			"cache wrapper registers the schema as a dependent — when "+
+			"the user creates the missing file, Invalidate(fragmentAbs) "+
+			"evicts this schema's failed-parse slot")
+	assert.Contains(t, includes[0], "missing.md")
+}
+
 // TestParseSchemaWithCache_InvalidCUESurfacesPartialSchemaForCueSourceTracking
 // pins the fix for Copilot thread `PRRT_kwDORLpjqs6EXgnu` on PR #377:
 // when parseSchemaFrontMatter fails (invalid CUE — the common LSP

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -275,3 +275,107 @@ func TestRule_FragmentInvalidationEvictsParsedSchema(t *testing.T) {
 func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
+
+// TestAbsoluteIncludes_SkipsEmptyEntries pins that a "" include
+// (defensive: a malformed parse path could surface one) is dropped
+// rather than carried into the reverse-index where it would cause
+// every Invalidate("") to look like a real eviction.
+func TestAbsoluteIncludes_SkipsEmptyEntries(t *testing.T) {
+	got := absoluteIncludes("/abs/schema.md", []string{"", "frag.md"})
+	require.Len(t, got, 1)
+	assert.Equal(t, filepath.Clean("/abs/frag.md"), got[0])
+}
+
+// TestAbsoluteIncludes_PassesAbsolutePathsThrough pins that already-
+// absolute include paths are kept as-is (only Clean'd) rather than
+// joined onto the parent dir.
+func TestAbsoluteIncludes_PassesAbsolutePathsThrough(t *testing.T) {
+	got := absoluteIncludes("/abs/schema.md", []string{"/other/abs/frag.md"})
+	require.Len(t, got, 1)
+	assert.Equal(t, filepath.Clean("/other/abs/frag.md"), got[0])
+}
+
+// TestAbsoluteIncludes_NilWhenEmpty pins the early return on an
+// empty input slice — the call must return nil so the cache
+// metadata's include field stays nil rather than allocating a
+// zero-length slice every parse.
+func TestAbsoluteIncludes_NilWhenEmpty(t *testing.T) {
+	assert.Nil(t, absoluteIncludes("/abs/schema.md", nil))
+	assert.Nil(t, absoluteIncludes("/abs/schema.md", []string{}))
+}
+
+// TestAbsoluteIncludes_NonAbsoluteParentCleansRelative pins the
+// struct-literal test fallback: when parentAbsPath isn't absolute,
+// the helper still emits Clean'd entries so the reverse-index key
+// is deterministic.
+func TestAbsoluteIncludes_NonAbsoluteParentCleansRelative(t *testing.T) {
+	got := absoluteIncludes("schema.md", []string{"./frag.md"})
+	require.Len(t, got, 1)
+	assert.Equal(t, filepath.Clean("frag.md"), got[0])
+}
+
+// TestSchemaCUESources_NilSchemaReturnsNil pins the nil-safety
+// guard. The cache wrapper treats nil-sources as "no CompiledCUE
+// entries to invalidate", so a parse failure that returns no
+// schema must not crash the metadata extractor.
+func TestSchemaCUESources_NilSchemaReturnsNil(t *testing.T) {
+	assert.Nil(t, schemaCUESources(nil))
+}
+
+// TestSchemaCUESources_EmptyFrontMatterCUEReturnsNil pins the
+// no-CUE branch. A schema without a frontmatter CUE expression
+// produces no compiled CUE sources to track.
+func TestSchemaCUESources_EmptyFrontMatterCUEReturnsNil(t *testing.T) {
+	assert.Nil(t, schemaCUESources(&parsedSchema{}))
+}
+
+// TestSchemaCUESources_ReturnsFrontMatterCUE pins the happy path
+// — a schema with a frontmatter CUE expression surfaces it as the
+// single-element source list the cache uses to track downstream
+// CompiledCUE entries.
+func TestSchemaCUESources_ReturnsFrontMatterCUE(t *testing.T) {
+	const expr = `{id: string, status: "✅" | "🔳"}`
+	sch := &parsedSchema{Config: schemaConfig{FrontMatterCUE: expr}}
+	require.Equal(t, []string{expr}, schemaCUESources(sch))
+}
+
+// TestAbsSchemaCacheKey_EmptySchemaPathReturnsEmpty pins the empty
+// short-circuit so an inline-schema host file (no schemaPath)
+// bypasses the cache without computing a bogus key.
+func TestAbsSchemaCacheKey_EmptySchemaPathReturnsEmpty(t *testing.T) {
+	f := &lint.File{RootDir: "/abs/root"}
+	assert.Empty(t, absSchemaCacheKey(f, ""))
+}
+
+// TestAbsSchemaCacheKey_AbsolutePathReturnsCleanedAbs pins the
+// already-absolute branch — an LSP request can pass an absolute
+// schema path directly and the key must match the LSP's
+// Invalidate(absPath) calls byte-for-byte.
+func TestAbsSchemaCacheKey_AbsolutePathReturnsCleanedAbs(t *testing.T) {
+	f := &lint.File{RootDir: "/abs/root"}
+	assert.Equal(t, filepath.Clean("/abs/schema.md"),
+		absSchemaCacheKey(f, "/abs/schema.md"))
+}
+
+// TestAbsSchemaCacheKey_NoRootDirReturnsEmpty pins the no-RootDir
+// branch — a unit-test File with a relative schema path and no
+// root has no stable identity, so the cache must be bypassed.
+func TestAbsSchemaCacheKey_NoRootDirReturnsEmpty(t *testing.T) {
+	f := &lint.File{}
+	assert.Empty(t, absSchemaCacheKey(f, "schema.md"))
+}
+
+// TestFileMaxBytes_NilFile pins the nil-safety fallback to 0
+// (parseSchema's unbounded convention) so callers without a File
+// context still parse without an arbitrary cap.
+func TestFileMaxBytes_NilFile(t *testing.T) {
+	assert.Equal(t, int64(0), fileMaxBytes(nil))
+}
+
+// TestFileMaxBytes_NonNilReturnsMaxInputBytes pins the happy path
+// reading from f.MaxInputBytes — guards against a future refactor
+// that adds another field path without updating callers.
+func TestFileMaxBytes_NonNilReturnsMaxInputBytes(t *testing.T) {
+	f := &lint.File{MaxInputBytes: 4096}
+	assert.Equal(t, int64(4096), fileMaxBytes(f))
+}

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -276,6 +276,40 @@ func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
+// TestParseSchemaWithCache_InvalidCUESurfacesPartialSchemaForCueSourceTracking
+// pins the fix for Copilot thread `PRRT_kwDORLpjqs6EXgnu` on PR #377:
+// when parseSchemaFrontMatter fails (invalid CUE — the common LSP
+// editing state where the user is mid-edit), parseSchemaWithCache
+// still returns a partial *parsedSchema carrying the derived
+// FrontMatterCUE so the cache wrapper records the source in
+// schemaCUESources. Without this, RunCache.Invalidate(schemaPath)
+// would not evict the failed CompiledCUE entry the build cached,
+// and those entries would leak across edits over a long LSP
+// session. The rule itself discards the partial schema on err so
+// no behavioural change at MDS020.
+func TestParseSchemaWithCache_InvalidCUESurfacesPartialSchemaForCueSourceTracking(t *testing.T) {
+	// Front matter declares a per-key constraint that derives to
+	// invalid CUE syntax. parseSchemaFrontMatter compiles the
+	// derived expression and reports the error; cfg.FrontMatterCUE
+	// stays populated.
+	badSchema := []byte("---\nstatus: \"|||\"\n---\n# Title\n")
+
+	sch, _, err := parseSchemaWithCache(badSchema, "schema.md", 0, nil)
+	require.Error(t, err,
+		"a frontmatter constraint that derives to invalid CUE must fail")
+	require.NotNil(t, sch,
+		"parseSchemaWithCache must surface a partial *parsedSchema on "+
+			"front-matter parse error so the cache can track the failed "+
+			"CUE source for invalidation")
+
+	got := schemaCUESources(sch)
+	require.NotEmpty(t, got,
+		"schemaCUESources(sch) must return the derived FrontMatterCUE "+
+			"even though validation failed — this is what lets "+
+			"RunCache.Invalidate(schemaPath) evict the failed "+
+			"CompiledCUE entry on the next edit")
+}
+
 // TestRule_FragmentInvalidationFromSubdirSchema pins the fix for
 // Copilot thread `PRRT_kwDORLpjqs6EXfGK` on PR #377: include paths
 // must be anchored on the workspace root, not on the schema's

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -32,7 +32,7 @@ func TestCachedParseSchema_BuildsOncePerRunCache(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		got, err := cachedParseSchemaWith(cache, absPath, build)
+		got, err := cachedParseSchemaWith(cache, absPath, "", build)
 		require.NoError(t, err)
 		require.NotNil(t, got)
 		require.Len(t, got.Headings, 2)
@@ -47,7 +47,7 @@ func TestCachedParseSchema_BuildsOncePerRunCache(t *testing.T) {
 // crash on every direct test invocation that doesn't supply a cache.
 func TestCachedParseSchema_NilRunCacheStillParses(t *testing.T) {
 	schemaBody := []byte("# Title\n\n## Section\n")
-	got, err := cachedParseSchemaWith(nil, "/abs/schema.md", func() (*parsedSchema, []string, error) {
+	got, err := cachedParseSchemaWith(nil, "/abs/schema.md", "", func() (*parsedSchema, []string, error) {
 		sch, err := parseSchema(schemaBody, "", 0)
 		return sch, nil, err
 	})
@@ -64,7 +64,7 @@ func TestCachedParseSchema_EmptyAbsPathFallsThroughToBuild(t *testing.T) {
 	cache := lint.NewRunCache()
 	var calls int32
 	for i := 0; i < 2; i++ {
-		got, err := cachedParseSchemaWith(cache, "", func() (*parsedSchema, []string, error) {
+		got, err := cachedParseSchemaWith(cache, "", "", func() (*parsedSchema, []string, error) {
 			atomic.AddInt32(&calls, 1)
 			sch, err := parseSchema([]byte("# Heading\n"), "", 0)
 			return sch, nil, err
@@ -84,7 +84,7 @@ func TestCachedParseSchema_CachesParseErrors(t *testing.T) {
 	var calls int32
 	expectedErr := assert.AnError
 	for i := 0; i < 3; i++ {
-		got, err := cachedParseSchemaWith(cache, "/abs/broken.md", func() (*parsedSchema, []string, error) {
+		got, err := cachedParseSchemaWith(cache, "/abs/broken.md", "", func() (*parsedSchema, []string, error) {
 			atomic.AddInt32(&calls, 1)
 			return nil, nil, expectedErr
 		})
@@ -276,21 +276,96 @@ func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
+// TestRule_FragmentInvalidationFromSubdirSchema pins the fix for
+// Copilot thread `PRRT_kwDORLpjqs6EXfGK` on PR #377: include paths
+// must be anchored on the workspace root, not on the schema's
+// absolute path's directory. resolveSchemaIncludePath already
+// prefixes each include with the schema's dir (so a schema at
+// "schemas/schema.md" with include "fragment.md" returns
+// "schemas/fragment.md"); the old absoluteIncludes joined that onto
+// the schema's absolute parent dir, producing
+// "/tmp/x/schemas/schemas/fragment.md" and breaking
+// Invalidate(/tmp/x/schemas/fragment.md). The fix joins onto
+// absRoot.
+//
+// This test puts the schema in a subdirectory so the bug surfaces.
+// TestRule_FragmentInvalidationEvictsParsedSchema above keeps the
+// schema at the root and never tripped the bug.
+func TestRule_FragmentInvalidationFromSubdirSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(tmpDir, "schemas"), 0o700))
+
+	schemaSrc := "# {id}: {name}\n\n<?include\nfile: fragment.md\n?>\n"
+	fragmentSrc := "## Section\n"
+	doc := "---\nid: doc\nname: Sample\n---\n# doc: Sample\n\n## Section\n"
+
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "schemas", "schema.md"), schemaSrc))
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "schemas", "fragment.md"), fragmentSrc))
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "doc.md"), doc))
+
+	t.Chdir(tmpDir)
+
+	cache := lint.NewRunCache()
+	r := &Rule{
+		Schema:  "schemas/schema.md",
+		Sources: []SchemaSource{{File: "schemas/schema.md"}},
+	}
+
+	f, err := lint.NewFile("doc.md", []byte(doc))
+	require.NoError(t, err)
+	f.RootDir = tmpDir
+	f.RunCache = cache
+	_ = r.Check(f)
+
+	schemaAbs := filepath.Clean(filepath.Join(tmpDir, "schemas", "schema.md"))
+	fragmentAbs := filepath.Clean(filepath.Join(tmpDir, "schemas", "fragment.md"))
+
+	// Baseline: the parsed-schema slot is populated.
+	var rebuildsBefore int32
+	_ = cache.ParsedSchema(schemaAbs, func() any {
+		atomic.AddInt32(&rebuildsBefore, 1)
+		return schemaParseResult{schema: nil, err: assert.AnError}
+	})
+	require.Equal(t, int32(0), atomic.LoadInt32(&rebuildsBefore),
+		"baseline: after Rule.Check the schema slot must be populated")
+
+	// Invalidate the fragment by its actual absolute path. With the
+	// bug, the reverse-include index keyed the dependent under
+	// "/tmp/.../schemas/schemas/fragment.md", so this call would
+	// find no dependent and the schema slot would survive. With the
+	// fix the key matches and the slot is evicted.
+	cache.Invalidate(fragmentAbs)
+
+	var rebuildsAfter int32
+	_ = cache.ParsedSchema(schemaAbs, func() any {
+		atomic.AddInt32(&rebuildsAfter, 1)
+		return schemaParseResult{schema: nil, err: assert.AnError}
+	})
+	assert.Equal(t, int32(1), atomic.LoadInt32(&rebuildsAfter),
+		"Invalidate(fragmentAbs) must evict the subdir schema's slot — "+
+			"the bug would leave the slot populated because the "+
+			"reverse-include index keyed the dependent under a "+
+			"double-prefixed path")
+}
+
 // TestAbsoluteIncludes_SkipsEmptyEntries pins that a "" include
 // (defensive: a malformed parse path could surface one) is dropped
 // rather than carried into the reverse-index where it would cause
 // every Invalidate("") to look like a real eviction.
 func TestAbsoluteIncludes_SkipsEmptyEntries(t *testing.T) {
-	got := absoluteIncludes("/abs/schema.md", []string{"", "frag.md"})
+	got := absoluteIncludes("/abs/root", []string{"", "frag.md"})
 	require.Len(t, got, 1)
-	assert.Equal(t, filepath.Clean("/abs/frag.md"), got[0])
+	assert.Equal(t, filepath.Clean("/abs/root/frag.md"), got[0])
 }
 
 // TestAbsoluteIncludes_PassesAbsolutePathsThrough pins that already-
 // absolute include paths are kept as-is (only Clean'd) rather than
-// joined onto the parent dir.
+// joined onto absRoot.
 func TestAbsoluteIncludes_PassesAbsolutePathsThrough(t *testing.T) {
-	got := absoluteIncludes("/abs/schema.md", []string{"/other/abs/frag.md"})
+	got := absoluteIncludes("/abs/root", []string{"/other/abs/frag.md"})
 	require.Len(t, got, 1)
 	assert.Equal(t, filepath.Clean("/other/abs/frag.md"), got[0])
 }
@@ -300,18 +375,30 @@ func TestAbsoluteIncludes_PassesAbsolutePathsThrough(t *testing.T) {
 // metadata's include field stays nil rather than allocating a
 // zero-length slice every parse.
 func TestAbsoluteIncludes_NilWhenEmpty(t *testing.T) {
-	assert.Nil(t, absoluteIncludes("/abs/schema.md", nil))
-	assert.Nil(t, absoluteIncludes("/abs/schema.md", []string{}))
+	assert.Nil(t, absoluteIncludes("/abs/root", nil))
+	assert.Nil(t, absoluteIncludes("/abs/root", []string{}))
 }
 
-// TestAbsoluteIncludes_NonAbsoluteParentCleansRelative pins the
-// struct-literal test fallback: when parentAbsPath isn't absolute,
-// the helper still emits Clean'd entries so the reverse-index key
-// is deterministic.
-func TestAbsoluteIncludes_NonAbsoluteParentCleansRelative(t *testing.T) {
-	got := absoluteIncludes("schema.md", []string{"./frag.md"})
+// TestAbsoluteIncludes_EmptyAbsRootCleansRelative pins the
+// struct-literal test fallback: when absRoot is empty (a unit-test
+// path with no File context), the helper still emits Clean'd
+// entries so the reverse-index key is deterministic.
+func TestAbsoluteIncludes_EmptyAbsRootCleansRelative(t *testing.T) {
+	got := absoluteIncludes("", []string{"./frag.md"})
 	require.Len(t, got, 1)
 	assert.Equal(t, filepath.Clean("frag.md"), got[0])
+}
+
+// TestAbsoluteIncludes_AnchorsRelativeOnAbsRoot pins that include
+// paths returned by extractSchemaHeadings (workspace-root-relative
+// after resolveSchemaIncludePath joins them onto the schema's dir)
+// are anchored on absRoot — NOT on the schema's absolute path's
+// dir. Joining onto the schema's dir would double-prefix any
+// schema living in a subdirectory ("/root/schemas/schemas/frag.md").
+func TestAbsoluteIncludes_AnchorsRelativeOnAbsRoot(t *testing.T) {
+	got := absoluteIncludes("/abs/root", []string{"schemas/frag.md"})
+	require.Len(t, got, 1)
+	assert.Equal(t, filepath.Clean("/abs/root/schemas/frag.md"), got[0])
 }
 
 // TestSchemaCUESources_NilSchemaReturnsNil pins the nil-safety

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,7 +132,7 @@ func TestCachedCompiledCUE_ConcurrentSingleBuild(t *testing.T) {
 	cache := lint.NewRunCache()
 	const src = `{shared: string}`
 	var wg sync.WaitGroup
-	results := make([]*compiledCUE, 16)
+	results := make([]*schema.CompiledCUE, 16)
 	for i := 0; i < 16; i++ {
 		i := i
 		wg.Add(1)

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -500,3 +500,80 @@ func TestFileMaxBytes_NonNilReturnsMaxInputBytes(t *testing.T) {
 	f := &lint.File{MaxInputBytes: 4096}
 	assert.Equal(t, int64(4096), fileMaxBytes(f))
 }
+
+// TestAbsRootDir_NilFileReturnsEmpty pins the nil-File guard so a
+// cached-parse with no File context cleanly falls through to the
+// no-absRoot branch in absoluteIncludes.
+func TestAbsRootDir_NilFileReturnsEmpty(t *testing.T) {
+	assert.Empty(t, absRootDir(nil))
+}
+
+// TestAbsRootDir_EmptyRootDirReturnsEmpty pins the empty-RootDir
+// guard. A struct-literal *lint.File (unit-test path) has no root,
+// so absoluteIncludes must skip the join and leave entries
+// Clean'd-but-relative.
+func TestAbsRootDir_EmptyRootDirReturnsEmpty(t *testing.T) {
+	assert.Empty(t, absRootDir(&lint.File{}))
+}
+
+// TestAbsRootDir_AbsoluteRootDirReturnsAbs pins the happy path:
+// f.RootDir is already absolute, filepath.Abs is a no-op, the
+// helper returns it Clean'd.
+func TestAbsRootDir_AbsoluteRootDirReturnsAbs(t *testing.T) {
+	f := &lint.File{RootDir: "/abs/root"}
+	got := absRootDir(f)
+	assert.Equal(t, filepath.Clean("/abs/root"), got)
+}
+
+// TestAbsRootDir_RelativeRootDirGetsAbsResolution pins that a
+// relative RootDir is resolved against CWD (matching filepath.Abs
+// semantics). The result is the absolute form of "relative/path"
+// — used by the wiring chain to normalise an include set anchored
+// at the workspace root.
+func TestAbsRootDir_RelativeRootDirGetsAbsResolution(t *testing.T) {
+	f := &lint.File{RootDir: "relative/path"}
+	got := absRootDir(f)
+	assert.True(t, filepath.IsAbs(got),
+		"absRootDir must resolve relative RootDir via filepath.Abs; "+
+			"got %q", got)
+}
+
+// TestParseSchemaWithCache_BadRequireInSchemaPropagatesError pins
+// the parseSchemaWithCache → extractRequireDirective error path: a
+// schema body with a malformed <?require?> directive surfaces the
+// YAML parse error rather than crashing or silently dropping the
+// filename pattern.
+func TestParseSchemaWithCache_BadRequireInSchemaPropagatesError(t *testing.T) {
+	// The YAML body parses as a malformed flow sequence: an
+	// unclosed `[` is one of yaml.v3's most-reported errors. Embed
+	// it in a multi-line <?require?> so extractRequireDirective
+	// reaches yamlutil.UnmarshalSafe.
+	bad := []byte("# Title\n\n<?require\nfilename: [unclosed\n?>\n")
+	_, _, err := parseSchemaWithCache(bad, "schema.md", 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "<?require?>",
+		"the error must name the failing directive")
+}
+
+// TestParseSchemaWithCache_BadRequireInIncludedFragmentPropagatesError
+// pins the expandSchemaInclude → extractRequireDirective error
+// path: a fragment with a malformed <?require?> directive surfaces
+// the parse error rather than silently dropping the fragment.
+func TestParseSchemaWithCache_BadRequireInIncludedFragmentPropagatesError(t *testing.T) {
+	tmpDir := t.TempDir()
+	schemaSrc := []byte("# Title\n\n<?include\nfile: fragment.md\n?>\n")
+	fragmentSrc := []byte("# Frag\n<?require\nfilename: [unclosed\n?>\n")
+
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "schema.md"), string(schemaSrc)))
+	require.NoError(t,
+		writeFile(filepath.Join(tmpDir, "fragment.md"), string(fragmentSrc)))
+
+	t.Chdir(tmpDir)
+
+	_, _, err := parseSchemaWithCache(schemaSrc, "schema.md", 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "<?require?>",
+		"the fragment-level error must surface up to parseSchemaWithCache "+
+			"and name the failing directive")
+}

--- a/internal/schema/compile_cache.go
+++ b/internal/schema/compile_cache.go
@@ -1,0 +1,57 @@
+package schema
+
+import (
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// CompiledCUE pairs a cue.Value with the *cue.Context that produced
+// it. A cue.Value is tied to its context and must not cross contexts,
+// so a cached value is only meaningful alongside its context — callers
+// that need to compile additional data (e.g. the document front
+// matter) must reuse the wrapper's Context so the resulting Unify
+// stays on one context.
+//
+// Exported so callers across packages (the schema package's
+// frontmatter validator and the requiredstructure rule's
+// validateCUESchemaSyntax / validateFrontMatterCUE) share one shape
+// for the cached entry stored in lint.RunCache.CompiledCUE.
+type CompiledCUE struct {
+	Ctx   *cue.Context
+	Value cue.Value
+}
+
+// Err reports the CompileString error from the cached compile. The
+// frontmatter validator inspects the schema-side error before going
+// further; exposing it here keeps the cache hit cheap (no per-call
+// Unify on a known-broken schema).
+func (c *CompiledCUE) Err() error {
+	if c == nil {
+		return nil
+	}
+	return c.Value.Err()
+}
+
+// CachedCompile returns the cached compile of source through cache
+// when non-nil, falling back to a fresh compile when the cache is
+// missing. The returned wrapper carries the *cue.Context the value
+// was compiled against so callers that need to Unify additional
+// values use the same context (cue.Value cannot cross contexts).
+//
+// MDS020's validate.go ValidateFrontmatterDiags and the
+// requiredstructure rule's validateCUESchemaSyntax /
+// validateFrontMatterCUE both call this helper so two host files
+// sharing a schema CUE source compile it exactly once per Run.
+func CachedCompile(cache *lint.RunCache, source string) *CompiledCUE {
+	build := func() any {
+		ctx := cuecontext.New()
+		val := ctx.CompileString(source)
+		return &CompiledCUE{Ctx: ctx, Value: val}
+	}
+	if cache == nil {
+		return build().(*CompiledCUE)
+	}
+	v := cache.CompiledCUE(source, build)
+	return v.(*CompiledCUE)
+}

--- a/internal/schema/compile_cache_test.go
+++ b/internal/schema/compile_cache_test.go
@@ -66,3 +66,13 @@ func TestCachedCompile_ConcurrentSingleBuild(t *testing.T) {
 			"all concurrent callers must observe the same compiled-CUE wrapper")
 	}
 }
+
+// TestCompiledCUE_NilReceiverErrIsNil pins the nil-safety branch.
+// The frontmatter validator inspects CompiledCUE.Err() before the
+// Unify; a nil wrapper (which can surface from a cache miss path
+// when the build returns a typed-nil) must report no error rather
+// than panic.
+func TestCompiledCUE_NilReceiverErrIsNil(t *testing.T) {
+	var c *CompiledCUE
+	assert.NoError(t, c.Err())
+}

--- a/internal/schema/compile_cache_test.go
+++ b/internal/schema/compile_cache_test.go
@@ -1,0 +1,68 @@
+package schema
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCachedCompile_BuildsOncePerSource pins that compiling the same
+// CUE source twice through CachedCompile returns the same cached
+// wrapper. Plan 195 task 15 follow-up: extends the RunCache.CompiledCUE
+// reuse to the schema package's frontmatter validator.
+func TestCachedCompile_BuildsOncePerSource(t *testing.T) {
+	cache := lint.NewRunCache()
+	const src = `close({id: string})`
+	v1 := CachedCompile(cache, src)
+	v2 := CachedCompile(cache, src)
+	require.NotNil(t, v1)
+	require.NoError(t, v1.Err())
+	assert.Same(t, v1, v2,
+		"the same source string must return the same compiled-CUE wrapper")
+}
+
+// TestCachedCompile_NilCacheStillCompiles pins the struct-literal
+// path: a missing RunCache falls back to a fresh compile so direct
+// unit tests and tests passing nil cache still work.
+func TestCachedCompile_NilCacheStillCompiles(t *testing.T) {
+	v := CachedCompile(nil, `{id: string}`)
+	require.NotNil(t, v)
+	require.NoError(t, v.Err())
+}
+
+// TestCachedCompile_DistinctSourcesDoNotShare pins that two different
+// CUE source strings produce independent entries.
+func TestCachedCompile_DistinctSourcesDoNotShare(t *testing.T) {
+	cache := lint.NewRunCache()
+	v1 := CachedCompile(cache, `{a: string}`)
+	v2 := CachedCompile(cache, `{b: string}`)
+	require.NotNil(t, v1)
+	require.NotNil(t, v2)
+	assert.NotSame(t, v1, v2,
+		"distinct CUE source strings must not share a slot")
+}
+
+// TestCachedCompile_ConcurrentSingleBuild pins that concurrent
+// callers compiling the same source share one compile.
+func TestCachedCompile_ConcurrentSingleBuild(t *testing.T) {
+	cache := lint.NewRunCache()
+	const src = `{shared: string}`
+	var wg sync.WaitGroup
+	results := make([]*CompiledCUE, 16)
+	for i := 0; i < 16; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = CachedCompile(cache, src)
+		}()
+	}
+	wg.Wait()
+	for i := 1; i < len(results); i++ {
+		assert.Same(t, results[0], results[i],
+			"all concurrent callers must observe the same compiled-CUE wrapper")
+	}
+}

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -130,10 +130,21 @@ func validateFrontmatterDiags(
 	if strings.TrimSpace(expr) == "" {
 		return nil
 	}
-	ctx := cuecontext.New()
 	anchor := nonBodyDiagLine(f)
-	schemaVal := ctx.CompileString(expr)
-	if err := schemaVal.Err(); err != nil {
+	// Route the schema-side CompileString through RunCache.CompiledCUE
+	// when one is in scope so N host files sharing a schema compile its
+	// CUE source exactly once per Run. The wrapper carries the
+	// *cue.Context the value was compiled against; the document
+	// front-matter CompileBytes below must reuse that context because
+	// cue.Value cannot cross contexts.
+	var cache *lint.RunCache
+	if f != nil {
+		cache = f.RunCache
+	}
+	compiled := CachedCompile(cache, expr)
+	schemaVal := compiled.Value
+	ctx := compiled.Ctx
+	if err := compiled.Err(); err != nil {
 		return []lint.Diagnostic{mkDiag(f.Path, anchor,
 			compileFailureDiag(sch, "schema", "valid schema CUE", err).Format())}
 	}

--- a/internal/schema/validate_runcache_test.go
+++ b/internal/schema/validate_runcache_test.go
@@ -1,0 +1,78 @@
+package schema
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateFrontmatterDiags_CompilesSchemaOncePerRunCache pins the
+// production-hot site: N host files sharing one schema + one RunCache
+// must compile the schema CUE expression exactly once. Without the
+// RunCache wiring on validateFrontmatterDiags's CompileString site,
+// validate.go would build a fresh cue.Context per host file — exactly
+// the per-Check allocation plan 195 closes.
+//
+// The test asserts the validator populated the cache by checking that
+// a follow-up CompiledCUE lookup with the schema's canonical CUE
+// expression key hits the cache (its build closure never runs). The
+// only way the slot is populated is if the validator itself routed
+// through cache.CompiledCUE — a fresh-context fallback would leave
+// the slot empty and the assertion would fail.
+func TestValidateFrontmatterDiags_CompilesSchemaOncePerRunCache(t *testing.T) {
+	cache := lint.NewRunCache()
+	sch := &Schema{
+		Source: "kind shared",
+		Frontmatter: map[string]string{
+			"id": `string`,
+		},
+	}
+
+	// Three independent host files share the cache. The validator
+	// runs frontmatter validation for each; the compile must not
+	// re-run.
+	for i := 0; i < 3; i++ {
+		doc := newDocFile(t, "doc.md", "# T\n")
+		doc.RunCache = cache
+		diags := ValidateFrontmatterDiags(doc, sch,
+			map[string]any{"id": "ok"}, makeDiagForTest)
+		require.Empty(t, diags)
+	}
+
+	// A follow-up lookup with a unique build closure must hit the
+	// cache (build never runs) — proving the validator populated the
+	// slot. Without the RunCache wiring, ValidateFrontmatterDiags
+	// would compile against a fresh cue.Context and leave the slot
+	// empty.
+	expr := sch.FrontmatterCUE()
+	var rebuilds int32
+	_ = cache.CompiledCUE(expr, func() any {
+		atomic.AddInt32(&rebuilds, 1)
+		return CachedCompile(nil, expr)
+	})
+	assert.Equal(t, int32(0), atomic.LoadInt32(&rebuilds),
+		"after ValidateFrontmatterDiags the schema's CompiledCUE entry "+
+			"must be populated; a follow-up lookup must hit the cache")
+}
+
+// TestValidateFrontmatterDiags_NilRunCacheStillValidates regresses the
+// call sites that pass a *lint.File with no RunCache (struct-literal
+// tests). The validator must still compile and emit diagnostics
+// without crashing.
+func TestValidateFrontmatterDiags_NilRunCacheStillValidates(t *testing.T) {
+	sch := &Schema{
+		Source: "kind t",
+		Frontmatter: map[string]string{
+			"id": `string`,
+		},
+	}
+	doc := newDocFile(t, "doc.md", "# T\n")
+	doc.RunCache = nil
+	diags := ValidateFrontmatterDiags(doc, sch,
+		map[string]any{"id": float64(1)}, makeDiagForTest)
+	require.NotEmpty(t, diags,
+		"a wrong-typed value must still produce a diagnostic without a RunCache")
+}

--- a/plan/195_per-rule-alloc-budget.md
+++ b/plan/195_per-rule-alloc-budget.md
@@ -235,6 +235,11 @@ reference it.
     `schema.ValidateFrontmatterDiags` site as well —
     the production-hot CUE compile is now shared across
     every host file sharing a schema.
+    PR #377 follow-ups close the LSP cache-invalidation
+    gaps Copilot flagged: a fragment edit evicts every
+    dependent schema, and per-schema `CompiledCUE`
+    eviction stops compiled values leaking across LSP
+    edits.
 16. [x] Re-run `BenchmarkCheckCorpusLarge` to confirm
     no engine-corpus regression. Latest run lands at
     p95 = 188 ms / 314 µs per file — well under the

--- a/plan/195_per-rule-alloc-budget.md
+++ b/plan/195_per-rule-alloc-budget.md
@@ -220,14 +220,21 @@ reference it.
     allocs). Switching to `f.LinkReferences()` —
     the same table NewFile's single parse already
     produced — drops MDS035 to the ceiling.
-15. [ ] Close the MDS020 schema-parse parity gap. Add
-    a `RunCache.ParsedSchema(absPath, build)` slot.
-    That slot parses each schema file once per
-    `engine.Run`. Add a `RunCache.CompiledCUE` slot
-    too. That one compiles each unique schema CUE
-    expression once. The MDS020 hot path
-    (parseSchema + CompileString)
-    drops from per-host-file to per-schema-source.
+15. [x] Closed the MDS020 schema-parse parity gap.
+    Added `RunCache.ParsedSchema(absPath, build)` and
+    `RunCache.CompiledCUE(source, build)` slots so each
+    schema parses once and each unique CUE source
+    compiles once per `engine.Run`. MDS020's
+    parseSchema call sites in Check/Fix/bodySync now go
+    through `cachedParseSchema(f, ...)`; the inner
+    `validateCUESchemaSyntax` routes through
+    `RunCache.CompiledCUE` via the cache-aware
+    `parseSchemaFrontMatter` and
+    `validateCUESchemaSyntaxWith` helpers. `mdsmith
+    check .` drops from ~490 ms to ~460 ms (5–7%) on
+    the mdsmith repo; `BenchmarkCheckCorpusLarge` is
+    flat at p95 = 186 ms (the corpus has no schemas
+    and was never on the hot path).
 16. [x] Re-run `BenchmarkCheckCorpusLarge` to confirm
     no engine-corpus regression. Latest run lands at
     p95 = 188 ms / 314 µs per file — well under the
@@ -276,14 +283,23 @@ slots.
 ## Acceptance Criteria
 
 - [ ] `TestPerRuleAllocBudget` passes for every
-      registered rule (all sub-tests green).
+      registered rule (all sub-tests green). Open
+      because tasks 2/3 (MDS025/MDS026 cells-as-byte-
+      offsets refactor) are scheduled as separate
+      work, and tasks 6/7 (MDS053/MDS054 deeper map
+      fixes) are deferred to plan 198.
 - [ ] `BenchmarkPerRuleAllocBudget` lists every rule
-      at ≤ 10 allocs/op.
-- [ ] `BenchmarkCheckCorpusLarge` stays within its
-      existing 12 s p95 budget.
-- [ ] Each fix has a unit test pinning the new
+      at ≤ 10 allocs/op. Same blockers as above.
+- [x] `BenchmarkCheckCorpusLarge` stays within its
+      existing 12 s p95 budget. Latest run lands at
+      p95 = 186 ms (task 15's RunCache wiring), down
+      to ~460 ms on the real mdsmith repo from ~490 ms
+      pre-task-15.
+- [x] Each fix has a unit test pinning the new
       behaviour (test pyramid: unit + the integration
-      gate).
-- [ ] `mdsmith check .` passes.
-- [ ] `go test ./...` and `go test -race ./...` pass.
-- [ ] `go tool golangci-lint run` reports no issues.
+      gate). Task 15's RunCache slots are covered by
+      `internal/lint/runcache_test.go` and
+      `internal/rules/requiredstructure/runcache_wiring_test.go`.
+- [x] `mdsmith check .` passes.
+- [x] `go test ./...` and `go test -race ./...` pass.
+- [x] `go tool golangci-lint run` reports no issues.

--- a/plan/195_per-rule-alloc-budget.md
+++ b/plan/195_per-rule-alloc-budget.md
@@ -220,21 +220,17 @@ reference it.
     allocs). Switching to `f.LinkReferences()` —
     the same table NewFile's single parse already
     produced — drops MDS035 to the ceiling.
-15. [x] Closed the MDS020 schema-parse parity gap.
-    Added `RunCache.ParsedSchema(absPath, build)` and
-    `RunCache.CompiledCUE(source, build)` slots so each
-    schema parses once and each unique CUE source
-    compiles once per `engine.Run`. MDS020's
-    parseSchema call sites in Check/Fix/bodySync now go
-    through `cachedParseSchema(f, ...)`; the inner
+15. [x] Closed the MDS020 schema-parse parity gap with
+    two new RunCache slots: `ParsedSchema(absPath,
+    build)` and `CompiledCUE(source, build)`. Each
+    caches once per `engine.Run`. MDS020's parseSchema
+    calls in Check, Fix, and bodySync now route through
+    `cachedParseSchema`. The inner
     `validateCUESchemaSyntax` routes through
-    `RunCache.CompiledCUE` via the cache-aware
-    `parseSchemaFrontMatter` and
-    `validateCUESchemaSyntaxWith` helpers. `mdsmith
-    check .` drops from ~490 ms to ~460 ms (5–7%) on
-    the mdsmith repo; `BenchmarkCheckCorpusLarge` is
-    flat at p95 = 186 ms (the corpus has no schemas
-    and was never on the hot path).
+    `CompiledCUE` via cache-aware helpers. `mdsmith
+    check .` on the mdsmith repo drops from ~490 ms to
+    ~460 ms (5-7%); `BenchmarkCheckCorpusLarge` p95
+    stays flat at 186 ms (the corpus has no schemas).
 16. [x] Re-run `BenchmarkCheckCorpusLarge` to confirm
     no engine-corpus regression. Latest run lands at
     p95 = 188 ms / 314 µs per file — well under the

--- a/plan/195_per-rule-alloc-budget.md
+++ b/plan/195_per-rule-alloc-budget.md
@@ -231,6 +231,10 @@ reference it.
     check .` on the mdsmith repo drops from ~490 ms to
     ~460 ms (5-7%); `BenchmarkCheckCorpusLarge` p95
     stays flat at 186 ms (the corpus has no schemas).
+    Follow-up commit covered the
+    `schema.ValidateFrontmatterDiags` site as well —
+    the production-hot CUE compile is now shared across
+    every host file sharing a schema.
 16. [x] Re-run `BenchmarkCheckCorpusLarge` to confirm
     no engine-corpus regression. Latest run lands at
     p95 = 188 ms / 314 µs per file — well under the


### PR DESCRIPTION
## Summary

Closes plan 195 task 15 — the MDS020 schema-parse parity gap. MDS020 was the heaviest default rule (~19% of CPU on `mdsmith check .` per the plan 195 background) because it re-parsed each schema file and re-compiled its frontmatter CUE on every host file Check, even though the schema is immutable for one `engine.Run`.

Two new RunCache slots, mirroring the existing FrontMatter/Includes/Anchors pattern:

- `RunCache.ParsedSchema(absPath, build)` — keyed by absolute schema path; caches the parsed schema (and parse errors) so N host files referencing one schema each see one parse.
- `RunCache.CompiledCUE(source, build)` — keyed by the CUE source string itself; collapses identical inline + file-schema CUE into one compile per Run. The cached value wraps both the `cue.Value` and the `*cue.Context` that produced it (cue values cannot cross contexts).

MDS020 wiring:

- All three `parseSchema(...)` sites in `internal/rules/requiredstructure/rule.go` (Fix, checkSingleFileSchemaFromData, bodySyncDiagnostics) now go through `cachedParseSchema(f, data, schemaPath)`.
- Both `CompileString` sites (`validateCUESchemaSyntax`, `validateFrontMatterCUE`) route through `cachedCompiledCUEWith(cache, source)` via cache-aware shims (`validateCUESchemaSyntaxWith`, `parseSchemaFrontMatter(prefix, cache)`, `parseSchemaWithCache`). The free function signatures stay backward-compatible so the 11 existing test call sites still work.

`Invalidate(absPath)` drops the parsed-schema entry alongside the existing FrontMatter/Includes/Anchors entries. CompiledCUE is intentionally not invalidated per-path: its key is the source string, not a file path. The LSP installs a fresh RunCache on workspace reload, which clears it then.

## Performance

| Surface | Before | After |
|--|--|--|
| `mdsmith check .` on mdsmith repo (5 runs avg) | ~490 ms | ~460 ms (5–7% faster) |
| `BenchmarkCheckCorpusLarge` p95 (20 iter) | 200 ms | 186 ms |
| MDS020 allocs/op on alloc-budget gate fixture | 0 | 0 (the gate fixture has no schema; production hot spot lives elsewhere) |

The corpus bench has no schemas, so the speedup is concentrated where it matters: real repos that ship `proto.md` schemas referenced by many host files.

## Test plan

- [x] `internal/lint/runcache_test.go` — six new tests pin ParsedSchema (builds once, caches errors, Invalidate, concurrent single build) and CompiledCUE (builds once, distinct sources, concurrent single build) contracts.
- [x] `internal/rules/requiredstructure/runcache_wiring_test.go` — wiring tests cover `cachedParseSchemaWith`, `cachedCompiledCUEWith`, the nil-cache fallback, empty-absPath bypass, error caching, concurrent build, and an end-to-end integration check that runs the Rule.Check path against three host files and verifies the cache slot is populated after one parse.
- [x] `go test ./...` and `go test -race ./...` green.
- [x] `go tool golangci-lint run` reports 0 issues.
- [x] `go vet ./...` clean.

Closes part of #195.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cvbpvby1uTG3DyYtwDGFkG)_