### PR TITLE
feat(include): numeric target for heading-level (plan 233)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -158,4 +158,5 @@ footer: |
 | 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |
 | 231 | ✅     |        | [LSP newest-wins workspace singleton](plan/231_lsp-workspace-singleton.md)                                                              |
 | 232 | ✅     | opus   | [include heading-offset parameter](plan/232_include-heading-offset.md)                                                                  |
+| 233 | 🔳     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
 <?/catalog?>

--- a/docs/guides/directives/generating-content.md
+++ b/docs/guides/directives/generating-content.md
@@ -245,9 +245,10 @@ key: value
 
 ### Heading-level adjustment
 
-When including under an existing heading, use
-`heading-level: "absolute"` to shift included
-headings so they nest correctly:
+`heading-level` takes `"absolute"` or an integer 1-6.
+
+Use `"absolute"` when including under an existing heading,
+to shift included headings so they nest correctly:
 
 ```markdown
 ## Project
@@ -263,6 +264,21 @@ Steps here.
 
 Without this parameter, included headings keep their
 original level, which may break heading hierarchy.
+
+Use an integer to pin the shallowest included heading to
+that level, whatever the source or parent — handy at the
+document root, where `"absolute"` is a no-op:
+
+```markdown
+<?include
+file: features.md
+heading-level: "2"
+?>
+## Pinned To Level 2
+<?/include?>
+```
+
+`heading-level` is mutually exclusive with `heading-offset`.
 
 ### Heading-offset adjustment
 

--- a/internal/directives/generating-content.md
+++ b/internal/directives/generating-content.md
@@ -50,10 +50,11 @@ heading-level: "absolute"
 ```
 
 `strip-frontmatter` drops the leading YAML block.
-`heading-level: "absolute"` shifts included headings
-so they nest under the include site's parent
-heading; omit it to keep source heading levels
-unchanged. No other value is accepted.
+`heading-level` takes `"absolute"` or an integer 1-6.
+`"absolute"` nests included headings under the include
+site's parent heading; a number pins the shallowest
+heading to that level, which also works at the document
+root. Omit it to keep source heading levels unchanged.
 
 `heading-offset: "N"` shifts every included heading by
 the signed integer N (-6 to 6), so it works even with no

--- a/internal/rules/MDS021-include/README.md
+++ b/internal/rules/MDS021-include/README.md
@@ -48,7 +48,7 @@ for details.
 | `extract`           | no       | --       | Dotted path through the extract projection of a kind-typed `file:`. Splices one leaf value       |
 | `strip-frontmatter` | no       | `"true"` | Remove YAML frontmatter (incompatible with `extract:`)                                           |
 | `wrap`              | no       | --       | Wrap in code fence (value = language)                                                            |
-| `heading-level`     | no       | --       | `"absolute"`: shift headings to nest under parent (incompatible with `extract:`)                 |
+| `heading-level`     | no       | --       | `"absolute"` or 1-6: nest under parent, or pin shallowest heading to that level                  |
 | `heading-offset`    | no       | --       | Signed integer -6 to 6: shift every heading by N (incompatible with `heading-level`, `extract:`) |
 
 ## Link Adjustment
@@ -66,18 +66,23 @@ For example, `DEVELOPMENT.md` contains
 
 ## Heading-Level Adjustment
 
-When `heading-level: "absolute"` is set, included
-headings shift so the top-level heading becomes a
-child of the enclosing section.
+`heading-level` takes `"absolute"` or an integer 1-6.
 
-Example: the marker sits under `## Project` (level 2).
-The included file has `## Build` (level 2) and
-`### Sub` (level 3). The shift is
-`2 - 2 + 1 = 1`. Result: `### Build` (3) and
-`#### Sub` (4). Levels are capped at 6.
+`"absolute"` is parent-relative: included headings shift
+so the shallowest one becomes a child of the enclosing
+section. The marker sits under `## Project` (level 2). The
+included file has `## Build` (2) and `### Sub` (3). The
+shift is `2 - 2 + 1 = 1`: `### Build` (3) and `#### Sub`
+(4). At the document root no shift is applied.
 
