### PR TITLE
Plan 242: proto.md schemas declare content entries via `<?content?>`

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -160,7 +160,7 @@ footer: |
 | 239        | 🔲     | opus   | [cuelite phase 3 — surface C (row-expr evaluator)](plan/239_cuelite-surface-c.md)                                                       |
 | 240        | 🔲     | sonnet | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
 | 241        | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
-| 242        | 🔳     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
+| 242        | ✅     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243        | ✅     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 244        | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245        | ✅     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |

--- a/PLAN.md
+++ b/PLAN.md
@@ -160,7 +160,7 @@ footer: |
 | 239        | 🔲     | opus   | [cuelite phase 3 — surface C (row-expr evaluator)](plan/239_cuelite-surface-c.md)                                                       |
 | 240        | 🔲     | sonnet | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
 | 241        | 🔲     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
-| 242        | 🔲     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
+| 242        | 🔳     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243        | ✅     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 244        | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245        | ✅     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -519,14 +519,64 @@ H1 fails `mdsmith check`:
 docs/copy/product.md:4:1 MDS020 heading does not match frontmatter: expected "Product copy" (from title), got "Product page copy"
 ```
 
-Weigh two limits before switching to a proto.md.
-Every schema source on a file must declare the same
-root level, so an H1-rooted `proto.md` cannot
-compose with an H2-rooted inline schema on the same
-file. And a `proto.md` declares heading rows only,
-not `content:` entries, so the worked example's
-paragraph projections (`tagline.text`, …) drop out
-of the tree.
+The synced H1 also becomes data. `mdsmith extract`
+projects the H1 scope under a `title` key, with the
+captured heading text inside.
+
+The section paragraphs come back too. A
+`<?content?>` directive row in a `proto.md` section
+body declares the same content entry the inline
+`content:` list declares, so the worked example's
+sections keep their `text` projections instead of
+collapsing to empty objects:
+
+```markdown
+# {title}
+
+## Tagline
+
+<?content
+kind: paragraph
+?>
+
+## Lead
+
+<?content
+kind: paragraph
+?>
+```
+
+`mdsmith extract` then projects the H1 key, the
+synced heading text, and each section's paragraph:
+
+```json
+{
+  "frontmatter": {
+    "title": "Product copy"
+  },
+  "title": {
+    "lead": {
+      "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
+    },
+    "tagline": {
+      "text": "Mark down your ideas; smith them into shipping docs."
+    },
+    "title": "Product copy"
+  }
+}
+```
+
+One limit remains. Every schema source on a file
+must declare the same root level, so an H1-rooted
+`proto.md` cannot compose with an H2-rooted inline
+schema on the same file. The H1 sync and the body
+extraction must both live on the `proto.md`.
+
+mdsmith cannot project the H1 text without a
+frontmatter field behind it: a `{title}` row with
+no `title` field matches any heading, and `extract`
+skips wildcard scopes. Keep the `title` field when
+the kind syncs the H1.
 
 [mds004]: ../../internal/rules/MDS004-first-line-heading/README.md
 

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -168,10 +168,9 @@ is code, which span is a link — set
 paragraph then projects under an `inline` key as a
 typed, recursive span list instead of a flat string.
 
-A website headline whose hero template renders one
-emphasised word is the canonical case. The copy
-itself is the source of truth, and the consumer reads
-the emphasis position from the data:
+The canonical case is a website headline whose hero
+template renders one emphasised word — the consumer
+reads the emphasis position from the data:
 
 ```markdown
 ---
@@ -229,23 +228,11 @@ the trailing text:
 }
 ```
 
-Nesting composes through the same shape. A paragraph
-``run **`mdsmith fix`** daily`` projects the strong span
-with the code span nested in its `children` — the
-consumer walks one uniform tree, with no flat-versus-
-recursive mode switch:
-
-```json
-"inline": [
-  { "span": "text", "value": "run " },
-  {
-    "children": [{ "span": "code", "value": "mdsmith fix" }],
-    "level": 2,
-    "span": "strong"
-  },
-  { "span": "text", "value": " daily" }
-]
-```
+Nesting composes through the same shape: a paragraph
+``run **`mdsmith fix`** daily`` projects the strong
+span with the code span nested in its `children` —
+the consumer walks one uniform tree, with no
+flat-versus-recursive mode switch.
 
 Leaf spans (text, code, autolink) carry a `value`;
 container spans (emphasis, strong, link) carry
@@ -271,9 +258,8 @@ the list entry. Each item then projects as an object with
 its own `text`, a `checked` bool on task items, and a
 recursive `children` array on items that nest a sub-list.
 
-A sprint checklist is the canonical case. A status tool
-reads each task's `checked` state and walks `children`
-for sub-tasks:
+The canonical case is a sprint checklist whose
+status tool reads `checked` and walks `children`:
 
 ```markdown
 ---
@@ -402,24 +388,10 @@ emits:
 }
 ```
 
-The `columns` array preserves document order; the `rows`
-array omits object keys entirely, so duplicate column
-headers pose no problem and a chart script reads
-`latency.rows[0][1]` by index.
+A chart script reads `latency.rows[0][1]` by index.
 
-For the default `records` projection the same table
-produces `latency.rows` as an array of objects keyed by
-column header:
-
-```json
-"latency": {
-  "rows": [
-    { "Operation": "check", "p50 ms": "12", "p99 ms": "45" },
-    { "Operation": "fix",   "p50 ms": "18", "p99 ms": "70" }
-  ]
-}
-```
-
+The default `records` projection emits the same
+table as an array of objects keyed by column header.
 The full projection matrix and duplicate-header
 semantics are in the
 [extract reference][extract-table].
@@ -470,62 +442,24 @@ When the schema roots at H2 (all inline schemas do),
 under a reserved `title` key beside `frontmatter` —
 the `"title": "Product copy"` line in the
 [worked example](#worked-example) output above.
-When there is no H1, the `title` key is omitted.
-When a scope bound to `title` (via slug or `bind:`)
-collides with the reserved key, `extract` reports
-it as a collision before emitting any data; rename
-the scope with `bind:` to resolve it.
+When there is no H1 the key is omitted, and a scope
+that resolves to `title` (via slug or `bind:`) is
+reported as a collision before any data is emitted;
+rename the scope with `bind:` to resolve it.
 
-`<?include extract: title?>` splices the H1 plain
-text directly into a host file with no intermediate
-file needed:
-
-```markdown
-<?include
-file: docs/copy/product.md
-extract: title
-?>
-Product copy
-<?/include?>
-```
+An `<?include?>` with `extract: title` splices the
+H1 plain text directly into a host file, exactly
+like the `tagline.text` embed shown in
+[Reading a value back](#reading-a-value-back-into-markdown).
 
 ### Enforcing H1 ↔ frontmatter consistency
 
 Enforcement requires a file-based schema. An inline
 `schema:` starts matching at H2 — the H1 belongs to
 [first-line-heading][mds004] — so the kind switches
-to a `proto.md` whose first row is the `{title}`
-placeholder:
-
-```markdown
-# {title}
-
-## ...
-```
-
-```yaml
-kinds:
-  product-copy:
-    rules:
-      required-structure:
-        schema: copy-proto.md
-```
-
-The `{title}` row requires the frontmatter field
-and checks the H1 text against its value. A drifted
-H1 fails `mdsmith check`:
-
-```text
-docs/copy/product.md:4:1 MDS020 heading does not match frontmatter: expected "Product copy" (from title), got "Product page copy"
-```
-
-The synced H1 also becomes data. `mdsmith extract`
-projects the H1 scope under a `title` key, with the
-captured heading text inside.
-
-The section paragraphs come back too. A
-`<?content?>` directive row in a `proto.md` section
-body declares the same content entry the inline
+to a `proto.md` rooted at the `{title}` placeholder.
+A `<?content?>` directive row in a section body
+declares the same content entry the inline
 `content:` list declares, so the worked example's
 sections keep their `text` projections instead of
 collapsing to empty objects:
@@ -546,8 +480,26 @@ kind: paragraph
 ?>
 ```
 
-`mdsmith extract` then projects the H1 key, the
-synced heading text, and each section's paragraph:
+```yaml
+kinds:
+  product-copy:
+    rules:
+      required-structure:
+        schema: copy-proto.md
+```
+
+The `{title}` row requires the frontmatter field
+and checks the H1 text against its value. A drifted
+H1 fails `mdsmith check`:
+
+```text
+docs/copy/product.md:4:1 MDS020 heading does not match frontmatter: expected "Product copy" (from title), got "Product page copy"
+```
+
+The synced H1 also becomes data. `mdsmith extract`
+projects the H1 scope under a `title` key — the
+captured heading text inside — and each section's
+paragraph beneath it:
 
 ```json
 {

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -411,9 +411,8 @@ Front-matter keys map directly to CUE expressions.
 
 MDS020's file-schema check routes through its
 legacy parser: `{field}` in a proto.md heading row
-matches a non-empty run rather than resolving the
-document's frontmatter value via `fmvar(...)`.
-Heading rows are wildcards, not substitutions.
+is a wildcard matching a non-empty run, not a
+`fmvar(...)` substitution of the frontmatter value.
 
 `{field}` in a proto.md **body** is fully wired:
 MDS020 resolves the placeholder against the
@@ -422,13 +421,13 @@ document's front matter and flags any mismatch.
 current front-matter value for files that match a
 **single file-based schema source**. Composed or
 multi-source schemas do not get Fix body rewrites.
-The rule-readme `Meta-Information` body uses this
-to keep `ID`, `Name`, `Status`, and `Category`
-bullets in sync with front matter.
 
-The
-[section-schema reference](../reference/section-schema.md#protomd-file-syntax)
-records the heading-row wildcard mapping.
+A `<?content?>` directive row in a section body
+declares one content entry, so a proto-based kind
+validates and extracts body content like the
+equivalent inline `content:` list. The
+[section-schema reference](../reference/section-schema.md#the-content-directive)
+documents the directive.
 
 ## Choosing a source
 
@@ -438,6 +437,7 @@ records the heading-row wildcard mapping.
 | Schema reused via `<?include?>`        | no     | yes                |
 | Frontmatter-body `{field}` sync        | no     | yes                |
 | Nested section tree                    | yes    | via heading levels |
+| Section content entries                | yes    | via `<?content?>`  |
 | Per-scope rule overrides               | yes    | no                 |
 | Stays next to other kind rule settings | yes    | indirect           |
 

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -160,16 +160,8 @@ field `name`, regex-escapes its value, and
 returns it. Use it whenever the heading text
 must equal a frontmatter value. The escape is
 needed because field values can contain RE2
-metacharacters.
-
-```yaml
-- heading:
-    regex: 'Step \#(digits)'
-    repeat: { min: 1 }
-    sequential: true
-- heading:
-    regex: '\#(fmvar(id)): \#(fmvar(name))'
-```
+metacharacters. The "At a glance" block above
+shows both helpers in a pattern.
 
 `sequential: true` is a sibling field on the
 entry. Only meaningful with `digits` in the
@@ -256,22 +248,14 @@ schema:
 
 ## `proto.md` file syntax
 
-> **Heading rows vs body lines.** In heading
-> rows, `{field}` is a wildcard — not resolved
-> against front matter. The table below shows
-> the equivalent inline entry for each row.
->
-> In **body lines**, `{field}` is fully wired:
-> MDS020 checks each placeholder against front
-> matter and `mdsmith fix` rewrites stale lines
-> for a **single file-based schema source**.
-> Composed schemas skip the Fix body rewrite.
-
-Proto.md files use a literal-template surface
-distinct from the inline `regex:` form. Heading
-rows in the body act as the schema's
-`sections:` list. `{n}` and `{field}` survive
-here as template placeholders.
+Heading rows act as the schema's `sections:` list,
+mapping to the inline entries below. In a heading
+row, `{field}` is a wildcard, not a front-matter
+lookup. In a **body line**, `{field}` is fully
+wired: MDS020 checks it against front matter, and
+`mdsmith fix` rewrites stale lines for a single
+file-based schema source (composed schemas skip the
+Fix rewrite).
 
 | Row syntax        | Equivalent inline entry                        |
 | ----------------- | ---------------------------------------------- |
@@ -281,13 +265,32 @@ here as template placeholders.
 | `## Step {n}`     | `heading: { regex: 'Step \#(digits)' }`        |
 | `## {id}`         | `heading: { regex: '\#(fmvar(id))' }`          |
 
