### PR TITLE
plan: break the parity parse-skip migration into five batches

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -206,4 +206,9 @@ footer: |
 | 2606162214 | ✅     | sonnet | [Add named unit tests for unexported helpers in new lazy-parse packages](plan/2606162214_arch-fix-missing-helper-tests.md)              |
 | 2606171136 | 🔳     | opus   | [Parity perf: per-worker configured-rule cache + the Layer-0 path to gomarklint](plan/2606171136_parity-perf-configured-rule-cache.md)  |
 | 2606171258 | 🔳     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
+| 2606171400 | 🔲     | opus   | [Parity parse-skip: unify the two Layer-0 gate mechanisms](plan/2606171400_parity-gate-unification.md)                                  |
+| 2606171401 | 🔲     | sonnet | [Parity parse-skip: migrate the Layer-0 heading and front-matter rules](plan/2606171401_parity-layer0-heading-rules.md)                 |
+| 2606171402 | 🔲     | sonnet | [Parity parse-skip: migrate the Layer-0 fenced-code rules](plan/2606171402_parity-layer0-fenced-code-rules.md)                          |
+| 2606171403 | 🔲     | opus   | [Parity parse-skip: migrate the Layer-0 list and blockquote rules](plan/2606171403_parity-layer0-list-quote-rules.md)                   |
+| 2606171404 | 🔲     | opus   | [Parity parse-skip: migrate the Layer-1 inline rules](plan/2606171404_parity-layer1-inline-rules.md)                                    |
 <?/catalog?>

--- a/plan/2606171400_parity-gate-unification.md
+++ b/plan/2606171400_parity-gate-unification.md
@@ -1,0 +1,60 @@
+---
+id: 2606171400
+title: "Parity parse-skip: unify the two Layer-0 gate mechanisms"
+status: "🔲"
+summary: >-
+  Reconcile the engine's two parse-skip gates — the static
+  rulelayer.IsLayer0 set (block rules) and the config-aware
+  rule.LineCapable check (line rules) — into one per-file decision, so
+  a config-dependent line rule like MDS001 line-length counts as
+  Layer 0 under the parity config and stops forcing the parse.
+model: opus
+depends-on: [2606171258]
+---
+# Parity parse-skip: unify the two Layer-0 gate mechanisms
+
+## Goal
+
+Let the parse-skip gate admit rules whose Layer-0 status depends on
+their configuration. Then MDS001 line-length and its peers skip the
+parse under the parity config.
+
+## Background
+
+The engine has two parse-skip mechanisms today.
+
+- `layer0SkipEligible` keys off the **static**
+  [rulelayer](../internal/rulelayer/rule_walk_audit.json) set. It
+  supports block rules through `rule.BlockChecker`, but a rule whose
+  layer depends on config is marked AST-forcing for every config.
+- `computeFlatLayer0Active` keys off the **config-aware**
+  `rule.LineCapable` check. It handles MDS001 — line-length is
+  line-capable until a per-heading limit is set — but it covers only
+  line rules and builds no block spans.
+
+A scope sweep shows MDS001 is parity-enabled yet counts as AST-forcing
+to the block gate, because `rulelayer.IsLayer0("MDS001")` is false. The
+parity config sets no per-heading limit, so line-length is line-capable
+there. The two gates must become one decision that respects both
+signals.
+
+## Tasks
+
+1. Resolve each enabled rule's effective config first, then ask its
+   layer. A rule is skip-safe when it is `rulelayer.IsLayer0` OR its
+   configured instance reports `rule.LineCapable`.
+2. Replace `allEnabledRulesLayer0` with that per-file, config-aware
+   check. Keep the unknown-rule-is-AST-forcing default.
+3. Make the skip File serve both projections: the `ClassifyLines`
+   line classes (already wired) and the block-span scan.
+4. Extend `TestLayer0Gate_CorpusDiagnosticsEquivalence` to run the
+   parity config (not only the Layer-0-only config), so a
+   config-dependent rule's skip output is diffed against its parse
+   output across the corpus.
+
+## Acceptance Criteria
+
+- [ ] MDS001 line-length skips the parse under the parity config and is
+      byte-identical to the parse path on the corpus.
+- [ ] The two gate code paths share one eligibility function.
+- [ ] `go test ./...` passes.

