### PR TITLE
Code-review fixes for #591: enforce the soft-skip contract, fix the vs-mado denominator, refresh stale prose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -870,6 +870,10 @@ jobs:
         # install with `skipped=true` when the upstream registry entry
         # does not exist yet; verifying a binary that was never
         # installed would fail with exit 127, so skip alongside it.
+        # Hard install failures are covered by the implicit success()
+        # in this expression — do not add continue-on-error to the
+        # Install step, or a failed install would fall through to here
+        # with no skipped output and re-fail as a confusing exit 127.
         if: steps.install.outputs.skipped != 'true'
         run: |
           got=$(${{ matrix.run }})

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -51,7 +51,7 @@ docs read.
 
 | Corpus  | Files | Source                                            |
 | ------- | ----- | ------------------------------------------------- |
-| repo    | 722   | mdsmith's own tracked Markdown (fixtures dropped) |
+| repo    | 766   | mdsmith's own tracked Markdown (fixtures dropped) |
 | neutral | 234   | Rust Book + Rust Reference `src/` (third-party)   |
 
 ### Environment
@@ -90,7 +90,7 @@ mdsmith-only rules so the work class matches the markdownlint
 tools (see `bench-parity.mdsmith.yml`).
 
 **Repo corpus — 766 Markdown files** (median wall time, lower is
-better; `vs mado` is the median ratio to the fastest tool):
+better; `vs mado` is the ratio to mado's median):
 
 | Tool              | Median  | Min     | vs mado |
 | ----------------- | ------- | ------- | ------- |
@@ -147,8 +147,8 @@ rules (see
 mdsmith runs in mado's class. On the repo corpus the
 `mdsmith-parity` row comes in at mado's time (the two trade
 places run to run within noise), well ahead of rumdl; on the
-longer-prose neutral corpus it trails mado by roughly a tenth
-and comes in ahead of rumdl. The `mdsmith` → `mdsmith-parity`
+longer-prose neutral corpus it trails mado narrowly (the 1.1x
+in the table above) and comes in ahead of rumdl. The `mdsmith` → `mdsmith-parity`
 delta is the measured cost of the cross-file and
 generated-content layer — work users opt into, not waste.
 The residual gap to mado on long prose is genuine engine
@@ -191,7 +191,7 @@ is meant to be read as a result.
 
 **The repo corpus grows.** It is mdsmith's own tracked
 Markdown, and the project keeps adding docs — 523 files when
-this page was first written, 722 now. A linter that checks more
+this page was first written, 766 now. A linter that checks more
 files takes longer, so mdsmith's absolute repo-corpus time
 creeps up as the docs grow, with no change to the engine. The
 tell that growth — not a code regression — drives most of the

--- a/docs/research/benchmarks/gen_fragments.py
+++ b/docs/research/benchmarks/gen_fragments.py
@@ -51,12 +51,19 @@ def rows(json_dir: pathlib.Path, corpus: str):
             data[r["command"]] = (r["median"] * 1000, r["min"] * 1000)
     if not data:
         sys.exit(f"no JSON results for corpus {corpus!r} in {json_dir}")
-    fastest = min(v[0] for v in data.values())
+    if "mado" not in data:
+        sys.exit(f"corpus {corpus!r} has no mado result; the 'vs mado' "
+                 "column needs mado's median as its denominator")
+    # The column is literally "vs mado", so divide by mado's median —
+    # not the fastest tool's. The two coincided until mdsmith-parity
+    # started trading places with mado, at which point a min() here
+    # silently relabeled every ratio.
+    mado = data["mado"][0]
     order = sorted(data.items(), key=lambda kv: kv[1][0])
     lines = ["| Tool | Median | Min | vs mado |",
              "|---|---|---|---|"]
     for tool, (med, mn) in order:
-        ratio = med / fastest
+        ratio = med / mado
         rs = f"{ratio:.1f}x" if ratio < 10 else f"{round(ratio)}x"
         lines.append(f"| {tool} | {round(med)} ms | "
                      f"{round(mn)} ms | {rs} |")
@@ -82,8 +89,8 @@ def main() -> None:
             "`bench-parity.mdsmith.yml`).\n\n")
     results = (GEN + "\n" + note +
                f"**Repo corpus — {repo_n} Markdown files** (median "
-               "wall time, lower is\nbetter; `vs mado` is the median "
-               "ratio to the fastest tool):\n\n" + repo_tbl + "\n\n"
+               "wall time, lower is\nbetter; `vs mado` is the ratio "
+               "to mado's median):\n\n" + repo_tbl + "\n\n"
                f"**Neutral corpus — {neutral_n} files** (Rust Book + "
                "Rust Reference,\nlonger third-party prose):\n\n"
                + neut_tbl + "\n")

