### PR TITLE
feat(website): add ⌘K documentation search

### DIFF
--- a/website/e2e/README.md
+++ b/website/e2e/README.md
@@ -17,10 +17,11 @@ the interactive JavaScript that the Go render probes in
 
 ## What is tested
 
-| Spec                     | Coverage                                                                         |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| `install-picker.spec.ts` | Chip filtering, Windows command swap, copy-to-clipboard, no-JS noscript fallback |
-| `chrome.spec.ts`         | Scroll-triggered `is-scrolled` on `.topnav`, docs sidebar toggle                 |
+| Spec                     | Coverage                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------- |
+| `install-picker.spec.ts` | Chip filtering, Windows command swap, copy-to-clipboard, no-JS noscript fallback      |
+| `chrome.spec.ts`         | Scroll-triggered `is-scrolled` on `.topnav`, docs sidebar toggle                      |
+| `search.spec.ts`         | ⌘K search: JSON index fetch, dialog lifecycle, querying, keyboard nav, no-JS fallback |
 
 ## Run locally
 

--- a/website/e2e/tests/search.spec.ts
+++ b/website/e2e/tests/search.spec.ts
@@ -7,10 +7,11 @@ import { test, expect } from "@playwright/test";
  * static render cannot reach: the keyboard shortcut, the dialog
  * lifecycle, querying the JSON index, keyboard navigation, and the
  * no-JS fallback (the trigger is hidden, the sidebar still navigates).
+ *
+ * The shortcut is exercised with Control+K on every platform: search.js
+ * opens on `e.metaKey || e.ctrlKey`, so Ctrl works in the headless
+ * browser regardless of the host OS (no Node `process` platform sniff).
  */
