### PR TITLE
ci: bump pinned baseline to v0.40.0; adopt MDS069 for plan ids

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -12,8 +12,8 @@ runs:
         # Bump here only when intentionally updating that baseline.
         # After bumping, scan PLAN.md for plans waiting to adopt the
         # newly-released syntax. See docs/development/adopt-new-directive-syntax.md.
-        MDSMITH_VERSION: v0.33.0
-        MDSMITH_SHA256: 36960a577c5220c033b60ba8d992e9dc964e46c6496e45a5a76451d625c280ec
+        MDSMITH_VERSION: v0.40.0
+        MDSMITH_SHA256: 69da312cbb74a3ae5674f2fa10f2eef2c03e3956b73cb0238615aad1d4e09614
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.

--- a/.mdsmith.yml
+++ b/.mdsmith.yml
@@ -82,6 +82,13 @@ rules:
   include: true
   unclosed-code-block: true
   git-hook-sync: true
+  # Workspace-unique plan ids (plan/2606100534). Enabled once
+  # the pinned baseline shipped MDS069, per the adopt-new-syntax
+  # process; the pinned job would otherwise ignore the rule.
+  unique-frontmatter:
+    field: id
+    include: ["plan/*.md"]
+    exclude: ["plan/proto.md"]
 
 overrides:
   - glob: ["CLAUDE.md"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -177,7 +177,7 @@ footer: |
 | 2606092208 | ✅     | sonnet | [Recover from panics in the LSP lint pipeline](plan/2606092208_lsp-panic-recovery.md)                                                   |
 | 2606092209 | ✅     | sonnet | [Security hardening batch — 2026-06-09 audit](plan/2606092209_secreview-2026-06-09-hardening.md)                                        |
 | 2606100533 | ✅     | sonnet | [Coordination-free plan ids from UTC creation timestamps](plan/2606100533_timestamp-plan-ids.md)                                        |
-| 2606100534 | 🔳     | sonnet | [Workspace-unique front-matter fields (unique-frontmatter rule)](plan/2606100534_unique-frontmatter-rule.md)                            |
+| 2606100534 | ✅     | sonnet | [Workspace-unique front-matter fields (unique-frontmatter rule)](plan/2606100534_unique-frontmatter-rule.md)                            |
 | 2606101546 | 🔲     | opus   | [Builder execution wired into `mdsmith fix`](plan/2606101546_builder-execution-in-fix.md)                                               |
 | 2606101547 | 🔲     | opus   | [Build execution UX (stdout/stderr, debug, parallel)](plan/2606101547_build-execution-ux.md)                                            |
 | 2606101548 | 🔲     | opus   | [Build execution hardening](plan/2606101548_build-execution-hardening.md)                                                               |

--- a/plan/2606100534_unique-frontmatter-rule.md
+++ b/plan/2606100534_unique-frontmatter-rule.md
@@ -1,7 +1,7 @@
 ---
 id: 2606100534
 title: 'Workspace-unique front-matter fields (unique-frontmatter rule)'
-status: "🔳"
+status: "✅"
 model: sonnet
 summary: >-
   New rule MDS069: within configured include/exclude globs,
@@ -140,22 +140,26 @@ dogfooding: unique ids or titles across any kind.
    `internal/rules/MDS069-unique-frontmatter/` (good/bad
    with expected diagnostics) plus the rule README on the
    rule-readme schema.
-4. [ ] Gated on the pin bump: after a release ships
+4. [x] Gated on the pin bump: after a release ships
    MDS069 and `MDSMITH_VERSION` in
    `setup-mdsmith-pinned-version` moves to it, add the
    plan-id block to [.mdsmith.yml](../.mdsmith.yml)
    (consent above) and verify a duplicate plan id fails
-   `mdsmith check .` while the clean tree passes.
+   `mdsmith check .` while the clean tree passes. Done
+   with the v0.40.0 pin bump, which ships MDS069.
 
 ## Acceptance Criteria
 
-- [ ] (Gated on task 4.) A duplicated plan id added
+- [x] (Gated on task 4.) A duplicated plan id added
   locally makes `mdsmith check .` fail; the diagnostic
   lands on the later file in path order and its message
   names the field, the value, and the earlier file.
   Verified once pre-gate with a temporary config block
   and a probe file: the probe failed at its `id:` line
-  naming the first holder.
+  naming the first holder. Re-verified with the live
+  block: the probe failed the same way, and the clean
+  tree passes under both the branch binary and the
+  pinned v0.40.0 one.
 - [x] The bad fixture yields exactly one diagnostic per
   extra file sharing a value; the good fixture is clean.
 - [x] A file missing the configured field, or outside the


### PR DESCRIPTION
## Pin bump

Sets `MDSMITH_VERSION` to `v0.40.0` in
`.github/actions/setup-mdsmith-pinned-version/action.yml` (was `v0.33.0`).
The `MDSMITH_SHA256` for `mdsmith-linux-amd64` was cross-verified against
two sources: the release's `checksums.txt` and the GitHub API asset digest.
Also verified end-to-end locally: download, `sha256sum -c`, and
`mdsmith version` reporting `v0.40.0`.

## Gated adoption: workspace-unique plan ids (plan 2606100534)

Per `docs/development/adopt-new-directive-syntax.md`, bumping the pin means
scanning `PLAN.md` for plans waiting on it. Plan `2606100534` had exactly
one task left, gated on this bump: enable MDS069 (`unique-frontmatter`)
for plan ids once the pinned baseline ships the rule (it shipped in
v0.40.0 via #544). The plan records maintainer consent for exactly the
`.mdsmith.yml` block added here:

```yaml
unique-frontmatter:
  field: id
  include: ["plan/*.md"]
  exclude: ["plan/proto.md"]
```

The plan is now ✅ and `PLAN.md` regenerated via `mdsmith fix`.

## Verification

- Red: a probe file duplicating id `2606100534` fails `mdsmith check` at
  its `id:` line — `MDS069 front-matter "id": value 2606100534 already
  used by plan/2606100534_unique-frontmatter-rule.md`.
- Green: `mdsmith check .` passes on the clean tree under **both** the
  branch binary and the pinned v0.40.0 binary (452 files, 0 failures) —
  so `mdsmith-fixed-version` stays green.
- `go test ./...` passes with no failures.

https://claude.ai/code/session_01EW9CdoY1xa1b914igQs2z1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW9CdoY1xa1b914igQs2z1)_