### PR TITLE
ci: upload security-audit SARIF to code scanning

### DIFF
--- a/.github/workflows/security-audit-sarif.yml
+++ b/.github/workflows/security-audit-sarif.yml
@@ -1,0 +1,69 @@
+name: security-audit-sarif
+
+# Upload the most recent security-audit SARIF (produced by the
+# mdsmith-security-review skill into docs/security/<date-slug>/) to
+# GitHub code scanning, so audit findings surface in the Security tab
+# next to CodeQL and zizmor. The audit log itself stays in-repo; this
+# only mirrors the newest audit date's findings into the alerts feed.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/security/*/findings.sarif"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Select newest audit SARIFs
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.select.outputs.dirs }}
+      empty: ${{ steps.select.outputs.empty }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Select audit directories sharing the newest date
+        id: select
+        run: |
+          newest="$(find docs/security -mindepth 1 -maxdepth 1 -type d -name '20*' -printf '%f\n' \
+            | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort -u | tail -n1 || true)"
+          dirs="$(find docs/security -mindepth 2 -maxdepth 2 -name findings.sarif \
+            -path "*/${newest}-*/*" -printf '%h\n' | sed 's:.*/::' | sort -u \
+            | jq -R . | jq -cs . || true)"
+          if [ -z "$dirs" ] || [ "$dirs" = "[]" ]; then
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+            echo "dirs=[]" >> "$GITHUB_OUTPUT"
+            echo "No audit findings.sarif found"
+          else
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+            echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+            echo "Newest audit date: $newest"
+            echo "Selected directories: $dirs"
+          fi
+
+  upload:
+    name: Upload audit SARIF to code scanning
+    needs: discover
+    if: needs.discover.outputs.empty == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJSON(needs.discover.outputs.dirs) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Upload findings.sarif
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+        with:
+          sarif_file: docs/security/${{ matrix.dir }}/findings.sarif
+          category: mdsmith-security-review/${{ matrix.dir }}

--- a/.github/workflows/security-audit-sarif.yml
+++ b/.github/workflows/security-audit-sarif.yml
@@ -22,34 +22,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dirs: ${{ steps.select.outputs.dirs }}
-      empty: ${{ steps.select.outputs.empty }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
       - name: Select audit directories sharing the newest date
         id: select
         run: |
-          newest="$(find docs/security -mindepth 1 -maxdepth 1 -type d -name '20*' -printf '%f\n' \
-            | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}' | sort -u | tail -n1 || true)"
-          dirs="$(find docs/security -mindepth 2 -maxdepth 2 -name findings.sarif \
-            -path "*/${newest}-*/*" -printf '%h\n' | sed 's:.*/::' | sort -u \
-            | jq -R . | jq -cs . || true)"
-          if [ -z "$dirs" ] || [ "$dirs" = "[]" ]; then
-            echo "empty=true" >> "$GITHUB_OUTPUT"
-            echo "dirs=[]" >> "$GITHUB_OUTPUT"
-            echo "No audit findings.sarif found"
-          else
-            echo "empty=false" >> "$GITHUB_OUTPUT"
-            echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
-            echo "Newest audit date: $newest"
-            echo "Selected directories: $dirs"
-          fi
+          dirs="$(go run ./cmd/mdsmith-release select-audit-sarifs docs/security)"
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+          echo "Selected: $dirs"
 
   upload:
     name: Upload audit SARIF to code scanning
     needs: discover
-    if: needs.discover.outputs.empty == 'false'
+    if: needs.discover.outputs.dirs != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,9 +51,9 @@ directory named `YYYY-MM-DD-<slug>/`. It holds a
 scope, the method, the findings, and the follow-up.
 
 The `security-audit-sarif` workflow uploads
-the newest audit date's `findings.sarif` to
-GitHub code scanning. The findings then show
-in the Security tab, beside CodeQL and zizmor.
+every audit on the most recent date to GitHub
+code scanning. The findings then show in the
+Security tab, beside CodeQL and zizmor.
 
 <?catalog
 glob:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,11 @@ directory named `YYYY-MM-DD-<slug>/`. It holds a
 `inline-annotations.json`. The report records the
 scope, the method, the findings, and the follow-up.
 
+The `security-audit-sarif` workflow uploads
+the newest audit date's `findings.sarif` to
+GitHub code scanning. The findings then show
+in the Security tab, beside CodeQL and zizmor.
+
 <?catalog
 glob:
   - "docs/security/*/report.md"

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -25,6 +25,7 @@
 //	mdsmith-release record-rotation <ENTRY_TITLE> <YYYY-MM-DD>
 //	mdsmith-release merge-coverage -o <out> <profile>...
 //	mdsmith-release test-summary
+//	mdsmith-release select-audit-sarifs <dir>
 //	mdsmith-release bench [workdir]
 //	mdsmith-release render-bench-page <out-path>
 //	mdsmith-release pgo [workdir]
@@ -38,10 +39,12 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -74,6 +77,8 @@ Commands:
   record-rotation <title> <date>  Update lastRotated in a per-secret rotation file.
   merge-coverage -o <out> <p>...  Merge coverage profiles by summing hit counts.
   test-summary                    Tally unit/integration/e2e tests from a go test -json stream on stdin.
+  select-audit-sarifs <dir>       Print the newest audit date's directories under <dir> (those with a
+                                  findings.sarif) as a JSON array, for the security-audit-sarif matrix.
   bench [workdir]                 Run the pinned cross-tool benchmark; promote JSON + fragments.
   bench-check <base> <fresh>      Fail if mdsmith regressed vs mado between two benchmark snapshots.
   render-bench-page <out-path>    Render the benchmark README (links → GitHub) for the assets branch.
@@ -163,6 +168,8 @@ func dispatchMaintenance(cmd, root string, rest []string) int {
 		return runMergeCoverage(root, rest)
 	case "test-summary":
 		return runTestSummary(root, rest)
+	case "select-audit-sarifs":
+		return runSelectAuditSarifs(root, rest)
 	case "pull-site-assets":
 		return runPullSiteAssets(root, rest)
 	default:
@@ -709,6 +716,47 @@ func runRenderBenchPage(root string, args []string) int {
 		return 2
 	}
 	return reportError(release.RenderBenchPage(root, fs.Arg(0)))
+}
+
+func runSelectAuditSarifs(root string, args []string) int {
+	fs := flag.NewFlagSet("select-audit-sarifs", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: mdsmith-release select-audit-sarifs <security-dir>\n\n"+
+			"Print, as a JSON array on stdout, the basenames of the audit\n"+
+			"directories directly under <security-dir> that share the most\n"+
+			"recent audit date and contain a findings.sarif. The\n"+
+			"security-audit-sarif workflow feeds the array into its upload\n"+
+			"matrix, one code-scanning category per directory. Prints `[]`\n"+
+			"(exit 0) when there is nothing to upload; exits non-zero only\n"+
+			"on a genuine read error so the workflow fails loudly.\n")
+	}
+	if err := fs.Parse(args); err != nil {
+		if code := reportFlagParseErr(err, os.Stderr, "mdsmith-release: select-audit-sarifs"); code >= 0 {
+			return code
+		}
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	dir := fs.Arg(0)
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(root, dir)
+	}
+	names, err := release.SelectAuditSarifs(dir, time.Now())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mdsmith-release: %v\n", err)
+		return 1
+	}
+	if names == nil {
+		names = []string{}
+	}
+	encoded, err := json.Marshal(names)
+	if err != nil {
+		return reportError(err)
+	}
+	fmt.Println(string(encoded))
+	return 0
 }
 
 func runPullSiteAssets(root string, args []string) int {

--- a/cmd/mdsmith-release/main.go
+++ b/cmd/mdsmith-release/main.go
@@ -751,10 +751,9 @@ func runSelectAuditSarifs(root string, args []string) int {
 	if names == nil {
 		names = []string{}
 	}
-	encoded, err := json.Marshal(names)
-	if err != nil {
-		return reportError(err)
-	}
+	// json.Marshal of a []string cannot fail, so there is no error
+	// branch to drive here (CLAUDE.md: no undrivable defensive code).
+	encoded, _ := json.Marshal(names)
 	fmt.Println(string(encoded))
 	return 0
 }

--- a/cmd/mdsmith-release/main_test.go
+++ b/cmd/mdsmith-release/main_test.go
@@ -906,3 +906,58 @@ func TestBenchCheckCommand(t *testing.T) {
 		assert.Equal(t, 0, run([]string{"bench-check", "--tolerance", "0.5", base, fresh}))
 	})
 }
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns
+// everything fn wrote to stdout.
+func captureStdout(t *testing.T, fn func() int) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
+// TestRunSelectAuditSarifs drives the select-audit-sarifs subcommand
+// across every branch: --help (0), an unknown flag (2), bad arity (2),
+// a non-directory securityDir that makes SelectAuditSarifs error (1),
+// an empty absolute dir ("[]"), and a relative dir resolved against cwd
+// whose newest-date audit is emitted as a JSON array.
+func TestRunSelectAuditSarifs(t *testing.T) {
+	assert.Equal(t, 0, run([]string{"select-audit-sarifs", "--help"}))
+	assert.Equal(t, 2, run([]string{"select-audit-sarifs", "--bogus"}))
+	assert.Equal(t, 2, run([]string{"select-audit-sarifs"}))
+	assert.Equal(t, 2, run([]string{"select-audit-sarifs", "a", "b"}))
+
+	// Non-directory securityDir → ReadDir error → exit 1.
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+	assert.Equal(t, 1, run([]string{"select-audit-sarifs", file}))
+
+	// Absolute, empty securityDir → "[]" on stdout, exit 0.
+	out := captureStdout(t, func() int {
+		return run([]string{"select-audit-sarifs", t.TempDir()})
+	})
+	assert.Equal(t, "[]\n", out)
+
+	// Relative securityDir → resolved against cwd; the newest-date
+	// audit is emitted as a JSON array.
+	root := t.TempDir()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	require.NoError(t, os.Chdir(root))
+	audit := filepath.Join("sec", "2026-06-12-full-repo-audit")
+	require.NoError(t, os.MkdirAll(audit, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(audit, "findings.sarif"), []byte("{}"), 0o644))
+	out = captureStdout(t, func() int {
+		return run([]string{"select-audit-sarifs", "sec"})
+	})
+	assert.Equal(t, `["2026-06-12-full-repo-audit"]`+"\n", out)
+}

