### PR TITLE
website: surface product category, fix mobile layout and contrast

### DIFF
--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -415,8 +415,10 @@ func runVerifyWebsiteLinks(_ string, args []string) int {
 				"page permalink, `index.md` drop → section URL, no\n"+
 				"unpublished `README.md` hrefs in rule pages,\n"+
 				"javascript:/data: hrefs neutralized, and the configured\n"+
-				"baseURL prefix on site-absolute hrefs. Exits non-zero on\n"+
-				"the first failed probe.\n")
+				"baseURL prefix on site-absolute hrefs. Also resolves\n"+
+				"every internal homepage href to a rendered page, since\n"+
+				"template-emitted links bypass the markdown link rules.\n"+
+				"Exits non-zero on the first failed probe.\n")
 	}
 	if err := fs.Parse(args); err != nil {
 		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: verify-website-links"); code >= 0 {

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -356,6 +356,8 @@ func TestRunVerifyWebsiteLinksHappyPath(t *testing.T) {
 		[]byte(`<a href="/rules/mds020-required-structure/">x</a>`), 0o644))
 	require.NoError(t, os.WriteFile(rule,
 		[]byte(`<a href="/rules/mds021/">x</a>`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "index.html"),
+		[]byte(`<p>home</p>`), 0o644))
 
 	assert.Equal(t, 0, run([]string{"verify-website-links", "--dir", root}))
 }

--- a/internal/release/verifylinks.go
+++ b/internal/release/verifylinks.go
@@ -45,7 +45,42 @@ func VerifyWebsiteLinks(htmlDir, baseURL string) error {
 			return err
 		}
 	}
+	if err := verifyHomeHrefs(htmlDir, prefix); err != nil {
+		return err
+	}
 	return verifyBreadcrumbs(htmlDir, prefix)
+}
+
+// homeLinkRe matches one anchor on the homepage, capturing its
+// href whether quoted (Hugo's default) or unquoted (--minify).
+// Other attributes may precede href (class on buttons and cards),
+// so the prefix is lazy.
+var homeLinkRe = regexp.MustCompile(`<a\s[^>]*?href="?([^"\s>]+)"?`)
+
+// verifyHomeHrefs resolves every site-internal <a href> on the
+// rendered homepage to a page on disk. The homepage is assembled
+// almost entirely from templates (hero, nav, feature cards,
+// footer), so its hardcoded hrefs bypass both the markdown-side
+// link rules and the render-link hook that docs pages get — a
+// renamed or pruned guide would otherwise rot a homepage link
+// silently. External and protocol-relative links are skipped;
+// each remaining site-absolute href resolves under the same rules
+// breadcrumb crumbs use.
+func verifyHomeHrefs(htmlDir, prefix string) error {
+	data, err := readHTMLFile(filepath.Join(htmlDir, "index.html"))
+	if err != nil {
+		return fmt.Errorf("verify homepage hrefs: %w", err)
+	}
+	for _, m := range homeLinkRe.FindAllSubmatch(data, -1) {
+		href := string(m[1])
+		if !strings.HasPrefix(href, "/") || strings.HasPrefix(href, "//") {
+			continue
+		}
+		if err := resolveCrumbHref(htmlDir, prefix, href); err != nil {
+			return fmt.Errorf("verify homepage hrefs: %w", err)
+		}
+	}
+	return nil
 }
 
 // breadcrumbNavRe captures the inner HTML of the docs-breadcrumb

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -200,8 +200,20 @@ func TestVerifyWebsiteLinks_HomeInternalHrefResolves(t *testing.T) {
 	writeFile(t, filepath.Join(root, "index.html"),
 		`<a class="hero-switch-link" href="/guides/migrate-from-markdownlint/">guide</a>`+
 			`<a href=/guides/install/>install</a>`+
-			`<a href="https://github.com/jeduden/mdsmith" rel="noopener">gh</a>`)
+			`<a href="https://github.com/jeduden/mdsmith" rel="noopener">gh</a>`+
+			`<a href="//cdn.example.com/x/">protocol-relative</a>`)
 	require.NoError(t, VerifyWebsiteLinks(root, ""))