--- a/docs/research/benchmarks/results.fragment.md
+++ b/docs/research/benchmarks/results.fragment.md
@@ -7,7 +7,7 @@ mdsmith-only rules so the work class matches the markdownlint
 tools (see `bench-parity.mdsmith.yml`).
 
 **Repo corpus — 766 Markdown files** (median wall time, lower is
-better; `vs mado` is the median ratio to the fastest tool):
+better; `vs mado` is the ratio to mado's median):
 
 | Tool              | Median  | Min     | vs mado |
 | ----------------- | ------- | ------- | ------- |

--- a/internal/release/releasesmoke.go
+++ b/internal/release/releasesmoke.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -30,11 +31,20 @@ const smokeJobName = "smoke-test"
 // warns rather than fails until that registry entry lands.
 var RequiredSmokeChannels = []string{"asdf", "go", "mise", "npm", "pip"}
 
+// softSkipMarker is the GITHUB_OUTPUT line a best-effort channel's
+// install script writes before exiting 0, telling the shared Verify
+// step to skip rather than run `mdsmith version` against a binary that
+// was never installed. Only channels outside RequiredSmokeChannels may
+// carry it: a required channel that soft-skips would satisfy the
+// matrix-coverage check while never verifying anything.
+const softSkipMarker = "skipped=true"
+
 type smokeRawJob struct {
 	Strategy struct {
 		Matrix struct {
 			Include []struct {
 				Channel string `yaml:"channel"`
+				Install string `yaml:"install"`
 			} `yaml:"include"`
 		} `yaml:"matrix"`
 	} `yaml:"strategy"`
@@ -63,21 +73,35 @@ func CheckReleaseSmoke(workflowYAML []byte) ([]GateViolation, error) {
 		}}, nil
 	}
 	have := make(map[string]bool, len(job.Strategy.Matrix.Include))
+	softSkips := make(map[string]bool)
 	for _, entry := range job.Strategy.Matrix.Include {
 		have[entry.Channel] = true
+		if strings.Contains(entry.Install, softSkipMarker) {
+			softSkips[entry.Channel] = true
+		}
 	}
 	var violations []GateViolation
 	for _, channel := range RequiredSmokeChannels {
-		if have[channel] {
+		if !have[channel] {
+			violations = append(violations, GateViolation{
+				Job: smokeJobName,
+				Reason: fmt.Sprintf(
+					"matrix has no entry for channel %q; every directly consumable "+
+						"channel must be installed and version-checked after publication",
+					channel),
+			})
 			continue
 		}
-		violations = append(violations, GateViolation{
-			Job: smokeJobName,
-			Reason: fmt.Sprintf(
-				"matrix has no entry for channel %q; every directly consumable "+
-					"channel must be installed and version-checked after publication",
-				channel),
-		})
+		if softSkips[channel] {
+			violations = append(violations, GateViolation{
+				Job: smokeJobName,
+				Reason: fmt.Sprintf(
+					"channel %q is required but its install script writes %q; a "+
+						"required channel must never soft-skip the Verify step — only "+
+						"best-effort channels outside RequiredSmokeChannels may",
+					channel, softSkipMarker),
+			})
+		}
 	}
 	return violations, nil
 }

--- a/internal/release/releasesmoke_test.go
+++ b/internal/release/releasesmoke_test.go
@@ -93,6 +93,64 @@ jobs:
 	require.Len(t, got, len(RequiredSmokeChannels)-1)
 }
 
