### PR TITLE
feat(include): heading-offset parameter (+ dark-mode logo mark fix)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -157,5 +157,5 @@ footer: |
 | 225 | ✅     |        | [Add internal/punkt to the architecture layering map](plan/225_arch-fix-punkt-layering.md)                                              |
 | 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |
 | 231 | ✅     |        | [LSP newest-wins workspace singleton](plan/231_lsp-workspace-singleton.md)                                                              |
-| 232 | 🔳     | opus   | [include heading-offset parameter](plan/232_include-heading-offset.md)                                                                  |
+| 232 | ✅     | opus   | [include heading-offset parameter](plan/232_include-heading-offset.md)                                                                  |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -157,4 +157,5 @@ footer: |
 | 225 | ✅     |        | [Add internal/punkt to the architecture layering map](plan/225_arch-fix-punkt-layering.md)                                              |
 | 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |
 | 231 | ✅     |        | [LSP newest-wins workspace singleton](plan/231_lsp-workspace-singleton.md)                                                              |
+| 232 | 🔳     | opus   | [include heading-offset parameter](plan/232_include-heading-offset.md)                                                                  |
 <?/catalog?>

--- a/docs/guides/directives/generating-content.md
+++ b/docs/guides/directives/generating-content.md
@@ -264,6 +264,28 @@ Steps here.
 Without this parameter, included headings keep their
 original level, which may break heading hierarchy.
 
+### Heading-offset adjustment
+
+To shift every included heading by a fixed amount, use
+`heading-offset` with a signed integer from -6 to 6:
+
+```markdown
+<?include
+file: features.md
+heading-offset: "1"
+?>
+## Was An H1 In The Source
+<?/include?>
+```
+
+A positive value demotes headings; a negative value
+promotes them. Unlike `heading-level: "absolute"`, the
+shift does not depend on a preceding heading, so it also
+works at the document root — handy when a file's visual
+title is a logo or image rather than an H1.
+`heading-offset` and `heading-level` are mutually
+exclusive.
+
 ### Link rewriting
 
 Relative links in included content are automatically

--- a/docs/guides/directives/generating-content.md
+++ b/docs/guides/directives/generating-content.md
@@ -283,8 +283,9 @@ promotes them. Unlike `heading-level: "absolute"`, the
 shift does not depend on a preceding heading, so it also
 works at the document root — handy when a file's visual
 title is a logo or image rather than an H1.
-`heading-offset` and `heading-level` are mutually
-exclusive.
+`heading-offset` cannot combine with `heading-level` or
+`extract:` — those parameters are mutually exclusive with
+it.
 
 ### Link rewriting
 

--- a/internal/directives/generating-content.md
+++ b/internal/directives/generating-content.md
@@ -55,6 +55,10 @@ so they nest under the include site's parent
 heading; omit it to keep source heading levels
 unchanged. No other value is accepted.
 
+`heading-offset: "N"` shifts every included heading by
+the signed integer N (-6 to 6), so it works even with no
+parent heading. It cannot combine with `heading-level`.
+
 See the full
 [generating-content guide](../../docs/guides/directives/generating-content.md)
 for sort orders, gitignore filtering, format

--- a/internal/directives/generating-content.md
+++ b/internal/directives/generating-content.md
@@ -57,7 +57,8 @@ unchanged. No other value is accepted.
 
 `heading-offset: "N"` shifts every included heading by
 the signed integer N (-6 to 6), so it works even with no
-parent heading. It cannot combine with `heading-level`.
+parent heading. It cannot combine with `heading-level`
+or `extract:`.
 
 See the full
 [generating-content guide](../../docs/guides/directives/generating-content.md)

--- a/internal/rules/MDS021-include/README.md
+++ b/internal/rules/MDS021-include/README.md
@@ -49,6 +49,7 @@ for details.
 | `strip-frontmatter` | no       | `"true"` | Remove YAML frontmatter (incompatible with `extract:`)                                     |
 | `wrap`              | no       | --       | Wrap in code fence (value = language)                                                      |
 | `heading-level`     | no       | --       | `"absolute"`: shift headings to nest under parent (incompatible with `extract:`)           |
+| `heading-offset`    | no       | --       | Signed integer -6 to 6: shift every heading by N (incompatible with `heading-level`)       |
 
 ## Link Adjustment
 
@@ -77,6 +78,19 @@ The included file has `## Build` (level 2) and
 
 When the marker sits at document root (no preceding
 heading), no shift is applied.
+
+## Heading-Offset Adjustment
+
+When `heading-offset: "N"` is set, every heading in the
+included content shifts by N levels. `N` is a signed
+integer from -6 to 6. A positive value demotes a heading
+(adds a `#`); a negative value promotes it. Levels are
+capped at the 1-6 range.
+
+Unlike `heading-level: "absolute"`, the shift is fixed. It
+does not read a preceding heading, so it also applies at
+the document root. `heading-offset` and `heading-level`
+are mutually exclusive.
 
 ## Cycle Detection
 
