### PR TITLE
refactor(tablefmt): export ScanTableBoundaries; tablereadability uses it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -161,7 +161,7 @@ footer: |
 | 233 | ✅     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
 | 234 | 🔳     | sonnet | [Distribute mdsmith on Windows via Scoop and WinGet](plan/234_windows-package-managers.md)                                              |
 | 235 | ✅     | sonnet | [Playwright end-to-end tests for the website, runnable by CI and agents](plan/235_playwright-site-e2e.md)                               |
-| 236 | 🔲     | sonnet | [Consolidate duplicated table-parse helpers in tablereadability](plan/236_arch-fix-tablereadability-dup.md)                             |
+| 236 | 🔳     | sonnet | [Consolidate duplicated table-parse helpers in tablereadability](plan/236_arch-fix-tablereadability-dup.md)                             |
 | 236 | 🔲     | opus   | [cuelite phase 0 — package, façade, and differential harness](plan/236_cuelite-package-harness.md)                                      |
 | 237 | ✅     | haiku  | [Unit tests for include-rule private validation helpers](plan/237_arch-fix-include-helper-tests.md)                                     |
 | 237 | 🔲     | sonnet | [cuelite phase 1 — surface D (placeholder paths)](plan/237_cuelite-surface-d.md)                                                        |

--- a/PLAN.md
+++ b/PLAN.md
@@ -161,7 +161,7 @@ footer: |
 | 233 | ✅     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
 | 234 | 🔳     | sonnet | [Distribute mdsmith on Windows via Scoop and WinGet](plan/234_windows-package-managers.md)                                              |
 | 235 | ✅     | sonnet | [Playwright end-to-end tests for the website, runnable by CI and agents](plan/235_playwright-site-e2e.md)                               |
-| 236 | 🔳     | sonnet | [Consolidate duplicated table-parse helpers in tablereadability](plan/236_arch-fix-tablereadability-dup.md)                             |
+| 236 | ✅     | sonnet | [Consolidate duplicated table-parse helpers in tablereadability](plan/236_arch-fix-tablereadability-dup.md)                             |
 | 236 | 🔲     | opus   | [cuelite phase 0 — package, façade, and differential harness](plan/236_cuelite-package-harness.md)                                      |
 | 237 | ✅     | haiku  | [Unit tests for include-rule private validation helpers](plan/237_arch-fix-include-helper-tests.md)                                     |
 | 237 | 🔲     | sonnet | [cuelite phase 1 — surface D (placeholder paths)](plan/237_cuelite-surface-d.md)                                                        |

