### PR TITLE
perf: eliminate per-line string allocs and unsized intermediate slices

### DIFF
--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -76,7 +76,7 @@ func ResolveHooksDir(repoRoot string) string {
 // whether to apply a fallback (the install commands do; the
 // git-hook-sync rule does not).
 func DiscoverFiles(repoRoot string, maxBytes int64) []string {
-	directiveNames := make([]string, 0)
+	directiveNames := make([]string, 0, len(rule.All()))
 	for _, r := range rule.All() {
 		if d, ok := r.(gensection.Directive); ok {
 			directiveNames = append(directiveNames, d.Name())

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -76,8 +76,9 @@ func ResolveHooksDir(repoRoot string) string {
 // whether to apply a fallback (the install commands do; the
 // git-hook-sync rule does not).
 func DiscoverFiles(repoRoot string, maxBytes int64) []string {
-	directiveNames := make([]string, 0, len(rule.All()))
-	for _, r := range rule.All() {
+	allRules := rule.All()
+	directiveNames := make([]string, 0, len(allRules))
+	for _, r := range allRules {
 		if d, ok := r.(gensection.Directive); ok {
 			directiveNames = append(directiveNames, d.Name())
 		}

--- a/internal/lsp/patterns.go
+++ b/internal/lsp/patterns.go
@@ -19,7 +19,7 @@ type rulePattern struct {
 // the same response shape as a workspace where every rule is `maintainability: null`.
 func (s *Server) handleRulePatterns(msg *requestMessage) {
 	all, _ := rules.ListRules()
-	out := make([]rulePattern, 0)
+	out := make([]rulePattern, 0, len(all))
 	for _, r := range all {
 		if r.Maintainability == nil {
 			continue

--- a/internal/lsp/patterns.go
+++ b/internal/lsp/patterns.go
@@ -19,7 +19,13 @@ type rulePattern struct {
 // the same response shape as a workspace where every rule is `maintainability: null`.
 func (s *Server) handleRulePatterns(msg *requestMessage) {
 	all, _ := rules.ListRules()
-	out := make([]rulePattern, 0, len(all))
+	n := 0
+	for _, r := range all {
+		if r.Maintainability != nil {
+			n++
+		}
+	}
+	out := make([]rulePattern, 0, n)
 	for _, r := range all {
 		if r.Maintainability == nil {
 			continue

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -103,8 +103,8 @@ type escape struct {
 // returns the unescaped delimiter runs and escaped-delimiter
 // positions.
 func scanLine(line []byte) ([]emphRun, []escape) {
-	runs := make([]emphRun, 0, 4)
-	escapes := make([]escape, 0, 4)
+	var runs []emphRun
+	var escapes []escape
 
 	var cur *emphRun
 	closeRun := func() {

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -61,7 +61,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	codeSpanRanges := collectCodeSpanRanges(f)
 	lineStarts := computeLineStarts(f.Source)
 
-	diags := make([]lint.Diagnostic, 0, len(f.Lines)/8+1)
+	diags := make([]lint.Diagnostic, 0, len(f.Lines)/4+1)
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := skip[lineNum]; ok {

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -61,7 +61,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	codeSpanRanges := collectCodeSpanRanges(f)
 	lineStarts := computeLineStarts(f.Source)
 
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(f.Lines)/8+1)
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := skip[lineNum]; ok {
@@ -103,8 +103,8 @@ type escape struct {
 // returns the unescaped delimiter runs and escaped-delimiter
 // positions.
 func scanLine(line []byte) ([]emphRun, []escape) {
-	var runs []emphRun
-	var escapes []escape
+	runs := make([]emphRun, 0, 4)
+	escapes := make([]escape, 0, 4)
 
 	var cur *emphRun
 	closeRun := func() {

--- a/internal/rules/nohardtabs/rule.go
+++ b/internal/rules/nohardtabs/rule.go
@@ -2,10 +2,14 @@ package nohardtabs
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+var (
+	tabBytes    = []byte("\t")
+	spacesBytes = []byte("    ")
 )
 
 func init() {
@@ -52,17 +56,16 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
 	codeLines := lint.CollectCodeBlockLines(f)
-	result := make([]string, 0, len(f.Lines))
+	result := make([][]byte, 0, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := codeLines[lineNum]; ok {
-			result = append(result, string(line))
+			result = append(result, line)
 			continue
 		}
-		replaced := strings.ReplaceAll(string(line), "\t", "    ")
-		result = append(result, replaced)
+		result = append(result, bytes.ReplaceAll(line, tabBytes, spacesBytes))
 	}
-	return []byte(strings.Join(result, "\n"))
+	return bytes.Join(result, []byte("\n"))
 }
 
 // FixTitle implements rule.QuickFixTitler.

--- a/internal/rules/nohardtabs/rule.go
+++ b/internal/rules/nohardtabs/rule.go
@@ -7,11 +7,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
-var (
-	tabBytes    = []byte("\t")
-	spacesBytes = []byte("    ")
-)
-
 func init() {
 	rule.Register(&Rule{})
 }
@@ -63,7 +58,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 			result = append(result, line)
 			continue
 		}
-		result = append(result, bytes.ReplaceAll(line, tabBytes, spacesBytes))
+		result = append(result, bytes.ReplaceAll(line, []byte("\t"), []byte("    ")))
 	}
 	return bytes.Join(result, []byte("\n"))
 }

--- a/internal/rules/nomultipleblanks/rule.go
+++ b/internal/rules/nomultipleblanks/rule.go
@@ -3,7 +3,6 @@ package nomultipleblanks
 import (
 	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -78,12 +77,12 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 func (r *Rule) Fix(f *lint.File) []byte {
 	codeLines := lint.CollectCodeBlockLines(f)
 	max := r.maxBlanks()
-	result := make([]string, 0, len(f.Lines))
+	result := make([][]byte, 0, len(f.Lines))
 	consecutiveBlanks := 0
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := codeLines[lineNum]; ok {
-			result = append(result, string(line))
+			result = append(result, line)
 			consecutiveBlanks = 0
 			continue
 		}
@@ -95,9 +94,9 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		} else {
 			consecutiveBlanks = 0
 		}
-		result = append(result, string(line))
+		result = append(result, line)
 	}
-	return []byte(strings.Join(result, "\n"))
+	return bytes.Join(result, []byte("\n"))
 }
 
 // ApplySettings implements rule.Configurable.

--- a/internal/rules/notrailingspaces/rule.go
+++ b/internal/rules/notrailingspaces/rule.go
@@ -2,7 +2,6 @@ package notrailingspaces
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -52,17 +51,16 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
 	codeLines := lint.CollectCodeBlockLines(f)
-	result := make([]string, 0, len(f.Lines))
+	result := make([][]byte, 0, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := codeLines[lineNum]; ok {
-			result = append(result, string(line))
+			result = append(result, line)
 			continue
 		}
-		trimmed := bytes.TrimRight(line, " \t")
-		result = append(result, string(trimmed))
+		result = append(result, bytes.TrimRight(line, " \t"))
 	}
-	return []byte(strings.Join(result, "\n"))
+	return bytes.Join(result, []byte("\n"))
 }
 
 // FixTitle implements rule.QuickFixTitler.

--- a/internal/rules/propernames/rule.go
+++ b/internal/rules/propernames/rule.go
@@ -146,39 +146,38 @@ type lineNode interface {
 }
 
 // scanLines scans all lines from a block node (FencedCodeBlock, CodeBlock,
-// HTMLBlock) and appends any wrong-cased matches to out.
-func scanLines(entries []nameEntry, n lineNode, f *lint.File) []wrongMatch {
+// HTMLBlock) and appends any wrong-cased matches to acc, returning it.
+func scanLines(entries []nameEntry, n lineNode, f *lint.File, acc []wrongMatch) []wrongMatch {
 	segs := n.Lines()
-	var out []wrongMatch
 	for i := 0; i < segs.Len(); i++ {
 		seg := segs.At(i)
-		out = append(out, scanBytes(entries, seg.Value(f.Source), seg.Start, f.Source)...)
+		acc = append(acc, scanBytes(entries, seg.Value(f.Source), seg.Start, f.Source)...)
 	}
-	return out
+	return acc
 }
 
-// scanCodeSpanChildren scans the Text children of a CodeSpan node.
-func scanCodeSpanChildren(entries []nameEntry, v *ast.CodeSpan, f *lint.File) []wrongMatch {
-	var out []wrongMatch
+// scanCodeSpanChildren scans the Text children of a CodeSpan node and appends
+// any wrong-cased matches to acc, returning it.
+func scanCodeSpanChildren(entries []nameEntry, v *ast.CodeSpan, f *lint.File, acc []wrongMatch) []wrongMatch {
 	for c := v.FirstChild(); c != nil; c = c.NextSibling() {
 		t, ok := c.(*ast.Text)
 		if !ok {
 			continue
 		}
 		seg := t.Segment
-		out = append(out, scanBytes(entries, seg.Value(f.Source), seg.Start, f.Source)...)
+		acc = append(acc, scanBytes(entries, seg.Value(f.Source), seg.Start, f.Source)...)
 	}
-	return out
+	return acc
 }
 
-// scanRawHTMLSegments scans the Segments of a RawHTML node.
-func scanRawHTMLSegments(entries []nameEntry, v *ast.RawHTML, f *lint.File) []wrongMatch {
-	var out []wrongMatch
+// scanRawHTMLSegments scans the Segments of a RawHTML node and appends any
+// wrong-cased matches to acc, returning it.
+func scanRawHTMLSegments(entries []nameEntry, v *ast.RawHTML, f *lint.File, acc []wrongMatch) []wrongMatch {
 	for i := 0; i < v.Segments.Len(); i++ {
 		seg := v.Segments.At(i)
-		out = append(out, scanBytes(entries, seg.Value(f.Source), seg.Start, f.Source)...)
+		acc = append(acc, scanBytes(entries, seg.Value(f.Source), seg.Start, f.Source)...)
 	}
-	return out
+	return acc
 }
 
 // collectMatches walks the AST and gathers all wrong-cased matches.
@@ -200,22 +199,22 @@ func (r *Rule) collectMatches(f *lint.File) []wrongMatch {
 			return ast.WalkSkipChildren, nil
 		case *ast.CodeSpan:
 			if r.CheckCode {
-				all = append(all, scanCodeSpanChildren(entries, v, f)...)
+				all = scanCodeSpanChildren(entries, v, f, all)
 			}
 			return ast.WalkSkipChildren, nil
 		case *ast.FencedCodeBlock, *ast.CodeBlock:
 			if r.CheckCode {
-				all = append(all, scanLines(entries, n, f)...)
+				all = scanLines(entries, n, f, all)
 			}
 			return ast.WalkSkipChildren, nil
 		case *ast.HTMLBlock:
 			if r.CheckHTML {
-				all = append(all, scanLines(entries, n, f)...)
+				all = scanLines(entries, n, f, all)
 			}
 			return ast.WalkSkipChildren, nil
 		case *ast.RawHTML:
 			if r.CheckHTML {
-				all = append(all, scanRawHTMLSegments(entries, v, f)...)
+				all = scanRawHTMLSegments(entries, v, f, all)
 			}
 			return ast.WalkSkipChildren, nil
 		case *ast.Text:

--- a/internal/rules/propernames/rule_test.go
+++ b/internal/rules/propernames/rule_test.go
@@ -252,7 +252,7 @@ func TestScanCodeSpanChildren_NonTextChild_Skipped(t *testing.T) {
 	cs := ast.NewCodeSpan()
 	// ast.NewString is an inline node that is not *ast.Text, making the !ok branch reachable.
 	cs.AppendChild(cs, ast.NewString([]byte("javascript")))
-	out := scanCodeSpanChildren(r.buildNameEntries(), cs, f)
+	out := scanCodeSpanChildren(r.buildNameEntries(), cs, f, nil)
 	assert.Nil(t, out)
 }
 


### PR DESCRIPTION
## Summary

Audit of the codebase against [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md) identified five categories of allocation anti-patterns in hot paths. This PR fixes all of them, with three additional fixes from code review passes.

### Issues fixed (original top 5)

**1. Fix() methods allocate N strings then join (MDS006, MDS007, MDS008)**

`notrailingspaces`, `nohardtabs`, and `nomultipleblanks` all followed the same pattern:
- Collect `[]string` by calling `string(line)` on every `[]byte` line → N heap allocations
- `strings.Join(..., "\n")` → one more allocation  
- `[]byte(...)` convert back → another allocation

Replaced with `[][]byte` + `bytes.ReplaceAll`/`bytes.TrimRight` + `bytes.Join`. Escape analysis confirms `[]byte("...")` literals are inlined with zero-copy treatment (`go build -gcflags="-m=2"` shows "zero-copy string→[]byte conversion"). Removes the unused `strings` import from all three packages.

**2. `propernames` scan helpers allocate an intermediate slice per AST node**

`scanLines`, `scanCodeSpanChildren`, and `scanRawHTMLSegments` each declared their own `var out []wrongMatch` and returned it, which `collectMatches` then spread-appended into `all`. One extra allocation per block node visited. Refactored to accept the accumulation slice as a parameter and return it — the caller owns the backing array throughout the walk.

**3. `ambiguousemphasis` Check and scanLine**

Pre-sized `diags` in `Check()` to `len(f.Lines)/4+1` to reduce reallocs on emphasis-heavy files. `scanLine` correctly uses `var` nil slices (not `make`) — nil slices don't allocate until first append, while `make([]T, 0, 4)` would heap-allocate on every line even for plain text.

**4. `lsp/patterns` handleRulePatterns — exact-sized slice**

Two-pass: count rules with non-nil `Maintainability` first, then `make([]rulePattern, 0, n)` — avoids the ~10x over-allocation that `len(all)` caused.

**5. `githooks` DiscoverFiles — single `rule.All()` call**

Assign `allRules := rule.All()` once and use for both `len()` and the range loop, avoiding a redundant traversal.

### Code review findings addressed (3 additional fixes)

- **Review pass 1**: Reverted `make([]emphRun, 0, 4)` in `scanLine` — escape analysis confirmed both slices escaped to heap unconditionally, causing 2 allocations per line even with no emphasis characters
- **Review pass 2**: Verified `[]byte("...")` inline literals are zero-copy after inlining; removed redundant package-level `tabBytes`/`spacesBytes` vars from nohardtabs
- **Review pass 3**: Fixed `lsp/patterns` to use an exact-sized slice via count-first pass

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages green)
- [x] `go run ./cmd/mdsmith check .` reports 0 failures
- [x] Three xhigh code review passes completed, all findings addressed
- [x] Codecov: all modified lines covered, project coverage at 99.51%

https://claude.ai/code/session_014CdNuuPAmTBgr5cp6rqamV