### PR TITLE
ci: bump pinned mdsmith baseline to v0.28.0

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -10,8 +10,8 @@ runs:
       env:
         # Pinned compatibility baseline for mdsmith release checks and merge tooling.
         # Bump here only when intentionally updating that baseline.
-        MDSMITH_VERSION: v0.27.0
-        MDSMITH_SHA256: 3329edfc0fc019014af3c2a52e5e575f9907e5b5425e0f8aff3b7199e474b3f0
+        MDSMITH_VERSION: v0.28.0
+        MDSMITH_SHA256: 62870ea2fd0681dd42ef4c43cf1760a035949fa51592e52ed16575386828b6a7
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bumps `MDSMITH_VERSION` from `v0.27.0` to `v0.28.0` in `.github/actions/setup-mdsmith-pinned-version/action.yml`
- Updates `MDSMITH_SHA256` to the SHA256 of the `mdsmith-linux-amd64` asset from the v0.28.0 release

## Test plan

- [ ] CI `mdsmith-fixed-version` job passes with the new binary

https://claude.ai/code/session_01YSrCih54L9pzBBKUAgGL4W
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSrCih54L9pzBBKUAgGL4W)_