@@ -170,6 +184,20 @@ Details.
 <?/include?>
 ```
 
+### With Heading Offset
+
+Demote every heading in the included file by one level,
+even when no heading precedes the marker:
+
+```markdown
+<?include
+file: features.md
+heading-offset: "1"
+?>
+## Was An H1 In The Source
+<?/include?>
+```
+
 ### With Link Rewriting
 
 Given `DEVELOPMENT.md` in the repo root contains
@@ -208,9 +236,9 @@ ambiguous: the directive surfaces a lint error
 listing the keys. Frontmatter scalars sit under the
 `frontmatter` key: `extract: frontmatter.title`.
 
-`extract:` is incompatible with `strip-frontmatter:`
-and `heading-level:`. The projection returns one
-scalar, so those parameters do not apply.
+`extract:` is incompatible with `strip-frontmatter:`,
+`heading-level:`, and `heading-offset:`. The projection
+returns one scalar, so those parameters do not apply.
 
 ### Bad — Outdated Content
 
@@ -224,23 +252,26 @@ Outdated content
 
 ## Diagnostics
 
-| Condition              | Message                                                                 |
-| ---------------------- | ----------------------------------------------------------------------- |
-| content mismatch       | generated section is out of date                                        |
-| missing file           | include file "x.md" not found                                           |
-| no file param          | include directive missing required "file" parameter                     |
-| absolute path          | include directive has absolute file path                                |
-| escapes root           | include file path escapes project root                                  |
-| no root for dotdot     | include file path contains ".." but project root is not configured      |
-| invalid heading-level  | include directive "heading-level" must be "absolute"                    |
-| empty extract          | include directive "extract" value is empty                              |
-| extract + sfm          | include directive "extract" cannot be combined with "strip-frontmatter" |
-| extract + hl           | include directive "extract" cannot be combined with "heading-level"     |
-| extract miss           | extract: missing key "x" in extract projection                          |
-| extract no kind        | extract: "x.md" has no resolved kind; cannot project a typed value      |
-| extract not conformant | extract: target file does not conform to its schema: ...                |
-| cyclic include         | cyclic include: a.md -> b.md -> a.md                                    |
-| depth exceeded         | include depth exceeds maximum (10)                                      |
+| Condition              | Message                                                                    |
+| ---------------------- | -------------------------------------------------------------------------- |
+| content mismatch       | generated section is out of date                                           |
+| missing file           | include file "x.md" not found                                              |
+| no file param          | include directive missing required "file" parameter                        |
+| absolute path          | include directive has absolute file path                                   |
+| escapes root           | include file path escapes project root                                     |
+| no root for dotdot     | include file path contains ".." but project root is not configured         |
+| invalid heading-level  | include directive "heading-level" must be "absolute"                       |
+| invalid heading-offset | include directive "heading-offset" must be an integer between -6 and 6     |
+| offset + level         | include directive "heading-offset" cannot be combined with "heading-level" |
+| empty extract          | include directive "extract" value is empty                                 |
+| extract + sfm          | include directive "extract" cannot be combined with "strip-frontmatter"    |
+| extract + hl           | include directive "extract" cannot be combined with "heading-level"        |
+| extract + offset       | include directive "extract" cannot be combined with "heading-offset"       |
+| extract miss           | extract: missing key "x" in extract projection                             |
+| extract no kind        | extract: "x.md" has no resolved kind; cannot project a typed value         |
+| extract not conformant | extract: target file does not conform to its schema: ...                   |
+| cyclic include         | cyclic include: a.md -> b.md -> a.md                                       |
+| depth exceeded         | include depth exceeds maximum (10)                                         |
 
 ## Pattern
 

--- a/internal/rules/MDS021-include/README.md
+++ b/internal/rules/MDS021-include/README.md
@@ -42,14 +42,14 @@ for details.
 
 ## Parameters
 
-| Parameter           | Required | Default  | Description                                                                                |
-| ------------------- | -------- | -------- | ------------------------------------------------------------------------------------------ |
-| `file`              | yes      | --       | Relative path to include                                                                   |
-| `extract`           | no       | --       | Dotted path through the extract projection of a kind-typed `file:`. Splices one leaf value |
-| `strip-frontmatter` | no       | `"true"` | Remove YAML frontmatter (incompatible with `extract:`)                                     |
-| `wrap`              | no       | --       | Wrap in code fence (value = language)                                                      |
-| `heading-level`     | no       | --       | `"absolute"`: shift headings to nest under parent (incompatible with `extract:`)           |
-| `heading-offset`    | no       | --       | Signed integer -6 to 6: shift every heading by N (incompatible with `heading-level`)       |
+| Parameter           | Required | Default  | Description                                                                                      |
+| ------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `file`              | yes      | --       | Relative path to include                                                                         |
+| `extract`           | no       | --       | Dotted path through the extract projection of a kind-typed `file:`. Splices one leaf value       |
+| `strip-frontmatter` | no       | `"true"` | Remove YAML frontmatter (incompatible with `extract:`)                                           |
+| `wrap`              | no       | --       | Wrap in code fence (value = language)                                                            |
+| `heading-level`     | no       | --       | `"absolute"`: shift headings to nest under parent (incompatible with `extract:`)                 |
+| `heading-offset`    | no       | --       | Signed integer -6 to 6: shift every heading by N (incompatible with `heading-level`, `extract:`) |
 
 ## Link Adjustment
 
@@ -89,8 +89,8 @@ capped at the 1-6 range.
 
 Unlike `heading-level: "absolute"`, the shift is fixed. It
 does not read a preceding heading, so it also applies at
-the document root. `heading-offset` and `heading-level`
-are mutually exclusive.
+the document root. `heading-offset` cannot combine with
+`heading-level` or `extract:`.
 
 ## Cycle Detection
 

--- a/internal/rules/MDS021-include/bad/data/offset-src.md
+++ b/internal/rules/MDS021-include/bad/data/offset-src.md
@@ -1,0 +1,9 @@
+Overview of the included content goes here first.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.

--- a/internal/rules/MDS021-include/bad/heading-offset.md
+++ b/internal/rules/MDS021-include/bad/heading-offset.md
@@ -1,0 +1,22 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: generated section is out of date
+---
+# Heading Offset Example
+
+<?include
+file: data/offset-src.md
+heading-offset: "1"
+?>
+Overview of the included content goes here first.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.
+<?/include?>

--- a/internal/rules/MDS021-include/fixed/data/offset-src.md
+++ b/internal/rules/MDS021-include/fixed/data/offset-src.md
@@ -1,0 +1,9 @@
+Overview of the included content goes here first.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.

--- a/internal/rules/MDS021-include/fixed/heading-offset.md
+++ b/internal/rules/MDS021-include/fixed/heading-offset.md
@@ -1,0 +1,16 @@
+# Heading Offset Example
+
+<?include
+file: data/offset-src.md
+heading-offset: "1"
+?>
+Overview of the included content goes here first.
+
+## Primary
+
+Body for the primary section with a few words.
+
+### Secondary
+
+Body for the secondary section with a few words.
+<?/include?>

--- a/internal/rules/MDS021-include/good/data/offset-src.md
+++ b/internal/rules/MDS021-include/good/data/offset-src.md
@@ -1,0 +1,9 @@
+Overview of the included content goes here first.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.

--- a/internal/rules/MDS021-include/good/heading-offset.md
+++ b/internal/rules/MDS021-include/good/heading-offset.md
@@ -1,0 +1,16 @@
+# Heading Offset Example
+
+<?include
+file: data/offset-src.md
+heading-offset: "1"
+?>
+Overview of the included content goes here first.
+
+## Primary
+
+Body for the primary section with a few words.
+
+### Secondary
+
+Body for the secondary section with a few words.
+<?/include?>

--- a/internal/rules/include/headings.go
+++ b/internal/rules/include/headings.go
@@ -48,6 +48,20 @@ func adjustHeadings(content string, parentLevel int) string {
 	return strings.Join(result, "\n")
 }
 
+// adjustHeadingsByOffset shifts every heading level in content by offset,
+// clamped to the 1..6 range. An offset of 0 returns content unchanged.
+// Unlike adjustHeadings, the shift is uniform and source-absolute: it does
+// not read a parent heading level and may move headings up (negative
+// offset), so it calls applyShift directly without the "skip when shift
+// <= 0" guard that parent-relative nesting needs.
+func adjustHeadingsByOffset(content string, offset int) string {
+	if offset == 0 {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	return strings.Join(applyShift(lines, offset), "\n")
+}
+
 // findMinHeadingLevel scans lines and returns the minimum heading level found,
 // ignoring lines inside fenced code blocks. Returns 0 if no headings are found.
 func findMinHeadingLevel(lines []string) int {

--- a/internal/rules/include/headings_test.go
+++ b/internal/rules/include/headings_test.go
@@ -141,6 +141,72 @@ func TestAdjustHeadings_CodeBlocks(t *testing.T) {
 	}
 }
 
+func TestAdjustHeadingsByOffset(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		offset  int
+		want    string
+	}{
+		{
+			name:    "positive offset demotes ATX headings",
+			content: "# One\n\n## Two\n\nText.\n",
+			offset:  1,
+			want:    "## One\n\n### Two\n\nText.\n",
+		},
+		{
+			name:    "negative offset promotes ATX headings",
+			content: "## Two\n\n### Three\n",
+			offset:  -1,
+			want:    "# Two\n\n## Three\n",
+		},
+		{
+			name:    "offset 0 returns unchanged",
+			content: "## Two\n\n### Three\n",
+			offset:  0,
+			want:    "## Two\n\n### Three\n",
+		},
+		{
+			name:    "negative offset clamps at level 1",
+			content: "# One\n\n## Two\n",
+			offset:  -1,
+			want:    "# One\n\n# Two\n",
+		},
+		{
+			name:    "positive offset clamps at level 6",
+			content: "##### Five\n\n###### Six\n",
+			offset:  2,
+			want:    "###### Five\n\n###### Six\n",
+		},
+		{
+			name:    "setext h1 converted to ATX when shifted",
+			content: "Title\n=====\n\nBody.\n",
+			offset:  1,
+			want:    "## Title\n\nBody.\n",
+		},
+		{
+			name:    "hash lines inside code fence are not shifted",
+			content: "# Real\n\n```bash\n# comment\n```\n",
+			offset:  1,
+			want:    "## Real\n\n```bash\n# comment\n```\n",
+		},
+		{
+			name:    "no headings returns unchanged",
+			content: "Just text.\n\nMore text.\n",
+			offset:  2,
+			want:    "Just text.\n\nMore text.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adjustHeadingsByOffset(tt.content, tt.offset)
+			assert.Equal(t, tt.want, got,
+				"adjustHeadingsByOffset() =\n%q\nwant:\n%q", got, tt.want)
+		})
+	}
+}
+
 // --- isResultPrevLineFence ---
 
 // TestIsResultPrevLineFence pins both branches: empty result

