### PR TITLE
perf: follow-up fixes from code review of #585

### DIFF
--- a/internal/fix/source.go
+++ b/internal/fix/source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 // SourceOptions configures an in-memory fix run. The fix functions
@@ -106,10 +107,7 @@ func fixSourceImpl(opts SourceOptions, only []string) ([]byte, error) {
 		return nil, errors.Join(settingsErrs...)
 	}
 	if only != nil {
-		set := make(map[string]struct{}, len(only))
-		for _, n := range only {
-			set[n] = struct{}{}
-		}
+		set := setutil.FromStrings(only)
 		filtered := fixable[:0]
 		for _, r := range fixable {
 			if _, ok := set[r.Name()]; ok {

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/bytelimit"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 // readFile, atomicWriteFn, and lstatFile are variables so tests can substitute
@@ -371,8 +372,8 @@ func isClosingFence(line []byte, ch byte, openLen int) bool {
 // or hook script that lists the same path twice still compares equal
 // to a deduplicated list.
 func FilesMatch(a, b []string) bool {
-	setA := toSet(a)
-	setB := toSet(b)
+	setA := setutil.FromStrings(a)
+	setB := setutil.FromStrings(b)
 	if len(setA) != len(setB) {
 		return false
 	}
@@ -382,14 +383,6 @@ func FilesMatch(a, b []string) bool {
 		}
 	}
 	return true
-}
-
-func toSet(s []string) map[string]struct{} {
-	m := make(map[string]struct{}, len(s))
-	for _, v := range s {
-		m[v] = struct{}{}
-	}
-	return m
 }
 
 // ExtractHookFiles parses a pre-merge-commit hook script and returns

--- a/internal/rules/blanklinearoundfencedcode/rule.go
+++ b/internal/rules/blanklinearoundfencedcode/rule.go
@@ -2,13 +2,16 @@ package blanklinearoundfencedcode
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/fencepos"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 )
+
+// newlineSep is the bytes.Join separator; a package-level var avoids
+// a heap allocation for []byte("\n") on every Fix call.
+var newlineSep = []byte("\n")
 
 func init() {
 	rule.Register(&Rule{})
@@ -99,26 +102,26 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return f.Source
 	}
 
-	var result []string
+	result := make([][]byte, 0, len(f.Lines)+len(insertBeforeLine)+len(insertAfterLine))
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if insertBeforeLine[lineNum] {
-			result = append(result, "")
+		if _, ok := insertBeforeLine[lineNum]; ok {
+			result = append(result, nil)
 		}
-		result = append(result, string(line))
-		if insertAfterLine[lineNum] {
-			result = append(result, "")
+		result = append(result, line)
+		if _, ok := insertAfterLine[lineNum]; ok {
+			result = append(result, nil)
 		}
 	}
 
-	return []byte(strings.Join(result, "\n"))
+	return bytes.Join(result, newlineSep)
 }
 
 // collectFenceBlankLineInsertions walks the AST and returns sets of 1-based line
 // numbers that need a blank line inserted before or after them.
-func collectFenceBlankLineInsertions(f *lint.File) (beforeSet, afterSet map[int]bool) {
-	beforeSet = make(map[int]bool)
-	afterSet = make(map[int]bool)
+func collectFenceBlankLineInsertions(f *lint.File) (beforeSet, afterSet map[int]struct{}) {
+	beforeSet = make(map[int]struct{})
+	afterSet = make(map[int]struct{})
 
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -136,10 +139,10 @@ func collectFenceBlankLineInsertions(f *lint.File) (beforeSet, afterSet map[int]
 		closeLine := f.LineOfOffset(closeStart)
 
 		if needsBlankBefore(f, openLine) {
-			beforeSet[openLine] = true
+			beforeSet[openLine] = struct{}{}
 		}
 		if needsBlankAfter(f, closeLine) {
-			afterSet[closeLine] = true
+			afterSet[closeLine] = struct{}{}
 		}
 
 		return ast.WalkContinue, nil

--- a/internal/rules/blanklinearoundheadings/alloc_test.go
+++ b/internal/rules/blanklinearoundheadings/alloc_test.go
@@ -15,8 +15,11 @@ import (
 // the 6-line fixture; the refactored code targets ≤ 8.
 const fixAllocBudget = 8
 
-// fixAllocFixture is a 6-line document that requires four blank-line
-// insertions so the Fix path exercises all insertion branches.
+// fixAllocFixture is a 6-line document that requires five blank-line
+// insertions (insertAfter={1,3,5}, insertBefore={3,5}). The adjacent
+// dedup guard (suppressing insertBefore when insertAfter was set on
+// the previous line) is not triggered here — that path is exercised by
+// TestFix_AdjacentHeadings_NoDoubleBlanks in rule_test.go.
 const fixAllocFixture = "# Title\nSome text\n## Section\nMore text\n## Final\nEnd.\n"
 
 func TestFixAllocBudget(t *testing.T) {

--- a/internal/rules/blanklinearoundheadings/rule_test.go
+++ b/internal/rules/blanklinearoundheadings/rule_test.go
@@ -182,6 +182,21 @@ func TestCheckNode_HeadingInCodeBlockRegion(t *testing.T) {
 	assert.Nil(t, diags, "heading whose line falls inside a code-block region must be skipped")
 }
 
+// TestFix_NoTrailingNewline verifies that Fix preserves the absence of
+// a trailing newline. bytes.Join round-trips a Split that produces no
+// trailing empty element, so the output must not gain a spurious "\n".
+func TestFix_NoTrailingNewline(t *testing.T) {
+	src := []byte("# Title\nSome text")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{}
+	result := r.Fix(f)
+	expected := "# Title\n\nSome text"
+	if string(result) != expected {
+		t.Errorf("expected %q, got %q", expected, string(result))
+	}
+}
+
 // TestFix_HeadingInCodeBlockRegion pins the parallel guard
 // inside collectHeadingBlankLineInsertions (rule.go line ~153):
 // Fix must not insert blank lines around a synthetic heading

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -180,19 +180,17 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	beforeSet, afterSet := r.collectBlankLineInsertions(f)
 
 	if len(beforeSet) == 0 && len(afterSet) == 0 {
-		result := make([]byte, len(f.Source))
-		copy(result, f.Source)
-		return result
+		return f.Source
 	}
 
 	var resultLines [][]byte
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if beforeSet[lineNum] {
+		if _, ok := beforeSet[lineNum]; ok {
 			resultLines = append(resultLines, []byte{})
 		}
 		resultLines = append(resultLines, line)
-		if afterSet[lineNum] {
+		if _, ok := afterSet[lineNum]; ok {
 			resultLines = append(resultLines, []byte{})
 		}
 	}
@@ -202,9 +200,9 @@ func (r *Rule) Fix(f *lint.File) []byte {
 
 // collectBlankLineInsertions walks the AST and returns sets of 1-based line numbers
 // that need a blank line inserted before or after them.
-func (r *Rule) collectBlankLineInsertions(f *lint.File) (beforeSet, afterSet map[int]bool) {
-	beforeSet = make(map[int]bool)
-	afterSet = make(map[int]bool)
+func (r *Rule) collectBlankLineInsertions(f *lint.File) (beforeSet, afterSet map[int]struct{}) {
+	beforeSet = make(map[int]struct{})
+	afterSet = make(map[int]struct{})
 	codeLines := lint.CollectCodeBlockLines(f)
 
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -229,10 +227,10 @@ func (r *Rule) collectBlankLineInsertions(f *lint.File) (beforeSet, afterSet map
 		}
 
 		if needsBlankAdjacent(f, listStartLine, -1) {
-			beforeSet[listStartLine] = true
+			beforeSet[listStartLine] = struct{}{}
 		}
 		if needsBlankAdjacent(f, listEndLine, +1) {
-			afterSet[listEndLine] = true
+			afterSet[listEndLine] = struct{}{}
 		}
 
 		return ast.WalkContinue, nil

--- a/internal/rules/concisenessscoring/classifier/model.go
+++ b/internal/rules/concisenessscoring/classifier/model.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 // Embedded artifact metadata used for checksum and loading validation.
@@ -486,11 +488,7 @@ func dedupeSorted(values []string) []string {
 }
 
 func wordSetFromSlice(values []string) map[string]struct{} {
-	out := make(map[string]struct{}, len(values))
-	for _, v := range values {
-		out[v] = struct{}{}
-	}
-	return out
+	return setutil.FromStrings(values)
 }
 
 func sigmoid(x float64) float64 {

--- a/internal/schema/acronyms.go
+++ b/internal/schema/acronyms.go
@@ -101,13 +101,11 @@ func acronymRanges(heads []DocHeading, f *lint.File, sch *Schema, scope []string
 			// not checked separately — the parser sets
 			// `sc.Heading == sc.Matcher.Regex` for mapping-form
 			// entries, so (b) already covers it.
-			_, inText := matchSet[headingText]
-			_, inHeading := matchSet[sc.Heading]
-			if inText {
+			if _, ok := matchSet[headingText]; ok {
 				out = append(out, lineRange{Start: start, End: end})
 				return
 			}
-			if inHeading {
+			if _, ok := matchSet[sc.Heading]; ok {
 				out = append(out, lineRange{Start: start, End: end})
 				return
 			}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Follow-up to #585 (five high-performance-go fixes), addressing issues surfaced during the xhigh code review rounds that landed after the original PR was in the merge queue.

- **blanklinearoundfencedcode** (HIGH — same O(n) defect as #585): Fix() was still using `[]string + string([]byte)` per-line + `strings.Join`. Rewritten to `[][]byte + bytes.Join` with a package-level `newlineSep` var, matching the pattern already applied in blanklinearoundheadings. `collectFenceBlankLineInsertions` return type changed `map[int]bool` → `map[int]struct{}`.

- **blanklinearoundlists**: Fix() no-change path was allocating a full copy of `f.Source` (`make([]byte)+copy`); now returns `f.Source` directly (no-copy, same as the other two blank-line rules). `collectBlankLineInsertions` maps converted to `map[int]struct{}`.

- **schema/acronyms**: Restore short-circuit in `acronymRanges` — the previous refactor inadvertently changed `if matchSet[x] { return }` to pre-evaluate both `inText`/`inHeading` unconditionally (always two lookups, even when the first hit would have short-circuited). Reverted to sequential inline comma-ok form.

- **githooks, concisenessscoring/classifier, fix/source**: Replace `toSet`, `wordSetFromSlice`, and an inline set-building loop with `setutil.FromStrings` — the remaining duplicates the code review identified after #585 removed `buildKnownSet`.

- **alloc_test.go**: Fix incorrect comment (5 blank-line insertions, not 4; dedup guard exercised elsewhere).

- **rule_test.go**: Add `TestFix_NoTrailingNewline` — verifies `bytes.Join` does not add a spurious `\n` when the source has no trailing newline.

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] `go build ./...` — clean build
- [ ] CI lint check passes (no `map[K]bool` regressions in changed files)

https://claude.ai/code/session_014H2Pu9nEiYrnbpGb3hLxxx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014H2Pu9nEiYrnbpGb3hLxxx)_