### PR TITLE
refactor(config): DRY kind schemas via extends; collapse duplicated CLI walk-flags note

### DIFF
--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -315,6 +315,20 @@ ignore:
   - "editors/**/dist/**"
 
 kinds:
+  free-body:
+    # Shared schema skeleton for doc kinds whose body is
+    # free-form prose: a preamble followed by any headings.
+    # Each consumer sets only its own `frontmatter:` and
+    # reuses this section shape plus `closed: false` via
+    # `extends:`, removing the duplication these kinds used
+    # to each carry.
+    schema:
+      closed: false
+      sections:
+        - heading: null
+        - heading:
+            regex: '.+'
+            repeat: { min: 0 }
   proto:
     rules:
       # proto.md files lead with directives and placeholder
@@ -364,37 +378,28 @@ kinds:
       required-structure:
         schema: docs/security/proto.md
   architecture-doc:
+    extends: free-body
     schema:
       frontmatter:
         title: nonEmpty
         slug: nonEmpty
         summary: nonEmpty
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
     rules:
       max-file-length:
         max: 500
   cli-command:
+    extends: free-body
     schema:
       frontmatter:
         command: nonEmpty
         summary: nonEmpty
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
   release-channel:
     path-pattern: "{docs,website/content/docs}/development/release-channels/{proto.md,*.md}"
     rules:
       required-structure:
         schema: docs/development/release-channels/proto.md
   secret-rotation:
+    extends: free-body
     schema:
       frontmatter:
         title: nonEmpty
@@ -406,31 +411,21 @@ kinds:
         usedBy: nonEmpty
         scope: nonEmpty
         releaseEnvScoped: bool
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
   audit-log:
+    extends: free-body
     schema:
       frontmatter:
         title: nonEmpty
         "summary?": string
         audit-from: '=~"^[0-9a-f]{7,40}$"'
       filename: "architecture-audit.md"
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
   feature:
     # Marketing feature pages under docs/features/. The homepage
     # feature grid (website/layouts/partials/feature-grid.html)
     # and the README <?include?> both depend on this front
     # matter, so the schema makes a missing/typo'd field fail
     # `mdsmith check` instead of silently breaking a card.
+    extends: free-body
     schema:
       frontmatter:
         title: nonEmpty
@@ -446,26 +441,15 @@ kinds:
         group: '"Clean, consistent Markdown" | "One engine, every surface" | "A connected docs tree" | "Markdown as a single source of truth" | "Built for your pipeline"'
         "link?": string
         "rules?": '[...string]'
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
   feature-index:
     # docs/features/index.md is the shared "Why mdsmith"
     # overview, not a card: it carries only title + summary
     # (no icon/weight), so it gets its own kind.
+    extends: free-body
     schema:
       frontmatter:
         title: nonEmpty
         summary: nonEmpty
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
   messaging:
     # docs/brand/messaging.md is the single source of truth
     # for the product slogan, lead, tagline, and per-surface
@@ -537,6 +521,7 @@ kinds:
     # the same content can be indexed by either Hugo or
     # `<?catalog?>`.
     path-pattern: "website/content/*.md"
+    extends: free-body
     schema:
       frontmatter:
         title: nonEmpty
@@ -548,12 +533,6 @@ kinds:
         # consume the specific keys.
         "hero?": '{...}'
         "install?": '[...{...}]'
-      closed: false
-      sections:
-        - heading: null
-        - heading:
-            regex: '.+'
-            repeat: { min: 0 }
     rules:
       first-line-heading: false
       heading-increment: false

--- a/docs/reference/cli/backlinks.md
+++ b/docs/reference/cli/backlinks.md
@@ -30,16 +30,9 @@ entries (`../foo.md`) are rejected with exit code 2.
 | `--follow-symlinks` | config  | Follow symlinks; tri-state — see below              |
 | `--max-input-size`  | `2MB`   | Max file size (e.g. `2MB`, `0`=none)                |
 