--- a/internal/rules/include/headings_test.go
+++ b/internal/rules/include/headings_test.go
@@ -178,6 +178,24 @@ func TestAdjustHeadingsByOffset(t *testing.T) {
 			offset:  2,
 			want:    "###### Five\n\n###### Six\n",
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adjustHeadingsByOffset(tt.content, tt.offset)
+			assert.Equal(t, tt.want, got,
+				"adjustHeadingsByOffset() =\n%q\nwant:\n%q", got, tt.want)
+		})
+	}
+}
+
+func TestAdjustHeadingsByOffset_SetextAndFences(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		offset  int
+		want    string
+	}{
 		{
 			name:    "setext h1 converted to ATX when shifted",
 			content: "Title\n=====\n\nBody.\n",

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -149,6 +149,19 @@ func validateIncludeDirective(
 		}
 	}
 
+	// Validate heading-offset parameter if present.
+	if ho, ok := params["heading-offset"]; ok {
+		n, err := strconv.Atoi(strings.TrimSpace(ho))
+		if err != nil || n < -6 || n > 6 {
+			return []lint.Diagnostic{makeDiag(filePath, line,
+				`include directive "heading-offset" must be an integer between -6 and 6`)}
+		}
+		if _, hasHL := params["heading-level"]; hasHL {
+			return []lint.Diagnostic{makeDiag(filePath, line,
+				`include directive "heading-offset" cannot be combined with "heading-level"`)}
+		}
+	}
+
 	// Validate extract parameter if present.
 	if ex, ok := params["extract"]; ok {
 		if strings.TrimSpace(ex) == "" {
@@ -162,6 +175,10 @@ func validateIncludeDirective(
 		if _, hasHL := params["heading-level"]; hasHL {
 			return []lint.Diagnostic{makeDiag(filePath, line,
 				`include directive "extract" cannot be combined with "heading-level"`)}
+		}
+		if _, hasHO := params["heading-offset"]; hasHO {
+			return []lint.Diagnostic{makeDiag(filePath, line,
+				`include directive "extract" cannot be combined with "heading-offset"`)}
 		}
 		// generateIncludeContent returns the projected leaf directly
 		// for extract: directives and never runs the wrap / source-dir
@@ -323,6 +340,12 @@ func processIncludedContent(
 
 	if params["heading-level"] == "absolute" {
 		text = adjustHeadings(text, findParentHeadingLevel(f, line))
+	}
+	if off, ok := params["heading-offset"]; ok {
+		// Validated to a -6..6 integer in validateIncludeDirective; on any
+		// unexpected parse failure fall back to 0 (no shift).
+		n, _ := strconv.Atoi(strings.TrimSpace(off))
+		text = adjustHeadingsByOffset(text, n)
 	}
 	if wrap, ok := params["wrap"]; ok {
 		fence := strings.Repeat("`", minFenceLen(text))

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -150,49 +150,78 @@ func validateIncludeDirective(
 	}
 
 	// Validate heading-offset parameter if present.
-	if ho, ok := params["heading-offset"]; ok {
-		n, err := strconv.Atoi(strings.TrimSpace(ho))
-		if err != nil || n < -6 || n > 6 {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "heading-offset" must be an integer between -6 and 6`)}
-		}
-		if _, hasHL := params["heading-level"]; hasHL {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "heading-offset" cannot be combined with "heading-level"`)}
-		}
+	if diags := validateHeadingOffset(filePath, line, params); len(diags) > 0 {
+		return diags
 	}
 
 	// Validate extract parameter if present.
-	if ex, ok := params["extract"]; ok {
-		if strings.TrimSpace(ex) == "" {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "extract" value is empty`)}
-		}
-		if _, hasSFM := params["strip-frontmatter"]; hasSFM {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "extract" cannot be combined with "strip-frontmatter"`)}
-		}
-		if _, hasHL := params["heading-level"]; hasHL {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "extract" cannot be combined with "heading-level"`)}
-		}
-		if _, hasHO := params["heading-offset"]; hasHO {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "extract" cannot be combined with "heading-offset"`)}
-		}
-		// generateIncludeContent returns the projected leaf directly
-		// for extract: directives and never runs the wrap / source-dir
-		// pipeline, so silently accepting these params would drop them.
-		if _, hasWrap := params["wrap"]; hasWrap {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "extract" cannot be combined with "wrap"`)}
-		}
-		if _, hasSD := params["source-dir"]; hasSD {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "extract" cannot be combined with "source-dir"`)}
-		}
+	if diags := validateExtractParam(filePath, line, params); len(diags) > 0 {
+		return diags
 	}
 
