### PR TITLE
docs: clarify mise installation options and registry status

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -64,12 +64,13 @@ row: "| {title} | `{command}` | {audience} |"
 | Flatpak         | `flatpak install ./mdsmith-x86_64.flatpak`                                                 | Sandboxed Linux x86_64 desktops via Flatpak       |
 <?/catalog?>
 
-The short `asdf plugin add mdsmith` and bare
-`mise use mdsmith@latest` forms — with no explicit URL or
-backend prefix — depend on registry submissions tracked in
-[plan/145](../../plan/145_asdf-mise-registry-submissions.md). The
-explicit-URL asdf install, Homebrew, and mise's `github:`,
-`asdf:`, `go:`, and `ubi:` backends all work today.
+A bare `mise use mdsmith@latest` needs a registry entry —
+"bare" meaning no backend prefix and no prior
+`mise plugins install`. The short `asdf plugin add mdsmith`
+needs one too. Both are tracked in
+[plan/145](../../plan/145_asdf-mise-registry-submissions.md).
+Everything else works today: the explicit-URL asdf install,
+Homebrew, and every backend-prefixed mise form below.
 
 The binary ships for linux x86_64, linux aarch64, macOS
 x86_64, macOS arm64, and Windows amd64. Other targets
@@ -193,12 +194,14 @@ it for new registry entries:
 mise use -g ubi:jeduden/mdsmith@latest
 ```
 
-Only the shortest form — `mise use mdsmith@latest`, with no
-backend prefix — needs an entry in mise's curated registry
-([`jdx/mise`](https://github.com/jdx/mise) `registry.toml`),
-tracked in
+The one gap is a bare `mise use mdsmith@latest`: no backend
+prefix, and no prior `mise plugins install` like the asdf
+step above. That form needs an entry in mise's curated
+registry ([`jdx/mise`](https://github.com/jdx/mise)
+`registry.toml`), tracked in
 [plan/145](../../plan/145_asdf-mise-registry-submissions.md).
-Until that merges, use a backend-prefixed form above.
+Until it merges, use a backend-prefixed form, or install the
+plugin first as shown above.
 
 ## Flatpak
 

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -64,11 +64,12 @@ row: "| {title} | `{command}` | {audience} |"
 | Flatpak         | `flatpak install ./mdsmith-x86_64.flatpak`                                                 | Sandboxed Linux x86_64 desktops via Flatpak       |
 <?/catalog?>
 
-The short `asdf plugin add mdsmith` and `mise use mdsmith@latest`
-forms — without an explicit URL — depend on registry submissions
-tracked in
+The short `asdf plugin add mdsmith` and bare
+`mise use mdsmith@latest` forms — with no explicit URL or
+backend prefix — depend on registry submissions tracked in
 [plan/145](../../plan/145_asdf-mise-registry-submissions.md). The
-explicit-URL asdf install, Homebrew, and `ubi:` mise all work today.
+explicit-URL asdf install, Homebrew, and mise's `github:`,
+`asdf:`, `go:`, and `ubi:` backends all work today.
 
 The binary ships for linux x86_64, linux aarch64, macOS
 x86_64, macOS arm64, and Windows amd64. Other targets
@@ -161,21 +162,43 @@ brew install mdsmith
 ## mise
 
 ```bash
-mise use -g ubi:jeduden/mdsmith@latest
+mise use -g github:jeduden/mdsmith
 mdsmith version
 ```
 
-mise's `ubi` backend reads our GitHub release assets directly, so
-this command works today without any registry submission. Once
-the registry PR for mdsmith merges into
-[`mise-plugins/registry`](https://github.com/mise-plugins/registry),
-the shorter form
+mise installs mdsmith through any of its tool backends —
+all of these resolve today, none need a registry submission.
+The `github` backend above reads our release assets directly
+and auto-selects the build for your OS and architecture; pin
+a version with `github:jeduden/mdsmith@0.13.2`.
+
+To reuse the same plugin the asdf install uses:
 
 ```bash
