### PR TITLE
fix(vscode): open rule/kinds virtual docs via skipEncoding URIs

### DIFF
--- a/editors/vscode/bun.lock
+++ b/editors/vscode/bun.lock
@@ -13,6 +13,10 @@
         "@types/vscode": "^1.85.0",
         "@vscode/vsce": "^3.0.0",
         "typescript": "^5.4.0",
+        "vscode-uri": "^3.1.0",
+      },
+      "optionalDependencies": {
+        "@mdsmith/cli": "0.0.0-dev",
       },
     },
   },
@@ -590,6 +594,8 @@
     "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -200,6 +200,7 @@
     "@types/node": "^20.11.0",
     "@types/vscode": "^1.85.0",
     "@vscode/vsce": "^3.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vscode-uri": "^3.1.0"
   }
 }

--- a/editors/vscode/src/commands/kinds.test.ts
+++ b/editors/vscode/src/commands/kinds.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { URI } from "vscode-uri";
 import {
   extractRuleIds,
   makeKindsContentProvider,
@@ -10,6 +11,7 @@ import {
 import {
   buildResolveUri,
   buildWhyUri,
+  kindsContentUri,
   parseKindsUri,
   fetchKindsContent,
 } from "./virtual-doc";
@@ -105,6 +107,35 @@ describe("parseKindsUri", () => {
     expect(parseKindsUri("http://example.com")).toBeNull();
     expect(parseKindsUri("mdsmith-kinds://why?rule=MDS001")).toBeNull();
     expect(parseKindsUri("mdsmith-kinds://why?file=/foo.md")).toBeNull();
+  });
+});
+
+// ---- kindsContentUri (vscode.Uri round trip) ----
+
+describe("kindsContentUri", () => {
+  // The content provider receives the Uri VS Code parsed from
+  // buildResolveUri/buildWhyUri and must turn it back into a string
+  // parseKindsUri can read. The default Uri.toString() percent-encodes
+  // the query separators ('=' -> %3D, and the param-joining '&' -> %26),
+  // so the file/rule keys vanish and the provider reports "malformed
+  // kinds URI". URI here is the same implementation backing vscode.Uri.
+  test("round-trips a resolve URI through parseKindsUri", () => {
+    const uri = URI.parse(buildResolveUri("/a/b.md"));
+    expect(uri.toString()).toBe("mdsmith-kinds://resolve?file%3D%2Fa%2Fb.md");
+    expect(parseKindsUri(kindsContentUri(uri))).toEqual({
+      command: "resolve",
+      file: "/a/b.md",
+      rule: undefined,
+    });
+  });
+
+  test("round-trips a why URI (two query params) through parseKindsUri", () => {
+    const uri = URI.parse(buildWhyUri("/a/b.md", "MDS001"));
+    expect(parseKindsUri(kindsContentUri(uri))).toEqual({
+      command: "why",
+      file: "/a/b.md",
+      rule: "MDS001",
+    });
   });
 });
 

--- a/editors/vscode/src/commands/rule-doc.test.ts
+++ b/editors/vscode/src/commands/rule-doc.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { URI } from "vscode-uri";
 import type { SpawnFn } from "./runner";
 import {
   buildRuleDocUri,
@@ -6,6 +7,7 @@ import {
   isRuleId,
   OPEN_RULE_DOC_COMMAND,
   parseRuleDocUri,
+  provideRuleDocContent,
   rewriteHoverMarkdown,
   rewriteRuleDocLinks,
   ruleDocCommandUri,
@@ -187,5 +189,31 @@ describe("fetchRuleDocContent", () => {
     const out = await fetchRuleDocContent(buildRuleDocUri("MDS001"), "mdsmith", undefined, failing);
     expect(out).toContain("could not start");
     expect(out).toContain("ENOENT");
+  });
+});
+
+// ---- provideRuleDocContent (vscode.Uri round trip) ----
+
+describe("provideRuleDocContent", () => {
+  test("survives the real vscode.Uri round trip and passes the bare ID", async () => {
+    // Regression: clicking a rule's hover doc link opened a virtual
+    // document that only read "mdsmith: malformed rule URI". The content
+    // provider received the Uri VS Code built from buildRuleDocUri and
+    // stringified it with the default Uri.toString(), which percent-
+    // encodes the query's '=' separator (id=MDS019 -> id%3DMDS019) — a
+    // form parseRuleDocUri rightly rejects. URI here is the same
+    // implementation backing vscode.Uri, so this reproduces it exactly.
+    const uri = URI.parse(buildRuleDocUri("MDS019"));
+    expect(uri.toString()).toBe("mdsmith-rule://doc?id%3DMDS019");
+
+    let seen: string[] = [];
+    const out = await provideRuleDocContent(
+      uri,
+      "mdsmith",
+      undefined,
+      fakeSpawn({ stdout: "# MDS019\n\nbody\n" }, (a) => (seen = a)),
+    );
+    expect(seen).toEqual(["help", "rule", "MDS019"]);
+    expect(out).toBe("# MDS019\n\nbody\n");
   });
 });

--- a/editors/vscode/src/commands/rule-doc.ts
+++ b/editors/vscode/src/commands/rule-doc.ts
@@ -146,3 +146,22 @@ export async function fetchRuleDocContent(
 
   return result.stdout.trimEnd() + "\n";
 }