+	return nil
+}
+
+// validateExtractParam checks the extract parameter when present: a non-empty
+// value that cannot combine with strip-frontmatter, heading-level,
+// heading-offset, wrap, or source-dir. extract returns a single projected
+// leaf, so the body-processing pipeline does not apply.
+func validateExtractParam(
+	filePath string, line int, params map[string]string,
+) []lint.Diagnostic {
+	ex, ok := params["extract"]
+	if !ok {
+		return nil
+	}
+	if strings.TrimSpace(ex) == "" {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "extract" value is empty`)}
+	}
+	if _, hasSFM := params["strip-frontmatter"]; hasSFM {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "extract" cannot be combined with "strip-frontmatter"`)}
+	}
+	if _, hasHL := params["heading-level"]; hasHL {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "extract" cannot be combined with "heading-level"`)}
+	}
+	if _, hasHO := params["heading-offset"]; hasHO {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "extract" cannot be combined with "heading-offset"`)}
+	}
+	// generateIncludeContent returns the projected leaf directly for
+	// extract: directives and never runs the wrap / source-dir pipeline,
+	// so silently accepting these params would drop them.
+	if _, hasWrap := params["wrap"]; hasWrap {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "extract" cannot be combined with "wrap"`)}
+	}
+	if _, hasSD := params["source-dir"]; hasSD {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "extract" cannot be combined with "source-dir"`)}
+	}
+	return nil
+}
+
+// validateHeadingOffset checks the heading-offset parameter when present: it
+// must parse as an integer in -6..6, and it cannot combine with heading-level
+// (the two are rival heading-adjustment strategies).
+func validateHeadingOffset(
+	filePath string, line int, params map[string]string,
+) []lint.Diagnostic {
+	ho, ok := params["heading-offset"]
+	if !ok {
+		return nil
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(ho))
+	if err != nil || n < -6 || n > 6 {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "heading-offset" must be an integer between -6 and 6`)}
+	}
+	if _, hasHL := params["heading-level"]; hasHL {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "heading-offset" cannot be combined with "heading-level"`)}
+	}
 	return nil
 }
 

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -555,6 +555,96 @@ func TestFix_HeadingLevelAbsolute(t *testing.T) {
 }
 
 // =====================================================================
