### PR TITLE
ci: serialize and retry pushes to orphan `assets` branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,6 +73,14 @@ jobs:
     needs: record
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    # Serialize against demo.yml's publish job: both rewrite
+    # disjoint subtrees on the same orphan `assets` ref, so a
+    # concurrent run loses one workflow's push to non-fast-forward
+    # rejection. cancel-in-progress: false because the queued run
+    # still has unique work (its own subtree update) to land.
+    concurrency:
+      group: assets-branch
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -92,28 +100,53 @@ jobs:
           # same branch, so neither workflow may wipe the whole
           # tree — each touches only its own subtree and commits
           # only when its subtree changed.
+          #
+          # The job-level concurrency group `assets-branch`
+          # serializes against demo.yml's publish. The
+          # retry-with-refetch loop below is defense-in-depth:
+          # rebuild our subtree on top of the latest origin/assets
+          # if any other writer landed a commit between our fetch
+          # and our push.
+          set -euo pipefail
+
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then
-            git fetch origin assets
-            git checkout assets
-          else
-            # First ever publish: unborn branch, no siblings yet.
-            git checkout --orphan assets
-            git rm -r --cached . >/dev/null 2>&1 || true
-          fi
+          publish_once() {
+            if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then
+              git fetch origin assets
+              git checkout -f -B assets origin/assets
+            else
+              # First ever publish: unborn branch, no siblings yet.
+              git checkout --orphan assets
+              git rm -r --cached . >/dev/null 2>&1 || true
+            fi
 
-          # Replace only the benchmarks subtree. assets/demo.gif
-          # (if present) is left exactly as demo.yml wrote it.
-          rm -rf assets/benchmarks
-          mkdir -p assets/benchmarks
-          cp -R /tmp/bench/. assets/benchmarks/
+            # Replace only the benchmarks subtree. assets/demo.gif
+            # (if present) is left exactly as demo.yml wrote it.
+            rm -rf assets/benchmarks
+            mkdir -p assets/benchmarks
+            cp -R /tmp/bench/. assets/benchmarks/
 
-          git add assets/benchmarks
-          if git diff --staged --quiet; then
-            echo "benchmark numbers unchanged — nothing to push"
-          else
+            git add assets/benchmarks
+            if git diff --staged --quiet; then
+              echo "benchmark numbers unchanged — nothing to push"
+              return 0
+            fi
             git commit -m "chore: refresh cross-tool benchmark numbers"
             git push -u origin assets
-          fi
+          }
+
+          attempt=1
+          max_attempts=5
+          backoff=2
+          until publish_once; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "push failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            echo "push race on assets branch; retry $attempt/$max_attempts after ${backoff}s"
+            sleep "$backoff"
+            attempt=$((attempt + 1))
+            backoff=$((backoff * 2))
+          done

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -17,6 +17,14 @@ jobs:
     needs: record
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    # Serialize against benchmark.yml's publish job: both rewrite
+    # disjoint subtrees on the same orphan `assets` ref, so a
+    # concurrent run loses one workflow's push to non-fast-forward
+    # rejection. cancel-in-progress: false because the queued run
+    # still has unique work (its own subtree update) to land.
+    concurrency:
+      group: assets-branch
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -40,27 +48,51 @@ jobs:
           # touches only its own subtree and pushes only when
           # that subtree changed. Pushing to the assets branch
           # avoids main entirely — no branch protection bypass.
+          #
+          # The job-level concurrency group `assets-branch`
+          # serializes against benchmark.yml's publish. The
+          # retry-with-refetch loop below is defense-in-depth:
+          # rebuild our subtree on top of the latest origin/assets
+          # if any other writer landed a commit between our fetch
+          # and our push.
+          set -euo pipefail
+
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Check if assets branch exists on remote
-          if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then
-            git fetch origin assets
-            git checkout assets
-          else
-            # First ever publish: unborn branch, no siblings yet.
-            git checkout --orphan assets
-            git rm -r --cached . >/dev/null 2>&1 || true
-          fi
+          publish_once() {
+            # Refresh from remote (or create the orphan on first
+            # ever publish) so our commit is a fast-forward.
+            if git ls-remote --exit-code origin refs/heads/assets >/dev/null 2>&1; then
+              git fetch origin assets
+              git checkout -f -B assets origin/assets
+            else
+              git checkout --orphan assets
+              git rm -r --cached . >/dev/null 2>&1 || true
+            fi
 
-          mkdir -p assets
-          cp /tmp/demo/demo.gif assets/demo.gif
+            mkdir -p assets
+            cp /tmp/demo/demo.gif assets/demo.gif
 
-          # Only push if the GIF actually changed
-          git add assets/demo.gif
-          if git diff --staged --quiet; then
-            echo "assets/demo.gif unchanged — nothing to push"
-          else
+            git add assets/demo.gif
+            if git diff --staged --quiet; then
+              echo "assets/demo.gif unchanged — nothing to push"
+              return 0
+            fi
             git commit -m "chore: update demo GIF"
             git push -u origin assets
-          fi
+          }
+
+          attempt=1
+          max_attempts=5
+          backoff=2
+          until publish_once; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "push failed after $max_attempts attempts" >&2
+              exit 1
+            fi
+            echo "push race on assets branch; retry $attempt/$max_attempts after ${backoff}s"
+            sleep "$backoff"
+            attempt=$((attempt + 1))
+            backoff=$((backoff * 2))
+          done


### PR DESCRIPTION
## Summary

`demo.yml` and `benchmark.yml` both run on `push: branches: [main]` and each update a disjoint subtree (`assets/demo.gif` vs `assets/benchmarks/`) on the shared orphan `assets` ref. When they run concurrently — which they do on every merge to `main` — both checkouts land on the same `origin/assets` commit, both commit on top, and the second push is rejected as non-fast-forward. That workflow's update is silently dropped until the next merge.

Two-layer fix on each `publish` job:

- **Shared concurrency group** `assets-branch` with `cancel-in-progress: false` so the queued run still lands its unique subtree update (mirrors how `pages.yml` already serializes the `pages` deploys).
- **Retry-with-refetch loop**: on push failure, re-fetch `origin/assets`, force-reset the local branch to it, re-apply the subtree changes from the downloaded artifact, recommit, and retry with exponential backoff up to 5 attempts. Defense-in-depth for any concurrent writer that isn't covered by the group.

## Test plan

- [ ] Merge a no-op commit to `main`; both `Demo GIF` and `Cross-tool benchmark` workflows queue and run sequentially on the `assets-branch` concurrency group rather than racing.
- [ ] Confirm both subtrees (`assets/demo.gif` and `assets/benchmarks/`) coexist on the `assets` branch after the merge.
- [ ] Inject a synthetic race (e.g. manual `git push origin assets` from a local checkout) while a workflow's `publish` job is between fetch and push; confirm the retry loop refetches and lands the change rather than failing the job.

---
_Generated by [Claude Code](https://claude.ai/code/session_018D5MtSd55VeH2scDEhD9bf)_