### PR TITLE
fix(merge-driver): never write the worktree path during a merge

### DIFF
--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -2409,6 +2409,103 @@ func TestE2E_PreMergeCommit_ConflictingMergeResolvesWithHookSync(t *testing.T) {
 	assert.Equal(t, 0, code, "check after merge must pass; stderr:\n%s", stderr)
 }
 
+// queueMergeBranch performs one merge exactly the way the merge
+// queue does: `git merge --no-ff --no-commit <branch>`, assert the
+// driver left no unmerged paths, run the pre-merge-commit hook, and
+// `git commit`. Returns after the merge commit exists.
+func queueMergeBranch(t *testing.T, dir, branch string) {
+	t.Helper()
+	mergeOut, mergeErr := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-ff", "--no-commit", branch).CombinedOutput()
+	// `--no-commit` exits non-zero by design; resolution is judged by
+	// the absence of unmerged index paths.
+	require.Empty(t, strings.TrimSpace(gitInDir(t, dir, "ls-files", "-u")),
+		"merge of %s must leave no unmerged paths; exit=%v output:\n%s",
+		branch, mergeErr, mergeOut)
+
+	hook := exec.Command(filepath.Join(gitHooksDir(t, dir), "pre-merge-commit"))
+	hook.Dir = dir
+	hookOut, hookErr := hook.CombinedOutput()
+	require.NoErrorf(t, hookErr, "pre-merge-commit hook failed for %s: %s",
+		branch, hookOut)
+
+	commitOut, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"commit", "--no-edit").CombinedOutput()
+	require.NoErrorf(t, err, "merge commit for %s failed: %s", branch, commitOut)
+}
+
+// TestE2E_MergeQueue_BatchTwoPRs_RightCommits simulates a full
+// merge-queue batch end to end with real git: `ci-install` (the
+// queue's installer), then two PR branches that each regenerate
+// PLAN.md's catalog are merged back to back with the queue's exact
+// sequence (merge --no-ff --no-commit, hook, commit). The second
+// merge must check out results over paths the first merge's driver
+// already processed, so any worktree side effect the driver leaves
+// behind surfaces here. The batch must end with two merge commits,
+// a catalog listing every plan, a clean tree, and a green check.
+func TestE2E_MergeQueue_BatchTwoPRs_RightCommits(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+
+	// install writes the managed .gitattributes; commit it so
+	// ci-install (the queue's verifying installer) can pass later.
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// Two PRs, each bumping its own plan file and regenerating the
+	// shared catalog — the classic queue-batch conflict shape.
+	completePlanOnBranch(t, dir, "pr1", seedSHA, 2)
+	completePlanOnBranch(t, dir, "pr2", seedSHA, 3)
+
+	// The queue starts from a batch branch at main and runs
+	// ci-install, which verifies the committed .gitattributes and
+	// registers the driver + hook without writing tracked files.
+	gitInDir(t, dir, "checkout", "-b", "batch", seedSHA)
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "ci-install")
+	require.Equal(t, 0, code, "ci-install failed: %s", stderr)
+
+	queueMergeBranch(t, dir, "pr1")
+	queueMergeBranch(t, dir, "pr2")
+
+	// Two merge commits on top of seed, in order.
+	subjects := gitInDir(t, dir, "log", "--format=%s", seedSHA+"..HEAD")
+	assert.Equal(t, 2, strings.Count(subjects, "Merge branch"),
+		"batch must contain exactly two merge commits, got:\n%s", subjects)
+
+	// The committed catalog lists every plan with its final status.
+	committedPlan := gitInDir(t, dir, "show", "HEAD:PLAN.md")
+	for _, id := range []string{"1", "2", "3"} {
+		assert.Regexp(t, `\| `+id+` +\|`, committedPlan,
+			"batch PLAN.md must list plan %s; got:\n%s", id, committedPlan)
+	}
+	assert.NotContains(t, committedPlan, "<<<<<<<",
+		"no conflict markers may survive into the batch commits")
+
+	// Clean end state: no stale lock, clean tree, green check.
+	assert.NoFileExists(t, filepath.Join(dir, ".git", "index.lock"),
+		"no stale .git/index.lock may remain after the batch")
+	status := strings.TrimSpace(gitInDir(t, dir, "status", "--porcelain"))
+	assert.Empty(t, status,
+		"worktree must be clean after the batch; got:\n%s", status)
+	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code, "check after batch must pass; stderr:\n%s", stderr)
+}
+
 // TestE2E_PreMergeCommit_NoCommitMergeCapturesBoth exercises the
 // invocation model the merge queue uses: `git merge --no-ff
 // --no-commit`, then the pre-merge-commit hook, then a separate `git

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -2074,6 +2074,230 @@ func TestE2E_MergeDriver_RebasePick_Succeeds(t *testing.T) {
 		"check after rebase + fix must pass; stderr:\n%s", stderr)
 }
 