+// Heading offset
+// =====================================================================
+
+func TestCheck_HeadingOffsetAtDocRoot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.md": {Data: []byte("# Title\n\nText.\n\n## Sub\n\nMore.\n")},
+	}
+	// No heading precedes the marker, yet heading-offset still demotes:
+	// # -> ##, ## -> ###. This is the case absolute mode cannot handle.
+	src := "<?include\nfile: data.md\nheading-offset: \"1\"\n?>\n" +
+		"## Title\n\nText.\n\n### Sub\n\nMore.\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestCheck_HeadingOffsetNegative(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.md": {Data: []byte("## Two\n\n### Three\n")},
+	}
+	// heading-offset: "-1" promotes: ## -> #, ### -> ##.
+	src := "# Doc\n\n<?include\nfile: data.md\nheading-offset: \"-1\"\n?>\n" +
+		"# Two\n\n## Three\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestFix_HeadingOffset(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.md": {Data: []byte("# Title\n\n## Sub\n")},
+	}
+	src := "<?include\nfile: data.md\nheading-offset: \"1\"\n?>\n" +
+		"old\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	got := string(r.Fix(f))
+	want := "<?include\nfile: data.md\nheading-offset: \"1\"\n?>\n" +
+		"## Title\n\n### Sub\n<?/include?>\n"
+	assert.Equal(t, want, got, "Fix output mismatch\ngot:\n%s\nwant:\n%s", got, want)
+}
+
+func TestCheck_HeadingOffsetNonInteger(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("content\n")}}
+	src := "<?include\nfile: data.md\nheading-offset: \"x\"\n?>\n" +
+		"content\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"heading-offset" must be an integer between -6 and 6`)
+}
+
+func TestCheck_HeadingOffsetOutOfRange(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("content\n")}}
+	src := "<?include\nfile: data.md\nheading-offset: \"7\"\n?>\n" +
+		"content\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"heading-offset" must be an integer between -6 and 6`)
+}
+
+func TestCheck_HeadingOffsetWithHeadingLevel(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("## A\n")}}
+	src := "# Doc\n\n<?include\nfile: data.md\n" +
+		"heading-level: \"absolute\"\nheading-offset: \"1\"\n?>\n" +
+		"## A\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"heading-offset" cannot be combined with "heading-level"`)
+}
+
+func TestCheck_HeadingOffsetWithExtract(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("content\n")}}
+	src := "<?include\nfile: data.md\n" +
+		"extract: foo\nheading-offset: \"1\"\n?>\ncontent\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"extract" cannot be combined with "heading-offset"`)
+}
+
+// =====================================================================
 // Combined link adjustment and heading level
 // =====================================================================
 

