### PR TITLE
docs: add Obsidian release-channel page

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,7 +57,7 @@ row: "- [{summary}](../{filename})"
 - [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](../docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](../docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](../docs/development/release-channels/npx.md)
-- [A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](../docs/development/release-channels/obsidian.md)
+- [A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](../docs/development/release-channels/obsidian.md)
 - [The same `.vsix` republished to Open VSX so VSCodium, Cursor, Theia, and Gitpod can install it.](../docs/development/release-channels/open-vsx.md)
 - [`pipx install mdsmith` puts the PyPI wheel's `mdsmith` console script on PATH inside its own isolated virtualenv.](../docs/development/release-channels/pipx.md)
 - [One platform-tagged wheel per supported host, published via OIDC Trusted Publishing.](../docs/development/release-channels/pypi.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,7 @@ row: "- [{summary}](../{filename})"
 - [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](../docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](../docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](../docs/development/release-channels/npx.md)
+- [A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](../docs/development/release-channels/obsidian.md)
 - [The same `.vsix` republished to Open VSX so VSCodium, Cursor, Theia, and Gitpod can install it.](../docs/development/release-channels/open-vsx.md)
 - [`pipx install mdsmith` puts the PyPI wheel's `mdsmith` console script on PATH inside its own isolated virtualenv.](../docs/development/release-channels/pipx.md)
 - [One platform-tagged wheel per supported host, published via OIDC Trusted Publishing.](../docs/development/release-channels/pypi.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ row: "- [{summary}]({filename})"
 - [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](docs/development/release-channels/npx.md)
-- [A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)
+- [A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)
 - [The same `.vsix` republished to Open VSX so VSCodium, Cursor, Theia, and Gitpod can install it.](docs/development/release-channels/open-vsx.md)
 - [`pipx install mdsmith` puts the PyPI wheel's `mdsmith` console script on PATH inside its own isolated virtualenv.](docs/development/release-channels/pipx.md)
 - [One platform-tagged wheel per supported host, published via OIDC Trusted Publishing.](docs/development/release-channels/pypi.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ row: "- [{summary}]({filename})"
 - [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](docs/development/release-channels/npx.md)
+- [A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)
 - [The same `.vsix` republished to Open VSX so VSCodium, Cursor, Theia, and Gitpod can install it.](docs/development/release-channels/open-vsx.md)
 - [`pipx install mdsmith` puts the PyPI wheel's `mdsmith` console script on PATH inside its own isolated virtualenv.](docs/development/release-channels/pipx.md)
 - [One platform-tagged wheel per supported host, published via OIDC Trusted Publishing.](docs/development/release-channels/pypi.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ row: "- [{summary}]({filename})"
 - [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](docs/development/release-channels/npx.md)
-- [A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)
+- [A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)
 - [The same `.vsix` republished to Open VSX so VSCodium, Cursor, Theia, and Gitpod can install it.](docs/development/release-channels/open-vsx.md)
 - [`pipx install mdsmith` puts the PyPI wheel's `mdsmith` console script on PATH inside its own isolated virtualenv.](docs/development/release-channels/pipx.md)
 - [One platform-tagged wheel per supported host, published via OIDC Trusted Publishing.](docs/development/release-channels/pypi.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ row: "- [{summary}]({filename})"
 - [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](docs/development/release-channels/npx.md)
+- [A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)
 - [The same `.vsix` republished to Open VSX so VSCodium, Cursor, Theia, and Gitpod can install it.](docs/development/release-channels/open-vsx.md)
 - [`pipx install mdsmith` puts the PyPI wheel's `mdsmith` console script on PATH inside its own isolated virtualenv.](docs/development/release-channels/pipx.md)
 - [One platform-tagged wheel per supported host, published via OIDC Trusted Publishing.](docs/development/release-channels/pypi.md)

--- a/docs/development/release-channels/obsidian.md
+++ b/docs/development/release-channels/obsidian.md
@@ -1,9 +1,9 @@
 ---
 title: Obsidian
 summary: >-
-  A `mdsmith-obsidian-<version>.zip` of the WebAssembly
-  engine plus the plugin's five load files, attached to
-  each GitHub release and installed by unzipping into a
+  A `mdsmith-obsidian-<version>.zip` of the plugin's five
+  load files — the WebAssembly engine among them — attached
+  to each GitHub release and installed by unzipping into a
   vault's `.obsidian/plugins/mdsmith/` folder.
 mechanism: push
 artifact: obsidian-plugin
@@ -67,6 +67,7 @@ the raw binaries.
 
 Auth: none of its own. The zip rides the `release` job's
 `GITHUB_TOKEN` upload and OIDC signing — the same path the
-other release artifacts take. There is no publisher token to
-rotate and no `release` environment gate, because the only
-channel is the GitHub release itself.
+other release artifacts take. The `obsidian` job needs no
+publisher token to rotate and no `release` environment gate
+of its own; the `release` job that attaches and signs the
+zip stays gated as usual.

--- a/docs/development/release-channels/obsidian.md
+++ b/docs/development/release-channels/obsidian.md
@@ -1,0 +1,72 @@
+---
+title: Obsidian
+summary: >-
+  A `mdsmith-obsidian-<version>.zip` of the WebAssembly
+  engine plus the plugin's five load files, attached to
+  each GitHub release and installed by unzipping into a
+  vault's `.obsidian/plugins/mdsmith/` folder.
+mechanism: push
+artifact: obsidian-plugin
+command: unzip mdsmith-obsidian-<version>.zip -d <vault>/.obsidian/plugins/mdsmith/
+audience: Obsidian vaults on desktop and mobile
+platforms: [editor]
+registry: github.com/jeduden/mdsmith/releases
+credential: GITHUB_TOKEN + OIDC
+job: obsidian
+channelurl: https://github.com/jeduden/mdsmith/releases
+weight: 14
+---
+# Obsidian
+
+Release page: <https://github.com/jeduden/mdsmith/releases>
+
+The Obsidian channel ships the plugin as a single
+`mdsmith-obsidian-<version>.zip` attached to each GitHub
+release. The zip holds the five files Obsidian loads, flat:
+`main.js`, `manifest.json`, `styles.css`, `mdsmith.wasm`,
+and `wasm_exec.js`. The engine is compiled to WebAssembly.
+So one artifact runs on every platform Obsidian supports.
+There is no per-platform build matrix and no native binary.
+
+The plugin is **not** in the Obsidian community catalog
+(plan 217 Non-Goals). GitHub Releases is its only channel,
+so a user installs it by hand:
+
+1. Download `mdsmith-obsidian-<version>.zip` from the
+   release page.
+2. Create `<vault>/.obsidian/plugins/mdsmith/`.
+3. Unzip the five files into that folder.
+4. In Obsidian, open **Settings → Community plugins** and
+   enable **mdsmith**.
+
+The user-facing
+[mdsmith for Obsidian](../../guides/editors/obsidian.md)
+guide covers the same steps plus the settings and
+troubleshooting.
+
+The `obsidian` job in `release.yml` builds the artifact. It
+does not depend on the `build` matrix — there is one WASM
+artifact, not a per-platform binary. The job stamps the
+release version into the tracked manifests with
+[`stamp`](../release-tooling.md) (the plugin's
+`manifest.json` and `package.json` are in the tracked set),
+compiles the engine with `cmd/mdsmith-wasm/build.sh`, builds
+the plugin with `bun run build.ts --production`, and packs
+`dist/` with [`package-obsidian`](../release-tooling.md).
+That command reads the version from the stamped
+`manifest.json` and writes `mdsmith-obsidian-<version>.zip`
+through Go's `archive/zip`, so the channel needs no `zip`
+binary. The zip stays inside the
+[WASM size budget](../../background/concepts/engine-api.md).
+
+The `release` job attaches that artifact to the draft. The
+zip name matches the `mdsmith-*` glob the release job
+already uses, so `checksums.txt`, the SLSA build-provenance
+attestation, and the cosign signature cover it the same as
+the raw binaries.
+
+Auth: none of its own. The zip rides the `release` job's
+`GITHUB_TOKEN` upload and OIDC signing — the same path the
+other release artifacts take. There is no publisher token to
+rotate and no `release` environment gate, because the only
+channel is the GitHub release itself.

--- a/docs/development/release-channels/proto.md
+++ b/docs/development/release-channels/proto.md
@@ -2,7 +2,7 @@
 title: 'string & != ""'
 summary: 'string & != ""'
 mechanism: '"push" | "pull" | "toolchain"'
-artifact: '"cli" | "vscode-extension" | "claude-plugin"'
+artifact: '"cli" | "vscode-extension" | "claude-plugin" | "obsidian-plugin"'
 command: 'string & != ""'
 audience: 'string & != ""'
 platforms: '[...string] | *[]'

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -34,6 +34,7 @@ row: "| [{title}]({filename}) | <{channelurl}> | {credential} |"
 | [Flatpak](release-channels/flatpak.md)                                     | <https://github.com/jeduden/mdsmith/releases>                         | GITHUB_TOKEN + OIDC     |
 | [GitHub Releases](release-channels/github-releases.md)                     | <https://github.com/jeduden/mdsmith/releases>                         | GITHUB_TOKEN + OIDC     |
 | [npm](release-channels/npm.md)                                             | <https://www.npmjs.com/package/@mdsmith/cli>                          | OIDC Trusted Publishing |
+| [Obsidian](release-channels/obsidian.md)                                   | <https://github.com/jeduden/mdsmith/releases>                         | GITHUB_TOKEN + OIDC     |
 | [Open VSX](release-channels/open-vsx.md)                                   | <https://open-vsx.org/extension/jeduden/mdsmith>                      | OVSX_PAT                |
 | [PyPI](release-channels/pypi.md)                                           | <https://pypi.org/project/mdsmith/>                                   | OIDC Trusted Publishing |
 | [Visual Studio Marketplace](release-channels/visual-studio-marketplace.md) | <https://marketplace.visualstudio.com/items?itemName=jeduden.mdsmith> | VSCE_PAT                |

--- a/website/data/channels.yaml
+++ b/website/data/channels.yaml
@@ -136,7 +136,7 @@
   url: https://github.com/jeduden/mdsmith/releases
   weight: 13
 - title: Obsidian
-  summary: A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.
+  summary: A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.
   mechanism: push
   artifact: obsidian-plugin
   command: unzip mdsmith-obsidian-<version>.zip -d <vault>/.obsidian/plugins/mdsmith/

--- a/website/data/channels.yaml
+++ b/website/data/channels.yaml
@@ -135,3 +135,13 @@
     - linux
   url: https://github.com/jeduden/mdsmith/releases
   weight: 13
+- title: Obsidian
+  summary: A `mdsmith-obsidian-<version>.zip` of the WebAssembly engine plus the plugin's five load files, attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.
+  mechanism: push
+  artifact: obsidian-plugin
+  command: unzip mdsmith-obsidian-<version>.zip -d <vault>/.obsidian/plugins/mdsmith/
+  audience: Obsidian vaults on desktop and mobile
+  platforms:
+    - editor
+  url: https://github.com/jeduden/mdsmith/releases
+  weight: 14


### PR DESCRIPTION
## What

Adds a dedicated `docs/development/release-channels/obsidian.md` page so the Obsidian plugin's release/install path is documented alongside the other channels (npm, PyPI, Flatpak, …). Until now those steps lived only in plan 217 and inline `release.yml` comments.

## Why

The Obsidian plugin (plan 217) was the only shipped artifact without a release-channels page. The catalogs in `release.md`, `CLAUDE.md`, and the install guide cross-reference every other channel; this fills the gap.

## Changes

- **New page** `docs/development/release-channels/obsidian.md` — what ships (`mdsmith-obsidian-<version>.zip` with the five load files + WASM engine), how the `obsidian` job builds it, how the `release` job attaches + signs it (checksums / SLSA / cosign), and the manual download-and-unzip install path. GitHub Releases is the only channel — no community catalog, no publisher token of its own (it rides the release job's `GITHUB_TOKEN`, like Flatpak).
- **Schema** `release-channels/proto.md` — added an `obsidian-plugin` value to the `artifact` enum, since the plugin is neither a CLI, a VS Code extension, nor a Claude plugin.
- Regenerated catalogs: `release.md` (Obsidian now in the credential table), `CLAUDE.md`, and the `CLAUDE.md` includes in `AGENTS.md` / `.github/copilot-instructions.md`.

## Verification

- `mdsmith check .` → 412 files pass (the new page validates against the extended schema; MDS023 readability and all generated catalogs are clean).

https://claude.ai/code/session_013di25PaEvr1CMvA5m86oPX

---
_Generated by [Claude Code](https://claude.ai/code/session_013di25PaEvr1CMvA5m86oPX)_