-When the marker sits at document root (no preceding
-heading), no shift is applied.
+An integer pins the shallowest included heading to that
+level, whatever the source starts at, so it also works at
+the document root. `heading-level: "2"` renders a source
+`# Title` / `## Sub` as `## Title` / `### Sub`. A deeper
+source is promoted; levels are capped at 1-6.
+
+`heading-level` cannot combine with `heading-offset` or
+`extract:`.
 
 ## Heading-Offset Adjustment
 
@@ -252,26 +257,26 @@ Outdated content
 
 ## Diagnostics
 
-| Condition              | Message                                                                    |
-| ---------------------- | -------------------------------------------------------------------------- |
-| content mismatch       | generated section is out of date                                           |
-| missing file           | include file "x.md" not found                                              |
-| no file param          | include directive missing required "file" parameter                        |
-| absolute path          | include directive has absolute file path                                   |
-| escapes root           | include file path escapes project root                                     |
-| no root for dotdot     | include file path contains ".." but project root is not configured         |
-| invalid heading-level  | include directive "heading-level" must be "absolute"                       |
-| invalid heading-offset | include directive "heading-offset" must be an integer between -6 and 6     |
-| offset + level         | include directive "heading-offset" cannot be combined with "heading-level" |
-| empty extract          | include directive "extract" value is empty                                 |
-| extract + sfm          | include directive "extract" cannot be combined with "strip-frontmatter"    |
-| extract + hl           | include directive "extract" cannot be combined with "heading-level"        |
-| extract + offset       | include directive "extract" cannot be combined with "heading-offset"       |
-| extract miss           | extract: missing key "x" in extract projection                             |
-| extract no kind        | extract: "x.md" has no resolved kind; cannot project a typed value         |
-| extract not conformant | extract: target file does not conform to its schema: ...                   |
-| cyclic include         | cyclic include: a.md -> b.md -> a.md                                       |
-| depth exceeded         | include depth exceeds maximum (10)                                         |
+| Condition              | Message                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| content mismatch       | generated section is out of date                                                   |
+| missing file           | include file "x.md" not found                                                      |
+| no file param          | include directive missing required "file" parameter                                |
+| absolute path          | include directive has absolute file path                                           |
+| escapes root           | include file path escapes project root                                             |
+| no root for dotdot     | include file path contains ".." but project root is not configured                 |
+| invalid heading-level  | include directive "heading-level" must be "absolute" or an integer between 1 and 6 |
+| invalid heading-offset | include directive "heading-offset" must be an integer between -6 and 6             |
+| offset + level         | include directive "heading-offset" cannot be combined with "heading-level"         |
+| empty extract          | include directive "extract" value is empty                                         |
+| extract + sfm          | include directive "extract" cannot be combined with "strip-frontmatter"            |
+| extract + hl           | include directive "extract" cannot be combined with "heading-level"                |
+| extract + offset       | include directive "extract" cannot be combined with "heading-offset"               |
+| extract miss           | extract: missing key "x" in extract projection                                     |
+| extract no kind        | extract: "x.md" has no resolved kind; cannot project a typed value                 |
+| extract not conformant | extract: target file does not conform to its schema: ...                           |
+| cyclic include         | cyclic include: a.md -> b.md -> a.md                                               |
+| depth exceeded         | include depth exceeds maximum (10)                                                 |
 
 ## Pattern
 

--- a/internal/rules/MDS021-include/bad/data/hl-src.md
+++ b/internal/rules/MDS021-include/bad/data/hl-src.md
@@ -1,0 +1,9 @@
+Overview text for the heading-level target fixture.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.

--- a/internal/rules/MDS021-include/bad/heading-level-target.md
+++ b/internal/rules/MDS021-include/bad/heading-level-target.md
@@ -1,0 +1,22 @@
+---
+diagnostics:
+  - line: 3
+    column: 1
+    message: generated section is out of date
+---
+# Numeric Heading Level
+
+<?include
+file: data/hl-src.md
+heading-level: "2"
+?>
+Overview text for the heading-level target fixture.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.
+<?/include?>

--- a/internal/rules/MDS021-include/fixed/data/hl-src.md
+++ b/internal/rules/MDS021-include/fixed/data/hl-src.md
@@ -1,0 +1,9 @@
+Overview text for the heading-level target fixture.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.

