### PR TITLE
perf: top-5 hot-path optimizations per high-performance-go.md

### DIFF
--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -349,7 +349,7 @@ func emitLines(srcLines [][]byte, strip map[int]bool) []byte {
 // and anchor leading/trailing trims. That preserves intentional
 // blank lines inside fenced and indented code blocks, matching how
 // MDS008 (blank-line rule) leaves code-block whitespace alone.
-func normalizeBlankLines(src []byte, codeBlockLines map[int]bool) []byte {
+func normalizeBlankLines(src []byte, codeBlockLines map[int]struct{}) []byte {
 	if len(src) == 0 {
 		return src
 	}
@@ -366,7 +366,8 @@ func normalizeBlankLines(src []byte, codeBlockLines map[int]bool) []byte {
 	}
 	lines := make([]srcLine, len(rawLines))
 	for i, l := range rawLines {
-		lines[i] = srcLine{text: l, inCode: codeBlockLines[i+1]}
+		_, inCode := codeBlockLines[i+1]
+		lines[i] = srcLine{text: l, inCode: inCode}
 	}
 
 	isBlank := func(l srcLine) bool {

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -61,10 +61,7 @@ func ExtractWikiLinks(f *lint.File) []WikiLink {
 	for _, m := range wikilinkRE.FindAllSubmatchIndex(source, -1) {
 		start := m[0]
 		line := f.LineOfOffset(start)
-		if _, ok := codeLines[line]; ok {
-			continue
-		}
-		if _, ok := piLines[line]; ok {
+		if lint.InCodeOrPI(codeLines, piLines, line) {
 			continue
 		}
 		if inCodeSpan(codeSpans, start) {

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -61,9 +61,10 @@ func ExtractWikiLinks(f *lint.File) []WikiLink {
 	for _, m := range wikilinkRE.FindAllSubmatchIndex(source, -1) {
 		start := m[0]
 		line := f.LineOfOffset(start)
-		_, inCode := codeLines[line]
-		_, inPI := piLines[line]
-		if inCode || inPI {
+		if _, ok := codeLines[line]; ok {
+			continue
+		}
+		if _, ok := piLines[line]; ok {
 			continue
 		}
 		if inCodeSpan(codeSpans, start) {

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -61,7 +61,9 @@ func ExtractWikiLinks(f *lint.File) []WikiLink {
 	for _, m := range wikilinkRE.FindAllSubmatchIndex(source, -1) {
 		start := m[0]
 		line := f.LineOfOffset(start)
-		if codeLines[line] || piLines[line] {
+		_, inCode := codeLines[line]
+		_, inPI := piLines[line]
+		if inCode || inPI {
 			continue
 		}
 		if inCodeSpan(codeSpans, start) {

--- a/internal/lint/codeblocks.go
+++ b/internal/lint/codeblocks.go
@@ -52,6 +52,19 @@ func collectPIBlockLinesInto(n ast.Node, f *File, lines map[int]struct{}) {
 	}
 }
 
+// InCodeOrPI reports whether the 1-based line is present in codeLines or
+// piLines. It checks codeLines first and returns early, so the piLines
+// lookup is skipped for a line already known to sit inside a code block —
+// preserving the short-circuit of the original `codeLines[l] || piLines[l]`
+// expression while keeping each call site to a single statement.
+func InCodeOrPI(codeLines, piLines map[int]struct{}, line int) bool {
+	if _, ok := codeLines[line]; ok {
+		return true
+	}
+	_, ok := piLines[line]
+	return ok
+}
+
 // CollectCodeBlockLines returns a set of 1-based line numbers that
 // belong to fenced code blocks (including fence lines) or indented code
 // blocks. The walk is computed once per File and cached; the returned

--- a/internal/lint/codeblocks.go
+++ b/internal/lint/codeblocks.go
@@ -11,7 +11,7 @@ import (
 // the returned map is shared read-only and must not be mutated. The
 // atomic.Bool + mutex memo avoids the once.Do closure box (see the
 // File.piBlockLines field comment).
-func CollectPIBlockLines(f *File) map[int]bool {
+func CollectPIBlockLines(f *File) map[int]struct{} {
 	if f.piBlockLinesDone.Load() {
 		return f.piBlockLines
 	}
@@ -24,8 +24,8 @@ func CollectPIBlockLines(f *File) map[int]bool {
 	return f.piBlockLines
 }
 
-func collectPIBlockLines(f *File) map[int]bool {
-	lines := map[int]bool{}
+func collectPIBlockLines(f *File) map[int]struct{} {
+	lines := map[int]struct{}{}
 	collectPIBlockLinesInto(f.AST, f, lines)
 	return lines
 }
@@ -34,17 +34,17 @@ func collectPIBlockLines(f *File) map[int]bool {
 // ast.Walk) so the per-File memo build sheds the closure box
 // ast.Walk would otherwise allocate. The helper closes over
 // nothing.
-func collectPIBlockLinesInto(n ast.Node, f *File, lines map[int]bool) {
+func collectPIBlockLinesInto(n ast.Node, f *File, lines map[int]struct{}) {
 	if n == nil {
 		return
 	}
 	if pi, ok := n.(*piparser.ProcessingInstruction); ok {
 		segs := pi.Lines()
 		for i := 0; i < segs.Len(); i++ {
-			lines[f.LineOfOffset(segs.At(i).Start)] = true
+			lines[f.LineOfOffset(segs.At(i).Start)] = struct{}{}
 		}
 		if pi.HasClosure() {
-			lines[f.LineOfOffset(pi.ClosureLine.Start)] = true
+			lines[f.LineOfOffset(pi.ClosureLine.Start)] = struct{}{}
 		}
 	}
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
@@ -58,7 +58,7 @@ func collectPIBlockLinesInto(n ast.Node, f *File, lines map[int]bool) {
 // map is shared read-only and must not be mutated. The atomic.Bool +
 // mutex memo avoids the once.Do closure box (see the
 // File.codeBlockLines field comment).
-func CollectCodeBlockLines(f *File) map[int]bool {
+func CollectCodeBlockLines(f *File) map[int]struct{} {
 	if f.codeBlockLinesDone.Load() {
 		return f.codeBlockLines
 	}
@@ -71,8 +71,8 @@ func CollectCodeBlockLines(f *File) map[int]bool {
 	return f.codeBlockLines
 }
 
-func collectCodeBlockLines(f *File) map[int]bool {
-	lines := map[int]bool{}
+func collectCodeBlockLines(f *File) map[int]struct{} {
+	lines := map[int]struct{}{}
 	collectCodeBlockLinesInto(f.AST, f, lines)
 	return lines
 }
@@ -81,7 +81,7 @@ func collectCodeBlockLines(f *File) map[int]bool {
 // closure box) and folds every fenced or indented code block's
 // content lines into the supplied set. Matches the previous
 // ast.Walk shape byte-for-byte; the helper closes over nothing.
-func collectCodeBlockLinesInto(n ast.Node, f *File, lines map[int]bool) {
+func collectCodeBlockLinesInto(n ast.Node, f *File, lines map[int]struct{}) {
 	if n == nil {
 		return
 	}
@@ -98,14 +98,14 @@ func collectCodeBlockLinesInto(n ast.Node, f *File, lines map[int]bool) {
 
 // addFencedCodeBlockLines marks the opening fence line, all content lines,
 // and the closing fence line.
-func addFencedCodeBlockLines(f *File, fcb *ast.FencedCodeBlock, set map[int]bool) {
+func addFencedCodeBlockLines(f *File, fcb *ast.FencedCodeBlock, set map[int]struct{}) {
 	// Determine the opening fence line by looking at the node's info or
 	// the first content line. The opening fence is always the line before
 	// the first content line (or, when there are no content lines, we find
 	// it via the Info segment).
 	openLine := FindFencedOpenLine(f, fcb)
 	if openLine > 0 {
-		set[openLine] = true
+		set[openLine] = struct{}{}
 	}
 
 	// Content lines from the code block's segments.
@@ -114,7 +114,7 @@ func addFencedCodeBlockLines(f *File, fcb *ast.FencedCodeBlock, set map[int]bool
 	for i := 0; i < segs.Len(); i++ {
 		seg := segs.At(i)
 		ln := f.LineOfOffset(seg.Start)
-		set[ln] = true
+		set[ln] = struct{}{}
 		if ln > lastContentLine {
 			lastContentLine = ln
 		}
@@ -130,7 +130,7 @@ func addFencedCodeBlockLines(f *File, fcb *ast.FencedCodeBlock, set map[int]bool
 		closeLine = openLine + 1
 	}
 	if closeLine > 0 && closeLine <= len(f.Lines) {
-		set[closeLine] = true
+		set[closeLine] = struct{}{}
 	}
 }
 
@@ -164,11 +164,11 @@ func FindFencedOpenLine(f *File, fcb *ast.FencedCodeBlock) int {
 }
 
 // addBlockLines marks all content lines of an indented code block.
-func addBlockLines(f *File, cb *ast.CodeBlock, set map[int]bool) {
+func addBlockLines(f *File, cb *ast.CodeBlock, set map[int]struct{}) {
 	segs := cb.Lines()
 	for i := 0; i < segs.Len(); i++ {
 		seg := segs.At(i)
 		ln := f.LineOfOffset(seg.Start)
-		set[ln] = true
+		set[ln] = struct{}{}
 	}
 }

--- a/internal/lint/codeblocks_test.go
+++ b/internal/lint/codeblocks_test.go
@@ -34,6 +34,21 @@ func TestCollectPIBlockLines_CachedPerFile(t *testing.T) {
 	assertSameMap(t, first, second)
 }
 
+// TestInCodeOrPI pins the short-circuit membership helper: a line in
+// codeLines reports true without consulting piLines, a line only in
+// piLines reports true, and a line in neither reports false. Nil maps
+// are safe (membership reads on a nil map return the zero value).
+func TestInCodeOrPI(t *testing.T) {
+	code := map[int]struct{}{1: {}, 3: {}}
+	pi := map[int]struct{}{2: {}}
+
+	assert.True(t, InCodeOrPI(code, pi, 1), "line in codeLines")
+	assert.True(t, InCodeOrPI(code, pi, 2), "line in piLines")
+	assert.False(t, InCodeOrPI(code, pi, 4), "line in neither")
+	assert.False(t, InCodeOrPI(nil, nil, 1), "nil maps are safe and report false")
+	assert.True(t, InCodeOrPI(nil, pi, 2), "nil codeLines, hit in piLines")
+}
+
 // assertSameMap asserts the two maps are the identical backing map,
 // which proves the walk ran once and the result was cached rather than
 // recomputed (a fresh map each call would have a different address).

--- a/internal/lint/codeblocks_test.go
+++ b/internal/lint/codeblocks_test.go
@@ -37,11 +37,17 @@ func TestCollectPIBlockLines_CachedPerFile(t *testing.T) {
 // assertSameMap asserts the two maps are the identical backing map,
 // which proves the walk ran once and the result was cached rather than
 // recomputed (a fresh map each call would have a different address).
-func assertSameMap(t *testing.T, a, b map[int]bool) {
+func assertSameMap(t *testing.T, a, b map[int]struct{}) {
 	t.Helper()
-	a[-1] = true
-	assert.True(t, b[-1], "second call must return the cached map, not a fresh walk")
+	a[-1] = struct{}{}
+	_, ok := b[-1]
+	assert.True(t, ok, "second call must return the cached map, not a fresh walk")
 	delete(a, -1)
+}
+
+func inSet(m map[int]struct{}, k int) bool {
+	_, ok := m[k]
+	return ok
 }
 
 func TestCollectPIBlockLines_MultiLine(t *testing.T) {
@@ -58,10 +64,10 @@ func TestCollectPIBlockLines_MultiLine(t *testing.T) {
 	require.NoError(t, err)
 	lines := CollectPIBlockLines(f)
 	for _, ln := range []int{3, 4, 5} {
-		assert.True(t, lines[ln], "expected line %d to be in PI block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in PI block lines", ln)
 	}
 	for _, ln := range []int{1, 2, 6, 7} {
-		assert.False(t, lines[ln], "expected line %d to NOT be in PI block lines", ln)
+		assert.False(t, inSet(lines, ln), "expected line %d to NOT be in PI block lines", ln)
 	}
 }
 
@@ -87,11 +93,11 @@ func TestCollectCodeBlockLines_FencedCodeBlock(t *testing.T) {
 	lines := CollectCodeBlockLines(f)
 	// Lines 3 (open fence), 4 (content), 5 (close fence) should be in set.
 	for _, ln := range []int{3, 4, 5} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 	// Lines 1, 2 should NOT be in set.
 	for _, ln := range []int{1, 2} {
-		assert.False(t, lines[ln], "expected line %d to NOT be in code block lines", ln)
+		assert.False(t, inSet(lines, ln), "expected line %d to NOT be in code block lines", ln)
 	}
 }
 
@@ -101,7 +107,7 @@ func TestCollectCodeBlockLines_FencedWithInfoString(t *testing.T) {
 	require.NoError(t, err)
 	lines := CollectCodeBlockLines(f)
 	for _, ln := range []int{3, 4, 5} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 }
 
@@ -112,10 +118,10 @@ func TestCollectCodeBlockLines_IndentedCodeBlock(t *testing.T) {
 	require.NoError(t, err)
 	lines := CollectCodeBlockLines(f)
 	for _, ln := range []int{3, 4} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 	// Line 1 should not be in set.
-	assert.False(t, lines[1], "expected line 1 to NOT be in code block lines")
+	assert.False(t, inSet(lines, 1), "expected line 1 to NOT be in code block lines")
 }
 
 func TestCollectCodeBlockLines_NoCodeBlocks(t *testing.T) {
@@ -149,7 +155,7 @@ func TestCollectCodeBlockLines_EmptyFencedCodeBlockWithInfo(t *testing.T) {
 	lines := CollectCodeBlockLines(f)
 	// Line 1 (open fence) and line 2 (close fence) should be in the set.
 	for _, ln := range []int{1, 2} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 }
 
@@ -160,10 +166,10 @@ func TestCollectCodeBlockLines_MultipleFencedCodeBlocks(t *testing.T) {
 	lines := CollectCodeBlockLines(f)
 	// Lines 1,2,3 (first block) and 5,6,7 (second block).
 	for _, ln := range []int{1, 2, 3, 5, 6, 7} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 	// Line 4 (blank between blocks) should NOT be.
-	assert.False(t, lines[4], "expected line 4 to NOT be in code block lines")
+	assert.False(t, inSet(lines, 4), "expected line 4 to NOT be in code block lines")
 }
 
 func TestCollectCodeBlockLines_TildeFence(t *testing.T) {
@@ -172,7 +178,7 @@ func TestCollectCodeBlockLines_TildeFence(t *testing.T) {
 	require.NoError(t, err)
 	lines := CollectCodeBlockLines(f)
 	for _, ln := range []int{1, 2, 3} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 }
 
@@ -182,7 +188,7 @@ func TestCollectCodeBlockLines_FencedWithMultipleContentLines(t *testing.T) {
 	require.NoError(t, err)
 	lines := CollectCodeBlockLines(f)
 	for _, ln := range []int{1, 2, 3, 4, 5} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 }
 
@@ -201,8 +207,8 @@ func TestCollectCodeBlockLines_TabIndentedLine(t *testing.T) {
 	f, err := NewFile("test.md", src)
 	require.NoError(t, err)
 	lines := CollectCodeBlockLines(f)
-	assert.True(t, lines[1], "expected line 1 to be in code block lines (tab-indented = indented code block)")
-	assert.False(t, lines[2], "expected line 2 to NOT be in code block lines")
+	assert.True(t, inSet(lines, 1), "expected line 1 to be in code block lines (tab-indented = indented code block)")
+	assert.False(t, inSet(lines, 2), "expected line 2 to NOT be in code block lines")
 }
 
 func TestCollectCodeBlockLines_FencedWithBlankLinesInside(t *testing.T) {
@@ -212,7 +218,7 @@ func TestCollectCodeBlockLines_FencedWithBlankLinesInside(t *testing.T) {
 	require.NoError(t, err)
 	lines := CollectCodeBlockLines(f)
 	for _, ln := range []int{1, 2, 3, 4, 5, 6} {
-		assert.True(t, lines[ln], "expected line %d to be in code block lines", ln)
+		assert.True(t, inSet(lines, ln), "expected line %d to be in code block lines", ln)
 	}
 }
 
@@ -221,7 +227,7 @@ func TestCollectCodeBlockLines_FencedWithBlankLinesInside(t *testing.T) {
 // ast.Walk closure; the guard exists so unit-test struct-literal
 // *File values with no AST stay safe to call.
 func TestCollectPIBlockLinesInto_NilNode(t *testing.T) {
-	lines := map[int]bool{}
+	lines := map[int]struct{}{}
 	collectPIBlockLinesInto(nil, &File{}, lines)
 	assert.Empty(t, lines)
 }
@@ -229,7 +235,7 @@ func TestCollectPIBlockLinesInto_NilNode(t *testing.T) {
 // TestCollectCodeBlockLinesInto_NilNode pins the same nil-node
 // guard for the code-block walker. Mirrors PIBlockLinesInto.
 func TestCollectCodeBlockLinesInto_NilNode(t *testing.T) {
-	lines := map[int]bool{}
+	lines := map[int]struct{}{}
 	collectCodeBlockLinesInto(nil, &File{}, lines)
 	assert.Empty(t, lines)
 }

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -86,10 +86,10 @@ type File struct {
 	// profiling). The cached map is shared read-only with every
 	// caller; no caller mutates it. atomic.Bool + mutex matches
 	// newlineOffsets above for the same closure-box reason.
-	codeBlockLines     map[int]bool
+	codeBlockLines     map[int]struct{}
 	codeBlockLinesDone atomic.Bool
 	codeBlockLinesMu   sync.Mutex
-	piBlockLines       map[int]bool
+	piBlockLines       map[int]struct{}
 	piBlockLinesDone   atomic.Bool
 	piBlockLinesMu     sync.Mutex
 

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -64,7 +64,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if skip[lineNum] {
+		if _, ok := skip[lineNum]; ok {
 			continue
 		}
 		masked := maskCodeSpans(line, lineNum, codeSpanRanges, lineStarts)

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/mdtext"
@@ -260,14 +261,22 @@ func IsTable(para *ast.Paragraph, f *lint.File) bool {
 	return bytes.HasPrefix(bytes.TrimSpace(f.Source[seg.Start:seg.Stop]), []byte("|"))
 }
 
+// headingTextPool pools bytes.Buffer values used by HeadingText so
+// heading-text extraction in the hot-path rule walk allocates zero
+// buffers per call instead of one.
+var headingTextPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
+
 // HeadingText returns the plain-text content of a heading by
 // recursively extracting all text segments from its children.
 func HeadingText(heading *ast.Heading, source []byte) string {
-	var buf bytes.Buffer
+	buf := headingTextPool.Get().(*bytes.Buffer)
+	buf.Reset()
 	for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
-		ExtractText(c, source, &buf)
+		ExtractText(c, source, buf)
 	}
-	return buf.String()
+	s := buf.String()
+	headingTextPool.Put(buf)
+	return s
 }
 
 // ExtractText recursively writes the text content of n and its

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -271,12 +271,11 @@ var headingTextPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 func HeadingText(heading *ast.Heading, source []byte) string {
 	buf := headingTextPool.Get().(*bytes.Buffer)
 	buf.Reset()
+	defer headingTextPool.Put(buf)
 	for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
 		ExtractText(c, source, buf)
 	}
-	s := buf.String()
-	headingTextPool.Put(buf)
-	return s
+	return buf.String()
 }
 
 // ExtractText recursively writes the text content of n and its

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -263,15 +263,28 @@ func IsTable(para *ast.Paragraph, f *lint.File) bool {
 
 // headingTextPool pools bytes.Buffer values used by HeadingText so
 // heading-text extraction in the hot-path rule walk allocates zero
-// buffers per call instead of one.
+// buffers per call instead of one. Buffers beyond headingTextMaxPooledCap
+// are discarded on release to prevent the LSP long-running process from
+// retaining an oversized backing array indefinitely (mirrors the cap
+// guard in mdtext.ExtractPlainText / extractTextMaxPooledCap).
 var headingTextPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
+
+// headingTextMaxPooledCap is the maximum buffer capacity returned to
+// headingTextPool. Heading text is always short (typically < 200 bytes);
+// 4 KiB is a generous cap that prevents any pathological case from
+// inflating the pool's steady-state footprint.
+const headingTextMaxPooledCap = 4 * 1024
 
 // HeadingText returns the plain-text content of a heading by
 // recursively extracting all text segments from its children.
 func HeadingText(heading *ast.Heading, source []byte) string {
 	buf := headingTextPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	defer headingTextPool.Put(buf)
+	defer func() {
+		if buf.Cap() <= headingTextMaxPooledCap {
+			headingTextPool.Put(buf)
+		}
+	}()
 	for c := heading.FirstChild(); c != nil; c = c.NextSibling() {
 		ExtractText(c, source, buf)
 	}

--- a/internal/rules/atxheadingwhitespace/rule.go
+++ b/internal/rules/atxheadingwhitespace/rule.go
@@ -31,10 +31,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for i, rawLine := range f.Lines {
 		lineNum := i + 1
-		if _, ok := codeLines[lineNum]; ok {
-			continue
-		}
-		if _, ok := piLines[lineNum]; ok {
+		if lint.InCodeOrPI(codeLines, piLines, lineNum) {
 			continue
 		}
 		diags = append(diags, r.checkLine(f.Path, lineNum, rawLine)...)
@@ -142,11 +139,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	result := make([]string, 0, len(f.Lines))
 	for i, rawLine := range f.Lines {
 		lineNum := i + 1
-		if _, ok := codeLines[lineNum]; ok {
-			result = append(result, string(rawLine))
-			continue
-		}
-		if _, ok := piLines[lineNum]; ok {
+		if lint.InCodeOrPI(codeLines, piLines, lineNum) {
 			result = append(result, string(rawLine))
 			continue
 		}

--- a/internal/rules/atxheadingwhitespace/rule.go
+++ b/internal/rules/atxheadingwhitespace/rule.go
@@ -31,7 +31,9 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for i, rawLine := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] || piLines[lineNum] {
+		_, inCode := codeLines[lineNum]
+		_, inPI := piLines[lineNum]
+		if inCode || inPI {
 			continue
 		}
 		diags = append(diags, r.checkLine(f.Path, lineNum, rawLine)...)
@@ -139,7 +141,9 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	result := make([]string, 0, len(f.Lines))
 	for i, rawLine := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] || piLines[lineNum] {
+		_, inCode := codeLines[lineNum]
+		_, inPI := piLines[lineNum]
+		if inCode || inPI {
 			result = append(result, string(rawLine))
 			continue
 		}

--- a/internal/rules/atxheadingwhitespace/rule.go
+++ b/internal/rules/atxheadingwhitespace/rule.go
@@ -31,9 +31,10 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for i, rawLine := range f.Lines {
 		lineNum := i + 1
-		_, inCode := codeLines[lineNum]
-		_, inPI := piLines[lineNum]
-		if inCode || inPI {
+		if _, ok := codeLines[lineNum]; ok {
+			continue
+		}
+		if _, ok := piLines[lineNum]; ok {
 			continue
 		}
 		diags = append(diags, r.checkLine(f.Path, lineNum, rawLine)...)
@@ -141,9 +142,11 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	result := make([]string, 0, len(f.Lines))
 	for i, rawLine := range f.Lines {
 		lineNum := i + 1
-		_, inCode := codeLines[lineNum]
-		_, inPI := piLines[lineNum]
-		if inCode || inPI {
+		if _, ok := codeLines[lineNum]; ok {
+			result = append(result, string(rawLine))
+			continue
+		}
+		if _, ok := piLines[lineNum]; ok {
 			result = append(result, string(rawLine))
 			continue
 		}

--- a/internal/rules/blanklinearoundheadings/rule.go
+++ b/internal/rules/blanklinearoundheadings/rule.go
@@ -51,7 +51,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 
 	// Skip headings whose lines overlap with code block regions.
 	codeLines := lint.CollectCodeBlockLines(f)
-	if codeLines[line] {
+	if _, ok := codeLines[line]; ok {
 		return nil
 	}
 	lastLine := headingLastLine(heading, f)
@@ -150,7 +150,7 @@ func collectHeadingBlankLineInsertions(f *lint.File) (insertBefore, insertAfter 
 			return ast.WalkContinue, nil
 		}
 		line := astutil.HeadingLine(heading, f)
-		if codeLines[line] {
+		if _, ok := codeLines[line]; ok {
 			return ast.WalkContinue, nil
 		}
 		headings = append(headings, headingInfo{line: line, lastLine: headingLastLine(heading, f)})

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -49,10 +49,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	listEndLine := lastLineOfNode(f, list)
 
 	codeLines := lint.CollectCodeBlockLines(f)
-	if _, ok := codeLines[listStartLine]; ok {
-		return nil
-	}
-	if _, ok := codeLines[listEndLine]; ok {
+	if lineInSet(codeLines, listStartLine) || lineInSet(codeLines, listEndLine) {
 		return nil
 	}
 
@@ -169,6 +166,15 @@ func isBlank(line []byte) bool {
 	return len(bytes.TrimSpace(line)) == 0
 }
 
+// lineInSet reports whether the 1-based line is a member of set. It
+// wraps the comma-ok membership test so callers can compose two
+// checks in a single short-circuiting `||` expression — when the
+// first line is already in a code block the second lookup is skipped.
+func lineInSet(set map[int]struct{}, line int) bool {
+	_, ok := set[line]
+	return ok
+}
+
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
 	beforeSet, afterSet := r.collectBlankLineInsertions(f)
@@ -218,10 +224,7 @@ func (r *Rule) collectBlankLineInsertions(f *lint.File) (beforeSet, afterSet map
 		listStartLine := lineOfNode(f, list)
 		listEndLine := lastLineOfNode(f, list)
 
-		if _, ok := codeLines[listStartLine]; ok {
-			return ast.WalkContinue, nil
-		}
-		if _, ok := codeLines[listEndLine]; ok {
+		if lineInSet(codeLines, listStartLine) || lineInSet(codeLines, listEndLine) {
 			return ast.WalkContinue, nil
 		}
 

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -49,9 +49,10 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	listEndLine := lastLineOfNode(f, list)
 
 	codeLines := lint.CollectCodeBlockLines(f)
-	_, startInCode := codeLines[listStartLine]
-	_, endInCode := codeLines[listEndLine]
-	if startInCode || endInCode {
+	if _, ok := codeLines[listStartLine]; ok {
+		return nil
+	}
+	if _, ok := codeLines[listEndLine]; ok {
 		return nil
 	}
 
@@ -217,9 +218,10 @@ func (r *Rule) collectBlankLineInsertions(f *lint.File) (beforeSet, afterSet map
 		listStartLine := lineOfNode(f, list)
 		listEndLine := lastLineOfNode(f, list)
 
-		_, startInCode := codeLines[listStartLine]
-		_, endInCode := codeLines[listEndLine]
-		if startInCode || endInCode {
+		if _, ok := codeLines[listStartLine]; ok {
+			return ast.WalkContinue, nil
+		}
+		if _, ok := codeLines[listEndLine]; ok {
 			return ast.WalkContinue, nil
 		}
 

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -49,7 +49,9 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	listEndLine := lastLineOfNode(f, list)
 
 	codeLines := lint.CollectCodeBlockLines(f)
-	if codeLines[listStartLine] || codeLines[listEndLine] {
+	_, startInCode := codeLines[listStartLine]
+	_, endInCode := codeLines[listEndLine]
+	if startInCode || endInCode {
 		return nil
 	}
 
@@ -215,7 +217,9 @@ func (r *Rule) collectBlankLineInsertions(f *lint.File) (beforeSet, afterSet map
 		listStartLine := lineOfNode(f, list)
 		listEndLine := lastLineOfNode(f, list)
 
-		if codeLines[listStartLine] || codeLines[listEndLine] {
+		_, startInCode := codeLines[listStartLine]
+		_, endInCode := codeLines[listEndLine]
+		if startInCode || endInCode {
 			return ast.WalkContinue, nil
 		}
 

--- a/internal/rules/blanklinearoundlists/rule_coverage_test.go
+++ b/internal/rules/blanklinearoundlists/rule_coverage_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/yuin/goldmark/ast"
 )
 
+// --- lineInSet coverage ---
+
+func TestLineInSet(t *testing.T) {
+	set := map[int]struct{}{2: {}, 5: {}}
+	assert.True(t, lineInSet(set, 2), "member line reports true")
+	assert.False(t, lineInSet(set, 3), "non-member line reports false")
+	assert.False(t, lineInSet(nil, 1), "nil set is safe and reports false")
+}
+
 // --- isInlineNode coverage ---
 
 func TestIsInlineNode_Text(t *testing.T) {

--- a/internal/rules/blockquotewhitespace/rule.go
+++ b/internal/rules/blockquotewhitespace/rule.go
@@ -54,7 +54,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// a > that appears in the actual content of the blockquote is not flagged.
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			continue
 		}
 		prefix := reBlockquotePrefix.Find(line)
@@ -133,7 +133,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	lines := make([]string, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			lines[i] = string(line)
 			continue
 		}

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -588,7 +588,8 @@ func escapeDiag(filePath string, line int) globResolution {
 // silently producing partial matches.
 func containsDotDotInsideBraces(p string) bool {
 	depth := 0
-	for i := 0; i < len(p); i++ {
+	n := len(p)
+	for i := 0; i < n; i++ {
 		switch p[i] {
 		case '{':
 			depth++
@@ -597,7 +598,7 @@ func containsDotDotInsideBraces(p string) bool {
 				depth--
 			}
 		case '.':
-			if depth == 0 || i+1 >= len(p) || p[i+1] != '.' {
+			if depth == 0 || i+1 >= n || p[i+1] != '.' {
 				continue
 			}
 			if !braceSegmentBoundary(p, i-1) || !braceSegmentBoundary(p, i+2) {

--- a/internal/rules/catalog/wrap.go
+++ b/internal/rules/catalog/wrap.go
@@ -63,10 +63,11 @@ func wrapCellBr(text string, maxWidth int) string {
 
 	spans := parseMarkdownSpansRunes(runes)
 	var lines []string
+	n := len(runes)
 	offset := 0 // current rune offset into original text
 
-	for len(runes)-offset > maxWidth {
-		remLen := len(runes) - offset
+	for n-offset > maxWidth {
+		remLen := n - offset
 		adjustedSpans := spansInRange(spans, offset, offset+remLen)
 		breakPos := findBreakPointRunes(runes[offset:], adjustedSpans, maxWidth)
 
@@ -79,12 +80,12 @@ func wrapCellBr(text string, maxWidth int) string {
 
 		// Advance past the break and any leading spaces.
 		offset += breakPos
-		for offset < len(runes) && runes[offset] == ' ' {
+		for offset < n && runes[offset] == ' ' {
 			offset++
 		}
 	}
 
-	if offset < len(runes) {
+	if offset < n {
 		lines = append(lines, string(runes[offset:]))
 	}
 
@@ -102,12 +103,13 @@ type markdownSpan struct {
 func parseMarkdownSpansRunes(runes []rune) []markdownSpan {
 	var spans []markdownSpan
 
+	n := len(runes)
 	i := 0
-	for i < len(runes) {
+	for i < n {
 		// Check for inline code: `...`
 		if runes[i] == '`' {
 			end := -1
-			for j := i + 1; j < len(runes); j++ {
+			for j := i + 1; j < n; j++ {
 				if runes[j] == '`' {
 					end = j
 					break
@@ -123,7 +125,7 @@ func parseMarkdownSpansRunes(runes []rune) []markdownSpan {
 		// Check for markdown link: [text](url)
 		if runes[i] == '[' {
 			closeBracket := findClosingBracketRunes(runes, i)
-			if closeBracket > i && closeBracket+1 < len(runes) && runes[closeBracket+1] == '(' {
+			if closeBracket > i && closeBracket+1 < n && runes[closeBracket+1] == '(' {
 				closeParen := findClosingParenRunes(runes, closeBracket+1)
 				if closeParen > closeBracket+1 {
 					spans = append(spans, markdownSpan{start: i, end: closeParen + 1})
@@ -142,7 +144,8 @@ func parseMarkdownSpansRunes(runes []rune) []markdownSpan {
 // findClosingBracketRunes finds the closing ] for an opening [ at pos in a rune slice.
 func findClosingBracketRunes(runes []rune, pos int) int {
 	depth := 0
-	for i := pos; i < len(runes); i++ {
+	n := len(runes)
+	for i := pos; i < n; i++ {
 		switch runes[i] {
 		case '[':
 			depth++
@@ -159,7 +162,8 @@ func findClosingBracketRunes(runes []rune, pos int) int {
 // findClosingParenRunes finds the closing ) for an opening ( at pos in a rune slice.
 func findClosingParenRunes(runes []rune, pos int) int {
 	depth := 0
-	for i := pos; i < len(runes); i++ {
+	n := len(runes)
+	for i := pos; i < n; i++ {
 		switch runes[i] {
 		case '(':
 			depth++

--- a/internal/rules/catalog/wrap.go
+++ b/internal/rules/catalog/wrap.go
@@ -181,8 +181,9 @@ func findClosingParenRunes(runes []rune, pos int) int {
 // targetWidth, respecting markdown spans (not breaking inside them). It prefers
 // word boundaries (spaces) but will break before a span that exceeds the width.
 func findBreakPointRunes(runes []rune, spans []markdownSpan, targetWidth int) int {
-	if targetWidth >= len(runes) {
-		return len(runes)
+	n := len(runes)
+	if targetWidth >= n {
+		return n
 	}
 
 	// Check if targetWidth falls inside a markdown span

--- a/internal/rules/linelength/rule.go
+++ b/internal/rules/linelength/rule.go
@@ -188,11 +188,15 @@ func (r *Rule) activeMax(baseMax int, lc lineCategories, lineNum int) int {
 
 // isSkipped returns true if the line should be excluded from checking.
 func (r *Rule) isSkipped(line []byte, lineNum, limit int, lc lineCategories) bool {
-	if _, ok := lc.code[lineNum]; r.isExcluded("code-blocks") && ok {
-		return true
+	if r.isExcluded("code-blocks") {
+		if _, ok := lc.code[lineNum]; ok {
+			return true
+		}
 	}
-	if _, ok := lc.table[lineNum]; r.isExcluded("tables") && ok {
-		return true
+	if r.isExcluded("tables") {
+		if _, ok := lc.table[lineNum]; ok {
+			return true
+		}
 	}
 	if r.isExcluded("urls") && isURLOnlyLine(line) {
 		return true

--- a/internal/rules/linelength/rule.go
+++ b/internal/rules/linelength/rule.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"unicode/utf8"
@@ -157,9 +156,9 @@ func (r *Rule) DefaultSettings() map[string]any {
 // and no per-line branch. Pre-creating empty maps to "look uniform"
 // added three wasted allocations per Check before plan 195.
 type lineCategories struct {
-	code    map[int]bool
-	table   map[int]bool
-	heading map[int]bool
+	code    map[int]struct{}
+	table   map[int]struct{}
+	heading map[int]struct{}
 }
 
 func (r *Rule) buildCategories(f *lint.File) lineCategories {
@@ -178,10 +177,10 @@ func (r *Rule) buildCategories(f *lint.File) lineCategories {
 
 // activeMax returns the effective maximum for a line given its categories.
 func (r *Rule) activeMax(baseMax int, lc lineCategories, lineNum int) int {
-	if lc.heading[lineNum] && r.HeadingMax != nil {
+	if _, ok := lc.heading[lineNum]; ok && r.HeadingMax != nil {
 		return *r.HeadingMax
 	}
-	if lc.code[lineNum] && r.CodeBlockMax != nil {
+	if _, ok := lc.code[lineNum]; ok && r.CodeBlockMax != nil {
 		return *r.CodeBlockMax
 	}
 	return baseMax
@@ -189,10 +188,10 @@ func (r *Rule) activeMax(baseMax int, lc lineCategories, lineNum int) int {
 
 // isSkipped returns true if the line should be excluded from checking.
 func (r *Rule) isSkipped(line []byte, lineNum, limit int, lc lineCategories) bool {
-	if r.isExcluded("code-blocks") && lc.code[lineNum] {
+	if _, ok := lc.code[lineNum]; r.isExcluded("code-blocks") && ok {
 		return true
 	}
-	if r.isExcluded("tables") && lc.table[lineNum] {
+	if _, ok := lc.table[lineNum]; r.isExcluded("tables") && ok {
 		return true
 	}
 	if r.isExcluded("urls") && isURLOnlyLine(line) {
@@ -380,11 +379,11 @@ func hasSpacePastLimit(line []byte, limit int) bool {
 // (`^\s*\|`) with a tight byte loop; the regexp engine's internal
 // buffer rentals were the dominant per-Check allocator for this
 // helper before plan 195.
-func collectTableLines(f *lint.File) map[int]bool {
-	lines := map[int]bool{}
+func collectTableLines(f *lint.File) map[int]struct{} {
+	lines := map[int]struct{}{}
 	for i, line := range f.Lines {
 		if isTableLineStart(line) {
-			lines[i+1] = true
+			lines[i+1] = struct{}{}
 		}
 	}
 	return lines
@@ -414,8 +413,8 @@ var setextUnderlineRe = regexp.MustCompile(`^[=-]+$`)
 
 // collectHeadingLines walks the AST and returns a set of 1-based line numbers
 // that are heading lines, including Setext underlines.
-func collectHeadingLines(f *lint.File) map[int]bool {
-	lines := map[int]bool{}
+func collectHeadingLines(f *lint.File) map[int]struct{} {
+	lines := map[int]struct{}{}
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
@@ -426,12 +425,12 @@ func collectHeadingLines(f *lint.File) map[int]bool {
 		}
 		ln := headingLineNum(h, f)
 		if ln > 0 {
-			lines[ln] = true
+			lines[ln] = struct{}{}
 			// For Setext headings, also include the underline line.
 			if ln < len(f.Lines) {
-				next := strings.TrimSpace(string(f.Lines[ln])) // 0-indexed: ln is the next line
-				if setextUnderlineRe.MatchString(next) {
-					lines[ln+1] = true
+				next := bytes.TrimSpace(f.Lines[ln]) // 0-indexed: ln is the next line
+				if setextUnderlineRe.Match(next) {
+					lines[ln+1] = struct{}{}
 				}
 			}
 		}

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -287,10 +287,7 @@ func (r *Rule) skipPredicate(f *lint.File) func(int) bool {
 	piLines := lint.CollectPIBlockLines(f)
 	ranges := f.GeneratedRanges
 	return func(ln int) bool {
-		if _, ok := codeLines[ln]; ok {
-			return true
-		}
-		if _, ok := piLines[ln]; ok {
+		if lint.InCodeOrPI(codeLines, piLines, ln) {
 			return true
 		}
 		for _, gr := range ranges {

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -287,7 +287,9 @@ func (r *Rule) skipPredicate(f *lint.File) func(int) bool {
 	piLines := lint.CollectPIBlockLines(f)
 	ranges := f.GeneratedRanges
 	return func(ln int) bool {
-		if codeLines[ln] || piLines[ln] {
+		_, inCode := codeLines[ln]
+		_, inPI := piLines[ln]
+		if inCode || inPI {
 			return true
 		}
 		for _, gr := range ranges {

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -287,9 +287,10 @@ func (r *Rule) skipPredicate(f *lint.File) func(int) bool {
 	piLines := lint.CollectPIBlockLines(f)
 	ranges := f.GeneratedRanges
 	return func(ln int) bool {
-		_, inCode := codeLines[ln]
-		_, inPI := piLines[ln]
-		if inCode || inPI {
+		if _, ok := codeLines[ln]; ok {
+			return true
+		}
+		if _, ok := piLines[ln]; ok {
 			return true
 		}
 		for _, gr := range ranges {

--- a/internal/rules/noduplicateheadings/rule.go
+++ b/internal/rules/noduplicateheadings/rule.go
@@ -55,7 +55,8 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 				RuleID:   r.ID(),
 				RuleName: r.Name(),
 				Severity: lint.Warning,
-				Message:  "duplicate heading " + strconv.Quote(text) + " (first defined on line " + strconv.Itoa(firstLine) + ")",
+				Message: "duplicate heading " + strconv.Quote(text) +
+					" (first defined on line " + strconv.Itoa(firstLine) + ")",
 			})
 		} else {
 			seen[text] = line

--- a/internal/rules/noduplicateheadings/rule.go
+++ b/internal/rules/noduplicateheadings/rule.go
@@ -1,7 +1,7 @@
 package noduplicateheadings
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -55,7 +55,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 				RuleID:   r.ID(),
 				RuleName: r.Name(),
 				Severity: lint.Warning,
-				Message:  fmt.Sprintf("duplicate heading %q (first defined on line %d)", text, firstLine),
+				Message:  "duplicate heading " + strconv.Quote(text) + " (first defined on line " + strconv.Itoa(firstLine) + ")",
 			})
 		} else {
 			seen[text] = line

--- a/internal/rules/nohardtabs/rule.go
+++ b/internal/rules/nohardtabs/rule.go
@@ -30,7 +30,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			continue
 		}
 		idx := bytes.IndexByte(line, '\t')
@@ -55,7 +55,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	result := make([]string, 0, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			result = append(result, string(line))
 			continue
 		}

--- a/internal/rules/nomultipleblanks/rule.go
+++ b/internal/rules/nomultipleblanks/rule.go
@@ -50,7 +50,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	consecutiveBlanks := 0
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			consecutiveBlanks = 0
 			continue
 		}
@@ -82,7 +82,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	consecutiveBlanks := 0
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			result = append(result, string(line))
 			consecutiveBlanks = 0
 			continue

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -227,21 +227,27 @@ func collectReferenceDefinitions(f *lint.File) []referenceDefinition {
 		labelStart, labelEnd, ok := scanRefDefLine(source, lineStart, eol)
 		if ok {
 			raw := source[labelStart:labelEnd]
-			if _, inCode := codeLines[lineNum]; labelInRefs(raw, refs) && !inCode {
-				bracketAbs := labelStart - 1
-				end := eol
-				// Include the trailing newline so a fix can drop the
-				// line cleanly.
-				if end < len(source) && source[end] == '\n' {
-					end++
+			// labelInRefs normalizes and scans, so check it first; the
+			// codeLines membership is only consulted when the label is
+			// actually referenced, keeping the && short-circuit the
+			// previous `labelInRefs(...) && !codeLines[lineNum]` had.
+			if labelInRefs(raw, refs) {
+				if _, inCode := codeLines[lineNum]; !inCode {
+					bracketAbs := labelStart - 1
+					end := eol
+					// Include the trailing newline so a fix can drop
+					// the line cleanly.
+					if end < len(source) && source[end] == '\n' {
+						end++
+					}
+					out = append(out, referenceDefinition{
+						label: string(raw),
+						line:  lineNum,
+						col:   f.ColumnOfOffset(bracketAbs),
+						start: lineStart,
+						end:   end,
+					})
 				}
-				out = append(out, referenceDefinition{
-					label: string(raw),
-					line:  lineNum,
-					col:   f.ColumnOfOffset(bracketAbs),
-					start: lineStart,
-					end:   end,
-				})
 			}
 		}
 		if eol >= len(source) {

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -227,7 +227,7 @@ func collectReferenceDefinitions(f *lint.File) []referenceDefinition {
 		labelStart, labelEnd, ok := scanRefDefLine(source, lineStart, eol)
 		if ok {
 			raw := source[labelStart:labelEnd]
-			if labelInRefs(raw, refs) && !codeLines[lineNum] {
+			if _, inCode := codeLines[lineNum]; labelInRefs(raw, refs) && !inCode {
 				bracketAbs := labelStart - 1
 				end := eol
 				// Include the trailing newline so a fix can drop the
@@ -362,7 +362,7 @@ var footnoteRefRE = regexp.MustCompile(`\[\^([^\]\n]+)\]`)
 var footnoteDefRE = regexp.MustCompile(`(?m)^[ ]{0,3}\[\^([^\]\n]+)\]:`)
 
 func scanFootnoteReferences(
-	f *lint.File, codeLines map[int]bool, codeSpans []byteRange,
+	f *lint.File, codeLines map[int]struct{}, codeSpans []byteRange,
 ) []footnoteOccurrence {
 	source := f.Source
 	matches := footnoteRefRE.FindAllSubmatchIndex(source, -1)
@@ -374,7 +374,7 @@ func scanFootnoteReferences(
 			continue
 		}
 		line := f.LineOfOffset(start)
-		if codeLines[line] {
+		if _, ok := codeLines[line]; ok {
 			continue
 		}
 		if rangeContains(codeSpans, start) {
@@ -392,7 +392,7 @@ func scanFootnoteReferences(
 }
 
 func scanFootnoteDefinitions(
-	f *lint.File, codeLines map[int]bool,
+	f *lint.File, codeLines map[int]struct{},
 ) []footnoteOccurrence {
 	source := f.Source
 	matches := footnoteDefRE.FindAllSubmatchIndex(source, -1)
@@ -400,7 +400,7 @@ func scanFootnoteDefinitions(
 	for _, m := range matches {
 		start := m[0]
 		line := f.LineOfOffset(start)
-		if codeLines[line] {
+		if _, ok := codeLines[line]; ok {
 			continue
 		}
 		out = append(out, footnoteOccurrence{
@@ -452,10 +452,10 @@ func footnotePlacementMessage(
 	defs []footnoteOccurrence,
 	source []byte,
 ) string {
-	defLines := map[int]bool{}
+	defLines := map[int]struct{}{}
 	hasMatchingSlug := false
 	for _, d := range defs {
-		defLines[d.line] = true
+		defLines[d.line] = struct{}{}
 		if d.slug == ref.slug {
 			hasMatchingSlug = true
 		}
@@ -479,10 +479,13 @@ func footnotePlacementMessage(
 // belonging to the paragraph that contains `line`. The paragraph
 // stops at the next blank line, the next footnote definition, or
 // end of file.
-func paragraphEndLine(source []byte, line int, defLines map[int]bool) int {
+func paragraphEndLine(source []byte, line int, defLines map[int]struct{}) int {
 	lines := bytes.Split(source, []byte("\n"))
 	end := line
-	for end < len(lines) && !isBlankLine(lines[end]) && !defLines[end+1] {
+	for end < len(lines) && !isBlankLine(lines[end]) {
+		if _, ok := defLines[end+1]; ok {
+			break
+		}
 		end++
 	}
 	return end

--- a/internal/rules/notrailingspaces/rule.go
+++ b/internal/rules/notrailingspaces/rule.go
@@ -30,7 +30,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			continue
 		}
 		trimmed := bytes.TrimRight(line, " \t")
@@ -55,7 +55,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	result := make([]string, 0, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			result = append(result, string(line))
 			continue
 		}

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -267,15 +267,8 @@ func (r *Rule) scanFullRefs(
 			continue
 		}
 		line := f.LineOfOffset(open1)
-		if _, ok := codeLines[line]; ok {
-			pos = ca2
-			continue
-		}
-		if _, ok := piLines[line]; ok {
-			pos = ca2
-			continue
-		}
-		if inCodeSpan(spans, open1) || isEscapedBracket(source, open1) {
+		if lint.InCodeOrPI(codeLines, piLines, line) ||
+			inCodeSpan(spans, open1) || isEscapedBracket(source, open1) {
 			pos = ca2
 			continue
 		}
@@ -331,15 +324,8 @@ func (r *Rule) scanCollapsedRefs(
 			continue
 		}
 		line := f.LineOfOffset(open)
-		if _, ok := codeLines[line]; ok {
-			pos = ca + 2
-			continue
-		}
-		if _, ok := piLines[line]; ok {
-			pos = ca + 2
-			continue
-		}
-		if inCodeSpan(spans, open) || isEscapedBracket(source, open) {
+		if lint.InCodeOrPI(codeLines, piLines, line) ||
+			inCodeSpan(spans, open) || isEscapedBracket(source, open) {
 			pos = ca + 2
 			continue
 		}
@@ -410,15 +396,8 @@ func (r *Rule) scanShortcutRefs(
 			}
 		}
 		line := f.LineOfOffset(open)
-		if _, ok := codeLines[line]; ok {
-			pos = ca
-			continue
-		}
-		if _, ok := piLines[line]; ok {
-			pos = ca
-			continue
-		}
-		if inCodeSpan(spans, open) || isEscapedBracket(source, open) {
+		if lint.InCodeOrPI(codeLines, piLines, line) ||
+			inCodeSpan(spans, open) || isEscapedBracket(source, open) {
 			pos = ca
 			continue
 		}

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -240,7 +240,7 @@ func (r *Rule) scanFullRefs(
 	f *lint.File,
 	defs []string,
 	spans []byteRange,
-	codeLines, piLines map[int]bool,
+	codeLines, piLines map[int]struct{},
 ) []lint.Diagnostic {
 	source := f.Source
 	var diags []lint.Diagnostic
@@ -267,7 +267,9 @@ func (r *Rule) scanFullRefs(
 			continue
 		}
 		line := f.LineOfOffset(open1)
-		if codeLines[line] || piLines[line] ||
+		_, inCode := codeLines[line]
+		_, inPI := piLines[line]
+		if inCode || inPI ||
 			inCodeSpan(spans, open1) || isEscapedBracket(source, open1) {
 			pos = ca2
 			continue
@@ -303,7 +305,7 @@ func (r *Rule) scanCollapsedRefs(
 	f *lint.File,
 	defs []string,
 	spans []byteRange,
-	codeLines, piLines map[int]bool,
+	codeLines, piLines map[int]struct{},
 ) []lint.Diagnostic {
 	source := f.Source
 	var diags []lint.Diagnostic
@@ -324,7 +326,9 @@ func (r *Rule) scanCollapsedRefs(
 			continue
 		}
 		line := f.LineOfOffset(open)
-		if codeLines[line] || piLines[line] ||
+		_, inCode := codeLines[line]
+		_, inPI := piLines[line]
+		if inCode || inPI ||
 			inCodeSpan(spans, open) || isEscapedBracket(source, open) {
 			pos = ca + 2
 			continue
@@ -362,7 +366,7 @@ func (r *Rule) scanShortcutRefs(
 	f *lint.File,
 	defs []string,
 	spans []byteRange,
-	codeLines, piLines map[int]bool,
+	codeLines, piLines map[int]struct{},
 	shortcutMode string,
 ) []lint.Diagnostic {
 	source := f.Source
@@ -396,12 +400,14 @@ func (r *Rule) scanShortcutRefs(
 			}
 		}
 		line := f.LineOfOffset(open)
-		if codeLines[line] || piLines[line] ||
+		_, inCode := codeLines[line]
+		_, inPI := piLines[line]
+		if inCode || inPI ||
 			inCodeSpan(spans, open) || isEscapedBracket(source, open) {
 			pos = ca
 			continue
 		}
-		if defLines[line] {
+		if _, ok := defLines[line]; ok {
 			pos = ca
 			continue
 		}
@@ -433,14 +439,14 @@ func (r *Rule) scanShortcutRefs(
 // contain a reference definition `[label]: dest`. The byte-level
 // scan replaces the per-line refDefStartRE.Match call (the regex
 // dispatch was small but non-zero on the alloc-budget path).
-func collectRefDefLines(source []byte) map[int]bool {
-	lines := make(map[int]bool)
+func collectRefDefLines(source []byte) map[int]struct{} {
+	lines := make(map[int]struct{})
 	lineNum := 1
 	start := 0
 	for i := 0; i <= len(source); i++ {
 		if i == len(source) || source[i] == '\n' {
 			if refDefLineStarts(source, start, i) {
-				lines[lineNum] = true
+				lines[lineNum] = struct{}{}
 			}
 			lineNum++
 			start = i + 1

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -267,10 +267,15 @@ func (r *Rule) scanFullRefs(
 			continue
 		}
 		line := f.LineOfOffset(open1)
-		_, inCode := codeLines[line]
-		_, inPI := piLines[line]
-		if inCode || inPI ||
-			inCodeSpan(spans, open1) || isEscapedBracket(source, open1) {
+		if _, ok := codeLines[line]; ok {
+			pos = ca2
+			continue
+		}
+		if _, ok := piLines[line]; ok {
+			pos = ca2
+			continue
+		}
+		if inCodeSpan(spans, open1) || isEscapedBracket(source, open1) {
 			pos = ca2
 			continue
 		}
@@ -326,10 +331,15 @@ func (r *Rule) scanCollapsedRefs(
 			continue
 		}
 		line := f.LineOfOffset(open)
-		_, inCode := codeLines[line]
-		_, inPI := piLines[line]
-		if inCode || inPI ||
-			inCodeSpan(spans, open) || isEscapedBracket(source, open) {
+		if _, ok := codeLines[line]; ok {
+			pos = ca + 2
+			continue
+		}
+		if _, ok := piLines[line]; ok {
+			pos = ca + 2
+			continue
+		}
+		if inCodeSpan(spans, open) || isEscapedBracket(source, open) {
 			pos = ca + 2
 			continue
 		}
@@ -400,10 +410,15 @@ func (r *Rule) scanShortcutRefs(
 			}
 		}
 		line := f.LineOfOffset(open)
-		_, inCode := codeLines[line]
-		_, inPI := piLines[line]
-		if inCode || inPI ||
-			inCodeSpan(spans, open) || isEscapedBracket(source, open) {
+		if _, ok := codeLines[line]; ok {
+			pos = ca
+			continue
+		}
+		if _, ok := piLines[line]; ok {
+			pos = ca
+			continue
+		}
+		if inCodeSpan(spans, open) || isEscapedBracket(source, open) {
 			pos = ca
 			continue
 		}

--- a/internal/rules/nounusedlinkdefinitions/rule.go
+++ b/internal/rules/nounusedlinkdefinitions/rule.go
@@ -328,23 +328,20 @@ func collectDefinitions(f *lint.File) []referenceDefinition {
 					piLines = lint.CollectPIBlockLines(f)
 					blockLinesReady = true
 				}
-				_, inCode := codeLines[lineNum]
-				if !inCode {
-					_, inPI := piLines[lineNum]
-					if !inPI && !lineInGeneratedRanges(lineNum, f.GeneratedRanges) {
-						bracketAbs := labelStart - 1
-						end := eol
-						if end < len(source) && source[end] == '\n' {
-							end++
-						}
-						out = append(out, referenceDefinition{
-							rawLabel: rawLabel,
-							line:     lineNum,
-							col:      f.ColumnOfOffset(bracketAbs),
-							start:    lineStart,
-							end:      end,
-						})
+				if !lint.InCodeOrPI(codeLines, piLines, lineNum) &&
+					!lineInGeneratedRanges(lineNum, f.GeneratedRanges) {
+					bracketAbs := labelStart - 1
+					end := eol
+					if end < len(source) && source[end] == '\n' {
+						end++
 					}
+					out = append(out, referenceDefinition{
+						rawLabel: rawLabel,
+						line:     lineNum,
+						col:      f.ColumnOfOffset(bracketAbs),
+						start:    lineStart,
+						end:      end,
+					})
 				}
 			}
 		}

--- a/internal/rules/nounusedlinkdefinitions/rule.go
+++ b/internal/rules/nounusedlinkdefinitions/rule.go
@@ -329,21 +329,22 @@ func collectDefinitions(f *lint.File) []referenceDefinition {
 					blockLinesReady = true
 				}
 				_, inCode := codeLines[lineNum]
-				_, inPI := piLines[lineNum]
-				if !inCode && !inPI &&
-					!lineInGeneratedRanges(lineNum, f.GeneratedRanges) {
-					bracketAbs := labelStart - 1
-					end := eol
-					if end < len(source) && source[end] == '\n' {
-						end++
+				if !inCode {
+					_, inPI := piLines[lineNum]
+					if !inPI && !lineInGeneratedRanges(lineNum, f.GeneratedRanges) {
+						bracketAbs := labelStart - 1
+						end := eol
+						if end < len(source) && source[end] == '\n' {
+							end++
+						}
+						out = append(out, referenceDefinition{
+							rawLabel: rawLabel,
+							line:     lineNum,
+							col:      f.ColumnOfOffset(bracketAbs),
+							start:    lineStart,
+							end:      end,
+						})
 					}
-					out = append(out, referenceDefinition{
-						rawLabel: rawLabel,
-						line:     lineNum,
-						col:      f.ColumnOfOffset(bracketAbs),
-						start:    lineStart,
-						end:      end,
-					})
 				}
 			}
 		}

--- a/internal/rules/nounusedlinkdefinitions/rule.go
+++ b/internal/rules/nounusedlinkdefinitions/rule.go
@@ -307,7 +307,7 @@ func collectDefinitions(f *lint.File) []referenceDefinition {
 	}
 
 	var (
-		codeLines, piLines map[int]bool
+		codeLines, piLines map[int]struct{}
 		blockLinesReady    bool
 		out                []referenceDefinition
 	)
@@ -328,7 +328,9 @@ func collectDefinitions(f *lint.File) []referenceDefinition {
 					piLines = lint.CollectPIBlockLines(f)
 					blockLinesReady = true
 				}
-				if !codeLines[lineNum] && !piLines[lineNum] &&
+				_, inCode := codeLines[lineNum]
+				_, inPI := piLines[lineNum]
+				if !inCode && !inPI &&
 					!lineInGeneratedRanges(lineNum, f.GeneratedRanges) {
 					bracketAbs := labelStart - 1
 					end := eol

--- a/internal/rules/tablefmt/find_tables_test.go
+++ b/internal/rules/tablefmt/find_tables_test.go
@@ -25,6 +25,23 @@ func TestTryParseTable_FirstLineHasPipeButNotTableRow(t *testing.T) {
 	assert.Equal(t, 0, end)
 }
 
+// TestTryParseTable_SeparatorLineInCodeBlock covers the
+// `codeLines[start+2]` guard: a header-shaped first row whose
+// separator row (1-based line start+2) sits inside a fenced or
+// indented code block is not a real table, so tryParseTable bails
+// out. With start == 0 the separator is 1-based line 2, so a
+// codeLines set containing 2 trips the guard.
+func TestTryParseTable_SeparatorLineInCodeBlock(t *testing.T) {
+	lines := [][]byte{
+		[]byte("| Col | Col2 |"),
+		[]byte("|-----|------|"),
+	}
+	codeLines := map[int]struct{}{2: {}}
+	tbl, end := tryParseTable(lines, 0, codeLines)
+	require.Nil(t, tbl, "expected nil when the separator row is inside a code block")
+	assert.Equal(t, 0, end)
+}
+
 // TestFindTables_SkipsNonPipeLines covers the plan-195 fast-path
 // in findTables that skips tryParseTable on lines without `|`.
 // Pinning the behaviour anchors the optimisation against an

--- a/internal/rules/tablefmt/find_tables_test.go
+++ b/internal/rules/tablefmt/find_tables_test.go
@@ -40,7 +40,7 @@ func TestFindTables_SkipsNonPipeLines(t *testing.T) {
 		[]byte("|-----|------|"),
 		[]byte("| a   | b    |"),
 	}
-	got := findTables(lines, map[int]bool{})
+	got := findTables(lines, map[int]struct{}{})
 	require.Len(t, got, 1)
 	assert.Equal(t, 5, got[0].startLine)
 }

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -247,8 +247,10 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]struct{}) (*tabl
 	}
 
 	// Need at least 2 lines (header + separator).
-	_, nextInCode := codeLines[start+2]
-	if start+1 >= len(lines) || nextInCode {
+	if start+1 >= len(lines) {
+		return nil, start
+	}
+	if _, ok := codeLines[start+2]; ok {
 		return nil, start
 	}
 

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -90,7 +90,7 @@ func FormatStringWithConfig(s string, cfg Config) string {
 // Violations returns the formatting violations found in lines. codeLines
 // maps 1-based line numbers known to sit inside a fenced or indented
 // code block; those lines are skipped.
-func Violations(lines [][]byte, codeLines map[int]bool, cfg Config) []Violation {
+func Violations(lines [][]byte, codeLines map[int]struct{}, cfg Config) []Violation {
 	tables := findTables(lines, codeLines)
 	cfg = normalizeConfig(cfg)
 
@@ -111,7 +111,7 @@ func Violations(lines [][]byte, codeLines map[int]bool, cfg Config) []Violation 
 // FormatLines rewrites every table found in source with canonical
 // formatting, preserving everything else. lines must be the result of
 // splitting source on newlines (i.e. f.Lines from internal/lint).
-func FormatLines(source []byte, lines [][]byte, codeLines map[int]bool, cfg Config) []byte {
+func FormatLines(source []byte, lines [][]byte, codeLines map[int]struct{}, cfg Config) []byte {
 	tables := findTables(lines, codeLines)
 	if len(tables) == 0 {
 		out := make([]byte, len(source))
@@ -205,12 +205,12 @@ var separatorRe = regexp.MustCompile(`^:?-+:?$`)
 // otherwise pay — on every non-pipe line. On real corpora most
 // lines have no `|`, so the per-Check overhead drops to the cost of
 // scanning the lines that could plausibly start a table.
-func findTables(lines [][]byte, codeLines map[int]bool) []table {
+func findTables(lines [][]byte, codeLines map[int]struct{}) []table {
 	var tables []table
 	i := 0
 	for i < len(lines) {
 		lineNum := i + 1 // 1-based
-		if codeLines[lineNum] {
+		if _, ok := codeLines[lineNum]; ok {
 			i++
 			continue
 		}
@@ -233,7 +233,7 @@ func findTables(lines [][]byte, codeLines map[int]bool) []table {
 // Returns the table and the index of the line after the table, or nil if
 // no table starts here. A valid table must have at least a header row and
 // a separator row.
-func tryParseTable(lines [][]byte, start int, codeLines map[int]bool) (*table, int) {
+func tryParseTable(lines [][]byte, start int, codeLines map[int]struct{}) (*table, int) {
 	if start >= len(lines) {
 		return nil, start
 	}
@@ -247,7 +247,8 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]bool) (*table, i
 	}
 
 	// Need at least 2 lines (header + separator).
-	if start+1 >= len(lines) || codeLines[start+2] {
+	_, nextInCode := codeLines[start+2]
+	if start+1 >= len(lines) || nextInCode {
 		return nil, start
 	}
 
@@ -278,7 +279,7 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]bool) (*table, i
 	// Data rows.
 	end := start + 2
 	for end < len(lines) {
-		if codeLines[end+1] { // end is 0-based, codeLines is 1-based
+		if _, ok := codeLines[end+1]; ok { // end is 0-based, codeLines is 1-based
 			break
 		}
 		rowContent := stripPrefix(lines[end], prefix)

--- a/internal/rules/tablefmt/tablefmt_test.go
+++ b/internal/rules/tablefmt/tablefmt_test.go
@@ -168,7 +168,7 @@ func TestFindTables_FirstLineInCodeBlock_Skipped(t *testing.T) {
 	// there.
 	src := "| a | b |\n|---|---|\n| 1 | 2 |\n"
 	lines := splitLines(src)
-	tables := findTables(lines, map[int]struct{}{1: struct{}{}})
+	tables := findTables(lines, map[int]struct{}{1: {}})
 	assert.Empty(t, tables, "no tables should be parsed when the header line is inside code")
 }
 
@@ -410,7 +410,7 @@ func TestTryParseTable_DataRowInCodeBlock(t *testing.T) {
 		[]byte("|---|---|"),
 		[]byte("| 1 | 2 |"),
 	}
-	codeLines := map[int]struct{}{3: struct{}{}} // 1-based: line 3 is in code
+	codeLines := map[int]struct{}{3: {}} // 1-based: line 3 is in code
 	tbl, end := tryParseTable(lines, 0, codeLines)
 	require.NotNil(t, tbl, "expected a valid table (header+sep only)")
 	// end should be 2 (not 3), because data row at index 2 is in code
@@ -689,7 +689,7 @@ func TestFormatLines_TableInsideSkippedCodeBlock_NotRewritten(t *testing.T) {
 		"|---|---|\n" + // 8
 		"| foo | barbaz |\n") // 9
 	lines := splitLines(string(src))
-	codeLines := map[int]struct{}{2: struct{}{}, 3: struct{}{}, 4: struct{}{}}
+	codeLines := map[int]struct{}{2: {}, 3: {}, 4: {}}
 
 	out := FormatLines(src, lines, codeLines, Config{Pad: 1})
 	outStr := string(out)

--- a/internal/rules/tablefmt/tablefmt_test.go
+++ b/internal/rules/tablefmt/tablefmt_test.go
@@ -168,7 +168,7 @@ func TestFindTables_FirstLineInCodeBlock_Skipped(t *testing.T) {
 	// there.
 	src := "| a | b |\n|---|---|\n| 1 | 2 |\n"
 	lines := splitLines(src)
-	tables := findTables(lines, map[int]bool{1: true})
+	tables := findTables(lines, map[int]struct{}{1: struct{}{}})
 	assert.Empty(t, tables, "no tables should be parsed when the header line is inside code")
 }
 
@@ -410,7 +410,7 @@ func TestTryParseTable_DataRowInCodeBlock(t *testing.T) {
 		[]byte("|---|---|"),
 		[]byte("| 1 | 2 |"),
 	}
-	codeLines := map[int]bool{3: true} // 1-based: line 3 is in code
+	codeLines := map[int]struct{}{3: struct{}{}} // 1-based: line 3 is in code
 	tbl, end := tryParseTable(lines, 0, codeLines)
 	require.NotNil(t, tbl, "expected a valid table (header+sep only)")
 	// end should be 2 (not 3), because data row at index 2 is in code
@@ -689,7 +689,7 @@ func TestFormatLines_TableInsideSkippedCodeBlock_NotRewritten(t *testing.T) {
 		"|---|---|\n" + // 8
 		"| foo | barbaz |\n") // 9
 	lines := splitLines(string(src))
-	codeLines := map[int]bool{2: true, 3: true, 4: true}
+	codeLines := map[int]struct{}{2: struct{}{}, 3: struct{}{}, 4: struct{}{}}
 
 	out := FormatLines(src, lines, codeLines, Config{Pad: 1})
 	outStr := string(out)

--- a/internal/rules/tableformat/rule.go
+++ b/internal/rules/tableformat/rule.go
@@ -164,23 +164,23 @@ func (r *Rule) config() tablefmt.Config {
 // only reads the skip set, so handing back the cache avoids a
 // per-Check allocation on the hot path. The merged map is built only
 // when one of the other inputs is non-empty.
-func formatSkipLines(f *lint.File) map[int]bool {
+func formatSkipLines(f *lint.File) map[int]struct{} {
 	code := lint.CollectCodeBlockLines(f)
 	pi := lint.CollectPIBlockLines(f)
 	gen := f.GeneratedRanges
 	if len(pi) == 0 && len(gen) == 0 {
 		return code
 	}
-	skip := make(map[int]bool, len(code)+len(pi))
+	skip := make(map[int]struct{}, len(code)+len(pi))
 	for n := range code {
-		skip[n] = true
+		skip[n] = struct{}{}
 	}
 	for n := range pi {
-		skip[n] = true
+		skip[n] = struct{}{}
 	}
 	for _, gr := range gen {
 		for n := gr.From; n <= gr.To; n++ {
-			skip[n] = true
+			skip[n] = struct{}{}
 		}
 	}
 	return skip

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -284,10 +284,7 @@ func structureSkipFunc(f *lint.File) func(int) bool {
 	pi := lint.CollectPIBlockLines(f)
 	gen := f.GeneratedRanges
 	return func(lineNum int) bool {
-		if _, ok := code[lineNum]; ok {
-			return true
-		}
-		if _, ok := pi[lineNum]; ok {
+		if lint.InCodeOrPI(code, pi, lineNum) {
 			return true
 		}
 		for _, gr := range gen {

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -284,9 +284,10 @@ func structureSkipFunc(f *lint.File) func(int) bool {
 	pi := lint.CollectPIBlockLines(f)
 	gen := f.GeneratedRanges
 	return func(lineNum int) bool {
-		_, inCode := code[lineNum]
-		_, inPI := pi[lineNum]
-		if inCode || inPI {
+		if _, ok := code[lineNum]; ok {
+			return true
+		}
+		if _, ok := pi[lineNum]; ok {
 			return true
 		}
 		for _, gr := range gen {

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -284,7 +284,9 @@ func structureSkipFunc(f *lint.File) func(int) bool {
 	pi := lint.CollectPIBlockLines(f)
 	gen := f.GeneratedRanges
 	return func(lineNum int) bool {
-		if code[lineNum] || pi[lineNum] {
+		_, inCode := code[lineNum]
+		_, inPI := pi[lineNum]
+		if inCode || inPI {
 			return true
 		}
 		for _, gr := range gen {

--- a/internal/rules/tableformat/structure_test.go
+++ b/internal/rules/tableformat/structure_test.go
@@ -31,6 +31,34 @@ func fix(t *testing.T, style, src string) string {
 	return string(applyStructureFix(f, style))
 }
 
+// TestFormatSkipLines_MergedCodeAndPI covers the merged-map branch of
+// formatSkipLines: when a file has both a code block and a PI block,
+// the function allocates a fresh set and folds the code lines into it
+// (the `for n := range code` loop) rather than returning the cached
+// code map directly. The fenced block contributes code lines and the
+// `<?toc?>` directive contributes PI lines, so both inputs are
+// non-empty and the merged path runs.
+func TestFormatSkipLines_MergedCodeAndPI(t *testing.T) {
+	src := "# Title\n\n```go\ncode\n```\n\n<?toc?>\n<?/toc?>\n"
+	f, err := lint.NewFile("merge.md", []byte(src))
+	require.NoError(t, err)
+
+	code := lint.CollectCodeBlockLines(f)
+	pi := lint.CollectPIBlockLines(f)
+	require.NotEmpty(t, code, "fenced block must yield code lines")
+	require.NotEmpty(t, pi, "toc directive must yield PI lines")
+
+	skip := formatSkipLines(f)
+	for n := range code {
+		_, ok := skip[n]
+		assert.True(t, ok, "code line %d must be in the merged skip set", n)
+	}
+	for n := range pi {
+		_, ok := skip[n]
+		assert.True(t, ok, "PI line %d must be in the merged skip set", n)
+	}
+}
+
 func TestMD058CRLFBlankLine(t *testing.T) {
 	// A CRLF file must get a CRLF blank line inserted, not a bare
 	// LF, so `mdsmith fix` does not introduce mixed line endings.

--- a/internal/rules/tablereadability/branch_coverage_test.go
+++ b/internal/rules/tablereadability/branch_coverage_test.go
@@ -12,7 +12,7 @@ import (
 // negative arm returns nil without paying detectPrefix.
 func TestTryParseTable_StartAtLastLine(t *testing.T) {
 	lines := [][]byte{[]byte("| only one row |")}
-	tbl, end := tryParseTable(lines, 0, map[int]bool{})
+	tbl, end := tryParseTable(lines, 0, map[int]struct{}{})
 	require.Nil(t, tbl)
 	require.Equal(t, 0, end)
 }
@@ -25,7 +25,7 @@ func TestTryParseTable_HeaderNotTableRow(t *testing.T) {
 		[]byte("| foo"),
 		[]byte("| bar |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, map[int]bool{})
+	tbl, _ := tryParseTable(lines, 0, map[int]struct{}{})
 	require.Nil(t, tbl)
 }
 
@@ -40,7 +40,7 @@ func TestFindTables_TryParseReturnsNil(t *testing.T) {
 		[]byte("| not a table"),
 		[]byte("just prose"),
 	}
-	got := findTables(lines, map[int]bool{})
+	got := findTables(lines, map[int]struct{}{})
 	require.Empty(t, got)
 }
 

--- a/internal/rules/tablereadability/byte_scanners_test.go
+++ b/internal/rules/tablereadability/byte_scanners_test.go
@@ -65,7 +65,7 @@ func TestFindTables_SkipsNonPipeLines(t *testing.T) {
 		[]byte("|-----|------|"),
 		[]byte("| a   | b    |"),
 	}
-	got := findTables(lines, map[int]bool{})
+	got := findTables(lines, map[int]struct{}{})
 	if len(got) != 1 {
 		t.Fatalf("findTables returned %d tables, want 1", len(got))
 	}

--- a/internal/rules/tablereadability/rule.go
+++ b/internal/rules/tablereadability/rule.go
@@ -212,10 +212,10 @@ type tableRow struct {
 
 var separatorRe = regexp.MustCompile(`^:?-+:?$`)
 
-func findTables(lines [][]byte, codeLines map[int]bool) []table {
+func findTables(lines [][]byte, codeLines map[int]struct{}) []table {
 	var tables []table
 	for i := 0; i < len(lines); {
-		if codeLines[i+1] {
+		if _, ok := codeLines[i+1]; ok {
 			i++
 			continue
 		}
@@ -242,7 +242,7 @@ func findTables(lines [][]byte, codeLines map[int]bool) []table {
 	return tables
 }
 
-func tryParseTable(lines [][]byte, start int, codeLines map[int]bool) (*table, int) {
+func tryParseTable(lines [][]byte, start int, codeLines map[int]struct{}) (*table, int) {
 	if start+1 >= len(lines) {
 		return nil, start
 	}
@@ -253,7 +253,7 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]bool) (*table, i
 		return nil, start
 	}
 
-	if codeLines[start+2] {
+	if _, ok := codeLines[start+2]; ok {
 		return nil, start
 	}
 	separator := stripPrefix(lines[start+1], prefix)
@@ -272,7 +272,7 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]bool) (*table, i
 
 	end := start + 2
 	for end < len(lines) {
-		if codeLines[end+1] {
+		if _, ok := codeLines[end+1]; ok {
 			break
 		}
 		content := stripPrefix(lines[end], prefix)

--- a/internal/rules/tablereadability/rule_coverage_test.go
+++ b/internal/rules/tablereadability/rule_coverage_test.go
@@ -275,7 +275,7 @@ func TestTryParseTable_SeparatorNotSeparatorRow(t *testing.T) {
 // tryParseTable: separator line is in a code block → return nil
 // codeLines uses 1-based line numbers; start=0, separator is at index 1 → 1-based=2
 func TestTryParseTable_SeparatorInCodeBlock(t *testing.T) {
-	codeLines := map[int]struct{}{2: struct{}{}} // 1-based line 2 = index 1 (separator)
+	codeLines := map[int]struct{}{2: {}} // 1-based line 2 = index 1 (separator)
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("|---|---|"),
@@ -288,7 +288,7 @@ func TestTryParseTable_SeparatorInCodeBlock(t *testing.T) {
 // tryParseTable: subsequent data row is in a code block → loop breaks early.
 // With start=0, end starts at 2. codeLines[end+1]=codeLines[3] means index 2 (lines[2]).
 func TestTryParseTable_DataRowInCodeBlock(t *testing.T) {
-	codeLines := map[int]struct{}{3: struct{}{}} // 1-based line 3 = index 2 (lines[2])
+	codeLines := map[int]struct{}{3: {}} // 1-based line 3 = index 2 (lines[2])
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("|---|---|"),

--- a/internal/rules/tablereadability/rule_coverage_test.go
+++ b/internal/rules/tablereadability/rule_coverage_test.go
@@ -257,7 +257,7 @@ func TestTryParseTable_SeparatorNotTableRow(t *testing.T) {
 		[]byte("just text"), // not a table row
 		[]byte("| C | D |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, map[int]bool{})
+	tbl, _ := tryParseTable(lines, 0, map[int]struct{}{})
 	assert.Nil(t, tbl, "expected nil when separator is not a table row")
 }
 
@@ -268,14 +268,14 @@ func TestTryParseTable_SeparatorNotSeparatorRow(t *testing.T) {
 		[]byte("| C | D |"), // is table row but not separator
 		[]byte("| E | F |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, map[int]bool{})
+	tbl, _ := tryParseTable(lines, 0, map[int]struct{}{})
 	assert.Nil(t, tbl, "expected nil when second line is not a separator row")
 }
 
 // tryParseTable: separator line is in a code block → return nil
 // codeLines uses 1-based line numbers; start=0, separator is at index 1 → 1-based=2
 func TestTryParseTable_SeparatorInCodeBlock(t *testing.T) {
-	codeLines := map[int]bool{2: true} // 1-based line 2 = index 1 (separator)
+	codeLines := map[int]struct{}{2: struct{}{}} // 1-based line 2 = index 1 (separator)
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("|---|---|"),
@@ -288,7 +288,7 @@ func TestTryParseTable_SeparatorInCodeBlock(t *testing.T) {
 // tryParseTable: subsequent data row is in a code block → loop breaks early.
 // With start=0, end starts at 2. codeLines[end+1]=codeLines[3] means index 2 (lines[2]).
 func TestTryParseTable_DataRowInCodeBlock(t *testing.T) {
-	codeLines := map[int]bool{3: true} // 1-based line 3 = index 2 (lines[2])
+	codeLines := map[int]struct{}{3: struct{}{}} // 1-based line 3 = index 2 (lines[2])
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("|---|---|"),


### PR DESCRIPTION
## Summary

Performance audit against `docs/development/high-performance-go.md`. Five fixes targeting the hot path (rule `Check` functions running over every workspace file), plus four additional fixes surfaced by three rounds of xhigh code review.

### Core performance fixes

**Fix 1 — `map[int]struct{}` for code/PI block line sets** (`lint/codeblocks.go`, 20+ call sites)
`CollectCodeBlockLines` and `CollectPIBlockLines` returned `map[int]bool`. The bool value is always `true`; switching to `map[int]struct{}` drops the 1-byte value per code-block line and aligns with Go 1.24 Swiss-table optimizations. Guideline: *"map[K]struct{} for sets — zero-byte value type."*

**Fix 2 — `sync.Pool` for `HeadingText` buffer** (`internal/rules/astutil/astutil.go`)
`astutil.HeadingText` allocated a fresh `bytes.Buffer` on every heading node visit. A package-scope `sync.Pool` reuses buffers across calls. Guideline: *"sync.Pool for transient state."*

**Fix 3 — Hoist `len(runes)` in `catalog/wrap.go`**
`wrapCellBr`, `parseMarkdownSpansRunes`, `findClosingBracketRunes`, `findClosingParenRunes`, and `findBreakPointRunes` recomputed `len(runes)` on every loop iteration. `n := len(runes)` before the loop removes redundant slice-header loads. Guideline: *"Skip work you don't need."*

**Fix 4 — `strconv` over `fmt.Sprintf` in `noduplicateheadings`** (`rule.go`)
The duplicate-heading diagnostic used `fmt.Sprintf("%q", text)` + `%d` — reflection machinery on every violation. Replaced with `strconv.Quote(text) + strconv.Itoa(firstLine)`. Guideline: *"strconv over fmt.Sprintf."*

**Fix 5 — Hoist `len(p)` in `containsDotDotInsideBraces`** (`catalog/rule.go`)
The glob-safety validator recomputed `len(p)` on every iteration. `n := len(p)` before the loop removes redundant string-length loads. Guideline: *"Skip work you don't need."*

**Bonus — `[]byte` stays in `linelength/rule.go`**
`collectHeadingLines` used `strings.TrimSpace(string(f.Lines[ln]))` inside the AST walk, converting bytes to string on each heading line. Replaced with `bytes.TrimSpace(f.Lines[ln])` + `regexp.Match`. Guideline: *"Stay in []byte."*

### Code review fixes (3 × xhigh passes)

**Review pass 1:**
- `tablefmt/tryParseTable`: split compound `||` condition so bounds check fires before the `map[int]struct{}` lookup — restores original short-circuit intent
- `linelength/isSkipped`: moved `isExcluded()` guards before map lookups so the common (no-exclude) path skips the map access entirely

**Review pass 2:**
- `astutil/HeadingText`: changed `headingTextPool.Put(buf)` to use `defer` so the buffer is returned to the pool even if `ExtractText` panics — mirrors `mdtext.ExtractPlainText`'s established pattern
- `catalog/wrap.go findBreakPointRunes`: hoisted `n := len(runes)` for consistency with every other function in the same file that received this treatment

**Review pass 3:**
- `astutil/HeadingText`: added `headingTextMaxPooledCap = 4*1024` cap guard to the defer — oversized buffers are discarded rather than retained, preventing LSP long-running process memory bloat (mirrors `mdtext.extractTextMaxPooledCap` pattern from PR #368)

## Test plan

- [x] `go test ./...` — all 118 packages pass
- [x] `go build ./...` — clean build, no warnings
- [x] `go vet ./...` — clean
- [x] Three rounds of xhigh code review — all findings addressed

## References

- `docs/development/high-performance-go.md` — the guideline this PR audits against

https://claude.ai/code/session_01EFgMjFavnhMrkMX4KsLCBz