### PR TITLE
Add plan 230: navigable schema diagnostics in the editor

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -151,5 +151,5 @@ footer: |
 | 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
-| 221 | 🔲     | opus   | [Navigable schema diagnostics in the editor](plan/221_navigable-schema-diagnostics.md)                                                  |
+| 221 | 🔳     | opus   | [Navigable schema diagnostics in the editor](plan/221_navigable-schema-diagnostics.md)                                                  |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,4 +151,5 @@ footer: |
 | 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
+| 221 | 🔲     | opus   | [Navigable schema diagnostics in the editor](plan/221_navigable-schema-diagnostics.md)                                                  |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,5 +151,5 @@ footer: |
 | 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
-| 221 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/221_navigable-schema-diagnostics.md)                                                  |
+| 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,5 +151,5 @@ footer: |
 | 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
-| 221 | 🔳     | opus   | [Navigable schema diagnostics in the editor](plan/221_navigable-schema-diagnostics.md)                                                  |
+| 221 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/221_navigable-schema-diagnostics.md)                                                  |
 <?/catalog?>

--- a/docs/features/live-diagnostics.md
+++ b/docs/features/live-diagnostics.md
@@ -26,8 +26,10 @@ search spans the whole project.
 Implementation jumps to every
 target of a heading at once. Completion suggests anchors,
 labels, kind names, and directive paths as you type. Hover on a
-diagnostic leads with the issue and a link to the schema constraint
-it broke, then a condensed rule identity and a docs link.
+diagnostic leads with the issue; when it carries a related location
+(a schema check like MDS020 names the constraint it broke), a link
+to that source comes next, then a condensed rule identity and a
+docs link.
 
 Two capabilities have their own pages. [Rename](rename.md)
 rewrites a heading and every anchor link to it in one edit.

--- a/docs/features/live-diagnostics.md
+++ b/docs/features/live-diagnostics.md
@@ -26,8 +26,8 @@ search spans the whole project.
 Implementation jumps to every
 target of a heading at once. Completion suggests anchors,
 labels, kind names, and directive paths as you type. Hover on a
-diagnostic leads with the issue, then links to the schema
-constraint it broke and the rule's help.
+diagnostic leads with the issue and a link to the schema constraint
+it broke, then a condensed rule identity and a docs link.
 
 Two capabilities have their own pages. [Rename](rename.md)
 rewrites a heading and every anchor link to it in one edit.

--- a/docs/features/live-diagnostics.md
+++ b/docs/features/live-diagnostics.md
@@ -25,9 +25,9 @@ search spans the whole project.
 
 Implementation jumps to every
 target of a heading at once. Completion suggests anchors,
-labels, kind names, and directive paths as you type. Hover
-shows the rule's help on a diagnostic and the guide page on a
-directive.
+labels, kind names, and directive paths as you type. Hover on a
+diagnostic leads with the issue, then links to the schema
+constraint it broke and the rule's help.
 
 Two capabilities have their own pages. [Rename](rename.md)
 rewrites a heading and every anchor link to it in one edit.

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -46,9 +46,11 @@ indentation, and table alignment. Setting `mdsmith.run` to
 every fix routes through VS Code's Refactor Preview pane, so
 you see the diff before it is written.
 
-**Hover for help.** Hover a diagnostic for the rule's
-documentation; hover inside a `<?…?>` directive for its guide
-page.
+**Hover for help.** Hover a diagnostic for the rule's one-line
+summary plus a link that opens its full documentation offline:
+a read-only tab rendered from the binary's embedded README, no
+browser or network. Hover inside a `<?…?>` directive for its
+guide page.
 
 ### Across your project
 

--- a/editors/vscode/src/commands/rule-doc.test.ts
+++ b/editors/vscode/src/commands/rule-doc.test.ts
@@ -3,6 +3,7 @@ import type { SpawnFn } from "./runner";
 import {
   buildRuleDocUri,
   fetchRuleDocContent,
+  isRuleId,
   OPEN_RULE_DOC_COMMAND,
   parseRuleDocUri,
   rewriteHoverMarkdown,
@@ -11,6 +12,21 @@ import {
   RULE_SCHEME,
   type MarkdownLike,
 } from "./rule-doc";
+
+// ---- isRuleId ----
+
+describe("isRuleId", () => {
+  test("accepts MDS followed by digits, case-insensitive", () => {
+    expect(isRuleId("MDS020")).toBe(true);
+    expect(isRuleId("mds1")).toBe(true);
+  });
+
+  test("rejects slugs, partials, flags, and empties", () => {
+    for (const bad of ["", "MDS", "MDS01a", "required-structure", "mds020-required-structure", "--version"]) {
+      expect(isRuleId(bad)).toBe(false);
+    }
+  });
+});
 
 // ---- buildRuleDocUri / parseRuleDocUri ----
 

--- a/editors/vscode/src/commands/rule-doc.test.ts
+++ b/editors/vscode/src/commands/rule-doc.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import type { SpawnFn } from "./runner";
+import {
+  buildRuleDocUri,
+  fetchRuleDocContent,
+  OPEN_RULE_DOC_COMMAND,
+  parseRuleDocUri,
+  rewriteHoverMarkdown,
+  rewriteRuleDocLinks,
+  ruleDocCommandUri,
+  RULE_SCHEME,
+  type MarkdownLike,
+} from "./rule-doc";
+
+// ---- buildRuleDocUri / parseRuleDocUri ----
+
+describe("buildRuleDocUri", () => {
+  test("encodes the rule ID in the query, preserving case", () => {
+    expect(buildRuleDocUri("MDS020")).toBe(`${RULE_SCHEME}://doc?id=MDS020`);
+  });
+
+  test("round-trips through parseRuleDocUri", () => {
+    expect(parseRuleDocUri(buildRuleDocUri("MDS001"))).toEqual({ id: "MDS001" });
+  });
+});
+
+describe("parseRuleDocUri", () => {
+  test("extracts a well-formed rule ID", () => {
+    expect(parseRuleDocUri("mdsmith-rule://doc?id=MDS042")).toEqual({ id: "MDS042" });
+  });
+
+  test("rejects the wrong scheme", () => {
+    expect(parseRuleDocUri("mdsmith-kinds://doc?id=MDS001")).toBeNull();
+  });
+
+  test("rejects the wrong host", () => {
+    expect(parseRuleDocUri("mdsmith-rule://rule?id=MDS001")).toBeNull();
+  });
+
+  test("rejects a missing id", () => {
+    expect(parseRuleDocUri("mdsmith-rule://doc")).toBeNull();
+  });
+
+  test("rejects a malformed URI", () => {
+    expect(parseRuleDocUri("not a uri")).toBeNull();
+  });
+
+  test("rejects an id that is not a rule ID (defense-in-depth)", () => {
+    // A crafted URI must never smuggle an arbitrary argument into the
+    // spawned `mdsmith help rule`.
+    expect(parseRuleDocUri("mdsmith-rule://doc?id=--version")).toBeNull();
+    expect(parseRuleDocUri("mdsmith-rule://doc?id=required-structure")).toBeNull();
+  });
+});
+
+// ---- ruleDocCommandUri ----
+
+describe("ruleDocCommandUri", () => {
+  test("builds a command URI with the ID as a JSON argument", () => {
+    expect(ruleDocCommandUri("MDS020")).toBe(
+      `command:${OPEN_RULE_DOC_COMMAND}?${encodeURIComponent('["MDS020"]')}`,
+    );
+  });
+});
+
+// ---- rewriteRuleDocLinks ----
+
+describe("rewriteRuleDocLinks", () => {
+  test("rewrites a published rule-docs link to the offline command", () => {
+    const md = "[Open rule docs ↗](https://mdsmith.dev/rules/mds020-required-structure/)";
+    expect(rewriteRuleDocLinks(md)).toBe(
+      `[Open rule docs ↗](${ruleDocCommandUri("MDS020")})`,
+    );
+  });
+
+  test("preserves the link label", () => {
+    const md = "see [the docs](https://mdsmith.dev/rules/mds001-line-length/) now";
+    expect(rewriteRuleDocLinks(md)).toBe(
+      `see [the docs](${ruleDocCommandUri("MDS001")}) now`,
+    );
+  });
+
+  test("is host-agnostic", () => {
+    const md = "[d](https://docs.example.test/rules/mds007-no-tabs)";
+    expect(rewriteRuleDocLinks(md)).toBe(`[d](${ruleDocCommandUri("MDS007")})`);
+  });
+
+  test("rewrites every link when several are present", () => {
+    const md =
+      "[a](https://mdsmith.dev/rules/mds001-x/) and [b](https://mdsmith.dev/rules/mds002-y/)";
+    expect(rewriteRuleDocLinks(md)).toBe(
+      `[a](${ruleDocCommandUri("MDS001")}) and [b](${ruleDocCommandUri("MDS002")})`,
+    );
+  });
+
+  test("leaves markdown without a rule-docs link untouched", () => {
+    const md = "MDS020 — see [home](https://mdsmith.dev/) for more";
+    expect(rewriteRuleDocLinks(md)).toBe(md);
+  });
+});
+
+// ---- rewriteHoverMarkdown ----
+
+describe("rewriteHoverMarkdown", () => {
+  test("rewrites and trusts only the open-rule-doc command", () => {
+    const md: MarkdownLike = {
+      value: "[Open rule docs ↗](https://mdsmith.dev/rules/mds020-required-structure/)",
+    };
+    expect(rewriteHoverMarkdown(md)).toBe(true);
+    expect(md.value).toBe(`[Open rule docs ↗](${ruleDocCommandUri("MDS020")})`);
+    expect(md.isTrusted).toEqual({ enabledCommands: [OPEN_RULE_DOC_COMMAND] });
+  });
+
+  test("leaves an unrelated block untouched, including its trust level", () => {
+    const md: MarkdownLike = { value: "just a message", isTrusted: false };
+    expect(rewriteHoverMarkdown(md)).toBe(false);
+    expect(md.value).toBe("just a message");
+    expect(md.isTrusted).toBe(false);
+  });
+});
+
+// ---- fetchRuleDocContent ----
+
+const fakeSpawn =
+  (result: { stdout?: string; stderr?: string; exitCode?: number }, capture?: (args: string[]) => void): SpawnFn =>
+  async (_binary, args) => {
+    capture?.(args);
+    return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", exitCode: result.exitCode ?? 0 };
+  };
+
+describe("fetchRuleDocContent", () => {
+  test("returns the embedded README on success and passes the bare ID", async () => {
+    let seen: string[] = [];
+    const out = await fetchRuleDocContent(
+      buildRuleDocUri("MDS020"),
+      "mdsmith",
+      undefined,
+      fakeSpawn({ stdout: "# MDS020: required-structure\n\nbody\n" }, (a) => (seen = a)),
+    );
+    expect(seen).toEqual(["help", "rule", "MDS020"]);
+    expect(out).toBe("# MDS020: required-structure\n\nbody\n");
+  });
+
+  test("reports a malformed URI without spawning", async () => {
+    let spawned = false;
+    const out = await fetchRuleDocContent(
+      "mdsmith-rule://doc?id=nope",
+      "mdsmith",
+      undefined,
+      fakeSpawn({}, () => (spawned = true)),
+    );
+    expect(spawned).toBe(false);
+    expect(out).toContain("malformed rule URI");
+  });
+
+  test("reports a non-zero exit with stderr", async () => {
+    const out = await fetchRuleDocContent(
+      buildRuleDocUri("MDS999"),
+      "mdsmith",
+      undefined,
+      fakeSpawn({ stderr: "mdsmith: unknown rule MDS999", exitCode: 2 }),
+    );
+    expect(out).toContain("failed (exit 2)");
+    expect(out).toContain("unknown rule MDS999");
+  });
+
+  test("reports a spawn failure", async () => {
+    const failing: SpawnFn = async () => {
+      throw new Error("ENOENT");
+    };
+    const out = await fetchRuleDocContent(buildRuleDocUri("MDS001"), "mdsmith", undefined, failing);
+    expect(out).toContain("could not start");
+    expect(out).toContain("ENOENT");
+  });
+});

--- a/editors/vscode/src/commands/rule-doc.ts
+++ b/editors/vscode/src/commands/rule-doc.ts
@@ -1,0 +1,140 @@
+// Offline rule documentation: a TextDocumentContentProvider backing for
+// the mdsmith-rule: URI scheme plus the hover-link rewrite that points
+// VS Code at it instead of the public docs website.
+//
+// The LSP server emits hover links to <https://mdsmith.dev/rules/…> so
+// that *any* editor gets a working link. mdsmith itself never fetches
+// that URL — but following it needs a browser and a network. Because the
+// full rule README is embedded in the binary and printed offline by
+// `mdsmith help rule <id>`, the extension rewrites that link to a
+// command: link that opens the README in a read-only virtual document.
+// Closing the tab discards the buffer; nothing touches the network.
+//
+// URI format:
+//   mdsmith-rule://doc?id=<RULE-ID>
+
+import { SpawnFn, defaultSpawn } from "./runner";
+
+export const RULE_SCHEME = "mdsmith-rule";
+
+// OPEN_RULE_DOC_COMMAND is the command a rewritten hover link invokes.
+// It is registered programmatically (not a palette command) and is the
+// only command the rewritten MarkdownString trusts.
+export const OPEN_RULE_DOC_COMMAND = "mdsmith.openRuleDoc";
+
+// RULE_ID_RE matches an mdsmith rule ID. Rule IDs are always "MDS"
+// followed by digits; `mdsmith help rule` accepts the bare ID (case
+// insensitive) but not the docs slug, so the ID is what we extract and
+// pass through.
+const RULE_ID_RE = /^MDS\d+$/i;
+
+// RULE_DOC_LINK_RE matches a Markdown link target that points at a
+// published rule-docs page, e.g.
+//   ](https://mdsmith.dev/rules/mds020-required-structure/)
+// It is host-agnostic — it keys off the "/rules/<id>-<name>/" path so a
+// docs-host change does not silently disable the offline rewrite — and
+// captures the lower-cased rule ID (group 2) out of the slug prefix.
+const RULE_DOC_LINK_RE =
+  /\]\((https?:\/\/[^\s)]*\/rules\/(mds\d+)-[a-z0-9-]*\/?)\)/gi;
+
+// buildRuleDocUri returns the virtual-document URI for a rule ID. The ID
+// rides in a query parameter (not the hostname) so its case survives URL
+// normalization.
+export function buildRuleDocUri(id: string): string {
+  return `${RULE_SCHEME}://doc?id=${encodeURIComponent(id)}`;
+}
+
+// parseRuleDocUri extracts the rule ID from a mdsmith-rule: URI. Returns
+// null when the URI is malformed, has the wrong scheme/host, carries no
+// id, or the id is not a well-formed rule ID. The last guard is
+// defense-in-depth: only "MDS<digits>" ever reaches the spawned binary,
+// so a hand-crafted mdsmith-rule:// URI cannot smuggle an arbitrary
+// argument into `mdsmith help rule`.
+export function parseRuleDocUri(uri: string): { id: string } | null {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== `${RULE_SCHEME}:`) return null;
+  if (url.hostname !== "doc") return null;
+  const id = url.searchParams.get("id");
+  if (!id || !RULE_ID_RE.test(id)) return null;
+  return { id };
+}
+
+// ruleDocCommandUri returns the command: URI that opens the offline rule
+// doc for an ID, with the ID encoded as the command's single JSON
+// argument. Only fires when the hosting MarkdownString trusts
+// OPEN_RULE_DOC_COMMAND.
+export function ruleDocCommandUri(id: string): string {
+  const args = encodeURIComponent(JSON.stringify([id]));
+  return `command:${OPEN_RULE_DOC_COMMAND}?${args}`;
+}
+
+// rewriteRuleDocLinks swaps every published rule-docs link target in a
+// hover markdown string for a command: link that opens the doc offline.
+// The link label is preserved. Returns the input unchanged when it holds
+// no rule-docs link, so the caller can leave non-rule hovers (and their
+// trust level) untouched.
+export function rewriteRuleDocLinks(markdown: string): string {
+  return markdown.replace(
+    RULE_DOC_LINK_RE,
+    (_full, _url: string, idLower: string) =>
+      `](${ruleDocCommandUri(idLower.toUpperCase())})`,
+  );
+}
+
+// MarkdownLike is the structural subset of vscode.MarkdownString the
+// hover rewrite touches. Defined here so the transform is unit-testable
+// without the vscode runtime.
+export interface MarkdownLike {
+  value: string;
+  isTrusted?: boolean | { readonly enabledCommands: readonly string[] };
+}
+
+// rewriteHoverMarkdown rewrites rule-docs links in one markdown block
+// and, when it changed anything, trusts ONLY OPEN_RULE_DOC_COMMAND so the
+// command link is clickable without opening the markdown to arbitrary
+// commands. Returns true when the block was rewritten. Blocks with no
+// rule-docs link are left untouched — including their isTrusted — so we
+// never broaden trust on unrelated hovers.
+export function rewriteHoverMarkdown(md: MarkdownLike): boolean {
+  const next = rewriteRuleDocLinks(md.value);
+  if (next === md.value) return false;
+  md.value = next;
+  md.isTrusted = { enabledCommands: [OPEN_RULE_DOC_COMMAND] };
+  return true;
+}
+
+// fetchRuleDocContent runs `mdsmith help rule <id>` and returns the
+// embedded README markdown. On error the stderr (or spawn failure) is
+// returned as plain text. Fully offline: help rule reads READMEs
+// embedded in the binary and makes no network call.
+export async function fetchRuleDocContent(
+  uri: string,
+  binary: string,
+  workspaceRoot: string | undefined,
+  spawn: SpawnFn = defaultSpawn,
+): Promise<string> {
+  const parsed = parseRuleDocUri(uri);
+  if (!parsed) {
+    return `**mdsmith: malformed rule URI**\n\n~~~\n${uri}\n~~~`;
+  }
+
+  const args = ["help", "rule", parsed.id];
+
+  let result: Awaited<ReturnType<typeof spawn>>;
+  try {
+    result = await spawn(binary, args, workspaceRoot);
+  } catch (err) {
+    return `**mdsmith help rule could not start**\n\n~~~\n${err}\n~~~`;
+  }
+
+  if (result.exitCode !== 0) {
+    return `**mdsmith help rule ${parsed.id} failed (exit ${result.exitCode})**\n\n~~~\n${result.stderr.trim()}\n~~~`;
+  }
+
+  return result.stdout.trimEnd() + "\n";
+}

--- a/editors/vscode/src/commands/rule-doc.ts
+++ b/editors/vscode/src/commands/rule-doc.ts
@@ -28,6 +28,14 @@ export const OPEN_RULE_DOC_COMMAND = "mdsmith.openRuleDoc";
 // pass through.
 const RULE_ID_RE = /^MDS\d+$/i;
 
+// isRuleId reports whether s is a well-formed mdsmith rule ID. The
+// mdsmith-rule: URI, the link rewrite, and the openRuleDoc command all
+// gate on this — the single source of truth for the constraint — so only
+// a real rule ID ever reaches the spawned `mdsmith help rule`.
+export function isRuleId(s: string): boolean {
+  return RULE_ID_RE.test(s);
+}
+
 // RULE_DOC_LINK_RE matches a Markdown link target that points at a
 // published rule-docs page, e.g.
 //   ](https://mdsmith.dev/rules/mds020-required-structure/)
@@ -60,7 +68,7 @@ export function parseRuleDocUri(uri: string): { id: string } | null {
   if (url.protocol !== `${RULE_SCHEME}:`) return null;
   if (url.hostname !== "doc") return null;
   const id = url.searchParams.get("id");
-  if (!id || !RULE_ID_RE.test(id)) return null;
+  if (!id || !isRuleId(id)) return null;
   return { id };
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -34,6 +34,7 @@ import {
   OPEN_RULE_DOC_COMMAND,
   buildRuleDocUri,
   fetchRuleDocContent,
+  isRuleId,
   rewriteHoverMarkdown,
 } from "./commands/rule-doc";
 
@@ -511,11 +512,13 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
     }),
 
     // Open a rule's embedded README in a read-only virtual document.
-    // Invoked only from hover links the middleware rewrote (and trusted
-    // via isTrusted.enabledCommands), so id is always a rule ID — but
-    // registerCommand is callable programmatically, so guard anyway.
+    // Invoked from hover links the middleware rewrote (and trusted via
+    // isTrusted.enabledCommands), so id is normally a rule ID. But
+    // registerCommand is globally callable, so enforce the same
+    // MDS<digits> shape here and no-op on anything else, rather than
+    // opening a tab that just reports a malformed URI.
     vscode.commands.registerCommand(OPEN_RULE_DOC_COMMAND, async (id?: string) => {
-      if (!id) return;
+      if (!id || !isRuleId(id)) return;
       const doc = await vscode.workspace.openTextDocument(
         vscode.Uri.parse(buildRuleDocUri(id))
       );

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -29,6 +29,13 @@ import { runInit } from "./commands/init";
 import { runMergeDriverInstall } from "./commands/merge-driver";
 import { runKindsResolve, runKindsWhy, makeKindsContentProvider } from "./commands/kinds";
 import { KINDS_SCHEME, parseKindsUri } from "./commands/virtual-doc";
+import {
+  RULE_SCHEME,
+  OPEN_RULE_DOC_COMMAND,
+  buildRuleDocUri,
+  fetchRuleDocContent,
+  rewriteHoverMarkdown,
+} from "./commands/rule-doc";
 
 let client: LanguageClient | undefined;
 // Track the .mdsmith.yml file watcher across the activate /
@@ -141,6 +148,26 @@ async function startServer(context: vscode.ExtensionContext): Promise<void> {
   // extension. The mdsmith.restartServer command stays the
   // explicit manual recovery path either way.
   clientOptions.errorHandler = new MdsmithErrorHandler();
+
+  // Rewrite the server's public-website rule-docs links (in hovers) so
+  // they open the README offline from the bundled binary instead of a
+  // browser. The server keeps emitting https links so editors without
+  // this extension still get a working link; VS Code intercepts them
+  // here and points them at the mdsmith-rule: virtual document. See
+  // commands/rule-doc.ts.
+  clientOptions.middleware = {
+    provideHover: async (document, position, token, next) => {
+      const hover = await next(document, position, token);
+      if (hover) {
+        for (const block of hover.contents) {
+          if (block instanceof vscode.MarkdownString) {
+            rewriteHoverMarkdown(block);
+          }
+        }
+      }
+      return hover;
+    },
+  };
 
   client = new LanguageClient("mdsmith", "mdsmith", serverOptions, clientOptions);
 
@@ -483,6 +510,22 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       });
     }),
 
+    // Open a rule's embedded README in a read-only virtual document.
+    // Invoked only from hover links the middleware rewrote (and trusted
+    // via isTrusted.enabledCommands), so id is always a rule ID — but
+    // registerCommand is callable programmatically, so guard anyway.
+    vscode.commands.registerCommand(OPEN_RULE_DOC_COMMAND, async (id?: string) => {
+      if (!id) return;
+      const doc = await vscode.workspace.openTextDocument(
+        vscode.Uri.parse(buildRuleDocUri(id))
+      );
+      const mdDoc = await vscode.languages.setTextDocumentLanguage(doc, "markdown");
+      await vscode.window.showTextDocument(mdDoc, {
+        preview: true,
+        viewColumn: vscode.ViewColumn.Beside,
+      });
+    }),
+
     // Register the virtual document provider for the mdsmith-kinds: scheme.
     vscode.workspace.registerTextDocumentContentProvider(
       KINDS_SCHEME,
@@ -509,6 +552,17 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
           const provider = makeKindsContentProvider(binary, fileFolder?.uri.fsPath);
           return provider.provideTextDocumentContent(uriStr);
         },
