### PR TITLE
Implement custom binding overrides for mdsmith extract (plan 167)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -93,7 +93,7 @@ footer: |
 | 164 | ✅     |        | [GitHub-UI-triggered releases and a split website deploy](plan/164_github-ui-releases-and-split-website.md)                             |
 | 165 | ✅     | opus   | [Portable Markdown export (mdsmith export)](plan/165_portable-markdown-export.md)                                                       |
 | 166 | ✅     | opus   | [Schema-driven data extraction (mdsmith extract)](plan/166_schema-driven-data-extraction.md)                                            |
-| 167 | 🔲     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                                    |
+| 167 | ✅     | opus   | [Custom binding overrides for mdsmith extract](plan/167_custom-binding-overrides.md)                                                    |
 | 168 | ✅     | sonnet | [Obsidian Flavored Markdown support](plan/168_obsidian-markdown-support.md)                                                             |
 | 169 | ✅     | opus   | [Enforce terminal Meta-Information and render it from frontmatter](plan/169_rule-readme-meta-information-sync.md)                       |
 | 170 | ✅     | opus   | [Audit link handling across mdsmith and the website](plan/170_link-handling-audit.md)                                                   |

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -580,7 +580,10 @@ placeholder, a `heading: null` section's content hoists
 into its enclosing object, and `code-block` / `list` /
 `table` / `paragraph` content entries project under
 `code` / `items` / `rows` / `text`. Wildcard slots and
-unlisted headings are skipped. See
+unlisted headings are skipped. Set `bind: <name>` on a
+scope or content entry to override the default key;
+`bind: ""` hoists a scope's children into the parent.
+See
 [`mdsmith extract`](../reference/cli/extract.md) for the
 full projection rules and exit codes.
 

--- a/docs/reference/cli/extract.md
+++ b/docs/reference/cli/extract.md
@@ -63,10 +63,26 @@ are a schema error. It is reported at extract time.
 Optional sections that did not match are omitted, not
 emitted as null.
 
-Renaming or restructuring beyond this default is a
-downstream job. Use a tool like `jq` or `yq` over the
-standard output. Custom binding overrides are a
-separate follow-up.
+## Custom binding with `bind`
+
+A scope or content entry can set an optional
+`bind:` field to override the default key:
+
+- `bind: <name>` renames a scope's key (replacing
+  the slugified heading) or a content entry's key
+  (replacing `code` / `items` / `rows` / `text`).
+- `bind: ""` on a scope hoists its children and
+  content directly into the parent — useful when a
+  wrapper heading exists only for document structure
+  and should not nest in the data tree.
+
+Duplicate sibling binds, `bind:` on a preamble,
+slot, or broad matcher, `bind: ""` on a content
+entry, and a real disagreement between composed
+kinds each surface as an error before extraction
+runs. For ad-hoc transformations beyond what
+`bind:` covers, pipe the standard output through
+`jq` or `yq`.
 
 ## Examples
 

