### PR TITLE
docs(extract): make worked examples runnable and outputs verbatim

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -169,4 +169,9 @@ footer: |
 | 239 | 🔲     | opus   | [cuelite phase 3 — surface C (row-expr evaluator)](plan/239_cuelite-surface-c.md)                                                       |
 | 240 | 🔲     | sonnet | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
 | 241 | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
+| 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
+| 243 | 🔲     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
+| 244 | 🔲     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
+| 245 | 🔲     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
+| 246 | 🔲     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
 <?/catalog?>

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -281,6 +281,81 @@ than one line, and anything that benefits from
 Markdown formatting (code, emphasis, links) all
 belong in the body.
 
+## Frontmatter `title` and the H1
+
+The worked example carries the same string twice:
+`title: Product copy` in frontmatter and
+`# Product copy` as the H1. Nothing checks the two
+against each other by default, so they can drift
+apart edit by edit.
+
+The test from the previous section decides it. When
+no catalog row, site template, or release script
+reads `frontmatter.title`, delete the field; the H1
+alone is the title. When a tool does read the
+field, keep it and let MDS020 enforce the match.
+
+Enforcement needs a file-based schema. An inline
+`schema:` starts matching at H2 — the H1 belongs to
+[first-line-heading][mds004] — so the kind switches
+to a `proto.md` whose first row is the `{title}`
+placeholder:
+
+```markdown
+# {title}
+
+## ...
+```
+
+```yaml
+kinds:
+  product-copy:
+    rules:
+      required-structure:
+        schema: copy-proto.md
+```
+
+The `{title}` row requires the frontmatter field
+and checks the H1 text against its value. A drifted
+H1 fails `mdsmith check`:
+
+```text
+docs/copy/product.md:4:1 MDS020 heading does not match frontmatter: expected "Product copy" (from title), got "Product page copy"
+```
+
+The synced H1 also becomes data. `mdsmith extract`
+projects the H1 scope under a `title` key, with the
+captured heading text inside:
+
+```json
+{
+  "frontmatter": {
+    "title": "Product copy"
+  },
+  "title": {
+    "title": "Product copy"
+  }
+}
+```
+
+Weigh two limits before switching. Every schema
+source on a file must declare the same root level,
+so an H1-rooted `proto.md` cannot compose with an
+H2-rooted inline schema on the same file. And a
+`proto.md` declares heading rows only, not
+`content:` entries, so the worked example's
+paragraph projections (`tagline.text`, …) drop out
+of the tree.
+
+When the kind's main job is extraction, keep the
+inline schema and delete the frontmatter field
+instead. mdsmith cannot project the H1 text without
+a frontmatter field behind it: a `{title}` row with
+no `title` field matches any heading, and `extract`
+skips wildcard scopes.
+
+[mds004]: ../../internal/rules/MDS004-first-line-heading/README.md
+
 ## `bind:` patterns
 
 `bind:` renames the JSON key that a heading or

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -38,14 +38,16 @@ YAML scalar.
 The trap is to reach for frontmatter for everything
 because it's structured. A 60-character `tagline` in
 frontmatter and the same 60 characters in a
-`## Tagline` body section produce identical JSON;
-the body version is shorter to edit, diffs cleanly
-when wrapped, and is lintable as Markdown.
+`## Tagline` body section project the same string;
+only the key moves, from `frontmatter.tagline` to
+`tagline.text`. The body version is shorter to edit,
+diffs cleanly when wrapped, and is lintable as
+Markdown.
 
 ## Worked example
 
-A product-copy file with a tagline, a lead, and one
-per-surface description.
+A product-copy file at `docs/copy/product.md` with a
+tagline, a lead, and one per-surface description.
 
 ### Frontmatter-heavy (the trap)
 
@@ -101,7 +103,8 @@ Inline diagnostics, fix-on-save, and instant
 navigation for Markdown in VS Code.
 ```
 
-With a matching schema in `.mdsmith.yml`:
+With a matching schema and kind assignment in
+`.mdsmith.yml`:
 
 ```yaml
 kinds:
@@ -109,25 +112,49 @@ kinds:
     schema:
       sections:
         - heading: { regex: '^Tagline$' }
