### PR TITLE
Default mdsmith.run to onType and rework run/fix-on-save semantics

### DIFF
--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -124,14 +124,14 @@ preferences go in your user settings. Changing any setting
 takes effect on the next document event, with no window
 reload.
 
-| Setting                | Default   | Purpose                                                                              |
-| ---------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `mdsmith.run`          | `onType`  | When to lint: `onType` (default), `onSave`, or `off` (off disables mdsmith entirely) |
-| `mdsmith.fixOnSave`    | `false`   | Run `mdsmith fix` on save; ignored when `mdsmith.run` is `off`                       |
-| `mdsmith.previewFix`   | `false`   | Open Refactor Preview before applying any fix                                        |
-| `mdsmith.config`       | `""`      | Override the `.mdsmith.yml` path (absolute or workspace)                             |
-| `mdsmith.path`         | `mdsmith` | Pin a binary; the default runs the bundled per-platform one                          |
-| `mdsmith.trace.server` | `off`     | LSP trace verbosity: `off`, `messages`, or `verbose`                                 |
+| Setting                | Default   | Purpose                                                                            |
+| ---------------------- | --------- | ---------------------------------------------------------------------------------- |
+| `mdsmith.run`          | `onType`  | When to lint: `onType` (default), `onSave`, or `off` (off stops automatic linting) |
+| `mdsmith.fixOnSave`    | `false`   | Run `mdsmith fix` on save; ignored when `mdsmith.run` is `off`                     |
+| `mdsmith.previewFix`   | `false`   | Open Refactor Preview before applying any fix                                      |
+| `mdsmith.config`       | `""`      | Override the `.mdsmith.yml` path (absolute or workspace)                           |
+| `mdsmith.path`         | `mdsmith` | Pin a binary; the default runs the bundled per-platform one                        |
+| `mdsmith.trace.server` | `off`     | LSP trace verbosity: `off`, `messages`, or `verbose`                               |
 
 `mdsmith.run` defaults to `onType`, so diagnostics update
 live as you type. `mdsmith.fixOnSave` layers auto-fixing on
@@ -139,13 +139,13 @@ top, and `off` is a master switch: it stops diagnostics and
 suppresses fix-on-save, so a save never rewrites the buffer
 while `mdsmith.run` is `off`.
 
-| `mdsmith.run` | `mdsmith.fixOnSave` | Behavior                                          |
-| ------------- | ------------------- | ------------------------------------------------- |
-| `onType`      | `false`             | Diagnostics update live as you type (default)     |
-| `onType`      | `true`              | Live diagnostics; saving also auto-fixes the file |
-| `onSave`      | `false`             | Diagnostics update only when you save             |
-| `onSave`      | `true`              | Saving re-lints and auto-fixes the file           |
-| `off`         | either              | mdsmith is inert: no diagnostics, no fix-on-save  |
+| `mdsmith.run` | `mdsmith.fixOnSave` | Behavior                                              |
+| ------------- | ------------------- | ----------------------------------------------------- |
+| `onType`      | `false`             | Diagnostics update live as you type (default)         |
+| `onType`      | `true`              | Live diagnostics; saving also auto-fixes the file     |
+| `onSave`      | `false`             | Diagnostics update only when you save                 |
+| `onSave`      | `true`              | Saving re-lints and auto-fixes the file               |
+| `off`         | either              | No diagnostics or fix-on-save; quick fixes still work |
 
 To bind fix-on-save through `editor.codeActionsOnSave`
 instead of `mdsmith.fixOnSave`:

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -26,7 +26,8 @@ Each feature links to a page with its rules and examples.
 ### As you write
 
 **Inline diagnostics.** Every rule violation shows as a
-squiggle, on save or on each keystroke, set by `mdsmith.run`.
+squiggle — live as you type by default, or only on save,
+set by `mdsmith.run`.
 The [same checks run in CI](../../reference/cli/check.md),
 so the editor never disagrees with the build.
 
@@ -38,7 +39,8 @@ clicked.
 **Fix on save.** Enable `mdsmith.fixOnSave` (off by default).
 On each save, the whole-file fixer rewrites trailing
 whitespace, heading style, code fences, bare URLs, list
-indentation, and table alignment.
+indentation, and table alignment. Setting `mdsmith.run` to
+`off` suppresses it.
 
 **Preview before applying.** Enable `mdsmith.previewFix` and
 every fix routes through VS Code's Refactor Preview pane, so
@@ -122,19 +124,31 @@ preferences go in your user settings. Changing any setting
 takes effect on the next document event, with no window
 reload.
 
-| Setting                | Default   | Purpose                                                     |
-| ---------------------- | --------- | ----------------------------------------------------------- |
-| `mdsmith.run`          | `onSave`  | When to lint: `onType`, `onSave`, or `off`                  |
-| `mdsmith.fixOnSave`    | `false`   | Run `mdsmith fix` on save                                   |
-| `mdsmith.previewFix`   | `false`   | Open Refactor Preview before applying any fix               |
-| `mdsmith.config`       | `""`      | Override the `.mdsmith.yml` path (absolute or workspace)    |
-| `mdsmith.path`         | `mdsmith` | Pin a binary; the default runs the bundled per-platform one |
-| `mdsmith.trace.server` | `off`     | LSP trace verbosity: `off`, `messages`, or `verbose`        |
+| Setting                | Default   | Purpose                                                                              |
+| ---------------------- | --------- | ------------------------------------------------------------------------------------ |
+| `mdsmith.run`          | `onType`  | When to lint: `onType` (default), `onSave`, or `off` (off disables mdsmith entirely) |
+| `mdsmith.fixOnSave`    | `false`   | Run `mdsmith fix` on save; ignored when `mdsmith.run` is `off`                       |
+| `mdsmith.previewFix`   | `false`   | Open Refactor Preview before applying any fix                                        |
+| `mdsmith.config`       | `""`      | Override the `.mdsmith.yml` path (absolute or workspace)                             |
+| `mdsmith.path`         | `mdsmith` | Pin a binary; the default runs the bundled per-platform one                          |
+| `mdsmith.trace.server` | `off`     | LSP trace verbosity: `off`, `messages`, or `verbose`                                 |
 
