### PR TITLE
website: hero category lead, agent-first engine pillar, badge hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,17 @@ The same engine runs in CI, in your editor, and in your coding
 agent, from one fast static binary you can install through any
 channel.
 
+**[Editors and agents](docs/features/editor-agent-integration.md).**
+A bundled VS Code extension and a Claude Code plugin drive the
+same `mdsmith lsp` server, so diagnostics, fix-on-save, and
+navigation reach your editor and your agent with no separate
+install. The `.vsix` is republished to Open VSX for Cursor,
+VSCodium, and Theia.
+
 **[Live diagnostics wherever you write](docs/features/live-diagnostics.md).**
 `mdsmith lsp` serves diagnostics, quick-fixes, and navigation
 (definition, references, symbol search, and a call hierarchy) to
 any LSP-aware editor over stdio.
-
-**[Editors and agents](docs/features/editor-agent-integration.md).**
-A bundled VS Code extension and a Claude Code plugin drive that
-same server, so diagnostics, fix-on-save, and navigation reach
-your editor and your agent with no separate install. The `.vsix`
-is republished to Open VSX for Cursor, VSCodium, and Theia.
 
 **[Fast on every run](docs/features/performance.md).**
 One static Go binary, no runtime to start. The workspace walk runs

--- a/docs/brand/messaging.md
+++ b/docs/brand/messaging.md
@@ -35,11 +35,12 @@ Markdown as a single source of truth
 
 ## Lead
 
-Write content; mdsmith keeps your Markdown neat and consistent
-— fast enough to stay out of your way. Auto-fix on save, instant
-navigation, cross-file integrity, and generated sections that
-keep derived data in sync, so the same Markdown drives docs,
-READMEs, and downstream pipelines without drift.
+mdsmith is a Markdown linter and formatter that keeps your
+writing neat and consistent — fast enough to stay out of your
+way. Auto-fix on save, instant navigation, cross-file integrity,
+and generated sections that keep derived data in sync, so the
+same Markdown drives docs, READMEs, and downstream pipelines
+without drift.
 
 ## Tagline
 

--- a/docs/features/editor-agent-integration.md
+++ b/docs/features/editor-agent-integration.md
@@ -6,7 +6,7 @@ summary: >-
   reach your editor and your coding agent unchanged.
 icon: plug
 link: "/guides/editors/vscode/"
-weight: 5
+weight: 4
 group: "One engine, every surface"
 ---
 # Editors and agents

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -50,16 +50,17 @@ The same engine runs in CI, in your editor, and in your coding
 agent, from one fast static binary you can install through any
 channel.
 
+**[Editors and agents](editor-agent-integration.md).**
+A bundled VS Code extension and a Claude Code plugin drive the
+same `mdsmith lsp` server, so diagnostics, fix-on-save, and
+navigation reach your editor and your agent with no separate
+install. The `.vsix` is republished to Open VSX for Cursor,
+VSCodium, and Theia.
+
 **[Live diagnostics wherever you write](live-diagnostics.md).**
 `mdsmith lsp` serves diagnostics, quick-fixes, and navigation
 (definition, references, symbol search, and a call hierarchy) to
 any LSP-aware editor over stdio.
-
-**[Editors and agents](editor-agent-integration.md).**
-A bundled VS Code extension and a Claude Code plugin drive that
-same server, so diagnostics, fix-on-save, and navigation reach
-your editor and your agent with no separate install. The `.vsix`
-is republished to Open VSX for Cursor, VSCodium, and Theia.
 
 **[Fast on every run](performance.md).**
 One static Go binary, no runtime to start. The workspace walk runs

--- a/docs/features/live-diagnostics.md
+++ b/docs/features/live-diagnostics.md
@@ -7,7 +7,7 @@ summary: >-
   LSP-aware editor.
 icon: edit-3
 link: "/guides/editors/vscode/"
