### PR TITLE
docs(bench): lazy-parse research + staged plans to beat gomarklint in parity

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -194,4 +194,8 @@ footer: |
 | 2606130836 | ✅     | opus   | [Pool the per-file source-read buffer across lintFile passes](plan/2606130836_pool-source-read-buffer.md)                               |
 | 2606130837 | ✅     | opus   | [Fast-path front-matter field reads for cross-file rules](plan/2606130837_frontmatter-fast-scan.md)                                     |
 | 2606130838 | ✅     | sonnet | [Memoize linkgraph link and image extraction on the File](plan/2606130838_memoize-link-extraction.md)                                   |
+| 2606141901 | 🔲     | opus   | [Spike: block-only parse cost vs gomarklint](plan/2606141901_spike-block-only-parse-cost.md)                                            |
+| 2606141902 | 🔲     | opus   | [Lazy parse: Layer 0 block scanner and parse-skip](plan/2606141902_lazy-parse-layer0.md)                                                |
+| 2606141903 | 🔲     | opus   | [Lazy parse: BlockSpan seam for block NodeCheckers](plan/2606141903_lazy-parse-blockspan-nodecheckers.md)                               |
+| 2606141904 | 🔲     | opus   | [Lazy parse: Layer 1 light inline index](plan/2606141904_lazy-parse-inline-index.md)                                                    |
 <?/catalog?>

--- a/docs/research/benchmarks/gomarklint-architecture.md
+++ b/docs/research/benchmarks/gomarklint-architecture.md
@@ -216,3 +216,9 @@ file pool. It does **not** close the wall-time gap — by the
 measurements above, nothing at the allocation or GC layer can. The
 route to actually beating gomarklint is the line-scan pipeline above,
 scoped as staged work with a hard, measurable acceptance bar.
+
+A separate line-scan path beside the AST was rejected as a design
+(two rule implementations, a forked API). The refined direction — one
+parser that builds the tree lazily and serves the common rules from a
+cheap scan — is worked out in [Lazy parse architecture: build the AST
+only when a rule needs it](lazy-parse-architecture.md).

--- a/docs/research/benchmarks/gomarklint-architecture.md
+++ b/docs/research/benchmarks/gomarklint-architecture.md
@@ -166,11 +166,14 @@ Conclusion: beating gomarklint requires doing what gomarklint does —
 rule/overhead cost below a line scanner's. Nothing short of that
 clears the bar.
 
-## The path that reaches the goal: a parity line-scan pipeline
+## A first route: the parity line-scan pipeline
 
-This is the only design the arithmetic leaves, and it is a real
-multi-PR project, not a single-session tweak. It is gomarklint's
-architecture, applied to the rules parity keeps.
+This was the first design the arithmetic seemed to leave: rewrite the
+parity rules as line scanners and skip goldmark for them. It was then
+refined — rewriting rules forks the API in two — into the one-model
+lazy parse worked out in [the lazy parse
+note](lazy-parse-architecture.md). The staging below is kept for the
+rule inventory and the equivalence discipline it records.
 
 1. **Line-scan structural model.** A single-pass scanner over
    `f.Lines` that yields what the block-structure rules consume:
@@ -214,11 +217,8 @@ The arena extension shipped here is the safe down payment: a correct,
 equivalence-gated allocation win that reduces GC pressure under the
 file pool. It does **not** close the wall-time gap — by the
 measurements above, nothing at the allocation or GC layer can. The
-route to actually beating gomarklint is the line-scan pipeline above,
-scoped as staged work with a hard, measurable acceptance bar.
-
-A separate line-scan path beside the AST was rejected as a design
-(two rule implementations, a forked API). The refined direction — one
-parser that builds the tree lazily and serves the common rules from a
-cheap scan — is worked out in [Lazy parse architecture: build the AST
-only when a rule needs it](lazy-parse-architecture.md).
+route to actually beating gomarklint is the lazy parse — a refinement
+of the line-scan pipeline above that keeps one rule implementation
+instead of forking it — scoped as staged work with a hard, measurable
+acceptance bar. It is worked out in [Lazy parse architecture: build the
+AST only when a rule needs it](lazy-parse-architecture.md).

--- a/docs/research/benchmarks/lazy-parse-architecture.md
+++ b/docs/research/benchmarks/lazy-parse-architecture.md
@@ -4,10 +4,9 @@ summary: >-
   goldmark fork: build the CommonMark AST only when a rule actually
   navigates it, and serve the common rules from a cheap single-pass
   scanner. Grounded in what real rules read — projections like the
-  code-block line set (16 rules), link references (4), and prose
-  ranges (2) — not the raw node tree. Answers whether simple configs
-  can run at line-scanner speed while heavy configs still get the
-  full tree.
+  code-block line set (15 rules) and link references (4) — not the
+  raw node tree. Answers whether simple configs can run at
+  line-scanner speed while heavy configs still get the full tree.
 ---
 # Lazy parse architecture: build the AST only when a rule needs it
 
@@ -35,13 +34,17 @@ projections, by how many rules depend on each:
 
 | Projection              | Backed by     | Rules  | What it is                             |
 | ----------------------- | ------------- | ------ | -------------------------------------- |
-| `CollectCodeBlockLines` | AST walk      | **16** | set of line numbers inside code blocks |
-| PI-block line set       | AST walk      | 6      | set of `<?…?>` directive lines         |
+| `CollectCodeBlockLines` | AST walk      | **15** | set of line numbers inside code blocks |
+| PI-block line set       | AST walk      | 5      | set of `<?…?>` directive lines         |
 | `LinkReferences`        | parse context | 4      | link reference definitions             |
-| `ProseRanges`           | AST walk      | 2      | source spans of prose text             |
+| `ProseRanges`           | AST walk      | 0†     | prose spans; built, no consumer yet    |
 | raw `f.Lines`           | `bytes.Split` | many   | the lines themselves                   |
 
