### PR TITLE
arch: fix internal/fix → internal/engine import inversion (plan 204)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,7 +129,7 @@ footer: |
 | 201 | ✅     |        | [Rename internal/testutil to internal/testsymlink](plan/201_arch-fix-testutil-rename.md)                                                |
 | 202 | ✅     |        | [Split cmd/mdsmith/main.go into per-subcommand files](plan/202_arch-fix-main-split.md)                                                  |
 | 203 | 🔲     |        | [Split internal/lsp/server.go and symbols.go](plan/203_arch-fix-lsp-server-split.md)                                                    |
-| 204 | 🔲     |        | [Fix internal/fix importing internal/engine](plan/204_arch-fix-fix-engine-inversion.md)                                                 |
+| 204 | ✅     |        | [Fix internal/fix importing internal/engine](plan/204_arch-fix-fix-engine-inversion.md)                                                 |
 | 205 | 🔲     |        | [Move extension.ts concerns to wiring.ts](plan/205_arch-fix-extension-ts-srp.md)                                                        |
 | 206 | ✅     |        | [Document cue/ in architecture layering map](plan/206_arch-fix-cue-types-docs.md)                                                       |
 | 207 | ✅     | sonnet | [LSP fix preview via ChangeAnnotation](plan/207_lsp-fix-preview.md)                                                                     |

--- a/cmd/mdsmith/export.go
+++ b/cmd/mdsmith/export.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/bytelimit"
+	"github.com/jeduden/mdsmith/internal/checker"
 	"github.com/jeduden/mdsmith/internal/config"
-	"github.com/jeduden/mdsmith/internal/engine"
 	"github.com/jeduden/mdsmith/internal/export"
 	"github.com/jeduden/mdsmith/internal/gitignore"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -218,7 +218,7 @@ func exportFrontMatterFields(
 }
 
 // configuredEnabledRules clones+configures every enabled rule via
