### PR TITLE
Plan 213: Built-in no-llm-tells convention with append-mode forbidden lists

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -138,7 +138,7 @@ footer: |
 | 210 | ✅     | opus   | [Single source of truth for product messaging via `mdsmith extract`](plan/210_messaging-source-of-truth.md)                             |
 | 211 | 🔳     | opus   | [`<?include?>` projects any typed value of any kind via `extract`](plan/211_include-extract-value.md)                                   |
 | 212 | ✅     | opus   | [`mdsmith extract` projects paragraph inline spans as data](plan/212_extract-inline-spans.md)                                           |
-| 213 | 🔳     | opus   | [Built-in `no-llm-tells` convention with append-mode forbidden lists](plan/213_anti-slop-convention.md)                                 |
+| 213 | ✅     | opus   | [Built-in `no-llm-tells` convention with append-mode forbidden lists](plan/213_anti-slop-convention.md)                                 |
 | 214 | ✅     | sonnet | [MDS019 catalog: CUE-expression row templates](plan/214_catalog-cue-row-expressions.md)                                                 |
 | 214 | ⛔     | opus   | [Obsidian plugin via hand-rolled LSP bridge](plan/214_obsidian-plugin.md)                                                               |
 | 215 | ✅     | opus   | [mdsmith public engine API and WASM bindings](plan/215_engine-api-wasm.md)                                                              |

--- a/plan/213_anti-slop-convention.md
+++ b/plan/213_anti-slop-convention.md
@@ -1,7 +1,7 @@
 ---
 id: 213
 title: Built-in `no-llm-tells` convention with append-mode forbidden lists
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: []
 summary: >-


### PR DESCRIPTION
## Summary

- Marks plan 213 complete (`🔲` → `✅`) now that the implementation landed in PR #509
- Checks off all tasks and acceptance criteria in `plan/213_anti-slop-convention.md`
- Regenerates the `PLAN.md` catalog row to reflect the new status

## What was implemented (PR #509)

- `internal/convention/nollmtells.go`: curated forbidden-word, phrase, and paragraph-opener lists sourced from `.claude/skills/docs-author/slop-patterns.md`
- `internal/convention/convention.go`: `"no-llm-tells"` convention entry enabling MDS055, MDS056, MDS023 (`max-words-per-sentence: 25`), MDS024 (`max-index: 12.0`), and MDS063 (`descriptive-link-text`); flavor left as `FlavorAny` so GFM/Obsidian projects can opt in
- `internal/rules/forbiddenparagraphstarts`: `SettingMergeMode("starts") == MergeAppend` so user lists union with the convention's rather than replacing it
- `internal/rules/forbiddentext`: `SettingMergeMode("contains") == MergeAppend` (same)
- `internal/integration/nollmtells_drift_test.go`: drift-checker that reads `slop-patterns.md` and asserts the convention lists are a subset, failing CI on divergence
- `docs/reference/conventions.md`: `no-llm-tells` section matching the format of other built-in conventions
- `.claude/skills/docs-author/SKILL.md`: note pointing to the convention as the mechanical enforcement layer

## Test plan

- [x] `go test ./...` passes
- [x] `go run ./cmd/mdsmith check .` passes
- [x] PLAN.md catalog row updated to ✅

https://claude.ai/code/session_01Kr7nZnsF7i7xLghsqrJeGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr7nZnsF7i7xLghsqrJeGs)_