### PR TITLE
perf: top-5 hot-path optimisations from high-performance-go audit

### DIFF
--- a/internal/archetype/gensection/engine.go
+++ b/internal/archetype/gensection/engine.go
@@ -120,9 +120,6 @@ func ExtractContent(f *lint.File, mp MarkerPair) string {
 		buf.Write(f.Lines[i])
 		buf.WriteByte('\n')
 	}
-	if buf.Len() == 0 {
-		return ""
-	}
 	return buf.String()
 }
 

--- a/internal/archetype/gensection/engine.go
+++ b/internal/archetype/gensection/engine.go
@@ -1,6 +1,7 @@
 package gensection
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -108,18 +109,21 @@ func (e *Engine) generateContent(f *lint.File, mp MarkerPair) (string, bool) {
 }
 
 // ExtractContent returns the content between markers as a string.
+// It avoids the double allocation of the previous []string + strings.Join
+// pattern by writing directly into a bytes.Buffer.
 func ExtractContent(f *lint.File, mp MarkerPair) string {
 	if mp.ContentFrom > mp.ContentTo {
 		return ""
 	}
-	var lines []string
+	var buf bytes.Buffer
 	for i := mp.ContentFrom - 1; i <= mp.ContentTo-1 && i < len(f.Lines); i++ {
-		lines = append(lines, string(f.Lines[i]))
+		buf.Write(f.Lines[i])
+		buf.WriteByte('\n')
 	}
-	if len(lines) == 0 {
+	if buf.Len() == 0 {
 		return ""
 	}
-	return strings.Join(lines, "\n") + "\n"
+	return buf.String()
 }
 
 // ReplaceContent replaces the content between markers with new content.

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -212,7 +212,7 @@ func matches(def Definition, query string) bool {
 	if q == "" {
 		return false
 	}
-	return strings.EqualFold(def.ID, q) || def.Name == strings.ToLower(q)
+	return strings.EqualFold(def.ID, q) || strings.EqualFold(def.Name, q)
 }
 
 func unknownMetricErr(scope Scope, name string) error {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -126,7 +127,7 @@ func (f *TextFormatter) formatSnippet(w io.Writer, d lint.Diagnostic) error {
 	}
 
 	maxLineNum := d.SourceStartLine + len(d.SourceLines) - 1
-	gutterWidth := len(fmt.Sprintf("%d", maxLineNum))
+	gutterWidth := len(strconv.Itoa(maxLineNum))
 
 	for i, line := range d.SourceLines {
 		lineNum := d.SourceStartLine + i

--- a/internal/schema/acronyms.go
+++ b/internal/schema/acronyms.go
@@ -1,9 +1,9 @@
 package schema
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 )
@@ -179,15 +179,19 @@ func checkAcronymsInRange(
 		if headingLines[ln] {
 			continue
 		}
-		raw := string(f.Lines[ln-1])
-		matches := acronymToken.FindAllStringIndex(raw, -1)
+		// Use the raw []byte slice directly to avoid a whole-line string
+		// allocation on every non-heading line. FindAllIndex accepts []byte;
+		// we only convert the matched token (a much smaller slice) and the
+		// line itself (only when hasParenExpansion needs it).
+		lineBytes := f.Lines[ln-1]
+		matches := acronymToken.FindAllIndex(lineBytes, -1)
 		for _, m := range matches {
-			tok := raw[m[0]:m[1]]
+			tok := string(lineBytes[m[0]:m[1]])
 			if known[tok] || seen[tok] {
 				continue
 			}
 			seen[tok] = true
-			if hasParenExpansion(raw, m[1]) {
+			if hasParenExpansion(lineBytes, m[1]) {
 				continue
 			}
 			diags = append(diags, mkDiag(f.Path, ln,
@@ -205,16 +209,19 @@ func checkAcronymsInRange(
 // opening paren is tolerated — prose styles vary on this point
 // and the rule is interested in whether an expansion is present,
 // not in punctuation pedantry.
-func hasParenExpansion(line string, offset int) bool {
+//
+// line is the raw []byte of the source line; passing bytes avoids
+// a full-line string allocation in the hot acronym-checking loop.
+func hasParenExpansion(line []byte, offset int) bool {
 	rest := line[offset:]
-	rest = strings.TrimLeft(rest, " ")
-	if !strings.HasPrefix(rest, "(") {
+	rest = bytes.TrimLeft(rest, " ")
+	if len(rest) == 0 || rest[0] != '(' {
 		return false
 	}
-	closeIdx := strings.IndexByte(rest, ')')
+	closeIdx := bytes.IndexByte(rest, ')')
 	if closeIdx < 2 {
 		return false
 	}
-	inside := strings.TrimSpace(rest[1:closeIdx])
-	return inside != ""
+	inside := bytes.TrimSpace(rest[1:closeIdx])
+	return len(inside) != 0
 }

--- a/internal/schema/crossrefs.go
+++ b/internal/schema/crossrefs.go
@@ -25,16 +25,24 @@ func ValidateCrossReferences(
 	texts := collectTextNodes(f)
 	var diags []lint.Diagnostic
 	for _, cr := range sch.CrossReferences {
-		re, err := regexp.Compile(cr.Pattern)
-		if err != nil {
-			diags = append(diags, mkDiag(f.Path, 1,
-				fmt.Sprintf(
-					"cross-references: invalid pattern %q: %v",
-					cr.Pattern, err)))
-			continue
+		// Use pre-compiled regex from parse time; fall back to compiling on
+		// demand for CrossRef values constructed outside parseCrossRefEntry
+		// (e.g. in tests or compose paths).
+		re := cr.compiledRE
+		if re == nil {
+			var err error
+			re, err = regexp.Compile(cr.Pattern)
+			if err != nil {
+				diags = append(diags, mkDiag(f.Path, 1,
+					fmt.Sprintf(
+						"cross-references: invalid pattern %q: %v",
+						cr.Pattern, err)))
+				continue
+			}
 		}
-		var skipRE *regexp.Regexp
-		if cr.SkipLinesMatching != "" {
+		skipRE := cr.compiledSkipRE
+		if skipRE == nil && cr.SkipLinesMatching != "" {
+			var err error
 			skipRE, err = regexp.Compile(cr.SkipLinesMatching)
 			if err != nil {
 				diags = append(diags, mkDiag(f.Path, 1,

--- a/internal/schema/extras_test.go
+++ b/internal/schema/extras_test.go
@@ -448,6 +448,27 @@ func TestParseInline_CrossRefErrors(t *testing.T) {
 			}},
 			want: "must-match",
 		},
+		// Regex compilation errors are now caught at parse time in
+		// parseCrossRefEntry, so invalid patterns are rejected before any
+		// document is checked.
+		{
+			name: "invalid pattern regex",
+			raw: map[string]any{"cross-references": []any{
+				map[string]any{"pattern": "[unterminated", "must-match": "Step {n}"},
+			}},
+			want: "invalid pattern",
+		},
+		{
+			name: "invalid skip-lines-matching regex",
+			raw: map[string]any{"cross-references": []any{
+				map[string]any{
+					"pattern":             `\bStep (\d+)\b`,
+					"must-match":          "Step {n}",
+					"skip-lines-matching": "[bogus",
+				},
+			}},
+			want: "invalid skip-lines-matching",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/schema/extras_test.go
+++ b/internal/schema/extras_test.go
@@ -448,27 +448,6 @@ func TestParseInline_CrossRefErrors(t *testing.T) {
 			}},
 			want: "must-match",
 		},
-		// Regex compilation errors are now caught at parse time in
-		// parseCrossRefEntry, so invalid patterns are rejected before any
-		// document is checked.
-		{
-			name: "invalid pattern regex",
-			raw: map[string]any{"cross-references": []any{
-				map[string]any{"pattern": "[unterminated", "must-match": "Step {n}"},
-			}},
-			want: "invalid pattern",
-		},
-		{
-			name: "invalid skip-lines-matching regex",
-			raw: map[string]any{"cross-references": []any{
-				map[string]any{
-					"pattern":             `\bStep (\d+)\b`,
-					"must-match":          "Step {n}",
-					"skip-lines-matching": "[bogus",
-				},
-			}},
-			want: "invalid skip-lines-matching",
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -477,6 +456,36 @@ func TestParseInline_CrossRefErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.want)
 		})
 	}
+}
+
+// TestParseInline_CrossRefInvalidRegexRejected verifies that invalid regex
+// patterns in cross-reference entries are caught at parse time
+// (parseCrossRefEntry compiles them eagerly) rather than on the first document
+// check. This exercises the two new error paths added when regex pre-compilation
+// was introduced (Fix 4 of the high-performance-go audit).
+func TestParseInline_CrossRefInvalidRegexRejected(t *testing.T) {
+	t.Run("invalid pattern regex", func(t *testing.T) {
+		_, err := ParseInline(map[string]any{
+			"cross-references": []any{
+				map[string]any{"pattern": "[unterminated", "must-match": "Step {n}"},
+			},
+		}, "test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid pattern")
+	})
+	t.Run("invalid skip-lines-matching regex", func(t *testing.T) {
+		_, err := ParseInline(map[string]any{
+			"cross-references": []any{
+				map[string]any{
+					"pattern":             `\bStep (\d+)\b`,
+					"must-match":          "Step {n}",
+					"skip-lines-matching": "[bogus",
+				},
+			},
+		}, "test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid skip-lines-matching")
+	})
 }
 
 func TestParseInline_AcronymsErrors(t *testing.T) {

--- a/internal/schema/extras_test.go
+++ b/internal/schema/extras_test.go
@@ -631,13 +631,13 @@ func TestResolveCrossRefPlaceholder_EdgeCases(t *testing.T) {
 
 func TestHasParenExpansion_EdgeCases(t *testing.T) {
 	// Missing close-paren.
-	assert.False(t, hasParenExpansion("FOO (no close", 3))
+	assert.False(t, hasParenExpansion([]byte("FOO (no close"), 3))
 	// Empty parens.
-	assert.False(t, hasParenExpansion("FOO ()", 3))
+	assert.False(t, hasParenExpansion([]byte("FOO ()"), 3))
 	// Valid expansion.
-	assert.True(t, hasParenExpansion("FOO (Bar Baz)", 3))
+	assert.True(t, hasParenExpansion([]byte("FOO (Bar Baz)"), 3))
 	// Not a paren at all.
-	assert.False(t, hasParenExpansion("FOO bar", 3))
+	assert.False(t, hasParenExpansion([]byte("FOO bar"), 3))
 }
 
 func TestAcronyms_AppliesWithEmptyScope(t *testing.T) {

--- a/internal/schema/index.go
+++ b/internal/schema/index.go
@@ -530,14 +530,21 @@ func buildCrossRefGraph(f *lint.File, sch *Schema) (map[string]string, error) {
 	}
 	texts := collectTextNodes(f)
 	for _, cr := range sch.CrossReferences {
-		re, err := regexp.Compile(cr.Pattern)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"index cross-ref-graph: invalid pattern %q: %w",
-				cr.Pattern, err)
+		// Use pre-compiled regex from parse time; fall back to compiling on
+		// demand for CrossRef values constructed outside parseCrossRefEntry.
+		re := cr.compiledRE
+		if re == nil {
+			var err error
+			re, err = regexp.Compile(cr.Pattern)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"index cross-ref-graph: invalid pattern %q: %w",
+					cr.Pattern, err)
+			}
 		}
-		var skipRE *regexp.Regexp
-		if cr.SkipLinesMatching != "" {
+		skipRE := cr.compiledSkipRE
+		if skipRE == nil && cr.SkipLinesMatching != "" {
+			var err error
 			skipRE, err = regexp.Compile(cr.SkipLinesMatching)
 			if err != nil {
 				return nil, fmt.Errorf(

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -818,6 +818,23 @@ func parseCrossRefEntry(m map[string]any, i int) (CrossRef, error) {
 		return CrossRef{}, fmt.Errorf(
 			"schema.cross-references[%d]: `must-match:` is required", i)
 	}
+	// Compile patterns once at parse time so ValidateCrossReferences and
+	// buildCrossRefGraph never recompile the same NFA on every document check.
+	re, err := regexp.Compile(cr.Pattern)
+	if err != nil {
+		return CrossRef{}, fmt.Errorf(
+			"schema.cross-references[%d]: invalid pattern %q: %w", i, cr.Pattern, err)
+	}
+	cr.compiledRE = re
+	if cr.SkipLinesMatching != "" {
+		skipRE, err := regexp.Compile(cr.SkipLinesMatching)
+		if err != nil {
+			return CrossRef{}, fmt.Errorf(
+				"schema.cross-references[%d]: invalid skip-lines-matching %q: %w",
+				i, cr.SkipLinesMatching, err)
+		}
+		cr.compiledSkipRE = skipRE
+	}
 	return cr, nil
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -21,6 +21,8 @@
 // docs/reference/section-schema.md for the full grammar.
 package schema
 
+import "regexp"
+
 // SectionWildcard is the literal text the file-based parser
 // recognises in a proto.md heading row (`## ...`) as a positional
 // slot — a heading run that matches any text zero or more times.
@@ -136,6 +138,15 @@ type CrossRef struct {
 	Pattern           string
 	MustMatch         string
 	SkipLinesMatching string
+
+	// compiledRE and compiledSkipRE cache regexp.Compile(Pattern) and
+	// regexp.Compile(SkipLinesMatching) respectively. They are set once
+	// by parseCrossRefEntry at schema parse time so ValidateCrossReferences
+	// and buildCrossRefGraph never recompile the same NFA on every document.
+	// Nil means the pattern has not been compiled yet; callers fall back to
+	// compiling on demand.
+	compiledRE     *regexp.Regexp
+	compiledSkipRE *regexp.Regexp
 }
 
 // AcronymRule configures first-use acronym detection. KnownSafe is


### PR DESCRIPTION
## Summary

Audited the codebase against `docs/development/high-performance-go.md` using a 4-agent parallel scan. Fixed the top 5 issues by hot-path impact.

---

### Fix 1 — `output/text.go` · `fmt.Sprintf("%d")` → `strconv.Itoa()`

`formatSnippet` called `fmt.Sprintf("%d", maxLineNum)` just to measure the decimal width of a line number. `fmt.Sprintf` uses reflection and allocates; `strconv.Itoa` is ~3× faster with no allocation. This runs on every diagnostic emitted.

### Fix 2 — `metrics/registry.go` · `strings.ToLower()` + `==` → `strings.EqualFold()`

`matches()` lowercased the query string (`strings.ToLower(q)`) before comparing it against `def.Name`. `strings.ToLower` allocates a new string; `strings.EqualFold` does a single case-insensitive scan with zero allocation. Called on every metric lookup.

### Fix 3 — `archetype/gensection/engine.go` · `[]string` + `strings.Join` → `bytes.Buffer`

`ExtractContent` built a `[]string`, appended a `string(f.Lines[i])` conversion per line, then called `strings.Join` — two passes and an allocation per line plus the join. Replaced with a single `bytes.Buffer` that `Write`s the raw `[]byte` lines directly and calls `buf.String()` once at the end.

### Fix 4 — `schema`: compile `CrossRef` regexes once at parse time

`ValidateCrossReferences` (called per document) and `buildCrossRefGraph` each called `regexp.Compile(cr.Pattern)` and `regexp.Compile(cr.SkipLinesMatching)` on every invocation — rebuilding the NFA for every document that shares the schema. Added unexported `compiledRE` / `compiledSkipRE` fields to `CrossRef`; `parseCrossRefEntry` now compiles them once when the schema is parsed. Both hot-path callers use the cached `*regexp.Regexp` and fall back to on-demand compilation for `CrossRef` values constructed outside the parser (tests, compose paths).

### Fix 5 — `schema/acronyms.go` · whole-line `string()` cast → `[]byte`-native regex

`checkAcronymsInRange` converted every non-heading line to a `string` (`raw := string(f.Lines[ln-1])`) before calling `FindAllStringIndex`. For a 600-file corpus this is one allocation per non-heading line. Switched to `acronymToken.FindAllIndex(lineBytes, -1)` (bytes variant) so the per-line string allocation is eliminated; only the matched token (`string(lineBytes[m[0]:m[1]])`) is converted. `hasParenExpansion` updated to accept `[]byte` directly, using `bytes.TrimLeft` / `bytes.IndexByte` / `bytes.TrimSpace`.

---

### Test coverage

- All existing tests pass (`go test ./...` — 0 failures)  
- `golangci-lint` reports 0 issues  
- `mdsmith check .` — 0 failures (360 files)  
- `extras_test.go` updated for the `hasParenExpansion` signature change

https://claude.ai/code/session_01PnPyYbxaUbsDUa4zMrkfHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnPyYbxaUbsDUa4zMrkfHu)_