### PR TITLE
docs: update add-peer-linter step 3 to the row-expr matrix flow

### DIFF
--- a/docs/development/add-peer-linter.md
+++ b/docs/development/add-peer-linter.md
@@ -72,8 +72,9 @@ Add the `newtool` column to every peer-coverage block
 (all sections except the directive one), two edits
 each:
 
-- Append `newtool` to the `header:` row and its
-  `---` separator row.
+- Add `newtool` to the `header:` block: extend both
+  the column-names row and the alignment row of
+  dashes (`| --- |`) below it.
 - Append a peer cell to `row-expr:`. Copy an existing
   peer's cell and read the new key: `for m in
   newtool` when the key is a bare identifier, or the

--- a/docs/development/add-peer-linter.md
+++ b/docs/development/add-peer-linter.md
@@ -9,7 +9,7 @@ prose comparison page. Both stay accurate because
 every rule README owns its own peer-mapping front
 matter; the matrix is regenerated from those blocks.
 Adding a new peer — say `newtool` — touches the
-schema, the Go decoder, the matrix generator, every
+schema, the Go decoder, the matrix templates, every
 rule README, the prose comparison page, and the
 benchmark page.
 
@@ -56,25 +56,35 @@ matter into `RuleInfo`. Three edits:
 
 `go build ./...` should pass.
 
-## 3. Extend the coverage generator
+## 3. Extend the coverage matrix
 
-`internal/release/coverage.go` renders the matrix.
-Four edits:
+The matrix lives in
+`docs/research/markdownlint-coverage/README.md` as
+one `<?catalog?>` block per rule category. Each block
+carries a `header:` table and a `row-expr:` CUE
+template that renders one cell per peer from the rule
+README front matter. There is no Go renderer.
 
-- Append `"newtool"` to the `headers` slice in
-  `renderPeerTable`
-- Append `renderPeerCell(r.Newtool)` to the row
-  builder in the same function
-- Add `len(r.Newtool) > 0` to the disjunction in
-  `categoryIsMdsmithOnly`
-- Update the page summary and intro paragraph that
-  `RenderCoverageMatrix` writes — both currently
-  enumerate the linters by name
+Two edits add the `newtool` column to a block:
 
-`go test ./internal/release/` should pass. The
-existing tests do not assert column count, so they
-keep working with one extra column; add a new test
-case if you want the assertion explicit.
+- Append `newtool` to the `header:` row and its
+  `---` separator row.
+- Append a peer cell to `row-expr:`. Copy an existing
+  peer's cell and read the new key — `for m in
+  newtool` for a bare name, or `for m in
+  fm["newtool"]` for a hyphenated one, the way
+  `obsidian-linter` is read.
+
+A peer cell renders `—` for an empty list, otherwise
+a comma-joined entry per mapping: the peer `id`, a
+`✅`/`⚪` upstream-default marker, the `name` when it
+differs from the `id`, and a ` (partial)` suffix.
+Keep the new cell identical to the others so the
+legend holds.
+
+Every category block (one per `##` section) needs the
+same two edits. Step 5 regenerates the tables, and
+`mdsmith check` fails on any that drift.
 
 ## 4. Add per-rule mappings
 
@@ -172,7 +182,6 @@ obsidian-linter touched, in order:
 - `internal/rules/proto.md` and
   `directive-proto.md`
 - `internal/rules/ruledocs.go`
-- `internal/release/coverage.go`
 - 67 rule READMEs
 - the regenerated
   `docs/research/markdownlint-coverage/README.md`

--- a/docs/development/add-peer-linter.md
+++ b/docs/development/add-peer-linter.md
@@ -66,7 +66,9 @@ template that renders one cell per peer from the rule
 README front matter. The `category: "directive"`
 section is the exception: it is mdsmith-only, a
 two-column `mdsmith | What it adds` table with no peer
-cells. There is no Go renderer.
+cells. There is no dedicated Go coverage-matrix
+generator to extend anymore; `mdsmith fix` renders
+the `<?catalog?>` blocks from these templates.
 
 Add the `newtool` column to every peer-coverage block
 (all sections except the directive one), two edits