+      }
+    ),
+
+    // Register the virtual document provider for the mdsmith-rule: scheme,
+    // which renders `mdsmith help rule <id>` (the embedded README) offline
+    // so the rewritten hover doc link opens without a browser or network.
+    vscode.workspace.registerTextDocumentContentProvider(
+      RULE_SCHEME,
+      {
+        provideTextDocumentContent: (uri: vscode.Uri) =>
+          fetchRuleDocContent(uri.toString(), getBinary(), getWorkspaceRoot()),
       }
     ),
 

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -377,7 +377,7 @@ func effectiveRules(cfg *Config, filePath string, kinds []string) map[string]Rul
 			continue
 		}
 		if resolved := resolvedInlineSchema(cfg.Kinds, kindName, body); len(resolved) > 0 {
-			applyInlineSchemaSource(result, resolved)
+			applyInlineSchemaSource(result, resolved, body.SourcePath)
 		}
 		if body.PathPattern != "" {
 			applyPathPattern(result, kindName, body.PathPattern)
@@ -472,7 +472,7 @@ func resolvedInlineSchema(
 // applyInlineSchemaSource appends a KindBody.Schema (inline schema
 // map) as a `schema-sources` entry. Multiple kinds with inline
 // schemas thus accumulate rather than overwrite.
-func applyInlineSchemaSource(result map[string]RuleCfg, schema map[string]any) {
+func applyInlineSchemaSource(result map[string]RuleCfg, schema map[string]any, sourcePath string) {
 	rs, ok := result["required-structure"]
 	if !ok {
 		rs = RuleCfg{Enabled: true}
@@ -481,6 +481,13 @@ func applyInlineSchemaSource(result map[string]RuleCfg, schema map[string]any) {
 		rs.Settings = map[string]any{}
 	}
 	entry := map[string]any{"inline": cloneSettings(schema)}
+	// Carry the kind's defining file so an inline-schema violation
+	// points the reader at <.mdsmith.yml or kind file> rather than the
+	// bare "inline kind schema" label (plan 221). The rule reads this
+	// as the schema reference; it is not part of the schema content.
+	if sourcePath != "" {
+		entry["source"] = sourcePath
+	}
 	existing, _ := rs.Settings["schema-sources"].([]any)
 	rs.Settings["schema-sources"] = append(existing, entry)
 	rs.Enabled = true

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -483,7 +483,7 @@ func applyInlineSchemaSource(result map[string]RuleCfg, schema map[string]any, s
 	entry := map[string]any{"inline": cloneSettings(schema)}
 	// Carry the kind's defining file so an inline-schema violation
 	// points the reader at <.mdsmith.yml or kind file> rather than the
-	// bare "inline kind schema" label (plan 221). The rule reads this
+	// bare "inline kind schema" label (plan 230). The rule reads this
 	// as the schema reference; it is not part of the schema content.
 	if sourcePath != "" {
 		entry["source"] = sourcePath

--- a/internal/config/schema_kinds_test.go
+++ b/internal/config/schema_kinds_test.go
@@ -139,7 +139,7 @@ func TestEffectiveInjectsInlineSchema(t *testing.T) {
 	require.Contains(t, got, "sections")
 }
 
-// TestEffectiveInjectsInlineSchemaSourcePath covers plan 221: the
+// TestEffectiveInjectsInlineSchemaSourcePath covers plan 230: the
 // kind's defining file (SourcePath) rides on the schema-sources entry
 // as `source`, so an inline-kind violation names a navigable file
 // instead of the bare "inline kind schema" label.

--- a/internal/config/schema_kinds_test.go
+++ b/internal/config/schema_kinds_test.go
@@ -139,6 +139,33 @@ func TestEffectiveInjectsInlineSchema(t *testing.T) {
 	require.Contains(t, got, "sections")
 }
 
+// TestEffectiveInjectsInlineSchemaSourcePath covers plan 221: the
+// kind's defining file (SourcePath) rides on the schema-sources entry
+// as `source`, so an inline-kind violation names a navigable file
+// instead of the bare "inline kind schema" label.
+func TestEffectiveInjectsInlineSchemaSourcePath(t *testing.T) {
+	cfg := &Config{
+		Rules: map[string]RuleCfg{"required-structure": {Enabled: true}},
+		Kinds: map[string]KindBody{
+			"rfc": {
+				Schema: map[string]any{
+					"sections": []any{map[string]any{"heading": "Overview"}},
+				},
+				SourcePath: "/work/.mdsmith.yml",
+			},
+		},
+		KindAssignment: []KindAssignmentEntry{
+			{Glob: []string{"docs/rfcs/*.md"}, Kinds: []string{"rfc"}},
+		},
+	}
+	effective := Effective(cfg, "docs/rfcs/foo.md", nil, nil)
+	sources, ok := effective["required-structure"].Settings["schema-sources"].([]any)
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	entry := sources[0].(map[string]any)
+	require.Equal(t, "/work/.mdsmith.yml", entry["source"])
+}
+
 // TestEffectiveComposesSchemaSourcesAcrossKinds covers plan 156: when
 // kind A supplies a file-path schema and kind B supplies an inline
 // schema, both end up in the composed schema-sources list rather

--- a/internal/engine/kinds_test.go
+++ b/internal/engine/kinds_test.go
@@ -263,7 +263,9 @@ func TestKindPathPattern_MismatchEmitsMDS020(t *testing.T) {
 	d := result.Diagnostics[0]
 	assert.Equal(t, "MDS020", d.RuleID)
 	assert.Contains(t, d.Message, `path: got "plan/early-draft.md"`)
-	assert.Contains(t, d.Message, "kinds[plan] / path-pattern")
+	// The schema reference now rides on a structured related location.
+	require.Len(t, d.RelatedLocations, 1)
+	assert.Equal(t, "kinds[plan] / path-pattern", d.RelatedLocations[0].Message)
 }
 
 // TestKindPathPattern_MatchEmitsNoDiagnostic is the green half of the

--- a/internal/extract/bind_test.go
+++ b/internal/extract/bind_test.go
@@ -89,6 +89,10 @@ func TestExtract_BindHoistCollisionFlagged(t *testing.T) {
 		sch, nil)
 	require.NotEmpty(t, diags)
 	assert.Contains(t, diags[0].Message, "goal")
+	// The schema reference must survive as a related location (plan
+	// 221 moved it off the message; extract must Emit, not hand-build).
+	require.Len(t, diags[0].RelatedLocations, 1,
+		"collision diagnostic carries the schema reference")
 }
 
 // TestExtract_BindRepeatingHoistRejected covers the edge case where

--- a/internal/extract/bind_test.go
+++ b/internal/extract/bind_test.go
@@ -90,7 +90,7 @@ func TestExtract_BindHoistCollisionFlagged(t *testing.T) {
 	require.NotEmpty(t, diags)
 	assert.Contains(t, diags[0].Message, "goal")
 	// The schema reference must survive as a related location (plan
-	// 221 moved it off the message; extract must Emit, not hand-build).
+	// 230 moved it off the message; extract must Emit, not hand-build).
 	require.Len(t, diags[0].RelatedLocations, 1,
 		"collision diagnostic carries the schema reference")
 }

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -334,7 +334,7 @@ func (p *projector) collision(key, why string) {
 	//
 	// Route through Emit (rather than building the Diagnostic by hand)
 	// so the schema reference rides on a RelatedLocation like every
-	// other MDS020 emit site — Format() no longer carries it (plan 221).
+	// other MDS020 emit site — Format() no longer carries it (plan 230).
 	mk := func(file string, line int, msg string) lint.Diagnostic {
 		return lint.Diagnostic{
 			File:     file,

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -325,19 +325,24 @@ func (p *projector) collision(key, why string) {
 		Hint:      why,
 		SchemaRef: schema.FormatSchemaRef(p.sch, ""),
 	}
-	p.diags = append(p.diags, lint.Diagnostic{
-		File: p.f.Path,
-		// Extract returns its diagnostics straight to the CLI
-		// formatter without running them through
-		// lint.File.AdjustDiagnostics, so this must already be an
-		// absolute file line. schema.NonBodyDiagLine returns
-		// 1-LineOffset (meant for later adjustment) and would
-		// print a zero/negative line for front-matter-stripped
-		// files; line 1 is the correct fixed anchor for a
-		// whole-document projection error.
-		Line:     1,
-		RuleID:   "MDS020",
-		Severity: lint.Error,
-		Message:  d.Format(),
-	})
+	// Extract returns its diagnostics straight to the CLI formatter
+	// without running them through lint.File.AdjustDiagnostics, so the
+	// line must already be an absolute file line. schema.NonBodyDiagLine
+	// returns 1-LineOffset (meant for later adjustment) and would print
+	// a zero/negative line for front-matter-stripped files; line 1 is
+	// the correct fixed anchor for a whole-document projection error.
+	//
+	// Route through Emit (rather than building the Diagnostic by hand)
+	// so the schema reference rides on a RelatedLocation like every
+	// other MDS020 emit site — Format() no longer carries it (plan 221).
+	mk := func(file string, line int, msg string) lint.Diagnostic {
+		return lint.Diagnostic{
+			File:     file,
+			Line:     line,
+			RuleID:   "MDS020",
+			Severity: lint.Error,
+			Message:  msg,
+		}
+	}
+	p.diags = append(p.diags, d.Emit(mk, p.f.Path, 1))
 }

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -155,6 +155,15 @@ func parseFixtureFrontMatter(
 				"diagnostic %d sets both message: and message-prefix:; choose one",
 				i)
 		}
+		// Same mutual-exclusion guard on each related-location entry:
+		// assertRelated picks the prefix silently, so fail loudly here.
+		for j, r := range d.Related {
+			if r.Message != "" && r.MessagePrefix != "" {
+				t.Fatalf(
+					"diagnostic %d related %d sets both message: and message-prefix:; choose one",
+					i, j)
+			}
+		}
 	}
 
 	return fm.Settings, fm.Diagnostics, content

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -96,7 +96,7 @@ type expectedDiag struct {
 	// starts with this string. Mutually exclusive with Message.
 	MessagePrefix string `yaml:"message-prefix"`
 	// Related, when present, asserts the diagnostic's structured
-	// related locations (plan 221). Opt-in: an empty list skips the
+	// related locations (plan 230). Opt-in: an empty list skips the
 	// check, so only fixtures that exercise the schema reference need
 	// to declare it.
 	Related []expectedRelated `yaml:"related"`

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -95,6 +95,21 @@ type expectedDiag struct {
 	// decoder). The fixture asserts that the actual message
 	// starts with this string. Mutually exclusive with Message.
 	MessagePrefix string `yaml:"message-prefix"`
+	// Related, when present, asserts the diagnostic's structured
+	// related locations (plan 221). Opt-in: an empty list skips the
+	// check, so only fixtures that exercise the schema reference need
+	// to declare it.
+	Related []expectedRelated `yaml:"related"`
+}
+
+// expectedRelated asserts one RelatedLocation on a diagnostic. File
+// and Line are checked only when non-zero so a fixture can assert a
+// label-only related location (message, no navigable file/line).
+type expectedRelated struct {
+	File          string `yaml:"file"`
+	Line          int    `yaml:"line"`
+	Message       string `yaml:"message"`
+	MessagePrefix string `yaml:"message-prefix"`
 }
 
 type fixtureFrontMatter struct {
@@ -555,6 +570,46 @@ func assertExpectedDiags(
 		} else {
 			assert.Equal(t, exp.Message, d.Message,
 				"diagnostic %d message mismatch", i)
+		}
+		assertRelated(t, i, exp.Related, d.RelatedLocations)
+	}
+}
+
+// assertRelated checks a diagnostic's structured related locations
+// against the fixture's opt-in `related:` block. An empty expectation
+// skips the check. File and Line are compared only when the fixture
+// sets them, so a label-only related location (no navigable file)
+// can be asserted by its message alone.
+func assertRelated(
+	t *testing.T, idx int,
+	expected []expectedRelated, actual []lint.RelatedLocation,
+) {
+	t.Helper()
+	if len(expected) == 0 {
+		return
+	}
+	if !assert.Len(t, actual, len(expected),
+		"diagnostic %d related-location count", idx) {
+		return
+	}
+	for j, er := range expected {
+		al := actual[j]
+		if er.File != "" {
+			assert.Equal(t, er.File, al.File,
+				"diagnostic %d related %d file", idx, j)
+		}
+		if er.Line != 0 {
+			assert.Equal(t, er.Line, al.Line,
+				"diagnostic %d related %d line", idx, j)
+		}
+		switch {
+		case er.MessagePrefix != "":
+			assert.True(t, strings.HasPrefix(al.Message, er.MessagePrefix),
+				"diagnostic %d related %d message %q does not start with %q",
+				idx, j, al.Message, er.MessagePrefix)
+		case er.Message != "":
+			assert.Equal(t, er.Message, al.Message,
+				"diagnostic %d related %d message", idx, j)
 		}
 	}
 }

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -54,12 +54,11 @@ type Diagnostic struct {
 	// file, or .mdsmith.yml). The CLI prints these as trailer lines;
 	// the LSP maps them onto DiagnosticRelatedInformation. Nil on
 	// diagnostics that carry no secondary location.
+	//
+	// The rule-documentation link surfaced as the LSP codeDescription
+	// is not stored here: it is fully derived from RuleID at the LSP
+	// surface (see rules.DocURL), so there is no per-diagnostic field.
 	RelatedLocations []RelatedLocation
-
-	// DocURL, when non-empty, is the canonical documentation URL for the
-	// rule that fired. The LSP maps it onto Diagnostic.codeDescription
-	// so the rule code renders as a clickable link; the CLI ignores it.
-	DocURL string
 }
 
 // RelatedLocation is a secondary source location attached to a

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -61,6 +61,21 @@ type Diagnostic struct {
 	RelatedLocations []RelatedLocation
 }
 
+// DisplayLine returns Line clamped to at least 1 for user-facing output
+// (CLI text, JSON, and the public API). plan 221 may anchor a diagnostic
+// at a non-positive line internally so it survives generated-section
+// filtering when no safe positive anchor exists (a wholly generated
+// file); that sentinel must never surface as line 0 in 1-based output.
+// Column is not clamped: 0 is the established "column unknown" value
+// (the text formatter prints it and omits the caret), and
+// RelatedLocation lines keep their own 0 = "unknown" semantics too.
+func (d Diagnostic) DisplayLine() int {
+	if d.Line < 1 {
+		return 1
+	}
+	return d.Line
+}
+
 // RelatedLocation is a secondary source location attached to a
 // Diagnostic. It points the reader at the thing that explains the
 // finding — for a schema violation, the line of the schema constraint.

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -62,7 +62,7 @@ type Diagnostic struct {
 }
 
 // DisplayLine returns Line clamped to at least 1 for user-facing output
-// (CLI text, JSON, and the public API). plan 221 may anchor a diagnostic
+// (CLI text, JSON, and the public API). plan 230 may anchor a diagnostic
 // at a non-positive line internally so it survives generated-section
 // filtering when no safe positive anchor exists (a wholly generated
 // file); that sentinel must never surface as line 0 in 1-based output.

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -46,6 +46,41 @@ type Diagnostic struct {
 	// deprecation declares one. Empty on non-deprecation diagnostics
 	// and on deprecation diagnostics that only set `message:`.
 	ReplacedBy string
+
+	// RelatedLocations carries secondary source locations that explain
+	// the diagnostic — for MDS020, the schema constraint a value
+	// violated. A location may point at a different file than the one
+	// the diagnostic anchors in (the schema lives in proto.md, a kind
+	// file, or .mdsmith.yml). The CLI prints these as trailer lines;
+	// the LSP maps them onto DiagnosticRelatedInformation. Nil on
+	// diagnostics that carry no secondary location.
+	RelatedLocations []RelatedLocation
+
+	// DocURL, when non-empty, is the canonical documentation URL for the
+	// rule that fired. The LSP maps it onto Diagnostic.codeDescription
+	// so the rule code renders as a clickable link; the CLI ignores it.
+	DocURL string
+}
+
+// RelatedLocation is a secondary source location attached to a
+// Diagnostic. It points the reader at the thing that explains the
+// finding — for a schema violation, the line of the schema constraint.
+// File may differ from the owning Diagnostic.File: the schema that a
+// document violates lives in a separate proto.md, kind file, or config.
+type RelatedLocation struct {
+	// File is the path of the related source. It may be the linted
+	// file itself or a separate schema source.
+	File string
+
+	// Line is the 1-based line of the related location.
+	Line int
+
+	// Column is the 1-based column, or 0 when only the line is known.
+	Column int
+
+	// Message describes why the location is related, e.g.
+	// `schema requires one of: "open", "in-progress"`.
+	Message string
 }
 
 // Explanation describes the provenance of a rule's effective config at

--- a/internal/lint/diagnostic_test.go
+++ b/internal/lint/diagnostic_test.go
@@ -73,7 +73,7 @@ func TestLineRange_Contains(t *testing.T) {
 }
 
 // TestDiagnostic_DisplayLineClamp covers DisplayLine: a non-positive
-// sentinel (plan 221's wholly-generated anchor) clamps to 1 for 1-based
+// sentinel (plan 230's wholly-generated anchor) clamps to 1 for 1-based
 // output, while a real line passes through unchanged.
 func TestDiagnostic_DisplayLineClamp(t *testing.T) {
 	assert.Equal(t, 1, Diagnostic{Line: 0}.DisplayLine(), "zero clamps to 1")

--- a/internal/lint/diagnostic_test.go
+++ b/internal/lint/diagnostic_test.go
@@ -71,3 +71,12 @@ func TestLineRange_Contains(t *testing.T) {
 	assert.False(t, r.Contains(4), "before range")
 	assert.False(t, r.Contains(9), "after range")
 }
+
+// TestDiagnostic_DisplayLineClamp covers DisplayLine: a non-positive
+// sentinel (plan 221's wholly-generated anchor) clamps to 1 for 1-based
+// output, while a real line passes through unchanged.
+func TestDiagnostic_DisplayLineClamp(t *testing.T) {
+	assert.Equal(t, 1, Diagnostic{Line: 0}.DisplayLine(), "zero clamps to 1")
+	assert.Equal(t, 1, Diagnostic{Line: -3}.DisplayLine(), "negative clamps to 1")
+	assert.Equal(t, 7, Diagnostic{Line: 7}.DisplayLine(), "real line passes through")
+}

--- a/internal/lint/diagnostic_test.go
+++ b/internal/lint/diagnostic_test.go
@@ -34,7 +34,6 @@ func TestDiagnosticRelatedLocations(t *testing.T) {
 		RuleName: "required-structure",
 		Severity: Error,
 		Message:  `status: got "draft", expected one of "open"`,
-		DocURL:   "https://mdsmith.dev/rules/MDS020",
 		RelatedLocations: []RelatedLocation{{
 			File:    "plan/proto.md",
 			Line:    4,
@@ -43,7 +42,6 @@ func TestDiagnosticRelatedLocations(t *testing.T) {
 		}},
 	}
 
-	assert.Equal(t, "https://mdsmith.dev/rules/MDS020", d.DocURL)
 	if assert.Len(t, d.RelatedLocations, 1) {
 		rl := d.RelatedLocations[0]
 		assert.Equal(t, "plan/proto.md", rl.File)
@@ -54,11 +52,10 @@ func TestDiagnosticRelatedLocations(t *testing.T) {
 }
 
 func TestDiagnosticZeroValueHasNoRelatedLocations(t *testing.T) {
-	// A diagnostic built without the new fields keeps the old shape:
-	// a nil related-locations slice and an empty doc URL.
+	// A diagnostic built without the new field keeps the old shape:
+	// a nil related-locations slice.
 	d := Diagnostic{File: "README.md", Line: 10, RuleID: "MDS001"}
 	assert.Nil(t, d.RelatedLocations)
-	assert.Empty(t, d.DocURL)
 }
 
 func TestSeverityConstants(t *testing.T) {

--- a/internal/lint/diagnostic_test.go
+++ b/internal/lint/diagnostic_test.go
@@ -26,6 +26,41 @@ func TestDiagnosticFields(t *testing.T) {
 	assert.Equal(t, "line too long (120 > 80)", d.Message)
 }
 
+func TestDiagnosticRelatedLocations(t *testing.T) {
+	d := Diagnostic{
+		File:     "task.md",
+		Line:     1,
+		RuleID:   "MDS020",
+		RuleName: "required-structure",
+		Severity: Error,
+		Message:  `status: got "draft", expected one of "open"`,
+		DocURL:   "https://mdsmith.dev/rules/MDS020",
+		RelatedLocations: []RelatedLocation{{
+			File:    "plan/proto.md",
+			Line:    4,
+			Column:  3,
+			Message: `schema requires one of: "open", "in-progress"`,
+		}},
+	}
+
+	assert.Equal(t, "https://mdsmith.dev/rules/MDS020", d.DocURL)
+	if assert.Len(t, d.RelatedLocations, 1) {
+		rl := d.RelatedLocations[0]
+		assert.Equal(t, "plan/proto.md", rl.File)
+		assert.Equal(t, 4, rl.Line)
+		assert.Equal(t, 3, rl.Column)
+		assert.Equal(t, `schema requires one of: "open", "in-progress"`, rl.Message)
+	}
+}
+
+func TestDiagnosticZeroValueHasNoRelatedLocations(t *testing.T) {
+	// A diagnostic built without the new fields keeps the old shape:
+	// a nil related-locations slice and an empty doc URL.
+	d := Diagnostic{File: "README.md", Line: 10, RuleID: "MDS001"}
+	assert.Nil(t, d.RelatedLocations)
+	assert.Empty(t, d.DocURL)
+}
+
 func TestSeverityConstants(t *testing.T) {
 	assert.Equal(t, Severity("error"), Error)
 	assert.Equal(t, Severity("warning"), Warning)

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -87,7 +87,7 @@ func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRe
 			Character: clampZero(loc.Column - 1),
 		}
 		out = append(out, diagnosticRelatedInformation{
-			Location: Location{URI: uri, Range: Range{Start: pos, End: pos}},
+			Location: location{URI: uri, Range: Range{Start: pos, End: pos}},
 			Message:  loc.Message,
 		})
 	}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"bytes"
+	"path/filepath"
 	"unicode/utf8"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -29,7 +30,7 @@ import (
 // on the same line, which clamps every input to [0, line's UTF-16
 // length], so endCol is always >= startCol — no end-before-start
 // guard is needed.
-func toLSP(d lint.Diagnostic, lines [][]byte) Diagnostic {
+func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
 	startLine := d.Line - 1
 	if startLine < 0 {
 		startLine = 0
@@ -37,7 +38,7 @@ func toLSP(d lint.Diagnostic, lines [][]byte) Diagnostic {
 	line := currentLineBytes(lines, d.Line)
 	startCol := mdtext.UTF16FromByteOffset(line, d.Column-1)
 	endCol := utf16Length(line)
-	return Diagnostic{
+	out := Diagnostic{
 		Range: Range{
 			Start: Position{Line: startLine, Character: startCol},
 			End:   Position{Line: startLine, Character: endCol},
@@ -52,15 +53,63 @@ func toLSP(d lint.Diagnostic, lines [][]byte) Diagnostic {
 			ReplacedBy: d.ReplacedBy,
 		},
 	}
+	if ri := relatedInformation(d.RelatedLocations, root); len(ri) > 0 {
+		out.RelatedInformation = ri
+	}
+	if d.DocURL != "" {
+		out.CodeDescription = &codeDescription{Href: d.DocURL}
+	}
+	return out
+}
+
+// relatedInformation converts structured related locations to the LSP
+// wire form, resolving each file to a file:// URI against root
+// (a workspace-relative schema path becomes absolute first). A related
+// location with no File — an inline-schema label that names no source
+// file — cannot become a navigable URI and is dropped here; the CLI
+// still surfaces it as a trailer line. Coordinates flip 1-based →
+// 0-based and clamp at 0, so a file-only ref (Line 0) anchors at the
+// schema's first line.
+func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRelatedInformation {
+	var out []diagnosticRelatedInformation
+	for _, loc := range locs {
+		if loc.File == "" {
+			continue
+		}
+		path := loc.File
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, path)
+		}
+		pos := Position{
+			Line:      clampZero(loc.Line - 1),
+			Character: clampZero(loc.Column - 1),
+		}
+		out = append(out, diagnosticRelatedInformation{
+			Location: Location{URI: pathToURI(path), Range: Range{Start: pos, End: pos}},
+			Message:  loc.Message,
+		})
+	}
+	return out
+}
+
+// clampZero returns n, or 0 when n is negative. Used to flip 1-based
+// schema coordinates to 0-based LSP coordinates without underflowing
+// when the line or column is unknown (0).
+func clampZero(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
 }
 
 // toLSPAll maps a slice. Returns an empty (non-nil) slice for empty
-// input so the JSON wire form is `[]`, never `null`.
-func toLSPAll(diags []lint.Diagnostic, source []byte) []Diagnostic {
+// input so the JSON wire form is `[]`, never `null`. root resolves
+// cross-file related-location URIs (see relatedInformation).
+func toLSPAll(diags []lint.Diagnostic, source []byte, root string) []Diagnostic {
 	out := make([]Diagnostic, 0, len(diags))
 	lines := splitLines(source)
 	for _, d := range diags {
-		out = append(out, toLSP(d, lines))
+		out = append(out, toLSP(d, lines, root))
 	}
 	return out
 }

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/mdtext"
+	"github.com/jeduden/mdsmith/internal/rules"
 )
 
 // toLSP converts an mdsmith diagnostic to the LSP wire shape.
@@ -56,8 +57,16 @@ func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
 	if ri := relatedInformation(d.RelatedLocations, root); len(ri) > 0 {
 		out.RelatedInformation = ri
 	}
-	if d.DocURL != "" {
-		out.CodeDescription = &codeDescription{Href: d.DocURL}
+	// codeDescription gives the rule code a clickable docs link. A
+	// diagnostic may carry an explicit DocURL override; otherwise the
+	// canonical rule-doc URL is derived from the rule ID. Unknown IDs
+	// (rules.DocURL returns "") leave codeDescription unset.
+	href := d.DocURL
+	if href == "" {
+		href = rules.DocURL(d.RuleID)
+	}
+	if href != "" {
+		out.CodeDescription = &codeDescription{Href: href}
 	}
 	return out
 }

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -95,27 +95,25 @@ func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRe
 }
 
 // relatedURI resolves a related-location file to a file:// URI, or
-// reports ok=false when no safe, navigable URI exists. A label-only
-// location (empty File) is dropped. Both absolute and relative paths
-// must resolve inside the workspace root when one is known, so a config
-// that points a schema source at an arbitrary local file (e.g.
-// /etc/passwd from a malicious repo) is never turned into a navigable
-// editor link; a "../" escape is dropped for the same reason. With no
-// root there is nothing to bound an absolute path against, so it is
-// used as-is. Because every path reaching pathToURI is absolute, the
-// URI is always non-empty, so no empty-URI ever reaches the wire.
+// reports ok=false when no safe, navigable URI exists. A navigable URI
+// requires a bounded workspace root: without one (a rootless session)
+// no related location becomes a link, because nothing can vouch that a
+// path — absolute or relative — stays inside the project, and a config
+// could point a schema source at an arbitrary local file (e.g.
+// /etc/passwd from a malicious repo). With a root, both absolute and
+// relative paths must resolve inside it; a "../" escape or an absolute
+// path outside the root is dropped. Every path reaching pathToURI is
+// absolute, so the URI is always non-empty and no empty-URI reaches
+// the wire.
 func relatedURI(file, root string) (string, bool) {
-	if file == "" {
+	if file == "" || root == "" {
 		return "", false
 	}
 	if isAbsPath(file) {
-		if root != "" && !withinRoot(root, file) {
+		if !withinRoot(root, file) {
 			return "", false
 		}
 		return pathToURI(file), true
-	}
-	if root == "" {
-		return "", false
 	}
 	path := filepath.Join(root, filepath.FromSlash(file))
 	if !withinRoot(root, path) {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -57,15 +58,10 @@ func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
 	if ri := relatedInformation(d.RelatedLocations, root); len(ri) > 0 {
 		out.RelatedInformation = ri
 	}
-	// codeDescription gives the rule code a clickable docs link. A
-	// diagnostic may carry an explicit DocURL override; otherwise the
-	// canonical rule-doc URL is derived from the rule ID. Unknown IDs
-	// (rules.DocURL returns "") leave codeDescription unset.
-	href := d.DocURL
-	if href == "" {
-		href = rules.DocURL(d.RuleID)
-	}
-	if href != "" {
+	// codeDescription gives the rule code a clickable docs link,
+	// derived from the rule ID. Unknown IDs (rules.DocURL returns "")
+	// leave it unset.
+	if href := rules.DocURL(d.RuleID); href != "" {
 		out.CodeDescription = &codeDescription{Href: href}
 	}
 	return out
@@ -82,23 +78,46 @@ func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
 func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRelatedInformation {
 	var out []diagnosticRelatedInformation
 	for _, loc := range locs {
-		if loc.File == "" {
+		uri, ok := relatedURI(loc.File, root)
+		if !ok {
 			continue
-		}
-		path := loc.File
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(root, path)
 		}
 		pos := Position{
 			Line:      clampZero(loc.Line - 1),
 			Character: clampZero(loc.Column - 1),
 		}
 		out = append(out, diagnosticRelatedInformation{
-			Location: Location{URI: pathToURI(path), Range: Range{Start: pos, End: pos}},
+			Location: Location{URI: uri, Range: Range{Start: pos, End: pos}},
 			Message:  loc.Message,
 		})
 	}
 	return out
+}
+
+// relatedURI resolves a related-location file to a file:// URI, or
+// reports ok=false when no safe, navigable URI exists. A label-only
+// location (empty File) is dropped. An absolute path is used as-is. A
+// relative path needs a workspace root to become absolute, and must
+// stay within it — a "../" escape is dropped rather than pointing the
+// editor outside the workspace. Because every path reaching pathToURI
+// is absolute, the URI is always non-empty, so no empty-URI ever
+// reaches the wire.
+func relatedURI(file, root string) (string, bool) {
+	if file == "" {
+		return "", false
+	}
+	if filepath.IsAbs(file) {
+		return pathToURI(file), true
+	}
+	if root == "" {
+		return "", false
+	}
+	path := filepath.Join(root, file)
+	if rel, _ := filepath.Rel(root, path); rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return pathToURI(path), true
 }
 
 // clampZero returns n, or 0 when n is negative. Used to flip 1-based

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -33,6 +33,17 @@ import (
 // length], so endCol is always >= startCol — no end-before-start
 // guard is needed.
 func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
+	return toLSPWithRoot(d, lines, root, resolveSymlinks(root))
+}
+
+// toLSPWithRoot is toLSP with the workspace root's symlink-resolved form
+// precomputed. toLSPAll resolves the (constant) root once per publish and
+// passes it here, so the EvalSymlinks syscall in withinRoot does not
+// repeat once per related location on the keystroke hot path — only each
+// target path is resolved per entry. root stays the configured root for
+// the join and emitted URI; resolvedRoot is used only for the
+// symlink-safe containment check.
+func toLSPWithRoot(d lint.Diagnostic, lines [][]byte, root, resolvedRoot string) Diagnostic {
 	startLine := d.Line - 1
 	if startLine < 0 {
 		startLine = 0
@@ -55,7 +66,7 @@ func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
 			ReplacedBy: d.ReplacedBy,
 		},
 	}
-	if ri := relatedInformation(d.RelatedLocations, root); len(ri) > 0 {
+	if ri := relatedInformation(d.RelatedLocations, root, resolvedRoot); len(ri) > 0 {
 		out.RelatedInformation = ri
 	}
 	// codeDescription gives the rule code a clickable docs link,
@@ -75,10 +86,10 @@ func toLSP(d lint.Diagnostic, lines [][]byte, root string) Diagnostic {
 // still surfaces it as a trailer line. Coordinates flip 1-based →
 // 0-based and clamp at 0, so a file-only ref (Line 0) anchors at the
 // schema's first line.
-func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRelatedInformation {
+func relatedInformation(locs []lint.RelatedLocation, root, resolvedRoot string) []diagnosticRelatedInformation {
 	var out []diagnosticRelatedInformation
 	for _, loc := range locs {
-		uri, ok := relatedURI(loc.File, root)
+		uri, ok := relatedURI(loc.File, root, resolvedRoot)
 		if !ok {
 			continue
 		}
@@ -105,31 +116,34 @@ func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRe
 // path outside the root is dropped. Every path reaching pathToURI is
 // absolute, so the URI is always non-empty and no empty-URI reaches
 // the wire.
-func relatedURI(file, root string) (string, bool) {
+func relatedURI(file, root, resolvedRoot string) (string, bool) {
 	if file == "" || root == "" {
 		return "", false
 	}
 	if isAbsPath(file) {
-		if !withinRoot(root, file) {
+		if !withinRoot(resolvedRoot, file) {
 			return "", false
 		}
 		return pathToURI(file), true
 	}
 	path := filepath.Join(root, filepath.FromSlash(file))
-	if !withinRoot(root, path) {
+	if !withinRoot(resolvedRoot, path) {
 		return "", false
 	}
 	return pathToURI(path), true
 }
 
-// withinRoot reports whether path resolves inside root (root itself
-// counts). Both sides are absolutised and symlink-resolved first, so an
-// in-root symlink that points outside the workspace cannot bypass the
-// containment check — matching the symlink-safe guard the schema index
-// writer uses (internal/schema.resolveDir). A "../" escape, or a path
-// on a different volume that Rel cannot relate, is treated as outside.
-func withinRoot(root, path string) bool {
-	rel, err := filepath.Rel(resolveSymlinks(root), resolveSymlinks(path))
+// withinRoot reports whether path resolves inside resolvedRoot (the root
+// itself counts). resolvedRoot must already be absolute and symlink-
+// resolved (see resolveSymlinks); path is absolutised and symlink-
+// resolved here, so an in-root symlink that points outside the workspace
+// cannot bypass the containment check — matching the symlink-safe guard
+// the schema index writer uses (internal/schema.resolveDir). The caller
+// resolves the constant root once per publish rather than once per
+// related location. A "../" escape, or a path on a different volume that
+// Rel cannot relate, is treated as outside.
+func withinRoot(resolvedRoot, path string) bool {
+	rel, err := filepath.Rel(resolvedRoot, resolveSymlinks(path))
 	return err == nil && rel != ".." &&
 		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
@@ -176,8 +190,12 @@ func clampZero(n int) int {
 func toLSPAll(diags []lint.Diagnostic, source []byte, root string) []Diagnostic {
 	out := make([]Diagnostic, 0, len(diags))
 	lines := splitLines(source)
+	// The workspace root is constant across the publish, so resolve its
+	// symlinks once here instead of once per related location inside
+	// withinRoot (EvalSymlinks is a syscall on the keystroke hot path).
+	resolvedRoot := resolveSymlinks(root)
 	for _, d := range diags {
-		out = append(out, toLSP(d, lines, root))
+		out = append(out, toLSPWithRoot(d, lines, root, resolvedRoot))
 	}
 	return out
 }

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -106,18 +106,29 @@ func relatedURI(file, root string) (string, bool) {
 	if file == "" {
 		return "", false
 	}
-	if filepath.IsAbs(file) {
+	if isAbsPath(file) {
 		return pathToURI(file), true
 	}
 	if root == "" {
 		return "", false
 	}
-	path := filepath.Join(root, file)
+	path := filepath.Join(root, filepath.FromSlash(file))
 	if rel, _ := filepath.Rel(root, path); rel == ".." ||
 		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", false
 	}
 	return pathToURI(path), true
+}
+
+// isAbsPath reports whether p is absolute on any host OS — including
+// Windows drive-letter (`C:\x`) and UNC (`\\server\share`) paths,
+// which filepath.IsAbs rejects on a non-Windows host. This mirrors the
+// cross-platform classification pathToURI applies, so an absolute
+// related location from a Windows client (or a cross-platform test) is
+// passed straight to pathToURI rather than mis-joined to the workspace
+// root.
+func isAbsPath(p string) bool {
+	return filepath.IsAbs(p) || isWindowsDrivePath(p) || strings.HasPrefix(p, `\\`)
 }
 
 // clampZero returns n, or 0 when n is negative. Used to flip 1-based

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -96,28 +96,43 @@ func relatedInformation(locs []lint.RelatedLocation, root string) []diagnosticRe
 
 // relatedURI resolves a related-location file to a file:// URI, or
 // reports ok=false when no safe, navigable URI exists. A label-only
-// location (empty File) is dropped. An absolute path is used as-is. A
-// relative path needs a workspace root to become absolute, and must
-// stay within it — a "../" escape is dropped rather than pointing the
-// editor outside the workspace. Because every path reaching pathToURI
-// is absolute, the URI is always non-empty, so no empty-URI ever
-// reaches the wire.
+// location (empty File) is dropped. Both absolute and relative paths
+// must resolve inside the workspace root when one is known, so a config
+// that points a schema source at an arbitrary local file (e.g.
+// /etc/passwd from a malicious repo) is never turned into a navigable
+// editor link; a "../" escape is dropped for the same reason. With no
+// root there is nothing to bound an absolute path against, so it is
+// used as-is. Because every path reaching pathToURI is absolute, the
+// URI is always non-empty, so no empty-URI ever reaches the wire.
 func relatedURI(file, root string) (string, bool) {
 	if file == "" {
 		return "", false
 	}
 	if isAbsPath(file) {
+		if root != "" && !withinRoot(root, file) {
+			return "", false
+		}
 		return pathToURI(file), true
 	}
 	if root == "" {
 		return "", false
 	}
 	path := filepath.Join(root, filepath.FromSlash(file))
-	if rel, _ := filepath.Rel(root, path); rel == ".." ||
-		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if !withinRoot(root, path) {
 		return "", false
 	}
 	return pathToURI(path), true
+}
+
+// withinRoot reports whether path resolves inside root (root itself
+// counts). A "../" escape, or a path on a different volume that Rel
+// cannot relate, is treated as outside.
+func withinRoot(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // isAbsPath reports whether p is absolute on any host OS — including

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -123,14 +123,30 @@ func relatedURI(file, root string) (string, bool) {
 }
 
 // withinRoot reports whether path resolves inside root (root itself
-// counts). A "../" escape, or a path on a different volume that Rel
-// cannot relate, is treated as outside.
+// counts). Both sides are absolutised and symlink-resolved first, so an
+// in-root symlink that points outside the workspace cannot bypass the
+// containment check — matching the symlink-safe guard the schema index
+// writer uses (internal/schema.resolveDir). A "../" escape, or a path
+// on a different volume that Rel cannot relate, is treated as outside.
 func withinRoot(root, path string) bool {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return false
+	rel, err := filepath.Rel(resolveSymlinks(root), resolveSymlinks(path))
+	return err == nil && rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// resolveSymlinks returns p as an absolute, symlink-resolved path so a
+// lexical containment check cannot be fooled by a symlink. EvalSymlinks
+// needs the path to exist; when it does not (a stale or not-yet-created
+// reference), this falls back to the lexical absolute path — best-effort,
+// mirroring internal/schema.resolveDir. filepath.Abs only fails without
+// a working directory, an unrecoverable state, so its error is ignored
+// and Clean carries the fallback.
+func resolveSymlinks(p string) string {
+	abs, _ := filepath.Abs(p)
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
 	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	return filepath.Clean(abs)
 }
 
 // isAbsPath reports whether p is absolute on any host OS — including

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -127,7 +127,7 @@ func (s *Server) handleHover(msg *requestMessage) {
 
 // ruleHoverContent builds the hover body for a diagnostic, issue-first
 // (plan 221): the diagnostic message — what is wrong in this file —
-// leads as the primary block, followed by any navigable schema
+// leads as the primary block, followed by any navigable related
 // location, a separator, then a condensed rule-identity block (the
 // rule code, its one-line description, and a docs link). The full rule
 // README is no longer inlined, so the issue is not buried under
@@ -137,22 +137,29 @@ func ruleHoverContent(d Diagnostic) string {
 	b.WriteString(d.Message)
 	for _, ri := range d.RelatedInformation {
 		b.WriteString("\n\n")
-		b.WriteString(schemaHoverLink(ri))
+		b.WriteString(relatedHoverLink(ri))
 	}
 	b.WriteString("\n\n---\n\n")
 	b.WriteString(ruleIdentityBlock(d))
 	return b.String()
 }
 
-// schemaHoverLink renders a related location as a markdown link, e.g.
-// "Schema: [proto.md:5](file:///…/proto.md#L5)", so a reader can jump
-// to the constraint straight from the hover. This is the Obsidian
-// path; VS Code additionally surfaces the same location natively as
-// relatedInformation.
-func schemaHoverLink(ri diagnosticRelatedInformation) string {
+// relatedHoverLink renders a related location as a markdown link the
+// reader can jump to, e.g. "[proto.md:5](file:///…/proto.md#L5) —
+// required by schema". RelatedLocations is rule-agnostic, so the link
+// is rendered generically and the entry's own message (the reason the
+// location is related, "required by schema" for MDS020) trails it
+// rather than a hard-coded "Schema:" label. The em-dash form mirrors
+// the CLI trailer. This is the Obsidian path; VS Code additionally
+// surfaces the same location natively as relatedInformation.
+func relatedHoverLink(ri diagnosticRelatedInformation) string {
 	line := ri.Location.Range.Start.Line + 1
-	return fmt.Sprintf("Schema: [%s:%d](%s#L%d)",
+	link := fmt.Sprintf("[%s:%d](%s#L%d)",
 		path.Base(ri.Location.URI), line, ri.Location.URI, line)
+	if ri.Message != "" {
+		return link + " — " + ri.Message
+	}
+	return link
 }
 
 // ruleIdentityBlock renders the secondary block: the rule code, its

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -126,7 +126,7 @@ func (s *Server) handleHover(msg *requestMessage) {
 }
 
 // ruleHoverContent builds the hover body for a diagnostic, issue-first
-// (plan 221): the diagnostic message — what is wrong in this file —
+// (plan 230): the diagnostic message — what is wrong in this file —
 // leads as the primary block, followed by any navigable related
 // location, a separator, then a condensed rule-identity block (the
 // rule code, its one-line description, and a docs link). The full rule

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"path"
 	"strings"
 	"sync"
 
@@ -124,19 +125,60 @@ func (s *Server) handleHover(msg *requestMessage) {
 	_ = s.t.writeResponse(msg.ID, nil)
 }
 
-// ruleHoverContent builds the hover body for a diagnostic: the diagnostic
-// message on its own line, a blank line, then the rule's help text.
-// Unknown rules get a brief fallback pointing at `mdsmith help rule`.
+// ruleHoverContent builds the hover body for a diagnostic, issue-first
+// (plan 221): the diagnostic message — what is wrong in this file —
+// leads as the primary block, followed by any navigable schema
+// location, a separator, then a condensed rule-identity block (the
+// rule code, its one-line description, and a docs link). The full rule
+// README is no longer inlined, so the issue is not buried under
+// documentation.
 func ruleHoverContent(d Diagnostic) string {
+	var b strings.Builder
+	b.WriteString(d.Message)
+	for _, ri := range d.RelatedInformation {
+		b.WriteString("\n\n")
+		b.WriteString(schemaHoverLink(ri))
+	}
+	b.WriteString("\n\n---\n\n")
+	b.WriteString(ruleIdentityBlock(d))
+	return b.String()
+}
+
+// schemaHoverLink renders a related location as a markdown link, e.g.
+// "Schema: [proto.md:5](file:///…/proto.md#L5)", so a reader can jump
+// to the constraint straight from the hover. This is the Obsidian
+// path; VS Code additionally surfaces the same location natively as
+// relatedInformation.
+func schemaHoverLink(ri diagnosticRelatedInformation) string {
+	line := ri.Location.Range.Start.Line + 1
+	return fmt.Sprintf("Schema: [%s:%d](%s#L%d)",
+		path.Base(ri.Location.URI), line, ri.Location.URI, line)
+}
+
+// ruleIdentityBlock renders the secondary block: the rule code, its
+// name and one-line description, a docs link, and the optional
+// remediation hint. Unknown rules degrade to the code plus a
+// `mdsmith help rule` pointer.
+func ruleIdentityBlock(d Diagnostic) string {
+	header := "`" + d.Code + "`"
+	if d.Data != nil && d.Data.RuleName != "" {
+		header += " · " + d.Data.RuleName
+	}
 	info, ok := cachedRuleInfo(d.Code)
-	if !ok {
-		return fmt.Sprintf("**%s** %s\n\nSee `mdsmith help rule %s` for details.", d.Code, d.Message, d.Code)
+	if ok && info.Description != "" {
+		header += " — " + info.Description
 	}
-	body := fmt.Sprintf("**%s** %s\n\n%s", d.Code, d.Message, info.Content)
-	if info.Maintainability != nil && info.Maintainability.ForDiagnostic {
-		body += fmt.Sprintf("\n\nSuggested remediation: %s", info.Maintainability.Fix)
+	var b strings.Builder
+	b.WriteString(header)
+	if d.CodeDescription != nil && d.CodeDescription.Href != "" {
+		fmt.Fprintf(&b, "\n\n[Open rule docs ↗](%s)", d.CodeDescription.Href)
+	} else {
+		fmt.Fprintf(&b, "\n\nSee `mdsmith help rule %s` for details.", d.Code)
 	}
-	return body
+	if ok && info.Maintainability != nil && info.Maintainability.ForDiagnostic {
+		fmt.Fprintf(&b, "\n\nSuggested remediation: %s", info.Maintainability.Fix)
+	}
+	return b.String()
 }
 
 // cachedRuleInfo returns the rule metadata for a given diagnostic code, or

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -184,7 +184,7 @@ type Diagnostic struct {
 	Source   string             `json:"source,omitempty"`
 	Message  string             `json:"message"`
 	Data     *diagnosticData    `json:"data,omitempty"`
-	// RelatedInformation surfaces secondary locations (plan 221): for
+	// RelatedInformation surfaces secondary locations (plan 230): for
 	// MDS020, the proto.md / kind-file line that declares the violated
 	// constraint, which the editor renders as a navigable entry.
 	// Omitted when the diagnostic carries no navigable related

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -196,16 +196,12 @@ type Diagnostic struct {
 	CodeDescription *codeDescription `json:"codeDescription,omitempty"`
 }
 
-// Location is an LSP source location: a document URI plus a range.
-type Location struct {
-	URI   string `json:"uri"`
-	Range Range  `json:"range"`
-}
-
 // diagnosticRelatedInformation is one entry of Diagnostic.relatedInformation
 // (LSP §3.18.6): a location and a human message describing the relation.
+// It reuses the package's existing unexported `location` type (see
+// symbol_types.go).
 type diagnosticRelatedInformation struct {
-	Location Location `json:"location"`
+	Location location `json:"location"`
 	Message  string   `json:"message"`
 }
 

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -184,6 +184,35 @@ type Diagnostic struct {
 	Source   string             `json:"source,omitempty"`
 	Message  string             `json:"message"`
 	Data     *diagnosticData    `json:"data,omitempty"`
+	// RelatedInformation surfaces secondary locations (plan 221): for
+	// MDS020, the proto.md / kind-file line that declares the violated
+	// constraint, which the editor renders as a navigable entry.
+	// Omitted when the diagnostic carries no navigable related
+	// location (e.g. an inline-schema label with no file).
+	RelatedInformation []diagnosticRelatedInformation `json:"relatedInformation,omitempty"`
+	// CodeDescription, when set, gives the rule code a clickable link
+	// to its documentation. Href must be an http(s) URL per the LSP
+	// spec; clients render it next to the code.
+	CodeDescription *codeDescription `json:"codeDescription,omitempty"`
+}
+
+// Location is an LSP source location: a document URI plus a range.
+type Location struct {
+	URI   string `json:"uri"`
+	Range Range  `json:"range"`
+}
+
+// diagnosticRelatedInformation is one entry of Diagnostic.relatedInformation
+// (LSP §3.18.6): a location and a human message describing the relation.
+type diagnosticRelatedInformation struct {
+	Location Location `json:"location"`
+	Message  string   `json:"message"`
+}
+
+// codeDescription is Diagnostic.codeDescription (LSP §3.18.6): a single
+// href that points the code at its documentation.
+type codeDescription struct {
+	Href string `json:"href"`
 }
 
 // diagnosticData carries the rule name through to code-action handlers.

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1064,7 +1064,7 @@ func (s *Server) runLint(uri string) {
 	// just linted.
 	docDiags, otherDiags := partitionDocDiagnostics(res.Diagnostics, relPath)
 	s.surfaceForeignDiagnostics(uri, otherDiags)
-	lspDiags := toLSPAll(docDiags, doc.text)
+	lspDiags := toLSPAll(docDiags, doc.text, root)
 	// Cache and publish under diagsMu, re-checking the run mode inside
 	// the lock. mdsmith.run can flip to off while the CPU-bound
 	// RunSource above is in flight; clearOpenDiagnostics deletes and

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -3770,8 +3770,9 @@ func TestRuleHoverContent_IssueFirst(t *testing.T) {
 	issue, ruleBlock := got[:sep], got[sep:]
 
 	assert.Contains(t, issue, `status: got "draft"`, "issue leads")
-	assert.Contains(t, issue, "Schema: [proto.md:4](file:///w/plan/proto.md#L4)",
-		"navigable schema link sits in the issue block")
+	assert.Contains(t, issue,
+		"[proto.md:4](file:///w/plan/proto.md#L4) — required by schema",
+		"navigable related link with its message sits in the issue block")
 	assert.Contains(t, ruleBlock, "`MDS020` · required-structure",
 		"rule identity is secondary")
 	assert.Contains(t, ruleBlock, "Document structure and front matter",
@@ -4024,4 +4025,24 @@ func TestRelatedURI_CrossPlatformAbsolute(t *testing.T) {
 	require.True(t, ok)
 	assert.Contains(t, uri, "/lin/root/plan/proto.md",
 		"a workspace-relative path still joins to root")
+}
+
+// TestRelatedHoverLink covers the rule-agnostic related-link renderer:
+// the entry's own message trails the link, and an entry with no message
+// renders the bare link.
+func TestRelatedHoverLink(t *testing.T) {
+	t.Parallel()
+	ri := diagnosticRelatedInformation{
+		Location: location{
+			URI:   "file:///w/proto.md",
+			Range: Range{Start: Position{Line: 4}},
+		},
+		Message: "required by schema",
+	}
+	assert.Equal(t,
+		"[proto.md:5](file:///w/proto.md#L5) — required by schema",
+		relatedHoverLink(ri))
+
+	ri.Message = ""
+	assert.Equal(t, "[proto.md:5](file:///w/proto.md#L5)", relatedHoverLink(ri))
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -981,8 +981,46 @@ func TestComputeCodeActionsCachesNilEdits(t *testing.T) {
 func TestToLSPClampsZeroLine(t *testing.T) {
 	t.Parallel()
 	got := toLSP(lint.Diagnostic{Line: 0, Column: 1, RuleID: "MDS001", Severity: lint.Error},
-		[][]byte{[]byte("a")})
+		[][]byte{[]byte("a")}, "")
 	assert.Equal(t, 0, got.Range.Start.Line)
+}
+
+// TestToLSP_RelatedInformationAndCodeDescription pins plan 221's wire
+// mapping: a navigable related location becomes a relatedInformation
+// entry with a resolved file:// URI and 0-based coordinates, a doc URL
+// becomes codeDescription.href, and a file-less label is dropped.
+func TestToLSP_RelatedInformationAndCodeDescription(t *testing.T) {
+	t.Parallel()
+	d := lint.Diagnostic{
+		Line: 2, Column: 1, RuleID: "MDS020", RuleName: "required-structure",
+		Severity: lint.Error, Message: `status: got "x"`,
+		DocURL: "https://mdsmith.dev/rules/MDS020",
+		RelatedLocations: []lint.RelatedLocation{
+			{File: "proto.md", Line: 4, Column: 3, Message: "required by schema"},
+			{Message: "inline kind schema"}, // no file → dropped
+		},
+	}
+	got := toLSP(d, [][]byte{[]byte("a"), []byte("status: x")}, "/work")
+	require.NotNil(t, got.CodeDescription)
+	assert.Equal(t, "https://mdsmith.dev/rules/MDS020", got.CodeDescription.Href)
+	require.Len(t, got.RelatedInformation, 1, "the file-less label is dropped")
+	ri := got.RelatedInformation[0]
+	assert.Equal(t, "required by schema", ri.Message)
+	assert.Equal(t, 3, ri.Location.Range.Start.Line, "1-based line 4 → 0-based 3")
+	assert.Equal(t, 2, ri.Location.Range.Start.Character, "1-based col 3 → 0-based 2")
+	assert.True(t, strings.HasPrefix(ri.Location.URI, "file://"))
+	assert.Contains(t, ri.Location.URI, "proto.md")
+}
+
+// TestToLSP_NoRelatedNoCodeDescription confirms a plain diagnostic
+// gets neither field, so the wire form is unchanged for non-schema
+// rules.
+func TestToLSP_NoRelatedNoCodeDescription(t *testing.T) {
+	t.Parallel()
+	got := toLSP(lint.Diagnostic{Line: 1, Column: 1, RuleID: "MDS001"},
+		[][]byte{[]byte("x")}, "/w")
+	assert.Nil(t, got.RelatedInformation)
+	assert.Nil(t, got.CodeDescription)
 }
 
 // TestToLSPForwardsDeprecationData regresses plan 136: the
@@ -1001,7 +1039,7 @@ func TestToLSPForwardsDeprecationData(t *testing.T) {
 		Deprecated: true,
 		ReplacedBy: "owner",
 		Message:    "legacy_owner: deprecated field",
-	}, [][]byte{[]byte("---")})
+	}, [][]byte{[]byte("---")}, "")
 	require.NotNil(t, got.Data)
 	assert.True(t, got.Data.Deprecated)
 	assert.Equal(t, "owner", got.Data.ReplacedBy)
@@ -1015,6 +1053,7 @@ func TestToLSPEmptyLineProducesZeroWidthRange(t *testing.T) {
 	got := toLSP(
 		lint.Diagnostic{Line: 2, Column: 1, RuleID: "MDS001", Severity: lint.Error},
 		[][]byte{[]byte("first"), []byte("")},
+		"",
 	)
 	assert.Equal(t, 1, got.Range.Start.Line)
 	assert.Equal(t, 0, got.Range.Start.Character)
@@ -2166,6 +2205,7 @@ func TestToLSPMultiByteRuneBeforeColumn(t *testing.T) {
 	got := toLSP(
 		lint.Diagnostic{Line: 1, Column: 3, RuleID: "MDS001", Severity: lint.Error},
 		[][]byte{line},
+		"",
 	)
 	assert.Equal(t, 1, got.Range.Start.Character,
 		"Column 3 (byte offset 2 = after é) should map to UTF-16 character 1")
@@ -2181,6 +2221,7 @@ func TestToLSPSurrogatePairBeforeColumn(t *testing.T) {
 	got := toLSP(
 		lint.Diagnostic{Line: 1, Column: 5, RuleID: "MDS001", Severity: lint.Error},
 		[][]byte{line},
+		"",
 	)
 	assert.Equal(t, 2, got.Range.Start.Character,
 		"after a non-BMP rune the start character should advance by 2 UTF-16 units")

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -3756,7 +3756,7 @@ func TestRuleHoverContent_IssueFirst(t *testing.T) {
 		Data:            &diagnosticData{RuleName: "required-structure"},
 		CodeDescription: &codeDescription{Href: "https://mdsmith.dev/rules/MDS020"},
 		RelatedInformation: []diagnosticRelatedInformation{{
-			Location: Location{
+			Location: location{
 				URI:   "file:///w/plan/proto.md",
 				Range: Range{Start: Position{Line: 3}},
 			},

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -987,14 +987,14 @@ func TestToLSPClampsZeroLine(t *testing.T) {
 
 // TestToLSP_RelatedInformationAndCodeDescription pins plan 221's wire
 // mapping: a navigable related location becomes a relatedInformation
-// entry with a resolved file:// URI and 0-based coordinates, a doc URL
-// becomes codeDescription.href, and a file-less label is dropped.
+// entry with a resolved file:// URI and 0-based coordinates, the rule
+// code gets a derived codeDescription.href, and a file-less label is
+// dropped.
 func TestToLSP_RelatedInformationAndCodeDescription(t *testing.T) {
 	t.Parallel()
 	d := lint.Diagnostic{
 		Line: 2, Column: 1, RuleID: "MDS020", RuleName: "required-structure",
 		Severity: lint.Error, Message: `status: got "x"`,
-		DocURL: "https://mdsmith.dev/rules/MDS020",
 		RelatedLocations: []lint.RelatedLocation{
 			{File: "proto.md", Line: 4, Column: 3, Message: "required by schema"},
 			{Message: "inline kind schema"}, // no file → dropped
@@ -1002,7 +1002,8 @@ func TestToLSP_RelatedInformationAndCodeDescription(t *testing.T) {
 	}
 	got := toLSP(d, [][]byte{[]byte("a"), []byte("status: x")}, "/work")
 	require.NotNil(t, got.CodeDescription)
-	assert.Equal(t, "https://mdsmith.dev/rules/MDS020", got.CodeDescription.Href)
+	assert.Equal(t, "https://mdsmith.dev/rules/mds020-required-structure/",
+		got.CodeDescription.Href, "derived from the rule ID")
 	require.Len(t, got.RelatedInformation, 1, "the file-less label is dropped")
 	ri := got.RelatedInformation[0]
 	assert.Equal(t, "required by schema", ri.Message)
@@ -1023,8 +1024,7 @@ func TestToLSP_NoRelatedNoCodeDescription(t *testing.T) {
 }
 
 // TestToLSP_DerivesCodeDescriptionForKnownRule confirms a real rule ID
-// gets a codeDescription pointing at its website doc page, even without
-// an explicit DocURL override.
+// gets a codeDescription pointing at its website doc page.
 func TestToLSP_DerivesCodeDescriptionForKnownRule(t *testing.T) {
 	t.Parallel()
 	got := toLSP(lint.Diagnostic{Line: 1, Column: 1, RuleID: "MDS001"},
@@ -1050,6 +1050,25 @@ func TestToLSP_RelatedFileOnlyAnchorsAtLineZero(t *testing.T) {
 	require.Len(t, got.RelatedInformation, 1)
 	assert.Equal(t, 0, got.RelatedInformation[0].Location.Range.Start.Line)
 	assert.Equal(t, 0, got.RelatedInformation[0].Location.Range.Start.Character)
+}
+
+// TestToLSP_RelatedURIGuards covers relatedURI's safety branches: a
+// relative file with no workspace root, and a "../" path that escapes
+// the root, both drop the entry; an absolute path is kept.
+func TestToLSP_RelatedURIGuards(t *testing.T) {
+	t.Parallel()
+	mk := func(file, root string) []diagnosticRelatedInformation {
+		d := lint.Diagnostic{
+			Line: 1, Column: 1, RuleID: "MDS020",
+			RelatedLocations: []lint.RelatedLocation{{File: file, Line: 2, Message: "x"}},
+		}
+		return toLSP(d, [][]byte{[]byte("x")}, root).RelatedInformation
+	}
+	assert.Empty(t, mk("proto.md", ""), "relative file, no root → dropped")
+	assert.Empty(t, mk("../../etc/passwd", "/work/project"), "escaping root → dropped")
+	abs := mk("/abs/proto.md", "/work")
+	require.Len(t, abs, 1, "absolute path → kept")
+	assert.Contains(t, abs[0].Location.URI, "/abs/proto.md")
 }
 
 // TestToLSPForwardsDeprecationData regresses plan 136: the

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -985,7 +985,7 @@ func TestToLSPClampsZeroLine(t *testing.T) {
 	assert.Equal(t, 0, got.Range.Start.Line)
 }
 
-// TestToLSP_RelatedInformationAndCodeDescription pins plan 221's wire
+// TestToLSP_RelatedInformationAndCodeDescription pins plan 230's wire
 // mapping: a navigable related location becomes a relatedInformation
 // entry with a resolved file:// URI and 0-based coordinates, the rule
 // code gets a derived codeDescription.href, and a file-less label is
@@ -3747,7 +3747,7 @@ func TestRuleHoverContentFallback(t *testing.T) {
 	assert.Contains(t, content, "mdsmith help rule MDSZZZ")
 }
 
-// TestRuleHoverContent_IssueFirst pins plan 221's hover layout: the
+// TestRuleHoverContent_IssueFirst pins plan 230's hover layout: the
 // diagnostic message and the navigable schema link lead as the primary
 // block, a separator follows, then the condensed rule identity (code,
 // name, one-line description, docs link). The full README is not

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1034,6 +1034,24 @@ func TestToLSP_DerivesCodeDescriptionForKnownRule(t *testing.T) {
 		got.CodeDescription.Href)
 }
 
+// TestToLSP_RelatedFileOnlyAnchorsAtLineZero covers the clamp path: a
+// file-only related location (Line and Column unknown / 0) anchors at
+// the schema file's first line rather than underflowing to a negative
+// coordinate.
+func TestToLSP_RelatedFileOnlyAnchorsAtLineZero(t *testing.T) {
+	t.Parallel()
+	d := lint.Diagnostic{
+		Line: 1, Column: 1, RuleID: "MDS020",
+		RelatedLocations: []lint.RelatedLocation{
+			{File: "proto.md", Message: "required by schema"},
+		},
+	}
+	got := toLSP(d, [][]byte{[]byte("x")}, "/w")
+	require.Len(t, got.RelatedInformation, 1)
+	assert.Equal(t, 0, got.RelatedInformation[0].Location.Range.Start.Line)
+	assert.Equal(t, 0, got.RelatedInformation[0].Location.Range.Start.Character)
+}
+
 // TestToLSPForwardsDeprecationData regresses plan 136: the
 // lint.Diagnostic Deprecated / ReplacedBy fields must ride
 // through to LSP clients via the diagnostic Data payload so a

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1012,15 +1012,26 @@ func TestToLSP_RelatedInformationAndCodeDescription(t *testing.T) {
 	assert.Contains(t, ri.Location.URI, "proto.md")
 }
 
-// TestToLSP_NoRelatedNoCodeDescription confirms a plain diagnostic
-// gets neither field, so the wire form is unchanged for non-schema
-// rules.
+// TestToLSP_NoRelatedNoCodeDescription confirms a diagnostic with no
+// related locations and an unknown rule ID gets neither field.
 func TestToLSP_NoRelatedNoCodeDescription(t *testing.T) {
 	t.Parallel()
-	got := toLSP(lint.Diagnostic{Line: 1, Column: 1, RuleID: "MDS001"},
+	got := toLSP(lint.Diagnostic{Line: 1, Column: 1, RuleID: "MDSZZZ"},
 		[][]byte{[]byte("x")}, "/w")
 	assert.Nil(t, got.RelatedInformation)
 	assert.Nil(t, got.CodeDescription)
+}
+
+// TestToLSP_DerivesCodeDescriptionForKnownRule confirms a real rule ID
+// gets a codeDescription pointing at its website doc page, even without
+// an explicit DocURL override.
+func TestToLSP_DerivesCodeDescriptionForKnownRule(t *testing.T) {
+	t.Parallel()
+	got := toLSP(lint.Diagnostic{Line: 1, Column: 1, RuleID: "MDS001"},
+		[][]byte{[]byte("x")}, "/w")
+	require.NotNil(t, got.CodeDescription)
+	assert.Equal(t, "https://mdsmith.dev/rules/mds001-line-length/",
+		got.CodeDescription.Href)
 }
 
 // TestToLSPForwardsDeprecationData regresses plan 136: the
@@ -3693,6 +3704,42 @@ func TestRuleHoverContentFallback(t *testing.T) {
 	content := ruleHoverContent(d)
 	assert.Contains(t, content, "MDSZZZ")
 	assert.Contains(t, content, "mdsmith help rule MDSZZZ")
+}
+
+// TestRuleHoverContent_IssueFirst pins plan 221's hover layout: the
+// diagnostic message and the navigable schema link lead as the primary
+// block, a separator follows, then the condensed rule identity (code,
+// name, one-line description, docs link). The full README is not
+// inlined.
+func TestRuleHoverContent_IssueFirst(t *testing.T) {
+	t.Parallel()
+	d := Diagnostic{
+		Code:            "MDS020",
+		Message:         `status: got "draft", expected one of "open"`,
+		Data:            &diagnosticData{RuleName: "required-structure"},
+		CodeDescription: &codeDescription{Href: "https://mdsmith.dev/rules/MDS020"},
+		RelatedInformation: []diagnosticRelatedInformation{{
+			Location: Location{
+				URI:   "file:///w/plan/proto.md",
+				Range: Range{Start: Position{Line: 3}},
+			},
+			Message: "required by schema",
+		}},
+	}
+	got := ruleHoverContent(d)
+
+	sep := strings.Index(got, "\n---\n")
+	require.Positive(t, sep, "hover has an issue/rule separator")
+	issue, ruleBlock := got[:sep], got[sep:]
+
+	assert.Contains(t, issue, `status: got "draft"`, "issue leads")
+	assert.Contains(t, issue, "Schema: [proto.md:4](file:///w/plan/proto.md#L4)",
+		"navigable schema link sits in the issue block")
+	assert.Contains(t, ruleBlock, "`MDS020` · required-structure",
+		"rule identity is secondary")
+	assert.Contains(t, ruleBlock, "Document structure and front matter",
+		"one-line description, not the full README")
+	assert.Contains(t, ruleBlock, "https://mdsmith.dev/rules/MDS020")
 }
 
 // TestDirectiveHoverAtInRange covers the path where the cursor falls inside a

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1066,6 +1066,7 @@ func TestToLSP_RelatedURIGuards(t *testing.T) {
 		return toLSP(d, [][]byte{[]byte("x")}, root).RelatedInformation
 	}
 	assert.Empty(t, mk("proto.md", ""), "relative file, no root → dropped")
+	assert.Empty(t, mk("/abs/proto.md", ""), "absolute file, no root → dropped")
 	assert.Empty(t, mk("../../etc/passwd", "/work/project"), "escaping root → dropped")
 	assert.Empty(t, mk("/etc/passwd", "/work/project"),
 		"absolute path outside root → dropped")
@@ -4007,25 +4008,16 @@ func TestInvalidateCachedRead_DropsEntry(t *testing.T) {
 	}
 }
 
-// TestRelatedURI_CrossPlatformAbsolute pins that relatedURI treats
-// Windows drive-letter and UNC paths as absolute even on a non-Windows
-// host (matching pathToURI). With no workspace root to bound it, such a
-// path is passed straight through rather than mis-joined.
-func TestRelatedURI_CrossPlatformAbsolute(t *testing.T) {
+// TestIsAbsPath covers the cross-platform absolute-path classification
+// relatedURI relies on: POSIX absolute, Windows drive-letter, and UNC
+// paths are absolute on any host (so they are bounded against the root,
+// not mis-joined to it); a relative path is not.
+func TestIsAbsPath(t *testing.T) {
 	t.Parallel()
-	uri, ok := relatedURI(`C:\work\proto.md`, "")
-	require.True(t, ok)
-	assert.Equal(t, "file:///C:/work/proto.md", uri)
-
-	uri, ok = relatedURI(`\\server\share\proto.md`, "")
-	require.True(t, ok)
-	assert.True(t, strings.HasPrefix(uri, "file://"))
-	assert.Contains(t, uri, "server")
-
-	uri, ok = relatedURI("plan/proto.md", "/lin/root")
-	require.True(t, ok)
-	assert.Contains(t, uri, "/lin/root/plan/proto.md",
-		"a workspace-relative path joins to root and stays inside it")
+	assert.True(t, isAbsPath("/abs/proto.md"), "posix absolute")
+	assert.True(t, isAbsPath(`C:\work\proto.md`), "windows drive-letter")
+	assert.True(t, isAbsPath(`\\server\share\proto.md`), "UNC")
+	assert.False(t, isAbsPath("plan/proto.md"), "relative")
 }
 
 // TestRelatedHoverLink covers the rule-agnostic related-link renderer:

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -4049,5 +4049,25 @@ func TestWithinRoot(t *testing.T) {
 	assert.True(t, withinRoot("/work", "/work"), "root itself counts")
 	assert.False(t, withinRoot("/work", "/etc/passwd"), "sibling escapes")
 	assert.False(t, withinRoot("relative", "/abs/path"),
-		"Rel cannot relate a relative root to an absolute path → outside")
+		"a relative root and an absolute path resolve to disjoint subtrees → outside")
+}
+
+// TestWithinRoot_SymlinkEscapeRejected pins the symlink-safe behaviour
+// (Copilot review): a real file inside the root is contained, but an
+// in-root symlink that resolves outside the root is rejected — a purely
+// lexical check would have accepted it.
+func TestWithinRoot_SymlinkEscapeRejected(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	inside := filepath.Join(root, "proto.md")
+	require.NoError(t, os.WriteFile(inside, []byte("x"), 0o600))
+	assert.True(t, withinRoot(root, inside), "real in-root file is contained")
+
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.md")
+	require.NoError(t, os.WriteFile(secret, []byte("s"), 0o600))
+	link := filepath.Join(root, "evil.md")
+	require.NoError(t, os.Symlink(secret, link))
+	assert.False(t, withinRoot(root, link),
+		"an in-root symlink resolving outside the root is rejected")
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1053,8 +1053,9 @@ func TestToLSP_RelatedFileOnlyAnchorsAtLineZero(t *testing.T) {
 }
 
 // TestToLSP_RelatedURIGuards covers relatedURI's safety branches: a
-// relative file with no workspace root, and a "../" path that escapes
-// the root, both drop the entry; an absolute path is kept.
+// relative file with no workspace root, a "../" path that escapes the
+// root, and an absolute path outside the root are all dropped; an
+// absolute path inside the root is kept.
 func TestToLSP_RelatedURIGuards(t *testing.T) {
 	t.Parallel()
 	mk := func(file, root string) []diagnosticRelatedInformation {
@@ -1066,9 +1067,11 @@ func TestToLSP_RelatedURIGuards(t *testing.T) {
 	}
 	assert.Empty(t, mk("proto.md", ""), "relative file, no root → dropped")
 	assert.Empty(t, mk("../../etc/passwd", "/work/project"), "escaping root → dropped")
-	abs := mk("/abs/proto.md", "/work")
-	require.Len(t, abs, 1, "absolute path → kept")
-	assert.Contains(t, abs[0].Location.URI, "/abs/proto.md")
+	assert.Empty(t, mk("/etc/passwd", "/work/project"),
+		"absolute path outside root → dropped")
+	abs := mk("/work/project/sub/proto.md", "/work/project")
+	require.Len(t, abs, 1, "absolute path inside root → kept")
+	assert.Contains(t, abs[0].Location.URI, "/work/project/sub/proto.md")
 }
 
 // TestToLSPForwardsDeprecationData regresses plan 136: the
@@ -4006,17 +4009,15 @@ func TestInvalidateCachedRead_DropsEntry(t *testing.T) {
 
 // TestRelatedURI_CrossPlatformAbsolute pins that relatedURI treats
 // Windows drive-letter and UNC paths as absolute even on a non-Windows
-// host (matching pathToURI), so such a related location is passed
-// straight through rather than mis-joined to the workspace root.
+// host (matching pathToURI). With no workspace root to bound it, such a
+// path is passed straight through rather than mis-joined.
 func TestRelatedURI_CrossPlatformAbsolute(t *testing.T) {
 	t.Parallel()
-	uri, ok := relatedURI(`C:\work\proto.md`, "/lin/root")
+	uri, ok := relatedURI(`C:\work\proto.md`, "")
 	require.True(t, ok)
 	assert.Equal(t, "file:///C:/work/proto.md", uri)
-	assert.NotContains(t, uri, "lin/root",
-		"absolute Windows path must not be joined to the Linux root")
 
-	uri, ok = relatedURI(`\\server\share\proto.md`, "/lin/root")
+	uri, ok = relatedURI(`\\server\share\proto.md`, "")
 	require.True(t, ok)
 	assert.True(t, strings.HasPrefix(uri, "file://"))
 	assert.Contains(t, uri, "server")
@@ -4024,7 +4025,7 @@ func TestRelatedURI_CrossPlatformAbsolute(t *testing.T) {
 	uri, ok = relatedURI("plan/proto.md", "/lin/root")
 	require.True(t, ok)
 	assert.Contains(t, uri, "/lin/root/plan/proto.md",
-		"a workspace-relative path still joins to root")
+		"a workspace-relative path joins to root and stays inside it")
 }
 
 // TestRelatedHoverLink covers the rule-agnostic related-link renderer:
@@ -4045,4 +4046,16 @@ func TestRelatedHoverLink(t *testing.T) {
 
 	ri.Message = ""
 	assert.Equal(t, "[proto.md:5](file:///w/proto.md#L5)", relatedHoverLink(ri))
+}
+
+// TestWithinRoot covers the containment check, including the
+// filepath.Rel error branch (a relative root against an absolute path
+// cannot be related, so it counts as outside).
+func TestWithinRoot(t *testing.T) {
+	t.Parallel()
+	assert.True(t, withinRoot("/work", "/work/sub/x.md"), "inside root")
+	assert.True(t, withinRoot("/work", "/work"), "root itself counts")
+	assert.False(t, withinRoot("/work", "/etc/passwd"), "sibling escapes")
+	assert.False(t, withinRoot("relative", "/abs/path"),
+		"Rel cannot relate a relative root to an absolute path → outside")
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -4002,3 +4002,26 @@ func TestInvalidateCachedRead_DropsEntry(t *testing.T) {
 		t.Errorf("after invalidate: cache hit = %v, want rebuilt", got)
 	}
 }
+
+// TestRelatedURI_CrossPlatformAbsolute pins that relatedURI treats
+// Windows drive-letter and UNC paths as absolute even on a non-Windows
+// host (matching pathToURI), so such a related location is passed
+// straight through rather than mis-joined to the workspace root.
+func TestRelatedURI_CrossPlatformAbsolute(t *testing.T) {
+	t.Parallel()
+	uri, ok := relatedURI(`C:\work\proto.md`, "/lin/root")
+	require.True(t, ok)
+	assert.Equal(t, "file:///C:/work/proto.md", uri)
+	assert.NotContains(t, uri, "lin/root",
+		"absolute Windows path must not be joined to the Linux root")
+
+	uri, ok = relatedURI(`\\server\share\proto.md`, "/lin/root")
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(uri, "file://"))
+	assert.Contains(t, uri, "server")
+
+	uri, ok = relatedURI("plan/proto.md", "/lin/root")
+	require.True(t, ok)
+	assert.Contains(t, uri, "/lin/root/plan/proto.md",
+		"a workspace-relative path still joins to root")
+}

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -27,7 +27,7 @@ type jsonDiagnostic struct {
 	// deprecation diagnostics stay unchanged on the wire.
 	Deprecated bool   `json:"deprecated,omitempty"`
 	ReplacedBy string `json:"replaced_by,omitempty"`
-	// RelatedLocations mirrors lint.Diagnostic's plan-221 field so CI
+	// RelatedLocations mirrors lint.Diagnostic's plan-230 field so CI
 	// scripts can read the schema-constraint location without parsing
 	// the message. omitempty so diagnostics that carry none stay
 	// unchanged on the wire. The rule-doc URL is not emitted here — it

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -27,12 +27,12 @@ type jsonDiagnostic struct {
 	// deprecation diagnostics stay unchanged on the wire.
 	Deprecated bool   `json:"deprecated,omitempty"`
 	ReplacedBy string `json:"replaced_by,omitempty"`
-	// RelatedLocations and DocURL mirror lint.Diagnostic's plan-221
-	// fields so CI scripts can read the schema-constraint location and
-	// the rule-doc URL without parsing the message. Both omitempty so
-	// diagnostics that carry neither stay unchanged on the wire.
+	// RelatedLocations mirrors lint.Diagnostic's plan-221 field so CI
+	// scripts can read the schema-constraint location without parsing
+	// the message. omitempty so diagnostics that carry none stay
+	// unchanged on the wire. The rule-doc URL is not emitted here — it
+	// is derivable from the `rule` field and is an editor (LSP) concern.
 	RelatedLocations []jsonRelatedLocation `json:"related_locations,omitempty"`
-	DocURL           string                `json:"doc_url,omitempty"`
 }
 
 type jsonRelatedLocation struct {
@@ -72,7 +72,6 @@ func (f *JSONFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 			Deprecated:       d.Deprecated,
 			ReplacedBy:       d.ReplacedBy,
 			RelatedLocations: relatedToJSON(d.RelatedLocations),
-			DocURL:           d.DocURL,
 		})
 	}
 	enc := json.NewEncoder(w)

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -60,7 +60,7 @@ func (f *JSONFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 	for _, d := range diagnostics {
 		items = append(items, jsonDiagnostic{
 			File:             d.File,
-			Line:             d.Line,
+			Line:             d.DisplayLine(),
 			Column:           d.Column,
 			Rule:             d.RuleID,
 			Name:             d.RuleName,

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -27,6 +27,19 @@ type jsonDiagnostic struct {
 	// deprecation diagnostics stay unchanged on the wire.
 	Deprecated bool   `json:"deprecated,omitempty"`
 	ReplacedBy string `json:"replaced_by,omitempty"`
+	// RelatedLocations and DocURL mirror lint.Diagnostic's plan-221
+	// fields so CI scripts can read the schema-constraint location and
+	// the rule-doc URL without parsing the message. Both omitempty so
+	// diagnostics that carry neither stay unchanged on the wire.
+	RelatedLocations []jsonRelatedLocation `json:"related_locations,omitempty"`
+	DocURL           string                `json:"doc_url,omitempty"`
+}
+
+type jsonRelatedLocation struct {
+	File    string `json:"file,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Column  int    `json:"column,omitempty"`
+	Message string `json:"message"`
 }
 
 type jsonExplanation struct {
@@ -46,23 +59,40 @@ func (f *JSONFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 	items := make([]jsonDiagnostic, 0, len(diagnostics))
 	for _, d := range diagnostics {
 		items = append(items, jsonDiagnostic{
-			File:            d.File,
-			Line:            d.Line,
-			Column:          d.Column,
-			Rule:            d.RuleID,
-			Name:            d.RuleName,
-			Severity:        string(d.Severity),
-			Message:         d.Message,
-			SourceLines:     d.SourceLines,
-			SourceStartLine: d.SourceStartLine,
-			Explanation:     explanationToJSON(d.Explanation),
-			Deprecated:      d.Deprecated,
-			ReplacedBy:      d.ReplacedBy,
+			File:             d.File,
+			Line:             d.Line,
+			Column:           d.Column,
+			Rule:             d.RuleID,
+			Name:             d.RuleName,
+			Severity:         string(d.Severity),
+			Message:          d.Message,
+			SourceLines:      d.SourceLines,
+			SourceStartLine:  d.SourceStartLine,
+			Explanation:      explanationToJSON(d.Explanation),
+			Deprecated:       d.Deprecated,
+			ReplacedBy:       d.ReplacedBy,
+			RelatedLocations: relatedToJSON(d.RelatedLocations),
+			DocURL:           d.DocURL,
 		})
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(items)
+}
+
+// relatedToJSON maps the structured related locations onto their JSON
+// form. Returns nil (so omitempty fires) when there are none.
+func relatedToJSON(locs []lint.RelatedLocation) []jsonRelatedLocation {
+	if len(locs) == 0 {
+		return nil
+	}
+	out := make([]jsonRelatedLocation, 0, len(locs))
+	for _, l := range locs {
+		out = append(out, jsonRelatedLocation{
+			File: l.File, Line: l.Line, Column: l.Column, Message: l.Message,
+		})
+	}
+	return out
 }
 
 func explanationToJSON(e *lint.Explanation) *jsonExplanation {

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -350,3 +350,19 @@ func TestExplanationToJSON_EmptyLeavesIsEmptySlice(t *testing.T) {
 		t.Errorf("len(Leaves) = %d, want 0", len(got.Leaves))
 	}
 }
+
+// TestJSONFormatter_ClampsNonPositiveLine regresses plan 221: a
+// diagnostic anchored at line 0 serializes as line 1, not 0. Column is
+// left untouched (0 stays "unknown").
+func TestJSONFormatter_ClampsNonPositiveLine(t *testing.T) {
+	var buf bytes.Buffer
+	f := &JSONFormatter{}
+	require.NoError(t, f.Format(&buf, []lint.Diagnostic{
+		{File: "gen.md", Line: 0, Column: 3, RuleID: "MDS020", Message: "x"},
+	}))
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.EqualValues(t, 1, got[0]["line"])
+	assert.EqualValues(t, 3, got[0]["column"])
+}

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -351,7 +351,7 @@ func TestExplanationToJSON_EmptyLeavesIsEmptySlice(t *testing.T) {
 	}
 }
 
-// TestJSONFormatter_ClampsNonPositiveLine regresses plan 221: a
+// TestJSONFormatter_ClampsNonPositiveLine regresses plan 230: a
 // diagnostic anchored at line 0 serializes as line 1, not 0. Column is
 // left untouched (0 stays "unknown").
 func TestJSONFormatter_ClampsNonPositiveLine(t *testing.T) {

--- a/internal/output/output_coverage_test.go
+++ b/internal/output/output_coverage_test.go
@@ -278,3 +278,25 @@ func TestFormat_CaretWriterError(t *testing.T) {
 	err := f.Format(w, diagnostics)
 	assert.Error(t, err, "expected error from failing caret write")
 }
+
+// TestFormat_RelatedWriterError covers the writeRelated error return:
+// the header succeeds (write 1), the diagnostic has no SourceLines so
+// formatSnippet writes nothing, and the related-location trailer write
+// fails.
+func TestFormat_RelatedWriterError(t *testing.T) {
+	f := &TextFormatter{Color: false}
+	w := &limitedWriter{limit: 1}
+
+	diagnostics := []lint.Diagnostic{
+		{
+			File: "test.md", Line: 1, Column: 1,
+			RuleID: "MDS020", RuleName: "required-structure", Message: "test",
+			RelatedLocations: []lint.RelatedLocation{
+				{File: "proto.md", Line: 2, Message: "required by schema"},
+			},
+		},
+	}
+
+	err := f.Format(w, diagnostics)
+	assert.Error(t, err, "expected error from failing related-location write")
+}

--- a/internal/output/output_coverage_test.go
+++ b/internal/output/output_coverage_test.go
@@ -111,6 +111,37 @@ func TestFormatSnippet_SingleDigitLineNumber(t *testing.T) {
 	assert.Contains(t, output, strings.Repeat("·", 8)+"^")
 }
 
+func TestFormatSnippet_NonPositiveLineCaretMatchesHeader(t *testing.T) {
+	// A non-positive Line is a body-anchor sentinel (plan 230). The header
+	// clamps it to line 1 via DisplayLine(); the snippet caret must mark
+	// that same line rather than being silently dropped because it keyed
+	// off the raw sentinel.
+	f := &TextFormatter{Color: false}
+	var buf bytes.Buffer
+
+	diagnostics := []lint.Diagnostic{
+		{
+			File:            "doc.md",
+			Line:            0, // sentinel
+			Column:          1,
+			RuleID:          "MDS020",
+			RuleName:        "required-structure",
+			Message:         "missing required section",
+			SourceLines:     []string{"# Heading"},
+			SourceStartLine: 1,
+		},
+	}
+
+	err := f.Format(&buf, diagnostics)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Header clamps the sentinel to line 1.
+	assert.Contains(t, output, "doc.md:1:1")
+	// The caret marks that same line (gutterWidth=1, column=1, dots = 1+1+2 = 4).
+	assert.Contains(t, output, strings.Repeat("·", 4)+"^")
+}
+
 func TestFormatSnippet_TwoDigitLineNumber(t *testing.T) {
 	f := &TextFormatter{Color: false}
 	var buf bytes.Buffer

--- a/internal/output/related_test.go
+++ b/internal/output/related_test.go
@@ -17,7 +17,6 @@ func relatedDiag() lint.Diagnostic {
 		RuleID: "MDS020", RuleName: "required-structure",
 		Severity: lint.Error,
 		Message:  `status: got "draft", expected one of "open"`,
-		DocURL:   "https://mdsmith.dev/rules/MDS020",
 		RelatedLocations: []lint.RelatedLocation{{
 			File: "plan/proto.md", Line: 4,
 			Message: `schema requires one of: "open", "in-progress"`,
@@ -82,14 +81,14 @@ func TestTextFormatter_NoRelatedNoTrailer(t *testing.T) {
 	assert.NotContains(t, buf.String(), "↳")
 }
 
-func TestJSONFormatter_RelatedAndDocURL(t *testing.T) {
+func TestJSONFormatter_RelatedLocations(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, (&JSONFormatter{}).Format(&buf, []lint.Diagnostic{relatedDiag()}))
 
 	var got []map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
 	require.Len(t, got, 1)
-	assert.Equal(t, "https://mdsmith.dev/rules/MDS020", got[0]["doc_url"])
+	assert.NotContains(t, got[0], "doc_url", "doc URL is an LSP concern, not in JSON")
 	rls, ok := got[0]["related_locations"].([]any)
 	require.True(t, ok, "related_locations present")
 	require.Len(t, rls, 1)
@@ -102,12 +101,10 @@ func TestJSONFormatter_RelatedAndDocURL(t *testing.T) {
 func TestJSONFormatter_RelatedOmittedWhenAbsent(t *testing.T) {
 	d := relatedDiag()
 	d.RelatedLocations = nil
-	d.DocURL = ""
 	var buf bytes.Buffer
 	require.NoError(t, (&JSONFormatter{}).Format(&buf, []lint.Diagnostic{d}))
 	out := buf.String()
 	assert.False(t, strings.Contains(out, "related_locations"), "omitempty drops empty related list")
-	assert.False(t, strings.Contains(out, "doc_url"), "omitempty drops empty doc URL")
 }
 
 func TestTextFormatter_RelatedFileOnlyNoMessage(t *testing.T) {

--- a/internal/output/related_test.go
+++ b/internal/output/related_test.go
@@ -88,7 +88,6 @@ func TestJSONFormatter_RelatedLocations(t *testing.T) {
 	var got []map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
 	require.Len(t, got, 1)
-	assert.NotContains(t, got[0], "doc_url", "doc URL is an LSP concern, not in JSON")
 	rls, ok := got[0]["related_locations"].([]any)
 	require.True(t, ok, "related_locations present")
 	require.Len(t, rls, 1)

--- a/internal/output/related_test.go
+++ b/internal/output/related_test.go
@@ -109,3 +109,21 @@ func TestJSONFormatter_RelatedOmittedWhenAbsent(t *testing.T) {
 	assert.False(t, strings.Contains(out, "related_locations"), "omitempty drops empty related list")
 	assert.False(t, strings.Contains(out, "doc_url"), "omitempty drops empty doc URL")
 }
+
+func TestTextFormatter_RelatedFileOnlyNoMessage(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = []lint.RelatedLocation{{File: "plan/proto.md", Line: 7}}
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	out := buf.String()
+	assert.Contains(t, out, "↳ plan/proto.md:7")
+	assert.NotContains(t, out, " — ", "no separator when the location has no message")
+}
+
+func TestTextFormatter_RelatedEmptyLocationSkipped(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = []lint.RelatedLocation{{}} // neither file nor message
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	assert.NotContains(t, buf.String(), "↳", "an empty related location renders nothing")
+}

--- a/internal/output/related_test.go
+++ b/internal/output/related_test.go
@@ -1,0 +1,111 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func relatedDiag() lint.Diagnostic {
+	return lint.Diagnostic{
+		File: "task.md", Line: 1, Column: 1,
+		RuleID: "MDS020", RuleName: "required-structure",
+		Severity: lint.Error,
+		Message:  `status: got "draft", expected one of "open"`,
+		DocURL:   "https://mdsmith.dev/rules/MDS020",
+		RelatedLocations: []lint.RelatedLocation{{
+			File: "plan/proto.md", Line: 4,
+			Message: `schema requires one of: "open", "in-progress"`,
+		}},
+	}
+}
+
+func TestTextFormatter_RelatedTrailerPlain(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{relatedDiag()}))
+	out := buf.String()
+	assert.Contains(t, out, "↳ plan/proto.md:4 — ")
+	assert.Contains(t, out, `schema requires one of: "open", "in-progress"`)
+	assert.NotContains(t, out, "\033[", "no color codes when Color is false")
+}
+
+func TestTextFormatter_RelatedTrailerColor(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{Color: true}).Format(&buf, []lint.Diagnostic{relatedDiag()}))
+	out := buf.String()
+	assert.Contains(t, out, "↳ ")
+	assert.Contains(t, out, "\033[2m", "dim sequence around the related body")
+}
+
+func TestTextFormatter_RelatedFileOnlyNoLine(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = []lint.RelatedLocation{{File: "plan/proto.md", Message: "schema constraint"}}
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	out := buf.String()
+	assert.Contains(t, out, "↳ plan/proto.md — schema constraint")
+	assert.NotContains(t, out, "proto.md:0", "no :0 when line is unknown")
+}
+
+func TestTextFormatter_RelatedMessageOnlyNoFile(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = []lint.RelatedLocation{{Message: "inline kind schema"}}
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	out := buf.String()
+	assert.Contains(t, out, "↳ inline kind schema")
+	assert.NotContains(t, out, " — ", "no separator when there is no location")
+}
+
+func TestTextFormatter_RelatedSanitizesControlChars(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = []lint.RelatedLocation{{
+		File: "a\nb.md", Line: 2, Message: "inject\x1b[31mred",
+	}}
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	out := buf.String()
+	assert.NotContains(t, out, "\n\n", "embedded newline stripped from related line")
+	assert.NotContains(t, out, "\x1b[31m", "embedded ANSI stripped")
+}
+
+func TestTextFormatter_NoRelatedNoTrailer(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = nil
+	var buf bytes.Buffer
+	require.NoError(t, (&TextFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	assert.NotContains(t, buf.String(), "↳")
+}
+
+func TestJSONFormatter_RelatedAndDocURL(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, (&JSONFormatter{}).Format(&buf, []lint.Diagnostic{relatedDiag()}))
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "https://mdsmith.dev/rules/MDS020", got[0]["doc_url"])
+	rls, ok := got[0]["related_locations"].([]any)
+	require.True(t, ok, "related_locations present")
+	require.Len(t, rls, 1)
+	rl := rls[0].(map[string]any)
+	assert.Equal(t, "plan/proto.md", rl["file"])
+	assert.Equal(t, float64(4), rl["line"])
+	assert.Equal(t, `schema requires one of: "open", "in-progress"`, rl["message"])
+}
+
+func TestJSONFormatter_RelatedOmittedWhenAbsent(t *testing.T) {
+	d := relatedDiag()
+	d.RelatedLocations = nil
+	d.DocURL = ""
+	var buf bytes.Buffer
+	require.NoError(t, (&JSONFormatter{}).Format(&buf, []lint.Diagnostic{d}))
+	out := buf.String()
+	assert.False(t, strings.Contains(out, "related_locations"), "omitempty drops empty related list")
+	assert.False(t, strings.Contains(out, "doc_url"), "omitempty drops empty doc URL")
+}

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -53,10 +53,10 @@ func (f *TextFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 		var err error
 		if f.Color {
 			_, err = fmt.Fprintf(w, "\033[36m%s:%d:%d\033[0m \033[33m%s\033[0m %s\n",
-				safeFile, d.Line, d.Column, d.RuleID, safeMsg)
+				safeFile, d.DisplayLine(), d.Column, d.RuleID, safeMsg)
 		} else {
 			_, err = fmt.Fprintf(w, "%s:%d:%d %s %s\n",
-				safeFile, d.Line, d.Column, d.RuleID, safeMsg)
+				safeFile, d.DisplayLine(), d.Column, d.RuleID, safeMsg)
 		}
 		if err != nil {
 			return err

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -66,11 +66,61 @@ func (f *TextFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error
 			return err
 		}
 
+		if err := f.formatRelated(w, d.RelatedLocations); err != nil {
+			return err
+		}
+
 		if err := f.formatExplanation(w, d.Explanation); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// formatRelated writes one dimmed trailer line per related location,
+// e.g. "  ↳ plan/proto.md:4 — schema requires one of: ...". For an
+// MDS020 diagnostic this is where the schema reference surfaces,
+// sourced from the structured RelatedLocations rather than the message
+// body. File, line, and message can carry user-controlled text (schema
+// paths, expected vocabularies), so each piece is sanitized before it
+// is joined into the single-line trailer.
+func (f *TextFormatter) formatRelated(w io.Writer, locs []lint.RelatedLocation) error {
+	for _, loc := range locs {
+		body := relatedLine(loc)
+		if body == "" {
+			continue
+		}
+		var err error
+		if f.Color {
+			_, err = fmt.Fprintf(w, "  ↳ \033[2m%s\033[0m\n", body)
+		} else {
+			_, err = fmt.Fprintf(w, "  ↳ %s\n", body)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// relatedLine renders the "<file>:<line> — <message>" body for one
+// related location. The location is omitted when File is empty, the
+// ":<line>" is omitted when Line is 0, and the " — " separator appears
+// only when both a location and a message are present.
+func relatedLine(loc lint.RelatedLocation) string {
+	where := sanitizeControl(loc.File)
+	if where != "" && loc.Line > 0 {
+		where += ":" + strconv.Itoa(loc.Line)
+	}
+	msg := sanitizeControl(loc.Message)
+	switch {
+	case where != "" && msg != "":
+		return where + " — " + msg
+	case where != "":
+		return where
+	default:
+		return msg
+	}
 }
 
 // formatExplanation writes a one-line trailer naming the rule and

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -48,15 +48,22 @@ type TextFormatter struct {
 // source snippet with line-number gutter and caret marker.
 func (f *TextFormatter) Format(w io.Writer, diagnostics []lint.Diagnostic) error {
 	for _, d := range diagnostics {
+		// Normalize the local copy to the user-facing line up front so the
+		// header and the snippet caret always agree on which line to mark,
+		// even when Line is a non-positive body-anchor sentinel (plan 230).
+		// DisplayLine clamps to >= 1; the engine skips snippet context for
+		// such diagnostics today, so this keeps the formatter self-consistent
+		// for any diagnostic it is handed rather than relying on that guard.
+		d.Line = d.DisplayLine()
 		safeFile := sanitizeControl(d.File)
 		safeMsg := sanitizeControl(d.Message)
 		var err error
 		if f.Color {
 			_, err = fmt.Fprintf(w, "\033[36m%s:%d:%d\033[0m \033[33m%s\033[0m %s\n",
-				safeFile, d.DisplayLine(), d.Column, d.RuleID, safeMsg)
+				safeFile, d.Line, d.Column, d.RuleID, safeMsg)
 		} else {
 			_, err = fmt.Fprintf(w, "%s:%d:%d %s %s\n",
-				safeFile, d.DisplayLine(), d.Column, d.RuleID, safeMsg)
+				safeFile, d.Line, d.Column, d.RuleID, safeMsg)
 		}
 		if err != nil {
 			return err

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -598,3 +598,17 @@ func TestTextFormatter_SnippetDotPathAlignment(t *testing.T) {
 	require.GreaterOrEqual(t, caretPos, 0, "no ^ found in caret line")
 	assert.Equal(t, 'h', diagRunes[caretPos], "caret should point at 'h' in https")
 }
+
+// TestTextFormatter_ClampsNonPositiveLine regresses plan 221: a
+// diagnostic anchored at line 0 (a wholly generated file) prints as
+// line 1, never file:0. Column is left untouched (0 is "unknown",
+// covered by TestTextFormatter_SnippetColumnZero).
+func TestTextFormatter_ClampsNonPositiveLine(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TextFormatter{}
+	require.NoError(t, f.Format(&buf, []lint.Diagnostic{
+		{File: "gen.md", Line: 0, Column: 3, RuleID: "MDS020", Message: "missing section"},
+	}))
+	assert.Contains(t, buf.String(), "gen.md:1:3 ")
+	assert.NotContains(t, buf.String(), "gen.md:0:")
+}

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -599,7 +599,7 @@ func TestTextFormatter_SnippetDotPathAlignment(t *testing.T) {
 	assert.Equal(t, 'h', diagRunes[caretPos], "caret should point at 'h' in https")
 }
 
-// TestTextFormatter_ClampsNonPositiveLine regresses plan 221: a
+// TestTextFormatter_ClampsNonPositiveLine regresses plan 230: a
 // diagnostic anchored at line 0 (a wholly generated file) prints as
 // line 1, never file:0. Column is left untouched (0 is "unknown",
 // covered by TestTextFormatter_SnippetColumnZero).

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -316,7 +316,7 @@ status: got "draf", expected one of: "draft", "open", "done"
   ↳ plan/proto.md:4 — required by schema
 ```
 
-That schema reference rides on a related location (plan 221),
+That schema reference rides on a related location (plan 230),
 shown above; editors render it as a `relatedInformation` entry.
 
 | Condition            | Message                                                               |

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -313,11 +313,11 @@ constraint, and (when it can) a hint:
 ```text
 status: got "draf", expected one of: "draft", "open", "done"
   (did you mean "draft"?)
-schema: plan/proto.md:4
 ```
 
-The trailing `schema: <ref>` line points at the source; for
-proto.md schemas it includes the constraint's line number.
+The schema reference now rides on a related location (plan 221),
+not the message. The CLI prints it as a `↳ <ref>` trailer. Editors
+render it as a navigable `relatedInformation` entry.
 
 | Condition            | Message                                                               |
 | -------------------- | --------------------------------------------------------------------- |

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -313,11 +313,11 @@ constraint, and (when it can) a hint:
 ```text
 status: got "draf", expected one of: "draft", "open", "done"
   (did you mean "draft"?)
+  ↳ plan/proto.md:4 — required by schema
 ```
 
-The schema reference now rides on a related location (plan 221),
-not the message. The CLI prints it as a `↳ <ref>` trailer. Editors
-render it as a navigable `relatedInformation` entry.
+That schema reference rides on a related location (plan 221),
+shown above; editors render it as a `relatedInformation` entry.
 
 | Condition            | Message                                                               |
 | -------------------- | --------------------------------------------------------------------- |

--- a/internal/rules/MDS020-required-structure/bad/default.md
+++ b/internal/rules/MDS020-required-structure/bad/default.md
@@ -3,7 +3,7 @@ settings:
   schema: "../../internal/rules/MDS020-required-structure/bad/data/tmpl.md"
 diagnostics:
   # Missing section anchors at the preceding heading (## Goal, line 3),
-  # not file line 1 (plan 221 body anchoring).
+  # not file line 1 (plan 230 body anchoring).
   - line: 3
     column: 1
     message: |-

--- a/internal/rules/MDS020-required-structure/bad/default.md
+++ b/internal/rules/MDS020-required-structure/bad/default.md
@@ -6,7 +6,9 @@ diagnostics:
     column: 1
     message: |-
       ## Tasks: got <missing>, expected section to be present
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
+    related:
+      - file: "../../internal/rules/MDS020-required-structure/bad/data/tmpl.md"
+        message: "required by schema"
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/default.md
+++ b/internal/rules/MDS020-required-structure/bad/default.md
@@ -2,7 +2,9 @@
 settings:
   schema: "../../internal/rules/MDS020-required-structure/bad/data/tmpl.md"
 diagnostics:
-  - line: 1
+  # Missing section anchors at the preceding heading (## Goal, line 3),
+  # not file line 1 (plan 221 body anchoring).
+  - line: 3
     column: 1
     message: |-
       ## Tasks: got <missing>, expected section to be present

--- a/internal/rules/MDS020-required-structure/bad/extra-section.md
+++ b/internal/rules/MDS020-required-structure/bad/extra-section.md
@@ -7,7 +7,6 @@ diagnostics:
     message: |-
       ## Extra: got <present>, expected not declared in schema
         (expected "## Goal" here instead)
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/filename-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/filename-mismatch.md
@@ -6,6 +6,5 @@ diagnostics:
     column: 1
     message: |-
       filename: got "filename-mismatch.md", expected filename matching glob [0-9]*_*.md
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/filename-tmpl.md
 ---
 # My Doc

--- a/internal/rules/MDS020-required-structure/bad/inline-closed-unlisted.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-closed-unlisted.md
@@ -11,7 +11,6 @@ diagnostics:
     message: |-
       ## Notes: got <present>, expected not declared in schema
         (expected "## Decision" here instead)
-      schema: inline kind schema
 ---
 # RFC
 

--- a/internal/rules/MDS020-required-structure/bad/inline-level-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-level-mismatch.md
@@ -10,7 +10,6 @@ diagnostics:
     column: 1
     message: |-
       Step: got h2, expected h3
-      schema: inline kind schema
 ---
 # Runbook
 

--- a/internal/rules/MDS020-required-structure/bad/inline-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-missing.md
@@ -9,7 +9,8 @@ diagnostics:
     column: 1
     message: |-
       ## Tasks: got <missing>, expected section to be present
-      schema: inline kind schema
+    related:
+      - message: "inline kind schema"
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/inline-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/inline-missing.md
@@ -5,7 +5,8 @@ settings:
       - heading: "Goal"
       - heading: "Tasks"
 diagnostics:
-  - line: 1
+  # Missing section anchors at the preceding heading (## Goal, line 3).
+  - line: 3
     column: 1
     message: |-
       ## Tasks: got <missing>, expected section to be present

--- a/internal/rules/MDS020-required-structure/bad/multi-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/multi-missing.md
@@ -6,9 +6,15 @@ diagnostics:
     column: 1
     message: |-
       ## Goal: got <missing>, expected section to be present
+    related:
+      - file: "../../internal/rules/MDS020-required-structure/bad/data/tmpl.md"
+        message: "required by schema"
   - line: 1
     column: 1
     message: |-
       ## Tasks: got <missing>, expected section to be present
+    related:
+      - file: "../../internal/rules/MDS020-required-structure/bad/data/tmpl.md"
+        message: "required by schema"
 ---
 # Title Only

--- a/internal/rules/MDS020-required-structure/bad/multi-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/multi-missing.md
@@ -6,11 +6,9 @@ diagnostics:
     column: 1
     message: |-
       ## Goal: got <missing>, expected section to be present
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
   - line: 1
     column: 1
     message: |-
       ## Tasks: got <missing>, expected section to be present
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # Title Only

--- a/internal/rules/MDS020-required-structure/bad/nature-missing.md
+++ b/internal/rules/MDS020-required-structure/bad/nature-missing.md
@@ -8,7 +8,6 @@ diagnostics:
     column: 1
     message: |-
       nature: got <missing>, expected one of: "directive", "generator", "content", "style", "structure"
-      schema: inline kind schema
 ---
 # MDS999: example-rule
 

--- a/internal/rules/MDS020-required-structure/bad/out-of-order.md
+++ b/internal/rules/MDS020-required-structure/bad/out-of-order.md
@@ -7,7 +7,6 @@ diagnostics:
     message: |-
       ## Tasks: got <out of order>, expected in declared order
         (expected after "## Goal")
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/MDS020-required-structure/bad/path-pattern-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/path-pattern-mismatch.md
@@ -8,6 +8,7 @@ diagnostics:
     column: 1
     message: |-
       path: got "path-pattern-mismatch.md", expected path matching glob [0-9]*_*.md
-      schema: kinds[plan] / path-pattern
+    related:
+      - message: "kinds[plan] / path-pattern"
 ---
 # Plan body whose path does not match the kind's path-pattern

--- a/internal/rules/MDS020-required-structure/bad/wildcard-level.md
+++ b/internal/rules/MDS020-required-structure/bad/wildcard-level.md
@@ -6,6 +6,5 @@ diagnostics:
     column: 1
     message: |-
       Title: got h2, expected h1
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/wildcard-tmpl.md
 ---
 ## Title

--- a/internal/rules/MDS020-required-structure/bad/wrong-level.md
+++ b/internal/rules/MDS020-required-structure/bad/wrong-level.md
@@ -6,7 +6,6 @@ diagnostics:
     column: 1
     message: |-
       Goal: got h3, expected h2
-      schema: ../../internal/rules/MDS020-required-structure/bad/data/tmpl.md
 ---
 # My Plan
 

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -83,7 +83,7 @@ func TestCheck_InlineSchema_MissingSection(t *testing.T) {
 }
 
 // TestCheck_InlineSchema_MissingSectionAnchorsAtPrecedingHeading pins
-// plan 221's body anchoring: a missing section's diagnostic lands on
+// plan 230's body anchoring: a missing section's diagnostic lands on
 // the heading it should follow (## Goal, line 3), not file line 1.
 func TestCheck_InlineSchema_MissingSectionAnchorsAtPrecedingHeading(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
@@ -992,7 +992,7 @@ func TestCheck_InlineSchema_PerScopeRequiredMentions(t *testing.T) {
 }
 
 // TestCheck_InlineKindSchema_RelatedLocationCarriesSourcePath pins
-// plan 221: an inline kind schema delivered as a schema-sources entry
+// plan 230: an inline kind schema delivered as a schema-sources entry
 // with a `source` makes the violation's related location point at the
 // kind's defining file, not the bare "inline kind schema" label.
 func TestCheck_InlineKindSchema_RelatedLocationCarriesSourcePath(t *testing.T) {

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -990,3 +990,38 @@ func TestCheck_InlineSchema_PerScopeRequiredMentions(t *testing.T) {
 	// The diagnostic anchors at the Strict heading line (line 7).
 	assert.Equal(t, 7, mentions[0].Line)
 }
+
+// TestCheck_InlineKindSchema_RelatedLocationCarriesSourcePath pins
+// plan 221: an inline kind schema delivered as a schema-sources entry
+// with a `source` makes the violation's related location point at the
+// kind's defining file, not the bare "inline kind schema" label.
+func TestCheck_InlineKindSchema_RelatedLocationCarriesSourcePath(t *testing.T) {
+	r := &Rule{}
+	err := r.ApplySettings(map[string]any{
+		"schema-sources": []any{
+			map[string]any{
+				"inline": map[string]any{
+					"closed": true,
+					"sections": []any{
+						map[string]any{"heading": "Goal"},
+						map[string]any{"heading": "Tasks"},
+					},
+				},
+				"source": "/work/.mdsmith.yml",
+			},
+		},
+	})
+	require.NoError(t, err)
+	f := newTestFile(t, "doc.md", "# My Plan\n\n## Goal\n\nText.\n")
+	diags := r.Check(f)
+	var found bool
+	for _, d := range diags {
+		for _, rl := range d.RelatedLocations {
+			if rl.File == "/work/.mdsmith.yml" {
+				found = true
+			}
+		}
+	}
+	require.True(t, found,
+		"inline kind violation points at the kind's source file, not a label")
+}

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -82,6 +82,31 @@ func TestCheck_InlineSchema_MissingSection(t *testing.T) {
 	expectDiagMsg(t, diags, `## Tasks: got <missing>, expected section to be present`)
 }
 
+// TestCheck_InlineSchema_MissingSectionAnchorsAtPrecedingHeading pins
+// plan 221's body anchoring: a missing section's diagnostic lands on
+// the heading it should follow (## Goal, line 3), not file line 1.
+func TestCheck_InlineSchema_MissingSectionAnchorsAtPrecedingHeading(t *testing.T) {
+	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
+		"closed": true,
+		"sections": []any{
+			map[string]any{"heading": "Goal"},
+			map[string]any{"heading": "Tasks"},
+		},
+	})}
+	f := newTestFile(t, "doc.md", "# My Plan\n\n## Goal\n\nGoal text.\n")
+	diags := r.Check(f)
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "## Tasks") &&
+			strings.Contains(d.Message, "section to be present") {
+			assert.Equal(t, 3, d.Line,
+				"missing section anchors at the preceding heading (## Goal)")
+			found = true
+		}
+	}
+	require.True(t, found, "expected a missing-Tasks diagnostic")
+}
+
 func TestCheck_InlineSchema_ParityWithFileSchema(t *testing.T) {
 	// File-based and inline schemas with equivalent structure must
 	// emit the same diagnostic for the same document — this is

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -251,7 +251,15 @@ func parseSchemaSources(v any) ([]SchemaSource, error) {
 				return nil, fmt.Errorf(
 					"schema-sources[%d].inline must be a non-empty mapping, got %T", i, inlineV)
 			}
-			sch, err := schema.ParseInline(im, "inline kind schema")
+			// The merge layer (config.applyInlineSchemaSource) attaches
+			// the kind's defining file as `source` so the schema
+			// reference is navigable; fall back to the generic label
+			// when it is absent (e.g. a direct `inline-schema:` setting).
+			label := "inline kind schema"
+			if src, ok := m["source"].(string); ok && src != "" {
+				label = src
+			}
+			sch, err := schema.ParseInline(im, label)
 			if err != nil {
 				return nil, fmt.Errorf("schema-sources[%d].inline: %w", i, err)
 			}

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1841,7 +1841,7 @@ func flagTrailingExtras(
 			Expected:  "not declared in schema",
 			SchemaRef: ref,
 		}
-		diags = append(diags, makeDiag(f.Path, dh.Line, d.Format()))
+		diags = append(diags, d.Emit(makeDiag, f.Path, dh.Line))
 		docIdx++
 	}
 	return diags
@@ -1862,7 +1862,7 @@ func missingSectionDiagLegacy(
 	// non-body anchor so the engine's filterGeneratedDiags can't
 	// drop the diagnostic when body line 1 sits inside a
 	// generated section.
-	return makeDiag(f.Path, schema.NonBodyDiagLine(f), d.Format())
+	return d.Emit(makeDiag, f.Path, schema.NonBodyDiagLine(f))
 }
 
 // buildSchemaRefForLegacy returns the schema reference string
@@ -1911,7 +1911,7 @@ func matchRequired(
 				Hint:      fmt.Sprintf("expected after %q", formatHeading(req.Level, req.Text)),
 				SchemaRef: schemaRef,
 			}
-			diags = append(diags, makeDiag(f.Path, dh.Line, ooDiag.Format()))
+			diags = append(diags, ooDiag.Emit(makeDiag, f.Path, dh.Line))
 			if dh.Level != other.Level {
 				diags = append(diags, levelMismatchDiag(f, dh, other, schemaRef))
 			}
@@ -1927,7 +1927,7 @@ func matchRequired(
 				Hint:      fmt.Sprintf("expected %q here instead", formatHeading(req.Level, req.Text)),
 				SchemaRef: schemaRef,
 			}
-			diags = append(diags, makeDiag(f.Path, dh.Line, unexpDiag.Format()))
+			diags = append(diags, unexpDiag.Emit(makeDiag, f.Path, dh.Line))
 		}
 		docIdx++
 	}
@@ -1945,7 +1945,7 @@ func levelMismatchDiag(
 		Expected:  fmt.Sprintf("h%d", req.Level),
 		SchemaRef: schemaRef,
 	}
-	return makeDiag(f.Path, dh.Line, d.Format())
+	return d.Emit(makeDiag, f.Path, dh.Line)
 }
 
 // nextUnclaimed returns the first index in candidates that is >= minIdx
@@ -2285,7 +2285,7 @@ func (r *Rule) checkPathPatterns(f *lint.File) []lint.Diagnostic {
 			Expected:  fmt.Sprintf("path matching glob %s", pp.Pattern),
 			SchemaRef: fmt.Sprintf("kinds[%s] / path-pattern", pp.Kind),
 		}
-		diags = append(diags, makeDiag(f.Path, schema.NonBodyDiagLine(f), d.Format()))
+		diags = append(diags, d.Emit(makeDiag, f.Path, schema.NonBodyDiagLine(f)))
 	}
 	return diags
 }
@@ -2341,7 +2341,7 @@ func checkFilenamePattern(
 			Hint:      err.Error(),
 			SchemaRef: buildSchemaRefForLegacy(schemaSource),
 		}
-		return []lint.Diagnostic{makeDiag(f.Path, anchor, d.Format())}
+		return []lint.Diagnostic{d.Emit(makeDiag, f.Path, anchor)}
 	}
 	if !matched {
 		// `glob` keeps the wording aligned with schema.validateFilename
@@ -2352,7 +2352,7 @@ func checkFilenamePattern(
 			Expected:  fmt.Sprintf("filename matching glob %s", pattern),
 			SchemaRef: buildSchemaRefForLegacy(schemaSource),
 		}
-		return []lint.Diagnostic{makeDiag(f.Path, anchor, d.Format())}
+		return []lint.Diagnostic{d.Emit(makeDiag, f.Path, anchor)}
 	}
 	return nil
 }

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1821,7 +1821,8 @@ func walkRequiredHeadings(
 			allowExtra = false
 		}
 		if !found && !claimed[schIdx] {
-			diags = append(diags, missingSectionDiagLegacy(f, req, ref))
+			diags = append(diags, missingSectionDiagLegacy(
+				f, req, ref, legacyPrecedingLine(docHeadings, docIdx)))
 		}
 	}
 	return diags, docIdx, allowExtra
@@ -1850,7 +1851,7 @@ func flagTrailingExtras(
 // missingSectionDiagLegacy builds the SchemaDiagnostic for a
 // required heading that the document lacks.
 func missingSectionDiagLegacy(
-	f *lint.File, req schemaHeading, ref string,
+	f *lint.File, req schemaHeading, ref string, precedingLine int,
 ) lint.Diagnostic {
 	d := schema.SchemaDiagnostic{
 		Field:     formatHeading(req.Level, req.Text),
@@ -1858,11 +1859,22 @@ func missingSectionDiagLegacy(
 		Expected:  "section to be present",
 		SchemaRef: ref,
 	}
-	// Missing sections have no body line to point at; use the
-	// non-body anchor so the engine's filterGeneratedDiags can't
-	// drop the diagnostic when body line 1 sits inside a
-	// generated section.
-	return d.Emit(makeDiag, f.Path, schema.NonBodyDiagLine(f))
+	// Anchor at the heading the missing section should follow so the
+	// squiggle lands where the section belongs; MissingSectionAnchor
+	// falls back to the non-body anchor when there is no preceding
+	// heading or the insertion point sits inside a generated section
+	// (where filterGeneratedDiags would otherwise drop it).
+	return d.Emit(makeDiag, f.Path, schema.MissingSectionAnchor(f, precedingLine))
+}
+
+// legacyPrecedingLine returns the line of the document heading just
+// before docIdx (the section a missing required heading should
+// follow), or 0 when there is none.
+func legacyPrecedingLine(docHeadings []docHeading, docIdx int) int {
+	if idx := docIdx - 1; idx >= 0 && idx < len(docHeadings) {
+		return docHeadings[idx].Line
+	}
+	return 0
 }
 
 // buildSchemaRefForLegacy returns the schema reference string

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -76,7 +76,7 @@ func expectDiagMsg(
 }
 
 // expectRelatedMsg asserts that some diagnostic carries a related
-// location whose Message contains substr. Since plan 221, the schema
+// location whose Message contains substr. Since plan 230, the schema
 // reference rides on RelatedLocations rather than the message body, so
 // schema-ref assertions go through this helper.
 func expectRelatedMsg(
@@ -2237,7 +2237,7 @@ status: '"open" | "done"'
 	assert.True(t, found, "a related location points at schema line 3")
 }
 
-// TestCheck_EveryMDS020DiagnosticCarriesRelatedLocation pins plan 221's
+// TestCheck_EveryMDS020DiagnosticCarriesRelatedLocation pins plan 230's
 // invariant: every MDS020 diagnostic surfaces the schema reference as a
 // related location. One document here triggers several distinct emit
 // paths (unexpected section + two missing sections); reverting any of

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2237,6 +2237,24 @@ status: '"open" | "done"'
 	assert.True(t, found, "a related location points at schema line 3")
 }
 
+// TestCheck_EveryMDS020DiagnosticCarriesRelatedLocation pins plan 221's
+// invariant: every MDS020 diagnostic surfaces the schema reference as a
+// related location. One document here triggers several distinct emit
+// paths (unexpected section + two missing sections); reverting any of
+// them to the old message-trailer form would drop the navigation and
+// fail this test.
+func TestCheck_EveryMDS020DiagnosticCarriesRelatedLocation(t *testing.T) {
+	schemaPath := writeSchema(t, "---\n---\n# ?\n\n## Goal\n\n## Tasks\n")
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "doc.md", "# Title\n\n## Random\n\nbody\n")
+	diags := r.Check(f)
+	require.GreaterOrEqual(t, len(diags), 2, "expected several violations")
+	for i, d := range diags {
+		assert.Len(t, d.RelatedLocations, 1,
+			"diagnostic %d %q must carry a related location", i, d.Message)
+	}
+}
+
 // TestCheck_FrontMatter_DiagnosticLineAtKey regresses the
 // Copilot review comment: a FM violation should anchor its
 // diagnostic at the offending key's line, not at the start of

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2581,3 +2581,12 @@ func TestBuildSchemaRefForLegacy(t *testing.T) {
 			"proto.md", got, "proto.md")
 	}
 }
+
+// TestLegacyPrecedingLine covers the file-schema path's document-order
+// lookup mirror of precedingHeadingLine.
+func TestLegacyPrecedingLine(t *testing.T) {
+	heads := []docHeading{{Line: 2}, {Line: 5}}
+	assert.Equal(t, 0, legacyPrecedingLine(heads, 0))
+	assert.Equal(t, 2, legacyPrecedingLine(heads, 1))
+	assert.Equal(t, 5, legacyPrecedingLine(heads, 2))
+}

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -75,6 +75,24 @@ func expectDiagMsg(
 	)
 }
 
+// expectRelatedMsg asserts that some diagnostic carries a related
+// location whose Message contains substr. Since plan 221, the schema
+// reference rides on RelatedLocations rather than the message body, so
+// schema-ref assertions go through this helper.
+func expectRelatedMsg(
+	t *testing.T, diags []lint.Diagnostic, substr string,
+) {
+	t.Helper()
+	for _, d := range diags {
+		for _, rl := range d.RelatedLocations {
+			if strings.Contains(rl.Message, substr) {
+				return
+			}
+		}
+	}
+	t.Errorf("no related location contains %q", substr)
+}
+
 // =====================================================================
 // Rule metadata
 // =====================================================================
@@ -903,8 +921,9 @@ func TestCheck_PathPattern_Mismatch(t *testing.T) {
 		`path: got "plan/early-draft.md"`)
 	assert.Contains(t, diags[0].Message,
 		`glob plan/[0-9][0-9]*_*.md`)
-	assert.Contains(t, diags[0].Message,
-		`schema: kinds[plan] / path-pattern`)
+	require.Len(t, diags[0].RelatedLocations, 1)
+	assert.Equal(t, "kinds[plan] / path-pattern",
+		diags[0].RelatedLocations[0].Message)
 	assert.Equal(t, "MDS020", diags[0].RuleID)
 	assert.Equal(t, "required-structure", diags[0].RuleName)
 	assert.Equal(t, 1, diags[0].Line)
@@ -1022,8 +1041,8 @@ func TestCheck_PathPattern_MultipleKindsBothFail(t *testing.T) {
 	}}
 	diags := r.Check(f)
 	expectDiags(t, diags, 2)
-	expectDiagMsg(t, diags, "kinds[plan] / path-pattern")
-	expectDiagMsg(t, diags, "kinds[rfc] / path-pattern")
+	expectRelatedMsg(t, diags, "kinds[plan] / path-pattern")
+	expectRelatedMsg(t, diags, "kinds[rfc] / path-pattern")
 }
 
 func TestCheck_PathPattern_PlusRequireFilenameBothEmit(t *testing.T) {
@@ -1044,7 +1063,7 @@ filename: "[0-9]*_*.md"
 	diags := r.Check(f)
 	expectDiagMsg(t, diags,
 		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
-	expectDiagMsg(t, diags, "kinds[plan] / path-pattern")
+	expectRelatedMsg(t, diags, "kinds[plan] / path-pattern")
 }
 
 func TestApplySettings_PathPatternsParsesList(t *testing.T) {
@@ -2052,8 +2071,7 @@ status: '"🔲" | "🔳" | "✅"'
 	diags := r.Check(f)
 	var hasCUEDiag bool
 	for _, d := range diags {
-		if strings.Contains(d.Message, "id:") &&
-			strings.Contains(d.Message, "schema:") {
+		if strings.Contains(d.Message, "id:") && len(d.RelatedLocations) == 1 {
 			hasCUEDiag = true
 		}
 	}
@@ -2206,9 +2224,17 @@ status: '"open" | "done"'
 		"---\nstatus: bogus\n---\n# Any title\n")
 	diags := r.Check(f)
 	// status is on line 3 of the schema (line 1 is "---",
-	// line 2 is "id:", line 3 is "status:").
-	expectDiagMsg(t, diags, "schema:")
-	expectDiagMsg(t, diags, ":3")
+	// line 2 is "id:", line 3 is "status:"). The schema reference
+	// now rides on a related location pointing at that line.
+	var found bool
+	for _, d := range diags {
+		for _, rl := range d.RelatedLocations {
+			if rl.Line == 3 && strings.Contains(rl.File, ".md") {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "a related location points at schema line 3")
 }
 
 // TestCheck_FrontMatter_DiagnosticLineAtKey regresses the

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
@@ -67,6 +68,34 @@ type Maintainability struct {
 // ListRules returns all embedded rules sorted by ID.
 func ListRules() ([]RuleInfo, error) {
 	return listRulesFromFS(rulesFS)
+}
+
+// docSiteBase is the published rules-section base URL. SyncDocs serves
+// internal/rules/<ID>-<name>/README.md at <docSiteBase><lower(ID-name)>/,
+// so a rule's doc-page slug is its directory name lowercased (Hugo
+// case-folds path-derived URLs).
+const docSiteBase = "https://mdsmith.dev/rules/"
+
+var docURLOnce struct {
+	sync.Once
+	m map[string]string
+}
+
+// DocURL returns the canonical website documentation URL for a rule ID
+// (e.g. "MDS020" → "https://mdsmith.dev/rules/mds020-required-structure/"),
+// or "" when the ID is unknown. The map is built once from the embedded
+// rule list and cached; safe for concurrent use.
+func DocURL(id string) string {
+	docURLOnce.Do(func() {
+		all, _ := ListRules()
+		m := make(map[string]string, len(all))
+		for _, r := range all {
+			slug := strings.ToLower(r.ID + "-" + r.Name)
+			m[strings.ToUpper(r.ID)] = docSiteBase + slug + "/"
+		}
+		docURLOnce.m = m
+	})
+	return docURLOnce.m[strings.ToUpper(id)]
 }
 
 // LookupRule finds a rule by ID (e.g. "MDS001") or name (e.g. "line-length")

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -461,3 +461,29 @@ func TestDocURL_KnownAndUnknown(t *testing.T) {
 		"lookup is case-insensitive")
 	assert.Equal(t, "", DocURL("MDSZZZ"), "unknown ID yields no URL")
 }
+
+// TestDocURL_DirMatchesIDName guards the invariant rules.DocURL relies
+// on: each embedded rule directory is named exactly <ID>-<name> (the
+// website serves it at /rules/<lower(dir)>/). If a future rule's dir
+// diverges from its README id/name, DocURL would emit a 404 link in
+// the editor while the site publishes under the dir name — this test
+// catches that at build time.
+func TestDocURL_DirMatchesIDName(t *testing.T) {
+	entries, err := rulesFS.ReadDir(".")
+	require.NoError(t, err)
+	var dirs int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dirs++
+		data, err := rulesFS.ReadFile(e.Name() + "/README.md")
+		require.NoError(t, err, "rule dir %q has no README", e.Name())
+		info, err := parseFrontMatter(string(data))
+		require.NoError(t, err)
+		want := strings.ToLower(info.ID + "-" + info.Name)
+		assert.Equal(t, want, strings.ToLower(e.Name()),
+			"rule dir must equal lower(id-name) so DocURL resolves")
+	}
+	assert.Positive(t, dirs, "expected embedded rule directories")
+}

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -450,3 +450,14 @@ func TestParseFrontMatter_RejectsYAMLAliases(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "anchors/aliases")
 }
+
+// TestDocURL_KnownAndUnknown covers the canonical rule-doc URL builder:
+// a known ID resolves to its lowercased <ID-name> slug under the rules
+// section, an unknown ID returns "", and lookup is case-insensitive.
+func TestDocURL_KnownAndUnknown(t *testing.T) {
+	assert.Equal(t, "https://mdsmith.dev/rules/mds020-required-structure/",
+		DocURL("MDS020"))
+	assert.Equal(t, DocURL("MDS020"), DocURL("mds020"),
+		"lookup is case-insensitive")
+	assert.Equal(t, "", DocURL("MDSZZZ"), "unknown ID yields no URL")
+}

--- a/internal/schema/diagnostic.go
+++ b/internal/schema/diagnostic.go
@@ -81,7 +81,7 @@ type SchemaDiagnostic struct {
 
 // Format renders the human-facing message: the first line carries
 // field/actual/expected, and an optional hint follows in parentheses
-// on its own indented line. Per plan 221 the schema reference no
+// on its own indented line. Per plan 230 the schema reference no
 // longer rides on the message — Emit attaches it as a structured
 // lint.RelatedLocation so the CLI and the LSP surface it as a
 // navigable location rather than greppable text.

--- a/internal/schema/diagnostic.go
+++ b/internal/schema/diagnostic.go
@@ -3,7 +3,10 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
+
+	"github.com/jeduden/mdsmith/internal/lint"
 )
 
 // SchemaDiagnostic is the structured form of an MDS020 violation.
@@ -76,17 +79,18 @@ type SchemaDiagnostic struct {
 	DeprecationMessage string
 }
 
-// Format renders the diagnostic as the two-line message described
-// in plan 147: the first line carries field/actual/expected, an
-// optional hint follows in parentheses on its own indented line,
-// and the schema reference appears on a trailing line so it stays
-// greppable without parsing the message body.
+// Format renders the human-facing message: the first line carries
+// field/actual/expected, and an optional hint follows in parentheses
+// on its own indented line. Per plan 221 the schema reference no
+// longer rides on the message — Emit attaches it as a structured
+// lint.RelatedLocation so the CLI and the LSP surface it as a
+// navigable location rather than greppable text.
 //
 // When Deprecated is true the renderer switches to plan 136's
 // deprecation shape: the first line reads
 // "<field>: deprecated field" optionally followed by
 // "; replaced by `<name>`" when ReplacedBy is set, then an
-// optional message line, then the schema reference.
+// optional message line.
 func (d SchemaDiagnostic) Format() string {
 	if d.Deprecated {
 		return d.formatDeprecated()
@@ -110,10 +114,6 @@ func (d SchemaDiagnostic) Format() string {
 		b.WriteString(d.Hint)
 		b.WriteString(")")
 	}
-	if d.SchemaRef != "" {
-		b.WriteString("\nschema: ")
-		b.WriteString(d.SchemaRef)
-	}
 	return b.String()
 }
 
@@ -136,11 +136,82 @@ func (d SchemaDiagnostic) formatDeprecated() string {
 		b.WriteString("\n  message: ")
 		b.WriteString(d.DeprecationMessage)
 	}
-	if d.SchemaRef != "" {
-		b.WriteString("\nschema: ")
-		b.WriteString(d.SchemaRef)
-	}
 	return b.String()
+}
+
+// Emit builds the lint.Diagnostic for this schema diagnostic. It runs
+// the message through mk (which fills in file, line, rule ID, and
+// source context) and then attaches the schema reference as a
+// RelatedLocation so the CLI prints it as a trailer and the LSP maps
+// it onto relatedInformation. The (file, line, msg) MakeDiag signature
+// is unchanged across its call sites; Emit only augments the result.
+func (d SchemaDiagnostic) Emit(mk MakeDiag, file string, line int) lint.Diagnostic {
+	diag := mk(file, line, d.Format())
+	if rl, ok := d.related(); ok {
+		diag.RelatedLocations = append(diag.RelatedLocations, rl)
+	}
+	return diag
+}
+
+// related converts the textual SchemaRef into a structured
+// RelatedLocation. A ref of the form "<path>:<line>" or "<path>"
+// yields a navigable location; a descriptive label that names no file
+// (e.g. "inline kind schema" or "kinds[task] / path-pattern") yields a
+// message-only location so the reference still shows in CLI output
+// while the LSP, which needs a URI, skips it. Returns ok=false when
+// there is no reference at all.
+func (d SchemaDiagnostic) related() (lint.RelatedLocation, bool) {
+	if d.SchemaRef == "" {
+		return lint.RelatedLocation{}, false
+	}
+	file, line := parseSchemaRef(d.SchemaRef)
+	if file == "" {
+		// Label-only ref: keep the label as the message; no file means
+		// no navigable URI for the LSP, which drops empty-file entries.
+		return lint.RelatedLocation{Message: d.SchemaRef}, true
+	}
+	return lint.RelatedLocation{File: file, Line: line, Message: d.relatedMessage()}, true
+}
+
+// relatedMessage is the short label shown on a navigable schema
+// related-location. The detailed expectation stays in the main
+// diagnostic message, so this stays concise.
+func (d SchemaDiagnostic) relatedMessage() string {
+	if d.Deprecated {
+		return "deprecated by schema"
+	}
+	return "required by schema"
+}
+
+// parseSchemaRef splits a SchemaRef into a file path and 1-based line.
+// It recognizes "<path>:<line>" when the suffix is a positive integer
+// and the prefix looks like a path, and "<path>" on its own. Anything
+// that is not a path (labels with spaces, single words with no
+// separator) returns ("", 0) so the caller treats it as a label.
+func parseSchemaRef(ref string) (file string, line int) {
+	if i := strings.LastIndexByte(ref, ':'); i > 0 {
+		if n, err := strconv.Atoi(ref[i+1:]); err == nil && n > 0 {
+			if cand := ref[:i]; looksLikePath(cand) {
+				return cand, n
+			}
+		}
+	}
+	if looksLikePath(ref) {
+		return ref, 0
+	}
+	return "", 0
+}
+
+// looksLikePath reports whether s is plausibly a repo-relative file
+// path: no whitespace, and at least one "/" or "." separator. Schema
+// sources are POSIX paths like "plan/proto.md", so this rejects the
+// descriptive labels ("inline kind schema", "schema") without a false
+// positive on a real path.
+func looksLikePath(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t") {
+		return false
+	}
+	return strings.ContainsAny(s, "/.")
 }
 
 // formatActual renders a JSON-decoded front-matter value for the

--- a/internal/schema/diagnostic_test.go
+++ b/internal/schema/diagnostic_test.go
@@ -263,7 +263,7 @@ func TestParseFMBlockKeyLines_BlockScalarWithFenceSequence(t *testing.T) {
 // diagnostics for unrecoverable CUE/JSON failures used to drop
 // the schema reference. Every diagnostic the validator emits now
 // uses SchemaDiagnostic, so the source rides on a structured
-// related location rather than the message body (plan 221).
+// related location rather than the message body (plan 230).
 func TestValidateFrontmatterDiags_CompileFailureCarriesSchemaRef(t *testing.T) {
 	sch := &Schema{
 		Source: "kind broken",

--- a/internal/schema/diagnostic_test.go
+++ b/internal/schema/diagnostic_test.go
@@ -27,9 +27,15 @@ func TestSchemaDiagnostic_Format_AllFields(t *testing.T) {
 	}
 	got := d.Format()
 	want := "status: got \"draft\", expected one of: \"open\", \"in-progress\", \"done\"\n" +
-		"  (did you mean \"open\"?)\n" +
-		"schema: plan/proto.md:4"
-	assert.Equal(t, want, got)
+		"  (did you mean \"open\"?)"
+	assert.Equal(t, want, got, "Format no longer carries the schema trailer")
+
+	// The schema reference now rides on a structured related location.
+	rl, ok := d.related()
+	assert.True(t, ok)
+	assert.Equal(t, "plan/proto.md", rl.File)
+	assert.Equal(t, 4, rl.Line)
+	assert.Equal(t, "required by schema", rl.Message)
 }
 
 // TestSchemaDiagnostic_Format_NoActual covers the branch
@@ -43,8 +49,15 @@ func TestSchemaDiagnostic_Format_NoActual(t *testing.T) {
 		Expected:  "section to be present",
 		SchemaRef: "kind plan",
 	}
-	want := "## Goal: expected section to be present\nschema: kind plan"
+	want := "## Goal: expected section to be present"
 	assert.Equal(t, want, d.Format())
+
+	// "kind plan" is a descriptive label, not a file path, so the
+	// related location is message-only (no navigable file/line).
+	rl, ok := d.related()
+	assert.True(t, ok)
+	assert.Equal(t, "", rl.File)
+	assert.Equal(t, "kind plan", rl.Message)
 }
 
 // TestSchemaDiagnostic_Format_FieldOnly covers the very
@@ -54,6 +67,79 @@ func TestSchemaDiagnostic_Format_NoActual(t *testing.T) {
 func TestSchemaDiagnostic_Format_FieldOnly(t *testing.T) {
 	d := SchemaDiagnostic{Field: "field"}
 	assert.Equal(t, "field", d.Format())
+}
+
+// TestSchemaDiagnostic_Related_Variants pins how each SchemaRef shape
+// maps onto a structured related location: file:line and file-only
+// refs are navigable; descriptive labels (with spaces or no path
+// separator) become message-only; an empty ref yields no location.
+func TestSchemaDiagnostic_Related_Variants(t *testing.T) {
+	cases := []struct {
+		name     string
+		ref      string
+		wantOK   bool
+		wantFile string
+		wantLine int
+		wantMsg  string
+	}{
+		{"file with line", "plan/proto.md:4", true, "plan/proto.md", 4, "required by schema"},
+		{"file without line", "plan/proto.md", true, "plan/proto.md", 0, "required by schema"},
+		{"inline label", "inline kind schema", true, "", 0, "inline kind schema"},
+		{"path-pattern label", "kinds[plan] / path-pattern", true, "", 0, "kinds[plan] / path-pattern"},
+		{"single word label", "schema", true, "", 0, "schema"},
+		{"colon but non-numeric", "kind:rfc", true, "", 0, "kind:rfc"},
+		{"no ref", "", false, "", 0, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rl, ok := SchemaDiagnostic{SchemaRef: c.ref}.related()
+			require.Equal(t, c.wantOK, ok)
+			if !c.wantOK {
+				return
+			}
+			assert.Equal(t, c.wantFile, rl.File)
+			assert.Equal(t, c.wantLine, rl.Line)
+			assert.Equal(t, c.wantMsg, rl.Message)
+		})
+	}
+}
+
+// TestSchemaDiagnostic_Related_Deprecated covers the deprecation
+// label on a navigable ref.
+func TestSchemaDiagnostic_Related_Deprecated(t *testing.T) {
+	rl, ok := SchemaDiagnostic{SchemaRef: "plan/proto.md:4", Deprecated: true}.related()
+	require.True(t, ok)
+	assert.Equal(t, "deprecated by schema", rl.Message)
+}
+
+// TestSchemaDiagnostic_Emit_AttachesRelated checks that Emit runs the
+// message through MakeDiag and attaches the schema reference as a
+// related location rather than leaving it in the message body.
+func TestSchemaDiagnostic_Emit_AttachesRelated(t *testing.T) {
+	mk := func(file string, line int, msg string) lint.Diagnostic {
+		return lint.Diagnostic{File: file, Line: line, Message: msg, RuleID: "MDS020"}
+	}
+	d := SchemaDiagnostic{
+		Field: "status", Actual: `"x"`, Expected: `one of: "a"`,
+		SchemaRef: "plan/proto.md:4",
+	}
+	got := d.Emit(mk, "task.md", 7)
+	assert.Equal(t, "task.md", got.File)
+	assert.Equal(t, 7, got.Line)
+	assert.NotContains(t, got.Message, "schema:", "schema ref no longer in message")
+	require.Len(t, got.RelatedLocations, 1)
+	assert.Equal(t, "plan/proto.md", got.RelatedLocations[0].File)
+	assert.Equal(t, 4, got.RelatedLocations[0].Line)
+}
+
+// TestSchemaDiagnostic_Emit_NoRefNoRelated checks that a diagnostic
+// without a SchemaRef gets no related location.
+func TestSchemaDiagnostic_Emit_NoRefNoRelated(t *testing.T) {
+	mk := func(file string, line int, msg string) lint.Diagnostic {
+		return lint.Diagnostic{File: file, Line: line, Message: msg}
+	}
+	got := SchemaDiagnostic{Field: "x"}.Emit(mk, "a.md", 1)
+	assert.Nil(t, got.RelatedLocations)
 }
 
 // TestFormatActual_FallbackOnMarshalError exercises the
@@ -79,8 +165,7 @@ func TestSchemaDiagnostic_Format_NoHint(t *testing.T) {
 		SchemaRef: "kind rfc",
 	}
 	got := d.Format()
-	want := "id: got \"BAD\", expected string matching ^RFC-[0-9]{4}$\n" +
-		"schema: kind rfc"
+	want := "id: got \"BAD\", expected string matching ^RFC-[0-9]{4}$"
 	assert.Equal(t, want, got)
 }
 
@@ -176,9 +261,9 @@ func TestParseFMBlockKeyLines_BlockScalarWithFenceSequence(t *testing.T) {
 // TestValidateFrontmatterDiags_CompileFailureCarriesSchemaRef
 // regresses the Copilot review observation that early-return
 // diagnostics for unrecoverable CUE/JSON failures used to drop
-// the trailing `schema: ...` line. Every diagnostic the
-// validator emits now uses SchemaDiagnostic so the source is
-// always present.
+// the schema reference. Every diagnostic the validator emits now
+// uses SchemaDiagnostic, so the source rides on a structured
+// related location rather than the message body (plan 221).
 func TestValidateFrontmatterDiags_CompileFailureCarriesSchemaRef(t *testing.T) {
 	sch := &Schema{
 		Source: "kind broken",
@@ -191,8 +276,8 @@ func TestValidateFrontmatterDiags_CompileFailureCarriesSchemaRef(t *testing.T) {
 	doc := newDocFile(t, "doc.md", "# T\n")
 	diags := ValidateFrontmatterDiags(doc, sch, map[string]any{"id": 1}, makeDiagForTest)
 	require.NotEmpty(t, diags)
-	assert.Contains(t, diags[0].Message, "schema:")
-	assert.Contains(t, diags[0].Message, "kind broken")
+	require.Len(t, diags[0].RelatedLocations, 1)
+	assert.Equal(t, "kind broken", diags[0].RelatedLocations[0].Message)
 }
 
 // TestRenderExpected_IntRangeOverflowGuard regresses two

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -307,7 +307,7 @@ func nonBodyDiagLine(f *lint.File) int {
 // generated range (a positive line that both survives filtering and
 // formats as a valid location), or 0 when the whole file is generated
 // and no safe positive anchor exists, so the diagnostic still surfaces
-// rather than being dropped or printed as file:0 (plan 221).
+// rather than being dropped or printed as file:0 (plan 230).
 func MissingSectionAnchor(f *lint.File, candidate int) int {
 	if candidate > 0 && !lineInGeneratedRange(f, candidate) {
 		return candidate

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -159,12 +159,11 @@ func validateFrontmatterDiags(
 			compileFailureDiag(sch, "front matter", "JSON-marshalable front matter", err).
 				Emit(mkDiag, f.Path, anchor)}
 	}
+	// CompileBytes parses the JSON the marshal above produced, which is
+	// always valid CUE, so it cannot error here. A bottom value would
+	// still surface through the Unify + Validate path below, so there is
+	// no separate (untestable) compile-failure branch for it.
 	dataVal := ctx.CompileBytes(data)
-	if err := dataVal.Err(); err != nil {
-		return []lint.Diagnostic{
-			compileFailureDiag(sch, "front matter", "valid front matter", err).
-				Emit(mkDiag, f.Path, anchor)}
-	}
 	merged := schemaVal.Unify(dataVal)
 	verr := merged.Validate(cue.Concrete(true))
 	if verr == nil {
@@ -177,18 +176,12 @@ func validateFrontmatterDiags(
 		return validateDeprecatedFieldsWithLines(
 			f, sch, docFM, docFrontmatterKeyLines(f), mkDiag)
 	}
-	cueErrs := errors.Errors(verr)
-	if len(cueErrs) == 0 {
-		return []lint.Diagnostic{
-			SchemaDiagnostic{
-				Field:     "front matter",
-				Actual:    fmt.Sprintf("%v", verr),
-				Expected:  "valid CUE",
-				SchemaRef: schemaRef(sch, ""),
-			}.Emit(mkDiag, f.Path, anchor)}
-	}
+	// errors.Errors returns a non-empty list for any non-nil CUE
+	// validation error, so there is no separate (untestable) "valid CUE"
+	// fallback; the per-error diagnostics below cover every reachable
+	// validation failure.
 	keyLines := docFrontmatterKeyLines(f)
-	out := dedupedCUEErrorDiags(f, sch, docFM, cueErrs, keyLines, mkDiag)
+	out := dedupedCUEErrorDiags(f, sch, docFM, errors.Errors(verr), keyLines, mkDiag)
 	return append(out, validateDeprecatedFieldsWithLines(f, sch, docFM, keyLines, mkDiag)...)
 }
 

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -308,7 +308,8 @@ func nonBodyDiagLine(f *lint.File) int {
 // generated section would let engine.filterGeneratedDiags drop the
 // diagnostic — the very case NonBodyDiagLine's non-positive value
 // guards against. So this re-anchors at the insertion point only when
-// it is safe, and falls back to line 1 otherwise (plan 221).
+// it is safe, and falls back to the non-body anchor — the non-positive
+// NonBodyDiagLine value, not a literal line 1 — otherwise (plan 221).
 func MissingSectionAnchor(f *lint.File, candidate int) int {
 	if candidate > 0 && !lineInGeneratedRange(f, candidate) {
 		return candidate

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -294,30 +294,48 @@ func nonBodyDiagLine(f *lint.File) int {
 
 // MissingSectionAnchor returns the body line to anchor a
 // missing-section diagnostic. candidate is the natural insertion
-// point — the line of the heading the missing section should follow.
-// It is used when it is a real body line (> 0) that lies outside every
-// generated range; otherwise the non-body anchor is returned. A
-// missing section has no body line of its own, and anchoring inside a
-// generated section would let engine.filterGeneratedDiags drop the
-// diagnostic — the very case NonBodyDiagLine's non-positive value
-// guards against. So this re-anchors at the insertion point only when
-// it is safe, and falls back to the non-body anchor — the non-positive
-// NonBodyDiagLine value, not a literal line 1 — otherwise (plan 221).
+// point — the line of the heading the missing section should follow —
+// and is used when it is a real body line (> 0) outside every generated
+// range. A missing section has no body line of its own, and anchoring
+// inside a generated section would let engine.filterGeneratedDiags drop
+// the diagnostic. When candidate is unusable, the non-body anchor is
+// used: a non-positive value survives filtering and maps back to file
+// line 1, and a positive value (nothing stripped, line 1) is fine as
+// long as line 1 is not itself generated. The remaining case — a
+// document that opens with a generated section so the positive non-body
+// anchor sits inside it — anchors at the first body line outside every
+// generated range (a positive line that both survives filtering and
+// formats as a valid location), or 0 when the whole file is generated
+// and no safe positive anchor exists, so the diagnostic still surfaces
+// rather than being dropped or printed as file:0 (plan 221).
 func MissingSectionAnchor(f *lint.File, candidate int) int {
 	if candidate > 0 && !lineInGeneratedRange(f, candidate) {
 		return candidate
 	}
 	fallback := NonBodyDiagLine(f)
-	// NonBodyDiagLine is positive (line 1) when no front matter was
-	// stripped. A document that opens with a generated section then puts
-	// line 1 inside a generated range, where a positive anchor would be
-	// dropped by engine.filterGeneratedDiags. Clamp to 0: a non-positive
-	// line cannot fall within any 1-based generated range, so the
-	// missing-section diagnostic always survives.
-	if fallback > 0 && lineInGeneratedRange(f, fallback) {
-		return 0
+	if fallback <= 0 || !lineInGeneratedRange(f, fallback) {
+		return fallback
 	}
-	return fallback
+	// fallback is a positive line (nothing stripped) inside a leading
+	// generated range, where filterGeneratedDiags would drop it. Prefer
+	// the first body line outside every generated range; fall back to 0
+	// only when the whole file is generated.
+	if line := firstNonGeneratedLine(f); line > 0 {
+		return line
+	}
+	return 0
+}
+
+// firstNonGeneratedLine returns the first 1-based body line that lies
+// outside every generated range, or 0 when the file is empty or
+// entirely generated (no such line exists).
+func firstNonGeneratedLine(f *lint.File) int {
+	for line := 1; line <= len(f.Lines); line++ {
+		if !lineInGeneratedRange(f, line) {
+			return line
+		}
+	}
+	return 0
 }
 
 // precedingHeadingLine returns the line of the document heading just

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -299,6 +299,44 @@ func nonBodyDiagLine(f *lint.File) int {
 	return NonBodyDiagLine(f)
 }
 
+// MissingSectionAnchor returns the body line to anchor a
+// missing-section diagnostic. candidate is the natural insertion
+// point — the line of the heading the missing section should follow.
+// It is used when it is a real body line (> 0) that lies outside every
+// generated range; otherwise the non-body anchor is returned. A
+// missing section has no body line of its own, and anchoring inside a
+// generated section would let engine.filterGeneratedDiags drop the
+// diagnostic — the very case NonBodyDiagLine's non-positive value
+// guards against. So this re-anchors at the insertion point only when
+// it is safe, and falls back to line 1 otherwise (plan 221).
+func MissingSectionAnchor(f *lint.File, candidate int) int {
+	if candidate > 0 && !lineInGeneratedRange(f, candidate) {
+		return candidate
+	}
+	return NonBodyDiagLine(f)
+}
+
+// precedingHeadingLine returns the line of the document heading just
+// before docIdx — the section a missing scope should follow — or 0
+// when there is no preceding heading.
+func precedingHeadingLine(docHeads []DocHeading, docIdx int) int {
+	if idx := docIdx - 1; idx >= 0 && idx < len(docHeads) {
+		return docHeads[idx].Line
+	}
+	return 0
+}
+
+// lineInGeneratedRange reports whether the 1-based body line falls
+// within any of the file's generated-section ranges.
+func lineInGeneratedRange(f *lint.File, line int) bool {
+	for _, r := range f.GeneratedRanges {
+		if r.Contains(line) {
+			return true
+		}
+	}
+	return false
+}
+
 // fmDiagLine returns the line to anchor a front-matter diagnostic
 // at, expressed in the body-line coordinate system the engine
 // uses before lint.File.AdjustDiagnostics fires. When the doc's
@@ -641,13 +679,15 @@ func validateScopes(
 		if claimedThis {
 			allowExtra = false
 		} else if !claimed[i] && sc.Required() {
-			// Missing sections have no body line to point at;
-			// use the non-body anchor so filterGeneratedDiags
-			// can't drop the diagnostic if body line 1 sits
-			// inside a generated section.
+			// Anchor the missing section at the heading it should
+			// follow (the preceding document heading), so the
+			// squiggle lands where the section belongs rather than
+			// at file line 1. MissingSectionAnchor falls back to the
+			// non-body anchor when there is no preceding heading or
+			// the insertion point sits inside a generated section.
 			diags = append(diags, missingSectionDiag(
 				formatHeading(expectedLevel, displayHeading(sc)), sch).
-				Emit(mkDiag, f.Path, nonBodyDiagLine(f)))
+				Emit(mkDiag, f.Path, MissingSectionAnchor(f, precedingHeadingLine(docHeads, docIdx))))
 		}
 	}
 

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -146,21 +146,24 @@ func validateFrontmatterDiags(
 	schemaVal := compiled.Value
 	ctx := compiled.Ctx
 	if err := compiled.Err(); err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, anchor,
-			compileFailureDiag(sch, "schema", "valid schema CUE", err).Format())}
+		return []lint.Diagnostic{
+			compileFailureDiag(sch, "schema", "valid schema CUE", err).
+				Emit(mkDiag, f.Path, anchor)}
 	}
 	if docFM == nil {
 		docFM = map[string]any{}
 	}
 	data, err := json.Marshal(docFM)
 	if err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, anchor,
-			compileFailureDiag(sch, "front matter", "JSON-marshalable front matter", err).Format())}
+		return []lint.Diagnostic{
+			compileFailureDiag(sch, "front matter", "JSON-marshalable front matter", err).
+				Emit(mkDiag, f.Path, anchor)}
 	}
 	dataVal := ctx.CompileBytes(data)
 	if err := dataVal.Err(); err != nil {
-		return []lint.Diagnostic{mkDiag(f.Path, anchor,
-			compileFailureDiag(sch, "front matter", "valid front matter", err).Format())}
+		return []lint.Diagnostic{
+			compileFailureDiag(sch, "front matter", "valid front matter", err).
+				Emit(mkDiag, f.Path, anchor)}
 	}
 	merged := schemaVal.Unify(dataVal)
 	verr := merged.Validate(cue.Concrete(true))
@@ -176,13 +179,13 @@ func validateFrontmatterDiags(
 	}
 	cueErrs := errors.Errors(verr)
 	if len(cueErrs) == 0 {
-		return []lint.Diagnostic{mkDiag(f.Path, anchor,
+		return []lint.Diagnostic{
 			SchemaDiagnostic{
 				Field:     "front matter",
 				Actual:    fmt.Sprintf("%v", verr),
 				Expected:  "valid CUE",
 				SchemaRef: schemaRef(sch, ""),
-			}.Format())}
+			}.Emit(mkDiag, f.Path, anchor)}
 	}
 	keyLines := docFrontmatterKeyLines(f)
 	out := dedupedCUEErrorDiags(f, sch, docFM, cueErrs, keyLines, mkDiag)
@@ -208,7 +211,7 @@ func dedupedCUEErrorDiags(
 			continue
 		}
 		seen[key] = true
-		out = append(out, mkDiag(f.Path, fmDiagLine(f, ce.Path(), keyLines), d.Format()))
+		out = append(out, d.Emit(mkDiag, f.Path, fmDiagLine(f, ce.Path(), keyLines)))
 	}
 	return out
 }
@@ -255,7 +258,7 @@ func validateDeprecatedFieldsWithLines(
 			DeprecationMessage: meta.Message,
 			SchemaRef:          schemaRef(sch, k),
 		}
-		warn := mkDiag(f.Path, fmDiagLine(f, []string{bare}, keyLines), d.Format())
+		warn := d.Emit(mkDiag, f.Path, fmDiagLine(f, []string{bare}, keyLines))
 		warn.Severity = lint.Warning
 		warn.Deprecated = true
 		warn.ReplacedBy = meta.ReplacedBy
@@ -642,9 +645,9 @@ func validateScopes(
 			// use the non-body anchor so filterGeneratedDiags
 			// can't drop the diagnostic if body line 1 sits
 			// inside a generated section.
-			diags = append(diags, mkDiag(f.Path, nonBodyDiagLine(f),
-				missingSectionDiag(
-					formatHeading(expectedLevel, displayHeading(sc)), sch).Format()))
+			diags = append(diags, missingSectionDiag(
+				formatHeading(expectedLevel, displayHeading(sc)), sch).
+				Emit(mkDiag, f.Path, nonBodyDiagLine(f)))
 		}
 	}
 
@@ -779,8 +782,8 @@ func handleLeftoverHeadings(
 			continue
 		}
 		if !allowExtra && closed {
-			diags = append(diags, mkDiag(f.Path, dh.Line,
-				unexpectedSectionDiag(formatHeading(dh.Level, dh.Text), "", sch).Format()))
+			diags = append(diags, unexpectedSectionDiag(
+				formatHeading(dh.Level, dh.Text), "", sch).Emit(mkDiag, f.Path, dh.Line))
 		}
 		docIdx++
 	}
@@ -848,8 +851,8 @@ func claimLateScope(
 ) (int, []lint.Diagnostic) {
 	sc := scopes[idx]
 	dh := docHeads[docIdx]
-	diags := []lint.Diagnostic{mkDiag(f.Path, dh.Line,
-		outOfOrderDiag(formatHeading(dh.Level, dh.Text), "", sch).Format())}
+	diags := []lint.Diagnostic{outOfOrderDiag(
+		formatHeading(dh.Level, dh.Text), "", sch).Emit(mkDiag, f.Path, dh.Line)}
 	claimed[idx] = true
 	claimCounts[idx]++
 	docIdx++
@@ -1074,11 +1077,10 @@ func (s *matchRun) step(docHeads []DocHeading, docIdx int) (bool, int, bool) {
 			return true, docIdx, false
 		}
 		if !s.allowExtra && s.closed {
-			s.diags = append(s.diags, s.mkDiag(s.f.Path, dh.Line,
-				unexpectedSectionDiag(
-					formatHeading(dh.Level, dh.Text),
-					formatHeading(s.expectedLevel, displayHeading(sc)),
-					s.sch).Format()))
+			s.diags = append(s.diags, unexpectedSectionDiag(
+				formatHeading(dh.Level, dh.Text),
+				formatHeading(s.expectedLevel, displayHeading(sc)),
+				s.sch).Emit(s.mkDiag, s.f.Path, dh.Line))
 		}
 		return false, docIdx + 1, false
 	}
@@ -1171,11 +1173,10 @@ func (s *matchRun) handleNonMatch(docHeads []DocHeading, docIdx int) (bool, int,
 	}
 	if !s.allowExtra && s.closed {
 		sc := s.scopes[s.idx]
-		s.diags = append(s.diags, s.mkDiag(s.f.Path, dh.Line,
-			unexpectedSectionDiag(
-				formatHeading(dh.Level, dh.Text),
-				formatHeading(s.expectedLevel, displayHeading(sc)),
-				s.sch).Format()))
+		s.diags = append(s.diags, unexpectedSectionDiag(
+			formatHeading(dh.Level, dh.Text),
+			formatHeading(s.expectedLevel, displayHeading(sc)),
+			s.sch).Emit(s.mkDiag, s.f.Path, dh.Line))
 	}
 	return false, docIdx + 1, false
 }
@@ -1284,8 +1285,8 @@ func levelDiagIfNeeded(
 	if dh.Level == expectedLevel {
 		return nil
 	}
-	return []lint.Diagnostic{mkDiag(f.Path, dh.Line,
-		levelMismatchSchemaDiag(dh.Text, expectedLevel, dh.Level, sch).Format())}
+	return []lint.Diagnostic{levelMismatchSchemaDiag(
+		dh.Text, expectedLevel, dh.Level, sch).Emit(mkDiag, f.Path, dh.Line)}
 }
 
 // claimOutOfOrder records that docHeads[docIdx] matches scopes[ooIdx]
@@ -1300,11 +1301,10 @@ func claimOutOfOrder(
 	sc := scopes[idx]
 	ooSc := scopes[ooIdx]
 	dh := docHeads[docIdx]
-	diags := []lint.Diagnostic{mkDiag(f.Path, dh.Line,
-		outOfOrderDiag(
-			formatHeading(dh.Level, dh.Text),
-			formatHeading(expectedLevel, displayHeading(sc)),
-			sch).Format())}
+	diags := []lint.Diagnostic{outOfOrderDiag(
+		formatHeading(dh.Level, dh.Text),
+		formatHeading(expectedLevel, displayHeading(sc)),
+		sch).Emit(mkDiag, f.Path, dh.Line)}
 	diags = append(diags, levelDiagIfNeeded(f, sch, dh, expectedLevel, mkDiag)...)
 	// Count the contiguous run of same-level headings starting at
 	// docIdx that match ooSc. The recovery path still claims only
@@ -1589,7 +1589,7 @@ func validateFilename(
 			Hint:      err.Error(),
 			SchemaRef: schemaRef(sch, ""),
 		}
-		return []lint.Diagnostic{mkDiag(f.Path, anchor, d.Format())}
+		return []lint.Diagnostic{d.Emit(mkDiag, f.Path, anchor)}
 	}
 	if !matched {
 		// `glob` makes the constraint syntax explicit: users
@@ -1604,7 +1604,7 @@ func validateFilename(
 			Expected:  fmt.Sprintf("filename matching glob %s", pattern),
 			SchemaRef: schemaRef(sch, ""),
 		}
-		return []lint.Diagnostic{mkDiag(f.Path, anchor, d.Format())}
+		return []lint.Diagnostic{d.Emit(mkDiag, f.Path, anchor)}
 	}
 	return nil
 }

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -295,10 +295,14 @@ func nonBodyDiagLine(f *lint.File) int {
 // MissingSectionAnchor returns the body line to anchor a
 // missing-section diagnostic. candidate is the natural insertion
 // point — the line of the heading the missing section should follow —
-// and is used when it is a real body line (> 0) outside every generated
-// range. A missing section has no body line of its own, and anchoring
-// inside a generated section would let engine.filterGeneratedDiags drop
-// the diagnostic. When candidate is unusable, the non-body anchor is
+// and is used when it is a real body line (> 0 and within the file)
+// outside every generated range. An out-of-range candidate (e.g. an
+// insertion-point sentinel past EOF) is treated as unusable so the
+// result never exceeds len(f.Lines) and can never map to an
+// out-of-range editor/LSP position. A missing section has no body line
+// of its own, and anchoring inside a generated section would let
+// engine.filterGeneratedDiags drop the diagnostic. When candidate is
+// unusable, the non-body anchor is
 // used: a non-positive value survives filtering and maps back to file
 // line 1, and a positive value (nothing stripped, line 1) is fine as
 // long as line 1 is not itself generated. The remaining case — a
@@ -309,7 +313,7 @@ func nonBodyDiagLine(f *lint.File) int {
 // and no safe positive anchor exists, so the diagnostic still surfaces
 // rather than being dropped or printed as file:0 (plan 230).
 func MissingSectionAnchor(f *lint.File, candidate int) int {
-	if candidate > 0 && !lineInGeneratedRange(f, candidate) {
+	if candidate > 0 && candidate <= len(f.Lines) && !lineInGeneratedRange(f, candidate) {
 		return candidate
 	}
 	fallback := NonBodyDiagLine(f)

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -307,7 +307,17 @@ func MissingSectionAnchor(f *lint.File, candidate int) int {
 	if candidate > 0 && !lineInGeneratedRange(f, candidate) {
 		return candidate
 	}
-	return NonBodyDiagLine(f)
+	fallback := NonBodyDiagLine(f)
+	// NonBodyDiagLine is positive (line 1) when no front matter was
+	// stripped. A document that opens with a generated section then puts
+	// line 1 inside a generated range, where a positive anchor would be
+	// dropped by engine.filterGeneratedDiags. Clamp to 0: a non-positive
+	// line cannot fall within any 1-based generated range, so the
+	// missing-section diagnostic always survives.
+	if fallback > 0 && lineInGeneratedRange(f, fallback) {
+		return 0
+	}
+	return fallback
 }
 
 // precedingHeadingLine returns the line of the document heading just

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -283,7 +283,7 @@ func TestDocFrontmatterKeyLines_StrippedFrontMatter(t *testing.T) {
 }
 
 // TestMissingSectionAnchor covers the body-anchoring helper added in
-// plan 221: the natural insertion point is used when safe; otherwise the
+// plan 230: the natural insertion point is used when safe; otherwise the
 // anchor is the first body line outside every generated range so
 // engine.filterGeneratedDiags never drops the diagnostic and it still
 // formats as a valid location.

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -163,8 +163,8 @@ func TestValidateFrontmatterDiags_InvalidCUESchemaCarriesRef(t *testing.T) {
 	require.NoError(t, err)
 	diags := ValidateFrontmatterDiags(f, sch, map[string]any{"id": 1}, makeDiagForTest)
 	require.Len(t, diags, 1)
-	assert.Contains(t, diags[0].Message, "schema:")
-	assert.Contains(t, diags[0].Message, "kind bad")
+	require.Len(t, diags[0].RelatedLocations, 1)
+	assert.Equal(t, "kind bad", diags[0].RelatedLocations[0].Message)
 }
 
 // TestCompileFailureDiag_FieldsRoundTrip exercises the
@@ -215,7 +215,8 @@ func TestValidateFrontmatterDiags_JSONMarshalFailureCarriesRef(t *testing.T) {
 	diags := ValidateFrontmatterDiags(f, sch, docFM, makeDiagForTest)
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message, "JSON-marshalable")
-	assert.Contains(t, diags[0].Message, "kind broken")
+	require.Len(t, diags[0].RelatedLocations, 1)
+	assert.Equal(t, "kind broken", diags[0].RelatedLocations[0].Message)
 }
 
 // TestValidateFrontmatterDiags_ExtraFieldCarriesRef

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -283,38 +283,50 @@ func TestDocFrontmatterKeyLines_StrippedFrontMatter(t *testing.T) {
 }
 
 // TestMissingSectionAnchor covers the body-anchoring helper added in
-// plan 221: a real body line outside every generated range is used as
-// the anchor; a zero candidate (no preceding heading) and a candidate
-// inside a generated section both fall back to the non-body anchor so
-// engine.filterGeneratedDiags can never drop the diagnostic.
+// plan 221: the natural insertion point is used when safe; otherwise the
+// anchor is the first body line outside every generated range so
+// engine.filterGeneratedDiags never drops the diagnostic and it still
+// formats as a valid location.
 func TestMissingSectionAnchor(t *testing.T) {
 	f, err := lint.NewFile("doc.md", []byte("# A\n## B\n## C\n"))
 	require.NoError(t, err)
 	require.Equal(t, 1, NonBodyDiagLine(f))
 
 	assert.Equal(t, 2, MissingSectionAnchor(f, 2), "real body line is used")
-	assert.Equal(t, NonBodyDiagLine(f), MissingSectionAnchor(f, 0),
-		"no preceding heading → non-body anchor")
+	assert.Equal(t, 1, MissingSectionAnchor(f, 0),
+		"no preceding heading → first body line")
 
 	f.GeneratedRanges = []lint.LineRange{{From: 2, To: 4}}
-	assert.Equal(t, NonBodyDiagLine(f), MissingSectionAnchor(f, 3),
-		"candidate inside a generated range → non-body anchor")
+	assert.Equal(t, 1, MissingSectionAnchor(f, 3),
+		"candidate inside a generated range → first non-generated line")
 	assert.Equal(t, 5, MissingSectionAnchor(f, 5),
 		"candidate outside the range is still used")
 
-	// Regression (Copilot review): with no front matter stripped,
-	// NonBodyDiagLine is 1. If the document opens with a generated
-	// section that covers line 1, the fallback must not land on that
-	// generated line — it clamps to a non-positive anchor so
-	// engine.filterGeneratedDiags can never drop the missing-section
-	// diagnostic.
+	// Regression (Copilot review): a document that opens with a generated
+	// section. The anchor must not be a generated positive line (dropped
+	// by filterGeneratedDiags) nor a 0 that formats as file:0 — it is the
+	// first body line outside the generated range.
 	f.GeneratedRanges = []lint.LineRange{{From: 1, To: 3}}
-	require.Equal(t, 1, NonBodyDiagLine(f))
 	got := MissingSectionAnchor(f, 0)
-	assert.LessOrEqual(t, got, 0,
-		"fallback inside a generated range clamps to a non-positive anchor")
+	assert.Positive(t, got, "anchors at a real body line, not file:0")
 	assert.False(t, lineInGeneratedRange(f, got),
-		"the clamped anchor lies outside every generated range")
+		"the anchor lies outside every generated range")
+
+	// Whole file generated, nothing stripped: no positive line is safe
+	// and no non-positive line formats as a valid location, so 0 is the
+	// last resort that still surfaces the diagnostic.
+	f.GeneratedRanges = []lint.LineRange{{From: 1, To: len(f.Lines)}}
+	assert.Equal(t, 0, MissingSectionAnchor(f, 0),
+		"whole file generated, no front matter → file-start last resort")
+
+	// Whole file generated but front matter was stripped: the non-body
+	// anchor is non-positive, so it survives filtering and maps back onto
+	// the file rather than degenerating to 0.
+	f.LineOffset = 5
+	assert.Equal(t, NonBodyDiagLine(f), MissingSectionAnchor(f, 0),
+		"whole file generated, front matter stripped → non-body anchor")
+	assert.Negative(t, MissingSectionAnchor(f, 0),
+		"the non-body anchor is non-positive and survives filtering")
 }
 
 // TestPrecedingHeadingLine covers the document-order lookup: the

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -301,6 +301,20 @@ func TestMissingSectionAnchor(t *testing.T) {
 		"candidate inside a generated range → non-body anchor")
 	assert.Equal(t, 5, MissingSectionAnchor(f, 5),
 		"candidate outside the range is still used")
+
+	// Regression (Copilot review): with no front matter stripped,
+	// NonBodyDiagLine is 1. If the document opens with a generated
+	// section that covers line 1, the fallback must not land on that
+	// generated line — it clamps to a non-positive anchor so
+	// engine.filterGeneratedDiags can never drop the missing-section
+	// diagnostic.
+	f.GeneratedRanges = []lint.LineRange{{From: 1, To: 3}}
+	require.Equal(t, 1, NonBodyDiagLine(f))
+	got := MissingSectionAnchor(f, 0)
+	assert.LessOrEqual(t, got, 0,
+		"fallback inside a generated range clamps to a non-positive anchor")
+	assert.False(t, lineInGeneratedRange(f, got),
+		"the clamped anchor lies outside every generated range")
 }
 
 // TestPrecedingHeadingLine covers the document-order lookup: the

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -281,3 +281,34 @@ func TestDocFrontmatterKeyLines_StrippedFrontMatter(t *testing.T) {
 	assert.Equal(t, 2, lines["id"])
 	assert.Equal(t, 3, lines["status"])
 }
+
+// TestMissingSectionAnchor covers the body-anchoring helper added in
+// plan 221: a real body line outside every generated range is used as
+// the anchor; a zero candidate (no preceding heading) and a candidate
+// inside a generated section both fall back to the non-body anchor so
+// engine.filterGeneratedDiags can never drop the diagnostic.
+func TestMissingSectionAnchor(t *testing.T) {
+	f, err := lint.NewFile("doc.md", []byte("# A\n## B\n## C\n"))
+	require.NoError(t, err)
+	require.Equal(t, 1, NonBodyDiagLine(f))
+
+	assert.Equal(t, 2, MissingSectionAnchor(f, 2), "real body line is used")
+	assert.Equal(t, NonBodyDiagLine(f), MissingSectionAnchor(f, 0),
+		"no preceding heading → non-body anchor")
+
+	f.GeneratedRanges = []lint.LineRange{{From: 2, To: 4}}
+	assert.Equal(t, NonBodyDiagLine(f), MissingSectionAnchor(f, 3),
+		"candidate inside a generated range → non-body anchor")
+	assert.Equal(t, 5, MissingSectionAnchor(f, 5),
+		"candidate outside the range is still used")
+}
+
+// TestPrecedingHeadingLine covers the document-order lookup: the
+// heading just before docIdx, or 0 when there is none.
+func TestPrecedingHeadingLine(t *testing.T) {
+	heads := []DocHeading{{Line: 1}, {Line: 3}, {Line: 7}}
+	assert.Equal(t, 0, precedingHeadingLine(heads, 0))
+	assert.Equal(t, 1, precedingHeadingLine(heads, 1))
+	assert.Equal(t, 7, precedingHeadingLine(heads, 3))
+	assert.Equal(t, 0, precedingHeadingLine(nil, 5))
+}

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -299,8 +299,12 @@ func TestMissingSectionAnchor(t *testing.T) {
 	f.GeneratedRanges = []lint.LineRange{{From: 2, To: 4}}
 	assert.Equal(t, 1, MissingSectionAnchor(f, 3),
 		"candidate inside a generated range → first non-generated line")
-	assert.Equal(t, 5, MissingSectionAnchor(f, 5),
-		"candidate outside the range is still used")
+
+	f.GeneratedRanges = []lint.LineRange{{From: 2, To: 2}}
+	assert.Equal(t, 3, MissingSectionAnchor(f, 3),
+		"in-range candidate outside the generated range is used")
+	assert.Equal(t, 1, MissingSectionAnchor(f, len(f.Lines)+1),
+		"out-of-range candidate falls back; never returns > len(f.Lines)")
 
 	// Regression (Copilot review): a document that opens with a generated
 	// section. The anchor must not be a generated positive line (dropped

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -363,9 +363,9 @@ func firstError(errs []error) error {
 // cloneDiagnostics returns a shallow copy of the slice so a caller
 // cannot append into or overwrite the cache's backing array. The
 // Diagnostic elements are copied by value; their inner slices
-// (SourceLines) and pointer (Explanation) are shared, which is safe
-// because callers treat results as read-only and the engine never
-// mutates a diagnostic after producing it. nil maps to nil so the
+// (SourceLines, RelatedLocations) and pointer (Explanation) are
+// shared, which is safe because callers treat results as read-only and
+// the engine never mutates a diagnostic after producing it. nil maps to nil so the
 // public no-diagnostics contract (nil, not []) is preserved.
 func cloneDiagnostics(in []Diagnostic) []Diagnostic {
 	if in == nil {

--- a/pkg/mdsmith/session_api_test.go
+++ b/pkg/mdsmith/session_api_test.go
@@ -1,11 +1,59 @@
 package mdsmith
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestCheckCarriesRelatedLocations verifies the public Diagnostic
+// carries RelatedLocations for a schema (MDS020) violation and that it
+// JSON-marshals with the related_locations field — matching the CLI
+// --format json shape so a WASM/Session host (e.g. the Obsidian
+// plugin) reads one schema (plan 221).
+func TestCheckCarriesRelatedLocations(t *testing.T) {
+	cfg := ConfigYAML("kinds:\n" +
+		"  task:\n" +
+		"    schema:\n" +
+		"      sections:\n" +
+		"        - heading: \"Goal\"\n" +
+		"        - heading: \"Tasks\"\n" +
+		"kind-assignment:\n" +
+		"  - glob: [\"*.md\"]\n" +
+		"    kinds: [task]\n")
+	s, err := NewSession(SessionOptions{Workspace: NewMemWorkspace(nil), Config: cfg})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+	// The document has Goal but is missing the required Tasks section.
+	diags, err := s.Check("a.md", []byte("# Title\n\n## Goal\n\nbody\n"))
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	var found *Diagnostic
+	for i := range diags {
+		if diags[i].Rule == "MDS020" {
+			found = &diags[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no MDS020 diagnostic among %d diagnostics", len(diags))
+	}
+	if len(found.RelatedLocations) != 1 {
+		t.Fatalf("RelatedLocations = %d, want 1", len(found.RelatedLocations))
+	}
+	b, err := json.Marshal(*found)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(b), "related_locations") {
+		t.Errorf("public JSON missing related_locations: %s", b)
+	}
+}
 
 // --- ConfigSource: ConfigPath and ConfigYAML ---
 

--- a/pkg/mdsmith/session_api_test.go
+++ b/pkg/mdsmith/session_api_test.go
@@ -12,7 +12,7 @@ import (
 // carries RelatedLocations for a schema (MDS020) violation and that it
 // JSON-marshals with the related_locations field — matching the CLI
 // --format json shape so a WASM/Session host (e.g. the Obsidian
-// plugin) reads one schema (plan 221).
+// plugin) reads one schema (plan 230).
 func TestCheckCarriesRelatedLocations(t *testing.T) {
 	cfg := ConfigYAML("kinds:\n" +
 		"  task:\n" +

--- a/pkg/mdsmith/types.go
+++ b/pkg/mdsmith/types.go
@@ -24,10 +24,28 @@ type Diagnostic struct {
 	Deprecated      bool         `json:"deprecated,omitempty"`
 	ReplacedBy      string       `json:"replaced_by,omitempty"`
 
+	// RelatedLocations carries secondary source locations — for MDS020,
+	// the schema constraint a value violated — matching the CLI
+	// `--format json` shape so the WASM/Session host and the CLI decode
+	// one schema. A host (e.g. the Obsidian plugin) renders these as
+	// navigable links. Omitted when there are none.
+	RelatedLocations []RelatedLocation `json:"related_locations,omitempty"`
+
 	// RuleID is an unexported-on-the-wire convenience for Go callers
 	// that want the rule identifier without parsing JSON. It is not
 	// serialized; use Rule for the wire field.
 	RuleID string `json:"-"`
+}
+
+// RelatedLocation is a secondary source location attached to a
+// Diagnostic — for a schema violation, the line of the schema
+// constraint. File may differ from the owning Diagnostic.File (the
+// schema lives in a separate proto.md, kind file, or config).
+type RelatedLocation struct {
+	File    string `json:"file,omitempty"`
+	Line    int    `json:"line,omitempty"`
+	Column  int    `json:"column,omitempty"`
+	Message string `json:"message"`
 }
 
 // Explanation attaches per-leaf rule provenance to a Diagnostic. It is
@@ -74,19 +92,35 @@ func toDiagnostics(in []lint.Diagnostic) []Diagnostic {
 	out := make([]Diagnostic, 0, len(in))
 	for _, d := range in {
 		out = append(out, Diagnostic{
-			File:            d.File,
-			Line:            d.Line,
-			Column:          d.Column,
-			Rule:            d.RuleID,
-			RuleID:          d.RuleID,
-			Name:            d.RuleName,
-			Severity:        string(d.Severity),
-			Message:         d.Message,
-			SourceLines:     d.SourceLines,
-			SourceStartLine: d.SourceStartLine,
-			Explanation:     toExplanation(d.Explanation),
-			Deprecated:      d.Deprecated,
-			ReplacedBy:      d.ReplacedBy,
+			File:             d.File,
+			Line:             d.Line,
+			Column:           d.Column,
+			Rule:             d.RuleID,
+			RuleID:           d.RuleID,
+			Name:             d.RuleName,
+			Severity:         string(d.Severity),
+			Message:          d.Message,
+			SourceLines:      d.SourceLines,
+			SourceStartLine:  d.SourceStartLine,
+			Explanation:      toExplanation(d.Explanation),
+			Deprecated:       d.Deprecated,
+			ReplacedBy:       d.ReplacedBy,
+			RelatedLocations: toRelatedLocations(d.RelatedLocations),
+		})
+	}
+	return out
+}
+
+// toRelatedLocations converts engine related locations to the public
+// shape; returns nil for none so the JSON field is omitted.
+func toRelatedLocations(in []lint.RelatedLocation) []RelatedLocation {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]RelatedLocation, 0, len(in))
+	for _, l := range in {
+		out = append(out, RelatedLocation{
+			File: l.File, Line: l.Line, Column: l.Column, Message: l.Message,
 		})
 	}
 	return out

--- a/pkg/mdsmith/types.go
+++ b/pkg/mdsmith/types.go
@@ -93,7 +93,7 @@ func toDiagnostics(in []lint.Diagnostic) []Diagnostic {
 	for _, d := range in {
 		out = append(out, Diagnostic{
 			File:             d.File,
-			Line:             d.Line,
+			Line:             d.DisplayLine(),
 			Column:           d.Column,
 			Rule:             d.RuleID,
 			RuleID:           d.RuleID,

--- a/pkg/mdsmith/types_test.go
+++ b/pkg/mdsmith/types_test.go
@@ -39,3 +39,24 @@ func TestToExplanationConverts(t *testing.T) {
 		t.Fatalf("Leaves[1] = %+v, want {exclude tables kind:doc}", got.Leaves[1])
 	}
 }
+
+// TestToDiagnosticsClampsNonPositiveLine covers the public-API clamp:
+// plan 221's line-0 sentinel must not leak through the Session/WASM API;
+// it surfaces as 1, while a RelatedLocation line of 0 ("unknown") is
+// preserved.
+func TestToDiagnosticsClampsNonPositiveLine(t *testing.T) {
+	out := toDiagnostics([]lint.Diagnostic{{
+		File: "gen.md", Line: 0, Column: 3, RuleID: "MDS020",
+		RelatedLocations: []lint.RelatedLocation{{File: "p.md", Line: 0}},
+	}})
+	if len(out) != 1 {
+		t.Fatalf("got %d diagnostics, want 1", len(out))
+	}
+	if out[0].Line != 1 || out[0].Column != 3 {
+		t.Fatalf("public Line/Column = %d/%d, want 1/3 (line clamped, column kept)",
+			out[0].Line, out[0].Column)
+	}
+	if len(out[0].RelatedLocations) != 1 || out[0].RelatedLocations[0].Line != 0 {
+		t.Fatalf("related location line not preserved as 0 (unknown)")
+	}
+}

--- a/pkg/mdsmith/types_test.go
+++ b/pkg/mdsmith/types_test.go
@@ -41,7 +41,7 @@ func TestToExplanationConverts(t *testing.T) {
 }
 
 // TestToDiagnosticsClampsNonPositiveLine covers the public-API clamp:
-// plan 221's line-0 sentinel must not leak through the Session/WASM API;
+// plan 230's line-0 sentinel must not leak through the Session/WASM API;
 // it surfaces as 1, while a RelatedLocation line of 0 ("unknown") is
 // preserved.
 func TestToDiagnosticsClampsNonPositiveLine(t *testing.T) {

--- a/plan/217_obsidian-plugin.md
+++ b/plan/217_obsidian-plugin.md
@@ -96,10 +96,11 @@ a wavy underline. Severity classes live in
 `styles.css`.
 
 A hover tooltip is issue-first (plan 221): the
-message leads, then a navigable link to the
-schema constraint (from `relatedLocations`),
-then the rule code and a docs link. The "Fix"
-link runs the same flow as the palette command.
+message leads, then the schema constraint from
+`relatedLocations` (a navigable link when it has
+a file/line, else plain text), then the rule code
+and a docs link. The "Fix" link runs the same flow
+as the palette command.
 
 A "mdsmith Diagnostics" [`ItemView`][iv]
 lists every workspace diagnostic in a sortable
@@ -265,7 +266,8 @@ artifact.
       file on desktop, 2 s on a modern
       iPad.
 - [ ] Hover tooltip is issue-first: message,
-      then a navigable schema-constraint link,
+      then the schema constraint (a navigable link
+      when it has a file/line, else plain text),
       then rule code and a docs link. The "Fix"
       link applies the quick-fix.
 - [ ] `mdsmith: Fix file` produces the

--- a/plan/217_obsidian-plugin.md
+++ b/plan/217_obsidian-plugin.md
@@ -97,7 +97,7 @@ a wavy underline. Severity classes live in
 
 A hover tooltip is issue-first (plan 221): the
 message leads, then the schema constraint from
-`relatedLocations` (a navigable link when it has
+`related_locations` (a navigable link when it has
 a file/line, else plain text), then the rule code
 and a docs link. The "Fix" link runs the same flow
 as the palette command.

--- a/plan/217_obsidian-plugin.md
+++ b/plan/217_obsidian-plugin.md
@@ -95,7 +95,7 @@ field tracks the diagnostics. Each shows as
 a wavy underline. Severity classes live in
 `styles.css`.
 
-A hover tooltip is issue-first (plan 221): the
+A hover tooltip is issue-first (plan 230): the
 message leads, then the schema constraint from
 `related_locations` (a navigable link when it has
 a file/line, else plain text), then the rule code

--- a/plan/217_obsidian-plugin.md
+++ b/plan/217_obsidian-plugin.md
@@ -95,10 +95,11 @@ field tracks the diagnostics. Each shows as
 a wavy underline. Severity classes live in
 `styles.css`.
 
-A hover tooltip shows the rule code and
-the message. The tooltip footer carries a
-"Fix" link. The link runs the same
-code-action flow as the palette command.
+A hover tooltip is issue-first (plan 221): the
+message leads, then a navigable link to the
+schema constraint (from `relatedLocations`),
+then the rule code and a docs link. The "Fix"
+link runs the same flow as the palette command.
 
 A "mdsmith Diagnostics" [`ItemView`][iv]
 lists every workspace diagnostic in a sortable
@@ -263,9 +264,10 @@ artifact.
       underline within 1 s of opening the
       file on desktop, 2 s on a modern
       iPad.
-- [ ] Hover tooltip shows rule code and
-      message. The "Fix" link applies the
-      quick-fix.
+- [ ] Hover tooltip is issue-first: message,
+      then a navigable schema-constraint link,
+      then rule code and a docs link. The "Fix"
+      link applies the quick-fix.
 - [ ] `mdsmith: Fix file` produces the
       same buffer as `mdsmith fix` on the
       same input.

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -210,9 +210,10 @@ the one new input to its signature.
 contract. Its tooltip adopts the issue-first layout
 and renders the schema location as a link, since
 CodeMirror has no native `relatedInformation`. The
-WASM payload carries `relatedLocations` and `docURL`.
-This plan updates 217's text; the rendering stays
-there.
+WASM payload carries `relatedLocations`
+(`pkg/mdsmith.Diagnostic`); the rule-doc link is
+derived from the rule ID, not stored. This plan
+updates 217's text; the rendering stays there.
 
 ### Inline-schema location
 

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -7,18 +7,16 @@ depends-on: [147, 133]
 summary: >-
   Make MDS020 schema violations navigable and
   readable in editors. Add structured
-  `RelatedLocations` and a doc URL to
-  `lint.Diagnostic` so each diagnostic points at the
-  `proto.md` or kind-file line that declares the
-  violated constraint. Anchor missing-section,
-  filename, and schema-level diagnostics at the body
-  insertion point instead of file line 1. Redesign
+  `RelatedLocations` to `lint.Diagnostic` so each
+  diagnostic points at the `proto.md` or kind-file
+  line that declares the violated constraint. Redesign
   the LSP hover so the file's issue is the primary
   content and the rule docs sit below a separator as
   a one-line summary plus a link. Map
-  `RelatedLocations` to LSP `relatedInformation` and
-  the doc URL to `codeDescription`, and fix the same
-  contract for the Obsidian tooltip.
+  `RelatedLocations` to LSP `relatedInformation`, and
+  derive a `codeDescription` doc link from the rule
+  ID, and fix the same contract for the Obsidian
+  tooltip.
 ---
 # Navigable schema diagnostics in the editor
 
@@ -110,13 +108,15 @@ type RelatedLocation struct {
 
 // On Diagnostic:
 //   RelatedLocations []RelatedLocation
-//   DocURL           string // canonical rule-doc URL
 ```
 
 `RelatedLocations` is rule-agnostic. Any rule may
 attach them. `lint.Diagnostic` stays the single shared
 seam. The schema package is the first producer; the
-LSP and CLI consume.
+LSP and CLI consume. The rule-doc link (LSP
+`codeDescription`) is not a diagnostic field — it is
+derived from the rule ID via `rules.DocURL` at the LSP
+surface.
 
 The schema reference stops being baked into the
 message. `SchemaDiagnostic.Format()`
@@ -188,11 +188,11 @@ Design rules:
 one-line `Description` from the README front matter
 (MDS020: "Document structure and front matter must
 match its schema"). The hover uses `Description`, not
-`info.Content`. Two calls to settle in code: whether
-to keep the plan-147 remediation line, and the
-`DocURL` scheme. `codeDescription.href` must be an
-`http(s)` URL; a `command:` link is valid only for the
-doc link inside the hover markdown.
+`info.Content`. The doc link comes from
+`rules.DocURL(RuleID)` (rule-ID → website page), mapped
+to `codeDescription.href`, which must be an `http(s)`
+URL. One call to settle in code: whether to keep the
+plan-147 remediation line.
 
 ### LSP wire and Obsidian
 
@@ -229,8 +229,7 @@ declaration's line — still navigable.
 
 ## Tasks
 
-1. Add `RelatedLocation`, `RelatedLocations`, and
-   `DocURL` to
+1. Add `RelatedLocation` and `RelatedLocations` to
    [diagnostic.go](../internal/lint/diagnostic.go),
    with a test that zero values stay compatible.
 2. Drop the `schema:` trailer from
@@ -247,8 +246,9 @@ declaration's line — still navigable.
 4. (Follow-up) Re-anchor missing section / content
    off line 1. Deferred to keep the
    `filterGeneratedDiags` guarantee (see Design).
-5. Populate `DocURL` for MDS020 via a reusable
-   rule→URL lookup.
+5. Add `rules.DocURL` (a reusable rule-ID → doc-page
+   URL lookup) and derive `codeDescription` from it in
+   `toLSP`. No `DocURL` field on the diagnostic.
 6. CLI: print `RelatedLocations` as trailer lines in
    `check` / `fix`. Update surface tests.
 7. LSP: add `relatedInformation` and
@@ -274,8 +274,10 @@ declaration's line — still navigable.
 
 ## Acceptance Criteria
 
-- [x] `lint.Diagnostic` carries `RelatedLocations` and
-      `DocURL`; old diagnostics serialize unchanged.
+- [x] `lint.Diagnostic` carries `RelatedLocations`;
+      old diagnostics serialize unchanged. The rule-doc
+      link is derived from the rule ID at the LSP
+      surface, not stored on the diagnostic.
 - [x] An MDS020 FM violation has a `RelatedLocation`
       naming the schema file and line.
 - [ ] An inline-kind violation gets a real file/line

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -1,0 +1,286 @@
+---
+id: 221
+title: Navigable schema diagnostics in the editor
+status: "🔲"
+model: opus
+depends-on: [147, 133]
+summary: >-
+  Make MDS020 schema violations navigable and
+  readable in editors. Add structured
+  `RelatedLocations` and a doc URL to
+  `lint.Diagnostic` so each diagnostic points at the
+  `proto.md` or kind-file line that declares the
+  violated constraint. Anchor missing-section,
+  filename, and schema-level diagnostics at the body
+  insertion point instead of file line 1. Redesign
+  the LSP hover so the file's issue is the primary
+  content and the rule docs sit below a separator as
+  a one-line summary plus a link. Map
+  `RelatedLocations` to LSP `relatedInformation` and
+  the doc URL to `codeDescription`, and fix the same
+  contract for the Obsidian tooltip.
+---
+# Navigable schema diagnostics in the editor
+
+## Goal
+
+A reader who hits a schema violation should see three
+things, in this order of prominence. What is wrong in
+their file. Where in the file it is. A one-click jump
+to the `proto.md` or kind-schema line that declares
+the rule. The rule's own docs stay available, but
+secondary.
+
+## Background
+
+[Plan 147](147_actionable-schema-diagnostics.md) made
+MDS020 emit one diagnostic per violation. Each names
+the field, the value, the expected constraint, a
+hint, and a `schema:` reference. That solved the
+message *text*. Three gaps remain on the editor
+surface.
+
+- **The schema location is not navigable.** It lives
+  only as plain text in the message. The LSP wire
+  diagnostic
+  ([diagnostics.go](../internal/lsp/diagnostics.go))
+  carries `Code`, `Source`, and `Message` — no
+  `relatedInformation`, no `codeDescription`. So the
+  editor shows the rule ID as a structured element
+  while the schema location stays unlinked text. For
+  inline kind schemas it is worse: `schemaRef`
+  ([validate.go](../internal/schema/validate.go))
+  returns the bare label `inline kind schema`, with
+  no file and no line.
+- **Diagnostics anchor at line 1, not the issue.**
+  Frontmatter-field errors anchor at the field line.
+  But missing sections, filename violations, and
+  schema-compile errors fall back to
+  `nonBodyDiagLine(f)` — file line 1. In a plan or
+  kind file, that is where the frontmatter and the
+  leading `<?require?>` directive sit. So the squiggle
+  lands "at the start of the directive", not where
+  the section belongs.
+- **Rule docs dominate the issue in hover.**
+  `ruleHoverContent`
+  ([hover.go](../internal/lsp/hover.go)) renders the
+  message as one line, then appends the *entire* rule
+  README. The issue reads as a footnote above a wall
+  of documentation.
+
+`lint.Diagnostic`
+([diagnostic.go](../internal/lint/diagnostic.go)) has
+no field for a secondary location at all. The VS Code
+extension
+([extension.ts](../editors/vscode/src/extension.ts))
+is a thin client; it renders what the server sends,
+so it inherits every gap. Obsidian is unbuilt;
+[plan 217](217_obsidian-plugin.md) designs the same
+"rule code plus message" tooltip, so it would inherit
+the gaps too.
+
+## Non-Goals
+
+- Auto-fixing schema violations. Anchoring a missing
+  section is in scope; inserting it is not.
+- Changing CUE validation or the plan-147 extractors.
+- Building the Obsidian plugin. The rendering stays in
+  [plan 217](217_obsidian-plugin.md); this plan fixes
+  the shared contract and 217's design text.
+- New rule IDs. This rewires MDS020's emit path.
+
+## Design
+
+### Related locations on `lint.Diagnostic`
+
+The cross-cutting enabler. Add one type and two fields
+to [diagnostic.go](../internal/lint/diagnostic.go):
+
+```go
+// RelatedLocation is a secondary source location that
+// explains a diagnostic — e.g. the schema constraint
+// a value violated. File may differ from the
+// diagnostic's own File (the schema lives elsewhere).
+type RelatedLocation struct {
+    File    string // may be a proto.md / kind file
+    Line    int    // 1-based
+    Column  int    // 1-based; 0 when only line is known
+    Message string // e.g. "schema requires one of: …"
+}
+
+// On Diagnostic:
+//   RelatedLocations []RelatedLocation
+//   DocURL           string // canonical rule-doc URL
+```
+
+`RelatedLocations` is rule-agnostic. Any rule may
+attach them. `lint.Diagnostic` stays the single shared
+seam. The schema package is the first producer; the
+LSP and CLI consume.
+
+The schema reference stops being baked into the
+message. `SchemaDiagnostic.Format()`
+([diagnostic.go](../internal/schema/diagnostic.go))
+drops its trailing `schema:` line. The MDS020 emit
+path attaches a `RelatedLocation` built from the same
+`SchemaRef` data instead. One source of truth, two
+consumers:
+
+- **CLI** prints related locations as trailer lines,
+  so the schema reference still appears in `check`
+  output — from the struct, not the message.
+- **LSP** maps them to `relatedInformation`.
+
+### Anchor at the issue, not line 1
+
+| Failure                  | Today           | After                                           |
+| ------------------------ | --------------- | ----------------------------------------------- |
+| FM field value           | field line      | unchanged; + related location                   |
+| Missing required section | line 1          | insertion point: end of prior sibling, or H + 1 |
+| Missing content node     | section heading | end of the matched section body                 |
+| Filename / path-pattern  | line 1          | line 1 + related location to `path-pattern:`    |
+| Schema compile error     | line 1          | line 1 + related location to the schema file    |
+
+Every schema diagnostic gets the best anchor in the
+linted file, plus a related location to the schema
+rule. Absence cases move off line 1 where a
+meaningful insertion point exists. A new helper in
+[validate.go](../internal/schema/validate.go) derives
+the insertion line from the scope tree's matched
+siblings.
+
+### Issue-first hover
+
+Restructure `ruleHoverContent` so the issue leads and
+the rule identity follows a separator:
+
+```markdown
+**status** — got `"draft"`, expected one of
+`"open"`, `"in-progress"`, `"done"`
+*did you mean `"open"`?*
+
+Schema: [plan/proto.md:4](…#L4)
+
+---
+
+`MDS020` · required-structure — declared sections
+must be present and in order. [Open docs ↗](…)
+```
+
+Design rules:
+
+1. The issue block leads. The rule code is not
+   prefixed to it; it moves to the secondary block.
+2. A `---` separates the issue from rule identity.
+3. The rule block is condensed to the README's
+   one-line `summary:`, not the full body, plus a
+   doc link.
+4. The schema location renders as a link in the
+   tooltip footer (Obsidian) and as native
+   `relatedInformation` in VS Code.
+
+`cachedRuleInfo` already loads `RuleInfo`. Expose its
+`Summary` so the hover drops `info.Content` for the
+one-line form. Two calls to settle in code: whether to
+keep the plan-147 remediation line, and the `DocURL`
+scheme (a stable web route vs. a `command:` link).
+
+### LSP wire and Obsidian
+
+Add `relatedInformation` and `codeDescription` to the
+LSP `Diagnostic`
+([protocol.go](../internal/lsp/protocol.go)), per LSP
+§3.18.6. Map them in `toLSP`
+([diagnostics.go](../internal/lsp/diagnostics.go)).
+A related location can point at a different file, so
+`toLSP` resolves each `RelatedLocation.File` to a
+`file://` URI against the workspace root. That root is
+the one new input to its signature.
+
+[Plan 217](217_obsidian-plugin.md) consumes the same
+contract. Its tooltip adopts the issue-first layout
+and renders the schema location as a link, since
+CodeMirror has no native `relatedInformation`. The
+WASM payload carries `relatedLocations` and `docURL`.
+This plan updates 217's text; the rendering stays
+there.
+
+### Inline-schema location
+
+So inline kinds get a real file:line, the loader
+records each schema key's source position. Kind files
+([plan 208](208_kind-files.md)) and `proto.md` are
+standalone Markdown; the `yaml.Node` parse already
+has line numbers, so wire them into
+`Schema.FrontmatterLines`. Inline-in-`.mdsmith.yml`
+keys need the config loader to retain per-key lines.
+If that proves costly, fall back to the kind
+declaration's line — still navigable.
+
+## Tasks
+
+1. Add `RelatedLocation`, `RelatedLocations`, and
+   `DocURL` to
+   [diagnostic.go](../internal/lint/diagnostic.go),
+   with a test that zero values stay compatible.
+2. Drop the `schema:` trailer from
+   `SchemaDiagnostic.Format()`; add a method that
+   returns the schema reference as a
+   `RelatedLocation`. Update tests in lockstep.
+3. Attach a schema `RelatedLocation` to every MDS020
+   diagnostic in
+   [validate.go](../internal/schema/validate.go) and
+   [the rule](../internal/rules/requiredstructure/rule.go).
+4. Add the insertion-point helper; re-anchor missing
+   section and missing content off line 1. Unit-test
+   each anchor.
+5. Populate `DocURL` for MDS020 via a reusable
+   rule→URL lookup.
+6. CLI: print `RelatedLocations` as trailer lines in
+   `check` / `fix`. Update surface tests.
+7. LSP: add `relatedInformation` and
+   `codeDescription` to the wire `Diagnostic`; map
+   them in `toLSP`, resolving cross-file URIs.
+8. Redesign `ruleHoverContent`
+   ([hover.go](../internal/lsp/hover.go)) to the
+   issue-first layout; expose `RuleInfo.Summary`.
+9. Thread `yaml.Node` lines for kind files and
+   `proto.md` into `Schema.FrontmatterLines`; add the
+   `.mdsmith.yml` path or the kind-line fallback.
+10. Update [plan 217](217_obsidian-plugin.md) to
+    require the issue-first tooltip and the
+    schema-location link.
+11. Document the new shape in the
+    [MDS020 README](../internal/rules/MDS020-required-structure/README.md)
+    and
+    [live-diagnostics](../docs/features/live-diagnostics.md).
+12. Run `mdsmith fix .` and confirm `check .` passes.
+
+## Acceptance Criteria
+
+- [ ] `lint.Diagnostic` carries `RelatedLocations` and
+      `DocURL`; old diagnostics serialize unchanged.
+- [ ] An MDS020 FM violation has a `RelatedLocation`
+      naming the schema file and line.
+- [ ] An inline-kind violation gets a real file/line
+      (or documented kind line), never the bare label.
+- [ ] A missing section anchors at the insertion
+      point, not file line 1.
+- [ ] A filename violation stays on line 1 but carries
+      a related location to `path-pattern:`.
+- [ ] `mdsmith check` prints the schema reference from
+      `RelatedLocations`, not the message body.
+- [ ] The LSP diagnostic includes
+      `relatedInformation` (cross-file URI) and
+      `codeDescription.href` for MDS020.
+- [ ] A VS Code hover shows the issue first, a
+      separator, then a one-line summary and a doc
+      link — not the full README.
+- [ ] [Plan 217](217_obsidian-plugin.md) requires the
+      issue-first tooltip and a navigable link.
+- [ ] The
+      [MDS020 README](../internal/rules/MDS020-required-structure/README.md)
+      documents the new shape.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues.
+- [ ] `mdsmith check .` passes.

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -208,7 +208,7 @@ the one new input to its signature.
 contract. Its tooltip adopts the issue-first layout
 and renders the schema location as a link, since
 CodeMirror has no native `relatedInformation`. The
-WASM payload carries `relatedLocations`
+WASM payload carries `related_locations`
 (`pkg/mdsmith.Diagnostic`); the rule-doc link is
 derived from the rule ID, not stored. This plan
 updates 217's text; the rendering stays there.

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -1,7 +1,7 @@
 ---
 id: 221
 title: Navigable schema diagnostics in the editor
-status: "🔲"
+status: "🔳"
 model: opus
 depends-on: [147, 133]
 summary: >-

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -179,11 +179,15 @@ Design rules:
    tooltip footer (Obsidian) and as native
    `relatedInformation` in VS Code.
 
-`cachedRuleInfo` already loads `RuleInfo`. Expose its
-`Summary` so the hover drops `info.Content` for the
-one-line form. Two calls to settle in code: whether to
-keep the plan-147 remediation line, and the `DocURL`
-scheme (a stable web route vs. a `command:` link).
+`cachedRuleInfo` already loads `RuleInfo`, which has a
+one-line `Description` from the README front matter
+(MDS020: "Document structure and front matter must
+match its schema"). The hover uses `Description`, not
+`info.Content`. Two calls to settle in code: whether
+to keep the plan-147 remediation line, and the
+`DocURL` scheme. `codeDescription.href` must be an
+`http(s)` URL; a `command:` link is valid only for the
+doc link inside the hover markdown.
 
 ### LSP wire and Obsidian
 
@@ -231,6 +235,9 @@ declaration's line — still navigable.
    diagnostic in
    [validate.go](../internal/schema/validate.go) and
    [the rule](../internal/rules/requiredstructure/rule.go).
+   Callers mutate the `Diagnostic` that `MakeDiag`
+   returns, so its `(file, line, msg)` signature stays
+   unchanged across its ~30 call sites.
 4. Add the insertion-point helper; re-anchor missing
    section and missing content off line 1. Unit-test
    each anchor.
@@ -243,7 +250,8 @@ declaration's line — still navigable.
    them in `toLSP`, resolving cross-file URIs.
 8. Redesign `ruleHoverContent`
    ([hover.go](../internal/lsp/hover.go)) to the
-   issue-first layout; expose `RuleInfo.Summary`.
+   issue-first layout, using `RuleInfo.Description`
+   for the one-line rule summary.
 9. Thread `yaml.Node` lines for kind files and
    `proto.md` into `Schema.FrontmatterLines`; add the
    `.mdsmith.yml` path or the kind-line fallback.

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -1,7 +1,7 @@
 ---
 id: 221
 title: Navigable schema diagnostics in the editor
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: [147, 133]
 summary: >-
@@ -143,16 +143,14 @@ consumers:
 
 Every schema diagnostic gets the best anchor in the
 linted file, plus a related location to the schema
-rule. FM-field anchoring and the related locations
-shipped. Re-anchoring the *absence* cases (missing
-section, missing content) is deferred.
-`nonBodyDiagLine` returns a non-positive coordinate
-on purpose, so
+rule. A missing section anchors at the heading it
+should follow, via `MissingSectionAnchor`, not at the
+top of the file. The guard stays intact. When the
+insertion point sits inside a generated section, or
+there is no preceding heading, the anchor falls back
+to the non-positive `nonBodyDiagLine` value. That way
 [`filterGeneratedDiags`](../internal/engine/check.go)
-never drops a missing-section diagnostic. A body
-anchor would bring that drop risk back. The related
-location already reaches the constraint, so the
-re-anchor is a follow-up.
+can never drop a missing-section diagnostic.
 
 ### Issue-first hover
 
@@ -243,9 +241,10 @@ declaration's line — still navigable.
    Callers mutate the `Diagnostic` that `MakeDiag`
    returns, so its `(file, line, msg)` signature stays
    unchanged across its ~30 call sites.
-4. (Follow-up) Re-anchor missing section / content
-   off line 1. Deferred to keep the
-   `filterGeneratedDiags` guarantee (see Design).
+4. Re-anchor a missing section at the preceding
+   heading (`MissingSectionAnchor`), guarded so an
+   insertion point inside a generated section falls
+   back to the non-body anchor.
 5. Add `rules.DocURL` (a reusable rule-ID → doc-page
    URL lookup) and derive `codeDescription` from it in
    `toLSP`. No `DocURL` field on the diagnostic.
@@ -258,11 +257,11 @@ declaration's line — still navigable.
    ([hover.go](../internal/lsp/hover.go)) to the
    issue-first layout, using `RuleInfo.Description`
    for the one-line rule summary.
-9. (Follow-up) Thread `yaml.Node` lines for inline
-   kind / `.mdsmith.yml` schemas into
-   `Schema.FrontmatterLines`. File schemas (`proto.md`)
-   already resolve to a line; inline schemas still show
-   the `inline kind schema` label.
+9. Thread the kind's `SourcePath` onto the inline
+   schema-sources entry in the merge layer so an inline
+   kind schema names its defining file, not the bare
+   `inline kind schema` label. (Per-key `yaml.Node`
+   line numbers within that file remain a follow-up.)
 10. Update [plan 217](217_obsidian-plugin.md) to
     require the issue-first tooltip and the
     schema-location link.
@@ -280,15 +279,12 @@ declaration's line — still navigable.
       surface, not stored on the diagnostic.
 - [x] An MDS020 FM violation has a `RelatedLocation`
       naming the schema file and line.
-- [ ] An inline-kind violation gets a real file/line
-      (or documented kind line), never the bare label.
-      Follow-up: inline schemas still show the
-      `inline kind schema` label (needs config-loader
-      per-key position tracking).
-- [ ] A missing section anchors at the insertion
-      point, not file line 1. Follow-up: deferred to
-      preserve the `filterGeneratedDiags` guarantee
-      (see Design).
+- [x] An inline-kind violation names the kind's
+      defining file, not the bare label. (Per-key line
+      numbers within that file stay a follow-up.)
+- [x] A missing section anchors at the preceding
+      heading, not file line 1, while keeping the
+      `filterGeneratedDiags` guarantee (see Design).
 - [x] A filename violation stays on line 1 but carries
       a related location to `path-pattern:`.
 - [x] `mdsmith check` prints the schema reference from

--- a/plan/221_navigable-schema-diagnostics.md
+++ b/plan/221_navigable-schema-diagnostics.md
@@ -143,11 +143,16 @@ consumers:
 
 Every schema diagnostic gets the best anchor in the
 linted file, plus a related location to the schema
-rule. Absence cases move off line 1 where a
-meaningful insertion point exists. A new helper in
-[validate.go](../internal/schema/validate.go) derives
-the insertion line from the scope tree's matched
-siblings.
+rule. FM-field anchoring and the related locations
+shipped. Re-anchoring the *absence* cases (missing
+section, missing content) is deferred.
+`nonBodyDiagLine` returns a non-positive coordinate
+on purpose, so
+[`filterGeneratedDiags`](../internal/engine/check.go)
+never drops a missing-section diagnostic. A body
+anchor would bring that drop risk back. The related
+location already reaches the constraint, so the
+re-anchor is a follow-up.
 
 ### Issue-first hover
 
@@ -238,9 +243,9 @@ declaration's line — still navigable.
    Callers mutate the `Diagnostic` that `MakeDiag`
    returns, so its `(file, line, msg)` signature stays
    unchanged across its ~30 call sites.
-4. Add the insertion-point helper; re-anchor missing
-   section and missing content off line 1. Unit-test
-   each anchor.
+4. (Follow-up) Re-anchor missing section / content
+   off line 1. Deferred to keep the
+   `filterGeneratedDiags` guarantee (see Design).
 5. Populate `DocURL` for MDS020 via a reusable
    rule→URL lookup.
 6. CLI: print `RelatedLocations` as trailer lines in
@@ -252,9 +257,11 @@ declaration's line — still navigable.
    ([hover.go](../internal/lsp/hover.go)) to the
    issue-first layout, using `RuleInfo.Description`
    for the one-line rule summary.
-9. Thread `yaml.Node` lines for kind files and
-   `proto.md` into `Schema.FrontmatterLines`; add the
-   `.mdsmith.yml` path or the kind-line fallback.
+9. (Follow-up) Thread `yaml.Node` lines for inline
+   kind / `.mdsmith.yml` schemas into
+   `Schema.FrontmatterLines`. File schemas (`proto.md`)
+   already resolve to a line; inline schemas still show
+   the `inline kind schema` label.
 10. Update [plan 217](217_obsidian-plugin.md) to
     require the issue-first tooltip and the
     schema-location link.
@@ -266,29 +273,34 @@ declaration's line — still navigable.
 
 ## Acceptance Criteria
 
-- [ ] `lint.Diagnostic` carries `RelatedLocations` and
+- [x] `lint.Diagnostic` carries `RelatedLocations` and
       `DocURL`; old diagnostics serialize unchanged.
-- [ ] An MDS020 FM violation has a `RelatedLocation`
+- [x] An MDS020 FM violation has a `RelatedLocation`
       naming the schema file and line.
 - [ ] An inline-kind violation gets a real file/line
       (or documented kind line), never the bare label.
+      Follow-up: inline schemas still show the
+      `inline kind schema` label (needs config-loader
+      per-key position tracking).
 - [ ] A missing section anchors at the insertion
-      point, not file line 1.
-- [ ] A filename violation stays on line 1 but carries
+      point, not file line 1. Follow-up: deferred to
+      preserve the `filterGeneratedDiags` guarantee
+      (see Design).
+- [x] A filename violation stays on line 1 but carries
       a related location to `path-pattern:`.
-- [ ] `mdsmith check` prints the schema reference from
+- [x] `mdsmith check` prints the schema reference from
       `RelatedLocations`, not the message body.
-- [ ] The LSP diagnostic includes
+- [x] The LSP diagnostic includes
       `relatedInformation` (cross-file URI) and
       `codeDescription.href` for MDS020.
-- [ ] A VS Code hover shows the issue first, a
+- [x] A VS Code hover shows the issue first, a
       separator, then a one-line summary and a doc
       link — not the full README.
-- [ ] [Plan 217](217_obsidian-plugin.md) requires the
+- [x] [Plan 217](217_obsidian-plugin.md) requires the
       issue-first tooltip and a navigable link.
-- [ ] The
+- [x] The
       [MDS020 README](../internal/rules/MDS020-required-structure/README.md)
       documents the new shape.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues.
-- [ ] `mdsmith check .` passes.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues.
+- [x] `mdsmith check .` passes.

--- a/plan/230_navigable-schema-diagnostics.md
+++ b/plan/230_navigable-schema-diagnostics.md
@@ -269,7 +269,13 @@ declaration's line — still navigable.
     [MDS020 README](../internal/rules/MDS020-required-structure/README.md)
     and
     [live-diagnostics](../docs/features/live-diagnostics.md).
-12. Run `mdsmith fix .` and confirm `check .` passes.
+12. VS Code: rewrite the hover's `rules.DocURL`
+    website link to a `command:` link that opens the
+    rule's embedded README offline in a `mdsmith-rule:`
+    virtual document, backed by `mdsmith help rule`.
+    The server keeps emitting the https link so other
+    editors are unaffected.
+13. Run `mdsmith fix .` and confirm `check .` passes.
 
 ## Acceptance Criteria
 
@@ -295,6 +301,10 @@ declaration's line — still navigable.
 - [x] A VS Code hover shows the issue first, a
       separator, then a one-line summary and a doc
       link — not the full README.
+- [x] The VS Code hover's doc link opens the rule's
+      embedded README offline (a `mdsmith-rule:`
+      virtual doc via `mdsmith help rule`), not the
+      website — preserving the offline guarantee.
 - [x] [Plan 217](217_obsidian-plugin.md) requires the
       issue-first tooltip and a navigable link.
 - [x] The

--- a/plan/230_navigable-schema-diagnostics.md
+++ b/plan/230_navigable-schema-diagnostics.md
@@ -1,5 +1,5 @@
 ---
-id: 221
+id: 230
 title: Navigable schema diagnostics in the editor
 status: "✅"
 model: opus


### PR DESCRIPTION
## What

Implements **plan 230 — navigable schema diagnostics** end-to-end. Plan status: ✅ (all acceptance criteria met).

> Renumbered 221 → 230 after rebasing onto main, whose merged Flatpak plan already claims id 221.

### Plan
- `plan/230_navigable-schema-diagnostics.md` (✅) + `PLAN.md` catalog row.

### Implementation
- **`lint.Diagnostic`**: new `RelatedLocation` type plus a `RelatedLocations` field (zero-valued on existing diagnostics). The rule-doc link is derived from the rule ID at the LSP surface (`rules.DocURL`), not stored on the diagnostic.
- **Schema (MDS020)**: `SchemaDiagnostic.Format()` no longer appends a `schema:` message trailer; `SchemaDiagnostic.Emit()` attaches the reference as a structured `RelatedLocation` (file+line for proto.md/kind-file schemas, the kind's defining file for inline kinds). Every emit site — including `mdsmith extract` — routes through `Emit`.
- **Body anchoring**: a missing required section now anchors at the heading it should follow (`MissingSectionAnchor`), not file line 1, while preserving the guarantee that `filterGeneratedDiags` can never drop a missing-section diagnostic — when the insertion point sits inside a generated section it falls back to the first body line outside every generated range, or to the non-body anchor.
- **Inline kind schemas**: the merge layer threads the kind's `SourcePath` onto the schema-sources entry, so an inline-kind violation's related location names that file instead of the bare `inline kind schema` label.
- **CLI**: text output prints a `↳ file:line — message` trailer; JSON and the public `pkg/mdsmith` API gain `related_locations`. User-facing line numbers are clamped to ≥ 1 (the body-anchor sentinel can be non-positive internally so it survives generated-section filtering).
- **LSP**: wire `Diagnostic` gains `relatedInformation` and `codeDescription` (derived from the rule ID). Cross-file URIs resolve against the workspace root behind a symlink-safe, within-root containment guard (cross-platform absolute-path classification; a related location is dropped unless a bounded root is known).
- **Hover**: redesigned issue-first — the diagnostic and a navigable related link (with its own message) lead, then a separator, then a condensed rule identity (code, one-line description, docs link).
- **VS Code — offline rule docs**: a LanguageClient hover middleware rewrites the server's `rules.DocURL` website link into a `command:mdsmith.openRuleDoc` link that opens the rule's embedded README (via `mdsmith help rule`) in a read-only `mdsmith-rule:` virtual document — mirroring the existing `mdsmith-kinds:` provider, so rule docs open offline with no browser or network. The markdown trusts only that one command; the rule ID is validated against `MDS\d+` before it reaches the binary. The LSP server still emits the https link, so editors without the extension are unaffected (their offline route stays `mdsmith help rule`).
- **`rules.DocURL`**: reusable rule-ID → canonical website doc-page URL, guarded by a dir==`-` slug-invariant test.
- Fixtures, integration runner (`related:` assertions), and engine/LSP/schema/output/config tests updated.

## Remaining follow-up (out of scope for 230)
- Per-key `yaml.Node` line numbers *within* an inline `.mdsmith.yml` / kind file (the reference resolves to the file today; a specific line is a future refinement).
- The Problems-panel `codeDescription` link still opens the website (VS Code opens that href externally and it cannot be a `command:` URI); the offline route there is the hover link or `mdsmith help rule`.

## Validation
- Go: `go test ./...`, `go vet ./...`, `go tool golangci-lint run` (0 issues), and `mdsmith check .` (392 files) all pass.
- Extension: `bunx tsc --noEmit` clean and `bun test` (136 pass, incl. 20 new rule-doc tests).

https://claude.ai/code/session_012VUZRtcCJYbxZdSCMHivf9