+          content:
+            - { kind: paragraph }
         - heading: { regex: '^Lead$' }
+          content:
+            - { kind: paragraph }
         - heading: { regex: '^VS Code$' }
           bind: vscode-description
+          content:
+            - { kind: paragraph }
+kind-assignment:
+  - glob: ["docs/copy/product.md"]
+    kinds: [product-copy]
 ```
 
-`mdsmith extract product-copy --format json` emits
-the same shape both encodings would produce:
+Each `content:` entry declares the paragraph its
+section projects. A section without one projects as
+an empty object — the schema, not the body, decides
+what `extract` emits.
+
+`mdsmith extract product-copy --format json docs/copy/product.md`
+emits:
 
 ```json
 {
-  "frontmatter": { "title": "Product copy" },
-  "tagline": { "text": "Mark down your ideas; smith them into shipping docs." },
-  "lead": { "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions." },
-  "vscode-description": { "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code." }
+  "frontmatter": {
+    "title": "Product copy"
+  },
+  "lead": {
+    "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
+  },
+  "tagline": {
+    "text": "Mark down your ideas; smith them into shipping docs."
+  },
+  "vscode-description": {
+    "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code."
+  }
 }
 ```
 
-The body version costs nothing at the projection
-layer and is the editable artifact.
+Keys come out sorted, not in document order. The
+consumer reads the same strings the frontmatter
+version held, and the body version is the editable
+artifact.
 
 ## Projecting inline structure
 
@@ -165,21 +192,36 @@ kinds:
             - { kind: paragraph, projection: inline, required: true }
 ```
 
-`mdsmith extract product-copy --format json` emits the
-headline as a span list — text, then the level-1
-emphasis span with its own `children`, then the
-trailing text:
+`mdsmith extract product-copy --format json docs/copy/product.md`
+emits the headline as a span list: text, then the
+level-1 emphasis span with its own `children`, then
+the trailing text:
 
 ```json
 {
-  "frontmatter": { "title": "Product copy" },
+  "frontmatter": {
+    "title": "Product copy"
+  },
   "headline": {
     "inline": [
-      { "span": "text", "value": "Mark" },
-      { "span": "emphasis", "level": 1, "children": [
-        { "span": "text", "value": "down" }
-      ]},
-      { "span": "text", "value": ", smithed." }
+      {
+        "span": "text",
+        "value": "Mark"
+      },
+      {
+        "children": [
+          {
+            "span": "text",
+            "value": "down"
+          }
+        ],
+        "level": 1,
+        "span": "emphasis"
+      },
+      {
+        "span": "text",
+        "value": ", smithed."
+      }
     ]
   }
 }
@@ -194,9 +236,11 @@ recursive mode switch:
 ```json
 "inline": [
   { "span": "text", "value": "run " },
-  { "span": "strong", "level": 2, "children": [
-    { "span": "code", "value": "mdsmith fix" }
-  ]},
+  {
+    "children": [{ "span": "code", "value": "mdsmith fix" }],
+    "level": 2,
+    "span": "strong"
+  },
   { "span": "text", "value": " daily" }
 ]
 ```
@@ -281,13 +325,14 @@ embed reads the tagline directly:
 file: docs/copy/product.md
 extract: tagline.text
 ?>
-Mark down your ideas; smith them into shipping
-docs.
+Mark down your ideas; smith them into shipping docs.
 <?/include?>
 ```
 
-The directive runs the included file through the
-same projection rules `mdsmith extract` produces,
+The spliced text lands on one line: a `text`
+projection joins a soft-wrapped paragraph with
+spaces. The directive runs the included file through
+the same projection rules `mdsmith extract` uses,
 walks the dotted path, and splices the leaf. There
 is no intermediate "fragment" file to keep in sync —
 the README reads the source of truth on every lint.

--- a/docs/reference/cli/extract.md
+++ b/docs/reference/cli/extract.md
@@ -59,8 +59,9 @@ Content entries project under default keys:
 - `paragraph` → `text` (plain text), or `inline` when
   the entry sets `projection: inline` (see below).
 
-Two sibling projections that resolve to the same key
-are a schema error. It is reported at extract time.
+Sibling keys are emitted in sorted order, not document
+order. Two sibling projections that resolve to the same
+key are a schema error. It is reported at extract time.
 Optional sections that did not match are omitted, not
 emitted as null.
 
