### PR TITLE
Remove Copilot auto-review hook from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,19 +42,5 @@
     ],
     "ask": [
     ]
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -re '.tool_input.command // \"\"' | grep -q 'git push' && REPO=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\\.git)?$|\\1|') && BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) && PR=$(gh api \"repos/$REPO/pulls\" 2>/dev/null | jq -r --arg b \"$BRANCH\" '.[] | select(.head.ref == $b) | .number' | head -1) && [ -n \"$PR\" ] && gh api \"repos/$REPO/pulls/$PR/requested_reviewers\" -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]' 2>/dev/null; true",
-            "statusMessage": "Requesting code review..."
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
## Summary

Removes the `PostToolUse` hook from `.claude/settings.json` that automatically requested a review from `copilot-pull-request-reviewer[bot]` after every `git push`.

The hook fired in every Claude Code session in this repo — it grepped each Bash command for `git push`, looked up the open PR for the current branch, and POSTed a `requested_reviewers` entry, independent of which skills were invoked. This was the source of Copilot review requests appearing "without instructions".

PR reviews move to explicit `/code-review` runs instead.

Not touched here (follow-up): the "request a Copilot re-review" instructions in `CLAUDE.md` / `docs/development/pr-fixup-workflow.md` and their generated mirrors (`AGENTS.md`, `.github/copilot-instructions.md`, the skills, and the `.github/*-pr-fixup.md` copies).

https://claude.ai/code/session_01GvXczBVHDRpguDa6G1UkpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvXczBVHDRpguDa6G1UkpB)_