--- a/internal/rules/MDS021-include/fixed/heading-level-target.md
+++ b/internal/rules/MDS021-include/fixed/heading-level-target.md
@@ -1,0 +1,16 @@
+# Numeric Heading Level
+
+<?include
+file: data/hl-src.md
+heading-level: "2"
+?>
+Overview text for the heading-level target fixture.
+
+## Primary
+
+Body for the primary section with a few words.
+
+### Secondary
+
+Body for the secondary section with a few words.
+<?/include?>

--- a/internal/rules/MDS021-include/good/data/hl-src.md
+++ b/internal/rules/MDS021-include/good/data/hl-src.md
@@ -1,0 +1,9 @@
+Overview text for the heading-level target fixture.
+
+# Primary
+
+Body for the primary section with a few words.
+
+## Secondary
+
+Body for the secondary section with a few words.

--- a/internal/rules/MDS021-include/good/heading-level-target.md
+++ b/internal/rules/MDS021-include/good/heading-level-target.md
@@ -1,0 +1,16 @@
+# Numeric Heading Level
+
+<?include
+file: data/hl-src.md
+heading-level: "2"
+?>
+Overview text for the heading-level target fixture.
+
+## Primary
+
+Body for the primary section with a few words.
+
+### Secondary
+
+Body for the secondary section with a few words.
+<?/include?>

--- a/internal/rules/include/headings.go
+++ b/internal/rules/include/headings.go
@@ -62,6 +62,25 @@ func adjustHeadingsByOffset(content string, offset int) string {
 	return strings.Join(applyShift(lines, offset), "\n")
 }
 
+// adjustHeadingsToLevel shifts headings so the shallowest one becomes the
+// given target level (1..6), reusing findMinHeadingLevel and applyShift. The
+// shift may be negative (promotion); levels are clamped to 1..6. Content with
+// no heading, or already at the target, is returned unchanged. Unlike
+// adjustHeadings this carries no parent-relative guards: the target is
+// stated outright, so an explicit promotion is allowed.
+func adjustHeadingsToLevel(content string, target int) string {
+	lines := strings.Split(content, "\n")
+	minLevel := findMinHeadingLevel(lines)
+	if minLevel == 0 {
+		return content
+	}
+	shift := target - minLevel
+	if shift == 0 {
+		return content
+	}
+	return strings.Join(applyShift(lines, shift), "\n")
+}
+
 // findMinHeadingLevel scans lines and returns the minimum heading level found,
 // ignoring lines inside fenced code blocks. Returns 0 if no headings are found.
 func findMinHeadingLevel(lines []string) int {

--- a/internal/rules/include/headings_test.go
+++ b/internal/rules/include/headings_test.go
@@ -225,6 +225,60 @@ func TestAdjustHeadingsByOffset_SetextAndFences(t *testing.T) {
 	}
 }
 
+func TestAdjustHeadingsToLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		target  int
+		want    string
+	}{
+		{
+			name:    "pin source h1 to level 2",
+			content: "# One\n\n## Two\n",
+			target:  2,
+			want:    "## One\n\n### Two\n",
+		},
+		{
+			name:    "pin deeper source up to level 1 (promote)",
+			content: "### Deep\n\n#### Deeper\n",
+			target:  1,
+			want:    "# Deep\n\n## Deeper\n",
+		},
+		{
+			name:    "target equals min is a no-op",
+			content: "## Two\n\n### Three\n",
+			target:  2,
+			want:    "## Two\n\n### Three\n",
+		},
+		{
+			name:    "clamp at level 6",
+			content: "## A\n\n##### B\n",
+			target:  6,
+			want:    "###### A\n\n###### B\n",
+		},
+		{
+			name:    "no headings returns unchanged",
+			content: "Just text.\n\nMore.\n",
+			target:  2,
+			want:    "Just text.\n\nMore.\n",
+		},
+		{
+			name:    "setext h1 pinned to level 2 becomes ATX",
+			content: "Title\n=====\n\nBody.\n",
+			target:  2,
+			want:    "## Title\n\nBody.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adjustHeadingsToLevel(tt.content, tt.target)
+			assert.Equal(t, tt.want, got,
+				"adjustHeadingsToLevel() =\n%q\nwant:\n%q", got, tt.want)
+		})
+	}
+}
+
 // --- isResultPrevLineFence ---
 
 // TestIsResultPrevLineFence pins both branches: empty result

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -142,11 +142,8 @@ func validateIncludeDirective(
 	}
 
 	// Validate heading-level parameter if present.
