### PR TITLE
docs: round the doc count in the progressive disclosure guide

### DIFF
--- a/docs/guides/progressive-disclosure.md
+++ b/docs/guides/progressive-disclosure.md
@@ -80,7 +80,7 @@ row: "- [{summary}]({filename})"
 <?/catalog?>
 ```
 
-The 113-doc tree compresses to ~3 400 tokens of index.
+The ~110-doc tree compresses to ~3 400 tokens of index.
 The agent reads `CLAUDE.md` once at session start and
 already knows which file to open for any task it gets.
 


### PR DESCRIPTION
## Summary

One-line follow-up to #548. The guide's freshly corrected sentence — "The 113-doc tree compresses to ~3 400 tokens of index." — went stale before it finished merging: main gained a doc while the PR sat in the merge queue, so the published guide claims 113 where the live `CLAUDE.md` index has 114 rows.

The review sweep on #548 warned about exactly this ("rounded so it cannot go stale within the same commit"); this applies that advice. `~110` stays honest as the tree drifts, and the `~3 400 tokens` figure (measured 3,398 today) already reads as an approximation.

## Verification

- `go run ./cmd/mdsmith check .` passes (442 files, 0 failures)

https://claude.ai/code/session_01YPNjbRwLvVEvebdc674a8z

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPNjbRwLvVEvebdc674a8z)_