### PR TITLE
Harden the install-picker channel loader

### DIFF
--- a/internal/release/channels.go
+++ b/internal/release/channels.go
@@ -304,14 +304,19 @@ func CheckChannelsData(root string, chs []Channel) (bool, error) {
 // Hugo template consumed, so a render probe compares the page against
 // its true input rather than a parallel source.
 func LoadChannelsFromDataFile(root string) ([]Channel, error) {
-	path := filepath.Join(root, ChannelsDataFile)
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(channelsDataPath(root))
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", ChannelsDataFile, err)
 	}
 	var chs []Channel
 	if err := yaml.Unmarshal(data, &chs); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", ChannelsDataFile, err)
+	}
+	// An empty or truncated data file unmarshals to a nil slice with
+	// no error; without this guard a render probe would expect zero
+	// install rows and pass vacuously on a broken picker.
+	if len(chs) == 0 {
+		return nil, fmt.Errorf("%s has no channels", ChannelsDataFile)
 	}
 	return chs, nil
 }

--- a/internal/release/channels_test.go
+++ b/internal/release/channels_test.go
@@ -388,4 +388,14 @@ func TestLoadChannelsFromDataFile_Errors(t *testing.T) {
 	require.NoError(t, os.WriteFile(p, []byte("title: not-a-list\n  bad: ]["), 0o644))
 	_, err = LoadChannelsFromDataFile(root)
 	require.Error(t, err)
+
+	// Present but empty (comment-only) → no channels, error rather
+	// than a silent empty slice that would pass a probe vacuously.
+	root = t.TempDir()
+	p = filepath.Join(root, ChannelsDataFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte("# generated, then emptied\n"), 0o644))
+	_, err = LoadChannelsFromDataFile(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no channels")
 }


### PR DESCRIPTION
Follow-up to the install-picker render probe that landed in #482. A post-merge `xhigh` code-review pass surfaced two minor hardening items in `LoadChannelsFromDataFile` (neither a live bug — production `channels.yaml` has 14 channels). Split out here rather than disrupting #482's merge-queue batch.

## Changes

**1. Reuse `channelsDataPath(root)`** instead of a one-off `filepath.Join(root, ChannelsDataFile)`. This matches the sibling readers/writers (`WriteChannelsData`, `CheckChannelsData`) and their `filepath.FromSlash` separator handling, so all four agree on how the slash-separated constant maps to a path.

**2. Error on zero channels.** An empty or truncated `channels.yaml` unmarshals to a nil slice with **no error**. Without a guard, `verify-install-picker` would then expect zero install rows and **pass vacuously on a broken picker** — the exact "broken picker ships green" regression the deploy-job probe exists to catch. Now the loader fails loudly, and the CLI handler surfaces it as a non-zero exit. (`channels-drift` already gates the file, so this is belt-and-suspenders.)

A new test covers the empty-file guard.

## Review

Three review→fix iterations (`xhigh`) converged: iteration 1 found these two items (plus two non-actionable: an unreachable `html.Parse` error branch and a non-constructible `TrimSpace` asymmetry); iterations 2 and 3 found nothing. The empty-set guard was confirmed to be at the right layer — the only caller of `VerifyInstallPicker` reaches it through this loader, so a second guard would be untestable redundancy.

## Verification

- `go test ./...` green · `go tool golangci-lint run` 0 issues · `mdsmith check .` 415/0

https://claude.ai/code/session_01RGBUkRscaPiT5ZfohXWUgL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGBUkRscaPiT5ZfohXWUgL)_