### PR TITLE
Fix action.yml for GitHub Marketplace publish validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
-name: mdsmith
+name: mdsmith Markdown linter
 description: >-
-  Install the mdsmith Markdown linter from a checksum-verified GitHub release
-  binary for the runner's OS and architecture, put it on PATH, and optionally
-  run a mdsmith command.
+  Install the mdsmith Markdown linter from a checksum-verified
+  release binary and optionally run it.
 author: jeduden
 branding:
   icon: check-square

--- a/docs/development/release-channels/github-actions.md
+++ b/docs/development/release-channels/github-actions.md
@@ -14,13 +14,13 @@ platforms: [linux, macos, windows]
 registry: github.com/marketplace
 credential: GITHUB_TOKEN
 job: release
-channelurl: https://github.com/marketplace/actions/mdsmith
+channelurl: https://github.com/marketplace/actions/mdsmith-markdown-linter
 weight: 15
 unlisted: true
 ---
 # GitHub Actions
 
-Release page: <https://github.com/marketplace/actions/mdsmith>
+Release page: <https://github.com/marketplace/actions/mdsmith-markdown-linter>
 
 The repository root carries an `action.yml`, so a workflow
 step runs mdsmith with:


### PR DESCRIPTION
## What

Fixes the two GitHub Marketplace validation errors that block publishing the action (from #623):

- **Name** — `mdsmith` is rejected ("must be unique; cannot match an existing action, user, or organization name"). Renamed to **`mdsmith Markdown linter`**.
- **Description** — exceeded the 125-character limit. Shortened to **98 chars**: _"Install the mdsmith Markdown linter from a checksum-verified release binary and optionally run it."_

Also points the channel doc's Marketplace URL at the new name's slug (`/marketplace/actions/mdsmith-markdown-linter`), so the frontmatter `channelurl` and the body `Release page:` line stay in sync (the channel is still `unlisted`, so this isn't rendered user-facing yet).

## Notes

- The action's runtime behavior is unchanged — `name`/`description` are Marketplace metadata only; the smoke test (`uses: ./`) is unaffected.
- The Marketplace slug is predicted as `mdsmith-markdown-linter` (GitHub derives it from the name). If GitHub assigns a different slug on first publish, the `channelurl` is a one-line follow-up.

## Testing

`mdsmith check` clean (484 files; the `Release page:` line matches `channelurl`) · `sync-channels --check` drift-free · zizmor clean · description length verified at 98 < 125.

https://claude.ai/code/session_01TKgJTS4UcFPqtdwkxYzTUC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKgJTS4UcFPqtdwkxYzTUC)_