+
+// provideRuleDocContent is the mdsmith-rule: TextDocumentContentProvider
+// entry point. Its uri parameter is the structural slice of vscode.Uri
+// this needs — declared inline rather than imported so the function
+// stays unit-testable without the editor runtime.
+//
+// It MUST stringify with skipEncoding=true. VS Code's default
+// Uri.toString() percent-encodes the query's "=" separator
+// (id=MDS019 → id%3DMDS019), which parseRuleDocUri then rejects, so the
+// clicked hover link opened a virtual document that only read
+// "malformed rule URI". skipEncoding leaves the "=" intact.
+export function provideRuleDocContent(
+  uri: { toString(skipEncoding?: boolean): string },
+  binary: string,
+  workspaceRoot: string | undefined,
+  spawn: SpawnFn = defaultSpawn,
+): Promise<string> {
+  return fetchRuleDocContent(uri.toString(true), binary, workspaceRoot, spawn);
+}

--- a/editors/vscode/src/commands/virtual-doc.ts
+++ b/editors/vscode/src/commands/virtual-doc.ts
@@ -25,6 +25,22 @@ export function buildWhyUri(filePath: string, rule: string): string {
   );
 }
 
+// kindsContentUri returns the parseable string form of the Uri handed
+// to the mdsmith-kinds: TextDocumentContentProvider. Its argument is the
+// structural slice of vscode.Uri this needs, declared inline so the
+// function stays unit-testable without the editor runtime.
+//
+// skipEncoding=true is required. VS Code's default Uri.toString()
+// percent-encodes the query separators ("=" → %3D, and the param-joining
+// "&" → %26), so parseKindsUri can no longer split out the file and rule
+// keys and the provider reports "malformed kinds URI". skipEncoding
+// leaves those separators intact.
+export function kindsContentUri(uri: {
+  toString(skipEncoding?: boolean): string;
+}): string {
+  return uri.toString(true);
+}
+
 // parseKindsUri extracts command, file, and optional rule from a
 // mdsmith-kinds: URI string. Returns null when the URI is malformed.
 // Uses URL parsing so both "mdsmith-kinds://resolve?file=…" and the

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -28,13 +28,13 @@ import { runFixWorkspace } from "./commands/fix-workspace";
 import { runInit } from "./commands/init";
 import { runMergeDriverInstall } from "./commands/merge-driver";
 import { runKindsResolve, runKindsWhy, makeKindsContentProvider } from "./commands/kinds";
-import { KINDS_SCHEME, parseKindsUri } from "./commands/virtual-doc";
+import { KINDS_SCHEME, kindsContentUri, parseKindsUri } from "./commands/virtual-doc";
 import {
   RULE_SCHEME,
   OPEN_RULE_DOC_COMMAND,
   buildRuleDocUri,
-  fetchRuleDocContent,
   isRuleId,
+  provideRuleDocContent,
   rewriteHoverMarkdown,
 } from "./commands/rule-doc";
 
@@ -534,7 +534,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       KINDS_SCHEME,
       {
         provideTextDocumentContent: (uri: vscode.Uri) => {
-          const uriStr = uri.toString();
+          const uriStr = kindsContentUri(uri);
           const parsed = parseKindsUri(uriStr);
           // Derive the workspace folder from the file encoded in the URI so
           // binary/config lookups use the correct per-folder settings even
@@ -565,7 +565,7 @@ function registerPaletteCommands(context: vscode.ExtensionContext): void {
       RULE_SCHEME,
       {
         provideTextDocumentContent: (uri: vscode.Uri) =>
-          fetchRuleDocContent(uri.toString(), getBinary(), getWorkspaceRoot()),
+          provideRuleDocContent(uri, getBinary(), getWorkspaceRoot()),
       }
     ),
 


### PR DESCRIPTION
## Problem

Clicking a rule's hover documentation link in the VS Code extension opened a virtual document that only read:

> **mdsmith: malformed rule URI**
> ```
> mdsmith-rule://doc?id%3DMDS019
> ```

## Root cause

The `mdsmith-rule:` and `mdsmith-kinds:` `TextDocumentContentProvider`s stringified the incoming `vscode.Uri` with the **default** `Uri.toString()`. That method percent-encodes the query's `=` separator (`id=MDS019` → `id%3DMDS019`).

The parsers (`parseRuleDocUri` / `parseKindsUri`) use the WHATWG `URL` class, where `%3D` is a *literal `=` inside the key* rather than a key/value separator — so `searchParams.get("id")` returned `null` and the URI was rejected as malformed.

The round trip was never exercised by tests: the existing unit tests call `parseRuleDocUri(buildRuleDocUri(...))` directly, with no `vscode.Uri` in between, so the encoding mismatch never showed up.

The `mdsmith-kinds:` provider shared the identical defect. Its `why` URIs even encode the `&` param separator to `%26`, which is why hardening the parser is not viable — `toString(true)` is the only correct fix.

## Fix

Stringify with `skipEncoding=true` so the separators survive the round trip. Both providers now route through small, `vscode`-free, unit-testable entry points:

- `provideRuleDocContent(uri, …)` in `rule-doc.ts`
- `kindsContentUri(uri)` in `virtual-doc.ts`

## Tests

Added faithful round-trip regression tests using [`vscode-uri`](https://www.npmjs.com/package/vscode-uri) — the standalone implementation that backs `vscode.Uri` — added as a **dev-only** dependency (verified not bundled into the shipped `.vsix`). The tests reproduce the exact reported URI (`mdsmith-rule://doc?id%3DMDS019`) and would have caught the bug.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test` — 141 pass
- `bun run build.ts --production` — builds; `vscode-uri` absent from `dist/`
- `bun install --frozen-lockfile` — in sync
- `mdsmith check .` — 405 files, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01CoChGRKvb7ZTfi3zjjSF5H)_