-Proto.md cannot express `repeat: { min, max }`
-or `sequential:`. Callers needing those switch
-to the inline-YAML form on a kind in
-`.mdsmith.yml`.
+Proto.md cannot express `repeat:` or `sequential:`;
+switch to the inline form for those. The `<?require
+filename: "..."?>` directive is unchanged.
 
-The `<?require filename: "..."?>` directive in
-proto.md bodies is unchanged.
+### The `<?content?>` directive
+
+A `<?content?>` row in a section body declares one
+content entry. It is the proto.md form of one
+inline `content:` list entry. The body takes the
+same keys: `kind`, `projection`, `required`,
+`bind`, and the kind-specific fields.
+
+```markdown
+## Tagline
+
+<?content
+kind: paragraph
+?>
+```
+
+Two rows declare two ordered entries, keyed by the
+inline positional rule (`text` / `text-2`, …). Each
+row parses through the inline content parser, so a
+bad key, kind, or kind/projection pair fails at
+load. MDS020's legacy check skips these rows;
+validation and extraction use the schema parser.
 
 ## Migration from the old shape
 

--- a/internal/extract/proto_content_diff_test.go
+++ b/internal/extract/proto_content_diff_test.go
@@ -1,0 +1,82 @@
+package extract
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtract_ProtoContentMatchesInline is plan 242's differential
+// acceptance test: one schema expressed both ways — a proto.md file
+// with `<?content?>` rows and the equivalent inline `content:` list —
+// projects byte-identical section content from the same document body,
+// modulo the proto form's H1 root wrapper.
+//
+// The proto schema roots at H1 (`# {title}`), so its section objects
+// nest one level under the H1's projection key; the inline schema
+// roots at H2 (it cannot express the `# {title}` heading-sync), so its
+// section objects sit at the root. Comparing the proto's unwrapped
+// section subtree against the inline root removes that level
+// difference; the remaining content must match exactly.
+func TestExtract_ProtoContentMatchesInline(t *testing.T) {
+	body := "# My Title\n\n## Tagline\n\nThe tagline text.\n\n" +
+		"## Snippet\n\n```go\nx := 1\n```\n"
+
+	// Proto form: `<?content?>` rows under H1-rooted headings.
+	dir := t.TempDir()
+	protoPath := filepath.Join(dir, "schema.md")
+	require.NoError(t, os.WriteFile(protoPath, []byte(
+		"# {title}\n\n"+
+			"## Tagline\n\n<?content\nkind: paragraph\n?>\n\n"+
+			"## Snippet\n\n<?content\nkind: code-block\nlang: go\n?>\n"), 0o644))
+	protoSch, err := schema.ParseFile(&schema.FileReader{}, protoPath)
+	require.NoError(t, err)
+	gotProto, diags := run(t, body, protoSch, map[string]any{"title": "My Title"})
+	require.Empty(t, diags)
+	protoRoot := gotProto.(map[string]any)
+
+	// Inline form: the same two sections with `content:` lists,
+	// rooted at H2.
+	inlineSch, err := schema.ParseInline(map[string]any{
+		"sections": []any{
+			map[string]any{
+				"heading": "Tagline",
+				"content": []any{map[string]any{"kind": "paragraph"}},
+			},
+			map[string]any{
+				"heading": "Snippet",
+				"content": []any{map[string]any{"kind": "code-block", "lang": "go"}},
+			},
+		},
+	}, "kind k")
+	require.NoError(t, err)
+	inlineBody := "## Tagline\n\nThe tagline text.\n\n## Snippet\n\n```go\nx := 1\n```\n"
+	gotInline, diags := run(t, inlineBody, inlineSch, nil)
+	require.Empty(t, diags)
+	inlineRoot := gotInline.(map[string]any)
+
+	// Unwrap the proto H1 scope (key derived from the `{title}` fmvar)
+	// and drop its own heading-sync key so only the projected sections
+	// remain — the same shape the inline root carries beside its
+	// frontmatter object.
+	h1 := protoRoot["title"].(map[string]any)
+	delete(h1, "title") // the H1's `# {title}` heading-sync value
+
+	for _, key := range []string{"tagline", "snippet"} {
+		assert.Equal(t, jsonBytes(t, inlineRoot[key]), jsonBytes(t, h1[key]),
+			"section %q must project identically from proto and inline schemas", key)
+	}
+}
+
+// jsonBytes marshals v to canonical JSON for byte-level comparison.
+func jsonBytes(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/internal/extract/proto_content_diff_test.go
+++ b/internal/extract/proto_content_diff_test.go
@@ -1,7 +1,6 @@
 package extract
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,15 +71,7 @@ func TestExtract_ProtoContentMatchesInline(t *testing.T) {
 	for _, key := range []string{"tagline", "snippet"} {
 		require.Contains(t, h1, key,
 			"proto projection must carry section %q", key)
-		assert.Equal(t, jsonBytes(t, inlineRoot[key]), jsonBytes(t, h1[key]),
+		assert.Equal(t, inlineRoot[key], h1[key],
 			"section %q must project identically from proto and inline schemas", key)
 	}
-}
-
-// jsonBytes marshals v to canonical JSON for byte-level comparison.
-func jsonBytes(t *testing.T, v any) string {
-	t.Helper()
-	b, err := json.Marshal(v)
-	require.NoError(t, err)
-	return string(b)
 }

--- a/internal/extract/proto_content_diff_test.go
+++ b/internal/extract/proto_content_diff_test.go
@@ -64,10 +64,14 @@ func TestExtract_ProtoContentMatchesInline(t *testing.T) {
 	// and drop its own heading-sync key so only the projected sections
 	// remain — the same shape the inline root carries beside its
 	// frontmatter object.
-	h1 := protoRoot["title"].(map[string]any)
+	h1, ok := protoRoot["title"].(map[string]any)
+	require.True(t, ok, "proto root must project the H1 scope under `title`, got %T",
+		protoRoot["title"])
 	delete(h1, "title") // the H1's `# {title}` heading-sync value
 
 	for _, key := range []string{"tagline", "snippet"} {
+		require.Contains(t, h1, key,
+			"proto projection must carry section %q", key)
 		assert.Equal(t, jsonBytes(t, inlineRoot[key]), jsonBytes(t, h1[key]),
 			"section %q must project identically from proto and inline schemas", key)
 	}

--- a/internal/rules/requiredstructure/content_directive_test.go
+++ b/internal/rules/requiredstructure/content_directive_test.go
@@ -7,6 +7,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// assertNoInBodySyncPoints fails when any collected sync point is an
+// in-body one — the shared assertion of the PI-opacity tests.
+func assertNoInBodySyncPoints(t *testing.T, tmpl *parsedSchema) {
+	t.Helper()
+	for idx, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			assert.False(t, sp.InBody,
+				"heading %d: a directive body must not yield a body sync point (got field %q)",
+				idx, sp.Field)
+		}
+	}
+}
+
+// assertHasInBodySyncPoint fails unless some in-body sync point was
+// collected for field — the positive control of the PI-opacity tests.
+func assertHasInBodySyncPoint(t *testing.T, tmpl *parsedSchema, field, msg string) {
+	t.Helper()
+	for _, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			if sp.InBody && sp.Field == field {
+				return
+			}
+		}
+	}
+	assert.Fail(t, msg)
+}
+
 // TestParseSchema_ContentDirectiveNoBodySync locks down plan 242: the
 // legacy MDS020 proto parser must treat a `<?content?>` directive row
 // as opaque. A `{field}`-looking token inside the directive body
@@ -16,13 +43,7 @@ func TestParseSchema_ContentDirectiveNoBodySync(t *testing.T) {
 	schemaSrc := "# {id}\n\n## Tagline\n\n<?content\nkind: paragraph\nbind: tag-{id}\n?>\n"
 	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err)
-	for idx, sps := range tmpl.SyncPoints {
-		for _, sp := range sps {
-			assert.False(t, sp.InBody,
-				"heading %d: <?content?> body must not yield a body sync point (got field %q)",
-				idx, sp.Field)
-		}
-	}
+	assertNoInBodySyncPoints(t, tmpl)
 }
 
 // TestParseSchema_ContentDirectiveSingleLineNoBodySync covers the
@@ -32,13 +53,7 @@ func TestParseSchema_ContentDirectiveSingleLineNoBodySync(t *testing.T) {
 	schemaSrc := "# {id}\n\n## Tagline\n\n<?content kind: paragraph bind: tag-{id} ?>\n"
 	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err)
-	for idx, sps := range tmpl.SyncPoints {
-		for _, sp := range sps {
-			assert.False(t, sp.InBody,
-				"heading %d: single-line <?content?> must not yield a body sync point (got field %q)",
-				idx, sp.Field)
-		}
-	}
+	assertNoInBodySyncPoints(t, tmpl)
 }
 
 // TestParseSchema_ContentDirectiveNotAHeading verifies the legacy
@@ -83,13 +98,7 @@ func TestParseSchema_PIBlockClosesOnExactLineOnly(t *testing.T) {
 	schemaSrc := "# {id}\n\n## Tagline\n\n<?content\nkind: paragraph\nbind: \"a?>b\"\nalso: tag-{id}\n?>\n"
 	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err)
-	for idx, sps := range tmpl.SyncPoints {
-		for _, sp := range sps {
-			assert.False(t, sp.InBody,
-				"heading %d: a `?>` substring must not end the block early (got field %q)",
-				idx, sp.Field)
-		}
-	}
+	assertNoInBodySyncPoints(t, tmpl)
 }
 
 // TestParseSchema_AnyPIBlockSkipped verifies the skip is not
@@ -99,13 +108,20 @@ func TestParseSchema_AnyPIBlockSkipped(t *testing.T) {
 	schemaSrc := "# {id}\n\n## Tagline\n\n<?require\nfilename: \"{id}.md\"\n?>\n"
 	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err)
-	for idx, sps := range tmpl.SyncPoints {
-		for _, sp := range sps {
-			assert.False(t, sp.InBody,
-				"heading %d: <?require?> body must not yield a body sync point (got field %q)",
-				idx, sp.Field)
-		}
-	}
+	assertNoInBodySyncPoints(t, tmpl)
+}
+
+// TestParseSchema_FencedDirectiveExampleDoesNotOpenPIBlock locks
+// down fence precedence: the block parser never opens a PI inside a
+// fenced code block, so a directive opener shown in a fence must not
+// flip the scanner into PI-skip state — a `{field}` body line after
+// the fence is still collected.
+func TestParseSchema_FencedDirectiveExampleDoesNotOpenPIBlock(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n```markdown\n<?content\nkind: paragraph\n```\n\ntag-{id} body line\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	assertHasInBodySyncPoint(t, tmpl, "id",
+		"the {id} line after the fence is body text; the fenced directive example must not suppress it")
 }
 
 // TestParseSchema_IndentedDirectiveExampleStaysBodyText is the