--- a/plan/2606171401_parity-layer0-heading-rules.md
+++ b/plan/2606171401_parity-layer0-heading-rules.md
@@ -1,0 +1,61 @@
+---
+id: 2606171401
+title: "Parity parse-skip: migrate the Layer-0 heading and front-matter rules"
+status: "🔲"
+summary: >-
+  Add a nil-AST path to the parity rules that read only a heading's
+  line or the front matter — MDS003 heading-increment, MDS004
+  first-line-heading, MDS051 single-h1, MDS069 unique-frontmatter — so
+  each resolves to Layer 0 and stops forcing the goldmark parse, gated
+  byte-identical to the AST path across the corpus.
+model: sonnet
+depends-on: [2606171258]
+---
+# Parity parse-skip: migrate the Layer-0 heading and front-matter rules
+
+## Goal
+
+Move the heading-shape and front-matter parity rules onto the Layer-0
+block scan, so they no longer force the parse.
+
+## Background
+
+[MDS002 heading-style](../internal/rules/headingstyle/rule.go) is the
+proven template. It reads a heading's style and level from the heading
+line and serves the nil-AST path through a `rule.BlockChecker`
+`CheckBlock`, byte-identical to its AST `CheckNode`.
+
+The rules below read only line-level facts: a heading's level
+(leading-`#` run or setext underline), its position, or front-matter
+keys. None needs the inline tree.
+
+| Rule   | Name               | Reads                     |
+| ------ | ------------------ | ------------------------- |
+| MDS003 | heading-increment  | heading levels, in order  |
+| MDS004 | first-line-heading | first block kind + level  |
+| MDS051 | single-h1          | count of level-1 headings |
+| MDS069 | unique-frontmatter | front-matter keys         |
+
+MDS003 and MDS004 carry a placeholder setting. A placeholder match
+needs the heading text, which is inline. When the placeholder list is
+empty (the parity case) that branch is dead, so the line-only path is
+exact. Guard the nil-AST path so it only claims Layer 0 when the
+placeholder list is empty; otherwise it stays on the AST.
+
+## Tasks
+
+For each rule:
+
+1. Add the nil-AST path — a `CheckBlock` for the per-heading rules, or
+   a span/line walk in `Check` for the document-order rules (MDS003,
+   MDS051). Reuse the existing level/position extraction.
+2. Keep the diagnostic byte-identical: same line, column, message.
+3. Regenerate the walk audit (`MDSMITH_REGEN_WALK_AUDIT=1`) and sync
+   the embedded [rulelayer copy](../internal/rulelayer/rule_walk_audit.json).
+4. Add a `TestCheck_NilASTMatchesAST` unit test, the shape MDS002 uses.
+
+## Acceptance Criteria
+
+- [ ] Each rule resolves to Layer 0 (audit `A-no-skipping`).
+- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with them on.
+- [ ] `go test ./...` passes.

