### PR TITLE
perf: five allocation-budget fixes across hot paths

### DIFF
--- a/cue/cuelite/eval.go
+++ b/cue/cuelite/eval.go
@@ -17,6 +17,8 @@ var reCache sync.Map // map[string]*regexp.Regexp
 
 // cachedRegexp returns a compiled *regexp.Regexp for pattern, compiling it on
 // the first call and returning the cached result on subsequent calls.
+// Failed compilations are not cached — each invalid pattern recompiles and
+// returns the error fresh so callers always see the original compile error.
 func cachedRegexp(pattern string) (*regexp.Regexp, error) {
 	if v, ok := reCache.Load(pattern); ok {
 		return v.(*regexp.Regexp), nil

--- a/cue/cuelite/eval.go
+++ b/cue/cuelite/eval.go
@@ -19,6 +19,8 @@ var reCache sync.Map // map[string]*regexp.Regexp
 // the first call and returning the cached result on subsequent calls.
 // Failed compilations are not cached — each invalid pattern recompiles and
 // returns the error fresh so callers always see the original compile error.
+// The returned pointer is shared across goroutines; callers MUST NOT invoke
+// mutating methods (e.g., Longest) — only read-only methods like MatchString.
 func cachedRegexp(pattern string) (*regexp.Regexp, error) {
 	if v, ok := reCache.Load(pattern); ok {
 		return v.(*regexp.Regexp), nil

--- a/cue/cuelite/eval.go
+++ b/cue/cuelite/eval.go
@@ -5,9 +5,29 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sync"
 
 	"github.com/jeduden/mdsmith/cue/cuelite/syntax"
 )
+
+// reCache caches compiled *regexp.Regexp values keyed by pattern string.
+// compareConcrete may be called once per file during a query that uses =~
+// on two concrete strings; caching avoids rebuilding the NFA on every call.
+var reCache sync.Map // map[string]*regexp.Regexp
+
+// cachedRegexp returns a compiled *regexp.Regexp for pattern, compiling it on
+// the first call and returning the cached result on subsequent calls.
+func cachedRegexp(pattern string) (*regexp.Regexp, error) {
+	if v, ok := reCache.Load(pattern); ok {
+		return v.(*regexp.Regexp), nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	v, _ := reCache.LoadOrStore(pattern, re)
+	return v.(*regexp.Regexp), nil
+}
 
 // errUnresolved signals that an expression could not be evaluated because it
 // references a sibling field whose value is not yet known (a forward or
@@ -465,7 +485,7 @@ func compareConcrete(l *engineValue, op syntax.Token, r *engineValue) (bool, err
 		if l.kind != kString || r.kind != kString {
 			return false, fmt.Errorf("cuelite: %s requires strings", op)
 		}
-		re, err := regexp.Compile(r.str)
+		re, err := cachedRegexp(r.str)
 		if err != nil {
 			return false, err
 		}

--- a/cue/cuelite/regex_cache_test.go
+++ b/cue/cuelite/regex_cache_test.go
@@ -1,0 +1,38 @@
+package cuelite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCachedRegexp_SamePointer verifies the cache returns the same compiled
+// *regexp.Regexp for repeated calls with the same pattern. This test is RED
+// until cachedRegexp is added to eval.go.
+func TestCachedRegexp_SamePointer(t *testing.T) {
+	pat := "^test[0-9]+$"
+	re1, err := cachedRegexp(pat)
+	require.NoError(t, err)
+	re2, err := cachedRegexp(pat)
+	require.NoError(t, err)
+	assert.Same(t, re1, re2, "cachedRegexp must return the same *regexp.Regexp on cache hit")
+}
+
+// TestCachedRegexp_ZeroAllocsOnHit verifies that a warm (cached) call to
+// cachedRegexp allocates zero objects — the regex is not recompiled.
+func TestCachedRegexp_ZeroAllocsOnHit(t *testing.T) {
+	pat := "^cached[a-z]+$"
+	_, err := cachedRegexp(pat) // warm: populate cache
+	require.NoError(t, err)
+	avg := testing.AllocsPerRun(100, func() {
+		_, _ = cachedRegexp(pat)
+	})
+	assert.Equal(t, 0.0, avg, "cached cachedRegexp must allocate 0 per call")
+}
+
+// TestCachedRegexp_InvalidPattern verifies that invalid patterns return an error.
+func TestCachedRegexp_InvalidPattern(t *testing.T) {
+	_, err := cachedRegexp("(unclosed")
+	assert.Error(t, err)
+}

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -196,7 +196,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		}
 	}
 
-	return bytes.Join(resultLines, []byte("\n"))
+	return bytes.Join(resultLines, newline)
 }
 
 // collectBlankLineInsertions walks the AST and returns sets of 1-based line numbers
@@ -252,6 +252,8 @@ func needsBlankAdjacent(f *lint.File, targetLine, direction int) bool {
 
 // FixTitle implements rule.QuickFixTitler.
 func (r *Rule) FixTitle() string { return "Add blank lines around list" }
+
+var newline = []byte("\n")
 
 // enteringKinds is the static node-kind interest CheckNode declares
 // via rule.KindScopedChecker; package-level so EnteringKinds returns

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -183,7 +183,8 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return f.Source
 	}
 
-	var resultLines [][]byte
+	// Upper bound: each line may need a blank inserted before and after it.
+	resultLines := make([][]byte, 0, len(f.Lines)+len(beforeSet)+len(afterSet))
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := beforeSet[lineNum]; ok {

--- a/internal/rules/blanklinearoundlists/rule.go
+++ b/internal/rules/blanklinearoundlists/rule.go
@@ -196,7 +196,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		}
 	}
 
-	return bytes.Join(resultLines, newline)
+	return bytes.Join(resultLines, newlineSep)
 }
 
 // collectBlankLineInsertions walks the AST and returns sets of 1-based line numbers
