### PR TITLE
docs(rules): link rumdl, mado, panache, obsidian-linter in rule READMEs

### DIFF
--- a/docs/development/add-peer-linter.md
+++ b/docs/development/add-peer-linter.md
@@ -56,6 +56,21 @@ matter into `RuleInfo`. Three edits:
 
 `go build ./...` should pass.
 
+Each rule README links its peer rules in its
+Meta-Information section. The test
+`internal/rules/peerlinks_test.go` builds that block.
+Teach it the new peer's links:
+
+- Add `{"newtool", info.Newtool}` to `peerLinkSpecs`
+- Add a `peerRefID` case (a label prefix like
+  `mdl-`, or the bare rule name for a shortcut peer)
+- Add a `peerRefURL` case returning the per-rule doc
+  URL; if the tool has no per-rule page, point every
+  entry at one section anchor (as `mado` does)
+- For a tool that pages rules by category (like
+  obsidian-linter), add a name-to-category map and a
+  `peerEntry` shortcut branch via `isShortcutPeer`
+
 ## 3. Extend the coverage matrix
 
 The matrix lives in
@@ -127,19 +142,26 @@ Two facts about defaults are easy to miss:
 README against the proto schema. Run it after every
 batch of edits.
 
-## 5. Regenerate the matrix
+## 5. Regenerate the matrix and rule README links
 
 ```bash
 go run ./cmd/mdsmith fix docs/research/markdownlint-coverage/
+MDSMITH_UPDATE_PEER_LINKS=1 go test ./internal/rules \
+  -run TestRuleREADMEPeerLinks
 go run ./cmd/mdsmith check internal/rules/ docs/research/
 go test ./internal/release/ ./internal/rules/
 ```
 
 `mdsmith fix` rebuilds the `<?catalog?>` tables in
-place from the rule README front matter. Commit the
-diff in the same change as the front-matter edits.
-`mdsmith check` fails on a table left out of sync
-with the rule READMEs.
+place from the rule README front matter. The
+`MDSMITH_UPDATE_PEER_LINKS` run rewrites the
+peer-linter bullets in each rule README's
+Meta-Information section from the same front matter;
+a plain `go test ./internal/rules` fails when a
+README has drifted. Commit both diffs in the same
+change as the front-matter edits. `mdsmith check`
+fails on a table left out of sync with the rule
+READMEs.
 
 ## 6. Update the comparison page
 

--- a/internal/rules/MDS001-line-length/README.md
+++ b/internal/rules/MDS001-line-length/README.md
@@ -268,6 +268,10 @@ This line inside a code block is over 80 characters but within the code-block-ma
 - **Implementation**:
   [source](./)
 - **Category**: line
-- **Markdownlint**: [MD013][mdl-md013] (line-length)
+- **markdownlint**: [MD013][mdl-md013] (line-length)
+- **rumdl**: [MD013][rumdl-md013] (line-length)
+- **mado**: [MD013][mado-rules] (line-length)
 
 [mdl-md013]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
+[rumdl-md013]: https://rumdl.dev/md013/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS002-heading-style/README.md
+++ b/internal/rules/MDS002-heading-style/README.md
@@ -167,6 +167,10 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD003][mdl-md003] (heading-style)
+- **markdownlint**: [MD003][mdl-md003] (heading-style)
+- **rumdl**: [MD003][rumdl-md003] (heading-style)
+- **mado**: [MD003][mado-rules] (heading-style)
 
 [mdl-md003]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md003.md
+[rumdl-md003]: https://rumdl.dev/md003/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -108,6 +108,16 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD001][mdl-md001] (heading-increment)
+- **markdownlint**: [MD001][mdl-md001] (heading-increment)
+- **rumdl**: [MD001][rumdl-md001] (heading-increment)
+- **mado**: [MD001][mado-rules] (heading-increment)
+- **panache**: [heading-hierarchy]
+- **obsidian-linter**: [header-increment]
 
 [mdl-md001]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md
+[rumdl-md001]: https://rumdl.dev/md001/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[heading-hierarchy]:
+  https://panache.bz/reference/linter-rules.html#heading-hierarchy
+[header-increment]:
+  https://platers.github.io/obsidian-linter/settings/heading-rules/#header-increment

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -133,6 +133,10 @@ Some content here.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD041][mdl-md041] (first-line-h1)
+- **markdownlint**: [MD041][mdl-md041] (first-line-h1)
+- **rumdl**: [MD041][rumdl-md041] (first-line-h1)
+- **mado**: [MD041][mado-rules] (first-line-h1)
 
 [mdl-md041]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md
+[rumdl-md041]: https://rumdl.dev/md041/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS005-no-duplicate-headings/README.md
+++ b/internal/rules/MDS005-no-duplicate-headings/README.md
@@ -94,6 +94,10 @@ Body two.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD024][mdl-md024] (no-duplicate-heading)
+- **markdownlint**: [MD024][mdl-md024] (no-duplicate-heading)
+- **rumdl**: [MD024][rumdl-md024] (multiple-headings)
+- **mado**: [MD024][mado-rules] (no-duplicate-heading)
 
 [mdl-md024]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md
+[rumdl-md024]: https://rumdl.dev/md024/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS006-no-trailing-spaces/README.md
+++ b/internal/rules/MDS006-no-trailing-spaces/README.md
@@ -94,6 +94,13 @@ code block with language tag
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**: [MD009][mdl-md009] (no-trailing-spaces)
+- **markdownlint**: [MD009][mdl-md009] (no-trailing-spaces)
+- **rumdl**: [MD009][rumdl-md009] (no-trailing-spaces)
+- **mado**: [MD009][mado-rules] (no-trailing-spaces)
+- **obsidian-linter**: [trailing-spaces]
 
 [mdl-md009]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md
+[rumdl-md009]: https://rumdl.dev/md009/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[trailing-spaces]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#trailing-spaces

--- a/internal/rules/MDS007-no-hard-tabs/README.md
+++ b/internal/rules/MDS007-no-hard-tabs/README.md
@@ -91,6 +91,10 @@ No tabs here.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**: [MD010][mdl-md010] (no-hard-tabs)
+- **markdownlint**: [MD010][mdl-md010] (no-hard-tabs)
+- **rumdl**: [MD010][rumdl-md010] (no-hard-tabs)
+- **mado**: [MD010][mado-rules] (no-hard-tabs)
 
 [mdl-md010]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md
+[rumdl-md010]: https://rumdl.dev/md010/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS008-no-multiple-blanks/README.md
+++ b/internal/rules/MDS008-no-multiple-blanks/README.md
@@ -98,6 +98,13 @@ more code with blank lines above
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**: [MD012][mdl-md012] (no-multiple-blanks)
+- **markdownlint**: [MD012][mdl-md012] (no-multiple-blanks)
+- **rumdl**: [MD012][rumdl-md012] (no-multiple-blanks)
+- **mado**: [MD012][mado-rules] (no-multiple-blanks)
+- **obsidian-linter**: [consecutive-blank-lines]
 
 [mdl-md012]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md