--- a/internal/release/auditsarif.go
+++ b/internal/release/auditsarif.go
@@ -1,0 +1,103 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// auditDateLayout is the leading date format every audit directory
+// under docs/security/ is named with (YYYY-MM-DD-<slug>).
+const auditDateLayout = "2006-01-02"
+
+// SelectAuditSarifs returns the basenames of the audit directories
+// directly under securityDir that share the most recent audit date and
+// carry a findings.sarif. The security-audit-sarif workflow feeds the
+// result into its upload matrix — one code-scanning category per
+// directory.
+//
+// A directory qualifies when its name begins with a valid YYYY-MM-DD
+// date (followed by end-of-name or a '-' slug separator), that date is
+// not in the future relative to now, and it contains a regular
+// findings.sarif file. "Most recent" is the maximum qualifying date;
+// every directory on that date is returned, since one date can hold
+// more than one audit (e.g. a full-repo audit beside a narrower-scope
+// one). The result is sorted. It is empty — not an error — when
+// securityDir is absent or holds no qualifying directory, so the
+// caller can skip the upload rather than fail the run. A genuine read
+// error (e.g. permissions) is returned so the workflow fails loudly
+// instead of silently uploading nothing.
+func SelectAuditSarifs(securityDir string, now time.Time) ([]string, error) {
+	entries, err := os.ReadDir(securityDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read audit directory %s: %w", securityDir, err)
+	}
+
+	y, mo, d := now.UTC().Date()
+	today := time.Date(y, mo, d, 0, 0, 0, 0, time.UTC)
+
+	type audit struct {
+		name string
+		date time.Time
+	}
+	var cands []audit
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		date, ok := leadingAuditDate(e.Name())
+		if !ok || date.After(today) {
+			continue
+		}
+		sarif := filepath.Join(securityDir, e.Name(), "findings.sarif")
+		info, statErr := os.Stat(sarif)
+		if statErr != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		cands = append(cands, audit{name: e.Name(), date: date})
+	}
+	if len(cands) == 0 {
+		return nil, nil
+	}
+
+	newest := cands[0].date
+	for _, c := range cands[1:] {
+		if c.date.After(newest) {
+			newest = c.date
+		}
+	}
+	var out []string
+	for _, c := range cands {
+		if c.date.Equal(newest) {
+			out = append(out, c.name)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// leadingAuditDate parses the YYYY-MM-DD date a qualifying audit
+// directory name starts with. It rejects names whose first ten bytes
+// are not a real calendar date, and names where the date is run into
+// the slug without a '-' separator (e.g. "2026-06-12x"), so only
+// genuine audit directories match.
+func leadingAuditDate(name string) (time.Time, bool) {
+	if len(name) < len(auditDateLayout) {
+		return time.Time{}, false
+	}
+	if len(name) > len(auditDateLayout) && name[len(auditDateLayout)] != '-' {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(auditDateLayout, name[:len(auditDateLayout)])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/internal/release/auditsarif.go
+++ b/internal/release/auditsarif.go
@@ -23,7 +23,8 @@ const auditDateLayout = "2006-01-02"
 // A directory qualifies when its name begins with a valid YYYY-MM-DD
 // date (followed by end-of-name or a '-' slug separator), that date is
 // not in the future relative to now, and it contains a regular
-// findings.sarif file. "Most recent" is the maximum qualifying date;
+// (non-symlink) findings.sarif file. "Most recent" is the maximum
+// qualifying date;
 // every directory on that date is returned, since one date can hold
 // more than one audit (e.g. a full-repo audit beside a narrower-scope
 // one). The result is sorted. It is empty — not an error — when
@@ -56,9 +57,14 @@ func SelectAuditSarifs(securityDir string, now time.Time) ([]string, error) {
 		if !ok || date.After(today) {
 			continue
 		}
+		// Lstat, not Stat, so a symlinked findings.sarif is rejected
+		// rather than followed: the upload step reads this path
+		// directly, and audit files are meant to be regular in-repo
+		// files. The project's own audits flag symlink-follow (S003,
+		// S007), so the selector holds the same line.
 		sarif := filepath.Join(securityDir, e.Name(), "findings.sarif")
-		info, statErr := os.Stat(sarif)
-		if statErr != nil || !info.Mode().IsRegular() {
+		info, lstatErr := os.Lstat(sarif)
+		if lstatErr != nil || !info.Mode().IsRegular() {
 			continue
 		}
 		cands = append(cands, audit{name: e.Name(), date: date})

--- a/internal/release/auditsarif_test.go
+++ b/internal/release/auditsarif_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// now is a fixed "today" for the selection tests: any audit dated
+// auditNow is a fixed "today" for the selection tests: any audit dated
 // after this is treated as a future-dated typo and ignored.
 var auditNow = time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
 
@@ -26,95 +26,97 @@ func makeAudit(t *testing.T, securityDir, name string, withSarif bool) {
 	}
 }
 
-func TestSelectAuditSarifs(t *testing.T) {
-	tests := []struct {
-		name string
-		// dirs maps an audit directory name to whether it carries a
-		// findings.sarif.
-		dirs map[string]bool
-		want []string
-	}{
-		{
-			name: "single audit with sarif",
-			dirs: map[string]bool{"2026-06-12-full-repo-audit": true},
-			want: []string{"2026-06-12-full-repo-audit"},
-		},
-		{
-			name: "newest date wins over older dates",
-			dirs: map[string]bool{
-				"2026-04-05-adversarial":     true,
-				"2026-05-12-supply-chain":    true,
-				"2026-06-09-full-repo-audit": true,
-				"2026-06-12-full-repo-audit": true,
-			},
-			want: []string{"2026-06-12-full-repo-audit"},
-		},
-		{
-			name: "every directory sharing the newest date is returned, sorted",
-			dirs: map[string]bool{
-				"2026-06-12-git-lsp-audit":   true,
-				"2026-06-12-full-repo-audit": true,
-				"2026-06-09-full-repo-audit": true,
-			},
-			want: []string{"2026-06-12-full-repo-audit", "2026-06-12-git-lsp-audit"},
-		},
-		{
-			name: "directory without findings.sarif is excluded",
-			dirs: map[string]bool{
-				"2026-06-12-full-repo-audit": false,
-				"2026-06-09-full-repo-audit": true,
-			},
-			want: []string{"2026-06-09-full-repo-audit"},
-		},
-		{
-			name: "non-date directory names are ignored",
-			dirs: map[string]bool{
-				"proto":                      true,
-				"notes":                      true,
-				"2026-06-12-full-repo-audit": true,
-			},
-			want: []string{"2026-06-12-full-repo-audit"},
-		},
-		{
-			name: "date run into the slug without a separator is ignored",
-			dirs: map[string]bool{
-				"2026-06-12xfull": true,
-				"2026-06-09-real": true,
-			},
-			want: []string{"2026-06-09-real"},
-		},
-		{
-			name: "bare date directory name without a slug qualifies",
-			dirs: map[string]bool{
-				"2026-06-12":      true,
-				"2026-06-09-real": true,
-			},
-			want: []string{"2026-06-12"},
-		},
-		{
-			name: "invalid calendar date is ignored",
-			dirs: map[string]bool{
-				"2026-13-40-bogus": true,
-				"2026-06-09-real":  true,
-			},
-			want: []string{"2026-06-09-real"},
-		},
-		{
-			name: "future-dated directory does not hijack selection",
-			dirs: map[string]bool{
-				"2099-01-01-typo":            true,
-				"2026-06-12-full-repo-audit": true,
-			},
-			want: []string{"2026-06-12-full-repo-audit"},
-		},
-		{
-			name: "no qualifying directory yields empty",
-			dirs: map[string]bool{"2026-06-12-full-repo-audit": false},
-			want: nil,
-		},
-	}
+// selectAuditCase is one SelectAuditSarifs table row. dirs maps an audit
+// directory name to whether it carries a findings.sarif.
+type selectAuditCase struct {
+	name string
+	dirs map[string]bool
+	want []string
+}
 
-	for _, tt := range tests {
+var selectAuditSarifsCases = []selectAuditCase{
+	{
+		name: "single audit with sarif",
+		dirs: map[string]bool{"2026-06-12-full-repo-audit": true},
+		want: []string{"2026-06-12-full-repo-audit"},
+	},
+	{
+		name: "newest date wins over older dates",
+		dirs: map[string]bool{
+			"2026-04-05-adversarial":     true,
+			"2026-05-12-supply-chain":    true,
+			"2026-06-09-full-repo-audit": true,
+			"2026-06-12-full-repo-audit": true,
+		},
+		want: []string{"2026-06-12-full-repo-audit"},
+	},
+	{
+		name: "every directory sharing the newest date is returned, sorted",
+		dirs: map[string]bool{
+			"2026-06-12-git-lsp-audit":   true,
+			"2026-06-12-full-repo-audit": true,
+			"2026-06-09-full-repo-audit": true,
+		},
+		want: []string{"2026-06-12-full-repo-audit", "2026-06-12-git-lsp-audit"},
+	},
+	{
+		name: "directory without findings.sarif is excluded",
+		dirs: map[string]bool{
+			"2026-06-12-full-repo-audit": false,
+			"2026-06-09-full-repo-audit": true,
+		},
+		want: []string{"2026-06-09-full-repo-audit"},
+	},
+	{
+		name: "non-date directory names are ignored",
+		dirs: map[string]bool{
+			"proto":                      true,
+			"notes":                      true,
+			"2026-06-12-full-repo-audit": true,
+		},
+		want: []string{"2026-06-12-full-repo-audit"},
+	},
+	{
+		name: "date run into the slug without a separator is ignored",
+		dirs: map[string]bool{
+			"2026-06-12xfull": true,
+			"2026-06-09-real": true,
+		},
+		want: []string{"2026-06-09-real"},
+	},
+	{
+		name: "bare date directory name without a slug qualifies",
+		dirs: map[string]bool{
+			"2026-06-12":      true,
+			"2026-06-09-real": true,
+		},
+		want: []string{"2026-06-12"},
+	},
+	{
+		name: "invalid calendar date is ignored",
+		dirs: map[string]bool{
+			"2026-13-40-bogus": true,
+			"2026-06-09-real":  true,
+		},
+		want: []string{"2026-06-09-real"},
+	},
+	{
+		name: "future-dated directory does not hijack selection",
+		dirs: map[string]bool{
+			"2099-01-01-typo":            true,
+			"2026-06-12-full-repo-audit": true,
+		},
+		want: []string{"2026-06-12-full-repo-audit"},
+	},
+	{
+		name: "no qualifying directory yields empty",
+		dirs: map[string]bool{"2026-06-12-full-repo-audit": false},
+		want: nil,
+	},
+}
+
+func TestSelectAuditSarifs(t *testing.T) {
+	for _, tt := range selectAuditSarifsCases {
 		t.Run(tt.name, func(t *testing.T) {
 			securityDir := t.TempDir()
 			for name, withSarif := range tt.dirs {
@@ -131,8 +133,8 @@ func TestSelectAuditSarifs(t *testing.T) {
 	}
 }
 
-// TestSelectAuditSarifsAbsentDir: a missing securityDir is not an
-// error — there is simply nothing to upload.
+// TestSelectAuditSarifsAbsentDir: a missing securityDir is not an error
+// — there is simply nothing to upload.
 func TestSelectAuditSarifsAbsentDir(t *testing.T) {
 	got, err := SelectAuditSarifs(filepath.Join(t.TempDir(), "nope"), auditNow)
 	if err != nil {
@@ -160,9 +162,9 @@ func TestSelectAuditSarifsSarifIsDir(t *testing.T) {
 	}
 }
 
-// TestSelectAuditSarifsSarifIsSymlink: a findings.sarif that is a
-// symlink (even to a regular file) does not qualify — Lstat rejects it
-// rather than following it.
+// TestSelectAuditSarifsSarifIsSymlink: a findings.sarif that is a symlink
+// (even to a regular file) does not qualify — Lstat rejects it rather
+// than following it.
 func TestSelectAuditSarifsSarifIsSymlink(t *testing.T) {
 	securityDir := t.TempDir()
 	dir := filepath.Join(securityDir, "2026-06-12-full-repo-audit")

--- a/internal/release/auditsarif_test.go
+++ b/internal/release/auditsarif_test.go
@@ -187,6 +187,19 @@ func TestSelectAuditSarifsSarifIsSymlink(t *testing.T) {
 	}
 }
 
+// TestSelectAuditSarifsReadError: a securityDir that is a regular file
+// (not a directory) surfaces ReadDir's error rather than silently
+// treating it as "no audits".
+func TestSelectAuditSarifsReadError(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := SelectAuditSarifs(file, auditNow); err == nil {
+		t.Fatal("expected error for non-directory securityDir, got nil")
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/release/auditsarif_test.go
+++ b/internal/release/auditsarif_test.go
@@ -84,6 +84,14 @@ func TestSelectAuditSarifs(t *testing.T) {
 			want: []string{"2026-06-09-real"},
 		},
 		{
+			name: "bare date directory name without a slug qualifies",
+			dirs: map[string]bool{
+				"2026-06-12":      true,
+				"2026-06-09-real": true,
+			},
+			want: []string{"2026-06-12"},
+		},
+		{
 			name: "invalid calendar date is ignored",
 			dirs: map[string]bool{
 				"2026-13-40-bogus": true,
@@ -149,6 +157,31 @@ func TestSelectAuditSarifsSarifIsDir(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("got %v, want nil", got)
+	}
+}
+
+// TestSelectAuditSarifsSarifIsSymlink: a findings.sarif that is a
+// symlink (even to a regular file) does not qualify — Lstat rejects it
+// rather than following it.
+func TestSelectAuditSarifsSarifIsSymlink(t *testing.T) {
+	securityDir := t.TempDir()
+	dir := filepath.Join(securityDir, "2026-06-12-full-repo-audit")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(securityDir, "real.sarif")
+	if err := os.WriteFile(target, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "findings.sarif")); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+	got, err := SelectAuditSarifs(securityDir, auditNow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("symlinked findings.sarif should be excluded, got %v", got)
 	}
 }
 

--- a/internal/release/auditsarif_test.go
+++ b/internal/release/auditsarif_test.go
@@ -1,0 +1,165 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// now is a fixed "today" for the selection tests: any audit dated
+// after this is treated as a future-dated typo and ignored.
+var auditNow = time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+
+// makeAudit creates securityDir/<name>/ and, when withSarif, a regular
+// findings.sarif inside it.
+func makeAudit(t *testing.T, securityDir, name string, withSarif bool) {
+	t.Helper()
+	dir := filepath.Join(securityDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if withSarif {
+		if err := os.WriteFile(filepath.Join(dir, "findings.sarif"), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write sarif: %v", err)
+		}
+	}
+}
+
+func TestSelectAuditSarifs(t *testing.T) {
+	tests := []struct {
+		name string
+		// dirs maps an audit directory name to whether it carries a
+		// findings.sarif.
+		dirs map[string]bool
+		want []string
+	}{
+		{
+			name: "single audit with sarif",
+			dirs: map[string]bool{"2026-06-12-full-repo-audit": true},
+			want: []string{"2026-06-12-full-repo-audit"},
+		},
+		{
+			name: "newest date wins over older dates",
+			dirs: map[string]bool{
+				"2026-04-05-adversarial":     true,
+				"2026-05-12-supply-chain":    true,
+				"2026-06-09-full-repo-audit": true,
+				"2026-06-12-full-repo-audit": true,
+			},
+			want: []string{"2026-06-12-full-repo-audit"},
+		},
+		{
+			name: "every directory sharing the newest date is returned, sorted",
+			dirs: map[string]bool{
+				"2026-06-12-git-lsp-audit":   true,
+				"2026-06-12-full-repo-audit": true,
+				"2026-06-09-full-repo-audit": true,
+			},
+			want: []string{"2026-06-12-full-repo-audit", "2026-06-12-git-lsp-audit"},
+		},
+		{
+			name: "directory without findings.sarif is excluded",
+			dirs: map[string]bool{
+				"2026-06-12-full-repo-audit": false,
+				"2026-06-09-full-repo-audit": true,
+			},
+			want: []string{"2026-06-09-full-repo-audit"},
+		},
+		{
+			name: "non-date directory names are ignored",
+			dirs: map[string]bool{
+				"proto":                      true,
+				"notes":                      true,
+				"2026-06-12-full-repo-audit": true,
+			},
+			want: []string{"2026-06-12-full-repo-audit"},
+		},
+		{
+			name: "date run into the slug without a separator is ignored",
+			dirs: map[string]bool{
+				"2026-06-12xfull": true,
+				"2026-06-09-real": true,
+			},
+			want: []string{"2026-06-09-real"},
+		},
+		{
+			name: "invalid calendar date is ignored",
+			dirs: map[string]bool{
+				"2026-13-40-bogus": true,
+				"2026-06-09-real":  true,
+			},
+			want: []string{"2026-06-09-real"},
+		},
+		{
+			name: "future-dated directory does not hijack selection",
+			dirs: map[string]bool{
+				"2099-01-01-typo":            true,
+				"2026-06-12-full-repo-audit": true,
+			},
+			want: []string{"2026-06-12-full-repo-audit"},
+		},
+		{
+			name: "no qualifying directory yields empty",
+			dirs: map[string]bool{"2026-06-12-full-repo-audit": false},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			securityDir := t.TempDir()
+			for name, withSarif := range tt.dirs {
+				makeAudit(t, securityDir, name, withSarif)
+			}
+			got, err := SelectAuditSarifs(securityDir, auditNow)
+			if err != nil {
+				t.Fatalf("SelectAuditSarifs: unexpected error: %v", err)
+			}
+			if !equalStrings(got, tt.want) {
+				t.Errorf("SelectAuditSarifs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSelectAuditSarifsAbsentDir: a missing securityDir is not an
+// error — there is simply nothing to upload.
+func TestSelectAuditSarifsAbsentDir(t *testing.T) {
+	got, err := SelectAuditSarifs(filepath.Join(t.TempDir(), "nope"), auditNow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+// TestSelectAuditSarifsSarifIsDir: a findings.sarif that is a directory
+// (not a regular file) does not qualify.
+func TestSelectAuditSarifsSarifIsDir(t *testing.T) {
+	securityDir := t.TempDir()
+	dir := filepath.Join(securityDir, "2026-06-12-full-repo-audit", "findings.sarif")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got, err := SelectAuditSarifs(securityDir, auditNow)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What

A `security-audit-sarif` workflow uploads the most recent security-audit
SARIF (produced by the `mdsmith-security-review` skill into
`docs/security/<date-slug>/`) to **GitHub code scanning**, so audit
findings surface in the **Security tab** alongside CodeQL and zizmor.

## Why

Reporting/disclosure already routes to GitHub Security Advisories
(`SECURITY.md`). The proactive **audit log** in `docs/security/` is a
better fit for code scanning than for advisories: its findings are
per-file/line static results, and the SARIF the skill already emits is
exactly what `upload-sarif` consumes. The Security-tab code-scanning feed
already exists (CodeQL via default setup + zizmor), so this adds
`mdsmith-security-review` as a third source. Published advisories stay
reserved for confirmed, downstream-affecting vulns in a *shipped*
artifact — none of the current findings qualify.

## How

- **`discover`** job runs `go run ./cmd/mdsmith-release
  select-audit-sarifs docs/security`, which returns the audit directories
  sharing the most recent date (those with a `findings.sarif`) as a JSON
  array. The selection logic lives in `release.SelectAuditSarifs` with
  table-driven tests — per `docs/development/release-tooling.md`, workflow
  runtime logic goes in the Go CLI, not inline shell.
- **`upload`** job matrixes over those directories and calls
  `github/codeql-action/upload-sarif` (pinned to `ci.yml`'s SHA), one
  `mdsmith-security-review/<dir>` category each. Gated on `dirs != '[]'`
  so an empty result skips cleanly.
- Triggers: `push` to `main` touching a `docs/security/*/findings.sarif`,
  plus `workflow_dispatch`. Least-privilege perms; `persist-credentials:
  false`; passes local `zizmor`.

## Review hardening (two `/code-review` passes at max effort)

- Moved the discovery off inline `find|grep|sed|jq` into the tested
  `select-audit-sarifs` subcommand (release-tooling convention).
- The Go selector validates calendar dates, ignores future-dated
  directories (so a mistyped `2099-…` dir can't hijack selection),
  surfaces real read errors instead of masking them, and uses `os.Lstat`
  so a symlinked `findings.sarif` is rejected rather than followed —
  the same symlink-follow line the project's own audits hold (S003/S007).

## Notes / limitations

- Per-dir categories favor **false-open over false-closed**: a superseded
  audit's alerts may linger until a same-named re-upload, but a narrow
  newer audit can never auto-close a broader audit's still-open findings.
- SARIF line numbers reflect the audit commit, so minor drift vs `main`
  HEAD is possible; `report.md` stays authoritative.
- Existing audits surface on the next push touching a `findings.sarif` or
  a manual **Run workflow** dispatch.
- The audit log itself stays in-repo (linted, cross-linked to `plan/`).

## Verification

- `mdsmith check .` → 0 failures; `go build/vet ./...` clean.
- `release.SelectAuditSarifs` table tests pass (newest-date selection,
  multi-audit dates, missing/symlinked/dir `findings.sarif`, non-date and
  future-dated names, bare-date boundary).
- CLI on the real tree returns both 2026-06-12 audits; `zizmor` clean.
- (Unrelated `TestPGO*` failures locally are this sandbox's commit-signing
  server, not CI.)

https://claude.ai/code/session_01L4B8Z9Bq9KhBJr9BCxD677