### PR TITLE
Rename internal/testutil to internal/testsymlink

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -126,7 +126,7 @@ footer: |
 | 197 | ✅     | opus   | [PoC — review goldmark's allocation architecture, then pool the best lever](plan/197_fork-goldmark-for-allocs.md)                       |
 | 198 | 🔲     | opus   | [Fork goldmark with a per-parse arena for the four structural allocators](plan/198_goldmark-arena-fork.md)                              |
 | 200 | ✅     |        | [Move docs/ embed out of internal/lsp/hover.go](plan/200_arch-fix-hover-embed.md)                                                       |
-| 201 | 🔲     |        | [Rename internal/testutil to internal/testsymlink](plan/201_arch-fix-testutil-rename.md)                                                |
+| 201 | ✅     |        | [Rename internal/testutil to internal/testsymlink](plan/201_arch-fix-testutil-rename.md)                                                |
 | 202 | 🔲     |        | [Split cmd/mdsmith/main.go into per-subcommand files](plan/202_arch-fix-main-split.md)                                                  |
 | 203 | 🔲     |        | [Split internal/lsp/server.go and symbols.go](plan/203_arch-fix-lsp-server-split.md)                                                    |
 | 204 | 🔲     |        | [Fix internal/fix importing internal/engine](plan/204_arch-fix-fix-engine-inversion.md)                                                 |

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/githooks"
-	"github.com/jeduden/mdsmith/internal/testutil"
+	"github.com/jeduden/mdsmith/internal/testsymlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -218,11 +218,11 @@ func writeFixture(t *testing.T, dir, name, content string) string {
 }
 
 // skipIfSymlinkUnsupported is a thin local alias for
-// testutil.SkipIfSymlinkUnsupported so existing call sites stay
-// readable. The probing logic lives in internal/testutil.
+// testsymlink.SkipIfSymlinkUnsupported so existing call sites stay
+// readable. The probing logic lives in internal/testsymlink.
 func skipIfSymlinkUnsupported(t *testing.T) {
 	t.Helper()
-	testutil.SkipIfSymlinkUnsupported(t)
+	testsymlink.SkipIfSymlinkUnsupported(t)
 }
 
 func parseStats(t *testing.T, stderr string) (checked, fixed, failures, unfixed int) {

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -101,6 +101,22 @@ non-test file under `internal/config/`.
 It fails if any import path contains
 `internal/rules/`.
 
+### resolved by plan/201
+
+`internal/testutil` used an
+anti-pattern name. The package
+comment read "small helpers shared
+across test binaries" — the canonical
+`util` / `helpers` smell — but held a
+single helper, `symlink.go`.
+
+[plan/201](../../plan/201_arch-fix-testutil-rename.md)
+renamed the package to
+[internal/testsymlink](../../internal/testsymlink/).
+The new name states the question the
+one file answers. Five test files now
+import the new path.
+
 ### tax
 
 `editors/vscode/src/extension.ts` is too
@@ -205,21 +221,6 @@ handlers into per-subcommand files.
 The pattern is already used for
 `kinds.go`, `metrics.go`,
 `backlinks.go`, and `mergedriver.go`.
-
-`internal/testutil` uses an
-anti-pattern name.
-
-The
-[testutil package](../../internal/testutil/)
-comment reads "small helpers shared
-across test binaries". That is the
-canonical `util` / `helpers`
-anti-pattern. The architecture hub
-flags it on sight. The current
-contents are a single focused helper
-(`symlink.go`). Severity: tax. Fix by
-renaming to the question it answers
-(e.g. `testsymlink`).
 
 ### nice-to-have
 

--- a/internal/discovery/discovery_coverage_test.go
+++ b/internal/discovery/discovery_coverage_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jeduden/mdsmith/internal/testutil"
+	"github.com/jeduden/mdsmith/internal/testsymlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -189,8 +189,8 @@ func TestDiscover_FollowSymlinks_OptIn(t *testing.T) {
 	require.Len(t, files, 2, "both real and linked entries are discovered")
 }
 
-// skipIfSymlinkUnsupported forwards to the shared testutil helper.
+// skipIfSymlinkUnsupported forwards to the shared testsymlink helper.
 func skipIfSymlinkUnsupported(t *testing.T) {
 	t.Helper()
-	testutil.SkipIfSymlinkUnsupported(t)
+	testsymlink.SkipIfSymlinkUnsupported(t)
 }

