### PR TITLE
Add plans 214 and 215 for Obsidian editor integration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -139,4 +139,6 @@ footer: |
 | 211 | 🔲     | opus   | [`<?include?>` projects any typed value of any kind via `extract`](plan/211_include-extract-value.md)                                   |
 | 212 | 🔲     | opus   | [`mdsmith extract` projects paragraph inline spans as data](plan/212_extract-inline-spans.md)                                           |
 | 213 | 🔲     | opus   | [Built-in `no-llm-tells` convention with append-mode forbidden lists](plan/213_anti-slop-convention.md)                                 |
+| 214 | 🔲     | opus   | [Obsidian plugin via hand-rolled LSP bridge](plan/214_obsidian-plugin.md)                                                               |
+| 215 | 🔲     | opus   | [WASM mdsmith for mobile Obsidian](plan/215_obsidian-wasm-mobile.md)                                                                    |
 <?/catalog?>

--- a/plan/214_obsidian-plugin.md
+++ b/plan/214_obsidian-plugin.md
@@ -1,0 +1,312 @@
+---
+id: 214
+title: Obsidian plugin via hand-rolled LSP bridge
+status: "🔲"
+model: opus
+summary: >-
+  Ship a desktop-only Obsidian plugin under
+  `editors/obsidian/` that spawns `mdsmith lsp`, drives a
+  hand-rolled JSON-RPC client, and renders diagnostics
+  plus quick-fixes inside Obsidian's CodeMirror 6 editor.
+depends-on: [121, 168]
+---
+# Obsidian plugin via hand-rolled LSP bridge
+
+## Goal
+
+Surface mdsmith inside Obsidian. A writer opening a
+`.md` file sees inline squiggles. A "Fix" lightbulb
+applies the matching quick-fix. Fix-on-save runs
+`fixAll` on the active buffer. The plugin reuses
+the LSP server from
+[plan 121](121_vscode-integration.md) unchanged.
+
+## Background
+
+Plan 121 shipped `mdsmith lsp` and a VS Code client.
+Plan 168 added the `obsidian` convention. Together
+they cover the rules. The gap is the editor wiring.
+
+Obsidian runs on Electron. Plugins are bundled to
+one `main.js` plus `manifest.json`, loaded from
+`<vault>/.obsidian/plugins/<id>/`. Desktop plugins
+have Node access. So spawning `mdsmith lsp` via
+`child_process` works. No `vscode-languageclient`
+analog exists in the Obsidian ecosystem. The plugin
+hand-rolls JSON-RPC framing and dispatch.
+
+[Mobile Obsidian][mob] runs no Node. It cannot
+spawn binaries. The manifest sets
+`isDesktopOnly: true`. Mobile is the scope of
+[plan 215](215_obsidian-wasm-mobile.md).
+
+Ship via GitHub Release only. The zip holds
+`main.js`, `manifest.json`, and `styles.css`. No
+PR to [obsidian-releases][cp].
+
+[mob]: https://help.obsidian.md/mobile
+[cp]: https://github.com/obsidianmd/obsidian-releases
+
+## Design
+
+### Layout
+
+`editors/obsidian/` mirrors `editors/vscode/`:
+
+```text
+editors/obsidian/
+  manifest.json
+  package.json
+  tsconfig.json
+  build.ts
+  src/
+    main.ts
+    lsp-client.ts
+    diagnostics.ts
+    actions.ts
+    settings.ts
+    binary.ts
+    *.test.ts
+  styles.css
+  README.md
+```
+
+The build emits one CommonJS bundle to
+`dist/main.js`. Obsidian requires CommonJS. Static
+files are copied as-is. The release zip holds
+those three files plus the staged binaries.
+
+### Binary resolution
+
+Reuse the VS Code bundle path. The shared
+`@mdsmith/cli` shim maps host to target. `build.ts`
+copies `npm/mdsmith/bin/mdsmith.js` and stages each
+platform binary under `dist/cli/@mdsmith/<target>/`.
+`binary.ts` loads the shim and calls
+`resolveBinary(process.platform, process.arch, …)`.
+
+The resolver falls back to a `mdsmith.path` setting,
+then `$PATH`. The fallback notice points at the
+[releases page][rel].
+
+[rel]: https://github.com/jeduden/mdsmith/releases
+
+### JSON-RPC client
+
+`lsp-client.ts` owns the JSON-RPC surface. It
+spawns the binary, frames messages with
+`Content-Length` headers, and dispatches replies
+by id. The framing is around 80 lines. No
+third-party package is used.
+
+The client exposes:
+
+- `spawn(binary, args, cwd)` and `kill()`.
+- `request(method, params): Promise<unknown>`.
+- `notify(method, params): void`.
+- `onNotification(method, handler)`.
+- Lifecycle: `initialize` → `initialized` →
+  requests → `shutdown` → `exit`.
+
+Methods the plugin sends or receives:
+
+| Direction | Method                            | Why               |
+| --------- | --------------------------------- | ----------------- |
+| → server  | `initialize`                      | Handshake         |
+| → server  | `textDocument/didOpen`            | Buffer opened     |
+| → server  | `textDocument/didChange`          | Debounced edit    |
+| → server  | `textDocument/didSave`            | Triggers fix      |
+| → server  | `textDocument/didClose`           | Buffer closed     |
+| → server  | `textDocument/codeAction`         | Quick fixes       |
+| → server  | `workspace/executeCommand`        | Run `fixAll`      |
+| ← server  | `textDocument/publishDiagnostics` | Squiggles         |
+| ← server  | `window/showMessage`              | `new Notice(...)` |
+
+Hover, completion, rename, and navigation are
+deferred. Obsidian exposes those through different
+surfaces. They warrant their own plan.
+
+### Diagnostics in CodeMirror 6
+
+Obsidian's source and live-preview editors both
+use [CodeMirror 6][cm6]. The plugin adds a CM6
+`StateField<DecorationSet>`. It holds active
+diagnostics per file. Decorations apply a
+severity-themed underline. Classes live in
+`styles.css`.
+
+Hover uses `hoverTooltip` from `@codemirror/view`.
+The tooltip shows `code + message`. The footer
+holds a "Fix" link. The link runs the same
+code-action flow as the lightbulb.
+
+[cm6]: https://codemirror.net/
+
+A "mdsmith Diagnostics" [`ItemView`][iv] lists
+workspace-wide diagnostics as a sortable table.
+Click jumps to the source location.
+
+[iv]: https://docs.obsidian.md/Plugins/User+interface/Views
+
+### Code actions and fix-on-save
+
+Obsidian has no lightbulb. Three surfaces stand in:
+
+1. The hover tooltip "Fix" link.
+2. Per-line palette commands. Each active
+   diagnostic on the cursor line registers a
+   transient `mdsmith: Fix — {code}` command. The
+   set clears on cursor move.
+3. The `mdsmith: Fix file` command. It runs
+   `workspace/executeCommand` with the `fixAll`
+   command id. The returned `WorkspaceEdit`
+   applies to the active buffer.
+
+`fixOnSave` (off by default) debounces
+`vault.on('modify')` and triggers `Fix file` 200 ms
+after the last save. The command path is shared
+with the palette entry.
+
+### Settings
+
+A `PluginSettingTab` renders five controls:
+
+| Setting       | Default    | Purpose                    |
+| ------------- | ---------- | -------------------------- |
+| `binaryPath`  | `""`       | Override resolver          |
+| `configPath`  | `""`       | Pass `-c` to the server    |
+| `runMode`     | `"onSave"` | `onType`/`onSave`/`off`    |
+| `fixOnSave`   | `false`    | Run `fixAll` after save    |
+| `traceServer` | `"off"`    | `off`/`messages`/`verbose` |
+
+Settings round-trip via `loadData` and `saveData`.
+Changing `binaryPath` or `configPath` restarts the
+server. Changing `runMode` or `fixOnSave`
+reconfigures listeners without a restart.
+
+### Lifecycle
+
+`onload` reads settings, resolves the binary,
+spawns the server, registers the CM6 extension,
+registers commands and the diagnostics view, and
+attaches vault listeners. `onunload` sends
+`shutdown` and `exit`, kills the child after 1 s,
+disposes views, and removes listeners. A
+`mdsmith: Restart server` command exists for the
+same reason VS Code has one.
+
+### Build, test, release
+
+`bun run build.ts --production` writes `dist/`,
+stages the platform binaries, and zips the
+artifact. CI runs `bun test`, then the build,
+then attaches the zip to the GitHub Release.
+The release pipeline picks it up the same way it
+picks up the `.vsix`.
+
+### Docs
+
+A new `docs/guides/editors/obsidian.md` covers
+install, settings, and troubleshooting. Update the
+[linter comparison][lc] to cite the new plugin in
+its Obsidian row. Add a note to the
+[conventions reference][conv] that
+`convention: obsidian` pairs with this plugin.
+Mention the artifact in [github-releases.md][gh].
+
+[lc]: ../docs/background/markdown-linters.md
+[conv]: ../docs/reference/conventions.md
+[gh]: ../docs/development/release-channels/github-releases.md
+
+## Tasks
+
+1. Scaffold `editors/obsidian/`: `package.json`,
+   `tsconfig.json`, `manifest.json` with
+   `isDesktopOnly: true`, `build.ts`, a stub
+   `src/main.ts` extending `Plugin`, and a
+   `README.md` that passes default rules.
+2. Implement `lsp-client.ts`. Cover framing,
+   request correlation, notification fan-out, and
+   the `initialize`/`shutdown` cycle. Unit-test
+   against an in-process `Duplex`.
+3. Implement `binary.ts`. Load the `@mdsmith/cli`
+   shim. Fall back to setting, then `$PATH`. Match
+   the test surface of the VS Code module.
+4. Implement `diagnostics.ts`. Add the CM6
+   `StateField`, the effect type, and a
+   `hoverTooltip` provider rendering code, message,
+   and a Fix link.
+5. Implement `actions.ts`. Add per-line palette
+   commands from active diagnostics, the
+   `Fix file` command via `executeCommand`, and the
+   debounced `vault.on('modify')` handler.
+6. Implement `settings.ts`. Wire the five controls,
+   the `loadData`/`saveData` round-trip, and the
+   restart-on-change for `binaryPath` and
+   `configPath`.
+7. Wire `main.ts`. `onload` spawns the server,
+   registers the CM6 extension, the diagnostics
+   view, the commands, and the settings tab.
+   `onunload` cleans up.
+8. Add `styles.css` for severity underlines and
+   tooltip styling.
+9. Add a `.github/workflows/` step that builds the
+   plugin and uploads the zip as a release
+   artifact, mirroring the existing `vscode` job.
+10. Write `docs/guides/editors/obsidian.md`.
+    Update the conventions reference, the
+    linter-comparison page, and the GitHub
+    Releases page.
+11. Run `mdsmith fix .` and confirm `mdsmith check
+    .` passes against the updated `PLAN.md`.
+
+## Acceptance Criteria
+
+- [ ] `editors/obsidian/` builds with `bun run
+      build.ts --production`. The output is
+      `dist/main.js`, `manifest.json`, and
+      `styles.css`.
+- [ ] `bun test` passes. The suite covers framing,
+      binary resolution, diagnostics decoration,
+      and settings round-trip.
+- [ ] Loading the plugin in a vault that holds an
+      `MDS001` violation shows a wavy underline
+      within 500 ms of opening the file. Manual
+      smoke step.
+- [ ] The hover tooltip shows the rule code and
+      message. The "Fix" link applies the
+      quick-fix.
+- [ ] `mdsmith: Fix file` produces the same buffer
+      as `mdsmith fix` on the same input.
+- [ ] Toggling `fixOnSave: true` runs `Fix file`
+      after each save without a plugin restart.
+- [ ] Editing `.mdsmith.yml` re-lints open files
+      without a restart. The
+      `didChangeWatchedFiles` event is forwarded.
+- [ ] `manifest.json` has `isDesktopOnly: true`.
+      Mobile Obsidian treats the plugin as absent,
+      not as a crash.
+- [ ] CI attaches `mdsmith-obsidian-<version>.zip`
+      to the release artifacts.
+- [ ] `docs/guides/editors/obsidian.md` exists.
+      The linter-comparison page cites the new
+      plugin in its Obsidian row.
+- [ ] `mdsmith check .` passes against the
+      updated `PLAN.md`.
+
+## Non-Goals
+
+- LSP hover, completion, rename, and symbol
+  navigation. Each goes in its own follow-up.
+- Mobile support. That is plan 215.
+- Submission to the Obsidian Community Plugins
+  catalog. The chosen channel is GitHub Releases.
+- Live-preview rendering changes.
+- New rule bindings beyond what the `obsidian`
+  convention activates.
+
+## See also
+
+- [Plan 121: VS Code via LSP](121_vscode-integration.md)
+- [Plan 215: WASM for mobile](215_obsidian-wasm-mobile.md)
+- [Linter comparison][lc]

