### PR TITLE
ci: tally unit/integration/e2e test counts in the test job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,9 +503,19 @@ jobs:
       - name: Install mdsmith
         run: go install ./cmd/mdsmith
       - name: Run tests with coverage
+        # -json streams structured events into `mdsmith-release
+        # test-summary`, which tallies the unit/integration/e2e test
+        # counts into the job summary and echoes a terse (non -v) log
+        # to the console. set -o pipefail keeps a `go test` failure
+        # fatal despite the pipe (it is also the GitHub default shell's
+        # behaviour). -coverprofile still writes unit.cov for the
+        # Codecov upload below.
         run: |
+          set -o pipefail
           mkdir -p "$GITHUB_WORKSPACE/e2e-cover"
-          E2E_COVERDIR="$GITHUB_WORKSPACE/e2e-cover" go test -covermode=atomic -coverprofile=unit.cov ./...
+          E2E_COVERDIR="$GITHUB_WORKSPACE/e2e-cover" \
+            go test -json -covermode=atomic -coverprofile=unit.cov ./... \
+            | go run ./cmd/mdsmith-release test-summary
       - name: Merge coverage profiles
         run: |
           e2e_profile="$GITHUB_WORKSPACE/e2e-cover/e2e_coverage.txt"

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -22,6 +22,7 @@
 //	mdsmith-release check-secret-rotations
 //	mdsmith-release record-rotation <ENTRY_TITLE> <YYYY-MM-DD>
 //	mdsmith-release merge-coverage -o <out> <profile>...
+//	mdsmith-release test-summary
 //	mdsmith-release bench [workdir]
 //	mdsmith-release pull-site-assets
 //	mdsmith-release sync-messaging [--check]
@@ -65,6 +66,7 @@ Commands:
   check-secret-rotations          Open GitHub issues for secrets due for rotation.
   record-rotation <title> <date>  Update lastRotated in a per-secret rotation file.
   merge-coverage -o <out> <p>...  Merge coverage profiles by summing hit counts.
+  test-summary                    Tally unit/integration/e2e tests from a go test -json stream on stdin.
   bench [workdir]                 Run the pinned cross-tool benchmark; promote JSON + fragments.
   bench-check <base> <fresh>      Fail if mdsmith regressed vs mado between two benchmark snapshots.
   pull-site-assets                Fetch the published demo GIF for the site build.
@@ -135,6 +137,8 @@ func dispatch(cmd, root string, rest []string) int {
 		return runRecordRotation(root, rest)
 	case "merge-coverage":
 		return runMergeCoverage(root, rest)
+	case "test-summary":
+		return runTestSummary(root, rest)
 	case "pull-site-assets":
 		return runPullSiteAssets(root, rest)
 	default:

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -110,6 +110,7 @@ func TestSubcommandHelpExitsZero(t *testing.T) {
 		"render-scoop-manifest",
 		"render-winget-manifest",
 		"pull-site-assets",
+		"test-summary",
 		"bench",
 		"bench-check",
 	} {
@@ -130,6 +131,7 @@ func TestSubcommandRejectsUnknownFlag(t *testing.T) {
 		"sync-channels",
 		"render-scoop-manifest",
 		"render-winget-manifest",
+		"test-summary",
 	} {
 		assert.Equal(t, 2, run([]string{sub, "--bogus"}), "%s --bogus", sub)
 	}

--- a/cmd/mdsmith-release/testsummary.go
+++ b/cmd/mdsmith-release/testsummary.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/jeduden/mdsmith/internal/release"
+)
+
+// runTestSummary reads a `go test -json` stream on stdin, echoes a
+// terse test log to stdout, and appends a per-layer count table to
+// the GitHub step summary (or prints it when run outside CI).
+func runTestSummary(root string, args []string) int {
+	fs := flag.NewFlagSet("test-summary", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			"Usage: go test -json ./... | mdsmith-release test-summary\n\n"+
+				"Read a `go test -json` event stream on stdin, re-emit a\n"+
+				"terse test log to stdout, and append a unit/integration/e2e\n"+
+				"count table to $GITHUB_STEP_SUMMARY (or print it when the\n"+
+				"variable is unset). Tests are classified by file location:\n"+
+				"internal/integration is the integration layer, *e2e*_test.go\n"+
+				"files are the e2e layer, everything else is unit.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: test-summary"); code >= 0 {
+			return code
+		}
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	counts, err := release.SummarizeTestRun(root, os.Stdin, os.Stdout)
+	if err != nil {
+		return reportError(err)
+	}
+	table := release.RenderTestSummaryMarkdown(counts)
+	if path := os.Getenv("GITHUB_STEP_SUMMARY"); path != "" {
+		if err := appendFile(path, table); err != nil {
+			return reportError(err)
+		}
+		// The table is on the summary page; keep the console to a recap.
+		fmt.Print(release.RenderTestSummaryLine(counts))
+	} else {
+		fmt.Print(table)
+	}
+	return 0
+}
+
+// appendFile appends s to the file at path, creating it if needed.
+func appendFile(path, s string) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck // append-only; write error is reported below
+	_, err = io.WriteString(f, s)
+	return err
+}

