### PR TITLE
test(pkg/mdsmith): add unit tests for Session.CheckSource

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -161,4 +161,6 @@ footer: |
 | 233 | ✅     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
 | 234 | 🔳     | sonnet | [Distribute mdsmith on Windows via Scoop and WinGet](plan/234_windows-package-managers.md)                                              |
 | 235 | ✅     | sonnet | [Playwright end-to-end tests for the website, runnable by CI and agents](plan/235_playwright-site-e2e.md)                               |
+| 236 | 🔲     | sonnet | [Consolidate duplicated table-parse helpers in tablereadability](plan/236_arch-fix-tablereadability-dup.md)                             |
+| 237 | 🔲     | haiku  | [Unit tests for include-rule private validation helpers](plan/237_arch-fix-include-helper-tests.md)                                     |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: 37488a7c524f6e2d0a686b9f33662c6f786f966c
+audit-from: 82583fc1cce6f4be8451196f60e5dc6d1e6a5b28
 ---
 # Architecture audit log
 
@@ -290,3 +290,13 @@ Plans 200, 201, 202 green. Tax:
 split into sibling packages.
 
 [225]: ../../plan/225_arch-fix-punkt-layering.md
+
+## Audit 2026-06-07 (range: 37488a7..82583fc)
+
+Plans 203–225 green. Blocker: `Session.CheckSource`
+(public API) had no unit test. Fixed: added
+`pkg/mdsmith/checksource_test.go` with 4 tests.
+Tax: [plan/236][236], [plan/237][237].
+
+[236]: ../../plan/236_arch-fix-tablereadability-dup.md
+[237]: ../../plan/237_arch-fix-include-helper-tests.md

