### PR TITLE
docs: complete the gomarklint comparison (benchmark + linter-comparison page)

### DIFF
--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -170,8 +170,8 @@ of scope. A repo that wants both layers runs gomarklint's
 
 #### gomarklint equivalence and the line-scanner trade-off
 
-gomarklint parses no Markdown AST. It strips front matter,
-splits the file into lines, and scans each line with
+gomarklint 3.2.3 parses no Markdown AST. It strips front
+matter, splits the file into lines, and scans each line with
 hand-written byte and string matching. Its only dependencies
 are a glob library and a CLI parser — no goldmark, no
 CommonMark parser. mdsmith parses every file to a goldmark
@@ -188,25 +188,38 @@ AST linter on the common cases. Three rules diverge:
   tables or reference-link definitions. mdsmith's
   [MDS001][mds001] counts characters and excludes code
   blocks, tables, and URLs, and runs by default; gomarklint
-  leaves its own rule off.
+  leaves its own rule off. At a shared limit of 30,
+  gomarklint flags a 20-character CJK line with
+  `line exceeds 30 bytes (60)`, which mdsmith passes.
 - `duplicate-heading` does not track code fences, so a `#`
   line inside a fenced block counts as a heading. It also
   reads any `#`-led line as a heading, with or without a
   following space. mdsmith resolves headings from the
-  goldmark AST, so neither case misfires.
+  goldmark AST. For a `# Build` inside a fence, gomarklint
+  prints `duplicate heading: "build"`; mdsmith reports
+  nothing.
 - `link-fragments` resolves `#anchor` links within one file
   only; it has no cross-file `other.md#section` resolution.
   mdsmith's [MDS027][mds027] walks the whole-repo link and
   anchor graph, so the shared mapping is a subset of what
-  mdsmith checks, not an equal. gomarklint does carry a
-  richer per-file slug vocabulary (GitHub, GitLab, Hugo,
-  MkDocs), configurable per project.
+  mdsmith checks, not an equal. On a broken `other.md#nope`,
+  gomarklint stays silent while MDS027 reports
+  `broken link target "other.md#nope" not found`. gomarklint
+  does carry a richer per-file slug vocabulary (GitHub,
+  GitLab, Hugo, MkDocs), configurable per project.
 
 The trade runs both ways. gomarklint deliberately skips a
 lone URL fenced by blank lines (a GitHub or Zenn
-link-preview card) that markdownlint and mdsmith both flag.
-Its `external-link` rule then validates live URLs over the
-network, the one check mdsmith omits by design.
+link-preview card) that markdownlint and mdsmith both flag;
+mdsmith's MDS012 reports the standalone URL gomarklint passes
+over. Its `external-link` rule then validates live URLs over
+the network, the one check mdsmith omits by design.
+
+Every line of output quoted here comes from gomarklint 3.2.3
+and mdsmith on minimal fixtures. The
+[gomarklint equivalence evidence][gml-evidence] note carries
+each fixture, the exact commands, and both tools' full
+output.
 
 gomarklint claims 100,000+ lines in ~170 ms for its
 structural checks. It is pinned into the first-party
@@ -1077,3 +1090,4 @@ if you need a stable rule set across upgrades.
 [conventions]: ../reference/conventions.md
 [bench]: ../research/benchmarks/README.md
 [mdcov]: ../research/markdownlint-coverage/README.md
+[gml-evidence]: ../research/gomarklint-equivalence/README.md

--- a/docs/background/markdown-linters.md
+++ b/docs/background/markdown-linters.md
@@ -168,10 +168,54 @@ an external URL still answers HTTP 200 is deliberately out
 of scope. A repo that wants both layers runs gomarklint's
 `external-link` job next to `mdsmith check` in CI.
 
