### PR TITLE
Website: fix install-filter contrast (WCAG AA) and de-duplicate the install area

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -105,7 +105,7 @@ release-channel docs, gated against drift in CI:
   `hugo.Data.channels` (the generated
   `website/data/channels.yaml`). It renders every channel
   with platform-tag filter chips.
-- **"Distributed via" strip** — the release-channel docs
+- **"Published to" strip** — the release-channel docs
   `../docs/development/release-channels/*.md`. Each
   carries a canonical `channelurl:` and an ordering
   `weight:`; `logos-strip.html` ranges the synced

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -13,7 +13,7 @@
     <div class="container">
       <div class="section-eyebrow">Install</div>
       <h2 class="section-title">Copy one line for your platform.</h2>
-      <p class="section-lead">Filter by your platform, then copy the one line you need. Every channel is listed; the <a href="{{ "/guides/install/" | relURL }}">install guide</a> adds editor extensions, verification, and version pinning.</p>
+      <p class="section-lead">Filter by your platform, then copy the one line you need — each command installs the latest release. The <a href="{{ "/guides/install/" | relURL }}">install guide</a> adds editor setup, verification, and version-pinned forms for CI.</p>
       {{ partial "install-picker.html" . }}
     </div>
   </section>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -12,7 +12,7 @@
   <section class="section">
     <div class="container">
       <div class="section-eyebrow">Install</div>
-      <h2 class="section-title">Install for your toolchain.</h2>
+      <h2 class="section-title">Copy one line for your platform.</h2>
       <p class="section-lead">Filter by your platform, then copy the one line you need. Every channel is listed; the <a href="{{ "/guides/install/" | relURL }}">install guide</a> adds editor extensions, verification, and version pinning.</p>
       {{ partial "install-picker.html" . }}
     </div>

--- a/website/layouts/partials/install-picker.html
+++ b/website/layouts/partials/install-picker.html
@@ -27,10 +27,16 @@
   <div class="install-list">
     {{- range $channels }}
     <div class="install-row" data-platforms="{{ delimit .platforms " " }}">
-      <span class="install-label">{{ .title }}</span>
+      <a class="install-label" href="{{ .url }}" target="_blank" rel="noopener" title="Open the {{ .title }} page">{{ .title }}</a>
       <code class="install-cmd"><span class="prompt">$</span> <span class="cmd">{{ .command }}</span></code>
       <button class="install-copy" type="button" aria-label="Copy {{ .title }} install command" data-copy="{{ .command }}">copy</button>
     </div>
     {{- end }}
   </div>
+  {{- /* Surface the headline supply-chain facts on the page so a
+         security reviewer can triage without clicking into a docs
+         page. These restate what the channel docs already publish
+         (github-releases / npm / pypi front matter); per-channel
+         detail lives in the install guide. */ -}}
+  <p class="install-note">Releases are Sigstore-signed and checksummed; npm and PyPI publish via OIDC Trusted Publishing. The <a href="{{ "/guides/install/" | relURL }}">install guide</a> lists per-channel verification.</p>
 </div>

--- a/website/layouts/partials/install-picker.html
+++ b/website/layouts/partials/install-picker.html
@@ -27,7 +27,7 @@
   <div class="install-list">
     {{- range $channels }}
     <div class="install-row" data-platforms="{{ delimit .platforms " " }}">
-      <a class="install-label" href="{{ .url }}" target="_blank" rel="noopener" title="Open the {{ .title }} page">{{ .title }}</a>
+      <a class="install-label" href="{{ .url }}" rel="noopener">{{ .title }}</a>
       <code class="install-cmd"><span class="prompt">$</span> <span class="cmd">{{ .command }}</span></code>
       <button class="install-copy" type="button" aria-label="Copy {{ .title }} install command" data-copy="{{ .command }}">copy</button>
     </div>

--- a/website/layouts/partials/logos-strip.html
+++ b/website/layouts/partials/logos-strip.html
@@ -1,7 +1,7 @@
 <div class="logos">
   <div class="container">
     <div class="logos-strip">