-weight: 4
+weight: 5
 group: "One engine, every surface"
 ---
 # Live diagnostics wherever you write

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -6,10 +6,10 @@ hero:
   headline_pre: "Mark"
   headline_em: "down"
   headline_post: ", smithed."
-  lead: "Write content; mdsmith keeps your Markdown neat and consistent — fast enough to stay out of your way. Auto-fix on save, instant navigation, cross-file integrity, and generated sections that keep derived data in sync, so the same Markdown drives docs, READMEs, and downstream pipelines without drift."
+  lead: "mdsmith is a Markdown linter and formatter that keeps your writing neat and consistent — fast enough to stay out of your way. Auto-fix on save, instant navigation, cross-file integrity, and generated sections that keep derived data in sync, so the same Markdown drives docs, READMEs, and downstream pipelines without drift."
 ---
-mdsmith is a Markdown linter and formatter written in Go. It checks style,
-readability, structure, and cross-file integrity, and auto-fixes what fixes
-cleanly. One rule engine powers the CLI, the LSP server, and the VS Code
-extension — Neovim and other LSP-aware editors plug in through the same
-server, and a Claude Code plugin is available for users of that editor.
+mdsmith checks style, readability, structure, and cross-file integrity,
+and auto-fixes what fixes cleanly. One rule engine powers the CLI, the LSP
+server, and the VS Code extension — Neovim and other LSP-aware editors plug
+in through the same server, and a Claude Code plugin is available for users
+of that editor.

