### PR TITLE
docs(plan): add plan 241 for `.mdsmith/schemas/` YAML schema files

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -166,7 +166,7 @@ footer: |
 | 237 | 🔲     | haiku  | [Unit tests for include-rule private validation helpers](plan/237_arch-fix-include-helper-tests.md)                                     |
 | 237 | 🔲     | sonnet | [cuelite phase 1 — surface D (placeholder paths)](plan/237_cuelite-surface-d.md)                                                        |
 | 238 | 🔲     | opus   | [cuelite phase 2 — surfaces A + B (schema, query)](plan/238_cuelite-surfaces-ab.md)                                                     |
-| 238 | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/238_schema-files.md)                                                            |
 | 239 | 🔲     | opus   | [cuelite phase 3 — surface C (row-expr evaluator)](plan/239_cuelite-surface-c.md)                                                       |
 | 240 | 🔲     | sonnet | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
+| 241 | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -166,6 +166,7 @@ footer: |
 | 237 | 🔲     | haiku  | [Unit tests for include-rule private validation helpers](plan/237_arch-fix-include-helper-tests.md)                                     |
 | 237 | 🔲     | sonnet | [cuelite phase 1 — surface D (placeholder paths)](plan/237_cuelite-surface-d.md)                                                        |
 | 238 | 🔲     | opus   | [cuelite phase 2 — surfaces A + B (schema, query)](plan/238_cuelite-surfaces-ab.md)                                                     |
+| 238 | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/238_schema-files.md)                                                            |
 | 239 | 🔲     | opus   | [cuelite phase 3 — surface C (row-expr evaluator)](plan/239_cuelite-surface-c.md)                                                       |
 | 240 | 🔲     | sonnet | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
 <?/catalog?>

--- a/plan/238_schema-files.md
+++ b/plan/238_schema-files.md
@@ -40,10 +40,10 @@ named, reusable bundle.
 
 Today a kind embeds its schema inline under
 `kinds.<name>.schema:` or points at a `proto.md`.
-Inline does not share; `proto.md` shares but
-uses a different matcher grammar. A YAML file
-under `.mdsmith/schemas/` shares AND uses the
-plan 146 matcher engine. The body parses through
+Inline does not share; `proto.md` shares but uses
+a different matcher grammar. A YAML file under
+`.mdsmith/schemas/` shares AND uses the plan 146
+matcher engine via
 [`schema.ParseInline`](../internal/schema/parse_inline.go).
 
 `docs/guides/conventions.md` does not exist; the
@@ -74,10 +74,9 @@ plan adds it as a side deliverable parallel to
     runbook.yaml
 ```
 
-Both `*.yaml` and `*.yml` are scanned at the
-workspace root. Subdirectories and symlinks are
-rejected. The 1 MB cap on `.mdsmith.yml` applies
-unchanged.
+Both `*.yaml` and `*.yml` are scanned.
+Subdirectories and symlinks are rejected. The
+1 MB `.mdsmith.yml` cap applies unchanged.
 
 ### Schema file shape
 
@@ -147,29 +146,24 @@ Interactions:
 
 ### Mutual exclusion
 
+A named `schema:` resolves to an inline map
+before validation runs.
 [`validateKindSchemaSources`](../internal/config/validate.go)
-rejects a kind that sets more than one of
-`kinds.<name>.schema:`,
-`rules.required-structure.schema:`, or the
-legacy `inline-schema:`. The named form is a new
-shape on the `schema:` slot. The check treats it
-like the inline map for both pairwise checks.
+then rejects any kind with two schema sources,
+the same as today.
 
 ### Sharing and provenance
 
 Multi-kind composition per
 [plan 156](156_kind-schema-composition.md) is
-unchanged. Each kind contributes one
-`schema-sources` entry whose `inline` body is
-the resolved YAML; `schema.Compose` merges them.
+unchanged. Each kind adds one `schema-sources`
+entry (`inline` = resolved YAML). `schema.Compose`
+merges them.
 
-`applyInlineSchemaSource` in
-[`merge.go`](../internal/config/merge.go)
-already accepts a `sourcePath`. For a named
-reference it carries the schema file's path; for
-the inline form, the kind's defining file. The
-entry's `source` key holds it so diagnostics
-navigate to the right file.
+`applyInlineSchemaSource` already takes a
+`sourcePath`. For a named reference it carries
+the schema file's path, so a violation's "go to
+schema" location points there.
 
 ## ...
 
@@ -182,13 +176,20 @@ Per
 no new package. Discovery lives in
 `internal/config`.
 
-1. **`internal/config`**: add a `SchemaRef`
-   type with `UnmarshalYAML` dispatching on
-   `yaml.Node.Kind`. Scalar string → named
-   reference; mapping → inline body. Replace
-   `KindBody.Schema map[string]any` with it.
+1. **`internal/config`** (+ `internal/kindsout`):
+   add a `SchemaRef` type with `UnmarshalYAML`
+   dispatching on `yaml.Node.Kind` (scalar →
+   named ref, mapping → inline body). Replace
+   `KindBody.Schema map[string]any` and route
+   every map reader through a `Map()` accessor:
+   `resolvedInlineSchema`, `extendsChainSchemas`,
+   `validateKindSchemaSources`,
+   `effectiveExplicit`, `resolveLayerInlineSchema`,
+   and `kindsout`'s frontmatter index.
+   `copyKinds` must deep-copy the resolved body
+   so load-time resolution survives the merge.
    Unit test covers scalar, mapping, sequence,
-   null, and malformed scalar.
+   null, malformed scalar.
 2. **`internal/config`**: add
    `discoverSchemas(workspaceDir)` mirroring
    `discoverKinds`'s checks (basename
@@ -200,22 +201,21 @@ no new package. Discovery lives in
    `mergeSchemaFiles(cfg, cfgPath)` populates
    it. `ParseBytes` skips disk discovery.
 4. **`internal/config`**: in `Load`, after the
-   kind and convention merges, call
-   `mergeSchemaFiles` and then
+   kind/convention merges and before
+   `ValidateKinds`, call `mergeSchemaFiles` then
    `resolveNamedSchemas(cfg)`. The resolver
    replaces each kind's named `SchemaRef` with
    the discovered body in place. Undeclared
    names error. Unit tests cover happy path,
    undeclared name, and the inline form
    passing through.
-5. **`internal/config`**: extend
-   `validateKindSchemaSources` so a kind
-   setting a named `schema:` AND
-   `rules.required-structure.schema:` errors,
-   and so a kind setting a named `schema:` AND
-   `rules.required-structure.inline-schema:`
-   errors — both with the "pick one source"
-   wording.
+5. **`internal/config`**: adapt
+   `validateKindSchemaSources` to read
+   `body.Schema.Map()` (filled by resolution).
+   A named `schema:` plus
+   `rules.required-structure.schema:` — or plus
+   `inline-schema:` — then trips the existing
+   pairwise checks with "pick one source".
 6. **`internal/config`**: thread the schema
    file's path through
    `applyInlineSchemaSource` as `sourcePath`
@@ -233,34 +233,32 @@ no new package. Discovery lives in
    named YAML reference, same Markdown input —
    assert byte-equal diagnostic streams.
 9. **CLI**: extend `mdsmith kinds resolve` to
-   print the schema's defining-source path on
-   the kind's resolved entry. JSON shape gains
-   `schema-source-path:`, omitted when the
-   schema is inline (its source is already on
-   `source-path`).
+   print the schema's defining-source path.
+   JSON gains `schema-source-path:`, populated
+   for named-YAML and `proto.md` sources,
+   omitted for inline (already on `source-path`).
 10. **Docs — new reference**: add
     `docs/reference/schema-files.md` with the
     H2s kind-files.md and convention-files.md
-    share: directory layout, file shape,
-    basename rule, composition with
-    `.mdsmith.yml`, audit surface.
+    share (file shape, basename rule,
+    composition, audit); the directory tree
+    goes in the preamble.
 11. **Docs — schemas guide**: in
     [schemas.md](../docs/guides/schemas.md)
-    update the source list to three sources,
-    add a "File-based YAML schemas" H2 between
-    inline and proto.md, and add a row to the
+    grow the source list to three, add a
+    "File-based YAML schemas" H2 between inline
+    and proto.md, and add a column to the
     "Choosing a source" table.
 12. **Docs — kind-files reference**: in
     [kind-files.md](../docs/reference/kind-files.md)'s
     "Schema sources" section, add the named
     reference as a fourth source.
 13. **Docs — conventions guide**: add
-    `docs/guides/conventions.md` with H2s:
-    declaring a convention inline, picking
-    one via top-level `convention:`, layering
-    rules over a preset, and the "split into
-    its own file" recipe. The CLAUDE.md
-    catalog picks it up on next `mdsmith fix`.
+    `docs/guides/conventions.md` with H2s for
+    declaring a convention inline, the
+    top-level `convention:` selector, layering
+    rules over a preset, and the "split into a
+    file" recipe. The catalog auto-includes it.
 14. **Docs — architecture boundaries**: add a
     row in [cross-system.md][cs] for
     `.mdsmith/schemas/`.
@@ -274,15 +272,15 @@ no new package. Discovery lives in
 
 ## Acceptance Criteria
 
-- [ ] A schema at `.mdsmith/schemas/foo.yaml`
-      with the body of inline
-      `kinds.bar.schema:` produces byte-equal
-      diagnostics when the kind sets
-      `schema: foo`.
-- [ ] Two kinds with `schema: foo` produce
-      identical diagnostics; the integration
-      fixture pair (inline vs named) emits
-      byte-equal streams.
+- [ ] A kind with `schema: foo` (file) and a
+      kind with the same body inline produce the
+      same diagnostic messages and anchors on a
+      reference doc (the schema-source related
+      location differs by design).
+- [ ] The integration fixture pair (inline vs
+      named) emits matching message+anchor
+      streams; two kinds sharing `schema: foo`
+      both validate.
 - [ ] A kind referencing an undeclared schema
       name errors, naming both.
 - [ ] Each of these errors with a clear
@@ -297,11 +295,13 @@ no new package. Discovery lives in
       source".
 - [ ] `mdsmith kinds resolve <file>` prints
       the schema's defining-source path. JSON
-      adds `schema-source-path:`, omitted when
-      the schema is inline.
+      `schema-source-path:` is set for file
+      sources, omitted for inline.
 - [ ] `docs/reference/schema-files.md` exists.
       [schemas.md](../docs/guides/schemas.md)
       documents all three sources.
+- [ ] kind-files.md and cross-system.md each
+      reference `.mdsmith/schemas/`.
 - [ ] `docs/guides/conventions.md` covers the
       four H2s named in task 13.
 - [ ] Unit tests cover `SchemaRef.UnmarshalYAML`,

--- a/plan/238_schema-files.md
+++ b/plan/238_schema-files.md
@@ -3,16 +3,15 @@ id: 238
 title: Schema-per-file config under `.mdsmith/schemas/`
 status: "🔲"
 model: opus
-depends-on: [146, 208]
+depends-on: [146, 208, 209]
 summary: >-
   Lift reusable schemas out of
   `kinds.<name>.schema:` in `.mdsmith.yml` into
   standalone YAML files under
   `.mdsmith/schemas/<name>.yaml`. A kind references
   one by name (`schema: rfc-v1`) so the same schema
-  can drive many kinds without duplication. Inline
-  `schema:` maps stay first-class. Also closes the
-  conventions docs gap by adding
+  can drive many kinds without duplication. Also
+  closes the conventions docs gap with
   `docs/guides/conventions.md`.
 ---
 # Schema-per-file config under `.mdsmith/schemas/`
@@ -25,10 +24,8 @@ summary: >-
 
 Lift each reusable schema out of
 `kinds.<name>.schema:` into a standalone YAML file
-under `.mdsmith/schemas/<name>.yaml`, addressable
-by name from any kind. One file holds one
-schema's body so the same heading tree can drive
-multiple kinds without copy-paste.
+under `.mdsmith/schemas/<name>.yaml`. Any kind
+references it by name via `schema: rfc-v1`.
 
 ## ...
 
@@ -36,41 +33,31 @@ multiple kinds without copy-paste.
 
 ## Background
 
-Plan 208 split kinds into
-[`.mdsmith/kinds/`](../docs/reference/kind-files.md).
-Plan 209 split user conventions into
-[`.mdsmith/conventions/`](../docs/reference/convention-files.md).
-Schemas are the next named, reusable bundle.
+Plans 208 and 209 split kinds and conventions
+into `.mdsmith/kinds/` and
+`.mdsmith/conventions/`. Schemas are the next
+named, reusable bundle.
 
-Today a kind either embeds its schema inline
-under `kinds.<name>.schema:` or points at a
-`proto.md` file. The inline form does not share.
-The `proto.md` form shares but does not use the
-modern matcher engine from plan 146 (`regex:`,
-`repeat:`, `\#(digits)`, `\#(fmvar(...))`).
-
-A YAML file under `.mdsmith/schemas/` closes
-the gap. The body parses through the existing
+Today a kind embeds its schema inline under
+`kinds.<name>.schema:` or points at a `proto.md`.
+Inline does not share; `proto.md` shares but
+uses a different matcher grammar. A YAML file
+under `.mdsmith/schemas/` shares AND uses the
+plan 146 matcher engine. The body parses through
 [`schema.ParseInline`](../internal/schema/parse_inline.go).
