### PR TITLE
Plan 103: build target staleness and dependency tracking

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -37,7 +37,7 @@ footer: |
 | 100        | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                                 |
 | 101        | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                              |
 | 102        | ✅     | opus   | [Multi-output `<?build?>` directive](plan/102_build-subcommand.md)                                                                      |
-| 103        | 🔲     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                                                  |
+| 103        | 🔳     | opus   | [Build target staleness and dependency tracking](plan/103_build-staleness-and-deps.md)                                                  |
 | 104        | 🔲     | sonnet | [Build lifecycle hooks (before/after)](plan/104_build-lifecycle-hooks.md)                                                               |
 | 105        | ✅     | sonnet | [No inline HTML rule](plan/105_no-inline-html.md)                                                                                       |
 | 106        | ✅     | sonnet | [Emphasis style rule](plan/106_emphasis-style.md)                                                                                       |

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ up front and opens only the files a task touches. mdsmith's own
 
 **[Build artifacts in sync](docs/features/build-artifacts.md).**
 The `<?build?>` directive declares an artifact and a recipe;
-`mdsmith fix` rebuilds the section body from the recipe output so
-the doc never quotes a stale file. `MDS040` shell-safety-checks
-the recipe without running it.
+`mdsmith fix` rebuilds only the targets whose inputs, recipe, or
+outputs changed, tracking freshness in
+`.mdsmith/build-cache.json`. `MDS040` shell-safety-checks the
+recipe without running it.
 
 **[Markdown as a data source](docs/features/markdown-as-data.md).**
 `mdsmith extract` projects a schema-conformant file to a JSON,

--- a/cmd/mdsmith/buildpass.go
+++ b/cmd/mdsmith/buildpass.go
@@ -21,12 +21,15 @@ import (
 // never runs from pkg/mdsmith, the WASM bindings, the LSP fix path, or
 // the merge driver.
 type buildPassOpts struct {
-	noBuild   bool          // --no-build: skip the build pass entirely
-	buildOnly bool          // --build-only: run only the build pass
-	recipe    string        // --build-recipe: only this recipe's directives
-	dryRun    bool          // --build-dry-run: enumerate targets, run nothing
-	timeout   time.Duration // --build-timeout: per-recipe timeout
-	maxBytes  int64         // file-size cap inherited from the fix run
+	noBuild    bool          // --no-build: skip the build pass entirely
+	buildOnly  bool          // --build-only: run only the build pass
+	recipe     string        // --build-recipe: only this recipe's directives
+	dryRun     bool          // --build-dry-run: enumerate targets, run nothing
+	force      bool          // --build-force: rebuild every target
+	checkStale bool          // --build-check-stale: report stale targets, run nothing
+	noCache    bool          // --build-no-cache: ignore and do not write the cache
+	timeout    time.Duration // --build-timeout: per-recipe timeout
+	maxBytes   int64         // file-size cap inherited from the fix run
 }
 
 // buildTarget pairs a resolved build.Target with the file and line it
@@ -70,6 +73,12 @@ func runBuildPass(
 		_, _ = fmt.Fprintf(w, "mdsmith: %v\n", err)
 	}
 
+	// Overlapping outputs across directives is a hard error: run no recipe.
+	if err := detectOverlap(targets); err != nil {
+		_, _ = fmt.Fprintf(w, "mdsmith: %v\n", err)
+		return 2
+	}
+
 	if len(targets) == 0 {
 		if len(errs) > 0 {
 			return 2
@@ -83,25 +92,203 @@ func runBuildPass(
 		timeout = 30 * time.Second
 	}
 
-	failed := false
+	cache := loadBuildCache(root, opts, w)
+	code := dispatchTargets(builder, targets, cfg, root, opts, cache, timeout, w)
+	if len(errs) > 0 && code == 0 {
+		return 2
+	}
+	return code
+}
+
+// detectOverlap maps the collected targets to OverlapTargets and runs the
+// build package's overlap detector.
+func detectOverlap(targets []buildTarget) error {
+	ot := make([]buildexec.OverlapTarget, 0, len(targets))
 	for _, bt := range targets {
-		label := fmt.Sprintf("%s:%d (%s)", bt.file, bt.line, bt.target.Recipe)
-		if opts.dryRun {
-			_, _ = fmt.Fprintf(w, "build %s: DRY-RUN\n", label)
-			continue
+		ot = append(ot, buildexec.OverlapTarget{
+			File:    bt.file,
+			Line:    bt.line,
+			Outputs: bt.target.Outputs,
+		})
+	}
+	return buildexec.DetectOutputOverlap(ot)
+}
+
+// loadBuildCache loads the build cache unless --build-no-cache is set. A
+// corrupt cache is reported but treated as empty so the run can proceed
+// (every target then rebuilds).
+func loadBuildCache(root string, opts buildPassOpts, w io.Writer) *buildexec.Cache {
+	if opts.noCache {
+		return buildexec.NewCache()
+	}
+	cache, err := buildexec.LoadCache(root)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "mdsmith: %v; treating all targets as stale\n", err)
+		return buildexec.NewCache()
+	}
+	return cache
+}
+
+// stalenessFor builds the StalenessInput for one target, resolving the
+// recipe's default-inputs (param tokens to their relative path values).
+func stalenessFor(bt buildTarget, cfg *config.Config) buildexec.StalenessInput {
+	recipeCfg := cfg.Build.Recipes[bt.target.Recipe]
+	defaults := resolveDefaultInputs(recipeCfg.DefaultInputs, bt.target.Params)
+	return buildexec.StalenessInput{
+		Target:        bt.target,
+		Command:       recipeCfg.Command,
+		DefaultInputs: defaults,
+	}
+}
+
+// resolveDefaultInputs maps each default-inputs entry to a relative path.
+// A {param} token resolves to the param's value (the relative path it
+// supplies); a literal entry passes through unchanged.
+func resolveDefaultInputs(entries []string, params map[string]string) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if len(e) > 2 && e[0] == '{' && e[len(e)-1] == '}' {
+			name := e[1 : len(e)-1]
+			if v, ok := params[name]; ok {
+				out = append(out, v)
+				continue
+			}
 		}
-		if err := runOneTarget(builder, bt, timeout); err != nil {
-			_, _ = fmt.Fprintf(w, "build %s: FAIL: %v\n", label, err)
+		out = append(out, e)
+	}
+	return out
+}
+
+// targetOutcome is the per-target result of one dispatch loop iteration.
+type targetOutcome int
+
+const (
+	outcomeNeutral targetOutcome = iota // reported, no state change (dry-run, skip, fresh-stale-report)
+	outcomeFailed                       // a failure was reported
+	outcomeStale                        // --build-check-stale found this target stale
+	outcomeRebuilt                      // recipe ran and the cache entry was refreshed
+)
+
+// dispatchTargets runs the staleness check, dispatch, and cache refresh
+// loop. It returns the build pass exit code.
+func dispatchTargets(
+	builder buildexec.Builder, targets []buildTarget, cfg *config.Config,
+	root string, opts buildPassOpts, cache *buildexec.Cache,
+	timeout time.Duration, w io.Writer,
+) int {
+	failed := false
+	anyStale := false
+	rebuilt := false
+	for _, bt := range targets {
+		switch dispatchOne(builder, bt, cfg, opts, cache, timeout, w) {
+		case outcomeFailed:
 			failed = true
-			continue
+		case outcomeStale:
+			anyStale = true
+		case outcomeRebuilt:
+			rebuilt = true
+		case outcomeNeutral:
 		}
-		_, _ = fmt.Fprintf(w, "build %s: OK\n", label)
 	}
 
-	if failed || len(errs) > 0 {
+	if opts.checkStale {
+		if anyStale {
+			return 2
+		}
+		return 0
+	}
+	if rebuilt && !opts.noCache {
+		if err := cache.Save(root); err != nil {
+			_, _ = fmt.Fprintf(w, "mdsmith: saving build cache: %v\n", err)
+			return 2
+		}
+	}
+	if failed {
 		return 2
 	}
 	return 0
+}
+
+// dispatchOne handles a single target: staleness verdict, then report or
+// rebuild per the active flags. It returns the outcome the caller folds
+// into the run-level state.
+func dispatchOne(
+	builder buildexec.Builder, bt buildTarget, cfg *config.Config,
+	opts buildPassOpts, cache *buildexec.Cache, timeout time.Duration, w io.Writer,
+) targetOutcome {
+	label := fmt.Sprintf("%s:%d (%s)", bt.file, bt.line, bt.target.Recipe)
+	stin := stalenessFor(bt, cfg)
+
+	verdict, serr := targetVerdict(stin, cache, opts)
+	if serr != nil {
+		_, _ = fmt.Fprintf(w, "build %s: FAIL: %v\n", label, serr)
+		return outcomeFailed
+	}
+
+	if opts.checkStale {
+		if verdict == buildexec.Stale {
+			_, _ = fmt.Fprintf(w, "build %s: STALE\n", label)
+			return outcomeStale
+		}
+		return outcomeNeutral
+	}
+	if opts.dryRun {
+		_, _ = fmt.Fprintf(w, "build %s: %s\n", label, verdict)
+		return outcomeNeutral
+	}
+	if verdict == buildexec.Fresh {
+		_, _ = fmt.Fprintf(w, "build %s: SKIP\n", label)
+		return outcomeNeutral
+	}
+	if err := runOneTarget(builder, bt, timeout); err != nil {
+		_, _ = fmt.Fprintf(w, "build %s: FAIL: %v\n", label, err)
+		return outcomeFailed
+	}
+	if err := refreshCacheEntry(stin, cache, opts); err != nil {
+		_, _ = fmt.Fprintf(w, "build %s: FAIL: %v\n", label, err)
+		return outcomeFailed
+	}
+	_, _ = fmt.Fprintf(w, "build %s: OK\n", label)
+	return outcomeRebuilt
+}
+
+// targetVerdict returns the staleness verdict for one target, honouring
+// --build-force and --build-no-cache (both force a Stale verdict).
+func targetVerdict(
+	stin buildexec.StalenessInput, cache *buildexec.Cache, opts buildPassOpts,
+) (buildexec.Verdict, error) {
+	if opts.force || opts.noCache {
+		// Still resolve inputs so a missing input or empty glob is an error.
+		if _, err := buildexec.CheckStaleness(stin, buildexec.NewCache()); err != nil {
+			return buildexec.Stale, err
+		}
+		return buildexec.Stale, nil
+	}
+	res, err := buildexec.CheckStaleness(stin, cache)
+	if err != nil {
+		return buildexec.Stale, err
+	}
+	return res.Verdict, nil
+}
+
+// refreshCacheEntry records a rebuilt target's cache entry, stamping
+// built-at. With --build-no-cache it is a no-op.
+func refreshCacheEntry(
+	stin buildexec.StalenessInput, cache *buildexec.Cache, opts buildPassOpts,
+) error {
+	if opts.noCache {
+		return nil
+	}
+	entry, err := buildexec.RecordBuild(stin)
+	if err != nil {
+		return err
+	}
+	entry.BuiltAt = time.Now().UTC().Format(time.RFC3339)
+	cache.Put(entry)
+	return nil
 }
 
 // runOneTarget dispatches a single target with a per-recipe timeout.

--- a/cmd/mdsmith/buildpass_unit_test.go
+++ b/cmd/mdsmith/buildpass_unit_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +15,15 @@ import (
 	buildexec "github.com/jeduden/mdsmith/internal/build"
 	"github.com/jeduden/mdsmith/internal/config"
 )
+
+// mockBuilder is a test-only Builder whose Build fn is injected per test.
+type mockBuilder struct {
+	fn func(ctx context.Context, target buildexec.Target) error
+}
+
+func (m *mockBuilder) Build(ctx context.Context, target buildexec.Target) error {
+	return m.fn(ctx, target)
+}
 
 // buildPassCfg returns a minimal *config.Config with the given recipe
 // YAML snippet (already indented under recipes:) for buildpass unit tests.
@@ -465,4 +475,87 @@ func TestRunBuildPass_SaveCacheError(t *testing.T) {
 	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{timeout: time.Second}, &buf)
 	// Recipe ran (OK) but cache.Save failed → exit 2.
 	assert.Equal(t, 2, code)
+}
+
+// TestRunBuildPass_ReadErrorWithSuccessfulBuild_ExitsTwo covers the
+// len(errs) > 0 && code == 0 path: one file fails to read (goes into errs),
+// another file's target builds successfully (code == 0), so the function
+// returns 2 rather than masking the read error.
+func TestRunBuildPass_ReadErrorWithSuccessfulBuild_ExitsTwo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("touch not available on Windows")
+	}
+	root := t.TempDir()
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	var buf strings.Builder
+	// p is a valid file with a target; the nonexistent path becomes an error.
+	// The build succeeds (code == 0), but len(errs) > 0 triggers return 2.
+	code := runBuildPass(cfg, cfgPath, []string{p, "/nonexistent/ghost.md"},
+		buildPassOpts{noCache: true, timeout: time.Second}, &buf)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, buf.String(), "OK")
+	assert.Contains(t, buf.String(), "reading")
+}
+
+// TestRunBuildPass_OverlappingOutputsReturnsTwo covers the detectOverlap error
+// branch: two directives writing the same output file returns exit 2 before
+// any recipe runs.
+func TestRunBuildPass_OverlappingOutputsReturnsTwo(t *testing.T) {
+	root := t.TempDir()
+	cfg := buildPassCfg("    cp:\n      command: cp {inputs} {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+
+	md := "# A\n\n" +
+		"<?build\nrecipe: cp\noutputs:\n  - out.txt\n?>\n[out.txt](out.txt)\n<?/build?>\n\n" +
+		"# B\n\n" +
+		"<?build\nrecipe: cp\noutputs:\n  - out.txt\n?>\n[out.txt](out.txt)\n<?/build?>\n"
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	var buf strings.Builder
+	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{timeout: time.Second}, &buf)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, buf.String(), "overlap")
+}
+
+// TestDispatchOne_RefreshCacheEntryError covers the refreshCacheEntry error
+// path inside dispatchOne. The mock builder creates the declared output and
+// then replaces the input with a directory; when refreshCacheEntry calls
+// RecordBuild it tries to hash the input and fails.
+func TestDispatchOne_RefreshCacheEntryError(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.txt"), []byte("content"), 0o644))
+
+	cfg := buildPassCfg("    cp:\n      command: cp {inputs} {outputs}\n")
+	bt := buildTarget{
+		file: "test.md",
+		line: 1,
+		target: buildexec.Target{
+			Recipe:  "cp",
+			Root:    root,
+			Inputs:  []string{"src.txt"},
+			Outputs: []string{"out.txt"},
+		},
+	}
+
+	builder := &mockBuilder{fn: func(_ context.Context, target buildexec.Target) error {
+		// Create the declared output so RecordBuild's resolveOutputs passes.
+		_ = os.WriteFile(filepath.Join(root, "out.txt"), []byte("result"), 0o644)
+		// Replace the input with a directory so hashFile fails inside RecordBuild.
+		_ = os.Remove(filepath.Join(root, "src.txt"))
+		_ = os.MkdirAll(filepath.Join(root, "src.txt"), 0o755)
+		return nil
+	}}
+
+	cache := buildexec.NewCache()
+	var buf strings.Builder
+	outcome := dispatchOne(builder, bt, cfg, buildPassOpts{}, cache, time.Second, &buf)
+	assert.Equal(t, outcomeFailed, outcome)
+	assert.Contains(t, buf.String(), "FAIL")
 }