--- a/internal/extract/bind_test.go
+++ b/internal/extract/bind_test.go
@@ -1,0 +1,178 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// strPtr returns a pointer to s — used to set the Bind *string field
+// from test literals.
+func strPtr(s string) *string { return &s }
+
+// boundScope builds a literal-heading scope with an explicit bind
+// override. Mirrors the shape an inline schema would parse into.
+func boundScope(heading, bind string) schema.Scope {
+	sc := litScope(heading)
+	sc.Bind = strPtr(bind)
+	return sc
+}
+
+// TestExtract_BindRenamesKey overrides the default slug with the
+// `bind:` value; the projected key is the user's name rather than
+// the slugified heading.
+func TestExtract_BindRenamesKey(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections:  []schema.Scope{boundScope("Goal", "objective")},
+	}
+	got, diags := run(t, "## Goal\n\nbody\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Contains(t, root, "objective")
+	assert.NotContains(t, root, "goal")
+}
+
+// TestExtract_BindEmptyHoistsChildren ensures `bind: ""` lifts the
+// scope's child sections and content into the parent without a
+// wrapper key.
+func TestExtract_BindEmptyHoistsChildren(t *testing.T) {
+	inner := litScope("First")
+	outer := litScope("Steps")
+	outer.Sections = []schema.Scope{inner}
+	outer.Bind = strPtr("") // hoist
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{outer}}
+	got, diags := run(t, "## Steps\n\n### First\n\nx\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	// `steps` is gone; `first` lives directly on the root.
+	assert.NotContains(t, root, "steps")
+	assert.Contains(t, root, "first")
+}
+
+// TestExtract_BindEmptyHoistsContent confirms the hoist also lifts
+// the scope's content entries (paragraph text in this case).
+func TestExtract_BindEmptyHoistsContent(t *testing.T) {
+	sc := schema.Scope{
+		Heading: "Notes",
+		Matcher: &schema.Matcher{Regex: "Notes"},
+		Bind:    strPtr(""),
+		Content: []schema.ContentEntry{
+			{Kind: schema.ContentKindParagraph, Required: true},
+		},
+	}
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{sc}}
+	got, diags := run(t, "## Notes\n\na note\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.NotContains(t, root, "notes")
+	assert.Equal(t, "a note", root["text"])
+}
+
+// TestExtract_BindHoistCollisionFlagged surfaces a hoist that would
+// silently overwrite a sibling key — the projector reports it as
+// a sibling-key collision so the user can adjust the schema.
+func TestExtract_BindHoistCollisionFlagged(t *testing.T) {
+	inner := litScope("Goal")
+	outer := litScope("Wrapper")
+	outer.Sections = []schema.Scope{inner}
+	outer.Bind = strPtr("")
+	other := litScope("Goal")
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections:  []schema.Scope{outer, other},
+	}
+	_, diags := run(t,
+		"## Wrapper\n\n### Goal\n\nx\n\n## Goal\n\ny\n",
+		sch, nil)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "goal")
+}
+
+// TestExtract_BindRepeatingHoistRejected covers the edge case where
+// a repeating scope is marked `bind: ""`. Two occurrences would
+// silently overwrite each other on hoist, so the projector flags
+// the collision rather than producing lossy output.
+func TestExtract_BindRepeatingHoistRejected(t *testing.T) {
+	rep := schema.Scope{
+		Heading: "Step {n}",
+		Matcher: &schema.Matcher{
+			Regex:  `Step \#(digits)`,
+			Repeat: schema.Repeat{Set: true, Min: 1},
+		},
+		Bind: strPtr(""),
+	}
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{rep}}
+	_, diags := run(t, "## Step 1\n\na\n\n## Step 2\n\nb\n", sch, nil)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "hoist")
+}
+
+// TestExtract_ContentBindRenamesKey: a content entry's bind value
+// replaces the default `code` / `items` / `rows` / `text` key.
+func TestExtract_ContentBindRenamesKey(t *testing.T) {
+	sc := schema.Scope{
+		Heading: "Examples",
+		Matcher: &schema.Matcher{Regex: "Examples"},
+		Content: []schema.ContentEntry{
+			{Kind: schema.ContentKindParagraph, Required: true, Bind: strPtr("blurb")},
+			{Kind: schema.ContentKindCodeBlock, Required: true, Bind: strPtr("snippet")},
+		},
+	}
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{sc}}
+	body := "## Examples\n\nintro\n\n```go\nx := 1\n```\n"
+	got, diags := run(t, body, sch, nil)
+	require.Empty(t, diags)
+	ex := got.(map[string]any)["examples"].(map[string]any)
+	assert.Equal(t, "x := 1", ex["snippet"])
+	assert.Equal(t, "intro", ex["blurb"])
+	assert.NotContains(t, ex, "code")
+	assert.NotContains(t, ex, "text")
+}
+
+// TestExtract_BindRepeatingArray confirms a repeating scope keeps
+// its array projection under the bound key (not the default slug).
+func TestExtract_BindRepeatingArray(t *testing.T) {
+	rep := schema.Scope{
+		Heading: "Step {n}",
+		Matcher: &schema.Matcher{
+			Regex:  `Step \#(digits)`,
+			Repeat: schema.Repeat{Set: true, Min: 1},
+		},
+		Bind: strPtr("steps"),
+	}
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{rep}}
+	got, diags := run(t, "## Step 1\n\na\n\n## Step 2\n\nb\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Contains(t, root, "steps")
+	assert.NotContains(t, root, "step")
+	arr := root["steps"].([]any)
+	require.Len(t, arr, 2)
+}
+
+// TestExtract_BindSurvivesComposition: a file resolving to two
+// kinds where one sets `bind:` for a heading uses the bound key in
+// the projection.
+func TestExtract_BindSurvivesComposition(t *testing.T) {
+	a := &schema.Schema{
+		RootLevel: 2,
+		Sections:  []schema.Scope{boundScope("Goal", "objective")},
+	}
+	b := &schema.Schema{
+		RootLevel: 2,
+		Sections:  []schema.Scope{litScope("Goal")},
+	}
+	composed, err := schema.Compose(a, b)
+	require.NoError(t, err)
+
+	f := doc(t, "## Goal\n\nbody\n")
+	mt := schema.BuildMatchTree(f, composed, nil)
+	got, diags := Extract(f, composed, mt)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Contains(t, root, "objective")
+	assert.NotContains(t, root, "goal")
+}

--- a/internal/extract/bind_test.go
+++ b/internal/extract/bind_test.go
@@ -153,6 +153,26 @@ func TestExtract_BindRepeatingArray(t *testing.T) {
 	require.Len(t, arr, 2)
 }
 
+// TestHoistsToParent_NilSafe covers the defensive nil branches:
+// hoistsToParent must not panic on a nil match or a match whose
+// Scope is nil (the synthetic MatchTree.Root has Scope == nil).
+func TestHoistsToParent_NilSafe(t *testing.T) {
+	assert.False(t, hoistsToParent(nil))
+	assert.False(t, hoistsToParent(&schema.ScopeMatch{}))
+}
+
+// TestKeyFor_EmptyBindFallsBackToDefault verifies the defensive
+// `*Bind == ""` guard in keyFor: even if a caller bypasses the
+// hoistsToParent check, keyFor never emits an empty key.
+func TestKeyFor_EmptyBindFallsBackToDefault(t *testing.T) {
+	sc := &schema.Scope{
+		Heading: "Goal",
+		Matcher: &schema.Matcher{Regex: "Goal"},
+		Bind:    strPtr(""),
+	}
+	assert.Equal(t, "goal", keyFor(sc))
+}
+
 // TestExtract_BindSurvivesComposition: a file resolving to two
 // kinds where one sets `bind:` for a heading uses the bound key in
 // the projection.

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -55,15 +55,17 @@ type projector struct {
 }
 
 // keyFor is the single key-naming seam — the one function plan 167
