### PR TITLE
feat(build): build execution hardening (trust gate, hermetic env, atomic write, post-conditions)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,6 +134,7 @@ row: "- [{summary}](../{filename})"
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](../docs/reference/cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](../docs/reference/cli/query.md)
 - [Rename a heading or link-reference label and rewrite every dependent edit.](../docs/reference/cli/rename.md)
+- [Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.](../docs/reference/cli/trust.md)
 - [Print the mdsmith build version and exit.](../docs/reference/cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](../docs/reference/convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](../docs/reference/conventions.md)

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,6 @@ cmd/mdsmith/default.pgo
 # cache, per-recipe staging dirs, and the per-clone build trust marker.
 .mdsmith/build-cache.json
 .mdsmith/build-staging/
-.mdsmith.yml.trust
+# The marker plus any crash-orphaned temp file from its atomic write
+# (.mdsmith.yml.trust.NNNN).
+.mdsmith.yml.trust*

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,13 @@ cmd/mdsmith/default.pgo
 
 # Build pass machine-local state (plan 2606101548): the incremental
 # cache, per-recipe staging dirs, and the per-clone build trust marker.
-.mdsmith/build-cache.json
+# The trailing-* forms also cover a crash-orphaned atomic-write temp file
+# (build-cache.json.NNNN.tmp / .mdsmith.yml.trust.NNNN.tmp).
+.mdsmith/build-cache.json*
 .mdsmith/build-staging/
-# The marker plus any crash-orphaned temp file from its atomic write
-# (.mdsmith.yml.trust.NNNN).
+# Trust markers are named after the loaded config, so cover both the
+# default and any custom config passed via `mdsmith fix -c <name>.yml`
+# (which writes <name>.yml.trust). Trust is per-clone — never commit it.
 .mdsmith.yml.trust*
+*.yml.trust
+*.yml.trust.*

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ website/static/img/demo.gif
 # profile burdens every merge with a repo-specific binary artifact.
 # See plan/ for wiring PGO into the release build instead.
 cmd/mdsmith/default.pgo
+
+# Build pass machine-local state (plan 2606101548): the incremental
+# cache, per-recipe staging dirs, and the per-clone build trust marker.
+.mdsmith/build-cache.json
+.mdsmith/build-staging/
+.mdsmith.yml.trust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ row: "- [{summary}]({filename})"
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](docs/reference/cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](docs/reference/cli/query.md)
 - [Rename a heading or link-reference label and rewrite every dependent edit.](docs/reference/cli/rename.md)
+- [Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.](docs/reference/cli/trust.md)
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](docs/reference/convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ row: "- [{summary}]({filename})"
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](docs/reference/cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](docs/reference/cli/query.md)
 - [Rename a heading or link-reference label and rewrite every dependent edit.](docs/reference/cli/rename.md)
+- [Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.](docs/reference/cli/trust.md)
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](docs/reference/convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -180,7 +180,7 @@ footer: |
 | 2606100534 | ✅     | sonnet | [Workspace-unique front-matter fields (unique-frontmatter rule)](plan/2606100534_unique-frontmatter-rule.md)                            |
 | 2606101546 | ✅     | opus   | [Builder execution wired into `mdsmith fix`](plan/2606101546_builder-execution-in-fix.md)                                               |
 | 2606101547 | 🔲     | opus   | [Build execution UX (stdout/stderr, debug, parallel)](plan/2606101547_build-execution-ux.md)                                            |
-| 2606101548 | 🔲     | opus   | [Build execution hardening](plan/2606101548_build-execution-hardening.md)                                                               |
+| 2606101548 | ✅     | opus   | [Build execution hardening](plan/2606101548_build-execution-hardening.md)                                                               |
 | 2606110517 | ✅     | sonnet | [tinygo wasm build under the 8 MiB budget](plan/247_tinygo-wasm-build.md)                                                               |
 | 2606110639 | ✅     |        | [Audience split for website-published docs](plan/2606110639_website-docs-audience-split.md)                                             |
 | 2606111048 | ✅     |        | [Consolidate tinygo compat stubs into internal/oscompat](plan/2606111048_arch-fix-oscompat-consolidation.md)                            |

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 | [`metrics`](docs/reference/cli/metrics.md)                   | List and rank shared Markdown metrics (file length, token estimate, readability, …).                                                      |
 | [`pre-merge-commit`](docs/reference/cli/pre-merge-commit.md) | Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.                                                           |
 | [`rename`](docs/reference/cli/rename.md)                     | Rename a heading or link-reference label and rewrite every dependent edit.                                                                |
+| [`trust`](docs/reference/cli/trust.md)                       | Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.                                   |
 | [`version`](docs/reference/cli/version.md)                   | Print the mdsmith build version and exit.                                                                                                 |
 <?/catalog?>
 

--- a/cmd/mdsmith/buildpass.go
+++ b/cmd/mdsmith/buildpass.go
@@ -505,10 +505,22 @@ func buildExecConfig(cfg *config.Config) buildexec.ExecConfig {
 }
 
 // envIsSet reports whether the named environment variable is set to a
-// non-empty value. It is the production environment lookup passed to the
-// trust gate.
+// truthy value. It is the production environment lookup passed to the
+// trust gate, so an explicit MDSMITH_TRUST_BUILD=0 (or false/no/off)
+// does NOT grant trust — only an affirmative value does. This avoids the
+// footgun where a user who sets the variable to a disabling value still
+// has the build pass run.
 func envIsSet(name string) bool {
-	return os.Getenv(name) != ""
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 // collectBuildTargets parses each file, walks its <?build?> directives,

--- a/cmd/mdsmith/buildpass.go
+++ b/cmd/mdsmith/buildpass.go
@@ -136,7 +136,20 @@ func runBuildPass(
 		return 0
 	}
 
-	builder := buildexec.NewCustomBuilder(recipes)
+	// Trust gate: a freshly cloned repo may declare recipes that run
+	// arbitrary binaries. The gate is consulted only when a recipe would
+	// actually execute — never on --build-dry-run or --build-check-stale,
+	// which enumerate targets without running anything. When it denies
+	// trust the build pass is skipped with a clear message; the lint-fix
+	// pass has already run.
+	if !opts.dryRun && !opts.checkStale {
+		if trust := buildexec.CheckTrust(root, envIsSet); !trust.Trusted {
+			_, _ = fmt.Fprintf(w, "mdsmith: %s\n", trust.Reason)
+			return 2
+		}
+	}
+
+	builder := buildexec.NewCustomBuilderExec(recipes, buildExecConfig(cfg))
 	timeout := opts.timeout
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -472,6 +485,23 @@ func buildRecipeSpecs(cfg *config.Config) map[string]buildexec.RecipeSpec {
 		out[name] = buildexec.RecipeSpec{Command: r.Command}
 	}
 	return out
+}
+
+// buildExecConfig maps the loaded config's build.exec section into the
+// build package's ExecConfig. Empty fields fall through to the build
+// executor's compiled defaults.
+func buildExecConfig(cfg *config.Config) buildexec.ExecConfig {
+	return buildexec.ExecConfig{
+		Path:           cfg.Build.Exec.Path,
+		EnvPassThrough: cfg.Build.Exec.EnvPassThrough,
+	}
+}
+
+// envIsSet reports whether the named environment variable is set to a
+// non-empty value. It is the production environment lookup passed to the
+// trust gate.
+func envIsSet(name string) bool {
+	return os.Getenv(name) != ""
 }
 
 // collectBuildTargets parses each file, walks its <?build?> directives,

--- a/cmd/mdsmith/buildpass.go
+++ b/cmd/mdsmith/buildpass.go
@@ -143,7 +143,14 @@ func runBuildPass(
 	// trust the build pass is skipped with a clear message; the lint-fix
 	// pass has already run.
 	if !opts.dryRun && !opts.checkStale {
-		if trust := buildexec.CheckTrust(root, envIsSet); !trust.Trusted {
+		// Pin the config file the run actually loaded (cfgPath), so the gate
+		// is correct under `mdsmith fix -c other.yml`. A defaults-only run
+		// (cfgPath == "") falls back to the default config name under root.
+		trustPath := cfgPath
+		if trustPath == "" {
+			trustPath = buildexec.ConfigPathForRoot(root)
+		}
+		if trust := buildexec.CheckTrust(trustPath, envIsSet); !trust.Trusted {
 			_, _ = fmt.Fprintf(w, "mdsmith: %s\n", trust.Reason)
 			return 2
 		}

--- a/cmd/mdsmith/buildpass_unit_test.go
+++ b/cmd/mdsmith/buildpass_unit_test.go
@@ -37,6 +37,17 @@ func buildPassCfg(recipesYAML string) *config.Config {
 	return cfg
 }
 
+// trustRoot writes a .mdsmith.yml file and an identical trust marker in
+// root so the build pass trust gate is satisfied. Unit tests that drive
+// runBuildPass to actually execute a recipe call this; the file bytes are
+// arbitrary (the gate only checks that config and marker match).
+func trustRoot(t *testing.T, root string) {
+	t.Helper()
+	body := []byte("rules: {}\nbuild:\n  recipes: {}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), body, 0o600))
+}
+
 // buildPassDirective returns a minimal Markdown snippet with one
 // <?build?> directive referencing the given recipe and output filename.
 func buildPassDirective(recipe, output string) string {
@@ -158,6 +169,7 @@ func TestRunBuildPass_OK(t *testing.T) {
 		t.Skip("touch not available on Windows")
 	}
 	root := t.TempDir()
+	trustRoot(t, root)
 	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
 	cfgPath := filepath.Join(root, ".mdsmith.yml")
 
@@ -178,6 +190,7 @@ func TestRunBuildPass_FAIL(t *testing.T) {
 		t.Skip("false not available on Windows")
 	}
 	root := t.TempDir()
+	trustRoot(t, root)
 	cfg := buildPassCfg("    boom:\n      command: false\n")
 	cfgPath := filepath.Join(root, ".mdsmith.yml")
 
@@ -396,6 +409,7 @@ func TestRunBuildPass_RebuildNoCache_ExitsZero(t *testing.T) {
 		t.Skip("touch not available on Windows")
 	}
 	root := t.TempDir()
+	trustRoot(t, root)
 	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
 	cfgPath := filepath.Join(root, ".mdsmith.yml")
 
@@ -417,6 +431,7 @@ func TestRunBuildPass_CheckStale_FreshTarget_ExitsZero(t *testing.T) {
 		t.Skip("touch not available on Windows")
 	}
 	root := t.TempDir()
+	trustRoot(t, root)
 	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
 	cfgPath := filepath.Join(root, ".mdsmith.yml")
 
@@ -460,6 +475,7 @@ func TestRunBuildPass_SaveCacheError(t *testing.T) {
 		t.Skip("touch and chmod not reliable on Windows")
 	}
 	root := t.TempDir()
+	trustRoot(t, root)
 	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
 	cfgPath := filepath.Join(root, ".mdsmith.yml")
 
@@ -487,6 +503,7 @@ func TestRunBuildPass_ReadErrorWithSuccessfulBuild_ExitsTwo(t *testing.T) {
 		t.Skip("touch not available on Windows")
 	}
 	root := t.TempDir()
+	trustRoot(t, root)
 	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
 	cfgPath := filepath.Join(root, ".mdsmith.yml")
 

--- a/cmd/mdsmith/buildpass_unit_test.go
+++ b/cmd/mdsmith/buildpass_unit_test.go
@@ -37,6 +37,23 @@ func buildPassCfg(recipesYAML string) *config.Config {
 	return cfg
 }
 
+func TestEnvIsSet_Truthiness(t *testing.T) {
+	const name = "MDSMITH_TEST_TRUST_FLAG"
+	truthy := []string{"1", "true", "yes", "on", "anything", " 1 ", "TRUE"}
+	falsy := []string{"", "0", "false", "no", "off", "FALSE", " 0 ", "  "}
+	for _, v := range truthy {
+		t.Setenv(name, v)
+		assert.True(t, envIsSet(name), "value %q should grant", v)
+	}
+	for _, v := range falsy {
+		t.Setenv(name, v)
+		assert.False(t, envIsSet(name), "value %q should not grant", v)
+	}
+	// Unset is falsy.
+	require.NoError(t, os.Unsetenv(name))
+	assert.False(t, envIsSet(name))
+}
+
 // trustRoot writes a .mdsmith.yml file and an identical trust marker in
 // root so the build pass trust gate is satisfied. Unit tests that drive
 // runBuildPass to actually execute a recipe call this; the file bytes are

--- a/cmd/mdsmith/buildpass_unit_test.go
+++ b/cmd/mdsmith/buildpass_unit_test.go
@@ -559,6 +559,48 @@ func TestRunBuildPass_OverlappingOutputsReturnsTwo(t *testing.T) {
 	assert.Contains(t, buf.String(), "overlap")
 }
 
+// TestRunBuildPass_TrustDenied covers the !trust.Trusted branch: the build pass
+// exits 2 with a trust-related message when no trust marker exists.
+func TestRunBuildPass_TrustDenied(t *testing.T) {
+	root := t.TempDir()
+	// Write a config with no trust marker so CheckTrust returns not-trusted.
+	cfgBody := []byte("build:\n  recipes:\n    mk:\n      command: touch {outputs}\n")
+	cfgPath := filepath.Join(root, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, cfgBody, 0o644))
+
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	var buf strings.Builder
+	// Not dryRun, not checkStale → trust gate runs; no marker → denied.
+	code := runBuildPass(cfg, cfgPath, []string{p}, buildPassOpts{timeout: time.Second}, &buf)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, buf.String(), "mdsmith:")
+}
+
+// TestRunBuildPass_TrustGate_EmptyCfgPath covers the cfgPath=="" branch inside
+// the trust gate, which falls back to ConfigPathForRoot(root).
+func TestRunBuildPass_TrustGate_EmptyCfgPath(t *testing.T) {
+	root := t.TempDir()
+	// Write a root .mdsmith.yml with no trust marker so CheckTrust denies.
+	cfgBody := []byte("build:\n  recipes: {}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), cfgBody, 0o644))
+
+	cfg := buildPassCfg("    mk:\n      command: touch {outputs}\n")
+
+	md := buildPassDirective("mk", "out.txt")
+	p := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(p, []byte(md), 0o644))
+
+	var buf strings.Builder
+	// cfgPath="" triggers the fallback branch; no trust marker → denied.
+	code := runBuildPass(cfg, "", []string{p}, buildPassOpts{timeout: time.Second}, &buf)
+	assert.Equal(t, 2, code)
+}
+
 // TestDispatchOne_RefreshCacheEntryError covers the refreshCacheEntry error
 // path inside dispatchOne. The mock builder creates the declared output and
 // then replaces the input with a directory; when refreshCacheEntry calls

--- a/cmd/mdsmith/coverage100_test.go
+++ b/cmd/mdsmith/coverage100_test.go
@@ -91,12 +91,18 @@ func TestRunMergeDriverInstall_RegisterError(t *testing.T) {
 	dir := t.TempDir()
 	initTestRepo(t, dir)
 	orig := executableFunc
-	executableFunc = func() (string, error) { return "", errors.New("no executable") }
+	// Return a temp-dir path so resolveInstalledBinary treats it as transient.
+	executableFunc = func() (string, error) {
+		return filepath.Join(os.TempDir(), "go-run-fake", "mdsmith"), nil
+	}
 	t.Cleanup(func() { executableFunc = orig })
+	// Restrict PATH to only git so LookPath("mdsmith") and goEnvPath (which
+	// needs "go") both fail, while git rev-parse still resolves.
+	pathWithOnlyGit(t)
 	t.Chdir(dir)
 	captureStderr(func() {
 		// In a git repo, but registerMergeDriver fails because the binary
-		// cannot be located.
+		// cannot be located via any fallback.
 		assert.Equal(t, 2, runMergeDriverInstall(nil))
 	})
 }

--- a/cmd/mdsmith/coverage100_test.go
+++ b/cmd/mdsmith/coverage100_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/config"
+)
+
+// chdirToRemoved changes into a fresh temp dir and then deletes it, so the
+// process has no valid working directory and os.Getwd fails. t.Chdir
+// restores the original directory at cleanup. This drives the Getwd-error
+// fallbacks that a normal filesystem never reaches.
+func chdirToRemoved(t *testing.T) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "mdsmith-nowd-*")
+	require.NoError(t, err)
+	t.Chdir(dir)
+	require.NoError(t, os.Remove(dir))
+}
+
+func TestReportFlagParseErr_NilReturnsContinue(t *testing.T) {
+	// A nil parse error means "no error": the caller should continue,
+	// signalled by -1.
+	assert.Equal(t, -1, reportFlagParseErr(nil, os.Stderr, "mdsmith: x"))
+}
+
+func TestDiscoverConfigPath_GetwdError(t *testing.T) {
+	chdirToRemoved(t)
+	// With no cwd, discoverConfigPath falls back to the empty-rooted default.
+	assert.Equal(t, config.DefaultConfigPath(""), discoverConfigPath(""))
+}
+
+func TestRootDirFromConfig_GetwdError(t *testing.T) {
+	chdirToRemoved(t)
+	// An empty cfgPath with no cwd yields an empty root.
+	assert.Equal(t, "", rootDirFromConfig(""))
+}
+
+func TestLoadConfigRaw_GetwdErrorFallsBackToDefaults(t *testing.T) {
+	chdirToRemoved(t)
+	cfg, path, err := loadConfigRaw("")
+	require.NoError(t, err)
+	assert.Equal(t, "", path, "no config discovered without a cwd")
+	require.NotNil(t, cfg)
+}
+
+func TestRunQuery_LoadConfigError(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.yml")
+	require.NoError(t, os.WriteFile(bad, []byte("this: : : not yaml\n"), 0o644))
+	// ResolveFilesWithOpts(["."]) succeeds, then loadConfig parses the bad
+	// config and fails — the runQuery config-error branch.
+	code := runQuery([]string{"-c", bad, "status: \"x\"", "."})
+	assert.Equal(t, 2, code)
+}
+
+func TestRunQuery_ResolveFilesError(t *testing.T) {
+	// An explicit, nonexistent file argument makes file resolution fail
+	// before any config load.
+	code := runQuery([]string{"status: \"x\"", filepath.Join(t.TempDir(), "nope.md")})
+	assert.Equal(t, 2, code)
+}
+
+func TestExecuteMetricsRank_ResolveFilesError(t *testing.T) {
+	// Metric selection and config load succeed, but an explicit nonexistent
+	// file makes resolveRankFiles fail — the rank file-resolution branch.
+	code := runMetricsRank([]string{filepath.Join(t.TempDir(), "missing.md")})
+	assert.Equal(t, 2, code)
+}

--- a/cmd/mdsmith/coverage100_test.go
+++ b/cmd/mdsmith/coverage100_test.go
@@ -43,24 +43,13 @@ func TestMergeAndClean_FatalMergeError(t *testing.T) {
 	})
 }
 
-func TestMergeAndClean_GuardFailsAfterMerge(t *testing.T) {
+func TestMergeAndClean_ReadResultError(t *testing.T) {
 	dir := t.TempDir()
 	base, ours, theirs := writeMergeInputs(t, dir, false)
-	// Pass the three input-validation guard calls, then fail the post-merge
-	// re-check (the symlink-swap guard before reading the merge result).
-	orig := guardFn
-	calls := 0
-	guardFn = func(string) error {
-		calls++
-		if calls <= 3 {
-			return nil
-		}
-		return errors.New("guard failed")
-	}
-	t.Cleanup(func() { guardFn = orig })
-
+	// A maxBytes smaller than the merged file makes ReadFileLimited fail
+	// after a clean merge — the "reading merge result" branch.
 	captureStderr(func() {
-		_, rc := mergeAndClean(base, ours, theirs, 1<<20)
+		_, rc := mergeAndClean(base, ours, theirs, 1)
 		assert.Equal(t, 2, rc)
 	})
 }
@@ -140,13 +129,13 @@ func TestEnsurePreMergeCommitHook_ChmodError(t *testing.T) {
 
 func TestRunBacklinks_DiscoverError(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.yml"), []byte("not: [valid\n"), 0o644))
-	target := filepath.Join(dir, "target.md")
-	require.NoError(t, os.WriteFile(target, []byte("# T\n"), 0o644))
-	// A bad config makes discoverFiles return exit code 2, which runBacklinks
-	// surfaces rather than treating as an empty result.
+	badYml := filepath.Join(dir, "bad.yml")
+	require.NoError(t, os.WriteFile(badYml, []byte("not: [valid\n"), 0o644))
+	// A workspace-relative target passes validateBacklinksArgs, so we reach
+	// discoverFiles; the bad config makes it return exit code 2, which
+	// runBacklinks surfaces rather than treating as an empty result.
 	captureStderr(func() {
-		code := runBacklinks([]string{"-c", filepath.Join(dir, "bad.yml"), target})
+		code := runBacklinks([]string{"-c", badYml, "target.md"})
 		assert.Equal(t, 2, code)
 	})
 }

--- a/cmd/mdsmith/coverage100_test.go
+++ b/cmd/mdsmith/coverage100_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,145 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/config"
 )
+
+// writeMergeInputs writes base/ours/theirs files in dir and returns their
+// paths. content selects a clean merge (identical) or a two-conflict merge.
+func writeMergeInputs(t *testing.T, dir string, conflicting bool) (base, ours, theirs string) {
+	t.Helper()
+	base = filepath.Join(dir, "base")
+	ours = filepath.Join(dir, "ours")
+	theirs = filepath.Join(dir, "theirs")
+	if conflicting {
+		// Two separated conflict regions make git merge-file exit 2, which
+		// this driver treats as a fatal (non-1) merge error.
+		require.NoError(t, os.WriteFile(base, []byte("1\n2\n3\n4\n5\n6\n7\n8\n9\n"), 0o644))
+		require.NoError(t, os.WriteFile(ours, []byte("1\nO2\n3\n4\n5\n6\n7\nO8\n9\n"), 0o644))
+		require.NoError(t, os.WriteFile(theirs, []byte("1\nT2\n3\n4\n5\n6\n7\nT8\n9\n"), 0o644))
+		return base, ours, theirs
+	}
+	body := []byte("hello\nworld\n")
+	require.NoError(t, os.WriteFile(base, body, 0o644))
+	require.NoError(t, os.WriteFile(ours, body, 0o644))
+	require.NoError(t, os.WriteFile(theirs, body, 0o644))
+	return base, ours, theirs
+}
+
+func TestMergeAndClean_FatalMergeError(t *testing.T) {
+	dir := t.TempDir()
+	base, ours, theirs := writeMergeInputs(t, dir, true)
+	captureStderr(func() {
+		_, rc := mergeAndClean(base, ours, theirs, 1<<20)
+		assert.Equal(t, 2, rc, "two-conflict merge is a fatal merge error")
+	})
+}
+
+func TestMergeAndClean_GuardFailsAfterMerge(t *testing.T) {
+	dir := t.TempDir()
+	base, ours, theirs := writeMergeInputs(t, dir, false)
+	// Pass the three input-validation guard calls, then fail the post-merge
+	// re-check (the symlink-swap guard before reading the merge result).
+	orig := guardFn
+	calls := 0
+	guardFn = func(string) error {
+		calls++
+		if calls <= 3 {
+			return nil
+		}
+		return errors.New("guard failed")
+	}
+	t.Cleanup(func() { guardFn = orig })
+
+	captureStderr(func() {
+		_, rc := mergeAndClean(base, ours, theirs, 1<<20)
+		assert.Equal(t, 2, rc)
+	})
+}
+
+func TestRunMergeDriverRun_LoadConfigError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte("not: [valid\n"), 0o644))
+	base, ours, theirs := writeMergeInputs(t, dir, false)
+	t.Chdir(dir)
+	captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriverRun([]string{base, ours, theirs, "p.md"}))
+	})
+}
+
+func TestRunMergeDriverRun_MaxInputSizeError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("max-input-size: not-a-size\n"), 0o644))
+	base, ours, theirs := writeMergeInputs(t, dir, false)
+	t.Chdir(dir)
+	captureStderr(func() {
+		assert.Equal(t, 2, runMergeDriverRun([]string{base, ours, theirs, "p.md"}))
+	})
+}
+
+func TestRunMergeDriverRun_MergeFails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte("rules: {}\n"), 0o644))
+	base, ours, theirs := writeMergeInputs(t, dir, true)
+	t.Chdir(dir)
+	captureStderr(func() {
+		// mergeAndClean returns a non-zero code, which runMergeDriverRun
+		// propagates.
+		assert.Equal(t, 2, runMergeDriverRun([]string{base, ours, theirs, "p.md"}))
+	})
+}
+
+func TestRunMergeDriverInstall_RegisterError(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+	orig := executableFunc
+	executableFunc = func() (string, error) { return "", errors.New("no executable") }
+	t.Cleanup(func() { executableFunc = orig })
+	t.Chdir(dir)
+	captureStderr(func() {
+		// In a git repo, but registerMergeDriver fails because the binary
+		// cannot be located.
+		assert.Equal(t, 2, runMergeDriverInstall(nil))
+	})
+}
+
+func TestRegisterMergeDriver_GitConfigError(t *testing.T) {
+	orig := executableFunc
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+	t.Cleanup(func() { executableFunc = orig })
+	// Not a git repository, so `git config` fails.
+	t.Chdir(t.TempDir())
+	err := registerMergeDriver()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git config")
+}
+
+func TestEnsurePreMergeCommitHook_ChmodError(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+	origExe := executableFunc
+	executableFunc = func() (string, error) { return "/usr/local/bin/mdsmith", nil }
+	t.Cleanup(func() { executableFunc = origExe })
+	origChmod := chmodFunc
+	chmodFunc = func(string, os.FileMode) error { return errors.New("chmod failed") }
+	t.Cleanup(func() { chmodFunc = origChmod })
+
+	err := ensurePreMergeCommitHook(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setting permissions")
+}
+
+func TestRunBacklinks_DiscoverError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.yml"), []byte("not: [valid\n"), 0o644))
+	target := filepath.Join(dir, "target.md")
+	require.NoError(t, os.WriteFile(target, []byte("# T\n"), 0o644))
+	// A bad config makes discoverFiles return exit code 2, which runBacklinks
+	// surfaces rather than treating as an empty result.
+	captureStderr(func() {
+		code := runBacklinks([]string{"-c", filepath.Join(dir, "bad.yml"), target})
+		assert.Equal(t, 2, code)
+	})
+}
 
 // chdirToRemoved changes into a fresh temp dir and then deletes it, so the
 // process has no valid working directory and os.Getwd fails. t.Chdir

--- a/cmd/mdsmith/e2e_build_hardening_test.go
+++ b/cmd/mdsmith/e2e_build_hardening_test.go
@@ -1,0 +1,254 @@
+package main_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeUntrustedBuildRepo is writeBuildRepo without the trust marker: the
+// build pass should refuse to run recipes until trust is granted.
+func writeUntrustedBuildRepo(t *testing.T, recipesYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	cfg := "rules: {}\nbuild:\n  recipes:\n" + recipesYAML
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	return dir
+}
+
+func TestE2E_Trust_MissingMarkerBlocksBuildButLintRuns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeUntrustedBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hi"), 0o644))
+	// A fixable lint issue (trailing space) so we can prove lint-fix still ran.
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt")+"trailing   \n")
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "doc.md")
+	assert.Equal(t, 2, code, "missing trust marker fails the build pass: %s", stderr)
+	assert.Contains(t, stderr, "not trusted")
+	assert.NoFileExists(t, filepath.Join(dir, "dst.txt"), "untrusted build must not run the recipe")
+
+	// Lint-fix still ran: the trailing whitespace is gone.
+	got, err := os.ReadFile(filepath.Join(dir, "doc.md"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), "trailing   ")
+}
+
+func TestE2E_Trust_EnvVarIsAlternateSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeUntrustedBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hi"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	stdout, stderr, code := runBinaryInDirEnv(t, dir, "", []string{"MDSMITH_TRUST_BUILD=1"},
+		"fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 0, code, "MDSMITH_TRUST_BUILD=1 grants trust: %s", stdout+stderr)
+	assert.FileExists(t, filepath.Join(dir, "dst.txt"))
+}
+
+func TestE2E_Trust_NoBuildSkipsGate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeUntrustedBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hi"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--no-build", "doc.md")
+	assert.Equal(t, 0, code, "--no-build skips the gate entirely: %s", stderr)
+	assert.NotContains(t, stderr, "not trusted")
+	assert.NoFileExists(t, filepath.Join(dir, "dst.txt"))
+}
+
+func TestE2E_Trust_StaleMarkerBlocks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	// Tamper with .mdsmith.yml so it no longer matches the trust marker.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"),
+		[]byte("rules: {}\nbuild:\n  recipes:\n    copy:\n      command: cp {inputs} {outputs}\n# drift\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hi"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "changed since it was trusted")
+}
+
+func TestE2E_TrustCommand_ShowsDiffAndReTrusts(t *testing.T) {
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	// Drift the config.
+	newCfg := "rules: {}\nbuild:\n  recipes:\n    copy:\n      command: install {inputs} {outputs}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(newCfg), 0o644))
+
+	// `mdsmith trust -y` shows the diff and re-trusts without a prompt.
+	stdout, stderr, code := runBinaryInDir(t, dir, "", "trust", "--yes")
+	require.Equal(t, 0, code, stderr)
+	assert.Contains(t, stdout, "install")
+	assert.Contains(t, stdout, "Trusted")
+
+	// The marker now matches the current config.
+	marker, err := os.ReadFile(filepath.Join(dir, ".mdsmith.yml.trust"))
+	require.NoError(t, err)
+	assert.Equal(t, newCfg, string(marker))
+}
+
+func TestE2E_TrustCommand_PromptDeclineLeavesMarker(t *testing.T) {
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	newCfg := "rules: {}\nbuild:\n  recipes:\n    copy:\n      command: install {inputs} {outputs}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(newCfg), 0o644))
+
+	// Decline at the prompt: answer "n".
+	stdout, _, code := runBinaryInDir(t, dir, "n\n", "trust")
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stdout, "Aborted")
+
+	// Marker is unchanged (still the original cp command).
+	marker, err := os.ReadFile(filepath.Join(dir, ".mdsmith.yml.trust"))
+	require.NoError(t, err)
+	assert.Contains(t, string(marker), "cp {inputs}")
+}
+
+func TestE2E_Build_UndeclaredWriteFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on Windows")
+	}
+	// A recipe that writes its declared output AND an undeclared sibling in
+	// the same parent dir. The post-condition check must fail the build and
+	// name the undeclared file.
+	dir := writeBuildRepo(t, "    sneaky:\n      command: /bin/sh -c\n")
+	// Recipe writes out.txt (declared, staged via {outputs}) and also
+	// sneaky.txt next to it in the project tree.
+	script := "#!/bin/sh\nprintf ok > \"$1\"\nprintf evil > \"" +
+		filepath.Join(dir, "sneaky.txt") + "\"\n"
+	scriptPath := filepath.Join(dir, "run.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+	dir2 := reconfigureRecipe(t, dir, "    sneaky:\n      command: "+scriptPath+" {outputs}\n")
+
+	writeFixture(t, dir2, "doc.md", buildDirective("sneaky", "", "out.txt"))
+	_, stderr, code := runBinaryInDir(t, dir2, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code, stderr)
+	assert.Contains(t, stderr, "outside its declared outputs")
+	assert.Contains(t, stderr, "sneaky.txt")
+}
+
+func TestE2E_Build_HermeticEnvAllowlistOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh/env not available on Windows")
+	}
+	dir := writeBuildRepo(t, "")
+	// Recipe dumps its environment to the declared output.
+	scriptPath := filepath.Join(dir, "dumpenv.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nenv > \"$1\"\n"), 0o755))
+	reconfigureRecipe(t, dir, "    dumpenv:\n      command: "+scriptPath+" {outputs}\n"+
+		"  exec:\n    path: \"/usr/bin:/bin\"\n    env-pass-through: [HOME]\n")
+	writeFixture(t, dir, "doc.md", buildDirective("dumpenv", "", "env.txt"))
+
+	// Inject a secret into the parent environment; it must not leak in.
+	_, stderr, code := runBinaryInDirEnv(t, dir, "",
+		[]string{"MDSMITH_TRUST_BUILD=1", "SECRET_TOKEN=leak-me", "HOME=/home/tester"},
+		"fix", "--no-color", "--build-only", "doc.md")
+	require.Equal(t, 0, code, stderr)
+
+	got, err := os.ReadFile(filepath.Join(dir, "env.txt"))
+	require.NoError(t, err)
+	body := string(got)
+	assert.Contains(t, body, "PATH=/usr/bin:/bin")
+	assert.Contains(t, body, "HOME=/home/tester")
+	assert.NotContains(t, body, "SECRET_TOKEN", "non-allowlisted var must not pass through")
+	assert.NotContains(t, body, "MDSMITH_TRUST_BUILD", "trust env var must not pass through to recipe")
+}
+
+// reconfigureRecipe rewrites .mdsmith.yml (and the trust marker) in dir
+// with a new recipes block, returning dir for chaining.
+func reconfigureRecipe(t *testing.T, dir, recipesYAML string) string {
+	t.Helper()
+	cfg := "rules: {}\nbuild:\n  recipes:\n" + recipesYAML
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml.trust"), []byte(cfg), 0o600))
+	return dir
+}
+
+func TestE2E_Build_MissingDeclaredOutputFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("true not available on Windows")
+	}
+	// A recipe that exits 0 without producing its declared output.
+	dir := writeBuildRepo(t, "    noop:\n      command: true {outputs}\n")
+	writeFixture(t, dir, "doc.md", buildDirective("noop", "", "out.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "did not produce declared output")
+	assert.NoFileExists(t, filepath.Join(dir, "out.txt"))
+}
+
+func TestE2E_Build_GroupWritableStagingRootRefused(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission checks")
+	}
+	dir := writeBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hi"), 0o644))
+	// Pre-create a group-writable staging root.
+	staging := filepath.Join(dir, ".mdsmith", "build-staging")
+	require.NoError(t, os.MkdirAll(staging, 0o700))
+	require.NoError(t, os.Chmod(staging, 0o770))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr, "writable")
+}
+
+func TestE2E_Build_TimeoutKillsSpawnedChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group kill tested on Unix")
+	}
+	dir := writeBuildRepo(t, "")
+	// Recipe spawns a long-lived child that records its PID, then sleeps.
+	pidFile := filepath.Join(dir, "child.pid")
+	script := "#!/bin/sh\nsleep 120 & echo $! > \"" + pidFile + "\"\nsleep 120\ntouch \"$1\"\n"
+	scriptPath := filepath.Join(dir, "spawn.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+	reconfigureRecipe(t, dir, "    spawn:\n      command: "+scriptPath+" {outputs}\n")
+	writeFixture(t, dir, "doc.md", buildDirective("spawn", "", "out.txt"))
+
+	_, stderr, code := runBinaryInDir(t, dir, "",
+		"fix", "--no-color", "--build-only", "--build-timeout", "1s", "doc.md")
+	assert.Equal(t, 2, code, stderr)
+	assert.Contains(t, stderr, "FAIL")
+
+	// The spawned child must be reaped, not orphaned.
+	var childPID int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(pidFile)
+		if err == nil {
+			if n, perr := strconv.Atoi(strings.TrimSpace(string(b))); perr == nil {
+				childPID = n
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NotZero(t, childPID, "child pid should have been recorded")
+	assert.Eventually(t, func() bool {
+		return !unixProcessAlive(childPID)
+	}, 6*time.Second, 100*time.Millisecond, "spawned child must not be orphaned")
+}

--- a/cmd/mdsmith/e2e_build_hardening_test.go
+++ b/cmd/mdsmith/e2e_build_hardening_test.go
@@ -58,6 +58,22 @@ func TestE2E_Trust_EnvVarIsAlternateSource(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dir, "dst.txt"))
 }
 