@@ -253,7 +253,9 @@ func needsBlankAdjacent(f *lint.File, targetLine, direction int) bool {
 // FixTitle implements rule.QuickFixTitler.
 func (r *Rule) FixTitle() string { return "Add blank lines around list" }
 
-var newline = []byte("\n")
+// newlineSep is the bytes.Join separator; a package-level var avoids
+// a heap allocation for []byte("\n") on every Fix call.
+var newlineSep = []byte("\n")
 
 // enteringKinds is the static node-kind interest CheckNode declares
 // via rule.KindScopedChecker; package-level so EnteringKinds returns

--- a/internal/rules/blanklinearoundlists/rule_test.go
+++ b/internal/rules/blanklinearoundlists/rule_test.go
@@ -228,3 +228,32 @@ func TestCheck_EmptyFencedCodeBlockAdjacentToList_NoDiagnostics(t *testing.T) {
 	diags := r.Check(f)
 	assert.Len(t, diags, 0, "expected 0 diagnostics, got %d: %+v", len(diags), diags)
 }
+
+// TestFix_PreSizeAllocBudget verifies that Fix pre-sizes resultLines with
+// make([][]byte, 0, cap) instead of starting from nil, so the backing array
+// is allocated once rather than growing 4× for a file with several insertions.
+// Budget is below the current 8-alloc baseline.
+func TestFix_PreSizeAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	// 4 lines; 2 blank-line insertions required (before list and after list).
+	src := []byte("text\n- item1\n- item2\nmore text\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{}
+	_ = r.Fix(f) // warm up
+	const (
+		runs = 100
+		// Current: 8 allocs (4 growth allocs from nil resultLines + 2-map setup +
+		// bytes.Join). After make(0, cap): growth allocs replaced by 1 make alloc;
+		// budget = 6 requires at least 2 allocs saved.
+		budget = 6
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = r.Fix(f)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"Fix allocs/op = %.0f (budget=%d); pre-size resultLines with make([][]byte, 0, cap)",
+		allocs, budget)
+}

--- a/internal/rules/blockquotewhitespace/rule.go
+++ b/internal/rules/blockquotewhitespace/rule.go
@@ -160,14 +160,14 @@ func (r *Rule) checkBlankBetween(f *lint.File) []lint.Diagnostic {
 	return diags
 }
 
+// bqFixedSpace is the canonical single-space replacement for collapsed
+// multi-space runs in blockquote prefixes; defined at package scope to avoid
+// allocating []byte("> ") on every ReplaceAllLiteral call.
+var bqFixedSpace = []byte("> ")
+
 // Fix implements rule.FixableRule. Collapses multiple spaces after > to one
 // space on every non-code-block blockquote line. MD028 violations are not
 // auto-fixed because the intent (one quote vs two) is ambiguous.
-// bqFixedSpace is the canonical single-space replacement for collapsed
-// multi-space runs in blockquote prefixes; defined at package scope to avoid
-// allocating []byte("> ") on every ReplaceAll call.
-var bqFixedSpace = []byte("> ")
-
 func (r *Rule) Fix(f *lint.File) []byte {
 	codeLines := lint.CollectCodeBlockLines(f)
 	var buf bytes.Buffer
@@ -186,7 +186,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 			buf.Write(line)
 			continue
 		}
-		fixedPrefix := reMultiSpace.ReplaceAll(prefix, bqFixedSpace)
+		fixedPrefix := reMultiSpace.ReplaceAllLiteral(prefix, bqFixedSpace)
 		content := line[len(prefix):]
 		if len(content) == 0 {
 			// No content after the marker chain: trim trailing space so we don't

--- a/internal/rules/blockquotewhitespace/rule.go
+++ b/internal/rules/blockquotewhitespace/rule.go
@@ -6,7 +6,6 @@ package blockquotewhitespace
 import (
 	"bytes"
 	"regexp"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -164,31 +163,41 @@ func (r *Rule) checkBlankBetween(f *lint.File) []lint.Diagnostic {
 // Fix implements rule.FixableRule. Collapses multiple spaces after > to one
 // space on every non-code-block blockquote line. MD028 violations are not
 // auto-fixed because the intent (one quote vs two) is ambiguous.
+// bqFixedSpace is the canonical single-space replacement for collapsed
+// multi-space runs in blockquote prefixes; defined at package scope to avoid
+// allocating []byte("> ") on every ReplaceAll call.
+var bqFixedSpace = []byte("> ")
+
 func (r *Rule) Fix(f *lint.File) []byte {
 	codeLines := lint.CollectCodeBlockLines(f)
-	lines := make([]string, len(f.Lines))
+	var buf bytes.Buffer
+	buf.Grow(len(f.Source))
 	for i, line := range f.Lines {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
 		lineNum := i + 1
 		if _, ok := codeLines[lineNum]; ok {
-			lines[i] = string(line)
+			buf.Write(line)
 			continue
 		}
 		prefix := reBlockquotePrefix.Find(line)
 		if !reMultiSpace.Match(prefix) {
-			lines[i] = string(line)
+			buf.Write(line)
 			continue
 		}
-		fixedPrefix := reMultiSpace.ReplaceAll(prefix, []byte("> "))
+		fixedPrefix := reMultiSpace.ReplaceAll(prefix, bqFixedSpace)
 		content := line[len(prefix):]
 		if len(content) == 0 {
 			// No content after the marker chain: trim trailing space so we don't
 			// introduce a trailing-whitespace violation that needs a second pass.
-			lines[i] = strings.TrimRight(string(fixedPrefix), " \t")
+			buf.Write(bytes.TrimRight(fixedPrefix, " \t"))
 		} else {
-			lines[i] = string(fixedPrefix) + string(content)
+			buf.Write(fixedPrefix)
+			buf.Write(content)
 		}
 	}
-	return []byte(strings.Join(lines, "\n"))
+	return buf.Bytes()
 }
 
 // emptyBQLine finds the source line of n, an empty AST blockquote node with

--- a/internal/rules/blockquotewhitespace/rule_test.go
+++ b/internal/rules/blockquotewhitespace/rule_test.go
@@ -611,11 +611,8 @@ func TestFix_BytesBufferAllocBudget(t *testing.T) {
 	require.NoError(t, err)
 	r := &Rule{}
 	_ = r.Fix(f) // warm up
-	const (
-		runs   = 100
-		// Current: 12 allocs. After bytes.Buffer refactor: ~5; budget = 7 is tight.
-		budget = 7
-	)
+	const runs = 100
+	const budget = 7 // bytes.Buffer refactor: was 12 allocs; now ~5
 	allocs := testing.AllocsPerRun(runs, func() {
 		_ = r.Fix(f)
 	})

--- a/internal/rules/blockquotewhitespace/rule_test.go
+++ b/internal/rules/blockquotewhitespace/rule_test.go
@@ -597,3 +597,29 @@ func TestMultiSpaceAfterMarker_MatchesRegexSemantics(t *testing.T) {
 		assert.Equal(t, wantLoc[0], col, "line %q", s)
 	}
 }
+
+// TestFix_BytesBufferAllocBudget verifies that Fix uses bytes.Buffer to write
+// output directly — eliminating the []string + strings.Join + []byte round-trip
+// and the per-fixed-line string(a)+string(b) concatenation allocs.
+// Budget is below the current 12-alloc baseline.
+func TestFix_BytesBufferAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	src := "> foo\n>  bar\n>   baz\n"
+	f, err := lint.NewFile("test.md", []byte(src))
+	require.NoError(t, err)
+	r := &Rule{}
+	_ = r.Fix(f) // warm up
+	const (
+		runs   = 100
+		// Current: 12 allocs. After bytes.Buffer refactor: ~5; budget = 7 is tight.
+		budget = 7
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = r.Fix(f)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"Fix allocs/op = %.0f (budget=%d); use bytes.Buffer to eliminate string-conversion allocs",
+		allocs, budget)
+}

--- a/internal/rules/listmarkerspace/rule.go
+++ b/internal/rules/listmarkerspace/rule.go
@@ -192,7 +192,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 			resultLines[i] = line
 		}
 	}
-	return bytes.Join(resultLines, []byte("\n"))
+	return bytes.Join(resultLines, newline)
 }
 
 // adjustSpaces replaces the spaces between the list marker and item text.
