### PR TITLE
website: recast the homepage positioning strip as a spec-sheet band

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -10,21 +10,21 @@ the website cannot drift out of sync with the binary.
 
 ## Layout
 
-| Path                           | Purpose                                                                     |
-| ------------------------------ | --------------------------------------------------------------------------- |
-| `hugo.toml`                    | Site config + module mounts (does NOT mount `../docs` directly).            |
-| `content/_index.md`            | Homepage front matter and copy.                                             |
-| `content/docs/`                | **Synced** from `../docs/` by `mdsmith-release build-website` (gitignored). |
-| `layouts/_default/baseof.html` | Page shell — `<head>`, top nav, footer.                                     |
-| `layouts/index.html`           | Homepage template (hero · feature grid · install tabs · terminal).          |
-| `layouts/_default/single.html` | Docs page template (sidebar + prose).                                       |
-| `layouts/_default/list.html`   | Section index template.                                                     |
-| `layouts/partials/`            | `topnav`, `footer`, `hero`, `feature-grid`, etc.                            |
-| `layouts/shortcodes/`          | `callout`, `diag`, `pill`, `chip`, `install-cmd`.                           |
-| `layouts/_default/_markup/`    | Goldmark render hooks (headings, code blocks).                              |
-| `static/css/`                  | `colors_and_type.css` (tokens) + `app.css` (component styles).              |
-| `static/fonts/`                | Self-hosted WOFF2: 0xProto (mono) + IBM Plex Sans/Serif.                    |
-| `static/img/`                  | Logo SVGs.                                                                  |
+| Path                           | Purpose                                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------- |
+| `hugo.toml`                    | Site config + module mounts (does NOT mount `../docs` directly).             |
+| `content/_index.md`            | Homepage front matter and copy.                                              |
+| `content/docs/`                | **Synced** from `../docs/` by `mdsmith-release build-website` (gitignored).  |
+| `layouts/_default/baseof.html` | Page shell — `<head>`, top nav, footer.                                      |
+| `layouts/index.html`           | Homepage template (hero · positioning band · feature grid · install picker). |
+| `layouts/_default/single.html` | Docs page template (sidebar + prose).                                        |
+| `layouts/_default/list.html`   | Section index template.                                                      |
+| `layouts/partials/`            | `topnav`, `footer`, `hero`, `feature-grid`, etc.                             |
+| `layouts/shortcodes/`          | `callout`, `diag`, `pill`, `chip`, `install-cmd`.                            |
+| `layouts/_default/_markup/`    | Goldmark render hooks (headings, code blocks).                               |
+| `static/css/`                  | `colors_and_type.css` (tokens) + `app.css` (component styles).               |
+| `static/fonts/`                | Self-hosted WOFF2: 0xProto (mono) + IBM Plex Sans/Serif.                     |
+| `static/img/`                  | Logo SVGs.                                                                   |
 
 ## Develop
 
@@ -119,6 +119,11 @@ release-channel docs, gated against drift in CI:
 
 - **Hero** — front matter (`hero:`) on the homepage
   itself, `content/_index.md`, read by `hero.html`.
+- **Positioning band** — the `content/_index.md` body (the
+  one-sentence scope statement) plus the linked "One engine"
+  surface row, hardcoded in `layouts/index.html` like the
+  hero CTAs and rendered directly above the "Available on"
+  strip.
 - **Install picker** — `install-picker.html` reads
   `hugo.Data.channels` (the generated
   `website/data/channels.yaml`). It renders every channel

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -8,8 +8,5 @@ hero:
   headline_post: ", smithed."
   lead: "mdsmith is a Markdown linter and formatter that keeps your writing neat and consistent — fast enough to stay out of your way. Auto-fix on save, instant navigation, cross-file integrity, and generated sections that keep derived data in sync, so the same Markdown drives docs, READMEs, and downstream pipelines without drift."
 ---
-mdsmith checks style, readability, structure, and cross-file integrity,
-and auto-fixes what fixes cleanly. One rule engine powers the CLI, the LSP
-server, and the VS Code extension — Neovim and other LSP-aware editors plug
-in through the same server, and a Claude Code plugin is available for users
-of that editor.
+mdsmith checks style, readability, structure, and cross-file
+integrity — and auto-fixes what fixes *cleanly*.