+func TestE2E_Trust_EnvVarDisablingValueDoesNotGrant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cp not available on Windows")
+	}
+	dir := writeUntrustedBuildRepo(t, "    copy:\n      command: cp {inputs} {outputs}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("hi"), 0o644))
+	writeFixture(t, dir, "doc.md", buildDirective("copy", "src.txt", "dst.txt"))
+
+	// MDSMITH_TRUST_BUILD=0 must NOT grant trust.
+	_, stderr, code := runBinaryInDirEnv(t, dir, "", []string{"MDSMITH_TRUST_BUILD=0"},
+		"fix", "--no-color", "--build-only", "doc.md")
+	assert.Equal(t, 2, code, "a disabling value leaves the gate in force: %s", stderr)
+	assert.Contains(t, stderr, "not trusted")
+	assert.NoFileExists(t, filepath.Join(dir, "dst.txt"))
+}
+
 func TestE2E_Trust_NoBuildSkipsGate(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("cp not available on Windows")

--- a/cmd/mdsmith/e2e_build_test.go
+++ b/cmd/mdsmith/e2e_build_test.go
@@ -27,12 +27,16 @@ func buildDirective(recipe, input, output string) string {
 
 // writeBuildRepo sets up an isolated repo with a .mdsmith.yml carrying
 // the given build.recipes YAML block (already indented under recipes:).
+// It also writes a matching .mdsmith.yml.trust marker so the build pass
+// trust gate is satisfied, mirroring a developer who has run
+// `mdsmith trust` on their clone.
 func writeBuildRepo(t *testing.T, recipesYAML string) string {
 	t.Helper()
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
 	cfg := "rules: {}\nbuild:\n  recipes:\n" + recipesYAML
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml.trust"), []byte(cfg), 0o600))
 	return dir
 }
 
@@ -271,8 +275,11 @@ func TestE2E_Build_RecipeCommandChangeRebuilds(t *testing.T) {
 	require.Equal(t, 0, code1)
 
 	// Edit the recipe command; the ActionID changes, so the target rebuilds.
+	// Editing the config invalidates the trust marker, so re-trust it (as a
+	// developer would via `mdsmith trust`) before the second build.
 	cfg := "rules: {}\nbuild:\n  recipes:\n    copy:\n      command: install {inputs} {outputs}\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml.trust"), []byte(cfg), 0o600))
 	_, stderr2, code2 := runBinaryInDir(t, dir, "", "fix", "--no-color", "--build-only", "doc.md")
 	require.Equal(t, 0, code2, stderr2)
 	assert.Contains(t, stderr2, "OK", "a recipe command change must invalidate the target")

--- a/cmd/mdsmith/e2e_build_test.go
+++ b/cmd/mdsmith/e2e_build_test.go
@@ -467,13 +467,16 @@ func TestE2E_Check_RunsNoRecipe(t *testing.T) {
 
 // --- Plan 104: build lifecycle hooks ---
 
-// writeBuildRepoWithHooks sets up a repo with recipes and hooks.
+// writeBuildRepoWithHooks sets up a repo with recipes and hooks. It also
+// writes a matching .mdsmith.yml.trust marker so the build pass trust gate
+// is satisfied, mirroring a developer who has run `mdsmith trust`.
 func writeBuildRepoWithHooks(t *testing.T, recipesYAML, hooksYAML string) string {
 	t.Helper()
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
 	cfg := "rules: {}\nbuild:\n  recipes:\n" + recipesYAML + "\n  hooks:\n" + hooksYAML
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte(cfg), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml.trust"), []byte(cfg), 0o600))
 	return dir
 }
 

--- a/cmd/mdsmith/e2e_build_unix_test.go
+++ b/cmd/mdsmith/e2e_build_unix_test.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package main_test
+
+import "syscall"
+
+// unixProcessAlive reports whether a process with the given PID exists,
+// using signal 0 (existence probe). EPERM still implies the process is
+// alive (we just may not be allowed to signal it).
+func unixProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/cmd/mdsmith/e2e_build_windows_test.go
+++ b/cmd/mdsmith/e2e_build_windows_test.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package main_test
+
+// unixProcessAlive is a Windows stub. The timeout/process-group test that
+// calls it skips on Windows at runtime; the stub only satisfies the
+// compiler so the shared hardening test file builds on all platforms.
+func unixProcessAlive(int) bool { return false }

--- a/cmd/mdsmith/e2e_test.go
+++ b/cmd/mdsmith/e2e_test.go
@@ -143,10 +143,21 @@ func runBinary(t *testing.T, stdin string, args ...string) (stdout, stderr strin
 // runBinaryInDir runs the mdsmith binary with the given args in the given directory.
 func runBinaryInDir(t *testing.T, dir, stdin string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runBinaryInDirEnv(t, dir, stdin, nil, args...)
+}
+
+// runBinaryInDirEnv is runBinaryInDir with extra environment variables.
+// Each entry in extraEnv is a KEY=VALUE string appended after the
+// coverage-dir environment so it can override or add to the inherited
+// process environment.
+func runBinaryInDirEnv(
+	t *testing.T, dir, stdin string, extraEnv []string, args ...string,
+) (stdout, stderr string, exitCode int) {
+	t.Helper()
 
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Dir = dir
-	cmd.Env = envWithCoverDir(coverDir)
+	cmd.Env = append(envWithCoverDir(coverDir), extraEnv...)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -51,6 +51,7 @@ Commands:
   kinds             Inspect declared kinds and resolve effective config per file
   init              Generate .mdsmith.yml (--from-markdownlint converts an existing config)
   lsp               Run the Language Server Protocol server on stdio
+  trust             Review the .mdsmith.yml diff and trust the build pass on this clone
   version           Print version and exit
 
 Global flags:
@@ -115,6 +116,8 @@ func dispatch(first string, args []string) int {
 		return runInit(args)
 	case "lsp":
 		return runLSP(args)
+	case "trust":
+		return runTrust(args)
 	case "version":
 		printVersion()
 		return 0

--- a/cmd/mdsmith/main.go
+++ b/cmd/mdsmith/main.go
@@ -680,6 +680,27 @@ func sessionForCLI(cfg *config.Config, cfgPath string) *mdsmith.Session {
 	return sess
 }
 
+// discoverConfigPath returns the path to the config file a command would
+// load: an explicit --config wins, otherwise the workspace config
+// discovered from the current directory, otherwise the default config
+// path under the current directory. It mirrors loadConfigRaw's path
+// resolution without loading (and possibly failing to parse) the file,
+// so commands that only need the path — like `mdsmith trust` — agree
+// with the file the build pass actually pins.
+func discoverConfigPath(configPath string) string {
+	if configPath != "" {
+		return configPath
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return config.DefaultConfigPath("")
+	}
+	if discovered, derr := config.Discover(cwd); derr == nil && discovered != "" {
+		return discovered
+	}
+	return config.DefaultConfigPath(cwd)
+}
+
 // rootDirFromConfig returns the project root directory derived from the
 // config file path. If cfgPath is empty, it falls back to the current
 // working directory so that includes with ".." paths still resolve.

--- a/cmd/mdsmith/main_unit_test.go
+++ b/cmd/mdsmith/main_unit_test.go
@@ -1463,6 +1463,46 @@ func TestDispatch(t *testing.T) {
 	assert.Equal(t, 2, code)
 }
 
+// TestDispatch_Trust covers the "trust" arm of the dispatch switch, which
+// calls runTrust → runTrustIO. An already-trusted config returns 0 without
+// reading stdin, so we can drive it without redirecting os.Stdin.
+func TestDispatch_Trust(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfg, body, 0o644))
+	require.NoError(t, os.WriteFile(cfg+".trust", body, 0o600))
+
+	stdout := captureStdout(func() {
+		code := dispatch("trust", []string{"-c", cfg})
+		assert.Equal(t, 0, code)
+	})
+	assert.Contains(t, stdout, "already trusted")
+}
+
+// TestDiscoverConfigPath covers the discoverConfigPath helper added in this PR.
+func TestDiscoverConfigPath_ExplicitPath(t *testing.T) {
+	assert.Equal(t, "/explicit/cfg.yml", discoverConfigPath("/explicit/cfg.yml"))
+}
+
+func TestDiscoverConfigPath_EmptyFindsConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("rules: {}\n"), 0o644))
+	t.Chdir(dir)
+
+	got := discoverConfigPath("")
+	assert.Equal(t, cfgPath, got)
+}
+
+func TestDiscoverConfigPath_EmptyNoConfigFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got := discoverConfigPath("")
+	assert.Equal(t, filepath.Join(dir, ".mdsmith.yml"), got)
+}
+
 // --- init config generation ---
 
 func TestDefaultConfigBytes(t *testing.T) {

--- a/cmd/mdsmith/metrics.go
+++ b/cmd/mdsmith/metrics.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -76,12 +77,12 @@ func runMetricsList(args []string) int {
 	defs := metricspkg.ForScope(scope)
 	switch format {
 	case "text":
-		if err := writeMetricsListText(defs); err != nil {
+		if err := writeMetricsListText(os.Stdout, defs); err != nil {
 			fmt.Fprintf(os.Stderr, "mdsmith: writing output: %v\n", err)
 			return 2
 		}
 	case "json":
-		if err := writeMetricsListJSON(defs); err != nil {
+		if err := writeMetricsListJSON(os.Stdout, defs); err != nil {
 			fmt.Fprintf(os.Stderr, "mdsmith: writing output: %v\n", err)
 			return 2
 		}
@@ -196,7 +197,7 @@ func executeMetricsRank(opts metricsRankOptions, fileArgs []string) int {
 	metricspkg.SortRows(rows, byDef, order)
 	rows = metricspkg.LimitRows(rows, opts.top)
 
-	if err := writeRankOutput(opts.format, rows, defs); err != nil {
+	if err := writeRankOutput(os.Stdout, opts.format, rows, defs); err != nil {
 		if strings.Contains(err.Error(), "unknown format") {
 			fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 			return 2
@@ -261,15 +262,16 @@ func resolveRankFiles(cfg *config.Config, opts metricsRankOptions, fileArgs []st
 }
 
 func writeRankOutput(
+	w io.Writer,
 	format string,
 	rows []metricspkg.Row,
 	defs []metricspkg.Definition,
 ) error {
 	switch format {
 	case "text":
-		return writeMetricsRankText(rows, defs)
+		return writeMetricsRankText(w, rows, defs)
 	case "json":
-		return writeMetricsRankJSON(rows, defs)
+		return writeMetricsRankJSON(w, rows, defs)
 	default:
 		return fmt.Errorf("unknown format %q (supported: text, json)", format)
 	}
@@ -284,8 +286,8 @@ func containsMetric(defs []metricspkg.Definition, id string) bool {
 	return false
 }
 
-func writeMetricsListText(defs []metricspkg.Definition) error {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func writeMetricsListText(w io.Writer, defs []metricspkg.Definition) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	if _, err := fmt.Fprintln(tw, "ID\tNAME\tSCOPE\tORDER\tDEFAULT\tDESCRIPTION"); err != nil {
 		return err
 	}
@@ -306,7 +308,7 @@ func writeMetricsListText(defs []metricspkg.Definition) error {
 	return tw.Flush()
 }
 
-func writeMetricsListJSON(defs []metricspkg.Definition) error {
+func writeMetricsListJSON(w io.Writer, defs []metricspkg.Definition) error {
 	items := make([]map[string]any, 0, len(defs))
 	for _, def := range defs {
 		items = append(items, map[string]any{
@@ -318,13 +320,13 @@ func writeMetricsListJSON(defs []metricspkg.Definition) error {
 			"default_order": def.DefaultOrder,
 		})
 	}
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(items)
 }
 
-func writeMetricsRankText(rows []metricspkg.Row, defs []metricspkg.Definition) error {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func writeMetricsRankText(w io.Writer, rows []metricspkg.Row, defs []metricspkg.Definition) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 
 	headers := make([]string, 0, len(defs)+1)
 	for _, def := range defs {
@@ -349,7 +351,7 @@ func writeMetricsRankText(rows []metricspkg.Row, defs []metricspkg.Definition) e
 	return tw.Flush()
 }
 
-func writeMetricsRankJSON(rows []metricspkg.Row, defs []metricspkg.Definition) error {
+func writeMetricsRankJSON(w io.Writer, rows []metricspkg.Row, defs []metricspkg.Definition) error {
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		item := map[string]any{
@@ -360,7 +362,7 @@ func writeMetricsRankJSON(rows []metricspkg.Row, defs []metricspkg.Definition) e
 		}
 		items = append(items, item)
 	}
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(items)
 }

--- a/cmd/mdsmith/metrics_unit_test.go
+++ b/cmd/mdsmith/metrics_unit_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -166,23 +168,17 @@ func TestResolveRankSelection_ByNotInDefaultsGetsAppended(t *testing.T) {
 // --- writeRankOutput ---
 
 func TestWriteRankOutput_UnknownFormat_Error(t *testing.T) {
-	err := writeRankOutput("xml", nil, nil)
+	err := writeRankOutput(&bytes.Buffer{}, "xml", nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown format")
 }
 
 func TestWriteRankOutput_TextFormat_NoError(t *testing.T) {
-	captureStdout(func() {
-		err := writeRankOutput("text", nil, nil)
-		assert.NoError(t, err)
-	})
+	assert.NoError(t, writeRankOutput(&bytes.Buffer{}, "text", nil, nil))
 }
 
 func TestWriteRankOutput_JSONFormat_NoError(t *testing.T) {
-	captureStdout(func() {
-		err := writeRankOutput("json", nil, nil)
-		assert.NoError(t, err)
-	})
+	assert.NoError(t, writeRankOutput(&bytes.Buffer{}, "json", nil, nil))
 }
 
 // --- writeMetricsListText ---
@@ -191,10 +187,9 @@ func TestWriteMetricsListText_PrintsHeaderAndRows(t *testing.T) {
 	defs := []metricspkg.Definition{
 		{ID: "m1", Name: "Metric One", Scope: metricspkg.ScopeFile, DefaultOrder: "desc", Description: "a test metric"},
 	}
-	out := captureStdout(func() {
-		err := writeMetricsListText(defs)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsListText(&buf, defs))
+	out := buf.String()
 	assert.Contains(t, out, "ID")
 	assert.Contains(t, out, "NAME")
 	assert.Contains(t, out, "m1")
@@ -203,11 +198,15 @@ func TestWriteMetricsListText_PrintsHeaderAndRows(t *testing.T) {
 }
 
 func TestWriteMetricsListText_EmptyDefs_HeaderOnly(t *testing.T) {
-	out := captureStdout(func() {
-		err := writeMetricsListText(nil)
-		assert.NoError(t, err)
-	})
-	assert.Contains(t, out, "ID")
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsListText(&buf, nil))
+	assert.Contains(t, buf.String(), "ID")
+}
+
+func TestWriteMetricsListText_WriteError(t *testing.T) {
+	err := writeMetricsListText(&errWriter{err: errors.New("disk full")},
+		[]metricspkg.Definition{{ID: "m1", Name: "M"}})
+	require.Error(t, err)
 }
 
 // --- writeMetricsListJSON ---
@@ -216,10 +215,9 @@ func TestWriteMetricsListJSON_ValidJSONArray(t *testing.T) {
 	defs := []metricspkg.Definition{
 		{ID: "m1", Name: "Metric One", Description: "desc"},
 	}
-	out := captureStdout(func() {
-		err := writeMetricsListJSON(defs)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsListJSON(&buf, defs))
+	out := buf.String()
 	assert.Contains(t, out, `"id"`)
 	assert.Contains(t, out, `"m1"`)
 	assert.Contains(t, out, `"name"`)
@@ -227,11 +225,9 @@ func TestWriteMetricsListJSON_ValidJSONArray(t *testing.T) {
 }
 
 func TestWriteMetricsListJSON_EmptyDefs_EmptyArray(t *testing.T) {
-	out := captureStdout(func() {
-		err := writeMetricsListJSON(nil)
-		assert.NoError(t, err)
-	})
-	assert.Contains(t, out, "[]")
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsListJSON(&buf, nil))
+	assert.Contains(t, buf.String(), "[]")
 }
 
 // --- writeMetricsRankText ---
@@ -241,10 +237,9 @@ func TestWriteMetricsRankText_PrintsHeaderAndRows(t *testing.T) {
 	rows := []metricspkg.Row{
 		{Path: "a.md", Metrics: map[string]metricspkg.Value{"bytes": metricspkg.AvailableValue(100)}},
 	}
-	out := captureStdout(func() {
-		err := writeMetricsRankText(rows, defs)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsRankText(&buf, rows, defs))
+	out := buf.String()
 	assert.Contains(t, out, "BYTES")
 	assert.Contains(t, out, "PATH")
 	assert.Contains(t, out, "a.md")
@@ -252,11 +247,18 @@ func TestWriteMetricsRankText_PrintsHeaderAndRows(t *testing.T) {
 
 func TestWriteMetricsRankText_Empty_HeaderOnly(t *testing.T) {
 	defs := []metricspkg.Definition{{ID: "bytes", Name: "bytes"}}
-	out := captureStdout(func() {
-		err := writeMetricsRankText(nil, defs)
-		assert.NoError(t, err)
-	})
-	assert.Contains(t, out, "BYTES")
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsRankText(&buf, nil, defs))
+	assert.Contains(t, buf.String(), "BYTES")
+}
+
+func TestWriteMetricsRankText_WriteError(t *testing.T) {
+	defs := []metricspkg.Definition{{ID: "bytes", Name: "bytes"}}
+	rows := []metricspkg.Row{
+		{Path: "a.md", Metrics: map[string]metricspkg.Value{"bytes": metricspkg.AvailableValue(100)}},
+	}
+	err := writeMetricsRankText(&errWriter{err: errors.New("disk full")}, rows, defs)
+	require.Error(t, err)
 }
 
 // --- writeMetricsRankJSON ---
@@ -266,20 +268,17 @@ func TestWriteMetricsRankJSON_ValidJSONArray(t *testing.T) {
 	rows := []metricspkg.Row{
 		{Path: "a.md", Metrics: map[string]metricspkg.Value{"bytes": metricspkg.AvailableValue(100)}},
 	}
-	out := captureStdout(func() {
-		err := writeMetricsRankJSON(rows, defs)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsRankJSON(&buf, rows, defs))
+	out := buf.String()
 	assert.Contains(t, out, `"path"`)
 	assert.Contains(t, out, `"a.md"`)
 }
 
 func TestWriteMetricsRankJSON_Empty_EmptyArray(t *testing.T) {
-	out := captureStdout(func() {
-		err := writeMetricsRankJSON(nil, nil)
-		assert.NoError(t, err)
-	})
-	assert.Contains(t, out, "[]")
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsRankJSON(&buf, nil, nil))
+	assert.Contains(t, buf.String(), "[]")
 }
 
 // --- runMetrics dispatch ---
@@ -402,10 +401,9 @@ func TestWriteMetricsListText_MultipleRows(t *testing.T) {
 		{ID: "m1", Name: "Alpha", Scope: metricspkg.ScopeFile, DefaultOrder: "asc"},
 		{ID: "m2", Name: "Beta", Scope: metricspkg.ScopeFile, DefaultOrder: "desc"},
 	}
-	out := captureStdout(func() {
-		err := writeMetricsListText(defs)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsListText(&buf, defs))
+	out := buf.String()
 	assert.Contains(t, out, "m1")
 	assert.Contains(t, out, "m2")
 	assert.Contains(t, out, "Alpha")
@@ -427,10 +425,9 @@ func TestWriteMetricsRankText_MultipleMetrics(t *testing.T) {
 			"lines": metricspkg.AvailableValue(10),
 		}},
 	}
-	out := captureStdout(func() {
-		err := writeMetricsRankText(rows, defs)
-		assert.NoError(t, err)
-	})
+	var buf bytes.Buffer
+	require.NoError(t, writeMetricsRankText(&buf, rows, defs))
+	out := buf.String()
 	assert.True(t, strings.Contains(out, "a.md"))
 	assert.True(t, strings.Contains(out, "b.md"))
 }

--- a/cmd/mdsmith/trust.go
+++ b/cmd/mdsmith/trust.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+
+	buildexec "github.com/jeduden/mdsmith/internal/build"
+)
+
+// runTrust implements the `mdsmith trust` subcommand. It shows the diff
+// between the stored trust marker and the current .mdsmith.yml, then —
+// unless --yes is passed — prompts for confirmation before rewriting the
+// marker. Marking the config trusted is what lets `mdsmith fix` run the
+// build pass on this clone.
+func runTrust(args []string) int {
+	return runTrustIO(args, os.Stdin, os.Stdout, os.Stderr)
+}
+
+// runTrustIO is the injectable form of runTrust; tests supply alternate
+// streams to drive the prompt and capture output.
+func runTrustIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("trust", flag.ContinueOnError)
+	var (
+		configPath string
+		yes        bool
+	)
+	fs.StringVarP(&configPath, "config", "c", "", "Override config file path")
+	fs.BoolVarP(&yes, "yes", "y", false, "Skip the confirmation prompt and trust immediately")
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "Usage: mdsmith trust [flags]\n\n"+
+			"Review the .mdsmith.yml diff since it was last trusted and update the\n"+
+			".mdsmith.yml.trust marker so `mdsmith fix` may run the build pass on this clone.\n\n"+
+			"Flags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, stderr, "mdsmith: trust"); code >= 0 {
+			return code
+		}
+	}
+
+	root := rootDirFromConfig(configPath)
+
+	diff, changed, err := buildexec.TrustDiff(root)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "mdsmith: trust: %v\n", err)
+		return 2
+	}
+	if !changed {
+		_, _ = fmt.Fprintf(stdout, "%s is already trusted; no change.\n", buildexec.TrustMarkerPath(root))
+		return 0
+	}
+
+	_, _ = fmt.Fprint(stdout, diff)
+	if !yes && !confirmTrust(stdin, stdout) {
+		_, _ = fmt.Fprintln(stdout, "Aborted; trust marker unchanged.")
+		return 1
+	}
+
+	if err := buildexec.WriteTrustMarker(root); err != nil {
+		_, _ = fmt.Fprintf(stderr, "mdsmith: trust: %v\n", err)
+		return 2
+	}
+	_, _ = fmt.Fprintf(stdout, "Trusted %s.\n", buildexec.TrustMarkerPath(root))
+	return 0
+}
+
+// confirmTrust prompts on stdout and reads a yes/no answer from stdin.
+// Only an explicit "y"/"yes" (case-insensitive) confirms; anything else,
+// including EOF, declines.
+func confirmTrust(stdin io.Reader, stdout io.Writer) bool {
+	_, _ = fmt.Fprint(stdout, "\nTrust this configuration? [y/N] ")
+	sc := bufio.NewScanner(stdin)
+	if !sc.Scan() {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(sc.Text()))
+	return answer == "y" || answer == "yes"
+}

--- a/cmd/mdsmith/trust.go
+++ b/cmd/mdsmith/trust.go
@@ -10,7 +10,6 @@ import (
 	flag "github.com/spf13/pflag"
 
 	buildexec "github.com/jeduden/mdsmith/internal/build"
-	"github.com/jeduden/mdsmith/internal/config"
 )
 
 // runTrust implements the `mdsmith trust` subcommand. It shows the diff
@@ -47,7 +46,7 @@ func runTrustIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	// Pin the same config file the build pass would load, so `mdsmith trust`
 	// and the gate agree even under -c / config discovery.
-	cfgFile := resolveTrustConfigPath(configPath)
+	cfgFile := discoverConfigPath(configPath)
 
 	diff, changed, err := buildexec.TrustDiff(cfgFile)
 	if err != nil {
@@ -71,24 +70,6 @@ func runTrustIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	_, _ = fmt.Fprintf(stdout, "Trusted %s.\n", buildexec.TrustMarkerPath(cfgFile))
 	return 0
-}
-
-// resolveTrustConfigPath returns the config file the trust marker pins.
-// An explicit --config wins; otherwise it discovers the workspace config
-// the way the other subcommands do, falling back to the default config
-// path under the current directory when none is found.
-func resolveTrustConfigPath(configPath string) string {
-	if configPath != "" {
-		return configPath
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return buildexec.ConfigPathForRoot("")
-	}
-	if discovered, derr := config.Discover(cwd); derr == nil && discovered != "" {
-		return discovered
-	}
-	return buildexec.ConfigPathForRoot(cwd)
 }
 
 // confirmTrust prompts on stdout and reads a yes/no answer from stdin.

--- a/cmd/mdsmith/trust.go
+++ b/cmd/mdsmith/trust.go
@@ -10,6 +10,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	buildexec "github.com/jeduden/mdsmith/internal/build"
+	"github.com/jeduden/mdsmith/internal/config"
 )
 
 // runTrust implements the `mdsmith trust` subcommand. It shows the diff
@@ -44,15 +45,17 @@ func runTrustIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	root := rootDirFromConfig(configPath)
+	// Pin the same config file the build pass would load, so `mdsmith trust`
+	// and the gate agree even under -c / config discovery.
+	cfgFile := resolveTrustConfigPath(configPath)
 
-	diff, changed, err := buildexec.TrustDiff(root)
+	diff, changed, err := buildexec.TrustDiff(cfgFile)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "mdsmith: trust: %v\n", err)
 		return 2
 	}
 	if !changed {
-		_, _ = fmt.Fprintf(stdout, "%s is already trusted; no change.\n", buildexec.TrustMarkerPath(root))
+		_, _ = fmt.Fprintf(stdout, "%s is already trusted; no change.\n", buildexec.TrustMarkerPath(cfgFile))
 		return 0
 	}
 
@@ -62,12 +65,30 @@ func runTrustIO(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	if err := buildexec.WriteTrustMarker(root); err != nil {
+	if err := buildexec.WriteTrustMarker(cfgFile); err != nil {
 		_, _ = fmt.Fprintf(stderr, "mdsmith: trust: %v\n", err)
 		return 2
 	}
-	_, _ = fmt.Fprintf(stdout, "Trusted %s.\n", buildexec.TrustMarkerPath(root))
+	_, _ = fmt.Fprintf(stdout, "Trusted %s.\n", buildexec.TrustMarkerPath(cfgFile))
 	return 0
+}
+
+// resolveTrustConfigPath returns the config file the trust marker pins.
+// An explicit --config wins; otherwise it discovers the workspace config
+// the way the other subcommands do, falling back to the default config
+// path under the current directory when none is found.
+func resolveTrustConfigPath(configPath string) string {
+	if configPath != "" {
+		return configPath
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return buildexec.ConfigPathForRoot("")
+	}
+	if discovered, derr := config.Discover(cwd); derr == nil && discovered != "" {
+		return discovered
+	}
+	return buildexec.ConfigPathForRoot(cwd)
 }
 
 // confirmTrust prompts on stdout and reads a yes/no answer from stdin.

--- a/cmd/mdsmith/trust_test.go
+++ b/cmd/mdsmith/trust_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cfgTrust writes a .mdsmith.yml at cfg and an identical .trust marker so the
+// trust gate is satisfied. Returns the config path.
+func cfgTrust(t *testing.T, dir string, body []byte) string {
+	t.Helper()
+	cfg := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfg, body, 0o644))
+	require.NoError(t, os.WriteFile(cfg+".trust", body, 0o600))
+	return cfg
+}
+
+func TestRunTrustIO_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"-c", filepath.Join(dir, "nonexistent.yml")},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr.String(), "trust")
+}
+
+func TestRunTrustIO_AlreadyTrusted(t *testing.T) {
+	body := []byte("build: {}\n")
+	cfg := cfgTrust(t, t.TempDir(), body)
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"-c", cfg},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "already trusted")
+}
+
+func TestRunTrustIO_ConfirmYes(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfg, body, 0o644))
+	require.NoError(t, os.WriteFile(cfg+".trust", []byte("old: 1\n"), 0o600))
+
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"-c", cfg},
+		strings.NewReader("y\n"), &stdout, &stderr,
+	)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Trusted")
+}
+
+func TestRunTrustIO_ConfirmNo(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfg, body, 0o644))
+	require.NoError(t, os.WriteFile(cfg+".trust", []byte("old: 1\n"), 0o600))
+
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"-c", cfg},
+		strings.NewReader("n\n"), &stdout, &stderr,
+	)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stdout.String(), "Aborted")
+}
+
+func TestRunTrustIO_YesFlag(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfg, body, 0o644))
+	require.NoError(t, os.WriteFile(cfg+".trust", []byte("old: 1\n"), 0o600))
+
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"-c", cfg, "--yes"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Trusted")
+}
+
+func TestRunTrustIO_FlagParseError(t *testing.T) {
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"--no-such-flag"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	assert.Equal(t, 2, code)
+}
+
+func TestRunTrustIO_HelpFlag(t *testing.T) {
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"--help"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stderr.String(), "trust")
+}
+
+func TestRunTrustIO_WriteTrustMarkerError(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfg, body, 0o644))
+	// Marker exists with different content so TrustDiff returns changed=true.
+	require.NoError(t, os.WriteFile(cfg+".trust", []byte("old: 1\n"), 0o600))
+
+	// Place a non-empty directory where atomicWriteFile would put its temp file
+	// (same dir as the marker). We can't directly block the rename, but we can
+	// make the parent dir unwritable only on non-root systems.
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	var stdout, stderr strings.Builder
+	code := runTrustIO(
+		[]string{"-c", cfg, "--yes"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, stderr.String(), "trust")
+}
+
+func TestConfirmTrust_YesVariants(t *testing.T) {
+	for _, ans := range []string{"y\n", "yes\n", "Y\n", "YES\n"} {
+		var out strings.Builder
+		got := confirmTrust(strings.NewReader(ans), &out)
+		assert.True(t, got, "answer %q should confirm", ans)
+	}
+}
+
+func TestConfirmTrust_NoVariants(t *testing.T) {
+	for _, ans := range []string{"n\n", "\n", ""} {
+		var out strings.Builder
+		got := confirmTrust(strings.NewReader(ans), &out)
+		assert.False(t, got, "answer %q should not confirm", ans)
+	}
+}