--- a/internal/rules/tablefmt/scan_boundaries_test.go
+++ b/internal/rules/tablefmt/scan_boundaries_test.go
@@ -14,10 +14,7 @@ func TestScanTableBoundaries(t *testing.T) {
 		codeLines map[int]struct{}
 		want      [][2]int
 	}{
-		{
-			name:  "no tables",
-			lines: blines("# Title", "", "Prose paragraph."),
-		},
+		{name: "no tables", lines: blines("# Title", "", "Prose paragraph.")},
 		{
 			name:  "single table",
 			lines: blines("# Title", "", "| A | B |", "|---|---|", "| 1 | 2 |", "", "After."),
@@ -33,16 +30,51 @@ func TestScanTableBoundaries(t *testing.T) {
 			lines:     blines("| A | B |", "|---|---|", "| 1 | 2 |"),
 			codeLines: map[int]struct{}{1: {}, 2: {}, 3: {}},
 		},
-		{
-			name:  "header only no separator",
-			lines: blines("| A | B |", "not a separator"),
-		},
+		{name: "header only no separator", lines: blines("| A | B |", "not a separator")},
 		{
 			name:  "inclusive end index",
 			lines: blines("| Col1 | Col2 |", "|------|------|", "| v1   | v2   |", "| v3   | v4   |"),
 			want:  [][2]int{{0, 3}},
 		},
 	}
+	runScanCases(t, cases)
+}
+
+func TestScanTableBoundariesEdgeCases(t *testing.T) {
+	cases := []struct {
+		name      string
+		lines     [][]byte
+		codeLines map[int]struct{}
+		want      [][2]int
+	}{
+		// header on the very last line — no room for a separator row
+		{name: "pipe line at end of file", lines: blines("| A | B |")},
+		// separator line is a code-block line
+		{
+			name:      "separator line is code-block line",
+			lines:     blines("| A | B |", "|---|---|", "| 1 | 2 |"),
+			codeLines: map[int]struct{}{2: {}},
+		},
+		// a data row is in a code block — table stops before it
+		{
+			name:      "data row in code block truncates table",
+			lines:     blines("| A | B |", "|---|---|", "| 1 | 2 |", "| 3 | 4 |"),
+			codeLines: map[int]struct{}{3: {}},
+			want:      [][2]int{{0, 1}},
+		},
+		// line has | and - but cell content fails :?-+:? (e.g. "foo-bar")
+		{name: "dash in cell content not a separator", lines: blines("| A | B |", "| foo-bar | baz |")},
+	}
+	runScanCases(t, cases)
+}
+
+func runScanCases(t *testing.T, cases []struct {
+	name      string
+	lines     [][]byte
+	codeLines map[int]struct{}
+	want      [][2]int
+}) {
+	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ScanTableBoundaries(tc.lines, tc.codeLines)

--- a/internal/rules/tablefmt/scan_boundaries_test.go
+++ b/internal/rules/tablefmt/scan_boundaries_test.go
@@ -1,0 +1,67 @@
+package tablefmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanTableBoundaries(t *testing.T) {
+	cases := []struct {
+		name      string
+		lines     [][]byte
+		codeLines map[int]struct{}
+		want      [][2]int
+	}{
+		{
+			name:  "no tables",
+			lines: blines("# Title", "", "Prose paragraph."),
+		},
+		{
+			name:  "single table",
+			lines: blines("# Title", "", "| A | B |", "|---|---|", "| 1 | 2 |", "", "After."),
+			want:  [][2]int{{2, 4}},
+		},
+		{
+			name:  "two tables",
+			lines: blines("| A | B |", "|---|---|", "| 1 | 2 |", "", "| X | Y |", "|---|---|", "| a | b |"),
+			want:  [][2]int{{0, 2}, {4, 6}},
+		},
+		{
+			name:      "skips code-block lines",
+			lines:     blines("| A | B |", "|---|---|", "| 1 | 2 |"),
+			codeLines: map[int]struct{}{1: {}, 2: {}, 3: {}},
+		},
+		{
+			name:  "header only no separator",
+			lines: blines("| A | B |", "not a separator"),
+		},
+		{
+			name:  "inclusive end index",
+			lines: blines("| Col1 | Col2 |", "|------|------|", "| v1   | v2   |", "| v3   | v4   |"),
+			want:  [][2]int{{0, 3}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScanTableBoundaries(tc.lines, tc.codeLines)
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.Len(t, got, len(tc.want))
+			for i, w := range tc.want {
+				assert.Equal(t, w, got[i])
+			}
+		})
+	}
+}
+
+func blines(ss ...string) [][]byte {
+	out := make([][]byte, len(ss))
+	for i, s := range ss {
+		out[i] = []byte(s)
+	}
+	return out
+}

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -198,6 +198,91 @@ const (
 // separatorRe matches a table separator row cell content.
 var separatorRe = regexp.MustCompile(`^:?-+:?$`)
 
+// ScanTableBoundaries returns the 0-based [start, end] line-index pairs
+// (both inclusive) for each table block found in lines, without parsing
+// cell contents. codeLines maps 1-based line numbers of fenced or
+// indented code-block lines to skip. Returns nil when no tables are found.
+func ScanTableBoundaries(lines [][]byte, codeLines map[int]struct{}) [][2]int {
+	var out [][2]int
+	i := 0
+	for i < len(lines) {
+		if _, ok := codeLines[i+1]; ok {
+			i++
+			continue
+		}
+		if bytes.IndexByte(lines[i], '|') < 0 {
+			i++
+			continue
+		}
+		end, ok := scanTableEnd(lines, i, codeLines)
+		if !ok {
+			i++
+			continue
+		}
+		out = append(out, [2]int{i, end})
+		i = end + 1
+	}
+	return out
+}
+
+// scanTableEnd returns the 0-based inclusive end index of a table
+// starting at start. Returns (0, false) when no valid table starts here.
+// Does not allocate.
+func scanTableEnd(lines [][]byte, start int, codeLines map[int]struct{}) (int, bool) {
+	if start+1 >= len(lines) {
+		return 0, false
+	}
+	if _, ok := codeLines[start+2]; ok {
+		return 0, false
+	}
+	if !isSeparatorLine(lines[start+1]) {
+		return 0, false
+	}
+	end := start + 1
+	for end+1 < len(lines) {
+		if _, ok := codeLines[end+2]; ok {
+			break
+		}
+		if bytes.IndexByte(lines[end+1], '|') < 0 {
+			break
+		}
+		end++
+	}
+	return end, true
+}
+
+// isSeparatorLine reports whether line is a GFM table separator row.
+// It checks that every non-empty cell between pipes matches :?-+:?.
+// Tolerates a blockquote or indentation prefix before the first pipe.
+// Does not allocate.
+func isSeparatorLine(line []byte) bool {
+	idx := bytes.IndexByte(line, '|')
+	if idx < 0 || bytes.IndexByte(line, '-') < 0 {
+		return false
+	}
+	pos := idx + 1
+	hasCells := false
+	for pos <= len(line) {
+		end := bytes.IndexByte(line[pos:], '|')
+		var cell []byte
+		if end < 0 {
+			cell = bytes.TrimSpace(line[pos:])
+			pos = len(line) + 1
+		} else {
+			cell = bytes.TrimSpace(line[pos : pos+end])
+			pos += end + 1
+		}
+		if len(cell) == 0 {
+			continue
+		}
+		if !separatorRe.Match(cell) {
+			return false
+		}
+		hasCells = true
+	}
+	return hasCells
+}
+
 // findTables scans file lines for contiguous table blocks, skipping
 // lines inside fenced or indented code blocks. The byte-check
 // shortcut (`bytes.IndexByte(line, '|') < 0`) avoids a tryParseTable

--- a/internal/rules/tablereadability/branch_coverage_test.go
+++ b/internal/rules/tablereadability/branch_coverage_test.go
@@ -6,41 +6,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTryParseTable_StartAtLastLine covers the boundary check
+// TestParseTables_SingleRowOnly covers the boundary check
 // where a `|`-starting line at the end of the file cannot be a
-// table (a table requires at least header + separator). The
-// negative arm returns nil without paying detectPrefix.
-func TestTryParseTable_StartAtLastLine(t *testing.T) {
+// table (a table requires at least header + separator).
+func TestParseTables_SingleRowOnly(t *testing.T) {
 	lines := [][]byte{[]byte("| only one row |")}
-	tbl, end := tryParseTable(lines, 0, map[int]struct{}{})
-	require.Nil(t, tbl)
-	require.Equal(t, 0, end)
+	got := parseTables(lines, map[int]struct{}{})
+	require.Empty(t, got)
 }
 
-// TestTryParseTable_HeaderNotTableRow covers the path where the
+// TestParseTables_MalformedHeader covers the path where the
 // "header" line is pipe-leading but doesn't end with a `|` (e.g.
-// `| foo`) so isTableRow returns false.
-func TestTryParseTable_HeaderNotTableRow(t *testing.T) {
+// `| foo`) so it is not recognized as a table.
+func TestParseTables_MalformedHeader(t *testing.T) {
 	lines := [][]byte{
 		[]byte("| foo"),
 		[]byte("| bar |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, map[int]struct{}{})
-	require.Nil(t, tbl)
+	got := parseTables(lines, map[int]struct{}{})
+	require.Empty(t, got)
 }
 
-// TestFindTables_TryParseReturnsNil covers findTables' inner
-// `if tbl == nil` arm when tryParseTable finds a pipe line that
-// does not start a table — the loop advances by one rather than
-// jumping to `end`.
-func TestFindTables_TryParseReturnsNil(t *testing.T) {
-	// A pipe-leading line followed by a non-pipe line — tryParseTable
-	// returns nil because the separator row is missing.
+// TestParseTables_MissingSeparatorRow covers parseTables skipping
+// a pipe-containing line that does not start a valid table (the
+// separator row is missing), advancing by one rather than jumping.
+func TestParseTables_MissingSeparatorRow(t *testing.T) {
 	lines := [][]byte{
 		[]byte("| not a table"),
 		[]byte("just prose"),
 	}
-	got := findTables(lines, map[int]struct{}{})
+	got := parseTables(lines, map[int]struct{}{})
 	require.Empty(t, got)
 }
 

--- a/internal/rules/tablereadability/byte_scanners_test.go
+++ b/internal/rules/tablereadability/byte_scanners_test.go
@@ -51,11 +51,11 @@ func TestDetectPrefix(t *testing.T) {
 	}
 }
 
-// TestFindTables_SkipsNonPipeLines covers the plan-195 inner
-// guard that skips tryParseTable on lines without `|`. The
+// TestParseTables_SkipsNonPipeLines covers the plan-195 inner
+// guard that skips table parsing on lines without `|`. The
 // fixture's prose lines must not trigger the table parser; a
 // regression that removes the guard still parses every line.
-func TestFindTables_SkipsNonPipeLines(t *testing.T) {
+func TestParseTables_SkipsNonPipeLines(t *testing.T) {
 	lines := [][]byte{
 		[]byte("# Title"),
 		[]byte(""),
@@ -65,9 +65,9 @@ func TestFindTables_SkipsNonPipeLines(t *testing.T) {
 		[]byte("|-----|------|"),
 		[]byte("| a   | b    |"),
 	}
-	got := findTables(lines, map[int]struct{}{})
+	got := parseTables(lines, map[int]struct{}{})
 	if len(got) != 1 {
-		t.Fatalf("findTables returned %d tables, want 1", len(got))
+		t.Fatalf("parseTables returned %d tables, want 1", len(got))
 	}
 	if got[0].startLine != 5 {
 		t.Fatalf("table startLine = %d, want 5", got[0].startLine)

--- a/internal/rules/tablereadability/rule.go
+++ b/internal/rules/tablereadability/rule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
+	"github.com/jeduden/mdsmith/internal/rules/tablefmt"
 )
 
 const (
@@ -63,7 +64,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	maxRatio := positiveFloatOrDefault(r.MaxColumnWidthRatio, defaultMaxColumnWidthRatio)
 
 	codeLines := lint.CollectCodeBlockLines(f)
-	tables := findTables(f.Lines, codeLines)
+	tables := parseTables(f.Lines, codeLines)
 	if len(tables) == 0 {
 		return nil
 	}
@@ -212,78 +213,46 @@ type tableRow struct {
 
 var separatorRe = regexp.MustCompile(`^:?-+:?$`)
 
-func findTables(lines [][]byte, codeLines map[int]struct{}) []table {
-	var tables []table
-	for i := 0; i < len(lines); {
-		if _, ok := codeLines[i+1]; ok {
-			i++
-			continue
-		}
-
-		// Lines that cannot contain a `|` cannot start a table; the
-		// guard avoids a per-line detectPrefix allocation. detectPrefix
-		// returns "" for non-pipe lines anyway, but only after a
-		// `string(line)` conversion that was the dominant per-Check
-		// allocator on file-with-no-tables corpora before plan 195.
-		if bytes.IndexByte(lines[i], '|') < 0 {
-			i++
-			continue
-		}
-
-		tbl, end := tryParseTable(lines, i, codeLines)
-		if tbl == nil {
-			i++
-			continue
-		}
-
-		tables = append(tables, *tbl)
-		i = end
+// parseTables uses tablefmt.ScanTableBoundaries to locate table blocks,
+// then parses each block's cells into the tablereadability-local table
+// type. Scanning and cell-parsing are separated so the scanner lives in
+// one place (tablefmt) while the zero-alloc [][]byte cell representation
+// stays in this package.
+func parseTables(lines [][]byte, codeLines map[int]struct{}) []table {
+	bounds := tablefmt.ScanTableBoundaries(lines, codeLines)
+	if len(bounds) == 0 {
+		return nil
+	}
+	tables := make([]table, 0, len(bounds))
+	for _, b := range bounds {
+		tbl := parseTableBlock(lines, b[0], b[1])
+		tables = append(tables, tbl)
 	}
 	return tables
 }
 
-func tryParseTable(lines [][]byte, start int, codeLines map[int]struct{}) (*table, int) {
-	if start+1 >= len(lines) {
-		return nil, start
-	}
-
+// parseTableBlock parses cells from lines[start..end] (both 0-based,
+// inclusive) into a table value. It mirrors the prefix-strip and
+// splitRow logic of the former tryParseTable, keeping the [][]byte
+// cell representation for zero-alloc counting on the hot path.
+func parseTableBlock(lines [][]byte, start, end int) table {
 	prefix := detectPrefix(lines[start])
 	header := stripPrefix(lines[start], prefix)
-	if !isTableRow(header) {
-		return nil, start
-	}
+	rows := make([]tableRow, 0, end-start+1)
+	rows = append(rows, tableRow{line: start + 1, cells: splitRow(header)})
 
-	if _, ok := codeLines[start+2]; ok {
-		return nil, start
-	}
-	separator := stripPrefix(lines[start+1], prefix)
-	if !isTableRow(separator) {
-		return nil, start
-	}
-	sepCells := splitRow(separator)
-	if !isSeparatorRow(sepCells) {
-		return nil, start
-	}
+	if start+1 <= end {
+		separator := stripPrefix(lines[start+1], prefix)
+		sepCells := splitRow(separator)
+		rows = append(rows, tableRow{line: start + 2, cells: sepCells, isSeparator: true})
 
-	rows := []tableRow{
-		{line: start + 1, cells: splitRow(header)},
-		{line: start + 2, cells: sepCells, isSeparator: true},
-	}
-
-	end := start + 2
-	for end < len(lines) {
-		if _, ok := codeLines[end+1]; ok {
-			break
+		for i := start + 2; i <= end; i++ {
+			content := stripPrefix(lines[i], prefix)
+			rows = append(rows, tableRow{line: i + 1, cells: splitRow(content)})
 		}
-		content := stripPrefix(lines[end], prefix)
-		if !isTableRow(content) {
-			break
-		}
-		rows = append(rows, tableRow{line: end + 1, cells: splitRow(content)})
-		end++
 	}
 
-	return &table{startLine: start + 1, rows: rows}, end
+	return table{startLine: start + 1, rows: rows}
 }
 
 func (t table) columnCount() int {
@@ -543,14 +512,6 @@ func stripPrefix(line []byte, prefix string) []byte {
 		}
 	}
 	return line[len(prefix):]
-}
-
-func isTableRow(content []byte) bool {
-	trimmed := bytes.TrimSpace(content)
-	if len(trimmed) < 2 {
-		return false
-	}
-	return trimmed[0] == '|' && trimmed[len(trimmed)-1] == '|'
 }
 
 // splitRow splits a row's interior (after outer-pipe strip and

--- a/internal/rules/tablereadability/rule_coverage_test.go
+++ b/internal/rules/tablereadability/rule_coverage_test.go
@@ -250,44 +250,45 @@ func TestCheck_TooManyWordsPerCell_NoHeaderColumn(t *testing.T) {
 // Phase 5: additional branch coverage
 // =====================================================================
 
-// tryParseTable: separator line is not a table row → return nil
-func TestTryParseTable_SeparatorNotTableRow(t *testing.T) {
+// parseTables: separator line is not a table row → no tables found
+func TestParseTables_SeparatorNotTableRow(t *testing.T) {
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("just text"), // not a table row
 		[]byte("| C | D |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, map[int]struct{}{})
-	assert.Nil(t, tbl, "expected nil when separator is not a table row")
+	got := parseTables(lines, map[int]struct{}{})
+	assert.Empty(t, got, "expected no tables when separator is not a table row")
 }
 
-// tryParseTable: separator is a table row but not a separator row → return nil
-func TestTryParseTable_SeparatorNotSeparatorRow(t *testing.T) {
+// parseTables: separator is a table row but not a separator row → no tables found
+func TestParseTables_SeparatorNotSeparatorRow(t *testing.T) {
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("| C | D |"), // is table row but not separator
 		[]byte("| E | F |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, map[int]struct{}{})
-	assert.Nil(t, tbl, "expected nil when second line is not a separator row")
+	got := parseTables(lines, map[int]struct{}{})
+	assert.Empty(t, got, "expected no tables when second line is not a separator row")
 }
 
-// tryParseTable: separator line is in a code block → return nil
-// codeLines uses 1-based line numbers; start=0, separator is at index 1 → 1-based=2
-func TestTryParseTable_SeparatorInCodeBlock(t *testing.T) {
+// parseTables: separator line is in a code block → no tables found
+// codeLines uses 1-based line numbers; separator is at index 1 → 1-based=2
+func TestParseTables_SeparatorInCodeBlock(t *testing.T) {
 	codeLines := map[int]struct{}{2: {}} // 1-based line 2 = index 1 (separator)
 	lines := [][]byte{
 		[]byte("| A | B |"),
 		[]byte("|---|---|"),
 		[]byte("| C | D |"),
 	}
-	tbl, _ := tryParseTable(lines, 0, codeLines)
-	assert.Nil(t, tbl, "expected nil when separator line is a code line")
+	got := parseTables(lines, codeLines)
+	assert.Empty(t, got, "expected no tables when separator line is a code line")
 }
 
-// tryParseTable: subsequent data row is in a code block → loop breaks early.
-// With start=0, end starts at 2. codeLines[end+1]=codeLines[3] means index 2 (lines[2]).
-func TestTryParseTable_DataRowInCodeBlock(t *testing.T) {
+// parseTables: subsequent data row is in a code block → table boundary stops early.
+// codeLines[3] marks line index 2 (1-based=3) as a code line, so the table
+// only spans lines 0-1 (header + separator).
+func TestParseTables_DataRowInCodeBlock(t *testing.T) {
 	codeLines := map[int]struct{}{3: {}} // 1-based line 3 = index 2 (lines[2])
 	lines := [][]byte{
 		[]byte("| A | B |"),
@@ -295,11 +296,10 @@ func TestTryParseTable_DataRowInCodeBlock(t *testing.T) {
 		[]byte("| C | D |"), // this is in a code block
 		[]byte("| E | F |"),
 	}
-	tbl, end := tryParseTable(lines, 0, codeLines)
-	require.NotNil(t, tbl)
-	// The loop should break when it hits lines[2] (codeLines[3]=true).
-	// end should remain at 2 (start+2 initial value, loop doesn't advance).
-	assert.Equal(t, 2, end, "expected end at 2 (before code-blocked line)")
+	got := parseTables(lines, codeLines)
+	require.Len(t, got, 1, "expected one table found before code-blocked line")
+	// Table should only have header + separator rows (2 rows), not the code-blocked line.
+	assert.Equal(t, 2, len(got[0].rows), "expected 2 rows (header + separator)")
 }
 
 // columnWidthRatio: columns == 0 → return 0

--- a/plan/236_arch-fix-tablereadability-dup.md
+++ b/plan/236_arch-fix-tablereadability-dup.md
@@ -1,7 +1,7 @@
 ---
 id: 236
 title: Consolidate duplicated table-parse helpers in tablereadability
-status: "🔲"
+status: "✅"
 summary: >-
   Move tablereadability's private findTables/tryParseTable
   into tablefmt so the two rules share one copy.
@@ -47,8 +47,8 @@ pass).
 
 ## Acceptance Criteria
 
-- [ ] Table-boundary scanning exists in one package only.
-- [ ] `tablereadability` does not duplicate scanning logic.
-- [ ] `TestRulesDoNotImportEachOther` passes.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] Table-boundary scanning exists in one package only.
+- [x] `tablereadability` does not duplicate scanning logic.
+- [x] `TestRulesDoNotImportEachOther` passes.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
## Summary

Eliminates the duplicate `findTables`/`tryParseTable` copies in `tablereadability` and `tablefmt` that diverged on the plan-195 perf pass (DRY violation, plan 236).

- **`tablefmt`** exports a new zero-alloc `ScanTableBoundaries(lines, codeLines) [][2]int` that returns 0-based `[start, end]` inclusive line-index pairs for each table block, without parsing cell contents. Uses a bytes-only `isSeparatorLine` check (tolerates blockquote/indentation prefixes) to avoid the `tryParseTable` string-cell allocations.
- **`tablereadability`** drops its private `findTables`/`tryParseTable`/`isTableRow` copies. `parseTables` calls `ScanTableBoundaries` to locate blocks, then `parseTableBlock` parses `[][]byte` cells from the detected ranges — keeping MDS026 within its ≤ 10 allocs/op budget (the initial wiring hit 30/op before the scanner was rewritten).
- New `internal/rules/tablefmt/scan_boundaries_test.go` covers the exported scanner.

## Acceptance criteria met

- [x] Table-boundary scanning exists in one package only (`tablefmt`).
- [x] `tablereadability` does not duplicate scanning logic.
- [x] `TestRulesDoNotImportEachOther` passes.
- [x] `go test ./...` — all tests pass, alloc budget ≤ 10.
- [x] `go tool golangci-lint run` — 0 issues.
- [x] `go run ./cmd/mdsmith check .` — 437 files, 0 failures.

Closes plan 236.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USvyKc2yWLbLnsNtEtxstT)_