@@ -116,15 +132,7 @@ func TestParseSchema_IndentedDirectiveExampleStaysBodyText(t *testing.T) {
 	schemaSrc := "# {id}\n\n## Tagline\n\n    <?content {id} ?>\n"
 	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
 	require.NoError(t, err)
-	found := false
-	for _, sps := range tmpl.SyncPoints {
-		for _, sp := range sps {
-			if sp.InBody && sp.Field == "id" {
-				found = true
-			}
-		}
-	}
-	assert.True(t, found,
+	assertHasInBodySyncPoint(t, tmpl, "id",
 		"an indented directive example is body text; its {id} must be collected")
 }
 

--- a/internal/rules/requiredstructure/content_directive_test.go
+++ b/internal/rules/requiredstructure/content_directive_test.go
@@ -31,7 +31,9 @@ func assertHasInBodySyncPoint(t *testing.T, tmpl *parsedSchema, field, msg strin
 			}
 		}
 	}
-	assert.Fail(t, msg)
+	assert.Failf(t, msg,
+		"no in-body sync point for field %q; collected sync points: %v",
+		field, tmpl.SyncPoints)
 }
 
 // TestParseSchema_ContentDirectiveNoBodySync locks down plan 242: the
@@ -124,6 +126,50 @@ func TestParseSchema_FencedDirectiveExampleDoesNotOpenPIBlock(t *testing.T) {
 		"the {id} line after the fence is body text; the fenced directive example must not suppress it")
 }
 
+// TestParseSchema_FenceCloseRequiresMatchingChar locks down the
+// CommonMark close rule the block parser applies: a tilde line inside
+// a backtick fence does not close it, so a directive line that is
+// still fence content stays body text and its `{field}` is collected.
+func TestParseSchema_FenceCloseRequiresMatchingChar(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n```go\n~~~\n<?content bind: tag-{inner} ?>\n```\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	assertHasInBodySyncPoint(t, tmpl, "inner",
+		"a ~~~ line must not close a backtick fence; the directive line is fence content")
+}
+
+// TestParseSchema_FenceCloseRequiresOpenerLength locks down the
+// length half of the close rule: a three-backtick line does not close
+// a four-backtick fence.
+func TestParseSchema_FenceCloseRequiresOpenerLength(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n````\n```\n<?content bind: tag-{inner} ?>\n````\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	assertHasInBodySyncPoint(t, tmpl, "inner",
+		"an inner ``` must not close a ```` fence; the directive line is fence content")
+}
+
+// TestParseSchema_FenceCloseRejectsTrailingContent locks down that a
+// marker line followed by other text is not a closer.
+func TestParseSchema_FenceCloseRejectsTrailingContent(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n```\n``` not-a-closer\n<?content bind: tag-{inner} ?>\n```\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	assertHasInBodySyncPoint(t, tmpl, "inner",
+		"a ``` with trailing text must not close the fence; the directive line is fence content")
+}
+
+// TestParseSchema_IndentedFenceMarkerDoesNotOpenFence locks down the
+// indent half of the open rule: a 4-space-indented marker is indented
+// code to the parser, so it must not flip the scanner into fence
+// state — the directive that follows is a real PI and stays opaque.
+func TestParseSchema_IndentedFenceMarkerDoesNotOpenFence(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n    ```\n\n<?content bind: tag-{inner} ?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	assertNoInBodySyncPoints(t, tmpl)
+}
+
 // TestParseSchema_IndentedDirectiveExampleStaysBodyText is the
 // positive control for the indent guard: a 4-space-indented line
 // showing a directive is a code line to the parser, so its `{field}`
@@ -134,6 +180,40 @@ func TestParseSchema_IndentedDirectiveExampleStaysBodyText(t *testing.T) {
 	require.NoError(t, err)
 	assertHasInBodySyncPoint(t, tmpl, "id",
 		"an indented directive example is body text; its {id} must be collected")
+}
+
+// TestFenceOpenRun pins the open rule the scanner mirrors: a run of
+// at least three identical markers with at most three spaces of
+// indentation.
+func TestFenceOpenRun(t *testing.T) {
+	c, n := fenceOpenRun([]byte("```go"), []byte("```go"))
+	assert.Equal(t, byte('`'), c)
+	assert.Equal(t, 3, n)
+	c, n = fenceOpenRun([]byte("~~~~"), []byte("~~~~"))
+	assert.Equal(t, byte('~'), c)
+	assert.Equal(t, 4, n)
+	_, n = fenceOpenRun([]byte("``x``"), []byte("``x``"))
+	assert.Zero(t, n, "a two-marker run is not a fence")
+	_, n = fenceOpenRun([]byte("    ```"), []byte("```"))
+	assert.Zero(t, n, "4-space indent is indented code")
+	_, n = fenceOpenRun([]byte("text"), []byte("text"))
+	assert.Zero(t, n)
+}
+
+// TestFenceClose pins the close rule: same character, a run at least
+// as long as the opener, nothing else on the line, indent at most 3.
+func TestFenceClose(t *testing.T) {
+	assert.True(t, fenceClose([]byte("```"), []byte("```"), '`', 3))
+	assert.True(t, fenceClose([]byte("`````"), []byte("`````"), '`', 3),
+		"a longer close run is valid")
+	assert.False(t, fenceClose([]byte("```"), []byte("```"), '`', 4),
+		"shorter than the opener")
+	assert.False(t, fenceClose([]byte("~~~"), []byte("~~~"), '`', 3),
+		"wrong marker character")
+	assert.False(t, fenceClose([]byte("``` x"), []byte("``` x"), '`', 3),
+		"trailing content")
+	assert.False(t, fenceClose([]byte("    ```"), []byte("```"), '`', 3),
+		"4-space indent")
 }
 
 // TestHeadingIndexForLine covers both outcomes: the index of the

--- a/internal/rules/requiredstructure/content_directive_test.go
+++ b/internal/rules/requiredstructure/content_directive_test.go
@@ -53,3 +53,25 @@ func TestParseSchema_ContentDirectiveNotAHeading(t *testing.T) {
 		"only the H2 is a heading; the <?content?> row is a directive")
 	assert.Equal(t, "Tagline", tmpl.Headings[0].Text)
 }
+
+// TestIsContentDirectiveOpen pins the directive-name boundary: only
+// `<?content` followed by a non-identifier byte (or nothing) opens a
+// block, so a differently named directive like `<?content-foo?>` is
+// not mistaken for one.
+func TestIsContentDirectiveOpen(t *testing.T) {
+	assert.True(t, isContentDirectiveOpen([]byte("<?content kind: paragraph ?>")))
+	assert.True(t, isContentDirectiveOpen([]byte("<?content?>")))
+	assert.True(t, isContentDirectiveOpen([]byte("<?content")))
+	assert.False(t, isContentDirectiveOpen([]byte("<?content-foo?>")))
+	assert.False(t, isContentDirectiveOpen([]byte("<?contents kind: x ?>")))
+	assert.False(t, isContentDirectiveOpen([]byte("plain body line")))
+}
+
+// TestHeadingIndexForLine covers both outcomes: the index of the
+// first schema heading matching a body heading line, and -1 when no
+// schema heading matches.
+func TestHeadingIndexForLine(t *testing.T) {
+	heads := []docHeading{{Text: "Tagline"}, {Text: "Lead"}}
+	assert.Equal(t, 1, headingIndexForLine(heads, "## Lead"))
+	assert.Equal(t, -1, headingIndexForLine(heads, "## Other"))
+}

--- a/internal/rules/requiredstructure/content_directive_test.go
+++ b/internal/rules/requiredstructure/content_directive_test.go
@@ -1,0 +1,55 @@
+package requiredstructure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseSchema_ContentDirectiveNoBodySync locks down plan 242: the
+// legacy MDS020 proto parser must treat a `<?content?>` directive row
+// as opaque. A `{field}`-looking token inside the directive body
+// (here `bind: tag-{id}`) must NOT become a body-sync point — the row
+// is a schema directive, not body-sync template text.
+func TestParseSchema_ContentDirectiveNoBodySync(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n<?content\nkind: paragraph\nbind: tag-{id}\n?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	for idx, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			assert.False(t, sp.InBody,
+				"heading %d: <?content?> body must not yield a body sync point (got field %q)",
+				idx, sp.Field)
+		}
+	}
+}
+
+// TestParseSchema_ContentDirectiveSingleLineNoBodySync covers the
+// single-line directive form `<?content ... ?>`: a `{field}` token on
+// that one line must also stay opaque to the body-sync collector.
+func TestParseSchema_ContentDirectiveSingleLineNoBodySync(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n<?content kind: paragraph bind: tag-{id} ?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	for idx, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			assert.False(t, sp.InBody,
+				"heading %d: single-line <?content?> must not yield a body sync point (got field %q)",
+				idx, sp.Field)
+		}
+	}
+}
+
+// TestParseSchema_ContentDirectiveNotAHeading verifies the legacy
+// parser never treats a `<?content?>` row as a required heading: the
+// schema below declares exactly one heading (the H2), so the directive
+// row must not inflate the heading count.
+func TestParseSchema_ContentDirectiveNotAHeading(t *testing.T) {
+	schemaSrc := "## Tagline\n\n<?content\nkind: paragraph\n?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	require.Len(t, tmpl.Headings, 1,
+		"only the H2 is a heading; the <?content?> row is a directive")
+	assert.Equal(t, "Tagline", tmpl.Headings[0].Text)
+}

--- a/internal/rules/requiredstructure/content_directive_test.go
+++ b/internal/rules/requiredstructure/content_directive_test.go
@@ -54,17 +54,78 @@ func TestParseSchema_ContentDirectiveNotAHeading(t *testing.T) {
 	assert.Equal(t, "Tagline", tmpl.Headings[0].Text)
 }
 
