### PR TITLE
Plan 172: link-style rule (MDS068) and shared links config

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -98,7 +98,7 @@ footer: |
 | 169 | ✅     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)                       |
 | 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                                   |
 | 171 | ✅     | opus   | [MDS027 link-integrity hardening](plan/171_mds027-link-integrity-hardening.md)                                                          |
-| 172 | 🔲     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                                       |
+| 172 | ✅     | opus   | [Link-style rule and shared links config](plan/172_link-style-rule-and-config.md)                                                       |
 | 173 | ✅     | sonnet | [Website rewriter tolerates titled links](plan/173_rewriter-titled-links.md)                                                            |
 | 174 | ✅     | opus   | [Expose rename and dependency-graph as CLI subcommands and feature docs](plan/174_expose-rename-and-deps-cli.md)                        |
 | 175 | 🔳     | opus   | [CI performance gate for mdsmith check, modelled on the LSP latency gate](plan/175_check-performance-gate.md)                           |

--- a/docs/research/links/README.md
+++ b/docs/research/links/README.md
@@ -196,9 +196,12 @@ Mixed relative/absolute, `.md`/extensionless, and
 inline/reference within one doc set (census: `docs/` is
 ~50% reference-style, rule READMEs ~0%). Today: no
 signal. Should: an opt-in rule flags deviation from a
-per-kind declared style. **Decision: (a)** — new opt-in
-rule `link-style` reading the shared `links:` block
-(below). Plan 172.
+per-kind declared style. **Decision: (a), shipped.** —
+opt-in
+[MDS068 `link-style`](../../../internal/rules/MDS068-link-style/README.md)
+reads the shared `links:` block (below) and flags
+deviation on three independent axes — `style.path`,
+`style.extension`, `style.form`. Plan 172.
 
 ### G9 — Heading-anchor stability across renderers
 
@@ -248,18 +251,24 @@ folding network I/O into it would make every CI run
 network-bound and flaky. A separate off-by-default rule
 (`external-link-check`) with skip patterns, caching, and
 a timeout keeps offline CI fast and the failure modes
-isolated. Tracked by issue #47; Plan 172 carries the
-shared skip-pattern config it depends on, so the rule
-lands on a config foundation rather than inventing its
-own.
+isolated. Tracked by issue #47. Plan 172 lands the
+shared `links.external-skip` parser on MDS068 so the
+future rule can read the same YAML key without inventing
+its own schema.
 
-## Sketched `links:` config block
+## Shared `links:` config block
 
