### PR TITLE
perf: vectorize whole-buffer byte scans with bytes.IndexByte/Count + document the lesson

### DIFF
--- a/docs/development/high-performance-go.md
+++ b/docs/development/high-performance-go.md
@@ -172,6 +172,13 @@ per workspace file.
   copies. `bytes.IndexByte` and `bytes.Contains` are
   SIMD-accelerated on amd64; faster than `strings.*` once
   you already have bytes.
+- **`bytes.IndexByte` over a hand-rolled byte loop or a
+  regex.** The compiler does not vectorize `for i := range
+  b { if b[i]==c }`; `bytes.IndexByte` is SIMD assembly, so
+  use it to scan `[]byte` forward for one byte. `lineIndex`
+  (behind `LineOfOffset`) was ~5% of a parity check on prose
+  as a manual loop; `IndexByte` erased it. Worth it on big
+  `Source` scans, not short per-line or `[]rune` loops.
 - **`strings.Builder` over `+`.** Concatenation in a loop
   allocates a new backing array each time. Call
   `Grow(n)` first if you know the final size.
@@ -184,13 +191,6 @@ per workspace file.
   zero-copy `[]byte`↔`string`. The caller must guarantee
   the source isn't mutated and outlives the view. Use
   sparingly, with a comment naming the invariant.
-
-### Fixed-string search beats regex
-
-`bytes.IndexByte('#')` is a hardware-assisted single-byte
-scan. `regexp.MustCompile("#").FindIndex` builds an NFA
-and walks it. For anything expressible as a literal,
-substring, or prefix/suffix check, skip `regexp`.
 
 ### Data structures
 

--- a/internal/index/build.go
+++ b/internal/index/build.go
@@ -255,13 +255,9 @@ func lineOfOffset(source []byte, offset int) int {
 	if offset > len(source) {
 		offset = len(source)
 	}
-	line := 1
-	for i := 0; i < offset; i++ {
-		if source[i] == '\n' {
-			line++
-		}
-	}
-	return line
+	// bytes.Count special-cases a one-byte separator to a SIMD byte count;
+	// a hand-rolled scan loop is not vectorized.
+	return 1 + bytes.Count(source[:offset], []byte{'\n'})
 }
 
 // frontMatterAll walks the front-matter YAML once and returns the

--- a/internal/linkgraph/directives.go
+++ b/internal/linkgraph/directives.go
@@ -1,6 +1,7 @@
 package linkgraph
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
@@ -265,11 +266,7 @@ func lineOfOffset(source []byte, offset int) int {
 	if offset > len(source) {
 		offset = len(source)
 	}
-	line := 1
-	for i := 0; i < offset; i++ {
-		if source[i] == '\n' {
-			line++
-		}
-	}
-	return line
+	// bytes.Count special-cases a one-byte separator to a SIMD byte count;
+	// a hand-rolled scan loop is not vectorized.
+	return 1 + bytes.Count(source[:offset], []byte{'\n'})
 }

--- a/internal/lint/linkrefscan.go
+++ b/internal/lint/linkrefscan.go
@@ -164,11 +164,16 @@ func buildLineSegments(source []byte) []text.Segment {
 	n := bytes.Count(source, lineIndexNewline) + 1
 	segs := make([]text.Segment, 0, n)
 	start := 0
-	for i := 0; i < len(source); i++ {
-		if source[i] == '\n' {
-			segs = append(segs, text.NewSegment(start, i+1))
-			start = i + 1
+	// bytes.IndexByte is SIMD-accelerated; a hand-rolled byte loop is not
+	// vectorized. Walk newline to newline over the (whole-document) source.
+	for {
+		i := bytes.IndexByte(source[start:], '\n')
+		if i < 0 {
+			break
 		}
+		nl := start + i
+		segs = append(segs, text.NewSegment(start, nl+1))
+		start = nl + 1
 	}
 	if start < len(source) {
 		segs = append(segs, text.NewSegment(start, len(source)))

--- a/internal/rename/rename.go
+++ b/internal/rename/rename.go
@@ -413,13 +413,9 @@ func lineOfBodyOffset(body []byte, off int) int {
 	if off > len(body) {
 		off = len(body)
 	}
-	line := 1
-	for i := 0; i < off; i++ {
-		if body[i] == '\n' {
-			line++
-		}
-	}
-	return line
+	// bytes.Count special-cases a one-byte separator to a SIMD byte count;
+	// a hand-rolled scan loop is not vectorized.
+	return 1 + bytes.Count(body[:off], []byte{'\n'})
 }
 
 // bodyLineIndex precomputes every line-start offset so a rename

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -460,14 +460,23 @@ func collectRefDefLines(source []byte) map[int]struct{} {
 	lines := make(map[int]struct{})
 	lineNum := 1
 	start := 0
-	for i := 0; i <= len(source); i++ {
-		if i == len(source) || source[i] == '\n' {
-			if refDefLineStarts(source, start, i) {
-				lines[lineNum] = struct{}{}
-			}
-			lineNum++
-			start = i + 1
+	// Walk line by line with bytes.IndexByte (SIMD) rather than a
+	// non-vectorized byte-at-a-time scan; the final iteration (no newline)
+	// processes the trailing segment, matching the old i==len(source) case.
+	for start <= len(source) {
+		nl := bytes.IndexByte(source[start:], '\n')
+		end := len(source)
+		if nl >= 0 {
+			end = start + nl
 		}
+		if refDefLineStarts(source, start, end) {
+			lines[lineNum] = struct{}{}
+		}
+		lineNum++
+		if nl < 0 {
+			break
+		}
+		start = end + 1
 	}
 	return lines
 }


### PR DESCRIPTION
## Summary

Follow-up to #641, which found that `lineIndex`'s hand-rolled newline loop was ~5% of a parity check on long prose: the Go compiler does **not** vectorize a `for i := range b { if b[i]==c }` scan, while `bytes.IndexByte`/`bytes.Count` are SIMD assembly. This (a) documents the lesson and (b) applies it to the other whole-buffer single-byte scans.

## Documentation

`docs/development/high-performance-go.md` gains a **"`bytes.IndexByte` over a hand-rolled byte loop"** note in the Strings/bytes section, scoped to sizeable `[]byte` scans (explicitly *not* short per-line or `[]rune` loops, which are below the call-overhead break-even). It folds in the old "fixed-string search beats regex" subsection so the file stays within its MDS022 length budget.

## Code — each byte-identical, gated by existing tests + the corpus equivalence suite

| Site | Was | Now |
| --- | --- | --- |
| `lint.buildLineSegments` | byte-at-a-time newline collection over whole-document source | `bytes.IndexByte` walk |
| `index` / `linkgraph` / `rename` `lineOfOffset` | count newlines up to an offset with a manual loop | `bytes.Count` (one-byte-separator SIMD fast path) |
| `noundefinedreferencelabels.collectRefDefLines` | whole-source line iterator, byte-at-a-time | `bytes.IndexByte` walk (trailing-segment case matches the old `i==len(source)` branch) |

`lineIndex` itself is already vectorized in #641; `nounusedlinkdefinitions` has only single-byte boundary checks (no scan loop) and is untouched. Short per-line/per-token loops are deliberately left alone per the documented break-even.

All packages build, their tests pass, and `gofmt`/`go vet` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt)_