+// TestE2E_MergeDriver_CherryPick_Succeeds covers the third real-git
+// replay path next to merge and rebase: a cherry-pick performs the
+// same 3-way merge as a rebase pick, so it would have hit the same
+// stale-stat abort with the old worktree-writing driver.
+func TestE2E_MergeDriver_CherryPick_Succeeds(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	completePlanOnBranch(t, dir, "ours", seedSHA, 1)
+	completePlanOnBranch(t, dir, "theirs", seedSHA, 2)
+	theirsSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "theirs"))
+
+	gitInDir(t, dir, "checkout", "ours")
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"cherry-pick", theirsSHA).CombinedOutput()
+	require.NoError(t, err, "git cherry-pick failed: %s", out)
+
+	_, statErr := os.Stat(filepath.Join(dir, ".git", "CHERRY_PICK_HEAD"))
+	assert.True(t, os.IsNotExist(statErr),
+		"cherry-pick must not be left in progress")
+	status := gitInDir(t, dir, "status", "--porcelain", "--untracked-files=no")
+	assert.Empty(t, strings.TrimSpace(status),
+		"tracked files must be clean after the cherry-pick, got:\n%s", status)
+
+	for _, path := range []string{"plan/01.md", "plan/02.md"} {
+		data, err := os.ReadFile(filepath.Join(dir, path))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `status: "✅"`,
+			"%s status must be ✅ after cherry-pick", path)
+	}
+
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "post-cherry-pick fix failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code,
+		"check after cherry-pick + fix must pass; stderr:\n%s", stderr)
+}
+
+// TestE2E_MergeDriver_RebaseMultiFile_Succeeds replays a pick where
+// the driver runs on THREE both-sides-modified files in one merge —
+// a catalog file, an include file, and the include's plain-prose
+// source. This is the shape of the rebase that exposed the
+// worktree-write bug: one stat-dirtied path is enough to abort the
+// pick, and a multi-file pick multiplies the chances. The pick must
+// complete in one shot with every generated section resolved.
+func TestE2E_MergeDriver_RebaseMultiFile_Succeeds(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+	writeFixture(t, dir, "NOTES.md",
+		"# Notes\n\nalpha line stays.\n\nbravo line stays.\n")
+	writeFixture(t, dir, "DOC.md",
+		"# Doc\n\n<?include\nfile: NOTES.md\nheading-level: \"2\"\n?>\n<?/include?>\n")
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// ours: bump plan 01, edit NOTES line 1, regenerate everything.
+	gitInDir(t, dir, "checkout", "-b", "ours", seedSHA)
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "✅", 1))
+	writeFixture(t, dir, "NOTES.md",
+		"# Notes\n\nalpha line changed by ours.\n\nbravo line stays.\n")
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "ours fix failed: %s", stderr)
+	gitCommit(t, dir, "ours: plan 1 + alpha edit")
+
+	// theirs: bump plan 02, edit NOTES line 2, regenerate everything.
+	gitInDir(t, dir, "checkout", "-b", "theirs", seedSHA)
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "✅", 2))
+	writeFixture(t, dir, "NOTES.md",
+		"# Notes\n\nalpha line stays.\n\nbravo line changed by theirs.\n")
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "theirs fix failed: %s", stderr)
+	gitCommit(t, dir, "theirs: plan 2 + bravo edit")
+
+	gitInDir(t, dir, "checkout", "ours")
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"rebase", "theirs").CombinedOutput()
+	require.NoError(t, err, "multi-file rebase failed: %s", out)
+
+	_, statErr := os.Stat(filepath.Join(dir, ".git", "rebase-merge"))
+	assert.True(t, os.IsNotExist(statErr),
+		"rebase must not be left in progress")
+	status := gitInDir(t, dir, "status", "--porcelain", "--untracked-files=no")
+	assert.Empty(t, strings.TrimSpace(status),
+		"tracked files must be clean after the rebase, got:\n%s", status)
+
+	// Both prose edits to the include source must survive the replay.
+	notes, err := os.ReadFile(filepath.Join(dir, "NOTES.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(notes), "alpha line changed by ours")
+	assert.Contains(t, string(notes), "bravo line changed by theirs")
+
+	// No generated section may carry conflict markers.
+	for _, path := range []string{"PLAN.md", "DOC.md"} {
+		data, err := os.ReadFile(filepath.Join(dir, path))
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "<<<<<<<",
+			"%s must not carry conflict markers", path)
+	}
+
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "post-rebase fix failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code,
+		"check after rebase + fix must pass; stderr:\n%s", stderr)
+}
+
+// TestE2E_MergeDriver_RealMerge_ProseConflict_AbortRestores drives
+// the driver's failure path through real git: a conflict in
+// hand-written prose is not resolvable, so the driver exits 1, git
+// must record the path as unmerged with markers in the worktree,
+// and `git merge --abort` must restore the pre-merge tree exactly —
+// proving the failed driver run left no stray writes behind.
+func TestE2E_MergeDriver_RealMerge_ProseConflict_AbortRestores(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml", "rules:\n  catalog: true\n")
+	writeFixture(t, dir, "NOTES.md", "# Notes\n\noriginal line here.\n")
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	oursContent := "# Notes\n\nours change here.\n"
+	gitInDir(t, dir, "checkout", "-b", "ours", seedSHA)
+	writeFixture(t, dir, "NOTES.md", oursContent)
+	gitCommit(t, dir, "ours edit")
+	gitInDir(t, dir, "checkout", "-b", "theirs", seedSHA)
+	writeFixture(t, dir, "NOTES.md", "# Notes\n\ntheirs change here.\n")
+	gitCommit(t, dir, "theirs edit")
+	gitInDir(t, dir, "checkout", "ours")
+
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-ff", "theirs").CombinedOutput()
+	require.Error(t, err, "prose conflict must stop the merge, got:\n%s", out)
+
+	// git must record the unmerged path and leave markers in place.
+	require.Contains(t, gitInDir(t, dir, "ls-files", "-u"), "NOTES.md",
+		"NOTES.md must be recorded as unmerged")
+	data, readErr := os.ReadFile(filepath.Join(dir, "NOTES.md"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "<<<<<<<")
+	assert.Contains(t, string(data), "ours change here.")
+	assert.Contains(t, string(data), "theirs change here.")
+
+	// Abort must restore the pre-merge state cleanly.
+	abortOut, abortErr := exec.Command("git", "-C", dir,
+		"merge", "--abort").CombinedOutput()
+	require.NoError(t, abortErr, "merge --abort failed: %s", abortOut)
+	status := gitInDir(t, dir, "status", "--porcelain", "--untracked-files=no")
+	assert.Empty(t, strings.TrimSpace(status),
+		"tracked files must be clean after abort, got:\n%s", status)
+	data, readErr = os.ReadFile(filepath.Join(dir, "NOTES.md"))
+	require.NoError(t, readErr)
+	assert.Equal(t, oursContent, string(data),
+		"abort must restore the pre-merge ours content")
+}
+
+// TestE2E_MergeDriver_RealMerge_Diff3SectionConflict_Resolved pins
+// diff3 conflict-marker handling through real git. With
+// merge.conflictstyle=diff3 the driver's internal `git merge-file`
+// emits ||||||| base sections inside the conflicted generated
+// block; stripSectionConflicts must strip those too, and the
+// regeneration replaces any leftover base lines.
+func TestE2E_MergeDriver_RealMerge_Diff3SectionConflict_Resolved(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := setupConflictingMergeRepo(t)
+	gitInDir(t, dir, "config", "merge.conflictstyle", "diff3")
+
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-ff", "-m", "merge theirs", "theirs").CombinedOutput()
+	require.NoError(t, err, "git merge failed: %s", out)
+
+	plan, readErr := os.ReadFile(filepath.Join(dir, "PLAN.md"))
+	require.NoError(t, readErr)
+	planStr := string(plan)
+	for _, id := range []string{"1", "2", "3"} {
+		assert.Regexp(t, `\| `+id+` +\|`, planStr,
+			"merged PLAN.md catalog must list plan %s; got:\n%s", id, planStr)
+	}
+	for _, marker := range []string{"<<<<<<<", ">>>>>>>", "|||||||"} {
+		assert.NotContains(t, planStr, marker,
+			"no %s marker may survive the diff3 merge", marker)
+	}
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code,
+		"check after diff3 merge must pass; stderr:\n%s", stderr)
+}
+
 // setupConflictingMergeRepo builds a repo whose `ours` and `theirs`
 // branches both regenerate PLAN.md's catalog (ours adds plan 02,
 // theirs adds plan 03), so merging conflicts inside the generated

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -2002,6 +2002,78 @@ func TestE2E_MergeDriver_FileOrderingRace_Resolved(t *testing.T) {
 		"check after merge must pass; stderr:\n%s", stderr)
 }
 