--- a/cmd/mdsmith/buildpass_unit_test.go
+++ b/cmd/mdsmith/buildpass_unit_test.go
@@ -79,7 +79,7 @@ func TestRunBuildPass_DryRun(t *testing.T) {
 	var buf strings.Builder
 	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{dryRun: true, timeout: time.Second}, &buf)
 	assert.Equal(t, 0, code)
-	assert.Contains(t, buf.String(), "DRY-RUN")
+	assert.Contains(t, buf.String(), "STALE")
 }
 
 func TestRunBuildPass_NoTargets(t *testing.T) {

--- a/cmd/mdsmith/buildpass_unit_test.go
+++ b/cmd/mdsmith/buildpass_unit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	buildexec "github.com/jeduden/mdsmith/internal/build"
 	"github.com/jeduden/mdsmith/internal/config"
 )
 
@@ -277,4 +278,191 @@ func TestCollectBuildTargets_MalformedDirectiveSkipped(t *testing.T) {
 	targets, errs := collectBuildTargets([]string{p}, root, "", 0)
 	assert.Empty(t, errs)
 	assert.Empty(t, targets, "directive with non-string recipe param must be skipped")
+}
+
+// --- resolveDefaultInputs ---
+
+func TestResolveDefaultInputs_ParamToken_Resolved(t *testing.T) {
+	out := resolveDefaultInputs([]string{"{tape}"}, map[string]string{"tape": "demo.tape"})
+	assert.Equal(t, []string{"demo.tape"}, out)
+}
+
+func TestResolveDefaultInputs_ParamToken_NotInParams_PassesThrough(t *testing.T) {
+	// A {token} whose name is absent from params falls through as a literal.
+	out := resolveDefaultInputs([]string{"{unknown}"}, map[string]string{})
+	assert.Equal(t, []string{"{unknown}"}, out)
+}
+
+func TestResolveDefaultInputs_LiteralEntry(t *testing.T) {
+	out := resolveDefaultInputs([]string{"assets/logo.svg"}, map[string]string{"tape": "demo.tape"})
+	assert.Equal(t, []string{"assets/logo.svg"}, out)
+}
+
+func TestResolveDefaultInputs_Empty(t *testing.T) {
+	assert.Nil(t, resolveDefaultInputs(nil, nil))
+	assert.Nil(t, resolveDefaultInputs([]string{}, nil))
+}
+
+// --- loadBuildCache ---
+
+func TestLoadBuildCache_NoCacheFlag_ReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	var buf strings.Builder
+	c := loadBuildCache(root, buildPassOpts{noCache: true}, &buf)
+	assert.Empty(t, c.Entries)
+	assert.Empty(t, buf.String(), "noCache must not print anything")
+}
+
+func TestLoadBuildCache_CorruptFile_ReturnsEmptyAndWarns(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mdsmith"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".mdsmith", "build-cache.json"), []byte("{bad json"), 0o644))
+	var buf strings.Builder
+	c := loadBuildCache(root, buildPassOpts{}, &buf)
+	assert.Empty(t, c.Entries, "corrupt cache should yield empty cache")
+	assert.Contains(t, buf.String(), "stale")
+}
+
+// --- refreshCacheEntry ---
+
+func TestRefreshCacheEntry_NoCache_IsNoop(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "out.txt"), []byte("x"), 0o644))
+	stin := buildexec.StalenessInput{
+		Target: buildexec.Target{
+			Recipe:  "cp",
+			Root:    root,
+			Inputs:  []string{"src.txt"},
+			Outputs: []string{"out.txt"},
+		},
+		Command: "cp {inputs} {outputs}",
+	}
+	cache := buildexec.NewCache()
+	err := refreshCacheEntry(stin, cache, buildPassOpts{noCache: true})
+	require.NoError(t, err)
+	assert.Empty(t, cache.Entries, "noCache must not write to cache")
+}
+
+// --- targetVerdict with force + error ---
+
+func TestTargetVerdict_ForceAndMissingInput_ReturnsError(t *testing.T) {
+	root := t.TempDir()
+	// No src.txt on disk; --build-force still resolves inputs to catch errors.
+	stin := buildexec.StalenessInput{
+		Target: buildexec.Target{
+			Recipe:  "cp",
+			Root:    root,
+			Inputs:  []string{"absent.txt"},
+			Outputs: []string{"out.txt"},
+		},
+		Command: "cp {inputs} {outputs}",
+	}
+	_, err := targetVerdict(stin, buildexec.NewCache(), buildPassOpts{force: true})
+	require.Error(t, err, "--build-force must still surface missing-input errors")
+}
+
+func TestTargetVerdict_NoCacheAndMissingInput_ReturnsError(t *testing.T) {
+	root := t.TempDir()
+	stin := buildexec.StalenessInput{
+		Target: buildexec.Target{
+			Recipe:  "cp",
+			Root:    root,
+			Inputs:  []string{"absent.txt"},
+			Outputs: []string{"out.txt"},
+		},
+		Command: "cp {inputs} {outputs}",
+	}
+	_, err := targetVerdict(stin, buildexec.NewCache(), buildPassOpts{noCache: true})
+	require.Error(t, err, "--build-no-cache must still surface missing-input errors")
+}
+
+// --- dispatchTargets exit-code paths ---
+
+func TestRunBuildPass_RebuildNoCache_ExitsZero(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("touch not available on Windows")
+	}
+	root := t.TempDir()
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	var buf strings.Builder
+	// --build-no-cache + success: must exit 0, must not write cache.
+	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{noCache: true, timeout: time.Second}, &buf)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, buf.String(), "OK")
+	_, err := os.Stat(filepath.Join(root, ".mdsmith", "build-cache.json"))
+	assert.True(t, os.IsNotExist(err), "cache must not be written when --build-no-cache is set")
+}
+
+func TestRunBuildPass_CheckStale_FreshTarget_ExitsZero(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("touch not available on Windows")
+	}
+	root := t.TempDir()
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	// Run once to build and prime the cache.
+	var buf strings.Builder
+	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{timeout: time.Second}, &buf)
+	require.Equal(t, 0, code)
+
+	// Now check-stale: target is fresh, so exit 0.
+	buf.Reset()
+	code = runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{checkStale: true, timeout: time.Second}, &buf)
+	assert.Equal(t, 0, code)
+	assert.NotContains(t, buf.String(), "STALE")
+}
+
+func TestRunBuildPass_CheckStale_StaleTarget_ExitsTwo(t *testing.T) {
+	root := t.TempDir()
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	// No prior run — target is stale.
+	var buf strings.Builder
+	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{checkStale: true, timeout: time.Second}, &buf)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, buf.String(), "STALE")
+}
+
+func TestRunBuildPass_SaveCacheError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("touch and chmod not reliable on Windows")
+	}
+	root := t.TempDir()
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	// Create .mdsmith dir and make it unwritable so cache.Save fails.
+	mdsmithDir := filepath.Join(root, ".mdsmith")
+	require.NoError(t, os.MkdirAll(mdsmithDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(mdsmithDir, 0o755) })
+
+	var buf strings.Builder
+	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{timeout: time.Second}, &buf)
+	// Recipe ran (OK) but cache.Save failed → exit 2.
+	assert.Equal(t, 2, code)
 }

--- a/cmd/mdsmith/e2e_build_test.go
+++ b/cmd/mdsmith/e2e_build_test.go
@@ -119,7 +119,7 @@ func TestE2E_Build_DryRunRunsNothing(t *testing.T) {
 
 	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-dry-run", "--build-only", "doc.md")
 	assert.Equal(t, 0, code)
-	assert.Contains(t, stderr, "DRY-RUN")
+	assert.Contains(t, stderr, "STALE", "--build-dry-run prints a STALE | FRESH verdict")
 	assert.NoFileExists(t, filepath.Join(dir, "dst.txt"), "--build-dry-run must not run the recipe")
 }
 
@@ -155,6 +155,37 @@ func TestE2E_Build_TimeoutKillsRecipe(t *testing.T) {
 	assert.Contains(t, stderr, "FAIL")
 }
 
