### PR TITLE
close plan 234: mark Scoop/WinGet distribution complete

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -152,7 +152,7 @@ footer: |
 | 231        | ✅     |        | [LSP newest-wins workspace singleton](plan/231_lsp-workspace-singleton.md)                                                              |
 | 232        | ✅     | opus   | [include heading-offset parameter](plan/232_include-heading-offset.md)                                                                  |
 | 233        | ✅     | opus   | [numeric heading-level target for include](plan/233_include-heading-level-target.md)                                                    |
-| 234        | 🔳     | sonnet | [Distribute mdsmith on Windows via Scoop and WinGet](plan/234_windows-package-managers.md)                                              |
+| 234        | ✅     | sonnet | [Distribute mdsmith on Windows via Scoop and WinGet](plan/234_windows-package-managers.md)                                              |
 | 235        | ✅     | sonnet | [Playwright end-to-end tests for the website, runnable by CI and agents](plan/235_playwright-site-e2e.md)                               |
 | 236        | ✅     | opus   | [cuelite phase 0 — package, façade, and differential harness](plan/236_cuelite-package-harness.md)                                      |
 | 237        | ✅     | sonnet | [cuelite phase 1 — surface D (placeholder paths)](plan/237_cuelite-surface-d.md)                                                        |

--- a/plan/234_windows-package-managers.md
+++ b/plan/234_windows-package-managers.md
@@ -1,7 +1,7 @@
 ---
 id: 234
 title: Distribute mdsmith on Windows via Scoop and WinGet
-status: "🔳"
+status: "✅"
 summary: >-
   Publish the prebuilt `mdsmith-windows-amd64.exe` through
   a Scoop bucket and a WinGet manifest, mirroring the

--- a/plan/234_windows-package-managers.md
+++ b/plan/234_windows-package-managers.md
@@ -178,12 +178,12 @@ default-Windows reach (WinGet ships with Windows 11).
 
 ## Acceptance Criteria
 
-All in-repo tasks are complete. The two criteria below are
-external-only: the `jeduden/scoop-mdsmith` bucket repo is live and
-self-bumping; the `winget-submit` job submits each release to
-`microsoft/winget-pkgs` automatically. Neither can be end-to-end
-verified from this repo, so they remain unchecked. `✅` reflects that
-all in-repo work is done.
+All in-repo tasks are complete. `✅` reflects that all in-repo work is
+done. The two criteria below remain unchecked because each has an
+external gate. The Scoop bucket (`jeduden/scoop-mdsmith`) self-bumps
+but lives outside this repo. The `winget-submit` job runs here and
+opens the PR, but `winget install jeduden.mdsmith` only works after
+Microsoft moderation merges that PR.
 
 - [ ] `scoop install mdsmith` (after `scoop bucket add`)
       installs the released `.exe`, checksum-verified.

--- a/plan/234_windows-package-managers.md
+++ b/plan/234_windows-package-managers.md
@@ -190,7 +190,8 @@ all in-repo work is done.
       (external — jeduden/scoop-mdsmith repo is live)
 - [ ] `winget install jeduden.mdsmith` installs the released
       `.exe` once the manifest PR is merged.
-      (external — submitted automatically via winget-submit job)
+      (external — winget-submit job opens the PR; Microsoft
+      moderation must merge it before the command works)
 - [x] Manifest generation lives in `mdsmith-release`
       (`render-scoop-manifest`, `render-winget-manifest`),
       not inline workflow shell; the recurring

--- a/plan/234_windows-package-managers.md
+++ b/plan/234_windows-package-managers.md
@@ -178,12 +178,19 @@ default-Windows reach (WinGet ships with Windows 11).
 
 ## Acceptance Criteria
 
+All in-repo tasks are complete. The two criteria below are
+external-only: the `jeduden/scoop-mdsmith` bucket repo is live and
+self-bumping; the `winget-submit` job submits each release to
+`microsoft/winget-pkgs` automatically. Neither can be end-to-end
+verified from this repo, so they remain unchecked. `✅` reflects that
+all in-repo work is done.
+
 - [ ] `scoop install mdsmith` (after `scoop bucket add`)
       installs the released `.exe`, checksum-verified.
-      (external — needs jeduden/scoop-mdsmith repo)
+      (external — jeduden/scoop-mdsmith repo is live)
 - [ ] `winget install jeduden.mdsmith` installs the released
       `.exe` once the manifest PR is merged.
-      (external — needs microsoft/winget-pkgs PR)
+      (external — submitted automatically via winget-submit job)
 - [x] Manifest generation lives in `mdsmith-release`
       (`render-scoop-manifest`, `render-winget-manifest`),
       not inline workflow shell; the recurring


### PR DESCRIPTION
Closes plan 234 — Distribute mdsmith on Windows via Scoop and WinGet.

## Summary

- All in-repo tasks verified complete: `render-scoop-manifest`, `render-winget-manifest` subcommands, release workflow jobs (`notify-scoop-bucket`, `winget-submit`), channel docs, secret rotation entries, install guide Windows section, picker/table updates
- Plan status advanced from 🔳 → ✅
- Two acceptance criteria remain open pending external repositories: `jeduden/scoop-mdsmith` bucket and `microsoft/winget-pkgs` manifest PR — both are external-only gates, no further in-repo work needed

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `mdsmith check .` passes on all tracked docs

https://claude.ai/code/session_01SfqM4TD96vnJgiwPs28dHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfqM4TD96vnJgiwPs28dHp)_