### PR TITLE
docs: add apples-to-apples rule set comparison tables

### DIFF
--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -165,15 +165,21 @@ and self-maintaining sections are the point.
 ### Apples-to-apples rule sets
 
 Reference material for the parity claim above: the rule
-class each configuration actually runs. The MD↔MDS mapping
-comes from
-[the markdownlint coverage matrix](../markdownlint-coverage/README.md);
-the table below restates it in the benchmark's terms.
-Per-rule lists for mado, rumdl, panache, and
-markdownlint-cli2 are not vendored — each one ships its
-own subset of MD rules and we don't track which row each
-tool covers; we treat them as "markdownlint-compatible"
-and compare against the full MD class.
+class each configuration actually runs. The cross-tool
+mapping (markdownlint, markdownlint-cli2, mado, rumdl,
+panache) lives in each rule's README frontmatter — see
+the `markdownlint:`, `markdownlint-cli2:`, `mado:`, and
+`rumdl:` keys on the
+[rule README schema](../../../internal/rules/proto.md).
+The tables below restate that data in benchmark terms.
+The MD↔MDS mapping originates in
+[the markdownlint coverage matrix](../markdownlint-coverage/README.md).
+panache is not in the tables: it uses its own rule IDs
+(not MD-compatible) and we have no public per-rule list
+to populate yet. markdownlint-cli2 is omitted as a column
+because it ships the canonical markdownlint rule set
+by definition — read its support as identical to the
+markdownlint column.
 
 | Configuration       | Rule class             | Source                                                                               |
 | ------------------- | ---------------------- | ------------------------------------------------------------------------------------ |
@@ -181,153 +187,169 @@ and compare against the full MD class.
 | `mdsmith-parity`    | Table A only           | [`bench-parity.mdsmith.yml`](bench-parity.mdsmith.yml) disables every row in Table B |
 | `mado`              | MD-compatible subset   | <https://github.com/akiomik/mado>                                                    |
 | `rumdl`             | MD-compatible subset   | <https://github.com/rvben/rumdl>                                                     |
-| `panache`           | MD-compatible subset   | <https://panache.bz>                                                                 |
+| `panache`           | distinct rule IDs      | <https://panache.bz>                                                                 |
 | `markdownlint-cli2` | canonical markdownlint | <https://github.com/DavidAnson/markdownlint>                                         |
 
 #### Table A — shared rule class (markdownlint-compatible)
 
-Both `mdsmith` configurations run the rows marked ✅; "opt-in"
-means mdsmith ships the rule but it is off by default in
-both columns (users must enable it). Only MD054 has no
-mdsmith implementation (scheduled in plan 172); a
-markdownlint tool that ships MD054 would do marginally more
-work than `mdsmith-parity` on that one rule — this is the
-residual asymmetry called out above. Two rows are ✅ in
-full and **disabled** in parity (MD043 and MD051): mdsmith
-implements them via cross-file mechanisms (`required-structure`
-takes a CUE schema; `cross-file-reference-integrity` walks
-the whole-repo link graph), so parity disables them rather
-than claim parity at higher fidelity. The grouping mirrors
+Both `mdsmith` configurations run the rows marked yes;
+"opt-in" means mdsmith ships the rule but it is off by
+default in both columns (users must enable it). Only
+MD054 has no mdsmith implementation — it is not yet
+scheduled in any plan. Two rows are yes in full and
+**disabled** in parity (MD043 and MD051): mdsmith
+implements them via cross-file mechanisms
+(`required-structure` takes a CUE schema;
+`cross-file-reference-integrity` walks the whole-repo
+link graph), so parity disables them rather than claim
+parity at higher fidelity. The grouping mirrors
 [the coverage matrix](../markdownlint-coverage/README.md)
 to make cross-reference easy.
 
+Legend for the mado and rumdl columns: yes implements the
+rule, unstable implements but marked unstable in the tool's
+README, — does not implement.
+
 ##### Headings
 
