### PR TITLE
ci: bump merge-queue-action to v0.7.9

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -49,7 +49,7 @@ jobs:
           mdsmith merge-driver ci-install
           mdsmith pre-merge-commit install
 
-      - uses: jeduden/merge-queue-action@389ad414544a693f6c98e0dfdca349007b64d0df #v0.7.8
+      - uses: jeduden/merge-queue-action@2edfb80a17f2f70481d9e153428c17448ff6d120 #v0.7.9
         with:
           token: ${{ secrets.MERGE_QUEUE_TOKEN }}
           ci_workflow: .github/workflows/ci.yml


### PR DESCRIPTION
Update the pinned `jeduden/merge-queue-action` SHA in `.github/workflows/merge-queue.yml` from `389ad41` (v0.7.8) to `2edfb80a17f2f70481d9e153428c17448ff6d120` (v0.7.9).

The version comment is updated to match. No other references to the action pin a version, so this is the only change needed.

`mdsmith check .` passes (checked=432, failures=0).

https://claude.ai/code/session_012Rq5uFuxqhtDitWsXKiYje

---
_Generated by [Claude Code](https://claude.ai/code/session_012Rq5uFuxqhtDitWsXKiYje)_