--- a/internal/discovery/discovery_unix_test.go
+++ b/internal/discovery/discovery_unix_test.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/jeduden/mdsmith/internal/testutil"
+	"github.com/jeduden/mdsmith/internal/testsymlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +36,7 @@ func TestDiscover_SkipsFifoEntries(t *testing.T) {
 // symlink-to-non-regular skip branch: even in opt-in mode, a
 // symlink whose target is a FIFO must not be included.
 func TestDiscover_SymlinkToFifo_SkippedUnderOptIn(t *testing.T) {
-	testutil.SkipIfSymlinkUnsupported(t)
+	testsymlink.SkipIfSymlinkUnsupported(t)
 	dir := t.TempDir()
 
 	require.NoError(t, os.WriteFile(

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/config"
-	"github.com/jeduden/mdsmith/internal/testutil"
+	"github.com/jeduden/mdsmith/internal/testsymlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -256,7 +256,7 @@ func TestDiscoverFiles_IgnoresDirectiveMentionsInProse(t *testing.T) {
 }
 
 func TestDiscoverFiles_SkipsSymlinks(t *testing.T) {
-	testutil.SkipIfSymlinkUnsupported(t)
+	testsymlink.SkipIfSymlinkUnsupported(t)
 	dir := t.TempDir()
 	// A real file with a directive that should be discovered.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.md"),

--- a/internal/lint/files_test.go
+++ b/internal/lint/files_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jeduden/mdsmith/internal/testutil"
+	"github.com/jeduden/mdsmith/internal/testsymlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -704,8 +704,8 @@ func TestHasSymlinkAncestorWithCwd_HonorsCwdArg(t *testing.T) {
 			"not os.Getwd; otherwise the precomputed-cwd optimisation is moot")
 }
 
-// skipIfSymlinkUnsupported forwards to the shared testutil helper.
+// skipIfSymlinkUnsupported forwards to the shared testsymlink helper.
 func skipIfSymlinkUnsupported(t *testing.T) {
 	t.Helper()
-	testutil.SkipIfSymlinkUnsupported(t)
+	testsymlink.SkipIfSymlinkUnsupported(t)
 }

--- a/internal/testsymlink/symlink.go
+++ b/internal/testsymlink/symlink.go
@@ -1,6 +1,7 @@
-// Package testutil holds small helpers shared across test
-// binaries. It is intended for use only from *_test.go files.
-package testutil
+// Package testsymlink probes whether the host can create symbolic
+// links and skips the calling test when it cannot. It is intended
+// for use only from *_test.go files.
+package testsymlink
 
 import (
 	"os"

--- a/internal/testsymlink/symlink_test.go
+++ b/internal/testsymlink/symlink_test.go
@@ -1,4 +1,4 @@
-package testutil
+package testsymlink
 
 import "testing"
 

--- a/plan/201_arch-fix-testutil-rename.md
+++ b/plan/201_arch-fix-testutil-rename.md
@@ -1,7 +1,7 @@
 ---
 id: 201
 title: Rename internal/testutil to internal/testsymlink
-status: "🔲"
+status: "✅"
 summary: >-
   Fix the anti-pattern package name. internal/testutil
   answers "a grab bag"; rename it to
@@ -14,14 +14,14 @@ depends-on: []
 
 ## Goal
 
-[internal/testutil](../internal/testutil) violates the SRP
+`internal/testutil` violated the SRP
 naming rule from the architecture hub.
 A package named `util` attracts unrelated
-code. The package has one non-test file,
-[symlink.go](../internal/testutil/symlink.go), that creates temporary
-symlinks for tests. Renaming to
-`internal/testsymlink` signals the
-narrow scope.
+code. The package had one non-test file,
+`symlink.go`, that creates temporary
+symlinks for tests. It now lives at
+[internal/testsymlink](../internal/testsymlink/symlink.go),
+which signals the narrow scope.
 
 ## Tasks
 
@@ -36,10 +36,10 @@ narrow scope.
 
 ## Acceptance Criteria
 
-- [ ] `internal/testutil/` is gone.
-- [ ] `internal/testsymlink/` exists.
-- [ ] `grep -r --include='*.go' 'internal/testutil'`
+- [x] `internal/testutil/` is gone.
+- [x] `internal/testsymlink/` exists.
+- [x] `grep -r --include='*.go' 'internal/testutil'`
   returns no results.
-- [ ] `go build ./...` clean.
-- [ ] `go test ./...` passes.
-- [ ] `go tool golangci-lint run` clean.
+- [x] `go build ./...` clean.
+- [x] `go test ./...` passes.
+- [x] `go tool golangci-lint run` clean.


### PR DESCRIPTION
Resolves plan/201 by renaming the `internal/testutil` package to `internal/testsymlink` to fix an anti-pattern package name.

## Summary

The `internal/testutil` package violated the SRP naming rule from the architecture hub. A package named `util` attracts unrelated code, but this package contained only a single focused helper: `symlink.go`, which probes whether the host can create symbolic links and skips tests when it cannot. Renaming to `internal/testsymlink` signals the narrow scope and answers the question the package addresses.

## Changes

- **Package rename**: `internal/testutil` → `internal/testsymlink`
- **Updated package comment**: Changed from "small helpers shared across test binaries" to "probes whether the host can create symbolic links and skips the calling test when it cannot"
- **Updated all import paths**: Five test files now import `internal/testsymlink`:
  - `cmd/mdsmith/e2e_test.go`
  - `internal/discovery/discovery_coverage_test.go`
  - `internal/discovery/discovery_unix_test.go`
  - `internal/lint/files_test.go`
  - `internal/githooks/githooks_test.go`
- **Updated documentation**: 
  - Moved the `internal/testutil` tax item from the architecture audit to a "resolved by plan/201" section
  - Updated plan/201 status from 🔲 to ✅ and marked all acceptance criteria complete
  - Updated PLAN.md to reflect plan/201 completion

## Implementation Details

All call sites that previously used `testutil.SkipIfSymlinkUnsupported()` now use `testsymlink.SkipIfSymlinkUnsupported()`. Local wrapper functions in test files were updated to reference the new package name in their comments.

https://claude.ai/code/session_01CUt2ZGZeiqB5km53FJyV9L