### PR TITLE
ci: bump pinned mdsmith baseline to v0.31.0, adopt merge-driver ci-install

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -10,8 +10,8 @@ runs:
       env:
         # Pinned compatibility baseline for mdsmith release checks and merge tooling.
         # Bump here only when intentionally updating that baseline.
-        MDSMITH_VERSION: v0.29.0
-        MDSMITH_SHA256: 130d784cec7fe096ba332974dcd615fc3b4a0ca479730c5fd5a3c9f1f1f55bd3
+        MDSMITH_VERSION: v0.31.0
+        MDSMITH_SHA256: 030f3b65e7060b2c5e66bbf8dc4c7bdf18904165cef32dc9c66cb7dac01d957d
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -37,16 +37,16 @@ jobs:
 
       - uses: ./.github/actions/setup-mdsmith-pinned-version
       - name: Install mdsmith merge driver and pre-merge-commit hook
-        # NOTE: switch `merge-driver install` to `merge-driver ci-install`
-        # once the pinned baseline (setup-mdsmith-pinned-version) ships it.
-        # `install` re-renders .gitattributes from .mdsmith.yml; a drifted
-        # committed copy would be rewritten here, dirtying the worktree and
-        # aborting the action's `git merge` — which requeues the PR and
-        # re-fires the labeled trigger forever. `ci-install` verifies
-        # .gitattributes instead of writing it (it cannot dirty the tree)
-        # and fails loudly on drift, turning a loop into one clean red run.
+        # Use `ci-install`, not `install`: `install` re-renders
+        # .gitattributes from .mdsmith.yml, so a drifted committed copy
+        # would be rewritten here, dirtying the worktree and aborting the
+        # action's `git merge` — which requeues the PR and re-fires the
+        # labeled trigger forever. `ci-install` verifies .gitattributes
+        # instead of writing it (it cannot dirty the tree) and fails loudly
+        # on drift, turning a loop into one clean red run. Requires the
+        # pinned baseline (setup-mdsmith-pinned-version) to ship ci-install.
         run: |
-          mdsmith merge-driver install
+          mdsmith merge-driver ci-install
           mdsmith pre-merge-commit install
 
       - uses: jeduden/merge-queue-action@389ad414544a693f6c98e0dfdca349007b64d0df #v0.7.8


### PR DESCRIPTION
## What

Bump the pinned mdsmith compatibility baseline from **v0.29.0 → v0.31.0** in `.github/actions/setup-mdsmith-pinned-version/action.yml`, and adopt the `merge-driver ci-install` subcommand that the bump unblocks.

### Changes

- **`action.yml`**: `MDSMITH_VERSION` → `v0.31.0`; `MDSMITH_SHA256` → `030f3b65e7060b2c5e66bbf8dc4c7bdf18904165cef32dc9c66cb7dac01d957d` (the v0.31.0 `mdsmith-linux-amd64` binary).
- **`merge-queue.yml`**: switch `mdsmith merge-driver install` → `mdsmith merge-driver ci-install`, retiring the NOTE that gated this switch on "once the pinned baseline ships it" (v0.31.0 ships it, from PR #456). `ci-install` verifies `.gitattributes` instead of rewriting it, so a drifted copy fails loudly as one red run rather than dirtying the worktree and looping the queue. The rationale comment is preserved.

### Verification

The SHA256 was confirmed three ways, all in agreement:

- GitHub release asset API `digest`
- the release `checksums.txt`
- locally-computed `sha256sum` of the downloaded binary

Using the v0.31.0 binary in this checkout:

- `mdsmith version` → `mdsmith v0.31.0`, and `merge-driver ci-install` is present.
- `merge-driver ci-install` reports `.gitattributes` "verified in sync; not modified" — so the flipped workflow step won't fail on drift.
- `mdsmith check .` → `checked=400 fixed=0 failures=0 unfixed=0`.

https://claude.ai/code/session_012ykG37HkJne5Z6ngKTjNH5

---
_Generated by [Claude Code](https://claude.ai/code/session_012ykG37HkJne5Z6ngKTjNH5)_