### PR TITLE
Plan 246: Typed block projection and full-document extract

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -164,7 +164,7 @@ footer: |
 | 243        | ✅     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 244        | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245        | ✅     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
-| 246        | 🔲     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
+| 246        | 🔳     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
 | 2606022122 | ✅     | sonnet | [Review and centralize YAML handling](plan/2606022122_yaml-handling-review.md)                                                          |
 | 2606022123 | ✅     | sonnet | [Catalog directive — accept `..` globs within project root](plan/2606022123_catalog-dotdot-globs.md)                                    |
 | 2606022124 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/2606022124_schema-entry-unification.md)                        |

--- a/PLAN.md
+++ b/PLAN.md
@@ -164,7 +164,7 @@ footer: |
 | 243        | ✅     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |
 | 244        | ✅     | opus   | [Structured list projection; fix nested-item text corruption](plan/244_structured-list-projection.md)                                   |
 | 245        | ✅     | sonnet | [Table projection modes: `records` and `rows`](plan/245_table-projection-modes.md)                                                      |
-| 246        | 🔳     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
+| 246        | ✅     | opus   | [Typed block projection and full-document extract](plan/246_block-projection-full-extract.md)                                           |
 | 2606022122 | ✅     | sonnet | [Review and centralize YAML handling](plan/2606022122_yaml-handling-review.md)                                                          |
 | 2606022123 | ✅     | sonnet | [Catalog directive — accept `..` globs within project root](plan/2606022123_catalog-dotdot-globs.md)                                    |
 | 2606022124 | ✅     | opus   | [Section schema — unify entry shape under `heading:` discriminator](plan/2606022124_schema-entry-unification.md)                        |