+// TestE2E_MergeDriver_RebasePick_Succeeds is the rebase twin of the
+// FileOrderingRace merge test. A rebase pick performs the same 3-way
+// merge, but git verifies worktree paths are up to date against
+// cached stat data before checking out the result. The old driver
+// wrote-and-restored %P in the worktree, bumping its mtime, so the
+// pick aborted with "Your local changes ... would be overwritten"
+// and git rescheduled it — every retry hit the same wall, so the
+// rebase could never finish. The driver must leave the rebase able
+// to complete in one shot with a clean worktree.
+func TestE2E_MergeDriver_RebasePick_Succeeds(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml",
+		"rules:\n  catalog: true\n  include: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
+	writeFixture(t, dir, "PLAN.md", planMdTmpl)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "PLAN.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// Both branches modify PLAN.md (regenerated catalog) plus their
+	// own plan file, so the rebase pick merges PLAN.md via the driver.
+	completePlanOnBranch(t, dir, "ours", seedSHA, 1)
+	completePlanOnBranch(t, dir, "theirs", seedSHA, 2)
+
+	gitInDir(t, dir, "checkout", "ours")
+	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+
+	// Replay ours on top of theirs. With the old worktree-writing
+	// driver this exits non-zero with the pick rescheduled.
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"rebase", "theirs").CombinedOutput()
+	require.NoError(t, err, "git rebase failed: %s", out)
+
+	// The rebase must have fully completed, not stopped mid-pick.
+	_, statErr := os.Stat(filepath.Join(dir, ".git", "rebase-merge"))
+	assert.True(t, os.IsNotExist(statErr),
+		"rebase must not be left in progress")
+
+	// No driver-induced modifications to tracked files may remain.
+	// (install drops an untracked .gitattributes; that is setup, not
+	// driver output, so untracked files are excluded.)
+	status := gitInDir(t, dir, "status", "--porcelain", "--untracked-files=no")
+	assert.Empty(t, strings.TrimSpace(status),
+		"tracked files must be clean after the rebase, got:\n%s", status)
+
+	// Both plan bumps survive the replay. (Rebase runs no
+	// pre-merge-commit hook, so PLAN.md's catalog may need one
+	// `mdsmith fix` — the documented post-rebase step — but the
+	// plan files themselves must hold both ✅ states.)
+	for _, path := range []string{"plan/01.md", "plan/02.md"} {
+		data, err := os.ReadFile(filepath.Join(dir, path))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `status: "✅"`,
+			"%s status must be ✅ after rebase", path)
+	}
+
+	// One fix pass settles the catalog; check must then be clean.
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "post-rebase fix failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code,
+		"check after rebase + fix must pass; stderr:\n%s", stderr)
+}
+
 // setupConflictingMergeRepo builds a repo whose `ours` and `theirs`
 // branches both regenerate PLAN.md's catalog (ours adds plan 02,
 // theirs adds plan 03), so merging conflicts inside the generated

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -2128,14 +2128,14 @@ func TestE2E_MergeDriver_CherryPick_Succeeds(t *testing.T) {
 		"check after cherry-pick + fix must pass; stderr:\n%s", stderr)
 }
 
