### PR TITLE
Plan 244: Structured list projection; fix nested-item text corruption

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -173,7 +173,7 @@ footer: |
 | 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243 | 🔲     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 243 | 🔲     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
-| 244 | 🔳     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
+| 244 | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245 | 🔲     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
 | 246 | 🔲     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -173,7 +173,7 @@ footer: |
 | 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243 | 🔲     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 243 | 🔲     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
-| 244 | 🔲     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
+| 244 | 🔳     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245 | 🔲     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
 | 246 | 🔲     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
 <?/catalog?>

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -258,6 +258,86 @@ table is in the [extract reference][extract-inline].
 
 [extract-inline]: ../reference/cli/extract.md#inline-span-projection
 
+## Projecting list structure
+
+A list projects as an array of strings by default — each
+the item's own text. That flat shape loses nesting, and
+it strips a task checkbox down to a literal `[x]` prefix.
+When the consumer needs the structure — which items are
+checked, which nest children — set `projection: tree` on
+the list entry. Each item then projects as an object with
+its own `text`, a `checked` bool on task items, and a
+recursive `children` array on items that nest a sub-list.
+
+A sprint checklist is the canonical case. A status tool
+reads each task's `checked` state and walks `children`
+for sub-tasks:
+
+```markdown
+---
+title: Sprint tasks
+---
+# Sprint tasks
+
+## Tasks
+
+- [x] done item
+- [ ] open item with **bold**
+  - nested child
+- plain item
+```
+
+```yaml
+kinds:
+  checklist:
+    schema:
+      sections:
+        - heading: { regex: '^Tasks$' }
+          content:
+            - { kind: list, projection: tree }
+kind-assignment:
+  - glob: ["tasks.md"]
+    kinds: [checklist]
+```
+
+`mdsmith extract checklist --format json tasks.md` emits:
+
+```json
+{
+  "frontmatter": {
+    "title": "Sprint tasks"
+  },
+  "tasks": {
+    "items": [
+      {
+        "checked": true,
+        "text": "done item"
+      },
+      {
+        "checked": false,
+        "children": [
+          {
+            "text": "nested child"
+          }
+        ],
+        "text": "open item with bold"
+      },
+      {
+        "text": "plain item"
+      }
+    ]
+  }
+}
+```
+
+The `[x]` / `[ ]` marker becomes the `checked` bool and
+never leaks into `text`; the `**bold**` flattens to its
+text; `nested child` rides inside its parent's `children`
+rather than concatenating into the parent string. A plain
+item with no marker and no sub-list is just `{text}`. The
+array order is the item order — ordered-list numbering is
+out of scope. YAML and msgpack emit the same tree.
+
 ## When frontmatter is the right call
 
 - **Short scalars where YAML's typing earns its

--- a/docs/reference/cli/extract.md
+++ b/docs/reference/cli/extract.md
@@ -53,11 +53,21 @@ Content entries project under default keys:
 
 - `code-block` → `code` (raw body; more blocks get
   `code-2`, …).
-- `list` → `items`.
+- `list` → `items` (an array of strings, each the item's
+  own text), or a tree of item objects when the entry
+  sets `projection: tree` (see below).
 - `table` with columns → `rows` (row objects keyed by
   column header).
 - `paragraph` → `text` (plain text), or `inline` when
   the entry sets `projection: inline` (see below).
+
+A flat `items` string holds the item's own text only.
+A nested sub-list is excluded, not folded in, so `- a`
+with child `- b` projects `"a"`, never `"ab"`. Inline
+markup flattens to text; a task marker stays verbatim
+(`[x]` / `[ ]`); a nest-only item projects the empty
+string, keeping its slot. Use `projection: tree` (below)
+to keep the nesting and split the marker out.
 
 Sibling keys are emitted in sorted order, not document
 order. Two sibling projections that resolve to the same
