### PR TITLE
perf: cut check CPU across YAML, gitignore, glob, and word-count hot paths

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -187,4 +187,7 @@ footer: |
 | 2606111049 | ✅     |        | [Harden WASM size test to match production build](plan/2606111049_wasm-size-test-hardening.md)                                          |
 | 2606111050 | ✅     |        | [Guard schema.chmodFile with a mutex like fix.chmodFile](plan/2606111050_schema-chmodfile-mutex.md)                                     |
 | 2606120633 | ✅     |        | [Wire PGO into the release build without a committed profile](plan/2606120633_release-built-pgo-profile.md)                             |
+| 2606130836 | 🔲     | opus   | [Pool the per-file source-read buffer across lintFile passes](plan/2606130836_pool-source-read-buffer.md)                               |
+| 2606130837 | 🔲     | opus   | [Fast-path front-matter field reads for cross-file rules](plan/2606130837_frontmatter-fast-scan.md)                                     |
+| 2606130838 | 🔲     | sonnet | [Memoize linkgraph link and image extraction on the File](plan/2606130838_memoize-link-extraction.md)                                   |
 <?/catalog?>

--- a/internal/gitignore/gitignore.go
+++ b/internal/gitignore/gitignore.go
@@ -261,10 +261,27 @@ func (m *Matcher) DirChainIgnored(dir string, memo map[string]bool) bool {
 	return v
 }
 
