### PR TITLE
fix(lsp): newest-wins workspace singleton reaps orphaned servers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -156,4 +156,5 @@ footer: |
 | 224 | ✅     |        | [Split internal/lint along question boundaries](plan/224_arch-fix-lint-srp.md)                                                          |
 | 225 | ✅     |        | [Add internal/punkt to the architecture layering map](plan/225_arch-fix-punkt-layering.md)                                              |
 | 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |
+| 231 | ✅     |        | [LSP newest-wins workspace singleton](plan/231_lsp-workspace-singleton.md)                                                              |
 <?/catalog?>

--- a/cmd/mdsmith/lsp.go
+++ b/cmd/mdsmith/lsp.go
@@ -78,6 +78,10 @@ func runLSPWith(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writ
 		Reader:         stdin,
 		Writer:         stdout,
 		OnConfigReload: installIncludeExtractProjector,
+		// Reap an orphaned server left behind by a leaked editor host:
+		// when a reload spawns a fresh server for the same workspace,
+		// the older one steps aside so exactly one stays live.
+		EnableWorkspaceSingleton: true,
 	})
 	// SIGINT/SIGTERM cancel ctx, so srv.Run returns context.Canceled.
 	// That's a clean shutdown (the user or the OS asked us to exit), not

--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -184,6 +184,15 @@ tripped because the binary crashes on every request. Open the
 "mdsmith" Output channel for the stack trace, fix the cause,
 then run `mdsmith: Restart Language Server`.
 
