### PR TITLE
perf: eliminate hot-path allocations in 5 rules

### DIFF
--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -700,8 +700,8 @@ func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
 // If a rule implements Configurable and has settings, it is cloned and
 // configured before being returned.
 func (f *Fixer) fixableRules(effective map[string]config.RuleCfg) ([]rule.FixableRule, []error) {
-	var fixable []rule.FixableRule
-	var errs []error
+	fixable := make([]rule.FixableRule, 0, len(f.Rules))
+	errs := make([]error, 0, len(f.Rules))
 	for _, rl := range f.Rules {
 		cfg, ok := effective[rl.Name()]
 		if !ok || !cfg.Enabled {

--- a/internal/rules/blanklinearoundheadings/rule.go
+++ b/internal/rules/blanklinearoundheadings/rule.go
@@ -1,6 +1,7 @@
 package blanklinearoundheadings
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -62,8 +63,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	if line > 1 {
 		prevLineIdx := line - 2 // 0-based index
 		if prevLineIdx >= 0 && prevLineIdx < len(f.Lines) {
-			prevLine := strings.TrimSpace(string(f.Lines[prevLineIdx]))
-			if prevLine != "" {
+			if len(bytes.TrimSpace(f.Lines[prevLineIdx])) != 0 {
 				diags = append(diags, lint.Diagnostic{
 					File:     f.Path,
 					Line:     line,
@@ -80,8 +80,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	// Check blank line after (not needed for last line)
 	nextLineIdx := lastLine // 0-based index of line after heading
 	if nextLineIdx < len(f.Lines) {
-		nextLine := strings.TrimSpace(string(f.Lines[nextLineIdx]))
-		if nextLine != "" {
+		if len(bytes.TrimSpace(f.Lines[nextLineIdx])) != 0 {
 			diags = append(diags, lint.Diagnostic{
 				File:     f.Path,
 				Line:     line,
@@ -176,7 +175,7 @@ func isNonBlankLine(lines [][]byte, idx int) bool {
 	if idx < 0 || idx >= len(lines) {
 		return false
 	}
-	return strings.TrimSpace(string(lines[idx])) != ""
+	return len(bytes.TrimSpace(lines[idx])) != 0
 }
 
 func headingLastLine(heading *ast.Heading, f *lint.File) int {

--- a/internal/rules/horizontalrulestyle/rule.go
+++ b/internal/rules/horizontalrulestyle/rule.go
@@ -119,7 +119,8 @@ func (r *Rule) checkLength(f *lint.File, line int, count int) []lint.Diagnostic 
 		RuleID:   r.ID(),
 		RuleName: r.Name(),
 		Severity: lint.Warning,
-		Message:  "horizontal rule has length " + strconv.Itoa(count) + "; configured length is " + strconv.Itoa(r.Length),
+		Message: "horizontal rule has length " + strconv.Itoa(count) +
+				"; configured length is " + strconv.Itoa(r.Length),
 	}}
 }
 

--- a/internal/rules/horizontalrulestyle/rule.go
+++ b/internal/rules/horizontalrulestyle/rule.go
@@ -120,7 +120,7 @@ func (r *Rule) checkLength(f *lint.File, line int, count int) []lint.Diagnostic 
 		RuleName: r.Name(),
 		Severity: lint.Warning,
 		Message: "horizontal rule has length " + strconv.Itoa(count) +
-				"; configured length is " + strconv.Itoa(r.Length),
+			"; configured length is " + strconv.Itoa(r.Length),
 	}}
 }
 

--- a/internal/rules/horizontalrulestyle/rule.go
+++ b/internal/rules/horizontalrulestyle/rule.go
@@ -3,6 +3,7 @@ package horizontalrulestyle
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -118,7 +119,7 @@ func (r *Rule) checkLength(f *lint.File, line int, count int) []lint.Diagnostic 
 		RuleID:   r.ID(),
 		RuleName: r.Name(),
 		Severity: lint.Warning,
-		Message:  fmt.Sprintf("horizontal rule has length %d; configured length is %d", count, r.Length),
+		Message:  "horizontal rule has length " + strconv.Itoa(count) + "; configured length is " + strconv.Itoa(r.Length),
 	}}
 }
 

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -98,7 +98,7 @@ func (r *Rule) diag(f *lint.File, line int, msg string) lint.Diagnostic {
 // that goes nowhere; markdownlint MD042 treats `#` the same way.
 func emptyDestination(dest []byte) bool {
 	t := bytes.TrimSpace(dest)
-	return len(t) == 0 || string(t) == "#"
+	return len(t) == 0 || (len(t) == 1 && t[0] == '#')
 }
 
 // hasVisibleContent reports whether the link renders any visible

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -14,9 +14,9 @@ package tableformat
 
 import (
 	"bytes"
-	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -209,13 +209,16 @@ func checkPipeStyle(f *lint.File, t tableBlock, style, ruleID, ruleName string) 
 
 func checkColumnCount(f *lint.File, t tableBlock, ruleID, ruleName string) []lint.Diagnostic {
 	want := t.rows[0].cells
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(t.rows)-1)
 	for _, row := range t.rows[1:] {
 		if row.cells == want {
 			continue
 		}
 		diags = append(diags, structureDiag(f, row.lineNum, 1, ruleID, ruleName,
-			fmt.Sprintf("table column count; expected %d, got %d", want, row.cells)))
+			"table column count; expected "+strconv.Itoa(want)+", got "+strconv.Itoa(row.cells)))
+	}
+	if len(diags) == 0 {
+		return nil
 	}
 	return diags
 }


### PR DESCRIPTION
## Summary

Audit of the codebase against `docs/development/high-performance-go.md` identified five allocation hot-spots in rule `Check` functions and the fix pipeline. Each fix is a targeted, behavior-preserving change.

| # | File | Violation | Fix |
|---|------|-----------|-----|
| 1 | `internal/rules/blanklinearoundheadings/rule.go` | `string()+strings.TrimSpace()` per heading boundary check (2 allocs/heading) | `bytes.TrimSpace()` — zero allocation |
| 2 | `internal/rules/linkvalidity/rule.go` | `string(t) == "#"` per link visited (1 alloc/link) | Direct byte comparison `len(t)==1 && t[0]=='#'` |
| 3 | `internal/rules/horizontalrulestyle/rule.go` | `fmt.Sprintf` with `%d` in `checkLength` (reflection + format parse per violation) | `strconv.Itoa` concatenation |
| 4 | `internal/fix/fix.go` | Unpreized `var fixable []rule.FixableRule` and `var errs []error` in `fixableRules` (called per file during fix) | `make([]T, 0, len(f.Rules))` |
| 5 | `internal/rules/tableformat/structure.go` | `fmt.Sprintf` + unpreized `diags` slice in `checkColumnCount` (per mismatched row) | `strconv.Itoa` + `make([]lint.Diagnostic, 0, len(t.rows)-1)` + `nil` on clean tables |

## Guideline references

All five fixes address patterns documented in [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md):

- **Allocations** → _Pre-size slices_, _Return `nil` not `[]T{}`_
- **Strings and bytes** → _Stay in `[]byte`_, _`bytes.TrimSpace` over `string()+strings.TrimSpace`_
- **`strconv` over `fmt.Sprintf`** → `strconv.Itoa` is ~3× faster and skips reflection

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/rules/blanklinearoundheadings/... ./internal/rules/linkvalidity/... ./internal/rules/horizontalrulestyle/... ./internal/fix/... ./internal/rules/tableformat/...` — all pass
- [x] `go test ./...` — full suite green (no failures)
- [x] `go run ./cmd/mdsmith check .` — `checked=422 fixed=0 failures=0 unfixed=0`

https://claude.ai/code/session_01UqdAHkP28bdvpLytZB1ifH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqdAHkP28bdvpLytZB1ifH)_