--- a/cue/extract/grammar.cue
+++ b/cue/extract/grammar.cue
@@ -1,0 +1,70 @@
+// Package extract is the published CUE contract for the typed
+// output grammar of `mdsmith extract`: the block list a
+// `projection: blocks` section emits (#Block) and the inline-span
+// list a paragraph emits under `projection: inline` or the
+// `block-paragraphs: inline` option (#Span).
+//
+// mdsmith embeds this file via go:embed; a differential test
+// validates every extract fixture's JSON against these definitions,
+// so the grammar cannot drift from the implementation. The
+// definitions are closed (`close({...})`) so an unexpected key fails
+// validation rather than being silently accepted.
+//
+// See plan/246_block-projection-full-extract.md (block grammar) and
+// plan/212_extract-inline-spans.md (span grammar).
+package extract
+
+// #Span is one inline span. Leaf spans (text, code, autolink) carry a
+// `value`; container spans (emphasis, strong, link, image) carry a
+// recursive `children` list. `break` records a wrapped line.
+#Span: close({block_span_text}) |
+	close({block_span_break}) |
+	close({block_span_code}) |
+	close({block_span_autolink}) |
+	close({block_span_emphasis}) |
+	close({block_span_strong}) |
+	close({block_span_link}) |
+	close({block_span_image})
+
+block_span_text: {span: "text", value: string}
+block_span_break: {span: "break", hard: bool}
+block_span_code: {span: "code", value: string}
+block_span_autolink: {span: "autolink", value: string, url: string}
+block_span_emphasis: {span: "emphasis", level: 1, children: [...#Span]}
+block_span_strong: {span: "strong", level: 2, children: [...#Span]}
+block_span_link: {span: "link", url: string, title?: string, children: [...#Span]}
+// `image` appears only under the lenient block-mode inline option.
+block_span_image: {span: "image", url: string, title?: string, children: [...#Span]}
+
+// #Item is one list item in the structured `tree` / block-list item
+// shape (plan 244): its own `text`, an optional `checked` bool on a
+// GFM task item, and an optional recursive `children` sub-list.
+#Item: close({
+	text: string
+	checked?: bool
+	children?: [...#Item]
+})
+
+// #Block is one block in a `blocks` list. Container blocks (quote,
+// section) carry a recursive `blocks` list; leaves carry their own
+// payload. A `paragraph` carries either flat `text` or an `inline`
+// span list, never both.
+#Block: close({block_para_text}) |
+	close({block_para_inline}) |
+	close({block_code}) |
+	close({block_list}) |
+	close({block_table}) |
+	close({block_quote}) |
+	close({block_break}) |
+	close({block_html}) |
+	close({block_section})
+
+block_para_text: {block: "paragraph", text: string}
+block_para_inline: {block: "paragraph", inline: [...#Span]}
+block_code: {block: "code", lang?: string, value: string}
+block_list: {block: "list", items: [...#Item]}
+block_table: {block: "table", columns: [...string], rows: [...[...string]]}
+block_quote: {block: "quote", blocks: [...#Block]}
+block_break: {block: "break"}
+block_html: {block: "html", value: string}
+block_section: {block: "section", level: int, heading: string, blocks: [...#Block]}

--- a/cue/extract/grammar.go
+++ b/cue/extract/grammar.go
@@ -1,0 +1,25 @@
+// Package extract embeds the published CUE contract for the
+// `mdsmith extract` block- and span-list output grammar so the
+// differential test can validate fixtures against it without reading
+// from disk at runtime. The contract source lives in `grammar.cue`
+// next to this file.
+//
+// The intended import path for external CUE consumers is
+// `github.com/jeduden/mdsmith/extract`. The literal CUE import syntax
+// is not yet wired; today the surface is the embedded definition the
+// extract reference documents and the differential test consumes.
+//
+//nolint:revive // "extract" mirrors the CUE-side import path
+package extract
+
+import _ "embed"
+
+//go:embed grammar.cue
+var source string
+
+// Source returns the embedded `grammar.cue` contents verbatim. The
+// differential test in internal/extract compiles it and unifies every
+// projected block / span against #Block / #Span.
+//
+// no test by design: trivial embed accessor
+func Source() string { return source }

--- a/cue/extract/grammar.go
+++ b/cue/extract/grammar.go
@@ -20,6 +20,4 @@ var source string
 // Source returns the embedded `grammar.cue` contents verbatim. The
 // differential test in internal/extract compiles it and unifies every
 // projected block / span against #Block / #Span.
-//
-// no test by design: trivial embed accessor
 func Source() string { return source }

--- a/cue/extract/grammar_test.go
+++ b/cue/extract/grammar_test.go
@@ -1,0 +1,26 @@
+package extract
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSource pins that the embedded grammar is non-empty and carries
+// the `#Block` definition the differential test unifies against. Go's
+// coverage tooling does not attribute the cross-package calls the
+// internal/extract differential test makes, so this in-package test
+// keeps the embed accessor covered and guards against an empty embed
+// (a missing or renamed grammar.cue would surface here rather than as
+// a confusing CUE compile failure across the module boundary).
+func TestSource(t *testing.T) {
+	src := Source()
+	if src == "" {
+		t.Fatal("Source() returned empty; grammar.cue did not embed")
+	}
+	if !strings.Contains(src, "#Block") {
+		t.Errorf("Source() missing the #Block definition:\n%s", src)
+	}
+	if !strings.Contains(src, "#Span") {
+		t.Errorf("Source() missing the #Span definition")
+	}
+}

--- a/docs/guides/extract-markdown-as-data.md
+++ b/docs/guides/extract-markdown-as-data.md
@@ -20,7 +20,12 @@ parts of the file feed the tree:
 - **Body sections** — H1 / H2 / H3 headings and the
   content under them, projected as siblings.
 
-This guide is about when to use which.
+This guide is about when to use which. Two modes share
+the work: declared schema entries **constrain and
+rename** the slice you name, while
+[`projection: blocks`](#projecting-a-whole-section-body)
+**captures everything else** — a section's whole body,
+or, at the schema root, the whole document.
 
 ## The principle
 
@@ -136,19 +141,11 @@ emits:
 
 ```json
 {
-  "frontmatter": {
-    "title": "Product copy"
-  },
+  "frontmatter": { "title": "Product copy" },
   "title": "Product copy",
-  "lead": {
-    "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
-  },
-  "tagline": {
-    "text": "Mark down your ideas; smith them into shipping docs."
-  },
-  "vscode-description": {
-    "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code."
-  }
+  "lead": { "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions." },
+  "tagline": { "text": "Mark down your ideas; smith them into shipping docs." },
+  "vscode-description": { "text": "Inline diagnostics, fix-on-save, and instant navigation for Markdown in VS Code." }
 }
 ```
 
@@ -169,8 +166,7 @@ paragraph then projects under an `inline` key as a
 typed, recursive span list instead of a flat string.
 
 The canonical case is a website headline whose hero
-template renders one emphasised word — the consumer
-reads the emphasis position from the data:
+template renders one emphasised word from the data:
 
 ```markdown
 ---
@@ -200,29 +196,15 @@ the trailing text:
 
 ```json
 {
-  "frontmatter": {
-    "title": "Product copy"
-  },
+  "frontmatter": { "title": "Product copy" },
   "headline": {
     "inline": [
+      { "span": "text", "value": "Mark" },
       {
-        "span": "text",
-        "value": "Mark"
+        "span": "emphasis", "level": 1,
+        "children": [{ "span": "text", "value": "down" }]
       },
-      {
-        "children": [
-          {
-            "span": "text",
-            "value": "down"
-          }
-        ],
-        "level": 1,
-        "span": "emphasis"
-      },
-      {
-        "span": "text",
-        "value": ", smithed."
-      }
+      { "span": "text", "value": ", smithed." }
     ]
   }
 }
@@ -237,10 +219,8 @@ flat-versus-recursive mode switch.
 Leaf spans (text, code, autolink) carry a `value`;
 container spans (emphasis, strong, link) carry
 `children`. A wrapped line emits a `break` span between
-the surrounding text spans — `hard` is `true` for a
-hard break (a backslash or two trailing spaces) and
-`false` for a soft wrap — so a multi-line paragraph
-keeps its line structure. An image, inline raw HTML, or
+the surrounding text spans (`hard: true` for a backslash
+or double-space break). An image, inline raw HTML, or
 any node outside that set is a hard error — the same
 exit code as a non-conformant file. The full mapping
 table is in the [extract reference][extract-inline].
@@ -249,14 +229,14 @@ table is in the [extract reference][extract-inline].
 
 ## Projecting list structure
 
-A list projects as an array of strings by default — each
-the item's own text. That flat shape loses nesting, and
-it strips a task checkbox down to a literal `[x]` prefix.
-When the consumer needs the structure — which items are
-checked, which nest children — set `projection: tree` on
-the list entry. Each item then projects as an object with
-its own `text`, a `checked` bool on task items, and a
-recursive `children` array on items that nest a sub-list.
+A list projects as an array of own-text strings by
+default. That flat shape loses nesting and strips a task
+checkbox to a literal `[x]` prefix. When the consumer
+needs the structure — which items are checked, which
+nest children — set `projection: tree` on the list
+entry. Each item then projects as an object with its own
+`text`, a `checked` bool on task items, and a recursive
+`children` array on items that nest a sub-list.
 
 The canonical case is a sprint checklist whose
 status tool reads `checked` and walks `children`:
@@ -292,54 +272,39 @@ kind-assignment:
 
 ```json
 {
-  "frontmatter": {
-    "title": "Sprint tasks"
-  },
+  "frontmatter": { "title": "Sprint tasks" },
   "tasks": {
     "items": [
+      { "checked": true, "text": "done item" },
       {
-        "checked": true,
-        "text": "done item"
+        "checked": false, "text": "open item with bold",
+        "children": [{ "text": "nested child" }]
       },
-      {
-        "checked": false,
-        "children": [
-          {
-            "text": "nested child"
-          }
-        ],
-        "text": "open item with bold"
-      },
-      {
-        "text": "plain item"
-      }
+      { "text": "plain item" }
     ]
   }
 }
 ```
 
 The `[x]` / `[ ]` marker becomes the `checked` bool and
-never leaks into `text`; the `**bold**` flattens to its
-text; `nested child` rides inside its parent's `children`
-rather than concatenating into the parent string. A plain
-item with no marker and no sub-list is just `{text}`. The
-array order is the item order — ordered-list numbering is
-out of scope. YAML and msgpack emit the same tree.
+never leaks into `text`; `**bold**` flattens to its
+text; `nested child` rides inside its parent's
+`children`, not concatenated into the parent string. A
+plain item is just `{text}`. Array order is item order;
+YAML and msgpack emit the same tree.
 
 ## Projecting a table as positional rows
 
 A `kind: table` content entry projects as `rows` (an
 array of record objects) by default. Set
-`projection: rows` on the entry when the consumer
-needs column order preserved, tolerates duplicate
-headers, or works with positional data (a chart
-script, a CSV writer, a diff tool).
+`projection: rows` when the consumer needs column order
+preserved, tolerates duplicate headers, or works with
+positional data (a chart script, a CSV writer).
 
-The `rows` projection injects two sibling keys directly
-into the enclosing section object — `columns` (the
-header array in document order) and `rows` (an array of
-string arrays, one per body row). Short body rows are
-padded with empty strings to match the header width.
+The `rows` projection injects two sibling keys into the
+section object — `columns` (the header array) and `rows`
+(string arrays, one per body row). Short rows are padded
+with empty strings to the header width.
 
 A benchmark table in a performance section:
 
@@ -375,15 +340,10 @@ emits:
 
 ```json
 {
-  "frontmatter": {
-    "title": "Benchmark results"
-  },
+  "frontmatter": { "title": "Benchmark results" },
   "latency": {
     "columns": ["Operation", "p50 ms", "p99 ms"],
-    "rows": [
-      ["check", "12", "45"],
-      ["fix", "18", "70"]
-    ]
+    "rows": [["check", "12", "45"], ["fix", "18", "70"]]
   }
 }
 ```
@@ -397,6 +357,78 @@ semantics are in the
 [extract reference][extract-table].
 
 [extract-table]: ../reference/cli/extract.md#table-projection-modes
+
+## Projecting a whole section body
+
+Everything above names a slice and constrains it. The
+opposite need is to capture a section's *whole* body
+without listing each node. Set `projection: blocks` on
+the scope — or once at the schema root, as the default
+for every section. The body projects as a typed,
+recursive `blocks` list in document order: paragraphs,
+code, lists, tables, quotes, and deeper headings (as
+nested `section` blocks).
+
+A schema-level switch projects a whole document in one
+line. Declared sections still project as keyed objects,
+and gain a `blocks` list. The sections the walker would
+skip — wildcard and unlisted headings — now project
+too. Each lands under its slug, its heading text in a
+`heading` field:
+
+```markdown
+---
+title: Release notes
+---
+# Release notes
+
+## Summary
+
+Ships **block projection**.
+
+## Details
+
+Two new switches.
+```
+
+```yaml
+kinds:
+  notebook:
+    schema:
+      projection: blocks
+      sections:
+        - heading: { regex: '^Summary$' }
+kind-assignment:
+  - glob: ["notes.md"]
+    kinds: [notebook]
+```
+
+`mdsmith extract notebook --format json notes.md`
+emits the H1 under `title`, the declared `summary`, and
+the unlisted `details` (with its `heading` text):
+
+```json
+{
+  "frontmatter": { "title": "Release notes" },
+  "title": "Release notes",
+  "summary": {
+    "blocks": [{ "block": "paragraph", "text": "Ships block projection." }]
+  },
+  "details": {
+    "heading": "Details",
+    "blocks": [{ "block": "paragraph", "text": "Two new switches." }]
+  }
+}
+```
+
+A paragraph block defaults to flat `text`. Add
+`block-paragraphs: inline` beside `projection: blocks`
+to project each paragraph's span list under `inline`
+instead — the same span shape as above, lenient about
+images. The full grammar and its CUE contract are in
+the [extract reference][extract-blocks].
+
+[extract-blocks]: ../reference/cli/extract.md#block-projection-whole-body
 
 ## When frontmatter is the right call
 
@@ -496,38 +528,19 @@ H1 fails `mdsmith check`:
 docs/copy/product.md:4:1 MDS020 heading does not match frontmatter: expected "Product copy" (from title), got "Product page copy"
 ```
 
-The synced H1 also becomes data. `mdsmith extract`
-projects the H1 scope under a `title` key — the
-captured heading text inside — and each section's
-paragraph beneath it:
+The synced H1 also becomes data: `mdsmith extract`
+projects the H1 scope under a `title` object, the
+captured heading text and each section's paragraph
+nested inside it.
 
-```json
-{
-  "frontmatter": {
-    "title": "Product copy"
-  },
-  "title": {
-    "lead": {
-      "text": "A lint-and-fix tool that keeps your Markdown consistent across every surface — READMEs, docs site, editor extensions."
-    },
-    "tagline": {
-      "text": "Mark down your ideas; smith them into shipping docs."
-    },
-    "title": "Product copy"
-  }
-}
-```
-
-One limit remains. Every schema source on a file
-must declare the same root level, so an H1-rooted
-`proto.md` cannot compose with an H2-rooted inline
-schema on the same file. The H1 sync and the body
-extraction must both live on the `proto.md`.
-
-mdsmith cannot project the H1 text without a
-frontmatter field behind it: a `{title}` row with
-no `title` field matches any heading, and `extract`
-skips wildcard scopes. Keep the `title` field when
+One limit remains. Every schema source on a file must
+declare the same root level, so an H1-rooted `proto.md`
+cannot compose with an H2-rooted inline schema. The H1
+sync and the body extraction both live on the
+`proto.md`. And mdsmith cannot project the H1 text
+without a frontmatter field behind it — a `{title}` row
+with no `title` field matches any heading, and `extract`
+skips wildcard scopes — so keep the `title` field when
 the kind syncs the H1.
 
 [mds004]: ../../internal/rules/MDS004-first-line-heading/README.md
@@ -540,18 +553,14 @@ human-readable heading and the consumer-friendly key
 don't match.
 
 - **Heading-to-key rename.** `## VS Code` slugs to
-  `vs-code` by default. Set `bind: vscode-description`
-  on the section so the JSON consumer reads
-  `vscode-description` (matching the field name in
-  the consuming code or manifest).
-- **Collapse a wrapper.** `bind: ""` on a parent
-  scope hoists its children into the grandparent
-  scope. Use it when a heading exists for human
-  reading but should not nest in the data tree.
-- **Repeating sections.** A section with
-  `repeat: {min, max}` and a placeholder-bearing
-  heading projects as an array; combine with
-  `bind:` to rename the array key.
+  `vs-code`; set `bind: vscode-description` so the
+  consumer reads the field name its code expects.
+- **Collapse a wrapper.** `bind: ""` on a parent scope
+  hoists its children into the grandparent — for a
+  heading that should not nest in the data tree.
+- **Repeating sections.** A `repeat: {min, max}` section
+  with a placeholder heading projects as an array;
+  `bind:` renames the array key.
 
 See [the section-schema reference][secref] for the
 full grammar.
@@ -560,16 +569,15 @@ full grammar.
 
 ## Reading a value back into Markdown
 
-`mdsmith extract` writes the projection out as JSON,
-YAML, or msgpack — the right shape for a release
-script, a Hugo data file, or any non-Markdown
+`mdsmith extract` writes the projection out for a
+release script, a Hugo data file, or any non-Markdown
 consumer. The read-side counterpart lives on the
-`<?include?>` directive: the `extract:` parameter
-walks the same JSON tree and splices one leaf into
-the host file's Markdown body.
+`<?include?>` directive: its `extract:` parameter walks
+the same JSON tree and splices one leaf into the host
+file's Markdown body.
 
-Re-using the product-copy example above, a README
-embed reads the tagline directly:
+Re-using the product-copy example, a README embed reads
+the tagline directly:
 
 ```markdown
 <?include
@@ -580,16 +588,10 @@ Mark down your ideas; smith them into shipping docs.
 <?/include?>
 ```
 
-The spliced text lands on one line: a `text`
-projection joins a soft-wrapped paragraph with
-spaces. The directive runs the included file through
-the same projection rules `mdsmith extract` uses,
-walks the dotted path, and splices the leaf. There
-is no intermediate "fragment" file to keep in sync —
-the README reads the source of truth on every lint.
-
-The full set of supported paths, content-key
-shortcuts, and lint-time errors are documented in
+The directive runs the same projection rules, walks the
+dotted path, and splices the leaf — no intermediate
+"fragment" file to keep in sync. The supported paths,
+content-key shortcuts, and lint-time errors are in
 [generating-content.md](directives/generating-content.md#include-a-typed-value).
 
 ## See also

--- a/docs/reference/cli/extract.md
+++ b/docs/reference/cli/extract.md
@@ -31,29 +31,28 @@ The projection walks the composed schema in lockstep
 with the validated match and mirrors the hierarchy:
 
 - The root holds a `frontmatter` object (the decoded
-  front matter, unchanged) and the projected sections
-  beside it at the same level.
+  front matter) and the projected sections beside it.
 - When the schema roots at H2 (all inline schemas do),
   the document H1's plain text is emitted under the
-  reserved `title` key beside `frontmatter`. No H1 in
-  the document omits the key. A sibling scope whose
-  projection key resolves to `title` is reported as a
-  collision; rename it with `bind:`.
+  reserved `title` key beside `frontmatter`. No H1 omits
+  the key. A sibling scope that resolves to `title` is
+  reported as a collision; rename it with `bind:`.
 - A literal heading (`## Goal`) becomes an object keyed
   by the slugified heading (`goal`).
 - A repeating section (`## Step {n}` with a `repeat:`
   cardinality) becomes an array keyed by the slug of the
   heading's literal stem (`step`), or the placeholder
   name when the heading is only a placeholder. Each
-  element retains every captured placeholder as a
-  `name: value` field plus its own child scopes and
-  content.
+  element keeps its captured placeholders, child scopes,
+  and content.
 - A `heading: null` no-heading section projects its
   content directly into the enclosing object — there is
   no `preamble` wrapper key.
 - Wildcard slots (`regex: '.+'`) and unlisted or closed
-  headings are skipped: the output is a faithful image
-  of the *declared* schema only.
+  headings are skipped by default: the output is a
+  faithful image of the *declared* schema. A
+  schema-level [`projection: blocks`](#block-projection-whole-body)
+  lifts that — it projects every section.
 - H1-rooted schemas (file-based proto.md schemas where
   the top heading is H1) do not emit the reserved
   `title` key; the H1 is already a scope in `Sections`.
@@ -62,45 +61,33 @@ Content entries project under default keys:
 
 - `code-block` → `code` (raw body; more blocks get
   `code-2`, …).
-- `list` → `items` (an array of strings, each the item's
-  own text), or a tree of item objects when the entry
-  sets `projection: tree` (see below).
-- `table` → `rows` (default `records` projection: row
-  objects keyed by column header). With `projection: rows`
-  the table injects `columns` (header array) and `rows`
-  (positional row arrays) as two sibling keys into the
-  enclosing section object instead (see below).
+- `list` → `items` (an array of own-text strings), or a
+  tree of item objects under `projection: tree` (below).
+- `table` → `rows` (default `records`: row objects keyed
+  by column header). With `projection: rows` the table
+  injects `columns` and `rows` (positional) as two
+  sibling keys into the section object instead (below).
 - `paragraph` → `text` (plain text), or `inline` when
   the entry sets `projection: inline` (see below).
 
-A flat `items` string holds the item's own text only.
-A nested sub-list is excluded, not folded in, so `- a`
-with child `- b` projects `"a"`, never `"ab"`. Inline
-markup flattens to text; a task marker stays verbatim
-(`[x]` / `[ ]`); a nest-only item projects the empty
-string, keeping its slot. Use `projection: tree` (below)
-to keep the nesting and split the marker out.
+A flat `items` string holds the item's own text only; a
+nested sub-list is excluded, so `- a` with child `- b`
+projects `"a"`, never `"ab"`. Use `projection: tree`
+(below) to keep nesting and split the task marker out.
 
 Sibling keys are emitted in sorted order, not document
 order. Two sibling projections that resolve to the same
-key are a schema error. It is reported at extract time.
-Optional sections that did not match are omitted, not
-emitted as null. A section that declares no `content:`
-entry projects as an empty object.
+key are a schema error, reported at extract time. An
+unmatched optional section is omitted, not null; a
+section with no `content:` entry projects as `{}`.
 
 ## Inline-span projection
 
 A paragraph entry projects its plain text by default.
-Set `projection: inline` on the entry to project the
-paragraph's inline structure instead. The result is a
-typed, recursive list of spans under the `inline` key:
-
-```yaml
-sections:
-  - heading: { regex: '^Headline$' }
-    content:
-      - { kind: paragraph, projection: inline, required: true }
-```
+Set `projection: inline` on the entry
+(`{ kind: paragraph, projection: inline }`) to project
+the paragraph's inline structure instead — a typed,
+recursive list of spans under the `inline` key.
 
 Each AST node maps to one span object:
 
@@ -116,39 +103,22 @@ Each AST node maps to one span object:
 
 Leaf spans (text, code, autolink) carry `value`;
 container spans (emphasis, strong, link) carry
-`children` and recurse through the same mapping.
-A link omits `title` when none was written.
+`children` and recurse. A link omits `title` when none
+was written. A wrapped paragraph keeps line structure:
+a text span, then a `break` span (`hard: true` for
+backslash/double-space, `false` for soft wrap), then
+the next text span.
 
-A wrapped paragraph keeps line structure: a text span,
-then a `break` span (`hard: true` for backslash/double-
-space, `false` for soft wrap), then the next text span.
+The headline `Mark*down*, smithed.` projects under
+`inline` as a text span, then an `emphasis` span whose
+`children` hold the `down` text, then a trailing text
+span — see the [guide][igd] for the full output.
 
-For the headline `Mark*down*, smithed.`:
+[igd]: ../../guides/extract-markdown-as-data.md#projecting-inline-structure
 
-```json
-"headline": {
-  "inline": [
-    { "span": "text", "value": "Mark" },
-    {
-      "children": [{ "span": "text", "value": "down" }],
-      "level": 1,
-      "span": "emphasis"
-    },
-    { "span": "text", "value": ", smithed." }
-  ]
-}
-```
-
-A nested example — a strong span wrapping a code span,
-``**`mdsmith fix`**`` — projects with no mode switch:
-
-```json
-{
-  "children": [{ "span": "code", "value": "mdsmith fix" }],
-  "level": 2,
-  "span": "strong"
-}
-```
+Nesting composes through the same shape: a strong span
+wrapping a code span (``**`mdsmith fix`**``) carries
+the code span in its `children`, no mode switch.
 
 Each kind limits which projection it takes. A bad pair
 fails when the config loads, not later at extract:
@@ -161,11 +131,12 @@ fails when the config loads, not later at extract:
 | `table`      | `records` (default), `rows`     |
 | `unlisted`   | none                            |
 
-Anything outside the mapping table is a hard error at
-extract time, with the same exit code as a non-conformant
-file: images, inline raw HTML, and custom inline nodes.
-The `text` and `inline` default keys differ, so one
-paragraph can project each without colliding.
+A node outside the table — an image, inline raw HTML, a
+custom node — is a hard error at extract time, the same
+exit code as a non-conformant file. (The block-mode
+inline option below is lenient about images.) The `text`
+and `inline` default keys differ, so one paragraph can
+project each without colliding.
 
 ## Tree projection for lists
 
@@ -174,14 +145,13 @@ default. Set `projection: tree` on a `kind: list` entry
 to project each item as an object instead. Each object
 carries:
 
-- `text` — the item's own inline text, flattened, with
-  soft wraps joined and any task marker removed.
-- `checked` — a bool, present only on a GFM task item
-  (`- [x]` / `- [ ]`). Detection matches the renderer: a
-  bare `[x]` and a no-space `[x]done` count; a non-marker
-  word like `[TODO]` does not and stays in `text`.
-- `children` — a recursive array of item objects, present
-  only when the item nests a sub-list.
+- `text` — the item's own inline text, flattened, the
+  task marker removed.
+- `checked` — a bool, only on a GFM task item
+  (`- [x]` / `- [ ]`). Detection matches the renderer; a
+  non-marker word like `[TODO]` stays in `text`.
+- `children` — a recursive item array, only when the
+  item nests a sub-list.
 
 A checked task nesting one plain child projects as:
 
@@ -189,11 +159,10 @@ A checked task nesting one plain child projects as:
 { "checked": true, "children": [{ "text": "child" }], "text": "done" }
 ```
 
-The array order is the item order; ordered-list numbering
-and `start` are out of scope. YAML and msgpack emit the
-same tree. The
-[extract guide](../../guides/extract-markdown-as-data.md)
-has a full worked checklist.
+Array order is item order; ordered-list numbering is out
+of scope. YAML and msgpack emit the same tree. The
+[guide](../../guides/extract-markdown-as-data.md) has a
+worked checklist.
 
 ## Table projection modes
 
@@ -216,20 +185,77 @@ document order) and `rows` (string arrays, one per body
 row). Short rows are padded with `""` to header width.
 Duplicate headers are accepted — `columns` is positional.
 
-For a `Feature`/`Status` table with `{ kind: table }`:
+A `Feature`/`Status` table, default vs.
+`projection: rows`:
 
 ```json
 "matrix": { "rows": [{ "Feature": "check", "Status": "ready" }] }
+"matrix": { "columns": ["Feature", "Status"], "rows": [["check", "ready"]] }
 ```
 
-With `{ kind: table, projection: rows }`:
+## Block projection (whole-body)
+
+`projection: blocks` projects a section's whole body as
+a typed, recursive `blocks` list, in document order. It
+is the block-level analogue of `projection: inline`. Set
+it on a scope, or once at the schema root as the default
+for every section:
+
+```yaml
+sections:
+  - heading: { regex: '^Notes$' }
+    projection: blocks
+```
+
+Each body node maps to one block object:
+
+| Body node      | Emitted block                              |
+| -------------- | ------------------------------------------ |
+| paragraph      | `{block: paragraph, text}`                 |
+| fenced code    | `{block: code, lang?, value}`              |
+| list           | `{block: list, items: [tree items]}`       |
+| table          | `{block: table, columns, rows}`            |
+| blockquote     | `{block: quote, blocks: [...]}`            |
+| thematic break | `{block: break}`                           |
+| HTML block     | `{block: html, value}`                     |
+| deeper heading | `{block: section, level, heading, blocks}` |
+
+Container blocks (`quote`, `section`) recurse through
+the same grammar. A `section` block appears only for a
+heading deeper than the declared schema. Declared
+child scopes keep projecting as keyed objects. `code`
+keeps its trailing newline; `items` reuse the `tree`
+shape above.
+
+A **schema-level** `projection: blocks` also projects
+the sections the walker skips — wildcard and unlisted
+headings. Each lands under its slug, its heading text in
+a `heading` field, a repeated heading as an array. With
+the [`title`](#default-projection) key, one switch
+yields the whole document as data.
 
 ```json
-"matrix": {
-  "columns": ["Feature", "Status"],
-  "rows": [["check", "ready"]]
+"background": {
+  "heading": "Background",
+  "blocks": [{ "block": "paragraph", "text": "Why it exists." }]
 }
 ```
+
+Paragraph blocks default to flat `text`. Set
+`block-paragraphs: inline` beside `projection: blocks`
+to project each paragraph's span list under `inline`
+instead. Block-mode inline is lenient: an image
+projects an `{span: image, url, …}` span rather than
+the hard error strict `projection: inline` raises.
+
+### The CUE contract
+
+The grammar ships as a CUE definition at
+`github.com/jeduden/mdsmith/extract`. It is a closed
+`#Block` disjunction plus the `#Span` from
+[inline projection](#inline-span-projection). A
+differential test validates every fixture against it.
+The shape cannot drift from this reference.
 
 ## Custom binding with `bind`
 
@@ -239,17 +265,15 @@ A scope or content entry can set an optional
 - `bind: <name>` renames a scope's key (replacing
   the slugified heading) or a content entry's key
   (replacing `code` / `inline` / `items` / `rows` / `text`).
-- `bind: ""` on a scope hoists its children and
-  content directly into the parent — useful when a
-  wrapper heading exists only for document structure
-  and should not nest in the data tree.
+- `bind: ""` on a scope hoists its children and content
+  into the parent — for a wrapper heading that should not
+  nest in the data tree.
 
-Duplicate sibling binds, `bind:` on a preamble,
-slot, or broad matcher, `bind: ""` on a content
-entry, and a real disagreement between composed
-kinds each surface as an error before extraction
-runs. For ad-hoc transformations beyond what
-`bind:` covers, pipe the standard output through
+Misuses each surface as an error before extraction
+runs: duplicate sibling binds, `bind:` on a preamble,
+slot, or broad matcher, `bind: ""` on a content entry,
+or a real disagreement between composed kinds. For
+transformations beyond `bind:`, pipe the output through
 `jq` or `yq`.
 
 ## Examples

--- a/internal/extract/block.go
+++ b/internal/extract/block.go
@@ -1,0 +1,183 @@
+package extract
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/yuin/goldmark/ast"
+	extast "github.com/yuin/goldmark/extension/ast"
+)
+
+// blocksFromNodes maps a document-ordered slice of block-level AST
+// nodes to the typed `blocks` list (plan 246's block grammar). It is
+// the block-level analogue of inlineSpans: container blocks
+// (blockquote, deeper-heading section) recurse through the same
+// grammar, leaves carry their own payload.
+//
+// A heading node in the slice opens a nested `section` block: every
+// following node, up to the next heading of the same or a shallower
+// level, becomes that section's recursive `blocks`. So a heading and
+// the body beneath it nest under one `section` object rather than
+// flattening into siblings. The caller bounds the slice to the
+// enclosing scope's body, so every heading here is deeper than that
+// scope.
+//
+// The walker drives `mdsmith extract` only — never the check hot
+// path — so it favours a clear recursive shape over the allocation
+// budget the lint rules hold to.
+func (p *projector) blocksFromNodes(nodes []ast.Node) []any {
+	blocks := make([]any, 0, len(nodes))
+	for i := 0; i < len(nodes); {
+		n := nodes[i]
+		if h, ok := n.(*ast.Heading); ok {
+			// Gather the heading's body: siblings up to the next
+			// heading of the same or shallower level.
+			j := i + 1
+			for j < len(nodes) && !headingAtOrAbove(nodes[j], h.Level) {
+				j++
+			}
+			blocks = append(blocks, p.sectionBlock(h, nodes[i+1:j]))
+			i = j
+			continue
+		}
+		if b := p.blockNode(n); b != nil {
+			blocks = append(blocks, b)
+		}
+		i++
+	}
+	return blocks
+}
+
+// headingAtOrAbove reports whether n is a heading whose level is <=
+// level — the boundary that closes a nested `section` block's body.
+func headingAtOrAbove(n ast.Node, level int) bool {
+	h, ok := n.(*ast.Heading)
+	return ok && h.Level <= level
+}
+
+// blocksFromChildren maps every block child of parent. Container
+// blocks (blockquote) recurse through it. A blockquote body has no
+// headings in practice, but routing through blocksFromNodes keeps the
+// section-nesting behaviour uniform if one appears.
+func (p *projector) blocksFromChildren(parent ast.Node) []any {
+	var nodes []ast.Node
+	for c := parent.FirstChild(); c != nil; c = c.NextSibling() {
+		nodes = append(nodes, c)
+	}
+	return p.blocksFromNodes(nodes)
+}
+
+// blockNode maps one block-level AST node to its block object per the
+// plan 246 grammar table. It returns nil (after recording a
+// diagnostic) for any node the table does not cover, mirroring
+// inlineSpan's hard-error contract.
+func (p *projector) blockNode(n ast.Node) map[string]any {
+	switch node := n.(type) {
+	case *ast.Paragraph, *ast.TextBlock:
+		return p.paragraphBlock(n)
+	case *ast.FencedCodeBlock:
+		return p.fencedCodeBlock(node)
+	case *ast.CodeBlock:
+		return p.indentedCodeBlock(node)
+	case *ast.List:
+		return map[string]any{"block": "list", "items": p.listTree(node)}
+	case *extast.Table:
+		cols, rows := p.tableRowsPositional(node)
+		return map[string]any{"block": "table", "columns": cols, "rows": rows}
+	case *ast.Blockquote:
+		return map[string]any{"block": "quote", "blocks": p.blocksFromChildren(node)}
+	case *ast.ThematicBreak:
+		return map[string]any{"block": "break"}
+	case *ast.HTMLBlock:
+		return map[string]any{"block": "html", "value": p.htmlBlockValue(node)}
+	default:
+		p.unsupportedBlock(n)
+		return nil
+	}
+}
+
+// paragraphBlock projects a paragraph (or a loose list item's
+// TextBlock) as `{block: paragraph, text}`. The inline-span option
+// (`{block: paragraph, inline}`) is wired by task 5; the default is
+// plain text, matching the `text` content projection.
+func (p *projector) paragraphBlock(n ast.Node) map[string]any {
+	return map[string]any{"block": "paragraph", "text": p.nodeText(n)}
+}
+
+// fencedCodeBlock projects a fenced code block as `{block: code,
+// lang?, value}`. The fence info string becomes `lang` when present.
+// `value` keeps the body's trailing newline (the `code` content
+// projection's codeBody trims it; the block grammar promises the
+// verbatim body, so rawLines does not trim).
+func (p *projector) fencedCodeBlock(n *ast.FencedCodeBlock) map[string]any {
+	b := map[string]any{"block": "code", "value": p.rawLines(n)}
+	if lang := string(n.Language(p.f.Source)); lang != "" {
+		b["lang"] = lang
+	}
+	return b
+}
+
+// indentedCodeBlock projects an indented (non-fenced) code block. It
+// has no info string, so `lang` is always absent.
+func (p *projector) indentedCodeBlock(n *ast.CodeBlock) map[string]any {
+	return map[string]any{"block": "code", "value": p.rawLines(n)}
+}
+
+// rawLines concatenates a block's Lines() segments verbatim.
+func (p *projector) rawLines(n ast.Node) string {
+	var b strings.Builder
+	segs := n.Lines()
+	for i := 0; i < segs.Len(); i++ {
+		seg := segs.At(i)
+		b.Write(seg.Value(p.f.Source))
+	}
+	return b.String()
+}
+
+// htmlBlockValue concatenates an HTML block's raw lines plus its
+// closing line (when present), so the projected `value` is the
+// verbatim HTML the source carried.
+func (p *projector) htmlBlockValue(n *ast.HTMLBlock) string {
+	var b strings.Builder
+	segs := n.Lines()
+	for i := 0; i < segs.Len(); i++ {
+		seg := segs.At(i)
+		b.Write(seg.Value(p.f.Source))
+	}
+	if n.HasClosure() {
+		cl := n.ClosureLine
+		b.Write(cl.Value(p.f.Source))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// sectionBlock projects a heading deeper than the declared schema as
+// `{block: section, level, heading, blocks}`. body is the heading's
+// run of following nodes (up to the next same-or-shallower heading),
+// which recurse through the same grammar — so a deeper heading nested
+// inside body opens its own `section` block.
+func (p *projector) sectionBlock(h *ast.Heading, body []ast.Node) map[string]any {
+	return map[string]any{
+		"block":   "section",
+		"level":   h.Level,
+		"heading": p.nodeText(h),
+		"blocks":  p.blocksFromNodes(body),
+	}
+}
+
+// unsupportedBlock records a hard projection error naming the block
+// node type the grammar cannot represent. Mirrors unsupportedInline:
+// extract treats any diagnostic as a hard failure and emits nothing.
+// The grammar covers every standard CommonMark + GFM-table block, so
+// this fires only for a custom block node a future extension adds.
+func (p *projector) unsupportedBlock(n ast.Node) {
+	p.emit(schema.SchemaDiagnostic{
+		Field:    "blocks",
+		Actual:   fmt.Sprintf("an unsupported block node (%T)", n),
+		Expected: "one of: paragraph, code, list, table, quote, break, html, section",
+		Hint: "the `projection: blocks` grammar covers only those blocks; " +
+			"remove the node or project the section a different way",
+		SchemaRef: schema.FormatSchemaRef(p.sch, ""),
+	})
+}

--- a/internal/extract/block.go
+++ b/internal/extract/block.go
@@ -98,10 +98,20 @@ func (p *projector) blockNode(n ast.Node) map[string]any {
 }
 
 // paragraphBlock projects a paragraph (or a loose list item's
-// TextBlock) as `{block: paragraph, text}`. The inline-span option
-// (`{block: paragraph, inline}`) is wired by task 5; the default is
-// plain text, matching the `text` content projection.
+// TextBlock). The default is flat `text`, matching the `text` content
+// projection. When the scope's `block-paragraphs` is `inline`
+// (p.blockInline), it projects the paragraph's typed inline-span list
+// under `inline` instead, so block mode does not force plain text.
+// Block-mode inline is lenient (lenientInlineSpans): an image projects
+// an `image` span rather than aborting, so representable content never
+// exits non-zero. Plan 246.
 func (p *projector) paragraphBlock(n ast.Node) map[string]any {
+	if p.blockInline {
+		return map[string]any{
+			"block":  "paragraph",
+			"inline": p.lenientInlineSpans(n),
+		}
+	}
 	return map[string]any{"block": "paragraph", "text": p.nodeText(n)}
 }
 

--- a/internal/extract/block.go
+++ b/internal/extract/block.go
@@ -26,7 +26,7 @@ import (
 // The walker drives `mdsmith extract` only — never the check hot
 // path — so it favours a clear recursive shape over the allocation
 // budget the lint rules hold to.
-func (p *projector) blocksFromNodes(nodes []ast.Node) []any {
+func (p *projector) blocksFromNodes(nodes []ast.Node, inline bool) []any {
 	blocks := make([]any, 0, len(nodes))
 	for i := 0; i < len(nodes); {
 		n := nodes[i]
@@ -37,11 +37,11 @@ func (p *projector) blocksFromNodes(nodes []ast.Node) []any {
 			for j < len(nodes) && !headingAtOrAbove(nodes[j], h.Level) {
 				j++
 			}
-			blocks = append(blocks, p.sectionBlock(h, nodes[i+1:j]))
+			blocks = append(blocks, p.sectionBlock(h, nodes[i+1:j], inline))
 			i = j
 			continue
 		}
-		if b := p.blockNode(n); b != nil {
+		if b := p.blockNode(n, inline); b != nil {
 			blocks = append(blocks, b)
 		}
 		i++
@@ -60,22 +60,24 @@ func headingAtOrAbove(n ast.Node, level int) bool {
 // blocks (blockquote) recurse through it. A blockquote body has no
 // headings in practice, but routing through blocksFromNodes keeps the
 // section-nesting behaviour uniform if one appears.
-func (p *projector) blocksFromChildren(parent ast.Node) []any {
+func (p *projector) blocksFromChildren(parent ast.Node, inline bool) []any {
 	var nodes []ast.Node
 	for c := parent.FirstChild(); c != nil; c = c.NextSibling() {
 		nodes = append(nodes, c)
 	}
-	return p.blocksFromNodes(nodes)
+	return p.blocksFromNodes(nodes, inline)
 }
 
 // blockNode maps one block-level AST node to its block object per the
 // plan 246 grammar table. It returns nil (after recording a
 // diagnostic) for any node the table does not cover, mirroring
-// inlineSpan's hard-error contract.
-func (p *projector) blockNode(n ast.Node) map[string]any {
+// inlineSpan's hard-error contract. inline selects the paragraph
+// rendering (`block-paragraphs: inline`) and flows through container
+// recursion.
+func (p *projector) blockNode(n ast.Node, inline bool) map[string]any {
 	switch node := n.(type) {
 	case *ast.Paragraph, *ast.TextBlock:
-		return p.paragraphBlock(n)
+		return p.paragraphBlock(n, inline)
 	case *ast.FencedCodeBlock:
 		return p.fencedCodeBlock(node)
 	case *ast.CodeBlock:
@@ -86,7 +88,7 @@ func (p *projector) blockNode(n ast.Node) map[string]any {
 		cols, rows := p.tableRowsPositional(node)
 		return map[string]any{"block": "table", "columns": cols, "rows": rows}
 	case *ast.Blockquote:
-		return map[string]any{"block": "quote", "blocks": p.blocksFromChildren(node)}
+		return map[string]any{"block": "quote", "blocks": p.blocksFromChildren(node, inline)}
 	case *ast.ThematicBreak:
 		return map[string]any{"block": "break"}
 	case *ast.HTMLBlock:
@@ -99,14 +101,14 @@ func (p *projector) blockNode(n ast.Node) map[string]any {
 
 // paragraphBlock projects a paragraph (or a loose list item's
 // TextBlock). The default is flat `text`, matching the `text` content
-// projection. When the scope's `block-paragraphs` is `inline`
-// (p.blockInline), it projects the paragraph's typed inline-span list
-// under `inline` instead, so block mode does not force plain text.
-// Block-mode inline is lenient (lenientInlineSpans): an image projects
-// an `image` span rather than aborting, so representable content never
-// exits non-zero. Plan 246.
-func (p *projector) paragraphBlock(n ast.Node) map[string]any {
-	if p.blockInline {
+// projection. When the scope's `block-paragraphs` is `inline`, it
+// projects the paragraph's typed inline-span list under `inline`
+// instead, so block mode does not force plain text. Block-mode inline
+// is lenient (lenientInlineSpans): an image projects an `image` span
+// rather than aborting, so representable content never exits
+// non-zero. Plan 246.
+func (p *projector) paragraphBlock(n ast.Node, inline bool) map[string]any {
+	if inline {
 		return map[string]any{
 			"block":  "paragraph",
 			"inline": p.lenientInlineSpans(n),
@@ -149,17 +151,11 @@ func (p *projector) rawLines(n ast.Node) string {
 // closing line (when present), so the projected `value` is the
 // verbatim HTML the source carried.
 func (p *projector) htmlBlockValue(n *ast.HTMLBlock) string {
-	var b strings.Builder
-	segs := n.Lines()
-	for i := 0; i < segs.Len(); i++ {
-		seg := segs.At(i)
-		b.Write(seg.Value(p.f.Source))
-	}
+	v := p.rawLines(n)
 	if n.HasClosure() {
-		cl := n.ClosureLine
-		b.Write(cl.Value(p.f.Source))
+		v += string(n.ClosureLine.Value(p.f.Source))
 	}
-	return strings.TrimRight(b.String(), "\n")
+	return strings.TrimRight(v, "\n")
 }
 
 // sectionBlock projects a heading deeper than the declared schema as
@@ -167,12 +163,12 @@ func (p *projector) htmlBlockValue(n *ast.HTMLBlock) string {
 // run of following nodes (up to the next same-or-shallower heading),
 // which recurse through the same grammar — so a deeper heading nested
 // inside body opens its own `section` block.
-func (p *projector) sectionBlock(h *ast.Heading, body []ast.Node) map[string]any {
+func (p *projector) sectionBlock(h *ast.Heading, body []ast.Node, inline bool) map[string]any {
 	return map[string]any{
 		"block":   "section",
 		"level":   h.Level,
 		"heading": p.nodeText(h),
-		"blocks":  p.blocksFromNodes(body),
+		"blocks":  p.blocksFromNodes(body, inline),
 	}
 }
 

--- a/internal/extract/block_test.go
+++ b/internal/extract/block_test.go
@@ -1,0 +1,211 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/jeduden/mdsmith/pkg/markdown/flavor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/text"
+)
+
+// topNodes returns body's top-level block children in document order,
+// parsed table-aware so GFM tables surface as *extast.Table (the same
+// parse the section blocks-projection feeds the walker). It is the
+// unit-level driver for the block grammar.
+func topNodes(t *testing.T, body string) (*projector, []ast.Node) {
+	t.Helper()
+	f := doc(t, body)
+	parser, reset := flavor.NewPooledParserWith(extension.Table)
+	defer reset()
+	root := parser.Parse(text.NewReader(f.Source))
+	p := &projector{f: f}
+	var nodes []ast.Node
+	for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+		nodes = append(nodes, c)
+	}
+	return p, nodes
+}
+
+// walkBody parses body, walks its top-level blocks through the block
+// grammar, and returns the typed list plus the projector (for diags).
+func walkBody(t *testing.T, body string) ([]any, *projector) {
+	t.Helper()
+	p, nodes := topNodes(t, body)
+	return p.blocksFromNodes(nodes), p
+}
+
+func TestBlockWalker_Paragraph(t *testing.T) {
+	got, p := walkBody(t, "First paragraph.\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "paragraph",
+		"text":  "First paragraph.",
+	}, got[0])
+}
+
+func TestBlockWalker_FencedCodeWithLang(t *testing.T) {
+	got, p := walkBody(t, "```go\nfunc F() {}\n```\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "code",
+		"lang":  "go",
+		"value": "func F() {}\n",
+	}, got[0])
+}
+
+// A fence with no info string omits `lang` entirely.
+func TestBlockWalker_FencedCodeNoLang(t *testing.T) {
+	got, p := walkBody(t, "```\nplain\n```\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "code",
+		"value": "plain\n",
+	}, got[0])
+}
+
+// An indented code block also projects as a `code` block, never with
+// a `lang` (indented fences carry no info string).
+func TestBlockWalker_IndentedCode(t *testing.T) {
+	got, p := walkBody(t, "    indented\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "code",
+		"value": "indented\n",
+	}, got[0])
+}
+
+func TestBlockWalker_List(t *testing.T) {
+	got, p := walkBody(t, "- one item\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "list",
+		"items": []any{map[string]any{"text": "one item"}},
+	}, got[0])
+}
+
+func TestBlockWalker_Table(t *testing.T) {
+	got, p := walkBody(t, "| A |\n| - |\n| 1 |\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block":   "table",
+		"columns": []any{"A"},
+		"rows":    []any{[]any{"1"}},
+	}, got[0])
+}
+
+func TestBlockWalker_Quote(t *testing.T) {
+	got, p := walkBody(t, "> A quoted line.\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "quote",
+		"blocks": []any{
+			map[string]any{"block": "paragraph", "text": "A quoted line."},
+		},
+	}, got[0])
+}
+
+func TestBlockWalker_ThematicBreak(t *testing.T) {
+	got, p := walkBody(t, "---\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{"block": "break"}, got[0])
+}
+
+func TestBlockWalker_HTMLBlock(t *testing.T) {
+	got, p := walkBody(t, "<div>raw</div>\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "html",
+		"value": "<div>raw</div>",
+	}, got[0])
+}
+
+// A deeper heading inside the slice opens a nested `section` block;
+// the body beneath it recurses through the same grammar.
+func TestBlockWalker_SectionFromHeading(t *testing.T) {
+	got, p := walkBody(t, "### Sub\n\nbody text\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block":   "section",
+		"level":   3,
+		"heading": "Sub",
+		"blocks": []any{
+			map[string]any{"block": "paragraph", "text": "body text"},
+		},
+	}, got[0])
+}
+
+// A heading of the same or shallower level closes the previous
+// section's body — two sibling sections, not a nested one.
+func TestBlockWalker_SiblingSectionsCloseAtSameLevel(t *testing.T) {
+	got, p := walkBody(t, "### One\n\na\n\n### Two\n\nb\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 2)
+	assert.Equal(t, 3, got[0].(map[string]any)["level"])
+	assert.Equal(t, "One", got[0].(map[string]any)["heading"])
+	assert.Equal(t, "Two", got[1].(map[string]any)["heading"])
+}
+
+// A deeper heading nests under its parent section recursively.
+func TestBlockWalker_NestedSection(t *testing.T) {
+	got, p := walkBody(t, "### Parent\n\np\n\n#### Child\n\nc\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	parent := got[0].(map[string]any)
+	inner := parent["blocks"].([]any)
+	// parent's paragraph, then the nested child section
+	require.Len(t, inner, 2)
+	assert.Equal(t, "paragraph", inner[0].(map[string]any)["block"])
+	child := inner[1].(map[string]any)
+	assert.Equal(t, "section", child["block"])
+	assert.Equal(t, 4, child["level"])
+	assert.Equal(t, "Child", child["heading"])
+}
+
+// Document order is preserved across mixed block kinds.
+func TestBlockWalker_DocumentOrder(t *testing.T) {
+	body := "First paragraph.\n\n```go\nfunc F() {}\n```\n\n> A quoted line.\n\n" +
+		"- one item\n\n| A |\n| - |\n| 1 |\n"
+	got, p := walkBody(t, body)
+	require.Empty(t, p.diags)
+	require.Len(t, got, 5)
+	kinds := make([]string, len(got))
+	for i, b := range got {
+		kinds[i] = b.(map[string]any)["block"].(string)
+	}
+	assert.Equal(t, []string{"paragraph", "code", "quote", "list", "table"}, kinds)
+}
+
+// headingAtOrAbove is a small predicate; pin both arms.
+func TestHeadingAtOrAbove(t *testing.T) {
+	h2 := ast.NewHeading(2)
+	assert.True(t, headingAtOrAbove(h2, 2))
+	assert.True(t, headingAtOrAbove(h2, 3))
+	assert.False(t, headingAtOrAbove(h2, 1))
+	assert.False(t, headingAtOrAbove(ast.NewParagraph(), 1))
+}
+
+// An unsupported block node records a hard diagnostic and is dropped
+// from the output (extract treats any diagnostic as a hard failure).
+// No Markdown source produces a node outside the grammar, so feed the
+// walker a synthetic document node to drive the default arm.
+func TestBlockWalker_UnsupportedBlock(t *testing.T) {
+	p := &projector{f: doc(t, "x\n"), sch: &schema.Schema{}}
+	got := p.blocksFromNodes([]ast.Node{ast.NewDocument()})
+	assert.Empty(t, got)
+	require.NotEmpty(t, p.diags)
+	assert.Contains(t, p.diags[0].Message, "unsupported block")
+}

--- a/internal/extract/block_test.go
+++ b/internal/extract/block_test.go
@@ -103,6 +103,21 @@ func TestBlockWalker_Table(t *testing.T) {
 	}, got[0])
 }
 
+// A header-only table (valid GFM: header + delimiter, no body rows)
+// projects `rows` as an empty, non-nil slice so it serialises to
+// `"rows": []` — the published CUE `#Block` contract rejects the
+// `"rows": null` a nil slice would produce.
+func TestBlockWalker_TableHeaderOnly(t *testing.T) {
+	got, p := walkBody(t, "| A | B |\n| - | - |\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block":   "table",
+		"columns": []any{"A", "B"},
+		"rows":    []any{},
+	}, got[0])
+}
+
 func TestBlockWalker_Quote(t *testing.T) {
 	got, p := walkBody(t, "> A quoted line.\n")
 	require.Empty(t, p.diags)
@@ -129,6 +144,19 @@ func TestBlockWalker_HTMLBlock(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		"block": "html",
 		"value": "<div>raw</div>",
+	}, got[0])
+}
+
+// A multi-line HTML block with an explicit closing line (a comment
+// block, goldmark HTML-block type 2) carries its closure line into the
+// projected `value`, exercising htmlBlockValue's HasClosure() branch.
+func TestBlockWalker_HTMLBlockWithClosure(t *testing.T) {
+	got, p := walkBody(t, "<!-- open\nmiddle\nclose -->\n")
+	require.Empty(t, p.diags)
+	require.Len(t, got, 1)
+	assert.Equal(t, map[string]any{
+		"block": "html",
+		"value": "<!-- open\nmiddle\nclose -->",
 	}, got[0])
 }
 

--- a/internal/extract/block_test.go
+++ b/internal/extract/block_test.go
@@ -35,7 +35,7 @@ func topNodes(t *testing.T, body string) (*projector, []ast.Node) {
 func walkBody(t *testing.T, body string) ([]any, *projector) {
 	t.Helper()
 	p, nodes := topNodes(t, body)
-	return p.blocksFromNodes(nodes), p
+	return p.blocksFromNodes(nodes, false), p
 }
 
 func TestBlockWalker_Paragraph(t *testing.T) {
@@ -232,7 +232,7 @@ func TestHeadingAtOrAbove(t *testing.T) {
 // walker a synthetic document node to drive the default arm.
 func TestBlockWalker_UnsupportedBlock(t *testing.T) {
 	p := &projector{f: doc(t, "x\n"), sch: &schema.Schema{}}
-	got := p.blocksFromNodes([]ast.Node{ast.NewDocument()})
+	got := p.blocksFromNodes([]ast.Node{ast.NewDocument()}, false)
 	assert.Empty(t, got)
 	require.NotEmpty(t, p.diags)
 	assert.Contains(t, p.diags[0].Message, "unsupported block")

--- a/internal/extract/blocks_projection_test.go
+++ b/internal/extract/blocks_projection_test.go
@@ -1,0 +1,130 @@
+package extract
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blocksScope builds a single named section that projects its whole
+// body via `projection: blocks`.
+func blocksScope(heading string) *schema.Schema {
+	return &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:    heading,
+			Matcher:    &schema.Matcher{Regex: heading},
+			Projection: schema.ProjectionBlocks,
+		}},
+	}
+}
+
+// TestExtract_ScopeBlocksWholeBody is the plan-246 worked example: a
+// scope with `projection: blocks` projects its entire body, in
+// document order, with containers recursing.
+func TestExtract_ScopeBlocksWholeBody(t *testing.T) {
+	body := "## Notes\n\n" +
+		"First paragraph.\n\n" +
+		"```go\nfunc F() {}\n```\n\n" +
+		"> A quoted line.\n\n" +
+		"- one item\n\n" +
+		"| A |\n| - |\n| 1 |\n"
+	got, diags := run(t, body, blocksScope("Notes"), nil)
+	require.Empty(t, diags)
+	notes := got.(map[string]any)["notes"].(map[string]any)
+	blocks := notes["blocks"].([]any)
+	assert.Equal(t, []any{
+		map[string]any{"block": "paragraph", "text": "First paragraph."},
+		map[string]any{"block": "code", "lang": "go", "value": "func F() {}\n"},
+		map[string]any{"block": "quote", "blocks": []any{
+			map[string]any{"block": "paragraph", "text": "A quoted line."},
+		}},
+		map[string]any{"block": "list", "items": []any{
+			map[string]any{"text": "one item"},
+		}},
+		map[string]any{"block": "table", "columns": []any{"A"}, "rows": []any{[]any{"1"}}},
+	}, blocks)
+}
+
+// A deeper heading inside a blocks-projected section nests as a
+// `section` block, recursive, with the heading text preserved.
+func TestExtract_ScopeBlocksNestsDeeperHeading(t *testing.T) {
+	body := "## Notes\n\nlead para\n\n### Detail\n\ndetail para\n"
+	got, diags := run(t, body, blocksScope("Notes"), nil)
+	require.Empty(t, diags)
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 2)
+	assert.Equal(t, map[string]any{"block": "paragraph", "text": "lead para"}, blocks[0])
+	assert.Equal(t, map[string]any{
+		"block":   "section",
+		"level":   3,
+		"heading": "Detail",
+		"blocks": []any{
+			map[string]any{"block": "paragraph", "text": "detail para"},
+		},
+	}, blocks[1])
+}
+
+// A scope can declare content entries AND project blocks; the two
+// coexist as sibling keys (the declared `text`, plus `blocks`).
+func TestExtract_ScopeBlocksAlongsideContent(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:    "Notes",
+			Matcher:    &schema.Matcher{Regex: "Notes"},
+			Projection: schema.ProjectionBlocks,
+			Content: []schema.ContentEntry{
+				{Kind: schema.ContentKindParagraph, Required: true},
+			},
+		}},
+	}
+	got, diags := run(t, "## Notes\n\nintro\n", sch, nil)
+	require.Empty(t, diags)
+	notes := got.(map[string]any)["notes"].(map[string]any)
+	assert.Equal(t, "intro", notes["text"])
+	blocks := notes["blocks"].([]any)
+	assert.Equal(t, []any{
+		map[string]any{"block": "paragraph", "text": "intro"},
+	}, blocks)
+}
+
+// A declared content entry that binds to `blocks` collides with the
+// whole-body blocks key — reported, not silently overwritten.
+func TestExtract_ScopeBlocksKeyCollidesWithBoundEntry(t *testing.T) {
+	bindBlocks := "blocks"
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:    "Notes",
+			Matcher:    &schema.Matcher{Regex: "Notes"},
+			Projection: schema.ProjectionBlocks,
+			Content: []schema.ContentEntry{
+				{Kind: schema.ContentKindParagraph, Required: true, Bind: &bindBlocks},
+			},
+		}},
+	}
+	_, diags := run(t, "## Notes\n\nintro\n", sch, nil)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "blocks")
+}
+
+// An empty blocks-projected section emits an empty `blocks` array
+// (not nil): the body slice is empty but non-nil, so the key appears.
+func TestExtract_ScopeBlocksEmptyBody(t *testing.T) {
+	body := "## Notes\n\n## Other\n\nx\n"
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{
+			{Heading: "Notes", Matcher: &schema.Matcher{Regex: "Notes"},
+				Projection: schema.ProjectionBlocks},
+			litScope("Other"),
+		},
+	}
+	got, diags := run(t, body, sch, nil)
+	require.Empty(t, diags)
+	notes := got.(map[string]any)["notes"].(map[string]any)
+	assert.Equal(t, []any{}, notes["blocks"])
+}

--- a/internal/extract/blocks_projection_test.go
+++ b/internal/extract/blocks_projection_test.go
@@ -211,3 +211,120 @@ func TestExtract_SchemaBlocksUnlistedCollidesWithDeclared(t *testing.T) {
 	require.NotEmpty(t, diags)
 	assert.Contains(t, diags[0].Message, "goal")
 }
+
+// With the inline-paragraph option, a paragraph block carries `inline`
+// spans instead of flat `text`, so block mode does not force plain
+// text (plan 246 task 5; reuses plan 212's span shape).
+func TestExtract_ScopeBlocksInlineParagraphs(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:         "Notes",
+			Matcher:         &schema.Matcher{Regex: "Notes"},
+			Projection:      schema.ProjectionBlocks,
+			BlockParagraphs: schema.ProjectionInline,
+		}},
+	}
+	got, diags := run(t, "## Notes\n\nMark*down*.\n", sch, nil)
+	require.Empty(t, diags)
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 1)
+	para := blocks[0].(map[string]any)
+	assert.Equal(t, "paragraph", para["block"])
+	assert.NotContains(t, para, "text")
+	assert.Equal(t, []any{
+		map[string]any{"span": "text", "value": "Mark"},
+		map[string]any{
+			"span": "emphasis", "level": 1,
+			"children": []any{map[string]any{"span": "text", "value": "down"}},
+		},
+		map[string]any{"span": "text", "value": "."},
+	}, para["inline"])
+}
+
+// An image inside a blocks-mode paragraph projects under the inline
+// option without a hard error (the acceptance criterion: extract does
+// not exit non-zero for representable content). The image projects as
+// an `image` span rather than aborting like plan 212's strict inline.
+func TestExtract_ScopeBlocksInlineParagraphImage(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:         "Notes",
+			Matcher:         &schema.Matcher{Regex: "Notes"},
+			Projection:      schema.ProjectionBlocks,
+			BlockParagraphs: schema.ProjectionInline,
+		}},
+	}
+	got, diags := run(t, "## Notes\n\nSee ![alt](pic.png) here.\n", sch, nil)
+	require.Empty(t, diags, "an image must not abort blocks-mode inline projection")
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 1)
+	spans := blocks[0].(map[string]any)["inline"].([]any)
+	// text "See ", image span, text " here."
+	var sawImage bool
+	for _, s := range spans {
+		if s.(map[string]any)["span"] == "image" {
+			sawImage = true
+		}
+	}
+	assert.True(t, sawImage, "the image must project as an image span")
+}
+
+// The default (text) blocks projection still drops an image to plain
+// text without erroring — the defined fallback the acceptance
+// criterion allows.
+func TestExtract_ScopeBlocksTextParagraphImageFallback(t *testing.T) {
+	got, diags := run(t, "## Notes\n\nSee ![alt](pic.png) here.\n", blocksScope("Notes"), nil)
+	require.Empty(t, diags)
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, map[string]any{
+		"block": "paragraph",
+		"text":  "See alt here.",
+	}, blocks[0])
+}
+
+// A schema-level `block-paragraphs: inline` applies to an unlisted
+// section (nil scope -> schema default): its paragraph blocks carry
+// inline spans.
+func TestExtract_SchemaBlockParagraphsInlineUnlisted(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel:       2,
+		Projection:      schema.ProjectionBlocks,
+		BlockParagraphs: schema.ProjectionInline,
+		Sections: []schema.Scope{
+			{Heading: "Goal", Matcher: &schema.Matcher{Regex: "Goal"}},
+		},
+	}
+	got, diags := run(t, "## Goal\n\nx\n\n## Extra\n\n`code` here\n", sch, nil)
+	require.Empty(t, diags)
+	extra := got.(map[string]any)["extra"].(map[string]any)
+	para := extra["blocks"].([]any)[0].(map[string]any)
+	assert.NotContains(t, para, "text")
+	spans := para["inline"].([]any)
+	assert.Equal(t, map[string]any{"span": "code", "value": "code"}, spans[0])
+}
+
+// The inline-paragraph choice propagates into nested `section` blocks:
+// a deeper heading's paragraph also renders inline.
+func TestExtract_BlockParagraphsInlineNestedSection(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:         "Notes",
+			Matcher:         &schema.Matcher{Regex: "Notes"},
+			Projection:      schema.ProjectionBlocks,
+			BlockParagraphs: schema.ProjectionInline,
+		}},
+	}
+	got, diags := run(t, "## Notes\n\n### Sub\n\n`x` y\n", sch, nil)
+	require.Empty(t, diags)
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 1)
+	section := blocks[0].(map[string]any)
+	require.Equal(t, "section", section["block"])
+	para := section["blocks"].([]any)[0].(map[string]any)
+	assert.Contains(t, para, "inline")
+	assert.NotContains(t, para, "text")
+}

--- a/internal/extract/blocks_projection_test.go
+++ b/internal/extract/blocks_projection_test.go
@@ -111,6 +111,64 @@ func TestExtract_ScopeBlocksKeyCollidesWithBoundEntry(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "blocks")
 }
 
+// schemaBlocksDefault builds a schema with a single declared section
+// plus a schema-level `projection: blocks` default.
+func schemaBlocksDefault(declared string) *schema.Schema {
+	return &schema.Schema{
+		RootLevel:  2,
+		Projection: schema.ProjectionBlocks,
+		Sections: []schema.Scope{
+			{Heading: declared, Matcher: &schema.Matcher{Regex: declared}},
+		},
+	}
+}
+
+// TestExtract_SchemaBlocksProjectsUnlisted is the plan-246 acceptance
+// criterion: a schema-level `projection: blocks` projects an unlisted
+// section under its slug, with its heading text preserved and its body
+// as blocks — no section of a matched document is dropped.
+func TestExtract_SchemaBlocksProjectsUnlisted(t *testing.T) {
+	body := "## Goal\n\ndeclared body\n\n## Background\n\nbackground body\n"
+	got, diags := run(t, body, schemaBlocksDefault("Goal"), nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	// Declared section: keyed object, now also carrying blocks.
+	goal := root["goal"].(map[string]any)
+	assert.Equal(t, []any{
+		map[string]any{"block": "paragraph", "text": "declared body"},
+	}, goal["blocks"])
+	// Unlisted section: keyed by slug, heading text preserved.
+	bg := root["background"].(map[string]any)
+	assert.Equal(t, "Background", bg["heading"])
+	assert.Equal(t, []any{
+		map[string]any{"block": "paragraph", "text": "background body"},
+	}, bg["blocks"])
+}
+
+// A declared scope under a schema-level blocks default has no
+// `heading` key (its slug already names it); only unlisted scopes
+// carry the `heading` text field.
+func TestExtract_SchemaBlocksDeclaredHasNoHeadingKey(t *testing.T) {
+	body := "## Goal\n\nx\n"
+	got, diags := run(t, body, schemaBlocksDefault("Goal"), nil)
+	require.Empty(t, diags)
+	goal := got.(map[string]any)["goal"].(map[string]any)
+	assert.NotContains(t, goal, "heading")
+}
+
+// Two unlisted sections whose headings slugify to the same key
+// project as an array under that key (repeating matches -> array).
+func TestExtract_SchemaBlocksRepeatingUnlistedArray(t *testing.T) {
+	body := "## Goal\n\nx\n\n## Note\n\nfirst\n\n## Note\n\nsecond\n"
+	got, diags := run(t, body, schemaBlocksDefault("Goal"), nil)
+	require.Empty(t, diags)
+	arr, ok := got.(map[string]any)["note"].([]any)
+	require.True(t, ok, "repeated unlisted slug must project as an array")
+	require.Len(t, arr, 2)
+	assert.Equal(t, "first", arr[0].(map[string]any)["blocks"].([]any)[0].(map[string]any)["text"])
+	assert.Equal(t, "second", arr[1].(map[string]any)["blocks"].([]any)[0].(map[string]any)["text"])
+}
+
 // An empty blocks-projected section emits an empty `blocks` array
 // (not nil): the body slice is empty but non-nil, so the key appears.
 func TestExtract_ScopeBlocksEmptyBody(t *testing.T) {
@@ -127,4 +185,29 @@ func TestExtract_ScopeBlocksEmptyBody(t *testing.T) {
 	require.Empty(t, diags)
 	notes := got.(map[string]any)["notes"].(map[string]any)
 	assert.Equal(t, []any{}, notes["blocks"])
+}
+
+// Schema-level blocks + plan 243's H1 title: a single switch yields
+// the whole document as data — the H1 under `title`, every section
+// (declared and unlisted) under its slug with `blocks`.
+func TestExtract_SchemaBlocksWithH1Title(t *testing.T) {
+	body := "# Doc Title\n\n## Goal\n\ng\n\n## Extra\n\ne\n"
+	got, diags := run(t, body, schemaBlocksDefault("Goal"), nil)
+	require.Empty(t, diags)
+	root := got.(map[string]any)
+	assert.Equal(t, "Doc Title", root["title"])
+	assert.Contains(t, root["goal"].(map[string]any), "blocks")
+	extra := root["extra"].(map[string]any)
+	assert.Equal(t, "Extra", extra["heading"])
+	assert.Contains(t, extra, "blocks")
+}
+
+// An unlisted heading whose slug collides with a declared scope's key
+// is reported (the declared `goal`, then a second unlisted `## Goal`
+// that the open schema tolerates but cannot key without colliding).
+func TestExtract_SchemaBlocksUnlistedCollidesWithDeclared(t *testing.T) {
+	body := "## Goal\n\nfirst\n\n## Goal\n\nsecond\n"
+	_, diags := run(t, body, schemaBlocksDefault("Goal"), nil)
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "goal")
 }

--- a/internal/extract/blocks_projection_test.go
+++ b/internal/extract/blocks_projection_test.go
@@ -271,6 +271,38 @@ func TestExtract_ScopeBlocksInlineParagraphImage(t *testing.T) {
 	assert.True(t, sawImage, "the image must project as an image span")
 }
 
+// A titled image in blocks-mode inline projects its title under a
+// `title` key on the image span (exercising the lenient image span's
+// title branch), with the alt text in `children`.
+func TestExtract_ScopeBlocksInlineParagraphImageTitle(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:         "Notes",
+			Matcher:         &schema.Matcher{Regex: "Notes"},
+			Projection:      schema.ProjectionBlocks,
+			BlockParagraphs: schema.ProjectionInline,
+		}},
+	}
+	got, diags := run(t, "## Notes\n\n![alt](pic.png \"the title\")\n", sch, nil)
+	require.Empty(t, diags)
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 1)
+	spans := blocks[0].(map[string]any)["inline"].([]any)
+	var img map[string]any
+	for _, s := range spans {
+		if sm := s.(map[string]any); sm["span"] == "image" {
+			img = sm
+		}
+	}
+	require.NotNil(t, img, "expected an image span")
+	assert.Equal(t, "the title", img["title"])
+	assert.Equal(t, "pic.png", img["url"])
+	assert.Equal(t, []any{
+		map[string]any{"span": "text", "value": "alt"},
+	}, img["children"])
+}
+
 // The default (text) blocks projection still drops an image to plain
 // text without erroring — the defined fallback the acceptance
 // criterion allows.

--- a/internal/extract/blocks_projection_test.go
+++ b/internal/extract/blocks_projection_test.go
@@ -338,6 +338,35 @@ func TestExtract_SchemaBlockParagraphsInlineUnlisted(t *testing.T) {
 	assert.Equal(t, map[string]any{"span": "code", "value": "code"}, spans[0])
 }
 
+// Scope-wins precedence in the OFF direction: a schema-level
+// `block-paragraphs: inline` default is overridden by a scope that sets
+// `block-paragraphs: text`, so that scope's paragraphs render flat
+// `text` rather than inline spans. (The inline-ON direction is covered
+// by TestExtract_ScopeBlocksInlineParagraphs; this pins the override
+// turning the option back off — the scope-wins branch of
+// inlineBlockParagraphs.)
+func TestExtract_ScopeBlockParagraphsTextOverridesSchemaInline(t *testing.T) {
+	sch := &schema.Schema{
+		RootLevel:       2,
+		Projection:      schema.ProjectionBlocks,
+		BlockParagraphs: schema.ProjectionInline,
+		Sections: []schema.Scope{{
+			Heading:         "Notes",
+			Matcher:         &schema.Matcher{Regex: "Notes"},
+			Projection:      schema.ProjectionBlocks,
+			BlockParagraphs: schema.ProjectionText,
+		}},
+	}
+	got, diags := run(t, "## Notes\n\nMark*down*.\n", sch, nil)
+	require.Empty(t, diags)
+	blocks := got.(map[string]any)["notes"].(map[string]any)["blocks"].([]any)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, map[string]any{
+		"block": "paragraph",
+		"text":  "Markdown.",
+	}, blocks[0])
+}
+
 // The inline-paragraph choice propagates into nested `section` blocks:
 // a deeper heading's paragraph also renders inline.
 func TestExtract_BlockParagraphsInlineNestedSection(t *testing.T) {

--- a/internal/extract/cue_diff_test.go
+++ b/internal/extract/cue_diff_test.go
@@ -1,0 +1,217 @@
+package extract
+
+import (
+	"encoding/json"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	cueextract "github.com/jeduden/mdsmith/cue/extract"
+	"github.com/jeduden/mdsmith/internal/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// validateAgainst compiles the published grammar, looks up the named
+// definition, and reports whether v (a projected block or span)
+// unifies with it concretely. A non-nil error means the value is
+// outside the documented grammar.
+func validateAgainst(t *testing.T, ctx *cue.Context, grammar cue.Value, def string, v any) error {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	data := ctx.CompileBytes(b)
+	require.NoError(t, data.Err())
+	unified := grammar.LookupPath(cue.ParsePath(def)).Unify(data)
+	return unified.Validate(cue.Concrete(true))
+}
+
+// grammarValue compiles the embedded grammar.cue once.
+func grammarValue(t *testing.T) (*cue.Context, cue.Value) {
+	t.Helper()
+	ctx := cuecontext.New()
+	g := ctx.CompileString(cueextract.Source())
+	require.NoError(t, g.Err(), "grammar.cue must compile")
+	return ctx, g
+}
+
+// TestCUEGrammar_Compiles is the smoke test: the published grammar
+// compiles and a single paragraph block validates against #Block.
+func TestCUEGrammar_Compiles(t *testing.T) {
+	ctx, g := grammarValue(t)
+	err := validateAgainst(t, ctx, g, "#Block",
+		map[string]any{"block": "paragraph", "text": "hi"})
+	require.NoError(t, err)
+}
+
+// TestCUEGrammar_RejectsInvalid pins that the closed definitions
+// reject malformed values: an unknown block type, an extra key, and a
+// paragraph carrying both `text` and `inline` (the disjunction forbids
+// it). If any of these validated, the contract would be too loose to
+// catch drift.
+func TestCUEGrammar_RejectsInvalid(t *testing.T) {
+	ctx, g := grammarValue(t)
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"unknown block type", map[string]any{"block": "footnote", "value": "x"}},
+		{"extra key", map[string]any{"block": "break", "stray": 1}},
+		{"paragraph text and inline", map[string]any{
+			"block": "paragraph", "text": "x", "inline": []any{},
+		}},
+		{"code missing value", map[string]any{"block": "code", "lang": "go"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateAgainst(t, ctx, g, "#Block", c.v)
+			require.Error(t, err, "grammar must reject %s", c.name)
+		})
+	}
+}
+
+// TestCUEGrammar_RejectsInvalidSpan pins span-level rejection.
+func TestCUEGrammar_RejectsInvalidSpan(t *testing.T) {
+	ctx, g := grammarValue(t)
+	cases := []struct {
+		name string
+		v    any
+	}{
+		{"unknown span", map[string]any{"span": "smallcaps", "value": "x"}},
+		{"emphasis wrong level", map[string]any{
+			"span": "emphasis", "level": 2, "children": []any{},
+		}},
+		{"text extra key", map[string]any{"span": "text", "value": "x", "url": "y"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateAgainst(t, ctx, g, "#Span", c.v)
+			require.Error(t, err, "grammar must reject %s", c.name)
+		})
+	}
+}
+
+// validateBlocksRecursive validates every block in a `blocks` list
+// against #Block, descending into container blocks (quote, section)
+// and validating each `inline` paragraph's spans against #Span. It is
+// the differential check the plan's acceptance criterion names: a
+// fixture's projected blocks must all conform to the published
+// grammar, so the grammar cannot drift from the walker.
+func validateBlocksRecursive(t *testing.T, ctx *cue.Context, g cue.Value, blocks []any) {
+	t.Helper()
+	for _, raw := range blocks {
+		b, ok := raw.(map[string]any)
+		require.True(t, ok, "block must be an object, got %T", raw)
+		require.NoError(t, validateAgainst(t, ctx, g, "#Block", b),
+			"block %v must validate against #Block", b)
+		switch b["block"] {
+		case "quote", "section":
+			validateBlocksRecursive(t, ctx, g, b["blocks"].([]any))
+		case "paragraph":
+			if inline, hasInline := b["inline"]; hasInline {
+				for _, s := range inline.([]any) {
+					validateSpansRecursive(t, ctx, g, s.(map[string]any))
+				}
+			}
+		}
+	}
+}
+
+// validateSpansRecursive validates one span against #Span and recurses
+// into a container span's children.
+func validateSpansRecursive(t *testing.T, ctx *cue.Context, g cue.Value, span map[string]any) {
+	t.Helper()
+	require.NoError(t, validateAgainst(t, ctx, g, "#Span", span),
+		"span %v must validate against #Span", span)
+	if kids, ok := span["children"]; ok {
+		for _, c := range kids.([]any) {
+			validateSpansRecursive(t, ctx, g, c.(map[string]any))
+		}
+	}
+}
+
+// blocksCorpus projects a set of documents that together exercise
+// every block-grammar row and the inline-span option, returning each
+// projection's `blocks` list. The differential test validates the
+// whole corpus against the published grammar.
+func blocksCorpus(t *testing.T) [][]any {
+	t.Helper()
+	textScope := blocksScope("Notes")
+	inlineScopeSchema := &schema.Schema{
+		RootLevel: 2,
+		Sections: []schema.Scope{{
+			Heading:         "Notes",
+			Matcher:         &schema.Matcher{Regex: "Notes"},
+			Projection:      schema.ProjectionBlocks,
+			BlockParagraphs: schema.ProjectionInline,
+		}},
+	}
+	cases := []struct {
+		sch  *schema.Schema
+		body string
+	}{
+		// Every leaf + container block in document order.
+		{textScope, "## Notes\n\npara\n\n```go\nx := 1\n```\n\n    indented\n\n" +
+			"> quoted\n\n- a\n  - b\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\n---\n\n" +
+			"<div>raw</div>\n\n### Sub\n\nnested para\n"},
+		// Inline-paragraph option: text, emphasis, strong, code, link,
+		// autolink, image, and a soft break.
+		{inlineScopeSchema, "## Notes\n\nMark*down* **bold** `code` " +
+			"[t](u) <https://x.test> ![alt](pic.png)\nwrapped line\n"},
+		// A task list (tree items carry `checked`).
+		{textScope, "## Notes\n\n- [x] done\n- [ ] open\n  - child\n"},
+	}
+	corpus := make([][]any, 0, len(cases))
+	for _, c := range cases {
+		got, diags := run(t, c.body, c.sch, nil)
+		require.Empty(t, diags, "corpus body must project cleanly: %q", c.body)
+		notes := got.(map[string]any)["notes"].(map[string]any)
+		corpus = append(corpus, notes["blocks"].([]any))
+	}
+	return corpus
+}
+
+// TestCUEGrammar_AllBlockFixturesValidate is the plan-246 acceptance
+// criterion: every block a fixture projects validates against the
+// published #Block definition (spans against #Span), so the grammar
+// stays locked to the implementation.
+func TestCUEGrammar_AllBlockFixturesValidate(t *testing.T) {
+	ctx, g := grammarValue(t)
+	for _, blocks := range blocksCorpus(t) {
+		validateBlocksRecursive(t, ctx, g, blocks)
+	}
+}
+
+// TestCUEGrammar_CorpusCoversImageAndBreak guards the differential
+// test's value: it would still pass if the corpus never produced an
+// `image` or `break` span (those grammar rows would go unexercised).
+// Assert the inline corpus case actually emits both.
+func TestCUEGrammar_CorpusCoversImageAndBreak(t *testing.T) {
+	corpus := blocksCorpus(t)
+	var sawImage, sawBreak bool
+	var walk func(blocks []any)
+	walk = func(blocks []any) {
+		for _, raw := range blocks {
+			b := raw.(map[string]any)
+			switch b["block"] {
+			case "quote", "section":
+				walk(b["blocks"].([]any))
+			case "paragraph":
+				if inline, ok := b["inline"]; ok {
+					for _, s := range inline.([]any) {
+						switch s.(map[string]any)["span"] {
+						case "image":
+							sawImage = true
+						case "break":
+							sawBreak = true
+						}
+					}
+				}
+			}
+		}
+	}
+	for _, blocks := range corpus {
+		walk(blocks)
+	}
+	require.True(t, sawImage, "corpus must exercise the image span row")
+	require.True(t, sawBreak, "corpus must exercise the break span row")
+}

