### PR TITLE
ci: bump pinned mdsmith baseline to v0.27.0

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -10,8 +10,8 @@ runs:
       env:
         # Pinned compatibility baseline for mdsmith release checks and merge tooling.
         # Bump here only when intentionally updating that baseline.
-        MDSMITH_VERSION: v0.24.0
-        MDSMITH_SHA256: 75df5b5c38dbc6f6d1dadbd1a637f1f7c7a612d948d28310c50b06304863ff06
+        MDSMITH_VERSION: v0.27.0
+        MDSMITH_SHA256: 3329edfc0fc019014af3c2a52e5e575f9907e5b5425e0f8aff3b7199e474b3f0
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.


### PR DESCRIPTION
## Summary

Bumps the pinned mdsmith compatibility baseline used by CI and the merge-queue workflows from `v0.24.0` to `v0.27.0`.

This is the version installed by `.github/actions/setup-mdsmith-pinned-version`, consumed by `ci.yml` and `merge-queue.yml`. It is the only place in the repo pinning that baseline (the npm/PyPI/VS Code/Hugo manifests carry the `0.0.0-dev` sentinel and are stamped at release time, so they need no change here).

## Changes

- `MDSMITH_VERSION`: `v0.24.0` → `v0.27.0`
- `MDSMITH_SHA256`: updated to the `v0.27.0` `mdsmith-linux-amd64` checksum

## Verification

The new checksum was cross-checked against three independent sources, all in agreement:

- GitHub release API asset `digest`
- The release's published `checksums.txt`
- A local `sha256sum` of the downloaded binary

```
3329edfc0fc019014af3c2a52e5e575f9907e5b5425e0f8aff3b7199e474b3f0  mdsmith-linux-amd64
```

Reproduced the exact CI step locally — `sha256sum -c` passes (`mdsmith-linux-amd64: OK`) and the binary self-reports `mdsmith v0.27.0`.

https://claude.ai/code/session_01FnaDiJYq4gX4ZW41rwg76L