### PR TITLE
fix: mdsmith fix/check empties catalogs when run inside an ignored worktree path

### DIFF
--- a/cmd/mdsmith/e2e_worktree_catalog_test.go
+++ b/cmd/mdsmith/e2e_worktree_catalog_test.go
@@ -1,0 +1,110 @@
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitInRepo runs a git command inside dir with a fixed identity so the
+// test does not depend on the host's global git config.
+func gitInRepo(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{
+		"-C", dir,
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=mdsmith-test",
+		"-c", "commit.gpgsign=false",
+		"-c", "init.defaultBranch=main",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}
+
+// TestE2E_Fix_PreservesCatalogInIgnoredWorktree is the regression test
+// for the worktree catalog-emptying bug.
+//
+// It builds a real Git superproject whose .gitignore and .mdsmith.yml
+// both ignore ".claude/worktrees/**", then adds a linked worktree under
+// that ignored path (mirroring how the agent harness lays out
+// .claude/worktrees/agent-x). Running `fix` and `check` from inside the
+// worktree on its own PLAN.md must NOT empty the populated
+// `<?catalog?>` over plan/*.md: the worktree is its own working tree, so
+// the superproject's ignore rule must not classify the worktree's files
+// as ignored.
+//
+// Before the fix, the catalog glob resolved to zero files and `fix`
+// rewrote the section body to empty; this test asserts the rows survive.
+func TestE2E_Fix_PreservesCatalogInIgnoredWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+
+	// Superproject config: ignore the worktrees directory both in git and
+	// in mdsmith's own ignore list, exactly as the real repo does.
+	writeFixture(t, repo, ".gitignore", ".claude/worktrees/\n")
+	writeFixture(t, repo, ".mdsmith.yml",
+		"rules:\n  first-line-heading: false\n  line-length: false\n"+
+			"ignore:\n  - \".claude/worktrees/**\"\n")
+
+	// A small plan directory and an index file whose catalog enumerates it.
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "plan"), 0o755))
+	writeFixture(t, repo, "plan/alpha.md", "# Alpha\n\nFirst plan.\n")
+	writeFixture(t, repo, "plan/beta.md", "# Beta\n\nSecond plan.\n")
+	planSrc := "<?catalog\nglob: \"plan/*.md\"\nrow: \"- [{filename}]({filename})\"\n?>\n" +
+		"- [plan/alpha.md](plan/alpha.md)\n- [plan/beta.md](plan/beta.md)\n<?/catalog?>\n"
+	writeFixture(t, repo, "PLAN.md", planSrc)
+
+	// Make it a real Git working tree and commit, so a linked worktree
+	// can be added (git worktree requires at least one commit).
+	gitInRepo(t, repo, "init")
+	gitInRepo(t, repo, "add", "-A")
+	gitInRepo(t, repo, "commit", "-m", "initial")
+
+	// Add a linked worktree under the ignored .claude/worktrees/ path.
+	// Its absolute path therefore contains the ".claude/worktrees"
+	// segment the superproject's .gitignore matches.
+	worktree := filepath.Join(repo, ".claude", "worktrees", "agent-x")
+	gitInRepo(t, repo, "worktree", "add", "--detach", worktree, "HEAD")
+
+	// Sanity: the worktree boundary marker is a .git FILE, not a dir.
+	gitInfo, err := os.Lstat(filepath.Join(worktree, ".git"))
+	require.NoError(t, err, "worktree .git must exist")
+	assert.False(t, gitInfo.IsDir(),
+		"worktree .git must be a file (gitdir pointer), confirming a working-tree boundary")
+
+	wtPlan := filepath.Join(worktree, "PLAN.md")
+
+	// `check` from inside the worktree must not report the section as out
+	// of date (it would, if the glob spuriously resolved to zero files).
+	_, checkErr, checkCode := runBinaryInDir(t, worktree, "",
+		"check", "--no-color", "PLAN.md")
+	assert.Equal(t, 0, checkCode,
+		"check from inside the worktree should pass; stderr: %s", checkErr)
+	assert.NotContains(t, checkErr, "out of date",
+		"catalog must not read as out of date from inside the worktree; stderr: %s", checkErr)
+
+	// `fix` from inside the worktree must leave the populated catalog
+	// intact rather than emptying it.
+	_, fixErr, _ := runBinaryInDir(t, worktree, "",
+		"fix", "--no-color", "PLAN.md")
+
+	got, err := os.ReadFile(wtPlan)
+	require.NoError(t, err, "reading PLAN.md after fix; fix stderr: %s", fixErr)
+	gotStr := string(got)
+
+	assert.Contains(t, gotStr, "plan/alpha.md",
+		"fix emptied the catalog: alpha row missing.\nfix stderr: %s\nfile:\n%s", fixErr, gotStr)
+	assert.Contains(t, gotStr, "plan/beta.md",
+		"fix emptied the catalog: beta row missing.\nfix stderr: %s\nfile:\n%s", fixErr, gotStr)
+	assert.Equal(t, 2, strings.Count(gotStr, "](plan/"),
+		"expected both catalog rows preserved.\nfile:\n%s", gotStr)
+}

