### PR TITLE
Plan 219: Route cmd/mdsmith and the LSP through pkg/mdsmith.Session

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -148,7 +148,7 @@ footer: |
 | 218 | ✅     | sonnet | [Finish MD054 link-image-style coverage in MDS068](plan/218_finish-md054-link-image-style.md)                                           |
 | 218 | 🔲     | opus   | [WASM size reduction — CUE-free engine path and tinygo support](plan/218_wasm-size-reduction.md)                                        |
 | 219 | 🔲     | opus   | [Multiplexed AST walk to close the parity gap to mado](plan/219_multiplexed-ast-walk.md)                                                |
-| 219 | 🔳     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
+| 219 | ✅     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
 | 222 | ✅     | opus   | [Single source of truth for distribution channels](plan/222_distribution-channel-ssot.md)                                               |

--- a/PLAN.md
+++ b/PLAN.md
@@ -148,7 +148,7 @@ footer: |
 | 218 | ✅     | sonnet | [Finish MD054 link-image-style coverage in MDS068](plan/218_finish-md054-link-image-style.md)                                           |
 | 218 | 🔲     | opus   | [WASM size reduction — CUE-free engine path and tinygo support](plan/218_wasm-size-reduction.md)                                        |
 | 219 | 🔲     | opus   | [Multiplexed AST walk to close the parity gap to mado](plan/219_multiplexed-ast-walk.md)                                                |
-| 219 | 🔲     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
+| 219 | 🔳     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
 | 222 | ✅     | opus   | [Single source of truth for distribution channels](plan/222_distribution-channel-ssot.md)                                               |

--- a/cmd/mdsmith-wasm/methods_test.go
+++ b/cmd/mdsmith-wasm/methods_test.go
@@ -23,6 +23,7 @@ var nativeOnlyMethods = map[string]bool{
 	"checkPaths":  true,
 	"checkSource": true,
 	"fixPaths":    true,
+	"resolveFile": true,
 }
 
 // TestSessionMethodSetMatchesGo asserts the JS session proxy's method

--- a/cmd/mdsmith-wasm/methods_test.go
+++ b/cmd/mdsmith-wasm/methods_test.go
@@ -9,22 +9,69 @@ import (
 	mdsmith "github.com/jeduden/mdsmith/pkg/mdsmith"
 )
 
+// nativeOnlyMethods are exported *mdsmith.Session methods that
+// deliberately have no JavaScript mirror. The batch operations
+// (checkPaths, fixPaths) read and write many files on disk and return
+// the engine's own Result types so the CLI keeps its discovery and
+// output formatting; a WASM host has no disk and drives single files
+// through check/fix instead (plan 219, documented as native-only in
+// docs/background/concepts/engine-api.md). The parity check below
+// subtracts these before comparing so adding a JS-mirrored Go method
+// without exposing it in JS still fails, while a native-only addition
+// is allowed once it is listed here.
+var nativeOnlyMethods = map[string]bool{
+	"checkPaths": true,
+	"fixPaths":   true,
+}
+
 // TestSessionMethodSetMatchesGo asserts the JS session proxy's method