@@ -132,22 +142,50 @@ A nested example — a strong span wrapping a code span,
 }
 ```
 
-Each content kind constrains its projection at schema-
-load time. A `paragraph` takes `text` or `inline`. A
-`code-block` takes `code`. A `table`, `list`, or
-`unlisted` slot takes none. An incompatible combination
-fails when the config loads, not silently at extract
-time. Rejected cases include `projection: code` on a
-paragraph, `projection: inline` on a code-block, and any
-`projection` on a table.
+Each kind limits which projection it takes. A bad pair
+fails when the config loads, not later at extract:
+
+| Kind         | Allowed `projection`            |
+| ------------ | ------------------------------- |
+| `paragraph`  | `text`, `inline`                |
+| `code-block` | `code`                          |
+| `list`       | `tree` (flat string if omitted) |
+| `table`      | none                            |
+| `unlisted`   | none                            |
 
 Anything outside the mapping table is a hard error at
 extract time, with the same exit code as a non-conformant
-file. Images, inline raw HTML, and custom inline nodes
-fall in this set. The `text` and `inline` default keys
-differ, so one paragraph entry can project `text` and
-another `inline` without colliding. A `bind:` override
-renames either key.
+file: images, inline raw HTML, and custom inline nodes.
+The `text` and `inline` default keys differ, so one
+paragraph can project each without colliding.
+
+## Tree projection for lists
+
+A list entry projects an array of own-text strings by
+default. Set `projection: tree` on a `kind: list` entry
+to project each item as an object instead. Each object
+carries:
+
+- `text` — the item's own inline text, flattened, with
+  soft wraps joined and any task marker removed.
+- `checked` — a bool, present only on a GFM task item
+  (`- [x]` / `- [ ]`). Detection matches the renderer: a
+  bare `[x]` and a no-space `[x]done` count; a non-marker
+  word like `[TODO]` does not and stays in `text`.
+- `children` — a recursive array of item objects, present
+  only when the item nests a sub-list.
+
+A checked task nesting one plain child projects as:
+
+```json
+{ "checked": true, "children": [{ "text": "child" }], "text": "done" }
+```
+
+The array order is the item order; ordered-list numbering
+and `start` are out of scope. YAML and msgpack emit the
+same tree. The
+[extract guide](../../guides/extract-markdown-as-data.md)
+has a full worked checklist.
 
 ## Custom binding with `bind`
 

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -196,7 +196,11 @@ func (p *projector) projectContent(
 		case schema.ContentKindCodeBlock:
 			p.setKey(obj, nextKey(base), p.codeBody(cm.Node))
 		case schema.ContentKindList:
-			p.setKey(obj, nextKey(base), p.listItems(cm.Node))
+			if cm.Entry.Projection == schema.ProjectionTree {
+				p.setKey(obj, nextKey(base), p.listTree(cm.Node))
+			} else {
+				p.setKey(obj, nextKey(base), p.listItems(cm.Node))
+			}
 		case schema.ContentKindTable:
 			p.setKey(obj, nextKey(base), p.tableRows(cm.Node))
 		case schema.ContentKindParagraph:

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -261,10 +261,29 @@ func (p *projector) listItems(n ast.Node) []any {
 	}
 	var items []any
 	for c := lst.FirstChild(); c != nil; c = c.NextSibling() {
-		items = append(items, strings.TrimSpace(
-			mdtext.ExtractPlainText(c, p.f.Source)))
+		items = append(items, p.itemOwnText(c))
 	}
 	return items
+}
+
+// itemOwnText returns a list item's own inline text — the text of its
+// direct block children, with any nested sub-list excluded. The bare
+// mdtext.ExtractPlainText recursion would splice a child item's text
+// into the parent with no separator (`boldnested child`), corrupting
+// the data; restricting it to non-List blocks keeps each flat string
+// to the item it belongs to. An item whose only content is a nested
+// list has no own text and projects as the empty string, preserving
+// the item's position in the array. Task markers (`[x]` / `[ ]`) are
+// left verbatim in flat mode, matching the historical output.
+func (p *projector) itemOwnText(item ast.Node) string {
+	var b strings.Builder
+	for c := item.FirstChild(); c != nil; c = c.NextSibling() {
+		if _, ok := c.(*ast.List); ok {
+			continue
+		}
+		b.WriteString(mdtext.ExtractPlainText(c, p.f.Source))
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func (p *projector) tableRows(n ast.Node) []any {

--- a/internal/extract/extract_cover_test.go
+++ b/internal/extract/extract_cover_test.go
@@ -18,6 +18,7 @@ func TestProjectorHelpers_WrongNodeType(t *testing.T) {
 	para := ast.NewParagraph()
 	assert.Equal(t, "", p.codeBody(para))
 	assert.Nil(t, p.listItems(para))
+	assert.Nil(t, p.listTree(para))
 	assert.Nil(t, p.tableRows(para))
 }
 

--- a/internal/extract/list_test.go
+++ b/internal/extract/list_test.go
@@ -1,0 +1,73 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listScope builds a single-section schema whose body is one list
+// content entry projected with the given mode (empty for the flat
+// default).
+func listScope(projection string) *schema.Schema {
+	return &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading: "Items",
+			Matcher: &schema.Matcher{Regex: "Items"},
+			Content: []schema.ContentEntry{{
+				Kind:       schema.ContentKindList,
+				Required:   true,
+				Projection: projection,
+			}},
+		}},
+	}
+}
+
+// runList projects body through listScope(projection) and returns the
+// `items` value plus any diagnostics.
+func runList(t *testing.T, body, projection string) (any, []lint.Diagnostic) {
+	t.Helper()
+	got, diags := run(t, body, listScope(projection), nil)
+	if len(diags) > 0 {
+		return nil, diags
+	}
+	items := got.(map[string]any)["items"].(map[string]any)["items"]
+	return items, nil
+}
+
+// TestExtract_FlatListNoNestedConcatenation is the plan-244 bugfix
+// reproduction: a parent item's own text must not absorb a nested
+// child's text. The corrupt behaviour emitted
+// "open item with boldnested child"; the fix emits only the parent's
+// own inline text ("open item with bold"), children excluded.
+func TestExtract_FlatListNoNestedConcatenation(t *testing.T) {
+	body := "## Items\n\n" +
+		"- [x] done item\n" +
+		"- [ ] open item with **bold**\n" +
+		"  - nested child\n"
+	items, diags := runList(t, body, "")
+	require.Empty(t, diags)
+	assert.Equal(t, []any{
+		"[x] done item",
+		"[ ] open item with bold",
+	}, items)
+}
+
+// TestExtract_FlatListItemOnlyNestedList pins the design decision the
+// plan calls out: a top-level item whose only content is a nested
+// sub-list has no own text, so flat mode projects it as the empty
+// string. The item keeps its slot in the array (order preserved); the
+// nested child is excluded, since flat mode emits own text only.
+func TestExtract_FlatListItemOnlyNestedList(t *testing.T) {
+	body := "## Items\n\n" +
+		"- parent\n" +
+		"-\n" +
+		"  - lonely child\n"
+	items, diags := runList(t, body, "")
+	require.Empty(t, diags)
+	assert.Equal(t, []any{"parent", ""}, items)
+}

--- a/internal/extract/list_test.go
+++ b/internal/extract/list_test.go
@@ -1,12 +1,16 @@
 package extract
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/extract/encode"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+	"gopkg.in/yaml.v3"
 )
 
 // listScope builds a single-section schema whose body is one list
@@ -70,4 +74,139 @@ func TestExtract_FlatListItemOnlyNestedList(t *testing.T) {
 	items, diags := runList(t, body, "")
 	require.Empty(t, diags)
 	assert.Equal(t, []any{"parent", ""}, items)
+}
+
+// TestExtract_TreeListWorkedExample pins the plan-244 tree-mode worked
+// example: each item is an object with its own `text`; a task item
+// carries a `checked` bool (the `[x]`/`[ ]` marker never leaks into
+// `text`); a nesting item carries recursive `children`.
+func TestExtract_TreeListWorkedExample(t *testing.T) {
+	body := "## Items\n\n" +
+		"- [x] done item\n" +
+		"- [ ] open item with **bold**\n" +
+		"  - nested child\n"
+	items, diags := runList(t, body, schema.ProjectionTree)
+	require.Empty(t, diags)
+	assert.Equal(t, []any{
+		map[string]any{"text": "done item", "checked": true},
+		map[string]any{
+			"text":    "open item with bold",
+			"checked": false,
+			"children": []any{
+				map[string]any{"text": "nested child"},
+			},
+		},
+	}, items)
+}
+
+// TestExtract_TreeListPlainItem verifies a non-task, non-nesting item
+// projects as just `{text}` — no `checked`, no `children` keys.
+func TestExtract_TreeListPlainItem(t *testing.T) {
+	items, diags := runList(t, "## Items\n\n- plain item\n", schema.ProjectionTree)
+	require.Empty(t, diags)
+	assert.Equal(t, []any{map[string]any{"text": "plain item"}}, items)
+}
+
+// TestExtract_TreeListTaskMarkerEdges pins task-marker detection to
+// match the goldmark task-list extension byte-for-byte: a bare `[x]`
+// (empty label) is a checked task with empty text; an unchecked `[ ]`
+// with a label strips the marker; and a bracketed word that is not a
+// valid marker (`[a]`, `[TODO]`) is left verbatim with no `checked`.
+func TestExtract_TreeListTaskMarkerEdges(t *testing.T) {
+	cases := []struct {
+		name string
+		item string
+		want map[string]any
+	}{
+		{"bare checked", "- [x]\n", map[string]any{"text": "", "checked": true}},
+		{"bare unchecked", "- [ ]\n", map[string]any{"text": "", "checked": false}},
+		{"no space after marker", "- [x]done\n",
+			map[string]any{"text": "done", "checked": true}},
+		{"non-marker bracket word", "- [a] label\n",
+			map[string]any{"text": "[a] label"}},
+		{"non-marker uppercase word", "- [TODO] task\n",
+			map[string]any{"text": "[TODO] task"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			items, diags := runList(t, "## Items\n\n"+c.item, schema.ProjectionTree)
+			require.Empty(t, diags)
+			assert.Equal(t, []any{c.want}, items)
+		})
+	}
+}
+
+// TestExtract_TreeListNestedTaskItems verifies `checked` is computed
+// per item at any depth: a nested child task carries its own marker.
+func TestExtract_TreeListNestedTaskItems(t *testing.T) {
+	body := "## Items\n\n" +
+		"- [ ] parent task\n" +
+		"  - [x] child task\n"
+	items, diags := runList(t, body, schema.ProjectionTree)
+	require.Empty(t, diags)
+	assert.Equal(t, []any{
+		map[string]any{
+			"text":    "parent task",
+			"checked": false,
+			"children": []any{
+				map[string]any{"text": "child task", "checked": true},
+			},
+		},
+	}, items)
+}
+
+// TestExtract_TreeListSameAcrossFormats pins the acceptance criterion
+// that YAML and msgpack emit the same tree as JSON — including the
+// `checked` bool and nested `children`, the two shapes new to plan
+// 244. The full document tree is encoded in each format and decoded
+// back; all three must round-trip to an identical structure.
+func TestExtract_TreeListSameAcrossFormats(t *testing.T) {
+	body := "## Items\n\n" +
+		"- [x] done item\n" +
+		"- [ ] open item with **bold**\n" +
+		"  - nested child\n"
+	got, diags := run(t, body, listScope(schema.ProjectionTree), nil)
+	require.Empty(t, diags)
+
+	jb, err := encode.Encode(encode.JSON, got)
+	require.NoError(t, err)
+	var jv any
+	require.NoError(t, json.Unmarshal(jb, &jv))
+
+	yb, err := encode.Encode(encode.YAML, got)
+	require.NoError(t, err)
+	var yv any
+	require.NoError(t, yaml.Unmarshal(yb, &yv))
+
+	mb, err := encode.Encode(encode.Msgpack, got)
+	require.NoError(t, err)
+	var mv any
+	require.NoError(t, msgpack.Unmarshal(mb, &mv))
+
+	assert.Equal(t, jv, yv, "YAML tree must equal JSON tree")
+	assert.Equal(t, jv, mv, "msgpack tree must equal JSON tree")
+}
+
+// TestExtract_TreeListChildrenOnlyWhenNonEmpty verifies `children` is
+// present only when an item nests a sub-list, and recursive to depth.
+func TestExtract_TreeListChildrenOnlyWhenNonEmpty(t *testing.T) {
+	body := "## Items\n\n" +
+		"- a\n" +
+		"  - b\n" +
+		"    - c\n"
+	items, diags := runList(t, body, schema.ProjectionTree)
+	require.Empty(t, diags)
+	assert.Equal(t, []any{
+		map[string]any{
+			"text": "a",
+			"children": []any{
+				map[string]any{
+					"text": "b",
+					"children": []any{
+						map[string]any{"text": "c"},
+					},
+				},
+			},
+		},
+	}, items)
 }

--- a/internal/extract/list_tree.go
+++ b/internal/extract/list_tree.go
@@ -1,0 +1,77 @@
+package extract
+
+import (
+	"regexp"
+
+	"github.com/yuin/goldmark/ast"
+)
+
+// taskMarkerRE matches a leading GFM task-list marker — `[ ]`, `[x]`,
+// or `[X]`, optionally followed by trailing whitespace. It is the
+// regexp the goldmark task-list extension uses verbatim
+// (`pkg/goldmark/extension/tasklist.go`), applied here over the item's
+// already-extracted plain text rather than the AST: mdsmith's schema
+// content walker parses with CommonMark + Table only (no task-list
+// inline parser), so a marker reaches extract as literal text, not a
+// TaskCheckBox node. Matching goldmark byte-for-byte keeps tree-mode
+// task detection identical to what the renderer would treat as a
+// checkbox — including a bare `[x]` and a no-space `[x]done`. The
+// capture group is the marker's state character: whitespace means
+// unchecked, `x`/`X` checked.
+var taskMarkerRE = regexp.MustCompile(`^\[([\sxX])\]\s*`)
+
+// listTree projects a list as a typed recursive item tree (plan 244's
+// `projection: tree`). Each item becomes an object carrying its own
+// `text`; a GFM task item additionally carries a `checked` bool with
+// the marker stripped from `text`; an item that nests a sub-list
+// carries recursive `children`. `children` is present only when the
+// nested list has items, and `checked` only on task items, so a plain
+// leaf item projects as just `{text}`.
+func (p *projector) listTree(n ast.Node) []any {
+	lst, ok := n.(*ast.List)
+	if !ok {
+		return nil
+	}
+	items := make([]any, 0)
+	for c := lst.FirstChild(); c != nil; c = c.NextSibling() {
+		items = append(items, p.treeItem(c))
+	}
+	return items
+}
+
+// treeItem builds the object for one list item: its own text (task
+// marker split off into `checked`), then any nested sub-list as
+// `children`.
+func (p *projector) treeItem(item ast.Node) map[string]any {
+	obj := map[string]any{}
+	text := p.itemOwnText(item)
+	if marker := taskMarkerRE.FindString(text); marker != "" {
+		obj["checked"] = isCheckedMarker(marker)
+		text = text[len(marker):]
+	}
+	obj["text"] = text
+	if kids := p.childItems(item); len(kids) > 0 {
+		obj["children"] = kids
+	}
+	return obj
+}
+
+// childItems returns the projected items of an item's first nested
+// sub-list, or nil when the item nests no list. A list item holds at
+// most one direct child List in goldmark's model; the first one wins.
+func (p *projector) childItems(item ast.Node) []any {
+	for c := item.FirstChild(); c != nil; c = c.NextSibling() {
+		if sub, ok := c.(*ast.List); ok {
+			return p.listTree(sub)
+		}
+	}
+	return nil
+}
+
+// isCheckedMarker reports whether a task marker matched by
+// taskMarkerRE is in the checked state. The state character is the
+// first byte after the opening bracket; only `x`/`X` mean checked.
+func isCheckedMarker(marker string) bool {
+	state := marker[1]
+	return state == 'x' || state == 'X'
+}

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -1060,8 +1060,8 @@ func applyContentField(k string, vv any, ce *ContentEntry, path string) error {
 }
 
 // setContentProjection reads the optional `projection:` mode for a
-// content entry (`text` / `code` / `inline`). Omitting the key uses
-// the kind's default projection; this runs only when `projection:`
+// content entry (`text` / `code` / `inline` / `tree`). Omitting the key
+// uses the kind's default projection; this runs only when `projection:`
 // is present, so an explicit empty string is rejected as an unknown
 // projection like any other unrecognised value.
 //
@@ -1069,18 +1069,21 @@ func applyContentField(k string, vv any, ce *ContentEntry, path string) error {
 // incompatible combination is a schema-load error rather than a
 // silently-ignored field: a paragraph projects `text` or `inline`
 // (its plain text or its typed inline-span tree); a code-block
-// projects `code` (its raw body); and a table, list, or unlisted slot
-// has no projection mode at all. Plan 212.
+// projects `code` (its raw body); a list projects `tree` (a typed
+// recursive item tree) or, with projection omitted, its flat string
+// default; and an unlisted slot has no projection mode at all.
+// Plans 212, 244.
 func setContentProjection(ce *ContentEntry, v any, path string) error {
 	s, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("%s.projection must be a string, got %T", path, v)
 	}
 	switch s {
-	case ProjectionText, ProjectionCode, ProjectionInline:
+	case ProjectionText, ProjectionCode, ProjectionInline, ProjectionTree:
 	default:
 		return fmt.Errorf(
-			"%s.projection: unknown projection %q (valid: text, code, inline)",
+			"%s.projection: unknown projection %q "+
+				"(valid: text, code, inline, tree)",
 			path, s)
 	}
 	if err := checkProjectionKind(ce.Kind, s, path); err != nil {
@@ -1091,13 +1094,13 @@ func setContentProjection(ce *ContentEntry, v any, path string) error {
 }
 
 // checkProjectionKind enforces the projection/kind matrix at schema
-// load. proj is already a known mode (text / code / inline). The
-// error names what the kind allows so an incompatible combination
+// load. proj is already a known mode (text / code / inline / tree).
+// The error names what the kind allows so an incompatible combination
 // fails with a fix inline rather than being dropped at extract time.
 func checkProjectionKind(kind, proj, path string) error {
 	switch kind {
 	case ContentKindParagraph:
-		if proj == ProjectionCode {
+		if proj != ProjectionText && proj != ProjectionInline {
 			return fmt.Errorf(
 				"%s.projection: kind: paragraph allows projection text or "+
 					"inline, not %s", path, proj)
@@ -1108,10 +1111,16 @@ func checkProjectionKind(kind, proj, path string) error {
 				"%s.projection: kind: code-block allows projection code, "+
 					"not %s", path, proj)
 		}
+	case ContentKindList:
+		if proj != ProjectionTree {
+			return fmt.Errorf(
+				"%s.projection: kind: list allows projection tree, "+
+					"not %s", path, proj)
+		}
 	default:
 		return fmt.Errorf(
 			"%s.projection: projection is not allowed on kind: %s "+
-				"(only paragraph and code-block project)", path, kind)
+				"(only paragraph, code-block, and list project)", path, kind)
 	}
 	return nil
 }

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -400,6 +400,12 @@ const (
 	// recursive list (text / emphasis / strong / code / link /
 	// autolink). Valid only on `kind: paragraph`.
 	ProjectionInline = "inline"
+	// ProjectionTree emits a list's items as a typed recursive tree:
+	// each item is an object carrying its own `text`, an optional
+	// `checked` bool for GFM task items, and optional `children` for a
+	// nested sub-list. Valid only on `kind: list`. The flat default
+	// (projection omitted) keeps emitting plain strings. Plan 244.
+	ProjectionTree = "tree"
 )
 
 // IsEmpty reports whether s carries no constraints. Used by callers

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -450,12 +450,13 @@ func parseProjectionCombo(kind, projection string) (*Schema, error) {
 
 // TestParseInline_ProjectionMatrixAllowed pins every (kind,
 // projection) pair the schema accepts: paragraph takes text or
-// inline, code-block takes code.
+// inline, code-block takes code, list takes tree.
 func TestParseInline_ProjectionMatrixAllowed(t *testing.T) {
 	allowed := []struct{ kind, projection string }{
 		{"paragraph", "text"},
 		{"paragraph", "inline"},
 		{"code-block", "code"},
+		{"list", "tree"},
 	}
 	for _, c := range allowed {
 		t.Run(c.kind+"/"+c.projection, func(t *testing.T) {
@@ -509,13 +510,38 @@ func TestParseInline_ProjectionOnTableRejected(t *testing.T) {
 	}
 }
 
-// TestParseInline_ProjectionOnListRejected rejects any projection on a
-// list.
-func TestParseInline_ProjectionOnListRejected(t *testing.T) {
-	_, err := parseProjectionCombo("list", "text")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(),
-		"projection is not allowed on kind: list")
+// TestParseInline_ProjectionNonTreeOnListRejected rejects the
+// paragraph/code-block projections on a list — a list projects only
+// `tree` (or its flat default when projection is omitted).
+func TestParseInline_ProjectionNonTreeOnListRejected(t *testing.T) {
+	for _, p := range []string{"text", "code", "inline"} {
+		t.Run(p, func(t *testing.T) {
+			_, err := parseProjectionCombo("list", p)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(),
+				"kind: list allows projection tree, not "+p)
+		})
+	}
+}
+
+// TestParseInline_ProjectionTreeOnNonListRejected rejects
+// `projection: tree` everywhere except a list — tree is the list's
+// structured mode and has no meaning on a paragraph, code-block,
+// table, or unlisted slot.
+func TestParseInline_ProjectionTreeOnNonListRejected(t *testing.T) {
+	cases := []struct{ kind, want string }{
+		{"paragraph", "kind: paragraph allows projection text or inline, not tree"},
+		{"code-block", "kind: code-block allows projection code, not tree"},
+		{"table", "projection is not allowed on kind: table"},
+		{"unlisted", "projection is not allowed on kind: unlisted"},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			_, err := parseProjectionCombo(c.kind, "tree")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.want)
+		})
+	}
 }
 
 // TestParseInline_ProjectionOnUnlistedRejected rejects any projection

--- a/plan/244_structured-list-projection.md
+++ b/plan/244_structured-list-projection.md
@@ -1,7 +1,7 @@
 ---
 id: 244
 title: "Structured list projection; fix nested-item text corruption"
-status: "🔳"
+status: "✅"
 summary: >-
   Fix flat list projection concatenating nested-item text into
   the parent with no separator, then add `projection: tree` so
@@ -105,12 +105,12 @@ projects each item as an object:
 - [x] Flat `items` never concatenates nested-item text into a
   parent string; the corrupt case above projects
   `"[ ] open item with bold"`.
-- [ ] `projection: tree` emits item objects with `text`,
+- [x] `projection: tree` emits item objects with `text`,
   `checked` only on task items, `children` only when
   non-empty, recursive to any depth.
-- [ ] `projection: tree` on a non-list content entry fails at
+- [x] `projection: tree` on a non-list content entry fails at
   config load.
-- [ ] YAML and msgpack formats emit the same tree.
-- [ ] Reference and guide updated with verified outputs.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] YAML and msgpack formats emit the same tree.
+- [x] Reference and guide updated with verified outputs.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues

--- a/plan/244_structured-list-projection.md
+++ b/plan/244_structured-list-projection.md
@@ -1,7 +1,7 @@
 ---
 id: 244
 title: "Structured list projection; fix nested-item text corruption"
-status: "🔲"
+status: "🔳"
 summary: >-
   Fix flat list projection concatenating nested-item text into
   the parent with no separator, then add `projection: tree` so
@@ -102,7 +102,7 @@ projects each item as an object:
 
 ## Acceptance Criteria
 
-- [ ] Flat `items` never concatenates nested-item text into a
+- [x] Flat `items` never concatenates nested-item text into a
   parent string; the corrupt case above projects
   `"[ ] open item with bold"`.
 - [ ] `projection: tree` emits item objects with `text`,


### PR DESCRIPTION
Draft PR for [plan/244_structured-list-projection.md](plan/244_structured-list-projection.md).

Status will move 🔲 → 🔳 in PLAN.md once the first real
commit lands. Marking ready for review when the
acceptance criteria are checked off.

https://claude.ai/code/session_01V5FGdWSHdvuKjKtDjzM746

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5FGdWSHdvuKjKtDjzM746)_