--- a/internal/lint/gitignore.go
+++ b/internal/lint/gitignore.go
@@ -144,7 +144,9 @@ func NewGitignoreMatcher(root string) *GitignoreMatcher {
 }
 
 // collectAncestorGitignores finds .gitignore files in directories above
-// the given root, ordered from the filesystem root down to root's parent.
+// the given root, ordered from the top of root's own working tree down
+// to root's parent — the walk stops at the working-tree boundary, as
+// detailed below.
 //
 // The walk stops at a Git working-tree boundary. Git applies a
 // .gitignore only to paths within the working tree that contains it, so

--- a/internal/lint/gitignore.go
+++ b/internal/lint/gitignore.go
@@ -145,13 +145,42 @@ func NewGitignoreMatcher(root string) *GitignoreMatcher {
 
 // collectAncestorGitignores finds .gitignore files in directories above
 // the given root, ordered from the filesystem root down to root's parent.
+//
+// The walk stops at a Git working-tree boundary. Git applies a
+// .gitignore only to paths within the working tree that contains it, so
+// rules from an enclosing repository do not cross into a nested working
+// tree. Concretely:
+//
+//   - If root is itself a working-tree root (it contains a .git entry,
+//     which is a file for a linked worktree and a directory for the main
+//     checkout), no ancestor .gitignore is collected at all.
+//   - Otherwise the walk climbs through ancestors and stops after the
+//     first ancestor that is a working-tree root — that ancestor is the
+//     top of root's own working tree.
+//
+// Without this boundary, a worktree nested under a path its superproject
+// ignores (e.g. ".claude/worktrees/agent-x") would inherit that ignore
+// rule and classify every file inside the worktree as ignored, so a
+// catalog glob would resolve to zero files and `fix` would empty the
+// section.
 func collectAncestorGitignores(root string) []string {
+	// A matcher rooted at its own working tree must not inherit the
+	// superproject's ignore rules.
+	if isWorktreeRoot(root) {
+		return nil
+	}
+
 	var ancestors []string
 	dir := filepath.Dir(root)
 	for {
 		gi := filepath.Join(dir, ".gitignore")
 		if _, err := os.Stat(gi); err == nil {
 			ancestors = append([]string{gi}, ancestors...)
+		}
+		// Stop after the working-tree root that root belongs to; rules
+		// above it are in an enclosing repository and do not apply.
+		if isWorktreeRoot(dir) {
+			break
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -162,6 +191,16 @@ func collectAncestorGitignores(root string) []string {
 	// Reverse so they go from root-of-tree down to immediate parent.
 	// They are already collected root-first due to prepending, so no reversal needed.
 	return ancestors
+}
+
+// isWorktreeRoot reports whether dir is the root of a Git working tree,
+// i.e. it directly contains a ".git" entry. For the main checkout this
+// is a directory; for a linked worktree (git worktree add) it is a file
+// holding a "gitdir:" pointer. Either form marks a working-tree boundary
+// that ancestor .gitignore collection must not cross.
+func isWorktreeRoot(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+	return err == nil
 }
 
 // IsIgnored returns true if the given absolute path should be ignored.

--- a/internal/lint/gitignore_worktree_test.go
+++ b/internal/lint/gitignore_worktree_test.go
@@ -88,3 +88,33 @@ func TestNewGitignoreMatcher_AncestorGitignoreStillAppliesWithoutBoundary(t *tes
 	assert.True(t, m.IsIgnored(logFile, false),
 		"ancestor .gitignore *.log rule should still apply when no working-tree boundary intervenes")
 }
+
+// TestNewGitignoreMatcher_StopsAtAncestorWorktreeBoundary covers the
+// ancestor-walk `break`: the matcher root is an ordinary subdirectory,
+// but an ancestor between it and the superproject is itself a worktree
+// root (a `.git` file). The walk must stop at that inner worktree root,
+// so the superproject's .gitignore above it is never collected.
+func TestNewGitignoreMatcher_StopsAtAncestorWorktreeBoundary(t *testing.T) {
+	super := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(super, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(super, ".gitignore"),
+		[]byte("*.log\n"), 0o644))
+
+	// Inner worktree root nested below the superproject: .git is a file.
+	wt := filepath.Join(super, "nested", "wt")
+	require.NoError(t, os.MkdirAll(wt, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".git"),
+		[]byte("gitdir: /elsewhere\n"), 0o644))
+
+	// Matcher root is a plain subdirectory of the inner worktree.
+	sub := filepath.Join(wt, "a", "b")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	logFile := filepath.Join(sub, "out.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("log"), 0o644))
+
+	m := NewGitignoreMatcher(sub)
+	require.NotNil(t, m)
+	assert.False(t, m.IsIgnored(logFile, false),
+		"the ancestor walk must stop at the inner worktree root, so the "+
+			"superproject's *.log rule is never inherited across it")
+}

--- a/internal/lint/gitignore_worktree_test.go
+++ b/internal/lint/gitignore_worktree_test.go
@@ -1,0 +1,90 @@
+package lint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewGitignoreMatcher_StopsAtWorktreeBoundary pins the worktree
+// catalog-emptying bug at the gitignore layer.
+//
+// Layout mirrors a Git worktree nested under an ignored path of its
+// superproject:
+//
+//	<repo>/.git                         (dir → repo is a working tree)
+//	<repo>/.gitignore                   contains ".claude/worktrees/"
+//	<repo>/.claude/worktrees/agent-x/   the worktree root
+//	<repo>/.claude/worktrees/agent-x/.git   (file → worktree boundary)
+//	<repo>/.claude/worktrees/agent-x/plan/foo.md
+//
+// A matcher built at the worktree root must NOT classify files inside
+// the worktree as ignored just because the worktree's own absolute path
+// contains a segment (".claude/worktrees") that the superproject's
+// .gitignore matches. Git itself does not apply the superproject's
+// ignore rules across the working-tree boundary, and neither must
+// mdsmith — otherwise a `plan/*.md` catalog glob resolves to zero files
+// and `fix` empties the section.
+func TestNewGitignoreMatcher_StopsAtWorktreeBoundary(t *testing.T) {
+	repo := t.TempDir()
+	// Repo is a working tree: .git is a directory.
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitignore"),
+		[]byte(".claude/worktrees/\n"), 0o644))
+
+	wt := filepath.Join(repo, ".claude", "worktrees", "agent-x")
+	require.NoError(t, os.MkdirAll(filepath.Join(wt, "plan"), 0o755))
+	// Worktree boundary: .git is a file ("gitdir: ...").
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".git"),
+		[]byte("gitdir: "+filepath.Join(repo, ".git", "worktrees", "agent-x")+"\n"),
+		0o644))
+
+	planFile := filepath.Join(wt, "plan", "foo.md")
+	require.NoError(t, os.WriteFile(planFile, []byte("# foo\n"), 0o644))
+
+	m := NewGitignoreMatcher(wt)
+	require.NotNil(t, m)
+
+	// The file itself must not be ignored.
+	assert.False(t, m.IsIgnored(planFile, false),
+		"plan/foo.md inside the worktree must not be ignored by the superproject's .claude/worktrees/ rule")
+
+	// No ancestor directory of the file (within the worktree, and the
+	// worktree root and its ancestors) may be reported as ignored,
+	// because catalog's gitignore check walks ancestors with isDir=true.
+	for dir := filepath.Dir(planFile); ; dir = filepath.Dir(dir) {
+		assert.False(t, m.IsIgnored(dir, true),
+			"ancestor %q must not be ignored from a worktree-rooted matcher", dir)
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+	}
+}
+
+// TestNewGitignoreMatcher_AncestorGitignoreStillAppliesWithoutBoundary
+// guards the normal (non-worktree) case: when the matcher root is an
+// ordinary subdirectory of a repo — with NO intervening .git marker —
+// an ancestor .gitignore must still apply. This is the behavior the
+// worktree fix must preserve, so the fix cannot simply drop all
+// ancestor .gitignore collection.
+func TestNewGitignoreMatcher_AncestorGitignoreStillAppliesWithoutBoundary(t *testing.T) {
+	repo := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitignore"),
+		[]byte("*.log\n"), 0o644))
+
+	sub := filepath.Join(repo, "docs", "deep")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	logFile := filepath.Join(sub, "out.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("log"), 0o644))
+
+	// Matcher rooted at the subdirectory; the ancestor .gitignore's
+	// "*.log" rule must still be collected and applied.
+	m := NewGitignoreMatcher(sub)
+	require.NotNil(t, m)
+	assert.True(t, m.IsIgnored(logFile, false),
+		"ancestor .gitignore *.log rule should still apply when no working-tree boundary intervenes")
+}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2258,7 +2258,7 @@ func TestQuickFixBytesForCatalogProducesEdit(t *testing.T) {
 		"users expect mdsmith fix in the Quick Fix lightbulb menu")
 	assert.Contains(t, string(fixed), "a.md",
 		"regenerated catalog body should list the matched file")