-// overrides through `bind:`. When the scope sets a non-nil `Bind`,
-// its value wins (an empty string is the hoist signal handled at the
-// call site, so this function never returns it as a key). Otherwise
-// the default binding derives every key from the heading: a literal
+// overrides through `bind:`. A non-empty `Bind` wins (the value
+// replaces the default key). An empty bind is the hoist signal —
+// projectChildren routes hoist groups through hoistGroup before
+// reaching keyFor, but the empty-string check here keeps any
+// future caller from accidentally writing a blank key. The
+// fallback chain derives the default from the heading: a literal
 // heading slugifies whole; a placeholder-bearing heading slugifies
 // its literal stem, falling back to the first `fmvar` field name
 // when the heading is only a placeholder (`## {id}`).
 func keyFor(sc *schema.Scope) string {
-	if sc != nil && sc.Bind != nil {
+	if sc != nil && sc.Bind != nil && *sc.Bind != "" {
 		return *sc.Bind
 	}
 	stem, fmvars, _ := schema.HeadingStem(sc)

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -54,13 +54,18 @@ type projector struct {
 	diags []lint.Diagnostic
 }
 
-// keyFor is the single key-naming seam — the one function a future
-// custom-binding plan (plan 167) overrides. The default binding
-// derives every key from the heading: a literal heading slugifies
-// whole; a placeholder-bearing heading slugifies its literal stem,
-// falling back to the first `fmvar` field name when the heading is
-// only a placeholder (`## {id}`).
+// keyFor is the single key-naming seam — the one function plan 167
+// overrides through `bind:`. When the scope sets a non-nil `Bind`,
+// its value wins (an empty string is the hoist signal handled at the
+// call site, so this function never returns it as a key). Otherwise
+// the default binding derives every key from the heading: a literal
+// heading slugifies whole; a placeholder-bearing heading slugifies
+// its literal stem, falling back to the first `fmvar` field name
+// when the heading is only a placeholder (`## {id}`).
 func keyFor(sc *schema.Scope) string {
+	if sc != nil && sc.Bind != nil {
+		return *sc.Bind
+	}
 	stem, fmvars, _ := schema.HeadingStem(sc)
 	if s := mdtext.Slugify(stem); s != "" {
 		return s
@@ -69,6 +74,17 @@ func keyFor(sc *schema.Scope) string {
 		return fmvars[0]
 	}
 	return mdtext.Slugify(sc.Heading)
+}
+
+// hoistsToParent reports whether sm is a scope match whose bind
+// override directs it to be hoisted into the parent (`bind: ""`).
+// A preamble has the same effect by definition; this helper covers
+// the explicit bind form for non-preamble scopes.
+func hoistsToParent(sm *schema.ScopeMatch) bool {
+	if sm == nil || sm.Scope == nil {
+		return false
+	}
+	return sm.Scope.Bind != nil && *sm.Scope.Bind == ""
 }
 
 // isRepeating reports whether a scope projects as an array. A
@@ -80,8 +96,9 @@ func isRepeating(sc *schema.Scope) bool {
 
 // projectChildren walks a contiguous list of sibling scope matches,
 // grouping consecutive occurrences of the same schema scope, and
-// writes each group's projection into obj. A preamble group hoists
-// its content directly into obj (no wrapper key).
+// writes each group's projection into obj. A preamble group — and a
+// non-preamble group whose scope sets `bind: ""` — hoists its
+// content directly into obj (no wrapper key).
 func (p *projector) projectChildren(
 	children []*schema.ScopeMatch, obj map[string]any,
 ) {
@@ -100,6 +117,11 @@ func (p *projector) projectChildren(
 		group := children[i:j]
 		i = j
 
+		if hoistsToParent(sm) {
+			p.hoistGroup(group, obj)
+			continue
+		}
+
 		key := keyFor(sm.Scope)
 		if isRepeating(sm.Scope) {
 			arr := make([]any, 0, len(group))
@@ -114,6 +136,25 @@ func (p *projector) projectChildren(
 			continue
 		}
 		p.setKey(obj, key, p.projectScopeObject(group[0]))
+	}
+}
+
+// hoistGroup merges every element of group directly into obj
+// instead of nesting under a key. A `bind: ""` scope's projection
+// is its own child-scopes and content, so projectScopeObject's
+// captures, children, and content all surface as siblings of obj's
+// existing keys; collisions go through setKey like any other write.
+// A repeating hoisted scope would silently overwrite — same shape
+// as duplicate headings on a non-repeating bind, so we flag it.
+func (p *projector) hoistGroup(group []*schema.ScopeMatch, obj map[string]any) {
+	if len(group) > 1 {
+		p.collision("<hoist>",
+			"a repeating scope cannot hoist (`bind: \"\"`) because "+
+				"multiple occurrences would overwrite each other")
+		return
+	}
+	for k, v := range p.projectScopeObject(group[0]) {
+		p.setKey(obj, k, v)
 	}
 }
 
@@ -133,7 +174,9 @@ func (p *projector) projectScopeObject(sm *schema.ScopeMatch) map[string]any {
 // projectContent projects code-block, list, table, and paragraph
 // entries under their default keys. Repeated kinds get a -N suffix
 // (code, code-2, …) so a second block never silently overwrites
-// the first.
+// the first. A non-nil `bind:` on the entry overrides the default
+// base name; the same -N collision-suffix logic still applies so
+// two entries that bind to the same name disambiguate.
 func (p *projector) projectContent(
 	content []schema.ContentMatch, obj map[string]any,
 ) {
@@ -146,17 +189,38 @@ func (p *projector) projectContent(
 		return fmt.Sprintf("%s-%d", base, counts[base])
 	}
 	for _, cm := range content {
+		base := contentBaseKey(cm.Entry)
 		switch cm.Entry.Kind {
 		case schema.ContentKindCodeBlock:
-			p.setKey(obj, nextKey("code"), p.codeBody(cm.Node))
+			p.setKey(obj, nextKey(base), p.codeBody(cm.Node))
 		case schema.ContentKindList:
-			p.setKey(obj, nextKey("items"), p.listItems(cm.Node))
+			p.setKey(obj, nextKey(base), p.listItems(cm.Node))
 		case schema.ContentKindTable:
-			p.setKey(obj, nextKey("rows"), p.tableRows(cm.Node))
+			p.setKey(obj, nextKey(base), p.tableRows(cm.Node))
 		case schema.ContentKindParagraph:
-			p.setKey(obj, nextKey("text"), p.nodeText(cm.Node))
+			p.setKey(obj, nextKey(base), p.nodeText(cm.Node))
 		}
 	}
+}
+
+// contentBaseKey returns the base projection key for a content
+// entry: the user-supplied bind value when set, otherwise the
+// kind's default name (`code`/`items`/`rows`/`text`).
+func contentBaseKey(e *schema.ContentEntry) string {
+	if e.Bind != nil {
+		return *e.Bind
+	}
+	switch e.Kind {
+	case schema.ContentKindCodeBlock:
+		return "code"
+	case schema.ContentKindList:
+		return "items"
+	case schema.ContentKindTable:
+		return "rows"
+	case schema.ContentKindParagraph:
+		return "text"
+	}
+	return ""
 }
 
 func (p *projector) codeBody(n ast.Node) string {

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -168,6 +168,9 @@ func extractRootSections(schemas []*Schema) [][]Scope {
 // stable identity and DOES merge, so two proto.md sources that
 // each wrap their sections in the same H1 yield one combined H1
 // scope rather than requiring two H1s in the document.
+//
+// Per plan 167, distinct sibling scopes that bind to the same key
+// are a compose-time error — the projection would collide.
 func composeSectionLists(lists [][]Scope) ([]Scope, error) {
 	acc := &sectionAcc{indexByHeading: map[string]int{}}
 	for _, list := range lists {
@@ -190,7 +193,36 @@ func composeSectionLists(lists [][]Scope) ([]Scope, error) {
 			}
 		}
 	}
+	if err := rejectComposedDuplicateBinds(acc.out); err != nil {
+		return nil, err
+	}
 	return acc.out, nil
+}
+
+// rejectComposedDuplicateBinds errors when two distinct scopes in
+// the composed section list share a non-empty bind value. Empty
+// binds (the hoist signal) do not collide because they produce no
+// key. This catches the case where two kinds bind sibling scopes
+// to the same name; identical bound headings already merged
+// upstream so duplicates here are by definition different scopes
+// in conflict.
+func rejectComposedDuplicateBinds(scopes []Scope) error {
+	seen := make(map[string]string, len(scopes))
+	for i := range scopes {
+		b := scopes[i].Bind
+		if b == nil || *b == "" {
+			continue
+		}
+		if prev, ok := seen[*b]; ok {
+			return fmt.Errorf(
+				"composed schemas bind two sibling scopes to the same "+
+					"projection key %q: %q and %q — every source must "+
+					"agree on the key for each composed heading",
+				*b, prev, scopes[i].Heading)
+		}
+		seen[*b] = scopes[i].Heading
+	}
+	return nil
 }
 
 // sectionAcc accumulates composed scopes while tracking where each
@@ -276,7 +308,10 @@ func canMergeByHeading(sc Scope) bool {
 // intersection of both inputs' run-length ranges (disjoint ranges
 // return an error). Child sections and per-scope rule overrides
 // compose by the same rules as the root; positional Content
-// constraints concatenate in input order.
+// constraints concatenate in input order. Per plan 167, `Bind`
+// values must agree across the merged scopes: nil unifies with
+// anything, two equal non-nil values keep that value, and any
+// genuine disagreement is a compose-time error.
 func mergeScopes(a, b Scope) (Scope, error) {
 	out := cloneScope(a)
 	if b.Closed {
@@ -291,12 +326,39 @@ func mergeScopes(a, b Scope) (Scope, error) {
 	if err != nil {
 		return Scope{}, err
 	}
+	bind, err := mergeBind(a.Bind, b.Bind, a.Heading)
+	if err != nil {
+		return Scope{}, err
+	}
+	out.Bind = bind
 	// Rules: union by rule name; later input wins on key collisions.
 	// The schema-rule walker is the only consumer, and its semantics
 	// are already "later overrides earlier" within a single scope.
 	out.Rules = mergeScopeRules(a.Rules, b.Rules)
 	out.Content = append(cloneContent(a.Content), cloneContent(b.Content)...)
 	return out, nil
+}
+
+// mergeBind intersects two scope-level `bind:` overrides for scopes
+// being merged by heading. The rules mirror filename composition:
+// nil + anything keeps the non-nil side; two equal non-nil values
+// keep that value; a real disagreement returns an error so the
+// caller surfaces a clear diagnostic.
+func mergeBind(a, b *string, heading string) (*string, error) {
+	if a == nil {
+		return b, nil
+	}
+	if b == nil {
+		return a, nil
+	}
+	if *a == *b {
+		return a, nil
+	}
+	return nil, fmt.Errorf(
+		"composed schemas declare conflicting `bind:` overrides for "+
+			"heading %q: %q vs %q — every source must agree on the "+
+			"projection key",
+		heading, *a, *b)
 }
 
 // mergeMatcher combines two matchers for scopes that share a

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -356,9 +356,20 @@ func mergeBind(a, b *string, heading string) (*string, error) {
 	}
 	return nil, fmt.Errorf(
 		"composed schemas declare conflicting `bind:` overrides for "+
-			"heading %q: %q vs %q — every source must agree on the "+
-			"projection key",
-		heading, *a, *b)
+			"heading %q: %s vs %s — every source must agree on whether "+
+			"the scope is hoisted (`bind: \"\"`) or projected under a "+
+			"specific key",
+		heading, bindLabel(*a), bindLabel(*b))
+}
+
+// bindLabel renders a bind value for an error message: the empty
+// string is the hoist signal and prints as `hoist (\"\")`, every
+// other value prints quoted as a projection key.
+func bindLabel(s string) string {
+	if s == "" {
+		return `hoist ("")`
+	}
+	return fmt.Sprintf("projection key %q", s)
 }
 
 // mergeMatcher combines two matchers for scopes that share a

--- a/internal/schema/compose_bind_test.go
+++ b/internal/schema/compose_bind_test.go
@@ -19,15 +19,26 @@ func litBound(heading, bind string) Scope {
 
 // TestCompose_BindNilWithBindCarriesOver: when one kind sets a bind
 // and the other leaves it unset, the composed scope keeps the
-// non-nil value.
+// non-nil value. Covers both orderings — bind on the second input
+// and bind on the first input — since mergeBind's nil branches are
+// distinct.
 func TestCompose_BindNilWithBindCarriesOver(t *testing.T) {
-	a := &Schema{Sections: []Scope{lit("Goal")}}
-	b := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
-	out, err := Compose(a, b)
-	require.NoError(t, err)
-	require.Len(t, out.Sections, 1)
-	require.NotNil(t, out.Sections[0].Bind)
-	assert.Equal(t, "objective", *out.Sections[0].Bind)
+	t.Run("nil_then_bound", func(t *testing.T) {
+		a := &Schema{Sections: []Scope{lit("Goal")}}
+		b := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
+		out, err := Compose(a, b)
+		require.NoError(t, err)
+		require.NotNil(t, out.Sections[0].Bind)
+		assert.Equal(t, "objective", *out.Sections[0].Bind)
+	})
+	t.Run("bound_then_nil", func(t *testing.T) {
+		a := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
+		b := &Schema{Sections: []Scope{lit("Goal")}}
+		out, err := Compose(a, b)
+		require.NoError(t, err)
+		require.NotNil(t, out.Sections[0].Bind)
+		assert.Equal(t, "objective", *out.Sections[0].Bind)
+	})
 }
 
 // TestCompose_BindEqualUnifies: two kinds with the same bind for
@@ -50,6 +61,22 @@ func TestCompose_BindConflict(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conflicting `bind:`")
 	assert.Contains(t, err.Error(), "Goal")
+	assert.Contains(t, err.Error(), `"objective"`)
+	assert.Contains(t, err.Error(), `"purpose"`)
+}
+
+// TestCompose_BindHoistVsKeyConflict: one source asks to hoist
+// (`bind: ""`) while another asks for a named projection key —
+// the message must distinguish the hoist case so the diagnostic
+// is actionable.
+func TestCompose_BindHoistVsKeyConflict(t *testing.T) {
+	a := &Schema{Sections: []Scope{litBound("Wrapper", "")}}
+	b := &Schema{Sections: []Scope{litBound("Wrapper", "result")}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Wrapper")
+	assert.Contains(t, err.Error(), `hoist`)
+	assert.Contains(t, err.Error(), `"result"`)
 }
 
 // TestCompose_BindEmptyWithUnset: an explicit `bind: ""` (hoist)

--- a/internal/schema/compose_bind_test.go
+++ b/internal/schema/compose_bind_test.go
@@ -1,0 +1,87 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bindPtr(s string) *string { return &s }
+
+// litBound builds a literal-heading scope with an explicit `bind:`
+// override (the inline form's parsed shape).
+func litBound(heading, bind string) Scope {
+	sc := lit(heading)
+	sc.Bind = bindPtr(bind)
+	return sc
+}
+
+// TestCompose_BindNilWithBindCarriesOver: when one kind sets a bind
+// and the other leaves it unset, the composed scope keeps the
+// non-nil value.
+func TestCompose_BindNilWithBindCarriesOver(t *testing.T) {
+	a := &Schema{Sections: []Scope{lit("Goal")}}
+	b := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	require.NotNil(t, out.Sections[0].Bind)
+	assert.Equal(t, "objective", *out.Sections[0].Bind)
+}
+
+// TestCompose_BindEqualUnifies: two kinds with the same bind for
+// the same heading compose without conflict.
+func TestCompose_BindEqualUnifies(t *testing.T) {
+	a := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
+	b := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Sections[0].Bind)
+	assert.Equal(t, "objective", *out.Sections[0].Bind)
+}
+
+// TestCompose_BindConflict: a real disagreement between two kinds
+// surfaces as a compose-time error rather than silently picking one.
+func TestCompose_BindConflict(t *testing.T) {
+	a := &Schema{Sections: []Scope{litBound("Goal", "objective")}}
+	b := &Schema{Sections: []Scope{litBound("Goal", "purpose")}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting `bind:`")
+	assert.Contains(t, err.Error(), "Goal")
+}
+
+// TestCompose_BindEmptyWithUnset: an explicit `bind: ""` (hoist)
+// from one kind overrides a nil from another.
+func TestCompose_BindEmptyWithUnset(t *testing.T) {
+	a := &Schema{Sections: []Scope{lit("Wrapper")}}
+	b := &Schema{Sections: []Scope{litBound("Wrapper", "")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	require.NotNil(t, out.Sections[0].Bind)
+	assert.Equal(t, "", *out.Sections[0].Bind)
+}
+
+// TestCompose_DuplicateSiblingBindsAcrossKinds: two kinds binding
+// *different* sibling scopes to the same key collide at compose
+// time — one heading from each kind cannot share a projection key.
+func TestCompose_DuplicateSiblingBindsAcrossKinds(t *testing.T) {
+	a := &Schema{Sections: []Scope{litBound("Goal", "result")}}
+	b := &Schema{Sections: []Scope{litBound("Risks", "result")}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "two sibling scopes")
+	assert.Contains(t, err.Error(), "result")
+}
+
+// TestCompose_EmptyBindsDoNotCollide: two siblings both hoisting
+// (`bind: ""`) produce no keys and therefore cannot collide on the
+// projection. Compose accepts them.
+func TestCompose_EmptyBindsDoNotCollide(t *testing.T) {
+	a := &Schema{Sections: []Scope{litBound("A", "")}}
+	b := &Schema{Sections: []Scope{litBound("B", "")}}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Len(t, out.Sections, 2)
+}

--- a/internal/schema/parse_bind_test.go
+++ b/internal/schema/parse_bind_test.go
@@ -1,0 +1,189 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseInline_BindUnsetVsExplicit pins the *string round-trip:
+// a scope with no `bind:` key parses to Bind == nil, an explicit
+// empty bind parses to Bind != nil && *Bind == "", and a non-empty
+// bind preserves the user's value. Plan 167.
+func TestParseInline_BindUnsetVsExplicit(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "Default"},
+			map[string]any{"heading": "Renamed", "bind": "out"},
+			map[string]any{"heading": "Hoisted", "bind": ""},
+		},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	require.Len(t, sch.Sections, 3)
+
+	assert.Nil(t, sch.Sections[0].Bind, "unset bind must round-trip to nil")
+
+	require.NotNil(t, sch.Sections[1].Bind)
+	assert.Equal(t, "out", *sch.Sections[1].Bind)
+
+	require.NotNil(t, sch.Sections[2].Bind,
+		"explicit empty bind must round-trip to a non-nil pointer")
+	assert.Equal(t, "", *sch.Sections[2].Bind)
+}
+
+func TestParseInline_BindWrongType(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": "Goal",
+			"bind":    42,
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind must be a string")
+}
+
+// `bind:` makes no sense on the preamble: the preamble already
+// hoists, and renaming the no-key projection would be misleading.
+func TestParseInline_BindRejectedOnPreamble(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": nil,
+			"bind":    "intro",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "preamble")
+	assert.Contains(t, err.Error(), "bind")
+}
+
+// A slot scope is skipped by the projector, so a bind would be
+// unreachable. Reject it at parse time so the override surfaces as
+// a config error rather than a silent no-op.
+func TestParseInline_BindRejectedOnSlot(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": map[string]any{
+				"regex":  ".+",
+				"repeat": map[string]any{"min": 0},
+			},
+			"bind": "anywhere",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slot")
+	assert.Contains(t, err.Error(), "bind")
+}
+
+// A broad matcher (`.+` with a non-zero repeat min) is also skipped
+// by the projector. The diagnostic explains why the bind would be
+// unreachable.
+func TestParseInline_BindRejectedOnBroadMatcher(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": map[string]any{"regex": ".+"},
+			"bind":    "anywhere",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broad-match")
+	assert.Contains(t, err.Error(), "unreachable")
+}
+
+// Two sibling scopes binding to the same key would collide on the
+// projection. Reject at parse time.
+func TestParseInline_DuplicateSiblingBindsRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "Goal", "bind": "result"},
+			map[string]any{"heading": "Risks", "bind": "result"},
+		},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicates")
+	assert.Contains(t, err.Error(), "result")
+}
+
+// Two siblings both hoisting (`bind: ""`) are allowed: neither
+// produces a key, so they cannot collide on one. (Whether the
+// projection itself collides is a separate runtime check.)
+func TestParseInline_DuplicateEmptyBindsAllowed(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{
+			map[string]any{"heading": "A", "bind": ""},
+			map[string]any{"heading": "B", "bind": ""},
+		},
+	}, "kind x")
+	require.NoError(t, err)
+}
+
+// Content entries pick up the same `bind:` key. A non-empty value
+// renames the default key (code/items/rows/text).
+func TestParseInline_ContentBindRenames(t *testing.T) {
+	raw := map[string]any{
+		"sections": []any{map[string]any{
+			"heading": "Examples",
+			"content": []any{
+				map[string]any{"kind": "code-block", "bind": "sample"},
+				map[string]any{"kind": "list", "bind": "steps"},
+				map[string]any{"kind": "table", "bind": "settings"},
+				map[string]any{"kind": "paragraph", "bind": "summary"},
+			},
+		}},
+	}
+	sch, err := ParseInline(raw, "kind x")
+	require.NoError(t, err)
+	entries := sch.Sections[0].Content
+	require.Len(t, entries, 4)
+	for i, want := range []string{"sample", "steps", "settings", "summary"} {
+		require.NotNil(t, entries[i].Bind,
+			"entry %d should have a non-nil Bind", i)
+		assert.Equal(t, want, *entries[i].Bind)
+	}
+}
+
+// An empty bind on a content entry has no clean semantics — a
+// content entry has no children to hoist into the parent. Reject
+// it at parse time so authors restructure the schema instead.
+func TestParseInline_ContentBindEmptyRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": "Examples",
+			"content": []any{
+				map[string]any{"kind": "code-block", "bind": ""},
+			},
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty string is not allowed on a content entry")
+}
+
+// `bind:` on a `kind: unlisted` slot is unreachable — the slot
+// never projects a key to rename. Reject at parse time.
+func TestParseInline_ContentBindOnUnlistedRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": "Examples",
+			"content": []any{
+				map[string]any{"kind": "unlisted", "bind": "anywhere"},
+			},
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unlisted")
+	assert.Contains(t, err.Error(), "bind")
+}
+
+func TestParseInline_ContentBindWrongType(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading": "Examples",
+			"content": []any{
+				map[string]any{"kind": "code-block", "bind": 42},
+			},
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind must be a string")
+}

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -238,7 +238,34 @@ func parseInlineScopeList(list []any, path string) ([]Scope, error) {
 		}
 		scopes = append(scopes, sc)
 	}