+}
+
+// TestVerifyWebsiteLinks_FailsOnMissingHomepage pins the probe's
+// fail-closed behavior: a rendered tree without a homepage cannot
+// pass, mirroring the single-file probes.
+func TestVerifyWebsiteLinks_FailsOnMissingHomepage(t *testing.T) {
+	root := goodSite(t, "")
+	require.NoError(t, os.Remove(filepath.Join(root, "index.html")))
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify homepage hrefs")
 }
 
 // TestVerifyWebsiteLinks_FailsOnHomeHrefMissingTarget pins the

--- a/internal/release/verifylinks_test.go
+++ b/internal/release/verifylinks_test.go
@@ -57,6 +57,7 @@ func TestVerifyWebsiteLinks_AcceptsUnquotedHref(t *testing.T) {
 		`<a href=/rules/mds020-required-structure/>rule</a>`)
 	writeFile(t, filepath.Join(root, "rules", "mds001", "index.html"),
 		`<a href=/rules/mds021/>sibling</a>`)
+	writeFile(t, filepath.Join(root, "index.html"), `<p>home</p>`)
 	require.NoError(t, VerifyWebsiteLinks(root, ""))
 }
 
@@ -183,6 +184,49 @@ func TestVerifyWebsiteLinks_MissingRecursiveRootWraps(t *testing.T) {
 	err := VerifyWebsiteLinks(root, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "walk")
+}
+
+// --- homepage href probes ---
+
+// TestVerifyWebsiteLinks_HomeInternalHrefResolves accepts a
+// homepage whose internal links point at rendered pages; external
+// links and unquoted (--minify) hrefs are handled too.
+func TestVerifyWebsiteLinks_HomeInternalHrefResolves(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "guides", "migrate-from-markdownlint", "index.html"),
+		`<p>guide</p>`)
+	writeFile(t, filepath.Join(root, "guides", "install", "index.html"),
+		`<p>install</p>`)
+	writeFile(t, filepath.Join(root, "index.html"),
+		`<a class="hero-switch-link" href="/guides/migrate-from-markdownlint/">guide</a>`+
+			`<a href=/guides/install/>install</a>`+
+			`<a href="https://github.com/jeduden/mdsmith" rel="noopener">gh</a>`)
+	require.NoError(t, VerifyWebsiteLinks(root, ""))
+}
+
+// TestVerifyWebsiteLinks_FailsOnHomeHrefMissingTarget pins the
+// link-rot guard: the homepage is assembled from templates (hero,
+// nav, cards, footer), so its hardcoded hrefs bypass the markdown
+// link rules — a renamed guide must fail the probe.
+func TestVerifyWebsiteLinks_FailsOnHomeHrefMissingTarget(t *testing.T) {
+	root := goodSite(t, "")
+	writeFile(t, filepath.Join(root, "index.html"),
+		`<a href="/guides/migrate-from-markdownlint/">moved guide</a>`)
+	err := VerifyWebsiteLinks(root, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "migrate-from-markdownlint")
+}
+
+// TestVerifyWebsiteLinks_HomeHrefSubpathResolves trims the
+// project-pages baseURL prefix before resolving, mirroring the
+// breadcrumb resolution rules.
+func TestVerifyWebsiteLinks_HomeHrefSubpathResolves(t *testing.T) {
+	root := goodSite(t, "/mdsmith")
+	writeFile(t, filepath.Join(root, "guides", "install", "index.html"),
+		`<p>install</p>`)
+	writeFile(t, filepath.Join(root, "index.html"),
+		`<a href="/mdsmith/guides/install/">install</a>`)
+	require.NoError(t, VerifyWebsiteLinks(root, "https://example.com/mdsmith/"))
 }
 
 // --- breadcrumb probes ---

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -10,8 +10,6 @@ hero:
 ---
 mdsmith is a Markdown linter and formatter written in Go. It checks style,
 readability, structure, and cross-file integrity, and auto-fixes what fixes
-cleanly. Where markdownlint-compatible linters stop at per-file style,
-mdsmith adds the cross-file graph, generated sections, and readability
-budgets. One rule engine powers the CLI, the LSP server, and the VS Code
+cleanly. One rule engine powers the CLI, the LSP server, and the VS Code
 extension — Neovim and other LSP-aware editors plug in through the same
 server, and a Claude Code plugin is available for users of that editor.

