### PR TITLE
perf: pre-size cell slices, map[string]struct{} sets, and dead code removal

### DIFF
--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -426,15 +426,15 @@ func (p *projector) tableRows(n ast.Node) []any {
 			// keys, silently dropping every cell but the last.
 			// Surface it as a projection collision (once) rather
 			// than emitting lossy rows.
-			seen := make(map[string]bool, len(cols))
+			seen := make(map[string]struct{}, len(cols))
 			for _, c := range cols {
 				if c == "" {
 					continue
 				}
-				if seen[c] {
+				if _, ok := seen[c]; ok {
 					p.collision(c, "duplicate table column header")
 				}
-				seen[c] = true
+				seen[c] = struct{}{}
 			}
 			continue
 		}

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -233,9 +233,9 @@ func (f *Fixer) fixOnce(paths []string) *Result {
 	// sums would inflate Failures and WouldFix to N when only one
 	// underlying issue exists.
 	var allBefore, allAfter []lint.Diagnostic
-	var bytesChangedByPath map[string]bool
+	var bytesChangedByPath map[string]struct{}
 	if f.DryRun {
-		bytesChangedByPath = make(map[string]bool)
+		bytesChangedByPath = make(map[string]struct{})
 	}
 	for _, path := range paths {
 		if config.IsIgnored(f.Config.Ignore, path) {
@@ -251,7 +251,7 @@ func (f *Fixer) fixOnce(paths []string) *Result {
 			res.Modified = append(res.Modified, modified)
 		}
 		if f.DryRun && bytesChanged {
-			bytesChangedByPath[path] = true
+			bytesChangedByPath[path] = struct{}{}
 		}
 		res.Errors = append(res.Errors, errs...)
 	}
@@ -399,7 +399,7 @@ func keyOf(d lint.Diagnostic) diagKey {
 // WouldFix total by the number of files in the repo.
 func computeWouldFixAggregated(
 	allBefore, allAfter []lint.Diagnostic,
-	bytesChangedByPath map[string]bool,
+	bytesChangedByPath map[string]struct{},
 ) ([]WouldFixFile, int) {
 	beforeByFile := groupDiagsByFile(lint.DedupeDiagnostics(allBefore))
 	afterByFile := groupDiagsByFile(lint.DedupeDiagnostics(allAfter))
@@ -423,7 +423,8 @@ func computeWouldFixAggregated(
 	result := make([]WouldFixFile, 0, len(paths))
 	total := 0
 	for _, p := range paths {
-		wf := computeWouldFix(p, beforeByFile[p], afterByFile[p], bytesChangedByPath[p])
+		_, bytesChanged := bytesChangedByPath[p]
+		wf := computeWouldFix(p, beforeByFile[p], afterByFile[p], bytesChanged)
 		if wf == nil {
 			continue
 		}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1337,14 +1337,13 @@ func TestComputeWouldFixAggregated_DedupesByDiagnosticFile(t *testing.T) {
 	// entry is keyed by the diagnostic's File, and the count is not
 	// inflated by the number of host markdown files.
 	hostA := "a.md"
-	hostB := "b.md"
 	target := ".gitattributes"
 	allBefore := []lint.Diagnostic{
 		{File: target, Line: 1, Column: 1, RuleID: "MDS048", RuleName: "git-hook-sync", Message: "drift"},
 		{File: target, Line: 1, Column: 1, RuleID: "MDS048", RuleName: "git-hook-sync", Message: "drift"},
 	}
 	allAfter := []lint.Diagnostic{} // fixed across the run
-	bytesChangedByPath := map[string]bool{hostA: true, hostB: false}
+	bytesChangedByPath := map[string]struct{}{hostA: {}} // hostB omitted: bytes unchanged
 
 	files, total := computeWouldFixAggregated(allBefore, allAfter, bytesChangedByPath)
 	require.Equal(t, 1, total, "deduped MDS048 must contribute exactly 1 to WouldFix")

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1342,7 +1342,7 @@ func TestComputeWouldFixAggregated_DedupesByDiagnosticFile(t *testing.T) {
 		{File: target, Line: 1, Column: 1, RuleID: "MDS048", RuleName: "git-hook-sync", Message: "drift"},
 		{File: target, Line: 1, Column: 1, RuleID: "MDS048", RuleName: "git-hook-sync", Message: "drift"},
 	}
-	allAfter := []lint.Diagnostic{} // fixed across the run
+	allAfter := []lint.Diagnostic{}                      // fixed across the run
 	bytesChangedByPath := map[string]struct{}{hostA: {}} // hostB omitted: bytes unchanged
 
 	files, total := computeWouldFixAggregated(allBefore, allAfter, bytesChangedByPath)

--- a/internal/rules/tablefmt/race_off_test.go
+++ b/internal/rules/tablefmt/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package tablefmt
+
+const raceEnabled = false

--- a/internal/rules/tablefmt/race_on_test.go
+++ b/internal/rules/tablefmt/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package tablefmt
+
+const raceEnabled = true

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -198,6 +198,10 @@ const (
 // separatorRe matches a table separator row cell content.
 var separatorRe = regexp.MustCompile(`^:?-+:?$`)
 
+// pipeBytes is the single-byte separator used by bytes.Count to pre-size
+// the cells slice in splitRowBytes without a per-call allocation.
+var pipeBytes = []byte("|")
+
 // ScanTableBoundaries returns the 0-based [start, end] line-index pairs
 // (both inclusive) for each table block found in lines, without parsing
 // cell contents. codeLines maps 1-based line numbers of fenced or
@@ -468,8 +472,10 @@ func splitRow(row string) []string {
 		row = row[:len(row)-1]
 	}
 
-	// Split on unescaped pipes.
-	var cells []string
+	// Split on unescaped pipes. Pre-size to avoid slice-growth allocs in
+	// the tryParseTable hot path; pipe count is an upper bound (escaped
+	// pipes \| are not delimiters but counted anyway).
+	cells := make([]string, 0, strings.Count(row, "|")+1)
 	var current strings.Builder
 	for i := 0; i < len(row); i++ {
 		if row[i] == '\\' && i+1 < len(row) && row[i+1] == '|' {
@@ -501,7 +507,10 @@ func splitRowBytes(row []byte) []string {
 		row = row[:len(row)-1]
 	}
 
-	var cells []string
+	// Pre-size to avoid slice-growth allocs; bytes.Count is SIMD-accelerated
+	// for single-byte separators and over-estimates slightly for escaped
+	// pipes, which is fine for capacity.
+	cells := make([]string, 0, bytes.Count(row, pipeBytes)+1)
 	var current strings.Builder
 	for i := 0; i < len(row); i++ {
 		if row[i] == '\\' && i+1 < len(row) && row[i+1] == '|' {

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -198,10 +198,6 @@ const (
 // separatorRe matches a table separator row cell content.
 var separatorRe = regexp.MustCompile(`^:?-+:?$`)
 
-// pipeBytes is the single-byte separator used by bytes.Count to pre-size
-// the cells slice in splitRowBytes without a per-call allocation.
-var pipeBytes = []byte("|")
-
 // ScanTableBoundaries returns the 0-based [start, end] line-index pairs
 // (both inclusive) for each table block found in lines, without parsing
 // cell contents. codeLines maps 1-based line numbers of fenced or
@@ -507,10 +503,11 @@ func splitRowBytes(row []byte) []string {
 		row = row[:len(row)-1]
 	}
 
-	// Pre-size to avoid slice-growth allocs; bytes.Count is SIMD-accelerated
-	// for single-byte separators and over-estimates slightly for escaped
-	// pipes, which is fine for capacity.
-	cells := make([]string, 0, bytes.Count(row, pipeBytes)+1)
+	// Pre-size to avoid slice-growth allocs; over-estimates slightly for
+	// escaped \| pairs (which are not delimiters) but that is fine for
+	// capacity. []byte("|") is a stack-allocated needle; escape analysis
+	// confirms bytes.Count does not retain it.
+	cells := make([]string, 0, bytes.Count(row, []byte("|"))+1)
 	var current strings.Builder
 	for i := 0; i < len(row); i++ {
 		if row[i] == '\\' && i+1 < len(row) && row[i+1] == '|' {

--- a/internal/rules/tablefmt/tablefmt_test.go
+++ b/internal/rules/tablefmt/tablefmt_test.go
@@ -1054,3 +1054,52 @@ func TestTable_StructFieldsRoundTrip(t *testing.T) {
 		t.Errorf("tableEqual(tbl, tbl) must be true")
 	}
 }
+
+// --- Allocation budget tests ---
+
+// TestSplitRowBytes_AllocBudget verifies that splitRowBytes pre-sizes the
+// cells slice via make([]string, 0, n), eliminating append-growth allocs
+// in the tryParseTable hot path. Budget: make + builder-buf + one String()
+// per cell; no slice-growth allocs.
+func TestSplitRowBytes_AllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	row := []byte("| col one | col two | col three |")
+	_ = splitRowBytes(row) // warm up
+	const (
+		runs   = 100
+		budget = 7 // make(1) + builder-buf-growths(~3) + String()×3; no slice-growth allocs
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = splitRowBytes(row)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"splitRowBytes allocs/op = %.0f (budget=%d); pre-size cells slice to fix",
+		allocs, budget)
+}
+
+// TestSplitRow_AllocBudget verifies that splitRow pre-sizes its cells slice.
+func TestSplitRow_AllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	row := "| col one | col two | col three |"
+	_ = splitRow(row) // warm up
+	const (
+		runs   = 100
+		budget = 7 // make(1) + builder-buf-growths(~3) + String()×3; no slice-growth allocs
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = splitRow(row)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"splitRow allocs/op = %.0f (budget=%d); pre-size cells slice to fix",
+		allocs, budget)
+}

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -685,7 +685,9 @@ func countUnescapedPipes(b []byte) int {
 // one cell — because tablefmt parses it that way and the structure
 // pass must agree.
 func splitCells(s string) []string {
-	var cells []string
+	// Pre-size to avoid slice-growth allocs; pipe count over-estimates for
+	// escaped \| pairs but is cheap and keeps the hot path allocation-free.
+	cells := make([]string, 0, strings.Count(s, "|")+1)
 	var cur strings.Builder
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -678,35 +678,6 @@ func countUnescapedPipes(b []byte) int {
 	return n
 }
 
-// splitCells splits a row body on unescaped pipes. A `\|` pair is
-// kept inside the current cell as a literal escaped pipe, matching
-// tablefmt's GFM rule. Two leading backslashes do not enter a parity
-// dance — `\\|` is a literal backslash followed by an escaped pipe,
-// one cell — because tablefmt parses it that way and the structure
-// pass must agree.
-func splitCells(s string) []string {
-	// Pre-size to avoid slice-growth allocs; pipe count over-estimates for
-	// escaped \| pairs but is cheap and keeps the hot path allocation-free.
-	cells := make([]string, 0, strings.Count(s, "|")+1)
-	var cur strings.Builder
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case c == '\\' && i+1 < len(s) && s[i+1] == '|':
-			cur.WriteByte('\\')
-			cur.WriteByte('|')
-			i++ // skip the escaped pipe
-		case c == '|':
-			cells = append(cells, cur.String())
-			cur.Reset()
-		default:
-			cur.WriteByte(c)
-		}
-	}
-	cells = append(cells, cur.String())
-	return cells
-}
-
 func isBlank(line []byte) bool {
 	return len(bytes.TrimSpace(line)) == 0
 }

--- a/internal/rules/tableformat/structure_test.go
+++ b/internal/rules/tableformat/structure_test.go
@@ -548,20 +548,6 @@ func TestContainsUnescapedPipe(t *testing.T) {
 	assert.False(t, containsUnescapedPipe([]byte("plain text")))
 }
 
-func TestSplitCells_EscapedPipe(t *testing.T) {
-	// GFM (per tablefmt) treats `\|` as an escaped-pipe literal in a
-	// cell. The structure pass uses the same rule so the two passes
-	// agree on cell counts and edge detection for inputs containing
-	// `\|` or `\\|`. CommonMark's full backslash grammar (where `\\`
-	// would be a literal `\` so `\\|` becomes literal-backslash +
-	// unescaped-pipe-delimiter) is intentionally NOT honored inside
-	// table cells, matching tablefmt and GitHub's renderer.
-	assert.Equal(t, []string{"\\|"}, splitCells("\\|"))
-	assert.Equal(t, []string{"\\\\|"}, splitCells("\\\\|"))
-	assert.Equal(t, []string{"\\\\\\|"}, splitCells("\\\\\\|"))
-	assert.Equal(t, []string{"a ", " b"}, splitCells("a | b"))
-}
-
 func TestEscapedPipeOnlyParagraphNotHeader(t *testing.T) {
 	// "A \| B" contains only an escaped pipe; even when followed by a
 	// delimiter-looking row, it is not a table header.

--- a/internal/rules/tableformat/structure_test.go
+++ b/internal/rules/tableformat/structure_test.go
@@ -681,3 +681,27 @@ func TestFix_CRLF_RoundTrips_TableLines(t *testing.T) {
 		"reformatted table row must keep CRLF; got:\n%q", got)
 	assert.NotContains(t, got, "|\n", "no bare-LF line endings after a pipe row")
 }
+
+// TestSplitCells_AllocBudget verifies that splitCells pre-sizes the cells
+// slice via make([]string, 0, n), eliminating append-growth allocs in the
+// structure-check hot path. Budget: make + builder-buf + one String() per cell.
+func TestSplitCells_AllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	s := " col one | col two | col three "
+	_ = splitCells(s) // warm up
+	const (
+		runs   = 100
+		budget = 7 // make(1) + builder-buf-growths(~3) + String()×3; no slice-growth allocs
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = splitCells(s)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"splitCells allocs/op = %.0f (budget=%d); pre-size cells slice to fix",
+		allocs, budget)
+}

--- a/internal/rules/tableformat/structure_test.go
+++ b/internal/rules/tableformat/structure_test.go
@@ -681,27 +681,3 @@ func TestFix_CRLF_RoundTrips_TableLines(t *testing.T) {
 		"reformatted table row must keep CRLF; got:\n%q", got)
 	assert.NotContains(t, got, "|\n", "no bare-LF line endings after a pipe row")
 }
-
-// TestSplitCells_AllocBudget verifies that splitCells pre-sizes the cells
-// slice via make([]string, 0, n), eliminating append-growth allocs in the
-// structure-check hot path. Budget: make + builder-buf + one String() per cell.
-func TestSplitCells_AllocBudget(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	if raceEnabled {
-		t.Skip("alloc gate skipped under -race")
-	}
-	s := " col one | col two | col three "
-	_ = splitCells(s) // warm up
-	const (
-		runs   = 100
-		budget = 7 // make(1) + builder-buf-growths(~3) + String()×3; no slice-growth allocs
-	)
-	allocs := testing.AllocsPerRun(runs, func() {
-		_ = splitCells(s)
-	})
-	require.LessOrEqualf(t, allocs, float64(budget),
-		"splitCells allocs/op = %.0f (budget=%d); pre-size cells slice to fix",
-		allocs, budget)
-}


### PR DESCRIPTION
## Summary

Performance audit against `docs/development/high-performance-go.md`. Three targeted fixes eliminate unnecessary allocations in hot paths, plus dead code removal surfaced by three rounds of xhigh code review.

### Fixes

**1. Pre-size cell slices in table parsing hot paths** (`tablefmt/tablefmt.go`)

`splitRow` and `splitRowBytes` used `var cells []string` (nil slice, capacity 0), causing append-growth reallocations on every table row parse. Changed to `make([]string, 0, N)` where N is the pipe count (an upper bound). For a typical 4-column row, this eliminates 2–3 `mallocgc` calls per invocation.

- Guideline: *"Pre-size slices with make([]X, 0, n)"*
- Red/green gates: `TestSplitRowBytes_AllocBudget` and `TestSplitRow_AllocBudget` (budget: 7 allocs/op)

**2. `map[string]struct{}` set in `extract.go`** (`extract/extract.go`)

`tableRows` used `map[string]bool` for duplicate column-header detection. Changed to `map[string]struct{}` (zero-byte value vs 8-byte bool), saving one byte per stored entry.

- Guideline: *"map[K]struct{} for sets"*

**3. `map[string]struct{}` set in `fix.go`** (`fix/fix.go`)

`bytesChangedByPath` used `map[string]bool` as a presence set. Changed to `map[string]struct{}`. Updated `computeWouldFixAggregated` signature and all write/read sites.

- Guideline: *"map[K]struct{} for sets"*

### Code review findings addressed (3× xhigh passes)

**Round 1** — Fixed gofmt alignment in `fix_test.go`; removed mutable `var pipeBytes = []byte("|")` package-level slice (latent mutation hazard) and replaced with inline `[]byte("|")` literal (stack-allocated via escape analysis).

**Round 2** — Removed `TestSplitCells_AllocBudget`: the test was measuring a function (`splitCells` in `tableformat/structure.go`) with no production callers. Optimizing dead code is wasteful; the alloc test was adding noise to the test suite.

**Round 3** — Deleted `splitCells` and its test (`TestSplitCells_EscapedPipe`) entirely. The function had no production callers. The pre-sizing commit added a "hot path allocation-free" comment that was factually wrong for dead code; the correct altitude fix is deletion, not comment polishing.

## Test plan

- [x] `go test ./internal/rules/tablefmt/... ./internal/rules/tableformat/... ./internal/fix/... ./internal/extract/...` — all green
- [x] `go build ./...` — clean
- [x] `TestSplitRow_AllocBudget` / `TestSplitRowBytes_AllocBudget` — pass at ≤7 allocs/op
- [x] Codecov: 99.53% project coverage, all modified lines covered
- [x] Three xhigh code-review passes completed; all surviving CONFIRMED/PLAUSIBLE findings addressed

https://claude.ai/code/session_01RmRV1xH4mrAeXxu8AKXUoL