### PR TITLE
perf: five high-performance-go fixes — map[K]struct{}, pre-sized slices, O(n) alloc removal

### DIFF
--- a/internal/rules/blanklinearoundheadings/alloc_test.go
+++ b/internal/rules/blanklinearoundheadings/alloc_test.go
@@ -1,0 +1,66 @@
+package blanklinearoundheadings
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// fixAllocBudget is the maximum heap allocations Fix may perform on a
+// small document that requires blank-line insertions. The budget
+// accounts for two set maps (insertBefore/insertAfter), the
+// CollectCodeBlockLines memo, the AST-walk closure, one pre-sized
+// result slice, and the bytes.Join output. The previous O(n)
+// string([]byte) per-line conversion pattern allocated ~23 objects for
+// the 6-line fixture; the refactored code targets ≤ 8.
+const fixAllocBudget = 8
+
+// fixAllocFixture is a 6-line document that requires four blank-line
+// insertions so the Fix path exercises all insertion branches.
+const fixAllocFixture = "# Title\nSome text\n## Section\nMore text\n## Final\nEnd.\n"
+
+func TestFixAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race; the race detector perturbs allocation counts")
+	}
+	src := []byte(fixAllocFixture)
+	r := &Rule{}
+
+	// Warm: ensure no first-run overhead charges to the measured frame.
+	warm, err := lint.NewFile("warm.md", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Fix(warm)
+
+	const runs = 100
+	parse := testing.AllocsPerRun(runs, func() {
+		f, err := lint.NewFile("parse.md", src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = f
+	})
+	full := testing.AllocsPerRun(runs, func() {
+		f, err := lint.NewFile("fix.md", src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = r.Fix(f)
+	})
+	delta := full - parse
+	if delta < 0 {
+		delta = 0
+	}
+	t.Logf("Fix allocs/op = %.1f (budget = %d)", delta, fixAllocBudget)
+	if delta > float64(fixAllocBudget) {
+		t.Fatalf(
+			"Fix allocs/op = %.1f exceeds budget %d; "+
+				"check for O(n) string([]byte) per-line conversions in Fix "+
+				"(docs/development/high-performance-go.md §Strings and bytes)",
+			delta, fixAllocBudget)
+	}
+}

--- a/internal/rules/blanklinearoundheadings/race_off_test.go
+++ b/internal/rules/blanklinearoundheadings/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package blanklinearoundheadings
+
+const raceEnabled = false

--- a/internal/rules/blanklinearoundheadings/race_on_test.go
+++ b/internal/rules/blanklinearoundheadings/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package blanklinearoundheadings
+
+const raceEnabled = true

--- a/internal/rules/blanklinearoundheadings/rule.go
+++ b/internal/rules/blanklinearoundheadings/rule.go
@@ -2,7 +2,6 @@ package blanklinearoundheadings
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -13,6 +12,10 @@ import (
 func init() {
 	rule.Register(&Rule{})
 }
+
+// newlineSep is the bytes.Join separator; a package-level var avoids
+// a heap allocation for []byte("\n") on every Fix call.
+var newlineSep = []byte("\n")
 
 // Rule checks that headings have blank lines before and after them.
 type Rule struct{}
@@ -103,42 +106,38 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return f.Source
 	}
 
-	lines := make([]string, len(f.Lines))
-	for i, l := range f.Lines {
-		lines[i] = string(l)
-	}
-
-	var result []string
-	for i, line := range lines {
+	// Pre-size to avoid growth allocations; worst case each line gets a
+	// blank before and after. Work directly with []byte to avoid the
+	// O(n) string([]byte) conversion that the previous string-join path
+	// paid for every line in the document.
+	result := make([][]byte, 0, len(f.Lines)+len(insertBefore)+len(insertAfter))
+	for i, line := range f.Lines {
 		lineNum := i + 1
-		if insertBefore[lineNum] {
+		if _, ok := insertBefore[lineNum]; ok {
 			// Avoid inserting a blank line if one was just inserted
 			// after the previous line (prevents double blank lines).
-			if !insertAfter[lineNum-1] {
-				result = append(result, "")
+			if _, ok2 := insertAfter[lineNum-1]; !ok2 {
+				result = append(result, nil)
 			}
 		}
 		result = append(result, line)
-		if insertAfter[lineNum] {
-			result = append(result, "")
+		if _, ok := insertAfter[lineNum]; ok {
+			result = append(result, nil)
 		}
 	}
 
-	return []byte(strings.Join(result, "\n"))
+	return bytes.Join(result, newlineSep)
 }
 
 // collectHeadingBlankLineInsertions walks the AST and returns sets of 1-based
-// line numbers that need a blank line inserted before or after them.
-func collectHeadingBlankLineInsertions(f *lint.File) (insertBefore, insertAfter map[int]bool) {
-	insertBefore = make(map[int]bool)
-	insertAfter = make(map[int]bool)
+// line numbers that need a blank line inserted before or after them. Insertion
+// decisions are made directly inside the walk to avoid an intermediate slice
+// and its growth allocations.
+func collectHeadingBlankLineInsertions(f *lint.File) (insertBefore, insertAfter map[int]struct{}) {
+	insertBefore = make(map[int]struct{})
+	insertAfter = make(map[int]struct{})
 	codeLines := lint.CollectCodeBlockLines(f)
-
-	type headingInfo struct {
-		line     int
-		lastLine int
-	}
-	var headings []headingInfo
+	lines := f.Lines
 
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -152,19 +151,15 @@ func collectHeadingBlankLineInsertions(f *lint.File) (insertBefore, insertAfter 
 		if _, ok := codeLines[line]; ok {
 			return ast.WalkContinue, nil
 		}
-		headings = append(headings, headingInfo{line: line, lastLine: headingLastLine(heading, f)})
+		lastLine := headingLastLine(heading, f)
+		if line > 1 && isNonBlankLine(lines, line-2) {
+			insertBefore[line] = struct{}{}
+		}
+		if isNonBlankLine(lines, lastLine) {
+			insertAfter[lastLine] = struct{}{}
+		}
 		return ast.WalkContinue, nil
 	})
-
-	lines := f.Lines
-	for _, h := range headings {
-		if h.line > 1 && isNonBlankLine(lines, h.line-2) {
-			insertBefore[h.line] = true
-		}
-		if isNonBlankLine(lines, h.lastLine) {
-			insertAfter[h.lastLine] = true
-		}
-	}
 
 	return insertBefore, insertAfter
 }

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -826,6 +826,8 @@ func resolveGlobMatchesFrom(res globResolution, f *lint.File, params map[string]
 		base = ""
 	}
 
+	// 8 is a rough heuristic: each glob pattern typically matches several
+	// files, so pre-sizing avoids the first few growth doublings.
 	seen := make(map[string]struct{}, len(res.includes)*8)
 	var files []string
 	for _, pattern := range res.includes {

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -826,7 +826,7 @@ func resolveGlobMatchesFrom(res globResolution, f *lint.File, params map[string]
 		base = ""
 	}
 
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{}, len(res.includes)*8)
 	var files []string
 	for _, pattern := range res.includes {
 		matches, err := doublestar.Glob(res.fs, pattern)
@@ -834,7 +834,7 @@ func resolveGlobMatchesFrom(res globResolution, f *lint.File, params map[string]
 			continue
 		}
 		for _, m := range matches {
-			if seen[m] {
+			if _, ok := seen[m]; ok {
 				continue
 			}
 			info, err := fs.Stat(res.fs, m)
@@ -847,7 +847,7 @@ func resolveGlobMatchesFrom(res globResolution, f *lint.File, params map[string]
 			if matcher != nil && base != "" && isGitignored(matcher, base, m) {
 				continue
 			}
-			seen[m] = true
+			seen[m] = struct{}{}
 			files = append(files, m)
 		}
 	}
@@ -1543,11 +1543,11 @@ func (r *Rule) checkCaseMismatches(f *lint.File) []lint.Diagnostic {
 // referenced by {field} placeholders in a row template string.
 func extractPlaceholderFields(row string) []string {
 	all := fieldinterp.Fields(row)
-	seen := make(map[string]bool, len(all))
+	seen := make(map[string]struct{}, len(all))
 	var fields []string
 	for _, name := range all {
-		if !seen[name] {
-			seen[name] = true
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
 			fields = append(fields, name)
 		}
 	}

--- a/internal/rules/recipesafety/rule.go
+++ b/internal/rules/recipesafety/rule.go
@@ -13,22 +13,22 @@ import (
 
 // shellInterpreters is the set of first-token values that indicate a shell
 // interpreter.
-var shellInterpreters = map[string]bool{
-	"sh":            true,
-	"bash":          true,
-	"zsh":           true,
-	"ksh":           true,
-	"fish":          true,
-	"/bin/sh":       true,
-	"/bin/bash":     true,
-	"/bin/zsh":      true,
-	"/bin/ksh":      true,
-	"/bin/fish":     true,
-	"/usr/bin/sh":   true,
-	"/usr/bin/bash": true,
-	"/usr/bin/zsh":  true,
-	"/usr/bin/ksh":  true,
-	"/usr/bin/fish": true,
+var shellInterpreters = map[string]struct{}{
+	"sh":            {},
+	"bash":          {},
+	"zsh":           {},
+	"ksh":           {},
+	"fish":          {},
+	"/bin/sh":       {},
+	"/bin/bash":     {},
+	"/bin/zsh":      {},
+	"/bin/ksh":      {},
+	"/bin/fish":     {},
+	"/usr/bin/sh":   {},
+	"/usr/bin/bash": {},
+	"/usr/bin/zsh":  {},
+	"/usr/bin/ksh":  {},
+	"/usr/bin/fish": {},
 }
 
 // shellOperators are substrings that indicate shell pipeline/redirection when
@@ -222,16 +222,16 @@ func (r *Rule) checkRecipe(filePath, name string, rec recipe) []lint.Diagnostic 
 // (inputs, outputs) declared in params.required or params.optional.
 // Results are in reservedParamNames (alphabetical) order.
 func (r *Rule) checkReservedParams(filePath, name string, rec recipe) []lint.Diagnostic {
-	declared := make(map[string]bool, len(rec.Required)+len(rec.Optional))
+	declared := make(map[string]struct{}, len(rec.Required)+len(rec.Optional))
 	for _, p := range rec.Required {
-		declared[p] = true
+		declared[p] = struct{}{}
 	}
 	for _, p := range rec.Optional {
-		declared[p] = true
+		declared[p] = struct{}{}
 	}
 	var diags []lint.Diagnostic
 	for _, reserved := range reservedParamNames {
-		if declared[reserved] {
+		if _, ok := declared[reserved]; ok {
 			diags = append(diags, r.diag(filePath, lint.Error,
 				fmt.Sprintf("recipe %q: reserved parameter name %q must not be declared in params",
 					name, reserved)))
@@ -242,7 +242,7 @@ func (r *Rule) checkReservedParams(filePath, name string, rec recipe) []lint.Dia
 
 func (r *Rule) checkExecutable(filePath, name, exe string) []lint.Diagnostic {
 	var diags []lint.Diagnostic
-	if shellInterpreters[exe] {
+	if _, ok := shellInterpreters[exe]; ok {
 		diags = append(diags, r.diag(filePath, lint.Error,
 			fmt.Sprintf("recipe %q: command uses shell interpreter %q — use the direct binary",
 				name, exe)))
@@ -316,25 +316,26 @@ func isReservedParamName(name string) bool {
 }
 
 func (r *Rule) checkUnusedParams(filePath, name string, rec recipe) []lint.Diagnostic {
-	declared := make(map[string]bool)
+	declared := make(map[string]struct{}, len(rec.Required)+len(rec.Optional))
 	for _, p := range rec.Required {
-		declared[p] = true
+		declared[p] = struct{}{}
 	}
 	for _, p := range rec.Optional {
-		declared[p] = true
+		declared[p] = struct{}{}
 	}
 	// Reserved names are reported by checkReservedParams; don't also
 	// flag them here as unreferenced.
 	for _, reserved := range reservedParamNames {
 		delete(declared, reserved)
 	}
-	used := make(map[string]bool)
-	for _, m := range placeholderRe.FindAllStringSubmatch(rec.Command, -1) {
-		used[m[1]] = true
+	cmdMatches := placeholderRe.FindAllStringSubmatch(rec.Command, -1)
+	used := make(map[string]struct{}, len(cmdMatches))
+	for _, m := range cmdMatches {
+		used[m[1]] = struct{}{}
 	}
 	var unused []string
 	for p := range declared {
-		if !used[p] {
+		if _, ok := used[p]; !ok {
 			unused = append(unused, p)
 		}
 	}

--- a/internal/schema/acronyms.go
+++ b/internal/schema/acronyms.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 // acronymToken matches all-caps alphanumeric tokens of length 2-6.
@@ -36,10 +37,11 @@ func ValidateAcronyms(
 		return nil
 	}
 	a := sch.Acronyms
-	known := buildKnownSet(a.KnownSafe)
+	known := setutil.FromStrings(a.KnownSafe)
 
-	headingLines := documentHeadingLines(f)
-	ranges := acronymRanges(f, sch, a.Scope, docFM)
+	heads := ExtractDocHeadings(f)
+	headingLines := documentHeadingLines(heads)
+	ranges := acronymRanges(heads, f, sch, a.Scope, docFM)
 	var diags []lint.Diagnostic
 	for _, rng := range ranges {
 		diags = append(diags, checkAcronymsInRange(f, rng, known, headingLines, mkDiag)...)
@@ -48,23 +50,14 @@ func ValidateAcronyms(
 }
 
 // documentHeadingLines returns the set of 1-based line numbers
-// occupied by Markdown headings in f. Used to skip heading lines
+// occupied by Markdown headings. Used to skip heading lines
 // during acronym scans so a "## OIDC configuration" heading does
 // not consume the "first use" slot before the body's
 // parenthesised expansion.
-func documentHeadingLines(f *lint.File) map[int]struct{} {
-	heads := ExtractDocHeadings(f)
+func documentHeadingLines(heads []DocHeading) map[int]struct{} {
 	out := make(map[int]struct{}, len(heads))
 	for _, h := range heads {
 		out[h.Line] = struct{}{}
-	}
-	return out
-}
-
-func buildKnownSet(list []string) map[string]struct{} {
-	out := make(map[string]struct{}, len(list))
-	for _, s := range list {
-		out[s] = struct{}{}
 	}
 	return out
 }
@@ -83,18 +76,14 @@ type lineRange struct {
 // unbounded) contributes a range for each matched heading, so a
 // scope name like "Diagnosis" applied to two `## Diagnosis`
 // sections scans both bodies for first-use acronyms.
-func acronymRanges(f *lint.File, sch *Schema, scope []string, docFM map[string]any) []lineRange {
+func acronymRanges(heads []DocHeading, f *lint.File, sch *Schema, scope []string, docFM map[string]any) []lineRange {
 	if len(scope) == 0 {
 		return []lineRange{{Start: 1, End: len(f.Lines) + 1}}
 	}
-	heads := ExtractDocHeadings(f)
 	rootLevel := sch.EffectiveRootLevel()
 	body := skipBelow(heads, rootLevel)
 
-	matchSet := make(map[string]struct{}, len(scope))
-	for _, s := range scope {
-		matchSet[s] = struct{}{}
-	}
+	matchSet := setutil.FromStrings(scope)
 
 	var out []lineRange
 	walkRanges(sch.Sections, body, rootLevel, 1, len(f.Lines)+1, docFM,

--- a/internal/schema/acronyms.go
+++ b/internal/schema/acronyms.go
@@ -52,18 +52,19 @@ func ValidateAcronyms(
 // during acronym scans so a "## OIDC configuration" heading does
 // not consume the "first use" slot before the body's
 // parenthesised expansion.
-func documentHeadingLines(f *lint.File) map[int]bool {
-	out := map[int]bool{}
-	for _, h := range ExtractDocHeadings(f) {
-		out[h.Line] = true
+func documentHeadingLines(f *lint.File) map[int]struct{} {
+	heads := ExtractDocHeadings(f)
+	out := make(map[int]struct{}, len(heads))
+	for _, h := range heads {
+		out[h.Line] = struct{}{}
 	}
 	return out
 }
 
-func buildKnownSet(list []string) map[string]bool {
-	out := make(map[string]bool, len(list))
+func buildKnownSet(list []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(list))
 	for _, s := range list {
-		out[s] = true
+		out[s] = struct{}{}
 	}
 	return out
 }
@@ -90,9 +91,9 @@ func acronymRanges(f *lint.File, sch *Schema, scope []string, docFM map[string]a
 	rootLevel := sch.EffectiveRootLevel()
 	body := skipBelow(heads, rootLevel)
 
-	matchSet := make(map[string]bool, len(scope))
+	matchSet := make(map[string]struct{}, len(scope))
 	for _, s := range scope {
-		matchSet[s] = true
+		matchSet[s] = struct{}{}
 	}
 
 	var out []lineRange
@@ -111,11 +112,13 @@ func acronymRanges(f *lint.File, sch *Schema, scope []string, docFM map[string]a
 			// not checked separately — the parser sets
 			// `sc.Heading == sc.Matcher.Regex` for mapping-form
 			// entries, so (b) already covers it.
-			if matchSet[headingText] {
+			_, inText := matchSet[headingText]
+			_, inHeading := matchSet[sc.Heading]
+			if inText {
 				out = append(out, lineRange{Start: start, End: end})
 				return
 			}
-			if matchSet[sc.Heading] {
+			if inHeading {
 				out = append(out, lineRange{Start: start, End: end})
 				return
 			}
@@ -170,13 +173,13 @@ func nextSectionLine(heads []DocHeading, idx, level, parentEnd int) int {
 }
 
 func checkAcronymsInRange(
-	f *lint.File, rng lineRange, known map[string]bool,
-	headingLines map[int]bool, mkDiag MakeDiag,
+	f *lint.File, rng lineRange, known map[string]struct{},
+	headingLines map[int]struct{}, mkDiag MakeDiag,
 ) []lint.Diagnostic {
-	seen := map[string]bool{}
+	seen := map[string]struct{}{}
 	var diags []lint.Diagnostic
 	for ln := rng.Start; ln < rng.End && ln-1 < len(f.Lines); ln++ {
-		if headingLines[ln] {
+		if _, ok := headingLines[ln]; ok {
 			continue
 		}
 		// Use the raw []byte slice directly to avoid a whole-line string
@@ -187,10 +190,12 @@ func checkAcronymsInRange(
 		matches := acronymToken.FindAllIndex(lineBytes, -1)
 		for _, m := range matches {
 			tok := string(lineBytes[m[0]:m[1]])
-			if known[tok] || seen[tok] {
+			_, inKnown := known[tok]
+			_, inSeen := seen[tok]
+			if inKnown || inSeen {
 				continue
 			}
-			seen[tok] = true
+			seen[tok] = struct{}{}
 			if hasParenExpansion(lineBytes, m[1]) {
 				continue
 			}

--- a/internal/schema/crossrefs.go
+++ b/internal/schema/crossrefs.go
@@ -102,8 +102,8 @@ func collectTextNodes(f *lint.File) []textNode {
 // documentSlugSet returns the set of heading slugs present in f. The
 // slugifier matches mdtext.Slugify; duplicates collapse to one entry
 // because the cross-reference resolver only needs membership.
-func documentSlugSet(f *lint.File) map[string]bool {
-	out := map[string]bool{}
+func documentSlugSet(f *lint.File) map[string]struct{} {
+	out := map[string]struct{}{}
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
@@ -115,7 +115,7 @@ func documentSlugSet(f *lint.File) map[string]bool {
 		text := mdtext.ExtractPlainText(h, f.Source)
 		slug := mdtext.Slugify(text)
 		if slug != "" {
-			out[slug] = true
+			out[slug] = struct{}{}
 		}
 		return ast.WalkContinue, nil
 	})
@@ -124,7 +124,7 @@ func documentSlugSet(f *lint.File) map[string]bool {
 
 func checkCrossRef(
 	f *lint.File, cr CrossRef, re, skipRE *regexp.Regexp,
-	slugs map[string]bool, texts []textNode, mkDiag MakeDiag,
+	slugs map[string]struct{}, texts []textNode, mkDiag MakeDiag,
 ) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	groupNames := re.SubexpNames()
@@ -143,7 +143,8 @@ func checkCrossRef(
 				continue
 			}
 			slug := mdtext.Slugify(target)
-			if slug == "" || !slugs[slug] {
+			_, ok := slugs[slug]
+			if slug == "" || !ok {
 				diags = append(diags, mkDiag(f.Path, tn.Line,
 					fmt.Sprintf(
 						"cross-reference %q does not resolve to a heading (looked for %q)",

--- a/internal/schema/perf_settype_test.go
+++ b/internal/schema/perf_settype_test.go
@@ -20,10 +20,11 @@ func TestDocumentHeadingLinesReturnsStructSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	heads := ExtractDocHeadings(f)
 	// Compile-time check: the blank func call enforces the exact type without
 	// triggering QF1011; if documentHeadingLines returned map[int]bool, this
 	// would not compile.
-	got := documentHeadingLines(f)
+	got := documentHeadingLines(heads)
 	func(_ map[int]struct{}) {}(got)
 	if _, ok := got[1]; !ok {
 		t.Fatal("expected line 1 (# Title) in heading-line set")
@@ -33,21 +34,6 @@ func TestDocumentHeadingLinesReturnsStructSet(t *testing.T) {
 	}
 	if _, ok := got[2]; ok {
 		t.Fatal("did not expect blank line 2 in heading-line set")
-	}
-}
-
-func TestBuildKnownSetReturnsStructSet(t *testing.T) {
-	got := buildKnownSet([]string{"A", "B"})
-	// Compile-time check (see package doc above).
-	func(_ map[string]struct{}) {}(got)
-	if _, ok := got["A"]; !ok {
-		t.Fatal("expected A in known set")
-	}
-	if _, ok := got["B"]; !ok {
-		t.Fatal("expected B in known set")
-	}
-	if _, ok := got["C"]; ok {
-		t.Fatal("did not expect C in known set")
 	}
 }
 

--- a/internal/schema/perf_settype_test.go
+++ b/internal/schema/perf_settype_test.go
@@ -1,0 +1,57 @@
+package schema
+
+// TestSetTypesAreStructNotBool documents the project's map[K]struct{}
+// convention (docs/development/high-performance-go.md §Data structures)
+// for the set-typed maps in this package. Each variable assignment below
+// is a compile-time assertion: the test will not compile if the named
+// function returns map[K]bool instead of map[K]struct{}.
+//
+// Run: go test -run TestSetTypesAreStructNotBool ./internal/schema/
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+func TestDocumentHeadingLinesReturnsStructSet(t *testing.T) {
+	src := []byte("# Title\n\n## Section\n")
+	f, err := lint.NewFile("t.md", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compile-time check: documentHeadingLines must return map[int]struct{}.
+	var _ map[int]struct{} = documentHeadingLines(f)
+}
+
+func TestBuildKnownSetReturnsStructSet(t *testing.T) {
+	// Compile-time check: buildKnownSet must return map[string]struct{}.
+	var _ map[string]struct{} = buildKnownSet([]string{"A", "B"})
+	got := buildKnownSet([]string{"A", "B"})
+	if _, ok := got["A"]; !ok {
+		t.Fatal("expected A in known set")
+	}
+	if _, ok := got["B"]; !ok {
+		t.Fatal("expected B in known set")
+	}
+	if _, ok := got["C"]; ok {
+		t.Fatal("did not expect C in known set")
+	}
+}
+
+func TestDocumentSlugSetReturnsStructSet(t *testing.T) {
+	src := []byte("# Hello World\n\n## Another Heading\n")
+	f, err := lint.NewFile("t.md", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compile-time check: documentSlugSet must return map[string]struct{}.
+	var _ map[string]struct{} = documentSlugSet(f)
+	got := documentSlugSet(f)
+	if _, ok := got["hello-world"]; !ok {
+		t.Fatalf("expected slug hello-world in set, got %v", got)
+	}
+	if _, ok := got["another-heading"]; !ok {
+		t.Fatalf("expected slug another-heading in set, got %v", got)
+	}
+}

--- a/internal/schema/perf_settype_test.go
+++ b/internal/schema/perf_settype_test.go
@@ -2,9 +2,9 @@ package schema
 
 // TestSetTypesAreStructNotBool documents the project's map[K]struct{}
 // convention (docs/development/high-performance-go.md §Data structures)
-// for the set-typed maps in this package. Each variable assignment below
-// is a compile-time assertion: the test will not compile if the named
-// function returns map[K]bool instead of map[K]struct{}.
+// for the set-typed maps in this package. Each function call below is a
+// compile-time assertion: the test will not compile if the named function
+// returns map[K]bool instead of map[K]struct{}.
 //
 // Run: go test -run TestSetTypesAreStructNotBool ./internal/schema/
 
@@ -20,14 +20,26 @@ func TestDocumentHeadingLinesReturnsStructSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Compile-time check: documentHeadingLines must return map[int]struct{}.
-	var _ map[int]struct{} = documentHeadingLines(f)
+	// Compile-time check: the blank func call enforces the exact type without
+	// triggering QF1011; if documentHeadingLines returned map[int]bool, this
+	// would not compile.
+	got := documentHeadingLines(f)
+	func(_ map[int]struct{}) {}(got)
+	if _, ok := got[1]; !ok {
+		t.Fatal("expected line 1 (# Title) in heading-line set")
+	}
+	if _, ok := got[3]; !ok {
+		t.Fatal("expected line 3 (## Section) in heading-line set")
+	}
+	if _, ok := got[2]; ok {
+		t.Fatal("did not expect blank line 2 in heading-line set")
+	}
 }
 
 func TestBuildKnownSetReturnsStructSet(t *testing.T) {
-	// Compile-time check: buildKnownSet must return map[string]struct{}.
-	var _ map[string]struct{} = buildKnownSet([]string{"A", "B"})
 	got := buildKnownSet([]string{"A", "B"})
+	// Compile-time check (see package doc above).
+	func(_ map[string]struct{}) {}(got)
 	if _, ok := got["A"]; !ok {
 		t.Fatal("expected A in known set")
 	}
@@ -45,9 +57,9 @@ func TestDocumentSlugSetReturnsStructSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Compile-time check: documentSlugSet must return map[string]struct{}.
-	var _ map[string]struct{} = documentSlugSet(f)
 	got := documentSlugSet(f)
+	// Compile-time check (see package doc above).
+	func(_ map[string]struct{}) {}(got)
 	if _, ok := got["hello-world"]; !ok {
 		t.Fatalf("expected slug hello-world in set, got %v", got)
 	}


### PR DESCRIPTION
## Summary

Audit of the codebase against `docs/development/high-performance-go.md` identified five violations of the project's documented performance guidelines. Each fix follows red/green TDD: a failing test (alloc budget or compile-time type assertion) is written first, then the implementation.

### Fix 1 — `blanklinearoundheadings` Fix: O(n) `string([]byte)` allocations removed (23 → 8 allocs)

The previous `Fix` path allocated one heap object per source line (`string([]byte)` conversion) plus multiple growth copies of an unsized `[]string` result slice. An intermediate `headingInfo` slice also grew from nil inside the AST-walk closure.

**Changes:**
- Collapse collection and insertion logic into a single AST walk, eliminating the intermediate `headingInfo` slice and its growth allocs
- Replace `[]string` + `strings.Join` with a pre-sized `[][]byte` + `bytes.Join` (zero per-line string conversions; lines are already `[]byte`)
- Add package-level `newlineSep` to avoid a `[]byte("\n")` heap allocation on every `Fix` call
- Change `insertBefore`/`insertAfter` from `map[int]bool` to `map[int]struct{}`

**Gate:** `internal/rules/blanklinearoundheadings/alloc_test.go` — budget 8 allocs (fails at 23 without the fix)

### Fix 2 — `schema/crossrefs.go`: `documentSlugSet` `map[string]bool` → `map[string]struct{}`

`documentSlugSet` built a `map[string]bool` for slug-set membership in the per-file cross-reference validator. Updated to `map[string]struct{}` per the project's `map[K]struct{} for sets` guideline. Updated `checkCrossRef` signature and membership checks accordingly.

### Fix 3 — `schema/acronyms.go`: four `map[K]bool` set patterns → `map[K]struct{}`

`documentHeadingLines`, `buildKnownSet`, `matchSet` (in `acronymRanges`), and `seen` (in `checkAcronymsInRange`) all used `map[K]bool` as sets. All four changed to `map[K]struct{}`. `documentHeadingLines` also gains a capacity hint pre-sized to the heading count.

### Fix 4 — `catalog/rule.go` `resolveGlobMatchesFrom`: `seen` map — no capacity, bool type

`seen := make(map[string]bool)` had no capacity hint (causing rehash growth when a catalog glob returns many matches) and used `bool` as the value type. Changed to `map[string]struct{}` with an initial capacity estimate (`len(res.includes)*8`). Also fixed `extractPlaceholderFields`'s `seen` map for consistency.

### Fix 5 — `recipesafety/rule.go`: `map[string]bool` sets → `map[string]struct{}`

`shellInterpreters` (package-level) and the `declared`/`used` maps in `checkReservedParams` and `checkUnusedParams` all used `bool` as the value type. Changed to `map[string]struct{}`; `checkUnusedParams` gains capacity hints on both maps.

**Compile-time type tests** for fixes 2 and 3 live in `internal/schema/perf_settype_test.go` — they fail to compile against the pre-fix code.

## Guideline references

All fixes address violations documented in `docs/development/high-performance-go.md`:
- §Allocations: "Pre-size slices", "Return `nil`, not `[]T{}`"
- §Strings and bytes: "Stay in `[]byte`" — `string(b)` allocates and copies
- §Data structures: "`map[K]struct{}` for sets — zero-byte value type"

## Test plan

- [x] `go test ./internal/rules/blanklinearoundheadings/` — alloc gate passes at 8/8 (was 23)
- [x] `go test ./internal/schema/` — compile-time type tests pass; all existing schema tests pass
- [x] `go test ./internal/rules/catalog/ ./internal/rules/recipesafety/` — all existing tests pass
- [x] `go test ./...` — full suite green, no failures
- [x] `go vet ./...` — clean
- [x] `go run ./cmd/mdsmith check .` — 459 files checked, 0 failures

https://claude.ai/code/session_014H2Pu9nEiYrnbpGb3hLxxx

---
_Generated by [Claude Code](https://claude.ai/code/session_014H2Pu9nEiYrnbpGb3hLxxx)_