### PR TITLE
docs(guides): order index body like the navigation sidebar

### DIFF
--- a/docs/guides/coexist-with-prettier.md
+++ b/docs/guides/coexist-with-prettier.md
@@ -1,5 +1,6 @@
 ---
 title: Coexist with Prettier
+weight: 50
 summary: >-
   Run mdsmith alongside Prettier by ordering
   `mdsmith fix` before `prettier --write` in the

--- a/docs/guides/coexist-with-vale-and-remark.md
+++ b/docs/guides/coexist-with-vale-and-remark.md
@@ -1,5 +1,6 @@
 ---
 title: Coexist with Vale and remark
+weight: 60
 summary: >-
   Vale owns brand voice and prose style; remark owns
   Markdown AST transformations; mdsmith owns formatting,

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,9 +9,9 @@ summary: >-
 
 <?catalog
 glob:
-  - "**/*.md"
+  - "*.md"
   - "!index.md"
-sort: title
+sort: numeric:weight
 header: |
   | Guide | Description |
   |-------|-------------|
@@ -19,20 +19,50 @@ row: "| [{title}]({filename}) | {summary} |"
 ?>
 | Guide                                                                               | Description                                                                                                                                                                                                                                                                                                       |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Build directive](directives/build.md)                                              | How to use the build directive to declare artifact outputs, keep generated bodies in sync, and configure user-declared recipes.                                                                                                                                                                                   |
+| [Installation](install.md)                                                          | Every channel that ships the mdsmith binary, the VS Code extension, or the Claude Code plugin — npm, PyPI, Homebrew, asdf, mise, a Flatpak bundle, the GitHub release, the Visual Studio Marketplace plus Open VSX, and the in-repository Claude Code marketplace — and which channel to pick for which workflow. |
+| [File Kinds](file-kinds.md)                                                         | How to declare file kinds, assign files to them, and read the merged rule config that results.                                                                                                                                                                                                                    |
+| [Schemas](schemas.md)                                                               | Declare a document-structure schema inline on a kind or in a proto.md file, validate headings and front matter, and tighten rule config per section.                                                                                                                                                              |
+| [Extract Markdown as data](extract-markdown-as-data.md)                             | When a Markdown file's payload is prose, put it in the body under H2 sections — not in YAML frontmatter. `mdsmith extract` projects body structure into a JSON tree the same way it projects frontmatter, so the file stays editable as Markdown.                                                                 |
 | [Choosing Readability, Conciseness, and Token Budget Metrics](metrics-tradeoffs.md) | Trade-offs and threshold guidance for readability, structure, length, and token budgets.                                                                                                                                                                                                                          |
 | [Coexist with Prettier](coexist-with-prettier.md)                                   | Run mdsmith alongside Prettier by ordering `mdsmith fix` before `prettier --write` in the same pre-commit hook.                                                                                                                                                                                                   |
 | [Coexist with Vale and remark](coexist-with-vale-and-remark.md)                     | Vale owns brand voice and prose style; remark owns Markdown AST transformations; mdsmith owns formatting, cross-file integrity, and generated sections. They sit side by side in CI without overlap.                                                                                                              |
-| [Coming from Hugo](directives/hugo-migration.md)                                    | Key differences between Hugo templates and mdsmith directives for users familiar with Hugo.                                                                                                                                                                                                                       |
-| [Enforcing Document Structure with Schemas](directives/enforcing-structure.md)      | How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.                                                                                                                                                                                                           |
-| [Extract Markdown as data](extract-markdown-as-data.md)                             | When a Markdown file's payload is prose, put it in the body under H2 sections — not in YAML frontmatter. `mdsmith extract` projects body structure into a JSON tree the same way it projects frontmatter, so the file stays editable as Markdown.                                                                 |
-| [File Kinds](file-kinds.md)                                                         | How to declare file kinds, assign files to them, and read the merged rule config that results.                                                                                                                                                                                                                    |
-| [Generating Content with Directives](directives/generating-content.md)              | How to use catalog and include directives to generate and embed content in Markdown files.                                                                                                                                                                                                                        |
-| [Installation](install.md)                                                          | Every channel that ships the mdsmith binary, the VS Code extension, or the Claude Code plugin — npm, PyPI, Homebrew, asdf, mise, a Flatpak bundle, the GitHub release, the Visual Studio Marketplace plus Open VSX, and the in-repository Claude Code marketplace — and which channel to pick for which workflow. |
-| [mdsmith for Obsidian](editors/obsidian.md)                                         | Install the mdsmith Obsidian plugin and use its inline diagnostics, hover fixes, fix-on-save, and diagnostics panel — one WebAssembly runtime on desktop and mobile.                                                                                                                                              |
-| [mdsmith for VS Code](editors/vscode.md)                                            | Install the mdsmith VS Code extension and use its inline diagnostics, quick fixes, fix-on-save, and cross-file navigation — one bundled binary, no extra setup.                                                                                                                                                   |
 | [Migrating from markdownlint](migrate-from-markdownlint.md)                         | Move a project from markdownlint-cli or markdownlint-cli2 to mdsmith — the rule mapping, the config rewrite, and the markdownlint-to-mdsmith rule correspondence.                                                                                                                                                 |
