### PR TITLE
Auto-discover .mdsmith.yml at the vault root in the Obsidian plugin

### DIFF
--- a/docs/guides/editors/obsidian.md
+++ b/docs/guides/editors/obsidian.md
@@ -137,7 +137,11 @@ in `<vault>/.obsidian/plugins/mdsmith/` — `main.js`,
 `manifest.json`, `styles.css`, `mdsmith.wasm`, and
 `wasm_exec.js`. A missing `mdsmith.wasm` or
 `wasm_exec.js` is the usual cause. Re-unzip the
-release and reload the plugin.
+release and reload the plugin. If the notice instead
+reads `parsing config file: …`, your `.mdsmith.yml`
+has a syntax error — the engine refuses an invalid
+config rather than linting on defaults — so fix the
+YAML and run `mdsmith: Restart session`.
 
 **No diagnostics appear.** Check that **Run mode** is
 not `off`. With `onSave`, diagnostics refresh only

--- a/docs/guides/editors/obsidian.md
+++ b/docs/guides/editors/obsidian.md
@@ -100,8 +100,10 @@ drop the unzipped files there.
 You need Obsidian 1.5 or later. A config file is
 optional: mdsmith lints with built-in defaults, so the
 plugin works as soon as you enable it. To tune the
-rules, add a `.mdsmith.yml` to the vault and point the
-**Config path** setting at it.
+rules, add a `.mdsmith.yml` to the vault root and the
+plugin discovers it automatically — no setting to
+change. To load a config from another location, set the
+**Config path** setting to its vault-relative path.
 
 [gh]: https://github.com/jeduden/mdsmith/releases
 
@@ -109,11 +111,11 @@ rules, add a `.mdsmith.yml` to the vault and point the
 
 Open **Settings → Community plugins → mdsmith**.
 
-| Setting      | Default  | Purpose                                                   |
-| ------------ | -------- | --------------------------------------------------------- |
-| `configPath` | `""`     | Override the `.mdsmith.yml` path; empty uses the defaults |
-| `runMode`    | `onSave` | When to re-lint: `onType`, `onSave`, or `off`             |
-| `fixOnSave`  | `false`  | Run `Fix file` 200 ms after each save                     |
+| Setting      | Default  | Purpose                                                              |
+| ------------ | -------- | -------------------------------------------------------------------- |
+| `configPath` | `""`     | Path to a `.mdsmith.yml`; empty auto-discovers one at the vault root |
+| `runMode`    | `onSave` | When to re-lint: `onType`, `onSave`, or `off`                        |
+| `fixOnSave`  | `false`  | Run `Fix file` 200 ms after each save                                |
 
 `runMode` controls when diagnostics refresh. `onType`
 re-lints on each edit; `onSave` re-lints only when you
@@ -142,10 +144,15 @@ not `off`. With `onSave`, diagnostics refresh only
 when you save the note. Open and re-save the file to
 force a re-lint.
 
-**The config is not applied.** An unreadable **Config
-path** reports a notice and falls back to the engine
-defaults. Confirm the path is vault-relative and the
-file exists, then run `mdsmith: Restart session`.
+**The config is not applied.** With **Config path**
+empty, the plugin loads a `.mdsmith.yml` only from the
+vault root — confirm the file sits there, not in a
+subfolder. An unreadable **Config path** reports a
+notice and falls back to the engine defaults. Confirm
+the path is vault-relative and the file exists, then run
+`mdsmith: Restart session`. After editing a discovered
+config in place, run `mdsmith: Restart session` too —
+the session compiles config once at startup.
 
 ## See also
 