--- a/website/e2e/tests/home.spec.ts
+++ b/website/e2e/tests/home.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Homepage positioning and audience-path tests.
+ *
+ * Covers the category statement (the content/_index.md body that
+ * layouts/index.html renders under the hero) and the markdownlint
+ * migration link in the hero — the two elements that tell a
+ * first-time visitor what mdsmith is and where to start.
+ */
+test.describe("homepage positioning", () => {
+  test("category statement renders under the hero", async ({ page }) => {
+    await page.goto("/");
+
+    const positioning = page.locator(".positioning-body");
+    await expect(positioning).toBeVisible();
+    await expect(positioning).toContainText(
+      "mdsmith is a Markdown linter and formatter written in Go",
+    );
+  });
+
+  test("hero links markdownlint users to the migration guide", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const link = page.locator(".hero-switch a");
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      "href",
+      /\/guides\/migrate-from-markdownlint\/$/,
+    );
+  });
+
+  test("install commands stay readable on a narrow viewport", async ({
+    page,
+  }) => {
+    // Below 560 px each install row wraps: the command line gets the
+    // full row width instead of the truncated leftover next to the
+    // label and copy button.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+
+    const row = page.locator(".install-row").first();
+    const cmd = row.locator(".install-cmd");
+    const rowBox = await row.boundingBox();
+    const cmdBox = await cmd.boundingBox();
+    expect(rowBox).not.toBeNull();
+    expect(cmdBox).not.toBeNull();
+    // Full-width line: the command spans (almost) the row's inner
+    // width rather than the ~40% it got next to the label.
+    expect(cmdBox!.width).toBeGreaterThan(rowBox!.width * 0.8);
+  });
+});

--- a/website/e2e/tests/home.spec.ts
+++ b/website/e2e/tests/home.spec.ts
@@ -42,11 +42,17 @@ test.describe("homepage positioning", () => {
     await page.goto("/");
 
     const row = page.locator(".install-row").first();
+    const label = row.locator(".install-label");
     const cmd = row.locator(".install-cmd");
     const rowBox = await row.boundingBox();
+    const labelBox = await label.boundingBox();
     const cmdBox = await cmd.boundingBox();
     expect(rowBox).not.toBeNull();
+    expect(labelBox).not.toBeNull();
     expect(cmdBox).not.toBeNull();
+    // Wrapped: the command renders on a line below the label
+    // rather than truncated beside it.
+    expect(cmdBox!.y).toBeGreaterThanOrEqual(labelBox!.y + labelBox!.height);
     // Full-width line: the command spans (almost) the row's inner
     // width rather than the ~40% it got next to the label.
     expect(cmdBox!.width).toBeGreaterThan(rowBox!.width * 0.8);

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -4,7 +4,10 @@
          category statement ("mdsmith is a Markdown linter and
          formatter written in Go…"). Render it right under the
          hero so a first-time visitor can classify the product
-         without scrolling to the Why section. */ -}}
+         without scrolling to the Why section. The canonical copy
+         is the intro of docs/features/index.md (which the README
+         includes and /features/ renders); keep the _index.md body
+         aligned with it when either changes. */ -}}
   {{ with .Content }}
   <section class="positioning">
     <div class="container">

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -1,11 +1,23 @@
 {{ define "main" }}
   {{ partial "hero.html" . }}
+  {{- /* The page body of content/_index.md is the one-paragraph
+         category statement ("mdsmith is a Markdown linter and
+         formatter written in Go…"). Render it right under the
+         hero so a first-time visitor can classify the product
+         without scrolling to the Why section. */ -}}
+  {{ with .Content }}
+  <section class="positioning">
+    <div class="container">
+      <div class="positioning-body">{{ . }}</div>
+    </div>
+  </section>
+  {{ end }}
   {{ partial "logos-strip.html" . }}
   <section class="section">
     <div class="container">
       <div class="section-eyebrow">Why mdsmith</div>
       <h2 class="section-title">Forged <em>whole.</em></h2>
-      <p class="section-lead">Where other linters stop at per-file style, mdsmith forges the whole tree: it checks readability, ties files together with links, includes, and schemas, keeps generated sections in sync, and gates the result in CI — all from one engine that runs the same in your editor, your agent, and your pipeline. Each card opens a fuller write-up; the same copy backs the repository README.</p>
+      <p class="section-lead">Where other linters stop at per-file style, mdsmith forges the whole tree: it checks readability, ties files together with links, includes, and schemas, keeps generated sections in sync, and gates the result in CI — all from one engine that runs the same in your editor, your agent, and your pipeline.</p>
       {{ partial "feature-grid.html" . }}
     </div>
   </section>

