### PR TITLE
feat(website): bento feature grid that fills any pillar size

### DIFF
--- a/website/layouts/partials/feature-grid.html
+++ b/website/layouts/partials/feature-grid.html
@@ -6,7 +6,15 @@
        the five "pillars" via each page's `group` front-matter
        field, so the homepage mirrors the README's grouped
        overview. Groups render in weight order (first
-       appearance); cards within a group render by weight. */ -}}
+       appearance); cards within a group render by weight.
+
+       Bento featured-first layout: the first card in each group
+       gets `feature-card--hero` (a 2-column anchor tile), and the
+       group's card count is stamped as `data-count` on
+       `.feature-grid`. All void-filling for non-multiple-of-3
+       counts is pure CSS keyed on `data-count` and the
+       `:last-child` / `:nth-last-child(2)` of the cards — see the
+       feature-grid rules in app.css. No per-section config. */ -}}
 {{- $features := site.GetPage "/features" -}}
 {{- if $features -}}
 {{- $pages := $features.Pages.ByWeight -}}
@@ -17,23 +25,25 @@
   {{- end -}}
 {{- end -}}
 {{- range $group := $groups }}
+  {{- $groupPages := where $pages "Params.group" $group -}}
+  {{- $count := len $groupPages -}}
   <div class="feature-group">
     <h3 class="feature-group-title">{{ $group }}</h3>
-    <div class="feature-grid">
-      {{- range (where $pages "Params.group" $group) }}
-      <a class="feature-card" href="{{ .RelPermalink }}">
+    <div class="feature-grid" data-count="{{ $count }}">
+      {{- range $i, $page := $groupPages }}
+      <a class="feature-card{{ if eq $i 0 }} feature-card--hero{{ end }}" href="{{ $page.RelPermalink }}">
         <span class="icon" aria-hidden="true">
-          <i data-lucide="{{ .Params.icon | default "check" }}" width="18" height="18"></i>
+          <i data-lucide="{{ $page.Params.icon | default "check" }}" width="{{ if eq $i 0 }}20{{ else }}18{{ end }}" height="{{ if eq $i 0 }}20{{ else }}18{{ end }}"></i>
         </span>
-        <h4>{{ .Title }}</h4>
+        <h4>{{ $page.Title }}</h4>
         {{/* Inline render so the summary's inline markup
              (code spans, links) does not nest a block <p>
              inside this wrapping <p>. summary is required by
              the `feature` kind's schema, so `mdsmith check`
              fails on an incomplete page before it can ship —
              no template-side guard needed. */}}
-        <p>{{ .RenderString (dict "display" "inline") .Params.summary }}</p>
-        {{- with .Params.rules }}
+        <p>{{ $page.RenderString (dict "display" "inline") $page.Params.summary }}</p>
+        {{- with $page.Params.rules }}
         <div class="feature-rules">
           {{ range . }}<span class="rule-chip">{{ . }}</span>{{ end }}
         </div>

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -241,6 +241,20 @@ main {
   margin: 0 0 14px;
 }
 
+/*
+ * Bento featured-first. A 3-column grid with hairline separators
+ * (the 1px gap over a --border background). The template marks the
+ * first card .feature-card--hero (spans 2 columns, to anchor the
+ * pillar) and stamps data-count="N" on .feature-grid, which drives a
+ * void-free fill at every group size 1-9 with no JS:
+ *   tail = (N - 2) mod 3  — cards left after the hero's row of three
+ *     tail 0  (2,5,8): rows fill exactly; no special rule
+ *     tail 1  (6,9)  : the lone last card spans the whole row
+ *     tail 2  (4,7)  : 2nd-to-last spans 2, last spans 1 -> 3 wide
+ *   N = 1: the hero spans the full width
+ *   N = 3: a 2-column grid — hero banner on top, two tiles beneath
+ *          (a clean "hero + two", never a wide stub)
+ */
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -250,6 +264,14 @@ main {
   border-radius: 8px;
   overflow: hidden;
 }
