### PR TITLE
docs: add gomarklint to the peer-linter comparison

### DIFF
--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -169,8 +169,9 @@ of scope. A repo that wants both layers runs gomarklint's
 `external-link` job next to `mdsmith check` in CI.
 
 gomarklint claims 100,000+ lines in ~170 ms for its
-structural checks. It is not yet in the first-party
-[benchmark](#benchmarks) harness.
+structural checks. It is pinned into the first-party
+[benchmark](#benchmarks) harness; its row joins the
+published tables at the next snapshot refresh.
 
 ### [Prettier][]
 

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -120,6 +120,58 @@ formatters and linters on code blocks."
   Pandoc, rumdl, mdformat, mado, and markdownlint; see
   [Benchmarks](#benchmarks)
 
+### [gomarklint][]
+
+Go binary, MIT. Tagline: "Catch broken links before your
+readers do — and keep your Markdown clean while you're at
+it." A young, deliberately small linter (v3.2.x as of
+2026-06) with its own kebab-case rule IDs, built for CI
+gates.
+
+- 23 rules: heading structure, blank-line placement,
+  fence/emphasis/list-marker consistency, bare URLs, and
+  link checks. All ship enabled except `external-link` and
+  `max-line-length`
+- `external-link` (opt-in) HTTP-validates external URLs
+  with timeout, retry, and per-host rate-limit settings —
+  the only tool on this page that checks links over the
+  network
+- `link-fragments` resolves `#anchor` links against a
+  configurable heading-slug algorithm (GitHub style by
+  default)
+- Check-only: no autofix and no LSP; a VS Code extension
+  is planned. Output is text or JSON
+- Config: JSON (`.gomarklint.json`); a rule is `true`,
+  `false`, `"warning"`, or an options object; unlisted
+  rules stay enabled
+- Install: Homebrew tap, npm, `go install`, curl script,
+  or GitHub release binaries; ships a GitHub Action and a
+  pre-commit hook
+
+| Aspect        | gomarklint             | mdsmith                          |
+| ------------- | ---------------------- | -------------------------------- |
+| Distribution  | static Go binary       | static Go binary                 |
+| Rule set      | 23, kebab-case IDs     | 67, `MDSxxx` IDs                 |
+| Autofix       | no                     | `mdsmith fix`, multi-pass        |
+| LSP / editor  | no (VS Code planned)   | LSP for any editor               |
+| Config        | `.gomarklint.json`     | `.mdsmith.yml`                   |
+| External URLs | `external-link` (HTTP) | not checked (offline by design)  |
+| Cross-file    | no                     | links, includes, catalogs, kinds |
+| Generated     | no                     | catalog, include, toc, build     |
+
+22 of its 23 rules have an mdsmith analog; the
+[peer-linter coverage matrix][mdcov] lists each pairing.
+The exception is `external-link`: mdsmith makes no network
+calls at runtime (see
+[Security Posture](#security-posture)), so validating that
+an external URL still answers HTTP 200 is deliberately out
+of scope. A repo that wants both layers runs gomarklint's
+`external-link` job next to `mdsmith check` in CI.
+
+gomarklint claims 100,000+ lines in ~170 ms for its
+structural checks. It is not yet in the first-party
+[benchmark](#benchmarks) harness.
+
 ### [Prettier][]
 
 Node.js. Opinionated formatter, not a linter. ~51.7k
@@ -705,6 +757,14 @@ Its lossless CST keeps the Pandoc syntax that Prettier and
 mdformat flatten. It bundles the formatter, linter, and LSP
 for those formats.
 
+**gomarklint** fits a minimal CI gate that must also catch
+dead external links. Its small rule set is check-only, so
+fixes stay manual, but the opt-in `external-link` rule
+HTTP-validates every URL — the one check no other tool
+here performs. Pair it with mdsmith when the same repo
+also needs autofix, cross-file integrity, or generated
+sections.
+
 **obsidian-linter** fits a team that writes notes in
 Obsidian and wants every save to clean up YAML keys,
 heading case, and spacing inside the editor. There is no
@@ -965,6 +1025,8 @@ if you need a stable rule set across upgrades.
 [rumdl]: https://github.com/rvben/rumdl
 [mado]: https://github.com/akiomik/mado
 [panache]: https://panache.bz/
+<!-- gomarklint links -->
+[gomarklint]: https://github.com/shinagawa-web/gomarklint
 <!-- mdsmith security + reference links -->
 [mdsmith-sec]: ../security/2026-04-05-adversarial-markdown/report.md
 [conventions]: ../reference/conventions.md

--- a/docs/development/add-peer-linter.md
+++ b/docs/development/add-peer-linter.md
@@ -214,16 +214,51 @@ right place to state it.
 
 ## 7. Decide on the benchmark
 
-The harness in `docs/research/benchmarks/run.sh`
-expects a static binary that hyperfine can invoke
-N times against a corpus directory. If `newtool`
-ships that way, add it to the `tools` list in
-`run.sh` and re-run the harness; commit the
-refreshed `data/*.json`.
+The harness expects a static binary. hyperfine
+invokes it N times against a corpus directory.
+The tool list does not live in
+`docs/research/benchmarks/run.sh` — that script is
+a thin wrapper over `mdsmith-release bench`. It
+lives in `internal/release/bench.go`. If `newtool`
+ships a static binary, wire it in:
 
-If it does not — e.g. an editor plugin without a
-CLI — skip the harness. Write a short "Why newtool
-is not benchmarked" subsection in
+- Pin it in the `benchTools` manifest: the GitHub
+  release `.tar.gz` URL (the version tag must appear
+  in the URL path) and the SHA-256 of the tarball.
+  Record the digest by downloading the tarball once
+  and cross-check it against the publisher's
+  checksums file when one exists.
+  `validateBenchManifest` rejects a half-specified
+  entry. The entry's `Name` must equal both the
+  executable's basename inside the tarball and the
+  hyperfine `--command-name`.
+- Add the command line to `runHyperfine` next to the
+  other comparison tools, on the tool's defaults.
+  Disable its on-disk cache if it has one
+  (`rumdl --no-cache` is the precedent).
+- Extend `TestBenchManifestInvariants` so the pin
+  cannot be dropped silently.
+
+`gen_fragments.py` needs no edit: it renders one
+table row per command found in the hyperfine JSON
+(only `mado`, the ratio base, is required by name).
+
+Merging the wiring does not change the committed
+numbers. `data/*.json` only moves when a maintainer
+re-runs the harness via `run.sh` and reviews the
+diff in a PR, because cross-tool ratios are only
+valid within a single run on one machine. From the
+merge onward the per-merge `benchmark.yml` run and
+the per-release `benchmark-publish` job measure the
+new tool; the in-repo tables gain its row at the
+next deliberate refresh. Add a short subsection to
+`docs/research/benchmarks/README.md` saying exactly
+that, so the missing row reads as pending, not
+overlooked.
+
+If the tool cannot run that way — e.g. an editor
+plugin without a CLI — skip the harness. Write a
+short "Why newtool is not benchmarked" subsection in
 `docs/research/benchmarks/README.md` instead. Name
 the structural reason: a plugin runtime that is
 not AOT-compiled, defaults that produce a no-op

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -33,18 +33,18 @@ docs read.
   full default set users actually run.
 - Caches disabled for the tools that have one (`rumdl
   --no-cache`, `panache --no-cache`) so every run is
-  worst-case cold. mdsmith, mado, and markdownlint-cli2 keep
-  no on-disk cache.
+  worst-case cold. mdsmith, mado, gomarklint, and
+  markdownlint-cli2 keep no on-disk cache.
 - `mdsmith` vs the markdownlint tools is not like-for-like
   (it does more per file); `mdsmith-parity` vs them is the
   closest like-for-like, with one residual asymmetry noted
   in [Reading the result](#reading-the-result).
 - Integrity: every comparison binary is fetched at a pinned
   version and verified by SHA-256 before it runs.
-  hyperfine, mado, panache, and rumdl come from pinned
-  GitHub release tarballs (rumdl moved off an unpinned
-  `uv tool install`); markdownlint-cli2 installs via
-  `npm ci` from the committed lockfile in `npm/`. A
+  gomarklint, hyperfine, mado, panache, and rumdl come from
+  pinned GitHub release tarballs (rumdl moved off an
+  unpinned `uv tool install`); markdownlint-cli2 installs
+  via `npm ci` from the committed lockfile in `npm/`. A
   tampered or silently-rebuilt download fails the run loud.
 
 ### Corpora
@@ -279,20 +279,23 @@ The rule-by-rule mapping against the other linters
 lives in the [peer-linter coverage matrix][mdcov]
 instead.
 
-### Why gomarklint is not in the table yet
+### gomarklint joins the table at the next refresh
 
-gomarklint qualifies structurally where obsidian-linter
-does not: it is a static Go binary hyperfine can drive.
-It is absent for a process reason instead. The committed
-`data/*.json` snapshot only moves when a maintainer
-re-runs the whole harness via `run.sh` and reviews the
-result in a PR, because cross-tool ratios are only valid
-within a single run on one machine. Adding gomarklint
-means pinning its release tarball and SHA-256 in the
-`benchTools` manifest (`internal/release/bench.go`), then
-doing that deliberate full refresh. Until that run lands,
-the rule-by-rule comparison lives in the
-[peer-linter coverage matrix][mdcov].
+gomarklint is wired into the harness: its release tarball
+and SHA-256 are pinned in the `benchTools` manifest
+(`internal/release/bench.go`), and `runHyperfine` drives
+it on bare defaults next to the other tools. From the
+merge onward, the per-merge `benchmark.yml` run and each
+release's `benchmark-publish` job measure it.
+
+The tables above lack a gomarklint row only because they
+render from the committed `data/*.json` snapshot, and
+that snapshot moves when a maintainer re-runs the whole
+harness via `run.sh` and reviews the result in a PR —
+cross-tool ratios are only valid within a single run on
+one machine. The row appears with the next deliberate
+refresh. Until then the rule-by-rule comparison lives in
+the [peer-linter coverage matrix][mdcov].
 
 [mdcov]: ../markdownlint-coverage/README.md
 
@@ -310,14 +313,15 @@ benchmark-specific layer: which rules `mdsmith` (full)
 runs and which `mdsmith-parity` disables via
 [`bench-parity.mdsmith.yml`](bench-parity.mdsmith.yml).
 
-| Configuration       | Rule class                                               |
-| ------------------- | -------------------------------------------------------- |
-| `mdsmith` (full)    | every default-enabled MDS rule                           |
-| `mdsmith-parity`    | same set minus the 24 rules listed below                 |
-| `mado`              | see the coverage matrix `mado` column                    |
-| `rumdl`             | see the coverage matrix `rumdl` column                   |
-| `panache`           | distinct rule IDs — see coverage matrix `panache` column |
-| `markdownlint-cli2` | canonical markdownlint rule set                          |
+| Configuration       | Rule class                                                   |
+| ------------------- | ------------------------------------------------------------ |
+| `mdsmith` (full)    | every default-enabled MDS rule                               |
+| `mdsmith-parity`    | same set minus the 24 rules listed below                     |
+| `mado`              | see the coverage matrix `mado` column                        |
+| `rumdl`             | see the coverage matrix `rumdl` column                       |
+| `panache`           | distinct rule IDs — see coverage matrix `panache` column     |
+| `gomarklint`        | own kebab-case IDs — see coverage matrix `gomarklint` column |
+| `markdownlint-cli2` | canonical markdownlint rule set                              |
 
 #### Rules the `parity` convention disables
 

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -279,6 +279,21 @@ The rule-by-rule mapping against the other linters
 lives in the [peer-linter coverage matrix][mdcov]
 instead.
 
+### Why gomarklint is not in the table yet
+
+gomarklint qualifies structurally where obsidian-linter
+does not: it is a static Go binary hyperfine can drive.
+It is absent for a process reason instead. The committed
+`data/*.json` snapshot only moves when a maintainer
+re-runs the whole harness via `run.sh` and reviews the
+result in a PR, because cross-tool ratios are only valid
+within a single run on one machine. Adding gomarklint
+means pinning its release tarball and SHA-256 in the
+`benchTools` manifest (`internal/release/bench.go`), then
+doing that deliberate full refresh. Until that run lands,
+the rule-by-rule comparison lives in the
+[peer-linter coverage matrix][mdcov].
+
 [mdcov]: ../markdownlint-coverage/README.md
 
 ### Apples-to-apples rule sets

--- a/docs/research/markdownlint-coverage/README.md
+++ b/docs/research/markdownlint-coverage/README.md
@@ -2,14 +2,14 @@
 summary: >-
   Per-tool, per-rule coverage matrix: each mdsmith rule
   alongside its analog in markdownlint, rumdl, mado,
-  panache, and obsidian-linter, with the upstream
-  default-enabled state per peer.
+  panache, obsidian-linter, and gomarklint, with the
+  upstream default-enabled state per peer.
 ---
 # Peer-linter coverage matrix
 
 For every mdsmith rule, the analog rule in each peer
 Markdown linter (markdownlint, rumdl, mado, panache,
-obsidian-linter) with the peer's upstream
+obsidian-linter, gomarklint) with the peer's upstream
 default-enabled state. Each section is a `<?catalog?>`
 directive over the rule READMEs filtered by `category:`;
 run `mdsmith fix` to regenerate from front matter.
@@ -29,8 +29,8 @@ glob: "MDS*/README.md"
 where: 'category: "heading"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -96,21 +96,33 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                                                  | markdownlint                                                                                                                                                                      | rumdl                                                                                                                                                       | mado                                                                                                                                                                              | panache              | obsidian-linter                           |
-| ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----------------------------------------- |
-| [MDS002](../../../internal/rules/MDS002-heading-style/README.md) heading-style                                           | MD003 ✅ heading-style                                                                                                                                                            | MD003 ✅ heading-style                                                                                                                                      | MD003 ⚪ heading-style                                                                                                                                                            | —                    | —                                         |
-| [MDS003](../../../internal/rules/MDS003-heading-increment/README.md) heading-increment                                   | MD001 ✅ heading-increment                                                                                                                                                        | MD001 ✅ heading-increment                                                                                                                                  | MD001 ✅ heading-increment                                                                                                                                                        | heading-hierarchy ✅ | header-increment ⚪                       |
-| [MDS004](../../../internal/rules/MDS004-first-line-heading/README.md) first-line-heading                                 | MD041 ✅ first-line-h1                                                                                                                                                            | MD041 ✅ first-line-h1                                                                                                                                      | MD041 ✅ first-line-h1                                                                                                                                                            | —                    | —                                         |
-| [MDS005](../../../internal/rules/MDS005-no-duplicate-headings/README.md) no-duplicate-headings                           | MD024 ✅ no-duplicate-heading                                                                                                                                                     | MD024 ✅ multiple-headings                                                                                                                                  | MD024 ✅ no-duplicate-heading                                                                                                                                                     | —                    | —                                         |
-| [MDS013](../../../internal/rules/MDS013-blank-line-around-headings/README.md) blank-line-around-headings                 | MD022 ✅ blanks-around-headings                                                                                                                                                   | MD022 ✅ blanks-around-headings                                                                                                                             | MD022 ✅ blanks-around-headings                                                                                                                                                   | —                    | heading-blank-lines ⚪                    |
-| [MDS017](../../../internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md) no-trailing-punctuation-in-heading | MD026 ✅ no-trailing-punctuation                                                                                                                                                  | MD026 ✅ no-trailing-punctuation                                                                                                                            | MD026 ✅ no-trailing-punctuation                                                                                                                                                  | —                    | remove-trailing-punctuation-in-heading ⚪ |
-| [MDS018](../../../internal/rules/MDS018-no-emphasis-as-heading/README.md) no-emphasis-as-heading                         | MD036 ✅ no-emphasis-as-heading                                                                                                                                                   | MD036 ✅ no-emphasis-as-heading                                                                                                                             | MD036 ✅ no-emphasis-as-heading                                                                                                                                                   | —                    | —                                         |
-| [MDS030](../../../internal/rules/MDS030-empty-section-body/README.md) empty-section-body                                 | —                                                                                                                                                                                 | —                                                                                                                                                           | —                                                                                                                                                                                 | —                    | —                                         |
-| [MDS036](../../../internal/rules/MDS036-max-section-length/README.md) max-section-length                                 | —                                                                                                                                                                                 | —                                                                                                                                                           | —                                                                                                                                                                                 | —                    | —                                         |
-| [MDS051](../../../internal/rules/MDS051-single-h1/README.md) single-h1                                                   | MD025 ✅ single-h1                                                                                                                                                                | MD025 ✅ single-title                                                                                                                                       | MD025 ✅ single-h1                                                                                                                                                                | —                    | —                                         |
-| [MDS064](../../../internal/rules/MDS064-atx-heading-whitespace/README.md) atx-heading-whitespace                         | MD018 ✅ no-missing-space-atx, MD019 ✅ no-multiple-space-atx, MD020 ✅ no-missing-space-closed-atx (partial), MD021 ✅ no-multiple-space-closed-atx, MD023 ✅ heading-start-left | MD018 ✅ no-space-atx, MD019 ✅ multiple-space-atx, MD020 ✅ no-space-closed-atx (partial), MD021 ✅ multiple-space-closed-atx, MD023 ✅ heading-start-left | MD018 ✅ no-missing-space-atx, MD019 ✅ no-multiple-space-atx, MD020 ⚪ no-missing-space-closed-atx (partial), MD021 ✅ no-multiple-space-closed-atx, MD023 ✅ heading-start-left | —                    | headings-start-line ⚪ (partial)          |
+| mdsmith                                                                                                                  | markdownlint                                                                                                                                                                      | rumdl                                                                                                                                                       | mado                                                                                                                                                                              | panache              | obsidian-linter                           | gomarklint                 |
+| ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----------------------------------------- | -------------------------- |
+| [MDS002](../../../internal/rules/MDS002-heading-style/README.md) heading-style                                           | MD003 ✅ heading-style                                                                                                                                                            | MD003 ✅ heading-style                                                                                                                                      | MD003 ⚪ heading-style                                                                                                                                                            | —                    | —                                         | no-setext-headings ✅      |
+| [MDS003](../../../internal/rules/MDS003-heading-increment/README.md) heading-increment                                   | MD001 ✅ heading-increment                                                                                                                                                        | MD001 ✅ heading-increment                                                                                                                                  | MD001 ✅ heading-increment                                                                                                                                                        | heading-hierarchy ✅ | header-increment ⚪                       | heading-level ✅           |
+| [MDS004](../../../internal/rules/MDS004-first-line-heading/README.md) first-line-heading                                 | MD041 ✅ first-line-h1                                                                                                                                                            | MD041 ✅ first-line-h1                                                                                                                                      | MD041 ✅ first-line-h1                                                                                                                                                            | —                    | —                                         | —                          |
+| [MDS005](../../../internal/rules/MDS005-no-duplicate-headings/README.md) no-duplicate-headings                           | MD024 ✅ no-duplicate-heading                                                                                                                                                     | MD024 ✅ multiple-headings                                                                                                                                  | MD024 ✅ no-duplicate-heading                                                                                                                                                     | —                    | —                                         | duplicate-heading ✅       |
+| [MDS013](../../../internal/rules/MDS013-blank-line-around-headings/README.md) blank-line-around-headings                 | MD022 ✅ blanks-around-headings                                                                                                                                                   | MD022 ✅ blanks-around-headings                                                                                                                             | MD022 ✅ blanks-around-headings                                                                                                                                                   | —                    | heading-blank-lines ⚪                    | blanks-around-headings ✅  |
+| [MDS017](../../../internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md) no-trailing-punctuation-in-heading | MD026 ✅ no-trailing-punctuation                                                                                                                                                  | MD026 ✅ no-trailing-punctuation                                                                                                                            | MD026 ✅ no-trailing-punctuation                                                                                                                                                  | —                    | remove-trailing-punctuation-in-heading ⚪ | no-trailing-punctuation ✅ |
+| [MDS018](../../../internal/rules/MDS018-no-emphasis-as-heading/README.md) no-emphasis-as-heading                         | MD036 ✅ no-emphasis-as-heading                                                                                                                                                   | MD036 ✅ no-emphasis-as-heading                                                                                                                             | MD036 ✅ no-emphasis-as-heading                                                                                                                                                   | —                    | —                                         | no-emphasis-as-heading ✅  |
+| [MDS030](../../../internal/rules/MDS030-empty-section-body/README.md) empty-section-body                                 | —                                                                                                                                                                                 | —                                                                                                                                                           | —                                                                                                                                                                                 | —                    | —                                         | —                          |
+| [MDS036](../../../internal/rules/MDS036-max-section-length/README.md) max-section-length                                 | —                                                                                                                                                                                 | —                                                                                                                                                           | —                                                                                                                                                                                 | —                    | —                                         | —                          |
+| [MDS051](../../../internal/rules/MDS051-single-h1/README.md) single-h1                                                   | MD025 ✅ single-h1                                                                                                                                                                | MD025 ✅ single-title                                                                                                                                       | MD025 ✅ single-h1                                                                                                                                                                | —                    | —                                         | single-h1 ✅               |
+| [MDS064](../../../internal/rules/MDS064-atx-heading-whitespace/README.md) atx-heading-whitespace                         | MD018 ✅ no-missing-space-atx, MD019 ✅ no-multiple-space-atx, MD020 ✅ no-missing-space-closed-atx (partial), MD021 ✅ no-multiple-space-closed-atx, MD023 ✅ heading-start-left | MD018 ✅ no-space-atx, MD019 ✅ multiple-space-atx, MD020 ✅ no-space-closed-atx (partial), MD021 ✅ multiple-space-closed-atx, MD023 ✅ heading-start-left | MD018 ✅ no-missing-space-atx, MD019 ✅ no-multiple-space-atx, MD020 ⚪ no-missing-space-closed-atx (partial), MD021 ✅ no-multiple-space-closed-atx, MD023 ✅ heading-start-left | —                    | headings-start-line ⚪ (partial)          | —                          |
 <?/catalog?>
 
 ## Lists
@@ -121,8 +133,8 @@ glob: "MDS*/README.md"
 where: 'category: "list"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -188,15 +200,27 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                            | markdownlint                                       | rumdl                                              | mado                                               | panache | obsidian-linter                    |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- | ------- | ---------------------------------- |
-| [MDS014](../../../internal/rules/MDS014-blank-line-around-lists/README.md) blank-line-around-lists | MD032 ✅ blanks-around-lists                       | MD032 ✅ blanks-around-lists                       | MD032 ⚪ blanks-around-lists                       | —       | paragraph-blank-lines ⚪ (partial) |
-| [MDS016](../../../internal/rules/MDS016-list-indent/README.md) list-indent                         | MD005 ✅ list-indent (partial), MD007 ✅ ul-indent | MD005 ✅ list-indent (partial), MD007 ✅ ul-indent | MD005 ✅ list-indent (partial), MD007 ⚪ ul-indent | —       | —                                  |
-| [MDS045](../../../internal/rules/MDS045-list-marker-style/README.md) list-marker-style             | MD004 ✅ ul-style                                  | MD004 ✅ ul-style                                  | MD004 ✅ ul-style                                  | —       | unordered-list-style ⚪            |
-| [MDS046](../../../internal/rules/MDS046-ordered-list-numbering/README.md) ordered-list-numbering   | MD029 ✅ ol-prefix                                 | MD029 ✅ ol-prefix                                 | MD029 ✅ ol-prefix                                 | —       | ordered-list-style ⚪              |
-| [MDS061](../../../internal/rules/MDS061-list-marker-space/README.md) list-marker-space             | MD030 ✅ list-marker-space                         | MD030 ✅ list-marker-space                         | MD030 ✅ list-marker-space                         | —       | space-after-list-markers ⚪        |
+| mdsmith                                                                                            | markdownlint                                       | rumdl                                              | mado                                               | panache | obsidian-linter                    | gomarklint                |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- | ------- | ---------------------------------- | ------------------------- |
+| [MDS014](../../../internal/rules/MDS014-blank-line-around-lists/README.md) blank-line-around-lists | MD032 ✅ blanks-around-lists                       | MD032 ✅ blanks-around-lists                       | MD032 ⚪ blanks-around-lists                       | —       | paragraph-blank-lines ⚪ (partial) | blanks-around-lists ✅    |
+| [MDS016](../../../internal/rules/MDS016-list-indent/README.md) list-indent                         | MD005 ✅ list-indent (partial), MD007 ✅ ul-indent | MD005 ✅ list-indent (partial), MD007 ✅ ul-indent | MD005 ✅ list-indent (partial), MD007 ⚪ ul-indent | —       | —                                  | —                         |
+| [MDS045](../../../internal/rules/MDS045-list-marker-style/README.md) list-marker-style             | MD004 ✅ ul-style                                  | MD004 ✅ ul-style                                  | MD004 ✅ ul-style                                  | —       | unordered-list-style ⚪            | consistent-list-marker ✅ |
+| [MDS046](../../../internal/rules/MDS046-ordered-list-numbering/README.md) ordered-list-numbering   | MD029 ✅ ol-prefix                                 | MD029 ✅ ol-prefix                                 | MD029 ✅ ol-prefix                                 | —       | ordered-list-style ⚪              | —                         |
+| [MDS061](../../../internal/rules/MDS061-list-marker-space/README.md) list-marker-space             | MD030 ✅ list-marker-space                         | MD030 ✅ list-marker-space                         | MD030 ✅ list-marker-space                         | —       | space-after-list-markers ⚪        | —                         |
 <?/catalog?>
 
 ## Whitespace, blank lines, tabs
@@ -207,8 +231,8 @@ glob: "MDS*/README.md"
 where: 'category: "whitespace"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -274,17 +298,29 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                            | markdownlint                                                         | rumdl                                                           | mado                                                                 | panache | obsidian-linter                                                           |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------- |
-| [MDS006](../../../internal/rules/MDS006-no-trailing-spaces/README.md) no-trailing-spaces           | MD009 ✅ no-trailing-spaces                                          | MD009 ✅ no-trailing-spaces                                     | MD009 ✅ no-trailing-spaces                                          | —       | trailing-spaces ⚪                                                        |
-| [MDS007](../../../internal/rules/MDS007-no-hard-tabs/README.md) no-hard-tabs                       | MD010 ✅ no-hard-tabs                                                | MD010 ✅ no-hard-tabs                                           | MD010 ✅ no-hard-tabs                                                | —       | —                                                                         |
-| [MDS008](../../../internal/rules/MDS008-no-multiple-blanks/README.md) no-multiple-blanks           | MD012 ✅ no-multiple-blanks                                          | MD012 ✅ no-multiple-blanks                                     | MD012 ✅ no-multiple-blanks                                          | —       | consecutive-blank-lines ⚪                                                |
-| [MDS009](../../../internal/rules/MDS009-single-trailing-newline/README.md) single-trailing-newline | MD047 ✅ single-trailing-newline                                     | MD047 ✅ file-end-newline                                       | MD047 ✅ single-trailing-newline                                     | —       | line-break-at-document-end ⚪                                             |
-| [MDS044](../../../internal/rules/MDS044-horizontal-rule-style/README.md) horizontal-rule-style     | MD035 ✅ hr-style                                                    | MD035 ✅ hr-style                                               | MD035 ✅ hr-style                                                    | —       | —                                                                         |
-| [MDS052](../../../internal/rules/MDS052-no-space-in-code-spans/README.md) no-space-in-code-spans   | MD038 ✅ no-space-in-code                                            | MD038 ✅ no-space-in-code                                       | MD038 ✅ no-space-in-code                                            | —       | —                                                                         |
-| [MDS059](../../../internal/rules/MDS059-blockquote-whitespace/README.md) blockquote-whitespace     | MD027 ✅ no-multiple-space-blockquote, MD028 ✅ no-blanks-blockquote | MD027 ✅ multiple-spaces-blockquote, MD028 ✅ blanks-blockquote | MD027 ⚪ no-multiple-space-blockquote, MD028 ✅ no-blanks-blockquote | —       | blockquote-style ⚪ (partial), empty-line-around-blockquotes ⚪ (partial) |
+| mdsmith                                                                                            | markdownlint                                                         | rumdl                                                           | mado                                                                 | panache | obsidian-linter                                                           | gomarklint                 |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------- | -------------------------- |
+| [MDS006](../../../internal/rules/MDS006-no-trailing-spaces/README.md) no-trailing-spaces           | MD009 ✅ no-trailing-spaces                                          | MD009 ✅ no-trailing-spaces                                     | MD009 ✅ no-trailing-spaces                                          | —       | trailing-spaces ⚪                                                        | —                          |
+| [MDS007](../../../internal/rules/MDS007-no-hard-tabs/README.md) no-hard-tabs                       | MD010 ✅ no-hard-tabs                                                | MD010 ✅ no-hard-tabs                                           | MD010 ✅ no-hard-tabs                                                | —       | —                                                                         | no-hard-tabs ✅            |
+| [MDS008](../../../internal/rules/MDS008-no-multiple-blanks/README.md) no-multiple-blanks           | MD012 ✅ no-multiple-blanks                                          | MD012 ✅ no-multiple-blanks                                     | MD012 ✅ no-multiple-blanks                                          | —       | consecutive-blank-lines ⚪                                                | no-multiple-blank-lines ✅ |
+| [MDS009](../../../internal/rules/MDS009-single-trailing-newline/README.md) single-trailing-newline | MD047 ✅ single-trailing-newline                                     | MD047 ✅ file-end-newline                                       | MD047 ✅ single-trailing-newline                                     | —       | line-break-at-document-end ⚪                                             | final-blank-line ✅        |
+| [MDS044](../../../internal/rules/MDS044-horizontal-rule-style/README.md) horizontal-rule-style     | MD035 ✅ hr-style                                                    | MD035 ✅ hr-style                                               | MD035 ✅ hr-style                                                    | —       | —                                                                         | —                          |
+| [MDS052](../../../internal/rules/MDS052-no-space-in-code-spans/README.md) no-space-in-code-spans   | MD038 ✅ no-space-in-code                                            | MD038 ✅ no-space-in-code                                       | MD038 ✅ no-space-in-code                                            | —       | —                                                                         | —                          |
+| [MDS059](../../../internal/rules/MDS059-blockquote-whitespace/README.md) blockquote-whitespace     | MD027 ✅ no-multiple-space-blockquote, MD028 ✅ no-blanks-blockquote | MD027 ✅ multiple-spaces-blockquote, MD028 ✅ blanks-blockquote | MD027 ⚪ no-multiple-space-blockquote, MD028 ✅ no-blanks-blockquote | —       | blockquote-style ⚪ (partial), empty-line-around-blockquotes ⚪ (partial) | —                          |
 <?/catalog?>
 
 ## Code blocks and code spans
@@ -295,8 +331,8 @@ glob: "MDS*/README.md"
 where: 'category: "code"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -362,16 +398,28 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                                        | markdownlint                  | rumdl                         | mado                          | panache | obsidian-linter                  |
-| -------------------------------------------------------------------------------------------------------------- | ----------------------------- | ----------------------------- | ----------------------------- | ------- | -------------------------------- |
-| [MDS010](../../../internal/rules/MDS010-fenced-code-style/README.md) fenced-code-style                         | MD048 ✅ code-fence-style     | MD048 ✅ code-fence-style     | —                             | —       | —                                |
-| [MDS011](../../../internal/rules/MDS011-fenced-code-language/README.md) fenced-code-language                   | MD040 ✅ fenced-code-language | MD040 ✅ fenced-code-language | MD040 ✅ fenced-code-language | —       | —                                |
-| [MDS015](../../../internal/rules/MDS015-blank-line-around-fenced-code/README.md) blank-line-around-fenced-code | MD031 ✅ blanks-around-fences | MD031 ✅ blanks-around-fences | MD031 ✅ blanks-around-fences | —       | empty-line-around-code-fences ⚪ |
-| [MDS031](../../../internal/rules/MDS031-unclosed-code-block/README.md) unclosed-code-block                     | —                             | —                             | —                             | —       | —                                |
-| [MDS065](../../../internal/rules/MDS065-code-block-style/README.md) code-block-style                           | MD046 ✅ code-block-style     | MD046 ✅ code-block-style     | MD046 ✅ code-block-style     | —       | —                                |
-| [MDS066](../../../internal/rules/MDS066-commands-show-output/README.md) commands-show-output                   | MD014 ✅ commands-show-output | MD014 ✅ commands-show-output | MD014 ✅ commands-show-output | —       | —                                |
+| mdsmith                                                                                                        | markdownlint                  | rumdl                         | mado                          | panache | obsidian-linter                  | gomarklint               |
+| -------------------------------------------------------------------------------------------------------------- | ----------------------------- | ----------------------------- | ----------------------------- | ------- | -------------------------------- | ------------------------ |
+| [MDS010](../../../internal/rules/MDS010-fenced-code-style/README.md) fenced-code-style                         | MD048 ✅ code-fence-style     | MD048 ✅ code-fence-style     | —                             | —       | —                                | consistent-code-fence ✅ |
+| [MDS011](../../../internal/rules/MDS011-fenced-code-language/README.md) fenced-code-language                   | MD040 ✅ fenced-code-language | MD040 ✅ fenced-code-language | MD040 ✅ fenced-code-language | —       | —                                | fenced-code-language ✅  |
+| [MDS015](../../../internal/rules/MDS015-blank-line-around-fenced-code/README.md) blank-line-around-fenced-code | MD031 ✅ blanks-around-fences | MD031 ✅ blanks-around-fences | MD031 ✅ blanks-around-fences | —       | empty-line-around-code-fences ⚪ | blanks-around-fences ✅  |
+| [MDS031](../../../internal/rules/MDS031-unclosed-code-block/README.md) unclosed-code-block                     | —                             | —                             | —                             | —       | —                                | unclosed-code-block ✅   |
+| [MDS065](../../../internal/rules/MDS065-code-block-style/README.md) code-block-style                           | MD046 ✅ code-block-style     | MD046 ✅ code-block-style     | MD046 ✅ code-block-style     | —       | —                                | —                        |
+| [MDS066](../../../internal/rules/MDS066-commands-show-output/README.md) commands-show-output                   | MD014 ✅ commands-show-output | MD014 ✅ commands-show-output | MD014 ✅ commands-show-output | —       | —                                | —                        |
 <?/catalog?>
 
 ## Links and references
@@ -382,8 +430,8 @@ glob: "MDS*/README.md"
 where: 'category: "link"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -449,18 +497,30 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                                          | markdownlint                                        | rumdl                                           | mado                       | panache                                              | obsidian-linter |
-| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------- | -------------------------- | ---------------------------------------------------- | --------------- |
-| [MDS012](../../../internal/rules/MDS012-no-bare-urls/README.md) no-bare-urls                                     | MD034 ✅ no-bare-urls                               | MD034 ✅ no-bare-urls                           | MD034 ✅ no-bare-urls      | —                                                    | no-bare-urls ⚪ |
-| [MDS027](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) cross-file-reference-integrity | MD051 ✅ link-fragments                             | MD051 ✅ link-fragments                         | —                          | undefined-anchor ✅                                  | —               |
-| [MDS043](../../../internal/rules/MDS043-no-reference-style/README.md) no-reference-style                         | —                                                   | —                                               | —                          | —                                                    | —               |
-| [MDS049](../../../internal/rules/MDS049-no-space-in-link-text/README.md) no-space-in-link-text                   | MD039 ✅ no-space-in-links                          | MD039 ✅ no-space-in-links                      | MD039 ✅ no-space-in-links | —                                                    | —               |
-| [MDS053](../../../internal/rules/MDS053-no-unused-link-definitions/README.md) no-unused-link-definitions         | MD053 ✅ link-image-reference-definitions           | MD053 ✅ link-image-definitions                 | —                          | duplicate-reference-labels ✅, unused-definitions ✅ | —               |
-| [MDS054](../../../internal/rules/MDS054-no-undefined-reference-labels/README.md) no-undefined-reference-labels   | MD052 ✅ reference-links-images                     | MD052 ✅ reference-links-images                 | —                          | undefined-references ✅                              | —               |
-| [MDS062](../../../internal/rules/MDS062-link-validity/README.md) link-validity                                   | MD011 ✅ no-reversed-links, MD042 ✅ no-empty-links | MD011 ✅ reversed-link, MD042 ✅ no-empty-links | —                          | —                                                    | —               |
-| [MDS068](../../../internal/rules/MDS068-link-style/README.md) link-style                                         | MD054 ✅ link-image-style                           | MD054 ✅ link-image-style                       | —                          | —                                                    | —               |
+| mdsmith                                                                                                          | markdownlint                                        | rumdl                                           | mado                       | panache                                              | obsidian-linter | gomarklint        |
+| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------- | -------------------------- | ---------------------------------------------------- | --------------- | ----------------- |
+| [MDS012](../../../internal/rules/MDS012-no-bare-urls/README.md) no-bare-urls                                     | MD034 ✅ no-bare-urls                               | MD034 ✅ no-bare-urls                           | MD034 ✅ no-bare-urls      | —                                                    | no-bare-urls ⚪ | no-bare-urls ✅   |
+| [MDS027](../../../internal/rules/MDS027-cross-file-reference-integrity/README.md) cross-file-reference-integrity | MD051 ✅ link-fragments                             | MD051 ✅ link-fragments                         | —                          | undefined-anchor ✅                                  | —               | link-fragments ✅ |
+| [MDS043](../../../internal/rules/MDS043-no-reference-style/README.md) no-reference-style                         | —                                                   | —                                               | —                          | —                                                    | —               | —                 |
+| [MDS049](../../../internal/rules/MDS049-no-space-in-link-text/README.md) no-space-in-link-text                   | MD039 ✅ no-space-in-links                          | MD039 ✅ no-space-in-links                      | MD039 ✅ no-space-in-links | —                                                    | —               | —                 |
+| [MDS053](../../../internal/rules/MDS053-no-unused-link-definitions/README.md) no-unused-link-definitions         | MD053 ✅ link-image-reference-definitions           | MD053 ✅ link-image-definitions                 | —                          | duplicate-reference-labels ✅, unused-definitions ✅ | —               | —                 |
+| [MDS054](../../../internal/rules/MDS054-no-undefined-reference-labels/README.md) no-undefined-reference-labels   | MD052 ✅ reference-links-images                     | MD052 ✅ reference-links-images                 | —                          | undefined-references ✅                              | —               | —                 |
+| [MDS062](../../../internal/rules/MDS062-link-validity/README.md) link-validity                                   | MD011 ✅ no-reversed-links, MD042 ✅ no-empty-links | MD011 ✅ reversed-link, MD042 ✅ no-empty-links | —                          | —                                                    | —               | no-empty-links ✅ |
+| [MDS068](../../../internal/rules/MDS068-link-style/README.md) link-style                                         | MD054 ✅ link-image-style                           | MD054 ✅ link-image-style                       | —                          | —                                                    | —               | —                 |
 <?/catalog?>
 
 ## Tables
@@ -471,8 +531,8 @@ glob: "MDS*/README.md"
 where: 'category: "table"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -538,12 +598,24 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                | markdownlint                                                                                    | rumdl                                                                                    | mado | panache | obsidian-linter                       |
-| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---- | ------- | ------------------------------------- |
-| [MDS025](../../../internal/rules/MDS025-table-format/README.md) table-format           | MD055 ✅ table-pipe-style, MD056 ✅ table-column-count (partial), MD058 ✅ blanks-around-tables | MD055 ✅ table-pipe-style, MD056 ✅ table-column-count (partial), MD058 ✅ table-spacing | —    | —       | empty-line-around-tables ⚪ (partial) |
-| [MDS026](../../../internal/rules/MDS026-table-readability/README.md) table-readability | —                                                                                               | —                                                                                        | —    | —       | —                                     |
+| mdsmith                                                                                | markdownlint                                                                                    | rumdl                                                                                    | mado | panache | obsidian-linter                       | gomarklint |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---- | ------- | ------------------------------------- | ---------- |
+| [MDS025](../../../internal/rules/MDS025-table-format/README.md) table-format           | MD055 ✅ table-pipe-style, MD056 ✅ table-column-count (partial), MD058 ✅ blanks-around-tables | MD055 ✅ table-pipe-style, MD056 ✅ table-column-count (partial), MD058 ✅ table-spacing | —    | —       | empty-line-around-tables ⚪ (partial) | —          |
+| [MDS026](../../../internal/rules/MDS026-table-readability/README.md) table-readability | —                                                                                               | —                                                                                        | —    | —       | —                                     | —          |
 <?/catalog?>
 
 ## Prose and readability
@@ -554,8 +626,8 @@ glob: "MDS*/README.md"
 where: 'category: "prose"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -621,23 +693,35 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                                  | markdownlint                                   | rumdl                                          | mado                          | panache | obsidian-linter                    |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- | ----------------------------- | ------- | ---------------------------------- |
-| [MDS023](../../../internal/rules/MDS023-paragraph-readability/README.md) paragraph-readability           | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS024](../../../internal/rules/MDS024-paragraph-structure/README.md) paragraph-structure               | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS028](../../../internal/rules/MDS028-token-budget/README.md) token-budget                             | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS029](../../../internal/rules/MDS029-conciseness-scoring/README.md) conciseness-scoring (not-ready)   | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS037](../../../internal/rules/MDS037-duplicated-content/README.md) duplicated-content                 | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS042](../../../internal/rules/MDS042-emphasis-style/README.md) emphasis-style                         | MD049 ✅ emphasis-style, MD050 ✅ strong-style | MD049 ✅ emphasis-style, MD050 ✅ strong-style | —                             | —       | emphasis-style ⚪, strong-style ⚪ |
-| [MDS047](../../../internal/rules/MDS047-ambiguous-emphasis/README.md) ambiguous-emphasis                 | MD037 ✅ no-space-in-emphasis                  | MD037 ✅ spaces-around-emphasis                | MD037 ✅ no-space-in-emphasis | —       | —                                  |
-| [MDS050](../../../internal/rules/MDS050-proper-names/README.md) proper-names                             | MD044 ✅ proper-names                          | MD044 ✅ proper-names                          | —                             | —       | —                                  |
-| [MDS055](../../../internal/rules/MDS055-forbidden-paragraph-starts/README.md) forbidden-paragraph-starts | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS056](../../../internal/rules/MDS056-forbidden-text/README.md) forbidden-text                         | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS057](../../../internal/rules/MDS057-required-text-patterns/README.md) required-text-patterns         | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS058](../../../internal/rules/MDS058-required-mentions/README.md) required-mentions                   | —                                              | —                                              | —                             | —       | —                                  |
-| [MDS063](../../../internal/rules/MDS063-descriptive-link-text/README.md) descriptive-link-text           | MD059 ✅ descriptive-link-text                 | MD059 ✅ link-text                             | —                             | —       | —                                  |
+| mdsmith                                                                                                  | markdownlint                                   | rumdl                                          | mado                          | panache | obsidian-linter                    | gomarklint                   |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- | ----------------------------- | ------- | ---------------------------------- | ---------------------------- |
+| [MDS023](../../../internal/rules/MDS023-paragraph-readability/README.md) paragraph-readability           | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS024](../../../internal/rules/MDS024-paragraph-structure/README.md) paragraph-structure               | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS028](../../../internal/rules/MDS028-token-budget/README.md) token-budget                             | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS029](../../../internal/rules/MDS029-conciseness-scoring/README.md) conciseness-scoring (not-ready)   | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS037](../../../internal/rules/MDS037-duplicated-content/README.md) duplicated-content                 | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS042](../../../internal/rules/MDS042-emphasis-style/README.md) emphasis-style                         | MD049 ✅ emphasis-style, MD050 ✅ strong-style | MD049 ✅ emphasis-style, MD050 ✅ strong-style | —                             | —       | emphasis-style ⚪, strong-style ⚪ | consistent-emphasis-style ✅ |
+| [MDS047](../../../internal/rules/MDS047-ambiguous-emphasis/README.md) ambiguous-emphasis                 | MD037 ✅ no-space-in-emphasis                  | MD037 ✅ spaces-around-emphasis                | MD037 ✅ no-space-in-emphasis | —       | —                                  | —                            |
+| [MDS050](../../../internal/rules/MDS050-proper-names/README.md) proper-names                             | MD044 ✅ proper-names                          | MD044 ✅ proper-names                          | —                             | —       | —                                  | —                            |
+| [MDS055](../../../internal/rules/MDS055-forbidden-paragraph-starts/README.md) forbidden-paragraph-starts | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS056](../../../internal/rules/MDS056-forbidden-text/README.md) forbidden-text                         | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS057](../../../internal/rules/MDS057-required-text-patterns/README.md) required-text-patterns         | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS058](../../../internal/rules/MDS058-required-mentions/README.md) required-mentions                   | —                                              | —                                              | —                             | —       | —                                  | —                            |
+| [MDS063](../../../internal/rules/MDS063-descriptive-link-text/README.md) descriptive-link-text           | MD059 ✅ descriptive-link-text                 | MD059 ✅ link-text                             | —                             | —       | —                                  | —                            |
 <?/catalog?>
 
 ## Structure and cross-file
