### PR TITLE
ci: bump pinned mdsmith baseline to v0.41.0

### DIFF
--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -12,8 +12,8 @@ runs:
         # Bump here only when intentionally updating that baseline.
         # After bumping, scan PLAN.md for plans waiting to adopt the
         # newly-released syntax. See docs/development/adopt-new-directive-syntax.md.
-        MDSMITH_VERSION: v0.40.0
-        MDSMITH_SHA256: 69da312cbb74a3ae5674f2fa10f2eef2c03e3956b73cb0238615aad1d4e09614
+        MDSMITH_VERSION: v0.41.0
+        MDSMITH_SHA256: 4df9683fe598db9ea7e55789fd8b78db6390760fb88d0f46beb9bfc25e775dde
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.


### PR DESCRIPTION
## What

Bump the `setup-mdsmith-pinned-version` compatibility baseline from **v0.40.0** to **v0.41.0** (`.github/actions/setup-mdsmith-pinned-version/action.yml`). This is step 2 of [Ship and adopt new directive syntax](https://github.com/jeduden/mdsmith/blob/main/docs/development/adopt-new-directive-syntax.md) — the pinned binary that the `mdsmith-fixed-version` job and the merge-queue tooling run as the compatibility baseline.

```diff
-        MDSMITH_VERSION: v0.40.0
-        MDSMITH_SHA256: 69da312cbb74a3ae5674f2fa10f2eef2c03e3956b73cb0238615aad1d4e09614
+        MDSMITH_VERSION: v0.41.0
+        MDSMITH_SHA256: 4df9683fe598db9ea7e55789fd8b78db6390760fb88d0f46beb9bfc25e775dde
```

## SHA256 provenance

The pinned digest is the v0.41.0 `mdsmith-linux-amd64` asset, verified three independent ways — all agree on `4df9683f…775dde`:

1. GitHub release **asset digest** reported by the API
2. The release's own **`checksums.txt`** entry
3. A fresh **`sha256sum`** of the downloaded binary

## Verification

- Ran the v0.41.0 binary's `mdsmith check .` over the full tree → `checked=454 failures=0`, so the `mdsmith-fixed-version` guardrail stays green.
- Branch-build `go run ./cmd/mdsmith check .` → `checked=454 failures=0`.
- Old SHA appears nowhere else; `merge-queue.yml` consumes the action via `uses:` and picks up the new pin automatically.

## Adoption follow-up

Per the doc's "track the adoption" step, I scanned `PLAN.md`: the plans that were gated on this pin (232/233 `<?include?>` heading params, 2606100534 MDS069) are already `✅`, and the v0.41.0 binary parses the whole checked-in tree, so this bump unblocks no pending adoption work.

https://claude.ai/code/session_01BWT18Z9J5ZLzkj6U2W99sb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWT18Z9J5ZLzkj6U2W99sb)_