-// TestE2E_MergeDriver_RebaseMultiFile_Succeeds replays a pick where
-// the driver runs on THREE both-sides-modified files in one merge —
-// a catalog file, an include file, and the include's plain-prose
-// source. This is the shape of the rebase that exposed the
-// worktree-write bug: one stat-dirtied path is enough to abort the
-// pick, and a multi-file pick multiplies the chances. The pick must
-// complete in one shot with every generated section resolved.
-func TestE2E_MergeDriver_RebaseMultiFile_Succeeds(t *testing.T) {
+// setupMultiFileRebaseRepo builds a repo whose ours and theirs
+// branches each modify three driver-managed files — PLAN.md's
+// catalog, DOC.md's include body, and NOTES.md, the include's
+// plain-prose source (non-overlapping line edits) — and installs
+// the merge driver. ours is left checked out, ready to rebase
+// onto theirs.
+func setupMultiFileRebaseRepo(t *testing.T) string {
+	t.Helper()
 	dir := t.TempDir()
 	gitInit(t, dir)
 
@@ -2176,6 +2176,18 @@ func TestE2E_MergeDriver_RebaseMultiFile_Succeeds(t *testing.T) {
 	gitInDir(t, dir, "checkout", "ours")
 	_, stderr, code = runBinaryInDir(t, dir, "", "merge-driver", "install")
 	require.Equal(t, 0, code, "install failed: %s", stderr)
+	return dir
+}
+
+// TestE2E_MergeDriver_RebaseMultiFile_Succeeds replays a pick where
+// the driver runs on THREE both-sides-modified files in one merge —
+// a catalog file, an include file, and the include's plain-prose
+// source. This is the shape of the rebase that exposed the
+// worktree-write bug: one stat-dirtied path is enough to abort the
+// pick, and a multi-file pick multiplies the chances. The pick must
+// complete in one shot with every generated section resolved.
+func TestE2E_MergeDriver_RebaseMultiFile_Succeeds(t *testing.T) {
+	dir := setupMultiFileRebaseRepo(t)
 
 	out, err := exec.Command("git", "-C", dir,
 		"-c", "commit.gpgsign=false",
@@ -2203,7 +2215,7 @@ func TestE2E_MergeDriver_RebaseMultiFile_Succeeds(t *testing.T) {
 			"%s must not carry conflict markers", path)
 	}
 
-	_, stderr, code = runBinaryInDir(t, dir, "", "fix", ".")
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", ".")
 	require.Equal(t, 0, code, "post-rebase fix failed: %s", stderr)
 	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
 	assert.Equal(t, 0, code,

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -1523,6 +1523,69 @@ func TestE2E_MergeDriver_CatalogConflict_Resolved(t *testing.T) {
 	assert.NotContains(t, content, "<<<<<<<", "expected no conflict markers after merge-driver")
 }
 
+// TestE2E_MergeDriver_Run_LeavesWorktreeUntouched pins the driver's
+// no-worktree-writes contract. The driver used to copy the merged
+// content to %P, run fix there, and restore the original bytes. The
+// restore is byte-identical but rewrites the file, so its stat data
+// (mtime) changes while the parent merge is still in flight. Git's
+// up-to-date check compares cached stat data, so it then treats the
+// path as locally modified and aborts the very merge that invoked
+// the driver ("Your local changes ... would be overwritten") — and
+// a `git rebase` pick that hits this is rescheduled forever. The
+// driver must write only %A.
+func TestE2E_MergeDriver_Run_LeavesWorktreeUntouched(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+
+	writeFixture(t, dir, ".mdsmith.yml", "rules:\n  catalog: true\n")
+
+	catalogBase := "# Doc\n\n<?catalog\nglob: \"plans/*.md\"\nsort: title\n" +
+		"header: |\n  | Title |\n  |-------|\nrow: \"| [{title}]({filename}) |\"\n?>\n" +
+		"| Title       |\n|-------------|\n| [Alpha](plans/alpha.md) |\n<?/catalog?>\n"
+	catalogOurs := "# Doc\n\n<?catalog\nglob: \"plans/*.md\"\nsort: title\n" +
+		"header: |\n  | Title |\n  |-------|\nrow: \"| [{title}]({filename}) |\"\n?>\n" +
+		"| Title       |\n|-------------|\n| [Alpha](plans/alpha.md) |\n| [Beta](plans/beta.md) |\n<?/catalog?>\n"
+	catalogTheirs := "# Doc\n\n<?catalog\nglob: \"plans/*.md\"\nsort: title\n" +
+		"header: |\n  | Title |\n  |-------|\nrow: \"| [{title}]({filename}) |\"\n?>\n" +
+		"| Title       |\n|-------------|\n| [Alpha](plans/alpha.md) |\n" +
+		"| [Gamma](plans/gamma.md) |\n<?/catalog?>\n"
+
+	base := writeFixture(t, dir, "base.md", catalogBase)
+	ours := writeFixture(t, dir, "ours.md", catalogOurs)
+	theirs := writeFixture(t, dir, "theirs.md", catalogTheirs)
+	pathname := writeFixture(t, dir, "CATALOG.md", catalogOurs)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plans"), 0o755))
+	writeFixture(t, dir, "plans/alpha.md", "---\ntitle: Alpha\n---\n\n# Alpha\n\nContent.\n")
+	writeFixture(t, dir, "plans/beta.md", "---\ntitle: Beta\n---\n\n# Beta\n\nContent.\n")
+	writeFixture(t, dir, "plans/gamma.md", "---\ntitle: Gamma\n---\n\n# Gamma\n\nContent.\n")
+
+	before, err := os.Lstat(pathname)
+	require.NoError(t, err)
+
+	_, stderr, exitCode := runBinaryInDir(t, dir, "", "merge-driver", "run", base, ours, theirs, pathname)
+	assert.Equal(t, 0, exitCode, "expected exit 0, got %d; stderr: %s", exitCode, stderr)
+
+	// The regenerated result must land in ours (%A) with both rows.
+	result, _ := os.ReadFile(ours)
+	content := string(result)
+	assert.NotContains(t, content, "<<<<<<<", "expected no conflict markers after merge-driver")
+	assert.Contains(t, content, "plans/beta.md", "fix must regenerate the catalog from neighbour files")
+	assert.Contains(t, content, "plans/gamma.md", "fix must regenerate the catalog from neighbour files")
+
+	// The worktree path (%P) must be untouched: same bytes AND same
+	// stat data — a byte-identical rewrite still bumps mtime.
+	after, err := os.Lstat(pathname)
+	require.NoError(t, err)
+	assert.True(t, before.ModTime().Equal(after.ModTime()),
+		"merge driver wrote the worktree path: mtime changed %v -> %v",
+		before.ModTime(), after.ModTime())
+	worktree, err := os.ReadFile(pathname)
+	require.NoError(t, err)
+	assert.Equal(t, catalogOurs, string(worktree),
+		"worktree content must be byte-identical after merge-driver run")
+}
+
 func TestE2E_MergeDriver_NonCatalogConflict_ExitsOne(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jeduden/mdsmith/internal/githooks"
 	"github.com/jeduden/mdsmith/internal/testsymlink"
@@ -2220,6 +2221,106 @@ func TestE2E_MergeDriver_RebaseMultiFile_Succeeds(t *testing.T) {
 	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
 	assert.Equal(t, 0, code,
 		"check after rebase + fix must pass; stderr:\n%s", stderr)
+}
+
+// setupAgedPickRepo reproduces the repo shape of the PR #553
+// incident. CATALOG.md carries a catalog plus hand prose; HEAD and
+// the feature branch both regenerate the catalog, and the feature
+// commit also edits the prose, so a pick of it must run the driver
+// AND check out a result that differs from the worktree. The file
+// is then aged: its mtime is moved into the past and the index
+// refreshed, so the index records stat data older than the index
+// itself — exactly the state of any repo that was not created
+// milliseconds ago. Git then trusts stat instead of re-hashing, so
+// a driver that bumps the file's mtime mid-merge (the old
+// write-and-restore behavior) makes the pick abort with "Your
+// local changes ... would be overwritten". Returns the repo dir
+// and the feature commit to pick.
+func setupAgedPickRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFixture(t, dir, ".mdsmith.yml", "rules:\n  catalog: true\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plan"), 0o755))
+	writeFixture(t, dir, "plan/01.md", fmt.Sprintf(planTmpl, 1, 1, "🔲", 1))
+	writeFixture(t, dir, "CATALOG.md",
+		"# Plans\n\nIntro line, version zero.\n\n"+
+			"<?catalog\nglob:\n  - \"plan/*.md\"\nsort: id\n"+
+			"row: \"- [{title}]({filename})\"\n?>\n<?/catalog?>\n")
+	_, stderr, code := runBinaryInDir(t, dir, "", "merge-driver", "install")
+	require.Equal(t, 0, code, "install failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "CATALOG.md")
+	require.Equal(t, 0, code, "seed fix failed: %s", stderr)
+	gitCommit(t, dir, "seed")
+	seedSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// feature: add plan 03, edit the prose line, regenerate.
+	gitInDir(t, dir, "checkout", "-b", "feature", seedSHA)
+	writeFixture(t, dir, "plan/03.md", fmt.Sprintf(planTmpl, 3, 3, "🔲", 3))
+	data, err := os.ReadFile(filepath.Join(dir, "CATALOG.md"))
+	require.NoError(t, err)
+	writeFixture(t, dir, "CATALOG.md", strings.Replace(string(data),
+		"Intro line, version zero.", "Intro line, version two.", 1))
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "CATALOG.md")
+	require.Equal(t, 0, code, "feature fix failed: %s", stderr)
+	gitCommit(t, dir, "feature: plan 3 + prose edit")
+	featureSHA := strings.TrimSpace(gitInDir(t, dir, "rev-parse", "HEAD"))
+
+	// HEAD moves on independently: add plan 02, regenerate.
+	gitInDir(t, dir, "checkout", "-b", "trunk", seedSHA)
+	writeFixture(t, dir, "plan/02.md", fmt.Sprintf(planTmpl, 2, 2, "🔲", 2))
+	_, stderr, code = runBinaryInDir(t, dir, "", "fix", "CATALOG.md")
+	require.Equal(t, 0, code, "trunk fix failed: %s", stderr)
+	gitCommit(t, dir, "trunk: plan 2")
+
+	// Age CATALOG.md and refresh, so its recorded stat is strictly
+	// older than the index — git now trusts stat over content.
+	aged := time.Now().Add(-time.Minute)
+	require.NoError(t, os.Chtimes(filepath.Join(dir, "CATALOG.md"), aged, aged))
+	gitInDir(t, dir, "update-index", "--refresh")
+	return dir, featureSHA
+}
+
+// TestE2E_MergeDriver_AgedWorktree_CherryPick_Succeeds is the
+// portable reproduction of the PR #553 incident: in a settled
+// worktree, a pick that both-modifies a driver-managed file used
+// to abort with "Your local changes ... would be overwritten" and
+// be rescheduled forever, because the old driver's byte-identical
+// write-and-restore of %P bumped its mtime while git trusted the
+// file's (older) recorded stat. A cherry-pick is used because it
+// runs the identical 3-way pick machinery without a preceding
+// branch checkout, which would re-freshen the aged file and let
+// git's racy-stat re-hash mask the regression.
+func TestE2E_MergeDriver_AgedWorktree_CherryPick_Succeeds(t *testing.T) {
+	dir, featureSHA := setupAgedPickRepo(t)
+
+	out, err := exec.Command("git", "-C", dir,
+		"-c", "commit.gpgsign=false",
+		"cherry-pick", featureSHA).CombinedOutput()
+	require.NoError(t, err,
+		"cherry-pick must complete; the old worktree-writing driver "+
+			"aborts here with 'local changes would be overwritten': %s", out)
+
+	_, statErr := os.Stat(filepath.Join(dir, ".git", "CHERRY_PICK_HEAD"))
+	assert.True(t, os.IsNotExist(statErr),
+		"cherry-pick must not be left in progress")
+
+	catalog, readErr := os.ReadFile(filepath.Join(dir, "CATALOG.md"))
+	require.NoError(t, readErr)
+	content := string(catalog)
+	assert.Contains(t, content, "Intro line, version two.",
+		"the picked prose edit must land")
+	assert.NotContains(t, content, "<<<<<<<", "no conflict markers")
+
+	status := gitInDir(t, dir, "status", "--porcelain", "--untracked-files=no")
+	assert.Empty(t, strings.TrimSpace(status),
+		"tracked files must be clean after the pick, got:\n%s", status)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", ".")
+	require.Equal(t, 0, code, "post-pick fix failed: %s", stderr)
+	_, stderr, code = runBinaryInDir(t, dir, "", "check", ".")
+	assert.Equal(t, 0, code, "check after pick + fix must pass; stderr:\n%s", stderr)
 }
 
 // TestE2E_MergeDriver_RealMerge_ProseConflict_AbortRestores drives

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/bytelimit"
 	fixpkg "github.com/jeduden/mdsmith/internal/fix"
 	"github.com/jeduden/mdsmith/internal/githooks"
-	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
@@ -22,8 +21,11 @@ Subcommands:
   run <base> <ours> <theirs> <pathname>
         Run as a git custom merge driver. Strips conflict
         markers inside regenerable sections (catalog, include),
-        runs mdsmith fix to regenerate them, and exits non-zero
-        if unresolved conflict markers remain.
+        runs mdsmith fix in memory to regenerate them, and exits
+        non-zero if unresolved conflict markers remain. Only the
+        <ours> temp file is written; the worktree <pathname> is
+        never touched, so the parent merge or rebase never sees
+        the path as locally modified.
 
   install [globs...]
         Register the merge driver in git config and ensure
@@ -134,13 +136,10 @@ var guardFn = guardRegularFile
 // to exercise error paths without needing OS tricks.
 var osWriteFile = os.WriteFile
 
-// readFileLimited is a variable so tests can substitute a failing
-// implementation to exercise the read-fixed-file error path in readAndRestore.
-var readFileLimited = bytelimit.ReadFileLimited
-
-// fixFileInPlaceFn is a variable so tests can substitute a failing
-// implementation to exercise the fix-failed error path in fixAtRealPath.
-var fixFileInPlaceFn = fixFileInPlace
+// fixSourceFn is a variable so tests can substitute a failing
+// implementation to exercise the fix-failed error path in
+// fixMergedContent.
+var fixSourceFn = fixMergedSource
 
 // mergeAndClean performs the 3-way merge and strips conflict markers.
 // Returns the cleaned content and an exit code (0 on success).
@@ -239,9 +238,15 @@ func runMergeDriverRun(args []string) int {
 		return rc
 	}
 
-	// Step 3: run mdsmith fix at the real path and write result
-	// back to ours.
-	fixed, rc := fixAtRealPath(cleaned, ours, pathname, maxBytes)
+	// Step 3: run mdsmith fix on the merged content in memory and
+	// write the result to ours. The worktree path (%P) is never
+	// written: the driver runs while the parent merge is still in
+	// flight, and even a byte-identical write-and-restore changes
+	// the file's stat data, which makes git's up-to-date check
+	// treat the path as locally modified and abort the merge with
+	// "Your local changes would be overwritten" — under git rebase
+	// the pick is rescheduled forever.
+	fixed, rc := fixMergedContent(cleaned, ours, pathname, maxBytes)
 	if rc != 0 {
 		return rc
 	}
@@ -257,45 +262,17 @@ func runMergeDriverRun(args []string) int {
 	return 0
 }
 
-// fixAtRealPath writes cleaned content to pathname, runs mdsmith
-// fix, copies the result to ours, and restores pathname.
-func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byte, int) {
-	pathnameMode := mergeFileMode(pathname, 0o644)
-	oursMode := mergeFileMode(ours, 0o644)
-
-	if err := guardFn(pathname); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
+// fixMergedContent runs the mdsmith fix pipeline on cleaned in
+// memory — anchored at pathname so config globs and neighbour-file
+// reads resolve as they would for the real file — and writes the
+// result to ours. pathname itself is never read or written; see
+// runMergeDriverRun step 3 for why a worktree write (even one
+// restored byte-for-byte) aborts the parent merge.
+func fixMergedContent(cleaned []byte, ours, pathname string, maxBytes int64) ([]byte, int) {
+	fixed, err := fixSourceFn(pathname, cleaned, maxBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith: fix failed: %v\n", err)
 		return nil, 2
-	}
-	if err := guardFn(ours); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return nil, 2
-	}
-	backup, backupErr := bytelimit.ReadFileLimited(pathname, maxBytes)
-	if backupErr != nil && !os.IsNotExist(backupErr) {
-		fmt.Fprintf(os.Stderr, "mdsmith: reading %s for backup: %v\n", pathname, backupErr)
-		return nil, 2
-	}
-	// Re-check immediately before writing to narrow the TOCTOU window.
-	if err := guardFn(pathname); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return nil, 2
-	}
-	if err := osWriteFile(pathname, cleaned, pathnameMode); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: writing to %s: %v\n", pathname, err)
-		return nil, 2
-	}
-
-	fixErr := fixFileInPlaceFn(pathname, maxBytes)
-
-	fixed, code := readAndRestore(pathname, backup, backupErr, pathnameMode, maxBytes)
-	if code != 0 {
-		return fixed, code
-	}
-
-	if fixErr != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: fix failed: %v\n", fixErr)
-		return fixed, 2
 	}
 
 	// Re-check ours immediately before writing the final merge result.