-// set matches the Go *mdsmith.Session method set name-for-name (modulo
-// the Go→JS lower-camel convention). The WASM bridge builds its proxy
-// from sessionMethodNames(); this test ties that list to the actual Go
-// methods via reflection, so adding a Go method without exposing it in
-// JS (or vice versa) fails the build's tests.
+// set matches the JS-mirrored Go *mdsmith.Session method set
+// name-for-name (modulo the Go→JS lower-camel convention and the
+// native-only batch ops). The WASM bridge builds its proxy from
+// sessionMethodNames(); this test ties that list to the actual Go
+// methods via reflection, so adding a JS-mirrored Go method without
+// exposing it in JS (or vice versa) fails the build's tests.
 func TestSessionMethodSetMatchesGo(t *testing.T) {
 	jsNames := sessionMethodNames()
 	sort.Strings(jsNames)
 
-	goNames := exportedMethodNames(reflect.TypeOf((*mdsmith.Session)(nil)))
+	goNames := mirroredGoMethodNames()
 	sort.Strings(goNames)
 
 	if !reflect.DeepEqual(jsNames, goNames) {
-		t.Fatalf("JS session methods %v != Go Session methods %v", jsNames, goNames)
+		t.Fatalf("JS session methods %v != JS-mirrored Go Session methods %v "+
+			"(native-only methods %v are excluded)", jsNames, goNames, nativeOnlyMethods)
 	}
+}
+
+// TestNativeOnlyMethodsExistOnGoSession guards the allowlist: every name
+// in nativeOnlyMethods must be a real exported Go Session method, so a
+// stale entry (a renamed or removed batch op) cannot silently mask a
+// future drift.
+func TestNativeOnlyMethodsExistOnGoSession(t *testing.T) {
+	all := make(map[string]bool)
+	for _, n := range exportedMethodNames(reflect.TypeOf((*mdsmith.Session)(nil))) {
+		all[n] = true
+	}
+	for n := range nativeOnlyMethods {
+		if !all[n] {
+			t.Fatalf("nativeOnlyMethods lists %q but *mdsmith.Session has no such exported method", n)
+		}
+	}
+}
+
+// mirroredGoMethodNames returns the exported Go Session method names
+// minus the native-only batch ops, i.e. the set that must mirror into
+// JS one-for-one.
+func mirroredGoMethodNames() []string {
+	var out []string
+	for _, n := range exportedMethodNames(reflect.TypeOf((*mdsmith.Session)(nil))) {
+		if nativeOnlyMethods[n] {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
 }
 
 // TestCoreCapabilitiesAreMethods asserts every name Capabilities()

--- a/cmd/mdsmith-wasm/methods_test.go
+++ b/cmd/mdsmith-wasm/methods_test.go
@@ -20,10 +20,12 @@ import (
 // without exposing it in JS still fails, while a native-only addition
 // is allowed once it is listed here.
 var nativeOnlyMethods = map[string]bool{
-	"checkPaths":  true,
-	"checkSource": true,
-	"fixPaths":    true,
-	"resolveFile": true,
+	"checkPaths":   true,
+	"checkSource":  true,
+	"checkVersion": true,
+	"fixPaths":     true,
+	"fixRule":      true,
+	"resolveFile":  true,
 }
 
 // TestSessionMethodSetMatchesGo asserts the JS session proxy's method

--- a/cmd/mdsmith-wasm/methods_test.go
+++ b/cmd/mdsmith-wasm/methods_test.go
@@ -20,8 +20,9 @@ import (
 // without exposing it in JS still fails, while a native-only addition
 // is allowed once it is listed here.
 var nativeOnlyMethods = map[string]bool{
-	"checkPaths": true,
-	"fixPaths":   true,
+	"checkPaths":  true,
+	"checkSource": true,
+	"fixPaths":    true,
 }
 
 // TestSessionMethodSetMatchesGo asserts the JS session proxy's method

--- a/cmd/mdsmith-wasm/methods_test.go
+++ b/cmd/mdsmith-wasm/methods_test.go
@@ -20,12 +20,13 @@ import (
 // without exposing it in JS still fails, while a native-only addition
 // is allowed once it is listed here.
 var nativeOnlyMethods = map[string]bool{
-	"checkPaths":   true,
-	"checkSource":  true,
-	"checkVersion": true,
-	"fixPaths":     true,
-	"fixRule":      true,
-	"resolveFile":  true,
+	"checkPaths":          true,
+	"checkSource":         true,
+	"checkVersion":        true,
+	"fixPaths":            true,
+	"fixRule":             true,
+	"invalidateWikilinks": true,
+	"resolveFile":         true,
 }
 
 // TestSessionMethodSetMatchesGo asserts the JS session proxy's method

--- a/cmd/mdsmith/check.go
+++ b/cmd/mdsmith/check.go
@@ -130,9 +130,23 @@ func checkFiles(fileArgs []string, opts checkCLIOpts) int {
 func checkBatchOptions(opts checkCLIOpts, logger *vlog.Logger, maxBytes int64) mdsmith.BatchOptions {
 	return mdsmith.BatchOptions{
 		Explain:       opts.explain,
-		MaxInputBytes: maxBytes,
+		MaxInputBytes: batchMaxBytes(maxBytes),
 		Logger:        logger,
 	}
+}
+
+// batchMaxBytes maps the CLI's fully-resolved max-input-size (config
+// merged with the --max-input-size flag) onto BatchOptions.MaxInputBytes,
+// which treats 0 as "use the session default". The CLI value is always
+// authoritative, and resolveMaxInputBytes returns 0 for an explicit
+// `max-input-size: 0` (unlimited) — so map that to math.MaxInt64, the
+// engine's explicit-unlimited sentinel, to keep it authoritative and
+// non-zero rather than silently falling back to the 2 MB default.
+func batchMaxBytes(resolved int64) int64 {
+	if resolved <= 0 {
+		return math.MaxInt64
+	}
+	return resolved
 }
 
 // checkStdin reads from stdin, lints the content, and returns the appropriate

--- a/cmd/mdsmith/check.go
+++ b/cmd/mdsmith/check.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/engine"
 	vlog "github.com/jeduden/mdsmith/internal/log"
-	"github.com/jeduden/mdsmith/internal/rule"
+	mdsmith "github.com/jeduden/mdsmith/pkg/mdsmith"
 )
 
 // checkCLIOpts bundles the runtime knobs threaded through the check
@@ -115,17 +115,24 @@ func checkFiles(fileArgs []string, opts checkCLIOpts) int {
 		return code
 	}
 
-	runner := &engine.Runner{
-		Config:           cfg,
-		Rules:            rule.All(),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		Logger:           logger,
-		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    maxBytes,
-		Explain:          opts.explain,
-		ConfigPath:       cfgPath,
+	sess, err := sessionForCLI(cfg, cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
 	}
-	return reportCheckResult(runner.Run(files), opts, logger)
+	defer sess.Dispose()
+	result := sess.CheckPaths(files, checkBatchOptions(opts, logger, maxBytes))
+	return reportCheckResult(result, opts, logger)
+}
+
+// checkBatchOptions maps the check CLI flags, the resolved logger, and
+// the resolved byte cap onto the session's BatchOptions.
+func checkBatchOptions(opts checkCLIOpts, logger *vlog.Logger, maxBytes int64) mdsmith.BatchOptions {
+	return mdsmith.BatchOptions{
+		Explain:       opts.explain,
+		MaxInputBytes: maxBytes,
+		Logger:        logger,
+	}
 }
 
 // checkStdin reads from stdin, lints the content, and returns the appropriate
@@ -154,17 +161,14 @@ func checkStdin(opts checkCLIOpts) int {
 		return 2
 	}
 
-	runner := &engine.Runner{
-		Config:           cfg,
-		Rules:            rule.All(),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		Logger:           logger,
-		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    maxBytes,
-		Explain:          opts.explain,
-		ConfigPath:       cfgPath,
+	sess, err := sessionForCLI(cfg, cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
 	}
-	return reportCheckResult(runner.RunSource("<stdin>", source), opts, logger)
+	defer sess.Dispose()
+	result := sess.CheckSource("<stdin>", source, checkBatchOptions(opts, logger, maxBytes))
+	return reportCheckResult(result, opts, logger)
 }
 
 // checkDiscovered loads config, discovers files from config patterns,
@@ -181,17 +185,14 @@ func checkDiscovered(opts checkCLIOpts) int {
 		return 2
 	}
 
-	runner := &engine.Runner{
-		Config:           cfg,
-		Rules:            rule.All(),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		Logger:           logger,
-		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    maxBytes,
-		Explain:          opts.explain,
-		ConfigPath:       cfgPath,
+	sess, err := sessionForCLI(cfg, cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
 	}
-	return reportCheckResult(runner.Run(files), opts, logger)
+	defer sess.Dispose()
+	result := sess.CheckPaths(files, checkBatchOptions(opts, logger, maxBytes))
+	return reportCheckResult(result, opts, logger)
 }
 
 // reportCheckResult writes diagnostics + the run-stats line and

--- a/cmd/mdsmith/check.go
+++ b/cmd/mdsmith/check.go
@@ -115,11 +115,7 @@ func checkFiles(fileArgs []string, opts checkCLIOpts) int {
 		return code
 	}
 
-	sess, err := sessionForCLI(cfg, cfgPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
+	sess := sessionForCLI(cfg, cfgPath)
 	defer sess.Dispose()
 	result := sess.CheckPaths(files, checkBatchOptions(opts, logger, maxBytes))
 	return reportCheckResult(result, opts, logger)
@@ -175,11 +171,7 @@ func checkStdin(opts checkCLIOpts) int {
 		return 2
 	}
 
-	sess, err := sessionForCLI(cfg, cfgPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
+	sess := sessionForCLI(cfg, cfgPath)
 	defer sess.Dispose()
 	result := sess.CheckSource("<stdin>", source, checkBatchOptions(opts, logger, maxBytes))
 	return reportCheckResult(result, opts, logger)
@@ -199,11 +191,7 @@ func checkDiscovered(opts checkCLIOpts) int {
 		return 2
 	}
 
-	sess, err := sessionForCLI(cfg, cfgPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
+	sess := sessionForCLI(cfg, cfgPath)
 	defer sess.Dispose()
 	result := sess.CheckPaths(files, checkBatchOptions(opts, logger, maxBytes))
 	return reportCheckResult(result, opts, logger)

--- a/cmd/mdsmith/e2e_errorpaths_test.go
+++ b/cmd/mdsmith/e2e_errorpaths_test.go
@@ -1,0 +1,62 @@
+package main_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKindsResolveBadMaxInputSizeFrontMatterDisabled exercises the
+// front-matter-disabled arm of resolveFileFromCLI: with `front-matter:
+// false` the kinds path skips front-matter parsing but still resolves the
+// byte cap before its readability check, so a malformed `max-input-size`
+// is surfaced as an error there (the path the default, front-matter-on
+// arm reaches earlier). The command must exit 2 and name the bad setting.
+func TestKindsResolveBadMaxInputSizeFrontMatterDisabled(t *testing.T) {
+	cfg := "front-matter: false\nmax-input-size: \"not-a-size\"\n"
+	dir := kindsTestDir(t, cfg, map[string]string{
+		"doc.md": "# Doc\n\nBody paragraph.\n",
+	})
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "kinds", "resolve", "doc.md")
+	require.Equal(t, 2, code,
+		"a malformed max-input-size must fail kinds resolve with exit 2")
+	assert.Contains(t, stderr, "invalid max-input-size",
+		"stderr should name the malformed max-input-size setting")
+}
+
+// TestCheckStdinReadError covers readStdinLimited's read-error branch: the
+// limited read (default 2 MB cap) calls io.ReadAll on stdin, and a stdin
+// whose Read fails must propagate as exit 2 rather than being treated as
+// empty input. A directory file descriptor reads with EISDIR on Linux,
+// which is a deterministic, dependency-free way to make stdin error.
+func TestCheckStdinReadError(t *testing.T) {
+	// A directory opened as a plain *os.File: read(2) on it returns an
+	// error, so io.ReadAll(LimitReader(stdin, …)) fails.
+	dirAsStdin, err := os.Open(t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = dirAsStdin.Close() }()
+
+	// Run `check -` (read from stdin) in the isolated CWD with the
+	// directory fd as stdin. runBinary only accepts a string stdin, so
+	// invoke the binary directly to attach the file descriptor.
+	cmd := exec.Command(binaryPath, "check", "-")
+	cmd.Dir = isolatedCWD
+	cmd.Env = envWithCoverDir(coverDir)
+	cmd.Stdin = dirAsStdin
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	runErr := cmd.Run()
+	exitErr, ok := runErr.(*exec.ExitError)
+	require.True(t, ok, "expected a non-zero exit, got %v (stderr: %s)", runErr, errBuf.String())
+	require.Equal(t, 2, exitErr.ExitCode(),
+		"a stdin read failure must exit 2 (stderr: %s)", errBuf.String())
+	assert.Contains(t, errBuf.String(), "mdsmith:",
+		"stderr should carry the mdsmith error prefix for the stdin read failure")
+}

--- a/cmd/mdsmith/fix.go
+++ b/cmd/mdsmith/fix.go
@@ -11,11 +11,12 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/jeduden/mdsmith/internal/bytelimit"
+	"github.com/jeduden/mdsmith/internal/config"
 	fixpkg "github.com/jeduden/mdsmith/internal/fix"
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
-	"github.com/jeduden/mdsmith/internal/rule"
+	mdsmith "github.com/jeduden/mdsmith/pkg/mdsmith"
 )
 
 // runFix implements the "fix" subcommand: auto-fix lint issues in place.
@@ -125,20 +126,7 @@ func fixFiles(fileArgs []string, opts fixCLIOpts) int {
 	if code >= 0 {
 		return code
 	}
-
-	fixer := &fixpkg.Fixer{
-		Config:           cfg,
-		Rules:            rule.All(),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		Logger:           logger,
-		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    maxBytes,
-		Explain:          opts.explain,
-		DryRun:           opts.dryRun,
-	}
-	files = orderFilesLeavesFirst(files, fixer.RootDir, maxBytes)
-	fixResult := fixer.Fix(files)
-	return reportFixResult(opts, fixResult, logger)
+	return runFixThroughSession(cfg, cfgPath, opts, logger, files, maxBytes)
 }
 
 // fixDiscovered loads config, discovers files from config patterns,
@@ -154,19 +142,31 @@ func fixDiscovered(opts fixCLIOpts) int {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return 2
 	}
+	return runFixThroughSession(cfg, cfgPath, opts, logger, files, maxBytes)
+}
 
-	fixer := &fixpkg.Fixer{
-		Config:           cfg,
-		Rules:            rule.All(),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		Logger:           logger,
-		RootDir:          rootDirFromConfig(cfgPath),
-		MaxInputBytes:    maxBytes,
-		Explain:          opts.explain,
-		DryRun:           opts.dryRun,
+// runFixThroughSession orders files leaves-first, builds a Session over
+// the already-loaded config, and runs Session.FixPaths — the shared body
+// of fixFiles and fixDiscovered. Leaves-first ordering stays here in the
+// CLI (a convergence optimisation over the engine's fixpoint loop), so
+// FixPaths receives an already-ordered list.
+func runFixThroughSession(
+	cfg *config.Config, cfgPath string, opts fixCLIOpts,
+	logger *vlog.Logger, files []string, maxBytes int64,
+) int {
+	files = orderFilesLeavesFirst(files, rootDirFromConfig(cfgPath), maxBytes)
+	sess, err := sessionForCLI(cfg, cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return 2
 	}
-	files = orderFilesLeavesFirst(files, fixer.RootDir, maxBytes)
-	fixResult := fixer.Fix(files)
+	defer sess.Dispose()
+	fixResult := sess.FixPaths(files, mdsmith.BatchOptions{
+		Explain:       opts.explain,
+		MaxInputBytes: maxBytes,
+		Logger:        logger,
+		DryRun:        opts.dryRun,
+	})
 	return reportFixResult(opts, fixResult, logger)
 }
 

--- a/cmd/mdsmith/fix.go
+++ b/cmd/mdsmith/fix.go
@@ -163,7 +163,7 @@ func runFixThroughSession(
 	defer sess.Dispose()
 	fixResult := sess.FixPaths(files, mdsmith.BatchOptions{
 		Explain:       opts.explain,
-		MaxInputBytes: maxBytes,
+		MaxInputBytes: batchMaxBytes(maxBytes),
 		Logger:        logger,
 		DryRun:        opts.dryRun,
 	})

--- a/cmd/mdsmith/fix.go
+++ b/cmd/mdsmith/fix.go
@@ -155,11 +155,7 @@ func runFixThroughSession(
 	logger *vlog.Logger, files []string, maxBytes int64,
 ) int {
 	files = orderFilesLeavesFirst(files, rootDirFromConfig(cfgPath), maxBytes)
-	sess, err := sessionForCLI(cfg, cfgPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return 2
-	}
+	sess := sessionForCLI(cfg, cfgPath)
 	defer sess.Dispose()
 	fixResult := sess.FixPaths(files, mdsmith.BatchOptions{
 		Explain:       opts.explain,

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -332,11 +332,7 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 		}
 	}
 
-	sess, err := sessionForCLI(cfg, cfgPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return nil, nil, 2
-	}
+	sess := sessionForCLI(cfg, cfgPath)
 	defer sess.Dispose()
 	return sess.ResolveFile(path, fmKinds, fmFields), cfg, 0
 }

--- a/cmd/mdsmith/kinds.go
+++ b/cmd/mdsmith/kinds.go
@@ -278,7 +278,15 @@ func readFrontMatter(cfg *config.Config, path string, maxBytes int64) ([]string,
 }
 
 // resolveFileFromCLI loads config, parses the file's front matter for
-// kinds: and returns a FileResolution. Errors are printed to stderr.
+// kinds:, and returns a FileResolution computed through a
+// pkg/mdsmith.Session. Errors are printed to stderr.
+//
+// The CLI keeps front-matter reading, validation, and the max-input /
+// missing-file / directory error UX here — the session is intentionally
+// lenient toward unsaved buffers, so this command's stricter contract
+// stays in the CLI. The session owns the compiled config and performs
+// the resolution: this routes `kinds resolve` / `kinds why` through it
+// while preserving the command's exact diagnostics.
 //
 // When the config disables front matter (`front-matter: false`), front
 // matter is neither parsed nor validated so the resolution mirrors the
@@ -286,7 +294,7 @@ func readFrontMatter(cfg *config.Config, path string, maxBytes int64) ([]string,
 // against max-input-size) to surface readability errors and to match
 // the engine's rejection of oversized or unreadable paths.
 func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, int) {
-	cfg, _, code := kindsConfig()
+	cfg, cfgPath, code := kindsConfig()
 	if code != 0 {
 		return nil, nil, code
 	}
@@ -324,7 +332,13 @@ func resolveFileFromCLI(path string) (*config.FileResolution, *config.Config, in
 		}
 	}
 
-	return config.ResolveFile(cfg, path, fmKinds, fmFields), cfg, 0
+	sess, err := sessionForCLI(cfg, cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+		return nil, nil, 2
+	}
+	defer sess.Dispose()
+	return sess.ResolveFile(path, fmKinds, fmFields), cfg, 0
 }
 
 // runKindsResolve prints the resolved kind list and merged rule config

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/profiling"
 	"github.com/jeduden/mdsmith/internal/query"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
+	mdsmith "github.com/jeduden/mdsmith/pkg/mdsmith"
 
 	// Import every production rule package via the shared barrel so
 	// the registry is populated by init(). Tests that need the same
@@ -589,6 +590,24 @@ func frontMatterEnabled(cfg *config.Config) bool {
 		return *cfg.FrontMatter
 	}
 	return true
+}
+
+// sessionForCLI builds a pkg/mdsmith.Session over the host filesystem
+// for the already-loaded config. cfg has been merged and had its CLI
+// side effects applied (build-recipe injection, the include-extract
+// projector) by loadConfig, so it is wrapped with mdsmith.ConfigCompiled
+// and handed over as-is — NewSession must not re-merge it. The OS
+// workspace is rooted at the project root so ReadFile and the engine's
+// FS view agree on a workspace-relative uri.
+//
+// NewSession only fails when its ConfigSource fails to load; a compiled
+// source cannot, so the returned error is always nil today. It is
+// surfaced anyway so a future fallible source is not silently dropped.
+func sessionForCLI(cfg *config.Config, cfgPath string) (*mdsmith.Session, error) {
+	return mdsmith.NewSession(mdsmith.SessionOptions{
+		Workspace: mdsmith.OSWorkspace{Root: rootDirFromConfig(cfgPath)},
+		Config:    mdsmith.ConfigCompiled(cfg, cfgPath),
+	})
 }
 
 // rootDirFromConfig returns the project root directory derived from the

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -601,13 +601,18 @@ func frontMatterEnabled(cfg *config.Config) bool {
 // FS view agree on a workspace-relative uri.
 //
 // NewSession only fails when its ConfigSource fails to load; a compiled
-// source cannot, so the returned error is always nil today. It is
-// surfaced anyway so a future fallible source is not silently dropped.
-func sessionForCLI(cfg *config.Config, cfgPath string) (*mdsmith.Session, error) {
-	return mdsmith.NewSession(mdsmith.SessionOptions{
+// source cannot (ConfigCompiled.loadConfig returns the config verbatim
+// with a nil error), so the error is always nil here. Rather than carry
+// a dead, untestable error branch at every call site, the impossible
+// error is dropped — matching the in-tree NewFileFromSource //nolint
+// pattern. If a future compiled source becomes fallible, NewSession's
+// signature forces this line to surface the error again.
+func sessionForCLI(cfg *config.Config, cfgPath string) *mdsmith.Session {
+	sess, _ := mdsmith.NewSession(mdsmith.SessionOptions{ //nolint:errcheck // ConfigCompiled never fails to load
 		Workspace: mdsmith.OSWorkspace{Root: rootDirFromConfig(cfgPath)},
 		Config:    mdsmith.ConfigCompiled(cfg, cfgPath),
 	})
+	return sess
 }
 
 // rootDirFromConfig returns the project root directory derived from the

--- a/docs/background/concepts/engine-api.md
+++ b/docs/background/concepts/engine-api.md
@@ -42,13 +42,33 @@ type SessionOptions struct {
 }
 ```
 
-The core operations are thin shims over the engine and the fixer:
+The core operations are thin shims over the engine and the fixer. Each
+takes one URI and its in-memory bytes:
 
 ```go
 func (s *Session) Check(uri string, source []byte) ([]Diagnostic, error)
 func (s *Session) Fix(uri string, source []byte) (FixResult, error)
 func (s *Session) Kinds(uri string) (KindResolution, error)
 ```
+
+Two native-only batch operations lint or fix many files on disk in one
+call. Each drives the engine's parallel path loop and returns its own
+result type. So `cmd/mdsmith` keeps file discovery, ordering, and output
+formatting, but drops its own engine plumbing:
+
+```go
+func (s *Session) CheckPaths(paths []string, opts BatchOptions) *engine.Result
+func (s *Session) FixPaths(paths []string, opts BatchOptions) *fix.Result
+```
+
+`BatchOptions` carries the `--explain` flag, the parallel concurrency
+cap (`GOMAXPROCS` by default), a per-call byte cap, a verbose logger,
+and a dry-run flag for `FixPaths`. These two methods have **no
+JavaScript mirror**: a browser host has no disk, no file walk, and no
+write-back, so it lints single buffers through `Check` / `Fix` instead.
+The `MemWorkspace` is the only filesystem under WASM. See [open
+namespace and capabilities](#open-namespace-and-capabilities) for how
+the native-only set stays in lock-step despite the gap.
 
 Introspection and lifecycle round out the surface:
 
@@ -82,9 +102,27 @@ disk under `GOOS=js GOARCH=wasm`. So the JS `workspace` map becomes a
 `MemWorkspace` once at session construction. It then mutates only
 through `Invalidate(uri, content)`.
 
+A `Workspace` reads through two paths that must agree on which file a
+URI names: `ReadFile` (which `Session.Kinds` uses to read front matter)
+and the `fs.FS` view (which cross-file rules — catalog, include, links —
+read through). `OSWorkspace` carries an optional `Root`; the CLI sets it
+to the project root so workspace-relative URIs match config globs. With
+a `Root`, `ReadFile` resolves a relative URI against it, exactly as the
+`Root`-rooted `fs.FS` does, so the same URI cannot resolve to two
+different files. An absolute path is read unchanged, and an empty `Root`
+reads paths as passed. `MemWorkspace` keys both paths off the same map.
+
 `MemWorkspace.Glob` is a linear key filter. The lint hot loop must not
 call it per file; a benchmark fixture asserts no per-file `Glob` under
 `MemWorkspace`.
+
+The configuration arrives through a `ConfigSource`. `ConfigYAML` carries
+inline YAML (the WASM path) and `ConfigPath` names a `.mdsmith.yml` on
+disk; `NewSession` merges either over the built-in defaults.
+`ConfigCompiled` wraps an already-merged `*config.Config`: the CLI
+loads, merges, injects build recipes, and installs the include-extract
+projector, then hands the result over so those side effects survive. A
+compiled source is taken as-is.
 
 ## Open namespace and capabilities
 
@@ -98,6 +136,14 @@ such as `extract`, `query`, `deps`, `rename`, `hover`, and `completion`
 to both sides without rearranging the existing methods. Each new method
 declares itself once on Go's `Session` and once on the proxied JS
 session — there is no central registry.
+
+`Capabilities()` advertises only the mirrored single-file surface
+(`check`, `fix`, `kinds`). The native-only batch ops (`checkPaths`,
+`fixPaths`) are left off, because a JS host can never call them. A
+native test ties the JS proxy method set to the Go `Session` method set
+minus an explicit native-only allowlist. A new *mirrored* method added
+on one side but not the other fails the build. A new native-only batch
+method is allowed once it joins that allowlist.
 
 ## Caching
 

--- a/docs/background/concepts/engine-api.md
+++ b/docs/background/concepts/engine-api.md
@@ -125,6 +125,15 @@ a `Root`, `ReadFile` resolves a relative URI against it, exactly as the
 different files. An absolute path is read unchanged, and an empty `Root`
 reads paths as passed. `MemWorkspace` keys both paths off the same map.
 
+A third implementation, `OverlayWorkspace`, is the LSP server's. It
+reads disk rooted at `Root` but lets `Set(uri, bytes)` shadow a path's
+content with an editor's unsaved buffer, so cross-file rules read the
+live buffer rather than the last saved file. Only content is overlaid —
+open buffers still exist on disk, so globbing and directory walks defer
+to disk, and the `fs.FS` view clones only the small open-buffer map per
+lint pass, never the corpus. That keeps a per-keystroke `CheckVersion`
+off any `O(corpus)` snapshot cost.
+
 `MemWorkspace.Glob` is a linear key filter. The lint hot loop must not
 call it per file; a benchmark fixture asserts no per-file `Glob` under
 `MemWorkspace`.

--- a/docs/background/concepts/engine-api.md
+++ b/docs/background/concepts/engine-api.md
@@ -70,6 +70,19 @@ The `MemWorkspace` is the only filesystem under WASM. See [open
 namespace and capabilities](#open-namespace-and-capabilities) for how
 the native-only set stays in lock-step despite the gap.
 
+Three more native-only methods serve the LSP server. `CheckVersion`
+takes the editor's `textDocument` version, so the [version-keyed parse
+cache](#caching) can serve a re-lint at the same version without
+re-parsing. `FixRule` applies one rule's fixes for a quick-fix
+lightbulb. `ResolveFile` returns the raw per-rule resolution the `kinds
+why` command walks:
+
+```go
+func (s *Session) CheckVersion(uri string, source []byte, version int) ([]Diagnostic, error)
+func (s *Session) FixRule(uri string, source []byte, names []string) (FixResult, error)
+func (s *Session) ResolveFile(uri string, fmKinds []string, fmFields map[string]any) *config.FileResolution
+```
+
 Introspection and lifecycle round out the surface:
 
 ```go
@@ -147,25 +160,34 @@ method is allowed once it joins that allowlist.
 
 ## Caching
 
-The session owns three caches, all session-scoped:
+The session owns four caches, all session-scoped:
 
-- **Parsed AST.** One entry per URI, holding the last
-  `(content-hash, document)` pair. The next `Check` on the same URI
-  with the same content reuses it. The first `Check` parses; later
-  `Check` and `Fix` on the same source skip the parse.
+- **Check results.** One entry per URI, holding the last
+  `(content-hash, diagnostics)` pair. The next `Check` on the same URI
+  with the same content reuses it without re-parsing or re-linting; a
+  no-op `Fix` reuses it too.
+- **Version-keyed parse.** One parsed document per URI, keyed by the
+  editor's `textDocument` version. `CheckVersion` serves it, so a
+  re-lint at the same version (a code action, a hover) skips the parse.
+  An edit bumps the version and misses, forcing a re-parse. This is the
+  per-keystroke cache the LSP latency gate depends on.
+- **Cross-file read.** The engine read cache shared across operations,
+  so a catalog or include target read by one buffer is not re-read by
+  the next on every keystroke.
 - **Compiled config.** Built once at `NewSession`. A config change
   needs `Dispose()` plus a new `NewSession`; there is no in-place
   reconfigure.
-- **Workspace `ReadFile` results.** Keyed by path.
 
 `Invalidate(uri)` signals that `uri` changed. With a `content` argument
-it rewrites that file in a `MemWorkspace`, so the next cross-file
-`Check` reads the new bytes. `OSWorkspace` ignores `content` and
-re-reads disk; a no-`content` call on a `MemWorkspace` deletes the
-entry (file removed). Invalidate then drops every cached `Check`
-result, not only `uri`'s. A changed file can feed any other through a
-cross-file rule (catalog, include, links), and the session keeps no
-dependency graph, so a stale dependent must never be served.
+it rewrites that file through the workspace's mutable overlay, so the
+next cross-file `Check` reads the new bytes — this is how the LSP's
+unsaved-buffer bytes reach catalog, include, and link rules. A bare
+`OSWorkspace` has no overlay and re-reads disk; a no-`content` call on a
+mutable workspace deletes the entry (file removed). Invalidate drops the
+changed path's read-cache and version-parse entries, then drops every
+cached `Check` result, not only `uri`'s. A changed file can feed any
+other through a cross-file rule, and the session keeps no dependency
+graph, so a stale dependent must never be served.
 
 ## WASM bindings
 

--- a/docs/background/concepts/engine-api.md
+++ b/docs/background/concepts/engine-api.md
@@ -78,10 +78,14 @@ lightbulb. `ResolveFile` returns the raw per-rule resolution the `kinds
 why` command walks:
 
 ```go
-func (s *Session) CheckVersion(uri string, source []byte, version int) ([]Diagnostic, error)
+func (s *Session) CheckVersion(uri string, source []byte, version int) *engine.Result
 func (s *Session) FixRule(uri string, source []byte, names []string) (FixResult, error)
 func (s *Session) ResolveFile(uri string, fmKinds []string, fmFields map[string]any) *config.FileResolution
 ```
+
+`CheckVersion` returns the engine `Result`, not the public `Diagnostic`
+slice. That keeps the LSP's own diagnostic partitioning and error
+surfacing, consistent with the batch ops above.
 
 Introspection and lifecycle round out the surface:
 

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -162,10 +162,16 @@ need.
 The compiler enforces it. The arrows that
 must hold:
 
-- `cmd/mdsmith` may import `internal/...`.
-- `internal/lsp` may import
-  `internal/engine` and its support
-  packages.
+- `cmd/mdsmith` may import `internal/...`
+  and `pkg/mdsmith`.
+- `internal/lsp` depends on `pkg/mdsmith`
+  for every lint, fix, and navigation
+  path; it does not import
+  `internal/engine` directly (plan 219).
+- `pkg/mdsmith` is the sanctioned
+  `Session` entrypoint over
+  `internal/engine`. Both entry points
+  depend on it, never the reverse.
 - `internal/index` is a peer support
   package both entry points may import;
   it must never import `internal/lsp`
@@ -191,17 +197,17 @@ appropriate ports package).
 
 ## Clean wiring in `cmd/mdsmith`
 
-The CLI entry does flag parsing,
-constructs the engine with its
-dependencies, invokes a subcommand
-handler, and translates the result into
-an exit code and output stream. Anything
-domain-related — including how files are
-discovered, how diagnostics are merged,
-how plans are validated — belongs in
-`internal/engine` or its dependencies. A
-handler in `cmd/mdsmith` longer than
-~50 lines is a smell.
+The CLI entry parses flags, builds a
+`pkg/mdsmith.Session` for its check/fix
+path (or the engine directly for a
+specialized command), invokes a
+subcommand handler, and maps the result
+to an exit code. Domain logic — file
+discovery, diagnostic merging, plan
+validation — belongs in `pkg/mdsmith`,
+`internal/engine`, or their dependencies.
+A handler longer than ~50 lines is a
+smell.
 
 ## Errors and panics
 

--- a/docs/development/architecture/index.md
+++ b/docs/development/architecture/index.md
@@ -63,16 +63,28 @@ hit.
 ## Project layering
 
 Go side. `cmd/mdsmith` and `internal/lsp`
-are both top-layer entry points; both
-depend on `internal/engine`, never the
-reverse.
+are both top-layer entry points. Both
+depend on `pkg/mdsmith` — the public
+`Session` engine API — never the reverse.
+`Session` is the sanctioned orchestration
+layer over `internal/engine`: it owns the
+workspace, the compiled config, and the
+cross-file and parse caches, and exposes
+check, fix, and kinds (plan 219). The LSP
+depends on it exclusively; the CLI routes
+its check/fix path through it and reads a
+few `internal/engine` result types
+directly for output formatting.
 
 ```text
 cmd/mdsmith              internal/lsp
   (CLI entry)              (LSP entry)
         └───────┐    ┌──────┘
                 ↓    ↓
-        internal/engine      (orchestration)
+        pkg/mdsmith          (Session:
+                              orchestration
+                              entrypoint)
+              └─> internal/engine
               └─> internal/{rule, fix,
                             config, output,
                             lint, linkgraph,

--- a/internal/lsp/bench_parsecache_test.go
+++ b/internal/lsp/bench_parsecache_test.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"strings"
 	"testing"
 	"time"
 )
@@ -66,12 +65,10 @@ func benchLatencyWarmCache(b *testing.B, lines int, budget time.Duration) {
 	})
 	h.awaitDiagnostics(b, uri, 5*time.Second)
 
-	// Sanity: the parse cache must hold the version-1 entry before
-	// we measure the warm path, otherwise the benchmark would be
-	// measuring an accidental cold lint.
-	if _, ok := h.srv.parseCache.Get(strings.TrimPrefix(uri, "file://"), 1); !ok {
-		b.Fatalf("parse cache empty after didOpen — benchmark cannot measure warm path")
-	}
+	// The session's version-keyed parse cache holds the version-1 entry
+	// after didOpen; same-version reruns below measure the warm path.
+	// (The cache hit/miss mechanics are unit-tested at the session layer
+	// in pkg/mdsmith.)
 
 	// Drive runLint on a goroutine so the bench main can read its
 	// published diagnostics notification: the transport is an

--- a/internal/lsp/parsecache_integration_test.go
+++ b/internal/lsp/parsecache_integration_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,16 +42,12 @@ func TestParseCache_DidChangeReflectsNewText(t *testing.T) {
 	require.NoError(t, json.Unmarshal(first, &p1))
 	assert.Empty(t, p1.Diagnostics, "clean buffer should produce no diagnostics on the first lint")
 
-	// Sanity: the server populated the parse cache. The relative
-	// path the cache keys off is the absolute path itself when no
-	// workspace root is configured (workspaceRelative returns the
-	// input). Either way, an entry must exist for version 1.
-	_, ok := h.srv.parseCache.Get("/workspace/parsecache.md", 1)
-	require.True(t, ok, "parse cache should hold the version-1 entry after the first lint")
-
-	// didChange at version 2: dirty buffer with trailing spaces.
-	// The cache must invalidate, force a reparse, and MDS006 must
-	// appear in the published diagnostics.
+	// didChange at version 2: dirty buffer with trailing spaces. The
+	// session's version-keyed parse cache must miss at the new version,
+	// force a reparse, and MDS006 must appear in the published
+	// diagnostics. (The cache mechanics themselves are unit-tested at the
+	// session layer in pkg/mdsmith; here we pin the editor-visible
+	// outcome.)
 	h.notify("textDocument/didChange", didChangeTextDocumentParams{
 		TextDocument: versionedTextDocumentIdentifier{URI: uri, Version: 2},
 		ContentChanges: []textDocumentContentChangeEvent{
@@ -71,21 +66,14 @@ func TestParseCache_DidChangeReflectsNewText(t *testing.T) {
 		}
 	}
 	assert.True(t, saw006, "expected MDS006 after didChange; got %+v", p2.Diagnostics)
-
-	// The version-1 entry must be gone: didChange invalidated it.
-	// The version-2 entry must exist: the post-edit runLint stored
-	// the fresh parse.
-	_, ok = h.srv.parseCache.Get("/workspace/parsecache.md", 1)
-	assert.False(t, ok, "didChange must drop the version-1 entry so a stale parse cannot resurface")
-	_, ok = h.srv.parseCache.Get("/workspace/parsecache.md", 2)
-	assert.True(t, ok, "the post-edit lint must store a fresh entry at the new version")
 }
 
-// TestParseCache_DidCloseDropsEntry pins didClose's invalidation:
-// once the buffer is closed the cache entry must be gone so a
-// reopen (which restarts at version 1) cannot accidentally serve a
-// stale *File parsed against the previous session's content.
-func TestParseCache_DidCloseDropsEntry(t *testing.T) {
+// TestParseCache_DidCloseReopenReflectsNewText pins didClose's
+// invalidation behaviourally: once a buffer is closed and reopened
+// (which restarts at version 1) with different content, the republished
+// diagnostics reflect the reopened text — a stale version-1 parse from
+// the first session must not resurface.
+func TestParseCache_DidCloseReopenReflectsNewText(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t)
 	_, errResp := h.request("initialize", initializeParams{})
@@ -94,31 +82,46 @@ func TestParseCache_DidCloseDropsEntry(t *testing.T) {
 	uri := "file:///workspace/close.md"
 	h.notify("textDocument/didOpen", didOpenTextDocumentParams{
 		TextDocument: textDocumentItem{
-			URI: uri, LanguageID: "markdown", Version: 1, Text: "# Hi\n\nclean\n",
+			URI: uri, LanguageID: "markdown", Version: 1, Text: "# Hi\n\nclean line\n",
 		},
 	})
-	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
-
-	_, ok := h.srv.parseCache.Get("/workspace/close.md", 1)
-	require.True(t, ok, "the open lint must populate the cache")
+	first := h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
+	var p1 publishDiagnosticsParams
+	require.NoError(t, json.Unmarshal(first, &p1))
+	assert.Empty(t, p1.Diagnostics, "clean buffer should produce no diagnostics")
 
 	h.notify("textDocument/didClose", didCloseTextDocumentParams{
 		TextDocument: textDocumentIdentifier{URI: uri},
 	})
 	_ = h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
 
-	_, ok = h.srv.parseCache.Get("/workspace/close.md", 1)
-	assert.False(t, ok, "didClose must drop the parse cache entry")
+	// Reopen at version 1 with dirty content. If a stale version-1 parse
+	// survived didClose, MDS006 would be missed.
+	h.notify("textDocument/didOpen", didOpenTextDocumentParams{
+		TextDocument: textDocumentItem{
+			URI: uri, LanguageID: "markdown", Version: 1, Text: "# Hi\n\ndirty line   \n",
+		},
+	})
+	second := h.awaitNotification("textDocument/publishDiagnostics", 5*time.Second)
+	var p2 publishDiagnosticsParams
+	require.NoError(t, json.Unmarshal(second, &p2))
+	var saw006 bool
+	for _, d := range p2.Diagnostics {
+		if d.Code == "MDS006" {
+			saw006 = true
+			break
+		}
+	}
+	assert.True(t, saw006, "reopen at version 1 must reflect the new dirty text, got %+v", p2.Diagnostics)
 }
 
-// TestParseCache_ReloadConfigClearsOnRootChange pins that the parse
-// cache is flushed when reloadConfig picks a different .mdsmith.yml.
-// snapshotConfig derives the workspace root from configPath, and
-// every cache key is relative to that root; when the path moves, the
-// previously stored keys belong to a stale root and must be cleared
-// so a subsequent runLint cannot miss an invalidate it issued against
-// the new key.
-func TestParseCache_ReloadConfigClearsOnRootChange(t *testing.T) {
+// TestParseCache_ReloadRebuildsSessionOnRootChange pins that a config
+// reload to a different .mdsmith.yml rebuilds the per-workspace session.
+// Every cache (the version-keyed parse cache, the cross-file read cache)
+// is owned by the session and is rooted at the config's directory, so a
+// rebuild on a moved config path gives fresh caches keyed against the
+// new root — no stale entry from the previous root can survive.
+func TestParseCache_ReloadRebuildsSessionOnRootChange(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t)
 
@@ -128,11 +131,6 @@ func TestParseCache_ReloadConfigClearsOnRootChange(t *testing.T) {
 	dirB := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dirA, ".mdsmith.yml"), []byte("{}\n"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(dirB, ".mdsmith.yml"), []byte("{}\n"), 0o600))
-
-	// Sanity: the dirs are distinct workspace roots. If they
-	// collapse to one (impossible with t.TempDir, but the contract
-	// the test gates on), the configPath flip would be a no-op and
-	// the test would pass without exercising InvalidateAll.
 	require.NotEqual(t, dirA, dirB, "test setup: the two configs must live in different directories")
 
 	// Point reloadConfig at dirA's config and let it land.
@@ -142,22 +140,20 @@ func TestParseCache_ReloadConfigClearsOnRootChange(t *testing.T) {
 	h.srv.reloadConfig()
 	_, _, rootA := h.srv.snapshotConfig()
 	require.Equal(t, dirA, rootA, "first reload must adopt dirA as the workspace root")
-
-	// Warm the cache with a synthetic entry keyed off dirA.
-	f, err := lint.NewFileFromSource("docs/foo.md", []byte("# Hi\n"), false)
-	require.NoError(t, err)
-	h.srv.parseCache.Put("docs/foo.md", 1, f)
+	sessA, _ := h.srv.currentSession()
+	require.NotNil(t, sessA, "first reload must build a session")
 
 	// Flip the override to dirB and reload. configPath changes, so
-	// reloadConfig must call parseCache.InvalidateAll.
+	// reloadConfig must rebuild the session against the new root.
 	h.srv.settingsMu.Lock()
 	h.srv.settings.ConfigPath = filepath.Join(dirB, ".mdsmith.yml")
 	h.srv.settingsMu.Unlock()
 	h.srv.reloadConfig()
 	_, _, rootB := h.srv.snapshotConfig()
 	require.Equal(t, dirB, rootB, "second reload must adopt dirB as the workspace root")
-	require.NotEqual(t, rootA, rootB, "the reload must change the workspace root for the InvalidateAll branch to fire")
+	require.NotEqual(t, rootA, rootB, "the reload must change the workspace root")
 
-	_, ok := h.srv.parseCache.Get("docs/foo.md", 1)
-	assert.False(t, ok, "config-path change must drop every parse cache entry")
+	sessB, _ := h.srv.currentSession()
+	require.NotNil(t, sessB, "second reload must build a session")
+	assert.NotSame(t, sessA, sessB, "a config-path change must rebuild the session with fresh caches")
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1712,13 +1712,19 @@ func (s *Server) rebuildSession(cfg *config.Config, cfgPath string) {
 		}
 	}
 	s.sessionMu.Lock()
-	old := s.session
 	s.session = sess
 	s.workspace = ws
 	s.sessionMu.Unlock()
-	if old != nil {
-		old.Dispose()
-	}
+	// Do NOT Dispose the superseded session. A lint/fix goroutine may
+	// still hold it (obtained from currentSession() before this swap),
+	// and Dispose nils its checkCache under lock — so the held session's
+	// next Check would lose its warm cache, and a concurrent reload while
+	// linting is in flight is exactly when that happens. The superseded
+	// session is unreferenced once every in-flight caller returns, so GC
+	// reclaims it (its caches are plain maps, nothing OS-level to release);
+	// the public Dispose() stays for external callers that own a session's
+	// whole lifetime. Letting GC reap it keeps the invariant simple: a
+	// session handed out by currentSession() is never disposed underfoot.
 }
 
 // currentSession returns the active session and its overlay workspace

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1,7 +1,6 @@
 package lsp
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,12 +22,11 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/bytelimit"
 	"github.com/jeduden/mdsmith/internal/config"
-	"github.com/jeduden/mdsmith/internal/engine"
-	fixpkg "github.com/jeduden/mdsmith/internal/fix"
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
+	mdsmith "github.com/jeduden/mdsmith/pkg/mdsmith"
 )
 
 // Server runs the LSP loop over a transport pair. One Server instance
@@ -110,23 +108,24 @@ type Server struct {
 	onSupersededExit   func()
 	singletonWatchOnce sync.Once
 
-	// runCache is the engine read cache shared across every runLint
-	// call so two host buffers that catalog over the same docs/**
-	// tree do not each re-read the matched targets from disk on
-	// every keystroke. didChange, didSave, and didChangeWatchedFiles
-	// call its Invalidate seam so an edited file's cached read is
-	// dropped — the next runLint that reaches that path re-reads
-	// from disk.
-	runCache *lint.RunCache
-	// parseCache memoizes the parsed *lint.File for the active
-	// buffer, keyed by (workspace-relative path, textDocument
-	// version). runLint passes doc.version into RunSourceWithVersion;
-	// on hit the engine skips lint.NewFileFromSource. didChange,
-	// didClose, and didChangeWatchedFiles call Invalidate on the
-	// affected path's relative key so a stale entry never serves a
-	// post-edit lint. didOpen needs no drop — the version starts
-	// fresh and no entry exists yet.
-	parseCache *lint.ParseCache
+	// session is the per-workspace pkg/mdsmith.Session every lint and
+	// fix path routes through (plan 219). It owns the cross-file read
+	// cache and the version-keyed parse cache the latency gate depends
+	// on, and an OverlayWorkspace whose open-buffer overlay lets the
+	// editor's unsaved bytes reach cross-file rules. reloadConfig
+	// rebuilds it when the compiled config changes (config is compiled
+	// once per session); sessionMu guards the rebuild against concurrent
+	// lint/fix readers. workspace is the session's overlay, held so
+	// document events can Set/Delete buffers on it.
+	//
+	// didChange/didSave/didClose/didChangeWatchedFiles push buffer edits
+	// and drop stale cache entries through session.Invalidate; a
+	// watched create/delete drops the wikilink index through
+	// session.InvalidateWikilinks. didOpen needs no drop — the version
+	// starts fresh.
+	sessionMu sync.RWMutex
+	session   *mdsmith.Session
+	workspace *mdsmith.OverlayWorkspace
 }
 
 // userSettings mirrors the subset of `mdsmith.*` VS Code keys the
@@ -230,8 +229,6 @@ func New(opts Options) *Server {
 		pending:        make(map[string]*pendingLint),
 		pendingResp:    make(map[string]chan rpcResponse),
 		diags:          make(map[string][]Diagnostic),
-		runCache:       lint.NewRunCache(),
-		parseCache:     lint.NewParseCache(),
 		// Parent-process watchdog defaults; Run() overwrites runCtx
 		// with its own context. Tests override these seams.
 		runCtx:         context.Background(),
@@ -594,6 +591,9 @@ func (s *Server) handleDidOpen(ctx context.Context, raw json.RawMessage) {
 		version: p.TextDocument.Version,
 	})
 	s.indexUpdate(path, []byte(p.TextDocument.Text))
+	// Seed the session overlay with the opened buffer so a cross-file
+	// rule in another open document reads its unsaved bytes.
+	s.syncBuffer(path, []byte(p.TextDocument.Text))
 	// didOpen lints unless run=off — the user wants an initial
 	// snapshot when linting is on at all. scheduleLint applies the
 	// same off-skip as every other trigger.
@@ -617,8 +617,10 @@ func (s *Server) handleDidChange(ctx context.Context, raw json.RawMessage) {
 	doc.version = p.TextDocument.Version
 	s.docs.set(p.TextDocument.URI, doc)
 	s.indexUpdate(doc.path, doc.text)
-	s.invalidateCachedRead(doc.path)
-	s.invalidateParseCache(doc.path)
+	// Push the edited bytes into the overlay and drop this path's stale
+	// read- and parse-cache entries: cross-file rules now see the new
+	// buffer, and the edited document re-parses (the version bumped).
+	s.syncBuffer(doc.path, doc.text)
 	s.scheduleLint(p.TextDocument.URI, lintTriggerChange)
 }
 
@@ -634,7 +636,10 @@ func (s *Server) handleDidSave(ctx context.Context, raw json.RawMessage) {
 		return
 	}
 	if doc, ok := s.docs.get(p.TextDocument.URI); ok {
-		s.invalidateCachedRead(doc.path)
+		// On save the on-disk file matches the buffer, so drop the
+		// overlay and caches; cross-file reads fall through to the saved
+		// file. The buffer is re-overlaid on the next edit.
+		s.dropPath(doc.path)
 	}
 	s.scheduleLint(p.TextDocument.URI, lintTriggerSave)
 }
@@ -670,10 +675,10 @@ func (s *Server) handleDidClose(raw json.RawMessage) {
 	// watcher path will catch the deletion if it lands separately.
 	if doc != nil {
 		s.indexReloadFromDisk(doc.path)
-		// Drop the per-document parse cache entry: the buffer is
-		// gone, and a reopen will land at version 1 again so any
-		// surviving entry would only waste memory until evicted.
-		s.invalidateParseCache(doc.path)
+		// Drop the overlay and per-document parse cache entry: the
+		// buffer is gone, so cross-file reads must fall through to the
+		// saved file, and a reopen lands at version 1 again.
+		s.dropPath(doc.path)
 	}
 	// Clear cached diagnostics and squiggles on close.
 	s.diagsMu.Lock()
@@ -689,24 +694,12 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 		return
 	}
 	configChanged := false
-	treeChanged := false
 	mdChanges := make([]string, 0, len(p.Changes))
 	for _, c := range p.Changes {
 		path := uriToPath(c.URI)
 		if strings.HasSuffix(path, ".mdsmith.yml") {
 			configChanged = true
 			continue
-		}
-		// The wikilink index indexes every file under the workspace
-		// — not just markdown — because embeds like `![[image.png]]`
-		// resolve to any extension. A create or delete of any
-		// non-config file therefore changes the candidate set; the
-		// flag is set before the markdown filter so an image add or
-		// a rename to a binary asset still rebuilds the index.
-		// Per LSP spec: 1=Created, 2=Changed, 3=Deleted. A rename
-		// is reported as a Deleted+Created pair.
-		if c.Type == fileChangeCreated || c.Type == fileChangeDeleted {
-			treeChanged = true
 		}
 		// Use isMarkdownExt for case-insensitive extension match
 		// — the rest of the navigation surface (docTextOrFile,
@@ -718,6 +711,7 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 			mdChanges = append(mdChanges, path)
 		}
 	}
+	treeChanged := watchedFilesTreeChanged(p.Changes)
 	if configChanged {
 		s.reloadConfig()
 		// kind / ignore globs may have shifted — drop the index so
@@ -728,66 +722,88 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, raw json.RawMe
 		}
 		return
 	}
-	if treeChanged && s.runCache != nil {
+	if treeChanged {
 		// File create / delete / rename changes the candidate set
 		// the WikilinkIndex keys off, so the next Check must rebuild
 		// the index from scratch — otherwise MDS027 would resolve
 		// `[[NewPage]]` against the pre-create set and report it
 		// missing (or keep resolving `[[OldName]]` after a delete).
-		s.runCache.InvalidateWikilinks()
+		if sess, _ := s.currentSession(); sess != nil {
+			sess.InvalidateWikilinks()
+		}
 	}
 	openPaths := s.openDocPaths()
 	for _, path := range mdChanges {
-		// External edits land on disk and are the run cache's primary
-		// staleness trigger — drop the entry whether or not we own
-		// the buffer, because the file the catalog rule would read
-		// next has changed underneath us.
-		s.invalidateCachedRead(path)
-		// The parse cache is keyed off the active buffer's
-		// workspace-relative path. When a watched file is also open
-		// in the editor, didChange has already (or will) bump the
-		// version — but if the on-disk edit lands while the buffer
-		// is open at the same content, the cached *File would still
-		// reflect the pre-disk-edit text. Invalidate eagerly to be
-		// safe; the next runLint pays one parse rather than serving
-		// stale results.
-		s.invalidateParseCache(path)
-		// Skip files the editor currently has open as a buffer — the
-		// watcher event would otherwise overwrite the live edits with
-		// the stale on-disk content, and symbol navigation would
-		// silently jump back to the last saved version. Open buffers
-		// are kept in sync via didOpen/didChange instead.
+		// Skip files the editor currently has open as a buffer: their
+		// authoritative content is the overlay buffer (kept current by
+		// didOpen/didChange), so an external on-disk edit does not change
+		// what we lint, and dropPath would wrongly delete the buffer
+		// overlay and make cross-file reads fall through to the stale
+		// disk content. Symbol navigation likewise stays on the live
+		// buffer.
 		if openPaths[path] {
 			continue
 		}
+		// External edit to a file we do not have open: drop its cache
+		// entries (it has no overlay) so the next cross-file Check
+		// re-reads the changed bytes from disk.
+		s.dropPath(path)
 		s.indexReloadFromDisk(path)
 	}
 }
 
-// invalidateCachedRead drops the run cache's entry for path so the
-// next runLint that crosses it re-reads from disk. path is the
-// document's absolute filesystem path, which matches the absolute
-// key the catalog rule computes when populating the cache.
-func (s *Server) invalidateCachedRead(path string) {
-	if s.runCache == nil || path == "" {
-		return
+// watchedFilesTreeChanged reports whether a watched-file batch creates
+// or deletes any non-config file, which changes the candidate set the
+// wikilink index keys off — so the session's wikilink index must rebuild
+// on the next Check (`[[NewPage]]` / `![[image.png]]` resolve against any
+// extension, so a binary asset add counts too). A pure-change batch (no
+// create/delete) leaves the candidate set intact. Per LSP spec:
+// 1=Created, 2=Changed, 3=Deleted; a rename arrives as a Deleted+Created
+// pair. Pulled out of handleDidChangeWatchedFiles so the decision is
+// unit-testable without a live session and its caches.
+func watchedFilesTreeChanged(changes []fileEvent) bool {
+	for _, c := range changes {
+		if strings.HasSuffix(uriToPath(c.URI), ".mdsmith.yml") {
+			continue
+		}
+		if c.Type == fileChangeCreated || c.Type == fileChangeDeleted {
+			return true
+		}
 	}
-	s.runCache.Invalidate(path)
+	return false
 }
 
-// invalidateParseCache drops the parse cache's entry for the
-// document at absPath. The parse cache is keyed by the workspace-
-// relative path RunSourceWithVersion sees, so this method resolves
-// absPath against the current workspace root before delegating to
-// the cache.
-//
-// Used by didChange (edits bump the version, so the prior entry is
-// already dead; this drops it promptly), didClose (buffer gone),
-// and didChangeWatchedFiles (on-disk content changed underneath the
-// editor).
-func (s *Server) invalidateParseCache(absPath string) {
+// syncBuffer pushes an open buffer's current bytes into the session's
+// overlay and drops the path's stale cache entries, so the next
+// cross-file Check reads the unsaved content and the edited document
+// itself re-parses. Called from didOpen (seed the overlay) and
+// didChange (refresh it). absPath is the document's absolute filesystem
+// path; the session keys the overlay and parse cache by the
+// workspace-relative form and the read cache by the absolute form, all
+// derived from the relative uri passed here.
+func (s *Server) syncBuffer(absPath string, content []byte) {
+	sess, _ := s.currentSession()
+	if sess == nil || absPath == "" {
+		return
+	}
 	_, _, root := s.snapshotConfig()
-	s.parseCache.Invalidate(workspaceRelative(root, absPath))
+	sess.Invalidate(workspaceRelative(root, absPath), content)
+}
+
+// dropPath drops the session caches for absPath and removes any overlay
+// entry, so the next read falls through to disk. Used by didSave and
+// didClose (the buffer's bytes are now the saved file) and by
+// didChangeWatchedFiles (an external edit landed on disk underneath us).
+// A no-content Invalidate deletes the overlay entry; for a file with no
+// overlay (a watched neighbour the editor never opened) it just drops
+// the caches.
+func (s *Server) dropPath(absPath string) {
+	sess, _ := s.currentSession()
+	if sess == nil || absPath == "" {
+		return
+	}
+	_, _, root := s.snapshotConfig()
+	sess.Invalidate(workspaceRelative(root, absPath))
 }
 
 // openDocPaths returns the set of filesystem paths currently held as
@@ -1037,7 +1053,7 @@ func (s *Server) runLint(uri string) {
 	if !ok {
 		return
 	}
-	cfg, configPath, root := s.snapshotConfig()
+	cfg, _, root := s.snapshotConfig()
 	if cfg == nil {
 		cfg = config.Merge(config.Defaults(), nil)
 	}
@@ -1050,33 +1066,21 @@ func (s *Server) runLint(uri string) {
 			publishDiagnosticsParams{URI: uri, Version: doc.version, Diagnostics: []Diagnostic{}})
 		return
 	}
-	maxBytes := s.resolveMaxInputBytes(cfg)
-	r := &engine.Runner{
-		Config:           cfg,
-		Rules:            s.rules,
-		StripFrontMatter: frontMatterEnabled(cfg),
-		RootDir:          root,
-		MaxInputBytes:    maxBytes,
-		SourceFS:         dirFSForPath(doc.path),
-		// ConfigPath gates whether config-target rules execute (see
-		// engine.Runner.runConfigTargetRules); without it, LSP
-		// linting silently skips those rules even when a config is
-		// loaded.
-		ConfigPath: configPath,
-		// Share the server-wide read cache across every runLint so
-		// the catalog rule does not re-read each docs/** target on
-		// every keystroke. didChange / didSave / didChangeWatchedFiles
-		// call s.runCache.Invalidate so an edited file's cached read
-		// is dropped before the next pass.
-		RunCache: s.runCache,
-		// Per-document parse cache, keyed by (relPath, doc.version).
-		// On hit the engine skips lint.NewFileFromSource and reuses
-		// the cached *lint.File. didChange / didClose /
-		// didChangeWatchedFiles invalidate the entry via
-		// s.invalidateParseCache(relPath).
-		ParseCache: s.parseCache,
+	// Route the lint through the per-workspace Session. It owns the
+	// cross-file read cache and the version-keyed parse cache, and reads
+	// neighbouring files through its OverlayWorkspace — so the open
+	// buffer this lint is about (pushed into the overlay by didOpen /
+	// didChange) and every other open buffer reach cross-file rules.
+	// CheckVersion serves the cached parse when (relPath, doc.version)
+	// is already parsed, holding the latency gate.
+	sess, _ := s.currentSession()
+	if sess == nil {
+		// No session yet (reloadConfig has not run): nothing to lint
+		// against. handleInitialized builds the first session before any
+		// document event, so this only guards a pre-init race.
+		return
 	}
-	res := r.RunSourceWithVersion(relPath, doc.text, doc.version)
+	res := sess.CheckVersion(relPath, doc.text, doc.version)
 	// engine.RunSource is CPU-bound and can run for hundreds of
 	// milliseconds on large buffers. The client may have requested
 	// shutdown/exit while we were busy; if so, drop everything we
@@ -1137,6 +1141,11 @@ func (s *Server) runLint(uri string) {
 // "0" → unlimited, otherwise the parsed byte count. Parse errors
 // fall back to the default and are surfaced via window/logMessage
 // so the editor user can correct the config.
+//
+// The session resolves its own byte cap from the same config field, so
+// rebuildSession calls this once per reload purely to surface the
+// editor-facing warning on a malformed value — the returned cap is the
+// session's job.
 func (s *Server) resolveMaxInputBytes(cfg *config.Config) int64 {
 	raw := ""
 	if cfg != nil {
@@ -1402,18 +1411,17 @@ func (s *Server) appendFixAllAction(
 	// at the document's real directory so include/catalog rules
 	// still resolve neighbour files independent of the process
 	// CWD.
-	relPath := workspaceRelative(root, doc.path)
-	fixed, err := fixpkg.Source(fixpkg.SourceOptions{
-		Config:           cfg,
-		Rules:            s.rules,
-		Path:             relPath,
-		Source:           doc.text,
-		RootDir:          root,
-		SourceFS:         dirFSForPath(doc.path),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		MaxInputBytes:    s.resolveMaxInputBytes(cfg),
-	})
-	if err == nil && !bytes.Equal(fixed, doc.text) {
+	// Fix-all routes through Session.Fix (today's fix.Source) so the LSP
+	// and `mdsmith fix` share one entry point. The session reads
+	// neighbours through its OverlayWorkspace, so include/catalog rules
+	// resolve against the project root and see open-buffer overlays.
+	sess, _ := s.currentSession()
+	if sess == nil {
+		return actions
+	}
+	res, err := sess.Fix(workspaceRelative(root, doc.path), doc.text)
+	if err == nil && res.Changed {
+		fixed := []byte(res.Source)
 		edit := buildFileEdit(p.TextDocument.URI, doc.text, fixed,
 			annotated, "mdsmith-fix-all", titleFixAllMdsmith)
 		actions = append(actions, codeAction{
@@ -1446,21 +1454,18 @@ func (s *Server) quickFixBytesFor(
 	if !isFixable(s.rules, rule) {
 		return nil
 	}
-	relPath := workspaceRelative(root, doc.path)
-	fixed, err := fixpkg.SourceWithRules(fixpkg.SourceOptions{
-		Config:           cfg,
-		Rules:            s.rules,
-		Path:             relPath,
-		Source:           doc.text,
-		RootDir:          root,
-		SourceFS:         dirFSForPath(doc.path),
-		StripFrontMatter: frontMatterEnabled(cfg),
-		MaxInputBytes:    s.resolveMaxInputBytes(cfg),
-	}, []string{rule})
-	if err != nil || bytes.Equal(fixed, doc.text) {
+	// Per-rule quick-fix routes through Session.FixRule (today's
+	// fix.SourceWithRules): only `rule`'s violations are rewritten, and
+	// neighbours resolve through the session's OverlayWorkspace.
+	sess, _ := s.currentSession()
+	if sess == nil {
 		return nil
 	}
-	return fixed
+	res, err := sess.FixRule(workspaceRelative(root, doc.path), doc.text, []string{rule})
+	if err != nil || !res.Changed {
+		return nil
+	}
+	return []byte(res.Source)
 }
 
 // wantsKind reports whether the client's `Only` filter accepts the
@@ -1643,6 +1648,83 @@ func documentEndPosition(source []byte) (int, int) {
 	return len(lines) - 1, utf16Length(lines[len(lines)-1])
 }
 
+// rebuildSession constructs a fresh per-workspace Session over an
+// OverlayWorkspace rooted at the effective project root, disposes the
+// previous one, and re-seeds the new overlay with every open buffer so
+// cross-file rules keep reading unsaved bytes across the rebuild. cfg is
+// already merged (and carries the include-extract projector / build
+// injection the host applied), so it is handed over with ConfigCompiled
+// and used as-is.
+//
+// A failure to build the session is non-fatal: NewSession only errors
+// when its ConfigSource fails to load, and a compiled source cannot, so
+// this never returns an error in practice. On the off chance it did, the
+// previous session is left in place rather than dropped.
+func (s *Server) rebuildSession(cfg *config.Config, cfgPath string) {
+	root := cfgPath
+	if root != "" {
+		root = filepath.Dir(cfgPath)
+	} else {
+		s.configMu.RLock()
+		root = s.rootDir
+		s.configMu.RUnlock()
+	}
+	// Surface a malformed max-input-size to the editor (the session
+	// silently falls back to the default; this keeps the user-facing
+	// warning the LSP showed before).
+	s.resolveMaxInputBytes(cfg)
+	ws := mdsmith.NewOverlayWorkspace(root)
+	sess, err := mdsmith.NewSession(mdsmith.SessionOptions{
+		Workspace: ws,
+		Config:    mdsmith.ConfigCompiled(cfg, cfgPath),
+	})
+	if err != nil {
+		s.logger.Printf("session: rebuild failed: %v", err)
+		return
+	}
+	// Seed the overlay with every open buffer before publishing the new
+	// session, so the first cross-file Check after a reload already sees
+	// unsaved bytes.
+	for _, uri := range s.docs.openURIs() {
+		if doc, ok := s.docs.get(uri); ok {
+			ws.Set(workspaceRelative(root, doc.path), doc.text)
+		}
+	}
+	s.sessionMu.Lock()
+	old := s.session
+	s.session = sess
+	s.workspace = ws
+	s.sessionMu.Unlock()
+	if old != nil {
+		old.Dispose()
+	}
+}
+
+// currentSession returns the active session and its overlay workspace
+// under the session lock, building one on demand if none exists yet.
+// reloadConfig (from handleInitialized) builds the session eagerly for
+// the normal path; this lazy fallback covers a client that lints after
+// only `initialize` — there the session must still exist, with whatever
+// config snapshotConfig holds (defaults when none was discovered),
+// matching the pre-session behaviour where runLint linted against
+// default config.
+func (s *Server) currentSession() (*mdsmith.Session, *mdsmith.OverlayWorkspace) {
+	s.sessionMu.RLock()
+	sess, ws := s.session, s.workspace
+	s.sessionMu.RUnlock()
+	if sess != nil {
+		return sess, ws
+	}
+	cfg, cfgPath, _ := s.snapshotConfig()
+	if cfg == nil {
+		cfg = config.Merge(config.Defaults(), nil)
+	}
+	s.rebuildSession(cfg, cfgPath)
+	s.sessionMu.RLock()
+	defer s.sessionMu.RUnlock()
+	return s.session, s.workspace
+}
+
 // snapshotConfig returns the cached config, its source path, and the
 // effective project root used for glob/ignore matching and as
 // Runner.RootDir. The root mirrors the CLI's rootDirFromConfig:
@@ -1681,14 +1763,15 @@ func (s *Server) reloadConfig() {
 	s.configPath = cfgPath
 	s.configMu.Unlock()
 
+	// Rebuild the per-workspace Session against the freshly merged
+	// config. The session compiles config once, so any reload (config or
+	// settings change) needs a new one; this also gives it fresh caches,
+	// which subsumes the old per-path parseCache.InvalidateAll on a moved
+	// config path. The new overlay is re-seeded with every open buffer so
+	// cross-file rules keep seeing unsaved bytes after the rebuild.
+	s.rebuildSession(cfg, cfgPath)
+
 	if pathChanged {
-		// snapshotConfig derives the workspace root from configPath;
-		// every parse cache key is workspace-relative to that root.
-		// When the config path moves (initial load, watched-file
-		// change, settings update) the existing keys belong to the
-		// previous root, so the cache must be cleared before the
-		// next runLint computes new ones.
-		s.parseCache.InvalidateAll()
 		// Notify the host only when the config path actually changes,
 		// matching the OnConfigReload field doc ("resolves a new
 		// config path"). A no-op reload (every didChangeConfiguration

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -126,6 +126,19 @@ type Server struct {
 	sessionMu sync.RWMutex
 	session   *mdsmith.Session
 	workspace *mdsmith.OverlayWorkspace
+	// newSession constructs the per-workspace Session. It is a test seam
+	// — production uses mdsmith.NewSession. NewSession only fails when its
+	// ConfigSource fails to load, and rebuildSession always passes a
+	// compiled (already-loaded) source, so the error path is unreachable
+	// in production; the seam lets a test drive rebuildSession's failure
+	// branch (and the nil-session guards downstream of it) red/green.
+	newSession func(mdsmith.SessionOptions) (*mdsmith.Session, error)
+	// afterLintCheck, when non-nil, runs in runLint immediately after the
+	// session Check returns and before the results are published. It is a
+	// test seam (nil in production) that lets a test deterministically
+	// simulate a didClose landing mid-lint — the race the "document was
+	// closed while we were linting" guard protects against.
+	afterLintCheck func()
 }
 
 // userSettings mirrors the subset of `mdsmith.*` VS Code keys the
@@ -241,6 +254,9 @@ func New(opts Options) *Server {
 		// (singleton.go) so both default closures are unit-testable.
 		singletonInterval: singletonPollInterval,
 		onSupersededExit:  func() { osExit(0) },
+		// Production session constructor; tests override to exercise the
+		// rebuild-failure branch.
+		newSession: mdsmith.NewSession,
 	}
 	if opts.EnableWorkspaceSingleton {
 		s.instanceID = newInstanceID()
@@ -1081,6 +1097,11 @@ func (s *Server) runLint(uri string) {
 		return
 	}
 	res := sess.CheckVersion(relPath, doc.text, doc.version)
+	if s.afterLintCheck != nil {
+		// Test seam: deterministically interpose a concurrent didClose /
+		// shutdown between the Check and the publish below.
+		s.afterLintCheck()
+	}
 	// engine.RunSource is CPU-bound and can run for hundreds of
 	// milliseconds on large buffers. The client may have requested
 	// shutdown/exit while we were busy; if so, drop everything we
@@ -1674,7 +1695,7 @@ func (s *Server) rebuildSession(cfg *config.Config, cfgPath string) {
 	// warning the LSP showed before).
 	s.resolveMaxInputBytes(cfg)
 	ws := mdsmith.NewOverlayWorkspace(root)
-	sess, err := mdsmith.NewSession(mdsmith.SessionOptions{
+	sess, err := s.newSession(mdsmith.SessionOptions{
 		Workspace: ws,
 		Config:    mdsmith.ConfigCompiled(cfg, cfgPath),
 	})

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2347,6 +2347,13 @@ func TestQuickFixBytesForCatalogProducesEdit(t *testing.T) {
 	stale := []byte("# Doc\n\n<?catalog\nglob: [\"a.md\"]\n?>\nold body\n<?/catalog?>\n")
 	doc := &document{path: docPath, text: stale}
 
+	// quickFixBytesFor now resolves the fix through the per-workspace
+	// session, which is rooted at the server's workspace root. Set it to
+	// dir so the catalog's `a.md` glob resolves against the on-disk file.
+	s.configMu.Lock()
+	s.rootDir = dir
+	s.configMu.Unlock()
+
 	fixed := s.quickFixBytesFor("catalog", doc, cfg, dir)
 	require.NotNil(t, fixed, "catalog must surface a quick-fix action; "+
 		"users expect mdsmith fix in the Quick Fix lightbulb menu")
@@ -3257,37 +3264,27 @@ func TestHandleDidChangeWatchedFiles_InvalidatesWikilinkIndex(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
-			rc := lint.NewRunCache()
-			s.runCache = rc
-			// Seed the cache so we can detect whether the handler
-			// cleared it.
-			var built int
-			rc.Wikilinks("/root", func() any {
-				built++
-				return "v1"
-			})
-			require.Equal(t, 1, built)
-
-			body, err := json.Marshal(didChangeWatchedFilesParams{
-				Changes: []fileEvent{{URI: tc.uri, Type: tc.changeType}},
-			})
-			require.NoError(t, err)
-			s.handleDidChangeWatchedFiles(context.Background(), body)
-
-			rc.Wikilinks("/root", func() any {
-				built++
-				return "v2"
-			})
-			if tc.want {
-				assert.Equal(t, 2, built,
-					"wikilink cache must rebuild after %s", tc.name)
-			} else {
-				assert.Equal(t, 1, built,
-					"%s must not invalidate the wikilink cache", tc.name)
-			}
+			// The handler routes a create/delete to
+			// session.InvalidateWikilinks via this decision. Testing the
+			// pure decision pins which change types rebuild the wikilink
+			// candidate set without a live session and its caches (the
+			// session-level wikilink drop is covered in pkg/mdsmith).
+			got := watchedFilesTreeChanged([]fileEvent{{URI: tc.uri, Type: tc.changeType}})
+			assert.Equal(t, tc.want, got,
+				"watchedFilesTreeChanged(%s) = %v, want %v", tc.name, got, tc.want)
 		})
 	}
+}
+
+// TestWatchedFilesTreeChangedSkipsConfig pins that a .mdsmith.yml change
+// alone does not flag a tree change (it is handled by the config-reload
+// path, which rebuilds the session entirely).
+func TestWatchedFilesTreeChangedSkipsConfig(t *testing.T) {
+	t.Parallel()
+	got := watchedFilesTreeChanged([]fileEvent{
+		{URI: "file:///proj/.mdsmith.yml", Type: fileChangeCreated},
+	})
+	assert.False(t, got, "a config-only create must not flag a wikilink tree change")
 }
 
 func TestDocumentStoreGetMissing(t *testing.T) {
@@ -3977,51 +3974,13 @@ func TestHandleDidClose_CancelsPendingLint(t *testing.T) {
 	assert.False(t, hasPending, "pending lint timer must be cleared after didClose")
 }
 
-// --- invalidateCachedRead ---
-
-// TestInvalidateCachedRead_NilRunCache pins the early-return when
-// the server has no run cache attached. The didChange handler
-// drives this in tests that construct a Server without seeding
-// s.runCache, but the branch was not explicitly asserted.
-func TestInvalidateCachedRead_NilRunCache(t *testing.T) {
-	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
-	// runCache is nil by default. The call must not panic.
-	s.invalidateCachedRead("/some/path")
-}
-
-// TestInvalidateCachedRead_EmptyPath pins the early-return when
-// the caller passes an empty path. The runCache is non-nil, so
-// only the path guard fires.
-func TestInvalidateCachedRead_EmptyPath(t *testing.T) {
-	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
-	rc := lint.NewRunCache()
-	s.runCache = rc
-	s.invalidateCachedRead("")
-	// Cache state should not have been touched.
-}
-
-// TestInvalidateCachedRead_DropsEntry pins the happy path: a
-// non-nil runCache plus a non-empty path forwards to
-// runCache.Invalidate. We seed a CatalogEntries entry for the
-// path and verify it is dropped after the call.
-func TestInvalidateCachedRead_DropsEntry(t *testing.T) {
-	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
-	rc := lint.NewRunCache()
-	s.runCache = rc
-	const path = "/seed/file.md"
-	rc.FrontMatter(path, func() any { return "stored" })
-	// Sanity: cache hit before invalidation.
-	got := rc.FrontMatter(path, func() any { return "rebuilt" })
-	if got != "stored" {
-		t.Fatalf("seed: cache hit = %v, want stored", got)
-	}
-	s.invalidateCachedRead(path)
-	// After invalidate, the build closure runs again.
-	got = rc.FrontMatter(path, func() any { return "rebuilt" })
-	if got != "rebuilt" {
-		t.Errorf("after invalidate: cache hit = %v, want rebuilt", got)
-	}
-}
+// Read-cache invalidation moved from the Server onto the per-workspace
+// pkg/mdsmith.Session: the nil-guard, empty-path, and drops-entry
+// branches that TestInvalidateCachedRead_* used to pin are now exercised
+// by the session's own Invalidate tests in pkg/mdsmith
+// (TestInvalidateClearsDependentCache, TestInvalidateDropsVersionParseCache).
+// The Server's syncBuffer/dropPath wrappers that route to the session
+// are covered behaviourally by the document-sync and overlay tests.
 
 // TestIsAbsPath covers the cross-platform absolute-path classification
 // relatedURI relies on: POSIX absolute, Windows drive-letter, and UNC

--- a/internal/lsp/session_rebuild_test.go
+++ b/internal/lsp/session_rebuild_test.go
@@ -3,7 +3,10 @@ package lsp
 import (
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,4 +157,120 @@ func TestQuickFixBytesForNoSessionReturnsNil(t *testing.T) {
 	got := s.quickFixBytesFor("no-trailing-spaces", doc, cfg, "")
 	require.Nil(t, got,
 		"quick-fix with no session must return nil so no broken edit is offered")
+}
+
+// serverWithSession builds a Server whose per-workspace session is
+// already constructed against an on-disk config under dir, mirroring the
+// post-handleInitialized state. It returns the server so a test can hold
+// the live session via currentSession() and drive concurrent reloads.
+func serverWithSession(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte("{}\n"), 0o600))
+
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All()})
+	s.configMu.Lock()
+	s.rootDir = dir
+	s.configMu.Unlock()
+	s.reloadConfig() // builds the first session
+	return s
+}
+
+// TestRebuildSessionDoesNotDisposeHeldSession is the use-after-dispose
+// regression guard. A lint/fix goroutine obtains a session from
+// currentSession(); a concurrent reloadConfig (config or
+// didChangeWatchedFiles change) then swaps in a new session. The swap
+// must NOT Dispose the superseded session, because the held goroutine is
+// still using it: Dispose nils its checkCache under lock, so the held
+// session's Check would lose its warm cache (and, without the engine's
+// nil-map guard, would panic on the next write). Run under -race.
+//
+// The held session is exercised through Check (which writes checkCache),
+// Fix (which routes through Check), and CheckVersion (the per-keystroke
+// path) while reloadConfig hammers rebuildSession in parallel. The
+// assertions: no panic/race, and the held session keeps returning the
+// correct diagnostic for a known-dirty buffer the whole time.
+func TestRebuildSessionDoesNotDisposeHeldSession(t *testing.T) {
+	t.Parallel()
+	s := serverWithSession(t)
+
+	held, _ := s.currentSession()
+	require.NotNil(t, held, "reloadConfig must have built a session")
+
+	// A buffer with a trailing-space violation (MDS006) and a long line
+	// (MDS001): every Check on it must keep reporting the same findings,
+	// proving the held session stays a working linter across the swap.
+	dirty := []byte("# Title\n\ntrailing line here   \n")
+
+	// Warm the held session's checkCache so a concurrent Dispose (the bug)
+	// would visibly nil a populated cache, not an empty one.
+	if _, err := held.Check("doc.md", dirty); err != nil {
+		t.Fatalf("warm Check: %v", err)
+	}
+
+	const iters = 200
+	var wg sync.WaitGroup
+
+	// Reloader: repeatedly rebuild the session under sessionMu. Before the
+	// fix this called old.Dispose() on the held session.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cfg, cfgPath, _ := s.snapshotConfig()
+		for i := 0; i < iters; i++ {
+			s.rebuildSession(cfg, cfgPath)
+		}
+	}()
+
+	// Users of the HELD session: Check / Fix / CheckVersion must keep
+	// working and keep finding MDS006 while the swap races underneath.
+	check := func(do func() bool) {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if !do() {
+				t.Errorf("held session lost its MDS006 finding mid-reload")
+				return
+			}
+		}
+	}
+	wg.Add(3)
+	go check(func() bool {
+		diags, err := held.Check("doc.md", dirty)
+		return err == nil && hasPublicRule(diags, "MDS006")
+	})
+	go check(func() bool {
+		res, err := held.Fix("doc.md", dirty)
+		// MDS006 (trailing spaces) is fixable, so a working Fix removes it:
+		// the source must change and the trailing run must be gone. This
+		// proves Fix re-linted through the held session without panic.
+		return err == nil && res.Changed && !strings.Contains(res.Source, "here   ")
+	})
+	go check(func() bool {
+		res := held.CheckVersion("doc.md", dirty, 1)
+		for _, d := range res.Diagnostics {
+			if d.RuleID == "MDS006" {
+				return true
+			}
+		}
+		return false
+	})
+
+	wg.Wait()
+
+	// After the storm, the held session must still cache and lint
+	// correctly — a Disposed session would have a dead checkCache.
+	diags, err := held.Check("doc.md", dirty)
+	require.NoError(t, err, "held session unusable after concurrent reloads")
+	assert.True(t, hasPublicRule(diags, "MDS006"),
+		"held session must still report MDS006 after the reload storm")
+}
+
+// hasPublicRule reports whether any public diagnostic carries ruleID.
+func hasPublicRule(diags []mdsmith.Diagnostic, ruleID string) bool {
+	for _, d := range diags {
+		if d.Rule == ruleID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/lsp/session_rebuild_test.go
+++ b/internal/lsp/session_rebuild_test.go
@@ -1,0 +1,157 @@
+package lsp
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	vlog "github.com/jeduden/mdsmith/internal/log"
+	"github.com/jeduden/mdsmith/internal/rule"
+	mdsmith "github.com/jeduden/mdsmith/pkg/mdsmith"
+
+	_ "github.com/jeduden/mdsmith/internal/rules/all"
+)
+
+// failingSessionServer returns a Server whose session constructor always
+// fails, so rebuildSession takes its error branch and currentSession
+// returns a nil session — the precondition the nil-session guards across
+// the LSP defend against. Production cannot reach this (a compiled config
+// source never fails to load), so the seam is the only red/green driver.
+func failingSessionServer(t *testing.T, w io.Writer) *Server {
+	t.Helper()
+	s := New(Options{Reader: nil, Writer: io.Discard, Rules: rule.All(),
+		Logger: &vlog.Logger{Enabled: true, W: w}})
+	s.newSession = func(mdsmith.SessionOptions) (*mdsmith.Session, error) {
+		return nil, errors.New("injected session-build failure")
+	}
+	return s
+}
+
+// TestRebuildSessionLogsAndKeepsNilSessionOnError covers rebuildSession's
+// error branch: when the session constructor fails, the server logs the
+// failure and leaves s.session nil rather than swapping in a half-built
+// one. currentSession then returns nil, which every lint/fix path guards.
+func TestRebuildSessionLogsAndKeepsNilSessionOnError(t *testing.T) {
+	t.Parallel()
+	var buf strings.Builder
+	s := failingSessionServer(t, &buf)
+
+	s.rebuildSession(config.Merge(config.Defaults(), nil), "")
+
+	s.sessionMu.RLock()
+	sess := s.session
+	s.sessionMu.RUnlock()
+	if sess != nil {
+		t.Fatal("rebuildSession: session must stay nil after a build failure")
+	}
+	if !strings.Contains(buf.String(), "rebuild failed") {
+		t.Fatalf("rebuildSession: expected a 'rebuild failed' log, got %q", buf.String())
+	}
+
+	// currentSession re-attempts the (still-failing) build and returns nil.
+	if got, _ := s.currentSession(); got != nil {
+		t.Fatal("currentSession: expected nil when every rebuild fails")
+	}
+}
+
+// TestSyncBufferNoSessionIsNoOp covers syncBuffer's guard: with no
+// session it returns without touching an overlay, so a buffer edit that
+// arrives before the session exists cannot panic.
+func TestSyncBufferNoSessionIsNoOp(t *testing.T) {
+	t.Parallel()
+	s := failingSessionServer(t, io.Discard)
+	// Must not panic and must not block: the guard returns immediately.
+	s.syncBuffer("/abs/x.md", []byte("# buffer\n"))
+	// The empty-absPath arm of the same guard.
+	s.syncBuffer("", []byte("# buffer\n"))
+}
+
+// TestDropPathNoSessionIsNoOp covers dropPath's guard: with no session it
+// returns without dropping caches, mirroring syncBuffer.
+func TestDropPathNoSessionIsNoOp(t *testing.T) {
+	t.Parallel()
+	s := failingSessionServer(t, io.Discard)
+	s.dropPath("/abs/x.md")
+	s.dropPath("") // empty-absPath arm
+}
+
+// TestRunLintNoSessionPublishesNothing covers runLint's nil-session
+// guard: a lint scheduled before any session exists publishes no
+// diagnostics instead of dereferencing a nil session.
+func TestRunLintNoSessionPublishesNothing(t *testing.T) {
+	t.Parallel()
+	var buf safeBuffer
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
+	s.newSession = func(mdsmith.SessionOptions) (*mdsmith.Session, error) {
+		return nil, errors.New("injected session-build failure")
+	}
+	s.docs.set("file:///x.md", &document{
+		uri: "file:///x.md", path: "x.md", text: []byte("# Hi\n\ndirty   \n"),
+	})
+
+	s.runLint("file:///x.md")
+	assert.NotContains(t, buf.String(), "publishDiagnostics",
+		"a lint with no session must not publish diagnostics")
+}
+
+// TestRunLintDiscardsResultsWhenDocClosedMidLint covers runLint's
+// "document was closed while we were linting" guard: didClose can land
+// after the Check has started but before the publish. The afterLintCheck
+// seam deletes the document at exactly that point; runLint must then
+// discard the results so it does not re-publish stale squiggles over
+// didClose's empty notification.
+func TestRunLintDiscardsResultsWhenDocClosedMidLint(t *testing.T) {
+	t.Parallel()
+	var buf safeBuffer
+	s := New(Options{Reader: nil, Writer: &buf, Rules: rule.All()})
+	const uri = "file:///x.md"
+	s.docs.set(uri, &document{
+		uri: uri, path: "x.md", text: []byte("# Hi\n\ndirty   \n"),
+	})
+	// Simulate didClose racing in after the Check returns: drop the doc
+	// before runLint re-checks docs.get below the Check.
+	s.afterLintCheck = func() { s.docs.delete(uri) }
+
+	s.runLint(uri)
+	assert.NotContains(t, buf.String(), "publishDiagnostics",
+		"results for a document closed mid-lint must be discarded")
+}
+
+// TestAppendFixAllActionNoSessionReturnsActions covers appendFixAllAction's
+// nil-session guard: a source.fixAll request with no session yet returns
+// the actions list unchanged (no fix-all entry) instead of panicking.
+func TestAppendFixAllActionNoSessionReturnsActions(t *testing.T) {
+	t.Parallel()
+	s := failingSessionServer(t, io.Discard)
+	cfg := config.Merge(config.Defaults(), nil)
+	doc := &document{path: "x.md", text: []byte("# Hi\n\ndirty   \n")}
+	p := codeActionParams{
+		TextDocument: textDocumentIdentifier{URI: "file:///x.md"},
+		Context:      codeActionContext{Only: []string{kindSourceFixAll}},
+	}
+
+	actions := s.computeCodeActions(p, doc, cfg, "")
+	assert.Empty(t, actions,
+		"fix-all with no session must surface no action (guarded), even on a fixable buffer")
+}
+
+// TestQuickFixBytesForNoSessionReturnsNil covers quickFixBytesFor's
+// nil-session guard: a per-rule quick-fix with no session returns nil
+// (no action) rather than dereferencing the nil session, even though the
+// buffer has a fixable violation the rule owns.
+func TestQuickFixBytesForNoSessionReturnsNil(t *testing.T) {
+	t.Parallel()
+	s := failingSessionServer(t, io.Discard)
+	cfg := config.Merge(config.Defaults(), nil)
+	// A real trailing-spaces violation: with a session this would fix.
+	doc := &document{path: "x.md", text: []byte("# Hi\n\ndirty   \n")}
+
+	got := s.quickFixBytesFor("no-trailing-spaces", doc, cfg, "")
+	require.Nil(t, got,
+		"quick-fix with no session must return nil so no broken edit is offered")
+}

--- a/pkg/mdsmith/batch.go
+++ b/pkg/mdsmith/batch.go
@@ -86,6 +86,21 @@ func (s *Session) FixPaths(paths []string, opts BatchOptions) *fixpkg.Result {
 	return fixer.Fix(paths)
 }
 
+// CheckSource lints one in-memory source (e.g. stdin) and returns the
+// engine result, including any config-target rule findings against the
+// loaded config. It is the single-source sibling of CheckPaths: the CLI
+// uses it for `mdsmith check -` so stdin shares the session path, while
+// the public [Session.Check] serves the cached, JS-mirrored single-file
+// surface. uri is the display path ("<stdin>"); cross-file rules see no
+// SourceFS, matching the engine's stdin behaviour.
+//
+// Native-only: it returns the engine's own Result so the CLI reuses its
+// reporting. A WASM host uses [Session.Check] (which returns the public
+// Diagnostic shape) instead.
+func (s *Session) CheckSource(uri string, source []byte, opts BatchOptions) *engine.Result {
+	return s.newBatchRunner(opts).RunSource(uri, source)
+}
+
 // newBatchRunner builds the engine.Runner shared by CheckPaths (and, on
 // the path-based fixer side, the post-fix lint). It threads the session
 // state plus the per-call BatchOptions. MaxInputBytes falls back to the

--- a/pkg/mdsmith/batch.go
+++ b/pkg/mdsmith/batch.go
@@ -1,0 +1,109 @@
+package mdsmith
+
+import (
+	"github.com/jeduden/mdsmith/internal/engine"
+	fixpkg "github.com/jeduden/mdsmith/internal/fix"
+	vlog "github.com/jeduden/mdsmith/internal/log"
+)
+
+// BatchOptions tunes a multi-file batch operation ([Session.CheckPaths],
+// [Session.FixPaths]). All fields are optional; the zero value runs at
+// the engine defaults (GOMAXPROCS concurrency, no explain, no verbose
+// logging, the session's configured byte cap).
+//
+// Batch ops are a native power surface: they read and (for FixPaths)
+// write many files on disk, walk in parallel, and return the engine's
+// own Result/fix.Result so the CLI keeps its discovery, ordering, and
+// output formatting. They have no JavaScript mirror — a WASM host has no
+// disk and drives single files through [Session.Check] / [Session.Fix].
+// See docs/background/concepts/engine-api.md.
+type BatchOptions struct {
+	// Explain, when true, attaches per-leaf rule provenance to each
+	// diagnostic (the CLI's --explain flag).
+	Explain bool
+	// Concurrency caps how many files are linted/fixed in parallel.
+	// Zero or negative means "use runtime.GOMAXPROCS"; the engine
+	// clamps the worker count to the file count. The value never
+	// changes observable output — only CPU vs wall-time.
+	Concurrency int
+	// MaxInputBytes overrides the session's default byte cap for this
+	// call. Zero leaves the session default in place; a positive value
+	// rejects files larger than that many bytes; a negative value
+	// (or math.MaxInt64) means unlimited. The CLI passes the value it
+	// resolved from --max-input-size / config here.
+	MaxInputBytes int64
+	// Logger receives the engine's verbose trace lines (config, files,
+	// rules) for the CLI's -v flag. Nil means no verbose output.
+	Logger *vlog.Logger
+	// DryRun applies only to [Session.FixPaths]: run the full fix
+	// pipeline but write nothing back to disk, recording the per-rule
+	// would-fix tally on the result instead (the CLI's `fix --dry-run`).
+	// Ignored by CheckPaths.
+	DryRun bool
+}
+
+// CheckPaths lints the on-disk files at paths and returns the aggregate
+// engine result — diagnostics sorted by file, line, column, message,
+// plus any per-file errors and the count of files checked. It drives
+// engine.Runner.Run internally with the session's compiled config,
+// rule set, root, and config path, so config-target rules (MDS040) run
+// once for the whole run rather than once per file.
+//
+// CheckPaths is native-only: it reads files from disk through the
+// engine's path-based loop. A WASM host lints in-memory buffers through
+// [Session.Check] instead. The caller (cmd/mdsmith) keeps file
+// discovery, ignore filtering at the walk layer, and output formatting.
+func (s *Session) CheckPaths(paths []string, opts BatchOptions) *engine.Result {
+	return s.newBatchRunner(opts).Run(paths)
+}
+
+// FixPaths auto-fixes the on-disk files at paths in place and returns
+// the aggregate fix result — remaining diagnostics, the list of
+// modified files, the would-fix preview (when DryRun is set), and any
+// errors. It drives fix.Fixer.Fix internally with the session's compiled
+// config, rule set, root, and the per-call BatchOptions.
+//
+// FixPaths is native-only: the fixer reads and writes files on disk. A
+// WASM host fixes in-memory buffers through [Session.Fix] instead. The
+// caller (cmd/mdsmith) keeps file discovery, leaves-first ordering, and
+// output formatting; pass paths already ordered so a cross-file
+// generated-section cascade converges in one productive pass.
+func (s *Session) FixPaths(paths []string, opts BatchOptions) *fixpkg.Result {
+	maxBytes := s.maxBytes
+	if opts.MaxInputBytes != 0 {
+		maxBytes = opts.MaxInputBytes
+	}
+	fixer := &fixpkg.Fixer{
+		Config:           s.cfg,
+		Rules:            s.rules,
+		StripFrontMatter: frontMatterEnabled(s.cfg),
+		Logger:           opts.Logger,
+		RootDir:          s.rootDir,
+		MaxInputBytes:    maxBytes,
+		Explain:          opts.Explain,
+		DryRun:           opts.DryRun,
+	}
+	return fixer.Fix(paths)
+}
+
+// newBatchRunner builds the engine.Runner shared by CheckPaths (and, on
+// the path-based fixer side, the post-fix lint). It threads the session
+// state plus the per-call BatchOptions. MaxInputBytes falls back to the
+// session default when the option is zero.
+func (s *Session) newBatchRunner(opts BatchOptions) *engine.Runner {
+	maxBytes := s.maxBytes
+	if opts.MaxInputBytes != 0 {
+		maxBytes = opts.MaxInputBytes
+	}
+	return &engine.Runner{
+		Config:           s.cfg,
+		Rules:            s.rules,
+		StripFrontMatter: frontMatterEnabled(s.cfg),
+		Logger:           opts.Logger,
+		RootDir:          s.rootDir,
+		MaxInputBytes:    maxBytes,
+		Explain:          opts.Explain,
+		Concurrency:      opts.Concurrency,
+		ConfigPath:       s.cfgPath,
+	}
+}

--- a/pkg/mdsmith/batch_test.go
+++ b/pkg/mdsmith/batch_test.go
@@ -1,0 +1,181 @@
+package mdsmith
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	vlog "github.com/jeduden/mdsmith/internal/log"
+)
+
+// TestCheckPathsLintsFilesOnDisk drives the native batch op the CLI's
+// check subcommand uses: CheckPaths reads the given on-disk files
+// through the engine Runner and returns the aggregate Result with
+// diagnostics sorted by file/line. A workspace-rooted at the temp dir
+// means the engine resolves cross-file content the same way the CLI
+// does.
+func TestCheckPathsLintsFilesOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.md")
+	// A line with trailing spaces (MDS006) — fixable, default-enabled.
+	if err := os.WriteFile(bad, []byte("# Title\n\ntrailing   \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s, err := NewSession(SessionOptions{
+		Workspace: OSWorkspace{Root: dir},
+		Config:    ConfigYAML(""),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	res := s.CheckPaths([]string{bad}, BatchOptions{})
+	if res.FilesChecked != 1 {
+		t.Fatalf("FilesChecked = %d, want 1", res.FilesChecked)
+	}
+	if len(res.Diagnostics) == 0 {
+		t.Fatalf("CheckPaths: expected a diagnostic for trailing spaces, got none")
+	}
+}
+
+// TestCheckPathsExplainAttachesProvenance verifies the Explain batch
+// option threads through to the Runner so diagnostics carry per-leaf
+// provenance — the --explain CLI flag.
+func TestCheckPathsExplainAttachesProvenance(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	cfg := "rules:\n  line-length:\n    max: 10\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("WriteFile cfg: %v", err)
+	}
+	long := filepath.Join(dir, "long.md")
+	if err := os.WriteFile(long, []byte("# Title\n\nthis line is definitely longer than ten\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s, err := NewSession(SessionOptions{
+		Workspace: OSWorkspace{Root: dir},
+		Config:    ConfigPath(cfgPath),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	res := s.CheckPaths([]string{long}, BatchOptions{Explain: true})
+	var found bool
+	for _, d := range res.Diagnostics {
+		if d.RuleID == "MDS001" && d.Explanation != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("CheckPaths(Explain): expected an MDS001 diagnostic with provenance, got %+v", res.Diagnostics)
+	}
+}
+
+// TestCheckPathsLoggerReceivesVerboseOutput verifies the Logger batch
+// option threads to the Runner so `-v` output reaches the caller's
+// writer.
+func TestCheckPathsLoggerReceivesVerboseOutput(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "a.md")
+	if err := os.WriteFile(doc, []byte("# Title\n\nBody paragraph.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	var buf bytes.Buffer
+	s, err := NewSession(SessionOptions{Workspace: OSWorkspace{Root: dir}, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	s.CheckPaths([]string{doc}, BatchOptions{Logger: &vlog.Logger{Enabled: true, W: &buf}})
+	if !bytes.Contains(buf.Bytes(), []byte("file:")) {
+		t.Fatalf("CheckPaths(Logger): expected verbose 'file:' line, got %q", buf.String())
+	}
+}
+
+// TestFixPathsRewritesFilesOnDisk drives the native batch op the CLI's
+// fix subcommand uses: FixPaths fixes the given on-disk files in place
+// and reports the modified set. A trailing-space line is rewritten.
+func TestFixPathsRewritesFilesOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "bad.md")
+	if err := os.WriteFile(doc, []byte("# Title\n\ntrailing   \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s, err := NewSession(SessionOptions{Workspace: OSWorkspace{Root: dir}, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	res := s.FixPaths([]string{doc}, BatchOptions{})
+	if len(res.Modified) != 1 {
+		t.Fatalf("FixPaths Modified = %v, want exactly [bad.md]", res.Modified)
+	}
+	got, err := os.ReadFile(doc)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if bytes.Contains(got, []byte("trailing   ")) {
+		t.Fatalf("FixPaths did not strip trailing spaces: %q", got)
+	}
+}
+
+// TestFixPathsDryRunWritesNothing verifies the DryRun batch option runs
+// the fix pipeline but leaves the file untouched while still reporting a
+// would-fix preview.
+func TestFixPathsDryRunWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "bad.md")
+	original := []byte("# Title\n\ntrailing   \n")
+	if err := os.WriteFile(doc, original, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s, err := NewSession(SessionOptions{Workspace: OSWorkspace{Root: dir}, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	res := s.FixPaths([]string{doc}, BatchOptions{DryRun: true})
+	if len(res.Modified) != 0 {
+		t.Fatalf("FixPaths(DryRun) Modified = %v, want empty", res.Modified)
+	}
+	if res.WouldFix == 0 {
+		t.Fatalf("FixPaths(DryRun): expected WouldFix > 0")
+	}
+	got, err := os.ReadFile(doc)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("FixPaths(DryRun) modified the file on disk: %q", got)
+	}
+}
+
+// TestCheckPathsMaxInputBytesOverrides verifies a per-call
+// MaxInputBytes in BatchOptions overrides the session default so the
+// CLI can pass its resolved --max-input-size.
+func TestCheckPathsMaxInputBytesOverrides(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "big.md")
+	if err := os.WriteFile(doc, []byte("# A heading longer than sixteen bytes\n\nBody.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s, err := NewSession(SessionOptions{Workspace: OSWorkspace{Root: dir}, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	res := s.CheckPaths([]string{doc}, BatchOptions{MaxInputBytes: 16})
+	if len(res.Errors) == 0 {
+		t.Fatalf("CheckPaths(MaxInputBytes=16): expected a 'file too large' error, got none")
+	}
+}

--- a/pkg/mdsmith/checkversion_test.go
+++ b/pkg/mdsmith/checkversion_test.go
@@ -1,0 +1,81 @@
+package mdsmith
+
+import "testing"
+
+// TestCheckVersionReflectsNewText is the LSP-facing contract: a
+// version-aware Check parses (and caches by version), and a later Check
+// at a new version on edited bytes reflects the post-edit text — the
+// per-keystroke path plan 216's parse cache backs.
+func TestCheckVersionReflectsNewText(t *testing.T) {
+	s := newTestSession(t, "", nil)
+
+	clean := []byte("# Hi\n\nclean line\n")
+	if diags, err := s.CheckVersion("a.md", clean, 1); err != nil {
+		t.Fatalf("CheckVersion v1: %v", err)
+	} else if hasRule(diags, "MDS006") {
+		t.Fatalf("CheckVersion v1: clean source should have no MDS006, got %+v", diags)
+	}
+
+	dirty := []byte("# Hi\n\ndirty line   \n")
+	diags, err := s.CheckVersion("a.md", dirty, 2)
+	if err != nil {
+		t.Fatalf("CheckVersion v2: %v", err)
+	}
+	if !hasRule(diags, "MDS006") {
+		t.Fatalf("CheckVersion v2: expected MDS006 for trailing space, got %+v", diags)
+	}
+}
+
+// TestCheckVersionReusesParseAtSameVersion verifies the version-keyed
+// parse cache: a second CheckVersion at the same (uri, version) reuses
+// the parsed file rather than re-parsing. Observed via the engine
+// ParseCache the session installs — a hit means the second call did not
+// allocate a fresh parse.
+func TestCheckVersionReusesParseAtSameVersion(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	src := []byte("# Hi\n\nsome body line here\n")
+
+	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
+		t.Fatalf("CheckVersion 1: %v", err)
+	}
+	hitsBefore := s.parseCacheHits()
+	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
+		t.Fatalf("CheckVersion 2: %v", err)
+	}
+	if s.parseCacheHits() <= hitsBefore {
+		t.Fatalf("expected a parse-cache hit on the second CheckVersion at the same version")
+	}
+}
+
+// TestCheckVersionCrossFileSeesOverlay verifies the version path reads
+// cross-file content through the session workspace: a catalog over a
+// MemWorkspace file projects that file's summary. This is the seam the
+// LSP buffer overlay rides on (footgun 3).
+func TestCheckVersionCrossFileSeesOverlay(t *testing.T) {
+	files := map[string][]byte{
+		"docs/one.md": []byte("---\nsummary: First\n---\n# One\n\nBody paragraph.\n"),
+	}
+	s := newTestSession(t, "", files)
+	// An index whose catalog row would be stale if the body did not list
+	// the projected summary. Check returns the catalog diagnostic (the
+	// body is empty and out of date), proving the cross-file read ran.
+	index := []byte("# Index\n\n<?catalog\nglob:\n  - \"docs/*.md\"\n" +
+		"row: \"- [{summary}](docs/{filename})\"\n?>\n<?/catalog?>\n")
+
+	diags, err := s.CheckVersion("index.md", index, 1)
+	if err != nil {
+		t.Fatalf("CheckVersion: %v", err)
+	}
+	if !hasRule(diags, "MDS019") {
+		t.Fatalf("CheckVersion: expected MDS019 (stale catalog) proving cross-file read, got %+v", diags)
+	}
+}
+
+func hasRule(diags []Diagnostic, rule string) bool {
+	for _, d := range diags {
+		if d.Rule == rule {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/mdsmith/checkversion_test.go
+++ b/pkg/mdsmith/checkversion_test.go
@@ -1,6 +1,20 @@
 package mdsmith
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// hasEngineRule reports whether any engine diagnostic carries ruleID.
+func hasEngineRule(diags []lint.Diagnostic, ruleID string) bool {
+	for _, d := range diags {
+		if d.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
 
 // TestCheckVersionReflectsNewText is the LSP-facing contract: a
 // version-aware Check parses (and caches by version), and a later Check
@@ -10,38 +24,30 @@ func TestCheckVersionReflectsNewText(t *testing.T) {
 	s := newTestSession(t, "", nil)
 
 	clean := []byte("# Hi\n\nclean line\n")
-	if diags, err := s.CheckVersion("a.md", clean, 1); err != nil {
-		t.Fatalf("CheckVersion v1: %v", err)
-	} else if hasRule(diags, "MDS006") {
-		t.Fatalf("CheckVersion v1: clean source should have no MDS006, got %+v", diags)
+	if res := s.CheckVersion("a.md", clean, 1); hasEngineRule(res.Diagnostics, "MDS006") {
+		t.Fatalf("CheckVersion v1: clean source should have no MDS006, got %+v", res.Diagnostics)
 	}
 
 	dirty := []byte("# Hi\n\ndirty line   \n")
-	diags, err := s.CheckVersion("a.md", dirty, 2)
-	if err != nil {
-		t.Fatalf("CheckVersion v2: %v", err)
+	res := s.CheckVersion("a.md", dirty, 2)
+	if len(res.Errors) != 0 {
+		t.Fatalf("CheckVersion v2: unexpected errors %v", res.Errors)
 	}
-	if !hasRule(diags, "MDS006") {
-		t.Fatalf("CheckVersion v2: expected MDS006 for trailing space, got %+v", diags)
+	if !hasEngineRule(res.Diagnostics, "MDS006") {
+		t.Fatalf("CheckVersion v2: expected MDS006 for trailing space, got %+v", res.Diagnostics)
 	}
 }
 
 // TestCheckVersionReusesParseAtSameVersion verifies the version-keyed
 // parse cache: a second CheckVersion at the same (uri, version) reuses
-// the parsed file rather than re-parsing. Observed via the engine
-// ParseCache the session installs — a hit means the second call did not
-// allocate a fresh parse.
+// the parsed file rather than re-parsing.
 func TestCheckVersionReusesParseAtSameVersion(t *testing.T) {
 	s := newTestSession(t, "", nil)
 	src := []byte("# Hi\n\nsome body line here\n")
 
-	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
-		t.Fatalf("CheckVersion 1: %v", err)
-	}
+	s.CheckVersion("a.md", src, 1)
 	hitsBefore := s.parseCacheHits()
-	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
-		t.Fatalf("CheckVersion 2: %v", err)
-	}
+	s.CheckVersion("a.md", src, 1)
 	if s.parseCacheHits() <= hitsBefore {
 		t.Fatalf("expected a parse-cache hit on the second CheckVersion at the same version")
 	}
@@ -56,26 +62,13 @@ func TestCheckVersionCrossFileSeesOverlay(t *testing.T) {
 		"docs/one.md": []byte("---\nsummary: First\n---\n# One\n\nBody paragraph.\n"),
 	}
 	s := newTestSession(t, "", files)
-	// An index whose catalog row would be stale if the body did not list
-	// the projected summary. Check returns the catalog diagnostic (the
-	// body is empty and out of date), proving the cross-file read ran.
+	// An index whose catalog body is empty and out of date. Check returns
+	// MDS019, proving the cross-file read ran.
 	index := []byte("# Index\n\n<?catalog\nglob:\n  - \"docs/*.md\"\n" +
 		"row: \"- [{summary}](docs/{filename})\"\n?>\n<?/catalog?>\n")
 
-	diags, err := s.CheckVersion("index.md", index, 1)
-	if err != nil {
-		t.Fatalf("CheckVersion: %v", err)
+	res := s.CheckVersion("index.md", index, 1)
+	if !hasEngineRule(res.Diagnostics, "MDS019") {
+		t.Fatalf("CheckVersion: expected MDS019 (stale catalog) proving cross-file read, got %+v", res.Diagnostics)
 	}
-	if !hasRule(diags, "MDS019") {
-		t.Fatalf("CheckVersion: expected MDS019 (stale catalog) proving cross-file read, got %+v", diags)
-	}
-}
-
-func hasRule(diags []Diagnostic, rule string) bool {
-	for _, d := range diags {
-		if d.Rule == rule {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/mdsmith/config_compiled_test.go
+++ b/pkg/mdsmith/config_compiled_test.go
@@ -40,7 +40,8 @@ func TestConfigCompiledUsedAsIs(t *testing.T) {
 	defer s.Dispose()
 
 	if got := s.cfg.Rules["line-length"].Settings["max"]; got != 999 {
-		t.Fatalf("session config line-length.max = %v, want 999 (compiled config must be used as-is, not re-merged)", got)
+		t.Fatalf("session config line-length.max = %v, want 999 "+
+			"(compiled config must be used as-is, not re-merged)", got)
 	}
 	if s.cfg != merged {
 		t.Fatalf("session should hold the supplied compiled config pointer unchanged")

--- a/pkg/mdsmith/config_compiled_test.go
+++ b/pkg/mdsmith/config_compiled_test.go
@@ -1,0 +1,54 @@
+package mdsmith
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+)
+
+// TestConfigCompiledUsedAsIs verifies a ConfigCompiled source is taken
+// exactly as supplied: NewSession does not re-merge it over defaults
+// (which would drop settings a caller injected onto the compiled config,
+// e.g. build recipes for MDS040) and reports the supplied config path.
+// The CLI uses this so its loadConfig side effects (InjectBuildConfig,
+// the include-extract projector) survive into the session.
+func TestConfigCompiledUsedAsIs(t *testing.T) {
+	// Build a config the way the CLI does, then mark a sentinel on a
+	// rule's settings the way InjectBuildConfig would. If NewSession
+	// re-merged over defaults, the sentinel-bearing entry would be
+	// recomputed and the marker lost.
+	merged := config.Merge(config.Defaults(), nil)
+	if merged.Rules == nil {
+		merged.Rules = map[string]config.RuleCfg{}
+	}
+	rc := merged.Rules["line-length"]
+	if rc.Settings == nil {
+		rc.Settings = map[string]any{}
+	}
+	rc.Settings["max"] = 999
+	merged.Rules["line-length"] = rc
+
+	src := ConfigCompiled(merged, "/proj/.mdsmith.yml")
+	if got := src.configPath(); got != "/proj/.mdsmith.yml" {
+		t.Fatalf("ConfigCompiled.configPath() = %q, want /proj/.mdsmith.yml", got)
+	}
+
+	s, err := NewSession(SessionOptions{Workspace: NewMemWorkspace(nil), Config: src})
+	if err != nil {
+		t.Fatalf("NewSession(ConfigCompiled): %v", err)
+	}
+	defer s.Dispose()
+
+	if got := s.cfg.Rules["line-length"].Settings["max"]; got != 999 {
+		t.Fatalf("session config line-length.max = %v, want 999 (compiled config must be used as-is, not re-merged)", got)
+	}
+	if s.cfg != merged {
+		t.Fatalf("session should hold the supplied compiled config pointer unchanged")
+	}
+	if s.cfgPath != "/proj/.mdsmith.yml" {
+		t.Fatalf("session cfgPath = %q, want /proj/.mdsmith.yml", s.cfgPath)
+	}
+	if s.rootDir != "" {
+		t.Fatalf("session rootDir = %q, want empty (MemWorkspace has no Root)", s.rootDir)
+	}
+}

--- a/pkg/mdsmith/fixrule_test.go
+++ b/pkg/mdsmith/fixrule_test.go
@@ -1,0 +1,67 @@
+package mdsmith
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFixRuleAppliesOnlyNamedRule is the LSP per-rule quick-fix
+// contract: FixRule applies only the named rule(s), leaving other
+// fixable violations in place. Here trailing whitespace (MDS006) is
+// fixed while a separate fixable issue the rule does not own is left
+// untouched.
+func TestFixRuleAppliesOnlyNamedRule(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	// Two independent fixable issues: trailing spaces (no-trailing-spaces)
+	// and a bare URL the bare-url rule would linkify. Fixing only
+	// no-trailing-spaces must strip the spaces but leave the bare URL.
+	src := []byte("# Title\n\nSee https://example.com now   \n")
+
+	res, err := s.FixRule("a.md", src, []string{"no-trailing-spaces"})
+	if err != nil {
+		t.Fatalf("FixRule: %v", err)
+	}
+	if !res.Changed {
+		t.Fatal("FixRule: expected Changed=true")
+	}
+	if strings.Contains(res.Source, "now   ") {
+		t.Fatalf("FixRule(no-trailing-spaces): trailing spaces not removed: %q", res.Source)
+	}
+	if !strings.Contains(res.Source, "https://example.com") {
+		t.Fatalf("FixRule must not touch other rules; bare URL line changed: %q", res.Source)
+	}
+}
+
+// TestFixRuleNoOpReportsUnchanged verifies FixRule reports Changed=false
+// and returns the input unchanged when the named rule has nothing to
+// fix — the LSP suppresses a no-op quick-fix action.
+func TestFixRuleNoOpReportsUnchanged(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	src := []byte("# Title\n\nClean body paragraph.\n")
+
+	res, err := s.FixRule("a.md", src, []string{"no-trailing-spaces"})
+	if err != nil {
+		t.Fatalf("FixRule: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("FixRule(no-op): expected Changed=false, got source %q", res.Source)
+	}
+	if res.Source != string(src) {
+		t.Fatalf("FixRule(no-op): source changed: %q", res.Source)
+	}
+}
+
+// TestFixRuleEmptyNamesNoOp verifies an empty rule list produces no
+// change (matching fix.SourceWithRules).
+func TestFixRuleEmptyNamesNoOp(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	src := []byte("# Title\n\ntrailing   \n")
+
+	res, err := s.FixRule("a.md", src, nil)
+	if err != nil {
+		t.Fatalf("FixRule: %v", err)
+	}
+	if res.Changed {
+		t.Fatal("FixRule(no names): expected Changed=false")
+	}
+}

--- a/pkg/mdsmith/invalidate_overlay_test.go
+++ b/pkg/mdsmith/invalidate_overlay_test.go
@@ -1,0 +1,98 @@
+package mdsmith
+
+import (
+	"sync"
+	"testing"
+)
+
+// recordingWorkspace is a Workspace that also implements Set/Delete so
+// the footgun-3 test can prove Invalidate routes open-document content
+// through the Workspace interface, not a hardcoded *MemWorkspace type
+// assertion. It delegates reads to an embedded MemWorkspace.
+type recordingWorkspace struct {
+	*MemWorkspace
+	mu      sync.Mutex
+	sets    map[string][]byte
+	deletes []string
+}
+
+func newRecordingWorkspace(files map[string][]byte) *recordingWorkspace {
+	return &recordingWorkspace{MemWorkspace: NewMemWorkspace(files), sets: map[string][]byte{}}
+}
+
+func (w *recordingWorkspace) Set(p string, data []byte) {
+	w.mu.Lock()
+	w.sets[p] = append([]byte(nil), data...)
+	w.mu.Unlock()
+	w.MemWorkspace.Set(p, data)
+}
+
+func (w *recordingWorkspace) Delete(p string) {
+	w.mu.Lock()
+	w.deletes = append(w.deletes, p)
+	w.mu.Unlock()
+	w.MemWorkspace.Delete(p)
+}
+
+// TestInvalidateRoutesContentThroughInterface proves footgun 3 is
+// resolved generically: a Workspace implementing Set/Delete (not the
+// concrete *MemWorkspace) receives the open-document content on
+// Invalidate, so an overlay workspace's buffer bytes reach cross-file
+// rules.
+func TestInvalidateRoutesContentThroughInterface(t *testing.T) {
+	ws := newRecordingWorkspace(nil)
+	s, err := NewSession(SessionOptions{Workspace: ws, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	s.Invalidate("docs/a.md", []byte("buffer bytes"))
+	ws.mu.Lock()
+	got, ok := ws.sets["docs/a.md"]
+	ws.mu.Unlock()
+	if !ok {
+		t.Fatal("Invalidate did not call Set on the Workspace interface")
+	}
+	if string(got) != "buffer bytes" {
+		t.Fatalf("Set received %q, want %q", got, "buffer bytes")
+	}
+
+	s.Invalidate("docs/a.md")
+	ws.mu.Lock()
+	deleted := len(ws.deletes) == 1 && ws.deletes[0] == "docs/a.md"
+	ws.mu.Unlock()
+	if !deleted {
+		t.Fatalf("no-content Invalidate did not call Delete: deletes=%v", ws.deletes)
+	}
+}
+
+// TestInvalidateDropsVersionParseCache verifies Invalidate drops the
+// version-keyed parse cache for the changed path, so a CheckVersion at
+// the same version after an external change re-parses instead of serving
+// a stale *lint.File.
+func TestInvalidateDropsVersionParseCache(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	src := []byte("# T\n\nBody paragraph here.\n")
+
+	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
+		t.Fatalf("CheckVersion 1: %v", err)
+	}
+	hits := s.parseCacheHits()
+	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
+		t.Fatalf("CheckVersion 2: %v", err)
+	}
+	if s.parseCacheHits() <= hits {
+		t.Fatal("expected a parse-cache hit before invalidation")
+	}
+
+	s.Invalidate("a.md", []byte("# T\n\nDifferent body now.\n"))
+
+	hitsAfter := s.parseCacheHits()
+	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
+		t.Fatalf("CheckVersion 3: %v", err)
+	}
+	if s.parseCacheHits() != hitsAfter {
+		t.Fatal("CheckVersion served the version parse cache after Invalidate dropped it")
+	}
+}

--- a/pkg/mdsmith/invalidate_overlay_test.go
+++ b/pkg/mdsmith/invalidate_overlay_test.go
@@ -75,13 +75,9 @@ func TestInvalidateDropsVersionParseCache(t *testing.T) {
 	s := newTestSession(t, "", nil)
 	src := []byte("# T\n\nBody paragraph here.\n")
 
-	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
-		t.Fatalf("CheckVersion 1: %v", err)
-	}
+	s.CheckVersion("a.md", src, 1)
 	hits := s.parseCacheHits()
-	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
-		t.Fatalf("CheckVersion 2: %v", err)
-	}
+	s.CheckVersion("a.md", src, 1)
 	if s.parseCacheHits() <= hits {
 		t.Fatal("expected a parse-cache hit before invalidation")
 	}
@@ -89,9 +85,7 @@ func TestInvalidateDropsVersionParseCache(t *testing.T) {
 	s.Invalidate("a.md", []byte("# T\n\nDifferent body now.\n"))
 
 	hitsAfter := s.parseCacheHits()
-	if _, err := s.CheckVersion("a.md", src, 1); err != nil {
-		t.Fatalf("CheckVersion 3: %v", err)
-	}
+	s.CheckVersion("a.md", src, 1)
 	if s.parseCacheHits() != hitsAfter {
 		t.Fatal("CheckVersion served the version parse cache after Invalidate dropped it")
 	}

--- a/pkg/mdsmith/overlay.go
+++ b/pkg/mdsmith/overlay.go
@@ -1,0 +1,153 @@
+package mdsmith
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// OverlayWorkspace reads from the host filesystem rooted at Root, but
+// lets in-memory buffers shadow the on-disk content of specific paths.
+// It is the LSP server's workspace: an editor's unsaved-buffer bytes,
+// pushed in through [Session.Invalidate] (which calls Set), shadow the
+// file on disk so cross-file rules — catalog, include, links — read the
+// live buffer rather than the last saved version.
+//
+// Only file content is overlaid. Open buffers still exist on disk, so
+// directory listing and globbing defer to disk; the overlay supplies the
+// shadowed bytes when a path is read. That keeps the fs.FS view cheap to
+// build per lint pass — it clones only the small open-buffer map, never
+// the whole corpus — so a per-keystroke Check pays no O(corpus) snapshot
+// cost.
+//
+// OverlayWorkspace is safe for concurrent use. Reads take a read lock;
+// Set and Delete take a write lock.
+type OverlayWorkspace struct {
+	root    string
+	mu      sync.RWMutex
+	overlay map[string][]byte
+}
+
+// NewOverlayWorkspace returns an OverlayWorkspace rooted at root with no
+// buffers overlaid. Mutate the overlay through Set and Delete.
+func NewOverlayWorkspace(root string) *OverlayWorkspace {
+	return &OverlayWorkspace{root: root, overlay: map[string][]byte{}}
+}
+
+// cleanKey normalises p to the slash-separated, cleaned form the overlay
+// map is keyed by, matching how the engine's FS view names paths.
+func cleanKey(p string) string {
+	return path.Clean(filepath.ToSlash(p))
+}
+
+// ReadFile returns the overlaid bytes for p when a buffer shadows it,
+// otherwise it reads from disk resolved against Root (an absolute path
+// is read unchanged), mirroring OSWorkspace so the on-disk fall-through
+// and the FS view name the same file for one uri.
+func (w *OverlayWorkspace) ReadFile(p string) ([]byte, error) {
+	key := cleanKey(p)
+	w.mu.RLock()
+	data, ok := w.overlay[key]
+	w.mu.RUnlock()
+	if ok {
+		return bytes.Clone(data), nil
+	}
+	return os.ReadFile(w.diskPath(p)) //nolint:gosec // path is caller-controlled; this is the native disk seam
+}
+
+// diskPath maps a workspace-relative path to an absolute on-disk path
+// rooted at Root, matching OSWorkspace.resolve. Absolute paths and an
+// empty Root pass through unchanged.
+func (w *OverlayWorkspace) diskPath(p string) string {
+	if w.root == "" || filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(w.root, filepath.FromSlash(p))
+}
+
+// Glob expands a doublestar pattern against the on-disk tree rooted at
+// Root. Open buffers exist on disk, so they are already discovered here;
+// the overlay only shadows content on read.
+func (w *OverlayWorkspace) Glob(pattern string) ([]string, error) {
+	matches, err := doublestar.FilepathGlob(filepath.Join(w.root, filepath.FromSlash(pattern)))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// FS returns an fs.FS that shadows disk with the current overlay
+// contents. The overlay map is snapshotted (cloned) so a later Set or
+// Delete does not affect an already-returned FS; the engine fetches a
+// fresh FS per lint pass, so an overlay edit applied through Invalidate
+// lands on the next Check. The snapshot copies only the open-buffer map,
+// not the corpus.
+func (w *OverlayWorkspace) FS() fs.FS {
+	w.mu.RLock()
+	snap := make(map[string][]byte, len(w.overlay))
+	for k, v := range w.overlay {
+		snap[k] = bytes.Clone(v)
+	}
+	w.mu.RUnlock()
+	root := w.root
+	if root == "" {
+		root = "."
+	}
+	return &overlayFS{disk: os.DirFS(root), overlay: snap}
+}
+
+// Set stores data (cloned) as the overlay for p, shadowing disk on the
+// next read.
+func (w *OverlayWorkspace) Set(p string, data []byte) {
+	key := cleanKey(p)
+	w.mu.Lock()
+	w.overlay[key] = bytes.Clone(data)
+	w.mu.Unlock()
+}
+
+// Delete drops the overlay for p so the next read falls through to disk.
+func (w *OverlayWorkspace) Delete(p string) {
+	key := cleanKey(p)
+	w.mu.Lock()
+	delete(w.overlay, key)
+	w.mu.Unlock()
+}
+
+// overlayFS is an fs.FS that serves overlaid bytes for shadowed paths
+// and defers everything else (directory walks, globs, unshadowed reads)
+// to disk. It implements fs.ReadFileFS so bytelimit.ReadFSFileLimited
+// and the catalog/include rules read a shadowed path's buffer bytes
+// without opening the on-disk file.
+type overlayFS struct {
+	disk    fs.FS
+	overlay map[string][]byte
+}
+
+func (o *overlayFS) Open(name string) (fs.File, error) {
+	if data, ok := o.overlay[name]; ok {
+		return &memFile{name: name, data: data}, nil
+	}
+	return o.disk.Open(name)
+}
+
+func (o *overlayFS) ReadFile(name string) ([]byte, error) {
+	if data, ok := o.overlay[name]; ok {
+		return bytes.Clone(data), nil
+	}
+	return fs.ReadFile(o.disk, name)
+}
+
+func (o *overlayFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return fs.ReadDir(o.disk, name)
+}
+
+func (o *overlayFS) Glob(pattern string) ([]string, error) {
+	return doublestar.Glob(o.disk, pattern)
+}

--- a/pkg/mdsmith/overlay_test.go
+++ b/pkg/mdsmith/overlay_test.go
@@ -1,0 +1,157 @@
+package mdsmith
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestOverlayWorkspaceReadFilePrefersOverlay verifies an
+// OverlayWorkspace returns the overlaid (open-buffer) bytes for a
+// shadowed path and falls through to disk for everything else. This is
+// the LSP's workspace: unsaved-buffer bytes shadow the on-disk file.
+func TestOverlayWorkspaceReadFilePrefersOverlay(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("disk-a"), 0o600); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.md"), []byte("disk-b"), 0o600); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	ws := NewOverlayWorkspace(root)
+	ws.Set("a.md", []byte("buffer-a"))
+
+	gotA, err := ws.ReadFile("a.md")
+	if err != nil {
+		t.Fatalf("ReadFile a: %v", err)
+	}
+	if string(gotA) != "buffer-a" {
+		t.Fatalf("ReadFile a = %q, want overlay bytes buffer-a", gotA)
+	}
+	gotB, err := ws.ReadFile("b.md")
+	if err != nil {
+		t.Fatalf("ReadFile b: %v", err)
+	}
+	if string(gotB) != "disk-b" {
+		t.Fatalf("ReadFile b = %q, want disk fall-through disk-b", gotB)
+	}
+}
+
+// TestOverlayWorkspaceFSPrefersOverlay verifies the fs.FS view also
+// shadows disk with overlay bytes, so cross-file rules (catalog,
+// include) reading through FS see the open-buffer content (footgun 3).
+func TestOverlayWorkspaceFSPrefersOverlay(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "a.md"), []byte("disk"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ws := NewOverlayWorkspace(root)
+	ws.Set("docs/a.md", []byte("overlay"))
+
+	got, err := fs.ReadFile(ws.FS(), "docs/a.md")
+	if err != nil {
+		t.Fatalf("fs.ReadFile: %v", err)
+	}
+	if string(got) != "overlay" {
+		t.Fatalf("FS ReadFile = %q, want overlay", got)
+	}
+
+	// A path with no overlay falls through to disk.
+	if err := os.WriteFile(filepath.Join(root, "docs", "c.md"), []byte("only-disk"), 0o600); err != nil {
+		t.Fatalf("WriteFile c: %v", err)
+	}
+	gotC, err := fs.ReadFile(ws.FS(), "docs/c.md")
+	if err != nil {
+		t.Fatalf("fs.ReadFile c: %v", err)
+	}
+	if string(gotC) != "only-disk" {
+		t.Fatalf("FS ReadFile c = %q, want disk fall-through", gotC)
+	}
+}
+
+// TestOverlayWorkspaceFSReflectsLatestSet verifies a Set after an FS
+// view was taken is visible to a freshly fetched FS — the engine
+// fetches a new FS per lint pass, so the overlay edit lands on the next
+// Check.
+func TestOverlayWorkspaceFSReflectsLatestSet(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("disk"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	ws := NewOverlayWorkspace(root)
+
+	ws.Set("a.md", []byte("v1"))
+	if got, _ := fs.ReadFile(ws.FS(), "a.md"); string(got) != "v1" {
+		t.Fatalf("FS after Set v1 = %q, want v1", got)
+	}
+	ws.Set("a.md", []byte("v2"))
+	if got, _ := fs.ReadFile(ws.FS(), "a.md"); string(got) != "v2" {
+		t.Fatalf("FS after Set v2 = %q, want v2", got)
+	}
+	ws.Delete("a.md")
+	if got, _ := fs.ReadFile(ws.FS(), "a.md"); string(got) != "disk" {
+		t.Fatalf("FS after Delete = %q, want disk fall-through", got)
+	}
+}
+
+// TestOverlayWorkspaceSatisfiesMutable confirms OverlayWorkspace
+// satisfies the mutable overlay interface Session.Invalidate uses, so
+// the LSP's buffer bytes reach cross-file rules.
+func TestOverlayWorkspaceSatisfiesMutable(t *testing.T) {
+	var _ mutableWorkspace = NewOverlayWorkspace(t.TempDir())
+	var _ Workspace = NewOverlayWorkspace(t.TempDir())
+}
+
+// TestSessionOverlayBufferReachesCrossFileRule is the end-to-end
+// footgun-3 acceptance for the LSP scenario: a Session over an
+// OverlayWorkspace catalogs a file whose unsaved-buffer summary differs
+// from disk. After Invalidate pushes the buffer bytes, the index's
+// catalog projects the buffer summary, not the saved one — the open
+// document reached the cross-file rule through the session.
+func TestSessionOverlayBufferReachesCrossFileRule(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "one.md"),
+		[]byte("---\nsummary: Saved\n---\n# One\n\nBody paragraph.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ws := NewOverlayWorkspace(root)
+	s, err := NewSession(SessionOptions{Workspace: ws, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	index := []byte("# Index\n\n<?catalog\nglob:\n  - \"docs/*.md\"\n" +
+		"row: \"- [{summary}](docs/{filename})\"\n?>\n<?/catalog?>\n")
+
+	// Saved state: the catalog projects "Saved".
+	res1, err := s.Fix("index.md", index)
+	if err != nil {
+		t.Fatalf("Fix 1: %v", err)
+	}
+	if !strings.Contains(res1.Source, "Saved") {
+		t.Fatalf("Fix 1: catalog should project the saved summary:\n%s", res1.Source)
+	}
+
+	// Push an unsaved buffer edit through Invalidate (the LSP didChange
+	// path), then re-fix: the catalog must pick up the buffer summary.
+	s.Invalidate("docs/one.md", []byte("---\nsummary: Buffered\n---\n# One\n\nBody paragraph.\n"))
+	res2, err := s.Fix("index.md", index)
+	if err != nil {
+		t.Fatalf("Fix 2: %v", err)
+	}
+	if !strings.Contains(res2.Source, "Buffered") {
+		t.Fatalf("Fix 2: open-buffer summary did not reach the catalog rule:\n%s", res2.Source)
+	}
+}

--- a/pkg/mdsmith/overlay_test.go
+++ b/pkg/mdsmith/overlay_test.go
@@ -205,6 +205,95 @@ func TestOverlayFSGlob(t *testing.T) {
 	}
 }
 
+// TestSessionOverlayAnchorsRootDir verifies a Session built over an
+// OverlayWorkspace (the LSP's workspace) anchors its rootDir at the
+// overlay's project root, not the empty string. The empty value would
+// flip the cross-file RunCache from absolute keys (the CLI's OSWorkspace
+// behaviour) to relative keys — an unintended asymmetry between the CLI
+// and the LSP. absPath, which Invalidate keys cache evictions by, must
+// then resolve the same absolute path Runner.RootDir keys cache writes
+// by, so the two stay consistent.
+func TestSessionOverlayAnchorsRootDir(t *testing.T) {
+	root := t.TempDir()
+	ws := NewOverlayWorkspace(root)
+	s, err := NewSession(SessionOptions{Workspace: ws, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	if s.rootDir != root {
+		t.Fatalf("session rootDir = %q, want overlay root %q", s.rootDir, root)
+	}
+	// absPath (cache-eviction keying) must produce an absolute path under
+	// the root for a workspace-relative uri, matching how the runner's
+	// RootDir anchors cross-file cache writes. A relative result would
+	// mean Invalidate evicts a key the rules never wrote.
+	if got := s.absPath("docs/a.md"); got != filepath.Join(root, "docs", "a.md") {
+		t.Fatalf("absPath(docs/a.md) = %q, want %q", got, filepath.Join(root, "docs", "a.md"))
+	}
+}
+
+// TestSessionOverlayInvalidateDropsStaleCrossFileRead is the
+// invalidation-consistency acceptance for the corrected absolute
+// keying: a cross-file Fix warms the RunCache for a neighbour (keyed by
+// the absolute path the runner's RootDir produces), then Invalidate
+// (keyed by absPath) must drop that exact entry so the next Fix reads
+// the changed bytes. If the write key and the eviction key disagreed —
+// the asymmetry an empty rootDir introduces — the second Fix would
+// project the stale summary from the cached cross-file read. Fix is
+// used (not a hand-written catalog body) so the canonical generated
+// formatting is produced by the engine, not guessed.
+func TestSessionOverlayInvalidateDropsStaleCrossFileRead(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "one.md"),
+		[]byte("---\nsummary: First\n---\n# One\n\nBody paragraph.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ws := NewOverlayWorkspace(root)
+	s, err := NewSession(SessionOptions{Workspace: ws, Config: ConfigYAML("")})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	index := []byte("# Index\n\n<?catalog\nglob:\n  - \"docs/*.md\"\n" +
+		"row: \"- [{summary}](docs/{filename})\"\n?>\n<?/catalog?>\n")
+
+	// First Fix reads docs/one.md through the RunCache and projects its
+	// saved summary, warming the absolute-keyed cross-file read.
+	res1, err := s.Fix("index.md", index)
+	if err != nil {
+		t.Fatalf("Fix 1: %v", err)
+	}
+	if !strings.Contains(res1.Source, "First") {
+		t.Fatalf("Fix 1: catalog should project the saved summary First:\n%s", res1.Source)
+	}
+
+	// Change the neighbour's summary through the overlay. Invalidate keys
+	// the eviction by absPath; the next Fix's cross-file read keys the
+	// lookup by the runner's RootDir-anchored absolute path. They must be
+	// the same key, or the cache returns the stale "First".
+	s.Invalidate("docs/one.md", []byte("---\nsummary: Second\n---\n# One\n\nBody paragraph.\n"))
+
+	res2, err := s.Fix("index.md", index)
+	if err != nil {
+		t.Fatalf("Fix 2: %v", err)
+	}
+	if !strings.Contains(res2.Source, "Second") {
+		t.Fatalf("Fix 2: expected the new summary Second, proving Invalidate "+
+			"dropped the absolute-keyed cross-file read:\n%s", res2.Source)
+	}
+	if strings.Contains(res2.Source, "First") {
+		t.Fatalf("Fix 2: stale summary First survived; the eviction key did "+
+			"not match the cross-file read key:\n%s", res2.Source)
+	}
+}
+
 // TestSessionOverlayBufferReachesCrossFileRule is the end-to-end
 // footgun-3 acceptance for the LSP scenario: a Session over an
 // OverlayWorkspace catalogs a file whose unsaved-buffer summary differs

--- a/pkg/mdsmith/overlay_test.go
+++ b/pkg/mdsmith/overlay_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -107,6 +108,101 @@ func TestOverlayWorkspaceFSReflectsLatestSet(t *testing.T) {
 func TestOverlayWorkspaceSatisfiesMutable(t *testing.T) {
 	var _ mutableWorkspace = NewOverlayWorkspace(t.TempDir())
 	var _ Workspace = NewOverlayWorkspace(t.TempDir())
+}
+
+// TestOverlayWorkspaceGlob verifies OverlayWorkspace.Glob expands a
+// doublestar pattern against the on-disk tree rooted at Root and returns
+// sorted, root-relative-resolved matches. Open buffers exist on disk, so
+// globbing defers to disk; the overlay only shadows content on read.
+func TestOverlayWorkspaceGlob(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for _, name := range []string{"docs/b.md", "docs/a.md", "docs/c.txt"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+
+	ws := NewOverlayWorkspace(root)
+	// An overlaid buffer must not add or remove a glob match: globbing
+	// reads disk, not the overlay.
+	ws.Set("docs/a.md", []byte("buffer"))
+
+	got, err := ws.Glob("docs/*.md")
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	want := []string{filepath.Join(root, "docs", "a.md"), filepath.Join(root, "docs", "b.md")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Glob(docs/*.md) = %v, want %v (sorted, disk-backed)", got, want)
+	}
+}
+
+// TestOverlayWorkspaceGlobBadPattern verifies a malformed doublestar
+// pattern surfaces an error rather than being silently swallowed,
+// matching OSWorkspace.Glob's error contract.
+func TestOverlayWorkspaceGlobBadPattern(t *testing.T) {
+	ws := NewOverlayWorkspace(t.TempDir())
+	if _, err := ws.Glob("[bad"); err == nil {
+		t.Fatal("Glob([bad): expected an error for a malformed pattern, got nil")
+	}
+}
+
+// TestOverlayWorkspaceReadFileAbsolutePath covers diskPath's
+// passthrough branch: an absolute path is read unchanged (not re-rooted
+// under Root), mirroring OSWorkspace.resolve so an absolute-path caller
+// reaches the file it named.
+func TestOverlayWorkspaceReadFileAbsolutePath(t *testing.T) {
+	root := t.TempDir()
+	// A file OUTSIDE Root, addressed by its absolute path. If diskPath
+	// wrongly joined it under Root, this read would miss.
+	other := t.TempDir()
+	abs := filepath.Join(other, "elsewhere.md")
+	if err := os.WriteFile(abs, []byte("absolute"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ws := NewOverlayWorkspace(root)
+	got, err := ws.ReadFile(abs)
+	if err != nil {
+		t.Fatalf("ReadFile(abs): %v", err)
+	}
+	if string(got) != "absolute" {
+		t.Fatalf("ReadFile(abs) = %q, want disk bytes read at the absolute path", got)
+	}
+}
+
+// TestOverlayFSGlob verifies the fs.FS view's Glob (fs.GlobFS) expands a
+// doublestar pattern against disk, so doublestar.Glob and the
+// catalog/include rules globbing through the FS view honour `**` and
+// brace alternatives just like the other glob surfaces in mdsmith.
+func TestOverlayFSGlob(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", "sub"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "a.md"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "sub", "b.md"), []byte("b"), 0o600); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	fsys, ok := NewOverlayWorkspace(root).FS().(fs.GlobFS)
+	if !ok {
+		t.Fatal("OverlayWorkspace.FS() must implement fs.GlobFS")
+	}
+	got, err := fsys.Glob("docs/**/*.md")
+	if err != nil {
+		t.Fatalf("FS().Glob: %v", err)
+	}
+	want := []string{"docs/a.md", "docs/sub/b.md"}
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("FS().Glob(docs/**/*.md) = %v, want %v", got, want)
+	}
 }
 
 // TestSessionOverlayBufferReachesCrossFileRule is the end-to-end

--- a/pkg/mdsmith/resolvefile_test.go
+++ b/pkg/mdsmith/resolvefile_test.go
@@ -1,0 +1,56 @@
+package mdsmith
+
+import "testing"
+
+// TestResolveFileReturnsRawResolution covers the native ResolveFile
+// entry the CLI's `kinds resolve` / `kinds why` route through: given a
+// uri plus its already-parsed front-matter kinds and fields, it returns
+// the raw *config.FileResolution (the per-rule merge chain the `why`
+// subcommand walks), resolved against the session's compiled config.
+func TestResolveFileReturnsRawResolution(t *testing.T) {
+	cfg := "kinds:\n  doc:\n    path-pattern: \"docs/**/*.md\"\n" +
+		"kind-assignment:\n  - glob: [\"docs/**/*.md\"]\n    kinds: [doc]\n"
+	s := newTestSession(t, cfg, nil)
+
+	res := s.ResolveFile("docs/guide.md", nil, nil)
+	if res == nil {
+		t.Fatal("ResolveFile returned nil")
+	}
+	if res.File != "docs/guide.md" {
+		t.Fatalf("res.File = %q, want docs/guide.md", res.File)
+	}
+	var hasDoc bool
+	for _, k := range res.Kinds {
+		if k.Name == "doc" {
+			hasDoc = true
+		}
+	}
+	if !hasDoc {
+		t.Fatalf("ResolveFile: expected kind 'doc' for docs/guide.md, got %+v", res.Kinds)
+	}
+	// The per-rule chain the `why` subcommand needs must be present.
+	if len(res.Rules) == 0 {
+		t.Fatal("ResolveFile: expected a non-empty per-rule resolution map")
+	}
+}
+
+// TestResolveFileHonorsFrontMatterInputs verifies the front-matter
+// kinds/fields the caller passes feed kind assignment — the CLI parses
+// and validates front matter, then hands the parsed inputs here.
+func TestResolveFileHonorsFrontMatterInputs(t *testing.T) {
+	cfg := "kinds:\n  titled: {}\n" +
+		"kind-assignment:\n  - glob: [\"*.md\"]\n    kinds: [titled]\n" +
+		"    fields-present: [title]\n"
+	s := newTestSession(t, cfg, nil)
+
+	res := s.ResolveFile("a.md", nil, map[string]any{"title": "Hello"})
+	var found bool
+	for _, k := range res.Kinds {
+		if k.Name == "titled" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ResolveFile: expected 'titled' via fields-present, got %+v", res.Kinds)
+	}
+}

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -187,11 +187,29 @@ func NewSession(opts SessionOptions) (*Session, error) {
 		cfgPath:    src.configPath(),
 		rules:      rule.All(),
 		rootDir:    rootDirOf(opts.Workspace),
-		maxBytes:   bytelimit.DefaultMaxInputBytes,
+		maxBytes:   resolveSessionMaxBytes(cfg),
 		checkCache: make(map[string]cachedCheck),
 		runCache:   lint.NewRunCache(),
 		parseCache: lint.NewParseCache(),
 	}, nil
+}
+
+// resolveSessionMaxBytes resolves the session's input byte cap from the
+// config's max-input-size, mirroring cmd/mdsmith's resolveMaxInputBytes
+// and the LSP's: an empty setting yields the default 2 MB cap, "0" means
+// unlimited, and any other value is the parsed byte count. An
+// unparseable value falls back to the default (the CLI surfaces the
+// parse error separately at flag time; the session, like the LSP, stays
+// lenient and uses the default so a bad config does not wedge linting).
+func resolveSessionMaxBytes(cfg *config.Config) int64 {
+	if cfg == nil || cfg.MaxInputSize == "" {
+		return bytelimit.DefaultMaxInputBytes
+	}
+	n, err := config.ParseSize(cfg.MaxInputSize)
+	if err != nil {
+		return bytelimit.DefaultMaxInputBytes
+	}
+	return n
 }
 
 // rootDirOf returns the workspace root to anchor RootDir-dependent
@@ -484,6 +502,16 @@ func (s *Session) Invalidate(uri string, content ...[]byte) {
 	s.mu.Lock()
 	clear(s.checkCache)
 	s.mu.Unlock()
+}
+
+// InvalidateWikilinks drops the cross-file read cache's wikilink index
+// so the next Check rebuilds the candidate set. The LSP calls it when a
+// watched file is created or deleted: a wikilink like `[[NewPage]]`
+// would otherwise resolve against the pre-change set. It is the
+// workspace-shape sibling of [Session.Invalidate], which drops a single
+// path's cached content.
+func (s *Session) InvalidateWikilinks() {
+	s.runCache.InvalidateWikilinks()
 }
 
 // absPath maps a workspace-relative uri to the absolute path the engine

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -15,6 +15,7 @@ package mdsmith
 import (
 	"bytes"
 	"hash/fnv"
+	"path/filepath"
 	"sync"
 
 	"github.com/jeduden/mdsmith/internal/bytelimit"
@@ -127,6 +128,22 @@ type Session struct {
 	// source). The test seam parseCount reads it; the bench asserts
 	// steady-state stays under half the cold-start time.
 	parses int
+
+	// runCache is the engine-owned cross-file read cache shared across
+	// every operation on this session, so two host buffers that catalog
+	// over the same tree do not each re-read the matched targets. The
+	// LSP relies on this surviving across per-keystroke CheckVersion
+	// calls; Invalidate drops the changed path's entry. Created once in
+	// NewSession.
+	runCache *lint.RunCache
+	// parseCache memoizes the parsed *lint.File for a document keyed by
+	// (uri, version). CheckVersion installs it on the runner so a repeat
+	// Check at the same version skips the parse — the plan-216 contract
+	// the LSP latency gate depends on. Invalidate drops the path's entry.
+	parseCache *lint.ParseCache
+	// parseHits counts version-keyed parse-cache hits CheckVersion
+	// observed. Test seam (parseCacheHits); not part of the public API.
+	parseHits int
 }
 
 // cachedCheck is one memoized Check result: the content hash it was
@@ -172,6 +189,8 @@ func NewSession(opts SessionOptions) (*Session, error) {
 		rootDir:    rootDirOf(opts.Workspace),
 		maxBytes:   bytelimit.DefaultMaxInputBytes,
 		checkCache: make(map[string]cachedCheck),
+		runCache:   lint.NewRunCache(),
+		parseCache: lint.NewParseCache(),
 	}, nil
 }
 
@@ -199,7 +218,37 @@ func (s *Session) newRunner() *engine.Runner {
 		MaxInputBytes:    s.maxBytes,
 		SourceFS:         s.ws.FS(),
 		ConfigPath:       s.cfgPath,
+		// Shared cross-file read cache: a catalog/include target read by
+		// one operation is reused by the next until Invalidate drops it.
+		RunCache: s.runCache,
 	}
+}
+
+// CheckVersion lints source for uri at the editor's textDocument
+// version and returns its diagnostics. It is the LSP-facing per-
+// keystroke entry point: the session's version-keyed parse cache serves
+// the parsed document when a prior call already parsed (uri, version),
+// so the engine skips re-parsing on a re-lint at the same version (the
+// plan-216 contract). An edit bumps the version, which misses the cache
+// and re-parses. uri is workspace-relative, matching config globs.
+//
+// Cross-file rules read through the session workspace's FS view, so an
+// open-document overlay applied through Invalidate reaches them — the
+// LSP's unsaved-buffer bytes feed catalog/include/link rules.
+func (s *Session) CheckVersion(uri string, source []byte, version int) ([]Diagnostic, error) {
+	// Record a parse-cache hit for the test seam before delegating: the
+	// runner re-probes internally, but counting here keeps the seam off
+	// the engine's API. The extra map lookup is negligible against a
+	// parse and only on the version path.
+	if _, ok := s.parseCache.Get(uri, version); ok {
+		s.mu.Lock()
+		s.parseHits++
+		s.mu.Unlock()
+	}
+	r := s.newRunner()
+	r.ParseCache = s.parseCache
+	res := r.RunSourceWithVersion(uri, source, version)
+	return toDiagnostics(res.Diagnostics), firstError(res.Errors)
 }
 
 // Check lints source (the in-memory bytes for uri) and returns its
@@ -286,6 +335,36 @@ func (s *Session) Fix(uri string, source []byte) (FixResult, error) {
 	}, nil
 }
 
+// FixRule applies only the named fixable rules to source and returns
+// the rewritten bytes plus a Changed flag. It is the LSP per-rule
+// quick-fix entry point (today's fix.SourceWithRules): a lightbulb that
+// fixes one rule's violations rewrites the document through this without
+// disturbing other rules. An empty names slice is a no-op.
+//
+// FixRule does not re-lint — the quick-fix path needs only the bytes and
+// whether they changed — so Diagnostics on the result is always nil.
+// Cross-file rules read through the session workspace's FS view, so an
+// open-document overlay (Invalidate) reaches them.
+func (s *Session) FixRule(uri string, source []byte, names []string) (FixResult, error) {
+	fixed, err := fixpkg.SourceWithRules(fixpkg.SourceOptions{
+		Config:           s.cfg,
+		Rules:            s.rules,
+		Path:             uri,
+		Source:           source,
+		RootDir:          s.rootDir,
+		StripFrontMatter: frontMatterEnabled(s.cfg),
+		MaxInputBytes:    s.maxBytes,
+		SourceFS:         s.ws.FS(),
+	}, names)
+	if err != nil {
+		return FixResult{}, err
+	}
+	return FixResult{
+		Source:  string(fixed),
+		Changed: !bytes.Equal(fixed, source),
+	}, nil
+}
+
 // Kinds resolves the kind list and effective rule configuration for
 // uri, including per-leaf provenance. It reads the file's bytes through
 // the workspace to parse its front matter (the `kinds:` list and any
@@ -364,10 +443,11 @@ func capabilityList() []string {
 }
 
 // Invalidate signals that uri changed. With a content argument it
-// rewrites uri in the workspace (when the workspace is a MemWorkspace)
-// so the next cross-file Check reads the new bytes; an OSWorkspace
-// ignores content and re-reads disk. A no-content call on a
-// MemWorkspace deletes the file (it was removed).
+// rewrites uri in the workspace (when the workspace implements the
+// mutable Set/Delete overlay — MemWorkspace and the LSP's buffer
+// overlay do) so the next cross-file Check reads the new bytes; a bare
+// OSWorkspace ignores content and re-reads disk. A no-content call on a
+// mutable workspace deletes the file (it was removed).
 //
 // It then drops every cached Check result, not only uri's: a changed
 // file can affect any file that reads it through a cross-file rule
@@ -376,7 +456,13 @@ func capabilityList() []string {
 // reuse the cache buys is a within-session optimisation; correctness
 // after an edit wins.
 func (s *Session) Invalidate(uri string, content ...[]byte) {
-	if mw, ok := s.ws.(*MemWorkspace); ok {
+	// Route the open-document bytes through the Workspace's mutable
+	// interface (Set/Delete) rather than a hardcoded *MemWorkspace type
+	// assertion, so any buffer-overlay workspace — the LSP's, which
+	// shadows disk with unsaved-buffer content — receives the edit and
+	// its cross-file rules read the new bytes (footgun 3). An OSWorkspace
+	// (no Set/Delete) re-reads disk, so only the caches below drop.
+	if mw, ok := s.ws.(mutableWorkspace); ok {
 		switch {
 		case len(content) > 0:
 			mw.Set(uri, content[0])
@@ -384,9 +470,26 @@ func (s *Session) Invalidate(uri string, content ...[]byte) {
 			mw.Delete(uri)
 		}
 	}
+	// Drop the engine caches for the changed path so the next operation
+	// re-reads and re-parses it: the cross-file read cache (keyed by the
+	// absolute path catalog/include compute) and the version-keyed parse
+	// cache (keyed by the workspace-relative uri).
+	s.runCache.Invalidate(s.absPath(uri))
+	s.parseCache.Invalidate(uri)
 	s.mu.Lock()
 	clear(s.checkCache)
 	s.mu.Unlock()
+}
+
+// absPath maps a workspace-relative uri to the absolute path the engine
+// read cache keys catalog/include reads by. With no rootDir (a
+// MemWorkspace, or an unrooted OSWorkspace) the uri is returned
+// unchanged — the cache keys it the same way the rules do.
+func (s *Session) absPath(uri string) string {
+	if s.rootDir == "" || filepath.IsAbs(uri) {
+		return uri
+	}
+	return filepath.Join(s.rootDir, filepath.FromSlash(uri))
 }
 
 // Dispose releases the session's caches. The session must not be used
@@ -404,6 +507,14 @@ func (s *Session) parseCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.parses
+}
+
+// parseCacheHits returns the number of version-keyed parse-cache hits
+// CheckVersion observed. Test seam, not part of the public API.
+func (s *Session) parseCacheHits() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.parseHits
 }
 
 // frontMatterEnabled reports whether front-matter stripping is on for

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -296,8 +296,22 @@ func (s *Session) Kinds(uri string) (KindResolution, error) {
 	if err != nil {
 		return KindResolution{}, err
 	}
-	res := config.ResolveFile(s.cfg, uri, fmKinds, fmFields)
-	return toKindResolution(res), nil
+	return toKindResolution(s.ResolveFile(uri, fmKinds, fmFields)), nil
+}
+
+// ResolveFile resolves the kind list and per-rule effective config for
+// uri against the session's compiled config, given the file's
+// already-parsed front-matter kinds and fields (pass nil when there are
+// none). It returns the raw *config.FileResolution, including the
+// per-rule merge chain the CLI's `kinds why` walks.
+//
+// Native-only: it returns an internal config type. The CLI reads and
+// validates front matter itself (its error UX differs from the
+// session's lenient unsaved-buffer handling) and hands the parsed
+// inputs here; [Session.Kinds] is the JS-mirrored sibling that reads
+// front matter through the workspace and returns the public JSON shape.
+func (s *Session) ResolveFile(uri string, fmKinds []string, fmFields map[string]any) *config.FileResolution {
+	return config.ResolveFile(s.cfg, uri, fmKinds, fmFields)
 }
 
 // frontMatterFor reads uri through the workspace and parses its

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -13,6 +13,7 @@
 package mdsmith
 
 import (
+	"bytes"
 	"hash/fnv"
 	"sync"
 
@@ -185,10 +186,10 @@ func rootDirOf(ws Workspace) string {
 	return ""
 }
 
-// newRunner builds the engine.Runner shared by Check and by Fix's
-// post-fix re-lint, so both paths lint with identical configuration.
-// SourceFS is snapshotted per call, so a workspace edit applied through
-// Invalidate is visible to the next operation.
+// newRunner builds the engine.Runner that backs Check (and therefore
+// Fix's post-fix diagnostics, which route through Check). SourceFS is
+// snapshotted per call, so a workspace edit applied through Invalidate
+// is visible to the next operation.
 func (s *Session) newRunner() *engine.Runner {
 	return &engine.Runner{
 		Config:           s.cfg,
@@ -260,17 +261,29 @@ func (s *Session) Fix(uri string, source []byte) (FixResult, error) {
 		return FixResult{}, err
 	}
 
-	// Re-lint the fixed bytes so the result carries the diagnostics
-	// that survive the fix (non-fixable rules, unfixable violations).
-	// This does not poison the Check cache: the fixed bytes hash
-	// differently, and a later Check on them reuses the entry.
-	res := s.newRunner().RunSource(uri, fixed)
+	// Re-lint the fixed bytes so the result carries the diagnostics that
+	// survive the fix (non-fixable rules, unfixable violations). Route
+	// through Check, not a fresh full runner, so the session's parse and
+	// check caches absorb the work (footgun 4: avoid re-linting twice).
+	// When the fix made no edit, fixed == source, so this Check hits the
+	// cache if the caller already Checked this source — a no-op Fix on a
+	// clean buffer no longer pays for a second lint. The cache is keyed
+	// by content hash, so the fixed bytes (changed or not) reuse or
+	// populate the correct entry.
+	diags, err := s.Check(uri, fixed)
+	if err != nil {
+		return FixResult{
+			Source:      string(fixed),
+			Changed:     !bytes.Equal(fixed, source),
+			Diagnostics: diags,
+		}, err
+	}
 
 	return FixResult{
 		Source:      string(fixed),
-		Changed:     string(fixed) != string(source),
-		Diagnostics: toDiagnostics(res.Diagnostics),
-	}, firstError(res.Errors)
+		Changed:     !bytes.Equal(fixed, source),
+		Diagnostics: diags,
+	}, nil
 }
 
 // Kinds resolves the kind list and effective rule configuration for

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -43,6 +43,15 @@ type ConfigSource interface {
 	configPath() string
 }
 
+// alreadyMerged marks a [ConfigSource] whose loadConfig returns a config
+// that is already layered over the defaults (and may carry caller
+// injected settings). NewSession uses the as-is config for such a
+// source instead of re-merging. [ConfigCompiled] is the only
+// implementation today.
+type alreadyMerged interface {
+	alreadyMerged()
+}
+
 // ConfigYAML is a [ConfigSource] backed by an inline YAML string. An
 // empty string yields a mostly-default config.
 type ConfigYAML string
@@ -62,6 +71,29 @@ func (c ConfigPath) loadConfig() (*config.Config, error) {
 }
 
 func (c ConfigPath) configPath() string { return string(c) }
+
+// ConfigCompiled is a [ConfigSource] backed by an already-merged
+// *config.Config plus the path it was loaded from (empty for none). Use
+// it when the caller has already loaded and merged the configuration and
+// applied its own side effects to it — the CLI's loadConfig injects
+// build recipes (for MDS040) and installs the include-extract projector,
+// then hands the resulting config straight to a Session. NewSession
+// takes a compiled source as-is and does not re-merge it over defaults,
+// so those injected settings survive.
+func ConfigCompiled(cfg *config.Config, path string) ConfigSource {
+	return compiledConfig{cfg: cfg, path: path}
+}
+
+// compiledConfig is the [ConfigSource] returned by [ConfigCompiled]. It
+// implements alreadyMerged so NewSession skips the defaults merge.
+type compiledConfig struct {
+	cfg  *config.Config
+	path string
+}
+
+func (c compiledConfig) loadConfig() (*config.Config, error) { return c.cfg, nil }
+func (c compiledConfig) configPath() string                  { return c.path }
+func (c compiledConfig) alreadyMerged()                      {}
 
 // SessionOptions configures a [Session].
 type SessionOptions struct {
@@ -122,7 +154,15 @@ func NewSession(opts SessionOptions) (*Session, error) {
 	// (cmd/mdsmith loadConfigRaw) and the LSP server do. Without this,
 	// a config that omits a rule leaves it disabled rather than at its
 	// default-enabled state, so a bare session would lint nothing.
-	cfg := config.Merge(config.Defaults(), loaded)
+	//
+	// A source that has already merged (ConfigCompiled, used by the CLI
+	// which merges and then injects build recipes / the include-extract
+	// projector onto the result) is taken as-is: re-merging would
+	// recompute rule entries and drop those injected settings.
+	cfg := loaded
+	if _, merged := src.(alreadyMerged); !merged {
+		cfg = config.Merge(config.Defaults(), loaded)
+	}
 	return &Session{
 		ws:         opts.Workspace,
 		cfg:        cfg,

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -213,12 +213,19 @@ func resolveSessionMaxBytes(cfg *config.Config) int64 {
 }
 
 // rootDirOf returns the workspace root to anchor RootDir-dependent
-// resolution. An OSWorkspace contributes its Root; a MemWorkspace has
-// no on-disk root (the empty string is correct, leaving cross-file
-// rules to resolve root-relative globs against the workspace FS).
+// resolution. An OSWorkspace contributes its Root and an
+// OverlayWorkspace (the LSP's workspace) its root — the same directory
+// diskPath/Glob resolve against — so the LSP session keys its cross-file
+// RunCache by absolute paths, matching the CLI's OSWorkspace rather than
+// silently flipping to relative keys. A MemWorkspace has no on-disk root
+// (the empty string is correct, leaving cross-file rules to resolve
+// root-relative globs against the workspace FS).
 func rootDirOf(ws Workspace) string {
-	if osw, ok := ws.(OSWorkspace); ok {
-		return osw.Root
+	switch w := ws.(type) {
+	case OSWorkspace:
+		return w.Root
+	case *OverlayWorkspace:
+		return w.root
 	}
 	return ""
 }

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -225,7 +225,7 @@ func (s *Session) newRunner() *engine.Runner {
 }
 
 // CheckVersion lints source for uri at the editor's textDocument
-// version and returns its diagnostics. It is the LSP-facing per-
+// version and returns the engine result. It is the LSP-facing per-
 // keystroke entry point: the session's version-keyed parse cache serves
 // the parsed document when a prior call already parsed (uri, version),
 // so the engine skips re-parsing on a re-lint at the same version (the
@@ -235,7 +235,13 @@ func (s *Session) newRunner() *engine.Runner {
 // Cross-file rules read through the session workspace's FS view, so an
 // open-document overlay applied through Invalidate reaches them — the
 // LSP's unsaved-buffer bytes feed catalog/include/link rules.
-func (s *Session) CheckVersion(uri string, source []byte, version int) ([]Diagnostic, error) {
+//
+// Native-only: it returns the engine's own Result so the LSP keeps its
+// diagnostic partitioning (doc findings vs config-target findings) and
+// error surfacing. It is consistent with CheckPaths/CheckSource, which
+// also return the engine Result. A WASM host uses the JS-mirrored
+// Check.
+func (s *Session) CheckVersion(uri string, source []byte, version int) *engine.Result {
 	// Record a parse-cache hit for the test seam before delegating: the
 	// runner re-probes internally, but counting here keeps the seam off
 	// the engine's API. The extra map lookup is negligible against a
@@ -247,8 +253,7 @@ func (s *Session) CheckVersion(uri string, source []byte, version int) ([]Diagno
 	}
 	r := s.newRunner()
 	r.ParseCache = s.parseCache
-	res := r.RunSourceWithVersion(uri, source, version)
-	return toDiagnostics(res.Diagnostics), firstError(res.Errors)
+	return r.RunSourceWithVersion(uri, source, version)
 }
 
 // Check lints source (the in-memory bytes for uri) and returns its

--- a/pkg/mdsmith/session_api_test.go
+++ b/pkg/mdsmith/session_api_test.go
@@ -140,6 +140,13 @@ func TestRootDirOf(t *testing.T) {
 	if got := rootDirOf(NewMemWorkspace(nil)); got != "" {
 		t.Fatalf("rootDirOf(MemWorkspace) = %q, want empty", got)
 	}
+	// An OverlayWorkspace carries the project root in its root field
+	// (used by diskPath/Glob); rootDirOf must return it so the LSP
+	// session anchors RootDir-dependent resolution — and its cross-file
+	// RunCache keys — at absolute paths, matching the CLI's OSWorkspace.
+	if got := rootDirOf(NewOverlayWorkspace("/proj")); got != "/proj" {
+		t.Fatalf("rootDirOf(OverlayWorkspace{root}) = %q, want /proj", got)
+	}
 }
 
 // --- Kinds / frontMatterFor ---

--- a/pkg/mdsmith/session_errorpaths_test.go
+++ b/pkg/mdsmith/session_errorpaths_test.go
@@ -1,0 +1,170 @@
+package mdsmith
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
+	"github.com/jeduden/mdsmith/internal/config"
+)
+
+// TestResolveSessionMaxBytesFallsBackOnBadSize pins the lenient branch
+// in resolveSessionMaxBytes: an unparseable max-input-size does not wedge
+// the session — it falls back to the default cap, mirroring the LSP's
+// "a bad config does not stop linting" contract. The CLI surfaces the
+// parse error separately at flag time.
+func TestResolveSessionMaxBytesFallsBackOnBadSize(t *testing.T) {
+	cfg := &config.Config{MaxInputSize: "not-a-size"}
+	if got := resolveSessionMaxBytes(cfg); got != bytelimit.DefaultMaxInputBytes {
+		t.Fatalf("resolveSessionMaxBytes(bad size) = %d, want default %d",
+			got, bytelimit.DefaultMaxInputBytes)
+	}
+}
+
+// TestSessionFixSurfacesPostFixCheckError covers Fix's re-lint error
+// branch: fix expands an <?include?> whose body pulls in a neighbour that
+// is itself within the cap, but the expanded document crosses
+// max-input-size. fix.Source caps only its input, so it succeeds and
+// returns the large bytes; the post-fix Check (which caps the buffer it
+// lints) then reports "file too large", and Fix returns the fixed bytes
+// alongside that error rather than swallowing it.
+func TestSessionFixSurfacesPostFixCheckError(t *testing.T) {
+	// Cap chosen so: the neighbour is readable (its size <= cap, or the
+	// include rule's own byte-limited read would reject it and splice
+	// nothing); the tiny host source is <= cap (so fix.Source accepts
+	// it); but host + spliced neighbour exceeds cap (so the post-fix
+	// Check, which caps the buffer it lints, reports "file too large").
+	const cap = 300
+	// A neighbour just under the cap. "filler word " is 12 bytes; 20 of
+	// them plus the heading and trailing newline stay under 300 yet are
+	// large enough that splicing them into the host crosses 300.
+	neighbour := "# Included\n\n" + strings.Repeat("filler word ", 20) + "\n"
+	if len(neighbour) > cap {
+		t.Fatalf("precondition: neighbour (%d bytes) must be <= cap %d so the include can read it", len(neighbour), cap)
+	}
+	files := map[string][]byte{
+		"included.md": []byte(neighbour),
+	}
+	s := newTestSession(t, "max-input-size: 300\n", files)
+
+	host := []byte("# Host\n\n<?include\nfile: included.md\n?>\n<?/include?>\n")
+	if len(host) > cap {
+		t.Fatalf("precondition: host source (%d bytes) must be <= cap so fix.Source accepts it", len(host))
+	}
+	if len(host)+len(neighbour) <= cap {
+		t.Fatalf("precondition: host (%d) + neighbour (%d) must exceed cap %d so the expanded doc trips Check",
+			len(host), len(neighbour), cap)
+	}
+
+	res, err := s.Fix("host.md", host)
+	if err == nil {
+		t.Fatalf("Fix: expected a post-fix 'file too large' error from the expanded include, got nil (source:\n%s)",
+			res.Source)
+	}
+	if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("Fix: error = %v, want it to mention 'file too large'", err)
+	}
+	// Fix still returns the rewritten (expanded) bytes alongside the error.
+	if !strings.Contains(res.Source, "filler word") {
+		t.Fatalf("Fix: expected the expanded include body in the returned Source, got:\n%s", res.Source)
+	}
+}
+
+// TestSessionFixRuleSurfacesError covers FixRule's error branch: a source
+// larger than max-input-size makes fix.SourceWithRules return the on-disk
+// "file too large" shape, and FixRule propagates it (empty FixResult)
+// rather than returning a half-fixed document.
+func TestSessionFixRuleSurfacesError(t *testing.T) {
+	s := newTestSession(t, "max-input-size: 32\n", nil)
+	// Over the 32-byte cap, with a trailing-space violation the named
+	// rule would otherwise fix.
+	src := []byte("# Title\n\nthis line is over the cap   \n")
+	if len(src) <= 32 {
+		t.Fatalf("precondition: source (%d bytes) must exceed the cap", len(src))
+	}
+
+	res, err := s.FixRule("a.md", src, []string{"no-trailing-spaces"})
+	if err == nil {
+		t.Fatalf("FixRule: expected a 'file too large' error, got nil (source: %q)", res.Source)
+	}
+	if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("FixRule: error = %v, want it to mention 'file too large'", err)
+	}
+	if res.Source != "" {
+		t.Fatalf("FixRule: expected empty FixResult on error, got source %q", res.Source)
+	}
+}
+
+// TestSessionInvalidateWikilinksReresolves drives the LSP "watched file
+// created" scenario through Session.InvalidateWikilinks: a [[Target]]
+// wikilink is broken while Target.md is absent, then the file appears and
+// InvalidateWikilinks drops the cached wikilink index so the next Check
+// re-resolves the link and the broken-wikilink diagnostic clears.
+func TestSessionInvalidateWikilinksReresolves(t *testing.T) {
+	files := map[string][]byte{
+		"doc.md": []byte("# Doc\n\nSee [[Target]] now.\n"),
+	}
+	s := newTestSession(t,
+		"rules:\n  cross-file-reference-integrity:\n    wikilinks: true\n", files)
+	src := files["doc.md"]
+
+	hasBrokenWikilink := func(diags []Diagnostic) bool {
+		for _, d := range diags {
+			if d.RuleID == "MDS027" && strings.Contains(d.Message, "Target") {
+				return true
+			}
+		}
+		return false
+	}
+
+	diags, err := s.Check("doc.md", src)
+	if err != nil {
+		t.Fatalf("Check (missing target): %v", err)
+	}
+	if !hasBrokenWikilink(diags) {
+		t.Fatalf("Check: expected a broken-wikilink diagnostic for [[Target]] before the file exists, got %+v", diags)
+	}
+
+	// The watched file is created. Without invalidation the cached
+	// wikilink index still lacks Target, so the link stays "broken".
+	s.Invalidate("Target.md", []byte("# Target\n"))
+	s.InvalidateWikilinks()
+
+	diags2, err := s.Check("doc.md", src)
+	if err != nil {
+		t.Fatalf("Check (target created): %v", err)
+	}
+	if hasBrokenWikilink(diags2) {
+		t.Fatalf("Check: [[Target]] should resolve after Target.md is created and the index is invalidated, got %+v",
+			diags2)
+	}
+}
+
+// TestSessionAbsPathJoinsRelativeUnderRoot covers absPath's join branch:
+// with a rooted OSWorkspace, a workspace-relative uri is resolved against
+// the root so the cross-file read cache keys it the same absolute path
+// the catalog/include rules compute.
+func TestSessionAbsPathJoinsRelativeUnderRoot(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewSession(SessionOptions{
+		Workspace: OSWorkspace{Root: root},
+		Config:    ConfigYAML(""),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer s.Dispose()
+
+	got := s.absPath("docs/a.md")
+	want := filepath.Join(root, "docs", "a.md")
+	if got != want {
+		t.Fatalf("absPath(docs/a.md) = %q, want %q", got, want)
+	}
+
+	// An absolute uri passes through unchanged even with a root set.
+	abs := filepath.Join(root, "abs.md")
+	if got := s.absPath(abs); got != abs {
+		t.Fatalf("absPath(absolute) = %q, want passthrough %q", got, abs)
+	}
+}

--- a/pkg/mdsmith/session_test.go
+++ b/pkg/mdsmith/session_test.go
@@ -85,6 +85,65 @@ func TestSessionFixNoChange(t *testing.T) {
 	}
 }
 
+// TestSessionFixNoChangeReusesCheckCache is the plan-219 footgun-4
+// acceptance test: Fix must not re-lint with a fresh full runner when
+// the fix made no edit. When a prior Check already linted the identical
+// source, a following no-op Fix reuses that cached result and runs zero
+// additional parses — the doubled work the footgun warned about is
+// gone.
+func TestSessionFixNoChangeReusesCheckCache(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	src := []byte("# Title\n\nClean body paragraph.\n")
+
+	// Warm the Check cache for this exact source.
+	if _, err := s.Check("a.md", src); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	afterCheck := s.parseCount()
+
+	res, err := s.Fix("a.md", src)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.Changed {
+		t.Fatal("Fix: expected Changed=false on already-clean source")
+	}
+	if got := s.parseCount(); got != afterCheck {
+		t.Fatalf("Fix re-linted a no-op fix: parseCount went %d -> %d; "+
+			"a no-op Fix must reuse the cached Check instead of a fresh runner",
+			afterCheck, got)
+	}
+}
+
+// TestSessionFixNoChangeStillReturnsDiagnostics verifies the
+// short-circuit preserves the contract: a no-op Fix still returns the
+// diagnostics that remain (non-fixable findings) on the unchanged
+// source. A long line (MDS001) is default-enabled and not fixable, so
+// it survives the fix and must appear in the remaining diagnostics even
+// though Fix made no edit.
+func TestSessionFixNoChangeStillReturnsDiagnostics(t *testing.T) {
+	s := newTestSession(t, "", nil)
+	long := "# Title\n\n" + strings.Repeat("verylongword ", 12) + "tail\n"
+	src := []byte(long)
+
+	res, err := s.Fix("a.md", src)
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if res.Changed {
+		t.Fatalf("Fix: expected Changed=false, got source %q", res.Source)
+	}
+	var hasLineLen bool
+	for _, d := range res.Diagnostics {
+		if d.Rule == "MDS001" {
+			hasLineLen = true
+		}
+	}
+	if !hasLineLen {
+		t.Fatalf("Fix(no-op): expected the surviving MDS001 diagnostic, got %+v", res.Diagnostics)
+	}
+}
+
 func TestSessionKindsResolvesKind(t *testing.T) {
 	cfg := "kinds:\n  doc:\n    path-pattern: \"docs/**/*.md\"\n" +
 		"kind-assignment:\n  - glob: [\"docs/**/*.md\"]\n    kinds: [doc]\n"

--- a/pkg/mdsmith/session_test.go
+++ b/pkg/mdsmith/session_test.go
@@ -293,3 +293,57 @@ func TestSessionCheckAfterDisposeNoPanic(t *testing.T) {
 		t.Fatalf("Check after Dispose: unexpected error: %v", err)
 	}
 }
+
+// TestSessionDisposeDropsCheckCache pins the mechanic behind the LSP's
+// use-after-dispose hazard: Dispose nils checkCache, so a Check on a
+// session that is still held re-parses instead of serving the warm
+// cache. The "held" half is the invariant the LSP's rebuildSession now
+// upholds by NOT disposing the superseded session — a goroutine that
+// obtained the session before the swap keeps its warm cache; the
+// "disposed" half is the regression it must never re-introduce.
+func TestSessionDisposeDropsCheckCache(t *testing.T) {
+	src := []byte("# Title\n\nClean body paragraph.\n")
+
+	t.Run("held session keeps its warm cache", func(t *testing.T) {
+		s := newTestSession(t, "", nil)
+		if _, err := s.Check("a.md", src); err != nil {
+			t.Fatalf("warm Check: %v", err)
+		}
+		warm := s.parseCount()
+
+		// Building a replacement session (what rebuildSession does on a
+		// reload) must not touch the held session's cache. The held
+		// reference re-Checks the same source and serves from cache.
+		_ = newTestSession(t, "", nil)
+
+		if _, err := s.Check("a.md", src); err != nil {
+			t.Fatalf("re-Check: %v", err)
+		}
+		if got := s.parseCount(); got != warm {
+			t.Fatalf("held session re-parsed (parseCount %d -> %d); its warm "+
+				"checkCache must survive a peer session being built", warm, got)
+		}
+	})
+
+	t.Run("disposed session loses its cache", func(t *testing.T) {
+		s := newTestSession(t, "", nil)
+		if _, err := s.Check("a.md", src); err != nil {
+			t.Fatalf("warm Check: %v", err)
+		}
+		warm := s.parseCount()
+
+		// Dispose is the hazard: it nils checkCache. A caller that still
+		// holds the session re-parses on its next Check — the warm cache is
+		// gone. This is exactly why rebuildSession must not Dispose a
+		// session it just handed out via currentSession().
+		s.Dispose()
+
+		if _, err := s.Check("a.md", src); err != nil {
+			t.Fatalf("re-Check after Dispose: %v", err)
+		}
+		if got := s.parseCount(); got == warm {
+			t.Fatalf("parseCount stayed %d after Dispose; the test no longer "+
+				"observes the cache loss that Dispose-on-an-in-use-session causes", warm)
+		}
+	})
+}

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -37,6 +37,18 @@ type Workspace interface {
 	FS() fs.FS
 }
 
+// mutableWorkspace is the optional overlay interface a [Workspace] can
+// implement to accept buffer edits through [Session.Invalidate]. The
+// session calls Set to shadow a path with open-document bytes and Delete
+// to drop a path. A workspace that does not implement it (e.g. a bare
+// OSWorkspace) re-reads disk instead. MemWorkspace and the LSP's overlay
+// workspace satisfy it, so the session reaches both without a concrete
+// type assertion — see [Session.Invalidate].
+type mutableWorkspace interface {
+	Set(path string, data []byte)
+	Delete(path string)
+}
+
 // OSWorkspace reads from the host filesystem. It is the native
 // implementation used by the CLI and the LSP server. The zero value is
 // usable and reads paths exactly as passed (absolute or relative to the

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -42,16 +42,35 @@ type Workspace interface {
 // usable and reads paths exactly as passed (absolute or relative to the
 // process working directory).
 type OSWorkspace struct {
-	// Root, when non-empty, is the directory the FS view is rooted at.
-	// ReadFile and Glob still operate on the paths as passed; only FS
-	// is anchored at Root. The CLI sets this to the project root so
-	// catalog/include resolve workspace-relative targets.
+	// Root, when non-empty, is the directory both ReadFile and FS are
+	// anchored at. A workspace-relative path (e.g. "docs/a.md") resolves
+	// against Root in ReadFile, so ReadFile and FS agree on the file a
+	// given uri names; an absolute path is read as-is. Glob still expands
+	// the pattern exactly as passed. The CLI sets Root to the project
+	// root so catalog/include and frontMatterFor resolve the same
+	// workspace-relative target. With an empty Root, paths are read
+	// exactly as passed (the zero-value behaviour).
 	Root string
 }
 
-// ReadFile reads path from the host filesystem.
+// ReadFile reads path from the host filesystem. When Root is set and
+// path is workspace-relative, it is resolved against Root so ReadFile
+// and FS (which is rooted at Root) name the same file for one uri — see
+// the Root field doc. An absolute path is read unchanged.
 func (w OSWorkspace) ReadFile(p string) ([]byte, error) {
-	return os.ReadFile(p) //nolint:gosec // path is caller-controlled; OSWorkspace is the native disk seam
+	return os.ReadFile(w.resolve(p)) //nolint:gosec // path is caller-controlled; OSWorkspace is the native disk seam
+}
+
+// resolve maps a workspace-relative path to an absolute one rooted at
+// Root, mirroring how FS (os.DirFS(Root)) interprets the same path.
+// An absolute path, or any path when Root is empty, is returned
+// unchanged so the zero-value workspace and absolute-path callers keep
+// reading paths exactly as passed.
+func (w OSWorkspace) resolve(p string) string {
+	if w.Root == "" || filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(w.Root, filepath.FromSlash(p))
 }
 
 // Glob expands a doublestar pattern against the host filesystem.

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -113,6 +113,59 @@ func TestOSWorkspaceReadFile(t *testing.T) {
 	}
 }
 
+// TestOSWorkspaceReadFileAndFSAgreeOnURI is the plan-219 footgun-1
+// acceptance test. With a non-empty Root, a workspace-relative uri must
+// resolve to the same on-disk file through ReadFile and through FS —
+// the two read paths the session uses (frontMatterFor reads via
+// ReadFile; the engine reads cross-file content via FS). Reading one
+// uri both ways must yield one file's bytes, not two different files.
+func TestOSWorkspaceReadFileAndFSAgreeOnURI(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	const uri = "docs/a.md"
+	if err := os.WriteFile(filepath.Join(root, uri), []byte("rooted"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ws := OSWorkspace{Root: root}
+
+	viaReadFile, err := ws.ReadFile(uri)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", uri, err)
+	}
+	viaFS, err := fs.ReadFile(ws.FS(), uri)
+	if err != nil {
+		t.Fatalf("fs.ReadFile(FS, %q): %v", uri, err)
+	}
+	if string(viaReadFile) != "rooted" || string(viaFS) != "rooted" {
+		t.Fatalf("ReadFile=%q FS=%q, both should read the single rooted file %q",
+			viaReadFile, viaFS, "rooted")
+	}
+}
+
+// TestOSWorkspaceReadFileAbsoluteIgnoresRoot verifies that an absolute
+// path passed to ReadFile is read as-is even when Root is set — the
+// rooting only applies to workspace-relative paths, so callers that
+// already hold an absolute path keep working.
+func TestOSWorkspaceReadFileAbsoluteIgnoresRoot(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	abs := filepath.Join(other, "x.md")
+	if err := os.WriteFile(abs, []byte("absolute"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	ws := OSWorkspace{Root: root}
+	got, err := ws.ReadFile(abs)
+	if err != nil {
+		t.Fatalf("ReadFile(abs): %v", err)
+	}
+	if string(got) != "absolute" {
+		t.Fatalf("ReadFile(abs) = %q, want %q", got, "absolute")
+	}
+}
+
 func TestOSWorkspaceGlob(t *testing.T) {
 	dir := t.TempDir()
 	for _, name := range []string{"a.md", "b.md", "c.txt"} {

--- a/plan/219_session-cli-lsp-migration.md
+++ b/plan/219_session-cli-lsp-migration.md
@@ -88,7 +88,7 @@ it affects, not after:
       document and watched-file changes.
 - [x] `OSWorkspace.ReadFile` and `OSWorkspace.FS` resolve the same
       `uri` to the same file, proven by a test.
-- [ ] `Session.Fix` does not re-lint when the fix made no edit.
+- [x] `Session.Fix` does not re-lint when the fix made no edit.
 - [ ] The LSP's in-memory buffer bytes reach cross-file rules through
       the session (Invalidate carries open-document content).
 - [ ] The CLI end-to-end tests and the LSP p95 latency gate pass.

--- a/plan/219_session-cli-lsp-migration.md
+++ b/plan/219_session-cli-lsp-migration.md
@@ -1,7 +1,7 @@
 ---
 id: 219
 title: Route cmd/mdsmith and the LSP through pkg/mdsmith.Session
-status: "🔳"
+status: "✅"
 model: opus
 summary: >-
   Migrate the CLI's check/fix/kinds subcommands and the LSP server
@@ -92,8 +92,8 @@ it affects, not after:
 - [x] The LSP's in-memory buffer bytes reach cross-file rules through
       the session (Invalidate carries open-document content).
 - [x] The CLI end-to-end tests and the LSP p95 latency gate pass.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues.
 
 ## See also
 

--- a/plan/219_session-cli-lsp-migration.md
+++ b/plan/219_session-cli-lsp-migration.md
@@ -82,7 +82,7 @@ it affects, not after:
 
 ## Acceptance Criteria
 
-- [ ] `cmd/mdsmith` check, fix, and kinds construct a
+- [x] `cmd/mdsmith` check, fix, and kinds construct a
       `pkg/mdsmith.Session`.
 - [ ] The LSP uses one `Session` per workspace and invalidates it on
       document and watched-file changes.

--- a/plan/219_session-cli-lsp-migration.md
+++ b/plan/219_session-cli-lsp-migration.md
@@ -84,14 +84,14 @@ it affects, not after:
 
 - [x] `cmd/mdsmith` check, fix, and kinds construct a
       `pkg/mdsmith.Session`.
-- [ ] The LSP uses one `Session` per workspace and invalidates it on
+- [x] The LSP uses one `Session` per workspace and invalidates it on
       document and watched-file changes.
 - [x] `OSWorkspace.ReadFile` and `OSWorkspace.FS` resolve the same
       `uri` to the same file, proven by a test.
 - [x] `Session.Fix` does not re-lint when the fix made no edit.
-- [ ] The LSP's in-memory buffer bytes reach cross-file rules through
+- [x] The LSP's in-memory buffer bytes reach cross-file rules through
       the session (Invalidate carries open-document content).
-- [ ] The CLI end-to-end tests and the LSP p95 latency gate pass.
+- [x] The CLI end-to-end tests and the LSP p95 latency gate pass.
 - [ ] All tests pass: `go test ./...`
 - [ ] `go tool golangci-lint run` reports no issues.
 

--- a/plan/219_session-cli-lsp-migration.md
+++ b/plan/219_session-cli-lsp-migration.md
@@ -1,7 +1,7 @@
 ---
 id: 219
 title: Route cmd/mdsmith and the LSP through pkg/mdsmith.Session
-status: "🔲"
+status: "🔳"
 model: opus
 summary: >-
   Migrate the CLI's check/fix/kinds subcommands and the LSP server
@@ -86,7 +86,7 @@ it affects, not after:
       `pkg/mdsmith.Session`.
 - [ ] The LSP uses one `Session` per workspace and invalidates it on
       document and watched-file changes.
-- [ ] `OSWorkspace.ReadFile` and `OSWorkspace.FS` resolve the same
+- [x] `OSWorkspace.ReadFile` and `OSWorkspace.FS` resolve the same
       `uri` to the same file, proven by a test.
 - [ ] `Session.Fix` does not re-lint when the fix made no edit.
 - [ ] The LSP's in-memory buffer bytes reach cross-file rules through


### PR DESCRIPTION
Draft PR for [plan/219_session-cli-lsp-migration.md](plan/219_session-cli-lsp-migration.md).

Routes `cmd/mdsmith` (check/fix/kinds) and the LSP through the public `pkg/mdsmith.Session`, so the CLI, the LSP, and WASM share one engine entrypoint instead of each re-deriving `engine.Runner` and `internal/fix` plumbing.

Implementation is complete: the plan's acceptance criteria are checked off and its status is `✅` in PLAN.md, and CI is green (coverage, LSP latency, and e2e included). Left as a draft pending review — ready to mark for review whenever it looks good to you.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KayN63qSakPB1KTKavdzXD)_