--- a/plan/232_include-heading-offset.md
+++ b/plan/232_include-heading-offset.md
@@ -1,0 +1,162 @@
+---
+id: 232
+title: include heading-offset parameter
+status: "🔳"
+summary: >-
+  Add a `heading-offset` parameter to the `<?include?>`
+  directive (MDS021) that shifts every heading in the
+  embedded content by a signed integer. It complements the
+  context-relative `heading-level: "absolute"` and works
+  even when no heading precedes the marker.
+model: opus
+depends-on: []
+---
+# include heading-offset parameter
+
+## Goal
+
+Give [`<?include?>`][include] a way to shift the headings in
+an embedded file by a fixed amount. The content then nests
+at the depth you pick. It works even with no heading before
+the marker.
+
+## Context
+
+`<?include?>` already adjusts headings with
+`heading-level: "absolute"`. That mode shifts the embedded
+headings so the shallowest one sits one level below the
+nearest preceding heading. The math lives in
+[`adjustHeadings`][headings].
+
+The mode is context-relative: it reads the parent heading
+level from the host document. When the marker sits at the
+document root, there is no parent. `adjustHeadings` then
+returns the content unchanged, so the embedded file keeps
+its source levels.
+
+That leaves a gap. Take a README whose visual title is a
+logo rather than an H1. A file embedded at the top of it
+cannot have its headings demoted: the source `# Title`
+stays an H1 and outranks the host's own `##` sections. The
+author needs a way to say "shift these down by one" that
+does not depend on a parent heading.
+
+## Design
+
+### New parameter: `heading-offset`
+
+A signed integer. It shifts every heading in the embedded
+content by that amount. The idea matches Pandoc's
+`--shift-heading-level-by` and AsciiDoc's `leveloffset`.
+
+```text
+<?include
+file: features.md
+heading-offset: "1"
+?>
+## Was An H1 In The Source
+<?/include?>
+```
+
+| Value  | Effect                                |
+| ------ | ------------------------------------- |
+| `"1"`  | every heading one level deeper, H1→H2 |
+| `"-1"` | every heading one level shallower     |
+| `"0"`  | no change                             |
+
+Levels are clamped to the 1–6 range after the shift, the
+same cap `absolute` already applies. The sign may carry an
+explicit `+`, as in `"+1"`.
+
+### Semantics next to `heading-level`
+
+`heading-level: "absolute"` is relative to the host: the
+shift depends on the parent heading. `heading-offset` is
+relative to the source: the shift is fixed and applies even
+at the document root. They are two strategies for one goal,
+so they are mutually exclusive. Setting both is a lint
+error.
+
+`heading-offset` shifts every heading by the same amount,
+upward too for a negative value. So it reuses the existing
+[`applyShift`][headings] helper directly. It skips the
+"no shift when the result is ≤ 0" guard that `adjustHeadings`
+needs for parent-relative nesting.
+
+### Validation
+
+- The value must parse as an integer from −6 to 6. Anything
+  else is a lint error.
+- `heading-offset` cannot pair with `heading-level`, since
+  the two are rival strategies.
+- `heading-offset` cannot pair with `extract:`, which
+  returns one scalar and has no headings. This mirrors the
+  rule `heading-level` already follows.
+
+### Out of scope
+
+- An absolute base form that pins the shallowest heading to
+  level N. It overlaps `heading-offset` for single-rooted
+  content, so it waits for a real need.
+- Stacking `heading-offset` on `absolute`. The two stay
+  mutually exclusive to keep the model simple.
+- Using the new syntax in any tracked Markdown file. Per
+  [the directive-syntax process][adopt], the pinned CI
+  baseline must ship the feature first, or
+  `mdsmith-fixed-version` breaks. This plan adds the
+  capability only. Adoption is a later, separate change.
+
+[include]: ../internal/rules/MDS021-include/README.md
+[headings]: ../internal/rules/include/headings.go
+[adopt]: ../docs/development/adopt-new-directive-syntax.md
+
+## Tasks
+
+1. [ ] Add `adjustHeadingsByOffset(content, offset)` to
+   [`headings.go`][headings], reusing `applyShift`. Unit
+   tests for ATX, setext, code fences, clamping, and the
+   `offset == 0` no-op land in `headings_test.go` first,
+   red.
+2. [ ] Apply `heading-offset` in `processIncludedContent`
+   in [`rule.go`][rule]: call `adjustHeadingsByOffset` when
+   the parameter is present.
+3. [ ] Extend `validateIncludeDirective`: reject a
+   non-integer or out-of-range value, reject the pairing
+   with `heading-level`, and reject the pairing with
+   `extract`. A unit test pins each branch.
+4. [ ] Add fixtures under [MDS021-include][include-dir]: a
+   `good/` plus matching `fixed/` pair that exercises
+   `heading-offset`, and a `bad/` case with a stale body.
+5. [ ] Update the rule README ([MDS021-include][include]):
+   the parameter table, a heading-offset section, an
+   example, and the new diagnostics rows.
+6. [ ] Update the directive guide
+   ([generating content][guide]) and the built-in help doc
+   [`internal/directives/generating-content.md`][help] to
+   cover `heading-offset`.
+7. [ ] Run `go test ./...`, `go tool golangci-lint run`,
+   the allocation-budget test, and `mdsmith check .`.
+
+[rule]: ../internal/rules/include/rule.go
+[include-dir]: ../internal/rules/MDS021-include/
+[guide]: ../docs/guides/directives/generating-content.md
+[help]: ../internal/directives/generating-content.md
+
+## Acceptance Criteria
+
+- [ ] `heading-offset: "1"` demotes every embedded heading
+      one level on `mdsmith fix`, even with no heading
+      before the marker
+- [ ] `heading-offset: "-1"` promotes every embedded
+      heading one level, clamped at H1
+- [ ] A stale `heading-offset` body reports the MDS021
+      "generated section is out of date" diagnostic on
+      `check`
+- [ ] Pairing `heading-offset` with `heading-level` or
+      `extract` is a lint error with a clear message
+- [ ] A non-integer or out-of-range `heading-offset` is a
+      lint error
+- [ ] No tracked Markdown uses the new syntax, so
+      `mdsmith-fixed-version` stays green
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/232_include-heading-offset.md
+++ b/plan/232_include-heading-offset.md
@@ -1,7 +1,7 @@
 ---
 id: 232
 title: include heading-offset parameter
