### PR TITLE
LSP fix preview: emit per-hunk edits instead of whole-file replacement

### DIFF
--- a/docs/reference/cli/lsp.md
+++ b/docs/reference/cli/lsp.md
@@ -115,21 +115,19 @@ any fix lands. Both capabilities below must appear in
 - `workspace.workspaceEdit.documentChanges`
 - `workspace.workspaceEdit.changeAnnotationSupport`
 
-When both are present, edits use `AnnotatedTextEdit`;
-the corresponding `changeAnnotation` entry is flagged
-`needsConfirmation: true` (LSP 3.16).
+When both are present, edits use `AnnotatedTextEdit`
+(LSP 3.16) with `needsConfirmation: true`. The
+`edits` slice carries one entry per line-aligned
+diff hunk, not one whole-file replacement (which
+Refactor Preview would render as "old file → new
+file" with no visible delta). All hunks share an
+`annotationId`.
 
-Annotation IDs:
-
-- Per-rule quick fix: `mdsmith-fix-<rule-name>` (e.g.
-  `mdsmith-fix-no-trailing-spaces`)
-- `source.fixAll.mdsmith`: `mdsmith-fix-all`
-
-`<rule-name>` is the name string, not the rule code.
-
-Missing either capability falls back to the legacy
-`changes` map. One warning is logged per session to
-`window/logMessage` naming the missing capability.
+Each quick fix carries the id
+`mdsmith-fix-<rule-name>`. The fix-all action uses
+`mdsmith-fix-all`. Drop either capability and the
+server emits the legacy `changes` map. A warning
+goes to `window/logMessage` once per session.
 
 ## Symbol navigation
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ tool (
 require (
 	cuelang.org/go v0.16.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/neurosnap/sentences v1.1.2
 	github.com/spf13/pflag v1.0.10
@@ -143,7 +144,6 @@ require (
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jgautheron/goconst v1.8.2 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1366,11 +1366,14 @@ func fullFileEditAnnotated(uri string, before, after []byte, annotationID, label
 }
 
 // annotatedHunkEdits computes a line-aligned diff between before and
-// after and returns one AnnotatedTextEdit per hunk. Myers emits a
-// Delete (range [I, J)) immediately followed by a zero-width Insert
-// at line J; this pair gets folded into a single Replace edit at
-// range [I, J) with the insert's text so the preview pane shows one
-// hunk per change instead of an empty delete plus a zero-width insert.
+// after and returns one AnnotatedTextEdit per hunk. Myers may emit
+// several adjacent raw edits per hunk — e.g. a Delete-per-line for a
+// multi-line removal followed by a zero-width Insert for the
+// replacement text. Any run of edits where each one's end position
+// touches the next one's start gets coalesced into a single Replace
+// covering the combined range so the preview pane shows one entry per
+// visible change rather than a list of zero-width inserts and empty
+// deletes.
 //
 // Each edit's range uses character 0 on both endpoints (line-aligned),
 // matching the LSP spec for "replace these whole lines": start at the
@@ -1380,26 +1383,26 @@ func annotatedHunkEdits(before, after []byte, annotationID string) []annotatedTe
 	raw := myers.ComputeEdits(span.URIFromPath(""), string(before), string(after))
 	gotextdiff.SortTextEdits(raw)
 	out := make([]annotatedTextEdit, 0, len(raw))
-	for i := 0; i < len(raw); i++ {
-		e := raw[i]
-		start, end := lineRange(e)
-		newText := e.NewText
-		if i+1 < len(raw) {
-			next := raw[i+1]
-			nStart, nEnd := lineRange(next)
-			// Delete then zero-width Insert at the delete's end:
-			// fold to a Replace covering the delete's range with
-			// the insert's text.
-			if newText == "" && nEnd == nStart && nStart == end {
-				newText = next.NewText
-				i++
+	for i := 0; i < len(raw); {
+		start, end := lineRange(raw[i])
+		var newText strings.Builder
+		newText.WriteString(raw[i].NewText)
+		j := i + 1
+		for j < len(raw) {
+			nStart, nEnd := lineRange(raw[j])
+			if nStart != end {
+				break
 			}
+			end = nEnd
+			newText.WriteString(raw[j].NewText)
+			j++
 		}
 		out = append(out, annotatedTextEdit{
 			Range:        Range{Start: start, End: end},
-			NewText:      newText,
+			NewText:      newText.String(),
 			AnnotationID: annotationID,
 		})
+		i = j
 	}
 	return out
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -17,6 +17,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/engine"
 	fixpkg "github.com/jeduden/mdsmith/internal/fix"
@@ -1329,22 +1333,26 @@ func fullFileEdit(uri string, before, after []byte) *workspaceEdit {
 // documentChanges + changeAnnotations path. The annotation is flagged
 // needsConfirmation: true so VS Code routes the edit through Refactor
 // Preview instead of applying it immediately.
+//
+// The edit body is a slice of per-hunk AnnotatedTextEdits computed by
+// a Myers line diff (same algorithm gopls uses). One whole-file
+// AnnotatedTextEdit would still apply correctly, but VS Code's
+// Refactor Preview pane diffs each TextEdit independently — so a
+// single full-file edit renders as "old file → new file" with the
+// changed lines lost in a wall of unchanged context, and the lower
+// tree-node previews the entire new document on one line. Emitting
+// one edit per hunk gives the preview real ranges to highlight and
+// short labels to render.
+//
+// All hunks carry the same annotationID; VS Code groups them under
+// one "Fix all <rule>" confirmation entry.
 func fullFileEditAnnotated(uri string, before, after []byte, annotationID, label string) *workspaceEdit {
-	endLine, endChar := documentEndPosition(before)
+	edits := annotatedHunkEdits(before, after, annotationID)
 	return &workspaceEdit{
 		DocumentChanges: []textDocumentEdit{
 			{
 				TextDocument: optionalVersionedTextDocumentIdentifier{URI: uri},
-				Edits: []annotatedTextEdit{
-					{
-						Range: Range{
-							Start: Position{Line: 0, Character: 0},
-							End:   Position{Line: endLine, Character: endChar},
-						},
-						NewText:      string(after),
-						AnnotationID: annotationID,
-					},
-				},
+				Edits:        edits,
 			},
 		},
 		ChangeAnnotations: map[string]changeAnnotation{
@@ -1355,6 +1363,52 @@ func fullFileEditAnnotated(uri string, before, after []byte, annotationID, label
 			},
 		},
 	}
+}
+
+// annotatedHunkEdits computes a line-aligned diff between before and
+// after and returns one AnnotatedTextEdit per hunk. Myers emits a
+// Delete (range [I, J)) immediately followed by a zero-width Insert
+// at line J; this pair gets folded into a single Replace edit at
+// range [I, J) with the insert's text so the preview pane shows one
+// hunk per change instead of an empty delete plus a zero-width insert.
+//
+// Each edit's range uses character 0 on both endpoints (line-aligned),
+// matching the LSP spec for "replace these whole lines": start at the
+// beginning of the first changed line, end at the beginning of the
+// line immediately after the last changed line.
+func annotatedHunkEdits(before, after []byte, annotationID string) []annotatedTextEdit {
+	raw := myers.ComputeEdits(span.URIFromPath(""), string(before), string(after))
+	gotextdiff.SortTextEdits(raw)
+	out := make([]annotatedTextEdit, 0, len(raw))
+	for i := 0; i < len(raw); i++ {
+		e := raw[i]
+		start, end := lineRange(e)
+		newText := e.NewText
+		if i+1 < len(raw) {
+			next := raw[i+1]
+			nStart, nEnd := lineRange(next)
+			// Delete then zero-width Insert at the delete's end:
+			// fold to a Replace covering the delete's range with
+			// the insert's text.
+			if newText == "" && nEnd == nStart && nStart == end {
+				newText = next.NewText
+				i++
+			}
+		}
+		out = append(out, annotatedTextEdit{
+			Range:        Range{Start: start, End: end},
+			NewText:      newText,
+			AnnotationID: annotationID,
+		})
+	}
+	return out
+}
+
+// lineRange converts a gotextdiff TextEdit (1-indexed line, column 1)
+// to an LSP Range (0-indexed line, character 0).
+func lineRange(e gotextdiff.TextEdit) (Position, Position) {
+	return Position{Line: e.Span.Start().Line() - 1, Character: 0},
+		Position{Line: e.Span.End().Line() - 1, Character: 0}
 }
 
 // documentEndPosition returns the LSP end position covering the

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1375,6 +1375,12 @@ func fullFileEditAnnotated(uri string, before, after []byte, annotationID, label
 // visible change rather than a list of zero-width inserts and empty
 // deletes.
 //
+// Edits are returned bottom-up (last hunk first) so a naive client
+// applying them in slice order doesn't shift the offsets a later
+// edit relies on — same convention as sortTextEditsBottomUp in
+// rename.go. The LSP spec only forbids overlap; it doesn't pin
+// application order.
+//
 // Each edit's range uses character 0 on both endpoints (line-aligned),
 // matching the LSP spec for "replace these whole lines": start at the
 // beginning of the first changed line, end at the beginning of the
@@ -1403,6 +1409,11 @@ func annotatedHunkEdits(before, after []byte, annotationID string) []annotatedTe
 			AnnotationID: annotationID,
 		})
 		i = j
+	}
+	// Coalesce runs above relied on top-down order. Reverse to the
+	// codebase's bottom-up emit convention.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
 	}
 	return out
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2540,12 +2540,16 @@ func hunkEditCasesSimple() []hunkEditCase {
 func hunkEditCasesComplex() []hunkEditCase {
 	return []hunkEditCase{
 		{
+			// Edits emit bottom-up so naive clients applying them
+			// in slice order don't shift later offsets — see
+			// annotatedHunkEdits' doc comment and
+			// sortTextEditsBottomUp in rename.go.
 			name:   "two distant single-line replacements emit two hunks",
 			before: "a\nold1\nc\nd\ne\nold2\ng\n",
 			after:  "a\nnew1\nc\nd\ne\nnew2\ng\n",
 			want: []hunkEditWant{
-				{1, 2, "new1\n"},
 				{5, 6, "new2\n"},
+				{1, 2, "new1\n"},
 			},
 		},
 		{
@@ -2656,12 +2660,16 @@ func applyAnnotatedEdits(t *testing.T, src []byte, edits []annotatedTextEdit) []
 			"applyAnnotatedEdits only supports line-aligned edits")
 		start := e.Range.Start.Line
 		end := e.Range.End.Line
-		if start > len(lines) {
-			start = len(lines)
-		}
-		if end > len(lines) {
-			end = len(lines)
-		}
+		// Validate rather than clamp: a silent clamp would mask
+		// off-by-one bugs in lineRange/annotatedHunkEdits by making
+		// out-of-range edits "work".
+		require.GreaterOrEqualf(t, start, 0, "start line %d < 0", start)
+		require.LessOrEqualf(t, start, len(lines),
+			"start line %d > line count %d", start, len(lines))
+		require.GreaterOrEqualf(t, end, start,
+			"end line %d < start line %d", end, start)
+		require.LessOrEqualf(t, end, len(lines),
+			"end line %d > line count %d", end, len(lines))
 		insert := strings.SplitAfter(e.NewText, "\n")
 		if len(insert) > 0 && insert[len(insert)-1] == "" {
 			insert = insert[:len(insert)-1]

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/span"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -2456,6 +2458,174 @@ func TestPreviewFixAnnotatedHunksNotWholeFile(t *testing.T) {
 	want := s.quickFixBytesFor("no-trailing-spaces", doc, cfg, "")
 	require.NotNil(t, want)
 	assert.Equal(t, string(want), string(got))
+}
+
+// TestAnnotatedHunkEdits covers annotatedHunkEdits directly so the
+// fold rule, the LSP range conversion, and round-trip correctness are
+// each tractable in isolation rather than only through computeCodeActions.
+//
+// Each case asserts:
+//   - the expected edit ranges (line-aligned, character 0), in the order
+//     the function emits them;
+//   - the expected NewText per edit;
+//   - that applying the edits to `before` round-trips to `after`;
+//   - that every edit carries the supplied annotation id.
+func TestAnnotatedHunkEdits(t *testing.T) {
+	t.Parallel()
+	for _, tc := range hunkEditCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			checkHunkEditCase(t, tc)
+		})
+	}
+}
+
+type hunkEditWant struct {
+	startLine, endLine int
+	newText            string
+}
+
+type hunkEditCase struct {
+	name   string
+	before string
+	after  string
+	want   []hunkEditWant
+}
+
+func hunkEditCases() []hunkEditCase {
+	return append(hunkEditCasesSimple(), hunkEditCasesComplex()...)
+}
+
+func hunkEditCasesSimple() []hunkEditCase {
+	return []hunkEditCase{
+		{
+			name:   "no change",
+			before: "a\nb\n",
+			after:  "a\nb\n",
+			want:   nil,
+		},
+		{
+			name:   "single-line replacement folds delete+insert",
+			before: "a\nold\nc\n",
+			after:  "a\nnew\nc\n",
+			want:   []hunkEditWant{{1, 2, "new\n"}},
+		},
+		{
+			name:   "pure deletion",
+			before: "a\nb\nc\n",
+			after:  "a\nc\n",
+			want:   []hunkEditWant{{1, 2, ""}},
+		},
+		{
+			name:   "pure insertion in the middle",
+			before: "a\nc\n",
+			after:  "a\nb\nc\n",
+			want:   []hunkEditWant{{1, 1, "b\n"}},
+		},
+		{
+			name:   "insertion at start of file",
+			before: "b\n",
+			after:  "a\nb\n",
+			want:   []hunkEditWant{{0, 0, "a\n"}},
+		},
+		{
+			name:   "append at end of file",
+			before: "a\n",
+			after:  "a\nb\n",
+			want:   []hunkEditWant{{1, 1, "b\n"}},
+		},
+	}
+}
+
+func hunkEditCasesComplex() []hunkEditCase {
+	return []hunkEditCase{
+		{
+			name:   "two distant single-line replacements emit two hunks",
+			before: "a\nold1\nc\nd\ne\nold2\ng\n",
+			after:  "a\nnew1\nc\nd\ne\nnew2\ng\n",
+			want: []hunkEditWant{
+				{1, 2, "new1\n"},
+				{5, 6, "new2\n"},
+			},
+		},
+		{
+			name:   "multi-line replacement",
+			before: "a\nb1\nb2\nb3\nc\n",
+			after:  "a\nX\nc\n",
+			want:   []hunkEditWant{{1, 4, "X\n"}},
+		},
+		{
+			name:   "empty before to non-empty after",
+			before: "",
+			after:  "a\n",
+			want:   []hunkEditWant{{0, 0, "a\n"}},
+		},
+		{
+			name:   "non-empty before to empty after",
+			before: "a\n",
+			after:  "",
+			want:   []hunkEditWant{{0, 1, ""}},
+		},
+	}
+}
+
+func checkHunkEditCase(t *testing.T, tc hunkEditCase) {
+	t.Helper()
+	const annot = "mdsmith-fix-x"
+	got := annotatedHunkEdits([]byte(tc.before), []byte(tc.after), annot)
+	require.Len(t, got, len(tc.want), "edit count mismatch: got %+v", got)
+	for i, w := range tc.want {
+		assert.Equalf(t, w.startLine, got[i].Range.Start.Line,
+			"edit %d start line", i)
+		assert.Equalf(t, w.endLine, got[i].Range.End.Line,
+			"edit %d end line", i)
+		assert.Zerof(t, got[i].Range.Start.Character,
+			"edit %d start character must be 0", i)
+		assert.Zerof(t, got[i].Range.End.Character,
+			"edit %d end character must be 0", i)
+		assert.Equalf(t, w.newText, got[i].NewText,
+			"edit %d NewText", i)
+		assert.Equalf(t, annot, got[i].AnnotationID,
+			"edit %d annotation id", i)
+	}
+	// Apply round-trip: every case must reproduce `after`.
+	if len(got) > 0 {
+		roundTrip := applyAnnotatedEdits(t, []byte(tc.before), got)
+		assert.Equal(t, tc.after, string(roundTrip))
+	}
+}
+
+// TestLineRange covers lineRange directly: the 1-indexed-line,
+// column-1 gotextdiff span maps to a 0-indexed-line, character-0 LSP
+// position. The conversion is one line of arithmetic but is the only
+// thing keeping our LSP edits aligned with the diff hunks the algorithm
+// returns; a regression here would shift every preview edit by a line.
+func TestLineRange(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name               string
+		spanStart, spanEnd int
+		wantStart, wantEnd int
+	}{
+		{"first line point", 1, 1, 0, 0},
+		{"first line span", 1, 2, 0, 1},
+		{"interior span", 4, 7, 3, 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e := gotextdiff.TextEdit{
+				Span: span.New(span.URIFromPath(""),
+					span.NewPoint(tc.spanStart, 1, 0),
+					span.NewPoint(tc.spanEnd, 1, 0)),
+			}
+			start, end := lineRange(e)
+			assert.Equal(t, tc.wantStart, start.Line)
+			assert.Zero(t, start.Character)
+			assert.Equal(t, tc.wantEnd, end.Line)
+			assert.Zero(t, end.Character)
+		})
+	}
 }
 
 // applyAnnotatedEdits applies a slice of annotatedTextEdit values to

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2379,6 +2380,127 @@ func TestPreviewFixAnnotatedPerRuleQuickFix(t *testing.T) {
 	ann, ok := edit.ChangeAnnotations[wantID]
 	require.True(t, ok)
 	assert.True(t, ann.NeedsConfirmation)
+}
+
+// TestPreviewFixAnnotatedHunksNotWholeFile verifies that the annotated
+// edit path emits per-hunk TextEdits sized to the actual diff, not one
+// giant whole-file replacement. VS Code's Refactor Preview renders each
+// TextEdit as a separate change; a single full-file edit collapses into
+// "old file → new file" with no visible delta and the whole document
+// flattened into the lower preview pane's single-line label.
+//
+// Setup: 12 unchanged lines bracketing two distant trailing-whitespace
+// lines (1 and 10). The per-rule quickfix path runs only
+// no-trailing-spaces, so the only diff is on those two lines and the
+// hunk count check isn't muddied by other auto-fixes.
+func TestPreviewFixAnnotatedHunksNotWholeFile(t *testing.T) {
+	t.Parallel()
+	s := newPreviewServer(t, true, true)
+	cfg := config.Merge(config.Defaults(), nil)
+	lines := []string{
+		"# Heading",
+		"intro line   ", // trailing spaces, line index 1
+		"",
+		"para a",
+		"para b",
+		"para c",
+		"",
+		"para d",
+		"para e",
+		"",
+		"closing line   ", // trailing spaces, line index 10
+		"",
+	}
+	src := []byte(strings.Join(lines, "\n") + "\n")
+	doc := &document{path: "x.md", text: src}
+	p := codeActionParams{
+		TextDocument: textDocumentIdentifier{URI: "file:///x.md"},
+		Context: codeActionContext{
+			Diagnostics: []Diagnostic{{
+				Code: "MDS006",
+				Data: &diagnosticData{RuleName: "no-trailing-spaces"},
+			}},
+			Only: []string{kindQuickFix},
+		},
+	}
+	actions := s.computeCodeActions(p, doc, cfg, "")
+	require.NotEmpty(t, actions)
+	edit := actions[0].Edit
+	require.NotNil(t, edit)
+	require.Len(t, edit.DocumentChanges, 1)
+	edits := edit.DocumentChanges[0].Edits
+	// Two distant changes → at least two hunks. A whole-file edit
+	// would emit exactly one entry spanning the full document.
+	require.GreaterOrEqual(t, len(edits), 2,
+		"preview path must emit per-hunk edits, not a whole-file replacement")
+
+	// No single edit may span the whole document.
+	for i, e := range edits {
+		span := e.Range.End.Line - e.Range.Start.Line
+		assert.Lessf(t, span, len(lines)-1,
+			"edit %d spans %d lines [%d..%d]; "+
+				"preview path must emit per-hunk edits, "+
+				"not a whole-file replacement",
+			i, span, e.Range.Start.Line, e.Range.End.Line)
+	}
+
+	// All edits must share the same annotation id so the preview
+	// pane groups them under one entry.
+	for _, e := range edits {
+		assert.Equal(t, "mdsmith-fix-no-trailing-spaces", e.AnnotationID)
+	}
+
+	// Applying the edits must yield the same bytes the per-rule
+	// fix pipeline would have written.
+	got := applyAnnotatedEdits(t, src, edits)
+	want := s.quickFixBytesFor("no-trailing-spaces", doc, cfg, "")
+	require.NotNil(t, want)
+	assert.Equal(t, string(want), string(got))
+}
+
+// applyAnnotatedEdits applies a slice of annotatedTextEdit values to
+// src using the LSP edit-application rules: edits' ranges refer to
+// positions in the original buffer, so we sort by descending start
+// position and splice each edit's NewText into the line-indexed slice.
+func applyAnnotatedEdits(t *testing.T, src []byte, edits []annotatedTextEdit) []byte {
+	t.Helper()
+	sorted := make([]annotatedTextEdit, len(edits))
+	copy(sorted, edits)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i].Range.Start, sorted[j].Range.Start
+		if a.Line != b.Line {
+			return a.Line > b.Line
+		}
+		return a.Character > b.Character
+	})
+	// All edits in this test use character 0 (line-aligned), so we
+	// can splice by line index.
+	lines := strings.SplitAfter(string(src), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for _, e := range sorted {
+		require.Zero(t, e.Range.Start.Character,
+			"applyAnnotatedEdits only supports line-aligned edits")
+		require.Zero(t, e.Range.End.Character,
+			"applyAnnotatedEdits only supports line-aligned edits")
+		start := e.Range.Start.Line
+		end := e.Range.End.Line
+		if start > len(lines) {
+			start = len(lines)
+		}
+		if end > len(lines) {
+			end = len(lines)
+		}
+		insert := strings.SplitAfter(e.NewText, "\n")
+		if len(insert) > 0 && insert[len(insert)-1] == "" {
+			insert = insert[:len(insert)-1]
+		}
+		tail := append([]string{}, lines[end:]...)
+		lines = append(lines[:start], insert...)
+		lines = append(lines, tail...)
+	}
+	return []byte(strings.Join(lines, ""))
 }
 
 // TestPreviewFixOffProducesLegacyEdits verifies that with previewFix


### PR DESCRIPTION
## Summary

Fixes three symptoms the user hit after Plan 207 (`mdsmith.previewFix`):

- LSP preview did not show the delta nicely.
- The diff editor pane appeared to show the outdated file twice.
- The lower change-tree pane flattened the entire markdown document into one line.

All three came from one root cause in `internal/lsp/server.go:1332`: the annotated `WorkspaceEdit` was a single `AnnotatedTextEdit` whose range spanned the whole document and whose `newText` was the entire fixed file. VS Code's Refactor Preview diffs each `TextEdit` independently, so the side-by-side pane rendered the whole pre-fix and post-fix file (the changed lines lost in a wall of unchanged context), and the tree-node label below used the giant `newText` as its preview string.

## Fix

`fullFileEditAnnotated` now computes a line-aligned Myers diff (via `gotextdiff`, the public mirror of the algorithm gopls uses internally) and emits one `AnnotatedTextEdit` per hunk. Adjacent Delete+Insert pairs fold into a single Replace so each visible change is one entry. All hunks in one code action share the same `annotationId`, so VS Code still groups them under one "Fix all" confirmation entry.

The legacy (non-preview) `fullFileEdit` path is unchanged, preserving Plan 207's byte-identical-to-today guarantee for `previewFix=false`.

## Test plan

- [x] New `TestPreviewFixAnnotatedHunksNotWholeFile` — input has two distant trailing-whitespace lines bracketed by 10 unchanged lines; asserts ≥2 edits, no edit spans the full document, all share `mdsmith-fix-no-trailing-spaces`, and applying the edits reproduces the per-rule fix output.
- [x] Existing `TestPreviewFixAnnotatedFixAllAction` / `TestPreviewFixAnnotatedPerRuleQuickFix` still pass (single-line input still produces one folded edit).
- [x] `TestPreviewFixOffProducesLegacyEdits` (snapshot regression on the legacy path) still passes.
- [x] `go test ./...`, `go vet ./...`, `go tool golangci-lint run`, `mdsmith check .` all clean.

## Manual verification

Manual VS Code verification of the actual Refactor Preview rendering still pending — I can't drive the VS Code UI from this environment. Worth a quick spot-check before un-drafting.

https://claude.ai/code/session_01C37g51j12x4Y4JkSb1K4EB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C37g51j12x4Y4JkSb1K4EB)_