### PR TITLE
website: share one shadow across all feature artifacts

### DIFF
--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -549,11 +549,13 @@ main {
 }
 
 /* ── Artifact frame — shared frame language ── */
+/* Every artifact (real capture or mockup, dark or light) floats on its
+   tile with this one shadow — variants must not override it. */
 .artifact-frame {
   width: 100%;
   max-width: 440px;
   border-radius: 9px;
-  box-shadow: 0 2px 12px rgba(15,20,25,0.09), 0 1px 3px rgba(15,20,25,0.06);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.45), 0 1px 4px rgba(0,0,0,0.3);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -593,7 +595,6 @@ main {
 .artifact-frame--terminal {
   border: 1px solid #1A1F26;
   background: #0F1419;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.45), 0 1px 4px rgba(0,0,0,0.3);
 }
 .artifact-titlebar--terminal {
   background: #070A0D;
@@ -620,7 +621,6 @@ main {
 .artifact-frame--shot {
   border: 1px solid var(--steel-200);
   background: #FFFFFF;
-  box-shadow: var(--shadow-md);
 }
 /* A real screenshot floats framed on the tile's light background (like
    the terminal), at its natural aspect — no cropping. */


### PR DESCRIPTION
## Summary

The five homepage feature-grid visuals declared three different frame shadows:

- the dark **terminal** artifact defined its own strong shadow (`0 4px 24px rgba(0,0,0,0.45), 0 1px 4px rgba(0,0,0,0.3)`),
- the real-screenshot slot (**editor.png**) used the soft `--shadow-md`, which is imperceptible around a dark, edge-to-edge capture on the light tile — the screenshot looked shadow-less,
- the light **graph/doc/CI** mockups inherited the subtle `.artifact-frame` base shadow.

This PR moves the terminal's shadow onto the shared `.artifact-frame` base rule and removes both per-variant `box-shadow` overrides, so every artifact in the "Why mdsmith" grid floats on its tile with the identical shadow.

## Changes

- `website/static/css/app.css`: one shared `box-shadow` on `.artifact-frame`; dropped the overrides in `.artifact-frame--terminal` and `.artifact-frame--shot`; comment noting variants must not override it.

No markdown, Go, or template changes. `mdsmith check .` passes (445 files, 0 failures).

https://claude.ai/code/session_01Qoji957rQoAYw5VBWjbqfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qoji957rQoAYw5VBWjbqfo)_