@@ -259,6 +259,8 @@ func pluralSpace(n int) string {
 	}
 	return "spaces"
 }
+
+var newline = []byte("\n")
 
 var (
 	_ rule.Configurable = (*Rule)(nil)

--- a/internal/rules/listmarkerspace/rule.go
+++ b/internal/rules/listmarkerspace/rule.go
@@ -192,7 +192,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 			resultLines[i] = line
 		}
 	}
-	return bytes.Join(resultLines, newline)
+	return bytes.Join(resultLines, newlineSep)
 }
 
 // adjustSpaces replaces the spaces between the list marker and item text.
@@ -260,7 +260,9 @@ func pluralSpace(n int) string {
 	return "spaces"
 }
 
-var newline = []byte("\n")
+// newlineSep is the bytes.Join separator; a package-level var avoids
+// a heap allocation for []byte("\n") on every Fix call.
+var newlineSep = []byte("\n")
 
 var (
 	_ rule.Configurable = (*Rule)(nil)

--- a/internal/rules/listmarkerspace/rule.go
+++ b/internal/rules/listmarkerspace/rule.go
@@ -4,8 +4,8 @@
 package listmarkerspace
 
 import (
+	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -183,16 +183,16 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return ast.WalkContinue, nil
 	})
 
-	resultLines := make([]string, len(f.Lines))
+	resultLines := make([][]byte, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if want, ok := editMap[lineNum]; ok {
-			resultLines[i] = string(adjustSpaces(line, want))
+			resultLines[i] = adjustSpaces(line, want)
 		} else {
-			resultLines[i] = string(line)
+			resultLines[i] = line
 		}
 	}