+[rumdl-md012]: https://rumdl.dev/md012/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[consecutive-blank-lines]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#consecutive-blank-lines

--- a/internal/rules/MDS009-single-trailing-newline/README.md
+++ b/internal/rules/MDS009-single-trailing-newline/README.md
@@ -98,6 +98,13 @@ is what the rule detects.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**: [MD047][mdl-md047] (single-trailing-newline)
+- **markdownlint**: [MD047][mdl-md047] (single-trailing-newline)
+- **rumdl**: [MD047][rumdl-md047] (file-end-newline)
+- **mado**: [MD047][mado-rules] (single-trailing-newline)
+- **obsidian-linter**: [line-break-at-document-end]
 
 [mdl-md047]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md047.md
+[rumdl-md047]: https://rumdl.dev/md047/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[line-break-at-document-end]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#line-break-at-document-end

--- a/internal/rules/MDS010-fenced-code-style/README.md
+++ b/internal/rules/MDS010-fenced-code-style/README.md
@@ -135,6 +135,8 @@ fmt.Println("hello")
 - **Implementation**:
   [source](./)
 - **Category**: code
-- **Markdownlint**: [MD048][mdl-md048] (code-fence-style)
+- **markdownlint**: [MD048][mdl-md048] (code-fence-style)
+- **rumdl**: [MD048][rumdl-md048] (code-fence-style)
 
 [mdl-md048]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md
+[rumdl-md048]: https://rumdl.dev/md048/

--- a/internal/rules/MDS011-fenced-code-language/README.md
+++ b/internal/rules/MDS011-fenced-code-language/README.md
@@ -90,6 +90,10 @@ fmt.Println("hello")
 - **Implementation**:
   [source](./)
 - **Category**: code
-- **Markdownlint**: [MD040][mdl-md040] (fenced-code-language)
+- **markdownlint**: [MD040][mdl-md040] (fenced-code-language)
+- **rumdl**: [MD040][rumdl-md040] (fenced-code-language)
+- **mado**: [MD040][mado-rules] (fenced-code-language)
 
 [mdl-md040]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md
+[rumdl-md040]: https://rumdl.dev/md040/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS012-no-bare-urls/README.md
+++ b/internal/rules/MDS012-no-bare-urls/README.md
@@ -90,6 +90,13 @@ Visit [example](https://example.com) for more.
 - **Implementation**:
   [source](./)
 - **Category**: link
-- **Markdownlint**: [MD034][mdl-md034] (no-bare-urls)
+- **markdownlint**: [MD034][mdl-md034] (no-bare-urls)
+- **rumdl**: [MD034][rumdl-md034] (no-bare-urls)
+- **mado**: [MD034][mado-rules] (no-bare-urls)
+- **obsidian-linter**: [no-bare-urls]
 
 [mdl-md034]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md
+[rumdl-md034]: https://rumdl.dev/md034/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[no-bare-urls]:
+  https://platers.github.io/obsidian-linter/settings/content-rules/#no-bare-urls

--- a/internal/rules/MDS013-blank-line-around-headings/README.md
+++ b/internal/rules/MDS013-blank-line-around-headings/README.md
@@ -100,6 +100,13 @@ Content here.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD022][mdl-md022] (blanks-around-headings)
+- **markdownlint**: [MD022][mdl-md022] (blanks-around-headings)
+- **rumdl**: [MD022][rumdl-md022] (blanks-around-headings)
+- **mado**: [MD022][mado-rules] (blanks-around-headings)
+- **obsidian-linter**: [heading-blank-lines]
 
 [mdl-md022]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md
+[rumdl-md022]: https://rumdl.dev/md022/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[heading-blank-lines]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#heading-blank-lines

--- a/internal/rules/MDS014-blank-line-around-lists/README.md
+++ b/internal/rules/MDS014-blank-line-around-lists/README.md
@@ -102,6 +102,13 @@ Content here.
 - **Implementation**:
   [source](./)
 - **Category**: list
-- **Markdownlint**: [MD032][mdl-md032] (blanks-around-lists)
+- **markdownlint**: [MD032][mdl-md032] (blanks-around-lists)
+- **rumdl**: [MD032][rumdl-md032] (blanks-around-lists)
+- **mado**: [MD032][mado-rules] (blanks-around-lists)
+- **obsidian-linter**: [paragraph-blank-lines] (partial)
 
 [mdl-md032]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md032.md
+[rumdl-md032]: https://rumdl.dev/md032/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[paragraph-blank-lines]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#paragraph-blank-lines

--- a/internal/rules/MDS015-blank-line-around-fenced-code/README.md
+++ b/internal/rules/MDS015-blank-line-around-fenced-code/README.md
@@ -104,6 +104,13 @@ Content here.
 - **Implementation**:
   [source](./)
 - **Category**: code
-- **Markdownlint**: [MD031][mdl-md031] (blanks-around-fences)
+- **markdownlint**: [MD031][mdl-md031] (blanks-around-fences)
+- **rumdl**: [MD031][rumdl-md031] (blanks-around-fences)
+- **mado**: [MD031][mado-rules] (blanks-around-fences)
+- **obsidian-linter**: [empty-line-around-code-fences]
 
 [mdl-md031]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md
+[rumdl-md031]: https://rumdl.dev/md031/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[empty-line-around-code-fences]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#empty-line-around-code-fences

--- a/internal/rules/MDS016-list-indent/README.md
+++ b/internal/rules/MDS016-list-indent/README.md
@@ -147,9 +147,18 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: list
-- **Markdownlint**:
+- **markdownlint**:
   - [MD005][mdl-md005] (list-indent) (partial)
   - [MD007][mdl-md007] (ul-indent)
+- **rumdl**:
+  - [MD005][rumdl-md005] (list-indent) (partial)
+  - [MD007][rumdl-md007] (ul-indent)
+- **mado**:
+  - [MD005][mado-rules] (list-indent) (partial)
+  - [MD007][mado-rules] (ul-indent)
 
 [mdl-md005]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md005.md
 [mdl-md007]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md
+[rumdl-md005]: https://rumdl.dev/md005/
+[rumdl-md007]: https://rumdl.dev/md007/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
+++ b/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
@@ -94,6 +94,13 @@ Body text.
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD026][mdl-md026] (no-trailing-punctuation)
+- **markdownlint**: [MD026][mdl-md026] (no-trailing-punctuation)
+- **rumdl**: [MD026][rumdl-md026] (no-trailing-punctuation)
+- **mado**: [MD026][mado-rules] (no-trailing-punctuation)
+- **obsidian-linter**: [remove-trailing-punctuation-in-heading]
 
 [mdl-md026]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md
+[rumdl-md026]: https://rumdl.dev/md026/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[remove-trailing-punctuation-in-heading]:
+  https://platers.github.io/obsidian-linter/settings/heading-rules/#remove-trailing-punctuation-in-heading

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -120,6 +120,10 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD036][mdl-md036] (no-emphasis-as-heading)
+- **markdownlint**: [MD036][mdl-md036] (no-emphasis-as-heading)
+- **rumdl**: [MD036][rumdl-md036] (no-emphasis-as-heading)
+- **mado**: [MD036][mado-rules] (no-emphasis-as-heading)
 
 [mdl-md036]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md036.md
