### PR TITLE
plan 233: adopt numeric heading-level "2" in README (drop top H1)

### DIFF
--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -156,6 +156,13 @@ overrides:
         max-rows: 40
       paragraph-structure:
         max-sentences: 30
+  - glob: ["README.md"]
+    rules:
+      # The top-level H1 is intentionally dropped — the centered
+      # logo lockup is the title — so the file's first heading is
+      # the features <?include?> body, pinned to level 2. Same
+      # opt-out the other include/template-driven files above use.
+      first-line-heading: false
   - glob: ["PLAN.md"]
     rules:
       table-readability:

--- a/PLAN.md
+++ b/PLAN.md
@@ -158,7 +158,7 @@ footer: |
 | 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |
 | 231 | ✅     |        | [LSP newest-wins workspace singleton](plan/231_lsp-workspace-singleton.md)                                                              |
 | 232 | ✅     | opus   | [include heading-offset parameter](plan/232_include-heading-offset.md)                                                                  |
-| 233 | 🔳     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
+| 233 | ✅     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
 | 234 | 🔲     | sonnet | [Distribute mdsmith on Windows via Scoop and WinGet](plan/234_windows-package-managers.md)                                              |
 | 235 | 🔲     | sonnet | [Playwright end-to-end tests for the website, runnable by CI and agents](plan/235_playwright-site-e2e.md)                               |
 <?/catalog?>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# 🔨 mdsmith
-
 <p align="center">
 <picture>
 <source media="(prefers-color-scheme: dark)" srcset="website/static/img/logo-lockup-inverse.svg">
@@ -62,7 +60,7 @@ src="https://raw.githubusercontent.com/jeduden/mdsmith/assets/assets/demo.gif">
 <?include
 file: docs/features/index.md
 strip-frontmatter: "true"
-heading-level: "absolute"
+heading-level: "2"
 ?>
 ## Why mdsmith
 

--- a/plan/233_include-heading-level-target.md
+++ b/plan/233_include-heading-level-target.md
@@ -1,7 +1,7 @@
 ---
 id: 233
 title: numeric heading-level target for include
-status: "🔳"
+status: "✅"
 summary: >-
   Extend the `<?include?>` directive's `heading-level`
   parameter (MDS021) to accept an integer 1-6 that pins
@@ -138,10 +138,14 @@ and in fenced doc examples, never as a live directive.
 
 ## Deferred — gated on the pin bump
 
-8. [ ] Adopt `heading-level: "<number>"` in tracked
-   Markdown only after a release ships it and the pinned
-   baseline is bumped. This task stays open as the
-   reminder; the plan holds at `🔳` until then.
+8. [x] Adopt `heading-level: "<number>"` in tracked
+   Markdown. The gate cleared: the feature shipped in
+   v0.32.0 and the pinned baseline is now v0.33.0.
+   `README.md` drops its top-level H1 — the logo lockup
+   is the title — and pins the features `<?include?>` to
+   `heading-level: "2"`. A `README.md`-only
+   `first-line-heading: false` override covers the now
+   intentionally H1-less file.
 
 ## Acceptance Criteria
 
@@ -156,7 +160,8 @@ and in fenced doc examples, never as a live directive.
       lint error naming the allowed values
 - [x] `heading-level` numeric still cannot pair with
       `heading-offset` or `extract`
-- [x] No tracked Markdown uses the numeric form, so
+- [x] `README.md` adopts the numeric form; the pinned
+      baseline (v0.33.0) parses it, so
       `mdsmith-fixed-version` stays green
 - [x] All tests pass: `go test ./...`
 - [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
Completes the deferred task 8 of [plan/233](plan/233_include-heading-level-target.md): adopt the numeric `heading-level` form (shipped in v0.32.0 via #473) now that the adoption gate has cleared.

## Why now

`docs/development/adopt-new-directive-syntax.md` gates new directive syntax on a release **and** a pinned-baseline bump:

- ✅ Feature shipped in **v0.32.0** (#473).
- ✅ Pinned baseline is now **v0.33.0** (≥ v0.32.0), so the `mdsmith-fixed-version` job parses the numeric form.

## What

- **README.md** — drop the top-level `# 🔨 mdsmith` H1 (the centered logo lockup is the title) and pin the features `<?include?>` to `heading-level: "2"`. At the document root `"absolute"` would now be a no-op, so the numeric target keeps the embedded section at level 2, consistent with the other H2 sections (Quickstart, Installation…).
- **.mdsmith.yml** — add a `README.md`-only `first-line-heading: false` override (the file is now intentionally H1-less). Matches the opt-out the other include/template-driven files already use; `website/README.md` keeps its own H1 and the rule.
- **plan/233 + PLAN.md** — task 8 checked off, status → ✅.

## Verification

- Include body is **byte-identical** (`"absolute"` and `"2"` both shift +1 here), so there is no generated-section churn.
- `mdsmith check .` — 415 files, 0 failures, on both the branch build **and** the SHA-verified pinned **v0.33.0** binary (replicating the `mdsmith-fixed-version` job).
- `go test ./...` — pass.

https://claude.ai/code/session_016jgXPirnWQcobzDqgjZxqW

---
_Generated by [Claude Code](https://claude.ai/code/session_016jgXPirnWQcobzDqgjZxqW)_