+// --- Plan 103: staleness and dependency tracking ---
+
+// fileMTime returns the modification time of root/rel.
+func fileMTime(t *testing.T, root, rel string) (mtime int64) {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(root, rel))
+	require.NoError(t, err)
+	return info.ModTime().UnixNano()
+}
+
+func TestE2E_Build_SecondRunSkipsFresh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp is not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hello"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, stderr1, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1, stderr1)
+	assert.Contains(t, stderr1, "OK")
+
+	// Capture the output's mtime, then run again: it must SKIP and not rewrite.
+	before := fileMTime(t, dir, "dst.txt")
+	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code2, stderr2)
+	assert.Contains(t, stderr2, "SKIP", "a fresh target must SKIP on the second run")
+	assert.NotContains(t, stderr2, ": OK")
+	assert.Equal(t, before, fileMTime(t, dir, "dst.txt"), "fresh target must not be rewritten")
+}
+
 func TestE2E_Build_LintDryRunSkipsBuildPass(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("cp is not available on Windows")
@@ -187,6 +218,232 @@ func TestE2E_Build_LintViolationsKeepNonZeroExit(t *testing.T) {
 	assert.Equal(t, 1, code, "lint violations must keep exit 1: %s", out)
 	assert.Contains(t, out, "OK", "the build pass still runs")
 	assert.FileExists(t, filepath.Join(dir, "dst.txt"))
+}
+
+func TestE2E_Build_RebuildsOnInputContentChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp is not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("v1"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, _, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("v2"), 0o644))
+	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code2, stderr2)
+	assert.Contains(t, stderr2, "OK", "an input content change must trigger a rebuild")
+
+	got, err := os.ReadFile(filepath.Join(dir, "dst.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "v2", string(got))
+}
+
+func TestE2E_Build_MtimeOnlyChangeDoesNotRebuild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp is not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("same"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, _, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1)
+
+	// Rewrite identical content (bumps mtime, content unchanged).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("same"), 0o644))
+	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code2, stderr2)
+	assert.Contains(t, stderr2, "SKIP", "an mtime-only change must not rebuild")
+}
+
+func TestE2E_Build_RecipeCommandChangeRebuilds(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp/install not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("x"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, _, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1)
+
+	// Edit the recipe command; the ActionID changes, so the target rebuilds.
+	cfg := "rules: {}\nbuild:\n  recipes:\n    copy:\n      command: install {inputs} {outputs}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code2, stderr2)
+	assert.Contains(t, stderr2, "OK", "a recipe command change must invalidate the target")
+}
+
+func TestE2E_Build_RebuildsWhenOneOutputDeleted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("touch not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    dup:\n      command: touch {outputs}\n")
+	doc := "# Build\n\n" +
+		"<?build\nrecipe: dup\noutputs:\n  - a.txt\n  - b.txt\n?>\n" +
+		"[a.txt](a.txt)\n[b.txt](b.txt)\n" +
+		"<?/build?>\n"
+	writeFixture(t, dir, "doc.md", doc)
+
+	_, _, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1)
+
+	// Second run: both fresh → SKIP.
+	_, stderr2, _ := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Contains(t, stderr2, "SKIP")
+
+	// Delete one output → rebuild.
+	require.NoError(t, os.Remove(filepath.Join(dir, "b.txt")))
+	_, stderr3, code3 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code3, stderr3)
+	assert.Contains(t, stderr3, "OK", "a deleted output must trigger a rebuild")
+	assert.FileExists(t, filepath.Join(dir, "b.txt"))
+}
+
+func TestE2E_Build_GlobMatchingZeroFilesIsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	doc := "# Build\n\n" +
+		"<?build\nrecipe: copy\ninputs:\n  - \"*.none\"\noutputs:\n  - dst.txt\n?>\n" +
+		"[dst.txt](dst.txt)\n<?/build?>\n"
+	writeFixture(t, dir, "doc.md", doc)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code, "a glob matching zero files is a build error")
+	assert.Contains(t, stderr, "FAIL")
+	assert.NoFileExists(t, filepath.Join(dir, "dst.txt"))
+}
+
+func TestE2E_Build_OverlappingOutputsIsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("touch not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    mk:\n      command: touch {outputs}\n")
+	// Two directives whose outputs overlap by directory prefix.
+	doc := "# Build\n\n" +
+		"<?build\nrecipe: mk\noutputs:\n  - book/\n?>\n[book/](book/)\n<?/build?>\n\n" +
+		"<?build\nrecipe: mk\noutputs:\n  - book/index.html\n?>\n" +
+		"[book/index.html](book/index.html)\n<?/build?>\n"
+	writeFixture(t, dir, "doc.md", doc)
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code, "overlapping outputs is a build error")
+	assert.Contains(t, stderr, "overlap")
+}
+
+func TestE2E_Build_ForceRebuildsFresh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("x"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, _, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1)
+
+	// Fresh now, but --build-force rebuilds anyway.
+	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "--build-force", "doc.md")
+	require.Equal(t, 0, code2, stderr2)
+	assert.Contains(t, stderr2, "OK", "--build-force must rebuild even a fresh target")
+	assert.NotContains(t, stderr2, "SKIP")
+}
+
+func TestE2E_Build_CheckStaleNonZeroThenZero(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("x"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	checkArgs := []string{"fix", "--no-color", "--build-only", "--build-check-stale", "doc.md"}
+
+	// Stale before any build → exit non-zero, no recipe runs.
+	_, stderr1, code1 := runBinaryInDir(t, dir, "", checkArgs...)
+	assert.Equal(t, 2, code1)
+	assert.Contains(t, stderr1, "STALE")
+	assert.NoFileExists(t, filepath.Join(dir, "dst.txt"), "--build-check-stale must not run a recipe")
+
+	// Build it, then check-stale again → exit zero.
+	_, _, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code2)
+	_, _, code3 := runBinaryInDir(t, dir, "", checkArgs...)
+	assert.Equal(t, 0, code3, "--build-check-stale exits zero when all fresh")
+}
+
+func TestE2E_Build_NoCacheRebuildsAndWritesNothing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("x"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "--build-no-cache", "doc.md")
+	require.Equal(t, 0, code, stderr)
+	assert.Contains(t, stderr, "OK")
+	assert.NoFileExists(t, filepath.Join(dir, ".mdsmith", "build-cache.json"),
+		"--build-no-cache must not write a cache file")
+}
+
+func TestE2E_Build_ForceWithCheckStaleIsUsageError(t *testing.T) {
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "", "dst.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--build-force", "--build-check-stale", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "--build-force")
+}
+
+func TestE2E_Build_TamperedOutputRebuilds(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("real"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, _, code1 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code1)
+
+	// Hand-edit the artifact: ActionID unchanged, output hash differs → rebuild.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dst.txt"), []byte("tampered"), 0o644))
+	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code2, stderr2)
+	assert.Contains(t, stderr2, "OK", "a hand-edited artifact must trigger a rebuild")
+	got, err := os.ReadFile(filepath.Join(dir, "dst.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "real", string(got), "rebuild restores the artifact")
+}
+
+func TestE2E_Build_CacheFileSchema(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("x"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, _, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code)
+
+	data, err := os.ReadFile(filepath.Join(dir, ".mdsmith", "build-cache.json"))
+	require.NoError(t, err)
+	s := string(data)
+	assert.Contains(t, s, "\"version\": 1")
+	assert.Contains(t, s, "\"action-id\": \"sha256-")
+	assert.Contains(t, s, "\"built-at\"")
+	assert.Contains(t, s, "\"outputs\"")
+	assert.Contains(t, s, "\"dst.txt\"")
+	assert.Contains(t, s, "\"inputs\"")
+	assert.Contains(t, s, "\"recipe\": \"copy\"")
 }
 
 func TestE2E_Check_RunsNoRecipe(t *testing.T) {

--- a/cmd/mdsmith/fix.go
+++ b/cmd/mdsmith/fix.go
@@ -39,16 +39,59 @@ func runFix(args []string) int {
 	return fixDiscovered(opts)
 }
 
-// register wires the --build-* flag group onto fs. A method on
-// buildPassOpts so parseFixFlags stays under the funlen limit and the
-// flag descriptions sit next to their defaults.
-func (b *buildPassOpts) register(fs *flag.FlagSet) {
+// buildFixFlags holds the flag variables for the --build-* group.
+// Separating them keeps parseFixFlags under the funlen limit and
+// co-locates the build-flag descriptions with their defaults.
+type buildFixFlags struct {
+	noBuild    bool
+	buildOnly  bool
+	dryRun     bool
+	force      bool
+	checkStale bool
+	noCache    bool
+	recipe     string
+	timeout    time.Duration
+}
+
+func (b *buildFixFlags) register(fs *flag.FlagSet) {
 	fs.BoolVar(&b.noBuild, "no-build", false, "Run the lint-fix pass only; skip the build pass")
 	fs.BoolVar(&b.buildOnly, "build-only", false, "Run the build pass only; skip the lint-fix pass")
 	fs.StringVar(&b.recipe, "build-recipe", "", "Only build <?build?> directives whose recipe matches NAME")
-	fs.BoolVar(&b.dryRun, "build-dry-run", false, "Enumerate build targets without running any recipe")
+	fs.BoolVar(&b.dryRun, "build-dry-run", false,
+		"Enumerate build targets with a STALE | FRESH verdict; run no recipe")
+	fs.BoolVar(&b.force, "build-force", false, "Rebuild every target; refresh all cache entries")
+	fs.BoolVar(&b.checkStale, "build-check-stale", false,
+		"Print stale targets and exit non-zero if any are stale; run no recipe")
+	fs.BoolVar(&b.noCache, "build-no-cache", false,
+		"Treat all targets as stale; do not read or write the build cache")
 	fs.DurationVar(&b.timeout, "build-timeout", 30*time.Second, "Per-recipe timeout (e.g. 30s, 2m)")
 }
+
+// conflict returns a non-empty message when the build-flag combination is
+// a usage error, or "" when the flags are compatible.
+func (b buildFixFlags) conflict() string {
+	if b.noBuild && b.buildOnly {
+		return "--no-build and --build-only are mutually exclusive"
+	}
+	if b.force && (b.checkStale || b.noCache) {
+		return "--build-force cannot be combined with --build-check-stale or --build-no-cache"
+	}
+	return ""
+}
+
+func (b buildFixFlags) toPassOpts() buildPassOpts {
+	return buildPassOpts{
+		noBuild:    b.noBuild,
+		buildOnly:  b.buildOnly,
+		recipe:     b.recipe,
+		dryRun:     b.dryRun,
+		force:      b.force,
+		checkStale: b.checkStale,
+		noCache:    b.noCache,
+		timeout:    b.timeout,
+	}
+}
+
 
 // setFixUsage wires the usage message for the fix subcommand onto fs.
 func setFixUsage(fs *flag.FlagSet) {
@@ -74,7 +117,7 @@ func parseFixFlags(args []string) (fixCLIOpts, []string, bool, int) {
 		configPath, format, maxInputSize                                      string
 		noColor, quiet, verbose, noGitignore, followSymlinks, explain, dryRun bool
 	)
-	var bp buildPassOpts
+	var bf buildFixFlags
 
 	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
 	fs.StringVarP(&format, "format", "f", "text", "Output format: text, json")
@@ -90,7 +133,7 @@ func parseFixFlags(args []string) (fixCLIOpts, []string, bool, int) {
 	fs.BoolVar(&dryRun, "dry-run", false,
 		"Preview which files would change without writing; "+
 			"per-file output lists the rules that would fire and their counts")
-	bp.register(fs)
+	bf.register(fs)
 	setFixUsage(fs)
 
 	if err := fs.Parse(args); err != nil {
@@ -103,8 +146,8 @@ func parseFixFlags(args []string) (fixCLIOpts, []string, bool, int) {
 		verbose = false
 	}
 
-	if bp.noBuild && bp.buildOnly {
-		fmt.Fprintf(os.Stderr, "mdsmith: fix: --no-build and --build-only are mutually exclusive\n")
+	if msg := bf.conflict(); msg != "" {
+		fmt.Fprintf(os.Stderr, "mdsmith: fix: %s\n", msg)
 		return fixCLIOpts{}, nil, false, 2
 	}
 
@@ -123,7 +166,7 @@ func parseFixFlags(args []string) (fixCLIOpts, []string, bool, int) {
 		maxInputSize: maxInputSize,
 		explain:      explain,
 		dryRun:       dryRun,
-		build:        bp,
+		build:        bf.toPassOpts(),
 	}, fileArgs, hasStdin, -1
 }
 

--- a/cmd/mdsmith/fix.go
+++ b/cmd/mdsmith/fix.go
@@ -92,7 +92,6 @@ func (b buildFixFlags) toPassOpts() buildPassOpts {
 	}
 }
 
-
 // setFixUsage wires the usage message for the fix subcommand onto fs.
 func setFixUsage(fs *flag.FlagSet) {
 	fs.Usage = func() {

--- a/demo.tape
+++ b/demo.tape
@@ -170,9 +170,19 @@ Sleep 50ms
 Set TypingSpeed 0.005
 Show
 
-Type "# A <?build?> directive runs its recipe on fix"
+Type "# <?build?> directive: recipe is a user-defined shell script"
 Enter
 Sleep 100ms
+Type "cat scripts/render.sh"
+Sleep 100ms
+Enter
+Sleep 300ms
+
+Type "cat .mdsmith.yml"
+Sleep 100ms
+Enter
+Sleep 300ms
+
 Type "mdsmith fix page.md"
 Sleep 100ms
 Enter

--- a/demo/build/.mdsmith.yml
+++ b/demo/build/.mdsmith.yml
@@ -1,4 +1,4 @@
 build:
   recipes:
-    copy:
-      command: cp {inputs} {outputs}
+    render:
+      command: scripts/render.sh {inputs} {outputs}

--- a/demo/build/page.md
+++ b/demo/build/page.md
@@ -1,10 +1,10 @@
 # Build directive demo
 
-The `copy` recipe copies `source.txt` to `artifact.txt` when you run
-`mdsmith fix`.
+The `render` recipe is a user-defined shell script. `mdsmith fix`
+runs it and keeps `artifact.txt` in sync with `source.txt`.
 
 <?build
-recipe: copy
+recipe: render
 inputs:
   - source.txt
 outputs:

--- a/demo/build/scripts/render.sh
+++ b/demo/build/scripts/render.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# User-defined render recipe — count words in the input.
+awk '{c+=NF} END{printf "words: %d\n", c}' "$1" > "$2"

--- a/demo/build/source.txt
+++ b/demo/build/source.txt
@@ -1,1 +1,1 @@
-built by mdsmith fix
+hello from mdsmith fix

--- a/docs/features/build-artifacts.md
+++ b/docs/features/build-artifacts.md
@@ -25,5 +25,26 @@ Recipes are inspected, not trusted. `MDS040` statically checks
 every recipe command for shell-safety at lint time and never
 executes a binary itself.
 
+## Incremental rebuilds
+
+The build pass is incremental. `mdsmith fix` hashes each target's
+recipe spec, input contents, and output set into one ActionID and
+rebuilds only the targets whose ActionID changed or whose outputs
+are missing or hand-edited. A fresh target prints `SKIP`; freshness
+is tracked in `.mdsmith/build-cache.json`. `--build-check-stale`
+turns that into a CI gate, exiting non-zero when any artifact is out
+of date without running a recipe.
+
+The build cache and working directories are machine-local. Add them
+to `.gitignore`. Never ignore the whole `.mdsmith/` folder: its
+`kinds/`, `schemas/`, and `conventions/` subfolders are checked-in
+config.
+
+```text
+.mdsmith/build-cache.json
+.mdsmith/build-logs/
+.mdsmith/build-staging/
+```
+
 See the [build directive guide](../guides/directives/build.md)
 for recipe declaration and the body-template syntax.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -123,9 +123,10 @@ up front and opens only the files a task touches. mdsmith's own
 
 **[Build artifacts in sync](build-artifacts.md).**
 The `<?build?>` directive declares an artifact and a recipe;
-`mdsmith fix` rebuilds the section body from the recipe output so
-the doc never quotes a stale file. `MDS040` shell-safety-checks
-the recipe without running it.
+`mdsmith fix` rebuilds only the targets whose inputs, recipe, or
+outputs changed, tracking freshness in
+`.mdsmith/build-cache.json`. `MDS040` shell-safety-checks the
+recipe without running it.
 
 **[Markdown as a data source](markdown-as-data.md).**
 `mdsmith extract` projects a schema-conformant file to a JSON,

--- a/docs/guides/directives/build.md
+++ b/docs/guides/directives/build.md
@@ -117,11 +117,14 @@ list inside a token fragment has no well-defined meaning.
 ## Running the build
 
 `mdsmith fix` runs a build pass after the lint-fix pass. It collects
-every `<?build?>` directive across the files it processed, dispatches
-each to its recipe, and prints one `OK` or `FAIL` line per target:
+every `<?build?>` directive across the files it processed, decides which
+targets are stale (see [Staleness and the build cache](#staleness-and-the-build-cache)),
+rebuilds only those, and prints one `OK`, `SKIP`, or `FAIL` line per
+target:
 
 ```text
 build docs/architecture.md:12 (render): OK
+build docs/guide.md:8 (render): SKIP
 build docs/overview.md:30 (pandoc): FAIL: recipe "pandoc" failed: exit status 1
 ```
 
@@ -151,18 +154,129 @@ matcher. A resolved input that escapes the project root (for example
 through a symlink), or one glob that matches more than 10 000 files,
 is a build error.
 
+Two directives may not declare overlapping outputs. An exact path
+collision (`a.txt` and `a.txt`) or a directory-prefix collision (`book/`
+and `book/index.html`) is a build error that names both source locations
+and runs neither recipe, so a build never races two writers to the same
+path.
+
 ### `mdsmith fix` build flags
 
-| Flag                  | Behavior                                        |
-| --------------------- | ----------------------------------------------- |
-| (none)                | Lint-fix pass, then build pass                  |
-| `--no-build`          | Lint-fix pass only                              |
-| `--build-only`        | Build pass only                                 |
-| `--build-recipe NAME` | Build only directives whose `recipe:` is `NAME` |
-| `--build-dry-run`     | Enumerate targets; run no recipe                |
-| `--build-timeout DUR` | Per-recipe timeout (default `30s`)              |
+| Flag                  | Behavior                                                           |
+| --------------------- | ------------------------------------------------------------------ |
+| (none)                | Lint-fix pass, then build only stale targets                       |
+| `--no-build`          | Lint-fix pass only                                                 |
+| `--build-only`        | Build pass only                                                    |
+| `--build-recipe NAME` | Build only directives whose `recipe:` is `NAME`                    |
+| `--build-dry-run`     | Print each target's `STALE` or `FRESH` verdict; run no recipe      |
+| `--build-force`       | Rebuild every target; refresh all cache entries                    |
+| `--build-check-stale` | Print stale targets, exit non-zero if any are stale; run no recipe |
+| `--build-no-cache`    | Treat all targets as stale; do not read or write the cache         |
+| `--build-timeout DUR` | Per-recipe timeout (default `30s`)                                 |
 
 `--no-build` and `--build-only` are mutually exclusive.
+`--build-force` cannot be combined with `--build-check-stale` or
+`--build-no-cache`.
+
+`--build-check-stale` makes artifact freshness a CI signal: it runs no
+recipe and exits non-zero when any declared output is out of date, so a
+build step can fail a pull request that forgot to regenerate.
+
+## Staleness and the build cache
+
+The build pass is incremental. By default `mdsmith fix` rebuilds only the
+targets whose recipe spec, inputs, or outputs changed; a fresh target
+prints `SKIP` and its recipe never runs. Three states appear in the
+per-target summary:
+
+| State  | Meaning                                          |
+| ------ | ------------------------------------------------ |
+| `OK`   | The target was stale and its recipe rebuilt it   |
+| `SKIP` | The target was fresh; its recipe was skipped     |
+| `FAIL` | The recipe failed, or an input could not resolve |
+
+### How freshness is decided
+
+For each target mdsmith computes one ActionID: a sha256 over the recipe
+`command`, the directive's params, the sorted relative input paths, the
+sha256 of each input's content, the sorted relative output paths, and the
+cache schema version. Every field is length-framed, so an input path
+containing a NUL byte or a sentinel character can never collide with a
+different input set.
+
+A target is **fresh** only when all of the following hold:
+
+1. Every declared `inputs:` entry resolves (a missing non-glob input is a
+   build error; a glob matching zero files is a build error).
+2. Every declared output exists on disk.
+3. The cached ActionID for the target's output set equals the freshly
+   computed ActionID.
+4. Each output's content hash equals the hash recorded in the cache —
+   so hand-editing or externally regenerating an artifact triggers a
+   rebuild on the next `fix`.
+
+Otherwise the target is stale and its recipe runs. Content hashing, not
+mtime, decides freshness: a `git checkout` rarely preserves mtimes, but
+file contents are stable.
+
+### The cache file
+
+mdsmith stores build state at `.mdsmith/build-cache.json`. It carries a
+schema `version` and one entry per target:
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "outputs": [{"path": "assets/diagram.png", "hash": "sha256-…"}],
+      "inputs": ["diagram.svg"],
+      "action-id": "sha256-…",
+      "recipe": "render",
+      "built-at": "2026-06-11T12:00:00Z"
+    }
+  ]
+}
+```
+
+All paths are stored relative to the project root, so the cache is stable
+across clone locations. Cache writes are atomic — a temp file plus a
+rename — so a mid-build crash leaves the previous cache readable. A
+target is keyed by its sorted set of output paths; the `action-id`,
+`recipe`, and `built-at` fields are advisory metadata.
+
+The build cache and the build working directories are machine-local
+state. Ignore them in Git, but never ignore the whole `.mdsmith/` folder
+— its `kinds/`, `schemas/`, and `conventions/` subfolders are
+checked-in config:
+
+```text
+.mdsmith/build-cache.json
+.mdsmith/build-logs/
+.mdsmith/build-staging/
+```
+
+### Recipe default inputs
+
+A recipe may declare implicit inputs in `default-inputs`. Each entry is a
+literal relative path or a `{param}` token naming one of the recipe's
+declared params:
+
+```yaml
+build:
+  recipes:
+    vhs:
+      command: "vhs {tape}"
+      params:
+        required: [tape]
+      default-inputs: ["{tape}"]
+```
+
+A directive supplying `tape: demo.tape` then has its effective input set
+computed as `{ demo.tape } ∪` the directive's own `inputs:`, so authors
+never restate the recipe's own source file. The token expands to the
+root-joined absolute path at exec time, but the value folded into the
+ActionID is always the relative path the param supplies (`demo.tape`).
 
 ### Markdown as data
 

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -25,6 +25,12 @@ import (
 	buildrule "github.com/jeduden/mdsmith/internal/rules/build"
 )
 
+// mkdirTempFn is the os.MkdirTemp implementation; tests may replace it.
+var mkdirTempFn = os.MkdirTemp
+
+// builderGlobCapFn is the CheckGlobMatchCap implementation; tests may replace it.
+var builderGlobCapFn = buildrule.CheckGlobMatchCap
+
 // RecipeSpec is the resolved command and tokenized argv for one
 // user-declared recipe. Tokenization happens once at construction so a
 // param value containing whitespace can never re-split.
@@ -87,7 +93,7 @@ func (b *CustomBuilder) Build(ctx context.Context, target Target) error {
 		return err
 	}
 
-	stageDir, err := os.MkdirTemp("", "mdsmith-build-")
+	stageDir, err := mkdirTempFn("", "mdsmith-build-")
 	if err != nil {
 		return fmt.Errorf("creating staging dir: %w", err)
 	}
@@ -136,7 +142,7 @@ func (b *CustomBuilder) resolveInputs(target Target) ([]string, error) {
 			if err != nil {
 				return nil, fmt.Errorf("inputs glob %q: %w", entry, err)
 			}
-			if err := buildrule.CheckGlobMatchCap(len(matches)); err != nil {
+			if err := builderGlobCapFn(len(matches)); err != nil {
 				return nil, err
 			}
 			for _, m := range matches {

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -472,3 +472,17 @@ func TestSubstituteParams_EmbeddedListPlaceholder(t *testing.T) {
 	// commands; here we verify the substituteParams passthrough.
 	assert.Equal(t, "prefix-{inputs}-suffix", substituteParams("prefix-{inputs}-suffix", nil))
 }
+
+func TestCommitOutputs_StatError(t *testing.T) {
+	root := t.TempDir()
+	// Create a regular file at the same path as the expected staging dir so
+	// os.Stat on "notadir/out0" fails with ENOTDIR — a non-ENOENT error that
+	// hits the "staging output" error branch rather than the "did not produce"
+	// branch.
+	notadir := filepath.Join(root, "notadir")
+	require.NoError(t, os.WriteFile(notadir, []byte("x"), 0o644))
+
+	err := commitOutputs(root, []string{"out.txt"}, []string{filepath.Join(notadir, "out0")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "staging output")
+}

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -240,12 +241,21 @@ func TestBuild_EmptyCommandErrors(t *testing.T) {
 }
 
 func TestBuild_GlobCapExceeded(t *testing.T) {
-	// A glob cap breach is a build error. We simulate by setting a tiny
-	// cap is not possible (const), so instead verify the helper wiring by
-	// matching a directory with many files would be too slow; instead we
-	// confirm a normal small glob does not error (covered elsewhere) and
-	// trust CheckGlobMatchCap unit tests in the rules/build package.
-	t.Skip("cap breach exercised via rules/build unit tests; 10k files too slow here")
+	old := builderGlobCapFn
+	builderGlobCapFn = func(_ int) error { return errors.New("cap exceeded") }
+	defer func() { builderGlobCapFn = old }()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0o644))
+	b := NewCustomBuilder(map[string]RecipeSpec{"r": recipeCmd("echo hi")})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "r",
+		Root:    root,
+		Inputs:  []string{"*.txt"},
+		Outputs: []string{"out.txt"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cap exceeded")
 }
 
 func TestArgvExpansion_ListsExpandPerEntry(t *testing.T) {
@@ -471,6 +481,22 @@ func TestSubstituteParams_EmbeddedListPlaceholder(t *testing.T) {
 	// token) must pass through literally — the MDS040 validator rejects such
 	// commands; here we verify the substituteParams passthrough.
 	assert.Equal(t, "prefix-{inputs}-suffix", substituteParams("prefix-{inputs}-suffix", nil))
+}
+
+func TestBuild_MkdirTempError(t *testing.T) {
+	old := mkdirTempFn
+	mkdirTempFn = func(_, _ string) (string, error) { return "", errors.New("no temp dir") }
+	defer func() { mkdirTempFn = old }()
+
+	root := t.TempDir()
+	b := NewCustomBuilder(map[string]RecipeSpec{"r": recipeCmd("echo hi")})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "r",
+		Root:    root,
+		Outputs: []string{"out.txt"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "staging dir")
 }
 
 func TestCommitOutputs_StatError(t *testing.T) {

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -160,7 +160,7 @@ func (c *Cache) Save(root string) error {
 // can inject a failing io.WriteCloser without needing file-system tricks.
 func writeTempFile(wc io.WriteCloser, data []byte) error {
 	if _, err := wc.Write(data); err != nil {
-		wc.Close()
+		_ = wc.Close()
 		return fmt.Errorf("writing temp cache file: %w", err)
 	}
 	if err := wc.Close(); err != nil {

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -1,0 +1,160 @@
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CacheVersion is the schema version stored in the cache file and folded
+// into every ActionID. Bumping it forces a single rebuild of every
+// target after an upgrade.
+const CacheVersion = 1
+
+// cacheRelPath is the project-root-relative location of the build cache.
+const cacheRelPath = ".mdsmith/build-cache.json"
+
+// OutputHash pairs a declared output path with the sha256 of its content
+// at build time. The path is project-root-relative and slash-normalized.
+type OutputHash struct {
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+// CacheEntry is one target's record in the build cache. A target is
+// identified by its sorted set of output paths; ActionID decides
+// freshness.
+type CacheEntry struct {
+	Outputs  []OutputHash `json:"outputs"`
+	Inputs   []string     `json:"inputs"`
+	ActionID string       `json:"action-id"`
+	Recipe   string       `json:"recipe"`
+	BuiltAt  string       `json:"built-at"`
+}
+
+// Cache is the in-memory form of .mdsmith/build-cache.json.
+type Cache struct {
+	Version int          `json:"version"`
+	Entries []CacheEntry `json:"entries"`
+}
+
+// NewCache returns an empty cache stamped with the current schema
+// version.
+func NewCache() *Cache {
+	return &Cache{Version: CacheVersion}
+}
+
+// LoadCache reads .mdsmith/build-cache.json under root. A missing file
+// yields an empty cache; a present but malformed file is an error so a
+// poisoned cache surfaces loudly rather than silently rebuilding.
+func LoadCache(root string) (*Cache, error) {
+	path := filepath.Join(root, filepath.FromSlash(cacheRelPath))
+	data, err := os.ReadFile(path) //nolint:gosec // path is the fixed in-root cache file
+	if err != nil {
+		if os.IsNotExist(err) {
+			return NewCache(), nil
+		}
+		return nil, fmt.Errorf("reading build cache: %w", err)
+	}
+	var c Cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parsing build cache: %w", err)
+	}
+	if c.Version == 0 {
+		c.Version = CacheVersion
+	}
+	return &c, nil
+}
+
+// outputSetKey joins a sorted set of output paths into a single
+// length-framed key so two different sets cannot collide.
+func outputSetKey(paths []string) string {
+	sorted := append([]string(nil), paths...)
+	sort.Strings(sorted)
+	var b strings.Builder
+	for _, p := range sorted {
+		fmt.Fprintf(&b, "%d:%s|", len(p), p)
+	}
+	return b.String()
+}
+
+// Lookup returns the entry whose output-path set equals the given set
+// (order-independent), and whether one was found.
+func (c *Cache) Lookup(outputPaths []string) (CacheEntry, bool) {
+	want := outputSetKey(outputPaths)
+	for _, e := range c.Entries {
+		if outputSetKey(e.outputPaths()) == want {
+			return e, true
+		}
+	}
+	return CacheEntry{}, false
+}
+
+// outputPaths returns just the path field of each output hash.
+func (e CacheEntry) outputPaths() []string {
+	paths := make([]string, len(e.Outputs))
+	for i, o := range e.Outputs {
+		paths[i] = o.Path
+	}
+	return paths
+}
+
+// Put inserts or replaces the entry identified by its output-path set.
+func (c *Cache) Put(entry CacheEntry) {
+	key := outputSetKey(entry.outputPaths())
+	for i, e := range c.Entries {
+		if outputSetKey(e.outputPaths()) == key {
+			c.Entries[i] = entry
+			return
+		}
+	}
+	c.Entries = append(c.Entries, entry)
+}
+
+// Save writes the cache to .mdsmith/build-cache.json under root via a
+// temp file and atomic rename, so a mid-build crash leaves the previous
+// cache readable. Entries are sorted by output-set key for stable diffs.
+func (c *Cache) Save(root string) error {
+	if c.Version == 0 {
+		c.Version = CacheVersion
+	}
+	sort.SliceStable(c.Entries, func(i, j int) bool {
+		return outputSetKey(c.Entries[i].outputPaths()) <
+			outputSetKey(c.Entries[j].outputPaths())
+	})
+
+	dir := filepath.Join(root, ".mdsmith")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating .mdsmith dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding build cache: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(dir, "build-cache-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp cache file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup on the failure path
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp cache file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp cache file: %w", err)
+	}
+
+	final := filepath.Join(dir, "build-cache.json")
+	if err := os.Rename(tmpName, final); err != nil {
+		return fmt.Errorf("committing build cache: %w", err)
+	}
+	return nil
+}

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -132,10 +132,7 @@ func (c *Cache) Save(root string) error {
 		return fmt.Errorf("creating .mdsmith dir: %w", err)
 	}
 
-	data, err := json.MarshalIndent(c, "", "  ")
-	if err != nil {
-		return fmt.Errorf("encoding build cache: %w", err)
-	}
+	data, _ := json.MarshalIndent(c, "", "  ")
 	data = append(data, '\n')
 
 	tmp, err := os.CreateTemp(dir, "build-cache-*.json.tmp")
@@ -145,7 +142,7 @@ func (c *Cache) Save(root string) error {
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup on the failure path
 
-	if err := writeTempFile(tmp, data); err != nil {
+	if err := writeTempFileVar(tmp, data); err != nil {
 		return err
 	}
 
@@ -155,6 +152,10 @@ func (c *Cache) Save(root string) error {
 	}
 	return nil
 }
+
+// writeTempFileVar is the writeTempFile implementation used by Save; tests may
+// replace it to inject write failures without file-system tricks.
+var writeTempFileVar = writeTempFile
 
 // writeTempFile writes data to wc and closes it. Extracted so tests
 // can inject a failing io.WriteCloser without needing file-system tricks.

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -3,6 +3,7 @@ package build
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -144,17 +145,26 @@ func (c *Cache) Save(root string) error {
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup on the failure path
 
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("writing temp cache file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("closing temp cache file: %w", err)
+	if err := writeTempFile(tmp, data); err != nil {
+		return err
 	}
 
 	final := filepath.Join(dir, "build-cache.json")
 	if err := os.Rename(tmpName, final); err != nil {
 		return fmt.Errorf("committing build cache: %w", err)
+	}
+	return nil
+}
+
+// writeTempFile writes data to wc and closes it. Extracted so tests
+// can inject a failing io.WriteCloser without needing file-system tricks.
+func writeTempFile(wc io.WriteCloser, data []byte) error {
+	if _, err := wc.Write(data); err != nil {
+		wc.Close()
+		return fmt.Errorf("writing temp cache file: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("closing temp cache file: %w", err)
 	}
 	return nil
 }

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -1,0 +1,98 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCache_MissingFileReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	c, err := LoadCache(root)
+	require.NoError(t, err)
+	assert.Equal(t, CacheVersion, c.Version)
+	assert.Empty(t, c.Entries)
+}
+
+func TestCache_SaveLoadRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	c := NewCache()
+	c.Put(CacheEntry{
+		Outputs:  []OutputHash{{Path: "out.txt", Hash: "sha256-abc"}},
+		Inputs:   []string{"src.txt"},
+		ActionID: "sha256-deadbeef",
+		Recipe:   "copy",
+		BuiltAt:  "2026-06-11T00:00:00Z",
+	})
+	require.NoError(t, c.Save(root))
+
+	got, err := LoadCache(root)
+	require.NoError(t, err)
+	require.Len(t, got.Entries, 1)
+	e := got.Entries[0]
+	assert.Equal(t, "sha256-deadbeef", e.ActionID)
+	assert.Equal(t, "copy", e.Recipe)
+	require.Len(t, e.Outputs, 1)
+	assert.Equal(t, "out.txt", e.Outputs[0].Path)
+	assert.Equal(t, "sha256-abc", e.Outputs[0].Hash)
+
+	// File lives at .mdsmith/build-cache.json.
+	_, statErr := os.Stat(filepath.Join(root, ".mdsmith", "build-cache.json"))
+	assert.NoError(t, statErr)
+}
+
+func TestCache_LookupBySortedOutputSet(t *testing.T) {
+	c := NewCache()
+	c.Put(CacheEntry{
+		Outputs:  []OutputHash{{Path: "b.txt", Hash: "h2"}, {Path: "a.txt", Hash: "h1"}},
+		ActionID: "sha256-id",
+	})
+	// Lookup with a differently-ordered output set must still match.
+	e, ok := c.Lookup([]string{"a.txt", "b.txt"})
+	require.True(t, ok)
+	assert.Equal(t, "sha256-id", e.ActionID)
+
+	_, ok = c.Lookup([]string{"a.txt"})
+	assert.False(t, ok)
+}
+
+func TestCache_PutReplacesByOutputSet(t *testing.T) {
+	c := NewCache()
+	c.Put(CacheEntry{
+		Outputs:  []OutputHash{{Path: "a.txt", Hash: "h1"}},
+		ActionID: "sha256-old",
+	})
+	c.Put(CacheEntry{
+		Outputs:  []OutputHash{{Path: "a.txt", Hash: "h2"}},
+		ActionID: "sha256-new",
+	})
+	assert.Len(t, c.Entries, 1)
+	e, ok := c.Lookup([]string{"a.txt"})
+	require.True(t, ok)
+	assert.Equal(t, "sha256-new", e.ActionID)
+}
+
+func TestLoadCache_CorruptFileReturnsError(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mdsmith"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".mdsmith", "build-cache.json"), []byte("{not json"), 0o644))
+	_, err := LoadCache(root)
+	require.Error(t, err)
+}
+
+func TestCache_SaveIsAtomic_NoTempLeftBehind(t *testing.T) {
+	root := t.TempDir()
+	c := NewCache()
+	c.Put(CacheEntry{Outputs: []OutputHash{{Path: "a", Hash: "h"}}, ActionID: "id"})
+	require.NoError(t, c.Save(root))
+
+	entries, err := os.ReadDir(filepath.Join(root, ".mdsmith"))
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.Equal(t, "build-cache.json", e.Name(), "no temp file should remain")
+	}
+}

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,6 +110,17 @@ func TestLoadCache_VersionZeroNormalized(t *testing.T) {
 	assert.Equal(t, CacheVersion, c.Version)
 }
 
+func TestLoadCache_DotMdsmithIsFile(t *testing.T) {
+	root := t.TempDir()
+	// .mdsmith as a regular file makes ReadFile on .mdsmith/build-cache.json
+	// fail with ENOTDIR — a non-ENOENT error that hits the "reading build
+	// cache" error path regardless of whether the process is root.
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith"), []byte("file"), 0o644))
+	_, err := LoadCache(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading build cache")
+}
+
 func TestLoadCache_UnreadableFile(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("root ignores file permissions")
@@ -138,4 +150,62 @@ func TestCache_Save_UnwritableDir(t *testing.T) {
 	c := NewCache()
 	err := c.Save(root)
 	require.Error(t, err)
+}
+
+func TestCache_Save_MkdirAllError(t *testing.T) {
+	root := t.TempDir()
+	// .mdsmith as a regular file: MkdirAll(".mdsmith") fails with ENOTDIR
+	// regardless of whether the process runs as root.
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith"), []byte("file"), 0o644))
+	c := NewCache()
+	err := c.Save(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating .mdsmith dir")
+}
+
+func TestCache_Save_RenameError(t *testing.T) {
+	root := t.TempDir()
+	mdsmithDir := filepath.Join(root, ".mdsmith")
+	require.NoError(t, os.MkdirAll(mdsmithDir, 0o755))
+	// build-cache.json as a directory: os.Rename(tmpFile → dir) fails with
+	// EISDIR on POSIX, which hits the "committing build cache" error path.
+	require.NoError(t, os.MkdirAll(filepath.Join(mdsmithDir, "build-cache.json"), 0o755))
+	c := NewCache()
+	err := c.Save(root)
+	require.Error(t, err)
+}
+
+func TestCache_Save_VersionZeroNormalized(t *testing.T) {
+	// Ensure the c.Version == 0 branch in Save normalises to CacheVersion.
+	root := t.TempDir()
+	c := &Cache{Version: 0}
+	c.Put(CacheEntry{Outputs: []OutputHash{{Path: "a.txt", Hash: "h"}}, ActionID: "id"})
+	require.NoError(t, c.Save(root))
+	got, err := LoadCache(root)
+	require.NoError(t, err)
+	assert.Equal(t, CacheVersion, got.Version)
+}
+
+// --- writeTempFile error paths ---
+
+type writeFailCloser struct{}
+
+func (w *writeFailCloser) Write([]byte) (int, error) { return 0, errors.New("disk full") }
+func (w *writeFailCloser) Close() error              { return nil }
+
+type closeFailWriter struct{}
+
+func (w *closeFailWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *closeFailWriter) Close() error                { return errors.New("flush failed") }
+
+func TestWriteTempFile_WriteError(t *testing.T) {
+	err := writeTempFile(&writeFailCloser{}, []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing temp cache file")
+}
+
+func TestWriteTempFile_CloseError(t *testing.T) {
+	err := writeTempFile(&closeFailWriter{}, []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "closing temp cache file")
 }

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -208,4 +209,31 @@ func TestWriteTempFile_CloseError(t *testing.T) {
 	err := writeTempFile(&closeFailWriter{}, []byte("data"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "closing temp cache file")
+}
+
+func TestCache_Save_SortOrder(t *testing.T) {
+	root := t.TempDir()
+	c := NewCache()
+	c.Put(CacheEntry{Outputs: []OutputHash{{Path: "z.txt", Hash: "h1"}}, ActionID: "id-z"})
+	c.Put(CacheEntry{Outputs: []OutputHash{{Path: "a.txt", Hash: "h2"}}, ActionID: "id-a"})
+	require.NoError(t, c.Save(root))
+
+	got, err := LoadCache(root)
+	require.NoError(t, err)
+	require.Len(t, got.Entries, 2)
+	assert.Equal(t, "a.txt", got.Entries[0].Outputs[0].Path)
+	assert.Equal(t, "z.txt", got.Entries[1].Outputs[0].Path)
+}
+
+func TestCache_Save_WriteTempFileError(t *testing.T) {
+	old := writeTempFileVar
+	writeTempFileVar = func(_ io.WriteCloser, _ []byte) error {
+		return errors.New("injected write error")
+	}
+	defer func() { writeTempFileVar = old }()
+
+	root := t.TempDir()
+	c := NewCache()
+	err := c.Save(root)
+	require.Error(t, err)
 }

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -96,3 +96,46 @@ func TestCache_SaveIsAtomic_NoTempLeftBehind(t *testing.T) {
 		assert.Equal(t, "build-cache.json", e.Name(), "no temp file should remain")
 	}
 }
+
+func TestLoadCache_VersionZeroNormalized(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mdsmith"), 0o755))
+	// Write a cache JSON with version: 0 — should be normalised to CacheVersion on load.
+	raw := `{"version":0,"entries":[]}`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".mdsmith", "build-cache.json"), []byte(raw), 0o644))
+	c, err := LoadCache(root)
+	require.NoError(t, err)
+	assert.Equal(t, CacheVersion, c.Version)
+}
+
+func TestLoadCache_UnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores file permissions")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, ".mdsmith")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	p := filepath.Join(dir, "build-cache.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{"version":1}`), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(p, 0o644) })
+
+	_, err := LoadCache(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading build cache")
+}
+
+func TestCache_Save_UnwritableDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, ".mdsmith")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	c := NewCache()
+	err := c.Save(root)
+	require.Error(t, err)
+}

--- a/internal/build/staleness.go
+++ b/internal/build/staleness.go
@@ -52,16 +52,6 @@ type StalenessResult struct {
 	Inputs  []string
 }
 
-// effectiveInputs returns the union of the directive inputs and the
-// recipe default-inputs as one slice (default-inputs stay literal; they
-// are not glob-expanded).
-func (in StalenessInput) effectiveInputs() []string {
-	out := make([]string, 0, len(in.Target.Inputs)+len(in.DefaultInputs))
-	out = append(out, in.Target.Inputs...)
-	out = append(out, in.DefaultInputs...)
-	return out
-}
-
 // resolveInputs resolves the effective input set against the project
 // root. Directive entries may be globs; default-inputs stay literal. The
 // result is sorted, de-duplicated, project-root-relative paths. A

--- a/internal/build/staleness.go
+++ b/internal/build/staleness.go
@@ -17,6 +17,9 @@ import (
 	buildrule "github.com/jeduden/mdsmith/internal/rules/build"
 )
 
+// globCapFn is the CheckGlobMatchCap implementation; tests may replace it.
+var globCapFn = buildrule.CheckGlobMatchCap
+
 // Verdict is the staleness result for one target.
 type Verdict int
 
@@ -79,7 +82,7 @@ func resolveInputs(in StalenessInput) ([]string, error) {
 			if len(matches) == 0 {
 				return nil, fmt.Errorf("inputs glob %q matched no files", entry)
 			}
-			if err := buildrule.CheckGlobMatchCap(len(matches)); err != nil {
+			if err := globCapFn(len(matches)); err != nil {
 				return nil, err
 			}
 			for _, m := range matches {
@@ -170,21 +173,9 @@ func canonicalPaths(paths []string) string {
 	return b.String()
 }
 
-// ComputeActionID computes the sha256 ActionID over the recipe command,
-// canonical params, sorted relative inputs, each input's content hash,
-// sorted relative outputs, and the cache version. Every field is framed
-// with an outer 8-byte big-endian length; nested keys, values, and paths
-// are themselves framed. Returns "sha256-<64 lowercase hex>".
-func ComputeActionID(in StalenessInput) (string, error) {
-	inputs, err := resolveInputs(in)
-	if err != nil {
-		return "", err
-	}
-	outputs, err := resolveOutputs(in)
-	if err != nil {
-		return "", err
-	}
-
+// computeActionIDFromResolved hashes the ActionID from pre-resolved inputs and
+// outputs, so both ComputeActionID and RecordBuild can resolve paths once.
+func computeActionIDFromResolved(in StalenessInput, inputs, outputs []string) (string, error) {
 	h := sha256.New()
 	frame(h, []byte(in.Command))
 	frame(h, []byte(canonicalParams(in.Target.Params)))
@@ -208,6 +199,23 @@ func ComputeActionID(in StalenessInput) (string, error) {
 	frame(h, verBuf[:])
 
 	return "sha256-" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// ComputeActionID computes the sha256 ActionID over the recipe command,
+// canonical params, sorted relative inputs, each input's content hash,
+// sorted relative outputs, and the cache version. Every field is framed
+// with an outer 8-byte big-endian length; nested keys, values, and paths
+// are themselves framed. Returns "sha256-<64 lowercase hex>".
+func ComputeActionID(in StalenessInput) (string, error) {
+	inputs, err := resolveInputs(in)
+	if err != nil {
+		return "", err
+	}
+	outputs, err := resolveOutputs(in)
+	if err != nil {
+		return "", err
+	}
+	return computeActionIDFromResolved(in, inputs, outputs)
 }
 
 // hashFile returns the lowercase-hex sha256 of a file's content.
@@ -279,15 +287,15 @@ func CheckStaleness(in StalenessInput, cache *Cache) (StalenessResult, error) {
 // from disk. Call after a successful Build. built-at is left empty; the
 // caller stamps it.
 func RecordBuild(in StalenessInput) (CacheEntry, error) {
-	actionID, err := ComputeActionID(in)
-	if err != nil {
-		return CacheEntry{}, err
-	}
 	inputs, err := resolveInputs(in)
 	if err != nil {
 		return CacheEntry{}, err
 	}
 	outputs, err := resolveOutputs(in)
+	if err != nil {
+		return CacheEntry{}, err
+	}
+	actionID, err := computeActionIDFromResolved(in, inputs, outputs)
 	if err != nil {
 		return CacheEntry{}, err
 	}

--- a/internal/build/staleness.go
+++ b/internal/build/staleness.go
@@ -1,0 +1,382 @@
+package build
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+
+	buildrule "github.com/jeduden/mdsmith/internal/rules/build"
+)
+
+// Verdict is the staleness result for one target.
+type Verdict int
+
+const (
+	// Fresh means the cached ActionID matches and every output exists with
+	// the recorded content hash; the recipe is skipped.
+	Fresh Verdict = iota
+	// Stale means the target must be rebuilt.
+	Stale
+)
+
+func (v Verdict) String() string {
+	if v == Fresh {
+		return "FRESH"
+	}
+	return "STALE"
+}
+
+// StalenessInput carries everything the staleness check needs for one
+// target: the resolved Target plus the recipe's command string and the
+// recipe's default-inputs already expanded to project-root-relative
+// paths (param tokens resolved to the relative path the param supplies).
+type StalenessInput struct {
+	Target        Target
+	Command       string
+	DefaultInputs []string
+}
+
+// StalenessResult is the verdict plus the resolved relative input set,
+// returned so the caller can report it.
+type StalenessResult struct {
+	Verdict Verdict
+	Inputs  []string
+}
+
+// effectiveInputs returns the union of the directive inputs and the
+// recipe default-inputs as one slice (default-inputs stay literal; they
+// are not glob-expanded).
+func (in StalenessInput) effectiveInputs() []string {
+	out := make([]string, 0, len(in.Target.Inputs)+len(in.DefaultInputs))
+	out = append(out, in.Target.Inputs...)
+	out = append(out, in.DefaultInputs...)
+	return out
+}
+
+// resolveInputs resolves the effective input set against the project
+// root. Directive entries may be globs; default-inputs stay literal. The
+// result is sorted, de-duplicated, project-root-relative paths. A
+// non-glob entry that does not exist, or a glob matching zero files, is
+// an error.
+func resolveInputs(in StalenessInput) ([]string, error) {
+	root := in.Target.Root
+	fsys := os.DirFS(root)
+	seen := make(map[string]struct{})
+	var out []string
+
+	add := func(rel string) {
+		if _, dup := seen[rel]; !dup {
+			seen[rel] = struct{}{}
+			out = append(out, rel)
+		}
+	}
+
+	for _, entry := range in.Target.Inputs {
+		if isGlob(entry) {
+			matches, err := doublestar.Glob(fsys, entry)
+			if err != nil {
+				return nil, fmt.Errorf("inputs glob %q: %w", entry, err)
+			}
+			if len(matches) == 0 {
+				return nil, fmt.Errorf("inputs glob %q matched no files", entry)
+			}
+			if err := buildrule.CheckGlobMatchCap(len(matches)); err != nil {
+				return nil, err
+			}
+			for _, m := range matches {
+				rel, err := buildrule.ResolvePathInRoot(root, m, true)
+				if err != nil {
+					return nil, err
+				}
+				add(rel)
+			}
+			continue
+		}
+		rel, err := buildrule.ResolvePathInRoot(root, entry, true)
+		if err != nil {
+			return nil, err
+		}
+		add(rel)
+	}
+
+	for _, entry := range in.DefaultInputs {
+		rel, err := buildrule.ResolvePathInRoot(root, entry, true)
+		if err != nil {
+			return nil, err
+		}
+		add(rel)
+	}
+
+	sort.Strings(out)
+	return out, nil
+}
+
+// resolveOutputs re-checks every declared output against the project
+// root (outputs may not exist yet) and returns sorted relative paths.
+func resolveOutputs(in StalenessInput) ([]string, error) {
+	out := make([]string, 0, len(in.Target.Outputs))
+	for _, entry := range in.Target.Outputs {
+		rel, err := buildrule.ResolvePathInRoot(in.Target.Root, entry, false)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rel)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// frame writes a length-framed field to h: an 8-byte big-endian length
+// prefix followed by the bytes. Two-layer framing on nested entries
+// prevents collisions across distinct input sets.
+func frame(h hash.Hash, b []byte) {
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(b)))
+	h.Write(lenBuf[:])
+	h.Write(b)
+}
+
+// frameString frames a single inner string (length + bytes) into a
+// builder for the canonical sub-fields that are themselves framed.
+func frameString(b *strings.Builder, s string) {
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(s)))
+	b.Write(lenBuf[:])
+	b.WriteString(s)
+}
+
+// canonicalParams returns the sorted, inner-framed serialization of the
+// param map: per pair len(key)|key|len(value)|value, no separators.
+func canonicalParams(params map[string]string) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		frameString(&b, k)
+		frameString(&b, params[k])
+	}
+	return b.String()
+}
+
+// canonicalPaths returns the inner-framed serialization of an already-
+// sorted path slice: per entry len(path)|path.
+func canonicalPaths(paths []string) string {
+	var b strings.Builder
+	for _, p := range paths {
+		frameString(&b, p)
+	}
+	return b.String()
+}
+
+// ComputeActionID computes the sha256 ActionID over the recipe command,
+// canonical params, sorted relative inputs, each input's content hash,
+// sorted relative outputs, and the cache version. Every field is framed
+// with an outer 8-byte big-endian length; nested keys, values, and paths
+// are themselves framed. Returns "sha256-<64 lowercase hex>".
+func ComputeActionID(in StalenessInput) (string, error) {
+	inputs, err := resolveInputs(in)
+	if err != nil {
+		return "", err
+	}
+	outputs, err := resolveOutputs(in)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+	frame(h, []byte(in.Command))
+	frame(h, []byte(canonicalParams(in.Target.Params)))
+	frame(h, []byte(canonicalPaths(inputs)))
+
+	var contents strings.Builder
+	for _, rel := range inputs {
+		abs := filepath.Join(in.Target.Root, filepath.FromSlash(rel))
+		sum, err := hashFile(abs)
+		if err != nil {
+			return "", err
+		}
+		contents.WriteString(sum)
+	}
+	frame(h, []byte(contents.String()))
+
+	frame(h, []byte(canonicalPaths(outputs)))
+
+	var verBuf [8]byte
+	binary.BigEndian.PutUint64(verBuf[:], uint64(CacheVersion))
+	frame(h, verBuf[:])
+
+	return "sha256-" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// hashFile returns the lowercase-hex sha256 of a file's content.
+func hashFile(abs string) (string, error) {
+	data, err := os.ReadFile(abs) //nolint:gosec // abs is an in-root input/output path
+	if err != nil {
+		return "", fmt.Errorf("hashing %s: %w", filepath.Base(abs), err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// CheckStaleness returns the staleness verdict for one target against the
+// cache. Steps, in order: resolve inputs (missing → error); any missing
+// output → stale; compute ActionID; cache miss or different ActionID →
+// stale; any output content hash mismatch → stale; otherwise fresh.
+func CheckStaleness(in StalenessInput, cache *Cache) (StalenessResult, error) {
+	inputs, err := resolveInputs(in)
+	if err != nil {
+		return StalenessResult{}, err
+	}
+	outputs, err := resolveOutputs(in)
+	if err != nil {
+		return StalenessResult{}, err
+	}
+
+	res := StalenessResult{Verdict: Stale, Inputs: inputs}
+
+	// Step 2: any output missing on disk → stale.
+	for _, rel := range outputs {
+		abs := filepath.Join(in.Target.Root, filepath.FromSlash(rel))
+		if _, err := os.Stat(abs); err != nil {
+			return res, nil
+		}
+	}
+
+	// Step 3-4: ActionID lookup.
+	actionID, err := ComputeActionID(in)
+	if err != nil {
+		return StalenessResult{}, err
+	}
+	entry, ok := cache.Lookup(outputs)
+	if !ok || entry.ActionID != actionID {
+		return res, nil
+	}
+
+	// Step 5: output content hashes must match the cache.
+	stored := make(map[string]string, len(entry.Outputs))
+	for _, o := range entry.Outputs {
+		stored[o.Path] = o.Hash
+	}
+	for _, rel := range outputs {
+		abs := filepath.Join(in.Target.Root, filepath.FromSlash(rel))
+		sum, err := hashFile(abs)
+		if err != nil {
+			return StalenessResult{}, err
+		}
+		if stored[rel] != "sha256-"+sum {
+			return res, nil
+		}
+	}
+
+	res.Verdict = Fresh
+	return res, nil
+}
+
+// RecordBuild builds the cache entry for a freshly-built target: the
+// ActionID, the sorted relative inputs, and each declared output hashed
+// from disk. Call after a successful Build. built-at is left empty; the
+// caller stamps it.
+func RecordBuild(in StalenessInput) (CacheEntry, error) {
+	actionID, err := ComputeActionID(in)
+	if err != nil {
+		return CacheEntry{}, err
+	}
+	inputs, err := resolveInputs(in)
+	if err != nil {
+		return CacheEntry{}, err
+	}
+	outputs, err := resolveOutputs(in)
+	if err != nil {
+		return CacheEntry{}, err
+	}
+	outHashes := make([]OutputHash, 0, len(outputs))
+	for _, rel := range outputs {
+		abs := filepath.Join(in.Target.Root, filepath.FromSlash(rel))
+		sum, err := hashFile(abs)
+		if err != nil {
+			return CacheEntry{}, err
+		}
+		outHashes = append(outHashes, OutputHash{Path: rel, Hash: "sha256-" + sum})
+	}
+	return CacheEntry{
+		Outputs:  outHashes,
+		Inputs:   inputs,
+		ActionID: actionID,
+		Recipe:   in.Target.Recipe,
+	}, nil
+}
+
+// OverlapTarget identifies one directive's declared outputs and its
+// source location for the overlap report.
+type OverlapTarget struct {
+	File    string
+	Line    int
+	Outputs []string
+}
+
+// DetectOutputOverlap reports an error when two directives declare
+// overlapping outputs — an exact path collision or a directory-prefix
+// collision (book/ vs book/index.html). The error names both source
+// locations. Targets are compared pairwise in source order.
+func DetectOutputOverlap(targets []OverlapTarget) error {
+	type owned struct {
+		file string
+		line int
+		raw  string
+	}
+	var claimed []owned
+	for _, t := range targets {
+		for _, o := range t.Outputs {
+			norm := normalizeOutput(o)
+			for _, c := range claimed {
+				if outputsOverlap(norm, normalizeOutput(c.raw)) {
+					return fmt.Errorf(
+						"build outputs overlap: %q (%s:%d) and %q (%s:%d) write to the same location",
+						c.raw, c.file, c.line, o, t.File, t.Line,
+					)
+				}
+			}
+			claimed = append(claimed, owned{file: t.File, line: t.Line, raw: o})
+		}
+	}
+	return nil
+}
+
+// normalizeOutput cleans an output path for comparison: forward slashes,
+// path.Clean, trailing slash stripped.
+func normalizeOutput(p string) string {
+	p = filepath.ToSlash(p)
+	p = strings.TrimRight(p, "/")
+	if p == "" {
+		return "."
+	}
+	return path.Clean(p)
+}
+
+// outputsOverlap reports whether two normalized output paths collide:
+// equal, or one is a directory prefix of the other.
+func outputsOverlap(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return isPrefixDir(a, b) || isPrefixDir(b, a)
+}
+
+// isPrefixDir reports whether dir is a directory prefix of p (p lives
+// under dir). "book" is a prefix dir of "book/index.html"; "book" is not
+// a prefix dir of "bookmark".
+func isPrefixDir(dir, p string) bool {
+	return strings.HasPrefix(p, dir+"/")
+}

--- a/internal/build/staleness_test.go
+++ b/internal/build/staleness_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -301,4 +302,70 @@ func TestRecordBuild_HashFileErrorForOutput(t *testing.T) {
 	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"out.txt"}, nil)
 	_, err := RecordBuild(in)
 	require.Error(t, err)
+}
+
+// --- ComputeActionID error paths ---
+
+func TestComputeActionID_BadInputPath(t *testing.T) {
+	root := t.TempDir()
+	in := newPlan(t, root, "r", "tool", []string{"../escape.txt"}, []string{"out.txt"}, nil)
+	_, err := ComputeActionID(in)
+	require.Error(t, err)
+}
+
+func TestComputeActionID_BadOutputPath(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"../escape.txt"}, nil)
+	_, err := ComputeActionID(in)
+	require.Error(t, err)
+}
+
+// TestCheckStaleness_ComputeActionIDError covers the ComputeActionID error
+// branch inside CheckStaleness (step 3). The output exists (so step 2 passes)
+// but the input is a directory — hashFile returns an error.
+func TestCheckStaleness_ComputeActionIDError(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src.txt"), 0o755))
+	writeFile(t, root, "out.txt", "result")
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"out.txt"}, nil)
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+}
+
+// TestResolveInputs_GlobMatchEscapesRoot covers the ResolvePathInRoot error
+// inside the glob-match loop in resolveInputs (the branch that handles a
+// glob that matches a file escaping the root via symlink).
+func TestResolveInputs_GlobMatchEscapesRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable on Windows CI")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("s"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(root, "leak.txt")))
+	in := newPlan(t, root, "r", "tool", []string{"*.txt"}, []string{"out.txt"}, nil)
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project root")
+}
+
+// TestResolveInputs_DuplicatesDeduped covers the dup=true branch in the add
+// closure: a file that appears in both Target.Inputs and DefaultInputs is
+// counted only once in the hash.
+func TestResolveInputs_DuplicatesDeduped(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "content")
+	writeFile(t, root, "out.txt", "out")
+	// src.txt in both Inputs and DefaultInputs — the second occurrence is
+	// deduplicated by the add closure.
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"out.txt"}, []string{"src.txt"})
+	id, err := ComputeActionID(in)
+	require.NoError(t, err)
+	assert.NotEmpty(t, id)
+}
+
+// TestNormalizeOutput_EmptyString covers the p == "" branch in normalizeOutput.
+func TestNormalizeOutput_EmptyString(t *testing.T) {
+	assert.Equal(t, ".", normalizeOutput(""))
 }

