### PR TITLE
Plan 220: Harden the git-index writers against a transient index.lock

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -149,5 +149,5 @@ footer: |
 | 218 | 🔲     | opus   | [WASM size reduction — CUE-free engine path and tinygo support](plan/218_wasm-size-reduction.md)                                        |
 | 219 | 🔲     | opus   | [Multiplexed AST walk to close the parity gap to mado](plan/219_multiplexed-ast-walk.md)                                                |
 | 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
-| 220 | 🔲     | opus   | [Make the pre-merge-commit hook the single git-index writer](plan/220_git-index-lock-retry.md)                                          |
+| 220 | 🔳     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -149,5 +149,5 @@ footer: |
 | 218 | 🔲     | opus   | [WASM size reduction — CUE-free engine path and tinygo support](plan/218_wasm-size-reduction.md)                                        |
 | 219 | 🔲     | opus   | [Multiplexed AST walk to close the parity gap to mado](plan/219_multiplexed-ast-walk.md)                                                |
 | 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
-| 220 | 🔳     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
+| 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 <?/catalog?>

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1699,6 +1699,131 @@ func TestE2E_MergeDriver_FileOrderingRace_Resolved(t *testing.T) {
 		"check after merge must pass; stderr:\n%s", stderr)
 }
 
+// TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth exercises the
+// invocation model the merge queue uses: `git merge --no-ff
+// --no-commit`, then the pre-merge-commit hook, then a separate `git
+// commit`. It is the plan-220 integration acceptance criterion.
+//
+// The repo carries a deliberately stale .gitattributes managed block
+// (missing the canonical *.markdown include) and a PLAN.md whose
+// catalog has not yet been regenerated for a newly merged plan file.
+// The hook's single `mdsmith fix .` then has real work on two fronts:
+// MDS048 rewrites .gitattributes and stages it (its in-process staging
+// is kept, not dropped), and the catalog rule regenerates PLAN.md
+// (staged by the hook's own hardened staging loop). The resulting
+// merge commit must capture both, and the worktree must be clean.
+//
+// The branches are arranged so the merge has no PLAN.md/.gitattributes
+// conflict: `theirs` adds plan/02.md without regenerating PLAN.md, and
+// `ours` touches only an unrelated file. That keeps the per-file merge
+// driver from pre-regenerating .gitattributes in the worktree, so the
+// stale managed block survives to hook time and MDS048 has a genuine
+// correction to stage — the realistic shape of the queue bug.
+func TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n  git-hook-sync: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+
+	// Install the merge driver + hook (this canonicalises .gitattributes
+	// in the working tree), then seed the catalog body so PLAN.md is
+	// clean for plan 1.
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+
+	// Commit a deliberately stale managed block (drop the *.markdown
+	// include) directly via git, with no later `mdsmith fix` to
+	// re-canonicalise it, so the stale block is what every branch
+	// inherits and what reaches the merge.
+	staleAttrs := "# BEGIN mdsmith merge-driver\n" +
+		"*.md merge=mdsmith\n" +
+		"# END mdsmith merge-driver\n"
+	writeFixture(t, dir, ".gitattributes", staleAttrs)
+	gitCommit(t, dir, "seed (stale .gitattributes)")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// theirs: add plan/02.md but leave PLAN.md's catalog stale, so the
+	// merge does not touch PLAN.md (no conflict, no driver run) yet the
+	// post-merge catalog is out of date — work for the hook's fix.
+	gitInDir(t, dir, "checkout", "-q", "-b", "theirs", seedSHA)
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
+	gitInDir(t, dir, "add", "plan/02.md")
+	gitInDir(t, dir, "-c", "commit.gpgsign=false", "commit", "-q", "-m",
+		"add plan 2 (catalog intentionally not regenerated)")
+
+	// ours: an unrelated change so the merge is a real --no-ff merge
+	// with no overlap on PLAN.md or .gitattributes.
+	gitInDir(t, dir, "checkout", "-q", "-b", "ours", seedSHA)
+	writeFixture(t, dir, "NOTES.txt", "note\n")
+	gitInDir(t, dir, "add", "NOTES.txt")
+	gitInDir(t, dir, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "ours note")
+
+	// Step 1: `git merge --no-ff --no-commit`, leaving the commit
+	// uncreated, exactly as the merge-queue action does.
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-ff", "--no-commit", "theirs").CombinedOutput()
+	// A clean --no-commit merge exits non-zero ("stopped before
+	// committing as requested"); only a real conflict is a failure.
+	if err != nil {
+		require.NotContains(t, string(out), "CONFLICT",
+			"merge must apply cleanly with no conflict: %s", out)
+	}
+
+	// Precondition: the stale block survived to hook time (the driver
+	// did not pre-regenerate it), so MDS048 has a real correction.
+	preHookAttrs, readErr := os.ReadFile(filepath.Join(dir, ".gitattributes"))
+	require.NoError(t, readErr)
+	require.NotContains(t, string(preHookAttrs), "*.markdown merge=mdsmith",
+		"the stale .gitattributes must survive to hook time for this test "+
+			"to exercise MDS048's regeneration; got:\n%s", preHookAttrs)
+
+	// Step 2: run the installed hook, exactly as the action does.
+	hookPath := filepath.Join(gitHooksDir(t, dir), "pre-merge-commit")
+	hookCmd := exec.Command(hookPath)
+	hookCmd.Dir = dir
+	hookOut, hookErr := hookCmd.CombinedOutput()
+	require.NoErrorf(t, hookErr, "pre-merge-commit hook failed: %s", hookOut)
+
+	// Step 3: create the merge commit.
+	out, err = exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"commit", "--no-edit").CombinedOutput()
+	require.NoErrorf(t, err, "git commit (merge) failed: %s", out)
+
+	// The merge commit's tree must contain both the regenerated
+	// .gitattributes (now including the previously missing *.markdown
+	// line, staged by MDS048) and the regenerated PLAN.md catalog (now
+	// listing plan 2, staged by the hook's staging loop).
+	committedAttrs := gitInDir(t, dir, "show", "HEAD:.gitattributes")
+	assert.Contains(t, committedAttrs, "*.markdown merge=mdsmith",
+		"merge commit must capture the regenerated .gitattributes "+
+			"(the *.markdown include MDS048 added); got:\n%s",
+		committedAttrs)
+
+	committedPlan := gitInDir(t, dir, "show", "HEAD:PLAN.md")
+	assert.Regexp(t, `\| 1 +\|`, committedPlan,
+		"merge commit's PLAN.md must list plan 1; got:\n%s", committedPlan)
+	assert.Regexp(t, `\| 2 +\|`, committedPlan,
+		"merge commit's PLAN.md must list the merged plan 2 (catalog "+
+			"regenerated by the hook); got:\n%s", committedPlan)
+
+	// The worktree must be clean: every regenerated file the hook
+	// touched is committed, nothing left modified or untracked.
+	status := gitInDir(t, dir, "status", "--porcelain")
+	assert.Empty(t, strings.TrimSpace(status),
+		"worktree must be clean after the hook+commit flow; git status:\n%s", status)
+}
+
 // gitInit initializes a git repo with isolated user/sign config so
 // commits succeed on machines that have global signing turned on.
 func gitInit(t *testing.T, dir string) {

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1818,6 +1818,7 @@ func TestE2E_PreMergeCommit_ConflictingMergeResolvesWithHookSync(t *testing.T) {
 // driver from pre-regenerating .gitattributes in the worktree, so the
 // stale managed block survives to hook time and MDS048 has a genuine
 // correction to stage — the realistic shape of the queue bug.
+
 // setupNoConflictMergeRepo builds the repo and two branches for
 // TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth: the merge driver
 // and hook are installed, a deliberately stale .gitattributes managed
@@ -1922,6 +1923,12 @@ func TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth(t *testing.T) {
 	status := gitInDir(t, dir, "status", "--porcelain")
 	assert.Empty(t, strings.TrimSpace(status),
 		"worktree must be clean after the hook+commit flow; git status:\n%s", status)
+
+	// A fresh check must pass — catches a structurally broken PLAN.md
+	// (malformed table, leftover markers) that the catalog-row regexps
+	// above would miss on a clean-but-wrong tree.
+	_, checkStderr, checkCode := runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, checkCode, "check after merge must pass; stderr:\n%s", checkStderr)
 }
 
 // gitInit initializes a git repo with isolated user/sign config so

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1758,12 +1758,12 @@ func TestE2E_PreMergeCommit_ConflictingMergeResolvesWithHookSync(t *testing.T) {
 	mergeOut, mergeErr := exec.Command("git", "-C", dir,
 		"-c", "commit.gpgsign=false",
 		"merge", "--no-ff", "--no-commit", "theirs").CombinedOutput()
-	// A driver-resolved --no-commit merge leaves no CONFLICT markers.
-	if mergeErr != nil {
-		require.NotContains(t, string(mergeOut), "CONFLICT",
-			"the merge driver must resolve the PLAN.md catalog conflict; got:\n%s",
-			mergeOut)
-	}
+	// `git merge --no-commit` exits non-zero by design, and some git
+	// versions print "CONFLICT" even when a merge driver resolves the
+	// file — so assert resolution directly: no unmerged index paths.
+	require.Empty(t, strings.TrimSpace(gitInDir(t, dir, "ls-files", "-u")),
+		"merge driver must leave no unmerged paths (conflict resolved); "+
+			"merge exit=%v output:\n%s", mergeErr, mergeOut)
 
 	hook := exec.Command(filepath.Join(gitHooksDir(t, dir), "pre-merge-commit"))
 	hook.Dir = dir

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1719,10 +1719,15 @@ func TestE2E_MergeDriver_FileOrderingRace_Resolved(t *testing.T) {
 // driver from pre-regenerating .gitattributes in the worktree, so the
 // stale managed block survives to hook time and MDS048 has a genuine
 // correction to stage — the realistic shape of the queue bug.
-func TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
+// setupNoConflictMergeRepo builds the repo and two branches for
+// TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth: the merge driver
+// and hook are installed, a deliberately stale .gitattributes managed
+// block (missing *.markdown) is committed directly via git so no later
+// `mdsmith fix` re-canonicalises it, `theirs` adds plan/02.md without
+// regenerating PLAN.md, and `ours` makes an unrelated change. ours is
+// left checked out, ready to merge theirs.
+func setupNoConflictMergeRepo(t *testing.T) string {
+	t.Helper()
 	dir := t.TempDir()
 	gitInit(t, dir)
 
@@ -1732,18 +1737,11 @@ func TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth(t *testing.T) {
 	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
 	writeFixture(t, dir, "PLAN.md", planMdTmpl)
 
-	// Install the merge driver + hook (this canonicalises .gitattributes
-	// in the working tree), then seed the catalog body so PLAN.md is
-	// clean for plan 1.
 	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
 	require.Equal(t, 0, code, "install failed: %s", stderr)
 	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "PLAN.md")
 	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
 
-	// Commit a deliberately stale managed block (drop the *.markdown
-	// include) directly via git, with no later `mdsmith fix` to
-	// re-canonicalise it, so the stale block is what every branch
-	// inherits and what reaches the merge.
 	staleAttrs := "# BEGIN mdsmith merge-driver\n" +
 		"*.md merge=mdsmith\n" +
 		"# END mdsmith merge-driver\n"
@@ -1751,21 +1749,24 @@ func TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth(t *testing.T) {
 	gitCommit(t, dir, "seed (stale .gitattributes)")
 	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
 
-	// theirs: add plan/02.md but leave PLAN.md's catalog stale, so the
-	// merge does not touch PLAN.md (no conflict, no driver run) yet the
-	// post-merge catalog is out of date — work for the hook's fix.
 	gitInDir(t, dir, "checkout", "-q", "-b", "theirs", seedSHA)
 	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
 	gitInDir(t, dir, "add", "plan/02.md")
 	gitInDir(t, dir, "-c", "commit.gpgsign=false", "commit", "-q", "-m",
 		"add plan 2 (catalog intentionally not regenerated)")
 
-	// ours: an unrelated change so the merge is a real --no-ff merge
-	// with no overlap on PLAN.md or .gitattributes.
 	gitInDir(t, dir, "checkout", "-q", "-b", "ours", seedSHA)
 	writeFixture(t, dir, "NOTES.txt", "note\n")
 	gitInDir(t, dir, "add", "NOTES.txt")
 	gitInDir(t, dir, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "ours note")
+	return dir
+}
+
+func TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := setupNoConflictMergeRepo(t)
 
 	// Step 1: `git merge --no-ff --no-commit`, leaving the commit
 	// uncreated, exactly as the merge-queue action does.

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1699,6 +1699,105 @@ func TestE2E_MergeDriver_FileOrderingRace_Resolved(t *testing.T) {
 		"check after merge must pass; stderr:\n%s", stderr)
 }
 
+// setupConflictingMergeRepo builds a repo whose `ours` and `theirs`
+// branches both regenerate PLAN.md's catalog (ours adds plan 02,
+// theirs adds plan 03), so merging conflicts inside the generated
+// section and the mdsmith merge driver runs. git-hook-sync is
+// enabled and the merge driver + hook are installed; ours is left
+// checked out, ready to merge theirs.
+func setupConflictingMergeRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n  git-hook-sync: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// ours adds plan 02, theirs adds plan 03: both rewrite PLAN.md's
+	// catalog body, so merging conflicts inside the generated section.
+	completePlanOnBranch(t, dir, "ours", seedSHA, 2)
+	completePlanOnBranch(t, dir, "theirs", seedSHA, 3)
+	gitInDir(t, dir, "checkout", "ours")
+	return dir
+}
+
+// TestE2E_PreMergeCommit_ConflictingMergeResolvesWithHookSync runs the
+// merge-queue model (`git merge --no-ff --no-commit`, then the
+// pre-merge-commit hook, then `git commit`) on a *conflicting* merge of
+// a driver-managed generated file, with git-hook-sync (MDS048) enabled
+// — the shape of the failing queue run.
+//
+// ours adds plan 02 and theirs adds plan 03, so both rewrite PLAN.md's
+// generated catalog and `git merge` invokes the mdsmith merge driver on
+// PLAN.md while git holds .git/index.lock. The driver must resolve the
+// conflict (regenerate the catalog from every plan file) WITHOUT running
+// MDS048's in-process `git add` — that add would race the merge for the
+// lock. MDS048 still runs in the hook afterward, when git no longer
+// holds the lock.
+//
+// This guards the concern that dropping MDS048 from the merge driver
+// could leave the conflict unresolved: it asserts the catalog resolves
+// to list every plan, the merge commits cleanly, .gitattributes
+// survives, the worktree is clean, and no stale .git/index.lock remains.
+func TestE2E_PreMergeCommit_ConflictingMergeResolvesWithHookSync(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := setupConflictingMergeRepo(t)
+
+	mergeOut, mergeErr := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-ff", "--no-commit", "theirs").CombinedOutput()
+	// A driver-resolved --no-commit merge leaves no CONFLICT markers.
+	if mergeErr != nil {
+		require.NotContains(t, string(mergeOut), "CONFLICT",
+			"the merge driver must resolve the PLAN.md catalog conflict; got:\n%s",
+			mergeOut)
+	}
+
+	hook := exec.Command(filepath.Join(gitHooksDir(t, dir), "pre-merge-commit"))
+	hook.Dir = dir
+	hookOut, hookErr := hook.CombinedOutput()
+	require.NoErrorf(t, hookErr, "pre-merge-commit hook failed: %s", hookOut)
+
+	commitOut, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"commit", "--no-edit").CombinedOutput()
+	require.NoErrorf(t, err, "git commit (merge) failed: %s", commitOut)
+
+	// Conflict resolved: the committed catalog lists all three plans.
+	committedPlan := gitInDir(t, dir, "show", "HEAD:PLAN.md")
+	for _, id := range []string{"1", "2", "3"} {
+		assert.Regexp(t, `\| `+id+` +\|`, committedPlan,
+			"merged PLAN.md catalog must list plan %s; got:\n%s", id, committedPlan)
+	}
+	assert.NotContains(t, committedPlan, "<<<<<<<",
+		"no conflict markers may survive into the merge commit")
+
+	// .gitattributes survived, no stale lock, clean worktree.
+	committedAttrs := gitInDir(t, dir, "show", "HEAD:.gitattributes")
+	assert.Contains(t, committedAttrs, "merge=mdsmith",
+		"merge commit must keep the managed .gitattributes")
+	assert.NoFileExists(t, filepath.Join(dir, ".git", "index.lock"),
+		"no stale .git/index.lock may remain after the merge")
+	status := strings.TrimSpace(gitInDir(t, dir, "status", "--porcelain"))
+	assert.Empty(t, status,
+		"worktree must be clean after the merge commit; got:\n%s", status)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code, "check after merge must pass; stderr:\n%s", stderr)
+}
+
 // TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth exercises the
 // invocation model the merge queue uses: `git merge --no-ff
 // --no-commit`, then the pre-merge-commit hook, then a separate `git

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -328,6 +328,37 @@ func readAndRestore(pathname string, backup []byte, backupErr error, mode os.Fil
 	return fixed, 0
 }
 
