### PR TITLE
Lazy parse: Layer 1 inline index (code spans + full inline rules)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -197,7 +197,7 @@ footer: |
 | 2606141901 | ✅     | opus   | [Spike: block-only parse cost vs gomarklint](plan/2606141901_spike-block-only-parse-cost.md)                                            |
 | 2606141902 | ✅     | opus   | [Lazy parse: Layer 0 block scanner and parse-skip](plan/2606141902_lazy-parse-layer0.md)                                                |
 | 2606141903 | ✅     | opus   | [Lazy parse: BlockSpan seam for block NodeCheckers](plan/2606141903_lazy-parse-blockspan-nodecheckers.md)                               |
-| 2606141904 | 🔲     | opus   | [Lazy parse: Layer 1 light inline index](plan/2606141904_lazy-parse-inline-index.md)                                                    |
+| 2606141904 | 🔳     | opus   | [Lazy parse: Layer 1 light inline index](plan/2606141904_lazy-parse-inline-index.md)                                                    |
 | 2606141910 | ✅     | sonnet | [Extract build path helpers out of internal/rules/build](plan/2606141910_arch-fix-build-rules-dip.md)                                   |
 | 2606141911 | ✅     | haiku  | [Remove deprecated engine wrappers for checker and lint](plan/2606141911_arch-fix-engine-deprecated-wrappers.md)                        |
 | 2606141912 | ✅     | haiku  | [Add per-function unit tests for secreview/report.go](plan/2606141912_arch-fix-secreview-report-tests.md)                               |

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -182,6 +182,12 @@ func classifySlot(checkRule rule.Rule, astNil bool) ruleSlot {
 			if bc, ok := checkRule.(rule.BlockChecker); ok {
 				return ruleSlot{bc: bc}
 			}
+			// An InlineChecker serves the nil-AST path from its own Check
+			// (reading lint.InlineBlocks), so route it to the plain-Check
+			// slot rather than dropping it.
+			if ic, ok := checkRule.(rule.InlineChecker); ok && ic.InlineCapable() {
+				return ruleSlot{check: checkRule}
+			}
 			return ruleSlot{}
 		}
 		return ruleSlot{nc: nc}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -82,6 +82,34 @@ func (r *blockCheckerRule) EnteringKinds() []ast.NodeKind {
 
 var _ rule.BlockChecker = (*blockCheckerRule)(nil)
 
+// inlineCheckerRule is a NodeChecker that is NOT a BlockChecker but
+// implements rule.InlineChecker: its Check serves the nil-AST path itself.
+// It lets a test pin that the engine routes such a rule to its own Check on
+// a parse-skipped File rather than dropping it.
+type inlineCheckerRule struct {
+	plainRule
+	message string
+}
+
+func (r *inlineCheckerRule) Check(f *lint.File) []lint.Diagnostic {
+	if f != nil && f.AST == nil {
+		// Stand in for the real rules' lint.InlineBlocks consumption.
+		return []lint.Diagnostic{{Line: 1, RuleID: r.id, Message: r.message}}
+	}
+	return rule.WalkNodes(r, f)
+}
+
+func (r *inlineCheckerRule) CheckNode(n ast.Node, entering bool, _ *lint.File) []lint.Diagnostic {
+	if entering && n.Kind() == ast.KindParagraph {
+		return []lint.Diagnostic{{Line: 1, RuleID: r.id, Message: r.message}}
+	}
+	return nil
+}
+
+func (r *inlineCheckerRule) InlineCapable() bool { return true }
+
+var _ rule.InlineChecker = (*inlineCheckerRule)(nil)
+
 type goodConfigurable struct {
 	plainRule
 	Applied map[string]any
@@ -209,6 +237,32 @@ func TestCheckRulesWithIntraFile_nodeCheckerNilAST(t *testing.T) {
 	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
 	assert.Empty(t, errs)
 	assert.Empty(t, diags, "NodeChecker without BlockChecker emits nothing on nil-AST path")
+}
+
+// TestCheckRulesWithIntraFile_inlineCheckerNilAST pins the InlineChecker
+// branch of classifySlot: a NodeChecker that is not a BlockChecker but
+// implements rule.InlineChecker is routed to its own Check on a
+// parse-skipped File (AST nil), so its diagnostics surface from the shared
+// inline parse rather than being dropped.
+func TestCheckRulesWithIntraFile_inlineCheckerNilAST(t *testing.T) {
+	f := lint.NewFileLines("doc.md", []byte("# Hello\n\nParagraph.\n"))
+	f.RootDir = "."
+	f.RunCache = lint.NewRunCache()
+	rules := []rule.Rule{&inlineCheckerRule{plainRule: plainRule{id: "TST001"}, message: "inline hit"}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	require.Len(t, diags, 1, "InlineChecker fires through its own Check on the nil-AST path")
+	assert.Equal(t, "inline hit", diags[0].Message)
+}
+
+// TestCheckRulesWithIntraFile_inlineCheckerASTPath pins that the same rule
+// still runs through the shared AST walk when a tree is present.
+func TestCheckRulesWithIntraFile_inlineCheckerASTPath(t *testing.T) {
+	f := newTestFile(t, "# Hello\n\nParagraph.\n")
+	rules := []rule.Rule{&inlineCheckerRule{plainRule: plainRule{id: "TST001"}, message: "inline hit"}}
+	diags, errs := checker.CheckRulesWithIntraFile(f, rules, enabled("TST001"), true, 1)
+	assert.Empty(t, errs)
+	require.Len(t, diags, 1, "InlineChecker fires through the shared AST walk on the parsed path")
 }
 
 // TestCheckRulesWithIntraFile_blockCheckerNilAST pins the BlockSpan

--- a/internal/engine/layer0_gate_test.go
+++ b/internal/engine/layer0_gate_test.go
@@ -186,13 +186,16 @@ func TestLayer0Gate_CodeBlockForcesParse(t *testing.T) {
 		"a source that may hold a code block must keep the AST parse")
 }
 
-// TestLayer0Gate_CodeSpanRuleForcesParse guards the soundness fix for the
-// inline-code-span gap: MDS054 (no-undefined-reference-labels) is
-// "A-no-skipping" in the AST-dependence audit but reads code-span ranges
-// that go empty without a parse, so it must force the parse even though it
-// never crashes on a nil AST. Without the parse it would emit a false
-// positive for `[ref]` inside a backtick span.
-func TestLayer0Gate_CodeSpanRuleForcesParse(t *testing.T) {
+// TestLayer0Gate_CodeSpanRuleSkipsParse proves the Layer 1 inline-index fix
+// closed the old code-span soundness gap: MDS054
+// (no-undefined-reference-labels) is "A-no-skipping" and reads code-span
+// ranges. Those ranges used to go empty without a parse, so the rule was
+// forced to AST; the byte-level inline index now reproduces them on the
+// nil-AST path, so the rule resolves to Layer 0 and skips the parse. The
+// `[undefined]` bracket text sits inside a code span, which the inline index
+// identifies, so the parse-skipped run reports nothing — byte-identical to
+// the full-parse run.
+func TestLayer0Gate_CodeSpanRuleSkipsParse(t *testing.T) {
 	withLayer0Skip(t, true)
 	dir, path := writeDoc(t, "# T\n\nUse `[undefined]` inline.\n")
 
@@ -209,9 +212,10 @@ func TestLayer0Gate_CodeSpanRuleForcesParse(t *testing.T) {
 	}
 	res := r.Run([]string{path})
 	require.Empty(t, res.Errors)
-	assert.False(t, probe.sawNilAST,
-		"a code-span-consuming rule must keep the AST parse")
-	// The bracket text sits inside a code span, so neither path reports it.
+	assert.True(t, probe.sawNilAST,
+		"a code-span-consuming rule backed by the inline index must skip the parse")
+	// The bracket text sits inside a code span the inline index identifies,
+	// so neither path reports it.
 	assert.Empty(t, res.Diagnostics)
 }
 

--- a/internal/integration/inline_index_equivalence_test.go
+++ b/internal/integration/inline_index_equivalence_test.go
@@ -1,0 +1,60 @@
+package integration
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// TestInlineIndexEquivalence_CodeSpans is the Layer 1 counterpart to
+// TestLayer0Equivalence_Fixtures: for every parse-skip-eligible Markdown
+// file in the repository corpus, the code-span content and literal ranges
+// served from the byte-level inline index (nil-AST File) must be byte-
+// identical to the ones the goldmark AST walk produces.
+//
+// It restricts the comparison to the files the production parse-skip gate
+// would actually skip — those with no fenced/indented code block
+// (lint.SourceMayHaveCodeBlock) and no `<?` directive marker. The inline
+// scanner does not descend into list-item content, so a code block or
+// directive can shift its code-span detection; the gate forces a full parse
+// for exactly those files, so the divergence is never observable. This test
+// proves the index is byte-identical on precisely the inputs the gate
+// admits — the soundness contract that lets MDS047 and MDS054 resolve to
+// Layer 0.
+func TestInlineIndexEquivalence_CodeSpans(t *testing.T) {
+	root := repoRoot(t)
+	files := collectMarkdownCorpus(t, root)
+	require.NotEmpty(t, files)
+
+	var checked int
+	for _, path := range files {
+		source, err := os.ReadFile(path)
+		require.NoError(t, err)
+		_, body := lint.StripFrontMatter(source)
+
+		// Mirror the engine's parse-skip eligibility (runner.layer0SkipEligible).
+		if lint.SourceMayHaveCodeBlock(body) || bytes.Contains(body, []byte("<?")) {
+			continue
+		}
+		checked++
+
+		rel, _ := filepath.Rel(root, path)
+		t.Run(rel, func(t *testing.T) {
+			astFile, err := lint.NewFile(path, body)
+			require.NoError(t, err)
+			l0File := lint.NewFileLines(path, body)
+
+			assert.Equal(t, astFile.CodeSpanContentRanges(), l0File.CodeSpanContentRanges(),
+				"code-span content ranges differ between AST and inline index")
+			assert.Equal(t, astFile.CodeSpanLiteralRanges(), l0File.CodeSpanLiteralRanges(),
+				"code-span literal ranges differ between AST and inline index")
+		})
+	}
+	require.NotZero(t, checked, "expected at least one parse-skip-eligible corpus file")
+}

--- a/internal/integration/inline_rule_equivalence_test.go
+++ b/internal/integration/inline_rule_equivalence_test.go
@@ -1,0 +1,65 @@
+package integration
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/nobareurls"
+	"github.com/jeduden/mdsmith/internal/rules/noemphasisasheading"
+)
+
+// inlineEquivRules are the inline rules re-backed on the Layer 1 inline
+// index / per-block parse: each must produce byte-identical diagnostics on
+// the parse-skipped path (f.AST nil) and the AST path for every file the
+// production parse-skip gate admits.
+func inlineEquivRules() []rule.Rule {
+	return []rule.Rule{
+		&nobareurls.Rule{},
+		&noemphasisasheading.Rule{},
+	}
+}
+
+// TestInlineRuleEquivalence_Corpus runs each re-backed inline rule over the
+// repository corpus on both the AST path and the parse-skipped path, for
+// exactly the files the production gate would skip (no fenced/indented code
+// block and no `<?` directive marker), and asserts the diagnostics are
+// byte-identical. This is the soundness contract that lets the rules resolve
+// to Layer 0: the gate admits only these files, and on them the two paths
+// agree.
+func TestInlineRuleEquivalence_Corpus(t *testing.T) {
+	root := repoRoot(t)
+	files := collectMarkdownCorpus(t, root)
+	require.NotEmpty(t, files)
+
+	var checked int
+	for _, path := range files {
+		source, err := os.ReadFile(path)
+		require.NoError(t, err)
+		_, body := lint.StripFrontMatter(source)
+
+		// Mirror the engine's parse-skip eligibility.
+		if lint.SourceMayHaveCodeBlock(body) || bytes.Contains(body, []byte("<?")) {
+			continue
+		}
+		checked++
+
+		rel, _ := filepath.Rel(root, path)
+		t.Run(rel, func(t *testing.T) {
+			for _, r := range inlineEquivRules() {
+				astFile, err := lint.NewFile(path, body)
+				require.NoError(t, err)
+				lineFile := lint.NewFileLines(path, body)
+				assert.Equal(t, r.Check(astFile), r.Check(lineFile),
+					"%s diverges between AST and Layer 1 paths", r.ID())
+			}
+		})
+	}
+	require.NotZero(t, checked, "expected at least one parse-skip-eligible corpus file")
+}

--- a/internal/integration/inline_rule_equivalence_test.go
+++ b/internal/integration/inline_rule_equivalence_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/nobareurls"
 	"github.com/jeduden/mdsmith/internal/rules/noemphasisasheading"
+	"github.com/jeduden/mdsmith/internal/rules/noemptyalttext"
 )
 
 // inlineEquivRules are the inline rules re-backed on the Layer 1 inline
@@ -23,6 +24,7 @@ func inlineEquivRules() []rule.Rule {
 	return []rule.Rule{
 		&nobareurls.Rule{},
 		&noemphasisasheading.Rule{},
+		&noemptyalttext.Rule{},
 	}
 }
 

--- a/internal/integration/inline_rule_equivalence_test.go
+++ b/internal/integration/inline_rule_equivalence_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/linkvalidity"
 	"github.com/jeduden/mdsmith/internal/rules/nobareurls"
 	"github.com/jeduden/mdsmith/internal/rules/noemphasisasheading"
 	"github.com/jeduden/mdsmith/internal/rules/noemptyalttext"
@@ -25,6 +26,7 @@ func inlineEquivRules() []rule.Rule {
 		&nobareurls.Rule{},
 		&noemphasisasheading.Rule{},
 		&noemptyalttext.Rule{},
+		&linkvalidity.Rule{},
 	}
 }
 