@@ -110,9 +111,11 @@ For the headline `Mark*down*, smithed.`:
 "headline": {
   "inline": [
     { "span": "text", "value": "Mark" },
-    { "span": "emphasis", "level": 1, "children": [
-      { "span": "text", "value": "down" }
-    ]},
+    {
+      "children": [{ "span": "text", "value": "down" }],
+      "level": 1,
+      "span": "emphasis"
+    },
     { "span": "text", "value": ", smithed." }
   ]
 }
@@ -122,9 +125,11 @@ A nested example — a strong span wrapping a code span,
 ``**`mdsmith fix`**`` — projects with no mode switch:
 
 ```json
-{ "span": "strong", "level": 2, "children": [
-    { "span": "code", "value": "mdsmith fix" }
-] }
+{
+  "children": [{ "span": "code", "value": "mdsmith fix" }],
+  "level": 2,
+  "span": "strong"
+}
 ```
 
 Each content kind constrains its projection at schema-
@@ -175,7 +180,10 @@ mdsmith extract plan --format msgpack plan/166_x.md > plan.mp
 
 ### Worked example
 
-A two-section kind schema and a conformant file:
+A two-section kind schema, a kind assignment, and a
+conformant file. Each section declares a `content:`
+entry. A section without one projects as an empty
+object:
 
 ```yaml
 # .mdsmith.yml
@@ -184,8 +192,15 @@ kinds:
     schema:
       sections:
         - heading: { regex: '^Tagline$' }
+          content:
+            - { kind: paragraph }
         - heading: { regex: '^VS Code$' }
           bind: vscode-description
+          content:
+            - { kind: paragraph }
+kind-assignment:
+  - glob: ["docs/copy.md"]
+    kinds: [product-copy]
 ```
 
 ```markdown
@@ -210,9 +225,15 @@ emits:
 
 ```json
 {
-  "frontmatter": { "title": "Product copy" },
-  "tagline": { "text": "Mark down your ideas; smith them into shipping docs." },
-  "vscode-description": { "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code." }
+  "frontmatter": {
+    "title": "Product copy"
+  },
+  "tagline": {
+    "text": "Mark down your ideas; smith them into shipping docs."
+  },
+  "vscode-description": {
+    "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code."
+  }
 }
 ```
 

--- a/plan/242_proto-content-entries.md
+++ b/plan/242_proto-content-entries.md
@@ -1,0 +1,117 @@
+---
+id: 242
+title: "proto.md schemas declare content entries via `<?content?>`"
+status: "🔲"
+summary: >-
+  A `<?content?>` directive row in a proto.md section body
+  declares the same content entry the inline `content:` list
+  declares, so file-based kinds validate and extract body
+  content instead of projecting empty section objects.
+model: opus
+depends-on: []
+---
+# proto.md schemas declare content entries via `<?content?>`
+
+## Goal
+
+A kind backed by a `proto.md` file schema validates headings
+only. The proto surface cannot express the inline schema's
+`content:` entries. `mdsmith extract` therefore projects
+every section of a proto-based kind as an empty object:
+
+```json
+"tagline": {}
+```
+
+The inline form of the same section declares
+`content: [{ kind: paragraph }]` and projects
+`"tagline": { "text": "…" }`. This asymmetry forces any
+extraction-centric kind onto the inline form. The inline form
+cannot root at H1, so such a kind can never combine body
+extraction with the `# {title}` heading sync
+(see the
+[extract guide](../docs/guides/extract-markdown-as-data.md)).
+
+After this plan, a `<?content?>` directive row in a proto
+section body declares one content entry. The directive body
+carries the same keys as an inline entry:
+
+```markdown
+# {title}
+
+## Tagline
+
+<?content
+kind: paragraph
+projection: inline
+?>
+```
+
+Two directives in one section declare two ordered entries
+(`text` / `text-2` keys behave as in the inline form). The
+precedent is `<?require filename: "…"?>`, which already lives
+in proto bodies as a directive row.
+
+## Design notes
+
+- The schema-package proto parser
+  ([`internal/schema/parse_file.go`](../internal/schema/parse_file.go))
+  parses the directive into the same `Content` slice the
+  inline parser fills. Validation reuses the inline rules
+  (`projection: inline` only on `kind: paragraph`, …).
+- MDS020's legacy file-schema parser must skip `<?content?>`
+  rows so they are not treated as body-sync template text.
+  Full content validation for proto-based kinds rides the
+  plan-156 parser that `mdsmith extract` already uses.
+- `bind:` and `required:` keys pass through unchanged.
+
+## Tasks
+
+1. Parse `<?content?>` rows in the schema-package proto
+   parser into content entries; reject unknown keys and
+   invalid kind/projection combinations at parse time with
+   the same diagnostics as the inline form.
+2. Teach the legacy MDS020 proto parser to skip
+   `<?content?>` rows (no body-sync interpretation, no
+   diagnostic).
+3. Wire extraction: a proto-based kind with `<?content?>`
+   entries projects body content identically to the
+   equivalent inline schema. Differential test: one schema
+   expressed both ways, byte-identical extract output
+   (modulo root level).
+4. Document the directive in the
+   [section-schema reference](../docs/reference/section-schema.md)
+   proto.md section and in the
+   [schemas guide](../docs/guides/schemas.md); update the
+   inline-vs-proto capability table.
+5. Revisit the
+   [extract guide](../docs/guides/extract-markdown-as-data.md)
+   "Frontmatter `title` and the H1" section: the
+   content-entries limit no longer applies; rewrite the
+   trade-off paragraph.
+
+## Acceptance Criteria
+
+- [ ] A proto.md section body may contain `<?content?>`
+  directive rows; each declares one content entry with the
+  inline keys (`kind`, `projection`, `required`, `bind`).
+- [ ] `mdsmith extract` on a proto-based kind with declared
+  content projects the same tree as the equivalent inline
+  schema.
+- [ ] MDS020 (legacy path) neither flags nor body-syncs a
+  `<?content?>` row.
+- [ ] Invalid directives (unknown kind, `projection: inline`
+  on a code-block, `bind: ""` on a content entry) fail at
+  config load with the inline form's diagnostics.
+- [ ] Docs updated: section-schema reference, schemas guide
+  capability table, extract guide trade-off paragraph.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues
+
+## Out of scope
+
+- Expressing `repeat:` / `sequential:` in proto.md (existing
+  limitation, unchanged).
+- The MDS020 cutover from the legacy parser to the
+  schema-package parser (separate effort; this plan only
+  makes the legacy parser skip the new rows).