+func TestCheckReleaseSmokeFlagsRequiredChannelThatSoftSkips(t *testing.T) {
+	// The skipped=true output is the best-effort contract: an install
+	// script writes it and exits 0, and the shared Verify step skips.
+	// A REQUIRED channel carrying that marker would pass the matrix
+	// coverage check while never actually verifying the binary, so the
+	// gate must reject the combination loudly.
+	const wf = `
+jobs:
+  smoke-test:
+    strategy:
+      matrix:
+        include:
+          - channel: npm
+          - channel: pip
+          - channel: mise
+            install: |
+              if ! mise use -g "mdsmith@1.0.0"; then
+                echo "skipped=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+          - channel: asdf
+          - channel: go
+`
+	got, err := CheckReleaseSmoke([]byte(wf))
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, smokeJobName, got[0].Job)
+	assert.Contains(t, got[0].Reason, `"mise"`)
+	assert.Contains(t, got[0].Reason, "skipped=true")
+}
+
+func TestCheckReleaseSmokeAcceptsBestEffortSoftSkip(t *testing.T) {
+	// A channel outside RequiredSmokeChannels (mise-registry while the
+	// jdx/mise registry entry is pending) may soft-skip: that is the
+	// designed best-effort path, not a coverage hole.
+	const wf = `
+jobs:
+  smoke-test:
+    strategy:
+      matrix:
+        include:
+          - channel: npm
+          - channel: pip
+          - channel: mise
+          - channel: mise-registry
+            install: |
+              if ! mise use -g "mdsmith@1.0.0"; then
+                echo "skipped=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+          - channel: asdf
+          - channel: go
+`
+	got, err := CheckReleaseSmoke([]byte(wf))
+	require.NoError(t, err)
+	assert.Empty(t, got, "a best-effort channel outside RequiredSmokeChannels may soft-skip")
+}
+
 func TestCheckReleaseSmokeFlagsMissingJob(t *testing.T) {
 	const wf = `
 jobs:


### PR DESCRIPTION
Follow-up to the merged #591: the user-requested xhigh code-review round over that diff surfaced three fixable findings (plus structural notes left for the maintainer). Round 2 of the review runs on this PR next.

## Fixes

**1. Required smoke channels can no longer soft-skip verification** (`internal/release/releasesmoke.go`, TDD)

#591 introduced the `skipped=true` output contract so the best-effort `mise-registry` leg skips the shared Verify step. The review found `CheckReleaseSmoke` only checks that each required channel has a matrix entry — a required channel carrying the soft-skip marker would pass the gate while never verifying the published binary (the concrete risk: promoting `mise-registry` into `RequiredSmokeChannels` once the jdx registry entry lands, without removing its skip path). The gate now rejects the combination; tests cover both the violation and the allowed best-effort case.

**2. The "vs mado" benchmark column now actually divides by mado** (`docs/research/benchmarks/gen_fragments.py`)

The table's ratio denominator was `min()` over all tools under a hardcoded `vs mado` header. In the pre-#591 committed data mdsmith-parity was faster than mado, so every published ratio was silently vs-parity — the old table literally showed mado at "1.1x vs mado". Pinned to mado's median with a loud exit if mado's result is missing; output is byte-identical for the current data except the caption, which now reads "the ratio to mado's median". (The headline's `int()` floor was left alone — its comment states the floor is deliberate: "the headline must never overstate the win".)

**3. Stale hand-written README numbers** (`docs/research/benchmarks/README.md`)

The corpora table and the growth paragraph still said 722 repo files (the fragments say 766); the parity-gap sentence said "trails mado by roughly a tenth" while the data gives 1.14x — it now cites the table's own 1.1x figure so it can't drift independently. Also added one clause to the Verify-step comment in `release.yml`: the skip mechanism relies on the implicit `success()` guard, so `continue-on-error` must not be added to the Install step.

## Review findings deliberately not fixed

- The mise-registry leg burns ~60s of retry sleeps + a container pull per release while the registry entry is pending — judged a fair trade vs. brittle error-string matching; the design comment already documents it.
- Baseline provenance (nothing stops a laptop `run.sh` promotion from reintroducing environment skew) and the 15% tolerance sitting near the observed ±14–19% ratio noise floor — structural policy calls, flagged in #591's notes.
- Refuted during verification: the claim that an explicit `if:` drops the implicit `success()` guard (GitHub docs: a status function is implied unless one is present), and the claim that `mise activate` pollutes the Verify step's captured stdout (run 107's green mise leg disproves it).

Validated: `go test ./internal/release/... ./cmd/mdsmith-release/...`, `check-release-gates`, `check-release-smoke`, fragment regeneration is byte-stable, and `mdsmith check .` is clean. golangci-lint could not run locally (tools/go.mod needs Go ≥ 1.25.8; environment has 1.25.0) — CI covers it.

https://claude.ai/code/session_0123efoHqbw98eAhPYYjaAkp

---
_Generated by [Claude Code](https://claude.ai/code/session_0123efoHqbw98eAhPYYjaAkp)_