### PR TITLE
perf: eliminate per-line allocation copies and separator allocs in five rules

### DIFF
--- a/internal/rules/headingstyle/rule.go
+++ b/internal/rules/headingstyle/rule.go
@@ -112,11 +112,17 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return ast.WalkContinue, nil
 	})
 
+	// Pre-size each replacement buffer to avoid the temporary inner slice
+	// that append(before, append([]byte(newText), after...)...) would create.
 	for i := len(replacements) - 1; i >= 0; i-- {
 		rep := replacements[i]
 		before := result[:rep.start]
 		after := result[rep.end:]
-		result = append(before, append([]byte(rep.newText), after...)...)
+		tmp := make([]byte, 0, rep.start+len(rep.newText)+len(after))
+		tmp = append(tmp, before...)
+		tmp = append(tmp, rep.newText...)
+		tmp = append(tmp, after...)
+		result = tmp
 	}
 
 	return result

--- a/internal/rules/headingstyle/rule_test.go
+++ b/internal/rules/headingstyle/rule_test.go
@@ -145,3 +145,23 @@ func TestCategory_HeadingStyle(t *testing.T) {
 		t.Errorf("expected heading, got %s", r.Category())
 	}
 }
+
+// TestFix_InnerAppendAllocBudget verifies Fix does not allocate a temporary
+// intermediate slice per replaced heading. One ATX→setext conversion should
+// cost one buffer allocation, not two.
+func TestFix_InnerAppendAllocBudget(t *testing.T) {
+	// File with an H1 in ATX style that gets converted to setext.
+	src := "# Heading One\n\nSome body text here.\n"
+	f, err := lint.NewFile("test.md", []byte(src))
+	require.NoError(t, err)
+	r := &Rule{Style: "setext"}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = r.Fix(f)
+	})
+	// After fix: initial copy + pre-sized tmp per replacement = 6 allocs.
+	// Before: initial copy + string-to-[]byte + inner-append growth = 7 allocs.
+	if allocs > 6 {
+		t.Fatalf("Fix allocs per call: want ≤ 6, got %v (inner append allocates intermediate slice)", allocs)
+	}
+}

--- a/internal/rules/listmarkerstyle/rule.go
+++ b/internal/rules/listmarkerstyle/rule.go
@@ -234,15 +234,16 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return out
 	}
 
-	// Apply edits line by line
+	// Apply edits line by line. replaceMarker copies the line internally,
+	// so unedited lines can reference f.Lines directly (joinLines only reads them).
 	resultLines := make([][]byte, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		newLine := append([]byte(nil), line...)
 		if newMarker, ok := markerEdits[lineNum]; ok {
-			newLine = replaceMarker(newLine, newMarker)
+			resultLines[i] = replaceMarker(line, newMarker)
+		} else {
+			resultLines[i] = line
 		}
-		resultLines[i] = newLine
 	}
 
 	return joinLines(resultLines)

--- a/internal/rules/listmarkerstyle/rule.go
+++ b/internal/rules/listmarkerstyle/rule.go
@@ -234,8 +234,9 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return out
 	}
 
-	// Apply edits line by line. replaceMarker copies the line internally,
-	// so unedited lines can reference f.Lines directly (joinLines only reads them).
+	// Apply edits line by line. replaceMarker allocates a fresh copy when it
+	// finds a marker; it returns the input unchanged when no marker is found.
+	// Either way joinLines only reads the slices, so f.Lines aliases are safe.
 	resultLines := make([][]byte, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1

--- a/internal/rules/listmarkerstyle/rule_test.go
+++ b/internal/rules/listmarkerstyle/rule_test.go
@@ -423,3 +423,23 @@ func TestBlockFirstLine_DirectLines(t *testing.T) {
 	p.Lines().Append(text.NewSegment(9, 17))
 	assert.Equal(t, 2, blockFirstLine(f, p))
 }
+
+// TestFix_AllocBudget_PerLineNotPerEdit verifies Fix allocates proportional
+// to the number of edits rather than the total number of lines. A file with
+// 10 lines and 2 list-marker edits must not allocate one buffer per line.
+func TestFix_AllocBudget_PerLineNotPerEdit(t *testing.T) {
+	// 10 lines: 2 asterisk items needing dash, 8 already-correct dash items
+	src := []byte("* bad one\n- good\n- good\n- good\n- good\n- good\n- good\n- good\n- good\n* bad two\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleDash}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = r.Fix(f)
+	})
+	// After the fix: resultLines slice + 2 replaceMarker copies + joinLines buf = ≤ 4 allocs.
+	// Before: 10 append copies + 2 replaceMarker copies + resultLines + joinLines = 14+.
+	if allocs > 6 {
+		t.Fatalf("Fix allocs per call: want ≤ 6, got %v (copying every line, not just edited ones)", allocs)
+	}
+}

