### PR TITLE
Fix merge-queue loop: resync .gitattributes and add `merge-driver ci-install`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,14 @@
 # BEGIN mdsmith merge-driver
 *.md merge=mdsmith
 *.markdown merge=mdsmith
+.git/** -merge
 demo/** -merge
 internal/rules/*/bad/** -merge
 internal/rules/*/bad.md -merge
 internal/rules/*/good/** -merge
 internal/rules/*/fixed/** -merge
+internal/rules/*/pattern/** -merge
 .claude/worktrees/** -merge
+editors/**/node_modules/** -merge
+editors/**/dist/** -merge
 # END mdsmith merge-driver

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -37,6 +37,14 @@ jobs:
 
       - uses: ./.github/actions/setup-mdsmith-pinned-version
       - name: Install mdsmith merge driver and pre-merge-commit hook
+        # NOTE: switch `merge-driver install` to `merge-driver ci-install`
+        # once the pinned baseline (setup-mdsmith-pinned-version) ships it.
+        # `install` re-renders .gitattributes from .mdsmith.yml; a drifted
+        # committed copy would be rewritten here, dirtying the worktree and
+        # aborting the action's `git merge` — which requeues the PR and
+        # re-fires the labeled trigger forever. `ci-install` verifies
+        # .gitattributes instead of writing it (it cannot dirty the tree)
+        # and fails loudly on drift, turning a loop into one clean red run.
         run: |
           mdsmith merge-driver install
           mdsmith pre-merge-commit install

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1400,6 +1400,65 @@ func TestE2E_MergeDriver_Install(t *testing.T) {
 	assert.NotEmpty(t, hookData, "installed hook must not be empty")
 }
 
+func TestE2E_MergeDriver_CIInstall_InSync(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run(), "git init")
+
+	// Seed an in-sync .gitattributes plus the driver and hook.
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install must succeed; stderr: %s", stderr)
+
+	attrPath := filepath.Join(dir, ".gitattributes")
+	before, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+
+	// ci-install verifies the committed file without rewriting it.
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "ci-install")
+	assert.Equal(t, 0, code,
+		"ci-install must succeed on an in-sync repo; stderr: %s", stderr)
+
+	after, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"ci-install must not modify .gitattributes")
+
+	// The driver is registered so `git merge` dispatches to it.
+	out, err := exec.Command("git", "-C", dir, "config", "merge.mdsmith.driver").Output()
+	require.NoError(t, err, "reading git config")
+	assert.Contains(t, string(out), "merge-driver run %O %A %B %P")
+
+	// The pre-merge-commit hook is installed (git-internal, untracked).
+	hookPath := filepath.Join(gitHooksDir(t, dir), "pre-merge-commit")
+	_, err = os.Stat(hookPath)
+	require.NoError(t, err, "ci-install must install the pre-merge-commit hook")
+}
+
+func TestE2E_MergeDriver_CIInstall_Drift_ExitsTwo(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", dir).Run(), "git init")
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install must succeed; stderr: %s", stderr)
+
+	attrPath := filepath.Join(dir, ".gitattributes")
+	before, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+
+	// Introduce drift: add an ignore pattern after install, so the
+	// committed .gitattributes no longer matches .mdsmith.yml.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("ignore:\n  - \"vendor/**\"\n"), 0o644))
+
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "ci-install")
+	assert.Equal(t, 2, code, "ci-install must fail on drift; stderr: %s", stderr)
+	assert.Contains(t, stderr, "out of sync")
+
+	after, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"ci-install must not modify .gitattributes on drift")
+}
+
 func TestE2E_MergeDriver_Install_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -45,17 +45,19 @@ Subcommands:
   ci-install
         Like install, but treats the committed .gitattributes as
         the source of truth instead of rewriting it — the npm-ci
-        analogue of install's npm-install. It registers the merge
-        driver and installs the pre-merge-commit hook (both
-        git-internal and untracked), then verifies that the
-        committed managed block matches the globs derived from
-        .mdsmith.yml. It exits non-zero if .gitattributes is
-        missing, has no managed block, or has drifted, and never
-        writes the file. Use it in CI and the merge queue, where
-        rewriting a tracked file mid-run would dirty the worktree
-        and abort the merge. Takes no glob arguments; it always
-        compares against the canonical default include set, so it
-        is incompatible with custom-glob installs (same as MDS048).
+        analogue of install's npm-install. It first verifies that
+        the committed managed block matches the globs derived from
+        .mdsmith.yml, and only then registers the merge driver and
+        installs the pre-merge-commit hook (both git-internal and
+        untracked). It exits non-zero — before touching git config
+        or the hook — if .gitattributes is missing, has no managed
+        block, or has drifted, and never writes the file, so a
+        failing run leaves the repository untouched. Use it in CI
+        and the merge queue, where rewriting a tracked file mid-run
+        would dirty the worktree and abort the merge. Takes no glob
+        arguments; it always compares against the canonical default
+        include set, so it is incompatible with custom-glob installs
+        (same as MDS048).
 
 Git config (set by install / ci-install):
   merge.mdsmith.driver = '/absolute/path/to/mdsmith' merge-driver run %O %A %B %P
@@ -685,13 +687,28 @@ func runMergeDriverCIInstall(args []string) int {
 	return 0
 }
 
+// osReadFile is a variable so tests can substitute a failing
+// implementation to exercise the read-error path in verifyGitattributes.
+var osReadFile = os.ReadFile
+
 // verifyGitattributes checks that the mdsmith managed block in the
 // committed .gitattributes at attrPath matches expected, without ever
 // writing the file. It returns 0 when they match. On a missing file, a
 // missing managed block, or drift it prints a message naming the fix
 // (`mdsmith merge-driver install`) and returns 2.
+//
+// It rejects a symlinked or otherwise non-regular .gitattributes before
+// reading, mirroring the lstat guard install applies in
+// githooks.WriteGitattributes, so ci-install cannot be tricked into
+// reading a path outside the repository. A missing file (ENOENT) passes
+// the guard and is reported as "not found" below.
 func verifyGitattributes(attrPath string, expected githooks.Globs) int {
-	data, err := os.ReadFile(attrPath)
+	if err := guardFn(attrPath); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
+	data, err := osReadFile(attrPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr,

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -53,12 +53,12 @@ Subcommands:
         .gitattributes is missing, has no managed block, or has
         drifted it exits before registering the driver or
         installing the hook, so a drift error leaves the
-        repository untouched. Use it in CI
-        and the merge queue, where rewriting a tracked file mid-run
-        would dirty the worktree and abort the merge. Takes no glob
-        arguments; it always compares against the canonical default
-        include set, so it is incompatible with custom-glob installs
-        (same as MDS048).
+        repository untouched. Use it in CI and the merge queue,
+        where rewriting a tracked file mid-run would dirty the
+        worktree and abort the merge. Takes no glob arguments; it
+        always compares against the canonical default include set,
+        so it is incompatible with custom-glob installs (same as
+        MDS048).
 
 Git config (set by install / ci-install):
   merge.mdsmith.driver = '/absolute/path/to/mdsmith' merge-driver run %O %A %B %P

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -699,9 +699,10 @@ var osReadFile = os.ReadFile
 //
 // It rejects a symlinked or otherwise non-regular .gitattributes before
 // reading, mirroring the lstat guard install applies in
-// githooks.WriteGitattributes, so ci-install cannot be tricked into
-// reading a path outside the repository. A missing file (ENOENT) passes
-// the guard and is reported as "not found" below.
+// githooks.WriteGitattributes, to reduce the risk of following a link to
+// a path outside the repository. As there, a narrow TOCTOU window
+// remains between this guard and the read. A missing file (ENOENT)
+// passes the guard and is reported as "not found" below.
 func verifyGitattributes(attrPath string, expected githooks.Globs) int {
 	if err := guardFn(attrPath); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -49,10 +49,11 @@ Subcommands:
         the committed managed block matches the globs derived from
         .mdsmith.yml, and only then registers the merge driver and
         installs the pre-merge-commit hook (both git-internal and
-        untracked). It exits non-zero — before touching git config
-        or the hook — if .gitattributes is missing, has no managed
-        block, or has drifted, and never writes the file, so a
-        failing run leaves the repository untouched. Use it in CI
+        untracked). It never writes .gitattributes, and when
+        .gitattributes is missing, has no managed block, or has
+        drifted it exits before registering the driver or
+        installing the hook, so a drift error leaves the
+        repository untouched. Use it in CI
         and the merge queue, where rewriting a tracked file mid-run
         would dirty the worktree and abort the merge. Takes no glob
         arguments; it always compares against the canonical default

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -42,7 +42,22 @@ Subcommands:
         excludes; do not enable git-hook-sync if you rely on a
         custom include set.
 
-Git config (set by install):
+  ci-install
+        Like install, but treats the committed .gitattributes as
+        the source of truth instead of rewriting it — the npm-ci
+        analogue of install's npm-install. It registers the merge
+        driver and installs the pre-merge-commit hook (both
+        git-internal and untracked), then verifies that the
+        committed managed block matches the globs derived from
+        .mdsmith.yml. It exits non-zero if .gitattributes is
+        missing, has no managed block, or has drifted, and never
+        writes the file. Use it in CI and the merge queue, where
+        rewriting a tracked file mid-run would dirty the worktree
+        and abort the merge. Takes no glob arguments; it always
+        compares against the canonical default include set, so it
+        is incompatible with custom-glob installs (same as MDS048).
+
+Git config (set by install / ci-install):
   merge.mdsmith.driver = '/absolute/path/to/mdsmith' merge-driver run %O %A %B %P
 
   The path is the absolute location of the mdsmith binary at install time,
@@ -64,6 +79,8 @@ func runMergeDriver(args []string) int {
 		return runMergeDriverRun(args[1:])
 	case "install":
 		return runMergeDriverInstall(args[1:])
+	case "ci-install":
+		return runMergeDriverCIInstall(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr,
 			"mdsmith: merge-driver: unknown subcommand %q\n\n%s",
@@ -594,6 +611,119 @@ func runMergeDriverInstall(args []string) int {
 	fmt.Fprintf(os.Stderr,
 		"\nTo also enable drift detection, add this to your .mdsmith.yml:\n\n%s\n",
 		githooks.EnableRuleSnippet("git-hook-sync"))
+	return 0
+}
+
+// runMergeDriverCIInstall is the npm-ci analogue of install: it sets up
+// the merge machinery (git config driver entry, pre-merge-commit hook)
+// but treats the committed .gitattributes as the source of truth rather
+// than rewriting it. It verifies that the committed managed block
+// matches the glob set derived from .mdsmith.yml and exits non-zero on a
+// missing block or drift.
+//
+// The merge queue runs this instead of install: install re-renders
+// .gitattributes from .mdsmith.yml, so a committed copy that has drifted
+// gets rewritten, dirtying the worktree and aborting the action's
+// `git merge` ("local changes would be overwritten") — which requeues
+// the PR and re-fires the labeled trigger forever. ci-install never
+// writes the tracked file, so the merge always starts from a clean tree;
+// genuine drift surfaces as one clear failed setup step (which does not
+// requeue) instead of an infinite loop.
+func runMergeDriverCIInstall(args []string) int {
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		fmt.Fprint(os.Stderr, mergeDriverUsage)
+		return 0
+	}
+	if len(args) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: merge-driver ci-install takes no glob arguments; it "+
+				"verifies the committed .gitattributes against .mdsmith.yml "+
+				"without rewriting it\n")
+		return 2
+	}
+
+	// Verify we're in a git repo.
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: not in a git repository\n")
+		return 2
+	}
+	repoRoot := strings.TrimSpace(string(out))
+
+	// Compute the expected glob set exactly as install would write it,
+	// so the two commands can never disagree on what "in sync" means.
+	// nil args means the canonical default include set plus the
+	// .mdsmith.yml ignore-derived -merge overrides.
+	expected, rc := resolveManagedGlobs(repoRoot, nil)
+	if rc != 0 {
+		return rc
+	}
+
+	// Verify the committed .gitattributes matches — never write it.
+	attrPath := filepath.Join(repoRoot, ".gitattributes")
+	if rc := verifyGitattributes(attrPath, expected); rc != 0 {
+		return rc
+	}
+
+	if err := registerMergeDriver(); err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
+	}
+
+	if err := ensurePreMergeCommitHook(repoRoot); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: installing pre-merge-commit hook: %v\n", err)
+		return 2
+	}
+
+	hookPath := filepath.Join(resolveHooksDir(repoRoot), "pre-merge-commit")
+	fmt.Fprintf(os.Stderr, "mdsmith: merge driver 'mdsmith' verified and installed (ci mode)\n")
+	fmt.Fprintf(os.Stderr, "  git config: merge.mdsmith.driver\n")
+	fmt.Fprintf(os.Stderr, "  .gitattributes: %s (verified in sync; not modified)\n", attrPath)
+	fmt.Fprintf(os.Stderr, "  pre-merge-commit hook: %s\n", hookPath)
+	return 0
+}
+
+// verifyGitattributes checks that the mdsmith managed block in the
+// committed .gitattributes at attrPath matches expected, without ever
+// writing the file. It returns 0 when they match. On a missing file, a
+// missing managed block, or drift it prints a message naming the fix
+// (`mdsmith merge-driver install`) and returns 2.
+func verifyGitattributes(attrPath string, expected githooks.Globs) int {
+	data, err := os.ReadFile(attrPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr,
+				"mdsmith: %s not found; run `mdsmith merge-driver install` "+
+					"and commit the result\n", attrPath)
+			return 2
+		}
+		fmt.Fprintf(os.Stderr, "mdsmith: reading %s: %v\n", attrPath, err)
+		return 2
+	}
+
+	installed, ok := githooks.ExtractGlobs(string(data))
+	if !ok {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: %s has no mdsmith merge-driver managed block; run "+
+				"`mdsmith merge-driver install` and commit the result\n",
+			attrPath)
+		return 2
+	}
+
+	if !githooks.GlobsEqual(installed, expected) {
+		fmt.Fprintf(os.Stderr,
+			"mdsmith: committed .gitattributes is out of sync with "+
+				".mdsmith.yml; run `mdsmith merge-driver install` and commit "+
+				"the result\n"+
+				"  committed: include=%v exclude=%v\n"+
+				"  expected:  include=%v exclude=%v\n",
+			installed.Include, installed.Exclude,
+			expected.Include, expected.Exclude)
+		return 2
+	}
+
 	return 0
 }
 

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1382,9 +1382,11 @@ func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {
 
 func TestRunMergeDriver_CIInstall_HelpFlag_ExitsZero(t *testing.T) {
 	for _, flag := range []string{"--help", "-h"} {
-		captureStderr(func() {
+		got := captureStderr(func() {
 			assert.Equal(t, 0, runMergeDriver([]string{"ci-install", flag}))
 		})
+		assert.Contains(t, got, "Usage: mdsmith merge-driver",
+			"help must print the usage banner for %q, not just exit 0", flag)
 	}
 }
 
@@ -1595,7 +1597,13 @@ func TestRunMergeDriver_CIInstall_RegisterDriverError(t *testing.T) {
 	got := captureStderr(func() {
 		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
 	})
+	// Pin the failure to the registration step: a hook-step failure
+	// would carry ci-install's "installing pre-merge-commit hook:"
+	// prefix, which registerMergeDriver's bare error does not — so its
+	// absence proves we failed before the hook was touched.
 	assert.Contains(t, got, "cannot locate mdsmith binary")
+	assert.NotContains(t, got, "installing pre-merge-commit hook",
+		"must fail at registerMergeDriver, before the hook step")
 }
 
 // When verification and driver registration pass but a user-authored
@@ -1627,7 +1635,11 @@ func TestRunMergeDriver_CIInstall_HookError_UnmanagedHook(t *testing.T) {
 	got := captureStderr(func() {
 		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
 	})
-	assert.Contains(t, got, "pre-merge-commit")
+	// Assert the specific refusal text, not just "pre-merge-commit" —
+	// that substring also appears in the success message and the usage
+	// banner, so it would not distinguish the unmanaged-hook branch from
+	// a different hook failure.
+	assert.Contains(t, got, "not managed by mdsmith")
 }
 
 // --- verifyGitattributes ---
@@ -1658,5 +1670,8 @@ func TestVerifyGitattributes_ReadError_ReturnsTwo(t *testing.T) {
 	got := captureStderr(func() {
 		assert.Equal(t, 2, verifyGitattributes(attr, githooks.Globs{}))
 	})
+	// Assert the injected error is surfaced, not just the generic
+	// "reading" prefix, so a swallowed underlying error fails the test.
 	assert.Contains(t, got, "reading")
+	assert.Contains(t, got, "boom")
 }

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1381,9 +1381,11 @@ func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {
 // --- merge-driver ci-install (npm-ci-style: verify, never write) ---
 
 func TestRunMergeDriver_CIInstall_HelpFlag_ExitsZero(t *testing.T) {
-	captureStderr(func() {
-		assert.Equal(t, 0, runMergeDriver([]string{"ci-install", "--help"}))
-	})
+	for _, flag := range []string{"--help", "-h"} {
+		captureStderr(func() {
+			assert.Equal(t, 0, runMergeDriver([]string{"ci-install", flag}))
+		})
+	}
 }
 
 func TestRunMergeDriver_CIInstall_NotInRepo(t *testing.T) {
@@ -1523,4 +1525,138 @@ func TestRunMergeDriver_CIInstall_Drift_Fails(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(before), string(after),
 		"ci-install must not modify .gitattributes even on drift")
+}
+
+func TestRunMergeDriver_CIInstall_LoadConfigError(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("not: [valid: yaml\n"), 0o644))
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "loading config")
+}
+
+// pathWithOnlyGit points PATH at a temp dir holding just a `git` symlink
+// for the rest of the test. resolveInstalledBinary's PATH and $GOPATH
+// lookups then fail (no `mdsmith`, and no `go` to query GOPATH) while the
+// merge-driver's own `git rev-parse` still resolves. Skips on Windows,
+// where os.Symlink needs privilege; the coverage gate runs on Linux.
+func pathWithOnlyGit(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink-based PATH isolation is POSIX-only")
+	}
+	gitPath, err := exec.LookPath("git")
+	require.NoError(t, err, "git must be on PATH for this test")
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(gitPath, filepath.Join(binDir, "git")))
+	t.Setenv("PATH", binDir)
+}
+
+// When verification passes but the binary cannot be located, ci-install
+// must surface registerMergeDriver's error and exit 2 — before writing
+// the hook.
+func TestRunMergeDriver_CIInstall_RegisterDriverError(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	// In-sync .gitattributes so verification passes and control reaches
+	// registerMergeDriver.
+	captureStderr(func() {
+		require.Equal(t, 0, runMergeDriver([]string{"install"}))
+	})
+
+	// Make the binary unlocatable (transient exe + a PATH without
+	// mdsmith or go), keeping git available for `rev-parse`.
+	executableFunc = func() (string, error) {
+		return filepath.Join(os.TempDir(), "go-run-fake", "mdsmith"), nil
+	}
+	pathWithOnlyGit(t)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "cannot locate mdsmith binary")
+}
+
+// When verification and driver registration pass but a user-authored
+// (unmanaged) pre-merge-commit hook is present, ci-install must surface
+// ensurePreMergeCommitHook's refusal and exit 2.
+func TestRunMergeDriver_CIInstall_HookError_UnmanagedHook(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	// install writes an in-sync .gitattributes plus a managed hook.
+	captureStderr(func() {
+		require.Equal(t, 0, runMergeDriver([]string{"install"}))
+	})
+
+	// Replace the managed hook with an unmanaged one so
+	// ensurePreMergeCommitHook refuses to overwrite it.
+	hookPath := filepath.Join(dir, ".git", "hooks", "pre-merge-commit")
+	require.NoError(t, os.WriteFile(hookPath,
+		[]byte("#!/bin/sh\necho user\n"), 0o755))
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "pre-merge-commit")
+}
+
+// --- verifyGitattributes ---
+
+// A non-regular .gitattributes (here a directory) must be rejected by
+// the lstat guard before any read, so ci-install cannot be tricked into
+// reading a path outside the repository.
+func TestVerifyGitattributes_NonRegularFile_ReturnsTwo(t *testing.T) {
+	dir := t.TempDir()
+	attr := filepath.Join(dir, ".gitattributes")
+	require.NoError(t, os.Mkdir(attr, 0o755))
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, verifyGitattributes(attr, githooks.Globs{}))
+	})
+	assert.Contains(t, got, "not a regular file")
+}
+
+func TestVerifyGitattributes_ReadError_ReturnsTwo(t *testing.T) {
+	dir := t.TempDir()
+	attr := filepath.Join(dir, ".gitattributes")
+	require.NoError(t, os.WriteFile(attr, []byte("x"), 0o644))
+
+	orig := osReadFile
+	t.Cleanup(func() { osReadFile = orig })
+	osReadFile = func(string) ([]byte, error) { return nil, fmt.Errorf("boom") }
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, verifyGitattributes(attr, githooks.Globs{}))
+	})
+	assert.Contains(t, got, "reading")
 }

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1377,3 +1377,150 @@ func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
 		"fixAtRealPath must preserve the original permissions of ours")
 }
+
+// --- merge-driver ci-install (npm-ci-style: verify, never write) ---
+
+func TestRunMergeDriver_CIInstall_HelpFlag_ExitsZero(t *testing.T) {
+	captureStderr(func() {
+		assert.Equal(t, 0, runMergeDriver([]string{"ci-install", "--help"}))
+	})
+}
+
+func TestRunMergeDriver_CIInstall_NotInRepo(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"),
+		[]byte("not a real gitdir"), 0o644))
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "not in a git repository")
+}
+
+// ci-install verifies the committed .gitattributes against .mdsmith.yml
+// rather than scoping a fresh install, so it rejects the positional glob
+// args that `install` accepts.
+func TestRunMergeDriver_CIInstall_RejectsGlobArgs(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install", "docs/**/*.md"}))
+	})
+	assert.Contains(t, got, "no glob arguments")
+}
+
+func TestRunMergeDriver_CIInstall_MissingGitattributes_Fails(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "merge-driver install",
+		"a missing .gitattributes must name the fix command")
+}
+
+func TestRunMergeDriver_CIInstall_NoManagedBlock_Fails(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitattributes"),
+		[]byte("*.txt text\n"), 0o644))
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "managed block")
+}
+
+func TestRunMergeDriver_CIInstall_InSync_DoesNotModifyGitattributes(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	// install writes a canonical, in-sync .gitattributes.
+	captureStderr(func() {
+		require.Equal(t, 0, runMergeDriver([]string{"install"}))
+	})
+	attrPath := filepath.Join(dir, ".gitattributes")
+	before, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+
+	got := captureStderr(func() {
+		assert.Equal(t, 0, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "verified")
+
+	after, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"ci-install must not modify .gitattributes")
+}
+
+// Drift is the exact condition that bounced the merge queue: an ignore
+// pattern added to .mdsmith.yml without regenerating .gitattributes.
+// ci-install must catch it and fail loudly without rewriting the file
+// (which is what would dirty the worktree and abort the queue's merge).
+func TestRunMergeDriver_CIInstall_Drift_Fails(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	orig := executableFunc
+	t.Cleanup(func() { executableFunc = orig })
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+
+	origWd, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	captureStderr(func() {
+		require.Equal(t, 0, runMergeDriver([]string{"install"}))
+	})
+	attrPath := filepath.Join(dir, ".gitattributes")
+	before, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+
+	// Add an ignore pattern so the expected glob set diverges from the
+	// committed .gitattributes.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("ignore:\n  - \"vendor/**\"\n"), 0o644))
+
+	got := captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriver([]string{"ci-install"}))
+	})
+	assert.Contains(t, got, "out of sync")
+
+	after, err := os.ReadFile(attrPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"ci-install must not modify .gitattributes even on drift")
+}

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -72,7 +72,7 @@ Driver entrypoint, invoked by Git. Not normally called by
 hand. After `install`, Git will dispatch to it whenever
 merging a file marked `merge=mdsmith`.
 
