### PR TITLE
docs: recommend mise github backend over deprecated ubi

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,7 @@ row: "- [{summary}](../{filename})"
 - [Per-platform mdsmith binaries plus the .vsix, the checksum file, and a Sigstore signature, attached to a tag-named release.](../docs/development/release-channels/github-releases.md)
 - [`go install` compiles mdsmith from the tagged module source with the host Go 1.25+ toolchain; no prebuilt binary is downloaded.](../docs/development/release-channels/go.md)
 - [The `jeduden/homebrew-mdsmith` tap installs the checksum-verified prebuilt binary for macOS or Linux on Intel or arm64.](../docs/development/release-channels/homebrew.md)
-- [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](../docs/development/release-channels/mise.md)
+- [mise's `github` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](../docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](../docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](../docs/development/release-channels/npx.md)
 - [A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](../docs/development/release-channels/obsidian.md)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -741,7 +741,7 @@ jobs:
             run: mdsmith version
           - channel: mise
             container: jdxcode/mise:latest
-            # `ubi:jeduden/mdsmith@VER` resolves the binary directly
+            # `github:jeduden/mdsmith@VER` resolves the binary directly
             # off the GitHub release the same `release` job above
             # just published. The shorter `mdsmith@VER` form depends
             # on the mise-plugins/registry follow-up; until that PR
@@ -750,7 +750,7 @@ jobs:
             install: |
               ok=0
               for attempt in 1 2 3 4 5; do
-                if mise use -g "ubi:jeduden/mdsmith@${VERSION#v}"; then
+                if mise use -g "github:jeduden/mdsmith@${VERSION#v}"; then
                   ok=1; break
                 fi
                 sleep 15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ row: "- [{summary}]({filename})"
 - [Per-platform mdsmith binaries plus the .vsix, the checksum file, and a Sigstore signature, attached to a tag-named release.](docs/development/release-channels/github-releases.md)
 - [`go install` compiles mdsmith from the tagged module source with the host Go 1.25+ toolchain; no prebuilt binary is downloaded.](docs/development/release-channels/go.md)
 - [The `jeduden/homebrew-mdsmith` tap installs the checksum-verified prebuilt binary for macOS or Linux on Intel or arm64.](docs/development/release-channels/homebrew.md)
-- [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
+- [mise's `github` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](docs/development/release-channels/npx.md)
 - [A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ row: "- [{summary}]({filename})"
 - [Per-platform mdsmith binaries plus the .vsix, the checksum file, and a Sigstore signature, attached to a tag-named release.](docs/development/release-channels/github-releases.md)
 - [`go install` compiles mdsmith from the tagged module source with the host Go 1.25+ toolchain; no prebuilt binary is downloaded.](docs/development/release-channels/go.md)
 - [The `jeduden/homebrew-mdsmith` tap installs the checksum-verified prebuilt binary for macOS or Linux on Intel or arm64.](docs/development/release-channels/homebrew.md)
-- [mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
+- [mise's `github` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.](docs/development/release-channels/mise.md)
 - [Root `@mdsmith/cli` plus one platform-specific subpackage per supported host, all published via OIDC Trusted Publishing.](docs/development/release-channels/npm.md)
 - [`npx @mdsmith/cli` runs mdsmith from the npm package with no global install, caching the platform binary after first use.](docs/development/release-channels/npx.md)
 - [A `mdsmith-obsidian-<version>.zip` of the plugin's five load files — the WebAssembly engine among them — attached to each GitHub release and installed by unzipping into a vault's `.obsidian/plugins/mdsmith/` folder.](docs/development/release-channels/obsidian.md)

--- a/docs/development/release-channels/mise.md
+++ b/docs/development/release-channels/mise.md
@@ -1,12 +1,12 @@
 ---
 title: mise
 summary: >-
-  mise's `ubi` backend installs mdsmith from GitHub
+  mise's `github` backend installs mdsmith from GitHub
   release assets; the short `mise use mdsmith` form
   awaits a registry entry.
 mechanism: pull
 artifact: cli
-command: mise use -g ubi:jeduden/mdsmith@latest
+command: mise use github:jeduden/mdsmith
 audience: Repos using mise; works today via GitHub releases
 platforms: [macos, linux]
 channelurl: https://mise.jdx.dev/
@@ -16,9 +16,11 @@ weight: 8
 
 Release page: <https://mise.jdx.dev/>
 
-mise installs mdsmith through its `ubi` backend, which
-reads the GitHub release assets directly. The
-`ubi:jeduden/mdsmith` form works today with no
-registry entry. The short `mise use mdsmith@latest`
+mise installs mdsmith through its `github` backend,
+which reads the GitHub release assets directly. The
+`github:jeduden/mdsmith` form works today with no
+registry entry. The older `ubi:jeduden/mdsmith` form
+still resolves, but mise has deprecated the `ubi`
+backend. The short `mise use mdsmith@latest`
 form needs the registry entry tracked in
 [plan/145](../../../plan/145_asdf-mise-registry-submissions.md).

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -59,7 +59,7 @@ row: "| {title} | `{command}` | {audience} |"
 | uvx             | `uvx mdsmith check .`                                                                                                                     | Ephemeral runs via uv                             |
 | pipx            | `pipx install mdsmith`                                                                                                                    | Isolated CLI install on Python hosts              |
 | Homebrew        | `brew install jeduden/mdsmith/mdsmith`                                                                                                    | macOS and Linux via Homebrew                      |
-| mise            | `mise use -g ubi:jeduden/mdsmith@latest`                                                                                                  | Repos using mise; works today via GitHub releases |
+| mise            | `mise use github:jeduden/mdsmith`                                                                                                         | Repos using mise; works today via GitHub releases |
 | asdf            | `asdf plugin add mdsmith https://github.com/jeduden/asdf-mdsmith.git`                                                                     | Repos standardized on asdf                        |
 | GitHub Releases | `curl -LO https://github.com/jeduden/mdsmith/releases/latest/download/mdsmith-<os>-<arch>`                                                | Air-gapped hosts and direct binary control        |
 | Scoop           | `scoop install mdsmith`                                                                                                                   | Windows users with Scoop installed                |
@@ -164,7 +164,7 @@ brew install mdsmith
 ## mise
 
 ```bash
-mise use -g github:jeduden/mdsmith
+mise use github:jeduden/mdsmith
 mdsmith version
 ```
 
@@ -178,21 +178,21 @@ To reuse the same plugin the asdf install uses:
 
 ```bash
 mise plugins install mdsmith https://github.com/jeduden/asdf-mdsmith.git
-mise use -g mdsmith@latest
+mise use mdsmith@latest
 ```
 
 To build from source with the Go backend (needs a Go
 toolchain):
 
 ```bash
-mise use -g go:github.com/jeduden/mdsmith/cmd/mdsmith
+mise use go:github.com/jeduden/mdsmith/cmd/mdsmith
 ```
 
 The `ubi` backend still works too, though mise has deprecated
 it for new registry entries:
 
 ```bash
-mise use -g ubi:jeduden/mdsmith@latest
+mise use ubi:jeduden/mdsmith@latest
 ```
 
 The one gap is a bare `mise use mdsmith@latest`: no backend

--- a/website/data/channels.yaml
+++ b/website/data/channels.yaml
@@ -90,10 +90,10 @@
   url: https://github.com/jeduden/homebrew-mdsmith
   weight: 7
 - title: mise
-  summary: mise's `ubi` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.
+  summary: mise's `github` backend installs mdsmith from GitHub release assets; the short `mise use mdsmith` form awaits a registry entry.
   mechanism: pull
   artifact: cli
-  command: mise use -g ubi:jeduden/mdsmith@latest
+  command: mise use github:jeduden/mdsmith
   audience: Repos using mise; works today via GitHub releases
   platforms:
     - macos


### PR DESCRIPTION
## Summary

mise has deprecated the `ubi` backend, so the recommended install command becomes `mise use github:jeduden/mdsmith`.

- **`docs/development/release-channels/mise.md`** (source of truth for the install table and website picker): `command:` is now `mise use github:jeduden/mdsmith`; summary and body describe the `github` backend, with `ubi` noted as still resolving but deprecated.
- **Regenerated** `website/data/channels.yaml` (`mdsmith-release sync-channels`) and the catalog rows in `docs/guides/install.md`, `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` (`mdsmith fix .`).
- **`docs/guides/install.md`**: the manual mise section's commands drop `-g` so they match the canonical repo-local form.
- **`.github/workflows/release.yml`**: the mise smoke-test installs via `github:jeduden/mdsmith@VER` instead of `ubi:…`, so the release gate verifies the path the docs now recommend. (Flagging for review since it changes what the next release exercises.)

The short bare `mise use mdsmith` form still awaits the registry entry tracked in plan/145 — that note is unchanged.

## Verification

- `go run ./cmd/mdsmith check .` — clean
- `go run ./cmd/mdsmith-release sync-channels --check` — no drift
- `go test ./internal/release/... ./cmd/mdsmith-release/...` — pass

https://claude.ai/code/session_012AqdD29MNm67HddWYVHXvC

---
_Generated by [Claude Code](https://claude.ai/code/session_012AqdD29MNm67HddWYVHXvC)_