--- a/internal/rules/nospaceincodespans/rule.go
+++ b/internal/rules/nospaceincodespans/rule.go
@@ -144,7 +144,11 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		// spaces on both sides so CommonMark's single-space trim removes them
 		// symmetrically, leaving the correct content.
 		if trimmed[0] == '`' || trimmed[len(trimmed)-1] == '`' {
-			trimmed = append(append([]byte{' '}, trimmed...), ' ')
+			padded := make([]byte, len(trimmed)+2)
+			padded[0] = ' '
+			copy(padded[1:], trimmed)
+			padded[len(padded)-1] = ' '
+			trimmed = padded
 		}
 		if bytes.Equal(trimmed, raw) {
 			return ast.WalkContinue, nil

--- a/internal/rules/nospaceincodespans/rule.go
+++ b/internal/rules/nospaceincodespans/rule.go
@@ -144,11 +144,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		// spaces on both sides so CommonMark's single-space trim removes them
 		// symmetrically, leaving the correct content.
 		if trimmed[0] == '`' || trimmed[len(trimmed)-1] == '`' {
-			padded := make([]byte, len(trimmed)+2)
-			padded[0] = ' '
-			copy(padded[1:], trimmed)
-			padded[len(padded)-1] = ' '
-			trimmed = padded
+			trimmed = padBacktickContent(trimmed)
 		}
 		if bytes.Equal(trimmed, raw) {
 			return ast.WalkContinue, nil
@@ -173,6 +169,18 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	}
 	out.Write(f.Source[prev:])
 	return out.Bytes()
+}
+
+// padBacktickContent wraps b in a single space on each side so that
+// CommonMark's rule that strips one leading and one trailing space from a
+// code-span does not merge a leading/trailing backtick in b into the
+// delimiter run.
+func padBacktickContent(b []byte) []byte {
+	padded := make([]byte, len(b)+2)
+	padded[0] = ' '
+	copy(padded[1:], b)
+	padded[len(padded)-1] = ' '
+	return padded
 }
 
 // openingBacktickOffset returns the byte offset of the opening backtick

--- a/internal/rules/nospaceincodespans/rule_test.go
+++ b/internal/rules/nospaceincodespans/rule_test.go
@@ -376,3 +376,24 @@ func TestFix_TrimmedEqualsRaw_NoChange(t *testing.T) {
 	got := (&Rule{}).Fix(f)
 	assert.Equal(t, src, got, "trimmed==raw must skip the rewrite")
 }
+
+// TestFix_BacktickPaddingAllocBudget verifies that adding balanced spaces
+// around code-span content that starts or ends with a backtick uses a single
+// allocation rather than the two-step double-append pattern.
+func TestFix_BacktickPaddingAllocBudget(t *testing.T) {
+	// Code span whose raw content is " `abc" — leading space before a backtick.
+	// Fix trims to "`abc", detects leading backtick, and adds a trailing space
+	// to produce " `abc " which differs from raw, creating a cut.
+	src := "Use `` `abc`` here.\n"
+	f := newFile(t, src)
+	r := &Rule{}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = r.Fix(f)
+	})
+	// After fix: make(padded) + cuts-slice + out-Buffer = 4 allocs (1 alloc saved vs double-append).
+	// Before: []byte{' '} alloc + inner-append growth = 5 allocs.
+	if allocs > 4 {
+		t.Fatalf("Fix allocs per call: want ≤ 4, got %v (double-append allocates intermediate slice)", allocs)
+	}
+}

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -159,15 +159,18 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return out
 	}
 
