### PR TITLE
docs(plan/145): record mise PR rejection and blocked-upstream status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -785,7 +785,7 @@ jobs:
             # `github:jeduden/mdsmith@VER` resolves the binary directly
             # off the GitHub release the same `release` job above
             # just published. The shorter `mdsmith@VER` form depends
-            # on the mise-plugins/registry follow-up; until that PR
+            # on the jdx/mise registry PR; until that PR
             # lands the smoke-test would fail on every release, so
             # exercise the form that works today.
             install: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -827,7 +827,7 @@ jobs:
                 sleep 15
               done
               if [ "$ok" -ne 1 ]; then
-                echo "::warning::bare 'mise use mdsmith@${VERSION#v}' did not resolve; the jdx/mise registry entry (plan 145) has not merged yet. The 'mise' channel above (ubi: backend) still verifies the binary."
+                echo "::warning::bare 'mise use mdsmith@${VERSION#v}' did not resolve; the jdx/mise registry entry (plan 145) has not merged yet. The 'mise' channel above (github: backend) still verifies the binary."
                 echo "skipped=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -62,30 +62,23 @@ on `asdf plugin add mdsmith`.
 3. After one successful release cycle, file a PR to
    [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins).
    The entry lets `asdf plugin add mdsmith` resolve
-   without an explicit URL.
+   without an explicit URL. See the Status section
+   before filing — adoption is the current gate.
 4. File a PR to mise's curated registry at
    [`jdx/mise`](https://github.com/jdx/mise).
    Each tool gets one TOML file under `registry/`.
    Add `registry/mdsmith.toml` with a
    `[tools.mdsmith]` section on the
    `github:jeduden/mdsmith` backend and a `test`
-   field (`ubi:` is rejected for new entries).
-   The PR body must make a popularity case.
-   On merge, `mise use mdsmith@latest`
-   resolves without a backend prefix.
+   field (`ubi:` is rejected; `aqua:` only works if
+   mdsmith is already in the Aqua registry; use
+   `github:`). The PR body must make a popularity
+   and maintenance case. On merge,
+   `mise use mdsmith@latest` resolves without a
+   backend prefix.
 
-   **Filed and rejected.**
-   [jdx/mise#10320](https://github.com/jdx/mise/pull/10320)
-   added `registry/mdsmith.toml` on the
-   `github:jeduden/mdsmith` backend with the required
-   `test` field and a popularity case. The maintainer
-   closed it unmerged on 2026-06-11: at 7 stars the
-   project is below the adoption bar the curated
-   registry applies to new tools. Re-submit only after
-   the repo gathers materially more traction; until
-   then the bare `mise use mdsmith@VER` form stays
-   unavailable and the backend-prefixed forms remain
-   the documented path.
+   **Filed and rejected.** See the Status section
+   for details and re-submission criteria.
 5. Update
    [docs/guides/install.md](../docs/guides/install.md)
    to drop the "pending follow-up" badge from the
@@ -95,7 +88,9 @@ on `asdf plugin add mdsmith`.
    in [release.yml](../.github/workflows/release.yml)
    to exercise `asdf install mdsmith X.Y.Z` and
    `mise use mdsmith@X.Y.Z` alongside `ubi:`.
-   The `asdf` channel must pass. The `mise-registry`
+   The `asdf` channel must pass (users install day
+   one via the explicit plugin URL). The
+   `mise-registry`
    channel is best-effort; it warns and exits 0
    until the registry PR merges.
 

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -66,7 +66,9 @@ on `asdf plugin add mdsmith`.
    before filing — adoption is the current gate.
 4. File a PR to mise's curated registry at
    [`jdx/mise`](https://github.com/jdx/mise).
-   Each tool gets one TOML file under `registry/`.
+   Each tool gets one TOML file under `registry/`
+   (the former `mise-plugins/registry` repo is
+   archived; PRs go to `jdx/mise` instead).
    Add `registry/mdsmith.toml` with a
    `[tools.mdsmith]` section on the
    `github:jeduden/mdsmith` backend and a `test`
@@ -78,7 +80,7 @@ on `asdf plugin add mdsmith`.
    backend prefix.
 
    **Filed and rejected.** See the Status section
-   for details and re-submission criteria.
+   for details and the re-submission trigger.
 5. Update
    [docs/guides/install.md](../docs/guides/install.md)
    to drop the "pending follow-up" badge from the
@@ -154,8 +156,3 @@ pending an upstream-acceptance window; revisit when
 the project's traction clears the registries' bars.
 The next concrete action is a mise re-submission once
 star/fork counts grow, then mirror it to asdf-plugins.
-
-Re-verified on 2026-06-14. `jeduden/mdsmith` is still
-at 7 stars. That is unchanged since the mise PR was
-closed. The adoption blocker holds. No new registry PR
-is warranted yet.

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -145,7 +145,10 @@ current adoption level:
   the registry's bar for new tools. The bare
   `mise use mdsmith@VER` form cannot resolve until a
   re-submission is accepted.
-- **asdf (Task 3):** no PR to
+- **asdf (Task 3):** the one-successful-release-cycle
+  precondition is now met — the pipeline has shipped
+  through `v0.47.0` (2026-06-14) — so the only remaining
+  gate is adoption. No PR to
   [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
   has been filed; that index has comparable curation
   expectations, so a submission now would likely meet
@@ -166,3 +169,8 @@ pending an upstream-acceptance window; revisit when
 the project's traction clears the registries' bars.
 The next concrete action is a mise re-submission once
 star/fork counts grow, then mirror it to asdf-plugins.
+
+Re-verified on 2026-06-14. `jeduden/mdsmith` is still
+at 7 stars. That is unchanged since the mise PR was
+closed. The adoption blocker holds. No new registry PR
+is warranted yet.

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -62,13 +62,12 @@ on `asdf plugin add mdsmith`.
 3. After one successful release cycle, file a PR to
    [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins).
    The entry lets `asdf plugin add mdsmith` resolve
-   without an explicit URL. See the Status section
+   without an explicit URL. See the Blockers section
    before filing — adoption is the current gate.
 4. File a PR to mise's curated registry at
    [`jdx/mise`](https://github.com/jdx/mise).
    Each tool gets one TOML file under `registry/`
-   (the former `mise-plugins/registry` repo is
-   archived; PRs go to `jdx/mise` instead).
+   (the former `mise-plugins/registry` is archived).
    Add `registry/mdsmith.toml` with a
    `[tools.mdsmith]` section on the
    `github:jeduden/mdsmith` backend and a `test`
@@ -79,7 +78,7 @@ on `asdf plugin add mdsmith`.
    `mise use mdsmith@latest` resolves without a
    backend prefix.
 
-   **Filed and rejected.** See the Status section
+   **Filed and rejected.** See the Blockers section
    for details and the re-submission trigger.
 5. Update
    [docs/guides/install.md](../docs/guides/install.md)
@@ -91,10 +90,9 @@ on `asdf plugin add mdsmith`.
    to exercise `asdf install mdsmith X.Y.Z` and
    `mise use mdsmith@X.Y.Z` alongside `ubi:`.
    The `asdf` channel must pass (users install day
-   one via the explicit plugin URL). The
-   `mise-registry`
-   channel is best-effort; it warns and exits 0
-   until the registry PR merges.
+   one via the explicit plugin URL).
+   The `mise-registry` channel is best-effort;
+   it warns and exits 0 until the registry PR merges.
 
 ## Acceptance Criteria
 
@@ -119,7 +117,7 @@ on `asdf plugin add mdsmith`.
       `mise-registry` channel is best-effort until
       the jdx/mise registry PR merges.
 
-## Status — blocked upstream
+## Blockers
 
 The remaining work is gated on two curated upstream
 registries, and neither will accept mdsmith at its
@@ -138,7 +136,7 @@ current adoption level:
   gate is adoption. No PR to
   [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
   has been filed; that index has comparable curation
-  expectations, so a submission now would likely meet
+  expectations, so a submission now would meet
   the same popularity objection that closed the mise
   PR. The `plugins/mdsmith` index entry does not exist.
 - **Docs (Task 5):** because neither registry PR has
@@ -149,10 +147,7 @@ current adoption level:
   resolving. The current "needs a registry entry" notes
   are accurate and stay until a PR lands.
 
-Everything inside this repo's control is done: the
-`jeduden/asdf-mdsmith` plugin, its CI, and the
-release.yml smoke-test matrix. The plan stays open
-pending an upstream-acceptance window; revisit when
-the project's traction clears the registries' bars.
-The next concrete action is a mise re-submission once
-star/fork counts grow, then mirror it to asdf-plugins.
+In-repo work is done: the `jeduden/asdf-mdsmith`
+plugin, its CI, and the release.yml smoke-test matrix.
+The plan stays open until adoption clears the
+registries' bar.

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -81,6 +81,19 @@ on `asdf plugin add mdsmith`.
    prefix-less `mise use mdsmith@latest` form starts
    resolving on user CLIs without any code change in
    this repo.
+
+   **Filed and rejected.**
+   [jdx/mise#10320](https://github.com/jdx/mise/pull/10320)
+   added `registry/mdsmith.toml` on the
+   `github:jeduden/mdsmith` backend with the required
+   `test` field and a popularity case. The maintainer
+   closed it unmerged on 2026-06-11: at 7 stars the
+   project is below the adoption bar the curated
+   registry applies to new tools. Re-submit only after
+   the repo gathers materially more traction; until
+   then the bare `mise use mdsmith@VER` form stays
+   unavailable and the backend-prefixed forms remain
+   the documented path.
 5. Update
    [docs/guides/install.md](../docs/guides/install.md)
    to drop the "pending follow-up" badge from the
@@ -118,3 +131,38 @@ on `asdf plugin add mdsmith`.
       The `asdf` channel is required-green; the bare
       `mise-registry` channel is best-effort until
       the jdx/mise registry PR merges.
+
+## Status — blocked upstream
+
+The remaining work is gated on two curated upstream
+registries, and neither will accept mdsmith at its
+current adoption level:
+
+- **mise (Task 4):**
+  [jdx/mise#10320](https://github.com/jdx/mise/pull/10320)
+  was filed with the correct `registry/mdsmith.toml`
+  and closed unmerged on 2026-06-11 — 7 stars is below
+  the registry's bar for new tools. The bare
+  `mise use mdsmith@VER` form cannot resolve until a
+  re-submission is accepted.
+- **asdf (Task 3):** no PR to
+  [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
+  has been filed; that index has comparable curation
+  expectations, so a submission now would likely meet
+  the same popularity objection that closed the mise
+  PR. The `plugins/mdsmith` index entry does not exist.
+- **Docs (Task 5):** because neither registry PR has
+  merged,
+  [docs/guides/install.md](../docs/guides/install.md)
+  must keep flagging the bare `asdf plugin add mdsmith`
+  and bare `mise use mdsmith@VER` forms as not-yet-
+  resolving. The current "needs a registry entry" notes
+  are accurate and stay until a PR lands.
+
+Everything inside this repo's control is done: the
+`jeduden/asdf-mdsmith` plugin, its CI, and the
+release.yml smoke-test matrix. The plan stays open
+pending an upstream-acceptance window; revisit when
+the project's traction clears the registries' bars.
+The next concrete action is a mise re-submission once
+star/fork counts grow, then mirror it to asdf-plugins.

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -56,31 +56,23 @@ on `asdf plugin add mdsmith`.
      and places the binary as `bin/mdsmith`.
   - `bin/list-bin-paths` prints `bin`.
 
-2. Add a CI workflow on `jeduden/asdf-mdsmith` that
-   runs `asdf install mdsmith latest` against the
-   most recent release and asserts `mdsmith version`
-   matches the resolved tag.
+2. Add a CI workflow on `jeduden/asdf-mdsmith`.
+   Run `asdf install mdsmith latest` and assert
+   that `mdsmith version` matches the resolved tag.
 3. After one successful release cycle, file a PR to
-   [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
-   adding mdsmith so `asdf plugin add mdsmith`
-   resolves without an explicit URL.
-4. File a PR to mise's curated registry: the
-   `registry/` directory in
-   [`jdx/mise`](https://github.com/jdx/mise), one
-   TOML file per tool. (The former root
-   `registry.toml` was split into per-tool files;
-   the separate `mise-plugins/registry` repo was
-   archived in Oct 2024.) Add
-   `registry/mdsmith.toml` with a `[tools.mdsmith]`
-   entry on the `github:jeduden/mdsmith` backend
-   (`ubi:` is rejected for new entries; `aqua:` is
-   preferred only for tools already in the aqua
-   registry) and the required `test` field. The PR
-   body must make a popularity/maintenance case,
-   since the registry is curated. Once merged, the
-   prefix-less `mise use mdsmith@latest` form starts
-   resolving on user CLIs without any code change in
-   this repo.
+   [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins).
+   The entry lets `asdf plugin add mdsmith` resolve
+   without an explicit URL.
+4. File a PR to mise's curated registry at
+   [`jdx/mise`](https://github.com/jdx/mise).
+   Each tool gets one TOML file under `registry/`.
+   Add `registry/mdsmith.toml` with a
+   `[tools.mdsmith]` section on the
+   `github:jeduden/mdsmith` backend and a `test`
+   field (`ubi:` is rejected for new entries).
+   The PR body must make a popularity case.
+   On merge, `mise use mdsmith@latest`
+   resolves without a backend prefix.
 
    **Filed and rejected.**
    [jdx/mise#10320](https://github.com/jdx/mise/pull/10320)
@@ -101,13 +93,11 @@ on `asdf plugin add mdsmith`.
    merges.
 6. [x] Update the release-workflow smoke-test matrix
    in [release.yml](../.github/workflows/release.yml)
-   to also exercise `asdf install mdsmith X.Y.Z` and
-   the bare `mise use mdsmith@X.Y.Z` form, in
-   addition to the `ubi:` form already covered. The
-   `asdf` entry is required (installs day one via the
-   explicit plugin URL); the bare `mise-registry`
-   entry is best-effort — it warns and exits 0 until
-   the jdx/mise registry PR merges.
+   to exercise `asdf install mdsmith X.Y.Z` and
+   `mise use mdsmith@X.Y.Z` alongside `ubi:`.
+   The `asdf` channel must pass. The `mise-registry`
+   channel is best-effort; it warns and exits 0
+   until the registry PR merges.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

- Documents that `jdx/mise#10320` was filed and closed 2026-06-11 — the project's 7 stars fell below the curated mise registry's adoption bar
- Records that the asdf-plugins PR has not been filed (same adoption objection expected)
- Explains why Tasks 3–5 in plan/145 stay open and what the re-submission trigger is (more traction)
- Everything inside this repo's control is already done (jeduden/asdf-mdsmith plugin, CI, release.yml smoke-test matrix)

## Test plan

- [ ] `mdsmith check` passes on the updated plan file
- [ ] Plan accurately reflects current blocked state

https://claude.ai/code/session_01B5TyBtxEbtoVmPBuWgVpa7

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5TyBtxEbtoVmPBuWgVpa7)_