### PR TITLE
plan/145: correct mise registry submission target

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -199,7 +199,7 @@ mise use -g ubi:jeduden/mdsmith@latest
 The one gap is a bare `mise use mdsmith@latest`: no backend
 prefix, and no prior `mise plugins install` like the asdf
 step above. That form needs an entry in mise's curated
-registry ([`jdx/mise`](https://github.com/jdx/mise)
+registry ([`mise-plugins/registry`](https://github.com/mise-plugins/registry)
 `registry.toml`), tracked in
 [plan/145](../../plan/145_asdf-mise-registry-submissions.md).
 Until it merges, use a backend-prefixed form, or install the

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -199,8 +199,8 @@ mise use -g ubi:jeduden/mdsmith@latest
 The one gap is a bare `mise use mdsmith@latest`: no backend
 prefix, and no prior `mise plugins install` like the asdf
 step above. That form needs an entry in mise's curated
-registry ([`mise-plugins/registry`](https://github.com/mise-plugins/registry)
-`registry.toml`), tracked in
+registry (the `registry/` dir in
+[`jdx/mise`](https://github.com/jdx/mise)), tracked in
 [plan/145](../../plan/145_asdf-mise-registry-submissions.md).
 Until it merges, use a backend-prefixed form, or install the
 plugin first as shown above.

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -6,7 +6,7 @@ title: >-
 status: "🔳"
 summary: >-
   Land the asdf-plugin repo (jeduden/asdf-mdsmith) and
-  the jdx/mise registry entry that the multi-channel
+  the mise-plugins/registry entry that the multi-channel
   release pipeline already documents but cannot trigger
   from this repo. Spun out of plan/130 because both
   tasks ship outside this repo.
@@ -65,7 +65,7 @@ on `asdf plugin add mdsmith`.
    adding mdsmith so `asdf plugin add mdsmith`
    resolves without an explicit URL.
 4. File a PR to mise's curated registry,
-   [`jdx/mise`](https://github.com/jdx/mise)
+   [`mise-plugins/registry`](https://github.com/mise-plugins/registry)
    `registry.toml`, adding a `[tools.mdsmith]` entry
    on the `github:jeduden/mdsmith` backend (`ubi:` is
    deprecated for new entries) with a `test` field.
@@ -94,7 +94,7 @@ on `asdf plugin add mdsmith`.
 - [x] `asdf install mdsmith X.Y.Z` then
       `mdsmith version` prints `mdsmith vX.Y.Z`.
 - [ ] `mise use mdsmith@X.Y.Z` (no backend prefix)
-      resolves after the `jdx/mise` registry PR
+      resolves after the `mise-plugins/registry` PR
       merges, and `mdsmith version` prints
       `mdsmith vX.Y.Z`.
 - [ ] [docs/guides/install.md](../docs/guides/install.md)

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -6,7 +6,7 @@ title: >-
 status: "🔳"
 summary: >-
   Land the asdf-plugin repo (jeduden/asdf-mdsmith) and
-  the mise-plugins/registry entry that the multi-channel
+  the jdx/mise registry entry that the multi-channel
   release pipeline already documents but cannot trigger
   from this repo. Spun out of plan/130 because both
   tasks ship outside this repo.
@@ -64,16 +64,23 @@ on `asdf plugin add mdsmith`.
    [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
    adding mdsmith so `asdf plugin add mdsmith`
    resolves without an explicit URL.
-4. File a PR to mise's curated registry,
-   [`mise-plugins/registry`](https://github.com/mise-plugins/registry)
-   `registry.toml`, adding a `[tools.mdsmith]` entry
-   on the `github:jeduden/mdsmith` backend (`ubi:` is
-   deprecated for new entries) with a `test` field.
-   The PR body must make a popularity/maintenance
-   case, since the registry is curated. Once merged,
-   the prefix-less `mise use mdsmith@latest` form
-   starts resolving on user CLIs without any code
-   change in this repo.
+4. File a PR to mise's curated registry: the
+   `registry/` directory in
+   [`jdx/mise`](https://github.com/jdx/mise), one
+   TOML file per tool. (The former root
+   `registry.toml` was split into per-tool files;
+   the separate `mise-plugins/registry` repo was
+   archived in Oct 2024.) Add
+   `registry/mdsmith.toml` with a `[tools.mdsmith]`
+   entry on the `github:jeduden/mdsmith` backend
+   (`ubi:` is rejected for new entries; `aqua:` is
+   preferred only for tools already in the aqua
+   registry) and the required `test` field. The PR
+   body must make a popularity/maintenance case,
+   since the registry is curated. Once merged, the
+   prefix-less `mise use mdsmith@latest` form starts
+   resolving on user CLIs without any code change in
+   this repo.
 5. Update
    [docs/guides/install.md](../docs/guides/install.md)
    to drop the "pending follow-up" badge from the
@@ -94,7 +101,7 @@ on `asdf plugin add mdsmith`.
 - [x] `asdf install mdsmith X.Y.Z` then
       `mdsmith version` prints `mdsmith vX.Y.Z`.
 - [ ] `mise use mdsmith@X.Y.Z` (no backend prefix)
-      resolves after the `mise-plugins/registry` PR
+      resolves after the `jdx/mise` registry PR
       merges, and `mdsmith version` prints
       `mdsmith vX.Y.Z`.
 - [ ] [docs/guides/install.md](../docs/guides/install.md)


### PR DESCRIPTION
## Summary

Plan/145 (asdf + mise registry submissions) pointed its mise task at a stale target. Verified against the live mise docs and repos:

- The separate [`mise-plugins/registry`](https://github.com/mise-plugins/registry) repo was **archived Oct 14, 2024** and points back to `jdx/mise`.
- The former root `registry.toml` in `jdx/mise` no longer exists — it was split into a [`registry/`](https://github.com/jdx/mise/tree/main/registry) directory with one TOML file per tool.
- Current acceptance rules from the [contributing docs](https://mise.jdx.dev/contributing.html): `ubi:` is rejected for new entries, `aqua:`/`github:` are the tier-1 backends, a `test` field is required, and the PR body needs a popularity/maintenance case.
- asdf is unchanged: [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins) remains the active shortname index, so task 3 stays as-is.

## Changes

- `plan/145_asdf-mise-registry-submissions.md` — task 4 now targets `registry/mdsmith.toml` in `jdx/mise`, notes the registry.toml→registry/ split and the archived external repo, and records the backend acceptance rules; acceptance criterion updated to match.
- `docs/guides/install.md` — the bare `mise use mdsmith@latest` gap now references the `registry/` dir in `jdx/mise`.

`mdsmith check .` passes (445 files).

https://claude.ai/code/session_0137Go6paLWLfkEc2oS7HyfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0137Go6paLWLfkEc2oS7HyfQ)_