@@ -303,47 +280,9 @@ func fixAtRealPath(cleaned []byte, ours, pathname string, maxBytes int64) ([]byt
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2
 	}
-	if err := osWriteFile(ours, fixed, oursMode); err != nil {
+	if err := osWriteFile(ours, fixed, mergeFileMode(ours, 0o644)); err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: writing merge output: %v\n", err)
 		return nil, 2
-	}
-	return fixed, 0
-}
-
-// readAndRestore reads the fixed content from pathname, restores its original
-// content (or removes it if it did not previously exist), and returns the fixed
-// bytes. A non-zero exit code means the caller should propagate the error.
-func readAndRestore(pathname string, backup []byte, backupErr error, mode os.FileMode, maxBytes int64) ([]byte, int) {
-	// Re-check before reading the fixed result to guard against a symlink swap.
-	if err := guardFn(pathname); err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-		return nil, 2
-	}
-	fixed, err := readFileLimited(pathname, maxBytes)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: reading fixed file: %v\n", err)
-		return nil, 2
-	}
-
-	var restoreErr error
-	if backupErr == nil {
-		// Re-check before restore to narrow TOCTOU window.
-		if err := guardFn(pathname); err != nil {
-			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-			return fixed, 2
-		}
-		restoreErr = osWriteFile(pathname, backup, mode)
-	} else if os.IsNotExist(backupErr) {
-		// Re-check before removal to avoid removing a swapped-in directory.
-		if err := guardFn(pathname); err != nil {
-			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
-			return fixed, 2
-		}
-		restoreErr = os.Remove(pathname)
-	}
-	if restoreErr != nil {
-		fmt.Fprintf(os.Stderr, "mdsmith: restoring %s: %v\n", pathname, restoreErr)
-		return fixed, 2
 	}
 	return fixed, 0
 }