-// engine.ConfigureRule, the same path fix.Fixer.fixableRules uses.
+// checker.ConfigureRule, the same path fix.Fixer.fixableRules uses.
 // A settings-apply error short-circuits the export with a clear
 // message rather than silently dropping the rule.
 func configuredEnabledRules(
@@ -233,7 +233,7 @@ func configuredEnabledRules(
 		if !cfg.Enabled {
 			continue
 		}
-		configured, err := engine.ConfigureRule(rl, cfg)
+		configured, err := checker.ConfigureRule(rl, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1,0 +1,239 @@
+// Package checker provides the shared rule-checking primitives used by
+// both internal/engine (the full linting runner) and internal/fix (the
+// auto-fix pipeline). It sits below both callers in the dependency
+// graph so neither needs to import the other.
+package checker
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/yuin/goldmark/ast"
+)
+
+// ConfigureRule clones a rule and applies settings from cfg if the rule
+// implements Configurable and cfg has settings. Returns the configured
+// rule (or the original if no settings apply) and any error from
+// ApplySettings.
+func ConfigureRule(rl rule.Rule, cfg config.RuleCfg) (rule.Rule, error) {
+	if cfg.Settings == nil {
+		return rl, nil
+	}
+	if _, ok := rl.(rule.Configurable); !ok {
+		return rl, nil
+	}
+	clone := rule.CloneRule(rl)
+	if c, ok := clone.(rule.Configurable); ok {
+		if err := c.ApplySettings(cfg.Settings); err != nil {
+			return nil, fmt.Errorf("applying settings for %s: %w", rl.Name(), err)
+		}
+	}
+	return clone, nil
+}
+
+// CheckRules runs all enabled rules against f, cloning and applying
+// settings for Configurable rules. It adjusts diagnostics using
+// f.AdjustDiagnostics and returns the collected diagnostics and any
+// settings-application errors. Source context is populated; callers
+// that discard SourceLines should use CheckRulesWithIntraFile with
+// skipSourceContext=true to avoid that allocation.
+func CheckRules(f *lint.File, rules []rule.Rule, effective map[string]config.RuleCfg) ([]lint.Diagnostic, []error) {
+	return CheckRulesWithIntraFile(f, rules, effective, false, 1)
+}
+
+// CheckRulesWithIntraFile is the core implementation that accepts an
+// explicit skip-source-context flag and intra-file concurrency cap.
+// The lintFile path in engine resolves the cap once per Run (via
+// resolveIntraFileWorkers) and passes it in here so the per-file
+// workers do not each query GOMAXPROCS.
+func CheckRulesWithIntraFile(
+	f *lint.File,
+	rules []rule.Rule,
+	effective map[string]config.RuleCfg,
+	skipSourceContext bool,
+	intraFileCap int,
+) ([]lint.Diagnostic, []error) {
+	slots, nodeCheckers, errs := classifyRules(rules, effective)
+
+	// Run non-NodeChecker rules. With cap=1 the loop stays serial and
+	// matches the legacy code path byte-for-byte. With cap>1, slots
+	// run concurrently into their own buckets; rules order is
+	// preserved because the concatenation step reads `slots` in
+	// index order at the end.
+	runNonNodeCheckers(f, slots, intraFileCap)
+
+	// The shared walk runs after the goroutine workers join, so its
+	// node visitor and the rules running inside it never race for
+	// any per-rule state. NodeCheckers stay internally serial: one
+	// goroutine, one walk, one rule per node — fast enough that
+	// splitting per rule would lose the cache locality the multiplex
+	// just won.
+	if len(nodeCheckers) > 0 {
+		_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			for _, s := range nodeCheckers {
+				s.diags = append(s.diags, s.nc.CheckNode(n, entering, f)...)
+			}
+			return ast.WalkContinue, nil
+		})
+	}
+
+	var diags []lint.Diagnostic
+	for _, s := range slots {
+		diags = append(diags, s.diags...)
+	}
+
+	diags = FilterGeneratedDiags(diags, f.GeneratedRanges)
+	f.AdjustDiagnostics(diags)
+	if !skipSourceContext {
+		PopulateSourceContext(f, diags, 2)
+	}
+	return diags, errs
+}
+
+// ruleSlot is one rule's diagnostic bucket. NodeCheckers append to
+// it from the shared walk; non-NodeCheckers fill it once via Check.
+// Slots are kept in rules order so the final concatenation reproduces
+// the sequential output exactly. Configure-failed rules never get a
+// slot — they short-circuit in classifyRules with an entry in errs.
+type ruleSlot struct {
+	nc    rule.NodeChecker
+	check rule.Rule // non-nil for non-NodeChecker slots
+	diags []lint.Diagnostic
+}
+
+// classifyRules walks the rules list once, configures each enabled
+// rule via ConfigureRule (which clones and applies settings only
+// when cfg.Settings is non-nil and the rule is Configurable —
+// otherwise the worker's existing clone is reused as-is), and splits
+// the result into per-rule slots. The slots slice keeps every
+// enabled rule in input order (so the final concatenation is
+// deterministic); the nodeCheckers slice is the subset whose group
+// will be filled by the shared walk.
+func classifyRules(
+	rules []rule.Rule, effective map[string]config.RuleCfg,
+) (slots []ruleSlot, nodeCheckers []*ruleSlot, errs []error) {
+	// Pre-size at the registered-rule count. In production all but a
+	// handful of rules are enabled by default. Allocating slots as a
+	// value slice (rather than a slice of `*ruleSlot`) collapses the
+	// 50+ per-file pointer allocations the previous shape paid into
+	// one backing-array allocation. nodeCheckers stays a pointer
+	// slice but references entries by `&slots[i]`, which is stable
+	// because the slots cap was pre-set to len(rules) — no append
+	// grows the backing, so the index-derived pointers do not
+	// dangle.
+	slots = make([]ruleSlot, 0, len(rules))
+	for _, rl := range rules {
+		cfg, ok := effective[rl.Name()]
+		if !ok || !cfg.Enabled {
+			continue
+		}
+		checkRule, err := ConfigureRule(rl, cfg)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if nc, ok := checkRule.(rule.NodeChecker); ok {
+			slots = append(slots, ruleSlot{nc: nc})
+			continue
+		}
+		slots = append(slots, ruleSlot{check: checkRule})
+	}
+	for i := range slots {
+		if slots[i].nc != nil {
+			if nodeCheckers == nil {
+				nodeCheckers = make([]*ruleSlot, 0, len(slots)/2+1)
+			}
+			nodeCheckers = append(nodeCheckers, &slots[i])
+		}
+	}
+	return slots, nodeCheckers, errs
+}
+
+// runNonNodeCheckers fills the non-NodeChecker slots' diags fields.
+// With cap<=1, runs serially (matches pre-plan-190 behaviour). With
+// cap>1, runs slots concurrently bounded by a semaphore so no more
+// than cap rule.Check calls execute at the same time. Each goroutine
+// writes only to its own slot, so the result needs no lock — slots
+// are concatenated in rules order after the workers join.
+//
+// The slots backing was pre-sized in classifyRules so `&slots[i]`
+// is stable for the lifetime of this call.
+func runNonNodeCheckers(f *lint.File, slots []ruleSlot, intraFileCap int) {
+	if intraFileCap <= 1 {
+		for i := range slots {
+			if slots[i].check == nil {
+				continue
+			}
+			slots[i].diags = slots[i].check.Check(f)
+		}
+		return
+	}
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, intraFileCap)
+	for i := range slots {
+		if slots[i].check == nil {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(slot *ruleSlot) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			slot.diags = slot.check.Check(f)
+		}(&slots[i])
+	}
+	wg.Wait()
+}
+
+// FilterGeneratedDiags removes diagnostics whose line falls within any
+// of the generated section ranges. Called before AdjustDiagnostics, so
+// lines are still in post-front-matter coordinates matching the ranges.
+func FilterGeneratedDiags(diags []lint.Diagnostic, ranges []lint.LineRange) []lint.Diagnostic {
+	if len(ranges) == 0 {
+		return diags
+	}
+	out := diags[:0:len(diags)]
+	for _, d := range diags {
+		keep := true
+		for _, r := range ranges {
+			if r.Contains(d.Line) {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// PopulateSourceContext fills each diagnostic's SourceLines and
+// SourceStartLine with surrounding context from f.Lines.
+func PopulateSourceContext(f *lint.File, diags []lint.Diagnostic, context int) {
+	// bytes.Split produces an empty trailing element when source ends
+	// with a newline. Exclude it so context windows don't include a
+	// phantom empty line.
+	numLines := len(f.Lines)
+	if numLines > 0 && len(f.Lines[numLines-1]) == 0 {
+		numLines--
+	}
+
+	for i := range diags {
+		lineIdx := diags[i].Line - f.LineOffset - 1 // 0-based into f.Lines
+		if lineIdx < 0 || lineIdx >= numLines {
+			continue
+		}
+		start := max(0, lineIdx-context)
+		end := min(numLines, lineIdx+context+1)
+		lines := make([]string, end-start)
+		for j := start; j < end; j++ {
+			lines[j-start] = string(f.Lines[j])
+		}
+		diags[i].SourceLines = lines
+		diags[i].SourceStartLine = start + f.LineOffset + 1
+	}
+}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -1,0 +1,91 @@
+package checker_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/checker"
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// plainRule is a minimal non-NodeChecker rule for testing.
+type plainRule struct{ id string }
+
+func (r *plainRule) ID() string                           { return r.id }
+func (r *plainRule) Name() string                         { return r.id }
+func (r *plainRule) Category() string                     { return "test" }
+func (r *plainRule) Check(_ *lint.File) []lint.Diagnostic { return nil }
+
+// errConfigurable implements rule.Configurable and always fails ApplySettings.
+type errConfigurable struct{ plainRule }
+
+func (r *errConfigurable) ApplySettings(_ map[string]any) error {
+	return errors.New("intentional settings error")
+}
+func (r *errConfigurable) DefaultSettings() map[string]any { return nil }
+
+var _ rule.Configurable = (*errConfigurable)(nil)
+
+func TestConfigureRule_settingsError(t *testing.T) {
+	r := &errConfigurable{plainRule: plainRule{id: "TST001"}}
+	_, err := checker.ConfigureRule(r, config.RuleCfg{Settings: map[string]any{"x": 1}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "intentional settings error")
+}
+
+func newTestFile(t *testing.T, src string) *lint.File {
+	t.Helper()
+	f, err := lint.NewFile("doc.md", []byte(src))
+	require.NoError(t, err)
+	f.RootDir = "."
+	f.RunCache = lint.NewRunCache()
+	return f
+}
+
+func TestCheckRulesWithIntraFile_concurrent(t *testing.T) {
+	f := newTestFile(t, "# Hello\n\nParagraph.\n")
+	rules := []rule.Rule{
+		&plainRule{id: "TST001"},
+		&plainRule{id: "TST002"},
+	}
+	effective := map[string]config.RuleCfg{
+		"TST001": {Enabled: true},
+		"TST002": {Enabled: true},
+	}
+	// intraFileCap > 1 exercises the goroutine path in runNonNodeCheckers.
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, effective, true, 2)
+	assert.Empty(t, errs)
+	assert.Empty(t, diags)
+}
+
+func TestCheckRulesWithIntraFile_settingsErrorPropagated(t *testing.T) {
+	f := newTestFile(t, "# Hello\n")
+	rules := []rule.Rule{&errConfigurable{plainRule: plainRule{id: "TST001"}}}
+	effective := map[string]config.RuleCfg{
+		"TST001": {Enabled: true, Settings: map[string]any{"x": 1}},
+	}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, effective, true, 1)
+	assert.Empty(t, diags)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "intentional settings error")
+}
+
+func TestPopulateSourceContext_outOfBoundLine(t *testing.T) {
+	f := newTestFile(t, "# Hello\n")
+	diags := []lint.Diagnostic{
+		{Line: 0, RuleID: "TST001"}, // lineIdx = 0 - 0 - 1 = -1, below bounds
+	}
+	checker.PopulateSourceContext(f, diags, 2)
+	// Out-of-bound lines must not populate SourceLines.
+	assert.Nil(t, diags[0].SourceLines)
+}
+
+func TestFilterGeneratedDiags_empty(t *testing.T) {
+	diags := []lint.Diagnostic{{Line: 5, RuleID: "TST001"}}
+	out := checker.FilterGeneratedDiags(diags, nil)
+	assert.Equal(t, diags, out)
+}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
 )
 
-// plainRule is a minimal non-NodeChecker rule for testing.
+// --- stubs ---
+
 type plainRule struct{ id string }
 
 func (r *plainRule) ID() string                           { return r.id }
@@ -20,7 +22,43 @@ func (r *plainRule) Name() string                         { return r.id }
 func (r *plainRule) Category() string                     { return "test" }
 func (r *plainRule) Check(_ *lint.File) []lint.Diagnostic { return nil }
 
-// errConfigurable implements rule.Configurable and always fails ApplySettings.
+type diagRule struct {
+	plainRule
+	diag lint.Diagnostic
+}
+
+func (r *diagRule) Check(_ *lint.File) []lint.Diagnostic {
+	return []lint.Diagnostic{r.diag}
+}
+
+type nodeCheckerRule struct {
+	plainRule
+	diag lint.Diagnostic
+}
+
+func (r *nodeCheckerRule) Check(_ *lint.File) []lint.Diagnostic { return nil }
+func (r *nodeCheckerRule) CheckNode(_ ast.Node, entering bool, _ *lint.File) []lint.Diagnostic {
+	if entering {
+		return []lint.Diagnostic{r.diag}
+	}
+	return nil
+}
+
+var _ rule.NodeChecker = (*nodeCheckerRule)(nil)
+
+type goodConfigurable struct {
+	plainRule
+	Applied map[string]any
+}
+
+func (r *goodConfigurable) ApplySettings(s map[string]any) error {
+	r.Applied = s
+	return nil
+}
+func (r *goodConfigurable) DefaultSettings() map[string]any { return nil }
+
+var _ rule.Configurable = (*goodConfigurable)(nil)
+
 type errConfigurable struct{ plainRule }
 
 func (r *errConfigurable) ApplySettings(_ map[string]any) error {
@@ -30,12 +68,7 @@ func (r *errConfigurable) DefaultSettings() map[string]any { return nil }
 
 var _ rule.Configurable = (*errConfigurable)(nil)
 
-func TestConfigureRule_settingsError(t *testing.T) {
-	r := &errConfigurable{plainRule: plainRule{id: "TST001"}}
-	_, err := checker.ConfigureRule(r, config.RuleCfg{Settings: map[string]any{"x": 1}})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "intentional settings error")
-}
+// --- helpers ---
 
 func newTestFile(t *testing.T, src string) *lint.File {
 	t.Helper()
@@ -46,46 +79,175 @@ func newTestFile(t *testing.T, src string) *lint.File {
 	return f
 }
 
+func enabled(ids ...string) map[string]config.RuleCfg {
+	m := make(map[string]config.RuleCfg, len(ids))
+	for _, id := range ids {
+		m[id] = config.RuleCfg{Enabled: true}
+	}
+	return m
+}
+
+// --- ConfigureRule ---
+
+func TestConfigureRule_nilSettings(t *testing.T) {
+	r := &plainRule{id: "TST001"}
+	got, err := checker.ConfigureRule(r, config.RuleCfg{Settings: nil})
+	require.NoError(t, err)
+	assert.Same(t, r, got.(*plainRule))
+}
+
+func TestConfigureRule_nonConfigurableWithSettings(t *testing.T) {
+	r := &plainRule{id: "TST001"}
+	got, err := checker.ConfigureRule(r, config.RuleCfg{Settings: map[string]any{"x": 1}})
+	require.NoError(t, err)
+	assert.Same(t, r, got.(*plainRule))
+}
+
+func TestConfigureRule_appliesSettings(t *testing.T) {
+	r := &goodConfigurable{plainRule: plainRule{id: "TST001"}}
+	got, err := checker.ConfigureRule(r, config.RuleCfg{Settings: map[string]any{"k": "v"}})
+	require.NoError(t, err)
+	clone := got.(*goodConfigurable)
+	assert.NotSame(t, r, clone)
+	assert.Equal(t, map[string]any{"k": "v"}, clone.Applied)
+}
+
+func TestConfigureRule_settingsError(t *testing.T) {
+	r := &errConfigurable{plainRule: plainRule{id: "TST001"}}
+	_, err := checker.ConfigureRule(r, config.RuleCfg{Settings: map[string]any{"x": 1}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "intentional settings error")
+}
+
+// --- CheckRules (thin wrapper) ---
+
+func TestCheckRules_basic(t *testing.T) {
+	f := newTestFile(t, "# Hello\n\nParagraph.\n")
+	rules := []rule.Rule{&plainRule{id: "TST001"}}
+	diags, errs := checker.CheckRules(f, rules, enabled("TST001"))
+	assert.Empty(t, errs)
+	assert.Empty(t, diags)
+}
+
+// --- CheckRulesWithIntraFile ---
+
+func TestCheckRulesWithIntraFile_serial(t *testing.T) {
+	f := newTestFile(t, "# Hello\n\nParagraph.\n")
+	d := lint.Diagnostic{Line: 1, RuleID: "TST001", Message: "test"}
+	rules := []rule.Rule{&diagRule{plainRule: plainRule{id: "TST001"}, diag: d}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "TST001", diags[0].RuleID)
+}
+
 func TestCheckRulesWithIntraFile_concurrent(t *testing.T) {
 	f := newTestFile(t, "# Hello\n\nParagraph.\n")
 	rules := []rule.Rule{
 		&plainRule{id: "TST001"},
 		&plainRule{id: "TST002"},
 	}
-	effective := map[string]config.RuleCfg{
-		"TST001": {Enabled: true},
-		"TST002": {Enabled: true},
-	}
-	// intraFileCap > 1 exercises the goroutine path in runNonNodeCheckers.
-	diags, errs := checker.CheckRulesWithIntraFile(f, rules, effective, true, 2)
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001", "TST002"), true, 4)
 	assert.Empty(t, errs)
 	assert.Empty(t, diags)
 }
 
-func TestCheckRulesWithIntraFile_settingsErrorPropagated(t *testing.T) {
+func TestCheckRulesWithIntraFile_nodeChecker(t *testing.T) {
+	f := newTestFile(t, "# Hello\n\nParagraph.\n")
+	d := lint.Diagnostic{Line: 1, RuleID: "TST001", Message: "node hit"}
+	rules := []rule.Rule{&nodeCheckerRule{plainRule: plainRule{id: "TST001"}, diag: d}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	assert.NotEmpty(t, diags)
+}
+
+func TestCheckRulesWithIntraFile_settingsError(t *testing.T) {
 	f := newTestFile(t, "# Hello\n")
 	rules := []rule.Rule{&errConfigurable{plainRule: plainRule{id: "TST001"}}}
-	effective := map[string]config.RuleCfg{
+	eff := map[string]config.RuleCfg{
 		"TST001": {Enabled: true, Settings: map[string]any{"x": 1}},
 	}
-	diags, errs := checker.CheckRulesWithIntraFile(f, rules, effective, true, 1)
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, eff, true, 1)
 	assert.Empty(t, diags)
 	require.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Error(), "intentional settings error")
 }
 
-func TestPopulateSourceContext_outOfBoundLine(t *testing.T) {
+func TestCheckRulesWithIntraFile_disabledRule(t *testing.T) {
 	f := newTestFile(t, "# Hello\n")
-	diags := []lint.Diagnostic{
-		{Line: 0, RuleID: "TST001"}, // lineIdx = 0 - 0 - 1 = -1, below bounds
-	}
-	checker.PopulateSourceContext(f, diags, 2)
-	// Out-of-bound lines must not populate SourceLines.
-	assert.Nil(t, diags[0].SourceLines)
+	d := lint.Diagnostic{Line: 1, RuleID: "TST001", Message: "should not appear"}
+	rules := []rule.Rule{&diagRule{plainRule: plainRule{id: "TST001"}, diag: d}}
+	eff := map[string]config.RuleCfg{"TST001": {Enabled: false}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, eff, true, 1)
+	assert.Empty(t, errs)
+	assert.Empty(t, diags)
 }
 
-func TestFilterGeneratedDiags_empty(t *testing.T) {
+// --- FilterGeneratedDiags ---
+
+func TestFilterGeneratedDiags_noRanges(t *testing.T) {
 	diags := []lint.Diagnostic{{Line: 5, RuleID: "TST001"}}
 	out := checker.FilterGeneratedDiags(diags, nil)
 	assert.Equal(t, diags, out)
+}
+
+func TestFilterGeneratedDiags_removesInsideRange(t *testing.T) {
+	diags := []lint.Diagnostic{
+		{Line: 3, RuleID: "TST001"},
+		{Line: 7, RuleID: "TST002"},
+		{Line: 10, RuleID: "TST003"},
+	}
+	ranges := []lint.LineRange{{From: 5, To: 8}}
+	out := checker.FilterGeneratedDiags(diags, ranges)
+	require.Len(t, out, 2)
+	assert.Equal(t, 3, out[0].Line)
+	assert.Equal(t, 10, out[1].Line)
+}
+
+func TestFilterGeneratedDiags_keepOutsideRange(t *testing.T) {
+	diags := []lint.Diagnostic{{Line: 1, RuleID: "TST001"}}
+	ranges := []lint.LineRange{{From: 5, To: 8}}
+	out := checker.FilterGeneratedDiags(diags, ranges)
+	require.Len(t, out, 1)
+}
+
+// --- PopulateSourceContext ---
+
+func TestPopulateSourceContext_validLine(t *testing.T) {
+	f := newTestFile(t, "line1\nline2\nline3\n")
+	diags := []lint.Diagnostic{{Line: 2, RuleID: "TST001"}}
+	checker.PopulateSourceContext(f, diags, 1)
+	assert.NotNil(t, diags[0].SourceLines)
+	assert.Equal(t, 1, diags[0].SourceStartLine)
+}
+
+func TestPopulateSourceContext_outOfBoundLine(t *testing.T) {
+	f := newTestFile(t, "# Hello\n")
+	diags := []lint.Diagnostic{{Line: 0, RuleID: "TST001"}}
+	checker.PopulateSourceContext(f, diags, 2)
+	assert.Nil(t, diags[0].SourceLines)
+}
+
+func TestPopulateSourceContext_emptyTrailingLine(t *testing.T) {
+	// Source ending with \n produces an empty trailing element in f.Lines;
+	// PopulateSourceContext must not include it in context windows.
+	f := newTestFile(t, "line1\nline2\n")
+	diags := []lint.Diagnostic{{Line: 1, RuleID: "TST001"}}
+	checker.PopulateSourceContext(f, diags, 0)
+	require.Len(t, diags[0].SourceLines, 1)
+	assert.Equal(t, "line1", diags[0].SourceLines[0])
+}
+
+func TestCheckRulesWithIntraFile_concurrent_withNodeChecker(t *testing.T) {
+	// Mix a NodeChecker (check==nil slot) and a plain rule (check!=nil slot)
+	// with intraFileCap>1 so the concurrent branch hits the check==nil skip.
+	f := newTestFile(t, "# Hello\n\nParagraph.\n")
+	d := lint.Diagnostic{Line: 1, RuleID: "TST002", Message: "node"}
+	rules := []rule.Rule{
+		&plainRule{id: "TST001"},
+		&nodeCheckerRule{plainRule: plainRule{id: "TST002"}, diag: d},
+	}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001", "TST002"), true, 4)
+	assert.Empty(t, errs)
+	assert.NotEmpty(t, diags)
 }

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -1,77 +1,52 @@
 package engine
 
 import (
-	"fmt"
-	"sync"
-
+	"github.com/jeduden/mdsmith/internal/checker"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
-	"github.com/yuin/goldmark/ast"
 )
 
 // ConfigureRule clones a rule and applies settings from cfg if the rule
 // implements Configurable and cfg has settings. Returns the configured
 // rule (or the original if no settings apply) and any error from
 // ApplySettings.
+//
+// Deprecated: call checker.ConfigureRule directly. This wrapper exists
+// so internal/engine callers need not be updated all at once.
 func ConfigureRule(rl rule.Rule, cfg config.RuleCfg) (rule.Rule, error) {
-	if cfg.Settings == nil {
-		return rl, nil
-	}
-	if _, ok := rl.(rule.Configurable); !ok {
-		return rl, nil
-	}
-	clone := rule.CloneRule(rl)
-	if c, ok := clone.(rule.Configurable); ok {
-		if err := c.ApplySettings(cfg.Settings); err != nil {
-			return nil, fmt.Errorf("applying settings for %s: %w", rl.Name(), err)
-		}
-	}
-	return clone, nil
+	return checker.ConfigureRule(rl, cfg)
 }
 
 // CheckRules runs all enabled rules against f, cloning and applying
 // settings for Configurable rules. It adjusts diagnostics using
 // f.AdjustDiagnostics and returns the collected diagnostics and any
 // settings-application errors. Source context is populated; callers
-// that discard SourceLines should use checkRules with
-// skipSourceContext=true to avoid that allocation.
+// that discard SourceLines should use checker.CheckRulesWithIntraFile
+// with skipSourceContext=true to avoid that allocation.
+//
+// Deprecated: call checker.CheckRules directly. This wrapper exists
+// so external callers need not be updated all at once.
 func CheckRules(f *lint.File, rules []rule.Rule, effective map[string]config.RuleCfg) ([]lint.Diagnostic, []error) {
-	return checkRules(f, rules, effective, false)
+	return checker.CheckRules(f, rules, effective)
 }
 
-// checkRules is the core CheckRules implementation. skipSourceContext
-// suppresses populateSourceContext, whose per-diagnostic string copies
-// and []string windows were the single largest object count on the
-// check gate (~315 MB / 3.8M objects, plan 175 profiling) and are
-// unused when the caller never renders SourceLines (the benchmark, and
-// machine output that omits them). Defaults intra-file concurrency to
-// 1 (serial); callers that already resolved the cap use
-// checkRulesWithIntraFile directly.
+// checkRules is an engine-internal shim that delegates to
+// checker.CheckRulesWithIntraFile with skipSourceContext and
+// intraFileCap=1. Used by engine tests and runner.go call sites that
+// previously called this unexported function directly.
 func checkRules(
 	f *lint.File,
 	rules []rule.Rule,
 	effective map[string]config.RuleCfg,
 	skipSourceContext bool,
 ) ([]lint.Diagnostic, []error) {
-	return checkRulesWithIntraFile(f, rules, effective, skipSourceContext, 1)
+	return checker.CheckRulesWithIntraFile(f, rules, effective, skipSourceContext, 1)
 }
 
-// ruleSlot is one rule's diagnostic bucket. NodeCheckers append to
-// it from the shared walk; non-NodeCheckers fill it once via Check.
-// Slots are kept in rules order so the final concatenation reproduces
-// the sequential output exactly. Configure-failed rules never get a
-// slot — they short-circuit in classifyRules with an entry in errs.
-type ruleSlot struct {
-	nc    rule.NodeChecker
-	check rule.Rule // non-nil for non-NodeChecker slots
-	diags []lint.Diagnostic
-}
-
-// checkRulesWithIntraFile is the core implementation that accepts an
-// explicit intra-file concurrency cap. The lintFile path resolves the
-// cap once per Run (via resolveIntraFileWorkers) and passes it in here
-// so the per-file workers do not each query GOMAXPROCS.
+// checkRulesWithIntraFile delegates to checker.CheckRulesWithIntraFile.
+// Kept as an unexported engine-local shim so runner.go can call it
+// without changing its call sites.
 func checkRulesWithIntraFile(
 	f *lint.File,
 	rules []rule.Rule,
@@ -79,173 +54,11 @@ func checkRulesWithIntraFile(
 	skipSourceContext bool,
 	intraFileCap int,
 ) ([]lint.Diagnostic, []error) {
-	slots, nodeCheckers, errs := classifyRules(rules, effective)
-
-	// Run non-NodeChecker rules. With cap=1 the loop stays serial and
-	// matches the legacy code path byte-for-byte. With cap>1, slots
-	// run concurrently into their own buckets; rules order is
-	// preserved because the concatenation step reads `slots` in
-	// index order at the end.
-	runNonNodeCheckers(f, slots, intraFileCap)
-
-	// The shared walk runs after the goroutine workers join, so its
-	// node visitor and the rules running inside it never race for
-	// any per-rule state. NodeCheckers stay internally serial: one
-	// goroutine, one walk, one rule per node — fast enough that
-	// splitting per rule would lose the cache locality the multiplex
-	// just won.
-	if len(nodeCheckers) > 0 {
-		_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-			for _, s := range nodeCheckers {
-				s.diags = append(s.diags, s.nc.CheckNode(n, entering, f)...)
-			}
-			return ast.WalkContinue, nil
-		})
-	}
-
-	var diags []lint.Diagnostic
-	for _, s := range slots {
-		diags = append(diags, s.diags...)
-	}
-
-	diags = filterGeneratedDiags(diags, f.GeneratedRanges)
-	f.AdjustDiagnostics(diags)
-	if !skipSourceContext {
-		populateSourceContext(f, diags, 2)
-	}
-	return diags, errs
+	return checker.CheckRulesWithIntraFile(f, rules, effective, skipSourceContext, intraFileCap)
 }
 
-// classifyRules walks the rules list once, configures each enabled
-// rule via ConfigureRule (which clones and applies settings only
-// when cfg.Settings is non-nil and the rule is Configurable —
-// otherwise the worker's existing clone is reused as-is), and splits
-// the result into per-rule slots. The slots slice keeps every
-// enabled rule in input order (so the final concatenation is
-// deterministic); the nodeCheckers slice is the subset whose group
-// will be filled by the shared walk.
-func classifyRules(
-	rules []rule.Rule, effective map[string]config.RuleCfg,
-) (slots []ruleSlot, nodeCheckers []*ruleSlot, errs []error) {
-	// Pre-size at the registered-rule count. In production all but a
-	// handful of rules are enabled by default. Allocating slots as a
-	// value slice (rather than a slice of `*ruleSlot`) collapses the
-	// 50+ per-file pointer allocations the previous shape paid into
-	// one backing-array allocation. nodeCheckers stays a pointer
-	// slice but references entries by `&slots[i]`, which is stable
-	// because the slots cap was pre-set to len(rules) — no append
-	// grows the backing, so the index-derived pointers do not
-	// dangle.
-	slots = make([]ruleSlot, 0, len(rules))
-	for _, rl := range rules {
-		cfg, ok := effective[rl.Name()]
-		if !ok || !cfg.Enabled {
-			continue
-		}
-		checkRule, err := ConfigureRule(rl, cfg)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		if nc, ok := checkRule.(rule.NodeChecker); ok {
-			slots = append(slots, ruleSlot{nc: nc})
-			continue
-		}
-		slots = append(slots, ruleSlot{check: checkRule})
-	}
-	for i := range slots {
-		if slots[i].nc != nil {
-			if nodeCheckers == nil {
-				nodeCheckers = make([]*ruleSlot, 0, len(slots)/2+1)
-			}
-			nodeCheckers = append(nodeCheckers, &slots[i])
-		}
-	}
-	return slots, nodeCheckers, errs
-}
-
-// runNonNodeCheckers fills the non-NodeChecker slots' diags fields.
-// With cap<=1, runs serially (matches pre-plan-190 behaviour). With
-// cap>1, runs slots concurrently bounded by a semaphore so no more
-// than cap rule.Check calls execute at the same time. Each goroutine
-// writes only to its own slot, so the result needs no lock — slots
-// are concatenated in rules order after the workers join.
-//
-// The slots backing was pre-sized in classifyRules so `&slots[i]`
-// is stable for the lifetime of this call.
-func runNonNodeCheckers(f *lint.File, slots []ruleSlot, intraFileCap int) {
-	if intraFileCap <= 1 {
-		for i := range slots {
-			if slots[i].check == nil {
-				continue
-			}
-			slots[i].diags = slots[i].check.Check(f)
-		}
-		return
-	}
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, intraFileCap)
-	for i := range slots {
-		if slots[i].check == nil {
-			continue
-		}
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(slot *ruleSlot) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			slot.diags = slot.check.Check(f)
-		}(&slots[i])
-	}
-	wg.Wait()
-}
-
-// filterGeneratedDiags removes diagnostics whose line falls within any
-// of the generated section ranges. Called before AdjustDiagnostics, so
-// lines are still in post-front-matter coordinates matching the ranges.
+// filterGeneratedDiags delegates to checker.FilterGeneratedDiags.
+// Kept for engine-internal test callers that test the filter directly.
 func filterGeneratedDiags(diags []lint.Diagnostic, ranges []lint.LineRange) []lint.Diagnostic {
-	if len(ranges) == 0 {
-		return diags
-	}
-	out := diags[:0:len(diags)]
-	for _, d := range diags {
-		keep := true
-		for _, r := range ranges {
-			if r.Contains(d.Line) {
-				keep = false
-				break
-			}
-		}
-		if keep {
-			out = append(out, d)
-		}
-	}
-	return out
-}
-
-// populateSourceContext fills each diagnostic's SourceLines and
-// SourceStartLine with surrounding context from f.Lines.
-func populateSourceContext(f *lint.File, diags []lint.Diagnostic, context int) {
-	// bytes.Split produces an empty trailing element when source ends
-	// with a newline. Exclude it so context windows don't include a
-	// phantom empty line.
-	numLines := len(f.Lines)
-	if numLines > 0 && len(f.Lines[numLines-1]) == 0 {
-		numLines--
-	}
-
-	for i := range diags {
-		lineIdx := diags[i].Line - f.LineOffset - 1 // 0-based into f.Lines
-		if lineIdx < 0 || lineIdx >= numLines {
-			continue
-		}
-		start := max(0, lineIdx-context)
-		end := min(numLines, lineIdx+context+1)
-		lines := make([]string, end-start)
-		for j := start; j < end; j++ {
-			lines[j-start] = string(f.Lines[j])
-		}
-		diags[i].SourceLines = lines
-		diags[i].SourceStartLine = start + f.LineOffset + 1
-	}
+	return checker.FilterGeneratedDiags(diags, ranges)
 }

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -372,9 +372,9 @@ func (r *Runner) lintFile(path string, rules []rule.Rule, intraFileCap int, cach
 // print the same warning N times and duplicate that entry in the
 // returned diagnostics. Earlier-encountered duplicates win so the
 // diagnostic order from the first hit is preserved. The input slice
-// is never modified; nil input returns nil and a non-nil input
-// always produces a freshly-allocated slice so callers can keep the
-// original around without worrying about aliasing.
+// is never modified; nil and empty non-nil inputs return nil; a
+// non-empty input always produces a freshly-allocated slice so
+// callers can keep the original around without worrying about aliasing.
 //
 // Deprecated: call lint.DedupeDiagnostics directly. This wrapper exists
 // so existing callers need not be updated all at once.

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -375,37 +375,11 @@ func (r *Runner) lintFile(path string, rules []rule.Rule, intraFileCap int, cach
 // is never modified; nil input returns nil and a non-nil input
 // always produces a freshly-allocated slice so callers can keep the
 // original around without worrying about aliasing.
+//
+// Deprecated: call lint.DedupeDiagnostics directly. This wrapper exists
+// so existing callers need not be updated all at once.
 func DedupeDiagnostics(diags []lint.Diagnostic) []lint.Diagnostic {
-	if len(diags) == 0 {
-		return nil
-	}
-	if len(diags) == 1 {
-		return append([]lint.Diagnostic(nil), diags[0])
-	}
-	type key struct {
-		File    string
-		Line    int
-		Column  int
-		RuleID  string
-		Message string
-	}
-	seen := make(map[key]struct{}, len(diags))
-	out := make([]lint.Diagnostic, 0, len(diags))
-	for _, d := range diags {
-		k := key{
-			File:    d.File,
-			Line:    d.Line,
-			Column:  d.Column,
-			RuleID:  d.RuleID,
-			Message: d.Message,
-		}
-		if _, ok := seen[k]; ok {
-			continue
-		}
-		seen[k] = struct{}{}
-		out = append(out, d)
-	}
-	return out
+	return lint.DedupeDiagnostics(diags)
 }
 
 // RunSource lints in-memory source bytes (e.g. from stdin or an LSP

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/bytelimit"
+	"github.com/jeduden/mdsmith/internal/checker"
 	"github.com/jeduden/mdsmith/internal/config"
-	"github.com/jeduden/mdsmith/internal/engine"
 	"github.com/jeduden/mdsmith/internal/explain"
 	"github.com/jeduden/mdsmith/internal/gitignore"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -253,9 +253,9 @@ func (f *Fixer) fixOnce(paths []string) *Result {
 		}
 		res.Errors = append(res.Errors, errs...)
 	}
-	res.Failures = len(engine.DedupeDiagnostics(allBefore))
+	res.Failures = len(lint.DedupeDiagnostics(allBefore))
 
-	res.Diagnostics = engine.DedupeDiagnostics(res.Diagnostics)
+	res.Diagnostics = lint.DedupeDiagnostics(res.Diagnostics)
 	sort.Slice(res.Diagnostics, func(i, j int) bool {
 		di, dj := res.Diagnostics[i], res.Diagnostics[j]
 		if di.File != dj.File {
@@ -305,7 +305,7 @@ func (f *Fixer) fixFile(path string) (
 
 	fixable, settingsErrs := f.fixableRules(effective)
 	lf.GeneratedRanges = gensection.FindAllGeneratedRanges(lf)
-	beforeDiags, checkErrs := engine.CheckRules(lf, f.Rules, effective)
+	beforeDiags, checkErrs := checker.CheckRules(lf, f.Rules, effective)
 	errs = append(errs, append(settingsErrs, checkErrs...)...)
 
 	current := f.applyFixPasses(path, lf.Source, fixable, lf, dirFS, &errs)
@@ -327,7 +327,7 @@ func (f *Fixer) fixFile(path string) (
 
 	finalFile := buildPostFixFile(path, current, lf, dirFS)
 
-	diags, checkErrs := engine.CheckRules(finalFile, f.Rules, effective)
+	diags, checkErrs := checker.CheckRules(finalFile, f.Rules, effective)
 	errs = append(errs, checkErrs...)
 	if f.DryRun {
 		diags = subtractPredictedDryRunFixes(diags, fixable, finalFile)
@@ -399,8 +399,8 @@ func computeWouldFixAggregated(
 	allBefore, allAfter []lint.Diagnostic,
 	bytesChangedByPath map[string]bool,
 ) ([]WouldFixFile, int) {
-	beforeByFile := groupDiagsByFile(engine.DedupeDiagnostics(allBefore))
-	afterByFile := groupDiagsByFile(engine.DedupeDiagnostics(allAfter))
+	beforeByFile := groupDiagsByFile(lint.DedupeDiagnostics(allBefore))
+	afterByFile := groupDiagsByFile(lint.DedupeDiagnostics(allAfter))
 
 	files := make(map[string]struct{}, len(beforeByFile)+len(bytesChangedByPath))
 	for path := range beforeByFile {
@@ -708,7 +708,7 @@ func (f *Fixer) fixableRules(effective map[string]config.RuleCfg) ([]rule.Fixabl
 			continue
 		}
 
-		configured, err := engine.ConfigureRule(rl, cfg)
+		configured, err := checker.ConfigureRule(rl, cfg)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/internal/integration/fix_engine_boundary_test.go
+++ b/internal/integration/fix_engine_boundary_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 // TestFixDoesNotImportEngine guards the architecture rule that
-// internal/fix must not import internal/engine. The engine layer sits
-// above the fix layer, so the dependency arrow must point downward
-// (fix → shared helpers → engine), not upward (fix → engine).
+// internal/fix must not import internal/engine. Both layers sit above
+// internal/checker (shared helpers); each imports downward into helpers,
+// but fix must not import engine (that arrow would invert the layering).
 func TestFixDoesNotImportEngine(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)

--- a/internal/integration/fix_engine_boundary_test.go
+++ b/internal/integration/fix_engine_boundary_test.go
@@ -37,7 +37,7 @@ func TestFixDoesNotImportEngine(t *testing.T) {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
 

--- a/internal/integration/fix_engine_boundary_test.go
+++ b/internal/integration/fix_engine_boundary_test.go
@@ -1,0 +1,64 @@
+package integration
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFixDoesNotImportEngine guards the architecture rule that
+// internal/fix must not import internal/engine. The engine layer sits
+// above the fix layer, so the dependency arrow must point downward
+// (fix → shared helpers → engine), not upward (fix → engine).
+func TestFixDoesNotImportEngine(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// Tests run from internal/integration/; fix lives at ../fix relative to that.
+	fixRoot := filepath.Clean(filepath.Join(wd, "..", "fix"))
+	info, err := os.Stat(fixRoot)
+	require.NoError(t, err, "fix package root %s must exist", fixRoot)
+	require.True(t, info.IsDir(), "fix package root %s must be a directory", fixRoot)
+
+	const forbidden = "github.com/jeduden/mdsmith/internal/engine"
+	fset := token.NewFileSet()
+
+	err = filepath.WalkDir(fixRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(fixRoot, path)
+		if err != nil {
+			return err
+		}
+		for _, imp := range file.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if importPath == forbidden {
+				assert.Failf(t, "fix imports engine",
+					"internal/fix/%s imports internal/engine; "+
+						"engine sits above fix — move shared helpers to a lower package",
+					rel)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/internal/integration/rule_walk_audit_test.go
+++ b/internal/integration/rule_walk_audit_test.go
@@ -44,7 +44,7 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/config"
-	"github.com/jeduden/mdsmith/internal/engine"
+	"github.com/jeduden/mdsmith/internal/checker"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/require"
@@ -247,7 +247,7 @@ func runRuleForAudit(tb testing.TB, r rule.Rule, in auditProbeInput, src []byte,
 		applied = settings
 	}
 
-	cr, err := engine.ConfigureRule(r, config.RuleCfg{Settings: applied})
+	cr, err := checker.ConfigureRule(r, config.RuleCfg{Settings: applied})
 	require.NoError(tb, err, "configuring %s for fixture %s", r.ID(), in.label)
 
 	f, err := lint.NewFile("doc.md", src)

--- a/internal/integration/rule_walk_audit_test.go
+++ b/internal/integration/rule_walk_audit_test.go
@@ -43,8 +43,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/checker"
+	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/require"

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -118,7 +118,7 @@ type ExplanationLeaf struct {
 // two diagnostics are considered equal when their (File, Line, Column,
 // RuleID, Message) tuples match. Earlier-encountered duplicates win so
 // the diagnostic order from the first hit is preserved. The input slice
-// is never modified; nil input returns nil and a non-nil input always
+// is never modified; nil input returns nil and a non-empty input always
 // produces a freshly-allocated slice so callers can keep the original
 // around without worrying about aliasing.
 func DedupeDiagnostics(diags []Diagnostic) []Diagnostic {

--- a/internal/lint/diagnostic.go
+++ b/internal/lint/diagnostic.go
@@ -113,3 +113,43 @@ type ExplanationLeaf struct {
 	Value  any
 	Source string
 }
+
+// DedupeDiagnostics removes duplicate diagnostics from diags, where
+// two diagnostics are considered equal when their (File, Line, Column,
+// RuleID, Message) tuples match. Earlier-encountered duplicates win so
+// the diagnostic order from the first hit is preserved. The input slice
+// is never modified; nil input returns nil and a non-nil input always
+// produces a freshly-allocated slice so callers can keep the original
+// around without worrying about aliasing.
+func DedupeDiagnostics(diags []Diagnostic) []Diagnostic {
+	if len(diags) == 0 {
+		return nil
+	}
+	if len(diags) == 1 {
+		return append([]Diagnostic(nil), diags[0])
+	}
+	type key struct {
+		File    string
+		Line    int
+		Column  int
+		RuleID  string
+		Message string
+	}
+	seen := make(map[key]struct{}, len(diags))
+	out := make([]Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		k := key{
+			File:    d.File,
+			Line:    d.Line,
+			Column:  d.Column,
+			RuleID:  d.RuleID,
+			Message: d.Message,
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, d)
+	}
+	return out
+}

--- a/internal/lint/diagnostic_test.go
+++ b/internal/lint/diagnostic_test.go
@@ -80,6 +80,8 @@ func TestDiagnostic_DisplayLineClamp(t *testing.T) {
 	assert.Equal(t, 1, Diagnostic{Line: 0}.DisplayLine(), "zero clamps to 1")
 	assert.Equal(t, 1, Diagnostic{Line: -3}.DisplayLine(), "negative clamps to 1")
 	assert.Equal(t, 7, Diagnostic{Line: 7}.DisplayLine(), "real line passes through")
+}
+
 func TestDedupeDiagnostics_nil(t *testing.T) {
 	assert.Nil(t, DedupeDiagnostics(nil))
 }

--- a/internal/lint/diagnostic_test.go
+++ b/internal/lint/diagnostic_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiagnosticFields(t *testing.T) {
@@ -79,4 +80,26 @@ func TestDiagnostic_DisplayLineClamp(t *testing.T) {
 	assert.Equal(t, 1, Diagnostic{Line: 0}.DisplayLine(), "zero clamps to 1")
 	assert.Equal(t, 1, Diagnostic{Line: -3}.DisplayLine(), "negative clamps to 1")
 	assert.Equal(t, 7, Diagnostic{Line: 7}.DisplayLine(), "real line passes through")
+func TestDedupeDiagnostics_nil(t *testing.T) {
+	assert.Nil(t, DedupeDiagnostics(nil))
+}
+
+func TestDedupeDiagnostics_single(t *testing.T) {
+	d := Diagnostic{File: "a.md", Line: 1, RuleID: "MDS001", Message: "x"}
+	out := DedupeDiagnostics([]Diagnostic{d})
+	require.Len(t, out, 1)
+	assert.Equal(t, d, out[0])
+}
+
+func TestDedupeDiagnostics_removeDuplicates(t *testing.T) {
+	d := Diagnostic{File: "a.md", Line: 1, RuleID: "MDS001", Message: "x"}
+	out := DedupeDiagnostics([]Diagnostic{d, d})
+	require.Len(t, out, 1)
+}
+
+func TestDedupeDiagnostics_keepsDistinct(t *testing.T) {
+	d1 := Diagnostic{File: "a.md", Line: 1, RuleID: "MDS001", Message: "x"}
+	d2 := Diagnostic{File: "a.md", Line: 2, RuleID: "MDS001", Message: "x"}
+	out := DedupeDiagnostics([]Diagnostic{d1, d2})
+	require.Len(t, out, 2)
 }

--- a/plan/204_arch-fix-fix-engine-inversion.md
+++ b/plan/204_arch-fix-fix-engine-inversion.md
@@ -29,9 +29,9 @@ intended direction.
   has no other dependencies.
 - `CheckRules` and `ConfigureRule` moved to a new
   `internal/checker` package: both need `config.RuleCfg`,
-  `rule.Rule`, and `lint.File`. The `rule` package
-  already imports `config` (which imports `rule`), so
-  adding `config` to `rule` would cycle. A new
+  `rule.Rule`, and `lint.File`. The `config` package
+  already imports `rule`, so adding `config` to `rule`
+  would create a `rule → config → rule` cycle. A new
   `internal/checker` package sits below both
   `internal/engine` and `internal/fix` with no
   import of either.

--- a/plan/204_arch-fix-fix-engine-inversion.md
+++ b/plan/204_arch-fix-fix-engine-inversion.md
@@ -1,7 +1,7 @@
 ---
 id: 204
 title: Fix internal/fix importing internal/engine
-status: "🔲"
+status: "✅"
 summary: >-
   internal/fix/fix.go imports internal/engine for
   CheckRules, ConfigureRule, and DedupeDiagnostics.
@@ -22,30 +22,44 @@ the three functions to a package both
 engine and fix can import restores the
 intended direction.
 
+## Target package choice
+
+- `DedupeDiagnostics` moved to `internal/lint`:
+  it only operates on `lint.Diagnostic` values and
+  has no other dependencies.
+- `CheckRules` and `ConfigureRule` moved to a new
+  `internal/checker` package: both need `config.RuleCfg`,
+  `rule.Rule`, and `lint.File`. The `rule` package
+  already imports `config` (which imports `rule`), so
+  adding `config` to `rule` would cycle. A new
+  `internal/checker` package sits below both
+  `internal/engine` and `internal/fix` with no
+  import of either.
+
 ## Tasks
 
-1. Read `CheckRules`, `ConfigureRule`,
+1. [x] Read `CheckRules`, `ConfigureRule`,
    and `DedupeDiagnostics` and identify
    their dependencies.
-2. Choose the target package (`internal/lint`,
+2. [x] Choose the target package (`internal/lint`,
    `internal/rule`, or a new package).
    Document the choice here.
-3. Move the three functions.
-4. Update all callers in `internal/engine`
+3. [x] Move the three functions.
+4. [x] Update all callers in `internal/engine`
    and `internal/fix`.
-5. Verify `internal/fix` no longer
+5. [x] Verify `internal/fix` no longer
    imports `internal/engine`.
-6. Add a contract test in
+6. [x] Add a contract test in
    `internal/integration/` that fails if
    `internal/fix` imports `internal/engine`.
-7. Run `go build ./...` and
+7. [x] Run `go build ./...` and
    `go test ./...`.
 
 ## Acceptance Criteria
 
-- [ ] `grep -r --include='*.go' '".*internal/engine"' internal/fix/`
+- [x] `grep -r --include='*.go' '".*internal/engine"' internal/fix/`
   returns nothing.
-- [ ] A contract test guards the boundary.
-- [ ] `go build ./...` clean.
-- [ ] `go test ./...` passes.
-- [ ] `go tool golangci-lint run` clean.
+- [x] A contract test guards the boundary.
+- [x] `go build ./...` clean.
+- [x] `go test ./...` passes.
+- [x] `go tool golangci-lint run` clean.


### PR DESCRIPTION
## Summary

- Moves `CheckRules` and `ConfigureRule` to a new `internal/checker` package, and `DedupeDiagnostics` to `internal/lint`, so `internal/fix` no longer imports `internal/engine` (which sits above fix in the architecture layer map).
- `internal/engine/check.go` is reduced to thin shims that delegate to `checker`, keeping existing engine callers and tests working without changes.
- Adds an integration contract test (`internal/integration/fix_engine_boundary_test.go`) that fails if `internal/fix` ever re-imports `internal/engine`.

Implements plan 204.

## Package choice rationale

- `DedupeDiagnostics` only operates on `lint.Diagnostic` — it lives in `internal/lint`.
- `CheckRules` and `ConfigureRule` both need `config.RuleCfg`, `rule.Rule`, and `lint.File`. The `rule` package already imports `config` (which imports `rule`), so adding `config` to `rule` would cycle. A new `internal/checker` package sits below both `internal/engine` and `internal/fix` without importing either.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all packages green)
- [ ] `go tool golangci-lint run` reports 0 issues
- [ ] `TestFixDoesNotImportEngine` (new contract test) passes
- [ ] `grep -r --include='*.go' '".*internal/engine"' internal/fix/` returns nothing

https://claude.ai/code/session_01VRQYHghvjyN9kbSiEhxzwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRQYHghvjyN9kbSiEhxzwh)_