-	return []byte(strings.Join(resultLines, "\n"))
+	return bytes.Join(resultLines, []byte("\n"))
 }
 
 // adjustSpaces replaces the spaces between the list marker and item text.

--- a/internal/rules/listmarkerspace/rule_test.go
+++ b/internal/rules/listmarkerspace/rule_test.go
@@ -404,12 +404,8 @@ func TestFix_BytesJoinAllocBudget(t *testing.T) {
 	require.NoError(t, err)
 	r := &Rule{}
 	_ = r.Fix(f) // warm up
-	const (
-		runs   = 100
-		// Current: 9 allocs (string conversions + join + []byte conversion).
-		// After [][]byte refactor: ~5 allocs; budget = 6 is tight enough.
-		budget = 6
-	)
+	const runs = 100
+	const budget = 6 // [][]byte refactor: was 9 allocs; now ~5
 	allocs := testing.AllocsPerRun(runs, func() {
 		_ = r.Fix(f)
 	})

--- a/internal/rules/listmarkerspace/rule_test.go
+++ b/internal/rules/listmarkerspace/rule_test.go
@@ -391,3 +391,29 @@ func TestCheck_MessageGrammar(t *testing.T) {
 	assert.Contains(t, diags2[0].Message, "1 space")
 	assert.NotContains(t, diags2[0].Message, "1 spaces")
 }
+
+// TestFix_BytesJoinAllocBudget verifies that Fix uses [][]byte + bytes.Join
+// instead of []string + strings.Join, eliminating per-line string-conversion
+// allocs. Budget is below the current 9-alloc baseline.
+func TestFix_BytesJoinAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	src := "-  item one\n-   item two\n*  item three\n"
+	f, err := lint.NewFile("test.md", []byte(src))
+	require.NoError(t, err)
+	r := &Rule{}
+	_ = r.Fix(f) // warm up
+	const (
+		runs   = 100
+		// Current: 9 allocs (string conversions + join + []byte conversion).
+		// After [][]byte refactor: ~5 allocs; budget = 6 is tight enough.
+		budget = 6
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = r.Fix(f)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"Fix allocs/op = %.0f (budget=%d); use [][]byte + bytes.Join to eliminate string-conversion allocs",
+		allocs, budget)
+}

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -582,8 +582,8 @@ func formatTable(tbl table, cfg Config) table {
 	colWidths := computeColWidths(normalizedRows, numCols, aligns, cfg)
 	padding := strings.Repeat(" ", cfg.Pad)
 
-	var formattedLines [][]byte
-	var formattedRows []row
+	formattedLines := make([][]byte, 0, len(normalizedRows))
+	formattedRows := make([]row, 0, len(normalizedRows))
 	for _, r := range normalizedRows {
 		var line strings.Builder
 		line.WriteString(tbl.prefix)

--- a/internal/rules/tablefmt/tablefmt_test.go
+++ b/internal/rules/tablefmt/tablefmt_test.go
@@ -1103,3 +1103,38 @@ func TestSplitRow_AllocBudget(t *testing.T) {
 		"splitRow allocs/op = %.0f (budget=%d); pre-size cells slice to fix",
 		allocs, budget)
 }
+
+// TestFormatTable_PreSizeAllocs verifies that formattedLines and formattedRows
+// are pre-sized with make(0, len(normalizedRows)) so no backing-array growth
+// allocs occur. Budget is set below the current 23-alloc baseline; it passes
+// once the two var declarations are replaced with make calls.
+func TestFormatTable_PreSizeAllocs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	tbl := table{
+		prefix: "",
+		rows: []row{
+			{cells: []string{"Col A", "Col B", "Col C"}},
+			{isSeparator: true, alignments: []align{alignLeft, alignCenter, alignRight}},
+			{cells: []string{"x", "y", "z"}},
+		},
+	}
+	cfg := Config{Pad: 1}
+	_ = formatTable(tbl, cfg) // warm up
+	const (
+		runs = 100
+		// Current allocs: 23 (includes 4 extra from un-pre-sized slice growth).
+		// After pre-sizing: 4 allocs removed, budget ≤ 20 satisfies.
+		budget = 20
+	)
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = formatTable(tbl, cfg)
+	})
+	require.LessOrEqualf(t, allocs, float64(budget),
+		"formatTable allocs/op = %.0f (budget=%d); pre-size formattedLines and formattedRows with make",
+		allocs, budget)
+}