--- a/demo.tape
+++ b/demo.tape
@@ -164,6 +164,11 @@ Sleep 300ms
 
 Hide
 Set TypingSpeed 0
+# The build trust gate is opted into here (a sandboxed demo); a real
+# clone runs `mdsmith trust` instead. Keep this in the hidden setup so
+# the on-screen `mdsmith fix page.md` runs the recipe unprompted.
+Type "export MDSMITH_TRUST_BUILD=1"
+Enter
 Type "cd $BUILD_DIR && clear"
 Enter
 Sleep 50ms

--- a/docs/guides/directives/build.md
+++ b/docs/guides/directives/build.md
@@ -343,10 +343,12 @@ variable instead of a committed marker:
 MDSMITH_TRUST_BUILD=1 mdsmith fix .
 ```
 
-When `MDSMITH_TRUST_BUILD` is set to any non-empty value the gate is
-satisfied without a marker file. The variable is consumed by the gate
-only; it is **not** passed through to recipes (see the hermetic
-environment below). Set it only on a runner you control.
+When `MDSMITH_TRUST_BUILD` is set to an affirmative value (anything other
+than `0`, `false`, `no`, or `off`) the gate is satisfied without a marker
+file; setting it to a disabling value leaves the gate in force. The
+variable is consumed by the gate only; it is **not** passed through to
+recipes (see the hermetic environment below). Set it only on a runner you
+control.
 
 ### Hermetic execution environment
 

--- a/docs/guides/directives/build.md
+++ b/docs/guides/directives/build.md
@@ -324,10 +324,6 @@ clone:
 The marker is per-clone, not per-repository: list it in `.gitignore`
 alongside the build cache and staging dir.
 
-```text
-.mdsmith.yml.trust
-```
-
 Run `mdsmith trust` to review and trust a config. It prints a unified
 diff between the stored marker and the current `.mdsmith.yml`, prompts
 for confirmation, and rewrites the marker (mode `0600`) on accept. Pass

--- a/docs/guides/directives/build.md
+++ b/docs/guides/directives/build.md
@@ -130,9 +130,17 @@ build docs/overview.md:30 (pandoc): FAIL: recipe "pandoc" failed: exit status 1
 
 `mdsmith fix` exits non-zero if any recipe fails. A failing recipe
 leaves no partial output: each target stages its outputs in a
-per-target temp directory, and mdsmith renames the staged files into
-place only after the recipe succeeds. A pre-existing output survives
-a failed rebuild untouched.
+random-suffixed per-recipe directory under `.mdsmith/build-staging/`,
+and mdsmith renames the staged files into place only after the recipe
+succeeds and the [output post-conditions](#output-post-conditions)
+pass. A pre-existing output survives a failed rebuild untouched.
+
+The build pass treats `.mdsmith.yml` and every `<?build?>` directive
+as untrusted. Before it runs any recipe it consults the
+[trust gate](#the-trust-gate); each recipe then runs under a
+[hermetic environment](#hermetic-execution-environment) in its own
+process group, and its writes are checked against the declared
+outputs. See [Build safety](#build-safety) for the full model.
 
 The build pass runs *after* the lint-fix pass, so a freshly-edited
 `outputs:` list is built with its new value. The pass runs only from
@@ -172,7 +180,7 @@ path.
 | `--build-force`                 | Rebuild every target; refresh all cache entries                  |
 | `--build-check-stale`           | Print stale targets, exit non-zero if any stale; run no recipe   |
 | `--build-no-cache`              | Treat all targets as stale; do not read or write the cache       |
-| `--build-timeout DUR`           | Per-recipe timeout (default `30s`)                               |
+| `--build-timeout DUR`           | Per-recipe timeout (default `30s`); fires a process-group kill   |
 | `--build-no-hooks`              | Run the build pass but skip both `before` and `after` hook lists |
 | `--build-skip-hooks-when-fresh` | Skip both hook lists when no target is stale; run them otherwise |
 
@@ -276,6 +284,149 @@ mdsmith fix --build-skip-hooks-when-fresh
 Use `--build-no-hooks` to skip hooks entirely and run only the recipe
 pass. Use `--no-build` to skip the build pass including hooks.
 
+## Build safety
+
+The build pass is the only part of mdsmith that runs an external
+process. It treats `.mdsmith.yml` and the `<?build?>` directives as
+untrusted input, so a freshly cloned repository cannot silently run a
+recipe. Four layers cooperate: a trust gate gates execution, a
+hermetic environment bounds what a recipe can read and how it is
+killed, atomic-write hardening protects the project tree from a hostile
+staging path, and output post-conditions reject any write outside the
+declared `outputs:`.
+
+These layers raise the cost of an accidental or hostile recipe; they
+are **not** a sandbox. PATH allowlisting and the staging working
+directory are for build determinism, not filesystem confinement: a
+recipe can still write through an absolute path or `../`, and a write
+into a directory that is not a declared output's parent is not
+detected. Real confinement needs an OS sandbox (a container, `bwrap`,
+or similar). Only run recipes you would run by hand.
+
+### The trust gate
+
+`mdsmith fix` always runs the lint-fix pass. The build pass — the part
+that executes recipes — runs only when the config is trusted on this
+clone:
+
+- The gate is satisfied when a sibling file `.mdsmith.yml.trust`
+  exists and its bytes are identical to the current `.mdsmith.yml`.
+- Any drift (an edit to `.mdsmith.yml` after it was trusted), or a
+  missing marker, makes the build pass abort with a
+  `build not trusted` message and exit code 2. The lint-fix pass has
+  already run, so formatting still happens.
+- `mdsmith fix --no-build` skips the gate and the build pass together.
+- `--build-dry-run` and `--build-check-stale` never consult the gate:
+  they enumerate targets without running anything.
+
+The marker is per-clone, not per-repository: list it in `.gitignore`
+alongside the build cache and staging dir.
+
+```text
+.mdsmith.yml.trust
+```
+
+Run `mdsmith trust` to review and trust a config. It prints a unified
+diff between the stored marker and the current `.mdsmith.yml`, prompts
+for confirmation, and rewrites the marker (mode `0600`) on accept. Pass
+`--yes` to skip the prompt. Re-run it whenever you change `build:`
+settings.
+
+#### CI guidance
+
+CI runners are presumed sandboxed and opt in with an environment
+variable instead of a committed marker:
+
+```sh
+MDSMITH_TRUST_BUILD=1 mdsmith fix .
+```
+
+When `MDSMITH_TRUST_BUILD` is set to any non-empty value the gate is
+satisfied without a marker file. The variable is consumed by the gate
+only; it is **not** passed through to recipes (see the hermetic
+environment below). Set it only on a runner you control.
+
+### Hermetic execution environment
+
+Each recipe runs with a minimal, explicit environment rather than
+inheriting the parent process's:
+
+- `PATH` is `build.exec.path` (default `/usr/bin:/bin`). Nothing else
+  is on the path unless you add its directory.
+- Only the environment variables named in `build.exec.env-pass-through`
+  are forwarded, each with its current value. The default list is
+  `[HOME, LANG, LC_ALL]`. A name that is unset in the parent
+  contributes no entry.
+- The working directory (`Cmd.Dir`) is the per-recipe staging dir.
+
+```yaml
+build:
+  exec:
+    path: "/usr/bin:/bin:/opt/pandoc/bin"
+    env-pass-through: [HOME, LANG, LC_ALL, SOURCE_DATE_EPOCH]
+```
+
+`env-pass-through` *replaces* the default list — it does not append.
+Re-list the defaults you still want; the example above keeps all three
+and adds `SOURCE_DATE_EPOCH` for reproducible builds. MDS040 rejects an
+empty pass-through name or a name containing `=` (which would smuggle in
+a value rather than forward a variable).
+
+The default `build.exec.path` deliberately omits mdsmith's own install
+directory. A recipe that invokes `mdsmith` (for example to run
+`mdsmith extract`) must add the directory holding the binary to
+`build.exec.path`.
+
+Each recipe runs in its own process group (a new session via `Setpgid`
+on Unix; `CREATE_NEW_PROCESS_GROUP` plus a Job Object on Windows). When
+`--build-timeout` expires mdsmith signals the whole group — `SIGTERM`
+on Unix, `CTRL_BREAK_EVENT` on Windows — waits five seconds, then force
+-kills the group (`SIGKILL` / Job Object termination). A recipe that
+spawns a background daemon cannot leave an orphan behind.
+
+### Atomic-write hardening
+
+The staging machinery refuses an unsafe staging root and writes each
+output atomically:
+
+1. `.mdsmith/build-staging/` is created `0700` if absent. If it exists
+   it must be a real directory — a symlink or a non-directory is
+   refused — and on Unix it must not be group- or world-writable, so a
+   hostile co-tenant cannot plant a symlink at a predictable name.
+2. The per-recipe staging dir is created with `os.MkdirTemp`, so its
+   name carries a random suffix.
+3. Each declared output maps to a file inside that staging dir.
+4. Before each output is committed, mdsmith `Lstat`s the destination
+   and refuses to replace an existing symlink. The replace itself is an
+   atomic `rename(2)` (`MoveFileEx` on Windows) for same-volume paths.
+
+Multi-output commit is **not** transactional: if the N+1th rename fails
+after N succeeded, mdsmith reports the partial state, removes the
+staging dir, and exits with `FAIL`. Because no cache entry was written,
+the next `mdsmith fix` reruns the whole recipe.
+
+### Output post-conditions
+
+After a recipe exits 0, two checks run before any file is committed:
+
+- **Every declared output exists** in the staging dir. A recipe that
+  exits 0 without producing a declared output is a build failure
+  (`recipe exited 0 but did not produce X`).
+- **No undeclared write** landed in the project tree. mdsmith snapshots
+  the parent directories of the declared outputs before the recipe
+  (file list, size, mtime, mode, and a sha256 of each file's content)
+  and diffs them after. Any added, removed, or modified file outside
+  the declared `outputs:` is a build failure that names the file.
+  Content hashing catches an edit that preserves size and mtime; mode
+  catches a `chmod`.
+
+Two limits apply. The check covers only the *parent directories* of
+declared outputs, so a write into an unrelated subtree is not seen.
+Symlinks are snapshotted via `Lstat` metadata plus `os.Readlink` and
+never followed. A snapshot scope above 2000 directory entries is a
+build error naming the oversized directory — point the outputs at a
+narrower directory.
+
 ## Staleness and the build cache
 
 The build pass is incremental. By default `mdsmith fix` rebuilds only the
@@ -348,7 +499,12 @@ checked-in config:
 .mdsmith/build-cache.json
 .mdsmith/build-logs/
 .mdsmith/build-staging/
+.mdsmith.yml.trust
 ```
+
+The `.mdsmith.yml.trust` marker is the per-clone build
+[trust gate](#the-trust-gate); it must stay untracked so trust is a
+decision each checkout makes for itself.
 
 ### Recipe default inputs
 

--- a/docs/guides/directives/build.md
+++ b/docs/guides/directives/build.md
@@ -309,12 +309,14 @@ or similar). Only run recipes you would run by hand.
 that executes recipes — runs only when the config is trusted on this
 clone:
 
-- The gate is satisfied when a sibling file `.mdsmith.yml.trust`
-  exists and its bytes are identical to the current `.mdsmith.yml`.
-- Any drift (an edit to `.mdsmith.yml` after it was trusted), or a
-  missing marker, makes the build pass abort with a
-  `build not trusted` message and exit code 2. The lint-fix pass has
-  already run, so formatting still happens.
+- The gate is satisfied when a marker named after the loaded config
+  (`.mdsmith.yml.trust` for the default `.mdsmith.yml`, or
+  `<name>.trust` under `mdsmith fix -c <name>`) exists and its bytes
+  are identical to that config.
+- Any drift (an edit to the config after it was trusted), or a missing
+  marker, makes the build pass abort with a `build not trusted` message
+  and exit code 2. The lint-fix pass has already run, so formatting
+  still happens.
 - `mdsmith fix --no-build` skips the gate and the build pass together.
 - `--build-dry-run` and `--build-check-stale` never consult the gate:
   they enumerate targets without running anything.
@@ -399,6 +401,14 @@ output atomically:
 4. Before each output is committed, mdsmith `Lstat`s the destination
    and refuses to replace an existing symlink. The replace itself is an
    atomic `rename(2)` (`MoveFileEx` on Windows) for same-volume paths.
+
+A declared output under `.mdsmith/` is refused by the build pass
+itself, not only by the MDS039 lint rule, so a recipe can never
+overwrite mdsmith's own state (the build cache, the trust marker, or
+the checked-in `kinds/`, `schemas/`, and `conventions/`) even if MDS039
+is disabled in config. A recipe that stages its declared output as a
+symlink or a directory rather than a regular file is also rejected
+before the commit.
 
 Multi-output commit is **not** transactional: if the N+1th rename fails
 after N succeeded, mdsmith reports the partial state, removes the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,6 +37,7 @@ row: "| [`{command}`]({filename}) | {summary} |"
 | [`metrics`](cli/metrics.md)                   | List and rank shared Markdown metrics (file length, token estimate, readability, …).                                                      |
 | [`pre-merge-commit`](cli/pre-merge-commit.md) | Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.                                                           |
 | [`rename`](cli/rename.md)                     | Rename a heading or link-reference label and rewrite every dependent edit.                                                                |
+| [`trust`](cli/trust.md)                       | Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.                                   |
 | [`version`](cli/version.md)                   | Print the mdsmith build version and exit.                                                                                                 |
 <?/catalog?>
 

