### PR TITLE
perf: eliminate per-call allocations in 5 hot-path functions

### DIFF
--- a/internal/gitignore/alloc_test.go
+++ b/internal/gitignore/alloc_test.go
@@ -1,0 +1,42 @@
+package gitignore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMatchDoublestar_LeadingDoublestar_ZeroAllocs confirms the
+// leading-** path allocates nothing after the strings.Split/Join rewrite.
+func TestMatchDoublestar_LeadingDoublestar_ZeroAllocs(t *testing.T) {
+	cases := []struct{ pattern, path string }{
+		{"**/*.md", "readme.md"},
+		{"**/*.md", "sub/readme.md"},
+		{"**/*.md", "a/b/c.md"},
+		{"**/foo", "a/b/c/foo"},
+	}
+	for _, c := range cases {
+		allocs := testing.AllocsPerRun(100, func() {
+			matchDoublestar(c.pattern, c.path)
+		})
+		assert.Equal(t, 0.0, allocs,
+			"matchDoublestar(%q, %q) allocs: want 0, got %v", c.pattern, c.path, allocs)
+	}
+}
+
+// TestMatchDoublestar_MiddleDoublestar_ZeroAllocs confirms the
+// middle-** path allocates nothing after the rewrite.
+func TestMatchDoublestar_MiddleDoublestar_ZeroAllocs(t *testing.T) {
+	cases := []struct{ pattern, path string }{
+		{"a/**/b.md", "a/b.md"},
+		{"docs/**/readme.md", "docs/readme.md"},
+		{"docs/**/readme.md", "docs/sub/readme.md"},
+	}
+	for _, c := range cases {
+		allocs := testing.AllocsPerRun(100, func() {
+			matchDoublestar(c.pattern, c.path)
+		})
+		assert.Equal(t, 0.0, allocs,
+			"matchDoublestar(%q, %q) allocs: want 0, got %v", c.pattern, c.path, allocs)
+	}
+}

