### PR TITLE
perf: let the Layer-0 parse-skip engage on code-bearing files

### DIFF
--- a/internal/engine/layer0_gate_test.go
+++ b/internal/engine/layer0_gate_test.go
@@ -161,12 +161,14 @@ func TestLayer0Gate_DiagnosticsMatchFullParse(t *testing.T) {
 		"Layer 0 parse-skip must produce identical diagnostics to a full parse")
 }
 
-// TestLayer0Gate_CodeBlockForcesParse proves the SourceMayHaveCodeBlock
-// guard: the Layer 0 scanner does not descend into a list item's content, so
-// a file that may hold a code block (here a hard tab — also a fence or a
-// four-space indent) forces the full parse rather than risk a CodeBlockLines
-// divergence, even when every enabled rule is otherwise Layer 0.
-func TestLayer0Gate_CodeBlockForcesParse(t *testing.T) {
+// TestLayer0Gate_CodeBlockSkipsParse proves the parse-skip now engages on
+// code-bearing files. The old SourceMayHaveCodeBlock guard bailed on any
+// code marker (here a hard tab — also a fence or a four-space indent) to
+// avoid a CodeBlockLines divergence; the skip File now carries the flat
+// ClassifyLines projection (gated byte-identical to the AST on code-bearing
+// corpus files), so a code marker no longer forces the parse when every
+// enabled rule is Layer 0.
+func TestLayer0Gate_CodeBlockSkipsParse(t *testing.T) {
 	withLayer0Skip(t, true)
 	dir, path := writeDoc(t, "# Title\n\nA line with a hard\ttab.\n")
 
@@ -182,8 +184,8 @@ func TestLayer0Gate_CodeBlockForcesParse(t *testing.T) {
 	}
 	res := r.Run([]string{path})
 	require.Empty(t, res.Errors)
-	assert.False(t, probe.sawNilAST,
-		"a source that may hold a code block must keep the AST parse")
+	assert.True(t, probe.sawNilAST,
+		"a code-bearing source with only Layer 0 rules must skip the parse")
 }
 
 // TestLayer0Gate_CodeSpanRuleSkipsParse proves the Layer 1 code-span fix

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -458,7 +458,13 @@ func (r *Runner) lintFile(path string, intraFileCap int, cache *lint.RunCache, r
 	var f *lint.File
 	releaseArena := func() {}
 	if r.layer0SkipEligible(source, rr.mdRules, effective) {
-		f = lint.NewFileLinesFromSource(path, source, r.StripFrontMatter)
+		// The parse-skip File carries the flat ClassifyLines projection so
+		// CollectCodeBlockLines serves the classifier (gated byte-identical
+		// to the AST across the corpus, code-bearing files included) rather
+		// than an on-demand scanLayer0; block-span rules still read
+		// Layer0(f).BlockSpans. This is what lets the gate engage on files
+		// with code blocks (see layer0SkipEligible).
+		f, _ = lint.NewFileFlatPooled(path, source, r.StripFrontMatter)
 	} else {
 		f, releaseArena = r.pooledFileConstructor(source)(path, source, r.StripFrontMatter)
 	}
@@ -612,7 +618,7 @@ func layer0SkipEnabled() bool {
 }
 
 // layer0SkipEligible reports whether this file's run can skip the goldmark
-// parse and lint from the Layer 0 scan alone. Four conditions must hold:
+// parse and lint from the Layer 0 scan alone. Three conditions must hold:
 //
 //  1. The MDSMITH_LAYER0_SKIP toggle is set (default off).
 //  2. Every enabled rule resolves to Layer 0 (rulelayer.IsLayer0) — no
@@ -621,12 +627,12 @@ func layer0SkipEnabled() bool {
 //  3. The source carries no `<?` directive marker. Generated-section
 //     suppression walks the AST for processing instructions, so a file
 //     with directives must be parsed.
-//  4. The source may contain no code block (lint.SourceMayHaveCodeBlock is
-//     false). The Layer 0 scanner does not descend into a list item's
-//     content, so a fenced or indented code block inside a list item makes
-//     its CodeBlockLines diverge from the AST; skipping only code-free files
-//     sidesteps that divergence, since a file with no code block has an empty
-//     CodeBlockLines under both paths.
+//
+// Code blocks no longer disqualify the skip: the skip File carries the flat
+// ClassifyLines code-line projection (which handles a fence or indent inside
+// a list item) and the block-span scan, both gated byte-identical to the AST
+// across the corpus's code-bearing files by
+// TestLayer0Gate_CorpusDiagnosticsEquivalence.
 //
 // The block-only and flat-Layer-0 spike flags force their own
 // constructors, so the gate stands down when either is set.
@@ -637,9 +643,6 @@ func (r *Runner) layer0SkipEligible(
 		return false
 	}
 	if bytes.Contains(source, piOpenScan) {
-		return false
-	}
-	if lint.SourceMayHaveCodeBlock(source) {
 		return false
 	}
 	return allEnabledRulesLayer0(rules, effective)

--- a/internal/rules/headingstyle/rule.go
+++ b/internal/rules/headingstyle/rule.go
@@ -56,17 +56,22 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	return r.verdict(f, isATXHeading(heading, f.Source), heading.Level, headingLine(heading, f))
 }
 
-// CheckBlock implements rule.BlockChecker. A heading span's Kind already
-// records its style — BlockATXHeading is exactly the AST path's
-// isATXHeading==true, BlockSetextHeading its false — and span.Start is
-// the heading line (headingLine on the AST path). The ATX level the
-// setext branch needs is the leading-`#` run on that line, which goldmark
-// parses the same way, so the verdict is byte-identical.
+// CheckBlock implements rule.BlockChecker. span.Start is the heading line
+// (headingLine on the AST path); the style and ATX level are read from
+// that line's bytes to match the AST path's isATXHeading and
+// heading.Level exactly, so the verdict is byte-identical.
 func (r *Rule) CheckBlock(span lint.BlockSpan, f *lint.File) []lint.Diagnostic {
-	isATX := span.Kind == lint.BlockATXHeading
+	line := f.Lines[span.Start-1]
+	// Match the AST path's isATXHeading exactly: it tests the first byte of
+	// the heading's source line via lineStartsWithHash and does NOT skip
+	// indentation. A ≤3-space-indented ATX heading is a BlockATXHeading span
+	// (goldmark still parses it as a heading), but MDS002's column-1 test
+	// reads it as non-ATX — so isATX keys off the raw first byte, not the
+	// span kind, to keep the two paths byte-identical.
+	isATX := len(line) > 0 && line[0] == '#'
 	level := 0
 	if isATX {
-		level = atxLevelFromLine(f.Lines[span.Start-1])
+		level = atxLevelFromLine(line)
 	}
 	return r.verdict(f, isATX, level, span.Start)
 }

--- a/internal/rules/headingstyle/rule_test.go
+++ b/internal/rules/headingstyle/rule_test.go
@@ -22,6 +22,11 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 		[]byte("# A\n\nSub heading\n-----------\n\nText\n"),
 		[]byte("###### Deep six\n\nText\n"),
 		[]byte("intro\n\nSetext two\n----------\n"),
+		// A ≤3-space-indented ATX heading: goldmark parses it as a heading
+		// (BlockATXHeading span), but MDS002's column-1 isATX test reads it
+		// as non-ATX. Both paths must agree (regression for the one corpus
+		// divergence the code-file equivalence sweep found).
+		[]byte("# Title\n\n   # Indented\n"),
 	}
 	for _, style := range []string{"atx", "setext"} {
 		for _, src := range srcs {

--- a/plan/2606171258_parity-layer0-parse-skip.md
+++ b/plan/2606171258_parity-layer0-parse-skip.md
@@ -70,16 +70,44 @@ re-parse instead.
 3. Confirm `TestLayer0Gate_CorpusDiagnosticsEquivalence` stays green — it
    enables every Layer-0 rule and diffs parse-skip vs full-parse across
    the corpus, so a divergent rule fails it.
-4. Once the list/quote rules land, drop the gate's code-block guard (the
-   scanner must match the AST on code-in-list first) and re-measure
-   parity vs gomarklint.
+4. ~~Once the list/quote rules land, drop the gate's code-block guard~~
+   Done early — see the measurement below.
+
+## Measurement: the code guard was the wrong fear
+
+A full corpus sweep (1046 files, 453 code-bearing) compared every
+Layer-0 rule's AST output against its nil-AST output, with front matter
+stripped on both sides as the engine does. Result: **one** divergence,
+not the feared code-in-list class. `scanLayer0`'s block spans and the
+flat `ClassifyLines` code-line projection both already match goldmark on
+code, including fences and indents inside list items. The lone
+divergence was MDS002 on a ≤3-space-indented ATX heading: the AST path's
+`lineStartsWithHash` reads column 1 without skipping indent, so it
+flagged a heading scanLayer0 (correctly) treats as ATX. Fixed by keying
+MDS002's `CheckBlock` `isATX` off the raw first byte too.
+
+So the coarse `SourceMayHaveCodeBlock` guard bailed on any fence, tab, or
+four-space run. That was far more conservative than the scanner needed.
+The guard is now gone. The skip File carries the `ClassifyLines`
+projection (via `NewFileFlatPooled`), so code-line rules serve the
+validated classifier. The corpus equivalence gate now engages on
+code-bearing files and stays green.
+
+This does not by itself speed up benchmark 2: `MDSMITH_LAYER0_SKIP` is
+still default-off, and the gate still requires *every* enabled rule to
+be Layer 0 (the remaining migration). But it removes the blocker that
+framed parse-skip on code as a scanner rewrite — it was a one-line rule
+fix plus a guard removal.
 
 ## Result so far
 
-- [x] MDS002 heading-style: reads only `span.Kind` (ATX vs setext) and
-      the leading-`#` level, never the inline tree. `CheckBlock` serves
-      the nil-AST path byte-identically; the corpus gate is green with
-      MDS002 enabled.
+- [x] MDS002 heading-style: reads only the heading line (style + level),
+      never the inline tree. `CheckBlock` serves the nil-AST path
+      byte-identically, including the indented-ATX edge.
+- [x] MDS013, MDS015, MDS044: confirmed byte-identical to the AST on all
+      453 code-bearing corpus files (the sweep above).
+- [x] Code guard removed; skip File carries `ClassifyLines`; the corpus
+      equivalence gate engages on code files and is green.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

Continues the parity Layer-0 migration (#643) by removing the blocker I had wrongly framed as a large, risky scanner rewrite. **It was a one-line rule fix plus a guard removal.**

## The measurement that reframed it

A full corpus sweep — 1046 files, 453 code-bearing — compared every Layer-0 rule's AST output against its nil-AST output, with front matter stripped on both sides exactly as the engine does. Result: **one** divergence, not the feared "code inside a list item" class. `scanLayer0`'s block spans and the flat `ClassifyLines` code-line projection already match goldmark on code — fences and indents inside list items included.

The lone divergence was **MDS002 (heading-style)** on a `   # Heading` (≤3-space-indented ATX). The AST path's `lineStartsWithHash` tests column 1 *without* skipping indent, so it flags a heading `scanLayer0` correctly classifies as ATX. Fixed by keying `CheckBlock`'s `isATX` off the raw first byte too — byte-for-byte with the AST (regression test added).

## The change

- **MDS002 `CheckBlock`**: `isATX` now reads the heading line's first byte (matches `lineStartsWithHash`), closing the one divergence.
- **Removed the `SourceMayHaveCodeBlock` gate guard** — it bailed on any fence/tab/4-space run, far more conservatively than the scanner needs.
- **Skip File now carries the `ClassifyLines` projection** (`NewFileFlatPooled`), so code-line rules serve the validated classifier instead of an on-demand `scanLayer0`.

## Gating

`TestLayer0Gate_CorpusDiagnosticsEquivalence` already diffs parse-skip vs full-parse across the whole corpus; with the guard gone it **now engages on the 453 code-bearing files** and stays green — the direct proof of safety. `TestLayer0Gate_CodeBlockForcesParse` → `TestLayer0Gate_CodeBlockSkipsParse`. Full suite green (excl. pre-existing `internal/release` signing infra).

## Honest scope

This does **not** change default behavior or speed up benchmark 2 on its own: `MDSMITH_LAYER0_SKIP` is still default-off, and the gate still requires *every* enabled rule to be Layer 0 (the remaining rule migration). What it does is remove the code blocker — the piece that made parse-skip on benchmark-2's code-heavy corpus look architecturally out of reach. The remaining path is mechanical rule migration (MDS002's template) plus flipping the flag default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt)_