### PR TITLE
fix(website): de-duplicate and complete docs breadcrumbs + add a breadcrumb check

### DIFF
--- a/docs/background/index.md
+++ b/docs/background/index.md
@@ -1,5 +1,5 @@
 ---
-title: Concepts
+title: Background
 weight: 50
 summary: >-
   The mental model behind mdsmith — how flavor, rule,
@@ -7,7 +7,7 @@ summary: >-
   work, the placeholder grammar, and how it compares to
   other Markdown linters.
 ---
-# Concepts
+# Background
 
 <?catalog
 glob:

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -45,6 +45,144 @@ func VerifyWebsiteLinks(htmlDir, baseURL string) error {
 			return err
 		}
 	}
+	return verifyBreadcrumbs(htmlDir, prefix)
+}
+
+// breadcrumbNavRe captures the inner HTML of the docs-breadcrumb
+// nav (partials/breadcrumb.html). The class attribute's quotes are
+// optional so the probe matches both Hugo's default output and
+// `hugo --minify`, which drops quotes around values that need none.
+var breadcrumbNavRe = regexp.MustCompile(`(?s)<nav class="?docs-breadcrumb"?>(.*?)</nav>`)
+
+// breadcrumbLinkRe matches one linked crumb `<a href=…>label</a>`,
+// capturing the href (group 1) and the visible label (group 2).
+// Labels are template-escaped page titles, so they never contain a
+// literal `<`.
+var breadcrumbLinkRe = regexp.MustCompile(`<a href="?([^"\s>]+)"?>([^<]*)</a>`)
+
+// breadcrumbCurrentRe matches the trailing current-page crumb — the
+// only attribute-less `<span>` in the nav (the separators all carry
+// `class="sep"`).
+var breadcrumbCurrentRe = regexp.MustCompile(`<span>([^<]*)</span>`)
+
+// verifyBreadcrumbs walks every rendered index.html under htmlDir
+// and validates the docs-breadcrumb trail on each page that has one.
+// The partial builds the trail from the page's URL segments, so
+// three invariants must hold:
+//
+//   - No two consecutive crumb labels are equal. A section titled
+//     the same as a child directory renders the same label twice in
+//     a row (the doubled "Concepts" report).
+//   - The crumb count below the "mdsmith" home crumb equals the
+//     page's URL depth, so no directory tier is skipped (the
+//     reference/cli/ command pages dropped the "CLI Reference" tier
+//     under the former .Ancestors trail).
+//   - Every linked crumb resolves to a rendered page on disk.
+//
+// Pages without a breadcrumb (the homepage, 404) are skipped. prefix
+// is the baseURL path component, trimmed from each href before it is
+// resolved against htmlDir.
+func verifyBreadcrumbs(htmlDir, prefix string) error {
+	return filepath.WalkDir(htmlDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("verify breadcrumbs: walk %s: %w", path, walkErr)
+		}
+		if d.IsDir() || filepath.Base(path) != "index.html" {
+			return nil
+		}
+		data, err := readHTMLFile(path)
+		if err != nil {
+			return fmt.Errorf("verify breadcrumbs: %w", err)
+		}
+		return checkPageBreadcrumb(htmlDir, prefix, path, data)
+	})
+}
+
+// checkPageBreadcrumb validates the single page at file. It returns
+// nil when the page carries no breadcrumb nav.
+func checkPageBreadcrumb(htmlDir, prefix, file string, data []byte) error {
+	nav := breadcrumbNavRe.FindSubmatch(data)
+	if nav == nil {
+		return nil
+	}
+	links := breadcrumbLinkRe.FindAllSubmatch(nav[1], -1)
+	labels := make([]string, 0, len(links)+1)
+	for _, m := range links {
+		labels = append(labels, string(m[2]))
+	}
+	if cur := breadcrumbCurrentRe.FindSubmatch(nav[1]); cur != nil {
+		labels = append(labels, string(cur[1]))
+	}
+	if len(labels) == 0 {
+		return fmt.Errorf("verify breadcrumbs: empty breadcrumb in %s", file)
+	}
+
+	for i := 1; i < len(labels); i++ {
+		if labels[i] == labels[i-1] {
+			return fmt.Errorf(
+				"verify breadcrumbs: duplicate consecutive crumb %q in %s",
+				labels[i], file)
+		}
+	}
+
+	depth, err := breadcrumbURLDepth(htmlDir, file)
+	if err != nil {
+		return err
+	}
+	if got := len(labels) - 1; got != depth {
+		return fmt.Errorf(
+			"verify breadcrumbs: %s has %d crumbs below home but URL depth is %d "+
+				"(a directory tier is missing or doubled)", file, got, depth)
+	}
+
+	for _, m := range links {
+		if err := resolveCrumbHref(htmlDir, prefix, string(m[1])); err != nil {
+			return fmt.Errorf("verify breadcrumbs: %s: %w", file, err)
+		}
+	}
+	return nil
+}
+
+// breadcrumbURLDepth returns the number of URL path segments for the
+// page rendered at file. Hugo emits each page as
+// `<segment>/.../index.html`, so the depth is the count of path
+// components between htmlDir and the index.html. The site root's
+// index.html has depth 0.
+func breadcrumbURLDepth(htmlDir, file string) (int, error) {
+	rel, err := filepath.Rel(htmlDir, file)
+	if err != nil {
+		return 0, fmt.Errorf("verify breadcrumbs: relpath %s: %w", file, err)
+	}
+	rel = strings.Trim(strings.TrimSuffix(filepath.ToSlash(rel), "index.html"), "/")
+	if rel == "" {
+		return 0, nil
+	}
+	return len(strings.Split(rel, "/")), nil
+}
+
+// resolveCrumbHref confirms a breadcrumb href points at a rendered
+// page under htmlDir. The baseURL path prefix is trimmed first, then
+// the site-absolute path maps to `<htmlDir>/<path>/index.html` (the
+// root "/" maps to `<htmlDir>/index.html`). Fragment and query tails
+// are dropped. An external href (a scheme or a protocol-relative
+// `//host`) is accepted without a filesystem check — breadcrumbs are
+// internal, but the guard keeps a stray external crumb from being
+// reported as a missing local page.
+func resolveCrumbHref(htmlDir, prefix, href string) error {
+	if strings.Contains(href, "://") || strings.HasPrefix(href, "//") {
+		return nil
+	}
+	if i := strings.IndexAny(href, "#?"); i >= 0 {
+		href = href[:i]
+	}
+	if prefix != "" {
+		href = strings.TrimPrefix(href, prefix)
+	}
+	rel := strings.Trim(href, "/")
+	target := filepath.Join(htmlDir, filepath.FromSlash(rel), "index.html")
+	if _, err := os.Stat(target); err != nil {
+		return fmt.Errorf("crumb href %q resolves to missing page %s", href, target)
+	}
 	return nil
 }
 

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -185,6 +185,250 @@ func TestVerifyWebsiteLinks_MissingRecursiveRootWraps(t *testing.T) {
 	assert.Contains(t, err.Error(), "walk")
 }
 
