### PR TITLE
perf: fix top-5 allocation issues from high-performance-go audit

### DIFF
--- a/internal/corpus/qa.go
+++ b/internal/corpus/qa.go
@@ -242,7 +242,7 @@ func ReadQAAnnotationsCSV(path string) ([]QAAnnotation, error) {
 		return nil, fmt.Errorf("read qa annotations: %w", err)
 	}
 	if len(rows) == 0 {
-		return []QAAnnotation{}, nil
+		return nil, nil
 	}
 
 	start := 0

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -63,12 +63,12 @@ func directiveDocFor(name string) (string, bool) {
 // directives rather than crashing.
 func loadDirectiveDocs(fsys fs.FS) map[string]string {
 	docs := make(map[string]string)
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	for _, fname := range directiveToDocFile {
-		if seen[fname] {
+		if _, ok := seen[fname]; ok {
 			continue
 		}
-		seen[fname] = true
+		seen[fname] = struct{}{}
 		data, err := fs.ReadFile(fsys, fname)
 		if err != nil {
 			continue
@@ -168,16 +168,19 @@ func relatedHoverLink(ri diagnosticRelatedInformation) string {
 // remediation hint. Unknown rules degrade to the code plus a
 // `mdsmith help rule` pointer.
 func ruleIdentityBlock(d Diagnostic) string {
-	header := "`" + d.Code + "`"
+	var b strings.Builder
+	b.WriteByte('`')
+	b.WriteString(d.Code)
+	b.WriteByte('`')
 	if d.Data != nil && d.Data.RuleName != "" {
-		header += " · " + d.Data.RuleName
+		b.WriteString(" · ")
+		b.WriteString(d.Data.RuleName)
 	}
 	info, ok := cachedRuleInfo(d.Code)
 	if ok && info.Description != "" {
-		header += " — " + info.Description
+		b.WriteString(" — ")
+		b.WriteString(info.Description)
 	}
-	var b strings.Builder
-	b.WriteString(header)
 	if d.CodeDescription != nil && d.CodeDescription.Href != "" {
 		fmt.Fprintf(&b, "\n\n[Open rule docs ↗](%s)", d.CodeDescription.Href)
 	} else {

--- a/internal/mdtext/mdtext.go
+++ b/internal/mdtext/mdtext.go
@@ -2,7 +2,7 @@ package mdtext
 
 import (
 	"bytes"
-	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -50,7 +50,7 @@ type TOCItem struct {
 // base slug matches an earlier heading's disambiguated anchor.
 func CollectTOCItems(root ast.Node, source []byte) []TOCItem {
 	var items []TOCItem
-	usedAnchors := make(map[string]bool)
+	usedAnchors := make(map[string]struct{})
 	slugCounts := make(map[string]int)
 	_ = ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -68,19 +68,19 @@ func CollectTOCItems(root ast.Node, source []byte) []TOCItem {
 
 		// Find a unique anchor by incrementing suffix until unused.
 		anchor := slug
-		if usedAnchors[anchor] {
+		if _, used := usedAnchors[anchor]; used {
 			count := slugCounts[slug]
 			for {
 				count++
-				anchor = fmt.Sprintf("%s-%d", slug, count)
-				if !usedAnchors[anchor] {
+				anchor = slug + "-" + strconv.Itoa(count)
+				if _, used = usedAnchors[anchor]; !used {
 					break
 				}
 			}
 			slugCounts[slug] = count
 		}
 
-		usedAnchors[anchor] = true
+		usedAnchors[anchor] = struct{}{}
 		items = append(items, TOCItem{Level: h.Level, Text: text, Anchor: anchor})
 		return ast.WalkContinue, nil
 	})

--- a/internal/mdtext/mdtext_test.go
+++ b/internal/mdtext/mdtext_test.go
@@ -415,6 +415,17 @@ func TestCollectTOCItems_Empty(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestCollectTOCItems_SuffixCollision(t *testing.T) {
+	// "Foo", then "Foo-1" (explicit), then another "Foo": the auto-generated
+	// "foo-1" is already taken, so the second duplicate must become "foo-2".
+	doc, src := parseDoc(t, "## Foo\n\n## Foo-1\n\n## Foo\n")
+	items := mdtext.CollectTOCItems(doc, src)
+	require.Len(t, items, 3)
+	assert.Equal(t, "foo", items[0].Anchor)
+	assert.Equal(t, "foo-1", items[1].Anchor)
+	assert.Equal(t, "foo-2", items[2].Anchor)
+}
+
 func TestCollectTOCItems_HeadingWithEmptySlug(t *testing.T) {
 	// A heading consisting only of punctuation produces an empty slug and
 	// is skipped.

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -574,6 +574,8 @@ func countCells(content string) int {
 
 // countUnescapedPipes counts the number of unescaped '|' characters in s.
 // A '\|' pair is treated as one escaped-pipe literal, not a cell delimiter.
+// The escape rule is identical to containsUnescapedPipe — both must stay in sync
+// if tablefmt's GFM escape semantics ever change.
 func countUnescapedPipes(s string) int {
 	n := 0
 	for i := 0; i < len(s); i++ {

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -553,15 +553,39 @@ func logicalCells(content string) []string {
 
 // countCells returns the logical cell count of a row. A row that is
 // only edge pipes or empty has no cells.
+//
+// This avoids allocating a []string via logicalCells: it strips edge
+// pipes directly, then counts unescaped interior pipes.
 func countCells(content string) int {
-	cells := logicalCells(content)
-	if len(cells) == 1 && strings.TrimSpace(cells[0]) == "" {
-		t := strings.TrimSpace(content)
-		if t == "" || t == "|" {
-			return 0
+	t := strings.TrimSpace(content)
+	if t == "" || t == "|" {
+		return 0
+	}
+	s := strings.TrimPrefix(t, "|")
+	if endsWithUnescapedPipe(s) {
+		s = s[:len(s)-1]
+	}
+	if strings.TrimSpace(s) == "" {
+		// Bordered row like "|  |" has one empty cell, not zero.
+		return 1
+	}
+	return countUnescapedPipes(s) + 1
+}
+
+// countUnescapedPipes counts the number of unescaped '|' characters in s.
+// A '\|' pair is treated as one escaped-pipe literal, not a cell delimiter.
+func countUnescapedPipes(s string) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && s[i+1] == '|' {
+			i++ // skip escaped pipe
+			continue
+		}
+		if s[i] == '|' {
+			n++
 		}
 	}
-	return len(cells)
+	return n
 }
 
 // splitCells splits a row body on unescaped pipes. A `\|` pair is

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -551,8 +551,10 @@ func logicalCells(content string) []string {
 	return splitCells(t)
 }
 
-// countCells returns the logical cell count of a row. A row that is
-// only edge pipes or empty has no cells.
+// countCells returns the logical cell count of a row. An empty row or
+// a row consisting of a single bare pipe ("|") has zero cells. A
+// bordered row whose interior is all whitespace (e.g. "|  |") has one
+// empty cell, not zero.
 //
 // This avoids allocating a []string via logicalCells: it strips edge
 // pipes directly, then counts unescaped interior pipes.

--- a/internal/rules/tableformat/structure_test.go
+++ b/internal/rules/tableformat/structure_test.go
@@ -313,6 +313,19 @@ func TestCountCellsDegenerate(t *testing.T) {
 	assert.Equal(t, 2, countCells("a | b"))
 }
 
+func TestCountUnescapedPipes(t *testing.T) {
+	assert.Equal(t, 0, countUnescapedPipes(""))
+	assert.Equal(t, 0, countUnescapedPipes("text"))
+	assert.Equal(t, 1, countUnescapedPipes("a|b"))
+	assert.Equal(t, 2, countUnescapedPipes("a|b|c"))
+	// Escaped pipe \| is not a cell delimiter.
+	assert.Equal(t, 0, countUnescapedPipes(`\|`))
+	// Escaped pipe followed by a real pipe: only the real one counts.
+	assert.Equal(t, 1, countUnescapedPipes(`\||`))
+	// Multiple escaped pipes with no real pipe.
+	assert.Equal(t, 0, countUnescapedPipes(`\|\|`))
+}
+
 func TestEscapedPipeIsOneCell(t *testing.T) {
 	// `a \| b` is a single cell; the escaped pipe must not split it.
 	src := "# T\n\n| A      | B |\n| ------ | - |\n| a \\| b | c |\n"


### PR DESCRIPTION
## Summary

Codebase audit against [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md) surfaced five concrete violations. This PR fixes the top 5, ranked by severity and call-frequency impact, then addresses all issues found in three rounds of xhigh code review.

| # | Location | Guideline violated | Fix |
|---|----------|--------------------|-----|
| 1 | `internal/rules/tableformat/structure.go` — `countCells()` | Avoid unnecessary allocations; cheapest call is the one never made | Replace `logicalCells()` call (allocates `[]string`) with zero-alloc `countUnescapedPipes` helper |
| 2 | `internal/lsp/hover.go` — `ruleIdentityBlock()` | `strings.Builder` over `+` | Write each part directly to the builder; eliminates 1–3 intermediate string allocations per hover |
| 3 | `internal/mdtext/mdtext.go` — `CollectTOCItems` | `strconv` over `fmt.Sprintf`; `map[K]struct{}` for sets | `fmt.Sprintf("%s-%d")` → `slug + "-" + strconv.Itoa(count)`; `map[string]bool` → `map[string]struct{}` |
| 4 | `internal/lsp/hover.go` — `loadDirectiveDocs` | `map[K]struct{}` for sets | `map[string]bool` → `map[string]struct{}` |
| 5 | `internal/corpus/qa.go` — `ReadAnnotations` | Return `nil` not `[]T{}` | `return []QAAnnotation{}, nil` → `return nil, nil` |

### Impact detail

**Issue 1 is the most impactful.** `countCells` is called from `parseRow` and `isHeader` for every table row in every workspace file. The old path (via `logicalCells` → `splitCells`) allocated a `[]string` and one `strings.Builder` backing array per cell on every call — a likely violation of the ≤10 allocs/Check budget for table-heavy files. The new `countUnescapedPipes` helper scans bytes directly with zero heap allocations.

## Code review findings addressed (3 × xhigh rounds)

| Round | Finding | Action |
|-------|---------|--------|
| 1 | `countUnescapedPipes` loop identical to `containsUnescapedPipe` — maintenance coupling | Added cross-reference comment linking the two; preserves early-exit performance |
| 3 | `countUnescapedPipes` lacked a direct unit test | Added `TestCountUnescapedPipes` (7 cases: empty, no-pipe, 1 pipe, 2 pipes, escaped-only, escaped+real, multiple escaped) |
| 3 | `CollectTOCItems` had no test for suffix-collision case | Added `TestCollectTOCItems_SuffixCollision` (Foo / Foo-1 / Foo → foo / foo-1 / foo-2) |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `go run ./cmd/mdsmith check .` — 413 files, 0 failures
- [x] Codecov: all modified lines covered, project coverage 97.42%

https://claude.ai/code/session_01XBqqaUB8dTXUm1NMTk4cq9