--- a/internal/gitignore/gitignore.go
+++ b/internal/gitignore/gitignore.go
@@ -271,53 +271,82 @@ func matchGitignorePattern(pattern, path string) bool {
 
 // matchDoublestar handles patterns containing **.
 func matchDoublestar(pattern, path string) bool {
-	// Split pattern on "**" and match each segment.
-	parts := strings.Split(pattern, "**")
-	if len(parts) == 2 {
-		prefix := parts[0]
-		suffix := parts[1]
-
-		// Leading ** — matches any path prefix.
-		if prefix == "" || prefix == "/" {
-			suffix = strings.TrimPrefix(suffix, "/")
-			if suffix == "" {
-				// Pattern is just "**" — matches everything.
-				return true
-			}
-			// Try matching suffix against every possible subpath.
-			pathParts := strings.Split(path, "/")
-			for i := range pathParts {
-				sub := strings.Join(pathParts[i:], "/")
-				if matchGitignorePattern(suffix, sub) {
-					return true
-				}
-			}
-			return false
-		}
-
-		// Trailing ** — matches any path suffix.
-		if suffix == "" || suffix == "/" {
-			prefix = strings.TrimSuffix(prefix, "/")
-			return strings.HasPrefix(path, prefix+"/") || path == prefix
-		}
-
-		// Middle ** — e.g., "a/**/b".
-		prefix = strings.TrimSuffix(prefix, "/")
-		suffix = strings.TrimPrefix(suffix, "/")
-		pathParts := strings.Split(path, "/")
-		for i := range pathParts {
-			prefixPart := strings.Join(pathParts[:i], "/")
-			suffixPart := strings.Join(pathParts[i:], "/")
-			if (i == 0 || matchGitignorePattern(prefix, prefixPart)) &&
-				matchGitignorePattern(suffix, suffixPart) {
-				return true
-			}
-		}
-		return false
+	// Find the single "**" without allocating. Multiple "**" fall back to
+	// the filepath.Match path at the bottom.
+	idx := strings.Index(pattern, "**")
+	if idx >= 0 && !strings.Contains(pattern[idx+2:], "**") {
+		prefix := pattern[:idx]
+		suffix := pattern[idx+2:]
+		return matchSingleDoublestar(prefix, suffix, path)
 	}
-
 	// Multiple ** in one pattern — fall back to simple matching.
-	// This is an edge case; try matching each path permutation.
 	matched, _ := filepath.Match(strings.ReplaceAll(pattern, "**", "*"), path)
 	return matched
+}
+
+// matchSingleDoublestar handles the three structural cases for a pattern
+// with exactly one "**": leading, trailing, and middle.
+// All string slicing is zero-copy (no allocations from splitting).
+func matchSingleDoublestar(prefix, suffix, path string) bool {
+	// Leading ** — matches any path prefix.
+	if prefix == "" || prefix == "/" {
+		return matchLeadingDoublestar(strings.TrimPrefix(suffix, "/"), path)
+	}
+	// Trailing ** — matches any path suffix.
+	if suffix == "" || suffix == "/" {
+		prefix = strings.TrimSuffix(prefix, "/")
+		return strings.HasPrefix(path, prefix+"/") || path == prefix
+	}
+	// Middle ** — e.g., "a/**/b".
+	return matchMiddleDoublestar(
+		strings.TrimSuffix(prefix, "/"),
+		strings.TrimPrefix(suffix, "/"),
+		path,
+	)
+}
+
+// matchLeadingDoublestar handles "**/suffix" style patterns. It tries the
+// suffix against every trailing sub-path of path, advancing one directory
+// component at a time. String slicing shares the backing array with path.
+func matchLeadingDoublestar(suffix, path string) bool {
+	if suffix == "" {
+		return true // pattern is just "**"
+	}
+	tail := path
+	for {
+		if matchGitignorePattern(suffix, tail) {
+			return true
+		}
+		j := strings.Index(tail, "/")
+		if j < 0 {
+			break
+		}
+		tail = tail[j+1:]
+	}
+	return false
+}
+
+// matchMiddleDoublestar handles "prefix/**/suffix" style patterns. It tries
+// every split position of path without allocating (substrings share the
+// backing array with path).
+func matchMiddleDoublestar(prefix, suffix, path string) bool {
+	// Position 0: no prefix constraint; check suffix against the whole path.
+	if matchGitignorePattern(suffix, path) {
+		return true
+	}
+	remaining := path
+	for {
+		j := strings.Index(remaining, "/")
+		if j < 0 {
+			break
+		}
+		prefixPart := path[:len(path)-len(remaining)+j]
+		suffixPart := remaining[j+1:]
+		if matchGitignorePattern(prefix, prefixPart) &&
+			matchGitignorePattern(suffix, suffixPart) {
+			return true
+		}
+		remaining = remaining[j+1:]
+	}
+	return false
 }

--- a/internal/gitignore/gitignore_test.go
+++ b/internal/gitignore/gitignore_test.go
@@ -194,6 +194,17 @@ func TestMatchDoublestar_MultipleDoublestars(t *testing.T) {
 
 func TestMatchDoublestar_NoMatch(t *testing.T) {
 	assert.False(t, matchDoublestar("docs/**/*.md", "src/file.md"))
+	// Leading ** with no matching tail: exercises the return-false path in
+	// matchLeadingDoublestar after the tail-advancing loop exhausts all slashes.
+	assert.False(t, matchDoublestar("**/*.md", "readme.txt"))
+	assert.False(t, matchDoublestar("**/foo.md", "bar/baz.txt"))
+}
+
+func TestMatchDoublestar_MiddleDoublestar_SuffixOnly(t *testing.T) {
+	// When ** expands to zero segments and the path starts with the suffix,
+	// matchMiddleDoublestar returns true via the pre-loop check.
+	// This is the same behavior as the original (i=0 guard skipped prefix check).
+	assert.True(t, matchDoublestar("a/**/b.md", "b.md"))
 }
 
 // --- parseGitignoreFile tests ---

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -44,13 +44,12 @@ func ResolveAgainstRoot(baseDir, p2 string) (resolved string, escapes bool) {
 
 // ContainsDotDotSegment reports whether p contains a ".." path element
 // when split on "/". Filenames like "..foo" do not match.
+// Uses zero-allocation string checks instead of strings.Split.
 func ContainsDotDotSegment(p string) bool {
-	for _, elem := range strings.Split(p, "/") {
-		if elem == ".." {
-			return true
-		}
-	}
-	return false
+	return p == ".." ||
+		strings.HasPrefix(p, "../") ||
+		strings.HasSuffix(p, "/..") ||
+		strings.Contains(p, "/../")
 }
 
 // Match reports whether path matches pattern using the doublestar matcher.

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -154,3 +154,20 @@ func TestContainsDotDotSegment(t *testing.T) {
 		assert.Equal(t, want, globpath.ContainsDotDotSegment(input), input)
 	}
 }
+
+func TestContainsDotDotSegment_ZeroAllocs(t *testing.T) {
+	paths := []string{
+		"..",
+		"../foo",
+		"foo/..",
+		"foo/../bar",
+		"foo/bar/baz",
+	}
+	for _, p := range paths {
+		allocs := testing.AllocsPerRun(100, func() {
+			globpath.ContainsDotDotSegment(p)
+		})
+		assert.Equal(t, 0.0, allocs,
+			"ContainsDotDotSegment(%q) allocs: want 0, got %v", p, allocs)
+	}
+}

--- a/internal/rules/include/alloc_test.go
+++ b/internal/rules/include/alloc_test.go
@@ -6,40 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestContainsDotDotElement_Correctness verifies all cases the function
-// must handle before the allocation-free rewrite.
-func TestContainsDotDotElement_Correctness(t *testing.T) {
-	assert.True(t, containsDotDotElement(".."), "bare ..")
-	assert.True(t, containsDotDotElement("../foo"), "leading ../")
-	assert.True(t, containsDotDotElement("foo/.."), "trailing /..")
-	assert.True(t, containsDotDotElement("foo/../bar"), "middle /../")
-	assert.True(t, containsDotDotElement("../"), "just ../ with trailing slash")
-
-	assert.False(t, containsDotDotElement("foo"), "plain name")
-	assert.False(t, containsDotDotElement("foo/bar"), "two-part path")
-	assert.False(t, containsDotDotElement("foo..bar"), "dots inside name")
-	assert.False(t, containsDotDotElement("..."), "triple dots")
-	assert.False(t, containsDotDotElement("..foo"), "dotdot prefix without slash")
-	assert.False(t, containsDotDotElement("foo.."), "dotdot suffix without slash")
-}
-
-// TestContainsDotDotElement_ZeroAllocs confirms the rewrite allocates nothing.
-func TestContainsDotDotElement_ZeroAllocs(t *testing.T) {
-	paths := []string{
-		"..",
-		"../foo",
-		"foo/..",
-		"foo/../bar",
-		"foo/bar/baz",
-	}
-	for _, p := range paths {
-		allocs := testing.AllocsPerRun(100, func() {
-			containsDotDotElement(p)
-		})
-		assert.Equal(t, 0.0, allocs, "containsDotDotElement(%q) allocs: want 0, got %v", p, allocs)
-	}
-}
-
 // TestMinFenceLen_Correctness verifies the function returns the right length
 // before and after the allocation-free rewrite.
 func TestMinFenceLen_Correctness(t *testing.T) {

--- a/internal/rules/include/alloc_test.go
+++ b/internal/rules/include/alloc_test.go
@@ -1,0 +1,68 @@
+package include
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestContainsDotDotElement_Correctness verifies all cases the function
+// must handle before the allocation-free rewrite.
+func TestContainsDotDotElement_Correctness(t *testing.T) {
+	assert.True(t, containsDotDotElement(".."), "bare ..")
+	assert.True(t, containsDotDotElement("../foo"), "leading ../")
+	assert.True(t, containsDotDotElement("foo/.."), "trailing /..")
+	assert.True(t, containsDotDotElement("foo/../bar"), "middle /../")
+	assert.True(t, containsDotDotElement("../"), "just ../ with trailing slash")
+
+	assert.False(t, containsDotDotElement("foo"), "plain name")
+	assert.False(t, containsDotDotElement("foo/bar"), "two-part path")
+	assert.False(t, containsDotDotElement("foo..bar"), "dots inside name")
+	assert.False(t, containsDotDotElement("..."), "triple dots")
+	assert.False(t, containsDotDotElement("..foo"), "dotdot prefix without slash")
+	assert.False(t, containsDotDotElement("foo.."), "dotdot suffix without slash")
+}
+
+// TestContainsDotDotElement_ZeroAllocs confirms the rewrite allocates nothing.
+func TestContainsDotDotElement_ZeroAllocs(t *testing.T) {
+	paths := []string{
+		"..",
+		"../foo",
+		"foo/..",
+		"foo/../bar",
+		"foo/bar/baz",
+	}
+	for _, p := range paths {
+		allocs := testing.AllocsPerRun(100, func() {
+			containsDotDotElement(p)
+		})
+		assert.Equal(t, 0.0, allocs, "containsDotDotElement(%q) allocs: want 0, got %v", p, allocs)
+	}
+}
+
+// TestMinFenceLen_Correctness verifies the function returns the right length
+// before and after the allocation-free rewrite.
+func TestMinFenceLen_Correctness(t *testing.T) {
+	assert.Equal(t, 3, minFenceLen("hello world"), "plain text → 3")
+	assert.Equal(t, 4, minFenceLen("text with ``` backticks"), "3 backticks → 4")
+	assert.Equal(t, 5, minFenceLen("a ```` run"), "4 backticks → 5")
+	assert.Equal(t, 3, minFenceLen(""), "empty string → 3")
+	assert.Equal(t, 4, minFenceLen("line1\n```line2\n"), "3 backticks across newline → 4")
+	assert.Equal(t, 5, minFenceLen("first ``` line\nsecond ```` line\n"), "max across lines → 5")
+}
+
+// TestMinFenceLen_ZeroAllocs confirms the rewrite allocates nothing.
+func TestMinFenceLen_ZeroAllocs(t *testing.T) {
+	inputs := []string{
+		"hello world",
+		"text with ``` backticks",
+		"line1\n```line2\nline3\n",
+	}
+	for _, s := range inputs {
+		s := s
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = minFenceLen(s)
+		})
+		assert.Equal(t, 0.0, allocs, "minFenceLen(%q) allocs: want 0, got %v", s, allocs)
+	}
+}

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -441,19 +441,18 @@ func makeDiag(file string, line int, msg string) lint.Diagnostic {
 
 // minFenceLen returns the minimum backtick fence length needed to safely
 // wrap text without conflicting with backtick runs inside the content.
+// Scans bytes directly to avoid the strings.Split allocation.
 func minFenceLen(text string) int {
 	n := 3
-	for _, line := range strings.Split(text, "\n") {
-		run := 0
-		for _, c := range line {
-			if c == '`' {
-				run++
-				if run >= n {
-					n = run + 1
-				}
-			} else {
-				run = 0
+	run := 0
+	for i := 0; i < len(text); i++ {
+		if text[i] == '`' {
+			run++
+			if run >= n {
+				n = run + 1
 			}
+		} else {
+			run = 0
 		}
 	}
 	return n
@@ -461,13 +460,12 @@ func minFenceLen(text string) int {
 
 // containsDotDotElement reports whether the slash-separated path contains
 // a ".." path element. It does not match filenames like "foo..bar.md".
+// Uses zero-allocation string checks instead of strings.Split.
 func containsDotDotElement(p string) bool {
-	for _, elem := range strings.Split(p, "/") {
-		if elem == ".." {
-			return true
-		}
-	}
-	return false
+	return p == ".." ||
+		strings.HasPrefix(p, "../") ||
+		strings.HasSuffix(p, "/..") ||
+		strings.Contains(p, "/../")
 }
 
 // expandNestedIncludes parses the included file for nested include

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/bytelimit"
+	"github.com/jeduden/mdsmith/internal/globpath"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/piparser"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -255,7 +256,7 @@ func resolveIncludePath(
 		}
 		readFS = f.RootFS
 		readPath = resolvedFile
-	} else if containsDotDotElement(file) {
+	} else if globpath.ContainsDotDotSegment(file) {
 		return nil, "", "", []lint.Diagnostic{makeDiag(filePath, line,
 			`include file path contains ".." but project root is not configured`)}
 	}
@@ -456,16 +457,6 @@ func minFenceLen(text string) int {
 		}
 	}
 	return n
-}
-
-// containsDotDotElement reports whether the slash-separated path contains
-// a ".." path element. It does not match filenames like "foo..bar.md".
-// Uses zero-allocation string checks instead of strings.Split.
-func containsDotDotElement(p string) bool {
-	return p == ".." ||
-		strings.HasPrefix(p, "../") ||
-		strings.HasSuffix(p, "/..") ||
-		strings.Contains(p, "/../")
 }
 
 // expandNestedIncludes parses the included file for nested include

--- a/internal/rules/noreferencestyle/alloc_test.go
+++ b/internal/rules/noreferencestyle/alloc_test.go
@@ -1,0 +1,48 @@
+package noreferencestyle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParagraphEndLine_ZeroAllocs confirms paragraphEndLine allocates nothing
+// after changing its signature to accept pre-split lines instead of raw source.
+func TestParagraphEndLine_ZeroAllocs(t *testing.T) {
+	lines := [][]byte{
+		[]byte("First line of paragraph."),
+		[]byte("Second line of paragraph."),
+		[]byte(""),
+		[]byte("After blank."),
+	}
+	defLines := map[int]struct{}{}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		paragraphEndLine(lines, 0, defLines)
+	})
+	assert.Equal(t, 0.0, allocs, "paragraphEndLine allocs: want 0, got %v", allocs)
+}
+
+// TestParagraphEndLine_Correctness verifies behavior is unchanged by the
+// signature change from []byte source to [][]byte lines.
+func TestParagraphEndLine_Correctness(t *testing.T) {
+	lines := [][]byte{
+		[]byte("First line."),
+		[]byte("Second line."),
+		[]byte(""),
+		[]byte("After blank."),
+	}
+	defLines := map[int]struct{}{3: {}}
+
+	// paragraph starting at line 0 ends before the blank (line 2 → index 2)
+	end := paragraphEndLine(lines, 0, defLines)
+	assert.Equal(t, 2, end, "should stop at blank line (index 2)")
+
+	// paragraph starting at line 3 (index 3 is "After blank.")
+	// defLines has line 3 (1-based), so it stops before consuming it
+	lines2 := [][]byte{
+		[]byte("Para start."),
+	}
+	end2 := paragraphEndLine(lines2, 0, map[int]struct{}{})
+	assert.Equal(t, 1, end2, "single-line paragraph ends at 1")
+}

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -169,7 +169,7 @@ func (r *Rule) checkFootnotes(f *lint.File) []lint.Diagnostic {
 			})
 			continue
 		}