+#### gomarklint equivalence and the line-scanner trade-off
+
+gomarklint parses no Markdown AST. It strips front matter,
+splits the file into lines, and scans each line with
+hand-written byte and string matching. Its only dependencies
+are a glob library and a CLI parser — no goldmark, no
+CommonMark parser. mdsmith parses every file to a goldmark
+AST. That one architectural difference sets where the 22
+shared rules are genuine equivalents and where they are not.
+
+Most gomarklint rules track fenced-code state and strip
+inline-code spans themselves as they scan. So they match an
+AST linter on the common cases. Three rules diverge:
+
+- `max-line-length` measures bytes, not characters, so a
+  line of CJK or emoji over-counts the limit. It exempts
+  only code fences, ATX headings, and whole-line URLs, not
+  tables or reference-link definitions. mdsmith's
+  [MDS001][mds001] counts characters and excludes code
+  blocks, tables, and URLs, and runs by default; gomarklint
+  leaves its own rule off.
+- `duplicate-heading` does not track code fences, so a `#`
+  line inside a fenced block counts as a heading. It also
+  reads any `#`-led line as a heading, with or without a
+  following space. mdsmith resolves headings from the
+  goldmark AST, so neither case misfires.
+- `link-fragments` resolves `#anchor` links within one file
+  only; it has no cross-file `other.md#section` resolution.
+  mdsmith's [MDS027][mds027] walks the whole-repo link and
+  anchor graph, so the shared mapping is a subset of what
+  mdsmith checks, not an equal. gomarklint does carry a
+  richer per-file slug vocabulary (GitHub, GitLab, Hugo,
+  MkDocs), configurable per project.
+
+The trade runs both ways. gomarklint deliberately skips a
+lone URL fenced by blank lines (a GitHub or Zenn
+link-preview card) that markdownlint and mdsmith both flag.
+Its `external-link` rule then validates live URLs over the
+network, the one check mdsmith omits by design.
+
 gomarklint claims 100,000+ lines in ~170 ms for its
 structural checks. It is pinned into the first-party