+	if err := rejectDuplicateSiblingBinds(scopes, path); err != nil {
+		return nil, err
+	}
 	return scopes, nil
+}
+
+// rejectDuplicateSiblingBinds errors when two scopes in the same
+// section list share a non-empty bind value — the override would
+// collide on the same projection key. Empty binds (the hoist
+// signal) do not collide because they produce no key at all. Plan
+// 167.
+func rejectDuplicateSiblingBinds(scopes []Scope, path string) error {
+	seen := make(map[string]int, len(scopes))
+	for i := range scopes {
+		b := scopes[i].Bind
+		if b == nil || *b == "" {
+			continue
+		}
+		if prev, ok := seen[*b]; ok {
+			return fmt.Errorf(
+				"%s[%d].bind: duplicates the bind value %q already "+
+					"set on %s[%d] — sibling scopes must produce "+
+					"distinct projection keys",
+				path, i, *b, path, prev)
+		}
+		seen[*b] = i
+	}
+	return nil
 }
 
 // removedScopeKeys lists the per-entry keys plan 156 removed. The
@@ -310,8 +337,11 @@ func parseInlineScopeEntry(entry any, path string) (Scope, error) {
 // caught by its presence, not its post-parsed value).
 func validateScopeShape(sc Scope, m map[string]any, path string) error {
 	if sc.Preamble {
+		// `bind:` is meaningless on a preamble: it has no key to
+		// rename (its content hoists into the parent), and the
+		// empty form is redundant with that default. Plan 167.
 		return rejectKeys(m, path, "preamble (`heading: null`)",
-			"sections")
+			"sections", "bind")
 	}
 	// After applyScopeFields succeeds, either Preamble is true
 	// (handled above) or Matcher is set by setScopeHeading; a
@@ -321,10 +351,25 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 	// A regex of '.+' is the wildcard-slot shape; rule overrides,
 	// nested sections, and per-section content do not make sense
 	// there because the slot has no fixed identity. Plan 156
-	// makes that explicit.
+	// makes that explicit. `bind:` is rejected too — the
+	// projector skips slot scopes entirely so a bind would be
+	// unreachable (plan 167).
 	if isSlotMatcher(sc.Matcher) {
 		return rejectKeys(m, path, "slot (`regex: '.+', repeat: { min: 0 }`)",
-			"sections", "rules", "content", "closed")
+			"sections", "rules", "content", "closed", "bind")
+	}
+	// A non-slot broad matcher (`regex: '.+'` with a non-zero
+	// `min`) is also skipped by the projector. `bind:` on such a
+	// scope is unreachable — surface it at parse time rather than
+	// silently dropping the override at extract time (plan 167).
+	if isBroadMatcher(sc.Matcher) {
+		if _, ok := m["bind"]; ok {
+			return fmt.Errorf(
+				"%s: `bind:` is not allowed on a broad-match scope "+
+					"(`regex: '.+'`) — the projector skips broad "+
+					"matchers so the override would be unreachable",
+				path)
+		}
 	}
 	return nil
 }
