### PR TITLE
Add docs-author skill for Markdown documentation writing

### DIFF
--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -28,7 +28,8 @@ allowed-tools: >-
 
 mdsmith's docs live in four homes that match the
 [Diátaxis](https://diataxis.fr/) compass:
-`docs/guides/` (how-to and tutorial),
+`docs/tutorials/` (tutorial),
+`docs/guides/` (how-to),
 `docs/reference/` (reference), and
 `docs/background/` (explanation). Each type has a
 different audience in a different mode — and a

--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -117,8 +117,7 @@ One page, one type.
   outcome → next steps.
 - **Banned**: explanation of why; API
   exhaustiveness; alternative paths.
-- **Home**: `docs/guides/` (mdsmith does not
-  separate `tutorials/` from `guides/` today).
+- **Home**: `docs/tutorials/`.
 
 ### How-to guide — task-oriented (application × action)
 
@@ -357,10 +356,11 @@ Rewriting rules:
 
 ## Project conventions to respect
 
-- **Front matter.** Every page carries `title`
-  and `summary`. Plan files also carry
-  `status:`. Do not invent new keys without a
-  schema entry.
+- **Front matter.** Most pages carry `title` and
+  `summary`. CLI reference pages use `command` and
+  `summary` (per the `cli-command` kind schema).
+  Plan files also carry `status`. Do not invent
+  new keys without a schema entry.
 - **Voice from CLAUDE.md.** Descriptions name
   *what data must satisfy what condition*. Name
   the inputs (front matter fields, glob, heading

--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -206,11 +206,20 @@ One page, one type.
 ### fragments
 
 1. Read the file. Classify the type.
-2. Derive `title:` and `summary:` from the body
-   using the per-type formula.
-3. Print three link-text candidates and one
+2. Read the file's resolved kind via `mdsmith
+   kinds resolve <path>` (or read the kind body)
+   to learn which front-matter keys its schema
+   declares.
+3. Derive `summary:` for every page using the
+   per-type formula. Derive a body H1 candidate
+   using the per-type title formula. Emit
+   `title:` only when the kind schema declares
+   it; emit `command:` for the `cli-command`
+   kind.
+4. Print three link-text candidates and one
    hover blurb (≤120 chars).
-4. Patch the front matter if the user accepts.
+5. Patch the front matter if the user accepts;
+   set or rewrite the H1 separately if needed.
 
 ## Fragment formulas
 
@@ -250,9 +259,19 @@ Rules that apply to every type:
 - No marketing adjectives (powerful, seamless,
   comprehensive, robust, …).
 
-### `title` / H1
+### Page title — the body H1
 
-The H1 and the `title` front matter agree.
+mdsmith docs carry the page title as the first
+body H1 and keep only `summary` in front matter
+(see `internal/release/syncdocs.go`, which lifts
+the H1 into `title:` when syncing to Hugo). So
+`title:` front matter is only emitted when a
+kind's schema declares it (e.g. CLI reference
+pages use `command:` instead; some legacy pages
+carry `title:`). The body H1 is the default
+surface for the title.
+
+The H1 still follows a per-type formula:
 
 - **Tutorial**: activity-framed verb phrase.
 - **How-to**: bare-infinitive verb phrase.
@@ -356,11 +375,16 @@ Rewriting rules:
 
 ## Project conventions to respect
 
-- **Front matter.** Most pages carry `title` and
-  `summary`. CLI reference pages use `command` and
-  `summary` (per the `cli-command` kind schema).
-  Plan files also carry `status`. Do not invent
-  new keys without a schema entry.
+- **Front matter.** Every page carries `summary`.
+  The page title lives in the body H1 by default;
+  the release pipeline lifts it into `title:` when
+  syncing to Hugo (`internal/release/syncdocs.go`).
+  A page emits `title:` in front matter only when
+  its kind schema declares it. CLI reference
+  pages use `command` + `summary` (the
+  `cli-command` kind). Plan files also carry
+  `status`. Do not invent new keys without a
+  schema entry.
 - **Voice from CLAUDE.md.** Descriptions name
   *what data must satisfy what condition*. Name
   the inputs (front matter fields, glob, heading

--- a/.claude/skills/docs-author/SKILL.md
+++ b/.claude/skills/docs-author/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: docs-author
+description: >-
+  Write Markdown documentation that picks the right
+  Diátaxis type (tutorial, how-to, reference,
+  background), derives matching title and summary
+  fragments, and passes a global-English and
+  anti-slop polish. Trigger when the user asks to
+  "draft a doc", "write a how-to", "draft a
+  reference", "write a background page", "rewrite
+  this in the house voice", "summary for this
+  page", "title for this page", "polish for
+  non-native readers", "this reads like AI",
+  "remove AI tells / slop", or "what type of doc
+  is this". Skip this skill for content-rule fixes
+  (line length, heading hygiene, readability) —
+  those are enforced by `mdsmith check`.
+user-invocable: true
+argument-hint: "[draft | revise | fragments]"
+allowed-tools: >-
+  Bash(mdsmith:*),
+  Bash(go run ./cmd/mdsmith:*),
+  Bash(ls:*),
+  Bash(find:*),
+  Bash(grep:*),
+  Bash(git ls-files:*)
+---
+
+mdsmith's docs live in four homes that match the
+[Diátaxis](https://diataxis.fr/) compass:
+`docs/guides/` (how-to and tutorial),
+`docs/reference/` (reference), and
+`docs/background/` (explanation). Each type has a
+different audience in a different mode — and a
+different voice that follows from that. This skill
+picks the type, writes to its rules, and emits the
+fragments the catalog and LSP already consume.
+
+Two filters run on every draft on top of the
+type-specific rules:
+
+- **Global English** — short sentences, active
+  voice, controlled vocabulary, no idioms — so a
+  non-native reader can parse the page on a first
+  pass.
+- **Anti-slop** — block the vocabulary, phrasing,
+  and structure patterns that read as
+  LLM-generated. The catalog lives in
+  `slop-patterns.md` (sibling file).
+
+## When to run this skill
+
+- Drafting a new doc page from a brief or a stub.
+- Revising an existing page that reads as
+  promotional, padded, or AI-shaped.
+- Generating fragments — `title`, `summary`, link
+  text, hover blurb — for a page that lacks them
+  or whose fragments do not match the page type.
+- Auditing a page whose type is unclear (a
+  reference that started explaining, a how-to that
+  drifted into background).
+
+Skip this skill for line-length, heading-style,
+table alignment, or other surface fixes — run
+`mdsmith fix` for those.
+
+## Modes
+
+Pass the mode as the skill argument.
+
+- **`draft`**. Take a brief plus an optional
+  target path, classify the type via the compass,
+  and write a new file under the matching
+  `docs/<area>/` subtree.
+- **`revise`** (default). Take an existing file,
+  re-classify it, rewrite to the type's voice and
+  shape, then run the global-English and
+  anti-slop passes.
+- **`fragments`**. Read a file's body and emit
+  `title:` and `summary:` front matter plus
+  candidate link text and hover blurb. No body
+  edits.
+
+Default to `revise` when no argument is given.
+
+## The compass — pick one of four types
+
+Apply two questions to every page. The answers
+fix the type and the voice.
+
+|                            | **Action** (doing) | **Cognition** (thinking) |
+| -------------------------- | ------------------ | ------------------------ |
+| **Acquisition** (studying) | tutorial           | background               |
+| **Application** (working)  | how-to             | reference                |
+
+- *Action or cognition?* — is the reader trying
+  to **do** a thing, or trying to **understand** a
+  thing?
+- *Acquisition or application?* — is the reader
+  **studying** (no prior competence assumed) or
+  **at work** (already competent, has a goal)?
+
+If the page is mixing two quadrants, split it.
+One page, one type.
+
+### Tutorial — learning-oriented (acquisition × action)
+
+- **Audience mode**: a learner with no prior
+  encounter. The author drives.
+- **Voice**: narrative, second person, present
+  tense. Concrete steps with a single, verifiable
+  outcome at the end.
+- **Title pattern**: activity-framed —
+  `Get started with mdsmith`, `Your first mdsmith
+  rule`. Never a noun phrase.
+- **Shape**: prerequisites → numbered steps →
+  outcome → next steps.
+- **Banned**: explanation of why; API
+  exhaustiveness; alternative paths.
+- **Home**: `docs/guides/` (mdsmith does not
+  separate `tutorials/` from `guides/` today).
+
+### How-to guide — task-oriented (application × action)
+
+- **Audience mode**: a competent practitioner who
+  arrived with a specific goal.
+- **Voice**: imperative. Goal-named. Minimal
+  scaffolding.
+- **Title pattern**: bare-infinitive verb phrase —
+  `Install mdsmith on macOS`, `Migrate from
+  markdownlint`.
+- **Shape**: one goal → ordered steps → a verified
+  end state.
+- **Banned**: teaching the reader; reference
+  tables; explanations of design.
+- **Home**: `docs/guides/`.
+
+### Reference — information-oriented (application × cognition)
+
+- **Audience mode**: a working practitioner who
+  needs one fact, fast. Will scan, not read.
+- **Voice**: neutral, declarative, exhaustive. No
+  narrative. No opinions. No "you".
+- **Title pattern**: canonical noun phrase or
+  identifier — `` `mdsmith check` ``, `Glob
+  patterns`, `Section schema`.
+- **Shape**: identifier → one-line definition →
+  parameters/fields table → exit codes / errors →
+  examples → see also.
+- **Banned**: rhetorical framing; tutorial steps;
+  history; rationale.
+- **Home**: `docs/reference/`.
+
+### Background — understanding-oriented (acquisition × cognition)
+
+- **Audience mode**: a reader at study, building
+  a mental model. Willing to follow prose.
+- **Voice**: discursive, may compare alternatives
+  and discuss trade-offs. Still concrete.
+- **Title pattern**: noun phrase explaining the
+  thing — `How generated sections work`,
+  `Placeholder grammar`.
+- **Shape**: framing → concept → how it relates
+  to other concepts → when it matters → links to
+  reference and how-to.
+- **Banned**: ordered steps; CLI flag tables;
+  goal-naming.
+- **Home**: `docs/background/`.
+
+## Workflow
+
+### draft
+
+1. Read the brief. If the type is not stated,
+   apply the compass and name the type back to
+   the user.
+2. Pick the target path under
+   `docs/<area>/<slug>.md`. The slug must satisfy
+   the kind's `path-pattern:` if one is declared.
+3. Write the front matter first — `title`,
+   `summary` — using the per-type formulas in
+   `## Fragment formulas` below.
+4. Write the body to the type's shape. Lean on
+   existing pages in the same area as voice
+   templates.
+5. Run the global-English pass, then the
+   anti-slop pass (see below).
+6. Run `mdsmith check <path>` and fix anything it
+   surfaces.
+
+### revise
+
+1. Read the file. Classify the type via the
+   compass.
+2. If the file mixes types, ask the user before
+   continuing. Splitting is a structural change,
+   not a copy edit.
+3. Rewrite to the type's voice and shape.
+   Preserve the file's facts; replace the
+   prose around them.
+4. Refresh fragments (`title`, `summary`) if the
+   re-classification changed the type.
+5. Run the global-English pass, then the
+   anti-slop pass.
+6. Run `mdsmith check <path>`.
+
+### fragments
+
+1. Read the file. Classify the type.
+2. Derive `title:` and `summary:` from the body
+   using the per-type formula.
+3. Print three link-text candidates and one
+   hover blurb (≤120 chars).
+4. Patch the front matter if the user accepts.
+
+## Fragment formulas
+
+A page's `summary` is read three places: the
+catalog row that lists it, the LSP hover that
+previews it, and the search snippet that
+surfaces it. All three modes are scanning, not
+reading. Same formula for all three.
+
+The formulas below are per-type because the
+fragment carries the page's promise — and that
+promise is type-specific.
+
+### `summary` — one sentence, ≤ 25 words, ≤ 160 chars
+
+- **Tutorial**: state the outcome — "Build your
+  first mdsmith rule end to end, from failing
+  test to green check."
+- **How-to**: name the goal — "Install mdsmith
+  on macOS, Linux, and Windows via npm, mise, or
+  the GitHub release."
+- **Reference**: name the surface and its
+  contract — "CLI commands, flags, exit codes,
+  and output format."
+- **Background**: name the concept and what it
+  resolves — "How generated sections work —
+  markers, directives, and fix behavior."
+
+Rules that apply to every type:
+
+- Declarative. Not "this page covers…", not "in
+  this guide we will…".
+- One sentence. If two ideas need joining, the
+  page is two pages.
+- Concrete subject. No floating "it".
+- Active voice.
+- No marketing adjectives (powerful, seamless,
+  comprehensive, robust, …).
+
+### `title` / H1
+
+The H1 and the `title` front matter agree.
+
+- **Tutorial**: activity-framed verb phrase.
+- **How-to**: bare-infinitive verb phrase.
+- **Reference**: canonical noun phrase or
+  identifier; code-fenced if it is one.
+- **Background**: noun phrase explaining the
+  thing.
+
+### Link text and hover
+
+- **Link text**: never "click here", never the
+  raw filename. Verb-led for how-to/tutorial;
+  noun-led for reference/background.
+- **Hover blurb**: same content as `summary`,
+  capped at 120 chars for editor surfaces.
+
+## Global-English pass
+
+Run on every draft after the type-specific shape
+is in place. The rules come from Simplified
+Technical English ([ASD-STE100][ste]) and the
+Plain Language standard
+([ISO 24495-1:2023][iso24495]); they are tuned so
+a non-native reader can parse on a first read.
+
+[ste]: https://en.wikipedia.org/wiki/Simplified_Technical_English
+[iso24495]: https://www.iso.org/standard/78907.html
+
+- **One concept, one word.** Pick one of
+  *configure / set up / set* per page and stick.
+  No synonym shuffle.
+- **Sentence cap.** ≤ 20 words in procedural
+  text (how-to, tutorial, reference). ≤ 25 in
+  background. Split when over.
+- **Active voice by default.** Passive only when
+  the agent is unknown or irrelevant.
+- **Concrete subject.** No floating *it* or
+  *this*; name the thing.
+- **No idioms, no phrasal-verb-where-a-verb-works.**
+  *Set up → configure. Find out → learn. Figure
+  out → determine. Look into → investigate.*
+- **Define jargon at first use** or link to a
+  reference page that does.
+- **Positive constructions.** *Disconnect before
+  X* beats *do not stay connected during X*.
+- **Parallel structure.** Lists and headings
+  share a grammatical shape — all verb phrases,
+  or all noun phrases, never mixed.
+- **One sentence per line in source.** mdsmith
+  wraps; the source line break does not.
+
+## Anti-slop pass
+
+Run after the global-English pass. The catalog
+lives in `slop-patterns.md`. Load it, then walk
+the draft against each category. The catalog
+covers:
+
+- **Vocabulary tells** — overused LLM words.
+- **Phrasal tells** — set phrases.
+- **Sentence openers** — banned at sentence
+  start.
+- **Structural tells** — rule-of-three garnish,
+  the hedging seesaw, meta-narration.
+- **Tone tells** — promotional, obsequious,
+  padded.
+- **Formatting tells** — bulleted lists with
+  bolded label-and-colon openers used as the
+  default rhythm; em-dash overuse.
+
+Rewriting rules:
+
+- **Catch the pattern, not the word.** Replacing
+  *delve* with *explore* yields different slop.
+  Recast the sentence so the word is not needed.
+- **Plain replaces clever.** Drop padded
+  qualifiers (*essentially, fundamentally,
+  ultimately*) without substitution.
+- **Cut meta-commentary.** "This document
+  explains…" → delete and start with the actual
+  content.
+- **Per-type allowances** — bulleted lists with
+  bolded openers are *allowed in reference*
+  (parameter tables in list form), *flagged
+  elsewhere* when used as default rhythm. The
+  rule of three is *allowed* when the three
+  items are genuinely the contents (e.g.
+  `check`, `fix`, `lsp`).
+
+## Tensions to know up front
+
+- **Em dashes.** Allowed; capped. ≤ 1 per
+  paragraph, ≤ 2 per page.
+- **Hedging language** (*may, in some cases*).
+  Allowed in background; restricted in how-to
+  and reference where the answer must be
+  definite.
+- **Bulleted lists with bolded labels.** Allowed
+  in reference, flagged elsewhere as default
+  rhythm.
+
+## Project conventions to respect
+
+- **Front matter.** Every page carries `title`
+  and `summary`. Plan files also carry
+  `status:`. Do not invent new keys without a
+  schema entry.
+- **Voice from CLAUDE.md.** Descriptions name
+  *what data must satisfy what condition*. Name
+  the inputs (front matter fields, glob, heading
+  level) — not just the mechanism. Avoid vague
+  verbs (*match, sync, reflect*) without saying
+  what is checked against what.
+- **Linter configuration.** Do not edit
+  `.mdsmith.yml` to make a draft pass. Rewrite
+  the draft.
+- **Generated sections.** Do not edit content
+  between `<?…?>` and `<?/…?>` markers. Edit the
+  directive parameters or the source file, then
+  `mdsmith fix`.
+
+## Notes
+
+- This skill writes prose; `markdown-audit`
+  audits structure (kinds, schemas, catalogs).
+  They compose: run `markdown-audit` first if the
+  page's home or kind is wrong, then this skill
+  for the writing.
+- The compass is a course-correction tool, not a
+  cage. Some pages legitimately straddle types —
+  a how-to with a one-paragraph background
+  preface, a reference with a worked example.
+  The test is: does the audience-mode stay the
+  same throughout? If not, split.
+- For every push-back from the user ("that's
+  intentional"), prefer leaving the prose alone
+  over adding a per-page exception. The skill is
+  advisory.

--- a/.claude/skills/docs-author/slop-patterns.md
+++ b/.claude/skills/docs-author/slop-patterns.md
@@ -1,0 +1,211 @@
+---
+title: Slop patterns
+summary: >-
+  Vocabulary, phrasing, structural, tone, and
+  formatting patterns the `docs-author` anti-slop
+  pass blocks. Each entry is a pattern the skill
+  rewrites at the sentence or paragraph level,
+  not a word the skill swaps in place.
+---
+# Slop patterns
+
+Patterns that mark prose as LLM-generated.
+
+The list is curated from
+[Wikipedia: Signs of AI writing][wp-signs] and
+the community anti-slop skills (`unslop`,
+`the-antislop`, `avoid-ai-writing`).
+
+Walk every draft against each section. Fix a hit
+by recasting the sentence — swapping the word
+leaves the same shape behind, and that shape is
+the tell.
+
+[wp-signs]: https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
+
+## Vocabulary tells
+
+Words that flag as LLM output. Avoid in any
+register; if one is the only right word for a
+fact, leave it — context decides.
+
+- delve, dive into, dive deep, deep dive
+- tapestry, landscape (figurative), realm
+- testament (to), stands as a testament
+- vibrant, pivotal, robust, seamless
+- leverage (as a verb), unlock, unleash, harness
+- embark, journey (figurative), navigate
+  (figurative)
+- foster, showcase, emphasize, enhance,
+  highlight, align with
+- crucial, essential, comprehensive, holistic
+- multifaceted, nuanced, intricate
+- paradigm, ecosystem, transformative
+- vital, profound, paramount
+
+Fix recipe: recast so the word is not the bearer
+of the claim. *"X plays a pivotal role"* → *"X
+does Y"*.
+
+## Phrasal tells
+
+Set phrases that flag the source.
+
+- "it's important to note that"
+- "it's worth mentioning that"
+- "in today's fast-paced world"
+- "in the digital age"
+- "in the realm of"
+- "in the world of"
+- "at its core"
+- "plays a crucial role"
+- "stands as a testament to"
+- "a deep dive into"
+- "ever-evolving X"
+- "as we navigate"
+- "harness the power of"
+- "unlock the potential of"
+- "embark on a journey"
+- "by understanding X, you can Y"
+- "when it comes to X"
+- "navigating the complexities of"
+
+Fix recipe: delete the framing; lead with the
+content the framing was hiding.
+
+## Sentence openers
+
+Banned as the first word of a sentence. Each
+shifts the sentence's job from claim to
+commentary.
+
+- Certainly,
+- Moreover,
+- Additionally,
+- Furthermore,
+- Indeed,
+- Notably,
+- Importantly,
+- Crucially,
+- Essentially,
+- Ultimately,
+- Fundamentally,
+- Basically,
+- In essence,
+- In conclusion,
+- To summarize,
+- To sum up,
+
+Fix recipe: drop the opener. If the sentence
+needs it to make sense, the sentence is doing
+two jobs — split it.
+
+## Structural tells
+
+Patterns of arrangement, not vocabulary.
+
+- **Rule-of-three garnish.** A trio of adjectives
+  or noun phrases used as decoration: *"clear,
+  concise, and compelling"*, *"fast, reliable,
+  and scalable"*. Allowed when the three items
+  are genuinely the contents (e.g. *`check`,
+  `fix`, `lsp`*); banned when they are filler.
+- **Hedging seesaw.** *"X isn't just Y — it's
+  Z"*, *"not just X but also Y"*, *"this isn't a
+  bug, it's a feature"*. Banned in any register.
+- **Meta-narration.** *"This document covers…"*,
+  *"In this guide we will…"*, *"Let's explore
+  how…"*. Banned. Start with the content.
+- **Uniform sentence length.** Every sentence
+  12–18 words. Read aloud; if rhythm is flat,
+  break the pattern — one short sentence breaks
+  it.
+- **Default scaffold.** *"First, …. Second, ….
+  Finally, …"* as the page's default skeleton.
+  Use a list instead.
+- **Recap block at the end.** *"In summary,
+  …"*, *"To recap, …"*, *"In conclusion,
+  …"*. Banned. The page either earned its end
+  or it did not.
+- **Bilateral framing.** *"On one hand X, on the
+  other hand Y"* as default rhythm. Use only
+  when both hands are genuinely the contents.
+
+## Tone tells
+
+- **Promotional / press-release.** *"powerful,
+  cutting-edge, industry-leading"*. Reference
+  pages especially must stay neutral.
+- **Obsequious.** *"Great question!"*,
+  *"Certainly!"*, *"I'd be happy to…"*. Banned.
+- **Padded qualifiers.** *essentially,
+  fundamentally, ultimately, basically, really,
+  simply, just*. Delete without substitution
+  unless the qualifier carries a real claim.
+- **Vague intensifiers.** *very, extremely,
+  incredibly, truly, quite*. Cut or replace
+  with a measurable claim.
+- **Promotional adjectives in `summary`.**
+  *powerful, seamless, comprehensive, robust,
+  effortless*. Banned in front matter — the
+  catalog row carries the page's promise and
+  must be factual.
+
+## Formatting tells
+
+- **Bulleted list of `**Label**: prose` items as
+  default rhythm.** Allowed in reference
+  (parameter tables in list form); flagged in
+  how-to, tutorial, and background when used as
+  the page's main shape.
+- **Em-dash overuse.** Cap at 1 per paragraph,
+  2 per page. Replace runs of em-dashes with
+  shorter sentences or parentheses.
+- **Emoji as bullet.** Banned. mdsmith front
+  matter uses `status: ✅` as data, not as
+  decoration; emoji never lead a list item.
+- **Code fences for non-code.** File paths,
+  identifiers, and command names belong in
+  inline backticks. Quoted prose belongs in
+  block quotes. Code fences are for code.
+- **Hashtag stacks.** Banned. The doc system has
+  no use for them.
+- **"Here are…" preambles.** *"Here are five
+  ways to …"*, *"Below are the steps to…"*.
+  Drop the preamble; lead with the list.
+
+## Per-type allowances
+
+A few patterns are slop *as default rhythm* and
+fine *as one tool among many*. The skill applies
+these per-type, not globally.
+
+- **Reference pages** — bulleted lists with
+  bolded label-and-colon openers are the canonical
+  form for parameter tables. Allowed.
+- **Background pages** — hedging language
+  (*may, in some cases, often*) is allowed
+  because the page legitimately discusses
+  trade-offs. The seesaw construction
+  (*"not just X, but Y"*) is still banned.
+- **Tutorial pages** — a closing "next steps"
+  block is fine; *"In conclusion,"* still is
+  not.
+- **How-to pages** — no allowances. How-tos are
+  the strictest register: imperative, declarative,
+  no decoration.
+
+## False positives
+
+Skip when the flagged word is one of these:
+
+- A code identifier (`Navigate`, `Foster`,
+  `Realm` — class or function names quoted
+  verbatim).
+- A direct quote from an external source.
+- A glossary or reference entry defining the
+  term itself ("**Tapestry** is a Java web
+  framework…").
+
+When in doubt, leave the prose and surface the
+finding to the user as a question.

--- a/PLAN.md
+++ b/PLAN.md
@@ -138,4 +138,5 @@ footer: |
 | 210 | ✅     | opus   | [Single source of truth for product messaging via `mdsmith extract`](plan/210_messaging-source-of-truth.md)                             |
 | 211 | 🔲     | opus   | [`<?include?>` projects any typed value of any kind via `extract`](plan/211_include-extract-value.md)                                   |
 | 212 | 🔲     | opus   | [`mdsmith extract` projects paragraph inline spans as data](plan/212_extract-inline-spans.md)                                           |
+| 213 | 🔲     | opus   | [Built-in `no-llm-tells` convention with append-mode forbidden lists](plan/213_anti-slop-convention.md)                                 |
 <?/catalog?>

--- a/plan/213_anti-slop-convention.md
+++ b/plan/213_anti-slop-convention.md
@@ -1,0 +1,240 @@
+---
+id: 213
+title: Built-in `no-llm-tells` convention with append-mode forbidden lists
+status: "🔲"
+model: opus
+depends-on: []
+summary: >-
+  Ship a built-in convention that enables MDS055 and
+  MDS056 with curated lists of LLM-writing tells
+  (banned words, phrases, paragraph starts), plus
+  tighter MDS023 / MDS024 thresholds for non-native
+  readers. Switch MDS055 `starts:` and MDS056
+  `contains:` to append-mode merge so projects can
+  extend the bundle without losing it.
+---
+# Built-in `no-llm-tells` convention with append-mode forbidden lists
+
+## Goal
+
+One config knob — `convention: no-llm-tells`.
+
+It enables a curated baseline of mechanical
+anti-slop checks. Three categories: banned
+vocabulary, banned phrases, banned sentence
+openers. It also tightens MDS023 and MDS024
+thresholds for non-native readers.
+
+## Background
+
+`docs-author` (`.claude/skills/docs-author/`)
+ships a catalog of LLM-writing tells in
+`slop-patterns.md`. The skill applies the catalog
+at write or revise time.
+
+Part of that catalog is mechanical. Banned words,
+banned phrases, banned paragraph openers — the kind
+of tells **MDS055 forbidden-paragraph-starts** and
+**MDS056 forbidden-text** can already check. A
+rule catches them in CI and in LSP without a model
+in the loop.
+
+The cleanest way to ship the mechanical layer is a
+new built-in convention. The
+[conventions reference](../docs/reference/conventions.md)
+already documents the pattern: an opinionated rule
+bundle behind one config key.
+
+One blocker: MDS055's `starts:` and MDS056's
+`contains:` are list settings, which replace by
+default per
+[CLAUDE.md's config merge semantics](../CLAUDE.md).
+A project that sets `convention: no-llm-tells` and
+then adds its own forbidden words would erase the
+built-in list. The convention is unusable until
+those keys merge by append.
+
+## Non-Goals
+
+- Detecting structural slop (rule-of-three
+  garnish, hedging seesaw, meta-narration,
+  uniform sentence length). Those stay in the
+  `docs-author` skill — they need contextual
+  judgement no `contains:` list can express.
+- Detecting tone slop (promotional voice,
+  obsequious phrasing, padded qualifiers).
+  Same — needs context.
+- Auto-generating the convention's lists from
+  `slop-patterns.md`. v1 hardcodes the lists in
+  Go; a follow-up plan can wire a generator if
+  drift becomes a problem.
+- Pinning a Markdown flavor. The convention
+  declares `Flavor: FlavorNone` (or the
+  least-restrictive option — see Open Questions)
+  so projects using GFM or Obsidian can still
+  opt in.
+
+## Design
+
+### Append-mode merge for forbidden lists
+
+Two rule packages opt their list settings into
+append-mode merge:
+
+- `internal/rules/MDS055-forbidden-paragraph-starts`
+  returns `MergeAppend` for `starts:`.
+- `internal/rules/MDS056-forbidden-text` returns
+  `MergeAppend` for `contains:`.
+
+Both implement `rule.ListMerger.SettingMergeMode(key)`.
+The placeholder
+vocabulary (MDS023 `placeholders:`) is the
+canonical reference implementation.
+
+After this change:
+
+- A user's `starts:` / `contains:` extends the
+  convention's list rather than replacing it.
+- Duplicate entries collapse to one (set-style
+  union).
+- Order is convention-first, then user (for
+  deterministic diagnostics when more than one
+  pattern matches at the same anchor).
+
+### Convention definition
+
+A new entry in
+`internal/convention/convention.go`:
+
+```go
+"no-llm-tells": {
+    Name: "no-llm-tells",
+    // Flavor: see Open Questions.
+    Rules: map[string]convention.RulePreset{
+        "forbidden-text": {
+            Enabled: true,
+            Settings: map[string]any{
+                "contains": llmVocabularyAndPhrases(),
+            },
+        },
+        "forbidden-paragraph-starts": {
+            Enabled: true,
+            Settings: map[string]any{
+                "starts": llmParagraphOpeners(),
+            },
+        },
+        "paragraph-structure": {
+            Enabled: true,
+            Settings: map[string]any{
+                "max-words-per-sentence": 25,
+            },
+        },
+        "paragraph-readability": {
+            Enabled: true,
+            Settings: map[string]any{"max-index": 12.0},
+        },
+        "descriptive-link-text": {Enabled: true},
+    },
+},
+```
+
+The two list helpers live next to the convention
+entry. v1 hardcodes their contents. The source is
+`.claude/skills/docs-author/slop-patterns.md` —
+its "Vocabulary tells", "Phrasal tells", and
+"Sentence openers" sections.
+
+### Source-of-truth note
+
+For v1, `slop-patterns.md` and the convention
+helpers carry parallel lists. A short comment
+above each helper points readers to
+`slop-patterns.md`; a short note in
+`slop-patterns.md` points back. A drift-checker
+test (see Tasks) asserts the rule lists are a
+subset of the skill catalog so the two cannot
+silently diverge.
+
+## Open Questions
+
+- **Flavor pinning.** Built-in conventions all pin
+  a flavor today. Anti-slop is renderer-agnostic;
+  pinning would force any user of this convention
+  off GFM. Options: (a) leave the convention's
+  `Flavor` unset and teach the loader to allow
+  that; (b) pin `commonmark` like `plain` and
+  document the trade-off; (c) ship one variant per
+  flavor (`no-llm-tells`, `no-llm-tells-gfm`).
+  Default: (a). User to confirm.
+- **Convention name.** Working title is
+  `no-llm-tells`. Alternatives: `plain-prose`,
+  `clear-prose`, `low-slop`, `house-voice`. User
+  to confirm before the plan moves to 🔳.
+- **Default severity.** MDS055 / MDS056 emit
+  Error today. Should the convention preset them
+  to Warning, given the heuristic nature of slop
+  detection? Default: leave at Error to match the
+  other rules; projects can downgrade per rule.
+
+## Tasks
+
+1. **MDS055 / MDS056 list-merger.** Implement
+   `SettingMergeMode("starts") == MergeAppend` on
+   MDS055 and `SettingMergeMode("contains") ==
+   MergeAppend` on MDS056. Add a failing unit
+   test asserting that a layered config (kind +
+   override) unions the lists rather than
+   replacing. Make it pass.
+2. **Convention entry.** Add `"no-llm-tells"` to
+   `conventions` in
+   `internal/convention/convention.go`. Add a
+   convention-loader unit test that loads it,
+   confirms the right rules are enabled, and
+   confirms the lists deep-merge with a user's
+   own forbidden entries.
+3. **Forbidden lists.** Add the curated word /
+   phrase / opener lists as package-level
+   functions next to the convention entry. Source
+   from `slop-patterns.md`.
+4. **Drift-checker test.** Integration test that
+   reads `.claude/skills/docs-author/slop-patterns.md`,
+   extracts the items under "Vocabulary tells",
+   "Phrasal tells", and "Sentence openers", and
+   asserts the convention's lists are a subset of
+   each. Fails CI when one source drifts from the
+   other.
+5. **Docs.** Add a `no-llm-tells` section to
+   [`docs/reference/conventions.md`](../docs/reference/conventions.md)
+   matching the format of `portable` / `github` /
+   `obsidian` / `plain`. Add a short pointer from
+   `slop-patterns.md` back to the convention.
+6. **Skill update.** Add a one-paragraph note to
+   `.claude/skills/docs-author/SKILL.md`
+   explaining that the mechanical layer ships as
+   the `no-llm-tells` convention, and that
+   `mdsmith check` enforces it without the skill
+   in the loop. The skill still owns the
+   structural / tone / formatting passes.
+
+## Acceptance Criteria
+
+- [ ] `convention: no-llm-tells` in a project's
+      `.mdsmith.yml` enables MDS055, MDS056,
+      MDS024, MDS023, and MDS063 with the
+      documented settings.
+- [ ] A project that also sets `rules.forbidden-text.contains:`
+      with extra strings unions its list with the
+      convention's list; neither side is dropped.
+- [ ] Same for `rules.forbidden-paragraph-starts.starts:`.
+- [ ] The drift-checker test fails when an item
+      is removed from either source.
+- [ ] `mdsmith check .` against a fixture with
+      "delve" or "It's important to note that"
+      produces an MDS056 diagnostic.
+- [ ] `mdsmith check .` against a fixture
+      starting a paragraph with "Certainly," or
+      "Moreover," produces an MDS055 diagnostic.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no
+      issues.
+- [ ] `mdsmith check .` passes.


### PR DESCRIPTION
## Summary

Introduces the `docs-author` skill, a comprehensive guide for writing and revising Markdown documentation that follows the Diátaxis framework. The skill provides structured guidance for classifying documentation into four types (tutorial, how-to, reference, background), enforces a consistent voice and shape per type, and applies global-English and anti-slop filters to all output.

## Changes

- **SKILL.md** — Complete skill definition covering:
  - When to invoke the skill (drafting, revising, generating fragments)
  - Three operational modes: `draft` (new pages), `revise` (existing pages), `fragments` (metadata only)
  - The Diátaxis compass: a 2×2 matrix (action/cognition × acquisition/application) that determines documentation type
  - Detailed rules for each type: audience mode, voice, title patterns, shape, and banned content
  - Workflow steps for each mode
  - Fragment formulas for `title` and `summary` front matter, with per-type rules
  - Global-English pass rules (sentence length, active voice, concrete subjects, no idioms, parallel structure)
  - Project conventions to respect (front matter keys, voice from CLAUDE.md, linter configuration, generated sections)

- **slop-patterns.md** — Catalog of LLM-generated prose patterns to avoid:
  - Vocabulary tells (delve, tapestry, leverage, embark, etc.)
  - Phrasal tells ("it's important to note that", "in today's fast-paced world", etc.)
  - Banned sentence openers (Certainly, Moreover, Additionally, etc.)
  - Structural tells (rule-of-three garnish, hedging seesaw, meta-narration, uniform sentence length, etc.)
  - Tone tells (promotional language, obsequious phrasing, padded qualifiers, vague intensifiers)
  - Formatting tells (bulleted lists with bolded labels as default, em-dash overuse, emoji bullets, etc.)
  - Per-type allowances (e.g., bolded labels allowed in reference, hedging allowed in background)
  - False positives to skip (code identifiers, direct quotes, glossary entries)

## Implementation Details

- The skill is user-invocable and accepts an optional argument (`draft`, `revise`, or `fragments`) to control behavior
- Allowed tools are restricted to mdsmith commands and basic Unix utilities (bash, ls, find, grep, git)
- The compass is presented as a decision tree to help classify ambiguous pages and split pages that mix types
- Fragment formulas are declarative and concrete, avoiding marketing language and vague framing
- The anti-slop pass is pattern-based rather than word-based, encouraging recasting of sentences rather than simple substitution
- Tensions (em-dashes, hedging, bulleted lists) are acknowledged with explicit caps and per-type rules
- The skill composes with other tools: `mdsmith check` for surface fixes, `markdown-audit` for structural issues

https://claude.ai/code/session_015c1PuqtTScHFmKxFsx1Lko