-mise use mdsmith@latest
+mise plugins install mdsmith https://github.com/jeduden/asdf-mdsmith.git
+mise use -g mdsmith@latest
 ```
 
-resolves on its own.
+To build from source with the Go backend (needs a Go
+toolchain):
+
+```bash
+mise use -g go:github.com/jeduden/mdsmith/cmd/mdsmith
+```
+
+The `ubi` backend still works too, though mise has deprecated
+it for new registry entries:
+
+```bash
+mise use -g ubi:jeduden/mdsmith@latest
+```
+
+Only the shortest form — `mise use mdsmith@latest`, with no
+backend prefix — needs an entry in mise's curated registry
+([`jdx/mise`](https://github.com/jdx/mise) `registry.toml`),
+tracked in
+[plan/145](../../plan/145_asdf-mise-registry-submissions.md).
+Until that merges, use a backend-prefixed form above.
 
 ## Flatpak
 

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -6,7 +6,7 @@ title: >-
 status: "🔳"
 summary: >-
   Land the asdf-plugin repo (jeduden/asdf-mdsmith) and
-  the mise-plugins/registry entry that the multi-channel
+  the jdx/mise registry entry that the multi-channel
   release pipeline already documents but cannot trigger
   from this repo. Spun out of plan/130 because both
   tasks ship outside this repo.
@@ -28,10 +28,11 @@ Neither registry knows about us yet.
 
 ## Background
 
-`mise` reads our GitHub releases directly via its
-`ubi` backend. A registry entry is just the
-difference between `ubi:jeduden/mdsmith@VER` (works
-today) and the shorter `mdsmith@VER` form.
+`mise` reads our GitHub releases directly. Its
+`github` backend already resolves
+`mise use github:jeduden/mdsmith@VER`. The `asdf:`
+and `go:` backends work too. A registry entry only
+adds the shorter, prefix-less `mdsmith@VER` form.
 
 `asdf` is different. It needs a plugin repo that
 knows how to list versions and fetch the binary.
@@ -63,13 +64,16 @@ on `asdf plugin add mdsmith`.
    [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
    adding mdsmith so `asdf plugin add mdsmith`
    resolves without an explicit URL.
-4. File a PR to
-   [`mise-plugins/registry`](https://github.com/mise-plugins/registry)
-   adding mdsmith via the `ubi` backend pointing at
-   `jeduden/mdsmith` releases. Once merged, the
-   shorter `mise use mdsmith@latest` form starts
-   resolving on user CLIs without any code change in
-   this repo.
+4. File a PR to mise's curated registry,
+   [`jdx/mise`](https://github.com/jdx/mise)
+   `registry.toml`, adding a `[tools.mdsmith]` entry
+   on the `github:jeduden/mdsmith` backend (`ubi:` is
+   deprecated for new entries) with a `test` field.
+   The PR body must make a popularity/maintenance
+   case, since the registry is curated. Once merged,
+   the prefix-less `mise use mdsmith@latest` form
+   starts resolving on user CLIs without any code
+   change in this repo.
 5. Update
    [docs/guides/install.md](../docs/guides/install.md)
    to drop the "pending follow-up" badge from the
@@ -89,9 +93,10 @@ on `asdf plugin add mdsmith`.
       explicit URL after the asdf-plugins PR merges.
 - [x] `asdf install mdsmith X.Y.Z` then
       `mdsmith version` prints `mdsmith vX.Y.Z`.
-- [ ] `mise use mdsmith@X.Y.Z` (no `ubi:`) resolves
-      after the mise-plugins/registry PR merges, and
-      `mdsmith version` prints `mdsmith vX.Y.Z`.
+- [ ] `mise use mdsmith@X.Y.Z` (no backend prefix)
+      resolves after the `jdx/mise` registry PR
+      merges, and `mdsmith version` prints
+      `mdsmith vX.Y.Z`.
 - [ ] [docs/guides/install.md](../docs/guides/install.md)
       no longer flags asdf or short-form mise as
       pending follow-ups.


### PR DESCRIPTION
## Summary

Update installation documentation to reflect mise's multiple working backends for mdsmith and clarify the distinction between backends that work today versus those awaiting registry submission.

## Key Changes

- **Simplified mise table entry**: Removed the `ubi` backend specification and replaced with `github:jeduden/mdsmith`, which is clearer and more maintainable
- **Expanded mise installation section**: Added detailed examples showing four working installation paths:
  - `github:` backend (reads releases directly, recommended)
  - `asdf:` backend (reuses the asdf plugin)
  - `go:` backend (builds from source)
  - `ubi:` backend (deprecated but still functional)
- **Clarified registry status**: Distinguished between backends that resolve today without registry submission (`github:`, `asdf:`, `go:`, `ubi:`) and the prefix-less form (`mise use mdsmith@latest`) that requires a `jdx/mise` registry entry
- **Updated plan/145**: Corrected registry target from `mise-plugins/registry` to `jdx/mise` (the curated registry), updated backend recommendation from `ubi:` to `github:`, and clarified that the registry entry is curated and requires a popularity/maintenance case

## Implementation Details

The changes reflect mise's actual capabilities: multiple backends can resolve mdsmith today without waiting for registry submissions. The documentation now guides users toward the `github:` backend as the primary recommendation while documenting all working alternatives. The plan file now accurately describes the registry submission process and the distinction between what works today versus what requires the registry entry.

https://claude.ai/code/session_01FJDfEzgpzjyz1mHGw4AoZC