+// gitHookSyncRuleID is MDS048 (git-hook-sync), the only rule whose
+// Fix mutates the git index — it stages .gitattributes via an
+// in-process `git add`. See mergeDriverRules.
+const gitHookSyncRuleID = "MDS048"
+
+// mergeDriverRules is the fix rule set the merge driver runs: every
+// registered rule except the git-index-mutating git-hook-sync rule
+// (MDS048).
+//
+// git invokes the merge driver from inside `git merge`, which holds
+// `.git/index.lock` for the whole merge. MDS048's Fix runs an
+// in-process `git add -- .gitattributes` (githooks.StageGitattributes);
+// executed here it is a second index writer racing the parent
+// `git merge` for that lock, which can leave a stale `.git/index.lock`
+// that fails the staging step and bounces the merge queue. The merge
+// driver only needs the content-regenerating rules to resolve a
+// conflict, so the index-mutating rule is dropped; the
+// pre-merge-commit hook still runs MDS048 afterward, when git no
+// longer holds the lock.
+func mergeDriverRules() []rule.Rule {
+	all := rule.All()
+	out := make([]rule.Rule, 0, len(all))
+	for _, r := range all {
+		if r.ID() == gitHookSyncRuleID {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
 // fixFileInPlace runs the mdsmith fix pipeline on a single file.
 func fixFileInPlace(path string, maxBytes int64) error {
 	cfg, _, err := loadConfig("")
@@ -337,7 +368,7 @@ func fixFileInPlace(path string, maxBytes int64) error {
 
 	fixer := &fixpkg.Fixer{
 		Config:           cfg,
-		Rules:            rule.All(),
+		Rules:            mergeDriverRules(),
 		StripFrontMatter: frontMatterEnabled(cfg),
 		Logger:           &vlog.Logger{},
 		MaxInputBytes:    maxBytes,

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -328,30 +328,27 @@ func readAndRestore(pathname string, backup []byte, backupErr error, mode os.Fil
 	return fixed, 0
 }
 
-// gitHookSyncRuleID is MDS048 (git-hook-sync), the only rule whose
-// Fix mutates the git index — it stages .gitattributes via an
-// in-process `git add`. See mergeDriverRules.
-const gitHookSyncRuleID = "MDS048"
-
 // mergeDriverRules is the fix rule set the merge driver runs: every
-// registered rule except the git-index-mutating git-hook-sync rule
-// (MDS048).
+// registered rule except those that mutate the git index (rules
+// implementing rule.GitIndexMutator — today only MDS048,
+// git-hook-sync).
 //
 // git invokes the merge driver from inside `git merge`, which holds
-// `.git/index.lock` for the whole merge. MDS048's Fix runs an
-// in-process `git add -- .gitattributes` (githooks.StageGitattributes);
-// executed here it is a second index writer racing the parent
-// `git merge` for that lock, which can leave a stale `.git/index.lock`
-// that fails the staging step and bounces the merge queue. The merge
-// driver only needs the content-regenerating rules to resolve a
-// conflict, so the index-mutating rule is dropped; the
-// pre-merge-commit hook still runs MDS048 afterward, when git no
-// longer holds the lock.
+// `.git/index.lock` for the whole merge. A rule whose Fix runs an
+// in-process `git add` (e.g. githooks.StageGitattributes) would be a
+// second index writer racing the parent `git merge` for that lock,
+// which can leave a stale `.git/index.lock` that fails the staging
+// step and bounces the merge queue. The merge driver only needs the
+// content-regenerating rules to resolve a conflict, so index-mutating
+// rules are dropped; the pre-merge-commit hook still runs them
+// afterward, when git no longer holds the lock. Filtering by the
+// capability interface (not a rule ID) excludes any future
+// index-mutating rule automatically.
 func mergeDriverRules() []rule.Rule {
 	all := rule.All()
 	out := make([]rule.Rule, 0, len(all))
 	for _, r := range all {
-		if r.ID() == gitHookSyncRuleID {
+		if m, ok := r.(rule.GitIndexMutator); ok && m.MutatesGitIndex() {
 			continue
 		}
 		out = append(out, r)

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -10,9 +10,27 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/githooks"
+	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMergeDriverRules_ExcludesGitHookSync(t *testing.T) {
+	// Precondition: MDS048 (git-hook-sync) is registered, so excluding
+	// it is meaningful rather than a silent no-op.
+	require.NotNil(t, rule.ByID("MDS048"),
+		"precondition: MDS048 must be registered")
+
+	rules := mergeDriverRules()
+	for _, r := range rules {
+		assert.NotEqual(t, "MDS048", r.ID(),
+			"the merge driver runs inside `git merge` (which holds "+
+				".git/index.lock); MDS048's Fix does an in-process `git add` "+
+				"that races it, so the merge driver must not run MDS048")
+	}
+	assert.Len(t, rules, len(rule.All())-1,
+		"mergeDriverRules must drop exactly the git-hook-sync rule")
+}
 
 func TestStripSectionConflicts_Diff3CatalogConflict(t *testing.T) {
 	// diff3-style conflict markers include a ||||||| base section

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -15,21 +15,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMergeDriverRules_ExcludesGitHookSync(t *testing.T) {
-	// Precondition: MDS048 (git-hook-sync) is registered, so excluding
-	// it is meaningful rather than a silent no-op.
-	require.NotNil(t, rule.ByID("MDS048"),
-		"precondition: MDS048 must be registered")
+func TestMergeDriverRules_ExcludesGitIndexMutators(t *testing.T) {
+	// Precondition: MDS048 (git-hook-sync) is a registered git-index
+	// mutator, so the exclusion is meaningful rather than a no-op.
+	mds048 := rule.ByID("MDS048")
+	require.NotNil(t, mds048, "precondition: MDS048 must be registered")
+	m, ok := mds048.(rule.GitIndexMutator)
+	require.True(t, ok && m.MutatesGitIndex(),
+		"precondition: MDS048 must declare rule.GitIndexMutator")
 
 	rules := mergeDriverRules()
 	for _, r := range rules {
-		assert.NotEqual(t, "MDS048", r.ID(),
+		gm, ok := r.(rule.GitIndexMutator)
+		assert.False(t, ok && gm.MutatesGitIndex(),
 			"the merge driver runs inside `git merge` (which holds "+
-				".git/index.lock); MDS048's Fix does an in-process `git add` "+
-				"that races it, so the merge driver must not run MDS048")
+				".git/index.lock); it must exclude every git-index-mutating "+
+				"rule, but %s remained", r.ID())
 	}
-	assert.Len(t, rules, len(rule.All())-1,
-		"mergeDriverRules must drop exactly the git-hook-sync rule")
+	assert.NotEmpty(t, rules,
+		"mergeDriverRules must still run the content-regenerating rules")
 }
 
 func TestStripSectionConflicts_Diff3CatalogConflict(t *testing.T) {

--- a/docs/reference/cli/pre-merge-commit.md
+++ b/docs/reference/cli/pre-merge-commit.md
@@ -11,6 +11,15 @@ Manage a Git `pre-merge-commit` hook that runs
 commit is created. Modified `.md` / `.markdown` files are
 re-staged automatically.
 
+A concurrent git process can briefly hold
+`.git/index.lock`. When `git add` fails for that reason,
+the hook retries with a bounded backoff. A transient
+lock no longer aborts the merge. The hook never deletes
+a lock it did not create. If the lock outlasts the
+retries, the hook prints `index locked` and exits
+non-zero, so the merge stops instead of committing a
+partially staged tree.
+
 ```text
 mdsmith pre-merge-commit <subcommand> [args]
 ```

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -965,6 +965,41 @@ func HasMdsmithMergeDriver(repoRoot string) bool {
 	return strings.TrimSpace(string(out)) != ""
 }
 
+// stagingHelperShellFunc is the POSIX `mdsmith_git_add` function the
+// hook uses to stage one path with index.lock-aware retry. It is kept
+// as a package-level constant so BuildHookScript stays short and so
+// the retry policy lives in one readable block. The function backs off
+// with `sleep 0.1 2>/dev/null || sleep 1` (fast on coreutils that
+// honor fractional sleep, portable elsewhere), bounds the retries, and
+// on a persistent lock prints `index locked` and exits the hook
+// non-zero. It never deletes `.git/index.lock` — only waits for the
+// holder to release it.
+const stagingHelperShellFunc = "# Stage one path, retrying a transient .git/index.lock with\n" +
+	"# bounded backoff. Never removes a lock it did not create; a\n" +
+	"# persistent lock exits non-zero with a clear message.\n" +
+	"mdsmith_git_add() {\n" +
+	"  _attempt=0\n" +
+	"  while :; do\n" +
+	"    _err=$(git add -- \"$1\" 2>&1)\n" +
+	"    _status=$?\n" +
+	"    [ \"$_status\" -eq 0 ] && return 0\n" +
+	"    case \"$_err\" in\n" +
+	"      *index.lock*\"File exists\"*)\n" +
+	"        if [ \"$_attempt\" -ge 5 ]; then\n" +
+	"          echo \"mdsmith pre-merge-commit hook: index locked: $_err\" >&2\n" +
+	"          exit 1\n" +
+	"        fi\n" +
+	"        _attempt=$((_attempt + 1))\n" +
+	"        sleep 0.1 2>/dev/null || sleep 1\n" +
+	"        ;;\n" +
+	"      *)\n" +
+	"        echo \"$_err\" >&2\n" +
+	"        exit \"$_status\"\n" +
+	"        ;;\n" +
+	"    esac\n" +
+	"  done\n" +
+	"}\n"
+
 // BuildHookScript returns the canonical pre-merge-commit hook
 // content. The script runs `mdsmith fix` once on the entire repo
 // after git resolves every per-file merge, so generated sections
@@ -1026,31 +1061,7 @@ func BuildHookScript(exe string) string {
 		"# marked with merge=mdsmith in .gitattributes.\n" +
 		"set -e\n" +
 		"cd \"$(git rev-parse --show-toplevel)\"\n" +
-		"# Stage one path, retrying a transient .git/index.lock with\n" +
-		"# bounded backoff. Never removes a lock it did not create; a\n" +
-		"# persistent lock exits non-zero with a clear message.\n" +
-		"mdsmith_git_add() {\n" +
-		"  _attempt=0\n" +
-		"  while :; do\n" +
-		"    _err=$(git add -- \"$1\" 2>&1)\n" +
-		"    _status=$?\n" +
-		"    [ \"$_status\" -eq 0 ] && return 0\n" +
-		"    case \"$_err\" in\n" +
-		"      *index.lock*\"File exists\"*)\n" +
-		"        if [ \"$_attempt\" -ge 5 ]; then\n" +
-		"          echo \"mdsmith pre-merge-commit hook: index locked: $_err\" >&2\n" +
-		"          exit 1\n" +
-		"        fi\n" +
-		"        _attempt=$((_attempt + 1))\n" +
-		"        sleep 0.1 2>/dev/null || sleep 1\n" +
-		"        ;;\n" +
-		"      *)\n" +
-		"        echo \"$_err\" >&2\n" +
-		"        exit \"$_status\"\n" +
-		"        ;;\n" +
-		"    esac\n" +
-		"  done\n" +
-		"}\n" +
+		stagingHelperShellFunc +
 		"# `set +e` around the fix invocation so we can capture its\n" +
 		"# raw exit code. `if ! cmd; then status=$?; ...` looks\n" +
 		"# tempting, but POSIX `! cmd` returns the logical NOT of\n" +

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -935,10 +935,8 @@ func StageGitattributes(repoRoot string) error {
 		// The lock outlasted every retry. Report it as locked and keep
 		// git's own message so the operator sees which lock file and the
 		// "remove the file manually" hint, without mdsmith ever removing
-		// a lock it did not create.
-		if msg == "" {
-			return fmt.Errorf("stage .gitattributes: index locked: %w", err)
-		}
+		// a lock it did not create. isIndexLockError matches only
+		// non-empty output, so msg always carries git's message here.
 		return fmt.Errorf("stage .gitattributes: index locked: %w: %s", err, msg)
 	}
 	if msg == "" {

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -993,6 +993,29 @@ func HasMdsmithMergeDriver(repoRoot string) bool {
 // (read uses IFS= -r) at the cost of mishandling the rare filename
 // that contains literal newlines — an acceptable trade for
 // portability.
+//
+// Each `git add` is wrapped in mdsmith_git_add, a bounded
+// retry-with-backoff that absorbs a transient `.git/index.lock`. If a
+// concurrent git invocation briefly holds the lock, `git add` fails
+// with `Unable to create '.../index.lock': File exists`; retrying
+// after a short wait turns a queue-bouncing hard failure into a brief
+// pause. The retry only waits for the holder to release the lock — it
+// never deletes `.git/index.lock`, so a lock the hook did not create
+// is left untouched. When the lock outlasts the retry budget the hook
+// prints `index locked` and exits non-zero so the merge aborts
+// loudly rather than committing a partially staged tree. A non-lock
+// `git add` failure is propagated immediately, since it will not
+// clear on retry.
+//
+// The backoff uses `sleep 0.1 2>/dev/null || sleep 1`: fractional
+// sleep is honored on GNU/BSD/macOS coreutils (fast), and the 1s
+// fallback keeps the script correct on any `sleep` that accepts only
+// integer seconds.
+//
+// The staging phase runs under `set +e` so the retry helper can
+// inspect each `git add` exit status itself; an assignment from a
+// failing command substitution would otherwise trip `set -e` before
+// the helper could classify the failure.
 func BuildHookScript(exe string) string {
 	return "#!/bin/sh\n" +
 		PreMergeCommitMarker + "\n" +
@@ -1003,6 +1026,31 @@ func BuildHookScript(exe string) string {
 		"# marked with merge=mdsmith in .gitattributes.\n" +
 		"set -e\n" +
 		"cd \"$(git rev-parse --show-toplevel)\"\n" +
+		"# Stage one path, retrying a transient .git/index.lock with\n" +
+		"# bounded backoff. Never removes a lock it did not create; a\n" +
+		"# persistent lock exits non-zero with a clear message.\n" +
+		"mdsmith_git_add() {\n" +
+		"  _attempt=0\n" +
+		"  while :; do\n" +
+		"    _err=$(git add -- \"$1\" 2>&1)\n" +
+		"    _status=$?\n" +
+		"    [ \"$_status\" -eq 0 ] && return 0\n" +
+		"    case \"$_err\" in\n" +
+		"      *index.lock*\"File exists\"*)\n" +
+		"        if [ \"$_attempt\" -ge 5 ]; then\n" +
+		"          echo \"mdsmith pre-merge-commit hook: index locked: $_err\" >&2\n" +
+		"          exit 1\n" +
+		"        fi\n" +
+		"        _attempt=$((_attempt + 1))\n" +
+		"        sleep 0.1 2>/dev/null || sleep 1\n" +
+		"        ;;\n" +
+		"      *)\n" +
+		"        echo \"$_err\" >&2\n" +
+		"        exit \"$_status\"\n" +
+		"        ;;\n" +
+		"    esac\n" +
+		"  done\n" +
+		"}\n" +
 		"# `set +e` around the fix invocation so we can capture its\n" +
 		"# raw exit code. `if ! cmd; then status=$?; ...` looks\n" +
 		"# tempting, but POSIX `! cmd` returns the logical NOT of\n" +
@@ -1012,16 +1060,25 @@ func BuildHookScript(exe string) string {
 		"set +e\n" +
 		shellQuote(exe) + " fix .\n" +
 		"status=$?\n" +
-		"set -e\n" +
 		"if [ \"$status\" -ne 0 ] && [ \"$status\" -ne 1 ]; then\n" +
 		"  exit \"$status\"\n" +
 		"fi\n" +
+		"# Stay under `set +e`: mdsmith_git_add captures each `git add`\n" +
+		"# exit status to classify a lock failure, and exits on a hard\n" +
+		"# error. The `while` loop runs in the pipeline's subshell, so a\n" +
+		"# `mdsmith_git_add` exit there ends only the subshell; capture\n" +
+		"# the pipeline status afterward and re-raise it so a persistent\n" +
+		"# lock (or other hard error) aborts the whole hook.\n" +
 		"git diff --name-only -- '*.md' '*.markdown' | " +
 		"while IFS= read -r f; do\n" +
 		"  if [ -n \"$f\" ]; then\n" +
-		"    git add -- \"$f\"\n" +
+		"    mdsmith_git_add \"$f\"\n" +
 		"  fi\n" +
-		"done\n"
+		"done\n" +
+		"stage_status=$?\n" +
+		"if [ \"$stage_status\" -ne 0 ]; then\n" +
+		"  exit \"$stage_status\"\n" +
+		"fi\n"
 }
 
 // HookMatchesCanonical reports whether hook content looks like the
@@ -1045,6 +1102,11 @@ func HookMatchesCanonical(hook string) bool {
 		`if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then`,
 		"git diff --name-only -- '*.md' '*.markdown' |",
 		`while IFS= read -r f; do`,
+		// Staging goes through the index.lock-aware retry helper. A
+		// hook that drifted back to a bare `git add -- "$f"` loop
+		// lacks this call and must be flagged so the lock hardening is
+		// not silently lost on an out-of-date hook.
+		`mdsmith_git_add "$f"`,
 	}
 	for _, frag := range required {
 		if !hookHasNonCommentLineContaining(hook, frag) {

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -935,8 +935,9 @@ func StageGitattributes(repoRoot string) error {
 		// The lock outlasted every retry. Report it as locked and keep
 		// git's own message so the operator sees which lock file and the
 		// "remove the file manually" hint, without mdsmith ever removing
-		// a lock it did not create. isIndexLockError matches only
-		// non-empty output, so msg always carries git's message here.
+		// a lock it did not create. isIndexLockError only returns true
+		// when git's output contains the lock message, so msg is
+		// non-empty here.
 		return fmt.Errorf("stage .gitattributes: index locked: %w: %s", err, msg)
 	}
 	if msg == "" {
@@ -1078,7 +1079,17 @@ func BuildHookScript(exe string) string {
 		"# `mdsmith_git_add` exit there ends only the subshell; capture\n" +
 		"# the pipeline status afterward and re-raise it so a persistent\n" +
 		"# lock (or other hard error) aborts the whole hook.\n" +
-		"git diff --name-only -- '*.md' '*.markdown' | " +
+		"#\n" +
+		"# Capture the changed-file list first and check `git diff`'s own\n" +
+		"# exit status. Piping `git diff` straight into the loop would tie\n" +
+		"# $? to the `while` (which exits 0 on empty input), masking a\n" +
+		"# hard `git diff` failure and committing without staging fixes.\n" +
+		"changed_md=$(git diff --name-only -- '*.md' '*.markdown')\n" +
+		"diff_status=$?\n" +
+		"if [ \"$diff_status\" -ne 0 ]; then\n" +
+		"  exit \"$diff_status\"\n" +
+		"fi\n" +
+		"printf '%s\\n' \"$changed_md\" | " +
 		"while IFS= read -r f; do\n" +
 		"  if [ -n \"$f\" ]; then\n" +
 		"    mdsmith_git_add \"$f\"\n" +
@@ -1109,7 +1120,7 @@ func HookMatchesCanonical(hook string) bool {
 		" fix .",
 		"status=$?",
 		`if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then`,
-		"git diff --name-only -- '*.md' '*.markdown' |",
+		`changed_md=$(git diff --name-only -- '*.md' '*.markdown')`,
 		`while IFS= read -r f; do`,
 		// Staging goes through the index.lock-aware retry helper. A
 		// hook that drifted back to a bare `git add -- "$f"` loop

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -1127,6 +1127,10 @@ func HookMatchesCanonical(hook string) bool {
 		// lacks this call and must be flagged so the lock hardening is
 		// not silently lost on an out-of-date hook.
 		`mdsmith_git_add "$f"`,
+		// The staging loop must capture and re-raise its exit status so
+		// a persistent lock fails the hook instead of being swallowed by
+		// the pipeline (a hook missing this falls through and exits 0).
+		"stage_status=$?",
 	}
 	for _, frag := range required {
 		if !hookHasNonCommentLineContaining(hook, frag) {

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/config"
@@ -855,26 +856,91 @@ func atomicWriteGitattributes(path string, data []byte, mode os.FileMode) error 
 	return os.Rename(tmpName, path)
 }
 
+// gitAddGitattributes runs `git add -- .gitattributes` against
+// repoRoot and returns git's combined output plus the exit error. It
+// is a package-level variable so tests can substitute a fake git that
+// fails with a synthetic index.lock message a fixed number of times
+// before succeeding, exercising the transient- and persistent-lock
+// retry paths deterministically without racing a real lock file.
+//
+// CombinedOutput is used so git's stderr (e.g. `fatal: Unable to
+// create '/.../.git/index.lock': File exists.`) is preserved — both
+// for the lock detector below and for MDS048's "staging failed"
+// diagnostic, which would otherwise carry only an `exit status N`
+// and nothing actionable.
+var gitAddGitattributes = func(repoRoot string) ([]byte, error) {
+	return exec.Command(
+		"git", "-C", repoRoot, "add", "--", ".gitattributes",
+	).CombinedOutput()
+}
+
+// stageRetryBackoff is the wait schedule between `git add` attempts in
+// StageGitattributes. Its length sets the retry budget: one initial
+// attempt plus one retry per entry. The waits ramp so a lock held for
+// a few hundred milliseconds clears without a tight spin, while a
+// genuinely stuck lock still fails in well under a second. It is a
+// variable so tests can shorten it to zero-length waits.
+var stageRetryBackoff = []time.Duration{
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+	40 * time.Millisecond,
+	80 * time.Millisecond,
+	160 * time.Millisecond,
+}
+
+// isIndexLockError reports whether git's combined output describes a
+// failure to acquire .git/index.lock. git prints a stable
+// "Unable to create '<path>/index.lock': File exists" line in that
+// case; matching both fragments avoids treating an unrelated mention
+// of a lock file as a retryable condition.
+func isIndexLockError(output []byte) bool {
+	s := string(output)
+	return strings.Contains(s, "index.lock") && strings.Contains(s, "File exists")
+}
+
 // StageGitattributes runs `git add -- .gitattributes` against repoRoot
 // so updates written by Fix end up in the index. Without this, the
 // pre-merge-commit hook flow stages only the markdown file passed to
 // `mdsmith fix`, leaving the regenerated .gitattributes in the working
 // tree but absent from the resulting merge commit. Errors are surfaced
 // so callers can decide whether to roll back; the working-tree write
-// itself is already done at the point this is called. CombinedOutput
-// is used so git's stderr (e.g. `fatal: Unable to create
-// '/.../.git/index.lock': File exists.`) is preserved in the error
-// returned to the caller — without it MDS048's "staging failed"
-// diagnostic would only carry an `exit status N` and nothing
-// actionable.
+// itself is already done at the point this is called.
+//
+// A `git add` that fails because `.git/index.lock` already exists is
+// retried with bounded backoff (stageRetryBackoff): a transient lock
+// held by a concurrent git invocation usually clears within a few
+// tens of milliseconds, and retrying turns a queue-bouncing hard
+// failure into a brief wait. The retry never deletes the lock — it
+// only waits for the holder to release it — so a lock this process
+// did not create is left untouched. When the lock persists past the
+// retry budget, StageGitattributes returns a clear "index locked"
+// error rather than a bare exit status. Non-lock failures are
+// returned immediately, since they will not clear on retry.
 func StageGitattributes(repoRoot string) error {
-	out, err := exec.Command(
-		"git", "-C", repoRoot, "add", "--", ".gitattributes",
-	).CombinedOutput()
-	if err == nil {
-		return nil
+	var out []byte
+	var err error
+	for attempt := 0; ; attempt++ {
+		out, err = gitAddGitattributes(repoRoot)
+		if err == nil {
+			return nil
+		}
+		if !isIndexLockError(out) || attempt >= len(stageRetryBackoff) {
+			break
+		}
+		time.Sleep(stageRetryBackoff[attempt])
 	}
+
 	msg := strings.TrimSpace(string(out))
+	if isIndexLockError(out) {
+		// The lock outlasted every retry. Report it as locked and keep
+		// git's own message so the operator sees which lock file and the
+		// "remove the file manually" hint, without mdsmith ever removing
+		// a lock it did not create.
+		if msg == "" {
+			return fmt.Errorf("stage .gitattributes: index locked: %w", err)
+		}
+		return fmt.Errorf("stage .gitattributes: index locked: %w: %s", err, msg)
+	}
 	if msg == "" {
 		return fmt.Errorf("stage .gitattributes: %w", err)
 	}

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -1127,10 +1127,18 @@ func HookMatchesCanonical(hook string) bool {
 		// lacks this call and must be flagged so the lock hardening is
 		// not silently lost on an out-of-date hook.
 		`mdsmith_git_add "$f"`,
-		// The staging loop must capture and re-raise its exit status so
-		// a persistent lock fails the hook instead of being swallowed by
-		// the pipeline (a hook missing this falls through and exits 0).
+		// Require the helper definition itself, not just the call, so a
+		// hook that dropped the `mdsmith_git_add()` function (and would
+		// fail at runtime) is flagged as drift.
+		`mdsmith_git_add() {`,
+		// The capture lines alone are not enough: require the guards that
+		// act on them, or a drifted hook could keep `stage_status=$?` yet
+		// drop the exit and silently swallow a staging failure. The
+		// diff-failure guard likewise keeps a hard `git diff` error from
+		// being masked by the pipeline.
 		"stage_status=$?",
+		`if [ "$stage_status" -ne 0 ]; then`,
+		`if [ "$diff_status" -ne 0 ]; then`,
 	}
 	for _, frag := range required {
 		if !hookHasNonCommentLineContaining(hook, frag) {

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/testsymlink"
@@ -782,6 +783,114 @@ func TestStageGitattributes_ReturnsErrorOutsideRepo(t *testing.T) {
 	// dir is not a git repo; `git -C dir add` exits non-zero.
 	err := StageGitattributes(dir)
 	assert.Error(t, err)
+}
+
+// withStubGitAdd swaps the package-level git-add seam and the retry
+// backoff schedule for the duration of a test, restoring both
+// afterward. The schedule is shortened to a few zero-length waits so
+// retry-driven tests run instantly.
+func withStubGitAdd(t *testing.T, stub func(repoRoot string) ([]byte, error)) {
+	t.Helper()
+	origAdd := gitAddGitattributes
+	origBackoff := stageRetryBackoff
+	t.Cleanup(func() {
+		gitAddGitattributes = origAdd
+		stageRetryBackoff = origBackoff
+	})
+	gitAddGitattributes = stub
+	stageRetryBackoff = []time.Duration{0, 0, 0, 0, 0}
+}
+
+// lockExistsOutput mirrors git's real message when it cannot create
+// .git/index.lock, so the lock detector is tested against the exact
+// stderr the field bug produced.
+const lockExistsOutput = "fatal: Unable to create '/repo/.git/index.lock': File exists.\n\n" +
+	"Another git process seems to be running in this repository."
+
+// TestStageGitattributes_RetriesTransientLock drives the
+// transient-lock-clears case with a fake git: the first attempts fail
+// with the index.lock message, then a later attempt succeeds. The
+// staging call must retry and ultimately report success.
+func TestStageGitattributes_RetriesTransientLock(t *testing.T) {
+	calls := 0
+	withStubGitAdd(t, func(repoRoot string) ([]byte, error) {
+		calls++
+		if calls < 3 {
+			return []byte(lockExistsOutput), &exec.ExitError{}
+		}
+		return nil, nil
+	})
+
+	require.NoError(t, StageGitattributes("/repo"),
+		"a lock that clears within the retry window must stage successfully")
+	assert.Equal(t, 3, calls, "StageGitattributes must retry until the lock clears")
+}
+
+// TestStageGitattributes_PersistentLockFailsClearly drives the
+// persistent-lock case: every attempt fails with the index.lock
+// message. The call must exhaust its retries and return a clear
+// "index locked" error rather than retrying forever or surfacing a
+// bare exit status.
+func TestStageGitattributes_PersistentLockFailsClearly(t *testing.T) {
+	calls := 0
+	withStubGitAdd(t, func(repoRoot string) ([]byte, error) {
+		calls++
+		return []byte(lockExistsOutput), &exec.ExitError{}
+	})
+
+	err := StageGitattributes("/repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "index locked",
+		"a persistent lock must surface a clear \"index locked\" message")
+	assert.Greater(t, calls, 1, "StageGitattributes must retry before giving up")
+}
+
+// TestStageGitattributes_NeverRemovesLockItDidNotCreate proves the
+// retry path waits for the lock to clear without deleting it: a
+// real .git/index.lock left in place stays in place after a
+// persistent-lock failure.
+func TestStageGitattributes_NeverRemovesLockItDidNotCreate(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run())
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".gitattributes"), []byte("*.md merge=mdsmith\n"), 0o644))
+
+	lockPath := filepath.Join(dir, ".git", "index.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte("held by someone else"), 0o644))
+
+	// Shorten the backoff so the real `git add` retries finish fast.
+	origBackoff := stageRetryBackoff
+	t.Cleanup(func() { stageRetryBackoff = origBackoff })
+	stageRetryBackoff = []time.Duration{0, 0}
+
+	err := StageGitattributes(dir)
+	require.Error(t, err, "a held lock must make staging fail")
+	assert.Contains(t, err.Error(), "index locked")
+
+	data, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr, "the pre-existing lock must not be removed")
+	assert.Equal(t, "held by someone else", string(data),
+		"StageGitattributes must never delete a lock it did not create")
+}
+
+// TestStageGitattributes_NonLockErrorNotRetried proves a non-lock
+// failure (e.g. running outside a repo) is returned immediately
+// rather than burning the whole retry budget on an error that will
+// never clear.
+func TestStageGitattributes_NonLockErrorNotRetried(t *testing.T) {
+	calls := 0
+	withStubGitAdd(t, func(repoRoot string) ([]byte, error) {
+		calls++
+		return []byte("fatal: not a git repository"), &exec.ExitError{}
+	})
+
+	err := StageGitattributes("/repo")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "index locked")
+	assert.Equal(t, 1, calls, "a non-lock error must not be retried")
 }
 
 func TestDefaultIncludes(t *testing.T) {

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -893,6 +893,22 @@ func TestStageGitattributes_NonLockErrorNotRetried(t *testing.T) {
 	assert.Equal(t, 1, calls, "a non-lock error must not be retried")
 }
 
+// TestStageGitattributes_NonLockErrorEmptyOutput drives a non-lock
+// failure that produces no output (e.g. git failing to exec): the
+// staging call must still return a wrapped "stage .gitattributes"
+// error, not misreport it as a lock or panic on the empty message.
+func TestStageGitattributes_NonLockErrorEmptyOutput(t *testing.T) {
+	withStubGitAdd(t, func(repoRoot string) ([]byte, error) {
+		return nil, &exec.ExitError{}
+	})
+
+	err := StageGitattributes("/repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stage .gitattributes")
+	assert.NotContains(t, err.Error(), "index locked",
+		"an empty-output non-lock error must not be misreported as a lock")
+}
+
 func TestDefaultIncludes(t *testing.T) {
 	got := DefaultIncludes()
 	assert.Equal(t, []string{"*.md", "*.markdown"}, got)

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -798,7 +798,9 @@ func withStubGitAdd(t *testing.T, stub func(repoRoot string) ([]byte, error)) {
 		stageRetryBackoff = origBackoff
 	})
 	gitAddGitattributes = stub
-	stageRetryBackoff = []time.Duration{0, 0, 0, 0, 0}
+	// Match production's retry count (zero-duration for speed) so
+	// assertions on len(stageRetryBackoff) validate the real budget.
+	stageRetryBackoff = make([]time.Duration, len(origBackoff))
 }
 
 // lockExistsOutput mirrors git's real message when it cannot create

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -842,7 +842,8 @@ func TestStageGitattributes_PersistentLockFailsClearly(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "index locked",
 		"a persistent lock must surface a clear \"index locked\" message")
-	assert.Greater(t, calls, 1, "StageGitattributes must retry before giving up")
+	assert.Equal(t, len(stageRetryBackoff)+1, calls,
+		"StageGitattributes must exhaust the full retry budget before giving up")
 }
 
 // TestStageGitattributes_NeverRemovesLockItDidNotCreate proves the

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -315,6 +315,11 @@ func TestHookStagingLoop_RetriesTransientLock(t *testing.T) {
 	assert.Contains(t, string(stagedOut), "PLAN.md",
 		"hook must stage the modified file once the transient lock clears; got %q",
 		string(stagedOut))
+
+	attempts, err := os.ReadFile(filepath.Join(binDir, "add-attempts"))
+	require.NoError(t, err)
+	assert.Equal(t, "3", strings.TrimSpace(string(attempts)),
+		"hook must retry git add exactly 3 times (2 transient failures + 1 success)")
 }
 
 // TestHookStagingLoop_PersistentLockFailsClearly drives the

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -299,7 +299,8 @@ func setupHookRepo(t *testing.T) (repoDir, binDir, target string) {
 // modified, and exit 0.
 func TestHookStagingLoop_RetriesTransientLock(t *testing.T) {
 	repoDir, binDir, _ := setupHookRepo(t)
-	hookPATH := writeFakeGitLockOnAdd(t, binDir, 2)
+	const failCount = 2
+	hookPATH := writeFakeGitLockOnAdd(t, binDir, failCount)
 
 	cmd := exec.Command(filepath.Join(repoDir, ".git", "hooks", "pre-merge-commit"))
 	cmd.Dir = repoDir
@@ -318,8 +319,8 @@ func TestHookStagingLoop_RetriesTransientLock(t *testing.T) {
 
 	attempts, err := os.ReadFile(filepath.Join(binDir, "add-attempts"))
 	require.NoError(t, err)
-	assert.Equal(t, "3", strings.TrimSpace(string(attempts)),
-		"hook must retry git add exactly 3 times (2 transient failures + 1 success)")
+	assert.Equal(t, strconv.Itoa(failCount+1), strings.TrimSpace(string(attempts)),
+		"hook must call git add exactly failCount+1 times (failCount failures + 1 success)")
 }
 
 // TestHookStagingLoop_PersistentLockFailsClearly drives the

--- a/internal/githooks/githooks_unix_test.go
+++ b/internal/githooks/githooks_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -208,4 +209,139 @@ func TestHookScript_MissingSetPlusE_FailsToStageOnExitOne(t *testing.T) {
 	assert.NotContains(t, string(stagedOut), "PLAN.md",
 		"hook without set +e must NOT stage files when fix exits 1 — "+
 			"this is the original merge-queue bug; got staged=%q", string(stagedOut))
+}
+
+// writeFakeGitLockOnAdd installs a `git` shim in binDir that fails the
+// first failCount `git add` invocations with git's real index.lock
+// message (exit 128) and then delegates to the real git. Every other
+// subcommand is delegated unchanged. A counter file in binDir survives
+// across the separate `git add` processes the hook spawns, so the shim
+// models a lock that clears after a fixed number of attempts. The shim
+// never touches .git/index.lock, mirroring the hook's lock-safety
+// contract. It returns the PATH the hook must run with so the shim is
+// found ahead of the real git.
+func writeFakeGitLockOnAdd(t *testing.T, binDir string, failCount int) string {
+	t.Helper()
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+
+	counter := filepath.Join(binDir, "add-attempts")
+	shim := filepath.Join(binDir, "git")
+	script := "#!/bin/sh\n" +
+		"REAL=" + shellQuote(realGit) + "\n" +
+		"if [ \"$1\" = add ]; then\n" +
+		"  n=0\n" +
+		"  if [ -f " + shellQuote(counter) + " ]; then n=$(cat " + shellQuote(counter) + "); fi\n" +
+		"  n=$((n + 1))\n" +
+		"  echo \"$n\" > " + shellQuote(counter) + "\n" +
+		"  if [ \"$n\" -le " + shellQuoteInt(failCount) + " ]; then\n" +
+		"    echo \"fatal: Unable to create '$(pwd)/.git/index.lock': File exists.\" >&2\n" +
+		"    exit 128\n" +
+		"  fi\n" +
+		"fi\n" +
+		"exec \"$REAL\" \"$@\"\n"
+	require.NoError(t, os.WriteFile(shim, []byte(script), 0o755))
+	return binDir + string(os.PathListSeparator) + os.Getenv("PATH")
+}
+
+// shellQuoteInt single-quotes an integer for embedding in the shim.
+func shellQuoteInt(n int) string { return shellQuote(strconv.Itoa(n)) }
+
+// setupHookRepo initialises a git repo with one tracked markdown file
+// and a clean index, then installs the canonical pre-merge-commit hook
+// driven by a fake mdsmith that rewrites that file and exits 0. It
+// returns the repo dir, the bin dir (for a git shim), and the target
+// file path. It is shared by the lock-retry hook tests so each test
+// only has to express the lock behaviour.
+func setupHookRepo(t *testing.T) (repoDir, binDir, target string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repoDir = t.TempDir()
+	binDir = t.TempDir()
+
+	target = filepath.Join(repoDir, "PLAN.md")
+	fakeMdsmith := filepath.Join(binDir, "fake-mdsmith")
+	script := "#!/bin/sh\n" +
+		"echo 'fixed by fake mdsmith' > " + shellQuote(target) + "\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(fakeMdsmith, []byte(script), 0o755))
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	}
+	runGit("init", "-q", "-b", "main")
+	runGit("config", "user.email", "test@test")
+	runGit("config", "user.name", "test")
+	runGit("config", "commit.gpgsign", "false")
+	runGit("config", "tag.gpgsign", "false")
+	require.NoError(t, os.WriteFile(target, []byte("original\n"), 0o644))
+	runGit("add", "PLAN.md")
+	runGit("commit", "-q", "-m", "init")
+
+	hooksDir := filepath.Join(repoDir, ".git", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	hookPath := filepath.Join(hooksDir, "pre-merge-commit")
+	require.NoError(t, os.WriteFile(
+		hookPath, []byte(BuildHookScript(fakeMdsmith)), 0o755))
+	return repoDir, binDir, target
+}
+
+// TestHookStagingLoop_RetriesTransientLock drives the transient-lock
+// case for the hook's staging loop: a git shim fails the first two
+// `git add` invocations with the index.lock message, then succeeds.
+// The hook must retry and ultimately stage the file the fake mdsmith
+// modified, and exit 0.
+func TestHookStagingLoop_RetriesTransientLock(t *testing.T) {
+	repoDir, binDir, _ := setupHookRepo(t)
+	hookPATH := writeFakeGitLockOnAdd(t, binDir, 2)
+
+	cmd := exec.Command(filepath.Join(repoDir, ".git", "hooks", "pre-merge-commit"))
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "PATH="+hookPATH)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err,
+		"hook must retry past a transient lock and exit 0: %s", out)
+
+	staged := exec.Command("git", "diff", "--cached", "--name-only")
+	staged.Dir = repoDir
+	stagedOut, err := staged.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(stagedOut), "PLAN.md",
+		"hook must stage the modified file once the transient lock clears; got %q",
+		string(stagedOut))
+}
+
+// TestHookStagingLoop_PersistentLockFailsClearly drives the
+// persistent-lock case: the git shim fails every `git add` with the
+// index.lock message. The hook must exit non-zero, print a clear
+// "index locked" message, and never remove the lock file (the shim
+// never created one, and the hook must not synthesise a removal).
+func TestHookStagingLoop_PersistentLockFailsClearly(t *testing.T) {
+	repoDir, binDir, _ := setupHookRepo(t)
+	// A large fail count outlasts any bounded retry the hook performs.
+	hookPATH := writeFakeGitLockOnAdd(t, binDir, 1000)
+
+	// Plant a lock the hook did not create; the hook must leave it.
+	lockPath := filepath.Join(repoDir, ".git", "index.lock")
+	require.NoError(t, os.WriteFile(lockPath, []byte("held elsewhere"), 0o644))
+
+	cmd := exec.Command(filepath.Join(repoDir, ".git", "hooks", "pre-merge-commit"))
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "PATH="+hookPATH)
+	out, runErr := cmd.CombinedOutput()
+	require.Error(t, runErr,
+		"hook must exit non-zero when the index lock never clears; output=%s", out)
+	assert.Contains(t, string(out), "index locked",
+		"hook must print a clear \"index locked\" message; output=%s", out)
+
+	data, readErr := os.ReadFile(lockPath)
+	require.NoError(t, readErr, "the pre-existing lock must not be removed by the hook")
+	assert.Equal(t, "held elsewhere", string(data),
+		"hook must never delete a lock it did not create")
 }

--- a/internal/githooks/testdata/hooks/bad/legacy-plain-git-add.sh
+++ b/internal/githooks/testdata/hooks/bad/legacy-plain-git-add.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# mdsmith merge-driver pre-merge-commit hook
+set -e
+cd "$(git rev-parse --show-toplevel)"
+set +e
+'/usr/local/bin/mdsmith' fix .
+status=$?
+if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+  exit "$status"
+fi
+git diff --name-only -- '*.md' '*.markdown' | while IFS= read -r f; do
+  if [ -n "$f" ]; then
+    git add -- "$f"
+  fi
+done

--- a/internal/githooks/testdata/pre-merge-commit.golden.sh
+++ b/internal/githooks/testdata/pre-merge-commit.golden.sh
@@ -7,6 +7,31 @@
 # marked with merge=mdsmith in .gitattributes.
 set -e
 cd "$(git rev-parse --show-toplevel)"
+# Stage one path, retrying a transient .git/index.lock with
+# bounded backoff. Never removes a lock it did not create; a
+# persistent lock exits non-zero with a clear message.
+mdsmith_git_add() {
+  _attempt=0
+  while :; do
+    _err=$(git add -- "$1" 2>&1)
+    _status=$?
+    [ "$_status" -eq 0 ] && return 0
+    case "$_err" in
+      *index.lock*"File exists"*)
+        if [ "$_attempt" -ge 5 ]; then
+          echo "mdsmith pre-merge-commit hook: index locked: $_err" >&2
+          exit 1
+        fi
+        _attempt=$((_attempt + 1))
+        sleep 0.1 2>/dev/null || sleep 1
+        ;;
+      *)
+        echo "$_err" >&2
+        exit "$_status"
+        ;;
+    esac
+  done
+}
 # `set +e` around the fix invocation so we can capture its
 # raw exit code. `if ! cmd; then status=$?; ...` looks
 # tempting, but POSIX `! cmd` returns the logical NOT of
@@ -16,12 +41,21 @@ cd "$(git rev-parse --show-toplevel)"
 set +e
 '/usr/local/bin/mdsmith' fix .
 status=$?
-set -e
 if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
   exit "$status"
 fi
+# Stay under `set +e`: mdsmith_git_add captures each `git add`
+# exit status to classify a lock failure, and exits on a hard
+# error. The `while` loop runs in the pipeline's subshell, so a
+# `mdsmith_git_add` exit there ends only the subshell; capture
+# the pipeline status afterward and re-raise it so a persistent
+# lock (or other hard error) aborts the whole hook.
 git diff --name-only -- '*.md' '*.markdown' | while IFS= read -r f; do
   if [ -n "$f" ]; then
-    git add -- "$f"
+    mdsmith_git_add "$f"
   fi
 done
+stage_status=$?
+if [ "$stage_status" -ne 0 ]; then
+  exit "$stage_status"
+fi

--- a/internal/githooks/testdata/pre-merge-commit.golden.sh
+++ b/internal/githooks/testdata/pre-merge-commit.golden.sh
@@ -50,7 +50,17 @@ fi
 # `mdsmith_git_add` exit there ends only the subshell; capture
 # the pipeline status afterward and re-raise it so a persistent
 # lock (or other hard error) aborts the whole hook.
-git diff --name-only -- '*.md' '*.markdown' | while IFS= read -r f; do
+#
+# Capture the changed-file list first and check `git diff`'s own
+# exit status. Piping `git diff` straight into the loop would tie
+# $? to the `while` (which exits 0 on empty input), masking a
+# hard `git diff` failure and committing without staging fixes.
+changed_md=$(git diff --name-only -- '*.md' '*.markdown')
+diff_status=$?
+if [ "$diff_status" -ne 0 ]; then
+  exit "$diff_status"
+fi
+printf '%s\n' "$changed_md" | while IFS= read -r f; do
   if [ -n "$f" ]; then
     mdsmith_git_add "$f"
   fi

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -29,6 +29,18 @@ type DryRunPredictor interface {
 	PredictDryRunFix(f *lint.File) []lint.Diagnostic
 }
 
+// GitIndexMutator is implemented by a rule whose Fix mutates the git
+// index (e.g. an in-process `git add`). The merge driver excludes
+// such rules: it runs inside `git merge`, which holds
+// `.git/index.lock` for the whole merge, so a second index writer
+// there races the lock (see cmd/mdsmith/mergedriver.go). MDS048
+// (git-hook-sync) is the current implementer.
+type GitIndexMutator interface {
+	// MutatesGitIndex reports whether the rule's Fix writes the git
+	// index.
+	MutatesGitIndex() bool
+}
+
 // Configurable is implemented by rules that have user-tunable settings.
 type Configurable interface {
 	ApplySettings(settings map[string]any) error

--- a/internal/rules/githooksync/rule.go
+++ b/internal/rules/githooksync/rule.go
@@ -87,6 +87,12 @@ func (r *Rule) ID() string { return "MDS048" }
 // Name implements rule.Rule.
 func (r *Rule) Name() string { return "git-hook-sync" }
 
+// MutatesGitIndex reports that MDS048's Fix stages .gitattributes via
+// an in-process `git add` (see githooks.StageGitattributes), so the
+// merge driver must exclude it — the driver runs inside `git merge`,
+// which holds .git/index.lock. Implements rule.GitIndexMutator.
+func (r *Rule) MutatesGitIndex() bool { return true }
+
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "structural" }
 

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -116,20 +116,20 @@ loop. Both are kept; both are hardened against a transient lock.
 
 ## Tasks
 
-1. Harden MDS048's
+1. [x] Harden MDS048's
    [StageGitattributes](../internal/githooks/githooks.go) call
    site against a transient `.git/index.lock`. Use bounded retry
    with backoff. Never delete a lock it did not create. Return a
    clear "index locked" error on a persistent lock. Keep MDS048
    staging `.gitattributes` (no behavior change for the rule).
-2. Harden the hook's staging loop in
+2. [ ] Harden the hook's staging loop in
    [BuildHookScript](../internal/githooks/githooks.go) against a
    transient lock. Use bounded retry with backoff. Never delete a
    lock it did not create. Exit with a clear "index locked"
    message on a persistent lock. Update
    [HookMatchesCanonical](../internal/githooks/githooks.go) and the
    golden fixtures.
-3. Update the
+3. [ ] Update the
    [pre-merge-commit reference](../docs/reference/cli/pre-merge-commit.md).
 
 ## Acceptance Criteria

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -122,7 +122,7 @@ loop. Both are kept; both are hardened against a transient lock.
    with backoff. Never delete a lock it did not create. Return a
    clear "index locked" error on a persistent lock. Keep MDS048
    staging `.gitattributes` (no behavior change for the rule).
-2. [ ] Harden the hook's staging loop in
+2. [x] Harden the hook's staging loop in
    [BuildHookScript](../internal/githooks/githooks.go) against a
    transient lock. Use bounded retry with backoff. Never delete a
    lock it did not create. Exit with a clear "index locked"
@@ -134,14 +134,14 @@ loop. Both are kept; both are hardened against a transient lock.
 
 ## Acceptance Criteria
 
-- [ ] A transient lock that clears within the retry window is
+- [x] A transient lock that clears within the retry window is
       staged successfully, driven with a fake `git`. This holds
       for both MDS048's `StageGitattributes` and the hook's
       staging loop.
-- [ ] A persistent lock makes the writer fail with a clear "index
+- [x] A persistent lock makes the writer fail with a clear "index
       locked" message (MDS048 returns the error; the hook exits
       non-zero). Neither writer removes a lock it did not create.
-- [ ] `HookMatchesCanonical` recognizes the updated template.
+- [x] `HookMatchesCanonical` recognizes the updated template.
       `pre-merge-commit status` reports no drift.
 - [ ] Integration: after a `--no-commit` merge, run the hook, then
       commit. The merge commit captures both the regenerated

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -1,7 +1,7 @@
 ---
 id: 220
 title: Harden the git-index writers against a transient index.lock
-status: "🔳"
+status: "✅"
 model: opus
 summary: >-
   The merge queue bounces when the pre-merge-commit hook's `git
@@ -146,8 +146,8 @@ loop. Both are kept; both are hardened against a transient lock.
 - [x] Integration: after a `--no-commit` merge, run the hook, then
       commit. The merge commit captures both the regenerated
       `.gitattributes` and the fixed `*.md`. The worktree is clean.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues.
 
 ## Invocation model
 

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -1,24 +1,29 @@
 ---
 id: 220
-title: Make the pre-merge-commit hook the single git-index writer
-status: "🔲"
+title: Harden the git-index writers against a transient index.lock
+status: "🔳"
 model: opus
 summary: >-
   The merge queue bounces when the pre-merge-commit hook's `git
   add` fails on `.git/index.lock: File exists`. The action source
   rules out a concurrent or killed process, so the trigger is still
-  under investigation. Regardless, MDS048 does an in-process `git
-  add` that no linter should. Make the hook the single stager and
-  remove MDS048's index mutation.
+  under investigation. mdsmith has two git-index writers during a
+  merge: MDS048's in-process `git add` and the hook's staging loop.
+  Harden both with bounded retry/backoff and a clear "index locked"
+  failure on a persistent lock, never deleting a lock it did not
+  create.
 depends-on: []
 ---
-# Make the pre-merge-commit hook the single git-index writer
+# Harden the git-index writers against a transient index.lock
 
 ## Goal
 
 Stop the merge queue from bouncing on a `.git/index.lock`
-failure. Remove the in-process `git add` that `mdsmith fix` should
-never perform. Leave one git-index writer: the hook.
+failure. mdsmith has two git-index writers during a merge:
+MDS048's in-process `git add` and the pre-merge-commit hook's
+staging loop. Harden both against a transient lock instead of
+collapsing to one writer, so MDS048's user-facing behavior is
+unchanged.
 
 ## Symptom
 
@@ -81,57 +86,61 @@ caller in [githooksync](../internal/rules/githooksync/rule.go).
 The hook's own staging loop then runs `git add`.
 
 The log cannot order the two `git add` calls: the action captures
-all hook stderr as one block. It does not need to. The fix removes
-MDS048's in-process `git add`, leaving the hook as the single
-writer. That eliminates the double-writer condition whichever
-writer was at fault.
+all hook stderr as one block. It does not need to. The fix hardens
+both writers against a transient `index.lock` so a brief lock no
+longer bounces the queue, whichever writer hit it.
 
 ## Design
 
-Mutating the git index is orchestration, not linting. Today two
-mdsmith writers touch the index during a merge: the hook's staging
-loop and MDS048's in-process `git add`. The fix leaves one writer.
+Two mdsmith writers touch the index during a merge: MDS048's
+in-process `git add -- .gitattributes` and the hook's staging
+loop. Both are kept; both are hardened against a transient lock.
 
-- The pre-merge-commit hook is the only mdsmith component that
-  stages. It runs after `git merge --no-commit`, while git has
-  paused, so the index is free in the normal path.
-- MDS048 writes `.gitattributes` as a pure content transform. It
-  performs no `git add`. The hook stages `.gitattributes`.
+- MDS048 still stages `.gitattributes` from its `Fix` so the
+  rule's user-facing behavior is unchanged. Its
+  [StageGitattributes](../internal/githooks/githooks.go) call site
+  retries a `git add` that fails on a `.git/index.lock` with
+  bounded backoff, and returns a clear "index locked" error if the
+  lock persists.
+- The pre-merge-commit hook still stages the markdown files
+  `mdsmith fix` touched (and `.gitattributes` is already staged by
+  MDS048, which the hook runs via `mdsmith fix .`). Its staging
+  loop in [BuildHookScript](../internal/githooks/githooks.go)
+  retries a `git add` that fails on a lock with bounded backoff,
+  and exits with a clear "index locked" message if the lock
+  persists.
+- Lock-safety: neither writer deletes a `.git/index.lock` it did
+  not create. The retry only waits for an existing lock to clear;
+  on a persistent lock it fails loudly rather than forcing the
+  lock away.
 
 ## Tasks
 
-1. In one atomic change, remove the in-process `git add` from
-   MDS048 ([StageGitattributes](../internal/githooks/githooks.go)
-   and its caller in
-   [githooksync](../internal/rules/githooksync/rule.go)). Extend
-   the hook's staging loop in
-   [BuildHookScript](../internal/githooks/githooks.go) to add
-   `.gitattributes` beside `*.md` / `*.markdown`. Ship both halves
-   together. Experiment shows that removing the in-process `git
-   add` while the hook stages only `*.md` drops the regenerated
-   `.gitattributes` from the merge commit. Update
+1. Harden MDS048's
+   [StageGitattributes](../internal/githooks/githooks.go) call
+   site against a transient `.git/index.lock`. Use bounded retry
+   with backoff. Never delete a lock it did not create. Return a
+   clear "index locked" error on a persistent lock. Keep MDS048
+   staging `.gitattributes` (no behavior change for the rule).
+2. Harden the hook's staging loop in
+   [BuildHookScript](../internal/githooks/githooks.go) against a
+   transient lock. Use bounded retry with backoff. Never delete a
+   lock it did not create. Exit with a clear "index locked"
+   message on a persistent lock. Update
    [HookMatchesCanonical](../internal/githooks/githooks.go) and the
-   golden fixtures. Adjust MDS048's diagnostics and tests.
-2. Harden the hook's staging loop against a transient lock. Use
-   bounded retry with backoff. Never delete a lock it did not
-   create. Exit with a clear "index locked" message on a
-   persistent lock. This is defensive; no concurrent writer is
-   known.
+   golden fixtures.
 3. Update the
    [pre-merge-commit reference](../docs/reference/cli/pre-merge-commit.md).
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith fix` performs no in-process git index mutation:
-      MDS048 does no `git add`.
-- [ ] The hook stages `.gitattributes` beside `*.md` /
-      `*.markdown`, so a merge that regenerates `.gitattributes`
-      still captures it.
 - [ ] A transient lock that clears within the retry window is
-      staged successfully, driven with a fake `git`.
-- [ ] A persistent lock makes the hook exit with a clear "index
-      locked" message. The hook never removes a lock it did not
-      create.
+      staged successfully, driven with a fake `git`. This holds
+      for both MDS048's `StageGitattributes` and the hook's
+      staging loop.
+- [ ] A persistent lock makes the writer fail with a clear "index
+      locked" message (MDS048 returns the error; the hook exits
+      non-zero). Neither writer removes a lock it did not create.
 - [ ] `HookMatchesCanonical` recognizes the updated template.
       `pre-merge-commit status` reports no drift.
 - [ ] Integration: after a `--no-commit` merge, run the hook, then
@@ -166,12 +175,13 @@ auto-commit, staging breaks even today.
 
 ## Open decision
 
-Task 1 changes MDS048's behavior. Today its `fix` auto-stages
-`.gitattributes`. Afterward a manual `mdsmith fix` leaves it
-modified but unstaged, and the hook stages it during merges. The
-alternative keeps staging in MDS048 and only hardens the call
-site. The single-writer design is recommended. Confirm before
-implementing.
+Resolved 2026-05-31. The single-writer redesign (remove MDS048's
+in-process `git add`, make the hook the only stager) was
+considered and rejected. The maintainer chose the less invasive
+alternative: keep MDS048 staging `.gitattributes` and only harden
+the two call sites against a transient `index.lock`. MDS048's
+user-facing behavior — `fix` auto-stages `.gitattributes` — is
+unchanged.
 
 ## See also
 

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -129,7 +129,7 @@ loop. Both are kept; both are hardened against a transient lock.
    message on a persistent lock. Update
    [HookMatchesCanonical](../internal/githooks/githooks.go) and the
    golden fixtures.
-3. [ ] Update the
+3. [x] Update the
    [pre-merge-commit reference](../docs/reference/cli/pre-merge-commit.md).
 
 ## Acceptance Criteria

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -4,14 +4,16 @@ title: Harden the git-index writers against a transient index.lock
 status: "✅"
 model: opus
 summary: >-
-  The merge queue bounces when the pre-merge-commit hook's `git
-  add` fails on `.git/index.lock: File exists`. The action source
-  rules out a concurrent or killed process, so the trigger is still
-  under investigation. mdsmith has two git-index writers during a
-  merge: MDS048's in-process `git add` and the hook's staging loop.
-  Harden both with bounded retry/backoff and a clear "index locked"
-  failure on a persistent lock, never deleting a lock it did not
-  create.
+  The merge queue bounced when a `git add` failed on
+  `.git/index.lock: File exists` during a merge. Root cause,
+  confirmed from the GHA job log: the mdsmith merge driver runs
+  `mdsmith fix` — including MDS048's in-process `git add` — from
+  inside `git merge`, which holds the index lock, so the add
+  races the merge for it. The fix drops MDS048 from the merge
+  driver's rule set; a merge driver must not mutate the index.
+  MDS048 still stages in the pre-merge-commit hook, which runs
+  after the merge when the lock is free, and the hook's writers
+  retry a transient lock as defense-in-depth.
 depends-on: []
 ---
 # Harden the git-index writers against a transient index.lock
@@ -19,169 +21,182 @@ depends-on: []
 ## Goal
 
 Stop the merge queue from bouncing on a `.git/index.lock`
-failure. mdsmith has two git-index writers during a merge:
-MDS048's in-process `git add` and the pre-merge-commit hook's
-staging loop. Harden both against a transient lock instead of
-collapsing to one writer, so MDS048's user-facing behavior is
-unchanged.
+failure. The root cause is the mdsmith merge driver mutating the
+git index from inside `git merge`: the driver runs `mdsmith fix`,
+which runs MDS048's in-process `git add`, while git holds the
+index lock. Stop the merge driver from touching the index. Keep
+MDS048 staging in the pre-merge-commit hook — which runs after
+the merge, when the lock is free — and harden the hook's writers
+against a transient lock as defense-in-depth.
 
 ## Symptom
 
-The queue error is the pre-merge-commit hook's `git add` failing.
-It exits 128 with `fatal: Unable to create '.git/index.lock':
-File exists`. The action reports it as `pre-merge-commit hook
-failed (exit 128)`.
+The queue error is a `git add` failing during the merge. It
+exits 128 with `fatal: Unable to create '.git/index.lock': File
+exists`. The action reports it as `pre-merge-commit hook failed
+(exit 128)`.
 
 The `stats: ... fixed=3 ... unfixed=0` in the same message is
-mdsmith reporting a successful `fix`. The `fatal:` comes
-afterward, from the hook's `set -e` staging loop. See
+mdsmith reporting a successful `fix` (`failures`/`unfixed` are
+the fix accounting, not an error). The `fatal:` is a staging
+`git add` tripping over a pre-existing lock. See
 [BuildHookScript](../internal/githooks/githooks.go).
-
-A local experiment reproduces the error. A `git add` that hits a
-pre-existing `.git/index.lock` fails with this exact message. It
-fails the same way on retry. It recovers only when the lock is
-removed.
 
 ## Log evidence
 
-The failed run (`actions/runs/26677854302`) settles the cause:
+The failing run (PR #432 batch) settles the shape:
 
-- It was **not** a bisect run. The inputs were `bisect: false`,
-  `batch_prs: 423` — a single-PR batch. Nothing was killed.
-- A normal content merge ran (auto-merging `CLAUDE.md`,
-  `AGENTS.md`, `PLAN.md`, `.github/copilot-instructions.md`), then
-  the hook ran.
-- `mdsmith fix` reported success: `checked=387 fixed=3 unfixed=0`.
-  The `fatal: index.lock` came after.
-- The lock was stale, not held by a live process. The action's own
-  cleanup then failed on it too: `git merge --abort` exited 128
-  and `git reset` could not reset the index. A live process would
-  have released its lock on exit.
+- It was **not** a bisect run — a single-PR batch. Nothing was
+  killed.
+- `git merge --no-ff --no-commit` auto-merged four
+  merge-driver-managed files (`CLAUDE.md`, `AGENTS.md`,
+  `PLAN.md`, `.github/copilot-instructions.md`).
+- `mdsmith fix` reported success (`fixed=3 ... unfixed=0`); the
+  `fatal: index.lock` and a failed `git merge --abort` came
+  after.
+- The lock was stale, not held by a live process: it blocked
+  both the staging `git add` and the cleanup `--abort` seconds
+  apart. A live process would have released it on exit.
 
-So the lock outlived `mdsmith fix` and wedged the repo. mdsmith is
-the only git-index writer in that window.
+So the lock outlived `mdsmith fix` and wedged the repo. mdsmith
+is the only git-index writer in that window.
 
 ## What the cause is NOT
 
 An earlier draft blamed the merge-queue action. It supposedly
-killed a merge attempt and left a stale lock in a shared checkout.
-The run log and the action source at `v0.7.8` both disprove it:
+killed a merge and left a stale lock in a shared checkout. The
+run log and the action source disprove it:
 
-- The log shows `bisect: false`. No bisection ran, nothing killed.
+- The log shows `bisect: false`. No bisection ran, nothing
+  killed.
 - The action has no process-killing code (`kill`, `SIGKILL`,
   `SIGTERM`, `AbortController`).
-- Bisect, when it does run, re-dispatches a fresh workflow with a
-  fresh `actions/checkout`. No checkout is shared.
-- The action never stages. Its flow is `git merge --no-ff
+- The action itself never stages. Its flow is `git merge --no-ff
   --no-commit`, then the hook, then `git commit -m`.
 
 ## Cause
 
-The lock arises inside mdsmith's own hook execution. mdsmith has
-two git-index writers during a merge. MDS048 (`git-hook-sync`)
-runs an in-process `git add -- .gitattributes` during `mdsmith
-fix`; see
-[StageGitattributes](../internal/githooks/githooks.go) and its
-caller in [githooksync](../internal/rules/githooksync/rule.go).
-The hook's own staging loop then runs `git add`.
+git invokes the mdsmith merge driver
+([mergedriver.go](../cmd/mdsmith/mergedriver.go)) for each
+conflicting `*.md` file. It runs from *inside* `git merge`, which
+holds `.git/index.lock` for the whole merge.
 
-The log cannot order the two `git add` calls: the action captures
-all hook stderr as one block. It does not need to. The fix hardens
-both writers against a transient `index.lock` so a brief lock no
-longer bounces the queue, whichever writer hit it.
+The driver ran the fix pipeline with every rule. That includes
+MDS048 (`git-hook-sync`). Its `Fix` runs an in-process `git add
+-- .gitattributes` (see
+[StageGitattributes](../internal/githooks/githooks.go) and its
+caller in [githooksync](../internal/rules/githooksync/rule.go)).
+
+So each driver invocation spawned a `git add` racing the parent
+`git merge` for the index lock — the second index writer,
+running *during* the merge, not after. With four generated files
+merging at once, that is four races per merge. The hook's own
+staging loop (after the merge) was never the real culprit; it
+just tripped over the lock the merge-time `git add` left behind.
 
 ## Design
 
-Two mdsmith writers touch the index during a merge: MDS048's
-in-process `git add -- .gitattributes` and the hook's staging
-loop. Both are kept; both are hardened against a transient lock.
+A merge driver runs inside `git merge` and must be a pure
+content transform — it must never mutate the git index. The
+primary fix enforces that; the hook-side retry is
+defense-in-depth.
 
-- MDS048 still stages `.gitattributes` from its `Fix` so the
-  rule's user-facing behavior is unchanged. Its
-  [StageGitattributes](../internal/githooks/githooks.go) call site
-  retries a `git add` that fails on a `.git/index.lock` with
-  bounded backoff, and returns a clear "index locked" error if the
-  lock persists.
-- The pre-merge-commit hook still stages the markdown files
-  `mdsmith fix` touched (and `.gitattributes` is already staged by
-  MDS048, which the hook runs via `mdsmith fix .`). Its staging
-  loop in [BuildHookScript](../internal/githooks/githooks.go)
-  retries a `git add` that fails on a lock with bounded backoff,
-  and exits with a clear "index locked" message if the lock
-  persists.
-- Lock-safety: neither writer deletes a `.git/index.lock` it did
-  not create. The retry only waits for an existing lock to clear;
-  on a persistent lock it fails loudly rather than forcing the
-  lock away.
+- The merge driver runs a rule set
+  ([mergeDriverRules](../cmd/mdsmith/mergedriver.go)) that
+  excludes MDS048 (`git-hook-sync`), the only index-mutating
+  rule, so it performs no `git add` during `git merge`. It still
+  regenerates generated sections (catalog, include, toc) to
+  resolve the conflict, written through the driver's `%A`
+  output.
+- MDS048 still stages `.gitattributes` from its `Fix`, but only
+  via the pre-merge-commit hook, which runs after `git merge`
+  releases the lock. Its
+  [StageGitattributes](../internal/githooks/githooks.go) call
+  site retries a transient lock with bounded backoff and returns
+  a clear "index locked" error if it persists.
+- The hook's staging loop in
+  [BuildHookScript](../internal/githooks/githooks.go) likewise
+  retries a transient lock and exits with a clear "index locked"
+  message on a persistent one.
+- Lock-safety: no writer deletes a `.git/index.lock` it did not
+  create. Retry only waits for an existing lock to clear.
 
 ## Tasks
 
-1. [x] Harden MDS048's
+1. [x] Exclude MDS048 from the merge driver's fix pipeline
+   ([mergeDriverRules](../cmd/mdsmith/mergedriver.go)) so it does
+   no `git add` while running inside `git merge`. This is the
+   root-cause fix.
+2. [x] Harden MDS048's
    [StageGitattributes](../internal/githooks/githooks.go) call
-   site against a transient `.git/index.lock`. Use bounded retry
-   with backoff. Never delete a lock it did not create. Return a
-   clear "index locked" error on a persistent lock. Keep MDS048
-   staging `.gitattributes` (no behavior change for the rule).
-2. [x] Harden the hook's staging loop in
-   [BuildHookScript](../internal/githooks/githooks.go) against a
-   transient lock. Use bounded retry with backoff. Never delete a
-   lock it did not create. Exit with a clear "index locked"
-   message on a persistent lock. Update
-   [HookMatchesCanonical](../internal/githooks/githooks.go) and the
-   golden fixtures.
-3. [x] Update the
+   site against a transient `.git/index.lock`: bounded retry with
+   backoff, never delete a lock it did not create, clear "index
+   locked" error on a persistent lock. Keep MDS048 staging
+   `.gitattributes`.
+3. [x] Harden the hook's staging loop in
+   [BuildHookScript](../internal/githooks/githooks.go) the same
+   way, and check `git diff`'s own exit status so a hard failure
+   is not masked by the pipeline. Update
+   [HookMatchesCanonical](../internal/githooks/githooks.go) and
+   the golden fixtures.
+4. [x] Update the
    [pre-merge-commit reference](../docs/reference/cli/pre-merge-commit.md).
 
 ## Acceptance Criteria
 
+- [x] The merge driver performs no git-index mutation: its rule
+      set excludes MDS048.
+- [x] A conflicting merge of a generated file resolves through
+      the driver and commits cleanly with `git-hook-sync`
+      enabled, leaving no stale `.git/index.lock` and a clean
+      worktree.
 - [x] A transient lock that clears within the retry window is
-      staged successfully, driven with a fake `git`. This holds
-      for both MDS048's `StageGitattributes` and the hook's
-      staging loop.
-- [x] A persistent lock makes the writer fail with a clear "index
-      locked" message (MDS048 returns the error; the hook exits
-      non-zero). Neither writer removes a lock it did not create.
-- [x] `HookMatchesCanonical` recognizes the updated template.
+      staged successfully, driven with a fake `git`, for both
+      MDS048's `StageGitattributes` and the hook's staging loop.
+- [x] A persistent lock makes the writer fail with a clear
+      "index locked" message; neither writer removes a lock it
+      did not create.
+- [x] `HookMatchesCanonical` recognizes the updated template;
       `pre-merge-commit status` reports no drift.
-- [x] Integration: after a `--no-commit` merge, run the hook, then
-      commit. The merge commit captures both the regenerated
-      `.gitattributes` and the fixed `*.md`. The worktree is clean.
-- [x] All tests pass: `go test ./...`
-- [x] `go tool golangci-lint run` reports no issues.
+- [x] Integration: after a `--no-commit` merge, run the hook,
+      then commit. The merge commit captures both the regenerated
+      `.gitattributes` and the fixed `*.md`. The worktree is
+      clean.
+- [x] All tests pass: `go test ./...`; `go tool golangci-lint
+      run` reports no issues.
 
 ## Invocation model
 
 The queue runs `git merge --no-commit`, then the hook, then a
 separate `git commit`. Confirmed in
-[gitops.ts](https://github.com/jeduden/merge-queue-action) and the
-regression test at
+[gitops.ts](https://github.com/jeduden/merge-queue-action) and
+the regression test at
 [githooks_unix_test.go](../internal/githooks/githooks_unix_test.go).
 
 Experiment shows this split is load-bearing. Under `git merge`
-auto-commit, git finalizes the merge tree before the hook runs.
-The hook's staging is then dropped from the commit. Under the
-`--no-commit` model, the same staging is captured. So the fix
-assumes the `--no-commit` model. If the action ever switches to
-auto-commit, staging breaks even today.
+auto-commit, git finalizes the merge tree before the hook runs,
+so the hook's staging is dropped from the commit. Under the
+`--no-commit` model the same staging is captured. The fix
+assumes the `--no-commit` model.
 
 ## Open questions
 
-- The exact sub-mechanism is unconfirmed: whether MDS048's
-  in-process `git add` leaves a stale lock, or collides with the
-  hook's staging loop. The log localizes the bug to mdsmith but
-  cannot order the two `git add` calls. A local repro that installs
-  the real hook and runs the merge would pin it. The fix does not
-  depend on the answer.
+- Resolved. The second writer is confirmed: MDS048's in-process
+  `git add`, invoked by the merge driver from inside `git merge`.
+  Retry alone could not have cleared the resulting stale lock —
+  it persisted for seconds, far past the ~310 ms retry budget —
+  so the root-cause fix removes the index mutation from the merge
+  driver.
 
 ## Open decision
 
-Resolved 2026-05-31. The single-writer redesign (remove MDS048's
-in-process `git add`, make the hook the only stager) was
-considered and rejected. The maintainer chose the less invasive
-alternative: keep MDS048 staging `.gitattributes` and only harden
-the two call sites against a transient `index.lock`. MDS048's
-user-facing behavior — `fix` auto-stages `.gitattributes` — is
-unchanged.
+Resolved 2026-05-31. The single-writer redesign for the *hook*
+(remove MDS048's `git add`, make the hook the only stager) was
+considered and rejected; the maintainer chose to keep MDS048
+staging in the hook and harden the call sites. Separately, the
+merge driver must not stage at all — the root-cause fix above.
+MDS048's user-facing behavior — `fix` auto-stages
+`.gitattributes` — is unchanged.
 
 ## See also
 

--- a/plan/220_git-index-lock-retry.md
+++ b/plan/220_git-index-lock-retry.md
@@ -143,7 +143,7 @@ loop. Both are kept; both are hardened against a transient lock.
       non-zero). Neither writer removes a lock it did not create.
 - [x] `HookMatchesCanonical` recognizes the updated template.
       `pre-merge-commit status` reports no drift.
-- [ ] Integration: after a `--no-commit` merge, run the hook, then
+- [x] Integration: after a `--no-commit` merge, run the hook, then
       commit. The merge commit captures both the regenerated
       `.gitattributes` and the fixed `*.md`. The worktree is clean.
 - [ ] All tests pass: `go test ./...`


### PR DESCRIPTION
Plan 220 — stop the merge queue bouncing on `.git/index.lock`.

## Root cause (confirmed from the GHA job log)

git invokes the mdsmith merge driver from **inside** `git merge`, which holds `.git/index.lock` for the whole merge. The driver ran `mdsmith fix` with every rule, including MDS048 (`git-hook-sync`), whose `Fix` does an in-process `git add` — a second index writer racing the merge. With four generated files auto-merging, that is four races per merge.

## What changed

- **Root-cause fix:** the merge driver now runs `mergeDriverRules()` (`rule.All()` minus `git-hook-sync`), so it performs **zero** git-index mutation. MDS048 still stages `.gitattributes`, but only in the pre-merge-commit hook — which runs after `git merge` releases the lock.
- **Defense-in-depth:** both index writers retry a transient lock with bounded backoff and fail with a clear "index locked" message on a persistent one, never deleting a lock they didn't create; the hook also checks `git diff`'s own exit status so a hard failure isn't masked by the pipeline.
- **Tests:** a conflicting-merge e2e (driver + hook, `git-hook-sync` on) proving the conflict resolves with a clean worktree and no stale lock; fake-`git` unit + unix lock tests; the merge-driver rule-set test.
- **Docs/plan:** `docs/reference/cli/pre-merge-commit.md` updated; `plan/220_git-index-lock-retry.md` is complete (✅) and `PLAN.md` reflects it.

## Note

PR #432 (active in the queue) adds a *different* `plan/220_flatpak-bundle-distribution.md`, so id 220 will be a duplicate once it lands; PLAN.md's catalog may need a regen on rebase.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01WfEXMpKbVN9JBzn87H6MXQ)