-// TestIsContentDirectiveOpen pins the directive-name boundary: only
-// `<?content` followed by a non-identifier byte (or nothing) opens a
-// block, so a differently named directive like `<?content-foo?>` is
-// not mistaken for one.
-func TestIsContentDirectiveOpen(t *testing.T) {
-	assert.True(t, isContentDirectiveOpen([]byte("<?content kind: paragraph ?>")))
-	assert.True(t, isContentDirectiveOpen([]byte("<?content?>")))
-	assert.True(t, isContentDirectiveOpen([]byte("<?content")))
-	assert.False(t, isContentDirectiveOpen([]byte("<?content-foo?>")))
-	assert.False(t, isContentDirectiveOpen([]byte("<?contents kind: x ?>")))
-	assert.False(t, isContentDirectiveOpen([]byte("plain body line")))
+// TestIsPIOpenLine mirrors the block parser's opener rules: at most
+// three spaces of indentation, a `<?` prefix, and a non-empty name.
+// Any directive name opens a block (directive bodies are schema
+// syntax, never body-sync template text); an indented code example
+// or a nameless `<?` does not.
+func TestIsPIOpenLine(t *testing.T) {
+	assert.True(t, isPIOpenLine([]byte("<?content kind: paragraph ?>")))
+	assert.True(t, isPIOpenLine([]byte("<?content?>")))
+	assert.True(t, isPIOpenLine([]byte("<?content")))
+	assert.True(t, isPIOpenLine([]byte("<?content-foo?>")))
+	assert.True(t, isPIOpenLine([]byte("<?require filename: \"x.md\" ?>")))
+	assert.True(t, isPIOpenLine([]byte("   <?include")))
+	assert.False(t, isPIOpenLine([]byte("    <?content?>")),
+		"4-space indent is a code line to the parser")
+	assert.False(t, isPIOpenLine([]byte("<? content?>")),
+		"whitespace after <? means no name")
+	assert.False(t, isPIOpenLine([]byte("<??>")), "empty name")
+	assert.False(t, isPIOpenLine([]byte("<?")), "bare opener, no name")
+	assert.False(t, isPIOpenLine([]byte("plain body line")))
+}
+
+// TestParseSchema_PIBlockClosesOnExactLineOnly locks down the close
+// rule shared with the block parser: a `?>` substring inside a YAML
+// value does not end the block, so a `{field}` token on a later
+// directive line still yields no body-sync point.
+func TestParseSchema_PIBlockClosesOnExactLineOnly(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n<?content\nkind: paragraph\nbind: \"a?>b\"\nalso: tag-{id}\n?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	for idx, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			assert.False(t, sp.InBody,
+				"heading %d: a `?>` substring must not end the block early (got field %q)",
+				idx, sp.Field)
+		}
+	}
+}
+
+// TestParseSchema_AnyPIBlockSkipped verifies the skip is not
+// content-specific: a `{field}` token inside any directive body
+// (here `<?require?>`) stays opaque to the body-sync collector.
+func TestParseSchema_AnyPIBlockSkipped(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n<?require\nfilename: \"{id}.md\"\n?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	for idx, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			assert.False(t, sp.InBody,
+				"heading %d: <?require?> body must not yield a body sync point (got field %q)",
+				idx, sp.Field)
+		}
+	}
+}
+
+// TestParseSchema_IndentedDirectiveExampleStaysBodyText is the
+// positive control for the indent guard: a 4-space-indented line
+// showing a directive is a code line to the parser, so its `{field}`
+// token IS collected as a body-sync point.
+func TestParseSchema_IndentedDirectiveExampleStaysBodyText(t *testing.T) {
+	schemaSrc := "# {id}\n\n## Tagline\n\n    <?content {id} ?>\n"
+	tmpl, err := parseSchema([]byte(schemaSrc), "", 0)
+	require.NoError(t, err)
+	found := false
+	for _, sps := range tmpl.SyncPoints {
+		for _, sp := range sps {
+			if sp.InBody && sp.Field == "id" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found,
+		"an indented directive example is body text; its {id} must be collected")
 }
 
 // TestHeadingIndexForLine covers both outcomes: the index of the

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1337,6 +1337,7 @@ func collectBodySyncPoints(
 	// body (e.g. a `bind:` value) must not become a body-sync point,
 	// since the row is schema syntax, not body-sync template text.
 	inPIBlock := false
+	inFence := false
 	start := 0
 	for i := 0; i <= len(content); i++ {
 		if i < len(content) && content[i] != '\n' {
@@ -1355,7 +1356,15 @@ func collectBodySyncPoints(
 			inPIBlock = !bytes.Equal(lineB, piClose)
 			continue
 		}
-		if isPIOpenLine(raw) {
+		if bytes.HasPrefix(lineB, fenceBacktick) || bytes.HasPrefix(lineB, fenceTilde) {
+			// A fenced code block owns its lines before the PI parser
+			// runs, so a directive opener shown inside a fence is
+			// code, not a directive. The marker line itself falls
+			// through as ordinary body text, as it did before the
+			// PI skip existed.
+			inFence = !inFence
+		}
+		if !inFence && isPIOpenLine(raw) {
 			// A single-line `<?name ... ?>` opens and closes on the
 			// same line; only a multi-line opener leaves us inside the
 			// block for subsequent lines. The parser closes an opener
@@ -1410,6 +1419,9 @@ func appendBodySyncFields(
 var (
 	piOpenPrefix = []byte("<?")
 	piClose      = []byte("?>")
+
+	fenceBacktick = []byte("```")
+	fenceTilde    = []byte("~~~")
 )
 
 // isPIOpenLine reports whether a raw body line opens a processing
@@ -1433,7 +1445,7 @@ func isPIOpenLine(raw []byte) bool {
 	if rest[0] == ' ' || rest[0] == '\t' {
 		return false
 	}
-	if rest[0] == '?' && len(rest) > 1 && rest[1] == '>' {
+	if bytes.HasPrefix(rest, piClose) {
 		return false
 	}
 	return true

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1330,6 +1330,13 @@ func collectBodySyncPoints(
 	syncPoints map[int][]syncPoint,
 ) {
 	currentHeading := -1
+	// inContentDirective is true while scanning the lines of a
+	// multi-line `<?content?>` directive block. Plan 242 makes such a
+	// row opaque to the legacy body-sync collector: a `{field}` token
+	// inside the directive body (e.g. a `bind:` value) must not become
+	// a body-sync point, since the row is a schema directive parsed by
+	// schema.ParseFile, not body-sync template text.
+	inContentDirective := false
 	start := 0
 	for i := 0; i <= len(content); i++ {
 		if i < len(content) && content[i] != '\n' {
@@ -1340,30 +1347,85 @@ func collectBodySyncPoints(
 		if len(lineB) == 0 {
 			continue
 		}
+		if inContentDirective {
+			inContentDirective = !bytes.Contains(lineB, piClose)
+			continue
+		}
+		if isContentDirectiveOpen(lineB) {
+			// A single-line `<?content ... ?>` opens and closes on the
+			// same line; only a multi-line opener leaves us inside the
+			// block for subsequent lines.
+			inContentDirective = !bytes.Contains(lineB[len(contentDirectiveOpen):], piClose)
+			continue
+		}
 		if lineB[0] == '#' {
-			trimmed := string(lineB)
-			for j, h := range headings {
-				if headingMatchesLine(h, trimmed) {
-					currentHeading = j
-					break
-				}
+			if idx := headingIndexForLine(headings, string(lineB)); idx >= 0 {
+				currentHeading = idx
 			}
 			continue
 		}
 		if currentHeading >= 0 {
-			trimmed := string(lineB)
-			fields := fieldinterp.Fields(trimmed)
-			if len(fields) > 0 {
-				compiled := buildFieldPattern(trimmed)
-				for _, f := range fields {
-					syncPoints[currentHeading] = append(
-						syncPoints[currentHeading],
-						syncPoint{Field: f, InBody: true, BodyText: trimmed, compiled: compiled},
-					)
-				}
-			}
+			appendBodySyncFields(syncPoints, currentHeading, string(lineB))
 		}
 	}
+}
+
+// headingIndexForLine returns the index of the first schema heading
+// that matches the body line, or -1 when none does.
+func headingIndexForLine(headings []docHeading, line string) int {
+	for j, h := range headings {
+		if headingMatchesLine(h, line) {
+			return j
+		}
+	}
+	return -1
+}
+
+// appendBodySyncFields records a body-sync point under heading idx for
+// each `{field}` token found in the body line. Lines with no token add
+// nothing.
+func appendBodySyncFields(
+	syncPoints map[int][]syncPoint, idx int, trimmed string,
+) {
+	fields := fieldinterp.Fields(trimmed)
+	if len(fields) == 0 {
+		return
+	}
+	compiled := buildFieldPattern(trimmed)
+	for _, f := range fields {
+		syncPoints[idx] = append(syncPoints[idx],
+			syncPoint{Field: f, InBody: true, BodyText: trimmed, compiled: compiled})
+	}
+}
+
+// contentDirectiveOpen / piClose are the literal markers
+// collectBodySyncPoints scans for to skip a `<?content?>` directive
+// block. They are package-level so the byte slices are allocated
+// once rather than per call.
+var (
+	contentDirectiveOpen = []byte("<?content")
+	piClose              = []byte("?>")
+)
+
+// isContentDirectiveOpen reports whether a trimmed body line opens a
+// `<?content?>` directive. It matches the `<?content` prefix only
+// when the next byte is not an identifier character, so a directive
+// like `<?content-foo?>` (a different name) is not mistaken for one.
+func isContentDirectiveOpen(line []byte) bool {
+	if !bytes.HasPrefix(line, contentDirectiveOpen) {
+		return false
+	}
+	rest := line[len(contentDirectiveOpen):]
+	if len(rest) == 0 {
+		return true
+	}
+	c := rest[0]
+	if c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') {
+		return false
+	}
+	return true
 }
 
 // maxSchemaIncludeDepth is the maximum nesting depth for schema includes.

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1330,32 +1330,37 @@ func collectBodySyncPoints(
 	syncPoints map[int][]syncPoint,
 ) {
 	currentHeading := -1
-	// inContentDirective is true while scanning the lines of a
-	// multi-line `<?content?>` directive block. Plan 242 makes such a
-	// row opaque to the legacy body-sync collector: a `{field}` token
-	// inside the directive body (e.g. a `bind:` value) must not become
-	// a body-sync point, since the row is a schema directive parsed by
-	// schema.ParseFile, not body-sync template text.
-	inContentDirective := false
+	// inPIBlock is true while scanning the lines of a multi-line
+	// processing-instruction block (`<?content?>`, `<?require?>`,
+	// `<?include?>`, …). Plan 242 makes directive rows opaque to the
+	// legacy body-sync collector: a `{field}` token inside a directive
+	// body (e.g. a `bind:` value) must not become a body-sync point,
+	// since the row is schema syntax, not body-sync template text.
+	inPIBlock := false
 	start := 0
 	for i := 0; i <= len(content); i++ {
 		if i < len(content) && content[i] != '\n' {
 			continue
 		}
-		lineB := bytes.TrimSpace(content[start:i])
+		raw := content[start:i]
+		lineB := bytes.TrimSpace(raw)
 		start = i + 1
 		if len(lineB) == 0 {
 			continue
 		}
-		if inContentDirective {
-			inContentDirective = !bytes.Contains(lineB, piClose)
+		if inPIBlock {
+			// Mirror the block parser: a continuation line closes the
+			// PI only when its trimmed text is exactly `?>` — a `?>`
+			// substring inside a YAML value stays inside the block.
+			inPIBlock = !bytes.Equal(lineB, piClose)
 			continue
 		}
-		if isContentDirectiveOpen(lineB) {
-			// A single-line `<?content ... ?>` opens and closes on the
+		if isPIOpenLine(raw) {
+			// A single-line `<?name ... ?>` opens and closes on the
 			// same line; only a multi-line opener leaves us inside the
-			// block for subsequent lines.
-			inContentDirective = !bytes.Contains(lineB[len(contentDirectiveOpen):], piClose)
+			// block for subsequent lines. The parser closes an opener
+			// on a `?>` anywhere in its line.
+			inPIBlock = !bytes.Contains(lineB, piClose)
 			continue
 		}
 		if lineB[0] == '#' {
@@ -1398,31 +1403,37 @@ func appendBodySyncFields(
 	}
 }
 
-// contentDirectiveOpen / piClose are the literal markers
-// collectBodySyncPoints scans for to skip a `<?content?>` directive
-// block. They are package-level so the byte slices are allocated
+// piOpenPrefix / piClose are the literal markers
+// collectBodySyncPoints scans for to skip processing-instruction
+// blocks. They are package-level so the byte slices are allocated
 // once rather than per call.
 var (
-	contentDirectiveOpen = []byte("<?content")
-	piClose              = []byte("?>")
+	piOpenPrefix = []byte("<?")
+	piClose      = []byte("?>")
 )
 
-// isContentDirectiveOpen reports whether a trimmed body line opens a
-// `<?content?>` directive. It matches the `<?content` prefix only
-// when the next byte is not an identifier character, so a directive
-// like `<?content-foo?>` (a different name) is not mistaken for one.
-func isContentDirectiveOpen(line []byte) bool {
-	if !bytes.HasPrefix(line, contentDirectiveOpen) {
+// isPIOpenLine reports whether a raw body line opens a processing
+// instruction, mirroring the block parser in pkg/markdown: at most
+// three spaces of indentation, a `<?` opener, and a non-empty name
+// (the bytes up to the first whitespace or `?>`). An indented code
+// example showing a directive is therefore not mistaken for one.
+func isPIOpenLine(raw []byte) bool {
+	trimmed := bytes.TrimLeft(raw, " ")
+	if len(raw)-len(trimmed) > 3 {
 		return false
 	}
-	rest := line[len(contentDirectiveOpen):]
-	if len(rest) == 0 {
-		return true
+	trimmed = bytes.TrimRight(trimmed, " \t\r\n")
+	if !bytes.HasPrefix(trimmed, piOpenPrefix) {
+		return false
 	}
-	c := rest[0]
-	if c == '-' || c == '_' ||
-		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') {
+	rest := trimmed[len(piOpenPrefix):]
+	if len(rest) == 0 {
+		return false
+	}
+	if rest[0] == ' ' || rest[0] == '\t' {
+		return false
+	}
+	if rest[0] == '?' && len(rest) > 1 && rest[1] == '>' {
 		return false
 	}
 	return true

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1337,7 +1337,8 @@ func collectBodySyncPoints(
 	// body (e.g. a `bind:` value) must not become a body-sync point,
 	// since the row is schema syntax, not body-sync template text.
 	inPIBlock := false
-	inFence := false
+	var fenceChar byte
+	fenceLen := 0
 	start := 0
 	for i := 0; i <= len(content); i++ {
 		if i < len(content) && content[i] != '\n' {
@@ -1349,22 +1350,33 @@ func collectBodySyncPoints(
 		if len(lineB) == 0 {
 			continue
 		}
-		if inPIBlock {
+		switch {
+		case inPIBlock:
 			// Mirror the block parser: a continuation line closes the
 			// PI only when its trimmed text is exactly `?>` — a `?>`
 			// substring inside a YAML value stays inside the block.
 			inPIBlock = !bytes.Equal(lineB, piClose)
 			continue
-		}
-		if bytes.HasPrefix(lineB, fenceBacktick) || bytes.HasPrefix(lineB, fenceTilde) {
-			// A fenced code block owns its lines before the PI parser
-			// runs, so a directive opener shown inside a fence is
-			// code, not a directive. The marker line itself falls
-			// through as ordinary body text, as it did before the
-			// PI skip existed.
-			inFence = !inFence
-		}
-		if !inFence && isPIOpenLine(raw) {
+		case fenceLen > 0:
+			// Inside a fenced code block the only state change is a
+			// valid close (CommonMark: the opener's character, a run
+			// at least as long, nothing else on the line). Fence
+			// lines — markers included — fall through as ordinary
+			// body text, as they did before the PI skip existed.
+			if fenceClose(raw, lineB, fenceChar, fenceLen) {
+				fenceChar, fenceLen = 0, 0
+			}
+		default:
+			if c, n := fenceOpenRun(raw, lineB); n > 0 {
+				// A fenced code block owns its lines before the PI
+				// parser runs, so a directive opener shown inside a
+				// fence is code, not a directive.
+				fenceChar, fenceLen = c, n
+				break
+			}
+			if !isPIOpenLine(raw) {
+				break
+			}
 			// A single-line `<?name ... ?>` opens and closes on the
 			// same line; only a multi-line opener leaves us inside the
 			// block for subsequent lines. The parser closes an opener
@@ -1419,10 +1431,52 @@ func appendBodySyncFields(
 var (
 	piOpenPrefix = []byte("<?")
 	piClose      = []byte("?>")
-
-	fenceBacktick = []byte("```")
-	fenceTilde    = []byte("~~~")
 )
+
+// fenceOpenRun reports the marker character and run length when a
+// body line opens a fenced code block the way the block parser would:
+// at most three spaces of indentation and a run of at least three
+// backticks or tildes. n is 0 when the line opens no fence. (The same
+// open/close contract as include.rewriteSkippingCode.)
+func fenceOpenRun(raw, lineB []byte) (byte, int) {
+	if len(lineB) == 0 || (lineB[0] != '`' && lineB[0] != '~') {
+		return 0, 0
+	}
+	if lineIndent(raw) > 3 {
+		return 0, 0
+	}
+	n := fenceRun(lineB, lineB[0])
+	if n < 3 {
+		return 0, 0
+	}
+	return lineB[0], n
+}
+
+// fenceClose reports whether a body line closes the open fence per
+// CommonMark: the opener's character, a run at least as long as the
+// opener, nothing but the run on the trimmed line, and at most three
+// spaces of indentation.
+func fenceClose(raw, lineB []byte, ch byte, openLen int) bool {
+	if lineIndent(raw) > 3 {
+		return false
+	}
+	n := fenceRun(lineB, ch)
+	return n >= openLen && n == len(lineB)
+}
+
+// fenceRun returns the length of the run of ch at the start of line.
+func fenceRun(line []byte, ch byte) int {
+	n := 0
+	for n < len(line) && line[n] == ch {
+		n++
+	}
+	return n
+}
+
+// lineIndent returns the number of leading spaces on the raw line.
+func lineIndent(raw []byte) int {
+	return len(raw) - len(bytes.TrimLeft(raw, " "))
+}
 
 // isPIOpenLine reports whether a raw body line opens a processing
 // instruction, mirroring the block parser in pkg/markdown: at most
@@ -1430,10 +1484,10 @@ var (
 // (the bytes up to the first whitespace or `?>`). An indented code
 // example showing a directive is therefore not mistaken for one.
 func isPIOpenLine(raw []byte) bool {
-	trimmed := bytes.TrimLeft(raw, " ")
-	if len(raw)-len(trimmed) > 3 {
+	if lineIndent(raw) > 3 {
 		return false
 	}
+	trimmed := bytes.TrimLeft(raw, " ")
 	trimmed = bytes.TrimRight(trimmed, " \t\r\n")
 	if !bytes.HasPrefix(trimmed, piOpenPrefix) {
 		return false

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -350,7 +350,9 @@ func mergeScopes(a, b Scope) (Scope, error) {
 	// The schema-rule walker is the only consumer, and its semantics
 	// are already "later overrides earlier" within a single scope.
 	out.Rules = mergeScopeRules(a.Rules, b.Rules)
-	out.Content = append(cloneContent(a.Content), cloneContent(b.Content)...)
+	// cloneScope already deep-copied a.Content into out; appending
+	// b's clone onto it avoids re-cloning a's entries.
+	out.Content = append(out.Content, cloneContent(b.Content)...)
 	return out, nil
 }
 

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -90,7 +90,7 @@ func parseFileBytes(
 		sch.Filename = fp
 	}
 
-	headings, fp2, err := collectFileHeadings(f, r, path, fmLineCount(prefix), visited, chain)
+	headings, fp2, err := collectFileHeadings(f, r, path, lint.CountLines(prefix), visited, chain)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func extractRequireFilename(f *lint.File) (string, error) {
 		if !ok || pi.Name != "require" {
 			continue
 		}
-		body := piYAMLBody(pi, f.Source, "require")
+		body := piYAMLBody(pi, f.Source)
 		if body == "" {
 			continue
 		}
@@ -332,7 +332,7 @@ func parseContentDirective(pi *piparser.ProcessingInstruction, source []byte) (C
 		return ContentEntry{}, fmt.Errorf(
 			"<?content?> directive is missing its closing `?>`")
 	}
-	body := piYAMLBody(pi, source, "content")
+	body := piYAMLBody(pi, source)
 	var m map[string]any
 	if err := yamlutil.UnmarshalSafe([]byte(body), &m); err != nil {
 		return ContentEntry{}, fmt.Errorf("invalid <?content?> directive: %w", err)
@@ -340,12 +340,12 @@ func parseContentDirective(pi *piparser.ProcessingInstruction, source []byte) (C
 	return parseContentEntry(m, "<?content?>")
 }
 
-func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) string {
+func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte) string {
 	lines := pi.Lines()
 	if lines.Len() == 1 {
 		seg := lines.At(0)
 		line := strings.TrimSpace(string(seg.Value(source)))
-		line = strings.TrimPrefix(line, "<?"+name)
+		line = strings.TrimPrefix(line, "<?"+pi.Name)
 		if idx := strings.Index(line, "?>"); idx >= 0 {
 			line = line[:idx]
 		}
@@ -362,8 +362,9 @@ func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) 
 // collectFileHeadings walks the schema AST, collecting heading entries
 // and expanding <?include?> PIs by splicing the included file's
 // headings in place. lineBase is the number of source lines the
-// file's front matter occupied, so directive diagnostics name
-// absolute file lines rather than body-relative ones.
+// file's front matter occupied (lint.CountLines of the stripped
+// prefix); adding it to the 1-based body line from f.LineOfOffset
+// yields the absolute file line for directive diagnostics.
 func collectFileHeadings(
 	f *lint.File, r *FileReader, path string, lineBase int,
 	visited map[string]bool, chain []string,
@@ -419,13 +420,6 @@ func collectFileHeadings(
 	return heads, fp, nil
 }
 
-// fmLineCount returns the number of source lines a front-matter
-// prefix occupied (zero when the file has none), so body-relative
-// line numbers can be reported as absolute file lines.
-func fmLineCount(prefix []byte) int {
-	return bytes.Count(prefix, []byte("\n"))
-}
-
 func expandInclude(
 	pi *piparser.ProcessingInstruction, source []byte,
 	r *FileReader, schemaPath string, visited map[string]bool, chain []string,
@@ -467,7 +461,7 @@ func expandInclude(
 	visited[included] = true
 	nextChain := append([]string(nil), chain...)
 	nextChain = append(nextChain, included)
-	frag, fpFrag, err := collectFileHeadings(fragFile, r, included, fmLineCount(fragPrefix), visited, nextChain)
+	frag, fpFrag, err := collectFileHeadings(fragFile, r, included, lint.CountLines(fragPrefix), visited, nextChain)
 	delete(visited, included)
 	if err != nil {
 		return nil, "", err
@@ -482,7 +476,7 @@ func expandInclude(
 func resolveIncludePath(
 	pi *piparser.ProcessingInstruction, source []byte, schemaPath string,
 ) (string, error) {
-	body := piYAMLBody(pi, source, pi.Name)
+	body := piYAMLBody(pi, source)
 	if body == "" {
 		return "", fmt.Errorf(
 			"include processing instruction missing required 'file' attribute")

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -363,8 +363,9 @@ func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte) string {
 // and expanding <?include?> PIs by splicing the included file's
 // headings in place. lineBase is the number of source lines the
 // file's front matter occupied (lint.CountLines of the stripped
-// prefix); adding it to the 1-based body line from f.LineOfOffset
-// yields the absolute file line for directive diagnostics.
+// prefix, which StripFrontMatter always returns newline-terminated);
+// adding it to the 1-based body line from f.LineOfOffset yields the
+// absolute file line for directive diagnostics.
 func collectFileHeadings(
 	f *lint.File, r *FileReader, path string, lineBase int,
 	visited map[string]bool, chain []string,

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -307,10 +307,7 @@ func extractRequireFilename(f *lint.File) (string, error) {
 		if !ok || pi.Name != "require" {
 			continue
 		}
-		body, err := piYAMLBody(pi, f.Source, "require")
-		if err != nil {
-			return "", err
-		}
+		body := piYAMLBody(pi, f.Source, "require")
 		if body == "" {
 			continue
 		}
@@ -331,10 +328,7 @@ func extractRequireFilename(f *lint.File) (string, error) {
 // shape as one inline `content:` list entry (`kind`, `projection`,
 // `required`, `bind`, and the kind-specific fields).
 func parseContentDirective(pi *piparser.ProcessingInstruction, source []byte) (ContentEntry, error) {
-	body, err := piYAMLBody(pi, source, "content")
-	if err != nil {
-		return ContentEntry{}, err
-	}
+	body := piYAMLBody(pi, source, "content")
 	if body == "" {
 		return ContentEntry{}, fmt.Errorf(
 			"<?content?> directive missing a `kind:` key")
@@ -346,7 +340,7 @@ func parseContentDirective(pi *piparser.ProcessingInstruction, source []byte) (C
 	return parseContentEntry(m, "<?content?>")
 }
 
-func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) (string, error) {
+func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) string {
 	lines := pi.Lines()
 	if lines.Len() == 1 {
 		seg := lines.At(0)
@@ -355,14 +349,14 @@ func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) 
 		if idx := strings.Index(line, "?>"); idx >= 0 {
 			line = line[:idx]
 		}
-		return strings.TrimSpace(line), nil
+		return strings.TrimSpace(line)
 	}
 	var b strings.Builder
 	for i := 1; i < lines.Len(); i++ {
 		seg := lines.At(i)
 		b.Write(seg.Value(source))
 	}
-	return b.String(), nil
+	return b.String()
 }
 
 // collectFileHeadings walks the schema AST, collecting heading entries
@@ -471,10 +465,7 @@ func expandInclude(
 func resolveIncludePath(
 	pi *piparser.ProcessingInstruction, source []byte, schemaPath string,
 ) (string, error) {
-	body, err := piYAMLBody(pi, source, pi.Name)
-	if err != nil {
-		return "", fmt.Errorf("parsing include processing instruction: %w", err)
-	}
+	body := piYAMLBody(pi, source, pi.Name)
 	if body == "" {
 		return "", fmt.Errorf(
 			"include processing instruction missing required 'file' attribute")

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -90,7 +90,7 @@ func parseFileBytes(
 		sch.Filename = fp
 	}
 
-	headings, fp2, err := collectFileHeadings(f, r, path, visited, chain)
+	headings, fp2, err := collectFileHeadings(f, r, path, fmLineCount(prefix), visited, chain)
 	if err != nil {
 		return nil, err
 	}
@@ -322,17 +322,17 @@ func extractRequireFilename(f *lint.File) (string, error) {
 
 // parseContentDirective decodes a `<?content?>` PI body into one
 // ContentEntry, reusing the inline parser so the proto.md spelling
-// validates identically: unknown keys, unknown kinds, and illegal
-// kind/projection combinations fail here with the inline form's
-// diagnostics. The directive body carries the same `key: value`
-// shape as one inline `content:` list entry (`kind`, `projection`,
-// `required`, `bind`, and the kind-specific fields).
+// validates identically: unknown keys, unknown kinds, missing
+// `kind:`, and illegal kind/projection combinations fail here with
+// the inline form's diagnostics. The directive body carries the same
+// `key: value` shape as one inline `content:` list entry (`kind`,
+// `projection`, `required`, `bind`, and the kind-specific fields).
 func parseContentDirective(pi *piparser.ProcessingInstruction, source []byte) (ContentEntry, error) {
-	body := piYAMLBody(pi, source, "content")
-	if body == "" {
+	if !pi.HasClosure() {
 		return ContentEntry{}, fmt.Errorf(
-			"<?content?> directive missing a `kind:` key")
+			"<?content?> directive is missing its closing `?>`")
 	}
+	body := piYAMLBody(pi, source, "content")
 	var m map[string]any
 	if err := yamlutil.UnmarshalSafe([]byte(body), &m); err != nil {
 		return ContentEntry{}, fmt.Errorf("invalid <?content?> directive: %w", err)
@@ -361,13 +361,21 @@ func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) 
 
 // collectFileHeadings walks the schema AST, collecting heading entries
 // and expanding <?include?> PIs by splicing the included file's
-// headings in place.
+// headings in place. lineBase is the number of source lines the
+// file's front matter occupied, so directive diagnostics name
+// absolute file lines rather than body-relative ones.
 func collectFileHeadings(
-	f *lint.File, r *FileReader, path string,
+	f *lint.File, r *FileReader, path string, lineBase int,
 	visited map[string]bool, chain []string,
 ) ([]FileHeading, string, error) {
 	var heads []FileHeading
 	var fp string
+	// lastOwn indexes the most recent heading contributed by this
+	// file itself. An <?include?> splices fragment headings onto
+	// heads, but a <?content?> row in the host body declares an
+	// entry on the host's enclosing section, never on the included
+	// fragment's tail heading.
+	lastOwn := -1
 	err := ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
@@ -376,6 +384,7 @@ func collectFileHeadings(
 		case *ast.Heading:
 			text := headingText(node, f.Source)
 			heads = append(heads, FileHeading{Level: node.Level, Text: text})
+			lastOwn = len(heads) - 1
 		case *piparser.ProcessingInstruction:
 			switch node.Name {
 			case "include":
@@ -388,17 +397,18 @@ func collectFileHeadings(
 				}
 				heads = append(heads, frag...)
 			case "content":
-				if len(heads) == 0 {
+				line := lineBase + f.LineOfOffset(node.Lines().At(0).Start)
+				if lastOwn < 0 {
 					return ast.WalkStop, fmt.Errorf(
-						"schema %q: <?content?> directive must appear inside "+
-							"a section (after a heading)", path)
+						"schema %q line %d: <?content?> directive must appear inside "+
+							"a section (after a heading)", path, line)
 				}
 				entry, err := parseContentDirective(node, f.Source)
 				if err != nil {
-					return ast.WalkStop, err
+					return ast.WalkStop, fmt.Errorf(
+						"schema %q line %d: %w", path, line, err)
 				}
-				last := &heads[len(heads)-1]
-				last.Content = append(last.Content, entry)
+				heads[lastOwn].Content = append(heads[lastOwn].Content, entry)
 			}
 		}
 		return ast.WalkContinue, nil
@@ -407,6 +417,13 @@ func collectFileHeadings(
 		return nil, "", err
 	}
 	return heads, fp, nil
+}
+
+// fmLineCount returns the number of source lines a front-matter
+// prefix occupied (zero when the file has none), so body-relative
+// line numbers can be reported as absolute file lines.
+func fmLineCount(prefix []byte) int {
+	return bytes.Count(prefix, []byte("\n"))
 }
 
 func expandInclude(
@@ -435,7 +452,7 @@ func expandInclude(
 			"cannot read schema include file %q: %w", included, err)
 	}
 
-	_, body := lint.StripFrontMatter(data)
+	fragPrefix, body := lint.StripFrontMatter(data)
 	fragFile, err := lint.NewFile(included, body)
 	if err != nil {
 		return nil, "", fmt.Errorf(
@@ -450,7 +467,7 @@ func expandInclude(
 	visited[included] = true
 	nextChain := append([]string(nil), chain...)
 	nextChain = append(nextChain, included)
-	frag, fpFrag, err := collectFileHeadings(fragFile, r, included, visited, nextChain)
+	frag, fpFrag, err := collectFileHeadings(fragFile, r, included, fmLineCount(fragPrefix), visited, nextChain)
 	delete(visited, included)
 	if err != nil {
 		return nil, "", err
@@ -568,7 +585,17 @@ func headingsToScopes(heads []FileHeading) ([]Scope, int, error) {
 		// Attach any `<?content?>` directive rows collected in this
 		// heading's section body so a proto-based kind validates and
 		// extracts body content like the equivalent inline schema.
+		// A slot row matches zero-or-more arbitrary headings, so a
+		// content entry on it can never be validated — the inline
+		// parser rejects `content:` on slot scopes, and the proto
+		// spelling must fail the same way instead of storing dead
+		// entries the validation walk silently skips.
 		sc.Content = h.Content
+		if len(sc.Content) > 0 && isSlotMatcher(sc.Matcher) {
+			return nil, 0, fmt.Errorf(
+				"`<?content?>` is not allowed under a `## %s` slot row — "+
+					"move the directive under a named heading", SectionWildcard)
+		}
 		parent.scopes = append(parent.scopes, sc)
 		stack = append(stack, &frame{level: h.Level})
 	}

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -186,9 +186,14 @@ func resolveExtendsPath(schemaPath, parentPath string) (string, error) {
 }
 
 // FileHeading is a heading collected from a schema markdown file.
+// Content carries any `<?content?>` directive rows that appear in the
+// heading's section body, in source order — the proto.md spelling of
+// the inline `content:` list. headingsToScopes copies it onto the
+// scope built for this heading.
 type FileHeading struct {
-	Level int
-	Text  string
+	Level   int
+	Text    string
+	Content []ContentEntry
 }
 
 // parseFileFrontmatter reads the schema's YAML front matter into
@@ -318,6 +323,29 @@ func extractRequireFilename(f *lint.File) (string, error) {
 	return "", nil
 }
 
+// parseContentDirective decodes a `<?content?>` PI body into one
+// ContentEntry, reusing the inline parser so the proto.md spelling
+// validates identically: unknown keys, unknown kinds, and illegal
+// kind/projection combinations fail here with the inline form's
+// diagnostics. The directive body carries the same `key: value`
+// shape as one inline `content:` list entry (`kind`, `projection`,
+// `required`, `bind`, and the kind-specific fields).
+func parseContentDirective(pi *piparser.ProcessingInstruction, source []byte) (ContentEntry, error) {
+	body, err := piYAMLBody(pi, source, "content")
+	if err != nil {
+		return ContentEntry{}, err
+	}
+	if body == "" {
+		return ContentEntry{}, fmt.Errorf(
+			"<?content?> directive missing a `kind:` key")
+	}
+	var m map[string]any
+	if err := yamlutil.UnmarshalSafe([]byte(body), &m); err != nil {
+		return ContentEntry{}, fmt.Errorf("invalid <?content?> directive: %w", err)
+	}
+	return parseContentEntry(m, "<?content?>")
+}
+
 func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte, name string) (string, error) {
 	lines := pi.Lines()
 	if lines.Len() == 1 {
@@ -355,17 +383,29 @@ func collectFileHeadings(
 			text := headingText(node, f.Source)
 			heads = append(heads, FileHeading{Level: node.Level, Text: text})
 		case *piparser.ProcessingInstruction:
-			if node.Name != "include" {
-				return ast.WalkContinue, nil
+			switch node.Name {
+			case "include":
+				frag, fpInc, err := expandInclude(node, f.Source, r, path, visited, chain)
+				if err != nil {
+					return ast.WalkStop, err
+				}
+				if fpInc != "" && fp == "" {
+					fp = fpInc
+				}
+				heads = append(heads, frag...)
+			case "content":
+				if len(heads) == 0 {
+					return ast.WalkStop, fmt.Errorf(
+						"schema %q: <?content?> directive must appear inside "+
+							"a section (after a heading)", path)
+				}
+				entry, err := parseContentDirective(node, f.Source)
+				if err != nil {
+					return ast.WalkStop, err
+				}
+				last := &heads[len(heads)-1]
+				last.Content = append(last.Content, entry)
 			}
-			frag, fpInc, err := expandInclude(node, f.Source, r, path, visited, chain)
-			if err != nil {
-				return ast.WalkStop, err
-			}
-			if fpInc != "" && fp == "" {
-				fp = fpInc
-			}
-			heads = append(heads, frag...)
 		}
 		return ast.WalkContinue, nil
 	})
@@ -534,6 +574,10 @@ func headingsToScopes(heads []FileHeading) ([]Scope, int, error) {
 		if err != nil {
 			return nil, 0, err
 		}
+		// Attach any `<?content?>` directive rows collected in this
+		// heading's section body so a proto-based kind validates and
+		// extracts body content like the equivalent inline schema.
+		sc.Content = h.Content
 		parent.scopes = append(parent.scopes, sc)
 		stack = append(stack, &frame{level: h.Level})
 	}

--- a/internal/schema/parse_file_content_test.go
+++ b/internal/schema/parse_file_content_test.go
@@ -8,14 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// schemaFile writes src as a single-file proto.md schema in a fresh
+// temp dir and returns its path.
+func schemaFile(t *testing.T, src string) string {
+	t.Helper()
+	return writeFile(t, t.TempDir(), "schema.md", src)
+}
+
 // TestParseFile_ContentDirectiveParagraph is the happy path: a
 // `<?content kind: paragraph ?>` directive row in a proto.md section
 // body declares one content entry on the enclosing section's scope,
 // matching what the inline `content: [{ kind: paragraph }]` form
 // produces.
 func TestParseFile_ContentDirectiveParagraph(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"# {title}\n\n## Tagline\n\n<?content\nkind: paragraph\n?>\n")
 	sch, err := ParseFile(&FileReader{}, path)
 	require.NoError(t, err)
@@ -34,8 +40,7 @@ func TestParseFile_ContentDirectiveParagraph(t *testing.T) {
 // one section declare two ordered entries (the `text` / `text-2`
 // projection keys the inline form derives from positional order).
 func TestParseFile_ContentDirectiveTwoOrdered(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Body\n\n<?content\nkind: paragraph\n?>\n\n<?content\nkind: code-block\nlang: go\n?>\n")
 	sch, err := ParseFile(&FileReader{}, path)
 	require.NoError(t, err)
@@ -51,8 +56,7 @@ func TestParseFile_ContentDirectiveTwoOrdered(t *testing.T) {
 // `projection:` key passes through and is validated by the inline
 // rules (inline is legal on a paragraph).
 func TestParseFile_ContentDirectiveProjectionInline(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Tagline\n\n<?content\nkind: paragraph\nprojection: inline\n?>\n")
 	sch, err := ParseFile(&FileReader{}, path)
 	require.NoError(t, err)
@@ -64,8 +68,7 @@ func TestParseFile_ContentDirectiveProjectionInline(t *testing.T) {
 // TestParseFile_ContentDirectiveRejectsUnknownKind locks down that an
 // invalid kind fails at parse time with the inline form's diagnostic.
 func TestParseFile_ContentDirectiveRejectsUnknownKind(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Tagline\n\n<?content\nkind: bogus\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -76,8 +79,7 @@ func TestParseFile_ContentDirectiveRejectsUnknownKind(t *testing.T) {
 // that `projection: inline` on a code-block fails at parse time, the
 // same as the inline form.
 func TestParseFile_ContentDirectiveRejectsInlineOnCodeBlock(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Snippet\n\n<?content\nkind: code-block\nprojection: inline\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -88,8 +90,7 @@ func TestParseFile_ContentDirectiveRejectsInlineOnCodeBlock(t *testing.T) {
 // `bind: ""` on a content entry fails at parse time — a content entry
 // has no children to hoist, the same rule the inline form enforces.
 func TestParseFile_ContentDirectiveRejectsEmptyBind(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Tagline\n\n<?content\nkind: paragraph\nbind: \"\"\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -100,8 +101,7 @@ func TestParseFile_ContentDirectiveRejectsEmptyBind(t *testing.T) {
 // unknown key on the directive fails at parse time, matching the
 // inline content parser's unknown-key diagnostic.
 func TestParseFile_ContentDirectiveRejectsUnknownKey(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Tagline\n\n<?content\nkind: paragraph\nbogus: 1\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -119,8 +119,7 @@ func TestParseFile_ContentDirectiveRequiresKind(t *testing.T) {
 		"multi-line":  "## Tagline\n\n<?content\n\n?>\n",
 	} {
 		t.Run(name, func(t *testing.T) {
-			dir := t.TempDir()
-			path := writeFile(t, dir, "schema.md", src)
+			path := schemaFile(t, src)
 			_, err := ParseFile(&FileReader{}, path)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "must set a `kind:` key")
@@ -132,8 +131,7 @@ func TestParseFile_ContentDirectiveRequiresKind(t *testing.T) {
 // `<?content` block left open at EOF (a missing `?>` line) is a
 // parse error rather than a silently accepted directive.
 func TestParseFile_ContentDirectiveUnclosedFails(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Tagline\n\n<?content\nkind: paragraph\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -145,8 +143,7 @@ func TestParseFile_ContentDirectiveUnclosedFails(t *testing.T) {
 // under a `## ...` row must fail instead of storing entries the
 // validation walk silently skips.
 func TestParseFile_ContentDirectiveOnSlotRowFails(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## ...\n\n<?content\nkind: paragraph\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -178,8 +175,7 @@ func TestParseFile_ContentDirectiveAfterIncludeAttachesToHost(t *testing.T) {
 // directive diagnostic carries the absolute source line, including
 // the lines a front-matter block occupied.
 func TestParseFile_ContentDirectiveErrorNamesLine(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"---\ntitle: string\n---\n## Tagline\n\n<?content\nkind: bogus\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -192,8 +188,7 @@ func TestParseFile_ContentDirectiveErrorNamesLine(t *testing.T) {
 // directive body that is not valid YAML fails at parse time with the
 // invalid-directive diagnostic.
 func TestParseFile_ContentDirectiveRejectsInvalidYAML(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"## Tagline\n\n<?content\nkind: [unclosed\n?>\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
@@ -204,8 +199,7 @@ func TestParseFile_ContentDirectiveRejectsInvalidYAML(t *testing.T) {
 // `<?content?>` row above the first heading is rejected — the entry
 // would have no section to attach to.
 func TestParseFile_ContentDirectiveBeforeHeadingFails(t *testing.T) {
-	dir := t.TempDir()
-	path := writeFile(t, dir, "schema.md",
+	path := schemaFile(t,
 		"<?content\nkind: paragraph\n?>\n\n## Tagline\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)

--- a/internal/schema/parse_file_content_test.go
+++ b/internal/schema/parse_file_content_test.go
@@ -12,7 +12,7 @@ import (
 // temp dir and returns its path.
 func schemaFile(t *testing.T, src string) string {
 	t.Helper()
-	return writeFile(t, t.TempDir(), "schema.md", src)
+	return writeFile(t, t.TempDir(), "proto.md", src)
 }
 
 // TestParseFile_ContentDirectiveParagraph is the happy path: a
@@ -172,16 +172,28 @@ func TestParseFile_ContentDirectiveAfterIncludeAttachesToHost(t *testing.T) {
 }
 
 // TestParseFile_ContentDirectiveErrorNamesLine locks down that a
-// directive diagnostic carries the absolute source line, including
-// the lines a front-matter block occupied.
+// directive diagnostic carries the absolute source line — with front
+// matter the block's lines are added; without it the body line is
+// already absolute.
 func TestParseFile_ContentDirectiveErrorNamesLine(t *testing.T) {
-	path := schemaFile(t,
-		"---\ntitle: string\n---\n## Tagline\n\n<?content\nkind: bogus\n?>\n")
-	_, err := ParseFile(&FileReader{}, path)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "line 6",
-		"three front-matter lines plus the body offset of the directive")
-	assert.Contains(t, err.Error(), "unknown content kind")
+	for name, tc := range map[string]struct{ src, line string }{
+		"front matter": {
+			src:  "---\ntitle: string\n---\n## Tagline\n\n<?content\nkind: bogus\n?>\n",
+			line: "line 6",
+		},
+		"no front matter": {
+			src:  "## Tagline\n\n<?content\nkind: bogus\n?>\n",
+			line: "line 3",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := schemaFile(t, tc.src)
+			_, err := ParseFile(&FileReader{}, path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.line)
+			assert.Contains(t, err.Error(), "unknown content kind")
+		})
+	}
 }
 
 // TestParseFile_ContentDirectiveRejectsInvalidYAML locks down that a

--- a/internal/schema/parse_file_content_test.go
+++ b/internal/schema/parse_file_content_test.go
@@ -1,0 +1,85 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseFile_ContentDirectiveParagraph is the happy path: a
+// `<?content kind: paragraph ?>` directive row in a proto.md section
+// body declares one content entry on the enclosing section's scope,
+// matching what the inline `content: [{ kind: paragraph }]` form
+// produces.
+func TestParseFile_ContentDirectiveParagraph(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"# {title}\n\n## Tagline\n\n<?content\nkind: paragraph\n?>\n")
+	sch, err := ParseFile(&FileReader{}, path)
+	require.NoError(t, err)
+	require.Len(t, sch.Sections, 1, "one H1 root scope")
+	h1 := sch.Sections[0]
+	require.Len(t, h1.Sections, 1, "one H2 under the H1")
+	tagline := h1.Sections[0]
+	require.Len(t, tagline.Content, 1,
+		"the <?content?> row must declare one content entry")
+	assert.Equal(t, ContentKindParagraph, tagline.Content[0].Kind)
+	assert.True(t, tagline.Content[0].Required,
+		"a literal content entry defaults to required")
+}
+
+// TestParseFile_ContentDirectiveTwoOrdered verifies two directives in
+// one section declare two ordered entries (the `text` / `text-2`
+// projection keys the inline form derives from positional order).
+func TestParseFile_ContentDirectiveTwoOrdered(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Body\n\n<?content\nkind: paragraph\n?>\n\n<?content\nkind: code-block\nlang: go\n?>\n")
+	sch, err := ParseFile(&FileReader{}, path)
+	require.NoError(t, err)
+	require.Len(t, sch.Sections, 1)
+	body := sch.Sections[0]
+	require.Len(t, body.Content, 2, "two directives, two ordered entries")
+	assert.Equal(t, ContentKindParagraph, body.Content[0].Kind)
+	assert.Equal(t, ContentKindCodeBlock, body.Content[1].Kind)
+	assert.Equal(t, "go", body.Content[1].Lang)
+}
+
+// TestParseFile_ContentDirectiveProjectionInline verifies the
+// `projection:` key passes through and is validated by the inline
+// rules (inline is legal on a paragraph).
+func TestParseFile_ContentDirectiveProjectionInline(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Tagline\n\n<?content\nkind: paragraph\nprojection: inline\n?>\n")
+	sch, err := ParseFile(&FileReader{}, path)
+	require.NoError(t, err)
+	require.Len(t, sch.Sections, 1)
+	require.Len(t, sch.Sections[0].Content, 1)
+	assert.Equal(t, ProjectionInline, sch.Sections[0].Content[0].Projection)
+}
+
+// TestParseFile_ContentDirectiveRejectsUnknownKind locks down that an
+// invalid kind fails at parse time with the inline form's diagnostic.
+func TestParseFile_ContentDirectiveRejectsUnknownKind(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Tagline\n\n<?content\nkind: bogus\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown content kind")
+}
+
+// TestParseFile_ContentDirectiveRejectsInlineOnCodeBlock locks down
+// that `projection: inline` on a code-block fails at parse time, the
+// same as the inline form.
+func TestParseFile_ContentDirectiveRejectsInlineOnCodeBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Snippet\n\n<?content\nkind: code-block\nprojection: inline\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "projection")
+}

--- a/internal/schema/parse_file_content_test.go
+++ b/internal/schema/parse_file_content_test.go
@@ -109,15 +109,83 @@ func TestParseFile_ContentDirectiveRejectsUnknownKey(t *testing.T) {
 }
 
 // TestParseFile_ContentDirectiveRequiresKind locks down that a bare
-// `<?content ?>` with no body fails at parse time instead of
-// declaring an empty entry.
+// `<?content ?>` with no body fails at parse time with the inline
+// form's missing-kind diagnostic (the empty body flows through the
+// shared entry parser, so single-line and multi-line blank bodies
+// emit the same message).
 func TestParseFile_ContentDirectiveRequiresKind(t *testing.T) {
+	for name, src := range map[string]string{
+		"single-line": "## Tagline\n\n<?content ?>\n",
+		"multi-line":  "## Tagline\n\n<?content\n\n?>\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeFile(t, dir, "schema.md", src)
+			_, err := ParseFile(&FileReader{}, path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must set a `kind:` key")
+		})
+	}
+}
+
+// TestParseFile_ContentDirectiveUnclosedFails locks down that a
+// `<?content` block left open at EOF (a missing `?>` line) is a
+// parse error rather than a silently accepted directive.
+func TestParseFile_ContentDirectiveUnclosedFails(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "schema.md",
-		"## Tagline\n\n<?content ?>\n")
+		"## Tagline\n\n<?content\nkind: paragraph\n")
 	_, err := ParseFile(&FileReader{}, path)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing a `kind:` key")
+	assert.Contains(t, err.Error(), "missing its closing `?>`")
+}
+
+// TestParseFile_ContentDirectiveOnSlotRowFails mirrors the inline
+// parser: `content:` is rejected on a slot scope, so a `<?content?>`
+// under a `## ...` row must fail instead of storing entries the
+// validation walk silently skips.
+func TestParseFile_ContentDirectiveOnSlotRowFails(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## ...\n\n<?content\nkind: paragraph\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slot row")
+}
+
+// TestParseFile_ContentDirectiveAfterIncludeAttachesToHost pins the
+// attachment anchor: a `<?content?>` row that follows an
+// `<?include?>` splice still declares its entry on the host file's
+// enclosing section, not on the included fragment's tail heading.
+func TestParseFile_ContentDirectiveAfterIncludeAttachesToHost(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "frag.md", "## FragEnd\n")
+	path := writeFile(t, dir, "schema.md",
+		"## Host\n\n<?include\nfile: frag.md\n?>\n\n<?content\nkind: paragraph\n?>\n")
+	sch, err := ParseFile(&FileReader{}, path)
+	require.NoError(t, err)
+	require.Len(t, sch.Sections, 2, "host heading plus spliced fragment heading")
+	host, frag := sch.Sections[0], sch.Sections[1]
+	require.Equal(t, "Host", host.Heading)
+	require.Equal(t, "FragEnd", frag.Heading)
+	assert.Len(t, host.Content, 1,
+		"the content entry belongs to the host section")
+	assert.Empty(t, frag.Content,
+		"the spliced fragment heading must not receive the host's entry")
+}
+
+// TestParseFile_ContentDirectiveErrorNamesLine locks down that a
+// directive diagnostic carries the absolute source line, including
+// the lines a front-matter block occupied.
+func TestParseFile_ContentDirectiveErrorNamesLine(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"---\ntitle: string\n---\n## Tagline\n\n<?content\nkind: bogus\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 6",
+		"three front-matter lines plus the body offset of the directive")
+	assert.Contains(t, err.Error(), "unknown content kind")
 }
 
 // TestParseFile_ContentDirectiveRejectsInvalidYAML locks down that a

--- a/internal/schema/parse_file_content_test.go
+++ b/internal/schema/parse_file_content_test.go
@@ -83,3 +83,27 @@ func TestParseFile_ContentDirectiveRejectsInlineOnCodeBlock(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "projection")
 }
+
+// TestParseFile_ContentDirectiveRejectsEmptyBind locks down that
+// `bind: ""` on a content entry fails at parse time — a content entry
+// has no children to hoist, the same rule the inline form enforces.
+func TestParseFile_ContentDirectiveRejectsEmptyBind(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Tagline\n\n<?content\nkind: paragraph\nbind: \"\"\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind")
+}
+
+// TestParseFile_ContentDirectiveRejectsUnknownKey locks down that an
+// unknown key on the directive fails at parse time, matching the
+// inline content parser's unknown-key diagnostic.
+func TestParseFile_ContentDirectiveRejectsUnknownKey(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Tagline\n\n<?content\nkind: paragraph\nbogus: 1\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown content key")
+}

--- a/internal/schema/parse_file_content_test.go
+++ b/internal/schema/parse_file_content_test.go
@@ -107,3 +107,39 @@ func TestParseFile_ContentDirectiveRejectsUnknownKey(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown content key")
 }
+
+// TestParseFile_ContentDirectiveRequiresKind locks down that a bare
+// `<?content ?>` with no body fails at parse time instead of
+// declaring an empty entry.
+func TestParseFile_ContentDirectiveRequiresKind(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Tagline\n\n<?content ?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing a `kind:` key")
+}
+
+// TestParseFile_ContentDirectiveRejectsInvalidYAML locks down that a
+// directive body that is not valid YAML fails at parse time with the
+// invalid-directive diagnostic.
+func TestParseFile_ContentDirectiveRejectsInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"## Tagline\n\n<?content\nkind: [unclosed\n?>\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid <?content?> directive")
+}
+
+// TestParseFile_ContentDirectiveBeforeHeadingFails locks down that a
+// `<?content?>` row above the first heading is rejected — the entry
+// would have no section to attach to.
+func TestParseFile_ContentDirectiveBeforeHeadingFails(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "schema.md",
+		"<?content\nkind: paragraph\n?>\n\n## Tagline\n")
+	_, err := ParseFile(&FileReader{}, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must appear inside a section")
+}

--- a/plan/242_proto-content-entries.md
+++ b/plan/242_proto-content-entries.md
@@ -1,7 +1,7 @@
 ---
 id: 242
 title: "proto.md schemas declare content entries via `<?content?>`"
-status: "🔳"
+status: "✅"
 summary: >-
   A `<?content?>` directive row in a proto.md section body
   declares the same content entry the inline `content:` list
@@ -79,12 +79,12 @@ in proto bodies as a directive row.
    equivalent inline schema. Differential test: one schema
    expressed both ways, byte-identical extract output
    (modulo root level).
-4. Document the directive in the
+4. [x] Document the directive in the
    [section-schema reference](../docs/reference/section-schema.md)
    proto.md section and in the
    [schemas guide](../docs/guides/schemas.md); update the
    inline-vs-proto capability table.
-5. Revisit the
+5. [x] Revisit the
    [extract guide](../docs/guides/extract-markdown-as-data.md)
    "Frontmatter `title` and the H1" section: the
    content-entries limit no longer applies; rewrite the
@@ -103,10 +103,10 @@ in proto bodies as a directive row.
 - [x] Invalid directives (unknown kind, `projection: inline`
   on a code-block, `bind: ""` on a content entry) fail at
   config load with the inline form's diagnostics.
-- [ ] Docs updated: section-schema reference, schemas guide
+- [x] Docs updated: section-schema reference, schemas guide
   capability table, extract guide trade-off paragraph.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues
 
 ## Out of scope
 

--- a/plan/242_proto-content-entries.md
+++ b/plan/242_proto-content-entries.md
@@ -74,7 +74,7 @@ in proto bodies as a directive row.
 2. [x] Teach the legacy MDS020 proto parser to skip
    `<?content?>` rows (no body-sync interpretation, no
    diagnostic).
-3. [ ] Wire extraction: a proto-based kind with `<?content?>`
+3. [x] Wire extraction: a proto-based kind with `<?content?>`
    entries projects body content identically to the
    equivalent inline schema. Differential test: one schema
    expressed both ways, byte-identical extract output
@@ -95,7 +95,7 @@ in proto bodies as a directive row.
 - [x] A proto.md section body may contain `<?content?>`
   directive rows; each declares one content entry with the
   inline keys (`kind`, `projection`, `required`, `bind`).
-- [ ] `mdsmith extract` on a proto-based kind with declared
+- [x] `mdsmith extract` on a proto-based kind with declared
   content projects the same tree as the equivalent inline
   schema.
 - [x] MDS020 (legacy path) neither flags nor body-syncs a

--- a/plan/242_proto-content-entries.md
+++ b/plan/242_proto-content-entries.md
@@ -67,14 +67,14 @@ in proto bodies as a directive row.
 
 ## Tasks
 
-1. Parse `<?content?>` rows in the schema-package proto
+1. [x] Parse `<?content?>` rows in the schema-package proto
    parser into content entries; reject unknown keys and
    invalid kind/projection combinations at parse time with
    the same diagnostics as the inline form.
-2. Teach the legacy MDS020 proto parser to skip
+2. [x] Teach the legacy MDS020 proto parser to skip
    `<?content?>` rows (no body-sync interpretation, no
    diagnostic).
-3. Wire extraction: a proto-based kind with `<?content?>`
+3. [ ] Wire extraction: a proto-based kind with `<?content?>`
    entries projects body content identically to the
    equivalent inline schema. Differential test: one schema
    expressed both ways, byte-identical extract output
@@ -92,15 +92,15 @@ in proto bodies as a directive row.
 
 ## Acceptance Criteria
 
-- [ ] A proto.md section body may contain `<?content?>`
+- [x] A proto.md section body may contain `<?content?>`
   directive rows; each declares one content entry with the
   inline keys (`kind`, `projection`, `required`, `bind`).
 - [ ] `mdsmith extract` on a proto-based kind with declared
   content projects the same tree as the equivalent inline
   schema.
-- [ ] MDS020 (legacy path) neither flags nor body-syncs a
+- [x] MDS020 (legacy path) neither flags nor body-syncs a
   `<?content?>` row.
-- [ ] Invalid directives (unknown kind, `projection: inline`
+- [x] Invalid directives (unknown kind, `projection: inline`
   on a code-block, `bind: ""` on a content entry) fail at
   config load with the inline form's diagnostics.
 - [ ] Docs updated: section-schema reference, schemas guide

--- a/plan/242_proto-content-entries.md
+++ b/plan/242_proto-content-entries.md
@@ -1,7 +1,7 @@
 ---
 id: 242
 title: "proto.md schemas declare content entries via `<?content?>`"
-status: "🔲"
+status: "🔳"
 summary: >-
   A `<?content?>` directive row in a proto.md section body
   declares the same content entry the inline `content:` list


### PR DESCRIPTION
Draft PR for [plan/242_proto-content-entries.md](plan/242_proto-content-entries.md).

Status will move 🔲 → 🔳 in PLAN.md once the first real
commit lands. Marking ready for review when the
acceptance criteria are checked off.

https://claude.ai/code/session_01V5FGdWSHdvuKjKtDjzM746

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5FGdWSHdvuKjKtDjzM746)_