--- a/internal/build/staleness_test.go
+++ b/internal/build/staleness_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -368,4 +369,61 @@ func TestResolveInputs_DuplicatesDeduped(t *testing.T) {
 // TestNormalizeOutput_EmptyString covers the p == "" branch in normalizeOutput.
 func TestNormalizeOutput_EmptyString(t *testing.T) {
 	assert.Equal(t, ".", normalizeOutput(""))
+}
+
+func TestVerdictString(t *testing.T) {
+	assert.Equal(t, "FRESH", Fresh.String())
+	assert.Equal(t, "STALE", Stale.String())
+}
+
+func TestStaleness_GlobInputMatches(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src1.txt", "hello")
+	writeFile(t, root, "src2.txt", "world")
+	writeFile(t, root, "dst.txt", "result")
+	in := newPlan(t, root, "cat", "cat {inputs}", []string{"src*.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	require.Equal(t, Stale, res.Verdict)
+
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	res2, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Fresh, res2.Verdict)
+}
+
+func TestResolveInputs_GlobCapExceeded(t *testing.T) {
+	old := globCapFn
+	globCapFn = func(_ int) error { return errors.New("cap exceeded") }
+	defer func() { globCapFn = old }()
+
+	root := t.TempDir()
+	writeFile(t, root, "a.txt", "a")
+	in := newPlan(t, root, "r", "tool", []string{"*.txt"}, []string{"out.txt"}, nil)
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cap exceeded")
+}
+
+func TestRecordBuild_BadInputPath(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	in := newPlan(t, root, "r", "tool", []string{"../escape.txt"}, []string{"dst.txt"}, nil)
+	_, err := RecordBuild(in)
+	require.Error(t, err)
+}
+
+func TestRecordBuild_HashFileErrorForInput(t *testing.T) {
+	root := t.TempDir()
+	// src.txt is a directory: resolveInputs succeeds (path is in root),
+	// but computeActionIDFromResolved fails when it tries to hash the dir.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src.txt"), 0o755))
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	_, err := RecordBuild(in)
+	require.Error(t, err)
 }

--- a/internal/build/staleness_test.go
+++ b/internal/build/staleness_test.go
@@ -216,3 +216,89 @@ func TestDetectOutputOverlap_NoOverlap(t *testing.T) {
 	}
 	require.NoError(t, DetectOutputOverlap(plans))
 }
+
+// --- resolveInputs error branches ---
+
+func TestResolveInputs_GlobSyntaxError(t *testing.T) {
+	root := t.TempDir()
+	// An unclosed bracket is a glob syntax error in doublestar.
+	in := newPlan(t, root, "r", "tool", []string{"[invalid"}, []string{"out.txt"}, nil)
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+}
+
+func TestResolveInputs_LiteralPathEscapesRoot(t *testing.T) {
+	root := t.TempDir()
+	// A literal input with ".." that would escape the root is rejected.
+	in := newPlan(t, root, "r", "tool", []string{"../escape.txt"}, []string{"out.txt"}, nil)
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+}
+
+func TestResolveInputs_DefaultInputEscapesRoot(t *testing.T) {
+	root := t.TempDir()
+	// A default input with ".." that would escape the root is rejected.
+	in := newPlan(t, root, "r", "tool", nil, []string{"out.txt"}, []string{"../escape.txt"})
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+}
+
+// --- resolveOutputs error branch ---
+
+func TestCheckStaleness_BadOutputPath(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	// An output path with ".." that would escape the root is rejected.
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"../escape.txt"}, nil)
+	_, err := CheckStaleness(in, NewCache())
+	require.Error(t, err)
+}
+
+func TestRecordBuild_BadOutputPath(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"../escape.txt"}, nil)
+	_, err := RecordBuild(in)
+	require.Error(t, err)
+}
+
+// --- hashFile error branches ---
+
+func TestComputeActionID_HashFileError(t *testing.T) {
+	root := t.TempDir()
+	// Create a directory named like an input file — ReadFile on a dir fails.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src.txt"), 0o755))
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"out.txt"}, nil)
+	_, err := ComputeActionID(in)
+	require.Error(t, err)
+}
+
+func TestCheckStaleness_HashFileErrorForOutput(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	// Build the cache with a real file, then replace the output with a directory
+	// so the content-hash step (step 5) fails.
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	writeFile(t, root, "dst.txt", "world")
+	cache := NewCache()
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	// Replace dst.txt with a directory so hashFile returns an error.
+	require.NoError(t, os.Remove(filepath.Join(root, "dst.txt")))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "dst.txt"), 0o755))
+
+	_, err = CheckStaleness(in, cache)
+	require.Error(t, err)
+}
+
+func TestRecordBuild_HashFileErrorForOutput(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	// Replace the output with a directory so hashFile returns an error.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "out.txt"), 0o755))
+	in := newPlan(t, root, "r", "tool", []string{"src.txt"}, []string{"out.txt"}, nil)
+	_, err := RecordBuild(in)
+	require.Error(t, err)
+}