### PR DESCRIPTION
## Overview

Five targeted fixes from auditing the codebase against `docs/development/high-performance-go.md`. Each fix follows the project's allocation budget (≤10 allocs/Check call) and is enforced by a new `testing.AllocsPerRun` test written red-first.

## Fixes

### 1. Cache compiled regexps in `cue/cuelite` (`cachedRegexp`)

**File:** `cue/cuelite/eval.go`

**Motivation:** `compareConcrete` called `regexp.Compile(r.str)` on every evaluation of the `=~` operator in a CUE query expression. NFA construction is expensive (~5 allocs per compile) and the pattern strings are stable across a workspace run.

**Fix:** Added `var reCache sync.Map` and `cachedRegexp(pattern)`, which compiles once and returns the cached `*regexp.Regexp` on subsequent calls. Uses `LoadOrStore` to handle concurrent first-callers safely. Failed compilations are not cached so callers always see the original error. The returned pointer is shared; the code comment documents that callers must use read-only methods only.

**Test:** `TestCachedRegexp_SamePointer` (pointer identity on cache hit), `TestCachedRegexp_ZeroAllocsOnHit` (0 allocs on warm call), `TestCachedRegexp_InvalidPattern` (error propagated).

---

### 2. Pre-size `formattedLines`/`formattedRows` in `tablefmt` (`formatTable`)

**File:** `internal/rules/tablefmt/tablefmt.go`

**Motivation:** `formatTable` declared `var formattedLines [][]byte` and `var formattedRows []row` as nil slices, causing 4 backing-array growth allocations as the slices grew through the `normalizedRows` loop.