--- a/docs/reference/cli/trust.md
+++ b/docs/reference/cli/trust.md
@@ -1,0 +1,56 @@
+---
+command: trust
+summary: Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.
+---
+# `mdsmith trust`
+
+```text
+mdsmith trust [--yes] [--config PATH]
+```
+
+`mdsmith fix` runs the build pass — the part that executes
+`<?build?>` recipes — only when the config is trusted on the current
+clone. A config is trusted when the marker file `.mdsmith.yml.trust`
+sits beside `.mdsmith.yml` and its bytes are identical. `mdsmith trust`
+creates or refreshes that marker.
+
+The command reads the current `.mdsmith.yml`, compares it to the stored
+marker, and:
+
+- prints a unified diff of what changed since the config was last
+  trusted (the whole config when no marker exists yet),
+- prompts for confirmation, and
+- on accept, rewrites `.mdsmith.yml.trust` (mode `0600`) with the
+  current config bytes.
+
+If the marker already matches the config, the command reports that and
+makes no change.
+
+The marker is per-clone state; list it in `.gitignore`. CI runners opt
+in with `MDSMITH_TRUST_BUILD=1` instead of a committed marker — see the
+[build directive guide](../../guides/directives/build.md#the-trust-gate).
+
+## Flags
+
+| Flag             | Behavior                                            |
+| ---------------- | --------------------------------------------------- |
+| `-y`, `--yes`    | Skip the confirmation prompt and trust immediately  |
+| `-c`, `--config` | Override the config file path (default: discovered) |
+
+## Examples
+
+```bash
+# Review the diff and trust interactively.
+mdsmith trust
+
+# Trust without a prompt (e.g. a controlled provisioning script).
+mdsmith trust --yes
+```
+
+## Exit codes
+
+| Code | Meaning                                                 |
+| ---- | ------------------------------------------------------- |
+| 0    | Config trusted, or already trusted (no change)          |
+| 1    | The confirmation prompt was declined                    |
+| 2    | The config could not be read or the marker write failed |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -33,6 +33,7 @@ row: "- [{summary}]({filename})"
 - [Install / manage a pre-merge-commit hook that runs `mdsmith fix` after a merge.](cli/pre-merge-commit.md)
 - [Select Markdown files by a CUE expression on front matter.](cli/query.md)
 - [Rename a heading or link-reference label and rewrite every dependent edit.](cli/rename.md)
+- [Review the .mdsmith.yml diff since it was last trusted and update the build trust marker on this clone.](cli/trust.md)
 - [Print the mdsmith build version and exit.](cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](conventions.md)

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -15,10 +15,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -57,23 +58,38 @@ type Builder interface {
 }
 
 // CustomBuilder is the sole Builder implementation. It dispatches a
-// directive's recipe command via os/exec.
+// directive's recipe command via os/exec under a hermetic environment,
+// staging every output in a random-suffixed per-recipe dir, and
+// committing it with a symlink-safe atomic rename.
 type CustomBuilder struct {
 	recipes map[string]RecipeSpec
+	exec    ExecConfig
 }
 
-// NewCustomBuilder returns a CustomBuilder over the given recipe map.
+// NewCustomBuilder returns a CustomBuilder over the given recipe map. The
+// build executor runs every recipe under the compiled-default hermetic
+// environment (PATH /usr/bin:/bin, pass-through [HOME, LANG, LC_ALL]).
+// Use NewCustomBuilderExec to override those defaults from config.
 func NewCustomBuilder(recipes map[string]RecipeSpec) *CustomBuilder {
 	return &CustomBuilder{recipes: recipes}
+}
+
+// NewCustomBuilderExec returns a CustomBuilder whose recipes run under
+// the given exec configuration. An empty ExecConfig field falls back to
+// the compiled default at exec time.
+func NewCustomBuilderExec(recipes map[string]RecipeSpec, ec ExecConfig) *CustomBuilder {
+	return &CustomBuilder{recipes: recipes, exec: ec}
 }
 
 var _ Builder = (*CustomBuilder)(nil)
 
 // Build resolves the target's inputs and outputs against the project
-// root, stages every output in a per-target temp dir, runs the recipe
-// with the staged paths, and renames the staged files into place on
-// success. On any failure the temp dir is removed and no declared
-// output is touched.
+// root, stages every output in a random-suffixed per-recipe dir under
+// .mdsmith/build-staging/, runs the recipe under a hermetic environment
+// with that dir as its working directory, verifies the output
+// post-conditions, and commits the staged files with symlink-safe atomic
+// renames. On any failure before the commit phase the staging dir is
+// removed and no declared output is touched.
 func (b *CustomBuilder) Build(ctx context.Context, target Target) error {
 	spec, ok := b.recipes[target.Recipe]
 	if !ok {
@@ -84,41 +100,166 @@ func (b *CustomBuilder) Build(ctx context.Context, target Target) error {
 		return fmt.Errorf("recipe %q has an empty command", target.Recipe)
 	}
 
-	inputs, err := b.resolveInputs(target)
+	plan, cleanup, err := b.stage(target)
 	if err != nil {
 		return err
 	}
-	outputs, err := b.resolveOutputs(target)
+	defer cleanup()
+
+	argv := expandArgv(tokens, target.Params, plan.absInputs, plan.stagePaths)
+
+	before, err := snapshotDirs(plan.parents, snapshotCap)
 	if err != nil {
 		return err
 	}
 
-	stageDir, err := mkdirTempFn("", "mdsmith-build-")
-	if err != nil {
-		return fmt.Errorf("creating staging dir: %w", err)
-	}
-	defer os.RemoveAll(stageDir) //nolint:errcheck // best-effort cleanup
-
-	// Stage path per output: a flat file named by index, so a recipe
-	// writing to {outputs}[i] writes inside the staging dir.
-	stagePaths := make([]string, len(outputs))
-	for i := range outputs {
-		stagePaths[i] = filepath.Join(stageDir, fmt.Sprintf("out%d", i))
-	}
-
-	// Absolute input paths recomposed against root.
-	absInputs := make([]string, len(inputs))
-	for i, in := range inputs {
-		absInputs[i] = filepath.Join(target.Root, filepath.FromSlash(in))
-	}
-
-	argv := expandArgv(tokens, target.Params, absInputs, stagePaths)
-
-	if err := runRecipe(ctx, target.Root, argv); err != nil {
+	if err := runRecipe(ctx, runOpts{
+		argv:    argv,
+		dir:     plan.stageDir,
+		exec:    b.exec,
+		defExec: defaultExecConfig(),
+		timeout: timeoutFromContext(ctx),
+	}); err != nil {
 		return fmt.Errorf("recipe %q failed: %w", target.Recipe, err)
 	}
 
-	return commitOutputs(target.Root, outputs, stagePaths)
+	if err := verifyOutputsExist(plan.outputs, plan.stagePaths); err != nil {
+		return err
+	}
+	if err := verifyNoUndeclaredWrites(before, plan.parents, plan.finals); err != nil {
+		return err
+	}
+
+	return commitOutputs(plan.finals, plan.outputs, plan.stagePaths)
+}
+
+// buildPlan holds the resolved paths for one Build call: the recipe's
+// inputs/outputs (root-relative), their absolute forms, the per-output
+// staging paths, and the output parent dirs the post-condition snapshot
+// covers.
+type buildPlan struct {
+	outputs    []string // root-relative declared outputs
+	finals     []string // absolute destinations, one per output
+	stagePaths []string // absolute staging paths, one per output
+	absInputs  []string // absolute resolved inputs
+	parents    []string // de-duplicated output parent dirs
+	stageDir   string   // the per-recipe staging dir
+}
+
+// stage resolves the target's inputs and outputs, validates and creates
+// the per-recipe staging dir, and computes every absolute path Build
+// needs. It returns a cleanup closure that removes the staging dir; the
+// caller must defer it.
+func (b *CustomBuilder) stage(target Target) (buildPlan, func(), error) {
+	inputs, err := b.resolveInputs(target)
+	if err != nil {
+		return buildPlan{}, func() {}, err
+	}
+	outputs, err := b.resolveOutputs(target)
+	if err != nil {
+		return buildPlan{}, func() {}, err
+	}
+
+	stagingRoot, err := ensureStagingRoot(target.Root)
+	if err != nil {
+		return buildPlan{}, func() {}, err
+	}
+	stageDir, err := mkdirTempFn(stagingRoot, "recipe-")
+	if err != nil {
+		return buildPlan{}, func() {}, fmt.Errorf("creating staging dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(stageDir) }
+
+	plan := buildPlan{
+		outputs:    outputs,
+		finals:     make([]string, len(outputs)),
+		stagePaths: make([]string, len(outputs)),
+		absInputs:  make([]string, len(inputs)),
+		stageDir:   stageDir,
+	}
+	for i, rel := range outputs {
+		// A flat file named by index, so a recipe writing to {outputs}[i]
+		// writes inside the staging dir.
+		plan.stagePaths[i] = filepath.Join(stageDir, fmt.Sprintf("out%d", i))
+		plan.finals[i] = filepath.Join(target.Root, filepath.FromSlash(rel))
+	}
+	for i, in := range inputs {
+		plan.absInputs[i] = filepath.Join(target.Root, filepath.FromSlash(in))
+	}
+	plan.parents = outputParents(plan.finals)
+	return plan, cleanup, nil
+}
+
+// outputParents returns the de-duplicated set of parent directories of
+// the declared output paths — the scope the post-condition snapshot
+// covers.
+func outputParents(finals []string) []string {
+	seen := make(map[string]struct{}, len(finals))
+	var out []string
+	for _, f := range finals {
+		dir := filepath.Dir(f)
+		if _, dup := seen[dir]; dup {
+			continue
+		}
+		seen[dir] = struct{}{}
+		out = append(out, dir)
+	}
+	return out
+}
+
+// verifyOutputsExist confirms every declared output was produced in the
+// staging dir. A recipe that exits 0 without writing a declared output is
+// a build failure.
+func verifyOutputsExist(outputs, stagePaths []string) error {
+	for i, rel := range outputs {
+		if _, err := os.Lstat(stagePaths[i]); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("recipe exited 0 but did not produce declared output %q", rel)
+			}
+			return fmt.Errorf("staging output %q: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+// verifyNoUndeclaredWrites re-snapshots the output parent dirs and fails
+// the build if any file outside the declared finals was added, removed,
+// or modified by the recipe.
+func verifyNoUndeclaredWrites(before map[string]fileState, parents, finals []string) error {
+	after, err := snapshotDirs(parents, snapshotCap)
+	if err != nil {
+		return err
+	}
+	declared := make(map[string]struct{}, len(finals))
+	for _, f := range finals {
+		declared[f] = struct{}{}
+	}
+	violations := diffSnapshots(before, after, declared)
+	if len(violations) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(violations))
+	for _, v := range violations {
+		names = append(names, fmt.Sprintf("%s (%s)", v.path, v.kind))
+	}
+	return fmt.Errorf(
+		"recipe wrote outside its declared outputs: %s", strings.Join(names, ", "),
+	)
+}
+
+// timeoutFromContext derives a positive timeout from the context's
+// deadline so runRecipe can run its own process-group kill timer. A
+// context with no deadline yields 0 (no timeout).
+func timeoutFromContext(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0
+	}
+	d := time.Until(deadline)
+	if d <= 0 {
+		return time.Nanosecond // already past: fire the timeout path promptly
+	}
+	return d
 }
 
 // resolveInputs resolves every inputs: entry. A literal entry is
@@ -247,50 +388,60 @@ func substituteParams(tok string, params map[string]string) string {
 	return b.String()
 }
 
-// runRecipe execs argv with the project root as the working directory.
-// No shell is invoked: argv[0] is the program and argv[1:] its
-// arguments. The context bounds the run; on cancellation the process is
-// killed.
-func runRecipe(ctx context.Context, root string, argv []string) error {
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // argv is explicit; user-declared recipe
-	cmd.Dir = root
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		if ctx.Err() != nil {
-			return fmt.Errorf("%w (timed out)", ctx.Err())
-		}
-		return err
-	}
-	return nil
-}
-
-// commitOutputs renames each staged file to its final in-root location,
-// creating parent directories as needed. A staged file that the recipe
-// did not write is an error (the recipe failed to produce a declared
-// output). On any rename failure the already-committed renames are not
-// rolled back here — the per-target temp dir guarantees nothing was
-// touched until this point, and the basic contract (plan 2606101548
-// hardens it further) treats a partial commit failure as a hard error.
-func commitOutputs(root string, outputs, stagePaths []string) error {
+// commitOutputs renames each staged file to its final destination,
+// creating parent directories as needed. Before each replace it Lstats
+// the destination and refuses to overwrite a symlink — a symlink there
+// could redirect the write outside the project tree. The replace is
+// atomic per file (os.Rename → rename(2) / MoveFileEx). Multi-output
+// commit is *not* transactional: if rename N+1 fails after N succeeded,
+// mdsmith reports the partial state and returns an error; the caller
+// removes the staging dir and exits FAIL, and because no cache entry was
+// written the next `fix` reruns the whole recipe.
+func commitOutputs(finals, outputs, stagePaths []string) error {
 	for i, rel := range outputs {
 		stage := stagePaths[i]
-		if _, err := os.Stat(stage); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("recipe did not produce declared output %q", rel)
-			}
-			return fmt.Errorf("staging output %q: %w", rel, err)
+		final := finals[i]
+		if err := refuseSymlinkDest(final, rel); err != nil {
+			return err
 		}
-		final := filepath.Join(root, filepath.FromSlash(rel))
 		if err := os.MkdirAll(filepath.Dir(final), 0o755); err != nil {
 			return fmt.Errorf("creating output dir for %q: %w", rel, err)
 		}
 		if err := os.Rename(stage, final); err != nil {
 			// Cross-device rename can fail; fall back to copy.
 			if cerr := copyFile(stage, final); cerr != nil {
+				if i > 0 {
+					return fmt.Errorf(
+						"writing output %q (outputs 0..%d already committed; rerun fix): %w",
+						rel, i-1, cerr,
+					)
+				}
 				return fmt.Errorf("writing output %q: %w", rel, cerr)
 			}
 		}
+	}
+	return nil
+}
+
+// refuseSymlinkDest fails when the output destination is an existing
+// symlink. Overwriting a symlink with os.Rename replaces the link itself,
+// but a copy fallback (cross-device) would follow it and write through
+// to the link target — possibly outside the project tree. Refusing up
+// front keeps both paths safe and gives a clear diagnostic.
+func refuseSymlinkDest(final, rel string) error {
+	info, err := os.Lstat(final)
+	if err != nil {
+		// ErrNotExist: nothing to replace. ENOTDIR: a parent component is a
+		// file — there is no symlink at the destination, and the subsequent
+		// MkdirAll reports the parent problem with a clearer message. Any
+		// other error is surfaced.
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
+			return nil
+		}
+		return fmt.Errorf("inspecting output %q: %w", rel, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to replace output %q: it is a symlink", rel)
 	}
 	return nil
 }

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -107,7 +107,7 @@ func (b *CustomBuilder) Build(ctx context.Context, target Target) error {
 
 	argv := expandArgv(tokens, target.Params, plan.absInputs, plan.stagePaths)
 
-	before, err := snapshotDirs(plan.parents, snapshotCap)
+	before, err := snapshotDirs(plan.parents, snapshotCap, nil)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func verifyOutputsExist(outputs, stagePaths []string) error {
 // the build if any file outside the declared finals was added, removed,
 // or modified by the recipe.
 func verifyNoUndeclaredWrites(before map[string]fileState, parents, finals []string) error {
-	after, err := snapshotDirs(parents, snapshotCap)
+	after, err := snapshotDirs(parents, snapshotCap, before)
 	if err != nil {
 		return err
 	}
@@ -310,19 +310,12 @@ func (b *CustomBuilder) resolveOutputs(target Target) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if underMdsmithDir(rel) {
+		if buildrule.UnderMdsmithDir(rel) {
 			return nil, fmt.Errorf("output %q is under .mdsmith/; refusing to overwrite mdsmith state", rel)
 		}
 		out = append(out, rel)
 	}
 	return out, nil
-}
-
-// underMdsmithDir reports whether a cleaned, slash-separated
-// project-relative path is the .mdsmith state directory or a file inside
-// it.
-func underMdsmithDir(rel string) bool {
-	return rel == ".mdsmith" || strings.HasPrefix(rel, ".mdsmith/")
 }
 
 // isGlob reports whether a path entry contains doublestar glob meta.

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -118,7 +117,6 @@ func (b *CustomBuilder) Build(ctx context.Context, target Target) error {
 		dir:     plan.stageDir,
 		exec:    b.exec,
 		defExec: defaultExecConfig(),
-		timeout: timeoutFromContext(ctx),
 	}); err != nil {
 		return fmt.Errorf("recipe %q failed: %w", target.Recipe, err)
 	}
@@ -208,15 +206,24 @@ func outputParents(finals []string) []string {
 }
 
 // verifyOutputsExist confirms every declared output was produced in the
-// staging dir. A recipe that exits 0 without writing a declared output is
-// a build failure.
+// staging dir as a regular file. A recipe that exits 0 without writing a
+// declared output is a build failure; so is one that stages a symlink or
+// a directory in place of the output, since committing a symlink would
+// redirect the artifact's bytes outside the staging isolation.
 func verifyOutputsExist(outputs, stagePaths []string) error {
 	for i, rel := range outputs {
-		if _, err := os.Lstat(stagePaths[i]); err != nil {
+		info, err := os.Lstat(stagePaths[i])
+		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("recipe exited 0 but did not produce declared output %q", rel)
 			}
 			return fmt.Errorf("staging output %q: %w", rel, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("recipe staged declared output %q as a symlink; refusing to commit it", rel)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("recipe staged declared output %q as a non-regular file", rel)
 		}
 	}
 	return nil
@@ -245,21 +252,6 @@ func verifyNoUndeclaredWrites(before map[string]fileState, parents, finals []str
 	return fmt.Errorf(
 		"recipe wrote outside its declared outputs: %s", strings.Join(names, ", "),
 	)
-}
-
-// timeoutFromContext derives a positive timeout from the context's
-// deadline so runRecipe can run its own process-group kill timer. A
-// context with no deadline yields 0 (no timeout).
-func timeoutFromContext(ctx context.Context) time.Duration {
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		return 0
-	}
-	d := time.Until(deadline)
-	if d <= 0 {
-		return time.Nanosecond // already past: fire the timeout path promptly
-	}
-	return d
 }
 
 // resolveInputs resolves every inputs: entry. A literal entry is
@@ -306,7 +298,11 @@ func (b *CustomBuilder) resolveInputs(target Target) ([]string, error) {
 }
 
 // resolveOutputs re-checks every outputs: entry against the project
-// root. Outputs may not exist yet, so mustExist is false.
+// root. Outputs may not exist yet, so mustExist is false. An output under
+// .mdsmith/ is refused here, not just in the MDS039 lint rule: the build
+// pass must never let a recipe overwrite mdsmith's own state (the build
+// cache, the trust marker, kinds/schemas/conventions) even when MDS039 is
+// disabled or overridden in config.
 func (b *CustomBuilder) resolveOutputs(target Target) ([]string, error) {
 	out := make([]string, 0, len(target.Outputs))
 	for _, entry := range target.Outputs {
@@ -314,9 +310,19 @@ func (b *CustomBuilder) resolveOutputs(target Target) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		if underMdsmithDir(rel) {
+			return nil, fmt.Errorf("output %q is under .mdsmith/; refusing to overwrite mdsmith state", rel)
+		}
 		out = append(out, rel)
 	}
 	return out, nil
+}
+
+// underMdsmithDir reports whether a cleaned, slash-separated
+// project-relative path is the .mdsmith state directory or a file inside
+// it.
+func underMdsmithDir(rel string) bool {
+	return rel == ".mdsmith" || strings.HasPrefix(rel, ".mdsmith/")
 }
 
 // isGlob reports whether a path entry contains doublestar glob meta.

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -31,6 +31,24 @@ var mkdirTempFn = os.MkdirTemp
 // builderGlobCapFn is the CheckGlobMatchCap implementation; tests may replace it.
 var builderGlobCapFn = buildrule.CheckGlobMatchCap
 
+// snapshotDirsFn is the snapshotDirs implementation; tests may replace it to
+// inject snapshot failures in the before/after post-condition scan.
+var snapshotDirsFn = snapshotDirs
+
+// lstatFn is the os.Lstat implementation; tests may replace it to inject a
+// stat failure when inspecting an output destination.
+var lstatFn = os.Lstat
+
+// renameFn is the os.Rename implementation; tests may replace it to force the
+// cross-device copy fallback in commitOutputs.
+var renameFn = os.Rename
+
+// copyFileImplFn is the copyFile implementation used by the rename fallback;
+// tests may replace it to inject a copy failure.
+var copyFileImplFn = func(src, dst string) error {
+	return copyFile(src, dst)
+}
+
 // RecipeSpec is the resolved command and tokenized argv for one
 // user-declared recipe. Tokenization happens once at construction so a
 // param value containing whitespace can never re-split.
@@ -107,7 +125,7 @@ func (b *CustomBuilder) Build(ctx context.Context, target Target) error {
 
 	argv := expandArgv(tokens, target.Params, plan.absInputs, plan.stagePaths)
 
-	before, err := snapshotDirs(plan.parents, snapshotCap, nil)
+	before, err := snapshotDirsFn(plan.parents, snapshotCap, nil)
 	if err != nil {
 		return err
 	}
@@ -233,7 +251,7 @@ func verifyOutputsExist(outputs, stagePaths []string) error {
 // the build if any file outside the declared finals was added, removed,
 // or modified by the recipe.
 func verifyNoUndeclaredWrites(before map[string]fileState, parents, finals []string) error {
-	after, err := snapshotDirs(parents, snapshotCap, before)
+	after, err := snapshotDirsFn(parents, snapshotCap, before)
 	if err != nil {
 		return err
 	}
@@ -406,9 +424,9 @@ func commitOutputs(finals, outputs, stagePaths []string) error {
 		if err := os.MkdirAll(filepath.Dir(final), 0o755); err != nil {
 			return fmt.Errorf("creating output dir for %q: %w", rel, err)
 		}
-		if err := os.Rename(stage, final); err != nil {
+		if err := renameFn(stage, final); err != nil {
 			// Cross-device rename can fail; fall back to copy.
-			if cerr := copyFile(stage, final); cerr != nil {
+			if cerr := copyFileImplFn(stage, final); cerr != nil {
 				if i > 0 {
 					return fmt.Errorf(
 						"writing output %q (outputs 0..%d already committed; rerun fix): %w",
@@ -428,7 +446,7 @@ func commitOutputs(finals, outputs, stagePaths []string) error {
 // to the link target — possibly outside the project tree. Refusing up
 // front keeps both paths safe and gives a clear diagnostic.
 func refuseSymlinkDest(final, rel string) error {
-	info, err := os.Lstat(final)
+	info, err := lstatFn(final)
 	if err != nil {
 		// ErrNotExist: nothing to replace. ENOTDIR: a parent component is a
 		// file — there is no symlink at the destination, and the subsequent

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -371,7 +371,8 @@ func TestCommitOutputs_MkdirAllError(t *testing.T) {
 	stage := filepath.Join(stageDir, "out0")
 	require.NoError(t, os.WriteFile(stage, []byte("data"), 0o644))
 
-	err := commitOutputs(root, []string{"file.txt/result.txt"}, []string{stage})
+	finals := []string{filepath.Join(root, "file.txt", "result.txt")}
+	err := commitOutputs(finals, []string{"file.txt/result.txt"}, []string{stage})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating output dir")
 }
@@ -389,7 +390,8 @@ func TestCommitOutputs_RenameFallbackToCopyFails(t *testing.T) {
 	stage := filepath.Join(stageDir, "out0")
 	require.NoError(t, os.WriteFile(stage, []byte("data"), 0o644))
 
-	err := commitOutputs(root, []string{"result"}, []string{stage})
+	finals := []string{filepath.Join(root, "result")}
+	err := commitOutputs(finals, []string{"result"}, []string{stage})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "writing output")
 }
@@ -436,12 +438,14 @@ func TestCopyFile_PreservesSourceMode(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
-func TestBuild_StagingDirCreationFails(t *testing.T) {
-	// Allocate the temp dirs before overriding TMPDIR — t.TempDir would
-	// fail under the bogus value.
+func TestBuild_StagingRootCreationFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR semantics differ on Windows")
+	}
 	root := t.TempDir()
-	// Point TMPDIR at a path that does not exist so os.MkdirTemp fails.
-	t.Setenv("TMPDIR", filepath.Join(root, "nope"))
+	// Plant a regular file at .mdsmith so MkdirAll(.mdsmith/build-staging)
+	// fails with ENOTDIR before any recipe runs.
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith"), []byte("x"), 0o644))
 	b := NewCustomBuilder(map[string]RecipeSpec{
 		"echo": recipeCmd("echo hi"),
 	})
@@ -451,23 +455,30 @@ func TestBuild_StagingDirCreationFails(t *testing.T) {
 		Outputs: []string{"out.txt"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "creating staging dir")
+	assert.Contains(t, err.Error(), "staging root")
 }
 
-func TestCommitOutputs_StatNonNotExistError(t *testing.T) {
+func TestVerifyOutputsExist_StatNonNotExistError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("ENOTDIR semantics differ on Windows")
 	}
-	root := t.TempDir()
-	// A stage path that descends through a regular file makes os.Stat
+	// A stage path that descends through a regular file makes os.Lstat
 	// fail with ENOTDIR — a non-ErrNotExist error.
 	blocker := filepath.Join(t.TempDir(), "blocker")
 	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
 	stage := filepath.Join(blocker, "out0")
 
-	err := commitOutputs(root, []string{"out.txt"}, []string{stage})
+	err := verifyOutputsExist([]string{"out.txt"}, []string{stage})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "staging output")
+}
+
+func TestVerifyOutputsExist_MissingOutput(t *testing.T) {
+	stageDir := t.TempDir()
+	stage := filepath.Join(stageDir, "out0") // never created
+	err := verifyOutputsExist([]string{"out.txt"}, []string{stage})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not produce declared output")
 }
 
 func TestSubstituteParams_PrefixBeforePlaceholder(t *testing.T) {
@@ -499,16 +510,19 @@ func TestBuild_MkdirTempError(t *testing.T) {
 	assert.Contains(t, err.Error(), "staging dir")
 }
 
-func TestCommitOutputs_StatError(t *testing.T) {
+func TestVerifyOutputsExist_StatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR semantics differ on Windows")
+	}
 	root := t.TempDir()
 	// Create a regular file at the same path as the expected staging dir so
-	// os.Stat on "notadir/out0" fails with ENOTDIR — a non-ENOENT error that
-	// hits the "staging output" error branch rather than the "did not produce"
-	// branch.
+	// os.Lstat on "notadir/out0" fails with ENOTDIR — a non-ENOENT error
+	// that hits the "staging output" error branch rather than the
+	// "did not produce" branch.
 	notadir := filepath.Join(root, "notadir")
 	require.NoError(t, os.WriteFile(notadir, []byte("x"), 0o644))
 
-	err := commitOutputs(root, []string{"out.txt"}, []string{filepath.Join(notadir, "out0")})
+	err := verifyOutputsExist([]string{"out.txt"}, []string{filepath.Join(notadir, "out0")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "staging output")
 }

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -19,6 +19,15 @@ func recipeCmd(command string) RecipeSpec {
 	return RecipeSpec{Command: command}
 }
 
+func TestNewCustomBuilderExec(t *testing.T) {
+	recipes := map[string]RecipeSpec{"r": recipeCmd("echo")}
+	ec := ExecConfig{Path: "/custom/bin"}
+	b := NewCustomBuilderExec(recipes, ec)
+	require.NotNil(t, b)
+	assert.Equal(t, ec.Path, b.exec.Path)
+	assert.Len(t, b.recipes, 1)
+}
+
 func TestBuild_SingleOutputCp(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("cp is not available on Windows")

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -572,4 +573,173 @@ func TestVerifyOutputsExist_StatError(t *testing.T) {
 	err := verifyOutputsExist([]string{"out.txt"}, []string{filepath.Join(notadir, "out0")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "staging output")
+}
+
+func TestBuild_SnapshotDirsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh is not available on Windows")
+	}
+	old := snapshotDirsFn
+	snapshotDirsFn = func([]string, int, map[string]fileState) (map[string]fileState, error) {
+		return nil, errors.New("before-snapshot failed")
+	}
+	t.Cleanup(func() { snapshotDirsFn = old })
+
+	root := t.TempDir()
+	bindir := t.TempDir()
+	script := writeScript(t, bindir, "noop.sh", `printf x > "$1"`)
+	b := NewCustomBuilder(map[string]RecipeSpec{
+		"r": recipeCmd(script + " {outputs}"),
+	})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "r",
+		Root:    root,
+		Outputs: []string{"out.txt"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before-snapshot failed")
+}
+
+func TestBuild_VerifyNoUndeclaredWritesSnapshotError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh is not available on Windows")
+	}
+	// Fail only the SECOND snapshot call (the after-snapshot inside
+	// verifyNoUndeclaredWrites); the first (before-snapshot) succeeds so the
+	// recipe runs and we reach the after-snapshot error branch.
+	var calls atomic.Int32
+	old := snapshotDirsFn
+	snapshotDirsFn = func(dirs []string, max int, prior map[string]fileState) (map[string]fileState, error) {
+		if calls.Add(1) == 2 {
+			return nil, errors.New("after-snapshot failed")
+		}
+		return snapshotDirs(dirs, max, prior)
+	}
+	t.Cleanup(func() { snapshotDirsFn = old })
+
+	root := t.TempDir()
+	bindir := t.TempDir()
+	script := writeScript(t, bindir, "noop.sh", `printf x > "$1"`)
+	b := NewCustomBuilder(map[string]RecipeSpec{
+		"r": recipeCmd(script + " {outputs}"),
+	})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "r",
+		Root:    root,
+		Outputs: []string{"out.txt"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "after-snapshot failed")
+}
+
+func TestBuild_UndeclaredWriteDetected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh is not available on Windows")
+	}
+	root := t.TempDir()
+	// The output parent is root itself (output is just "dst.txt"). The recipe
+	// copies src to the staged output ($1) and also writes an undeclared
+	// sibling at an absolute path in that same parent ($2), which the
+	// post-condition snapshot must flag.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.txt"), []byte("hi"), 0o644))
+	sneaky := filepath.Join(root, "sneaky.txt")
+	bindir := t.TempDir()
+	script := writeScript(t, bindir, "sneak.sh", `printf x > "$1"; echo evil > "$2"`)
+	b := NewCustomBuilder(map[string]RecipeSpec{
+		"r": recipeCmd(script + " {outputs} " + sneaky),
+	})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "r",
+		Root:    root,
+		Inputs:  []string{"src.txt"},
+		Outputs: []string{"dst.txt"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wrote outside its declared outputs")
+	// The declared output must not be committed when the post-check fails.
+	assert.NoFileExists(t, filepath.Join(root, "dst.txt"))
+}
+
+func TestCommitOutputs_RefusesSymlinkDest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	root := t.TempDir()
+	// Plant a symlink at the output destination. commitOutputs must refuse to
+	// replace it rather than follow it through to the target. (A real Build
+	// resolves an output symlink earlier, so commitOutputs is exercised
+	// directly here to reach the symlink-destination guard.)
+	target := filepath.Join(t.TempDir(), "outside")
+	require.NoError(t, os.WriteFile(target, []byte("orig"), 0o644))
+	final := filepath.Join(root, "dst.txt")
+	require.NoError(t, os.Symlink(target, final))
+
+	stageDir := t.TempDir()
+	stage := filepath.Join(stageDir, "out0")
+	require.NoError(t, os.WriteFile(stage, []byte("new"), 0o644))
+
+	err := commitOutputs([]string{final}, []string{"dst.txt"}, []string{stage})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+	// The symlink target outside the tree must be untouched (not followed).
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "orig", string(got))
+}
+
+func TestBuild_LstatErrorRefusesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh is not available on Windows")
+	}
+	old := lstatFn
+	lstatFn = func(string) (os.FileInfo, error) { return nil, os.ErrPermission }
+	t.Cleanup(func() { lstatFn = old })
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.txt"), []byte("hi"), 0o644))
+	b := NewCustomBuilder(map[string]RecipeSpec{
+		"copy": recipeCmd("cp {inputs} {outputs}"),
+	})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "copy",
+		Root:    root,
+		Inputs:  []string{"src.txt"},
+		Outputs: []string{"dst.txt"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inspecting output")
+}
+
+func TestBuild_MultiOutputPartialFailure(t *testing.T) {
+	// Force the rename→copy fallback for every output, and make the copy
+	// fail on the SECOND output so the i>0 partial-failure branch fires.
+	oldRename := renameFn
+	renameFn = func(string, string) error { return errors.New("cross-device") }
+	t.Cleanup(func() { renameFn = oldRename })
+
+	var copyCalls atomic.Int32
+	oldCopy := copyFileImplFn
+	copyFileImplFn = func(src, dst string) error {
+		if copyCalls.Add(1) == 2 {
+			return errors.New("copy failed on second output")
+		}
+		return copyFile(src, dst)
+	}
+	t.Cleanup(func() { copyFileImplFn = oldCopy })
+
+	root := t.TempDir()
+	stageDir := t.TempDir()
+	stage0 := filepath.Join(stageDir, "out0")
+	stage1 := filepath.Join(stageDir, "out1")
+	require.NoError(t, os.WriteFile(stage0, []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(stage1, []byte("b"), 0o644))
+
+	finals := []string{filepath.Join(root, "a.txt"), filepath.Join(root, "b.txt")}
+	err := commitOutputs(finals, []string{"a.txt", "b.txt"}, []string{stage0, stage1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already committed")
+	// The first output committed via the copy fallback.
+	got, rerr := os.ReadFile(finals[0])
+	require.NoError(t, rerr)
+	assert.Equal(t, "a", string(got))
 }

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -481,6 +481,44 @@ func TestVerifyOutputsExist_MissingOutput(t *testing.T) {
 	assert.Contains(t, err.Error(), "did not produce declared output")
 }
 
+func TestBuild_OutputUnderMdsmithRefused(t *testing.T) {
+	root := t.TempDir()
+	b := NewCustomBuilder(map[string]RecipeSpec{"r": recipeCmd("echo hi {outputs}")})
+	err := b.Build(context.Background(), Target{
+		Recipe:  "r",
+		Root:    root,
+		Outputs: []string{".mdsmith/build-cache.json"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".mdsmith/")
+	assert.NoFileExists(t, filepath.Join(root, ".mdsmith", "build-cache.json"))
+}
+
+func TestVerifyOutputsExist_StagedSymlinkRefused(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics")
+	}
+	stageDir := t.TempDir()
+	target := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o644))
+	stage := filepath.Join(stageDir, "out0")
+	require.NoError(t, os.Symlink(target, stage))
+
+	err := verifyOutputsExist([]string{"out.txt"}, []string{stage})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+}
+
+func TestVerifyOutputsExist_StagedDirRefused(t *testing.T) {
+	stageDir := t.TempDir()
+	stage := filepath.Join(stageDir, "out0")
+	require.NoError(t, os.MkdirAll(stage, 0o755))
+
+	err := verifyOutputsExist([]string{"out.txt"}, []string{stage})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-regular")
+}
+
 func TestSubstituteParams_PrefixBeforePlaceholder(t *testing.T) {
 	// A token with literal prefix text before a {name} placeholder exercises
 	// the WriteByte branch that copies non-'{' characters one at a time.

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -147,6 +147,12 @@ func (c *Cache) Save(root string) error {
 // file-system tricks.
 var writeTempFileVar = writeTempFile
 
+// chmodFileFn indirects the temp-file chmod in atomicWriteFile so a test
+// can inject a chmod failure without filesystem tricks.
+var chmodFileFn = func(f *os.File, mode os.FileMode) error {
+	return f.Chmod(mode)
+}
+
 // writeTempFile writes data to wc and closes it. Extracted so tests
 // can inject a failing io.WriteCloser without needing file-system tricks.
 func writeTempFile(wc io.WriteCloser, data []byte) error {
@@ -173,7 +179,7 @@ func atomicWriteFile(final string, mode os.FileMode, data []byte) error {
 	}
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup; harmless once rename succeeds
-	if err := tmp.Chmod(mode); err != nil {
+	if err := chmodFileFn(tmp, mode); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("setting temp file mode: %w", err)
 	}

--- a/internal/build/cache.go
+++ b/internal/build/cache.go
@@ -135,26 +135,16 @@ func (c *Cache) Save(root string) error {
 	data, _ := json.MarshalIndent(c, "", "  ")
 	data = append(data, '\n')
 
-	tmp, err := os.CreateTemp(dir, "build-cache-*.json.tmp")
-	if err != nil {
-		return fmt.Errorf("creating temp cache file: %w", err)
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup on the failure path
-
-	if err := writeTempFileVar(tmp, data); err != nil {
-		return err
-	}
-
 	final := filepath.Join(dir, "build-cache.json")
-	if err := os.Rename(tmpName, final); err != nil {
+	if err := atomicWriteFile(final, 0o644, data); err != nil {
 		return fmt.Errorf("committing build cache: %w", err)
 	}
 	return nil
 }
 
-// writeTempFileVar is the writeTempFile implementation used by Save; tests may
-// replace it to inject write failures without file-system tricks.
+// writeTempFileVar is the writeTempFile implementation used by
+// atomicWriteFile; tests may replace it to inject write failures without
+// file-system tricks.
 var writeTempFileVar = writeTempFile
 
 // writeTempFile writes data to wc and closes it. Extracted so tests
@@ -162,10 +152,36 @@ var writeTempFileVar = writeTempFile
 func writeTempFile(wc io.WriteCloser, data []byte) error {
 	if _, err := wc.Write(data); err != nil {
 		_ = wc.Close()
-		return fmt.Errorf("writing temp cache file: %w", err)
+		return fmt.Errorf("writing temp file: %w", err)
 	}
 	if err := wc.Close(); err != nil {
-		return fmt.Errorf("closing temp cache file: %w", err)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	return nil
+}
+
+// atomicWriteFile writes data to final atomically: a temp file in the same
+// directory (so the rename is same-volume), chmod'd to mode, then renamed
+// over final. A crash mid-write leaves final untouched. Shared by the
+// build cache and the trust marker so both get the same durability and
+// the same test-injectable inner write.
+func atomicWriteFile(final string, mode os.FileMode, data []byte) error {
+	dir := filepath.Dir(final)
+	tmp, err := os.CreateTemp(dir, filepath.Base(final)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup; harmless once rename succeeds
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("setting temp file mode: %w", err)
+	}
+	if err := writeTempFileVar(tmp, data); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, final); err != nil {
+		return fmt.Errorf("committing %s: %w", filepath.Base(final), err)
 	}
 	return nil
 }

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -202,13 +202,13 @@ func (w *closeFailWriter) Close() error                { return errors.New("flus
 func TestWriteTempFile_WriteError(t *testing.T) {
 	err := writeTempFile(&writeFailCloser{}, []byte("data"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "writing temp cache file")
+	assert.Contains(t, err.Error(), "writing temp file")
 }
 
 func TestWriteTempFile_CloseError(t *testing.T) {
 	err := writeTempFile(&closeFailWriter{}, []byte("data"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "closing temp cache file")
+	assert.Contains(t, err.Error(), "closing temp file")
 }
 
 func TestCache_Save_SortOrder(t *testing.T) {

--- a/internal/build/cache_test.go
+++ b/internal/build/cache_test.go
@@ -237,3 +237,23 @@ func TestCache_Save_WriteTempFileError(t *testing.T) {
 	err := c.Save(root)
 	require.Error(t, err)
 }
+
+func TestAtomicWriteFile_CreateTempError(t *testing.T) {
+	// The temp file is created in the destination's parent dir; a parent that
+	// does not exist makes os.CreateTemp fail.
+	final := filepath.Join(t.TempDir(), "nonexistent", "file.txt")
+	err := atomicWriteFile(final, 0o644, []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating temp file")
+}
+
+func TestAtomicWriteFile_ChmodError(t *testing.T) {
+	old := chmodFileFn
+	chmodFileFn = func(*os.File, os.FileMode) error { return errors.New("chmod failed") }
+	t.Cleanup(func() { chmodFileFn = old })
+
+	final := filepath.Join(t.TempDir(), "file.txt")
+	err := atomicWriteFile(final, 0o644, []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setting temp file mode")
+}

--- a/internal/build/exec.go
+++ b/internal/build/exec.go
@@ -1,0 +1,150 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"time"
+)
+
+// defaultExecPath is the compiled-default PATH a recipe runs under when
+// build.exec.path is empty. It is deliberately minimal: a recipe that
+// needs a tool outside these dirs must opt the directory in.
+const defaultExecPath = "/usr/bin:/bin"
+
+// defaultPassThrough is the compiled-default env-pass-through list. These
+// three names are safe, locale/home variables a typical recipe expects;
+// anything else (tokens, credentials, CI injected secrets) is withheld.
+func defaultPassThrough() []string {
+	return []string{"HOME", "LANG", "LC_ALL"}
+}
+
+// ExecConfig is the resolved build.exec settings for a run: the
+// allowlisted PATH and the names of environment variables passed through
+// to every recipe. Both fields are optional; an empty field means the
+// compiled default applies.
+type ExecConfig struct {
+	// Path is the PATH the recipe runs under. Empty means defaultExecPath.
+	Path string
+	// EnvPassThrough names the environment variables forwarded into the
+	// recipe. Nil means the compiled default list; a non-nil list
+	// *replaces* the default (it does not append).
+	EnvPassThrough []string
+}
+
+// defaultExecConfig returns the compiled defaults as an ExecConfig.
+func defaultExecConfig() ExecConfig {
+	return ExecConfig{Path: defaultExecPath, EnvPassThrough: defaultPassThrough()}
+}
+
+// buildEnv constructs the minimal KEY=VALUE environment slice for a
+// recipe. PATH comes from cfg.Path (or def.Path when empty). The
+// pass-through list comes from cfg.EnvPassThrough (or def's when nil);
+// each named variable that is actually set in the current process is
+// forwarded with its current value. An unset name produces no entry.
+// Entries are sorted for determinism.
+func buildEnv(cfg, def ExecConfig) []string {
+	path := cfg.Path
+	if path == "" {
+		path = def.Path
+	}
+	pass := cfg.EnvPassThrough
+	if pass == nil {
+		pass = def.EnvPassThrough
+	}
+
+	env := map[string]string{"PATH": path}
+	for _, name := range pass {
+		if name == "" || name == "PATH" {
+			// PATH is set explicitly above; an empty name is meaningless.
+			continue
+		}
+		if v, ok := os.LookupEnv(name); ok {
+			env[name] = v
+		}
+	}
+
+	out := make([]string, 0, len(env))
+	for _, k := range sortedKeysOf(env) {
+		out = append(out, k+"="+env[k])
+	}
+	return out
+}
+
+// sortedKeysOf returns the map keys in sorted order.
+func sortedKeysOf(m map[string]string) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+// runOpts bundles the inputs to runRecipe.
+type runOpts struct {
+	argv    []string      // program plus arguments (no shell)
+	dir     string        // working directory (the per-recipe staging dir)
+	exec    ExecConfig    // user-configured exec settings
+	defExec ExecConfig    // compiled defaults to fall back to
+	timeout time.Duration // per-recipe timeout; <=0 means no timeout
+}
+
+// runRecipe executes argv with a hermetic environment, a fixed working
+// directory, and process-group isolation. No shell is invoked: argv[0]
+// is the program and argv[1:] its arguments.
+//
+// The recipe runs in its own process group (Setpgid on Unix;
+// CREATE_NEW_PROCESS_GROUP plus a Job Object on Windows). On timeout
+// mdsmith signals the whole group (SIGTERM on Unix, CTRL_BREAK on
+// Windows), waits up to gracePeriod, then force-kills the group, so a
+// recipe that spawns daemons cannot leave orphans behind.
+func runRecipe(ctx context.Context, o runOpts) error {
+	// We manage the timeout and kill path ourselves (process group), so the
+	// command itself is not bound to a context-cancel kill — that would
+	// only kill the leader, not the group.
+	cmd := exec.Command(o.argv[0], o.argv[1:]...) //nolint:gosec // argv is explicit; user-declared recipe
+	cmd.Dir = o.dir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.Env = buildEnv(o.exec, o.defExec)
+	configureProcessGroup(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting recipe: %w", err)
+	}
+
+	jobCleanup := afterStart(cmd)
+	if jobCleanup != nil {
+		defer jobCleanup()
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	var timeoutCh <-chan time.Time
+	if o.timeout > 0 {
+		t := time.NewTimer(o.timeout)
+		defer t.Stop()
+		timeoutCh = t.C
+	}
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		killGroup(cmd)
+		<-done
+		return fmt.Errorf("recipe cancelled: %w", ctx.Err())
+	case <-timeoutCh:
+		killGroup(cmd)
+		<-done
+		return fmt.Errorf("recipe timed out after %s", o.timeout)
+	}
+}
+
+// gracePeriod is how long mdsmith waits after the first (polite)
+// termination signal before force-killing the process group.
+const gracePeriod = 5 * time.Second

--- a/internal/build/exec.go
+++ b/internal/build/exec.go
@@ -116,7 +116,7 @@ func runRecipe(ctx context.Context, o runOpts) error {
 		return fmt.Errorf("starting recipe: %w", err)
 	}
 
-	jobCleanup := afterStart(cmd)
+	jobCleanup := afterStartFn(cmd)
 	if jobCleanup != nil {
 		defer jobCleanup()
 	}
@@ -142,5 +142,10 @@ func runRecipe(ctx context.Context, o runOpts) error {
 }
 
 // gracePeriod is how long mdsmith waits after the first (polite)
-// termination signal before force-killing the process group.
-const gracePeriod = 5 * time.Second
+// termination signal before force-killing the process group. It is a var,
+// not a const, so a kill-path test can shorten it.
+var gracePeriod = 5 * time.Second
+
+// afterStartFn indirects afterStart so a test can install a non-nil job
+// cleanup and exercise the deferred-cleanup branch on Unix.
+var afterStartFn = afterStart

--- a/internal/build/exec.go
+++ b/internal/build/exec.go
@@ -2,10 +2,13 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
-	"sort"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -61,35 +64,32 @@ func buildEnv(cfg, def ExecConfig) []string {
 			// PATH is set explicitly above; an empty name is meaningless.
 			continue
 		}
+		if strings.ContainsAny(name, "=\x00\n\r") {
+			// Defense in depth: config validation already rejects these, but
+			// NewCustomBuilderExec is exported, so re-guard here. A name with
+			// "=" or a control char could smuggle a value or a second entry
+			// into the recipe environment.
+			continue
+		}
 		if v, ok := os.LookupEnv(name); ok {
 			env[name] = v
 		}
 	}
 
 	out := make([]string, 0, len(env))
-	for _, k := range sortedKeysOf(env) {
+	for _, k := range slices.Sorted(maps.Keys(env)) {
 		out = append(out, k+"="+env[k])
 	}
 	return out
 }
 
-// sortedKeysOf returns the map keys in sorted order.
-func sortedKeysOf(m map[string]string) []string {
-	ks := make([]string, 0, len(m))
-	for k := range m {
-		ks = append(ks, k)
-	}
-	sort.Strings(ks)
-	return ks
-}
-
-// runOpts bundles the inputs to runRecipe.
+// runOpts bundles the inputs to runRecipe. The per-recipe timeout is
+// carried by the context's deadline, not a separate field.
 type runOpts struct {
-	argv    []string      // program plus arguments (no shell)
-	dir     string        // working directory (the per-recipe staging dir)
-	exec    ExecConfig    // user-configured exec settings
-	defExec ExecConfig    // compiled defaults to fall back to
-	timeout time.Duration // per-recipe timeout; <=0 means no timeout
+	argv    []string   // program plus arguments (no shell)
+	dir     string     // working directory (the per-recipe staging dir)
+	exec    ExecConfig // user-configured exec settings
+	defExec ExecConfig // compiled defaults to fall back to
 }
 
 // runRecipe executes argv with a hermetic environment, a fixed working
@@ -124,24 +124,20 @@ func runRecipe(ctx context.Context, o runOpts) error {
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
-	var timeoutCh <-chan time.Time
-	if o.timeout > 0 {
-		t := time.NewTimer(o.timeout)
-		defer t.Stop()
-		timeoutCh = t.C
-	}
-
+	// The context carries the deadline (set by the caller via
+	// context.WithTimeout). We do not bind the command to a context-cancel
+	// kill — that would kill only the leader, not the process group — so on
+	// ctx.Done() we kill the whole group ourselves, then drain the Wait.
 	select {
 	case err := <-done:
 		return err
 	case <-ctx.Done():
 		killGroup(cmd)
 		<-done
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("recipe timed out: %w", ctx.Err())
+		}
 		return fmt.Errorf("recipe cancelled: %w", ctx.Err())
-	case <-timeoutCh:
-		killGroup(cmd)
-		<-done
-		return fmt.Errorf("recipe timed out after %s", o.timeout)
 	}
 }
 

--- a/internal/build/exec_test.go
+++ b/internal/build/exec_test.go
@@ -81,6 +81,22 @@ func envMap(env []string) map[string]string {
 	return m
 }
 
+func TestBuildEnv_SkipsEmptyAndPathPassThroughNames(t *testing.T) {
+	// An empty name and the literal "PATH" in the pass-through list must be
+	// silently skipped: PATH is set explicitly and an empty name is meaningless.
+	t.Setenv("PATH", "/injected")
+	cfg := ExecConfig{
+		Path:           "/custom/bin",
+		EnvPassThrough: []string{"", "PATH"},
+	}
+	env := buildEnv(cfg, defaultExecConfig())
+	got := envMap(env)
+	// PATH must come from cfg.Path, not from the environment.
+	assert.Equal(t, "/custom/bin", got["PATH"])
+	// Only PATH should be in the map; empty name produces no entry.
+	assert.Len(t, got, 1)
+}
+
 func TestRunRecipe_HermeticEnvVisibleToProcess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sh not available on Windows")

--- a/internal/build/exec_test.go
+++ b/internal/build/exec_test.go
@@ -57,6 +57,20 @@ func TestBuildEnv_UnsetPassThroughIsOmitted(t *testing.T) {
 	assert.False(t, ok, "an unset pass-through var produces no entry")
 }
 
+func TestBuildEnv_RejectsMalformedPassThroughName(t *testing.T) {
+	t.Setenv("GOOD", "yes")
+	// A name with "=" or a control char is skipped even if such a variable
+	// somehow exists, so it cannot smuggle an entry into the environment.
+	cfg := ExecConfig{EnvPassThrough: []string{"GOOD", "EVIL=injected", "BAD\nNAME"}}
+	env := buildEnv(cfg, defaultExecConfig())
+	got := envMap(env)
+	assert.Equal(t, "yes", got["GOOD"])
+	for k := range got {
+		assert.NotContains(t, k, "=")
+		assert.NotContains(t, k, "\n")
+	}
+}
+
 // envMap parses a KEY=VALUE slice into a map.
 func envMap(env []string) map[string]string {
 	m := make(map[string]string, len(env))
@@ -79,12 +93,13 @@ func TestRunRecipe_HermeticEnvVisibleToProcess(t *testing.T) {
 	// `env` is a coreutils binary on PATH /usr/bin:/bin.
 	script := writeScript(t, t.TempDir(), "dumpenv.sh", `env | sort > "$1"`)
 
-	err := runRecipe(context.Background(), runOpts{
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := runRecipe(ctx, runOpts{
 		argv:    []string{script, out},
 		dir:     stage,
 		exec:    ExecConfig{},
 		defExec: defaultExecConfig(),
-		timeout: 10 * time.Second,
 	})
 	require.NoError(t, err)
 
@@ -106,12 +121,13 @@ func TestRunRecipe_CmdDirIsStaging(t *testing.T) {
 	out := filepath.Join(stage, "pwd.txt")
 	script := writeScript(t, t.TempDir(), "pwd.sh", `pwd > "$1"`)
 
-	err = runRecipe(context.Background(), runOpts{
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = runRecipe(ctx, runOpts{
 		argv:    []string{script, out},
 		dir:     stage,
 		exec:    ExecConfig{},
 		defExec: defaultExecConfig(),
-		timeout: 10 * time.Second,
 	})
 	require.NoError(t, err)
 	data, err := os.ReadFile(out)
@@ -131,12 +147,13 @@ func TestRunRecipe_TimeoutKillsProcessGroup(t *testing.T) {
 	script := writeScript(t, t.TempDir(), "spawn.sh", body)
 
 	start := time.Now()
-	err := runRecipe(context.Background(), runOpts{
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	err := runRecipe(ctx, runOpts{
 		argv:    []string{script},
 		dir:     stage,
 		exec:    ExecConfig{},
 		defExec: defaultExecConfig(),
-		timeout: 500 * time.Millisecond,
 	})
 	require.Error(t, err)
 	assert.Less(t, time.Since(start), 10*time.Second, "kill should be prompt")
@@ -160,4 +177,48 @@ func TestRunRecipe_TimeoutKillsProcessGroup(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return !processAlive(childPID)
 	}, 6*time.Second, 100*time.Millisecond, "spawned child should not be orphaned")
+}
+
+func TestRunRecipe_TimeoutErrorMessageIsDeterministic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on Windows")
+	}
+	stage := t.TempDir()
+	script := writeScript(t, t.TempDir(), "slow.sh", `sleep 120`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := runRecipe(ctx, runOpts{
+		argv:    []string{script},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+	})
+	require.Error(t, err)
+	// A deadline-bound context reports a timeout, never a bare "cancelled".
+	assert.Contains(t, err.Error(), "timed out")
+	assert.NotContains(t, err.Error(), "cancelled")
+}
+
+func TestRunRecipe_CancellationReported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on Windows")
+	}
+	stage := t.TempDir()
+	script := writeScript(t, t.TempDir(), "slow.sh", `sleep 120`)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+	err := runRecipe(ctx, runOpts{
+		argv:    []string{script},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+	})
+	require.Error(t, err)
+	// A non-deadline cancellation reports "cancelled", not "timed out".
+	assert.Contains(t, err.Error(), "cancelled")
 }

--- a/internal/build/exec_test.go
+++ b/internal/build/exec_test.go
@@ -1,0 +1,163 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEnv_DefaultsOnly(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	t.Setenv("LANG", "en_US.UTF-8")
+	t.Setenv("SECRET_TOKEN", "leak-me")
+
+	env := buildEnv(ExecConfig{}, defaultExecConfig())
+
+	got := envMap(env)
+	assert.Equal(t, defaultExecPath, got["PATH"])
+	assert.Equal(t, "/home/tester", got["HOME"])
+	assert.Equal(t, "en_US.UTF-8", got["LANG"])
+	_, leaked := got["SECRET_TOKEN"]
+	assert.False(t, leaked, "non-allowlisted var must not pass through")
+}
+
+func TestBuildEnv_CustomPathAndPassThrough(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	t.Setenv("SOURCE_DATE_EPOCH", "1700000000")
+	t.Setenv("LANG", "C")
+
+	cfg := ExecConfig{
+		Path:           "/opt/bin:/bin",
+		EnvPassThrough: []string{"SOURCE_DATE_EPOCH"},
+	}
+	env := buildEnv(cfg, defaultExecConfig())
+	got := envMap(env)
+	assert.Equal(t, "/opt/bin:/bin", got["PATH"])
+	assert.Equal(t, "1700000000", got["SOURCE_DATE_EPOCH"])
+	// EnvPassThrough replaces the default list; HOME/LANG are not re-listed.
+	_, hasHome := got["HOME"]
+	assert.False(t, hasHome, "custom pass-through replaces defaults, not appends")
+	_, hasLang := got["LANG"]
+	assert.False(t, hasLang)
+}
+
+func TestBuildEnv_UnsetPassThroughIsOmitted(t *testing.T) {
+	_ = os.Unsetenv("LC_ALL")
+	t.Setenv("HOME", "/h")
+	env := buildEnv(ExecConfig{}, defaultExecConfig())
+	got := envMap(env)
+	_, ok := got["LC_ALL"]
+	assert.False(t, ok, "an unset pass-through var produces no entry")
+}
+
+// envMap parses a KEY=VALUE slice into a map.
+func envMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		k, v, _ := strings.Cut(e, "=")
+		m[k] = v
+	}
+	return m
+}
+
+func TestRunRecipe_HermeticEnvVisibleToProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on Windows")
+	}
+	t.Setenv("HOME", "/home/tester")
+	t.Setenv("SECRET_TOKEN", "leak-me")
+
+	stage := t.TempDir()
+	out := filepath.Join(stage, "env.txt")
+	// `env` is a coreutils binary on PATH /usr/bin:/bin.
+	script := writeScript(t, t.TempDir(), "dumpenv.sh", `env | sort > "$1"`)
+
+	err := runRecipe(context.Background(), runOpts{
+		argv:    []string{script, out},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+		timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	body := string(data)
+	assert.Contains(t, body, "PATH="+defaultExecPath)
+	assert.Contains(t, body, "HOME=/home/tester")
+	assert.NotContains(t, body, "SECRET_TOKEN")
+}
+
+func TestRunRecipe_CmdDirIsStaging(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh not available on Windows")
+	}
+	stage := t.TempDir()
+	realStage, err := filepath.EvalSymlinks(stage)
+	require.NoError(t, err)
+	out := filepath.Join(stage, "pwd.txt")
+	script := writeScript(t, t.TempDir(), "pwd.sh", `pwd > "$1"`)
+
+	err = runRecipe(context.Background(), runOpts{
+		argv:    []string{script, out},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+		timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, realStage, strings.TrimSpace(string(data)))
+}
+
+func TestRunRecipe_TimeoutKillsProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group kill tested on Unix")
+	}
+	stage := t.TempDir()
+	pidFile := filepath.Join(stage, "child.pid")
+	// Parent spawns a long-lived child in the background, records its PID,
+	// then sleeps. On timeout the whole group must die, including the child.
+	body := `sleep 120 & echo $! > "` + pidFile + `"; sleep 120`
+	script := writeScript(t, t.TempDir(), "spawn.sh", body)
+
+	start := time.Now()
+	err := runRecipe(context.Background(), runOpts{
+		argv:    []string{script},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+		timeout: 500 * time.Millisecond,
+	})
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 10*time.Second, "kill should be prompt")
+
+	// Give the kernel a moment to reap.
+	deadline := time.Now().Add(6 * time.Second)
+	var childPID int
+	for time.Now().Before(deadline) {
+		b, rerr := os.ReadFile(pidFile)
+		if rerr == nil {
+			if n, perr := parsePID(strings.TrimSpace(string(b))); perr == nil {
+				childPID = n
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NotZero(t, childPID, "child pid should have been recorded")
+
+	// The child must no longer be alive: signal 0 probes existence.
+	assert.Eventually(t, func() bool {
+		return !processAlive(childPID)
+	}, 6*time.Second, 100*time.Millisecond, "spawned child should not be orphaned")
+}

--- a/internal/build/exec_test.go
+++ b/internal/build/exec_test.go
@@ -3,15 +3,57 @@ package build
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunRecipe_StartError(t *testing.T) {
+	// A nonexistent program makes cmd.Start fail before Wait, hitting the
+	// "starting recipe" error branch.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := runRecipe(ctx, runOpts{
+		argv:    []string{filepath.Join(t.TempDir(), "does-not-exist")},
+		dir:     t.TempDir(),
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "starting recipe")
+}
+
+func TestRunRecipe_NonNilJobCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh is not available on Windows")
+	}
+	// On Unix afterStart returns nil; inject a non-nil cleanup so runRecipe
+	// installs and runs the deferred-cleanup branch.
+	var ran atomic.Bool
+	old := afterStartFn
+	afterStartFn = func(*exec.Cmd) func() { return func() { ran.Store(true) } }
+	t.Cleanup(func() { afterStartFn = old })
+
+	stage := t.TempDir()
+	script := writeScript(t, t.TempDir(), "noop.sh", `exit 0`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := runRecipe(ctx, runOpts{
+		argv:    []string{script},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+	})
+	require.NoError(t, err)
+	assert.True(t, ran.Load(), "deferred job cleanup must run")
+}
 
 func TestBuildEnv_DefaultsOnly(t *testing.T) {
 	t.Setenv("HOME", "/home/tester")

--- a/internal/build/exec_unix.go
+++ b/internal/build/exec_unix.go
@@ -1,0 +1,49 @@
+//go:build unix
+
+package build
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureProcessGroup puts the recipe in its own process group so a
+// timeout can signal the whole group, not just the leader. Setpgid makes
+// the child the leader of a new group whose pgid equals its pid.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// afterStart is a no-op on Unix; the Job Object equivalent is Windows
+// only. It returns nil so runRecipe installs no cleanup defer.
+func afterStart(*exec.Cmd) func() { return nil }
+
+// killGroup terminates the recipe's whole process group. It sends
+// SIGTERM first, waits up to gracePeriod for the group to exit, then
+// sends SIGKILL. Signaling the negative pgid reaches every process in
+// the group, so a recipe's background children are killed too.
+func killGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	pgid := cmd.Process.Pid // Setpgid made pgid == leader pid
+	_ = signalGroup(pgid, syscall.SIGTERM)
+
+	// Wait for the group to drain, polling with signal 0 (existence probe).
+	deadline := time.Now().Add(gracePeriod)
+	for time.Now().Before(deadline) {
+		if signalGroup(pgid, 0) != nil {
+			return // group is gone
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = signalGroup(pgid, syscall.SIGKILL)
+}
+
+// signalGroup sends sig to the process group pgid. It returns the syscall
+// error (nil on success); callers use a sig of 0 to probe whether the
+// group still exists.
+func signalGroup(pgid int, sig syscall.Signal) error {
+	return syscall.Kill(-pgid, sig)
+}

--- a/internal/build/exec_unix_test.go
+++ b/internal/build/exec_unix_test.go
@@ -3,8 +3,15 @@
 package build
 
 import (
+	"context"
+	"os/exec"
 	"strconv"
 	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // parsePID parses a decimal PID string.
@@ -18,4 +25,35 @@ func parsePID(s string) (int, error) {
 func processAlive(pid int) bool {
 	err := syscall.Kill(pid, 0)
 	return err == nil || err == syscall.EPERM
+}
+
+func TestKillGroup_NilProcess(t *testing.T) {
+	// A command that never started has a nil Process; killGroup must return
+	// immediately rather than dereference it.
+	killGroup(&exec.Cmd{})
+}
+
+func TestKillGroup_SIGKILLPath(t *testing.T) {
+	// A recipe that ignores SIGTERM must still be force-killed: killGroup
+	// waits gracePeriod for the polite signal to work, then sends SIGKILL.
+	old := gracePeriod
+	gracePeriod = 50 * time.Millisecond
+	t.Cleanup(func() { gracePeriod = old })
+
+	stage := t.TempDir()
+	// trap '' TERM makes the process ignore SIGTERM; only SIGKILL ends it.
+	script := writeScript(t, t.TempDir(), "ignore.sh", `trap '' TERM; sleep 60`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := runRecipe(ctx, runOpts{
+		argv:    []string{script},
+		dir:     stage,
+		exec:    ExecConfig{},
+		defExec: defaultExecConfig(),
+	})
+	require.Error(t, err)
+	// With a 50ms grace period and SIGTERM ignored, SIGKILL ends it quickly.
+	assert.Less(t, time.Since(start), 5*time.Second, "SIGKILL should be prompt")
 }

--- a/internal/build/exec_unix_test.go
+++ b/internal/build/exec_unix_test.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package build
+
+import (
+	"strconv"
+	"syscall"
+)
+
+// parsePID parses a decimal PID string.
+func parsePID(s string) (int, error) {
+	return strconv.Atoi(s)
+}
+
+// processAlive reports whether a process with the given PID exists. It
+// uses signal 0, which performs error checking without delivering a
+// signal: ESRCH means the process is gone.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/build/exec_windows.go
+++ b/internal/build/exec_windows.go
@@ -4,6 +4,7 @@ package build
 
 import (
 	"os/exec"
+	"sync"
 	"syscall"
 	"unsafe"
 )
@@ -46,16 +47,27 @@ func afterStart(cmd *exec.Cmd) func() {
 		return nil
 	}
 	_ = closeHandle(ph)
+	jobHandlesMu.Lock()
 	jobHandles[cmd] = job
+	jobHandlesMu.Unlock()
 	return func() {
 		_ = closeHandle(job) // KILL_ON_JOB_CLOSE reaps any survivors
+		jobHandlesMu.Lock()
 		delete(jobHandles, cmd)
+		jobHandlesMu.Unlock()
 	}
 }
 
 // jobHandles maps a running command to its Job Object handle so
 // killGroup can terminate the whole job synchronously on timeout.
-var jobHandles = map[*exec.Cmd]syscall.Handle{}
+// jobHandlesMu guards it: Build is an exported method with no
+// single-threaded contract, so afterStart, killGroup, and the cleanup
+// closure may run from different goroutines if a caller dispatches
+// recipes concurrently.
+var (
+	jobHandlesMu sync.Mutex
+	jobHandles   = map[*exec.Cmd]syscall.Handle{}
+)
 
 // killGroup sends CTRL_BREAK_EVENT to the recipe's process group, then
 // terminates the Job Object so any survivors (including grandchildren)
@@ -66,7 +78,10 @@ func killGroup(cmd *exec.Cmd) {
 		return
 	}
 	sendCtrlBreak(cmd.Process.Pid)
-	if job, ok := jobHandles[cmd]; ok {
+	jobHandlesMu.Lock()
+	job, ok := jobHandles[cmd]
+	jobHandlesMu.Unlock()
+	if ok {
 		_ = terminateJob(job)
 	}
 }
@@ -111,6 +126,13 @@ type ioCounters struct {
 	OtherTransferCount  uint64
 }
 
+// jobObjectExtendedLimitInformationStruct mirrors the Win32
+// JOBOBJECT_EXTENDED_LIMIT_INFORMATION layout. Only
+// BasicLimitInformation.LimitFlags is written, but every field below is
+// size- and offset-significant: SetInformationJobObject is passed
+// unsafe.Sizeof(info), so removing a field (or the IoInfo counters) would
+// shrink the struct and make the call fail, leaking survivor processes.
+// Do not prune the unused fields.
 type jobObjectExtendedLimitInformationStruct struct {
 	BasicLimitInformation jobObjectBasicLimitInformation
 	IoInfo                ioCounters

--- a/internal/build/exec_windows.go
+++ b/internal/build/exec_windows.go
@@ -1,0 +1,174 @@
+//go:build windows
+
+package build
+
+import (
+	"os/exec"
+	"syscall"
+	"unsafe"
+)
+
+// configureProcessGroup creates the recipe in a new process group so a
+// CTRL_BREAK_EVENT can target the group on timeout. The Job Object that
+// guarantees the kill path is created after Start (afterStart).
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windowsCreateNewProcessGroup,
+	}
+}
+
+// windowsCreateNewProcessGroup is CREATE_NEW_PROCESS_GROUP. Defined
+// locally so the file does not depend on x/sys/windows.
+const windowsCreateNewProcessGroup = 0x00000200
+
+// afterStart assigns the started process to a freshly created Job Object
+// configured to kill the whole tree when the handle closes. It returns a
+// cleanup closure that closes the job handle (and so kills any survivors)
+// when the recipe completes. On any failure setting up the job it returns
+// a no-op cleanup: the CREATE_NEW_PROCESS_GROUP flag still allows the
+// CTRL_BREAK kill path.
+func afterStart(cmd *exec.Cmd) func() {
+	if cmd.Process == nil {
+		return nil
+	}
+	job, err := createKillOnCloseJob()
+	if err != nil {
+		return nil
+	}
+	ph, err := openProcessForJob(cmd.Process.Pid)
+	if err != nil {
+		_ = closeHandle(job)
+		return nil
+	}
+	if err := assignProcessToJob(job, ph); err != nil {
+		_ = closeHandle(ph)
+		_ = closeHandle(job)
+		return nil
+	}
+	_ = closeHandle(ph)
+	jobHandles[cmd] = job
+	return func() {
+		_ = closeHandle(job) // KILL_ON_JOB_CLOSE reaps any survivors
+		delete(jobHandles, cmd)
+	}
+}
+
+// jobHandles maps a running command to its Job Object handle so
+// killGroup can terminate the whole job synchronously on timeout.
+var jobHandles = map[*exec.Cmd]syscall.Handle{}
+
+// killGroup sends CTRL_BREAK_EVENT to the recipe's process group, then
+// terminates the Job Object so any survivors (including grandchildren)
+// are killed. The job termination is the guaranteed kill path; the
+// CTRL_BREAK is the polite first signal.
+func killGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	sendCtrlBreak(cmd.Process.Pid)
+	if job, ok := jobHandles[cmd]; ok {
+		_ = terminateJob(job)
+	}
+}
+
+// --- thin syscall wrappers over kernel32 ---
+
+var (
+	modkernel32                  = syscall.NewLazyDLL("kernel32.dll")
+	procCreateJobObject          = modkernel32.NewProc("CreateJobObjectW")
+	procSetInformationJobObject  = modkernel32.NewProc("SetInformationJobObject")
+	procAssignProcessToJobObject = modkernel32.NewProc("AssignProcessToJobObject")
+	procTerminateJobObject       = modkernel32.NewProc("TerminateJobObject")
+	procOpenProcess              = modkernel32.NewProc("OpenProcess")
+	procGenConsoleCtrlEvent      = modkernel32.NewProc("GenerateConsoleCtrlEvent")
+)
+
+const (
+	jobObjectExtendedLimitInformation = 9
+	jobObjectLimitKillOnJobClose      = 0x00002000
+	processAllAccess                  = 0x1F0FFF
+	ctrlBreakEvent                    = 1
+)
+
+type jobObjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+
+type ioCounters struct {
+	ReadOperationCount  uint64
+	WriteOperationCount uint64
+	OtherOperationCount uint64
+	ReadTransferCount   uint64
+	WriteTransferCount  uint64
+	OtherTransferCount  uint64
+}
+
+type jobObjectExtendedLimitInformationStruct struct {
+	BasicLimitInformation jobObjectBasicLimitInformation
+	IoInfo                ioCounters
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+func createKillOnCloseJob() (syscall.Handle, error) {
+	r, _, e := procCreateJobObject.Call(0, 0)
+	if r == 0 {
+		return 0, e
+	}
+	job := syscall.Handle(r)
+	info := jobObjectExtendedLimitInformationStruct{}
+	info.BasicLimitInformation.LimitFlags = jobObjectLimitKillOnJobClose
+	rr, _, ee := procSetInformationJobObject.Call(
+		uintptr(job),
+		uintptr(jobObjectExtendedLimitInformation),
+		uintptr(unsafe.Pointer(&info)),
+		unsafe.Sizeof(info),
+	)
+	if rr == 0 {
+		_ = closeHandle(job)
+		return 0, ee
+	}
+	return job, nil
+}
+
+func openProcessForJob(pid int) (syscall.Handle, error) {
+	r, _, e := procOpenProcess.Call(uintptr(processAllAccess), 0, uintptr(pid))
+	if r == 0 {
+		return 0, e
+	}
+	return syscall.Handle(r), nil
+}
+
+func assignProcessToJob(job, proc syscall.Handle) error {
+	r, _, e := procAssignProcessToJobObject.Call(uintptr(job), uintptr(proc))
+	if r == 0 {
+		return e
+	}
+	return nil
+}
+
+func terminateJob(job syscall.Handle) error {
+	r, _, e := procTerminateJobObject.Call(uintptr(job), 1)
+	if r == 0 {
+		return e
+	}
+	return nil
+}
+
+func sendCtrlBreak(pid int) {
+	_, _, _ = procGenConsoleCtrlEvent.Call(uintptr(ctrlBreakEvent), uintptr(pid))
+}
+
+func closeHandle(h syscall.Handle) error {
+	return syscall.CloseHandle(h)
+}

--- a/internal/build/postcheck.go
+++ b/internal/build/postcheck.go
@@ -1,0 +1,163 @@
+package build
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// snapshotCap bounds the number of directory entries a single snapshot
+// may cover. Above it the snapshot is refused so a recipe pointed at a
+// huge tree cannot make the post-condition check quadratically slow.
+const snapshotCap = 2000
+
+// fileState is the recorded metadata for one file in a snapshot. mtime is
+// stored as a Unix-nanosecond value; sha256 is the content hash of a
+// regular file (empty for non-regular entries). link is the symlink
+// target (empty for non-symlinks), captured via Readlink so a symlink is
+// never followed.
+type fileState struct {
+	size  int64
+	mtime int64
+	mode  os.FileMode
+	hash  [32]byte
+	link  string
+}
+
+// snapshotDirs records the metadata of every entry in the (non-recursive)
+// listing of each directory in dirs. Directories are de-duplicated.
+// Symlinks are recorded via Lstat metadata plus Readlink and never
+// followed. A total entry count above cap is a build error naming the
+// offending directory.
+func snapshotDirs(dirs []string, maxEntries int) (map[string]fileState, error) {
+	snap := make(map[string]fileState)
+	seen := make(map[string]struct{}, len(dirs))
+	total := 0
+	for _, dir := range dirs {
+		if _, dup := seen[dir]; dup {
+			continue
+		}
+		seen[dir] = struct{}{}
+
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// A not-yet-created output parent contributes nothing.
+				continue
+			}
+			return nil, fmt.Errorf("scanning %s: %w", dir, err)
+		}
+		total += len(entries)
+		if total > maxEntries {
+			return nil, fmt.Errorf(
+				"build snapshot scope exceeds 2 000 entries at %s; point outputs at a narrower directory",
+				dir,
+			)
+		}
+		for _, e := range entries {
+			path := filepath.Join(dir, e.Name())
+			st, err := statFile(path)
+			if err != nil {
+				return nil, err
+			}
+			snap[path] = st
+		}
+	}
+	return snap, nil
+}
+
+// statFile records one path's metadata. A regular file is hashed; a
+// symlink's target is read but never followed; other types record
+// metadata only.
+func statFile(path string) (fileState, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fileState{}, fmt.Errorf("inspecting %s: %w", path, err)
+	}
+	st := fileState{
+		size:  info.Size(),
+		mtime: info.ModTime().UnixNano(),
+		mode:  info.Mode(),
+	}
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		target, lerr := os.Readlink(path)
+		if lerr != nil {
+			return fileState{}, fmt.Errorf("reading symlink %s: %w", path, lerr)
+		}
+		st.link = target
+	case info.Mode().IsRegular():
+		h, herr := hashFileSum(path)
+		if herr != nil {
+			return fileState{}, herr
+		}
+		st.hash = h
+	}
+	return st, nil
+}
+
+// hashFileSum returns the sha256 of a regular file's contents, streamed so a
+// large artifact never has to fit in memory.
+func hashFileSum(path string) ([32]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // path comes from a directory listing we control
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("hashing %s: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck // read-only
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return [32]byte{}, fmt.Errorf("hashing %s: %w", path, err)
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// undeclaredWrite names a file outside the declared outputs whose state
+// changed across the recipe.
+type undeclaredWrite struct {
+	path string
+	kind string // "added", "removed", or "modified"
+}
+
+// diffSnapshots reports every file whose state differs between before and
+// after, excluding paths in declared. A declared output legitimately
+// changes; anything else is an undeclared write. Results are sorted by
+// path for a deterministic diagnostic.
+func diffSnapshots(before, after map[string]fileState, declared map[string]struct{}) []undeclaredWrite {
+	var violations []undeclaredWrite
+	for path, post := range after {
+		if _, ok := declared[path]; ok {
+			continue
+		}
+		pre, existed := before[path]
+		if !existed {
+			violations = append(violations, undeclaredWrite{path: path, kind: "added"})
+			continue
+		}
+		if !sameState(pre, post) {
+			violations = append(violations, undeclaredWrite{path: path, kind: "modified"})
+		}
+	}
+	for path := range before {
+		if _, ok := declared[path]; ok {
+			continue
+		}
+		if _, stillThere := after[path]; !stillThere {
+			violations = append(violations, undeclaredWrite{path: path, kind: "removed"})
+		}
+	}
+	sort.Slice(violations, func(i, j int) bool { return violations[i].path < violations[j].path })
+	return violations
+}
+
+// sameState reports whether two file states are byte-for-byte
+// equivalent: size, mtime, mode, content hash, and symlink target all
+// match.
+func sameState(a, b fileState) bool {
+	return a.size == b.size && a.mtime == b.mtime &&
+		a.mode == b.mode && a.hash == b.hash && a.link == b.link
+}

--- a/internal/build/postcheck.go
+++ b/internal/build/postcheck.go
@@ -15,10 +15,13 @@ import (
 const snapshotCap = 2000
 
 // fileState is the recorded metadata for one file in a snapshot. mtime is
-// stored as a Unix-nanosecond value; sha256 is the content hash of a
-// regular file (empty for non-regular entries). link is the symlink
-// target (empty for non-symlinks), captured via Readlink so a symlink is
-// never followed.
+// stored as a Unix-nanosecond value. hash is the sha256 of a regular
+// file's content, captured eagerly: the before-snapshot must record the
+// original bytes because they are gone once the recipe overwrites them,
+// so the content-preserving-rewrite check (same size and mtime, different
+// bytes) cannot be deferred. hash is zero for non-regular entries. link
+// is the symlink target (empty for non-symlinks), captured via Readlink
+// so a symlink is never followed.
 type fileState struct {
 	size  int64
 	mtime int64
@@ -69,9 +72,9 @@ func snapshotDirs(dirs []string, maxEntries int) (map[string]fileState, error) {
 	return snap, nil
 }
 
-// statFile records one path's metadata. A regular file is hashed; a
-// symlink's target is read but never followed; other types record
-// metadata only.
+// statFile records one path's metadata. A regular file is hashed eagerly
+// (see fileState.hash); a symlink's target is read but never followed;
+// other types record metadata only.
 func statFile(path string) (fileState, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
@@ -154,9 +157,10 @@ func diffSnapshots(before, after map[string]fileState, declared map[string]struc
 	return violations
 }
 
-// sameState reports whether two file states are byte-for-byte
-// equivalent: size, mtime, mode, content hash, and symlink target all
-// match.
+// sameState reports whether two file states are equivalent: size, mtime,
+// mode, content hash, and symlink target all match. The hash comparison
+// catches a content-preserving rewrite (same size and mtime, different
+// bytes); the cheap metadata fields short-circuit the common case.
 func sameState(a, b fileState) bool {
 	return a.size == b.size && a.mtime == b.mtime &&
 		a.mode == b.mode && a.hash == b.hash && a.link == b.link

--- a/internal/build/postcheck.go
+++ b/internal/build/postcheck.go
@@ -35,7 +35,15 @@ type fileState struct {
 // Symlinks are recorded via Lstat metadata plus Readlink and never
 // followed. A total entry count above cap is a build error naming the
 // offending directory.
-func snapshotDirs(dirs []string, maxEntries int) (map[string]fileState, error) {
+//
+// prior is an earlier snapshot (or nil). When a file's cheap metadata
+// (size, mtime, mode) already differs from its prior entry, the verdict
+// is decided without the content hash, so this snapshot skips hashing
+// that file. The hash is computed only when the cheap fields match the
+// prior — the one case the content-preserving-rewrite check needs it.
+// The before-snapshot (prior == nil) always hashes, because its bytes
+// must be captured before the recipe overwrites them.
+func snapshotDirs(dirs []string, maxEntries int, prior map[string]fileState) (map[string]fileState, error) {
 	snap := make(map[string]fileState)
 	seen := make(map[string]struct{}, len(dirs))
 	total := 0
@@ -62,7 +70,8 @@ func snapshotDirs(dirs []string, maxEntries int) (map[string]fileState, error) {
 		}
 		for _, e := range entries {
 			path := filepath.Join(dir, e.Name())
-			st, err := statFile(path)
+			priorState, hadPrior := prior[path]
+			st, err := statFile(path, priorState, hadPrior)
 			if err != nil {
 				return nil, err
 			}
@@ -72,10 +81,16 @@ func snapshotDirs(dirs []string, maxEntries int) (map[string]fileState, error) {
 	return snap, nil
 }
 
-// statFile records one path's metadata. A regular file is hashed eagerly
-// (see fileState.hash); a symlink's target is read but never followed;
-// other types record metadata only.
-func statFile(path string) (fileState, error) {
+// statFile records one path's metadata. A symlink's target is read but
+// never followed; other non-regular types record metadata only. A
+// regular file is hashed, except that the hash read is skipped when a
+// prior snapshot already recorded this path with *different* size, mtime,
+// or mode: in that case the diff verdict is decided by the cheap fields
+// alone, so the content hash can never matter. When there is no prior
+// entry, or the cheap fields match the prior, the file is hashed — the
+// before-snapshot (hadPrior == false) therefore always hashes, capturing
+// the original bytes before the recipe can overwrite them.
+func statFile(path string, prior fileState, hadPrior bool) (fileState, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return fileState{}, fmt.Errorf("inspecting %s: %w", path, err)
@@ -93,6 +108,11 @@ func statFile(path string) (fileState, error) {
 		}
 		st.link = target
 	case info.Mode().IsRegular():
+		if hadPrior && !cheapFieldsMatch(prior, st) {
+			// Cheap fields already differ from the prior snapshot, so the
+			// verdict is "modified" without the hash; skip the read.
+			break
+		}
 		h, herr := hashFileSum(path)
 		if herr != nil {
 			return fileState{}, herr
@@ -161,7 +181,19 @@ func diffSnapshots(before, after map[string]fileState, declared map[string]struc
 // mode, content hash, and symlink target all match. The hash comparison
 // catches a content-preserving rewrite (same size and mtime, different
 // bytes); the cheap metadata fields short-circuit the common case.
+//
+// The after-snapshot only hashes files whose cheap fields match the
+// before-snapshot (see statFile), so when this returns a hash mismatch
+// both sides carry a real hash; when the cheap fields differ the after
+// hash is zero but a cheap field already differs, so the result is still
+// correct.
 func sameState(a, b fileState) bool {
 	return a.size == b.size && a.mtime == b.mtime &&
 		a.mode == b.mode && a.hash == b.hash && a.link == b.link
+}
+
+// cheapFieldsMatch reports whether two file states share the metadata a
+// snapshot can read without opening the file: size, mtime, and mode.
+func cheapFieldsMatch(a, b fileState) bool {
+	return a.size == b.size && a.mtime == b.mtime && a.mode == b.mode
 }

--- a/internal/build/postcheck.go
+++ b/internal/build/postcheck.go
@@ -14,6 +14,14 @@ import (
 // huge tree cannot make the post-condition check quadratically slow.
 const snapshotCap = 2000
 
+// statFileFn, readlinkFn, and hashFileSumFn indirect the per-file snapshot
+// reads so tests can drive their error branches without filesystem tricks.
+var (
+	statFileFn    = statFile
+	readlinkFn    = os.Readlink
+	hashFileSumFn = hashFileSum
+)
+
 // fileState is the recorded metadata for one file in a snapshot. mtime is
 // stored as a Unix-nanosecond value. hash is the sha256 of a regular
 // file's content, captured eagerly: the before-snapshot must record the
@@ -71,7 +79,7 @@ func snapshotDirs(dirs []string, maxEntries int, prior map[string]fileState) (ma
 		for _, e := range entries {
 			path := filepath.Join(dir, e.Name())
 			priorState, hadPrior := prior[path]
-			st, err := statFile(path, priorState, hadPrior)
+			st, err := statFileFn(path, priorState, hadPrior)
 			if err != nil {
 				return nil, err
 			}
@@ -102,7 +110,7 @@ func statFile(path string, prior fileState, hadPrior bool) (fileState, error) {
 	}
 	switch {
 	case info.Mode()&os.ModeSymlink != 0:
-		target, lerr := os.Readlink(path)
+		target, lerr := readlinkFn(path)
 		if lerr != nil {
 			return fileState{}, fmt.Errorf("reading symlink %s: %w", path, lerr)
 		}
@@ -113,7 +121,7 @@ func statFile(path string, prior fileState, hadPrior bool) (fileState, error) {
 			// verdict is "modified" without the hash; skip the read.
 			break
 		}
-		h, herr := hashFileSum(path)
+		h, herr := hashFileSumFn(path)
 		if herr != nil {
 			return fileState{}, herr
 		}

--- a/internal/build/postcheck_test.go
+++ b/internal/build/postcheck_test.go
@@ -57,21 +57,27 @@ func TestDiffSnapshots_DetectsModifiedContent(t *testing.T) {
 	root := t.TempDir()
 	other := filepath.Join(root, "other.txt")
 	require.NoError(t, os.WriteFile(other, []byte("aaaaa"), 0o644))
+	// Pin the mtime BEFORE the before-snapshot so that, after a same-size
+	// rewrite and an identical Chtimes, the after-file's cheap fields match
+	// the before-snapshot. That makes statFile hash the after-file too, so
+	// the verdict comes from two genuinely-computed content hashes — the
+	// content-preserving-rewrite path, not a zero-vs-real hash artifact.
+	fixedTime := time.Unix(1700000000, 0)
+	require.NoError(t, os.Chtimes(other, fixedTime, fixedTime))
 
 	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
-	// Same size, different content, with mtime reset to match so only the
-	// eagerly-captured content hash can distinguish the two snapshots —
-	// exercising the content-preserving-rewrite path.
-	fixedTime := time.Unix(1700000000, 0)
+	require.NotEqual(t, [32]byte{}, before[other].hash, "before hashes eagerly")
+
+	// Same size, different content, same mtime.
 	require.NoError(t, os.WriteFile(other, []byte("bbbbb"), 0o644))
 	require.NoError(t, os.Chtimes(other, fixedTime, fixedTime))
 	after, err := snapshotDirs([]string{root}, snapshotCap, before)
 	require.NoError(t, err)
-	// Force the before-state mtime to match the after-state mtime.
-	bs := before[other]
-	bs.mtime = after[other].mtime
-	before[other] = bs
+	// The after-file's cheap fields matched the before snapshot, so it was
+	// hashed; the two real hashes differ.
+	require.NotEqual(t, [32]byte{}, after[other].hash, "after hashes on cheap-field match")
+	require.NotEqual(t, before[other].hash, after[other].hash)
 
 	violations := diffSnapshots(before, after, map[string]struct{}{})
 	require.Len(t, violations, 1)

--- a/internal/build/postcheck_test.go
+++ b/internal/build/postcheck_test.go
@@ -1,0 +1,116 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotDirs_RecordsFiles(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0o644))
+
+	snap, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+	entry, ok := snap[filepath.Join(root, "a.txt")]
+	require.True(t, ok)
+	assert.Equal(t, int64(5), entry.size)
+}
+
+func TestSnapshotDirs_CapExceeded(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 5; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(root, string(rune('a'+i))+".txt"), []byte("x"), 0o644))
+	}
+	_, err := snapshotDirs([]string{root}, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "2 000")
+	assert.Contains(t, err.Error(), root)
+}
+
+func TestDiffSnapshots_DetectsAddedFile(t *testing.T) {
+	root := t.TempDir()
+	declared := filepath.Join(root, "declared.txt")
+	require.NoError(t, os.WriteFile(declared, []byte("orig"), 0o644))
+
+	before, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+
+	// Recipe writes an undeclared sibling.
+	undeclared := filepath.Join(root, "sneaky.txt")
+	require.NoError(t, os.WriteFile(undeclared, []byte("evil"), 0o644))
+
+	after, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+
+	violations := diffSnapshots(before, after, map[string]struct{}{declared: {}})
+	require.Len(t, violations, 1)
+	assert.Equal(t, undeclared, violations[0].path)
+	assert.Equal(t, "added", violations[0].kind)
+}
+
+func TestDiffSnapshots_DetectsModifiedContent(t *testing.T) {
+	root := t.TempDir()
+	other := filepath.Join(root, "other.txt")
+	require.NoError(t, os.WriteFile(other, []byte("aaaaa"), 0o644))
+
+	before, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+	// Same size, different content (hash catches it).
+	require.NoError(t, os.WriteFile(other, []byte("bbbbb"), 0o644))
+	after, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+
+	violations := diffSnapshots(before, after, map[string]struct{}{})
+	require.Len(t, violations, 1)
+	assert.Equal(t, "modified", violations[0].kind)
+}
+
+func TestDiffSnapshots_DeclaredOutputIgnored(t *testing.T) {
+	root := t.TempDir()
+	declared := filepath.Join(root, "out.txt")
+
+	before, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(declared, []byte("new"), 0o644))
+	after, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+
+	violations := diffSnapshots(before, after, map[string]struct{}{declared: {}})
+	assert.Empty(t, violations, "writes to declared outputs are allowed")
+}
+
+func TestDiffSnapshots_DetectsModeChange(t *testing.T) {
+	root := t.TempDir()
+	f := filepath.Join(root, "m.txt")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+
+	before, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(f, 0o600))
+	after, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+
+	violations := diffSnapshots(before, after, map[string]struct{}{})
+	require.Len(t, violations, 1)
+	assert.Equal(t, "modified", violations[0].kind)
+}
+
+func TestDiffSnapshots_DetectsRemoval(t *testing.T) {
+	root := t.TempDir()
+	f := filepath.Join(root, "gone.txt")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+
+	before, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(f))
+	after, err := snapshotDirs([]string{root}, snapshotCap)
+	require.NoError(t, err)
+
+	violations := diffSnapshots(before, after, map[string]struct{}{})
+	require.Len(t, violations, 1)
+	assert.Equal(t, "removed", violations[0].kind)
+}

--- a/internal/build/postcheck_test.go
+++ b/internal/build/postcheck_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -151,4 +152,70 @@ func TestDiffSnapshots_DetectsRemoval(t *testing.T) {
 	violations := diffSnapshots(before, after, map[string]struct{}{})
 	require.Len(t, violations, 1)
 	assert.Equal(t, "removed", violations[0].kind)
+}
+
+func TestSnapshotDirs_DeduplicatesDirs(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("x"), 0o644))
+
+	// Passing the same dir twice must not double-count entries.
+	snap, err := snapshotDirs([]string{root, root}, snapshotCap, nil)
+	require.NoError(t, err)
+	assert.Len(t, snap, 1)
+}
+
+func TestSnapshotDirs_ReadDirError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root — chmod 000 still allows reads")
+	}
+	root := t.TempDir()
+	unreadable := filepath.Join(root, "locked")
+	require.NoError(t, os.Mkdir(unreadable, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+
+	_, err := snapshotDirs([]string{unreadable}, snapshotCap, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scanning")
+}
+
+func TestSnapshotDirs_SymlinkEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	link := filepath.Join(root, "link.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hello"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	snap, err := snapshotDirs([]string{root}, snapshotCap, nil)
+	require.NoError(t, err)
+
+	entry, ok := snap[link]
+	require.True(t, ok, "symlink entry must be snapshotted")
+	assert.Equal(t, target, entry.link)
+}
+
+func TestDiffSnapshots_SortsTwoViolations(t *testing.T) {
+	root := t.TempDir()
+	// Take an empty before-snapshot, then add two files so both appear
+	// as "added" violations. The sort comparison function only fires with
+	// 2+ violations.
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "b.txt"), []byte("b"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0o644))
+
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
+	require.NoError(t, err)
+
+	violations := diffSnapshots(before, after, map[string]struct{}{})
+	require.Len(t, violations, 2)
+	// Violations must be sorted by path.
+	assert.Less(t, violations[0].path, violations[1].path)
+	assert.Equal(t, "added", violations[0].kind)
 }

--- a/internal/build/postcheck_test.go
+++ b/internal/build/postcheck_test.go
@@ -14,7 +14,7 @@ func TestSnapshotDirs_RecordsFiles(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("hello"), 0o644))
 
-	snap, err := snapshotDirs([]string{root}, snapshotCap)
+	snap, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
 	entry, ok := snap[filepath.Join(root, "a.txt")]
 	require.True(t, ok)
@@ -26,7 +26,7 @@ func TestSnapshotDirs_CapExceeded(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		require.NoError(t, os.WriteFile(filepath.Join(root, string(rune('a'+i))+".txt"), []byte("x"), 0o644))
 	}
-	_, err := snapshotDirs([]string{root}, 3)
+	_, err := snapshotDirs([]string{root}, 3, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "2 000")
 	assert.Contains(t, err.Error(), root)
@@ -37,14 +37,14 @@ func TestDiffSnapshots_DetectsAddedFile(t *testing.T) {
 	declared := filepath.Join(root, "declared.txt")
 	require.NoError(t, os.WriteFile(declared, []byte("orig"), 0o644))
 
-	before, err := snapshotDirs([]string{root}, snapshotCap)
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
 
 	// Recipe writes an undeclared sibling.
 	undeclared := filepath.Join(root, "sneaky.txt")
 	require.NoError(t, os.WriteFile(undeclared, []byte("evil"), 0o644))
 
-	after, err := snapshotDirs([]string{root}, snapshotCap)
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
 	require.NoError(t, err)
 
 	violations := diffSnapshots(before, after, map[string]struct{}{declared: {}})
@@ -58,7 +58,7 @@ func TestDiffSnapshots_DetectsModifiedContent(t *testing.T) {
 	other := filepath.Join(root, "other.txt")
 	require.NoError(t, os.WriteFile(other, []byte("aaaaa"), 0o644))
 
-	before, err := snapshotDirs([]string{root}, snapshotCap)
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
 	// Same size, different content, with mtime reset to match so only the
 	// eagerly-captured content hash can distinguish the two snapshots —
@@ -66,7 +66,7 @@ func TestDiffSnapshots_DetectsModifiedContent(t *testing.T) {
 	fixedTime := time.Unix(1700000000, 0)
 	require.NoError(t, os.WriteFile(other, []byte("bbbbb"), 0o644))
 	require.NoError(t, os.Chtimes(other, fixedTime, fixedTime))
-	after, err := snapshotDirs([]string{root}, snapshotCap)
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
 	require.NoError(t, err)
 	// Force the before-state mtime to match the after-state mtime.
 	bs := before[other]
@@ -78,14 +78,37 @@ func TestDiffSnapshots_DetectsModifiedContent(t *testing.T) {
 	assert.Equal(t, "modified", violations[0].kind)
 }
 
+func TestSnapshotDirs_AfterSkipsHashWhenCheapFieldsDiffer(t *testing.T) {
+	root := t.TempDir()
+	f := filepath.Join(root, "n.txt")
+	require.NoError(t, os.WriteFile(f, []byte("aaaaa"), 0o644))
+
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, [32]byte{}, before[f].hash, "before-snapshot hashes eagerly")
+
+	// Change the size so the cheap fields differ from the before-snapshot.
+	require.NoError(t, os.WriteFile(f, []byte("bb"), 0o644))
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
+	require.NoError(t, err)
+	// The after-snapshot skipped the content hash: the cheap fields already
+	// settle the verdict, so no bytes were read.
+	assert.Equal(t, [32]byte{}, after[f].hash)
+
+	// The verdict is still correct.
+	violations := diffSnapshots(before, after, map[string]struct{}{})
+	require.Len(t, violations, 1)
+	assert.Equal(t, "modified", violations[0].kind)
+}
+
 func TestDiffSnapshots_DeclaredOutputIgnored(t *testing.T) {
 	root := t.TempDir()
 	declared := filepath.Join(root, "out.txt")
 
-	before, err := snapshotDirs([]string{root}, snapshotCap)
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(declared, []byte("new"), 0o644))
-	after, err := snapshotDirs([]string{root}, snapshotCap)
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
 	require.NoError(t, err)
 
 	violations := diffSnapshots(before, after, map[string]struct{}{declared: {}})
@@ -97,10 +120,10 @@ func TestDiffSnapshots_DetectsModeChange(t *testing.T) {
 	f := filepath.Join(root, "m.txt")
 	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
 
-	before, err := snapshotDirs([]string{root}, snapshotCap)
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
 	require.NoError(t, os.Chmod(f, 0o600))
-	after, err := snapshotDirs([]string{root}, snapshotCap)
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
 	require.NoError(t, err)
 
 	violations := diffSnapshots(before, after, map[string]struct{}{})
@@ -113,10 +136,10 @@ func TestDiffSnapshots_DetectsRemoval(t *testing.T) {
 	f := filepath.Join(root, "gone.txt")
 	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
 
-	before, err := snapshotDirs([]string{root}, snapshotCap)
+	before, err := snapshotDirs([]string{root}, snapshotCap, nil)
 	require.NoError(t, err)
 	require.NoError(t, os.Remove(f))
-	after, err := snapshotDirs([]string{root}, snapshotCap)
+	after, err := snapshotDirs([]string{root}, snapshotCap, before)
 	require.NoError(t, err)
 
 	violations := diffSnapshots(before, after, map[string]struct{}{})

--- a/internal/build/postcheck_test.go
+++ b/internal/build/postcheck_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,10 +60,18 @@ func TestDiffSnapshots_DetectsModifiedContent(t *testing.T) {
 
 	before, err := snapshotDirs([]string{root}, snapshotCap)
 	require.NoError(t, err)
-	// Same size, different content (hash catches it).
+	// Same size, different content, with mtime reset to match so only the
+	// eagerly-captured content hash can distinguish the two snapshots —
+	// exercising the content-preserving-rewrite path.
+	fixedTime := time.Unix(1700000000, 0)
 	require.NoError(t, os.WriteFile(other, []byte("bbbbb"), 0o644))
+	require.NoError(t, os.Chtimes(other, fixedTime, fixedTime))
 	after, err := snapshotDirs([]string{root}, snapshotCap)
 	require.NoError(t, err)
+	// Force the before-state mtime to match the after-state mtime.
+	bs := before[other]
+	bs.mtime = after[other].mtime
+	before[other] = bs
 
 	violations := diffSnapshots(before, after, map[string]struct{}{})
 	require.Len(t, violations, 1)

--- a/internal/build/postcheck_test.go
+++ b/internal/build/postcheck_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -166,19 +167,89 @@ func TestSnapshotDirs_DeduplicatesDirs(t *testing.T) {
 
 func TestSnapshotDirs_ReadDirError(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission bits")
+		t.Skip("ENOTDIR semantics differ on Windows")
 	}
-	if os.Getuid() == 0 {
-		t.Skip("running as root — chmod 000 still allows reads")
-	}
+	// Point a "directory" path at a regular file so os.ReadDir returns
+	// ENOTDIR — a non-ErrNotExist error that hits the "scanning" branch
+	// regardless of whether the process runs as root.
 	root := t.TempDir()
-	unreadable := filepath.Join(root, "locked")
-	require.NoError(t, os.Mkdir(unreadable, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+	notadir := filepath.Join(root, "file")
+	require.NoError(t, os.WriteFile(notadir, []byte("x"), 0o644))
 
-	_, err := snapshotDirs([]string{unreadable}, snapshotCap, nil)
+	_, err := snapshotDirs([]string{notadir}, snapshotCap, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "scanning")
+}
+
+func TestSnapshotDirs_NotExistDir(t *testing.T) {
+	// A not-yet-created output parent contributes nothing and is not an
+	// error: the IsNotExist branch continues past it.
+	snap, err := snapshotDirs([]string{filepath.Join(t.TempDir(), "nonexistent")}, snapshotCap, nil)
+	require.NoError(t, err)
+	assert.Empty(t, snap)
+}
+
+func TestSnapshotDirs_StatFileError(t *testing.T) {
+	old := statFileFn
+	statFileFn = func(string, fileState, bool) (fileState, error) {
+		return fileState{}, errors.New("stat failed")
+	}
+	t.Cleanup(func() { statFileFn = old })
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("x"), 0o644))
+	_, err := snapshotDirs([]string{root}, snapshotCap, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stat failed")
+}
+
+func TestStatFile_LstatError(t *testing.T) {
+	// A nonexistent path makes os.Lstat fail with ErrNotExist, surfacing the
+	// "inspecting" error branch.
+	_, err := statFile(filepath.Join(t.TempDir(), "nonexistent"), fileState{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inspecting")
+}
+
+func TestStatFile_ReadlinkError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	old := readlinkFn
+	readlinkFn = func(string) (string, error) { return "", errors.New("readlink failed") }
+	t.Cleanup(func() { readlinkFn = old })
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	link := filepath.Join(root, "link.txt")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	_, err := statFile(link, fileState{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading symlink")
+}
+
+func TestStatFile_HashFileSumError(t *testing.T) {
+	old := hashFileSumFn
+	hashFileSumFn = func(string) ([32]byte, error) {
+		return [32]byte{}, errors.New("hash failed")
+	}
+	t.Cleanup(func() { hashFileSumFn = old })
+
+	root := t.TempDir()
+	f := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+
+	_, err := statFile(f, fileState{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hash failed")
+}
+
+func TestHashFileSum_OpenError(t *testing.T) {
+	_, err := hashFileSum(filepath.Join(t.TempDir(), "nonexistent.txt"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hashing")
 }
 
 func TestSnapshotDirs_SymlinkEntry(t *testing.T) {

--- a/internal/build/staging.go
+++ b/internal/build/staging.go
@@ -1,0 +1,57 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// stagingRootRel is the project-relative path to the build staging root.
+// Per-recipe staging dirs are created under it with random suffixes.
+var stagingRootRel = filepath.Join(".mdsmith", "build-staging")
+
+// groupWorldWritableMask is the permission bits that, if set on the
+// staging root, let another user plant files there. Either bit set is a
+// refusal on Unix.
+const groupWorldWritableMask = 0o022
+
+// ensureStagingRoot validates (and, if absent, creates) the
+// .mdsmith/build-staging/ directory under root, returning its absolute
+// path. It refuses a staging root that is a symlink, is not a directory,
+// or is group- or world-writable on Unix. A freshly created root is
+// chmod'd to 0o700 so the process umask cannot leave it more permissive.
+func ensureStagingRoot(root string) (string, error) {
+	dir := filepath.Join(root, stagingRootRel)
+
+	info, err := os.Lstat(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("inspecting staging root: %w", err)
+		}
+		// Create the parent (.mdsmith) and the staging dir, then tighten
+		// the mode: MkdirAll's mode is filtered by the umask, so an
+		// explicit Chmod is required to guarantee 0o700.
+		if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+			return "", fmt.Errorf("creating staging root: %w", mkErr)
+		}
+		if chErr := os.Chmod(dir, 0o700); chErr != nil {
+			return "", fmt.Errorf("securing staging root: %w", chErr)
+		}
+		return dir, nil
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("staging root %s is a symlink; refusing to use it", dir)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("staging root %s is not a directory", dir)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&groupWorldWritableMask != 0 {
+		return "", fmt.Errorf(
+			"staging root %s is group- or world-writable (mode %#o); run `chmod 700 %s`",
+			dir, info.Mode().Perm(), dir,
+		)
+	}
+	return dir, nil
+}

--- a/internal/build/staging.go
+++ b/internal/build/staging.go
@@ -16,6 +16,13 @@ var stagingRootRel = filepath.Join(".mdsmith", "build-staging")
 // refusal on Unix.
 const groupWorldWritableMask = 0o022
 
+// osMkdirAllFn and osChmodFn indirect the staging-root creation calls so
+// tests can drive their error branches without filesystem tricks.
+var (
+	osMkdirAllFn = os.MkdirAll
+	osChmodFn    = os.Chmod
+)
+
 // ensureStagingRoot validates (and, if absent, creates) the
 // .mdsmith/build-staging/ directory under root, returning its absolute
 // path. It refuses a staging root that is a symlink, is not a directory,
@@ -32,10 +39,10 @@ func ensureStagingRoot(root string) (string, error) {
 		// Create the parent (.mdsmith) and the staging dir, then tighten
 		// the mode: MkdirAll's mode is filtered by the umask, so an
 		// explicit Chmod is required to guarantee 0o700.
-		if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+		if mkErr := osMkdirAllFn(dir, 0o700); mkErr != nil {
 			return "", fmt.Errorf("creating staging root: %w", mkErr)
 		}
-		if chErr := os.Chmod(dir, 0o700); chErr != nil {
+		if chErr := osChmodFn(dir, 0o700); chErr != nil {
 			return "", fmt.Errorf("securing staging root: %w", chErr)
 		}
 		return dir, nil

--- a/internal/build/staging_test.go
+++ b/internal/build/staging_test.go
@@ -1,0 +1,90 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureStagingRoot_CreatesWith0700(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	root := t.TempDir()
+	dir, err := ensureStagingRoot(root)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, ".mdsmith", "build-staging"), dir)
+
+	info, err := os.Lstat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}
+
+func TestEnsureStagingRoot_RefusesSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics")
+	}
+	root := t.TempDir()
+	target := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mdsmith"), 0o700))
+	require.NoError(t, os.Symlink(target, filepath.Join(root, ".mdsmith", "build-staging")))
+
+	_, err := ensureStagingRoot(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+}
+
+func TestEnsureStagingRoot_RefusesNonDir(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mdsmith"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith", "build-staging"), []byte("x"), 0o600))
+
+	_, err := ensureStagingRoot(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestEnsureStagingRoot_RefusesGroupWritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	root := t.TempDir()
+	staging := filepath.Join(root, ".mdsmith", "build-staging")
+	require.NoError(t, os.MkdirAll(staging, 0o700))
+	require.NoError(t, os.Chmod(staging, 0o770))
+
+	_, err := ensureStagingRoot(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writable")
+}
+
+func TestEnsureStagingRoot_RefusesWorldWritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	root := t.TempDir()
+	staging := filepath.Join(root, ".mdsmith", "build-staging")
+	require.NoError(t, os.MkdirAll(staging, 0o700))
+	require.NoError(t, os.Chmod(staging, 0o707))
+
+	_, err := ensureStagingRoot(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writable")
+}
+
+func TestEnsureStagingRoot_AcceptsExisting0700(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	root := t.TempDir()
+	staging := filepath.Join(root, ".mdsmith", "build-staging")
+	require.NoError(t, os.MkdirAll(staging, 0o700))
+
+	dir, err := ensureStagingRoot(root)
+	require.NoError(t, err)
+	assert.Equal(t, staging, dir)
+}

--- a/internal/build/staging_test.go
+++ b/internal/build/staging_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEnsureStagingRoot_MkdirAllError(t *testing.T) {
+	old := osMkdirAllFn
+	osMkdirAllFn = func(string, os.FileMode) error { return errors.New("mkdir failed") }
+	t.Cleanup(func() { osMkdirAllFn = old })
+
+	_, err := ensureStagingRoot(t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating staging root")
+}
+
+func TestEnsureStagingRoot_ChmodError(t *testing.T) {
+	old := osChmodFn
+	osChmodFn = func(string, os.FileMode) error { return errors.New("chmod failed") }
+	t.Cleanup(func() { osChmodFn = old })
+
+	_, err := ensureStagingRoot(t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "securing staging root")
+}
 
 func TestEnsureStagingRoot_CreatesWith0700(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/build/staleness.go
+++ b/internal/build/staleness.go
@@ -218,13 +218,14 @@ func ComputeActionID(in StalenessInput) (string, error) {
 	return computeActionIDFromResolved(in, inputs, outputs)
 }
 
-// hashFile returns the lowercase-hex sha256 of a file's content.
+// hashFile returns the lowercase-hex sha256 of a file's content. It
+// streams through the shared hashFileSum primitive so large inputs never
+// have to fit in memory.
 func hashFile(abs string) (string, error) {
-	data, err := os.ReadFile(abs) //nolint:gosec // abs is an in-root input/output path
+	sum, err := hashFileSum(abs)
 	if err != nil {
-		return "", fmt.Errorf("hashing %s: %w", filepath.Base(abs), err)
+		return "", err
 	}
-	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil
 }
 

--- a/internal/build/trust.go
+++ b/internal/build/trust.go
@@ -24,9 +24,12 @@ const defaultConfigFileName = ".mdsmith.yml"
 // repository.
 const trustMarkerSuffix = ".trust"
 
-// envTrustBuild, when set to a non-empty value, grants build trust
+// envTrustBuild names the environment variable that grants build trust
 // without a marker file. CI environments are presumed sandboxed and opt
-// in this way rather than committing a marker.
+// in this way rather than committing a marker. Whether a given value
+// counts as "set" is decided by the envLookup callback passed to
+// CheckTrust — the production lookup treats 0/false/no/off as not set, so
+// an explicit disabling value leaves the gate in force.
 const envTrustBuild = "MDSMITH_TRUST_BUILD"
 
 // TrustResult is the verdict of the trust gate.
@@ -59,11 +62,12 @@ func TrustMarkerPath(configPath string) string {
 
 // CheckTrust decides whether the build pass may run recipes for the
 // config at configPath. The envLookup callback reports whether a named
-// environment variable is set to a non-empty value; production passes a
-// closure over os.Getenv so tests can inject a controlled environment.
+// environment variable should count as set; production passes a closure
+// that treats 0/false/no/off as not set, so a disabling value leaves the
+// gate in force. Tests inject a controlled lookup.
 //
 // Trust is granted when either:
-//   - MDSMITH_TRUST_BUILD is set (ViaEnv), or
+//   - envLookup(MDSMITH_TRUST_BUILD) is true (ViaEnv), or
 //   - the marker <configPath>.trust exists and its bytes are identical to
 //     the current config.
 //

--- a/internal/build/trust.go
+++ b/internal/build/trust.go
@@ -1,0 +1,159 @@
+package build
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+)
+
+// configFileName is the workspace config file whose bytes the trust gate
+// pins. It is the only file that can declare a build: section, so it is
+// the only file the gate must cover.
+const configFileName = ".mdsmith.yml"
+
+// trustMarkerName is the per-clone trust marker sitting beside the
+// config. It is .gitignored: trust is a property of a checkout, not of
+// the repository.
+const trustMarkerName = ".mdsmith.yml.trust"
+
+// envTrustBuild, when set to a non-empty value, grants build trust
+// without a marker file. CI environments are presumed sandboxed and opt
+// in this way rather than committing a marker.
+const envTrustBuild = "MDSMITH_TRUST_BUILD"
+
+// TrustResult is the verdict of the trust gate.
+type TrustResult struct {
+	// Trusted is true when the build pass may run recipes.
+	Trusted bool
+	// ViaEnv is true when trust came from MDSMITH_TRUST_BUILD rather than
+	// a matching marker file.
+	ViaEnv bool
+	// Reason explains why trust was denied. It is empty when Trusted.
+	Reason string
+}
+
+// TrustMarkerPath returns the absolute path to the trust marker beside
+// the config in root.
+func TrustMarkerPath(root string) string {
+	return filepath.Join(root, trustMarkerName)
+}
+
+// configPath returns the absolute path to the workspace config in root.
+func configPath(root string) string {
+	return filepath.Join(root, configFileName)
+}
+
+// CheckTrust decides whether the build pass may run recipes in root. The
+// envLookup callback reports whether a named environment variable is set
+// to a non-empty value; production passes a closure over os.Getenv so
+// tests can inject a controlled environment.
+//
+// Trust is granted when either:
+//   - MDSMITH_TRUST_BUILD is set (ViaEnv), or
+//   - .mdsmith.yml.trust exists and its bytes are identical to the
+//     current .mdsmith.yml.
+//
+// Any drift, a missing marker, or a missing/unreadable config denies
+// trust with a human-readable Reason.
+func CheckTrust(root string, envLookup func(name string) bool) TrustResult {
+	if envLookup != nil && envLookup(envTrustBuild) {
+		return TrustResult{Trusted: true, ViaEnv: true}
+	}
+
+	cfg, err := os.ReadFile(configPath(root)) //nolint:gosec // path is the workspace config
+	if err != nil {
+		return TrustResult{Reason: fmt.Sprintf("cannot read %s: %v", configFileName, err)}
+	}
+
+	marker, err := os.ReadFile(TrustMarkerPath(root)) //nolint:gosec // path is the workspace trust marker
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return TrustResult{Reason: fmt.Sprintf(
+				"build not trusted: %s is missing; review %s and run `mdsmith trust`"+
+					" (or set %s=1 in a sandboxed CI)",
+				trustMarkerName, configFileName, envTrustBuild,
+			)}
+		}
+		return TrustResult{Reason: fmt.Sprintf("cannot read %s: %v", trustMarkerName, err)}
+	}
+
+	if !bytes.Equal(cfg, marker) {
+		return TrustResult{Reason: fmt.Sprintf(
+			"build not trusted: %s changed since it was trusted; review the diff with"+
+				" `mdsmith trust` and re-trust",
+			configFileName,
+		)}
+	}
+
+	return TrustResult{Trusted: true}
+}
+
+// WriteTrustMarker copies the current .mdsmith.yml bytes into the trust
+// marker, recording the config as trusted. It is written 0o600: trust is
+// a per-user decision and the marker should not be group- or
+// world-readable. The write is atomic (temp file plus rename) so a
+// crash mid-write never leaves a half-written marker that would falsely
+// fail the byte comparison.
+func WriteTrustMarker(root string) error {
+	cfg, err := os.ReadFile(configPath(root)) //nolint:gosec // path is the workspace config
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", configFileName, err)
+	}
+	dst := TrustMarkerPath(root)
+	tmp, err := os.CreateTemp(root, trustMarkerName+".*")
+	if err != nil {
+		return fmt.Errorf("creating trust marker: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup if rename succeeds it is gone
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("setting trust marker mode: %w", err)
+	}
+	if _, err := tmp.Write(cfg); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing trust marker: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing trust marker: %w", err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return fmt.Errorf("installing trust marker: %w", err)
+	}
+	return nil
+}
+
+// TrustDiff returns a unified diff between the stored trust marker (old)
+// and the current config (new), whether the two differ, and any read
+// error. A missing marker is treated as an empty old side, so the diff
+// shows the whole config as added and changed is true.
+func TrustDiff(root string) (diff string, changed bool, err error) {
+	cfg, err := os.ReadFile(configPath(root)) //nolint:gosec // path is the workspace config
+	if err != nil {
+		return "", false, fmt.Errorf("reading %s: %w", configFileName, err)
+	}
+	var marker []byte
+	markerBytes, merr := os.ReadFile(TrustMarkerPath(root)) //nolint:gosec // path is the workspace trust marker
+	switch {
+	case merr == nil:
+		marker = markerBytes
+	case errors.Is(merr, os.ErrNotExist):
+		marker = nil
+	default:
+		return "", false, fmt.Errorf("reading %s: %w", trustMarkerName, merr)
+	}
+
+	if bytes.Equal(cfg, marker) {
+		return "", false, nil
+	}
+
+	edits := myers.ComputeEdits(span.URIFromPath(trustMarkerName), string(marker), string(cfg))
+	unified := fmt.Sprint(gotextdiff.ToUnified(trustMarkerName, configFileName, string(marker), edits))
+	return unified, true, nil
+}

--- a/internal/build/trust.go
+++ b/internal/build/trust.go
@@ -12,15 +12,17 @@ import (
 	"github.com/hexops/gotextdiff/span"
 )
 
-// configFileName is the workspace config file whose bytes the trust gate
-// pins. It is the only file that can declare a build: section, so it is
-// the only file the gate must cover.
-const configFileName = ".mdsmith.yml"
+// defaultConfigFileName is the conventional workspace config filename.
+// The trust gate pins whichever config file the run actually loaded
+// (which may differ under `mdsmith fix -c other.yml`), but this name is
+// used in diagnostics and to locate the default config under a root.
+const defaultConfigFileName = ".mdsmith.yml"
 
-// trustMarkerName is the per-clone trust marker sitting beside the
-// config. It is .gitignored: trust is a property of a checkout, not of
-// the repository.
-const trustMarkerName = ".mdsmith.yml.trust"
+// trustMarkerSuffix is appended to the loaded config's path to name its
+// per-clone trust marker (e.g. .mdsmith.yml -> .mdsmith.yml.trust). The
+// marker is .gitignored: trust is a property of a checkout, not of the
+// repository.
+const trustMarkerSuffix = ".trust"
 
 // envTrustBuild, when set to a non-empty value, grants build trust
 // without a marker file. CI environments are presumed sandboxed and opt
@@ -38,122 +40,127 @@ type TrustResult struct {
 	Reason string
 }
 
-// TrustMarkerPath returns the absolute path to the trust marker beside
-// the config in root.
-func TrustMarkerPath(root string) string {
-	return filepath.Join(root, trustMarkerName)
+// ConfigPathForRoot returns the default config path under root. It is the
+// fallback the trust subcommand uses when no explicit --config was given.
+func ConfigPathForRoot(root string) string {
+	return filepath.Join(root, defaultConfigFileName)
 }
 
-// configPath returns the absolute path to the workspace config in root.
-func configPath(root string) string {
-	return filepath.Join(root, configFileName)
+// TrustMarkerPath returns the trust marker path for a given loaded config
+// path (configPath + ".trust"). An empty configPath falls back to the
+// default config name in the current directory, so the marker is always
+// named after the file the gate actually pins.
+func TrustMarkerPath(configPath string) string {
+	if configPath == "" {
+		configPath = defaultConfigFileName
+	}
+	return configPath + trustMarkerSuffix
 }
 
-// CheckTrust decides whether the build pass may run recipes in root. The
-// envLookup callback reports whether a named environment variable is set
-// to a non-empty value; production passes a closure over os.Getenv so
-// tests can inject a controlled environment.
+// CheckTrust decides whether the build pass may run recipes for the
+// config at configPath. The envLookup callback reports whether a named
+// environment variable is set to a non-empty value; production passes a
+// closure over os.Getenv so tests can inject a controlled environment.
 //
 // Trust is granted when either:
 //   - MDSMITH_TRUST_BUILD is set (ViaEnv), or
-//   - .mdsmith.yml.trust exists and its bytes are identical to the
-//     current .mdsmith.yml.
+//   - the marker <configPath>.trust exists and its bytes are identical to
+//     the current config.
 //
 // Any drift, a missing marker, or a missing/unreadable config denies
-// trust with a human-readable Reason.
-func CheckTrust(root string, envLookup func(name string) bool) TrustResult {
+// trust with a human-readable Reason. Pinning the *loaded* config path
+// (not a hardcoded .mdsmith.yml) keeps the gate correct under
+// `mdsmith fix -c other.yml`.
+func CheckTrust(configPath string, envLookup func(name string) bool) TrustResult {
 	if envLookup != nil && envLookup(envTrustBuild) {
 		return TrustResult{Trusted: true, ViaEnv: true}
 	}
+	if configPath == "" {
+		configPath = defaultConfigFileName
+	}
+	name := filepath.Base(configPath)
 
-	cfg, err := os.ReadFile(configPath(root)) //nolint:gosec // path is the workspace config
+	cfg, err := os.ReadFile(configPath) //nolint:gosec // path is the loaded workspace config
 	if err != nil {
-		return TrustResult{Reason: fmt.Sprintf("cannot read %s: %v", configFileName, err)}
+		return TrustResult{Reason: fmt.Sprintf("cannot read %s: %v", name, err)}
 	}
 
-	marker, err := os.ReadFile(TrustMarkerPath(root)) //nolint:gosec // path is the workspace trust marker
+	markerPath := TrustMarkerPath(configPath)
+	marker, err := os.ReadFile(markerPath) //nolint:gosec // path is the workspace trust marker
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return TrustResult{Reason: fmt.Sprintf(
 				"build not trusted: %s is missing; review %s and run `mdsmith trust`"+
 					" (or set %s=1 in a sandboxed CI)",
-				trustMarkerName, configFileName, envTrustBuild,
+				filepath.Base(markerPath), name, envTrustBuild,
 			)}
 		}
-		return TrustResult{Reason: fmt.Sprintf("cannot read %s: %v", trustMarkerName, err)}
+		return TrustResult{Reason: fmt.Sprintf("cannot read %s: %v", filepath.Base(markerPath), err)}
 	}
 
 	if !bytes.Equal(cfg, marker) {
 		return TrustResult{Reason: fmt.Sprintf(
 			"build not trusted: %s changed since it was trusted; review the diff with"+
 				" `mdsmith trust` and re-trust",
-			configFileName,
+			name,
 		)}
 	}
 
 	return TrustResult{Trusted: true}
 }
 
-// WriteTrustMarker copies the current .mdsmith.yml bytes into the trust
-// marker, recording the config as trusted. It is written 0o600: trust is
-// a per-user decision and the marker should not be group- or
-// world-readable. The write is atomic (temp file plus rename) so a
-// crash mid-write never leaves a half-written marker that would falsely
-// fail the byte comparison.
-func WriteTrustMarker(root string) error {
-	cfg, err := os.ReadFile(configPath(root)) //nolint:gosec // path is the workspace config
+// WriteTrustMarker copies the current config bytes into its trust marker,
+// recording the config at configPath as trusted. The marker is written
+// 0o600: trust is a per-user decision and should not be group- or
+// world-readable. The write is atomic (temp file plus rename) so a crash
+// mid-write never leaves a half-written marker that would falsely fail
+// the byte comparison.
+func WriteTrustMarker(configPath string) error {
+	if configPath == "" {
+		configPath = defaultConfigFileName
+	}
+	name := filepath.Base(configPath)
+	cfg, err := os.ReadFile(configPath) //nolint:gosec // path is the loaded workspace config
 	if err != nil {
-		return fmt.Errorf("reading %s: %w", configFileName, err)
+		return fmt.Errorf("reading %s: %w", name, err)
 	}
-	dst := TrustMarkerPath(root)
-	tmp, err := os.CreateTemp(root, trustMarkerName+".*")
-	if err != nil {
-		return fmt.Errorf("creating trust marker: %w", err)
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName) //nolint:errcheck // best-effort cleanup if rename succeeds it is gone
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("setting trust marker mode: %w", err)
-	}
-	if _, err := tmp.Write(cfg); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("writing trust marker: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("closing trust marker: %w", err)
-	}
-	if err := os.Rename(tmpName, dst); err != nil {
+	if err := atomicWriteFile(TrustMarkerPath(configPath), 0o600, cfg); err != nil {
 		return fmt.Errorf("installing trust marker: %w", err)
 	}
 	return nil
 }
 
 // TrustDiff returns a unified diff between the stored trust marker (old)
-// and the current config (new), whether the two differ, and any read
-// error. A missing marker is treated as an empty old side, so the diff
-// shows the whole config as added and changed is true.
-func TrustDiff(root string) (diff string, changed bool, err error) {
-	cfg, err := os.ReadFile(configPath(root)) //nolint:gosec // path is the workspace config
-	if err != nil {
-		return "", false, fmt.Errorf("reading %s: %w", configFileName, err)
+// and the current config at configPath (new), whether the two differ, and
+// any read error. A missing marker is treated as an empty old side, so
+// the diff shows the whole config as added and changed is true.
+func TrustDiff(configPath string) (diff string, changed bool, err error) {
+	if configPath == "" {
+		configPath = defaultConfigFileName
 	}
+	name := filepath.Base(configPath)
+	cfg, err := os.ReadFile(configPath) //nolint:gosec // path is the loaded workspace config
+	if err != nil {
+		return "", false, fmt.Errorf("reading %s: %w", name, err)
+	}
+	markerPath := TrustMarkerPath(configPath)
+	markerName := filepath.Base(markerPath)
 	var marker []byte
-	markerBytes, merr := os.ReadFile(TrustMarkerPath(root)) //nolint:gosec // path is the workspace trust marker
+	markerBytes, merr := os.ReadFile(markerPath) //nolint:gosec // path is the workspace trust marker
 	switch {
 	case merr == nil:
 		marker = markerBytes
 	case errors.Is(merr, os.ErrNotExist):
 		marker = nil
 	default:
-		return "", false, fmt.Errorf("reading %s: %w", trustMarkerName, merr)
+		return "", false, fmt.Errorf("reading %s: %w", markerName, merr)
 	}
 
 	if bytes.Equal(cfg, marker) {
 		return "", false, nil
 	}
 
-	edits := myers.ComputeEdits(span.URIFromPath(trustMarkerName), string(marker), string(cfg))
-	unified := fmt.Sprint(gotextdiff.ToUnified(trustMarkerName, configFileName, string(marker), edits))
+	edits := myers.ComputeEdits(span.URIFromPath(markerName), string(marker), string(cfg))
+	unified := fmt.Sprint(gotextdiff.ToUnified(markerName, name, string(marker), edits))
 	return unified, true, nil
 }

--- a/internal/build/trust_test.go
+++ b/internal/build/trust_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -127,4 +128,104 @@ func TestTrustDiff_IdenticalNoChange(t *testing.T) {
 	_, changed, err := TrustDiff(cfg)
 	require.NoError(t, err)
 	assert.False(t, changed)
+}
+
+func TestConfigPathForRoot(t *testing.T) {
+	got := ConfigPathForRoot("/some/root")
+	assert.Equal(t, filepath.Join("/some/root", ".mdsmith.yml"), got)
+}
+
+func TestTrustMarkerPath_EmptyConfigPath(t *testing.T) {
+	// An empty configPath falls back to the default config name so the
+	// marker is still named after the file the gate actually pins.
+	got := TrustMarkerPath("")
+	assert.Equal(t, ".mdsmith.yml"+trustMarkerSuffix, got)
+}
+
+func TestCheckTrust_EmptyConfigPath(t *testing.T) {
+	// With an empty configPath the gate falls back to ".mdsmith.yml" in the
+	// process working directory; since that file doesn't exist in our temp
+	// dir the result is not-trusted.
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	res := CheckTrust("", func(string) bool { return false })
+	assert.False(t, res.Trusted)
+}
+
+func TestCheckTrust_MarkerReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root — chmod 000 still allows reads")
+	}
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := cfgIn(t, dir, body)
+	markerPath := cfg + ".trust"
+	require.NoError(t, os.WriteFile(markerPath, body, 0o000))
+
+	res := CheckTrust(cfg, func(string) bool { return false })
+	assert.False(t, res.Trusted)
+	assert.NotEmpty(t, res.Reason)
+}
+
+func TestWriteTrustMarker_EmptyConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	body := []byte("build: {}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), body, 0o644))
+
+	require.NoError(t, WriteTrustMarker(""))
+	got, err := os.ReadFile(filepath.Join(dir, ".mdsmith.yml.trust"))
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestWriteTrustMarker_MissingConfig(t *testing.T) {
+	err := WriteTrustMarker(filepath.Join(t.TempDir(), "nonexistent.yml"))
+	require.Error(t, err)
+}
+
+func TestTrustDiff_EmptyConfigPath(t *testing.T) {
+	// Empty configPath falls back to .mdsmith.yml in cwd; if absent,
+	// TrustDiff returns an error rather than a diff.
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	_, _, err = TrustDiff("")
+	require.Error(t, err)
+}
+
+func TestTrustDiff_MissingConfig(t *testing.T) {
+	_, _, err := TrustDiff(filepath.Join(t.TempDir(), "nonexistent.yml"))
+	require.Error(t, err)
+}
+
+func TestTrustDiff_MarkerReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root — chmod 000 still allows reads")
+	}
+	dir := t.TempDir()
+	body := []byte("a: 1\n")
+	cfg := cfgIn(t, dir, body)
+	markerPath := cfg + ".trust"
+	require.NoError(t, os.WriteFile(markerPath, []byte("old\n"), 0o000))
+
+	_, _, err := TrustDiff(cfg)
+	require.Error(t, err)
 }

--- a/internal/build/trust_test.go
+++ b/internal/build/trust_test.go
@@ -1,0 +1,104 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckTrust_MissingMarkerBlocks(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("build: {}\n"), 0o644))
+
+	res := CheckTrust(root, func(string) bool { return false })
+	assert.False(t, res.Trusted)
+	assert.NotEmpty(t, res.Reason)
+}
+
+func TestCheckTrust_MatchingMarkerTrusts(t *testing.T) {
+	root := t.TempDir()
+	body := []byte("build:\n  recipes: {}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), body, 0o644))
+
+	res := CheckTrust(root, func(string) bool { return false })
+	assert.True(t, res.Trusted)
+}
+
+func TestCheckTrust_StaleMarkerBlocks(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("build:\n  a: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), []byte("build:\n  a: 2\n"), 0o644))
+
+	res := CheckTrust(root, func(string) bool { return false })
+	assert.False(t, res.Trusted)
+	assert.Contains(t, res.Reason, "changed")
+}
+
+func TestCheckTrust_EnvOverrideTrusts(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("build: {}\n"), 0o644))
+	// No marker file; env override grants trust.
+	res := CheckTrust(root, func(name string) bool { return name == envTrustBuild })
+	assert.True(t, res.Trusted)
+	assert.True(t, res.ViaEnv)
+}
+
+func TestCheckTrust_MissingConfigBlocks(t *testing.T) {
+	root := t.TempDir()
+	// No .mdsmith.yml at all.
+	res := CheckTrust(root, func(string) bool { return false })
+	assert.False(t, res.Trusted)
+}
+
+func TestTrustMarkerPath(t *testing.T) {
+	assert.Equal(t, filepath.Join("/r", ".mdsmith.yml.trust"), TrustMarkerPath("/r"))
+}
+
+func TestWriteTrustMarker(t *testing.T) {
+	root := t.TempDir()
+	body := []byte("build:\n  recipes: {}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
+
+	require.NoError(t, WriteTrustMarker(root))
+
+	got, err := os.ReadFile(filepath.Join(root, ".mdsmith.yml.trust"))
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestTrustDiff_ReportsChange(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("a: 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), []byte("a: 2\n"), 0o644))
+
+	diff, changed, err := TrustDiff(root)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Contains(t, diff, "a: 1")
+	assert.Contains(t, diff, "a: 2")
+}
+
+func TestTrustDiff_NoMarkerIsChange(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("a: 1\n"), 0o644))
+
+	diff, changed, err := TrustDiff(root)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.NotEmpty(t, diff)
+}
+
+func TestTrustDiff_IdenticalNoChange(t *testing.T) {
+	root := t.TempDir()
+	body := []byte("a: 1\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), body, 0o644))
+
+	_, changed, err := TrustDiff(root)
+	require.NoError(t, err)
+	assert.False(t, changed)
+}

--- a/internal/build/trust_test.go
+++ b/internal/build/trust_test.go
@@ -3,7 +3,6 @@ package build
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,17 +156,13 @@ func TestCheckTrust_EmptyConfigPath(t *testing.T) {
 }
 
 func TestCheckTrust_MarkerReadError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission bits")
-	}
-	if os.Getuid() == 0 {
-		t.Skip("running as root — chmod 000 still allows reads")
-	}
 	dir := t.TempDir()
 	body := []byte("build: {}\n")
 	cfg := cfgIn(t, dir, body)
-	markerPath := cfg + ".trust"
-	require.NoError(t, os.WriteFile(markerPath, body, 0o000))
+	// A directory at the marker path makes os.ReadFile fail with EISDIR — a
+	// non-ErrNotExist error that hits the "cannot read marker" branch
+	// regardless of whether the process runs as root.
+	require.NoError(t, os.Mkdir(cfg+".trust", 0o755))
 
 	res := CheckTrust(cfg, func(string) bool { return false })
 	assert.False(t, res.Trusted)
@@ -214,18 +209,30 @@ func TestTrustDiff_MissingConfig(t *testing.T) {
 }
 
 func TestTrustDiff_MarkerReadError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix permission bits")
-	}
-	if os.Getuid() == 0 {
-		t.Skip("running as root — chmod 000 still allows reads")
-	}
 	dir := t.TempDir()
 	body := []byte("a: 1\n")
 	cfg := cfgIn(t, dir, body)
-	markerPath := cfg + ".trust"
-	require.NoError(t, os.WriteFile(markerPath, []byte("old\n"), 0o000))
+	// A directory at the marker path makes os.ReadFile fail with a
+	// non-ErrNotExist error, hitting the default error branch — and it works
+	// as root, unlike a chmod 000 file.
+	require.NoError(t, os.Mkdir(cfg+".trust", 0o755))
 
 	_, _, err := TrustDiff(cfg)
 	require.Error(t, err)
+}
+
+func TestWriteTrustMarker_AtomicWriteError(t *testing.T) {
+	// A directory at the marker path makes the atomic rename fail (it cannot
+	// replace a non-empty directory), surfacing the "installing trust marker"
+	// error — and it works as root.
+	dir := t.TempDir()
+	body := []byte("build: {}\n")
+	cfg := cfgIn(t, dir, body)
+	markerDir := cfg + ".trust"
+	require.NoError(t, os.Mkdir(markerDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(markerDir, "blocker"), []byte("x"), 0o644))
+
+	err := WriteTrustMarker(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "installing trust marker")
 }

--- a/internal/build/trust_test.go
+++ b/internal/build/trust_test.go
@@ -9,73 +9,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckTrust_MissingMarkerBlocks(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("build: {}\n"), 0o644))
+// cfgIn writes a .mdsmith.yml in dir and returns its path.
+func cfgIn(t *testing.T, dir string, body []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(p, body, 0o644))
+	return p
+}
 
-	res := CheckTrust(root, func(string) bool { return false })
+func TestCheckTrust_MissingMarkerBlocks(t *testing.T) {
+	cfg := cfgIn(t, t.TempDir(), []byte("build: {}\n"))
+	res := CheckTrust(cfg, func(string) bool { return false })
 	assert.False(t, res.Trusted)
 	assert.NotEmpty(t, res.Reason)
 }
 
 func TestCheckTrust_MatchingMarkerTrusts(t *testing.T) {
-	root := t.TempDir()
 	body := []byte("build:\n  recipes: {}\n")
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), body, 0o644))
+	cfg := cfgIn(t, t.TempDir(), body)
+	require.NoError(t, os.WriteFile(cfg+".trust", body, 0o644))
 
-	res := CheckTrust(root, func(string) bool { return false })
+	res := CheckTrust(cfg, func(string) bool { return false })
 	assert.True(t, res.Trusted)
 }
 
 func TestCheckTrust_StaleMarkerBlocks(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("build:\n  a: 1\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), []byte("build:\n  a: 2\n"), 0o644))
+	cfg := cfgIn(t, t.TempDir(), []byte("build:\n  a: 1\n"))
+	require.NoError(t, os.WriteFile(cfg+".trust", []byte("build:\n  a: 2\n"), 0o644))
 
-	res := CheckTrust(root, func(string) bool { return false })
+	res := CheckTrust(cfg, func(string) bool { return false })
 	assert.False(t, res.Trusted)
 	assert.Contains(t, res.Reason, "changed")
 }
 
 func TestCheckTrust_EnvOverrideTrusts(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("build: {}\n"), 0o644))
+	cfg := cfgIn(t, t.TempDir(), []byte("build: {}\n"))
 	// No marker file; env override grants trust.
-	res := CheckTrust(root, func(name string) bool { return name == envTrustBuild })
+	res := CheckTrust(cfg, func(name string) bool { return name == envTrustBuild })
 	assert.True(t, res.Trusted)
 	assert.True(t, res.ViaEnv)
 }
 
 func TestCheckTrust_MissingConfigBlocks(t *testing.T) {
-	root := t.TempDir()
-	// No .mdsmith.yml at all.
-	res := CheckTrust(root, func(string) bool { return false })
+	// No config file at the given path.
+	res := CheckTrust(filepath.Join(t.TempDir(), ".mdsmith.yml"), func(string) bool { return false })
 	assert.False(t, res.Trusted)
 }
 
+func TestCheckTrust_CustomConfigPathPinsItsOwnMarker(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("build:\n  recipes: {}\n")
+	custom := filepath.Join(dir, "custom.yml")
+	require.NoError(t, os.WriteFile(custom, body, 0o644))
+	// A default .mdsmith.yml with different content must NOT satisfy the
+	// gate for the custom config: the marker is named after the loaded file.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml"), []byte("other\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mdsmith.yml.trust"), []byte("other\n"), 0o644))
+
+	res := CheckTrust(custom, func(string) bool { return false })
+	assert.False(t, res.Trusted, "custom.yml has no custom.yml.trust marker")
+
+	require.NoError(t, os.WriteFile(custom+".trust", body, 0o644))
+	res = CheckTrust(custom, func(string) bool { return false })
+	assert.True(t, res.Trusted)
+}
+
 func TestTrustMarkerPath(t *testing.T) {
-	assert.Equal(t, filepath.Join("/r", ".mdsmith.yml.trust"), TrustMarkerPath("/r"))
+	assert.Equal(t, filepath.Join("/r", ".mdsmith.yml.trust"),
+		TrustMarkerPath(filepath.Join("/r", ".mdsmith.yml")))
+	assert.Equal(t, "/r/custom.yml.trust", TrustMarkerPath("/r/custom.yml"))
 }
 
 func TestWriteTrustMarker(t *testing.T) {
-	root := t.TempDir()
 	body := []byte("build:\n  recipes: {}\n")
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
+	cfg := cfgIn(t, t.TempDir(), body)
 
-	require.NoError(t, WriteTrustMarker(root))
+	require.NoError(t, WriteTrustMarker(cfg))
 
-	got, err := os.ReadFile(filepath.Join(root, ".mdsmith.yml.trust"))
+	got, err := os.ReadFile(cfg + ".trust")
 	require.NoError(t, err)
 	assert.Equal(t, body, got)
 }
 
-func TestTrustDiff_ReportsChange(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("a: 1\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), []byte("a: 2\n"), 0o644))
+func TestWriteTrustMarker_Mode0600(t *testing.T) {
+	cfg := cfgIn(t, t.TempDir(), []byte("a: 1\n"))
+	require.NoError(t, WriteTrustMarker(cfg))
+	info, err := os.Lstat(cfg + ".trust")
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
 
-	diff, changed, err := TrustDiff(root)
+func TestTrustDiff_ReportsChange(t *testing.T) {
+	cfg := cfgIn(t, t.TempDir(), []byte("a: 1\n"))
+	require.NoError(t, os.WriteFile(cfg+".trust", []byte("a: 2\n"), 0o644))
+
+	diff, changed, err := TrustDiff(cfg)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	assert.Contains(t, diff, "a: 1")
@@ -83,22 +111,20 @@ func TestTrustDiff_ReportsChange(t *testing.T) {
 }
 
 func TestTrustDiff_NoMarkerIsChange(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), []byte("a: 1\n"), 0o644))
+	cfg := cfgIn(t, t.TempDir(), []byte("a: 1\n"))
 
-	diff, changed, err := TrustDiff(root)
+	diff, changed, err := TrustDiff(cfg)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	assert.NotEmpty(t, diff)
 }
 
 func TestTrustDiff_IdenticalNoChange(t *testing.T) {
-	root := t.TempDir()
 	body := []byte("a: 1\n")
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml"), body, 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".mdsmith.yml.trust"), body, 0o644))
+	cfg := cfgIn(t, t.TempDir(), body)
+	require.NoError(t, os.WriteFile(cfg+".trust", body, 0o644))
 
-	_, changed, err := TrustDiff(root)
+	_, changed, err := TrustDiff(cfg)
 	require.NoError(t, err)
 	assert.False(t, changed)
 }

--- a/internal/config/build.go
+++ b/internal/config/build.go
@@ -11,6 +11,10 @@ import (
 type BuildConfig struct {
 	Recipes map[string]RecipeCfg `yaml:"recipes,omitempty"`
 	Hooks   HooksCfg             `yaml:"hooks,omitempty"`
+	// Exec configures the hermetic execution environment recipes run
+	// under (plan 2606101548). Both keys are optional; empty values mean
+	// the build executor's compiled defaults apply.
+	Exec ExecCfg `yaml:"exec,omitempty"`
 }
 
 // HooksCfg holds the before/after hook lists for the build pass.
@@ -24,6 +28,16 @@ type HookCfg struct {
 	Command string            `yaml:"command"`
 	Params  map[string]string `yaml:"params,omitempty"`
 	Name    string            `yaml:"name,omitempty"`
+}
+
+// ExecCfg is the build.exec: section: the allowlisted PATH and the
+// environment-variable names passed through to every recipe. An empty
+// Path or EnvPassThrough means the executor's compiled defaults apply
+// (PATH = /usr/bin:/bin on Unix; pass-through = [HOME, LANG, LC_ALL]).
+// EnvPassThrough *replaces* the default list rather than appending to it.
+type ExecCfg struct {
+	Path           string   `yaml:"path,omitempty"`
+	EnvPassThrough []string `yaml:"env-pass-through,omitempty"`
 }
 
 // RecipeCfg is a single user-defined recipe declaration.
@@ -90,7 +104,7 @@ func ValidateBuildConfig(cfg *Config) error {
 			return err
 		}
 	}
-	return nil
+	return validateExecConfig(cfg.Build.Exec)
 }
 
 // validateHook validates a single hook entry. listName is "before" or "after".
@@ -164,6 +178,24 @@ func validateHookCommandPlaceholders(label, command string, allowed map[string]b
 					label, param,
 				)
 			}
+		}
+	}
+	return nil
+}
+
+// validateExecConfig rejects an env-pass-through entry that is empty or
+// contains an "=" character. An empty name cannot identify an
+// environment variable; an "=" would let a config inject a value rather
+// than name a variable to pass through, defeating the allowlist.
+func validateExecConfig(exec ExecCfg) error {
+	for i, name := range exec.EnvPassThrough {
+		if name == "" {
+			return fmt.Errorf("build.exec.env-pass-through[%d]: name must not be empty", i)
+		}
+		if strings.Contains(name, "=") {
+			return fmt.Errorf(
+				"build.exec.env-pass-through[%d]: name %q must not contain %q", i, name, "=",
+			)
 		}
 	}
 	return nil

--- a/internal/config/build.go
+++ b/internal/config/build.go
@@ -197,6 +197,12 @@ func validateExecConfig(exec ExecCfg) error {
 				"build.exec.env-pass-through[%d]: name %q must not contain %q", i, name, "=",
 			)
 		}
+		if strings.ContainsAny(name, "\x00\n\r") {
+			return fmt.Errorf(
+				"build.exec.env-pass-through[%d]: name %q must not contain NUL, newline, or carriage return",
+				i, name,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/config/build_test.go
+++ b/internal/config/build_test.go
@@ -1,11 +1,17 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDefaultConfigPath(t *testing.T) {
+	assert.Equal(t, filepath.Join("/some/root", ".mdsmith.yml"), DefaultConfigPath("/some/root"))
+	assert.Equal(t, filepath.Join(".", ".mdsmith.yml"), DefaultConfigPath("."))
+}
 
 // --- build.base-url removal ---
 

--- a/internal/config/build_test.go
+++ b/internal/config/build_test.go
@@ -91,6 +91,18 @@ func TestValidateBuildConfig_ExecPassThroughNameWithEquals(t *testing.T) {
 	assert.Contains(t, err.Error(), "=")
 }
 
+func TestValidateBuildConfig_ExecPassThroughNameWithControlChar(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Exec: ExecCfg{EnvPassThrough: []string{"FOO\nBAR"}},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "env-pass-through")
+	assert.Contains(t, err.Error(), "newline")
+}
+
 func TestValidateBuildConfig_ExecValid(t *testing.T) {
 	cfg := &Config{
 		Build: BuildConfig{

--- a/internal/config/build_test.go
+++ b/internal/config/build_test.go
@@ -56,6 +56,61 @@ func TestRejectRemovedBuildKeys_NullDocumentRoot(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// --- build.exec ---
+
+func TestLoad_ExecConfigParses(t *testing.T) {
+	yml := []byte("build:\n  exec:\n    path: \"/opt/bin:/bin\"\n" +
+		"    env-pass-through: [HOME, LANG, SOURCE_DATE_EPOCH]\n")
+	cfg, err := loadFromBytes(yml, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/bin:/bin", cfg.Build.Exec.Path)
+	assert.Equal(t, []string{"HOME", "LANG", "SOURCE_DATE_EPOCH"}, cfg.Build.Exec.EnvPassThrough)
+}
+
+func TestValidateBuildConfig_ExecEmptyPassThroughName(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Exec: ExecCfg{EnvPassThrough: []string{"HOME", ""}},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "env-pass-through")
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestValidateBuildConfig_ExecPassThroughNameWithEquals(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Exec: ExecCfg{EnvPassThrough: []string{"HOME=evil"}},
+		},
+	}
+	err := ValidateBuildConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "env-pass-through")
+	assert.Contains(t, err.Error(), "=")
+}
+
+func TestValidateBuildConfig_ExecValid(t *testing.T) {
+	cfg := &Config{
+		Build: BuildConfig{
+			Exec: ExecCfg{Path: "/usr/bin:/bin", EnvPassThrough: []string{"HOME", "LANG"}},
+		},
+	}
+	assert.NoError(t, ValidateBuildConfig(cfg))
+}
+
+func TestMerge_PreservesExecConfigWithoutRecipes(t *testing.T) {
+	loaded := &Config{
+		Build: BuildConfig{
+			Exec: ExecCfg{Path: "/custom/bin", EnvPassThrough: []string{"FOO"}},
+		},
+	}
+	merged := Merge(Defaults(), loaded)
+	assert.Equal(t, "/custom/bin", merged.Build.Exec.Path)
+	assert.Equal(t, []string{"FOO"}, merged.Build.Exec.EnvPassThrough)
+}
+
 // --- ValidateBuildConfig ---
 
 func TestValidateBuildConfig_Nil(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1536,6 +1537,49 @@ func TestReadLimitedConfig_MissingFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestReadLimitedConfig_ReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Open on a directory + ReadAll error semantics differ on Windows")
+	}
+	// Opening a directory succeeds, but io.ReadAll on the resulting handle
+	// fails ("is a directory"), driving the post-open read-error branch.
+	_, err := readLimitedConfig(t.TempDir())
+	require.Error(t, err)
+}
+
+func TestStatFileSize_StatError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(path, []byte("rules: {}\n"), 0o644))
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	// Stat on a closed handle fails, so statFileSize reports -1.
+	assert.Equal(t, int64(-1), statFileSize(f))
+}
+
+func TestReadLimitedConfig_OversizedFileStatFails(t *testing.T) {
+	// When Stat fails, the over-limit error reports the read length instead
+	// of the unknown actual size. Force the Stat-failure path with the seam.
+	orig := statFileSize
+	statFileSize = func(*os.File) int64 { return -1 }
+	t.Cleanup(func() { statFileSize = orig })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mdsmith.yml")
+	oversized := make([]byte, maxConfigBytes+1)
+	for i := range oversized {
+		oversized[i] = '#'
+	}
+	require.NoError(t, os.WriteFile(path, oversized, 0o644))
+
+	_, err := readLimitedConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+	// The reported size is the read length (maxConfigBytes+1), not a stat size.
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d bytes", maxConfigBytes+1))
+}
+
 func TestLoadMaxInputSizeFromYAML(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, ".mdsmith.yml")
@@ -1591,12 +1635,19 @@ func TestMergeNilLoaded_CopiesExplicitRules(t *testing.T) {
 	assert.False(t, hasCopy, "merged ExplicitRules should be independent copy")
 }
 
-// TestUnmarshalYAML_MappingDecodeError exercises the mapping decode error branch.
-// This is reached when a YAML mapping node cannot be decoded into map[string]any.
-// A mapping with YAML anchors triggers the RejectYAMLAliases check, so we need
-// a different invalid mapping. In practice this branch is very hard to trigger
-// since yaml.Decode on a MappingNode rarely fails; skip if not possible to test.
-// Instead test via the "non-scalar non-mapping" fallthrough branch.
+// TestUnmarshalYAML_MappingDecodeError exercises the mapping decode error
+// branch, reached when a MappingNode cannot decode into map[string]any. A
+// mapping whose key is itself a sequence (a complex YAML key) cannot become a
+// string-keyed map, so Decode fails and the branch wraps it as "invalid rule
+// config".
+func TestUnmarshalYAML_MappingDecodeError(t *testing.T) {
+	input := "rules:\n  line-length:\n    ? [a, b]\n    : c\n"
+	var cfg Config
+	err := yaml.Unmarshal([]byte(input), &cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid rule config")
+}
+
 func TestUnmarshalYAML_NonScalarNonMappingValue(t *testing.T) {
 	// YAML sequence (list) as rule config → should return "rule config must be a bool or a mapping".
 	input := "rules:\n  line-length:\n    - item1\n    - item2\n"

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -293,6 +293,18 @@ func DumpDefaults() *Config {
 	}
 }
 
+// statFileSize returns the open file's size, or -1 if Stat fails. It is a
+// var so a test can force the Stat-failure path of readLimitedConfig's
+// over-limit size report, which a real filesystem never reaches once Open
+// has succeeded.
+var statFileSize = func(f *os.File) int64 {
+	info, err := f.Stat()
+	if err != nil {
+		return -1
+	}
+	return info.Size()
+}
+
 // readLimitedConfig reads a config file with a size cap to prevent OOM.
 func readLimitedConfig(path string) ([]byte, error) {
 	f, err := os.Open(path)
@@ -302,10 +314,7 @@ func readLimitedConfig(path string) ([]byte, error) {
 	defer f.Close() //nolint:errcheck // best-effort close on read-only file
 
 	// Stat for accurate size in error messages.
-	var actualSize int64 = -1
-	if info, err := f.Stat(); err == nil {
-		actualSize = info.Size()
-	}
+	actualSize := statFileSize(f)
 
 	data, err := io.ReadAll(io.LimitReader(f, maxConfigBytes+1))
 	if err != nil {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -18,6 +18,13 @@ const maxConfigBytes int64 = 1024 * 1024
 
 const configFileName = ".mdsmith.yml"
 
+// DefaultConfigPath returns the default config path under dir (the
+// conventional .mdsmith.yml). It is the single source of truth for the
+// config filename outside this package.
+func DefaultConfigPath(dir string) string {
+	return filepath.Join(dir, configFileName)
+}
+
 // Load reads and parses a config file at the given path.
 func Load(path string) (*Config, error) {
 	data, err := readLimitedConfig(path)

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -133,6 +133,17 @@ func copyUserConventions(m map[string]UserConvention) map[string]UserConvention 
 // Recipes map, each recipe's Params slices, and the Hooks lists so callers
 // can mutate them independently.
 func copyBuildConfig(b BuildConfig) BuildConfig {
+	exec := ExecCfg{
+		Path:           b.Exec.Path,
+		EnvPassThrough: copyStrings(b.Exec.EnvPassThrough),
+	}
+	hooks := HooksCfg{
+		Before: copyHooks(b.Hooks.Before),
+		After:  copyHooks(b.Hooks.After),
+	}
+	if len(b.Recipes) == 0 {
+		return BuildConfig{Hooks: hooks, Exec: exec}
+	}
 	recipes := make(map[string]RecipeCfg, len(b.Recipes))
 	for name, r := range b.Recipes {
 		recipes[name] = RecipeCfg{
@@ -145,13 +156,7 @@ func copyBuildConfig(b BuildConfig) BuildConfig {
 			DefaultInputs: copyStrings(r.DefaultInputs),
 		}
 	}
-	return BuildConfig{
-		Recipes: recipes,
-		Hooks: HooksCfg{
-			Before: copyHooks(b.Hooks.Before),
-			After:  copyHooks(b.Hooks.After),
-		},
-	}
+	return BuildConfig{Recipes: recipes, Hooks: hooks, Exec: exec}
 }
 
 // copyHooks returns a shallow copy of a hook list.

--- a/internal/rules/build/resolve.go
+++ b/internal/rules/build/resolve.go
@@ -8,6 +8,11 @@ import (
 	"github.com/jeduden/mdsmith/internal/oscompat"
 )
 
+// evalSymlinks is a var so tests can override it to drive the
+// no-existing-prefix branch of resolveLongestExistingPrefix, which a real
+// filesystem never reaches because the root always resolves.
+var evalSymlinks = oscompat.EvalSymlinks
+
 // MaxGlobMatches is the per-entry cap on how many files one inputs:
 // glob may resolve to. An author who needs more declares several
 // narrower patterns. The build executor (a later plan) enforces this
@@ -39,7 +44,7 @@ func CheckGlobMatchCap(n int) error {
 // slashes before comparison, keeping the slash-only invariant on
 // Windows. A path that resolves outside root is an error.
 func ResolvePathInRoot(root, rel string, mustExist bool) (string, error) {
-	resolvedRoot, err := oscompat.EvalSymlinks(root)
+	resolvedRoot, err := evalSymlinks(root)
 	if err != nil {
 		// Fall back to the lexical absolute root when the root itself
 		// cannot be resolved (e.g. it does not exist in a unit test of
@@ -52,7 +57,7 @@ func ResolvePathInRoot(root, rel string, mustExist bool) (string, error) {
 
 	var resolved string
 	if mustExist {
-		resolved, err = oscompat.EvalSymlinks(abs)
+		resolved, err = evalSymlinks(abs)
 		if err != nil {
 			return "", fmt.Errorf("cannot resolve %q: %w", rel, err)
 		}
@@ -77,7 +82,7 @@ func resolveLongestExistingPrefix(abs string) string {
 	missing := []string{}
 	cur := abs
 	for {
-		if resolved, err := oscompat.EvalSymlinks(cur); err == nil {
+		if resolved, err := evalSymlinks(cur); err == nil {
 			if len(missing) == 0 {
 				return resolved
 			}

--- a/internal/rules/build/resolve_test.go
+++ b/internal/rules/build/resolve_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -113,6 +114,20 @@ func TestResolvePathInRoot_ExistingOutputOK(t *testing.T) {
 	got, err := ResolvePathInRoot(root, "out.html", false)
 	require.NoError(t, err)
 	assert.Equal(t, "out.html", got)
+}
+
+func TestResolveLongestExistingPrefix_NoExistingPrefix(t *testing.T) {
+	// A real filesystem always resolves the root, so the loop never walks
+	// all the way up without finding an existing ancestor. Force every
+	// evalSymlinks call to fail so the walk reaches parent == cur and falls
+	// back to the lexical clean path.
+	orig := evalSymlinks
+	evalSymlinks = func(string) (string, error) { return "", errors.New("forced failure") }
+	t.Cleanup(func() { evalSymlinks = orig })
+
+	abs := filepath.Join(string(filepath.Separator)+"ghost", "a", "b")
+	got := resolveLongestExistingPrefix(abs)
+	assert.Equal(t, filepath.Clean(abs), got)
 }
 
 func TestResolvePathInRoot_SymlinkWithinRootOK(t *testing.T) {

--- a/internal/rules/build/rule.go
+++ b/internal/rules/build/rule.go
@@ -376,7 +376,7 @@ func validatePathEntry(p string, allowGlob bool) string {
 	if cleaned == ".." || cleaned == "." || strings.HasPrefix(cleaned, "../") {
 		return `must not contain ".." path components`
 	}
-	if underMdsmithDir(cleaned) {
+	if UnderMdsmithDir(cleaned) {
 		return "must not be under .mdsmith/"
 	}
 	return ""
@@ -398,9 +398,11 @@ func hasReservedDeviceName(p string) bool {
 	return false
 }
 
-// underMdsmithDir reports whether the cleaned, slash-separated path is
-// the .mdsmith state directory or a file inside it.
-func underMdsmithDir(cleaned string) bool {
+// UnderMdsmithDir reports whether the cleaned, slash-separated path is
+// the .mdsmith state directory or a file inside it. Exported so the build
+// executor can apply the same reserved-path guard at exec time that this
+// rule applies at lint time.
+func UnderMdsmithDir(cleaned string) bool {
 	return cleaned == ".mdsmith" || strings.HasPrefix(cleaned, ".mdsmith/")
 }
 

--- a/plan/2606101548_build-execution-hardening.md
+++ b/plan/2606101548_build-execution-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: 2606101548
 title: Build execution hardening
-status: "🔲"
+status: "✅"
 summary: >-
   Layer security on top of plan 2606101546's basic
   builder execution. Trust gate so a freshly
@@ -274,47 +274,47 @@ pass-through names or names containing `=`.
 
 ## Acceptance Criteria
 
-- [ ] Build pass refuses to run when
+- [x] Build pass refuses to run when
       `.mdsmith.yml.trust` is missing or
       stale (and `MDSMITH_TRUST_BUILD=1`
       is not set); lint-fix still runs
-- [ ] `mdsmith trust` shows the config
+- [x] `mdsmith trust` shows the config
       diff and updates the trust marker
       on confirmation
-- [ ] `mdsmith fix --no-build` skips the
+- [x] `mdsmith fix --no-build` skips the
       trust check and the build pass
       together
-- [ ] Recipe writing outside `outputs:`
+- [x] Recipe writing outside `outputs:`
       is a build failure; the undeclared
       file is named in the diagnostic
-- [ ] Recipe exiting 0 without producing
+- [x] Recipe exiting 0 without producing
       every declared output is a build
       failure
-- [ ] Atomic write uses `os.MkdirTemp` with
+- [x] Atomic write uses `os.MkdirTemp` with
       a random suffix under
       `.mdsmith/build-staging/`; that
       staging root is refused if it is a
       symlink, not a directory, or group-
       or world-writable
-- [ ] Rename phase `Lstat`s each output
+- [x] Rename phase `Lstat`s each output
       destination, refuses to replace a
       symlink, then uses `os.Rename`;
       multi-output partial failure cleans
       up the staging dir and exits with
       FAIL (next `fix` reruns the recipe)
-- [ ] Recipe is invoked with `Cmd.Env`
+- [x] Recipe is invoked with `Cmd.Env`
       restricted to the allowlist and
       `Cmd.Dir` set to the per-recipe
       staging dir
-- [ ] A snapshot scope above 2 000
+- [x] A snapshot scope above 2 000
       directory entries is a build error
       naming the oversized dir
-- [ ] Recipe runs in its own process
+- [x] Recipe runs in its own process
       group; timeout fires SIGTERM, then
       SIGKILL after 5 s
-- [ ] `build.exec.path` and
+- [x] `build.exec.path` and
       `build.exec.env-pass-through`
       parse, validate, and take effect
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool golangci-lint run`
+- [x] All tests pass: `go test ./...`
+- [x] `go tool golangci-lint run`
       reports no issues


### PR DESCRIPTION
Implements **plan/2606101548_build-execution-hardening.md**. Layers security on top of plan 2606101546's basic builder execution.

## What changed

- **Trust gate** (`internal/build/trust.go`): the build pass runs recipes only when `.mdsmith.yml.trust` matches `.mdsmith.yml` byte-for-byte, or `MDSMITH_TRUST_BUILD=1` is set (sandboxed CI). Drift or a missing marker aborts the build pass with a clear message; lint-fix still runs. New `mdsmith trust` subcommand shows the unified diff and rewrites the marker on confirmation. `--build-dry-run`/`--build-check-stale` never consult the gate (they execute nothing).
- **Hermetic execution env** (`internal/build/exec.go` + `exec_unix.go`/`exec_windows.go`): each recipe runs with `Cmd.Env` restricted to an allowlisted PATH (`build.exec.path`, default `/usr/bin:/bin`) plus `build.exec.env-pass-through` names (default `[HOME, LANG, LC_ALL]`), `Cmd.Dir` set to the staging dir, and its own process group. On `--build-timeout` it signals the whole group (SIGTERM / CTRL_BREAK), waits 5s, then force-kills — no orphaned children.
- **Atomic-write hardening** (`internal/build/staging.go`, `builder.go`): `.mdsmith/build-staging/` is created `0700`; a symlink, non-directory, or group/world-writable root is refused. Per-recipe dir via `os.MkdirTemp`. Each destination is `Lstat`ed and a symlink refused before the atomic rename; multi-output partial failure cleans up and exits FAIL (next `fix` reruns).
- **Output post-conditions** (`internal/build/postcheck.go`): after exit 0, every declared output must exist in staging, and a before/after snapshot (size, mtime, mode, sha256) of the output parents fails the build on any undeclared write. >2000-entry scope is an error.
- **Config schema** (`internal/config/build.go`, already committed): `build.exec.{path, env-pass-through}` parse, deep-merge, and validate (no empty names, no `=`).
- **Docs**: Build safety section in the build directive guide (with CI guidance), `mdsmith trust` CLI reference, demo.tape opt-in, `.gitignore` entries.

## Tests

- Unit tests for trust, hermetic env, staging-root checks, and snapshot diffing.
- Integration tests: missing/stale marker blocks build but lint-fix runs; `MDSMITH_TRUST_BUILD=1`; `mdsmith trust` diff + re-trust; `--no-build` skips the gate; undeclared write fails and is named; recipe exiting 0 without a declared output fails; group-writable staging root refused; timeout kills a spawned child; `Cmd.Env` allowlist-only.

`go build`, `go vet`, `go test ./...`, `mdsmith check .`, and `golangci-lint run` all pass.

https://claude.ai/code/session_01TUCuoye4F3Q4heCmpTkp2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUCuoye4F3Q4heCmpTkp2r)_