### PR TITLE
Plan 212 (task 5): adopt projection:inline in messaging

### DIFF
--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -492,7 +492,7 @@ kinds:
         - heading: null
         - heading: { regex: '^Headline$' }
           content:
-            - { kind: code-block, required: true }
+            - { kind: paragraph, projection: inline, required: true }
         - heading: { regex: '^Eyebrow$' }
           content:
             - { kind: paragraph, required: true }

--- a/PLAN.md
+++ b/PLAN.md
@@ -137,7 +137,7 @@ footer: |
 | 209 | ✅     | opus   | [Convention-per-file config under `.mdsmith/conventions/`](plan/209_convention-files.md)                                                |
 | 210 | ✅     | opus   | [Single source of truth for product messaging via `mdsmith extract`](plan/210_messaging-source-of-truth.md)                             |
 | 211 | 🔳     | opus   | [`<?include?>` projects any typed value of any kind via `extract`](plan/211_include-extract-value.md)                                   |
-| 212 | 🔳     | opus   | [`mdsmith extract` projects paragraph inline spans as data](plan/212_extract-inline-spans.md)                                           |
+| 212 | ✅     | opus   | [`mdsmith extract` projects paragraph inline spans as data](plan/212_extract-inline-spans.md)                                           |
 | 213 | 🔲     | opus   | [Built-in `no-llm-tells` convention with append-mode forbidden lists](plan/213_anti-slop-convention.md)                                 |
 | 214 | ✅     | sonnet | [MDS019 catalog: CUE-expression row templates](plan/214_catalog-cue-row-expressions.md)                                                 |
 | 214 | ⛔     | opus   | [Obsidian plugin via hand-rolled LSP bridge](plan/214_obsidian-plugin.md)                                                               |

--- a/cmd/mdsmith/e2e_extract_messaging_test.go
+++ b/cmd/mdsmith/e2e_extract_messaging_test.go
@@ -30,7 +30,7 @@ const messagingKindCfg = `kinds:
         - heading: null
         - heading: { regex: '^Headline$' }
           content:
-            - { kind: code-block, required: true }
+            - { kind: paragraph, projection: inline, required: true }
         - heading: { regex: '^Eyebrow$' }
           content:
             - { kind: paragraph, required: true }
@@ -73,9 +73,7 @@ const messagingFixture = "---\n" +
 	"\n" +
 	"## Headline\n" +
 	"\n" +
-	"```markdown\n" +
 	"Mark*down*, smithed.\n" +
-	"```\n" +
 	"\n" + `## Eyebrow
 
 Eyebrow text.
@@ -118,11 +116,11 @@ var expectedMessagingFrontmatter = []string{
 
 // expectedMessagingSections lists every top-level body-section
 // key the messaging kind must project (paragraph sections carry
-// a `text` field, the headline carries a `code` field — the
-// raw Markdown source whose single `*…*` emphasis span the
-// release tooling splits into pre/em/post). Adding a field
-// requires updating .mdsmith.yml, the real source file, this
-// constant, and the sync registry in one change.
+// a `text` field, the headline carries an `inline` span list —
+// the typed projection whose single `emphasis` span the release
+// tooling splits into pre/em/post). Adding a field requires
+// updating .mdsmith.yml, the real source file, this constant,
+// and the sync registry in one change.
 var expectedMessagingSections = []string{
 	"eyebrow",
 	"lead",
@@ -161,12 +159,20 @@ func TestE2E_Extract_Messaging(t *testing.T) {
 		assert.True(t, isString, "field %q is not a string: %T", key, v)
 		assert.NotEmpty(t, s, "field %q is empty", key)
 	}
-	// Headline projects as a code block (raw Markdown source).
+	// Headline projects as an inline-span list: the release tooling
+	// finds the single emphasis span and splits pre/em/post around
+	// it.
 	headline, ok := got["headline"].(map[string]any)
 	require.True(t, ok, "missing headline section")
-	src, isString := headline["code"].(string)
-	assert.True(t, isString, "headline.code not a string: %T", headline["code"])
-	assert.Contains(t, src, "*", "headline source must keep the emphasis span")
+	spans, isList := headline["inline"].([]any)
+	require.True(t, isList, "headline.inline not a list: %T", headline["inline"])
+	var emCount int
+	for _, s := range spans {
+		if s.(map[string]any)["span"] == "emphasis" {
+			emCount++
+		}
+	}
+	assert.Equal(t, 1, emCount, "headline must carry exactly one emphasis span")
 
 	for _, key := range expectedMessagingSections {
 		sec, present := got[key].(map[string]any)

--- a/docs/brand/messaging.md
+++ b/docs/brand/messaging.md
@@ -17,17 +17,14 @@ Edit a section here, then run `mdsmith-release sync-messaging`
 to propagate the change to every tracked surface. CI runs
 `sync-messaging --check` and fails the build on drift.
 
+The Headline keeps exactly one `*emphasized*` span (single
+asterisks, not `**`). The hero template splits the line on that
+span, and `sync-messaging --check` fails if the span is missing
+or doubled.
+
 ## Headline
 
-The website hero template renders the headline as
-`<h1>{pre}<em>{em}</em>{post}</h1>`. The raw Markdown source
-lives in the code block below; `mdsmith-release sync-messaging`
-parses the single emphasis span (`*…*`) to derive the pre / em
-/ post split.
-
-```markdown
 Mark*down*, smithed.