--- a/cmd/mdsmith-release/testsummary_test.go
+++ b/cmd/mdsmith-release/testsummary_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// feedStdin replaces os.Stdin with a pipe carrying s for the
+// duration of the test, restoring the real stdin on cleanup.
+func feedStdin(t *testing.T, s string) {
+	t.Helper()
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Stdin = old })
+	os.Stdin = r
+	go func() {
+		_, _ = io.WriteString(w, s)
+		_ = w.Close()
+	}()
+}
+
+// writeMiniModule lays down a one-package module whose single unit
+// test matches the miniStream event below.
+func writeMiniModule(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/m\n\ngo 1.24\n"), 0o644))
+	foo := filepath.Join(root, "foo")
+	require.NoError(t, os.MkdirAll(foo, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(foo, "foo_test.go"),
+		[]byte("package foo\nimport \"testing\"\nfunc TestU(t *testing.T) {}\n"), 0o644))
+	return root
+}
+
+const miniStream = `{"Action":"pass","Package":"example.com/m/foo","Test":"TestU"}` + "\n"
+
+// chdir changes into dir for the test, restoring the prior working
+// directory on cleanup.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	require.NoError(t, os.Chdir(dir))
+}
+
+// TestRunTestSummaryWritesStepSummary dispatches `run test-summary`
+// with a json stream on stdin and GITHUB_STEP_SUMMARY set, asserting
+// the count table lands in the summary file.
+func TestRunTestSummaryWritesStepSummary(t *testing.T) {
+	chdir(t, writeMiniModule(t))
+	summary := filepath.Join(t.TempDir(), "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summary)
+	feedStdin(t, miniStream)
+
+	assert.Equal(t, 0, run([]string{"test-summary"}))
+
+	data, err := os.ReadFile(summary)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "## Test suite")
+	assert.Contains(t, string(data), "| Unit | 1 | 1 |")
+}
+
+// TestRunTestSummaryPrintsTableWithoutCI covers the branch taken when
+// GITHUB_STEP_SUMMARY is unset: the table is printed to stdout.
+func TestRunTestSummaryPrintsTableWithoutCI(t *testing.T) {
+	chdir(t, writeMiniModule(t))
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	feedStdin(t, miniStream)
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	code := run([]string{"test-summary"})
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	assert.Equal(t, 0, code)
+	assert.Contains(t, buf.String(), "## Test suite")
+	assert.Contains(t, buf.String(), "| Unit | 1 | 1 |")
+}
+
+// TestRunTestSummaryRejectsArgs covers the arity guard (positional
+// args are not accepted; input arrives on stdin).
+func TestRunTestSummaryRejectsArgs(t *testing.T) {
+	assert.Equal(t, 2, run([]string{"test-summary", "extra"}))
+}
+
+// TestRunTestSummaryReportsError covers the reportError branch: with
+// no go.mod in cwd the source scan fails and the subcommand exits 1.
+func TestRunTestSummaryReportsError(t *testing.T) {
+	chdir(t, t.TempDir())
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	feedStdin(t, miniStream)
+	assert.Equal(t, 1, run([]string{"test-summary"}))
+}
+
+// TestRunTestSummaryAppendError covers the appendFile error branch:
+// GITHUB_STEP_SUMMARY points under a regular file, so the summary
+// cannot be written and the subcommand exits 1.
+func TestRunTestSummaryAppendError(t *testing.T) {
+	chdir(t, writeMiniModule(t))
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+	t.Setenv("GITHUB_STEP_SUMMARY", filepath.Join(blocker, "sub", "s.md"))
+	feedStdin(t, miniStream)
+	assert.Equal(t, 1, run([]string{"test-summary"}))
+}
+
+func TestAppendFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.md")
+	require.NoError(t, appendFile(p, "a"))
+	require.NoError(t, appendFile(p, "b"))
+	data, err := os.ReadFile(p)
+	require.NoError(t, err)
+	assert.Equal(t, "ab", string(data))
+
+	// A path that cannot be created surfaces an error.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+	assert.Error(t, appendFile(filepath.Join(blocker, "sub", "f.md"), "data"))
+}

--- a/docs/development/release-tooling.md
+++ b/docs/development/release-tooling.md
@@ -64,6 +64,7 @@ setup step.
 | `check-secret-rotations`     | `secret-rotation-reminder.yml`                                    |
 | `record-rotation <t> <d>`    | `record-secret-rotation.yml`                                      |
 | `merge-coverage -o <o> <p>`  | `ci.yml` test job                                                 |
+| `test-summary`               | `ci.yml` test job                                                 |
 | `bench [workdir]`            | `benchmark.yml` record; `release.yml` benchmark-publish; `run.sh` |
 | `bench-check <base> <fresh>` | `release.yml` benchmark-publish + bench-regression-gate           |
 | `pull-site-assets`           | `pages.yml` deploy job                                            |