-Kinds reference it by name; the same schema may
-drive many kinds.
 
-The conventions surface has a docs gap too:
-no `docs/guides/conventions.md` parallel to
-[`docs/guides/file-kinds.md`](../docs/guides/file-kinds.md).
-This plan closes that gap as a side
-deliverable.
+`docs/guides/conventions.md` does not exist; the
+plan adds it as a side deliverable parallel to
+[`file-kinds.md`](../docs/guides/file-kinds.md).
 
 ## Non-Goals
 
-- Migrating `proto.md` to YAML. `proto.md`
-  stays first-class.
-- Removing inline `schema:` maps. Inline stays
-  first-class.
-- Schema-file-level `extends:`. Out of scope.
-- Adopting `.mdsmith/schemas/` in this repo.
-  Deferred until the pinned mdsmith version
-  ships the feature.
+- Migrating `proto.md` to YAML.
+- Removing inline `schema:` maps.
+- Schema-file-level `extends:`.
+- Adopting `.mdsmith/schemas/` in this repo
+  (deferred until the pinned mdsmith version
+  ships the feature).
 - Auto-binding by basename.
 
 ## Design
@@ -88,16 +75,16 @@ deliverable.
 ```
 
 Both `*.yaml` and `*.yml` are scanned at the
-workspace root. Subdirectories and symlinks
-under `.mdsmith/schemas/` are rejected. The 1 MB
-size cap that protects `.mdsmith.yml` applies
+workspace root. Subdirectories and symlinks are
+rejected. The 1 MB cap on `.mdsmith.yml` applies
 unchanged.
 
 ### Schema file shape
 
-The body matches the inline
-`kinds.<name>.schema:` shape and feeds into
-`schema.ParseInline` unchanged:
+The body parses through `schema.ParseInline`.
+Allowed top-level keys (anything else errors):
+`frontmatter`, `filename`, `closed`, `sections`,
+`cross-references`, `acronyms`, and `index`.
 
 ```yaml
 # .mdsmith/schemas/rfc-v1.yaml
