### PR TITLE
Plan 243: Security hardening batch — 2026-06-09 audit

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -172,7 +172,7 @@ footer: |
 | 242 | 🔲     | sonnet | [Recover from panics in the LSP lint pipeline](plan/242_lsp-panic-recovery.md)                                                          |
 | 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243 | 🔲     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
-| 243 | 🔲     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
+| 243 | 🔳     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
 | 244 | 🔲     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245 | 🔲     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
 | 246 | 🔲     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |

--- a/PLAN.md
+++ b/PLAN.md
@@ -172,7 +172,7 @@ footer: |
 | 242 | 🔲     | sonnet | [Recover from panics in the LSP lint pipeline](plan/242_lsp-panic-recovery.md)                                                          |
 | 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243 | 🔲     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
-| 243 | 🔳     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
+| 243 | ✅     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
 | 244 | 🔲     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245 | 🔲     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
 | 246 | 🔲     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |

--- a/internal/config/convention.go
+++ b/internal/config/convention.go
@@ -193,22 +193,27 @@ func validateConventionRuleSettings(
 	return nil
 }
 
-// validateConventionScalar returns an error when the top-level
-// `convention:` value in the raw YAML is not a string scalar.
-// yaml.v3 silently coerces bare ints and bools into string fields,
-// which would surface as "unknown convention 123" instead of a
-// clean type error. Inspecting the raw node tag is the only way to
-// catch the type mismatch before that coercion happens.
+// validateConventionScalar rejects YAML that uses anchors or
+// aliases anywhere in the document, then returns an error when
+// the top-level `convention:` value in the raw YAML is not a
+// string scalar. yaml.v3 silently coerces bare ints and bools
+// into string fields, which would surface as "unknown
+// convention 123" instead of a clean type error. Inspecting the
+// raw node tag is the only way to catch the type mismatch before
+// that coercion happens.
 func validateConventionScalar(data []byte) error {
-	// Route through UnmarshalNodeSafe so anchors/aliases are rejected
-	// consistently with every other user-YAML entry point. Anchor/alias
-	// errors are propagated; other parse errors are swallowed so Load's
-	// subsequent UnmarshalSafe call surfaces them with its own message.
-	node, err := yamlutil.UnmarshalNodeSafe(data)
-	if err != nil {
-		if strings.Contains(err.Error(), "anchors/aliases") {
-			return err
-		}
+	// Reject anchors/aliases up front via the shared yamlutil
+	// pre-check — the same idiom as the kind-file and
+	// convention-file loaders. RejectYAMLAliases errors only on
+	// anchor/alias use; the direct yaml.Unmarshal below is
+	// deliberate, since its parse errors must stay swallowed so
+	// Load's subsequent UnmarshalSafe call surfaces them with
+	// its own message.
+	if err := yamlutil.RejectYAMLAliases(data); err != nil {
+		return err
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
 		return nil
 	}
 	if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {

--- a/internal/config/convention.go
+++ b/internal/config/convention.go
@@ -202,13 +202,11 @@ func validateConventionRuleSettings(
 // raw node tag is the only way to catch the type mismatch before
 // that coercion happens.
 func validateConventionScalar(data []byte) error {
-	// Reject anchors/aliases up front via the shared yamlutil
-	// pre-check — the same idiom as the kind-file and
-	// convention-file loaders. RejectYAMLAliases errors only on
-	// anchor/alias use; the direct yaml.Unmarshal below is
-	// deliberate, since its parse errors must stay swallowed so
-	// Load's subsequent UnmarshalSafe call surfaces them with
-	// its own message.
+	// Reject anchors/aliases up front, as the kind-file and
+	// convention-file loaders do. The direct yaml.Unmarshal
+	// below is deliberate: its parse errors must stay swallowed
+	// so the caller's follow-up UnmarshalSafe (Load and
+	// ParseBytes share that pipeline) reports them instead.
 	if err := yamlutil.RejectYAMLAliases(data); err != nil {
 		return err
 	}

--- a/internal/config/convention.go
+++ b/internal/config/convention.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/convention"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
 
 // applyConvention reads the top-level Convention selector from the
@@ -199,11 +200,15 @@ func validateConventionRuleSettings(
 // clean type error. Inspecting the raw node tag is the only way to
 // catch the type mismatch before that coercion happens.
 func validateConventionScalar(data []byte) error {
-	// yaml.Unmarshal into yaml.Node does not expand aliases, so this
-	// is safe without an alias-rejection pre-check. Errors are swallowed
-	// because Load's subsequent UnmarshalSafe call will surface them.
-	var node yaml.Node
-	if err := yaml.Unmarshal(data, &node); err != nil {
+	// Route through UnmarshalNodeSafe so anchors/aliases are rejected
+	// consistently with every other user-YAML entry point. Anchor/alias
+	// errors are propagated; other parse errors are swallowed so Load's
+	// subsequent UnmarshalSafe call surfaces them with its own message.
+	node, err := yamlutil.UnmarshalNodeSafe(data)
+	if err != nil {
+		if strings.Contains(err.Error(), "anchors/aliases") {
+			return err
+		}
 		return nil
 	}
 	if node.Kind != yaml.DocumentNode || len(node.Content) == 0 {

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -465,12 +465,15 @@ func TestLoad_InvalidConventionSurfacesError(t *testing.T) {
 	assert.Contains(t, err.Error(), "bogus")
 }
 
-// TestValidateConventionScalar_RejectsYAMLAnchors pins that a
-// config file whose convention: value uses anchors/aliases is
-// rejected by validateConventionScalar via UnmarshalNodeSafe.
-// Without the safe wrapper the direct yaml.Unmarshal into a
-// yaml.Node silently accepts anchors, leaving a latent risk for
-// any future .Decode() call on the resulting node.
+// TestValidateConventionScalar_RejectsYAMLAnchors pins that
+// config YAML using anchors/aliases is rejected by
+// validateConventionScalar via yamlutil.RejectYAMLAliases — the
+// same pre-check the kind-file and convention-file loaders run.
+// The old direct yaml.Unmarshal flagged an alias-valued
+// `convention:` only as a type error, and silently accepted
+// anchors on other keys (or an anchored scalar like
+// `convention: &a portable`), leaving a latent risk for any
+// future .Decode() call on the parsed node.
 func TestValidateConventionScalar_RejectsYAMLAnchors(t *testing.T) {
 	// A YAML doc with an anchor on the convention value.
 	data := []byte("base: &anchor portable\nconvention: *anchor\n")

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -465,6 +465,20 @@ func TestLoad_InvalidConventionSurfacesError(t *testing.T) {
 	assert.Contains(t, err.Error(), "bogus")
 }
 
+// TestValidateConventionScalar_RejectsYAMLAnchors pins that a
+// config file whose convention: value uses anchors/aliases is
+// rejected by validateConventionScalar via UnmarshalNodeSafe.
+// Without the safe wrapper the direct yaml.Unmarshal into a
+// yaml.Node silently accepts anchors, leaving a latent risk for
+// any future .Decode() call on the resulting node.
+func TestValidateConventionScalar_RejectsYAMLAnchors(t *testing.T) {
+	// A YAML doc with an anchor on the convention value.
+	data := []byte("base: &anchor portable\nconvention: *anchor\n")
+	err := validateConventionScalar(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchors/aliases")
+}
+
 func TestCopyConventionPreset_NilReturnsNil(t *testing.T) {
 	assert.Nil(t, copyConventionPreset(nil))
 }

--- a/internal/config/convention_test.go
+++ b/internal/config/convention_test.go
@@ -465,21 +465,20 @@ func TestLoad_InvalidConventionSurfacesError(t *testing.T) {
 	assert.Contains(t, err.Error(), "bogus")
 }
 
-// TestValidateConventionScalar_RejectsYAMLAnchors pins that
-// config YAML using anchors/aliases is rejected by
-// validateConventionScalar via yamlutil.RejectYAMLAliases — the
-// same pre-check the kind-file and convention-file loaders run.
-// The old direct yaml.Unmarshal flagged an alias-valued
-// `convention:` only as a type error, and silently accepted
-// anchors on other keys (or an anchored scalar like
-// `convention: &a portable`), leaving a latent risk for any
-// future .Decode() call on the parsed node.
+// TestValidateConventionScalar_RejectsYAMLAnchors pins the
+// document-wide anchor/alias rejection added for audit finding
+// S003: an alias-valued convention and an anchor on an
+// unrelated key are both rejected — the latter is the case a
+// per-value check would miss.
 func TestValidateConventionScalar_RejectsYAMLAnchors(t *testing.T) {
-	// A YAML doc with an anchor on the convention value.
-	data := []byte("base: &anchor portable\nconvention: *anchor\n")
-	err := validateConventionScalar(data)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "anchors/aliases")
+	for _, data := range []string{
+		"base: &anchor portable\nconvention: *anchor\n",
+		"other: &a x\nconvention: portable\n",
+	} {
+		err := validateConventionScalar([]byte(data))
+		require.Error(t, err, data)
+		assert.Contains(t, err.Error(), "anchors/aliases", data)
+	}
 }
 
 func TestCopyConventionPreset_NilReturnsNil(t *testing.T) {

--- a/internal/cuetemplate/cuetemplate.go
+++ b/internal/cuetemplate/cuetemplate.go
@@ -115,7 +115,7 @@ func (t *Template) Render(fm map[string]any) (string, error) {
 	}
 	src, err := buildSource(fm, t.expr)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("building cue source: %w", err)
 	}
 	val := t.ctx.CompileString(src)
 	if err := val.Err(); err != nil {
@@ -146,11 +146,12 @@ func (t *Template) Render(fm map[string]any) (string, error) {
 //     row-expr can write `\(id)` instead of `\(fm.id)`.
 //   - The synthetic outField holding the user's expression.
 //
-// JSON marshalling is infallible for the value shapes
-// produced by the YAML frontmatter loader. A non-zero error
-// indicates a non-JSON-serialisable type reached frontmatter,
-// which is a programming error upstream; returning the error
-// instead of panicking keeps the LSP server alive.
+// JSON marshalling can fail for real frontmatter: yaml.v3
+// decodes the YAML scalars `.inf`, `-.inf`, and `.nan` into
+// float64 ±Inf/NaN values, which json.Marshal rejects. A
+// non-nil error therefore reports a frontmatter value with no
+// JSON encoding; returning it (instead of the old panic) keeps
+// check, fix, and the LSP server alive on such input.
 func buildSource(fm map[string]any, expr string) (string, error) {
 	// Single-pass filter: drop the renderer's synthetic field
 	// names from the JSON-emitted map AND collect the sorted

--- a/internal/cuetemplate/cuetemplate.go
+++ b/internal/cuetemplate/cuetemplate.go
@@ -113,7 +113,10 @@ func (t *Template) Render(fm map[string]any) (string, error) {
 	if fm == nil {
 		fm = map[string]any{}
 	}
-	src := buildSource(fm, t.expr)
+	src, err := buildSource(fm, t.expr)
+	if err != nil {
+		return "", err
+	}
 	val := t.ctx.CompileString(src)
 	if err := val.Err(); err != nil {
 		return "", fmt.Errorf("evaluating cue expression: %w", err)
@@ -144,10 +147,11 @@ func (t *Template) Render(fm map[string]any) (string, error) {
 //   - The synthetic outField holding the user's expression.
 //
 // JSON marshalling is infallible for the value shapes
-// produced by the YAML frontmatter loader, so any encoding
-// failure indicates a programming bug upstream and the panic
-// is the correct response.
-func buildSource(fm map[string]any, expr string) string {
+// produced by the YAML frontmatter loader. A non-zero error
+// indicates a non-JSON-serialisable type reached frontmatter,
+// which is a programming error upstream; returning the error
+// instead of panicking keeps the LSP server alive.
+func buildSource(fm map[string]any, expr string) (string, error) {
 	// Single-pass filter: drop the renderer's synthetic field
 	// names from the JSON-emitted map AND collect the sorted
 	// alias keys in the same walk. Both surfaces use the same
@@ -171,7 +175,7 @@ func buildSource(fm map[string]any, expr string) string {
 
 	fmJSON, err := json.Marshal(emit)
 	if err != nil {
-		panic(fmt.Errorf("cuetemplate: encoding frontmatter: %w", err))
+		return "", fmt.Errorf("encoding frontmatter: %w", err)
 	}
 	var src []byte //nolint:prealloc
 	src = append(src, []byte(
@@ -186,5 +190,5 @@ func buildSource(fm map[string]any, expr string) string {
 	}
 	src = append(src, []byte(fmt.Sprintf("%s: %s\n",
 		outField, expr))...)
-	return string(src)
+	return string(src), nil
 }

--- a/internal/cuetemplate/cuetemplate.go
+++ b/internal/cuetemplate/cuetemplate.go
@@ -146,12 +146,10 @@ func (t *Template) Render(fm map[string]any) (string, error) {
 //     row-expr can write `\(id)` instead of `\(fm.id)`.
 //   - The synthetic outField holding the user's expression.
 //
-// JSON marshalling can fail for real frontmatter: yaml.v3
-// decodes the YAML scalars `.inf`, `-.inf`, and `.nan` into
-// float64 ±Inf/NaN values, which json.Marshal rejects. A
-// non-nil error therefore reports a frontmatter value with no
-// JSON encoding; returning it (instead of the old panic) keeps
-// check, fix, and the LSP server alive on such input.
+// JSON marshalling can fail for real frontmatter — among the
+// loader-produced shapes json.Marshal rejects are float64
+// ±Inf/NaN from `.inf`/`.nan` scalars and nested mappings with
+// non-string keys — so the error propagates to the caller.
 func buildSource(fm map[string]any, expr string) (string, error) {
 	// Single-pass filter: drop the renderer's synthetic field
 	// names from the JSON-emitted map AND collect the sorted

--- a/internal/cuetemplate/cuetemplate_test.go
+++ b/internal/cuetemplate/cuetemplate_test.go
@@ -1,6 +1,7 @@
 package cuetemplate
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -219,23 +220,29 @@ func TestTemplate_Render_CUEKeywordKeyIsQuoted(t *testing.T) {
 	assert.Equal(t, "MDS001", got)
 }
 
-// TestTemplate_Render_UnmarshalableValueReturnsError pins that
-// a frontmatter value that json.Marshal cannot serialise produces
-// an error return from Render rather than a panic. A chan is the
-// canonical non-JSON-marshallable Go type; go-yaml v3 scalars
-// never produce one, but the guard is needed for future-safety
-// and to keep the LSP alive if the type escapes into frontmatter.
-func TestTemplate_Render_UnmarshalableValueReturnsError(t *testing.T) {
+// TestTemplate_Render_MarshalErrorReturnsError pins that a
+// frontmatter value json.Marshal cannot serialise produces an
+// error return from Render rather than a panic. A chan is the
+// canonical non-JSON-marshalable Go type. A panic here would
+// still fail the test — the direct call needs no NotPanics
+// wrapper.
+func TestTemplate_Render_MarshalErrorReturnsError(t *testing.T) {
 	tpl, err := Compile(`"literal"`)
 	require.NoError(t, err)
-	// Use require.NotPanics so a panic produces a clear test failure
-	// rather than crashing the test binary with a non-deferred panic.
-	var gotErr error
-	require.NotPanics(t, func() {
-		_, gotErr = tpl.Render(map[string]any{
-			"bad": make(chan int),
-		})
-	})
-	require.Error(t, gotErr)
-	assert.Contains(t, gotErr.Error(), "encoding frontmatter")
+	_, err = tpl.Render(map[string]any{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encoding frontmatter")
+}
+
+// TestTemplate_Render_InfFrontMatterReturnsError covers the
+// trigger reachable from plain Markdown: yaml.v3 decodes the
+// scalars `.inf` and `.nan` into float64 values json.Marshal
+// rejects, so front matter like `weight: .inf` must surface as
+// a render error, not a panic.
+func TestTemplate_Render_InfFrontMatterReturnsError(t *testing.T) {
+	tpl, err := Compile(`"literal"`)
+	require.NoError(t, err)
+	_, err = tpl.Render(map[string]any{"weight": math.Inf(1)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encoding frontmatter")
 }

--- a/internal/cuetemplate/cuetemplate_test.go
+++ b/internal/cuetemplate/cuetemplate_test.go
@@ -218,3 +218,24 @@ func TestTemplate_Render_CUEKeywordKeyIsQuoted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "MDS001", got)
 }
+
+// TestTemplate_Render_UnmarshalableValueReturnsError pins that
+// a frontmatter value that json.Marshal cannot serialise produces
+// an error return from Render rather than a panic. A chan is the
+// canonical non-JSON-marshallable Go type; go-yaml v3 scalars
+// never produce one, but the guard is needed for future-safety
+// and to keep the LSP alive if the type escapes into frontmatter.
+func TestTemplate_Render_UnmarshalableValueReturnsError(t *testing.T) {
+	tpl, err := Compile(`"literal"`)
+	require.NoError(t, err)
+	// Use require.NotPanics so a panic produces a clear test failure
+	// rather than crashing the test binary with a non-deferred panic.
+	var gotErr error
+	require.NotPanics(t, func() {
+		_, gotErr = tpl.Render(map[string]any{
+			"bad": make(chan int),
+		})
+	})
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "encoding frontmatter")
+}

--- a/internal/cuetemplate/cuetemplate_test.go
+++ b/internal/cuetemplate/cuetemplate_test.go
@@ -1,11 +1,11 @@
 package cuetemplate
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // TestCompile_RejectsEmptyExpression keeps the contract clear:
@@ -223,9 +223,7 @@ func TestTemplate_Render_CUEKeywordKeyIsQuoted(t *testing.T) {
 // TestTemplate_Render_MarshalErrorReturnsError pins that a
 // frontmatter value json.Marshal cannot serialise produces an
 // error return from Render rather than a panic. A chan is the
-// canonical non-JSON-marshalable Go type. A panic here would
-// still fail the test — the direct call needs no NotPanics
-// wrapper.
+// canonical non-JSON-marshalable Go type.
 func TestTemplate_Render_MarshalErrorReturnsError(t *testing.T) {
 	tpl, err := Compile(`"literal"`)
 	require.NoError(t, err)
@@ -234,15 +232,19 @@ func TestTemplate_Render_MarshalErrorReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "encoding frontmatter")
 }
 
-// TestTemplate_Render_InfFrontMatterReturnsError covers the
-// trigger reachable from plain Markdown: yaml.v3 decodes the
-// scalars `.inf` and `.nan` into float64 values json.Marshal
-// rejects, so front matter like `weight: .inf` must surface as
-// a render error, not a panic.
-func TestTemplate_Render_InfFrontMatterReturnsError(t *testing.T) {
+// TestTemplate_Render_NonFiniteFrontMatterReturnsError covers
+// the trigger reachable from plain Markdown, decoding the YAML
+// for real: yaml.v3 turns the scalars `.inf` and `.nan` into
+// float64 values json.Marshal rejects, so such front matter
+// must surface as a render error, not a panic.
+func TestTemplate_Render_NonFiniteFrontMatterReturnsError(t *testing.T) {
 	tpl, err := Compile(`"literal"`)
 	require.NoError(t, err)
-	_, err = tpl.Render(map[string]any{"weight": math.Inf(1)})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "encoding frontmatter")
+	for _, src := range []string{"weight: .inf\n", "score: .nan\n"} {
+		var fm map[string]any
+		require.NoError(t, yaml.Unmarshal([]byte(src), &fm), src)
+		_, err := tpl.Render(fm)
+		require.Error(t, err, src)
+		assert.Contains(t, err.Error(), "encoding frontmatter", src)
+	}
 }

--- a/internal/rules/catalog/generate.go
+++ b/internal/rules/catalog/generate.go
@@ -21,6 +21,16 @@ type fileEntry struct {
 	matchPath string
 }
 
+// entryMatchPath returns the path that identifies entry in
+// diagnostics: the doublestar match path, falling back to the
+// rendered filename field for entries constructed without one.
+func entryMatchPath(entry fileEntry) string {
+	if entry.matchPath != "" {
+		return entry.matchPath
+	}
+	return fieldinterp.Stringify(entry.fields["filename"])
+}
+
 // renderTemplate renders header + row-per-file + footer. Each section is
 // terminated by \n; if the value already ends with \n, no extra is added.
 // If columns config is provided, column constraints (truncation/wrapping)
@@ -76,7 +86,9 @@ func renderTemplate(params map[string]string, entries []fileEntry, columns ...ma
 		if rowTpl != nil {
 			r, err := rowTpl.Render(entry.fields)
 			if err != nil {
-				return "", fmt.Errorf("rendering row-expr: %w", err)
+				return "", fmt.Errorf(
+					"rendering row-expr for %q: %w",
+					entryMatchPath(entry), err)
 			}
 			rendered = r
 		} else {

--- a/internal/rules/catalog/generate.go
+++ b/internal/rules/catalog/generate.go
@@ -21,16 +21,6 @@ type fileEntry struct {
 	matchPath string
 }
 
-// entryMatchPath returns the path that identifies entry in
-// diagnostics: the doublestar match path, falling back to the
-// rendered filename field for entries constructed without one.
-func entryMatchPath(entry fileEntry) string {
-	if entry.matchPath != "" {
-		return entry.matchPath
-	}
-	return fieldinterp.Stringify(entry.fields["filename"])
-}
-
 // renderTemplate renders header + row-per-file + footer. Each section is
 // terminated by \n; if the value already ends with \n, no extra is added.
 // If columns config is provided, column constraints (truncation/wrapping)
@@ -86,9 +76,12 @@ func renderTemplate(params map[string]string, entries []fileEntry, columns ...ma
 		if rowTpl != nil {
 			r, err := rowTpl.Render(entry.fields)
 			if err != nil {
+				// Display-form filename, matching the rule's other
+				// per-entry diagnostics (front-matter read errors,
+				// include-cycle reports).
 				return "", fmt.Errorf(
 					"rendering row-expr for %q: %w",
-					entryMatchPath(entry), err)
+					fieldinterp.Stringify(entry.fields["filename"]), err)
 			}
 			rendered = r
 		} else {

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -1180,7 +1180,10 @@ func checkCatalogIncludeCycle(
 	}
 	useAbs := hasScanAbs && f.RunCache != nil
 	for _, entry := range entries {
-		matchedPath := entryMatchPath(entry)
+		matchedPath := entry.matchPath
+		if matchedPath == "" {
+			matchedPath = fieldinterp.Stringify(entry.fields["filename"])
+		}
 		if matchedIncludesCatalog(f, scanFS, scanAbsDir, useAbs, matchedPath, catalogFile) {
 			displayPath := fieldinterp.Stringify(entry.fields["filename"])
 			return []lint.Diagnostic{makeDiag(filePath, line,

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -1180,10 +1180,7 @@ func checkCatalogIncludeCycle(
 	}
 	useAbs := hasScanAbs && f.RunCache != nil
 	for _, entry := range entries {
-		matchedPath := entry.matchPath
-		if matchedPath == "" {
-			matchedPath = fieldinterp.Stringify(entry.fields["filename"])
-		}
+		matchedPath := entryMatchPath(entry)
 		if matchedIncludesCatalog(f, scanFS, scanAbsDir, useAbs, matchedPath, catalogFile) {
 			displayPath := fieldinterp.Stringify(entry.fields["filename"])
 			return []lint.Diagnostic{makeDiag(filePath, line,

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -4626,3 +4626,34 @@ row-expr: '1 + 1'
 	}
 	assert.True(t, found, "expected render-time error diagnostic; got %v", diags)
 }
+
+func TestRowExpr_NonFiniteFrontMatterNamesFile(t *testing.T) {
+	// yaml.v3 decodes `.inf` to float64 +Inf, which json.Marshal
+	// rejects inside cuetemplate. The render error must surface
+	// as a diagnostic that names the matched file carrying the
+	// bad value, so the user need not bisect the matched set.
+	src := `<?catalog
+glob: "docs/*.md"
+row-expr: 'title'
+?>
+<?/catalog?>
+`
+	mapFS := fstest.MapFS{
+		"docs/bad.md": {Data: []byte(
+			"---\ntitle: B\nweight: .inf\n---\n# B\n")},
+	}
+	f := newTestFile(t, "index.md", src, mapFS)
+	r := &Rule{}
+	diags := r.Check(f)
+	require.NotEmpty(t, diags)
+	var found bool
+	for _, d := range diags {
+		if strings.Contains(d.Message, "encoding frontmatter") &&
+			strings.Contains(d.Message, "docs/bad.md") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"expected render error naming docs/bad.md; got %v", diags)
+}

--- a/internal/schema/extend.go
+++ b/internal/schema/extend.go
@@ -116,8 +116,16 @@ func mergeRawFrontmatter(out, parent, child map[string]any) {
 			continue
 		}
 		parentExpr, parentOK := existing.(string)
+		if !parentOK {
+			// The parent value failed normalisation (e.g. a
+			// non-finite float). Keep it so
+			// ValidateExtendedFrontmatter names the key rather
+			// than the child override silently dropping the
+			// malformed constraint.
+			continue
+		}
 		childStr, childIsStr := childExpr.(string)
-		if !parentOK || !childIsStr || parentExpr == childStr {
+		if !childIsStr || parentExpr == childStr {
 			merged[k] = childExpr
 			continue
 		}
@@ -131,8 +139,9 @@ func mergeRawFrontmatter(out, parent, child map[string]any) {
 // expression, scalars JSON-encode, and raw CUE strings pass
 // through verbatim. A value frontmatterExpr cannot resolve (an
 // unknown shortcut, an unsupported type) flows through unchanged
-// so the downstream ParseInline call surfaces the same error
-// signal the user would have seen without the extends merge.
+// so a downstream pass — ParseInline or
+// ValidateExtendedFrontmatter — surfaces the same error signal
+// the user would have seen without the extends merge.
 func normalizeFrontmatterValue(v any) any {
 	expr, err := frontmatterExpr(v)
 	if err != nil {

--- a/internal/schema/extend_test.go
+++ b/internal/schema/extend_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -385,6 +386,28 @@ func TestMergeRawMap_FrontmatterConflictMergesWithoutError(t *testing.T) {
 	out := MergeRawMap(parent, child)
 	fm := out["frontmatter"].(map[string]any)
 	assert.Contains(t, fm["x"], "&", "shared key joins via CUE conjunction")
+}
+
+// TestMergeRawMap_UnencodableParentConstraintStillErrors pins the
+// extends corner where the parent constraint is a value
+// frontmatterExpr cannot encode (yaml.v3 turns `.inf` into a
+// float64 +Inf) and the child overrides the same key: the
+// malformed parent must survive the merge so
+// ValidateExtendedFrontmatter names it, rather than the child
+// override silently dropping the broken constraint.
+func TestMergeRawMap_UnencodableParentConstraintStillErrors(t *testing.T) {
+	parent := map[string]any{
+		"frontmatter": map[string]any{"weight": math.Inf(1)},
+	}
+	child := map[string]any{
+		"frontmatter": map[string]any{"weight": "5"},
+	}
+	out := MergeRawMap(parent, child)
+	err := ValidateExtendedFrontmatter(out)
+	require.Error(t, err)
+	var fmErr *InvalidFrontmatterError
+	require.True(t, errors.As(err, &fmErr))
+	assert.Equal(t, "weight", fmErr.Key)
 }
 
 func TestValidateExtendedFrontmatter_RejectsUnsatisfiable(t *testing.T) {

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -174,14 +174,11 @@ func frontmatterExpr(v any) (string, error) {
 			return resolved, nil
 		}
 		return expr, nil
-	case bool, int, int64, float64, nil:
-		// json.Marshal cannot fail on these primitive types, so
-		// the error from the marshal call is intentionally
-		// discarded — keeping the err check would land on a
-		// permanently unreachable branch.
-		b, _ := json.Marshal(x)
-		return string(b), nil
-	case []any, map[string]any:
+	case bool, int, int64, float64, nil, []any, map[string]any:
+		// json.Marshal can fail here on loader-produced values:
+		// yaml.v3 decodes `.inf`/`.nan` scalars into float64
+		// ±Inf/NaN, which have no JSON encoding. Propagate the
+		// error so the offending field is named at config load.
 		b, err := json.Marshal(x)
 		if err != nil {
 			return "", err

--- a/internal/schema/plan156_coverage_test.go
+++ b/internal/schema/plan156_coverage_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -264,6 +265,20 @@ func TestFrontmatterExpr_MarshalErrorSliceMap(t *testing.T) {
 	require.Error(t, err,
 		"a map containing an unmarshalable value must surface "+
 			"the json error rather than silently returning")
+}
+
+// TestFrontmatterExpr_MarshalErrorPrimitive pins the same error
+// path for the primitive branch: yaml.v3 decodes the scalars
+// `.inf`, `-.inf`, and `.nan` into float64 values json.Marshal
+// rejects, so a schema frontmatter field carrying one must
+// surface an error instead of silently becoming an empty CUE
+// expression.
+func TestFrontmatterExpr_MarshalErrorPrimitive(t *testing.T) {
+	for _, v := range []float64{math.Inf(1), math.Inf(-1), math.NaN()} {
+		expr, err := frontmatterExpr(v)
+		require.Error(t, err, "value %v", v)
+		assert.Empty(t, expr, "value %v", v)
+	}
 }
 
 // TestHeadingLine_EmptyEverywhereFallback covers the trailing

--- a/internal/yamlutil/yamlutil.go
+++ b/internal/yamlutil/yamlutil.go
@@ -13,6 +13,13 @@
 //   - [Marshal] — thin wrapper around yaml.Marshal for consistency; safe for
 //     output marshaling where data originates from trusted Go values.
 //
+// One escape hatch is allowed: call [RejectYAMLAliases] directly, followed by
+// a raw decode, when the wrappers cannot express the decode — a strict
+// KnownFields decoder (kind and convention files), per-error-type diagnostics
+// (required-structure front matter), or parse errors that must defer to a
+// later [UnmarshalSafe] on the same bytes (the config convention pre-check).
+// Every such site keeps the pre-check directly above its decode.
+//
 // See docs/security/2026-04-05-adversarial-markdown.md for threat model context.
 package yamlutil
 

--- a/plan/243_secreview-2026-06-09-hardening.md
+++ b/plan/243_secreview-2026-06-09-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: 243
 title: 'Security hardening batch — 2026-06-09 audit'
-status: "🔲"
+status: "🔳"
 model: sonnet
 summary: >-
   Two low-risk hardening fixes from the 2026-06-09 audit:
@@ -51,11 +51,11 @@ package already imports `yamlutil` for the pre-check.
 
 ## Tasks
 
-1. [ ] Add a failing test that drives `buildCUESource`
+1. [x] Add a failing test that drives `buildCUESource`
    down its marshal-error branch and asserts an error
    return (not a panic); thread the error through
    `Render` and its catalog caller.
-2. [ ] Replace the `panic` in `buildCUESource` with an
+2. [x] Replace the `panic` in `buildCUESource` with an
    error return.
 3. [ ] Replace `yaml.Unmarshal(data, &node)` in
    `parseConventionFileBody` with
@@ -65,7 +65,7 @@ package already imports `yamlutil` for the pre-check.
 
 ## Acceptance Criteria
 
-- [ ] `buildCUESource` returns an error on marshal
+- [x] `buildCUESource` returns an error on marshal
       failure; no panic reaches the catalog render path or
       the LSP.
 - [ ] Convention-file YAML is parsed via

--- a/plan/243_secreview-2026-06-09-hardening.md
+++ b/plan/243_secreview-2026-06-09-hardening.md
@@ -22,14 +22,17 @@ warrant its own plan.
 
 ### A. cuetemplate panics on json.Marshal (S002)
 
-`buildCUESource` in
+`buildSource` in
 [`internal/cuetemplate/cuetemplate.go`](../internal/cuetemplate/cuetemplate.go)
 calls `json.Marshal(emit)` on front-matter-derived data
 and `panic`s on error. A catalog `row-expr:` directive
 reaches it. In the LSP it is unrecovered (see plan 242)
-and crashes the server. Standard go-yaml v3 scalars
-cannot trigger it today. A future non-marshalable type
-would make it live.
+and crashes the server. The audit rated the branch
+unreachable. It is live today: yaml.v3 decodes the
+scalars `.inf`, `-.inf`, and `.nan` into float64
+±Inf/NaN values, and `json.Marshal` rejects those.
+Front matter like `weight: .inf` in any file matched
+by a row-expr catalog triggers it.
 
 Return an error instead and propagate it up through
 `Render`. The catalog caller (`renderTemplate`) already
@@ -37,40 +40,44 @@ handles render errors, so only the signature changes.
 
 ### B. convention.go bypasses the safe YAML wrapper (S003)
 
-`parseConventionFileBody` in
+`validateConventionScalar` in
 [`internal/config/convention.go`](../internal/config/convention.go)
-calls `yaml.Unmarshal(data, &node)` directly. It does
-not use `yamlutil.UnmarshalNodeSafe`. There is no current
-exploit, since a yaml.Node does not expand aliases. But
-it breaks the project rule that every user-YAML entry
-point goes through the safe wrapper. A later `.Decode()`
-on the node would then reintroduce the alias risk.
+— the pre-check on the `.mdsmith.yml` top-level
+`convention:` scalar — calls `yaml.Unmarshal(data,
+&node)` directly with no anchor/alias guard. There is
+no current exploit, since a yaml.Node does not expand
+aliases. But it breaks the project rule that every
+user-YAML entry point rejects anchors/aliases. A later
+`.Decode()` on the node would then reintroduce the
+alias risk.
 
-Route the read through `yamlutil.UnmarshalNodeSafe`. The
-package already imports `yamlutil` for the pre-check.
+Guard the read with `yamlutil.RejectYAMLAliases`. The
+kind-file and convention-file loaders run the same
+pre-check. The tolerant `yaml.Unmarshal` stays: its
+parse errors defer to Load's `UnmarshalSafe`. The
+package already imports `yamlutil`.
 
 ## Tasks
 
-1. [x] Add a failing test that drives `buildCUESource`
+1. [x] Add a failing test that drives `buildSource`
    down its marshal-error branch and asserts an error
    return (not a panic); thread the error through
    `Render` and its catalog caller.
-2. [x] Replace the `panic` in `buildCUESource` with an
+2. [x] Replace the `panic` in `buildSource` with an
    error return.
-3. [x] Replace `yaml.Unmarshal(data, &node)` in
-   `parseConventionFileBody` with
-   `yamlutil.UnmarshalNodeSafe`; keep behaviour identical
-   for alias-free input and add a test that an
-   anchor/alias convention file is rejected.
+3. [x] Guard `validateConventionScalar` with
+   `yamlutil.RejectYAMLAliases`; keep behaviour
+   identical for alias-free input and add a test that
+   anchor/alias config YAML is rejected.
 
 ## Acceptance Criteria
 
-- [x] `buildCUESource` returns an error on marshal
+- [x] `buildSource` returns an error on marshal
       failure; no panic reaches the catalog render path or
       the LSP.
-- [x] Convention-file YAML is parsed via
-      `yamlutil.UnmarshalNodeSafe`; an anchor/alias file is
-      rejected.
+- [x] The `.mdsmith.yml` `convention:` scalar pre-check
+      rejects anchor/alias YAML via
+      `yamlutil.RejectYAMLAliases`.
 - [x] Both fixes covered by tests (driven red/green).
 - [x] All tests pass: `go test ./...`
 - [x] `go tool golangci-lint run` reports no issues

--- a/plan/243_secreview-2026-06-09-hardening.md
+++ b/plan/243_secreview-2026-06-09-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: 243
 title: 'Security hardening batch — 2026-06-09 audit'
-status: "🔳"
+status: "✅"
 model: sonnet
 summary: >-
   Two low-risk hardening fixes from the 2026-06-09 audit:
@@ -57,7 +57,7 @@ package already imports `yamlutil` for the pre-check.
    `Render` and its catalog caller.
 2. [x] Replace the `panic` in `buildCUESource` with an
    error return.
-3. [ ] Replace `yaml.Unmarshal(data, &node)` in
+3. [x] Replace `yaml.Unmarshal(data, &node)` in
    `parseConventionFileBody` with
    `yamlutil.UnmarshalNodeSafe`; keep behaviour identical
    for alias-free input and add a test that an
@@ -68,9 +68,9 @@ package already imports `yamlutil` for the pre-check.
 - [x] `buildCUESource` returns an error on marshal
       failure; no panic reaches the catalog render path or
       the LSP.
-- [ ] Convention-file YAML is parsed via
+- [x] Convention-file YAML is parsed via
       `yamlutil.UnmarshalNodeSafe`; an anchor/alias file is
       rejected.
-- [ ] Both fixes covered by tests (driven red/green).
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] Both fixes covered by tests (driven red/green).
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues

--- a/plan/243_secreview-2026-06-09-hardening.md
+++ b/plan/243_secreview-2026-06-09-hardening.md
@@ -56,10 +56,10 @@ kind-file and convention-file loaders run the same
 pre-check. The tolerant `yaml.Unmarshal` stays: its
 parse errors defer to Load's `UnmarshalSafe`.
 
-### C. Same-class sweep from review (round 2)
+### C. Same-class sweep
 
-Review of fix A found the same discarded-error pattern
-in `frontmatterExpr`
+Fix A's discarded-error pattern recurs in
+`frontmatterExpr`
 ([`internal/schema/parse_inline.go`](../internal/schema/parse_inline.go)):
 the primitive branch dropped the `json.Marshal` error
 as "unreachable". The same `.inf`/`.nan` front matter

--- a/plan/243_secreview-2026-06-09-hardening.md
+++ b/plan/243_secreview-2026-06-09-hardening.md
@@ -6,8 +6,8 @@ model: sonnet
 summary: >-
   Two low-risk hardening fixes from the 2026-06-09 audit:
   return an error instead of panicking in cuetemplate, and
-  route convention.go YAML through the safe wrapper. Closes
-  findings S002 and S003.
+  guard the convention pre-check with the yamlutil alias
+  rejection. Closes findings S002 and S003.
 ---
 # Security hardening batch — 2026-06-09 audit
 
@@ -54,8 +54,19 @@ alias risk.
 Guard the read with `yamlutil.RejectYAMLAliases`. The
 kind-file and convention-file loaders run the same
 pre-check. The tolerant `yaml.Unmarshal` stays: its
-parse errors defer to Load's `UnmarshalSafe`. The
-package already imports `yamlutil`.
+parse errors defer to Load's `UnmarshalSafe`.
+
+### C. Same-class sweep from review (round 2)
+
+Review of fix A found the same discarded-error pattern
+in `frontmatterExpr`
+([`internal/schema/parse_inline.go`](../internal/schema/parse_inline.go)):
+the primitive branch dropped the `json.Marshal` error
+as "unreachable". The same `.inf`/`.nan` front matter
+reaches it through inline kind schemas and `proto.md`.
+The branch now propagates the error. The catalog
+row-expr render error also names the matched file, so
+one bad file in a large catalog is findable.
 
 ## Tasks
 
@@ -69,6 +80,10 @@ package already imports `yamlutil`.
    `yamlutil.RejectYAMLAliases`; keep behaviour
    identical for alias-free input and add a test that
    anchor/alias config YAML is rejected.
+4. [x] Sweep the same discarded-error pattern:
+   propagate the `json.Marshal` error in
+   `frontmatterExpr` and name the matched file in the
+   catalog row-expr render error.
 
 ## Acceptance Criteria
 
@@ -78,6 +93,6 @@ package already imports `yamlutil`.
 - [x] The `.mdsmith.yml` `convention:` scalar pre-check
       rejects anchor/alias YAML via
       `yamlutil.RejectYAMLAliases`.
-- [x] Both fixes covered by tests (driven red/green).
+- [x] All fixes covered by tests (driven red/green).
 - [x] All tests pass: `go test ./...`
 - [x] `go tool golangci-lint run` reports no issues


### PR DESCRIPTION
Draft PR for [plan/243_secreview-2026-06-09-hardening.md](plan/243_secreview-2026-06-09-hardening.md).

Status will move 🔲 → 🔳 in PLAN.md once the first real
commit lands. Marking ready for review when the
acceptance criteria are checked off.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LXhkAzG4UNYyne1Mgczwf)_