### PR TITLE
Extend pick-plan with dep filtering, ranking, and Agent hand-off

### DIFF
--- a/.claude/skills/pick-plan/SKILL.md
+++ b/.claude/skills/pick-plan/SKILL.md
@@ -37,8 +37,10 @@ All paths below are relative to the repository root.
 ## When to use
 
 Run when the user wants to start fresh work. If the
-user already named a specific plan number, validate
-it (steps 1–3) then jump to step 6.
+user already named a specific plan number, do not
+skip ahead — step 5 still runs that id through the
+full status/branch/PR/dependency validation before
+the workflow moves on to step 6.
 
 ## Prerequisites
 
@@ -160,11 +162,20 @@ Run one `git show` per non-completed plan. The line
 is `depends-on: [146, 147]` (inline YAML); parse the
 integers between the brackets.
 
-Build two maps from the results:
+Build two maps from the results. Key plan records by
+filename, not by id — the catalog has duplicate plan
+ids and two plans sharing an id must not collapse to
+one node:
 
-- `deps[id]` → the list of plan ids this plan needs.
-- `dependents[id]` → count of other `🔲`/`🔳` plans
-  whose `deps[*]` includes this id.
+- `deps[filename]` → list of plan ids this plan
+  needs.
+- `dependents[id]` → count of plan-files whose
+  `deps` includes this id. A single id may resolve
+  to multiple filenames when duplicates exist; the
+  dependents count sums every plan-file that points
+  at that id, regardless of which duplicate they
+  meant. That's the safe direction — a dep is "met"
+  only when every plan sharing that id is `✅`.
 
 Skip the duplicate-id problem by reading by filename
 (you already have it from PLAN.md). If a plan's
@@ -218,8 +229,12 @@ important** when a plan fits both:
 
 Take the top 2 from each bucket for the menu. If one
 bucket has fewer than 2, fill from the other while
-keeping each bucket's internal order. Cap the menu
-at 4 options.
+keeping each bucket's internal order. Cap the
+`options` array you pass to `AskUserQuestion` at 4 —
+that is the tool's hard limit. The tool then renders
+an "Other" choice automatically on top of those, so
+the user always has a free-text fallback; you do not
+add it to `options` yourself.
 
 Use `AskUserQuestion` with each option labeled like:
 
@@ -230,8 +245,9 @@ Use `AskUserQuestion` with each option labeled like:
 Include the model tag so the user sees which model
 the implementation Agent will spawn at.)
 
-If the user picks "Other," accept a plan number from
-free-text and run the same dep-check validation.
+If the user picks the auto-rendered "Other," accept a
+plan number from free-text and run the same dep-check
+validation.
 
 If after filtering there's only one available plan,
 ask a yes/no `Start plan N now?` instead of a menu.

--- a/.claude/skills/pick-plan/SKILL.md
+++ b/.claude/skills/pick-plan/SKILL.md
@@ -1,46 +1,52 @@
 ---
 name: pick-plan
 description: >-
-  Pick the next plan to start work on. Reads PLAN.md from
-  origin/main, lists plans by status (completed, in
-  progress, not started), cross-references open PRs and
-  existing branches, asks which plan to start, then
-  creates a branch and opens a draft PR. Use when asked
-  to "pick a plan", "start the next plan", "what plan
-  should I work on", "begin a new plan", or "open a draft
-  PR for plan N".
+  Pick the next plan to start work on. Reads PLAN.md
+  from origin/main, cross-references open PRs and
+  existing branches, reads each non-completed plan's
+  `depends-on:` frontmatter, filters out plans whose
+  dependencies are not yet completed, splits the rest
+  into "structurally important" (other plans depend
+  on them) and "quick wins" (smaller-model plans),
+  presents the top 4, then creates a branch, opens a
+  draft PR, and dispatches an implementation Agent at
+  the model the plan declares. Use when asked to
+  "pick a plan", "start the next plan", "what plan
+  should I work on", "begin a new plan", or "open a
+  draft PR for plan N".
 user-invocable: true
 allowed-tools: >-
   Bash(git fetch:*), Bash(git show:*), Bash(git branch:*),