-| markdownlint                                                                                       | mdsmith                                                                                                                  | mdsmith (full) | mdsmith-parity |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------- | -------------- |
-| [MD001 heading-increment](https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md)       | [MDS003 heading-increment](../../../internal/rules/MDS003-heading-increment/README.md)                                   | ✅             | ✅             |
-| [MD003 heading-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md003.md)           | [MDS002 heading-style](../../../internal/rules/MDS002-heading-style/README.md)                                           | ✅             | ✅             |
-| [MD018–021, 023 atx whitespace](https://github.com/DavidAnson/markdownlint/blob/main/doc/md018.md) | [MDS064 atx-heading-whitespace](../../../internal/rules/MDS064-atx-heading-whitespace/README.md)                         | ✅             | ✅             |
-| [MD022 blanks-around-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md)  | [MDS013 blank-line-around-headings](../../../internal/rules/MDS013-blank-line-around-headings/README.md)                 | ✅             | ✅             |
-| [MD024 no-duplicate-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md)    | [MDS005 no-duplicate-headings](../../../internal/rules/MDS005-no-duplicate-headings/README.md)                           | ✅             | ✅             |
-| [MD025 single-title](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md)            | [MDS051 single-h1](../../../internal/rules/MDS051-single-h1/README.md)                                                   | opt-in         | opt-in         |
-| [MD026 trailing-punctuation](https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md)    | [MDS017 no-trailing-punctuation-in-heading](../../../internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md) | ✅             | ✅             |
-| [MD036 emphasis-as-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md036.md)     | [MDS018 no-emphasis-as-heading](../../../internal/rules/MDS018-no-emphasis-as-heading/README.md)                         | ✅             | ✅             |
-| [MD041 first-line-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md)      | [MDS004 first-line-heading](../../../internal/rules/MDS004-first-line-heading/README.md)                                 | ✅             | ✅             |
-| [MD043 required-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md)       | [MDS020 required-structure](../../../internal/rules/MDS020-required-structure/README.md) (CUE schema)                    | ✅             | disabled       |
+| markdownlint                                                                                       | mdsmith                                                                                                                  | mdsmith (full) | mdsmith-parity | mado                 | rumdl |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------- | -------------- | -------------------- | ----- |
+| [MD001 heading-increment](https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md)       | [MDS003 heading-increment](../../../internal/rules/MDS003-heading-increment/README.md)                                   | yes            | yes            | yes                  | yes   |
+| [MD003 heading-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md003.md)           | [MDS002 heading-style](../../../internal/rules/MDS002-heading-style/README.md)                                           | yes            | yes            | unstable             | yes   |
+| [MD018–021, 023 atx whitespace](https://github.com/DavidAnson/markdownlint/blob/main/doc/md018.md) | [MDS064 atx-heading-whitespace](../../../internal/rules/MDS064-atx-heading-whitespace/README.md) (MD020 partial)         | yes            | yes            | yes (MD020 unstable) | yes   |
+| [MD022 blanks-around-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md)  | [MDS013 blank-line-around-headings](../../../internal/rules/MDS013-blank-line-around-headings/README.md)                 | yes            | yes            | yes                  | yes   |
+| [MD024 no-duplicate-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md)    | [MDS005 no-duplicate-headings](../../../internal/rules/MDS005-no-duplicate-headings/README.md)                           | yes            | yes            | yes                  | yes   |
+| [MD025 single-title](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md)            | [MDS051 single-h1](../../../internal/rules/MDS051-single-h1/README.md)                                                   | opt-in         | opt-in         | yes                  | yes   |
+| [MD026 trailing-punctuation](https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md)    | [MDS017 no-trailing-punctuation-in-heading](../../../internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md) | yes            | yes            | yes                  | yes   |
+| [MD036 emphasis-as-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md036.md)     | [MDS018 no-emphasis-as-heading](../../../internal/rules/MDS018-no-emphasis-as-heading/README.md)                         | yes            | yes            | yes                  | yes   |
+| [MD041 first-line-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md)      | [MDS004 first-line-heading](../../../internal/rules/MDS004-first-line-heading/README.md)                                 | yes            | yes            | yes                  | yes   |
+| [MD043 required-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md)       | [MDS020 required-structure](../../../internal/rules/MDS020-required-structure/README.md) (CUE schema)                    | yes            | disabled       | —                    | yes   |
 
 ##### Lists
 
-| markdownlint                                                                                   | mdsmith                                                                                            | mdsmith (full) | mdsmith-parity |
-| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- | -------------- |
-| [MD004 ul-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md)            | [MDS045 list-marker-style](../../../internal/rules/MDS045-list-marker-style/README.md)             | opt-in         | opt-in         |
-| [MD005 list-indent](https://github.com/DavidAnson/markdownlint/blob/main/doc/md005.md)         | [MDS016 list-indent](../../../internal/rules/MDS016-list-indent/README.md) (partial)               | ✅             | ✅             |
-| [MD007 ul-indent](https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md)           | [MDS016 list-indent](../../../internal/rules/MDS016-list-indent/README.md)                         | ✅             | ✅             |
-| [MD029 ol-prefix](https://github.com/DavidAnson/markdownlint/blob/main/doc/md029.md)           | [MDS046 ordered-list-numbering](../../../internal/rules/MDS046-ordered-list-numbering/README.md)   | opt-in         | opt-in         |
-| [MD030 list-marker-space](https://github.com/DavidAnson/markdownlint/blob/main/doc/md030.md)   | [MDS061 list-marker-space](../../../internal/rules/MDS061-list-marker-space/README.md)             | ✅             | ✅             |
-| [MD032 blanks-around-lists](https://github.com/DavidAnson/markdownlint/blob/main/doc/md032.md) | [MDS014 blank-line-around-lists](../../../internal/rules/MDS014-blank-line-around-lists/README.md) | ✅             | ✅             |
+| markdownlint                                                                                   | mdsmith                                                                                            | mdsmith (full) | mdsmith-parity | mado     | rumdl |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- | -------------- | -------- | ----- |
+| [MD004 ul-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md)            | [MDS045 list-marker-style](../../../internal/rules/MDS045-list-marker-style/README.md)             | opt-in         | opt-in         | yes      | yes   |
+| [MD005 list-indent](https://github.com/DavidAnson/markdownlint/blob/main/doc/md005.md)         | [MDS016 list-indent](../../../internal/rules/MDS016-list-indent/README.md) (partial)               | yes            | yes            | yes      | yes   |
+| [MD007 ul-indent](https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md)           | [MDS016 list-indent](../../../internal/rules/MDS016-list-indent/README.md)                         | yes            | yes            | unstable | yes   |
+| [MD029 ol-prefix](https://github.com/DavidAnson/markdownlint/blob/main/doc/md029.md)           | [MDS046 ordered-list-numbering](../../../internal/rules/MDS046-ordered-list-numbering/README.md)   | opt-in         | opt-in         | yes      | yes   |
+| [MD030 list-marker-space](https://github.com/DavidAnson/markdownlint/blob/main/doc/md030.md)   | [MDS061 list-marker-space](../../../internal/rules/MDS061-list-marker-space/README.md)             | yes            | yes            | yes      | yes   |
+| [MD032 blanks-around-lists](https://github.com/DavidAnson/markdownlint/blob/main/doc/md032.md) | [MDS014 blank-line-around-lists](../../../internal/rules/MDS014-blank-line-around-lists/README.md) | yes            | yes            | unstable | yes   |
 
 ##### Whitespace, blank lines, tabs
 
-| markdownlint                                                                                  | mdsmith                                                                                            | mdsmith (full) | mdsmith-parity |
-| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- | -------------- |
-| [MD009 no-trailing-spaces](https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md) | [MDS006 no-trailing-spaces](../../../internal/rules/MDS006-no-trailing-spaces/README.md)           | ✅             | ✅             |
-| [MD010 no-hard-tabs](https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md)       | [MDS007 no-hard-tabs](../../../internal/rules/MDS007-no-hard-tabs/README.md)                       | ✅             | ✅             |
-| [MD012 no-multiple-blanks](https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md) | [MDS008 no-multiple-blanks](../../../internal/rules/MDS008-no-multiple-blanks/README.md)           | ✅             | ✅             |
-| [MD013 line-length](https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md)        | [MDS001 line-length](../../../internal/rules/MDS001-line-length/README.md)                         | ✅             | ✅             |
-| [MD027 multiple-space-bq](https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md)  | [MDS059 blockquote-whitespace](../../../internal/rules/MDS059-blockquote-whitespace/README.md)     | ✅             | ✅             |
-| [MD028 blank-line-bq](https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md)      | [MDS059 blockquote-whitespace](../../../internal/rules/MDS059-blockquote-whitespace/README.md)     | ✅             | ✅             |
-| [MD047 file-ends-newline](https://github.com/DavidAnson/markdownlint/blob/main/doc/md047.md)  | [MDS009 single-trailing-newline](../../../internal/rules/MDS009-single-trailing-newline/README.md) | ✅             | ✅             |
+| markdownlint                                                                                  | mdsmith                                                                                            | mdsmith (full) | mdsmith-parity | mado     | rumdl |
+| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- | -------------- | -------- | ----- |
+| [MD009 no-trailing-spaces](https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md) | [MDS006 no-trailing-spaces](../../../internal/rules/MDS006-no-trailing-spaces/README.md)           | yes            | yes            | yes      | yes   |
+| [MD010 no-hard-tabs](https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md)       | [MDS007 no-hard-tabs](../../../internal/rules/MDS007-no-hard-tabs/README.md)                       | yes            | yes            | yes      | yes   |
+| [MD012 no-multiple-blanks](https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md) | [MDS008 no-multiple-blanks](../../../internal/rules/MDS008-no-multiple-blanks/README.md)           | yes            | yes            | yes      | yes   |
+| [MD013 line-length](https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md)        | [MDS001 line-length](../../../internal/rules/MDS001-line-length/README.md)                         | yes            | yes            | yes      | yes   |
+| [MD027 multiple-space-bq](https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md)  | [MDS059 blockquote-whitespace](../../../internal/rules/MDS059-blockquote-whitespace/README.md)     | yes            | yes            | unstable | yes   |
+| [MD028 blank-line-bq](https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md)      | [MDS059 blockquote-whitespace](../../../internal/rules/MDS059-blockquote-whitespace/README.md)     | yes            | yes            | yes      | yes   |
+| [MD047 file-ends-newline](https://github.com/DavidAnson/markdownlint/blob/main/doc/md047.md)  | [MDS009 single-trailing-newline](../../../internal/rules/MDS009-single-trailing-newline/README.md) | yes            | yes            | yes      | yes   |
 
 ##### Code blocks and code spans
 
-| markdownlint                                                                                    | mdsmith                                                                                                        | mdsmith (full) | mdsmith-parity |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- | -------------- |
-| [MD014 commands-show-output](https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md) | [MDS066 commands-show-output](../../../internal/rules/MDS066-commands-show-output/README.md)                   | ✅             | ✅             |
-| [MD031 blanks-around-fences](https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md) | [MDS015 blank-line-around-fenced-code](../../../internal/rules/MDS015-blank-line-around-fenced-code/README.md) | ✅             | ✅             |
-| [MD038 spaces-in-code-span](https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md)  | [MDS052 no-space-in-code-spans](../../../internal/rules/MDS052-no-space-in-code-spans/README.md)               | opt-in         | opt-in         |
-| [MD040 fenced-code-language](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md) | [MDS011 fenced-code-language](../../../internal/rules/MDS011-fenced-code-language/README.md)                   | ✅             | ✅             |
-| [MD046 code-block-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md)     | [MDS065 code-block-style](../../../internal/rules/MDS065-code-block-style/README.md)                           | ✅             | ✅             |
-| [MD048 code-fence-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md)     | [MDS010 fenced-code-style](../../../internal/rules/MDS010-fenced-code-style/README.md)                         | ✅             | ✅             |
+| markdownlint                                                                                    | mdsmith                                                                                                        | mdsmith (full) | mdsmith-parity | mado | rumdl |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- | -------------- | ---- | ----- |
+| [MD014 commands-show-output](https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md) | [MDS066 commands-show-output](../../../internal/rules/MDS066-commands-show-output/README.md)                   | yes            | yes            | yes  | yes   |
+| [MD031 blanks-around-fences](https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md) | [MDS015 blank-line-around-fenced-code](../../../internal/rules/MDS015-blank-line-around-fenced-code/README.md) | yes            | yes            | yes  | yes   |
+| [MD038 spaces-in-code-span](https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md)  | [MDS052 no-space-in-code-spans](../../../internal/rules/MDS052-no-space-in-code-spans/README.md)               | opt-in         | opt-in         | yes  | yes   |
+| [MD040 fenced-code-language](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md) | [MDS011 fenced-code-language](../../../internal/rules/MDS011-fenced-code-language/README.md)                   | yes            | yes            | yes  | yes   |
+| [MD046 code-block-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md)     | [MDS065 code-block-style](../../../internal/rules/MDS065-code-block-style/README.md)                           | yes            | yes            | yes  | yes   |
+| [MD048 code-fence-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md)     | [MDS010 fenced-code-style](../../../internal/rules/MDS010-fenced-code-style/README.md)                         | yes            | yes            | —    | yes   |
 
 ##### Links and references
 
-| markdownlint                                                                                   | mdsmith                                                                                                                       | mdsmith (full) | mdsmith-parity |
-| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------- |
-| [MD011 no-reversed-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md)   | [MDS062 link-validity](../../../internal/rules/MDS062-link-validity/README.md)                                                | ✅             | ✅             |
-| [MD034 no-bare-urls](https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md)        | [MDS012 no-bare-urls](../../../internal/rules/MDS012-no-bare-urls/README.md)                                                  | ✅             | ✅             |
-| [MD039 spaces-in-link-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md) | [MDS049 no-space-in-link-text](../../../internal/rules/MDS049-no-space-in-link-text/README.md)                                | opt-in         | opt-in         |
-| [MD042 no-empty-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md)      | [MDS062 link-validity](../../../internal/rules/MDS062-link-validity/README.md)                                                | ✅             | ✅             |
-| [MD051 link-fragments](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md)      | [MDS027 cross-file-reference-integrity](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) (whole-repo) | ✅             | disabled       |
-| [MD052 reference-defined](https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md)   | [MDS054 no-undefined-reference-labels](../../../internal/rules/MDS054-no-undefined-reference-labels/README.md)                | ✅             | ✅             |
-| [MD053 reference-needed](https://github.com/DavidAnson/markdownlint/blob/main/doc/md053.md)    | [MDS053 no-unused-link-definitions](../../../internal/rules/MDS053-no-unused-link-definitions/README.md)                      | ✅             | ✅             |
-| [MD054 link-image-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md054.md)    | — (plan 172)                                                                                                                  | —              | —              |
-| [MD059 descriptive-link](https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md)    | [MDS063 descriptive-link-text](../../../internal/rules/MDS063-descriptive-link-text/README.md)                                | opt-in         | opt-in         |
+| markdownlint                                                                                   | mdsmith                                                                                                                       | mdsmith (full) | mdsmith-parity | mado | rumdl |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------- | ---- | ----- |
+| [MD011 no-reversed-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md)   | [MDS062 link-validity](../../../internal/rules/MDS062-link-validity/README.md)                                                | yes            | yes            | —    | yes   |
+| [MD034 no-bare-urls](https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md)        | [MDS012 no-bare-urls](../../../internal/rules/MDS012-no-bare-urls/README.md)                                                  | yes            | yes            | yes  | yes   |
+| [MD039 spaces-in-link-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md) | [MDS049 no-space-in-link-text](../../../internal/rules/MDS049-no-space-in-link-text/README.md)                                | opt-in         | opt-in         | yes  | yes   |
+| [MD042 no-empty-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md)      | [MDS062 link-validity](../../../internal/rules/MDS062-link-validity/README.md)                                                | yes            | yes            | —    | yes   |
+| [MD051 link-fragments](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md)      | [MDS027 cross-file-reference-integrity](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) (whole-repo) | yes            | disabled       | —    | yes   |
+| [MD052 reference-defined](https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md)   | [MDS054 no-undefined-reference-labels](../../../internal/rules/MDS054-no-undefined-reference-labels/README.md)                | yes            | yes            | —    | yes   |
+| [MD053 reference-needed](https://github.com/DavidAnson/markdownlint/blob/main/doc/md053.md)    | [MDS053 no-unused-link-definitions](../../../internal/rules/MDS053-no-unused-link-definitions/README.md)                      | yes            | yes            | —    | yes   |
+| [MD054 link-image-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md054.md)    | — (not yet planned)                                                                                                           | —              | —              | —    | yes   |
+| [MD059 descriptive-link](https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md)    | [MDS063 descriptive-link-text](../../../internal/rules/MDS063-descriptive-link-text/README.md)                                | opt-in         | opt-in         | —    | yes   |
 
 ##### Inline, emphasis, HTML
 
-| markdownlint                                                                                  | mdsmith                                                                                        | mdsmith (full) | mdsmith-parity |
-| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------- | -------------- |
-| [MD033 no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md)     | [MDS041 no-inline-html](../../../internal/rules/MDS041-no-inline-html/README.md)               | opt-in         | opt-in         |
-| [MD035 hr-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md035.md)           | [MDS044 horizontal-rule-style](../../../internal/rules/MDS044-horizontal-rule-style/README.md) | opt-in         | opt-in         |
-| [MD037 spaces-in-emphasis](https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md) | [MDS047 ambiguous-emphasis](../../../internal/rules/MDS047-ambiguous-emphasis/README.md)       | opt-in         | opt-in         |
-| [MD044 proper-names](https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md)       | [MDS050 proper-names](../../../internal/rules/MDS050-proper-names/README.md)                   | opt-in         | opt-in         |
-| [MD045 no-alt-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md)        | [MDS032 no-empty-alt-text](../../../internal/rules/MDS032-no-empty-alt-text/README.md)         | ✅             | ✅             |
-| [MD049 emphasis-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md)     | [MDS042 emphasis-style](../../../internal/rules/MDS042-emphasis-style/README.md)               | opt-in         | opt-in         |
-| [MD050 strong-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md050.md)       | [MDS042 emphasis-style](../../../internal/rules/MDS042-emphasis-style/README.md)               | opt-in         | opt-in         |
+| markdownlint                                                                                  | mdsmith                                                                                        | mdsmith (full) | mdsmith-parity | mado | rumdl |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------- | -------------- | ---- | ----- |
+| [MD033 no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md)     | [MDS041 no-inline-html](../../../internal/rules/MDS041-no-inline-html/README.md)               | opt-in         | opt-in         | yes  | yes   |
+| [MD035 hr-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md035.md)           | [MDS044 horizontal-rule-style](../../../internal/rules/MDS044-horizontal-rule-style/README.md) | opt-in         | opt-in         | yes  | yes   |
+| [MD037 spaces-in-emphasis](https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md) | [MDS047 ambiguous-emphasis](../../../internal/rules/MDS047-ambiguous-emphasis/README.md)       | opt-in         | opt-in         | yes  | yes   |
+| [MD044 proper-names](https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md)       | [MDS050 proper-names](../../../internal/rules/MDS050-proper-names/README.md)                   | opt-in         | opt-in         | —    | yes   |
+| [MD045 no-alt-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md)        | [MDS032 no-empty-alt-text](../../../internal/rules/MDS032-no-empty-alt-text/README.md)         | yes            | yes            | —    | yes   |
+| [MD049 emphasis-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md)     | [MDS042 emphasis-style](../../../internal/rules/MDS042-emphasis-style/README.md)               | opt-in         | opt-in         | —    | yes   |
+| [MD050 strong-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md050.md)       | [MDS042 emphasis-style](../../../internal/rules/MDS042-emphasis-style/README.md)               | opt-in         | opt-in         | —    | yes   |
 
 ##### Tables
 
-| markdownlint                                                                                    | mdsmith                                                                                | mdsmith (full) | mdsmith-parity |
-| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------- | -------------- |
-| [MD055 table-pipe-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md055.md)     | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md)           | ✅             | ✅             |
-| [MD056 table-column-count](https://github.com/DavidAnson/markdownlint/blob/main/doc/md056.md)   | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md) (partial) | ✅             | ✅             |
-| [MD058 blanks-around-tables](https://github.com/DavidAnson/markdownlint/blob/main/doc/md058.md) | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md)           | ✅             | ✅             |
+| markdownlint                                                                                    | mdsmith                                                                                | mdsmith (full) | mdsmith-parity | mado | rumdl |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------- | -------------- | ---- | ----- |
+| [MD055 table-pipe-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md055.md)     | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md)           | yes            | yes            | —    | yes   |
+| [MD056 table-column-count](https://github.com/DavidAnson/markdownlint/blob/main/doc/md056.md)   | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md) (partial) | yes            | yes            | —    | yes   |
+| [MD058 blanks-around-tables](https://github.com/DavidAnson/markdownlint/blob/main/doc/md058.md) | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md)           | yes            | yes            | —    | yes   |
 
 #### Table B — mdsmith-only rules (no markdownlint analog)
 
-`mdsmith` (full) runs the rows marked ✅; the rest are
-opt-in (off by default) but
-[`bench-parity.mdsmith.yml`](bench-parity.mdsmith.yml)
-disables them defensively so a user-modified config
-cannot accidentally enable them during a parity run.
-The real benchmark delta between `mdsmith` and
-`mdsmith-parity` is the 12 ✅ rows below — the 12 opt-in
-rows would not run in default mdsmith either.
+`mdsmith` (full) runs the rows marked yes; the rest are
+opt-in (off by default). The "parity" column reflects
+[`bench-parity.mdsmith.yml`](bench-parity.mdsmith.yml)'s
+24 explicit disables: every default-enabled mdsmith-only
+rule plus most opt-in ones. The real benchmark delta
+between `mdsmith` and `mdsmith-parity` is the 12 yes rows
+below — the 12 opt-in rows that parity disables would
+not run in default mdsmith either, so they are belt-and-
+braces against a user-supplied config that enables them.
 
-Two further mdsmith-only rules are intentionally **not**
-disabled by the parity config:
+Four mdsmith-only rules are **not** in the parity config's
+disable list. Two stay on for `mdsmith` (full) and `mdsmith-parity`:
 [MDS031 unclosed-code-block](../../../internal/rules/MDS031-unclosed-code-block/README.md)
 (cheap structural check, kept on) and
 [MDS034 markdown-flavor](../../../internal/rules/MDS034-markdown-flavor/README.md)
-(opt-in, off by default anyway).
+(opt-in, off by default anyway). The remaining two —
+MDS067 callout-type and MDS068 link-style — are listed
+at the bottom of the table; they are opt-in and rely on
+their default-off state rather than an explicit parity
+disable, so a user config that enabled them would slip
+through `mdsmith-parity`.
+
+All rows below have **mado: —** and **rumdl: —** (no MD
+analog), so the foreign-tool columns are omitted; the
+delta is entirely in the mdsmith-full vs mdsmith-parity
+columns.
 
 | MDS rule                                                                                                         | What it adds                      | mdsmith (full) | mdsmith-parity |
 | ---------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------- | -------------- |
-| [MDS019 catalog](../../../internal/rules/MDS019-catalog/README.md)                                               | generated index from front matter | ✅             | disabled       |
-| [MDS020 required-structure](../../../internal/rules/MDS020-required-structure/README.md)                         | CUE schema beyond MD043           | ✅             | disabled       |
-| [MDS021 include](../../../internal/rules/MDS021-include/README.md)                                               | spliced, synced file inclusion    | ✅             | disabled       |
-| [MDS022 max-file-length](../../../internal/rules/MDS022-max-file-length/README.md)                               | file size budget                  | ✅             | disabled       |
-| [MDS023 paragraph-readability](../../../internal/rules/MDS023-paragraph-readability/README.md)                   | ARI grade limit                   | ✅             | disabled       |
+| [MDS019 catalog](../../../internal/rules/MDS019-catalog/README.md)                                               | generated index from front matter | yes            | disabled       |
+| [MDS020 required-structure](../../../internal/rules/MDS020-required-structure/README.md)                         | CUE schema beyond MD043           | yes            | disabled       |
+| [MDS021 include](../../../internal/rules/MDS021-include/README.md)                                               | spliced, synced file inclusion    | yes            | disabled       |
+| [MDS022 max-file-length](../../../internal/rules/MDS022-max-file-length/README.md)                               | file size budget                  | yes            | disabled       |
+| [MDS023 paragraph-readability](../../../internal/rules/MDS023-paragraph-readability/README.md)                   | ARI grade limit                   | yes            | disabled       |
 | [MDS024 paragraph-structure](../../../internal/rules/MDS024-paragraph-structure/README.md)                       | sentence/word limits              | opt-in         | disabled       |
-| [MDS026 table-readability](../../../internal/rules/MDS026-table-readability/README.md)                           | width/row heuristics              | ✅             | disabled       |
-| [MDS027 cross-file-reference-integrity](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) | whole-repo link graph             | ✅             | disabled       |
-| [MDS028 token-budget](../../../internal/rules/MDS028-token-budget/README.md)                                     | LLM context budget                | ✅             | disabled       |
+| [MDS026 table-readability](../../../internal/rules/MDS026-table-readability/README.md)                           | width/row heuristics              | yes            | disabled       |
+| [MDS027 cross-file-reference-integrity](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) | whole-repo link graph             | yes            | disabled       |
+| [MDS028 token-budget](../../../internal/rules/MDS028-token-budget/README.md)                                     | LLM context budget                | yes            | disabled       |
 | [MDS029 conciseness-scoring](../../../internal/rules/MDS029-conciseness-scoring/README.md)                       | prose density (experimental)      | opt-in         | disabled       |
-| [MDS030 empty-section-body](../../../internal/rules/MDS030-empty-section-body/README.md)                         | no empty sections                 | ✅             | disabled       |
+| [MDS030 empty-section-body](../../../internal/rules/MDS030-empty-section-body/README.md)                         | no empty sections                 | yes            | disabled       |
 | [MDS033 directory-structure](../../../internal/rules/MDS033-directory-structure/README.md)                       | where files may live              | opt-in         | disabled       |
 | [MDS035 toc-directive](../../../internal/rules/MDS035-toc-directive/README.md)                                   | flag stray TOC tokens             | opt-in         | disabled       |
 | [MDS036 max-section-length](../../../internal/rules/MDS036-max-section-length/README.md)                         | per-section size                  | opt-in         | disabled       |
 | [MDS037 duplicated-content](../../../internal/rules/MDS037-duplicated-content/README.md)                         | copy-paste across files           | opt-in         | disabled       |
-| [MDS038 toc](../../../internal/rules/MDS038-toc/README.md)                                                       | generated heading TOC             | ✅             | disabled       |
-| [MDS039 build](../../../internal/rules/MDS039-build/README.md)                                                   | artifact-in-sync directive        | ✅             | disabled       |
-| [MDS040 recipe-safety](../../../internal/rules/MDS040-recipe-safety/README.md)                                   | shell-safety on build recipes     | ✅             | disabled       |
+| [MDS038 toc](../../../internal/rules/MDS038-toc/README.md)                                                       | generated heading TOC             | yes            | disabled       |
+| [MDS039 build](../../../internal/rules/MDS039-build/README.md)                                                   | artifact-in-sync directive        | yes            | disabled       |
+| [MDS040 recipe-safety](../../../internal/rules/MDS040-recipe-safety/README.md)                                   | shell-safety on build recipes     | yes            | disabled       |
 | [MDS043 no-reference-style](../../../internal/rules/MDS043-no-reference-style/README.md)                         | forbid reference links            | opt-in         | disabled       |
 | [MDS048 git-hook-sync](../../../internal/rules/MDS048-git-hook-sync/README.md)                                   | merge-driver / hook install state | opt-in         | disabled       |
 | [MDS055 forbidden-paragraph-starts](../../../internal/rules/MDS055-forbidden-paragraph-starts/README.md)         | banned opening phrases            | opt-in         | disabled       |
 | [MDS056 forbidden-text](../../../internal/rules/MDS056-forbidden-text/README.md)                                 | banned substrings                 | opt-in         | disabled       |
 | [MDS057 required-text-patterns](../../../internal/rules/MDS057-required-text-patterns/README.md)                 | mandated patterns                 | opt-in         | disabled       |
 | [MDS058 required-mentions](../../../internal/rules/MDS058-required-mentions/README.md)                           | mandated references               | opt-in         | disabled       |
+| [MDS067 callout-type](../../../internal/rules/MDS067-callout-type/README.md)                                     | Obsidian callout allowlist        | opt-in         | opt-in         |
+| [MDS068 link-style](../../../internal/rules/MDS068-link-style/README.md)                                         | path/extension/inline-vs-ref form | opt-in         | opt-in         |
 
 ### Fairness note on panache
 

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -162,6 +162,173 @@ Pick mado or rumdl for raw markdownlint-rule throughput;
 pick mdsmith when the cross-file graph, readability budgets,
 and self-maintaining sections are the point.
 
+### Apples-to-apples rule sets
+
+Reference material for the parity claim above: the rule
+class each configuration actually runs. The MD↔MDS mapping
+comes from
+[the markdownlint coverage matrix](../markdownlint-coverage/README.md);
+the table below restates it in the benchmark's terms.
+Per-rule lists for mado, rumdl, panache, and
+markdownlint-cli2 are not vendored — each one ships its
+own subset of MD rules and we don't track which row each
+tool covers; we treat them as "markdownlint-compatible"
+and compare against the full MD class.
+
+| Configuration       | Rule class             | Source                                                                               |
+| ------------------- | ---------------------- | ------------------------------------------------------------------------------------ |
+| `mdsmith` (full)    | Tables A + B           | every default-enabled MDS rule                                                       |
+| `mdsmith-parity`    | Table A only           | [`bench-parity.mdsmith.yml`](bench-parity.mdsmith.yml) disables every row in Table B |
+| `mado`              | MD-compatible subset   | <https://github.com/akiomik/mado>                                                    |
+| `rumdl`             | MD-compatible subset   | <https://github.com/rvben/rumdl>                                                     |
+| `panache`           | MD-compatible subset   | <https://panache.bz>                                                                 |
+| `markdownlint-cli2` | canonical markdownlint | <https://github.com/DavidAnson/markdownlint>                                         |
+
+#### Table A — shared rule class (markdownlint-compatible)
+
+Both `mdsmith` configurations run the rows marked ✅; "opt-in"
+means mdsmith ships the rule but it is off by default in
+both columns (users must enable it). Only MD054 has no
+mdsmith implementation (scheduled in plan 172); a
+markdownlint tool that ships MD054 would do marginally more
+work than `mdsmith-parity` on that one rule — this is the
+residual asymmetry called out above. Two rows are ✅ in
+full and **disabled** in parity (MD043 and MD051): mdsmith
+implements them via cross-file mechanisms (`required-structure`
+takes a CUE schema; `cross-file-reference-integrity` walks
+the whole-repo link graph), so parity disables them rather
+than claim parity at higher fidelity. The grouping mirrors
+[the coverage matrix](../markdownlint-coverage/README.md)
+to make cross-reference easy.
+
+##### Headings
+
+| markdownlint                                                                                       | mdsmith                                                                                                                  | mdsmith (full) | mdsmith-parity |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------- | -------------- |
+| [MD001 heading-increment](https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md)       | [MDS003 heading-increment](../../../internal/rules/MDS003-heading-increment/README.md)                                   | ✅             | ✅             |
+| [MD003 heading-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md003.md)           | [MDS002 heading-style](../../../internal/rules/MDS002-heading-style/README.md)                                           | ✅             | ✅             |
+| [MD018–021, 023 atx whitespace](https://github.com/DavidAnson/markdownlint/blob/main/doc/md018.md) | [MDS064 atx-heading-whitespace](../../../internal/rules/MDS064-atx-heading-whitespace/README.md)                         | ✅             | ✅             |
+| [MD022 blanks-around-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md)  | [MDS013 blank-line-around-headings](../../../internal/rules/MDS013-blank-line-around-headings/README.md)                 | ✅             | ✅             |
+| [MD024 no-duplicate-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md)    | [MDS005 no-duplicate-headings](../../../internal/rules/MDS005-no-duplicate-headings/README.md)                           | ✅             | ✅             |
+| [MD025 single-title](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md)            | [MDS051 single-h1](../../../internal/rules/MDS051-single-h1/README.md)                                                   | opt-in         | opt-in         |
+| [MD026 trailing-punctuation](https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md)    | [MDS017 no-trailing-punctuation-in-heading](../../../internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md) | ✅             | ✅             |
+| [MD036 emphasis-as-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md036.md)     | [MDS018 no-emphasis-as-heading](../../../internal/rules/MDS018-no-emphasis-as-heading/README.md)                         | ✅             | ✅             |
+| [MD041 first-line-heading](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md)      | [MDS004 first-line-heading](../../../internal/rules/MDS004-first-line-heading/README.md)                                 | ✅             | ✅             |
+| [MD043 required-headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md)       | [MDS020 required-structure](../../../internal/rules/MDS020-required-structure/README.md) (CUE schema)                    | ✅             | disabled       |
+
+##### Lists
+
+| markdownlint                                                                                   | mdsmith                                                                                            | mdsmith (full) | mdsmith-parity |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- | -------------- |
+| [MD004 ul-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md)            | [MDS045 list-marker-style](../../../internal/rules/MDS045-list-marker-style/README.md)             | opt-in         | opt-in         |
+| [MD005 list-indent](https://github.com/DavidAnson/markdownlint/blob/main/doc/md005.md)         | [MDS016 list-indent](../../../internal/rules/MDS016-list-indent/README.md) (partial)               | ✅             | ✅             |
+| [MD007 ul-indent](https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md)           | [MDS016 list-indent](../../../internal/rules/MDS016-list-indent/README.md)                         | ✅             | ✅             |
+| [MD029 ol-prefix](https://github.com/DavidAnson/markdownlint/blob/main/doc/md029.md)           | [MDS046 ordered-list-numbering](../../../internal/rules/MDS046-ordered-list-numbering/README.md)   | opt-in         | opt-in         |
+| [MD030 list-marker-space](https://github.com/DavidAnson/markdownlint/blob/main/doc/md030.md)   | [MDS061 list-marker-space](../../../internal/rules/MDS061-list-marker-space/README.md)             | ✅             | ✅             |
+| [MD032 blanks-around-lists](https://github.com/DavidAnson/markdownlint/blob/main/doc/md032.md) | [MDS014 blank-line-around-lists](../../../internal/rules/MDS014-blank-line-around-lists/README.md) | ✅             | ✅             |
+
+##### Whitespace, blank lines, tabs
+
+| markdownlint                                                                                  | mdsmith                                                                                            | mdsmith (full) | mdsmith-parity |
+| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- | -------------- |
+| [MD009 no-trailing-spaces](https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md) | [MDS006 no-trailing-spaces](../../../internal/rules/MDS006-no-trailing-spaces/README.md)           | ✅             | ✅             |
+| [MD010 no-hard-tabs](https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md)       | [MDS007 no-hard-tabs](../../../internal/rules/MDS007-no-hard-tabs/README.md)                       | ✅             | ✅             |
+| [MD012 no-multiple-blanks](https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md) | [MDS008 no-multiple-blanks](../../../internal/rules/MDS008-no-multiple-blanks/README.md)           | ✅             | ✅             |
+| [MD013 line-length](https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md)        | [MDS001 line-length](../../../internal/rules/MDS001-line-length/README.md)                         | ✅             | ✅             |
+| [MD027 multiple-space-bq](https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md)  | [MDS059 blockquote-whitespace](../../../internal/rules/MDS059-blockquote-whitespace/README.md)     | ✅             | ✅             |
+| [MD028 blank-line-bq](https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md)      | [MDS059 blockquote-whitespace](../../../internal/rules/MDS059-blockquote-whitespace/README.md)     | ✅             | ✅             |
+| [MD047 file-ends-newline](https://github.com/DavidAnson/markdownlint/blob/main/doc/md047.md)  | [MDS009 single-trailing-newline](../../../internal/rules/MDS009-single-trailing-newline/README.md) | ✅             | ✅             |
+
+##### Code blocks and code spans
+
+| markdownlint                                                                                    | mdsmith                                                                                                        | mdsmith (full) | mdsmith-parity |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- | -------------- |
+| [MD014 commands-show-output](https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md) | [MDS066 commands-show-output](../../../internal/rules/MDS066-commands-show-output/README.md)                   | ✅             | ✅             |
+| [MD031 blanks-around-fences](https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md) | [MDS015 blank-line-around-fenced-code](../../../internal/rules/MDS015-blank-line-around-fenced-code/README.md) | ✅             | ✅             |
+| [MD038 spaces-in-code-span](https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md)  | [MDS052 no-space-in-code-spans](../../../internal/rules/MDS052-no-space-in-code-spans/README.md)               | opt-in         | opt-in         |
+| [MD040 fenced-code-language](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md) | [MDS011 fenced-code-language](../../../internal/rules/MDS011-fenced-code-language/README.md)                   | ✅             | ✅             |
+| [MD046 code-block-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md)     | [MDS065 code-block-style](../../../internal/rules/MDS065-code-block-style/README.md)                           | ✅             | ✅             |
+| [MD048 code-fence-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md)     | [MDS010 fenced-code-style](../../../internal/rules/MDS010-fenced-code-style/README.md)                         | ✅             | ✅             |
+
+##### Links and references
+
+| markdownlint                                                                                   | mdsmith                                                                                                                       | mdsmith (full) | mdsmith-parity |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------- |
+| [MD011 no-reversed-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md)   | [MDS062 link-validity](../../../internal/rules/MDS062-link-validity/README.md)                                                | ✅             | ✅             |
+| [MD034 no-bare-urls](https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md)        | [MDS012 no-bare-urls](../../../internal/rules/MDS012-no-bare-urls/README.md)                                                  | ✅             | ✅             |
+| [MD039 spaces-in-link-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md) | [MDS049 no-space-in-link-text](../../../internal/rules/MDS049-no-space-in-link-text/README.md)                                | opt-in         | opt-in         |
+| [MD042 no-empty-links](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md)      | [MDS062 link-validity](../../../internal/rules/MDS062-link-validity/README.md)                                                | ✅             | ✅             |
+| [MD051 link-fragments](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md)      | [MDS027 cross-file-reference-integrity](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) (whole-repo) | ✅             | disabled       |
+| [MD052 reference-defined](https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md)   | [MDS054 no-undefined-reference-labels](../../../internal/rules/MDS054-no-undefined-reference-labels/README.md)                | ✅             | ✅             |
+| [MD053 reference-needed](https://github.com/DavidAnson/markdownlint/blob/main/doc/md053.md)    | [MDS053 no-unused-link-definitions](../../../internal/rules/MDS053-no-unused-link-definitions/README.md)                      | ✅             | ✅             |
+| [MD054 link-image-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md054.md)    | — (plan 172)                                                                                                                  | —              | —              |
+| [MD059 descriptive-link](https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md)    | [MDS063 descriptive-link-text](../../../internal/rules/MDS063-descriptive-link-text/README.md)                                | opt-in         | opt-in         |
+
+##### Inline, emphasis, HTML
+
+| markdownlint                                                                                  | mdsmith                                                                                        | mdsmith (full) | mdsmith-parity |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------- | -------------- |
+| [MD033 no-inline-html](https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md)     | [MDS041 no-inline-html](../../../internal/rules/MDS041-no-inline-html/README.md)               | opt-in         | opt-in         |
+| [MD035 hr-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md035.md)           | [MDS044 horizontal-rule-style](../../../internal/rules/MDS044-horizontal-rule-style/README.md) | opt-in         | opt-in         |
+| [MD037 spaces-in-emphasis](https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md) | [MDS047 ambiguous-emphasis](../../../internal/rules/MDS047-ambiguous-emphasis/README.md)       | opt-in         | opt-in         |
+| [MD044 proper-names](https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md)       | [MDS050 proper-names](../../../internal/rules/MDS050-proper-names/README.md)                   | opt-in         | opt-in         |
+| [MD045 no-alt-text](https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md)        | [MDS032 no-empty-alt-text](../../../internal/rules/MDS032-no-empty-alt-text/README.md)         | ✅             | ✅             |
+| [MD049 emphasis-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md)     | [MDS042 emphasis-style](../../../internal/rules/MDS042-emphasis-style/README.md)               | opt-in         | opt-in         |
+| [MD050 strong-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md050.md)       | [MDS042 emphasis-style](../../../internal/rules/MDS042-emphasis-style/README.md)               | opt-in         | opt-in         |
+
+##### Tables
+
+| markdownlint                                                                                    | mdsmith                                                                                | mdsmith (full) | mdsmith-parity |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------- | -------------- |
+| [MD055 table-pipe-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md055.md)     | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md)           | ✅             | ✅             |
+| [MD056 table-column-count](https://github.com/DavidAnson/markdownlint/blob/main/doc/md056.md)   | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md) (partial) | ✅             | ✅             |
+| [MD058 blanks-around-tables](https://github.com/DavidAnson/markdownlint/blob/main/doc/md058.md) | [MDS025 table-format](../../../internal/rules/MDS025-table-format/README.md)           | ✅             | ✅             |
+
+#### Table B — mdsmith-only rules (no markdownlint analog)
+
+`mdsmith` (full) runs the rows marked ✅; the rest are
+opt-in (off by default) but
+[`bench-parity.mdsmith.yml`](bench-parity.mdsmith.yml)
+disables them defensively so a user-modified config
+cannot accidentally enable them during a parity run.
+The real benchmark delta between `mdsmith` and
+`mdsmith-parity` is the 12 ✅ rows below — the 12 opt-in
+rows would not run in default mdsmith either.
+
+Two further mdsmith-only rules are intentionally **not**
+disabled by the parity config:
+[MDS031 unclosed-code-block](../../../internal/rules/MDS031-unclosed-code-block/README.md)
+(cheap structural check, kept on) and
+[MDS034 markdown-flavor](../../../internal/rules/MDS034-markdown-flavor/README.md)
+(opt-in, off by default anyway).
+
+| MDS rule                                                                                                         | What it adds                      | mdsmith (full) | mdsmith-parity |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------- | -------------- |
+| [MDS019 catalog](../../../internal/rules/MDS019-catalog/README.md)                                               | generated index from front matter | ✅             | disabled       |
+| [MDS020 required-structure](../../../internal/rules/MDS020-required-structure/README.md)                         | CUE schema beyond MD043           | ✅             | disabled       |
+| [MDS021 include](../../../internal/rules/MDS021-include/README.md)                                               | spliced, synced file inclusion    | ✅             | disabled       |
+| [MDS022 max-file-length](../../../internal/rules/MDS022-max-file-length/README.md)                               | file size budget                  | ✅             | disabled       |
+| [MDS023 paragraph-readability](../../../internal/rules/MDS023-paragraph-readability/README.md)                   | ARI grade limit                   | ✅             | disabled       |
+| [MDS024 paragraph-structure](../../../internal/rules/MDS024-paragraph-structure/README.md)                       | sentence/word limits              | opt-in         | disabled       |
+| [MDS026 table-readability](../../../internal/rules/MDS026-table-readability/README.md)                           | width/row heuristics              | ✅             | disabled       |
+| [MDS027 cross-file-reference-integrity](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) | whole-repo link graph             | ✅             | disabled       |
+| [MDS028 token-budget](../../../internal/rules/MDS028-token-budget/README.md)                                     | LLM context budget                | ✅             | disabled       |
+| [MDS029 conciseness-scoring](../../../internal/rules/MDS029-conciseness-scoring/README.md)                       | prose density (experimental)      | opt-in         | disabled       |
+| [MDS030 empty-section-body](../../../internal/rules/MDS030-empty-section-body/README.md)                         | no empty sections                 | ✅             | disabled       |
+| [MDS033 directory-structure](../../../internal/rules/MDS033-directory-structure/README.md)                       | where files may live              | opt-in         | disabled       |
+| [MDS035 toc-directive](../../../internal/rules/MDS035-toc-directive/README.md)                                   | flag stray TOC tokens             | opt-in         | disabled       |
+| [MDS036 max-section-length](../../../internal/rules/MDS036-max-section-length/README.md)                         | per-section size                  | opt-in         | disabled       |
+| [MDS037 duplicated-content](../../../internal/rules/MDS037-duplicated-content/README.md)                         | copy-paste across files           | opt-in         | disabled       |
+| [MDS038 toc](../../../internal/rules/MDS038-toc/README.md)                                                       | generated heading TOC             | ✅             | disabled       |
+| [MDS039 build](../../../internal/rules/MDS039-build/README.md)                                                   | artifact-in-sync directive        | ✅             | disabled       |
+| [MDS040 recipe-safety](../../../internal/rules/MDS040-recipe-safety/README.md)                                   | shell-safety on build recipes     | ✅             | disabled       |
+| [MDS043 no-reference-style](../../../internal/rules/MDS043-no-reference-style/README.md)                         | forbid reference links            | opt-in         | disabled       |
+| [MDS048 git-hook-sync](../../../internal/rules/MDS048-git-hook-sync/README.md)                                   | merge-driver / hook install state | opt-in         | disabled       |
+| [MDS055 forbidden-paragraph-starts](../../../internal/rules/MDS055-forbidden-paragraph-starts/README.md)         | banned opening phrases            | opt-in         | disabled       |
+| [MDS056 forbidden-text](../../../internal/rules/MDS056-forbidden-text/README.md)                                 | banned substrings                 | opt-in         | disabled       |
+| [MDS057 required-text-patterns](../../../internal/rules/MDS057-required-text-patterns/README.md)                 | mandated patterns                 | opt-in         | disabled       |
+| [MDS058 required-mentions](../../../internal/rules/MDS058-required-mentions/README.md)                           | mandated references               | opt-in         | disabled       |
+
 ### Fairness note on panache
 
 panache benchmarks itself on a small, Pandoc/Quarto-heavy

--- a/docs/research/markdownlint-coverage/README.md
+++ b/docs/research/markdownlint-coverage/README.md
@@ -21,7 +21,7 @@ Status legend:
 Deprecated markdownlint numbers (MD002, MD006, MD008,
 MD015-MD017) are omitted. As of 2026-05 mdsmith implements
 **51 of the 52** active markdownlint rules (**49** fully, **2** partially); the
-only outstanding rule is MD054, scheduled in plan 172.
+only outstanding rule is MD054, which is not yet scheduled.
 
 ## Headings
 
@@ -78,17 +78,17 @@ only outstanding rule is MD054, scheduled in plan 172.
 
 ## Links and references
 
-| markdownlint              | Checks           | mdsmith | Status      |
-| ------------------------- | ---------------- | ------- | ----------- |
-| MD011 no-reversed-links   | `(t)[u]`         | MDS062  | ✅          |
-| MD034 no-bare-urls        | raw URL          | MDS012  | ✅          |
-| MD039 spaces-in-link-text | `[ t ]`          | MDS049  | ✅          |
-| MD042 no-empty-links      | empty target     | MDS062  | ✅          |
-| MD051 link-fragments      | `#anchor` exists | MDS027  | ✅ x-file   |
-| MD052 reference-defined   | ref label set    | MDS054  | ✅          |
-| MD053 reference-needed    | unused defs      | MDS053  | ✅          |
-| MD054 link-image-style    | inline vs ref    | —       | 🔲 plan 172 |
-| MD059 descriptive-link    | "click here"     | MDS063  | ✅          |
+| markdownlint              | Checks           | mdsmith | Status         |
+| ------------------------- | ---------------- | ------- | -------------- |
+| MD011 no-reversed-links   | `(t)[u]`         | MDS062  | ✅             |
+| MD034 no-bare-urls        | raw URL          | MDS012  | ✅             |
+| MD039 spaces-in-link-text | `[ t ]`          | MDS049  | ✅             |
+| MD042 no-empty-links      | empty target     | MDS062  | ✅             |
+| MD051 link-fragments      | `#anchor` exists | MDS027  | ✅ x-file      |
+| MD052 reference-defined   | ref label set    | MDS054  | ✅             |
+| MD053 reference-needed    | unused defs      | MDS053  | ✅             |
+| MD054 link-image-style    | inline vs ref    | —       | 🔲 unscheduled |
+| MD059 descriptive-link    | "click here"     | MDS063  | ✅             |
 
 ## Inline, emphasis, HTML
 
@@ -141,3 +141,5 @@ only outstanding rule is MD054, scheduled in plan 172.
 | MDS056 forbidden-text                 | banned substrings                 |
 | MDS057 required-text-patterns         | mandated patterns                 |
 | MDS058 required-mentions              | mandated references               |
+| MDS067 callout-type                   | Obsidian callout allowlist        |
+| MDS068 link-style                     | path/extension/inline-vs-ref form |

--- a/internal/rules/MDS001-line-length/README.md
+++ b/internal/rules/MDS001-line-length/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD013
     name: line-length
+markdownlint-cli2:
+  - id: MD013
+    name: line-length
+mado:
+  - id: MD013
+    name: line-length
+rumdl:
+  - id: MD013
+    name: line-length
 ---
 # MDS001: line-length
 

--- a/internal/rules/MDS002-heading-style/README.md
+++ b/internal/rules/MDS002-heading-style/README.md
@@ -9,6 +9,16 @@ maintainability: null
 markdownlint:
   - id: MD003
     name: heading-style
+markdownlint-cli2:
+  - id: MD003
+    name: heading-style
+mado:
+  - id: MD003
+    name: heading-style
+    unstable: true
+rumdl:
+  - id: MD003
+    name: heading-style
 ---
 # MDS002: heading-style
 

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD001
     name: heading-increment
+markdownlint-cli2:
+  - id: MD001
+    name: heading-increment
+mado:
+  - id: MD001
+    name: heading-increment
+rumdl:
+  - id: MD001
+    name: heading-increment
 ---
 # MDS003: heading-increment
 

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD041
     name: first-line-h1
+markdownlint-cli2:
+  - id: MD041
+    name: first-line-h1
+mado:
+  - id: MD041
+    name: first-line-h1
+rumdl:
+  - id: MD041
+    name: first-line-h1
 ---
 # MDS004: first-line-heading
 

--- a/internal/rules/MDS005-no-duplicate-headings/README.md
+++ b/internal/rules/MDS005-no-duplicate-headings/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD024
     name: no-duplicate-heading
+markdownlint-cli2:
+  - id: MD024
+    name: no-duplicate-heading
+mado:
+  - id: MD024
+    name: no-duplicate-heading
+rumdl:
+  - id: MD024
+    name: no-duplicate-heading
 ---
 # MDS005: no-duplicate-headings
 

--- a/internal/rules/MDS006-no-trailing-spaces/README.md
+++ b/internal/rules/MDS006-no-trailing-spaces/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD009
     name: no-trailing-spaces
+markdownlint-cli2:
+  - id: MD009
+    name: no-trailing-spaces
+mado:
+  - id: MD009
+    name: no-trailing-spaces
+rumdl:
+  - id: MD009
+    name: no-trailing-spaces
 ---
 # MDS006: no-trailing-spaces
 

--- a/internal/rules/MDS007-no-hard-tabs/README.md
+++ b/internal/rules/MDS007-no-hard-tabs/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD010
     name: no-hard-tabs
+markdownlint-cli2:
+  - id: MD010
+    name: no-hard-tabs
+mado:
+  - id: MD010
+    name: no-hard-tabs
+rumdl:
+  - id: MD010
+    name: no-hard-tabs
 ---
 # MDS007: no-hard-tabs
 

--- a/internal/rules/MDS008-no-multiple-blanks/README.md
+++ b/internal/rules/MDS008-no-multiple-blanks/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD012
     name: no-multiple-blanks
+markdownlint-cli2:
+  - id: MD012
+    name: no-multiple-blanks
+mado:
+  - id: MD012
+    name: no-multiple-blanks
+rumdl:
+  - id: MD012
+    name: no-multiple-blanks
 ---
 # MDS008: no-multiple-blanks
 

--- a/internal/rules/MDS009-single-trailing-newline/README.md
+++ b/internal/rules/MDS009-single-trailing-newline/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD047
     name: single-trailing-newline
+markdownlint-cli2:
+  - id: MD047
+    name: single-trailing-newline
+mado:
+  - id: MD047
+    name: single-trailing-newline
+rumdl:
+  - id: MD047
+    name: single-trailing-newline
 ---
 # MDS009: single-trailing-newline
 

--- a/internal/rules/MDS010-fenced-code-style/README.md
+++ b/internal/rules/MDS010-fenced-code-style/README.md
@@ -9,6 +9,13 @@ maintainability: null
 markdownlint:
   - id: MD048
     name: code-fence-style
+markdownlint-cli2:
+  - id: MD048
+    name: code-fence-style
+mado: null
+rumdl:
+  - id: MD048
+    name: code-fence-style
 ---
 # MDS010: fenced-code-style
 

--- a/internal/rules/MDS011-fenced-code-language/README.md
+++ b/internal/rules/MDS011-fenced-code-language/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD040
     name: fenced-code-language
+markdownlint-cli2:
+  - id: MD040
+    name: fenced-code-language
+mado:
+  - id: MD040
+    name: fenced-code-language
+rumdl:
+  - id: MD040
+    name: fenced-code-language
 ---
 # MDS011: fenced-code-language
 

--- a/internal/rules/MDS012-no-bare-urls/README.md
+++ b/internal/rules/MDS012-no-bare-urls/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD034
     name: no-bare-urls
+markdownlint-cli2:
+  - id: MD034
+    name: no-bare-urls
+mado:
+  - id: MD034
+    name: no-bare-urls
+rumdl:
+  - id: MD034
+    name: no-bare-urls
 ---
 # MDS012: no-bare-urls
 

--- a/internal/rules/MDS013-blank-line-around-headings/README.md
+++ b/internal/rules/MDS013-blank-line-around-headings/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD022
     name: blanks-around-headings
+markdownlint-cli2:
+  - id: MD022
+    name: blanks-around-headings
+mado:
+  - id: MD022
+    name: blanks-around-headings
+rumdl:
+  - id: MD022
+    name: blanks-around-headings
 ---
 # MDS013: blank-line-around-headings
 

--- a/internal/rules/MDS014-blank-line-around-lists/README.md
+++ b/internal/rules/MDS014-blank-line-around-lists/README.md
@@ -9,6 +9,16 @@ maintainability: null
 markdownlint:
   - id: MD032
     name: blanks-around-lists
+markdownlint-cli2:
+  - id: MD032
+    name: blanks-around-lists
+mado:
+  - id: MD032
+    name: blanks-around-lists
+    unstable: true
+rumdl:
+  - id: MD032
+    name: blanks-around-lists
 ---
 # MDS014: blank-line-around-lists
 

--- a/internal/rules/MDS015-blank-line-around-fenced-code/README.md
+++ b/internal/rules/MDS015-blank-line-around-fenced-code/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD031
     name: blanks-around-fences
+markdownlint-cli2:
+  - id: MD031
+    name: blanks-around-fences
+mado:
+  - id: MD031
+    name: blanks-around-fences
+rumdl:
+  - id: MD031
+    name: blanks-around-fences
 ---
 # MDS015: blank-line-around-fenced-code
 

--- a/internal/rules/MDS016-list-indent/README.md
+++ b/internal/rules/MDS016-list-indent/README.md
@@ -12,6 +12,25 @@ markdownlint:
     partial: true
   - id: MD007
     name: ul-indent
+markdownlint-cli2:
+  - id: MD005
+    name: list-indent
+    partial: true
+  - id: MD007
+    name: ul-indent
+mado:
+  - id: MD005
+    name: list-indent
+    partial: true
+  - id: MD007
+    name: ul-indent
+    unstable: true
+rumdl:
+  - id: MD005
+    name: list-indent
+    partial: true
+  - id: MD007
+    name: ul-indent
 ---
 # MDS016: list-indent
 

--- a/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
+++ b/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD026
     name: no-trailing-punctuation
+markdownlint-cli2:
+  - id: MD026
+    name: no-trailing-punctuation
+mado:
+  - id: MD026
+    name: no-trailing-punctuation
+rumdl:
+  - id: MD026
+    name: no-trailing-punctuation
 ---
 # MDS017: no-trailing-punctuation-in-heading
 

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD036
     name: no-emphasis-as-heading
+markdownlint-cli2:
+  - id: MD036
+    name: no-emphasis-as-heading
+mado:
+  - id: MD036
+    name: no-emphasis-as-heading
+rumdl:
+  - id: MD036
+    name: no-emphasis-as-heading
 ---
 # MDS018: no-emphasis-as-heading
 

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -12,6 +12,13 @@ maintainability:
 markdownlint:
   - id: MD043
     name: required-headings
+markdownlint-cli2:
+  - id: MD043
+    name: required-headings
+mado: null
+rumdl:
+  - id: MD043
+    name: required-headings
 ---
 # MDS020: required-structure
 

--- a/internal/rules/MDS025-table-format/README.md
+++ b/internal/rules/MDS025-table-format/README.md
@@ -14,6 +14,23 @@ markdownlint:
     partial: true
   - id: MD058
     name: blanks-around-tables
+markdownlint-cli2:
+  - id: MD055
+    name: table-pipe-style
+  - id: MD056
+    name: table-column-count
+    partial: true
+  - id: MD058
+    name: blanks-around-tables
+mado: null
+rumdl:
+  - id: MD055
+    name: table-pipe-style
+  - id: MD056
+    name: table-column-count
+    partial: true
+  - id: MD058
+    name: blanks-around-tables
 ---
 # MDS025: table-format
 

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -9,6 +9,13 @@ maintainability: null
 markdownlint:
   - id: MD051
     name: link-fragments
+markdownlint-cli2:
+  - id: MD051
+    name: link-fragments
+mado: null
+rumdl:
+  - id: MD051
+    name: link-fragments
 ---
 # MDS027: cross-file-reference-integrity
 

--- a/internal/rules/MDS032-no-empty-alt-text/README.md
+++ b/internal/rules/MDS032-no-empty-alt-text/README.md
@@ -9,6 +9,13 @@ maintainability: null
 markdownlint:
   - id: MD045
     name: no-alt-text
+markdownlint-cli2:
+  - id: MD045
+    name: no-alt-text
+mado: null
+rumdl:
+  - id: MD045
+    name: no-alt-text
 ---
 # MDS032: no-empty-alt-text
 

--- a/internal/rules/MDS041-no-inline-html/README.md
+++ b/internal/rules/MDS041-no-inline-html/README.md
@@ -11,6 +11,15 @@ maintainability: null
 markdownlint:
   - id: MD033
     name: no-inline-html
+markdownlint-cli2:
+  - id: MD033
+    name: no-inline-html
+mado:
+  - id: MD033
+    name: no-inline-html
+rumdl:
+  - id: MD033
+    name: no-inline-html
 ---
 # MDS041: no-inline-html
 

--- a/internal/rules/MDS042-emphasis-style/README.md
+++ b/internal/rules/MDS042-emphasis-style/README.md
@@ -14,6 +14,17 @@ markdownlint:
     name: emphasis-style
   - id: MD050
     name: strong-style
+markdownlint-cli2:
+  - id: MD049
+    name: emphasis-style
+  - id: MD050
+    name: strong-style
+mado: null
+rumdl:
+  - id: MD049
+    name: emphasis-style
+  - id: MD050
+    name: strong-style
 ---
 # MDS042: emphasis-style
 

--- a/internal/rules/MDS044-horizontal-rule-style/README.md
+++ b/internal/rules/MDS044-horizontal-rule-style/README.md
@@ -11,6 +11,15 @@ maintainability: null
 markdownlint:
   - id: MD035
     name: hr-style
+markdownlint-cli2:
+  - id: MD035
+    name: hr-style
+mado:
+  - id: MD035
+    name: hr-style
+rumdl:
+  - id: MD035
+    name: hr-style
 ---
 # MDS044: horizontal-rule-style
 

--- a/internal/rules/MDS045-list-marker-style/README.md
+++ b/internal/rules/MDS045-list-marker-style/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD004
     name: ul-style
+markdownlint-cli2:
+  - id: MD004
+    name: ul-style
+mado:
+  - id: MD004
+    name: ul-style
+rumdl:
+  - id: MD004
+    name: ul-style
 ---
 # MDS045: list-marker-style
 

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD029
     name: ol-prefix
+markdownlint-cli2:
+  - id: MD029
+    name: ol-prefix
+mado:
+  - id: MD029
+    name: ol-prefix
+rumdl:
+  - id: MD029
+    name: ol-prefix
 ---
 # MDS046: ordered-list-numbering
 

--- a/internal/rules/MDS047-ambiguous-emphasis/README.md
+++ b/internal/rules/MDS047-ambiguous-emphasis/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD037
     name: no-space-in-emphasis
+markdownlint-cli2:
+  - id: MD037
+    name: no-space-in-emphasis
+mado:
+  - id: MD037
+    name: no-space-in-emphasis
+rumdl:
+  - id: MD037
+    name: no-space-in-emphasis
 ---
 # MDS047: ambiguous-emphasis
 

--- a/internal/rules/MDS049-no-space-in-link-text/README.md
+++ b/internal/rules/MDS049-no-space-in-link-text/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD039
     name: no-space-in-links
+markdownlint-cli2:
+  - id: MD039
+    name: no-space-in-links
+mado:
+  - id: MD039
+    name: no-space-in-links
+rumdl:
+  - id: MD039
+    name: no-space-in-links
 ---
 # MDS049: no-space-in-link-text
 

--- a/internal/rules/MDS050-proper-names/README.md
+++ b/internal/rules/MDS050-proper-names/README.md
@@ -9,6 +9,13 @@ maintainability: null
 markdownlint:
   - id: MD044
     name: proper-names
+markdownlint-cli2:
+  - id: MD044
+    name: proper-names
+mado: null
+rumdl:
+  - id: MD044
+    name: proper-names
 ---
 # MDS050: proper-names
 

--- a/internal/rules/MDS051-single-h1/README.md
+++ b/internal/rules/MDS051-single-h1/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD025
     name: single-h1
+markdownlint-cli2:
+  - id: MD025
+    name: single-h1
+mado:
+  - id: MD025
+    name: single-h1
+rumdl:
+  - id: MD025
+    name: single-h1
 ---
 # MDS051: single-h1
 

--- a/internal/rules/MDS052-no-space-in-code-spans/README.md
+++ b/internal/rules/MDS052-no-space-in-code-spans/README.md
@@ -9,6 +9,15 @@ maintainability: null
 markdownlint:
   - id: MD038
     name: no-space-in-code
+markdownlint-cli2:
+  - id: MD038
+    name: no-space-in-code
+mado:
+  - id: MD038
+    name: no-space-in-code
+rumdl:
+  - id: MD038
+    name: no-space-in-code
 ---
 # MDS052: no-space-in-code-spans
 

--- a/internal/rules/MDS053-no-unused-link-definitions/README.md
+++ b/internal/rules/MDS053-no-unused-link-definitions/README.md
@@ -11,6 +11,13 @@ maintainability: null
 markdownlint:
   - id: MD053
     name: link-image-reference-definitions
+markdownlint-cli2:
+  - id: MD053
+    name: link-image-reference-definitions
+mado: null
+rumdl:
+  - id: MD053
+    name: link-image-reference-definitions
 ---
 # MDS053: no-unused-link-definitions
 

--- a/internal/rules/MDS054-no-undefined-reference-labels/README.md
+++ b/internal/rules/MDS054-no-undefined-reference-labels/README.md
@@ -9,6 +9,13 @@ maintainability: null
 markdownlint:
   - id: MD052
     name: reference-links-images
+markdownlint-cli2:
+  - id: MD052
+    name: reference-links-images
+mado: null
+rumdl:
+  - id: MD052
+    name: reference-links-images
 ---
 # MDS054: no-undefined-reference-labels
 

--- a/internal/rules/MDS059-blockquote-whitespace/README.md
+++ b/internal/rules/MDS059-blockquote-whitespace/README.md
@@ -13,6 +13,22 @@ markdownlint:
     name: no-multiple-space-blockquote
   - id: MD028
     name: no-blanks-blockquote
+markdownlint-cli2:
+  - id: MD027
+    name: no-multiple-space-blockquote
+  - id: MD028
+    name: no-blanks-blockquote
+mado:
+  - id: MD027
+    name: no-multiple-space-blockquote
+    unstable: true
+  - id: MD028
+    name: no-blanks-blockquote
+rumdl:
+  - id: MD027
+    name: no-multiple-space-blockquote
+  - id: MD028
+    name: no-blanks-blockquote
 ---
 # MDS059: blockquote-whitespace
 

--- a/internal/rules/MDS061-list-marker-space/README.md
+++ b/internal/rules/MDS061-list-marker-space/README.md
@@ -11,6 +11,15 @@ maintainability: null
 markdownlint:
   - id: MD030
     name: list-marker-space
+markdownlint-cli2:
+  - id: MD030
+    name: list-marker-space
+mado:
+  - id: MD030
+    name: list-marker-space
+rumdl:
+  - id: MD030
+    name: list-marker-space
 ---
 # MDS061: list-marker-space
 

--- a/internal/rules/MDS062-link-validity/README.md
+++ b/internal/rules/MDS062-link-validity/README.md
@@ -14,6 +14,17 @@ markdownlint:
     name: no-reversed-links
   - id: MD042
     name: no-empty-links
+markdownlint-cli2:
+  - id: MD011
+    name: no-reversed-links
+  - id: MD042
+    name: no-empty-links
+mado: null
+rumdl:
+  - id: MD011
+    name: no-reversed-links
+  - id: MD042
+    name: no-empty-links
 ---
 # MDS062: link-validity
 

--- a/internal/rules/MDS063-descriptive-link-text/README.md
+++ b/internal/rules/MDS063-descriptive-link-text/README.md
@@ -11,6 +11,13 @@ maintainability: null
 markdownlint:
   - id: MD059
     name: descriptive-link-text
+markdownlint-cli2:
+  - id: MD059
+    name: descriptive-link-text
+mado: null
+rumdl:
+  - id: MD059
+    name: descriptive-link-text
 ---
 # MDS063: descriptive-link-text
 

--- a/internal/rules/MDS064-atx-heading-whitespace/README.md
+++ b/internal/rules/MDS064-atx-heading-whitespace/README.md
@@ -18,6 +18,43 @@ markdownlint:
     name: no-multiple-space-closed-atx
   - id: MD023
     name: heading-start-left
+markdownlint-cli2:
+  - id: MD018
+    name: no-missing-space-atx
+  - id: MD019
+    name: no-multiple-space-atx
+  - id: MD020
+    name: no-missing-space-closed-atx
+    partial: true
+  - id: MD021
+    name: no-multiple-space-closed-atx
+  - id: MD023
+    name: heading-start-left
+mado:
+  - id: MD018
+    name: no-missing-space-atx
+  - id: MD019
+    name: no-multiple-space-atx
+  - id: MD020
+    name: no-missing-space-closed-atx
+    partial: true
+    unstable: true
+  - id: MD021
+    name: no-multiple-space-closed-atx
+  - id: MD023
+    name: heading-start-left
+rumdl:
+  - id: MD018
+    name: no-missing-space-atx
+  - id: MD019
+    name: no-multiple-space-atx
+  - id: MD020
+    name: no-missing-space-closed-atx
+    partial: true
+  - id: MD021
+    name: no-multiple-space-closed-atx
+  - id: MD023
+    name: heading-start-left
 ---
 # MDS064: atx-heading-whitespace
 

--- a/internal/rules/MDS065-code-block-style/README.md
+++ b/internal/rules/MDS065-code-block-style/README.md
@@ -11,6 +11,15 @@ maintainability: null
 markdownlint:
   - id: MD046
     name: code-block-style
+markdownlint-cli2:
+  - id: MD046
+    name: code-block-style
+mado:
+  - id: MD046
+    name: code-block-style
+rumdl:
+  - id: MD046
+    name: code-block-style
 ---
 # MDS065: code-block-style
 

--- a/internal/rules/MDS066-commands-show-output/README.md
+++ b/internal/rules/MDS066-commands-show-output/README.md
@@ -11,6 +11,15 @@ maintainability: null
 markdownlint:
   - id: MD014
     name: commands-show-output
+markdownlint-cli2:
+  - id: MD014
+    name: commands-show-output
+mado:
+  - id: MD014
+    name: commands-show-output
+rumdl:
+  - id: MD014
+    name: commands-show-output
 ---
 # MDS066: commands-show-output
 

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -6,6 +6,10 @@ description: 'string & != ""'
 nature: '"directive" | "generator" | "content" | "style" | "structure"'
 maintainability: '{signal: string & != "", fix: string & != "", "for-diagnostic"?: bool | *false} | null'
 markdownlint: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial?: bool | *false}] | null'
+"markdownlint-cli2?": '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial?: bool | *false}] | null'
+"mado?": '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial?: bool | *false, unstable?: bool | *false}] | null'
+"rumdl?": '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial?: bool | *false}] | null'
+"panache?": '[...{id: string & != "", name: string & != "", partial?: bool | *false}] | null'
 category: '"accessibility" | "code" | "directive" | "heading" | "line" | "link" | "list" | "prose" | "structural" | "table" | "whitespace"'
 ---
 # {id}: {name}


### PR DESCRIPTION
## Summary

Add comprehensive reference material documenting the rule-by-rule parity between mdsmith and markdownlint configurations used in the benchmark suite. This clarifies which rules each tool actually runs and how the `mdsmith-parity` configuration differs from the full `mdsmith` configuration.

## Changes

- **New "Apples-to-apples rule sets" section** in the benchmarks README with:
  - Overview table mapping each benchmark configuration to its rule class and source
  - **Table A** (shared markdownlint-compatible rules) broken into 7 subsections:
    - Headings (10 rules)
    - Lists (6 rules)
    - Whitespace, blank lines, tabs (7 rules)
    - Code blocks and code spans (6 rules)
    - Links and references (9 rules)
    - Inline, emphasis, HTML (7 rules)
    - Tables (3 rules)
  - **Table B** (mdsmith-only rules) documenting 24 additional rules with their capabilities and default/parity status
  - Explanatory notes on cross-file mechanisms (required-structure, cross-file-reference-integrity) that are disabled in parity mode
  - Callouts for MD054 (unimplemented in mdsmith) and rules intentionally left enabled in parity mode

## Implementation details

- Tables use markdown format with links to both markdownlint and mdsmith rule documentation
- Status indicators: ✅ (enabled), opt-in (off by default), disabled (parity-specific), — (not implemented)
- Grouping mirrors the existing markdownlint coverage matrix for cross-reference ease
- Explains the 12-rule delta between full mdsmith and mdsmith-parity configurations
- Documents which mdsmith-only rules are defensively disabled vs. intentionally left enabled during parity runs

https://claude.ai/code/session_01M6usteLjPj1x3c4pDnCBrS