### PR TITLE
Plan 208: Kind-per-file config under `.mdsmith/kinds/`

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -133,4 +133,5 @@ footer: |
 | 205 | 🔲     |        | [Move extension.ts concerns to wiring.ts](plan/205_arch-fix-extension-ts-srp.md)                                                        |
 | 206 | 🔲     |        | [Document cue/ in architecture layering map](plan/206_arch-fix-cue-types-docs.md)                                                       |
 | 207 | 🔲     | sonnet | [LSP fix preview via ChangeAnnotation](plan/207_lsp-fix-preview.md)                                                                     |
+| 208 | 🔲     | opus   | [Kind-per-file config under `.mdsmith/kinds/`](plan/208_kind-files.md)                                                                  |
 <?/catalog?>

--- a/plan/208_kind-files.md
+++ b/plan/208_kind-files.md
@@ -37,10 +37,10 @@ A change to one kind dirties the same file
 as every other config edit, and reading one
 kind means scrolling past a dozen others.
 
-A YAML file per kind (basename = name) makes
-each kind self-contained. The `.mdsmith/`
-directory also reserves
-`.mdsmith/conventions/` for a later plan.
+A YAML file per kind (basename = name)
+makes each self-contained. The `.mdsmith/`
+tree reserves a `conventions/` slot for
+later.
 
 ## Non-Goals
 