-| [Neovim Integration](editors/neovim.md)                                             | Wire `mdsmith lsp` into Neovim's built-in LSP client so diagnostics, code actions, and navigation work inline with no extra plugin.                                                                                                                                                                               |
 | [Progressive Disclosure for AI Agents](progressive-disclosure.md)                   | Use `<?catalog?>` with a per-file `summary` front matter field to emit a one-line index of a directory, so AI coding agents read a few thousand tokens of metadata up front and only `Read` the files a task actually touches.                                                                                    |
-| [Schemas](schemas.md)                                                               | Declare a document-structure schema inline on a kind or in a proto.md file, validate headings and front matter, and tighten rule config per section.                                                                                                                                                              |
+<?/catalog?>
+
+## Directives
+
+<?catalog
+glob:
+  - "directives/*.md"
+sort: title
+header: |
+  | Guide | Description |
+  |-------|-------------|
+row: "| [{title}]({filename}) | {summary} |"
+?>
+| Guide                                                                          | Description                                                                                                                     |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| [Build directive](directives/build.md)                                         | How to use the build directive to declare artifact outputs, keep generated bodies in sync, and configure user-declared recipes. |
+| [Coming from Hugo](directives/hugo-migration.md)                               | Key differences between Hugo templates and mdsmith directives for users familiar with Hugo.                                     |
+| [Enforcing Document Structure with Schemas](directives/enforcing-structure.md) | How to use schemas, require, and allow-empty-section to validate headings, front matter, and filenames.                         |
+| [Generating Content with Directives](directives/generating-content.md)         | How to use catalog and include directives to generate and embed content in Markdown files.                                      |
+<?/catalog?>
+
+## Editors
+
+<?catalog
+glob:
+  - "editors/*.md"
+sort: title
+header: |
+  | Guide | Description |
+  |-------|-------------|
+row: "| [{title}]({filename}) | {summary} |"
+?>
+| Guide                                       | Description                                                                                                                                                          |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [mdsmith for Obsidian](editors/obsidian.md) | Install the mdsmith Obsidian plugin and use its inline diagnostics, hover fixes, fix-on-save, and diagnostics panel — one WebAssembly runtime on desktop and mobile. |
+| [mdsmith for VS Code](editors/vscode.md)    | Install the mdsmith VS Code extension and use its inline diagnostics, quick fixes, fix-on-save, and cross-file navigation — one bundled binary, no extra setup.      |
+| [Neovim Integration](editors/neovim.md)     | Wire `mdsmith lsp` into Neovim's built-in LSP client so diagnostics, code actions, and navigation work inline with no extra plugin.                                  |
 <?/catalog?>

--- a/docs/guides/migrate-from-markdownlint.md
+++ b/docs/guides/migrate-from-markdownlint.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating from markdownlint
+weight: 70
 summary: >-
   Move a project from markdownlint-cli or markdownlint-cli2
   to mdsmith — the rule mapping, the config rewrite, and

--- a/docs/guides/progressive-disclosure.md
+++ b/docs/guides/progressive-disclosure.md
@@ -1,5 +1,6 @@
 ---
 title: Progressive Disclosure for AI Agents
+weight: 80
 summary: >-
   Use `<?catalog?>` with a per-file `summary` front
   matter field to emit a one-line index of a directory,


### PR DESCRIPTION
## Why

On https://mdsmith.dev/guides/ the body listed guides alphabetically by
title, so the curated entry points (**Installation**, **File Kinds**,
**Schemas**) were buried under "Build directive" and "Choosing
Readability…". The navigation **sidebar** reads as a journey instead:
top-level pages by `weight`, then a **Directives** sub-group, then an
**Editors** sub-group (`docs-sidebar.html` renders `.RegularPages.ByWeight`
then `.Sections.ByWeight`).

This makes the body order match the sidebar order — and does it
*structurally*, by mirroring the sidebar's structure rather than
hand-sorting one table.

## What

- Split the single `<?catalog?>` into a **top-level catalog** plus
  per-subsection catalogs under `## Directives` and `## Editors`, so the
  body groups exactly like the sidebar.
- Top-level catalog now `sort: numeric:weight` (glob `*.md`, no longer
  recursive), matching the sidebar's `.RegularPages.ByWeight`.
- Gave the four previously-unweighted top-level guides explicit weights
  (`50`–`80`) so the order is locked rather than collation-dependent.
  These weights reproduce the existing sidebar order, so **the sidebar
  itself is unchanged**.
- Sub-group catalogs `sort: title`, matching the sidebar's weightless
  title sort for the `directives/` and `editors/` pages.

## Resulting order (body == sidebar)

1. Installation → File Kinds → Schemas → Extract Markdown as data →
   Choosing Readability… → Coexist with Prettier → Coexist with Vale and
   remark → Migrating from markdownlint → Progressive Disclosure for AI Agents
2. **Directives**: Build directive → Coming from Hugo → Enforcing
   Document Structure with Schemas → Generating Content with Directives
3. **Editors**: mdsmith for Obsidian → mdsmith for VS Code → Neovim Integration

## Verification

- `mdsmith fix` regenerated the three catalog bodies.
- `mdsmith check .` passes (424 files, 0 failures), including catalog
  freshness (MDS019).
- No Go code changed; no test asserts on the edited content.

https://claude.ai/code/session_01VsNZpLGob62s54kKp4oxup

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsNZpLGob62s54kKp4oxup)_