### PR TITLE
fix(lsp): apply quick fixes immediately; scope previewFix to fix-all

### DIFF
--- a/docs/guides/editors/vscode.md
+++ b/docs/guides/editors/vscode.md
@@ -51,12 +51,14 @@ clicked.
 Each save then fixes trailing whitespace, heading style, code
 fences, bare URLs, list indentation, and table alignment.
 
-**Preview before applying.** Enable `mdsmith.previewFix` and
-quick fixes and fix-on-save route through VS Code's Refactor
-Preview pane, so you see the diff and confirm it before it is
-written. The preview rides the code-action path above (the
-lightbulb and `editor.codeActionsOnSave`); that path carries
-the confirmation into the save.
+**Preview fix-on-save.** Enable `mdsmith.previewFix` and
+fix-on-save routes through VS Code's Refactor Preview pane, so
+you see the diff and confirm it before `source.fixAll.mdsmith`
+writes it on save. Interactive lightbulb quick fixes always
+apply immediately — they are the one fix you just chose, so
+there is nothing to confirm. To preview a single quick fix,
+use VS Code's built-in lightbulb Preview (the chevron, or
+Ctrl+Enter).
 
 **Hover for help.** Hover a diagnostic for the rule's one-line
 summary plus a link that opens its full documentation offline:
@@ -138,13 +140,13 @@ preferences go in your user settings. Changing any setting
 takes effect on the next document event, with no window
 reload.
 
-| Setting                | Default   | Purpose                                                                            |
-| ---------------------- | --------- | ---------------------------------------------------------------------------------- |
-| `mdsmith.run`          | `onType`  | When to lint: `onType` (default), `onSave`, or `off` (off stops automatic linting) |
-| `mdsmith.previewFix`   | `false`   | Show the diff (Refactor Preview) before applying a fix (quick fix or fix-on-save)  |
-| `mdsmith.config`       | `""`      | Override the `.mdsmith.yml` path (absolute or workspace)                           |
-| `mdsmith.path`         | `mdsmith` | Pin a binary; the default runs the bundled per-platform one                        |
-| `mdsmith.trace.server` | `off`     | LSP trace verbosity: `off`, `messages`, or `verbose`                               |
+| Setting                | Default   | Purpose                                                                                   |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------- |
+| `mdsmith.run`          | `onType`  | When to lint: `onType` (default), `onSave`, or `off` (off stops automatic linting)        |
+| `mdsmith.previewFix`   | `false`   | Show the diff (Refactor Preview) before fix-on-save writes; quick fixes apply immediately |
+| `mdsmith.config`       | `""`      | Override the `.mdsmith.yml` path (absolute or workspace)                                  |
+| `mdsmith.path`         | `mdsmith` | Pin a binary; the default runs the bundled per-platform one                               |
+| `mdsmith.trace.server` | `off`     | LSP trace verbosity: `off`, `messages`, or `verbose`                                      |
 
 `mdsmith.run` defaults to `onType`, so diagnostics update live
 as you type; `onSave` defers them to save, and `off` stops
@@ -155,7 +157,9 @@ Fix-on-save is configured through VS Code's native
 not through an mdsmith setting. The former `mdsmith.fixOnSave`
 toggle is now a deprecated no-op. Fix-on-save runs independently
 of `mdsmith.run`, and `mdsmith.previewFix` decides whether each