-  Bash(git checkout:*), Bash(git commit:*),
-  Bash(git push:*), Bash(git rev-parse:*),
-  Bash(git remote:*), Bash(sleep:*),
-  Bash(gh pr:*), Bash(gh api:*),
-  AskUserQuestion
+  Bash(git ls-tree:*), Bash(git checkout:*),
+  Bash(git commit:*), Bash(git push:*),
+  Bash(git rev-parse:*), Bash(git remote:*),
+  Bash(sleep:*), Bash(gh pr:*), Bash(gh api:*),
+  AskUserQuestion, Agent
 argument-hint: "[plan number]"
 ---
 
-Surface the next plan to start. Read `PLAN.md` from
-`origin/main`. Cross-reference existing branches and
-open PRs. Ask the user which plan to pick. Create the
-branch and open a draft PR.
+Surface the next plan. Filter out the ones blocked
+by unfinished dependencies. Rank the rest into
+"structurally important" and "quick wins" and let
+the user pick. Create the branch and open a draft
+PR. Hand the implementation off to an Agent at the
+model the plan declares.
 
 All paths below are relative to the repository root.
 
 ## When to use
 
-Run when the user wants to start fresh work and needs to
-know which plans are unclaimed. If the user already named
-a specific plan number, validate it (steps 1–2) then jump
-to step 5.
+Run when the user wants to start fresh work. If the
+user already named a specific plan number, validate
+it (steps 1–3) then jump to step 6.
 
 ## Prerequisites
 
 This skill assumes the clone tracks `jeduden/mdsmith`
 directly and the user has push access to it. The PR
-queries (steps 2 and 5) and the PR-create call
-(step 7) all target that repo by name, while the push
-in step 6 goes to `origin`. If `origin` is a fork,
+queries (steps 2 and 6) and the PR-create call
+(step 8) all target that repo by name, while the push
+in step 7 goes to `origin`. If `origin` is a fork,
 those two ends don't line up and `gh pr create` fails
 because the head branch never reaches the target.
 
@@ -140,44 +146,107 @@ derive plan ids from:
 
 Annotate each non-completed plan with any matching PR.
 
-### 3. Report status to the user
+### 3. Read `depends-on:` for every non-✅ plan
+
+For each plan with status `🔲` or `🔳`, read the file
+from `origin/main` and extract its `depends-on:`
+frontmatter list. Treat a missing key as `[]`.
+
+```bash
+git show origin/main:plan/<id>_<slug>.md
+```
+
+Run one `git show` per non-completed plan. The line
+is `depends-on: [146, 147]` (inline YAML); parse the
+integers between the brackets.
+
+Build two maps from the results:
+
+- `deps[id]` → the list of plan ids this plan needs.
+- `dependents[id]` → count of other `🔲`/`🔳` plans
+  whose `deps[*]` includes this id.
+
+Skip the duplicate-id problem by reading by filename
+(you already have it from PLAN.md). If a plan's
+`depends-on:` references an id that isn't in
+PLAN.md at all (typo, deleted plan), treat that dep
+as unmet so the plan stays blocked until someone
+fixes the typo — don't silently ignore it.
+
+### 4. Report status to the user
 
 Print a short summary in this order:
 
 1. `🔳 in progress` — plan id, title, model, matching
-   branches, and any PR number. If none of these exist,
-   note that the plan is marked in-progress but no one
-   has pushed yet.
-2. `🔲 not started, claimed` — branch or PR exists but
-   the catalog still says not-started. Flag these; do
-   not propose starting them.
-3. `🔲 available to start` — no branch, no PR. This is
-   the menu.
+   branches, and any PR number. If none of these
+   exist, note that the plan is marked in-progress
+   but no one has pushed yet.
+2. `🔲 not started, claimed` — branch or PR exists
+   but the catalog still says not-started. Flag
+   these; do not propose starting them.
+3. `🔲 blocked by deps` — list the plan id and which
+   unmet deps it's waiting on (use the ids from
+   `deps`, mark each unmet dep with its status,
+   e.g. `103 (🔲)`). Do not propose starting these.
+4. `🔲 available to start` — no branch, no PR, all
+   deps `✅`. This is the menu source.
 
-Mention the completed count as a single line (e.g.
-`106 completed`), not the list.
+Mention the completed count as a single line
+(e.g. `106 completed`), not the list.
 
-### 4. Ask which plan to start
+### 5. Categorize available plans and ask which to start
 
-If the user passed a plan number as an argument, skip the
-question and validate it: must be `🔲`, no branch, no PR.
+If the user passed a plan number as an argument, skip
+the question and validate it: must be `🔲`, no branch,
+no PR, and every `depends-on:` id must be `✅`. If
+the dep check fails, list the unmet deps and stop —
+don't auto-pick a different plan.
 
