### PR TITLE
docs(plan 219): record multiplexed AST walk as a profiler-backed negative

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -147,7 +147,7 @@ footer: |
 | 217 | ✅     | opus   | [Obsidian plugin (WASM runtime)](plan/217_obsidian-plugin.md)                                                                           |
 | 218 | ✅     | sonnet | [Finish MD054 link-image-style coverage in MDS068](plan/218_finish-md054-link-image-style.md)                                           |
 | 218 | 🔲     | opus   | [WASM size reduction — CUE-free engine path and tinygo support](plan/218_wasm-size-reduction.md)                                        |
-| 219 | 🔲     | opus   | [Multiplexed AST walk to close the parity gap to mado](plan/219_multiplexed-ast-walk.md)                                                |
+| 219 | ✅     | opus   | [Multiplexed AST walk to close the parity gap to mado](plan/219_multiplexed-ast-walk.md)                                                |
 | 219 | ✅     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |

--- a/plan/219_multiplexed-ast-walk.md
+++ b/plan/219_multiplexed-ast-walk.md
@@ -1,7 +1,7 @@
 ---
 id: 219
 title: Multiplexed AST walk to close the parity gap to mado
-status: "🔲"
+status: "✅"
 model: opus
 depends-on: [175, 195]
 summary: >-
@@ -92,3 +92,39 @@ N.
 - [ ] `mdsmith check .` passes.
 - [ ] All tests pass: `go test ./...`
 - [ ] `go tool golangci-lint run` reports no issues
+
+## Outcome — not promoting (re-benchmarked post-#496)
+
+Closed as a profiler-backed negative. PR #491 was closed,
+not merged, so the boxes above stay unchecked. The shared
+walk for stateless `NodeChecker`s already lives in
+`internal/checker`. Folding the two stateful heading rules
+(MDS003, MDS005) into it wins nothing. Three independent
+signals agree:
+
+- **Direct A/B (this plan's spike).** The two heading
+  rules folded into the shared walk vs. their own walks,
+  on a heading-dense 120-file corpus, `-count=8`
+  single-core: median **34.6 ms both ways** — no
+  wall-time difference.
+- **Post-#496 re-benchmark.** On current `main` (with
+  #496's GC/allocation cuts landed), an instruction-level
+  profile of the neutral parity corpus puts the AST-walk
+  *traversal* at **~4.4% flat** (`ast.walkHelper`); the
+  ~21% beneath `ast.Walk` is per-node rule **work**, which
+  one shared traversal does not remove. Parse now
+  dominates (`ParseContext` ~38%, `parseBlock` ~24%).
+- **Where the mado gap actually is.** The parity
+  profiling behind #496 attributed the gap to
+  GC/allocation (~40% of executed instructions, since cut
+  by #496), a startup `cuelang`/`apd` decimal-table init,
+  and MDS062's backtracking regex — not walk count. #496
+  took the real win (−39% wall, −30% allocations) via a
+  different lever.
+
+One note on the rebase. The walk machinery has moved since
+this plan forked. It went out of
+`internal/engine/check.go` into `internal/checker`
+(plan 204 + #496). Adapting the multiplex dispatch is now
+a re-port onto a new package, not a replay. That is not
+worth it for a confirmed zero.


### PR DESCRIPTION
## What

Records the outcome of plan 219 (multiplexed AST walk) on `main` and marks it ✅ "nothing to promote", so the negative is preserved against the current baseline after PR #491 is closed.

## Why — re-benchmarked post-#496

The multiplexed walk yields **no measurable win**, confirmed by three independent signals:

1. **The plan's own A/B** — the two stateful heading rules (MDS003, MDS005) folded into the shared walk vs. their own walks, heading-dense 120-file corpus, `-count=8` single-core: **34.6 ms both ways**.
2. **Post-#496 profile** — on current `main`, AST-walk *traversal* is **~4.4% flat** (`ast.walkHelper`); the ~21% under `ast.Walk` is per-node rule *work* the multiplex can't remove. Parse now dominates (`ParseContext` ~38%, `parseBlock` ~24%).
3. **Where the gap is** — the parity profiling behind #496 attributed it to GC/allocation (~40% of instructions, since cut by #496), a startup `cuelang`/`apd` decimal init, and MDS062's backtracking regex — not walk count. #496 took the real win (−39% wall, −30% allocations).

The stateless-`NodeChecker` multiplex already in `internal/checker` stays; only the two-stateful-rule extension is dropped. For the record, the rebase is no longer a replay — the walk machinery moved `engine` → `checker` (plan 204 + #496), so it would be a re-port for a confirmed zero.

Closes the investigation behind #491 (which is being closed unmerged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLNpDmsk8rRuhwtvmvPUJp)_