+// --- breadcrumb probes ---
+
+// crumb renders one breadcrumb entry; an empty href marks the
+// trailing current-page crumb (a bare <span>).
+func crumb(label, href string) string {
+	if href == "" {
+		return "<span>" + label + "</span>"
+	}
+	return `<a href="` + href + `">` + label + "</a>"
+}
+
+// crumbNav joins entries with separator spans into a docs-breadcrumb
+// nav, matching the markup partials/breadcrumb.html emits.
+func crumbNav(entries ...string) string {
+	return `<nav class="docs-breadcrumb">` +
+		strings.Join(entries, `<span class="sep">/</span>`) + "</nav>"
+}
+
+// goodCrumbSite materializes a rendered tree whose breadcrumbs
+// satisfy every verifyBreadcrumbs invariant: a home page (no
+// breadcrumb), a section, a section-overview page, and a leaf one
+// tier deeper. prefix is the baseURL path component carried on each
+// href, mirroring Hugo's relURL output.
+func goodCrumbSite(t *testing.T, prefix string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "index.html"), "<p>home</p>")
+	writeFile(t, filepath.Join(root, "reference", "index.html"),
+		crumbNav(crumb("mdsmith", prefix+"/"), crumb("Reference", "")))
+	writeFile(t, filepath.Join(root, "reference", "cli", "index.html"),
+		crumbNav(crumb("mdsmith", prefix+"/"),
+			crumb("Reference", prefix+"/reference/"),
+			crumb("CLI Reference", "")))
+	writeFile(t, filepath.Join(root, "reference", "cli", "check", "index.html"),
+		crumbNav(crumb("mdsmith", prefix+"/"),
+			crumb("Reference", prefix+"/reference/"),
+			crumb("CLI Reference", prefix+"/reference/cli/"),
+			crumb("mdsmith check", "")))
+	return root
+}
+
+func TestVerifyBreadcrumbs_GoodPasses(t *testing.T) {
+	require.NoError(t, verifyBreadcrumbs(goodCrumbSite(t, ""), ""))
+}
+
+func TestVerifyBreadcrumbs_GoodPassesSubpath(t *testing.T) {
+	require.NoError(t,
+		verifyBreadcrumbs(goodCrumbSite(t, "/mdsmith"), "/mdsmith"))
+}
+
+// TestVerifyBreadcrumbs_FailsOnDuplicate pins the reported bug: a
+// section titled the same as its child directory renders the same
+// label twice in a row ("mdsmith / Concepts / Concepts / …").
+func TestVerifyBreadcrumbs_FailsOnDuplicate(t *testing.T) {
+	root := goodCrumbSite(t, "")
+	writeFile(t, filepath.Join(root, "background", "concepts", "index.html"),
+		crumbNav(crumb("mdsmith", "/"),
+			crumb("Concepts", "/background/"),
+			crumb("Concepts", "")))
+	// Parent so the /background/ crumb href resolves.
+	writeFile(t, filepath.Join(root, "background", "index.html"),
+		crumbNav(crumb("mdsmith", "/"), crumb("Concepts", "")))
+	err := verifyBreadcrumbs(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate consecutive crumb")
+	assert.Contains(t, err.Error(), "Concepts")
+}
+
+// TestVerifyBreadcrumbs_FailsOnDepthMismatch pins the reference/cli/
+// regression: a page three URL segments deep whose trail skips a
+// directory tier has fewer crumbs than its depth.
+func TestVerifyBreadcrumbs_FailsOnDepthMismatch(t *testing.T) {
+	root := goodCrumbSite(t, "")
+	// reference/cli/check is depth 3 but this trail omits the CLI tier.
+	writeFile(t, filepath.Join(root, "reference", "cli", "check", "index.html"),
+		crumbNav(crumb("mdsmith", "/"),
+			crumb("Reference", "/reference/"),
+			crumb("mdsmith check", "")))
+	err := verifyBreadcrumbs(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "URL depth")
+}
+
+func TestVerifyBreadcrumbs_FailsOnBrokenLink(t *testing.T) {
+	root := goodCrumbSite(t, "")
+	writeFile(t, filepath.Join(root, "guides", "editors", "vscode", "index.html"),
+		crumbNav(crumb("mdsmith", "/"),
+			crumb("Guides", "/guides/"),
+			crumb("Editors", "/guides/editors/"), // no such page rendered
+			crumb("mdsmith for VS Code", "")))
+	writeFile(t, filepath.Join(root, "guides", "index.html"),
+		crumbNav(crumb("mdsmith", "/"), crumb("Guides", "")))
+	err := verifyBreadcrumbs(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing page")
+}
+
+// TestVerifyBreadcrumbs_SkipsPagesWithoutBreadcrumb confirms a page
+// with no docs-breadcrumb nav (homepage, 404) is ignored.
+func TestVerifyBreadcrumbs_SkipsPagesWithoutBreadcrumb(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "index.html"), "<p>home, no nav</p>")
+	writeFile(t, filepath.Join(root, "404.html"), "<p>not found</p>")
+	require.NoError(t, verifyBreadcrumbs(root, ""))
+}
+
+// TestVerifyBreadcrumbs_AcceptsMinified pins the unquoted-attribute
+// form `hugo --minify` emits, and confirms a duplicate is still
+// caught in that form.
+func TestVerifyBreadcrumbs_AcceptsMinified(t *testing.T) {
+	good := t.TempDir()
+	writeFile(t, filepath.Join(good, "index.html"), "<p>home</p>")
+	writeFile(t, filepath.Join(good, "reference", "index.html"),
+		`<nav class=docs-breadcrumb><a href=/>mdsmith</a>`+
+			`<span class=sep>/</span><span>Reference</span></nav>`)
+	require.NoError(t, verifyBreadcrumbs(good, ""))
+
+	bad := t.TempDir()
+	writeFile(t, filepath.Join(bad, "index.html"), "<p>home</p>")
+	writeFile(t, filepath.Join(bad, "background", "index.html"),
+		`<nav class=docs-breadcrumb><a href=/>mdsmith</a>`+
+			`<span class=sep>/</span><span>x</span></nav>`)
+	writeFile(t, filepath.Join(bad, "background", "concepts", "index.html"),
+		`<nav class=docs-breadcrumb><a href=/>mdsmith</a>`+
+			`<span class=sep>/</span><a href=/background/>Concepts</a>`+
+			`<span class=sep>/</span><span>Concepts</span></nav>`)
+	err := verifyBreadcrumbs(bad, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate consecutive crumb")
+}
+
+// TestVerifyBreadcrumbs_MissingRootWraps drives the WalkDir-error
+// branch: a non-existent root surfaces a wrapped walk error.
+func TestVerifyBreadcrumbs_MissingRootWraps(t *testing.T) {
+	err := verifyBreadcrumbs(filepath.Join(t.TempDir(), "nope"), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "walk")
+}
+
+// TestVerifyBreadcrumbs_UnreadableMemberWraps drives the
+// readHTMLFile-error branch: a dangling index.html symlink is a
+// non-dir entry the walk descends to but cannot read.
+func TestVerifyBreadcrumbs_UnreadableMemberWraps(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "page")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	link := filepath.Join(dir, "index.html")
+	if err := os.Symlink(filepath.Join(dir, "no-such-target"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	err := verifyBreadcrumbs(filepath.Dir(dir), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rendered HTML not found")
+}
+
+// TestVerifyWebsiteLinks_RunsBreadcrumbCheck confirms the breadcrumb
+// pass is wired into VerifyWebsiteLinks: a tree that satisfies every
+// link probe but carries a doubled crumb still fails.
+func TestVerifyWebsiteLinks_RunsBreadcrumbCheck(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "background", "index.html"),
+		crumbNav(crumb("mdsmith", "/"), crumb("Concepts", "")))
+	writeFile(t, filepath.Join(root, "background", "concepts", "index.html"),
+		crumbNav(crumb("mdsmith", "/"),
+			crumb("Concepts", "/background/"),
+			crumb("Concepts", "")))
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate consecutive crumb")
+}
+
+func TestResolveCrumbHref(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "index.html"), "home")
+	writeFile(t, filepath.Join(root, "reference", "index.html"), "ref")
+
+	cases := []struct {
+		name, prefix, href string
+		wantErr            bool
+	}{
+		{"root", "", "/", false},
+		{"section", "", "/reference/", false},
+		{"missing", "", "/nope/", true},
+		{"external", "", "https://example.com/x/", false},
+		{"protocol relative", "", "//cdn/x/", false},
+		{"fragment trimmed", "", "/reference/#output", false},
+		{"subpath stripped", "/mdsmith", "/mdsmith/reference/", false},
+		{"subpath missing", "/mdsmith", "/mdsmith/nope/", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := resolveCrumbHref(root, tc.prefix, tc.href)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "missing page")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCheckPageBreadcrumb_EmptyNavFails drives the empty-breadcrumb
+// branch: a nav element with no crumbs at all.
+func TestCheckPageBreadcrumb_EmptyNavFails(t *testing.T) {
+	err := checkPageBreadcrumb(t.TempDir(), "", "x/index.html",
+		[]byte(`<nav class="docs-breadcrumb"></nav>`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty breadcrumb")
+}
+
+// TestCheckPageBreadcrumb_DepthErrorWraps drives the
+// depth-computation error branch: a relative htmlDir against an
+// absolute file path makes filepath.Rel fail.
+func TestCheckPageBreadcrumb_DepthErrorWraps(t *testing.T) {
+	err := checkPageBreadcrumb("relative", "", "/abs/page/index.html",
+		[]byte(crumbNav(crumb("mdsmith", "/"), crumb("X", ""))))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relpath")
+}
+
+func TestBreadcrumbURLDepth(t *testing.T) {
+	cases := []struct {
+		name, root, file string
+		want             int
+		wantErr          bool
+	}{
+		{"root", "/site", "/site/index.html", 0, false},
+		{"section", "/site", "/site/reference/index.html", 1, false},
+		{"deep", "/site", "/site/reference/cli/check/index.html", 3, false},
+		{"rel error", "relative", "/abs/x/index.html", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := breadcrumbURLDepth(tc.root, tc.file)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestPathPrefixFromBaseURL(t *testing.T) {
 	cases := []struct {
 		name string

--- a/website/layouts/_default/list.html
+++ b/website/layouts/_default/list.html
@@ -4,17 +4,7 @@
       {{ partial "docs-sidebar.html" . }}
     </aside>
     <article class="docs-main">
-      <nav class="docs-breadcrumb">
-        <a href="{{ "/" | relURL }}">mdsmith</a>
-        {{ range .Ancestors.Reverse }}
-          {{ if not .IsHome }}
-            <span class="sep">/</span>
-            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-          {{ end }}
-        {{ end }}
-        <span class="sep">/</span>
-        <span>{{ .Title }}</span>
-      </nav>
+      {{ partial "breadcrumb.html" . }}
       <div class="docs-prose">
         <h1>{{ .Title }}</h1>
         {{- /* Inline render so inline markup (code spans, links)

--- a/website/layouts/_default/single.html
+++ b/website/layouts/_default/single.html
@@ -4,17 +4,7 @@
       {{ partial "docs-sidebar.html" . }}
     </aside>
     <article class="docs-main">
-      <nav class="docs-breadcrumb">
-        <a href="{{ "/" | relURL }}">mdsmith</a>
-        {{ range .Ancestors.Reverse }}
-          {{ if not .IsHome }}
-            <span class="sep">/</span>
-            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-          {{ end }}
-        {{ end }}
-        <span class="sep">/</span>
-        <span>{{ .Title }}</span>
-      </nav>
+      {{ partial "breadcrumb.html" . }}
       <div class="docs-prose">
         <h1>{{ .Title }}</h1>
         {{- /* Inline render so inline markup (code spans, links)

--- a/website/layouts/partials/breadcrumb.html
+++ b/website/layouts/partials/breadcrumb.html
@@ -1,0 +1,38 @@
+{{- /* Breadcrumb trail reconstructed from the current page's URL
+       path segments, not .Ancestors. Hugo's .Ancestors skips a
+       directory whose landing page is a regular page rather than a
+       section _index — reference/cli.md is the overview served at
+       /reference/cli/, but the command pages under reference/cli/
+       have no `cli` section in their ancestor chain, so an
+       .Ancestors trail jumped straight from "Reference" to the
+       command page. Walking the URL segments and resolving each one
+       with site.GetPage restores every tier and reads each tier's
+       title from its own page instead of Hugo's filename guess.
+
+       site.GetPage takes a logical content path with no baseURL
+       prefix, so the per-segment path is built from .RelPermalink
+       with site.Home.RelPermalink (which carries any project-pages
+       subpath such as /<repo>/) trimmed off the front; every
+       emitted href uses the resolved page's .RelPermalink, which
+       re-adds that prefix. */ -}}
+<nav class="docs-breadcrumb">
+  {{- $home := site.Home.RelPermalink -}}
+  {{- $rel := strings.Trim (strings.TrimPrefix $home .RelPermalink) "/" -}}
+  {{- $segs := slice -}}
+  {{- if $rel }}{{ $segs = split $rel "/" }}{{ end -}}
+  <a href="{{ $home }}">mdsmith</a>
+  {{- $acc := "" -}}
+  {{- range $i, $seg := $segs -}}
+    {{- $acc = printf "%s/%s" $acc $seg -}}
+    {{- $pg := site.GetPage $acc -}}
+    {{- $label := $seg | humanize -}}
+    {{- $href := printf "%s%s/" $home (strings.TrimPrefix "/" $acc) -}}
+    {{- with $pg }}{{ $label = .Title }}{{ $href = .RelPermalink }}{{ end -}}
+    <span class="sep">/</span>
+    {{- if eq (add $i 1) (len $segs) -}}
+      <span>{{ $label }}</span>
+    {{- else -}}
+      <a href="{{ $href }}">{{ $label }}</a>
+    {{- end -}}
+  {{- end -}}
+</nav>

--- a/website/layouts/rule/single.html
+++ b/website/layouts/rule/single.html
@@ -4,17 +4,7 @@
       {{ partial "docs-sidebar.html" . }}
     </aside>
     <article class="docs-main">
-      <nav class="docs-breadcrumb">
-        <a href="{{ "/" | relURL }}">mdsmith</a>
-        {{ range .Ancestors.Reverse }}
-          {{ if not .IsHome }}
-            <span class="sep">/</span>
-            <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-          {{ end }}
-        {{ end }}
-        <span class="sep">/</span>
-        <span>{{ .Title }}</span>
-      </nav>
+      {{ partial "breadcrumb.html" . }}
       <div class="docs-prose">
         <div class="rule-meta">
           {{ with .Params.id }}<span class="rule-id">{{ . }}</span>{{ end }}


### PR DESCRIPTION
## What & why

Reported: `https://mdsmith.dev/background/concepts/engine-api/` shows
`mdsmith / Concepts / Concepts / Engine API and WASM bindings` — a
doubled "Concepts" tier. The ask was to fix it, sweep **all**
breadcrumbs for the same class of mistake, verify the crumb links
resolve, and check whether any test guards breadcrumbs.

I built the site and extracted every rendered breadcrumb (141 pages).
Findings:

| Issue | Scope | Cause |
|-------|-------|-------|
| **Duplicate tier** | 5 pages under `/background/concepts/` | `docs/background/index.md` is titled `Concepts`, and the `concepts/` subdir (no `index.md`) is humanized to `Concepts` too. `.Ancestors` printed both. |
| **Skipped tier** | 17 `/reference/cli/<cmd>/` pages | `reference/cli.md` is a leaf *page*, not a section `_index`, so the command pages have no `cli` ancestor — the trail jumped `Reference → mdsmith check`, dropping `CLI Reference`. |
| Broken crumb links | none | all hrefs resolved |
| Breadcrumb test coverage | none | `verify-website-links` only probed render-link hook behavior; MDS027 checks Markdown source links, not rendered breadcrumbs |

## Changes

1. **`docs(background)`** — retitle the section `Concepts` → `Background`
   (matches its directory + Diátaxis role). The `concepts/` subsection
   keeps `Concepts`. URLs unchanged. Fixes both the breadcrumb and the
   sidebar duplication.

2. **`website`** — replace the three identical inline breadcrumb blocks
   (`single`/`list`/`rule`) with a shared `partials/breadcrumb.html`
   that rebuilds the trail from the page's **URL segments** (resolving
   each via `site.GetPage`) instead of `.Ancestors`. This restores the
   skipped `CLI Reference` tier and handles any "overview-page-as-
   section" case. Verified on all 141 pages, root **and** `/<repo>/`
   subpath, minified and not. (Chosen over moving `cli.md` into a
   section index, which would have required a `.mdsmith.yml` change and
   ~8 files of link rewrites.)

3. **`release`** — extend `VerifyWebsiteLinks` (the existing CI
   `verify-website-links` step) to walk every rendered `index.html` and
   assert: no two consecutive crumb labels are equal; the crumb count
   below `mdsmith` equals the page's URL depth; every linked crumb
   resolves. New functions at 100% statement coverage. Demonstrated to
   catch the original `Concepts / Concepts` regression end-to-end.

## Verification

- `go test ./...` ✅ · `go vet ./...` ✅ · `golangci-lint` 0 issues ✅
- `mdsmith check .` ✅ (424 files, 0 failures)
- `verify-website-links` ✅ on root + subpath builds; ❌ (exit 1) when a
  duplicate crumb is injected
- Breadcrumb sweep after fixes: **0 duplicates, 0 depth mismatches, 0
  broken links**

https://claude.ai/code/session_01EZha4mjhBVVSWur6QebngE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZha4mjhBVVSWur6QebngE)_