@@ -648,8 +732,8 @@ glob: "MDS*/README.md"
 where: 'category: "structural"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -715,18 +799,30 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                    | markdownlint               | rumdl                      | mado                    | panache | obsidian-linter |
-| ------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- | ----------------------- | ------- | --------------- |
-| [MDS020](../../../internal/rules/MDS020-required-structure/README.md) required-structure   | MD043 ✅ required-headings | MD043 ✅ required-headings | —                       | —       | —               |
-| [MDS022](../../../internal/rules/MDS022-max-file-length/README.md) max-file-length         | —                          | —                          | —                       | —       | —               |
-| [MDS033](../../../internal/rules/MDS033-directory-structure/README.md) directory-structure | —                          | —                          | —                       | —       | —               |
-| [MDS034](../../../internal/rules/MDS034-markdown-flavor/README.md) markdown-flavor         | —                          | —                          | —                       | —       | —               |
-| [MDS041](../../../internal/rules/MDS041-no-inline-html/README.md) no-inline-html           | MD033 ✅ no-inline-html    | MD033 ✅ no-inline-html    | MD033 ✅ no-inline-html | —       | —               |
-| [MDS048](../../../internal/rules/MDS048-git-hook-sync/README.md) git-hook-sync             | —                          | —                          | —                       | —       | —               |
-| [MDS067](../../../internal/rules/MDS067-callout-type/README.md) callout-type               | —                          | —                          | —                       | —       | —               |
-| [MDS069](../../../internal/rules/MDS069-unique-frontmatter/README.md) unique-frontmatter   | —                          | —                          | —                       | —       | —               |
+| mdsmith                                                                                    | markdownlint               | rumdl                      | mado                    | panache | obsidian-linter | gomarklint |
+| ------------------------------------------------------------------------------------------ | -------------------------- | -------------------------- | ----------------------- | ------- | --------------- | ---------- |
+| [MDS020](../../../internal/rules/MDS020-required-structure/README.md) required-structure   | MD043 ✅ required-headings | MD043 ✅ required-headings | —                       | —       | —               | —          |
+| [MDS022](../../../internal/rules/MDS022-max-file-length/README.md) max-file-length         | —                          | —                          | —                       | —       | —               | —          |
+| [MDS033](../../../internal/rules/MDS033-directory-structure/README.md) directory-structure | —                          | —                          | —                       | —       | —               | —          |
+| [MDS034](../../../internal/rules/MDS034-markdown-flavor/README.md) markdown-flavor         | —                          | —                          | —                       | —       | —               | —          |
+| [MDS041](../../../internal/rules/MDS041-no-inline-html/README.md) no-inline-html           | MD033 ✅ no-inline-html    | MD033 ✅ no-inline-html    | MD033 ✅ no-inline-html | —       | —               | —          |
+| [MDS048](../../../internal/rules/MDS048-git-hook-sync/README.md) git-hook-sync             | —                          | —                          | —                       | —       | —               | —          |
+| [MDS067](../../../internal/rules/MDS067-callout-type/README.md) callout-type               | —                          | —                          | —                       | —       | —               | —          |
+| [MDS069](../../../internal/rules/MDS069-unique-frontmatter/README.md) unique-frontmatter   | —                          | —                          | —                       | —       | —               | —          |
 <?/catalog?>
 
 ## Generated sections (directives) (mdsmith-only)