-	if hl, ok := params["heading-level"]; ok {
-		if hl != "absolute" {
-			return []lint.Diagnostic{makeDiag(filePath, line,
-				`include directive "heading-level" must be "absolute"`)}
-		}
+	if diags := validateHeadingLevel(filePath, line, params); len(diags) > 0 {
+		return diags
 	}
 
 	// Validate heading-offset parameter if present.
@@ -221,6 +218,24 @@ func validateHeadingOffset(
 	if _, hasHL := params["heading-level"]; hasHL {
 		return []lint.Diagnostic{makeDiag(filePath, line,
 			`include directive "heading-offset" cannot be combined with "heading-level"`)}
+	}
+	return nil
+}
+
+// validateHeadingLevel checks the heading-level parameter when present: it
+// must be "absolute" (parent-relative nesting) or an integer 1..6 (an
+// explicit target level for the shallowest included heading).
+func validateHeadingLevel(
+	filePath string, line int, params map[string]string,
+) []lint.Diagnostic {
+	hl, ok := params["heading-level"]
+	if !ok || hl == "absolute" {
+		return nil
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(hl))
+	if err != nil || n < 1 || n > 6 {
+		return []lint.Diagnostic{makeDiag(filePath, line,
+			`include directive "heading-level" must be "absolute" or an integer between 1 and 6`)}
 	}
 	return nil
 }
@@ -367,8 +382,12 @@ func processIncludedContent(
 		}
 	}
 
-	if params["heading-level"] == "absolute" {
+	if hl := params["heading-level"]; hl == "absolute" {
 		text = adjustHeadings(text, findParentHeadingLevel(f, line))
+	} else if hl != "" {
+		// Numeric target, validated to 1..6 in validateIncludeDirective.
+		n, _ := strconv.Atoi(strings.TrimSpace(hl))
+		text = adjustHeadingsToLevel(text, n)
 	}
 	if off, ok := params["heading-offset"]; ok {
 		// Validated to a -6..6 integer in validateIncludeDirective; on any

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -555,6 +555,96 @@ func TestFix_HeadingLevelAbsolute(t *testing.T) {
 }
 
 // =====================================================================
+// Heading level (numeric target)
+// =====================================================================
+
+func TestCheck_HeadingLevelNumericAtDocRoot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.md": {Data: []byte("# Title\n\nText.\n\n## Sub\n\nMore.\n")},
+	}
+	// No parent heading, yet "2" pins the shallowest heading to level 2:
+	// # -> ##, ## -> ###. This is what "absolute" cannot do at the root.
+	src := "<?include\nfile: data.md\nheading-level: \"2\"\n?>\n" +
+		"## Title\n\nText.\n\n### Sub\n\nMore.\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestCheck_HeadingLevelNumericPromote(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.md": {Data: []byte("### Deep\n\n#### Deeper\n")},
+	}
+	// "1" pins the shallowest (h3) to h1, promoting: ### -> #, #### -> ##.
+	src := "<?include\nfile: data.md\nheading-level: \"1\"\n?>\n" +
+		"# Deep\n\n## Deeper\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestFix_HeadingLevelNumeric(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.md": {Data: []byte("# Title\n\n## Sub\n")},
+	}
+	src := "<?include\nfile: data.md\nheading-level: \"2\"\n?>\n" +
+		"old\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	got := string(r.Fix(f))
+	want := "<?include\nfile: data.md\nheading-level: \"2\"\n?>\n" +
+		"## Title\n\n### Sub\n<?/include?>\n"
+	assert.Equal(t, want, got, "Fix output mismatch\ngot:\n%s\nwant:\n%s", got, want)
+}
+
+func TestCheck_HeadingLevelOutOfRange(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("# A\n")}}
+	src := "<?include\nfile: data.md\nheading-level: \"7\"\n?>\n" +
+		"# A\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"heading-level" must be "absolute" or an integer between 1 and 6`)
+}
+
+func TestCheck_HeadingLevelZeroInvalid(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("# A\n")}}
+	src := "<?include\nfile: data.md\nheading-level: \"0\"\n?>\n" +
+		"# A\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"heading-level" must be "absolute" or an integer between 1 and 6`)
+}
+
+func TestCheck_HeadingLevelNumericWithOffset(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("## A\n")}}
+	src := "<?include\nfile: data.md\n" +
+		"heading-level: \"2\"\nheading-offset: \"1\"\n?>\n" +
+		"## A\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"heading-offset" cannot be combined with "heading-level"`)
+}
+
+func TestCheck_HeadingLevelNumericWithExtract(t *testing.T) {
+	fsys := fstest.MapFS{"data.md": {Data: []byte("content\n")}}
+	src := "<?include\nfile: data.md\n" +
+		"extract: foo\nheading-level: \"2\"\n?>\ncontent\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`"extract" cannot be combined with "heading-level"`)
+}
+
+// =====================================================================
 // Heading offset
 // =====================================================================
 