-Design only — no parser changes in this audit. A shared
-block under `.mdsmith.yml`, deep-merged per kind like
-every other rule config, consumed by MDS027 (G1–G3) and
-the new `link-style` rule (G8), and supplying the skip
-list issue #47's rule (G13) reuses:
+The `links:` sub-block lives under each link-aware rule
+in `.mdsmith.yml` (one consumer per rule, deep-merged
+per kind like every other rule config). MDS027 reads
+`site-root`, `validate-images`, and
+`validate-reference-style` (G1–G3); MDS068 reads
+`style` and `external-skip` (G8); a future
+`external-link-check` rule (G13) will read
+`external-skip` from its own copy of the block. Each
+rule tolerates the others' keys without erroring, so a
+single YAML body can be pasted under both rule names
+when a project wants identical settings:
 
 ```yaml
 links:

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/horizontalrulestyle"
 	_ "github.com/jeduden/mdsmith/internal/rules/include"
 	_ "github.com/jeduden/mdsmith/internal/rules/linelength"
+	_ "github.com/jeduden/mdsmith/internal/rules/linkstyle"
 	_ "github.com/jeduden/mdsmith/internal/rules/linkvalidity"
 	_ "github.com/jeduden/mdsmith/internal/rules/listindent"
 	_ "github.com/jeduden/mdsmith/internal/rules/listmarkerspace"

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -49,6 +49,11 @@ extension. Targets ending in any other extension (`.png`, `.css`,
 `keep`/`strip`. Both `.md` and `.markdown` are treated as the
 same "with extension" form.
 
+Directory-style targets (trailing `/`, `.`, `..` — e.g.
+`/docs/rules/MDS027/` or `../`) reference a rendered page
+directory rather than a file. The `extension` axis also skips
+these, since there is no filename segment to judge.
+
 A note on adopting `extension: strip`. MDS027
 [cross-file-reference-integrity](../MDS027-cross-file-reference-integrity/README.md)
 checks `.md` and `.markdown` targets by default. It

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -26,7 +26,7 @@ and `validate-reference-style` flow to MDS027, while `style` and
 | Setting                 | Type   | Default | Description                                                                                                                    |
 |-------------------------|--------|---------|--------------------------------------------------------------------------------------------------------------------------------|
 | `links.style.path`      | string | `""`    | `relative` flags absolute targets; `absolute` flags relative targets                                                           |
-| `links.style.extension` | string | `""`    | `keep` flags Markdown-shaped targets without `.md`; `strip` flags those with `.md`                                             |
+| `links.style.extension` | string | `""`    | `keep` flags Markdown-shaped targets without a markdown extension; `strip` flags those with `.md`/`.markdown`                  |
 | `links.style.form`      | string | `""`    | `inline` flags reference-style links; `reference` flags inline links; `any` is permissive                                      |
 | `links.external-skip`   | list   | `[]`    | Regex patterns reserved for the future external-link-check rule (issue #47); parsed here so users can declare it once per kind |
 
@@ -40,9 +40,10 @@ references, and images are not checked. The style policy targets
 text links to local Markdown files.
 
 The extension policy only applies to Markdown-shaped targets — a
-target whose last segment ends in `.md`/`.markdown`, or has no
+target whose last segment ends in `.md` or `.markdown`, or has no
 extension. Targets ending in any other extension (`.png`, `.css`,
-…) are ignored regardless of `keep`/`strip`.
+…) are ignored regardless of `keep`/`strip`. Both `.md` and
+`.markdown` are treated as the same "with extension" form.
 
 ## Config
 
@@ -195,14 +196,14 @@ See [sibling](good/sibling.md) — inline form, as policy requires.
 
 ## Diagnostics
 
-| Condition                                   | Message                                                                    |
-|---------------------------------------------|----------------------------------------------------------------------------|
-| absolute target under `style.path=relative` | `link target is absolute; style.path=relative requires a relative path`    |
-| relative target under `style.path=absolute` | `link target is relative; style.path=absolute requires an absolute path`   |
-| extensionless under `style.extension=keep`  | `link target has no .md extension; style.extension=keep requires .md`      |
-| `.md` suffix under `style.extension=strip`  | `link target has .md extension; style.extension=strip forbids .md`         |
-| reference-style under `style.form=inline`   | `reference-style link; style.form=inline requires inline form [text](url)` |
-| inline under `style.form=reference`         | `inline link; style.form=reference requires reference form [text][label]`  |
+| Condition                                              | Message                                                                                 |
+|--------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| absolute target under `style.path=relative`            | `link target is absolute; style.path=relative requires a relative path`                 |
+| relative target under `style.path=absolute`            | `link target is relative; style.path=absolute requires an absolute path`                |
+| extensionless under `style.extension=keep`             | `link target has no markdown extension; style.extension=keep requires .md or .markdown` |
+| `.md`/`.markdown` suffix under `style.extension=strip` | `link target has a markdown extension; style.extension=strip forbids .md and .markdown` |
+| reference-style under `style.form=inline`              | `reference-style link; style.form=inline requires inline form [text](url)`              |
+| inline under `style.form=reference`                    | `inline link; style.form=reference requires reference form [text][label]`               |
 
 ## See also
 

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -36,14 +36,18 @@ three axes unset is a no-op — useful when the rule is on at the
 project level but a kind opts out by clearing one axis.
 
 External URLs (`http:`, `https:`, `mailto:`), local-anchor-only
-references, and images are not checked. The style policy targets
-text links to local Markdown files.
+references, and images are not checked. The `path` and `form`
+axes apply to every local text link, including non-Markdown
+targets like `theme.css` — consistency is the point. The
+`extension` axis is the only Markdown-shaped axis, described
+below.
 
 The extension policy only applies to Markdown-shaped targets — a
 target whose last segment ends in `.md` or `.markdown`, or has no
 extension. Targets ending in any other extension (`.png`, `.css`,
-…) are ignored regardless of `keep`/`strip`. Both `.md` and
-`.markdown` are treated as the same "with extension" form.
+…) are ignored by the `extension` axis regardless of
+`keep`/`strip`. Both `.md` and `.markdown` are treated as the
+same "with extension" form.
 
 A note on adopting `extension: strip`. MDS027
 [cross-file-reference-integrity](../MDS027-cross-file-reference-integrity/README.md)

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -45,6 +45,14 @@ extension. Targets ending in any other extension (`.png`, `.css`,
 …) are ignored regardless of `keep`/`strip`. Both `.md` and
 `.markdown` are treated as the same "with extension" form.
 
+A note on adopting `extension: strip`. MDS027
+[cross-file-reference-integrity](../MDS027-cross-file-reference-integrity/README.md)
+checks `.md` and `.markdown` targets by default. It
+silently skips extensionless ones unless `strict:
+true` is also set. So an extensionless target with a
+broken link will pass MDS027 silently. To keep that
+check on, also set `cross-file-reference-integrity.strict: true`.
+
 ## Config
 
 Enable with the default permissive policy:

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -1,0 +1,227 @@
+---
+id: MDS068
+name: link-style
+status: ready
+description: Flag links whose path, extension, or inline-vs-reference form deviates from the project's declared `links.style` policy.
+category: link
+nature: style
+maintainability: null
+markdownlint: null
+---
+# MDS068: link-style
+
+Flag links whose path, extension, or inline-vs-reference form
+deviates from the project's declared `links.style` policy.
+
+This rule closes gap G8 in the
+[link handling audit](../../../docs/research/links/README.md).
+It reads the shared `links:` config block — the same block MDS027
+reads for its own settings. Adding `link-style` keeps the block
+as one source of truth per kind: `site-root`, `validate-images`,
+and `validate-reference-style` flow to MDS027, while `style` and
+`external-skip` flow to this rule.
+
+## Settings
+
+| Setting                 | Type   | Default | Description                                                                                                                    |
+|-------------------------|--------|---------|--------------------------------------------------------------------------------------------------------------------------------|
+| `links.style.path`      | string | `""`    | `relative` flags absolute targets; `absolute` flags relative targets                                                           |
+| `links.style.extension` | string | `""`    | `keep` flags Markdown-shaped targets without `.md`; `strip` flags those with `.md`                                             |
+| `links.style.form`      | string | `""`    | `inline` flags reference-style links; `reference` flags inline links; `any` is permissive                                      |
+| `links.external-skip`   | list   | `[]`    | Regex patterns reserved for the future external-link-check rule (issue #47); parsed here so users can declare it once per kind |
+
+Each style axis is independent. An empty string disables that
+axis without affecting the other two. Enabling the rule with all
+three axes unset is a no-op — useful when the rule is on at the
+project level but a kind opts out by clearing one axis.
+
+External URLs (`http:`, `https:`, `mailto:`), local-anchor-only
+references, and images are not checked. The style policy targets
+text links to local Markdown files.
+
+The extension policy only applies to Markdown-shaped targets — a
+target whose last segment ends in `.md`/`.markdown`, or has no
+extension. Targets ending in any other extension (`.png`, `.css`,
+…) are ignored regardless of `keep`/`strip`.
+
+## Config
+
+Enable with the default permissive policy:
+
+```yaml
+rules:
+  link-style: true
+```
+
+Pin a project-wide style:
+
+```yaml
+rules:
+  link-style:
+    links:
+      style:
+        path: relative
+        extension: keep
+        form: inline
+```
+
+Override per kind. Rule READMEs are pure relative inline; the
+`docs` kind clears form back to any until the corpus is migrated:
+
+```yaml
+kinds:
+  rule-readme:
+    rules:
+      link-style:
+        links:
+          style:
+            path: relative
+            extension: keep
+            form: inline
+  docs:
+    rules:
+      link-style:
+        links:
+          style:
+            form: any
+```
+
+Disable:
+
+```yaml
+rules:
+  link-style: false
+```
+
+## Examples
+
+### Bad -- absolute target under style.path=relative
+
+<?include
+file: bad/path-relative.md
+wrap: markdown
+strip-frontmatter: "true"
+?>
+
+```markdown
+# Path Relative
+
+See [docs](/docs/target.md).
+```
+
+<?/include?>
+
+### Bad -- .md suffix under style.extension=strip
+
+<?include
+file: bad/extension-strip.md
+wrap: markdown
+strip-frontmatter: "true"
+?>
+
+```markdown
+# Extension Strip
+
+See [target](bad/sub/target.md).
+```
+
+<?/include?>
+
+### Bad -- reference link under style.form=inline
+
+<?include
+file: bad/form-inline.md
+wrap: markdown
+strip-frontmatter: "true"
+?>
+
+```markdown
+# Form Inline
+
+See [target][label].
+
+[label]: sub/target.md
+```
+
+<?/include?>
+
+### Good -- relative path
+
+<?include
+file: good/path-relative.md
+wrap: markdown
+strip-frontmatter: "true"
+?>
+
+```markdown
+# Path Relative
+
+See [sibling](good/sibling.md) for a relative link target.
+```
+
+<?/include?>
+
+### Good -- extensionless link
+
+<?include
+file: good/extension-strip.md
+wrap: markdown
+strip-frontmatter: "true"
+?>
+
+```markdown
+# Extension Strip
+
+See [target](good/sibling) — no .md suffix, as policy requires.
+```
+
+<?/include?>
+
+### Good -- inline link
+
+<?include
+file: good/form-inline.md
+wrap: markdown
+strip-frontmatter: "true"
+?>
+
+```markdown
+# Form Inline
+
+See [sibling](good/sibling.md) — inline form, as policy requires.
+```
+
+<?/include?>
+
+## Diagnostics
+
+| Condition                                   | Message                                                                    |
+|---------------------------------------------|----------------------------------------------------------------------------|
+| absolute target under `style.path=relative` | `link target is absolute; style.path=relative requires a relative path`    |
+| relative target under `style.path=absolute` | `link target is relative; style.path=absolute requires an absolute path`   |
+| extensionless under `style.extension=keep`  | `link target has no .md extension; style.extension=keep requires .md`      |
+| `.md` suffix under `style.extension=strip`  | `link target has .md extension; style.extension=strip forbids .md`         |
+| reference-style under `style.form=inline`   | `reference-style link; style.form=inline requires inline form [text](url)` |
+| inline under `style.form=reference`         | `inline link; style.form=reference requires reference form [text][label]`  |
+
+## See also
+
+- [Link handling audit](../../../docs/research/links/README.md) —
+  the G8 gap this rule closes.
+- [MDS027 cross-file-reference-integrity](../MDS027-cross-file-reference-integrity/README.md)
+  — shares the `links:` config block.
+- [MDS043 no-reference-style](../MDS043-no-reference-style/README.md)
+  — a hard ban on reference style. MDS068 with `form: inline` is
+  the softer per-kind equivalent.
+
+## Meta-Information
+
+- **ID**: MDS068
+- **Name**: `link-style`
+- **Status**: ready
+- **Default**: disabled, opt-in. When enabled, every style axis
+  defaults to `""` (no check) until set explicitly.
+- **Fixable**: no
+- **Implementation**:
+  [source](./)
+- **Category**: link

--- a/internal/rules/MDS068-link-style/bad/extension-strip.md
+++ b/internal/rules/MDS068-link-style/bad/extension-strip.md
@@ -1,0 +1,13 @@
+---
+settings:
+  links:
+    style:
+      extension: strip
+diagnostics:
+  - line: 3
+    column: 6
+    message: "link target has .md extension; style.extension=strip forbids .md"
+---
+# Extension Strip
+
+See [target](sub/target.md).

--- a/internal/rules/MDS068-link-style/bad/extension-strip.md
+++ b/internal/rules/MDS068-link-style/bad/extension-strip.md
@@ -6,7 +6,7 @@ settings:
 diagnostics:
   - line: 3
     column: 6
-    message: "link target has .md extension; style.extension=strip forbids .md"
+    message: "link target has a markdown extension; style.extension=strip forbids .md and .markdown"
 ---
 # Extension Strip
 

--- a/internal/rules/MDS068-link-style/bad/form-inline.md
+++ b/internal/rules/MDS068-link-style/bad/form-inline.md
@@ -1,0 +1,15 @@
+---
+settings:
+  links:
+    style:
+      form: inline
+diagnostics:
+  - line: 3
+    column: 6
+    message: "reference-style link; style.form=inline requires inline form [text](url)"
+---
+# Form Inline
+
+See [target][label].
+
+[label]: sub/target.md

--- a/internal/rules/MDS068-link-style/bad/path-relative.md
+++ b/internal/rules/MDS068-link-style/bad/path-relative.md
@@ -1,0 +1,13 @@
+---
+settings:
+  links:
+    style:
+      path: relative
+diagnostics:
+  - line: 3
+    column: 6
+    message: "link target is absolute; style.path=relative requires a relative path"
+---
+# Path Relative
+
+See [docs](/docs/target.md).

--- a/internal/rules/MDS068-link-style/good/extension-strip.md
+++ b/internal/rules/MDS068-link-style/good/extension-strip.md
@@ -1,0 +1,9 @@
+---
+settings:
+  links:
+    style:
+      extension: strip
+---
+# Extension Strip
+
+See [target](sibling) — no .md suffix, as policy requires.

--- a/internal/rules/MDS068-link-style/good/form-inline.md
+++ b/internal/rules/MDS068-link-style/good/form-inline.md
@@ -1,0 +1,9 @@
+---
+settings:
+  links:
+    style:
+      form: inline
+---
+# Form Inline
+
+See [sibling](sibling.md) — inline form, as policy requires.

--- a/internal/rules/MDS068-link-style/good/path-relative.md
+++ b/internal/rules/MDS068-link-style/good/path-relative.md
@@ -1,0 +1,9 @@
+---
+settings:
+  links:
+    style:
+      path: relative
+---
+# Path Relative
+
+See [sibling](sibling.md) for a relative link target.

--- a/internal/rules/MDS068-link-style/good/sibling.md
+++ b/internal/rules/MDS068-link-style/good/sibling.md
@@ -1,0 +1,3 @@
+# Sibling
+
+Anchor target for the other good fixtures in this folder.

--- a/internal/rules/all/all.go
+++ b/internal/rules/all/all.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/jeduden/mdsmith/internal/rules/horizontalrulestyle"         // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/include"                     // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/linelength"                  // registers rule
+	_ "github.com/jeduden/mdsmith/internal/rules/linkstyle"                   // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/linkvalidity"                // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/listindent"                  // registers rule
 	_ "github.com/jeduden/mdsmith/internal/rules/listmarkerspace"             // registers rule

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -695,6 +695,12 @@ func (r *Rule) applyLinksSettings(m map[string]any) error {
 				)
 			}
 			r.Links.ValidateReferenceStyle = b
+		// MDS068's keys are tolerated so a single shared `links:`
+		// block can configure both rules without forcing the user
+		// to split the YAML. MDS068 reads the values from its own
+		// settings map; here they are no-ops.
+		case "style", "external-skip":
+			// no-op for cross-file-reference-integrity
 		default:
 			return fmt.Errorf(
 				"cross-file-reference-integrity: unknown links setting %q",

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -1084,6 +1084,24 @@ func TestApplySettings_Links_UnknownKey(t *testing.T) {
 	require.Contains(t, err.Error(), "unknown links setting")
 }
 
+// TestApplySettings_Links_ToleratesMDS068Keys verifies the shared
+// `links:` block stays usable when both MDS027 and MDS068 are
+// configured from the same YAML body. MDS068's keys (`style`,
+// `external-skip`) reach MDS027 too; they must parse without
+// erroring even though MDS027 ignores them at runtime.
+func TestApplySettings_Links_ToleratesMDS068Keys(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"links": map[string]any{
+			"site-root":     "/srv",
+			"style":         map[string]any{"path": "relative"},
+			"external-skip": []any{"^https?://localhost"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/srv", r.Links.SiteRoot)
+}
+
 func TestDefaultSettings_Links(t *testing.T) {
 	r := &Rule{}
 	ds := r.DefaultSettings()

--- a/internal/rules/index.md
+++ b/internal/rules/index.md
@@ -86,6 +86,7 @@ row: "| [{id}]({filename}) | `{name}` | {category} | {status} | {description} |"
 | [MDS065](MDS065-code-block-style/README.md)                   | `code-block-style`                   | code          | ready     | Code blocks must use a single delimiter — fenced or four-space indented — consistently across the file.                                            |
 | [MDS066](MDS066-commands-show-output/README.md)               | `commands-show-output`               | code          | ready     | A fenced code block whose every non-blank line begins with `$ ` and shows no output must drop the prompt.                                          |
 | [MDS067](MDS067-callout-type/README.md)                       | `callout-type`                       | structural    | ready     | Validate Obsidian callout types against an allowed set.                                                                                            |
+| [MDS068](MDS068-link-style/README.md)                         | `link-style`                         | link          | ready     | Flag links whose path, extension, or inline-vs-reference form deviates from the project's declared `links.style` policy.                           |
 <?/catalog?>
 
 ## Directive rules

--- a/internal/rules/linkstyle/rule.go
+++ b/internal/rules/linkstyle/rule.go
@@ -1,0 +1,326 @@
+// Package linkstyle implements MDS068, an opt-in rule that flags
+// links whose path style, extension policy, or inline-vs-reference
+// form deviates from the project's declared `links.style` policy.
+// See docs/research/links/README.md gap G8 for the design.
+package linkstyle
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/linkgraph"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+func init() {
+	rule.Register(&Rule{})
+}
+
+// LinksConfig holds the `links:` sub-block this rule reads. The same
+// block name is used by MDS027; the two rules each parse the keys
+// they care about. The future external-link-check rule (issue #47)
+// reads ExternalSkip from this same block.
+type LinksConfig struct {
+	Style        StyleConfig
+	ExternalSkip []string
+}
+
+// StyleConfig captures the three policy axes the rule enforces.
+// Empty strings mean "no check" so users can enable one axis without
+// committing to all three.
+type StyleConfig struct {
+	Path      string // "relative" | "absolute" | ""
+	Extension string // "keep" | "strip" | ""
+	Form      string // "inline" | "reference" | "any" | ""
+}
+
+// Rule flags links whose style deviates from the declared policy.
+type Rule struct {
+	Links LinksConfig
+}
+
+// ID implements rule.Rule.
+func (r *Rule) ID() string { return "MDS068" }
+
+// Name implements rule.Rule.
+func (r *Rule) Name() string { return "link-style" }
+
+// Category implements rule.Rule.
+func (r *Rule) Category() string { return "link" }
+
+// EnabledByDefault implements rule.Defaultable.
+func (r *Rule) EnabledByDefault() bool { return false }
+
+const (
+	msgPathRelative  = "link target is absolute; style.path=relative requires a relative path"
+	msgPathAbsolute  = "link target is relative; style.path=absolute requires an absolute path"
+	msgExtensionKeep = "link target has no .md extension; style.extension=keep requires .md"
+	msgExtStripFmt   = "link target has .md extension; style.extension=strip forbids .md"
+	msgFormInline    = "reference-style link; style.form=inline requires inline form [text](url)"
+	msgFormReference = "inline link; style.form=reference requires reference form [text][label]"
+)
+
+// Check implements rule.Rule.
+func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	style := r.Links.Style
+	if style.Path == "" && style.Extension == "" && style.Form == "" {
+		return nil
+	}
+
+	var diags []lint.Diagnostic
+	for _, link := range linkgraph.ExtractLinks(f) {
+		diags = append(diags, r.checkOne(f, link, false)...)
+	}
+	for _, link := range linkgraph.ExtractRefLinkTargets(f) {
+		diags = append(diags, r.checkOne(f, link, true)...)
+	}
+	return diags
+}
+
+// checkOne returns 0..3 diagnostics for one link occurrence.
+// External links and pure local-anchor links are excluded earlier
+// by linkgraph.ParseTarget; what reaches here is always a local
+// path target with optional fragment.
+func (r *Rule) checkOne(f *lint.File, link linkgraph.Link, isRef bool) []lint.Diagnostic {
+	target := link.Target
+	if target.LocalAnchor {
+		return nil
+	}
+	style := r.Links.Style
+	var diags []lint.Diagnostic
+	if msg := checkPath(style.Path, target.Path); msg != "" {
+		diags = append(diags, diag(f, link, r, msg))
+	}
+	if msg := checkExtension(style.Extension, target.Path); msg != "" {
+		diags = append(diags, diag(f, link, r, msg))
+	}
+	if msg := checkForm(style.Form, isRef); msg != "" {
+		diags = append(diags, diag(f, link, r, msg))
+	}
+	return diags
+}
+
+// checkPath returns a diagnostic message when the configured path
+// style does not match this target, or "" to pass.
+func checkPath(policy, targetPath string) string {
+	if policy == "" || targetPath == "" {
+		return ""
+	}
+	isAbs := strings.HasPrefix(targetPath, "/")
+	switch policy {
+	case "relative":
+		if isAbs {
+			return msgPathRelative
+		}
+	case "absolute":
+		if !isAbs {
+			return msgPathAbsolute
+		}
+	}
+	return ""
+}
+
+// checkExtension returns a diagnostic message when the configured
+// extension policy does not match this target's path. Only Markdown-
+// shaped targets are considered: a `.md` suffix counts under keep,
+// no extension at all counts under strip. Other suffixes (`.png`,
+// `.css`, …) are not Markdown links and are silently ignored.
+func checkExtension(policy, targetPath string) string {
+	if policy == "" || targetPath == "" {
+		return ""
+	}
+	base := path.Base(targetPath)
+	ext := strings.ToLower(path.Ext(base))
+	isMD := ext == ".md" || ext == ".markdown"
+	hasOtherExt := ext != "" && !isMD
+	if hasOtherExt {
+		return ""
+	}
+	switch policy {
+	case "keep":
+		if !isMD {
+			return msgExtensionKeep
+		}
+	case "strip":
+		if isMD {
+			return msgExtStripFmt
+		}
+	}
+	return ""
+}
+
+// checkForm returns a diagnostic message when the link form does
+// not match the configured policy. "any" and "" are permissive.
+func checkForm(policy string, isRef bool) string {
+	switch policy {
+	case "inline":
+		if isRef {
+			return msgFormInline
+		}
+	case "reference":
+		if !isRef {
+			return msgFormReference
+		}
+	}
+	return ""
+}
+
+func diag(f *lint.File, link linkgraph.Link, r *Rule, msg string) lint.Diagnostic {
+	return lint.Diagnostic{
+		File:     f.Path,
+		Line:     link.Line,
+		Column:   link.Column,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  msg,
+	}
+}
+
+// ApplySettings implements rule.Configurable.
+func (r *Rule) ApplySettings(settings map[string]any) error {
+	for k, v := range settings {
+		if err := r.applyOne(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Rule) applyOne(key string, v any) error {
+	switch key {
+	case "links":
+		m, ok := v.(map[string]any)
+		if !ok {
+			return fmt.Errorf("link-style: links must be a map, got %T", v)
+		}
+		return r.applyLinks(m)
+	}
+	return fmt.Errorf("link-style: unknown setting %q", key)
+}
+
+func (r *Rule) applyLinks(m map[string]any) error {
+	for k, v := range m {
+		switch k {
+		case "style":
+			sm, ok := v.(map[string]any)
+			if !ok {
+				return fmt.Errorf("link-style: links.style must be a map, got %T", v)
+			}
+			if err := r.applyStyle(sm); err != nil {
+				return err
+			}
+		case "external-skip":
+			list, ok := toStringSlice(v)
+			if !ok {
+				return fmt.Errorf("link-style: links.external-skip must be a list of strings, got %T", v)
+			}
+			r.Links.ExternalSkip = list
+		// MDS027's keys are tolerated so a single shared `links:`
+		// block can configure both rules without forcing the user
+		// to split the YAML. The values are ignored here — MDS027
+		// reads them from its own settings map.
+		case "site-root", "validate-images", "validate-reference-style":
+			// no-op for link-style
+		default:
+			return fmt.Errorf("link-style: unknown links setting %q", k)
+		}
+	}
+	return nil
+}
+
+func (r *Rule) applyStyle(m map[string]any) error {
+	for k, v := range m {
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("link-style: links.style.%s must be a string, got %T", k, v)
+		}
+		switch k {
+		case "path":
+			if err := validatePathStyle(s); err != nil {
+				return err
+			}
+			r.Links.Style.Path = s
+		case "extension":
+			if err := validateExtensionStyle(s); err != nil {
+				return err
+			}
+			r.Links.Style.Extension = s
+		case "form":
+			if err := validateFormStyle(s); err != nil {
+				return err
+			}
+			r.Links.Style.Form = s
+		default:
+			return fmt.Errorf("link-style: unknown links.style setting %q", k)
+		}
+	}
+	return nil
+}
+
+func validatePathStyle(s string) error {
+	switch s {
+	case "", "relative", "absolute":
+		return nil
+	}
+	return fmt.Errorf("link-style: links.style.path %q not supported; want \"relative\" or \"absolute\"", s)
+}
+
+func validateExtensionStyle(s string) error {
+	switch s {
+	case "", "keep", "strip":
+		return nil
+	}
+	return fmt.Errorf("link-style: links.style.extension %q not supported; want \"keep\" or \"strip\"", s)
+}
+
+func validateFormStyle(s string) error {
+	switch s {
+	case "", "any", "inline", "reference":
+		return nil
+	}
+	return fmt.Errorf("link-style: links.style.form %q not supported; want \"inline\", \"reference\", or \"any\"", s)
+}
+
+// DefaultSettings implements rule.Configurable. All policy strings
+// default to "" so an enabled rule with no further config does
+// nothing — every check is explicitly opted into.
+func (r *Rule) DefaultSettings() map[string]any {
+	return map[string]any{
+		"links": map[string]any{
+			"style": map[string]any{
+				"path":      "",
+				"extension": "",
+				"form":      "",
+			},
+			"external-skip": []string{},
+		},
+	}
+}
+
+func toStringSlice(v any) ([]string, bool) {
+	switch list := v.(type) {
+	case []string:
+		out := make([]string, len(list))
+		copy(out, list)
+		return out, true
+	case []any:
+		out := make([]string, 0, len(list))
+		for _, item := range list {
+			s, ok := item.(string)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, s)
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+var (
+	_ rule.Configurable = (*Rule)(nil)
+	_ rule.Defaultable  = (*Rule)(nil)
+)

--- a/internal/rules/linkstyle/rule.go
+++ b/internal/rules/linkstyle/rule.go
@@ -253,6 +253,12 @@ func (r *Rule) applyStyle(m map[string]any) error {
 			if err := validateFormStyle(s); err != nil {
 				return err
 			}
+			// "any" and "" both mean "no form check"; normalize to
+			// "" so Check's no-op fast path stays a single
+			// three-way empty-string comparison.
+			if s == "any" {
+				s = ""
+			}
 			r.Links.Style.Form = s
 		default:
 			return fmt.Errorf("link-style: unknown links.style setting %q", k)

--- a/internal/rules/linkstyle/rule.go
+++ b/internal/rules/linkstyle/rule.go
@@ -128,11 +128,19 @@ func checkPath(policy, targetPath string) string {
 // shaped targets are considered: a `.md` suffix counts under keep,
 // no extension at all counts under strip. Other suffixes (`.png`,
 // `.css`, …) are not Markdown links and are silently ignored.
+// Directory-style targets (trailing `/`, `.`, `..`) reference a
+// rendered page directory rather than a file and are also skipped.
 func checkExtension(policy, targetPath string) string {
 	if policy == "" || targetPath == "" {
 		return ""
 	}
+	if strings.HasSuffix(targetPath, "/") {
+		return ""
+	}
 	base := path.Base(targetPath)
+	if base == "." || base == ".." {
+		return ""
+	}
 	ext := strings.ToLower(path.Ext(base))
 	isMD := ext == ".md" || ext == ".markdown"
 	hasOtherExt := ext != "" && !isMD

--- a/internal/rules/linkstyle/rule.go
+++ b/internal/rules/linkstyle/rule.go
@@ -266,7 +266,9 @@ func validatePathStyle(s string) error {
 	case "", "relative", "absolute":
 		return nil
 	}
-	return fmt.Errorf("link-style: links.style.path %q not supported; want \"relative\" or \"absolute\"", s)
+	return fmt.Errorf(
+		"link-style: links.style.path %q not supported; "+
+			"want \"relative\", \"absolute\", or \"\" (disables the check)", s)
 }
 
 func validateExtensionStyle(s string) error {
@@ -274,7 +276,9 @@ func validateExtensionStyle(s string) error {
 	case "", "keep", "strip":
 		return nil
 	}
-	return fmt.Errorf("link-style: links.style.extension %q not supported; want \"keep\" or \"strip\"", s)
+	return fmt.Errorf(
+		"link-style: links.style.extension %q not supported; "+
+			"want \"keep\", \"strip\", or \"\" (disables the check)", s)
 }
 
 func validateFormStyle(s string) error {
@@ -282,7 +286,9 @@ func validateFormStyle(s string) error {
 	case "", "any", "inline", "reference":
 		return nil
 	}
-	return fmt.Errorf("link-style: links.style.form %q not supported; want \"inline\", \"reference\", or \"any\"", s)
+	return fmt.Errorf(
+		"link-style: links.style.form %q not supported; "+
+			"want \"inline\", \"reference\", \"any\", or \"\" (disables the check)", s)
 }
 
 // DefaultSettings implements rule.Configurable. All policy strings

--- a/internal/rules/linkstyle/rule.go
+++ b/internal/rules/linkstyle/rule.go
@@ -56,8 +56,8 @@ func (r *Rule) EnabledByDefault() bool { return false }
 const (
 	msgPathRelative  = "link target is absolute; style.path=relative requires a relative path"
 	msgPathAbsolute  = "link target is relative; style.path=absolute requires an absolute path"
-	msgExtensionKeep = "link target has no .md extension; style.extension=keep requires .md"
-	msgExtStripFmt   = "link target has .md extension; style.extension=strip forbids .md"
+	msgExtensionKeep = "link target has no markdown extension; style.extension=keep requires .md or .markdown"
+	msgExtStripFmt   = "link target has a markdown extension; style.extension=strip forbids .md and .markdown"
 	msgFormInline    = "reference-style link; style.form=inline requires inline form [text](url)"
 	msgFormReference = "inline link; style.form=reference requires reference form [text][label]"
 )
@@ -80,9 +80,10 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 }
 
 // checkOne returns 0..3 diagnostics for one link occurrence.
-// External links and pure local-anchor links are excluded earlier
-// by linkgraph.ParseTarget; what reaches here is always a local
-// path target with optional fragment.
+// External links (scheme/host) are excluded earlier by
+// linkgraph.ParseTarget; local-anchor-only destinations
+// (`#section`) reach this function with LocalAnchor=true and are
+// filtered out here because they carry no path or form to judge.
 func (r *Rule) checkOne(f *lint.File, link linkgraph.Link, isRef bool) []lint.Diagnostic {
 	target := link.Target
 	if target.LocalAnchor {

--- a/internal/rules/linkstyle/rule_test.go
+++ b/internal/rules/linkstyle/rule_test.go
@@ -127,6 +127,23 @@ func TestCheck_ExtensionIgnoresNonMarkdownExtensions(t *testing.T) {
 	assert.Empty(t, r.Check(f), "strip should not flag .png or .css targets")
 }
 
+// TestCheck_PathAndFormApplyToNonMarkdownTargets locks in the
+// "path/form are not Markdown-specific" rule: a `.css` reference
+// link with an absolute path under `path: relative, form: inline`
+// must be flagged twice (path + form). Only the extension axis
+// short-circuits non-Markdown extensions.
+func TestCheck_PathAndFormApplyToNonMarkdownTargets(t *testing.T) {
+	src := "# Doc\n\nSee [stylesheet][css].\n\n[css]: /theme.css\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{
+		Path:      "relative", // /theme.css is absolute — flag
+		Extension: "strip",    // .css is not Markdown — silent
+		Form:      "inline",   // reference-style — flag
+	}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 2, "path and form must apply to non-Markdown targets; extension must not")
+}
+
 func TestCheck_FormInline_FlagsReferenceStyle(t *testing.T) {
 	src := "# Doc\n\nSee [x][label].\n\n[label]: sub/target.md\n"
 	f := newFile(t, src)

--- a/internal/rules/linkstyle/rule_test.go
+++ b/internal/rules/linkstyle/rule_test.go
@@ -66,8 +66,19 @@ func TestCheck_ExtensionStrip_FlagsMDSuffix(t *testing.T) {
 	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "strip"}}}
 	diags := r.Check(f)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, ".md")