--- a/internal/build/staleness_test.go
+++ b/internal/build/staleness_test.go
@@ -1,0 +1,218 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile writes content to root/rel, creating parent dirs.
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+}
+
+func newPlan(t *testing.T, root, recipe, cmd string, inputs, outputs, defaults []string) StalenessInput {
+	t.Helper()
+	return StalenessInput{
+		Target: Target{
+			Recipe:  recipe,
+			Root:    root,
+			Inputs:  inputs,
+			Outputs: outputs,
+		},
+		Command:       cmd,
+		DefaultInputs: defaults,
+	}
+}
+
+func TestStaleness_MissingOutputIsStale(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Stale, res.Verdict)
+}
+
+func TestStaleness_FreshAfterBuild(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	writeFile(t, root, "dst.txt", "hello")
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+
+	// First check: stale (no cache entry).
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	require.Equal(t, Stale, res.Verdict)
+
+	// Record the build in the cache, then re-check: fresh.
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	res2, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Fresh, res2.Verdict)
+}
+
+func TestStaleness_InputContentChangeIsStale(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	writeFile(t, root, "dst.txt", "hello")
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	// Change the input content.
+	writeFile(t, root, "src.txt", "changed")
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Stale, res.Verdict)
+}
+
+func TestStaleness_RecipeCommandChangeIsStale(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	writeFile(t, root, "dst.txt", "hello")
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	in.Command = "install {inputs} {outputs}"
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Stale, res.Verdict)
+}
+
+func TestStaleness_TamperedOutputIsStale(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src.txt", "hello")
+	writeFile(t, root, "dst.txt", "hello")
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"src.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	// Hand-edit the artifact: ActionID unchanged, output hash now differs.
+	writeFile(t, root, "dst.txt", "tampered")
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Stale, res.Verdict)
+}
+
+func TestStaleness_MissingInputIsError(t *testing.T) {
+	root := t.TempDir()
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"absent.txt"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+	_, err := CheckStaleness(in, cache)
+	require.Error(t, err)
+}
+
+func TestStaleness_GlobMatchingZeroFilesIsError(t *testing.T) {
+	root := t.TempDir()
+	in := newPlan(t, root, "copy", "cp {inputs} {outputs}", []string{"*.none"}, []string{"dst.txt"}, nil)
+	cache := NewCache()
+	_, err := CheckStaleness(in, cache)
+	require.Error(t, err)
+}
+
+func TestStaleness_DefaultInputsFoldedIntoHash(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "demo.tape", "v1")
+	writeFile(t, root, "out.gif", "rendered")
+	in := newPlan(t, root, "vhs", "vhs {tape}", nil, []string{"out.gif"}, []string{"demo.tape"})
+	cache := NewCache()
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	require.Equal(t, Fresh, res.Verdict)
+
+	// Changing the default-input content must invalidate.
+	writeFile(t, root, "demo.tape", "v2")
+	res2, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Stale, res2.Verdict)
+}
+
+func TestStaleness_TwoOutputRebuildsWhenEitherDeleted(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "a.txt", "a")
+	writeFile(t, root, "b.txt", "b")
+	in := newPlan(t, root, "dup", "tool {outputs}", nil, []string{"a.txt", "b.txt"}, nil)
+	cache := NewCache()
+	entry, err := RecordBuild(in)
+	require.NoError(t, err)
+	cache.Put(entry)
+
+	require.NoError(t, os.Remove(filepath.Join(root, "b.txt")))
+	res, err := CheckStaleness(in, cache)
+	require.NoError(t, err)
+	assert.Equal(t, Stale, res.Verdict)
+}
+
+func TestActionID_LengthFramedNoCollision(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "a", "x")
+	writeFile(t, root, "b", "y")
+	// Two param maps that would collide under naive concatenation:
+	// {"a":"b","c":"d"} vs {"a":"bc","":"d"} — framing must separate them.
+	in1 := StalenessInput{
+		Target:  Target{Recipe: "r", Root: root, Outputs: []string{"a"}, Params: map[string]string{"k": "v", "x": "y"}},
+		Command: "tool",
+	}
+	in2 := StalenessInput{
+		Target:  Target{Recipe: "r", Root: root, Outputs: []string{"a"}, Params: map[string]string{"k": "vx", "": "y"}},
+		Command: "tool",
+	}
+	id1, err := ComputeActionID(in1)
+	require.NoError(t, err)
+	id2, err := ComputeActionID(in2)
+	require.NoError(t, err)
+	assert.NotEqual(t, id1, id2)
+}
+
+func TestDetectOutputOverlap_ExactCollision(t *testing.T) {
+	plans := []OverlapTarget{
+		{File: "a.md", Line: 1, Outputs: []string{"out.txt"}},
+		{File: "b.md", Line: 5, Outputs: []string{"out.txt"}},
+	}
+	err := DetectOutputOverlap(plans)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a.md")
+	assert.Contains(t, err.Error(), "b.md")
+}
+
+func TestDetectOutputOverlap_DirPrefixCollision(t *testing.T) {
+	plans := []OverlapTarget{
+		{File: "a.md", Line: 1, Outputs: []string{"book/"}},
+		{File: "b.md", Line: 2, Outputs: []string{"book/index.html"}},
+	}
+	err := DetectOutputOverlap(plans)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "book")
+}
+
+func TestDetectOutputOverlap_NoOverlap(t *testing.T) {
+	plans := []OverlapTarget{
+		{File: "a.md", Line: 1, Outputs: []string{"a.txt"}},
+		{File: "b.md", Line: 2, Outputs: []string{"b.txt"}},
+	}
+	require.NoError(t, DetectOutputOverlap(plans))
+}