-save shows the diff before writing.
+save shows the diff before writing. `mdsmith.previewFix` governs
+fix-on-save only; interactive lightbulb quick fixes always apply
+immediately (use the lightbulb's own Preview to inspect one).
 
 ## Troubleshooting
 

--- a/docs/reference/cli/lsp.md
+++ b/docs/reference/cli/lsp.md
@@ -91,16 +91,17 @@ prints:
 - **`quickfix`** — one per fixable diagnostic. Each
   edit replaces the whole document with the output of
   running the single rule, so it covers every
-  occurrence of that rule (the action title reads
-  "Fix all `<rule>` with mdsmith"). Within one
+  occurrence of that rule. The action title is the
+  rule's own quick-fix label (e.g. "Remove trailing
+  whitespace"); a rule that supplies none falls back
+  to "Fix all `<rule>` with mdsmith". Within one
   request all quick-fix actions for the same rule
   share one `WorkspaceEdit`; the fix is run once
   regardless of how many diagnostics carry that
-  rule. Generated-section rules (catalog, toc,
-  include) regenerate the section in their fix; the
-  action surfaces normally and the title
-  ("Fix all `<rule>` with mdsmith") is explicit
-  about the whole-file scope.
+  rule. Quick fixes apply immediately (see Fix
+  preview below). Generated-section rules (catalog,
+  toc, include) regenerate the section in their fix;
+  the action surfaces normally.
 - **`source.fixAll.mdsmith`** — runs `mdsmith fix` on the
   current buffer; produces the same bytes the on-disk fixer
   would write.

--- a/docs/reference/cli/lsp.md
+++ b/docs/reference/cli/lsp.md
@@ -107,26 +107,24 @@ prints:
 
 ### Fix preview (ChangeAnnotation)
 
-Set `mdsmith.previewFix: true` to open Refactor Preview before
-any fix lands. Both capabilities below must appear in
-`initialize`:
+Set `mdsmith.previewFix: true` to preview the
+`source.fixAll.mdsmith` edit before it writes. That action
+is what fix-on-save runs. The preview is scoped to it:
+quick fixes apply right away. Both capabilities below must
+appear in `initialize`:
 
 - `workspace.workspaceEdit.documentChanges`
 - `workspace.workspaceEdit.changeAnnotationSupport`
 
-When both are present, edits use `AnnotatedTextEdit`
-(LSP 3.16) with `needsConfirmation: true`. The
-`edits` slice carries one entry per line-aligned
-diff hunk, not one whole-file replacement (which
-Refactor Preview would render as "old file → new
-file" with no visible delta). All hunks share an
-`annotationId`.
-
-Each quick fix carries the id
-`mdsmith-fix-<rule-name>`. The fix-all action uses
-`mdsmith-fix-all`. Drop either capability and the
-server emits the legacy `changes` map. A warning
-goes to `window/logMessage` once per session.
+When both are present, the `source.fixAll.mdsmith` edit
+uses `AnnotatedTextEdit` (LSP 3.16) with
+`needsConfirmation: true`. The `edits` slice carries one
+entry per line-aligned diff hunk, not one whole-file
+replacement (which Refactor Preview would render as "old
+file → new file" with no visible delta). All hunks share
+the `mdsmith-fix-all` `annotationId`. Drop either
+capability and the server emits the legacy `changes` map.
+A warning goes to `window/logMessage` once per session.
 
 ## Symbol navigation
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -49,7 +49,7 @@ code --install-extension mdsmith-<version>.vsix
 | `mdsmith.path`         | `"mdsmith"` | Binary path; default runs the bundled per-platform binary. Set an absolute path to override; falls back to PATH only if your platform was not bundled (e.g. `/go/bin/mdsmith`) |
 | `mdsmith.config`       | `""`        | Override `-c` config path                                                                                                                                                      |
 | `mdsmith.run`          | `"onType"`  | When to lint: `onType` (default), `onSave`, or `off` (off stops automatic linting)                                                                                             |
-| `mdsmith.previewFix`   | `false`     | Show the diff (Refactor Preview) before applying a fix (quick fix or fix-on-save)                                                                                              |
+| `mdsmith.previewFix`   | `false`     | Show the diff (Refactor Preview) before fix-on-save writes; quick fixes apply immediately                                                                                      |
 | `mdsmith.trace.server` | `"off"`     | LSP trace verbosity                                                                                                                                                            |
 
 Fix-on-save uses VS Code's native `editor.codeActionsOnSave`,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -162,7 +162,7 @@
         "mdsmith.previewFix": {
           "type": "boolean",
           "default": false,
-          "description": "Show the diff before applying a fix. When on, quick fixes and `source.fixAll.mdsmith` actions (including fix-on-save wired through `editor.codeActionsOnSave`) route through VS Code's Refactor Preview pane so you can inspect and confirm the diff before it is written. Requires a client that advertises both documentChanges and changeAnnotationSupport (VS Code 1.85+). Leave off to apply immediately."
+          "description": "Show the diff before applying fix-on-save. When on, the `source.fixAll.mdsmith` action (including fix-on-save wired through `editor.codeActionsOnSave`) routes through VS Code's Refactor Preview pane so you can inspect and confirm the diff before it is written. Interactive lightbulb quick fixes always apply immediately — use VS Code's built-in lightbulb Preview (the chevron / Ctrl+Enter) to preview a single fix. Requires a client that advertises both documentChanges and changeAnnotationSupport (VS Code 1.85+). Leave off to apply fix-on-save immediately."
         },
         "mdsmith.fixOnSave": {
           "type": "boolean",

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1361,6 +1361,17 @@ func (s *Server) useAnnotatedEdits() bool {
 // per-diagnostic actions, since each one would have produced the
 // same whole-file edit anyway. This keeps the latency budget bounded
 // even on files with many diagnostics from the same rule.
+//
+// mdsmith.previewFix's Refactor Preview is scoped to the
+// source.fixAll.mdsmith action only. Interactive lightbulb quick fixes
+// always apply immediately: the user picked one specific fix, so a
+// forced confirmation preview is friction — and worse, it stranded the
+// edit in a Refactor Preview pane whose Apply control is easy to miss,
+// so a second lightbulb click collided with the still-pending preview
+// ("Another refactoring is being previewed"). Preview belongs on the
+// auto-applied bulk edit (fix-on-save wires source.fixAll.mdsmith
+// through editor.codeActionsOnSave); VS Code's lightbulb still offers a
+// per-action "Preview" (the chevron / Ctrl+Enter) for a single fix.
 func (s *Server) computeCodeActions(
 	p codeActionParams, doc *document, cfg *config.Config, root string,
 ) []codeAction {
@@ -1368,14 +1379,11 @@ func (s *Server) computeCodeActions(
 	wantFixAll := wantsKind(p.Context.Only, kindSourceFixAll)
 
 	actions := make([]codeAction, 0, len(p.Context.Diagnostics)+1)
-	if wantQuickFix || wantFixAll {
-		annotated := s.useAnnotatedEdits()
-		if wantQuickFix {
-			actions = s.appendQuickFixActions(actions, p, doc, cfg, root, annotated)
-		}
-		if wantFixAll {
-			actions = s.appendFixAllAction(actions, p, doc, cfg, root, annotated)
-		}
+	if wantQuickFix {
+		actions = s.appendQuickFixActions(actions, p, doc, cfg, root)
+	}
+	if wantFixAll {
+		actions = s.appendFixAllAction(actions, p, doc, cfg, root, s.useAnnotatedEdits())
 	}
 	return actions
 }
@@ -1385,10 +1393,14 @@ func (s *Server) computeCodeActions(
 // fix.SourceWithRules call fires per distinct rule regardless of how many
 // diagnostics it covers. The same *workspaceEdit is shared across all
 // actions for the same rule so the fix only runs once even on noisy files.
+//
+// The edit is always the immediate (legacy changes-map) form, so VS Code
+// applies the quick fix the moment the user picks it — mdsmith.previewFix
+// does not route interactive quick fixes through the Refactor Preview (see
+// computeCodeActions for why).
 func (s *Server) appendQuickFixActions(
 	actions []codeAction,
 	p codeActionParams, doc *document, cfg *config.Config, root string,
-	annotated bool,
 ) []codeAction {
 	ruleEdits := make(map[string]*workspaceEdit)
 	for _, d := range p.Context.Diagnostics {
@@ -1400,8 +1412,7 @@ func (s *Server) appendQuickFixActions(
 		if !seen {
 			fixed := s.quickFixBytesFor(rule, doc, cfg, root)
 			if fixed != nil {
-				edit = buildFileEdit(p.TextDocument.URI, doc.text, fixed,
-					annotated, "mdsmith-fix-"+rule, quickFixTitle(s.rules, rule))
+				edit = fullFileEdit(p.TextDocument.URI, doc.text, fixed)
 			}
 			ruleEdits[rule] = edit
 		}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1522,8 +1522,8 @@ func wantsKind(only []string, kind string) bool {
 // MDS012 → "Wrap in angle brackets"); otherwise the generic "Fix all
 // <name> with mdsmith" is used. That phrasing signals the action's
 // WorkspaceEdit covers every occurrence of the rule, not only the
-// diagnostic the user clicked on — see the comment on quickFixEditFor
-// for why the edit is whole-file scoped.
+// diagnostic the user clicked on — see appendQuickFixActions /
+// quickFixBytesFor for why the edit is whole-file scoped.
 func quickFixTitle(rules []rule.Rule, name string) string {
 	for _, r := range rules {
 		if r.Name() != name {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2511,8 +2511,10 @@ func newPreviewServer(t *testing.T, docChanges, changeAnnotSupport bool) *Server
 }
 
 // TestPreviewFixLegacyFallbackWhenCapsMissing verifies that when
-// previewFix is on but the client lacks capability, edits stay in the
-// legacy changes form (not documentChanges).
+// previewFix is on but the client lacks capability, the
+// source.fixAll.mdsmith edit stays in the legacy changes form (not
+// documentChanges). Interactive quick fixes are always legacy and so
+// can't exercise the capability gate; fix-all is the annotated path.
 func TestPreviewFixLegacyFallbackWhenCapsMissing(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -2531,11 +2533,7 @@ func TestPreviewFixLegacyFallbackWhenCapsMissing(t *testing.T) {
 			p := codeActionParams{
 				TextDocument: textDocumentIdentifier{URI: "file:///x.md"},
 				Context: codeActionContext{
-					Diagnostics: []Diagnostic{{
-						Code: "MDS006",
-						Data: &diagnosticData{RuleName: "no-trailing-spaces"},
-					}},
-					Only: []string{kindQuickFix},
+					Only: []string{kindSourceFixAll},
 				},
 			}
 			actions := s.computeCodeActions(p, doc, cfg, "")
@@ -2587,11 +2585,7 @@ func TestPreviewFixFallbackLogsWarningOnce(t *testing.T) {
 			p := codeActionParams{
 				TextDocument: textDocumentIdentifier{URI: "file:///x.md"},
 				Context: codeActionContext{
-					Diagnostics: []Diagnostic{{
-						Code: "MDS006",
-						Data: &diagnosticData{RuleName: "no-trailing-spaces"},
-					}},
-					Only: []string{kindQuickFix},
+					Only: []string{kindSourceFixAll},
 				},
 			}
 
@@ -2640,10 +2634,15 @@ func TestPreviewFixAnnotatedFixAllAction(t *testing.T) {
 	assert.True(t, ann.NeedsConfirmation)
 }
 
-// TestPreviewFixAnnotatedPerRuleQuickFix verifies that per-rule quick
-// fixes carry annotations with IDs mdsmith-fix-<rule> when the
-// annotated path is active.
-func TestPreviewFixAnnotatedPerRuleQuickFix(t *testing.T) {
+// TestPreviewFixQuickFixAppliesImmediately verifies that interactive
+// lightbulb quick fixes always apply immediately — even with previewFix
+// on and the client advertising changeAnnotationSupport. The previewFix
+// Refactor Preview is scoped to source.fixAll.mdsmith (fix-on-save);
+// forcing it on a single, explicitly-chosen quick fix stranded the edit
+// in a preview pane whose Apply control is easy to miss, so a second
+// lightbulb click collided with the pending preview ("Another
+// refactoring is being previewed").
+func TestPreviewFixQuickFixAppliesImmediately(t *testing.T) {
 	t.Parallel()
 	s := newPreviewServer(t, true, true)
 	cfg := config.Merge(config.Defaults(), nil)
@@ -2662,12 +2661,58 @@ func TestPreviewFixAnnotatedPerRuleQuickFix(t *testing.T) {
 	require.NotEmpty(t, actions)
 	edit := actions[0].Edit
 	require.NotNil(t, edit)
-	assert.Empty(t, edit.Changes)
-	require.Len(t, edit.DocumentChanges, 1)
-	require.Len(t, edit.DocumentChanges[0].Edits, 1)
-	wantID := "mdsmith-fix-no-trailing-spaces"
-	assert.Equal(t, wantID, edit.DocumentChanges[0].Edits[0].AnnotationID)
-	ann, ok := edit.ChangeAnnotations[wantID]
+	// Legacy changes form => VS Code applies it directly, no preview.
+	assert.NotEmpty(t, edit.Changes, "quick fix must use the immediate (legacy) edit form")
+	assert.Empty(t, edit.DocumentChanges, "quick fix must not request a Refactor Preview")
+	assert.Empty(t, edit.ChangeAnnotations, "quick fix must carry no needsConfirmation annotation")
+}
+
+// TestPreviewFixLightbulbScopesPreviewToFixAll models the manual
+// lightbulb request (no Only filter) with previewFix on. In a single
+// response the per-rule quick fix must be immediate (legacy changes
+// form, no annotation) while the source.fixAll.mdsmith action carries
+// the needsConfirmation preview. This is the exact interaction that
+// regressed: a forced preview on the quick fix stranded it in a pane
+// whose Apply control is easy to miss, so retrying collided with the
+// pending preview.
+func TestPreviewFixLightbulbScopesPreviewToFixAll(t *testing.T) {
+	t.Parallel()
+	s := newPreviewServer(t, true, true)
+	cfg := config.Merge(config.Defaults(), nil)
+	doc := &document{path: "x.md", text: []byte("# Hi\n\ndirty   \n")}
+	p := codeActionParams{
+		TextDocument: textDocumentIdentifier{URI: "file:///x.md"},
+		Context: codeActionContext{
+			// No Only filter: the lightbulb asks for every kind.
+			Diagnostics: []Diagnostic{{
+				Code: "MDS006",
+				Data: &diagnosticData{RuleName: "no-trailing-spaces"},
+			}},
+		},
+	}
+	actions := s.computeCodeActions(p, doc, cfg, "")
+
+	var quickFix, fixAll *codeAction
+	for i := range actions {
+		switch actions[i].Kind {
+		case kindQuickFix:
+			quickFix = &actions[i]
+		case kindSourceFixAll:
+			fixAll = &actions[i]
+		}
+	}
+	require.NotNil(t, quickFix, "lightbulb must offer the per-rule quick fix")
+	require.NotNil(t, fixAll, "lightbulb must offer the fix-all action")
+
+	// Quick fix: immediate (legacy changes form), no preview.
+	assert.NotEmpty(t, quickFix.Edit.Changes, "quick fix must apply immediately")
+	assert.Empty(t, quickFix.Edit.DocumentChanges)
+	assert.Empty(t, quickFix.Edit.ChangeAnnotations)
+
+	// Fix-all: previewed (annotated, needsConfirmation).
+	assert.Empty(t, fixAll.Edit.Changes)
+	require.NotEmpty(t, fixAll.Edit.DocumentChanges)
+	ann, ok := fixAll.Edit.ChangeAnnotations["mdsmith-fix-all"]
 	require.True(t, ok)
 	assert.True(t, ann.NeedsConfirmation)
 }
@@ -2679,38 +2724,21 @@ func TestPreviewFixAnnotatedPerRuleQuickFix(t *testing.T) {
 // "old file → new file" with no visible delta and the whole document
 // flattened into the lower preview pane's single-line label.
 //
-// Setup: 12 unchanged lines bracketing two distant trailing-whitespace
-// lines (1 and 10). The per-rule quickfix path runs only
-// no-trailing-spaces, so the only diff is on those two lines and the
-// hunk count check isn't muddied by other auto-fixes.
+// The annotated path is now reached only through source.fixAll.mdsmith
+// (interactive quick fixes apply immediately). Setup: clean markdown
+// except two distant trailing-whitespace lines, so the fix-all diff is
+// just those two spots and the hunk count check isn't muddied by other
+// auto-fixes.
 func TestPreviewFixAnnotatedHunksNotWholeFile(t *testing.T) {
 	t.Parallel()
 	s := newPreviewServer(t, true, true)
 	cfg := config.Merge(config.Defaults(), nil)
-	lines := []string{
-		"# Heading",
-		"intro line   ", // trailing spaces, line index 1
-		"",
-		"para a",
-		"para b",
-		"para c",
-		"",
-		"para d",
-		"para e",
-		"",
-		"closing line   ", // trailing spaces, line index 10
-		"",
-	}
-	src := []byte(strings.Join(lines, "\n") + "\n")
+	src := []byte("# Heading\n\nintro line   \n\npara a\n\npara b\n\nclosing line   \n")
 	doc := &document{path: "x.md", text: src}
 	p := codeActionParams{
 		TextDocument: textDocumentIdentifier{URI: "file:///x.md"},
 		Context: codeActionContext{
-			Diagnostics: []Diagnostic{{
-				Code: "MDS006",
-				Data: &diagnosticData{RuleName: "no-trailing-spaces"},
-			}},
-			Only: []string{kindQuickFix},
+			Only: []string{kindSourceFixAll},
 		},
 	}
 	actions := s.computeCodeActions(p, doc, cfg, "")
@@ -2725,27 +2753,30 @@ func TestPreviewFixAnnotatedHunksNotWholeFile(t *testing.T) {
 		"preview path must emit per-hunk edits, not a whole-file replacement")
 
 	// No single edit may span the whole document.
+	lineCount := bytes.Count(src, []byte("\n")) + 1
 	for i, e := range edits {
 		span := e.Range.End.Line - e.Range.Start.Line
-		assert.Lessf(t, span, len(lines)-1,
+		assert.Lessf(t, span, lineCount-1,
 			"edit %d spans %d lines [%d..%d]; "+
 				"preview path must emit per-hunk edits, "+
 				"not a whole-file replacement",
 			i, span, e.Range.Start.Line, e.Range.End.Line)
 	}
 
-	// All edits must share the same annotation id so the preview
+	// All edits must share the fix-all annotation id so the preview
 	// pane groups them under one entry.
 	for _, e := range edits {
-		assert.Equal(t, "mdsmith-fix-no-trailing-spaces", e.AnnotationID)
+		assert.Equal(t, "mdsmith-fix-all", e.AnnotationID)
 	}
 
-	// Applying the edits must yield the same bytes the per-rule
-	// fix pipeline would have written.
+	// Applying the edits must yield the same bytes the fix-all
+	// pipeline would have written.
 	got := applyAnnotatedEdits(t, src, edits)
-	want := s.quickFixBytesFor("no-trailing-spaces", doc, cfg, "")
-	require.NotNil(t, want)
-	assert.Equal(t, string(want), string(got))
+	sess, _ := s.currentSession()
+	require.NotNil(t, sess)
+	res, err := sess.Fix(workspaceRelative("", doc.path), src)
+	require.NoError(t, err)
+	assert.Equal(t, res.Source, string(got))
 }
 
 // TestAnnotatedHunkEdits covers annotatedHunkEdits directly so the

--- a/plan/207_lsp-fix-preview.md
+++ b/plan/207_lsp-fix-preview.md
@@ -5,10 +5,11 @@ status: "✅"
 summary: >-
   Opt-in `mdsmith.previewFix` setting that attaches
   an LSP `ChangeAnnotation` flagged
-  `needsConfirmation: true` to every quick-fix and
-  `source.fixAll.mdsmith` WorkspaceEdit, so VS Code
-  opens its Refactor Preview pane with a diff
-  before applying.
+  `needsConfirmation: true` to the
+  `source.fixAll.mdsmith` (fix-on-save) WorkspaceEdit,
+  so VS Code opens its Refactor Preview pane with a
+  diff before applying. Interactive quick fixes apply
+  immediately (see the Revision note).
 model: sonnet
 depends-on: []
 ---
@@ -266,10 +267,10 @@ the matrix:
       server falls back to the legacy `changes`
       shape and logs the fallback once per
       session.
-- [x] Quick-fix actions carry one annotation per
-      rule (`mdsmith-fix-<rule>`);
-      `source.fixAll.mdsmith` carries
-      `mdsmith-fix-all`.
+- [x] `source.fixAll.mdsmith` carries the
+      `mdsmith-fix-all` annotation. (Revised: quick
+      fixes no longer carry a per-rule annotation —
+      they apply immediately. See the Revision note.)
 - [x] [`docs/guides/editors/vscode.md`](../docs/guides/editors/vscode.md)
       documents the setting and the
       `previewFix` × `fixOnSave` interaction.

--- a/plan/207_lsp-fix-preview.md
+++ b/plan/207_lsp-fix-preview.md
@@ -14,6 +14,19 @@ depends-on: []
 ---
 # LSP fix preview via ChangeAnnotation
 
+## Revision
+
+This was later narrowed. Only the fix-all action
+(`source.fixAll.mdsmith`, run on save) asks for a preview
+now. Lightbulb quick fixes apply right away. A quick fix is
+the one fix you just chose, so there is nothing to confirm.
+
+A forced preview hid the edit in a pane whose Apply button
+is easy to miss, and a second click hit the open preview.
+The lightbulb still has its own Preview (the chevron, or
+Ctrl+Enter). See
+[`internal/lsp/server.go`](../internal/lsp/server.go).
+
 ## Goal
 
 Let the user opt into a preview pane before any


### PR DESCRIPTION
## Problem

With `mdsmith.previewFix` on, VS Code quick fixes stopped working: clicking a
lightbulb fix did nothing the first time (no apply button), and a second click
popped **"Another refactoring is being previewed."**

## Root cause

`mdsmith.previewFix` attached a `needsConfirmation` `ChangeAnnotation` to
**every** code action — including per-rule lightbulb quick fixes. So VS Code
routed even a single, explicitly-chosen quick fix through the **Refactor
Preview** pane instead of applying it. That pane's Apply control lives in its
toolbar and is easy to miss, so:

1. the first click silently opened a pending preview ("nothing happened"), and
2. the second click collided with it (the dialog in the report).

The server-side edit itself was well-formed — the issue was forcing a preview
on interactive quick fixes.

## Fix

Scope the Refactor Preview to the **`source.fixAll.mdsmith`** action only — the
action `editor.codeActionsOnSave` runs on save, where reviewing an
auto-applied bulk edit is genuinely useful. Interactive lightbulb quick fixes
now always use the immediate (legacy `changes`-map) edit form, so VS Code
applies them the moment you pick one — the same model ESLint/Prettier use.
VS Code's lightbulb still offers a per-action **Preview** (the chevron /
`Ctrl+Enter`) for anyone who wants to inspect a single fix.

The matrix with `previewFix: true` is now:

| Action | Behavior |
| --- | --- |
| Lightbulb quick fix | applies immediately |
| `source.fixAll.mdsmith` (fix-on-save / "Fix all") | opens Refactor Preview |

## Changes

- `internal/lsp/server.go`: `computeCodeActions` passes the annotated/preview
  flag only to the fix-all action; `appendQuickFixActions` always builds the
  immediate edit (dropped its now-dead `annotated` param).
- `internal/lsp/server_test.go`: quick-fix tests assert immediate application;
  the capability-fallback / warning / hunk tests move to the fix-all path
  (the only annotated path now); new
  `TestPreviewFixLightbulbScopesPreviewToFixAll` guards the combined
  lightbulb request.
- Docs: `package.json` setting description, VS Code guide, LSP reference, and a
  revision note on plan 207.

## Testing

- `go test ./...` — green
- `go vet ./internal/lsp/` + `go tool golangci-lint run ./internal/lsp/...` — 0 issues
- `bun test` in `editors/vscode` — 139 pass
- `mdsmith check .` — 0 failures

> Note: the existing fix-on-save preview e2e
> (`codeactionsonsave.itest.ts`) is unaffected — `source.fixAll.mdsmith` still
> previews. The change is server-side and covered by unit tests; no new e2e
> was added.

https://claude.ai/code/session_011LFkfT5DDJhxa9VoNPSrjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011LFkfT5DDJhxa9VoNPSrjJ)_