-Otherwise use `AskUserQuestion` with up to four
-available plans, preferring the lowest ids (usually the
-oldest open work). Put the model tag in each label so
-the user sees the recommendation at a glance — for
-example: `102 [opus] — Builder interface and mdsmith
-build subcommand`.
+Otherwise sort the available set into two buckets.
+A plan can qualify for both. Prefer **Structurally
+important** when a plan fits both:
+
+- **Structurally important** — `dependents[id] > 0`.
+  Other open plans are waiting on this one. Sort
+  by `dependents` desc, then id asc.
+- **Quick wins** — smaller-model plans, sorted by the
+  plan's frontmatter `model:` field with `haiku`
+  before `sonnet` before `opus` before empty/missing,
+  then id asc. The model tag in PLAN.md is the
+  proxy for plan size; an empty field means
+  "unranked", treat it as the largest.
+
+Take the top 2 from each bucket for the menu. If one
+bucket has fewer than 2, fill from the other while
+keeping each bucket's internal order. Cap the menu
+at 4 options.
+
+Use `AskUserQuestion` with each option labeled like:
+
+- `🏗 102 [opus] — Builder interface and mdsmith build subcommand`
+- `⚡ 207 [sonnet] — LSP fix preview`
+
+(`🏗` for structurally important, `⚡` for quick wins.
+Include the model tag so the user sees which model
+the implementation Agent will spawn at.)
 
 If the user picks "Other," accept a plan number from
-free-text and run the same validation.
+free-text and run the same dep-check validation.
 
-### 5. Check for closed PRs on this plan
+If after filtering there's only one available plan,
+ask a yes/no `Start plan N now?` instead of a menu.
 
-Step 2 only sees open PRs. Before creating the branch,
-sweep for closed PRs that referenced this plan — they
-catch abandoned attempts and the rare case where a
-plan is actually merged but PLAN.md is stale.
+If the filtered set is empty, report that every
+unblocked plan is either claimed or waiting on deps
+and stop.
+
+### 6. Sanity-check for closed PRs on this plan
+
+Step 2 only sees open PRs. Before creating the
+branch, sweep for closed PRs that referenced this
+plan — they catch abandoned attempts and the rare
+case where a plan is actually merged but PLAN.md is
+stale.
 
 Call:
 
@@ -205,7 +274,7 @@ For each hit, read `.mergedAt`:
 
 If no hits, proceed.
 
-### 6. Create the branch
+### 7. Create the branch
 
 Branch name: `plan-<id>-<slug>`, where `<slug>` is the
 plan filename with the leading `<id>_` and trailing
@@ -225,7 +294,8 @@ git fetch origin main
 git checkout -b plan-<id>-<slug> origin/main
 ```
 
-Make an empty marker commit so the branch can host a PR:
+Make an empty marker commit so the branch can host a
+PR:
 
 ```bash
 git commit --allow-empty -m "Start plan <id>: <title>"
@@ -235,14 +305,15 @@ git commit --allow-empty -m "Start plan <id>: <title>"
 git push -u origin plan-<id>-<slug>
 ```
 
-If the push fails with a network error, retry up to four
-times with 2s / 4s / 8s / 16s exponential backoff.
+If the push fails with a network error, retry up to
+four times with 2s / 4s / 8s / 16s exponential
+backoff.
 
-### 7. Open the draft PR
+### 8. Open the draft PR
 
-Title format: `Plan <id>: <title>` — matches the existing
-convention (`Plan 200: move docs/ embed out of
-internal/lsp/hover.go`).
+Title format: `Plan <id>: <title>` — matches the
+existing convention (`Plan 200: move docs/ embed out
+of internal/lsp/hover.go`).
 
 Pipe the body in via `--body-file -` so `gh` is the
 only command in the call (no `$(cat ...)` subshell
@@ -261,43 +332,150 @@ acceptance criteria are checked off.
 EOF
 ```
 