-	uri := "file://" + docPath
+	uri := pathToURI(docPath)
 	edit := fullFileEdit(uri, doc.text, fixed)
 	require.Contains(t, edit.Changes, uri)
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2240,13 +2240,27 @@ func TestQuickFixBytesForCatalogProducesEdit(t *testing.T) {
 	t.Parallel()
 	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
 	cfg := config.Merge(config.Defaults(), nil)
+
+	// Use a real on-disk directory with a matching file so the catalog
+	// glob resolves to a non-empty result. The quick-fix then produces a
+	// genuine regeneration edit (a stale row → the correct row) rather
+	// than relying on the catalog being emptied: a populated catalog
+	// whose glob matches zero files is no longer auto-emptied, so an
+	// absolute path and a real match are needed to exercise the fix.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.md"), []byte("# A\n"), 0o644))
+	docPath := filepath.Join(dir, "x.md")
 	stale := []byte("# Doc\n\n<?catalog\nglob: [\"a.md\"]\n?>\nold body\n<?/catalog?>\n")
-	doc := &document{path: "x.md", text: stale}
-	fixed := s.quickFixBytesFor("catalog", doc, cfg, "")
+	doc := &document{path: docPath, text: stale}
+
+	fixed := s.quickFixBytesFor("catalog", doc, cfg, dir)
 	require.NotNil(t, fixed, "catalog must surface a quick-fix action; "+
 		"users expect mdsmith fix in the Quick Fix lightbulb menu")
-	edit := fullFileEdit("file:///x.md", doc.text, fixed)
-	require.Contains(t, edit.Changes, "file:///x.md")
+	assert.Contains(t, string(fixed), "a.md",
+		"regenerated catalog body should list the matched file")
+	uri := "file://" + docPath
+	edit := fullFileEdit(uri, doc.text, fixed)
+	require.Contains(t, edit.Changes, uri)
 }
 
 func TestQuickFixBytesForUnknownRule(t *testing.T) {

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -135,6 +135,23 @@ func (r *Rule) Generate(f *lint.File, filePath string, line int,
 			fmt.Sprintf("generated section template execution failed: %v", err))}
 	}
 