--- a/website/e2e/tests/home.spec.ts
+++ b/website/e2e/tests/home.spec.ts
@@ -3,20 +3,43 @@ import { test, expect } from "@playwright/test";
 /**
  * Homepage positioning and audience-path tests.
  *
- * Covers the category statement (the content/_index.md body that
- * layouts/index.html renders under the hero) and the markdownlint
- * migration link in the hero — the two elements that tell a
- * first-time visitor what mdsmith is and where to start.
+ * Covers the positioning band under the hero (the scope statement
+ * from the content/_index.md body plus the one-engine surface row
+ * from its front matter) and the markdownlint migration link in
+ * the hero — the elements that tell a first-time visitor what
+ * mdsmith is and where to start.
  */
 test.describe("homepage positioning", () => {
   test("scope statement renders under the hero", async ({ page }) => {
     await page.goto("/");
 
-    const positioning = page.locator(".positioning-body");
-    await expect(positioning).toBeVisible();
-    await expect(positioning).toContainText(
+    const statement = page.locator(".positioning-statement");
+    await expect(statement).toBeVisible();
+    await expect(statement).toContainText(
       "mdsmith checks style, readability, structure, and cross-file integrity",
     );
+  });
+
+  test("one-engine row links each product surface", async ({ page }) => {
+    await page.goto("/");
+
+    const row = page.locator(".positioning-engine");
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("One engine");
+
+    // Each surface chip is an audience path into the docs: the row
+    // replaces the old prose sentence ("One rule engine powers the
+    // CLI, the LSP server, and the VS Code extension …"), so every
+    // surface named there must stay reachable as a link.
+    const chips = row.locator("a.positioning-surface");
+    await expect(chips).toHaveCount(6);
+    await expect(chips.first()).toHaveAttribute("href", /\/reference\/cli\/$/);
+    await expect(
+      row.locator("a.positioning-surface", { hasText: "VS Code" }),
+    ).toHaveAttribute("href", /\/guides\/editors\/vscode\/$/);
+    await expect(
+      row.locator("a.positioning-surface", { hasText: "Claude Code" }),
+    ).toHaveAttribute("href", /\/features\/editor-agent-integration\/$/);
   });
 
   test("hero lead names the product category", async ({ page }) => {

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -1,20 +1,37 @@
 {{ define "main" }}
   {{ partial "hero.html" . }}
-  {{- /* The page body of content/_index.md is a one-paragraph
-         scope statement (what mdsmith checks, and the one engine
-         behind CLI, LSP, and editors). The hero lead carries the
-         category ("a Markdown linter and formatter"); this strip
-         adds the concrete scope right under it. The fuller copy
-         is the intro of docs/features/index.md (which the README
-         includes and /features/ renders); keep the _index.md body
-         aligned with it when either changes. */ -}}
-  {{ with .Content }}
+  {{- /* Positioning band. The content/_index.md body is a
+         one-sentence scope statement (what mdsmith checks and
+         fixes); the "One engine" row lists the product surfaces
+         the one rule engine reaches, each linking to its docs
+         page. The surface links are hardcoded here like the hero
+         CTAs in hero.html — the website-page front-matter schema
+         is closed, so homepage data blocks need a schema key
+         before they can move into front matter. The row is laid
+         out to pair with the "Available on" channels row from
+         logos-strip.html; together the three lines read as one
+         spec-sheet band under the hero. The fuller prose is the
+         intro of docs/features/index.md (which the README
+         includes and /features/ renders); keep the statement and
+         surface list aligned with it when either changes. */ -}}
   <section class="positioning">
     <div class="container">
-      <div class="positioning-body">{{ . }}</div>
+      {{ with .Content }}
+      <div class="positioning-statement">{{ . }}</div>
+      {{ end }}
+      <div class="positioning-engine">
+        <span class="positioning-label">One engine</span>
+        <div class="positioning-surfaces">
+          <a class="positioning-surface" href="{{ "/reference/cli/" | relURL }}">CLI</a>
+          <a class="positioning-surface" href="{{ "/features/live-diagnostics/" | relURL }}">LSP server</a>
+          <a class="positioning-surface" href="{{ "/guides/editors/vscode/" | relURL }}">VS Code</a>
+          <a class="positioning-surface" href="{{ "/guides/editors/neovim/" | relURL }}">Neovim</a>
+          <a class="positioning-surface" href="{{ "/guides/editors/obsidian/" | relURL }}">Obsidian</a>
+          <a class="positioning-surface" href="{{ "/features/editor-agent-integration/" | relURL }}">Claude Code</a>
+        </div>
+      </div>
     </div>
   </section>
-  {{ end }}
   {{ partial "logos-strip.html" . }}
   <section class="section">
     <div class="container">

--- a/website/layouts/partials/logos-strip.html
+++ b/website/layouts/partials/logos-strip.html
@@ -13,12 +13,14 @@
              data also holds pull/toolchain entries (go, npx, brew,
              asdf, …) that are install paths, not distribution
              registries, and do not belong here. */ -}}
-      {{ range where (sort hugo.Data.channels "weight") "mechanism" "push" }}
-        {{ $c := . }}
-        {{ with $c.url }}
-          <a class="logos-item" href="{{ . }}" rel="noopener">{{ $c.title }}</a>
+      <div class="logos-items">
+        {{ range where (sort hugo.Data.channels "weight") "mechanism" "push" }}
+          {{ $c := . }}
+          {{ with $c.url }}
+            <a class="logos-item" href="{{ . }}" rel="noopener">{{ $c.title }}</a>
+          {{ end }}
         {{ end }}
-      {{ end }}
+      </div>
     </div>
   </div>
 </div>

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -189,15 +189,15 @@ main {
   max-width: 540px;
   margin: 0 0 28px;
 }
-/* Hero lead and positioning bodies are rendered Markdown
+/* Hero lead and positioning statement are rendered Markdown
    (markdownify / .Content), which wraps the text in <p>.
    Without these resets, the global
    `p, .p { margin: 0 0 var(--space-4); }` from
    colors_and_type.css would stack on top of the blocks'
    own bottom margins. */
-.hero-lead p, .positioning-body p { margin: 0; }
+.hero-lead p, .positioning-statement p { margin: 0; }
 .hero-lead p:not(:last-child),
-.positioning-body p:not(:last-child) { margin-bottom: 12px; }
+.positioning-statement p:not(:last-child) { margin-bottom: 12px; }
 .hero-cta { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
 .hero-switch {
   font-size: 14px;
@@ -218,22 +218,76 @@ main {
 .hero-badges a[hidden] { display: none; }
 .hero-badges img { height: 20px; display: block; }
 
-/* ========== POSITIONING ========== */
+/* ========== POSITIONING BAND ========== */
 
-/* One-paragraph category statement (the content/_index.md body),
-   rendered between the hero and the logos strip so a first-time
-   visitor can classify the product without scrolling. */
+/* The band between the hero and "Why mdsmith": a one-sentence
+   scope statement (the content/_index.md body) set as display
+   type, then two labeled spec rows — "One engine" (the product
+   surfaces, from the homepage front matter) and "Available on"
+   (the publish channels, from logos-strip.html). The rows share
+   a label column, and the border that used to split .positioning
+   from .logos now closes the band at the bottom of .logos, so
+   the three lines read as one designed block instead of a stray
+   paragraph between two strips. */
 .positioning {
-  padding: 36px 0;
-  border-bottom: 1px solid var(--border-subtle);
+  padding: 44px 0 0;
 }
 /* Paragraph margin resets live with .hero-lead's (same
    rendered-Markdown wrapping). */
-.positioning-body {
-  max-width: 760px;
-  font-size: 16px;
-  line-height: 1.65;
-  color: var(--fg-muted);
+.positioning-statement {
+  max-width: 700px;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.5;
+  letter-spacing: -0.015em;
+  color: var(--fg);
+  margin-bottom: 26px;
+}
+/* Same serif-italic accent as the h1 and section titles. */
+.positioning-statement em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 400;
+  color: var(--forge-600);
+}
+/* Shared two-part row: fixed label column + wrapping item flow.
+   .logos-strip (logos-strip.html) uses the same skeleton so the
+   "One engine" and "Available on" lines align into a spec sheet. */
+.positioning-engine,
+.logos-strip {
+  display: flex;
+  align-items: center;
+}
+.positioning-label,
+.logos-label {
+  flex: 0 0 148px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fg-subtle);
+}
+.positioning-surfaces {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.positioning-surface {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--steel-700);
+  transition: border-color var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+}
+.positioning-surface:hover {
+  border-color: var(--forge-500);
+  color: var(--forge-600);
+  text-decoration: none;
 }
 
 /* ========== BUTTONS ========== */
@@ -1476,19 +1530,22 @@ a.install-label:hover { color: var(--forge-300); text-decoration: underline; }
 
 /* ========== LOGOS STRIP ========== */
 
+/* Second spec row of the positioning band; the row skeleton and
+   label column are shared with .positioning-engine (see the
+   POSITIONING BAND section). Channel names stay plain muted text
+   so the linked surface chips above keep the visual priority. */
 .logos {
-  padding: 40px 0;
+  padding: 14px 0 44px;
   border-bottom: 1px solid var(--border-subtle);
 }
-.logos-strip {
-  display: flex; align-items: center; justify-content: space-between;
-  flex-wrap: wrap; gap: 32px;
-  filter: grayscale(1); opacity: 0.7;
+.logos-items {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 26px;
 }
-.logos-label { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.05em; color: var(--fg-subtle); text-transform: uppercase; }
-.logos-item { font-family: var(--font-sans); font-size: 18px; font-weight: 600; color: var(--steel-700); letter-spacing: -0.01em; }
+.logos-item { font-family: var(--font-sans); font-size: 15px; font-weight: 500; color: var(--steel-600); letter-spacing: -0.01em; }
 .logos-item:hover { color: var(--accent); text-decoration: none; }
-.logos-strip:hover { filter: none; opacity: 1; }
 
 /* ========== FOOTER ========== */
 
@@ -1783,13 +1840,16 @@ a.rule-ref:hover code { text-decoration: underline; }
      both columns instead. */
   .footer-grid .footer-col:first-child { grid-column: 1 / -1; }
 
-  /* space-between + wrap scattered the channel names with ragged
-     gaps once they wrapped; switch to a left-aligned gap flow with
-     the label on its own line. */
-  .logos { padding: 28px 0; }
-  .logos-strip { justify-content: flex-start; gap: 12px 24px; }
-  .logos-label { flex-basis: 100%; }
-  .logos-item { font-size: 16px; }
+  /* The 148px label column eats too much of a narrow viewport;
+     stack each spec-row label on its own line above its items. */
+  .positioning { padding: 32px 0 0; }
+  .positioning-statement { font-size: 18px; margin-bottom: 22px; }
+  .positioning-engine,
+  .logos-strip { flex-direction: column; align-items: flex-start; gap: 10px; }
+  .positioning-label,
+  .logos-label { flex-basis: auto; }
+  .logos { padding: 18px 0 32px; }
+  .logos-item { font-size: 14px; }
 
   .pg { grid-template-columns: 1fr; height: auto; }
   .pg-pane + .pg-pane { border-left: 0; border-top: 1px solid var(--border); }


### PR DESCRIPTION
## Problem

The `content/_index.md` body rendered as a bare, unlabeled paragraph floating between the hero and the "Available on" logos strip. Every other homepage block has a mono eyebrow, a label, or a title; this one was raw body text with no visual anchor, so it read as bolted on — and its second sentence ("One rule engine powers the CLI, the LSP server, and the VS Code extension — Neovim and other LSP-aware editors plug in through the same server, and a Claude Code plugin is available for users of that editor.") was a surface list dressed as clunky prose.

## Change

The paragraph becomes a designed positioning band of three aligned lines:

1. **Scope statement** — the body's first sentence, set as display type (20px, full-color) with the site's serif-italic accent on *cleanly*, echoing the h1 and section titles.
2. **`ONE ENGINE` row** — the old second sentence recast as a labeled row of surface links: CLI, LSP server, VS Code, Neovim, Obsidian, Claude Code, each linking to its docs page.
3. **`AVAILABLE ON` row** — the existing channels strip, restyled from a `space-between` scatter (with the grayscale hover filter) onto the same 148px label column as the engine row.

The border that used to split `.positioning` from `.logos` now closes the band, so the three lines read as one spec-sheet block under the hero. On viewports under 560px each label stacks above its items.

The surface links are hardcoded in `index.html` like the hero CTAs: the `website-page` front-matter schema in `.mdsmith.yml` is closed, so a `positioning:` front-matter block would need a new schema key first (left out deliberately — `.mdsmith.yml` changes need explicit owner consent).

## Testing

- `website/e2e/tests/home.spec.ts`: the scope-statement test now targets `.positioning-statement`, and a new test asserts the one-engine row links each product surface (TDD: both failed against the old design first). Full Playwright suite: 28 passed.
- `go run ./cmd/mdsmith check .` — clean (445 files).

https://claude.ai/code/session_01DiQxL3uZQ9wSrVuoPMLnXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiQxL3uZQ9wSrVuoPMLnXN)_