### PR TITLE
docs: fill PGO catalog title

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -209,7 +209,7 @@ glob:
 sort: title
 row: "- [{title}](../docs/development/{filename})"
 ?>
-- [](../docs/development/pgo-profile.md)
+- [PGO and the uncommitted profile](../docs/development/pgo-profile.md)
 - [Adding a peer linter](../docs/development/add-peer-linter.md)
 - [Architecture audit log](../docs/development/architecture-audit.md)
 - [Architecture principles](../docs/development/architecture/index.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -209,7 +209,6 @@ glob:
 sort: title
 row: "- [{title}](../docs/development/{filename})"
 ?>
-- [PGO and the uncommitted profile](../docs/development/pgo-profile.md)
 - [Adding a peer linter](../docs/development/add-peer-linter.md)
 - [Architecture audit log](../docs/development/architecture-audit.md)
 - [Architecture principles](../docs/development/architecture/index.md)
@@ -218,6 +217,7 @@ row: "- [{title}](../docs/development/{filename})"
 - [File Placement](../docs/development/file-placement.md)
 - [High-Performance Go](../docs/development/high-performance-go.md)
 - [Merge Queue](../docs/development/merge-queue.md)
+- [PGO and the uncommitted profile](../docs/development/pgo-profile.md)
 - [PR Fixup Workflow](../docs/development/pr-fixup-workflow.md)
 - [Public Markdown Library](../docs/development/markdown-library.md)
 - [Release Pipeline](../docs/development/release.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,6 @@ glob:
 sort: title
 row: "- [{title}](docs/development/{filename})"
 ?>
-- [PGO and the uncommitted profile](docs/development/pgo-profile.md)
 - [Adding a peer linter](docs/development/add-peer-linter.md)
 - [Architecture audit log](docs/development/architecture-audit.md)
 - [Architecture principles](docs/development/architecture/index.md)
@@ -223,6 +222,7 @@ row: "- [{title}](docs/development/{filename})"
 - [File Placement](docs/development/file-placement.md)
 - [High-Performance Go](docs/development/high-performance-go.md)
 - [Merge Queue](docs/development/merge-queue.md)
+- [PGO and the uncommitted profile](docs/development/pgo-profile.md)
 - [PR Fixup Workflow](docs/development/pr-fixup-workflow.md)
 - [Public Markdown Library](docs/development/markdown-library.md)
 - [Release Pipeline](docs/development/release.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ glob:
 sort: title
 row: "- [{title}](docs/development/{filename})"
 ?>
-- [](docs/development/pgo-profile.md)
+- [PGO and the uncommitted profile](docs/development/pgo-profile.md)
 - [Adding a peer linter](docs/development/add-peer-linter.md)
 - [Architecture audit log](docs/development/architecture-audit.md)
 - [Architecture principles](docs/development/architecture/index.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ glob:
 sort: title
 row: "- [{title}](docs/development/{filename})"
 ?>
-- [](docs/development/pgo-profile.md)
+- [PGO and the uncommitted profile](docs/development/pgo-profile.md)
 - [Adding a peer linter](docs/development/add-peer-linter.md)
 - [Architecture audit log](docs/development/architecture-audit.md)
 - [Architecture principles](docs/development/architecture/index.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,6 @@ glob:
 sort: title
 row: "- [{title}](docs/development/{filename})"
 ?>
-- [PGO and the uncommitted profile](docs/development/pgo-profile.md)
 - [Adding a peer linter](docs/development/add-peer-linter.md)
 - [Architecture audit log](docs/development/architecture-audit.md)
 - [Architecture principles](docs/development/architecture/index.md)
@@ -209,6 +208,7 @@ row: "- [{title}](docs/development/{filename})"
 - [File Placement](docs/development/file-placement.md)
 - [High-Performance Go](docs/development/high-performance-go.md)
 - [Merge Queue](docs/development/merge-queue.md)
+- [PGO and the uncommitted profile](docs/development/pgo-profile.md)
 - [PR Fixup Workflow](docs/development/pr-fixup-workflow.md)
 - [Public Markdown Library](docs/development/markdown-library.md)
 - [Release Pipeline](docs/development/release.md)

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -15,7 +15,6 @@ glob:
 sort: title
 row: "- [{title}]({filename})"
 ?>
-- [PGO and the uncommitted profile](pgo-profile.md)
 - [Adding a peer linter](add-peer-linter.md)
 - [Architecture audit log](architecture-audit.md)
 - [Architecture principles](architecture/index.md)
@@ -24,6 +23,7 @@ row: "- [{title}]({filename})"
 - [File Placement](file-placement.md)
 - [High-Performance Go](high-performance-go.md)
 - [Merge Queue](merge-queue.md)
+- [PGO and the uncommitted profile](pgo-profile.md)
 - [PR Fixup Workflow](pr-fixup-workflow.md)
 - [Public Markdown Library](markdown-library.md)
 - [Release Pipeline](release.md)

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -15,7 +15,7 @@ glob:
 sort: title
 row: "- [{title}]({filename})"
 ?>
-- [](pgo-profile.md)
+- [PGO and the uncommitted profile](pgo-profile.md)
 - [Adding a peer linter](add-peer-linter.md)
 - [Architecture audit log](architecture-audit.md)
 - [Architecture principles](architecture/index.md)

--- a/docs/development/pgo-profile.md
+++ b/docs/development/pgo-profile.md
@@ -1,4 +1,5 @@
 ---
+title: PGO and the uncommitted profile
 summary: >-
   Why no PGO profile is committed: a checked-in
   `cmd/mdsmith/default.pgo` burdens every merge with a binary


### PR DESCRIPTION
## Summary
- add the missing title front matter to docs/development/pgo-profile.md
- update the generated development catalogs so the PGO entry is no longer rendered as an empty link

## Validation
- grep for empty pgo-profile links returned no matches
- git diff --check

Note: I could not run mdsmith/go-based checks locally because this environment does not have the Go toolchain (`go: command not found`).