+	// Defensive guard: refuse to silently empty a previously-populated
+	// catalog when the glob matched zero files and no `empty:` fallback
+	// applies. Emptying a non-empty section in that case is almost always
+	// a misconfiguration (a wrong working directory, a stale glob, or an
+	// ignore rule that swept up the whole tree) rather than an intentional
+	// edit, so destroying the rows would discard real content. Returning a
+	// diagnostic both surfaces the problem in `check` and, via the engine's
+	// generation-error path, leaves the body untouched in `fix`. An
+	// already-empty body is left alone (no rows to protect); an `empty:`
+	// fallback renders non-empty content and so never reaches this branch.
+	if len(entries) == 0 && content == "" && sectionBodyNonEmpty(f, line) {
+		return "", []lint.Diagnostic{makeDiag(filePath, line,
+			"catalog glob matched zero files but the section is non-empty; "+
+				"refusing to empty it — check the working directory, the glob, "+
+				"and ignore rules, or set an \"empty:\" fallback to clear it intentionally")}
+	}
+
 	// Format tables this rule generates using its own pad / separator
 	// settings; see Rule's doc comment for why catalog carries its own
 	// table-format knobs instead of consulting MDS025.
@@ -144,6 +161,24 @@ func (r *Rule) Generate(f *lint.File, filePath string, line int,
 	})
 
 	return content, nil