@@ -105,11 +105,13 @@ rules:
     max: 600
 ```
 
-The kind's name is the file's basename
-minus extension. The name must match
-`[a-z][a-z0-9-]*` (the existing kind-name
-syntax). A bad basename is a config error
-naming the file.
+The kind's name is the basename minus
+extension. The basename must match
+`[a-z][a-z0-9-]*` — a new constraint added
+here for filenames (OS case folding, path
+syntax) that doesn't apply to inline YAML
+keys. A bad basename errors. Inline
+`kinds.<name>:` keys stay unvalidated.
 
 One kind per file. A YAML document with
 top-level keys outside the `KindBody`
@@ -139,17 +141,15 @@ assignment runs.
 
 ### Schema sources within a kind file
 
-A kind body accepts three schema sources
-today. `schema:` is an inline map.
-`rules.required-structure.schema:` is a
-path to a `proto.md`. And
-`rules.required-structure.inline-schema:`
-is a legacy inline map under the rule. Two
-on the same kind is a config error, caught
-pairwise by `validateKindSchemaSources` in
+A kind body accepts three schema sources:
+an inline `schema:` map, a
+`rules.required-structure.schema:` path to
+a `proto.md`, and a legacy
+`…inline-schema:` map. Setting two on the
+same kind errors, caught pairwise by
+`validateKindSchemaSources` in
 [validate.go](../internal/config/validate.go).
-That check applies unchanged to file-defined
-kinds.
+The check applies unchanged to file kinds.
 
 ### Schema sharing across kinds
 
@@ -284,12 +284,13 @@ schema parsing lives in `internal/schema`.
 - [ ] Two kind files with the same
       basename across `.yaml`/`.yml` error
       naming both.
-- [ ] A bad basename or a file in a
-      subdirectory of `.mdsmith/kinds/`
-      errors naming the file.
-- [ ] A kind file with a top-level key
-      outside `KindBody` errors naming the
-      key and the file.
+- [ ] A basename failing `[a-z][a-z0-9-]*`
+      or a file in a subdir of
+      `.mdsmith/kinds/` errors; inline kind
+      names stay unvalidated.
+- [ ] A kind file with a key outside
+      `KindBody` errors naming key and
+      file.
 - [ ] The three pairwise schema-source
       checks in `validateKindSchemaSources`
       fire on a file-defined kind the same

--- a/plan/208_kind-files.md
+++ b/plan/208_kind-files.md
@@ -1,0 +1,313 @@
+---
+id: 208
+title: Kind-per-file config under `.mdsmith/kinds/`
+status: "🔲"
+model: opus
+depends-on: [146, 135]
+summary: >-
+  Move a kind out of `.mdsmith.yml` into a
+  standalone YAML file whose basename is the
+  kind name. The file holds the full
+  `KindBody` (schema, rules, path-pattern,
+  extends). The same `.mdsmith/` directory
+  reserves slots for conventions to follow in
+  a later plan.
+---
+# Kind-per-file config under `.mdsmith/kinds/`
+
+## Goal
+
+Lift each kind out of `.mdsmith.yml` into a
+standalone YAML file. The basename is the
+kind's identity. The file body holds the
+complete kind — schema, rules, path-pattern,
+extends — so one file describes everything
+about that kind in one place.
+
+## Background
+
+A kind today lives under `kinds.<name>:` in
+`.mdsmith.yml` (plan 92). Its body — schema,
+rules, `path-pattern:`, `extends:`,
+`categories:` — sits in the one shared file.
+
+This repo's `.mdsmith.yml` is 558 lines; the
+`kinds:` block alone covers lines 295–480.
+A change to one kind dirties the same file
+as every other config edit, and reading one
+kind means scrolling past a dozen others.
+
+A YAML file per kind (basename = name) makes
+each kind self-contained. The `.mdsmith/`
+directory also reserves
+`.mdsmith/conventions/` for a later plan.
+
+## Non-Goals
+
+- Removing inline `kinds.<name>:` from
+  `.mdsmith.yml`. Inline stays as a
+  first-class source.
+- Migrating `proto.md` schemas to YAML;
+  `proto.md` stays. A kind file may still
+  set `rules.required-structure.schema:`
+  pointing at a `proto.md`.
+- A standalone-schema directory. A schema
+  shared across kinds is shared via
+  `extends:` (plan 135), not by extracting
+  the `schema:` block to its own file.
+- Externalising conventions. The
+  `.mdsmith/conventions/` slot is reserved
+  but not wired in this plan.
+- Schema versioning (V-1).
+
+## Design
+
+### Directory layout
+
+```text
+.mdsmith.yml                   # unchanged
+.mdsmith/
+  kinds/
+    audit-log.yaml             # one full kind
+    secret-rotation.yaml
+    architecture-doc.yaml
+```
+
+The discovery root is the workspace root
+(parent of `.mdsmith.yml`). Both `*.yaml`
+and `*.yml` are scanned. Subdirectories
+under `.mdsmith/kinds/` are rejected at load
+time.
+
+### Kind file shape
+
+The body matches today's inline
+`kinds.<name>:` shape. It holds the full
+`KindBody` keys: `extends:`, `path-pattern:`,
+`categories:`, `schema:`, `rules:`.
+
+```yaml
+# .mdsmith/kinds/audit-log.yaml
+schema:
+  frontmatter:
+    title: 'string & != ""'
+    "summary?": 'string'
+    audit-from: '=~"^[0-9a-f]{7,40}$"'
+  filename: "architecture-audit.md"
+  closed: false
+  sections:
+    - heading: null
+    - heading:
+        regex: '.+'
+        repeat: { min: 0 }
+rules:
+  max-file-length:
+    max: 600
+```
+
+The kind's name is the file's basename
+minus extension. The name must match
+`[a-z][a-z0-9-]*` (the existing kind-name
+syntax). A bad basename is a config error
+naming the file.
+
+One kind per file. A YAML document with
+top-level keys outside the `KindBody`
+schema is a config error.
+
+### Composition with `.mdsmith.yml`
+
+A file-defined kind and an inline
+`kinds.<name>:` block under the same name
+is a config error naming both sources. The
+two sources do **not** merge — a merged
+kind would defeat the "read one file to
+know one kind" property this plan ships.
+
+Two kind files with the same basename
+across `*.yaml` and `*.yml` is also a
+config error naming both files.
+
+### Kind-assignment, overrides, ignore
+
+These three sections stay in `.mdsmith.yml`.
+They are glob-keyed and have no canonical
+name. A kind-assignment entry may reference
+either a file-defined or an inline kind by
+name — the resolution map merges before
+assignment runs.
+
+### Schema sources within a kind file
+
+A kind body accepts three schema sources
+today. `schema:` is an inline map.
+`rules.required-structure.schema:` is a
+path to a `proto.md`. And
+`rules.required-structure.inline-schema:`
+is a legacy inline map under the rule. Two
+on the same kind is a config error, caught
+pairwise by `validateKindSchemaSources` in
+[validate.go](../internal/config/validate.go).
+That check applies unchanged to file-defined
+kinds.
+
+### Schema sharing across kinds
+
+A schema shared across kinds uses
+`extends:` (plan 135). A file-defined kind
+may extend an inline kind and vice versa.
+The existing cycle detection in
+[kind_extends.go](../internal/config/kind_extends.go)
+runs across both sources.
+
+A path-shared `proto.md` schema works too.
+A kind file may set
+`rules.required-structure.schema: <path>`
+to point at a workspace `proto.md`.
+
+### CLI surface
+
+`mdsmith kinds resolve <file>` prints the
+defining-source path for each kind it
+reports (the file under `.mdsmith/kinds/`
+or `.mdsmith.yml`). No new subcommand.
+
+### Out of scope but seeded
+
+`.mdsmith/conventions/<name>.yaml` fits the
+same shape. A later plan slots it into the
+tree. The plan 113 convention body maps
+cleanly to one file per name.
+
+`overrides:`, `kind-assignment:`, and
+`ignore:` are glob-keyed with no canonical
+name and stay inline. The top-level
+`rules:` block is a single project-wide
+setting and stays inline too.
+
+## Tasks
+
+Per
+[Go architecture patterns](../docs/development/architecture/go.md):
+no new package is required. Discovery and
+kind parsing live in `internal/config`;
+schema parsing lives in `internal/schema`.
+
+1. **`internal/config`**: add
+   `discoverKinds(workspaceDir string)
+   (map[string]discoveredKind, error)`.
+   Walks `.mdsmith/kinds/*.{yaml,yml}` at
+   the workspace root. Validates
+   basenames, rejects subdirectories,
+   rejects basename collisions across
+   `*.yaml` and `*.yml`, rejects bodies
+   with keys outside `KindBody`. Unit test
+   `TestDiscoverKinds` with subtests per
+   rejection case.
+2. **`internal/config`**: update `Load` in
+   [load.go](../internal/config/load.go) to
+   call `discoverKinds` and merge the
+   result into `cfg.Kinds`. A name
+   colliding between a file kind and an
+   inline kind is a config error naming
+   both sources. Unit test
+   `TestLoad_KindFileInlineCollision`.
+3. **`internal/config`**: wire file-defined
+   kinds through the existing
+   `validateKindSchemaSources` in
+   [validate.go](../internal/config/validate.go)
+   so all three pairwise checks (`schema:`,
+   `rules.required-structure.schema:`,
+   `rules.required-structure.inline-schema:`)
+   fire on a kind file the same way they
+   fire on an inline kind. Pinned today by
+   `TestKindRejectsDualSchemaSources`,
+   `TestKindRejectsInlineMapInRules`, and
+   `TestKindRejectsBothSchemaAndInlineUnderRules`
+   in
+   [schema_kinds_test.go](../internal/config/schema_kinds_test.go);
+   add file-defined parallels of each.
+4. **`internal/engine`**: no change. The
+   resolved `cfg.Kinds` already drives
+   schema resolution and rule layering.
+5. **Provenance**: extend
+   [provenance.go](../internal/config/provenance.go)
+   so each kind layer records its
+   defining-source path. Unit test
+   `TestProvenance_KindSourcePath`.
+6. **Contract test**: add
+   `internal/integration/kind_file_contract_test.go`.
+   Locks the directory layout, the
+   basename rule, the dual-source
+   rejection, the subdirectory rejection,
+   and the no-extra-top-level-keys rule.
+   Per
+   [cross-system contracts](../docs/development/architecture/cross-system.md),
+   every public surface ships with a
+   contract test.
+7. **Integration test**: parallel fixtures
+   that share a Markdown body and assert
+   a file-defined kind produces the same
+   diagnostics as the equivalent inline
+   kind. Lives under
+   `internal/integration/`.
+8. **CLI**: extend `mdsmith kinds resolve`
+   to print the defining-source path next
+   to each kind it reports.
+9. **Docs**: add
+   `docs/reference/kind-files.md`. Add a
+   row to the boundaries table in
+   [cross-system.md](../docs/development/architecture/cross-system.md)
+   pointing at it. Extend
+   [file-kinds.md](../docs/guides/file-kinds.md)
+   with a "split a kind into its own file"
+   recipe.
+10. **Repo migration**: move every kind
+    from `.mdsmith.yml` to
+    `.mdsmith/kinds/*.yaml`. Names stay
+    stable so `kind-assignment:` entries
+    need no rewrite. Requires explicit
+    user consent per CLAUDE.md.
+11. **Follow-up plan**: open a plan file
+    (not implemented here) for
+    `.mdsmith/conventions/<name>.yaml` so
+    the directory convention is recorded.
+
+## Acceptance Criteria
+
+- [ ] A kind at `.mdsmith/kinds/foo.yaml`
+      with the same body as inline
+      `kinds.foo:` emits byte-equal
+      diagnostics. (LSP: substitutable.)
+- [ ] A kind declared both in a file and
+      inline errors naming both sources.
+- [ ] Two kind files with the same
+      basename across `.yaml`/`.yml` error
+      naming both.
+- [ ] A bad basename or a file in a
+      subdirectory of `.mdsmith/kinds/`
+      errors naming the file.
+- [ ] A kind file with a top-level key
+      outside `KindBody` errors naming the
+      key and the file.
+- [ ] The three pairwise schema-source
+      checks in `validateKindSchemaSources`
+      fire on a file-defined kind the same
+      way they fire on inline.
+- [ ] A file-defined kind may `extends:` an
+      inline kind and the reverse; a cycle
+      is detected.
+- [ ] A `kind-assignment:` entry resolves
+      a file-defined kind by name with no
+      extra wiring.
+- [ ] `mdsmith kinds resolve <file>` prints
+      the defining-source path per kind.
+- [ ] `cross-system.md` boundaries table
+      lists `.mdsmith/kinds/` with
+      `docs/reference/kind-files.md`.
+- [ ] Every new function in
+      `internal/config` ships with its
+      dedicated unit test. (Test pyramid.)
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` clean.
+- [ ] `mdsmith check .` passes.


### PR DESCRIPTION
## Summary

- New plan: lift each kind out of `.mdsmith.yml` into a standalone YAML file at `.mdsmith/kinds/<name>.yaml`. Basename = kind name. The file holds the full `KindBody` (schema, rules, path-pattern, extends) so one file describes everything about that kind.
- A kind declared in both a file and inline is a config error. The two sources do **not** merge — that would defeat the "read one file to know one kind" property.
- `kind-assignment:`, `overrides:`, `ignore:`, and top-level `rules:` stay in `.mdsmith.yml` (glob-keyed or single-block; no canonical name).
- A schema shared across kinds is shared via existing `extends:` (plan 135) or via `proto.md` paths, not via a separate schema-files directory.
- Reserves `.mdsmith/conventions/` for the same pattern in a later plan.
- Package boundaries respected: discovery in `internal/config`; no new package. New public surface gets a contract test and a row in `cross-system.md`'s boundaries table.

**History notes:**
- The earlier `.mdsmith/schemas/<name>.yaml` draft split only the schema out, leaving the rest of the kind in `.mdsmith.yml`. The user asked for a fully self-contained per-file config, so the unit of split is the kind, not the schema.
- Originally numbered 207; renumbered to 208 after PR #383 merged the LSP fix-preview plan as 207.
- Branch was squashed (four commits → one) and rebased onto current `main` to avoid cascading PLAN.md catalog conflicts.

## Test plan

- [ ] Review the design — directory layout, dual-source rejection, schema-sharing via `extends:`/`proto.md`.
- [ ] Decide on task 10 (migrate every existing kind in this repo to `.mdsmith/kinds/*.yaml`) — keep in this plan or split out?
- [ ] Once approved, implement the tasks red/green per CLAUDE.md.

https://claude.ai/code/session_01GuEe4MwqPKbdtSv2HWah4P

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuEe4MwqPKbdtSv2HWah4P)_