--- a/pkg/mdsmith/checksource_test.go
+++ b/pkg/mdsmith/checksource_test.go
@@ -1,0 +1,91 @@
+package mdsmith
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckSourceFindsDiagnostic verifies CheckSource lints an in-memory
+// source and returns diagnostics. This is the stdin path: the CLI passes
+// the raw source bytes rather than a file path.
+func TestCheckSourceFindsDiagnostic(t *testing.T) {
+	s := newTestSession(t, "", nil)
+
+	// Trailing spaces on line 3 trigger MDS006.
+	src := []byte("# Title\n\ntrailing   \n")
+	res := s.CheckSource("<stdin>", src, BatchOptions{})
+	var found bool
+	for _, d := range res.Diagnostics {
+		if d.RuleID == "MDS006" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("CheckSource: expected MDS006 diagnostic for trailing spaces, got %+v", res.Diagnostics)
+	}
+}
+
+// TestCheckSourceClean verifies CheckSource returns zero diagnostics for
+// a conformant in-memory source.
+func TestCheckSourceClean(t *testing.T) {
+	s := newTestSession(t, "", nil)
+
+	src := []byte("# Title\n\nBody paragraph.\n")
+	res := s.CheckSource("<stdin>", src, BatchOptions{})
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("CheckSource(clean): expected no diagnostics, got %+v", res.Diagnostics)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("CheckSource(clean): expected no errors, got %+v", res.Errors)
+	}
+}
+
+// TestCheckSourceMaxInputBytesOverride verifies a per-call MaxInputBytes
+// in BatchOptions limits the source size checked, consistent with
+// CheckPaths behaviour.
+func TestCheckSourceMaxInputBytesOverride(t *testing.T) {
+	s := newTestSession(t, "", nil)
+
+	// Source is 25 bytes; cap at 8 to force a "file too large" error.
+	src := []byte("# Title\n\nBody paragraph.\n")
+	res := s.CheckSource("<stdin>", src, BatchOptions{MaxInputBytes: 8})
+	if len(res.Errors) == 0 {
+		t.Fatalf("CheckSource(MaxInputBytes=8): expected a 'file too large' error, got none")
+	}
+}
+
+// TestCheckSourceConfigPath verifies CheckSource works when the session
+// was built from a config file path and that the loaded config is applied
+// to the in-memory source. A tight line-length cap (max: 10) triggers
+// MDS001 on a long source line, proving the disk config was read and
+// applied rather than silently falling back to defaults.
+func TestCheckSourceConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	if err := os.WriteFile(cfgPath, []byte("rules:\n  line-length:\n    max: 10\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s, err := NewSession(SessionOptions{
+		Workspace: OSWorkspace{Root: dir},
+		Config:    ConfigPath(cfgPath),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(s.Dispose)
+
+	// Line 3 is longer than 10 chars, so MDS001 must fire if the config
+	// was loaded correctly.
+	src := []byte("# Title\n\nThis line is definitely longer than ten.\n")
+	res := s.CheckSource("<stdin>", src, BatchOptions{})
+	var found bool
+	for _, d := range res.Diagnostics {
+		if d.RuleID == "MDS001" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("CheckSource with ConfigPath(max=10): expected MDS001 diagnostic, got %+v", res.Diagnostics)
+	}
+}

--- a/plan/236_arch-fix-tablereadability-dup.md
+++ b/plan/236_arch-fix-tablereadability-dup.md
@@ -1,0 +1,54 @@
+---
+id: 236
+title: Consolidate duplicated table-parse helpers in tablereadability
+status: "🔲"
+summary: >-
+  Move tablereadability's private findTables/tryParseTable
+  into tablefmt so the two rules share one copy.
+model: sonnet
+depends-on: []
+---
+# Consolidate duplicated table-parse helpers
+
+## Goal
+
+Remove duplicated `findTables` and `tryParseTable` from
+`internal/rules/tablereadability/rule.go` by sharing the
+boundary-detection logic already in
+`internal/rules/tablefmt`.
+
+## Background
+
+Both `tablereadability` and `tablefmt` carry private copies
+of `findTables` and `tryParseTable`. The copies diverged on
+the perf pass (`1ee98e7`). Future perf or correctness fixes
+risk being applied to one copy and missed in the other.
+
+The two `table` types differ. `tablefmt.table` stores
+`cells []string` for formatting. `tablereadability.tableRow`
+stores `cells [][]byte` for zero-alloc counting. A clean
+consolidation exports boundary detection separately from
+cell parsing. Or it accepts distinct `table` types with
+a shared scanner.
+
+Severity: tax (DRY violation; copies diverge on every perf
+pass).
+
+## Tasks
+
+1. Export a table-boundary scanner from `tablefmt` — a
+   helper that returns start/end indices of each table block
+   without parsing cells.
+2. Update `tablereadability` to call the exported scanner and
+   parse cells itself from the detected line ranges.
+3. Add or update unit tests in both packages.
+4. Verify `TestRulesDoNotImportEachOther` still passes.
+5. Verify no regression: `go test ./...`.
+
+## Acceptance Criteria
+
+- [ ] Table-boundary scanning exists in one package only.
+- [ ] `tablereadability` does not duplicate scanning logic.
+- [ ] `TestRulesDoNotImportEachOther` passes.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/237_arch-fix-include-helper-tests.md
+++ b/plan/237_arch-fix-include-helper-tests.md
@@ -1,0 +1,65 @@
+---
+id: 237
+title: Unit tests for include-rule private validation helpers
+status: "🔲"
+summary: >-
+  Add dedicated unit tests for the four private helpers
+  extracted from validateIncludeDirective in plan 232/233.
+model: haiku
+depends-on: []
+---
+# Unit tests for include-rule private validation helpers
+
+## Goal
+
+Add a named `Test<Function>` for each of the four private
+helpers extracted from `validateIncludeDirective` in plans
+232 and 233.
+
+## Background
+
+Commits `09403b4` (plan 232) and `74c72dc` (plan 233)
+extracted four private helpers:
+
+- `validateHeadingOffset` — integer −6 to 6, conflicts with
+  `heading-level`.
+- `validateHeadingLevel` — numeric h1–h6 or named level.
+- `validateExtractParam` — extract parameter validation.
+- `findParentHeadingLevel` — AST walk for nearest heading.
+
+Each commit added AST-transform tests only.
+The validation wrappers have no direct unit test.
+Integration and fixture tests cover them indirectly.
+No `Test<Function>` symbol names them.
+
+Severity: tax (private; covered indirectly, but no red/green
+entry point for future refactors).
+
+## Tasks
+
+1. Add `TestValidateHeadingOffset` in
+   `internal/rules/include/headings_test.go`:
+
+  - missing param, invalid integer, out-of-range, valid,
+     conflict with `heading-level`.
+
+2. Add `TestValidateHeadingLevel`:
+
+  - missing param, invalid string, valid numeric/named.
+
+3. Add `TestValidateExtractParam` covering its branches.
+4. Add `TestFindParentHeadingLevel`:
+
+  - no heading above marker; heading found at depth.
+
+5. Run `go test ./internal/rules/include/... -v` and confirm
+   the new `Test*` names appear.
+
+## Acceptance Criteria
+
+- [ ] `TestValidateHeadingOffset` covers five cases.
+- [ ] `TestValidateHeadingLevel` covers three cases.
+- [ ] `TestValidateExtractParam` has branch coverage.
+- [ ] `TestFindParentHeadingLevel` covers both cases.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

- **Blocker fix**: `Session.CheckSource` (public API, stdin/in-memory path) had no dedicated unit test — a blocker finding from the 2026-06-07 architecture audit. Adds `pkg/mdsmith/checksource_test.go` with 4 named tests covering the key branches of the method.
- **Tax plans filed**: plan/236 (DRY violation — `findTables`/`tryParseTable` duplicated between `tablereadability` and `tablefmt`) and plan/237 (include-rule private validation helpers lack direct unit tests).
- **Audit log updated**: `docs/development/architecture-audit.md` records the 2026-06-07 sweep (range `37488a7..82583fc`) and advances `audit-from` to the new HEAD SHA.

## New tests

| Test | What it checks |
|------|---------------|
| `TestCheckSourceFindsDiagnostic` | MDS006 fires on trailing-space source |
| `TestCheckSourceClean` | zero diagnostics and zero errors on conformant source |
| `TestCheckSourceMaxInputBytesOverride` | `BatchOptions.MaxInputBytes` cap triggers a file-too-large error |
| `TestCheckSourceConfigPath` | disk config is loaded and applied — MDS001 fires with `max: 10` |

## Test plan

- [x] `go test ./pkg/mdsmith/...` green
- [x] `go test ./...` green
- [x] `mdsmith check` clean on all modified Markdown files

https://claude.ai/code/session_01KBKB7gCt6UxVczvq1we8hB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBKB7gCt6UxVczvq1we8hB)_