-status: "🔳"
+status: "✅"
 summary: >-
   Add a `heading-offset` parameter to the `<?include?>`
   directive (MDS021) that shifts every heading in the
@@ -112,29 +112,29 @@ needs for parent-relative nesting.
 
 ## Tasks
 
-1. [ ] Add `adjustHeadingsByOffset(content, offset)` to
+1. [x] Add `adjustHeadingsByOffset(content, offset)` to
    [`headings.go`][headings], reusing `applyShift`. Unit
    tests for ATX, setext, code fences, clamping, and the
    `offset == 0` no-op land in `headings_test.go` first,
    red.
-2. [ ] Apply `heading-offset` in `processIncludedContent`
+2. [x] Apply `heading-offset` in `processIncludedContent`
    in [`rule.go`][rule]: call `adjustHeadingsByOffset` when
    the parameter is present.
-3. [ ] Extend `validateIncludeDirective`: reject a
+3. [x] Extend `validateIncludeDirective`: reject a
    non-integer or out-of-range value, reject the pairing
    with `heading-level`, and reject the pairing with
    `extract`. A unit test pins each branch.
-4. [ ] Add fixtures under [MDS021-include][include-dir]: a
+4. [x] Add fixtures under [MDS021-include][include-dir]: a
    `good/` plus matching `fixed/` pair that exercises
    `heading-offset`, and a `bad/` case with a stale body.
-5. [ ] Update the rule README ([MDS021-include][include]):
+5. [x] Update the rule README ([MDS021-include][include]):
    the parameter table, a heading-offset section, an
    example, and the new diagnostics rows.
-6. [ ] Update the directive guide
+6. [x] Update the directive guide
    ([generating content][guide]) and the built-in help doc
    [`internal/directives/generating-content.md`][help] to
    cover `heading-offset`.