--- a/plan/233_include-heading-level-target.md
+++ b/plan/233_include-heading-level-target.md
@@ -1,0 +1,162 @@
+---
+id: 233
+title: numeric heading-level target for include
+status: "🔳"
+summary: >-
+  Extend the `<?include?>` directive's `heading-level`
+  parameter (MDS021) to accept an integer 1-6 that pins
+  the shallowest embedded heading to that level, beside
+  the existing `"absolute"` keyword. A pinned target is
+  robust to source-file changes where `heading-offset`
+  (a delta) is not.
+model: opus
+depends-on: [232]
+---
+# numeric heading-level target for include
+
+## Goal
+
+Let `heading-level` name an explicit target level, not
+just the `"absolute"` keyword. `heading-level: "2"` pins
+the shallowest included heading to level 2, whatever the
+source starts at.
+
+## Context
+
+The directive now offers two heading strategies. Plan 232
+added `heading-offset`. This plan adds a third form so the
+trio is complete:
+
+- `heading-level: "absolute"` — parent-relative. Nests the
+  embed one level under the nearest preceding heading. At
+  the document root it is a no-op (no parent to read).
+- `heading-level: "N"` — target. Pins the shallowest
+  embedded heading to level N, regardless of the source or
+  any parent. This plan.
+- `heading-offset: "N"` — source-relative. Adds N to every
+  heading. The result tracks the source's own levels.
+
+`"absolute"` already computes a target: it shifts so the
+shallowest heading becomes `parentLevel + 1`. A numeric
+form is the same machinery with the target stated outright
+instead of derived from the parent. So the value reads as
+"what level should this land at" — one inferred, one
+explicit.
+
+Why keep all three instead of one? It is an owner call. A
+target is robust when the source changes: it always lands
+at N. A delta keeps a hand-set relationship instead. And
+`"absolute"` is the no-setup default for the common case —
+nesting under the current section.
+
+## Design
+
+### Syntax
+
+```text
+<?include
+file: features.md
+heading-level: "2"
+?>
+## Pinned To Level 2
+<?/include?>
+```
+
+`heading-level` accepts `"absolute"` or an integer from 1
+to 6. The two heading parameters stay mutually exclusive:
+`heading-level` (either form) cannot pair with
+`heading-offset`, and neither pairs with `extract:`.
+
+### Shift
+
+For target N the shift is `N - minLevel`, where `minLevel`
+is the shallowest heading in the source. A new
+[`adjustHeadingsToLevel`][headings] reuses the existing
+`findMinHeadingLevel` and `applyShift` helpers. It clamps
+to 1-6, allows promotion (negative shift), and no-ops when
+the shift is zero or the source has no heading. It omits
+the `parentLevel <= 0` and `shift <= 0` guards that
+`adjustHeadings` needs only for parent-relative nesting.
+
+`"absolute"` behavior is unchanged. The numeric path is a
+new branch. So tracked files that already use
+`heading-level: "absolute"` produce the same output under
+both the branch binary and the pinned one.
+
+### Validation
+
+- `heading-level` must be `"absolute"` or an integer 1-6.
+  Anything else is a lint error. The message becomes
+  `"heading-level" must be "absolute" or an integer
+  between 1 and 6`.
+- The existing mutual-exclusion checks already key on the
+  presence of the `heading-level` parameter, so they cover
+  the numeric form with no change.
+
+### Pinned baseline
+
+The new value is new directive syntax. Per
+[the adopt process][adopt], no tracked Markdown may use
+`heading-level: "<number>"` until a release ships it and
+`setup-mdsmith-pinned-version` is bumped, or
+`mdsmith-fixed-version` fails. This plan ships the feature
+only: the numeric form appears solely in ignored fixtures
+and in fenced doc examples, never as a live directive.
+
+[headings]: ../internal/rules/include/headings.go
+[adopt]: ../docs/development/adopt-new-directive-syntax.md
+
+## Tasks
+
+1. [ ] Add `adjustHeadingsToLevel(content, target)` to
+   [`headings.go`][headings], reusing `findMinHeadingLevel`
+   and `applyShift`. Unit tests for pin, promote, clamp,
+   zero-shift no-op, no-heading, and setext land first,
+   red.
+2. [ ] Accept an integer 1-6 for `heading-level` in
+   `validateIncludeDirective`; update the error message. A
+   unit test pins the valid and invalid cases.
+3. [ ] Apply the numeric target in `processIncludedContent`
+   via `adjustHeadingsToLevel`, leaving the `"absolute"`
+   branch untouched.
+4. [ ] Add a good/bad/fixed fixture trio under
+   [MDS021-include][dir] exercising `heading-level: "2"`.
+5. [ ] Update the rule README ([MDS021-include][readme]):
+   the parameter table, the heading-level section, an
+   example, and the new diagnostic message row.
+6. [ ] Update the directive guide ([generating][guide])
+   and the built-in help ([help][help]).
+7. [ ] Run `go test ./...`, `go tool golangci-lint run`,
+   the allocation-budget test, and `mdsmith check .`.
+   Confirm `mdsmith check .` shows no churn in the tracked
+   files that use `heading-level: "absolute"`.
+
+[dir]: ../internal/rules/MDS021-include/
+[readme]: ../internal/rules/MDS021-include/README.md
+[guide]: ../docs/guides/directives/generating-content.md
+[help]: ../internal/directives/generating-content.md
+
+## Deferred — gated on the pin bump
+
+8. [ ] Adopt `heading-level: "<number>"` in tracked
+   Markdown only after a release ships it and the pinned
+   baseline is bumped. This task stays open as the
+   reminder; the plan holds at `🔳` until then.
+
+## Acceptance Criteria
+
+- [ ] `heading-level: "2"` pins the shallowest embedded
+      heading to level 2 on `mdsmith fix`, even at the
+      document root
+- [ ] `heading-level: "1"` promotes a source that starts
+      deeper, clamped at level 1
+- [ ] `heading-level: "absolute"` output is unchanged for
+      existing tracked includes (no churn)
+- [ ] A non-integer or out-of-range `heading-level` is a
+      lint error naming the allowed values
+- [ ] `heading-level` numeric still cannot pair with
+      `heading-offset` or `extract`
+- [ ] No tracked Markdown uses the numeric form, so
+      `mdsmith-fixed-version` stays green
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/233_include-heading-level-target.md
+++ b/plan/233_include-heading-level-target.md
@@ -108,25 +108,25 @@ and in fenced doc examples, never as a live directive.
 
 ## Tasks
 