+}
+
+// sectionBodyNonEmpty reports whether the catalog section whose start
+// marker is on the given 1-based line currently has any non-whitespace
+// body content. It powers the destructive-empty guard in Generate: a
+// body of only blank lines (or no body at all) carries nothing worth
+// protecting, so the guard must not fire for it. Returns false when the
+// marker pair cannot be located, matching the conservative "nothing to
+// protect" default.
+func sectionBodyNonEmpty(f *lint.File, line int) bool {
+	pairs, _ := gensection.FindMarkerPairs(f, "catalog", "MDS019", "catalog")
+	for _, mp := range pairs {
+		if mp.StartLine != line {
+			continue
+		}
+		return strings.TrimSpace(gensection.ExtractContent(f, mp)) != ""
+	}
+	return false
 }
 
 // ApplySettings implements rule.Configurable.

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -783,6 +783,107 @@ glob: "*.md"
 	}
 }
 
+func TestFix_DoesNotEmptyPopulatedCatalogWhenGlobMatchesZeroFiles(t *testing.T) {
+	// Defensive guard: a previously-populated catalog body must not be
+	// silently emptied when the glob resolves to zero files. This is the
+	// failure mode the worktree bug produced; even if some future regression
+	// makes every file read as filtered/ignored, fix must refuse to destroy
+	// existing rows rather than wipe them.
+	src := `<?catalog
+glob: "*.md"
+?>
+- [a.md](a.md)
+- [b.md](b.md)
+<?/catalog?>
+`
+	// Empty FS: the glob matches nothing.
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	r := &Rule{}
+	result := r.Fix(f)
+	assert.Equal(t, src, string(result),
+		"Fix must not empty a populated catalog when the glob matches zero files")
+}
+
+func TestCheck_FlagsPopulatedCatalogThatWouldBeEmptied(t *testing.T) {
+	// The companion check: when the glob matches zero files but the body
+	// is non-empty, Check surfaces a diagnostic instead of silently
+	// accepting (and `fix` later silently wiping) the rows.
+	src := `<?catalog
+glob: "*.md"
+?>
+- [a.md](a.md)
+- [b.md](b.md)
+<?/catalog?>
+`
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	r := &Rule{}
+	diags := r.Check(f)
+	require.NotEmpty(t, diags, "expected a diagnostic when a populated catalog would be emptied")
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "matched zero files") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a 'matched zero files' diagnostic, got: %v", diags)
+}
+
+func TestFix_StillEmptiesAlreadyEmptyCatalogBody(t *testing.T) {
+	// The guard must not change the legitimate case: an already-empty
+	// body with zero matches stays empty and produces no diagnostic.
+	src := `<?catalog
+glob: "nonexistent/*.md"
+?>
+<?/catalog?>
+`
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	r := &Rule{}
+	result := r.Fix(f)
+	assert.Equal(t, src, string(result), "already-empty catalog must remain a no-op")
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestSectionBodyNonEmpty_PopulatedBody(t *testing.T) {
+	src := `<?catalog
+glob: "*.md"
+?>
+- [a.md](a.md)
+<?/catalog?>
+`
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	// The catalog start marker is on line 1.
+	assert.True(t, sectionBodyNonEmpty(f, 1),
+		"a body with a list row must be reported non-empty")
+}
+
+func TestSectionBodyNonEmpty_WhitespaceOnlyBody(t *testing.T) {
+	src := "<?catalog\nglob: \"*.md\"\n?>\n   \n\n<?/catalog?>\n"
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	assert.False(t, sectionBodyNonEmpty(f, 1),
+		"a body of only blank/whitespace lines must be reported empty")
+}
+
+func TestSectionBodyNonEmpty_EmptyBody(t *testing.T) {
+	src := "<?catalog\nglob: \"*.md\"\n?>\n<?/catalog?>\n"
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	assert.False(t, sectionBodyNonEmpty(f, 1),
+		"a body with no content lines must be reported empty")
+}
+
+func TestSectionBodyNonEmpty_NoMarkerAtLine(t *testing.T) {
+	src := `<?catalog
+glob: "*.md"
+?>
+- [a.md](a.md)
+<?/catalog?>
+`
+	f := newTestFile(t, "index.md", src, fstest.MapFS{})
+	// No marker pair starts on line 99; conservative default is false.
+	assert.False(t, sectionBodyNonEmpty(f, 99),
+		"a line with no matching start marker must report false")
+}
+
 func TestFix_LeavesTemplateErrorSectionsUnchanged(t *testing.T) {
 	// Invalid template syntax -> fix leaves section unchanged.
 	src := `<?catalog


### PR DESCRIPTION
## Problem

When `mdsmith fix`/`check` runs with its CWD inside a directory that matches a configured ignore glob (e.g. `.claude/worktrees/**`), the entire workspace reads as ignored: `<?catalog?>` globs like `plan/*.md` resolve to **zero files**, so `fix` silently rewrites the catalog body to **empty** and `check` accepts the empty result.

Reproduced deterministically: running `mdsmith fix PLAN.md` from a git worktree at `.claude/worktrees/agent-x/` took `PLAN.md`'s catalog from **134 rows → 0**; the same command from the repo root is a no-op. This bit three parallel agent PRs whose worktrees lived under the ignored path.

## Fix direction (verify, then implement with TDD)

- Anchor ignore-pattern matching to **workspace-root-relative** paths so a worktree file is evaluated as `plan/foo.md`, not `…/.claude/worktrees/agent-x/plan/foo.md`; and/or resolve the git **worktree root** as the workspace root.
- Defensive guard: `fix` must not silently empty a previously-populated generated section when its glob resolves to zero files.
- e2e: run `fix`/`check` from a nested worktree whose absolute path contains an ignored segment; assert the catalog is preserved.

Fix in mdsmith code — do **not** edit `.mdsmith.yml`.

https://claude.ai/code/session_011sGyW61mtEZEupgHKojSd6

---
_Generated by [Claude Code](https://claude.ai/code/session_011sGyW61mtEZEupgHKojSd6)_