+**Two mdsmith servers running; I want one.** A reload or
+update can leave the old extension host alive next to the new
+one, each running its own server. The newest server wins: it
+claims the workspace and the older one exits, sending an
+`mdsmith/superseded` notice first so the client does not
+restart it. If an older build left an orphan, kill its
+extension host once — not the `mdsmith` process, which the
+host respawns.
+
 ## See also
 
 - [`mdsmith lsp`](../../reference/cli/lsp.md) — the protocol

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -175,21 +175,25 @@ async function startServer(context: vscode.ExtensionContext): Promise<void> {
 
   client = new LanguageClient("mdsmith", "mdsmith", serverOptions, clientOptions);
 
+  // Listen for the server announcing that a newer instance for this
+  // workspace has taken over. Marking the error handler turns the
+  // imminent connection close into a no-restart, so this (now orphaned)
+  // editor host stops respawning a server the newer one immediately
+  // supersedes again. See the newest-wins workspace singleton in
+  // internal/lsp/singleton.go. Registered BEFORE start() so the
+  // notification can never land in the gap between start() resolving
+  // and handler registration — vscode-languageclient buffers pre-start
+  // notification handlers.
+  client.onNotification("mdsmith/superseded", () => {
+    errorHandler.markSuperseded();
+    getOutputChannel().appendLine(
+      "mdsmith: a newer server has taken over this workspace; " +
+        "stopping this instance (it will not be restarted)."
+    );
+  });
+
   try {
     await client.start();
-    // After a successful start, listen for the server announcing that a
-    // newer instance for this workspace has taken over. Marking the
-    // error handler turns the imminent connection close into a
-    // no-restart, so this (now orphaned) editor host stops respawning a
-    // server that the newer one immediately supersedes again. See the
-    // newest-wins workspace singleton in internal/lsp/singleton.go.
-    client.onNotification("mdsmith/superseded", () => {
-      errorHandler.markSuperseded();
-      getOutputChannel().appendLine(
-        "mdsmith: a newer server has taken over this workspace; " +
-          "stopping this instance (it will not be restarted)."
-      );
-    });
   } catch (err) {
     // start() rejected — leave the LanguageClient referenceable
     // briefly so the user can hit "Show Output" to read the

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -17,10 +17,12 @@ import {
   buildClientOptions,
   buildServerOptions,
   collectFixAllEdits,
+  decideClose,
   forwardMdsmithConfigChange,
   notifyConfigChangeToClient,
   shouldFixOnSave,
   startupErrorMessage,
+  RestartPolicyState,
   RUN_ON_TYPE
 } from "./wiring";
 import { findBinaryCandidates, resolveBinary } from "./binary";
@@ -148,7 +150,8 @@ async function startServer(context: vscode.ExtensionContext): Promise<void> {
   // "Show Output" prompt instead of silently disabling the
   // extension. The mdsmith.restartServer command stays the
   // explicit manual recovery path either way.
-  clientOptions.errorHandler = new MdsmithErrorHandler();
+  const errorHandler = new MdsmithErrorHandler();
+  clientOptions.errorHandler = errorHandler;
 
   // Rewrite the server's public-website rule-docs links (in hovers) so
   // they open the README offline from the bundled binary instead of a
@@ -174,6 +177,19 @@ async function startServer(context: vscode.ExtensionContext): Promise<void> {
 
   try {
     await client.start();
+    // After a successful start, listen for the server announcing that a
+    // newer instance for this workspace has taken over. Marking the
+    // error handler turns the imminent connection close into a
+    // no-restart, so this (now orphaned) editor host stops respawning a
+    // server that the newer one immediately supersedes again. See the
+    // newest-wins workspace singleton in internal/lsp/singleton.go.
+    client.onNotification("mdsmith/superseded", () => {
+      errorHandler.markSuperseded();
+      getOutputChannel().appendLine(
+        "mdsmith: a newer server has taken over this workspace; " +
+          "stopping this instance (it will not be restarted)."
+      );
+    });
   } catch (err) {
     // start() rejected — leave the LanguageClient referenceable
     // briefly so the user can hit "Show Output" to read the
@@ -268,27 +284,43 @@ function showOutput(): void {
 //    "Restart Language Server" / "Show Output" choice so the
 //    user can recover with one click instead of reloading the
 //    window.
+//  - Suppresses the restart entirely once the server announces it
+//    was superseded (markSuperseded). The decision itself lives in
+//    decideClose (wiring.ts) so it can be unit-tested without vscode.
 class MdsmithErrorHandler implements ErrorHandler {
   private static readonly maxRestarts = 25;
   private static readonly windowMs = 3 * 60 * 1000;
-  private restarts: number[] = [];
+  private state: RestartPolicyState = { restarts: [], superseded: false };
+
+  // markSuperseded records that the server told us (via the
+  // mdsmith/superseded notification) that a newer instance for this
+  // workspace has taken over. The imminent connection close is then
+  // expected and intentional, so closed() must NOT restart — otherwise
+  // this now-orphaned editor host would respawn a server the newer one
+  // supersedes again, the exact restart loop a leaked extension host
+  // used to sustain.
+  markSuperseded(): void {
+    this.state.superseded = true;
+  }
 
   error(_error: Error, _message: Message | undefined, _count: number | undefined): ErrorHandlerResult {
     return { action: ErrorAction.Continue };
   }
 
   closed(): CloseHandlerResult {
-    const now = Date.now();
-    this.restarts = this.restarts.filter((t) => now - t < MdsmithErrorHandler.windowMs);
-    this.restarts.push(now);
-    if (this.restarts.length > MdsmithErrorHandler.maxRestarts) {
+    const { restart, capExceeded } = decideClose(
+      this.state,
+      Date.now(),
+      MdsmithErrorHandler.maxRestarts,
+      MdsmithErrorHandler.windowMs
+    );
+    if (capExceeded) {
       // Show the prompt asynchronously so we do not block the
       // close handler. The promise body decides whether to
       // restart based on the user's choice.
       void promptRestartAfterRepeatedFailures();
-      return { action: CloseAction.DoNotRestart };
     }
-    return { action: CloseAction.Restart };
+    return { action: restart ? CloseAction.Restart : CloseAction.DoNotRestart };
   }
 }
 

--- a/editors/vscode/src/wiring.test.ts
+++ b/editors/vscode/src/wiring.test.ts
@@ -19,6 +19,7 @@ import {
   buildClientOptions,
   buildServerOptions,
   collectFixAllEdits,
+  decideClose,
   forwardMdsmithConfigChange,
   notifyConfigChangeToClient,
   shouldFixOnSave,
@@ -28,6 +29,7 @@ import {
   RUN_ON_TYPE,
   type CodeActionLike,
   type FileSystemWatcherLike,
+  type RestartPolicyState,
   type UriLike
 } from "./wiring";
 
@@ -447,5 +449,57 @@ describe("collectFixAllEdits", () => {
       action("source.fixAll.mdsmith", [[target, [second]]])
     ];
     expect(collectFixAllEdits(actions, target)).toEqual([first, second]);
+  });
+});
+
+describe("decideClose", () => {
+  const maxRestarts = 25;
+  const windowMs = 3 * 60 * 1000;
+
+  function fresh(): RestartPolicyState {
+    return { restarts: [], superseded: false };
+  }
+
+  test("restarts a normal close and records the timestamp", () => {
+    const state = fresh();
+    // The first close is under the cap, so it must restart.
+    const decision = decideClose(state, 1000, maxRestarts, windowMs);
+    expect(decision.restart).toBe(true);
+    expect(decision.capExceeded).toBe(false);
+    expect(state.restarts).toEqual([1000]);
+  });
+
+  test("does not restart and does not count once superseded", () => {
+    const state: RestartPolicyState = { restarts: [10, 20, 30], superseded: true };
+    const decision = decideClose(state, 9_999, maxRestarts, windowMs);
+    expect(decision.restart).toBe(false);
+    expect(decision.capExceeded).toBe(false);
+    // The superseded short-circuit must not touch the restart history.
+    expect(state.restarts).toEqual([10, 20, 30]);
+  });
+
+  test("stops restarting and flags the cap once more than maxRestarts close in the window", () => {
+    const state = fresh();
+    let last = decideClose(state, 0, maxRestarts, windowMs);
+    // 25 closes all restart; the 26th trips the cap.
+    for (let i = 1; i <= maxRestarts; i++) {
+      last = decideClose(state, i, maxRestarts, windowMs);
+    }
+    expect(last.restart).toBe(false);
+    expect(last.capExceeded).toBe(true);
+  });
+
+  test("prunes close timestamps older than the window so a slow trickle keeps restarting", () => {
+    const state = fresh();
+    // Seed maxRestarts closes far in the past.
+    for (let i = 0; i < maxRestarts; i++) {
+      decideClose(state, i, maxRestarts, windowMs);
+    }
+    // A close well past the window prunes the stale entries, so it is
+    // treated as the first recent close and restarts.
+    const decision = decideClose(state, windowMs + 1_000, maxRestarts, windowMs);
+    expect(decision.restart).toBe(true);
+    expect(decision.capExceeded).toBe(false);
+    expect(state.restarts).toEqual([windowMs + 1_000]);
   });
 });

--- a/editors/vscode/src/wiring.ts
+++ b/editors/vscode/src/wiring.ts
@@ -252,6 +252,55 @@ export function notifyConfigChangeToClient<T extends RunningClientLike>(
   void send(client).catch(() => {});
 }
 
+// RestartPolicyState is the mutable bookkeeping the LSP client's
+// CloseHandler carries across close events: the recent restart
+// timestamps (for rate-limiting respawns) and whether the server told
+// us it was intentionally superseded by a newer instance for the same
+// workspace (mdsmith/superseded). Defined here so the decision is
+// unit-testable without the `vscode` runtime.
+export interface RestartPolicyState {
+  restarts: number[];
+  superseded: boolean;
+}
+
+// CloseDecision is what decideClose returns: whether to restart the
+// server, and whether the restart-rate cap was just exceeded (the
+// caller surfaces the recovery prompt in that case).
+export interface CloseDecision {
+  restart: boolean;
+  capExceeded: boolean;
+}
+
+// decideClose is the pure restart policy for a closed LSP connection.
+//
+//   - If the server announced it was superseded, the close is expected:
+//     a newer mdsmith for this workspace has taken over. Restarting
+//     would respawn a server the newer one immediately supersedes again
+//     — the orphaned-host restart loop a leaked extension host caused.
+//     So: never restart, and do not even count it against the cap.
+//   - Otherwise count the close within a sliding window and restart
+//     until more than `maxRestarts` happen inside `windowMs`, at which
+//     point we stop and report capExceeded so the caller can prompt.
+//
+// It mutates `state.restarts` in place (the window prune + the new
+// entry) so successive calls share the rolling history.
+export function decideClose(
+  state: RestartPolicyState,
+  now: number,
+  maxRestarts: number,
+  windowMs: number
+): CloseDecision {
+  if (state.superseded) {
+    return { restart: false, capExceeded: false };
+  }
+  state.restarts = state.restarts.filter((t) => now - t < windowMs);
+  state.restarts.push(now);
+  if (state.restarts.length > maxRestarts) {
+    return { restart: false, capExceeded: true };
+  }
+  return { restart: true, capExceeded: false };
+}
+
 // Run modes for `mdsmith.run`. Mirror the enum declared in
 // package.json and the runMode constants in the Go server
 // (internal/lsp/server.go): onType lints live as you type, onSave

--- a/internal/lsp/parentwatch_test.go
+++ b/internal/lsp/parentwatch_test.go
@@ -67,6 +67,18 @@ func TestStartParentWatchNoopWithoutPID(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 }
 
+func TestNewDefaultOnParentExitCallsOsExit(t *testing.T) {
+	orig := osExit
+	t.Cleanup(func() { osExit = orig })
+	var called bool
+	var code int
+	osExit = func(c int) { called, code = true, c }
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	s.onParentExit() // run the real default closure New() installed
+	assert.True(t, called, "the default onParentExit must exit the process")
+	assert.Equal(t, 0, code)
+}
+
 func TestStartParentWatchNoExitWhileParentAlive(t *testing.T) {
 	t.Parallel()
 	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -236,12 +236,14 @@ func New(opts Options) *Server {
 		// with its own context. Tests override these seams.
 		runCtx:         context.Background(),
 		parentAlive:    processAlive,
-		onParentExit:   func() { os.Exit(0) },
+		onParentExit:   func() { osExit(0) },
 		parentInterval: parentPollInterval,
 		// Workspace-singleton defaults; the registry seams are wired
 		// only when the feature is enabled so unit tests stay hermetic.
+		// onParentExit and onSupersededExit share the osExit seam
+		// (singleton.go) so both default closures are unit-testable.
 		singletonInterval: singletonPollInterval,
-		onSupersededExit:  func() { os.Exit(0) },
+		onSupersededExit:  func() { osExit(0) },
 	}
 	if opts.EnableWorkspaceSingleton {
 		s.instanceID = newInstanceID()

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -92,6 +92,24 @@ type Server struct {
 	parentInterval  time.Duration
 	parentWatchOnce sync.Once
 
+	// Workspace singleton (newest-wins). When EnableWorkspaceSingleton
+	// is set, handleInitialize claims the workspace root in a shared
+	// registry under instanceID and starts a watcher that steps this
+	// server aside — notifying the editor via mdsmith/superseded, then
+	// exiting — once a newer server claims the same workspace. This
+	// reaps an orphaned server kept alive by a leaked editor host: the
+	// case the processId watchdog can't see, because that host stays
+	// alive. instanceID is "" when the feature is off, which makes
+	// startSingletonWatch a no-op. singletonClaim / singletonCurrent /
+	// singletonInterval / onSupersededExit are test seams — production
+	// uses a file registry, singletonPollInterval, and os.Exit(0).
+	instanceID         string
+	singletonClaim     func(key, id string) error
+	singletonCurrent   func(key string) string
+	singletonInterval  time.Duration
+	onSupersededExit   func()
+	singletonWatchOnce sync.Once
+
 	// runCache is the engine read cache shared across every runLint
 	// call so two host buffers that catalog over the same docs/**
 	// tree do not each re-read the matched targets from disk on
@@ -175,6 +193,14 @@ type Options struct {
 	// produce the same diagnostics in the editor as `mdsmith check`
 	// does on the CLI.
 	OnConfigReload func(cfgPath string)
+	// EnableWorkspaceSingleton turns on the newest-wins workspace
+	// singleton. When two servers run for the same workspace root — a
+	// leaked editor host left one orphaned and a reload spawned a fresh
+	// one — the older steps aside so exactly one stays live. cmd/mdsmith
+	// enables it; unit tests leave it off so they neither write to the
+	// real cache dir nor leak a watcher goroutine (the dedicated
+	// singleton tests drive the seams directly).
+	EnableWorkspaceSingleton bool
 }
 
 // New constructs a Server. The Server does not run until Run() is
@@ -191,7 +217,7 @@ func New(opts Options) *Server {
 	if logger == nil {
 		logger = &vlog.Logger{}
 	}
-	return &Server{
+	s := &Server{
 		t:              newTransport(opts.Reader, opts.Writer),
 		rules:          opts.Rules,
 		debounce:       debounce,
@@ -212,7 +238,18 @@ func New(opts Options) *Server {
 		parentAlive:    processAlive,
 		onParentExit:   func() { os.Exit(0) },
 		parentInterval: parentPollInterval,
+		// Workspace-singleton defaults; the registry seams are wired
+		// only when the feature is enabled so unit tests stay hermetic.
+		singletonInterval: singletonPollInterval,
+		onSupersededExit:  func() { os.Exit(0) },
 	}
+	if opts.EnableWorkspaceSingleton {
+		s.instanceID = newInstanceID()
+		reg := defaultRegistry()
+		s.singletonClaim = reg.claim
+		s.singletonCurrent = reg.current
+	}
+	return s
 }
 
 // Run drives the server until the input stream returns io.EOF, the
@@ -474,6 +511,13 @@ func (s *Server) handleInitialize(msg *requestMessage) {
 	// us goes away. Prevents an orphaned server from outliving an editor
 	// update/reload/crash and racing the freshly-spawned one.
 	s.startParentWatch(p.ProcessID)
+
+	// Newest-wins workspace singleton: claim this workspace and step
+	// aside if a newer server later claims it. Backstops the processId
+	// watchdog for the case it can't see — a leaked editor host that
+	// stays alive, holding our stdin open so no EOF arrives, while its
+	// window is gone.
+	s.startSingletonWatch(root)
 
 	res := initializeResult{
 		Capabilities: serverCapabilities{

--- a/internal/lsp/singleton.go
+++ b/internal/lsp/singleton.go
@@ -19,6 +19,11 @@ import (
 var (
 	randRead     = rand.Read
 	userCacheDir = os.UserCacheDir
+	// osExit is the process-exit seam shared by the parent-process and
+	// workspace-singleton watchdogs (see server.go). Overriding it lets
+	// tests exercise the default exit closures without terminating the
+	// test binary.
+	osExit = os.Exit
 )
 
 // singletonPollInterval is how often the workspace-singleton watcher
@@ -69,23 +74,29 @@ func watchSingleton(
 //
 // It is a no-op without a workspace root or instanceID (the feature is
 // off, or the client sent no rootUri); New only sets instanceID when it
-// also wires the registry seams, so the two travel together. A failed
-// claim leaves the server running without singleton protection rather
-// than risking it stepping itself aside on a transient registry error.
+// also wires the registry seams, so the two travel together (the nil
+// guard is belt-and-suspenders for a hand-built Server). A failed claim
+// leaves the server running without singleton protection rather than
+// risking it stepping itself aside on a transient registry error.
 func (s *Server) startSingletonWatch(root string) {
-	if root == "" || s.instanceID == "" {
+	if root == "" || s.instanceID == "" || s.singletonClaim == nil {
 		return
 	}
-	key := workspaceKey(root)
-	// Claim the workspace under this instance's id, overwriting any
-	// previous owner. Whichever server initialized most recently — the
-	// window the user just opened or reloaded — wins; an older server
-	// for the same workspace sees a different owner on its next poll.
-	if err := s.singletonClaim(key, s.instanceID); err != nil {
-		s.logger.Printf("lsp: workspace singleton claim failed: %v", err)
-		return
-	}
+	// Claim and watch exactly once. A spec-compliant client sends a
+	// single initialize, but guarding the claim with the watcher's Once
+	// means a stray second initialize cannot re-assert this (possibly
+	// already-superseded) server's ownership and invert newest-wins.
 	s.singletonWatchOnce.Do(func() {
+		key := workspaceKey(root)
+		// Claim the workspace under this instance's id, overwriting any
+		// previous owner. Whichever server initialized most recently —
+		// the window the user just opened or reloaded — wins; an older
+		// server for the same workspace sees a different owner on its
+		// next poll.
+		if err := s.singletonClaim(key, s.instanceID); err != nil {
+			s.logger.Printf("lsp: workspace singleton claim failed: %v", err)
+			return
+		}
 		go watchSingleton(s.runCtx, key, s.instanceID, s.singletonInterval, s.singletonCurrent, func() {
 			s.logger.Printf("lsp: superseded by a newer server for this workspace; exiting")
 			s.shutdown.Store(true)
@@ -164,7 +175,13 @@ func (r fileRegistry) claim(key, id string) error {
 	if err := os.WriteFile(tmp, []byte(id), 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, r.path(key))
+	if err := os.Rename(tmp, r.path(key)); err != nil {
+		// Best-effort: drop the temp file so a failed claim does not
+		// leave an orphan in the shared registry dir.
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // current returns the instance id currently recorded for key, or "" if

--- a/internal/lsp/singleton.go
+++ b/internal/lsp/singleton.go
@@ -12,6 +12,15 @@ import (
 	"time"
 )
 
+// randRead and userCacheDir indirect the crypto/rand and os entry
+// points the registry depends on, so their otherwise-unreachable
+// failure branches can be driven red/green in tests. Production points
+// them at the real calls.
+var (
+	randRead     = rand.Read
+	userCacheDir = os.UserCacheDir
+)
+
 // singletonPollInterval is how often the workspace-singleton watcher
 // re-reads the registry to see whether a newer server has claimed the
 // same workspace. 5s converges within a few seconds of a reload while
@@ -59,11 +68,12 @@ func watchSingleton(
 // watchdog stays quiet), then races the freshly-spawned server.
 //
 // It is a no-op without a workspace root or instanceID (the feature is
-// off, or the client sent no rootUri). A failed claim leaves the server
-// running without singleton protection rather than risking it stepping
-// itself aside on a transient registry write error.
+// off, or the client sent no rootUri); New only sets instanceID when it
+// also wires the registry seams, so the two travel together. A failed
+// claim leaves the server running without singleton protection rather
+// than risking it stepping itself aside on a transient registry error.
 func (s *Server) startSingletonWatch(root string) {
-	if root == "" || s.instanceID == "" || s.singletonClaim == nil {
+	if root == "" || s.instanceID == "" {
 		return
 	}
 	key := workspaceKey(root)
@@ -112,7 +122,7 @@ func workspaceKey(root string) string {
 // step aside for itself.
 func newInstanceID() string {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
+	if _, err := randRead(b[:]); err != nil {
 		return ""
 	}
 	return hex.EncodeToString(b[:])
@@ -129,7 +139,7 @@ type fileRegistry struct{ dir string }
 // the OS cache dir and falls back to the temp dir so a claim never fails
 // purely because the cache dir is unavailable.
 func defaultRegistry() fileRegistry {
-	base, err := os.UserCacheDir()
+	base, err := userCacheDir()
 	if err != nil {
 		base = os.TempDir()
 	}
@@ -140,32 +150,21 @@ func (r fileRegistry) path(key string) string {
 	return filepath.Join(r.dir, key+".owner")
 }
 
-// claim records id as the current owner of key. The write is atomic
-// (temp file + rename) so a concurrent reader never observes a partial
-// id and a newer claim cleanly replaces an older one.
+// claim records id as the current owner of key. It writes to a
+// per-instance temp path and renames it onto the owner record: the
+// rename is atomic, so a concurrent reader sees either the old owner or
+// the new one, never a half-written id, and the id-tagged temp name
+// keeps two servers claiming the same workspace at once from clobbering
+// each other's temp file.
 func (r fileRegistry) claim(key, id string) error {
 	if err := os.MkdirAll(r.dir, 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(r.dir, key+".*.tmp")
-	if err != nil {
+	tmp := r.path(key) + "." + id + ".tmp"
+	if err := os.WriteFile(tmp, []byte(id), 0o600); err != nil {
 		return err
 	}
-	tmpName := tmp.Name()
-	if _, err := tmp.WriteString(id); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := os.Rename(tmpName, r.path(key)); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return nil
+	return os.Rename(tmp, r.path(key))
 }
 
 // current returns the instance id currently recorded for key, or "" if

--- a/internal/lsp/singleton.go
+++ b/internal/lsp/singleton.go
@@ -1,0 +1,193 @@
+package lsp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// singletonPollInterval is how often the workspace-singleton watcher
+// re-reads the registry to see whether a newer server has claimed the
+// same workspace. 5s converges within a few seconds of a reload while
+// keeping the per-tick cost (one small file read) negligible.
+const singletonPollInterval = 5 * time.Second
+
+// watchSingleton polls current(key) every interval and calls
+// onSuperseded the first time the workspace's recorded owner is a
+// different, non-empty instance — meaning a newer server claimed this
+// workspace and this one should step aside. It returns without calling
+// onSuperseded if ctx is canceled first (a normal shutdown). An empty
+// owner (registry unreadable or never written) is treated as "still
+// ours": we never step the last server aside on a transient read miss.
+// Splitting the loop from the registry probe keeps it unit-testable
+// with a fake current, mirroring watchParentProcess.
+func watchSingleton(
+	ctx context.Context,
+	key, instanceID string,
+	interval time.Duration,
+	current func(string) string,
+	onSuperseded func(),
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if owner := current(key); owner != "" && owner != instanceID {
+				onSuperseded()
+				return
+			}
+		}
+	}
+}
+
+// startSingletonWatch claims the workspace for this server (newest wins)
+// and launches the watcher that steps it aside once a newer server
+// claims the same workspace. It is the spec-silent companion to the
+// processId watchdog: the watchdog reaps a server whose editor host has
+// *died*, while this reaps one whose host is still *alive but orphaned*
+// — a leaked extension host that survives its own window, keeps the
+// server's stdin pipe open (so no EOF) and registers as alive (so the
+// watchdog stays quiet), then races the freshly-spawned server.
+//
+// It is a no-op without a workspace root or instanceID (the feature is
+// off, or the client sent no rootUri). A failed claim leaves the server
+// running without singleton protection rather than risking it stepping
+// itself aside on a transient registry write error.
+func (s *Server) startSingletonWatch(root string) {
+	if root == "" || s.instanceID == "" || s.singletonClaim == nil {
+		return
+	}
+	key := workspaceKey(root)
+	// Claim the workspace under this instance's id, overwriting any
+	// previous owner. Whichever server initialized most recently — the
+	// window the user just opened or reloaded — wins; an older server
+	// for the same workspace sees a different owner on its next poll.
+	if err := s.singletonClaim(key, s.instanceID); err != nil {
+		s.logger.Printf("lsp: workspace singleton claim failed: %v", err)
+		return
+	}
+	s.singletonWatchOnce.Do(func() {
+		go watchSingleton(s.runCtx, key, s.instanceID, s.singletonInterval, s.singletonCurrent, func() {
+			s.logger.Printf("lsp: superseded by a newer server for this workspace; exiting")
+			s.shutdown.Store(true)
+			s.stopPendingLints()
+			// Tell the editor this exit is intentional so its client
+			// does not treat the imminent close as a crash and restart
+			// us — that respawn loop is what kept the orphan alive.
+			_ = s.t.writeNotification("mdsmith/superseded", supersededParams{Reason: "superseded"})
+			s.onSupersededExit()
+		})
+	})
+}
+
+// supersededParams is the payload of the mdsmith/superseded
+// server-to-client notification. The reason is informational; the
+// extension keys off the method itself to suppress its restart.
+type supersededParams struct {
+	Reason string `json:"reason"`
+}
+
+// workspaceKey maps a workspace root path to a stable, filesystem-safe
+// registry key. Cleaning first makes "/w", "/w/" and "/w/." share one
+// key, so two editor windows on the same workspace contend for the same
+// owner record.
+func workspaceKey(root string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(root)))
+	return hex.EncodeToString(sum[:])
+}
+
+// newInstanceID returns a random per-process identifier used to tell
+// servers apart in the registry. Returns "" only if the OS RNG fails,
+// which makes the singleton a no-op (the server still runs); we never
+// fall back to a guessable id that could collide and cause a server to
+// step aside for itself.
+func newInstanceID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// fileRegistry records the current owner of each workspace as a small
+// file under a shared directory, so sibling server processes (launched
+// by different editor hosts, with no parent/child relationship) can see
+// each other's claims. One file per workspace key; its contents are the
+// owning instance id.
+type fileRegistry struct{ dir string }
+
+// defaultRegistry locates the per-user registry directory. It prefers
+// the OS cache dir and falls back to the temp dir so a claim never fails
+// purely because the cache dir is unavailable.
+func defaultRegistry() fileRegistry {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		base = os.TempDir()
+	}
+	return fileRegistry{dir: filepath.Join(base, "mdsmith", "lsp-singleton")}
+}
+
+func (r fileRegistry) path(key string) string {
+	return filepath.Join(r.dir, key+".owner")
+}
+
+// claim records id as the current owner of key. The write is atomic
+// (temp file + rename) so a concurrent reader never observes a partial
+// id and a newer claim cleanly replaces an older one.
+func (r fileRegistry) claim(key, id string) error {
+	if err := os.MkdirAll(r.dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(r.dir, key+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(id); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, r.path(key)); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// current returns the instance id currently recorded for key, or "" if
+// none is recorded or the file cannot be read. The empty case is
+// deliberately conflated with "no owner": watchSingleton treats it as
+// "still ours" so a transient read error never reaps the last server.
+//
+// This is a deliberate direct infra read, NOT routed through the
+// pkg/mdsmith Workspace seam that internal/lsp uses for linted content:
+// the owner record lives in the OS cache dir, outside any workspace, and
+// is cross-process coordination state. os.Open + io.ReadAll keeps that
+// distinction explicit rather than borrowing the workspace-sandbox
+// reader for a file that is not workspace content.
+func (r fileRegistry) current(key string) string {
+	f, err := os.Open(r.path(key))
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/lsp/singleton_test.go
+++ b/internal/lsp/singleton_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -223,4 +226,58 @@ func TestNewInstanceIDUniqueAndNonEmpty(t *testing.T) {
 	b := newInstanceID()
 	assert.NotEmpty(t, a)
 	assert.NotEqual(t, a, b, "each instance id must be distinct")
+}
+
+// The following tests drive the registry's failure branches and the OS
+// seams. They override package-level seams, so they do NOT run in
+// parallel; Go schedules every t.Parallel() test after the sequential
+// ones finish, so the override-and-restore never races a concurrent
+// reader.
+
+func TestNewInstanceIDEmptyOnRandFailure(t *testing.T) {
+	orig := randRead
+	t.Cleanup(func() { randRead = orig })
+	randRead = func([]byte) (int, error) { return 0, errors.New("rng down") }
+	assert.Empty(t, newInstanceID(), "a failed RNG yields no id, disabling the singleton")
+}
+
+func TestDefaultRegistryUsesCacheDir(t *testing.T) {
+	orig := userCacheDir
+	t.Cleanup(func() { userCacheDir = orig })
+	userCacheDir = func() (string, error) { return "/cache", nil }
+	assert.Equal(t, filepath.Join("/cache", "mdsmith", "lsp-singleton"), defaultRegistry().dir)
+}
+
+func TestDefaultRegistryFallsBackToTempDirWhenCacheUnavailable(t *testing.T) {
+	orig := userCacheDir
+	t.Cleanup(func() { userCacheDir = orig })
+	userCacheDir = func() (string, error) { return "", errors.New("no cache dir") }
+	assert.Equal(t, filepath.Join(os.TempDir(), "mdsmith", "lsp-singleton"), defaultRegistry().dir)
+}
+
+func TestFileRegistryClaimErrorsWhenDirUncreatable(t *testing.T) {
+	t.Parallel()
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	// r.dir sits under a regular file, so MkdirAll cannot create it.
+	r := fileRegistry{dir: filepath.Join(blocker, "sub")}
+	assert.Error(t, r.claim("k", "id"))
+}
+
+func TestFileRegistryClaimErrorsWhenTempPathIsDir(t *testing.T) {
+	t.Parallel()
+	r := fileRegistry{dir: t.TempDir()}
+	// claim writes to "<owner>.<id>.tmp"; a directory there makes the
+	// WriteFile step fail.
+	require.NoError(t, os.Mkdir(r.path("k")+"."+"id"+".tmp", 0o755))
+	assert.Error(t, r.claim("k", "id"))
+}
+
+func TestFileRegistryCurrentEmptyWhenNotReadable(t *testing.T) {
+	t.Parallel()
+	r := fileRegistry{dir: t.TempDir()}
+	// A directory at the owner path: os.Open succeeds but io.ReadAll
+	// fails, so current reports no owner rather than a bogus one.
+	require.NoError(t, os.Mkdir(r.path("k"), 0o755))
+	assert.Equal(t, "", r.current("k"))
 }

--- a/internal/lsp/singleton_test.go
+++ b/internal/lsp/singleton_test.go
@@ -132,6 +132,54 @@ func TestStartSingletonWatchSupersedesAndNotifies(t *testing.T) {
 	assert.Equal(t, workspaceKey("/work/space"), claimedKey, "must claim under the workspace key")
 	assert.Contains(t, buf.String(), "mdsmith/superseded",
 		"must notify the editor before exiting so its client does not restart us")
+	assert.Contains(t, buf.String(), `"reason":"superseded"`,
+		"must serialize the superseded reason payload the supersededParams struct declares")
+}
+
+func TestStartSingletonWatchNoopWithoutClaimSeam(t *testing.T) {
+	t.Parallel()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	s.instanceID = "me" // set, but the registry seam is not wired
+	s.singletonClaim = nil
+	s.singletonCurrent = func(string) string {
+		t.Error("must not start a watcher when the claim seam is nil")
+		return ""
+	}
+	s.startSingletonWatch("/work/space") // must not panic on the nil seam
+	time.Sleep(20 * time.Millisecond)
+}
+
+func TestStartSingletonWatchClaimsOnlyOnce(t *testing.T) {
+	t.Parallel()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	s.runCtx = ctx
+	s.instanceID = "me"
+	s.singletonInterval = time.Hour // keep the watcher idle
+	var claims int
+	s.singletonClaim = func(string, string) error {
+		claims++
+		return nil
+	}
+	s.singletonCurrent = func(string) string { return "me" }
+
+	s.startSingletonWatch("/work/space")
+	s.startSingletonWatch("/work/space") // a stray re-initialize must not re-claim
+	s.startSingletonWatch("/other")      // nor one with a different root
+	assert.Equal(t, 1, claims, "claim is guarded by the watch Once, so it runs exactly once")
+}
+
+func TestNewDefaultOnSupersededExitCallsOsExit(t *testing.T) {
+	orig := osExit
+	t.Cleanup(func() { osExit = orig })
+	var called bool
+	var code int
+	osExit = func(c int) { called, code = true, c }
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	s.onSupersededExit() // run the real default closure New() installed
+	assert.True(t, called, "the default onSupersededExit must exit the process")
+	assert.Equal(t, 0, code, "must exit cleanly so the editor does not treat it as a crash")
 }
 
 func TestStartSingletonWatchKeepsRunningWhenClaimFails(t *testing.T) {
@@ -271,6 +319,17 @@ func TestFileRegistryClaimErrorsWhenTempPathIsDir(t *testing.T) {
 	// WriteFile step fail.
 	require.NoError(t, os.Mkdir(r.path("k")+"."+"id"+".tmp", 0o755))
 	assert.Error(t, r.claim("k", "id"))
+}
+
+func TestFileRegistryClaimRemovesTempOnRenameFailure(t *testing.T) {
+	t.Parallel()
+	r := fileRegistry{dir: t.TempDir()}
+	// A directory at the owner path makes os.Rename(tmp, owner) fail
+	// (can't rename a file onto a directory) after WriteFile succeeds.
+	require.NoError(t, os.Mkdir(r.path("k"), 0o755))
+	assert.Error(t, r.claim("k", "id"))
+	_, statErr := os.Stat(r.path("k") + "." + "id" + ".tmp")
+	assert.True(t, os.IsNotExist(statErr), "a failed claim must not leave its temp file behind")
 }
 
 func TestFileRegistryCurrentEmptyWhenNotReadable(t *testing.T) {

--- a/internal/lsp/singleton_test.go
+++ b/internal/lsp/singleton_test.go
@@ -1,0 +1,226 @@
+package lsp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+func TestWatchSingletonFiresWhenOwnerChanges(t *testing.T) {
+	t.Parallel()
+	var fired atomic.Bool
+	watchSingleton(context.Background(), "k", "me", time.Millisecond,
+		func(string) string { return "newer-instance" },
+		func() { fired.Store(true) })
+	assert.True(t, fired.Load(), "must step aside once a different owner claims the workspace")
+}
+
+func TestWatchSingletonStaysWhenOwnerMatches(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	var fired atomic.Bool
+	watchSingleton(ctx, "k", "me", time.Millisecond,
+		func(string) string { return "me" },
+		func() { fired.Store(true) })
+	assert.False(t, fired.Load(), "must not step aside while it is still the owner")
+}
+
+func TestWatchSingletonStaysWhenOwnerEmpty(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	var fired atomic.Bool
+	watchSingleton(ctx, "k", "me", time.Millisecond,
+		func(string) string { return "" },
+		func() { fired.Store(true) })
+	assert.False(t, fired.Load(), "an empty owner (unreadable registry) must not reap the last server")
+}
+
+func TestWatchSingletonStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var fired atomic.Bool
+	watchSingleton(ctx, "k", "me", time.Hour,
+		func(string) string { return "newer-instance" },
+		func() { fired.Store(true) })
+	assert.False(t, fired.Load(), "a canceled watcher must not fire onSuperseded")
+}
+
+func TestStartSingletonWatchNoopWithoutRoot(t *testing.T) {
+	t.Parallel()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	s.instanceID = "me"
+	s.singletonInterval = time.Millisecond
+	s.singletonClaim = func(string, string) error {
+		t.Error("must not claim a workspace when no root was provided")
+		return nil
+	}
+	s.startSingletonWatch("")
+	time.Sleep(20 * time.Millisecond)
+}
+
+func TestStartSingletonWatchNoopWithoutInstanceID(t *testing.T) {
+	t.Parallel()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	s.instanceID = "" // feature off
+	s.singletonClaim = func(string, string) error {
+		t.Error("must not claim a workspace when the feature is off")
+		return nil
+	}
+	s.startSingletonWatch("/work/space")
+	time.Sleep(20 * time.Millisecond)
+}
+
+func TestStartSingletonWatchStaysWhileOwner(t *testing.T) {
+	t.Parallel()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	s.runCtx = ctx
+	s.instanceID = "me"
+	s.singletonInterval = time.Millisecond
+	s.singletonClaim = func(string, string) error { return nil }
+	s.singletonCurrent = func(string) string { return "me" }
+	var exited atomic.Bool
+	s.onSupersededExit = func() { exited.Store(true) }
+
+	s.startSingletonWatch("/work/space")
+	time.Sleep(30 * time.Millisecond)
+	assert.False(t, exited.Load(), "must not step aside while it is still the registered owner")
+}
+
+func TestStartSingletonWatchSupersedesAndNotifies(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	s.runCtx = ctx
+	s.instanceID = "me"
+	s.singletonInterval = time.Millisecond
+	var claimedKey, claimedID string
+	s.singletonClaim = func(key, id string) error {
+		claimedKey, claimedID = key, id
+		return nil
+	}
+	s.singletonCurrent = func(string) string { return "newer-instance" }
+	exited := make(chan struct{})
+	s.onSupersededExit = func() { close(exited) }
+
+	s.startSingletonWatch("/work/space")
+
+	select {
+	case <-exited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not step aside when a newer server claimed the workspace")
+	}
+	assert.Equal(t, "me", claimedID, "must claim the workspace under its own instance id")
+	assert.Equal(t, workspaceKey("/work/space"), claimedKey, "must claim under the workspace key")
+	assert.Contains(t, buf.String(), "mdsmith/superseded",
+		"must notify the editor before exiting so its client does not restart us")
+}
+
+func TestStartSingletonWatchKeepsRunningWhenClaimFails(t *testing.T) {
+	t.Parallel()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	s.runCtx = ctx
+	s.instanceID = "me"
+	s.singletonInterval = time.Millisecond
+	s.singletonClaim = func(string, string) error { return io.ErrClosedPipe }
+	s.singletonCurrent = func(string) string {
+		t.Error("must not watch (and risk self-supersession) when the claim failed")
+		return "newer-instance"
+	}
+	var exited atomic.Bool
+	s.onSupersededExit = func() { exited.Store(true) }
+
+	s.startSingletonWatch("/work/space")
+	time.Sleep(30 * time.Millisecond)
+	assert.False(t, exited.Load(), "a failed claim must leave the server running, not reap it")
+}
+
+func TestHandleInitializeClaimsWorkspaceSingleton(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel) // stop the watcher goroutine started by handleInitialize
+	s.runCtx = ctx
+	s.instanceID = "me"
+	s.singletonInterval = time.Hour // keep the watcher idle for the test
+	var claimedKey, claimedID string
+	s.singletonClaim = func(key, id string) error {
+		claimedKey, claimedID = key, id
+		return nil
+	}
+	s.singletonCurrent = func(string) string { return "me" }
+
+	msg := &requestMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"processId":null,"rootUri":"file:///work/space"}`),
+	}
+	s.handleInitialize(msg)
+
+	assert.Equal(t, "me", claimedID, "initialize must claim the workspace singleton")
+	assert.Equal(t, workspaceKey("/work/space"), claimedKey,
+		"initialize must claim under the rootUri's workspace key")
+}
+
+func TestNewEnablesWorkspaceSingleton(t *testing.T) {
+	t.Parallel()
+	on := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All(), EnableWorkspaceSingleton: true})
+	assert.NotEmpty(t, on.instanceID, "an enabled server gets a real instance id")
+	require.NotNil(t, on.singletonClaim, "an enabled server wires the registry claim seam")
+	require.NotNil(t, on.singletonCurrent, "an enabled server wires the registry read seam")
+
+	off := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	assert.Empty(t, off.instanceID, "a disabled server has no instance id, so the watch is a no-op")
+	assert.Nil(t, off.singletonClaim, "a disabled server wires no registry seam")
+}
+
+func TestFileRegistryClaimCurrentRoundTrip(t *testing.T) {
+	t.Parallel()
+	r := fileRegistry{dir: t.TempDir()}
+	assert.Equal(t, "", r.current("k"), "no claim yet reads as no owner")
+
+	require.NoError(t, r.claim("k", "id-1"))
+	assert.Equal(t, "id-1", r.current("k"), "current reads back the claimed id")
+
+	require.NoError(t, r.claim("k", "id-2"))
+	assert.Equal(t, "id-2", r.current("k"), "a newer claim overwrites the older owner")
+
+	assert.Equal(t, "", r.current("other"), "an unrelated key has no owner")
+}
+
+func TestWorkspaceKeyStableAndDistinct(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, workspaceKey("/a/b"), workspaceKey("/a/b/"),
+		"a trailing slash must not change the key")
+	assert.Equal(t, workspaceKey("/a/b"), workspaceKey("/a/./b"),
+		"a redundant path element must not change the key")
+	assert.NotEqual(t, workspaceKey("/a/b"), workspaceKey("/a/c"),
+		"distinct workspaces get distinct keys")
+}
+
+func TestNewInstanceIDUniqueAndNonEmpty(t *testing.T) {
+	t.Parallel()
+	a := newInstanceID()
+	b := newInstanceID()
+	assert.NotEmpty(t, a)
+	assert.NotEqual(t, a, b, "each instance id must be distinct")
+}

--- a/plan/231_lsp-workspace-singleton.md
+++ b/plan/231_lsp-workspace-singleton.md
@@ -1,0 +1,81 @@
+---
+id: 231
+title: LSP newest-wins workspace singleton
+status: "✅"
+summary: >-
+  A leaked editor extension host can outlive its
+  window while staying alive and holding the LSP
+  server's stdin open, so neither the stdin-EOF
+  exit nor the processId watchdog fires and an
+  orphaned `mdsmith lsp` keeps running beside the
+  one a reload spawned. Add a newest-wins workspace
+  singleton: each server records its workspace root
+  in a shared registry under a per-process id; once
+  a newer server claims the same root, the older one
+  sends `mdsmith/superseded` and exits, and the VS
+  Code extension suppresses the restart so exactly
+  one server stays live per workspace.
+model: ""
+depends-on: []
+---
+# LSP newest-wins workspace singleton
+
+## Goal
+
+The processId watchdog
+([internal/lsp/parentwatch.go](../internal/lsp/parentwatch.go))
+reaps an `mdsmith lsp` server whose editor host has
+*died*. It cannot reap one whose host is *alive but
+orphaned* — a VS Code / code-server extension host
+that survives its own window after an abrupt
+reload. That host keeps the server's stdin pipe open
+(so no EOF arrives) and still reports as alive (so
+the watchdog stays quiet), and its language client
+even respawns the server if it is killed. The result
+is two servers for one workspace where the user wants
+one.
+
+Add a newest-wins workspace singleton so the older
+server steps aside on its own, leaving exactly one
+live server per workspace root.
+
+## Tasks
+
+1. Add the registry and watcher in
+   [internal/lsp/singleton.go](../internal/lsp/singleton.go):
+   a per-workspace owner file under the OS cache dir
+   (atomic claim, plain read), a `watchSingleton`
+   poll loop mirroring `watchParentProcess`, and a
+   `startSingletonWatch` that claims the workspace and
+   steps aside when a newer owner appears.
+2. On step-aside, send the `mdsmith/superseded`
+   server-to-client notification, then exit — so the
+   client knows the close is intentional.
+3. Gate it behind `Options.EnableWorkspaceSingleton`
+   in [internal/lsp/server.go](../internal/lsp/server.go);
+   call `startSingletonWatch` from `handleInitialize`;
+   enable it in
+   [cmd/mdsmith/lsp.go](../cmd/mdsmith/lsp.go).
+4. In the VS Code extension, suppress the restart on
+   `mdsmith/superseded`: a `decideClose` policy in
+   [editors/vscode/src/wiring.ts](../editors/vscode/src/wiring.ts)
+   and a `markSuperseded` hook on the error handler in
+   [editors/vscode/src/extension.ts](../editors/vscode/src/extension.ts).
+5. Document the behavior and the `mdsmith/superseded`
+   contract in the troubleshooting section of
+   [the VS Code guide](../docs/guides/editors/vscode.md).
+
+## Acceptance Criteria
+
+- [x] A second server started for the same workspace
+  root makes the older one send `mdsmith/superseded`
+  and exit, leaving one live server.
+- [x] The feature is off by default so unit tests
+  neither write to the real cache dir nor leak a
+  watcher goroutine; the singleton tests drive the
+  seams directly.
+- [x] The VS Code error handler does not restart the
+  server after `mdsmith/superseded`.
+- [x] `go test ./...` and
+  `go tool golangci-lint run` pass.
+- [x] `go run ./cmd/mdsmith check .` passes.


### PR DESCRIPTION
## Problem

Two `mdsmith lsp` servers end up running for one workspace, and reloading the window or killing the process doesn't converge to one.

Root cause is upstream of mdsmith: a VS Code / code-server **extension host that survives its own window** after an abrupt reload. mdsmith's two existing exit paths both key off the host being *dead*, and this host is *alive*:

- **stdin EOF** — the leaked host holds the server's stdin pipe open, so EOF never arrives.
- **processId watchdog** (`b785ed8`) — the host process still reports as alive, so the watchdog (correctly) stays quiet.

Worse, the orphaned host's `LanguageClient` **respawns** the server if you kill it (`closed()` → `Restart`), which is the "kill mdsmith → it comes back" loop.

## Fix — newest-wins workspace singleton

A third reaping mechanism that targets the *alive-but-orphaned* case:

- **`internal/lsp/singleton.go`** — each server records its `initialize` workspace root in a shared per-user registry under a random per-process id (atomic claim; plain infra read, deliberately *not* the workspace sandbox seam since the record lives in the OS cache dir). `watchSingleton` polls (mirroring `watchParentProcess`); once a **newer** server records the same root, the older one steps aside.
- On step-aside it sends the **`mdsmith/superseded`** notification, then exits — marking the close intentional.
- Gated behind `Options.EnableWorkspaceSingleton` (on in `cmd/mdsmith`, off in unit tests so they neither touch the real cache dir nor leak a goroutine; the singleton tests drive the seams directly).
- **VS Code extension** — `decideClose` (`wiring.ts`) + a `markSuperseded` hook on the error handler suppress the restart on `mdsmith/superseded`, breaking the respawn loop.

Net: the most recently started editor keeps the only live server per workspace.

## Scope / honesty note

This self-heals **once both sides run a build that has the fix**. It can't retroactively reap an already-running pre-fix orphan (e.g. a current `0.31.0` server) — that still needs a one-time `kill <extension-host-pid>`. The new VS Code troubleshooting entry says exactly this.

## Tests

- Go: `watchSingleton` fire/stay/cancel, claim-fail safety, supersede-and-notify, `handleInitialize` claim wiring, file-registry round-trip, key stability, feature-gate (`internal/lsp/singleton_test.go`). The supersede test locks the `mdsmith/superseded` wire contract.
- TS: `decideClose` policy incl. the superseded short-circuit and the restart-rate window (`wiring.test.ts`).
- `go test ./...`, `go vet`, `golangci-lint`, `bun test`, and `mdsmith check .` all pass.

Tracked by [plan 231](plan/231_lsp-workspace-singleton.md).

https://claude.ai/code/session_01NnCkt1PUZBHotU3ytyNBQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnCkt1PUZBHotU3ytyNBQz)_