-1. [ ] Add `adjustHeadingsToLevel(content, target)` to
+1. [x] Add `adjustHeadingsToLevel(content, target)` to
    [`headings.go`][headings], reusing `findMinHeadingLevel`
    and `applyShift`. Unit tests for pin, promote, clamp,
    zero-shift no-op, no-heading, and setext land first,
    red.
-2. [ ] Accept an integer 1-6 for `heading-level` in
+2. [x] Accept an integer 1-6 for `heading-level` in
    `validateIncludeDirective`; update the error message. A
    unit test pins the valid and invalid cases.
-3. [ ] Apply the numeric target in `processIncludedContent`
+3. [x] Apply the numeric target in `processIncludedContent`
    via `adjustHeadingsToLevel`, leaving the `"absolute"`
    branch untouched.
-4. [ ] Add a good/bad/fixed fixture trio under
+4. [x] Add a good/bad/fixed fixture trio under
    [MDS021-include][dir] exercising `heading-level: "2"`.
-5. [ ] Update the rule README ([MDS021-include][readme]):
+5. [x] Update the rule README ([MDS021-include][readme]):
    the parameter table, the heading-level section, an
    example, and the new diagnostic message row.
-6. [ ] Update the directive guide ([generating][guide])
+6. [x] Update the directive guide ([generating][guide])
    and the built-in help ([help][help]).