-## Git config (set by `install`)
+## Git config (set by `install` / `ci-install`)
 
 ```text
 merge.mdsmith.driver = '/abs/path/to/mdsmith' merge-driver run %O %A %B %P
@@ -86,6 +86,7 @@ at install time, shell-quoted so paths with spaces work.
 ```bash
 mdsmith merge-driver install
 mdsmith merge-driver install 'docs/**/*.md'
+mdsmith merge-driver ci-install   # CI / merge queue: verify, don't write
 ```
 
 After `install`, a merge with conflicts inside a

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -41,14 +41,16 @@ custom includes.
 Like `install`, but it treats the committed
 `.gitattributes` as the source of truth instead of
 rewriting it. This is the `npm ci` analogue of `install`'s
-`npm install`. It registers the merge driver in
-`git config` and installs the pre-merge-commit hook. Both
-live under `.git/`, so they are untracked.
+`npm install`. It first checks the committed managed block
+against the globs derived from `.mdsmith.yml`. It never
+writes the file. It exits non-zero when `.gitattributes`
+is missing, has no managed block, or has drifted.
 
-It then checks the committed managed block against the
-globs derived from `.mdsmith.yml`. It never writes the
-file. It exits non-zero when `.gitattributes` is missing,
-has no managed block, or has drifted.
+Only after that check passes does it register the merge
+driver in `git config` and install the pre-merge-commit
+hook. Both live under `.git/`, so they are untracked. A
+failing run touches neither, so it leaves the repository
+in place.
 
 Run it in CI and the merge queue. There, `install` would
 re-render `.gitattributes` mid-run. A drifted committed

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -48,9 +48,8 @@ is missing, has no managed block, or has drifted.
 
 Only after that check passes does it register the merge
 driver in `git config` and install the pre-merge-commit
-hook. Both live under `.git/`, so they are untracked. A
-failing run touches neither, so it leaves the repository
-in place.
+hook. Both are git-internal and untracked. A failing run
+touches neither, so it leaves the repository in place.
 
 Run it in CI and the merge queue. There, `install` would
 re-render `.gitattributes` mid-run. A drifted committed

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -48,8 +48,9 @@ is missing, has no managed block, or has drifted.
 
 Only after that check passes does it register the merge
 driver in `git config` and install the pre-merge-commit
-hook. Both are git-internal and untracked. A failing run
-touches neither, so it leaves the repository in place.
+hook. Both are git-internal and untracked. A failed
+verification exits before either, so a drift error leaves
+the repository in place.
 
 Run it in CI and the merge queue. There, `install` would
 re-render `.gitattributes` mid-run. A drifted committed

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -69,8 +69,8 @@ MDS048.
 ### `run <base> <ours> <theirs> <pathname>`
 
 Driver entrypoint, invoked by Git. Not normally called by
-hand. After `install`, Git will dispatch to it whenever
-merging a file marked `merge=mdsmith`.
+hand. After `install` or `ci-install`, Git will dispatch to
+it whenever merging a file marked `merge=mdsmith`.
 
 ## Git config (set by `install` / `ci-install`)
 

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -36,6 +36,34 @@ Custom include globs are not compatible with MDS048
 default set; do not enable `git-hook-sync` if you rely on
 custom includes.
 
+### `ci-install`
+
+Like `install`, but it treats the committed
+`.gitattributes` as the source of truth instead of
+rewriting it. This is the `npm ci` analogue of `install`'s
+`npm install`. It registers the merge driver in
+`git config` and installs the pre-merge-commit hook. Both
+live under `.git/`, so they are untracked.
+
+It then checks the committed managed block against the
+globs derived from `.mdsmith.yml`. It never writes the
+file. It exits non-zero when `.gitattributes` is missing,
+has no managed block, or has drifted.
+
+Run it in CI and the merge queue. There, `install` would
+re-render `.gitattributes` mid-run. A drifted committed
+copy would be rewritten, which dirties the worktree. That
+aborts the in-progress `git merge`, requeues the PR, and
+re-fires the labeled trigger forever. `ci-install` never
+writes the tracked file. The merge starts from a clean
+tree, and real drift fails one setup step loudly instead
+of looping.
+
+`ci-install` takes no glob arguments. It always compares
+against the canonical default include set. So it is
+incompatible with custom-glob installs, the same as
+MDS048.
+
 ### `run <base> <ours> <theirs> <pathname>`
 
 Driver entrypoint, invoked by Git. Not normally called by

--- a/internal/integration/gitattributes_sync_test.go
+++ b/internal/integration/gitattributes_sync_test.go
@@ -64,6 +64,6 @@ func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
 	assert.True(t, githooks.GlobsEqual(installed, expected),
 		"committed .gitattributes is out of sync with .mdsmith.yml — run "+
 			"`mdsmith merge-driver install` (or `mdsmith fix`) and commit the "+
-			"result.\n  committed exclude: %v\n  expected  exclude: %v",
-		installed.Exclude, expected.Exclude)
+			"result.\n  committed: include=%v exclude=%v\n  expected:  include=%v exclude=%v",
+		installed.Include, installed.Exclude, expected.Include, expected.Exclude)
 }

--- a/internal/integration/gitattributes_sync_test.go
+++ b/internal/integration/gitattributes_sync_test.go
@@ -17,9 +17,16 @@ func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 	for {
-		if _, err := os.Stat(filepath.Join(dir, ".mdsmith.yml")); err == nil {
+		marker := filepath.Join(dir, ".mdsmith.yml")
+		_, statErr := os.Stat(marker)
+		if statErr == nil {
 			return dir
 		}
+		// Only "does not exist" means "keep climbing". Any other stat
+		// error (e.g. a permission problem on a parent directory) is a
+		// real failure and must surface with its own message instead of
+		// being masked by the eventual "reached the filesystem root".
+		require.True(t, os.IsNotExist(statErr), "stat %s: %v", marker, statErr)
 		parent := filepath.Dir(dir)
 		require.NotEqual(t, parent, dir,
 			"reached the filesystem root without finding .mdsmith.yml")

--- a/internal/integration/gitattributes_sync_test.go
+++ b/internal/integration/gitattributes_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/githooks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +53,14 @@ func findRepoRoot(t *testing.T) string {
 func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
 	root := findRepoRoot(t)
 
-	expected := githooks.LoadGlobs(root)
+	// Load .mdsmith.yml with error-checking rather than githooks.LoadGlobs,
+	// which silently falls back to default globs on a missing or
+	// unparseable config. A broken config must fail this gate loudly, not
+	// slip through comparing against defaults (or fail later with a
+	// misleading "run merge-driver install" message).
+	cfg, err := config.Load(filepath.Join(root, ".mdsmith.yml"))
+	require.NoError(t, err, "repository .mdsmith.yml must load and parse")
+	expected, _ := githooks.GlobsFromConfig(cfg)
 
 	data, err := os.ReadFile(filepath.Join(root, ".gitattributes"))
 	require.NoError(t, err, "repository .gitattributes must exist")

--- a/internal/integration/gitattributes_sync_test.go
+++ b/internal/integration/gitattributes_sync_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/githooks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findRepoRoot walks up from the test's working directory until it
+// finds the directory that holds .mdsmith.yml — the repository root.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".mdsmith.yml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, parent, dir,
+			"reached the filesystem root without finding .mdsmith.yml")
+		dir = parent
+	}
+}
+
+// TestRepoGitattributesInSyncWithConfig dogfoods this repository's own
+// committed .gitattributes against its .mdsmith.yml.
+//
+// It guards the exact state that put the merge queue into an infinite
+// loop: the queue runs `mdsmith merge-driver install`, which re-renders
+// .gitattributes from .mdsmith.yml's ignore list. When the committed
+// copy has drifted (an ignore pattern was added without regenerating
+// .gitattributes), the re-render dirties the worktree, the action's
+// `git merge` aborts with "local changes would be overwritten",
+// the PR is requeued, and the labeled trigger fires again — forever.
+//
+// MDS048 already reports this drift in `mdsmith check`; asserting it
+// here pins the invariant at the `go test` gate too, so a stale
+// .gitattributes cannot reach main and bounce the queue. The failure
+// message names the fix.
+func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
+	root := findRepoRoot(t)
+
+	expected := githooks.LoadGlobs(root)
+
+	data, err := os.ReadFile(filepath.Join(root, ".gitattributes"))
+	require.NoError(t, err, "repository .gitattributes must exist")
+
+	installed, ok := githooks.ExtractGlobs(string(data))
+	require.True(t, ok,
+		"committed .gitattributes has no mdsmith merge-driver managed block")
+
+	assert.True(t, githooks.GlobsEqual(installed, expected),
+		"committed .gitattributes is out of sync with .mdsmith.yml — run "+
+			"`mdsmith merge-driver install` (or `mdsmith fix`) and commit the "+
+			"result.\n  committed exclude: %v\n  expected  exclude: %v",
+		installed.Exclude, expected.Exclude)
+}


### PR DESCRIPTION
## What was looping

The **Merge Queue** workflow ran 30+ times in ~3 minutes across 4 PRs, each ending in `cancelled`/`failure`. Every run hit the same deterministic failure:

```
##[error]merging PR #445: git merge failed (exit 2): error: Your local
changes to the following files would be overwritten by merge: .gitattributes
Please commit your changes or stash them before you merge. Aborting
```

## Root cause

`merge-queue.yml` runs `mdsmith merge-driver install` before the action merges PRs into a batch branch. That command re-renders the tracked `.gitattributes` managed block from `.mdsmith.yml`'s `ignore:` list. The committed block was **stale** — four `ignore:` patterns were added to `.mdsmith.yml` without regenerating `.gitattributes`:

- `.git/**`
- `internal/rules/*/pattern/**`
- `editors/**/node_modules/**`
- `editors/**/dist/**`

So `install` left `.gitattributes` modified in the worktree, the action's local `git merge` aborted ("local changes would be overwritten"), the action **requeued** the PRs (re-adding the `queue` label), and the `pull_request: labeled` trigger fired the workflow again → **infinite loop**. The same drift made `mdsmith check .` red on `main` (MDS048 git-hook-sync), so `main` itself was already broken; every PR inherited the stale file.

## Two-part fix

This PR stops the loop **today** and makes it **structurally unreachable** going forward.

### 1. Resync `.gitattributes` (immediate fix)

Regenerate the managed block so it matches `.mdsmith.yml`. `mdsmith check .` goes green and the queue's `merge-driver install` becomes a worktree no-op (idempotent), so the merge can no longer abort on it.

A red/green dogfood guard (`internal/integration/gitattributes_sync_test.go`) asserts the committed `.gitattributes` stays in sync with `.mdsmith.yml` at the `go test` gate, mirroring MDS048's own `GlobsEqual` check. A future `ignore:` edit that forgets to regenerate `.gitattributes` now fails CI here too, so the drift can't reach `main` and bounce the queue again.

There is **no version skew**: the pinned baseline (`v0.29.0`, used by the queue) and HEAD render the identical managed block from the same `.mdsmith.yml`, so resync alone is sufficient. An earlier `merge-driver install --no-gitattributes` flag and a `git checkout -- .gitattributes` workflow restore were dropped because they defended against a skew that doesn't exist.

### 2. `merge-driver ci-install` (durable structural fix)

Add a new subcommand — the `npm ci` analogue of `install`'s `npm install`. It treats the committed `.gitattributes` as the source of truth: it **verifies** the managed block against `.mdsmith.yml` and exits non-zero on a missing file, missing block, or drift, **without ever writing** the tracked file. Verification runs **first**; only on success does it register the merge driver and install the pre-merge-commit hook (both git-internal and untracked), so a failing run leaves git config and hooks untouched. Reads are lstat-guarded against symlinks, like `install`.

This makes the loop unreachable by construction: the queue can't dirty the worktree, so the merge always starts clean, and real drift fails one setup step (which doesn't requeue) instead of looping. The queue can adopt it once the pinned baseline ships it — `merge-queue.yml` carries a `NOTE` to switch the install step to `ci-install` then.

## Scope

- `.gitattributes` resync + `internal/integration/gitattributes_sync_test.go` dogfood guard
- `cmd/mdsmith/mergedriver.go`: `ci-install` subcommand + `verifyGitattributes` (symlink-guarded, never writes)
- unit + e2e tests for `ci-install`: in-sync (no write), missing file, no managed block, drift, glob-arg rejection, and the config / register-driver / unmanaged-hook / read / non-regular-file error paths
- `docs/reference/cli/merge-driver.md`: `ci-install` section
- `.github/workflows/merge-queue.yml`: `NOTE` to adopt `ci-install` after the next pinned-baseline bump

## Verification

- `mdsmith check .` → `exit=0` (391 files, 0 failures); was `exit=1` (MDS048) on the stale file
- `go build ./...`, `go vet`, `go test ./...`, and `golangci-lint` all pass
- 100% patch coverage on the new `ci-install` code

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHacbtgTVycBpi9XBX9bkm)_