--- a/editors/obsidian/src/config.test.ts
+++ b/editors/obsidian/src/config.test.ts
@@ -1,0 +1,86 @@
+// Drives config.ts — the vault-root .mdsmith.yml auto-discovery the
+// plugin runs when the Config path setting is empty.
+//
+// The CLI walks up from the working directory to the nearest
+// .mdsmith.yml. An Obsidian vault has one root and one lint session over
+// it, so the analog is a single config file at the vault root. Obsidian
+// hides dotfiles from its vault file API, so discovery reads through the
+// DataAdapter (exists + read), which sees them. These tests exercise
+// discoverConfigYAML against a fake adapter — no Obsidian host.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONFIG_FILE_NAME,
+  discoverConfigYAML,
+  type ConfigAdapter,
+} from "./config";
+
+// makeAdapter builds a ConfigAdapter over an in-memory file map and
+// records every read so a test can assert discovery did (or did not)
+// touch disk.
+function makeAdapter(files: Record<string, string>): ConfigAdapter & {
+  reads: string[];
+} {
+  const reads: string[] = [];
+  return {
+    reads,
+    async exists(path: string): Promise<boolean> {
+      return path in files;
+    },
+    async read(path: string): Promise<string> {
+      reads.push(path);
+      const v = files[path];
+      if (v === undefined) throw new Error(`ENOENT: ${path}`);
+      return v;
+    },
+  };
+}
+
+describe("discoverConfigYAML", () => {
+  test("returns the .mdsmith.yml text when one sits at the vault root", async () => {
+    const adapter = makeAdapter({
+      ".mdsmith.yml": "rules:\n  line-length: false\n",
+    });
+    expect(await discoverConfigYAML(adapter)).toBe(
+      "rules:\n  line-length: false\n",
+    );
+  });
+
+  test('returns "" when the vault has no .mdsmith.yml', async () => {
+    const adapter = makeAdapter({ "note.md": "# Hi\n" });
+    expect(await discoverConfigYAML(adapter)).toBe("");
+  });
+
+  test("does not read when the file is absent (the exists gate)", async () => {
+    const adapter = makeAdapter({});
+    await discoverConfigYAML(adapter);
+    expect(adapter.reads).toEqual([]);
+  });
+
+  test('degrades to "" when the file exists but the read fails', async () => {
+    // exists() reports the file, but read() rejects — a race with a
+    // delete, a permission error. Discovery must fall back to defaults
+    // rather than crash the engine bring-up.
+    const adapter: ConfigAdapter = {
+      async exists(): Promise<boolean> {
+        return true;
+      },
+      async read(): Promise<string> {
+        throw new Error("EACCES");
+      },
+    };
+    expect(await discoverConfigYAML(adapter)).toBe("");
+  });
+
+  test("honors an explicit candidate name", async () => {
+    const adapter = makeAdapter({ "alt.yml": "rules:\n  no-bare-urls: false\n" });
+    expect(await discoverConfigYAML(adapter, "alt.yml")).toBe(
+      "rules:\n  no-bare-urls: false\n",
+    );
+  });
+
+  test("looks for the same basename the CLI walks the tree for", () => {
+    expect(CONFIG_FILE_NAME).toBe(".mdsmith.yml");
+  });
+});

--- a/editors/obsidian/src/config.ts
+++ b/editors/obsidian/src/config.ts
@@ -28,9 +28,12 @@ export interface ConfigAdapter {
 
 // discoverConfigYAML returns the text of the vault-root .mdsmith.yml, or
 // "" when none is present. A read that fails after the existence check —
-// a race with a delete, a permission error — also degrades to "" so a
-// missing or unreadable config never blocks the engine; it falls back to
-// the built-in defaults exactly as an empty config does.
+// a race with a delete, a permission error — also degrades to "", so a
+// missing or unreadable file falls back to the built-in defaults rather
+// than throwing. It does NOT validate the contents: a present, readable
+// but malformed .mdsmith.yml is the engine's to reject — NewSession
+// surfaces the parse error on session creation, exactly as the CLI does
+// for a discovered config.
 export async function discoverConfigYAML(
   adapter: ConfigAdapter,
   name: string = CONFIG_FILE_NAME,

--- a/editors/obsidian/src/config.ts
+++ b/editors/obsidian/src/config.ts
@@ -1,0 +1,44 @@
+// Vault-root config discovery for the Obsidian plugin.
+//
+// The CLI finds a project's config by walking up from the working
+// directory to the nearest .mdsmith.yml (stopping at the repository
+// root). An Obsidian vault has a single root the adapter is rooted at,
+// and the plugin holds one lint session over the whole vault, so the
+// analog is one config file at the vault root. When the Config path
+// setting is empty, the plugin reads .mdsmith.yml from there instead of
+// falling straight back to the engine defaults.
+//
+// Obsidian's vault file API (getMarkdownFiles, getAbstractFileByPath)
+// hides dotfiles, so .mdsmith.yml never appears there. The DataAdapter
+// sees the raw vault directory, so discovery goes through it — the same
+// path the explicit-config read uses, which is why it also works on
+// mobile.
+
+// CONFIG_FILE_NAME is the config basename the plugin discovers, matching
+// the .mdsmith.yml the CLI walks the directory tree for.
+export const CONFIG_FILE_NAME = ".mdsmith.yml";
+
+// ConfigAdapter is the slice of Obsidian's DataAdapter discovery needs:
+// a vault-relative existence check and text read. The real
+// app.vault.adapter satisfies it on desktop and mobile alike.
+export interface ConfigAdapter {
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+}
+
+// discoverConfigYAML returns the text of the vault-root .mdsmith.yml, or
+// "" when none is present. A read that fails after the existence check —
+// a race with a delete, a permission error — also degrades to "" so a
+// missing or unreadable config never blocks the engine; it falls back to
+// the built-in defaults exactly as an empty config does.
+export async function discoverConfigYAML(
+  adapter: ConfigAdapter,
+  name: string = CONFIG_FILE_NAME,
+): Promise<string> {
+  try {
+    if (!(await adapter.exists(name))) return "";
+    return await adapter.read(name);
+  } catch {
+    return "";
+  }
+}

--- a/editors/obsidian/src/main.test.ts
+++ b/editors/obsidian/src/main.test.ts
@@ -331,6 +331,19 @@ describe("loadConfigYAML — config resolution + auto-discovery", () => {
     );
     expect(await load(plugin)).toBe("rules:\n  no-bare-urls: false\n");
   });
+
+  test('an unreadable explicit Config path degrades to "" (notice + defaults), not to discovery', async () => {
+    // configPath names a file the adapter cannot read, so read() rejects.
+    // The explicit-path branch surfaces a Notice (stubbed in tests) and
+    // returns "" — it must NOT silently fall through to the vault-root
+    // .mdsmith.yml, which would mask the user's broken path with an
+    // unrelated config. The present .mdsmith.yml is the bait.
+    const plugin = makeConfigPlugin(
+      { ".mdsmith.yml": "rules:\n  line-length: false\n" },
+      "cfg/missing.yml",
+    );
+    expect(await load(plugin)).toBe("");
+  });
 });
 
 describe("engine-down / restart safety (Copilot review)", () => {

--- a/editors/obsidian/src/main.test.ts
+++ b/editors/obsidian/src/main.test.ts
@@ -270,6 +270,69 @@ describe("teardownRuntime — vault listener cleanup (Copilot review)", () => {
   });
 });
 
