### PR TITLE
Code-review round 2: pin the soft-skip contract against release.yml, harden gate surfaces, drift-proof benchmark prose

### DIFF
--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -54,7 +54,7 @@ Commands:
   stamp <version>                 Rewrite tracked manifests to <version>.
   check                           Verify tracked manifests are at the dev sentinel.
   check-release-gates             Verify release-environment gating across .github/workflows.
-  check-release-smoke             Verify release.yml smoke-tests every required channel.
+  check-release-smoke             Verify release.yml smoke-tests every required channel (no soft-skips).
   build-npm <artifacts> <out>     Build npm platform sub-packages.
   build-wheels <artifacts> <out>  Build platform-tagged Python wheels.
   build-flatpak <art> <out>       Stage the .flatpak bundle's manifest + Linux binaries.
@@ -296,7 +296,9 @@ func runCheckReleaseSmoke(root string, args []string) int {
 			"`mdsmith version` reports the tag, so a channel broken at the\n"+
 			"source — like the go.mod replace directive that made v0.40.0\n"+
 			"uninstallable via `go install` — fails the release pipeline\n"+
-			"instead of a user. Used by the release-gate-guard CI job.\n"+
+			"instead of a user. A required channel must also not write the\n"+
+			"best-effort `skipped=true` output that suppresses the shared\n"+
+			"Verify step. Used by the release-gate-guard CI job.\n"+
 			"Exits non-zero on any violation.\n",
 			strings.Join(release.RequiredSmokeChannels, ", "))
 	}
@@ -317,7 +319,8 @@ func runCheckReleaseSmoke(root string, args []string) int {
 	return reportGuardViolations(violations,
 		"release smoke coverage violated:",
 		"\nevery directly consumable install channel needs a smoke-test matrix\n"+
-			"entry that installs the published version and checks `mdsmith version`.\n"+
+			"entry that installs the published version and checks `mdsmith version`\n"+
+			"without the best-effort skipped=true escape hatch.\n"+
 			"See docs/development/release.md.",
 		"release smoke-test matrix covers every required channel")
 }

--- a/cmd/mdsmith-release/releasesmoke_test.go
+++ b/cmd/mdsmith-release/releasesmoke_test.go
@@ -44,6 +44,29 @@ func TestRunCheckReleaseSmokeFailsOnMissingChannel(t *testing.T) {
 	assert.Equal(t, 1, run([]string{"check-release-smoke"}))
 }
 
