### PR TITLE
Fix mobile top nav overflow that left hero pinned with dead space

### DIFF
--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -108,6 +108,32 @@ main {
 }
 .topnav-gh:hover { background: var(--steel-800); color: var(--canvas); text-decoration: none; }
 
+/* Below ~500px the single-row nav (brand + section links + version
+   + GitHub) no longer fits. Unwrapped it overflowed the viewport,
+   widening the document past the screen so every section — the hero
+   most visibly — sat pinned to the left with dead space on the
+   right. Wrapping keeps the bar within the viewport and every item
+   reachable with no JS: the brand and GitHub button share the top
+   row, the section links drop to a full-width row beneath them. */
+@media (max-width: 560px) {
+  .topnav { height: auto; }
+  .topnav-inner {
+    flex-wrap: wrap;
+    column-gap: 16px;
+    row-gap: 2px;
+    padding: 8px 20px;
+  }
+  .topnav-brand { order: 1; }
+  .topnav-right { order: 2; }
+  .topnav-links {
+    order: 3;
+    flex-basis: 100%;
+    /* Offset the first link's padding so its text lines up with the
+       brand at the gutter edge. */
+    margin-left: -10px;
+  }
+}
+
 /* ========== HERO ========== */
 
 .hero {


### PR DESCRIPTION
## Problem

On mobile the homepage hero used only ~2/3 of the screen width, with a dead band of unused space on the right (see reported screenshot).

## Root cause

The top nav (`.topnav-inner`) is a single non-wrapping flex row holding the brand lockup, the section links (Guides / Reference / Rules), the version, and the GitHub button. Below ~500px those items no longer fit on one line, so the row **overflowed horizontally**. That widened the document past the viewport (e.g. a 360px viewport rendered a 502px-wide document), and because block sections size to the viewport, every section — the hero most visibly — sat pinned to the left edge with the extra scroll width showing as empty page background on the right.

The long install commands in `.install-cmd` also extend past the row, but those are contained by the existing `overflow-x: auto` (intended internal scroll) and do **not** widen the document.

## Fix

Add a `@media (max-width: 560px)` block that lets the nav wrap: the brand and GitHub button share the top row, the section links drop to a full-width row beneath. No JavaScript, so every nav item stays reachable (consistent with the site's "navigation reachable without scripting" principle).

## Verification

Built the real Hugo site and measured `document.scrollWidth` vs the viewport with headless Chromium across `320, 360, 390, 412, 480, 560, 600, 768, 880`px:

- **Before:** document stayed 502px wide for every viewport below ~500px (overflow → hero pinned left).
- **After:** `document.scrollWidth == viewport` at every width — no horizontal overflow, hero fills the full screen. Desktop (>560px) is unchanged.

CSS-only change; no Markdown touched.

https://claude.ai/code/session_014VGRNtmSwSVMuXZJfiiCBH

---
_Generated by [Claude Code](https://claude.ai/code/session_014VGRNtmSwSVMuXZJfiiCBH)_