--- a/plan/214_obsidian-plugin.md
+++ b/plan/214_obsidian-plugin.md
@@ -110,17 +110,16 @@ The client exposes:
 
 Methods the plugin sends or receives:
 
-| Direction | Method                            | Why               |
-| --------- | --------------------------------- | ----------------- |
-| → server  | `initialize`                      | Handshake         |
-| → server  | `textDocument/didOpen`            | Buffer opened     |
-| → server  | `textDocument/didChange`          | Debounced edit    |
-| → server  | `textDocument/didSave`            | Triggers fix      |
-| → server  | `textDocument/didClose`           | Buffer closed     |
-| → server  | `textDocument/codeAction`         | Quick fixes       |
-| → server  | `workspace/executeCommand`        | Run `fixAll`      |
-| ← server  | `textDocument/publishDiagnostics` | Squiggles         |
-| ← server  | `window/showMessage`              | `new Notice(...)` |
+| Direction | Method                            | Why                                      |
+| --------- | --------------------------------- | ---------------------------------------- |
+| → server  | `initialize`                      | Handshake                                |
+| → server  | `textDocument/didOpen`            | Buffer opened                            |
+| → server  | `textDocument/didChange`          | Debounced edit                           |
+| → server  | `textDocument/didSave`            | Triggers fix                             |
+| → server  | `textDocument/didClose`           | Buffer closed                            |
+| → server  | `textDocument/codeAction`         | Quick fixes plus `source.fixAll.mdsmith` |
+| ← server  | `textDocument/publishDiagnostics` | Squiggles                                |
+| ← server  | `window/showMessage`              | `new Notice(...)`                        |
 
 Hover, completion, rename, and navigation are
 deferred. Obsidian exposes those through different