+func TestRunCheckReleaseSmokeFailsOnRequiredChannelSoftSkip(t *testing.T) {
+	// All required channels are present, but one of them carries the
+	// best-effort skipped=true output — the second violation class.
+	const wf = `
+jobs:
+  smoke-test:
+    strategy:
+      matrix:
+        include:
+          - channel: npm
+          - channel: pip
+          - channel: mise
+            install: |
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+          - channel: asdf
+          - channel: go
+`
+	root := t.TempDir()
+	chdirTo(t, root)
+	gatesWriteWorkflow(t, root, "release.yml", wf)
+	assert.Equal(t, 1, run([]string{"check-release-smoke"}))
+}
+
 func TestRunCheckReleaseSmokeFailsWithoutWorkflow(t *testing.T) {
 	root := t.TempDir()
 	chdirTo(t, root)

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -303,7 +303,7 @@ enough.
   conditions, and on any sibling workflow that targets
   the release environments. Runs
   `mdsmith-release check-release-gates`, then
-  `check-release-smoke` (per-channel smoke coverage).
+  `check-release-smoke` (smoke coverage, no soft-skips).
 - **`if: github.repository == 'jeduden/mdsmith'`** on
   every publishing job, so a fork-cloned release
   workflow cannot reach the publish steps.

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -147,8 +147,8 @@ rules (see
 mdsmith runs in mado's class. On the repo corpus the
 `mdsmith-parity` row comes in at mado's time (the two trade
 places run to run within noise), well ahead of rumdl; on the
-longer-prose neutral corpus it trails mado narrowly (the 1.1x
-in the table above) and comes in ahead of rumdl. The `mdsmith` → `mdsmith-parity`
+longer-prose neutral corpus it trails mado narrowly and comes
+in ahead of rumdl. The `mdsmith` → `mdsmith-parity`
 delta is the measured cost of the cross-file and
 generated-content layer — work users opt into, not waste.
 The residual gap to mado on long prose is genuine engine
@@ -196,8 +196,9 @@ files takes longer, so mdsmith's absolute repo-corpus time
 creeps up as the docs grow, with no change to the engine. The
 tell that growth — not a code regression — drives most of the
 move is mado: a fixed-version check-only binary, its repo time
-went from 40 ms over 523 files to 57 ms over 722, about 1.4x,
-almost exactly the 1.38x file growth (722/523). When the
+went from 40 ms over 523 files to 57 ms over 722 across an
+earlier pair of snapshots — about 1.4x, almost exactly the
+1.38x file growth (722/523). When the
 fixed-version tool scales with the file count, the shared cause
 is the file count. (The neutral corpus does not grow — it is
 pinned third-party prose; see below.)

--- a/docs/research/benchmarks/gen_fragments.py
+++ b/docs/research/benchmarks/gen_fragments.py
@@ -52,12 +52,9 @@ def rows(json_dir: pathlib.Path, corpus: str):
     if not data:
         sys.exit(f"no JSON results for corpus {corpus!r} in {json_dir}")
     if "mado" not in data:
-        sys.exit(f"corpus {corpus!r} has no mado result; the 'vs mado' "
-                 "column needs mado's median as its denominator")
-    # The column is literally "vs mado", so divide by mado's median —
-    # not the fastest tool's. The two coincided until mdsmith-parity
-    # started trading places with mado, at which point a min() here
-    # silently relabeled every ratio.
+        sys.exit(f"no mado result for corpus {corpus!r} in {json_dir}")
+    # Divide by mado's median, not the fastest tool's, to match the
+    # "vs mado" column header.
     mado = data["mado"][0]
     order = sorted(data.items(), key=lambda kv: kv[1][0])
     lines = ["| Tool | Median | Min | vs mado |",

--- a/internal/release/releasesmoke.go
+++ b/internal/release/releasesmoke.go
@@ -36,7 +36,10 @@ var RequiredSmokeChannels = []string{"asdf", "go", "mise", "npm", "pip"}
 // step to skip rather than run `mdsmith version` against a binary that
 // was never installed. Only channels outside RequiredSmokeChannels may
 // carry it: a required channel that soft-skips would satisfy the
-// matrix-coverage check while never verifying anything.
+// matrix-coverage check while never verifying anything. Matched as a
+// plain substring — a deliberate tripwire, so even a script comment
+// mentioning the marker in a required channel trips the gate loudly
+// instead of the gate trying to parse shell.
 const softSkipMarker = "skipped=true"
 
 type smokeRawJob struct {
@@ -72,17 +75,14 @@ func CheckReleaseSmoke(workflowYAML []byte) ([]GateViolation, error) {
 				"exist so a broken channel fails the release, not a user",
 		}}, nil
 	}
-	have := make(map[string]bool, len(job.Strategy.Matrix.Include))
-	softSkips := make(map[string]bool)
+	installs := make(map[string]string, len(job.Strategy.Matrix.Include))
 	for _, entry := range job.Strategy.Matrix.Include {
-		have[entry.Channel] = true
-		if strings.Contains(entry.Install, softSkipMarker) {
-			softSkips[entry.Channel] = true
-		}
+		installs[entry.Channel] = entry.Install
 	}
 	var violations []GateViolation
 	for _, channel := range RequiredSmokeChannels {
-		if !have[channel] {
+		install, ok := installs[channel]
+		if !ok {
 			violations = append(violations, GateViolation{
 				Job: smokeJobName,
 				Reason: fmt.Sprintf(
@@ -92,7 +92,7 @@ func CheckReleaseSmoke(workflowYAML []byte) ([]GateViolation, error) {
 			})
 			continue
 		}
-		if softSkips[channel] {
+		if strings.Contains(install, softSkipMarker) {
 			violations = append(violations, GateViolation{
 				Job: smokeJobName,
 				Reason: fmt.Sprintf(

--- a/internal/release/releasesmoke_test.go
+++ b/internal/release/releasesmoke_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 const smokeCoveredWorkflow = `
@@ -230,4 +231,29 @@ func TestRepoReleaseWorkflowCoversRequiredSmokeChannels(t *testing.T) {
 	got, err := CheckReleaseSmokeRoot("../..")
 	require.NoError(t, err)
 	assert.Empty(t, got)
+}
+
+// TestRepoReleaseWorkflowSoftSkipMarkerInSync pins the marker contract
+// against the real release.yml. The gate detects soft-skips by
+// grepping install scripts for softSkipMarker, so a rename of the
+// `skipped=true` output in the workflow alone would make the gate
+// vacuous — this test goes red instead. It also pins mise-registry as
+// the best-effort channel: promoting it into RequiredSmokeChannels
+// (the plan 145 follow-up) must be a conscious edit here too, after
+// the install script's soft-skip path is removed.
+func TestRepoReleaseWorkflowSoftSkipMarkerInSync(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("../..", ReleaseWorkflowPath))
+	require.NoError(t, err)
+	var wf smokeRawWorkflow
+	require.NoError(t, yaml.Unmarshal(data, &wf))
+
+	installs := map[string]string{}
+	for _, entry := range wf.Jobs[smokeJobName].Strategy.Matrix.Include {
+		installs[entry.Channel] = entry.Install
+	}
+	require.Contains(t, installs, "mise-registry")
+	assert.Contains(t, installs["mise-registry"], softSkipMarker,
+		"the best-effort channel's install script must write the marker the gate greps for")
+	assert.NotContains(t, RequiredSmokeChannels, "mise-registry",
+		"a channel with a soft-skip path must stay best-effort")
 }


### PR DESCRIPTION
Round 2 of the requested xhigh code review, run over #592's diff after it merged. Nine finder angles plus a sweep produced ~30 raw candidates; after verification they reduce to the fixes below (the headline mechanisms of #592 all held up — the round confirmed the `if:` expression's implicit `success()` guard, the YAML comments sitting outside the `install:` block scalar, byte-stable fragment regeneration, and clean vet/tests).

## Fixes

**Gate hardening and surfaces** (`internal/release/`, `cmd/mdsmith-release/`)
- `TestRepoReleaseWorkflowSoftSkipMarkerInSync` pins the contract against the real `release.yml`: renaming the workflow's `skipped=true` literal without updating `softSkipMarker` would have made the gate silently vacuous — now it's a red test. The same test pins `mise-registry` as best-effort, so promoting it into `RequiredSmokeChannels` (the plan-145 follow-up) forces a conscious edit after its skip path is removed.
- The cmd layer gains the missing end-to-end test: a required channel that soft-skips now provably exits 1 through `run()` dispatch, catching e.g. a yaml-tag regression the unit tests can't see.
- `CheckReleaseSmoke`'s two membership maps fold into one channel→install map (matches the package's idiom).
- The subcommand's usage text, command-list one-liner, and failure hint now name the second violation class — previously an operator hitting it got a Reason string but help text describing only missing-channel coverage. `docs/development/release.md`'s gate-guard bullet gets the same one-phrase update (kept to net-zero lines; the file sits at its 380-line MDS022 budget).

**Prose drift-proofing** (`docs/research/benchmarks/`)
- The parity sentence cited the table's literal `1.1x` — a number `gen_fragments.py` regenerates while prose stands still. Now qualitative ("trails mado narrowly"); the table owns the number.
- The mado growth example's 523→722 figures are explicitly "an earlier pair of snapshots", so they no longer read as the current count two sentences after "766 now".
- `gen_fragments.py`'s new comment trims to the invariant (the file documents invariants, not history) and the mado exit message to one line, matching its other exits.

## Found, deliberately not fixed

- `strings.Contains` is a substring tripwire: a required channel's install script merely *mentioning* `skipped=true` in a shell comment would trip the gate (loudly, at PR time — the failure mode is annoying, not silent), and writing the output via a variable would evade it. Documented on the const; parsing shell would be over-engineering for a five-entry matrix.
- `"mado"` is a magic string in both `gen_fragments.py` and `benchcheck.go`'s `BaselineTool` default. Both fail loudly if mado disappears from the data, so the two-source risk is visible when it bites; cross-language constant plumbing wasn't worth it now.
- The `test(release)` prefix on merged commit `5cbec04` understated its production-code change — merged history, noted for next time.

Validated: `go test ./internal/release/... ./cmd/mdsmith-release/...` (17 smoke-gate tests incl. 3 new), `go vet`, `check-release-gates`, `check-release-smoke`, byte-stable fragment regeneration, `mdsmith check .` clean. golangci-lint needs Go ≥ 1.25.8 (environment has 1.25.0) — CI covers it.

https://claude.ai/code/session_0123efoHqbw98eAhPYYjaAkp

---
_Generated by [Claude Code](https://claude.ai/code/session_0123efoHqbw98eAhPYYjaAkp)_