@@ -88,6 +90,10 @@ a comma-joined entry per mapping: the peer `id`, a
 differs from the `id`, and a ` (partial)` suffix.
 Keep the new cell identical to the others so the
 legend holds.
+
+The page's `summary:` and opening paragraph name the
+peers in prose; add `newtool` to both so they match
+the columns.
 
 Step 5 regenerates the tables, and `mdsmith check`
 fails on any that drift.

--- a/docs/development/add-peer-linter.md
+++ b/docs/development/add-peer-linter.md
@@ -59,21 +59,27 @@ matter into `RuleInfo`. Three edits:
 ## 3. Extend the coverage matrix
 
 The matrix lives in
-`docs/research/markdownlint-coverage/README.md` as
-one `<?catalog?>` block per rule category. Each block
-carries a `header:` table and a `row-expr:` CUE
+`docs/research/markdownlint-coverage/README.md`. Most
+sections are a `<?catalog?>` block per rule category,
+each with a `header:` table and a `row-expr:` CUE
 template that renders one cell per peer from the rule
-README front matter. There is no Go renderer.
+README front matter. The `category: "directive"`
+section is the exception: it is mdsmith-only, a
+two-column `mdsmith | What it adds` table with no peer
+cells. There is no Go renderer.
 
-Two edits add the `newtool` column to a block:
+Add the `newtool` column to every peer-coverage block
+(all sections except the directive one), two edits
+each:
 
 - Append `newtool` to the `header:` row and its
   `---` separator row.
 - Append a peer cell to `row-expr:`. Copy an existing
-  peer's cell and read the new key — `for m in
-  newtool` for a bare name, or `for m in
-  fm["newtool"]` for a hyphenated one, the way
-  `obsidian-linter` is read.
+  peer's cell and read the new key: `for m in
+  newtool` when the key is a bare identifier, or the
+  `fm["..."]` accessor when it has a hyphen — the way
+  `obsidian-linter` is read as `for m in
+  fm["obsidian-linter"]`.
 
 A peer cell renders `—` for an empty list, otherwise
 a comma-joined entry per mapping: the peer `id`, a
@@ -82,9 +88,8 @@ differs from the `id`, and a ` (partial)` suffix.
 Keep the new cell identical to the others so the
 legend holds.
 
-Every category block (one per `##` section) needs the
-same two edits. Step 5 regenerates the tables, and
-`mdsmith check` fails on any that drift.
+Step 5 regenerates the tables, and `mdsmith check`
+fails on any that drift.
 
 ## 4. Add per-rule mappings
 


### PR DESCRIPTION
## Why

Plan 214 (#449) deleted `internal/release/coverage.go` and migrated the peer-linter coverage matrix to `<?catalog?>` + `row-expr` templates, but `docs/development/add-peer-linter.md` still instructed contributors to edit that deleted file (`coverage.go`, `renderPeerTable`, `renderPeerCell`, `categoryIsMdsmithOnly`, `RenderCoverageMatrix`). A contributor following step 3 would be sent to code that no longer exists.

## What

- **Rewrote step 3** ("Extend the coverage generator" → "Extend the coverage matrix") to describe the real flow: edit the per-category `row-expr` blocks in `docs/research/markdownlint-coverage/README.md` — append the new peer to each block's `header:` and add a peer cell to `row-expr:`, including the `fm["..."]` accessor for hyphenated names (as `obsidian-linter` uses). There is no Go renderer anymore (confirmed: no production Go reads `RuleInfo`'s peer-mapping fields after `coverage.go` was deleted).
- Fixed the intro's stale "the matrix generator" → "the matrix templates".
- Dropped the now-deleted `internal/release/coverage.go` from the worked-example file list.

`mdsmith check .` passes (403 files, 0 failures); `mdsmith fix` is a no-op (title/summary unchanged, so no catalog churn).

https://claude.ai/code/session_01PFtFEudVEceJG2xSAmxm31

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFtFEudVEceJG2xSAmxm31)_