### PR TITLE
docs(features): add motivation and worked example to file-kinds-schemas

### DIFF
--- a/docs/features/file-kinds-schemas.md
+++ b/docs/features/file-kinds-schemas.md
@@ -19,12 +19,11 @@ not a missing Decision section or an invented `status` value. A
 directory of similar files drifts as it grows.
 
 A **kind** gives each file a role; a **schema** gives that role a
-contract. Bind files to a kind by front matter, a
-`kind-assignment` glob, or a `path-pattern`. The kind's schema
-then constrains required headings, section order, and front-matter
-fields. Declare it inline on the kind, or share it from a
-`proto.md` template so a whole directory validates against one
-source of truth.
+contract. Bind files to a kind by a front-matter `kinds:` field or
+a `kind-assignment` glob. The kind's schema then constrains
+required headings, section order, and front-matter fields. Declare
+it inline on the kind, or share it from a `proto.md` template so a
+whole directory validates against one source of truth.
 
 For example, an `rfc` kind can declare its schema inline in
 `.mdsmith.yml`:
@@ -40,7 +39,7 @@ kinds:
         - heading: "Decision"
 ```
 
-Tag a file with that kind, then write it against the contract:
+Tag a file with that kind:
 
 ```markdown
 ---
@@ -64,6 +63,6 @@ RFC-0007.md:7:1 MDS020 ## Decision: got <missing>, expected section to be presen
 ```
 
 Schemas go further: they nest sections, repeat them, and inherit
-from one another. See the [file-kinds guide](../guides/file-kinds.md)
+from a parent. See the [file-kinds guide](../guides/file-kinds.md)
 and the [schemas guide](../guides/schemas.md) for the full
 vocabulary.

--- a/docs/features/file-kinds-schemas.md
+++ b/docs/features/file-kinds-schemas.md
@@ -13,19 +13,57 @@ group: "A connected docs tree"
 # File kinds and schemas
 
 Not every Markdown file plays the same role. A plan is not a rule
-README, and a release-channel page is not a guide. mdsmith lets
-you model that.
+README, and a release-channel page is not a guide. A per-file
+style linter treats them all alike: it catches a long line, but
+not a missing Decision section or an invented `status` value. A
+directory of similar files drifts as it grows.
 
-A **kind** is a named bundle of rule config. You bind files to it
-by front matter, a `kind-assignment` glob, or a `path-pattern`.
-Each kind can attach a **schema** that constrains required
-headings, section order, and front-matter fields.
+A **kind** gives each file a role; a **schema** gives that role a
+contract. Bind files to a kind by front matter, a
+`kind-assignment` glob, or a `path-pattern`. The kind's schema
+then constrains required headings, section order, and front-matter
+fields. Declare it inline on the kind, or share it from a
+`proto.md` template so a whole directory validates against one
+source of truth.
 
-Declare the schema inline on the kind or share it from a
-`proto.md` template, so a whole directory validates against one
-source of truth. Named field-type shortcuts keep the schema
-short. `MDS020` reports a precise diagnostic when a file breaks
-its contract.
+For example, an `rfc` kind can declare its schema inline in
+`.mdsmith.yml`:
 
-See the [file-kinds guide](../guides/file-kinds.md) and the
-[schemas guide](../guides/schemas.md) for the full vocabulary.
+```yaml
+kinds:
+  rfc:
+    schema:
+      frontmatter:
+        status: '"draft" | "ratified" | "deprecated"'
+      sections:
+        - heading: "Context"
+        - heading: "Decision"
+```
+
+Tag a file with that kind, then write it against the contract:
+
+```markdown
+---
+kinds: [rfc]
+status: approved
+---
+# RFC-0007: Adopt structured logging
+
+## Context
+
+We keep losing requests in unstructured log lines.
+```
+
+This file breaks the contract twice. `approved` is not an allowed
+`status`. The required `Decision` section is missing. `MDS020`
+reports both:
+
+```text
+RFC-0007.md:3:1 MDS020 status: got "approved", expected one of: "draft", "ratified", "deprecated"
+RFC-0007.md:7:1 MDS020 ## Decision: got <missing>, expected section to be present
+```
+
+Schemas go further: they nest sections, repeat them, and inherit
+from one another. See the [file-kinds guide](../guides/file-kinds.md)
+and the [schemas guide](../guides/schemas.md) for the full
+vocabulary.


### PR DESCRIPTION
## What

Revises the `docs/features/file-kinds-schemas.md` feature page (https://mdsmith.dev/features/file-kinds-schemas/) to add an intro/motivation and a concrete worked example before the schemas-guide link, as requested.

## Why

The page explained kinds and schemas abstractly — it told without showing. It now:

- **Leads with the problem** a per-file style linter cannot solve: a missing required section or an invented front-matter value. A directory of similar files drifts as it grows.
- **Shows a concrete `rfc` kind**: an inline schema in `.mdsmith.yml`, a file tagged against it, and the **real** `MDS020` diagnostics it produces (`status` not in the allowed set; required `Decision` section missing).
- **Links to the file-kinds and schemas guides last**, after the example.

## Verification

- The diagnostic transcript is captured from the actual binary (`mdsmith check` on the example), not hand-written. Line numbers in the output match the shown Markdown block.
- `mdsmith check .` passes (422 files, 0 failures).
- Ran the `docs-author` skill: feature-overview voice, global-English and anti-slop passes applied; em-dash and per-paragraph readability (MDS023) budgets respected.

The website copy under `website/content/docs/features/` is a generated, gitignored snapshot (produced by `sync-docs`), so only the source page is edited here.

https://claude.ai/code/session_01SpgczPR7JJZgousgzLW9of

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpgczPR7JJZgousgzLW9of)_