-`mdsmith.run` defaults to `onSave`. Linting on every keystroke
-is opt-in because its latency budget is tighter. To bind
-fix-on-save through `editor.codeActionsOnSave` instead of
-`mdsmith.fixOnSave`:
+`mdsmith.run` defaults to `onType`, so diagnostics update
+live as you type. `mdsmith.fixOnSave` layers auto-fixing on
+top, and `off` is a master switch: it stops diagnostics and
+suppresses fix-on-save, so a save never rewrites the buffer
+while `mdsmith.run` is `off`.
+
+| `mdsmith.run` | `mdsmith.fixOnSave` | Behavior                                          |
+| ------------- | ------------------- | ------------------------------------------------- |
+| `onType`      | `false`             | Diagnostics update live as you type (default)     |
+| `onType`      | `true`              | Live diagnostics; saving also auto-fixes the file |
+| `onSave`      | `false`             | Diagnostics update only when you save             |
+| `onSave`      | `true`              | Saving re-lints and auto-fixes the file           |
+| `off`         | either              | mdsmith is inert: no diagnostics, no fix-on-save  |
+
+To bind fix-on-save through `editor.codeActionsOnSave`
+instead of `mdsmith.fixOnSave`:
 
 ```jsonc
 {
@@ -143,6 +157,10 @@ fix-on-save through `editor.codeActionsOnSave` instead of
   }
 }
 ```
+
+This manual wiring is not gated by `mdsmith.run`: unlike
+`mdsmith.fixOnSave`, it still fixes on save even when
+`mdsmith.run` is `off`.
 
 ## Troubleshooting
 

--- a/docs/reference/cli/lsp.md
+++ b/docs/reference/cli/lsp.md
@@ -42,11 +42,10 @@ stdio transport. The server uses stdio either way.
 
 `mdsmith.run` controls when the server actually re-lints:
 
-- `onSave` (default): lint on `didOpen`, `didSave`, and config
-  changes. `didChange` events update the buffer but do not trigger a
-  lint pass.
-- `onType`: lint on every `didChange` (debounced 200 ms) plus the
-  same triggers as `onSave`.
+- `onType` (default): lint on every `didChange` (debounced 200 ms)
+  plus `didOpen`, `didSave`, and config changes.
+- `onSave`: lint on `didOpen`, `didSave`, and config changes only.
+  `didChange` events update the buffer but do not trigger a lint pass.
 - `off`: never lint automatically. Code actions still work when
   invoked explicitly.
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -48,7 +48,7 @@ code --install-extension mdsmith-<version>.vsix
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `mdsmith.path`         | `"mdsmith"` | Binary path; default runs the bundled per-platform binary. Set an absolute path to override; falls back to PATH only if your platform was not bundled (e.g. `/go/bin/mdsmith`) |
 | `mdsmith.config`       | `""`        | Override `-c` config path                                                                                                                                                      |
-| `mdsmith.run`          | `"onType"`  | When to lint: `onType` (default), `onSave`, or `off` (off disables mdsmith entirely)                                                                                           |
+| `mdsmith.run`          | `"onType"`  | When to lint: `onType` (default), `onSave`, or `off` (off stops automatic linting)                                                                                             |
 | `mdsmith.fixOnSave`    | `false`     | Auto-fix on save; ignored when `mdsmith.run` is `off`                                                                                                                          |
 | `mdsmith.trace.server` | `"off"`     | LSP trace verbosity                                                                                                                                                            |
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -48,8 +48,8 @@ code --install-extension mdsmith-<version>.vsix
 | ---------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `mdsmith.path`         | `"mdsmith"` | Binary path; default runs the bundled per-platform binary. Set an absolute path to override; falls back to PATH only if your platform was not bundled (e.g. `/go/bin/mdsmith`) |
 | `mdsmith.config`       | `""`        | Override `-c` config path                                                                                                                                                      |
-| `mdsmith.run`          | `"onSave"`  | When to lint: `onType`, `onSave`, or `off`                                                                                                                                     |
-| `mdsmith.fixOnSave`    | `false`     | Wires `source.fixAll.mdsmith` on save                                                                                                                                          |
+| `mdsmith.run`          | `"onType"`  | When to lint: `onType` (default), `onSave`, or `off` (off disables mdsmith entirely)                                                                                           |
+| `mdsmith.fixOnSave`    | `false`     | Auto-fix on save; ignored when `mdsmith.run` is `off`                                                                                                                          |
 | `mdsmith.trace.server` | `"off"`     | LSP trace verbosity                                                                                                                                                            |
 
 See the

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -154,10 +154,10 @@
           "enumDescriptions": [
             "Re-lint on every keystroke (debounced). Live diagnostics as you type.",
             "Re-lint only when the file is saved.",
-            "Disable mdsmith entirely: no diagnostics, and fix-on-save is suppressed even if mdsmith.fixOnSave is on."
+            "Stop automatic linting: no diagnostics, and fix-on-save is suppressed even if mdsmith.fixOnSave is on. Explicit quick fixes still work when invoked."
           ],
           "default": "onType",
-          "description": "When mdsmith lints. `onType` (default) re-lints on each keystroke (debounced); `onSave` re-lints only on save; `off` disables mdsmith entirely — no diagnostics, and `mdsmith.fixOnSave` is ignored."
+          "description": "When mdsmith lints. `onType` (default) re-lints on each keystroke (debounced); `onSave` re-lints only on save; `off` stops automatic linting — no diagnostics, and `mdsmith.fixOnSave` is ignored (explicit quick fixes still work)."
         },
         "mdsmith.fixOnSave": {
           "type": "boolean",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -151,13 +151,18 @@
             "onSave",
             "off"
           ],
-          "default": "onSave",
-          "description": "When to run the linter. `onSave` re-lints on save. `onType` re-lints with each keystroke (debounced). `off` disables linting."
+          "enumDescriptions": [
+            "Re-lint on every keystroke (debounced). Live diagnostics as you type.",
+            "Re-lint only when the file is saved.",
+            "Disable mdsmith entirely: no diagnostics, and fix-on-save is suppressed even if mdsmith.fixOnSave is on."
+          ],
+          "default": "onType",
+          "description": "When mdsmith lints. `onType` (default) re-lints on each keystroke (debounced); `onSave` re-lints only on save; `off` disables mdsmith entirely — no diagnostics, and `mdsmith.fixOnSave` is ignored."
         },
         "mdsmith.fixOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "Run mdsmith fix on save. Equivalent to wiring source.fixAll.mdsmith into editor.codeActionsOnSave."