@@ -376,26 +315,26 @@ func mergeDriverRules() []rule.Rule {
 	return out
 }
 
-// fixFileInPlace runs the mdsmith fix pipeline on a single file.
-func fixFileInPlace(path string, maxBytes int64) error {
+// fixMergedSource runs the merge driver's fix rule set over source
+// in memory and returns the fixed bytes. path anchors config-glob
+// matching, and — because git invokes merge drivers from the
+// worktree root — the dirFS derived from it resolves neighbour
+// files (include sources, catalog globs) exactly as a fix of the
+// on-disk file would. Nothing is written to disk.
+func fixMergedSource(path string, source []byte, maxBytes int64) ([]byte, error) {
 	cfg, _, err := loadConfig("")
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
-	fixer := &fixpkg.Fixer{
+	return fixpkg.Source(fixpkg.SourceOptions{
 		Config:           cfg,
 		Rules:            mergeDriverRules(),
+		Path:             path,
+		Source:           source,
 		StripFrontMatter: frontMatterEnabled(cfg),
-		Logger:           &vlog.Logger{},
 		MaxInputBytes:    maxBytes,
-	}
-
-	result := fixer.Fix([]string{path})
-	if len(result.Errors) > 0 {
-		return result.Errors[0]
-	}
-	return nil
+	})
 }
 
 // regenDirectiveNames returns the directive names whose content

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -1045,337 +1045,196 @@ func TestMergeAndClean_WriteFileFails_ExitsTwo(t *testing.T) {
 	assert.Contains(t, got, "writing cleaned merge")
 }
 
-func TestFixAtRealPath_WriteToPathnameFails_ExitsTwo(t *testing.T) {
+func TestFixMergedContent_FixFails_ExitsTwo(t *testing.T) {
 	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	content := []byte("# Hello\n")
-	pathname := filepath.Join(dir, "PLAN.md")
 	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, content, 0o644))
-	require.NoError(t, os.WriteFile(ours, content, 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
 
-	orig := osWriteFile
-	t.Cleanup(func() { osWriteFile = orig })
-	osWriteFile = func(name string, data []byte, perm os.FileMode) error {
-		if name == pathname {
-			return fmt.Errorf("mock: write to pathname failed")
-		}
-		return os.WriteFile(name, data, perm)
+	orig := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = orig })
+	fixSourceFn = func(string, []byte, int64) ([]byte, error) {
+		return nil, fmt.Errorf("mock fix failure")
 	}
 
 	got := captureStderr(func() {
-		_, code := fixAtRealPath(content, ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "writing to")
-}
-
-func TestFixAtRealPath_WriteToOursFails_ExitsTwo(t *testing.T) {
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	content := []byte("# Hello\n")
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, content, 0o644))
-	require.NoError(t, os.WriteFile(ours, content, 0o644))
-
-	orig := osWriteFile
-	t.Cleanup(func() { osWriteFile = orig })
-	osWriteFile = func(name string, data []byte, perm os.FileMode) error {
-		if name == ours {
-			return fmt.Errorf("mock: write to ours failed")
-		}
-		return os.WriteFile(name, data, perm)
-	}
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath(content, ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "writing merge output")
-}
-
-// guardCallN returns a guardFn replacement that delegates to the real
-// guardRegularFile for the first n-1 calls, then returns an error on call n,
-// then delegates again for all subsequent calls.
-func guardCallN(n int, msg string) func(string) error {
-	var calls int
-	return func(path string) error {
-		calls++
-		if calls == n {
-			return fmt.Errorf("%s: %s", path, msg)
-		}
-		return guardRegularFile(path)
-	}
-}
-
-func TestFixAtRealPath_ThirdGuardFails_ExitsTwo(t *testing.T) {
-	// 3rd guardFn call = re-check of pathname immediately before write.
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	orig := guardFn
-	t.Cleanup(func() { guardFn = orig })
-	guardFn = guardCallN(3, "injected pre-write guard")
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "injected pre-write guard")
-}
-
-func TestFixAtRealPath_FourthGuardFails_ExitsTwo(t *testing.T) {
-	// guardFn call sequence in fixAtRealPath + readAndRestore (backup exists):
-	//   1 = pathname, 2 = ours (start), 3 = pathname pre-write,
-	//   4 = pathname pre-read (readAndRestore), 5 = pathname pre-restore,
-	//   6 = ours pre-final-write
-	// This test exercises call 4 (pre-read guard in readAndRestore).
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	orig := guardFn
-	t.Cleanup(func() { guardFn = orig })
-	guardFn = guardCallN(4, "injected pre-read guard")
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "injected pre-read guard")
-}
-
-func TestFixAtRealPath_FifthGuardFails_ExitsTwo(t *testing.T) {
-	// guardFn call 5 = re-check of pathname before restore write.
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	orig := guardFn
-	t.Cleanup(func() { guardFn = orig })
-	guardFn = guardCallN(5, "injected pre-restore guard")
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "injected pre-restore guard")
-}
-
-func TestFixAtRealPath_SixthGuardFails_ExitsTwo(t *testing.T) {
-	// guardFn call 6 = re-check of ours before final write.
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	orig := guardFn
-	t.Cleanup(func() { guardFn = orig })
-	guardFn = guardCallN(6, "injected pre-ours-write guard")
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "injected pre-ours-write guard")
-}
-
-func TestFixAtRealPath_FixFails_ExitsTwo(t *testing.T) {
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	orig := fixFileInPlaceFn
-	t.Cleanup(func() { fixFileInPlaceFn = orig })
-	fixFileInPlaceFn = func(string, int64) error {
-		return fmt.Errorf("mock fix failure")
-	}
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		_, code := fixMergedContent([]byte("# Hello\n"), ours, "PLAN.md", 1<<20)
 		assert.Equal(t, 2, code)
 	})
 	assert.Contains(t, got, "fix failed")
 }
 
-func TestFixAtRealPath_PathnameNotExist_RemovesAfterFix(t *testing.T) {
-	// When pathname doesn't exist before the merge, fixAtRealPath should
-	// remove the temp file it created rather than restoring non-existent content.
+func TestFixMergedContent_GuardOursFails_ExitsTwo(t *testing.T) {
 	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "newfile.md")
-	ours := filepath.Join(dir, "ours.md")
-	// pathname does NOT exist — backup will be ENOENT.
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	fixed, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
-	assert.Equal(t, 0, code)
-	assert.NotEmpty(t, fixed)
-	// pathname should have been removed after the fix cycle.
-	_, statErr := os.Stat(pathname)
-	assert.True(t, os.IsNotExist(statErr), "pathname should be removed after fix")
-}
-
-func TestFixAtRealPath_GuardBeforeRemoveFails_ExitsTwo(t *testing.T) {
-	// 6th guardFn call = re-check of pathname before os.Remove in the
-	// ENOENT-backup branch of readAndRestore.
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "newfile.md")
 	ours := filepath.Join(dir, "ours.md")
 	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, src []byte, _ int64) ([]byte, error) {
+		return src, nil
+	}
 
 	orig := guardFn
 	t.Cleanup(func() { guardFn = orig })
