### PR TITLE
lsp: answer panicked requests, surface recoveries, contain the settings goroutine

### DIFF
--- a/internal/lsp/panic_recovery_test.go
+++ b/internal/lsp/panic_recovery_test.go
@@ -3,6 +3,8 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +12,7 @@ import (
 	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestRunLintPanicIsRecovered verifies that a panic inside the lint
@@ -50,10 +53,17 @@ func TestRunLintPanicIsRecovered(t *testing.T) {
 	assert.NotContains(t, out.String(), "publishDiagnostics",
 		"a panic in the lint pipeline must not publish diagnostics")
 
-	// The panic must have been logged so it is observable in the server
-	// log rather than silently swallowed.
+	// The panic must have been logged with its stack so the underlying
+	// bug is diagnosable from the only artifact recovery leaves.
 	assert.Contains(t, logBuf.String(), "injected lint panic",
 		"the recovered panic value must appear in the server log")
+	assert.Contains(t, logBuf.String(), "goroutine",
+		"the recovery log must include the stack trace")
+
+	// Production runs with logging disabled, so the recovery must also
+	// reach the editor's output channel via window/logMessage.
+	assert.Contains(t, out.String(), "window/logMessage",
+		"the recovered panic must surface to the editor")
 }
 
 // TestRunLintIfCurrentPanicIsRecovered verifies the same through the
@@ -128,11 +138,10 @@ func TestDispatchRawPanicAllowsNextRequest(t *testing.T) {
 		"dispatch loop must still serve requests after a recovered panic")
 }
 
-// TestDispatchRawPanicReturnsErrorForPendingRequest verifies that a
-// request whose handler panics gets an InternalError response rather
-// than leaving the client hanging. (Optional: only asserts the server
-// stays alive, since writing a response from recover is optional.)
-func TestDispatchRawPanicServerSurvivesOnRequestPanic(t *testing.T) {
+// TestDispatchRawPanicAnswersPendingRequest verifies that a request
+// whose handler panics gets an InternalError response, so the
+// client's promise for that ID settles instead of pending forever.
+func TestDispatchRawPanicAnswersPendingRequest(t *testing.T) {
 	t.Parallel()
 	var out safeBuffer
 	var logBuf strings.Builder
@@ -156,16 +165,78 @@ func TestDispatchRawPanicServerSurvivesOnRequestPanic(t *testing.T) {
 		Method  string          `json:"method"`
 	}{JSONRPC: "2.0", ID: json.RawMessage(`99`), Method: "shutdown"})
 
-	// Before the fix this panics; after the fix it returns normally.
 	s.dispatchRaw(context.Background(), raw)
 
-	// The panic must be logged.
+	// The panic must be logged with its stack.
 	assert.Contains(t, logBuf.String(), "injected dispatch panic",
 		"the recovered dispatch panic must be logged")
+	assert.Contains(t, logBuf.String(), "goroutine",
+		"the recovery log must include the stack trace")
+
+	// The in-flight request must be answered with InternalError.
+	assert.Contains(t, out.String(), `"id":99`,
+		"the panicked request's ID must be answered")
+	assert.Contains(t, out.String(), `-32603`,
+		"the answer must be an InternalError response")
 
 	// After the panic the server is not in a wedged state; a fresh
-	// request still works.
+	// request is served with a real response.
 	s.dispatchPanicHook = nil
 	s.dispatchRaw(context.Background(),
 		[]byte(`{"jsonrpc":"2.0","id":100,"method":"shutdown"}`))
+	assert.Contains(t, out.String(), `"id":100`,
+		"the follow-up request must receive its response")
+}
+
+// TestFetchClientSettingsPanicIsRecovered verifies that a panic on
+// the client-settings goroutine — here injected via the host's
+// OnConfigReload callback, which runs inside the response path's
+// reloadConfig — is contained instead of killing the server. The
+// same reload triggered from the dispatch loop was already covered
+// by dispatchRaw's recover; this pins the asymmetric goroutine path.
+func TestFetchClientSettingsPanicIsRecovered(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath,
+		[]byte("rules:\n  line-length:\n    max: 120\n"), 0o600))
+
+	var out safeBuffer
+	var logBuf strings.Builder
+	s := New(Options{
+		Reader: nil,
+		Writer: &out,
+		Rules:  rule.All(),
+		Logger: &vlog.Logger{Enabled: true, W: &logBuf},
+		OnConfigReload: func(string) {
+			panic("injected config-reload panic")
+		},
+	})
+	s.fetchTimeout = 5 * time.Second
+
+	// Deliver the workspace/configuration response (pointing
+	// mdsmith.config at the temp file, so the resolved path changes
+	// and OnConfigReload fires) once the request has been written.
+	respond := func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if strings.Contains(out.String(), "workspace/configuration") {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+		result, err := json.Marshal([]clientSettings{{ConfigPath: &cfgPath}})
+		require.NoError(t, err)
+		s.deliverResponse("1", rpcResponse{Result: result})
+	}
+	go respond()
+
+	// Direct call: without the deferred recover the injected panic
+	// propagates out of fetchClientSettings and fails this test.
+	s.fetchClientSettings(context.Background())
+
+	assert.Contains(t, logBuf.String(), "injected config-reload panic",
+		"the recovered settings-path panic must be logged")
+	assert.Contains(t, logBuf.String(), "goroutine",
+		"the recovery log must include the stack trace")
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -133,15 +134,16 @@ type Server struct {
 	// simulate a didClose landing mid-lint — the race the "document was
 	// closed while we were linting" guard protects against.
 	afterLintCheck func()
-	// lintPanicHook, when non-nil, is called inside runLint in place of
+	// lintPanicHook, when non-nil, is called inside runLint just before
 	// the real sess.CheckVersion call. Tests set it to panic so the
 	// deferred recover path can be driven red/green without a real rule
 	// that panics. Nil in production.
 	lintPanicHook func()
-	// dispatchPanicHook, when non-nil, is called at the start of
-	// dispatchRaw so a test can trigger a panic inside the dispatch path.
-	// One-shot: the hook disables itself after firing so subsequent
-	// messages route normally. Nil in production.
+	// dispatchPanicHook, when non-nil, is called by dispatchRaw after
+	// the frame is parsed and before dispatch, so a test can trigger a
+	// handler-stage panic inside the dispatch path. One-shot: the hook
+	// disables itself after firing so subsequent messages route
+	// normally. Nil in production.
 	dispatchPanicHook func()
 }
 