+	// applyIndentShift returns a new slice (shift≠0) or the original (shift=0).
+	// replaceLeadingDigits always allocates its own output. Neither mutates
+	// f.Lines, so the pre-copy is unnecessary — bytes.Join only reads the slice.
 	resultLines := make([][]byte, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		newLine := append([]byte(nil), line...)
-		newLine = applyIndentShift(newLine, indentDeltas[lineNum])
+		shifted := applyIndentShift(line, indentDeltas[lineNum])
 		if e, ok := markerEdits[lineNum]; ok {
-			newLine = replaceLeadingDigits(newLine, e.newDigits)
+			resultLines[i] = replaceLeadingDigits(shifted, e.newDigits)
+		} else {
+			resultLines[i] = shifted
 		}
-		resultLines[i] = newLine
 	}
 
 	return bytes.Join(resultLines, []byte("\n"))

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -23,6 +23,8 @@ const (
 	StyleAllOnes    = "all-ones"
 )
 
+var newlineSep = []byte{'\n'}
+
 func init() {
 	rule.Register(&Rule{Style: StyleSequential, Start: 1})
 }
@@ -173,7 +175,7 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		}
 	}
 
-	return bytes.Join(resultLines, []byte("\n"))
+	return bytes.Join(resultLines, newlineSep)
 }
 
 // collectListEdits records marker rewrites and continuation-indent

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -541,7 +541,8 @@ func TestFix_BlockquoteInListItem(t *testing.T) {
 // must not allocate one buffer copy per line.
 func TestFix_AllocBudget_PerLineNotPerEdit(t *testing.T) {
 	// 10 lines: ordered list with wrong numbers (all-ones style but sequential source)
-	src := []byte("1. first\n2. second\n3. third\n4. fourth\n5. fifth\n6. sixth\n7. seventh\n8. eighth\n9. ninth\n10. tenth\n")
+	src := []byte("1. first\n2. second\n3. third\n4. fourth\n5. fifth\n" +
+		"6. sixth\n7. seventh\n8. eighth\n9. ninth\n10. tenth\n")
 	f, err := lint.NewFile("test.md", src)
 	require.NoError(t, err)
 	r := &Rule{Style: StyleAllOnes}

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -535,3 +535,23 @@ func TestFix_BlockquoteInListItem(t *testing.T) {
 	got := r.Fix(f)
 	assert.Equal(t, string(src), string(got))
 }
+
+// TestFix_AllocBudget_PerLineNotPerEdit verifies Fix allocates proportional
+// to edits rather than total lines. A 10-line file with 2 numbering errors
+// must not allocate one buffer copy per line.
+func TestFix_AllocBudget_PerLineNotPerEdit(t *testing.T) {
+	// 10 lines: ordered list with wrong numbers (all-ones style but sequential source)
+	src := []byte("1. first\n2. second\n3. third\n4. fourth\n5. fifth\n6. sixth\n7. seventh\n8. eighth\n9. ninth\n10. tenth\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{Style: StyleAllOnes}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = r.Fix(f)
+	})
+	// After fix: 2 maps + resultLines + 9 replaceLeadingDigits + bytes.Join (sep+result) ≈ 15.
+	// Before: additionally 10 per-line append copies = ~25 allocs.
+	if allocs > 18 {
+		t.Fatalf("Fix allocs per call: want ≤ 18, got %v (copying every line unconditionally)", allocs)
+	}
+}

--- a/internal/rules/orderedlistnumbering/rule_test.go
+++ b/internal/rules/orderedlistnumbering/rule_test.go
@@ -550,7 +550,7 @@ func TestFix_AllocBudget_PerLineNotPerEdit(t *testing.T) {
 	allocs := testing.AllocsPerRun(100, func() {
 		_ = r.Fix(f)
 	})
-	// After fix: 2 maps + resultLines + 9 replaceLeadingDigits + bytes.Join (sep+result) ≈ 15.
+	// After fix: 2 maps + resultLines + 10 replaceLeadingDigits + bytes.Join result ≈ 15.
 	// Before: additionally 10 per-line append copies = ~25 allocs.
 	if allocs > 18 {
 		t.Fatalf("Fix allocs per call: want ≤ 18, got %v (copying every line unconditionally)", allocs)

--- a/internal/rules/requiredstructure/alloc_test.go
+++ b/internal/rules/requiredstructure/alloc_test.go
@@ -3,7 +3,9 @@ package requiredstructure
 import (
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCollectBodySyncPoints_NoByteSplitAlloc confirms collectBodySyncPoints
@@ -30,4 +32,28 @@ func TestCollectBodySyncPoints_NoByteSplitAlloc(t *testing.T) {
 	// After removing bytes.Split: 2 string() casts for 2 headings, no split alloc.
 	assert.LessOrEqual(t, allocs, 2.0,
 		"collectBodySyncPoints allocs: want ≤ 2 (string casts only), got %v", allocs)
+}
+
+// TestCheckBodySync_NoBytesPerLineAlloc confirms checkBodySync does not
+// allocate a string per body line when searching for a match. A 6-line body
+// section with no matching line must produce at most 3 allocs (one for
+// converting expected to []byte, one for bytes.Join in the paragraph loop,
+// one for the string conversion of the joined paragraph on comparison).
+func TestCheckBodySync_NoBytesPerLineAlloc(t *testing.T) {
+	src := "# Title\n\nline one\nline two\nline three\nline four\nline five\nline six\n"
+	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
+	require.NoError(t, err)
+
+	dh := docHeading{Level: 1, Text: "Title", Line: 1}
+	allHeadings := []docHeading{dh}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = checkBodySync(f, dh, 0, allHeadings, "no match here", "description")
+	})
+	// After fix: ≤ 3 allocs (expectedBytes conversion + bytes.Join + string compare).
+	// Before: 1 string() alloc per line × 6 lines in both loops = 12+ allocs.
+	// After fix: expectedBytes + pre-sized para make + bytes.Join sep + join result = ≤ 8.
+	// Before: one string() alloc per line in both loops = 13+ allocs.
+	assert.LessOrEqual(t, allocs, 8.0,
+		"checkBodySync allocs: want ≤ 8, got %v (string() conversion per line)", allocs)
 }

--- a/internal/rules/requiredstructure/alloc_test.go
+++ b/internal/rules/requiredstructure/alloc_test.go
@@ -35,10 +35,11 @@ func TestCollectBodySyncPoints_NoByteSplitAlloc(t *testing.T) {
 }
 
 // TestCheckBodySync_NoBytesPerLineAlloc confirms checkBodySync does not
-// allocate a string per body line when searching for a match. A 6-line body
-// section with no matching line must produce at most 3 allocs (one for
-// converting expected to []byte, one for bytes.Join in the paragraph loop,
-// one for the string conversion of the joined paragraph on comparison).
+// allocate a string per body line. A 6-line body section with no matching
+// line must stay within budget: expectedBytes (1) + make(para) (1) +
+// bytes.Join result (1) + fmt.Sprintf (1) + diagnostic slice (1) + 1
+// margin = 6 allocs. The old two-loop code paid one string() per line
+// in each loop = 12+ allocs, plus the []byte{' '} separator = 13+ total.
 func TestCheckBodySync_NoBytesPerLineAlloc(t *testing.T) {
 	src := "# Title\n\nline one\nline two\nline three\nline four\nline five\nline six\n"
 	f, err := lint.NewFileFromSource("doc.md", []byte(src), true)
@@ -50,10 +51,6 @@ func TestCheckBodySync_NoBytesPerLineAlloc(t *testing.T) {
 	allocs := testing.AllocsPerRun(100, func() {
 		_ = checkBodySync(f, dh, 0, allHeadings, "no match here", "description")
 	})
-	// After fix: ≤ 3 allocs (expectedBytes conversion + bytes.Join + string compare).
-	// Before: 1 string() alloc per line × 6 lines in both loops = 12+ allocs.
-	// After fix: expectedBytes + pre-sized para make + bytes.Join sep + join result = ≤ 8.
-	// Before: one string() alloc per line in both loops = 13+ allocs.
-	assert.LessOrEqual(t, allocs, 8.0,
-		"checkBodySync allocs: want ≤ 8, got %v (string() conversion per line)", allocs)
+	assert.LessOrEqual(t, allocs, 6.0,
+		"checkBodySync allocs: want ≤ 6, got %v", allocs)
 }

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -2275,32 +2275,34 @@ func checkBodySync(
 		endLine = allHeadings[headingIdx+1].Line - 1
 	}
 
+	// Convert expected once so per-line comparisons need no string() cast.
+	expectedBytes := []byte(expected)
+
 	// Check each individual line first (fast path).
 	for i := startLine - 1; i < endLine && i < len(f.Lines); i++ {
-		line := strings.TrimSpace(string(f.Lines[i]))
-		if line == expected {
+		if bytes.Equal(bytes.TrimSpace(f.Lines[i]), expectedBytes) {
 			return nil
 		}
 	}
 
 	// Join consecutive non-blank lines into paragraphs and check each.
-	var para []string
+	// Pre-size to the maximum lines in this section to avoid repeated growth allocs.
+	para := make([][]byte, 0, endLine-startLine+1)
 	for i := startLine - 1; i <= endLine && i <= len(f.Lines); i++ {
-		var line string
+		var lineB []byte
 		if i < endLine && i < len(f.Lines) {
-			line = strings.TrimSpace(string(f.Lines[i]))
+			lineB = bytes.TrimSpace(f.Lines[i])
 		}
-		if line == "" || i == endLine || i == len(f.Lines) {
+		if len(lineB) == 0 || i == endLine || i == len(f.Lines) {
 			if len(para) > 0 {
-				joined := strings.Join(para, " ")
-				if joined == expected {
+				if bytes.Equal(bytes.Join(para, []byte{' '}), expectedBytes) {
 					return nil
 				}
 				para = para[:0]
 			}
 			continue
 		}
-		para = append(para, line)
+		para = append(para, lineB)
 	}
 
 	return []lint.Diagnostic{makeDiag(f.Path, dh.Line,

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -2287,7 +2287,7 @@ func checkBodySync(
 
 	// Join consecutive non-blank lines into paragraphs and check each.
 	// Pre-size to the maximum lines in this section to avoid repeated growth allocs.
-	para := make([][]byte, 0, endLine-startLine+1)
+	para := make([][]byte, 0, max(0, endLine-startLine+1))
 	for i := startLine - 1; i <= endLine && i <= len(f.Lines); i++ {
 		var lineB []byte
 		if i < endLine && i < len(f.Lines) {

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1431,6 +1431,7 @@ func appendBodySyncFields(
 var (
 	piOpenPrefix = []byte("<?")
 	piClose      = []byte("?>")
+	spaceSep     = []byte{' '}
 )
 
 // fenceOpenRun reports the marker character and run length when a
@@ -2278,24 +2279,21 @@ func checkBodySync(
 	// Convert expected once so per-line comparisons need no string() cast.
 	expectedBytes := []byte(expected)
 
-	// Check each individual line first (fast path).
-	for i := startLine - 1; i < endLine && i < len(f.Lines); i++ {
-		if bytes.Equal(bytes.TrimSpace(f.Lines[i]), expectedBytes) {
-			return nil
-		}
-	}
-
-	// Join consecutive non-blank lines into paragraphs and check each.
-	// Pre-size to the maximum lines in this section to avoid repeated growth allocs.
+	// Single pass: trim each line once, check for a single-line match (fast path),
+	// and accumulate consecutive non-blank lines into paragraphs for a joined match.
+	// Pre-size para to the section line count to avoid growth allocs.
 	para := make([][]byte, 0, max(0, endLine-startLine+1))
 	for i := startLine - 1; i <= endLine && i <= len(f.Lines); i++ {
 		var lineB []byte
 		if i < endLine && i < len(f.Lines) {
 			lineB = bytes.TrimSpace(f.Lines[i])
+			if bytes.Equal(lineB, expectedBytes) {
+				return nil
+			}
 		}
 		if len(lineB) == 0 || i == endLine || i == len(f.Lines) {
 			if len(para) > 0 {
-				if bytes.Equal(bytes.Join(para, []byte{' '}), expectedBytes) {
+				if bytes.Equal(bytes.Join(para, spaceSep), expectedBytes) {
 					return nil
 				}
 				para = para[:0]

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jeduden/mdsmith/internal/bytelimit"
@@ -2286,7 +2287,7 @@ func checkBodySync(
 	for i := startLine - 1; i <= endLine && i <= len(f.Lines); i++ {
 		var lineB []byte
 		if i < endLine && i < len(f.Lines) {
-			lineB = bytes.TrimSpace(f.Lines[i])
+			lineB = bytes.TrimFunc(f.Lines[i], unicode.IsSpace)
 			if bytes.Equal(lineB, expectedBytes) {
 				return nil
 			}

--- a/internal/rules/singleh1/rule.go
+++ b/internal/rules/singleh1/rule.go
@@ -93,11 +93,17 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	}
 
 	// Apply in reverse order to preserve byte offsets.
+	// Pre-size each replacement buffer to avoid the temporary inner slice
+	// that append(before, append([]byte(newText), after...)...) would create.
 	for i := len(reps) - 1; i >= 0; i-- {
 		rep := reps[i]
 		before := result[:rep.start]
 		after := result[rep.end:]
-		result = append(before, append([]byte(rep.newText), after...)...)
+		tmp := make([]byte, 0, rep.start+len(rep.newText)+len(after))
+		tmp = append(tmp, before...)
+		tmp = append(tmp, rep.newText...)
+		tmp = append(tmp, after...)
+		result = tmp
 	}
 
 	return result
@@ -139,7 +145,8 @@ var (
 // with no text children (offset -1) are conservatively kept rather than
 // misclassified via a stale fallback of line 1.
 func collectH1s(f *lint.File) []*ast.Heading {
-	var h1s []*ast.Heading
+	// Pre-size to avoid the nil→1→2 growth allocs in the common case of ≤ 4 H1s.
+	h1s := make([]*ast.Heading, 0, 4)
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil

--- a/internal/rules/singleh1/rule_test.go
+++ b/internal/rules/singleh1/rule_test.go
@@ -434,3 +434,22 @@ func TestCheck_EmptyH1_UnknownOffset_ConservativelyKept(t *testing.T) {
 	require.Len(t, diags, 1)
 	assert.Equal(t, "extra H1 heading; only one H1 is allowed per file", diags[0].Message)
 }
+
+// TestFix_InnerAppendAllocBudget verifies Fix does not allocate a temporary
+// intermediate slice per replaced heading. One heading demotion should cost
+// one buffer allocation, not two.
+func TestFix_InnerAppendAllocBudget(t *testing.T) {
+	// File with a duplicate H1 that gets demoted to H2.
+	src := "# Title\n\n# Duplicate\n\nSome text.\n"
+	f := newFile(t, src)
+	r := &Rule{}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = r.Fix(f)
+	})
+	// After fix: result copy + pre-sized h1s + reps + tmp make = 4 allocs.
+	// Before: result copy + nil h1s grows 2× + reps + inner-append = 5 allocs.
+	if allocs > 4 {
+		t.Fatalf("Fix allocs per call: want ≤ 4, got %v (nil h1s grows 2× without pre-sizing)", allocs)
+	}
+}


### PR DESCRIPTION
## Summary

Audited the codebase against `docs/development/high-performance-go.md` and addressed the top 5 allocation hot spots across rule `Fix`/`Check` paths.

| Rule | Finding | Fix | Impact |
|---|---|---|---|
| `listmarkerstyle` | `append([]byte(nil), line...)` defensive copy for every line in `Fix` | Skip copy; `replaceMarker` allocates only when it changes a line; `joinLines` is read-only | 1 alloc/line → 0 |
| `orderedlistnumbering` | Same defensive-copy pattern; inline `[]byte("\n")` separator allocates on every `Fix` call | Remove per-line copy; hoist `newlineSep = []byte{'\n'}` to package scope | ~10 allocs saved on 10-item list |
| `nospaceincodespans` | `append(append([]byte{' '}, trimmed...), ' ')` — two allocs to pad a backtick-adjacent span | `make(len+2)` + `copy` — one alloc; extract `padBacktickContent` helper to stay under funlen | 2 allocs → 1 per padded span |
| `singleh1` / `headingstyle` | `append(before, append([]byte(newText), after...)...)` — inner `append` allocates a temporary; `collectH1s` grows from nil | Pre-sized `make` + sequential appends; `make([]*ast.Heading, 0, 4)` pre-size | Eliminates inner-append temp + nil-growth allocs |
| `requiredstructure` | `string(f.Lines[i])` per body line in `checkBodySync`, double-`TrimSpace` across two loops, `[]byte{' '}` separator inline | Convert `expected` to `[]byte` once; merge two-loop into single scan; hoist `spaceSep = []byte{' '}` to package scope; use `bytes.TrimFunc(…, unicode.IsSpace)` to preserve Unicode whitespace behaviour | 13+ allocs → ≤6 |

Each fix follows the red/green TDD pattern: allocation budget test written first (`testing.AllocsPerRun`), code changed to pass it.

## Bug fixes and correctness improvements (caught during code review, 3 rounds at xhigh)

- **`requiredstructure` panic** (Round 1): `make([][]byte, 0, endLine-startLine+1)` panics with negative capacity when two consecutive headings are on adjacent lines — fixed with `max(0, …)`.
- **`nospaceincodespans` funlen** (Round 1): backtick-padding block pushed `Fix` 1 line over the 60-line lint limit — fixed by extracting `padBacktickContent`.
- **`orderedlistnumbering` lll** (Round 1): long string literal in alloc-budget test — wrapped with `+` concatenation to stay under 120 chars.
- **`listmarkerstyle` comment** (Round 2): "replaceMarker copies internally" was false — it returns input unchanged when no marker character is found; corrected to accurately describe the aliasing safety.
- **`requiredstructure` double TrimSpace** (Round 2): fast-path loop and paragraph-join loop both trimmed the same lines independently — merged into a single loop.
- **`requiredstructure` Unicode whitespace** (Round 3): `bytes.TrimSpace` does not strip U+00A0 and other non-ASCII whitespace; the old `strings.TrimSpace` did — replaced with `bytes.TrimFunc(f.Lines[i], unicode.IsSpace)` to preserve the original behaviour.
- **`orderedlistnumbering` newlineSep** (Round 3): inline `[]byte("\n")` literal flagged in Round 3 review — hoisted to package-level `newlineSep` var.
- **`requiredstructure` alloc_test comment** (Round 3): comment said "≤ 3 allocs" but tested for ≤8 — corrected to reflect the actual ≤6 budget with per-item accounting.
- **`orderedlistnumbering` test comment** (Round 3): "9 replaceLeadingDigits" in a 10-item test — corrected to "10".

## Test plan

- [x] `go test ./internal/rules/listmarkerstyle/...` — `TestFix_AllocBudget_PerLineNotPerEdit` ≤6
- [x] `go test ./internal/rules/orderedlistnumbering/...` — `TestFix_AllocBudget_PerLineNotPerEdit` ≤18
- [x] `go test ./internal/rules/nospaceincodespans/...` — `TestFix_BacktickPaddingAllocBudget` ≤4
- [x] `go test ./internal/rules/singleh1/...` — `TestFix_InnerAppendAllocBudget` ≤4
- [x] `go test ./internal/rules/headingstyle/...` — `TestFix_InnerAppendAllocBudget` ≤6
- [x] `go test ./internal/rules/requiredstructure/...` — `TestCheckBodySync_NoBytesPerLineAlloc` ≤6 and `TestCollectBodySyncPoints_NoByteSplitAlloc` ≤2
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run` — no funlen or lll violations

https://claude.ai/code/session_01KykacQ2ZrdrPGERMqwg5WM