@@ -157,10 +156,10 @@ Obsidian has no lightbulb. Three surfaces stand in:
    diagnostic on the cursor line registers a
    transient `mdsmith: Fix — {code}` command. The
    set clears on cursor move.
-3. The `mdsmith: Fix file` command. It runs
-   `workspace/executeCommand` with the `fixAll`
-   command id. The returned `WorkspaceEdit`
-   applies to the active buffer.
+3. The `mdsmith: Fix file` command. It sends
+   `textDocument/codeAction` filtered to kind
+   `source.fixAll.mdsmith` and applies the
+   returned `WorkspaceEdit` — mirroring VS Code.
 
 `fixOnSave` (off by default) debounces
 `vault.on('modify')` and triggers `Fix file` 200 ms

--- a/plan/215_obsidian-wasm-mobile.md
+++ b/plan/215_obsidian-wasm-mobile.md
@@ -1,0 +1,265 @@
+---
+id: 215
+title: WASM mdsmith for mobile Obsidian
+status: "🔲"
+model: opus
+summary: >-
+  Build a `js+wasm` mdsmith target, expose a small
+  `check`/`fix` JS API, and load it from the Obsidian
+  plugin so the lint runs on iOS and Android where
+  Electron's `child_process` is unavailable.
+depends-on: [214]
+---
+# WASM mdsmith for mobile Obsidian
+
+## Goal
+
+Run mdsmith inside Obsidian on iOS and Android. A
+user sees the same diagnostics they get on desktop.
+The plugin loads a WASM build, runs `check` and
+`fix` in process, and skips the binary spawn.
+
+## Background
+
+[Plan 214](214_obsidian-plugin.md) ships the
+desktop bridge. It spawns `mdsmith lsp` via Node.
+Mobile Obsidian has no Node. It also blocks native
+binary loading from a plugin sandbox. The plan
+marks itself `isDesktopOnly: true` and names this
+follow-up as the mobile route.
+
+Go compiles to WebAssembly with `GOOS=js
+GOARCH=wasm`. The
+[plan 65 WASM spike](65_spike-wasm-embedded-inference.md)
+showed the build path works. The cost is binary
+size (Go's runtime adds about 10 MB even with
+trimming) and the loss of `os.Exec`, raw threads,
+and stdio.
+
+LSP fits poorly inside WASM. Client and server end
+up in one process. The JSON-RPC framing buys
+nothing. The plan exposes mdsmith as a small JS
+API instead.
+
+## Design
+
+### Build target
+
+A new `cmd/mdsmith-wasm/` builds with `GOOS=js
+GOARCH=wasm`. The existing `cmd/mdsmith` keeps the
+native build. The entry point exports an API
+surface via `syscall/js`:
+
+```go
+js.Global().Set("mdsmith", js.ValueOf(map[string]any{
+    "check":   js.FuncOf(check),
+    "fix":     js.FuncOf(fix),
+    "kinds":   js.FuncOf(kinds),
+    "version": Version,
+}))
+```
+
+`check(uri, source, configYAML)` returns a JS
+array of diagnostics shaped like the LSP payload.
+`fix(uri, source, configYAML)` returns the
+rewritten file plus the edit list.
+`kinds(configYAML)` mirrors the CLI.
+
+The bundle ships at
+`editors/obsidian/dist/mdsmith.wasm` next to
+`main.js`. `wasm_exec.js` is the Go loader.
+
+### Workspace abstraction
+
+mdsmith reads files through `os.ReadFile`. Mobile
+Obsidian routes file access through the [Vault
+API][va]. The host filesystem is not available.
+
+[va]: https://docs.obsidian.md/Reference/TypeScript+API/Vault
+
+The plugin pre-resolves content on the JS side. It
+passes a `Record<string, string>` of `relPath` to
+content as a third argument. Inside Go, an
+injectable `Workspace.ReadFile(path)` interface
+replaces the direct `os.ReadFile` call. The native
+build keeps using disk. The WASM build reads from
+the injected map.
+
+This refactor is the riskier piece. Task 1 lands
+it before the WASM build does.
+
+### Plugin glue
+
+A new `editors/obsidian/src/wasm-runtime.ts`
+mirrors `lsp-client.ts`:
+
+```ts
+export interface WasmRuntime {
+  check(uri: string, source: string,
+        workspace: Record<string, string>):
+    Promise<Diagnostic[]>;
+  fix(uri: string, source: string,
+      workspace: Record<string, string>):
+    Promise<{ output: string;
+              edits: TextEdit[] }>;
+  shutdown(): Promise<void>;
+}
+```
+
+`main.ts` picks the runtime at load via
+[`Platform.isMobile`][plat]:
+
+```ts
+const runtime = Platform.isMobile
+  ? await loadWasmRuntime(ctx)
+  : await spawnLspBridge(ctx);
+```
+
+[plat]: https://docs.obsidian.md/Reference/TypeScript+API/Platform
+
+The `manifest.json` drops `isDesktopOnly: true`.
+On desktop the LSP bridge stays the default. WASM
+is opt-in via `mdsmith.preferWasm`. Native is
+faster.
+
+### Size and speed
+
+Two budgets gate the plan:
+
+- **Bundle.** The zip must stay under 25 MB. A
+  trimmed Go WASM lands near 12–18 MB. A `tinygo`
+  build lands near 5–8 MB. Task 3 builds both and
+  picks one.
+- **Cold start.** First `check` on a 1000-line
+  file must finish in under 1 s on a modern iPad.
+  Later calls must finish in under 150 ms.
+  Numbers come from `wasm-runtime.bench.ts`.
+
+If the bundle exceeds the cap, fetch the WASM via
+[`requestUrl`][ru] on first run. The plugin
+caches the bytes. Stretch goal — the default plan
+in-bundles.
+
+[ru]: https://docs.obsidian.md/Reference/TypeScript+API/requestUrl
+
+### Rule subset
+
+Some rules touch the host filesystem. Examples
+include embed lint via `<?include?>`, recipe shell
+scanning, and `<?catalog?>` glob expansion. Each
+of these must run against the injected workspace
+map. Some need to degrade. Task 1 enumerates the
+list. Each rule gets a test against an in-memory
+backing.
+
+MDS040 needs real shell access. The WASM runtime
+skips it. The diagnostics view shows a one-line
+notice on mobile.
+
+### Distribution
+
+The `mdsmith-obsidian-<version>.zip` from plan 214
+gains the WASM bytes. The release job grows a
+step that builds the WASM target and stages it
+under `editors/obsidian/dist/`. No new channel.
+
+### Docs
+
+The guide drops the "desktop only" caveat and
+documents the `preferWasm` setting. A new
+`docs/background/concepts/wasm-build.md` explains
+the split: WASM vs native, what WASM can not do,
+the size cap. The linter-comparison page picks up
+mobile parity.
+
+## Tasks
+
+1. Refactor file reads in `internal/` behind a
+   `Workspace.ReadFile(path)` interface. Each site
+   keeps its tests green. One new test injects a
+   memory-backed workspace.
+2. Add `cmd/mdsmith-wasm/main.go`. Register
+   `globalThis.mdsmith` with `check`, `fix`,
+   `kinds`, and `version`. Run the binary under
+   [`wasmbrowsertest`][wbt] or a Node loader to
+   smoke-test the exports.
+3. Extend `editors/obsidian/build.ts` with a
+   `--wasm` flag. Build both with standard Go and
+   `tinygo`. Pick one by size and correctness.
+4. Implement `editors/obsidian/src/wasm-runtime.ts`.
+   Instantiate via `WebAssembly.instantiate`.
+   Marshal workspace snapshots in and diagnostics
+   out. Test in `bun test` against the built WASM.
+5. Wire runtime selection in
+   `editors/obsidian/src/main.ts`. Pick WASM on
+   mobile or when `preferWasm` is set. Add the
+   `preferWasm` toggle to the settings tab.
+6. Build a workspace snapshotter. Walk
+   `app.vault.getMarkdownFiles()` at startup. Keep
+   a `Map<string, string>`. Update on `'modify'`,
+   `'create'`, and `'delete'` with a 200 ms
+   debounce.
+7. Add `wasm-runtime.bench.ts`. Benchmark cold
+   start and steady state on a 1000-line fixture.
+   Record results in the plan completion note.
+8. Drop `isDesktopOnly: true` from the manifest
+   once mobile smoke tests pass.
+9. Write `docs/background/concepts/wasm-build.md`
+   and update the Obsidian guide. Flip the
+   Obsidian row in the linter-comparison page.
+10. Run `mdsmith fix .` and confirm `mdsmith
+    check .` passes.
+
+[wbt]: https://github.com/agnivade/wasmbrowsertest
+
+## Acceptance Criteria
+
+- [ ] `cmd/mdsmith-wasm/` builds with `GOOS=js
+      GOARCH=wasm`. It exports
+      `globalThis.mdsmith.{check,fix,kinds,version}`.
+- [ ] `mdsmith.wasm` and `wasm_exec.js` ship
+      inside the obsidian release zip.
+- [ ] Loading the plugin on Obsidian iOS lints a
+      `.md` file with an `MDS001` violation. The
+      underline shows within 2 s.
+- [ ] Quick-fix on a mobile diagnostic produces
+      the same buffer as `mdsmith fix` on desktop.
+- [ ] Total packaged zip stays under 25 MB.
+- [ ] Cold-start `check` on the 1000-line fixture
+      finishes in under 1 s on a modern iPad.
+      Later calls finish in under 150 ms.
+- [ ] The manifest no longer has `isDesktopOnly`.
+      Desktop keeps LSP as the default; WASM is
+      opt-in via `preferWasm`.
+- [ ] Every rule test passes against both the
+      OS-backed and in-memory `Workspace`
+      backings.
+- [ ] MDS040 skips silently on the WASM runtime
+      with a one-line notice in the diagnostics
+      view.
+- [ ] `docs/background/concepts/wasm-build.md` and
+      the updated Obsidian guide ship.
+- [ ] `mdsmith check .` passes; `go test ./...`
+      passes; `go tool golangci-lint run` is
+      clean.
+
+## Non-Goals
+
+- LSP over WASM. The JS API replaces the JSON-RPC
+  bridge on mobile.
+- A WASM build for `npm`, `pip`, or other
+  channels. The artifact stays inside the
+  Obsidian plugin.
+- Recipe execution. Mobile has no shell.
+- Indexing vaults larger than 10k Markdown files.
+  Snapshot semantics are a linear walk. Larger
+  vaults wait for a future plan.
+- A standalone WASM playground on the website.
+
+## See also
+
+- [Plan 214: Obsidian plugin][214]
+- [Plan 65: WASM spike][65]
+
+[214]: 214_obsidian-plugin.md
+[65]: 65_spike-wasm-embedded-inference.md


### PR DESCRIPTION
## Summary

- **Plan 214 — Obsidian plugin via hand-rolled LSP bridge.** Ship a desktop-only plugin under `editors/obsidian/` that spawns the existing `mdsmith lsp` server, hand-rolls a JSON-RPC client (Obsidian has no `vscode-languageclient` analog), and renders diagnostics + quick-fixes inside CodeMirror 6. Distribution is GitHub Releases only.
- **Plan 215 — WASM mdsmith for mobile Obsidian.** Follow-up that adds a `cmd/mdsmith-wasm/` `GOOS=js GOARCH=wasm` target, exposes `check`/`fix`/`kinds` as a JS API, and lets the plugin drop `isDesktopOnly: true` so iOS and Android lint the same content desktop does.

Both plans were sized down to fit under the 300-line file cap with all default rules passing (`mdsmith check .` clean across the repo).

## Test plan

- [ ] Plans are scheduled work — implementation lives in follow-up PRs (one per plan).
- [x] `mdsmith check .` passes against the new plans and the regenerated `PLAN.md` catalog.

https://claude.ai/code/session_017tJSghhQfy19cp55ZA9rKx

---
_Generated by [Claude Code](https://claude.ai/code/session_017tJSghhQfy19cp55ZA9rKx)_