### PR TITLE
plan: mark 218 and 240 completed — tinygo merged, lint CI-green

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -140,7 +140,7 @@ footer: |
 | 215        | ✅     | opus   | [mdsmith public engine API and WASM bindings](plan/215_engine-api-wasm.md)                                                              |
 | 216        | ✅     | opus   | [Per-document parse cache for the LSP, keyed by version](plan/216_lsp-parse-cache.md)                                                   |
 | 217        | ✅     | opus   | [Obsidian plugin (WASM runtime)](plan/217_obsidian-plugin.md)                                                                           |
-| 218        | 🔳     | opus   | [In-house CUE-subset engine for WASM size and tinygo](plan/218_wasm-size-reduction.md)                                                  |
+| 218        | ✅     | opus   | [In-house CUE-subset engine for WASM size and tinygo](plan/218_wasm-size-reduction.md)                                                  |
 | 219        | ✅     | opus   | [Route cmd/mdsmith and the LSP through pkg/mdsmith.Session](plan/219_session-cli-lsp-migration.md)                                      |
 | 220        | ✅     | opus   | [Harden the git-index writers against a transient index.lock](plan/220_git-index-lock-retry.md)                                         |
 | 221        | ✅     | opus   | [Ship mdsmith as a self-hosted Flatpak bundle](plan/221_flatpak-bundle-distribution.md)                                                 |
@@ -158,7 +158,7 @@ footer: |
 | 237        | ✅     | sonnet | [cuelite phase 1 — surface D (placeholder paths)](plan/237_cuelite-surface-d.md)                                                        |
 | 238        | ✅     | opus   | [cuelite phase 2 — surfaces A + B (schema, query)](plan/238_cuelite-surfaces-ab.md)                                                     |
 | 239        | ✅     | opus   | [cuelite phase 3 — surface C (row-expr evaluator)](plan/239_cuelite-surface-c.md)                                                       |
-| 240        | 🔳     | opus   | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
+| 240        | ✅     | opus   | [cuelite phase 4 — drop cuelang.org and enable tinygo](plan/240_cuelite-drop-cue.md)                                                    |
 | 241        | ✅     | opus   | [Schema-per-file config under `.mdsmith/schemas/`](plan/241_schema-files.md)                                                            |
 | 242        | ✅     | opus   | [proto.md schemas declare content entries via `<?content?>`](plan/242_proto-content-entries.md)                                         |
 | 243        | ✅     | sonnet | [`mdsmith extract` projects the document H1 as `title`](plan/243_extract-h1-title.md)                                                   |

--- a/plan/218_wasm-size-reduction.md
+++ b/plan/218_wasm-size-reduction.md
@@ -1,7 +1,7 @@
 ---
 id: 218
 title: In-house CUE-subset engine for WASM size and tinygo
-status: "🔳"
+status: "✅"
 model: opus
 summary: >-
   Replace the cuelang.org/go dependency with a small, pure-Go,
@@ -297,8 +297,8 @@ Split into per-phase plans, run in order, each keeping
       the `syntax` package's parser/scanner error branches are
       covered (`closeout_coverage_test.go`).
 - [x] All tests pass: `go test ./...`
-- [🔳] `go tool golangci-lint run` reports no issues — CI-verified
-      (needs Go ≥ 1.25.8; the dev container has 1.25.0).
+- [x] `go tool golangci-lint run` reports no issues — verified
+      by the green CI `lint` job (the dev container's Go cannot).
 
 ## Non-Goals
 

--- a/plan/240_cuelite-drop-cue.md
+++ b/plan/240_cuelite-drop-cue.md
@@ -1,7 +1,7 @@
 ---
 id: 240
 title: "cuelite phase 4 — drop cuelang.org and enable tinygo"
-status: "🔳"
+status: "✅"
 model: opus
 summary: >-
   With every surface flipped, delete cue/cuelite's CUE
@@ -121,9 +121,9 @@ above the `sonnet` band.
       capability set as the native session.
 - [x] All tests pass: `go test ./...` (and `-race` clean on the
       affected packages).
-- [🔳] `go tool golangci-lint run` reports no issues — the tools/go.mod
+- [x] `go tool golangci-lint run` reports no issues — the tools/go.mod
       golangci-lint needs Go ≥ 1.25.8; the dev container has 1.25.0, so
-      this is CI-verified.
+      the CI `lint` job is the verifier, green on main.
 
 ## Implementation Notes
 


### PR DESCRIPTION
## Summary

Bookkeeping closeout for the cuelite/WASM umbrella. PR #576 (plan 247) merged the tinygo build-tag seams and made the `tinygo-wasm` CI job enforcing, which checked the last implementation criterion on plans 218 and 240. The only remaining open criterion on both — golangci-lint — is verified by the green CI `lint` job (the dev container's Go 1.25.0 cannot run it locally).

- `plan/218_wasm-size-reduction.md`: lint criterion → checked, `status:` → ✅
- `plan/240_cuelite-drop-cue.md`: lint criterion → checked, `status:` → ✅
- `PLAN.md` catalog regenerated

With this, the whole plan-218 umbrella (phases 236–240 plus follow-up 247) is recorded complete. `mdsmith check .` passes on all 459 files.

https://claude.ai/code/session_01LkXAFkv3U2K7Bcmz6dDS62

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkXAFkv3U2K7Bcmz6dDS62)_