### PR TITLE
Plan 243: `mdsmith extract` projects the document H1 as `title`

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -171,7 +171,7 @@ footer: |
 | 241 | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
 | 242 | ✅     | sonnet | [Recover from panics in the LSP lint pipeline](plan/242_lsp-panic-recovery.md)                                                          |
 | 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
-| 243 | 🔲     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
+| 243 | 🔳     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 243 | ✅     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
 | 244 | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245 | ✅     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |

--- a/PLAN.md
+++ b/PLAN.md
@@ -171,7 +171,7 @@ footer: |
 | 241 | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
 | 242 | ✅     | sonnet | [Recover from panics in the LSP lint pipeline](plan/242_lsp-panic-recovery.md)                                                          |
 | 242 | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
-| 243 | 🔳     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
+| 243 | ✅     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 243 | ✅     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/243_secreview-2026-06-09-hardening.md)                                               |
 | 244 | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245 | ✅     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |

--- a/cmd/mdsmith/e2e_extract_test.go
+++ b/cmd/mdsmith/e2e_extract_test.go
@@ -69,6 +69,7 @@ Bake a cake.
 func expectedRecipeTree() map[string]any {
 	return map[string]any{
 		"frontmatter": map[string]any{},
+		"title":       "Cake",
 		"goal":        map[string]any{},
 		"steps": map[string]any{
 			"step": []any{
@@ -212,6 +213,7 @@ func TestE2E_Extract_InlineJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
 	want := map[string]any{
 		"frontmatter": map[string]any{},
+		"title":       "Hero",
 		"headline": map[string]any{
 			"inline": []any{
 				map[string]any{"span": "text", "value": "Mark"},
@@ -295,6 +297,7 @@ func TestE2E_Extract_InlineSoftBreak(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
 	want := map[string]any{
 		"frontmatter": map[string]any{},
+		"title":       "Hero",
 		"headline": map[string]any{
 			"inline": []any{
 				map[string]any{"span": "text", "value": "first"},

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -467,27 +467,9 @@ field, keep it and let MDS020 enforce the match.
 
 When the schema roots at H2 (all inline schemas do),
 `mdsmith extract` emits the document H1's plain text
-under a reserved `title` key beside `frontmatter`.
-For the body-structured example above:
-
-```json
-{
-  "frontmatter": {
-    "title": "Product copy"
-  },
-  "title": "Product copy",
-  "lead": {
-    "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
-  },
-  "tagline": {
-    "text": "Mark down your ideas; smith them into shipping docs."
-  },
-  "vscode-description": {
-    "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code."
-  }
-}
-```
-
+under a reserved `title` key beside `frontmatter` —
+the `"title": "Product copy"` line in the
+[worked example](#worked-example) output above.
 When there is no H1, the `title` key is omitted.
 When a scope bound to `title` (via slug or `bind:`)
 collides with the reserved key, `extract` reports

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -139,6 +139,7 @@ emits:
   "frontmatter": {
     "title": "Product copy"
   },
+  "title": "Product copy",
   "lead": {
     "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
   },
@@ -151,10 +152,11 @@ emits:
 }
 ```
 
-Keys come out sorted, not in document order. The
-consumer reads the same strings the frontmatter
-version held, and the body version is the editable
-artifact.
+The H1 `# Product copy` projects as the top-level
+`title` string. Keys come out sorted, not in document
+order. The consumer reads the same strings the
+frontmatter version held, and the body version is the
+editable artifact.
 
 ## Projecting inline structure
 
@@ -461,7 +463,53 @@ reads `frontmatter.title`, delete the field; the H1
 alone is the title. When a tool does read the
 field, keep it and let MDS020 enforce the match.
 
-Enforcement needs a file-based schema. An inline
+### H1 title in the projection
+
+When the schema roots at H2 (all inline schemas do),
+`mdsmith extract` emits the document H1's plain text
+under a reserved `title` key beside `frontmatter`.
+For the body-structured example above:
+
+```json
+{
+  "frontmatter": {
+    "title": "Product copy"
+  },
+  "title": "Product copy",
+  "lead": {
+    "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
+  },
+  "tagline": {
+    "text": "Mark down your ideas; smith them into shipping docs."
+  },
+  "vscode-description": {
+    "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code."
+  }
+}
+```
+
+When there is no H1, the `title` key is omitted.
+When a scope bound to `title` (via slug or `bind:`)
+collides with the reserved key, `extract` reports
+it as a collision before emitting any data; rename
+the scope with `bind:` to resolve it.
+
+`<?include extract: title?>` splices the H1 plain
+text directly into a host file with no intermediate
+file needed:
+
+```markdown
+<?include
+file: docs/copy/product.md
+extract: title
+?>
+Product copy
+<?/include?>
+```
+
+### Enforcing H1 ↔ frontmatter consistency
+
+Enforcement requires a file-based schema. An inline
 `schema:` starts matching at H2 — the H1 belongs to
 [first-line-heading][mds004] — so the kind switches
 to a `proto.md` whose first row is the `{title}`
@@ -489,36 +537,14 @@ H1 fails `mdsmith check`:
 docs/copy/product.md:4:1 MDS020 heading does not match frontmatter: expected "Product copy" (from title), got "Product page copy"
 ```
 
-The synced H1 also becomes data. `mdsmith extract`
-projects the H1 scope under a `title` key, with the
-captured heading text inside:
-
-```json
-{
-  "frontmatter": {
-    "title": "Product copy"
-  },
-  "title": {
-    "title": "Product copy"
-  }
-}
-```
-
-Weigh two limits before switching. Every schema
-source on a file must declare the same root level,
-so an H1-rooted `proto.md` cannot compose with an
-H2-rooted inline schema on the same file. And a
-`proto.md` declares heading rows only, not
-`content:` entries, so the worked example's
+Weigh two limits before switching to a proto.md.
+Every schema source on a file must declare the same
+root level, so an H1-rooted `proto.md` cannot
+compose with an H2-rooted inline schema on the same
+file. And a `proto.md` declares heading rows only,
+not `content:` entries, so the worked example's
 paragraph projections (`tagline.text`, …) drop out
 of the tree.
-
-When the kind's main job is extraction, keep the
-inline schema and delete the frontmatter field
-instead. mdsmith cannot project the H1 text without
-a frontmatter field behind it: a `{title}` row with
-no `title` field matches any heading, and `extract`
-skips wildcard scopes.
 
 [mds004]: ../../internal/rules/MDS004-first-line-heading/README.md
 

--- a/docs/reference/cli/extract.md
+++ b/docs/reference/cli/extract.md
@@ -33,6 +33,12 @@ with the validated match and mirrors the hierarchy:
 - The root holds a `frontmatter` object (the decoded
   front matter, unchanged) and the projected sections
   beside it at the same level.
+- When the schema roots at H2 (all inline schemas do),
+  the document H1's plain text is emitted under the
+  reserved `title` key beside `frontmatter`. No H1 in
+  the document omits the key. A sibling scope whose
+  projection key resolves to `title` is reported as a
+  collision; rename it with `bind:`.
 - A literal heading (`## Goal`) becomes an object keyed
   by the slugified heading (`goal`).
 - A repeating section (`## Step {n}` with a `repeat:`
@@ -48,6 +54,9 @@ with the validated match and mirrors the hierarchy:
 - Wildcard slots (`regex: '.+'`) and unlisted or closed
   headings are skipped: the output is a faithful image
   of the *declared* schema only.
+- H1-rooted schemas (file-based proto.md schemas where
+  the top heading is H1) do not emit the reserved
+  `title` key; the H1 is already a scope in `Sections`.
 
 Content entries project under default keys:
 

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -41,11 +41,37 @@ func Extract(
 	} else {
 		root["frontmatter"] = map[string]any{}
 	}
+	// When the composed schema roots at H2, the document H1 is
+	// outside every schema scope. Emit it under the reserved
+	// "title" key beside `frontmatter`. No H1 → key omitted
+	// (consistent with optional sections: omitted, not null).
+	// First H1 wins when a document carries more than one.
+	// Collision with a sibling scope that resolves to "title"
+	// is reported through the existing setKey machinery.
+	if sch.EffectiveRootLevel() == 2 {
+		if h1Text := p.firstH1PlainText(); h1Text != "" {
+			p.setKey(root, "title", h1Text)
+		}
+	}
 	p.projectChildren(m.Root.Children, root)
 	if len(p.diags) > 0 {
 		return nil, p.diags
 	}
 	return root, nil
+}
+
+// firstH1PlainText returns the plain text of the first H1 heading
+// found in the document, or an empty string if there is none.
+// It uses ExtractPlainText (the same renderer the heading matcher
+// and content projector use) so emphasis and code-span markers
+// are stripped and link text is kept.
+func (p *projector) firstH1PlainText() string {
+	for _, dh := range schema.ExtractDocHeadings(p.f) {
+		if dh.Level == 1 {
+			return strings.TrimSpace(dh.Text)
+		}
+	}
+	return ""
 }
 
 type projector struct {

--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -329,3 +329,78 @@ func TestExtract_TableProjectionRecordsDuplicateHeaderErrors(t *testing.T) {
 	_, diags := run(t, body, sch, nil)
 	require.NotEmpty(t, diags, "duplicate headers must error under records projection")
 }
+
+// --- Plan 243: H1 title projection ---
+
+// When the schema roots at H2 and the document has an H1, Extract
+// emits the H1's plain text under a reserved "title" key.
+func TestExtract_H1TitlePresent(t *testing.T) {
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{litScope("Goal")}}
+	got, diags := run(t, "# Product copy\n\n## Goal\n\nbody\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Equal(t, "Product copy", root["title"])
+}
+
+// When the schema roots at H2 but the document has no H1, the
+// "title" key is omitted entirely (consistent with optional
+// sections: omitted, not null).
+func TestExtract_H1TitleAbsent(t *testing.T) {
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{litScope("Goal")}}
+	got, diags := run(t, "## Goal\n\nbody\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.NotContains(t, root, "title")
+}
+
+// An emphasis-bearing H1 must project as plain text (emphasis
+// markers stripped, link text kept).
+func TestExtract_H1TitleEmphasis(t *testing.T) {
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{litScope("Goal")}}
+	got, diags := run(t, "# Mark*down*, smithed\n\n## Goal\n\nbody\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Equal(t, "Markdown, smithed", root["title"])
+}
+
+// When a document carries more than one H1, the first one wins.
+func TestExtract_H1TitleFirstWins(t *testing.T) {
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{litScope("Goal")}}
+	got, diags := run(t,
+		"# First title\n\n## Goal\n\nbody\n\n# Second title\n\n",
+		sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Equal(t, "First title", root["title"])
+}
+
+// When the schema roots at H1 (file-based proto.md schema),
+// the H1 is already a scope in Sections; no reserved "title"
+// key should be added.
+func TestExtract_H1RootedSchemaUnchanged(t *testing.T) {
+	h1scope := litScope("Product copy")
+	h1scope.Sections = []schema.Scope{litScope("Goal")}
+	sch := &schema.Schema{RootLevel: 1, Sections: []schema.Scope{h1scope}}
+	got, diags := run(t, "# Product copy\n\n## Goal\n\nbody\n", sch, nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	// H1-rooted: the H1 scope is projected under its slugified key,
+	// not under a reserved "title" key.
+	assert.NotContains(t, root, "title")
+	assert.Contains(t, root, "product-copy")
+}
+
+// A sibling scope whose key resolves to "title" (via bind: or
+// slugification) is a collision with the reserved H1 title key.
+func TestExtract_H1TitleCollision(t *testing.T) {
+	titleKey := "title"
+	titleScope := schema.Scope{
+		Heading: "title",
+		Matcher: &schema.Matcher{Regex: "title"},
+		Bind:    &titleKey,
+	}
+	sch := &schema.Schema{RootLevel: 2, Sections: []schema.Scope{titleScope}}
+	_, diags := run(t, "# My doc\n\n## title\n\nbody\n", sch, nil)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "title")
+}

--- a/internal/rules/include/extract_integration_test.go
+++ b/internal/rules/include/extract_integration_test.go
@@ -404,3 +404,38 @@ func TestFix_ExtractRoundTripStable(t *testing.T) {
 	second := r.Fix(f2)
 	assert.Equal(t, string(first), string(second))
 }
+
+// =====================================================================
+// Plan 243: <?include extract: title?> splices the H1 plain text
+// =====================================================================
+
+// TestCheck_ExtractH1Title verifies that `extract: title` in an
+// include directive splices the H1 plain text from an H2-rooted
+// schema file. The minimalMessagingFile has `# Mdsmith` as its H1.
+func TestCheck_ExtractH1Title(t *testing.T) {
+	root, hostRel := setupMessagingProject(t)
+	installTestProjector(t, filepath.Join(root, ".mdsmith.yml"))
+	src := "<?include\nfile: message.md\nextract: title\n?>\n" +
+		"Mdsmith\n<?/include?>\n"
+	f := newHostFile(t, root, hostRel, src)
+
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+// TestFix_ExtractH1Title verifies that fixing regenerates the body
+// from the H1 plain text when the include path is `extract: title`.
+func TestFix_ExtractH1Title(t *testing.T) {
+	root, hostRel := setupMessagingProject(t)
+	installTestProjector(t, filepath.Join(root, ".mdsmith.yml"))
+	src := "<?include\nfile: message.md\nextract: title\n?>\n" +
+		"stale\n<?/include?>\n"
+	f := newHostFile(t, root, hostRel, src)
+
+	r := &Rule{}
+	got := string(r.Fix(f))
+	want := "<?include\nfile: message.md\nextract: title\n?>\n" +
+		"Mdsmith\n<?/include?>\n"
+	assert.Equal(t, want, got)
+}

--- a/plan/243_extract-h1-title.md
+++ b/plan/243_extract-h1-title.md
@@ -1,7 +1,7 @@
 ---
 id: 243
 title: "`mdsmith extract` projects the document H1 as `title`"
-status: "🔲"
+status: "🔳"
 summary: >-
   When the composed schema roots at H2, extract emits the
   document H1's rendered plain text under a reserved top-level
@@ -59,15 +59,15 @@ title?>` splices it.
 
 ## Tasks
 
-1. Emit the reserved `title` key in
+1. [x] Emit the reserved `title` key in
    [`internal/extract`](../internal/extract) when the
    composed schema's root level is 2 and the document has an
    H1; omit it otherwise. Unit-test: present, absent,
    emphasis-bearing, and multi-H1 documents.
-2. Route the key through the existing collision check; test a
+2. [x] Route the key through the existing collision check; test a
    scope bound to `title` reports a collision naming both
    sources.
-3. Verify `<?include extract: title?>` splices the H1 text
+3. [x] Verify `<?include extract: title?>` splices the H1 text
    (the include path walks the same projection).
 4. Update the
    [extract reference](../docs/reference/cli/extract.md)
@@ -80,13 +80,13 @@ title?>` splices it.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith extract` on an H2-rooted kind emits
+- [x] `mdsmith extract` on an H2-rooted kind emits
   `"title": "<H1 plain text>"` at the top level; the key is
   omitted when the document has no H1.
-- [ ] A sibling projection that resolves to `title` is
+- [x] A sibling projection that resolves to `title` is
   reported as a collision before any data is emitted.
-- [ ] H1-rooted (proto.md) schemas produce unchanged output.
-- [ ] `<?include extract: title?>` splices the H1 text.
+- [x] H1-rooted (proto.md) schemas produce unchanged output.
+- [x] `<?include extract: title?>` splices the H1 text.
 - [ ] Reference and guide updated with verified outputs.
 - [ ] All tests pass: `go test ./...`
 - [ ] `go tool golangci-lint run` reports no issues

--- a/plan/243_extract-h1-title.md
+++ b/plan/243_extract-h1-title.md
@@ -1,7 +1,7 @@
 ---
 id: 243
 title: "`mdsmith extract` projects the document H1 as `title`"
-status: "🔳"
+status: "✅"
 summary: >-
   When the composed schema roots at H2, extract emits the
   document H1's rendered plain text under a reserved top-level
@@ -69,7 +69,7 @@ title?>` splices it.
    sources.
 3. [x] Verify `<?include extract: title?>` splices the H1 text
    (the include path walks the same projection).
-4. Update the
+4. [x] Update the
    [extract reference](../docs/reference/cli/extract.md)
    default-projection section and the
    [extract guide](../docs/guides/extract-markdown-as-data.md):
@@ -87,9 +87,9 @@ title?>` splices it.
   reported as a collision before any data is emitted.
 - [x] H1-rooted (proto.md) schemas produce unchanged output.
 - [x] `<?include extract: title?>` splices the H1 text.
-- [ ] Reference and guide updated with verified outputs.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] Reference and guide updated with verified outputs.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues
 
 ## Out of scope
 


### PR DESCRIPTION
Draft PR for [plan/243_extract-h1-title.md](plan/243_extract-h1-title.md).

Status will move 🔲 → 🔳 in PLAN.md once the first real
commit lands. Marking ready for review when the
acceptance criteria are checked off.

https://claude.ai/code/session_01VJ7tRFP87pC1sLuTP8Ft39

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJ7tRFP87pC1sLuTP8Ft39)_