### PR TITLE
fix(obsidian): make cross-file resolution work in the WASM engine

### DIFF
--- a/editors/obsidian/src/main.test.ts
+++ b/editors/obsidian/src/main.test.ts
@@ -41,16 +41,23 @@ function makeApp(): {
     };
     workspace: {
       on(event: string, cb: () => unknown): unknown;
+      onLayoutReady(cb: () => unknown): void;
       getActiveViewOfType(_t: unknown): FakeView | null;
       getLeavesOfType(_t: string): unknown[];
     };
   };
   active: { view: FakeView | null };
   fireModify(path: string): void;
+  fireLayoutReady(): void;
+  layoutReadyCount(): number;
   modifyListenerCount(): number;
 } {
   type Handler = (f: FakeFile) => unknown;
   const vaultHandlers: Record<string, Handler[]> = {};
+  // Captured onLayoutReady callbacks. The fake never runs them eagerly,
+  // modelling Obsidian's cold start where the vault index is not ready
+  // when onload runs; fireLayoutReady() simulates the vault becoming ready.
+  const layoutReadyCbs: Array<() => unknown> = [];
   const active: { view: FakeView | null } = { view: null };
   return {
     app: {
@@ -71,6 +78,9 @@ function makeApp(): {
         on(_event: string, _cb: () => unknown): unknown {
           return {};
         },
+        onLayoutReady(cb: () => unknown): void {
+          layoutReadyCbs.push(cb);
+        },
         getActiveViewOfType(_t: unknown): FakeView | null {
           return active.view;
         },
@@ -82,6 +92,12 @@ function makeApp(): {
     active,
     fireModify(path: string): void {
       for (const cb of vaultHandlers["modify"] ?? []) cb({ path });
+    },
+    fireLayoutReady(): void {
+      for (const cb of layoutReadyCbs) cb();
+    },
+    layoutReadyCount(): number {
+      return layoutReadyCbs.length;
     },
     modifyListenerCount(): number {
       return vaultHandlers["modify"]?.length ?? 0;
@@ -373,5 +389,32 @@ describe("engine-down / restart safety (Copilot review)", () => {
       plugin as unknown as { startRuntime(): Promise<boolean> }
     ).startRuntime();
     expect(ok).toBe(false);
+  });
+});
+
+describe("onload — defers the first snapshot to layout-ready (cold-start race)", () => {
+  // On a cold Obsidian start the vault file index is not fully populated
+  // when onload runs, so app.vault.getMarkdownFiles() — the workspace-
+  // snapshot source — can return a partial list, dropping deep
+  // include/link targets and making cross-file directives report a
+  // missing file. onload must defer the first startRuntime() until
+  // app.workspace.onLayoutReady fires, when the vault is fully indexed.
+  test("startRuntime runs on layout-ready, not during onload", async () => {
+    const { plugin, harness } = makePlugin();
+    const startSpy = mock(() => Promise.resolve(true));
+    (
+      plugin as unknown as { startRuntime: () => Promise<boolean> }
+    ).startRuntime = startSpy;
+
+    await plugin.onload();
+
+    // Deferred: onload registered exactly one layout-ready callback and
+    // has NOT snapshotted the vault yet.
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(harness.layoutReadyCount()).toBe(1);
+
+    // The vault finishes loading: the snapshot runs now.
+    harness.fireLayoutReady();
+    expect(startSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/editors/obsidian/src/main.ts
+++ b/editors/obsidian/src/main.ts
@@ -7,9 +7,14 @@
 // workspace, diagnostics, actions, settings, wiring); the methods here
 // just orchestrate the Obsidian lifecycle.
 //
-// onload order (plan 217 §Lifecycle): read settings → load the WASM
-// bundle → build the workspace snapshot → createRuntime once → register
-// the CM6 extension, commands, diagnostics view, and vault listeners.
+// onload order (plan 217 §Lifecycle): read settings → register the CM6
+// extension, commands, diagnostics view, and vault listeners → then,
+// once app.workspace.onLayoutReady fires, build the workspace snapshot
+// and createRuntime. The snapshot is deferred to layout-ready because
+// app.vault.getMarkdownFiles() is only complete after the vault finishes
+// indexing; running it during a cold-start onload can return a partial
+// file list, which drops deep include/link targets and makes cross-file
+// directives report a missing file.
 // onunload disposes the runtime, cancels listeners, and detaches the
 // view. A "Restart session" command runs the same dispose + create
 // flow a configPath change uses.
@@ -110,7 +115,12 @@ export default class MdsmithPlugin extends Plugin {
     this.registerActiveFileCheck();
     this.registerCursorCommands();
 
-    await this.startRuntime();
+    // Defer the first snapshot until the vault index is fully populated.
+    // onLayoutReady runs the callback once the vault is ready — or
+    // immediately if it already is (e.g. the plugin is enabled after
+    // startup) — so app.vault.getMarkdownFiles() returns the complete
+    // file list and cross-file include/link resolution sees every file.
+    this.app.workspace.onLayoutReady(() => void this.startRuntime());
   }
 
   override onunload(): void {

--- a/editors/obsidian/src/plugin.e2e.test.ts
+++ b/editors/obsidian/src/plugin.e2e.test.ts
@@ -243,6 +243,10 @@ async function bootPlugin(
       on(_event: string, _cb: () => unknown): unknown {
         return {};
       },
+      // onload defers the first snapshot to onLayoutReady; this e2e boots
+      // the runtime explicitly below (and awaits it), so the fake captures
+      // the callback without firing it to avoid starting the runtime twice.
+      onLayoutReady(_cb: () => unknown): void {},
       getActiveViewOfType(_t: unknown): FakeMarkdownView | null {
         return active.view;
       },
@@ -281,6 +285,12 @@ async function bootPlugin(
   internals.saveData = async () => {};
 
   await plugin.onload();
+  // onload now defers startRuntime() to onLayoutReady (faked as a no-op
+  // above); start the runtime here and await it so the assertions below
+  // run against a ready engine, exactly as the pre-deferral onload did.
+  await (
+    plugin as unknown as { startRuntime(): Promise<boolean> }
+  ).startRuntime();
 
   return {
     plugin,

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -553,6 +553,15 @@ func (r *Runner) populateFileFields(f *lint.File, path string) {
 	case filepath.IsAbs(path):
 		gitignoreDir = filepath.Dir(path)
 	}
+	// An in-memory workspace (the Session's MemWorkspace, e.g. the WASM
+	// build) has no on-disk RootDir, but its SourceFS is rooted at the
+	// project root — the same contract os.DirFS(RootDir) gives on disk.
+	// Wire it as RootFS so RootFS-aware cross-file rules (include's ".."
+	// resolution, MDS020's schema reads) read through the workspace
+	// instead of falling back to os.*, which is "not implemented on js".
+	if r.RootDir == "" && r.SourceFS != nil {
+		f.RootFS = r.SourceFS
+	}
 	if gitignoreDir != "" {
 		gd := gitignoreDir
 		f.GitignoreFunc = func() *gitignore.Matcher {

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -522,11 +523,23 @@ func (r *Rule) checkRelativeTarget(
 // resolveTargetFile when only file existence (not the read
 // helper) matters.
 func targetExists(f *lint.File, linkPath, resolvedRoot string) bool {
-	if path, ok := resolveTargetOSPath(f.Path, linkPath); ok && cachedStatExists(path) {
-		if resolvedRoot == "" || isWithinRoot(resolvedRoot, path) {
+	if osPath, ok := resolveTargetOSPath(f.Path, linkPath); ok && cachedStatExists(osPath) {
+		if resolvedRoot == "" || isWithinRoot(resolvedRoot, osPath) {
 			return true
 		}
 		return false
+	}
+	// In-memory / workspace-relative resolution: the WASM and LSP engines
+	// have no OS disk for the branch above. Resolve the link against the
+	// source file's directory within the project-root FS, collapsing ".."
+	// so io/fs — which rejects paths containing ".." — can stat an
+	// up-and-over target (e.g. docs/x.md -> ../../internal/y.md).
+	if f.RootFS != nil && !filepath.IsAbs(f.Path) {
+		if rel, ok := resolveWorkspaceRelTarget(f.Path, linkPath); ok {
+			if _, err := fs.Stat(f.RootFS, rel); err == nil {
+				return true
+			}
+		}
 	}
 	fsPath := filepath.ToSlash(linkPath)
 	fsPath = strings.TrimPrefix(fsPath, "./")
@@ -843,20 +856,37 @@ func buildAnchorsForTarget(target targetFile) (map[string]struct{}, error) {
 
 func resolveTargetFile(f *lint.File, linkPath, resolvedRoot string) (targetFile, bool) {
 	maxBytes := f.MaxInputBytes
-	if path, ok := resolveTargetOSPath(f.Path, linkPath); ok {
-		if cachedStatExists(path) {
+	if osPath, ok := resolveTargetOSPath(f.Path, linkPath); ok {
+		if cachedStatExists(osPath) {
 			// Reject links that resolve outside the project root,
 			// evaluating symlinks to prevent bypass via symlinked dirs.
-			if resolvedRoot != "" && !isWithinRoot(resolvedRoot, path) {
+			if resolvedRoot != "" && !isWithinRoot(resolvedRoot, osPath) {
 				return targetFile{}, false
 			}
 			return targetFile{
-				cacheKey:    "os:" + path,
-				runCacheKey: path,
+				cacheKey:    "os:" + osPath,
+				runCacheKey: osPath,
 				read: func() ([]byte, error) {
-					return bytelimit.ReadFileLimited(path, maxBytes)
+					return bytelimit.ReadFileLimited(osPath, maxBytes)
 				},
 			}, true
+		}
+	}
+
+	// In-memory / workspace-relative resolution (see targetExists): resolve
+	// the link within the project-root FS so an up-and-over ".." target,
+	// which io/fs rejects as a raw path, still reads on the WASM/LSP engines.
+	if f.RootFS != nil && !filepath.IsAbs(f.Path) {
+		if rel, ok := resolveWorkspaceRelTarget(f.Path, linkPath); ok {
+			if _, err := fs.Stat(f.RootFS, rel); err == nil {
+				rootFS := f.RootFS
+				return targetFile{
+					cacheKey: "fs:" + rel,
+					read: func() ([]byte, error) {
+						return bytelimit.ReadFSFileLimited(rootFS, rel, maxBytes)
+					},
+				}, true
+			}
 		}
 	}
 
@@ -934,6 +964,26 @@ func resolveTargetOSPath(sourcePath, linkPath string) (string, bool) {
 	}
 
 	return filepath.Clean(filepath.Join(filepath.Dir(sourcePath), linkPath)), true
+}
+
+// resolveWorkspaceRelTarget maps a workspace-relative source path and a
+// file-relative link to a slash path valid for fs.Stat against the
+// project-root FS (f.RootFS). It joins the link onto the source file's
+// directory and cleans ".." away — io/fs rejects any path containing
+// ".." — and returns ("", false) when the result escapes the workspace
+// root, is empty, or is absolute, none of which name a file inside the
+// in-memory workspace.
+func resolveWorkspaceRelTarget(sourcePath, linkPath string) (string, bool) {
+	lp := filepath.ToSlash(linkPath)
+	if lp == "" || strings.HasPrefix(lp, "/") {
+		return "", false
+	}
+	dir := path.Dir(filepath.ToSlash(sourcePath))
+	rel := path.Clean(path.Join(dir, lp))
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	return rel, true
 }
 
 func isMarkdownPath(path string) bool {

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -683,6 +683,30 @@ func TestResolveTargetFile_EmptyFSPathReturnsNotFound(t *testing.T) {
 	require.False(t, ok, "fsPath='' after TrimPrefix must return not found")
 }
 
+// TestTargetExists_ParentTraversalViaRootFS mirrors the WASM/Session
+// shape: a workspace-relative source path in a subdirectory, a
+// project-root RootFS, and an up-and-over link. The OS branch cannot
+// help (no on-disk file) and the legacy FS branch would hand ".." to
+// io/fs (which rejects it); RootFS-relative resolution collapses the
+// "..".
+func TestTargetExists_ParentTraversalViaRootFS(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "rules", "x"), 0o755))
+	writeFile(t, filepath.Join(root, "internal", "rules", "x", "README.md"), "# X\n")
+
+	f := &lint.File{
+		Path:   "docs/background/linters.md",
+		FS:     os.DirFS(root),
+		RootFS: os.DirFS(root),
+	}
+	assert.True(t, targetExists(f, "../../internal/rules/x/README.md", ""),
+		"an existing up-and-over target must resolve via RootFS")
+	assert.False(t, targetExists(f, "../../internal/rules/x/MISSING.md", ""),
+		"a missing up-and-over target must still report absent")
+	assert.False(t, targetExists(f, "../../../escape.md", ""),
+		"a link escaping the workspace root must not resolve here")
+}
+
 // =====================================================================
 // Additional coverage: toStringSlice with []string type
 // =====================================================================

--- a/internal/rules/crossfilereferenceintegrity/rule_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_test.go
@@ -707,6 +707,49 @@ func TestTargetExists_ParentTraversalViaRootFS(t *testing.T) {
 		"a link escaping the workspace root must not resolve here")
 }
 
+// TestResolveWorkspaceRelTarget covers every branch of the helper:
+// joining onto the source dir, collapsing "..", and the rejections for
+// empty, absolute, and root-escaping links.
+func TestResolveWorkspaceRelTarget(t *testing.T) {
+	rel, ok := resolveWorkspaceRelTarget("docs/background/linters.md", "../../internal/x.md")
+	require.True(t, ok)
+	assert.Equal(t, "internal/x.md", rel)
+
+	rel, ok = resolveWorkspaceRelTarget("docs/a.md", "b.md")
+	require.True(t, ok)
+	assert.Equal(t, "docs/b.md", rel)
+
+	_, ok = resolveWorkspaceRelTarget("docs/a.md", "")
+	assert.False(t, ok, "empty link is not a workspace target")
+	_, ok = resolveWorkspaceRelTarget("docs/a.md", "/etc/passwd")
+	assert.False(t, ok, "absolute link is not a workspace target")
+	_, ok = resolveWorkspaceRelTarget("docs/a.md", "../../escape.md")
+	assert.False(t, ok, "a link escaping the workspace root is rejected")
+}
+
+// TestResolveTargetFile_ParentTraversalViaRootFS exercises the in-memory
+// RootFS branch of resolveTargetFile (the anchored-link path), which the
+// Session/WASM engine takes for an up-and-over target.
+func TestResolveTargetFile_ParentTraversalViaRootFS(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "rules", "x"), 0o755))
+	writeFile(t, filepath.Join(root, "internal", "rules", "x", "README.md"), "# X\n")
+
+	f := &lint.File{
+		Path:   "docs/background/linters.md",
+		FS:     os.DirFS(root),
+		RootFS: os.DirFS(root),
+	}
+	tf, ok := resolveTargetFile(f, "../../internal/rules/x/README.md", "")
+	require.True(t, ok, "an existing up-and-over target must resolve via RootFS")
+	data, err := tf.read()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("# X\n"), data)
+
+	_, ok = resolveTargetFile(f, "../../internal/rules/x/MISSING.md", "")
+	assert.False(t, ok, "a missing up-and-over target must not resolve")
+}
+
 // =====================================================================
 // Additional coverage: toStringSlice with []string type
 // =====================================================================

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1405,6 +1406,18 @@ func parseSchema(data []byte, schemaPath string, maxBytes int64) (*parsedSchema,
 func parseSchemaWithCache(
 	data []byte, schemaPath string, maxBytes int64, cache *lint.RunCache,
 ) (*parsedSchema, []string, error) {
+	return parseSchemaWithRootFS(data, schemaPath, maxBytes, cache, nil)
+}
+
+// parseSchemaWithRootFS is parseSchemaWithCache plus the workspace RootFS
+// used to read <?include?> fragments. The Session/WASM and LSP engines
+// have no usable OS disk (os.ReadFile is "not implemented on js" in
+// WASM), so schema includes must read through the in-memory workspace FS;
+// the CLI passes a nil rootFS and reads from disk. cachedParseSchema
+// supplies f.RootFS.
+func parseSchemaWithRootFS(
+	data []byte, schemaPath string, maxBytes int64, cache *lint.RunCache, rootFS fs.FS,
+) (*parsedSchema, []string, error) {
 	prefix, content := lint.StripFrontMatter(data)
 
 	cfg, err := parseSchemaFrontMatter(prefix, cache)
@@ -1447,7 +1460,7 @@ func parseSchemaWithCache(
 		visited := map[string]bool{cleanPath: true}
 		chain := []string{cleanPath}
 		var fp string
-		headings, fp, includes, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes)
+		headings, fp, includes, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes, rootFS)
 		if err != nil {
 			// Surface a partial *parsedSchema (carrying the
 			// frontmatter CUE source the cache will track via
@@ -1502,7 +1515,7 @@ func parseSchemaWithCache(
 // transitive set appended after the fragment's own path.
 func extractSchemaHeadings(
 	schemaFile *lint.File, schemaPath string,
-	visited map[string]bool, chain []string, maxBytes int64,
+	visited map[string]bool, chain []string, maxBytes int64, rootFS fs.FS,
 ) ([]docHeading, string, []string, error) {
 	var headings []docHeading
 	var filenamePattern string
@@ -1524,7 +1537,7 @@ func extractSchemaHeadings(
 				return ast.WalkContinue, nil
 			}
 			fragHeadings, fp, fragIncluded, subIncludes, walkErr := expandSchemaInclude(
-				node, schemaFile.Source, schemaPath, visited, chain, maxBytes)
+				node, schemaFile.Source, schemaPath, visited, chain, maxBytes, rootFS)
 			if walkErr != nil {
 				// Record the broken-but-known fragment plus any
 				// transitive sub-includes the recursive walk
@@ -1604,7 +1617,7 @@ func resolveSchemaIncludePath(
 // full dependency footprint on RunCache's reverse-include index.
 func expandSchemaInclude(
 	pi *piparser.ProcessingInstruction, source []byte,
-	schemaPath string, visited map[string]bool, chain []string, maxBytes int64,
+	schemaPath string, visited map[string]bool, chain []string, maxBytes int64, rootFS fs.FS,
 ) ([]docHeading, string, string, []string, error) {
 	includedPath, err := resolveSchemaIncludePath(pi, source, schemaPath)
 	if err != nil {
@@ -1629,7 +1642,7 @@ func expandSchemaInclude(
 			"cyclic include: %s", strings.Join(chainCopy, " -> "))
 	}
 
-	fragData, err := bytelimit.ReadFileLimited(includedPath, maxBytes)
+	fragData, err := readSchemaInclude(rootFS, includedPath, maxBytes)
 	if err != nil {
 		return nil, "", includedPath, nil, fmt.Errorf(
 			"cannot read schema include file %q: %w", includedPath, err)
@@ -1650,7 +1663,7 @@ func expandSchemaInclude(
 	visited[includedPath] = true
 	chain = append(chain, includedPath)
 	fragHeadings, fp2, subIncludes, err := extractSchemaHeadings(
-		fragFile, includedPath, visited, chain, maxBytes)
+		fragFile, includedPath, visited, chain, maxBytes, rootFS)
 	delete(visited, includedPath)
 	if err != nil {
 		// Surface includedPath plus whatever subIncludes the
@@ -2406,6 +2419,28 @@ func readSchemaFile(f *lint.File, schema string) ([]byte, error) {
 		return bytelimit.ReadFSFileLimited(f.RootFS, clean, f.MaxInputBytes)
 	}
 	return bytelimit.ReadFileLimited(schema, f.MaxInputBytes)
+}
+
+// schemaRootFS returns f's workspace RootFS, or nil when f is nil. It is
+// the seam cachedParseSchema uses to feed RootFS-based <?include?>
+// fragment reads (see parseSchemaWithRootFS).
+func schemaRootFS(f *lint.File) fs.FS {
+	if f == nil {
+		return nil
+	}
+	return f.RootFS
+}
+
+// readSchemaInclude reads a schema <?include?> fragment. It prefers the
+// workspace RootFS — the Session/WASM and LSP path, where os.ReadFile is
+// absent or "not implemented on js" — and falls back to the OS filesystem
+// for the on-disk CLI. includedPath is project-relative
+// (resolveSchemaIncludePath rejects ".."), so it is a valid fs.FS key.
+func readSchemaInclude(rootFS fs.FS, includedPath string, maxBytes int64) ([]byte, error) {
+	if rootFS != nil {
+		return bytelimit.ReadFSFileLimited(rootFS, filepath.ToSlash(includedPath), maxBytes)
+	}
+	return bytelimit.ReadFileLimited(includedPath, maxBytes)
 }
 
 func makeDiag(file string, line int, msg string) lint.Diagnostic {

--- a/internal/rules/requiredstructure/runcache_wiring.go
+++ b/internal/rules/requiredstructure/runcache_wiring.go
@@ -67,13 +67,13 @@ func cachedParseSchema(
 		cache = f.RunCache
 	}
 	if cache == nil {
-		sch, _, err := parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), nil)
+		sch, _, err := parseSchemaWithRootFS(data, schemaPath, fileMaxBytes(f), nil, schemaRootFS(f))
 		return sch, err
 	}
 	absPath := absSchemaCacheKey(f, schemaPath)
 	absRoot := absRootDir(f)
 	return cachedParseSchemaWith(cache, absPath, absRoot, func() (*parsedSchema, []string, error) {
-		return parseSchemaWithCache(data, schemaPath, fileMaxBytes(f), cache)
+		return parseSchemaWithRootFS(data, schemaPath, fileMaxBytes(f), cache, schemaRootFS(f))
 	})
 }
 

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -3,6 +3,7 @@ package requiredstructure
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -204,6 +205,36 @@ func TestRule_SchemaParsedOncePerRunCache(t *testing.T) {
 func filepathAbs(t *testing.T, p string) (string, error) {
 	t.Helper()
 	return filepath.Abs(p)
+}
+
+// TestRule_SchemaIncludeViaRootFS verifies a schema <?include?> fragment
+// resolves through the workspace RootFS when there is no usable OS disk —
+// the Session/WASM shape (RootFS set, RootDir empty). Both the schema and
+// its fragment live only in the in-memory FS, so the os.ReadFile fallback
+// cannot find them; before RootFS was threaded into schema-include
+// resolution this surfaced a "cannot read schema include file"
+// diagnostic ("not implemented on js" in the actual WASM build).
+func TestRule_SchemaIncludeViaRootFS(t *testing.T) {
+	mfs := fstest.MapFS{
+		"rules/proto.md": &fstest.MapFile{
+			Data: []byte("# {id}: {name}\n\n<?include\nfile: section.md\n?>\n"),
+		},
+		"rules/section.md": &fstest.MapFile{
+			Data: []byte("## Section\n"),
+		},
+	}
+	r := &Rule{Schema: "rules/proto.md"}
+	f, err := lint.NewFile("rules/x/README.md",
+		[]byte("---\nid: MDS001\nname: line-length\n---\n# MDS001: line-length\n\n## Section\n"))
+	require.NoError(t, err)
+	f.FS = mfs
+	f.RootFS = mfs // RootDir intentionally empty: the Session/WASM shape.
+
+	for _, d := range r.Check(f) {
+		if strings.Contains(d.Message, "cannot read schema include") {
+			t.Fatalf("schema include must resolve via RootFS, got: %s", d.Message)
+		}
+	}
 }
 
 // TestRule_FragmentInvalidationEvictsParsedSchema is the end-to-end

--- a/internal/rules/requiredstructure/runcache_wiring_test.go
+++ b/internal/rules/requiredstructure/runcache_wiring_test.go
@@ -237,6 +237,14 @@ func TestRule_SchemaIncludeViaRootFS(t *testing.T) {
 	}
 }
 
+// TestSchemaRootFS covers both branches of the RootFS accessor: a nil
+// file (the cache primitive's struct-literal test path) yields nil, and a
+// file with a RootFS yields it.
+func TestSchemaRootFS(t *testing.T) {
+	assert.Nil(t, schemaRootFS(nil))
+	assert.NotNil(t, schemaRootFS(&lint.File{RootFS: fstest.MapFS{}}))
+}
+
 // TestRule_FragmentInvalidationEvictsParsedSchema is the end-to-end
 // integration check for Copilot thread 1 on PR #377: after Rule.Check
 // reads a schema whose <?include?> reaches a fragment, calling

--- a/pkg/mdsmith/session_test.go
+++ b/pkg/mdsmith/session_test.go
@@ -249,6 +249,53 @@ func TestSessionCheckCrossFileMemWorkspace(t *testing.T) {
 	}
 }
 
+// TestSessionParentTraversalLinkMemWorkspace verifies a relative link
+// that traverses ".." up and over resolves through the in-memory
+// workspace. The CLI resolves such links on disk; the Session has no
+// disk, so the engine must wire RootFS to the workspace FS and collapse
+// ".." for the io/fs lookup (which rejects raw ".." paths). Before that,
+// this reported a false MDS027 broken link — the Obsidian/WASM symptom.
+func TestSessionParentTraversalLinkMemWorkspace(t *testing.T) {
+	files := map[string][]byte{
+		"shared/b.md": []byte("# B\n\nBody paragraph for b here.\n"),
+	}
+	s := newTestSession(t, "", files)
+	host := []byte("# A\n\nSee [B](../../shared/b.md) for the details here now.\n")
+	diags, err := s.Check("docs/sub/a.md", host)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	for _, d := range diags {
+		if d.RuleID == "MDS027" {
+			t.Fatalf("unexpected MDS027 broken-link for an existing ..-target: %+v", diags)
+		}
+	}
+}
+
+// TestSessionParentTraversalIncludeMemWorkspace verifies an <?include?>
+// whose target sits above the including file resolves through the
+// in-memory workspace. Without RootFS wired to the workspace, include
+// resolution rejects ".." paths with "project root is not configured".
+func TestSessionParentTraversalIncludeMemWorkspace(t *testing.T) {
+	files := map[string][]byte{
+		"shared/snippet.md": []byte("Reusable snippet body here.\n"),
+	}
+	s := newTestSession(t, "", files)
+	host := []byte("# A\n\n<?include\nfile: ../../shared/snippet.md\n?>\n" +
+		"Reusable snippet body here.\n<?/include?>\n")
+	diags, err := s.Check("docs/sub/a.md", host)
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	for _, d := range diags {
+		if d.RuleID == "MDS021" &&
+			(strings.Contains(d.Message, "is not configured") ||
+				strings.Contains(d.Message, "cannot read include file")) {
+			t.Fatalf("include ..-target failed to resolve: %s", d.Message)
+		}
+	}
+}
+
 // TestSessionCheckResultIsolatedFromCache verifies the slice Check
 // returns does not alias the cached slice, so a caller mutating its
 // result cannot poison a later Check on the same (uri, source).


### PR DESCRIPTION
## Summary

Fixes a cluster of Obsidian/WASM bugs found while running the plugin against a vault rooted at the repo. Each was a false failure in the editor that the CLI/CI never showed, because the in-memory engine took a different (and broken) path than the on-disk CLI.

## Problems & fixes

**1. Config + workspace not fully loaded on cold start.**
The plugin snapshotted the vault with `app.vault.getMarkdownFiles()` during `onload`. On a cold Obsidian start the vault index isn't fully populated, so the snapshot missed files (deep include/link targets), and cross-file directives reported them missing.
→ `onload` now defers the first `startRuntime()` to `app.workspace.onLayoutReady`, when the vault is fully indexed.

**2. `..`-traversing links flagged as broken (MDS027).**
Docs that link *up* into the repo (e.g. `../../internal/rules/MDS001-line-length/README.md`) showed false broken-link warnings. The CLI resolves these on disk; the Session has no disk, so it fell to the in-memory FS branch, which handed the raw `../..` path to `io/fs` — and `io/fs` rejects any path containing `..`.

**3. `MDS020` schema read died with "not implemented on js".**
The Session's `MemWorkspace` has no on-disk `RootDir`, so the engine left `lint.File.RootFS` nil and `MDS020` fell back to `os.ReadFile` for the `proto.md` schema — "not implemented on js" in the WASM build. A `proto.md` that pulls in a fragment via an include directive hit the same wall on the fragment read.

## Changes

- **engine** (`internal/engine/runner.go`): `RootFS` falls back to `SourceFS` when `RootDir` is empty (the in-memory `RunSource` path), so `RootFS`-aware rules read through the workspace instead of the OS.
- **MDS027** (`crossfilereferenceintegrity`): resolve relative and `..`-traversing link targets against the source file's directory within the project-root FS, collapsing `..`.
- **MDS020** (`requiredstructure`): read included schema fragments through `RootFS`, so a schema that includes a fragment resolves in the in-memory workspace.
- **plugin** (`editors/obsidian`): defer the first snapshot to `onLayoutReady`.

## Commits

1. `fix(obsidian)`: defer first vault snapshot to `onLayoutReady`.
2. `fix(engine)`: resolve cross-file references through the in-memory workspace.
3. `test(engine)`: cover the new RootFS branches.

## Tests

- New unit + Session integration tests reproduce each symptom in an in-memory workspace (red before, green after), with per-package unit tests exercising every new branch.
- Full Go suite green; `go vet` + `golangci-lint` clean; `mdsmith check .` passes (422 files); WASM target builds; plugin suite 84/0.
- `codecov/patch`: 100% of modified lines covered.

## Verification status

Validated at the engine level — the in-memory FS now resolves the exact `..` and `proto.md` cases that were failing. **Not yet re-tested inside a live Obsidian vault end-to-end**; the remaining manual check is to rebuild the plugin (`bun run build`), load it in a vault, and confirm the squiggles are gone.

https://claude.ai/code/session_01RkZnJM1JYhhioZyzfvH3nt