@@ -114,11 +101,8 @@ sections:
 ```
 
 The schema's name is the basename minus
-extension. The basename must match
-`[a-z][a-z0-9-]*` — the same rule kind and
-convention files carry. A top-level key outside
-the inline-schema vocabulary errors naming the
-key.
+extension, matching `[a-z][a-z0-9-]*` — the same
+rule kind and convention files carry.
 
 ### Referencing from a kind
 
@@ -140,33 +124,52 @@ kinds:
 The string form looks the schema up by name.
 The map form keeps its inline meaning. The
 merge layer resolves the named reference at
-config-load time and threads the resolved body
+config-load time. The resolved body threads
 through the same `schema-sources` plumbing
 inline schemas use today.
 
-An undeclared name is a config error naming
-the kind and the missing schema.
+An undeclared name errors, naming the kind and
+the missing schema.
+
+Interactions:
+
+- **`extends:`** — name references resolve to
+  bodies **before** `ResolveKindInlineSchema`
+  walks the chain, so parent and child schemas
+  merge via the plan 135 semantics either way.
+- **`path-pattern:`** — runs independently from
+  the resolved schema's `filename:`. Both fire
+  on a mismatch (unchanged from inline).
+- **Namespace** — schema names live in a flat
+  registry under `.mdsmith/schemas/`. A `proto.md`
+  path under `rules.required-structure.schema:`
+  is a separate source type.
 
 ### Mutual exclusion
 
 [`validateKindSchemaSources`](../internal/config/validate.go)
-already rejects a kind that sets more than one
-of `kinds.<name>.schema:`,
+rejects a kind that sets more than one of
+`kinds.<name>.schema:`,
 `rules.required-structure.schema:`, or the
-legacy `inline-schema:`. The named form is a
-fourth shape on the inline slot. The check
-treats it identically to the inline map for
-the pairwise comparison.
+legacy `inline-schema:`. The named form is a new
+shape on the `schema:` slot. The check treats it
+like the inline map for both pairwise checks.
 
-### Sharing across kinds
+### Sharing and provenance
 
-A file resolving to several kinds per
-[plan 156](156_kind-schema-composition.md)
-where each kind references the same schema
-name composes identically to the inline case.
-The existing `schema.Compose` deduplicates
-byte-equal sources. No new composition
-semantics.
+Multi-kind composition per
+[plan 156](156_kind-schema-composition.md) is
+unchanged. Each kind contributes one
+`schema-sources` entry whose `inline` body is
+the resolved YAML; `schema.Compose` merges them.
+
+`applyInlineSchemaSource` in
+[`merge.go`](../internal/config/merge.go)
+already accepts a `sourcePath`. For a named
+reference it carries the schema file's path; for
+the inline form, the kind's defining file. The
+entry's `source` key holds it so diagnostics
+navigate to the right file.
 
 ## ...
 
@@ -180,74 +183,88 @@ no new package. Discovery lives in
 `internal/config`.
 
 1. **`internal/config`**: add a `SchemaRef`
-   type wrapping the polymorphic `schema:`
-   value with `UnmarshalYAML` that dispatches
-   on `yaml.Node.Kind`. Replace
-   `KindBody.Schema map[string]any` with the
-   new type. Unit test covers scalar,
-   mapping, and error paths.
+   type with `UnmarshalYAML` dispatching on
+   `yaml.Node.Kind`. Scalar string → named
+   reference; mapping → inline body. Replace
+   `KindBody.Schema map[string]any` with it.
+   Unit test covers scalar, mapping, sequence,
+   null, and malformed scalar.
 2. **`internal/config`**: add
-   `discoverSchemas(workspaceDir)` modelled on
-   `discoverKinds`. Rejects bad basenames,
-   subdirectories, symlinks, duplicates, and
-   unknown top-level keys. Unit test per
-   rejection case.
-3. **`internal/config`**: add `Schemas` map
-   on `Config`. `mergeSchemaFiles(cfg,
-   cfgPath)` populates it. The in-memory
-   `ParseBytes` path skips disk discovery.
-4. **`internal/config`**: in `Load`, after
-   the kind and convention merges, call
+   `discoverSchemas(workspaceDir)` mirroring
+   `discoverKinds`'s checks (basename
+   `[a-z][a-z0-9-]*`, no subdirs, no symlinks,
+   no `.yaml`/`.yml` duplicates, no unknown
+   top-level keys). Unit test per rejection.
+3. **`internal/config`**: add `Schemas
+   map[string]map[string]any` on `Config`.
+   `mergeSchemaFiles(cfg, cfgPath)` populates
+   it. `ParseBytes` skips disk discovery.
+4. **`internal/config`**: in `Load`, after the
+   kind and convention merges, call
    `mergeSchemaFiles` and then
-   `resolveNamedSchemas(cfg)`. Replaces each
-   named reference with the resolved inline
-   body. Undeclared names error. Unit test
-   covers happy path, undeclared name, and
-   inline form passing through.
+   `resolveNamedSchemas(cfg)`. The resolver
+   replaces each kind's named `SchemaRef` with
+   the discovered body in place. Undeclared
+   names error. Unit tests cover happy path,
+   undeclared name, and the inline form
+   passing through.
 5. **`internal/config`**: extend
-   `validateKindSchemaSources` so a kind that
-   sets both a named `schema:` and
-   `rules.required-structure.schema:` (or
-   `inline-schema:`) errors with the existing
-   "pick one source" wording.
-6. **`internal/config`**: extend provenance
-   so a resolved named schema records the
-   schema file's path as its source.
+   `validateKindSchemaSources` so a kind
+   setting a named `schema:` AND
+   `rules.required-structure.schema:` errors,
+   and so a kind setting a named `schema:` AND
+   `rules.required-structure.inline-schema:`
+   errors — both with the "pick one source"
+   wording.
+6. **`internal/config`**: thread the schema
+   file's path through
+   `applyInlineSchemaSource` as `sourcePath`
+   when the inline body came from a named
+   reference. Provenance test asserts the
+   `source` key on the schema-sources entry
+   carries `.mdsmith/schemas/<name>.yaml`.
 7. **`internal/integration`**: contract test
    covers directory layout, basename rule,
-   subdirectory rejection, dual-source
-   rejection, and undeclared-name rejection.
+   subdirectory/symlink rejection, both
+   dual-source rejections, and undeclared-name
+   rejection.
 8. **`internal/integration`**: parallel
-   fixtures asserting a kind referencing a
-   YAML schema produces the same diagnostics
-   as the equivalent inline schema.
+   fixtures — one kind defined inline, one via
+   named YAML reference, same Markdown input —
+   assert byte-equal diagnostic streams.
 9. **CLI**: extend `mdsmith kinds resolve` to
-   print the schema's defining-source path.
-   JSON shape gains `schema-source-path:`.
+   print the schema's defining-source path on
+   the kind's resolved entry. JSON shape gains
+   `schema-source-path:`, omitted when the
+   schema is inline (its source is already on
+   `source-path`).
 10. **Docs — new reference**: add
-    `docs/reference/schema-files.md` modelled
-    on `kind-files.md` and
-    `convention-files.md`.
-11. **Docs — schemas guide**: extend
+    `docs/reference/schema-files.md` with the
+    H2s kind-files.md and convention-files.md
+    share: directory layout, file shape,
+    basename rule, composition with
+    `.mdsmith.yml`, audit surface.
+11. **Docs — schemas guide**: in
     [schemas.md](../docs/guides/schemas.md)
-    with a "File-based YAML schemas" section.
-    Update the source list and the "Choosing
-    a source" table.
-12. **Docs — kind-files reference**: note the
-    named reference as a third schema source
-    in
-    [kind-files.md](../docs/reference/kind-files.md).
+    update the source list to three sources,
+    add a "File-based YAML schemas" H2 between
+    inline and proto.md, and add a row to the
+    "Choosing a source" table.
+12. **Docs — kind-files reference**: in
+    [kind-files.md](../docs/reference/kind-files.md)'s
+    "Schema sources" section, add the named
+    reference as a fourth source.
 13. **Docs — conventions guide**: add
-    `docs/guides/conventions.md` mirroring
-    `file-kinds.md`. Wire it into the
-    [CLAUDE.md](../CLAUDE.md) catalog.
+    `docs/guides/conventions.md` with H2s:
+    declaring a convention inline, picking
+    one via top-level `convention:`, layering
+    rules over a preset, and the "split into
+    its own file" recipe. The CLAUDE.md
+    catalog picks it up on next `mdsmith fix`.
 14. **Docs — architecture boundaries**: add a
-    row to the boundaries table in
-    [cross-system.md][cs] listing
+    row in [cross-system.md][cs] for
     `.mdsmith/schemas/`.
-15. **Repo migration**: deferred until the
-    pinned mdsmith version supports the
-    directory.
+15. **Repo migration**: deferred to a follow-up.
 
 [cs]: ../docs/development/architecture/cross-system.md
 
@@ -258,42 +275,38 @@ no new package. Discovery lives in
 ## Acceptance Criteria
 
 - [ ] A schema at `.mdsmith/schemas/foo.yaml`
-      whose body matches an inline
+      with the body of inline
       `kinds.bar.schema:` produces byte-equal
-      diagnostics on a reference document
-      when the kind sets `schema: foo`.
-- [ ] Two kinds referencing the same schema
-      name both validate against it.
-- [ ] A kind setting `schema: <name>` where
-      the name is undeclared errors, naming
-      the kind and the missing schema.
-- [ ] A schema basename failing
-      `[a-z][a-z0-9-]*`, a file in a
-      subdirectory, or a symlink errors.
-- [ ] Two schema files with the same
-      basename across `.yaml`/`.yml` error
-      naming both files.
-- [ ] A schema file with an unknown
-      top-level key errors naming the key.
-- [ ] A kind setting both a named `schema:`
-      and `rules.required-structure.schema:`
-      errors with the "pick one source"
-      wording.
+      diagnostics when the kind sets
+      `schema: foo`.
+- [ ] Two kinds with `schema: foo` produce
+      identical diagnostics; the integration
+      fixture pair (inline vs named) emits
+      byte-equal streams.
+- [ ] A kind referencing an undeclared schema
+      name errors, naming both.
+- [ ] Each of these errors with a clear
+      message: basename outside
+      `[a-z][a-z0-9-]*`, file in a subdirectory,
+      symlink, duplicate basename across
+      `.yaml`/`.yml`, unknown top-level key.
+- [ ] A kind that sets a named `schema:` and
+      `rules.required-structure.schema:` errors;
+      same for named `schema:` and
+      `inline-schema:`. Both quote "pick one
+      source".
 - [ ] `mdsmith kinds resolve <file>` prints
-      the schema's defining-source path;
-      JSON carries `schema-source-path:`.
-- [ ] `docs/reference/schema-files.md`
-      exists and is linked from the catalog,
-      the schemas guide, and the boundaries
-      table.
-- [ ] [schemas.md](../docs/guides/schemas.md)
+      the schema's defining-source path. JSON
+      adds `schema-source-path:`, omitted when
+      the schema is inline.
+- [ ] `docs/reference/schema-files.md` exists.
+      [schemas.md](../docs/guides/schemas.md)
       documents all three sources.
-- [ ] `docs/guides/conventions.md` exists
-      and mirrors
-      [file-kinds.md](../docs/guides/file-kinds.md).
-- [ ] Every new function in
-      `internal/config` ships with its
-      dedicated unit test.
+- [ ] `docs/guides/conventions.md` covers the
+      four H2s named in task 13.
+- [ ] Unit tests cover `SchemaRef.UnmarshalYAML`,
+      `discoverSchemas`, `mergeSchemaFiles`,
+      and `resolveNamedSchemas`.
 - [ ] All tests pass: `go test ./...`
 - [ ] `go tool golangci-lint run` clean.
 - [ ] `mdsmith check .` passes.

--- a/plan/238_schema-files.md
+++ b/plan/238_schema-files.md
@@ -1,0 +1,303 @@
+---
+id: 238
+title: Schema-per-file config under `.mdsmith/schemas/`
+status: "🔲"
+model: opus
+depends-on: [146, 208]
+summary: >-
+  Lift reusable schemas out of
+  `kinds.<name>.schema:` in `.mdsmith.yml` into
+  standalone YAML files under
+  `.mdsmith/schemas/<name>.yaml`. A kind references
+  one by name (`schema: rfc-v1`) so the same schema
+  can drive many kinds without duplication. Inline
+  `schema:` maps stay first-class. Also closes the
+  conventions docs gap by adding
+  `docs/guides/conventions.md`.
+---
+# Schema-per-file config under `.mdsmith/schemas/`
+
+## ...
+
+<?allow-empty-section?>
+
+## Goal
+
+Lift each reusable schema out of
+`kinds.<name>.schema:` into a standalone YAML file
+under `.mdsmith/schemas/<name>.yaml`, addressable
+by name from any kind. One file holds one
+schema's body so the same heading tree can drive
+multiple kinds without copy-paste.
+
+## ...
+
+<?allow-empty-section?>
+
+## Background
+
+Plan 208 split kinds into
+[`.mdsmith/kinds/`](../docs/reference/kind-files.md).
+Plan 209 split user conventions into
+[`.mdsmith/conventions/`](../docs/reference/convention-files.md).
+Schemas are the next named, reusable bundle.
+
+Today a kind either embeds its schema inline
+under `kinds.<name>.schema:` or points at a
+`proto.md` file. The inline form does not share.
+The `proto.md` form shares but does not use the
+modern matcher engine from plan 146 (`regex:`,
+`repeat:`, `\#(digits)`, `\#(fmvar(...))`).
+
+A YAML file under `.mdsmith/schemas/` closes
+the gap. The body parses through the existing
+[`schema.ParseInline`](../internal/schema/parse_inline.go).
+Kinds reference it by name; the same schema may
+drive many kinds.
+
+The conventions surface has a docs gap too:
+no `docs/guides/conventions.md` parallel to
+[`docs/guides/file-kinds.md`](../docs/guides/file-kinds.md).
+This plan closes that gap as a side
+deliverable.
+
+## Non-Goals
+
+- Migrating `proto.md` to YAML. `proto.md`
+  stays first-class.
+- Removing inline `schema:` maps. Inline stays
+  first-class.
+- Schema-file-level `extends:`. Out of scope.
+- Adopting `.mdsmith/schemas/` in this repo.
+  Deferred until the pinned mdsmith version
+  ships the feature.
+- Auto-binding by basename.
+
+## Design
+
+### Directory layout
+
+```text
+.mdsmith.yml                       # unchanged
+.mdsmith/
+  kinds/                           # plan 208
+  conventions/                     # plan 209
+  schemas/
+    rfc-v1.yaml
+    runbook.yaml
+```
+
+Both `*.yaml` and `*.yml` are scanned at the
+workspace root. Subdirectories and symlinks
+under `.mdsmith/schemas/` are rejected. The 1 MB
+size cap that protects `.mdsmith.yml` applies
+unchanged.
+
+### Schema file shape
+
+The body matches the inline
+`kinds.<name>.schema:` shape and feeds into
+`schema.ParseInline` unchanged:
+
+```yaml
+# .mdsmith/schemas/rfc-v1.yaml
+filename: "RFC-[0-9][0-9][0-9][0-9].md"
+frontmatter:
+  id: '=~"^RFC-[0-9]{4}$"'
+  status: '"draft" | "ratified" | "deprecated"'
+closed: true
+sections:
+  - heading: null
+  - heading: "Overview"
+  - heading: "Decision"
+  - heading: "References"
+```
+
+The schema's name is the basename minus
+extension. The basename must match
+`[a-z][a-z0-9-]*` — the same rule kind and
+convention files carry. A top-level key outside
+the inline-schema vocabulary errors naming the
+key.
+
+### Referencing from a kind
+
+A kind references a YAML schema file by name
+through the existing `schema:` key — its value
+becomes polymorphic:
+
+```yaml
+kinds:
+  rfc:
+    schema: rfc-v1            # resolves .mdsmith/schemas/rfc-v1.yaml
+  rfc-internal:
+    schema: rfc-v1            # one schema drives both kinds
+  draft:
+    schema:                   # inline form (unchanged)
+      filename: "DRAFT-*.md"
+```
+
+The string form looks the schema up by name.
+The map form keeps its inline meaning. The
+merge layer resolves the named reference at
+config-load time and threads the resolved body
+through the same `schema-sources` plumbing
+inline schemas use today.
+
+An undeclared name is a config error naming
+the kind and the missing schema.
+
+### Mutual exclusion
+
+[`validateKindSchemaSources`](../internal/config/validate.go)
+already rejects a kind that sets more than one
+of `kinds.<name>.schema:`,
+`rules.required-structure.schema:`, or the
+legacy `inline-schema:`. The named form is a
+fourth shape on the inline slot. The check
+treats it identically to the inline map for
+the pairwise comparison.
+
+### Sharing across kinds
+
+A file resolving to several kinds per
+[plan 156](156_kind-schema-composition.md)
+where each kind references the same schema
+name composes identically to the inline case.
+The existing `schema.Compose` deduplicates
+byte-equal sources. No new composition
+semantics.
+
+## ...
+
+<?allow-empty-section?>
+
+## Tasks
+
+Per
+[Go architecture patterns](../docs/development/architecture/go.md):
+no new package. Discovery lives in
+`internal/config`.
+
+1. **`internal/config`**: add a `SchemaRef`
+   type wrapping the polymorphic `schema:`
+   value with `UnmarshalYAML` that dispatches
+   on `yaml.Node.Kind`. Replace
+   `KindBody.Schema map[string]any` with the
+   new type. Unit test covers scalar,
+   mapping, and error paths.
+2. **`internal/config`**: add
+   `discoverSchemas(workspaceDir)` modelled on
+   `discoverKinds`. Rejects bad basenames,
+   subdirectories, symlinks, duplicates, and
+   unknown top-level keys. Unit test per
+   rejection case.
+3. **`internal/config`**: add `Schemas` map
+   on `Config`. `mergeSchemaFiles(cfg,
+   cfgPath)` populates it. The in-memory
+   `ParseBytes` path skips disk discovery.
+4. **`internal/config`**: in `Load`, after
+   the kind and convention merges, call
+   `mergeSchemaFiles` and then
+   `resolveNamedSchemas(cfg)`. Replaces each
+   named reference with the resolved inline
+   body. Undeclared names error. Unit test
+   covers happy path, undeclared name, and
+   inline form passing through.
+5. **`internal/config`**: extend
+   `validateKindSchemaSources` so a kind that
+   sets both a named `schema:` and
+   `rules.required-structure.schema:` (or
+   `inline-schema:`) errors with the existing
+   "pick one source" wording.
+6. **`internal/config`**: extend provenance
+   so a resolved named schema records the
+   schema file's path as its source.
+7. **`internal/integration`**: contract test
+   covers directory layout, basename rule,
+   subdirectory rejection, dual-source
+   rejection, and undeclared-name rejection.
+8. **`internal/integration`**: parallel
+   fixtures asserting a kind referencing a
+   YAML schema produces the same diagnostics
+   as the equivalent inline schema.
+9. **CLI**: extend `mdsmith kinds resolve` to
+   print the schema's defining-source path.
+   JSON shape gains `schema-source-path:`.
+10. **Docs — new reference**: add
+    `docs/reference/schema-files.md` modelled
+    on `kind-files.md` and
+    `convention-files.md`.
+11. **Docs — schemas guide**: extend
+    [schemas.md](../docs/guides/schemas.md)
+    with a "File-based YAML schemas" section.
+    Update the source list and the "Choosing
+    a source" table.
+12. **Docs — kind-files reference**: note the
+    named reference as a third schema source
+    in
+    [kind-files.md](../docs/reference/kind-files.md).
+13. **Docs — conventions guide**: add
+    `docs/guides/conventions.md` mirroring
+    `file-kinds.md`. Wire it into the
+    [CLAUDE.md](../CLAUDE.md) catalog.
+14. **Docs — architecture boundaries**: add a
+    row to the boundaries table in
+    [cross-system.md][cs] listing
+    `.mdsmith/schemas/`.
+15. **Repo migration**: deferred until the
+    pinned mdsmith version supports the
+    directory.
+
+[cs]: ../docs/development/architecture/cross-system.md
+
+## ...
+
+<?allow-empty-section?>
+
+## Acceptance Criteria
+
+- [ ] A schema at `.mdsmith/schemas/foo.yaml`
+      whose body matches an inline
+      `kinds.bar.schema:` produces byte-equal
+      diagnostics on a reference document
+      when the kind sets `schema: foo`.
+- [ ] Two kinds referencing the same schema
+      name both validate against it.
+- [ ] A kind setting `schema: <name>` where
+      the name is undeclared errors, naming
+      the kind and the missing schema.
+- [ ] A schema basename failing
+      `[a-z][a-z0-9-]*`, a file in a
+      subdirectory, or a symlink errors.
+- [ ] Two schema files with the same
+      basename across `.yaml`/`.yml` error
+      naming both files.
+- [ ] A schema file with an unknown
+      top-level key errors naming the key.
+- [ ] A kind setting both a named `schema:`
+      and `rules.required-structure.schema:`
+      errors with the "pick one source"
+      wording.
+- [ ] `mdsmith kinds resolve <file>` prints
+      the schema's defining-source path;
+      JSON carries `schema-source-path:`.
+- [ ] `docs/reference/schema-files.md`
+      exists and is linked from the catalog,
+      the schemas guide, and the boundaries
+      table.
+- [ ] [schemas.md](../docs/guides/schemas.md)
+      documents all three sources.
+- [ ] `docs/guides/conventions.md` exists
+      and mirrors
+      [file-kinds.md](../docs/guides/file-kinds.md).
+- [ ] Every new function in
+      `internal/config` ships with its
+      dedicated unit test.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` clean.
+- [ ] `mdsmith check .` passes.
+
+## ...
+
+<?allow-empty-section?>

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -1,5 +1,5 @@
 ---
-id: 238
+id: 241
 title: Schema-per-file config under `.mdsmith/schemas/`
 status: "🔲"
 model: opus

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -21,13 +21,14 @@ summary: >-
 
 ## Goal
 
-A user with many kinds outgrows inline schemas.
-This plan adds a top-level `schemas:` registry to
-`.mdsmith.yml`, mirrored at
-`.mdsmith/schemas/<name>.yaml` — the same pattern
-plans 208/209 set for `kinds:` and `conventions:`.
-Kinds reference a schema by name
-(`schema: rfc-v1`).
+Inline schemas bloat `.mdsmith.yml` the way
+`kinds:` and `conventions:` once did. This plan
+splits each schema into its own
+`.mdsmith/schemas/<name>.yaml` — a top-level
+`schemas:` registry mirrored to a folder, the
+208/209 pattern. A kind references one by name
+(`schema: rfc-v1`); one schema can drive several
+kinds.
 
 ## ...
 

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -5,14 +5,13 @@ status: "🔲"
 model: opus
 depends-on: [146, 208, 209]
 summary: >-
-  Lift reusable schemas out of
-  `kinds.<name>.schema:` in `.mdsmith.yml` into
-  standalone YAML files under
-  `.mdsmith/schemas/<name>.yaml`. A kind references
-  one by name (`schema: rfc-v1`) so the same schema
-  can drive many kinds without duplication. Also
-  closes the conventions docs gap with
-  `docs/guides/conventions.md`.
+  Add a top-level `schemas:` registry to
+  `.mdsmith.yml`, mirrored at
+  `.mdsmith/schemas/<name>.yaml` — the same
+  pattern plans 208 and 209 set for `kinds:` and
+  `conventions:`. A kind references a schema by
+  name (`schema: rfc-v1`). Also adds the missing
+  `docs/guides/conventions.md` guide.
 ---
 # Schema-per-file config under `.mdsmith/schemas/`
 

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -38,7 +38,7 @@ schema can drive several kinds.
 ## Background
 
 Today a kind embeds its schema inline under
-`kinds.<name>.schema:` or points at a `proto.md`.
+`kinds.<kind>.schema:` or points at a `proto.md`.
 Inline doesn't share; `proto.md` shares but uses
 a different matcher grammar. The registry
 shares AND uses the plan 156 matcher engine via

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -189,22 +189,23 @@ no new package; the type change ripples from
    `[a-z][a-z0-9-]*`, no subdirs, no symlinks,
    no `.yaml`/`.yml` duplicates, no unknown
    top-level keys). Unit test per rejection.
-3. **`internal/config`**: add top-level
-   `Schemas map[string]map[string]any` on
-   `Config`, populated by YAML unmarshal of
-   inline `schemas:` AND by `mergeSchemaFiles`.
-   An inline-vs-file name collision errors,
-   matching kinds/conventions. `ParseBytes`
-   skips disk discovery.
+3. **`internal/config`**: store the registry as
+   `map[string]discoveredSchema` (`{body,
+   sourcePath}`) so each entry keeps its origin.
+   Inline `schemas:` entries are tagged
+   `.mdsmith.yml`; `mergeSchemaFiles` tags file
+   entries with the `.yaml` path and errors on an
+   inline-vs-file collision. `ParseBytes` skips
+   disk discovery.
 4. **`internal/config`**: in `Load`, after the
    kind/convention merges and before
    `ValidateKinds`, call `mergeSchemaFiles` then
    `resolveNamedSchemas(cfg)`. The resolver
    replaces each kind's named `KindSchemaRef` with
-   the discovered body in place and sets its
-   `SourcePath`. An undeclared name errors. Unit
-   tests cover happy path, undeclared name, and
-   the inline form passing through.
+   the discovered body and sets the ref's
+   `SourcePath` from the entry's origin. An
+   undeclared name errors. Unit tests cover happy
+   path, undeclared name, inline passing through.
 5. **`internal/config`**: adapt
    `validateKindSchemaSources` to read
    `body.Schema.Map()` (filled by resolution).
@@ -213,10 +214,11 @@ no new package; the type change ripples from
    `inline-schema:` — then trips the existing
    pairwise checks with "pick one source".
 6. **`internal/config`**: thread the ref's
-   `SourcePath` through `applyInlineSchemaSource`.
-   Provenance tests assert the `source` key
-   carries `.mdsmith/schemas/<name>.yaml` for a
-   file entry and `.mdsmith.yml` for an
+   `SourcePath` through `applyInlineSchemaSource`,
+   falling back to the kind's file when empty
+   (inline-on-kind). Provenance tests assert the
+   `source` key is `.mdsmith/schemas/<name>.yaml`
+   for a file entry, `.mdsmith.yml` for an
    inline-registry entry.
 7. **`internal/integration`**: contract test
    covers directory layout, basename rule,
@@ -269,17 +271,15 @@ no new package; the type change ripples from
 
 ## Acceptance Criteria
 
-- [ ] A kind with `schema: foo` (file) and a
-      kind with the same body inline produce the
-      same diagnostic messages and anchors on a
-      reference doc (the schema-source related
-      location differs by design).
-- [ ] The integration fixture pair (inline vs
-      named) emits matching message+anchor
-      streams; two kinds sharing `schema: foo`
-      both validate.
-- [ ] A kind referencing an undeclared schema
-      name errors, naming both.
+- [ ] A `schema: foo` (file) kind and a kind
+      with the same body inline produce the same
+      messages and anchors on a reference doc;
+      only the schema-source location differs.
+- [ ] The inline-vs-named fixture pair emits
+      matching message+anchor streams; two kinds
+      sharing `schema: foo` both validate.
+- [ ] An undeclared `schema:` name errors,
+      naming the kind and the missing schema.
 - [ ] Each of these errors with a clear
       message: basename outside
       `[a-z][a-z0-9-]*`, file in a subdirectory,
@@ -292,17 +292,17 @@ no new package; the type change ripples from
       same for named `schema:` and
       `inline-schema:`. Both quote "pick one
       source".
-- [ ] `mdsmith kinds resolve <file>` prints
-      the schema's defining-source path. JSON
-      `schema-source-path:` is set for file
-      sources, omitted for inline.
+- [ ] `mdsmith kinds resolve <file>` prints the
+      schema's source path; `schema-source-path:`
+      is set for file and inline-registry sources,
+      omitted for inline-on-kind.
 - [ ] `docs/reference/schema-files.md` exists.
       [schemas.md](../docs/guides/schemas.md)
       documents all three sources.
 - [ ] kind-files.md and cross-system.md each
       reference `.mdsmith/schemas/`.
 - [ ] `docs/guides/conventions.md` covers the
-      four H2s named in task 13.
+      H2s named in task 13.
 - [ ] Unit tests cover `KindSchemaRef.UnmarshalYAML`,
       `discoverSchemas`, `mergeSchemaFiles`,
       and `resolveNamedSchemas`.

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -22,21 +22,19 @@ summary: >-
 
 ## Goal
 
-Lift each reusable schema out of
-`kinds.<name>.schema:` into a standalone YAML file
-under `.mdsmith/schemas/<name>.yaml`. Any kind
-references it by name via `schema: rfc-v1`.
+Help an mdsmith user with a growing `.mdsmith.yml`
+factor schemas into separate files. Plans 208 and
+209 covered kinds and conventions. This plan adds
+`.mdsmith/schemas/<name>.yaml`. Any inline
+`kinds.<name>.schema:` block can lift into a
+standalone YAML file, referenced by name
+(`schema: rfc-v1`).
 
 ## ...
 
 <?allow-empty-section?>
 
 ## Background
-
-Plans 208 and 209 split kinds and conventions
-into `.mdsmith/kinds/` and
-`.mdsmith/conventions/`. Schemas are the next
-named, reusable bundle.
 
 Today a kind embeds its schema inline under
 `kinds.<name>.schema:` or points at a `proto.md`.

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -3,7 +3,7 @@ id: 241
 title: Schema-per-file config under `.mdsmith/schemas/`
 status: "🔲"
 model: opus
-depends-on: [146, 208, 209]
+depends-on: [146, 156, 208, 209]
 summary: >-
   Add a top-level `schemas:` registry to
   `.mdsmith.yml`, mirrored at
@@ -39,7 +39,7 @@ Today a kind embeds its schema inline under
 `kinds.<name>.schema:` or points at a `proto.md`.
 Inline doesn't share; `proto.md` shares but uses
 a different matcher grammar. The registry
-shares AND uses the plan 146 matcher engine via
+shares AND uses the plan 156 matcher engine via
 [`schema.ParseInline`](../internal/schema/parse_inline.go).
 
 `docs/guides/conventions.md` does not exist; the
@@ -99,7 +99,7 @@ is a registry name, a map stays inline.
 # .mdsmith.yml
 schemas:                    # inline equivalent of
   rfc-v1:                   # .mdsmith/schemas/rfc-v1.yaml
-    filename: "RFC-*.md"
+    filename: "RFC-[0-9][0-9][0-9][0-9].md"
     sections:
       - heading: "Overview"
       - heading: "Decision"
@@ -131,24 +131,27 @@ Interactions:
 
 ### Mutual exclusion
 
-A named `schema:` resolves to an inline map
-before validation runs.
+A named `schema:` resolves to a map before
 [`validateKindSchemaSources`](../internal/config/validate.go)
-then rejects any kind with two schema sources,
-the same as today.
+runs, so a two-source kind is rejected as today.
+Every registry entry — referenced or not — is
+parsed by `schema.ParseInline` at load, so a typo
+in an unused schema still surfaces.
+`resolveNamedSchemas` collects all undeclared
+references into one error.
 
-### Sharing and provenance
+### Provenance
 
-Multi-kind composition per
+Composition per
 [plan 156](156_kind-schema-composition.md) is
-unchanged. Each kind adds one `schema-sources`
-entry (`inline` = resolved YAML). `schema.Compose`
-merges them.
+unchanged: each kind adds one `schema-sources`
+entry, merged by `schema.Compose`.
 
-`applyInlineSchemaSource` already takes a
-`sourcePath`. For a named reference it carries
-the schema file's path, so a violation's "go to
-schema" location points there.
+`applyInlineSchemaSource`'s `sourcePath` is the
+schema's home. It is the `.yaml` path for a file
+entry, `.mdsmith.yml` for an inline-registry
+entry, the kind's file for an inline-on-kind
+body. "Go to schema" lands there.
 
 ## ...
 
@@ -158,11 +161,11 @@ schema" location points there.
 
 Per
 [Go architecture patterns](../docs/development/architecture/go.md):
-no new package. Discovery lives in
-`internal/config`.
+no new package; the type change ripples from
+`internal/config` into `internal/kindsout`.
 
 1. **`internal/config`** (+ `internal/kindsout`):
-   add a `SchemaRef` type with `UnmarshalYAML`
+   add a `KindSchemaRef` type with `UnmarshalYAML`
    dispatching on `yaml.Node.Kind` (scalar →
    named ref, mapping → inline body). Replace
    `KindBody.Schema map[string]any` and route
@@ -192,7 +195,7 @@ no new package. Discovery lives in
    kind/convention merges and before
    `ValidateKinds`, call `mergeSchemaFiles` then
    `resolveNamedSchemas(cfg)`. The resolver
-   replaces each kind's named `SchemaRef` with
+   replaces each kind's named `KindSchemaRef` with
    the discovered body in place. Undeclared
    names error. Unit tests cover happy path,
    undeclared name, and the inline form
@@ -204,18 +207,17 @@ no new package. Discovery lives in
    `rules.required-structure.schema:` — or plus
    `inline-schema:` — then trips the existing
    pairwise checks with "pick one source".
-6. **`internal/config`**: thread the schema
-   file's path through
-   `applyInlineSchemaSource` as `sourcePath`
-   when the inline body came from a named
-   reference. Provenance test asserts the
-   `source` key on the schema-sources entry
-   carries `.mdsmith/schemas/<name>.yaml`.
+6. **`internal/config`**: thread each schema's
+   `sourcePath` through `applyInlineSchemaSource`.
+   Provenance tests assert the `source` key
+   carries `.mdsmith/schemas/<name>.yaml` for a
+   file entry and `.mdsmith.yml` for an
+   inline-registry entry.
 7. **`internal/integration`**: contract test
    covers directory layout, basename rule,
-   subdirectory/symlink rejection, both
-   dual-source rejections, and undeclared-name
-   rejection.
+   subdirectory/symlink rejection, the two
+   dual-source rejections, inline-vs-file and
+   cross-extension collisions, undeclared names.
 8. **`internal/integration`**: parallel
    fixtures — one kind defined inline, one via
    named YAML reference, same Markdown input —
@@ -243,10 +245,12 @@ no new package. Discovery lives in
     reference as a fourth source.
 13. **Docs — conventions guide**: add
     `docs/guides/conventions.md` with H2s for
-    declaring a convention inline, the
-    top-level `convention:` selector, layering
-    rules over a preset, and the "split into a
-    file" recipe. The catalog auto-includes it.
+    built-in vs user conventions, declaring one
+    inline, the `convention:` selector, the
+    flavor-must-agree rule, layering rules over
+    a preset, and the "split into a file"
+    recipe. `mdsmith fix` regenerates the
+    CLAUDE.md catalog to include it.
 14. **Docs — architecture boundaries**: add a
     row in [cross-system.md][cs] for
     `.mdsmith/schemas/`.
@@ -294,7 +298,7 @@ no new package. Discovery lives in
       reference `.mdsmith/schemas/`.
 - [ ] `docs/guides/conventions.md` covers the
       four H2s named in task 13.
-- [ ] Unit tests cover `SchemaRef.UnmarshalYAML`,
+- [ ] Unit tests cover `KindSchemaRef.UnmarshalYAML`,
       `discoverSchemas`, `mergeSchemaFiles`,
       and `resolveNamedSchemas`.
 - [ ] All tests pass: `go test ./...`

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -23,10 +23,12 @@ summary: >-
 ## Goal
 
 A user with many kinds outgrows inline schemas.
-This plan adds `.mdsmith/schemas/`: one file per
-schema, referenced from any kind by name
-(`schema: rfc-v1`). The same schema can then drive
-multiple kinds.
+This plan adds a top-level `schemas:` registry to
+`.mdsmith.yml`, mirrored at
+`.mdsmith/schemas/<name>.yaml` — the same pattern
+plans 208/209 set for `kinds:` and `conventions:`.
+Kinds reference a schema by name
+(`schema: rfc-v1`).
 
 ## ...
 
@@ -36,25 +38,21 @@ multiple kinds.
 
 Today a kind embeds its schema inline under
 `kinds.<name>.schema:` or points at a `proto.md`.
-Inline does not share; `proto.md` shares but uses
-a different matcher grammar. A YAML file under
-`.mdsmith/schemas/` shares AND uses the plan 146
-matcher engine via
+Inline doesn't share; `proto.md` shares but uses
+a different matcher grammar. The registry
+shares AND uses the plan 146 matcher engine via
 [`schema.ParseInline`](../internal/schema/parse_inline.go).
 
 `docs/guides/conventions.md` does not exist; the
-plan adds it as a side deliverable parallel to
-[`file-kinds.md`](../docs/guides/file-kinds.md).
+plan adds it as a side deliverable.
 
 ## Non-Goals
 
 - Migrating `proto.md` to YAML.
-- Removing inline `schema:` maps.
+- Removing inline `schema:` maps on kinds.
 - Schema-file-level `extends:`.
 - Adopting `.mdsmith/schemas/` in this repo
-  (deferred until the pinned mdsmith version
-  ships the feature).
-- Auto-binding by basename.
+  (deferred until the pinned mdsmith ships it).
 
 ## Design
 
@@ -76,69 +74,61 @@ Subdirectories and symlinks are rejected. The
 
 ### Schema file shape
 
-The body parses through `schema.ParseInline`.
-Allowed top-level keys (anything else errors):
-`frontmatter`, `filename`, `closed`, `sections`,
-`cross-references`, `acronyms`, and `index`.
+A file `.mdsmith/schemas/<name>.yaml` is the
+per-file split of an inline `schemas.<name>:`
+block. The body parses through
+`schema.ParseInline`. Top-level keys allowed:
 
-```yaml
-# .mdsmith/schemas/rfc-v1.yaml
-filename: "RFC-[0-9][0-9][0-9][0-9].md"
-frontmatter:
-  id: '=~"^RFC-[0-9]{4}$"'
-  status: '"draft" | "ratified" | "deprecated"'
-closed: true
-sections:
-  - heading: null
-  - heading: "Overview"
-  - heading: "Decision"
-  - heading: "References"
-```
+- `frontmatter`
+- `filename`
+- `closed`
+- `sections`
+- `cross-references`
+- `acronyms`
+- `index`
 
-The schema's name is the basename minus
-extension, matching `[a-z][a-z0-9-]*` — the same
-rule kind and convention files carry.
+The basename is the schema's name, matching
+`[a-z][a-z0-9-]*` — same rule kind and convention
+files carry.
 
 ### Referencing from a kind
 
-A kind references a YAML schema file by name
-through the existing `schema:` key — its value
-becomes polymorphic:
+A kind's `schema:` becomes polymorphic: a string
+is a registry name, a map stays inline.
 
 ```yaml