-
-// Ctrl on Linux/Windows, Cmd on macOS — search.js listens for both.
-const MOD = process.platform === "darwin" ? "Meta" : "Control";
 
 test.describe("⌘K search", () => {
   test.beforeEach(async ({ page }) => {
@@ -52,7 +53,7 @@ test.describe("⌘K search", () => {
     const dialog = page.locator("[data-search-dialog]");
     await expect(dialog).toBeHidden();
 
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await expect(dialog).toBeVisible();
     await expect(page.locator("[data-search-input]")).toBeFocused();
   });
@@ -61,9 +62,9 @@ test.describe("⌘K search", () => {
     page,
   }) => {
     const dialog = page.locator("[data-search-dialog]");
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await expect(dialog).toBeVisible();
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await expect(dialog).toBeHidden();
   });
 
@@ -79,7 +80,7 @@ test.describe("⌘K search", () => {
   // ─── querying ───────────────────────────────────────────────────────
 
   test("typing a query renders matching results", async ({ page }) => {
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     const input = page.locator("[data-search-input]");
     await input.fill("auto-fix");
 
@@ -94,18 +95,22 @@ test.describe("⌘K search", () => {
   });
 
   test("a query with no matches shows the empty status", async ({ page }) => {
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await page.locator("[data-search-input]").fill("zzzznomatchquery");
 
+    // Assert the real empty-state text, not merely a visible status: the
+    // "Loading…" status is also visible with zero results while the index
+    // fetches, so toContainText waits for the index to land and re-render.
+    const status = page.locator("[data-search-status]");
+    await expect(status).toContainText("No results");
     const results = page.locator("[data-search-results] .search-result");
     await expect(results).toHaveCount(0);
-    await expect(page.locator("[data-search-status]")).toBeVisible();
   });
 
   test("ArrowDown then Enter navigates to the active result", async ({
     page,
   }) => {
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await page.locator("[data-search-input]").fill("install");
 
     // First result is active on render; move to the second, then open.
@@ -122,7 +127,7 @@ test.describe("⌘K search", () => {
   });
 
   test("clicking a result navigates to its page", async ({ page }) => {
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await page.locator("[data-search-input]").fill("auto-fix");
 
     const link = page.locator(
@@ -136,7 +141,7 @@ test.describe("⌘K search", () => {
 
   test("Escape closes the dialog", async ({ page }) => {
     const dialog = page.locator("[data-search-dialog]");
-    await page.keyboard.press(`${MOD}+k`);
+    await page.keyboard.press(`Control+k`);
     await expect(dialog).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(dialog).toBeHidden();

--- a/website/e2e/tests/search.spec.ts
+++ b/website/e2e/tests/search.spec.ts
@@ -53,7 +53,7 @@ test.describe("⌘K search", () => {
     const dialog = page.locator("[data-search-dialog]");
     await expect(dialog).toBeHidden();
 
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await expect(dialog).toBeVisible();
     await expect(page.locator("[data-search-input]")).toBeFocused();
   });
@@ -62,9 +62,9 @@ test.describe("⌘K search", () => {
     page,
   }) => {
     const dialog = page.locator("[data-search-dialog]");
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await expect(dialog).toBeVisible();
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await expect(dialog).toBeHidden();
   });
 
@@ -80,7 +80,7 @@ test.describe("⌘K search", () => {
   // ─── querying ───────────────────────────────────────────────────────
 
   test("typing a query renders matching results", async ({ page }) => {
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     const input = page.locator("[data-search-input]");
     await input.fill("auto-fix");
 
@@ -95,7 +95,7 @@ test.describe("⌘K search", () => {
   });
 
   test("a query with no matches shows the empty status", async ({ page }) => {
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await page.locator("[data-search-input]").fill("zzzznomatchquery");
 
     // Assert the real empty-state text, not merely a visible status: the
@@ -110,7 +110,7 @@ test.describe("⌘K search", () => {
   test("ArrowDown then Enter navigates to the active result", async ({
     page,
   }) => {
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await page.locator("[data-search-input]").fill("install");
 
     // First result is active on render; move to the second, then open.
@@ -127,7 +127,7 @@ test.describe("⌘K search", () => {
   });
 
   test("clicking a result navigates to its page", async ({ page }) => {
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await page.locator("[data-search-input]").fill("auto-fix");
 
     const link = page.locator(
@@ -139,10 +139,16 @@ test.describe("⌘K search", () => {
 
   // ─── closing ────────────────────────────────────────────────────────
 
-  test("Escape closes the dialog", async ({ page }) => {
+  test("Escape closes the dialog even with a non-empty query", async ({
+    page,
+  }) => {
     const dialog = page.locator("[data-search-dialog]");
-    await page.keyboard.press(`Control+k`);
+    await page.keyboard.press("Control+k");
     await expect(dialog).toBeVisible();
+    // Type first: with a non-empty type=search input some engines (WebKit)
+    // consume the first Escape to clear the field, so search.js handles
+    // Escape explicitly. One Escape must still close the dialog.
+    await page.locator("[data-search-input]").fill("schema");
     await page.keyboard.press("Escape");
     await expect(dialog).toBeHidden();
   });

--- a/website/e2e/tests/search.spec.ts
+++ b/website/e2e/tests/search.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * ⌘K documentation search end-to-end tests.
+ *
+ * Covers the interactive JavaScript in static/js/search.js that a
+ * static render cannot reach: the keyboard shortcut, the dialog
+ * lifecycle, querying the JSON index, keyboard navigation, and the
+ * no-JS fallback (the trigger is hidden, the sidebar still navigates).
+ */
+
+// Ctrl on Linux/Windows, Cmd on macOS — search.js listens for both.
+const MOD = process.platform === "darwin" ? "Meta" : "Control";
+
+test.describe("⌘K search", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  // ─── index ─────────────────────────────────────────────────────────
+
+  test("the JSON search index is published and well-formed", async ({
+    page,
+  }) => {
+    const res = await page.request.get("/index.json");
+    expect(res.ok()).toBeTruthy();
+    const docs = await res.json();
+    expect(Array.isArray(docs)).toBeTruthy();
+    expect(docs.length).toBeGreaterThan(20);
+    for (const key of ["title", "summary", "section", "href", "body"]) {
+      expect(docs[0]).toHaveProperty(key);
+    }
+  });
+
+  // ─── opening ────────────────────────────────────────────────────────
+
+  test("the trigger button is visible and opens the dialog", async ({
+    page,
+  }) => {
+    const trigger = page.locator("[data-search-open]");
+    await expect(trigger).toBeVisible();
+
+    const dialog = page.locator("[data-search-dialog]");
+    await expect(dialog).toBeHidden();
+
+    await trigger.click();
+    await expect(dialog).toBeVisible();
+    await expect(page.locator("[data-search-input]")).toBeFocused();
+  });
+
+  test("the modifier+K shortcut opens the dialog", async ({ page }) => {
+    const dialog = page.locator("[data-search-dialog]");
+    await expect(dialog).toBeHidden();
+
+    await page.keyboard.press(`${MOD}+k`);
+    await expect(dialog).toBeVisible();
+    await expect(page.locator("[data-search-input]")).toBeFocused();
+  });
+
+  test("the modifier+K shortcut toggles the dialog closed again", async ({
+    page,
+  }) => {
+    const dialog = page.locator("[data-search-dialog]");
+    await page.keyboard.press(`${MOD}+k`);
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press(`${MOD}+k`);
+    await expect(dialog).toBeHidden();
+  });
+
+  test("the '/' shortcut opens search when not typing in a field", async ({
+    page,
+  }) => {
+    const dialog = page.locator("[data-search-dialog]");
+    await expect(dialog).toBeHidden();
+    await page.keyboard.press("/");
+    await expect(dialog).toBeVisible();
+  });
+
+  // ─── querying ───────────────────────────────────────────────────────
+
+  test("typing a query renders matching results", async ({ page }) => {
+    await page.keyboard.press(`${MOD}+k`);
+    const input = page.locator("[data-search-input]");
+    await input.fill("auto-fix");
+
+    const results = page.locator("[data-search-results] .search-result");
+    await expect(results.first()).toBeVisible();
+
+    // The auto-fix feature page must surface for that query.
+    const autofix = page.locator(
+      '[data-search-results] a[href="/features/auto-fix/"]'
+    );
+    await expect(autofix).toBeVisible();
+  });
+
+  test("a query with no matches shows the empty status", async ({ page }) => {
+    await page.keyboard.press(`${MOD}+k`);
+    await page.locator("[data-search-input]").fill("zzzznomatchquery");
+
+    const results = page.locator("[data-search-results] .search-result");
+    await expect(results).toHaveCount(0);
+    await expect(page.locator("[data-search-status]")).toBeVisible();
+  });
+
+  test("ArrowDown then Enter navigates to the active result", async ({
+    page,
+  }) => {
+    await page.keyboard.press(`${MOD}+k`);
+    await page.locator("[data-search-input]").fill("install");
+
+    // First result is active on render; move to the second, then open.
+    const second = page.locator(
+      "[data-search-results] .search-result"
+    ).nth(1);
+    await expect(second).toBeVisible();
+    await page.keyboard.press("ArrowDown");
+    await expect(second).toHaveClass(/is-active/);
+
+    const href = await second.locator("a").getAttribute("href");
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(new RegExp(escapeRegExp(href!) + "$"));
+  });
+
+  test("clicking a result navigates to its page", async ({ page }) => {
+    await page.keyboard.press(`${MOD}+k`);
+    await page.locator("[data-search-input]").fill("auto-fix");
+
+    const link = page.locator(
+      '[data-search-results] a[href="/features/auto-fix/"]'
+    );
+    await link.click();
+    await expect(page).toHaveURL(/\/features\/auto-fix\/$/);
+  });
+
+  // ─── closing ────────────────────────────────────────────────────────
+
+  test("Escape closes the dialog", async ({ page }) => {
+    const dialog = page.locator("[data-search-dialog]");
+    await page.keyboard.press(`${MOD}+k`);
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+
+  // ─── no-JS fallback ─────────────────────────────────────────────────
+
+  test("the trigger is hidden when JavaScript is disabled", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ javaScriptEnabled: false });
+    const page = await ctx.newPage();
+    await page.goto("/");
+
+    // Without html.js the trigger collapses to display:none; the docs
+    // sidebar remains the way to navigate.
+    await expect(page.locator("[data-search-open]")).toBeHidden();
+    await ctx.close();
+  });
+});
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -43,7 +43,7 @@ title = "mdsmith"
     target = "data"
 
 [outputs]
-  home = ["HTML"]
+  home = ["HTML", "JSON"]
   page = ["HTML"]
   section = ["HTML"]
 

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -33,6 +33,7 @@
   <link rel="stylesheet" href="{{ "css/colors_and_type.css" | relURL }}">
   <link rel="stylesheet" href="{{ "css/app.css" | relURL }}">
   <script src="{{ "js/lucide.min.js" | relURL }}" defer></script>
+  <script src="{{ "js/search.js" | relURL }}" defer></script>
 </head>
 <body>
   <div class="app">

--- a/website/layouts/index.json
+++ b/website/layouts/index.json
@@ -18,7 +18,7 @@
 {{- range $p := where site.Pages "Kind" "in" (slice "page" "section") -}}
   {{- $summary := "" -}}
   {{- with $p.Params.summary -}}
-    {{- $summary = $p.RenderString (dict "display" "inline") . | plainify | chomp -}}
+    {{- $summary = $p.RenderString (dict "display" "inline") . | plainify | htmlUnescape | chomp -}}
   {{- end -}}
   {{- $body := substr (replaceRE `\s+` " " ($p.Plain | htmlUnescape)) 0 $searchBodyChars -}}
   {{- $index = $index | append (dict

--- a/website/layouts/index.json
+++ b/website/layouts/index.json
@@ -1,0 +1,32 @@
+{{- /* Search index for the ⌘K search field.
+
+       Emitted as the home page's JSON output format (hugo.toml:
+       [outputs] home includes "JSON", so Hugo writes /index.json).
+       static/js/search.js fetches it once on first open and matches
+       titles, summaries, and a plain-text body excerpt entirely in
+       the browser — no external search service and no build-time
+       index step, in keeping with the site's self-hosted, no-runtime-
+       network posture.
+
+       Indexed pages are the leaf pages (Kind "page") and section
+       landing pages (Kind "section"); the home page, taxonomies, and
+       term pages are skipped. The body is whitespace-collapsed and
+       capped at searchBodyChars runes so the whole index stays small
+       enough to fetch in a single request. */ -}}
+{{- $searchBodyChars := 1600 -}}
+{{- $index := slice -}}
+{{- range $p := where site.Pages "Kind" "in" (slice "page" "section") -}}
+  {{- $summary := "" -}}
+  {{- with $p.Params.summary -}}
+    {{- $summary = $p.RenderString (dict "display" "inline") . | plainify | chomp -}}
+  {{- end -}}
+  {{- $body := substr (replaceRE `\s+` " " ($p.Plain | htmlUnescape)) 0 $searchBodyChars -}}
+  {{- $index = $index | append (dict
+        "title" $p.Title
+        "summary" $summary
+        "section" ($p.Section | title)
+        "href" $p.RelPermalink
+        "body" $body
+  ) -}}
+{{- end -}}
+{{- $index | jsonify -}}

--- a/website/layouts/partials/search.html
+++ b/website/layouts/partials/search.html
@@ -12,7 +12,7 @@
        the DOM (closed) so Lucide's createIcons() iconifies it at
        load. */ -}}
 <button type="button" class="topnav-kbd search-trigger" data-search-open
-        aria-haspopup="dialog" aria-keyshortcuts="Control+K Meta+K Slash"
+        aria-haspopup="dialog" aria-keyshortcuts="Control+K Meta+K /"
         aria-label="Search the documentation">
   <i data-lucide="search" width="15" height="15" aria-hidden="true"></i>
   <span class="search-trigger-text">Search</span>

--- a/website/layouts/partials/search.html
+++ b/website/layouts/partials/search.html
@@ -1,0 +1,46 @@
+{{- /* ⌘K / Ctrl+K documentation search.
+
+       The trigger reuses .topnav-kbd (styled for a keyboard-hinted
+       search field). static/js/search.js wires it up: it opens the
+       native <dialog>, fetches the home page's JSON output (the
+       search index at data-search-index) on first open, and matches
+       it in the browser.
+
+       Scoped to html.js in CSS — with JavaScript off the inert
+       button is hidden and the docs sidebar remains the way to
+       navigate, so no capability is lost. The dialog markup ships in
+       the DOM (closed) so Lucide's createIcons() iconifies it at
+       load. */ -}}
+<button type="button" class="topnav-kbd search-trigger" data-search-open
+        aria-haspopup="dialog" aria-keyshortcuts="Control+K Meta+K Slash"
+        aria-label="Search the documentation">
+  <i data-lucide="search" width="15" height="15" aria-hidden="true"></i>
+  <span class="search-trigger-text">Search</span>
+  <span class="search-trigger-keys" aria-hidden="true">
+    <kbd class="search-trigger-key" data-search-cmd>⌘</kbd><kbd class="search-trigger-key">K</kbd>
+  </span>
+</button>
+
+<dialog class="search-dialog" data-search-dialog
+        aria-label="Search the documentation"
+        data-search-index="{{ "index.json" | relURL }}">
+  <div class="search-panel">
+    <div class="search-field">
+      <i data-lucide="search" width="18" height="18" aria-hidden="true" class="search-field-icon"></i>
+      <input type="search" class="search-input" data-search-input
+             placeholder="Search the documentation…" autocomplete="off"
+             autocapitalize="off" autocorrect="off" spellcheck="false"
+             aria-label="Search query" role="combobox" aria-expanded="false"
+             aria-autocomplete="list" aria-controls="search-results">
+      <kbd class="search-esc" data-search-close>Esc</kbd>
+    </div>
+    <ul class="search-results" id="search-results" data-search-results
+        role="listbox" aria-label="Search results"></ul>
+    <p class="search-status" data-search-status hidden></p>
+    <div class="search-footer" aria-hidden="true">
+      <span class="search-foot"><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+      <span class="search-foot"><kbd>↵</kbd> open</span>
+      <span class="search-foot"><kbd>esc</kbd> close</span>
+    </div>
+  </div>
+</dialog>

--- a/website/layouts/partials/topnav.html
+++ b/website/layouts/partials/topnav.html
@@ -25,6 +25,7 @@
       {{ end }}
     </nav>
     <div class="topnav-right">
+      {{ partial "search.html" . }}
       <a class="topnav-version" href="{{ "/guides/install/" | relURL }}" title="Install mdsmith">v{{ .Site.Params.version }}</a>
       <a class="topnav-gh" href="https://github.com/{{ .Site.Params.githubRepo }}" rel="noopener" aria-label="mdsmith on GitHub">
         {{ partial "github-mark.html" (dict "size" 15) }}

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -1733,3 +1733,195 @@ a.rule-ref:hover code { text-decoration: underline; }
   .pg-pane + .pg-pane { border-left: 0; border-top: 1px solid var(--border); }
   .pg-pane { height: 360px; }
 }
+
+/* ========== SEARCH (⌘K) ========== */
+
+/* The trigger is inert without JS (search.js wires the dialog), so it
+   only appears once html.js lands. The docs sidebar stays the no-JS
+   path to every page. */
+.search-trigger { display: none; }
+html.js .search-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  /* Re-use .topnav-kbd's border/background; widen the right padding so
+     the ⌘K hint reads as a distinct chip from the "Search" label. */
+  padding: 4px 6px 4px 10px;
+  color: var(--fg-subtle);
+}
+.search-trigger:hover { color: var(--fg); }
+.search-trigger i,
+.search-trigger svg { color: var(--fg-subtle); flex: none; }
+.search-trigger-text { font-family: var(--font-sans); font-size: 13px; }
+.search-trigger-keys { display: inline-flex; gap: 2px; }
+.search-trigger-key {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 5px;
+  border-radius: var(--radius-xs);
+  background: var(--steel-100);
+  color: var(--steel-600);
+}
+
+/* The dialog itself is just a transparent, top-anchored container; the
+   visible card is .search-panel. */
+.search-dialog {
+  width: min(580px, calc(100vw - 32px));
+  max-width: 580px;
+  margin: 12vh auto auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  overflow: visible;
+}
+.search-dialog::backdrop {
+  background: rgba(15, 20, 25, 0.42);
+  backdrop-filter: saturate(140%) blur(3px);
+}
+.search-panel {
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.search-field-icon { color: var(--fg-subtle); flex: none; }
+.search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  color: var(--fg);
+}
+.search-input::placeholder { color: var(--fg-subtle); }
+/* Hide the native clear/search affordances so the field reads as one
+   flat input across browsers. */
+.search-input::-webkit-search-decoration,
+.search-input::-webkit-search-cancel-button { -webkit-appearance: none; appearance: none; }
+.search-esc {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 6px;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border);
+  background: var(--steel-50);
+  color: var(--fg-subtle);
+  cursor: pointer;
+}
+
+.search-results {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  overflow-y: auto;
+}
+.search-result { margin: 0; }
+.search-result-link {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 12px;
+  border-radius: var(--radius-md);
+  color: var(--fg);
+}
+.search-result-link:hover { text-decoration: none; }
+.search-result.is-active .search-result-link { background: var(--accent-soft); }
+.search-result.is-active .search-result-title { color: var(--accent); }
+.search-result-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.search-result-title {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.search-result-section {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-subtle);
+}
+.search-result-summary {
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  line-height: 1.4;
+  /* Clamp long summaries to two lines so every result stays scannable. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+.search-results mark {
+  background: transparent;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.search-status {
+  margin: 0;
+  padding: 18px 16px;
+  font-size: 13px;
+  color: var(--fg-subtle);
+  text-align: center;
+}
+
+.search-footer {
+  display: flex;
+  gap: 16px;
+  padding: 9px 14px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-sunken);
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+.search-foot { display: inline-flex; align-items: center; gap: 5px; }
+.search-footer kbd {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 2px 5px;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border);
+  background: var(--bg-raised);
+}
+
+/* Lock the page behind the modal so only the result list scrolls. */
+html.search-active { overflow: hidden; }
+
+@media (prefers-reduced-motion: no-preference) {
+  .search-dialog[open] { animation: search-in var(--dur-base) var(--ease-out); }
+  @keyframes search-in {
+    from { opacity: 0; transform: translateY(-6px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+}
+
+/* On narrow nav the label and key hint would crowd the bar; keep just
+   the icon button (still full-size, still keyboard-openable). */
+@media (max-width: 720px) {
+  .search-trigger-text,
+  .search-trigger-keys { display: none; }
+  html.js .search-trigger { padding: 5px 7px; }
+}

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -26,10 +26,14 @@
     const list = dialog.querySelector("[data-search-results]");
     const statusEl = dialog.querySelector("[data-search-status]");
     const indexURL = dialog.getAttribute("data-search-index");
+    // The dialog can exist without its inner controls if the partial is
+    // edited; bail rather than throw on the first open().
+    if (!input || !list || !statusEl) return;
 
-    let docs = null; // loaded index entries
+    let docs = null; // loaded index entries (lowercased fields cached)
     let loading = null; // in-flight fetch promise
     let results = []; // current result entries
+    let resultEls = []; // rendered <li> nodes, parallel to results
     let active = -1; // active result index, -1 = none
 
     // ── platform-aware key hint ──────────────────────────────────────
@@ -54,6 +58,15 @@
         })
         .then((data) => {
           docs = Array.isArray(data) ? data : [];
+          // Lowercase once at load, not once per keystroke: scoreDoc
+          // reads the cached _title/_summary and the body (which is
+          // only ever matched, never displayed, so it is folded to
+          // lowercase in place).
+          for (const d of docs) {
+            d._title = (d.title || "").toLowerCase();
+            d._summary = (d.summary || "").toLowerCase();
+            d.body = (d.body || "").toLowerCase();
+          }
           return docs;
         })
         .catch((err) => {
@@ -66,20 +79,17 @@
 
     // ── matching ─────────────────────────────────────────────────────
     function scoreDoc(doc, terms) {
-      const title = (doc.title || "").toLowerCase();
-      const summary = (doc.summary || "").toLowerCase();
-      const body = (doc.body || "").toLowerCase();
       let score = 0;
       for (const t of terms) {
         let s = 0;
-        const inTitle = title.indexOf(t);
+        const inTitle = doc._title.indexOf(t);
         if (inTitle !== -1) {
           s += 12;
           if (inTitle === 0) s += 10; // prefix
-          else if (/\s/.test(title.charAt(inTitle - 1))) s += 5; // word start
+          else if (/\s/.test(doc._title.charAt(inTitle - 1))) s += 5; // word start
         }
-        if (summary.indexOf(t) !== -1) s += 4;
-        if (body.indexOf(t) !== -1) s += 1;
+        if (doc._summary.indexOf(t) !== -1) s += 4;
+        if (doc.body.indexOf(t) !== -1) s += 1;
         // AND semantics: every term must appear somewhere.
         if (s === 0) return 0;
         score += s;
@@ -87,8 +97,7 @@
       return score;
     }
 
-    function search(query) {
-      const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    function search(terms) {
       if (!docs || terms.length === 0) return [];
       const scored = [];
       for (const doc of docs) {
@@ -100,43 +109,40 @@
     }
 
     // ── rendering ────────────────────────────────────────────────────
-    // Wrap each matched term in <mark>, building DOM nodes (never
-    // innerHTML) so the query string is escaped, not interpreted.
+    // Wrap each matched term in <mark>, building DOM text nodes (never
+    // innerHTML) so the query is escaped, not interpreted. Terms are
+    // matched longest-first so a shorter term cannot mask part of a
+    // longer overlapping one.
     function highlight(text, terms) {
       const frag = document.createDocumentFragment();
       if (!text) return frag;
-      const lower = text.toLowerCase();
-      let i = 0;
-      while (i < text.length) {
-        let next = -1;
-        let len = 0;
-        for (const t of terms) {
-          const at = lower.indexOf(t, i);
-          if (at !== -1 && (next === -1 || at < next)) {
-            next = at;
-            len = t.length;
-          }
-        }
-        if (next === -1) {
-          frag.appendChild(document.createTextNode(text.slice(i)));
-          break;
-        }
-        if (next > i) {
-          frag.appendChild(document.createTextNode(text.slice(i, next)));
-        }
-        const mark = document.createElement("mark");
-        mark.textContent = text.slice(next, next + len);
-        frag.appendChild(mark);
-        i = next + len;
+      if (terms.length === 0) {
+        frag.appendChild(document.createTextNode(text));
+        return frag;
       }
+      const ordered = terms.slice().sort((a, b) => b.length - a.length);
+      const re = new RegExp("(" + ordered.map(escapeRegExp).join("|") + ")", "gi");
+      // String.split with a capturing group yields [text, match, text,
+      // …]; odd indices are the captured matches.
+      text.split(re).forEach((part, i) => {
+        if (part === "") return;
+        if (i % 2 === 1) {
+          const mark = document.createElement("mark");
+          mark.textContent = part;
+          frag.appendChild(mark);
+        } else {
+          frag.appendChild(document.createTextNode(part));
+        }
+      });
       return frag;
     }
 
     function render(query) {
       const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
       list.textContent = "";
-      active = -1;
       results = [];
+      resultEls = [];
+      active = -1;
       input.removeAttribute("aria-activedescendant");
 
       if (terms.length === 0) {
@@ -153,7 +159,7 @@
         return;
       }
 
-      results = search(query);
+      results = search(terms);
       input.setAttribute("aria-expanded", results.length ? "true" : "false");
 
       if (results.length === 0) {
@@ -198,6 +204,7 @@
         li.addEventListener("mousemove", () => setActive(idx));
         li.appendChild(a);
         list.appendChild(li);
+        resultEls.push(li);
       });
 
       setActive(0);
@@ -209,21 +216,21 @@
     }
 
     function setActive(idx) {
-      const items = list.querySelectorAll(".search-result");
-      if (items.length === 0) {
+      if (resultEls.length === 0) {
         active = -1;
         return;
       }
-      active = (idx + items.length) % items.length;
-      items.forEach((el, i) => {
-        const on = i === active;
-        el.classList.toggle("is-active", on);
-        el.setAttribute("aria-selected", on ? "true" : "false");
-        if (on) {
-          input.setAttribute("aria-activedescendant", el.id);
-          el.scrollIntoView({ block: "nearest" });
-        }
-      });
+      // Only the previously- and newly-active rows change.
+      if (active >= 0 && resultEls[active]) {
+        resultEls[active].classList.remove("is-active");
+        resultEls[active].setAttribute("aria-selected", "false");
+      }
+      active = (idx + resultEls.length) % resultEls.length;
+      const el = resultEls[active];
+      el.classList.add("is-active");
+      el.setAttribute("aria-selected", "true");
+      input.setAttribute("aria-activedescendant", el.id);
+      el.scrollIntoView({ block: "nearest" });
     }
 
     function go() {
@@ -241,9 +248,15 @@
       input.focus();
       loadIndex()
         // Re-render the current query once the index lands — the user
-        // may have typed while the fetch was still in flight.
-        .then(() => render(input.value))
-        .catch(() => setStatus("Search is unavailable right now."));
+        // may have typed while the fetch was in flight. Guard on
+        // dialog.open so a fetch that resolves after the dialog was
+        // closed does not repopulate a hidden listbox.
+        .then(() => {
+          if (dialog.open) render(input.value);
+        })
+        .catch(() => {
+          if (dialog.open) setStatus("Search is unavailable right now.");
+        });
     }
 
     function close() {
@@ -314,6 +327,10 @@
       tag === "SELECT" ||
       el.isContentEditable
     );
+  }
+
+  function escapeRegExp(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
 
   if (document.readyState === "loading") {

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -109,21 +109,28 @@
     }
 
     // ── rendering ────────────────────────────────────────────────────
+    // Compile the case-insensitive matcher for a query once per render.
+    // Terms are ordered longest-first so a shorter term cannot mask part
+    // of a longer overlapping one. Returns null for an empty query.
+    function termsRegExp(terms) {
+      if (terms.length === 0) return null;
+      const ordered = terms.slice().sort((a, b) => b.length - a.length);
+      return new RegExp("(" + ordered.map(escapeRegExp).join("|") + ")", "gi");
+    }
+
     // Wrap each matched term in <mark>, building DOM text nodes (never
-    // innerHTML) so the query is escaped, not interpreted. Terms are
-    // matched longest-first so a shorter term cannot mask part of a
-    // longer overlapping one.
-    function highlight(text, terms) {
+    // innerHTML) so the query is escaped, not interpreted. `re` is the
+    // shared matcher from termsRegExp, compiled once per render.
+    function highlight(text, re) {
       const frag = document.createDocumentFragment();
       if (!text) return frag;
-      if (terms.length === 0) {
+      if (!re) {
         frag.appendChild(document.createTextNode(text));
         return frag;
       }
-      const ordered = terms.slice().sort((a, b) => b.length - a.length);
-      const re = new RegExp("(" + ordered.map(escapeRegExp).join("|") + ")", "gi");
       // String.split with a capturing group yields [text, match, text,
-      // …]; odd indices are the captured matches.
+      // …]; odd indices are the captured matches. split() ignores the
+      // regex's lastIndex, so one compiled re is safely reused per call.
       text.split(re).forEach((part, i) => {
         if (part === "") return;
         if (i % 2 === 1) {
@@ -168,6 +175,7 @@
       }
       setStatus("");
 
+      const re = termsRegExp(terms);
       results.forEach((doc, idx) => {
         const li = document.createElement("li");
         li.className = "search-result";
@@ -183,7 +191,7 @@
         head.className = "search-result-head";
         const title = document.createElement("span");
         title.className = "search-result-title";
-        title.appendChild(highlight(doc.title || "", terms));
+        title.appendChild(highlight(doc.title || "", re));
         head.appendChild(title);
         if (doc.section) {
           const sec = document.createElement("span");
@@ -196,7 +204,7 @@
         if (doc.summary) {
           const sum = document.createElement("span");
           sum.className = "search-result-summary";
-          sum.appendChild(highlight(doc.summary, terms));
+          sum.appendChild(highlight(doc.summary, re));
           a.appendChild(sum);
         }
 
@@ -234,7 +242,9 @@
     }
 
     function go() {
-      const doc = results[active] || results[0];
+      // active is always a valid index when results is non-empty (render
+      // calls setActive(0)), and Enter only calls go() under that guard.
+      const doc = results[active];
       if (doc) window.location.assign(doc.href);
     }
 
@@ -296,7 +306,13 @@
             go();
           }
           break;
-        // Esc is handled natively by <dialog>.
+        case "Escape":
+          // WebKit consumes Escape on a non-empty type=search input to
+          // clear the field, so it never reaches the <dialog>. Close
+          // explicitly for consistent Escape-to-close across browsers.
+          e.preventDefault();
+          close();
+          break;
         default:
           break;
       }

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -1,0 +1,324 @@
+/*
+ * ⌘K / Ctrl+K documentation search.
+ *
+ * Opens the native <dialog> rendered by partials/search.html, fetches
+ * the home page's JSON output (the search index) once on first open,
+ * and matches it in the browser. No external service, no build-time
+ * index tool — the index is plain JSON Hugo emits at /index.json.
+ *
+ * Pairs with layouts/partials/search.html and the ".search-" block in
+ * static/css/app.css. End-to-end behavior is covered by
+ * e2e/tests/search.spec.ts.
+ */
+(() => {
+  "use strict";
+
+  const MAX_RESULTS = 8;
+
+  function init() {
+    const trigger = document.querySelector("[data-search-open]");
+    const dialog = document.querySelector("[data-search-dialog]");
+    // Native <dialog> is required for the modal backdrop, focus trap,
+    // and Esc-to-close. Without it, leave the (hidden) trigger inert.
+    if (!trigger || !dialog || typeof dialog.showModal !== "function") return;
+
+    const input = dialog.querySelector("[data-search-input]");
+    const list = dialog.querySelector("[data-search-results]");
+    const statusEl = dialog.querySelector("[data-search-status]");
+    const indexURL = dialog.getAttribute("data-search-index");
+
+    let docs = null; // loaded index entries
+    let loading = null; // in-flight fetch promise
+    let results = []; // current result entries
+    let active = -1; // active result index, -1 = none
+
+    // ── platform-aware key hint ──────────────────────────────────────
+    // Mac shows ⌘K; everything else shows Ctrl K. The markup ships the
+    // ⌘ glyph; rewrite it off-Mac so the hint matches the real binding.
+    const isMac = /mac|iphone|ipad|ipod/i.test(
+      navigator.platform || navigator.userAgent || ""
+    );
+    if (!isMac) {
+      const cmd = trigger.querySelector("[data-search-cmd]");
+      if (cmd) cmd.textContent = "Ctrl";
+    }
+
+    // ── index loading ────────────────────────────────────────────────
+    function loadIndex() {
+      if (docs) return Promise.resolve(docs);
+      if (loading) return loading;
+      loading = fetch(indexURL)
+        .then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.json();
+        })
+        .then((data) => {
+          docs = Array.isArray(data) ? data : [];
+          return docs;
+        })
+        .catch((err) => {
+          // Let a later open retry the fetch.
+          loading = null;
+          throw err;
+        });
+      return loading;
+    }
+
+    // ── matching ─────────────────────────────────────────────────────
+    function scoreDoc(doc, terms) {
+      const title = (doc.title || "").toLowerCase();
+      const summary = (doc.summary || "").toLowerCase();
+      const body = (doc.body || "").toLowerCase();
+      let score = 0;
+      for (const t of terms) {
+        let s = 0;
+        const inTitle = title.indexOf(t);
+        if (inTitle !== -1) {
+          s += 12;
+          if (inTitle === 0) s += 10; // prefix
+          else if (/\s/.test(title.charAt(inTitle - 1))) s += 5; // word start
+        }
+        if (summary.indexOf(t) !== -1) s += 4;
+        if (body.indexOf(t) !== -1) s += 1;
+        // AND semantics: every term must appear somewhere.
+        if (s === 0) return 0;
+        score += s;
+      }
+      return score;
+    }
+
+    function search(query) {
+      const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+      if (!docs || terms.length === 0) return [];
+      const scored = [];
+      for (const doc of docs) {
+        const score = scoreDoc(doc, terms);
+        if (score > 0) scored.push({ doc, score });
+      }
+      scored.sort((a, b) => b.score - a.score);
+      return scored.slice(0, MAX_RESULTS).map((s) => s.doc);
+    }
+
+    // ── rendering ────────────────────────────────────────────────────
+    // Wrap each matched term in <mark>, building DOM nodes (never
+    // innerHTML) so the query string is escaped, not interpreted.
+    function highlight(text, terms) {
+      const frag = document.createDocumentFragment();
+      if (!text) return frag;
+      const lower = text.toLowerCase();
+      let i = 0;
+      while (i < text.length) {
+        let next = -1;
+        let len = 0;
+        for (const t of terms) {
+          const at = lower.indexOf(t, i);
+          if (at !== -1 && (next === -1 || at < next)) {
+            next = at;
+            len = t.length;
+          }
+        }
+        if (next === -1) {
+          frag.appendChild(document.createTextNode(text.slice(i)));
+          break;
+        }
+        if (next > i) {
+          frag.appendChild(document.createTextNode(text.slice(i, next)));
+        }
+        const mark = document.createElement("mark");
+        mark.textContent = text.slice(next, next + len);
+        frag.appendChild(mark);
+        i = next + len;
+      }
+      return frag;
+    }
+
+    function render(query) {
+      const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+      list.textContent = "";
+      active = -1;
+      results = [];
+      input.removeAttribute("aria-activedescendant");
+
+      if (terms.length === 0) {
+        setStatus("");
+        input.setAttribute("aria-expanded", "false");
+        return;
+      }
+      if (!docs) {
+        // The index is still loading; open() re-renders this query
+        // once the fetch resolves, so a query typed before the index
+        // lands is not silently dropped.
+        setStatus("Loading…");
+        input.setAttribute("aria-expanded", "false");
+        return;
+      }
+
+      results = search(query);
+      input.setAttribute("aria-expanded", results.length ? "true" : "false");
+
+      if (results.length === 0) {
+        setStatus("No results for “" + query + "”.");
+        return;
+      }
+      setStatus("");
+
+      results.forEach((doc, idx) => {
+        const li = document.createElement("li");
+        li.className = "search-result";
+        li.id = "search-result-" + idx;
+        li.setAttribute("role", "option");
+        li.setAttribute("aria-selected", "false");
+
+        const a = document.createElement("a");
+        a.className = "search-result-link";
+        a.href = doc.href;
+
+        const head = document.createElement("span");
+        head.className = "search-result-head";
+        const title = document.createElement("span");
+        title.className = "search-result-title";
+        title.appendChild(highlight(doc.title || "", terms));
+        head.appendChild(title);
+        if (doc.section) {
+          const sec = document.createElement("span");
+          sec.className = "search-result-section";
+          sec.textContent = doc.section;
+          head.appendChild(sec);
+        }
+        a.appendChild(head);
+
+        if (doc.summary) {
+          const sum = document.createElement("span");
+          sum.className = "search-result-summary";
+          sum.appendChild(highlight(doc.summary, terms));
+          a.appendChild(sum);
+        }
+
+        // Pointer hover mirrors keyboard focus so the two never fight.
+        li.addEventListener("mousemove", () => setActive(idx));
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+
+      setActive(0);
+    }
+
+    function setStatus(msg) {
+      statusEl.textContent = msg;
+      statusEl.hidden = !msg;
+    }
+
+    function setActive(idx) {
+      const items = list.querySelectorAll(".search-result");
+      if (items.length === 0) {
+        active = -1;
+        return;
+      }
+      active = (idx + items.length) % items.length;
+      items.forEach((el, i) => {
+        const on = i === active;
+        el.classList.toggle("is-active", on);
+        el.setAttribute("aria-selected", on ? "true" : "false");
+        if (on) {
+          input.setAttribute("aria-activedescendant", el.id);
+          el.scrollIntoView({ block: "nearest" });
+        }
+      });
+    }
+
+    function go() {
+      const doc = results[active] || results[0];
+      if (doc) window.location.assign(doc.href);
+    }
+
+    // ── open / close ─────────────────────────────────────────────────
+    function open() {
+      if (dialog.open) return;
+      input.value = "";
+      render("");
+      dialog.showModal();
+      document.documentElement.classList.add("search-active");
+      input.focus();
+      loadIndex()
+        // Re-render the current query once the index lands — the user
+        // may have typed while the fetch was still in flight.
+        .then(() => render(input.value))
+        .catch(() => setStatus("Search is unavailable right now."));
+    }
+
+    function close() {
+      if (dialog.open) dialog.close();
+    }
+
+    dialog.addEventListener("close", () => {
+      document.documentElement.classList.remove("search-active");
+    });
+
+    // Backdrop click: a modal <dialog> reports the click on the dialog
+    // element itself (not its inner panel) when the backdrop is hit.
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) close();
+    });
+
+    trigger.addEventListener("click", open);
+
+    const closeBtn = dialog.querySelector("[data-search-close]");
+    if (closeBtn) closeBtn.addEventListener("click", close);
+
+    input.addEventListener("input", () => render(input.value));
+
+    input.addEventListener("keydown", (e) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActive(active + 1);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActive(active - 1);
+          break;
+        case "Enter":
+          if (results.length) {
+            e.preventDefault();
+            go();
+          }
+          break;
+        // Esc is handled natively by <dialog>.
+        default:
+          break;
+      }
+    });
+
+    // ── global shortcuts ─────────────────────────────────────────────
+    document.addEventListener("keydown", (e) => {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        dialog.open ? close() : open();
+        return;
+      }
+      // "/" focuses search, but only when the user is not already
+      // typing into a field and the dialog is closed.
+      if (e.key === "/" && !dialog.open && !isTypingTarget(e.target)) {
+        e.preventDefault();
+        open();
+      }
+    });
+  }
+
+  function isTypingTarget(el) {
+    if (!el) return false;
+    const tag = el.tagName;
+    return (
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      el.isContentEditable
+    );
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## What

Enables the keyboard-hinted search field on mdsmith.dev — the one the
`.topnav-kbd` CSS was already styled for (added in `49fb0d6`) but never
wired up. Pressing **⌘K / Ctrl+K** (or **`/`**) opens a native
`<dialog>` that queries the docs and jumps to a page.

## How

A client-side index, no external service and no build-time index tool —
in keeping with the site's self-hosted, no-runtime-network posture:

- **`layouts/index.json`** — Hugo emits the search index as the home
  page's JSON output: `title`, `summary`, `section`, `href`, and a
  whitespace-collapsed plain-text `body` capped at 1600 runes, over
  every `page` and `section` (139 entries, ~200 KB → ~50 KB gzipped,
  fetched once on first open).
- **`partials/search.html`** — the `.topnav-kbd` trigger plus the
  dialog markup. Shipped closed in the DOM so Lucide iconifies it at
  load.
- **`static/js/search.js`** — lazy index fetch, term scoring
  (title ≫ summary ≫ body, AND semantics), `↑`/`↓`/`Enter` keyboard
  navigation, `<mark>` highlighting (built as DOM nodes, never
  `innerHTML`), and a platform-aware hint (⌘K on macOS, Ctrl K
  elsewhere). It re-renders once the index lands, so a query typed
  before the fetch resolves is not dropped.
- **`app.css`** — the `.search-*` styles. The trigger is scoped to
  `html.js`, so with JavaScript off it is inert and hidden and the docs
  sidebar remains the way to navigate.
- **`hugo.toml`** — adds `JSON` to the home output formats. Survives
  `mdsmith-release sync-messaging` (its TOML patcher re-emits the whole
  tree).

## Verification

- `npx playwright test` — **22/22 pass**; the new `search.spec.ts`
  covers the shortcut, dialog lifecycle, querying, keyboard nav, and the
  no-JS fallback. Stress-run `--repeat-each=5 --workers=4` → **55/55**.
- `go test ./internal/release/... ./cmd/mdsmith-release/...` — pass
  (the `hugo.toml` change does not disturb the release tooling).
- `mdsmith check .` — pass (422 checked, 0 failures).

https://claude.ai/code/session_0136zwVAxYNUXYFspPoAwi7Z