-7. [ ] Run `go test ./...`, `go tool golangci-lint run`,
+7. [x] Run `go test ./...`, `go tool golangci-lint run`,
    the allocation-budget test, and `mdsmith check .`.
 
 [rule]: ../internal/rules/include/rule.go
@@ -144,19 +144,19 @@ needs for parent-relative nesting.
 
 ## Acceptance Criteria
 
-- [ ] `heading-offset: "1"` demotes every embedded heading
+- [x] `heading-offset: "1"` demotes every embedded heading
       one level on `mdsmith fix`, even with no heading
       before the marker
-- [ ] `heading-offset: "-1"` promotes every embedded
+- [x] `heading-offset: "-1"` promotes every embedded
       heading one level, clamped at H1
-- [ ] A stale `heading-offset` body reports the MDS021
+- [x] A stale `heading-offset` body reports the MDS021
       "generated section is out of date" diagnostic on
       `check`
-- [ ] Pairing `heading-offset` with `heading-level` or
+- [x] Pairing `heading-offset` with `heading-level` or
       `extract` is a lint error with a clear message
-- [ ] A non-integer or out-of-range `heading-offset` is a
+- [x] A non-integer or out-of-range `heading-offset` is a
       lint error
-- [ ] No tracked Markdown uses the new syntax, so
+- [x] No tracked Markdown uses the new syntax, so
       `mdsmith-fixed-version` stays green
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues

--- a/website/static/img/logo-lockup-inverse.svg
+++ b/website/static/img/logo-lockup-inverse.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 80" role="img" aria-label="mdsmith">
   <title>mdsmith</title>
-  <g fill="#B4BBC4">
+  <g fill="#2A323D">
     <path d="M4 24 L10 20 L74 20 L74 34 L4 34 Z"/>
     <path d="M6 48 L74 48 L74 60 L70 64 L10 64 L6 60 Z"/>
     <rect x="22" y="8" width="8" height="68"/>
     <rect x="50" y="8" width="8" height="68"/>
   </g>
   <g transform="rotate(55 40 40)">
-    <path fill="#E58233" stroke="#FAF7F2" stroke-width="2.5" stroke-linejoin="round"
+    <path fill="#D9651D" stroke="#0F1419" stroke-width="2.5" stroke-linejoin="round"
           d="M 28 13 L 52 13 L 58 18 L 58 25 L 52 30 L 45 30 L 45 64 Q 45 67 42 67 L 38 67 Q 35 67 35 64 L 35 30 L 28 30 L 22 25 L 22 18 Z"/>
   </g>
   <text x="100" y="52" font-family="'IBM Plex Sans', system-ui, sans-serif" font-size="34" letter-spacing="-0.03em">


### PR DESCRIPTION
Two changes on this branch.

## 1. Dark-mode logo mark — `website/static/img/logo-lockup-inverse.svg`

Reverted the mark (hash/anvil fill + hammer fill/border) to the original brand colors so it renders identically on light and dark backgrounds; only the "mdsmith" wordmark stays light. This is the README's `prefers-color-scheme: dark` `<source>`.

## 2. `heading-offset` parameter for `<?include?>` (MDS021) — plan 232

A new signed-integer parameter (`-6`..`6`) that shifts **every** embedded heading uniformly (à la Pandoc `--shift-heading-level-by` / AsciiDoc `leveloffset`), complementing the context-relative `heading-level: "absolute"`. Unlike `absolute`, it works at the document root where there is no parent heading to nest under.

- `adjustHeadingsByOffset` helper — reuses the existing `applyShift` (ATX/setext/code-fence aware, clamps to 1–6); `0` is a no-op, negatives promote.
- Validation: integer-in-range, mutually exclusive with `heading-level` and with `extract`.
- Refactor: split `validateIncludeDirective` into `validateHeadingOffset` + `validateExtractParam` (SRP; keeps gocognit/funlen in budget).
- good/bad/fixed fixtures, unit tests, README + guide + built-in help docs, `plan/232`.

The new syntax is **not** used in any tracked Markdown yet (only fixtures in ignored dirs and docs inside code fences), so `mdsmith-fixed-version` stays green — adoption in live docs is a separate change gated on the pinned-baseline bump (see `docs/development/adopt-new-directive-syntax.md`).

## Verification

- `go test ./...`, `go vet ./...`, `go tool golangci-lint run` — all clean.
- `mdsmith check .` — 409 files, 0 failures. Allocation-budget and `-race` tests pass.
- 3 rounds of code review (correctness + cleanup finder agents; adversarial fix-idempotence and nested-include testing; final read). No code fixes were required; one **pre-existing** `applyShift` quirk (a kept YAML `---` can be misread as a setext underline, affecting `heading-level` equally) is noted as out of scope.

https://claude.ai/code/session_014xpEPq3jaUUV82DPRsiEnM