@@ -764,8 +860,8 @@ glob: "MDS*/README.md"
 where: 'category: "accessibility"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -831,11 +927,23 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                                | markdownlint         | rumdl                | mado | panache | obsidian-linter |
-| -------------------------------------------------------------------------------------- | -------------------- | -------------------- | ---- | ------- | --------------- |
-| [MDS032](../../../internal/rules/MDS032-no-empty-alt-text/README.md) no-empty-alt-text | MD045 ✅ no-alt-text | MD045 ✅ no-alt-text | —    | —       | —               |
+| mdsmith                                                                                | markdownlint         | rumdl                | mado | panache | obsidian-linter | gomarklint        |
+| -------------------------------------------------------------------------------------- | -------------------- | -------------------- | ---- | ------- | --------------- | ----------------- |
+| [MDS032](../../../internal/rules/MDS032-no-empty-alt-text/README.md) no-empty-alt-text | MD045 ✅ no-alt-text | MD045 ✅ no-alt-text | —    | —       | —               | empty-alt-text ✅ |
 <?/catalog?>
 
 ## Line length
@@ -846,8 +954,8 @@ glob: "MDS*/README.md"
 where: 'category: "line"'
 sort: id
 header: |
-  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter |
-  | ------- | ------------ | ----- | ---- | ------- | --------------- |
+  | mdsmith | markdownlint | rumdl | mado | panache | obsidian-linter | gomarklint |
+  | ------- | ------------ | ----- | ---- | ------- | --------------- | ---------- |
 row-expr: |
   "| [\(id)](../../../internal/rules/" +
   "\(id)-\(name)/README.md) \(name)" +