--- a/website/layouts/partials/hero.html
+++ b/website/layouts/partials/hero.html
@@ -23,6 +23,15 @@
             {{ $.Site.Params.githubRepo }}
           </a>
         </div>
+        {{- /* markdownlint users are the highest-intent audience;
+               give them a direct path to the rule mapping and
+               config rewrite instead of leaving the migration
+               guide buried in the docs tree. */ -}}
+        <p class="hero-switch">
+          Coming from markdownlint?
+          <a href="{{ "/guides/migrate-from-markdownlint/" | relURL }}">Follow the migration guide</a>
+          for the rule mapping and config rewrite.
+        </p>
         {{- $repo := $.Site.Params.githubRepo -}}
         <div class="hero-badges" aria-label="Live project health">
           <a href="https://github.com/{{ $repo }}/actions/workflows/ci.yml?query=branch%3Amain" rel="noopener">

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -86,7 +86,7 @@ main {
 .topnav-link.is-active { color: var(--fg); }
 .topnav-brand img { display: block; }
 .topnav-right { margin-left: auto; display: flex; align-items: center; gap: 10px; }
-.topnav-version { font-family: var(--font-mono); font-size: 12px; color: var(--fg-subtle); }
+.topnav-version { font-family: var(--font-mono); font-size: 12px; color: var(--fg-subtle); white-space: nowrap; }
 .topnav-version:hover { color: var(--accent); text-decoration: none; }
 .topnav-kbd {
   font-family: var(--font-mono);
@@ -197,12 +197,36 @@ main {
 .hero-lead p { margin: 0; }
 .hero-lead p:not(:last-child) { margin-bottom: 12px; }
 .hero-cta { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+.hero-switch {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  margin: 16px 0 0;
+}
 .hero-badges {
   display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
   margin-top: 22px;
 }
 .hero-badges a { display: inline-flex; line-height: 0; }
 .hero-badges img { height: 20px; display: block; }
+
+/* ========== POSITIONING ========== */
+
+/* One-paragraph category statement (the content/_index.md body),
+   rendered between the hero and the logos strip so a first-time
+   visitor can classify the product without scrolling. */
+.positioning {
+  padding: 36px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.positioning-body {
+  max-width: 760px;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--fg-muted);
+}
+.positioning-body p { margin: 0; }
+.positioning-body p:not(:last-child) { margin-bottom: 12px; }
 
 /* ========== BUTTONS ========== */
 
@@ -276,12 +300,14 @@ main {
   gap: 12px;
   margin-bottom: 16px;
 }
+/* steel-400 / steel-500: the lighter steel-300/400 pair sat below
+   the 4.5:1 WCAG AA contrast bar at these tiny sizes. */
 .pillar-num {
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.08em;
-  color: var(--steel-300);
+  color: var(--steel-400);
   flex-shrink: 0;
 }
 .pillar-name {
@@ -290,7 +316,7 @@ main {
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--steel-400);
+  color: var(--steel-500);
   flex-shrink: 0;
 }
 .pillar-rule {
@@ -456,6 +482,9 @@ main {
 
 .card-content { display: flex; flex-direction: column; flex: 1; }
 
+/* steel-500 / forge-600 bases: the old steel-300 / forge-400 read
+   at ~2:1 against the card background — under the 4.5:1 WCAG AA
+   bar — and touch users never see the darker hover state. */
 .card-more {
   display: inline-flex;
   align-items: center;
@@ -463,15 +492,15 @@ main {
   font-size: 11.5px;
   font-weight: 500;
   letter-spacing: 0.01em;
-  color: var(--steel-300);
+  color: var(--steel-500);
   margin-top: auto;
   padding-top: 18px;
   text-decoration: none;
   transition: color 130ms ease;
 }
-.card:hover .card-more { color: var(--steel-500); }
-.card-body--lead .card-more { color: var(--forge-400); font-size: 12.5px; }
-.card--lead:hover .card-more { color: var(--forge-600); }
+.card:hover .card-more { color: var(--steel-700); }
+.card-body--lead .card-more { color: var(--forge-600); font-size: 12.5px; }
+.card--lead:hover .card-more { color: var(--forge-700); }
 .card-more svg { transition: transform 130ms ease; }
 .card:hover .card-more svg { transform: translateX(2px); }
 
@@ -1130,6 +1159,18 @@ a.install-label:hover { color: var(--forge-300); text-decoration: underline; }
   color: var(--forge-700); border-color: var(--forge-500); background: var(--forge-50);
 }
 .install-row[hidden] { display: none; }
+
+/* On narrow screens the single-row layout truncated commands to a
+   few characters ("$ go install g…") with no visible affordance —
+   the overflow-x scroll is invisible until touched. Wrap instead:
+   label and copy button share the top line, the command drops to
+   a full-width line below (still nowrap + scrollable for the
+   longest curl/unzip lines). */
+@media (max-width: 560px) {
+  .install-row { flex-wrap: wrap; row-gap: 8px; padding: 12px 16px; }
+  .install-label { flex: 1 1 auto; }
+  .install-row .install-cmd { order: 3; flex-basis: 100%; }
+}
 /* Sits on the light section background; --fg-muted reads at ~8.4:1. */
 .install-note {
   margin: 0;
@@ -1729,6 +1770,19 @@ a.rule-ref:hover code { text-decoration: underline; }
   html.js .docs-side-nav { display: none; }
   html.js .docs-side-nav.is-open { display: block; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
+  /* The brand cell drops from 2fr to a half-width column here,
+     which crushed the tagline to ~12 characters per line; span
+     both columns instead. */
+  .footer-grid .footer-col:first-child { grid-column: 1 / -1; }
+
+  /* space-between + wrap scattered the channel names with ragged
+     gaps once they wrapped; switch to a left-aligned gap flow with
+     the label on its own line. */
+  .logos { padding: 28px 0; }
+  .logos-strip { justify-content: flex-start; gap: 12px 24px; }
+  .logos-label { flex-basis: 100%; }
+  .logos-item { font-size: 16px; }
+
   .pg { grid-template-columns: 1fr; height: auto; }
   .pg-pane + .pg-pane { border-left: 0; border-top: 1px solid var(--border); }
   .pg-pane { height: 360px; }

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -189,13 +189,15 @@ main {
   max-width: 540px;
   margin: 0 0 28px;
 }
-/* Hero lead body is rendered through Hugo's `markdownify`,
-   which wraps the text in <p>. Without these resets, the
-   global `p, .p { margin: 0 0 var(--space-4); }` from
-   colors_and_type.css would stack on top of .hero-lead's
-   own bottom margin. */
-.hero-lead p { margin: 0; }
-.hero-lead p:not(:last-child) { margin-bottom: 12px; }
+/* Hero lead and positioning bodies are rendered Markdown
+   (markdownify / .Content), which wraps the text in <p>.
+   Without these resets, the global
+   `p, .p { margin: 0 0 var(--space-4); }` from
+   colors_and_type.css would stack on top of the blocks'
+   own bottom margins. */
+.hero-lead p, .positioning-body p { margin: 0; }
+.hero-lead p:not(:last-child),
+.positioning-body p:not(:last-child) { margin-bottom: 12px; }
 .hero-cta { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
 .hero-switch {
   font-size: 14px;
@@ -219,14 +221,14 @@ main {
   padding: 36px 0;
   border-bottom: 1px solid var(--border-subtle);
 }
+/* Paragraph margin resets live with .hero-lead's (same
+   rendered-Markdown wrapping). */
 .positioning-body {
   max-width: 760px;
   font-size: 16px;
   line-height: 1.65;
   color: var(--fg-muted);
 }
-.positioning-body p { margin: 0; }
-.positioning-body p:not(:last-child) { margin-bottom: 12px; }
 
 /* ========== BUTTONS ========== */
 
@@ -300,14 +302,14 @@ main {
   gap: 12px;
   margin-bottom: 16px;
 }
-/* steel-400 / steel-500: the lighter steel-300/400 pair sat below
-   the 4.5:1 WCAG AA contrast bar at these tiny sizes. */
+/* steel-500: the lighter steel-300/400 pair sat below the 4.5:1
+   WCAG AA contrast bar at these tiny sizes. */
 .pillar-num {
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.08em;
-  color: var(--steel-400);
+  color: var(--steel-500);
   flex-shrink: 0;
 }
 .pillar-name {

--- a/website/static/css/colors_and_type.css
+++ b/website/static/css/colors_and_type.css
@@ -64,6 +64,9 @@
   --forge-900: #341606;
 
   /* ----- Steel ----- */
+  /* Text on light backgrounds needs steel-500 or darker to
+     clear the 4.5:1 WCAG AA contrast bar; steel-300/400 are
+     for borders, icons, and other non-text decoration. */
   --steel-50:  #F5F6F7;
   --steel-100: #EAECEF;
   --steel-200: #D6DAE0;


### PR DESCRIPTION
Design-review fixes for mdsmith.dev, verified in a real browser at desktop (1440px), tablet (768px), and iPhone 13 widths, followed by three rounds of high-effort code review with fixes after each.

## Frontpage engagement

- **Render the category statement.** The `content/_index.md` body — "mdsmith is a Markdown linter and formatter written in Go…" — was written and maintained but never rendered: `layouts/index.html` dropped `{{ .Content }}`. The homepage never named the product category; the first occurrence of "linter" was the Why-section lead a full scroll down. The paragraph now renders in a `.positioning` strip between the hero and the logos strip. Its markdownlint-comparison sentence is removed since the Why lead covers that differentiation; the template comment names the canonical copy (the `docs/features/index.md` intro) so the hand-aligned copies don't drift silently.
- **markdownlint migration path.** New "Coming from markdownlint?" line under the hero CTAs linking the migration guide — the highest-intent acquisition path, previously reachable only via the footer's "vs other linters".
- **Why-section lead** loses its self-referential sentence ("Each card opens a fuller write-up; the same copy backs the repository README") — internal plumbing, not visitor value.

## Mobile

- **Install picker rows wrap below 560px.** Commands were truncated to a few characters ("`$ go install g`") next to the 90px label, with no visible affordance for the horizontal scroll. The command now takes a full-width line under the label + copy button.
- **Footer ≤880px**: the brand cell (2fr on desktop) was crushed to a half-width column, wrapping the tagline at ~12 characters; it now spans both columns.
- **Logos strip ≤880px**: `space-between` + wrap scattered the channel names with ragged gaps; now a left-aligned gap flow with the label on its own line.
- **Topnav version** no longer wraps mid-token at tablet widths.

## Accessibility

- Card "Learn more" links were `--steel-300` ≈ 2.0:1 contrast (lead cards `--forge-400` ≈ 2.6:1) — under the WCAG AA 4.5:1 bar at 11.5px, and touch users never see the darker hover. Bumped to `--steel-500`/`--forge-600` (hover `--steel-700`/`--forge-700`); pillar numbers/names bumped to `--steel-500` too.
- `colors_and_type.css` now documents that steel-300/400 are decoration tokens on light backgrounds (text needs steel-500+).

## Link-rot guard (from review round 2)

`VerifyWebsiteLinks` now resolves every internal `<a href>` on the rendered homepage to a page on disk. The homepage is assembled almost entirely from templates, so its hardcoded hrefs — including the new migration link, plus the pre-existing nav/footer/card links — bypassed both the markdown link rules and the render-link hook; a renamed guide would have rotted them silently. Fails closed on a missing homepage; verified against both CI invocation modes (root and `https://example.com/mdsmith/` subpath render).

## Review rounds

1. **Round 1**: install-row wrap test strengthened to assert the actual wrap (y-geometry) before the width ratio; paragraph margin resets deduplicated into the `.hero-lead` rules; canonical-copy breadcrumb added; steel-300/400 token guidance + last text use fixed.
2. **Round 2**: homepage href-resolution probe added (TDD red/green), CLI usage text updated.
3. **Round 3**: covered the probe's fail-closed and protocol-relative skip branches (closes the codecov/patch gap).

## Tests

- `website/e2e/tests/home.spec.ts`: positioning paragraph renders, hero migration link targets the migrate guide, install command wraps below the label and spans the row at 390px. All 25 Playwright tests pass locally.
- `internal/release`: 5 new `VerifyWebsiteLinks` tests (resolve, unquoted, subpath, missing target, missing homepage); `verifyHomeHrefs` at 100% coverage.
- `mdsmith check .` clean (432 files); `go test`, `go vet`, `golangci-lint` clean; `sync-messaging --check` clean.

## Not in this PR (needs a product/messaging decision)

- Hero lead rewording to name the category in the lead itself (propagates to README and plugin manifests via `sync-messaging`).
- Promoting agent integration to a homepage pillar/lead card.
- Self-hosting or gracefully degrading the hero badge images.

https://claude.ai/code/session_01KgiiuPAk3xX1GYaHiKogXt