--- a/plan/243_extract-h1-title.md
+++ b/plan/243_extract-h1-title.md
@@ -1,0 +1,99 @@
+---
+id: 243
+title: "`mdsmith extract` projects the document H1 as `title`"
+status: "🔲"
+summary: >-
+  When the composed schema roots at H2, extract emits the
+  document H1's rendered plain text under a reserved top-level
+  `title` key beside `frontmatter`, so consumers read the title
+  without duplicating it into a frontmatter field.
+model: sonnet
+depends-on: []
+---
+# `mdsmith extract` projects the document H1 as `title`
+
+## Goal
+
+The H1 is the document's title, but `mdsmith extract` cannot
+project it. Inline schemas root at H2, so the H1 is outside
+every scope. The only workaround is a proto.md `# {title}`
+row, and that requires a frontmatter `title` field that
+duplicates the H1. An unresolved `{title}` row degrades to a
+wildcard, and extract skips wildcard scopes. The
+[extract guide](../docs/guides/extract-markdown-as-data.md)
+documents this as a current limit.
+
+After this plan, when the composed schema roots at H2, the
+projector emits the document H1's rendered plain text under a
+reserved top-level `title` key:
+
+```json
+{
+  "frontmatter": {},
+  "title": "Product copy",
+  "tagline": { "text": "…" }
+}
+```
+
+Files stop needing a frontmatter `title:` whose only consumer
+wanted the document title as data. `<?include extract:
+title?>` splices it.
+
+## Design notes
+
+- **Reserved key, no opt-in.** The key is `title`, emitted
+  beside `frontmatter` whenever the schema roots at H2 and
+  the document has an H1. No H1 → key omitted (consistent
+  with optional sections: omitted, not null).
+- **Rendered plain text.** Same renderer the heading matcher
+  uses: emphasis and code-span markers stripped, link text
+  kept, attribute lists and trailing ATX `#`s dropped.
+- **Collisions.** A sibling scope that resolves to the key
+  `title` (slug or `bind:`) is a collision, reported through
+  the existing sibling-collision machinery; the schema author
+  resolves it with `bind:`.
+- **H1-rooted schemas unchanged.** When the composed schema
+  roots at H1 (proto.md), the H1 is already a scope; no
+  reserved key is added.
+- **First H1 wins** when a document carries more than one.
+
+## Tasks
+
+1. Emit the reserved `title` key in
+   [`internal/extract`](../internal/extract) when the
+   composed schema's root level is 2 and the document has an
+   H1; omit it otherwise. Unit-test: present, absent,
+   emphasis-bearing, and multi-H1 documents.
+2. Route the key through the existing collision check; test a
+   scope bound to `title` reports a collision naming both
+   sources.
+3. Verify `<?include extract: title?>` splices the H1 text
+   (the include path walks the same projection).
+4. Update the
+   [extract reference](../docs/reference/cli/extract.md)
+   default-projection section and the
+   [extract guide](../docs/guides/extract-markdown-as-data.md):
+   the "cannot project the H1 without a frontmatter field"
+   limit is gone; rewrite the closing paragraph of the
+   "Frontmatter `title` and the H1" section and its verified
+   outputs.
+
+## Acceptance Criteria
+
+- [ ] `mdsmith extract` on an H2-rooted kind emits
+  `"title": "<H1 plain text>"` at the top level; the key is
+  omitted when the document has no H1.
+- [ ] A sibling projection that resolves to `title` is
+  reported as a collision before any data is emitted.
+- [ ] H1-rooted (proto.md) schemas produce unchanged output.
+- [ ] `<?include extract: title?>` splices the H1 text.
+- [ ] Reference and guide updated with verified outputs.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues
+
+## Out of scope
+
+- Inline-span projection of the H1 (rides the block grammar,
+  [plan 246](246_block-projection-full-extract.md)).
+- Enforcing H1 ↔ frontmatter consistency (already covered by
+  proto.md heading sync).

