### PR TITLE
Make the Flatpak install command copy-pastable

### DIFF
--- a/docs/development/release-channels/flatpak.md
+++ b/docs/development/release-channels/flatpak.md
@@ -7,7 +7,7 @@ summary: >-
   filesystem access for the linter.
 mechanism: push
 artifact: cli
-command: flatpak install ./mdsmith-x86_64.flatpak
+command: curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-x86_64.flatpak && flatpak install ./mdsmith-x86_64.flatpak
 audience: Sandboxed Linux x86_64 desktops via Flatpak
 platforms: [linux]
 registry: github.com/jeduden/mdsmith/releases
@@ -23,10 +23,11 @@ Release page: <https://github.com/jeduden/mdsmith/releases>
 The Flatpak channel ships mdsmith as a single-file
 `.flatpak` bundle. The bundle is attached to each GitHub
 release. Its app id is `io.github.jeduden.mdsmith`, and it
-is **x86_64 only**. Download `mdsmith-x86_64.flatpak` from
-the release page, then install and run it:
+is **x86_64 only**. The commands below download the latest
+`mdsmith-x86_64.flatpak`, install it, and run it:
 
 ```bash
+curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-x86_64.flatpak
 flatpak install ./mdsmith-x86_64.flatpak
 flatpak run io.github.jeduden.mdsmith check .
 ```

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -50,20 +50,20 @@ header: |
   | ------- | ------- | -------- |
 row: "| {title} | `{command}` | {audience} |"
 ?>
-| Channel         | Command                                                                                    | Best for                                          |
-| --------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------- |
-| Go              | `go install github.com/jeduden/mdsmith/cmd/mdsmith@latest`                                 | Go developers with a working Go toolchain         |
-| npm             | `npm install -g @mdsmith/cli`                                                              | Node / TypeScript repos and npm-friendly CI       |
-| npx             | `npx @mdsmith/cli check .`                                                                 | One-off checks without a global install           |
-| PyPI            | `pip install mdsmith`                                                                      | Python projects and Python-only CI images         |
-| uvx             | `uvx mdsmith check .`                                                                      | Ephemeral runs via uv                             |
-| pipx            | `pipx install mdsmith`                                                                     | Isolated CLI install on Python hosts              |
-| Homebrew        | `brew install jeduden/mdsmith/mdsmith`                                                     | macOS and Linux via Homebrew                      |
-| mise            | `mise use -g ubi:jeduden/mdsmith@latest`                                                   | Repos using mise; works today via GitHub releases |
-| asdf            | `asdf plugin add mdsmith https://github.com/jeduden/asdf-mdsmith.git`                      | Repos standardized on asdf                        |
-| GitHub Releases | `curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-<os>-<arch>` | Air-gapped hosts and direct binary control        |
-| Scoop           | `scoop install mdsmith`                                                                    | Windows users with Scoop installed                |
-| Flatpak         | `flatpak install ./mdsmith-x86_64.flatpak`                                                 | Sandboxed Linux x86_64 desktops via Flatpak       |
+| Channel         | Command                                                                                                                                   | Best for                                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Go              | `go install github.com/jeduden/mdsmith/cmd/mdsmith@latest`                                                                                | Go developers with a working Go toolchain         |
+| npm             | `npm install -g @mdsmith/cli`                                                                                                             | Node / TypeScript repos and npm-friendly CI       |
+| npx             | `npx @mdsmith/cli check .`                                                                                                                | One-off checks without a global install           |
+| PyPI            | `pip install mdsmith`                                                                                                                     | Python projects and Python-only CI images         |
+| uvx             | `uvx mdsmith check .`                                                                                                                     | Ephemeral runs via uv                             |
+| pipx            | `pipx install mdsmith`                                                                                                                    | Isolated CLI install on Python hosts              |
+| Homebrew        | `brew install jeduden/mdsmith/mdsmith`                                                                                                    | macOS and Linux via Homebrew                      |
+| mise            | `mise use -g ubi:jeduden/mdsmith@latest`                                                                                                  | Repos using mise; works today via GitHub releases |
+| asdf            | `asdf plugin add mdsmith https://github.com/jeduden/asdf-mdsmith.git`                                                                     | Repos standardized on asdf                        |
+| GitHub Releases | `curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-<os>-<arch>`                                                | Air-gapped hosts and direct binary control        |
+| Scoop           | `scoop install mdsmith`                                                                                                                   | Windows users with Scoop installed                |
+| Flatpak         | `curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-x86_64.flatpak && flatpak install ./mdsmith-x86_64.flatpak` | Sandboxed Linux x86_64 desktops via Flatpak       |
 <?/catalog?>
 
 A bare `mise use mdsmith@latest` needs a registry entry —
@@ -207,12 +207,13 @@ plugin first as shown above.
 
 ## Flatpak
 
-mdsmith ships an **x86_64-only** Flatpak bundle as a release
-asset. Download `mdsmith-x86_64.flatpak` from the
-[release page](https://github.com/jeduden/mdsmith/releases),
-then install and run it:
+mdsmith ships an **x86_64-only** Flatpak bundle as an asset
+on the [release page](https://github.com/jeduden/mdsmith/releases).
+The commands below download the latest
+`mdsmith-x86_64.flatpak`, install it, and run it:
 
 ```bash
+curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-x86_64.flatpak
 flatpak install ./mdsmith-x86_64.flatpak
 flatpak run io.github.jeduden.mdsmith check .
 ```

--- a/website/data/channels.yaml
+++ b/website/data/channels.yaml
@@ -158,7 +158,7 @@
   summary: A single-file `.flatpak` bundle built in CI from the x86_64 Linux release binary and attached to each GitHub release, installed by file with host filesystem access for the linter.
   mechanism: push
   artifact: cli
-  command: flatpak install ./mdsmith-x86_64.flatpak
+  command: curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-x86_64.flatpak && flatpak install ./mdsmith-x86_64.flatpak
   audience: Sandboxed Linux x86_64 desktops via Flatpak
   platforms:
     - linux


### PR DESCRIPTION
## Problem

The documented Flatpak install command was

```bash
flatpak install ./mdsmith-x86_64.flatpak
```

which assumes the bundle is already sitting in the current directory. Pasted into a shell as-is, it fails — unlike every other channel's one-shot command, and contrary to the website picker's promise to "copy the one line you need".

## Change

Prepend a `curl -LO` download of the latest release asset, following the GitHub Releases channel's existing pattern. Flatpak is x86_64-only, so the asset name is concrete — no `<os>-<arch>` placeholder needed:

```bash
curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-x86_64.flatpak
flatpak install ./mdsmith-x86_64.flatpak
```

Edited surfaces:

- `docs/development/release-channels/flatpak.md` — the `command:` front matter (single source of truth) and the channel page's code block/prose
- `docs/guides/install.md` — the Flatpak section's code block/prose; the channels table regenerated via `mdsmith fix`
- `website/data/channels.yaml` — regenerated via `mdsmith-release sync-channels`

## Verification

- `mdsmith check .` — 452 files, 0 failures
- `mdsmith-release sync-channels --check` and `sync-messaging --check` — no drift
- `go test ./internal/release/... ./cmd/mdsmith-release/...` — pass

https://claude.ai/code/session_01Fzv6inPiCsX8UkGPLgvjUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fzv6inPiCsX8UkGPLgvjUU)_