-[benchmark](#benchmarks) harness; its row joins the
-published tables at the next snapshot refresh.
+[benchmark](#benchmarks) harness and measured on every
+merge. The per-merge `assets` copy already carries its row;
+the committed in-repo tables add it at the next deliberate
+refresh. See the gomarklint fairness note in the
+[benchmark doc][bench] for how its time reads against the
+others.
 
 ### [Prettier][]
 

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -1,9 +1,10 @@
 ---
 summary: >-
-  First-party hyperfine benchmark of mdsmith against mado,
-  rumdl, panache, and markdownlint-cli2 over two corpora, with
-  the exact commands, environment, and an honest reading of why
-  mdsmith trails the per-file Rust linters.
+  First-party hyperfine benchmark of mdsmith against
+  gomarklint, mado, rumdl, panache, and markdownlint-cli2 over
+  two corpora, with the exact commands, environment, and an
+  honest reading of where mdsmith trails the lighter per-file
+  linters.
 ---
 # Markdown linter benchmark
 
@@ -62,9 +63,9 @@ docs read.
   numbers, which is why the per-tool ratio within one run, not
   the cross-tool absolute time across runs, is the signal (see
   [Why absolute numbers move](#why-absolute-numbers-move-and-how-the-factor-stays-stable)).
-- mdsmith (Go 1.25.8 build), mado 0.3.0, rumdl 0.1.93,
-  panache 2.46.0, markdownlint-cli2 0.22.1 (markdownlint
-  0.40.0)
+- mdsmith (Go 1.25.8 build), gomarklint 3.2.3, mado 0.3.0,
+  rumdl 0.1.93, panache 2.46.0, markdownlint-cli2 0.22.1
+  (markdownlint 0.40.0)
 - Date: 2026-06-12 (the v0.43.0 release run's
   `benchmark-publish` measurement, promoted from the
   `assets` branch so the committed baseline shares the
@@ -279,23 +280,34 @@ The rule-by-rule mapping against the other linters
 lives in the [peer-linter coverage matrix][mdcov]
 instead.
 
-### gomarklint joins the table at the next refresh
+### Fairness note on gomarklint
 
 gomarklint is wired into the harness: its release tarball
 and SHA-256 are pinned in the `benchTools` manifest
 (`internal/release/bench.go`), and `runHyperfine` drives
-it on bare defaults next to the other tools. From the
-merge onward, the per-merge `benchmark.yml` run and each
-release's `benchmark-publish` job measure it.
+it on bare defaults next to the other tools. The per-merge
+`benchmark.yml` run and each release's `benchmark-publish`
+job measure it.
 
-The tables above lack a gomarklint row only because they
-render from the committed `data/*.json` snapshot, and
-that snapshot moves when a maintainer re-runs the whole
-harness via `run.sh` and reviews the result in a PR —
-cross-tool ratios are only valid within a single run on
-one machine. The row appears with the next deliberate
-refresh. Until then the rule-by-rule comparison lives in
-the [peer-linter coverage matrix][mdcov].
+Whether a gomarklint row appears here depends on which copy
+you read. The committed `data/*.json` snapshot under this
+directory moves only when a maintainer re-runs `run.sh` and
+reviews the result in a PR. So it can still predate
+gomarklint and omit the row. The per-merge `assets` copy
+re-measures with gomarklint included, so it already carries
+the row.
+
+Read that row as the lightest-workload entry. gomarklint's
+defaults cover 21 of mdsmith's rules — 22 in all, one off by
+default, every one a full cover. That is the smallest
+default rule set of the markdownlint-family CLI tools here:
+mado covers 28, rumdl and markdownlint 42 each (counts from
+the [peer-linter coverage matrix][mdcov], generated from
+rule front matter). So when gomarklint posts the fastest
+time on both corpora, part of that lead is fewer checks per
+file, not a like-for-like win. Read it as the panache note
+reads panache, in the other direction: same job, lighter
+ruleset.
 
 [mdcov]: ../markdownlint-coverage/README.md
 

--- a/docs/research/benchmarks/README.md
+++ b/docs/research/benchmarks/README.md
@@ -292,10 +292,10 @@ job measure it.
 Whether a gomarklint row appears here depends on which copy
 you read. The committed `data/*.json` snapshot under this
 directory moves only when a maintainer re-runs `run.sh` and
-reviews the result in a PR. So it can still predate
-gomarklint and omit the row. The per-merge `assets` copy
-re-measures with gomarklint included, so it already carries
-the row.
+reviews the result in a PR. So that snapshot can still
+predate gomarklint and omit the row. The per-merge `assets`
+copy re-measures with gomarklint included, so it already
+carries the row.
 
 Read that row as the lightest-workload entry. gomarklint's
 defaults cover 21 of mdsmith's rules — 22 in all, one off by
@@ -305,9 +305,8 @@ mado covers 28, rumdl and markdownlint 42 each (counts from
 the [peer-linter coverage matrix][mdcov], generated from
 rule front matter). So when gomarklint posts the fastest
 time on both corpora, part of that lead is fewer checks per
-file, not a like-for-like win. Read it as the panache note
-reads panache, in the other direction: same job, lighter
-ruleset.
+file, not a like-for-like win. It runs the same job as the
+others with a lighter rule set.
 
 [mdcov]: ../markdownlint-coverage/README.md
 

--- a/docs/research/gomarklint-equivalence/README.md
+++ b/docs/research/gomarklint-equivalence/README.md
@@ -1,0 +1,192 @@
+---
+summary: >-
+  Reproducible evidence for the gomarklint-versus-mdsmith rule
+  divergences — one fixture per claim, the gomarklint 3.2.3 and
+  mdsmith commands, and both tools' verbatim output.
+---
+# gomarklint equivalence evidence
+
+The [linter comparison][cmp] states three places where
+gomarklint's line scanner diverges from mdsmith's AST checks,
+plus one where gomarklint reports less. Each claim here is one
+minimal fixture run through both tools, with verbatim output.
+Source-reading alone does not settle a behavioural claim, so
+every divergence below is a command you can re-run.
+
+## Versions
+
+- **gomarklint 3.2.3** — built from the `v3.2.3` tag of
+  [`shinagawa-web/gomarklint`][gml] (commit `4c3dc17`) with
+  `go build`. Its only direct dependencies are a glob library
+  and cobra; it links no Markdown parser, so it scans lines
+  rather than building a CommonMark AST.
+- **mdsmith `v0.0.0-20260614184107-53bee322dcd6`** — this
+  repository at the head of the change that adds this note.
+
+## Method
+
+Each case is one Markdown fixture plus a minimal
+`.gomarklint.json` that enables only the rule under test
+(`"default": false`). Both tools lint the same file:
+gomarklint as `gomarklint <file>`, mdsmith as
+`mdsmith check <file>`. Output is shown verbatim with color
+disabled; gomarklint's trailing "Checked … in Nms" timing line
+is elided because it varies run to run.
+
+## max-line-length counts bytes, not characters
+
+`.gomarklint.json`:
+
+```json
+{"default": false, "rules": {"max-line-length": {"enabled": true, "lineLength": 30}}}
+```
+
+`bytes.md` — line 3 is 20 CJK characters, which is 20 runes
+but 60 bytes:
+
+```markdown
+# H
+
+ああああああああああああああああああああ
+```
+
+gomarklint flags line 3 at a 30-unit limit, and its message
+names the unit:
+
+```text
+Errors in bytes.md:
+  bytes.md:3: [error] max-line-length: line exceeds 30 bytes (60)
+
+✖ 1 issues found
+```
+
+mdsmith, with `line-length.max: 30` on the same file, counts
+20 runes and stays silent:
+
+```text
+stats: checked=1 fixed=0 failures=0 unfixed=0
+```
+
+So at one shared limit the two tools disagree on a line of
+multi-byte text. mdsmith counts characters
+(`utf8.RuneCount`); gomarklint counts bytes.
+
+## duplicate-heading counts headings inside code fences
+
+`.gomarklint.json`:
+
+```json
+{"default": false, "rules": {"duplicate-heading": true}}
+```
+
+`dupfence.md` — the second `# Build` is inside a fenced code
+block, so it is code, not a heading:
+
+````markdown
+# Build
+
+```text
+# Build
+```
+````
+
+gomarklint has no fenced-block state in this rule, so it reads
+line 4 as a heading and reports a duplicate:
+
+```text
+Errors in dupfence.md:
+  dupfence.md:4: [error] duplicate heading: "build"
+
+✖ 1 issues found
+```
+
+mdsmith resolves headings from the AST, where line 4 is a code
+line, so there is no duplicate:
+
+```text
+stats: checked=1 fixed=0 failures=0 unfixed=0
+```
+
+## link-fragments resolves anchors in one file only
+
+`.gomarklint.json`:
+
+```json
+{"default": false, "rules": {"link-fragments": {"enabled": true, "slug-algorithm": "github"}}}
+```
+
+`links.md` — one broken same-file anchor and one broken
+cross-file anchor:
+
+```markdown
+# Title
+
+[same-file broken](#nope)
+
+[cross-file broken](other.md#nope)
+```
+
+gomarklint reports the same-file fragment only; its message
+says "in this document". The cross-file `other.md#nope` is not
+checked:
+
+```text
+Errors in links.md:
+  links.md:3: [error] link-fragments: fragment #nope not found in this document
+
+✖ 1 issues found
+```
+
+mdsmith's whole-repo graph (MDS027) reports both — including
+the cross-file target gomarklint passed over:
+
+```text
+links.md:3:2 MDS027 broken link target "#nope" has no matching heading anchor
+links.md:5:2 MDS027 broken link target "other.md#nope" not found
+stats: checked=1 fixed=0 failures=2 unfixed=2
+```
+
+## no-bare-urls skips a blank-line-fenced URL
+
+`.gomarklint.json`:
+
+```json
+{"default": false, "rules": {"no-bare-urls": true}}
+```
+
+`urls.md` — one URL inline in a sentence, one URL alone
+between blank lines:
+
+```markdown
+# Links
+
+Inline https://example.com/a here.
+
+https://example.com/b
+```
+
+gomarklint reports the inline URL only. A URL alone between
+blank lines is treated as a renderer link-card and left
+unflagged:
+
+```text
+Errors in urls.md:
+  urls.md:3: [error] no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com/a
+
+✖ 1 issues found
+```
+
+mdsmith (MDS012) reports both, including the standalone URL on
+line 5:
+
+```text
+urls.md:3:8 MDS012 bare URL — wrap in angle brackets or add link text
+urls.md:5:1 MDS012 bare URL — wrap in angle brackets or add link text
+stats: checked=1 fixed=0 failures=2 unfixed=2
+```
+
+This case runs the other way from the first three: here
+gomarklint reports less, by design, than mdsmith.
+
+[cmp]: ../../background/markdown-linters.md
+[gml]: https://github.com/shinagawa-web/gomarklint


### PR DESCRIPTION
Brings the gomarklint write-up up to date and completes its equivalence comparison, with every behavioural claim backed by a reproducible run.

## 1. Benchmark write-up (`docs/research/benchmarks/README.md`)

State-robust **"Fairness note on gomarklint"** (was the self-contradicting "joins the table at the next refresh"), the **feature-parity caveat** (gomarklint's defaults cover 21 of mdsmith's rules — the lightest markdownlint-family CLI set, vs mado 28 / rumdl 42 / markdownlint 42), and `gomarklint 3.2.3` in the env + summary.

## 2. Linter comparison page (`docs/background/markdown-linters.md`)

New **"gomarklint equivalence and the line-scanner trade-off"** subsection. gomarklint builds **no Markdown AST** (deps: a glob lib + cobra), so it scans lines; mdsmith parses to a goldmark AST. Three rules diverge (`max-line-length`, `duplicate-heading`, `link-fragments`), plus the reverse case (`no-bare-urls` link-card / `external-link`). Pins gomarklint 3.2.3 and quotes verbatim output inline. Also fixes the repeated stale benchmark-row line.

## 3. Reproducible evidence (`docs/research/gomarklint-equivalence/README.md`) — new

Source-reading is not enough to publish a behavioural claim, so each divergence is **demonstrated by running gomarklint 3.2.3 and mdsmith on a minimal fixture**, with both tools' verbatim output and the exact versions:

| Fixture | gomarklint 3.2.3 | mdsmith (same input) |
|---|---|---|
| 20-char CJK line, limit 30 | `line exceeds 30 bytes (60)` | `failures=0` (counts runes) |
| `# Build` inside a `text` fence | `duplicate heading: "build"` | `failures=0` (AST = code) |
| `other.md#nope` cross-file anchor | silent | `MDS027 broken link target "other.md#nope" not found` |
| standalone (blank-fenced) URL | silent (link card) | `MDS012` flags it |

Versions recorded: gomarklint **3.2.3** (built from the `v3.2.3` tag, commit `4c3dc17`), mdsmith at this PR head.

## Validation

- Caveats confirmed against gomarklint's **v3.2.3 source** and then **demonstrated empirically** (commands + verbatim output in the evidence note).
- `mdsmith check .` passes (473 files, 0 failures); `mdsmith fix` is a no-op.
- Numeric parity figures independently re-derived from rule front matter.

**Deliberately not done:** no fabricated gomarklint numbers in the committed benchmark snapshot — that needs a real `run.sh` refresh on a comparable runner (a maintainer step).

https://claude.ai/code/session_018ZCL5JQ2reXR2SxbjWyKu8