### PR TITLE
ci: bump pinned mdsmith baseline to v0.33.0

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -12,8 +12,8 @@ runs:
         # Bump here only when intentionally updating that baseline.
         # After bumping, scan PLAN.md for plans waiting to adopt the
         # newly-released syntax. See docs/development/adopt-new-directive-syntax.md.
-        MDSMITH_VERSION: v0.32.0
-        MDSMITH_SHA256: fc37f218a97aef4702244559ddd15842e1c9c608d8493e5911185dae570f34d8
+        MDSMITH_VERSION: v0.33.0
+        MDSMITH_SHA256: 36960a577c5220c033b60ba8d992e9dc964e46c6496e45a5a76451d625c280ec
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.


### PR DESCRIPTION
## Summary

Bumps the pinned mdsmith compatibility baseline in
`.github/actions/setup-mdsmith-pinned-version/action.yml` from `v0.32.0`
to the freshly published `v0.33.0` release. This is step 2 of the
[adopt-new-directive-syntax](https://github.com/jeduden/mdsmith/blob/main/docs/development/adopt-new-directive-syntax.md)
sequence — the `v0.33.0` release is already published, so the
`mdsmith-fixed-version` job can now run a binary that parses any syntax
shipped through v0.33.0.

- `MDSMITH_VERSION`: `v0.32.0` → `v0.33.0`
- `MDSMITH_SHA256`: → `36960a577c5220c033b60ba8d992e9dc964e46c6496e45a5a76451d625c280ec`

## Verification

- SHA256 confirmed against the release `checksums.txt` entry for
  `mdsmith-linux-amd64`.
- Downloaded the `mdsmith-linux-amd64` asset, ran `sha256sum -c` (OK),
  and confirmed `mdsmith version` reports `v0.33.0`.
- Ran `mdsmith check .` with the pinned v0.33.0 binary against the repo:
  `checked=413 fixed=0 failures=0 unfixed=0` (exit 0).

https://claude.ai/code/session_01QvzojbpT9VFxBPx842erj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvzojbpT9VFxBPx842erj6)_