--- a/internal/config/build.go
+++ b/internal/config/build.go
@@ -17,6 +17,13 @@ type RecipeCfg struct {
 	Command      string   `yaml:"command"`
 	BodyTemplate string   `yaml:"body-template,omitempty"`
 	Params       ParamCfg `yaml:"params,omitempty"`
+	// DefaultInputs declares implicit inputs folded into every directive's
+	// input set. Each entry is either a {param} token (a declared param
+	// name) or a literal relative path passing the path-shape rules. A
+	// param token expands to the root-joined absolute path at exec time;
+	// the value hashed into the ActionID is always the relative path the
+	// param supplies.
+	DefaultInputs []string `yaml:"default-inputs,omitempty"`
 }
 
 // ParamCfg names the params a recipe accepts.
@@ -72,7 +79,73 @@ func validateRecipe(name string, recipe RecipeCfg) error {
 	for _, p := range recipe.Params.Optional {
 		allowed[p] = true
 	}
-	return validateCommandPlaceholders(name, recipe.Command, allowed)
+	if err := validateCommandPlaceholders(name, recipe.Command, allowed); err != nil {
+		return err
+	}
+	return validateDefaultInputs(name, recipe.DefaultInputs, allowed)
+}
+
+// defaultInputTokenRe matches an entry that is exactly a single {name}
+// param token. A literal path entry never matches.
+var defaultInputTokenRe = regexp.MustCompile(`^\{([A-Za-z_][A-Za-z0-9_]*)\}$`)
+
+// validateDefaultInputs checks each default-inputs entry. A {param} token
+// must name a declared, non-reserved param; any other entry must be a
+// literal relative path passing the path-shape rules.
+func validateDefaultInputs(recipeName string, entries []string, allowed map[string]bool) error {
+	for _, entry := range entries {
+		if m := defaultInputTokenRe.FindStringSubmatch(entry); m != nil {
+			param := m[1]
+			if reservedParams[param] || collectivePlaceholders[param] {
+				return fmt.Errorf(
+					"build.recipes.%s: default-inputs uses reserved token {%s}",
+					recipeName, param,
+				)
+			}
+			if !allowed[param] {
+				return fmt.Errorf(
+					"build.recipes.%s: default-inputs references undeclared param {%s}",
+					recipeName, param,
+				)
+			}
+			continue
+		}
+		if reason := defaultInputPathShape(entry); reason != "" {
+			return fmt.Errorf(
+				"build.recipes.%s: default-inputs entry %q %s",
+				recipeName, entry, reason,
+			)
+		}
+	}
+	return nil
+}
+
+// defaultInputPathShape returns "" when entry is an acceptable literal
+// relative path, or a short reason phrase otherwise. The rules mirror the
+// directive path-shape allowlist: no absolute paths, no NUL/newline, no
+// backslashes, no ".." escape.
+func defaultInputPathShape(entry string) string {
+	if strings.TrimSpace(entry) == "" {
+		return "must not be empty"
+	}
+	if entry != strings.TrimSpace(entry) {
+		return "must not have leading or trailing whitespace"
+	}
+	if strings.ContainsAny(entry, "\x00\n\r") {
+		return "must not contain NUL, newline, or carriage return"
+	}
+	if strings.Contains(entry, `\`) {
+		return "must use forward-slash separators only"
+	}
+	if strings.HasPrefix(entry, "/") || strings.HasPrefix(entry, "~") {
+		return "must be a relative path"
+	}
+	cleaned := strings.TrimRight(entry, "/")
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") ||
+		strings.Contains(cleaned, "/../") || strings.HasSuffix(cleaned, "/..") {
+		return `must not contain ".." path components`
+	}
+	return ""
 }
 
 func validateDeclaredParams(recipeName string, params ParamCfg) error {
@@ -198,6 +271,13 @@ func serializeRecipes(recipes map[string]RecipeCfg) map[string]any {
 		}
 		if len(params) > 0 {
 			m["params"] = params
+		}
+		if len(r.DefaultInputs) > 0 {
+			s := make([]any, len(r.DefaultInputs))
+			for i, v := range r.DefaultInputs {
+				s[i] = v
+			}
+			m["default-inputs"] = s
 		}
 		out[name] = m
 	}

--- a/internal/config/build_test.go
+++ b/internal/config/build_test.go
@@ -652,6 +652,96 @@ func TestCopyBuildConfig_Empty(t *testing.T) {
 	assert.Empty(t, cp.Recipes)
 }
 
+// --- defaultInputPathShape branch coverage ---
+
+func TestDefaultInputPathShape_EmptyString(t *testing.T) {
+	assert.Equal(t, "must not be empty", defaultInputPathShape(""))
+}
+
+func TestDefaultInputPathShape_WhitespaceOnly(t *testing.T) {
+	assert.Equal(t, "must not be empty", defaultInputPathShape("   "))
+}
+
+func TestDefaultInputPathShape_LeadingWhitespace(t *testing.T) {
+	assert.Equal(t, "must not have leading or trailing whitespace", defaultInputPathShape(" valid/path"))
+}
+
+func TestDefaultInputPathShape_TrailingWhitespace(t *testing.T) {
+	assert.Equal(t, "must not have leading or trailing whitespace", defaultInputPathShape("valid/path "))
+}
+
+func TestDefaultInputPathShape_NULByte(t *testing.T) {
+	assert.Equal(t, "must not contain NUL, newline, or carriage return", defaultInputPathShape("pa\x00th"))
+}
+
+func TestDefaultInputPathShape_Newline(t *testing.T) {
+	assert.Equal(t, "must not contain NUL, newline, or carriage return", defaultInputPathShape("pa\nth"))
+}
+
+func TestDefaultInputPathShape_CarriageReturn(t *testing.T) {
+	assert.Equal(t, "must not contain NUL, newline, or carriage return", defaultInputPathShape("pa\rth"))
+}
+
+func TestDefaultInputPathShape_Backslash(t *testing.T) {
+	assert.Equal(t, "must use forward-slash separators only", defaultInputPathShape(`path\file`))
+}
+
+func TestDefaultInputPathShape_TildePrefix(t *testing.T) {
+	assert.Equal(t, "must be a relative path", defaultInputPathShape("~/home/file"))
+}
+
+func TestDefaultInputPathShape_JustDotDot(t *testing.T) {
+	assert.NotEmpty(t, defaultInputPathShape(".."))
+}
+
+func TestDefaultInputPathShape_EmbeddedDotDot(t *testing.T) {
+	assert.NotEmpty(t, defaultInputPathShape("a/../../b"))
+}
+
+func TestDefaultInputPathShape_SuffixDotDot(t *testing.T) {
+	assert.NotEmpty(t, defaultInputPathShape("a/b/.."))
+}
+
+func TestDefaultInputPathShape_ValidPath(t *testing.T) {
+	assert.Equal(t, "", defaultInputPathShape("assets/logo.svg"))
+}
+
+func TestValidateBuildConfig_DefaultInputsReservedAlt_Rejected(t *testing.T) {
+	// {alt} is in reservedParams (not collectivePlaceholders) — hits the
+	// reservedParams branch in validateDefaultInputs.
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"x": {
+					Command:       "tool {outputs}",
+					DefaultInputs: []string{"{alt}"},
+				},
+			},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default-inputs")
+	assert.Contains(t, err.Error(), "alt")
+}
+
+// --- serializeRecipes DefaultInputs ---
+
+func TestSerializeRecipes_WithDefaultInputs(t *testing.T) {
+	out := serializeRecipes(map[string]RecipeCfg{
+		"vhs": {
+			Command:       "vhs {tape}",
+			Params:        ParamCfg{Required: []string{"tape"}},
+			DefaultInputs: []string{"{tape}"},
+		},
+	})
+	m, ok := out["vhs"].(map[string]any)
+	require.True(t, ok)
+	di, hasDI := m["default-inputs"]
+	require.True(t, hasDI, "default-inputs must be serialized")
+	assert.Equal(t, []any{"{tape}"}, di)
+}
+
 // --- Build survives Merge ---
 
 func TestMerge_PreservesBuild(t *testing.T) {

--- a/internal/config/build_test.go
+++ b/internal/config/build_test.go
@@ -244,6 +244,111 @@ func TestValidateBuildConfig_OptionalParam_Allowed(t *testing.T) {
 	assert.NoError(t, ValidateBuildConfig(cfg))
 }
 
+// --- default-inputs ---
+
+func TestLoad_RecipeDefaultInputs(t *testing.T) {
+	yml := []byte("build:\n  recipes:\n    vhs:\n      command: vhs {tape}\n" +
+		"      params:\n        required: [tape]\n      default-inputs: [\"{tape}\"]\n")
+	cfg, err := loadFromBytes(yml, "", false)
+	require.NoError(t, err)
+	require.Contains(t, cfg.Build.Recipes, "vhs")
+	assert.Equal(t, []string{"{tape}"}, cfg.Build.Recipes["vhs"].DefaultInputs)
+}
+
+func TestValidateBuildConfig_DefaultInputsParamToken_Allowed(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"vhs": {
+					Command:       "vhs {tape}",
+					Params:        ParamCfg{Required: []string{"tape"}},
+					DefaultInputs: []string{"{tape}"},
+				},
+			},
+		},
+	}
+	assert.NoError(t, ValidateBuildConfig(cfg))
+}
+
+func TestValidateBuildConfig_DefaultInputsLiteralPath_Allowed(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"x": {
+					Command:       "tool {outputs}",
+					DefaultInputs: []string{"assets/header.css"},
+				},
+			},
+		},
+	}
+	assert.NoError(t, ValidateBuildConfig(cfg))
+}
+
+func TestValidateBuildConfig_DefaultInputsUndeclaredParam_Rejected(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"x": {
+					Command:       "tool {outputs}",
+					DefaultInputs: []string{"{missing}"},
+				},
+			},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default-inputs")
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestValidateBuildConfig_DefaultInputsReservedParam_Rejected(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"x": {
+					Command:       "tool {outputs}",
+					DefaultInputs: []string{"{inputs}"},
+				},
+			},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default-inputs")
+}
+
+func TestValidateBuildConfig_DefaultInputsAbsolutePath_Rejected(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"x": {
+					Command:       "tool {outputs}",
+					DefaultInputs: []string{"/etc/passwd"},
+				},
+			},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default-inputs")
+}
+
+func TestValidateBuildConfig_DefaultInputsParentEscape_Rejected(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Recipes: map[string]RecipeCfg{
+				"x": {
+					Command:       "tool {outputs}",
+					DefaultInputs: []string{"../secret.txt"},
+				},
+			},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default-inputs")
+}
+
 // --- InjectBuildConfig ---
 
 func TestInjectBuildConfig_Nil(t *testing.T) {

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -145,6 +145,7 @@ func copyBuildConfig(b BuildConfig) BuildConfig {
 				Required: copyStrings(r.Params.Required),
 				Optional: copyStrings(r.Params.Optional),
 			},
+			DefaultInputs: copyStrings(r.DefaultInputs),
 		}
 	}
 	return BuildConfig{Recipes: recipes}

--- a/plan/103_build-staleness-and-deps.md
+++ b/plan/103_build-staleness-and-deps.md
@@ -1,7 +1,7 @@
 ---
 id: 103
 title: Build target staleness and dependency tracking
-status: "🔲"
+status: "🔳"
 summary: >-
   Make the `mdsmith fix` build pass
   Make/Bazel-style. Hash `(recipe spec ‖ sorted
@@ -269,48 +269,48 @@ hashing. Parallel builds: plan 2606101547.
 
 ## Acceptance Criteria
 
-- [ ] A second `mdsmith fix` with no source
+- [x] A second `mdsmith fix` with no source
       changes runs zero recipes
-- [ ] Editing a declared input triggers a
+- [x] Editing a declared input triggers a
       rebuild of just that target
-- [ ] Touching mtime without content change
+- [x] Touching mtime without content change
       does not trigger a rebuild
-- [ ] Deleting any declared output triggers a
+- [x] Deleting any declared output triggers a
       rebuild of that target
-- [ ] Editing a recipe `command` invalidates
+- [x] Editing a recipe `command` invalidates
       every target using that recipe
-- [ ] An `inputs:` glob matching zero files
+- [x] An `inputs:` glob matching zero files
       is a build error
-- [ ] Overlapping `outputs:` paths (exact
+- [x] Overlapping `outputs:` paths (exact
       or directory-prefix) is a build error
       reporting both source locations
-- [ ] A recipe's `default-inputs` are folded
+- [x] A recipe's `default-inputs` are folded
       into the input hash
-- [ ] `mdsmith fix --build-force` rebuilds
+- [x] `mdsmith fix --build-force` rebuilds
       every target
-- [ ] `mdsmith fix --build-check-stale`
+- [x] `mdsmith fix --build-check-stale`
       prints stale targets and exits non-zero
       without running any recipe
-- [ ] `mdsmith fix --build-no-cache` rebuilds
+- [x] `mdsmith fix --build-no-cache` rebuilds
       everything; writes nothing to the cache
-- [ ] `mdsmith fix --build-dry-run` prints
+- [x] `mdsmith fix --build-dry-run` prints
       every target's `STALE | FRESH` verdict
-- [ ] Per-target summary distinguishes `OK`,
+- [x] Per-target summary distinguishes `OK`,
       `FAIL`, and `SKIP`
-- [ ] `.mdsmith/build-cache.json` has a
+- [x] `.mdsmith/build-cache.json` has a
       `version` field and per-target entries
       with `outputs[]` (path + content hash),
       `action-id`, `built-at`, `inputs`,
       `recipe`
-- [ ] Hand-editing an artifact triggers a
+- [x] Hand-editing an artifact triggers a
       rebuild on the next `fix` (hash
       mismatch)
-- [ ] ActionID is length-framed: paths with
+- [x] ActionID is length-framed: paths with
       NUL or sentinel bytes cannot collide
       with another input set
-- [ ] Cache writes are atomic (temp+rename);
+- [x] Cache writes are atomic (temp+rename);
       a mid-build crash leaves the previous
       cache readable
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run` reports no
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run` reports no
       issues


### PR DESCRIPTION
Implements plan 103 — Make/Bazel-style incremental builds for the `mdsmith fix` build pass.

> Note: this branch is based on the plan 2606101546 PR branch (`claude/determined-hamilton-nmqgtw`, PR #571), which is not yet merged. It targets `main` and will need a rebase once #571 merges. The first commits here belong to #571; the plan-103 work is the top 5 commits.

## What changed

- **`internal/config`**: `RecipeCfg.DefaultInputs` — each entry is a `{param}` token (declared, non-reserved) or a literal relative path passing the path-shape rules. Validated at config load.
- **`internal/build/cache.go`**: load/save `.mdsmith/build-cache.json` with an atomic temp+rename write; entries keyed by sorted output-set.
- **`internal/build/staleness.go`**: length-framed sha256 ActionID over `(recipe command ‖ canonical params ‖ sorted rel inputs ‖ per-input content hash ‖ sorted rel outputs ‖ cache version)`; per-target `FRESH`/`STALE` verdict; output content-hash check (catches hand-edited artifacts); `DetectOutputOverlap` for exact and directory-prefix collisions naming both source locations.
- **`mdsmith fix` build pass**: skips fresh targets (`SKIP`), rebuilds stale ones (`OK`), refreshes the cache atomically at end of run. New flags `--build-force`, `--build-check-stale`, `--build-no-cache`; `--build-dry-run` now prints `STALE | FRESH`. `--build-force` combined with `--build-check-stale` or `--build-no-cache` is a usage error.
- **Docs**: staleness model, cache schema, `default-inputs`, the `.gitignore` snippet, and the new flags in the build guide, the build-artifacts feature page, and the README.

## Verification

- All 18 acceptance criteria checked off in `plan/103_build-staleness-and-deps.md`.
- `go test ./...` green; `go vet ./...` clean; `golangci-lint run ./...` reports 0 issues.
- Integration tests in `cmd/mdsmith/e2e_build_test.go` cover every plan scenario; a manual end-to-end smoke test confirms SKIP/OK/FRESH/STALE, force, no-cache, tampered-artifact rebuild, and the usage error.

https://claude.ai/code/session_01ViTvoyyy5TrW7TozVxjukU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViTvoyyy5TrW7TozVxjukU)_