--- a/internal/integration/testdata/rule_walk_audit.json
+++ b/internal/integration/testdata/rule_walk_audit.json
@@ -123,8 +123,8 @@
   {
     "id": "MDS012",
     "name": "no-bare-urls",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
@@ -189,13 +189,13 @@
   {
     "id": "MDS018",
     "name": "no-emphasis-as-heading",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
     "uses_ast_walk": true,
-    "reads_file_ast": false
+    "reads_file_ast": true
   },
   {
     "id": "MDS019",

--- a/internal/integration/testdata/rule_walk_audit.json
+++ b/internal/integration/testdata/rule_walk_audit.json
@@ -348,7 +348,7 @@
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
-    "uses_ast_walk": true,
+    "uses_ast_walk": false,
     "reads_file_ast": true
   },
   {

--- a/internal/integration/testdata/rule_walk_audit.json
+++ b/internal/integration/testdata/rule_walk_audit.json
@@ -662,8 +662,8 @@
   {
     "id": "MDS062",
     "name": "link-validity",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": false,

--- a/internal/integration/testdata/rule_walk_audit.json
+++ b/internal/integration/testdata/rule_walk_audit.json
@@ -343,13 +343,13 @@
   {
     "id": "MDS032",
     "name": "no-empty-alt-text",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
-    "uses_ast_walk": false,
-    "reads_file_ast": false
+    "uses_ast_walk": true,
+    "reads_file_ast": true
   },
   {
     "id": "MDS033",

--- a/internal/lint/codespans.go
+++ b/internal/lint/codespans.go
@@ -41,6 +41,20 @@ func (f *File) ensureCodeSpanRanges() {
 	defer f.codeSpansMu.Unlock()
 	if !f.codeSpansDone.Load() {
 		defer f.codeSpansDone.Store(true)
+		// On the parse-skipped path (f.AST nil) the goldmark walk would
+		// surface nothing, so serve from the Layer 1 inline index instead.
+		// A struct-literal File with neither an AST nor a source has no code
+		// spans either way. The corpus equivalence harness pins the two
+		// projection sources byte-identical.
+		if f.AST == nil {
+			if len(f.Source) == 0 {
+				return
+			}
+			idx := InlineIndexProjection(f)
+			f.codeSpanContent = idx.CodeSpanContent
+			f.codeSpanLiteral = idx.CodeSpanLiteral
+			return
+		}
 		collectCodeSpanRangesInto(f.AST, f.Source, &f.codeSpanContent, &f.codeSpanLiteral)
 	}
 }

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -110,6 +110,16 @@ type File struct {
 	layer0Done atomic.Bool
 	layer0Mu   sync.Mutex
 
+	// inlineIndex caches the byte-level inline scan (inline_index.go)
+	// behind InlineIndexProjection. It is the inline-projection source
+	// (code-span ranges) whenever f.AST is nil — the parse-skipped path —
+	// so CodeSpanContentRanges / CodeSpanLiteralRanges serve from it
+	// instead of walking f.AST. atomic.Bool + mutex matches the caches
+	// above for the same closure-box reason.
+	inlineIndex     *InlineIndex
+	inlineIndexDone atomic.Bool
+	inlineIndexMu   sync.Mutex
+
 	// proseRanges caches the byte-offset projection behind ProseRanges:
 	// the source spans inside prose nodes (paragraph, heading, list-item
 	// and blockquote text) with code blocks, code spans, HTML, autolinks

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -120,16 +120,15 @@ type File struct {
 	inlineIndexDone atomic.Bool
 	inlineIndexMu   sync.Mutex
 
-	// emphasisLines caches the per-block whole-paragraph-emphasis scan
-	// (inline_emphasis.go) behind WholeParagraphEmphasisLines. It is the
-	// Layer 1 projection source for MDS018 (no-emphasis-as-heading) on the
-	// parse-skipped path (f.AST nil), so the rule reads the lone-emphasis
-	// paragraph lines from a bounded per-block parse instead of walking
-	// f.AST. atomic.Bool + mutex matches the caches above for the same
-	// closure-box reason.
-	emphasisLines     []EmphasisParagraph
-	emphasisLinesDone atomic.Bool
-	emphasisLinesMu   sync.Mutex
+	// inlineBlocks caches the run-grouped per-block inline parse
+	// (inline_blocks.go) behind InlineBlocks. It is the single shared
+	// inline-node stream every inline rule consumes on the parse-skipped
+	// path (f.AST nil), so each contiguous run of inline-bearing lines is
+	// parsed once per file rather than once per rule. atomic.Bool + mutex
+	// matches the caches above for the same closure-box reason.
+	inlineBlocks     []InlineBlock
+	inlineBlocksDone atomic.Bool
+	inlineBlocksMu   sync.Mutex
 
 	// proseRanges caches the byte-offset projection behind ProseRanges:
 	// the source spans inside prose nodes (paragraph, heading, list-item

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -120,6 +120,17 @@ type File struct {
 	inlineIndexDone atomic.Bool
 	inlineIndexMu   sync.Mutex
 
+	// emphasisLines caches the per-block whole-paragraph-emphasis scan
+	// (inline_emphasis.go) behind WholeParagraphEmphasisLines. It is the
+	// Layer 1 projection source for MDS018 (no-emphasis-as-heading) on the
+	// parse-skipped path (f.AST nil), so the rule reads the lone-emphasis
+	// paragraph lines from a bounded per-block parse instead of walking
+	// f.AST. atomic.Bool + mutex matches the caches above for the same
+	// closure-box reason.
+	emphasisLines     []int
+	emphasisLinesDone atomic.Bool
+	emphasisLinesMu   sync.Mutex
+
 	// proseRanges caches the byte-offset projection behind ProseRanges:
 	// the source spans inside prose nodes (paragraph, heading, list-item
 	// and blockquote text) with code blocks, code spans, HTML, autolinks

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -127,7 +127,7 @@ type File struct {
 	// paragraph lines from a bounded per-block parse instead of walking
 	// f.AST. atomic.Bool + mutex matches the caches above for the same
 	// closure-box reason.
-	emphasisLines     []int
+	emphasisLines     []EmphasisParagraph
 	emphasisLinesDone atomic.Bool
 	emphasisLinesMu   sync.Mutex
 

--- a/internal/lint/inline_blocks.go
+++ b/internal/lint/inline_blocks.go
@@ -147,19 +147,14 @@ func (f *File) trailingEmptyLine(i int) bool {
 	return i == len(f.Lines)-1 && len(f.Lines[i]) == 0
 }
 
-// ParseInlineWithRefs parses block as a standalone Markdown document with
-// the given link reference definitions pre-seeded into the parse context,
-// so a reference-style link or image in block resolves against a definition
-// that lives in another block of the document. The returned tree shares no
-// state with the File.
-func ParseInlineWithRefs(block []byte, refs []Reference) ast.Node {
-	return parseInlineWithRefsArena(block, refs, arena.New())
-}
-
-// parseInlineWithRefsArena is ParseInlineWithRefs with a caller-owned arena
-// so consecutive run parses for one file reuse slab memory. The arena must
+// parseInlineWithRefsArena parses block as a standalone Markdown document
+// with the given link reference definitions pre-seeded into the parse
+// context, so a reference-style link or image in block resolves against a
+// definition that lives in another block of the document. The caller-owned
+// arena lets consecutive run parses for one file reuse slab memory; it must
 // outlive every node in the returned tree (the inline scan caches them on
-// the File, so the arena lives with the File).
+// the File, so the arena lives with the File). The returned tree shares no
+// state with the File.
 func parseInlineWithRefsArena(block []byte, refs []Reference, a *arena.Arena) ast.Node {
 	ctx := parser.NewContext()
 	for _, ref := range refs {

--- a/internal/lint/inline_blocks.go
+++ b/internal/lint/inline_blocks.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"bytes"
 
+	"github.com/jeduden/mdsmith/pkg/goldmark/arena"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
 	"github.com/jeduden/mdsmith/pkg/markdown"
@@ -78,6 +79,12 @@ func scanInlineBlocks(f *File) []InlineBlock {
 		refs = f.LinkReferences()
 	}
 	skip := nonInlineLines(f)
+	// One arena backs every run's parse for this file. Goldmark draws the
+	// run's inline nodes from it; growing it across runs (never Reset) keeps
+	// every earlier run's nodes valid while reusing slab memory instead of
+	// allocating a fresh node pool per run. The arena outlives this scan via
+	// the parsed nodes cached on the File, so it is per-file, not pooled.
+	a := arena.New()
 	var out []InlineBlock
 	n := len(f.Lines)
 	i := 0
@@ -96,7 +103,7 @@ func scanInlineBlocks(f *File) []InlineBlock {
 			continue
 		}
 		out = append(out, InlineBlock{
-			Node:   ParseInlineWithRefs(f.Source[start:end], refs),
+			Node:   parseInlineWithRefsArena(f.Source[start:end], refs, a),
 			Offset: start,
 		})
 	}
@@ -146,11 +153,19 @@ func (f *File) trailingEmptyLine(i int) bool {
 // that lives in another block of the document. The returned tree shares no
 // state with the File.
 func ParseInlineWithRefs(block []byte, refs []Reference) ast.Node {
+	return parseInlineWithRefsArena(block, refs, arena.New())
+}
+
+// parseInlineWithRefsArena is ParseInlineWithRefs with a caller-owned arena
+// so consecutive run parses for one file reuse slab memory. The arena must
+// outlive every node in the returned tree (the inline scan caches them on
+// the File, so the arena lives with the File).
+func parseInlineWithRefsArena(block []byte, refs []Reference, a *arena.Arena) ast.Node {
 	ctx := parser.NewContext()
 	for _, ref := range refs {
 		ctx.AddReference(ref)
 	}
-	return markdown.ParseContext(block, ctx)
+	return markdown.ParseContextArena(block, ctx, a)
 }
 
 // lineEndOffset returns the byte offset in Source of the newline that ends

--- a/internal/lint/inline_blocks.go
+++ b/internal/lint/inline_blocks.go
@@ -1,24 +1,156 @@
 package lint
 
 import (
+	"bytes"
+
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
 	"github.com/jeduden/mdsmith/pkg/markdown"
 )
 
-// ParseInline parses block as a standalone Markdown document and returns
-// the resulting AST root. It is the per-block lazy-parse seam inline rules
-// use on the parse-skipped path (f.AST nil): re-using goldmark's own parser
-// on a single Layer 0 block span keeps the inline tree byte-identical to
-// the one a whole-document parse produces for that block — link, image,
-// autolink, code-span, and emphasis resolution are all local to a
-// paragraph or list item, never crossing a blank-line block boundary.
+// refDefMarker is the literal every link reference definition contains: the
+// `]` closing its label immediately followed by the `:` before its
+// destination. A source without it has no definitions to seed.
+var refDefMarker = []byte("]:")
+
+// InlineBlock is one contiguous run of inline-bearing source lines whose
+// markup has been parsed in isolation on the parse-skipped path. Node is
+// the parsed run's root (a goldmark Document holding the re-parsed lines);
+// Offset is the byte offset, in the original document's Source, of the
+// run's first byte, so a caller maps any run-local segment offset back to
+// the document with Offset + segment.Start.
+type InlineBlock struct {
+	Node   ast.Node
+	Offset int
+}
+
+// InlineBlocks returns the inline markup of the document parsed one
+// contiguous run of inline-bearing lines at a time, computed once per File
+// and cached. It is the single shared inline-node stream for the
+// parse-skipped path (f.AST nil): every inline rule consumes it, so a run
+// is parsed once per file rather than once per rule. The returned slice and
+// the parsed nodes are shared read-only and must not be mutated.
 //
-// The caller maps any block-local segment offset back to the document by
-// adding the span's start offset (LineStartOffset of the span's first
-// line). The returned tree shares no state with the File.
-func ParseInline(block []byte) ast.Node {
-	return markdown.ParseContext(block, parser.NewContext())
+// A run is the maximal span of consecutive lines that are not blank and
+// carry no code-block, processing-instruction, or HTML-block content (the
+// lines the Layer 0 scan marks classCode / classPI, or that fall inside a
+// BlockHTML span). goldmark parses no inline link/image markup on those
+// lines, so they are excluded; everything else — paragraphs, ATX and setext
+// headings, list items, block quotes — is parsed as part of its run.
+// Grouping by run (rather than by Layer 0 block span, which records a list
+// item or block quote as a single line) keeps a construct that wraps onto a
+// continuation line whole, so its link, image, or emphasis is reconstructed
+// exactly as the whole-document parse reconstructs it.
+//
+// Each run is parsed with the document's link reference definitions
+// (f.LinkReferences) pre-seeded into the parse context, so a reference-style
+// link or image whose definition lives in another block still resolves to a
+// Link / Image node — matching the whole-document parse, where all
+// definitions are visible to every block.
+func InlineBlocks(f *File) []InlineBlock {
+	if f.inlineBlocksDone.Load() {
+		return f.inlineBlocks
+	}
+	f.inlineBlocksMu.Lock()
+	defer f.inlineBlocksMu.Unlock()
+	if !f.inlineBlocksDone.Load() {
+		defer f.inlineBlocksDone.Store(true)
+		f.inlineBlocks = scanInlineBlocks(f)
+	}
+	return f.inlineBlocks
+}
+
+// scanInlineBlocks groups the inline-bearing lines into runs and parses each
+// run with the document references pre-seeded.
+func scanInlineBlocks(f *File) []InlineBlock {
+	if len(f.Source) == 0 {
+		return nil
+	}
+	// A link reference definition always contains the literal `]:` (the
+	// close-bracket of its label followed by the destination colon). When
+	// the source has none, there are no definitions to seed and the
+	// LinkReferences parse is pure waste, so the common reference-free file
+	// skips it. This keeps the parse-skipped path parse-free for documents
+	// without reference definitions; a file with `]:` pays one shared parse
+	// (cached on the File and reused by every inline rule).
+	var refs []Reference
+	if bytes.Contains(f.Source, refDefMarker) {
+		refs = f.LinkReferences()
+	}
+	skip := nonInlineLines(f)
+	var out []InlineBlock
+	n := len(f.Lines)
+	i := 0
+	for i < n {
+		if f.skipInlineLine(skip, i) {
+			i++
+			continue
+		}
+		runStart := i
+		for i < n && !f.skipInlineLine(skip, i) {
+			i++
+		}
+		start := f.LineStartOffset(runStart)
+		end := f.lineEndOffset(i - 1)
+		if end <= start {
+			continue
+		}
+		out = append(out, InlineBlock{
+			Node:   ParseInlineWithRefs(f.Source[start:end], refs),
+			Offset: start,
+		})
+	}
+	return out
+}
+
+// WalkInlineNodes drives visit over every node of every run in the shared
+// run-grouped inline parse (InlineBlocks), in document order. base is the
+// run's start byte offset in f.Source, which the visitor adds to a node's
+// run-local segment offsets to recover document-absolute positions. It is
+// the shared seam every inline rule's nil-AST Check uses so the
+// parse-once-per-file projection drives each rule's per-node predicate
+// without re-parsing.
+func WalkInlineNodes(f *File, visit func(n ast.Node, base int)) {
+	for _, blk := range InlineBlocks(f) {
+		base := blk.Offset
+		_ = ast.Walk(blk.Node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if entering {
+				visit(n, base)
+			}
+			return ast.WalkContinue, nil
+		})
+	}
+}
+
+// skipInlineLine reports whether 0-based line i cannot start or continue an
+// inline run: it is the trailing split artifact, a blank line, or a line in
+// the skip set (code / PI / HTML-block content).
+func (f *File) skipInlineLine(skip map[int]struct{}, i int) bool {
+	if f.trailingEmptyLine(i) || isBlankLine(f.Lines[i]) {
+		return true
+	}
+	_, ok := skip[i+1]
+	return ok
+}
+
+// trailingEmptyLine reports whether 0-based line i is the trailing empty
+// element bytes.Split appends for a Source ending in a newline. That element
+// has no corresponding source line, so it never opens a run.
+func (f *File) trailingEmptyLine(i int) bool {
+	return i == len(f.Lines)-1 && len(f.Lines[i]) == 0
+}
+
+// ParseInlineWithRefs parses block as a standalone Markdown document with
+// the given link reference definitions pre-seeded into the parse context,
+// so a reference-style link or image in block resolves against a definition
+// that lives in another block of the document. The returned tree shares no
+// state with the File.
+func ParseInlineWithRefs(block []byte, refs []Reference) ast.Node {
+	ctx := parser.NewContext()
+	for _, ref := range refs {
+		ctx.AddReference(ref)
+	}
+	return markdown.ParseContext(block, ctx)
 }
 
 // LineEndOffset returns the byte offset in Source of the newline that ends

--- a/internal/lint/inline_blocks.go
+++ b/internal/lint/inline_blocks.go
@@ -1,0 +1,32 @@
+package lint
+
+import (
+	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
+	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
+	"github.com/jeduden/mdsmith/pkg/markdown"
+)
+
+// ParseInline parses block as a standalone Markdown document and returns
+// the resulting AST root. It is the per-block lazy-parse seam inline rules
+// use on the parse-skipped path (f.AST nil): re-using goldmark's own parser
+// on a single Layer 0 block span keeps the inline tree byte-identical to
+// the one a whole-document parse produces for that block — link, image,
+// autolink, code-span, and emphasis resolution are all local to a
+// paragraph or list item, never crossing a blank-line block boundary.
+//
+// The caller maps any block-local segment offset back to the document by
+// adding the span's start offset (LineStartOffset of the span's first
+// line). The returned tree shares no state with the File.
+func ParseInline(block []byte) ast.Node {
+	return markdown.ParseContext(block, parser.NewContext())
+}
+
+// LineEndOffset returns the byte offset in Source of the newline that ends
+// 0-based source line i (or len(Source) for the last line). Paired with
+// LineStartOffset, it bounds a Layer 0 span's bytes for a per-block parse:
+// a span covering 1-based lines [Start, End] slices
+// Source[LineStartOffset(Start-1):LineEndOffset(End-1)]. i < 0 returns 0;
+// i past the last line returns len(Source).
+func (f *File) LineEndOffset(i int) int {
+	return f.lineEndOffset(i)
+}

--- a/internal/lint/inline_blocks.go
+++ b/internal/lint/inline_blocks.go
@@ -153,12 +153,18 @@ func ParseInlineWithRefs(block []byte, refs []Reference) ast.Node {
 	return markdown.ParseContext(block, ctx)
 }
 
-// LineEndOffset returns the byte offset in Source of the newline that ends
-// 0-based source line i (or len(Source) for the last line). Paired with
-// LineStartOffset, it bounds a Layer 0 span's bytes for a per-block parse:
-// a span covering 1-based lines [Start, End] slices
-// Source[LineStartOffset(Start-1):LineEndOffset(End-1)]. i < 0 returns 0;
-// i past the last line returns len(Source).
-func (f *File) LineEndOffset(i int) int {
-	return f.lineEndOffset(i)
+// lineEndOffset returns the byte offset in Source of the newline that ends
+// 0-based source line i (or len(Source) for the last line). It bounds an
+// inline run's bytes: a run of 0-based lines [start, end] slices
+// Source[LineStartOffset(start):lineEndOffset(end)]. i < 0 returns 0; i
+// past the last line returns len(Source).
+func (f *File) lineEndOffset(i int) int {
+	nl := f.lineIndex()
+	if i < 0 {
+		return 0
+	}
+	if i >= len(nl) {
+		return len(f.Source)
+	}
+	return nl[i]
 }

--- a/internal/lint/inline_blocks_test.go
+++ b/internal/lint/inline_blocks_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jeduden/mdsmith/pkg/goldmark/arena"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
 )
@@ -42,7 +43,7 @@ func TestInlineBlocks_EmptySource(t *testing.T) {
 // match the whole-document parse on cross-block references.
 func TestParseInlineWithRefs_ResolvesCrossBlockReference(t *testing.T) {
 	refs := []Reference{parser.NewReference([]byte("ref"), []byte("http://example.com"), nil)}
-	doc := ParseInlineWithRefs([]byte("[text][ref]"), refs)
+	doc := parseInlineWithRefsArena([]byte("[text][ref]"), refs, arena.New())
 	found := false
 	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if entering {
@@ -55,7 +56,7 @@ func TestParseInlineWithRefs_ResolvesCrossBlockReference(t *testing.T) {
 	assert.True(t, found, "seeded reference resolves [text][ref] to a Link node")
 
 	// Without the seed the same source has no Link node — it degrades to text.
-	none := ParseInlineWithRefs([]byte("[text][ref]"), nil)
+	none := parseInlineWithRefsArena([]byte("[text][ref]"), nil, arena.New())
 	hasLink := false
 	_ = ast.Walk(none, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if entering {
@@ -83,4 +84,34 @@ func TestWalkInlineNodes_OffsetMapping(t *testing.T) {
 	})
 	assert.Contains(t, gotText, "http://example.com",
 		"base+segment offsets recover the document bytes")
+}
+
+// TestInlineBlocks_RefDefGate pins the `]:` short-circuit in
+// scanInlineBlocks: a source carrying a reference definition resolves a
+// cross-block reference link to a Link node (the seed fired), while a
+// reference-free source still parses but leaves a bare `[text][ref]` as
+// plain text (no seed, no Link).
+func TestInlineBlocks_RefDefGate(t *testing.T) {
+	countLinks := func(blocks []InlineBlock) int {
+		n := 0
+		for _, b := range blocks {
+			_ = ast.Walk(b.Node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+				if entering {
+					if _, ok := node.(*ast.Link); ok {
+						n++
+					}
+				}
+				return ast.WalkContinue, nil
+			})
+		}
+		return n
+	}
+
+	withDef := NewFileLines("doc.md", []byte("[text][ref]\n\n[ref]: http://example.com\n"))
+	assert.Equal(t, 1, countLinks(InlineBlocks(withDef)),
+		"a `]:` definition seeds the reference so [text][ref] resolves to a Link")
+
+	noDef := NewFileLines("doc.md", []byte("[text][ref] and more text here\n"))
+	assert.Equal(t, 0, countLinks(InlineBlocks(noDef)),
+		"no `]:` definition leaves [text][ref] as unresolved plain text")
 }

--- a/internal/lint/inline_blocks_test.go
+++ b/internal/lint/inline_blocks_test.go
@@ -1,0 +1,86 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
+	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
+)
+
+// TestInlineBlocks_RunGrouping pins that contiguous inline-bearing lines are
+// grouped into one run (so a construct wrapping onto a continuation line
+// stays whole) and that blank lines split runs.
+func TestInlineBlocks_RunGrouping(t *testing.T) {
+	f := NewFileLines("doc.md", []byte("para one\nstill one\n\npara two\n"))
+	blocks := InlineBlocks(f)
+	require.Len(t, blocks, 2, "blank line splits into two runs")
+	assert.Equal(t, 0, blocks[0].Offset)
+	// The second run starts after "para one\nstill one\n\n".
+	assert.Equal(t, len("para one\nstill one\n\n"), blocks[1].Offset)
+}
+
+// TestInlineBlocks_Memoized pins one scan per file.
+func TestInlineBlocks_Memoized(t *testing.T) {
+	f := NewFileLines("doc.md", []byte("a paragraph\n"))
+	first := InlineBlocks(f)
+	second := InlineBlocks(f)
+	require.Len(t, first, 1)
+	assert.Same(t, &first[0], &second[0], "InlineBlocks is cached per File")
+}
+
+// TestInlineBlocks_EmptySource returns nil for a struct-literal File.
+func TestInlineBlocks_EmptySource(t *testing.T) {
+	assert.Nil(t, InlineBlocks(&File{}))
+}
+
+// TestParseInlineWithRefs_ResolvesCrossBlockReference pins that a
+// reference-style link is reconstructed as a Link node when its definition
+// is seeded from another block — the property that lets the per-block parse
+// match the whole-document parse on cross-block references.
+func TestParseInlineWithRefs_ResolvesCrossBlockReference(t *testing.T) {
+	refs := []Reference{parser.NewReference([]byte("ref"), []byte("http://example.com"), nil)}
+	doc := ParseInlineWithRefs([]byte("[text][ref]"), refs)
+	found := false
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if _, ok := n.(*ast.Link); ok {
+				found = true
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	assert.True(t, found, "seeded reference resolves [text][ref] to a Link node")
+
+	// Without the seed the same source has no Link node — it degrades to text.
+	none := ParseInlineWithRefs([]byte("[text][ref]"), nil)
+	hasLink := false
+	_ = ast.Walk(none, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if _, ok := n.(*ast.Link); ok {
+				hasLink = true
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	assert.False(t, hasLink, "unseeded reference leaves no Link node")
+}
+
+// TestWalkInlineNodes_OffsetMapping pins that the base offset WalkInlineNodes
+// hands the visitor maps a run-local Text segment back to its
+// document-absolute bytes.
+func TestWalkInlineNodes_OffsetMapping(t *testing.T) {
+	src := []byte("first\n\nhttp://example.com\n")
+	f := NewFileLines("doc.md", src)
+	var gotText string
+	WalkInlineNodes(f, func(n ast.Node, base int) {
+		if tn, ok := n.(*ast.Text); ok {
+			seg := tn.Segment
+			gotText += string(src[base+seg.Start : base+seg.Stop])
+		}
+	})
+	assert.Contains(t, gotText, "http://example.com",
+		"base+segment offsets recover the document bytes")
+}

--- a/internal/lint/inline_blocks_test.go
+++ b/internal/lint/inline_blocks_test.go
@@ -86,6 +86,27 @@ func TestWalkInlineNodes_OffsetMapping(t *testing.T) {
 		"base+segment offsets recover the document bytes")
 }
 
+// TestLineEndOffset_Guards covers both defensive guards in lineEndOffset
+// (lines 173-178 of inline_blocks.go): i<0 returns 0; i past the last
+// newline returns len(Source).
+func TestLineEndOffset_Guards(t *testing.T) {
+	f := NewFileLines("doc.md", []byte("hello\n"))
+	assert.Equal(t, 0, f.lineEndOffset(-1), "i<0 must return 0")
+	assert.Equal(t, len(f.Source), f.lineEndOffset(100), "i past last newline must return len(Source)")
+}
+
+// TestScanInlineBlocks_EndLeStart covers the end<=start guard in
+// scanInlineBlocks (line 102-103 of inline_blocks.go). A File whose
+// Lines[0] is non-blank but whose Source starts with a newline makes
+// lineIndex()[0]==0==LineStartOffset(0), so end==start and the guard fires.
+func TestScanInlineBlocks_EndLeStart(t *testing.T) {
+	f := &File{
+		Source: []byte("\n"),
+		Lines:  [][]byte{[]byte("x"), {}},
+	}
+	assert.Nil(t, scanInlineBlocks(f))
+}
+
 // TestInlineBlocks_RefDefGate pins the `]:` short-circuit in
 // scanInlineBlocks: a source carrying a reference definition resolves a
 // cross-block reference link to a Link node (the seed fired), while a

--- a/internal/lint/inline_emphasis.go
+++ b/internal/lint/inline_emphasis.go
@@ -80,14 +80,21 @@ func loneEmphasisFromParagraph(f *File, para *ast.Paragraph, base int) (Emphasis
 // placeholder check accumulates over the emphasis subtree — so a caller
 // that re-accumulates and tests each prefix reproduces that check
 // byte-identically, including its early stop.
+//
+// Each segment is materialised with t.Segment.Value, the identical call the
+// AST-path helper uses, so any Padding / ForceNewline a segment carries is
+// reproduced rather than dropped. The segment offsets are run-local, so the
+// buffer is f.Source sliced from the run's base; Value reads only
+// [Start, Stop) (plus padding) within it.
 func emphasisTextSegments(source []byte, base int, emph *ast.Emphasis) []string {
+	runBytes := source[base:]
 	var segs []string
 	_ = ast.Walk(emph, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
 		if t, ok := n.(*ast.Text); ok {
-			segs = append(segs, string(source[base+t.Segment.Start:base+t.Segment.Stop]))
+			segs = append(segs, string(t.Segment.Value(runBytes)))
 		}
 		return ast.WalkContinue, nil
 	})

--- a/internal/lint/inline_emphasis.go
+++ b/internal/lint/inline_emphasis.go
@@ -1,0 +1,168 @@
+package lint
+
+import (
+	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
+	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
+	"github.com/jeduden/mdsmith/pkg/markdown"
+)
+
+// WholeParagraphEmphasisLines returns the 1-based source line of every
+// paragraph whose sole inline child is a single emphasis (or strong
+// emphasis) span — the exact shape MDS018 (no-emphasis-as-heading) flags.
+// It is the Layer 1 projection source for that rule on the parse-skipped
+// path (f.AST nil), so the rule no longer forces a whole-document goldmark
+// parse to read one parsed emphasis node.
+//
+// The detector is bounded: it parses only the paragraphs whose first
+// non-space byte is `*` or `_` (the only bytes that can open emphasis),
+// one block at a time, rather than the whole document. A paragraph that
+// cannot open emphasis is skipped without any parse. This is the per-block
+// lazy parse the plan calls for: re-using goldmark's own inline parser on a
+// single block keeps the lone-emphasis result byte-identical to the AST
+// path by construction, while the byte gate keeps the cost proportional to
+// the rare emphasis-led paragraph rather than every paragraph.
+//
+// The returned slice is in document order. nil when no paragraph qualifies
+// or the File has no source. Computed once per File and cached; the slice
+// is shared read-only and must not be mutated.
+func WholeParagraphEmphasisLines(f *File) []int {
+	if f.emphasisLinesDone.Load() {
+		return f.emphasisLines
+	}
+	f.emphasisLinesMu.Lock()
+	defer f.emphasisLinesMu.Unlock()
+	if !f.emphasisLinesDone.Load() {
+		defer f.emphasisLinesDone.Store(true)
+		f.emphasisLines = scanWholeParagraphEmphasis(f)
+	}
+	return f.emphasisLines
+}
+
+// scanWholeParagraphEmphasis walks the Layer 0 block spans and, for each
+// paragraph whose first non-space byte can open emphasis, parses that
+// block's bytes in isolation to test the lone-emphasis-child shape.
+func scanWholeParagraphEmphasis(f *File) []int {
+	if len(f.Source) == 0 {
+		return nil
+	}
+	l0 := Layer0(f)
+	var out []int
+	for _, span := range l0.BlockSpans {
+		if span.Kind != BlockParagraph {
+			continue
+		}
+		if !paragraphMayOpenEmphasis(f, span) {
+			continue
+		}
+		if line, ok := loneEmphasisParagraphLine(f, span); ok {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// paragraphMayOpenEmphasis reports whether the first non-space byte of the
+// paragraph's first line is `*` or `_` — the only delimiter characters
+// goldmark's emphasis parser triggers on. Paragraphs that fail this gate
+// can never parse to a lone emphasis child, so they are skipped without a
+// parse.
+func paragraphMayOpenEmphasis(f *File, span BlockSpan) bool {
+	line := f.lineBytes(span.Start)
+	for _, b := range line {
+		switch b {
+		case ' ', '\t':
+			continue
+		case '*', '_':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// loneEmphasisParagraphLine parses the source bytes of one paragraph block
+// in isolation and, when the parse yields a single paragraph whose only
+// inline child is an emphasis node, returns the paragraph's 1-based source
+// line in the original document. The block is parsed standalone because
+// emphasis resolution is local to a paragraph: the delimiter run, its
+// flanking context, and its closer all lie within the block, so the inline
+// tree is identical to the one the whole-document parse produces for the
+// same paragraph.
+func loneEmphasisParagraphLine(f *File, span BlockSpan) (int, bool) {
+	start := f.LineStartOffset(span.Start - 1)
+	end := f.lineEndOffset(span.End - 1)
+	if end <= start {
+		return 0, false
+	}
+	block := f.Source[start:end]
+	doc := markdown.ParseContext(block, parser.NewContext())
+	para, ok := singleParagraph(doc)
+	if !ok {
+		return 0, false
+	}
+	first := para.FirstChild()
+	if first == nil || first.NextSibling() != nil {
+		return 0, false
+	}
+	if _, isEmph := first.(*ast.Emphasis); !isEmph {
+		return 0, false
+	}
+	// The paragraph's first content line, in the original document's
+	// coordinates: the local paragraph's first text line offset plus the
+	// block's start offset maps back through LineOfOffset.
+	if local := paraLocalFirstLineOffset(para); local >= 0 {
+		return f.LineOfOffset(start + local), true
+	}
+	return span.Start, true
+}
+
+// singleParagraph returns the lone Paragraph child of a parsed standalone
+// block, or ok=false when the block parsed to anything else (no paragraph,
+// several blocks, a heading, a list, …). A lone-emphasis-child shape can
+// only arise inside a single paragraph, so a non-paragraph or multi-block
+// parse is never the emphasis-as-heading shape this detector reports.
+func singleParagraph(doc ast.Node) (*ast.Paragraph, bool) {
+	first := doc.FirstChild()
+	if first == nil || first.NextSibling() != nil {
+		return nil, false
+	}
+	para, ok := first.(*ast.Paragraph)
+	if !ok {
+		return nil, false
+	}
+	return para, true
+}
+
+// paraLocalFirstLineOffset returns the byte offset (within the standalone
+// block) of the paragraph's first content line, or -1 when the node
+// carries no line information.
+func paraLocalFirstLineOffset(para *ast.Paragraph) int {
+	lines := para.Lines()
+	if lines == nil || lines.Len() == 0 {
+		return -1
+	}
+	return lines.At(0).Start
+}
+
+// lineBytes returns the bytes of 1-based source line n (without the line
+// terminator), or nil when n is out of range.
+func (f *File) lineBytes(n int) []byte {
+	if n < 1 || n > len(f.Lines) {
+		return nil
+	}
+	return f.Lines[n-1]
+}
+
+// lineEndOffset returns the byte offset in Source just past the end of
+// 0-based line i (the newline, or len(Source) for the last line).
+func (f *File) lineEndOffset(i int) int {
+	nl := f.lineIndex()
+	if i < 0 {
+		return 0
+	}
+	if i >= len(nl) {
+		return len(f.Source)
+	}
+	return nl[i]
+}

--- a/internal/lint/inline_emphasis.go
+++ b/internal/lint/inline_emphasis.go
@@ -2,8 +2,6 @@ package lint
 
 import (
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
-	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
-	"github.com/jeduden/mdsmith/pkg/markdown"
 )
 
 // EmphasisParagraph is one paragraph whose sole inline child is a single
@@ -77,14 +75,25 @@ func scanWholeParagraphEmphasis(f *File) []EmphasisParagraph {
 		if span.Kind != BlockParagraph {
 			continue
 		}
-		if !paragraphMayOpenEmphasis(f, span) {
-			continue
-		}
-		if p, ok := loneEmphasisParagraph(f, span); ok {
+		if p, ok := LoneEmphasisParagraph(f, span); ok {
 			out = append(out, p)
 		}
 	}
 	return out
+}
+
+// LoneEmphasisParagraph tests one Layer 0 paragraph span for the
+// emphasis-as-heading shape and, when it matches, returns the
+// EmphasisParagraph describing it. It is the per-span entry point the
+// engine's block dispatch drives for MDS018 on the parse-skipped path:
+// CheckBlock(span) calls it once per BlockParagraph span. The span is
+// gated on its first non-space byte being a delimiter before any parse, so
+// a non-emphasis paragraph costs only the cheap byte check.
+func LoneEmphasisParagraph(f *File, span BlockSpan) (EmphasisParagraph, bool) {
+	if span.Kind != BlockParagraph || !paragraphMayOpenEmphasis(f, span) {
+		return EmphasisParagraph{}, false
+	}
+	return loneEmphasisParagraph(f, span)
 }
 
 // paragraphMayOpenEmphasis reports whether the first non-space byte of the
@@ -122,7 +131,7 @@ func loneEmphasisParagraph(f *File, span BlockSpan) (EmphasisParagraph, bool) {
 		return EmphasisParagraph{}, false
 	}
 	block := f.Source[start:end]
-	doc := markdown.ParseContext(block, parser.NewContext())
+	doc := ParseInline(block)
 	para, ok := singleParagraph(doc)
 	if !ok {
 		return EmphasisParagraph{}, false

--- a/internal/lint/inline_emphasis.go
+++ b/internal/lint/inline_emphasis.go
@@ -6,12 +6,23 @@ import (
 	"github.com/jeduden/mdsmith/pkg/markdown"
 )
 
-// WholeParagraphEmphasisLines returns the 1-based source line of every
-// paragraph whose sole inline child is a single emphasis (or strong
-// emphasis) span — the exact shape MDS018 (no-emphasis-as-heading) flags.
-// It is the Layer 1 projection source for that rule on the parse-skipped
-// path (f.AST nil), so the rule no longer forces a whole-document goldmark
-// parse to read one parsed emphasis node.
+// EmphasisParagraph is one paragraph whose sole inline child is a single
+// emphasis (or strong emphasis) span — the exact shape MDS018
+// (no-emphasis-as-heading) flags. Line is the paragraph's 1-based source
+// line; TextSegments are the ordered plain-text values of the emphasis
+// span's Text descendants, so the rule can apply its placeholder filter
+// with the same incremental accumulation the AST path uses without
+// re-parsing.
+type EmphasisParagraph struct {
+	Line         int
+	TextSegments []string
+}
+
+// WholeParagraphEmphasis returns every paragraph whose sole inline child is
+// a single emphasis span, in document order. It is the Layer 1 projection
+// source for MDS018 (no-emphasis-as-heading) on the parse-skipped path
+// (f.AST nil), so the rule no longer forces a whole-document goldmark parse
+// to read one parsed emphasis node.
 //
 // The detector is bounded: it parses only the paragraphs whose first
 // non-space byte is `*` or `_` (the only bytes that can open emphasis),
@@ -22,10 +33,10 @@ import (
 // path by construction, while the byte gate keeps the cost proportional to
 // the rare emphasis-led paragraph rather than every paragraph.
 //
-// The returned slice is in document order. nil when no paragraph qualifies
-// or the File has no source. Computed once per File and cached; the slice
-// is shared read-only and must not be mutated.
-func WholeParagraphEmphasisLines(f *File) []int {
+// nil when no paragraph qualifies or the File has no source. Computed once
+// per File and cached; the slice is shared read-only and must not be
+// mutated.
+func WholeParagraphEmphasis(f *File) []EmphasisParagraph {
 	if f.emphasisLinesDone.Load() {
 		return f.emphasisLines
 	}
@@ -38,15 +49,30 @@ func WholeParagraphEmphasisLines(f *File) []int {
 	return f.emphasisLines
 }
 
+// WholeParagraphEmphasisLines returns just the 1-based source lines of the
+// paragraphs WholeParagraphEmphasis reports, in document order. nil when
+// none qualify.
+func WholeParagraphEmphasisLines(f *File) []int {
+	paras := WholeParagraphEmphasis(f)
+	if len(paras) == 0 {
+		return nil
+	}
+	lines := make([]int, len(paras))
+	for i, p := range paras {
+		lines[i] = p.Line
+	}
+	return lines
+}
+
 // scanWholeParagraphEmphasis walks the Layer 0 block spans and, for each
 // paragraph whose first non-space byte can open emphasis, parses that
 // block's bytes in isolation to test the lone-emphasis-child shape.
-func scanWholeParagraphEmphasis(f *File) []int {
+func scanWholeParagraphEmphasis(f *File) []EmphasisParagraph {
 	if len(f.Source) == 0 {
 		return nil
 	}
 	l0 := Layer0(f)
-	var out []int
+	var out []EmphasisParagraph
 	for _, span := range l0.BlockSpans {
 		if span.Kind != BlockParagraph {
 			continue
@@ -54,8 +80,8 @@ func scanWholeParagraphEmphasis(f *File) []int {
 		if !paragraphMayOpenEmphasis(f, span) {
 			continue
 		}
-		if line, ok := loneEmphasisParagraphLine(f, span); ok {
-			out = append(out, line)
+		if p, ok := loneEmphasisParagraph(f, span); ok {
+			out = append(out, p)
 		}
 	}
 	return out
@@ -81,40 +107,62 @@ func paragraphMayOpenEmphasis(f *File, span BlockSpan) bool {
 	return false
 }
 
-// loneEmphasisParagraphLine parses the source bytes of one paragraph block
-// in isolation and, when the parse yields a single paragraph whose only
-// inline child is an emphasis node, returns the paragraph's 1-based source
-// line in the original document. The block is parsed standalone because
-// emphasis resolution is local to a paragraph: the delimiter run, its
-// flanking context, and its closer all lie within the block, so the inline
-// tree is identical to the one the whole-document parse produces for the
-// same paragraph.
-func loneEmphasisParagraphLine(f *File, span BlockSpan) (int, bool) {
+// loneEmphasisParagraph parses the source bytes of one paragraph block in
+// isolation and, when the parse yields a single paragraph whose only inline
+// child is an emphasis node, returns the paragraph's source line (in the
+// original document's coordinates) and the emphasis span's plain inner
+// text. The block is parsed standalone because emphasis resolution is local
+// to a paragraph: the delimiter run, its flanking context, and its closer
+// all lie within the block, so the inline tree is identical to the one the
+// whole-document parse produces for the same paragraph.
+func loneEmphasisParagraph(f *File, span BlockSpan) (EmphasisParagraph, bool) {
 	start := f.LineStartOffset(span.Start - 1)
 	end := f.lineEndOffset(span.End - 1)
 	if end <= start {
-		return 0, false
+		return EmphasisParagraph{}, false
 	}
 	block := f.Source[start:end]
 	doc := markdown.ParseContext(block, parser.NewContext())
 	para, ok := singleParagraph(doc)
 	if !ok {
-		return 0, false
+		return EmphasisParagraph{}, false
 	}
 	first := para.FirstChild()
 	if first == nil || first.NextSibling() != nil {
-		return 0, false
+		return EmphasisParagraph{}, false
 	}
-	if _, isEmph := first.(*ast.Emphasis); !isEmph {
-		return 0, false
+	emph, isEmph := first.(*ast.Emphasis)
+	if !isEmph {
+		return EmphasisParagraph{}, false
 	}
 	// The paragraph's first content line, in the original document's
 	// coordinates: the local paragraph's first text line offset plus the
 	// block's start offset maps back through LineOfOffset.
+	line := span.Start
 	if local := paraLocalFirstLineOffset(para); local >= 0 {
-		return f.LineOfOffset(start + local), true
+		line = f.LineOfOffset(start + local)
 	}
-	return span.Start, true
+	return EmphasisParagraph{Line: line, TextSegments: emphasisTextSegments(emph, block)}, true
+}
+
+// emphasisTextSegments returns the plain-text value of every Text
+// descendant of the emphasis node, in walk order, against the standalone
+// block bytes the node was parsed from. It mirrors, segment by segment, the
+// incremental text the AST-path placeholder check accumulates over the
+// emphasis subtree — so a caller that re-accumulates and tests each prefix
+// reproduces that check byte-identically, including its early stop.
+func emphasisTextSegments(emph *ast.Emphasis, block []byte) []string {
+	var segs []string
+	_ = ast.Walk(emph, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if t, ok := n.(*ast.Text); ok {
+			segs = append(segs, string(t.Segment.Value(block)))
+		}
+		return ast.WalkContinue, nil
+	})
+	return segs
 }
 
 // singleParagraph returns the lone Paragraph child of a parsed standalone

--- a/internal/lint/inline_emphasis.go
+++ b/internal/lint/inline_emphasis.go
@@ -104,16 +104,3 @@ func paraLocalFirstLineOffset(para *ast.Paragraph) int {
 	}
 	return lines.At(0).Start
 }
-
-// lineEndOffset returns the byte offset in Source just past the end of
-// 0-based line i (the newline, or len(Source) for the last line).
-func (f *File) lineEndOffset(i int) int {
-	nl := f.lineIndex()
-	if i < 0 {
-		return 0
-	}
-	if i >= len(nl) {
-		return len(f.Source)
-	}
-	return nl[i]
-}

--- a/internal/lint/inline_emphasis.go
+++ b/internal/lint/inline_emphasis.go
@@ -22,120 +22,42 @@ type EmphasisParagraph struct {
 // (f.AST nil), so the rule no longer forces a whole-document goldmark parse
 // to read one parsed emphasis node.
 //
-// The detector is bounded: it parses only the paragraphs whose first
-// non-space byte is `*` or `_` (the only bytes that can open emphasis),
-// one block at a time, rather than the whole document. A paragraph that
-// cannot open emphasis is skipped without any parse. This is the per-block
-// lazy parse the plan calls for: re-using goldmark's own inline parser on a
-// single block keeps the lone-emphasis result byte-identical to the AST
-// path by construction, while the byte gate keeps the cost proportional to
-// the rare emphasis-led paragraph rather than every paragraph.
+// It reads the shared run-grouped inline parse (InlineBlocks): every
+// paragraph in every run — including the paragraphs goldmark nests inside a
+// block quote — is tested for the lone-emphasis shape, exactly the set of
+// paragraph nodes the AST walk visits. List items are not paragraphs in
+// goldmark's tight-list model, so a `- *x*` item never qualifies, matching
+// the AST path.
 //
-// nil when no paragraph qualifies or the File has no source. Computed once
-// per File and cached; the slice is shared read-only and must not be
-// mutated.
+// nil when no paragraph qualifies or the File has no source. The returned
+// slice is shared read-only and must not be mutated.
 func WholeParagraphEmphasis(f *File) []EmphasisParagraph {
-	if f.emphasisLinesDone.Load() {
-		return f.emphasisLines
-	}
-	f.emphasisLinesMu.Lock()
-	defer f.emphasisLinesMu.Unlock()
-	if !f.emphasisLinesDone.Load() {
-		defer f.emphasisLinesDone.Store(true)
-		f.emphasisLines = scanWholeParagraphEmphasis(f)
-	}
-	return f.emphasisLines
-}
-
-// WholeParagraphEmphasisLines returns just the 1-based source lines of the
-// paragraphs WholeParagraphEmphasis reports, in document order. nil when
-// none qualify.
-func WholeParagraphEmphasisLines(f *File) []int {
-	paras := WholeParagraphEmphasis(f)
-	if len(paras) == 0 {
-		return nil
-	}
-	lines := make([]int, len(paras))
-	for i, p := range paras {
-		lines[i] = p.Line
-	}
-	return lines
-}
-
-// scanWholeParagraphEmphasis walks the Layer 0 block spans and, for each
-// paragraph whose first non-space byte can open emphasis, parses that
-// block's bytes in isolation to test the lone-emphasis-child shape.
-func scanWholeParagraphEmphasis(f *File) []EmphasisParagraph {
-	if len(f.Source) == 0 {
-		return nil
-	}
-	l0 := Layer0(f)
 	var out []EmphasisParagraph
-	for _, span := range l0.BlockSpans {
-		if span.Kind != BlockParagraph {
-			continue
-		}
-		if p, ok := LoneEmphasisParagraph(f, span); ok {
-			out = append(out, p)
-		}
+	for _, blk := range InlineBlocks(f) {
+		base := blk.Offset
+		_ = ast.Walk(blk.Node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			para, ok := n.(*ast.Paragraph)
+			if !ok {
+				return ast.WalkContinue, nil
+			}
+			if p, ok := loneEmphasisFromParagraph(f, para, base); ok {
+				out = append(out, p)
+			}
+			return ast.WalkContinue, nil
+		})
 	}
 	return out
 }
 
-// LoneEmphasisParagraph tests one Layer 0 paragraph span for the
-// emphasis-as-heading shape and, when it matches, returns the
-// EmphasisParagraph describing it. It is the per-span entry point the
-// engine's block dispatch drives for MDS018 on the parse-skipped path:
-// CheckBlock(span) calls it once per BlockParagraph span. The span is
-// gated on its first non-space byte being a delimiter before any parse, so
-// a non-emphasis paragraph costs only the cheap byte check.
-func LoneEmphasisParagraph(f *File, span BlockSpan) (EmphasisParagraph, bool) {
-	if span.Kind != BlockParagraph || !paragraphMayOpenEmphasis(f, span) {
-		return EmphasisParagraph{}, false
-	}
-	return loneEmphasisParagraph(f, span)
-}
-
-// paragraphMayOpenEmphasis reports whether the first non-space byte of the
-// paragraph's first line is `*` or `_` — the only delimiter characters
-// goldmark's emphasis parser triggers on. Paragraphs that fail this gate
-// can never parse to a lone emphasis child, so they are skipped without a
-// parse.
-func paragraphMayOpenEmphasis(f *File, span BlockSpan) bool {
-	line := f.lineBytes(span.Start)
-	for _, b := range line {
-		switch b {
-		case ' ', '\t':
-			continue
-		case '*', '_':
-			return true
-		default:
-			return false
-		}
-	}
-	return false
-}
-
-// loneEmphasisParagraph parses the source bytes of one paragraph block in
-// isolation and, when the parse yields a single paragraph whose only inline
-// child is an emphasis node, returns the paragraph's source line (in the
-// original document's coordinates) and the emphasis span's plain inner
-// text. The block is parsed standalone because emphasis resolution is local
-// to a paragraph: the delimiter run, its flanking context, and its closer
-// all lie within the block, so the inline tree is identical to the one the
-// whole-document parse produces for the same paragraph.
-func loneEmphasisParagraph(f *File, span BlockSpan) (EmphasisParagraph, bool) {
-	start := f.LineStartOffset(span.Start - 1)
-	end := f.lineEndOffset(span.End - 1)
-	if end <= start {
-		return EmphasisParagraph{}, false
-	}
-	block := f.Source[start:end]
-	doc := ParseInline(block)
-	para, ok := singleParagraph(doc)
-	if !ok {
-		return EmphasisParagraph{}, false
-	}
+// loneEmphasisFromParagraph tests one parsed paragraph for the
+// lone-emphasis-child shape and, when it matches, returns the
+// EmphasisParagraph describing it. base is the run's start offset in
+// f.Source, used to map the paragraph's run-local first line and its
+// emphasis Text segments back to the document.
+func loneEmphasisFromParagraph(f *File, para *ast.Paragraph, base int) (EmphasisParagraph, bool) {
 	first := para.FirstChild()
 	if first == nil || first.NextSibling() != nil {
 		return EmphasisParagraph{}, false
@@ -144,71 +66,43 @@ func loneEmphasisParagraph(f *File, span BlockSpan) (EmphasisParagraph, bool) {
 	if !isEmph {
 		return EmphasisParagraph{}, false
 	}
-	// The paragraph's first content line, in the original document's
-	// coordinates: the local paragraph's first text line offset plus the
-	// block's start offset maps back through LineOfOffset.
-	line := span.Start
+	line := f.LineOfOffset(base)
 	if local := paraLocalFirstLineOffset(para); local >= 0 {
-		line = f.LineOfOffset(start + local)
+		line = f.LineOfOffset(base + local)
 	}
-	return EmphasisParagraph{Line: line, TextSegments: emphasisTextSegments(emph, block)}, true
+	return EmphasisParagraph{Line: line, TextSegments: emphasisTextSegments(f.Source, base, emph)}, true
 }
 
 // emphasisTextSegments returns the plain-text value of every Text
-// descendant of the emphasis node, in walk order, against the standalone
-// block bytes the node was parsed from. It mirrors, segment by segment, the
-// incremental text the AST-path placeholder check accumulates over the
-// emphasis subtree — so a caller that re-accumulates and tests each prefix
-// reproduces that check byte-identically, including its early stop.
-func emphasisTextSegments(emph *ast.Emphasis, block []byte) []string {
+// descendant of the emphasis node, in walk order, read from f.Source via
+// the run-absolute offsets (base + the run-local segment bounds). It
+// mirrors, segment by segment, the incremental text the AST-path
+// placeholder check accumulates over the emphasis subtree — so a caller
+// that re-accumulates and tests each prefix reproduces that check
+// byte-identically, including its early stop.
+func emphasisTextSegments(source []byte, base int, emph *ast.Emphasis) []string {
 	var segs []string
 	_ = ast.Walk(emph, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
 		if t, ok := n.(*ast.Text); ok {
-			segs = append(segs, string(t.Segment.Value(block)))
+			segs = append(segs, string(source[base+t.Segment.Start:base+t.Segment.Stop]))
 		}
 		return ast.WalkContinue, nil
 	})
 	return segs
 }
 
-// singleParagraph returns the lone Paragraph child of a parsed standalone
-// block, or ok=false when the block parsed to anything else (no paragraph,
-// several blocks, a heading, a list, …). A lone-emphasis-child shape can
-// only arise inside a single paragraph, so a non-paragraph or multi-block
-// parse is never the emphasis-as-heading shape this detector reports.
-func singleParagraph(doc ast.Node) (*ast.Paragraph, bool) {
-	first := doc.FirstChild()
-	if first == nil || first.NextSibling() != nil {
-		return nil, false
-	}
-	para, ok := first.(*ast.Paragraph)
-	if !ok {
-		return nil, false
-	}
-	return para, true
-}
-
-// paraLocalFirstLineOffset returns the byte offset (within the standalone
-// block) of the paragraph's first content line, or -1 when the node
-// carries no line information.
+// paraLocalFirstLineOffset returns the byte offset (within the run) of the
+// paragraph's first content line, or -1 when the node carries no line
+// information.
 func paraLocalFirstLineOffset(para *ast.Paragraph) int {
 	lines := para.Lines()
 	if lines == nil || lines.Len() == 0 {
 		return -1
 	}
 	return lines.At(0).Start
-}
-
-// lineBytes returns the bytes of 1-based source line n (without the line
-// terminator), or nil when n is out of range.
-func (f *File) lineBytes(n int) []byte {
-	if n < 1 || n > len(f.Lines) {
-		return nil
-	}
-	return f.Lines[n-1]
 }
 
 // lineEndOffset returns the byte offset in Source just past the end of

--- a/internal/lint/inline_emphasis_test.go
+++ b/internal/lint/inline_emphasis_test.go
@@ -1,0 +1,107 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
+)
+
+// astLoneEmphasisLines parses src normally and returns the 1-based source
+// lines of every paragraph whose sole inline child is an Emphasis node —
+// the exact condition MDS018 checks on the AST path. It is the byte-
+// identical target the bounded inline detector must reproduce.
+func astLoneEmphasisLines(t *testing.T, src string) []int {
+	t.Helper()
+	f, err := NewFile("doc.md", []byte(src))
+	require.NoError(t, err)
+	var lines []int
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		para, ok := n.(*ast.Paragraph)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		first := para.FirstChild()
+		if first == nil || first.NextSibling() != nil {
+			return ast.WalkContinue, nil
+		}
+		if _, isEmph := first.(*ast.Emphasis); !isEmph {
+			return ast.WalkContinue, nil
+		}
+		lines = append(lines, paragraphFirstLine(para, f))
+		return ast.WalkContinue, nil
+	})
+	return lines
+}
+
+// paragraphFirstLine returns the 1-based source line of a paragraph's
+// first text segment, mirroring astutil.ParagraphLine closely enough for
+// the equivalence assertion (the detector emits the same line).
+func paragraphFirstLine(para ast.Node, f *File) int {
+	lines := para.Lines()
+	if lines != nil && lines.Len() > 0 {
+		return f.LineOfOffset(lines.At(0).Start)
+	}
+	return 1
+}
+
+func indexLoneEmphasisLines(src string) []int {
+	f := NewFileLines("doc.md", []byte(src))
+	out := WholeParagraphEmphasisLines(f)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// TestWholeParagraphEmphasis_Equivalence pins the bounded detector byte-
+// identical to goldmark's lone-emphasis-child result across the shapes the
+// corpus exercises: simple and strong emphasis, underscore variants,
+// emphasis with trailing/leading spaces, multi-child paragraphs (not
+// flagged), partial emphasis (not flagged), and non-emphasis paragraphs.
+func TestWholeParagraphEmphasis_Equivalence(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"star-emphasis", "*just emphasis*\n"},
+		{"strong-emphasis", "**just strong**\n"},
+		{"underscore-emphasis", "_just emphasis_\n"},
+		{"underscore-strong", "__just strong__\n"},
+		{"emphasis-with-trailing-space", "*emphasis*  \n"},
+		{"emphasis-then-text", "*emphasis* and text\n"},
+		{"text-then-emphasis", "text and *emphasis*\n"},
+		{"two-emphasis", "*one* *two*\n"},
+		{"plain-paragraph", "just plain text\n"},
+		{"heading-not-paragraph", "# heading\n"},
+		{"partial-emphasis", "*not closed\n"},
+		{"nested-strong-in-emphasis", "*outer **inner** outer*\n"},
+		{"emphasis-with-code", "*a `code` b*\n"},
+		{"empty-emphasis-markers", "**\n"},
+		{"multi-paragraph", "*first*\n\nnormal\n\n*second*\n"},
+		{"leading-spaces", "   *emphasis*\n"},
+		{"intraword-underscore", "snake_case_word\n"},
+		{"emphasis-over-two-lines", "*emphasis\nspanning*\n"},
+		{"thematic-break-not-emphasis", "***\n"},
+		{"star-list-not-paragraph", "* list item\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := astLoneEmphasisLines(t, tc.src)
+			got := indexLoneEmphasisLines(tc.src)
+			assert.Equal(t, want, got, "lone-emphasis lines diverge from AST")
+		})
+	}
+}
+
+// TestWholeParagraphEmphasis_NilSource keeps a struct-literal File (no AST,
+// no source) returning nil, matching the empty-document case.
+func TestWholeParagraphEmphasis_NilSource(t *testing.T) {
+	f := &File{}
+	assert.Nil(t, WholeParagraphEmphasisLines(f))
+}

--- a/internal/lint/inline_emphasis_test.go
+++ b/internal/lint/inline_emphasis_test.go
@@ -109,3 +109,11 @@ func TestWholeParagraphEmphasis_NilSource(t *testing.T) {
 	f := &File{}
 	assert.Nil(t, WholeParagraphEmphasis(f))
 }
+
+// TestParaLocalFirstLineOffset_NilLines covers the nil/empty Lines guard
+// (lines 109-111 of inline_emphasis.go): a paragraph created without any
+// line information returns -1.
+func TestParaLocalFirstLineOffset_NilLines(t *testing.T) {
+	p := ast.NewParagraph()
+	assert.Equal(t, -1, paraLocalFirstLineOffset(p))
+}

--- a/internal/lint/inline_emphasis_test.go
+++ b/internal/lint/inline_emphasis_test.go
@@ -52,9 +52,13 @@ func paragraphFirstLine(para ast.Node, f *File) int {
 
 func indexLoneEmphasisLines(src string) []int {
 	f := NewFileLines("doc.md", []byte(src))
-	out := WholeParagraphEmphasisLines(f)
-	if len(out) == 0 {
+	paras := WholeParagraphEmphasis(f)
+	if len(paras) == 0 {
 		return nil
+	}
+	out := make([]int, len(paras))
+	for i, p := range paras {
+		out[i] = p.Line
 	}
 	return out
 }
@@ -103,5 +107,5 @@ func TestWholeParagraphEmphasis_Equivalence(t *testing.T) {
 // no source) returning nil, matching the empty-document case.
 func TestWholeParagraphEmphasis_NilSource(t *testing.T) {
 	f := &File{}
-	assert.Nil(t, WholeParagraphEmphasisLines(f))
+	assert.Nil(t, WholeParagraphEmphasis(f))
 }

--- a/internal/lint/inline_index.go
+++ b/internal/lint/inline_index.go
@@ -12,11 +12,11 @@ import "github.com/jeduden/mdsmith/pkg/goldmark/util"
 //
 // A backtick code span is a run of N backticks (the opener) followed by a
 // content run that contains no run of exactly N backticks, closed by the
-// next run of exactly N backticks. CommonMark converts interior line
-// endings to spaces and, when the content both begins and ends with a
-// space and is not all spaces, strips one space from each side; goldmark
-// records the post-trim bounds as the span's Text-child segments, so the
-// scan reproduces that trim to keep CodeSpanContentRanges identical.
+// next run of exactly N backticks. When the raw content both begins and
+// ends with a space (or '\n') and is not entirely blank, CommonMark strips
+// one byte from each side; goldmark records the post-trim bounds as the
+// span's Text-child segments, so the scan reproduces that trim to keep
+// CodeSpanContentRanges identical.
 //
 // Backticks inside fenced or indented code blocks are not code-span
 // delimiters. The scan skips any byte on a line the Layer 0 scan marks as a

--- a/internal/lint/inline_index.go
+++ b/internal/lint/inline_index.go
@@ -1,0 +1,254 @@
+package lint
+
+// Layer 1 inline index: a byte-level scan over File.Source that locates
+// inline code spans without a goldmark parse. It is the parse-skip source
+// for CodeSpanContentRanges / CodeSpanLiteralRanges when f.AST is nil,
+// mirroring the way Layer 0 (layer0.go) backs the block-level code/PI line
+// sets. The scan finds only what the re-backed rules need today — code
+// spans — and is gated byte-identical to goldmark's CodeSpan node bounds by
+// the corpus equivalence harness (internal/integration).
+//
+// A backtick code span is a run of N backticks (the opener) followed by a
+// content run that contains no run of exactly N backticks, closed by the
+// next run of exactly N backticks. CommonMark converts interior line
+// endings to spaces and, when the content both begins and ends with a
+// space and is not all spaces, strips one space from each side; goldmark
+// records the post-trim bounds as the span's Text-child segments, so the
+// scan reproduces that trim to keep CodeSpanContentRanges identical.
+//
+// Backticks inside fenced or indented code blocks are not code-span
+// delimiters. The scan skips any byte on a line the Layer 0 scan marks as a
+// code-block line, exactly as the AST walk never descends into a code block.
+
+// InlineIndex is the product of one byte-level inline scan: the code-span
+// content and literal byte ranges in document order. It carries no node
+// tree and is the inline-projection source whenever f.AST is nil.
+type InlineIndex struct {
+	// CodeSpanContent holds each span's text-content range (backticks and
+	// the CommonMark single-space trim excluded), in document order. Empty
+	// (zero-width) content ranges are omitted, matching the AST projection.
+	CodeSpanContent []Range
+	// CodeSpanLiteral holds each span's range including its surrounding
+	// backtick runs, in document order. Indexes correspond 1:1 with
+	// CodeSpanContent's omission rule: a span contributes a literal range
+	// only when it contributes a content range, matching the AST walk which
+	// records a literal range only for spans with Text children.
+	CodeSpanLiteral []Range
+}
+
+// InlineIndexProjection returns the cached inline scan for f, computing it
+// once on first use. The atomic.Bool + mutex memo matches the other File
+// projections (see the File.codeBlockLines field comment) so the build
+// sheds the closure box sync.Once would force. The returned pointer is
+// shared read-only; callers must not mutate it.
+func InlineIndexProjection(f *File) *InlineIndex {
+	if f.inlineIndexDone.Load() {
+		return f.inlineIndex
+	}
+	f.inlineIndexMu.Lock()
+	defer f.inlineIndexMu.Unlock()
+	if !f.inlineIndexDone.Load() {
+		defer f.inlineIndexDone.Store(true)
+		f.inlineIndex = scanInlineIndex(f)
+	}
+	return f.inlineIndex
+}
+
+// scanInlineIndex runs the byte-level inline pass over f.Source, skipping
+// bytes on lines that hold no inline content — fenced/indented code blocks,
+// HTML blocks, and processing-instruction blocks (from the Layer 0 scan).
+// goldmark never parses inline markup inside those blocks, so a backtick
+// there is not a code-span delimiter. It returns an index whose code-span
+// ranges match goldmark's CodeSpan node bounds.
+func scanInlineIndex(f *File) *InlineIndex {
+	idx := &InlineIndex{}
+	codeLines := nonInlineLines(f)
+	src := f.Source
+	i := 0
+	for i < len(src) {
+		c := src[i]
+		if c == '\\' {
+			// A backslash escapes the next byte; a backslash-escaped
+			// backtick cannot open a code span. Skip both bytes. Inside a
+			// code block this is irrelevant (the line is skipped below), but
+			// the cheap escape skip keeps the common prose path correct.
+			i += 2
+			continue
+		}
+		if c != '`' {
+			i++
+			continue
+		}
+		if lineInSet(f, codeLines, i) {
+			i++
+			continue
+		}
+		next := scanCodeSpanAt(f, codeLines, i)
+		if next < 0 {
+			// No closing run: the backtick run is literal text. Advance past
+			// the whole run so its later backticks are not re-scanned as a
+			// fresh opener (goldmark treats an unclosed run as text).
+			i = endOfBacktickRun(src, i)
+			continue
+		}
+		appendCodeSpan(idx, src, i, next)
+		i = next
+	}
+	return idx
+}
+
+// nonInlineLines returns the set of 1-based source lines whose bytes carry
+// no inline markup: fenced/indented code-block lines, PI-block lines, and
+// every line inside an HTML block. goldmark parses no inline content on
+// these lines, so a backtick there opens no code span. The set is built
+// from the Layer 0 scan: its CodeBlockLines and PIBlockLines sets plus the
+// line span of every BlockHTML block. Returns the CodeBlockLines map
+// directly (no copy) when there are no PI or HTML lines to add, so the
+// common code-only document allocates nothing extra.
+func nonInlineLines(f *File) map[int]struct{} {
+	l0 := Layer0(f)
+	hasHTML := false
+	for _, span := range l0.BlockSpans {
+		if span.Kind == BlockHTML {
+			hasHTML = true
+			break
+		}
+	}
+	if len(l0.PIBlockLines) == 0 && !hasHTML {
+		return l0.CodeBlockLines
+	}
+	set := make(map[int]struct{}, len(l0.CodeBlockLines)+len(l0.PIBlockLines))
+	for ln := range l0.CodeBlockLines {
+		set[ln] = struct{}{}
+	}
+	for ln := range l0.PIBlockLines {
+		set[ln] = struct{}{}
+	}
+	for _, span := range l0.BlockSpans {
+		if span.Kind != BlockHTML {
+			continue
+		}
+		for ln := span.Start; ln <= span.End; ln++ {
+			set[ln] = struct{}{}
+		}
+	}
+	return set
+}
+
+// scanCodeSpanAt tests whether a code span opens at the backtick at src[i]
+// and, if so, returns the byte offset just past its closing backtick run.
+// It returns -1 when the run has no matching closing run (the opener is
+// literal text). The opening run length is the count of consecutive
+// backticks; the span closes at the next run of exactly that length whose
+// bytes are not on a code-block line.
+func scanCodeSpanAt(f *File, codeLines map[int]struct{}, i int) int {
+	src := f.Source
+	openEnd := endOfBacktickRun(src, i)
+	runLen := openEnd - i
+	j := openEnd
+	for j < len(src) {
+		if src[j] != '`' {
+			j++
+			continue
+		}
+		if lineInSet(f, codeLines, j) {
+			j++
+			continue
+		}
+		closeEnd := endOfBacktickRun(src, j)
+		if closeEnd-j == runLen {
+			return closeEnd
+		}
+		// A run of a different length is interior content; skip it whole so
+		// its backticks are not re-tested one at a time.
+		j = closeEnd
+	}
+	return -1
+}
+
+// appendCodeSpan records one span's content and literal ranges, matching
+// goldmark exactly. goldmark records the span's Text-child segment as the
+// post-trim content (the CommonMark single-space trim applied), then the
+// projection derives the literal range by extending that content over any
+// backtick bytes immediately adjacent to it (collectCodeSpanRangesInto in
+// codespans.go). The literal therefore differs from the raw [openStart,
+// closeEnd) span when a trimmed-off space separates the content from a
+// delimiter backtick — so the literal is computed the same two-step way
+// here. A zero-width content range contributes neither entry, matching the
+// AST projection which records nothing for a span with no Text child.
+func appendCodeSpan(idx *InlineIndex, src []byte, openStart, closeEnd int) {
+	openEnd := endOfBacktickRun(src, openStart)
+	runLen := openEnd - openStart
+	contentStart := openEnd
+	contentEnd := closeEnd - runLen
+	cs, ce := trimCodeSpanContent(src, contentStart, contentEnd)
+	if ce <= cs {
+		return
+	}
+	idx.CodeSpanContent = append(idx.CodeSpanContent, Range{Start: cs, End: ce})
+	ls := cs
+	for ls > 0 && src[ls-1] == '`' {
+		ls--
+	}
+	le := ce
+	for le < len(src) && src[le] == '`' {
+		le++
+	}
+	idx.CodeSpanLiteral = append(idx.CodeSpanLiteral, Range{Start: ls, End: le})
+}
+
+// trimCodeSpanContent reproduces CommonMark's code-span content trim that
+// goldmark records: when the content both begins and ends with a space (or
+// line-ending byte goldmark treats as a space) and is not made up entirely
+// of such bytes, one byte is stripped from each side. The returned range is
+// the post-trim content [start, end).
+func trimCodeSpanContent(src []byte, start, end int) (int, int) {
+	if end <= start {
+		return start, end
+	}
+	if !isCodeSpanSpace(src[start]) || !isCodeSpanSpace(src[end-1]) {
+		return start, end
+	}
+	if allCodeSpanSpaces(src, start, end) {
+		return start, end
+	}
+	return start + 1, end - 1
+}
+
+// isCodeSpanSpace reports whether b is a byte CommonMark folds to a space
+// inside a code span for the strip-one-space rule: a space or a line ending.
+func isCodeSpanSpace(b byte) bool {
+	return b == ' ' || b == '\n' || b == '\r'
+}
+
+// allCodeSpanSpaces reports whether every byte in [start, end) is a
+// code-span space byte; such a span is never trimmed (CommonMark keeps an
+// all-space span verbatim).
+func allCodeSpanSpaces(src []byte, start, end int) bool {
+	for k := start; k < end; k++ {
+		if !isCodeSpanSpace(src[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+// endOfBacktickRun returns the offset just past the run of backticks that
+// starts at src[i]. src[i] must be a backtick.
+func endOfBacktickRun(src []byte, i int) int {
+	j := i
+	for j < len(src) && src[j] == '`' {
+		j++
+	}
+	return j
+}
+
+// lineInSet reports whether the source byte at offset belongs to a line in
+// set (a 1-based line-number set, e.g. the Layer 0 code-block lines).
+func lineInSet(f *File, set map[int]struct{}, offset int) bool {
+	if len(set) == 0 {
+		return false
+	}
+	_, ok := set[f.LineOfOffset(offset)]
+	return ok
+}

--- a/internal/lint/inline_index.go
+++ b/internal/lint/inline_index.go
@@ -1,5 +1,7 @@
 package lint
 
+import "github.com/jeduden/mdsmith/pkg/goldmark/util"
+
 // Layer 1 inline index: a byte-level scan over File.Source that locates
 // inline code spans without a goldmark parse. It is the parse-skip source
 // for CodeSpanContentRanges / CodeSpanLiteralRanges when f.AST is nil,
@@ -209,7 +211,7 @@ func trimCodeSpanContent(src []byte, start, end int) (int, int) {
 	if !isCodeSpanSpace(src[start]) || !isCodeSpanSpace(src[end-1]) {
 		return start, end
 	}
-	if allCodeSpanSpaces(src, start, end) {
+	if allCodeSpanBlank(src, start, end) {
 		return start, end
 	}
 	return start + 1, end - 1
@@ -223,21 +225,15 @@ func isCodeSpanSpace(b byte) bool {
 	return b == ' ' || b == '\n'
 }
 
-// isCodeSpanBlank reports whether b counts as blank for the "content is
-// entirely spaces" guard that suppresses the single-space trim. goldmark
-// uses util.IsSpace (backed by spaceTable) for this check: it accepts ' ',
-// '\t', '\n', and '\r' (spaceTable indices 32, 9, 10, 13). Using a wider
-// predicate here than isCodeSpanSpace matches goldmark's two-predicate
-// design: narrow for the trim boundary, wide for the all-blank guard.
-func isCodeSpanBlank(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
-}
-
-// allCodeSpanSpaces reports whether every byte in [start, end) is blank
-// per isCodeSpanBlank; such a span is never trimmed.
-func allCodeSpanSpaces(src []byte, start, end int) bool {
+// allCodeSpanBlank reports whether every byte in [start, end) is blank
+// per goldmark's util.IsSpace (spaceTable: ' ', '\t', '\n', '\r'). A span
+// that is entirely blank is never trimmed — CommonMark §6.1's all-spaces
+// guard — and goldmark checks this via node.IsBlank which calls util.IsBlank
+// which calls util.IsSpace. Delegating to util.IsSpace keeps the predicate
+// in sync with goldmark automatically if spaceTable ever widens.
+func allCodeSpanBlank(src []byte, start, end int) bool {
 	for k := start; k < end; k++ {
-		if !isCodeSpanBlank(src[k]) {
+		if !util.IsSpace(src[k]) {
 			return false
 		}
 	}

--- a/internal/lint/inline_index.go
+++ b/internal/lint/inline_index.go
@@ -215,18 +215,29 @@ func trimCodeSpanContent(src []byte, start, end int) (int, int) {
 	return start + 1, end - 1
 }
 
-// isCodeSpanSpace reports whether b is a byte CommonMark folds to a space
-// inside a code span for the strip-one-space rule: a space or a line ending.
+// isCodeSpanSpace reports whether b matches goldmark's isSpaceOrNewline
+// predicate used for the strip-one-space trim condition: only ' ' and '\n'
+// qualify. '\r' and '\t' are deliberately excluded — goldmark's
+// code_span.go:isSpaceOrNewline is `c == ' ' || c == '\n'`.
 func isCodeSpanSpace(b byte) bool {
-	return b == ' ' || b == '\n' || b == '\r'
+	return b == ' ' || b == '\n'
 }
 
-// allCodeSpanSpaces reports whether every byte in [start, end) is a
-// code-span space byte; such a span is never trimmed (CommonMark keeps an
-// all-space span verbatim).
+// isCodeSpanBlank reports whether b counts as blank for the "content is
+// entirely spaces" guard that suppresses the single-space trim. goldmark
+// uses util.IsSpace (backed by spaceTable) for this check: it accepts ' ',
+// '\t', '\n', and '\r' (spaceTable indices 32, 9, 10, 13). Using a wider
+// predicate here than isCodeSpanSpace matches goldmark's two-predicate
+// design: narrow for the trim boundary, wide for the all-blank guard.
+func isCodeSpanBlank(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// allCodeSpanSpaces reports whether every byte in [start, end) is blank
+// per isCodeSpanBlank; such a span is never trimmed.
 func allCodeSpanSpaces(src []byte, start, end int) bool {
 	for k := start; k < end; k++ {
-		if !isCodeSpanSpace(src[k]) {
+		if !isCodeSpanBlank(src[k]) {
 			return false
 		}
 	}

--- a/internal/lint/inline_index_test.go
+++ b/internal/lint/inline_index_test.go
@@ -56,6 +56,15 @@ func TestInlineIndex_CodeSpanEquivalence(t *testing.T) {
 		{"no-spans", "plain paragraph with no code\n"},
 		{"leading-space-only", "a ` x` b\n"},
 		{"trailing-space-only", "a `x ` b\n"},
+		// \r is not in goldmark's isSpaceOrNewline (code_span.go), so a span
+		// whose boundary byte is \r must not be trimmed by the inline scanner.
+		{"crlf-boundary-no-trim", "a `\r x\r` b\n"},
+		// A content of all-blank bytes (including \t) suppresses trim in
+		// goldmark via util.IsBlank / util.IsSpace which includes TAB. The
+		// inline scanner's all-blank guard must use the same wider predicate.
+		{"all-tab-no-trim", "a `\t` b\n"},
+		{"space-tab-space-no-trim", "a ` \t ` b\n"},
+		{"backtick-in-html-block", "<div>\n`not a span`\n</div>\n\n`real`\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/lint/inline_index_test.go
+++ b/internal/lint/inline_index_test.go
@@ -43,7 +43,10 @@ func TestInlineIndex_CodeSpanEquivalence(t *testing.T) {
 		{"empty-span", "a `` b\n"},
 		{"unclosed-run", "a `code without close\n"},
 		{"mismatched-len", "a ``code` more\n"},
-		{"adjacent", "`one``two`\n"},
+		// One span, not two: single-backtick opener at 0; the double-backtick
+		// run at positions 4-5 has length 2 ≠ 1, so it is interior content,
+		// not a closer. The closer is the single backtick at 9.
+		{"single-span-double-interior", "`one``two`\n"},
 		{"two-spans", "`one` and `two`\n"},
 		{"escaped-backtick", "a \\`not a span\\` b\n"},
 		{"escaped-then-real", "a \\` then `real` b\n"},
@@ -59,10 +62,13 @@ func TestInlineIndex_CodeSpanEquivalence(t *testing.T) {
 		// \r is not in goldmark's isSpaceOrNewline (code_span.go), so a span
 		// whose boundary byte is \r must not be trimmed by the inline scanner.
 		{"crlf-boundary-no-trim", "a `\r x\r` b\n"},
-		// A content of all-blank bytes (including \t) suppresses trim in
-		// goldmark via util.IsBlank / util.IsSpace which includes TAB. The
-		// inline scanner's all-blank guard must use the same wider predicate.
-		{"all-tab-no-trim", "a `\t` b\n"},
+		// \t is not in goldmark's isSpaceOrNewline, so a span whose sole
+		// content byte is \t has a non-space boundary and is returned
+		// without trimming by the early-exit path in trimCodeSpanContent.
+		{"tab-only-no-trim", "a `\t` b\n"},
+		// When boundaries are spaces but the interior contains \t, goldmark's
+		// all-blank guard (util.IsBlank / util.IsSpace, which includes TAB)
+		// fires and suppresses trim. This case exercises allCodeSpanBlank.
 		{"space-tab-space-no-trim", "a ` \t ` b\n"},
 		{"backtick-in-html-block", "<div>\n`not a span`\n</div>\n\n`real`\n"},
 	}

--- a/internal/lint/inline_index_test.go
+++ b/internal/lint/inline_index_test.go
@@ -71,6 +71,13 @@ func TestInlineIndex_CodeSpanEquivalence(t *testing.T) {
 		// fires and suppresses trim. This case exercises allCodeSpanBlank.
 		{"space-tab-space-no-trim", "a ` \t ` b\n"},
 		{"backtick-in-html-block", "<div>\n`not a span`\n</div>\n\n`real`\n"},
+		// An opener backtick on line 1 (normal) has no valid closer because the
+		// backticks on lines 2–4 are all inside a fenced code block (codeLines
+		// set). scanCodeSpanAt encounters each of them and skips them via the
+		// lineInSet branch (lines 156-158 of inline_index.go). The span is
+		// unclosed so no code-span is recorded — matching the AST, which also
+		// finds none (the fenced code interrupts the paragraph on line 1).
+		{"closer-on-code-line", "`opener\n```\ncloser` here\n```\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -80,6 +87,43 @@ func TestInlineIndex_CodeSpanEquivalence(t *testing.T) {
 			assert.Equal(t, wantLiteral, gotLiteral, "literal ranges diverge from AST")
 		})
 	}
+}
+
+// TestNonInlineLines_PIAndCodeBlocks covers the merged path of nonInlineLines
+// (lines 123-128 of inline_index.go): a source with both a PI block and a
+// fenced code block triggers the set-merge branch (rather than the
+// CodeBlockLines direct-return), exercising the CodeBlockLines copy loop and
+// the PIBlockLines copy loop.
+func TestNonInlineLines_PIAndCodeBlocks(t *testing.T) {
+	// Line 1: inline code span (should be found by both AST and index).
+	// Line 3: PI block `<?x?>` → PIBlockLines = {3} → merged path triggered.
+	// Lines 5-7: fenced code block → CodeBlockLines = {5,6,7} → copy loop hit.
+	src := "`real span`\n\n<?x?>\n\n```\n`code`\n```\n"
+	wantContent, wantLiteral := astCodeSpanRanges(t, src)
+	gotContent, gotLiteral := indexCodeSpanRanges(src)
+	assert.Equal(t, wantContent, gotContent, "content ranges diverge from AST")
+	assert.Equal(t, wantLiteral, gotLiteral, "literal ranges diverge from AST")
+}
+
+// TestTrimCodeSpanContent_EqualBounds covers the end<=start guard
+// (lines 208-210 of inline_index.go): when start == end the function
+// returns the range unchanged without inspecting the source bytes.
+func TestTrimCodeSpanContent_EqualBounds(t *testing.T) {
+	src := []byte("hello world")
+	s, e := trimCodeSpanContent(src, 5, 5)
+	assert.Equal(t, 5, s, "start must be unchanged")
+	assert.Equal(t, 5, e, "end must be unchanged")
+}
+
+// TestAppendCodeSpan_ZeroWidthContent covers the ce<=cs early return
+// (lines 187-189 of inline_index.go): a double-backtick opener with
+// closeEnd == 2 gives contentStart=2, contentEnd=0, trimCodeSpanContent
+// returns (2,0), so ce(0) <= cs(2) and nothing is appended.
+func TestAppendCodeSpan_ZeroWidthContent(t *testing.T) {
+	idx := &InlineIndex{}
+	appendCodeSpan(idx, []byte("``"), 0, 2)
+	assert.Nil(t, idx.CodeSpanContent, "zero-width content must not be recorded")
+	assert.Nil(t, idx.CodeSpanLiteral, "zero-width literal must not be recorded")
 }
 
 // TestInlineIndex_NilSourceFile keeps a struct-literal File (no AST, no

--- a/internal/lint/inline_index_test.go
+++ b/internal/lint/inline_index_test.go
@@ -1,0 +1,84 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// astCodeSpanRanges parses src normally and returns the AST-derived
+// code-span content and literal ranges — the byte-identical target the
+// inline index must reproduce on the parse-skipped path.
+func astCodeSpanRanges(t *testing.T, src string) (content, literal []Range) {
+	t.Helper()
+	f, err := NewFile("doc.md", []byte(src))
+	require.NoError(t, err)
+	return f.CodeSpanContentRanges(), f.CodeSpanLiteralRanges()
+}
+
+// indexCodeSpanRanges builds a nil-AST File from src and returns its
+// inline-index-derived code-span ranges.
+func indexCodeSpanRanges(src string) (content, literal []Range) {
+	f := NewFileLines("doc.md", []byte(src))
+	return f.CodeSpanContentRanges(), f.CodeSpanLiteralRanges()
+}
+
+// TestInlineIndex_CodeSpanEquivalence pins the inline scanner byte-identical
+// to goldmark's CodeSpan node bounds across the cases the corpus exercises:
+// plain spans, multi-backtick fences, the single-space trim, all-space
+// spans, unclosed runs, backticks inside fenced and indented code blocks,
+// adjacent spans, and escaped backticks.
+func TestInlineIndex_CodeSpanEquivalence(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"plain", "before `code` after\n"},
+		{"double-backtick", "a ``code`` b\n"},
+		{"backtick-in-content", "a ``a`b`` c\n"},
+		{"single-space-trim", "a `  x ` b\n"},
+		{"both-space-trim", "a ` x ` b\n"},
+		{"all-spaces", "a `   ` b\n"},
+		{"empty-span", "a `` b\n"},
+		{"unclosed-run", "a `code without close\n"},
+		{"mismatched-len", "a ``code` more\n"},
+		{"adjacent", "`one``two`\n"},
+		{"two-spans", "`one` and `two`\n"},
+		{"escaped-backtick", "a \\`not a span\\` b\n"},
+		{"escaped-then-real", "a \\` then `real` b\n"},
+		{"span-in-list", "- item `code` here\n"},
+		{"span-after-fence", "```\nx\n```\n\nthen `code`\n"},
+		{"backtick-in-fence", "```\n`not a span`\n```\n\n`real`\n"},
+		{"backtick-in-indented", "    `not a span`\n\n`real`\n"},
+		{"multiline-span", "a `line one\nline two` b\n"},
+		{"triple-backtick-span", "a ```code``` b\n"},
+		{"no-spans", "plain paragraph with no code\n"},
+		{"leading-space-only", "a ` x` b\n"},
+		{"trailing-space-only", "a `x ` b\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wantContent, wantLiteral := astCodeSpanRanges(t, tc.src)
+			gotContent, gotLiteral := indexCodeSpanRanges(tc.src)
+			assert.Equal(t, wantContent, gotContent, "content ranges diverge from AST")
+			assert.Equal(t, wantLiteral, gotLiteral, "literal ranges diverge from AST")
+		})
+	}
+}
+
+// TestInlineIndex_NilSourceFile keeps a struct-literal File (no AST, no
+// source) returning nil ranges, matching the AST guard.
+func TestInlineIndex_NilSourceFile(t *testing.T) {
+	f := &File{}
+	assert.Nil(t, f.CodeSpanContentRanges())
+	assert.Nil(t, f.CodeSpanLiteralRanges())
+}
+
+// TestInlineIndex_Memoized pins the projection to one scan per file.
+func TestInlineIndex_Memoized(t *testing.T) {
+	f := NewFileLines("doc.md", []byte("x `y` z\n"))
+	first := InlineIndexProjection(f)
+	second := InlineIndexProjection(f)
+	assert.Same(t, first, second)
+}

--- a/internal/rule/walk.go
+++ b/internal/rule/walk.go
@@ -70,6 +70,28 @@ type BlockChecker interface {
 	BlockKinds() []lint.BlockKind
 }
 
+// InlineChecker is an optional capability for a NodeChecker rule whose
+// Check handles the parse-skipped path (f.AST nil) itself, by reading the
+// shared run-grouped inline parse (lint.InlineBlocks) instead of the tree.
+// The engine routes such a rule to its own Check on a nil-AST File rather
+// than dropping it (a NodeChecker that navigates the tree cannot run on a
+// nil AST) or forcing it onto the block-span dispatch (a rule reacting to
+// inline link/image markup needs the parsed inline nodes, not a block's
+// line span).
+//
+// Contract: on a nil-AST File, Check must return precisely the diagnostics
+// the rule's NodeChecker path would over the same document — same line,
+// column, message, severity — so the two paths are byte-identical (the
+// corpus and gate equivalence harnesses enforce this). InlineCapable is a
+// pure marker; its result must be constant for the life of the rule.
+type InlineChecker interface {
+	NodeChecker
+	// InlineCapable reports that this rule's Check serves the nil-AST
+	// path from lint.InlineBlocks. It is a marker only — the dispatch
+	// decision is made from it, no behaviour hangs off the value.
+	InlineCapable() bool
+}
+
 // WalkBlocks runs r.CheckBlock over the Layer 0 block scan of f,
 // dispatching only the spans whose Kind is in r.BlockKinds(), in
 // document order. A BlockChecker's standalone Check delegates here for

--- a/internal/rulelayer/rule_walk_audit.json
+++ b/internal/rulelayer/rule_walk_audit.json
@@ -123,8 +123,8 @@
   {
     "id": "MDS012",
     "name": "no-bare-urls",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
@@ -189,13 +189,13 @@
   {
     "id": "MDS018",
     "name": "no-emphasis-as-heading",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
     "uses_ast_walk": true,
-    "reads_file_ast": false
+    "reads_file_ast": true
   },
   {
     "id": "MDS019",

--- a/internal/rulelayer/rule_walk_audit.json
+++ b/internal/rulelayer/rule_walk_audit.json
@@ -348,7 +348,7 @@
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
-    "uses_ast_walk": true,
+    "uses_ast_walk": false,
     "reads_file_ast": true
   },
   {

--- a/internal/rulelayer/rule_walk_audit.json
+++ b/internal/rulelayer/rule_walk_audit.json
@@ -662,8 +662,8 @@
   {
     "id": "MDS062",
     "name": "link-validity",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": false,

--- a/internal/rulelayer/rule_walk_audit.json
+++ b/internal/rulelayer/rule_walk_audit.json
@@ -343,13 +343,13 @@
   {
     "id": "MDS032",
     "name": "no-empty-alt-text",
-    "category": "hybrid",
-    "nil_ast_safe": false,
+    "category": "A-no-skipping",
+    "nil_ast_safe": true,
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": true,
-    "uses_ast_walk": false,
-    "reads_file_ast": false
+    "uses_ast_walk": true,
+    "reads_file_ast": true
   },
   {
     "id": "MDS033",

--- a/internal/rulelayer/rulelayer.go
+++ b/internal/rulelayer/rulelayer.go
@@ -52,18 +52,21 @@ var layerByID = buildLayerMap()
 // "A-no-skipping" — they never crash with a nil AST — but which still read
 // an AST-derived projection that Layer 0 does not reproduce, so their
 // output silently diverges on a parse-skipped File. The audit's probe
-// measured crash-safety, not output equivalence: these rules consume the
-// inline code-span ranges (CodeSpanLiteralRanges / CodeSpanContentRanges),
-// which return empty without a parse, causing false positives inside
-// backtick spans. Until Layer 1 projects code spans, they are forced to
-// LayerAST so the parse-skip gate never admits them.
+// measured crash-safety, not output equivalence.
 //
-//   - MDS047 ambiguous-emphasis  → CodeSpanContentRanges
-//   - MDS054 no-undefined-reference-labels → CodeSpanLiteralRanges
-var astProjectionConsumers = map[string]bool{
-	"MDS047": true,
-	"MDS054": true,
-}
+// MDS047 (ambiguous-emphasis) and MDS054 (no-undefined-reference-labels)
+// formerly sat here: both consume the inline code-span ranges
+// (CodeSpanContentRanges / CodeSpanLiteralRanges), which returned empty
+// without a parse and caused false positives inside backtick spans. Layer 1
+// (internal/lint/inline_index.go) now reproduces those ranges byte-
+// identically on the nil-AST path — gated across the parse-skip-eligible
+// corpus by the equivalence harness — so both rules resolve to Layer 0
+// straight from their A-no-skipping audit category and no override remains.
+//
+// The map stays as the seam for any future projection-only consumer the
+// audit marks A-no-skipping but Layer N does not yet back. It is empty
+// today.
+var astProjectionConsumers = map[string]bool{}
 
 // buildLayerMap decodes the embedded manifest into the id→layer table.
 // "A-no-skipping" rules are Layer 0 unless they appear in

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -34,6 +34,15 @@ func TestIsLayer0(t *testing.T) {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0", id)
 		assert.Equal(t, Layer0, Of(id))
 	}
+	// MDS047 (ambiguous-emphasis) and MDS054 (no-undefined-reference-labels)
+	// are "A-no-skipping" and formerly forced to AST because they read the
+	// inline code-span ranges. Layer 1 (internal/lint/inline_index.go) now
+	// backs those ranges on the nil-AST path, so the override is gone and both
+	// resolve to Layer 0.
+	for _, id := range []string{"MDS047", "MDS054"} {
+		assert.True(t, IsLayer0(id), "%s should be Layer 0 once code spans are backed", id)
+		assert.Equal(t, Layer0, Of(id))
+	}
 	// AST-requiring rules are not Layer 0.
 	for _, id := range []string{"MDS001", "MDS019", "MDS023"} {
 		assert.False(t, IsLayer0(id), "%s should require the AST", id)
@@ -41,13 +50,13 @@ func TestIsLayer0(t *testing.T) {
 	}
 }
 
-// TestAuditLayer0RulesAreCodeSpanFree guards the parse-skip gate's
-// soundness invariant: every rule the manifest marks "A-no-skipping" and
-// rulelayer admits as Layer 0 must not consume an AST-only inline
-// projection. MDS047 and MDS054 are "A-no-skipping" (nil-AST safe) yet read
-// code-span ranges that go empty without a parse, so they are excluded.
-// This test fails if a future rule lands in "A-no-skipping" while reading
-// code spans and is not added to astProjectionConsumers.
+// TestAstProjectionConsumersAreNotLayer0 guards the parse-skip gate's
+// soundness invariant: any rule the manifest marks "A-no-skipping" yet
+// listed in astProjectionConsumers (because it reads an AST-only projection
+// Layer N does not yet back) must be forced to AST, so the gate never
+// admits it. The map is empty today — Layer 1 backs the code-span ranges
+// that were its only entries — so this test is vacuous but pins the
+// invariant for any future entry.
 func TestAstProjectionConsumersAreNotLayer0(t *testing.T) {
 	for id := range astProjectionConsumers {
 		assert.False(t, IsLayer0(id),
@@ -70,16 +79,30 @@ func TestBuildLayerMapFromPanicsOnMalformedManifest(t *testing.T) {
 	})
 }
 
-// TestBuildLayerMapFromClassifies confirms both arms of the category switch:
-// an "A-no-skipping" rule maps to Layer0, an astProjectionConsumer and any
-// other category map to LayerAST.
+// TestBuildLayerMapFromClassifies confirms both arms of the category
+// switch: an "A-no-skipping" rule maps to Layer0 and any other category
+// maps to LayerAST. The astProjectionConsumers override is empty today, so
+// the only way to reach LayerAST is a non-"A-no-skipping" category.
 func TestBuildLayerMapFromClassifies(t *testing.T) {
 	m := buildLayerMapFrom([]byte(`[
 		{"id":"MDS900","category":"A-no-skipping"},
-		{"id":"MDS047","category":"A-no-skipping"},
 		{"id":"MDS901","category":"ast-required"}
 	]`))
 	assert.Equal(t, Layer0, m["MDS900"])
-	assert.Equal(t, LayerAST, m["MDS047"], "astProjectionConsumer stays AST")
 	assert.Equal(t, LayerAST, m["MDS901"])
+}
+
+// TestAstProjectionConsumerOverrideForcesAST pins the override arm of the
+// category switch independently of the (currently empty) production map: a
+// rule whose category is "A-no-skipping" but which is listed in
+// astProjectionConsumers must still resolve to LayerAST. It mutates the
+// package map for the duration of one buildLayerMapFrom call so the test
+// does not depend on a live override entry.
+func TestAstProjectionConsumerOverrideForcesAST(t *testing.T) {
+	astProjectionConsumers["MDS902"] = true
+	t.Cleanup(func() { delete(astProjectionConsumers, "MDS902") })
+	m := buildLayerMapFrom([]byte(`[
+		{"id":"MDS902","category":"A-no-skipping"}
+	]`))
+	assert.Equal(t, LayerAST, m["MDS902"], "override forces an A-no-skipping rule to AST")
 }

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -43,6 +43,18 @@ func TestIsLayer0(t *testing.T) {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0 once code spans are backed", id)
 		assert.Equal(t, Layer0, Of(id))
 	}
+	// MDS012 (no-bare-urls) and MDS018 (no-emphasis-as-heading) were
+	// "hybrid": they walked the inline tree (Text nodes for bare URLs, a
+	// lone Emphasis child for emphasis-as-heading) and produced no
+	// diagnostics on a nil AST. Layer 1 re-backs both via the per-block
+	// inline parse (internal/lint/inline_blocks.go + inline_emphasis.go):
+	// each implements rule.BlockChecker so the engine's block-span dispatch
+	// drives them on the parse-skipped File. The audit now classes them
+	// "A-no-skipping" and the gate admits both.
+	for _, id := range []string{"MDS012", "MDS018"} {
+		assert.True(t, IsLayer0(id), "%s should be Layer 0 once re-backed on Layer 1", id)
+		assert.Equal(t, Layer0, Of(id))
+	}
 	// AST-requiring rules are not Layer 0.
 	for _, id := range []string{"MDS001", "MDS019", "MDS023"} {
 		assert.False(t, IsLayer0(id), "%s should require the AST", id)

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -51,7 +51,15 @@ func TestIsLayer0(t *testing.T) {
 	// each implements rule.BlockChecker so the engine's block-span dispatch
 	// drives them on the parse-skipped File. The audit now classes them
 	// "A-no-skipping" and the gate admits both.
-	for _, id := range []string{"MDS012", "MDS018"} {
+	// MDS012 (no-bare-urls), MDS018 (no-emphasis-as-heading), MDS032
+	// (no-empty-alt-text), and MDS062 (link-validity) were "hybrid": each
+	// walked the inline tree and produced no (or different) diagnostics on
+	// a nil AST. Layer 1 re-backs all four via the per-block inline parse
+	// (internal/lint/inline_blocks.go, inline_emphasis.go): the NodeChecker
+	// rules implement rule.BlockChecker so the engine's block-span dispatch
+	// drives them, and MDS062 (a plain Check rule) parses each span in its
+	// own Check. The audit now classes all four "A-no-skipping".
+	for _, id := range []string{"MDS012", "MDS018", "MDS032", "MDS062"} {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0 once re-backed on Layer 1", id)
 		assert.Equal(t, Layer0, Of(id))
 	}

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -54,11 +54,12 @@ func TestIsLayer0(t *testing.T) {
 	// MDS012 (no-bare-urls), MDS018 (no-emphasis-as-heading), MDS032
 	// (no-empty-alt-text), and MDS062 (link-validity) were "hybrid": each
 	// walked the inline tree and produced no (or different) diagnostics on
-	// a nil AST. Layer 1 re-backs all four via the per-block inline parse
-	// (internal/lint/inline_blocks.go, inline_emphasis.go): the NodeChecker
-	// rules implement rule.BlockChecker so the engine's block-span dispatch
-	// drives them, and MDS062 (a plain Check rule) parses each span in its
-	// own Check. The audit now classes all four "A-no-skipping".
+	// a nil AST. Layer 1 re-backs all four on the shared run-grouped inline
+	// parse (internal/lint/inline_blocks.go, inline_emphasis.go): the three
+	// NodeChecker rules implement rule.InlineChecker so the engine routes
+	// them to their own Check on a nil-AST File, and MDS062 (a plain Check
+	// rule) reads the same projection in its Check. The audit now classes
+	// all four "A-no-skipping".
 	for _, id := range []string{"MDS012", "MDS018", "MDS032", "MDS062"} {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0 once re-backed on Layer 1", id)
 		assert.Equal(t, Layer0, Of(id))

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -60,31 +60,64 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 // Direct recursion (entering visits only) replaces ast.Walk: the rule
 // only reacts to two node types, and the closure-driven double visit
 // per node was measurable on every file.
+//
+// On the parse-skipped path (f.AST nil) the document tree is unavailable,
+// so each inline-bearing Layer 0 block span is parsed in isolation and the
+// same node recursion runs over it, with span-local segment offsets mapped
+// back to the document via the span's start offset. Re-using goldmark's
+// parser per span reproduces the link/image nodes byte-identically.
 func (r *Rule) checkEmpty(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
-	r.checkEmptyNode(f.AST, f, &diags)
+	if f.AST != nil {
+		r.checkEmptyNode(f.AST, f, 0, &diags)
+		return diags
+	}
+	for _, span := range lint.Layer0(f).BlockSpans {
+		if !inlineBearingBlock(span.Kind) {
+			continue
+		}
+		start := f.LineStartOffset(span.Start - 1)
+		end := f.LineEndOffset(span.End - 1)
+		if end <= start {
+			continue
+		}
+		doc := lint.ParseInline(f.Source[start:end])
+		r.checkEmptyNode(doc, f, start, &diags)
+	}
 	return diags
 }
 
-func (r *Rule) checkEmptyNode(n ast.Node, f *lint.File, diags *[]lint.Diagnostic) {
+// inlineBearingBlock reports whether a Layer 0 block kind can carry inline
+// link or image markup the empty-link check reacts to.
+func inlineBearingBlock(k lint.BlockKind) bool {
+	switch k {
+	case lint.BlockParagraph, lint.BlockATXHeading, lint.BlockSetextHeading,
+		lint.BlockList, lint.BlockQuote:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Rule) checkEmptyNode(n ast.Node, f *lint.File, base int, diags *[]lint.Diagnostic) {
 	if n == nil {
 		return
 	}
 	switch node := n.(type) {
 	case *ast.Image:
 		if emptyDestination(node.Destination) {
-			*diags = append(*diags, r.diag(f, nodeLine(node, f), "empty image destination"))
+			*diags = append(*diags, r.diag(f, nodeLine(node, f, base), "empty image destination"))
 		}
 	case *ast.Link:
 		switch {
 		case emptyDestination(node.Destination):
-			*diags = append(*diags, r.diag(f, nodeLine(node, f), "empty link destination"))
-		case !hasVisibleContent(node, f.Source):
-			*diags = append(*diags, r.diag(f, nodeLine(node, f), "empty link text"))
+			*diags = append(*diags, r.diag(f, nodeLine(node, f, base), "empty link destination"))
+		case !hasVisibleContent(node, f.Source, base):
+			*diags = append(*diags, r.diag(f, nodeLine(node, f, base), "empty link text"))
 		}
 	}
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-		r.checkEmptyNode(c, f, diags)
+		r.checkEmptyNode(c, f, base, diags)
 	}
 }
 
@@ -110,8 +143,9 @@ func emptyDestination(dest []byte) bool {
 
 // hasVisibleContent reports whether the link renders any visible
 // content: an image, code span, autolink, raw HTML, or non-whitespace
-// text anywhere in its subtree.
-func hasVisibleContent(link *ast.Link, source []byte) bool {
+// text anywhere in its subtree. base maps span-local Text segment offsets
+// to the document on the per-block path (zero on the AST path).
+func hasVisibleContent(link *ast.Link, source []byte, base int) bool {
 	found := false
 	_ = ast.Walk(link, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -122,7 +156,7 @@ func hasVisibleContent(link *ast.Link, source []byte) bool {
 			found = true
 			return ast.WalkStop, nil
 		case *ast.Text:
-			if len(bytes.TrimSpace(t.Segment.Value(source))) > 0 {
+			if len(bytes.TrimSpace(source[base+t.Segment.Start:base+t.Segment.Stop])) > 0 {
 				found = true
 				return ast.WalkStop, nil
 			}
@@ -134,9 +168,11 @@ func hasVisibleContent(link *ast.Link, source []byte) bool {
 
 // nodeLine returns the 1-based source line of an inline node. Inline
 // nodes carry no position, so it uses the first descendant text segment
-// and falls back to the nearest block ancestor's first line.
-func nodeLine(n ast.Node, f *lint.File) int {
-	if ln := firstTextLine(n, f); ln > 0 {
+// and falls back to the nearest block ancestor's first line. base maps
+// span-local offsets to the document on the per-block path (zero on the
+// AST path).
+func nodeLine(n ast.Node, f *lint.File, base int) int {
+	if ln := firstTextLine(n, f, base); ln > 0 {
 		return ln
 	}
 	for p := n.Parent(); p != nil; p = p.Parent() {
@@ -145,18 +181,18 @@ func nodeLine(n ast.Node, f *lint.File) int {
 		}
 		lines := p.Lines()
 		if lines != nil && lines.Len() > 0 {
-			return f.LineOfOffset(lines.At(0).Start)
+			return f.LineOfOffset(base + lines.At(0).Start)
 		}
 	}
 	return 1
 }
 
-func firstTextLine(n ast.Node, f *lint.File) int {
+func firstTextLine(n ast.Node, f *lint.File, base int) int {
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
 		if t, ok := c.(*ast.Text); ok {
-			return f.LineOfOffset(t.Segment.Start)
+			return f.LineOfOffset(base + t.Segment.Start)
 		}
-		if ln := firstTextLine(c, f); ln > 0 {
+		if ln := firstTextLine(c, f, base); ln > 0 {
 			return ln
 		}
 	}

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -62,10 +62,10 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 // per node was measurable on every file.
 //
 // On the parse-skipped path (f.AST nil) the document tree is unavailable,
-// so each inline-bearing Layer 0 block span is parsed in isolation and the
-// same node recursion runs over it, with span-local segment offsets mapped
-// back to the document via the span's start offset. Re-using goldmark's
-// parser per span reproduces the link/image nodes byte-identically.
+// so the same per-node check runs over the shared run-grouped inline parse
+// (lint.WalkInlineNodes), with run-local segment offsets mapped back to the
+// document via base. Re-using goldmark's parser per run reproduces the
+// link/image nodes byte-identically.
 func (r *Rule) checkEmpty(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	if f.AST != nil {

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -72,37 +72,33 @@ func (r *Rule) checkEmpty(f *lint.File) []lint.Diagnostic {
 		r.checkEmptyNode(f.AST, f, 0, &diags)
 		return diags
 	}
-	for _, span := range lint.Layer0(f).BlockSpans {
-		if !inlineBearingBlock(span.Kind) {
-			continue
-		}
-		start := f.LineStartOffset(span.Start - 1)
-		end := f.LineEndOffset(span.End - 1)
-		if end <= start {
-			continue
-		}
-		doc := lint.ParseInline(f.Source[start:end])
-		r.checkEmptyNode(doc, f, start, &diags)
-	}
+	// On the parse-skipped path the document tree is unavailable, so the
+	// same per-node check runs over the shared run-grouped inline parse,
+	// with run-local segment offsets mapped to the document via base.
+	lint.WalkInlineNodes(f, func(n ast.Node, base int) {
+		r.checkEmptyNodeOne(n, f, base, &diags)
+	})
 	return diags
 }
 
-// inlineBearingBlock reports whether a Layer 0 block kind can carry inline
-// link or image markup the empty-link check reacts to.
-func inlineBearingBlock(k lint.BlockKind) bool {
-	switch k {
-	case lint.BlockParagraph, lint.BlockATXHeading, lint.BlockSetextHeading,
-		lint.BlockList, lint.BlockQuote:
-		return true
-	default:
-		return false
-	}
-}
-
+// checkEmptyNode recursively applies checkEmptyNodeOne over n's subtree on
+// the AST path, where offsets are document-absolute (base zero).
 func (r *Rule) checkEmptyNode(n ast.Node, f *lint.File, base int, diags *[]lint.Diagnostic) {
 	if n == nil {
 		return
 	}
+	r.checkEmptyNodeOne(n, f, base, diags)
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		r.checkEmptyNode(c, f, base, diags)
+	}
+}
+
+// checkEmptyNodeOne flags a single Link or Image node with an empty/`#`
+// destination, or (links only) empty visible text. base maps the node's
+// segment offsets to the document: zero on the AST path, the run's start
+// offset on the inline-walk path (where WalkInlineNodes already visits
+// every node, so no extra recursion is needed here).
+func (r *Rule) checkEmptyNodeOne(n ast.Node, f *lint.File, base int, diags *[]lint.Diagnostic) {
 	switch node := n.(type) {
 	case *ast.Image:
 		if emptyDestination(node.Destination) {
@@ -115,9 +111,6 @@ func (r *Rule) checkEmptyNode(n ast.Node, f *lint.File, base int, diags *[]lint.
 		case !hasVisibleContent(node, f.Source, base):
 			*diags = append(*diags, r.diag(f, nodeLine(node, f, base), "empty link text"))
 		}
-	}
-	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-		r.checkEmptyNode(c, f, base, diags)
 	}
 }
 

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -194,10 +194,12 @@ func firstTextLine(n ast.Node, f *lint.File, base int) int {
 
 // isInlineNode reports whether n is an inline node, whose Lines() would
 // panic. nodeLine skips these while walking ancestors for a block with a
-// source position.
+// source position. *ast.String is included alongside the other inline kinds
+// because it too is a BaseInline whose Lines() panics; omitting it would let
+// the ancestor walk reach lines := p.Lines() on a String node and crash.
 func isInlineNode(n ast.Node) bool {
 	switch n.(type) {
-	case *ast.Text, *ast.CodeSpan, *ast.Emphasis,
+	case *ast.Text, *ast.String, *ast.CodeSpan, *ast.Emphasis,
 		*ast.Link, *ast.Image, *ast.AutoLink, *ast.RawHTML:
 		return true
 	}

--- a/internal/rules/linkvalidity/rule_test.go
+++ b/internal/rules/linkvalidity/rule_test.go
@@ -306,6 +306,7 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"ref-link-empty-text", "[ ][ref]\n\n[ref]: http://example.com\n"},
 		{"wrapped-link-list", "- [\n  ](http://x.com)\n"},
 		{"bq-empty-link", "> [text]()\n"},
+		{"empty-link-in-html-block", "<div>\n[a]() text\n</div>\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/linkvalidity/rule_test.go
+++ b/internal/rules/linkvalidity/rule_test.go
@@ -227,7 +227,7 @@ func TestEmptyDestLinkWithEmphasisText(t *testing.T) {
 func TestNodeLineDetachedFallback(t *testing.T) {
 	f, err := lint.NewFile("t.md", []byte("x"))
 	require.NoError(t, err)
-	assert.Equal(t, 1, nodeLine(ast.NewLink(), f))
+	assert.Equal(t, 1, nodeLine(ast.NewLink(), f, 0))
 }
 
 func TestFixSkipsFencedBlock(t *testing.T) {
@@ -275,6 +275,43 @@ func TestCheckEmptyNode_NilNode(t *testing.T) {
 	// Struct-literal Files in unit tests can carry a nil AST; the
 	// recursive walker must tolerate the nil root.
 	var diags []lint.Diagnostic
-	(&Rule{}).checkEmptyNode(nil, &lint.File{}, &diags)
+	(&Rule{}).checkEmptyNode(nil, &lint.File{}, 0, &diags)
 	assert.Empty(t, diags)
+}
+
+// TestCheck_NilASTEquivalence pins the parse-skipped path (f.AST nil,
+// served from the Layer 1 per-block inline parse) byte-identical to the
+// AST path across empty-link, empty-image, reversed-link, and visible-
+// content shapes in several block contexts.
+func TestCheck_NilASTEquivalence(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"empty-dest", "see [text]() here\n"},
+		{"good-link", "see [text](https://x.com) here\n"},
+		{"hash-dest", "see [text](#) here\n"},
+		{"empty-text", "see [](https://x.com) here\n"},
+		{"empty-image-dest", "![alt]() here\n"},
+		{"reversed", "see (text)[url] here\n"},
+		{"empty-in-list", "- [text]() bad\n- [ok](https://x.com)\n"},
+		{"empty-in-heading", "# title [text]()\n"},
+		{"empty-in-quote", "> quote [text]()\n"},
+		{"empty-in-emphasis", "lead\n\n*[](https://x.com)*\n"},
+		{"emphasis-text-empty-dest", "an [*here*]() link\n"},
+		{"image-in-link", "[![](img.png)](dest)\n"},
+		{"two-empty", "[a]() and [b]()\n"},
+		{"no-link", "just plain text\n"},
+		{"multiline-para", "text [link]()\nmore text\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			astFile, err := lint.NewFile("test.md", []byte(tc.src))
+			require.NoError(t, err)
+			lineFile := lint.NewFileLines("test.md", []byte(tc.src))
+			r := &Rule{}
+			assert.Equal(t, r.Check(astFile), r.Check(lineFile),
+				"nil-AST diagnostics diverge from AST path")
+		})
+	}
 }

--- a/internal/rules/linkvalidity/rule_test.go
+++ b/internal/rules/linkvalidity/rule_test.go
@@ -303,6 +303,9 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"two-empty", "[a]() and [b]()\n"},
 		{"no-link", "just plain text\n"},
 		{"multiline-para", "text [link]()\nmore text\n"},
+		{"ref-link-empty-text", "[ ][ref]\n\n[ref]: http://example.com\n"},
+		{"wrapped-link-list", "- [\n  ](http://x.com)\n"},
+		{"bq-empty-link", "> [text]()\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/nobareurls/rule.go
+++ b/internal/rules/nobareurls/rule.go
@@ -38,62 +38,25 @@ func (r *Rule) Category() string { return "link" }
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
-	// nodes, so drive the per-block dispatch over the Layer 0 block scan:
-	// each inline-bearing span is parsed in isolation and the same
-	// Text-node logic runs over it, with span-local segment offsets mapped
-	// back to the document. Re-using goldmark's own parser per span keeps
-	// the flagged bare-URL set byte-identical to the AST path.
+	// nodes, so serve from the shared run-grouped inline parse: the same
+	// Text-node logic runs over every parsed run, with run-local segment
+	// offsets mapped back to the document. Re-using goldmark's own parser
+	// keeps the flagged bare-URL set byte-identical to the AST path.
 	if f.AST == nil {
-		return rule.WalkBlocks(r, f)
+		var diags []lint.Diagnostic
+		lint.WalkInlineNodes(f, func(n ast.Node, base int) {
+			diags = append(diags, r.flagTextNode(n, f, base)...)
+		})
+		return diags
 	}
 	return rule.WalkNodes(r, f)
 }
 
-// CheckBlock implements rule.BlockChecker. It parses the span's own source
-// bytes in isolation and applies the per-Text-node bare-URL check,
-// translating each span-local offset to the document via the span's start
-// offset. Re-using goldmark's parser on the span reproduces the link,
-// autolink, and code-span context the AST walk relied on to suppress
-// non-bare URLs.
-func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
-	start := f.LineStartOffset(span.Start - 1)
-	end := f.LineEndOffset(span.End - 1)
-	if end <= start {
-		return nil
-	}
-	block := f.Source[start:end]
-	doc := lint.ParseInline(block)
-	diags := make([]lint.Diagnostic, 0)
-	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		diags = append(diags, r.flagTextNode(n, f, start)...)
-		return ast.WalkContinue, nil
-	})
-	if len(diags) == 0 {
-		return nil
-	}
-	return diags
-}
+// InlineCapable implements rule.InlineChecker: Check serves the nil-AST
+// path from lint.WalkInlineNodes (which reads lint.InlineBlocks).
+func (r *Rule) InlineCapable() bool { return true }
 
-// blockKinds is the static block-kind interest CheckBlock declares via
-// rule.BlockChecker; package-level so BlockKinds returns it without
-// allocating. A bare URL can appear in body text under any of these block
-// kinds, so the rule reacts to every inline-bearing span the Layer 0 scan
-// emits.
-var blockKinds = []lint.BlockKind{
-	lint.BlockParagraph,
-	lint.BlockATXHeading,
-	lint.BlockSetextHeading,
-	lint.BlockList,
-	lint.BlockQuote,
-}
-
-// BlockKinds implements rule.BlockChecker.
-func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
-
-var _ rule.BlockChecker = (*Rule)(nil)
+var _ rule.InlineChecker = (*Rule)(nil)
 
 // CheckNode implements rule.NodeChecker. On the AST path the segment
 // offsets are already document-absolute, so the base offset is zero.

--- a/internal/rules/nobareurls/rule.go
+++ b/internal/rules/nobareurls/rule.go
@@ -37,14 +37,81 @@ func (r *Rule) Category() string { return "link" }
 // this rule into one shared AST walk; a direct call still works via
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
+	// nodes, so drive the per-block dispatch over the Layer 0 block scan:
+	// each inline-bearing span is parsed in isolation and the same
+	// Text-node logic runs over it, with span-local segment offsets mapped
+	// back to the document. Re-using goldmark's own parser per span keeps
+	// the flagged bare-URL set byte-identical to the AST path.
+	if f.AST == nil {
+		return rule.WalkBlocks(r, f)
+	}
 	return rule.WalkNodes(r, f)
 }
 
-// CheckNode implements rule.NodeChecker.
+// CheckBlock implements rule.BlockChecker. It parses the span's own source
+// bytes in isolation and applies the per-Text-node bare-URL check,
+// translating each span-local offset to the document via the span's start
+// offset. Re-using goldmark's parser on the span reproduces the link,
+// autolink, and code-span context the AST walk relied on to suppress
+// non-bare URLs.
+func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
+	start := f.LineStartOffset(span.Start - 1)
+	end := f.LineEndOffset(span.End - 1)
+	if end <= start {
+		return nil
+	}
+	block := f.Source[start:end]
+	doc := lint.ParseInline(block)
+	diags := make([]lint.Diagnostic, 0)
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		diags = append(diags, r.flagTextNode(n, f, start)...)
+		return ast.WalkContinue, nil
+	})
+	if len(diags) == 0 {
+		return nil
+	}
+	return diags
+}
+
+// blockKinds is the static block-kind interest CheckBlock declares via
+// rule.BlockChecker; package-level so BlockKinds returns it without
+// allocating. A bare URL can appear in body text under any of these block
+// kinds, so the rule reacts to every inline-bearing span the Layer 0 scan
+// emits.
+var blockKinds = []lint.BlockKind{
+	lint.BlockParagraph,
+	lint.BlockATXHeading,
+	lint.BlockSetextHeading,
+	lint.BlockList,
+	lint.BlockQuote,
+}
+
+// BlockKinds implements rule.BlockChecker.
+func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
+
+var _ rule.BlockChecker = (*Rule)(nil)
+
+// CheckNode implements rule.NodeChecker. On the AST path the segment
+// offsets are already document-absolute, so the base offset is zero.
 func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
 	if !entering {
 		return nil
 	}
+	return r.flagTextNode(n, f, 0)
+}
+
+// flagTextNode emits a diagnostic for each bare URL inside a Text node that
+// is not within a link, autolink, or code span. base is added to the node's
+// segment-local offsets to recover document-absolute positions: zero on the
+// AST path (segments are already absolute), the run's start offset on the
+// per-block path. The node's content is read against f.Source on the AST
+// path and against the same Source via the absolute offsets on the per-block
+// path — both index the identical bytes.
+func (r *Rule) flagTextNode(n ast.Node, f *lint.File, base int) []lint.Diagnostic {
 	textNode, ok := n.(*ast.Text)
 	if !ok {
 		return nil
@@ -55,7 +122,9 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	}
 
 	seg := textNode.Segment
-	content := seg.Value(f.Source)
+	absStart := base + seg.Start
+	absStop := base + seg.Stop
+	content := f.Source[absStart:absStop]
 	// Every urlPattern match starts with "http"; gating on the
 	// literal spares the regex engine on the overwhelming majority
 	// of text nodes.
@@ -67,9 +136,9 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		return nil
 	}
 
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(matches))
 	for _, m := range matches {
-		offset := seg.Start + m[0]
+		offset := absStart + m[0]
 		diags = append(diags, lint.Diagnostic{
 			File:     f.Path,
 			Line:     f.LineOfOffset(offset),

--- a/internal/rules/nobareurls/rule_test.go
+++ b/internal/rules/nobareurls/rule_test.go
@@ -185,6 +185,8 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"trailing-punct", "see https://example.com.\n"},
 		{"wrapped-list-url", "- see\n  https://example.com\n"},
 		{"bq-multiline-url", "> line one https://a.com\n> line two\n"},
+		{"url-in-html-block", "<div>\nhttps://x.com\n</div>\n"},
+		{"html-block-interrupt", "text https://a.com\n<div>raw</div>\nmore https://b.com\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/nobareurls/rule_test.go
+++ b/internal/rules/nobareurls/rule_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -155,5 +156,42 @@ func TestCategory(t *testing.T) {
 	r := &Rule{}
 	if r.Category() == "" {
 		t.Error("expected non-empty category")
+	}
+}
+
+// TestCheck_NilASTEquivalence pins the parse-skipped path (f.AST nil,
+// served from the Layer 1 per-block inline parse) byte-identical to the
+// AST path across the shapes the corpus exercises: plain prose, headings,
+// list items, links and autolinks (whose URLs must not be flagged), code
+// spans, and multi-line paragraphs.
+func TestCheck_NilASTEquivalence(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"prose-bare", "Visit https://example.com today\n"},
+		{"no-url", "just a plain paragraph\n"},
+		{"linked", "See [example](https://example.com) here\n"},
+		{"autolink", "See <https://example.com> here\n"},
+		{"code-span-url", "Run `https://example.com` here\n"},
+		{"heading-bare", "# See https://example.com\n"},
+		{"list-bare", "- visit https://a.com\n- and https://b.com\n"},
+		{"list-mixed", "- visit https://a.com\n- and [x](https://b.com)\n"},
+		{"link-text-url", "[https://example.com](https://example.com)\n"},
+		{"two-paragraphs", "first https://a.com\n\nsecond https://b.com\n"},
+		{"multiline-para", "line one https://a.com\nline two https://b.com\n"},
+		{"quote-bare", "> quoted https://example.com\n"},
+		{"http-and-https", "http://a.com and https://b.com\n"},
+		{"trailing-punct", "see https://example.com.\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			astFile, err := lint.NewFile("test.md", []byte(tc.src))
+			require.NoError(t, err)
+			lineFile := lint.NewFileLines("test.md", []byte(tc.src))
+			r := &Rule{}
+			assert.Equal(t, r.Check(astFile), r.Check(lineFile),
+				"nil-AST diagnostics diverge from AST path")
+		})
 	}
 }

--- a/internal/rules/nobareurls/rule_test.go
+++ b/internal/rules/nobareurls/rule_test.go
@@ -159,6 +159,14 @@ func TestCategory(t *testing.T) {
 	}
 }
 
+// TestInlineCapable_NoBareURLs covers the InlineCapable method (line 57 of
+// rule.go), which is called only by the engine's nil-AST dispatcher and is
+// otherwise skipped by direct Check() calls in unit tests.
+func TestInlineCapable_NoBareURLs(t *testing.T) {
+	r := &Rule{}
+	assert.True(t, r.InlineCapable())
+}
+
 // TestCheck_NilASTEquivalence pins the parse-skipped path (f.AST nil,
 // served from the Layer 1 per-block inline parse) byte-identical to the
 // AST path across the shapes the corpus exercises: plain prose, headings,
@@ -187,6 +195,10 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"bq-multiline-url", "> line one https://a.com\n> line two\n"},
 		{"url-in-html-block", "<div>\nhttps://x.com\n</div>\n"},
 		{"html-block-interrupt", "text https://a.com\n<div>raw</div>\nmore https://b.com\n"},
+		// "http" appears in the text but no full URL (no "://") follows, so
+		// urlNeedle matches but urlPattern finds no match — exercises the
+		// len(matches)==0 early return (lines 98-100 of rule.go).
+		{"http-no-url", "http scheme used here\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/nobareurls/rule_test.go
+++ b/internal/rules/nobareurls/rule_test.go
@@ -183,6 +183,8 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"quote-bare", "> quoted https://example.com\n"},
 		{"http-and-https", "http://a.com and https://b.com\n"},
 		{"trailing-punct", "see https://example.com.\n"},
+		{"wrapped-list-url", "- see\n  https://example.com\n"},
+		{"bq-multiline-url", "> line one https://a.com\n> line two\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/noemphasisasheading/rule.go
+++ b/internal/rules/noemphasisasheading/rule.go
@@ -38,51 +38,51 @@ func (r *Rule) Category() string { return "heading" }
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
-	// nodes, so drive the per-block dispatch over the Layer 0 block scan,
-	// which the corpus equivalence harness pins byte-identical to the
+	// nodes, so serve from the shared run-grouped inline parse, which the
+	// corpus equivalence harness pins byte-identical to the
 	// lone-emphasis-child result this rule reads from the tree.
 	if f.AST == nil {
-		return rule.WalkBlocks(r, f)
+		return r.checkFromInline(f)
 	}
 	return rule.WalkNodes(r, f)
 }
 
-// CheckBlock implements rule.BlockChecker. It is invoked once per
-// BlockParagraph span on the parse-skipped path. A paragraph is flagged
-// when its inline content (parsed in isolation by the Layer 1 detector) is
-// a single emphasis span, unless the emphasis text holds a configured
-// placeholder token. A lone-emphasis paragraph never starts with `|`, so it
+// InlineCapable implements rule.InlineChecker: Check serves the nil-AST
+// path from lint.WholeParagraphEmphasis (which reads lint.InlineBlocks).
+func (r *Rule) InlineCapable() bool { return true }
+
+var _ rule.InlineChecker = (*Rule)(nil)
+
+// checkFromInline reports one diagnostic per lone-emphasis paragraph the
+// shared inline parse finds, applying the same placeholder suppression the
+// AST path applies. A lone-emphasis paragraph never starts with `|`, so it
 // can never be a GFM table; the AST path's table guard is therefore vacuous
 // here and needs no counterpart.
-func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
-	p, ok := lint.LoneEmphasisParagraph(f, span)
-	if !ok {
+func (r *Rule) checkFromInline(f *lint.File) []lint.Diagnostic {
+	paras := lint.WholeParagraphEmphasis(f)
+	if len(paras) == 0 {
 		return nil
 	}
-	if segmentsContainPlaceholder(p.TextSegments, r.Placeholders) {
+	diags := make([]lint.Diagnostic, 0, len(paras))
+	for _, p := range paras {
+		if segmentsContainPlaceholder(p.TextSegments, r.Placeholders) {
+			continue
+		}
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     p.Line,
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "emphasis used instead of a heading",
+		})
+	}
+	if len(diags) == 0 {
 		return nil
 	}
-	return []lint.Diagnostic{{
-		File:     f.Path,
-		Line:     p.Line,
-		Column:   1,
-		RuleID:   r.ID(),
-		RuleName: r.Name(),
-		Severity: lint.Warning,
-		Message:  "emphasis used instead of a heading",
-	}}
+	return diags
 }
-
-// blockKinds is the static block-kind interest CheckBlock declares via
-// rule.BlockChecker; package-level so BlockKinds returns it without
-// allocating. Emphasis-as-heading is a paragraph-only shape.
-var blockKinds = []lint.BlockKind{lint.BlockParagraph}
-
-// BlockKinds implements rule.BlockChecker: CheckBlock reacts only to
-// paragraph spans.
-func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
-
-var _ rule.BlockChecker = (*Rule)(nil)
 
 // CheckNode implements rule.NodeChecker.
 func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {

--- a/internal/rules/noemphasisasheading/rule.go
+++ b/internal/rules/noemphasisasheading/rule.go
@@ -37,7 +37,42 @@ func (r *Rule) Category() string { return "heading" }
 // this rule into one shared AST walk; a direct call still works via
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
+	// nodes, so serve from the Layer 1 whole-paragraph-emphasis index,
+	// which the corpus equivalence harness pins byte-identical to the
+	// lone-emphasis-child result this rule reads from the tree.
+	if f.AST == nil {
+		return r.checkFromIndex(f)
+	}
 	return rule.WalkNodes(r, f)
+}
+
+// checkFromIndex reports one diagnostic per Layer 1 emphasis paragraph,
+// applying the same placeholder suppression the AST path applies. A
+// lone-emphasis paragraph never starts with `|`, so it can never be a
+// GFM table; the AST path's table guard is therefore vacuous here and
+// needs no counterpart.
+func (r *Rule) checkFromIndex(f *lint.File) []lint.Diagnostic {
+	paras := lint.WholeParagraphEmphasis(f)
+	if len(paras) == 0 {
+		return nil
+	}
+	var diags []lint.Diagnostic
+	for _, p := range paras {
+		if segmentsContainPlaceholder(p.TextSegments, r.Placeholders) {
+			continue
+		}
+		diags = append(diags, lint.Diagnostic{
+			File:     f.Path,
+			Line:     p.Line,
+			Column:   1,
+			RuleID:   r.ID(),
+			RuleName: r.Name(),
+			Severity: lint.Warning,
+			Message:  "emphasis used instead of a heading",
+		})
+	}
+	return diags
 }
 
 // CheckNode implements rule.NodeChecker.
@@ -83,6 +118,26 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 		Severity: lint.Warning,
 		Message:  "emphasis used instead of a heading",
 	}}
+}
+
+// segmentsContainPlaceholder mirrors emphasisContainsPlaceholder for the
+// parse-skipped path: it accumulates the emphasis's Text segments in order
+// and tests placeholders.ContainsBodyToken on each growing prefix, stopping
+// at the first match — the identical incremental semantics the AST walk
+// applies as it visits each Text child. No placeholder tokens means no
+// suppression, matching the AST helper's empty-token early return.
+func segmentsContainPlaceholder(segs, toks []string) bool {
+	if len(toks) == 0 {
+		return false
+	}
+	var sb strings.Builder
+	for _, seg := range segs {
+		sb.WriteString(seg)
+		if placeholders.ContainsBodyToken(sb.String(), toks) {
+			return true
+		}
+	}
+	return false
 }
 
 func emphasisContainsPlaceholder(n ast.Node, src []byte, toks []string) bool {

--- a/internal/rules/noemphasisasheading/rule.go
+++ b/internal/rules/noemphasisasheading/rule.go
@@ -38,42 +38,51 @@ func (r *Rule) Category() string { return "heading" }
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
-	// nodes, so serve from the Layer 1 whole-paragraph-emphasis index,
+	// nodes, so drive the per-block dispatch over the Layer 0 block scan,
 	// which the corpus equivalence harness pins byte-identical to the
 	// lone-emphasis-child result this rule reads from the tree.
 	if f.AST == nil {
-		return r.checkFromIndex(f)
+		return rule.WalkBlocks(r, f)
 	}
 	return rule.WalkNodes(r, f)
 }
 
-// checkFromIndex reports one diagnostic per Layer 1 emphasis paragraph,
-// applying the same placeholder suppression the AST path applies. A
-// lone-emphasis paragraph never starts with `|`, so it can never be a
-// GFM table; the AST path's table guard is therefore vacuous here and
-// needs no counterpart.
-func (r *Rule) checkFromIndex(f *lint.File) []lint.Diagnostic {
-	paras := lint.WholeParagraphEmphasis(f)
-	if len(paras) == 0 {
+// CheckBlock implements rule.BlockChecker. It is invoked once per
+// BlockParagraph span on the parse-skipped path. A paragraph is flagged
+// when its inline content (parsed in isolation by the Layer 1 detector) is
+// a single emphasis span, unless the emphasis text holds a configured
+// placeholder token. A lone-emphasis paragraph never starts with `|`, so it
+// can never be a GFM table; the AST path's table guard is therefore vacuous
+// here and needs no counterpart.
+func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
+	p, ok := lint.LoneEmphasisParagraph(f, span)
+	if !ok {
 		return nil
 	}
-	var diags []lint.Diagnostic
-	for _, p := range paras {
-		if segmentsContainPlaceholder(p.TextSegments, r.Placeholders) {
-			continue
-		}
-		diags = append(diags, lint.Diagnostic{
-			File:     f.Path,
-			Line:     p.Line,
-			Column:   1,
-			RuleID:   r.ID(),
-			RuleName: r.Name(),
-			Severity: lint.Warning,
-			Message:  "emphasis used instead of a heading",
-		})
+	if segmentsContainPlaceholder(p.TextSegments, r.Placeholders) {
+		return nil
 	}
-	return diags
+	return []lint.Diagnostic{{
+		File:     f.Path,
+		Line:     p.Line,
+		Column:   1,
+		RuleID:   r.ID(),
+		RuleName: r.Name(),
+		Severity: lint.Warning,
+		Message:  "emphasis used instead of a heading",
+	}}
 }
+
+// blockKinds is the static block-kind interest CheckBlock declares via
+// rule.BlockChecker; package-level so BlockKinds returns it without
+// allocating. Emphasis-as-heading is a paragraph-only shape.
+var blockKinds = []lint.BlockKind{lint.BlockParagraph}
+
+// BlockKinds implements rule.BlockChecker: CheckBlock reacts only to
+// paragraph spans.
+func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
+
+var _ rule.BlockChecker = (*Rule)(nil)
 
 // CheckNode implements rule.NodeChecker.
 func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {

--- a/internal/rules/noemphasisasheading/rule_test.go
+++ b/internal/rules/noemphasisasheading/rule_test.go
@@ -196,3 +196,39 @@ func TestCheck_TableShapedSingleEmphasisLine_NotFlagged(t *testing.T) {
 	diags := r.Check(f)
 	require.Empty(t, diags, "table-shaped emphasis line must not be flagged")
 }
+
+// TestCheck_NilASTEquivalence pins the parse-skipped path (f.AST nil,
+// served from the Layer 1 whole-paragraph-emphasis index) byte-identical
+// to the AST path across emphasis-as-heading shapes, including the
+// placeholder suppression.
+func TestCheck_NilASTEquivalence(t *testing.T) {
+	cases := []struct {
+		name         string
+		src          string
+		placeholders []string
+	}{
+		{"bold-heading", "**Bold text**\n", nil},
+		{"italic-heading", "*Italic text*\n", nil},
+		{"underscore-heading", "_Italic_\n", nil},
+		{"inline-emphasis-ok", "Some **bold** text here.\n", nil},
+		{"plain-ok", "just plain text\n", nil},
+		{"two-paragraphs", "*one*\n\nplain\n\n**two**\n", nil},
+		{"emphasis-then-text", "*emphasis* and more\n", nil},
+		{"leading-spaces", "   *emphasis*\n", nil},
+		{"multiline-emphasis", "*emphasis\ncontinued*\n", nil},
+		{"placeholder-question", "*?*\n", []string{"?"}},
+		{"placeholder-ellipsis", "*...*\n", []string{"..."}},
+		{"placeholder-no-match", "*real heading*\n", []string{"?"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			astFile, err := lint.NewFile("test.md", []byte(tc.src))
+			require.NoError(t, err)
+			lineFile := lint.NewFileLines("test.md", []byte(tc.src))
+			r1 := &Rule{Placeholders: tc.placeholders}
+			r2 := &Rule{Placeholders: tc.placeholders}
+			assert.Equal(t, r1.Check(astFile), r2.Check(lineFile),
+				"nil-AST diagnostics diverge from AST path")
+		})
+	}
+}

--- a/internal/rules/noemphasisasheading/rule_test.go
+++ b/internal/rules/noemphasisasheading/rule_test.go
@@ -219,6 +219,10 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"placeholder-question", "*?*\n", []string{"?"}},
 		{"placeholder-ellipsis", "*...*\n", []string{"..."}},
 		{"placeholder-no-match", "*real heading*\n", []string{"?"}},
+		{"blockquote-emph", "> *just emphasis*\n", nil},
+		{"wrapped-emph-quote", "> *just\n> emph*\n", nil},
+		{"multi-bq-emph", "> *a*\n>\n> *b*\n", nil},
+		{"list-emph-not-flagged", "- *x*\n", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/noemphasisasheading/rule_test.go
+++ b/internal/rules/noemphasisasheading/rule_test.go
@@ -165,6 +165,14 @@ func TestSettingMergeMode_NoEmphasisAsHeading(t *testing.T) {
 	assert.Equal(t, rule.MergeReplace, r.SettingMergeMode("unknown"))
 }
 
+// TestInlineCapable_NoEmphasisAsHeading covers the InlineCapable method
+// (line 52 of rule.go), which is called only by the engine's nil-AST
+// dispatcher and is otherwise skipped by direct Check() calls in unit tests.
+func TestInlineCapable_NoEmphasisAsHeading(t *testing.T) {
+	r := &Rule{}
+	assert.True(t, r.InlineCapable())
+}
+
 // --- Issue #320: emphasis inside a table cell is intentional inline styling ---
 
 func TestCheck_EmphasisInsideTable_NotFlagged(t *testing.T) {
@@ -224,6 +232,11 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"multi-bq-emph", "> *a*\n>\n> *b*\n", nil},
 		{"list-emph-not-flagged", "- *x*\n", nil},
 		{"emph-then-html-block", "*emph*\n<div>x</div>\n", nil},
+		// var-token placeholder suppresses the lone-emphasis diagnostic on
+		// the nil-AST path: exercises segmentsContainPlaceholder return-true
+		// (lines 145-147), the checkFromInline continue (lines 68-69), and
+		// the empty-diags early-return (lines 81-83) in rule.go.
+		{"var-token-suppressed", "*{draft}*\n", []string{"var-token"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/noemphasisasheading/rule_test.go
+++ b/internal/rules/noemphasisasheading/rule_test.go
@@ -223,6 +223,7 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"wrapped-emph-quote", "> *just\n> emph*\n", nil},
 		{"multi-bq-emph", "> *a*\n>\n> *b*\n", nil},
 		{"list-emph-not-flagged", "- *x*\n", nil},
+		{"emph-then-html-block", "*emph*\n<div>x</div>\n", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/noemptyalttext/rule.go
+++ b/internal/rules/noemptyalttext/rule.go
@@ -30,59 +30,27 @@ func (r *Rule) Category() string { return "accessibility" }
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
-	// nodes, so drive the per-block dispatch over the Layer 0 block scan:
-	// each inline-bearing span is parsed in isolation and the same Image
-	// logic runs over it, with span-local segment offsets mapped back to
-	// the document. Re-using goldmark's parser per span keeps the flagged
-	// empty-alt set byte-identical to the AST path.
+	// nodes, so serve from the shared run-grouped inline parse: the same
+	// Image logic runs over every parsed run, with run-local segment
+	// offsets mapped back to the document. Re-using goldmark's parser
+	// keeps the flagged empty-alt set byte-identical to the AST path.
 	if f.AST == nil {
-		return rule.WalkBlocks(r, f)
+		var diags []lint.Diagnostic
+		lint.WalkInlineNodes(f, func(n ast.Node, base int) {
+			if d, ok := r.checkImage(n, f, base); ok {
+				diags = append(diags, d)
+			}
+		})
+		return diags
 	}
 	return rule.WalkNodes(r, f)
 }
 
-// CheckBlock implements rule.BlockChecker. It parses the span's own source
-// bytes in isolation and applies the per-Image empty-alt check, mapping
-// span-local segment offsets to the document via the span's start offset.
-func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
-	start := f.LineStartOffset(span.Start - 1)
-	end := f.LineEndOffset(span.End - 1)
-	if end <= start {
-		return nil
-	}
-	doc := lint.ParseInline(f.Source[start:end])
-	var diags []lint.Diagnostic
-	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		if d, ok := r.checkImage(n, f, start); ok {
-			diags = append(diags, d)
-		}
-		return ast.WalkContinue, nil
-	})
-	if len(diags) == 0 {
-		return nil
-	}
-	return diags
-}
+// InlineCapable implements rule.InlineChecker: Check serves the nil-AST
+// path from lint.WalkInlineNodes (which reads lint.InlineBlocks).
+func (r *Rule) InlineCapable() bool { return true }
 
-// blockKinds is the static block-kind interest CheckBlock declares via
-// rule.BlockChecker; package-level so BlockKinds returns it without
-// allocating. An image can appear in body text under any of these block
-// kinds.
-var blockKinds = []lint.BlockKind{
-	lint.BlockParagraph,
-	lint.BlockATXHeading,
-	lint.BlockSetextHeading,
-	lint.BlockList,
-	lint.BlockQuote,
-}
-
-// BlockKinds implements rule.BlockChecker.
-func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
-
-var _ rule.BlockChecker = (*Rule)(nil)
+var _ rule.InlineChecker = (*Rule)(nil)
 
 // CheckNode implements rule.NodeChecker. On the AST path segment offsets
 // are already document-absolute, so the base offset is zero.

--- a/internal/rules/noemptyalttext/rule.go
+++ b/internal/rules/noemptyalttext/rule.go
@@ -29,48 +29,110 @@ func (r *Rule) Category() string { return "accessibility" }
 // this rule into one shared AST walk; a direct call still works via
 // rule.WalkNodes.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
+	// On the parse-skipped path (f.AST nil) the AST walk surfaces no
+	// nodes, so drive the per-block dispatch over the Layer 0 block scan:
+	// each inline-bearing span is parsed in isolation and the same Image
+	// logic runs over it, with span-local segment offsets mapped back to
+	// the document. Re-using goldmark's parser per span keeps the flagged
+	// empty-alt set byte-identical to the AST path.
+	if f.AST == nil {
+		return rule.WalkBlocks(r, f)
+	}
 	return rule.WalkNodes(r, f)
 }
 
-// CheckNode implements rule.NodeChecker.
+// CheckBlock implements rule.BlockChecker. It parses the span's own source
+// bytes in isolation and applies the per-Image empty-alt check, mapping
+// span-local segment offsets to the document via the span's start offset.
+func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
+	start := f.LineStartOffset(span.Start - 1)
+	end := f.LineEndOffset(span.End - 1)
+	if end <= start {
+		return nil
+	}
+	doc := lint.ParseInline(f.Source[start:end])
+	var diags []lint.Diagnostic
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if d, ok := r.checkImage(n, f, start); ok {
+			diags = append(diags, d)
+		}
+		return ast.WalkContinue, nil
+	})
+	if len(diags) == 0 {
+		return nil
+	}
+	return diags
+}
+
+// blockKinds is the static block-kind interest CheckBlock declares via
+// rule.BlockChecker; package-level so BlockKinds returns it without
+// allocating. An image can appear in body text under any of these block
+// kinds.
+var blockKinds = []lint.BlockKind{
+	lint.BlockParagraph,
+	lint.BlockATXHeading,
+	lint.BlockSetextHeading,
+	lint.BlockList,
+	lint.BlockQuote,
+}
+
+// BlockKinds implements rule.BlockChecker.
+func (r *Rule) BlockKinds() []lint.BlockKind { return blockKinds }
+
+var _ rule.BlockChecker = (*Rule)(nil)
+
+// CheckNode implements rule.NodeChecker. On the AST path segment offsets
+// are already document-absolute, so the base offset is zero.
 func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnostic {
 	if !entering {
 		return nil
 	}
+	if d, ok := r.checkImage(n, f, 0); ok {
+		return []lint.Diagnostic{d}
+	}
+	return nil
+}
+
+var _ rule.NodeChecker = (*Rule)(nil)
+
+// checkImage emits a diagnostic when n is an image with empty (or
+// whitespace-only) alt text. base is added to the node's segment-local
+// offsets to recover document-absolute positions: zero on the AST path,
+// the span's start offset on the per-block path.
+func (r *Rule) checkImage(n ast.Node, f *lint.File, base int) (lint.Diagnostic, bool) {
 	img, ok := n.(*ast.Image)
 	if !ok {
-		return nil
+		return lint.Diagnostic{}, false
 	}
-	alt := imageAltText(img, f)
-	if strings.TrimSpace(alt) != "" {
-		return nil
+	if strings.TrimSpace(imageAltText(img, f, base)) != "" {
+		return lint.Diagnostic{}, false
 	}
-	line := imageLine(img, f)
-	return []lint.Diagnostic{{
+	return lint.Diagnostic{
 		File:     f.Path,
-		Line:     line,
+		Line:     imageLine(img, f, base),
 		Column:   1,
 		RuleID:   r.ID(),
 		RuleName: r.Name(),
 		Severity: lint.Warning,
 		Message:  "image has empty alt text",
-	}}
+	}, true
 }
 
-var _ rule.NodeChecker = (*Rule)(nil)
-
-func imageAltText(img *ast.Image, f *lint.File) string {
+func imageAltText(img *ast.Image, f *lint.File, base int) string {
 	var b strings.Builder
-	collectText(&b, img, f.Source)
+	collectText(&b, img, f.Source, base)
 	return b.String()
 }
 
-func collectText(b *strings.Builder, n ast.Node, source []byte) {
+func collectText(b *strings.Builder, n ast.Node, source []byte, base int) {
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
 		if t, ok := c.(*ast.Text); ok {
-			b.Write(t.Segment.Value(source))
+			b.Write(source[base+t.Segment.Start : base+t.Segment.Stop])
 		} else {
-			collectText(b, c, source)
+			collectText(b, c, source, base)
 		}
 	}
 }
@@ -85,9 +147,9 @@ func isInlineNode(n ast.Node) bool {
 	return false
 }
 
-func imageLine(img *ast.Image, f *lint.File) int {
+func imageLine(img *ast.Image, f *lint.File, base int) int {
 	// Try child text nodes first for precise position.
-	line := firstTextLine(img, f)
+	line := firstTextLine(img, f, base)
 	if line > 0 {
 		return line
 	}
@@ -98,18 +160,18 @@ func imageLine(img *ast.Image, f *lint.File) int {
 		}
 		lines := p.Lines()
 		if lines != nil && lines.Len() > 0 {
-			return f.LineOfOffset(lines.At(0).Start)
+			return f.LineOfOffset(base + lines.At(0).Start)
 		}
 	}
 	return 1
 }
 
-func firstTextLine(n ast.Node, f *lint.File) int {
+func firstTextLine(n ast.Node, f *lint.File, base int) int {
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
 		if t, ok := c.(*ast.Text); ok {
-			return f.LineOfOffset(t.Segment.Start)
+			return f.LineOfOffset(base + t.Segment.Start)
 		}
-		if line := firstTextLine(c, f); line > 0 {
+		if line := firstTextLine(c, f, base); line > 0 {
 			return line
 		}
 	}

--- a/internal/rules/noemptyalttext/rule_test.go
+++ b/internal/rules/noemptyalttext/rule_test.go
@@ -153,7 +153,7 @@ func TestFirstTextLine(t *testing.T) {
 		txt := ast.NewText()
 		txt.Segment = text.NewSegment(0, 1)
 		p.AppendChild(p, txt)
-		assert.Equal(t, 1, firstTextLine(p, f))
+		assert.Equal(t, 1, firstTextLine(p, f, 0))
 	})
 	t.Run("nested Text via Link", func(t *testing.T) {
 		p := ast.NewParagraph()
@@ -162,10 +162,42 @@ func TestFirstTextLine(t *testing.T) {
 		txt.Segment = text.NewSegment(7, 8) // points into line 3
 		link.AppendChild(link, txt)
 		p.AppendChild(p, link)
-		assert.Equal(t, 3, firstTextLine(p, f))
+		assert.Equal(t, 3, firstTextLine(p, f, 0))
 	})
 	t.Run("no descendant text returns zero", func(t *testing.T) {
 		p := ast.NewParagraph()
-		assert.Equal(t, 0, firstTextLine(p, f))
+		assert.Equal(t, 0, firstTextLine(p, f, 0))
 	})
+}
+
+// TestCheck_NilASTEquivalence pins the parse-skipped path (f.AST nil,
+// served from the Layer 1 per-block inline parse) byte-identical to the
+// AST path across image shapes and block contexts.
+func TestCheck_NilASTEquivalence(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"empty-alt", "![](img.png)\n"},
+		{"good-alt", "![a cat](img.png)\n"},
+		{"whitespace-alt", "![   ](img.png)\n"},
+		{"empty-in-prose", "see ![](img.png) here\n"},
+		{"empty-in-list", "- item ![](img.png)\n- ok ![alt](x.png)\n"},
+		{"empty-in-heading", "# title ![](img.png)\n"},
+		{"empty-in-quote", "> quote ![](img.png)\n"},
+		{"two-empty", "![](a.png) and ![](b.png)\n"},
+		{"empty-multiline-para", "text\n![](img.png)\n"},
+		{"linked-image-empty", "[![](img.png)](dest)\n"},
+		{"no-image", "just text\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			astFile, err := lint.NewFile("test.md", []byte(tc.src))
+			require.NoError(t, err)
+			lineFile := lint.NewFileLines("test.md", []byte(tc.src))
+			r := &Rule{}
+			assert.Equal(t, r.Check(astFile), r.Check(lineFile),
+				"nil-AST diagnostics diverge from AST path")
+		})
+	}
 }

--- a/internal/rules/noemptyalttext/rule_test.go
+++ b/internal/rules/noemptyalttext/rule_test.go
@@ -188,6 +188,8 @@ func TestCheck_NilASTEquivalence(t *testing.T) {
 		{"two-empty", "![](a.png) and ![](b.png)\n"},
 		{"empty-multiline-para", "text\n![](img.png)\n"},
 		{"linked-image-empty", "[![](img.png)](dest)\n"},
+		{"ref-image-empty", "![][ref]\n\n[ref]: http://x/y.png\n"},
+		{"wrapped-image-list", "- ![\n  ](img.png)\n"},
 		{"no-image", "just text\n"},
 	}
 	for _, tc := range cases {

--- a/internal/rules/noemptyalttext/rule_test.go
+++ b/internal/rules/noemptyalttext/rule_test.go
@@ -170,6 +170,27 @@ func TestFirstTextLine(t *testing.T) {
 	})
 }
 
+// TestInlineCapable_NoEmptyAltText covers the InlineCapable method (line 51
+// of rule.go), which is called only by the engine's nil-AST dispatcher and
+// is otherwise skipped by direct Check() calls in unit tests.
+func TestInlineCapable_NoEmptyAltText(t *testing.T) {
+	r := &Rule{}
+	assert.True(t, r.InlineCapable())
+}
+
+// TestImageLine_FallbackOne covers the return-1 fallback in imageLine
+// (line 134 of rule.go): an image inside a synthetic paragraph that has no
+// Lines() causes the ancestor walk to exhaust without finding a block offset,
+// so imageLine returns the document-start sentinel 1.
+func TestImageLine_FallbackOne(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("# X\n"))
+	require.NoError(t, err)
+	img := ast.NewImage(ast.NewLink())
+	para := ast.NewParagraph() // no Lines set — walk exhausts without match
+	para.AppendChild(para, img)
+	assert.Equal(t, 1, imageLine(img, f, 0))
+}
+
 // TestCheck_NilASTEquivalence pins the parse-skipped path (f.AST nil,
 // served from the Layer 1 per-block inline parse) byte-identical to the
 // AST path across image shapes and block contexts.

--- a/plan/2606141904_lazy-parse-inline-index.md
+++ b/plan/2606141904_lazy-parse-inline-index.md
@@ -97,30 +97,78 @@ Done:
       equivalence test now green with MDS047/MDS054
       enabled.
 
-Deferred to a follow-up (needs the link / image /
-autolink / raw-HTML / emphasis scanner, a much larger and
-higher-risk surface):
+This branch re-backs the hybrid inline rules via a
+**per-block lazy parse**, not a bespoke
+link/image/autolink/raw-HTML byte scanner.
+`lint.ParseInline` re-parses each Layer 0 span with
+goldmark's own parser. The inline tree is then
+byte-identical by construction. The cost stays proportional
+to the inline-bearing blocks. Each rule maps the
+block-local segment offsets back to the document with the
+span's start offset. The NodeChecker rules implement
+`rule.BlockChecker`, so the engine's nil-AST block-span
+dispatch drives them.
 
-- [ ] Re-back the hybrid inline rules that walk inline AST
-      nodes: `no-bare-urls` (MDS012), `no-empty-alt-text`
-      (MDS032), `no-inline-html` (MDS041),
-      `no-space-in-code-spans` (MDS052), `link-validity`
-      (MDS062), and the remaining reference rules.
-- [ ] Bounded whole-paragraph-emphasis detector for
-      `no-emphasis-as-heading` (MDS018) and the per-block
-      Layer 2 fallback.
-- [ ] `LinkReferences` re-backed on the index.
+Done (this branch):
+
+- [x] `no-emphasis-as-heading` (MDS018): bounded
+      whole-paragraph-emphasis detector
+      ([inline_emphasis.go][newfile-emph]) parses only the
+      paragraphs whose first non-space byte is `*` or `_`,
+      byte-identical to goldmark's lone-emphasis-child
+      result. This is the per-block fallback the plan calls
+      for. MDS018 implements `rule.BlockChecker`.
+- [x] `no-bare-urls` (MDS012): `CheckBlock` parses each
+      inline-bearing span and applies the Text-node URL
+      check; URLs inside links, autolinks, and code spans
+      are skipped exactly as on the AST path.
+- [x] `no-empty-alt-text` (MDS032): `CheckBlock` parses
+      each span and applies the per-Image empty-alt check
+      with offset remapping.
+- [x] `link-validity` (MDS062): the empty-link check parses
+      each span; the reversed-link check was already
+      byte-level on the re-backed code-span ranges.
+- [x] All four reclassified `A-no-skipping` by the audit;
+      `internal/rulelayer` admits them to Layer 0. Corpus
+      and end-to-end gate equivalence
+      ([inline_rule_equivalence_test.go][newfile-eq])
+      pin every re-backed rule byte-identical to the AST
+      path on the gate-eligible corpus.
+
+Still deferred:
+
+- [ ] `no-inline-html` (MDS041) and `no-space-in-code-spans`
+      (MDS052): both opt-in (not in the parity set), so they
+      do not block the parity gate. MDS052 needs the
+      code-span literal bounds it already reads via the
+      re-backed projection but still walks via `WalkNodes`;
+      MDS041 needs the raw-HTML span projection. Left for a
+      follow-up.
+- [ ] `LinkReferences` re-backed on a byte-level
+      reference-definition scanner. It still parses the
+      whole document once, lazily, the first time a
+      reference rule reads it on a nil-AST file containing
+      `[`. The byte-identity risk (multi-line labels,
+      escaped destinations, titles) matches the link
+      scanner's; the reference rules are already correct and
+      Layer 0 through the lazy parse, so this is the
+      remaining piece to shed that one residual parse.
 
 ## Acceptance Criteria
 
-- [ ] With Layer 0 and Layer 1, the full parity config
-      runs with no whole-document goldmark parse. (Partial:
-      the code-span gap that forced MDS047/MDS054 to AST is
-      closed; the hybrid inline rules above still force a
-      parse.)
-- [ ] `no-emphasis-as-heading` output is byte-identical to
-      its AST path across the corpus and fixtures.
-      (Deferred — see status.)
+- [~] With Layer 0 and Layer 1, the full parity config
+      runs with no whole-document goldmark parse. Every
+      inline parity rule (MDS012/018/032/062, MDS047,
+      MDS054) is now Layer 0. Residual full-document parses
+      remain only for (a) `LinkReferences` on files
+      containing `[` (lazy, on-demand — see status) and (b)
+      the ~20 block-level parity rules (MDS001–011, 014–017,
+      031, …) a sibling Layer 0 block plan owns, not this
+      one. The inline rules no longer force a parse.
+- [x] `no-emphasis-as-heading` output is byte-identical to
+      its AST path across the corpus and fixtures
+      (`TestInlineRuleEquivalence_Corpus`,
+      `TestWholeParagraphEmphasis_Equivalence`).
 - [x] Reference matching is byte-identical to the AST
       path, including case folding, across the corpus.
       MDS054's labels normalize through goldmark's own
@@ -136,6 +184,8 @@ higher-risk surface):
       on commit-signing infra unrelated to this change).
 
 [newfile-idx]: ../internal/lint/inline_index.go
+[newfile-emph]: ../internal/lint/inline_emphasis.go
+[newfile-eq]: ../internal/integration/inline_rule_equivalence_test.go
 [rulelayer]: ../internal/rulelayer/rulelayer.go
 
 [research]: ../docs/research/benchmarks/lazy-parse-architecture.md

--- a/plan/2606141904_lazy-parse-inline-index.md
+++ b/plan/2606141904_lazy-parse-inline-index.md
@@ -98,36 +98,44 @@ Done:
       enabled.
 
 This branch re-backs the hybrid inline rules via a
-**per-block lazy parse**, not a bespoke
+**shared per-block lazy parse**, not a bespoke
 link/image/autolink/raw-HTML byte scanner.
-`lint.ParseInline` re-parses each Layer 0 span with
-goldmark's own parser. The inline tree is then
-byte-identical by construction. The cost stays proportional
-to the inline-bearing blocks. Each rule maps the
-block-local segment offsets back to the document with the
-span's start offset. The NodeChecker rules implement
-`rule.BlockChecker`, so the engine's nil-AST block-span
-dispatch drives them.
+`lint.InlineBlocks` re-parses each contiguous run of
+inline-bearing lines with goldmark's own parser, once per
+file and cached. The inline tree is byte-identical by
+construction. Runs (not single-line Layer 0 spans) keep a
+construct that wraps onto a list or quote continuation line
+whole. The document's link reference definitions are seeded
+into each run's context, so a cross-block `[text][ref]`
+still resolves.
+
+Each rule maps the run-local segment offsets back to the
+document with the run's start offset via
+`lint.WalkInlineNodes`. The NodeChecker rules
+(MDS012/018/032) implement `rule.InlineChecker`. That
+marker routes a NodeChecker to its own `Check` on a nil-AST
+File. `link-validity` (MDS062) is a plain `Check` rule, so
+the engine already calls its `Check` on that path.
 
 Done (this branch):
 
-- [x] `no-emphasis-as-heading` (MDS018): bounded
+- [x] `no-emphasis-as-heading` (MDS018): the
       whole-paragraph-emphasis detector
-      ([inline_emphasis.go][newfile-emph]) parses only the
-      paragraphs whose first non-space byte is `*` or `_`,
-      byte-identical to goldmark's lone-emphasis-child
-      result. This is the per-block fallback the plan calls
-      for. MDS018 implements `rule.BlockChecker`.
-- [x] `no-bare-urls` (MDS012): `CheckBlock` parses each
-      inline-bearing span and applies the Text-node URL
-      check; URLs inside links, autolinks, and code spans
-      are skipped exactly as on the AST path.
-- [x] `no-empty-alt-text` (MDS032): `CheckBlock` parses
-      each span and applies the per-Image empty-alt check
-      with offset remapping.
-- [x] `link-validity` (MDS062): the empty-link check parses
-      each span; the reversed-link check was already
-      byte-level on the re-backed code-span ranges.
+      ([inline_emphasis.go][newfile-emph]) reads the shared
+      run parse and flags every paragraph (including those
+      goldmark nests in a block quote) whose sole inline
+      child is one emphasis span, byte-identical to
+      goldmark's lone-emphasis-child result.
+- [x] `no-bare-urls` (MDS012): the same Text-node URL check
+      runs over the shared run parse; URLs inside links,
+      autolinks, and code spans are skipped exactly as on
+      the AST path.
+- [x] `no-empty-alt-text` (MDS032): the per-Image empty-alt
+      check runs over the shared run parse with offset
+      remapping.
+- [x] `link-validity` (MDS062): the empty-link check runs
+      over the shared run parse; the reversed-link check was
+      already byte-level on the re-backed code-span ranges.
 - [x] All four reclassified `A-no-skipping` by the audit;
       `internal/rulelayer` admits them to Layer 0. Corpus
       and end-to-end gate equivalence

--- a/plan/2606141904_lazy-parse-inline-index.md
+++ b/plan/2606141904_lazy-parse-inline-index.md
@@ -1,7 +1,7 @@
 ---
 id: 2606141904
 title: "Lazy parse: Layer 1 light inline index"
-status: "🔲"
+status: "🔳"
 summary: >-
   Build the byte-level inline index (links, autolinks,
   images, code spans, raw HTML, reference defs and uses)
@@ -63,18 +63,80 @@ normalization as a pure function so the two agree.
    byte is `*` or `_`. The gate then keys on "no
    whole-document parse", not "no Layer 2".
 
+## Implementation Status
+
+This plan landed a first slice. The inline index now scans
+**code spans**. It re-backs the two rules whose only AST
+need was the code-span projection. The output stays
+byte-identical to the AST path.
+
+Done:
+
+- [x] Byte-level inline scanner for code spans
+      ([inline_index.go][newfile-idx]). It skips lines
+      inside fenced/indented code blocks, HTML blocks,
+      and PI blocks via the Layer 0 scan, reproduces
+      CommonMark's single-space content trim, and derives
+      the literal range the same two-step way goldmark
+      does (content bounds extended over adjacent
+      backticks).
+- [x] [`CodeSpanContentRanges` / `CodeSpanLiteralRanges`][newfile]
+      re-backed on the index for the nil-AST path.
+- [x] Reference-label normalization: goldmark already
+      exports the pure `util.ToLinkReference` (case fold +
+      whitespace collapse); MDS054 already calls it, so no
+      lift was needed.
+- [x] MDS047 (ambiguous-emphasis) and MDS054
+      (no-undefined-reference-labels) promoted from the
+      `astProjectionConsumers` AST override to Layer 0 in
+      [`internal/rulelayer`][rulelayer]; the parse-skip
+      gate now admits them.
+- [x] Corpus equivalence guards: a Layer 1 code-span
+      equivalence test over every parse-skip-eligible
+      corpus file, and the existing Layer 0 corpus gate
+      equivalence test now green with MDS047/MDS054
+      enabled.
+
+Deferred to a follow-up (needs the link / image /
+autolink / raw-HTML / emphasis scanner, a much larger and
+higher-risk surface):
+
+- [ ] Re-back the hybrid inline rules that walk inline AST
+      nodes: `no-bare-urls` (MDS012), `no-empty-alt-text`
+      (MDS032), `no-inline-html` (MDS041),
+      `no-space-in-code-spans` (MDS052), `link-validity`
+      (MDS062), and the remaining reference rules.
+- [ ] Bounded whole-paragraph-emphasis detector for
+      `no-emphasis-as-heading` (MDS018) and the per-block
+      Layer 2 fallback.
+- [ ] `LinkReferences` re-backed on the index.
+
 ## Acceptance Criteria
 
 - [ ] With Layer 0 and Layer 1, the full parity config
-      runs with no whole-document goldmark parse.
+      runs with no whole-document goldmark parse. (Partial:
+      the code-span gap that forced MDS047/MDS054 to AST is
+      closed; the hybrid inline rules above still force a
+      parse.)
 - [ ] `no-emphasis-as-heading` output is byte-identical to
       its AST path across the corpus and fixtures.
-- [ ] Reference matching is byte-identical to the AST
+      (Deferred — see status.)
+- [x] Reference matching is byte-identical to the AST
       path, including case folding, across the corpus.
-- [ ] All existing rule fixtures pass unchanged.
+      MDS054's labels normalize through goldmark's own
+      `util.ToLinkReference`, and the Layer 0 corpus gate
+      equivalence test passes with it enabled.
+- [x] All existing rule fixtures pass unchanged.
 - [ ] `mdsmith check -c parity` beats gomarklint on
-      benchmark 2.
-- [ ] All tests pass: `go test ./...`
+      benchmark 2. (Not measured here; the parity rule set
+      still forces a parse via the deferred hybrid rules,
+      so the benchmark gain awaits the follow-up.)
+- [x] All tests pass: `go test ./...` (excluding the
+      pre-existing `internal/release` PGO tests, which fail
+      on commit-signing infra unrelated to this change).
+
+[newfile-idx]: ../internal/lint/inline_index.go
+[rulelayer]: ../internal/rulelayer/rulelayer.go
 
 [research]: ../docs/research/benchmarks/lazy-parse-architecture.md
 [newfile]: ../internal/lint/file.go


### PR DESCRIPTION
## Summary

Consolidated PR for the **Layer 1 lazy-parse inline index** — all changes from the former stack (#631 code-span index + #632 full inline index) that are **not yet on `main`**, now rebased into a single branch off `main`. The Layer 0 dependencies (#628, #630) have already merged to `main`; this PR is the remaining inline work, implementing plan `2606141904_lazy-parse-inline-index.md`.

Re-backs the hybrid inline rules so they no longer force a whole-document goldmark parse on the parse-skipped path, and promotes them to Layer 0.

Rather than hand-write a byte-for-byte link/image/autolink/raw-HTML scanner (deep, high-divergence-risk), the nil-AST path re-parses the document one **run of inline-bearing lines at a time** with goldmark's own parser (`lint.InlineBlocks`), once per file and cached. The inline tree is byte-identical by construction; each rule maps run-local segment offsets back to the document with the run's start offset via `lint.WalkInlineNodes`.

## What changed

**Code-span index (formerly #631):**
- Byte-level inline scanner (`internal/lint/inline_index.go`) that locates inline code spans without a goldmark parse, mirroring CommonMark's single-space trim and goldmark's literal-range derivation. Closes the code-span gap that forced **MDS047** (ambiguous-emphasis) and **MDS054** (no-undefined-reference-labels) to the AST; both resolve to **Layer 0**.

**Full inline index (tasks 2–6 of the plan):**
- **Task 2 (normalization):** Confirmed `util.ToLinkReference` is the single shared reference-label normalizer (case fold + whitespace collapse) already used everywhere. No duplication to remove.
- **Task 3 — shared inline projection (`lint.InlineBlocks`):** Groups maximal contiguous inline-bearing line **runs** (so a construct wrapping onto a list/quote continuation stays whole), seeds the document's link reference definitions into each run's parse context (so cross-block `[text][ref]` / `[alt][ref]` resolves exactly as the whole-document parse does, gated by a cheap `]:` byte check), and parses each run through one shared per-file arena.
- **Task 3/4 — re-backed rules:** **MDS012 (no-bare-urls)**, **MDS032 (no-empty-alt-text)**, **MDS062 (link-validity)** empty-link check, and **MDS018 (no-emphasis-as-heading)** read the shared run parse via `WalkInlineNodes` / `WholeParagraphEmphasis` with offset remapping. The three NodeChecker rules implement the new `rule.InlineChecker` marker so the engine routes them on a nil-AST File.
- **Task 5/6 (emphasis):** `WholeParagraphEmphasis` flags every paragraph (including block-quote-nested) whose sole inline child is one emphasis span, byte-identical to goldmark's lone-emphasis-child result.
- **Audit + rulelayer:** regenerated `rule_walk_audit.json` — MDS012/018/032/047/054/062 now `A-no-skipping`, admitted to Layer 0.

## Tests

- Per-rule `TestCheck_NilASTEquivalence` (AST vs nil-AST) for MDS012/018/032/062, covering blockquote, list, wrapped continuation, cross-block reference link/image, and HTML-block boundary shapes.
- `internal/lint`: `TestWholeParagraphEmphasis_Equivalence`, `TestInlineBlocks_RunGrouping` / `_Memoized` / `_RefDefGate`, `TestParseInlineWithRefs_ResolvesCrossBlockReference`, `TestWalkInlineNodes_OffsetMapping`, code-span index equivalence.
- `internal/checker`: `TestCheckRulesWithIntraFile_inlineChecker{NilAST,ASTPath}`.
- `internal/integration`: corpus AST-vs-nil-AST equivalence for every parse-skip-eligible file across all rules; `TestLayer0Gate_CorpusDiagnosticsEquivalence` green (real engine, skip-on vs skip-off).
- `go test ./...` passes except the pre-existing `internal/release` PGO tests (need a signing server; fail identically on `main`).

## Review

Three sequential xhigh code-review rounds during development. Round 1 found three real correctness regressions in an earlier per-span approach (missed blockquote emphasis, cross-block reference links/images, markup wrapping a list/quote continuation); all fixed by switching to the shared run-grouped, reference-seeded projection. Round 2 fixed a latent `ast.String` panic path and added the arena. Round 3 returned no findings.

## Deferred

- `no-inline-html` (MDS041) and `no-space-in-code-spans` (MDS052): opt-in, not in the parity set.
- A byte-level reference-definition scanner to shed the one residual `LinkReferences` parse for files containing `]:`.
- The "no whole-document parse for full parity" criterion also depends on ~20 block-level parity rules owned by a sibling Layer 0 block plan.

---
_Supersedes the former stacked PR #631 (its commits are included here)._

https://claude.ai/code/session_01NdexqYtbBjQhGMq3VGt1s7