+          "description": "Auto-fix on save by wiring `source.fixAll.mdsmith` into the save flow. Subordinate to `mdsmith.run`: when `mdsmith.run` is `off`, fix-on-save is suppressed and a save never rewrites the buffer."
         },
         "mdsmith.previewFix": {
           "type": "boolean",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -19,7 +19,9 @@ import {
   collectFixAllEdits,
   forwardMdsmithConfigChange,
   notifyConfigChangeToClient,
-  startupErrorMessage
+  shouldFixOnSave,
+  startupErrorMessage,
+  RUN_ON_TYPE
 } from "./wiring";
 import { findBinaryCandidates, resolveBinary } from "./binary";
 import { runFixWorkspace } from "./commands/fix-workspace";
@@ -48,13 +50,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   registerPaletteCommands(context);
 
-  // Wire fix-on-save once. The handler reads the setting on every
-  // save so toggling the option does not require a restart.
+  // Wire fix-on-save once. The handler reads both settings on every
+  // save so toggling either option does not require a restart.
+  // fixOnSave is gated by mdsmith.run: when run is "off" mdsmith is
+  // inert, so a save must not rewrite the buffer even if fixOnSave was
+  // left on (shouldFixOnSave centralizes that rule).
   context.subscriptions.push(
     vscode.workspace.onWillSaveTextDocument((event) => {
       if (event.document.languageId !== "markdown") return;
-      const fixOnSave = vscode.workspace.getConfiguration("mdsmith").get<boolean>("fixOnSave", false);
-      if (!fixOnSave) return;
+      const cfg = vscode.workspace.getConfiguration("mdsmith");
+      const run = cfg.get<string>("run", RUN_ON_TYPE);
+      const fixOnSave = cfg.get<boolean>("fixOnSave", false);
+      if (!shouldFixOnSave(run, fixOnSave)) return;
       event.waitUntil(
         vscode.commands.executeCommand(
           "vscode.executeCodeActionProvider",

--- a/editors/vscode/src/settings.test.ts
+++ b/editors/vscode/src/settings.test.ts
@@ -7,7 +7,10 @@ const pkg = JSON.parse(
 ) as {
   contributes?: {
     configuration?: {
-      properties?: Record<string, { type?: string; default?: unknown }>;
+      properties?: Record<
+        string,
+        { type?: string; default?: unknown; enum?: string[] }
+      >;
     };
   };
 };
@@ -17,6 +20,28 @@ const props = pkg.contributes?.configuration?.properties ?? {};
 describe("package.json settings", () => {
   test("mdsmith.previewFix is a boolean defaulting to false", () => {
     const setting = props["mdsmith.previewFix"];
+    expect(setting).toBeDefined();
+    expect(setting.type).toBe("boolean");
+    expect(setting.default).toBe(false);
+  });
+
+  test("mdsmith.run defaults to onType — lint as you type", () => {
+    // The shipped default is live linting; onSave and off are opt-in.
+    // Keep this in lockstep with the Go server's runMode default
+    // (internal/lsp/server.go) so VS Code and bare LSP clients agree.
+    const setting = props["mdsmith.run"];
+    expect(setting).toBeDefined();
+    expect(setting.type).toBe("string");
+    expect(setting.default).toBe("onType");
+  });
+
+  test("mdsmith.run offers exactly onType, onSave, off", () => {
+    const setting = props["mdsmith.run"];
+    expect(setting.enum).toEqual(["onType", "onSave", "off"]);
+  });
+
+  test("mdsmith.fixOnSave is a boolean defaulting to false", () => {
+    const setting = props["mdsmith.fixOnSave"];
     expect(setting).toBeDefined();
     expect(setting.type).toBe("boolean");
     expect(setting.default).toBe(false);

--- a/editors/vscode/src/wiring.test.ts
+++ b/editors/vscode/src/wiring.test.ts
@@ -19,6 +19,7 @@ import {
   collectFixAllEdits,
   forwardMdsmithConfigChange,
   notifyConfigChangeToClient,
+  shouldFixOnSave,
   startupErrorMessage,
   type CodeActionLike,
   type FileSystemWatcherLike,
@@ -342,6 +343,26 @@ describe("notifyConfigChangeToClient", () => {
     // Bun would surface an unhandledRejection and fail the test here.
     await new Promise((r) => setTimeout(r, 0));
     expect(f.sends()).toBe(1);
+  });
+});
+
+describe("shouldFixOnSave", () => {
+  test("fixes on save when fixOnSave is on and run is not off", () => {
+    expect(shouldFixOnSave("onType", true)).toBe(true);
+    expect(shouldFixOnSave("onSave", true)).toBe(true);
+  });
+
+  test("never fixes when run is off, even if fixOnSave is on", () => {
+    // run=off is the master switch: mdsmith is inert, so a save must
+    // not rewrite the buffer. Mirrors the server publishing no
+    // diagnostics in off mode.
+    expect(shouldFixOnSave("off", true)).toBe(false);
+  });
+
+  test("never fixes when fixOnSave is off, whatever the run mode", () => {
+    expect(shouldFixOnSave("onType", false)).toBe(false);
+    expect(shouldFixOnSave("onSave", false)).toBe(false);
+    expect(shouldFixOnSave("off", false)).toBe(false);
   });
 });
 

--- a/editors/vscode/src/wiring.test.ts
+++ b/editors/vscode/src/wiring.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 // `vscode-languageclient/node` does an unconditional `require("vscode")`
 // at import time, but the `vscode` package is only available inside the
@@ -21,6 +23,9 @@ import {
   notifyConfigChangeToClient,
   shouldFixOnSave,
   startupErrorMessage,
+  RUN_OFF,
+  RUN_ON_SAVE,
+  RUN_ON_TYPE,
   type CodeActionLike,
   type FileSystemWatcherLike,
   type UriLike
@@ -363,6 +368,25 @@ describe("shouldFixOnSave", () => {
     expect(shouldFixOnSave("onType", false)).toBe(false);
     expect(shouldFixOnSave("onSave", false)).toBe(false);
     expect(shouldFixOnSave("off", false)).toBe(false);
+  });
+});
+
+describe("run-mode constants", () => {
+  test("match the mdsmith.run enum declared in package.json", () => {
+    // wiring.ts claims to mirror package.json's mdsmith.run enum; pin
+    // that here so the constants and the contributed setting cannot
+    // drift apart — a drift would make shouldFixOnSave (and the
+    // willSave handler) compare against a value VS Code never sends.
+    const pkg = JSON.parse(
+      readFileSync(resolve(__dirname, "../package.json"), "utf-8")
+    ) as {
+      contributes: {
+        configuration: { properties: Record<string, { enum?: string[] }> };
+      };
+    };
+    const runEnum =
+      pkg.contributes.configuration.properties["mdsmith.run"].enum;
+    expect(runEnum).toEqual([RUN_ON_TYPE, RUN_ON_SAVE, RUN_OFF]);
   });
 });
 

--- a/editors/vscode/src/wiring.ts
+++ b/editors/vscode/src/wiring.ts
@@ -255,17 +255,18 @@ export function notifyConfigChangeToClient<T extends RunningClientLike>(
 // Run modes for `mdsmith.run`. Mirror the enum declared in
 // package.json and the runMode constants in the Go server
 // (internal/lsp/server.go): onType lints live as you type, onSave
-// lints only on save, and off disables mdsmith entirely.
+// lints only on save, and off stops automatic linting (no
+// diagnostics; explicit code actions still work when invoked).
 export const RUN_ON_TYPE = "onType";
 export const RUN_ON_SAVE = "onSave";
 export const RUN_OFF = "off";
 
 // shouldFixOnSave decides whether the willSave handler runs the
 // whole-file fix. `mdsmith.fixOnSave` is subordinate to `mdsmith.run`:
-// when run is "off" mdsmith is inert, so a save must not rewrite the
-// buffer even if fixOnSave was left on — matching the server, which
-// publishes no diagnostics in off mode. onType and onSave both allow
-// fix-on-save when fixOnSave is enabled.
+// when run is "off" automatic linting is disabled, so a save must not
+// rewrite the buffer even if fixOnSave was left on — matching the
+// server, which publishes no diagnostics in off mode. onType and
+// onSave both allow fix-on-save when fixOnSave is enabled.
 export function shouldFixOnSave(run: string, fixOnSave: boolean): boolean {
   return fixOnSave && run !== RUN_OFF;
 }

--- a/editors/vscode/src/wiring.ts
+++ b/editors/vscode/src/wiring.ts
@@ -252,6 +252,24 @@ export function notifyConfigChangeToClient<T extends RunningClientLike>(
   void send(client).catch(() => {});
 }
 
+// Run modes for `mdsmith.run`. Mirror the enum declared in
+// package.json and the runMode constants in the Go server
+// (internal/lsp/server.go): onType lints live as you type, onSave
+// lints only on save, and off disables mdsmith entirely.
+export const RUN_ON_TYPE = "onType";
+export const RUN_ON_SAVE = "onSave";
+export const RUN_OFF = "off";
+
+// shouldFixOnSave decides whether the willSave handler runs the
+// whole-file fix. `mdsmith.fixOnSave` is subordinate to `mdsmith.run`:
+// when run is "off" mdsmith is inert, so a save must not rewrite the
+// buffer even if fixOnSave was left on — matching the server, which
+// publishes no diagnostics in off mode. onType and onSave both allow
+// fix-on-save when fixOnSave is enabled.
+export function shouldFixOnSave(run: string, fixOnSave: boolean): boolean {
+  return fixOnSave && run !== RUN_OFF;
+}
+
 // Minimal shapes of the bits of vscode.CodeAction / WorkspaceEdit /
 // Uri / TextEdit we touch when filtering fixAll edits. Defining them
 // here lets tests drive the pure pipeline without importing `vscode`.

--- a/internal/lsp/bench_test.go
+++ b/internal/lsp/bench_test.go
@@ -24,8 +24,8 @@ import (
 
 // BenchmarkLatency1kLines measures end-to-end didChange →
 // publishDiagnostics latency on a 1 000-line synthetic Markdown
-// document. Plan 121 sets a p95 budget of 150 ms; missing it blocks
-// the default `mdsmith.run` from flipping to `onType`.
+// document. Plan 121 sets a p95 budget of 150 ms; the benchmark
+// guards that budget now that `onType` is the default `mdsmith.run`.
 func BenchmarkLatency1kLines(b *testing.B) {
 	benchLatency(b, 1000, 150*time.Millisecond)
 }
@@ -48,9 +48,9 @@ func benchLatency(b *testing.B, lines int, budget time.Duration) {
 	// timeout to every benchmark run.
 	h := newBenchHarness(b)
 
-	// Force `mdsmith.run = onType` for the benchmark — it intentionally
-	// drives didChange events that would otherwise be filtered when
-	// run defaults to onSave.
+	// Force `mdsmith.run = onType` so the benchmark stays independent
+	// of the production default (also onType) and always drives the
+	// didChange events that onSave would otherwise filter.
 	h.srv.settingsMu.Lock()
 	h.srv.settings.Run = runOnType
 	h.srv.settingsMu.Unlock()

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -937,6 +937,39 @@ func (s *Server) runMode() string {
 	}
 }
 
+// clearOpenDiagnostics drops every published diagnostic for open
+// documents and asks the client to remove the squiggles. Used when
+// mdsmith.run flips to off: scheduleLint publishes nothing in off
+// mode, so diagnostics shown before the switch would otherwise linger
+// until the buffer is closed. Any armed debounce timer is cancelled
+// first so a lint scheduled just before the switch cannot re-publish
+// after the clear.
+func (s *Server) clearOpenDiagnostics() {
+	for _, uri := range s.docs.openURIs() {
+		// Collect the pending timer under pendingMu, then Stop outside
+		// the lock — Stop hits the runtime timer heap and can block,
+		// and holding pendingMu across it would serialize scheduleLint.
+		s.pendingMu.Lock()
+		pending, hadPending := s.pending[uri]
+		if hadPending {
+			delete(s.pending, uri)
+		}
+		s.pendingMu.Unlock()
+		if hadPending && pending.timer != nil {
+			pending.timer.Stop()
+		}
+		s.diagsMu.Lock()
+		delete(s.diags, uri)
+		s.diagsMu.Unlock()
+		version := 0
+		if doc, ok := s.docs.get(uri); ok {
+			version = doc.version
+		}
+		_ = s.t.writeNotification("textDocument/publishDiagnostics",
+			publishDiagnosticsParams{URI: uri, Version: version, Diagnostics: []Diagnostic{}})
+	}
+}
+
 // runLint executes one lint pass on the buffer and publishes the
 // resulting diagnostics. Safe to call from any goroutine.
 //
@@ -1719,8 +1752,16 @@ func (s *Server) fetchClientSettings(ctx context.Context) {
 		// applied settings rather than whatever was in effect when
 		// handleDidChangeConfiguration fired.
 		s.reloadConfig()
-		for _, uri := range s.docs.openURIs() {
-			s.scheduleLint(uri, lintTriggerConfig)
+		if s.runMode() == runOff {
+			// off is a master switch: scheduleLint publishes nothing
+			// in off mode, so squiggles shown before the switch would
+			// linger until the buffer closes. Drop them and tell the
+			// client to clear them.
+			s.clearOpenDiagnostics()
+		} else {
+			for _, uri := range s.docs.openURIs() {
+				s.scheduleLint(uri, lintTriggerConfig)
+			}
 		}
 	case <-timeout.C:
 		// Client never replied; defaults stand.

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -199,7 +199,7 @@ func New(opts Options) *Server {
 		onConfigReload: opts.OnConfigReload,
 		logger:         logger,
 		docs:           newDocumentStore(),
-		settings:       userSettings{Run: runOnSave},
+		settings:       userSettings{Run: runOnType},
 		pending:        make(map[string]*pendingLint),
 		pendingResp:    make(map[string]chan rpcResponse),
 		diags:          make(map[string][]Diagnostic),
@@ -933,7 +933,7 @@ func (s *Server) runMode() string {
 	case runOff, runOnSave, runOnType:
 		return s.settings.Run
 	default:
-		return runOnSave
+		return runOnType
 	}
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -958,15 +958,20 @@ func (s *Server) clearOpenDiagnostics() {
 		if hadPending && pending.timer != nil {
 			pending.timer.Stop()
 		}
-		s.diagsMu.Lock()
-		delete(s.diags, uri)
-		s.diagsMu.Unlock()
 		version := 0
 		if doc, ok := s.docs.get(uri); ok {
 			version = doc.version
 		}
+		// Delete and publish the empty set under diagsMu so this clear
+		// serializes with runLint's mode-checked publish (which holds
+		// the same lock across its check and write). Once mdsmith.run is
+		// off, an in-flight lint either skips publishing or is ordered
+		// before this clear — so the empty set is always the last word.
+		s.diagsMu.Lock()
+		delete(s.diags, uri)
 		_ = s.t.writeNotification("textDocument/publishDiagnostics",
 			publishDiagnosticsParams{URI: uri, Version: version, Diagnostics: []Diagnostic{}})
+		s.diagsMu.Unlock()
 	}
 }
 
@@ -1041,16 +1046,6 @@ func (s *Server) runLint(uri string) {
 	if _, ok := s.docs.get(uri); !ok {
 		return
 	}
-	// run mode can flip to off while the CPU-bound RunSource above was
-	// in flight (the user toggled mdsmith.run mid-lint).
-	// fetchClientSettings already cleared the squiggles for that switch
-	// via clearOpenDiagnostics; re-check here so this in-flight pass
-	// does not re-publish them and undo the master switch. Normal
-	// scheduling never reaches runLint in off mode — scheduleLint
-	// returns early — so this only guards the race.
-	if s.runMode() == runOff {
-		return
-	}
 	// Mirror `mdsmith check`: surface lint pipeline errors (parse
 	// failures, oversized buffers, config-target rule errors) to
 	// the editor instead of silently dropping them. Otherwise the
@@ -1070,11 +1065,22 @@ func (s *Server) runLint(uri string) {
 	docDiags, otherDiags := partitionDocDiagnostics(res.Diagnostics, relPath)
 	s.surfaceForeignDiagnostics(uri, otherDiags)
 	lspDiags := toLSPAll(docDiags, doc.text)
-	// Cache before publishing so hover requests that arrive after the
-	// client observes the notification always find current diagnostics.
+	// Cache and publish under diagsMu, re-checking the run mode inside
+	// the lock. mdsmith.run can flip to off while the CPU-bound
+	// RunSource above is in flight; clearOpenDiagnostics deletes and
+	// publishes the empty set under the same lock when that happens.
+	// Holding diagsMu across the check, the cache, and the wire write
+	// serializes the two: an in-flight lint either sees off and
+	// publishes nothing, or publishes under the lock before the clear —
+	// whose empty publish is then ordered last — so off stays a true
+	// master switch with no stale squiggles. Caching before the write
+	// also keeps hover consistent with what the client just received.
 	s.diagsMu.Lock()
+	defer s.diagsMu.Unlock()
+	if s.runMode() == runOff {
+		return
+	}
 	s.diags[uri] = lspDiags
-	s.diagsMu.Unlock()
 	_ = s.t.writeNotification("textDocument/publishDiagnostics",
 		publishDiagnosticsParams{URI: uri, Version: doc.version, Diagnostics: lspDiags})
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1041,6 +1041,16 @@ func (s *Server) runLint(uri string) {
 	if _, ok := s.docs.get(uri); !ok {
 		return
 	}
+	// run mode can flip to off while the CPU-bound RunSource above was
+	// in flight (the user toggled mdsmith.run mid-lint).
+	// fetchClientSettings already cleared the squiggles for that switch
+	// via clearOpenDiagnostics; re-check here so this in-flight pass
+	// does not re-publish them and undo the master switch. Normal
+	// scheduling never reaches runLint in off mode — scheduleLint
+	// returns early — so this only guards the race.
+	if s.runMode() == runOff {
+		return
+	}
 	// Mirror `mdsmith check`: surface lint pipeline errors (parse
 	// failures, oversized buffers, config-target rule errors) to
 	// the editor instead of silently dropping them. Otherwise the

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1555,6 +1555,38 @@ func TestFetchClientSettingsAppliesResponse(t *testing.T) {
 	assert.Equal(t, "/tmp/x.yml", s.settings.ConfigPath)
 }
 
+func TestFetchClientSettingsOffClearsDiagnostics(t *testing.T) {
+	t.Parallel()
+	var buf safeBuffer
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
+	// Seed an open document with a previously published diagnostic, as
+	// if an onType/onSave lint had already run and shown a squiggle.
+	uri := "file:///x.md"
+	s.docs.set(uri, &document{
+		uri: uri, path: "x.md", text: []byte("# Hi\n"), version: 1,
+	})
+	s.diagsMu.Lock()
+	s.diags[uri] = []Diagnostic{{Message: "stale"}}
+	s.diagsMu.Unlock()
+
+	// Client switches mdsmith.run to off.
+	done := make(chan struct{})
+	go func() { defer close(done); s.fetchClientSettings(context.Background()) }()
+	deliverPendingResponse(t, s, json.RawMessage(`[{"run":"off"}]`), nil)
+	awaitDone(t, done)
+
+	// off is a master switch: cached diagnostics for the open document
+	// must be dropped and an empty publishDiagnostics sent so the editor
+	// removes the squiggles instead of leaving them until the buffer is
+	// closed.
+	s.diagsMu.RLock()
+	got := s.diags[uri]
+	s.diagsMu.RUnlock()
+	assert.Empty(t, got, "switching to run=off must clear cached diagnostics")
+	assert.Contains(t, buf.String(), `"diagnostics":[]`,
+		"switching to run=off must publish empty diagnostics")
+}
+
 func TestFetchClientSettingsIgnoresErrorResponse(t *testing.T) {
 	t.Parallel()
 	var buf safeBuffer

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -100,8 +100,8 @@ func newHarnessWithDebounce(t *testing.T, debounce time.Duration) *testHarness {
 		Debounce: debounce,
 	})
 	// Tests want lint-on-didChange to fire so they can verify the
-	// pipeline. Production defaults to onSave (skipping didChange);
-	// flipping to onType keeps the existing tests deterministic.
+	// pipeline. Production also defaults to onType now; setting it
+	// explicitly keeps the harness independent of that default.
 	srv.settingsMu.Lock()
 	srv.settings.Run = runOnType
 	srv.settingsMu.Unlock()
@@ -807,7 +807,11 @@ func TestScheduleLintOnSaveSkipsChange(t *testing.T) {
 	t.Parallel()
 	var buf safeBuffer
 	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
-	// Default run mode is onSave.
+	// Production now defaults to onType, so opt into onSave explicitly
+	// to exercise the didChange-skip path this test covers.
+	s.settingsMu.Lock()
+	s.settings.Run = runOnSave
+	s.settingsMu.Unlock()
 	s.docs.set("file:///x.md", &document{
 		uri: "file:///x.md", path: "x.md", text: []byte("# Hi\n\ndirty   \n"),
 	})
@@ -840,7 +844,7 @@ func TestRunModeFallsBackOnEmpty(t *testing.T) {
 	s.settingsMu.Lock()
 	s.settings.Run = ""
 	s.settingsMu.Unlock()
-	assert.Equal(t, runOnSave, s.runMode())
+	assert.Equal(t, runOnType, s.runMode())
 }
 
 func TestFetchClientSettingsHandlesEmptyArray(t *testing.T) {
@@ -859,7 +863,7 @@ func TestFetchClientSettingsHandlesEmptyArray(t *testing.T) {
 	awaitDone(t, done)
 	s.settingsMu.RLock()
 	defer s.settingsMu.RUnlock()
-	assert.Equal(t, runOnSave, s.settings.Run)
+	assert.Equal(t, runOnType, s.settings.Run)
 }
 
 func TestFetchClientSettingsHandlesMalformedResult(t *testing.T) {
@@ -873,7 +877,7 @@ func TestFetchClientSettingsHandlesMalformedResult(t *testing.T) {
 	awaitDone(t, done)
 	s.settingsMu.RLock()
 	defer s.settingsMu.RUnlock()
-	assert.Equal(t, runOnSave, s.settings.Run)
+	assert.Equal(t, runOnType, s.settings.Run)
 }
 
 // deliverPendingResponse polls s.pendingResp for the (single)
@@ -1562,7 +1566,7 @@ func TestFetchClientSettingsIgnoresErrorResponse(t *testing.T) {
 	// Run should remain at the default; we just verify no panic.
 	s.settingsMu.RLock()
 	defer s.settingsMu.RUnlock()
-	assert.Equal(t, runOnSave, s.settings.Run)
+	assert.Equal(t, runOnType, s.settings.Run)
 }
 
 func TestDidChangeWatchedFilesRelintsOpenDocs(t *testing.T) {
@@ -2130,7 +2134,7 @@ func TestRunModeFallsBackOnUnknown(t *testing.T) {
 	s.settingsMu.Lock()
 	s.settings.Run = "garbage-mode"
 	s.settingsMu.Unlock()
-	assert.Equal(t, runOnSave, s.runMode())
+	assert.Equal(t, runOnType, s.runMode())
 }
 
 // Regression: catalog/toc/include used to be excluded from

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1587,6 +1587,65 @@ func TestFetchClientSettingsOffClearsDiagnostics(t *testing.T) {
 		"switching to run=off must publish empty diagnostics")
 }
 
+func TestClearOpenDiagnosticsCancelsPendingLint(t *testing.T) {
+	t.Parallel()
+	var buf safeBuffer
+	// Long debounce so the armed timer never fires during the test —
+	// clearOpenDiagnostics must cancel it, not race it.
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All(), Debounce: 10 * time.Second})
+	uri := "file:///x.md"
+	s.docs.set(uri, &document{
+		uri: uri, path: "x.md", text: []byte("# Hi\n"), version: 2,
+	})
+	// Arm a debounced lint (onType) and seed a cached diagnostic.
+	s.settingsMu.Lock()
+	s.settings.Run = runOnType
+	s.settingsMu.Unlock()
+	s.scheduleLint(uri, lintTriggerChange)
+	s.pendingMu.Lock()
+	_, armed := s.pending[uri]
+	s.pendingMu.Unlock()
+	require.True(t, armed, "precondition: a debounce timer is armed")
+	s.diagsMu.Lock()
+	s.diags[uri] = []Diagnostic{{Message: "stale"}}
+	s.diagsMu.Unlock()
+
+	s.clearOpenDiagnostics()
+
+	s.pendingMu.Lock()
+	_, stillArmed := s.pending[uri]
+	s.pendingMu.Unlock()
+	assert.False(t, stillArmed, "clearOpenDiagnostics must cancel the pending lint")
+	s.diagsMu.RLock()
+	_, cached := s.diags[uri]
+	s.diagsMu.RUnlock()
+	assert.False(t, cached, "clearOpenDiagnostics must drop cached diagnostics")
+	assert.Contains(t, buf.String(), `"diagnostics":[]`,
+		"clearOpenDiagnostics must publish empty diagnostics")
+}
+
+func TestRunLintSkipsPublishWhenOff(t *testing.T) {
+	t.Parallel()
+	var buf safeBuffer
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
+	// off is reachable inside runLint only via the race the guard
+	// covers: a lint already in flight when the user switches to off.
+	s.settingsMu.Lock()
+	s.settings.Run = runOff
+	s.settingsMu.Unlock()
+	uri := "file:///x.md"
+	s.docs.set(uri, &document{
+		uri: uri, path: "x.md", text: []byte("# Hi\n\ndirty   \n"), version: 1,
+	})
+	s.runLint(uri)
+	assert.NotContains(t, buf.String(), "publishDiagnostics",
+		"runLint must not publish while run mode is off")
+	s.diagsMu.RLock()
+	_, cached := s.diags[uri]
+	s.diagsMu.RUnlock()
+	assert.False(t, cached, "runLint must not cache diagnostics while run mode is off")
+}
+
 func TestFetchClientSettingsIgnoresErrorResponse(t *testing.T) {
 	t.Parallel()
 	var buf safeBuffer

--- a/plan/121_vscode-integration.md
+++ b/plan/121_vscode-integration.md
@@ -127,7 +127,7 @@ Settings the extension contributes:
 | ---------------------- | ----------- | ------------------------------------- |
 | `mdsmith.path`         | `"mdsmith"` | Binary path; resolved against `$PATH` |
 | `mdsmith.config`       | `""`        | Override `-c` config path             |
-| `mdsmith.run`          | `"onSave"`  | `onType`, `onSave`, or `off`          |
+| `mdsmith.run`          | `"onType"`  | `onType`, `onSave`, or `off`          |
 | `mdsmith.fixOnSave`    | `false`     | Wires `source.fixAll.mdsmith` on save |
 | `mdsmith.trace.server` | `"off"`     | LSP trace verbosity                   |
 
@@ -135,7 +135,7 @@ Settings the extension contributes:
 it to spawn the server. The server pulls only
 `mdsmith.config`, `mdsmith.run`, and
 `mdsmith.trace.server`. The `mdsmith.run` default
-is `onSave`. Live linting per keystroke is opt-in.
+is `onType`; `onSave` and `off` are opt-in.
 
 Document selector: `markdown` and `*.markdown` files.
 Activation event: `onLanguage:markdown`. The
@@ -166,8 +166,8 @@ buffer so config edits take effect immediately.
   150 ms on a 1 000-line file and under 500 ms on a
   5 000-line file, measured end-to-end (`didChange`
   to `publishDiagnostics`). The benchmark drives
-  the perf task; missing it blocks the default flip
-  to `onType`.
+  the perf task and guards the latency budget for
+  the `onType` default.
 
 ### Distribution
 


### PR DESCRIPTION
## Why

The VS Code extension lints **as you type**, but `mdsmith.run` was
documented and defaulted to `onSave` everywhere — package.json, the Go
server's init value, and the `runMode()` fallback. The labelled default
and the real behavior disagreed.

Separately, `mdsmith.run` (when to lint) and `mdsmith.fixOnSave` (auto-fix
on save) were wired completely independently: the save handler checked
only `fixOnSave`, never `run`. So `run: "off"` + `fixOnSave: true` still
silently rewrote the file on save — exactly the confusing combination
this PR removes.

## What changed

**a) `onType` is now the default**, consistently across:

- `editors/vscode/package.json` (`mdsmith.run.default` + new `enumDescriptions`)
- the Go LSP server (`internal/lsp/server.go`: init value and `runMode()`
  fallback) — so bare LSP clients (Neovim, Helix) get the same default
- the VS Code guide, LSP reference, extension README, and plan 121

**b) `mdsmith.fixOnSave` is now subordinate to `mdsmith.run`.** A new
`shouldFixOnSave(run, fixOnSave)` helper suppresses fix-on-save when
`run` is `off`. `off` is now a true master switch — no diagnostics **and**
no fix-on-save — so a disabled linter never rewrites a file on save.

| `run`    | `fixOnSave` | Behavior                                          |
| -------- | ----------- | ------------------------------------------------- |
| `onType` | `false`     | Diagnostics update live as you type (default)     |
| `onType` | `true`      | Live diagnostics; saving also auto-fixes the file |
| `onSave` | `false`     | Diagnostics update only when you save             |
| `onSave` | `true`      | Saving re-lints and auto-fixes the file           |
| `off`    | either      | mdsmith is inert: no diagnostics, no fix-on-save  |

The guide now carries this matrix so the semantics are explicit.

## Scope notes

- Explicit, on-demand code actions (lightbulb / a hand-wired
  `editor.codeActionsOnSave` entry) are unchanged — only the
  `mdsmith.fixOnSave` convenience toggle is gated by `run`. This is
  documented in the guide.
- The latency benchmark that gated the `onType` flip still runs and
  guards the live-linting budget; comments updated to reflect that
  `onType` is now the shipped default.

## Testing

- `go vet ./...` clean; `go test ./... -short` green (run-mode tests
  updated to assert the `onType` default; the onSave-skips-`didChange`
  test sets its mode explicitly)
- `bun test` green (108 tests) incl. new `shouldFixOnSave` and
  package.json default tests; `tsc --noEmit` clean; esbuild build OK
- `mdsmith check .` passes (388 files, 0 failures)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qix246YVb5MmsrjhGqUL7d)_