+// relTo returns path relative to base, matching filepath.Rel for the
+// inputs the matcher sees (absolute, cleaned paths). The fast path is a
+// zero-allocation prefix strip — filepath.Rel re-cleans both arguments
+// on every call, which dominated the matcher's CPU when every rule of
+// every .gitignore recomputed it per candidate path. Inputs that do not
+// share the base prefix fall back to filepath.Rel for full fidelity.
+func relTo(base, path string) (string, error) {
+	if base == path {
+		return ".", nil
+	}
+	if len(path) > len(base) && path[len(base)] == filepath.Separator &&
+		path[:len(base)] == base {
+		return path[len(base)+1:], nil
+	}
+	return filepath.Rel(base, path)
+}
+
 // matchRule checks whether a single rule matches the given absolute path.
 func matchRule(r ignoreRule, absPath string) bool {
 	// Compute the path relative to the rule's base directory.
-	rel, err := filepath.Rel(r.base, absPath)
+	rel, err := relTo(r.base, absPath)
 	if err != nil {
 		return false
 	}

--- a/internal/gitignore/gitignore.go
+++ b/internal/gitignore/gitignore.go
@@ -261,37 +261,47 @@ func (m *Matcher) DirChainIgnored(dir string, memo map[string]bool) bool {
 	return v
 }
 
-// relTo returns path relative to base, matching filepath.Rel for the
-// inputs the matcher sees (absolute, cleaned paths). The fast path is a
-// zero-allocation prefix strip — filepath.Rel re-cleans both arguments
-// on every call, which dominated the matcher's CPU when every rule of
-// every .gitignore recomputed it per candidate path. Inputs that do not
-// share the base prefix fall back to filepath.Rel for full fidelity.
-func relTo(base, path string) (string, error) {
+// relTo returns path relative to base when path lies within base, with
+// ok=false when it does not (filepath.Rel would have produced a
+// ".."-prefixed result, which no gitignore rule can match). The fast
+// paths are zero-allocation prefix strips — filepath.Rel re-cleans both
+// arguments on every call, which dominated the matcher's CPU when every
+// rule of every .gitignore recomputed it per candidate path. Two
+// distinct rooted Unix paths settle on the prefix alone; anything else
+// (Windows volumes, relative inputs) falls back to filepath.Rel.
+func relTo(base, path string) (rel string, ok bool) {
 	if base == path {
-		return ".", nil
+		return ".", true
 	}
 	if len(path) > len(base) && path[len(base)] == filepath.Separator &&
 		path[:len(base)] == base {
-		return path[len(base)+1:], nil
+		return path[len(base)+1:], true
 	}
-	return filepath.Rel(base, path)
+	if base == string(filepath.Separator) &&
+		len(path) > 1 && path[0] == filepath.Separator {
+		return path[1:], true
+	}
+	if filepath.Separator == '/' &&
+		strings.HasPrefix(base, "/") && strings.HasPrefix(path, "/") {
+		return "", false
+	}
+	r, err := filepath.Rel(base, path)
+	if err != nil || r == ".." || strings.HasPrefix(r, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return r, true
 }
 
 // matchRule checks whether a single rule matches the given absolute path.
 func matchRule(r ignoreRule, absPath string) bool {
-	// Compute the path relative to the rule's base directory.
-	rel, err := relTo(r.base, absPath)
-	if err != nil {
+	// Compute the path relative to the rule's base directory; paths
+	// outside the rule's base never match.
+	rel, ok := relTo(r.base, absPath)
+	if !ok {
 		return false
 	}
 	// Normalize to forward slashes for matching.
 	rel = filepath.ToSlash(rel)
-
-	// Paths outside the rule's base should not match.
-	if strings.HasPrefix(rel, "..") {
-		return false
-	}
 
 	if r.hasSlash {
 		// Pattern contains a slash: match against the full relative path.

--- a/internal/gitignore/gitignore.go
+++ b/internal/gitignore/gitignore.go
@@ -303,6 +303,16 @@ func matchRule(r ignoreRule, absPath string) bool {
 	// Normalize to forward slashes for matching.
 	rel = filepath.ToSlash(rel)
 
+	// A relative form that still begins with ".." never matches: it
+	// either escapes the base or names a top segment literally
+	// starting with "..". relTo's fast path returns the uncleaned
+	// suffix, so this guard also covers an interior ".." in an
+	// uncleaned input — preserving the pre-relTo filepath.Rel form,
+	// which cleaned the path and then rejected a ".." prefix.
+	if strings.HasPrefix(rel, "..") {
+		return false
+	}
+
 	if r.hasSlash {
 		// Pattern contains a slash: match against the full relative path.
 		return matchGitignorePattern(r.pattern, rel)

--- a/internal/gitignore/gitignore_test.go
+++ b/internal/gitignore/gitignore_test.go
@@ -68,6 +68,22 @@ func TestRelTo_AgreesWithFilepathRel(t *testing.T) {
 	}
 }
 
+// TestRelTo_RelativeInputsFallBackToRel pins the filepath.Rel fallback
+// for inputs outside the absolute fast paths: relative bases and paths
+// (defensive — IsIgnored's contract is absolute paths) still resolve
+// exactly as filepath.Rel does, and unrelated relative trees report
+// ok=false.
+func TestRelTo_RelativeInputsFallBackToRel(t *testing.T) {
+	// "./repo" vs "repo/..." defeats the prefix strip but Rel still
+	// resolves it inside the base.
+	got, ok := relTo("./repo", "repo/sub/file.md")
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join("sub", "file.md"), got)
+
+	_, ok = relTo("repo/a", "other/b")
+	assert.False(t, ok, "unrelated relative trees yield a ..-prefixed Rel result")
+}
+
 // --- NewMatcher tests ---
 
 func TestNewMatcher_NoGitignore(t *testing.T) {

--- a/internal/gitignore/gitignore_test.go
+++ b/internal/gitignore/gitignore_test.go
@@ -37,6 +37,31 @@ func TestTrimTrailingWhitespace_AllWhitespace(t *testing.T) {
 	assert.Equal(t, "", trimTrailingWhitespace("   "))
 }
 
+// --- relTo tests ---
+
+// TestRelTo_AgreesWithFilepathRel pins the fast prefix-strip path to
+// filepath.Rel's answer for the absolute, cleaned inputs the matcher
+// sees, including paths outside the base.
+func TestRelTo_AgreesWithFilepathRel(t *testing.T) {
+	cases := []struct{ base, path string }{
+		{"/repo", "/repo/file.md"},
+		{"/repo", "/repo/sub/dir/file.md"},
+		{"/repo", "/repo"},
+		{"/repo/sub", "/repo/other/file.md"},
+		{"/repo/sub", "/repo/subdir/file.md"},
+		{"/", "/file.md"},
+		{"/a/b", "/a/bc/d"},
+	}
+	for _, tc := range cases {
+		want, wantErr := filepath.Rel(tc.base, tc.path)
+		got, gotErr := relTo(tc.base, tc.path)
+		assert.Equal(t, wantErr == nil, gotErr == nil, "err for (%q, %q)", tc.base, tc.path)
+		if wantErr == nil {
+			assert.Equal(t, want, got, "rel for (%q, %q)", tc.base, tc.path)
+		}
+	}
+}
+
 // --- NewMatcher tests ---
 
 func TestNewMatcher_NoGitignore(t *testing.T) {

--- a/internal/gitignore/gitignore_test.go
+++ b/internal/gitignore/gitignore_test.go
@@ -84,6 +84,23 @@ func TestRelTo_RelativeInputsFallBackToRel(t *testing.T) {
 	assert.False(t, ok, "unrelated relative trees yield a ..-prefixed Rel result")
 }
 
+// TestIsIgnored_DotDotPrefixedNameNeverMatches pins the guard that a
+// within-base entry whose basename begins with ".." is never matched,
+// matching the pre-relTo behavior (filepath.Rel returned "..name" and
+// the matcher rejected any ".."-prefixed relative form).
+func TestIsIgnored_DotDotPrefixedNameNeverMatches(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".gitignore"), []byte("*config\n..cache\n"), 0o644))
+	m := NewMatcher(dir)
+	// Both a "*config" glob and an exact "..cache" rule would match
+	// the basename if the ".." guard were dropped.
+	assert.False(t, m.IsIgnored(filepath.Join(dir, "..config"), false),
+		"a file named ..config must not be gitignore-matched")
+	assert.False(t, m.IsIgnored(filepath.Join(dir, "..cache"), true),
+		"a dir named ..cache must not be gitignore-matched")
+}
+
 // --- NewMatcher tests ---
 
 func TestNewMatcher_NoGitignore(t *testing.T) {

--- a/internal/gitignore/gitignore_test.go
+++ b/internal/gitignore/gitignore_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,9 +40,11 @@ func TestTrimTrailingWhitespace_AllWhitespace(t *testing.T) {
 
 // --- relTo tests ---
 
-// TestRelTo_AgreesWithFilepathRel pins the fast prefix-strip path to
-// filepath.Rel's answer for the absolute, cleaned inputs the matcher
-// sees, including paths outside the base.
+// TestRelTo_AgreesWithFilepathRel pins relTo to filepath.Rel's answer
+// for the absolute, cleaned inputs the matcher sees: within-base paths
+// return Rel's result with ok=true, and paths outside the base (where
+// Rel yields "" or a ".."-prefixed result no rule can match) return
+// ok=false.
 func TestRelTo_AgreesWithFilepathRel(t *testing.T) {
 	cases := []struct{ base, path string }{
 		{"/repo", "/repo/file.md"},
@@ -50,13 +53,16 @@ func TestRelTo_AgreesWithFilepathRel(t *testing.T) {
 		{"/repo/sub", "/repo/other/file.md"},
 		{"/repo/sub", "/repo/subdir/file.md"},
 		{"/", "/file.md"},
+		{"/", "/sub/file.md"},
 		{"/a/b", "/a/bc/d"},
+		{"/a/b/c", "/a/b"},
 	}
 	for _, tc := range cases {
 		want, wantErr := filepath.Rel(tc.base, tc.path)
-		got, gotErr := relTo(tc.base, tc.path)
-		assert.Equal(t, wantErr == nil, gotErr == nil, "err for (%q, %q)", tc.base, tc.path)
-		if wantErr == nil {
+		wantOK := wantErr == nil && want != ".." && !strings.HasPrefix(want, "../")
+		got, gotOK := relTo(tc.base, tc.path)
+		assert.Equal(t, wantOK, gotOK, "ok for (%q, %q)", tc.base, tc.path)
+		if wantOK {
 			assert.Equal(t, want, got, "rel for (%q, %q)", tc.base, tc.path)
 		}
 	}

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -52,22 +53,47 @@ func ContainsDotDotSegment(p string) bool {
 		strings.Contains(p, "/../")
 }
 
+// validPatterns caches doublestar.ValidatePattern verdicts. Match runs
+// once per pattern per file on the check hot path (ignore lists, kind
+// path-patterns, overrides), and doublestar.Match re-validates its
+// pattern on every call — the validation walk showed up as ~4% of check
+// CPU. Patterns reaching this package come from bounded config
+// surfaces, so the cache stays small for the life of the process.
+var validPatterns sync.Map // pattern string -> bool
+
+// patternValid reports whether pattern is a valid doublestar pattern,
+// memoizing the verdict.
+func patternValid(pattern string) bool {
+	if v, ok := validPatterns.Load(pattern); ok {
+		return v.(bool)
+	}
+	v := doublestar.ValidatePattern(pattern)
+	validPatterns.Store(pattern, v)
+	return v
+}
+
 // Match reports whether path matches pattern using the doublestar matcher.
 // It checks the raw path, the cleaned path, and the base name so that
 // patterns without path separators (e.g. "slides.md") match files in any
 // directory.
 // Invalid patterns return false.
 func Match(pattern, path string) bool {
-	cleanPath := filepath.Clean(path)
-	base := filepath.Base(path)
-
-	for _, candidate := range []string{path, cleanPath, base} {
-		if ok, err := doublestar.Match(
-			filepath.ToSlash(pattern),
-			filepath.ToSlash(candidate),
-		); err == nil && ok {
-			return true
-		}
+	pat := filepath.ToSlash(pattern)
+	if !patternValid(pat) {
+		return false
+	}
+	if doublestar.MatchUnvalidated(pat, filepath.ToSlash(path)) {
+		return true
+	}
+	// Identical candidates cannot change the verdict, so the cleaned
+	// path and base name only run when they differ from the raw path.
+	if cleanPath := filepath.Clean(path); cleanPath != path &&
+		doublestar.MatchUnvalidated(pat, filepath.ToSlash(cleanPath)) {
+		return true
+	}
+	if base := filepath.Base(path); base != path &&
+		doublestar.MatchUnvalidated(pat, filepath.ToSlash(base)) {
+		return true
 	}
 	return false
 }

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -62,14 +62,15 @@ func ContainsDotDotSegment(p string) bool {
 var validPatterns sync.Map // pattern string -> bool
 
 // patternValid reports whether pattern is a valid doublestar pattern,
-// memoizing the verdict.
+// memoizing the verdict. LoadOrStore collapses the miss path to one
+// map op and keeps concurrent first-touch callers from each storing
+// their own (identical) verdict.
 func patternValid(pattern string) bool {
 	if v, ok := validPatterns.Load(pattern); ok {
 		return v.(bool)
 	}
-	v := doublestar.ValidatePattern(pattern)
-	validPatterns.Store(pattern, v)
-	return v
+	actual, _ := validPatterns.LoadOrStore(pattern, doublestar.ValidatePattern(pattern))
+	return actual.(bool)
 }
 
 // Match reports whether path matches pattern using the doublestar matcher.

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -23,6 +23,11 @@ func TestMatch_Basename(t *testing.T) {
 func TestMatch_CleanedPath(t *testing.T) {
 	assert.True(t, globpath.Match("vendor/**", "vendor/./lib.md"),
 		"cleaned path: vendor/./lib.md should match vendor/**")
+	// "vendor/*.md" cannot match the raw "vendor/./lib.md" (the "."
+	// segment defeats the single-star), so only the cleaned-path
+	// candidate produces this match.
+	assert.True(t, globpath.Match("vendor/*.md", "vendor/./lib.md"),
+		"match must fall through to the cleaned-path candidate")
 }
 
 func TestMatch_DoubleStarRecursion(t *testing.T) {

--- a/internal/lint/files.go
+++ b/internal/lint/files.go
@@ -448,9 +448,11 @@ func addDirFiles(dir string, opts ResolveOpts, addFile func(string)) error {
 
 // walkDir recursively walks a directory and returns all markdown files.
 // When useGitignore is true, files matched by .gitignore patterns are skipped.
-// Symlinks are skipped unless followSymlinks is true. filepath.Walk is
-// Lstat-based, so symlinked directories encountered during the walk are
-// never descended into either way.
+// Symlinks are skipped unless followSymlinks is true. filepath.WalkDir
+// reports the Lstat-based entry type, so symlinked directories
+// encountered during the walk are never descended into either way —
+// and unlike filepath.Walk it costs no extra lstat per entry, which
+// was one syscall per workspace file on the check hot path.
 func walkDir(dir string, useGitignore, followSymlinks bool) ([]string, error) {
 	var matcher *gitignore.Matcher
 	if useGitignore {
@@ -458,15 +460,15 @@ func walkDir(dir string, useGitignore, followSymlinks bool) ([]string, error) {
 	}
 
 	var files []string
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Symlink entries always have Lstat-based info with
-		// IsDir()==false under filepath.Walk, so a plain return nil
-		// here also means Walk won't try to descend.
-		if info.Mode()&os.ModeSymlink != 0 {
+		// Symlink entries always have an Lstat-based type with
+		// IsDir()==false under filepath.WalkDir, so a plain return nil
+		// here also means WalkDir won't try to descend.
+		if d.Type()&os.ModeSymlink != 0 {
 			if !followSymlinks {
 				return nil
 			}
@@ -481,21 +483,21 @@ func walkDir(dir string, useGitignore, followSymlinks bool) ([]string, error) {
 			}
 		}
 
-		if matcher != nil && isGitignored(matcher, path, info.IsDir()) {
-			if info.IsDir() {
+		if matcher != nil && isGitignored(matcher, path, d.IsDir()) {
+			if d.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 		// Only regular files and opted-in symlinks (target regular,
 		// verified above) are markdown candidates. Skip FIFOs,
 		// devices, and sockets to avoid blocking reads later.
-		isSymlink := info.Mode()&os.ModeSymlink != 0
-		if !isSymlink && !info.Mode().IsRegular() {
+		isSymlink := d.Type()&os.ModeSymlink != 0
+		if !isSymlink && !d.Type().IsRegular() {
 			return nil
 		}
 		if isMarkdown(path) {

--- a/internal/mdtext/asciispace_internal_test.go
+++ b/internal/mdtext/asciispace_internal_test.go
@@ -1,0 +1,18 @@
+package mdtext
+
+import "testing"
+
+// TestASCIISpaceTableMatchesIsSpace ties the asciiSpace byte table to
+// IsSpace across the whole ASCII range. The byte-scan word counters
+// (CountWordsBytes, countWordsString, wordCounter.writeBytes) classify
+// ASCII through the table; the rune scans use IsSpace. If the two ever
+// disagree those counters would silently diverge from the rune scans.
+// This pins the two definitions to one another.
+func TestASCIISpaceTableMatchesIsSpace(t *testing.T) {
+	for c := 0; c < 0x80; c++ {
+		if asciiSpace[c] != IsSpace(rune(c)) {
+			t.Errorf("asciiSpace and IsSpace disagree on byte 0x%02x: table=%v IsSpace=%v",
+				c, asciiSpace[c], IsSpace(rune(c)))
+		}
+	}
+}

--- a/internal/mdtext/mdtext.go
+++ b/internal/mdtext/mdtext.go
@@ -197,6 +197,14 @@ func IsSpace(r rune) bool {
 	return unicode.IsSpace(r)
 }
 
+// asciiSpace marks the ASCII bytes [IsSpace] reports as spaces, so the
+// word-count scans below classify ASCII bytes with one table load
+// instead of a rune decode plus comparisons — the same table-driven
+// shape strings.Fields uses for its ASCII fast path.
+var asciiSpace = [utf8.RuneSelf]bool{
+	'\t': true, '\n': true, '\v': true, '\f': true, '\r': true, ' ': true,
+}
+
 // CountWords counts whitespace-delimited words in text. It is exactly
 // len(strings.Fields(text)) — a word is a maximal run of non-space
 // runes, space being [IsSpace] (exactly unicode.IsSpace) — but counts
@@ -205,14 +213,61 @@ func IsSpace(r rune) bool {
 // strings.Fields built only to be discarded was ~0.48 GB over the
 // 600-file check gate (plan 175 profiling).
 func CountWords(text string) int {
+	return countWordsString(text)
+}
+
+// CountWordsBytes is CountWords for a []byte source, so whole-file
+// callers (token-budget's heuristic mode) need not copy the source
+// into a string first.
+func CountWordsBytes(text []byte) int {
 	n := 0
 	inWord := false
-	for _, r := range text {
-		if IsSpace(r) {
-			inWord = false
+	for i := 0; i < len(text); {
+		c := text[i]
+		if c < utf8.RuneSelf {
+			i++
+			if asciiSpace[c] {
+				inWord = false
+			} else if !inWord {
+				inWord = true
+				n++
+			}
 			continue
 		}
-		if !inWord {
+		r, size := utf8.DecodeRune(text[i:])
+		i += size
+		if unicode.IsSpace(r) {
+			inWord = false
+		} else if !inWord {
+			inWord = true
+			n++
+		}
+	}
+	return n
+}
+
+// countWordsString mirrors [CountWordsBytes] for string input; the two
+// loops stay byte-identical in shape so they cannot drift.
+func countWordsString(text string) int {
+	n := 0
+	inWord := false
+	for i := 0; i < len(text); {
+		c := text[i]
+		if c < utf8.RuneSelf {
+			i++
+			if asciiSpace[c] {
+				inWord = false
+			} else if !inWord {
+				inWord = true
+				n++
+			}
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		i += size
+		if unicode.IsSpace(r) {
+			inWord = false
+		} else if !inWord {
 			inWord = true
 			n++
 		}

--- a/internal/mdtext/mdtext.go
+++ b/internal/mdtext/mdtext.go
@@ -306,20 +306,34 @@ type wordCounter struct {
 	inWord bool
 }
 
-// writeBytes folds b into the running count, decoding UTF-8 runes
-// one at a time. Equivalent to feeding b through [CountWords] except
-// that the inWord state is shared with later writeBytes / writeSpace
-// calls so two adjacent calls do not introduce a spurious word break.
+// writeBytes folds b into the running count. Equivalent to feeding b
+// through [CountWords] except that the inWord state is shared with
+// later writeBytes / writeSpace calls so two adjacent calls do not
+// introduce a spurious word break. ASCII bytes are classified through
+// the asciiSpace table without a rune decode, the same fast path
+// [CountWordsBytes] uses — this is the per-segment hot path
+// CountWordsInNode drives for every paragraph.
 func (wc *wordCounter) writeBytes(b []byte) {
 	for len(b) > 0 {
+		c := b[0]
+		if c < utf8.RuneSelf {
+			b = b[1:]
+			if asciiSpace[c] {
+				wc.inWord = false
+			} else if !wc.inWord {
+				wc.inWord = true
+				wc.n++
+			}
+			continue
+		}
 		r, size := utf8.DecodeRune(b)
+		b = b[size:]
 		if IsSpace(r) {
 			wc.inWord = false
 		} else if !wc.inWord {
 			wc.inWord = true
 			wc.n++
 		}
-		b = b[size:]
 	}
 }
 

--- a/internal/mdtext/mdtext.go
+++ b/internal/mdtext/mdtext.go
@@ -371,15 +371,18 @@ func CountSentences(text string) int {
 		return 0
 	}
 	count := 0
-	runes := []rune(text)
-	for i, r := range runes {
-		if r == '.' || r == '!' || r == '?' {
-			if i == len(runes)-1 {
-				count++
-			} else if IsSpace(runes[i+1]) {
-				count++
-			}
+	// Track whether the previous rune ended a sentence instead of
+	// materialising []rune(text) for lookahead — the rune slice was
+	// one whole-text allocation per call on the check hot path.
+	prevTerminal := false
+	for _, r := range text {
+		if prevTerminal && IsSpace(r) {
+			count++
 		}
+		prevTerminal = r == '.' || r == '!' || r == '?'
+	}
+	if prevTerminal {
+		count++
 	}
 	if count == 0 {
 		return 1

--- a/internal/mdtext/mdtext_test.go
+++ b/internal/mdtext/mdtext_test.go
@@ -127,6 +127,14 @@ func TestCountWordsInNode(t *testing.T) {
 			src: "Hello  \nworld.\n", want: 2},
 		{name: "Heading is walked like any other parent",
 			src: "# Hello world\n", want: 2},
+		// Non-ASCII text exercises writeBytes' multibyte decode path:
+		// accented letters are non-space runes...
+		{name: "multibyte non-ASCII words",
+			src: "café ünïcode wörds\n", want: 3},
+		// ...and a non-ASCII space (U+00A0 no-break space) is a word
+		// boundary on that same decode path.
+		{name: "non-ASCII space separates words",
+			src: "alpha beta\n", want: 2},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/mdtext/mdtext_test.go
+++ b/internal/mdtext/mdtext_test.go
@@ -221,6 +221,26 @@ func TestCountWords_EquivalentToStringsFields(t *testing.T) {
 
 // --- CountSentences tests ---
 
+func TestCountWordsBytes_EquivalentToCountWords(t *testing.T) {
+	cases := []string{
+		"",
+		"one",
+		"two words",
+		"  leading and trailing  ",
+		"tabs\tand\nnewlines",
+		"non breaking space", // U+00A0 is a Unicode space
+		"ünïcode wörds here", // U+2003 em space separates words
+		"　ideographic　space", // U+3000 space delimits
+		"mixed ascii  and line-sep",
+	}
+	for _, tc := range cases {
+		assert.Equal(t, mdtext.CountWords(tc), mdtext.CountWordsBytes([]byte(tc)),
+			"CountWordsBytes must agree with CountWords for %q", tc)
+	}
+	assert.Equal(t, 2, mdtext.CountWordsBytes([]byte("hello world")))
+	assert.Equal(t, 0, mdtext.CountWordsBytes(nil))
+}
+
 func TestCountSentences_OneSentence(t *testing.T) {
 	assert.Equal(t, 1, mdtext.CountSentences("Hello world."))
 }

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -886,27 +886,37 @@ func resolveGlobMatchesFrom(res globResolution, f *lint.File, params map[string]
 	}
 	var files []string
 	for _, pattern := range res.includes {
-		matches, err := doublestar.Glob(res.fs, pattern)
-		if err != nil {
-			continue
-		}
-		for _, m := range matches {
-			if _, ok := seen[m]; ok {
-				continue
-			}
-			info, err := fs.Stat(res.fs, m)
-			if err != nil || info.IsDir() {
-				continue
-			}
-			if isExcluded(m, res.excludes) {
-				continue
-			}
-			if matcher != nil && base != "" && isGitignoredMemo(matcher, base, m, dirVerdicts) {
-				continue
-			}
-			seen[m] = struct{}{}
-			files = append(files, m)
-		}
+		// GlobWalk hands over the walk's own DirEntry, so the
+		// regular-file check below costs no follow-up stat through
+		// res.fs — the former per-match fs.Stat was several syscalls
+		// per matched file through the os.Root-backed DirFS. Only
+		// symlink entries still stat, to keep the old follow
+		// semantics: a symlink to a file is included, a symlink to a
+		// directory (or a broken one) is skipped.
+		_ = doublestar.GlobWalk(res.fs, pattern,
+			func(m string, d fs.DirEntry) error {
+				if _, ok := seen[m]; ok {
+					return nil
+				}
+				if d.IsDir() {
+					return nil
+				}
+				if d.Type()&fs.ModeSymlink != 0 {
+					info, err := fs.Stat(res.fs, m)
+					if err != nil || info.IsDir() {
+						return nil
+					}
+				}
+				if isExcluded(m, res.excludes) {
+					return nil
+				}
+				if matcher != nil && base != "" && isGitignoredMemo(matcher, base, m, dirVerdicts) {
+					return nil
+				}
+				seen[m] = struct{}{}
+				files = append(files, m)
+				return nil
+			})
 	}
 	return files
 }

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -3710,6 +3711,37 @@ func TestSpec_GitignoreFiltersMatchedFiles(t *testing.T) {
 
 	indexPath := filepath.Join(dir, "index.md")
 	src := "<?catalog\nglob: \"**/*.md\"\n?>\n- [ok.md](sub/ok.md)\n- [visible.md](visible.md)\n<?/catalog?>\n"
+	f, err := lint.NewFile(indexPath, []byte(src))
+	require.NoError(t, err)
+	f.FS = os.DirFS(dir)
+	d := dir // capture for closure
+	f.GitignoreFunc = func() *gitignore.Matcher { return gitignore.NewMatcher(d) }
+
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestSpec_GlobSymlinks_FileFollowedDirAndBrokenSkipped(t *testing.T) {
+	// The glob walk's DirEntry reports symlinks without following
+	// them; the resolver stats those entries so a symlink to a file
+	// is catalogued, while a symlink to a directory and a broken
+	// symlink are skipped — the same follow semantics the per-match
+	// fs.Stat gave before the GlobWalk switch.
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on Windows")
+	}
+	dir := t.TempDir()
+
+	writeFile(t, dir, "real.md", "# Real\n")
+	mkdirAll(t, dir, "sub")
+	require.NoError(t, os.Symlink(filepath.Join(dir, "real.md"), filepath.Join(dir, "link.md")))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "sub"), filepath.Join(dir, "dirlink.md")))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "missing.md"), filepath.Join(dir, "broken.md")))
+
+	indexPath := filepath.Join(dir, "index.md")
+	src := "<?catalog\nglob: \"*.md\"\n?>\n" +
+		"- [link.md](link.md)\n- [real.md](real.md)\n<?/catalog?>\n"
 	f, err := lint.NewFile(indexPath, []byte(src))
 	require.NoError(t, err)
 	f.FS = os.DirFS(dir)

--- a/internal/rules/tokenbudget/rule.go
+++ b/internal/rules/tokenbudget/rule.go
@@ -70,10 +70,11 @@ func (r *Rule) Category() string { return "prose" }
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	budget := r.activeBudget(f.Path)
-	count, modeLabel := r.tokenCountAndMode(string(f.Source))
+	count := r.tokenCount(f.Source)
 	if count <= budget {
 		return nil
 	}
+	modeLabel := r.modeLabel()
 
 	overage := count - budget
 	tpw := r.TokensPerWord
@@ -124,28 +125,46 @@ func (r *Rule) activeBudget(path string) int {
 	return budget
 }
 
-func (r *Rule) tokenCountAndMode(text string) (int, string) {
+// tokenCount estimates the token count of source without copying it.
+// The mode label is built separately by modeLabel, only when a
+// diagnostic is actually emitted — formatting it for every under-budget
+// file was measurable on whole-corpus runs.
+func (r *Rule) tokenCount(source []byte) int {
 	switch normalizeMode(r.Mode) {
 	case "tokenizer":
 		tok := normalizeTokenizer(r.Tokenizer)
 		enc := normalizeEncoding(r.Encoding)
-		count := tokenizerCount(text, tok, enc)
-		return count, fmt.Sprintf("tokenizer:%s/%s", tok, enc)
+		return tokenizerCount(source, tok, enc)
 	default:
 		tpw := r.TokensPerWord
 		if tpw <= 0 {
 			tpw = defaultTokensPerWord
 		}
-		words := mdtext.CountWords(text)
+		words := mdtext.CountWordsBytes(source)
 		count := int(math.Round(float64(words) * tpw))
 		if count < 0 {
 			count = 0
 		}
-		return count, fmt.Sprintf("heuristic:tokens-per-word=%.2f", tpw)
+		return count
 	}
 }
 
-func tokenizerCount(text, tokenizer, encoding string) int {
+// modeLabel names the counting mode for the over-budget diagnostic.
+func (r *Rule) modeLabel() string {
+	switch normalizeMode(r.Mode) {
+	case "tokenizer":
+		return fmt.Sprintf("tokenizer:%s/%s",
+			normalizeTokenizer(r.Tokenizer), normalizeEncoding(r.Encoding))
+	default:
+		tpw := r.TokensPerWord
+		if tpw <= 0 {
+			tpw = defaultTokensPerWord
+		}
+		return fmt.Sprintf("heuristic:tokens-per-word=%.2f", tpw)
+	}
+}
+
+func tokenizerCount(text []byte, tokenizer, encoding string) int {
 	_ = tokenizer // reserved for future tokenizer families.
 
 	var re *regexp.Regexp
@@ -156,7 +175,7 @@ func tokenizerCount(text, tokenizer, encoding string) int {
 		re = cl100kPattern
 	}
 
-	return len(re.FindAllStringIndex(text, -1))
+	return len(re.FindAllIndex(text, -1))
 }
 
 // ApplySettings implements rule.Configurable.

--- a/internal/rules/tokenbudget/rule_test.go
+++ b/internal/rules/tokenbudget/rule_test.go
@@ -40,6 +40,18 @@ func TestCheck_HeuristicBudgetExceeded(t *testing.T) {
 		"message should include words-over-budget estimate, got: %s", d.Message)
 }
 
+func TestCheck_HeuristicZeroTokensPerWord_LabelsDefault(t *testing.T) {
+	// A zero TokensPerWord falls back to the default ratio in both the
+	// count and the diagnostic's mode label.
+	f := mustFile(t, "test.md", "one two three four five six")
+	r := &Rule{Max: 3, Mode: "heuristic"}
+	diags := r.Check(f)
+
+	require.Len(t, diags, 1, "expected 1 diagnostic, got %d", len(diags))
+	require.Contains(t, diags[0].Message, "mode=heuristic:tokens-per-word=1.33",
+		"label must show the default ratio, got: %s", diags[0].Message)
+}
+
 func TestCheck_HeuristicAtBudget_NoDiagnostic(t *testing.T) {
 	f := mustFile(t, "test.md", "one two three four")
 	r := &Rule{Max: 4, Mode: "heuristic", TokensPerWord: 1.0}

--- a/internal/yamlutil/yamlutil.go
+++ b/internal/yamlutil/yamlutil.go
@@ -66,28 +66,77 @@ func RejectYAMLAliases(data []byte) error {
 	}
 }
 
+// parseSafeDocuments decodes data document by document into yaml.Node
+// trees, rejecting anchors/aliases anywhere in the stream, and returns
+// the first document's node (nil when the input holds no document).
+// Decoding into yaml.Node does not expand aliases, so the scan is safe
+// even for billion-laughs payloads. A syntax error in the first
+// document is returned for the caller's decode step to surface; a
+// syntax error in a later document ends the scan silently, matching
+// yaml.Unmarshal, which never reads past the first document.
+//
+// This single parse replaces the former RejectYAMLAliases + raw-decode
+// pair inside the wrappers below: front matter and directive bodies
+// are parsed once per call instead of twice.
+func parseSafeDocuments(data []byte) (*yaml.Node, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	var first *yaml.Node
+	for i := 0; ; i++ {
+		var doc yaml.Node
+		err := dec.Decode(&doc)
+		if err == io.EOF {
+			return first, nil
+		}
+		if err != nil {
+			// An undefined alias causes a parse error containing
+			// "unknown anchor". Reject this as evidence of alias usage.
+			if strings.Contains(err.Error(), "unknown anchor") {
+				return nil, fmt.Errorf("yaml anchors/aliases are not permitted")
+			}
+			if i == 0 {
+				return nil, err
+			}
+			return first, nil
+		}
+		if hasYAMLAnchorOrAlias(&doc) {
+			return nil, fmt.Errorf("yaml anchors/aliases are not permitted")
+		}
+		if i == 0 {
+			first = &doc
+		}
+	}
+}
+
 // UnmarshalSafe rejects YAML anchors/aliases then unmarshals data into v.
 // Use this for all user-supplied YAML content (config files, front matter,
 // directive parameters).
 func UnmarshalSafe(data []byte, v any) error {
-	if err := RejectYAMLAliases(data); err != nil {
+	first, err := parseSafeDocuments(data)
+	if err != nil {
 		return err
 	}
-	return yaml.Unmarshal(data, v)
+	if first == nil {
+		// No document: leave v at its zero value, like yaml.Unmarshal.
+		return nil
+	}
+	return first.Decode(v)
 }
 
 // UnmarshalNodeSafe rejects YAML anchors/aliases then unmarshals data into a
 // yaml.Node document node. Use this when raw node inspection is needed before
 // typed decoding (e.g. checking top-level key presence or tag types).
 func UnmarshalNodeSafe(data []byte) (yaml.Node, error) {
-	if err := RejectYAMLAliases(data); err != nil {
+	first, err := parseSafeDocuments(data)
+	if err != nil {
 		return yaml.Node{}, err
 	}
-	var node yaml.Node
-	if err := yaml.Unmarshal(data, &node); err != nil {
-		return yaml.Node{}, err
+	if first == nil {
+		return yaml.Node{}, nil
 	}
-	return node, nil
+	return *first, nil
 }
 
 // Marshal is a thin wrapper around yaml.Marshal for consistency with

--- a/internal/yamlutil/yamlutil_test.go
+++ b/internal/yamlutil/yamlutil_test.go
@@ -79,6 +79,27 @@ func TestUnmarshalSafe(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "", out.Title)
 	})
+
+	t.Run("rejects undefined alias", func(t *testing.T) {
+		// An alias with no anchor surfaces as a parse error containing
+		// "unknown anchor", which the scan converts to the alias
+		// rejection like a defined one.
+		var out map[string]any
+		err := yamlutil.UnmarshalSafe([]byte("key: *missing\n"), &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "anchors/aliases are not permitted")
+	})
+
+	t.Run("syntax error in a later document decodes the first", func(t *testing.T) {
+		// yaml.Unmarshal never reads past the first document, so a
+		// malformed second document must not fail the decode.
+		var out struct {
+			Title string `yaml:"title"`
+		}
+		err := yamlutil.UnmarshalSafe([]byte("title: a\n---\nkey: [unclosed\n"), &out)
+		require.NoError(t, err)
+		assert.Equal(t, "a", out.Title)
+	})
 }
 
 func TestUnmarshalNodeSafe(t *testing.T) {

--- a/plan/2606130836_pool-source-read-buffer.md
+++ b/plan/2606130836_pool-source-read-buffer.md
@@ -1,0 +1,120 @@
+---
+id: 2606130836
+title: Pool the per-file source-read buffer across lintFile passes
+status: "🔲"
+model: opus
+summary: >-
+  bytelimit.readAllSized is the top allocator on a check run
+  (~10 MB / ~10% of alloc_space on the repo corpus). Every
+  workspace file's source bytes are a fresh allocation that dies
+  with the File. lintFile already owns a clean release boundary
+  (the arena pool's release closure), so pool the source buffer
+  on that same boundary the way plan 198 pooled the parse arena.
+depends-on: []
+---
+# Pool the per-file source-read buffer across lintFile passes
+
+## Goal
+
+Reuse one pooled byte buffer per worker for the file source on
+`mdsmith check`. Today the engine allocates a fresh `source` slice
+for every workspace file. That slice is the largest remaining
+allocator the PR #600 profiling found.
+
+## Background
+
+An `-alloc_space` profile of `mdsmith check` over the repo
+benchmark corpus ranks
+[`bytelimit.readAllSized`](../internal/bytelimit/bytelimit.go) as
+the top allocator. It accounts for about 10.6 MB, near 10% of all
+bytes allocated on the run. The profile was taken after the PR #600
+changes.
+
+That buffer holds a file's full source bytes. The engine reads it
+once per file in
+[`Runner.lintFile`](../internal/engine/runner.go). The parsed
+`*lint.File` then aliases it. `Source` points at it, and the
+`Lines` slices come from `bytes.Split` over it.
+
+The slice is garbage the moment the File dies. lintFile already
+marks that point. The `release()` closure from
+[`NewFileFromSourcePooled`](../internal/lint/filepool.go) is
+deferred in lintFile. It resets and returns the parse arena.
+
+Plan 198 set up this boundary for arena slabs. It also documented
+the rule: diagnostics carry only copied strings and ints. So after
+`release()` the File and its aliased memory are dead. The source
+buffer has the same lifetime. It can ride the same boundary.
+
+This is a measured allocation lever, not a CPU rewrite. The
+goldmark parse and the cross-file caches dominate CPU. This plan
+targets GC pressure instead. The alloc budget and the
+`BenchmarkCheckCorpus*` wall-time gates both observe it.
+
+## Design
+
+Add a process-wide `sync.Pool` of `*[]byte` source buffers. lintFile
+draws one and returns it from the same `release()` closure that
+returns the arena. The read path fills a pooled buffer instead of
+allocating fresh.
+
+These constraints keep it sound:
+
+- Only the engine's `lintFile` uses the pooled read. It is the one
+  caller whose File provably dies before `release()`. Every other
+  reader keeps the plain allocating read. That set is the LSP
+  `ParseCache`, the `RunCache` target loads, and `mdsmith export`.
+  Those callers already keep `NewFileFromSource` over the pooled
+  variant for the same reason.
+- The buffer returns only inside the existing `release()`. By then
+  Check has returned and diagnostics are copied out. The File, its
+  `Lines`, and any output aliasing `Source` are done.
+- Buffers vary up to the 2 MB input cap. On `Get`, reslice to the
+  needed length. Grow only when capacity is short. One large file
+  must not permanently inflate every pooled buffer.
+- The overflow semantics stay. The read still checks `max+1` and
+  flags a too-large file. This is an allocation change only.
+
+The cleanest seam is a new `bytelimit` entry point that fills a
+caller-owned buffer (for example `ReadFileLimitedInto`). lintFile
+owns the pool. The existing `ReadFileLimited` delegates to it with
+a nil buffer, so its callers are unchanged.
+
+## Tasks
+
+1. [ ] Add a failing alloc-focused benchmark or test. It pins the
+   per-file source allocation count on the engine check path. The
+   win is then observable and regression-gated.
+2. [ ] Add the buffer-filling read entry point in
+   [`internal/bytelimit`](../internal/bytelimit/bytelimit.go). Keep
+   the `max+1` overflow check. Add unit tests for the in-cap,
+   at-cap, over-cap, grow-needed, and reuse cases.
+3. [ ] Add the `sync.Pool` of source buffers in
+   [`internal/engine`](../internal/engine/runner.go). Draw in
+   lintFile. Return it from the existing `release()` closure so the
+   buffer and the arena share one lifetime boundary.
+4. [ ] Confirm no other caller is on the pooled path. Leave
+   `NewFileFromSource` and plain `ReadFileLimited` callers as they
+   are.
+5. [ ] Verify behaviour is unchanged. Run the integration fixtures,
+   `go test -race ./...`, and `mdsmith check .`.
+6. [ ] Re-profile `-alloc_space` on both corpora. Record the
+   measured drop, or a negative result, in this plan.
+
+## Acceptance Criteria
+
+- [ ] The engine check path does no per-file source-buffer
+      allocation in steady state. The new benchmark or test pins
+      this.
+- [ ] Source-read bytes fall measurably on the repo-corpus
+      `-alloc_space` profile. The number is recorded here.
+- [ ] No reader whose File outlives the call uses the pooled
+      buffer. That set is the LSP ParseCache, RunCache target
+      loads, and export.
+- [ ] Byte-limit overflow behaviour is unchanged for in-cap,
+      at-cap, and over-cap files.
+- [ ] `BenchmarkCheckCorpus{Small,Large}` stay within budget.
+- [ ] `mdsmith check .` passes (generated sections in sync).
+- [ ] All tests pass, race-clean: `go test -race ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint run` reports no
+      issues.

--- a/plan/2606130837_frontmatter-fast-scan.md
+++ b/plan/2606130837_frontmatter-fast-scan.md
@@ -1,0 +1,123 @@
+---
+id: 2606130837
+title: Fast-path front-matter field reads for cross-file rules
+status: "🔲"
+model: opus
+summary: >-
+  The catalog rule reads every globbed target's front matter
+  through a full yaml.v3 decode. On the repo corpus those decodes
+  are the dominant cross-file cost (yaml parser/node allocations
+  ~6-9 MB plus CPU). Add a line scanner for the common flat-scalar
+  front matter that falls back to the full safe decode on anything
+  non-trivial, preserving alias rejection.
+depends-on: []
+---
+# Fast-path front-matter field reads for cross-file rules
+
+## Goal
+
+Read flat `key: scalar` front matter from cross-file targets with a
+direct line scan. Keep the full yaml.v3 decode only for front
+matter that needs it. The catalog directive reads one target per
+globbed file, so this is its hot path. Parsed values and the
+YAML-safety guarantee must not change.
+
+## Background
+
+A CPU profile of `mdsmith check` over the repo corpus still shows
+[`catalog.cachedFrontMatter`](../internal/rules/catalog/rule.go) as
+a top cross-file cost. It calls `readFrontMatter`, which calls
+`yamlutil.UnmarshalSafe`. The profile was taken after the PR #600
+single-parse YAML change.
+
+The reads add up because catalogs glob wide. The `CLAUDE.md`
+catalog globs the whole `docs/**` tree and reads each file's
+`summary`. The `PLAN.md` catalog reads every `plan/*.md`. The
+`-alloc_space` profile charges several MB to the yaml.v3 parser and
+node tree on this path.
+
+Plan 192 already de-duplicates these reads across host files. A
+target globbed by N catalogs is parsed once. The residual cost is
+the first parse of each distinct target. Front matter here is
+almost always a flat mapping of scalar values. Common keys are
+`title`, `summary`, `status`, `model`, and `id`. A single line scan
+reads that far cheaper than a yaml.v3 decoder and a node tree.
+
+## Design
+
+Add a fast-path reader. It returns the same scalar-map shape
+`readFrontMatter` produces today. It runs only for inputs it can
+read with certainty:
+
+- Walk the stripped front-matter bytes line by line. Accept a line
+  only when it is a top-level `key: scalar` pair. The key must have
+  no leading indentation. The value must be a plain or simply
+  quoted scalar. The line must carry no YAML metacharacter that
+  changes meaning. Those include `&`, `*`, `<<`, `|`, `>`, `?`,
+  `[`, `{`, a `#` comment mid-value, and an empty value that opens
+  a nested mapping.
+- Bail out the instant a line leaves that grammar. Triggers are
+  nesting, sequences, block scalars, multi-document markers,
+  anchors, and aliases. On bail-out, fall back to the existing
+  `yamlutil.UnmarshalSafe`.
+- The fallback preserves the security property. It already rejects
+  anchors and aliases. A billion-laughs payload is not flat
+  scalars, so it never reaches the fast path. The fallback rejects
+  it as it does today.
+- Scalar canonicalization must match yaml. Quoted versus bare, and
+  int and bool spellings, must agree. Otherwise catalog rows and
+  `unique-frontmatter` comparisons would shift. Reuse the
+  canonicalization already in
+  [`yamlutil`](../internal/yamlutil/yamlutil.go). It lives in
+  `TopLevelScalarField` and `canonicalScalar`.
+
+A differential test gates correctness. For a set of real and
+adversarial samples, the fast path must either return exactly what
+`UnmarshalSafe` returns or defer to it. Any other outcome fails the
+test.
+
+The change is opt-in at the call site. Only cross-file readers that
+want a few scalar fields route through it. The catalog is the first
+such reader. The generic `lint.ParseFrontMatter` typed-struct path
+stays on yaml.
+
+## Tasks
+
+1. [ ] Add a differential test harness. It runs the fast path and
+   `yamlutil.UnmarshalSafe` over one shared sample set. The set
+   covers flat scalars and quoted, int, and bool spellings. It also
+   covers nesting, sequences, block scalars, multi-doc, anchors,
+   and aliases. It asserts equality or fallback.
+2. [ ] Implement the flat-scalar line scanner with the bail-out
+   grammar above. Reuse `yamlutil` canonicalization. Fall back to
+   `UnmarshalSafe` on any non-flat or metacharacter-bearing input.
+3. [ ] Route
+   [`catalog.readFrontMatter`](../internal/rules/catalog/rule.go)
+   through the fast path. Keep the RunCache slot and shape so plan
+   192 cross-host sharing still holds.
+4. [ ] Add a test that hostile front matter reaching the catalog
+   still has its anchors and aliases rejected, via the fallback.
+5. [ ] Verify behaviour. Run the integration fixtures,
+   `go test ./...`, and `mdsmith check .`. The `CLAUDE.md` and
+   `PLAN.md` catalogs must regenerate byte-identically.
+6. [ ] Re-profile both corpora. Record the measured CPU and alloc
+   delta, or a negative, in this plan.
+
+## Acceptance Criteria
+
+- [ ] The fast path returns values byte-identical to
+      `yamlutil.UnmarshalSafe` for every flat-scalar sample. It
+      defers for every non-flat or metacharacter-bearing one. The
+      differential test pins this.
+- [ ] Anchors and aliases in catalog-read front matter are still
+      rejected, via the fallback. A test pins this.
+- [ ] `CLAUDE.md` and `PLAN.md` catalog bodies regenerate
+      unchanged under `mdsmith fix`.
+- [ ] Cross-file front-matter CPU and yaml allocations fall
+      measurably on the repo-corpus profile. The number is recorded
+      here.
+- [ ] `BenchmarkCheckCorpus{Small,Large}` stay within budget.
+- [ ] `mdsmith check .` passes (generated sections in sync).
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint run` reports no
+      issues.

--- a/plan/2606130838_memoize-link-extraction.md
+++ b/plan/2606130838_memoize-link-extraction.md
@@ -1,0 +1,94 @@
+---
+id: 2606130838
+title: Memoize linkgraph link and image extraction on the File
+status: "🔲"
+model: sonnet
+summary: >-
+  linkgraph.ExtractLinks runs a fresh ast.Walk on every call and is
+  not memoized. crossfilereferenceintegrity and mdsmith deps both
+  walk it per file. Memoize the link and image collections on the
+  per-Check File, the way plan 187 memoized CollectSectionParagraphs,
+  so the link walk runs once per file rather than per caller.
+depends-on: []
+---
+# Memoize linkgraph link and image extraction on the File
+
+## Goal
+
+Run the link-and-image AST walk once per file. Today
+[`linkgraph.ExtractLinks`](../internal/linkgraph/linkgraph.go) walks
+`f.AST` fresh on every call. Memoize the result on the per-Check
+`*lint.File` so repeated callers share one walk.
+
+## Background
+
+A CPU profile of `mdsmith check` over the repo corpus, taken after
+PR #600, shows `linkgraph.ExtractLinks` at roughly 7%. It is its
+own `ast.Walk`, separate from the engine's multiplexed walk.
+
+`ExtractLinks` is not memoized. It rebuilds the link slice on each
+call. The MDS027 cross-file-reference-integrity rule calls it
+during Check. The `mdsmith deps` command and the LSP
+call-hierarchy walk the same graph. Each entry point pays its own
+full walk.
+
+Plan 187 set the pattern to copy. It memoized
+`astutil.CollectSectionParagraphs` on the File via the `File.Memo`
+primitive. The prose rules then shared one paragraph walk. The same
+primitive fits link extraction. The collection is a pure function
+of `f.AST`, so one cached slice serves every caller.
+
+This is a single-rule lever on the check path, so the gain is
+modest. The value is the removed redundant walk and a shared seam
+that `deps` and the LSP can reuse. It does not touch the
+multiplexed walk, which plans 189 and 2606022128 already settled.
+
+## Design
+
+Memoize the link and image slices on the File:
+
+- Add memoized accessors built on `File.Memo`, keyed per
+  collection. `ExtractLinks` and `ExtractImages` compute once and
+  cache the result on the File.
+- The cached slice is read-only for callers. They already treat the
+  returned slice as a value to range over, so no caller mutates it.
+- The result must stay byte-identical to today's output. Order is
+  document order. Lines are body-relative. Reference-style links
+  are still skipped the same way.
+- Keep the lifetime inside one Check. The memo lives on the File,
+  which the engine builds per file and discards after Check. No
+  cross-file or cross-run caching is added here.
+
+## Tasks
+
+1. [ ] Add a test that pins reference identity. Two calls to the
+   memoized link accessor on one File return the same backing slice.
+   A second test pins identical contents to the current
+   `ExtractLinks` output across a fixture set.
+2. [ ] Memoize `ExtractLinks` and `ExtractImages` on the File via
+   `File.Memo`, keyed per collection.
+3. [ ] Point the MDS027 cross-file-reference-integrity rule at the
+   memoized accessor.
+4. [ ] Point the `mdsmith deps` command and any LSP caller that
+   walks links at the same accessor, where they operate on a live
+   per-Check File.
+5. [ ] Verify behaviour. Run the integration fixtures,
+   `go test ./...`, and `mdsmith check .`. Diagnostics and `deps`
+   output are unchanged.
+6. [ ] Re-profile the repo corpus. Record the measured delta, or a
+   negative, in this plan.
+
+## Acceptance Criteria
+
+- [ ] The memoized accessor runs the link walk once per File,
+      pinned by a reference-identity test.
+- [ ] Link and image collections are byte-identical to the current
+      `ExtractLinks` and `ExtractImages` output across the fixture
+      set.
+- [ ] `crossfilereferenceintegrity` diagnostics and `mdsmith deps`
+      output are unchanged.
+- [ ] `BenchmarkCheckCorpus{Small,Large}` stay within budget.
+- [ ] `mdsmith check .` passes (generated sections in sync).
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint run` reports no
+      issues.


### PR DESCRIPTION
## Goal

Drive `mdsmith check` (full default rule set) toward gomarklint's wall time on the two benchmark corpora.

## What changed

Four profiling-driven rounds, each behavior-preserving and verified against the full test suite:

1. **Single-parse YAML safety wrappers** (`internal/yamlutil`). `UnmarshalSafe` / `UnmarshalNodeSafe` parsed every payload twice — once into a `yaml.Node` tree for anchor/alias rejection, then a full `yaml.Unmarshal` re-parse. `parseSafeDocuments` keeps the node from the rejection scan and decodes it directly. This halves YAML parse cost on every front matter and directive body (~19% of repo-corpus CPU before the fix).
2. **Zero-alloc gitignore rel paths + out-of-tree short-circuit** (`internal/gitignore`). `matchRule` called `filepath.Rel` per rule per candidate path (~8% of repo-corpus CPU). `relTo` strips the base prefix without allocation, and paths outside a rule's base (every ancestor-`.gitignore` rule) now return "no match" without paying `Rel`'s Clean allocations.
3. **Cached glob validation + byte-table word counts + lazy token-budget label.** `globpath.Match` re-validated its pattern through `doublestar.Match` on every call; a validity cache plus `MatchUnvalidated` removes the repeated validation walk. `CountWords` gains an ASCII byte-table fast path, mirrored in a new `CountWordsBytes` that token-budget uses directly on `f.Source` instead of copying each whole file into a string; the diagnostic mode label is now built only when a file is actually over budget.
4. **WalkDir-based file walk, stat-free catalog globs, allocation-free `CountSentences`.** `lint.walkDir` moves from `filepath.Walk` (one extra lstat per entry) to `filepath.WalkDir`; catalog glob resolution reuses `GlobWalk`'s `DirEntry` instead of a follow-up `fs.Stat` per match (each avoided stat was an open/fcntl/fcntl/stat/close sequence through the os.Root-backed DirFS); `CountSentences` no longer materialises `[]rune(text)` per call.

## Measured effect (local 4-core, harness-equivalent setup: corpus built per `internal/release/bench.go`, run from the repo root, pinned gomarklint v3.2.3, median of 12 runs)

| Corpus | mdsmith before | mdsmith after | gomarklint | gap before | gap after |
| --- | --- | --- | --- | --- | --- |
| repo (768 files) | 240 ms | 209 ms | ~80 ms | 3.4x | 2.5x |
| neutral (233 files) | 175 ms | 163 ms | ~40 ms | 4.4x | 4.1x |

Total syscalls on the repo corpus drop from ~41.4k to ~37.8k; sys time from ~148 ms to ~95 ms; user+sys CPU from ~720 ms to ~640 ms.

## Honest assessment of the remaining gap

Full parity with gomarklint is not reachable by micro-optimization while the default rule set keeps its current scope. The post-change profile is dominated by work gomarklint does not do at all:

- goldmark AST parse (~17% repo CPU) — gomarklint is line-oriented;
- catalog/include generated-section regeneration and the cross-file front-matter/glob caches (~20% repo CPU, mostly once-per-run);
- the Punkt sentence segmenter behind MDS024 (~27% of neutral CPU) — opt-in by default but enabled by this repo's `.mdsmith.yml`, which both benchmark rows run under; plan 187 already established no faster pure-Go equivalent and a sound skip-gate stronger than the existing `cheapBounds` would amount to re-implementing the annotation pipeline;
- cross-file link integrity, token budgets, and readability scoring.

That structural framing matches the benchmark README: `mdsmith-parity` (same work class as the markdownlint-family tools) already runs in gomarklint/mado's class; the `mdsmith` → `parity` delta is the cross-file and generated-content layer users opt into. The wins here narrow the full-ruleset gap (repo corpus 3.4x → 2.5x) and also speed up the parity row, since the YAML, gitignore, walk, and word-count paths are shared.

Gated benchmarks (`BenchmarkCheckCorpusSmall/Large`), the alloc-budget gate, `golangci-lint`, and `mdsmith check .` all pass.

https://claude.ai/code/session_01D2km9eEecgA2XhgcB6gmLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2km9eEecgA2XhgcB6gmLS)_