### PR TITLE
docs(bench): link performance page to the assets-branch benchmark write-up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1154,10 +1154,12 @@ jobs:
         run: go run ./cmd/mdsmith-release bench /tmp/mdsmith-bench
       - name: Normalize the freshly measured fragments
         # Normalize the gen_fragments.py tables to the gate's canonical
-        # form (the same step benchmark.yml runs). No host page is
-        # re-spliced here: the pages job bakes performance.md from the
-        # artifact at deploy time, and the README links to
-        # results.fragment.md directly.
+        # form (the same step benchmark.yml runs). Only the fragments
+        # are touched here — those feed the artifact. The benchmark
+        # README is spliced and link-rewritten later, in the publish
+        # step below, solely to produce the assets-branch prose copy;
+        # the site's own performance.md is baked from the artifact at
+        # deploy time.
         run: |
           go run ./cmd/mdsmith fix \
             docs/research/benchmarks/results.fragment.md \
@@ -1182,10 +1184,11 @@ jobs:
           if-no-files-found: error
       - name: Publish the numbers to the assets branch
         # GitHub Actions cannot open PRs here, but it can push to the
-        # orphan `assets` branch. Push this release's data + fragments
-        # there, so the README's [bench-live] link target
-        # (assets/benchmarks/results.fragment.md) shows the release's
-        # numbers. This job OWNS assets/benchmarks/; demo.yml owns
+        # orphan `assets` branch. Push this release's data, fragments,
+        # and the rendered prose page there, so the performance page's
+        # link to assets/benchmarks/pages/benchmark.md shows the
+        # release's freshly measured numbers. This job OWNS
+        # assets/benchmarks/; demo.yml owns
         # assets/demo.gif and benchmark.yml owns assets/benchmarks-drift/,
         # so the three subtrees are disjoint. Subtree-safe and
         # best-effort: it rewrites only assets/benchmarks/, commits only
@@ -1200,16 +1203,29 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Stage the subtree before switching branches: the raw data and
-          # the two fragments. results.fragment.md is the README's link
-          # target; both render as clean tables with no inner links to
-          # 404 on the assets branch.
+          # Stage the subtree before switching branches: the raw data,
+          # the two fragments, and the rendered prose page. The fragments
+          # render as clean tables with no inner links to 404 on the
+          # assets branch.
           rm -rf /tmp/bench-assets
