### PR TITLE
docs: document the pinned-version adoption sequence

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -10,6 +10,8 @@ runs:
       env:
         # Pinned compatibility baseline for mdsmith release checks and merge tooling.
         # Bump here only when intentionally updating that baseline.
+        # After bumping, scan PLAN.md for plans waiting to adopt the
+        # newly-released syntax. See docs/development/adopt-new-directive-syntax.md.
         MDSMITH_VERSION: v0.31.0
         MDSMITH_SHA256: 030f3b65e7060b2c5e66bbf8dc4c7bdf18904165cef32dc9c66cb7dac01d957d
       # The binary is downloaded over HTTPS and SHA256-verified above

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ row: "- [{summary}](../{filename})"
 - [The mental model behind mdsmith — how flavor, rule, convention, and kind relate, how generated sections work, the placeholder grammar, and how it compares to other Markdown linters.](../docs/background/index.md)
 - [How mdsmith compares to other Markdown linters.](../docs/background/markdown-linters.md)
 - [How to wire a new peer Markdown linter into mdsmith's comparison docs, the per-rule coverage matrix, and the benchmark page.](../docs/development/add-peer-linter.md)
+- [Release new directive syntax and bump the pinned CI baseline before checked-in Markdown uses it, so the `mdsmith-fixed-version` job stays green.](../docs/development/adopt-new-directive-syntax.md)
 - [Running log of SOLID and clean-architecture findings on origin/main. The solid-architecture skill (audit mode) appends here; blockers are also filed as plans.](../docs/development/architecture-audit.md)
 - [Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.](../docs/development/architecture/audit-checklist.md)
 - [External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.](../docs/development/architecture/cross-system.md)
@@ -203,6 +204,7 @@ row: "- [{title}](../docs/development/{filename})"
 - [Release Pipeline](../docs/development/release.md)
 - [Release Tooling Architecture](../docs/development/release-tooling.md)
 - [Secret Rotations](../docs/development/secret-rotations.md)
+- [Ship and adopt new directive syntax](../docs/development/adopt-new-directive-syntax.md)
 - [Website configuration](../docs/development/website-config.md)
 <?/catalog?>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ row: "- [{summary}]({filename})"
 - [The mental model behind mdsmith — how flavor, rule, convention, and kind relate, how generated sections work, the placeholder grammar, and how it compares to other Markdown linters.](docs/background/index.md)
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 - [How to wire a new peer Markdown linter into mdsmith's comparison docs, the per-rule coverage matrix, and the benchmark page.](docs/development/add-peer-linter.md)
+- [Release new directive syntax and bump the pinned CI baseline before checked-in Markdown uses it, so the `mdsmith-fixed-version` job stays green.](docs/development/adopt-new-directive-syntax.md)
 - [Running log of SOLID and clean-architecture findings on origin/main. The solid-architecture skill (audit mode) appends here; blockers are also filed as plans.](docs/development/architecture-audit.md)
 - [Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.](docs/development/architecture/audit-checklist.md)
 - [External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.](docs/development/architecture/cross-system.md)
@@ -208,6 +209,7 @@ row: "- [{title}](docs/development/{filename})"
 - [Release Pipeline](docs/development/release.md)
 - [Release Tooling Architecture](docs/development/release-tooling.md)
 - [Secret Rotations](docs/development/secret-rotations.md)
+- [Ship and adopt new directive syntax](docs/development/adopt-new-directive-syntax.md)
 - [Website configuration](docs/development/website-config.md)
 <?/catalog?>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ row: "- [{summary}]({filename})"
 - [The mental model behind mdsmith — how flavor, rule, convention, and kind relate, how generated sections work, the placeholder grammar, and how it compares to other Markdown linters.](docs/background/index.md)
 - [How mdsmith compares to other Markdown linters.](docs/background/markdown-linters.md)
 - [How to wire a new peer Markdown linter into mdsmith's comparison docs, the per-rule coverage matrix, and the benchmark page.](docs/development/add-peer-linter.md)
+- [Release new directive syntax and bump the pinned CI baseline before checked-in Markdown uses it, so the `mdsmith-fixed-version` job stays green.](docs/development/adopt-new-directive-syntax.md)
 - [Running log of SOLID and clean-architecture findings on origin/main. The solid-architecture skill (audit mode) appends here; blockers are also filed as plans.](docs/development/architecture-audit.md)
 - [Checklist for sweeping origin/main for SOLID and boundary violations. Records findings in the audit log; schedules blockers as new plan files.](docs/development/architecture/audit-checklist.md)
 - [External-surface contracts: LSP, CLI, .mdsmith.yml, generated markers, plugin manifest, distribution shims. Public APIs.](docs/development/architecture/cross-system.md)
@@ -194,6 +195,7 @@ row: "- [{title}](docs/development/{filename})"
 - [Release Pipeline](docs/development/release.md)
 - [Release Tooling Architecture](docs/development/release-tooling.md)
 - [Secret Rotations](docs/development/secret-rotations.md)
+- [Ship and adopt new directive syntax](docs/development/adopt-new-directive-syntax.md)
 - [Website configuration](docs/development/website-config.md)
 <?/catalog?>
 

--- a/docs/development/adopt-new-directive-syntax.md
+++ b/docs/development/adopt-new-directive-syntax.md
@@ -1,0 +1,52 @@
+---
+title: Ship and adopt new directive syntax
+summary: >-
+  Release new directive syntax and bump the pinned
+  CI baseline before checked-in Markdown uses it, so
+  the `mdsmith-fixed-version` job stays green.
+---
+# Ship and adopt new directive syntax
+
+mdsmith lints its own repository. The
+`mdsmith-fixed-version` job runs `mdsmith check .`
+with the pinned release binary, not the branch
+build. The job lives in `.github/workflows/ci.yml`;
+the pin lives in the `setup-mdsmith-pinned-version`
+action. So checked-in Markdown can use only
+directive syntax that the pinned release already
+parses. Adopt new syntax in three ordered steps.
+
+## Steps
+
+1. **Ship the feature in a tagged release.** Land
+   the parser and renderer change, then cut a
+   release so the new syntax exists in a published
+   binary.
+2. **Bump the pinned baseline.** Set
+   `MDSMITH_VERSION` and `MDSMITH_SHA256` in
+   `.github/actions/setup-mdsmith-pinned-version/action.yml`
+   to that release. Now `mdsmith-fixed-version`
+   runs a binary that parses the new syntax.
+3. **Adopt the syntax.** Migrate the repository's
+   own Markdown to the new directive. `mdsmith
+   check .` then passes under both the branch
+   binary and the pinned one.
+
+Do step 3 last. If checked-in Markdown uses syntax
+the pinned binary cannot parse,
+`mdsmith-fixed-version` fails. The job is the
+guardrail: it blocks adoption before the pin is
+ready.
+
+## Track the adoption
+
+The guardrail blocks only early adoption. Nothing
+forces step 3 after step 2, so a released feature
+can sit unused. Track the gap in `PLAN.md`:
+
+- Keep the feature's plan at `🔳` with the adoption
+  task gated on the pin bump. The open plan is the
+  reminder.
+- When you bump the pin in step 2, scan `PLAN.md`
+  for plans waiting to adopt the new syntax.
+  Schedule them.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -27,6 +27,7 @@ row: "- [{title}]({filename})"
 - [Release Pipeline](release.md)
 - [Release Tooling Architecture](release-tooling.md)
 - [Secret Rotations](secret-rotations.md)
+- [Ship and adopt new directive syntax](adopt-new-directive-syntax.md)
 - [Website configuration](website-config.md)
 <?/catalog?>
 


### PR DESCRIPTION
## Why

mdsmith lints its own repository with the **pinned release binary** (the
`mdsmith-fixed-version` CI job in `.github/workflows/ci.yml`), so checked-in
Markdown can only use directive syntax the pin already parses. That job is the
guardrail against *using a feature before pinning it* — but nothing forces the
reverse: actually adopting a feature *after* it ships and the pin is bumped, so
a released feature can sit unused.

This is a follow-up to the discussion on #449 (plan 214 migrated the coverage
matrix to `row-expr:`, which only worked because the pin already shipped that
syntax). It documents the rule so future syntax features follow the same
sequence deliberately.

## What

- New contributor how-to `docs/development/adopt-new-directive-syntax.md`
  covering the ordered sequence: **ship in a release → bump the pinned baseline
  (`MDSMITH_VERSION` + `MDSMITH_SHA256`) → only then adopt in self-linted
  Markdown**, plus the `mdsmith-fixed-version` guardrail and the
  open-plan-as-tracker convention for not forgetting to adopt.
- Reciprocal reminder comment at the pin
  (`.github/actions/setup-mdsmith-pinned-version/action.yml`): after bumping,
  scan `PLAN.md` for plans waiting to adopt newly-released syntax.
- Regenerated doc catalogs (`CLAUDE.md`, `AGENTS.md`,
  `.github/copilot-instructions.md`, `docs/development/index.md`).

`mdsmith check .` passes (392 files, 0 failures).

https://claude.ai/code/session_01PFtFEudVEceJG2xSAmxm31

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFtFEudVEceJG2xSAmxm31)_