### PR TITLE
refactor(vscode): import RestartPolicyState as a type-only import

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -22,7 +22,7 @@ import {
   notifyConfigChangeToClient,
   shouldFixOnSave,
   startupErrorMessage,
-  RestartPolicyState,
+  type RestartPolicyState,
   RUN_ON_TYPE
 } from "./wiring";
 import { findBinaryCandidates, resolveBinary } from "./binary";


### PR DESCRIPTION
Follow-up to the Copilot review on #466 (which is now merged).

`RestartPolicyState` is a type-only export from `wiring.ts`, but `extension.ts` imported it as a value. This marks it `type` so it can never become an accidental runtime import and stays correct under `verbatimModuleSyntax` / ESM strictness — matching the type-only import pattern already used elsewhere (e.g. `wiring.test.ts`).

```diff
-  RestartPolicyState,
+  type RestartPolicyState,
```

Non-functional cleanup (the value import compiled fine); split out of #466 so it didn't disrupt that PR's in-flight merge.

**Verified:** `bunx tsc --noEmit` (0 errors) and `bun test` (145 pass) on this branch off the merged `main`.

https://claude.ai/code/session_01NnCkt1PUZBHotU3ytyNBQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnCkt1PUZBHotU3ytyNBQz)_