-7. [ ] Run `go test ./...`, `go tool golangci-lint run`,
+7. [x] Run `go test ./...`, `go tool golangci-lint run`,
    the allocation-budget test, and `mdsmith check .`.
    Confirm `mdsmith check .` shows no churn in the tracked
    files that use `heading-level: "absolute"`.
@@ -145,18 +145,18 @@ and in fenced doc examples, never as a live directive.
 
 ## Acceptance Criteria
 
-- [ ] `heading-level: "2"` pins the shallowest embedded
+- [x] `heading-level: "2"` pins the shallowest embedded
       heading to level 2 on `mdsmith fix`, even at the
       document root
-- [ ] `heading-level: "1"` promotes a source that starts
+- [x] `heading-level: "1"` promotes a source that starts
       deeper, clamped at level 1
-- [ ] `heading-level: "absolute"` output is unchanged for
+- [x] `heading-level: "absolute"` output is unchanged for
       existing tracked includes (no churn)
-- [ ] A non-integer or out-of-range `heading-level` is a
+- [x] A non-integer or out-of-range `heading-level` is a
       lint error naming the allowed values
-- [ ] `heading-level` numeric still cannot pair with
+- [x] `heading-level` numeric still cannot pair with
       `heading-offset` or `extract`
-- [ ] No tracked Markdown uses the numeric form, so
+- [x] No tracked Markdown uses the numeric form, so
       `mdsmith-fixed-version` stays green
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
Follow-up to #470. Extends the `<?include?>` directive's `heading-level` parameter (MDS021) to accept an integer 1–6 alongside `"absolute"`, completing the three heading-adjustment strategies (plan 233).

## What

- `heading-level: "absolute"` — parent-relative (existing): nests the embed one level under the nearest preceding heading; a no-op at the document root.
- `heading-level: "<1-6>"` — **new**: pins the shallowest included heading to that level, regardless of source or parent — so it works at the document root where `"absolute"` is a no-op.
- `heading-offset: "<-6..6>"` — source-relative delta (from #470).

A pinned target is robust when the source restructures (always lands at N); a delta preserves a hand-set relationship; `"absolute"` stays the zero-config default. Per the owner decision, all three coexist.

## Implementation

- `adjustHeadingsToLevel(content, target)` — reuses `findMinHeadingLevel` + `applyShift`; allows promotion (negative shift), clamps to 1–6, no-ops on a zero shift or headingless content.
- Validation extracted to a `validateHeadingLevel` helper (symmetric with `validateHeadingOffset` / `validateExtractParam`): accepts `"absolute"` or 1–6, else `… must be "absolute" or an integer between 1 and 6`. The offset/extract mutual-exclusion checks already key on the parameter's presence, so they cover the numeric form unchanged.
- `"absolute"` behavior is untouched (a new branch), so the many tracked files using `heading-level: "absolute"` produce byte-identical output — **confirmed zero churn** via `mdsmith fix`, so `mdsmith-fixed-version` stays green.
- good/bad/fixed fixtures, unit + rule tests, README + guide + built-in help, `plan/233`.

## Pinned-baseline guardrail

The numeric form is new directive syntax. Per `docs/development/adopt-new-directive-syntax.md`, it appears **only** in ignored fixtures and fenced (inert) doc examples — never as a live directive — so the pinned binary (v0.31.0) never parses it. Adopting it in tracked Markdown is a separate, later step gated on a release + pin bump; plan 233 holds at `🔳` with that adoption task open as the reminder.

## Verification

- `go test ./...`, `go vet ./...`, `go tool golangci-lint run` — all clean.
- `mdsmith check .` — 412 files, 0 failures.

https://claude.ai/code/session_014xpEPq3jaUUV82DPRsiEnM

---
_Generated by [Claude Code](https://claude.ai/code/session_014xpEPq3jaUUV82DPRsiEnM)_