-	// guardFn call sequence for the ENOENT-backup path:
-	//   1 = pathname at top of fixAtRealPath
-	//   2 = ours at top of fixAtRealPath
-	//   3 = pathname re-check before write
-	//   4 = pathname pre-read in readAndRestore
-	//   5 = pathname re-check before os.Remove in readAndRestore
-	// (the restore guard is skipped because backupErr is ENOENT)
-	guardFn = guardCallN(5, "injected pre-remove guard")
-
-	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
-		assert.Equal(t, 2, code)
-	})
-	assert.Contains(t, got, "injected pre-remove guard")
-}
-
-func TestFixAtRealPath_ReadFixedFileFails_ExitsTwo(t *testing.T) {
-	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
-	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
-	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
-
-	orig := readFileLimited
-	t.Cleanup(func() { readFileLimited = orig })
-	readFileLimited = func(string, int64) ([]byte, error) {
-		return nil, fmt.Errorf("mock read fixed failure")
+	guardFn = func(path string) error {
+		return fmt.Errorf("%s: injected pre-ours-write guard", path)
 	}
 
 	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		_, code := fixMergedContent([]byte("# Hello\n"), ours, "PLAN.md", 1<<20)
 		assert.Equal(t, 2, code)
 	})
-	assert.Contains(t, got, "reading fixed file")
+	assert.Contains(t, got, "injected pre-ours-write guard")
 }
 
-func TestFixAtRealPath_RestoreWriteFails_ExitsTwo(t *testing.T) {
-	// Restore write (2nd osWriteFile call) fails.
+func TestFixMergedContent_WriteToOursFails_ExitsTwo(t *testing.T) {
 	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	pathname := filepath.Join(dir, "PLAN.md")
 	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# Hello\n"), 0o644))
 	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
 
-	var writeCount int
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, src []byte, _ int64) ([]byte, error) {
+		return src, nil
+	}
+
 	orig := osWriteFile
 	t.Cleanup(func() { osWriteFile = orig })
-	osWriteFile = func(name string, data []byte, perm os.FileMode) error {
-		writeCount++
-		if writeCount == 2 { // second write = restore
-			return fmt.Errorf("mock restore failure")
-		}
-		return orig(name, data, perm)
+	osWriteFile = func(string, []byte, os.FileMode) error {
+		return fmt.Errorf("mock: write to ours failed")
 	}
 
 	got := captureStderr(func() {
-		_, code := fixAtRealPath([]byte("# Hello\n"), ours, pathname, 1<<20)
+		_, code := fixMergedContent([]byte("# Hello\n"), ours, "PLAN.md", 1<<20)
 		assert.Equal(t, 2, code)
 	})
-	assert.Contains(t, got, "restoring")
+	assert.Contains(t, got, "writing merge output")
 }
 
-func TestFixAtRealPath_PreservesOursFileMode(t *testing.T) {
+func TestFixMergedContent_DoesNotTouchWorktreePathname(t *testing.T) {
+	// The worktree path exists; the driver must neither read nor
+	// write it — a byte-identical rewrite would still change stat
+	// data and abort the parent merge (see runMergeDriverRun).
+	dir := t.TempDir()
+	pathname := filepath.Join(dir, "PLAN.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(pathname, []byte("worktree\n"), 0o644))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+	before, err := os.Lstat(pathname)
+	require.NoError(t, err)
+
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, _ []byte, _ int64) ([]byte, error) {
+		return []byte("# Fixed\n"), nil
+	}
+
+	fixed, code := fixMergedContent([]byte("# Hello\n"), ours, pathname, 1<<20)
+	require.Equal(t, 0, code)
+	assert.Equal(t, "# Fixed\n", string(fixed))
+
+	result, err := os.ReadFile(ours)
+	require.NoError(t, err)
+	assert.Equal(t, "# Fixed\n", string(result), "fixed content must land in ours")
+
+	after, err := os.Lstat(pathname)
+	require.NoError(t, err)
+	assert.True(t, before.ModTime().Equal(after.ModTime()),
+		"worktree pathname mtime must be untouched")
+	worktree, err := os.ReadFile(pathname)
+	require.NoError(t, err)
+	assert.Equal(t, "worktree\n", string(worktree),
+		"worktree pathname content must be untouched")
+}
+
+func TestFixMergedContent_PathnameNotExist_Succeeds(t *testing.T) {
+	// %P may not exist in the worktree (add/add merges). The driver
+	// never touches it, so a missing pathname is not an error and
+	// nothing is created at that path.
+	dir := t.TempDir()
+	pathname := filepath.Join(dir, "newfile.md")
+	ours := filepath.Join(dir, "ours.md")
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o644))
+
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, src []byte, _ int64) ([]byte, error) {
+		return src, nil
+	}
+
+	fixed, code := fixMergedContent([]byte("# Hello\n"), ours, pathname, 1<<20)
+	assert.Equal(t, 0, code)
+	assert.NotEmpty(t, fixed)
+	_, statErr := os.Stat(pathname)
+	assert.True(t, os.IsNotExist(statErr),
+		"pathname must not be created by the merge driver")
+}
+
+func TestFixMergedContent_PreservesOursFileMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("file mode bits not meaningful on Windows")
 	}
 
 	dir := t.TempDir()
-	origWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { _ = os.Chdir(origWd) })
-
-	content := []byte("# Hello\n\nWorld.\n")
-	pathname := filepath.Join(dir, "PLAN.md")
 	ours := filepath.Join(dir, "ours.md")
-	require.NoError(t, os.WriteFile(pathname, content, 0o644))
-	require.NoError(t, os.WriteFile(ours, content, 0o600))
+	require.NoError(t, os.WriteFile(ours, []byte("# Hello\n"), 0o600))
 
-	fixed, code := fixAtRealPath(content, ours, pathname, 1<<20)
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, src []byte, _ int64) ([]byte, error) {
+		return src, nil
+	}
+
+	fixed, code := fixMergedContent([]byte("# Hello\n"), ours, "PLAN.md", 1<<20)
 	require.Equal(t, 0, code)
 	assert.NotEmpty(t, fixed)
 
 	info, err := os.Stat(ours)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
-		"fixAtRealPath must preserve the original permissions of ours")
+		"fixMergedContent must preserve the original permissions of ours")
+}
+
+func TestFixMergedSource_RegeneratesCatalog_NoDiskWrites(t *testing.T) {
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("rules:\n  catalog: true\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "plans"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plans", "alpha.md"),
+		[]byte("---\ntitle: Alpha\n---\n\n# Alpha\n\nContent.\n"), 0o644))
+
+	// Stale catalog body: regeneration must fill in the alpha row.
+	source := "# Doc\n\n<?catalog\nglob: \"plans/*.md\"\nsort: title\n" +
+		"row: \"- [{title}]({filename})\"\n?>\n<?/catalog?>\n"
+
+	fixed, err := fixMergedSource("CATALOG.md", []byte(source), 1<<20)
+	require.NoError(t, err)
+	assert.Contains(t, string(fixed), "- [Alpha](plans/alpha.md)",
+		"catalog must regenerate from neighbour files on disk")
+
+	_, statErr := os.Stat(filepath.Join(dir, "CATALOG.md"))
+	assert.True(t, os.IsNotExist(statErr),
+		"fixMergedSource must not create the file on disk")
+}
+
+func TestFixMergedSource_ConfigLoadFails(t *testing.T) {
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte(":\tnot yaml"), 0o644))
+
+	_, err = fixMergedSource("PLAN.md", []byte("# Hello\n"), 1<<20)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading config")
 }
 
 // --- merge-driver ci-install (npm-ci-style: verify, never write) ---