+	assert.Contains(t, diags[0].Message, "markdown extension")
 	assert.Contains(t, diags[0].Message, "strip")
+}
+
+func TestCheck_ExtensionStrip_FlagsMarkdownSuffix(t *testing.T) {
+	// `.markdown` is treated the same as `.md` — both are Markdown
+	// targets under the extension policy.
+	src := "# Doc\n\nSee [x](sub/target.markdown).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "strip"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, ".markdown")
 }
 
 func TestCheck_ExtensionStrip_AcceptsExtensionless(t *testing.T) {
@@ -89,6 +100,14 @@ func TestCheck_ExtensionKeep_FlagsExtensionless(t *testing.T) {
 
 func TestCheck_ExtensionKeep_AcceptsMDSuffix(t *testing.T) {
 	src := "# Doc\n\nSee [x](sub/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "keep"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_ExtensionKeep_AcceptsMarkdownSuffix(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.markdown).\n"
 	f := newFile(t, src)
 	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "keep"}}}
 	diags := r.Check(f)

--- a/internal/rules/linkstyle/rule_test.go
+++ b/internal/rules/linkstyle/rule_test.go
@@ -144,6 +144,25 @@ func TestCheck_PathAndFormApplyToNonMarkdownTargets(t *testing.T) {
 	require.Len(t, diags, 2, "path and form must apply to non-Markdown targets; extension must not")
 }
 