@@ -913,9 +1021,21 @@ row-expr: |
         if !m.partial {""}][0]
      }], ", ")
    }][0] +
+  " | " +
+  [if gomarklint == [] {"—"},
+   if gomarklint != [] {
+     strings.Join([for m in gomarklint {
+       "\(m.id) " +
+       [if m.default {"✅"}, if !m.default {"⚪"}][0] +
+       [if m.id != m.name {" \(m.name)"},
+        if m.id == m.name {""}][0] +
+       [if m.partial {" (partial)"},
+        if !m.partial {""}][0]
+     }], ", ")
+   }][0] +
   " |"
 ?>
-| mdsmith                                                                    | markdownlint         | rumdl                | mado                 | panache | obsidian-linter |
-| -------------------------------------------------------------------------- | -------------------- | -------------------- | -------------------- | ------- | --------------- |
-| [MDS001](../../../internal/rules/MDS001-line-length/README.md) line-length | MD013 ✅ line-length | MD013 ✅ line-length | MD013 ✅ line-length | —       | —               |
+| mdsmith                                                                    | markdownlint         | rumdl                | mado                 | panache | obsidian-linter | gomarklint         |
+| -------------------------------------------------------------------------- | -------------------- | -------------------- | -------------------- | ------- | --------------- | ------------------ |
+| [MDS001](../../../internal/rules/MDS001-line-length/README.md) line-length | MD013 ✅ line-length | MD013 ✅ line-length | MD013 ✅ line-length | —       | —               | max-line-length ⚪ |
 <?/catalog?>

--- a/internal/release/bench.go
+++ b/internal/release/bench.go
@@ -59,8 +59,8 @@ const defaultBenchWorkdir = "/tmp/mdsmith-bench"
 // benchTool is one pinned, integrity-verified comparison binary
 // fetched from a GitHub release tarball. Name is BOTH the
 // hyperfine `--command-name` and the executable's basename inside
-// the archive — true for all four tools (hyperfine, mado,
-// panache, rumdl), whose tarballs differ only in directory
+// the archive — true for all five tools (gomarklint, hyperfine,
+// mado, panache, rumdl), whose tarballs differ only in directory
 // nesting. URL embeds the version tag so a version bump that
 // forgets to refresh the pin trips validateBenchManifest. SHA256
 // is the lowercase-hex digest of the downloaded `.tar.gz`.