+.feature-card--hero { grid-column: span 2; }
+.feature-grid[data-count="1"] .feature-card--hero { grid-column: 1 / -1; }
+.feature-grid[data-count="3"] { grid-template-columns: 1fr 1fr; }
+.feature-grid[data-count="6"] .feature-card:last-child,
+.feature-grid[data-count="9"] .feature-card:last-child { grid-column: 1 / -1; }
+.feature-grid[data-count="4"] .feature-card:nth-last-child(2),
+.feature-grid[data-count="7"] .feature-card:nth-last-child(2) { grid-column: span 2; }
+
 .feature-card {
   background: var(--bg-raised);
   padding: 28px 24px;
@@ -268,7 +290,6 @@ main {
 .feature-card h4,
 .feature-card:hover h4,
 .feature-card:focus-visible h4 { color: var(--fg); }
-.feature-card p { color: var(--fg-muted); }
 .feature-more {
   margin-top: auto;
   display: inline-flex; align-items: center; gap: 5px;
@@ -300,6 +321,15 @@ main {
   background: var(--steel-50); border: 1px solid var(--border-strong);
   padding: 1px 6px; border-radius: 3px; margin-right: 4px; color: var(--steel-700);
 }
+
+/* Hero enlargements — declared after the generic .feature-card rules
+   so they win at equal specificity. The hero's hover accent moves to
+   the bottom edge, since the hero is wide rather than tall. */
+.feature-card--hero:hover,
+.feature-card--hero:focus-visible { box-shadow: inset 0 -3px 0 var(--forge-500); }
+.feature-card--hero .icon { width: 40px; height: 40px; border-radius: var(--radius-lg); }
+.feature-card--hero h4 { font-size: 20px; letter-spacing: -0.02em; }
+.feature-card--hero p { font-size: 15px; max-width: 52ch; }
 
 /* ========== INSTALL LIST ========== */
 
@@ -901,7 +931,19 @@ a.rule-ref:hover code { text-decoration: underline; }
 @media (max-width: 880px) {
   .hero-grid { grid-template-columns: 1fr; gap: 36px; }
   .hero h1 { font-size: 44px; }
-  .feature-grid { grid-template-columns: 1fr; }
+  /* Feature grid -> single column; undo every bento span and the
+     enlarged hero sizing so cards stack uniformly on small screens. */
+  .feature-grid,
+  .feature-grid[data-count="3"] { grid-template-columns: 1fr; }
+  .feature-card--hero,
+  .feature-grid[data-count="1"] .feature-card--hero,
+  .feature-grid[data-count="6"] .feature-card:last-child,
+  .feature-grid[data-count="9"] .feature-card:last-child,
+  .feature-grid[data-count="4"] .feature-card:nth-last-child(2),
+  .feature-grid[data-count="7"] .feature-card:nth-last-child(2) { grid-column: auto; }
+  .feature-card--hero .icon { width: 32px; height: 32px; border-radius: 6px; }
+  .feature-card--hero h4 { font-size: 17px; letter-spacing: -0.01em; }
+  .feature-card--hero p { font-size: 14px; max-width: none; }
   .docs-index { grid-template-columns: 1fr; }
   .docs-grid { grid-template-columns: 1fr; gap: 20px; }
   /* Standard mobile pattern: the long docs nav collapses


### PR DESCRIPTION
## Problem

The homepage feature grid was `grid-template-columns: repeat(3, 1fr)`. A pillar whose card count isn't a multiple of 3 left empty cells showing the grey container background — e.g. a **4-card pillar** rendered as a row of 3 then a single card with two grey voids beside it. A nicer fill colour wouldn't help; the space needed a different layout.

## Approach

I had three design agents each build a distinct layout — balanced adaptive matrix, bento featured-first, and editorial rows — as self-contained counts-1–9 demos, screenshotted them with headless Chromium, and picked **bento featured-first**.

- The first card in each pillar is a 2-column **hero** anchor (`.feature-card--hero`).
- The template stamps `data-count="N"` on `.feature-grid`; pure CSS keyed on the count fills the trailing row with no void:
  - lone last card spans the row (counts 6, 9)
  - second-to-last spans 2 columns (counts 4, 7)
  - **count 3** → a 2-column "hero + two" (no wide stub — and 3 is two of the five real pillars)
  - count 1 → full-width hero
- Hero enlargements are declared *after* the generic card rules so they win at equal specificity; the mobile (`≤880px`) block collapses every span back to a single column.

No JavaScript and no per-section config — add or remove a feature and the pillar re-arranges itself.

## Verification

Rendered the **real compiled `app.css`** (not a mockup) at counts 1–9, desktop and mobile, via headless Chromium. Every count is void-free and collapses cleanly on mobile. Real pillar counts today are 3, 3, 4, 4, 4.

The website is built with Hugo and isn't covered by `mdsmith check`; this is a CSS + template change only (no Go or Markdown).

https://claude.ai/code/session_014xpEPq3jaUUV82DPRsiEnM

---
_Generated by [Claude Code](https://claude.ai/code/session_014xpEPq3jaUUV82DPRsiEnM)_