### PR TITLE
Rename pr-fixup skill to gh-pr-fixup; replace merge-queue Copilot gate with /code-review

### DIFF
--- a/.claude/skills/gh-pr-fixup/SKILL.md
+++ b/.claude/skills/gh-pr-fixup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-fixup
+name: gh-pr-fixup
 description: >-
   Push changes, monitor CI, and address review comments
   until the PR is clean. Run after creating or updating
@@ -135,12 +135,12 @@ gh api --method POST \
 
 ### 5. Schedule recurring polling
 
-Use the `/loop` skill to re-invoke `/pr-fixup` every
+Use the `/loop` skill to re-invoke `/gh-pr-fixup` every
 minute. This avoids blocking bash loops and long-running
 `--watch` commands:
 
 ```text
-/loop 1m /pr-fixup
+/loop 1m /gh-pr-fixup
 ```
 
 On each invocation, check CI and review threads. If

--- a/.claude/skills/merge-queue/SKILL.md
+++ b/.claude/skills/merge-queue/SKILL.md
@@ -67,8 +67,8 @@ workflow only runs for same-repo PRs targeting
 ### 2. Verify readiness
 
 Confirm CI is green, no review threads are
-unresolved, and the latest commit has a Copilot
-review before enqueuing.
+unresolved, and a high-effort code review leaves
+nothing to fix before enqueuing.
 
 Check CI:
 
@@ -108,34 +108,20 @@ are more than 100 threads and you must paginate
 before trusting the count.
 
 Stop if the count is greater than zero. Run
-`/pr-fixup` first to address the remaining
+`/gh-pr-fixup` first to address the remaining
 threads.
 
-Check that Copilot reviewed the latest commit:
+Run a final high-effort code review and auto-apply
+its fixes:
 
-```bash
-gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews" \
-  -q '[.[] | select(.user.login ==
-  "copilot-pull-request-reviewer[bot]")]
-  | last | .commit_id'
+```text
+/code-review xhigh --fix
 ```
 
-Compare the returned commit SHA with the PR head:
-
-```bash
-gh pr view "$PR" --json commits \
-  -q '.commits[-1].oid'
-```
-
-If the two SHAs do not match, Copilot has not
-reviewed the latest push. Request a review and
-wait before enqueuing:
-
-```bash
-gh api --method POST \
-  "repos/$OWNER/$REPO/pulls/$PR/requested_reviewers" \
-  -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
-```
+If the review changes any files, the branch is not
+ready — run `/gh-pr-fixup` to commit, push, and
+re-run CI before enqueuing. If it makes no changes,
+the review is clean; proceed.
 
 ### 3. Add the `queue` label
 

--- a/.claude/skills/pick-plan/SKILL.md
+++ b/.claude/skills/pick-plan/SKILL.md
@@ -428,7 +428,7 @@ since this is what shows in the Agent's status line).
 
 When the Agent returns, relay its summary to the user
 in two or three sentences plus the PR URL from step 8.
-The user can then run `/pr-fixup` to babysit CI and
+The user can then run `/gh-pr-fixup` to babysit CI and
 review comments.
 
 ## Gotchas

--- a/.github/AGENTS-PR-FIXUP.md
+++ b/.github/AGENTS-PR-FIXUP.md
@@ -128,12 +128,12 @@ gh api --method POST \
 
 ### 5. Schedule recurring polling
 
-Use the `/loop` skill to re-invoke `/pr-fixup` every
+Use the `/loop` skill to re-invoke `/gh-pr-fixup` every
 minute. This avoids blocking bash loops and long-running
 `--watch` commands:
 
 ```text