-      <span class="logos-label">Distributed via</span>
+      <span class="logos-label">Published to</span>
       {{- /* Sourced from the release-channel docs
              (docs/development/release-channels/*.md), synced and
              served at /development/release-channels/. Each carries

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -362,11 +362,13 @@ main {
 .install-picker { display: flex; flex-direction: column; gap: 14px; }
 .install-filters { display: flex; flex-wrap: wrap; gap: 8px; }
 /* Chips sit on the light section background, not on the dark
-   install list. Their text must read against --bg (canvas), so
-   they use dark steel/forge tokens — not the light --steel-300 /
-   --canvas the dark-context copy button uses. The active state
-   reuses the site's .chip.is-on treatment (forge-700 on forge-50,
-   ~7:1) for a consistent, legible "selected" look. */
+   install list, so their text must read against --bg (canvas).
+   The old default/hover text (--steel-300 / --canvas) washed out
+   there; the text now uses --fg-muted / --fg. The 1px border still
+   uses --border-strong (--steel-300) — a line, not text, so it
+   needs no 4.5:1 contrast. The active state reuses the site's
+   .chip.is-on treatment (forge-700 on forge-50, ~7:1) for a
+   consistent, legible "selected" look. */
 .install-filter {
   background: transparent;
   border: 1px solid var(--border-strong);

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -319,6 +319,12 @@ main {
   letter-spacing: 0.06em;
   color: var(--forge-400);
 }
+/* The label links to the channel's registry / marketplace page so
+   editor users reach the storefront's install button and anyone can
+   check provenance. Keep the forge-400 look on the dark list — the
+   global link color (forge-700) would be too dark there. */
+a.install-label { text-decoration: none; }
+a.install-label:hover { color: var(--forge-300); text-decoration: underline; }
 .install-row .install-cmd {
   flex: 1 1 auto;
   min-width: 0;
@@ -383,6 +389,13 @@ main {
   color: var(--forge-700); border-color: var(--forge-500); background: var(--forge-50);
 }
 .install-row[hidden] { display: none; }
+/* Sits on the light section background; --fg-muted reads at ~8.4:1. */
+.install-note {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+}
 
 /* ========== TERMINAL ========== */
 

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -369,22 +369,22 @@ a.install-label:hover { color: var(--forge-300); text-decoration: underline; }
 .install-filters { display: flex; flex-wrap: wrap; gap: 8px; }
 /* Chips sit on the light section background, not on the dark
    install list, so their text must read against --bg (canvas).
-   The old default/hover text (--steel-300 / --canvas) washed out
-   there; the text now uses --fg-muted / --fg. The 1px border still
-   uses --border-strong (--steel-300) — a line, not text, so it
-   needs no 4.5:1 contrast. The active state reuses the site's
-   .chip.is-on treatment (forge-700 on forge-50, ~7:1) for a
-   consistent, legible "selected" look. */
+   Only the text changed: the old --steel-300 / --canvas washed out
+   on the light canvas, so default/hover text now uses --fg-muted /
+   --fg. The borders keep their original steel-700 / steel-500
+   tokens (both clear the 3:1 non-text-contrast bar on canvas). The
+   active state moves to the site's .chip.is-on treatment (forge-700
+   on forge-50, ~7:1) for a consistent, legible "selected" look. */
 .install-filter {
   background: transparent;
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--steel-700);
   color: var(--fg-muted);
   padding: 5px 12px; font-size: 12px; font-family: var(--font-mono);
   text-transform: uppercase; letter-spacing: 0.05em;
   border-radius: 999px; cursor: pointer;
   transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
 }
-.install-filter:hover { color: var(--fg); border-color: var(--border-strong); background: var(--bg-sunken); }
+.install-filter:hover { color: var(--fg); border-color: var(--steel-500); }
 .install-filter.is-active {
   color: var(--forge-700); border-color: var(--forge-500); background: var(--forge-50);
 }

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -361,18 +361,24 @@ main {
    stays visible and the chips are inert. */
 .install-picker { display: flex; flex-direction: column; gap: 14px; }
 .install-filters { display: flex; flex-wrap: wrap; gap: 8px; }
+/* Chips sit on the light section background, not on the dark
+   install list. Their text must read against --bg (canvas), so
+   they use dark steel/forge tokens — not the light --steel-300 /
+   --canvas the dark-context copy button uses. The active state
+   reuses the site's .chip.is-on treatment (forge-700 on forge-50,
+   ~7:1) for a consistent, legible "selected" look. */
 .install-filter {
   background: transparent;
-  border: 1px solid var(--steel-700);
-  color: var(--steel-300);
+  border: 1px solid var(--border-strong);
+  color: var(--fg-muted);
   padding: 5px 12px; font-size: 12px; font-family: var(--font-mono);
   text-transform: uppercase; letter-spacing: 0.05em;
   border-radius: 999px; cursor: pointer;
   transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
 }
-.install-filter:hover { color: var(--canvas); border-color: var(--steel-500); }
+.install-filter:hover { color: var(--fg); border-color: var(--border-strong); background: var(--bg-sunken); }
 .install-filter.is-active {
-  color: var(--forge-300); border-color: var(--forge-400); background: var(--steel-950);
+  color: var(--forge-700); border-color: var(--forge-500); background: var(--forge-50);
 }
 .install-row[hidden] { display: none; }
 


### PR DESCRIPTION
Fixes the reported issues on the mdsmith.dev homepage install area, then implements the UX follow-ups the audience panel surfaced.

## 1. Contrast — install filter chips (`fix(website)`)

The platform filter chips sit on the **light** section background but were
styled with the dark-context tokens the copy button (inside the dark install
list) uses. On the light background that rendered as light text on the warm
canvas — the reported "white on yellow":

| Chip state | Before | After |
| --- | --- | --- |
| default | `--steel-300` text on canvas — **1.81:1** ❌ | `--fg-muted` on canvas — **8.4:1** ✅ |
| hover | `--canvas` text on canvas — **1.00:1** (invisible) ❌ | `--fg` on canvas — **17.3:1** ✅ |
| active | gold on near-black (inconsistent dark pill) | `.chip.is-on` style: forge-700 on forge-50 — **6.8:1** ✅ |

The fix changes only the chip **text** tokens (plus the active restyle for
consistency). The borders keep their original `--steel-700` / `--steel-500`
tokens — both also clear the 3:1 non-text-contrast bar (12.1 / 5.4:1), whereas
`--border-strong` would not (1.81:1). Ratios computed from the
`colors_and_type.css` tokens.

## 2. Duplicate "Distributed via" + "Install for your toolchain" (`docs(website)`)

A blind audience panel — five independent personas (hurried solo dev, evaluating
eng lead, CI/platform engineer, editor-first writer, supply-chain reviewer) —
found both sections answered *"where do I get it?"*, so they read as duplicate.
The fix gives each a distinct job rather than deleting either:

- **Band → "Published to"** — states provenance (the registries mdsmith
  publishes to), a credibility signal rather than a second install nav.
- **Heading → "Copy one line for your platform."** — owns the install action;
  drops the eyebrow/title "Install" echo and the "toolchain" jargon.
- `website/README.md` design note updated to match.

## 3. Install-picker UX follow-ups (`feat(website)`)

Implements the three concerns the same panel raised, using data already in
`channels.yaml` (no pipeline change):

- **Editor-first writer** → each channel name now links (same-tab, matching the
  site convention) to its registry / marketplace `url`, so the Visual Studio
  Marketplace / Open VSX rows reach the storefront's install button instead of
  stranding a non-CLI user on a `code --install-extension` command.
- **CI engineer** → the lead states the commands install the latest release and
  points to version-pinned forms for CI in the guide.
- **Supply-chain reviewer** → a note under the picker surfaces the headline
  trust facts on the page (Sigstore + checksums on releases, OIDC Trusted
  Publishing on npm/PyPI), restating what the channel docs already publish, with
  the install guide for per-channel detail.

## Review follow-ups (Copilot)

- Round 1: clarified the install-filter CSS comment.
- Round 2: kept the contrast fix text-only by restoring the original chip
  borders (`--steel-700` / `--steel-500`), and dropped `target="_blank"` on the
  channel link so it matches the site's same-tab external-link convention.

## Possible further work (not in this PR)

A *structured* per-channel verification badge (a `verify:` field added to each
channel's source front matter + the `release-channel` proto.md schema + the
`Channel` struct + sync code + regenerated `channels.yaml` + tests) would let
each row show its own badge. That makes public supply-chain claims per channel,
so it's left out pending maintainer sign-off on the wording.

## Verification

- `mdsmith check .` → 401 files, 0 failures.
- WCAG ratios (text and non-text) computed from the design tokens.
- No Go tests assert the changed strings; Hugo/browser not available in this
  environment, so the contrast claim is verified numerically rather than by
  screenshot.

> Note: this branch is ahead of the stale `origin/main` snapshot in this
> environment, so the diff may show prior merged work. The changes owned by this
> PR are the `website/` commits.

https://claude.ai/code/session_016NDRugchdLiDWkUHjGXkE7