-Report the PR URL back to the user and stop. They can
-run `/pr-fixup` once real changes are pushed.
+Capture the PR number from the output for step 10.
+
+### 9. Suggest a session name
+
+No programmatic API can set a Claude Code web
+session's title from inside the session. Tell the
+user, in one line, to run the slash command. That
+makes the session findable in the picker and the
+mobile app:
+
+```text
+Suggested session name. Run:
+/rename plan-<id>-<slug>
+```
+
+Print it once, don't loop. The user runs it (or
+doesn't); either way, proceed to step 10.
+
+### 10. Dispatch the implementation Agent at the plan's model
+
+Read the plan's frontmatter `model:` field. Map it to
+the Agent tool's `model` parameter:
+
+| frontmatter | Agent `model`                                     |
+| ----------- | ------------------------------------------------- |
+| `haiku`     | `haiku`                                           |
+| `sonnet`    | `sonnet`                                          |
+| `opus`      | `opus`                                            |
+| empty/`""`  | `opus` (default — biggest model for unsized work) |
+
+Spawn one `Agent` call with `subagent_type: "claude"`,
+`model` set per the table above, and a self-contained
+prompt. The Agent has no view of this conversation,
+so the prompt must include: plan id, plan title,
+plan file path, branch name, draft PR number, and
+the implementation discipline. Use this shape:
+
+```text
+Implement plan <id>: <title>.
+
+Branch `plan-<id>-<slug>` is already checked out from
+`origin/main` with one empty marker commit, and draft
+PR #<pr-num> on jeduden/mdsmith is open against it.
+Do not recreate the branch or PR.
+
+Read plan/<id>_<slug>.md. Work through its `## Tasks`
+section using red/green TDD: write a failing test,
+make it pass, commit. Keep commits small and focused
+on one change.
+
+Plan maintenance: in your first real commit, edit the
+plan's frontmatter `status:` from `🔲` to `🔳` and
+run `mdsmith fix PLAN.md` so the catalog reflects it.
+Check off tasks and acceptance criteria as you verify
+them — update the plan file as part of implementation,
+not as a follow-up.
+
+Before every commit, run `mdsmith check .` (must pass)
+and `go test ./...` for any package you touched. Do
+not modify `.mdsmith.yml`. Push after each commit
+with `git push -u origin plan-<id>-<slug>`.
+
+When every acceptance criterion is checked off, move
+the frontmatter `status:` from `🔳` to `✅`, run
+`mdsmith fix PLAN.md`, push, then return a summary:
+final commit count, files touched, and any deviations
+from the plan that you made along the way. Don't
+mark the PR ready for review — leave that to the
+user.
+
+If you hit a design decision the plan doesn't pin
+down, stop and surface it in your return message
+instead of guessing.
+```
+
+Set `description` to `Implement plan <id>` (short,
+since this is what shows in the Agent's status line).
+
+When the Agent returns, relay its summary to the user
+in two or three sentences plus the PR URL from step 8.
+The user can then run `/pr-fixup` to babysit CI and
+review comments.
 
 ## Gotchas
 
-- **Plan-id boundary matching.** Match plan ids with a
-  non-digit boundary on both sides so plan 102 doesn't
-  also match a `plan-1020-…` branch. This applies both
-  to the branch scan and to the PR title scan.
-- **Duplicate plan ids exist.** Two `121`s, two `153`s,
-  two `156`s. If a duplicate id ever surfaces as `🔲`,
-  ask which file the user means. The slug disambiguates.
+- **Plan-id boundary matching.** Match plan ids with
+  a non-digit boundary on both sides so plan 102
+  doesn't also match a `plan-1020-…` branch. This
+  applies to the branch scan, the PR title scan, and
+  the `depends-on:` parse.
+- **Duplicate plan ids exist.** Two `121`s, two
+  `153`s, two `156`s. If a duplicate id ever surfaces
+  as `🔲`, ask which file the user means. The slug
+  disambiguates. Always key the dependency graph by
+  filename, not just id, so a duplicate doesn't
+  collapse two plans into one node.
 - **`origin/main` may be stale.** Always fetch first.
-  Step 1 does this, but if you re-run later parts of the
-  workflow, re-fetch.
-- **Empty start commit.** Step 6 makes an empty commit
-  so the draft PR has something to point at. Do not
-  amend it — keep it as the marker that work began, and
-  stack real commits on top.
-- **Catalog format drift.** The row format above is the
-  contract. If PLAN.md ever renders a different shape
-  (extra column, missing model field), update this skill
-  before pushing — don't paper over it with looser
-  parsing.
+  Step 1 does this, but if you re-run later parts of
+  the workflow, re-fetch.
+- **Empty start commit.** Step 7 makes an empty
+  commit so the draft PR has something to point at.
+  Do not amend it — keep it as the marker that work
+  began, and stack real commits on top.
+- **Catalog format drift.** The row format above is
+  the contract. If PLAN.md ever renders a different
+  shape (extra column, missing model field), update
+  this skill before pushing — don't paper over it
+  with looser parsing.
+- **Empty `model:`.** Treat an empty or missing
+  frontmatter `model:` as `opus` when dispatching the
+  Agent. Don't ask the user to pick a model — the
+  whole point is that the plan declares it.
+- **Session rename is advisory.** The skill can't
+  call `/rename` for the user; the slash command
+  only runs when typed into the prompt bar. Step 9
+  prints the suggestion and moves on.
 
 ## Troubleshooting
 
-- **Zero plans parsed**: the `<?catalog?>` row template
-  in PLAN.md was edited. Open
+- **Zero plans parsed**: the `<?catalog?>` row
+  template in PLAN.md was edited. Open
   [PLAN.md](../../../PLAN.md), check the catalog
-  directive's `row:` line, and adjust step 1's column
-  expectations to match.
-- **`git fetch` hangs**: a proxy is broken. Either fix
-  the network or skip the fetch and use whatever
+  directive's `row:` line, and adjust step 1's
+  column expectations to match.
+- **`git fetch` hangs**: a proxy is broken. Either
+  fix the network or skip the fetch and use whatever
   `origin/main` you have cached — the rest of the
   workflow still works, the catalog just might be
   stale.
+- **Every available plan is blocked**: step 5 reports
+  the empty set. Look at the `🔲 blocked by deps`
+  list from step 4 — the unblocking work is whichever
+  in-progress (`🔳`) plan is named in those `deps`
+  entries. Suggest the user finish that one first
+  rather than picking around it.
+- **Agent dispatched at the wrong model**: re-read
+  the plan's frontmatter directly with
+  `git show origin/main:plan/<id>_<slug>.md` and
+  confirm the `model:` field. If the plan says one
+  model and the Agent ran at another, the mapping
+  table in step 10 was misapplied — fix the call,
+  don't try to "switch model" inside the running
+  Agent (it can't).
 - **`AskUserQuestion` complains about option count**:
-  it accepts 2–4 options. If only one plan is
-  available, ask a yes/no `Start plan N now?` instead.
+  it accepts 2–4 options. Step 5 covers the
+  single-option and zero-option cases; check that
+  path if you're hitting the error.


### PR DESCRIPTION
## Summary

Rework `.claude/skills/pick-plan/SKILL.md` so the skill carries through from "what should I work on" to "implementation is running":

- **Filter blocked plans.** New step 3 reads every non-✅ plan's `depends-on:` frontmatter from `origin/main` and tags plans whose dependencies aren't all `✅` as blocked. Blocked plans are surfaced in the status report (step 4) but not offered as menu options.
- **Two-bucket ranking.** Step 5 splits the unblocked set into **Structurally important** (`dependents > 0`) and **Quick wins** (smaller-model `haiku`/`sonnet`/`opus`/empty). Top 2 from each bucket fills the 4-option menu, with `🏗`/`⚡` prefixes so the user can see which bucket each option came from at a glance.
- **Model-aware hand-off.** New step 10 spawns the implementation via the `Agent` tool with `model:` set from the plan's frontmatter (`haiku`/`sonnet`/`opus`, defaulting to `opus` when the field is empty), passing a self-contained prompt with branch name, PR number, TDD discipline, and the plan-status maintenance rules.
- **Session-rename suggestion.** Step 9 prints `/rename plan-<id>-<slug>` for the user to run manually — there's no in-session API for setting a Claude Code on the web session title, so this is the closest we can get.

## Test plan

- [ ] `go run ./cmd/mdsmith check .` passes (verified locally)
- [ ] User invokes `/pick-plan` and confirms the new categorized menu surfaces both `🏗` and `⚡` options
- [ ] User invokes `/pick-plan <id>` with a blocked id and confirms the skill refuses with the unmet-deps list rather than silently picking another
- [ ] After picking, the Agent tool fires with `model` matching the plan's frontmatter (eyeball the status line / model indicator)

https://claude.ai/code/session_01PfQQkjTdpT1XpkMKWWBD9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfQQkjTdpT1XpkMKWWBD9K)_