### PR TITLE
ci: bump pinned mdsmith baseline to v0.32.0

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -12,8 +12,8 @@ runs:
         # Bump here only when intentionally updating that baseline.
         # After bumping, scan PLAN.md for plans waiting to adopt the
         # newly-released syntax. See docs/development/adopt-new-directive-syntax.md.
-        MDSMITH_VERSION: v0.31.0
-        MDSMITH_SHA256: 030f3b65e7060b2c5e66bbf8dc4c7bdf18904165cef32dc9c66cb7dac01d957d
+        MDSMITH_VERSION: v0.32.0
+        MDSMITH_SHA256: fc37f218a97aef4702244559ddd15842e1c9c608d8493e5911185dae570f34d8
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.


### PR DESCRIPTION
## Summary

Bumps the pinned compatibility-baseline mdsmith binary used by the
`mdsmith-fixed-version` CI job and the merge tooling from **v0.31.0 → v0.32.0**.

The pin lives in `.github/actions/setup-mdsmith-pinned-version/action.yml`.
Both the version string and the SHA256 are updated — the SHA256 is required
for the `sha256sum -c` verification CI runs after downloading the binary.

```
MDSMITH_VERSION: v0.31.0 → v0.32.0
MDSMITH_SHA256:  030f3b65… → fc37f218a97aef4702244559ddd15842e1c9c608d8493e5911185dae570f34d8
```

## Verification

- The new SHA256 matches the published `checksums.txt` for the v0.32.0
  release (`mdsmith-linux-amd64`).
- Downloaded the pinned binary and confirmed `sha256sum -c` → `OK` (exactly
  what CI does).
- Ran the pinned `v0.32.0` binary's `mdsmith check .` across the repo:
  **413 files checked, 0 failures** — so `mdsmith-fixed-version` stays green.

## Scope / follow-up

This PR is the pin bump only (step 2 of
[adopt-new-directive-syntax](https://github.com/jeduden/mdsmith/blob/main/docs/development/adopt-new-directive-syntax.md)).
v0.32.0 ships the new `<?include?>` `heading-offset` (plan 232) and numeric
`heading-level` (plan 233) syntax. Adopting that syntax in the repo's own
Markdown is a separate, later change — plan 233's deferred task 8 tracks it
and stays open until then.


---
_Generated by [Claude Code](https://claude.ai/code/session_012KnpY4P7cfs2z1kXAL7Gn1)_