+describe("loadConfigYAML — config resolution + auto-discovery", () => {
+  // makeConfigPlugin wires a plugin onto a fake App whose vault adapter
+  // serves the given files through exists/read — the surface both the
+  // explicit-path read and auto-discovery call. configPath seeds the
+  // setting under test.
+  function makeConfigPlugin(
+    files: Record<string, string>,
+    configPath = "",
+  ): MdsmithPlugin {
+    const adapter = {
+      async exists(path: string): Promise<boolean> {
+        return path in files;
+      },
+      async read(path: string): Promise<string> {
+        const v = files[path];
+        if (v === undefined) throw new Error(`ENOENT: ${path}`);
+        return v;
+      },
+    };
+    const app = { vault: { adapter } };
+    const PluginCtor = MdsmithPlugin as unknown as new (
+      a: unknown,
+      m: unknown,
+    ) => MdsmithPlugin;
+    const plugin = new PluginCtor(app, { dir: "plugin" });
+    const internals = plugin as unknown as {
+      app: unknown;
+      cfg: MdsmithSettings;
+    };
+    internals.app = app;
+    internals.cfg = { configPath, runMode: "onSave", fixOnSave: false };
+    return plugin;
+  }
+
+  const load = (plugin: MdsmithPlugin): Promise<string> =>
+    (
+      plugin as unknown as { loadConfigYAML(): Promise<string> }
+    ).loadConfigYAML();
+
+  test("auto-discovers the vault-root .mdsmith.yml when no Config path is set", async () => {
+    const plugin = makeConfigPlugin({
+      ".mdsmith.yml": "rules:\n  line-length: false\n",
+    });
+    expect(await load(plugin)).toBe("rules:\n  line-length: false\n");
+  });
+
+  test('falls back to "" when no path is set and the vault has no .mdsmith.yml', async () => {
+    const plugin = makeConfigPlugin({ "note.md": "# Hi\n" });
+    expect(await load(plugin)).toBe("");
+  });
+
+  test("an explicit Config path is read in preference to auto-discovery", async () => {
+    const plugin = makeConfigPlugin(
+      {
+        ".mdsmith.yml": "rules:\n  line-length: false\n",
+        "cfg/custom.yml": "rules:\n  no-bare-urls: false\n",
+      },
+      "cfg/custom.yml",
+    );
+    expect(await load(plugin)).toBe("rules:\n  no-bare-urls: false\n");
+  });
+});
+
 describe("engine-down / restart safety (Copilot review)", () => {
   test("teardownRuntime clears the active editor's diagnostics so none linger when the engine is down", () => {
     const { plugin, harness } = makePlugin({ runMode: "onSave" });

--- a/editors/obsidian/src/main.ts
+++ b/editors/obsidian/src/main.ts
@@ -33,6 +33,7 @@ import {
   type DebouncedFn,
   type LineCommand,
 } from "./actions";
+import { discoverConfigYAML } from "./config";
 import {
   editorExtensions,
   setDiagnostics,
@@ -191,20 +192,24 @@ export default class MdsmithPlugin extends Plugin {
     }
   }
 
-  // loadConfigYAML reads the override config file when configPath is
-  // set, else returns "" (engine defaults). The override is read through
-  // the vault adapter so it works on mobile too.
+  // loadConfigYAML resolves the YAML the engine compiles. An explicit
+  // Config path wins: it is read through the vault adapter (so it works
+  // on mobile too) and a read failure surfaces a Notice. With no path
+  // set, the plugin auto-discovers a .mdsmith.yml at the vault root; an
+  // absent file falls back to "" (the engine defaults).
   private async loadConfigYAML(): Promise<string> {
     const p = this.cfg.configPath.trim();
-    if (!p) return "";
-    try {
-      return await this.app.vault.adapter.read(p);
-    } catch (err) {
-      new Notice(
-        `mdsmith: could not read config ${p}: ${(err as Error).message}`,
-      );
-      return "";
+    if (p) {
+      try {
+        return await this.app.vault.adapter.read(p);
+      } catch (err) {
+        new Notice(
+          `mdsmith: could not read config ${p}: ${(err as Error).message}`,
+        );
+        return "";
+      }
     }
+    return discoverConfigYAML(this.app.vault.adapter);
   }
 
   // checkActiveFile lints the active Markdown buffer and pushes the

--- a/editors/obsidian/src/plugin.e2e.test.ts
+++ b/editors/obsidian/src/plugin.e2e.test.ts
@@ -26,10 +26,17 @@
 // toolchain is absent (mirrors wasm-runtime.test.ts).
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { CONFIG_FILE_NAME } from "./config";
 import { buildDecorations, decorationSetFor } from "./diagnostics";
 import MdsmithPlugin from "./main";
 import type { Diagnostic } from "./wasm-runtime";
@@ -177,7 +184,7 @@ interface Harness {
 // active fake view.
 async function bootPlugin(
   files: Record<string, string>,
-  cfg: { runMode?: string; fixOnSave?: boolean } = {},
+  cfg: { runMode?: string; fixOnSave?: boolean; configYAML?: string } = {},
 ): Promise<Harness> {
   type Handler = (f: { path: string }) => unknown;
   const vaultHandlers: Record<string, Handler[]> = {};
@@ -189,8 +196,14 @@ async function bootPlugin(
       adapter: {
         // The plugin reads its bundled assets through the adapter; serve
         // them from the temp plugin dir. Paths arrive as
-        // `${manifest.dir}/wasm_exec.js` etc.
+        // `${manifest.dir}/wasm_exec.js` etc. The vault-root .mdsmith.yml
+        // auto-discovery reads through the same adapter, so serve the
+        // test's config (when given) for that vault-relative name.
         async read(p: string): Promise<string> {
+          if (p === CONFIG_FILE_NAME) {
+            if (cfg.configYAML === undefined) throw new Error(`ENOENT: ${p}`);
+            return cfg.configYAML;
+          }
           return readFileSync(p, "utf8");
         },
         async readBinary(p: string): Promise<ArrayBuffer> {
@@ -199,6 +212,10 @@ async function bootPlugin(
             buf.byteOffset,
             buf.byteOffset + buf.byteLength,
           ) as ArrayBuffer;
+        },
+        async exists(p: string): Promise<boolean> {
+          if (p === CONFIG_FILE_NAME) return cfg.configYAML !== undefined;
+          return existsSync(p);
         },
       },
       getMarkdownFiles(): Array<{ path: string; extension: string }> {
@@ -328,6 +345,30 @@ describe.skipIf(skip)("plugin e2e (criteria 3 & 6)", () => {
     expect(decorationSetFor(doc, pushed ?? [])).not.toBe(
       decorationSetFor(doc, []),
     );
+  }, 120_000);
+
+  test("auto-discovers a vault-root .mdsmith.yml and compiles it into the session (no Config path set)", async () => {
+    // Criterion 3 proves the same LONG_LINE trips MDS001 under the
+    // defaults. Here a vault-root .mdsmith.yml turns line-length off;
+    // with discovery wired, the engine compiles that config and the
+    // long line no longer reports MDS001 — proving the config was found
+    // AND applied end to end, not merely read.
+    __resetEngineForTests();
+    const path = "note.md";
+    const source = `# Title\n\n${LONG_LINE}\n`;
+    const harness = await bootPlugin(
+      { [path]: source },
+      { configYAML: "rules:\n  line-length: false\n" },
+    );
+    const view = harness.newView(path, source);
+    harness.setActive(view);
+
+    await (
+      harness.plugin as unknown as { checkActiveFile(): Promise<void> }
+    ).checkActiveFile();
+
+    const pushed = view.editor.cm.lastDiagnostics ?? [];
+    expect(pushed.map((d) => d.rule)).not.toContain("MDS001");
   }, 120_000);
 
   test("criterion 6: a save fixes the active buffer in place with no restart", async () => {

--- a/editors/obsidian/src/settings.ts
+++ b/editors/obsidian/src/settings.ts
@@ -14,9 +14,10 @@ export type RunMode = "onType" | "onSave" | "off";
 
 // MdsmithSettings is the typed settings shape, persisted as JSON.
 export interface MdsmithSettings {
-  // configPath overrides the auto-discovered .mdsmith.yml. Empty defers
-  // to the engine's default. Changing it rebuilds the session (plan 215
-  // has no in-place reconfigure).
+  // configPath overrides auto-discovery. Empty auto-discovers a
+  // .mdsmith.yml at the vault root (and falls back to the engine
+  // defaults when there is none). Changing it rebuilds the session
+  // (plan 215 has no in-place reconfigure).
   configPath: string;
   runMode: RunMode;
   // fixOnSave runs Fix file 200 ms after each save when true.
@@ -131,8 +132,8 @@ export class MdsmithSettingTab extends PluginSettingTab {
     new Setting(this.containerEl)
       .setName("Config path")
       .setDesc(
-        "Override the auto-discovered .mdsmith.yml. Empty uses the engine " +
-          "default. Changing this rebuilds the lint session.",
+        "Path to a .mdsmith.yml, vault-relative. Empty auto-discovers one " +
+          "at the vault root. Changing this rebuilds the lint session.",
       )
       .addText(
         (text: {


### PR DESCRIPTION
## Problem

The Obsidian plugin didn't find `.mdsmith.yml`. It only loaded a config when the user explicitly set the **Config path** setting. With it empty (the default), `loadConfigYAML()` returned `""` immediately and the engine ran on built-in defaults — so a `.mdsmith.yml` dropped into the vault was silently ignored.

The setting's own description even claimed to "override the **auto-discovered** `.mdsmith.yml`" — but that discovery was never implemented.

## Fix

Add vault-root auto-discovery. A new `editors/obsidian/src/config.ts` reads `.mdsmith.yml` from the vault root through the `DataAdapter`, which sees dotfiles that Obsidian hides from its vault file API (the same adapter the explicit-path read already uses, so it works on mobile too).

- When **Config path** is empty, `loadConfigYAML()` now falls back to discovery instead of returning `""`.
- An absent or unreadable file still degrades to the engine defaults rather than throwing (an `exists` gate avoids exception-as-control-flow; a post-`exists` read failure is caught).
- An explicit **Config path** continues to take precedence.

This mirrors the CLI, which walks up to the nearest `.mdsmith.yml`. A vault has one root the adapter is rooted at and one lint session over it, so the analog is a single config at the vault root.

## Tests

- **Unit** (`config.test.ts`): `discoverConfigYAML` — present, absent, the exists-gate (no read when absent), read-failure degradation, custom name.
- **Unit** (`main.test.ts`): `loadConfigYAML` resolution — discover when empty, fall back to `""`, explicit-path precedence.
- **End-to-end** (`plugin.e2e.test.ts`): boots the **real WASM engine** with a vault-root `.mdsmith.yml` that disables `line-length`, and asserts the long line no longer reports `MDS001` — proving the config is found **and compiled**, not merely read. (Criterion 3 already proves the same line trips `MDS001` under defaults, so the contrast is airtight.)

`bunx tsc --noEmit` clean, all 82 plugin tests pass, and `mdsmith check .` passes (418 files).

## Docs / UX

Updated the Obsidian guide (install + settings table + troubleshooting) and the settings UI copy/comments to describe auto-discovery.

https://claude.ai/code/session_012oegF5TA5sxAJgfBoPnmwL

---
_Generated by [Claude Code](https://claude.ai/code/session_012oegF5TA5sxAJgfBoPnmwL)_