-          mkdir -p /tmp/bench-assets/data
+          mkdir -p /tmp/bench-assets/data /tmp/bench-assets/pages
           cp docs/research/benchmarks/results.fragment.md \
              docs/research/benchmarks/headline.fragment.md \
              /tmp/bench-assets/
           cp docs/research/benchmarks/data/*.json /tmp/bench-assets/data/
+
+          # Publish the prose research write-up too. Splice this release's
+          # fresh fragments into the README, then rewrite its repo-relative
+          # links to absolute GitHub URLs so none 404 on the assets branch
+          # (the sibling files do not exist there). Lands at
+          # assets/benchmarks/pages/benchmark.md — the rendered, fresh-
+          # numbers copy the performance page links to. Both `go run`s
+          # execute here, on the full source tree, before the branch
+          # switch below; the working-tree README edit is then discarded
+          # by `git checkout -f`, so main's committed snapshot is untouched.
+          go run ./cmd/mdsmith fix docs/research/benchmarks/README.md
+          go run ./cmd/mdsmith-release render-bench-page \
+            /tmp/bench-assets/pages/benchmark.md
 
           # The push authenticates via a masked http.extraheader (checkout
           # ran with persist-credentials: false).

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -26,6 +26,7 @@
 //	mdsmith-release merge-coverage -o <out> <profile>...
 //	mdsmith-release test-summary
 //	mdsmith-release bench [workdir]
+//	mdsmith-release render-bench-page <out-path>
 //	mdsmith-release pgo [workdir]
 //	mdsmith-release pull-site-assets
 //	mdsmith-release sync-messaging [--check]
@@ -75,6 +76,7 @@ Commands:
   test-summary                    Tally unit/integration/e2e tests from a go test -json stream on stdin.
   bench [workdir]                 Run the pinned cross-tool benchmark; promote JSON + fragments.
   bench-check <base> <fresh>      Fail if mdsmith regressed vs mado between two benchmark snapshots.
+  render-bench-page <out-path>    Render the benchmark README (links → GitHub) for the assets branch.
   pgo [workdir]                   Generate a PGO profile over the bench corpora into cmd/mdsmith/default.pgo.
   pull-site-assets                Fetch the published demo GIF for the site build.
   sync-messaging [--check]        Propagate docs/brand/messaging.md into every tracked surface (or check drift).
@@ -187,6 +189,8 @@ func dispatchGenerators(cmd, root string, rest []string) int {
 		return runBench(root, rest)
 	case "bench-check":
 		return runBenchCheck(root, rest)
+	case "render-bench-page":
+		return runRenderBenchPage(root, rest)
 	case "pgo":
 		return runPGO(root, rest)
 	default:
@@ -680,6 +684,31 @@ func runBenchCheck(_ string, args []string) int {
 	}
 	return reportError(release.BenchCheck(os.Stdout, fs.Arg(0), fs.Arg(1),
 		release.BenchCheckConfig{Tolerance: tolerance}))
+}
+
+func runRenderBenchPage(root string, args []string) int {
+	fs := flag.NewFlagSet("render-bench-page", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mdsmith-release render-bench-page <out-path>\n\n"+
+			"Read docs/research/benchmarks/README.md (run `mdsmith fix`\n"+
+			"on it first so its <?include?> tables carry the freshly\n"+
+			"measured numbers), rewrite every repo-relative link to an\n"+
+			"absolute GitHub URL on main, and write the result to\n"+
+			"<out-path>. release.yml's benchmark-publish job publishes\n"+
+			"that file to assets/benchmarks/pages/benchmark.md on the\n"+
+			"orphan assets branch, the rendered fresh-numbers copy the\n"+
+			"performance page links to and whose inner links resolve.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: render-bench-page"); code >= 0 {
+			return code
+		}
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	return reportError(release.RenderBenchPage(root, fs.Arg(0)))
 }
 
 func runPullSiteAssets(root string, args []string) int {

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -65,6 +65,8 @@ func TestRunRejectsBadArity(t *testing.T) {
 		{"package-obsidian without args", []string{"package-obsidian"}},
 		{"package-obsidian with one arg", []string{"package-obsidian", "dist"}},
 		{"build-website with three positionals", []string{"build-website", "a", "b", "c"}},
+		{"render-bench-page without out-path", []string{"render-bench-page"}},
+		{"render-bench-page with extra arg", []string{"render-bench-page", "a", "b"}},
 		{"pgo with extra args", []string{"pgo", "workdir", "extra"}},
 	}
 	for _, c := range cases {
@@ -121,6 +123,7 @@ func TestSubcommandHelpExitsZero(t *testing.T) {
 		"test-summary",
 		"bench",
 		"bench-check",
+		"render-bench-page",
 		"pgo",
 	} {
 		assert.Equal(t, 0, run([]string{sub, "--help"}), "%s --help", sub)
@@ -149,6 +152,7 @@ func TestSubcommandRejectsUnknownFlag(t *testing.T) {
 		"test-summary",
 		"bench",
 		"bench-check",
+		"render-bench-page",
 		"pgo",
 	} {
 		assert.Equal(t, 2, run([]string{sub, "--bogus"}), "%s --bogus", sub)
@@ -818,6 +822,45 @@ func TestPrintCheckResult(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunRenderBenchPageEndToEnd dispatches through `run
+// render-bench-page` against a staged benchmark README so the
+// subcommand wiring (arity check, default-toolkit handoff,
+// reportError) runs end-to-end and the output carries a GitHub-
+// rewritten link.
+func TestRunRenderBenchPageEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	readme := filepath.Join(root, "docs", "research", "benchmarks", "README.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(readme), 0o755))
+	require.NoError(t, os.WriteFile(readme,
+		[]byte("# Bench\n\nReproduce with [`run.sh`](run.sh).\n"), 0o644))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	require.NoError(t, os.Chdir(root))
+
+	out := filepath.Join(root, "pages", "benchmark.md")
+	assert.Equal(t, 0, run([]string{"render-bench-page", out}))
+
+	got, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(got),
+		"https://github.com/jeduden/mdsmith/blob/main/docs/research/benchmarks/run.sh")
+}
+
+// TestRunRenderBenchPageReportsError covers reportError's non-nil
+// branch: no benchmark README in cwd, so RenderBenchPage's ReadFile
+// fails and the subcommand exits 1.
+func TestRunRenderBenchPageReportsError(t *testing.T) {
+	root := t.TempDir()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	require.NoError(t, os.Chdir(root))
+
+	assert.Equal(t, 1, run([]string{"render-bench-page", filepath.Join(root, "out.md")}))
 }
 
 // writeBenchExport writes a minimal hyperfine export with mdsmith and

--- a/docs/development/release-tooling.md
+++ b/docs/development/release-tooling.md
@@ -69,6 +69,7 @@ setup step.
 | `test-summary`               | `ci.yml` test job                                                 |
 | `bench [workdir]`            | `benchmark.yml` record; `release.yml` benchmark-publish; `run.sh` |
 | `bench-check <base> <fresh>` | `release.yml` benchmark-publish + bench-regression-gate           |
+| `render-bench-page <out>`    | `release.yml` benchmark-publish                                   |
 | `pull-site-assets`           | `pages.yml` deploy job                                            |
 | `sync-messaging [--check]`   | `ci.yml` messaging-drift; local sync                              |
 | `sync-channels [--check]`    | `ci.yml` channels-drift; local sync                               |

--- a/docs/features/performance.md
+++ b/docs/features/performance.md
@@ -48,7 +48,9 @@ gate (`check-bench`, modelled on the LSP latency gate) fails the
 build if a 60- or 600-file synthetic check regresses past its
 budget. See the
 [benchmark research doc](../research/benchmarks/README.md) for the
-full cross-tool comparison.
+full cross-tool comparison — on the published site this link
+resolves to the rendered copy on the `assets` branch, which
+carries each release's freshly measured numbers.
 
 See the [`check`](../reference/cli/check.md) reference for flags
 and exit codes.

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -455,8 +455,9 @@ Four gates in CI:
   `benchmark-numbers` artifact (which the website deploy
   bakes in, so each release's site shows its own
   freshly-measured figures) and pushes the numbers plus the
-  rendered benchmark page to the orphan `assets` branch the
-  README links to. GitHub Actions cannot open a PR here, so
+  rendered benchmark page (assets/benchmarks/pages/benchmark.md)
+  to the orphan `assets` branch the performance page links to.
+  GitHub Actions cannot open a PR here, so
   it never touches the committed snapshot. The separate
   `bench-regression-gate` job runs
   `mdsmith-release bench-check`, which compares mdsmith's

--- a/internal/release/benchpage.go
+++ b/internal/release/benchpage.go
@@ -83,9 +83,8 @@ func githubURLForRelativeTarget(target, srcDirRel string) (string, bool) {
 	if i := strings.IndexByte(target, '#'); i >= 0 {
 		rel, frag = target[:i], target[i:]
 	}
-	if rel == "" {
-		return "", false
-	}
+	// rel is always non-empty here: the guard above rejects a
+	// leading '#', so any '#' found sits at index >= 1.
 	resolved := path.Join(srcDirRel, rel)
 	if strings.HasSuffix(rel, "/") {
 		resolved += "/"

--- a/internal/release/benchpage.go
+++ b/internal/release/benchpage.go
@@ -1,0 +1,123 @@
+package release
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// benchReadmeRel is the repo-relative path of the benchmark research
+// README whose rendered, link-rewritten copy release.yml publishes to
+// the orphan assets branch (assets/benchmarks/pages/benchmark.md). It
+// is the prose write-up the performance page links to: a copy carrying
+// this release's freshly measured numbers, where main's committed
+// snapshot lags between deliberate run.sh refreshes.
+const benchReadmeRel = benchDirRel + "/README.md"
+
+// linkScheme matches a leading URI scheme (https:, mailto:, …) so an
+// already-absolute link target is left untouched by the rewrite.
+var linkScheme = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*:`)
+
+// benchInlineLink matches an inline Markdown link's `](target)` tail,
+// capturing the target (group 1, up to the first whitespace or `)`)
+// and an optional double-quoted title (group 2). Image embeds share
+// the same tail and are rewritten identically — both are real link
+// targets once the page is lifted off the repo tree.
+var benchInlineLink = regexp.MustCompile(`\]\(([^)\s]+)((?:\s+"[^"]*")?)\)`)
+
+// benchRefDef matches a reference-style link definition line,
+// capturing the `[label]: ` prefix (group 1), the target (group 2),
+// and an optional title (group 3). Multiline so `^`/`$` anchor at each
+// line within the non-code segments applyOutsideCode hands it.
+var benchRefDef = regexp.MustCompile(
+	`(?m)^(\[[^\]]+\]:[ \t]+)(\S+)((?:[ \t]+"[^"]*")?)[ \t]*$`)
+
+// rewriteRelativeLinksToGitHub rewrites every repo-relative Markdown
+// link in data — resolved against srcDirRel, a repo-root-relative
+// directory — to an absolute GitHub URL on main, so a page lifted out
+// of the repo tree has no link that 404s. The benchmark README is the
+// caller: published to the orphan assets branch, none of its sibling
+// files (run.sh, the coverage matrix, the rule READMEs it cites) exist
+// there, so each relative link must point back at github.com/main.
+//
+// Targets that already resolve as-is are left untouched: anchor-only
+// (`#sec`), site-absolute (`/x`), and scheme-qualified (`https://…`,
+// `mailto:…`) links, plus anything inside a fenced block or inline
+// code span — those are documentation examples, not real targets, and
+// applyOutsideCode keeps the rewrite away from them.
+func rewriteRelativeLinksToGitHub(data []byte, srcDirRel string) []byte {
+	return applyOutsideCode(data, func(seg []byte) []byte {
+		seg = benchInlineLink.ReplaceAllFunc(seg, func(m []byte) []byte {
+			sub := benchInlineLink.FindSubmatch(m)
+			url, ok := githubURLForRelativeTarget(string(sub[1]), srcDirRel)
+			if !ok {
+				return m
+			}
+			return []byte("](" + url + string(sub[2]) + ")")
+		})
+		return benchRefDef.ReplaceAllFunc(seg, func(m []byte) []byte {
+			sub := benchRefDef.FindSubmatch(m)
+			url, ok := githubURLForRelativeTarget(string(sub[2]), srcDirRel)
+			if !ok {
+				return m
+			}
+			return []byte(string(sub[1]) + url + string(sub[3]))
+		})
+	})
+}
+
+// githubURLForRelativeTarget resolves a single Markdown link target
+// against srcDirRel and returns its absolute GitHub URL on main plus
+// true, or ("", false) when the target must be left as-is (empty,
+// anchor-only, site-absolute, or already scheme-qualified). A trailing
+// `#fragment` is preserved, and a trailing slash routes to /tree/
+// (GitHub's directory view) rather than /blob/ via githubURLForPath.
+func githubURLForRelativeTarget(target, srcDirRel string) (string, bool) {
+	if target == "" || target[0] == '#' || target[0] == '/' ||
+		linkScheme.MatchString(target) {
+		return "", false
+	}
+	rel, frag := target, ""
+	if i := strings.IndexByte(target, '#'); i >= 0 {
+		rel, frag = target[:i], target[i:]
+	}
+	if rel == "" {
+		return "", false
+	}
+	resolved := path.Join(srcDirRel, rel)
+	if strings.HasSuffix(rel, "/") {
+		resolved += "/"
+	}
+	return githubURLForPath([]byte(resolved)) + frag, true
+}
+
+// RenderBenchPage reads the benchmark README (already `mdsmith fix`ed
+// upstream so its <?include?> tables carry this release's freshly
+// measured numbers), rewrites every repo-relative link to an absolute
+// GitHub URL on main, and writes the result to outPath. release.yml's
+// benchmark-publish job publishes that file to
+// assets/benchmarks/pages/benchmark.md so the performance page links a
+// rendered, fresh-numbers copy whose inner links all resolve.
+func (t *Toolkit) RenderBenchPage(root, outPath string) error {
+	src := filepath.Join(root, filepath.FromSlash(benchReadmeRel))
+	data, err := t.fs.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read benchmark README %s: %w", src, err)
+	}
+	page := rewriteRelativeLinksToGitHub(data, benchDirRel)
+	dir := filepath.Dir(outPath)
+	if err := t.fs.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err := t.fs.WriteFile(outPath, page, 0o644); err != nil {
+		return fmt.Errorf("write benchmark page %s: %w", outPath, err)
+	}
+	return nil
+}
+
+// RenderBenchPage delegates to a default-OS Toolkit (see Stamp).
+func RenderBenchPage(root, outPath string) error {
+	return New().RenderBenchPage(root, outPath)
+}

--- a/internal/release/benchpage_test.go
+++ b/internal/release/benchpage_test.go
@@ -99,8 +99,10 @@ func TestRenderBenchPageHappyPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(readme,
 		[]byte("# Bench\n\nReproduce with [`run.sh`](run.sh).\n"), 0o644))
 
+	// Exercise the package-level delegator (the public API) so its
+	// success path is covered within this package's profile.
 	out := filepath.Join(root, "pages", "benchmark.md")
-	require.NoError(t, New().RenderBenchPage(root, out))
+	require.NoError(t, RenderBenchPage(root, out))
 
 	got, err := os.ReadFile(out)
 	require.NoError(t, err)

--- a/internal/release/benchpage_test.go
+++ b/internal/release/benchpage_test.go
@@ -1,0 +1,197 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const benchSrcDir = "docs/research/benchmarks"
+
+// TestGithubURLForRelativeTarget pins the resolve-and-route helper:
+// repo-relative targets become absolute GitHub URLs on main (file →
+// /blob/, directory → /tree/, fragment preserved); anchor-only,
+// site-absolute, and already-absolute targets are declined.
+func TestGithubURLForRelativeTarget(t *testing.T) {
+	const blob = "https://github.com/jeduden/mdsmith/blob/main/"
+	const tree = "https://github.com/jeduden/mdsmith/tree/main/"
+	cases := []struct {
+		name   string
+		target string
+		want   string
+		ok     bool
+	}{
+		{"sibling file", "run.sh", blob + benchSrcDir + "/run.sh", true},
+		{"sibling yml", "bench-parity.mdsmith.yml",
+			blob + benchSrcDir + "/bench-parity.mdsmith.yml", true},
+		{"one up", "../markdownlint-coverage/README.md",
+			blob + "docs/research/markdownlint-coverage/README.md", true},
+		{"two up", "../../reference/conventions.md",
+			blob + "docs/reference/conventions.md", true},
+		{"three up into internal", "../../../internal/rules/MDS068-link-style/README.md",
+			blob + "internal/rules/MDS068-link-style/README.md", true},
+		{"fragment preserved", "results.fragment.md#x",
+			blob + benchSrcDir + "/results.fragment.md#x", true},
+		{"directory routes to tree", "../markdownlint-coverage/",
+			tree + "docs/research/markdownlint-coverage/", true},
+		{"anchor only declined", "#reading-the-result", "", false},
+		{"site absolute declined", "/reference/cli/", "", false},
+		{"https declined", "https://example.com/x", "", false},
+		{"mailto declined", "mailto:a@b.c", "", false},
+		{"empty declined", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := githubURLForRelativeTarget(tc.target, benchSrcDir)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRewriteRelativeLinksToGitHub covers the full pass over a body
+// mixing inline links, a titled link, a reference definition, an
+// absolute reference def, an anchor link, and a code span / fenced
+// block whose example links must survive verbatim.
+func TestRewriteRelativeLinksToGitHub(t *testing.T) {
+	const blob = "https://github.com/jeduden/mdsmith/blob/main/"
+	in := "See [`run.sh`](run.sh) and the\n" +
+		"[matrix](../markdownlint-coverage/README.md) plus\n" +
+		"[the PGO page](../../development/pgo-profile.md \"PGO\").\n" +
+		"Jump to [results](#results).\n" +
+		"[mdcov]: ../markdownlint-coverage/README.md\n" +
+		"[pn]: https://github.com/jolars/panache\n" +
+		"\n" +
+		"Inline `[x](../keep.md)` stays. Fenced too:\n" +
+		"```md\n" +
+		"[y](../also-keep.md)\n" +
+		"```\n"
+	got := string(rewriteRelativeLinksToGitHub([]byte(in), benchSrcDir))
+
+	// Relative links rewritten to GitHub main.
+	assert.Contains(t, got, "[`run.sh`]("+blob+benchSrcDir+"/run.sh)")
+	assert.Contains(t, got,
+		"[matrix]("+blob+"docs/research/markdownlint-coverage/README.md)")
+	// Title is preserved after the rewritten URL.
+	assert.Contains(t, got,
+		"[the PGO page]("+blob+"docs/development/pgo-profile.md \"PGO\")")
+	// Reference definition rewritten.
+	assert.Contains(t, got,
+		"[mdcov]: "+blob+"docs/research/markdownlint-coverage/README.md")
+
+	// Left untouched: anchor, absolute ref def, code span, fenced block.
+	assert.Contains(t, got, "[results](#results)")
+	assert.Contains(t, got, "[pn]: https://github.com/jolars/panache")
+	assert.Contains(t, got, "`[x](../keep.md)`")
+	assert.Contains(t, got, "[y](../also-keep.md)")
+}
+
+// TestRenderBenchPageHappyPath stages a benchmark README under the
+// repo-relative path, renders it, and asserts the output file lands
+// (creating its parent) with links rewritten to GitHub main.
+func TestRenderBenchPageHappyPath(t *testing.T) {
+	root := t.TempDir()
+	readme := filepath.Join(root, filepath.FromSlash(benchReadmeRel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(readme), 0o755))
+	require.NoError(t, os.WriteFile(readme,
+		[]byte("# Bench\n\nReproduce with [`run.sh`](run.sh).\n"), 0o644))
+
+	out := filepath.Join(root, "pages", "benchmark.md")
+	require.NoError(t, New().RenderBenchPage(root, out))
+
+	got, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(got),
+		"https://github.com/jeduden/mdsmith/blob/main/"+benchSrcDir+"/run.sh")
+}
+
+// TestRenderBenchPageReadError surfaces a missing README as an error
+// naming the source path.
+func TestRenderBenchPageReadError(t *testing.T) {
+	err := New().RenderBenchPage(t.TempDir(), filepath.Join(t.TempDir(), "out.md"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read benchmark README")
+}
+
+// TestRenderBenchPageMkdirError covers the parent-dir MkdirAll fault
+// branch via the injecting fake FS.
+func TestRenderBenchPageMkdirError(t *testing.T) {
+	root := t.TempDir()
+	readme := filepath.Join(root, filepath.FromSlash(benchReadmeRel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(readme), 0o755))
+	require.NoError(t, os.WriteFile(readme, []byte("# Bench\n"), 0o644))
+
+	ff := newFakeFS()
+	ff.failOnMkdirAllCall = 1
+	err := NewWithFS(ff).RenderBenchPage(root, filepath.Join(root, "pages", "benchmark.md"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errInjected)
+	assert.Contains(t, err.Error(), "mkdir")
+}
+
+// TestRenderBenchPageWriteError covers the WriteFile fault branch.
+func TestRenderBenchPageWriteError(t *testing.T) {
+	root := t.TempDir()
+	readme := filepath.Join(root, filepath.FromSlash(benchReadmeRel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(readme), 0o755))
+	require.NoError(t, os.WriteFile(readme, []byte("# Bench\n"), 0o644))
+
+	ff := newFakeFS()
+	ff.failOnWriteFileCall = 1
+	err := NewWithFS(ff).RenderBenchPage(root, filepath.Join(root, "pages", "benchmark.md"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errInjected)
+	assert.Contains(t, err.Error(), "write benchmark page")
+}
+
+// TestIsPerformanceFeaturePage pins the matcher that scopes the
+// assets-branch repoint to docs/features/performance.md alone.
+func TestIsPerformanceFeaturePage(t *testing.T) {
+	assert.True(t, isPerformanceFeaturePage("docs/features", "performance.md"))
+	// Any docs-root basename works (the recursion builds repoDir
+	// with path.Join, and only the last segment is matched).
+	assert.True(t, isPerformanceFeaturePage("tmpdocs/features", "performance.md"))
+	assert.False(t, isPerformanceFeaturePage("docs/features", "auto-fix.md"))
+	assert.False(t, isPerformanceFeaturePage("docs/reference", "performance.md"))
+}
+
+// TestRepointBenchDocToAssets confirms the main-source benchmark URL
+// (what rewriteRuleLinks emits) is swapped for the assets-branch page,
+// and an unrelated GitHub link is left untouched.
+func TestRepointBenchDocToAssets(t *testing.T) {
+	in := "a [doc](" + benchDocReadmeMainURL + ") and " +
+		"[other](" + githubBlobBase + "docs/reference/cli.md)\n"
+	got := string(repointBenchDocToAssets([]byte(in)))
+	assert.Contains(t, got, "[doc]("+benchDocAssetsPageURL+")")
+	assert.NotContains(t, got, benchDocReadmeMainURL)
+	assert.Contains(t, got, "[other]("+githubBlobBase+"docs/reference/cli.md)")
+}
+
+// TestSyncDocsRepointsBenchLinkOnlyForPerformancePage drives the
+// scope end-to-end: a features/performance.md and a sibling feature
+// page both carry the relative benchmark-README link, but only the
+// performance page's synced output resolves to the assets branch.
+func TestSyncDocsRepointsBenchLinkOnlyForPerformancePage(t *testing.T) {
+	src := t.TempDir()
+	feat := filepath.Join(src, "features")
+	require.NoError(t, os.MkdirAll(feat, 0o755))
+	body := "# X\n\nSee the [bench](../research/benchmarks/README.md).\n"
+	require.NoError(t, os.WriteFile(filepath.Join(feat, "performance.md"), []byte(body), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(feat, "other.md"), []byte(body), 0o644))
+
+	dst := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, New().SyncDocs(src, dst))
+
+	perf, err := os.ReadFile(filepath.Join(dst, "features", "performance.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(perf), benchDocAssetsPageURL)
+	assert.NotContains(t, string(perf), benchDocReadmeMainURL)
+
+	other, err := os.ReadFile(filepath.Join(dst, "features", "other.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(other), benchDocReadmeMainURL)
+	assert.NotContains(t, string(other), benchDocAssetsPageURL)
+}

--- a/internal/release/syncdocs.go
+++ b/internal/release/syncdocs.go
@@ -347,12 +347,24 @@ func (t *Toolkit) syncDocsFile(src, dst, name, repoDir string) (bool, error) {
 	}
 	if ext == ".md" {
 		data = rewriteSiblingNonPublished(transformMarkdown(data), repoDir)
+		if isPerformanceFeaturePage(repoDir, name) {
+			data = repointBenchDocToAssets(data)
+		}
 	}
 	dstPath := filepath.Join(dst, dstName)
 	if err := t.fs.WriteFile(dstPath, data, 0o644); err != nil {
 		return false, fmt.Errorf("write %s: %w", dstPath, err)
 	}
 	return true, nil
+}
+
+// isPerformanceFeaturePage reports whether the file being synced is
+// docs/features/performance.md — the one page whose benchmark-README
+// link is repointed to the assets branch. repoDir is built with
+// path.Join (forward slashes), so path.Base reads its last segment
+// regardless of the docs-root basename.
+func isPerformanceFeaturePage(repoDir, name string) bool {
+	return name == "performance.md" && path.Base(repoDir) == "features"
 }
 
 // synthesizeSectionIndex writes a minimal front-matter-only

--- a/internal/release/website.go
+++ b/internal/release/website.go
@@ -316,6 +316,31 @@ func githubURLForPath(path []byte) string {
 	return githubBlobBase + string(path)
 }
 
+// benchDocReadmeMainURL is the URL rewriteRuleLinks produces for a
+// `../research/benchmarks/README.md` link: research/ is pruned from
+// the site, so repoPrunedDocLink routes it to the committed source on
+// main. benchDocAssetsPageURL is the rendered benchmark page
+// release.yml publishes to the orphan assets branch — the copy
+// carrying each release's freshly measured numbers, where main's
+// committed snapshot lags between deliberate run.sh refreshes.
+const (
+	benchDocReadmeMainURL = githubBlobBase + benchReadmeRel
+	benchDocAssetsPageURL = "https://github.com/jeduden/mdsmith/blob/assets/assets/benchmarks/pages/benchmark.md"
+)
+
+// repointBenchDocToAssets swaps the benchmark-README link (already
+// rewritten to its main source URL by rewriteRuleLinks) for the
+// rendered page on the assets branch. syncDocsFile applies it only to
+// docs/features/performance.md: that feature page's strict 80-column
+// line-length budget rules out carrying the long absolute URL in the
+// source, so the source keeps a short relative link and the site swap
+// alone points it at the fresh-numbers copy. The other docs that cite
+// the benchmark README keep the main source link (maintainer choice).
+func repointBenchDocToAssets(data []byte) []byte {
+	return bytes.ReplaceAll(data,
+		[]byte(benchDocReadmeMainURL), []byte(benchDocAssetsPageURL))
+}
+
 // ruleDirName matches the MDS-prefixed directory names used for
 // per-rule subdirectories under internal/rules/. The prefix guard
 // stops syncRulePages from copying non-rule directories (fixtures,


### PR DESCRIPTION
## Problem

The performance page (`/features/performance/`) links the benchmark
research doc. `research/` is pruned from the site, so the site sync
rewrote that relative link to **main**
(`blob/main/docs/research/benchmarks/README.md`). main's committed
benchmark snapshot only moves on a deliberate `run.sh` refresh, so the
linked numbers lag the freshly measured figures each release publishes —
readers landed on stale data.

## Fix

Publish a rendered prose copy of the benchmark write-up to the release
path on the orphan `assets` branch, and repoint **only** the performance
page's link there.

- **`mdsmith-release render-bench-page <out>`** (new): reads the
  benchmark README and rewrites every repo-relative link to an absolute
  GitHub URL on main, so the page has no 404 links once it is lifted onto
  the `assets` branch (where the sibling files don't exist). Pure,
  unit-tested transform reusing the existing `applyOutsideCode` /
  `githubURLForPath` helpers.
- **`release.yml` `benchmark-publish`**: splices this release's fresh
  fragments into the README, renders it via the new subcommand, and
  publishes it to `assets/benchmarks/pages/benchmark.md` alongside the
  numbers it already pushes. The working-tree README edit is discarded by
  the branch switch, so main's committed snapshot is untouched.
- **Site sync**: `docs/features/performance.md`'s benchmark link is
  repointed to the assets page. The feature page's strict 80-column
  line-length budget (non-`stern`, and the URL alone is 83 chars) rules
  out carrying the absolute URL in the source, so the source keeps the
  short relative link and only the synced site copy is swapped
  (`repointBenchDocToAssets`, scoped to that one file).

Per the decisions taken while scoping this: **target** = publish prose to
the release path (not the per-merge drift path, which violates the
record-only `#502` principle); **scope** = the performance page only —
`background/markdown-linters.md` and `reference/conventions.md` keep their
main source links. This also makes the README's "Gates" section accurate
(it already claimed a rendered page was published; it wasn't).

## Tests

- New unit + fixture tests for the link transform, the scoped matcher,
  and an end-to-end `SyncDocs` check that the repoint hits the
  performance page and **only** the performance page.
- New CLI dispatch/arity/help coverage for `render-bench-page`.
- `go build ./...`, `go vet`, `gofmt`, full `go test ./...` green (the
  pre-existing `TestPGO*` git-commit tests fail only under the sandbox's
  commit-signing restriction, unrelated to this change).
- `mdsmith check .` passes (472 files).

> Note: golangci-lint couldn't run in the dev sandbox (its `tools/go.mod`
> needs Go 1.25.8; sandbox has 1.25.0) — CI will run it. The new code
> follows the package's established patterns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLnY6SqQVXQxBSq8RYPZg5)_