### PR TITLE
ci(benchmark): publish rendered benchmark pages to the assets branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -76,7 +76,7 @@ jobs:
              docs/research/benchmarks/headline.fragment.md \
              artifacts/benchmarks/
           cp docs/research/benchmarks/data/*.json artifacts/benchmarks/data/
-          cp README.md artifacts/benchmarks/pages/README.md
+          cp README.md artifacts/benchmarks/pages/repo-readme.md
           cp docs/research/benchmarks/README.md \
              artifacts/benchmarks/pages/benchmark.md
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,12 +1,14 @@
 name: Cross-tool benchmark
 
 # Re-measure the mdsmith-vs-Rust benchmark on every merge to
-# main and publish the refreshed numbers to the orphan `assets`
-# branch (the demo.gif pattern). Record-only: it never gates a
-# merge or a release. The website pulls these numbers at
-# build time; the in-repo committed snapshot stays the
-# `bench-fragments` CI gate's source of truth and is unaffected
-# by this workflow.
+# main and publish to the orphan `assets` branch (the demo.gif
+# pattern): both the refreshed numbers (data + fragments) and
+# the benchmark Markdown pages rendered from main's READMEs with
+# those numbers spliced in. Record-only: it never gates a merge
+# or a release, and it never pushes to protected main — the
+# in-repo committed snapshot stays the `bench-fragments` gate's
+# source of truth, hand-refreshed via run.sh. The website pulls
+# the assets numbers at build time.
 
 on:
   push:
@@ -55,13 +57,28 @@ jobs:
           go run ./cmd/mdsmith fix \
             docs/research/benchmarks/results.fragment.md \
             docs/research/benchmarks/headline.fragment.md
-      - name: Stage publishable numbers
+      - name: Render the benchmark pages from main's READMEs
+        # Splice the freshly measured fragments into the pages that
+        # embed them via <?include?> — the top-level README (headline)
+        # and this benchmark README (result tables) — producing
+        # rendered Markdown to publish alongside the raw numbers. Runs
+        # in this creds-free record job (no push token), not the
+        # publish job. The working-tree edits are never committed; the
+        # in-repo snapshot on protected main is untouched.
         run: |
-          mkdir -p artifacts/benchmarks/data
+          go run ./cmd/mdsmith fix \
+            README.md \
+            docs/research/benchmarks/README.md
+      - name: Stage publishable numbers and rendered pages
+        run: |
+          mkdir -p artifacts/benchmarks/data artifacts/benchmarks/pages
           cp docs/research/benchmarks/results.fragment.md \
              docs/research/benchmarks/headline.fragment.md \
              artifacts/benchmarks/
           cp docs/research/benchmarks/data/*.json artifacts/benchmarks/data/
+          cp README.md artifacts/benchmarks/pages/README.md
+          cp docs/research/benchmarks/README.md \
+             artifacts/benchmarks/pages/benchmark.md
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-numbers

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -10,11 +10,12 @@ summary: >-
 Our own benchmark run, not a re-quote of each project's README.
 Reproduce it with [`run.sh`](run.sh), a thin wrapper over
 `mdsmith-release bench`. The same harness runs automatically on
-every merge to `main` and publishes the refreshed numbers to the
-orphan `assets` branch; the website reads them at build time
-(the demo.gif pattern). The committed `data/*.json` snapshot in
-this directory stays the `bench-fragments` gate's source of
-truth and is what the tables below render from in-repo.
+every merge to `main` and publishes to the orphan `assets`
+branch: the refreshed numbers plus this page and the repo README
+rendered with those numbers spliced in; the website reads them
+at build time (the demo.gif pattern). The committed `data/*.json`
+snapshot in this directory stays the `bench-fragments` gate's
+source of truth and is what the tables below render from in-repo.
 
 ## Method
 


### PR DESCRIPTION
## What

On every merge to `main`, render the benchmark Markdown pages — the top-level `README.md` (headline) and the benchmark `README.md` (result tables) — from main's sources with the freshly measured numbers spliced in, and publish them to the orphan **`assets` branch** alongside the raw numbers (`data/` + fragments).

## Why this shape

The original idea was to commit refreshed numbers back to `main`, but a 3-agent review found a hard blocker: **the default `GITHUB_TOKEN` cannot push to protected `main`** (proven by `merge-queue.yml` needing a dedicated bypass PAT). Working around it would have required a bypass PAT → which re-triggers the workflow (loop) → `[skip ci]` → and a build/push split to contain the bypass-token blast radius.

Publishing to **`assets`** sidesteps all of it: the `publish` job already has write access there, so there's **no protected-main push, no bypass token, no trigger loop, and no `set -e`/branch-protection hazards.**

## How

- **`record` job (creds-free):** after the bench, `mdsmith fix README.md docs/research/benchmarks/README.md` splices the fresh fragments into the page bodies, and the rendered pages are staged into the artifact under `pages/`. The render runs here precisely because this job holds **no push token** — addressing the review's "don't compile/run under a push token" concern.
- **`publish` job (git-only):** unchanged — it already copies the artifact subtree to `assets/benchmarks/`, so `pages/README.md` and `pages/benchmark.md` ride along.
- The in-repo committed snapshot on `main` is **untouched** — it stays the `bench-fragments` gate's source of truth, hand-refreshed via `run.sh`.

## Review findings, resolved

This supersedes the commit-to-main implementation (force-pushed over). The new shape moots the review's blocker (protected-main push), the `set -e`-in-`until` correctness bug, the bypass-token/compile-under-token security delta, and the phantom-`markdown-linters.md` issue (the render fixes only the two real includers).

## Validation

YAML parses (`record` + `publish` only); `go build` clean; the render step is a no-op exit-0 on in-sync fragments; `mdsmith check .` passes (422 files).

> Note: the branch name `benchmark-commit-to-main` is now a misnomer — the change publishes to `assets`, not main.