@@ -334,20 +336,26 @@ var errExitWithoutShutdown = errors.New("lsp: exit notification received before 
 // and any future server-initiated request.
 //
 // A deferred recover wraps the entire body so a panic inside a message
-// handler does not kill the dispatch loop. The panic is logged and the
-// offending frame is dropped; the next frame is processed normally.
+// handler does not kill the dispatch loop. The panic is logged with
+// its stack and the offending frame is dropped; when the frame was a
+// request, an InternalError response settles the client's pending
+// call. The next frame is processed normally.
 func (s *Server) dispatchRaw(ctx context.Context, raw []byte) {
+	var reqID json.RawMessage
 	defer func() {
-		if r := recover(); r != nil {
-			s.logger.Printf("dispatch: recovered panic: %v", r)
+		r := recover()
+		if r == nil {
+			return
+		}
+		s.logPanic("dispatch", r)
+		// JSON-RPC 2.0 §5: every call gets a response. Without one
+		// the client's promise for this ID pends forever — the
+		// crash would become a hang.
+		if len(reqID) > 0 {
+			_ = s.t.writeError(reqID, codeInternalError,
+				"internal error: panic while handling request")
 		}
 	}()
-	// dispatchPanicHook is a test seam (nil in production). When set, it
-	// fires at the top of dispatchRaw so a test can trigger a panic
-	// inside the dispatch path and verify the deferred recover catches it.
-	if s.dispatchPanicHook != nil {
-		s.dispatchPanicHook()
-	}
 	var probe struct {
 		JSONRPC string          `json:"jsonrpc"`
 		ID      json.RawMessage `json:"id,omitempty"`
@@ -387,7 +395,40 @@ func (s *Server) dispatchRaw(ctx context.Context, raw []byte) {
 	msg := &requestMessage{
 		JSONRPC: probe.JSONRPC, ID: probe.ID, Method: probe.Method, Params: probe.Params,
 	}
+	reqID = msg.ID
+	// dispatchPanicHook is a test seam (nil in production). It fires
+	// after the frame is parsed and before dispatch, so a test can
+	// inject a handler-stage panic and assert the deferred recover
+	// both survives it and answers the in-flight request.
+	if s.dispatchPanicHook != nil {
+		s.dispatchPanicHook()
+	}
 	s.dispatch(ctx, msg)
+}
+
+// recoverPanic is the deferred half of panic containment. It must be
+// deferred directly (`defer s.recoverPanic("scope")`) so its
+// recover() call observes the goroutine's panic.
+func (s *Server) recoverPanic(scope string) {
+	if r := recover(); r != nil {
+		s.logPanic(scope, r)
+	}
+}
+
+// logPanic records a recovered panic with its stack on the server log
+// and forwards the same text as a window/logMessage error so the
+// signal reaches the editor's output channel even when verbose
+// logging is off — the production default: `mdsmith lsp` wires no
+// Logger, so s.logger alone would swallow the only evidence of the
+// contained crash.
+func (s *Server) logPanic(scope string, r any) {
+	stack := debug.Stack()
+	s.logger.Printf("%s: recovered panic: %v\n%s", scope, r, stack)
+	_ = s.t.writeNotification("window/logMessage", logMessageParams{
+		Type: messageTypeError,
+		Message: fmt.Sprintf("mdsmith: recovered panic in %s: %v\n%s",
+			scope, r, stack),
+	})
 }
 
 func (s *Server) dispatch(ctx context.Context, msg *requestMessage) {
@@ -755,6 +796,12 @@ func (s *Server) resolveConfig(override string) (cfg *config.Config, cfgPath, lo
 // Must be called from a goroutine other than the dispatch loop, since
 // the response arrives on the same loop.
 func (s *Server) fetchClientSettings(ctx context.Context) {
+	// This runs on its own goroutine (never the dispatch loop), so a
+	// panic in the response path — config load, schema compile,
+	// session rebuild, the host's OnConfigReload callback — would
+	// kill the whole server without this recover, the same crash
+	// class the lint and dispatch recovers contain.
+	defer s.recoverPanic("fetch client settings")
 	id := s.nextReqID.Add(1)
 	// json.Marshal(int64) cannot fail; ignoring the error is safe.
 	idJSON, _ := json.Marshal(id)

--- a/internal/lsp/server_diagnostics.go
+++ b/internal/lsp/server_diagnostics.go
@@ -243,11 +243,7 @@ func (s *Server) clearOpenDiagnostics() {
 // dropped. The server stays running and that document's diagnostics are
 // left at their previous value for the cycle.
 func (s *Server) runLint(uri string) {
-	defer func() {
-		if r := recover(); r != nil {
-			s.logger.Printf("lint %s: recovered panic: %v", uri, r)
-		}
-	}()
+	defer s.recoverPanic("lint " + uri)
 	doc, ok := s.docs.get(uri)
 	if !ok {
 		return
@@ -280,8 +276,9 @@ func (s *Server) runLint(uri string) {
 		return
 	}
 	// lintPanicHook is a test seam (nil in production). When set, it
-	// replaces the real CheckVersion call so a test can trigger a panic
-	// inside the lint pipeline and verify the deferred recover catches it.
+	// fires just before the real CheckVersion call so a test can
+	// trigger a panic inside the lint pipeline and verify the deferred
+	// recover catches it.
 	if s.lintPanicHook != nil {
 		s.lintPanicHook()
 	}


### PR DESCRIPTION
Follow-up hardening of the panic containment shipped in #545 ([plan/242_lsp-panic-recovery.md](plan/242_lsp-panic-recovery.md), audit finding S001), from its post-merge review.

## What

1. **A panicked request is now answered.** `dispatchRaw`'s recover writes an InternalError (`-32603`) response for the in-flight request ID. Previously the frame was dropped silently: the server survived, but the client's promise (code action, hover, rename…) pended forever — `vscode-languageclient` has no request timeout, so the crash had become a hang. The dispatch panic seam moves after frame parsing, where real handler panics occur, so the test can assert the reply.
2. **Recovery is visible in production.** A shared `logPanic` helper logs the panic with `debug.Stack()` and mirrors the same text to `window/logMessage`. `mdsmith lsp` constructs the server without a `Logger` (disabled by default), so the previous log-only recovery left zero trace in shipped binaries — diagnostics just froze silently.
3. **The third goroutine origin is contained.** `go s.fetchClientSettings(ctx)` runs config load, kind-schema CUE compile, session rebuild, and the host's `OnConfigReload` callback with no recover — the same reload pipeline that was already contained when triggered from the dispatch loop. A deferred `recoverPanic` closes the asymmetry; a hostile workspace config can no longer kill the server via the settings round-trip while surviving via `initialized`.
4. **Comment accuracy.** The lint seam comments claimed the hook "replaces" `CheckVersion` (it fires just before it); a test comment named a nonexistent test and described the InternalError reply as unimplemented — it is now implemented and asserted.

The parent-process and singleton watcher goroutines remain unprotected by choice: they process no untrusted content.

## Tests

All red/green via the existing seams plus the host `OnConfigReload` callback as a real in-frame panic source: the answered-request assertions (`"id":99` + `-32603`), stack-trace presence (`goroutine`), `window/logMessage` surfacing, and `fetchClientSettings` containment. `go test -race ./internal/lsp/`, full `go test ./...`, `golangci-lint`, and `mdsmith check .` all green.

https://claude.ai/code/session_019LXhkAzG4UNYyne1Mgczwf

---
_Generated by [Claude Code](https://claude.ai/code/session_019LXhkAzG4UNYyne1Mgczwf)_