--- a/internal/release/testsummary.go
+++ b/internal/release/testsummary.go
@@ -81,12 +81,10 @@ func SummarizeTestRun(srcRoot string, r io.Reader, logOut io.Writer) (TestCounts
 	// so leaf (case) counting can exclude container nodes.
 	results := make(map[testKey]TestLayer)
 	hasChild := make(map[testKey]bool)
+	log := newTerseLog(logOut)
 
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
-	out := bufio.NewWriter(logOut)
-	defer out.Flush() //nolint:errcheck // best-effort log echo
-
 	for sc.Scan() {
 		line := sc.Bytes()
 		if len(line) == 0 {
@@ -94,45 +92,126 @@ func SummarizeTestRun(srcRoot string, r io.Reader, logOut io.Writer) (TestCounts
 		}
 		var ev testEvent
 		if err := json.Unmarshal(line, &ev); err != nil {
-			// A line that opens with `{` but does not parse is a
-			// mangled event from `go test -json`'s rare cross-package
-			// write interleaving; drop it so the terse log stays clean
-			// (the package result line still reports the outcome). Any
-			// other unparseable line — a `go: downloading …` notice or
-			// stray stdout text — is echoed so nothing is swallowed.
-			if !startsWithBrace(line) {
-				_, _ = out.Write(line)
-				_ = out.WriteByte('\n')
-			}
+			log.passthrough(line)
 			continue
 		}
 		switch ev.Action {
 		case "output":
-			if keepTerseOutput(ev.Output) {
-				_, _ = out.WriteString(ev.Output)
-			}
+			log.output(ev)
 		case "pass", "fail", "skip":
-			if ev.Test == "" {
-				continue
+			log.terminal(ev)
+			if ev.Test != "" {
+				recordResult(results, hasChild, layers, ev)
 			}
-			parent := ev.Test
-			if i := strings.IndexByte(parent, '/'); i >= 0 {
-				parent = parent[:i]
-			}
-			layer, ok := layers[testKey{ev.Package, parent}]
-			if !ok {
-				// A test the source scan did not classify (e.g. a
-				// generated suite) falls to the pyramid base.
-				layer = LayerUnit
-			}
-			results[testKey{ev.Package, ev.Test}] = layer
-			markAncestors(hasChild, ev.Package, ev.Test)
 		}
 	}
+	log.flush()
 	if err := sc.Err(); err != nil {
 		return TestCounts{}, fmt.Errorf("reading test json: %w", err)
 	}
 	return tallyCounts(results, hasChild), nil
+}
+
+// terseLog reconstructs a non-verbose `go test` console log from a
+// -json stream. `go test -json` forces the test binary into verbose
+// mode, so the stream carries every test's output even on success.
+// Plain `go test` instead hides a passing test's output and shows it
+// only on failure; terseLog reproduces that by buffering each test's
+// output under its top-level test and emitting it only if that test
+// fails. Package-level lines (the `ok pkg` / `FAIL pkg` results and
+// build errors) pass through immediately.
+type terseLog struct {
+	out *bufio.Writer
+	buf map[testKey][]string
+}
+
+func newTerseLog(w io.Writer) *terseLog {
+	return &terseLog{out: bufio.NewWriter(w), buf: make(map[testKey][]string)}
+}
+
+// passthrough echoes a non-JSON line (e.g. a `go: downloading …`
+// notice) verbatim, but drops a `{`-led line — a mangled event from
+// `go test -json`'s rare cross-package write interleaving — so the
+// log never shows half a JSON record.
+func (l *terseLog) passthrough(line []byte) {
+	if startsWithBrace(line) {
+		return
+	}
+	_, _ = l.out.Write(line)
+	_ = l.out.WriteByte('\n')
+}
+
+// output routes one "output" event: verbose scaffolding is dropped,
+// a package-level line is shown now, and a test-attributed line is
+// buffered under its top-level test until that test resolves.
+func (l *terseLog) output(ev testEvent) {
+	if !keepTerseOutput(ev.Output) {
+		return
+	}
+	if ev.Test == "" {
+		_, _ = l.out.WriteString(ev.Output)
+		return
+	}
+	key := testKey{ev.Package, topLevelTest(ev.Test)}
+	l.buf[key] = append(l.buf[key], ev.Output)
+}
+
+// terminal handles a pass/fail/skip event: when a top-level test
+// resolves it flushes that test's buffered output on failure and
+// drops it otherwise. Subtest events wait for their parent, whose
+// buffer already holds their output.
+func (l *terseLog) terminal(ev testEvent) {
+	if ev.Test == "" || strings.Contains(ev.Test, "/") {
+		return
+	}
+	key := testKey{ev.Package, ev.Test}
+	if ev.Action == "fail" {
+		for _, line := range l.buf[key] {
+			_, _ = l.out.WriteString(line)
+		}
+	}
+	delete(l.buf, key)
+}
+
+// flush emits any output still buffered for tests that never
+// reached a terminal event — a panic that aborts the package leaves
+// its output unresolved, and hiding it would lose the crash — then
+// flushes the underlying writer.
+func (l *terseLog) flush() {
+	for _, lines := range l.buf {
+		for _, line := range lines {
+			_, _ = l.out.WriteString(line)
+		}
+	}
+	l.buf = nil
+	_ = l.out.Flush()
+}
+
+// topLevelTest returns the parent test name — everything before the
+// first '/' — under which a test and all its subtests share one
+// output buffer and one layer classification.
+func topLevelTest(test string) string {
+	if i := strings.IndexByte(test, '/'); i >= 0 {
+		return test[:i]
+	}
+	return test
+}
+
+// recordResult files one terminal test result under its pyramid
+// layer (defaulting to unit when the source scan did not classify
+// it) and marks its ancestors as non-leaf.
+func recordResult(
+	results map[testKey]TestLayer,
+	hasChild map[testKey]bool,
+	layers map[testKey]TestLayer,
+	ev testEvent,
+) {
+	layer, ok := layers[testKey{ev.Package, topLevelTest(ev.Test)}]
+	if !ok {
+		layer = LayerUnit
+	}
+	results[testKey{ev.Package, ev.Test}] = layer
+	markAncestors(hasChild, ev.Package, ev.Test)
 }
 
 // tallyCounts reduces the recorded terminal results into per-layer

--- a/internal/release/testsummary.go
+++ b/internal/release/testsummary.go
@@ -233,10 +233,9 @@ func scanTestLayers(root string) (map[testKey]TestLayer, error) {
 		if !strings.HasSuffix(d.Name(), "_test.go") {
 			return nil
 		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return relErr
-		}
+		// path is always rooted at root, so trimming the prefix is
+		// exact and avoids filepath.Rel's unreachable error branch.
+		rel := strings.TrimPrefix(strings.TrimPrefix(path, root), string(os.PathSeparator))
 		layer := layerForTestFile(rel)
 		pkg := importPath(module, filepath.Dir(rel))
 		names, scanErr := scanTestFuncNames(path)

--- a/internal/release/testsummary.go
+++ b/internal/release/testsummary.go
@@ -409,16 +409,24 @@ func readModulePath(root string) (string, error) {
 // section: one row per pyramid layer with its function and case
 // counts, then a bold total row.
 func RenderTestSummaryMarkdown(c TestCounts) string {
+	totF := c.Functions[LayerUnit] + c.Functions[LayerIntegration] + c.Functions[LayerE2E]
+	totC := c.Cases[LayerUnit] + c.Cases[LayerIntegration] + c.Cases[LayerE2E]
 	var b strings.Builder
 	b.WriteString("## Test suite\n\n")
+	// Lead with a bold one-line headline so the counts read at a
+	// glance at the top of the job-summary panel, above the table.
+	fmt.Fprintf(&b, "**%s test functions** — %s unit · %s integration · %s end-to-end "+
+		"· **%s cases** including subtests\n\n",
+		thousands(totF),
+		thousands(c.Functions[LayerUnit]),
+		thousands(c.Functions[LayerIntegration]),
+		thousands(c.Functions[LayerE2E]),
+		thousands(totC))
 	b.WriteString("| Layer | Test functions | Test cases |\n")
 	b.WriteString("| --- | --: | --: |\n")
-	var totF, totC int
 	for _, layer := range testLayerOrder {
-		fn, cs := c.Functions[layer], c.Cases[layer]
-		totF += fn
-		totC += cs
-		fmt.Fprintf(&b, "| %s | %s | %s |\n", layerLabel(layer), thousands(fn), thousands(cs))
+		fmt.Fprintf(&b, "| %s | %s | %s |\n",
+			layerLabel(layer), thousands(c.Functions[layer]), thousands(c.Cases[layer]))
 	}
 	fmt.Fprintf(&b, "| **Total** | **%s** | **%s** |\n", thousands(totF), thousands(totC))
 	b.WriteString("\n*Test functions count top-level `func Test…`; " +

--- a/internal/release/testsummary.go
+++ b/internal/release/testsummary.go
@@ -1,0 +1,392 @@
+package release
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// TestLayer names one rung of the test pyramid documented in
+// docs/development/architecture/tests.md.
+type TestLayer string
+
+const (
+	// LayerUnit is a test that lives next to its source and exercises
+	// one function or method.
+	LayerUnit TestLayer = "unit"
+	// LayerIntegration is a test under internal/integration that
+	// composes several packages against real fixtures (its contract
+	// tests included).
+	LayerIntegration TestLayer = "integration"
+	// LayerE2E is a test that drives the built binary or otherwise
+	// exercises the full process boundary.
+	LayerE2E TestLayer = "e2e"
+)
+
+// testLayerOrder is the fixed display order — the pyramid base
+// (unit) first, its apex (e2e) last.
+var testLayerOrder = []TestLayer{LayerUnit, LayerIntegration, LayerE2E}
+
+// TestCounts holds, per layer, the number of top-level test
+// functions and the number of test cases. Functions answers "how
+// many `func Test…` ran"; Cases counts each leaf subtest, so a
+// fixture-driven layer like internal/integration reports far more
+// cases than functions.
+type TestCounts struct {
+	Functions map[TestLayer]int
+	Cases     map[TestLayer]int
+}
+
+// testKey identifies a top-level test function by its package import
+// path and name.
+type testKey struct {
+	pkg  string
+	name string
+}
+
+// testFuncRe matches a top-level test entry point at column zero:
+// Test*, Example*, or Fuzz*. A method (`func (r R) TestX`) has a
+// receiver between `func ` and the name, so it never matches —
+// only package-level functions are recorded.
+var testFuncRe = regexp.MustCompile(`^func ((?:Test|Example|Fuzz)[A-Za-z0-9_]*)\(`)
+
+// testEvent is the subset of a `go test -json` event we read.
+type testEvent struct {
+	Action  string
+	Package string
+	Test    string
+	Output  string
+}
+
+// SummarizeTestRun reads a `go test -json` event stream from r,
+// echoing a terse (non-`-v`) reconstruction of the test log to
+// logOut as it streams, and returns the per-layer test counts.
+// srcRoot is the module root whose *_test.go files classify each
+// executed test by file location.
+func SummarizeTestRun(srcRoot string, r io.Reader, logOut io.Writer) (TestCounts, error) {
+	layers, err := scanTestLayers(srcRoot)
+	if err != nil {
+		return TestCounts{}, err
+	}
+
+	// results records the layer of every (pkg,test) that reached a
+	// terminal action; hasChild marks every test that owns a subtest
+	// so leaf (case) counting can exclude container nodes.
+	results := make(map[testKey]TestLayer)
+	hasChild := make(map[testKey]bool)
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	out := bufio.NewWriter(logOut)
+	defer out.Flush() //nolint:errcheck // best-effort log echo
+
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev testEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// A line that opens with `{` but does not parse is a
+			// mangled event from `go test -json`'s rare cross-package
+			// write interleaving; drop it so the terse log stays clean
+			// (the package result line still reports the outcome). Any
+			// other unparseable line — a `go: downloading …` notice or
+			// stray stdout text — is echoed so nothing is swallowed.
+			if !startsWithBrace(line) {
+				_, _ = out.Write(line)
+				_ = out.WriteByte('\n')
+			}
+			continue
+		}
+		switch ev.Action {
+		case "output":
+			if keepTerseOutput(ev.Output) {
+				_, _ = out.WriteString(ev.Output)
+			}
+		case "pass", "fail", "skip":
+			if ev.Test == "" {
+				continue
+			}
+			parent := ev.Test
+			if i := strings.IndexByte(parent, '/'); i >= 0 {
+				parent = parent[:i]
+			}
+			layer, ok := layers[testKey{ev.Package, parent}]
+			if !ok {
+				// A test the source scan did not classify (e.g. a
+				// generated suite) falls to the pyramid base.
+				layer = LayerUnit
+			}
+			results[testKey{ev.Package, ev.Test}] = layer
+			markAncestors(hasChild, ev.Package, ev.Test)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return TestCounts{}, fmt.Errorf("reading test json: %w", err)
+	}
+	return tallyCounts(results, hasChild), nil
+}
+
+// tallyCounts reduces the recorded terminal results into per-layer
+// counts: a result whose name has no '/' is a top-level function,
+// and a result with no recorded child is a leaf case.
+func tallyCounts(results map[testKey]TestLayer, hasChild map[testKey]bool) TestCounts {
+	counts := TestCounts{
+		Functions: make(map[TestLayer]int),
+		Cases:     make(map[TestLayer]int),
+	}
+	for key, layer := range results {
+		if !strings.Contains(key.name, "/") {
+			counts.Functions[layer]++
+		}
+		if !hasChild[key] {
+			counts.Cases[layer]++
+		}
+	}
+	return counts
+}
+
+// startsWithBrace reports whether the first non-space byte of line
+// is '{' — the opening of a (here, mangled) JSON event.
+func startsWithBrace(line []byte) bool {
+	for _, b := range line {
+		if b == ' ' || b == '\t' {
+			continue
+		}
+		return b == '{'
+	}
+	return false
+}
+
+// markAncestors flags every ancestor of test (TestA, TestA/b, …) as
+// a non-leaf so case counting credits only the leaf subtests.
+func markAncestors(hasChild map[testKey]bool, pkg, test string) {
+	for i := 0; i < len(test); i++ {
+		if test[i] == '/' {
+			hasChild[testKey{pkg, test[:i]}] = true
+		}
+	}
+}
+
+// keepTerseOutput reports whether a `go test -json` output line
+// belongs in a non-`-v` log. `-json` forces the test binary into
+// verbose mode, so the stream carries the per-test scaffolding that
+// a plain `go test` hides; dropping it reconstructs the terse log
+// (package result lines and any failure detail) the CI job showed
+// before this command was introduced.
+func keepTerseOutput(s string) bool {
+	t := strings.TrimLeft(s, " \t")
+	switch {
+	case strings.HasPrefix(t, "=== RUN"),
+		strings.HasPrefix(t, "=== PAUSE"),
+		strings.HasPrefix(t, "=== CONT"),
+		strings.HasPrefix(t, "=== NAME"),
+		strings.HasPrefix(t, "--- PASS:"),
+		strings.HasPrefix(t, "--- SKIP:"),
+		t == "PASS\n",
+		t == "PASS":
+		return false
+	}
+	return true
+}
+
+// scanTestLayers walks the module rooted at root and returns the
+// pyramid layer of every top-level test function, keyed by import
+// path and name. Nested modules (their own go.mod) and the
+// directories the go tool never compiles — testdata, node_modules,
+// and names beginning with "." or "_" — are skipped so the map
+// matches what `go test ./...` actually runs.
+func scanTestLayers(root string) (map[testKey]TestLayer, error) {
+	module, err := readModulePath(root)
+	if err != nil {
+		return nil, err
+	}
+	layers := make(map[testKey]TestLayer)
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if path == root {
+				return nil
+			}
+			name := d.Name()
+			if name == "testdata" || name == "node_modules" ||
+				strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+				return fs.SkipDir
+			}
+			// A nested module is built by its own `go test` run, not by
+			// the root `./...`, so its tests are out of this tally.
+			if _, statErr := os.Stat(filepath.Join(path, "go.mod")); statErr == nil {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		layer := layerForTestFile(rel)
+		pkg := importPath(module, filepath.Dir(rel))
+		names, scanErr := scanTestFuncNames(path)
+		if scanErr != nil {
+			return scanErr
+		}
+		for _, n := range names {
+			layers[testKey{pkg, n}] = layer
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return layers, nil
+}
+
+// layerForTestFile classifies a repo-root-relative *_test.go path
+// into a pyramid layer, matching the tree layout in
+// docs/development/architecture/tests.md: internal/integration is the
+// integration layer, an `*e2e*_test.go` file (or any file under an
+// e2e/ directory) is the e2e layer, and everything else is a unit
+// test living beside its source.
+func layerForTestFile(rel string) TestLayer {
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "internal/integration/") {
+		return LayerIntegration
+	}
+	segs := strings.Split(rel, "/")
+	for _, s := range segs[:len(segs)-1] {
+		if s == "e2e" {
+			return LayerE2E
+		}
+	}
+	if strings.Contains(strings.ToLower(segs[len(segs)-1]), "e2e") {
+		return LayerE2E
+	}
+	return LayerUnit
+}
+
+// importPath joins a module path and a repo-relative directory into
+// the package import path the `go test -json` Package field carries.
+func importPath(module, relDir string) string {
+	relDir = filepath.ToSlash(relDir)
+	if relDir == "." || relDir == "" {
+		return module
+	}
+	return module + "/" + relDir
+}
+
+// scanTestFuncNames returns the names of every top-level test entry
+// point declared in a Go file.
+func scanTestFuncNames(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // read-only
+
+	var names []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		if m := testFuncRe.FindSubmatch(sc.Bytes()); m != nil {
+			names = append(names, string(m[1]))
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return names, nil
+}
+
+// readModulePath returns the module path from root/go.mod. It reads
+// only the `module` line so it needs no module-file dependency and
+// never promotes one from indirect to direct.
+func readModulePath(root string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", fmt.Errorf("no module path in %s", filepath.Join(root, "go.mod"))
+}
+
+// RenderTestSummaryMarkdown formats counts as a GitHub step-summary
+// section: one row per pyramid layer with its function and case
+// counts, then a bold total row.
+func RenderTestSummaryMarkdown(c TestCounts) string {
+	var b strings.Builder
+	b.WriteString("## Test suite\n\n")
+	b.WriteString("| Layer | Test functions | Test cases |\n")
+	b.WriteString("| --- | --: | --: |\n")
+	var totF, totC int
+	for _, layer := range testLayerOrder {
+		fn, cs := c.Functions[layer], c.Cases[layer]
+		totF += fn
+		totC += cs
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", layerLabel(layer), thousands(fn), thousands(cs))
+	}
+	fmt.Fprintf(&b, "| **Total** | **%s** | **%s** |\n", thousands(totF), thousands(totC))
+	b.WriteString("\n*Test functions count top-level `func Test…`; " +
+		"test cases count each leaf subtest (e.g. one per fixture), " +
+		"so fixture-driven layers report more cases than functions.*\n")
+	return b.String()
+}
+
+// RenderTestSummaryLine is the one-line console recap printed
+// alongside the step-summary table.
+func RenderTestSummaryLine(c TestCounts) string {
+	return fmt.Sprintf(
+		"test summary: %s functions, %s cases "+
+			"(unit %s, integration %s, e2e %s functions)\n",
+		thousands(c.Functions[LayerUnit]+c.Functions[LayerIntegration]+c.Functions[LayerE2E]),
+		thousands(c.Cases[LayerUnit]+c.Cases[LayerIntegration]+c.Cases[LayerE2E]),
+		thousands(c.Functions[LayerUnit]),
+		thousands(c.Functions[LayerIntegration]),
+		thousands(c.Functions[LayerE2E]),
+	)
+}
+
+// layerLabel is the human-readable column label for a layer.
+func layerLabel(l TestLayer) string {
+	switch l {
+	case LayerUnit:
+		return "Unit"
+	case LayerIntegration:
+		return "Integration"
+	case LayerE2E:
+		return "End-to-end"
+	default:
+		return string(l)
+	}
+}
+
+// thousands renders a non-negative count with comma group
+// separators (1234 → "1,234").
+func thousands(n int) string {
+	s := strconv.Itoa(n)
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/internal/release/testsummary_chmod_unix_test.go
+++ b/internal/release/testsummary_chmod_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScanTestLayersWalkError drives scanTestLayers' walk-error
+// branch by chmod-ing a subdirectory unreadable so WalkDir's
+// ReadDir fails. It mirrors channels_chmod_unix_test.go: the chmod
+// permission semantics are not portable to Windows, and root
+// bypasses them, so the file is Unix-tagged and the test skips when
+// running as root.
+func TestScanTestLayersWalkError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based readonly test is unreliable as root")
+	}
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/m\n"), 0o644))
+	locked := filepath.Join(root, "locked")
+	require.NoError(t, os.MkdirAll(locked, 0o755))
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	_, err := scanTestLayers(root)
+	assert.Error(t, err)
+}

--- a/internal/release/testsummary_test.go
+++ b/internal/release/testsummary_test.go
@@ -176,8 +176,8 @@ func TestSummarizeTestRun(t *testing.T) {
 
 	logStr := log.String()
 	assert.Contains(t, logStr, "ok  \texample.com/m/foo")
-	assert.Contains(t, logStr, "hello from log")
 	assert.Contains(t, logStr, "go: downloading example.com/x")
+	assert.NotContains(t, logStr, "hello from log", "a passing test's output is hidden")
 	assert.NotContains(t, logStr, "=== RUN")
 	assert.NotContains(t, logStr, "--- PASS:")
 	assert.NotContains(t, logStr, `"Action":"output"`, "mangled event must not leak")
@@ -196,6 +196,50 @@ func TestSummarizeTestRunUnclassifiedFallsToUnit(t *testing.T) {
 func TestSummarizeTestRunErrorsWithoutModule(t *testing.T) {
 	_, err := SummarizeTestRun(t.TempDir(), strings.NewReader(""), &bytes.Buffer{})
 	assert.Error(t, err)
+}
+
+// TestSummarizeTestRunLogHidesPassShowsFail pins the terse-log
+// contract: a passing test's output (including a noisy multi-line
+// dump like a CLI usage block) is hidden, while a failing test's
+// output — and a failing subtest's, via the parent — is shown.
+func TestSummarizeTestRunLogHidesPassShowsFail(t *testing.T) {
+	root := writeTestModule(t)
+	var s strings.Builder
+	// Passing test prints a usage-like block — must be hidden.
+	s.WriteString(evLine(t, "output", "example.com/m/foo", "TestU", "    Usage: do the thing\n"))
+	s.WriteString(evLine(t, "output", "example.com/m/foo", "TestU", "    build-website [--no-fix]\n"))
+	s.WriteString(evLine(t, "pass", "example.com/m/foo", "TestU", ""))
+	// Failing test with a detail line and a failing subtest — shown.
+	s.WriteString(evLine(t, "output", "example.com/m/foo", "TestBoom", "    foo_test.go:9: boom detail\n"))
+	s.WriteString(evLine(t, "output", "example.com/m/foo", "TestBoom/case", "    sub detail\n"))
+	s.WriteString(evLine(t, "fail", "example.com/m/foo", "TestBoom/case", ""))
+	s.WriteString(evLine(t, "output", "example.com/m/foo", "TestBoom", "--- FAIL: TestBoom (0.00s)\n"))
+	s.WriteString(evLine(t, "fail", "example.com/m/foo", "TestBoom", ""))
+	// Package result line — always shown.
+	s.WriteString(evLine(t, "output", "example.com/m/foo", "", "FAIL\texample.com/m/foo\t0.01s\n"))
+
+	var log bytes.Buffer
+	_, err := SummarizeTestRun(root, strings.NewReader(s.String()), &log)
+	require.NoError(t, err)
+	out := log.String()
+	assert.NotContains(t, out, "Usage: do the thing", "passing test output hidden")
+	assert.NotContains(t, out, "build-website", "passing test output hidden")
+	assert.Contains(t, out, "boom detail", "failing test output shown")
+	assert.Contains(t, out, "sub detail", "failing subtest output shown via parent")
+	assert.Contains(t, out, "--- FAIL: TestBoom")
+	assert.Contains(t, out, "FAIL\texample.com/m/foo")
+}
+
+// TestSummarizeTestRunLogFlushesUnresolved covers the flush of output
+// for a test that never reaches a terminal event — a panic aborts the
+// package, and that crash must not be swallowed.
+func TestSummarizeTestRunLogFlushesUnresolved(t *testing.T) {
+	root := writeTestModule(t)
+	s := evLine(t, "output", "example.com/m/foo", "TestPanic", "panic: boom\n")
+	var log bytes.Buffer
+	_, err := SummarizeTestRun(root, strings.NewReader(s), &log)
+	require.NoError(t, err)
+	assert.Contains(t, log.String(), "panic: boom")
 }
 
 // errReader fails on the first read so the scanner surfaces a

--- a/internal/release/testsummary_test.go
+++ b/internal/release/testsummary_test.go
@@ -3,6 +3,7 @@ package release
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,6 +154,8 @@ func TestSummarizeTestRun(t *testing.T) {
 	stream.WriteString(evLine(t, "pass", ip, "TestIt", ""))
 	// E2E: one function.
 	stream.WriteString(evLine(t, "pass", "example.com/m/cmd/app", "TestE2EThing", ""))
+	// A package-level pass (empty Test) is skipped, not counted.
+	stream.WriteString(evLine(t, "pass", "example.com/m/foo", "", ""))
 	// A mangled JSON event (drop from log, do not count).
 	stream.WriteString(`{"Time":"x","Action":"output","Package":"example.com/m/foo","Test":"TestU` + "\n")
 	// A genuine non-JSON notice (echo to log).
@@ -192,6 +195,37 @@ func TestSummarizeTestRunUnclassifiedFallsToUnit(t *testing.T) {
 
 func TestSummarizeTestRunErrorsWithoutModule(t *testing.T) {
 	_, err := SummarizeTestRun(t.TempDir(), strings.NewReader(""), &bytes.Buffer{})
+	assert.Error(t, err)
+}
+
+// errReader fails on the first read so the scanner surfaces a
+// non-EOF error.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom") }
+
+func TestSummarizeTestRunScannerError(t *testing.T) {
+	_, err := SummarizeTestRun(writeTestModule(t), errReader{}, &bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading test json")
+}
+
+// TestScanTestLayersScanError drives the propagation of a per-file
+// scan failure: a _test.go line longer than scanTestFuncNames'
+// 1 MiB token cap makes the scanner return bufio.ErrTooLong, which
+// must surface as an error from scanTestLayers.
+func TestScanTestLayersScanError(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/m\n"), 0o644))
+	huge := append([]byte("// "), bytes.Repeat([]byte("a"), 2*1024*1024)...)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "huge_test.go"), huge, 0o644))
+
+	_, err := scanTestLayers(root)
+	require.Error(t, err)
+
+	// The same oversized line trips scanTestFuncNames directly.
+	_, err = scanTestFuncNames(filepath.Join(root, "huge_test.go"))
 	assert.Error(t, err)
 }
 

--- a/internal/release/testsummary_test.go
+++ b/internal/release/testsummary_test.go
@@ -1,0 +1,309 @@
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLayerForTestFile(t *testing.T) {
+	cases := []struct {
+		rel  string
+		want TestLayer
+	}{
+		{"internal/integration/rules_test.go", LayerIntegration},
+		{"internal/integration/sub/contract_test.go", LayerIntegration},
+		{"cmd/mdsmith/e2e_test.go", LayerE2E},
+		{"cmd/mdsmith/explain_e2e_test.go", LayerE2E},
+		{"some/pkg/e2e/walk_test.go", LayerE2E},
+		{"cmd/mdsmith/lsp_test.go", LayerUnit},
+		{"cmd/mdsmith/main_unit_test.go", LayerUnit},
+		{"internal/rules/foo/foo_test.go", LayerUnit},
+		{"pkg/markdown/parse_test.go", LayerUnit},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, layerForTestFile(c.rel), c.rel)
+	}
+}
+
+func TestImportPath(t *testing.T) {
+	const m = "example.com/m"
+	assert.Equal(t, m, importPath(m, "."))
+	assert.Equal(t, m, importPath(m, ""))
+	assert.Equal(t, m+"/cmd/app", importPath(m, "cmd/app"))
+	assert.Equal(t, m+"/cmd/app", importPath(m, filepath.FromSlash("cmd/app")))
+}
+
+func TestReadModulePath(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/m\n\ngo 1.24\n"), 0o644))
+	got, err := readModulePath(root)
+	require.NoError(t, err)
+	assert.Equal(t, "example.com/m", got)
+
+	// Missing go.mod is an error.
+	_, err = readModulePath(t.TempDir())
+	assert.Error(t, err)
+
+	// A go.mod without a module line is an error.
+	noMod := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(noMod, "go.mod"),
+		[]byte("go 1.24\n"), 0o644))
+	_, err = readModulePath(noMod)
+	assert.Error(t, err)
+}
+
+func TestScanTestFuncNames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x_test.go")
+	src := "package x\n\n" +
+		"import \"testing\"\n\n" +
+		"func TestAlpha(t *testing.T) {}\n" +
+		"func ExampleBeta() {}\n" +
+		"func FuzzGamma(f *testing.F) {}\n" +
+		"func (r recv) TestMethodNotCounted() {}\n" +
+		"func helperNotCounted() {}\n" +
+		"func Outer() {\n\tfunc() { _ = \"not a TestNested\" }()\n}\n"
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	names, err := scanTestFuncNames(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"TestAlpha", "ExampleBeta", "FuzzGamma"}, names)
+
+	_, err = scanTestFuncNames(filepath.Join(dir, "missing_test.go"))
+	assert.Error(t, err)
+}
+
+// writeTestModule lays down a small module tree exercising every
+// classification and skip rule, and returns its root.
+func writeTestModule(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, body string) {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+	write("go.mod", "module example.com/m\n\ngo 1.24\n")
+	write("foo/foo_test.go", "package foo\nimport \"testing\"\nfunc TestU(t *testing.T) {}\n")
+	write("internal/integration/it_test.go",
+		"package integration\nimport \"testing\"\nfunc TestIt(t *testing.T) {}\n")
+	write("cmd/app/e2e_test.go", "package app\nimport \"testing\"\nfunc TestE2EThing(t *testing.T) {}\n")
+	// Skipped: testdata, nested module, dot-dir.
+	write("foo/testdata/ignored_test.go", "package x\nfunc TestSkippedTestdata() {}\n")
+	write("sub/go.mod", "module example.com/sub\n")
+	write("sub/nested_test.go", "package sub\nfunc TestSkippedNested() {}\n")
+	write(".hidden/h_test.go", "package h\nfunc TestSkippedHidden() {}\n")
+	return root
+}
+
+func TestScanTestLayers(t *testing.T) {
+	root := writeTestModule(t)
+	layers, err := scanTestLayers(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, LayerUnit, layers[testKey{"example.com/m/foo", "TestU"}])
+	assert.Equal(t, LayerIntegration,
+		layers[testKey{"example.com/m/internal/integration", "TestIt"}])
+	assert.Equal(t, LayerE2E, layers[testKey{"example.com/m/cmd/app", "TestE2EThing"}])
+
+	// The three skip rules: testdata dir, nested module, dot-dir.
+	for _, name := range []string{"TestSkippedTestdata", "TestSkippedNested", "TestSkippedHidden"} {
+		for key := range layers {
+			assert.NotEqual(t, name, key.name, "%s should have been skipped", name)
+		}
+	}
+
+	// Missing go.mod surfaces as an error.
+	_, err = scanTestLayers(t.TempDir())
+	assert.Error(t, err)
+}
+
+// evLine marshals one go-test JSON event line.
+func evLine(t *testing.T, action, pkg, test, output string) string {
+	t.Helper()
+	b, err := json.Marshal(testEvent{Action: action, Package: pkg, Test: test, Output: output})
+	require.NoError(t, err)
+	return string(b) + "\n"
+}
+
+func TestSummarizeTestRun(t *testing.T) {
+	root := writeTestModule(t)
+
+	var stream strings.Builder
+	// Unit: one function, no subtests.
+	stream.WriteString(evLine(t, "run", "example.com/m/foo", "TestU", ""))
+	stream.WriteString(evLine(t, "output", "example.com/m/foo", "TestU", "=== RUN   TestU\n"))
+	stream.WriteString(evLine(t, "output", "example.com/m/foo", "TestU", "    hello from log\n"))
+	stream.WriteString(evLine(t, "output", "example.com/m/foo", "TestU", "--- PASS: TestU (0.00s)\n"))
+	stream.WriteString(evLine(t, "pass", "example.com/m/foo", "TestU", ""))
+	stream.WriteString(evLine(t, "output", "example.com/m/foo", "", "ok  \texample.com/m/foo\t0.10s\n"))
+	// Integration: one function fanning out to two leaf subtests.
+	ip := "example.com/m/internal/integration"
+	stream.WriteString(evLine(t, "run", ip, "TestIt", ""))
+	stream.WriteString(evLine(t, "pass", ip, "TestIt/A", ""))
+	stream.WriteString(evLine(t, "skip", ip, "TestIt/B", ""))
+	stream.WriteString(evLine(t, "pass", ip, "TestIt", ""))
+	// E2E: one function.
+	stream.WriteString(evLine(t, "pass", "example.com/m/cmd/app", "TestE2EThing", ""))
+	// A mangled JSON event (drop from log, do not count).
+	stream.WriteString(`{"Time":"x","Action":"output","Package":"example.com/m/foo","Test":"TestU` + "\n")
+	// A genuine non-JSON notice (echo to log).
+	stream.WriteString("go: downloading example.com/x v1.0.0\n")
+	// A blank line (ignored).
+	stream.WriteString("\n")
+
+	var log bytes.Buffer
+	counts, err := SummarizeTestRun(root, strings.NewReader(stream.String()), &log)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, counts.Functions[LayerUnit])
+	assert.Equal(t, 1, counts.Functions[LayerIntegration])
+	assert.Equal(t, 1, counts.Functions[LayerE2E])
+	assert.Equal(t, 1, counts.Cases[LayerUnit])
+	assert.Equal(t, 2, counts.Cases[LayerIntegration], "two leaf subtests")
+	assert.Equal(t, 1, counts.Cases[LayerE2E])
+
+	logStr := log.String()
+	assert.Contains(t, logStr, "ok  \texample.com/m/foo")
+	assert.Contains(t, logStr, "hello from log")
+	assert.Contains(t, logStr, "go: downloading example.com/x")
+	assert.NotContains(t, logStr, "=== RUN")
+	assert.NotContains(t, logStr, "--- PASS:")
+	assert.NotContains(t, logStr, `"Action":"output"`, "mangled event must not leak")
+}
+
+func TestSummarizeTestRunUnclassifiedFallsToUnit(t *testing.T) {
+	root := writeTestModule(t)
+	// A package/test the source scan never saw defaults to unit.
+	stream := evLine(t, "pass", "example.com/m/ghost", "TestPhantom", "")
+	counts, err := SummarizeTestRun(root, strings.NewReader(stream), &bytes.Buffer{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts.Functions[LayerUnit])
+	assert.Equal(t, 1, counts.Cases[LayerUnit])
+}
+
+func TestSummarizeTestRunErrorsWithoutModule(t *testing.T) {
+	_, err := SummarizeTestRun(t.TempDir(), strings.NewReader(""), &bytes.Buffer{})
+	assert.Error(t, err)
+}
+
+func TestTallyCounts(t *testing.T) {
+	results := map[testKey]TestLayer{
+		{"p", "TestSolo"}:  LayerUnit, // function + leaf
+		{"p", "TestPar"}:   LayerE2E,  // function, has child below
+		{"p", "TestPar/a"}: LayerE2E,  // leaf only
+		{"p", "TestPar/b"}: LayerE2E,  // leaf only
+		{"q", "TestI"}:     LayerIntegration,
+	}
+	hasChild := map[testKey]bool{}
+	for key := range results {
+		markAncestors(hasChild, key.pkg, key.name)
+	}
+	got := tallyCounts(results, hasChild)
+	assert.Equal(t, 1, got.Functions[LayerUnit])
+	assert.Equal(t, 1, got.Functions[LayerE2E])         // TestPar
+	assert.Equal(t, 1, got.Functions[LayerIntegration]) // TestI
+	assert.Equal(t, 1, got.Cases[LayerUnit])            // TestSolo
+	assert.Equal(t, 2, got.Cases[LayerE2E])             // TestPar/a, /b
+	assert.Equal(t, 1, got.Cases[LayerIntegration])     // TestI
+}
+
+func TestRenderTestSummaryMarkdown(t *testing.T) {
+	c := TestCounts{
+		Functions: map[TestLayer]int{LayerUnit: 7919, LayerIntegration: 28, LayerE2E: 284},
+		Cases:     map[TestLayer]int{LayerUnit: 9088, LayerIntegration: 629, LayerE2E: 288},
+	}
+	got := RenderTestSummaryMarkdown(c)
+	assert.Contains(t, got, "## Test suite")
+	assert.Contains(t, got, "| Unit | 7,919 | 9,088 |")
+	assert.Contains(t, got, "| Integration | 28 | 629 |")
+	assert.Contains(t, got, "| End-to-end | 284 | 288 |")
+	assert.Contains(t, got, "| **Total** | **8,231** | **10,005** |")
+	// Layers render base-first.
+	assert.Less(t, strings.Index(got, "| Unit |"), strings.Index(got, "| Integration |"))
+	assert.Less(t, strings.Index(got, "| Integration |"), strings.Index(got, "| End-to-end |"))
+}
+
+func TestRenderTestSummaryLine(t *testing.T) {
+	c := TestCounts{
+		Functions: map[TestLayer]int{LayerUnit: 10, LayerIntegration: 2, LayerE2E: 3},
+		Cases:     map[TestLayer]int{LayerUnit: 12, LayerIntegration: 9, LayerE2E: 3},
+	}
+	got := RenderTestSummaryLine(c)
+	assert.Equal(t,
+		"test summary: 15 functions, 24 cases (unit 10, integration 2, e2e 3 functions)\n",
+		got)
+}
+
+func TestKeepTerseOutput(t *testing.T) {
+	drop := []string{
+		"=== RUN   TestX\n",
+		"=== PAUSE TestX\n",
+		"=== CONT  TestX\n",
+		"=== NAME  TestX\n",
+		"--- PASS: TestX (0.00s)\n",
+		"    --- PASS: TestX/sub (0.00s)\n",
+		"--- SKIP: TestX (0.00s)\n",
+		"PASS\n",
+		"PASS",
+	}
+	for _, s := range drop {
+		assert.False(t, keepTerseOutput(s), "%q", s)
+	}
+	keep := []string{
+		"--- FAIL: TestY (0.01s)\n",
+		"ok  \tpkg\t0.10s\n",
+		"FAIL\tpkg\t0.10s\n",
+		"?   \tpkg\t[no test files]\n",
+		"    some_test.go:42: boom\n",
+	}
+	for _, s := range keep {
+		assert.True(t, keepTerseOutput(s), "%q", s)
+	}
+}
+
+func TestStartsWithBrace(t *testing.T) {
+	assert.True(t, startsWithBrace([]byte(`{"a":1}`)))
+	assert.True(t, startsWithBrace([]byte("  \t{x")))
+	assert.False(t, startsWithBrace([]byte("go: downloading x")))
+	assert.False(t, startsWithBrace([]byte("")))
+	assert.False(t, startsWithBrace([]byte("   ")))
+}
+
+func TestMarkAncestors(t *testing.T) {
+	hasChild := map[testKey]bool{}
+	markAncestors(hasChild, "pkg", "TestA/b/c")
+	assert.True(t, hasChild[testKey{"pkg", "TestA"}])
+	assert.True(t, hasChild[testKey{"pkg", "TestA/b"}])
+	assert.False(t, hasChild[testKey{"pkg", "TestA/b/c"}], "the leaf is not its own ancestor")
+
+	// A top-level test with no subtests marks nothing.
+	markAncestors(hasChild, "pkg", "TestSolo")
+	assert.False(t, hasChild[testKey{"pkg", "TestSolo"}])
+}
+
+func TestThousands(t *testing.T) {
+	cases := map[int]string{
+		0: "0", 5: "5", 42: "42", 999: "999",
+		1000: "1,000", 12345: "12,345", 100000: "100,000",
+		1000000: "1,000,000",
+	}
+	for n, want := range cases {
+		assert.Equal(t, want, thousands(n), "%d", n)
+	}
+}
+
+func TestLayerLabel(t *testing.T) {
+	assert.Equal(t, "Unit", layerLabel(LayerUnit))
+	assert.Equal(t, "Integration", layerLabel(LayerIntegration))
+	assert.Equal(t, "End-to-end", layerLabel(LayerE2E))
+	assert.Equal(t, "other", layerLabel(TestLayer("other")))
+}

--- a/internal/release/testsummary_test.go
+++ b/internal/release/testsummary_test.go
@@ -301,6 +301,11 @@ func TestRenderTestSummaryMarkdown(t *testing.T) {
 	}
 	got := RenderTestSummaryMarkdown(c)
 	assert.Contains(t, got, "## Test suite")
+	// Bold one-line headline leads the panel, above the table.
+	assert.Contains(t, got,
+		"**8,231 test functions** — 7,919 unit · 28 integration · 284 end-to-end · **10,005 cases** including subtests")
+	assert.Less(t, strings.Index(got, "8,231 test functions"), strings.Index(got, "| Layer |"),
+		"headline appears above the table")
 	assert.Contains(t, got, "| Unit | 7,919 | 9,088 |")
 	assert.Contains(t, got, "| Integration | 28 | 629 |")
 	assert.Contains(t, got, "| End-to-end | 284 | 288 |")


### PR DESCRIPTION
## What

The CI **test** job now reports how many unit, integration, and e2e tests it runs, in the run's job summary.

On the current tree that table is:

| Layer | Test functions | Test cases |
| --- | --: | --: |
| Unit | 7,919 | 9,088 |
| Integration | 28 | 629 |
| End-to-end | 284 | 288 |
| **Total** | **8,231** | **10,005** |

*Functions* count top-level `func Test…`; *cases* count each leaf subtest (e.g. one per fixture), which is why `internal/integration` shows 28 functions but 629 cases — that column is the only one that reveals the real pyramid.

## How

- New `mdsmith-release test-summary` subcommand (per the workflow-logic-lives-in-`mdsmith-release` convention). It reads a `go test -json` stream on stdin, classifies every executed test by its `_test.go` file location, and appends the table to `$GITHUB_STEP_SUMMARY`:
  - `internal/integration/…` → integration (its contract tests included)
  - `*e2e*_test.go` (or any file under an `e2e/` dir) → e2e
  - everything else → unit
- The `test` job's run step becomes `go test -json … ./... | go run ./cmd/mdsmith-release test-summary`. The subcommand reconstructs a terse (non-`-v`) console log so the visible CI output is unchanged, and the shell's `pipefail` keeps a `go test` failure fatal. `-coverprofile` still writes `unit.cov` for the Codecov upload.
- Nested modules (`pkg/goldmark`), `testdata/`, and dot/underscore dirs are skipped so the tally matches what `go test ./...` actually runs. The website Playwright suite and the goldmark fork run in their own jobs and are out of scope for this job's count.

## Notes

- `go test -json` very rarely interleaves two events on one line under cross-package parallelism (~0.17% of lines locally; ≤5 of 10,492 terminal events). Those mangled lines are dropped from the count and the log, a ≤0.05% undercount that doesn't move the displayed totals.

## Tests

- `internal/release/testsummary_test.go` and `cmd/mdsmith-release/testsummary_test.go` cover classification, the skip rules, leaf/case counting, the terse-log filter, mangled-line handling, the Markdown render, and the CLI wiring (step-summary write, stdout fallback, error/arity paths). `go vet`, `golangci-lint`, and `mdsmith check .` are clean.

https://claude.ai/code/session_018wy6VodCbvkt4cSyZPjbjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018wy6VodCbvkt4cSyZPjbjQ)_