@@ -77,11 +77,20 @@ type benchTool struct {
 // joins the same fetch+verify path as the other three rather
 // than needing a separate uv install with no integrity. The
 // digests were recorded by downloading each tarball once;
-// rumdl's was cross-checked against the publisher's `.sha256`.
+// rumdl's was cross-checked against the publisher's `.sha256`,
+// gomarklint's against the publisher's
+// `gomarklint_3.2.3_checksums.txt`.
 // markdownlint-cli2 is intentionally absent — it installs from a
 // committed npm lockfile via `npm ci`, not a tarball.
 func benchTools() []benchTool {
 	return []benchTool{
+		{
+			Name:    "gomarklint",
+			Version: "v3.2.3",
+			URL: "https://github.com/shinagawa-web/gomarklint/releases/download/" +
+				"v3.2.3/gomarklint_Linux_x86_64.tar.gz",
+			SHA256: "96216f058b9d2a0a5d4c395f7885d38fee0b2917393e7359b084e7b586a02301",
+		},
 		{
 			Name:    "hyperfine",
 			Version: "v1.20.0",
@@ -186,11 +195,12 @@ func verifyChecksum(data []byte, want string) error {
 
 // extractTarGzBinary pulls the single executable named binName
 // out of a gzip-compressed tar archive and writes it to dstPath
-// with 0o755. The four tool tarballs nest the binary differently
-// (hyperfine under a versioned dir, panache under "./", mado and
-// rumdl at the root), so the match is on path.Base of a regular
-// file rather than a hardcoded member path — the same robustness
-// run.sh got from `find -name <tool> -type f`.
+// with 0o755. The five tool tarballs nest the binary differently
+// (hyperfine under a versioned dir, panache under "./", mado,
+// rumdl, and gomarklint at the root), so the match is on
+// path.Base of a regular file rather than a hardcoded member
+// path — the same robustness run.sh got from
+// `find -name <tool> -type f`.
 func extractTarGzBinary(r io.Reader, binName, dstPath string) error {
 	gz, err := gzip.NewReader(r)
 	if err != nil {
@@ -638,6 +648,7 @@ func (t *Toolkit) runHyperfine(binDir, outDir, workdir, mdsmithBin, mdlBin, root
 	mado := filepath.Join(binDir, "mado")
 	rumdl := filepath.Join(binDir, "rumdl")
 	panache := filepath.Join(binDir, "panache")
+	gomarklint := filepath.Join(binDir, "gomarklint")
 	for _, corpus := range []string{"corpus_repo", "corpus_neutral"} {
 		cpath := filepath.Join(workdir, corpus)
 		fmt.Printf("bench: hyperfine over %s\n", corpus)
@@ -646,6 +657,9 @@ func (t *Toolkit) runHyperfine(binDir, outDir, workdir, mdsmithBin, mdlBin, root
 			"--command-name", "mado", mado+" check "+cpath,
 			"--command-name", "rumdl", rumdl+" check --no-cache "+cpath,
 			"--command-name", "panache", panache+" lint --no-cache "+cpath,
+			// gomarklint keeps no on-disk cache, so it takes no
+			// cache-disabling flag; bare defaults match the method.
+			"--command-name", "gomarklint", gomarklint+" "+cpath,
 			"--command-name", "mdsmith-parity", mdsmithBin+" check -c "+parity+" "+cpath,
 			"--command-name", "mdsmith", mdsmithBin+" check "+cpath,
 			"--export-json", filepath.Join(outDir, corpus+".json"),

--- a/internal/release/bench_test.go
+++ b/internal/release/bench_test.go
@@ -27,8 +27,14 @@ func TestBenchManifestInvariants(t *testing.T) {
 
 	tools := benchTools()
 	require.NotEmpty(t, tools)
-	assert.GreaterOrEqual(t, len(tools), 4,
-		"hyperfine, mado, panache, rumdl are all pinned")
+	assert.GreaterOrEqual(t, len(tools), 5,
+		"gomarklint, hyperfine, mado, panache, rumdl are all pinned")
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	assert.True(t, names["gomarklint"],
+		"gomarklint is pinned so the post-merge benchmark run measures it")
 
 	assert.Error(t, validateBenchManifest(nil), "empty manifest")
 

--- a/internal/release/bench_test.go
+++ b/internal/release/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,6 +78,64 @@ func TestBenchManifestInvariants(t *testing.T) {
 		err := validateBenchManifest(dup)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate manifest entry")
+	})
+}
+
+// TestRunHyperfine pins the exact hyperfine invocation: one
+// comparison pass per corpus naming every pinned tool (mado,
+// rumdl, panache, gomarklint) plus the two mdsmith rows, and a
+// separate markdownlint-cli2 pass. A tool dropped from the
+// command line — while still fetched via the manifest — would
+// silently vanish from the published tables; this pins the
+// wiring, not just the pin. The error subtests cover both
+// per-pass failure branches.
+func TestRunHyperfine(t *testing.T) {
+	t.Run("commands pin the tool set", func(t *testing.T) {
+		rec := &recordingRunner{}
+		tk := NewWithDeps(osFS{}, rec)
+		require.NoError(t, tk.runHyperfine(
+			"/bin", "/out", "/work", "/bin/mdsmith", "/mdl/markdownlint-cli2", "/root"))
+
+		require.Len(t, rec.calls, 4, "two hyperfine passes per corpus, two corpora")
+		parity := "/root/docs/research/benchmarks/bench-parity.mdsmith.yml"
+		for i, corpus := range []string{"corpus_repo", "corpus_neutral"} {
+			cpath := "/work/" + corpus
+			main := rec.calls[2*i]
+			assert.Equal(t, "/bin/hyperfine", main.name)
+			joined := strings.Join(main.args, " ")
+			assert.Contains(t, joined, "--command-name mado /bin/mado check "+cpath)
+			assert.Contains(t, joined,
+				"--command-name rumdl /bin/rumdl check --no-cache "+cpath)
+			assert.Contains(t, joined,
+				"--command-name panache /bin/panache lint --no-cache "+cpath)
+			assert.Contains(t, joined,
+				"--command-name gomarklint /bin/gomarklint "+cpath)
+			assert.Contains(t, joined,
+				"--command-name mdsmith-parity /bin/mdsmith check -c "+parity+" "+cpath)
+			assert.Contains(t, joined, "--command-name mdsmith /bin/mdsmith check "+cpath)
+			assert.Contains(t, joined, "--export-json /out/"+corpus+".json")
+
+			mdl := rec.calls[2*i+1]
+			assert.Equal(t, "/bin/hyperfine", mdl.name)
+			assert.Contains(t, strings.Join(mdl.args, " "),
+				"--command-name markdownlint-cli2 /mdl/markdownlint-cli2 '"+cpath+"/**/*.md'")
+		}
+	})
+
+	t.Run("comparison pass failure propagates", func(t *testing.T) {
+		tk := NewWithDeps(osFS{}, &fakeRunner{failOnCall: 1})
+		err := tk.runHyperfine("/bin", "/out", "/work", "/bin/mdsmith", "/mdl", "/root")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errInjected)
+		assert.Contains(t, err.Error(), "hyperfine corpus_repo")
+	})
+
+	t.Run("markdownlint pass failure propagates", func(t *testing.T) {
+		tk := NewWithDeps(osFS{}, &fakeRunner{failOnCall: 2})
+		err := tk.runHyperfine("/bin", "/out", "/work", "/bin/mdsmith", "/mdl", "/root")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errInjected)
+		assert.Contains(t, err.Error(), "markdownlint")
 	})
 }
 

--- a/internal/rules/MDS001-line-length/README.md
+++ b/internal/rules/MDS001-line-length/README.md
@@ -23,6 +23,11 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: max-line-length
+    name: max-line-length
+    partial: false
+    default: false
 ---
 # MDS001: line-length
 
@@ -271,7 +276,9 @@ This line inside a code block is over 80 characters but within the code-block-ma
 - **markdownlint**: [MD013][mdl-md013] (line-length)
 - **rumdl**: [MD013][rumdl-md013] (line-length)
 - **mado**: [MD013][mado-rules] (line-length)
+- **gomarklint**: [max-line-length][gomarklint-rules]
 
 [mdl-md013]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
 [rumdl-md013]: https://rumdl.dev/md013/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS002-heading-style/README.md
+++ b/internal/rules/MDS002-heading-style/README.md
@@ -23,6 +23,11 @@ mado:
     default: false
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: no-setext-headings
+    name: no-setext-headings
+    partial: false
+    default: true
 ---
 # MDS002: heading-style
 
@@ -170,7 +175,9 @@ Body text.
 - **markdownlint**: [MD003][mdl-md003] (heading-style)
 - **rumdl**: [MD003][rumdl-md003] (heading-style)
 - **mado**: [MD003][mado-rules] (heading-style)
+- **gomarklint**: [no-setext-headings][gomarklint-rules]
 
 [mdl-md003]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md003.md
 [rumdl-md003]: https://rumdl.dev/md003/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -31,6 +31,11 @@ obsidian-linter:
     name: header-increment
     partial: false
     default: false
+gomarklint:
+  - id: heading-level
+    name: heading-level
+    partial: false
+    default: true
 ---
 # MDS003: heading-increment
 
@@ -113,6 +118,7 @@ Body text.
 - **mado**: [MD001][mado-rules] (heading-increment)
 - **panache**: [heading-hierarchy]
 - **obsidian-linter**: [header-increment]
+- **gomarklint**: [heading-level][gomarklint-rules]
 
 [mdl-md001]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md
 [rumdl-md001]: https://rumdl.dev/md001/
@@ -121,3 +127,4 @@ Body text.
   https://panache.bz/reference/linter-rules.html#heading-hierarchy
 [header-increment]:
   https://platers.github.io/obsidian-linter/settings/heading-rules/#header-increment
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -23,6 +23,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS004: first-line-heading
 

--- a/internal/rules/MDS005-no-duplicate-headings/README.md
+++ b/internal/rules/MDS005-no-duplicate-headings/README.md
@@ -23,6 +23,11 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: duplicate-heading
+    name: duplicate-heading
+    partial: false
+    default: true
 ---
 # MDS005: no-duplicate-headings
 
@@ -97,7 +102,9 @@ Body two.
 - **markdownlint**: [MD024][mdl-md024] (no-duplicate-heading)
 - **rumdl**: [MD024][rumdl-md024] (multiple-headings)
 - **mado**: [MD024][mado-rules] (no-duplicate-heading)
+- **gomarklint**: [duplicate-heading][gomarklint-rules]
 
 [mdl-md024]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md
 [rumdl-md024]: https://rumdl.dev/md024/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS006-no-trailing-spaces/README.md
+++ b/internal/rules/MDS006-no-trailing-spaces/README.md
@@ -27,6 +27,7 @@ obsidian-linter:
     name: trailing-spaces
     partial: false
     default: false
+gomarklint: []
 ---
 # MDS006: no-trailing-spaces
 

--- a/internal/rules/MDS007-no-hard-tabs/README.md
+++ b/internal/rules/MDS007-no-hard-tabs/README.md
@@ -23,6 +23,11 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: no-hard-tabs
+    name: no-hard-tabs
+    partial: false
+    default: true
 ---
 # MDS007: no-hard-tabs
 
@@ -94,7 +99,9 @@ No tabs here.
 - **markdownlint**: [MD010][mdl-md010] (no-hard-tabs)
 - **rumdl**: [MD010][rumdl-md010] (no-hard-tabs)
 - **mado**: [MD010][mado-rules] (no-hard-tabs)
+- **gomarklint**: [no-hard-tabs][gomarklint-rules]
 
 [mdl-md010]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md010.md
 [rumdl-md010]: https://rumdl.dev/md010/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS008-no-multiple-blanks/README.md
+++ b/internal/rules/MDS008-no-multiple-blanks/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: consecutive-blank-lines
     partial: false
     default: false
+gomarklint:
+  - id: no-multiple-blank-lines
+    name: no-multiple-blank-lines
+    partial: false
+    default: true
 ---
 # MDS008: no-multiple-blanks
 
@@ -102,9 +107,11 @@ more code with blank lines above
 - **rumdl**: [MD012][rumdl-md012] (no-multiple-blanks)
 - **mado**: [MD012][mado-rules] (no-multiple-blanks)
 - **obsidian-linter**: [consecutive-blank-lines]
+- **gomarklint**: [no-multiple-blank-lines][gomarklint-rules]
 
 [mdl-md012]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md012.md
 [rumdl-md012]: https://rumdl.dev/md012/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [consecutive-blank-lines]:
   https://platers.github.io/obsidian-linter/settings/spacing-rules/#consecutive-blank-lines
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS009-single-trailing-newline/README.md
+++ b/internal/rules/MDS009-single-trailing-newline/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: line-break-at-document-end
     partial: false
     default: false
+gomarklint:
+  - id: final-blank-line
+    name: final-blank-line
+    partial: false
+    default: true
 ---
 # MDS009: single-trailing-newline
 
@@ -102,9 +107,11 @@ is what the rule detects.
 - **rumdl**: [MD047][rumdl-md047] (file-end-newline)
 - **mado**: [MD047][mado-rules] (single-trailing-newline)
 - **obsidian-linter**: [line-break-at-document-end]
+- **gomarklint**: [final-blank-line][gomarklint-rules]
 
 [mdl-md047]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md047.md
 [rumdl-md047]: https://rumdl.dev/md047/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [line-break-at-document-end]:
   https://platers.github.io/obsidian-linter/settings/spacing-rules/#line-break-at-document-end
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS010-fenced-code-style/README.md
+++ b/internal/rules/MDS010-fenced-code-style/README.md
@@ -19,6 +19,11 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: consistent-code-fence
+    name: consistent-code-fence
+    partial: false
+    default: true
 ---
 # MDS010: fenced-code-style
 
@@ -137,6 +142,8 @@ fmt.Println("hello")
 - **Category**: code
 - **markdownlint**: [MD048][mdl-md048] (code-fence-style)
 - **rumdl**: [MD048][rumdl-md048] (code-fence-style)
+- **gomarklint**: [consistent-code-fence][gomarklint-rules]
 
 [mdl-md048]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md
 [rumdl-md048]: https://rumdl.dev/md048/
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS011-fenced-code-language/README.md
+++ b/internal/rules/MDS011-fenced-code-language/README.md
@@ -23,6 +23,11 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: fenced-code-language
+    name: fenced-code-language
+    partial: false
+    default: true
 ---
 # MDS011: fenced-code-language
 
@@ -93,7 +98,9 @@ fmt.Println("hello")
 - **markdownlint**: [MD040][mdl-md040] (fenced-code-language)
 - **rumdl**: [MD040][rumdl-md040] (fenced-code-language)
 - **mado**: [MD040][mado-rules] (fenced-code-language)
+- **gomarklint**: [fenced-code-language][gomarklint-rules]
 
 [mdl-md040]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md
 [rumdl-md040]: https://rumdl.dev/md040/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS012-no-bare-urls/README.md
+++ b/internal/rules/MDS012-no-bare-urls/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: no-bare-urls
     partial: false
     default: false
+gomarklint:
+  - id: no-bare-urls
+    name: no-bare-urls
+    partial: false
+    default: true
 ---
 # MDS012: no-bare-urls
 
@@ -94,9 +99,11 @@ Visit [example](https://example.com) for more.
 - **rumdl**: [MD034][rumdl-md034] (no-bare-urls)
 - **mado**: [MD034][mado-rules] (no-bare-urls)
 - **obsidian-linter**: [no-bare-urls]
+- **gomarklint**: [no-bare-urls][gomarklint-rules]
 
 [mdl-md034]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md
 [rumdl-md034]: https://rumdl.dev/md034/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [no-bare-urls]:
   https://platers.github.io/obsidian-linter/settings/content-rules/#no-bare-urls
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS013-blank-line-around-headings/README.md
+++ b/internal/rules/MDS013-blank-line-around-headings/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: heading-blank-lines
     partial: false
     default: false
+gomarklint:
+  - id: blanks-around-headings
+    name: blanks-around-headings
+    partial: false
+    default: true
 ---
 # MDS013: blank-line-around-headings
 
@@ -104,9 +109,11 @@ Content here.
 - **rumdl**: [MD022][rumdl-md022] (blanks-around-headings)
 - **mado**: [MD022][mado-rules] (blanks-around-headings)
 - **obsidian-linter**: [heading-blank-lines]
+- **gomarklint**: [blanks-around-headings][gomarklint-rules]
 
 [mdl-md022]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md
 [rumdl-md022]: https://rumdl.dev/md022/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [heading-blank-lines]:
   https://platers.github.io/obsidian-linter/settings/spacing-rules/#heading-blank-lines
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS014-blank-line-around-lists/README.md
+++ b/internal/rules/MDS014-blank-line-around-lists/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: paragraph-blank-lines
     partial: true
     default: false
+gomarklint:
+  - id: blanks-around-lists
+    name: blanks-around-lists
+    partial: false
+    default: true
 ---
 # MDS014: blank-line-around-lists
 
@@ -106,9 +111,11 @@ Content here.
 - **rumdl**: [MD032][rumdl-md032] (blanks-around-lists)
 - **mado**: [MD032][mado-rules] (blanks-around-lists)
 - **obsidian-linter**: [paragraph-blank-lines] (partial)
+- **gomarklint**: [blanks-around-lists][gomarklint-rules]
 
 [mdl-md032]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md032.md
 [rumdl-md032]: https://rumdl.dev/md032/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [paragraph-blank-lines]:
   https://platers.github.io/obsidian-linter/settings/spacing-rules/#paragraph-blank-lines
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS015-blank-line-around-fenced-code/README.md
+++ b/internal/rules/MDS015-blank-line-around-fenced-code/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: empty-line-around-code-fences
     partial: false
     default: false
+gomarklint:
+  - id: blanks-around-fences
+    name: blanks-around-fences
+    partial: false
+    default: true
 ---
 # MDS015: blank-line-around-fenced-code
 
@@ -108,9 +113,11 @@ Content here.
 - **rumdl**: [MD031][rumdl-md031] (blanks-around-fences)
 - **mado**: [MD031][mado-rules] (blanks-around-fences)
 - **obsidian-linter**: [empty-line-around-code-fences]
+- **gomarklint**: [blanks-around-fences][gomarklint-rules]
 
 [mdl-md031]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md031.md
 [rumdl-md031]: https://rumdl.dev/md031/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [empty-line-around-code-fences]:
   https://platers.github.io/obsidian-linter/settings/spacing-rules/#empty-line-around-code-fences
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS016-list-indent/README.md
+++ b/internal/rules/MDS016-list-indent/README.md
@@ -35,6 +35,7 @@ mado:
     default: false
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS016: list-indent
 

--- a/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
+++ b/internal/rules/MDS017-no-trailing-punctuation-in-heading/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: remove-trailing-punctuation-in-heading
     partial: false
     default: false
+gomarklint:
+  - id: no-trailing-punctuation
+    name: no-trailing-punctuation
+    partial: false
+    default: true
 ---
 # MDS017: no-trailing-punctuation-in-heading
 
@@ -98,9 +103,11 @@ Body text.
 - **rumdl**: [MD026][rumdl-md026] (no-trailing-punctuation)
 - **mado**: [MD026][mado-rules] (no-trailing-punctuation)
 - **obsidian-linter**: [remove-trailing-punctuation-in-heading]
+- **gomarklint**: [no-trailing-punctuation][gomarklint-rules]
 
 [mdl-md026]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md
 [rumdl-md026]: https://rumdl.dev/md026/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [remove-trailing-punctuation-in-heading]:
   https://platers.github.io/obsidian-linter/settings/heading-rules/#remove-trailing-punctuation-in-heading
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -23,6 +23,11 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: no-emphasis-as-heading
+    name: no-emphasis-as-heading
+    partial: false
+    default: true
 ---
 # MDS018: no-emphasis-as-heading
 
@@ -123,7 +128,9 @@ wrap: markdown
 - **markdownlint**: [MD036][mdl-md036] (no-emphasis-as-heading)
 - **rumdl**: [MD036][rumdl-md036] (no-emphasis-as-heading)
 - **mado**: [MD036][mado-rules] (no-emphasis-as-heading)
+- **gomarklint**: [no-emphasis-as-heading][gomarklint-rules]
 
 [mdl-md036]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md036.md
 [rumdl-md036]: https://rumdl.dev/md036/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS019-catalog/README.md
+++ b/internal/rules/MDS019-catalog/README.md
@@ -14,6 +14,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS019: catalog
 

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -22,6 +22,7 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS020: required-structure
 

--- a/internal/rules/MDS021-include/README.md
+++ b/internal/rules/MDS021-include/README.md
@@ -14,6 +14,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS021: include
 

--- a/internal/rules/MDS022-max-file-length/README.md
+++ b/internal/rules/MDS022-max-file-length/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS022: max-file-length
 

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS023: paragraph-readability
 

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS024: paragraph-structure
 

--- a/internal/rules/MDS025-table-format/README.md
+++ b/internal/rules/MDS025-table-format/README.md
@@ -39,6 +39,7 @@ obsidian-linter:
     name: empty-line-around-tables
     partial: true
     default: false
+gomarklint: []
 ---
 # MDS025: table-format
 

--- a/internal/rules/MDS026-table-readability/README.md
+++ b/internal/rules/MDS026-table-readability/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS026: table-readability
 

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -23,6 +23,11 @@ panache:
     partial: false
     default: true
 obsidian-linter: []
+gomarklint:
+  - id: link-fragments
+    name: link-fragments
+    partial: false
+    default: true
 ---
 # MDS027: cross-file-reference-integrity
 
@@ -203,8 +208,10 @@ See [guide](bad/ref/guide.md#missing-section).
 - **markdownlint**: [MD051][mdl-md051] (link-fragments)
 - **rumdl**: [MD051][rumdl-md051] (link-fragments)
 - **panache**: [undefined-anchor]
+- **gomarklint**: [link-fragments][gomarklint-rules]
 
 [mdl-md051]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md
 [rumdl-md051]: https://rumdl.dev/md051/
 [undefined-anchor]:
   https://panache.bz/reference/linter-rules.html#undefined-anchor
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS028-token-budget/README.md
+++ b/internal/rules/MDS028-token-budget/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS028: token-budget
 

--- a/internal/rules/MDS029-conciseness-scoring/README.md
+++ b/internal/rules/MDS029-conciseness-scoring/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS029: conciseness-scoring
 

--- a/internal/rules/MDS030-empty-section-body/README.md
+++ b/internal/rules/MDS030-empty-section-body/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS030: empty-section-body
 

--- a/internal/rules/MDS031-unclosed-code-block/README.md
+++ b/internal/rules/MDS031-unclosed-code-block/README.md
@@ -11,6 +11,11 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: unclosed-code-block
+    name: unclosed-code-block
+    partial: false
+    default: true
 ---
 # MDS031: unclosed-code-block
 
@@ -79,3 +84,6 @@ wrap: markdown
 - **Implementation**:
   [source](./)
 - **Category**: code
+- **gomarklint**: [unclosed-code-block][gomarklint-rules]
+
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS032-no-empty-alt-text/README.md
+++ b/internal/rules/MDS032-no-empty-alt-text/README.md
@@ -19,6 +19,11 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: empty-alt-text
+    name: empty-alt-text
+    partial: false
+    default: true
 ---
 # MDS032: no-empty-alt-text
 
@@ -84,6 +89,8 @@ wrap: markdown
 - **Category**: accessibility
 - **markdownlint**: [MD045][mdl-md045] (no-alt-text)
 - **rumdl**: [MD045][rumdl-md045] (no-alt-text)
+- **gomarklint**: [empty-alt-text][gomarklint-rules]
 
 [mdl-md045]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md
 [rumdl-md045]: https://rumdl.dev/md045/
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS033-directory-structure/README.md
+++ b/internal/rules/MDS033-directory-structure/README.md
@@ -14,6 +14,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS033: directory-structure
 

--- a/internal/rules/MDS034-markdown-flavor/README.md
+++ b/internal/rules/MDS034-markdown-flavor/README.md
@@ -13,6 +13,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS034: markdown-flavor
 

--- a/internal/rules/MDS035-toc-directive/README.md
+++ b/internal/rules/MDS035-toc-directive/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS035: toc-directive
 

--- a/internal/rules/MDS036-max-section-length/README.md
+++ b/internal/rules/MDS036-max-section-length/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS036: max-section-length
 

--- a/internal/rules/MDS037-duplicated-content/README.md
+++ b/internal/rules/MDS037-duplicated-content/README.md
@@ -14,6 +14,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS037: duplicated-content
 

--- a/internal/rules/MDS038-toc/README.md
+++ b/internal/rules/MDS038-toc/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS038: toc
 

--- a/internal/rules/MDS039-build/README.md
+++ b/internal/rules/MDS039-build/README.md
@@ -13,6 +13,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS039: build
 

--- a/internal/rules/MDS040-recipe-safety/README.md
+++ b/internal/rules/MDS040-recipe-safety/README.md
@@ -13,6 +13,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS040: recipe-safety
 

--- a/internal/rules/MDS041-no-inline-html/README.md
+++ b/internal/rules/MDS041-no-inline-html/README.md
@@ -25,6 +25,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS041: no-inline-html
 

--- a/internal/rules/MDS042-emphasis-style/README.md
+++ b/internal/rules/MDS042-emphasis-style/README.md
@@ -38,6 +38,11 @@ obsidian-linter:
     name: strong-style
     partial: false
     default: false
+gomarklint:
+  - id: consistent-emphasis-style
+    name: consistent-emphasis-style
+    partial: false
+    default: true
 ---
 # MDS042: emphasis-style
 
@@ -163,6 +168,7 @@ The following cases emit diagnostics but are
 - **obsidian-linter**:
   - [emphasis-style]
   - [strong-style]
+- **gomarklint**: [consistent-emphasis-style][gomarklint-rules]
 
 [mdl-md049]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md049.md
 [mdl-md050]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md050.md
@@ -172,3 +178,4 @@ The following cases emit diagnostics but are
   https://platers.github.io/obsidian-linter/settings/content-rules/#emphasis-style
 [strong-style]:
   https://platers.github.io/obsidian-linter/settings/content-rules/#strong-style
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS043-no-reference-style/README.md
+++ b/internal/rules/MDS043-no-reference-style/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS043: no-reference-style
 

--- a/internal/rules/MDS044-horizontal-rule-style/README.md
+++ b/internal/rules/MDS044-horizontal-rule-style/README.md
@@ -25,6 +25,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS044: horizontal-rule-style
 

--- a/internal/rules/MDS045-list-marker-style/README.md
+++ b/internal/rules/MDS045-list-marker-style/README.md
@@ -27,6 +27,11 @@ obsidian-linter:
     name: unordered-list-style
     partial: false
     default: false
+gomarklint:
+  - id: consistent-list-marker
+    name: consistent-list-marker
+    partial: false
+    default: true
 ---
 # MDS045: list-marker-style
 
@@ -170,9 +175,11 @@ Outer uses dash (correct), inner should use asterisk but uses dash.
 - **rumdl**: [MD004][rumdl-md004] (ul-style)
 - **mado**: [MD004][mado-rules] (ul-style)
 - **obsidian-linter**: [unordered-list-style]
+- **gomarklint**: [consistent-list-marker][gomarklint-rules]
 
 [mdl-md004]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md004.md
 [rumdl-md004]: https://rumdl.dev/md004/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
 [unordered-list-style]:
   https://platers.github.io/obsidian-linter/settings/content-rules/#unordered-list-style
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS046-ordered-list-numbering/README.md
+++ b/internal/rules/MDS046-ordered-list-numbering/README.md
@@ -27,6 +27,7 @@ obsidian-linter:
     name: ordered-list-style
     partial: false
     default: false
+gomarklint: []
 ---
 # MDS046: ordered-list-numbering
 

--- a/internal/rules/MDS047-ambiguous-emphasis/README.md
+++ b/internal/rules/MDS047-ambiguous-emphasis/README.md
@@ -23,6 +23,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS047: ambiguous-emphasis
 

--- a/internal/rules/MDS048-git-hook-sync/README.md
+++ b/internal/rules/MDS048-git-hook-sync/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS048: git-hook-sync
 

--- a/internal/rules/MDS049-no-space-in-link-text/README.md
+++ b/internal/rules/MDS049-no-space-in-link-text/README.md
@@ -23,6 +23,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS049: no-space-in-link-text
 

--- a/internal/rules/MDS050-proper-names/README.md
+++ b/internal/rules/MDS050-proper-names/README.md
@@ -19,6 +19,7 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS050: proper-names
 

--- a/internal/rules/MDS051-single-h1/README.md
+++ b/internal/rules/MDS051-single-h1/README.md
@@ -23,6 +23,11 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: single-h1
+    name: single-h1
+    partial: false
+    default: true
 ---
 # MDS051: single-h1
 
@@ -120,7 +125,9 @@ title: My Doc
 - **markdownlint**: [MD025][mdl-md025] (single-h1)
 - **rumdl**: [MD025][rumdl-md025] (single-title)
 - **mado**: [MD025][mado-rules] (single-h1)
+- **gomarklint**: [single-h1][gomarklint-rules]
 
 [mdl-md025]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md
 [rumdl-md025]: https://rumdl.dev/md025/
 [mado-rules]: https://github.com/akiomik/mado#supported-rules
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS052-no-space-in-code-spans/README.md
+++ b/internal/rules/MDS052-no-space-in-code-spans/README.md
@@ -23,6 +23,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS052: no-space-in-code-spans
 

--- a/internal/rules/MDS053-no-unused-link-definitions/README.md
+++ b/internal/rules/MDS053-no-unused-link-definitions/README.md
@@ -29,6 +29,7 @@ panache:
     partial: false
     default: true
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS053: no-unused-link-definitions
 

--- a/internal/rules/MDS054-no-undefined-reference-labels/README.md
+++ b/internal/rules/MDS054-no-undefined-reference-labels/README.md
@@ -23,6 +23,7 @@ panache:
     partial: false
     default: true
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS054: no-undefined-reference-labels
 

--- a/internal/rules/MDS055-forbidden-paragraph-starts/README.md
+++ b/internal/rules/MDS055-forbidden-paragraph-starts/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS055: forbidden-paragraph-starts
 

--- a/internal/rules/MDS056-forbidden-text/README.md
+++ b/internal/rules/MDS056-forbidden-text/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS056: forbidden-text
 

--- a/internal/rules/MDS057-required-text-patterns/README.md
+++ b/internal/rules/MDS057-required-text-patterns/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS057: required-text-patterns
 

--- a/internal/rules/MDS058-required-mentions/README.md
+++ b/internal/rules/MDS058-required-mentions/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS058: required-mentions
 

--- a/internal/rules/MDS059-blockquote-whitespace/README.md
+++ b/internal/rules/MDS059-blockquote-whitespace/README.md
@@ -45,6 +45,7 @@ obsidian-linter:
     name: empty-line-around-blockquotes
     partial: true
     default: false
+gomarklint: []
 ---
 # MDS059: blockquote-whitespace
 

--- a/internal/rules/MDS061-list-marker-space/README.md
+++ b/internal/rules/MDS061-list-marker-space/README.md
@@ -29,6 +29,7 @@ obsidian-linter:
     name: space-after-list-markers
     partial: false
     default: false
+gomarklint: []
 ---
 # MDS061: list-marker-space
 

--- a/internal/rules/MDS062-link-validity/README.md
+++ b/internal/rules/MDS062-link-validity/README.md
@@ -30,6 +30,11 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint:
+  - id: no-empty-links
+    name: no-empty-links
+    partial: false
+    default: true
 ---
 # MDS062: link-validity
 
@@ -179,8 +184,10 @@ The reversed form `(text)[url]` is shown as code, not as a link.
 - **rumdl**:
   - [MD011][rumdl-md011] (reversed-link)
   - [MD042][rumdl-md042] (no-empty-links)
+- **gomarklint**: [no-empty-links][gomarklint-rules]
 
 [mdl-md011]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md011.md
 [mdl-md042]: https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md
 [rumdl-md011]: https://rumdl.dev/md011/
 [rumdl-md042]: https://rumdl.dev/md042/
+[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/

--- a/internal/rules/MDS063-descriptive-link-text/README.md
+++ b/internal/rules/MDS063-descriptive-link-text/README.md
@@ -21,6 +21,7 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS063: descriptive-link-text
 

--- a/internal/rules/MDS064-atx-heading-whitespace/README.md
+++ b/internal/rules/MDS064-atx-heading-whitespace/README.md
@@ -75,6 +75,7 @@ obsidian-linter:
     name: headings-start-line
     partial: true
     default: false
+gomarklint: []
 ---
 # MDS064: atx-heading-whitespace
 

--- a/internal/rules/MDS065-code-block-style/README.md
+++ b/internal/rules/MDS065-code-block-style/README.md
@@ -25,6 +25,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS065: code-block-style
 

--- a/internal/rules/MDS066-commands-show-output/README.md
+++ b/internal/rules/MDS066-commands-show-output/README.md
@@ -25,6 +25,7 @@ mado:
     default: true
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS066: commands-show-output
 

--- a/internal/rules/MDS067-callout-type/README.md
+++ b/internal/rules/MDS067-callout-type/README.md
@@ -11,6 +11,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS067: callout-type
 

--- a/internal/rules/MDS068-link-style/README.md
+++ b/internal/rules/MDS068-link-style/README.md
@@ -19,6 +19,7 @@ rumdl:
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS068: link-style
 

--- a/internal/rules/MDS069-unique-frontmatter/README.md
+++ b/internal/rules/MDS069-unique-frontmatter/README.md
@@ -13,6 +13,7 @@ rumdl: []
 mado: []
 panache: []
 obsidian-linter: []
+gomarklint: []
 ---
 # MDS069: unique-frontmatter
 

--- a/internal/rules/directive-proto.md
+++ b/internal/rules/directive-proto.md
@@ -10,6 +10,7 @@ rumdl: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial: bool, default:
 mado: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial: bool, default: bool}]'
 panache: '[...{id: =~"^[a-z][a-z0-9-]*$", name: string & != "", partial: bool, default: bool}]'
 obsidian-linter: '[...{id: =~"^[a-z][a-z0-9-]*$", name: string & != "", partial: bool, default: bool}]'
+gomarklint: '[...{id: =~"^[a-z][a-z0-9-]*$", name: string & != "", partial: bool, default: bool}]'
 category: '"directive"'
 ---
 # {id}: {name}

--- a/internal/rules/peerlinks_test.go
+++ b/internal/rules/peerlinks_test.go
@@ -14,9 +14,10 @@ import (
 // The "Meta-Information" section of every rule README lists the peer
 // Markdown linters this rule covers, one bullet per peer, each linking
 // to that peer's rule documentation. The bullets are derived from the
-// `markdownlint:`/`rumdl:`/`mado:`/`panache:`/`obsidian-linter:` front
-// matter (the same source the coverage matrix reads), so this test is
-// the golden generator and validator that keeps the two in sync.
+// `markdownlint:`/`rumdl:`/`mado:`/`panache:`/`obsidian-linter:`/
+// `gomarklint:` front matter (the same source the coverage matrix
+// reads), so this test is the golden generator and validator that
+// keeps the two in sync.
 //
 // Regenerate after editing peer front matter:
 //
@@ -31,7 +32,7 @@ type peerLinkSpec struct {
 	maps  []RuleMapping
 }
 
-// peerLinkSpecs returns the five peer linters in their canonical bullet
+// peerLinkSpecs returns the six peer linters in their canonical bullet
 // order. The label is the peer's own (lowercase) brand name.
 func peerLinkSpecs(info RuleInfo) []peerLinkSpec {
 	return []peerLinkSpec{
@@ -40,6 +41,7 @@ func peerLinkSpecs(info RuleInfo) []peerLinkSpec {
 		{"mado", info.Mado},
 		{"panache", info.Panache},
 		{"obsidian-linter", info.ObsidianLinter},
+		{"gomarklint", info.Gomarklint},
 	}
 }
 
@@ -87,8 +89,12 @@ func isShortcutPeer(label string) bool {
 // markdownlint, rumdl, and mado prefix the markdownlint-style id so the
 // same `MDxxx` covered by several peers gets a distinct label per peer.
 // Every mado entry shares one label because mado has no per-rule docs,
-// only a single "Supported Rules" table. Shortcut peers (panache,
-// obsidian-linter) use the bare rule name as the label.
+// only a single "Supported Rules" table; gomarklint shares one label the
+// same way (its docs put every rule on a single Rules page), which also
+// keeps its kebab rule names from colliding with a shortcut peer's bare
+// label (obsidian-linter and gomarklint both have a `no-bare-urls`).
+// Shortcut peers (panache, obsidian-linter) use the bare rule name as
+// the label.
 func peerRefID(label string, m RuleMapping) string {
 	switch label {
 	case "markdownlint":
@@ -97,6 +103,8 @@ func peerRefID(label string, m RuleMapping) string {
 		return "rumdl-" + strings.ToLower(m.ID)
 	case "mado":
 		return "mado-rules"
+	case "gomarklint":
+		return "gomarklint-rules"
 	case "panache", "obsidian-linter":
 		return m.Name
 	default:
@@ -115,6 +123,8 @@ func peerRefURL(label string, m RuleMapping) (string, error) {
 		return "https://rumdl.dev/" + strings.ToLower(m.ID) + "/", nil
 	case "mado":
 		return "https://github.com/akiomik/mado#supported-rules", nil
+	case "gomarklint":
+		return "https://shinagawa-web.github.io/gomarklint/docs/rules/", nil
 	case "panache":
 		return "https://panache.bz/reference/linter-rules.html#" + m.Name, nil
 	case "obsidian-linter":
@@ -138,13 +148,18 @@ func (e *peerLinkError) Error() string {
 
 // peerEntry renders the link for one peer mapping. markdownlint-style
 // peers show "[MD013][mdl-md013] (line-length)"; shortcut peers show
-// "[undefined-anchor]". A trailing " (partial)" marks a partial cover,
-// matching the coverage-matrix legend.
+// "[undefined-anchor]". A peer whose id is its kebab name (gomarklint)
+// drops the parenthetical, which would just repeat the id. A trailing
+// " (partial)" marks a partial cover, matching the coverage-matrix
+// legend.
 func peerEntry(label string, m RuleMapping) string {
 	var text string
-	if isShortcutPeer(label) {
+	switch {
+	case isShortcutPeer(label):
 		text = "[" + m.Name + "]"
-	} else {
+	case m.ID == m.Name:
+		text = "[" + m.ID + "][" + peerRefID(label, m) + "]"
+	default:
 		text = "[" + m.ID + "][" + peerRefID(label, m) + "] (" + m.Name + ")"
 	}
 	if m.Partial {
@@ -222,7 +237,7 @@ func renderPeerLinks(info RuleInfo) (string, error) {
 // which has no fixed prefix to scan for; in practice every panache /
 // obsidian-linter rule also has a markdownlint analog, so these still
 // catch a fully de-mapped rule.)
-var peerRefMarkers = []string{"[mdl-", "[rumdl-", "[mado-rules]"}
+var peerRefMarkers = []string{"[mdl-", "[rumdl-", "[mado-rules]", "[gomarklint-rules]"}
 
 const categoryMarker = "\n- **Category**:"
 
@@ -296,6 +311,12 @@ func TestPeerEntry(t *testing.T) {
 		})
 		assert.Equal(t, "[header-increment] (partial)", got)
 	})
+	t.Run("gomarklint id equals name so no parenthetical", func(t *testing.T) {
+		got := peerEntry("gomarklint", RuleMapping{
+			ID: "link-fragments", Name: "link-fragments",
+		})
+		assert.Equal(t, "[link-fragments][gomarklint-rules]", got)
+	})
 }
 
 func TestPeerBullet(t *testing.T) {
@@ -332,6 +353,8 @@ func TestPeerRefURL(t *testing.T) {
 			want: "https://platers.github.io/obsidian-linter/settings/spacing-rules/#trailing-spaces"},
 		{label: "obsidian-linter", m: RuleMapping{ID: "no-bare-urls", Name: "no-bare-urls"},
 			want: "https://platers.github.io/obsidian-linter/settings/content-rules/#no-bare-urls"},
+		{label: "gomarklint", m: RuleMapping{ID: "single-h1", Name: "single-h1"},
+			want: "https://shinagawa-web.github.io/gomarklint/docs/rules/"},
 	}
 	for _, c := range cases {
 		got, err := peerRefURL(c.label, c.m)
@@ -361,6 +384,28 @@ func TestMadoShareSingleRef(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(block, "[mado-rules]: "))
 	assert.Contains(t, block, "[MD018][mado-rules] (no-missing-space-atx)")
 	assert.Contains(t, block, "[MD019][mado-rules] (no-multiple-space-atx)")
+}
+
+func TestGomarklintSharesSingleRef(t *testing.T) {
+	info := RuleInfo{
+		ID:       "MDS012",
+		Category: "link",
+		// The obsidian-linter shortcut label is the bare rule name; the
+		// gomarklint entry for the same upstream name must not collide
+		// with it, which is why gomarklint shares one prefixed label.
+		ObsidianLinter: []RuleMapping{
+			{ID: "no-bare-urls", Name: "no-bare-urls", Default: false},
+		},
+		Gomarklint: []RuleMapping{
+			{ID: "no-bare-urls", Name: "no-bare-urls", Default: true},
+		},
+	}
+	block, err := renderPeerLinks(info)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(block, "[gomarklint-rules]: "))
+	assert.Contains(t, block, "- **gomarklint**: [no-bare-urls][gomarklint-rules]")
+	assert.Contains(t, block,
+		"[gomarklint-rules]: https://shinagawa-web.github.io/gomarklint/docs/rules/")
 }
 
 func TestRenderPeerLinks_ConflictingShortcutLabels(t *testing.T) {

--- a/internal/rules/proto.md
+++ b/internal/rules/proto.md
@@ -10,6 +10,7 @@ rumdl: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial: bool, default:
 mado: '[...{id: =~"^MD[0-9]{3}$", name: string & != "", partial: bool, default: bool}]'
 panache: '[...{id: =~"^[a-z][a-z0-9-]*$", name: string & != "", partial: bool, default: bool}]'
 obsidian-linter: '[...{id: =~"^[a-z][a-z0-9-]*$", name: string & != "", partial: bool, default: bool}]'
+gomarklint: '[...{id: =~"^[a-z][a-z0-9-]*$", name: string & != "", partial: bool, default: bool}]'
 category: '"accessibility" | "code" | "directive" | "heading" | "line" | "link" | "list" | "prose" | "structural" | "table" | "whitespace"'
 ---
 # {id}: {name}
@@ -22,8 +23,9 @@ category: '"accessibility" | "code" | "directive" | "heading" | "line" | "link" 
      by mdsmith check against the literal CUE union in this file's
      `category:` front matter, which is hand-kept in sync with
      config.ValidCategories.
-     The `markdownlint:`, `rumdl:`, `mado:`, `panache:`, and
-     `obsidian-linter:` keys each list the peer linter's rules
+     The `markdownlint:`, `rumdl:`, `mado:`, `panache:`,
+     `obsidian-linter:`, and `gomarklint:` keys each list the
+     peer linter's rules
      that this mdsmith rule covers. Each entry has `id:`,
      `name:`, a required `partial: bool` (true when the mdsmith
      rule only partly covers the peer check), and a required
@@ -125,23 +127,26 @@ rules:
 
 <!-- Bullets in this order: ID, Name, Status, Default, Fixable,
      Implementation, Category, then one bullet per peer linter the rule
-     covers (markdownlint, rumdl, mado, panache, obsidian-linter), and
-     optionally Concept or Guide.
+     covers (markdownlint, rumdl, mado, panache, obsidian-linter,
+     gomarklint), and optionally Concept or Guide.
      Default may include key settings: "enabled, max: 80".
      Category must match the `category:` front-matter field and one
      of the values in ValidCategories. Pick the narrowest that fits.
 
      The peer-linter bullets above and their link-reference definitions
      are GENERATED from the `markdownlint:`/`rumdl:`/`mado:`/`panache:`/
-     `obsidian-linter:` front matter. Do not hand-write them; edit the
-     front matter and regenerate (the same data feeds the coverage
-     matrix):
+     `obsidian-linter:`/`gomarklint:` front matter. Do not hand-write
+     them; edit the front matter and regenerate (the same data feeds
+     the coverage matrix):
        MDSMITH_UPDATE_PEER_LINKS=1 go test ./internal/rules \
          -run TestRuleREADMEPeerLinks
      One bullet per peer with a non-empty list, one entry per covered
      rule (nested when more than one), "(partial)" marking a partial
      cover. markdownlint/rumdl/mado link the MDxxx id (mado shares one
-     `mado-rules` label -- it has no per-rule docs); panache and
+     `mado-rules` label -- it has no per-rule docs); gomarklint links
+     its kebab rule id through one shared `gomarklint-rules` label (a
+     single Rules page, and the bare name would collide with a shortcut
+     peer's label); panache and
      obsidian-linter use a bare `rule-name` shortcut reference. A
      definition past the line limit wraps onto an indented URL line.
      A rule whose peer lists are all empty has no peer bullets.

--- a/internal/rules/ruledocs.go
+++ b/internal/rules/ruledocs.go
@@ -29,6 +29,7 @@ type RuleInfo struct {
 	Mado            []RuleMapping
 	Panache         []RuleMapping
 	ObsidianLinter  []RuleMapping
+	Gomarklint      []RuleMapping
 }
 
 // RuleMapping names a rule in a peer Markdown linter that the mdsmith rule
@@ -170,13 +171,12 @@ func lookupRuleFromFS(fsys fs.FS, query string) (string, error) {
 	return "", fmt.Errorf("unknown rule %q", query)
 }
 
-// parseFrontMatter extracts id, name, status, description, and maintainability
-// from YAML front matter. Block scalars (`description: >-`) are folded; any
-// embedded newlines collapse to a single space so summaries render on one line.
-func parseFrontMatter(content string) (RuleInfo, error) {
+// frontMatterLines returns the raw lines between the opening and closing
+// front-matter fences, or an error when either fence is missing.
+func frontMatterLines(content string) ([]string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	if !scanner.Scan() || strings.TrimSpace(scanner.Text()) != "---" {
-		return RuleInfo{}, fmt.Errorf("missing front matter")
+		return nil, fmt.Errorf("missing front matter")
 	}
 
 	var front []string
@@ -190,10 +190,21 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 		front = append(front, line)
 	}
 	if err := scanner.Err(); err != nil {
-		return RuleInfo{}, fmt.Errorf("scanning front matter: %w", err)
+		return nil, fmt.Errorf("scanning front matter: %w", err)
 	}
 	if !terminated {
-		return RuleInfo{}, fmt.Errorf("unterminated front matter")
+		return nil, fmt.Errorf("unterminated front matter")
+	}
+	return front, nil
+}
+
+// parseFrontMatter extracts id, name, status, description, and maintainability
+// from YAML front matter. Block scalars (`description: >-`) are folded; any
+// embedded newlines collapse to a single space so summaries render on one line.
+func parseFrontMatter(content string) (RuleInfo, error) {
+	front, err := frontMatterLines(content)
+	if err != nil {
+		return RuleInfo{}, err
 	}
 	var meta struct {
 		ID              string           `yaml:"id"`
@@ -207,6 +218,7 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 		Mado            []RuleMapping    `yaml:"mado"`
 		Panache         []RuleMapping    `yaml:"panache"`
 		ObsidianLinter  []RuleMapping    `yaml:"obsidian-linter"`
+		Gomarklint      []RuleMapping    `yaml:"gomarklint"`
 	}
 	if err := yamlutil.UnmarshalSafe([]byte(strings.Join(front, "\n")), &meta); err != nil {
 		return RuleInfo{}, fmt.Errorf("parsing front matter: %w", err)
@@ -223,6 +235,7 @@ func parseFrontMatter(content string) (RuleInfo, error) {
 		Mado:            meta.Mado,
 		Panache:         meta.Panache,
 		ObsidianLinter:  meta.ObsidianLinter,
+		Gomarklint:      meta.Gomarklint,
 	}
 
 	if info.ID == "" {

--- a/internal/rules/ruledocs_test.go
+++ b/internal/rules/ruledocs_test.go
@@ -419,6 +419,10 @@ func TestParseFrontMatter_PeerLinterBlocks(t *testing.T) {
 		"  - id: heading-hierarchy\n" +
 		"    name: heading-hierarchy\n" +
 		"    default: false\n" +
+		"gomarklint:\n" +
+		"  - id: max-line-length\n" +
+		"    name: max-line-length\n" +
+		"    default: false\n" +
 		"---\n# Body\n"
 	info, err := parseFrontMatter(content)
 	require.NoError(t, err)
@@ -433,6 +437,30 @@ func TestParseFrontMatter_PeerLinterBlocks(t *testing.T) {
 	require.Len(t, info.Panache, 1)
 	assert.Equal(t, "heading-hierarchy", info.Panache[0].ID)
 	assert.False(t, info.Panache[0].Default)
+	require.Len(t, info.Gomarklint, 1)
+	assert.Equal(t, "max-line-length", info.Gomarklint[0].ID)
+	assert.False(t, info.Gomarklint[0].Default)
+}
+
+// TestFrontMatterLines covers the fence scanner on its own: the lines
+// between the fences come back verbatim, and a missing opening or
+// closing fence is an error.
+func TestFrontMatterLines(t *testing.T) {
+	t.Run("returns lines between fences", func(t *testing.T) {
+		front, err := frontMatterLines("---\nid: MDS999\nname: example\n---\n# Body\n")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"id: MDS999", "name: example"}, front)
+	})
+	t.Run("missing opening fence", func(t *testing.T) {
+		_, err := frontMatterLines("# Body\n")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing front matter")
+	})
+	t.Run("unterminated front matter", func(t *testing.T) {
+		_, err := frontMatterLines("---\nid: MDS999\n# Body\n")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unterminated front matter")
+	})
 }
 
 // TestParseFrontMatter_RejectsYAMLAliases verifies that the safe-YAML wrapper


### PR DESCRIPTION
Wires [gomarklint](https://github.com/shinagawa-web/gomarklint) (https://shinagawa-web.github.io/gomarklint/) into the peer-linter comparison, following the checklist in `docs/development/add-peer-linter.md`.

## What gomarklint is

A young (v3.2.x), MIT-licensed Go Markdown linter built for CI: 23 kebab-case rules, JSON config (`.gomarklint.json`), check-only (no autofix, no LSP), text/JSON output, GitHub Action + pre-commit support. All rules ship enabled except `external-link` and `max-line-length` (verified against `internal/config/config.go` upstream — the published migration page's "default off" note for `link-fragments` is stale).

## Changes per checklist step

1. **Schema** — `gomarklint:` key in `internal/rules/proto.md` and `directive-proto.md` (kebab-case id regex, required `partial`/`default`).
2. **Decoder** — `RuleInfo.Gomarklint` in `ruledocs.go`; peer-link generator renders one shared `gomarklint-rules` reference label (its docs put every rule on a single Rules page, like mado), with no parenthetical when a mapping's id equals its name. The shared label also avoids colliding with obsidian-linter's bare `no-bare-urls` shortcut label on MDS012. `parseFrontMatter` got a `frontMatterLines` extraction to stay inside the funlen budget.
3. **Coverage matrix** — gomarklint column in all nine peer catalog blocks, tables regenerated via `mdsmith fix`.
4. **Per-rule mappings** — all 68 rule READMEs seeded; 22 carry real mappings, validated against gomarklint's own [markdownlint migration table](https://shinagawa-web.github.io/gomarklint/docs/migration/). Notably MDS031 unclosed-code-block gains its first peer analog. `external-link` is the one gomarklint rule with no mdsmith analog (mdsmith makes no network calls at runtime).
5. **Regeneration** — peer-link bullets re-emitted via `MDSMITH_UPDATE_PEER_LINKS=1`.
6. **Comparison page** — `docs/background/markdown-linters.md` gains the gomarklint subsection (placed with the other lightweight native linters), a two-column table vs mdsmith, and a When to Use What entry.
7. **Benchmark** — gomarklint v3.2.3 is pinned into the `benchTools` manifest (`internal/release/bench.go`): Linux x86_64 release tarball, SHA-256 cross-checked against the publisher's `gomarklint_3.2.3_checksums.txt`, driven by `runHyperfine` on bare defaults. The binary was smoke-tested against this repo's docs tree (recursive directory walk, exit 1 on findings — covered by hyperfine's existing `-i`). The committed `data/*.json` snapshot is deliberately untouched: cross-tool ratios are only valid within one run on one machine, so the post-merge `benchmark.yml` run measures gomarklint from the merge onward, and the in-repo tables gain its row at the next deliberate `run.sh` refresh promoted in a PR. The benchmarks README documents exactly this.
8. **Skill instructions** — `add-peer-linter.md` step 7 was stale (it pointed at a `tools` list in `run.sh` that no longer exists); it now documents the `benchTools` pin, the `runHyperfine` command line, the `TestBenchManifestInvariants` guard, and the snapshot-refresh policy.

## Validation

- `mdsmith check .` — clean (462 files)
- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all pass except five pre-existing `internal/release` PGO tests that fail in this sandbox (forced commit signing breaks their temp-repo commits; they fail identically on an unmodified checkout)
- `golangci-lint run ./internal/rules/ ./internal/release/` — 0 issues
- gomarklint tarball: download + SHA-256 verified against publisher checksums; binary runs over a directory corpus in ~25 ms

https://claude.ai/code/session_012QX19ZcaDez27jawNykA5K