--- a/internal/extract/cue_diff_test.go
+++ b/internal/extract/cue_diff_test.go
@@ -159,6 +159,10 @@ func blocksCorpus(t *testing.T) [][]any {
 			"[t](u) <https://x.test> ![alt](pic.png)\nwrapped line\n"},
 		// A task list (tree items carry `checked`).
 		{textScope, "## Notes\n\n- [x] done\n- [ ] open\n  - child\n"},
+		// A header-only table (no body rows) emits `rows: []`; the
+		// closed `block_table` arm must accept the empty list, not
+		// just populated rows.
+		{textScope, "## Notes\n\n| A | B |\n| - | - |\n"},
 	}
 	corpus := make([][]any, 0, len(cases))
 	for _, c := range cases {

--- a/internal/extract/cue_diff_test.go
+++ b/internal/extract/cue_diff_test.go
@@ -105,11 +105,19 @@ func validateBlocksRecursive(t *testing.T, ctx *cue.Context, g cue.Value, blocks
 			"block %v must validate against #Block", b)
 		switch b["block"] {
 		case "quote", "section":
-			validateBlocksRecursive(t, ctx, g, b["blocks"].([]any))
+			kids, ok := b["blocks"].([]any)
+			require.True(t, ok,
+				"container block %v must carry a []any blocks list", b)
+			validateBlocksRecursive(t, ctx, g, kids)
 		case "paragraph":
 			if inline, hasInline := b["inline"]; hasInline {
-				for _, s := range inline.([]any) {
-					validateSpansRecursive(t, ctx, g, s.(map[string]any))
+				spans, ok := inline.([]any)
+				require.True(t, ok,
+					"paragraph %v must carry a []any inline list", b)
+				for _, s := range spans {
+					sp, ok := s.(map[string]any)
+					require.True(t, ok, "span must be an object, got %T", s)
+					validateSpansRecursive(t, ctx, g, sp)
 				}
 			}
 		}
@@ -123,8 +131,13 @@ func validateSpansRecursive(t *testing.T, ctx *cue.Context, g cue.Value, span ma
 	require.NoError(t, validateAgainst(t, ctx, g, "#Span", span),
 		"span %v must validate against #Span", span)
 	if kids, ok := span["children"]; ok {
-		for _, c := range kids.([]any) {
-			validateSpansRecursive(t, ctx, g, c.(map[string]any))
+		list, isList := kids.([]any)
+		require.True(t, isList,
+			"span %v children must be a []any list", span)
+		for _, c := range list {
+			child, isObj := c.(map[string]any)
+			require.True(t, isObj, "child span must be an object, got %T", c)
+			validateSpansRecursive(t, ctx, g, child)
 		}
 	}
 }
@@ -171,6 +184,14 @@ func blocksCorpus(t *testing.T) [][]any {
 		// is validated for a non-trivial child, not just a bare alt.
 		{inlineScopeSchema, "## Notes\n\n[![alt](i.png)](u) and " +
 			"![a *b* c](j.png)\n"},
+		// Childless containers: an empty-text link and an empty-alt
+		// image must emit `children: []`, never `children: null` — the
+		// null-vs-empty class the contract rejects (the rows:[] case
+		// above is the block-level sibling of the same class).
+		{inlineScopeSchema, "## Notes\n\n[](u) and ![](p.png)\n"},
+		// Empty containers at block level: a bare blockquote and a
+		// body-less deeper heading must emit `blocks: []`.
+		{textScope, "## Notes\n\n> x\n\n### Only\n"},
 	}
 	corpus := make([][]any, 0, len(cases))
 	for _, c := range cases {

--- a/internal/extract/cue_diff_test.go
+++ b/internal/extract/cue_diff_test.go
@@ -163,6 +163,14 @@ func blocksCorpus(t *testing.T) [][]any {
 		// closed `block_table` arm must accept the empty list, not
 		// just populated rows.
 		{textScope, "## Notes\n\n| A | B |\n| - | - |\n"},
+		// Lenient image spans nested inside container spans: an image
+		// linked (image inside a link's `children`) and an image whose
+		// alt text carries emphasis (a non-text image child). These pin
+		// that block-inline leniency propagates through a container
+		// span's recursion, so the image arm's `children: [...#Span]`
+		// is validated for a non-trivial child, not just a bare alt.
+		{inlineScopeSchema, "## Notes\n\n[![alt](i.png)](u) and " +
+			"![a *b* c](j.png)\n"},
 	}
 	corpus := make([][]any, 0, len(cases))
 	for _, c := range cases {

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -75,9 +75,22 @@ func (p *projector) firstH1PlainText() string {
 }
 
 type projector struct {
-	f     *lint.File
-	sch   *schema.Schema
-	diags []lint.Diagnostic
+	f   *lint.File
+	sch *schema.Schema
+	// blockInline, when true, makes the block walker render paragraph
+	// blocks as inline-span lists (`{block: paragraph, inline}`)
+	// instead of flat `text`. projectScopeObject sets it per matched
+	// scope from the effective `block-paragraphs` choice (scope wins
+	// over schema default) for the duration of one body projection;
+	// nested sections and quotes inherit the same choice. Plan 246.
+	blockInline bool
+	// lenientInline, when true, makes the inline-span walker project an
+	// image as an `image` span rather than a hard error — the
+	// block-mode inline path (lenientInlineSpans). Plan 212's strict
+	// content-entry inline leaves it false, so an image there still
+	// aborts. Plan 246.
+	lenientInline bool
+	diags         []lint.Diagnostic
 }
 
 // keyFor is the single key-naming seam — the one function plan 167
@@ -102,6 +115,18 @@ func keyFor(sc *schema.Scope) string {
 		return fmvars[0]
 	}
 	return mdtext.Slugify(sc.Heading)
+}
+
+// inlineBlockParagraphs reports whether paragraph blocks in this
+// scope's body render as inline spans. The scope's own
+// `block-paragraphs` wins; an unset scope value (or a nil scope, the
+// unlisted case) falls back to the schema-level default. Only an
+// explicit `inline` turns it on. Plan 246.
+func (p *projector) inlineBlockParagraphs(sc *schema.Scope) bool {
+	if sc != nil && sc.BlockParagraphs != "" {
+		return sc.BlockParagraphs == schema.ProjectionInline
+	}
+	return p.sch != nil && p.sch.BlockParagraphs == schema.ProjectionInline
 }
 
 // hoistsToParent reports whether sm is a scope match whose bind
@@ -261,9 +286,11 @@ func (p *projector) projectScopeObject(sm *schema.ScopeMatch) map[string]any {
 	// declared content entry that binds to `blocks` is reported rather
 	// than silently overwritten. An empty section still emits
 	// `blocks: []` (keyed on ProjectsBlocks, not len(Body)) for a
-	// stable shape.
+	// stable shape. blockInline is scoped to this body projection.
 	if sm.ProjectsBlocks {
+		p.blockInline = p.inlineBlockParagraphs(sm.Scope)
 		p.setKey(obj, "blocks", p.blocksFromNodes(sm.Body))
+		p.blockInline = false
 	}
 	return obj
 }

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -188,7 +188,8 @@ func (p *projector) hoistGroup(group []*schema.ScopeMatch, obj map[string]any) {
 
 // projectScopeObject builds the object value for one matched scope:
 // its captured placeholders (name: value), then its child scopes,
-// then its content entries.
+// then its content entries, then — when the scope (or the schema)
+// projects `blocks` — its whole body under a `blocks` key.
 func (p *projector) projectScopeObject(sm *schema.ScopeMatch) map[string]any {
 	obj := map[string]any{}
 	for name, val := range sm.Captures {
@@ -196,6 +197,15 @@ func (p *projector) projectScopeObject(sm *schema.ScopeMatch) map[string]any {
 	}
 	p.projectChildren(sm.Children, obj)
 	p.projectContent(sm.Content, obj)
+	// The whole-body `blocks` list (plan 246) joins the default-key
+	// set: setKey routes it through the same collision check, so a
+	// declared content entry that binds to `blocks` is reported rather
+	// than silently overwritten. An empty section still emits
+	// `blocks: []` (keyed on ProjectsBlocks, not len(Body)) for a
+	// stable shape.
+	if sm.ProjectsBlocks {
+		p.setKey(obj, "blocks", p.blocksFromNodes(sm.Body))
+	}
 	return obj
 }
 

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -138,6 +138,21 @@ func (p *projector) projectChildren(
 			i++
 			continue
 		}
+		if sm.Unlisted {
+			// Unlisted matches (schema-level `projection: blocks` only)
+			// have a nil Scope, so they group by heading slug rather
+			// than scope pointer. Hand the whole contiguous run to
+			// projectUnlisted, which groups same-slug headings into
+			// arrays. collectUnlistedBlockMatches appends them after
+			// the declared matches, so the run reaches the end.
+			j := i + 1
+			for j < len(children) && children[j].Unlisted {
+				j++
+			}
+			p.projectUnlisted(children[i:j], obj)
+			i = j
+			continue
+		}
 		j := i + 1
 		for j < len(children) && children[j].Scope == sm.Scope {
 			j++
@@ -165,6 +180,50 @@ func (p *projector) projectChildren(
 		}
 		p.setKey(obj, key, p.projectScopeObject(group[0]))
 	}
+}
+
+// projectUnlisted projects a run of unlisted (synthetic) scope matches
+// under a schema-level `projection: blocks`. Each projects as a
+// `{heading, blocks}` object keyed by the slug of its heading text.
+// Headings whose slugs collide project as an array under that key, so
+// a section heading that repeats (`## Note`, `## Note`) survives
+// without a collision diagnostic. Plan 246.
+func (p *projector) projectUnlisted(
+	group []*schema.ScopeMatch, obj map[string]any,
+) {
+	// Group by slug in first-seen order so the array elements keep
+	// document order.
+	bySlug := map[string][]*schema.ScopeMatch{}
+	var order []string
+	for _, sm := range group {
+		key := mdtext.Slugify(sm.Heading.Text)
+		if _, seen := bySlug[key]; !seen {
+			order = append(order, key)
+		}
+		bySlug[key] = append(bySlug[key], sm)
+	}
+	for _, key := range order {
+		ms := bySlug[key]
+		if len(ms) == 1 {
+			p.setKey(obj, key, p.projectUnlistedObject(ms[0]))
+			continue
+		}
+		arr := make([]any, 0, len(ms))
+		for _, sm := range ms {
+			arr = append(arr, p.projectUnlistedObject(sm))
+		}
+		p.setKey(obj, key, arr)
+	}
+}
+
+// projectUnlistedObject builds the object for one unlisted section: a
+// `heading` text field (preserving the original heading text the slug
+// key flattens) plus the body `blocks` list. projectScopeObject adds
+// the `blocks` key from sm.Body.
+func (p *projector) projectUnlistedObject(sm *schema.ScopeMatch) map[string]any {
+	obj := p.projectScopeObject(sm)
+	p.setKey(obj, "heading", sm.Heading.Text)
+	return obj
 }
 
 // hoistGroup merges every element of group directly into obj

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -481,11 +481,19 @@ func (p *projector) tableRows(n ast.Node) []any {
 //
 // Duplicate headers are accepted — the columns array is positional, so
 // there is no key collision. Plan 245.
+//
+// A table node with a header but no body rows returns rows as a
+// non-nil empty slice (not nil): under `projection: blocks` the result
+// serialises to `"rows": []`, which the published CUE contract's
+// `rows: [...[...string]]` accepts, whereas a nil slice would serialise
+// to `"rows": null` and fail validation. The nil return above stays
+// reserved for the not-a-table guard.
 func (p *projector) tableRowsPositional(n ast.Node) (cols []any, rows []any) {
 	tbl, ok := n.(*extast.Table)
 	if !ok {
 		return nil, nil
 	}
+	rows = []any{}
 	var colCount int
 	for r := tbl.FirstChild(); r != nil; r = r.NextSibling() {
 		var cells []string

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -75,22 +75,9 @@ func (p *projector) firstH1PlainText() string {
 }
 
 type projector struct {
-	f   *lint.File
-	sch *schema.Schema
-	// blockInline, when true, makes the block walker render paragraph
-	// blocks as inline-span lists (`{block: paragraph, inline}`)
-	// instead of flat `text`. projectScopeObject sets it per matched
-	// scope from the effective `block-paragraphs` choice (scope wins
-	// over schema default) for the duration of one body projection;
-	// nested sections and quotes inherit the same choice. Plan 246.
-	blockInline bool
-	// lenientInline, when true, makes the inline-span walker project an
-	// image as an `image` span rather than a hard error — the
-	// block-mode inline path (lenientInlineSpans). Plan 212's strict
-	// content-entry inline leaves it false, so an image there still
-	// aborts. Plan 246.
-	lenientInline bool
-	diags         []lint.Diagnostic
+	f     *lint.File
+	sch   *schema.Schema
+	diags []lint.Diagnostic
 }
 
 // keyFor is the single key-naming seam — the one function plan 167
@@ -286,11 +273,13 @@ func (p *projector) projectScopeObject(sm *schema.ScopeMatch) map[string]any {
 	// declared content entry that binds to `blocks` is reported rather
 	// than silently overwritten. An empty section still emits
 	// `blocks: []` (keyed on ProjectsBlocks, not len(Body)) for a
-	// stable shape. blockInline is scoped to this body projection.
+	// stable shape. The paragraph rendering choice (scope wins over
+	// schema default) is passed down the walk, never stored, so no
+	// state survives this projection; nested sections and quotes
+	// inherit the same choice.
 	if sm.ProjectsBlocks {
-		p.blockInline = p.inlineBlockParagraphs(sm.Scope)
-		p.setKey(obj, "blocks", p.blocksFromNodes(sm.Body))
-		p.blockInline = false
+		p.setKey(obj, "blocks",
+			p.blocksFromNodes(sm.Body, p.inlineBlockParagraphs(sm.Scope)))
 	}
 	return obj
 }
@@ -383,13 +372,7 @@ func (p *projector) codeBody(n ast.Node) string {
 	if !ok {
 		return ""
 	}
-	var b strings.Builder
-	segs := fcb.Lines()
-	for i := 0; i < segs.Len(); i++ {
-		seg := segs.At(i)
-		b.Write(seg.Value(p.f.Source))
-	}
-	return strings.TrimRight(b.String(), "\n")
+	return strings.TrimRight(p.rawLines(fcb), "\n")
 }
 
 func (p *projector) listItems(n ast.Node) []any {
@@ -493,6 +476,10 @@ func (p *projector) tableRowsPositional(n ast.Node) (cols []any, rows []any) {
 	if !ok {
 		return nil, nil
 	}
+	// Both halves start non-nil for the same contract reason: a table
+	// node without a TableHeader child (hand-built; the GFM parser
+	// always emits one) must serialise `"columns": []`, not null.
+	cols = []any{}
 	rows = []any{}
 	var colCount int
 	for r := tbl.FirstChild(); r != nil; r = r.NextSibling() {

--- a/internal/extract/extract_cover_test.go
+++ b/internal/extract/extract_cover_test.go
@@ -170,3 +170,16 @@ func TestExtract_NilFrontmatterEmptyObject(t *testing.T) {
 	// the document has no front matter.
 	assert.Equal(t, map[string]any{}, got.(map[string]any)["frontmatter"])
 }
+
+// The GFM parser always emits a TableHeader, so a header-less table is
+// reachable only from hand-built nodes; both halves must still come
+// back as empty lists, not nil, so `columns` and `rows` serialise as
+// `[]` under the published contract rather than `null`.
+func TestTableRowsPositional_HeaderlessHandBuiltTable(t *testing.T) {
+	p := &projector{f: doc(t, "x\n")}
+	cols, rows := p.tableRowsPositional(extast.NewTable())
+	require.NotNil(t, cols)
+	require.NotNil(t, rows)
+	assert.Empty(t, cols)
+	assert.Empty(t, rows)
+}

--- a/internal/extract/inline.go
+++ b/internal/extract/inline.go
@@ -27,6 +27,20 @@ func (p *projector) inlineSpans(key string, n ast.Node) []any {
 	return p.walkInlineChildren(key, n)
 }
 
+// lenientInlineSpans walks a paragraph's inline children like
+// inlineSpans but in lenient mode: an image projects an `image` span
+// (url, title?, children) instead of a hard error. It backs the
+// `block-paragraphs: inline` option so a `blocks`-mode paragraph with
+// an image stays representable rather than aborting (plan 246). Raw
+// HTML and any other out-of-mapping node still error — those are not
+// representable as data. The lenient flag is scoped to this walk.
+func (p *projector) lenientInlineSpans(n ast.Node) []any {
+	p.lenientInline = true
+	spans := p.walkInlineChildren("blocks", n)
+	p.lenientInline = false
+	return spans
+}
+
 // walkInlineChildren maps every inline child of parent to a span
 // object and returns the ordered list. A child outside the mapping
 // table records a collision-style diagnostic and is skipped; because
@@ -127,6 +141,25 @@ func (p *projector) inlineSpan(key string, n ast.Node) map[string]any {
 	case *ast.Link:
 		span := map[string]any{
 			"span":     "link",
+			"url":      string(node.Destination),
+			"children": p.walkInlineChildren(key, node),
+		}
+		if len(node.Title) > 0 {
+			span["title"] = string(node.Title)
+		}
+		return span
+	case *ast.Image:
+		// Strict (plan 212) inline projection treats an image as a hard
+		// error. Block-mode inline (lenientInlineSpans) instead projects
+		// it as an `image` span so a `blocks`-mode paragraph with an
+		// image stays representable. The alt text rides in `children`,
+		// mirroring `link`. Plan 246.
+		if !p.lenientInline {
+			p.unsupportedInline(key, n)
+			return nil
+		}
+		span := map[string]any{
+			"span":     "image",
 			"url":      string(node.Destination),
 			"children": p.walkInlineChildren(key, node),
 		}

--- a/internal/extract/inline.go
+++ b/internal/extract/inline.go
@@ -24,7 +24,7 @@ import (
 // check hot path — so it favours a clear recursive shape over the
 // allocation budget the lint rules hold to.
 func (p *projector) inlineSpans(key string, n ast.Node) []any {
-	return p.walkInlineChildren(key, n)
+	return p.walkInlineChildren(key, n, false)
 }
 
 // lenientInlineSpans walks a paragraph's inline children like
@@ -33,12 +33,10 @@ func (p *projector) inlineSpans(key string, n ast.Node) []any {
 // `block-paragraphs: inline` option so a `blocks`-mode paragraph with
 // an image stays representable rather than aborting (plan 246). Raw
 // HTML and any other out-of-mapping node still error — those are not
-// representable as data. The lenient flag is scoped to this walk.
+// representable as data. Leniency is passed down the walk, never
+// stored, so no state survives the call.
 func (p *projector) lenientInlineSpans(n ast.Node) []any {
-	p.lenientInline = true
-	spans := p.walkInlineChildren("blocks", n)
-	p.lenientInline = false
-	return spans
+	return p.walkInlineChildren("blocks", n, true)
 }
 
 // walkInlineChildren maps every inline child of parent to a span
@@ -51,10 +49,15 @@ func (p *projector) lenientInlineSpans(n ast.Node) []any {
 // `break` span when the node carries a soft or hard line break. The
 // break span is appended after the text span so the wrapped-line
 // structure of a paragraph survives projection.
-func (p *projector) walkInlineChildren(key string, parent ast.Node) []any {
-	var spans []any
+//
+// The list is never nil: a childless container (`[](u)`, `![](p)`)
+// returns the empty list so its `children` key serializes as `[]`,
+// which the published contract's `[...#Span]` accepts where `null`
+// would not.
+func (p *projector) walkInlineChildren(key string, parent ast.Node, lenient bool) []any {
+	spans := []any{}
 	for c := parent.FirstChild(); c != nil; c = c.NextSibling() {
-		span := p.inlineSpan(key, c)
+		span := p.inlineSpan(key, c, lenient)
 		if span == nil {
 			continue
 		}
@@ -99,8 +102,10 @@ func breakSpan(n ast.Node) map[string]any {
 
 // inlineSpan maps one inline AST node to its span object per the plan
 // 212 mapping table. It returns nil (after recording a diagnostic)
-// for any node the table does not cover.
-func (p *projector) inlineSpan(key string, n ast.Node) map[string]any {
+// for any node the table does not cover. lenient widens the table by
+// the `image` span (the block-mode contract, plan 246) and flows into
+// every recursive child walk.
+func (p *projector) inlineSpan(key string, n ast.Node, lenient bool) map[string]any {
 	switch node := n.(type) {
 	case *ast.Text:
 		return map[string]any{
@@ -136,13 +141,13 @@ func (p *projector) inlineSpan(key string, n ast.Node) map[string]any {
 		return map[string]any{
 			"span":     name,
 			"level":    node.Level,
-			"children": p.walkInlineChildren(key, node),
+			"children": p.walkInlineChildren(key, node, lenient),
 		}
 	case *ast.Link:
 		span := map[string]any{
 			"span":     "link",
 			"url":      string(node.Destination),
-			"children": p.walkInlineChildren(key, node),
+			"children": p.walkInlineChildren(key, node, lenient),
 		}
 		if len(node.Title) > 0 {
 			span["title"] = string(node.Title)
@@ -154,14 +159,14 @@ func (p *projector) inlineSpan(key string, n ast.Node) map[string]any {
 		// it as an `image` span so a `blocks`-mode paragraph with an
 		// image stays representable. The alt text rides in `children`,
 		// mirroring `link`. Plan 246.
-		if !p.lenientInline {
+		if !lenient {
 			p.unsupportedInline(key, n)
 			return nil
 		}
 		span := map[string]any{
 			"span":     "image",
 			"url":      string(node.Destination),
-			"children": p.walkInlineChildren(key, node),
+			"children": p.walkInlineChildren(key, node, lenient),
 		}
 		if len(node.Title) > 0 {
 			span["title"] = string(node.Title)

--- a/internal/extract/inline_nodes_test.go
+++ b/internal/extract/inline_nodes_test.go
@@ -17,7 +17,7 @@ import (
 // survive a normal parse, so the branch is exercised directly.
 func TestInlineSpanStringNode(t *testing.T) {
 	p := &projector{f: &lint.File{Path: "headline.md"}, sch: inlineScope()}
-	got := p.inlineSpan("inline", ast.NewString([]byte("typeset")))
+	got := p.inlineSpan("inline", ast.NewString([]byte("typeset")), false)
 	assert.Equal(t, map[string]any{"span": "text", "value": "typeset"}, got)
 	assert.Empty(t, p.diags)
 }
@@ -35,7 +35,7 @@ func TestWalkInlineChildren_TextNodeContributesTextAndBreak(t *testing.T) {
 	txt := ast.NewTextSegment(text.NewSegment(0, 5))
 	txt.SetSoftLineBreak(true)
 	parent.AppendChild(parent, txt)
-	got := p.walkInlineChildren("inline", parent)
+	got := p.walkInlineChildren("inline", parent, false)
 	require.Len(t, got, 2)
 	assert.Equal(t, map[string]any{"span": "text", "value": "first"}, got[0])
 	assert.Equal(t, map[string]any{"span": "break", "hard": false}, got[1])
@@ -56,4 +56,16 @@ func TestUnsupportedInlineDefault(t *testing.T) {
 	assert.Contains(t, p.diags[0].Message, "ast.Text")
 	assert.Truef(t, strings.HasPrefix(p.diags[0].Message, "body:"),
 		"diagnostic should lead with the projection key, got %q", p.diags[0].Message)
+}
+
+// TestWalkInlineChildren_ChildlessContainerReturnsEmpty pins the
+// null-vs-empty contract: a childless container (`[](u)`) must return
+// the empty list, never nil, so its `children` key serialises as `[]`
+// where the published `[...#Span]` constraint rejects `null`.
+func TestWalkInlineChildren_ChildlessContainerReturnsEmpty(t *testing.T) {
+	p := &projector{f: &lint.File{Path: "headline.md"}, sch: inlineScope()}
+	got := p.walkInlineChildren("inline", ast.NewLink(), false)
+	require.NotNil(t, got, "a nil slice would serialise to null")
+	assert.Empty(t, got)
+	assert.Empty(t, p.diags)
 }

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -368,6 +368,15 @@ func mergeScopes(a, b Scope) (Scope, error) {
 	if err != nil {
 		return Scope{}, err
 	}
+	// The same co-presence guard the inline parser applies per scope:
+	// merged halves must not pair `block-paragraphs` with a scope that
+	// lost `projection: blocks`.
+	if out.BlockParagraphs != "" && out.Projection != ProjectionBlocks {
+		return Scope{}, fmt.Errorf(
+			"composed schemas set `block-paragraphs:` for heading %q "+
+				"without `projection: blocks` on the same scope",
+			a.Heading)
+	}
 	return out, nil
 }
 
@@ -390,6 +399,16 @@ func composeProjection(out *Schema, in []*Schema) error {
 			return err
 		}
 		out.BlockParagraphs = bp
+	}
+	// Mirror the parse-time co-presence guard: a merge must not
+	// synthesize `block-paragraphs` without `projection: blocks` — the
+	// pair the parser rejects would otherwise survive composition as a
+	// silently dead setting.
+	if out.BlockParagraphs != "" && out.Projection != ProjectionBlocks {
+		return fmt.Errorf(
+			"composed schemas set `block-paragraphs:` without a " +
+				"schema-level `projection: blocks` — declare the " +
+				"projection on a composed source or drop the option")
 	}
 	return nil
 }

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -52,6 +52,9 @@ func Compose(schemas ...*Schema) (*Schema, error) {
 		return nil, err
 	}
 	composeRootClosed(out, nonNil)
+	if err := composeProjection(out, nonNil); err != nil {
+		return nil, err
+	}
 	out.Sections, err = composeSectionLists(extractRootSections(nonNil))
 	if err != nil {
 		return nil, err
@@ -353,7 +356,63 @@ func mergeScopes(a, b Scope) (Scope, error) {
 	// cloneScope already deep-copied a.Content into out; appending
 	// b's clone onto it avoids re-cloning a's entries.
 	out.Content = append(out.Content, cloneContent(b.Content)...)
+	// The scope-level projection family merges like bind: cloneScope
+	// carried a's values, so fold b's in or error on disagreement.
+	out.Projection, err = mergeProjectionField(
+		a.Projection, b.Projection, "projection", a.Heading)
+	if err != nil {
+		return Scope{}, err
+	}
+	out.BlockParagraphs, err = mergeProjectionField(
+		a.BlockParagraphs, b.BlockParagraphs, "block-paragraphs", a.Heading)
+	if err != nil {
+		return Scope{}, err
+	}
 	return out, nil
+}
+
+// composeProjection merges the schema-level `projection:` and
+// `block-paragraphs:` defaults across the composed inputs by the
+// mergeBind rules applied to strings: an empty value yields to a set
+// one, equal values survive, and a genuine disagreement errors so
+// `projection: blocks` never silently disappears when kinds compose.
+func composeProjection(out *Schema, in []*Schema) error {
+	for _, s := range in {
+		p, err := mergeProjectionField(out.Projection, s.Projection,
+			"projection", "")
+		if err != nil {
+			return err
+		}
+		out.Projection = p
+		bp, err := mergeProjectionField(out.BlockParagraphs,
+			s.BlockParagraphs, "block-paragraphs", "")
+		if err != nil {
+			return err
+		}
+		out.BlockParagraphs = bp
+	}
+	return nil
+}
+
+// mergeProjectionField merges one projection-family string across two
+// sources: empty yields, equal survives, disagreement errors. heading
+// is empty for the schema-level defaults and names the scope for
+// scope-level merges.
+func mergeProjectionField(a, b, key, heading string) (string, error) {
+	if a == "" {
+		return b, nil
+	}
+	if b == "" || a == b {
+		return a, nil
+	}
+	where := "the schema level"
+	if heading != "" {
+		where = fmt.Sprintf("heading %q", heading)
+	}
+	return "", fmt.Errorf(
+		"composed schemas declare conflicting `%s:` values at %s: "+
+			"%q vs %q — every source must agree",
+		key, where, a, b)
 }
 
 // mergeBind intersects two scope-level `bind:` overrides for scopes

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -931,3 +931,48 @@ func TestCompose_ProjectionKeyConflictErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `heading "Notes"`)
 }
+
+// TestCloneScope_CarriesProjectionFields pins that the projection
+// family survives cloneScope's struct copy — mergeScopes relies on
+// that carry when folding the second scope's values in.
+func TestCloneScope_CarriesProjectionFields(t *testing.T) {
+	sc := Scope{
+		Heading:         "Notes",
+		Projection:      ProjectionBlocks,
+		BlockParagraphs: ProjectionInline,
+	}
+	out := cloneScope(sc)
+	assert.Equal(t, ProjectionBlocks, out.Projection)
+	assert.Equal(t, ProjectionInline, out.BlockParagraphs)
+}
+
+// TestCompose_BlockParagraphsRequiresProjection mirrors the
+// parse-time co-presence guard at compose time: a merge must not
+// synthesize `block-paragraphs` without `projection: blocks` at
+// either level — the parser rejects that pair, so composition cannot
+// be a back door to a silently dead setting.
+func TestCompose_BlockParagraphsRequiresProjection(t *testing.T) {
+	_, err := Compose(
+		&Schema{RootLevel: 2, BlockParagraphs: ProjectionInline},
+		&Schema{RootLevel: 2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "without a schema-level")
+
+	mk := func(projection, bp string) *Schema {
+		return &Schema{RootLevel: 2, Sections: []Scope{{
+			Heading:         "Notes",
+			Matcher:         &Matcher{Regex: "Notes"},
+			Projection:      projection,
+			BlockParagraphs: bp,
+		}}}
+	}
+	_, err = Compose(mk("", ProjectionInline), mk("", ""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `heading "Notes"`)
+
+	// The coherent pair still composes.
+	out, err := Compose(mk(ProjectionBlocks, ProjectionInline), mk("", ""))
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.Equal(t, ProjectionInline, out.Sections[0].BlockParagraphs)
+}

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -976,3 +976,28 @@ func TestCompose_BlockParagraphsRequiresProjection(t *testing.T) {
 	require.Len(t, out.Sections, 1)
 	assert.Equal(t, ProjectionInline, out.Sections[0].BlockParagraphs)
 }
+
+// TestCompose_ProjectionOrderingSymmetry drives the directions the
+// earlier tests leave implicit: first-source-wins for the carry, and
+// the co-presence guard firing regardless of which input carries the
+// orphaned `block-paragraphs`.
+func TestCompose_ProjectionOrderingSymmetry(t *testing.T) {
+	mk := func(projection string) *Schema {
+		return &Schema{RootLevel: 2, Sections: []Scope{{
+			Heading:    "Notes",
+			Matcher:    &Matcher{Regex: "Notes"},
+			Projection: projection,
+		}}}
+	}
+	out, err := Compose(mk(ProjectionBlocks), mk(""))
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.Equal(t, ProjectionBlocks, out.Sections[0].Projection,
+		"the first source's scope projection must survive too")
+
+	_, err = Compose(
+		&Schema{RootLevel: 2},
+		&Schema{RootLevel: 2, BlockParagraphs: ProjectionInline})
+	require.Error(t, err, "the guard fires when the second input carries it")
+	assert.Contains(t, err.Error(), "without a schema-level")
+}

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -844,3 +844,90 @@ func TestMergeMatcher_DisjointWithUnboundedError(t *testing.T) {
 	assert.Contains(t, err.Error(), "5..unbounded")
 	assert.Contains(t, err.Error(), "1..2")
 }
+
+// TestCompose_ProjectionDefaults pins that the schema-level
+// projection family survives composition: an empty value yields to a
+// set one and equal values survive, so `projection: blocks` never
+// silently disappears when kinds share a file.
+func TestCompose_ProjectionDefaults(t *testing.T) {
+	a := &Schema{RootLevel: 2, Projection: ProjectionBlocks}
+	b := &Schema{RootLevel: 2, BlockParagraphs: ProjectionInline}
+	out, err := Compose(a, b)
+	require.NoError(t, err)
+	assert.Equal(t, ProjectionBlocks, out.Projection,
+		"an empty projection yields to the set one")
+	assert.Equal(t, ProjectionInline, out.BlockParagraphs,
+		"an empty block-paragraphs yields to the set one")
+
+	out, err = Compose(a, &Schema{RootLevel: 2, Projection: ProjectionBlocks})
+	require.NoError(t, err)
+	assert.Equal(t, ProjectionBlocks, out.Projection, "equal values survive")
+}
+
+// TestCompose_ProjectionConflictErrors mirrors the bind rule: a
+// genuine schema-level disagreement is a compose-time error, not a
+// silent first-wins.
+func TestCompose_ProjectionConflictErrors(t *testing.T) {
+	a := &Schema{RootLevel: 2, BlockParagraphs: ProjectionInline}
+	b := &Schema{RootLevel: 2, BlockParagraphs: ProjectionText}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "block-paragraphs")
+	assert.Contains(t, err.Error(), "schema level")
+}
+
+// TestCompose_ScopeProjectionCarriesFromEitherSide pins the
+// scope-level merge: when two composed kinds declare the same heading
+// and only one sets `projection: blocks`, the merged scope keeps it.
+func TestCompose_ScopeProjectionCarriesFromEitherSide(t *testing.T) {
+	mk := func(projection string) *Schema {
+		return &Schema{RootLevel: 2, Sections: []Scope{{
+			Heading:    "Notes",
+			Matcher:    &Matcher{Regex: "Notes"},
+			Projection: projection,
+		}}}
+	}
+	out, err := Compose(mk(""), mk(ProjectionBlocks))
+	require.NoError(t, err)
+	require.Len(t, out.Sections, 1)
+	assert.Equal(t, ProjectionBlocks, out.Sections[0].Projection,
+		"the second source's scope projection must survive the merge")
+
+	_, err = Compose(
+		&Schema{RootLevel: 2, Sections: []Scope{{
+			Heading: "Notes", Matcher: &Matcher{Regex: "Notes"},
+			BlockParagraphs: ProjectionInline,
+			Projection:      ProjectionBlocks,
+		}}},
+		&Schema{RootLevel: 2, Sections: []Scope{{
+			Heading: "Notes", Matcher: &Matcher{Regex: "Notes"},
+			BlockParagraphs: ProjectionText,
+			Projection:      ProjectionBlocks,
+		}}})
+	require.Error(t, err, "scope-level disagreement errors")
+	assert.Contains(t, err.Error(), `heading "Notes"`)
+}
+
+// TestCompose_ProjectionKeyConflictErrors drives the projection-key
+// conflict arms at both levels. Parse validation only admits `blocks`
+// today, so the disagreement is hand-built — the arm must still hold
+// for any future second projection value.
+func TestCompose_ProjectionKeyConflictErrors(t *testing.T) {
+	_, err := Compose(
+		&Schema{RootLevel: 2, Projection: ProjectionBlocks},
+		&Schema{RootLevel: 2, Projection: "spans"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "`projection:`")
+	assert.Contains(t, err.Error(), "schema level")
+
+	mk := func(projection string) *Schema {
+		return &Schema{RootLevel: 2, Sections: []Scope{{
+			Heading:    "Notes",
+			Matcher:    &Matcher{Regex: "Notes"},
+			Projection: projection,
+		}}}
+	}
+	_, err = Compose(mk(ProjectionBlocks), mk("spans"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `heading "Notes"`)
+}

--- a/internal/schema/extend.go
+++ b/internal/schema/extend.go
@@ -323,7 +323,9 @@ func Extend(parent, child *Schema) (*Schema, error) {
 		return nil, err
 	}
 	extendFilename(out, parent, child)
-	extendProjection(out, parent, child)
+	if err := extendProjection(out, parent, child); err != nil {
+		return nil, err
+	}
 	extendSections(out, parent, child)
 	extendCrossRefs(out, parent, child)
 	extendAcronyms(out, parent, child)
@@ -463,8 +465,11 @@ func extendFilename(out, parent, child *Schema) {
 // extendProjection layers the schema-level projection defaults like
 // filename: a child that sets `projection:` or `block-paragraphs:`
 // overrides the parent; an unset child inherits the parent's value,
-// so `projection: blocks` survives an extends chain.
-func extendProjection(out, parent, child *Schema) {
+// so `projection: blocks` survives an extends chain. The layered
+// result must satisfy the same co-presence rule the parser and
+// composeProjection enforce — `block-paragraphs` without
+// `projection: blocks` is a silently dead setting.
+func extendProjection(out, parent, child *Schema) error {
 	out.Projection = child.Projection
 	if out.Projection == "" {
 		out.Projection = parent.Projection
@@ -473,6 +478,12 @@ func extendProjection(out, parent, child *Schema) {
 	if out.BlockParagraphs == "" {
 		out.BlockParagraphs = parent.BlockParagraphs
 	}
+	if out.BlockParagraphs != "" && out.Projection != ProjectionBlocks {
+		return fmt.Errorf(
+			"extended schemas set `block-paragraphs:` without a " +
+				"schema-level `projection: blocks`")
+	}
+	return nil
 }
 
 // extendSections copies the child's sections wholesale when it

--- a/internal/schema/extend.go
+++ b/internal/schema/extend.go
@@ -323,6 +323,7 @@ func Extend(parent, child *Schema) (*Schema, error) {
 		return nil, err
 	}
 	extendFilename(out, parent, child)
+	extendProjection(out, parent, child)
 	extendSections(out, parent, child)
 	extendCrossRefs(out, parent, child)
 	extendAcronyms(out, parent, child)
@@ -457,6 +458,21 @@ func extendFilename(out, parent, child *Schema) {
 		return
 	}
 	out.Filename = parent.Filename
+}
+
+// extendProjection layers the schema-level projection defaults like
+// filename: a child that sets `projection:` or `block-paragraphs:`
+// overrides the parent; an unset child inherits the parent's value,
+// so `projection: blocks` survives an extends chain.
+func extendProjection(out, parent, child *Schema) {
+	out.Projection = child.Projection
+	if out.Projection == "" {
+		out.Projection = parent.Projection
+	}
+	out.BlockParagraphs = child.BlockParagraphs
+	if out.BlockParagraphs == "" {
+		out.BlockParagraphs = parent.BlockParagraphs
+	}
 }
 
 // extendSections copies the child's sections wholesale when it

--- a/internal/schema/extend_test.go
+++ b/internal/schema/extend_test.go
@@ -813,3 +813,22 @@ func TestInvalidFrontmatterError_Error(t *testing.T) {
 	assert.NotContains(t, msg, "child")
 	assert.ErrorIs(t, err, cause)
 }
+
+// TestExtend_ProjectionChildWinsElseParent pins the extends layering
+// for the schema-level projection family: a set child value overrides
+// the parent and an unset child inherits it, so `projection: blocks`
+// survives an extends chain.
+func TestExtend_ProjectionChildWinsElseParent(t *testing.T) {
+	parent := &Schema{
+		RootLevel:       2,
+		Projection:      ProjectionBlocks,
+		BlockParagraphs: ProjectionText,
+	}
+	child := &Schema{RootLevel: 2, BlockParagraphs: ProjectionInline}
+	out, err := Extend(parent, child)
+	require.NoError(t, err)
+	assert.Equal(t, ProjectionBlocks, out.Projection,
+		"an unset child inherits the parent's projection")
+	assert.Equal(t, ProjectionInline, out.BlockParagraphs,
+		"a set child overrides the parent")
+}

--- a/internal/schema/extend_test.go
+++ b/internal/schema/extend_test.go
@@ -832,3 +832,14 @@ func TestExtend_ProjectionChildWinsElseParent(t *testing.T) {
 	assert.Equal(t, ProjectionInline, out.BlockParagraphs,
 		"a set child overrides the parent")
 }
+
+// TestExtend_BlockParagraphsRequiresProjection gives Extend the same
+// co-presence guard test compose carries: a layered result pairing
+// `block-paragraphs` with a missing `projection: blocks` errors
+// instead of propagating the silently dead setting.
+func TestExtend_BlockParagraphsRequiresProjection(t *testing.T) {
+	parent := &Schema{RootLevel: 2, BlockParagraphs: ProjectionInline}
+	_, err := Extend(parent, &Schema{RootLevel: 2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "without a schema-level")
+}

--- a/internal/schema/matchtree.go
+++ b/internal/schema/matchtree.go
@@ -94,6 +94,20 @@ type ScopeMatch struct {
 
 	// Content are the matched content entries in declared order.
 	Content []ContentMatch
+
+	// ProjectsBlocks reports whether this match's whole body should be
+	// projected as a `blocks` list — set when the scope (or, by
+	// default, the schema) declares `projection: blocks`. The
+	// projector keys on this rather than len(Body) so an empty section
+	// still emits `blocks: []` for a stable shape. Plan 246.
+	ProjectsBlocks bool
+
+	// Body holds the section's whole body in document order — every
+	// top-level block node in the scope's line range, deeper headings
+	// included so the block walker can nest them as `section` blocks.
+	// Meaningful only when ProjectsBlocks is true; nil (empty body)
+	// otherwise. Plan 246.
+	Body []ast.Node
 }
 
 // ContentMatch pairs a schema ContentEntry with the AST node that
@@ -117,17 +131,38 @@ func BuildMatchTree(f *lint.File, sch *Schema, docFM map[string]any) *MatchTree 
 	rootLevel := sch.EffectiveRootLevel()
 	heads := skipBelow(ExtractDocHeadings(f), rootLevel)
 
+	// The body block scan feeds two consumers: per-entry content
+	// matching (anyScopeHasContent) and the whole-body `blocks`
+	// projection (a scope's or the schema's `projection: blocks`).
+	// Parse once when either needs it.
+	blocksDefault := sch.Projection == ProjectionBlocks
 	var blocks []contentBlock
-	if anyScopeHasContent(sch.Sections) {
+	if anyScopeHasContent(sch.Sections) || blocksDefault ||
+		anyScopeProjectsBlocks(sch.Sections) {
 		blocks = topLevelBlocks(f, parseWithTableExt(f.Source))
 	}
 
 	claimed := make(map[int]bool)
 	buildScopeMatches(
 		f, sch.Sections, heads, rootLevel, 1, len(f.Lines)+1,
-		claimed, blocks, docFM, mt.Root,
+		claimed, blocks, docFM, blocksDefault, mt.Root,
 	)
 	return mt
+}
+
+// anyScopeProjectsBlocks reports whether any scope in the tree sets a
+// scope-level `projection: blocks`, so BuildMatchTree knows to parse
+// the body block list even when no scope declares `content:`.
+func anyScopeProjectsBlocks(scopes []Scope) bool {
+	for i := range scopes {
+		if scopes[i].Projection == ProjectionBlocks {
+			return true
+		}
+		if anyScopeProjectsBlocks(scopes[i].Sections) {
+			return true
+		}
+	}
+	return false
 }
 
 // buildScopeMatches mirrors walkContentScopes: pair each scope with
@@ -139,7 +174,7 @@ func buildScopeMatches(
 	f *lint.File, scopes []Scope, heads []DocHeading,
 	expectedLevel, parentStart, parentEnd int,
 	claimed map[int]bool, blocks []contentBlock,
-	docFM map[string]any, parent *ScopeMatch,
+	docFM map[string]any, blocksDefault bool, parent *ScopeMatch,
 ) {
 	for i := range scopes {
 		sc := &scopes[i]
@@ -165,15 +200,41 @@ func buildScopeMatches(
 				Captures: scopeCaptures(sc, dh, docFM),
 			}
 			collectContent(sc, blocks, dh.Line+1, end, sm)
+			// A scope-level `projection: blocks`, or a schema-level
+			// default, captures the section's whole body (deeper
+			// headings kept) so the projector can emit the `blocks`
+			// list. The per-scope setting overrides the default off,
+			// matching the parser's per-scope-wins contract.
+			if sc.Projection == ProjectionBlocks ||
+				(blocksDefault && sc.Projection == "") {
+				sm.ProjectsBlocks = true
+				sm.Body = bodyBlocksInRange(blocks, dh.Line+1, end)
+			}
 			if len(sc.Sections) > 0 {
 				buildScopeMatches(
 					f, sc.Sections, heads, expectedLevel+1, dh.Line, end,
-					claimed, blocks, docFM, sm,
+					claimed, blocks, docFM, blocksDefault, sm,
 				)
 			}
 			parent.Children = append(parent.Children, sm)
 		}
 	}
+}
+
+// bodyBlocksInRange returns the block nodes whose start line is in
+// [startLine, endLine), in document order, with headings KEPT (unlike
+// blocksInRange). The block walker turns a deeper heading into a
+// nested `section` block, so the projection needs the headings the
+// content validator filters out. Plan 246.
+func bodyBlocksInRange(blocks []contentBlock, startLine, endLine int) []ast.Node {
+	var out []ast.Node
+	for _, b := range blocks {
+		if b.line < startLine || b.line >= endLine {
+			continue
+		}
+		out = append(out, b.node)
+	}
+	return out
 }
 
 // scopeCaptures merges the regex named captures with the `{field}`

--- a/internal/schema/matchtree.go
+++ b/internal/schema/matchtree.go
@@ -79,6 +79,13 @@ type ScopeMatch struct {
 	// no-heading section (content before the first child heading).
 	Preamble bool
 
+	// Unlisted reports whether this match is a synthetic one for a
+	// heading no declared scope claimed, added only under a
+	// schema-level `projection: blocks`. Scope is nil for these; the
+	// projector keys them by the slug of Heading.Text and adds a
+	// `heading` text field. Plan 246.
+	Unlisted bool
+
 	// Heading is the document heading that matched. Zero-valued for
 	// the preamble and the synthetic root.
 	Heading DocHeading
@@ -147,7 +154,39 @@ func BuildMatchTree(f *lint.File, sch *Schema, docFM map[string]any) *MatchTree 
 		f, sch.Sections, heads, rootLevel, 1, len(f.Lines)+1,
 		claimed, blocks, docFM, blocksDefault, mt.Root,
 	)
+	if blocksDefault {
+		collectUnlistedBlockMatches(
+			heads, rootLevel, len(f.Lines)+1, claimed, blocks, mt.Root)
+	}
 	return mt
+}
+
+// collectUnlistedBlockMatches appends a synthetic ScopeMatch for every
+// root-level heading no declared scope claimed, so a schema-level
+// `projection: blocks` projects the sections the structural walker
+// skips (wildcard slots, unlisted, and closed-overflow headings).
+// Each synthetic match carries the heading (for its slug key and a
+// `heading` text field), ProjectsBlocks, and the section's whole body
+// — deeper sub-headings included, which the block walker nests as
+// `section` blocks rather than separate top-level keys. A conformant
+// document nests deeper headings under a root-level one, so capturing
+// each unclaimed root heading's body reaches every section. Plan 246.
+func collectUnlistedBlockMatches(
+	heads []DocHeading, rootLevel, docEnd int,
+	claimed map[int]bool, blocks []contentBlock, parent *ScopeMatch,
+) {
+	for i, dh := range heads {
+		if claimed[i] || dh.Level != rootLevel {
+			continue
+		}
+		end := contentScopeEndLine(heads, i, dh.Level, docEnd)
+		parent.Children = append(parent.Children, &ScopeMatch{
+			Heading:        dh,
+			Unlisted:       true,
+			ProjectsBlocks: true,
+			Body:           bodyBlocksInRange(blocks, dh.Line+1, end),
+		})
+	}
 }
 
 // anyScopeProjectsBlocks reports whether any scope in the tree sets a

--- a/internal/schema/matchtree_test.go
+++ b/internal/schema/matchtree_test.go
@@ -307,3 +307,57 @@ func TestBuildMatchTree_Content(t *testing.T) {
 	assert.Equal(t, ContentKindCodeBlock, mt.Root.Children[0].Content[0].Entry.Kind)
 	assert.Equal(t, ContentKindList, mt.Root.Children[0].Content[1].Entry.Kind)
 }
+
+// A scope with `projection: blocks` captures its whole body on the
+// match (ProjectsBlocks set, Body populated with deeper headings
+// kept). Plan 246.
+func TestBuildMatchTree_ScopeBlocksBody(t *testing.T) {
+	body := "## Notes\n\npara\n\n### Sub\n\nx\n"
+	sch := &Schema{
+		RootLevel: 2,
+		Sections: []Scope{{
+			Heading:    "Notes",
+			Matcher:    &Matcher{Regex: "Notes"},
+			Projection: ProjectionBlocks,
+		}},
+	}
+	mt := BuildMatchTree(mtFile(t, body), sch, nil)
+	require.Len(t, mt.Root.Children, 1)
+	sm := mt.Root.Children[0]
+	assert.True(t, sm.ProjectsBlocks)
+	// para paragraph + the ### Sub heading (kept for section nesting)
+	// + the nested paragraph -> three body nodes.
+	require.Len(t, sm.Body, 3)
+}
+
+// A schema-level `projection: blocks` default sets ProjectsBlocks on
+// a matched scope that does not itself set a projection. Plan 246.
+func TestBuildMatchTree_SchemaBlocksDefault(t *testing.T) {
+	sch := &Schema{
+		RootLevel:  2,
+		Projection: ProjectionBlocks,
+		Sections:   []Scope{{Heading: "Notes", Matcher: &Matcher{Regex: "Notes"}}},
+	}
+	mt := BuildMatchTree(mtFile(t, "## Notes\n\npara\n"), sch, nil)
+	require.Len(t, mt.Root.Children, 1)
+	assert.True(t, mt.Root.Children[0].ProjectsBlocks)
+}
+
+func TestAnyScopeProjectsBlocks(t *testing.T) {
+	assert.False(t, anyScopeProjectsBlocks(nil))
+	assert.False(t, anyScopeProjectsBlocks([]Scope{{Heading: "A"}}))
+	assert.True(t, anyScopeProjectsBlocks([]Scope{{Projection: ProjectionBlocks}}))
+	// Nested scope projects blocks -> the recursive arm reports true.
+	parent := Scope{Heading: "P", Sections: []Scope{{Projection: ProjectionBlocks}}}
+	assert.True(t, anyScopeProjectsBlocks([]Scope{parent}))
+}
+
+func TestBodyBlocksInRange_KeepsHeadings(t *testing.T) {
+	f := mtFile(t, "## Notes\n\npara\n\n### Sub\n\nx\n")
+	blocks := topLevelBlocks(f, parseWithTableExt(f.Source))
+	// Range covering the whole document keeps the ### Sub heading,
+	// unlike blocksInRange which strips every heading.
+	body := bodyBlocksInRange(blocks, 1, len(f.Lines)+1)
+	stripped := blocksInRange(blocks, 1, len(f.Lines)+1)
+	assert.Greater(t, len(body), len(stripped))
+}

--- a/internal/schema/matchtree_test.go
+++ b/internal/schema/matchtree_test.go
@@ -343,6 +343,55 @@ func TestBuildMatchTree_SchemaBlocksDefault(t *testing.T) {
 	assert.True(t, mt.Root.Children[0].ProjectsBlocks)
 }
 
+// A schema-level `projection: blocks` default appends a synthetic
+// unlisted ScopeMatch for every root-level heading no declared scope
+// claimed, carrying the heading, Unlisted, ProjectsBlocks, and the
+// section body (exercising collectUnlistedBlockMatches' append). Plan
+// 246.
+func TestBuildMatchTree_CollectsUnlistedBlockMatches(t *testing.T) {
+	body := "## Goal\n\ng\n\n## Background\n\nb1\n\nb2\n"
+	sch := &Schema{
+		RootLevel:  2,
+		Projection: ProjectionBlocks,
+		Sections:   []Scope{{Heading: "Goal", Matcher: &Matcher{Regex: "Goal"}}},
+	}
+	mt := BuildMatchTree(mtFile(t, body), sch, nil)
+	require.Len(t, mt.Root.Children, 2)
+	// Declared Goal scope first, then the synthetic unlisted Background.
+	assert.False(t, mt.Root.Children[0].Unlisted)
+	bg := mt.Root.Children[1]
+	require.True(t, bg.Unlisted, "Background must be a synthetic unlisted match")
+	assert.True(t, bg.ProjectsBlocks)
+	assert.Equal(t, "Background", bg.Heading.Text)
+	assert.Nil(t, bg.Scope, "unlisted match has a nil Scope")
+	// Body spans the two background paragraphs.
+	require.Len(t, bg.Body, 2)
+}
+
+// collectUnlistedBlockMatches skips a heading a declared scope already
+// claimed (the claimed[i] continue) and a heading shallower/deeper than
+// the root level (the dh.Level != rootLevel continue): only the
+// unclaimed root-level Extra heading becomes a synthetic match.
+func TestCollectUnlistedBlockMatches_SkipsClaimedAndOffLevel(t *testing.T) {
+	// H1 (off level, skipped) + claimed H2 Goal + H3 under it (off
+	// level) + unclaimed H2 Extra (collected).
+	body := "# Title\n\n## Goal\n\ng\n\n### Deep\n\nd\n\n## Extra\n\ne\n"
+	sch := &Schema{
+		RootLevel:  2,
+		Projection: ProjectionBlocks,
+		Sections:   []Scope{{Heading: "Goal", Matcher: &Matcher{Regex: "Goal"}}},
+	}
+	mt := BuildMatchTree(mtFile(t, body), sch, nil)
+	var unlisted []string
+	for _, c := range mt.Root.Children {
+		if c.Unlisted {
+			unlisted = append(unlisted, c.Heading.Text)
+		}
+	}
+	assert.Equal(t, []string{"Extra"}, unlisted,
+		"only the unclaimed root-level heading is collected")
+}
+
 func TestAnyScopeProjectsBlocks(t *testing.T) {
 	assert.False(t, anyScopeProjectsBlocks(nil))
 	assert.False(t, anyScopeProjectsBlocks([]Scope{{Heading: "A"}}))

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -94,6 +94,7 @@ var inlineTopKeys = map[string]bool{
 	"acronyms":         true,
 	"index":            true,
 	"projection":       true,
+	"block-paragraphs": true,
 }
 
 var validIndexIncludes = map[string]bool{
@@ -220,25 +221,43 @@ func parseInlineRootClosed(raw map[string]any, sch *Schema) error {
 }
 
 // parseInlineProjection reads the optional schema-level `projection:`
-// key. The only legal value is `blocks` — it makes the whole-body
-// block projection the default for every matched section, wildcard and
-// unlisted sections included (plan 246). Any other value is rejected
-// with a pointer to the one accepted mode.
+// and `block-paragraphs:` keys. The only legal `projection:` value is
+// `blocks` — it makes the whole-body block projection the default for
+// every matched section, wildcard and unlisted sections included.
+// `block-paragraphs:` (`inline` / `text`) sets the schema-level
+// default for paragraph-block rendering and is valid only when the
+// schema also projects blocks. Plan 246.
 func parseInlineProjection(raw map[string]any, sch *Schema) error {
-	v, ok := raw["projection"]
+	if v, ok := raw["projection"]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("schema.projection must be a string, got %T", v)
+		}
+		if s != ProjectionBlocks {
+			return fmt.Errorf(
+				"schema.projection: the only schema-level projection is "+
+					"`blocks`, not %q", s)
+		}
+		sch.Projection = s
+	}
+	v, ok := raw["block-paragraphs"]
 	if !ok {
 		return nil
 	}
 	s, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("schema.projection must be a string, got %T", v)
+		return fmt.Errorf("schema.block-paragraphs must be a string, got %T", v)
 	}
-	if s != ProjectionBlocks {
+	if s != ProjectionInline && s != ProjectionText {
 		return fmt.Errorf(
-			"schema.projection: the only schema-level projection is "+
-				"`blocks`, not %q", s)
+			"schema.block-paragraphs: must be `inline` or `text`, not %q", s)
 	}
-	sch.Projection = s
+	if sch.Projection != ProjectionBlocks {
+		return fmt.Errorf(
+			"schema.block-paragraphs: only valid with a schema-level " +
+				"`projection: blocks`")
+	}
+	sch.BlockParagraphs = s
 	return nil
 }
 
@@ -379,7 +398,7 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 		// `projection:` is rejected for the same reason — a preamble
 		// has no scope object to carry a `blocks` key. Plan 246.
 		return rejectKeys(m, path, "preamble (`heading: null`)",
-			"sections", "bind", "projection")
+			"sections", "bind", "projection", "block-paragraphs")
 	}
 	// After applyScopeFields succeeds, either Preamble is true
 	// (handled above) or Matcher is set by setScopeHeading; a
@@ -398,7 +417,8 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 		// here would be unreachable. Schema-level `projection: blocks`
 		// covers slots instead (plan 246).
 		return rejectKeys(m, path, "slot (`regex: '.+', repeat: { min: 0 }`)",
-			"sections", "rules", "content", "closed", "bind", "projection")
+			"sections", "rules", "content", "closed", "bind", "projection",
+			"block-paragraphs")
 	}
 	// A non-slot broad matcher (`regex: '.+'` with a non-zero
 	// `min`) is also skipped by the projector. `bind:` and
@@ -406,7 +426,7 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 	// parse time rather than silently dropping at extract time (plans
 	// 167, 246).
 	if isBroadMatcher(sc.Matcher) {
-		for _, k := range []string{"bind", "projection"} {
+		for _, k := range []string{"bind", "projection", "block-paragraphs"} {
 			if _, ok := m[k]; ok {
 				return fmt.Errorf(
 					"%s: `%s:` is not allowed on a broad-match scope "+
@@ -415,6 +435,14 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 					path, k)
 			}
 		}
+	}
+	// `block-paragraphs:` only has an effect alongside
+	// `projection: blocks` — without the blocks list there are no
+	// paragraph blocks to render. Reject the orphan key at parse time.
+	if sc.BlockParagraphs != "" && sc.Projection != ProjectionBlocks {
+		return fmt.Errorf(
+			"%s.block-paragraphs: only valid with `projection: blocks` "+
+				"on the same scope", path)
 	}
 	return nil
 }
@@ -482,6 +510,8 @@ func applyScopeFields(m map[string]any, sc *Scope, path string) error {
 			err = setScopeBind(sc, vv, path)
 		case "projection":
 			err = setScopeProjection(sc, vv, path)
+		case "block-paragraphs":
+			err = setScopeBlockParagraphs(sc, vv, path)
 		default:
 			return fmt.Errorf("%s: unknown scope key %q", path, k)
 		}
@@ -525,6 +555,25 @@ func setScopeProjection(sc *Scope, v any, path string) error {
 				"go on a `content:` entry), not %q", path, s)
 	}
 	sc.Projection = s
+	return nil
+}
+
+// setScopeBlockParagraphs reads the optional scope-level
+// `block-paragraphs:` mode, which selects how paragraph blocks render
+// inside the scope's `blocks` list — `inline` (typed spans) or `text`
+// (flat, the default). It is only meaningful with
+// `projection: blocks`; validateScopeBlockParagraphs rejects it when
+// the scope does not project blocks. Plan 246.
+func setScopeBlockParagraphs(sc *Scope, v any, path string) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("%s.block-paragraphs must be a string, got %T", path, v)
+	}
+	if s != ProjectionInline && s != ProjectionText {
+		return fmt.Errorf(
+			"%s.block-paragraphs: must be `inline` or `text`, not %q", path, s)
+	}
+	sc.BlockParagraphs = s
 	return nil
 }
 

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -61,6 +61,9 @@ func ParseInline(raw map[string]any, source string) (*Schema, error) {
 	if err := parseInlineIndex(raw, sch); err != nil {
 		return nil, err
 	}
+	if err := parseInlineProjection(raw, sch); err != nil {
+		return nil, err
+	}
 
 	// schema-level `closed:` only makes sense when the schema also
 	// declares a non-empty `sections:` list — strictness has no
@@ -90,6 +93,7 @@ var inlineTopKeys = map[string]bool{
 	"cross-references": true,
 	"acronyms":         true,
 	"index":            true,
+	"projection":       true,
 }
 
 var validIndexIncludes = map[string]bool{
@@ -212,6 +216,29 @@ func parseInlineRootClosed(raw map[string]any, sch *Schema) error {
 		return fmt.Errorf("schema.closed must be a boolean, got %T", v)
 	}
 	sch.Closed = b
+	return nil
+}
+
+// parseInlineProjection reads the optional schema-level `projection:`
+// key. The only legal value is `blocks` — it makes the whole-body
+// block projection the default for every matched section, wildcard and
+// unlisted sections included (plan 246). Any other value is rejected
+// with a pointer to the one accepted mode.
+func parseInlineProjection(raw map[string]any, sch *Schema) error {
+	v, ok := raw["projection"]
+	if !ok {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("schema.projection must be a string, got %T", v)
+	}
+	if s != ProjectionBlocks {
+		return fmt.Errorf(
+			"schema.projection: the only schema-level projection is "+
+				"`blocks`, not %q", s)
+	}
+	sch.Projection = s
 	return nil
 }
 

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -349,8 +349,10 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 		// `bind:` is meaningless on a preamble: it has no key to
 		// rename (its content hoists into the parent), and the
 		// empty form is redundant with that default. Plan 167.
+		// `projection:` is rejected for the same reason — a preamble
+		// has no scope object to carry a `blocks` key. Plan 246.
 		return rejectKeys(m, path, "preamble (`heading: null`)",
-			"sections", "bind")
+			"sections", "bind", "projection")
 	}
 	// After applyScopeFields succeeds, either Preamble is true
 	// (handled above) or Matcher is set by setScopeHeading; a
@@ -364,20 +366,27 @@ func validateScopeShape(sc Scope, m map[string]any, path string) error {
 	// projector skips slot scopes entirely so a bind would be
 	// unreachable (plan 167).
 	if isSlotMatcher(sc.Matcher) {
+		// `projection:` joins the rejected set: the per-scope blocks
+		// projection skips slots, so a scope-level `projection: blocks`
+		// here would be unreachable. Schema-level `projection: blocks`
+		// covers slots instead (plan 246).
 		return rejectKeys(m, path, "slot (`regex: '.+', repeat: { min: 0 }`)",
-			"sections", "rules", "content", "closed", "bind")
+			"sections", "rules", "content", "closed", "bind", "projection")
 	}
 	// A non-slot broad matcher (`regex: '.+'` with a non-zero
-	// `min`) is also skipped by the projector. `bind:` on such a
-	// scope is unreachable — surface it at parse time rather than
-	// silently dropping the override at extract time (plan 167).
+	// `min`) is also skipped by the projector. `bind:` and
+	// `projection:` on such a scope are unreachable — surface them at
+	// parse time rather than silently dropping at extract time (plans
+	// 167, 246).
 	if isBroadMatcher(sc.Matcher) {
-		if _, ok := m["bind"]; ok {
-			return fmt.Errorf(
-				"%s: `bind:` is not allowed on a broad-match scope "+
-					"(`regex: '.+'`) — the projector skips broad "+
-					"matchers so the override would be unreachable",
-				path)
+		for _, k := range []string{"bind", "projection"} {
+			if _, ok := m[k]; ok {
+				return fmt.Errorf(
+					"%s: `%s:` is not allowed on a broad-match scope "+
+						"(`regex: '.+'`) — the projector skips broad "+
+						"matchers so it would be unreachable",
+					path, k)
+			}
 		}
 	}
 	return nil
@@ -444,6 +453,8 @@ func applyScopeFields(m map[string]any, sc *Scope, path string) error {
 			err = setScopeContent(sc, vv, path)
 		case "bind":
 			err = setScopeBind(sc, vv, path)
+		case "projection":
+			err = setScopeProjection(sc, vv, path)
 		default:
 			return fmt.Errorf("%s: unknown scope key %q", path, k)
 		}
@@ -464,6 +475,29 @@ func setScopeBind(sc *Scope, v any, path string) error {
 		return fmt.Errorf("%s.bind must be a string, got %T", path, v)
 	}
 	sc.Bind = &s
+	return nil
+}
+
+// setScopeProjection reads the optional scope-level `projection:`
+// mode. The only legal value is `blocks` — the whole-body block
+// projection (plan 246). The content-entry projections (`text`,
+// `inline`, `tree`, `records`, `rows`) belong on a `content:` entry,
+// not a scope, so they are rejected here with a pointer to the right
+// surface. validateScopeShape rejects `projection:` outright on
+// preamble, slot, and broad scopes (the projector skips those), so
+// this setter handles only ordinary named scopes.
+func setScopeProjection(sc *Scope, v any, path string) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("%s.projection must be a string, got %T", path, v)
+	}
+	if s != ProjectionBlocks {
+		return fmt.Errorf(
+			"%s.projection: a scope only projects `blocks` "+
+				"(content-entry projections like text/inline/tree/records/rows "+
+				"go on a `content:` entry), not %q", path, s)
+	}
+	sc.Projection = s
 	return nil
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -119,6 +119,13 @@ type Schema struct {
 	// per-scope `projection:` still overrides this default. Empty means
 	// the historical declared-entries-only projection. Plan 246.
 	Projection string
+
+	// BlockParagraphs is the schema-level default for paragraph-block
+	// rendering under `projection: blocks` (ProjectionInline or
+	// ProjectionText). A scope's own BlockParagraphs overrides it.
+	// Valid only alongside a schema-level `projection: blocks`. Plan
+	// 246.
+	BlockParagraphs string
 }
 
 // FieldMeta carries optional schema-side metadata for a single
@@ -263,6 +270,15 @@ type Scope struct {
 	// entries only). The parser rejects it on preamble, slot, and
 	// broad-match scopes, which the projector skips. Plan 246.
 	Projection string
+
+	// BlockParagraphs selects how paragraph blocks render inside this
+	// scope's `blocks` list: ProjectionInline emits each paragraph's
+	// typed inline-span list under an `inline` key, ProjectionText (or
+	// empty) emits flat `text`. Valid only alongside
+	// `projection: blocks`; the parser rejects it otherwise. Block-mode
+	// inline is lenient — an image projects an `image` span rather than
+	// aborting like plan 212's strict content-entry inline. Plan 246.
+	BlockParagraphs string
 }
 
 // Matcher describes how a Scope claims one or more consecutive

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -111,6 +111,14 @@ type Schema struct {
 	// fixer is triggered, but never writes the file itself. See
 	// plan 143.
 	Index *IndexSpec
+
+	// Projection, when set to ProjectionBlocks, makes `mdsmith extract`
+	// project every matched section's whole body as a `blocks` list by
+	// default — including wildcard and unlisted sections the walker
+	// otherwise skips, each under its slug with its heading text. A
+	// per-scope `projection:` still overrides this default. Empty means
+	// the historical declared-entries-only projection. Plan 246.
+	Projection string
 }
 
 // FieldMeta carries optional schema-side metadata for a single
@@ -247,6 +255,14 @@ type Scope struct {
 	// hoists the scope's children into the parent instead of nesting
 	// under a key. Nil means "use the default key". Plan 167.
 	Bind *string
+
+	// Projection, when set to ProjectionBlocks, makes `mdsmith extract`
+	// project this scope's whole body as a typed recursive `blocks`
+	// list (in addition to any declared captures, child scopes, and
+	// content entries). Empty means the default projection (declared
+	// entries only). The parser rejects it on preamble, slot, and
+	// broad-match scopes, which the projector skips. Plan 246.
+	Projection string
 }
 
 // Matcher describes how a Scope claims one or more consecutive
@@ -416,6 +432,13 @@ const (
 	// are accepted (the columns array is positional). Short body rows are
 	// padded with empty strings to match the header width. Plan 245.
 	ProjectionRows = "rows"
+	// ProjectionBlocks projects a whole section body as a typed,
+	// recursive `blocks` list (the block-level analogue of
+	// ProjectionInline). It is a *scope*-level and *schema*-level
+	// projection, not a content-entry one: set on a Scope's
+	// `projection:` key, or once at the schema root to make it the
+	// default for every matched section. Plan 246.
+	ProjectionBlocks = "blocks"
 )
 
 // IsEmpty reports whether s carries no constraints. Used by callers

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -578,6 +578,28 @@ func TestParseInline_ProjectionOnUnlistedRejected(t *testing.T) {
 		"projection is not allowed on kind: unlisted")
 }
 
+// TestParseInline_SchemaProjectionBlocks accepts a schema-level
+// `projection: blocks` and records it on the Schema (plan 246).
+func TestParseInline_SchemaProjectionBlocks(t *testing.T) {
+	sch, err := ParseInline(map[string]any{
+		"projection": "blocks",
+		"sections":   []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.NoError(t, err)
+	assert.Equal(t, ProjectionBlocks, sch.Projection)
+}
+
+// TestParseInline_SchemaProjectionUnknownRejected rejects a
+// schema-level projection value other than `blocks`.
+func TestParseInline_SchemaProjectionUnknownRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"projection": "tree",
+		"sections":   []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocks")
+}
+
 // TestParseInline_ScopeProjectionBlocks accepts `projection: blocks`
 // on a scope and records it on the Scope (plan 246).
 func TestParseInline_ScopeProjectionBlocks(t *testing.T) {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -655,6 +655,72 @@ func TestParseInline_ScopeProjectionOnSlotRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "slot")
 }
 
+// TestParseInline_ScopeBlockParagraphsInline accepts
+// `block-paragraphs: inline` alongside `projection: blocks`.
+func TestParseInline_ScopeBlockParagraphsInline(t *testing.T) {
+	sch, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":          "Notes",
+			"projection":       "blocks",
+			"block-paragraphs": "inline",
+		}},
+	}, "kind x")
+	require.NoError(t, err)
+	assert.Equal(t, ProjectionInline, sch.Sections[0].BlockParagraphs)
+}
+
+// TestParseInline_ScopeBlockParagraphsWithoutBlocksRejected rejects
+// `block-paragraphs:` when the scope does not project blocks.
+func TestParseInline_ScopeBlockParagraphsWithoutBlocksRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":          "Notes",
+			"block-paragraphs": "inline",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "projection: blocks")
+}
+
+// TestParseInline_ScopeBlockParagraphsUnknownRejected rejects a value
+// other than inline/text.
+func TestParseInline_ScopeBlockParagraphsUnknownRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":          "Notes",
+			"projection":       "blocks",
+			"block-paragraphs": "tree",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inline")
+}
+
+// TestParseInline_SchemaBlockParagraphsInline accepts a schema-level
+// `block-paragraphs: inline` alongside a schema-level
+// `projection: blocks`.
+func TestParseInline_SchemaBlockParagraphsInline(t *testing.T) {
+	sch, err := ParseInline(map[string]any{
+		"projection":       "blocks",
+		"block-paragraphs": "inline",
+		"sections":         []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.NoError(t, err)
+	assert.Equal(t, ProjectionInline, sch.BlockParagraphs)
+}
+
+// TestParseInline_SchemaBlockParagraphsWithoutBlocksRejected rejects a
+// schema-level `block-paragraphs:` without a schema-level
+// `projection: blocks`.
+func TestParseInline_SchemaBlockParagraphsWithoutBlocksRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"block-paragraphs": "inline",
+		"sections":         []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "projection: blocks")
+}
+
 func TestParseInline_ContentUnknownKind(t *testing.T) {
 	_, err := ParseInline(map[string]any{
 		"sections": []any{map[string]any{

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -578,6 +578,61 @@ func TestParseInline_ProjectionOnUnlistedRejected(t *testing.T) {
 		"projection is not allowed on kind: unlisted")
 }
 
+// TestParseInline_ScopeProjectionBlocks accepts `projection: blocks`
+// on a scope and records it on the Scope (plan 246).
+func TestParseInline_ScopeProjectionBlocks(t *testing.T) {
+	sch, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":    "Notes",
+			"projection": "blocks",
+		}},
+	}, "kind x")
+	require.NoError(t, err)
+	require.Len(t, sch.Sections, 1)
+	assert.Equal(t, ProjectionBlocks, sch.Sections[0].Projection)
+}
+
+// TestParseInline_ScopeProjectionUnknownRejected rejects a scope-level
+// projection value other than `blocks` (the only scope projection).
+func TestParseInline_ScopeProjectionUnknownRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":    "Notes",
+			"projection": "tree",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blocks")
+}
+
+// TestParseInline_ScopeProjectionOnPreambleRejected rejects
+// `projection:` on a preamble — the projector hoists a preamble's
+// content, so a blocks key would have no scope object to live on.
+func TestParseInline_ScopeProjectionOnPreambleRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":    nil,
+			"projection": "blocks",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "preamble")
+}
+
+// TestParseInline_ScopeProjectionOnSlotRejected rejects `projection:`
+// on a wildcard slot — the per-scope blocks projection skips slots
+// (schema-level projection covers them instead).
+func TestParseInline_ScopeProjectionOnSlotRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":    map[string]any{"regex": ".+", "repeat": map[string]any{"min": 0}},
+			"projection": "blocks",
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slot")
+}
+
 func TestParseInline_ContentUnknownKind(t *testing.T) {
 	_, err := ParseInline(map[string]any{
 		"sections": []any{map[string]any{

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -721,6 +721,65 @@ func TestParseInline_SchemaBlockParagraphsWithoutBlocksRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "projection: blocks")
 }
 
+// A non-string schema-level `projection:` is a type error naming the
+// offending key, not a silent ignore.
+func TestParseInline_SchemaProjectionNonStringRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"projection": 42,
+		"sections":   []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema.projection")
+}
+
+// A non-string schema-level `block-paragraphs:` is a type error.
+func TestParseInline_SchemaBlockParagraphsNonStringRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"projection":       "blocks",
+		"block-paragraphs": true,
+		"sections":         []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema.block-paragraphs")
+}
+
+// A schema-level `block-paragraphs:` with a value other than
+// inline/text is rejected before the projection-presence check.
+func TestParseInline_SchemaBlockParagraphsBadValueRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"projection":       "blocks",
+		"block-paragraphs": "tree",
+		"sections":         []any{map[string]any{"heading": "Notes"}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inline")
+}
+
+// A non-string scope-level `projection:` is a type error.
+func TestParseInline_ScopeProjectionNonStringRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":    "Notes",
+			"projection": 7,
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "projection")
+}
+
+// A non-string scope-level `block-paragraphs:` is a type error.
+func TestParseInline_ScopeBlockParagraphsNonStringRejected(t *testing.T) {
+	_, err := ParseInline(map[string]any{
+		"sections": []any{map[string]any{
+			"heading":          "Notes",
+			"projection":       "blocks",
+			"block-paragraphs": 9,
+		}},
+	}, "kind x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "block-paragraphs")
+}
+
 func TestParseInline_ContentUnknownKind(t *testing.T) {
 	_, err := ParseInline(map[string]any{
 		"sections": []any{map[string]any{

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -110,7 +110,7 @@ contract instead of prose.
 3. [x] Accept schema-level `projection: blocks`; project wildcard
    and unlisted scopes under their slug with a `heading` text
    field; repeating matches project as arrays.
-4. Write the `#Block` / `#Span` CUE definitions; add the
+4. [x] Write the `#Block` / `#Span` CUE definitions; add the
    differential test validating all extract fixtures against
    them.
 5. [x] Offer a paragraph option for inline spans inside blocks

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -1,7 +1,7 @@
 ---
 id: 246
 title: "Typed block projection and full-document extract"
-status: "🔲"
+status: "🔳"
 summary: >-
   A block-level analogue of the inline-span grammar: a section
   projects its whole body as a typed, recursive `blocks` list,
@@ -100,7 +100,7 @@ contract instead of prose.
 
 ## Tasks
 
-1. Implement the block walker in
+1. [x] Implement the block walker in
    [`internal/extract`](../internal/extract) over the grammar
    table above, reusing plan 244's item shape and plan 245's
    `columns`/`rows` shape; paragraphs default to `text`.

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -1,7 +1,7 @@
 ---
 id: 246
 title: "Typed block projection and full-document extract"
-status: "🔳"
+status: "✅"
 summary: >-
   A block-level analogue of the inline-span grammar: a section
   projects its whole body as a typed, recursive `blocks` list,
@@ -117,27 +117,27 @@ contract instead of prose.
    (`{block: paragraph, inline: [...]}`) gated by the same
    entry-level choice as plan 212, so block mode does not
    force plain text.
-6. Document the grammar in the extract reference and rewrite
+6. [x] Document the grammar in the extract reference and rewrite
    the guide's framing: declared entries constrain and
    rename; `projection: blocks` captures everything else.
 
 ## Acceptance Criteria
 
-- [ ] `projection: blocks` on a scope projects its full body
+- [x] `projection: blocks` on a scope projects its full body
   as the typed list, document order preserved, containers
   recursive.
-- [ ] Schema-level `projection: blocks` projects wildcard and
+- [x] Schema-level `projection: blocks` projects wildcard and
   unlisted sections with `heading` text; no section of a
   matched document is silently dropped.
-- [ ] Every block fixture validates against the published CUE
+- [x] Every block fixture validates against the published CUE
   `#Block` definition in a differential test.
-- [ ] An HTML block and a thematic break project (no hard
+- [x] An HTML block and a thematic break project (no hard
   error); an image inside a `blocks`-mode paragraph projects
   via the inline option or a defined fallback — extract does
   not exit non-zero for representable content.
-- [ ] Reference and guide updated with verified outputs.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no issues
+- [x] Reference and guide updated with verified outputs.
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no issues
 
 ## Out of scope
 

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -113,7 +113,7 @@ contract instead of prose.
 4. Write the `#Block` / `#Span` CUE definitions; add the
    differential test validating all extract fixtures against
    them.
-5. Offer a paragraph option for inline spans inside blocks
+5. [x] Offer a paragraph option for inline spans inside blocks
    (`{block: paragraph, inline: [...]}`) gated by the same
    entry-level choice as plan 212, so block mode does not
    force plain text.

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -104,7 +104,7 @@ contract instead of prose.
    [`internal/extract`](../internal/extract) over the grammar
    table above, reusing plan 244's item shape and plan 245's
    `columns`/`rows` shape; paragraphs default to `text`.
-2. Accept `projection: blocks` on a scope; the `blocks` key
+2. [x] Accept `projection: blocks` on a scope; the `blocks` key
    joins the default-key set (`bind:`-renamable, collision-
    checked against declared content entries).
 3. Accept schema-level `projection: blocks`; project wildcard

--- a/plan/246_block-projection-full-extract.md
+++ b/plan/246_block-projection-full-extract.md
@@ -107,7 +107,7 @@ contract instead of prose.
 2. [x] Accept `projection: blocks` on a scope; the `blocks` key
    joins the default-key set (`bind:`-renamable, collision-
    checked against declared content entries).
-3. Accept schema-level `projection: blocks`; project wildcard
+3. [x] Accept schema-level `projection: blocks`; project wildcard
    and unlisted scopes under their slug with a `heading` text
    field; repeating matches project as arrays.
 4. Write the `#Block` / `#Span` CUE definitions; add the


### PR DESCRIPTION
Draft PR for [plan/246_block-projection-full-extract.md](plan/246_block-projection-full-extract.md).

Status will move 🔲 → 🔳 in PLAN.md once the first real
commit lands. Marking ready for review when the
acceptance criteria are checked off.

https://claude.ai/code/session_01V5FGdWSHdvuKjKtDjzM746

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5FGdWSHdvuKjKtDjzM746)_