-		msg := footnotePlacementMessage(ref, defs, f.Source)
+		msg := footnotePlacementMessage(ref, defs, f.Lines)
 		if msg != "" {
 			diags = append(diags, lint.Diagnostic{
 				File:     f.Path,
@@ -456,7 +456,7 @@ func isFootnoteDefinitionAt(source []byte, start int) bool {
 func footnotePlacementMessage(
 	ref footnoteOccurrence,
 	defs []footnoteOccurrence,
-	source []byte,
+	lines [][]byte,
 ) string {
 	defLines := map[int]struct{}{}
 	hasMatchingSlug := false
@@ -466,7 +466,7 @@ func footnotePlacementMessage(
 			hasMatchingSlug = true
 		}
 	}
-	endLine := paragraphEndLine(source, ref.line, defLines)
+	endLine := paragraphEndLine(lines, ref.line, defLines)
 	for _, d := range defs {
 		if d.slug != ref.slug {
 			continue
@@ -484,9 +484,8 @@ func footnotePlacementMessage(
 // paragraphEndLine returns the 1-based line number of the last line
 // belonging to the paragraph that contains `line`. The paragraph
 // stops at the next blank line, the next footnote definition, or
-// end of file.
-func paragraphEndLine(source []byte, line int, defLines map[int]struct{}) int {
-	lines := bytes.Split(source, []byte("\n"))
+// end of file. lines is f.Lines (pre-split by lint.NewFile).
+func paragraphEndLine(lines [][]byte, line int, defLines map[int]struct{}) int {
 	end := line
 	for end < len(lines) && !isBlankLine(lines[end]) {
 		if _, ok := defLines[end+1]; ok {

--- a/internal/rules/requiredstructure/alloc_test.go
+++ b/internal/rules/requiredstructure/alloc_test.go
@@ -1,0 +1,33 @@
+package requiredstructure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCollectBodySyncPoints_NoByteSplitAlloc confirms collectBodySyncPoints
+// no longer calls bytes.Split after the direct-scan rewrite. The only
+// remaining allocations are the necessary string() casts for heading
+// lines passed to headingMatchesLine — one per heading in the content.
+// The content below has 2 headings and no {field} references, so we
+// expect exactly 2 allocs (the two string conversions) rather than the
+// original 3 (bytes.Split slice + 2 string conversions).
+func TestCollectBodySyncPoints_NoByteSplitAlloc(t *testing.T) {
+	content := []byte("## Section One\n\nSome prose without fields.\n\n## Section Two\n\nMore prose.\n")
+	headings := []docHeading{
+		{Text: "Section One", Level: 2, Line: 1},
+		{Text: "Section Two", Level: 2, Line: 5},
+	}
+	syncPoints := make(map[int][]syncPoint)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		for k := range syncPoints {
+			delete(syncPoints, k)
+		}
+		collectBodySyncPoints(content, headings, syncPoints)
+	})
+	// After removing bytes.Split: 2 string() casts for 2 headings, no split alloc.
+	assert.LessOrEqual(t, allocs, 2.0,
+		"collectBodySyncPoints allocs: want ≤ 2 (string casts only), got %v", allocs)
+}

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1324,19 +1324,24 @@ func cueFieldLabel(key string) string {
 
 // collectBodySyncPoints scans body content for {field} references and
 // adds them to the syncPoints map under their nearest preceding heading.
+// Iterates over content bytes directly to avoid the bytes.Split allocation.
 func collectBodySyncPoints(
 	content []byte, headings []docHeading,
 	syncPoints map[int][]syncPoint,
 ) {
-	lines := bytes.Split(content, []byte("\n"))
 	currentHeading := -1
-	for _, lineB := range lines {
-		trimmedB := bytes.TrimSpace(lineB)
-		if len(trimmedB) == 0 {
+	start := 0
+	for i := 0; i <= len(content); i++ {
+		if i < len(content) && content[i] != '\n' {
 			continue
 		}
-		if trimmedB[0] == '#' {
-			trimmed := string(trimmedB)
+		lineB := bytes.TrimSpace(content[start:i])
+		start = i + 1
+		if len(lineB) == 0 {
+			continue
+		}
+		if lineB[0] == '#' {
+			trimmed := string(lineB)
 			for j, h := range headings {
 				if headingMatchesLine(h, trimmed) {
 					currentHeading = j
@@ -1346,7 +1351,7 @@ func collectBodySyncPoints(
 			continue
 		}
 		if currentHeading >= 0 {
-			trimmed := string(trimmedB)
+			trimmed := string(lineB)
 			fields := fieldinterp.Fields(trimmed)
 			if len(fields) > 0 {
 				compiled := buildFieldPattern(trimmed)


### PR DESCRIPTION
## Summary

Audited the codebase against `docs/development/high-performance-go.md` and identified five functions that allocate on every invocation due to `strings.Split`, `bytes.Split`, or `strings.Join` calls that can be replaced with zero-allocation alternatives. Each fix follows Red/Green TDD: a failing alloc test was added first, then the implementation was changed to make it pass.

### Fixes

| # | Function | File | Anti-pattern | Allocs before → after |
|---|----------|------|--------------|----------------------|
| 1 | `containsDotDotElement` | `internal/rules/include/rule.go` | `strings.Split(p, "/")` in hot per-directive path | 1 → **0** |
| 2 | `minFenceLen` | `internal/rules/include/rule.go` | `strings.Split(text, "\n")` allocates a full lines slice | 1 → **0** |
| 3 | `paragraphEndLine` | `internal/rules/noreferencestyle/rule.go` | `bytes.Split(source, "\n")` re-split the whole file; caller now passes `f.Lines` directly | 1 → **0** |
| 4 | `matchDoublestar` | `internal/gitignore/gitignore.go` | `strings.Split(pattern, "**")` + `strings.Split(path, "/")` + `strings.Join` inside a loop — O(n) allocations per path | 3–5 → **0** |
| 5 | `collectBodySyncPoints` | `internal/rules/requiredstructure/rule.go` | `bytes.Split(content, "\n")` on schema body | 3 → **2** (only the inherent `string()` casts for heading comparison remain) |

### Motivation

`docs/development/high-performance-go.md` specifies: _"each removed alloc in a per-file Check saves one alloc per workspace file"_ and calls out `strings.Split`/`bytes.Split` returning newly-allocated slices as the canonical anti-pattern to avoid. With a 600-file corpus, each 1-alloc reduction translates directly to 600 fewer heap allocations per `mdsmith check` run.

`matchDoublestar` is called once per `.gitignore` pattern per file during workspace discovery — the most upstream hot path. Eliminating 3–5 allocations per `**`-pattern match compounds across all workspace files and all rules.

### Approach

- `containsDotDotElement`: replaced with `HasPrefix`/`HasSuffix`/`Contains` checks that match the exact four cases without any slice allocation.
- `minFenceLen`: a single-pass byte scan replaces the split+inner-loop; `\n` is just another non-`` ` `` character that resets the run counter.
- `paragraphEndLine`: changed parameter type from `[]byte` (raw source) to `[][]byte` (pre-split lines from `lint.File`). Updated the single call site to pass `f.Lines`.
- `matchDoublestar`: replaced `strings.Split(pattern, "**")` with `strings.Index` (no alloc); replaced the `strings.Split(path, "/")` + per-iteration `strings.Join` with index-based substringing (Go string slices share the backing array). Extracted three helper functions (`matchSingleDoublestar`, `matchLeadingDoublestar`, `matchMiddleDoublestar`) to keep the cognitive complexity below the 30-node lint ceiling while making each branch readable.
- `collectBodySyncPoints`: replaced `bytes.Split(content, "\n")` with a direct `i`-pointer scan over `content`, eliminating the `[][]byte` header slice. The two `string()` casts for heading-line comparison against `headingMatchesLine` are inherent and unchanged.

## Test plan

- [x] New alloc tests added for all 5 functions (`*_test.go` beside each changed file)
- [x] Alloc tests confirmed **failing before** the fix (red phase)
- [x] Alloc tests confirmed **passing after** the fix (green phase)
- [x] All existing tests in changed packages pass (`go test ./...` — 0 failures)
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` on changed packages — 0 issues
- [x] `mdsmith check .` on repository — 437 files, 0 failures

https://claude.ai/code/session_017d9EhXPVmeoCfMq1747hCU

---
_Generated by [Claude Code](https://claude.ai/code/session_017d9EhXPVmeoCfMq1747hCU)_