--- a/plan/244_structured-list-projection.md
+++ b/plan/244_structured-list-projection.md
@@ -1,0 +1,116 @@
+---
+id: 244
+title: "Structured list projection; fix nested-item text corruption"
+status: "🔲"
+summary: >-
+  Fix flat list projection concatenating nested-item text into
+  the parent with no separator, then add `projection: tree` so
+  list items project as objects with `text`, a `checked` bool
+  for task items, and recursive `children`.
+model: opus
+depends-on: []
+---
+# Structured list projection; fix nested-item text corruption
+
+## Goal
+
+`kind: list` projects items as flat strings. The flattening
+is corrupt. A nested child's text concatenates into its
+parent with no separator. Inline markup is silently
+stripped. For
+
+```markdown
+- [x] done item
+- [ ] open item with **bold**
+  - nested child
+```
+
+extract emits
+
+```json
+"items": [
+  "[x] done item",
+  "[ ] open item with boldnested child"
+]
+```
+
+`boldnested child` is data corruption, not just loss. Task
+checkboxes survive only as literal `"[x] "` prefixes, nesting
+is gone, and no consumer can recover any of it.
+
+This plan has two parts. First, an unconditional bugfix: a
+flat item projects its own text only — children are excluded,
+word boundaries survive. Second, an opt-in structured mode:
+
+```yaml
+content:
+  - { kind: list, projection: tree }
+```
+
+projects each item as an object:
+
+```json
+"items": [
+  { "text": "done item", "checked": true },
+  {
+    "checked": false,
+    "children": [
+      { "text": "nested child" }
+    ],
+    "text": "open item with bold"
+  }
+]
+```
+
+- `text` — the item's own inline text, soft wraps joined.
+- `checked` — present only on task-list items
+  (`- [x]` / `- [ ]`); the marker leaves `text`.
+- `children` — present only when the item nests a sub-list;
+  recursive through the same shape.
+
+## Design notes
+
+- The flat default keeps emitting strings (compat), minus the
+  corruption: own text only, task markers kept as today.
+- `projection: tree` is validated at schema-load time like
+  `projection: inline` (list-only; rejected elsewhere).
+- Ordered-list metadata (`start`, numbering) is out of scope;
+  the item order is the array order either way.
+- Inline spans inside items
+  (`projection: tree` + span lists) ride the block grammar
+  ([plan 246](246_block-projection-full-extract.md)), not
+  this plan.
+
+## Tasks
+
+1. **Bugfix first (red/green).** Failing test reproducing
+   `boldnested child`; fix flat projection to emit each
+   top-level item's own text. Decide and test what flat mode
+   emits for an item that is *only* a nested list.
+2. Add `projection: tree` to content-entry validation
+   (list-only) and implement the recursive item walker in
+   [`internal/extract`](../internal/extract): `text`,
+   optional `checked`, optional `children`.
+3. Task-list detection: `checked` appears only on items with
+   a GFM task marker; the marker text never leaks into
+   `text` in tree mode.
+4. Document both modes and the bugfix in the
+   [extract reference](../docs/reference/cli/extract.md)
+   (default-projection table + a tree example) and add a
+   worked example to the
+   [extract guide](../docs/guides/extract-markdown-as-data.md).
+
+## Acceptance Criteria
+
+- [ ] Flat `items` never concatenates nested-item text into a
+  parent string; the corrupt case above projects
+  `"[ ] open item with bold"`.
+- [ ] `projection: tree` emits item objects with `text`,
+  `checked` only on task items, `children` only when
+  non-empty, recursive to any depth.
+- [ ] `projection: tree` on a non-list content entry fails at
+  config load.
+- [ ] YAML and msgpack formats emit the same tree.
+- [ ] Reference and guide updated with verified outputs.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/245_table-projection-modes.md
+++ b/plan/245_table-projection-modes.md
@@ -1,0 +1,92 @@
+---
+id: 245
+title: "Table projection modes: `records` and `rows`"
+status: "🔲"
+summary: >-
+  Name the current header-keyed object projection
+  `projection: records`, add `projection: rows` emitting a
+  `columns` array plus row arrays that preserve column order
+  and tolerate duplicate headers, and define the
+  duplicate-header semantics for both.
+model: sonnet
+depends-on: []
+---
+# Table projection modes: `records` and `rows`
+
+## Goal
+
+`kind: table` projects one shape: an array of objects keyed
+by column header. That shape loses column order (output keys
+are sorted), cannot represent duplicate column headers, and
+is awkward for consumers that want positional data — a chart
+script, a CSV writer, a diff over runs.
+
+After this plan a table content entry picks one of two
+projections. `projection: records` is the current shape and
+stays the default:
+
+```json
+"matrix": {
+  "rows": [
+    { "Feature": "check", "Status": "ready" }
+  ]
+}
+```
+
+`projection: rows` emits column order and positional rows:
+
+```json
+"matrix": {
+  "columns": ["Feature", "Status"],
+  "rows": [
+    ["check", "ready"]
+  ]
+}
+```
+
+## Design notes
+
+- **Duplicate headers.** `records` reports a duplicate column
+  header as an extract-time error (two cells would collide on
+  one key). `rows` accepts duplicates — the `columns` array
+  is positional.
+- **Column order.** `columns` preserves document order; this
+  is the only projection surface where order survives the
+  sorted-key serializer.
+- **Cell text.** Both modes keep today's plain-text cells
+  (inline markup flattened, link URLs dropped). Inline-span
+  cells ride the block grammar
+  ([plan 246](246_block-projection-full-extract.md)).
+- Today any `projection:` on a table is rejected at config
+  load; this plan narrows that rejection to unknown values.
+
+## Tasks
+
+1. Accept `projection: records | rows` on `kind: table` at
+   schema-load time; keep rejecting other values and keep
+   `records` the default.
+2. Implement the `rows` walker: `columns` from the header
+   row in document order, each body row as a same-length
+   array (short rows pad with `""`, matching GFM rendering).
+3. Define duplicate-header behavior red/green: `records`
+   errors with both column positions named; `rows` projects
+   them positionally.
+4. Document both modes in the
+   [extract reference](../docs/reference/cli/extract.md)
+   (projection table, duplicate-header semantics) and show
+   one `rows` example in the
+   [extract guide](../docs/guides/extract-markdown-as-data.md).
+
+## Acceptance Criteria
+
+- [ ] `projection: rows` emits `columns` in document order
+  plus positional row arrays; `projection: records` output is
+  byte-identical to today's default.
+- [ ] A duplicate column header errors under `records` and
+  projects under `rows`.
+- [ ] A short body row pads with empty strings to the header
+  width under `rows`.
+- [ ] An unknown table projection still fails at config load.
+- [ ] Reference and guide updated with verified outputs.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -1,0 +1,148 @@
+---
+id: 246
+title: "Typed block projection and full-document extract"
+status: "🔲"
+summary: >-
+  A block-level analogue of the inline-span grammar: a section
+  projects its whole body as a typed, recursive `blocks` list,
+  a schema-level default applies it everywhere (wildcard
+  sections included), and a CUE definition of the output
+  grammar ships as the documented contract.
+model: opus
+depends-on: [244, 245]
+---
+# Typed block projection and full-document extract
+
+## Goal
+
+Extract output is a faithful image of the *declared* schema
+only. A section without `content:` entries projects as `{}`,
+wildcard and unlisted sections are skipped, and heading text
+is reduced to a lossy slug key. There is no way to say "give
+me all heading body content" — the premise of the
+[extract guide](../docs/guides/extract-markdown-as-data.md)
+stops at declared entries.
+
+Exposing the raw goldmark AST would be unwieldy and would
+freeze a third-party API into the output. The precedent is
+[plan 212](212_extract-inline-spans.md): a small, documented,
+typed grammar — spans for inline content. This plan is the
+block-level analogue, plus a default mode that applies it to
+every matched section.
+
+A scope-level projection:
+
+```yaml
+sections:
+  - heading: { regex: '^Notes$' }
+    projection: blocks
+```
+
+projects the section's whole body, in document order:
+
+```json
+"notes": {
+  "blocks": [
+    { "block": "paragraph", "text": "First paragraph." },
+    { "block": "code", "lang": "go", "value": "func F() {}\n" },
+    { "block": "quote", "blocks": [
+      { "block": "paragraph", "text": "A quoted line." }
+    ]},
+    { "block": "list", "items": [ { "text": "one item" } ] },
+    { "block": "table", "columns": ["A"], "rows": [["1"]] }
+  ]
+}
+```
+
+A schema-level `projection: blocks` makes that the default
+for every scope. It also projects the sections the walker
+currently skips. A wildcard or unlisted section projects
+under its slug, with its heading text preserved:
+
+```json
+"background": {
+  "heading": "Background",
+  "blocks": [ … ]
+}
+```
+
+With [plan 243](243_extract-h1-title.md)'s `title` key, a
+single schema-level switch yields the whole document as data.
+
+## The block grammar
+
+| Body node      | Emitted block                                   |
+| -------------- | ----------------------------------------------- |
+| paragraph      | `{block: paragraph, text}`                      |
+| fenced code    | `{block: code, lang?, value}`                   |
+| list           | `{block: list, items: [tree items]}` (plan 244) |
+| table          | `{block: table, columns, rows}` (plan 245)      |
+| blockquote     | `{block: quote, blocks: [...]}` (recursive)     |
+| thematic break | `{block: break}`                                |
+| HTML block     | `{block: html, value}`                          |
+| deeper heading | `{block: section, level, heading, blocks}`      |
+
+Container blocks (`quote`, `section`) recurse through the
+same grammar. This mirrors the span list's split between
+containers and leaves. A `section` block appears only for
+headings deeper than the declared schema. Declared child
+scopes keep projecting as keyed objects.
+
+## The CUE contract
+
+The output grammar ships as a CUE definition (one `#Block`
+disjunction plus the plan-212 `#Span`), published in the
+[extract reference](../docs/reference/cli/extract.md). A
+differential test validates every extract fixture's JSON
+against the CUE definition, so the grammar cannot drift from
+the implementation. Consumers get a machine-checkable
+contract instead of prose.
+
+## Tasks
+
+1. Implement the block walker in
+   [`internal/extract`](../internal/extract) over the grammar
+   table above, reusing plan 244's item shape and plan 245's
+   `columns`/`rows` shape; paragraphs default to `text`.
+2. Accept `projection: blocks` on a scope; the `blocks` key
+   joins the default-key set (`bind:`-renamable, collision-
+   checked against declared content entries).
+3. Accept schema-level `projection: blocks`; project wildcard
+   and unlisted scopes under their slug with a `heading` text
+   field; repeating matches project as arrays.
+4. Write the `#Block` / `#Span` CUE definitions; add the
+   differential test validating all extract fixtures against
+   them.
+5. Offer a paragraph option for inline spans inside blocks
+   (`{block: paragraph, inline: [...]}`) gated by the same
+   entry-level choice as plan 212, so block mode does not
+   force plain text.
+6. Document the grammar in the extract reference and rewrite
+   the guide's framing: declared entries constrain and
+   rename; `projection: blocks` captures everything else.
+
+## Acceptance Criteria
+
+- [ ] `projection: blocks` on a scope projects its full body
+  as the typed list, document order preserved, containers
+  recursive.
+- [ ] Schema-level `projection: blocks` projects wildcard and
+  unlisted sections with `heading` text; no section of a
+  matched document is silently dropped.
+- [ ] Every block fixture validates against the published CUE
+  `#Block` definition in a differential test.
+- [ ] An HTML block and a thematic break project (no hard
+  error); an image inside a `blocks`-mode paragraph projects
+  via the inline option or a defined fallback — extract does
+  not exit non-zero for representable content.
+- [ ] Reference and guide updated with verified outputs.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool golangci-lint run` reports no issues
+
+## Out of scope
+
+- Raw-Markdown (verbatim source) projection of a section
+  body; revisit if a consumer needs round-tripping rather
+  than data.
+- Changing the default projection of existing schemas;
+  without `projection: blocks` nothing changes.


### PR DESCRIPTION
## Summary

The "good" examples in `docs/guides/extract-markdown-as-data.md` could not be reproduced as written. Every problem below was found by building `mdsmith` and running the examples end to end:

- The schemas declared no `content:` entries, so every section projected as an **empty object** instead of the documented `{"text": ...}` values.
- The `mdsmith extract` commands omitted the required `<file>` argument (`extract <kind> --format <fmt> <file>`).
- The config never assigned the `product-copy` kind to the file, so `extract` exited with `kind "product-copy" is not assigned`.
- The JSON blocks showed authored key order and compacted formatting; `extract` emits sorted keys, pretty-printed.
- The `<?include extract:?>` example showed the spliced tagline wrapped across two lines; the actual splice lands on one line.
- "produce identical JSON" overstated the frontmatter/body comparison: the strings match but the keys differ (`frontmatter.tagline` vs `tagline.text`).

## Changes

- Guide: add `content:` entries and a `kind-assignment:` to the worked-example config, add the file argument to both commands, and replace both JSON blocks with byte-for-byte captures of `mdsmith extract` output (verified by diff).
- Guide: correct the identical-JSON claim, note sorted key order, and fix the include-splice body.
- Guide: new "Frontmatter `title` and the H1" section — when to drop the frontmatter field, how a proto.md `# {title}` row makes MDS020 enforce H1/title agreement (heading sync), and the verified limits of that route.
- CLI reference (`docs/reference/cli/extract.md`): apply the same `content:`/`kind-assignment` fix to its worked example, make its output verbatim, document sorted sibling-key ordering, and align the span fragments with emitted key order.
- Plans 242–246: design the extract projection-coverage work that fell out of the gap analysis — proto.md `<?content?>` entries, H1-as-`title` projection, structured list projection (plus a flat-mode corruption bugfix), `records`/`rows` table modes, and the typed block grammar with a schema-level full-document default and a CUE output contract.

## Verification

- Each documented JSON block diffs clean against actual `mdsmith extract` output.
- `mdsmith check .` passes (442 files, 0 failures).
- `go test ./cmd/mdsmith -run Extract` passes.

https://claude.ai/code/session_01VQ2KCQb2pRoRqAT62SnkyS