+# .mdsmith.yml
+schemas:                    # inline equivalent of
+  rfc-v1:                   # .mdsmith/schemas/rfc-v1.yaml
+    filename: "RFC-*.md"
+    sections:
+      - heading: "Overview"
+      - heading: "Decision"
+
 kinds:
   rfc:
-    schema: rfc-v1            # resolves .mdsmith/schemas/rfc-v1.yaml
+    schema: rfc-v1          # registry reference
   rfc-internal:
-    schema: rfc-v1            # one schema drives both kinds
+    schema: rfc-v1          # one schema drives both kinds
   draft:
-    schema:                   # inline form (unchanged)
+    schema:                 # inline body still allowed
       filename: "DRAFT-*.md"
 ```
 
-The string form looks the schema up by name.
-The map form keeps its inline meaning. The
-merge layer resolves the named reference at
-config-load time. The resolved body threads
-through the same `schema-sources` plumbing
-inline schemas use today.
-
-An undeclared name errors, naming the kind and
-the missing schema.
+The merge layer resolves the registry reference
+at load time so the rule sees one inline body.
+An undeclared name errors. A name declared both
+inline under `schemas:` AND as a file errors,
+naming both — same rule as kinds and conventions.
 
 Interactions:
 
-- **`extends:`** — name references resolve to
+- **`extends:`** — registry refs resolve to
   bodies **before** `ResolveKindInlineSchema`
-  walks the chain, so parent and child schemas
-  merge via the plan 135 semantics either way.
+  walks the chain.
 - **`path-pattern:`** — runs independently from
   the resolved schema's `filename:`. Both fire
-  on a mismatch (unchanged from inline).
-- **Namespace** — schema names live in a flat
-  registry under `.mdsmith/schemas/`. A `proto.md`
-  path under `rules.required-structure.schema:`
-  is a separate source type.
+  on a mismatch.
 
 ### Mutual exclusion
 
@@ -192,10 +182,13 @@ no new package. Discovery lives in
    `[a-z][a-z0-9-]*`, no subdirs, no symlinks,
    no `.yaml`/`.yml` duplicates, no unknown
    top-level keys). Unit test per rejection.
-3. **`internal/config`**: add `Schemas
-   map[string]map[string]any` on `Config`.
-   `mergeSchemaFiles(cfg, cfgPath)` populates
-   it. `ParseBytes` skips disk discovery.
+3. **`internal/config`**: add top-level
+   `Schemas map[string]map[string]any` on
+   `Config`, populated by YAML unmarshal of
+   inline `schemas:` AND by `mergeSchemaFiles`.
+   An inline-vs-file name collision errors,
+   matching kinds/conventions. `ParseBytes`
+   skips disk discovery.
 4. **`internal/config`**: in `Load`, after the
    kind/convention merges and before
    `ValidateKinds`, call `mergeSchemaFiles` then
@@ -283,7 +276,9 @@ no new package. Discovery lives in
       message: basename outside
       `[a-z][a-z0-9-]*`, file in a subdirectory,
       symlink, duplicate basename across
-      `.yaml`/`.yml`, unknown top-level key.
+      `.yaml`/`.yml`, unknown top-level key,
+      name declared inline under `schemas:` AND
+      as a file.
 - [ ] A kind that sets a named `schema:` and
       `rules.required-structure.schema:` errors;
       same for named `schema:` and

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -22,13 +22,11 @@ summary: >-
 
 ## Goal
 
-Help an mdsmith user with a growing `.mdsmith.yml`
-factor schemas into separate files. Plans 208 and
-209 covered kinds and conventions. This plan adds
-`.mdsmith/schemas/<name>.yaml`. Any inline
-`kinds.<name>.schema:` block can lift into a
-standalone YAML file, referenced by name
-(`schema: rfc-v1`).
+A user with many kinds outgrows inline schemas.
+This plan adds `.mdsmith/schemas/`: one file per
+schema, referenced from any kind by name
+(`schema: rfc-v1`). The same schema can then drive
+multiple kinds.
 
 ## ...
 

--- a/plan/241_schema-files.md
+++ b/plan/241_schema-files.md
@@ -21,14 +21,15 @@ summary: >-
 
 ## Goal
 
-Inline schemas bloat `.mdsmith.yml` the way
-`kinds:` and `conventions:` once did. This plan
-splits each schema into its own
-`.mdsmith/schemas/<name>.yaml` — a top-level
-`schemas:` registry mirrored to a folder, the
-208/209 pattern. A kind references one by name
-(`schema: rfc-v1`); one schema can drive several
-kinds.
+Plans 208 and 209 let a crowded `kinds:` or
+`conventions:` block move into one file per entry
+under `.mdsmith/kinds/` and `.mdsmith/conventions/`.
+Inline schemas have the same problem and no such
+escape. This plan adds a top-level `schemas:`
+registry mirrored at `.mdsmith/schemas/<name>.yaml`,
+so each schema moves to its own file. A kind
+references one by name (`schema: rfc-v1`); one
+schema can drive several kinds.
 
 ## ...
 
@@ -135,11 +136,10 @@ Interactions:
 A named `schema:` resolves to a map before
 [`validateKindSchemaSources`](../internal/config/validate.go)
 runs, so a two-source kind is rejected as today.
-Every registry entry — referenced or not — is
-parsed by `schema.ParseInline` at load, so a typo
-in an unused schema still surfaces.
-`resolveNamedSchemas` collects all undeclared
-references into one error.
+A referenced schema's body is grammar-checked
+when its kind validates — the same point an
+inline schema is checked today. An undeclared
+name errors at load.
 
 ### Provenance
 
@@ -148,11 +148,13 @@ Composition per
 unchanged: each kind adds one `schema-sources`
 entry, merged by `schema.Compose`.
 
-`applyInlineSchemaSource`'s `sourcePath` is the
-schema's home. It is the `.yaml` path for a file
-entry, `.mdsmith.yml` for an inline-registry
-entry, the kind's file for an inline-on-kind
-body. "Go to schema" lands there.
+`KindSchemaRef` carries the schema's own
+`SourcePath`, set at resolution. It is the `.yaml`
+path for a file entry, `.mdsmith.yml` for an
+inline-registry entry, empty for an inline-on-kind
+body (the kind's file then applies).
+`applyInlineSchemaSource` threads it, so "go to
+schema" lands on the schema, not the kind.
 
 ## ...
 
@@ -168,9 +170,11 @@ no new package; the type change ripples from
 1. **`internal/config`** (+ `internal/kindsout`):
    add a `KindSchemaRef` type with `UnmarshalYAML`
    dispatching on `yaml.Node.Kind` (scalar →
-   named ref, mapping → inline body). Replace
-   `KindBody.Schema map[string]any` and route
-   every map reader through a `Map()` accessor:
+   named ref, mapping → inline body) plus a
+   `SourcePath` field for the schema's own origin.
+   Replace `KindBody.Schema map[string]any` and
+   route every map reader through a `Map()`
+   accessor:
    `resolvedInlineSchema`, `extendsChainSchemas`,
    `validateKindSchemaSources`,
    `effectiveExplicit`, `resolveLayerInlineSchema`,
@@ -197,10 +201,10 @@ no new package; the type change ripples from
    `ValidateKinds`, call `mergeSchemaFiles` then
    `resolveNamedSchemas(cfg)`. The resolver
    replaces each kind's named `KindSchemaRef` with
-   the discovered body in place. Undeclared
-   names error. Unit tests cover happy path,
-   undeclared name, and the inline form
-   passing through.
+   the discovered body in place and sets its
+   `SourcePath`. An undeclared name errors. Unit
+   tests cover happy path, undeclared name, and
+   the inline form passing through.
 5. **`internal/config`**: adapt
    `validateKindSchemaSources` to read
    `body.Schema.Map()` (filled by resolution).
@@ -208,8 +212,8 @@ no new package; the type change ripples from
    `rules.required-structure.schema:` — or plus
    `inline-schema:` — then trips the existing
    pairwise checks with "pick one source".
-6. **`internal/config`**: thread each schema's
-   `sourcePath` through `applyInlineSchemaSource`.
+6. **`internal/config`**: thread the ref's
+   `SourcePath` through `applyInlineSchemaSource`.
    Provenance tests assert the `source` key
    carries `.mdsmith/schemas/<name>.yaml` for a
    file entry and `.mdsmith.yml` for an


### PR DESCRIPTION
## Summary

Drafts [plan 241](plan/241_schema-files.md): lift reusable schemas out of `kinds.<name>.schema:` into standalone YAML files under `.mdsmith/schemas/<name>.yaml`, addressable by name from any kind. Same `.mdsmith/<thing>/<name>.yaml` pattern as plan 208 (kinds) and plan 209 (conventions).

> Renumbered from 238 → 241 after rebase: main landed an unrelated `cuelite phase 2` plan at 238 while this PR was open.

Design choices captured in the plan:

- **Polymorphic `schema:` key** — string = named lookup, map = inline. Keeps the user-facing model "one `schema:` per kind, three places it can live" instead of growing a parallel key.
- **Shareable across kinds** — the main reuse motivation; same schema can drive many kinds without `extends:` chains.
- **Inline `schema:` maps stay first-class** — same first-class-inline-alternative stance as plan 208/209.
- **Side deliverable**: closes the conventions docs gap with a new `docs/guides/conventions.md` mirroring [`docs/guides/file-kinds.md`](docs/guides/file-kinds.md).

The plan was hardened across three review rounds (cross-reference accuracy, design consistency, the `SchemaRef` type-bridge that ripples into `internal/kindsout`, and the provenance/byte-equal contradiction).

Depends on plans 146 (matcher engine), 208 (`.mdsmith/` directory pattern), and 209 (convention-file merge ordering).

## Test plan

- [ ] Plan file passes `mdsmith check plan/241_schema-files.md`
- [ ] `PLAN.md` catalog regenerated and passes `mdsmith check`
- [ ] Implementation lands as a follow-up branch once the plan is approved

https://claude.ai/code/session_01Hn7qp8K6yDrqcLaQSUaMRM