### PR TITLE
plan-103: schemas/ is checked-in config again (plan 241 landed)

### DIFF
--- a/plan/103_build-staleness-and-deps.md
+++ b/plan/103_build-staleness-and-deps.md
@@ -168,7 +168,7 @@ The recommended `.gitignore` snippet:
 ```
 
 Never ignore the whole `.mdsmith/` dir.
-Its other folders (`kinds/`,
+Its other folders (`kinds/`, `schemas/`,
 `conventions/`) are checked-in config.
 
 ### Flags on `mdsmith fix`


### PR DESCRIPTION
One-word follow-up to #235.

During #235's third review round, `schemas/` was removed from plan 103's "never gitignore the whole `.mdsmith/` dir" folder list because plan 241 (`.mdsmith/schemas/`) had not landed. Plan 241 merged the same day (#557), so `.mdsmith/schemas/` is real checked-in config again and belongs back in the list — it is precisely the kind of file a whole-directory ignore would silently drop from clones.

The change was held out of #235 deliberately: it arose while the merge-queue batch was running, and pushing would have invalidated the batch.

`mdsmith check .` is green (452 files).

https://claude.ai/code/session_01T31cAtznAH5Qs9qECNPSj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T31cAtznAH5Qs9qECNPSj9)_