### PR TITLE
perf: eliminate allocations and NFA recompilation on hot paths

### DIFF
--- a/internal/metrics/docs.go
+++ b/internal/metrics/docs.go
@@ -69,10 +69,9 @@ func lookupDocFromFS(fsys fs.FS, query string) (string, error) {
 		return "", err
 	}
 
-	q := strings.ToUpper(strings.TrimSpace(query))
-	qName := strings.ToLower(strings.TrimSpace(query))
+	q := strings.TrimSpace(query)
 	for _, d := range docs {
-		if strings.ToUpper(d.ID) == q || d.Name == qName {
+		if strings.EqualFold(d.ID, q) || strings.EqualFold(d.Name, q) {
 			return stripFrontMatter(d.Content), nil
 		}
 	}

--- a/internal/metrics/docs_test.go
+++ b/internal/metrics/docs_test.go
@@ -30,6 +30,18 @@ func TestLookupDoc_ByIDAndName(t *testing.T) {
 	require.Contains(t, content, "MET001", "expected MET001 content, got: %s", content)
 }
 
+func TestLookupDoc_CaseInsensitive(t *testing.T) {
+	// ID lookup is case-insensitive via strings.EqualFold.
+	content, err := LookupDoc("met001")
+	require.NoError(t, err, "LookupDoc(met001): %v", err)
+	require.Contains(t, content, "bytes", "expected bytes content for lowercase ID query")
+
+	// Name lookup is case-insensitive via strings.EqualFold.
+	content, err = LookupDoc("BYTES")
+	require.NoError(t, err, "LookupDoc(BYTES): %v", err)
+	require.Contains(t, content, "MET001", "expected MET001 content for uppercase name query")
+}
+
 func TestLookupDoc_Unknown(t *testing.T) {
 	_, err := LookupDoc("MET999")
 	require.Error(t, err, "expected unknown metric error")

--- a/internal/release/version.go
+++ b/internal/release/version.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // DevSentinel is the version every tracked manifest carries
@@ -222,6 +223,19 @@ func (t *Toolkit) Check(root string) error {
 // Check delegates to a default-OS Toolkit (see Stamp).
 func Check(root string) error { return New().Check(root) }
 
+// pinRECache caches compiled optionalDependencies pin regexes by package name so
+// repeated checkManifest calls for the same key set skip NFA recompilation.
+var pinRECache sync.Map // map[string]*regexp.Regexp
+
+func pinRE(key string) *regexp.Regexp {
+	if v, ok := pinRECache.Load(key); ok {
+		return v.(*regexp.Regexp)
+	}
+	re := regexp.MustCompile(`(?m)^[ \t]*"` + regexp.QuoteMeta(key) + `"[ \t]*:[ \t]*"([^"]+)"`)
+	pinRECache.Store(key, re)
+	return re
+}
+
 func (t *Toolkit) checkManifest(m Manifest, note func(string)) {
 	body, err := t.fs.ReadFile(m.Path)
 	if err != nil {
@@ -241,9 +255,7 @@ func (t *Toolkit) checkManifest(m Manifest, note func(string)) {
 		note(fmt.Sprintf("%s: version is %q, want %q", m.Path, sub[2], DevSentinel))
 	}
 	for _, key := range m.RequiredMdsmithPins {
-		keyRE := regexp.MustCompile(`(?m)^[ \t]*"` + regexp.QuoteMeta(key) +
-			`"[ \t]*:[ \t]*"([^"]+)"`)
-		kSub := keyRE.FindSubmatch(body)
+		kSub := pinRE(key).FindSubmatch(body)
 		if kSub == nil {
 			note(fmt.Sprintf("%s: optionalDependencies missing key %s", m.Path, key))
 			continue

--- a/internal/rules/maxfilelength/rule.go
+++ b/internal/rules/maxfilelength/rule.go
@@ -2,6 +2,7 @@ package maxfilelength
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -46,7 +47,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			RuleID:   r.ID(),
 			RuleName: r.Name(),
 			Severity: lint.Warning,
-			Message:  fmt.Sprintf("file too long (%d > %d)", lineCount, max),
+			Message:  "file too long (" + strconv.Itoa(lineCount) + " > " + strconv.Itoa(max) + ")",
 		}}
 	}
 	return nil

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1941,8 +1941,8 @@ func levelMismatchDiag(
 ) lint.Diagnostic {
 	d := schema.SchemaDiagnostic{
 		Field:     dh.Text,
-		Actual:    fmt.Sprintf("h%d", dh.Level),
-		Expected:  fmt.Sprintf("h%d", req.Level),
+		Actual:    "h" + strconv.Itoa(dh.Level),
+		Expected:  "h" + strconv.Itoa(req.Level),
 		SchemaRef: schemaRef,
 	}
 	return makeDiag(f.Path, dh.Line, d.Format())

--- a/internal/rules/tablereadability/rule.go
+++ b/internal/rules/tablereadability/rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"unicode/utf8"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -73,7 +74,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			diags = append(diags, makeDiag(
 				f,
 				tbl.startLine,
-				fmt.Sprintf("table has too many columns (%d > %d)", cols, maxColumns),
+				"table has too many columns (" + strconv.Itoa(cols) + " > " + strconv.Itoa(maxColumns) + ")",
 			))
 		}
 
@@ -81,14 +82,14 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			diags = append(diags, makeDiag(
 				f,
 				tbl.startLine,
-				fmt.Sprintf("table has too many rows (%d > %d)", rows, maxRows),
+				"table has too many rows (" + strconv.Itoa(rows) + " > " + strconv.Itoa(maxRows) + ")",
 			))
 		}
 
 		if words, line, col := tbl.maxCellWords(); words > maxWordsPerCell {
-			msg := fmt.Sprintf("table cell has too many words (%d > %d)", words, maxWordsPerCell)
+			msg := "table cell has too many words (" + strconv.Itoa(words) + " > " + strconv.Itoa(maxWordsPerCell) + ")"
 			if header := tbl.columnHeader(col); header != "" {
-				msg += fmt.Sprintf(" in column %q", header)
+				msg += " in column " + strconv.Quote(header)
 			}
 			diags = append(diags, makeDiag(
 				f,

--- a/internal/rules/tablereadability/rule.go
+++ b/internal/rules/tablereadability/rule.go
@@ -74,7 +74,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			diags = append(diags, makeDiag(
 				f,
 				tbl.startLine,
-				"table has too many columns (" + strconv.Itoa(cols) + " > " + strconv.Itoa(maxColumns) + ")",
+				"table has too many columns ("+strconv.Itoa(cols)+" > "+strconv.Itoa(maxColumns)+")",
 			))
 		}
 
@@ -82,7 +82,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 			diags = append(diags, makeDiag(
 				f,
 				tbl.startLine,
-				"table has too many rows (" + strconv.Itoa(rows) + " > " + strconv.Itoa(maxRows) + ")",
+				"table has too many rows ("+strconv.Itoa(rows)+" > "+strconv.Itoa(maxRows)+")",
 			))
 		}
 


### PR DESCRIPTION
## Summary

Audit of the codebase against `docs/development/high-performance-go.md` surfaced five issues. Each fix targets a specific anti-pattern from the guide.

- **`strings.EqualFold` in `metrics/docs.go`**: The lookup loop called `strings.ToUpper(d.ID)` on every iteration, allocating a temporary string per comparison. Replaced with `strings.EqualFold` — one pass, zero allocations.

- **Cached regex compilation in `release/version.go`**: `checkManifest` compiled a new NFA via `regexp.MustCompile` inside the `RequiredMdsmithPins` loop on every call. A `sync.Map` cache (`pinRECache`) now reuses compiled patterns across repeated calls for the same key set.

- **`strconv.Itoa` in `requiredstructure/rule.go`**: `fmt.Sprintf("h%d", level)` used reflection to format a single digit. Replaced with `"h" + strconv.Itoa(level)` — ~3× faster per the guide, skips reflection entirely.

- **`strconv.Itoa` in `maxfilelength/rule.go`**: Same pattern — `fmt.Sprintf("file too long (%d > %d)", ...)` replaced with `strconv.Itoa` concatenation.

- **`strconv.Itoa` / `strconv.Quote` in `tablereadability/rule.go`**: Three `fmt.Sprintf("%d > %d")` calls and one `fmt.Sprintf(" in column %q")` replaced with `strconv` equivalents in the table-scan diagnostic path.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./...` — all packages green
- [ ] `go run ./cmd/mdsmith check .` — 391 files, 0 failures

https://claude.ai/code/session_01HB4xGEurr1GM9jw8fTcKvA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HB4xGEurr1GM9jw8fTcKvA)_