### PR TITLE
fix(website): relabel install strip "Published to" → "Available on"

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -105,7 +105,7 @@ release-channel docs, gated against drift in CI:
   `hugo.Data.channels` (the generated
   `website/data/channels.yaml`). It renders every channel
   with platform-tag filter chips.
-- **"Published to" strip** — the release-channel docs
+- **"Available on" strip** — the release-channel docs
   `../docs/development/release-channels/*.md`. Each
   carries a canonical `channelurl:` and an ordering
   `weight:`; `logos-strip.html` ranges the synced

--- a/website/layouts/partials/logos-strip.html
+++ b/website/layouts/partials/logos-strip.html
@@ -1,7 +1,7 @@
 <div class="logos">
   <div class="container">
     <div class="logos-strip">
-      <span class="logos-label">Published to</span>
+      <span class="logos-label">Available on</span>
       {{- /* Sourced from the generated install data
              (website/data/channels.yaml, produced by
              `mdsmith-release sync-channels` from


### PR DESCRIPTION
## What

Rename the homepage install-channel logos strip label from **"Published to"** to **"Available on"**.

## Why

The strip (`website/layouts/partials/logos-strip.html`) is filtered to `mechanism: push` channels, which includes **Flatpak** and **Obsidian**. Those are *not* published to a registry — the `.flatpak` and `.zip` bundles are built in CI and **attached to a GitHub release**, then installed from the file (see `website/data/channels.yaml`). So "Published to Flatpak / Obsidian" was inaccurate.

"Available on" is correct for every channel in the strip — npm, PyPI, GitHub Releases, the Visual Studio Marketplace, Open VSX, Flatpak, Obsidian — regardless of whether mdsmith pushes to a registry or bundles into a release. It also matches the familiar app-store convention ("Available on …").

## Changes

- `website/layouts/partials/logos-strip.html` — label text `Published to` → `Available on`.
- `website/README.md` — update the doc reference to the strip (`"Published to" strip` → `"Available on" strip`) so docs don't drift.

## Notes

- Text-only swap inside the existing `<span class="logos-label">`; no template logic or data changed.
- `mdsmith check .` passes (413 files, 0 failures).
- No Go test asserts on the label string.

https://claude.ai/code/session_01Kt5fSEpkQWNQDsqcPzoMcv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt5fSEpkQWNQDsqcPzoMcv)_