+// TestCheck_ExtensionIgnoresDirectoryTargets covers links to
+// Hugo-rendered page directories: `/docs/rules/MDS027/`, `docs/`,
+// `.`, `..`. They have no filename segment and must not be
+// flagged as extensionless Markdown by `extension: keep`.
+func TestCheck_ExtensionIgnoresDirectoryTargets(t *testing.T) {
+	src := "# Doc\n\n" +
+		"See [a](/docs/rules/MDS027/).\n\n" +
+		"See [b](sub/).\n\n" +
+		"See [c](./).\n\n" +
+		"See [d](.).\n\n" +
+		"See [e](..).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "keep"}}}
+	assert.Empty(t, r.Check(f), "directory-style targets must not be flagged by extension: keep")
+
+	r = &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "strip"}}}
+	assert.Empty(t, r.Check(f), "directory-style targets must not be flagged by extension: strip either")
+}
+
 func TestCheck_FormInline_FlagsReferenceStyle(t *testing.T) {
 	src := "# Doc\n\nSee [x][label].\n\n[label]: sub/target.md\n"
 	f := newFile(t, src)

--- a/internal/rules/linkstyle/rule_test.go
+++ b/internal/rules/linkstyle/rule_test.go
@@ -374,10 +374,25 @@ func TestPerKindOverride_FlipsVerdict(t *testing.T) {
 	docsRules := config.Effective(cfg, "docs/guides/foo.md", nil, nil)
 	rB := &Rule{}
 	require.NoError(t, rB.ApplySettings(docsRules["link-style"].Settings))
-	assert.Equal(t, "any", rB.Links.Style.Form,
-		"docs kind must inherit base form: any unchanged")
+	// ApplySettings normalizes "any" to "" so the runtime no-op
+	// fast path stays cheap; the docs kind effectively disables
+	// the form check the same way an empty string would.
+	assert.Equal(t, "", rB.Links.Style.Form,
+		"docs kind inherits base form: any, normalized to \"\"")
 	diags = rB.Check(f)
 	assert.Empty(t, diags, "docs kind (form: any inherited) must pass")
+}
+
+// TestApplySettings_NormalizesAnyToEmptyString ensures the
+// runtime no-op fast path (all-three-empty-strings) covers
+// users who explicitly set `form: any`. Without this, an
+// otherwise-unset rule still walks the AST and allocates link
+// slices on every Check.
+func TestApplySettings_NormalizesAnyToEmptyString(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(styleWith(map[string]any{"form": "any"})))
+	assert.Equal(t, "", r.Links.Style.Form,
+		"`form: any` must normalize to \"\" so Check's fast path applies")
 }
 
 func newFile(t *testing.T, src string) *lint.File {

--- a/internal/rules/linkstyle/rule_test.go
+++ b/internal/rules/linkstyle/rule_test.go
@@ -1,0 +1,369 @@
+package linkstyle
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuleMetadata(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "MDS068", r.ID())
+	assert.Equal(t, "link-style", r.Name())
+	assert.Equal(t, "link", r.Category())
+	assert.False(t, r.EnabledByDefault())
+}
+
+func TestCheck_DisabledWhenStyleEmpty(t *testing.T) {
+	src := "# Doc\n\nSee [x](/abs/target.md).\n"
+	f := newFile(t, src)
+	diags := (&Rule{}).Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_PathRelative_FlagsAbsoluteTarget(t *testing.T) {
+	src := "# Doc\n\nSee [x](/docs/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Path: "relative"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "absolute")
+	assert.Equal(t, "MDS068", diags[0].RuleID)
+}
+
+func TestCheck_PathRelative_AcceptsRelativeTarget(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.md).\n\nSee [y](../up/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Path: "relative"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_PathAbsolute_FlagsRelativeTarget(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Path: "absolute"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "relative")
+}
+
+func TestCheck_PathAbsolute_AcceptsAbsoluteTarget(t *testing.T) {
+	src := "# Doc\n\nSee [x](/docs/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Path: "absolute"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_ExtensionStrip_FlagsMDSuffix(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "strip"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, ".md")
+	assert.Contains(t, diags[0].Message, "strip")
+}
+
+func TestCheck_ExtensionStrip_AcceptsExtensionless(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "strip"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_ExtensionKeep_FlagsExtensionless(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "keep"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "keep")
+}
+
+func TestCheck_ExtensionKeep_AcceptsMDSuffix(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "keep"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_ExtensionIgnoresNonMarkdownExtensions(t *testing.T) {
+	// `.png`, `.css`, etc. are not Markdown links — the extension
+	// policy should silently ignore them regardless of keep/strip.
+	src := "# Doc\n\n![logo](images/logo.png)\n\nSee [stylesheet](theme.css).\n"
+	f := newFile(t, src)
+
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "keep"}}}
+	assert.Empty(t, r.Check(f), "keep should not flag .png or .css targets")
+
+	r = &Rule{Links: LinksConfig{Style: StyleConfig{Extension: "strip"}}}
+	assert.Empty(t, r.Check(f), "strip should not flag .png or .css targets")
+}
+
+func TestCheck_FormInline_FlagsReferenceStyle(t *testing.T) {
+	src := "# Doc\n\nSee [x][label].\n\n[label]: sub/target.md\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Form: "inline"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "reference-style")
+	assert.Contains(t, diags[0].Message, "inline")
+}
+
+func TestCheck_FormInline_AcceptsInlineStyle(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Form: "inline"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_FormReference_FlagsInlineStyle(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/target.md).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Form: "reference"}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "inline")
+	assert.Contains(t, diags[0].Message, "reference")
+}
+
+func TestCheck_FormAny_AcceptsBoth(t *testing.T) {
+	src := "# Doc\n\nSee [x](sub/a.md).\n\nSee [y][label].\n\n[label]: sub/b.md\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Form: "any"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_IgnoresLocalAnchorOnlyLinks(t *testing.T) {
+	src := "# Doc\n\nJump [up](#top).\n\n## Top\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Path: "relative", Extension: "keep", Form: "inline"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags, "anchor-only links carry no path; all three checks must be quiet")
+}
+
+func TestCheck_IgnoresExternalLinks(t *testing.T) {
+	src := "# Doc\n\nSee [x](https://example.com/page).\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{Path: "relative", Extension: "keep", Form: "inline"}}}
+	diags := r.Check(f)
+	assert.Empty(t, diags)
+}
+
+func TestCheck_AllThreeAxesEmitSeparateDiagnostics(t *testing.T) {
+	// One link that violates all three policies emits three diagnostics.
+	// Confirms each axis is independent.
+	src := "# Doc\n\nSee [x][label].\n\n[label]: /docs/target.md\n"
+	f := newFile(t, src)
+	r := &Rule{Links: LinksConfig{Style: StyleConfig{
+		Path:      "relative", // /docs/target.md is absolute — flag
+		Extension: "strip",    // .md suffix — flag
+		Form:      "inline",   // reference-style — flag
+	}}}
+	diags := r.Check(f)
+	require.Len(t, diags, 3)
+}
+
+func TestApplySettings_PathStyle(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"links": map[string]any{
+			"style": map[string]any{"path": "relative"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "relative", r.Links.Style.Path)
+}
+
+func TestApplySettings_ExtensionStyle(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"links": map[string]any{
+			"style": map[string]any{"extension": "strip"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "strip", r.Links.Style.Extension)
+}
+
+func TestApplySettings_FormStyle(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"links": map[string]any{
+			"style": map[string]any{"form": "inline"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inline", r.Links.Style.Form)
+}
+
+func TestApplySettings_ExternalSkip(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"links": map[string]any{
+			"external-skip": []any{"^https?://localhost", "^http://10\\."},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.Links.ExternalSkip, 2)
+	assert.Equal(t, "^https?://localhost", r.Links.ExternalSkip[0])
+	assert.Equal(t, "^http://10\\.", r.Links.ExternalSkip[1])
+}
+
+func TestApplySettings_ToleratesMDS027Keys(t *testing.T) {
+	// A user can put a single `links:` block on a kind to configure
+	// both MDS027 and MDS068; each rule must accept the other's
+	// keys without erroring.
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"links": map[string]any{
+			"site-root":                "/srv",
+			"validate-images":          true,
+			"validate-reference-style": false,
+			"style":                    map[string]any{"path": "relative"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "relative", r.Links.Style.Path)
+}
+
+type applyErrCase struct {
+	name     string
+	settings map[string]any
+	wantErr  string
+}
+
+func linksWith(m map[string]any) map[string]any {
+	return map[string]any{"links": m}
+}
+
+func styleWith(m map[string]any) map[string]any {
+	return linksWith(map[string]any{"style": m})
+}
+
+func invalidApplyCases() []applyErrCase {
+	return []applyErrCase{
+		{"unknown top-level setting", map[string]any{"unknown": true}, "unknown setting"},
+		{"links not a map", map[string]any{"links": "x"}, "links must be a map"},
+		{"links.style not a map", linksWith(map[string]any{"style": "x"}), "links.style must be a map"},
+		{"links.style.path bad value", styleWith(map[string]any{"path": "sometimes"}), "links.style.path"},
+		{"links.style.extension bad value",
+			styleWith(map[string]any{"extension": "keep-it-real"}), "links.style.extension"},
+		{"links.style.form bad value", styleWith(map[string]any{"form": "shortcut"}), "links.style.form"},
+		{"links.style unknown key", styleWith(map[string]any{"unknown": "x"}), "unknown links.style setting"},
+		{"links unknown key", linksWith(map[string]any{"unknown": true}), "unknown links setting"},
+		{"links.external-skip not a list", linksWith(map[string]any{"external-skip": 42}), "links.external-skip"},
+		{"links.style.path non-string", styleWith(map[string]any{"path": 42}), "links.style.path"},
+	}
+}
+
+func TestApplySettings_InvalidValues(t *testing.T) {
+	for _, tc := range invalidApplyCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (&Rule{}).ApplySettings(tc.settings)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestDefaultSettings(t *testing.T) {
+	r := &Rule{}
+	ds := r.DefaultSettings()
+	links, ok := ds["links"].(map[string]any)
+	require.True(t, ok)
+
+	style, ok := links["style"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "", style["path"])
+	assert.Equal(t, "", style["extension"])
+	assert.Equal(t, "", style["form"])
+
+	skip, ok := links["external-skip"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, skip)
+}
+
+func TestApplyDefaultSettingsLeavesRuleQuiet(t *testing.T) {
+	// Round-trip: defaults applied to an empty rule must keep the
+	// rule silent — every check is opt-in via an explicit policy.
+	r := &Rule{}
+	err := r.ApplySettings(r.DefaultSettings())
+	require.NoError(t, err)
+
+	src := "# Doc\n\nSee [x][label].\n\n[label]: /docs/target.md\n"
+	f := newFile(t, src)
+	assert.Empty(t, r.Check(f))
+}
+
+// TestPerKindOverride_FlipsVerdict exercises the layered config
+// deep-merge: a base sets `links.style.form: any` at the rules:
+// level, then two kinds override it. The `rule-readme` kind pins
+// `form: inline` so a reference-style link is flagged for files
+// in that kind; the `docs` kind leaves the base untouched, so the
+// same link passes. Task 3 of plan 172.
+func TestPerKindOverride_FlipsVerdict(t *testing.T) {
+	cfg := &config.Config{
+		Rules: map[string]config.RuleCfg{
+			"link-style": {
+				Enabled: true,
+				Settings: map[string]any{
+					"links": map[string]any{
+						"style": map[string]any{"form": "any"},
+					},
+				},
+			},
+		},
+		Kinds: map[string]config.KindBody{
+			"rule-readme": {Rules: map[string]config.RuleCfg{
+				"link-style": {Enabled: true, Settings: map[string]any{
+					"links": map[string]any{
+						"style": map[string]any{"form": "inline"},
+					},
+				}},
+			}},
+			"docs": {Rules: map[string]config.RuleCfg{}},
+		},
+		KindAssignment: []config.KindAssignmentEntry{
+			{Files: []string{"rules/**/README.md"}, Kinds: []string{"rule-readme"}},
+			{Files: []string{"docs/**/*.md"}, Kinds: []string{"docs"}},
+		},
+	}
+
+	src := "# Doc\n\nSee [x][label].\n\n[label]: sub/target.md\n"
+	f := newFile(t, src)
+
+	readmeRules := config.Effective(cfg, "rules/foo/README.md", nil, nil)
+	rA := &Rule{}
+	require.NoError(t, rA.ApplySettings(readmeRules["link-style"].Settings))
+	assert.Equal(t, "inline", rA.Links.Style.Form,
+		"rule-readme kind must override base form: any with form: inline")
+	diags := rA.Check(f)
+	require.Len(t, diags, 1, "rule-readme override (form: inline) must flag the ref link")
+	assert.Contains(t, diags[0].Message, "reference-style")
+
+	docsRules := config.Effective(cfg, "docs/guides/foo.md", nil, nil)
+	rB := &Rule{}
+	require.NoError(t, rB.ApplySettings(docsRules["link-style"].Settings))
+	assert.Equal(t, "any", rB.Links.Style.Form,
+		"docs kind must inherit base form: any unchanged")
+	diags = rB.Check(f)
+	assert.Empty(t, diags, "docs kind (form: any inherited) must pass")
+}
+
+func newFile(t *testing.T, src string) *lint.File {
+	t.Helper()
+	f, err := lint.NewFile("doc.md", []byte(src))
+	require.NoError(t, err)
+	return f
+}

--- a/plan/172_link-style-rule-and-config.md
+++ b/plan/172_link-style-rule-and-config.md
@@ -1,7 +1,7 @@
 ---
 id: 172
 title: Link-style rule and shared links config
-status: "🔲"
+status: "✅"
 model: opus
 depends-on: [170, 171]
 summary: >-
@@ -57,12 +57,12 @@ also adds the rule that consumes `style:`.
 
 ## Acceptance Criteria
 
-- [ ] `link-style` is opt-in (off by default) and
+- [x] `link-style` is opt-in (off by default) and
   flags path/extension/form deviations per kind.
-- [ ] Per-kind override changes the verdict for the
+- [x] Per-kind override changes the verdict for the
   same link in two kinds.
-- [ ] `links.external-skip` parses and is readable by
+- [x] `links.external-skip` parses and is readable by
   rule code.
-- [ ] Rule README exists and is in the rule catalog.
-- [ ] All tests pass: `go test ./...`.
-- [ ] `go tool golangci-lint run` reports no issues.
+- [x] Rule README exists and is in the rule catalog.
+- [x] All tests pass: `go test ./...`.
+- [x] `go tool golangci-lint run` reports no issues.


### PR DESCRIPTION
## Summary

- Add **MDS068 `link-style`**, an opt-in rule that flags links whose path style, extension policy, or inline-vs-reference form deviates from the per-kind `links.style` policy. Closes G8 from the [link handling audit](docs/research/links/README.md).
- Extend the shared `links:` config block parser with `style: {path, extension, form}` and `external-skip: []`, deep-merged per kind.
- Parse `links.external-skip` and store it on the rule so the future issue #47 external-link-check rule has its config foundation.
- MDS027 keeps its own keys (`site-root`, `validate-images`, `validate-reference-style`); MDS068 reads `style` and `external-skip`. Each rule tolerates the other's keys so a single `links:` YAML body works under both rule names.

## How the three policy axes work

- `links.style.path`: `relative` flags absolute targets; `absolute` flags relative targets
- `links.style.extension`: `keep` flags Markdown-shaped targets without `.md`; `strip` flags those with `.md`. Targets ending in `.png`/`.css`/… are ignored.
- `links.style.form`: `inline` flags reference-style links; `reference` flags inline links; `any` is permissive.

Each axis is independent — empty string means "no check". Enabling the rule with all three axes unset is a no-op.

## Per-kind override

`TestPerKindOverride_FlipsVerdict` drives the real `config.Effective` deep-merge to prove a `rule-readme` kind pinned to `form: inline` flags a reference-style link that the `docs` kind (inheriting base `form: any`) lets through.

## Test plan

- [x] `go test ./...` — all tests pass (incl. fixture tests in `MDS068-link-style/{good,bad}/`)
- [x] `go tool golangci-lint run` — 0 issues
- [x] `go vet ./...` — clean
- [x] `mdsmith check .` — clean across all 356 files
- [x] Per-rule alloc budget test still passes
- [x] Rule README auto-discovered into the rule catalog by the `<?catalog?>` directive

https://claude.ai/code/session_01TJWuJyKqpQW7XQ76HJ2Qjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJWuJyKqpQW7XQ76HJ2Qjj)_