### PR TITLE
Lazy parse: BlockSpan seam for block NodeCheckers (plan 2606141903)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -196,7 +196,7 @@ footer: |
 | 2606130838 | ✅     | sonnet | [Memoize linkgraph link and image extraction on the File](plan/2606130838_memoize-link-extraction.md)                                   |
 | 2606141901 | ✅     | opus   | [Spike: block-only parse cost vs gomarklint](plan/2606141901_spike-block-only-parse-cost.md)                                            |
 | 2606141902 | ✅     | opus   | [Lazy parse: Layer 0 block scanner and parse-skip](plan/2606141902_lazy-parse-layer0.md)                                                |
-| 2606141903 | 🔲     | opus   | [Lazy parse: BlockSpan seam for block NodeCheckers](plan/2606141903_lazy-parse-blockspan-nodecheckers.md)                               |
+| 2606141903 | ✅     | opus   | [Lazy parse: BlockSpan seam for block NodeCheckers](plan/2606141903_lazy-parse-blockspan-nodecheckers.md)                               |
 | 2606141904 | 🔲     | opus   | [Lazy parse: Layer 1 light inline index](plan/2606141904_lazy-parse-inline-index.md)                                                    |
 | 2606141910 | ✅     | sonnet | [Extract build path helpers out of internal/rules/build](plan/2606141910_arch-fix-build-rules-dip.md)                                   |
 | 2606141911 | ✅     | haiku  | [Remove deprecated engine wrappers for checker and lint](plan/2606141911_arch-fix-engine-deprecated-wrappers.md)                        |

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -56,7 +56,7 @@ func CheckRulesWithIntraFile(
 	skipSourceContext bool,
 	intraFileCap int,
 ) ([]lint.Diagnostic, []error) {
-	slots, nodeCheckers, errs := classifyRules(rules, effective)
+	slots, nodeCheckers, blockCheckers, errs := classifyRules(f, rules, effective)
 
 	// Run non-NodeChecker rules. With cap=1 the loop stays serial and
 	// matches the legacy code path byte-for-byte. With cap>1, slots
@@ -71,8 +71,15 @@ func CheckRulesWithIntraFile(
 	// goroutine, one walk, one rule per node — fast enough that
 	// splitting per rule would lose the cache locality the multiplex
 	// just won.
+	//
+	// On a parse-skipped File (f.AST nil), classifyRules routes every
+	// rule into blockCheckers instead, so nodeCheckers is empty and the
+	// AST walk is never entered with a nil tree.
 	if len(nodeCheckers) > 0 {
 		runNodeCheckers(f, nodeCheckers)
+	}
+	if len(blockCheckers) > 0 {
+		runBlockCheckers(f, blockCheckers)
 	}
 
 	var diags []lint.Diagnostic
@@ -88,14 +95,16 @@ func CheckRulesWithIntraFile(
 	return diags, errs
 }
 
-// ruleSlot is one rule's diagnostic bucket. NodeCheckers append to
-// it from the shared walk; non-NodeCheckers fill it once via Check.
-// Slots are kept in rules order so the final concatenation reproduces
-// the sequential output exactly. Configure-failed rules never get a
-// slot — they short-circuit in classifyRules with an entry in errs.
+// ruleSlot is one rule's diagnostic bucket. NodeCheckers append to it
+// from the shared AST walk; BlockCheckers from the shared block-span
+// dispatch on a parse-skipped File; non-NodeCheckers fill it once via
+// Check. Slots are kept in rules order so the final concatenation
+// reproduces the sequential output exactly. Configure-failed rules never
+// get a slot — they short-circuit in classifyRules with an entry in errs.
 type ruleSlot struct {
 	nc    rule.NodeChecker
-	check rule.Rule // non-nil for non-NodeChecker slots
+	bc    rule.BlockChecker // non-nil for the nil-AST block-span path
+	check rule.Rule         // non-nil for non-NodeChecker slots
 	diags []lint.Diagnostic
 }
 
@@ -105,11 +114,22 @@ type ruleSlot struct {
 // otherwise the worker's existing clone is reused as-is), and splits
 // the result into per-rule slots. The slots slice keeps every
 // enabled rule in input order (so the final concatenation is
-// deterministic); the nodeCheckers slice is the subset whose group
-// will be filled by the shared walk.
+// deterministic); nodeCheckers and blockCheckers are the subsets the
+// two shared dispatches fill.
+//
+// The two dispatches are mutually exclusive per File: when f.AST is set
+// (the parsed path) a NodeChecker goes to nodeCheckers and the shared
+// AST walk drives its CheckNode; when f.AST is nil (the Layer 0
+// parse-skip path) a rule that is also a rule.BlockChecker goes to
+// blockCheckers and the shared block-span dispatch drives its CheckBlock
+// instead. A nil-AST NodeChecker that is NOT a BlockChecker cannot run
+// on the tree-less File, so it is dropped from both — the engine's gate
+// guarantees that case never reaches here (it parses unless every
+// enabled rule is Layer 0), so dropping it is a defensive belt, not a
+// behaviour the production path relies on.
 func classifyRules(
-	rules []rule.Rule, effective map[string]config.RuleCfg,
-) (slots []ruleSlot, nodeCheckers []*ruleSlot, errs []error) {
+	f *lint.File, rules []rule.Rule, effective map[string]config.RuleCfg,
+) (slots []ruleSlot, nodeCheckers, blockCheckers []*ruleSlot, errs []error) {
 	// Pre-size at the registered-rule count. In production all but a
 	// handful of rules are enabled by default. Allocating slots as a
 	// value slice (rather than a slice of `*ruleSlot`) collapses the
@@ -119,6 +139,7 @@ func classifyRules(
 	// because the slots cap was pre-set to len(rules) — no append
 	// grows the backing, so the index-derived pointers do not
 	// dangle.
+	astNil := f != nil && f.AST == nil
 	slots = make([]ruleSlot, 0, len(rules))
 	for _, rl := range rules {
 		cfg, ok := effective[rl.Name()]
@@ -130,21 +151,42 @@ func classifyRules(
 			errs = append(errs, err)
 			continue
 		}
-		if nc, ok := checkRule.(rule.NodeChecker); ok {
-			slots = append(slots, ruleSlot{nc: nc})
-			continue
-		}
-		slots = append(slots, ruleSlot{check: checkRule})
+		slots = append(slots, classifySlot(checkRule, astNil))
 	}
 	for i := range slots {
-		if slots[i].nc != nil {
+		switch {
+		case slots[i].bc != nil:
+			if blockCheckers == nil {
+				blockCheckers = make([]*ruleSlot, 0, len(slots)/2+1)
+			}
+			blockCheckers = append(blockCheckers, &slots[i])
+		case slots[i].nc != nil:
 			if nodeCheckers == nil {
 				nodeCheckers = make([]*ruleSlot, 0, len(slots)/2+1)
 			}
 			nodeCheckers = append(nodeCheckers, &slots[i])
 		}
 	}
-	return slots, nodeCheckers, errs
+	return slots, nodeCheckers, blockCheckers, errs
+}
+
+// classifySlot builds one rule's slot. On a parse-skipped File (astNil)
+// a rule.BlockChecker is routed to the block-span dispatch; on a parsed
+// File a rule.NodeChecker is routed to the shared AST walk. A non-node
+// rule fills its own slot via Check. A nil-AST NodeChecker that is not a
+// BlockChecker gets an empty slot (no dispatch claims it); see
+// classifyRules for why that path is unreachable in production.
+func classifySlot(checkRule rule.Rule, astNil bool) ruleSlot {
+	if nc, ok := checkRule.(rule.NodeChecker); ok {
+		if astNil {
+			if bc, ok := checkRule.(rule.BlockChecker); ok {
+				return ruleSlot{bc: bc}
+			}
+			return ruleSlot{}
+		}
+		return ruleSlot{nc: nc}
+	}
+	return ruleSlot{check: checkRule}
 }
 
 // kindTable is the per-file dispatch plan for the shared NodeChecker
@@ -287,6 +329,44 @@ func dispatchWithGeneric(n ast.Node, f *lint.File, t *kindTable) {
 			s.diags = append(s.diags, ds...)
 		}
 	}
+}
+
+// runBlockCheckers drives the shared block-span dispatch for a
+// parse-skipped File (f.AST nil): it walks the Layer 0 block scan once,
+// in document order, and for each span calls CheckBlock on every
+// block-checker slot whose rule reacts to that span's kind, appending
+// diagnostics into each rule's own slot. Spans are visited in document
+// order and slots in rule order, so the concatenated result is grouped
+// by rule exactly as the AST walk groups CheckNode output — the byte-
+// identical contract rule.BlockChecker promises.
+//
+// The block-checker count is tiny (the migrated structural rules), so a
+// per-span linear scan over the slots beats building a kind-indexed
+// table and allocates nothing beyond the diagnostics themselves.
+func runBlockCheckers(f *lint.File, blockCheckers []*ruleSlot) {
+	scan := lint.Layer0(f)
+	for _, span := range scan.BlockSpans {
+		for _, s := range blockCheckers {
+			if !blockCheckerReactsTo(s.bc, span.Kind) {
+				continue
+			}
+			if ds := s.bc.CheckBlock(span, f); len(ds) > 0 {
+				s.diags = append(s.diags, ds...)
+			}
+		}
+	}
+}
+
+// blockCheckerReactsTo reports whether bc declares interest in kind. The
+// kind set per rule is tiny (one or two kinds), so a linear scan over
+// BlockKinds() beats a map and allocates nothing.
+func blockCheckerReactsTo(bc rule.BlockChecker, kind lint.BlockKind) bool {
+	for _, want := range bc.BlockKinds() {
+		if want == kind {
+			return true
+		}
+	}
+	return false
 }
 
 // runNonNodeCheckers fills the non-NodeChecker slots' diags fields.

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -197,6 +197,20 @@ func TestCheckRulesWithIntraFile_nodeChecker(t *testing.T) {
 	assert.NotEmpty(t, diags)
 }
 
+// TestCheckRulesWithIntraFile_nodeCheckerNilAST exercises the defensive branch
+// in classifySlot where a NodeChecker that is not a BlockChecker runs against a
+// parse-skipped File (AST nil). The rule cannot run, so no diagnostics are emitted.
+func TestCheckRulesWithIntraFile_nodeCheckerNilAST(t *testing.T) {
+	f := lint.NewFileLines("doc.md", []byte("# Hello\n\nParagraph.\n"))
+	f.RootDir = "."
+	f.RunCache = lint.NewRunCache()
+	d := lint.Diagnostic{Line: 1, RuleID: "TST001", Message: "node hit"}
+	rules := []rule.Rule{&nodeCheckerRule{plainRule: plainRule{id: "TST001"}, diag: d}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	assert.Empty(t, diags, "NodeChecker without BlockChecker emits nothing on nil-AST path")
+}
+
 // TestCheckRulesWithIntraFile_blockCheckerNilAST pins the BlockSpan
 // dispatch: on a parse-skipped File (AST nil) the engine drives a
 // rule.BlockChecker over the Layer 0 block spans, so its diagnostics

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -46,6 +46,42 @@ func (r *nodeCheckerRule) CheckNode(_ ast.Node, entering bool, _ *lint.File) []l
 
 var _ rule.NodeChecker = (*nodeCheckerRule)(nil)
 
+// blockCheckerRule emits one diagnostic per thematic-break span (block
+// path) and one per ThematicBreak node (AST path), so a test can assert
+// the engine drives the same output through both seams.
+type blockCheckerRule struct {
+	plainRule
+	message string
+}
+
+func (r *blockCheckerRule) Check(f *lint.File) []lint.Diagnostic {
+	if f != nil && f.AST == nil {
+		return rule.WalkBlocks(r, f)
+	}
+	return rule.WalkNodes(r, f)
+}
+
+func (r *blockCheckerRule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
+	if entering && n.Kind() == ast.KindThematicBreak {
+		return []lint.Diagnostic{{Line: 1, RuleID: r.id, Message: r.message}}
+	}
+	return nil
+}
+
+func (r *blockCheckerRule) CheckBlock(span lint.BlockSpan, _ *lint.File) []lint.Diagnostic {
+	return []lint.Diagnostic{{Line: span.Start, RuleID: r.id, Message: r.message}}
+}
+
+func (r *blockCheckerRule) BlockKinds() []lint.BlockKind {
+	return []lint.BlockKind{lint.BlockThematicBreak}
+}
+
+func (r *blockCheckerRule) EnteringKinds() []ast.NodeKind {
+	return []ast.NodeKind{ast.KindThematicBreak}
+}
+
+var _ rule.BlockChecker = (*blockCheckerRule)(nil)
+
 type goodConfigurable struct {
 	plainRule
 	Applied map[string]any
@@ -159,6 +195,34 @@ func TestCheckRulesWithIntraFile_nodeChecker(t *testing.T) {
 	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
 	assert.Empty(t, errs)
 	assert.NotEmpty(t, diags)
+}
+
+// TestCheckRulesWithIntraFile_blockCheckerNilAST pins the BlockSpan
+// dispatch: on a parse-skipped File (AST nil) the engine drives a
+// rule.BlockChecker over the Layer 0 block spans, so its diagnostics
+// still surface even though the shared AST walk has no tree to traverse.
+func TestCheckRulesWithIntraFile_blockCheckerNilAST(t *testing.T) {
+	f := lint.NewFileLines("doc.md", []byte("para\n\n---\n\nmore\n"))
+	f.RootDir = "."
+	f.RunCache = lint.NewRunCache()
+	rules := []rule.Rule{&blockCheckerRule{plainRule: plainRule{id: "TST001"}, message: "hr seen"}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	require.Len(t, diags, 1, "block checker fires on the nil-AST path")
+	assert.Equal(t, 3, diags[0].Line, "thematic break at line 3")
+}
+
+// TestCheckRulesWithIntraFile_blockCheckerASTPath pins that the same
+// rule still runs through the shared AST walk when a tree is present, so
+// the migration adds the BlockSpan seam without disturbing the parsed
+// path.
+func TestCheckRulesWithIntraFile_blockCheckerASTPath(t *testing.T) {
+	f := newTestFile(t, "para\n\n---\n\nmore\n")
+	rules := []rule.Rule{&blockCheckerRule{plainRule: plainRule{id: "TST001"}, message: "hr seen"}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	require.Len(t, diags, 1, "block checker fires on the AST path")
+	assert.Equal(t, 1, diags[0].Line)
 }
 
 func TestCheckRulesWithIntraFile_settingsError(t *testing.T) {

--- a/internal/engine/layer0_gate_test.go
+++ b/internal/engine/layer0_gate_test.go
@@ -215,6 +215,73 @@ func TestLayer0Gate_CodeSpanRuleForcesParse(t *testing.T) {
 	assert.Empty(t, res.Diagnostics)
 }
 
+// TestLayer0Gate_BlockCheckerRulesSkipParse proves acceptance criterion 1
+// of plan 2606141903: the migrated block NodeCheckers (MDS013
+// blank-line-around-headings, MDS044 horizontal-rule-style) run with no
+// parse. With only those two block rules enabled and the gate on, the
+// File reaches the rules with a nil AST, and the block-span dispatch still
+// produces their diagnostics.
+func TestLayer0Gate_BlockCheckerRulesSkipParse(t *testing.T) {
+	withLayer0Skip(t, true)
+	// A heading with no blank line after (MDS013) and a non-dash thematic
+	// break with surrounding blanks (MDS044). No fence, tab, or four-space
+	// indent, so the gate skips the parse.
+	dir, path := writeDoc(t, "# Title\nbody\n\n***\n\nmore\n")
+
+	probe := &astProbeRule{}
+	cfg := config.Defaults()
+	for name := range cfg.Rules {
+		cfg.Rules[name] = config.RuleCfg{Enabled: false}
+	}
+	cfg.Rules["blank-line-around-headings"] = config.RuleCfg{Enabled: true}
+	cfg.Rules["horizontal-rule-style"] = config.RuleCfg{Enabled: true}
+	cfg.Rules[probe.Name()] = config.RuleCfg{Enabled: true}
+
+	r := &Runner{
+		Config:           cfg,
+		Rules:            append(rule.All(), probe),
+		StripFrontMatter: true,
+		RootDir:          dir,
+	}
+	res := r.Run([]string{path})
+	require.Empty(t, res.Errors)
+	assert.True(t, probe.sawNilAST,
+		"block-checker-only config must skip the parse")
+	assert.NotEmpty(t, res.Diagnostics,
+		"block checkers must still produce diagnostics on the parse-skipped path")
+}
+
+// TestLayer0Gate_BlockCheckerDiagnosticsMatchFullParse is the per-rule
+// equivalence for the migrated block NodeCheckers driven through the real
+// engine: the diagnostics with the gate on (block-span dispatch, nil AST)
+// are identical to the gate off (AST walk).
+func TestLayer0Gate_BlockCheckerDiagnosticsMatchFullParse(t *testing.T) {
+	dir, path := writeDoc(t, "# Title\nbody\n\n***\n\nmore\n\n## Next\nx\n")
+	cfg := config.Defaults()
+	for name := range cfg.Rules {
+		cfg.Rules[name] = config.RuleCfg{Enabled: false}
+	}
+	cfg.Rules["blank-line-around-headings"] = config.RuleCfg{Enabled: true}
+	cfg.Rules["horizontal-rule-style"] = config.RuleCfg{Enabled: true}
+
+	run := func(skip bool) []lint.Diagnostic {
+		withLayer0Skip(t, skip)
+		r := &Runner{
+			Config:           cfg,
+			Rules:            rule.All(),
+			StripFrontMatter: true,
+			RootDir:          dir,
+		}
+		return r.Run([]string{path}).Diagnostics
+	}
+
+	skipped := run(true)
+	parsed := run(false)
+	require.NotEmpty(t, parsed)
+	assert.Equal(t, parsed, skipped,
+		"block-checker parse-skip must match the full parse")
+}
+
 // astProbeRule is a test rule that records whether the File it checked had
 // a nil AST (the parse-skipped state). It declares itself Layer 0 via an
 // id the audit manifest covers... but as a synthetic rule its id is not in

--- a/internal/integration/testdata/rule_walk_audit.json
+++ b/internal/integration/testdata/rule_walk_audit.json
@@ -134,8 +134,8 @@
   {
     "id": "MDS013",
     "name": "blank-line-around-headings",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
@@ -475,8 +475,8 @@
   {
     "id": "MDS044",
     "name": "horizontal-rule-style",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,

--- a/internal/lint/layer0.go
+++ b/internal/lint/layer0.go
@@ -803,7 +803,23 @@ func piName(b []byte) []byte {
 // spaces of indent, followed by a space, tab, or end of line). Headings
 // are a single line. Returns false when the cursor line is not a heading.
 func (s *scanner) tryATXHeading() bool {
-	line := s.lines[s.i]
+	if !isATXHeadingLine(s.lines[s.i]) {
+		return false
+	}
+	start := s.i
+	s.addSpan(BlockATXHeading, start, start, 0)
+	s.i++
+	s.prevNonBlankParagraph = false
+	return true
+}
+
+// isATXHeadingLine reports whether line is an ATX heading: 1–6 `#` after
+// up to 3 spaces of indent, followed by a space, tab, carriage return, or
+// end of line. Mirrors atxHeadingParser.Open and is the same predicate
+// tryATXHeading and scanParagraph (paragraph interruption) both use. It
+// takes a full unstripped line (and so enforces the indent < 4 guard
+// itself), distinct from lineclass_scan.go's indent-stripped isATXHeading.
+func isATXHeadingLine(line []byte) bool {
 	indent := leadingSpaces(line)
 	if indent >= 4 {
 		return false
@@ -816,14 +832,7 @@ func (s *scanner) tryATXHeading() bool {
 	if level < 1 || level > 6 {
 		return false
 	}
-	if j < len(line) && line[j] != ' ' && line[j] != '\t' && line[j] != '\r' {
-		return false
-	}
-	start := s.i
-	s.addSpan(BlockATXHeading, start, start, 0)
-	s.i++
-	s.prevNonBlankParagraph = false
-	return true
+	return j >= len(line) || line[j] == ' ' || line[j] == '\t' || line[j] == '\r'
 }
 
 // tryIndentedCode recognises an indented code block at the cursor. An
@@ -909,6 +918,11 @@ func (s *scanner) scanParagraph() {
 			break
 		}
 		if opensPI(cur) {
+			break
+		}
+		// An ATX heading interrupts a paragraph (atxHeadingParser:
+		// CanInterruptParagraph is true), so the paragraph ends before it.
+		if isATXHeadingLine(cur) {
 			break
 		}
 		// HTML blocks of types 1–6 can interrupt a paragraph (type 7

--- a/internal/lint/layer0_test.go
+++ b/internal/lint/layer0_test.go
@@ -587,6 +587,18 @@ func TestOpeningFence_TwoCharRunNotAFence(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestScanParagraph_ATXHeadingInterruptsParagraph(t *testing.T) {
+	// An ATX heading can interrupt a paragraph (CommonMark CanInterruptParagraph).
+	// The paragraph span ends before the heading; the heading is its own span.
+	l0 := scan("para text\n## Section\n")
+	kinds := make(map[BlockKind]int)
+	for _, sp := range l0.BlockSpans {
+		kinds[sp.Kind]++
+	}
+	assert.Equal(t, 1, kinds[BlockParagraph], "paragraph before heading")
+	assert.Equal(t, 1, kinds[BlockATXHeading], "ATX heading after paragraph")
+}
+
 func TestScanParagraph_FenceInterruptsParagraph(t *testing.T) {
 	// A fenced code block interrupts an open paragraph without a blank line.
 	// The paragraph span ends before the fence; the fence is its own span.

--- a/internal/rule/walk.go
+++ b/internal/rule/walk.go
@@ -43,6 +43,65 @@ type KindScopedChecker interface {
 	EnteringKinds() []ast.NodeKind
 }
 
+// BlockChecker is an optional capability for a NodeChecker rule whose
+// per-node logic depends only on a block's kind and source line span —
+// never on the inline node tree under it. Such a rule can run from the
+// Layer 0 block scan (lint.Layer0) without a goldmark parse: the engine
+// drives CheckBlock over the block spans of a nil-AST File instead of
+// CheckNode over an AST.
+//
+// Contract: for every File, CheckBlock must return precisely the
+// diagnostics CheckNode would over the same document — same line,
+// column, message, severity — so the two paths are byte-identical
+// (the layer0 equivalence gate enforces this across the corpus).
+// BlockKinds must return every lint.BlockKind CheckBlock can emit a
+// diagnostic for; the engine dispatches a span to a rule only when the
+// span's kind is in that set, exactly as KindScopedChecker.EnteringKinds
+// scopes the AST walk. The result must be constant for the life of the
+// rule.
+type BlockChecker interface {
+	NodeChecker
+	// CheckBlock is invoked once per block span whose Kind is in
+	// BlockKinds(), in document order. It reads the span's kind and
+	// 1-based inclusive line range plus f.Lines; it must not touch
+	// f.AST (which is nil on the Layer 0 path).
+	CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic
+	// BlockKinds returns the block kinds CheckBlock reacts to.
+	BlockKinds() []lint.BlockKind
+}
+
+// WalkBlocks runs r.CheckBlock over the Layer 0 block scan of f,
+// dispatching only the spans whose Kind is in r.BlockKinds(), in
+// document order. A BlockChecker's standalone Check delegates here for
+// the nil-AST path so direct callers (unit tests) get behaviour
+// identical to the engine's block dispatch. A nil File returns nil.
+func WalkBlocks(r BlockChecker, f *lint.File) []lint.Diagnostic {
+	if f == nil {
+		return nil
+	}
+	kinds := r.BlockKinds()
+	var diags []lint.Diagnostic
+	for _, span := range lint.Layer0(f).BlockSpans {
+		if !blockKindInSet(span.Kind, kinds) {
+			continue
+		}
+		diags = append(diags, r.CheckBlock(span, f)...)
+	}
+	return diags
+}
+
+// blockKindInSet reports whether k is in kinds. The set is tiny (a rule
+// reacts to one or two block kinds), so a linear scan beats a map and
+// allocates nothing.
+func blockKindInSet(k lint.BlockKind, kinds []lint.BlockKind) bool {
+	for _, want := range kinds {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
 // WalkNodes runs r.CheckNode over a single ast.Walk of f. A
 // NodeChecker's standalone Check delegates here so direct callers
 // (the LSP, unit tests) get behaviour identical to the engine's

--- a/internal/rule/walk_test.go
+++ b/internal/rule/walk_test.go
@@ -87,6 +87,49 @@ func TestWalkNodes_EqualsManualWalk(t *testing.T) {
 	assert.Equal(t, manual, viaHelper)
 }
 
+// blockCheckerStub emits one diagnostic per thematic-break span and
+// records every span kind it is shown, so the test can assert WalkBlocks
+// dispatches only the kinds BlockKinds declares, in document order.
+type blockCheckerStub struct {
+	nodeCheckerStub
+	seenKinds []lint.BlockKind
+}
+
+func (s *blockCheckerStub) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
+	s.seenKinds = append(s.seenKinds, span.Kind)
+	return []lint.Diagnostic{{RuleID: s.ID(), Line: span.Start, Message: "block seen"}}
+}
+
+func (s *blockCheckerStub) BlockKinds() []lint.BlockKind {
+	return []lint.BlockKind{lint.BlockThematicBreak}
+}
+
+var _ BlockChecker = (*blockCheckerStub)(nil)
+
+// TestWalkBlocks_DispatchesScopedKindsInOrder pins that WalkBlocks drives
+// CheckBlock only for spans whose kind is in BlockKinds, in document
+// order, on a nil-AST File served from the Layer 0 scan.
+func TestWalkBlocks_DispatchesScopedKindsInOrder(t *testing.T) {
+	f := lint.NewFileLines("t.md", []byte("# Heading\n\ntext\n\n---\n\nmore\n\n***\n"))
+
+	s := &blockCheckerStub{}
+	diags := WalkBlocks(s, f)
+
+	require.Len(t, diags, 2, "one diagnostic per thematic-break span")
+	assert.Equal(t, 5, diags[0].Line, "first break at line 5")
+	assert.Equal(t, 9, diags[1].Line, "second break at line 9")
+	for _, k := range s.seenKinds {
+		assert.Equal(t, lint.BlockThematicBreak, k,
+			"only thematic-break spans are dispatched")
+	}
+}
+
+// TestWalkBlocks_NilFile pins the defensive nil guard so unit-test stubs
+// that pass a nil File do not crash.
+func TestWalkBlocks_NilFile(t *testing.T) {
+	assert.Nil(t, WalkBlocks(&blockCheckerStub{}, nil))
+}
+
 // TestWalkNodes_NilFileAndNilAST pins the defensive nil guard:
 // unit-test stubs that construct `&lint.File{}` literals must not
 // crash WalkNodes. The engine path never produces such files (NewFile

--- a/internal/rulelayer/rule_walk_audit.json
+++ b/internal/rulelayer/rule_walk_audit.json
@@ -134,8 +134,8 @@
   {
     "id": "MDS013",
     "name": "blank-line-around-headings",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
@@ -475,8 +475,8 @@
   {
     "id": "MDS044",
     "name": "horizontal-rule-style",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -26,7 +26,11 @@ func TestEmbeddedManifestMatchesAuditOracle(t *testing.T) {
 
 func TestIsLayer0(t *testing.T) {
 	// A few representative "A-no-skipping" rules resolve to Layer 0.
-	for _, id := range []string{"MDS006", "MDS007", "MDS022", "MDS064"} {
+	// MDS013 (blank-line-around-headings) and MDS044 (horizontal-rule-
+	// style) were migrated to rule.BlockChecker (plan 2606141903): their
+	// nil-AST paths serve from the Layer 0 block scan, so the audit
+	// reclassified them A-no-skipping and the gate now admits them.
+	for _, id := range []string{"MDS006", "MDS007", "MDS013", "MDS022", "MDS044", "MDS064"} {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0", id)
 		assert.Equal(t, Layer0, Of(id))
 	}

--- a/internal/rules/blanklinearoundheadings/rule.go
+++ b/internal/rules/blanklinearoundheadings/rule.go
@@ -29,11 +29,17 @@ func (r *Rule) Name() string { return "blank-line-around-headings" }
 // Category implements rule.Rule.
 func (r *Rule) Category() string { return "heading" }
 
-// Check implements rule.Rule. The per-heading logic is pure and
-// stateless, so it is expressed as CheckNode and the engine can fold
-// this rule into one shared AST walk; a direct call still works via
-// rule.WalkNodes.
+// Check implements rule.Rule. The per-heading logic depends only on the
+// heading's line span and the blank lines around it — never on the inline
+// tree — so the rule is a rule.BlockChecker: on a parsed File it folds
+// into the engine's shared AST walk (rule.WalkNodes), and on a parse-
+// skipped File (f.AST nil) it reads the Layer 0 block scan instead
+// (rule.WalkBlocks). Both resolve the same heading line span, so the
+// diagnostics are identical.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	if f != nil && f.AST == nil {
+		return rule.WalkBlocks(r, f)
+	}
 	return rule.WalkNodes(r, f)
 }
 
@@ -59,7 +65,34 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		return nil
 	}
 	lastLine := headingLastLine(heading, f)
+	return r.checkBlankLines(f, line, lastLine)
+}
 
+// CheckBlock implements rule.BlockChecker. A heading span's 1-based
+// Start is the first heading line (HeadingLine on the AST path) and End
+// is its last line — the underline for a setext heading, the heading
+// line itself for ATX — matching headingLastLine. The Layer 0 scanner
+// never emits a heading span for a line inside a code block, so the
+// AST path's code-line skip has no nil-AST counterpart to reproduce.
+func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
+	return r.checkBlankLines(f, span.Start, span.End)
+}
+
+// blockKinds is the static block-kind interest CheckBlock declares via
+// rule.BlockChecker; package-level so BlockKinds returns it without
+// allocating. ATX and setext headings both map from ast.KindHeading.
+var blockKinds = []lint.BlockKind{lint.BlockATXHeading, lint.BlockSetextHeading}
+
+// BlockKinds implements rule.BlockChecker: CheckBlock reacts to both
+// heading shapes.
+func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
+
+var _ rule.BlockChecker = (*Rule)(nil)
+
+// checkBlankLines is the shared per-heading check both the AST
+// (CheckNode) and Layer 0 (CheckBlock) paths drive: line is the 1-based
+// first heading line, lastLine its 1-based last line.
+func (r *Rule) checkBlankLines(f *lint.File, line, lastLine int) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 
 	// Check blank line before (not needed for line 1)

--- a/internal/rules/blanklinearoundheadings/rule_test.go
+++ b/internal/rules/blanklinearoundheadings/rule_test.go
@@ -23,6 +23,8 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 		[]byte("intro\nTitle\n=====\n\nText.\n"),
 		[]byte("# A\n## B\n### C\n"),
 		[]byte("para\n\n# Only\n"),
+		[]byte("multi\nline\ntitle\n=====\ntext\n"),
+		[]byte("text\n# Mid heading\nmore text\n"),
 	}
 	for _, src := range srcs {
 		astFile, err := lint.NewFile("f.md", src)

--- a/internal/rules/blanklinearoundheadings/rule_test.go
+++ b/internal/rules/blanklinearoundheadings/rule_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestCheck_NilASTMatchesAST pins the BlockChecker migration: Check on a
+// nil-AST File (the Layer 0 parse-skip path) must produce byte-identical
+// diagnostics to the AST path for ATX and setext headings alike.
+func TestCheck_NilASTMatchesAST(t *testing.T) {
+	srcs := [][]byte{
+		[]byte("# Title\n\nSome text\n\n## Section\n\nMore text\n"),
+		[]byte("# Title\n\nSome text\n## Section\n\nMore text\n"),
+		[]byte("# Title\nSome text\n"),
+		[]byte("Title\n=====\nText immediately after\n"),
+		[]byte("intro\nTitle\n=====\n\nText.\n"),
+		[]byte("# A\n## B\n### C\n"),
+		[]byte("para\n\n# Only\n"),
+	}
+	for _, src := range srcs {
+		astFile, err := lint.NewFile("f.md", src)
+		require.NoError(t, err)
+		astDiags := (&Rule{}).Check(astFile)
+		l0Diags := (&Rule{}).Check(lint.NewFileLines("f.md", src))
+		assert.Equal(t, astDiags, l0Diags,
+			"nil-AST diagnostics must match AST for %q", string(src))
+	}
+}
+
 func TestCheck_ProperBlankLines_NoViolation(t *testing.T) {
 	src := []byte("# Title\n\nSome text\n\n## Section\n\nMore text\n")
 	f, err := lint.NewFile("test.md", src)

--- a/internal/rules/horizontalrulestyle/rule.go
+++ b/internal/rules/horizontalrulestyle/rule.go
@@ -39,11 +39,16 @@ func (r *Rule) Category() string { return "whitespace" }
 // EnabledByDefault implements rule.Defaultable.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// Check implements rule.Rule. The per-thematic-break logic is pure and
-// stateless, so it is expressed as CheckNode and the engine can fold
-// this rule into one shared AST walk; a direct call still works via
-// rule.WalkNodes.
+// Check implements rule.Rule. The per-thematic-break logic depends only
+// on the rule's source line — never on the inline tree — so the rule is
+// a rule.BlockChecker: on a parsed File it folds into the engine's shared
+// AST walk (rule.WalkNodes), and on a parse-skipped File (f.AST nil) it
+// reads the Layer 0 block scan instead (rule.WalkBlocks). Both paths
+// resolve to the same source line, so the diagnostics are identical.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	if f != nil && f.AST == nil {
+		return rule.WalkBlocks(r, f)
+	}
 	return rule.WalkNodes(r, f)
 }
 
@@ -59,6 +64,24 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	line := thematicBreakLine(tb, f)
 	return r.checkHR(f, line)
 }
+
+// CheckBlock implements rule.BlockChecker: a thematic-break span's
+// 1-based start line is the source line CheckNode would resolve from the
+// AST node, so it drives the same per-line checks.
+func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
+	return r.checkHR(f, span.Start)
+}
+
+// blockKinds is the static block-kind interest CheckBlock declares via
+// rule.BlockChecker; package-level so BlockKinds returns it without
+// allocating.
+var blockKinds = []lint.BlockKind{lint.BlockThematicBreak}
+
+// BlockKinds implements rule.BlockChecker: CheckBlock only reacts to
+// thematic-break spans.
+func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
+
+var _ rule.BlockChecker = (*Rule)(nil)
 
 func (r *Rule) checkHR(f *lint.File, line int) []lint.Diagnostic {
 	lineIdx := line - 1

--- a/internal/rules/horizontalrulestyle/rule_test.go
+++ b/internal/rules/horizontalrulestyle/rule_test.go
@@ -67,6 +67,30 @@ func TestCheckSetextHeadingNotFlagged(t *testing.T) {
 	assert.Empty(t, diags)
 }
 
+// TestCheckNilASTMatchesAST pins the BlockChecker migration: Check on a
+// nil-AST File (the Layer 0 parse-skip path, served from lint.Layer0)
+// must produce byte-identical diagnostics to the AST path for every
+// thematic-break shape the rule flags. This is the per-rule equivalence
+// the corpus gate enforces in aggregate.
+func TestCheckNilASTMatchesAST(t *testing.T) {
+	srcs := [][]byte{
+		[]byte("# Title\n\nText.\n\n---\n\nMore.\n"),
+		[]byte("# Title\n\nText.\n\n***\n\nMore.\n"),
+		[]byte("# Title\n\nText.\n\n- - -\n\nMore.\n"),
+		[]byte("# Title\n\nText.\n\n-----\n\nMore.\n"),
+		[]byte("# Title\n---\n\nText.\n"),
+		[]byte("# Title\n\n---\nText.\n"),
+		[]byte("Title\n=====\n\nText.\n"),
+		[]byte("a\n\n---\n\nb\n\n***\n\nc\n"),
+	}
+	for _, src := range srcs {
+		astDiags := newRule().Check(newFile(t, "f.md", src))
+		l0Diags := newRule().Check(lint.NewFileLines("f.md", src))
+		assert.Equal(t, astDiags, l0Diags,
+			"nil-AST diagnostics must match AST for %q", string(src))
+	}
+}
+
 func TestCheckDisabledByDefault(t *testing.T) {
 	r := &Rule{Style: "dash", Length: 3, RequireBlankLines: true}
 	assert.False(t, r.EnabledByDefault())

--- a/plan/2606141903_lazy-parse-blockspan-nodecheckers.md
+++ b/plan/2606141903_lazy-parse-blockspan-nodecheckers.md
@@ -1,7 +1,7 @@
 ---
 id: 2606141903
 title: "Lazy parse: BlockSpan seam for block NodeCheckers"
-status: "🔲"
+status: "✅"
 summary: >-
   Run the block-kind NodeChecker rules over the Layer 0
   BlockSpan model instead of the heap AST, so parity's
@@ -46,14 +46,42 @@ they already read only kind and position.
    `n.(*ast.Heading)` and onto `BlockSpan`.
 4. Extend the parse-skip gate to cover these rules.
 
+## Implementation notes
+
+The seam is `rule.BlockChecker`. It refines `NodeChecker`
+with `CheckBlock` and `BlockKinds`, paired with
+`rule.WalkBlocks`. `internal/checker` adds a block-span
+dispatch. It runs each enabled block checker over the
+Layer 0 spans when `f.AST` is nil. The AST path is
+unchanged.
+
+Two block-only rules were migrated.
+
+- MDS044 (`horizontal-rule-style`) reads a thematic-break
+  span.
+- MDS013 (`blank-line-around-headings`) reads ATX and
+  setext heading spans.
+
+Each keeps `CheckNode` for the parsed path. Each gains a
+`CheckBlock` that resolves the same source lines from the
+span. The output is byte-identical. The other block-kind
+rules read inline content. They stay on the AST path.
+
+The Layer 0 scanner gained ATX-heading paragraph
+interruption in `scanParagraph`. An ATX heading mid-text
+now ends the paragraph and emits its own span, as goldmark
+does. The audit reclassifies both migrated rules
+`A-no-skipping`. So `rulelayer` admits them to Layer 0.
+The gate covers them with no new override.
+
 ## Acceptance Criteria
 
-- [ ] Parity's block NodeCheckers run with no parse when
+- [x] Parity's block NodeCheckers run with no parse when
       no Layer 1 or Layer 2 rule is enabled.
-- [ ] Each migrated rule's diagnostics are byte-identical
+- [x] Each migrated rule's diagnostics are byte-identical
       to its AST output across the corpus and fixtures.
-- [ ] All existing rule fixtures pass unchanged.
-- [ ] The equivalence gate is green.
-- [ ] All tests pass: `go test ./...`
+- [x] All existing rule fixtures pass unchanged.
+- [x] The equivalence gate is green.
+- [x] All tests pass: `go test ./...`
 
 [research]: ../docs/research/benchmarks/lazy-parse-architecture.md


### PR DESCRIPTION
Implements plan **2606141903** — serve the block-kind NodeChecker rules from Layer 0 so structural rules no longer force the goldmark parse.

## Dependency

Builds on plan 2606141902 (PR #628, branch `claude/youthful-knuth-mlfp0k`), which is **not yet merged into `main`**. This PR's branch already contains those commits, so the diff against `main` includes PR #628's work until it merges. Review only the commits authored here:

- `feat(lint): serve block NodeCheckers from Layer 0 BlockSpan`
- `test(blanklinearoundheadings): cover multi-line setext and mid-paragraph headings`

## What changed

- **New seam `rule.BlockChecker`** (`internal/rule/walk.go`): a `NodeChecker` refinement declaring `CheckBlock(span lint.BlockSpan, f)` and `BlockKinds() []lint.BlockKind`, plus a `rule.WalkBlocks` helper that drives it over `lint.Layer0(f).BlockSpans`. A `BlockChecker` reads a block's kind and 1-based line span only — never the inline tree.
- **Shared block-span dispatch** (`internal/checker/checker.go`): `classifyRules` now takes the `*lint.File`. On a parse-skipped File (`f.AST == nil`) each enabled `BlockChecker` is routed to a new `runBlockCheckers` driver that walks the Layer 0 spans in document order; the AST walk path is untouched for parsed files. Diagnostics group by rule exactly as the AST walk does.
- **Migrated two block-only rules**:
  - **MDS044** `horizontal-rule-style` (thematic-break span)
  - **MDS013** `blank-line-around-headings` (ATX + setext heading spans)

  Each keeps `CheckNode` for the parsed path and gains a `CheckBlock` that resolves the same source lines from the span, so output is byte-identical. The remaining block-kind rules read inline content (heading text/level, list-item structure) and stay on the AST path.
- **Scanner fix** (`internal/lint/layer0.go`): `scanParagraph` now breaks a paragraph on an ATX heading (`isATXHeadingLine`), matching goldmark's `CanInterruptParagraph`, so heading block spans align with the AST. Caught by the per-rule equivalence test.
- **Layer reclassification**: regenerated the rule-walk audit manifest — both rules flip `hybrid` → `A-no-skipping`, so `rulelayer` admits them to Layer 0 and the parse-skip gate covers them with no new override. The embedded `rulelayer` copy is kept byte-identical to the integration oracle.

## Acceptance criteria

- [x] Block NodeCheckers run with no parse when only Layer 0 rules are enabled (`TestLayer0Gate_BlockCheckerRulesSkipParse`).
- [x] Each migrated rule's diagnostics are byte-identical to its AST output (per-rule `TestCheck_NilASTMatchesAST` + corpus `TestLayer0Gate_*DiagnosticsMatchFullParse`).
- [x] All existing rule fixtures pass unchanged.
- [x] The equivalence gate is green (`TestLayer0Equivalence_Fixtures`, `TestLayer0Gate_CorpusDiagnosticsEquivalence`).
- [x] `go test ./...` passes (the only failures are the pre-existing `internal/release` PGO tests, which require a commit-signing server unavailable in this environment).

## Testing

`go test ./...`, `go vet`, `go test -race ./internal/checker ./internal/rule`, alloc-budget gate, and `mdsmith check .` all green.

https://claude.ai/code/session_01XFudgsakuqtatKgHATh4CM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFudgsakuqtatKgHATh4CM)_