### PR TITLE
website: reserve scrollbar gutter so opening search does not shift the page

### DIFF
--- a/website/e2e/tests/search.spec.ts
+++ b/website/e2e/tests/search.spec.ts
@@ -77,6 +77,43 @@ test.describe("⌘K search", () => {
     await expect(dialog).toBeVisible();
   });
 
+  // ─── layout stability ───────────────────────────────────────────────
+
+  test("opening the dialog does not shift the page behind it", async ({
+    page,
+  }) => {
+    // The scroll lock (html.search-active { overflow: hidden }) hides
+    // the page scrollbar; without a reserved gutter the page widens by
+    // the scrollbar width and visibly shifts. Headless Linux Chromium
+    // draws overlay scrollbars that take no layout space, so the pixel
+    // shift cannot be reproduced here — assert the gutter contract on
+    // the root element instead. It must be unconditional: this same
+    // Chromium reserves a nonzero stable gutter, so applying it only
+    // alongside the lock would itself shift the page on open. That
+    // wrong variant is what the width checks below catch.
+    const gutter = await page.evaluate(
+      () => getComputedStyle(document.documentElement).scrollbarGutter
+    );
+    expect(gutter).toBe("stable");
+
+    const widthBefore = await page.evaluate(
+      () => document.documentElement.clientWidth
+    );
+    const nav = page.locator(".topnav-inner");
+    const navBefore = (await nav.boundingBox())!;
+
+    await page.keyboard.press("Control+k");
+    await expect(page.locator("[data-search-dialog]")).toBeVisible();
+
+    const widthAfter = await page.evaluate(
+      () => document.documentElement.clientWidth
+    );
+    const navAfter = (await nav.boundingBox())!;
+    expect(widthAfter).toBe(widthBefore);
+    expect(navAfter.x).toBe(navBefore.x);
+    expect(navAfter.width).toBe(navBefore.width);
+  });
+
   // ─── querying ───────────────────────────────────────────────────────
 
   test("typing a query renders matching results", async ({ page }) => {

--- a/website/static/css/app.css
+++ b/website/static/css/app.css
@@ -2118,7 +2118,13 @@ html.js .search-trigger {
   background: var(--bg-raised);
 }
 
-/* Lock the page behind the modal so only the result list scrolls. */
+/* Lock the page behind the modal so only the result list scrolls.
+   The always-on stable gutter keeps the scrollbar's space reserved
+   while the lock hides it, so the page never widens and shifts
+   behind the dialog. It must not move into the lock rule: Chromium
+   reserves a nonzero stable gutter even with overlay scrollbars, so
+   a lock-scoped gutter would itself shift the page on open. */
+html { scrollbar-gutter: stable; }
 html.search-active { overflow: hidden; }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Problem

Opening the ⌘K search dialog adds `html.search-active { overflow: hidden }` to lock the page behind the modal. That drops the page scrollbar, so on platforms with classic (space-taking) scrollbars the page widens by the scrollbar width and visibly shifts behind the dialog — and shifts back on close.

## Fix

Reserve the scrollbar's space unconditionally with `scrollbar-gutter: stable` on `html` (`website/static/css/app.css`). The gutter stays reserved while the lock hides the scrollbar, so the layout width never changes:

- Classic-scrollbar platforms (Windows, Linux with classic bars): scrollbar hides, gutter stays — no shift.
- Overlay-scrollbar platforms (macOS default): the bar never took space, stable reserves what the platform's bar occupies — no shift.

The gutter deliberately does **not** live in the lock rule itself: Chromium reserves a nonzero stable gutter even when its scrollbars are overlay, so a lock-scoped gutter would introduce the very shift on open it is meant to prevent (verified empirically in the e2e environment).

## Test

New e2e regression test in `website/e2e/tests/search.spec.ts` (red before the fix, green after):

- asserts the unconditional `scrollbar-gutter: stable` contract on the root element — headless Linux Chromium draws overlay scrollbars that take no layout space, so the literal pixel shift cannot be reproduced there;
- asserts `documentElement.clientWidth` and the topnav box are identical before and after opening the dialog — the platform-independent invariant, which also catches the lock-scoped wrong variant in this environment.

Full e2e suite passes (30/30); `mdsmith check .` clean (453 files).

https://claude.ai/code/session_01HLQrMdDs24QaWsLVM1kZPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLQrMdDs24QaWsLVM1kZPj)_