-```
 
 ## Eyebrow
 

--- a/internal/release/messaging.go
+++ b/internal/release/messaging.go
@@ -1,16 +1,11 @@
 package release
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
-
-	"github.com/yuin/goldmark/ast"
-
-	"github.com/jeduden/mdsmith/pkg/markdown"
 )
 
 // MessagingKind is the kind name registered in .mdsmith.yml that
@@ -23,7 +18,7 @@ const MessagingSourceFile = "docs/brand/messaging.md"
 
 // Messaging is the flat, in-process Go value every patcher
 // consumes. The JSON shape `mdsmith extract messaging`
-// produces (frontmatter scalars + a code-block headline
+// produces (frontmatter scalars + an inline-span headline
 // section + paragraph sections for the prose fields) is
 // decoded via the internal `messagingDoc` envelope in
 // LoadMessaging and copied here; no field on Messaging is
@@ -61,16 +56,17 @@ func (m *Messaging) Headline() string {
 // LoadMessaging projects MessagingSourceFile through
 // `mdsmith extract <MessagingKind> --format json` and decodes
 // it into a typed Messaging value. The JSON shape mirrors the
-// kind's schema: `title`, `summary`, and the headline triple
-// live under `frontmatter`; the prose values
-// (`eyebrow`, `lead`, `tagline`, and the five per-surface
-// descriptions) live under their own top-level objects keyed
-// by the section's bind/slug, each carrying a `text` field —
-// the projection rule for a paragraph under an H2. The mdsmith
-// binary is invoked via `go run ./cmd/mdsmith` so the same
-// source tree drives the linter and the release tooling.
-// Every documented field must be non-empty; a missing or blank
-// field is a hard error.
+// kind's schema: `title` and `summary` live under `frontmatter`;
+// the headline lives under a top-level `headline` object whose
+// `inline` array is the paragraph's typed inline-span projection
+// (plan 212); the prose values (`eyebrow`, `lead`, `tagline`,
+// and the five per-surface descriptions) live under their own
+// top-level objects keyed by the section's bind/slug, each
+// carrying a `text` field — the projection rule for a paragraph
+// under an H2. The mdsmith binary is invoked via
+// `go run ./cmd/mdsmith` so the same source tree drives the
+// linter and the release tooling. Every documented field must be
+// non-empty; a missing or blank field is a hard error.
 func LoadMessaging(root string) (*Messaging, error) {
 	out, err := messagingExtractor(root)
 	if err != nil {
@@ -80,13 +76,13 @@ func LoadMessaging(root string) (*Messaging, error) {
 	if err := json.Unmarshal(out, &doc); err != nil {
 		return nil, fmt.Errorf("decode messaging json: %w", err)
 	}
-	// An empty headline.code is left for Validate to surface as
-	// the standard missing-field message; a non-empty code that
-	// does not match the canonical shape is a hard headline
-	// error that points at the parse problem directly.
+	// An empty headline.inline is left for Validate to surface as
+	// the standard missing-field message; a non-empty span list
+	// that does not match the canonical shape is a hard headline
+	// error that points at the problem directly.
 	var pre, em, post string
-	if strings.TrimSpace(doc.Headline.Code) != "" {
-		p, e, s, perr := parseHeadlineEmphasis(doc.Headline.Code)
+	if len(doc.Headline.Inline) > 0 {
+		p, e, s, perr := splitHeadlineSpans(doc.Headline.Inline)
 		if perr != nil {
 			return nil, fmt.Errorf("headline: %w", perr)
 		}
@@ -113,102 +109,130 @@ func LoadMessaging(root string) (*Messaging, error) {
 	return &m, nil
 }
 
-// parseHeadlineEmphasis walks the headline source as Markdown
-// via pkg/markdown.Parse (the same goldmark parser the linter
-// uses) and splits it on its single Level-1 emphasis span.
-// Returns pre, em, post for the website hero template
-// `<h1>{pre}<em>{em}</em>{post}</h1>`. Errors if the source
-// has zero or more than one Level-1 emphasis span — the hero
-// template can render only one — or if the parse produces
-// anything other than a single Paragraph.
+// headlineSpan is one element of the headline paragraph's `inline`
+// projection (plan 212). It is the typed shape `mdsmith extract`
+// emits; the release tool reads it directly instead of re-parsing
+// Markdown. Leaf spans (text, code, autolink) carry Value; container
+// spans (emphasis, strong, link) carry Children.
+type headlineSpan struct {
+	Span     string         `json:"span"`
+	Value    string         `json:"value"`
+	Level    int            `json:"level"`
+	Children []headlineSpan `json:"children"`
+}
+
+// splitHeadlineSpans walks the top-level inline spans of the headline
+// paragraph and splits them on the single emphasis span. It returns
+// pre, em, post for the website hero template
+// `<h1>{pre}<em>{em}</em>{post}</h1>`.
 //
-// The release tool does no Markdown parsing itself: the AST is
-// the projection mdsmith owns; this function only walks it.
-func parseHeadlineEmphasis(src string) (pre, em, post string, err error) {
-	doc := markdown.Parse([]byte(strings.TrimSpace(src)))
-	body := doc.Body
-	root := doc.AST
-	// The headline source is a single line of inline content;
-	// the parser wraps it in a single Paragraph.
-	first := root.FirstChild()
-	if first == nil || first.NextSibling() != nil ||
-		first.Kind() != ast.KindParagraph {
-		return "", "", "", fmt.Errorf(
-			"expected a single paragraph, got %q", src)
-	}
-	// Walk the paragraph's inline children once. Accumulate text
-	// before / inside / after the Emphasis node; reject when the
-	// shape doesn't match.
-	var preBuf, emBuf, postBuf bytes.Buffer
+// The release tool does no Markdown parsing: the inline projection is
+// what mdsmith owns; this function only walks the typed data. It
+// errors when the spans have zero or more than one top-level
+// `emphasis` span (the hero template renders exactly one <em>), when
+// the single span is `strong` rather than `emphasis` (double `**`
+// means <strong>, not <em>), when a non-text span sits at the top
+// level, or when the emphasis span's children are not all text.
+func splitHeadlineSpans(spans []headlineSpan) (pre, em, post string, err error) {
+	var preB, emB, postB strings.Builder
 	emCount := 0
-	for child := first.FirstChild(); child != nil; child = child.NextSibling() {
-		switch n := child.(type) {
-		case *ast.Text:
-			seg := n.Segment.Value(body)
+	for _, s := range spans {
+		switch s.Span {
+		case "text":
 			if emCount == 0 {
-				preBuf.Write(seg)
+				preB.WriteString(s.Value)
 			} else {
-				postBuf.Write(seg)
+				postB.WriteString(s.Value)
 			}
-		case *ast.Emphasis:
-			if n.Level != 1 {
-				return "", "", "", fmt.Errorf(
-					"headline emphasis must use single `*…*` (em), not double `**`")
+		case "break":
+			// A reflowed headline projects a soft/hard line break
+			// between text runs; render it as a space (matching the
+			// plain-text extractor) so wrapping the source line does
+			// not fail sync-messaging.
+			if emCount == 0 {
+				preB.WriteByte(' ')
+			} else {
+				postB.WriteByte(' ')
 			}
+		case "emphasis":
 			emCount++
 			if emCount > 1 {
-				return "", "", "", fmt.Errorf(
+				return "", "", "", errors.New(
 					"expected exactly one `*…*` emphasis span, got more")
 			}
-			for t := n.FirstChild(); t != nil; t = t.NextSibling() {
-				tn, ok := t.(*ast.Text)
-				if !ok {
-					return "", "", "", fmt.Errorf(
-						"headline emphasis must contain plain text only")
-				}
-				emBuf.Write(tn.Segment.Value(body))
+			flat, ferr := flattenTextChildren(s.Children)
+			if ferr != nil {
+				return "", "", "", ferr
 			}
+			emB.WriteString(flat)
+		case "strong":
+			return "", "", "", errors.New(
+				"headline emphasis must use single `*…*` (em), not " +
+					"a `strong` span (double `**`)")
 		default:
 			return "", "", "", fmt.Errorf(
-				"unsupported inline node in headline: %T", child)
+				"unsupported inline span in headline: %q", s.Span)
 		}
 	}
 	if emCount == 0 {
-		return "", "", "", fmt.Errorf(
+		return "", "", "", errors.New(
 			"expected exactly one `*…*` emphasis span, got none")
 	}
-	if emBuf.Len() == 0 {
-		return "", "", "", fmt.Errorf("emphasis span is empty")
+	if emB.Len() == 0 {
+		return "", "", "", errors.New("emphasis span is empty")
 	}
-	return preBuf.String(), emBuf.String(), postBuf.String(), nil
+	return preB.String(), emB.String(), postB.String(), nil
+}
+
+// flattenTextChildren concatenates a span's children, requiring every
+// child to be a text leaf. The hero template's <em> renders inline
+// text only, so a nested emphasis, code, or link inside the headline
+// emphasis is rejected.
+func flattenTextChildren(children []headlineSpan) (string, error) {
+	var b strings.Builder
+	for _, c := range children {
+		switch c.Span {
+		case "text":
+			b.WriteString(c.Value)
+		case "break":
+			// A break inside the emphasized run (the emphasis wrapped
+			// across source lines) renders as a space, same as the
+			// top-level handling.
+			b.WriteByte(' ')
+		default:
+			return "", errors.New(
+				"headline emphasis must contain plain text only")
+		}
+	}
+	return b.String(), nil
 }
 
 // messagingDoc mirrors the shape `mdsmith extract messaging`
 // emits. The body-section fields land at the document root
-// (not under `frontmatter`); each carries a `text` field that
-// holds the paragraph the H2 section contains.
+// (not under `frontmatter`); each prose section carries a `text`
+// field, while the headline carries an `inline` span list.
 type messagingDoc struct {
 	Frontmatter struct {
 		Title   string `json:"title"`
 		Summary string `json:"summary"`
 	} `json:"frontmatter"`
-	Headline                    sectionCode `json:"headline"`
-	Eyebrow                     sectionText `json:"eyebrow"`
-	Lead                        sectionText `json:"lead"`
-	Tagline                     sectionText `json:"tagline"`
-	VSCodeDescription           sectionText `json:"vscode-description"`
-	VSCodeOverview              sectionText `json:"vscode-overview"`
-	ClaudeCodeLSPDescription    sectionText `json:"claude-code-lsp-description"`
-	ClaudeCodeSkillsDescription sectionText `json:"claude-code-skills-description"`
-	ClaudeCodeAuditDescription  sectionText `json:"claude-code-audit-description"`
+	Headline                    sectionInline `json:"headline"`
+	Eyebrow                     sectionText   `json:"eyebrow"`
+	Lead                        sectionText   `json:"lead"`
+	Tagline                     sectionText   `json:"tagline"`
+	VSCodeDescription           sectionText   `json:"vscode-description"`
+	VSCodeOverview              sectionText   `json:"vscode-overview"`
+	ClaudeCodeLSPDescription    sectionText   `json:"claude-code-lsp-description"`
+	ClaudeCodeSkillsDescription sectionText   `json:"claude-code-skills-description"`
+	ClaudeCodeAuditDescription  sectionText   `json:"claude-code-audit-description"`
 }
 
 type sectionText struct {
 	Text string `json:"text"`
 }
 
-type sectionCode struct {
-	Code string `json:"code"`
+type sectionInline struct {
+	Inline []headlineSpan `json:"inline"`
 }
 
 // Validate fails fast if any required field is empty. The

--- a/internal/release/messaging_test.go
+++ b/internal/release/messaging_test.go
@@ -21,12 +21,23 @@ func repoRoot(t *testing.T) string {
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 }
 
+// canonicalHeadlineInline is the inline-span projection of
+// `Mark*down*, smithed.` — the shape `mdsmith extract` now emits for
+// the Headline paragraph.
+const canonicalHeadlineInline = `{ "inline": [
+    { "span": "text", "value": "Mark" },
+    { "span": "emphasis", "level": 1, "children": [
+      { "span": "text", "value": "down" }
+    ]},
+    { "span": "text", "value": ", smithed." }
+  ]}`
+
 const fullMessagingJSON = `{
   "frontmatter": {
     "title": "mdsmith product messaging",
     "summary": "Canonical product messaging."
   },
-  "headline": { "code": "Mark*down*, smithed." },
+  "headline": ` + canonicalHeadlineInline + `,
   "eyebrow": { "text": "Markdown as a single source of truth" },
   "lead": { "text": "Lead text." },
   "tagline": { "text": "Tagline text." },
@@ -86,7 +97,7 @@ func TestLoadMessaging_WhitespaceOnlyFieldFails(t *testing.T) {
 	// sections at the document root, not under `frontmatter`).
 	bad := `{
 		"frontmatter": {"title": "t", "summary": "s"},
-		"headline":  {"code": "Mark*down*, smithed."},
+		"headline":  ` + canonicalHeadlineInline + `,
 		"eyebrow":   {"text": "e"},
 		"lead":      {"text": "   \t\n"},
 		"tagline":   {"text": "tg"},
@@ -116,63 +127,82 @@ func TestLoadMessaging_ExtractorError(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
-func TestParseHeadlineEmphasis_CanonicalShape(t *testing.T) {
-	pre, em, post, err := parseHeadlineEmphasis("Mark*down*, smithed.")
+// spans is a tiny constructor helper so the splitHeadlineSpans tests
+// build inline span lists without repeating the literal shape.
+func textSpan(v string) headlineSpan { return headlineSpan{Span: "text", Value: v} }
+
+func TestSplitHeadlineSpans_CanonicalShape(t *testing.T) {
+	pre, em, post, err := splitHeadlineSpans([]headlineSpan{
+		textSpan("Mark"),
+		{Span: "emphasis", Level: 1, Children: []headlineSpan{textSpan("down")}},
+		textSpan(", smithed."),
+	})
 	require.NoError(t, err)
 	assert.Equal(t, "Mark", pre)
 	assert.Equal(t, "down", em)
 	assert.Equal(t, ", smithed.", post)
 }
 
-func TestParseHeadlineEmphasis_NoEmphasisFails(t *testing.T) {
-	_, _, _, err := parseHeadlineEmphasis("Markdown, smithed.")
+func TestSplitHeadlineSpans_NoEmphasisFails(t *testing.T) {
+	_, _, _, err := splitHeadlineSpans([]headlineSpan{textSpan("Markdown, smithed.")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one")
 }
 
-func TestParseHeadlineEmphasis_MultipleEmphasisFails(t *testing.T) {
-	// Two `*…*` spans cannot map to a single `<em>` in the
-	// hero template; the parser must reject.
-	_, _, _, err := parseHeadlineEmphasis("Mark*down*, *smithed*.")
+func TestSplitHeadlineSpans_MultipleEmphasisFails(t *testing.T) {
+	// Two emphasis spans cannot map to a single <em> in the hero
+	// template; the walk must reject.
+	_, _, _, err := splitHeadlineSpans([]headlineSpan{
+		{Span: "emphasis", Level: 1, Children: []headlineSpan{textSpan("a")}},
+		{Span: "emphasis", Level: 1, Children: []headlineSpan{textSpan("b")}},
+	})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
 }
 
-func TestParseHeadlineEmphasis_EmptySpanFails(t *testing.T) {
-	_, _, _, err := parseHeadlineEmphasis("Mark**, smithed.")
+func TestSplitHeadlineSpans_EmptySpanFails(t *testing.T) {
+	_, _, _, err := splitHeadlineSpans([]headlineSpan{
+		textSpan("Mark"),
+		{Span: "emphasis", Level: 1},
+		textSpan(", smithed."),
+	})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
 }
 
-func TestParseHeadlineEmphasis_StrongRejected(t *testing.T) {
-	// Double asterisks mean strong / <strong>, not <em>. The
-	// website hero template only knows the em form.
-	_, _, _, err := parseHeadlineEmphasis("Mark**down**, smithed.")
+func TestSplitHeadlineSpans_StrongRejected(t *testing.T) {
+	// A strong span (level 2 emphasis) means <strong>, not <em>.
+	// The website hero template only knows the em form.
+	_, _, _, err := splitHeadlineSpans([]headlineSpan{
+		textSpan("Mark"),
+		{Span: "strong", Level: 2, Children: []headlineSpan{textSpan("down")}},
+		textSpan(", smithed."),
+	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "double")
+	assert.Contains(t, err.Error(), "strong")
 }
 
-func TestParseHeadlineEmphasis_NonParagraphRejected(t *testing.T) {
-	// A line that goldmark parses as a heading rather than a
-	// paragraph (a `#` prefix) fails the single-paragraph
-	// guard.
-	_, _, _, err := parseHeadlineEmphasis("# Mark*down*, smithed.")
+func TestSplitHeadlineSpans_UnsupportedTopLevelRejected(t *testing.T) {
+	// A code span at the top level is not text or emphasis; the
+	// headline split rejects it.
+	_, _, _, err := splitHeadlineSpans([]headlineSpan{
+		{Span: "emphasis", Level: 1, Children: []headlineSpan{textSpan("down")}},
+		{Span: "code", Value: "x"},
+	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "single paragraph")
+	assert.Contains(t, err.Error(), "code")
 }
 
-func TestParseHeadlineEmphasis_UnsupportedInlineRejected(t *testing.T) {
-	// A bare URL parses as an autolink — not Text or Emphasis,
-	// so the default case in the inline switch fires.
-	_, _, _, err := parseHeadlineEmphasis("Mark*down*, smithed. <https://x.test>")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported inline")
-}
-
-func TestParseHeadlineEmphasis_NestedInsideEmphasisRejected(t *testing.T) {
-	// Inline code inside the emphasis span (`*x`y`z*` parses as
-	// Emphasis containing Text + CodeSpan + Text) — the inner
-	// walk over the emphasis children rejects anything that
-	// isn't plain text.
-	_, _, _, err := parseHeadlineEmphasis("Mark*x`y`z*, smithed.")
+func TestSplitHeadlineSpans_NonTextEmphasisChildRejected(t *testing.T) {
+	// Inline code inside the emphasis span — the em flatten step
+	// rejects anything that is not a text leaf.
+	_, _, _, err := splitHeadlineSpans([]headlineSpan{
+		textSpan("Mark"),
+		{Span: "emphasis", Level: 1, Children: []headlineSpan{
+			textSpan("d"), {Span: "code", Value: "own"},
+		}},
+		textSpan(", smithed."),
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "plain text only")
 }
@@ -188,13 +218,35 @@ func TestMessaging_Headline(t *testing.T) {
 			"website hero splits into pre/em/post")
 }
 
-func TestLoadMessaging_HeadlineParseError(t *testing.T) {
-	// headline.code is non-empty but has no `*…*` span; the
-	// parser surfaces an error and LoadMessaging wraps it with a
+func TestSplitHeadlineSpans_BreakRendersAsSpace(t *testing.T) {
+	// A reflowed headline projects `break` spans between text runs
+	// (and may carry one inside the emphasis). They render as spaces
+	// instead of failing the split, so wrapping the source line does
+	// not break sync-messaging.
+	pre, em, post, err := splitHeadlineSpans([]headlineSpan{
+		textSpan("Mark"),
+		{Span: "break"},
+		textSpan("smith"),
+		{Span: "emphasis", Level: 1, Children: []headlineSpan{
+			textSpan("ma"), {Span: "break"}, textSpan("gic"),
+		}},
+		textSpan(","),
+		{Span: "break"},
+		textSpan("fast."),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Mark smith", pre)
+	assert.Equal(t, "ma gic", em)
+	assert.Equal(t, ", fast.", post)
+}
+
+func TestLoadMessaging_HeadlineError(t *testing.T) {
+	// headline.inline is non-empty but carries no emphasis span;
+	// the split surfaces an error and LoadMessaging wraps it with a
 	// "headline:" prefix.
 	bad := `{
 		"frontmatter": {"title": "t", "summary": "s"},
-		"headline":  {"code": "Markdown, smithed."},
+		"headline":  {"inline": [{"span": "text", "value": "Markdown, smithed."}]},
 		"eyebrow":   {"text": "e"},
 		"lead":      {"text": "l"},
 		"tagline":   {"text": "tg"},

--- a/plan/212_extract-inline-spans.md
+++ b/plan/212_extract-inline-spans.md
@@ -1,7 +1,7 @@
 ---
 id: 212
 title: "`mdsmith extract` projects paragraph inline spans as data"
-status: "🔳"
+status: "✅"
 summary: >-
   Add a content-entry projection mode that emits a paragraph's
   inline spans (text, emphasis, strong, code, link) as a
@@ -70,13 +70,6 @@ the release side. Just a typed walk over data.
 
 ## Tasks
 
-> **Adoption deferred.** Task 5 and the `messaging.go`
-> acceptance criterion below are reverted from this PR:
-> `mdsmith-fixed-version` runs the pinned release binary, which
-> cannot parse `projection:` until plan-212 ships and the
-> baseline is bumped. Re-apply after the pin bump — see
-> [the doc](../docs/development/adopt-new-directive-syntax.md).
-
 1. [x] **Content-projection field on schema.** Add a `projection:`
    key to schema content entries. Allowed values: `text` (the
    current default), `code` (for code blocks, already
@@ -109,7 +102,7 @@ the release side. Just a typed walk over data.
    sibling keys; declare and document the default keys
    (`text` and `inline`) so a schema author can resolve a
    collision via `bind:`.
-5. [ ] **Adopt in messaging.** Switch
+5. [x] **Adopt in messaging.** Switch
    [`docs/brand/messaging.md`](../docs/brand/messaging.md)'s
    `## Headline` from a code block to a paragraph with
    `projection: inline`. Drop the
@@ -144,12 +137,11 @@ the release side. Just a typed walk over data.
 - [x] Nested inline (``**`code`**``, `[**bold**](url)`, etc.)
   round-trips through the projection without error; the
   consumer walks one uniform shape.
-- [ ] `internal/release/messaging.go` no longer imports
+- [x] `internal/release/messaging.go` no longer imports
   `pkg/markdown` or parses Markdown itself. The headline parsing
   helper is deleted; the release tool reads `headline.inline`
   directly. (`syncdocs.go`'s unrelated `pkg/markdown` use for
-  Hugo doc reconciliation is out of scope.) *(Deferred with
-  task 5.)*
+  Hugo doc reconciliation is out of scope.)
 - [x] `mdsmith extract` rejects an unsupported inline node
   (raw HTML, image, custom) when the schema asks for `inline`.
 - [x] The mapping table is documented in the extract


### PR DESCRIPTION
Completes the **deferred task 5** of [plan/212_extract-inline-spans.md](plan/212_extract-inline-spans.md).

The core of plan 212 (the `projection: inline` engine, schema validation, serializers, docs) shipped in #448. Task 5 — adopting the new projection in the repo's own messaging source — was deferred because the pinned `mdsmith-fixed-version` CI binary couldn't parse `projection:` yet. That gate has now cleared: the pinned baseline is **v0.33.0** (which contains the #448 merge), so checked-in Markdown may use `projection:`.

This PR re-applies the adoption:

- `.mdsmith.yml`: `messaging` kind's `## Headline` content entry `code-block` → `paragraph` + `projection: inline` (edit explicitly approved by the maintainer).
- `docs/brand/messaging.md`: `## Headline` becomes a paragraph instead of a code block.
- `internal/release/messaging.go`: drop the `pkg/markdown` import and delete `parseHeadlineEmphasis`; read `headline.inline` as typed spans (find the single top-level emphasis span, flatten its text children → pre/em/post).
- Plan file: check off task 5 + its acceptance criterion, drop the "Adoption deferred" note, flip status 🔳 → ✅.

`mdsmith-release sync-messaging --check` must stay clean.

https://claude.ai/code/session_01NZPdHGqY2f4ikQi9p9nEyq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZPdHGqY2f4ikQi9p9nEyq)_