### PR TITLE
test(pkg/mdsmith): add unit tests for five private helpers (plan 223)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -152,7 +152,7 @@ footer: |
 | 220 | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221 | 🔳     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
 | 222 | ✅     | opus   | [Single source of truth for distribution channels](plan/222_distribution-channel-ssot.md)                                               |
-| 223 | 🔲     |        | [Add unit tests for pkg/mdsmith private helpers](plan/223_arch-fix-mdsmith-helper-tests.md)                                             |
+| 223 | ✅     |        | [Add unit tests for pkg/mdsmith private helpers](plan/223_arch-fix-mdsmith-helper-tests.md)                                             |
 | 224 | ✅     |        | [Split internal/lint along question boundaries](plan/224_arch-fix-lint-srp.md)                                                          |
 | 225 | ✅     |        | [Add internal/punkt to the architecture layering map](plan/225_arch-fix-punkt-layering.md)                                              |
 | 230 | ✅     | opus   | [Navigable schema diagnostics in the editor](plan/230_navigable-schema-diagnostics.md)                                                  |

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -559,8 +559,9 @@ func (s *Session) parseCacheHits() int {
 
 // frontMatterEnabled reports whether front-matter stripping is on for
 // the compiled config. Mirrors cmd/mdsmith's helper of the same name.
+// A nil cfg is treated as the default (enabled).
 func frontMatterEnabled(cfg *config.Config) bool {
-	return cfg.FrontMatter == nil || *cfg.FrontMatter
+	return cfg == nil || cfg.FrontMatter == nil || *cfg.FrontMatter
 }
 
 // hashBytes returns a fast non-cryptographic content hash for cache

--- a/pkg/mdsmith/session_api_test.go
+++ b/pkg/mdsmith/session_api_test.go
@@ -2,6 +2,7 @@ package mdsmith
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -332,6 +333,108 @@ func TestKindsFieldsParseError(t *testing.T) {
 	s := newTestSession(t, cfg, files)
 	if _, err := s.Kinds("seq.md"); err == nil {
 		t.Fatal("Kinds: expected a ParseFrontMatterFields error for sequence front matter, got nil")
+	}
+}
+
+// --- capabilityList ---
+
+// TestCapabilityList asserts the returned slice contains the expected
+// capability names in sorted order. The WASM bridge reads the same list,
+// so any rename must update both sides; this test locks the exact names.
+func TestCapabilityList(t *testing.T) {
+	got := capabilityList()
+	want := []string{"check", "fix", "kinds"}
+	if len(got) != len(want) {
+		t.Fatalf("capabilityList() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("capabilityList()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// --- frontMatterEnabled ---
+
+// TestFrontMatterEnabled covers enabled (nil pointer — the default),
+// explicitly true, and explicitly false. The helper gates both
+// StripFrontMatter on the engine runner and frontMatterFor's parse path.
+func TestFrontMatterEnabled(t *testing.T) {
+	// nil config → enabled (default)
+	if !frontMatterEnabled(nil) {
+		t.Fatal("frontMatterEnabled(nil) = false, want true")
+	}
+	// FrontMatter field nil (key absent in YAML) → enabled
+	cfg, err := ConfigYAML("").loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if !frontMatterEnabled(cfg) {
+		t.Fatal("frontMatterEnabled(defaultConfig) = false, want true")
+	}
+	// Explicitly enabled
+	cfgTrue, err := ConfigYAML("front-matter: true").loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig true: %v", err)
+	}
+	if !frontMatterEnabled(cfgTrue) {
+		t.Fatal("frontMatterEnabled(front-matter:true) = false, want true")
+	}
+	// Explicitly disabled
+	cfgFalse, err := ConfigYAML("front-matter: false").loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig false: %v", err)
+	}
+	if frontMatterEnabled(cfgFalse) {
+		t.Fatal("frontMatterEnabled(front-matter:false) = true, want false")
+	}
+}
+
+// --- firstError ---
+
+// TestFirstError covers the empty-slice (nil) and non-empty contracts.
+func TestFirstError(t *testing.T) {
+	if got := firstError(nil); got != nil {
+		t.Fatalf("firstError(nil) = %v, want nil", got)
+	}
+	if got := firstError([]error{}); got != nil {
+		t.Fatalf("firstError([]) = %v, want nil", got)
+	}
+	sentinel := errors.New("sentinel")
+	other := errors.New("other")
+	got := firstError([]error{sentinel, other})
+	if got != sentinel {
+		t.Fatalf("firstError([sentinel, other]) = %v, want sentinel", got)
+	}
+}
+
+// --- cloneDiagnostics ---
+
+// TestCloneDiagnostics asserts the clone is a distinct backing array and
+// that mutating it does not touch the source slice.
+func TestCloneDiagnostics(t *testing.T) {
+	// nil input must return nil (preserves the public no-diagnostics contract)
+	if got := cloneDiagnostics(nil); got != nil {
+		t.Fatalf("cloneDiagnostics(nil) = %v, want nil", got)
+	}
+	// Non-nil: clone is distinct but carries the same values
+	src := []Diagnostic{
+		{Rule: "MDS001", Message: "alpha"},
+		{Rule: "MDS002", Message: "beta"},
+	}
+	clone := cloneDiagnostics(src)
+	if len(clone) != len(src) {
+		t.Fatalf("clone length = %d, want %d", len(clone), len(src))
+	}
+	for i := range src {
+		if clone[i].Rule != src[i].Rule || clone[i].Message != src[i].Message {
+			t.Fatalf("clone[%d] = %+v, want Rule=%q Message=%q", i, clone[i], src[i].Rule, src[i].Message)
+		}
+	}
+	// Mutate the clone; source must be untouched
+	clone[0].Message = "mutated"
+	if src[0].Message != "alpha" {
+		t.Fatalf("mutating clone poisoned source: src[0].Message = %q", src[0].Message)
 	}
 }
 

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -266,6 +266,28 @@ func TestMemFSGlobDoublestar(t *testing.T) {
 	}
 }
 
+// --- indexSlash ---
+
+// TestIndexSlash covers the four boundary cases: no slash, slash at
+// index 0, slash in the middle, and slash at the last position.
+func TestIndexSlash(t *testing.T) {
+	cases := []struct {
+		input string
+		want  int
+	}{
+		{"noslash", -1},
+		{"/leading", 0},
+		{"mid/dle", 3},
+		{"trailing/", 8},
+	}
+	for _, tc := range cases {
+		got := indexSlash(tc.input)
+		if got != tc.want {
+			t.Errorf("indexSlash(%q) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}
+
 // Workspace is satisfied by both implementations.
 var (
 	_ Workspace = OSWorkspace{}

--- a/plan/223_arch-fix-mdsmith-helper-tests.md
+++ b/plan/223_arch-fix-mdsmith-helper-tests.md
@@ -1,7 +1,7 @@
 ---
 id: 223
 title: Add unit tests for pkg/mdsmith private helpers
-status: "🔲"
+status: "✅"
 summary: >-
   Five private helpers in the new public
   pkg/mdsmith package lack dedicated unit
@@ -64,13 +64,13 @@ not test-only):
 
 ## Acceptance Criteria
 
-- [ ] `TestCapabilityList` exists and
+- [x] `TestCapabilityList` exists and
   passes.
-- [ ] `TestFrontMatterEnabled` exists and
+- [x] `TestFrontMatterEnabled` exists and
   passes.
-- [ ] `TestFirstError` exists and passes.
-- [ ] `TestCloneDiagnostics` exists and
+- [x] `TestFirstError` exists and passes.
+- [x] `TestCloneDiagnostics` exists and
   passes.
-- [ ] `TestIndexSlash` exists and passes.
-- [ ] `go test ./pkg/mdsmith/...` green.
-- [ ] `go tool golangci-lint run` clean.
+- [x] `TestIndexSlash` exists and passes.
+- [x] `go test ./pkg/mdsmith/...` green.
+- [x] `go tool golangci-lint run` clean.


### PR DESCRIPTION
## Summary

Adds five dedicated unit tests for unexported helpers in `pkg/mdsmith/` that previously had no coverage, satisfying the test pyramid rule in the architecture docs.

- `TestCapabilityList` — asserts `capabilityList()` returns `["check", "fix", "kinds"]` in sorted order
- `TestFrontMatterEnabled` — nil cfg, default cfg, explicit `true`, explicit `false`
- `TestFirstError` — empty/nil slice returns nil; non-empty returns `errs[0]`
- `TestCloneDiagnostics` — clone is distinct; mutating it does not affect the source
- `TestIndexSlash` — no slash, slash at 0, slash in middle, slash at end

Also adds a nil-guard in `frontMatterEnabled` for the `nil *config.Config` case (matches documented semantics).

## Plan

Closes plan 223 (`plan/223_arch-fix-mdsmith-helper-tests.md`). Status: ✅

## Test plan

- [x] `go test ./pkg/mdsmith/...` — green
- [x] `go test ./...` — green
- [x] `go tool golangci-lint run` — 0 issues
- [x] `go run ./cmd/mdsmith check .` — 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01VARTxnj78ts6mxn7ucJgdz)_