+[rumdl-md036]: https://rumdl.dev/md036/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -37,11 +37,9 @@ Document structure and front matter must match its schema.
 
 Useful tokens: `cue-frontmatter`.
 
-When neither `schema` nor `inline-schema` is set the
-rule skips structure and front matter validation, but
-still warns on misplaced `<?require?>` directives. Use
-overrides or `kinds:` to apply schemas to specific file
-groups.
+When neither `schema` nor `inline-schema` is set the rule skips structure
+and front matter validation, but still warns on misplaced `<?require?>`
+directives. Use overrides or `kinds:` to apply schemas to specific file groups.
 
 A kind may declare its schema in either form. The config loader
 rejects a kind that sets both — see [file kinds](../../../docs/guides/file-kinds.md).
@@ -370,6 +368,8 @@ Other shapes get no hint.
 - **Guide**:
   [directive guide](../../../docs/guides/directives/enforcing-structure.md)
 - **Category**: structural
-- **Markdownlint**: [MD043][mdl-md043] (required-headings)
+- **markdownlint**: [MD043][mdl-md043] (required-headings)
+- **rumdl**: [MD043][rumdl-md043] (required-headings)
 
 [mdl-md043]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md
+[rumdl-md043]: https://rumdl.dev/md043/

--- a/internal/rules/MDS025-table-format/README.md
+++ b/internal/rules/MDS025-table-format/README.md
@@ -351,5 +351,21 @@ Paragraph after.
 - **Implementation**:
   [source](./)
 - **Category**: table