-`--follow-symlinks` semantics match
-[`mdsmith check`](check.md#flags). Omit the flag to
-defer to the `follow-symlinks:` config key (default
-skip). `--follow-symlinks` (or `=true`) opts in for
-this run. `=false` forces skip even when config opts
-in.
-
-File discovery follows the `files:` patterns in
-`.mdsmith.yml` and the same `ignore:` rules `check` and
-`fix` use.
+`--follow-symlinks` and file discovery (the `files:` and
+`ignore:` patterns in `.mdsmith.yml`) match
+[`mdsmith check`](check.md#flags).
 
 ## Output
 

--- a/docs/reference/cli/deps.md
+++ b/docs/reference/cli/deps.md
@@ -29,10 +29,9 @@ with exit code 2.
 | `--follow-symlinks` | config  | Follow symlinks; tri-state — see below     |
 | `--max-input-size`  | `2MB`   | Max file size (e.g. `2MB`, `0`=none)       |
 
-`--follow-symlinks` semantics match
-[`mdsmith check`](check.md#flags). File discovery
-follows the `files:` patterns in `.mdsmith.yml` and the
-same `ignore:` rules `check` and `fix` use.
+`--follow-symlinks` and file discovery (the `files:` and
+`ignore:` patterns in `.mdsmith.yml`) match
+[`mdsmith check`](check.md#flags).
 
 ## Output
 

--- a/docs/reference/cli/rename.md
+++ b/docs/reference/cli/rename.md
@@ -52,10 +52,9 @@ the conflict. No partial edit is written.
 | `--follow-symlinks` | config  | Follow symlinks; tri-state — see below     |
 | `--max-input-size`  | `2MB`   | Max file size (e.g. `2MB`, `0`=none)       |
 
-`--follow-symlinks` semantics match
-[`mdsmith check`](check.md#flags). File discovery follows
-the `files:` patterns in `.mdsmith.yml` and the same
-`ignore:` rules `check` and `fix` use.
+`--follow-symlinks` and file discovery (the `files:` and
+`ignore:` patterns in `.mdsmith.yml`) match
+[`mdsmith check`](check.md#flags).
 
 ## Output
 


### PR DESCRIPTION
## What & why

A review of the CLI command docs (`docs/reference/cli/`) for places where
advanced mdsmith features could remove duplicated content. The docs are
already well-structured (the `cli-command` kind + inline schema, a
`<?catalog?>` index in `cli.md`, centrally-documented `--max-input-size`
and output schema), so the real duplication was elsewhere.

## Changes

### 1. Extract a shared `free-body` kind schema via `extends:` (−21 lines)

Seven doc kinds — `cli-command`, `architecture-doc`, `secret-rotation`,
`audit-log`, `feature`, `feature-index`, `website-page` — each repeated the
identical `closed: false` + free-form `sections:` skeleton:

```yaml
closed: false
sections:
  - heading: null
  - heading:
      regex: '.+'
      repeat: { min: 0 }
```

Add a `free-body` base kind that owns that skeleton and have the seven
extend it (each keeps only its own `frontmatter:`/`rules:`). This mirrors
the existing `directive-rule-readme → rule-readme` pattern the config
already uses. Verified that `extends:` deep-merges inline `schema:` blocks
(base `sections`+`closed` + child `frontmatter`) and that enforcement is
intact — removing a required frontmatter field still fires MDS020.

### 2. Collapse the duplicated CLI walk-flags note (−9 lines)

`deps.md` and `rename.md` carried a verbatim-identical paragraph restating
`--follow-symlinks` + file-discovery semantics (MDS037 flags the pair once
its 200-char threshold is lowered); `backlinks.md` additionally re-explained
the tri-state already documented in `check.md#flags`. All three now use one
concise sentence that points at `check.md`.

I deliberately used a cross-reference here rather than an `<?include?>`
fragment: for a single ~90-char note, a fragment file + a `.mdsmith.yml`
override + directive markers would *add* more lines than they remove — the
opposite of the goal. `<?include?>` pays off for substantial shared blocks,
which the CLI docs don't have.

## Considered but not done: tighten the `cli-command` schema to bind the H1

The intent was to make a page's H1 fail `mdsmith check` unless it renders to
`` mdsmith <command> `` (via `\#(fmvar(command))`). This is **not achievable
with the pinned version**:

- Inline `kinds.<name>.schema:` blocks are always `RootLevel = 2`
  (`internal/schema/schema.go`), so the H1 is *preamble* (`heading: null`),
  outside the section list. `fmvar` binding applies to section headings
  (H2+), not the title — empirically the matcher looked for
  `` mdsmith <command> `` among the H2s (`Flags`, `Examples`, …) and reported
  the section missing.
- The H2 structure varies across pages (no universal section), so there is
  no worthwhile inline tightening.
- The only `RootLevel = 1` path is a `proto.md` file-based schema, whose
  heading binding goes through MDS020's documented legacy parser — too murky
  to rely on for this small enforcement gain.

## Verification

- `go run ./cmd/mdsmith check .` → 422 checked, 0 failures, after each commit.
- Red/green probes: inherited `free-body` schema still enforces frontmatter
  and section requirements; `cli-command` still requires `command`.

`.mdsmith.yml` was changed with explicit user consent (per CLAUDE.md).

https://claude.ai/code/session_01NKdWdyXRSuprJWeLARKvBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKdWdyXRSuprJWeLARKvBE)_