### PR TITLE
docs(install): document Homebrew + asdf channels; trigger tap bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,6 +586,30 @@ jobs:
           fi
           echo "channel=${{ matrix.channel }}: $got"
 
+  # Nudge the Homebrew tap to bump its formula to this version right
+  # away. Best-effort glue, not part of the gated publish: the tap at
+  # jeduden/homebrew-mdsmith also self-bumps on a daily schedule, so a
+  # missing token or a failed dispatch never blocks a release. The
+  # token is a fine-grained PAT with Contents: write on the tap repo,
+  # stored as the HOMEBREW_TAP_DISPATCH_TOKEN repo secret.
+  notify-homebrew-tap:
+    needs: [release]
+    if: *release_repo_trigger_ok
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch a formula bump to the tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+          VERSION: ${{ env.VERSION }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_DISPATCH_TOKEN unset; the tap will self-bump on its daily schedule."
+            exit 0
+          fi
+          gh api repos/jeduden/homebrew-mdsmith/dispatches \
+            -f event_type=mdsmith-release \
+            -f "client_payload[version]=${VERSION#v}"
+
   # A tool release also ships the website. The deploy itself lives
   # in pages.yml (its own workflow, also triggered by docs-only
   # pushes to main and by manual workflow_dispatch); this job just

--- a/PLAN.md
+++ b/PLAN.md
@@ -73,7 +73,7 @@ footer: |
 | 142 | ✅     | sonnet | [Content rules for prose constraints](plan/142_schema-content-constraints.md)                                                           |
 | 143 | ✅     | sonnet | [Schema cross-references, acronyms, and index](plan/143_schema-cross-refs-acronyms-index.md)                                            |
 | 144 | ✅     | sonnet | [Numeric sort for `<?catalog?>` directive](plan/144_catalog-numeric-sort.md)                                                            |
-| 145 | 🔲     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                                    |
+| 145 | 🔳     | opus   | [Publish mdsmith via asdf and mise registry submissions](plan/145_asdf-mise-registry-submissions.md)                                    |
 | 146 | ✅     | opus   | [Schema engine — sources, scope tree, per-scope rules](plan/146_inline-schema-in-kinds.md)                                              |
 | 147 | ✅     | opus   | [Actionable schema diagnostics for MDS020](plan/147_actionable-schema-diagnostics.md)                                                   |
 | 148 | ✅     | sonnet | [Named field-type shortcuts for inline schemas](plan/148_named-field-type-shortcuts.md)                                                 |

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -45,13 +45,16 @@ into the binary at build time. Pick one path:
 | PyPI (pip)           | `pip install mdsmith`                                                                               | Python projects and Python-only CI images                               |
 | uvx                  | `uvx mdsmith check .`                                                                               | Ephemeral runs via uv                                                   |
 | pipx                 | `pipx install mdsmith`                                                                              | Isolated CLI install on Python hosts                                    |
+| Homebrew             | `brew install jeduden/mdsmith/mdsmith`                                                              | macOS and Linux via Homebrew                                            |
 | mise (`ubi` backend) | `mise use -g ubi:jeduden/mdsmith@latest`                                                            | Repos using mise; works today via GitHub releases without a registry PR |
+| asdf                 | `asdf plugin add mdsmith https://github.com/jeduden/asdf-mdsmith.git`                               | Repos standardized on asdf                                              |
 | GitHub release       | Download `mdsmith-<os>-<arch>` from the [release page](https://github.com/jeduden/mdsmith/releases) | Air-gapped hosts and direct binary control                              |
 
-asdf and the short `mise use mdsmith@latest` form depend on
-follow-up registry submissions tracked in
-[plan/145](../../plan/145_asdf-mise-registry-submissions.md); the
-sections below explain how to use each one once those land.
+The short `asdf plugin add mdsmith` and `mise use mdsmith@latest`
+forms — without an explicit URL — depend on registry submissions
+tracked in
+[plan/145](../../plan/145_asdf-mise-registry-submissions.md). The
+explicit-URL asdf install, Homebrew, and `ubi:` mise all work today.
 
 The binary ships for linux x86_64, linux aarch64, macOS
 x86_64, macOS arm64, and Windows amd64. Other targets
@@ -107,13 +110,9 @@ and `python -m mdsmith` all work.
 
 ## asdf
 
-> **Pending follow-up.** The `jeduden/asdf-mdsmith` plugin repo is
-> a follow-up tracked in
-> [plan/145](../../plan/145_asdf-mise-registry-submissions.md).
-> Until that repo exists, the commands below will not resolve.
-> Use one of the channels above in the meantime.
-
-Once the plugin repo is published:
+The [`jeduden/asdf-mdsmith`](https://github.com/jeduden/asdf-mdsmith)
+plugin installs the prebuilt binary for your platform and verifies it
+against the release `checksums.txt`:
 
 ```bash
 asdf plugin add mdsmith https://github.com/jeduden/asdf-mdsmith.git
@@ -126,6 +125,24 @@ Once the plugin is also listed in
 [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins),
 the explicit URL becomes optional:
 `asdf plugin add mdsmith` resolves on its own.
+
+## Homebrew
+
+```bash
+brew install jeduden/mdsmith/mdsmith
+mdsmith version
+```
+
+This taps
+[`jeduden/homebrew-mdsmith`](https://github.com/jeduden/homebrew-mdsmith)
+and installs the prebuilt binary for macOS or Linux, on Intel or
+arm64, verified against the release `checksums.txt`. Upgrade with
+`brew upgrade mdsmith`. To tap once and then install by short name:
+
+```bash
+brew tap jeduden/mdsmith
+brew install mdsmith
+```
 
 ## mise
 

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -3,7 +3,7 @@ id: 145
 title: >-
   Publish mdsmith via asdf and mise registry
   submissions
-status: "🔲"
+status: "🔳"
 summary: >-
   Land the asdf-plugin repo (jeduden/asdf-mdsmith) and
   the mise-plugins/registry entry that the multi-channel
@@ -83,11 +83,11 @@ on `asdf plugin add mdsmith`.
 
 ## Acceptance Criteria
 
-- [ ] `jeduden/asdf-mdsmith` exists with the four
+- [x] `jeduden/asdf-mdsmith` exists with the four
       `bin/` scripts and a green CI workflow.
 - [ ] `asdf plugin add mdsmith` resolves without an
       explicit URL after the asdf-plugins PR merges.
-- [ ] `asdf install mdsmith X.Y.Z` then
+- [x] `asdf install mdsmith X.Y.Z` then
       `mdsmith version` prints `mdsmith vX.Y.Z`.
 - [ ] `mise use mdsmith@X.Y.Z` (no `ubi:`) resolves
       after the mise-plugins/registry PR merges, and


### PR DESCRIPTION
## What

The asdf plugin ([`jeduden/asdf-mdsmith`](https://github.com/jeduden/asdf-mdsmith), green CI) and the Homebrew tap ([`jeduden/homebrew-mdsmith`](https://github.com/jeduden/homebrew-mdsmith), green CI) now exist and install the prebuilt release binaries. This brings the repo's docs and release pipeline in step.

### Changes

- **`docs/guides/install.md`**
  - New **Homebrew** section (`brew install jeduden/mdsmith/mdsmith`).
  - Added **Homebrew** and **asdf** rows to the channels table.
  - Replaced the stale asdf note ("until that repo exists, the commands below will not resolve") — the plugin repo is live and the explicit-URL install works today. The note now only flags the registry-index *short forms* (`asdf plugin add mdsmith` / `mise use mdsmith@latest`) as pending.
- **`.github/workflows/release.yml`** — a best-effort `notify-homebrew-tap` job that `repository_dispatch`es the tap to bump its formula immediately on each release. It no-ops when `HOMEBREW_TAP_DISPATCH_TOKEN` is unset and never blocks a release (the tap also self-bumps daily). Secrets/inputs are passed via `env:` (no `${{ }}` in the run script), matching the workflow's existing zizmor-safe pattern.
- **`plan/145`** — marked in-progress; checked the two acceptance criteria that are now built and CI-verified (the repo + green CI, and `asdf install` → `mdsmith vX.Y.Z`).

## Validation

- `./mdsmith check .` passes on the full tree (384 files), built from this branch's HEAD — identical to the `mdsmith check` CI job.
- `release.yml` parses (anchors resolve); the new job reuses the existing `*release_repo_trigger_ok` repo guard.

## Action required for the auto-bump (optional)

Create repo secret **`HOMEBREW_TAP_DISPATCH_TOKEN`** — a fine-grained PAT with **Contents: write** on `jeduden/homebrew-mdsmith`. Without it, the release simply logs a notice and the tap still updates on its daily schedule. I left this token out of the secret-rotation tracker on purpose: it's non-critical (graceful degradation), unlike the publisher tokens whose expiry breaks a release. Happy to add a rotation entry if you'd prefer it tracked.

## Not included (tracked in plan/145)

PRs to `asdf-vm/asdf-plugins` and `mise-plugins/registry` (drop the explicit URL / `ubi:` prefix), and extending the release smoke-test matrix to the bare asdf/mise forms.

https://claude.ai/code/session_01KZGNgvRpcFoZfgJFH8CqdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZGNgvRpcFoZfgJFH8CqdU)_