@@ -388,6 +433,8 @@ func applyScopeFields(m map[string]any, sc *Scope, path string) error {
 			err = setScopeRules(sc, vv, path)
 		case "content":
 			err = setScopeContent(sc, vv, path)
+		case "bind":
+			err = setScopeBind(sc, vv, path)
 		default:
 			return fmt.Errorf("%s: unknown scope key %q", path, k)
 		}
@@ -395,6 +442,19 @@ func applyScopeFields(m map[string]any, sc *Scope, path string) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// setScopeBind reads the optional `bind:` override that renames the
+// scope's projection key in `mdsmith extract`. The empty string
+// (`bind: ""`) is the explicit "hoist children into parent" signal —
+// `*string` keeps unset (nil) distinguishable from explicit-empty.
+func setScopeBind(sc *Scope, v any, path string) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("%s.bind must be a string, got %T", path, v)
+	}
+	sc.Bind = &s
 	return nil
 }
 
@@ -961,9 +1021,35 @@ func applyContentField(k string, vv any, ce *ContentEntry, path string) error {
 		return setContentItemBound(&ce.MinItems, vv, path, k, ce.Kind)
 	case "max-items":
 		return setContentItemBound(&ce.MaxItems, vv, path, k, ce.Kind)
+	case "bind":
+		return setContentBind(ce, vv, path)
 	default:
 		return fmt.Errorf("%s: unknown content key %q", path, k)
 	}