--- a/cmd/mdsmith/mergedriver_unix_test.go
+++ b/cmd/mdsmith/mergedriver_unix_test.go
@@ -71,7 +71,11 @@ func TestMergeAndClean_TheirsIsSymlink_ExitsTwo(t *testing.T) {
 	assert.Equal(t, 2, code)
 }
 
-func TestFixAtRealPath_PathnameIsSymlink_ExitsTwo(t *testing.T) {
+func TestFixMergedContent_PathnameIsSymlink_Harmless(t *testing.T) {
+	// The driver never dereferences the worktree path (%P) — it is
+	// only a label for config-glob matching — so a symlinked %P
+	// cannot pull content from outside the worktree and is not an
+	// error. The link itself must be left untouched.
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.md")
 	link := filepath.Join(dir, "pathname.md")
@@ -81,20 +85,34 @@ func TestFixAtRealPath_PathnameIsSymlink_ExitsTwo(t *testing.T) {
 	ours := filepath.Join(dir, "ours.md")
 	require.NoError(t, os.WriteFile(ours, []byte("# content\n"), 0o644))
 
-	_, code := fixAtRealPath([]byte("# content\n"), ours, link, 1<<20)
-	assert.Equal(t, 2, code)
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, src []byte, _ int64) ([]byte, error) {
+		return src, nil
+	}
+
+	_, code := fixMergedContent([]byte("# content\n"), ours, link, 1<<20)
+	assert.Equal(t, 0, code)
+
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "# content\n", string(data),
+		"symlink target must be untouched")
 }
 
-func TestFixAtRealPath_OursIsSymlink_ExitsTwo(t *testing.T) {
+func TestFixMergedContent_OursIsSymlink_ExitsTwo(t *testing.T) {
 	dir := t.TempDir()
-	pathname := filepath.Join(dir, "pathname.md")
-	require.NoError(t, os.WriteFile(pathname, []byte("# content\n"), 0o644))
-
 	oursTarget := filepath.Join(dir, "ours-target.md")
 	oursLink := filepath.Join(dir, "ours.md")
 	require.NoError(t, os.WriteFile(oursTarget, []byte("# content\n"), 0o644))
 	require.NoError(t, os.Symlink(oursTarget, oursLink))
 
-	_, code := fixAtRealPath([]byte("# content\n"), oursLink, pathname, 1<<20)
+	origFix := fixSourceFn
+	t.Cleanup(func() { fixSourceFn = origFix })
+	fixSourceFn = func(_ string, src []byte, _ int64) ([]byte, error) {
+		return src, nil
+	}
+
+	_, code := fixMergedContent([]byte("# content\n"), oursLink, "pathname.md", 1<<20)
 	assert.Equal(t, 2, code)
 }

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -72,6 +72,18 @@ Driver entrypoint, invoked by Git. Not normally called by
 hand. After `install` or `ci-install`, Git will dispatch to
 it whenever merging a file marked `merge=mdsmith`.
 
+The driver writes only the `<ours>` temp file (`%A`). It
+regenerates sections by running `mdsmith fix` on the merged
+content in memory, anchored at `<pathname>` so neighbour
+files resolve as they would for the real file. The worktree
+path itself is never read or written. The driver runs while
+the parent merge is still in flight, so a worktree write
+changes the file's stat data — even when the bytes are
+restored exactly. Git then treats the path as locally
+modified and aborts the merge ("Your local changes ...
+would be overwritten"). Under `git rebase`, a pick that
+hits this is rescheduled forever.
+
 ## Git config (set by `install` / `ci-install`)
 
 ```text


### PR DESCRIPTION
## Summary

Fixes the rebase-reschedule loop discovered while rebasing #548: with the merge driver installed, a `git rebase` pick touching both-sides-modified `*.md` files could abort with "Your local changes ... would be overwritten" and be rescheduled forever.

**Root cause.** `merge-driver run` copied the merged content to the worktree path (`%P`), ran `mdsmith fix` there so neighbour files would resolve, then restored the original bytes. The restore is byte-identical but **rewrites the file, changing its stat data mid-merge**. In a *settled* worktree — recorded stat older than the index, true of any real repo — git trusts stat over content, treats the path as locally modified, and aborts the very merge that invoked the driver. (Fresh repos mask the bug: every entry is racily clean, so git re-hashes and the byte-identical restore is rescued — which is why the original test suite never caught it.)

**Fix.** Run the fix pipeline on the merged content **in memory** via `fix.Source` (the same machinery the LSP uses on unsaved buffers), anchored at `%P` for config-glob matching and neighbour resolution. Only `%A` is written. The `%P` backup/restore machinery and its symlink-guard ladder are deleted; a symlinked or missing `%P` is now harmless rather than an error.

## Tests

**Red on the old driver, green on this PR (the regression guards):**
- `TestE2E_MergeDriver_Run_LeavesWorktreeUntouched` — driver contract: `%P` bytes *and mtime* untouched while `%A` gets the regenerated section
- `TestE2E_MergeDriver_AgedWorktree_CherryPick_Succeeds` — portable reproduction of the incident through real git: age the driver-managed file (`Chtimes` + `update-index --refresh`), then pick a commit that both-modifies it; the old driver aborts with the verbatim incident error
- Unit tests for `fixMergedContent` / `fixMergedSource` (all branches, mode preservation, missing/symlinked `%P` contracts)

**Real-git flow locks (green on both, pinning end states):**
- `TestE2E_MergeQueue_BatchTwoPRs_RightCommits` — the queue's exact sequence (`ci-install`, then per batched PR: `merge --no-ff --no-commit` → pre-merge-commit hook → `commit`) for two PRs regenerating the same catalog; asserts two merge commits, the committed catalog lists every plan, no markers, no stale `index.lock`, clean tree, green check
- `TestE2E_MergeDriver_RebasePick_Succeeds` and `_RebaseMultiFile_Succeeds` (catalog + include + prose source in one pick)
- `TestE2E_MergeDriver_CherryPick_Succeeds`
- `TestE2E_MergeDriver_RealMerge_ProseConflict_AbortRestores` — driver exit 1 leaves a proper unmerged path; `merge --abort` restores exactly
- `TestE2E_MergeDriver_RealMerge_Diff3SectionConflict_Resolved` — `merge.conflictstyle=diff3` base markers through real git

`go test ./...`, `go vet`, `golangci-lint`, and `mdsmith check .` all pass; the pre-existing ordering-race and hook e2e tests are unchanged and green.

## Docs

`docs/reference/cli/merge-driver.md` documents the no-worktree-writes contract under `run`; the CLI usage text mentions it.

https://claude.ai/code/session_01YPNjbRwLvVEvebdc674a8z