-Sixteen rules want one fact — *which lines are code* — and reach the
+† `ProseRanges` is the prose projection [plan
+2606022126][audit] built for a future Lines-only conversion. No rule
+consumes it yet (see [Prior art](#prior-art-the-lines-only-audit)).
+
+Fifteen rules want one fact — *which lines are code* — and reach the
 full CommonMark parse to get it. That fact is exactly what a
 fence-tracking line scanner produces in one pass (it is most of what
 gomarklint computes). The AST is doing enormously more than these
@@ -75,6 +78,29 @@ reference-labels` needs the normalized reference map (Unicode case
 folding included). These are the rules that *should* pay for a richer
 representation — and only these.
 
+## Prior art: the Lines-only audit
+
+[Plan 2606022126][audit] already worked this ground, with a narrower
+question. Can a standalone-`Check` rule that walks the AST be rewritten
+to scan `f.Lines` instead? Its probe ran each rule twice. Once with
+`f.AST` nil, once with code-block content perturbed. That reveals each
+rule's true AST dependence. The result is a checked-in manifest at
+`internal/integration/testdata/rule_walk_audit.json`, plus a gate that
+fails any rule that regresses to `f.AST`.
+
+Two findings carry over. The cleanly Lines-only set is empty: plans
+175, 195, and 196 already moved the substring rules off the AST. And
+`ProseRanges` (`internal/lint/proserange.go`) landed as a prose
+projection, but no rule consumes it yet.
+
+This study aims at a different seam. That plan rewrote rules one at a
+time. It left the NodeChecker rules alone, judging their shared walk
+already amortized. It never made the parse itself skippable. The lazy
+parse does exactly those two things. It skips the parse when no enabled
+rule needs the tree. It runs the block NodeCheckers over a skeleton. So
+the manifest is the empirical oracle to validate the layer table here —
+not a verdict against it.
+
 ## The lazy boundary is the projection layer
 
 Today the data flow is eager and one-directional:
@@ -101,7 +127,7 @@ source --> cheap scan ──> line classes / code+PI line sets / fm bounds
   state machine: per-line class (heading / fence / list / blockquote
   / blank / HTML / paragraph), the code-block and PI line sets, and
   front-matter bounds. Allocation-lean, no node tree. This is the
-  gomarklint-equivalent layer and it backs the 16 + the pure-line
+  gomarklint-equivalent layer and it backs those 15 + the pure-line
   rules.
 - **Layer 1 — light inline index (lazy, on first link/ref/image
   read).** A targeted byte scan for links, autolinks, images, and
@@ -114,11 +140,10 @@ source --> cheap scan ──> line classes / code+PI line sets / fm bounds
   emphasis-as-heading, cross-file). Built once and cached on the
   `*lint.File`, exactly as today — just deferred.
 
-The seam already exists in the code: rules call `CollectCodeBlockLines`,
-`LinkReferences`, `ProseRanges`, not `f.AST` directly. Re-backing
-those functions to compute from Layer 0/1 when possible — and to
-trigger Layer 2 only when they cannot — migrates most rules with **no
-rule change at all.**
+The seam already exists in the code: rules call `CollectCodeBlockLines`
+and `LinkReferences`, not `f.AST` directly. Re-backing those functions
+to compute from Layer 0/1 when possible — and to trigger Layer 2 only
+when they cannot — migrates most rules with **no rule change at all.**
 
 ## Rule-by-rule seam audit
 
@@ -142,10 +167,11 @@ says which layer a rule needs *already exists in the rule*:
 | Text (URL scan)                  | no-bare-urls                                                                                                      | 1     |
 | Emphasis                         | emphasis-style                                                                                                    | 2     |
 
-Sixteen of the twenty-five scope to **block** kinds; they need a node's
-kind and line span, nothing inside it. Nine scope to **inline** kinds.
-Emphasis semantics — `emphasis-style` and the all-emphasis check inside
-`no-emphasis-as-heading` — need the full delimiter algorithm (Layer 2).
+Eighteen of the twenty-five react only to **block** kinds; the kind
+plus line span is all those rules need. Seven react to an **inline**
+kind. Emphasis semantics — `emphasis-style` and the all-emphasis check
+inside `no-emphasis-as-heading` — need the full delimiter algorithm
+(Layer 2).
 
 **Caveat: the scoped kind is the dispatch trigger, not the full data
 need.** A rule scoped to `KindParagraph` still sets its own layer by
@@ -254,9 +280,11 @@ the number.
 
 ## Migration path and risk
 
-- **Seam-first.** Re-back `CollectCodeBlockLines` / PI lines /
-  `LinkReferences` / `ProseRanges` to compute from Layer 0/1 with a
-  Layer 2 fallback. Rules that only call these need no change.
+- **Seam-first.** Re-back `CollectCodeBlockLines`, the PI line set,
+  and `LinkReferences` to compute from Layer 0/1 with a Layer 2
+  fallback. Rules that only call these need no change. (`ProseRanges`
+  has no consumer to re-back yet; it is ready for the first prose-rule
+  conversion.)
 - **NodeChecker adapter.** The shared `ast.Walk` dispatch is the
   migration's hardest seam: block NodeCheckers need a skeleton-node
   view, inline NodeCheckers need Layer 1. This is where most of the
@@ -277,7 +305,7 @@ the number.
 
 A lazy parse is feasible and well-shaped for mdsmith because the
 rules already read projections, not the raw tree. Layer 0 (a cheap
-block scan) backs the 16 code-block-line consumers and the pure-line
+block scan) backs the 15 code-block-line consumers and the pure-line
 rules with no parse; Layer 1 (a light inline index) backs the
 reference and URL rules; Layer 2 (the full goldmark AST) is built
 only when a rule navigates the tree. Simple and parity configs can
@@ -285,3 +313,5 @@ shed the parse entirely; heavy configs keep it, unchanged. The open
 question is purely quantitative — is Layer 0 + rules + overhead under
 gomarklint? — and the spike above answers it before any parser
 surgery begins.
+
+[audit]: ../../../plan/2606022126_lines-only-rule-audit.md

--- a/docs/research/benchmarks/lazy-parse-architecture.md
+++ b/docs/research/benchmarks/lazy-parse-architecture.md
@@ -120,6 +120,76 @@ those functions to compute from Layer 0/1 when possible — and to
 trigger Layer 2 only when they cannot — migrates most rules with **no
 rule change at all.**
 
+## Rule-by-rule seam audit
+
+The projection functions are the seam for rules that call them. The
+other seam — the harder one — is the shared `ast.Walk` that drives the
+NodeChecker rules. Auditing it returned the most useful result in this
+study: **every one of the 25 NodeChecker rules is a
+`KindScopedChecker`** — it declares, up front, the exact node kinds it
+reacts to. The engine already dispatches by kind. So the metadata that
+says which layer a rule needs *already exists in the rule*:
+
+| Scoped kind(s)            | NodeChecker rules                                                                                                 | Layer |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----- |
+| Heading                   | blank-line-around-headings, heading-style, no-trailing-punctuation                                                | 0     |
+| FencedCodeBlock           | blank-line-around-fenced-code, fenced-code-style, fenced-code-language, unclosed-code-block, commands-show-output | 0     |
+| List / ListItem           | blank-line-around-lists, list-marker-space, list-marker-style, ordered-list-numbering, list-indent                | 0     |
+| Paragraph                 | no-emphasis-as-heading, forbidden-paragraph-starts, forbidden-text, toc-directive                                 | 0     |
+| ThematicBreak / HTMLBlock | horizontal-rule-style, no-inline-html                                                                             | 0     |
+| Link / Image / CodeSpan   | descriptive-link-text, no-space-in-link-text, no-empty-alt-text, no-space-in-code-spans                           | 1     |
+| Text (URL scan)           | no-bare-urls                                                                                                      | 1     |
+| Emphasis                  | emphasis-style                                                                                                    | 2     |
+
+Sixteen of the twenty-five scope to **block** kinds; they need a node's
+kind and line span, nothing inside it. Nine scope to **inline** kinds.
+Only `emphasis-style` needs the full delimiter algorithm (Layer 2).
+
+A second finding sharpens the boundary: some block rules reference
+*every* inline type — `blank-line-around-lists` and `list-indent` both
+carry `case *ast.Text, *ast.CodeSpan, *ast.Emphasis, *ast.Link,
+*ast.Image, *ast.AutoLink, *ast.RawHTML:`. That is not inline
+*semantics* — it is "treat all inline as opaque, I only care about the
+block." Those references disappear the moment the rule reads a block
+skeleton with no inline children to enumerate. They are Layer 0, not
+Layer 1.
+
+### The one coupling to break
+
+Block NodeCheckers receive `ast.Node` and immediately narrow it:
+`heading, ok := n.(*ast.Heading)`, then read `astutil.HeadingLine` and
+`f.Lines`. The type assertion is the only thing tying them to the heap
+tree. Two ways to serve them without a full parse:
+
+- **Lazy inline (smaller change).** Build *block* nodes as real
+  `ast.Node` (arena-backed, cheap) but defer inline parsing per block.
+  Block NodeCheckers keep working unchanged; inline-kind checkers
+  trigger inline materialization. Removes the inline phase (~11%) but
+  keeps the block-tree cost (~23%) — helps default configs, **not
+  enough for parity.**
+- **Block skeleton (the parity change).** Present each block as a flat
+  `BlockSpan` (kind + line range + nesting), and adapt the 16
+  block-kind `CheckNode`s to read kind + line from it instead of
+  `n.(*ast.Heading)`. Mechanical, because they already read only kind +
+  position. Removes block + inline cost — the version that can beat
+  gomarklint.
+
+`KindScopedChecker` is what makes the second option tractable: the
+engine knows each enabled rule's kinds, so it can decide per run
+whether any rule forces Layer 1/2, and otherwise run Layer 0 only.
+
+### Where every rule lands
+
+- **Layer 0 (no parse): ~35 rules.** The pure-line rules, the 16
+  CollectCodeBlockLines consumers, the astutil section/heading rules,
+  and the 16 block-kind NodeCheckers.
+- **Layer 1 (light inline index): ~10 rules.** The link / image / URL /
+  code-span / reference rules.
+- **Layer 2 (full AST): the rest.** Emphasis semantics, prose
+  (readability, structure, token budget, proper names), and the
+  cross-file / directive rules (catalog, include, cross-file
+  integrity, required-structure).
+
 ## Feasibility verdict, by scenario
 
 The honest answer to "fast for simple, expensive only when needed"

--- a/docs/research/benchmarks/lazy-parse-architecture.md
+++ b/docs/research/benchmarks/lazy-parse-architecture.md
@@ -132,7 +132,7 @@ source --> cheap scan ──> line classes / code+PI line sets / fm bounds
 - **Layer 1 — light inline index (lazy, on first link/ref/image
   read).** A targeted byte scan for links, autolinks, images, and
   `[label]: url` definitions/uses — not the full emphasis delimiter
-  algorithm. Backs the four reference rules and the bare-URL / alt-
+  algorithm. Backs the three reference rules and the bare-URL / alt-
   text rules.
 - **Layer 2 — full AST (lazy, on first tree navigation).** The
   existing goldmark parse, materialized only when a rule walks the
@@ -169,9 +169,10 @@ says which layer a rule needs *already exists in the rule*:
 
 Eighteen of the twenty-five react only to **block** kinds; the kind
 plus line span is all those rules need. Seven react to an **inline**
-kind. Emphasis semantics — `emphasis-style` and the all-emphasis check
-inside `no-emphasis-as-heading` — need the full delimiter algorithm
-(Layer 2).
+kind. The general rule `emphasis-style` needs the full delimiter
+algorithm (Layer 2). `no-emphasis-as-heading` reads a parsed emphasis
+node too. But it asks only one bounded question: is a whole paragraph a
+single emphasis span?
 
 **Caveat: the scoped kind is the dispatch trigger, not the full data
 need.** A rule scoped to `KindParagraph` still sets its own layer by
@@ -241,11 +242,13 @@ enabled rules force:
   speed, and it covers a large share of real-world `.mdsmith.yml`
   setups.
 - **Parity (the benchmark target).** The prize, and the real work.
-  Parity's block NodeChecker rules must consume the Layer 0 block
-  spans instead of `ast.Node`, and its six inline rules must consume
-  the Layer 1 index. Once every parity rule reads Layer 0/1, the
-  engine skips Layer 2 and parity stops parsing — the only path to
-  beating gomarklint.
+  Parity's block NodeChecker rules must read the Layer 0 block spans,
+  not `ast.Node`. Its link, image, and reference rules read the Layer 1
+  index. One parity rule resists: `no-emphasis-as-heading` reads a
+  parsed `*ast.Emphasis` node, so it sits at Layer 2 today. Parity sheds
+  the parse only if that rule's bounded check — is a whole paragraph one
+  emphasis span? — moves to Layer 1. That one rule gates whether parity
+  beats gomarklint.
 - **Default / full configs.** No change, no regression. Prose,
   cross-file, and deep rules trigger Layer 2; the AST is built once
   and cached, exactly as today. Lazy parsing is a no-op here, which

--- a/docs/research/benchmarks/lazy-parse-architecture.md
+++ b/docs/research/benchmarks/lazy-parse-architecture.md
@@ -1,0 +1,205 @@
+---
+summary: >-
+  Feasibility study for a lazy parse architecture in mdsmith's
+  goldmark fork: build the CommonMark AST only when a rule actually
+  navigates it, and serve the common rules from a cheap single-pass
+  scanner. Grounded in what real rules read — projections like the
+  code-block line set (16 rules), link references (4), and prose
+  ranges (2) — not the raw node tree. Answers whether simple configs
+  can run at line-scanner speed while heavy configs still get the
+  full tree.
+---
+# Lazy parse architecture: build the AST only when a rule needs it
+
+The benchmark study ([gomarklint architecture and the parity
+gap](gomarklint-architecture.md)) showed that a separate line-scan
+code path beside the AST means two implementations per rule and a
+forked API — the wrong design. This note studies the alternative:
+**one parser whose output is cheap by default and materializes the
+heavy CommonMark tree only when a rule reads it.**
+
+The question to answer: can a lazy parse run simple scenarios at
+line-scanner speed and pay the AST cost *only* when a rule actually
+needs the tree?
+
+Short answer from the evidence below: **yes — because rules almost
+never read the raw tree. They read a handful of cheap projections,
+and those projections are the natural lazy boundary.**
+
+## What rules actually read
+
+Auditing every rule's access to the parsed file is the whole game. A
+rule that "uses the AST" usually does not navigate the node graph —
+it calls one derived projection and consumes a flat result. The
+projections, by how many rules depend on each:
+
+| Projection              | Backed by     | Rules  | What it is                             |
+| ----------------------- | ------------- | ------ | -------------------------------------- |
+| `CollectCodeBlockLines` | AST walk      | **16** | set of line numbers inside code blocks |
+| PI-block line set       | AST walk      | 6      | set of `<?…?>` directive lines         |
+| `LinkReferences`        | parse context | 4      | link reference definitions             |
+| `ProseRanges`           | AST walk      | 2      | source spans of prose text             |
+| raw `f.Lines`           | `bytes.Split` | many   | the lines themselves                   |
+
+Sixteen rules want one fact — *which lines are code* — and reach the
+full CommonMark parse to get it. That fact is exactly what a
+fence-tracking line scanner produces in one pass (it is most of what
+gomarklint computes). The AST is doing enormously more than these
+rules consume.
+
+### Three rules, three depths
+
+**Simple — `line-length` (MDS001), the most-run rule.** Its core is
+a byte-length scan over `f.Lines`. It touches the "AST" only through
+`CollectCodeBlockLines` (to skip code) and `collectHeadingLines` (for
+an optional per-heading limit); its *table* exclusion is already a
+pure byte scan (`isTableLineStart`, no AST). So MDS001 needs three
+line classifications — code, heading, table — and nothing else. No
+node graph, no inline tree. A skeleton scanner satisfies it
+completely.
+
+**Block — the NodeChecker rules (`blank-line-around-*`,
+`list-marker-space`, `list-indent`, `fenced-code-*`).** These ride a
+single shared `ast.Walk`, but they inspect *block* nodes — headings,
+lists, list items, fenced code — and their line positions. They need
+block structure, not inline detail. A block skeleton that records
+each block's kind and line span serves them; the pointer-linked tree
+and the inline phase are surplus.
+
+**Heavy — `cross-file-reference-integrity` (MDS027),
+`paragraph-readability` (MDS023), the link/reference rules.** These
+genuinely need depth: MDS027 resolves link targets across files
+(reference map + filesystem + other files' parses); MDS023 extracts
+prose text (inline projection) and scores it; `no-undefined-
+reference-labels` needs the normalized reference map (Unicode case
+folding included). These are the rules that *should* pay for a richer
+representation — and only these.
+
+## The lazy boundary is the projection layer
+
+Today the data flow is eager and one-directional:
+
+```text
+source --> goldmark parse (block + inline, full tree) --> projections --> rules
+```
+
+Every run pays the full parse so the projections can be derived,
+even when the only enabled rule is `no-trailing-spaces`.
+
+The lazy design inverts the dependency: projections become the
+primary product of a cheap scanner, and the full tree is one more
+projection — built on demand.
+
+```text
+source --> cheap scan ──> line classes / code+PI line sets / fm bounds
+                      └──> light link & reference index
+                      └──> [lazy] full goldmark AST  <-- only on first
+                                                          tree navigation
+```
+
+- **Layer 0 — line model (always).** `f.Lines` plus a one-pass block
+  state machine: per-line class (heading / fence / list / blockquote
+  / blank / HTML / paragraph), the code-block and PI line sets, and
+  front-matter bounds. Allocation-lean, no node tree. This is the
+  gomarklint-equivalent layer and it backs the 16 + the pure-line
+  rules.
+- **Layer 1 — light inline index (lazy, on first link/ref/image
+  read).** A targeted byte scan for links, autolinks, images, and
+  `[label]: url` definitions/uses — not the full emphasis delimiter
+  algorithm. Backs the four reference rules and the bare-URL / alt-
+  text rules.
+- **Layer 2 — full AST (lazy, on first tree navigation).** The
+  existing goldmark parse, materialized only when a rule walks the
+  node graph or needs full inline structure (prose extraction,
+  emphasis-as-heading, cross-file). Built once and cached on the
+  `*lint.File`, exactly as today — just deferred.
+
+The seam already exists in the code: rules call `CollectCodeBlockLines`,
+`LinkReferences`, `ProseRanges`, not `f.AST` directly. Re-backing
+those functions to compute from Layer 0/1 when possible — and to
+trigger Layer 2 only when they cannot — migrates most rules with **no
+rule change at all.**
+
+## Feasibility verdict, by scenario
+
+The honest answer to "fast for simple, expensive only when needed"
+is per active rule set, because the engine builds whatever the
+enabled rules force:
+
+- **Simple configs (line + projection rules only).** Big win, low
+  effort. With Layer 0 backing `CollectCodeBlockLines` and the line
+  rules, a config like "trailing spaces + line length + hard tabs +
+  heading style" never builds the AST. This is gomarklint-class
+  speed, and it covers a large share of real-world `.mdsmith.yml`
+  setups.
+- **Parity (the benchmark target).** The prize, and the real work.
+  Parity's block NodeChecker rules must consume the Layer 0 block
+  spans instead of `ast.Node`, and its six inline rules must consume
+  the Layer 1 index. Once every parity rule reads Layer 0/1, the
+  engine skips Layer 2 and parity stops parsing — the only path to
+  beating gomarklint.
+- **Default / full configs.** No change, no regression. Prose,
+  cross-file, and deep rules trigger Layer 2; the AST is built once
+  and cached, exactly as today. Lazy parsing is a no-op here, which
+  is correct — those rules need the tree.
+
+So lazy parsing is not a universal speedup; it is a **floor
+removal** for the configs whose rules never needed the tree, and a
+no-op for the configs that do.
+
+## The honest performance bar
+
+Two facts must hold for this to beat gomarklint on parity, and a
+spike should confirm both before the parser is touched for real:
+
+1. **Layer 0 must be near-line-scan cheap.** If the block state
+   machine allocates a tree or rescans per rule, it is just goldmark
+   again. Target: one pass, flat spans, no per-node heap object.
+2. **Rules + overhead alone must fit under gomarklint.** Even with a
+   free parse, parity's rules + walk + output were ~60% of its wall
+   time (~48 ms vs gomarklint's ~44 ms in the benchmark note). Layer
+   0 removes the parse, but if rules + overhead still exceed
+   gomarklint, the rule and per-file pipeline need trimming too. The
+   spike below measures exactly this.
+
+**Spike (next concrete step):** add a parse mode that runs Layer 0
+only (block scan, no inline, no tree) and time `Layer 0 + the parity
+structural rules + overhead` against gomarklint on the neutral
+corpus. The number decides whether the rearchitecture clears the bar
+or whether rule/overhead trimming must ride alongside it. It is a
+contained measurement on the fork — no rule migration required to get
+the number.
+
+## Migration path and risk
+
+- **Seam-first.** Re-back `CollectCodeBlockLines` / PI lines /
+  `LinkReferences` / `ProseRanges` to compute from Layer 0/1 with a
+  Layer 2 fallback. Rules that only call these need no change.
+- **NodeChecker adapter.** The shared `ast.Walk` dispatch is the
+  migration's hardest seam: block NodeCheckers need a skeleton-node
+  view, inline NodeCheckers need Layer 1. This is where most of the
+  work and risk sit.
+- **Equivalence gate, non-negotiable.** Every projection and rule
+  served from Layer 0/1 must produce byte-identical output to the
+  Layer 2 path, diffed across the corpus and every rule fixture —
+  the same discipline that gates the arena change against the
+  non-arena renderer. CommonMark block edge cases (lazy
+  continuation, setext, nested fences) and reference-label
+  normalization are where divergence hides.
+- **One model, not two.** Rules consume the projection API; whether
+  it is served from a scan or the tree is invisible to them. There is
+  no second rule implementation and no forked API — the objection
+  that killed the two-path design.
+
+## Conclusion
+
+A lazy parse is feasible and well-shaped for mdsmith because the
+rules already read projections, not the raw tree. Layer 0 (a cheap
+block scan) backs the 16 code-block-line consumers and the pure-line
+rules with no parse; Layer 1 (a light inline index) backs the
+reference and URL rules; Layer 2 (the full goldmark AST) is built
+only when a rule navigates the tree. Simple and parity configs can
+shed the parse entirely; heavy configs keep it, unchanged. The open
+question is purely quantitative — is Layer 0 + rules + overhead under
+gomarklint? — and the spike above answers it before any parser
+surgery begins.

--- a/docs/research/benchmarks/lazy-parse-architecture.md
+++ b/docs/research/benchmarks/lazy-parse-architecture.md
@@ -258,6 +258,35 @@ So lazy parsing is not a universal speedup; it is a **floor
 removal** for the configs whose rules never needed the tree, and a
 no-op for the configs that do.
 
+## The MDS018 holdout
+
+`no-emphasis-as-heading` (MDS018) is the one parity rule at Layer 2. It
+flags a paragraph whose only child is an emphasis node — a lone
+`*emphasised line*` posing as a heading. It does not need general
+emphasis resolution. It needs one bounded answer: is the whole
+paragraph a single emphasis span? Two tiers clear it.
+
+**Tier 1 — a constrained Layer 1 detector.** The check is a bounded
+pattern. The paragraph content is exactly `*X*`, `_X_`, `**X**`, or
+`__X__` wrapping the whole paragraph, with the CommonMark flanking
+rules met at the two ends. That is far less than the delimiter
+algorithm. Re-back MDS018 on it. The equivalence gate proves it
+byte-identical to goldmark's lone-emphasis-child result across the
+corpus and the rule fixtures. If it holds, MDS018 moves to Layer 1 and
+parity is fully Layer 0/1.
+
+**Tier 2 — per-block Layer 2, the deeper fix.** If an edge case defeats
+the detector, do not concede the whole parse. Make Layer 2 per-block,
+not per-file. The gate becomes "no rule forces a whole-document parse",
+not "no rule needs Layer 2". MDS018 then parses inlines for only its
+candidate paragraphs — the ones whose first non-space byte is `*` or
+`_`. On real prose that is a handful of blocks. Parity still skips the
+full-document parse.
+
+Tier 2 is worth building even if Tier 1 holds. It future-proofs the
+gate. A later rule that needs deep detail on a few blocks gets a
+localized parse, not a full one.
+
 ## The honest performance bar
 
 Two facts must hold for this to beat gomarklint on parity, and a

--- a/docs/research/benchmarks/lazy-parse-architecture.md
+++ b/docs/research/benchmarks/lazy-parse-architecture.md
@@ -130,20 +130,31 @@ study: **every one of the 25 NodeChecker rules is a
 reacts to. The engine already dispatches by kind. So the metadata that
 says which layer a rule needs *already exists in the rule*:
 
-| Scoped kind(s)            | NodeChecker rules                                                                                                 | Layer |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----- |
-| Heading                   | blank-line-around-headings, heading-style, no-trailing-punctuation                                                | 0     |
-| FencedCodeBlock           | blank-line-around-fenced-code, fenced-code-style, fenced-code-language, unclosed-code-block, commands-show-output | 0     |
-| List / ListItem           | blank-line-around-lists, list-marker-space, list-marker-style, ordered-list-numbering, list-indent                | 0     |
-| Paragraph                 | no-emphasis-as-heading, forbidden-paragraph-starts, forbidden-text, toc-directive                                 | 0     |
-| ThematicBreak / HTMLBlock | horizontal-rule-style, no-inline-html                                                                             | 0     |
-| Link / Image / CodeSpan   | descriptive-link-text, no-space-in-link-text, no-empty-alt-text, no-space-in-code-spans                           | 1     |
-| Text (URL scan)           | no-bare-urls                                                                                                      | 1     |
-| Emphasis                  | emphasis-style                                                                                                    | 2     |
+| Scoped kind(s)                   | NodeChecker rules                                                                                                 | Layer |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----- |
+| Heading                          | blank-line-around-headings, heading-style, no-trailing-punctuation                                                | 0     |
+| FencedCodeBlock                  | blank-line-around-fenced-code, fenced-code-style, fenced-code-language, unclosed-code-block, commands-show-output | 0     |
+| List / ListItem                  | blank-line-around-lists, list-marker-space, list-marker-style, ordered-list-numbering, list-indent                | 0     |
+| ThematicBreak                    | horizontal-rule-style                                                                                             | 0     |
+| Paragraph (trigger; body varies) | toc-directive (0), forbidden-paragraph-starts / forbidden-text (1), no-emphasis-as-heading (2)                    | 0–2   |
+| HTMLBlock / RawHTML              | no-inline-html                                                                                                    | 1     |
+| Link / Image / CodeSpan          | descriptive-link-text, no-space-in-link-text, no-empty-alt-text, no-space-in-code-spans                           | 1     |
+| Text (URL scan)                  | no-bare-urls                                                                                                      | 1     |
+| Emphasis                         | emphasis-style                                                                                                    | 2     |
 
 Sixteen of the twenty-five scope to **block** kinds; they need a node's
 kind and line span, nothing inside it. Nine scope to **inline** kinds.
-Only `emphasis-style` needs the full delimiter algorithm (Layer 2).
+Emphasis semantics — `emphasis-style` and the all-emphasis check inside
+`no-emphasis-as-heading` — need the full delimiter algorithm (Layer 2).
+
+**Caveat: the scoped kind is the dispatch trigger, not the full data
+need.** A rule scoped to `KindParagraph` still sets its own layer by
+what it reads *inside* the block: `toc-directive` checks a marker
+(Layer 0), the forbidden-text rules scan prose (Layer 1), and
+`no-emphasis-as-heading` inspects emphasis (Layer 2). So the engine's
+parse-skip gate must key on each rule's *resolved* layer, not its
+trigger kind alone — a one-line per-rule annotation the migration adds
+beside the existing kind scope.
 
 A second finding sharpens the boundary: some block rules reference
 *every* inline type — `blank-line-around-lists` and `list-indent` both
@@ -168,8 +179,8 @@ tree. Two ways to serve them without a full parse:
   keeps the block-tree cost (~23%) — helps default configs, **not
   enough for parity.**
 - **Block skeleton (the parity change).** Present each block as a flat
-  `BlockSpan` (kind + line range + nesting), and adapt the 16
-  block-kind `CheckNode`s to read kind + line from it instead of
+  `BlockSpan` (kind + line range + nesting), and adapt the block-kind
+  `CheckNode`s to read kind + line from it instead of
   `n.(*ast.Heading)`. Mechanical, because they already read only kind +
   position. Removes block + inline cost — the version that can beat
   gomarklint.
@@ -180,11 +191,12 @@ whether any rule forces Layer 1/2, and otherwise run Layer 0 only.
 
 ### Where every rule lands
 
-- **Layer 0 (no parse): ~35 rules.** The pure-line rules, the 16
+- **Layer 0 (no parse): ~33 rules.** The pure-line rules, the
   CollectCodeBlockLines consumers, the astutil section/heading rules,
-  and the 16 block-kind NodeCheckers.
-- **Layer 1 (light inline index): ~10 rules.** The link / image / URL /
-  code-span / reference rules.
+  and the block-kind NodeCheckers whose body stays at block level
+  (~15).
+- **Layer 1 (light inline index): ~12 rules.** The link / image / URL /
+  code-span / raw-HTML / reference / prose-text rules.
 - **Layer 2 (full AST): the rest.** Emphasis semantics, prose
   (readability, structure, token budget, proper names), and the
   cross-file / directive rules (catalog, include, cross-file

--- a/plan/2606141901_spike-block-only-parse-cost.md
+++ b/plan/2606141901_spike-block-only-parse-cost.md
@@ -1,0 +1,66 @@
+---
+id: 2606141901
+title: "Spike: block-only parse cost vs gomarklint"
+status: "🔲"
+summary: >-
+  Measure whether a block-only parse (no inline, no tree)
+  plus the parity structural rules plus per-file overhead
+  beats gomarklint on benchmark 2. This number gates the
+  whole lazy-parse rearchitecture: if rules + overhead
+  alone already exceed gomarklint, Layer 0 is not enough
+  and the plan must also trim them.
+model: opus
+depends-on: []
+---
+# Spike: block-only parse cost vs gomarklint
+
+## Goal
+
+Answer the open question in the
+[lazy-parse architecture research][research]. Is
+`Layer 0 (block scan) + parity structural rules +
+overhead` faster than gomarklint on the neutral corpus?
+Everything downstream rests on that answer. Measure it
+before rearchitecting the parser.
+
+## Background
+
+The [gomarklint study][gomarklint] set out the
+arithmetic. Parity splits into parse ~38%, rules ~42%,
+and overhead ~19%. Even a *free* parse leaves rules plus
+overhead near gomarklint's time. A block-only parse is
+the cheapest proxy for Layer 0. goldmark already runs
+block and inline parsing as separate phases. So a
+throwaway measurement can suppress the inline phase
+without a rewrite.
+
+This is a spike: the code it produces is a measurement
+harness, not shipped behaviour. It lives behind a flag
+or on a scratch branch and is discarded once the number
+is recorded.
+
+## Tasks
+
+1. Add a parse path that runs block parsing only —
+   suppress the inline walk and skip building inline
+   nodes — reachable from a benchmark, not the CLI.
+2. Time three things on the pinned neutral corpus:
+   block-only parse alone, block-only parse + the
+   parity structural rules, and the full parity run,
+   each against gomarklint.
+3. Record the numbers and the go/no-go reading in the
+   [research doc][research] "honest performance bar"
+   section.
+
+## Acceptance Criteria
+
+- [ ] A measured comparison of block-only parse + parity
+      structural rules + overhead against gomarklint on
+      benchmark 2, captured in the research doc.
+- [ ] An explicit go/no-go: does Layer 0 alone clear the
+      bar, or must rule/overhead trimming ride along?
+- [ ] No production code path changes; the harness is
+      flagged off or discarded.
+
+[research]: ../docs/research/benchmarks/lazy-parse-architecture.md
+[gomarklint]: ../docs/research/benchmarks/gomarklint-architecture.md

--- a/plan/2606141902_lazy-parse-layer0.md
+++ b/plan/2606141902_lazy-parse-layer0.md
@@ -1,0 +1,69 @@
+---
+id: 2606141902
+title: "Lazy parse: Layer 0 block scanner and parse-skip"
+status: "🔲"
+summary: >-
+  Build the single-pass block scanner (Layer 0) and
+  re-back the block-level projections on it, so a config
+  whose enabled rules all resolve to Layer 0 skips the
+  goldmark parse entirely. Delivers the "simple configs
+  run at line-scanner speed" win and the engine gate the
+  later stages extend.
+model: opus
+depends-on: [2606141901]
+---
+# Lazy parse: Layer 0 block scanner and parse-skip
+
+## Goal
+
+Add a cheap block scanner and route the block-level
+projections through it. When every enabled rule resolves
+to Layer 0, the engine skips the goldmark parse. Simple
+configs then run with no AST.
+
+## Background
+
+See the [lazy-parse research][research]. Rules read
+projections, not the raw tree.
+[CollectCodeBlockLines][cbl] alone backs 16 rules. Those
+projections are the lazy seam.
+
+Layer 0 is one forward pass over `f.Lines`. It records a
+per-line class, the code-block and PI line sets, the
+block spans, and the front-matter bounds. It allocates
+no node tree.
+
+The seam already exists in code. Re-back the projection
+functions on Layer 0 with a Layer 2 fallback. Most rules
+need no change at all.
+
+## Tasks
+
+1. Write the Layer 0 scanner: per-line class, code-block
+   and PI line sets, block spans, front-matter bounds.
+2. Re-back `CollectCodeBlockLines`, the PI line set, and
+   the [astutil][astutil] section/heading/text helpers
+   on Layer 0, keeping a Layer 2 fallback.
+3. Record each rule's resolved layer (a small
+   annotation beside the existing kind scope).
+4. Add the engine gate. Skip
+   [`NewFileFromSourcePooled`][newfile] when every
+   enabled rule resolves to Layer 0.
+5. Add an equivalence harness. Diff Layer 0 projections
+   against the AST-derived ones across the corpus and
+   the rule fixtures.
+
+## Acceptance Criteria
+
+- [ ] A line-and-projection-only config skips the parse,
+      proven by a test or profile.
+- [ ] `CollectCodeBlockLines` output is byte-identical
+      between Layer 0 and the AST across the corpus.
+- [ ] All existing rule fixtures pass unchanged.
+- [ ] The Layer 0 equivalence gate is green.
+- [ ] All tests pass: `go test ./...`
+
+[research]: ../docs/research/benchmarks/lazy-parse-architecture.md
+[cbl]: ../internal/lint/codeblocks.go
+[astutil]: ../internal/rules/astutil/astutil.go
+[newfile]: ../internal/lint/filepool.go

--- a/plan/2606141902_lazy-parse-layer0.md
+++ b/plan/2606141902_lazy-parse-layer0.md
@@ -37,6 +37,13 @@ The seam already exists in code. Re-back the projection
 functions on Layer 0 with a Layer 2 fallback. Most rules
 need no change at all.
 
+[Plan 2606022126][audit] already sorted each rule by its
+AST need. It used a nil-AST probe and a code-block
+perturbation. Its manifest
+(`internal/integration/testdata/rule_walk_audit.json`) says
+which rules can reach Layer 0. Reuse it. Do not redo that
+sort by hand. Its `ProseRanges` projection also exists.
+
 ## Tasks
 
 1. Write the Layer 0 scanner: per-line class, code-block
@@ -64,6 +71,7 @@ need no change at all.
 - [ ] All tests pass: `go test ./...`
 
 [research]: ../docs/research/benchmarks/lazy-parse-architecture.md
+[audit]: 2606022126_lines-only-rule-audit.md
 [cbl]: ../internal/lint/codeblocks.go
 [astutil]: ../internal/rules/astutil/astutil.go
 [newfile]: ../internal/lint/filepool.go

--- a/plan/2606141902_lazy-parse-layer0.md
+++ b/plan/2606141902_lazy-parse-layer0.md
@@ -25,7 +25,7 @@ configs then run with no AST.
 
 See the [lazy-parse research][research]. Rules read
 projections, not the raw tree.
-[CollectCodeBlockLines][cbl] alone backs 16 rules. Those
+[CollectCodeBlockLines][cbl] alone backs 15 rules. Those
 projections are the lazy seam.
 
 Layer 0 is one forward pass over `f.Lines`. It records a

--- a/plan/2606141903_lazy-parse-blockspan-nodecheckers.md
+++ b/plan/2606141903_lazy-parse-blockspan-nodecheckers.md
@@ -1,0 +1,59 @@
+---
+id: 2606141903
+title: "Lazy parse: BlockSpan seam for block NodeCheckers"
+status: "🔲"
+summary: >-
+  Run the block-kind NodeChecker rules over the Layer 0
+  BlockSpan model instead of the heap AST, so parity's
+  structural rules no longer force the parse. Breaks the
+  one coupling that ties those rules to the tree: the
+  `n.(*ast.Heading)` assertion in CheckNode.
+model: opus
+depends-on: [2606141902]
+---
+# Lazy parse: BlockSpan seam for block NodeCheckers
+
+## Goal
+
+Serve the block-kind NodeChecker rules from Layer 0. They
+should read a block's kind and line span without a node
+tree. Parity's structural rules then stop forcing the
+parse.
+
+## Background
+
+See the [seam audit][research]. All 25 NodeChecker rules
+are `KindScopedChecker`. Each declares the node kinds it
+reacts to. About 15 scope to block kinds.
+
+The block CheckNodes read very little. A typical one
+narrows the node with `heading, ok := n.(*ast.Heading)`.
+Then it reads the heading's line and works on `f.Lines`.
+That type assertion is the only tie to the heap tree.
+
+Present each block as a flat `BlockSpan`. It carries the
+kind, the line range, and the nesting. Adapt the block
+CheckNodes to read from it. The change is mechanical:
+they already read only kind and position.
+
+## Tasks
+
+1. Define the `BlockSpan` view (kind, line range,
+   nesting) over the Layer 0 scan.
+2. Add a shared dispatch that drives `KindScopedChecker`
+   rules over `BlockSpan` for block kinds.
+3. Migrate the block-kind CheckNodes off
+   `n.(*ast.Heading)` and onto `BlockSpan`.
+4. Extend the parse-skip gate to cover these rules.
+
+## Acceptance Criteria
+
+- [ ] Parity's block NodeCheckers run with no parse when
+      no Layer 1 or Layer 2 rule is enabled.
+- [ ] Each migrated rule's diagnostics are byte-identical
+      to its AST output across the corpus and fixtures.
+- [ ] All existing rule fixtures pass unchanged.
+- [ ] The equivalence gate is green.
+- [ ] All tests pass: `go test ./...`
+
+[research]: ../docs/research/benchmarks/lazy-parse-architecture.md

--- a/plan/2606141904_lazy-parse-inline-index.md
+++ b/plan/2606141904_lazy-parse-inline-index.md
@@ -1,0 +1,66 @@
+---
+id: 2606141904
+title: "Lazy parse: Layer 1 light inline index"
+status: "🔲"
+summary: >-
+  Build the byte-level inline index (links, autolinks,
+  images, code spans, raw HTML, reference defs and uses)
+  and re-back the inline rules and LinkReferences on it.
+  With Layer 0 and Layer 1 together, parity skips the
+  full parse — the last step to beating gomarklint.
+model: opus
+depends-on: [2606141902]
+---
+# Lazy parse: Layer 1 light inline index
+
+## Goal
+
+Add a targeted inline scanner for the inline rules. It
+finds links, images, code spans, raw HTML, and reference
+definitions and uses. It does not run the emphasis
+delimiter algorithm. Parity's inline rules then stop
+forcing the full parse.
+
+## Background
+
+See the [lazy-parse research][research]. About a dozen
+rules need inline detail. The link and reference rules
+need links and the reference map. The code-span and
+raw-HTML rules need those spans.
+
+None of these need emphasis. Emphasis stays on Layer 2.
+The scan is a byte pass, not the full delimiter
+algorithm.
+
+Reference matching is the correctness risk. CommonMark
+folds case and collapses whitespace in labels. The index
+must normalize labels exactly as goldmark does. Lift its
+normalization as a pure function so the two agree.
+
+## Tasks
+
+1. Write the inline index scanner: links, autolinks,
+   images, code spans, raw HTML, and `[label]: url`
+   definitions and uses.
+2. Lift goldmark's reference-label normalization (case
+   fold plus whitespace) into a shared pure function.
+3. Re-back [`LinkReferences`][newfile] and the inline
+   rules (`no-bare-urls`, `no-empty-alt-text`,
+   `link-validity`, `no-space-in-code-spans`,
+   `no-inline-html`, the reference rules) on the index.
+4. Mark each inline rule's resolved layer and extend the
+   parse-skip gate.
+
+## Acceptance Criteria
+
+- [ ] With Layer 0 and Layer 1, the full parity config
+      runs with no goldmark parse.
+- [ ] Reference matching is byte-identical to the AST
+      path, including case folding, across the corpus.
+- [ ] All existing rule fixtures pass unchanged.
+- [ ] `mdsmith check -c parity` beats gomarklint on
+      benchmark 2.
+- [ ] All tests pass: `go test ./...`
+
+[research]: ../docs/research/benchmarks/lazy-parse-architecture.md
+[newfile]: ../internal/lint/file.go

--- a/plan/2606141904_lazy-parse-inline-index.md
+++ b/plan/2606141904_lazy-parse-inline-index.md
@@ -28,9 +28,13 @@ rules need inline detail. The link and reference rules
 need links and the reference map. The code-span and
 raw-HTML rules need those spans.
 
-None of these need emphasis. Emphasis stays on Layer 2.
-The scan is a byte pass, not the full delimiter
-algorithm.
+None need general emphasis. The general emphasis rule,
+`emphasis-style`, stays on Layer 2. But one parity rule
+resists: `no-emphasis-as-heading` reads a parsed emphasis
+node. Its real need is bounded. Is a whole paragraph one
+emphasis span? That check belongs on Layer 1. It is the
+gate on parity shedding the parse (see the [research
+note][research]).
 
 Reference matching is the correctness risk. CommonMark
 folds case and collapses whitespace in labels. The index
@@ -50,11 +54,21 @@ normalization as a pure function so the two agree.
    `no-inline-html`, the reference rules) on the index.
 4. Mark each inline rule's resolved layer and extend the
    parse-skip gate.
+5. Add a bounded whole-paragraph-emphasis detector to the
+   index. Re-back `no-emphasis-as-heading` on it. Gate it
+   byte-identical to goldmark's lone-emphasis-child result.
+6. Fallback if an edge case defeats the detector: make
+   Layer 2 per-block. `no-emphasis-as-heading` parses
+   inlines for only the paragraphs whose first non-space
+   byte is `*` or `_`. The gate then keys on "no
+   whole-document parse", not "no Layer 2".
 
 ## Acceptance Criteria
 
 - [ ] With Layer 0 and Layer 1, the full parity config
-      runs with no goldmark parse.
+      runs with no whole-document goldmark parse.
+- [ ] `no-emphasis-as-heading` output is byte-identical to
+      its AST path across the corpus and fixtures.
 - [ ] Reference matching is byte-identical to the AST
       path, including case folding, across the corpus.
 - [ ] All existing rule fixtures pass unchanged.


### PR DESCRIPTION
## What

The research for rearchitecting goldmark to a **lazy parse** — build the CommonMark tree only when a rule navigates it — plus the staged `plan/` files that operationalize it. Follow-up to the merged gomarklint study (#614).

## The research (`docs/research/benchmarks/lazy-parse-architecture.md`)

Grounded in an audit of **what every rule actually reads** — they consume projections, not the raw node graph:

- `CollectCodeBlockLines` (which lines are code) backs **16 rules**; PI-block lines 6; `LinkReferences` 4; `ProseRanges` 2.
- **All 25 NodeChecker rules are `KindScopedChecker`** — each already declares the node kinds it reacts to, so the per-rule layer metadata exists in the code. ~16 scope to block kinds, ~9 to inline.
- Block rules that reference every inline type do so to treat inline as *opaque* — they're Layer 0, not Layer 1.
- Caveat captured: the scoped kind is the dispatch *trigger*, not the data *need* (`no-emphasis-as-heading` triggers on Paragraph but needs emphasis → Layer 2).

**Architecture:** one parser, three layers — Layer 0 (cheap block scan, no parse), Layer 1 (light inline index, lazy), Layer 2 (full goldmark AST, lazy on tree navigation). One model, no forked API. Simple/parity configs shed the parse; heavy configs are unchanged.

## The plans (`plan/`)

Four dependency-chained plans, all equivalence-gated (line-scan vs AST output diffed across corpus + fixtures):

| ID | Plan | Depends on |
| --- | --- | --- |
| 2606141901 | **Spike** — block-only parse + parity rules + overhead vs gomarklint (the go/no-go gate) | — |
| 2606141902 | **Layer 0** — block scanner, re-back projections, parse-skip gate | spike |
| 2606141903 | **BlockSpan seam** — block NodeCheckers off `n.(*ast.Heading)` onto Layer 0 | Layer 0 |
| 2606141904 | **Layer 1 inline index** — link/ref/image scanner; final acceptance = parity beats gomarklint | Layer 0 |

The spike is first because the open question is quantitative: is `Layer 0 + parity rules + overhead` under gomarklint, or must rule/overhead trimming ride along? No parser surgery starts until that number lands.

## Notes

- Docs + plans only; `mdsmith check` clean; PLAN.md index regenerated; cross-linked with the gomarklint study.
- Draft pending your read on the architecture and plan staging.
