### PR TITLE
ci: bump pinned mdsmith baseline to v0.29.0

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -10,8 +10,8 @@ runs:
       env:
         # Pinned compatibility baseline for mdsmith release checks and merge tooling.
         # Bump here only when intentionally updating that baseline.
-        MDSMITH_VERSION: v0.28.0
-        MDSMITH_SHA256: 62870ea2fd0681dd42ef4c43cf1760a035949fa51592e52ed16575386828b6a7
+        MDSMITH_VERSION: v0.29.0
+        MDSMITH_SHA256: 130d784cec7fe096ba332974dcd615fc3b4a0ca479730c5fd5a3c9f1f1f55bd3
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.


### PR DESCRIPTION
## What

Bump the pinned mdsmith compatibility-baseline binary from **v0.28.0 → v0.29.0** in `.github/actions/setup-mdsmith-pinned-version/action.yml`.

This is the binary installed across CI and merge-queue workflows as the release/merge compatibility baseline. It follows the established cadence (each release bumps the pin to the previous tag): the v0.29.0 release itself carried the bump to v0.28.0 (#442), so the baseline now moves to v0.29.0.

## Changes

```diff
-        MDSMITH_VERSION: v0.28.0
-        MDSMITH_SHA256: 62870ea2fd0681dd42ef4c43cf1760a035949fa51592e52ed16575386828b6a7
+        MDSMITH_VERSION: v0.29.0
+        MDSMITH_SHA256: 130d784cec7fe096ba332974dcd615fc3b4a0ca479730c5fd5a3c9f1f1f55bd3
```

The action downloads `mdsmith-linux-amd64` over HTTPS and verifies it with `sha256sum -c` against the pinned hash, so the checksum must be bumped in lockstep with the version.

## Verification

- **Checksum cross-checked against three independent sources** — all agree on `130d784cec7fe096ba332974dcd615fc3b4a0ca479730c5fd5a3c9f1f1f55bd3`:
  - GitHub release API asset digest for `mdsmith-linux-amd64`
  - `sha256sum` of the downloaded binary
  - the v0.29.0 release `checksums.txt` entry
- Simulated the action's `sha256sum -c` step against the new hash → `OK`
- `mdsmith check .` with the v0.29.0 binary → `checked=389 fixed=0 failures=0 unfixed=0` (exit 0)

https://claude.ai/code/session_01UXMYUjKeZr98A7p3q4dyWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXMYUjKeZr98A7p3q4dyWZ)_