--- a/website/e2e/tests/home.spec.ts
+++ b/website/e2e/tests/home.spec.ts
@@ -9,14 +9,22 @@ import { test, expect } from "@playwright/test";
  * first-time visitor what mdsmith is and where to start.
  */
 test.describe("homepage positioning", () => {
-  test("category statement renders under the hero", async ({ page }) => {
+  test("scope statement renders under the hero", async ({ page }) => {
     await page.goto("/");
 
     const positioning = page.locator(".positioning-body");
     await expect(positioning).toBeVisible();
     await expect(positioning).toContainText(
-      "mdsmith is a Markdown linter and formatter written in Go",
+      "mdsmith checks style, readability, structure, and cross-file integrity",
     );
+  });
+
+  test("hero lead names the product category", async ({ page }) => {
+    await page.goto("/");
+
+    const lead = page.locator(".hero-lead");
+    await expect(lead).toBeVisible();
+    await expect(lead).toContainText("Markdown linter and formatter");
   });
 
   test("hero links markdownlint users to the migration guide", async ({
@@ -30,6 +38,24 @@ test.describe("homepage positioning", () => {
       "href",
       /\/guides\/migrate-from-markdownlint\/$/,
     );
+  });
+
+  test("failed badge images hide their links instead of breaking", async ({
+    page,
+  }) => {
+    // Simulate the badge hosts being blocked or down: abort every
+    // request that leaves the local site. The JS in baseof.html
+    // must hide each failed badge's link so the hero never shows
+    // a broken-image icon.
+    await page.route(/^https?:\/\/(?!localhost)/, route => route.abort());
+    await page.goto("/");
+
+    const badges = page.locator(".hero-badges a");
+    const count = await badges.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(badges.nth(i)).toBeHidden();
+    }
   });
 
   test("install commands stay readable on a narrow viewport", async ({

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -62,6 +62,21 @@
         document.addEventListener("scroll", onScroll, { passive: true });
         onScroll();
       }
+      // The hero badges load from three external hosts (GitHub,
+      // goreportcard, codecov, shields). When a host is slow,
+      // blocked, or down, the browser paints a broken-image icon
+      // in the hero's most prominent slot. Hide the failed badge's
+      // link instead; with JS off the current (broken-icon)
+      // behavior is unchanged. Images can fail before listeners
+      // attach, so completed-but-empty images are swept too.
+      document.querySelectorAll(".hero-badges img").forEach(img => {
+        const hide = () => {
+          const a = img.closest("a");
+          if (a) a.hidden = true;
+        };
+        if (img.complete && img.naturalWidth === 0) hide();
+        else img.addEventListener("error", hide);
+      });
       const sideToggle = document.querySelector(".docs-side-toggle");
       const sideNav = document.getElementById("docs-nav");
       if (sideToggle && sideNav) {

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -1,10 +1,10 @@
 {{ define "main" }}
   {{ partial "hero.html" . }}
-  {{- /* The page body of content/_index.md is the one-paragraph
-         category statement ("mdsmith is a Markdown linter and
-         formatter written in Go…"). Render it right under the
-         hero so a first-time visitor can classify the product
-         without scrolling to the Why section. The canonical copy
+  {{- /* The page body of content/_index.md is a one-paragraph
+         scope statement (what mdsmith checks, and the one engine
+         behind CLI, LSP, and editors). The hero lead carries the
+         category ("a Markdown linter and formatter"); this strip
+         adds the concrete scope right under it. The fuller copy
          is the intro of docs/features/index.md (which the README
          includes and /features/ renders); keep the _index.md body
          aligned with it when either changes. */ -}}

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -205,11 +205,17 @@ main {
   color: var(--fg-muted);
   margin: 16px 0 0;
 }
+/* min-height reserves the badge row so late or failed external
+   badge images don't shift the hero; the JS in baseof.html hides
+   a failed badge's link ([hidden]) instead of letting the browser
+   paint a broken-image icon. */
 .hero-badges {
   display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
   margin-top: 22px;
+  min-height: 20px;
 }
 .hero-badges a { display: inline-flex; line-height: 0; }
+.hero-badges a[hidden] { display: none; }
 .hero-badges img { height: 20px; display: block; }
 
 /* ========== POSITIONING ========== */


### PR DESCRIPTION
Follow-ups to #537 — the three items that PR deferred as product/messaging decisions, now approved.

## Hero lead names the category (`docs/brand/messaging.md`)

The Lead now opens "mdsmith is a Markdown linter and formatter that keeps your writing neat and consistent — fast enough to stay out of your way." The category lands in the first viewport on every device (the positioning strip from #537 sits below the fold on mobile); the headline and eyebrow keep the payoff framing per the marketing-surface rules in the docs-author skill. Propagated via `sync-messaging` (one target changed: the hero front matter); `sync-messaging --check` is clean.

The positioning strip drops its now-duplicate category sentence and carries the concrete scope instead (what mdsmith checks, plus the one engine behind CLI, LSP, and editors). A new e2e test pins the category phrase in the hero lead.

## "Editors and agents" leads the engine pillar (`docs/features/`)

Agent integration is one of mdsmith's most distinctive capabilities but rendered as a small support card while the generic LSP card led the "One engine, every surface" pillar. The weights are swapped so "Editors and agents" takes the lead card and the editor artifact on the homepage. The shared overview prose is reordered to match, with its "that same server" cross-reference reworded so it doesn't dangle; the README regenerated through its `<?include?>`.

## Hero badges degrade gracefully (`baseof.html`, `app.css`)

The four hero badges load from three external hosts; a slow or blocked host painted a broken-image icon in the hero's most prominent slot. A progressive enhancement hides a failed badge's link (including images that failed before listeners attached), the badge row reserves its 20px height against layout shift, and behavior with JS off is unchanged. A new e2e test aborts all external requests and asserts every badge link is hidden — the local render (where badge hosts are unreachable) now shows a clean hero.

## Verification

- 27/27 Playwright tests (3 new: hero category pin, scope-statement pin update, blocked-badge test)
- `mdsmith check .` clean (432 files), `sync-messaging --check` clean, `verify-website-links` clean (root render)
- `go test ./internal/release/ ./cmd/mdsmith-release/` pass
- Hero and pillar-2 screenshots verified at 1440px

https://claude.ai/code/session_01KgiiuPAk3xX1GYaHiKogXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgiiuPAk3xX1GYaHiKogXt)_