-/loop 1m /pr-fixup
+/loop 1m /gh-pr-fixup
 ```
 
 On each invocation, check CI and review threads. If

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -147,7 +147,7 @@ row: "- [{summary}](../{filename})"
 
 ### PR Workflow
 
-Use the `/pr-fixup`, `/gh-resolve-threads`, and `/merge-queue`
+Use the `/gh-pr-fixup`, `/gh-resolve-threads`, and `/merge-queue`
 skills for PR work — they cover rebases, CI monitoring, thread
 resolution, and merge enqueuing. After every push, request a
 Copilot re-review (the skills do this automatically).

--- a/.github/copilot-pr-fixup.md
+++ b/.github/copilot-pr-fixup.md
@@ -121,12 +121,12 @@ gh api --method POST \
 
 ### 5. Schedule recurring polling
 
-Use the `/loop` skill to re-invoke `/pr-fixup` every
+Use the `/loop` skill to re-invoke `/gh-pr-fixup` every
 minute. This avoids blocking bash loops and long-running
 `--watch` commands:
 
 ```text
-/loop 1m /pr-fixup
+/loop 1m /gh-pr-fixup
 ```
 
 On each invocation, check CI and review threads. If

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ row: "- [{summary}]({filename})"
 
 ## PR Workflow
 
-Use the `/pr-fixup`, `/gh-resolve-threads`, and `/merge-queue`
+Use the `/gh-pr-fixup`, `/gh-resolve-threads`, and `/merge-queue`
 skills for PR work — they cover rebases, CI monitoring, thread
 resolution, and merge enqueuing. After every push, request a
 Copilot re-review (the skills do this automatically).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ row: "- [{summary}]({filename})"
 
 ## PR Workflow
 
-Use the `/pr-fixup`, `/gh-resolve-threads`, and `/merge-queue`
+Use the `/gh-pr-fixup`, `/gh-resolve-threads`, and `/merge-queue`
 skills for PR work — they cover rebases, CI monitoring, thread
 resolution, and merge enqueuing. After every push, request a
 Copilot re-review (the skills do this automatically).

--- a/docs/development/pr-fixup-workflow.md
+++ b/docs/development/pr-fixup-workflow.md
@@ -120,12 +120,12 @@ gh api --method POST \
 
 ### 5. Schedule recurring polling
 
-Use the `/loop` skill to re-invoke `/pr-fixup` every
+Use the `/loop` skill to re-invoke `/gh-pr-fixup` every
 minute. This avoids blocking bash loops and long-running
 `--watch` commands:
 
 ```text
-/loop 1m /pr-fixup
+/loop 1m /gh-pr-fixup
 ```
 
 On each invocation, check CI and review threads. If


### PR DESCRIPTION
## What

- **Rename** the `/pr-fixup` skill to `/gh-pr-fixup` — directory, `name:` frontmatter, and every slash-command reference across the repo. Its workflow content is otherwise unchanged, **including the Copilot review requests** it issues after each push.
- **merge-queue**: drop the "verify Copilot reviewed the latest commit / request a review" readiness gate and replace it with a local high-effort code review:

  ```text
  /code-review xhigh --fix
  ```

  If that review changes any files, the skill defers to `/gh-pr-fixup` to commit, push, and re-run CI before enqueuing.
- **`/gh-resolve-threads` is left untouched** (per request), so it keeps its own Copilot re-review request.

## Why

Requested: remove Copilot-review requests from the in-repo skills in favor of `/code-review xhigh` with auto-fix — except `gh-resolve-threads` (unchanged) and `pr-fixup`, which is renamed to `gh-pr-fixup` rather than altered.

## Notes

- The source doc `docs/development/pr-fixup-workflow.md` keeps its filename (it is pinned in `.mdsmith.yml` globs, which must not change without consent). Only the `/pr-fixup` → `/gh-pr-fixup` slash references inside it changed.
- The `AGENTS.md`, `.github/copilot-instructions.md`, `.github/AGENTS-PR-FIXUP.md`, and `.github/copilot-pr-fixup.md` mirrors were regenerated via `mdsmith fix` from their `<?include?>` sources.
- `mdsmith check .` passes (failures=0).

https://claude.ai/code/session_01BEzHp3UnbApiukSE2KRgiU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEzHp3UnbApiukSE2KRgiU)_