### PR TITLE
fix(release): verify komac SHA256 and fix broken download URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1013,13 +1013,18 @@ jobs:
           # fail an otherwise-successful release, so each fallible
           # step logs a warning and exits 0.
           KOMAC_VERSION="2.10.0"
+          KOMAC_SHA256="523a5c4d685741f540a403e329581ab42c30e2db9b3dd1dd90389f7eefe8a3ba"
           if ! curl -fsSL \
-            "https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-musl" \
-            -o /usr/local/bin/komac; then
+            "https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            -o /tmp/komac.tar.gz; then
             echo "::warning::could not download komac; skipping WinGet submission."
             exit 0
           fi
-          chmod +x /usr/local/bin/komac
+          if ! echo "${KOMAC_SHA256}  /tmp/komac.tar.gz" | sha256sum -c -; then
+            echo "::warning::komac checksum mismatch; skipping WinGet submission."
+            exit 0
+          fi
+          tar -xzf /tmp/komac.tar.gz -C /usr/local/bin/
           installer="https://github.com/jeduden/mdsmith/releases/download/${VERSION}/mdsmith-windows-amd64.exe"
           if ! komac update jeduden.mdsmith \
             --version "${VERSION#v}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1024,7 +1024,10 @@ jobs:
             echo "::warning::komac checksum mismatch; skipping WinGet submission."
             exit 0
           fi
-          tar -xzf /tmp/komac.tar.gz -C /usr/local/bin/
+          if ! tar -xzf /tmp/komac.tar.gz -C /usr/local/bin/; then
+            echo "::warning::could not extract komac; skipping WinGet submission."
+            exit 0
+          fi
           installer="https://github.com/jeduden/mdsmith/releases/download/${VERSION}/mdsmith-windows-amd64.exe"
           if ! komac update jeduden.mdsmith \
             --version "${VERSION#v}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1014,7 +1014,7 @@ jobs:
           # step logs a warning and exits 0.
           KOMAC_VERSION="2.10.0"
           KOMAC_SHA256="523a5c4d685741f540a403e329581ab42c30e2db9b3dd1dd90389f7eefe8a3ba"
-          if ! curl -fsSL \
+          if ! curl -fsSL --max-time 120 --connect-timeout 15 \
             "https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
             -o /tmp/komac.tar.gz; then
             echo "::warning::could not download komac; skipping WinGet submission."
@@ -1024,7 +1024,7 @@ jobs:
             echo "::warning::komac checksum mismatch; skipping WinGet submission."
             exit 0
           fi
-          if ! tar -xzf /tmp/komac.tar.gz -C /usr/local/bin/; then
+          if ! tar -xzf /tmp/komac.tar.gz -C /usr/local/bin/ komac; then
             echo "::warning::could not extract komac; skipping WinGet submission."
             exit 0
           fi

--- a/PLAN.md
+++ b/PLAN.md
@@ -189,7 +189,7 @@ footer: |
 | 2606120633 | ✅     |        | [Wire PGO into the release build without a committed profile](plan/2606120633_release-built-pgo-profile.md)                             |
 | 2606122012 | ✅     | sonnet | [Add lstat guard to hook-file install, uninstall, and status](plan/2606122012_hook-file-lstat-guard.md)                                 |
 | 2606122013 | ✅     | sonnet | [Security hardening batch — 2026-06-12 git/LSP audit](plan/2606122013_security-hardening-batch-2026-06-12.md)                           |
-| 2606122014 | 🔲     | sonnet | [Add SHA256 checksum verification for komac download in release.yml](plan/2606122014_komac-sha256-checksum.md)                          |
+| 2606122014 | ✅     | sonnet | [Add SHA256 checksum verification for komac download in release.yml](plan/2606122014_komac-sha256-checksum.md)                          |
 | 2606122015 | ✅     | sonnet | [Security hardening batch — 2026-06-12 full-repo audit](plan/2606122015_security-hardening-batch-full-repo.md)                          |
 | 2606130836 | 🔲     | opus   | [Pool the per-file source-read buffer across lintFile passes](plan/2606130836_pool-source-read-buffer.md)                               |
 | 2606130837 | 🔲     | opus   | [Fast-path front-matter field reads for cross-file rules](plan/2606130837_frontmatter-fast-scan.md)                                     |

--- a/plan/2606122014_komac-sha256-checksum.md
+++ b/plan/2606122014_komac-sha256-checksum.md
@@ -1,7 +1,7 @@
 ---
 id: 2606122014
 title: "Add SHA256 checksum verification for komac download in release.yml"
-status: "🔲"
+status: "✅"
 summary: >-
   S001 from the 2026-06-12 full-repo audit: the winget-submit job
   downloads the komac binary with curl and executes it without any
@@ -34,10 +34,10 @@ that privileged step with no post-download integrity check.
 
 ## Tasks
 
-- [ ] Find the exact komac version pinned in `release.yml` (e.g.
+- [x] Find the exact komac version pinned in `release.yml` (e.g.
   `v1.x.y`) and compute the SHA256 of the Linux amd64 binary for
   that release.
-- [ ] Add a `sha256sum -c` check in `release.yml` immediately after
+- [x] Add a `sha256sum -c` check in `release.yml` immediately after
   the curl line, following the same pattern as tinygo in
   `ci.yml:563-568`:
   `echo "<sha256>  /usr/local/bin/komac" | sha256sum -c`
@@ -48,8 +48,8 @@ that privileged step with no post-download integrity check.
 
 ## Acceptance Criteria
 
-- The winget-submit job verifies the komac binary's SHA256 before
+- [x] The winget-submit job verifies the komac binary's SHA256 before
   executing it.
-- The hardcoded hash matches the komac binary for the pinned version.
-- The pattern matches the one used by other binary downloads in the
+- [x] The hardcoded hash matches the komac binary for the pinned version.
+- [x] The pattern matches the one used by other binary downloads in the
   repository (echo + sha256sum -c, not a separate file).


### PR DESCRIPTION
## Summary

- Fixes security finding S001 from the 2026-06-12 full-repo audit: the `winget-submit` job downloaded the komac binary without any SHA256 verification and executed it with `WINGET_PR_TOKEN` in scope.
- Also fixes a broken download URL: the workflow referenced `komac-2.10.0-x86_64-unknown-linux-musl` (never published); the correct asset is `komac-2.10.0-x86_64-unknown-linux-gnu.tar.gz`.
- Adds `sha256sum -c` verification following the same pattern as tinygo in `ci.yml:563-568`.
- Extracts the binary from the tar.gz with `tar -xzf`.

## Test plan

- [ ] Trigger a release dispatch and verify the `winget-submit` job passes the checksum check and invokes `komac` successfully.
- [ ] Verify that tampering with `/tmp/komac.tar.gz` after download causes the job to emit `::warning::komac checksum mismatch` and exit 0 (manual test or unit test of the shell logic).

https://claude.ai/code/session_01NGs2wRFBYB6PeizJczewHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGs2wRFBYB6PeizJczewHg)_