**Fix:** `make([][]byte, 0, len(normalizedRows))` and `make([]row, 0, len(normalizedRows))` — exact capacity since the loop appends one entry per normalized row.

**Test:** `TestFormatTable_PreSizeAllocs` — budget ≤20, down from 23-alloc baseline.

---

### 3. `[][]byte + bytes.Join` in `listmarkerspace` Fix

**File:** `internal/rules/listmarkerspace/rule.go`

**Motivation:** `Fix` built a `[]string` result and called `strings.Join(..., "\n")` then cast back to `[]byte`. Every line paid one `string(line)` allocation even if it was unchanged; every fixed line paid `string(adjustSpaces(...))` on top of that.

**Fix:** Switched to `make([][]byte, len(f.Lines))`, assigned `adjustSpaces(line, want)` (already `[]byte`) or `line` (already `[]byte`) directly, then `bytes.Join(resultLines, newlineSep)`. Added package-level `var newlineSep = []byte("\n")` so the separator itself is not heap-allocated on every Fix call.

**Test:** `TestFix_BytesJoinAllocBudget` — budget ≤6, down from 9-alloc baseline.

---

### 4. `bytes.Buffer` + `ReplaceAllLiteral` in `blockquotewhitespace` Fix

**File:** `internal/rules/blockquotewhitespace/rule.go`

**Motivation:** `Fix` built a `[]string` with per-line `string(fixedPrefix) + string(content)` concatenations, then `strings.Join(lines, "\n")` cast back to `[]byte`. That was 12 allocs/call: one per line conversion plus the join plus the final cast.

**Fix:** Switched to `bytes.Buffer` with `buf.Grow(len(f.Source))` upfront, writing each line with `buf.Write` and `'\n'` separator. Hoisted `var bqFixedSpace = []byte("> ")` to package scope (avoids one `[]byte` allocation per `ReplaceAllLiteral` call). Changed `ReplaceAll` → `ReplaceAllLiteral` — the old code passed a literal `[]byte("> ")` with no `$` references, so the behavior is identical but `ReplaceAllLiteral` documents the intent explicitly and avoids the template-expansion code path.

**Test:** `TestFix_BytesBufferAllocBudget` — budget ≤7, down from 12-alloc baseline.

---

### 5. Pre-size `resultLines` in `blanklinearoundlists` Fix

**File:** `internal/rules/blanklinearoundlists/rule.go`

**Motivation:** `Fix` declared `var resultLines [][]byte` as nil, then appended source lines plus blank-line insertions. A file with N lines needing insertions before and after a list caused the slice to grow through multiple backing-array copies.

**Fix:** `make([][]byte, 0, len(f.Lines)+len(beforeSet)+len(afterSet))` — tight upper bound since at most `len(beforeSet)+len(afterSet)` blank lines are inserted. Changed `[]byte("\n")` literal in `bytes.Join` to the new package-level `var newlineSep = []byte("\n")`.

**Test:** `TestFix_PreSizeAllocBudget` — budget ≤6, down from 8-alloc baseline.

---

## Review rounds completed

Three `/code-review --fix xhigh` passes were run against this diff:

- **Round 1:** Removed unused `strings` import in `listmarkerspace` and `blockquotewhitespace`; changed `ReplaceAll` → `ReplaceAllLiteral` in blockquote fix; fixed gofmt alignment in const blocks.
- **Round 2:** Renamed `newline` → `newlineSep` in all packages to match the established naming convention from `blanklinearoundheadings` and `blanklinearoundfencedcode`; added allocation-rationale comment on each `newlineSep` var; added doc-comment guard on `Fix` in blockquotewhitespace after `bqFixedSpace` var was inserted; fixed revive lint on missing doc comment.
- **Round 3:** No actionable findings — all candidates verified as REFUTED or out of scope.

## Test plan

- [ ] `go test ./cue/cuelite/...` — regex cache tests pass
- [ ] `go test ./internal/rules/tablefmt/...` — alloc budget test passes
- [ ] `go test ./internal/rules/listmarkerspace/...` — alloc budget test passes
- [ ] `go test ./internal/rules/blockquotewhitespace/...` — alloc budget test passes
- [ ] `go test ./internal/rules/blanklinearoundlists/...` — alloc budget test passes
- [ ] `go test ./...` — full suite green
- [ ] `go tool -modfile=tools/go.mod golangci-lint run` — no lint errors

https://claude.ai/code/session_01RZQG264pN9S7LwjT7PY9Pc