+}
+
+// setContentBind reads the optional `bind:` override for a content
+// entry. A non-empty value renames the default key (`code` / `items`
+// / `rows` / `text`). The empty form is rejected because a content
+// entry has no children to hoist; users who want to drop the wrapper
+// key should restructure the schema instead.
+func setContentBind(ce *ContentEntry, v any, path string) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("%s.bind must be a string, got %T", path, v)
+	}
+	if s == "" {
+		return fmt.Errorf(
+			"%s.bind: empty string is not allowed on a content entry — "+
+				"hoist only applies to scopes (sections)", path)
+	}
+	if ce.Kind == ContentKindUnlisted {
+		return fmt.Errorf(
+			"%s.bind: not allowed on `kind: unlisted` — slots have no "+
+				"projection key to rename", path)
+	}
+	ce.Bind = &s
+	return nil
 }
 
 func setContentLang(ce *ContentEntry, v any, path string) error {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -205,6 +205,13 @@ type Scope struct {
 	// follow the same out-of-order + unlisted-slot semantics the
 	// heading-tree validator uses.
 	Content []ContentEntry
+
+	// Bind, when non-nil, overrides the default schema-derived key
+	// for this scope when projected by `mdsmith extract`. A non-empty
+	// value renames the key; an explicit empty string (`bind: ""`)
+	// hoists the scope's children into the parent instead of nesting
+	// under a key. Nil means "use the default key". Plan 167.
+	Bind *string
 }
 
 // Matcher describes how a Scope claims one or more consecutive
@@ -325,6 +332,14 @@ type ContentEntry struct {
 	// entry's match. Zero means unbounded.
 	MinItems int
 	MaxItems int
+
+	// Bind, when non-nil, overrides the default key for this content
+	// entry when projected by `mdsmith extract` (`code` / `items` /
+	// `rows` / `text`). A non-empty value renames the key; the empty
+	// form (`bind: ""`) is rejected at parse time because a content
+	// entry has no children to hoist into the parent. Nil means
+	// "use the default key". Plan 167.
+	Bind *string
 }
 
 // IsEmpty reports whether s carries no constraints. Used by callers

--- a/plan/167_custom-binding-overrides.md
+++ b/plan/167_custom-binding-overrides.md
@@ -1,7 +1,7 @@
 ---
 id: 167
 title: Custom binding overrides for mdsmith extract
-status: "🔲"
+status: "✅"
 model: opus
 depends-on: [166]
 summary: >-
@@ -54,14 +54,14 @@ parsing. The walk, encoders, and CLI are untouched.
 
 ## Acceptance Criteria
 
-- [ ] `bind:` overrides the default key; output is
+- [x] `bind:` overrides the default key; output is
       otherwise identical to plan 166.
-- [ ] `bind: ""` hoists a node's children into its
+- [x] `bind: ""` hoists a node's children into its
       parent.
-- [ ] Duplicate or unreachable binds are rejected with
+- [x] Duplicate or unreachable binds are rejected with
       actionable diagnostics.
-- [ ] Conflicting binds across composed kinds are a
+- [x] Conflicting binds across composed kinds are a
       compose-time error.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
-- [ ] `mdsmith check .` passes
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues
+- [x] `mdsmith check .` passes


### PR DESCRIPTION
Implements plan 167: custom `bind:` overrides that let users rename projection keys and hoist scope children into parent objects during `mdsmith extract`.

## Summary

Adds optional `bind:` field to scopes and content entries, allowing users to:
- Rename a scope's projection key (replacing the slugified heading)
- Rename a content entry's key (replacing `code` / `items` / `rows` / `text`)
- Hoist a scope's children into the parent with `bind: ""`

The implementation includes comprehensive validation to reject invalid configurations at parse time and compose time, with clear error messages.

## Key Changes

**Schema & Parsing** (`internal/schema/`)
- Added `Bind *string` field to `Scope` and `ContentEntry` types (nil = unset, empty string = hoist signal)
- Implemented `setScopeBind()` and `setContentBind()` to parse the `bind:` field
- Added validation to reject `bind:` on preambles, slots, broad matchers, and unlisted content entries
- Added `rejectDuplicateSiblingBinds()` to catch duplicate non-empty binds within a section list at parse time
- Added `mergeBind()` and `rejectComposedDuplicateBinds()` to handle bind conflicts during schema composition

**Extraction** (`internal/extract/`)
- Modified `keyFor()` to use `Bind` value when set, falling back to default heading-based key
- Added `hoistsToParent()` helper to detect `bind: ""` scopes
- Implemented `hoistGroup()` to merge hoisted scope content directly into parent object
- Modified `projectChildren()` to handle hoisting before normal key-based projection
- Added `contentBaseKey()` to apply bind overrides to content entry keys
- Updated `projectContent()` to use bind-overridden keys with collision-suffix logic

**Documentation & Tests**
- Updated `docs/reference/cli/extract.md` with `bind:` usage and constraints
- Updated `docs/guides/schemas.md` to reference plan 167
- Added comprehensive test suites:
  - `internal/schema/parse_bind_test.go`: 11 tests covering parse-time validation
  - `internal/extract/bind_test.go`: 8 tests covering extraction behavior
  - `internal/schema/compose_bind_test.go`: 7 tests covering composition conflicts
- Marked plan 167 as complete (✅)

## Implementation Details

- Uses `*string` for `Bind` to distinguish unset (nil) from explicit empty string (`""`)
- Empty binds (`bind: ""`) do not collide with each other since they produce no key
- Hoisting a repeating scope is rejected at extract time (multiple occurrences would overwrite)
- Hoisting collisions with sibling keys are flagged as diagnostics
- Bind overrides survive schema composition when kinds agree or one is unset
- All validation happens before extraction runs, surfacing configuration errors early

https://claude.ai/code/session_01JYzZmpSYwR6XGw2Hw4Dz9L