-- **markdownlint coverage**: MD055 (table-pipe-style), MD056
-  (table-column-count, flag only), MD058 (blanks-around-tables)
+- **markdownlint**:
+  - [MD055][mdl-md055] (table-pipe-style)
+  - [MD056][mdl-md056] (table-column-count) (partial)
+  - [MD058][mdl-md058] (blanks-around-tables)
+- **rumdl**:
+  - [MD055][rumdl-md055] (table-pipe-style)
+  - [MD056][rumdl-md056] (table-column-count) (partial)
+  - [MD058][rumdl-md058] (table-spacing)
+- **obsidian-linter**: [empty-line-around-tables] (partial)
+
+[mdl-md055]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md055.md
+[mdl-md056]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md056.md
+[mdl-md058]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md058.md
+[rumdl-md055]: https://rumdl.dev/md055/
+[rumdl-md056]: https://rumdl.dev/md056/
+[rumdl-md058]: https://rumdl.dev/md058/
+[empty-line-around-tables]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#empty-line-around-tables

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -200,6 +200,11 @@ See [guide](bad/ref/guide.md#missing-section).
 - **Implementation**:
   [source](./)
 - **Category**: link
-- **Markdownlint**: [MD051][mdl-md051] (link-fragments)
+- **markdownlint**: [MD051][mdl-md051] (link-fragments)
+- **rumdl**: [MD051][rumdl-md051] (link-fragments)
+- **panache**: [undefined-anchor]
 
 [mdl-md051]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md
+[rumdl-md051]: https://rumdl.dev/md051/
+[undefined-anchor]:
+  https://panache.bz/reference/linter-rules.html#undefined-anchor

--- a/internal/rules/MDS032-no-empty-alt-text/README.md
+++ b/internal/rules/MDS032-no-empty-alt-text/README.md
@@ -82,6 +82,8 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: accessibility
-- **Markdownlint**: [MD045][mdl-md045] (no-alt-text)
+- **markdownlint**: [MD045][mdl-md045] (no-alt-text)
+- **rumdl**: [MD045][rumdl-md045] (no-alt-text)
 
 [mdl-md045]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md
+[rumdl-md045]: https://rumdl.dev/md045/

--- a/internal/rules/MDS041-no-inline-html/README.md
+++ b/internal/rules/MDS041-no-inline-html/README.md
@@ -118,6 +118,10 @@ Press <kbd>Enter</kbd> to continue.
 - **Implementation**:
   [source](./)
 - **Category**: structural
-- **Markdownlint**: [MD033][mdl-md033] (no-inline-html)
+- **markdownlint**: [MD033][mdl-md033] (no-inline-html)
+- **rumdl**: [MD033][rumdl-md033] (no-inline-html)
+- **mado**: [MD033][mado-rules] (no-inline-html)
 
 [mdl-md033]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md
+[rumdl-md033]: https://rumdl.dev/md033/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS042-emphasis-style/README.md
+++ b/internal/rules/MDS042-emphasis-style/README.md
@@ -154,9 +154,21 @@ The following cases emit diagnostics but are
 - **Implementation**:
   [source](./)
 - **Category**: prose
-- **Markdownlint**:
+- **markdownlint**:
   - [MD049][mdl-md049] (emphasis-style)
   - [MD050][mdl-md050] (strong-style)
+- **rumdl**:
+  - [MD049][rumdl-md049] (emphasis-style)
+  - [MD050][rumdl-md050] (strong-style)
+- **obsidian-linter**:
+  - [emphasis-style]
+  - [strong-style]
 
 [mdl-md049]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md
 [mdl-md050]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md050.md
+[rumdl-md049]: https://rumdl.dev/md049/
+[rumdl-md050]: https://rumdl.dev/md050/
+[emphasis-style]:
+  https://platers.github.io/obsidian-linter/settings/content-rules/#emphasis-style
+[strong-style]:
+  https://platers.github.io/obsidian-linter/settings/content-rules/#strong-style

--- a/internal/rules/MDS044-horizontal-rule-style/README.md
+++ b/internal/rules/MDS044-horizontal-rule-style/README.md
@@ -227,6 +227,10 @@ blank lines above and below.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**: [MD035][mdl-md035] (hr-style)
+- **markdownlint**: [MD035][mdl-md035] (hr-style)
+- **rumdl**: [MD035][rumdl-md035] (hr-style)
+- **mado**: [MD035][mado-rules] (hr-style)
 
 [mdl-md035]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md035.md
+[rumdl-md035]: https://rumdl.dev/md035/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS045-list-marker-style/README.md
+++ b/internal/rules/MDS045-list-marker-style/README.md
@@ -166,6 +166,13 @@ Outer uses dash (correct), inner should use asterisk but uses dash.
 - **Implementation**:
   [source](./)
 - **Category**: list
-- **Markdownlint**: [MD004][mdl-md004] (ul-style)
+- **markdownlint**: [MD004][mdl-md004] (ul-style)
+- **rumdl**: [MD004][rumdl-md004] (ul-style)
+- **mado**: [MD004][mado-rules] (ul-style)
+- **obsidian-linter**: [unordered-list-style]
 
 [mdl-md004]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md
+[rumdl-md004]: https://rumdl.dev/md004/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[unordered-list-style]:
+  https://platers.github.io/obsidian-linter/settings/content-rules/#unordered-list-style

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -175,6 +175,13 @@ that the start fix already covers.
 - **Implementation**:
   [source](./)
 - **Category**: list
-- **Markdownlint**: [MD029][mdl-md029] (ol-prefix)
+- **markdownlint**: [MD029][mdl-md029] (ol-prefix)
+- **rumdl**: [MD029][rumdl-md029] (ol-prefix)
+- **mado**: [MD029][mado-rules] (ol-prefix)
+- **obsidian-linter**: [ordered-list-style]
 
 [mdl-md029]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md029.md
+[rumdl-md029]: https://rumdl.dev/md029/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[ordered-list-style]:
+  https://platers.github.io/obsidian-linter/settings/content-rules/#ordered-list-style

--- a/internal/rules/MDS047-ambiguous-emphasis/README.md
+++ b/internal/rules/MDS047-ambiguous-emphasis/README.md
@@ -231,6 +231,10 @@ __a__b__
 - **Implementation**:
   [source](./)
 - **Category**: prose
-- **Markdownlint**: [MD037][mdl-md037] (no-space-in-emphasis)
+- **markdownlint**: [MD037][mdl-md037] (no-space-in-emphasis)
+- **rumdl**: [MD037][rumdl-md037] (spaces-around-emphasis)
+- **mado**: [MD037][mado-rules] (no-space-in-emphasis)
 
 [mdl-md037]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md
+[rumdl-md037]: https://rumdl.dev/md037/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS049-no-space-in-link-text/README.md
+++ b/internal/rules/MDS049-no-space-in-link-text/README.md
@@ -101,6 +101,10 @@ Visit [example](https://example.com) for more.
 - **Implementation**:
   [source](./)
 - **Category**: link
-- **Markdownlint**: [MD039][mdl-md039] (no-space-in-links)
+- **markdownlint**: [MD039][mdl-md039] (no-space-in-links)
+- **rumdl**: [MD039][rumdl-md039] (no-space-in-links)
+- **mado**: [MD039][mado-rules] (no-space-in-links)
 
 [mdl-md039]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md
+[rumdl-md039]: https://rumdl.dev/md039/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS050-proper-names/README.md
+++ b/internal/rules/MDS050-proper-names/README.md
@@ -201,6 +201,8 @@ diagnostic is emitted.
 - **Implementation**:
   [source](./)
 - **Category**: prose
-- **Markdownlint**: [MD044][mdl-md044] (proper-names)
+- **markdownlint**: [MD044][mdl-md044] (proper-names)
+- **rumdl**: [MD044][rumdl-md044] (proper-names)
 
 [mdl-md044]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md
+[rumdl-md044]: https://rumdl.dev/md044/

--- a/internal/rules/MDS051-single-h1/README.md
+++ b/internal/rules/MDS051-single-h1/README.md
@@ -117,6 +117,10 @@ title: My Doc
 - **Fixable**: yes — extra H1s are demoted to H2; front-matter conflicts are not auto-fixed
 - **Implementation**: [source](./)
 - **Category**: heading
-- **Markdownlint**: [MD025][mdl-md025] (single-h1)
+- **markdownlint**: [MD025][mdl-md025] (single-h1)
+- **rumdl**: [MD025][rumdl-md025] (single-title)
+- **mado**: [MD025][mado-rules] (single-h1)
 
 [mdl-md025]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md
+[rumdl-md025]: https://rumdl.dev/md025/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS052-no-space-in-code-spans/README.md
+++ b/internal/rules/MDS052-no-space-in-code-spans/README.md
@@ -146,6 +146,10 @@ Use `foo bar` for multi-word.
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**: [MD038][mdl-md038] (no-space-in-code)
+- **markdownlint**: [MD038][mdl-md038] (no-space-in-code)
+- **rumdl**: [MD038][rumdl-md038] (no-space-in-code)
+- **mado**: [MD038][mado-rules] (no-space-in-code)
 
 [mdl-md038]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md
+[rumdl-md038]: https://rumdl.dev/md038/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS053-no-unused-link-definitions/README.md
+++ b/internal/rules/MDS053-no-unused-link-definitions/README.md
@@ -154,6 +154,15 @@ Ignored labels are never removed.
 - **Fixable**: yes
 - **Implementation**: [source](./)
 - **Category**: link
-- **Markdownlint**: [MD053][mdl-md053] (link-image-reference-definitions)
+- **markdownlint**: [MD053][mdl-md053] (link-image-reference-definitions)
+- **rumdl**: [MD053][rumdl-md053] (link-image-definitions)
+- **panache**:
+  - [duplicate-reference-labels]
+  - [unused-definitions]
 
 [mdl-md053]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md053.md
+[rumdl-md053]: https://rumdl.dev/md053/
+[duplicate-reference-labels]:
+  https://panache.bz/reference/linter-rules.html#duplicate-reference-labels
+[unused-definitions]:
+  https://panache.bz/reference/linter-rules.html#unused-definitions

--- a/internal/rules/MDS054-no-undefined-reference-labels/README.md
+++ b/internal/rules/MDS054-no-undefined-reference-labels/README.md
@@ -192,6 +192,11 @@ against `[bar]: url`.
 - **Fixable**: no
 - **Implementation**: [source](./)
 - **Category**: link
-- **Markdownlint**: [MD052][mdl-md052] (reference-links-images)
+- **markdownlint**: [MD052][mdl-md052] (reference-links-images)
+- **rumdl**: [MD052][rumdl-md052] (reference-links-images)
+- **panache**: [undefined-references]
 
 [mdl-md052]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md
+[rumdl-md052]: https://rumdl.dev/md052/
+[undefined-references]:
+  https://panache.bz/reference/linter-rules.html#undefined-references

--- a/internal/rules/MDS059-blockquote-whitespace/README.md
+++ b/internal/rules/MDS059-blockquote-whitespace/README.md
@@ -155,9 +155,25 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: whitespace
-- **Markdownlint**:
+- **markdownlint**:
   - [MD027][mdl-md027] (no-multiple-space-blockquote)
   - [MD028][mdl-md028] (no-blanks-blockquote)
+- **rumdl**:
+  - [MD027][rumdl-md027] (multiple-spaces-blockquote)
+  - [MD028][rumdl-md028] (blanks-blockquote)
+- **mado**:
+  - [MD027][mado-rules] (no-multiple-space-blockquote)
+  - [MD028][mado-rules] (no-blanks-blockquote)
+- **obsidian-linter**:
+  - [blockquote-style] (partial)
+  - [empty-line-around-blockquotes] (partial)
 
 [mdl-md027]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md
 [mdl-md028]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md
+[rumdl-md027]: https://rumdl.dev/md027/
+[rumdl-md028]: https://rumdl.dev/md028/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[blockquote-style]:
+  https://platers.github.io/obsidian-linter/settings/content-rules/#blockquote-style
+[empty-line-around-blockquotes]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#empty-line-around-blockquotes

--- a/internal/rules/MDS061-list-marker-space/README.md
+++ b/internal/rules/MDS061-list-marker-space/README.md
@@ -166,6 +166,13 @@ Ordered list with two spaces after each marker.
 - **Implementation**:
   [source](./)
 - **Category**: list
-- **Markdownlint**: [MD030][mdl-md030] (list-marker-space)
+- **markdownlint**: [MD030][mdl-md030] (list-marker-space)
+- **rumdl**: [MD030][rumdl-md030] (list-marker-space)
+- **mado**: [MD030][mado-rules] (list-marker-space)
+- **obsidian-linter**: [space-after-list-markers]
 
 [mdl-md030]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md030.md
+[rumdl-md030]: https://rumdl.dev/md030/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[space-after-list-markers]:
+  https://platers.github.io/obsidian-linter/settings/spacing-rules/#space-after-list-markers

--- a/internal/rules/MDS062-link-validity/README.md
+++ b/internal/rules/MDS062-link-validity/README.md
@@ -173,9 +173,14 @@ The reversed form `(text)[url]` is shown as code, not as a link.
 - **Implementation**:
   [source](../linkvalidity/)
 - **Category**: link
-- **Markdownlint**:
+- **markdownlint**:
   - [MD011][mdl-md011] (no-reversed-links)
   - [MD042][mdl-md042] (no-empty-links)
+- **rumdl**:
+  - [MD011][rumdl-md011] (reversed-link)
+  - [MD042][rumdl-md042] (no-empty-links)
 
 [mdl-md011]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md
 [mdl-md042]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md
+[rumdl-md011]: https://rumdl.dev/md011/
+[rumdl-md042]: https://rumdl.dev/md042/

--- a/internal/rules/MDS063-descriptive-link-text/README.md
+++ b/internal/rules/MDS063-descriptive-link-text/README.md
@@ -103,6 +103,8 @@ See [`SomeAPI`](https://example.com/api) for details.
 - **Implementation**:
   [source](../descriptivelinktext/)
 - **Category**: prose
-- **Markdownlint**: [MD059][mdl-md059] (descriptive-link-text)
+- **markdownlint**: [MD059][mdl-md059] (descriptive-link-text)
+- **rumdl**: [MD059][rumdl-md059] (link-text)
 
 [mdl-md059]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md
+[rumdl-md059]: https://rumdl.dev/md059/

--- a/internal/rules/MDS064-atx-heading-whitespace/README.md
+++ b/internal/rules/MDS064-atx-heading-whitespace/README.md
@@ -163,15 +163,36 @@ Tab after opening `#`:
 - **Fixable**: yes
 - **Implementation**: [source](./)
 - **Category**: heading
-- **Markdownlint**:
+- **markdownlint**:
   - [MD018][mdl-md018] (no-missing-space-atx)
   - [MD019][mdl-md019] (no-multiple-space-atx)
   - [MD020][mdl-md020] (no-missing-space-closed-atx) (partial)
   - [MD021][mdl-md021] (no-multiple-space-closed-atx)
   - [MD023][mdl-md023] (heading-start-left)
+- **rumdl**:
+  - [MD018][rumdl-md018] (no-space-atx)
+  - [MD019][rumdl-md019] (multiple-space-atx)
+  - [MD020][rumdl-md020] (no-space-closed-atx) (partial)
+  - [MD021][rumdl-md021] (multiple-space-closed-atx)
+  - [MD023][rumdl-md023] (heading-start-left)
+- **mado**:
+  - [MD018][mado-rules] (no-missing-space-atx)
+  - [MD019][mado-rules] (no-multiple-space-atx)
+  - [MD020][mado-rules] (no-missing-space-closed-atx) (partial)
+  - [MD021][mado-rules] (no-multiple-space-closed-atx)
+  - [MD023][mado-rules] (heading-start-left)
+- **obsidian-linter**: [headings-start-line] (partial)
 
 [mdl-md018]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md018.md
 [mdl-md019]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md019.md
 [mdl-md020]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md020.md
 [mdl-md021]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md021.md
 [mdl-md023]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md023.md
+[rumdl-md018]: https://rumdl.dev/md018/
+[rumdl-md019]: https://rumdl.dev/md019/
+[rumdl-md020]: https://rumdl.dev/md020/
+[rumdl-md021]: https://rumdl.dev/md021/
+[rumdl-md023]: https://rumdl.dev/md023/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
+[headings-start-line]:
+  https://platers.github.io/obsidian-linter/settings/heading-rules/#headings-start-line

--- a/internal/rules/MDS065-code-block-style/README.md
+++ b/internal/rules/MDS065-code-block-style/README.md
@@ -151,6 +151,10 @@ Some text first.
 - **Implementation**:
   [source](./)
 - **Category**: code
-- **Markdownlint**: [MD046][mdl-md046] (code-block-style)
+- **markdownlint**: [MD046][mdl-md046] (code-block-style)
+- **rumdl**: [MD046][rumdl-md046] (code-block-style)
+- **mado**: [MD046][mado-rules] (code-block-style)
 
 [mdl-md046]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md
+[rumdl-md046]: https://rumdl.dev/md046/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS066-commands-show-output/README.md
+++ b/internal/rules/MDS066-commands-show-output/README.md
@@ -128,6 +128,10 @@ $ pwd
 - **Implementation**:
   [source](./)
 - **Category**: code
-- **Markdownlint**: [MD014][mdl-md014] (commands-show-output)
+- **markdownlint**: [MD014][mdl-md014] (commands-show-output)
+- **rumdl**: [MD014][rumdl-md014] (commands-show-output)
+- **mado**: [MD014][mado-rules] (commands-show-output)
 
 [mdl-md014]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md
+[rumdl-md014]: https://rumdl.dev/md014/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -297,3 +297,8 @@ See [sibling](good/sibling.md) — inline form, as policy requires.
 - **Implementation**:
   [source](./)
 - **Category**: link
+- **markdownlint**: [MD054][mdl-md054] (link-image-style)
+- **rumdl**: [MD054][rumdl-md054] (link-image-style)
+
+[mdl-md054]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md054.md
+[rumdl-md054]: https://rumdl.dev/md054/

--- a/internal/rules/peerlinks_test.go
+++ b/internal/rules/peerlinks_test.go
@@ -1,0 +1,398 @@
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The "Meta-Information" section of every rule README lists the peer
+// Markdown linters this rule covers, one bullet per peer, each linking
+// to that peer's rule documentation. The bullets are derived from the
+// `markdownlint:`/`rumdl:`/`mado:`/`panache:`/`obsidian-linter:` front
+// matter (the same source the coverage matrix reads), so this test is
+// the golden generator and validator that keeps the two in sync.
+//
+// Regenerate after editing peer front matter:
+//
+//	MDSMITH_UPDATE_PEER_LINKS=1 go test ./internal/rules -run TestRuleREADMEPeerLinks
+//
+// A normal `go test` run only validates and fails when a README's peer
+// block has drifted from its front matter.
+
+// peerLinkSpec pairs a peer linter's display label with its mappings.
+type peerLinkSpec struct {
+	label string
+	maps  []RuleMapping
+}
+
+// peerLinkSpecs returns the five peer linters in their canonical bullet
+// order. The label is the peer's own (lowercase) brand name.
+func peerLinkSpecs(info RuleInfo) []peerLinkSpec {
+	return []peerLinkSpec{
+		{"markdownlint", info.Markdownlint},
+		{"rumdl", info.Rumdl},
+		{"mado", info.Mado},
+		{"panache", info.Panache},
+		{"obsidian-linter", info.ObsidianLinter},
+	}
+}
+
+// obsidianCategory maps an obsidian-linter rule id to the docs-site
+// settings page that documents it. The published docs render each
+// category on its own page (settings/<category>-rules/) and anchor each
+// rule by its kebab-case name, so a link needs the rule's category.
+// Add an entry here when a rule README maps a new obsidian-linter rule.
+var obsidianCategory = map[string]string{
+	// Heading rules.
+	"header-increment":                       "heading",
+	"headings-start-line":                    "heading",
+	"remove-trailing-punctuation-in-heading": "heading",
+	// Spacing rules.
+	"heading-blank-lines":           "spacing",
+	"paragraph-blank-lines":         "spacing",
+	"trailing-spaces":               "spacing",
+	"consecutive-blank-lines":       "spacing",
+	"line-break-at-document-end":    "spacing",
+	"empty-line-around-code-fences": "spacing",
+	"empty-line-around-tables":      "spacing",
+	"empty-line-around-blockquotes": "spacing",
+	"space-after-list-markers":      "spacing",
+	// Content rules.
+	"blockquote-style":     "content",
+	"no-bare-urls":         "content",
+	"emphasis-style":       "content",
+	"strong-style":         "content",
+	"unordered-list-style": "content",
+	"ordered-list-style":   "content",
+}
+
+// shortcutPeers carry their own kebab rule names as ids, so their
+// bullets use a CommonMark shortcut reference link — `[rule-name]` whose
+// own text doubles as the reference label. That keeps the bullet short
+// (the long names would otherwise appear twice, overrunning the line
+// limit) and reads naturally. markdownlint, rumdl, and mado instead show
+// a markdownlint-style `MDxxx` id, so they use a full `[MDxxx][label]`
+// reference with a prefixed label.
+func isShortcutPeer(label string) bool {
+	return label == "panache" || label == "obsidian-linter"
+}
+
+// peerRefID returns the link-reference label for one peer mapping.
+// markdownlint, rumdl, and mado prefix the markdownlint-style id so the
+// same `MDxxx` covered by several peers gets a distinct label per peer.
+// Every mado entry shares one label because mado has no per-rule docs,
+// only a single "Supported Rules" table. Shortcut peers (panache,
+// obsidian-linter) use the bare rule name as the label.
+func peerRefID(label string, m RuleMapping) string {
+	switch label {
+	case "markdownlint":
+		return "mdl-" + strings.ToLower(m.ID)
+	case "rumdl":
+		return "rumdl-" + strings.ToLower(m.ID)
+	case "mado":
+		return "mado-rules"
+	case "panache", "obsidian-linter":
+		return m.Name
+	default:
+		return ""
+	}
+}
+
+// peerRefURL returns the documentation URL for one peer mapping, or an
+// error when an obsidian-linter rule has no known category.
+func peerRefURL(label string, m RuleMapping) (string, error) {
+	switch label {
+	case "markdownlint":
+		return "https://github.com/DavidAnson/markdownlint/blob/main/doc/" +
+			strings.ToLower(m.ID) + ".md", nil
+	case "rumdl":
+		return "https://rumdl.dev/" + strings.ToLower(m.ID) + "/", nil
+	case "mado":
+		return "https://github.com/akiomik/mado#supported-rules", nil
+	case "panache":
+		return "https://panache.bz/reference/linter-rules.html#" + m.Name, nil
+	case "obsidian-linter":
+		cat, ok := obsidianCategory[m.Name]
+		if !ok {
+			return "", &peerLinkError{m.Name}
+		}
+		return "https://platers.github.io/obsidian-linter/settings/" +
+			cat + "-rules/#" + m.Name, nil
+	default:
+		return "", &peerLinkError{label}
+	}
+}
+
+type peerLinkError struct{ what string }
+
+func (e *peerLinkError) Error() string {
+	return "no obsidian-linter category for " + e.what +
+		" (add it to obsidianCategory in peerlinks_test.go)"
+}
+
+// peerEntry renders the link for one peer mapping. markdownlint-style
+// peers show "[MD013][mdl-md013] (line-length)"; shortcut peers show
+// "[undefined-anchor]". A trailing " (partial)" marks a partial cover,
+// matching the coverage-matrix legend.
+func peerEntry(label string, m RuleMapping) string {
+	var text string
+	if isShortcutPeer(label) {
+		text = "[" + m.Name + "]"
+	} else {
+		text = "[" + m.ID + "][" + peerRefID(label, m) + "] (" + m.Name + ")"
+	}
+	if m.Partial {
+		text += " (partial)"
+	}
+	return text
+}
+
+// peerBullet renders the "- **<label>**:" bullet. A single mapping sits
+// inline; multiple mappings become a nested list, the same shape the
+// existing markdownlint bullets already use.
+func peerBullet(label string, maps []RuleMapping) string {
+	if len(maps) == 1 {
+		return "- **" + label + "**: " + peerEntry(label, maps[0])
+	}
+	var b strings.Builder
+	b.WriteString("- **" + label + "**:")
+	for _, m := range maps {
+		b.WriteString("\n  - " + peerEntry(label, m))
+	}
+	return b.String()
+}
+
+// refDef renders a link-reference definition. A definition longer than
+// the 80-column line limit puts the URL on its own indented line: the
+// label line stays short and the URL line is a bare URL, which the
+// line-length rule's "urls" exclusion skips. CommonMark allows the
+// destination on the line after the colon, and `mdsmith fix` leaves the
+// wrapped form untouched.
+func refDef(ref, url string) string {
+	oneLine := "[" + ref + "]: " + url
+	if len(oneLine) <= 80 {
+		return oneLine
+	}
+	return "[" + ref + "]:\n  " + url
+}
+
+// renderPeerLinks builds the peer-linter block that follows the
+// "- **Category**:" bullet: one bullet per non-empty peer, a blank line,
+// then the link-reference definitions. It returns "" when the rule maps
+// to no peer linter.
+func renderPeerLinks(info RuleInfo) (string, error) {
+	var bullets, refs []string
+	seen := map[string]string{}
+	for _, p := range peerLinkSpecs(info) {
+		if len(p.maps) == 0 {
+			continue
+		}
+		bullets = append(bullets, peerBullet(p.label, p.maps))
+		for _, m := range p.maps {
+			ref := peerRefID(p.label, m)
+			url, err := peerRefURL(p.label, m)
+			if err != nil {
+				return "", err
+			}
+			if prev, ok := seen[ref]; ok {
+				if prev != url {
+					return "", fmt.Errorf("reference label %q resolves to two URLs (%s, %s)", ref, prev, url)
+				}
+				continue
+			}
+			seen[ref] = url
+			refs = append(refs, refDef(ref, url))
+		}
+	}
+	if len(bullets) == 0 {
+		return "", nil
+	}
+	return strings.Join(bullets, "\n") + "\n\n" + strings.Join(refs, "\n") + "\n", nil
+}
+
+// peerRefMarkers are the link-reference label prefixes a markdownlint-
+// style peer block emits. A rule that maps to no peer linter must carry
+// none of them. (Shortcut peers reuse the bare rule name as the label,
+// which has no fixed prefix to scan for; in practice every panache /
+// obsidian-linter rule also has a markdownlint analog, so these still
+// catch a fully de-mapped rule.)
+var peerRefMarkers = []string{"[mdl-", "[rumdl-", "[mado-rules]"}
+
+const categoryMarker = "\n- **Category**:"
+
+// TestRuleREADMEPeerLinks validates (or, with MDSMITH_UPDATE_PEER_LINKS=1,
+// regenerates) the peer-linter block at the end of each rule README's
+// Meta-Information section against the peer front matter.
+func TestRuleREADMEPeerLinks(t *testing.T) {
+	update := os.Getenv("MDSMITH_UPDATE_PEER_LINKS") == "1"
+	paths, err := filepath.Glob("MDS*/README.md")
+	require.NoError(t, err)
+	require.NotEmpty(t, paths)
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			raw, err := os.ReadFile(path)
+			require.NoError(t, err)
+			content := string(raw)
+
+			info, err := parseFrontMatter(content)
+			require.NoError(t, err)
+
+			block, err := renderPeerLinks(info)
+			require.NoError(t, err)
+
+			if block == "" {
+				for _, m := range peerRefMarkers {
+					assert.NotContainsf(t, content, m,
+						"%s maps to no peer linter but its body still defines %s links", path, m)
+				}
+				return
+			}
+
+			ci := strings.Index(content, categoryMarker)
+			require.GreaterOrEqualf(t, ci, 0, "%s: no Category bullet found", path)
+			rel := strings.IndexByte(content[ci+1:], '\n')
+			require.GreaterOrEqualf(t, rel, 0, "%s: Category bullet not terminated", path)
+			afterIdx := ci + 1 + rel + 1
+
+			if update {
+				next := content[:afterIdx] + block
+				if next != content {
+					require.NoError(t, os.WriteFile(path, []byte(next), 0o644))
+				}
+				return
+			}
+
+			assert.Equalf(t, block, content[afterIdx:],
+				"%s peer-link block out of sync with front matter; "+
+					"regenerate with MDSMITH_UPDATE_PEER_LINKS=1 go test ./internal/rules -run TestRuleREADMEPeerLinks",
+				path)
+		})
+	}
+}
+
+func TestPeerEntry(t *testing.T) {
+	t.Run("markdownlint id and name differ", func(t *testing.T) {
+		got := peerEntry("markdownlint", RuleMapping{ID: "MD013", Name: "line-length"})
+		assert.Equal(t, "[MD013][mdl-md013] (line-length)", got)
+	})
+	t.Run("partial cover", func(t *testing.T) {
+		got := peerEntry("markdownlint", RuleMapping{ID: "MD020", Name: "no-missing-space-closed-atx", Partial: true})
+		assert.Equal(t, "[MD020][mdl-md020] (no-missing-space-closed-atx) (partial)", got)
+	})
+	t.Run("panache uses a shortcut reference", func(t *testing.T) {
+		got := peerEntry("panache", RuleMapping{ID: "heading-hierarchy", Name: "heading-hierarchy"})
+		assert.Equal(t, "[heading-hierarchy]", got)
+	})
+	t.Run("obsidian uses a shortcut reference", func(t *testing.T) {
+		got := peerEntry("obsidian-linter", RuleMapping{
+			ID: "header-increment", Name: "header-increment", Partial: true,
+		})
+		assert.Equal(t, "[header-increment] (partial)", got)
+	})
+}
+
+func TestPeerBullet(t *testing.T) {
+	t.Run("single mapping inline", func(t *testing.T) {
+		got := peerBullet("rumdl", []RuleMapping{{ID: "MD013", Name: "line-length"}})
+		assert.Equal(t, "- **rumdl**: [MD013][rumdl-md013] (line-length)", got)
+	})
+	t.Run("multiple mappings nest", func(t *testing.T) {
+		got := peerBullet("markdownlint", []RuleMapping{
+			{ID: "MD018", Name: "no-missing-space-atx"},
+			{ID: "MD019", Name: "no-multiple-space-atx"},
+		})
+		want := "- **markdownlint**:\n" +
+			"  - [MD018][mdl-md018] (no-missing-space-atx)\n" +
+			"  - [MD019][mdl-md019] (no-multiple-space-atx)"
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestPeerRefURL(t *testing.T) {
+	cases := []struct {
+		label string
+		m     RuleMapping
+		want  string
+	}{
+		{label: "markdownlint", m: RuleMapping{ID: "MD013"},
+			want: "https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md"},
+		{label: "rumdl", m: RuleMapping{ID: "MD051"}, want: "https://rumdl.dev/md051/"},
+		{label: "mado", m: RuleMapping{ID: "MD040"},
+			want: "https://github.com/akiomik/mado#supported-rules"},
+		{label: "panache", m: RuleMapping{ID: "undefined-anchor", Name: "undefined-anchor"},
+			want: "https://panache.bz/reference/linter-rules.html#undefined-anchor"},
+		{label: "obsidian-linter", m: RuleMapping{ID: "trailing-spaces", Name: "trailing-spaces"},
+			want: "https://platers.github.io/obsidian-linter/settings/spacing-rules/#trailing-spaces"},
+		{label: "obsidian-linter", m: RuleMapping{ID: "no-bare-urls", Name: "no-bare-urls"},
+			want: "https://platers.github.io/obsidian-linter/settings/content-rules/#no-bare-urls"},
+	}
+	for _, c := range cases {
+		got, err := peerRefURL(c.label, c.m)
+		require.NoError(t, err)
+		assert.Equal(t, c.want, got)
+	}
+}
+
+func TestPeerRefURL_UnknownObsidianCategory(t *testing.T) {
+	_, err := peerRefURL("obsidian-linter", RuleMapping{ID: "made-up-rule", Name: "made-up-rule"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "made-up-rule")
+}
+
+func TestMadoShareSingleRef(t *testing.T) {
+	info := RuleInfo{
+		ID:       "MDS064",
+		Category: "heading",
+		Mado: []RuleMapping{
+			{ID: "MD018", Name: "no-missing-space-atx", Default: true},
+			{ID: "MD019", Name: "no-multiple-space-atx", Default: true},
+		},
+	}
+	block, err := renderPeerLinks(info)
+	require.NoError(t, err)
+	// Two mado entries, but only one shared reference definition.
+	assert.Equal(t, 1, strings.Count(block, "[mado-rules]: "))
+	assert.Contains(t, block, "[MD018][mado-rules] (no-missing-space-atx)")
+	assert.Contains(t, block, "[MD019][mado-rules] (no-multiple-space-atx)")
+}
+
+func TestRenderPeerLinks_ConflictingShortcutLabels(t *testing.T) {
+	// A future rule that maps the same bare name to two different peer
+	// URLs would emit one ambiguous shortcut label; the renderer must
+	// reject it rather than silently link one of them wrong.
+	info := RuleInfo{
+		ID:             "MDS999",
+		Category:       "prose",
+		Panache:        []RuleMapping{{ID: "emphasis-style", Name: "emphasis-style"}},
+		ObsidianLinter: []RuleMapping{{ID: "emphasis-style", Name: "emphasis-style"}},
+	}
+	_, err := renderPeerLinks(info)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "emphasis-style")
+}
+
+func TestRefDefWrapsLongURL(t *testing.T) {
+	short := refDef("rumdl-md013", "https://rumdl.dev/md013/")
+	assert.Equal(t, "[rumdl-md013]: https://rumdl.dev/md013/", short)
+
+	url := "https://platers.github.io/obsidian-linter/settings/heading-rules/" +
+		"#remove-trailing-punctuation-in-heading"
+	long := refDef("remove-trailing-punctuation-in-heading", url)
+	assert.Equal(t, "[remove-trailing-punctuation-in-heading]:\n  "+url, long)
+	// The label line stays within the column budget; the URL line is a
+	// bare URL the line-length rule's "urls" exclusion skips.
+	assert.LessOrEqual(t, len("[remove-trailing-punctuation-in-heading]:"), 80)
+}
+
+func TestRenderPeerLinks_NoPeers(t *testing.T) {
+	block, err := renderPeerLinks(RuleInfo{ID: "MDS022", Category: "structural"})
+	require.NoError(t, err)
+	assert.Equal(t, "", block)
+}

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -115,22 +115,37 @@ rules:
 - **Implementation**:
   [source](./)
 - **Category**: {category}
-- **Markdownlint**: [MDxxx][mdl-mdxxx] (name)
+- **markdownlint**: [MDxxx][mdl-mdxxx] (name)
+- **rumdl**: [MDxxx][rumdl-mdxxx] (name)
+- **mado**: [MDxxx][mado-rules] (name)
 
 [mdl-mdxxx]: https://github.com/DavidAnson/markdownlint/blob/main/doc/mdxxx.md
+[rumdl-mdxxx]: https://rumdl.dev/mdxxx/
+[mado-rules]: https://github.com/akiomik/mado#supported-rules
 
 <!-- Bullets in this order: ID, Name, Status, Default, Fixable,
-     Implementation, Category, Markdownlint, and optionally Concept.
+     Implementation, Category, then one bullet per peer linter the rule
+     covers (markdownlint, rumdl, mado, panache, obsidian-linter), and
+     optionally Concept or Guide.
      Default may include key settings: "enabled, max: 80".
      Category must match the `category:` front-matter field and one
-     of the values in ValidCategories. Pick the narrowest that fits;
-     drop any category not in this list.
-     The Markdownlint bullet mirrors the `markdownlint:` front-matter
-     list. One entry per markdownlint rule the mdsmith rule covers,
-     joined with commas; "(partial)" suffixes a partial cover. The
-     matching link-reference definition follows the bullet block.
-     Omit the Markdownlint bullet (and the link refs) for mdsmith-only
-     rules with `markdownlint: []` in front matter.
+     of the values in ValidCategories. Pick the narrowest that fits.
+
+     The peer-linter bullets above and their link-reference definitions
+     are GENERATED from the `markdownlint:`/`rumdl:`/`mado:`/`panache:`/
+     `obsidian-linter:` front matter. Do not hand-write them; edit the
+     front matter and regenerate (the same data feeds the coverage
+     matrix):
+       MDSMITH_UPDATE_PEER_LINKS=1 go test ./internal/rules \
+         -run TestRuleREADMEPeerLinks
+     One bullet per peer with a non-empty list, one entry per covered
+     rule (nested when more than one), "(partial)" marking a partial
+     cover. markdownlint/rumdl/mado link the MDxxx id (mado shares one
+     `mado-rules` label -- it has no per-rule docs); panache and
+     obsidian-linter use a bare `rule-name` shortcut reference. A
+     definition past the line limit wraps onto an indented URL line.
+     A rule whose peer lists are all empty has no peer bullets.
+
      Add a Concept bullet when the rule has a dedicated concept page:
        - **Concept**: [NAME](../../../docs/background/concepts/NAME.md)
      Omit the Concept bullet when no concept page applies. -->


### PR DESCRIPTION
## What

Every rule README's **Meta-Information** section linked only its
`markdownlint` analog. The `rumdl` / `mado` / `panache` /
`obsidian-linter` mappings already lived in front matter (and feed the
coverage matrix) but were never linked in the body. This adds a bullet
per covered peer linter, each linking to that peer's rule documentation,
across all 42 rule READMEs that map to a peer.

## Per-peer link scheme

| Peer | Target |
| --- | --- |
| markdownlint | `…/markdownlint/blob/main/doc/<id>.md` (already present) |
| rumdl | `https://rumdl.dev/<id>/` |
| mado | the shared **Supported Rules** table — mado has no per-rule docs |
| panache | `https://panache.bz/reference/linter-rules.html#<rule>` |
| obsidian-linter | `…/settings/<category>-rules/#<rule>` (heading/content/spacing) |

- `panache` and `obsidian-linter` use **shortcut reference links**
  (`[rule-name]`) because their id *is* the rule name — this keeps the
  long names from appearing twice and overrunning the line limit.
- Long link-reference definitions wrap onto an indented URL line, which
  the line-length rule's `urls` exclusion skips and `mdsmith fix` leaves
  intact.
- Peer labels are normalized to their lowercase brand names. Two
  pre-existing inconsistencies are fixed along the way: MDS025's
  plain-text "markdownlint coverage" line and MDS068's missing bullet.

## Keeping it in sync

`internal/rules/peerlinks_test.go` is the golden generator **and**
validator, deriving each block from the same front matter the coverage
matrix reads:

```
# validate (runs in CI via `go test ./...`)
go test ./internal/rules -run TestRuleREADMEPeerLinks

# regenerate after editing peer front matter
MDSMITH_UPDATE_PEER_LINKS=1 go test ./internal/rules -run TestRuleREADMEPeerLinks
```

`proto.md` and `docs/development/add-peer-linter.md` document the
convention. One MDS020 paragraph was reflowed (content-preserving) so the
added bullet keeps the file under its length cap.

## Checks

- `go test ./...` ✅
- `go vet ./...` ✅
- `go tool golangci-lint run ./internal/rules/` ✅ (0 issues)
- `mdsmith check .` ✅ (424 files, 0 failures)

Peer documentation URLs were verified live against each tool's docs site
(rumdl.dev per-rule pages, panache.bz `linter-rules.html` anchors, the
obsidian-linter category pages, and mado's table-only README).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SnjFQaf27vTABbz9g7NggE)_