--- a/plan/2606171402_parity-layer0-fenced-code-rules.md
+++ b/plan/2606171402_parity-layer0-fenced-code-rules.md
@@ -1,0 +1,59 @@
+---
+id: 2606171402
+title: "Parity parse-skip: migrate the Layer-0 fenced-code rules"
+status: "🔲"
+summary: >-
+  Add a nil-AST path to the parity rules that read only a fenced code
+  block's fence lines — MDS010 fenced-code-style, MDS011
+  fenced-code-language, MDS031 unclosed-code-block, MDS065
+  code-block-style, MDS066 commands-show-output — so each resolves to
+  Layer 0, gated byte-identical to the AST across the corpus.
+model: sonnet
+depends-on: [2606171258]
+---
+# Parity parse-skip: migrate the Layer-0 fenced-code rules
+
+## Goal
+
+Move the fenced-code parity rules onto the Layer-0 block scan, so they
+no longer force the parse.
+
+## Background
+
+The [Layer-0 scanner](../internal/lint/layer0.go) emits a
+`BlockFencedCode` span per fenced block, fence lines included. MDS015
+blank-line-around-fenced-code already reads those spans on the nil-AST
+path. The code-skip unblock
+(PR #644) confirmed the scanner matches the AST on code-bearing files,
+fences inside list items included.
+
+These rules read only the fence lines — the fence character, its run
+length, and the info string — and the block body lines. None needs the
+inline tree.
+
+| Rule   | Name                 | Reads                         |
+| ------ | -------------------- | ----------------------------- |
+| MDS010 | fenced-code-style    | fence char (backtick / tilde) |
+| MDS011 | fenced-code-language | info string presence          |
+| MDS031 | unclosed-code-block  | an unterminated opening fence |
+| MDS065 | code-block-style     | fenced vs indented form       |
+| MDS066 | commands-show-output | shell info string + body      |
+
+## Tasks
+
+For each rule:
+
+1. Add the nil-AST path — a `CheckBlock` over `BlockFencedCode` (and
+   `BlockIndentedCode` where the rule needs it), reusing the existing
+   fence parsing.
+2. Keep the diagnostic byte-identical: same line, column, message.
+3. Regenerate the walk audit and sync the embedded
+   [rulelayer copy](../internal/rulelayer/rule_walk_audit.json).
+4. Add a `TestCheck_NilASTMatchesAST` unit test with code-bearing
+   inputs, including a fence inside a list item.
+
+## Acceptance Criteria
+
+- [ ] Each rule resolves to Layer 0 (audit `A-no-skipping`).
+- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with them on.
+- [ ] `go test ./...` passes.

--- a/plan/2606171403_parity-layer0-list-quote-rules.md
+++ b/plan/2606171403_parity-layer0-list-quote-rules.md
@@ -1,0 +1,59 @@
+---
+id: 2606171403
+title: "Parity parse-skip: migrate the Layer-0 list and blockquote rules"
+status: "🔲"
+summary: >-
+  Add a nil-AST path to the parity rules that read list and blockquote
+  structure — MDS014 blank-line-around-lists, MDS016 list-indent,
+  MDS045 list-marker-style, MDS046 ordered-list-numbering, MDS061
+  list-marker-space, MDS059 blockquote-whitespace — each gated
+  byte-identical to the AST across the corpus.
+model: opus
+depends-on: [2606171258]
+---
+# Parity parse-skip: migrate the Layer-0 list and blockquote rules
+
+## Goal
+
+Move the list and blockquote parity rules onto the Layer-0 block scan,
+so they no longer force the parse.
+
+## Background
+
+List and quote spans are the subtle case. CommonMark list parsing
+folds in loose vs tight lists, nesting, and lazy continuation, so a
+Layer-0 span boundary can drift from the AST. The
+[Layer-0 scanner](../internal/lint/layer0.go) emits `BlockList`,
+`BlockListItem`, and `BlockQuote` spans and descends into their bodies.
+
+Each rule needs the marker shape (`-` / `*` / `+`, or `1.` / `1)`),
+the marker indent, and the inter-item spacing — all line-level facts.
+Verify the span boundaries match the AST before trusting them.
+
+| Rule   | Name                    | Reads                     |
+| ------ | ----------------------- | ------------------------- |
+| MDS014 | blank-line-around-lists | top-level list span edges |
+| MDS016 | list-indent             | item marker indent        |
+| MDS045 | list-marker-style       | bullet marker character   |
+| MDS046 | ordered-list-numbering  | ordered marker sequence   |
+| MDS061 | list-marker-space       | spaces after the marker   |
+| MDS059 | blockquote-whitespace   | `>` marker spacing        |
+
+## Tasks
+
+For each rule:
+
+1. First confirm the relevant span boundary matches the AST across the
+   corpus. Add the nil-AST path only once it does.
+2. Add a `CheckBlock` (or span walk) reusing the existing extraction.
+   Keep the diagnostic byte-identical: same line, column, message.
+3. Regenerate the walk audit and sync the embedded
+   [rulelayer copy](../internal/rulelayer/rule_walk_audit.json).
+4. Add a `TestCheck_NilASTMatchesAST` unit test covering nested lists,
+   a loose list, and a list that holds a code fence.
+
+## Acceptance Criteria
+
+- [ ] Each rule resolves to Layer 0 (audit `A-no-skipping`).
+- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with them on.
+- [ ] `go test ./...` passes.

--- a/plan/2606171403_parity-layer0-list-quote-rules.md
+++ b/plan/2606171403_parity-layer0-list-quote-rules.md
@@ -6,8 +6,8 @@ summary: >-
   Add a nil-AST path to the parity rules that read list and blockquote
   structure — MDS014 blank-line-around-lists, MDS016 list-indent,
   MDS045 list-marker-style, MDS046 ordered-list-numbering, MDS061
-  list-marker-space, MDS059 blockquote-whitespace — each gated
-  byte-identical to the AST across the corpus.
+  list-marker-space, MDS059 blockquote-whitespace, MDS067 callout-type
+  — each gated byte-identical to the AST across the corpus.
 model: opus
 depends-on: [2606171258]
 ---
@@ -23,12 +23,15 @@ so they no longer force the parse.
 List and quote spans are the subtle case. CommonMark list parsing
 folds in loose vs tight lists, nesting, and lazy continuation, so a
 Layer-0 span boundary can drift from the AST. The
-[Layer-0 scanner](../internal/lint/layer0.go) emits `BlockList`,
-`BlockListItem`, and `BlockQuote` spans and descends into their bodies.
+[Layer-0 scanner](../internal/lint/layer0.go) emits one `BlockList`
+span per list-item run and one `BlockQuote` span, and descends into
+their bodies. There is no per-item span kind; a rule that needs
+item-level granularity walks the list span's body lines itself.
 
 Each rule needs the marker shape (`-` / `*` / `+`, or `1.` / `1)`),
 the marker indent, and the inter-item spacing — all line-level facts.
-Verify the span boundaries match the AST before trusting them.
+MDS067 callout-type reads only a blockquote's first line, so it lives
+here too. Verify the span boundaries match the AST before trusting them.
 
 | Rule   | Name                    | Reads                     |
 | ------ | ----------------------- | ------------------------- |
@@ -38,6 +41,7 @@ Verify the span boundaries match the AST before trusting them.
 | MDS046 | ordered-list-numbering  | ordered marker sequence   |
 | MDS061 | list-marker-space       | spaces after the marker   |
 | MDS059 | blockquote-whitespace   | `>` marker spacing        |
+| MDS067 | callout-type            | blockquote first line     |
 
 ## Tasks
 

--- a/plan/2606171404_parity-layer1-inline-rules.md
+++ b/plan/2606171404_parity-layer1-inline-rules.md
@@ -39,7 +39,6 @@ the whole-document parse.
 | MDS052 | no-space-in-code-spans             | code-span content     |
 | MDS053 | no-unused-link-definitions         | ref defs and uses     |
 | MDS063 | descriptive-link-text              | link text             |
-| MDS067 | callout-type                       | blockquote callout    |
 | MDS068 | link-style                         | link form             |
 | MDS034 | markdown-flavor                    | flavor-specific spans |
 
@@ -48,7 +47,9 @@ the whole-document parse.
 For each rule:
 
 1. Add the nil-AST path that drives `lint.InlineBlocks` for the blocks
-   the rule cares about, reusing the existing inline extraction.
+   the rule cares about, reusing the existing inline extraction. MDS053
+   is cross-block: assemble its reference def/use map by walking every
+   block's re-parsed inline spans, not one block in isolation.
 2. Keep the diagnostic byte-identical: same line, column, message.
 3. Regenerate the walk audit and sync the embedded
    [rulelayer copy](../internal/rulelayer/rule_walk_audit.json).

--- a/plan/2606171404_parity-layer1-inline-rules.md
+++ b/plan/2606171404_parity-layer1-inline-rules.md
@@ -1,0 +1,63 @@
+---
+id: 2606171404
+title: "Parity parse-skip: migrate the Layer-1 inline rules"
+status: "🔲"
+summary: >-
+  Add a nil-AST path to the parity rules that read inline content —
+  heading text, links, emphasis, code spans, inline HTML, reference
+  definitions — by driving the shared per-block inline re-parse
+  (lint.InlineBlocks) instead of the full document parse, each gated
+  byte-identical to the AST across the corpus.
+model: opus
+depends-on: [2606171258]
+---
+# Parity parse-skip: migrate the Layer-1 inline rules
+
+## Goal
+
+Move the inline-content parity rules onto the Layer 1 path, so they
+read re-parsed inline spans instead of forcing the document parse.
+
+## Background
+
+These rules read flattened inline content, not just lines: a heading's
+text, a link's text and destination, an emphasis run, a code span, an
+inline HTML tag, or the reference-definition map. The line scan cannot
+produce that. The Layer 1 index
+([lint.InlineBlocks](../internal/lint/inline_blocks.go)) re-parses one
+block's inline tree on demand, so a rule reaches inline spans without
+the whole-document parse.
+
+| Rule   | Name                               | Reads                 |
+| ------ | ---------------------------------- | --------------------- |
+| MDS005 | no-duplicate-headings              | heading text          |
+| MDS017 | no-trailing-punctuation-in-heading | heading text          |
+| MDS041 | no-inline-html                     | inline HTML nodes     |
+| MDS042 | emphasis-style                     | emphasis markers      |
+| MDS049 | no-space-in-link-text              | link text edges       |
+| MDS050 | proper-names                       | inline text runs      |
+| MDS052 | no-space-in-code-spans             | code-span content     |
+| MDS053 | no-unused-link-definitions         | ref defs and uses     |
+| MDS063 | descriptive-link-text              | link text             |
+| MDS067 | callout-type                       | blockquote callout    |
+| MDS068 | link-style                         | link form             |
+| MDS034 | markdown-flavor                    | flavor-specific spans |
+
+## Tasks
+
+For each rule:
+
+1. Add the nil-AST path that drives `lint.InlineBlocks` for the blocks
+   the rule cares about, reusing the existing inline extraction.
+2. Keep the diagnostic byte-identical: same line, column, message.
+3. Regenerate the walk audit and sync the embedded
+   [rulelayer copy](../internal/rulelayer/rule_walk_audit.json).
+4. Add a `TestCheck_NilASTMatchesAST` unit test covering the inline
+   edge cases — emphasis at a heading's end, a link inside emphasis,
+   a code span holding bracket text.
+
+## Acceptance Criteria
+
+- [ ] Each rule resolves to Layer 0 / Layer 1 (audit `A-no-skipping`).
+- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with them on.
+- [ ] `go test ./...` passes.


### PR DESCRIPTION
## Summary

Breaks the remaining parity parse-skip migration into **five batch plans**, so the work tracked by [plan 2606171258](plan/2606171258_parity-layer0-parse-skip.md) can be picked up incrementally. A scope sweep found **28** parity-enabled rules still force the goldmark parse; these plans group them by the data each rule reads (which decides its layer) and by difficulty.

| Plan | Scope | Rules |
| --- | --- | --- |
| `2606171400` | **Gate unification** — reconcile the static `rulelayer` gate with the config-aware `LineCapable` gate so MDS001 line-length counts as Layer 0 under parity | MDS001 + mechanism |
| `2606171401` | Layer-0 heading + front-matter | MDS003, 004, 051, 069 |
| `2606171402` | Layer-0 fenced-code | MDS010, 011, 031, 065, 066 |
| `2606171403` | Layer-0 list + blockquote (divergence-prone spans) | MDS014, 016, 045, 046, 061, 059 |
| `2606171404` | Layer-1 inline (via `lint.InlineBlocks`) | MDS005, 017, 041, 042, 049, 050, 052, 053, 063, 067, 068, 034 |

Each batch follows MDS002's proven template — add the nil-AST path, regenerate the walk audit, gate byte-identical to the AST via `TestLayer0Gate_CorpusDiagnosticsEquivalence` — and each is `depends-on: [2606171258]`. All five pass `mdsmith check plan/` and the PLAN.md catalog is regenerated.

These are planning docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt)_