### PR TITLE
perf(engine): unify the two Layer-0 parse-skip gates (plan 2606171400)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -206,7 +206,7 @@ footer: |
 | 2606162214 | ✅     | sonnet | [Add named unit tests for unexported helpers in new lazy-parse packages](plan/2606162214_arch-fix-missing-helper-tests.md)              |
 | 2606171136 | 🔳     | opus   | [Parity perf: per-worker configured-rule cache + the Layer-0 path to gomarklint](plan/2606171136_parity-perf-configured-rule-cache.md)  |
 | 2606171258 | 🔳     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
-| 2606171400 | 🔲     | opus   | [Parity parse-skip: unify the two Layer-0 gate mechanisms](plan/2606171400_parity-gate-unification.md)                                  |
+| 2606171400 | ✅     | opus   | [Parity parse-skip: unify the two Layer-0 gate mechanisms](plan/2606171400_parity-gate-unification.md)                                  |
 | 2606171401 | 🔲     | sonnet | [Parity parse-skip: migrate the Layer-0 heading and front-matter rules](plan/2606171401_parity-layer0-heading-rules.md)                 |
 | 2606171402 | 🔲     | sonnet | [Parity parse-skip: migrate the Layer-0 fenced-code rules](plan/2606171402_parity-layer0-fenced-code-rules.md)                          |
 | 2606171403 | 🔲     | opus   | [Parity parse-skip: migrate the Layer-0 list and blockquote rules](plan/2606171403_parity-layer0-list-quote-rules.md)                   |

--- a/internal/engine/layer0_gate_test.go
+++ b/internal/engine/layer0_gate_test.go
@@ -68,16 +68,77 @@ func TestLayer0Gate_SkipsParseForLayer0OnlyConfig(t *testing.T) {
 	assert.True(t, probe.sawNilAST, "expected the parse to be skipped (nil AST)")
 }
 
-// TestLayer0Gate_ParsesWhenAnASTRuleIsEnabled confirms the gate stands
-// down when any enabled rule needs the AST: line-length (MDS001) is
-// AST-requiring, so the File must carry a parsed tree.
-func TestLayer0Gate_ParsesWhenAnASTRuleIsEnabled(t *testing.T) {
+// TestLayer0Gate_LineCapableRuleSkipsParse proves the gate unification
+// (plan 2606171400): line-length (MDS001) is not in the static rulelayer
+// Layer-0 set, but with no per-heading limit it reports rule.LineCapable,
+// so it lints from f.Lines via the ClassifyLines projection the skip File
+// carries. The gate must therefore skip the parse for a line-capable rule,
+// where the static-only gate forced it.
+func TestLayer0Gate_LineCapableRuleSkipsParse(t *testing.T) {
 	withLayer0Skip(t, true)
 	dir, path := writeDoc(t, "# Title\n\nbody\n")
 
 	probe := &astProbeRule{}
 	cfg := layer0OnlyConfig()
 	cfg.Rules["line-length"] = config.RuleCfg{Enabled: true}
+	cfg.Rules[probe.Name()] = config.RuleCfg{Enabled: true}
+
+	r := &Runner{
+		Config:           cfg,
+		Rules:            append(rule.All(), probe),
+		StripFrontMatter: true,
+		RootDir:          dir,
+	}
+	res := r.Run([]string{path})
+	require.Empty(t, res.Errors)
+	assert.True(t, probe.sawNilAST,
+		"line-capable rule (line-length, no heading limit) must skip the parse")
+}
+
+// TestLayer0Gate_LineCapableDiagnosticsMatchFullParse is the equivalence
+// guarantee for the unification: a config that adds the line-capable
+// line-length rule produces identical diagnostics with the gate on (nil
+// AST, ClassifyLines) and off (full parse). The fixture has an over-length
+// line so line-length actually fires on both paths.
+func TestLayer0Gate_LineCapableDiagnosticsMatchFullParse(t *testing.T) {
+	longLine := "This is a deliberately long prose line that exceeds the default eighty column line-length budget.\n"
+	dir, path := writeDoc(t, "# Title\n\n"+longLine)
+	cfg := layer0OnlyConfig()
+	cfg.Rules["line-length"] = config.RuleCfg{Enabled: true}
+
+	run := func(skip bool) []lint.Diagnostic {
+		withLayer0Skip(t, skip)
+		r := &Runner{
+			Config:           cfg,
+			Rules:            rule.All(),
+			StripFrontMatter: true,
+			RootDir:          dir,
+		}
+		return r.Run([]string{path}).Diagnostics
+	}
+
+	skipped := run(true)
+	parsed := run(false)
+	require.NotEmpty(t, parsed, "line-length must fire so the comparison is not vacuous")
+	assert.Equal(t, parsed, skipped,
+		"line-capable parse-skip must match the full parse")
+}
+
+// TestLayer0Gate_ParsesWhenAnASTRuleIsEnabled confirms the gate stands
+// down when any enabled rule needs the AST: line-length WITH a per-heading
+// limit is not line-capable (it must walk headings), so the File must carry
+// a parsed tree. (Plain line-length, with no heading limit, is line-capable
+// and skips — see TestLayer0Gate_LineCapableRuleSkipsParse.)
+func TestLayer0Gate_ParsesWhenAnASTRuleIsEnabled(t *testing.T) {
+	withLayer0Skip(t, true)
+	dir, path := writeDoc(t, "# Title\n\nbody\n")
+
+	probe := &astProbeRule{}
+	cfg := layer0OnlyConfig()
+	cfg.Rules["line-length"] = config.RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"heading-max": 60},
+	}
 	cfg.Rules[probe.Name()] = config.RuleCfg{Enabled: true}
 
 	r := &Runner{

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -567,17 +567,13 @@ func (r *Runner) computeFlatLayer0Active() bool {
 		if !ok || !cfg.Enabled {
 			continue
 		}
-		// Apply the rule's effective settings before asking LineCapable:
-		// a rule's line-capability can depend on its config (line-length
+		// A rule's line-capability can depend on its config (line-length
 		// is not line-capable once a per-heading limit is set). With no
 		// kinds or overrides, the empty-path effective config is the
-		// rule's settings for every file.
-		configured, err := checker.ConfigureRule(rl, cfg)
-		if err != nil {
-			return false
-		}
-		lc, ok := configured.(rule.LineCapable)
-		if !ok || !lc.LineCapable() {
+		// rule's settings for every file. ruleConfiguredLineCapable
+		// applies those settings before asking — the same check the
+		// unified parse-skip gate uses.
+		if !ruleConfiguredLineCapable(rl, cfg) {
 			return false
 		}
 	}
@@ -645,27 +641,56 @@ func (r *Runner) layer0SkipEligible(
 	if bytes.Contains(source, piOpenScan) {
 		return false
 	}
-	return allEnabledRulesLayer0(rules, effective)
+	return allEnabledRulesSkipSafe(rules, effective)
 }
 
 // piOpenScan is the directive opener the gate scans for; any occurrence
 // disqualifies the parse skip.
 var piOpenScan = []byte("<?")
 
-// allEnabledRulesLayer0 reports whether every enabled rule in effective is
-// a Layer 0 rule. A run with no enabled rules trivially qualifies. A
-// disabled rule is ignored — it will not run, so its layer is irrelevant.
-func allEnabledRulesLayer0(rules []rule.Rule, effective map[string]config.RuleCfg) bool {
+// allEnabledRulesSkipSafe reports whether every enabled rule in effective
+// can lint the parse-skipped (nil-AST) File. A rule qualifies two ways,
+// unifying the engine's two parse-skip signals (plan 2606171400):
+//
+//   - It is a static Layer 0 rule (rulelayer.IsLayer0). Block rules serve
+//     the nil-AST path through their rule.BlockChecker dispatch.
+//   - Its configured instance reports rule.LineCapable. Line rules whose
+//     layer depends on config — line-length is line-capable only without a
+//     per-heading limit — serve the nil-AST path through the File's
+//     ClassifyLines projection.
+//
+// A run with no enabled rules trivially qualifies. A disabled rule is
+// ignored. An unknown rule that is neither Layer 0 nor line-capable forces
+// the parse.
+func allEnabledRulesSkipSafe(rules []rule.Rule, effective map[string]config.RuleCfg) bool {
 	for _, rl := range rules {
 		cfg, ok := effective[rl.Name()]
 		if !ok || !cfg.Enabled {
 			continue
 		}
-		if !rulelayer.IsLayer0(rl.ID()) {
-			return false
+		if rulelayer.IsLayer0(rl.ID()) {
+			continue
 		}
+		if ruleConfiguredLineCapable(rl, cfg) {
+			continue
+		}
+		return false
 	}
 	return true
+}
+
+// ruleConfiguredLineCapable reports whether rl, once configured with cfg,
+// can lint from f.Lines alone (rule.LineCapable). A rule's line-capability
+// can depend on its settings, so the rule is configured before the check —
+// line-length is line-capable until a per-heading limit is set. A config
+// error makes the rule non-skip-safe (the parse path surfaces the error).
+func ruleConfiguredLineCapable(rl rule.Rule, cfg config.RuleCfg) bool {
+	configured, err := checker.ConfigureRule(rl, cfg)
+	if err != nil {
+		return false
+	}
+	lc, ok := configured.(rule.LineCapable)
+	return ok && lc.LineCapable()
 }
 
 // RunSource lints in-memory source bytes (e.g. from stdin or an LSP

--- a/internal/integration/layer0_gate_equivalence_test.go
+++ b/internal/integration/layer0_gate_equivalence_test.go
@@ -70,6 +70,44 @@ func layer0OnlyConfigForCorpus() *config.Config {
 	return cfg
 }
 
+// TestLayer0Gate_LineCapableCorpusEquivalence is the gate-unification
+// (plan 2606171400) corpus guard. It enables the static Layer 0 rules plus
+// line-length — a rule that is NOT in the rulelayer Layer 0 set but reports
+// rule.LineCapable under its default config — and asserts the parse-skip
+// run matches the full-parse run across the repository corpus. With the
+// unified gate, line-length no longer forces the parse; its diagnostics
+// must come out byte-identical from the ClassifyLines projection on the
+// parse-skipped File, on real content (over-length lines, code, the lot).
+func TestLayer0Gate_LineCapableCorpusEquivalence(t *testing.T) {
+	root := repoRoot(t)
+	files := collectMarkdownCorpus(t, root)
+	require.NotEmpty(t, files)
+
+	cfg := layer0OnlyConfigForCorpus()
+	cfg.Rules["line-length"] = config.RuleCfg{Enabled: true}
+
+	run := func(skip bool) []lint.Diagnostic {
+		if skip {
+			t.Setenv("MDSMITH_LAYER0_SKIP", "1")
+		} else {
+			t.Setenv("MDSMITH_LAYER0_SKIP", "")
+		}
+		r := &engine.Runner{
+			Config:           cfg,
+			Rules:            rule.All(),
+			StripFrontMatter: true,
+			RootDir:          root,
+		}
+		return r.Run(files).Diagnostics
+	}
+
+	skipped := run(true)
+	parsed := run(false)
+	require.NotEmpty(t, parsed, "line-length must fire somewhere in the corpus")
+	assert.Equal(t, diagKeys(parsed), diagKeys(skipped),
+		"line-capable parse-skip must match the full-parse run across the corpus")
+}
+
 // diagKeys reduces diagnostics to comparable tuples (file, line, column,
 // rule, message) so two runs compare on observable output alone.
 func diagKeys(diags []lint.Diagnostic) [][5]string {

--- a/plan/2606171400_parity-gate-unification.md
+++ b/plan/2606171400_parity-gate-unification.md
@@ -1,7 +1,7 @@
 ---
 id: 2606171400
 title: "Parity parse-skip: unify the two Layer-0 gate mechanisms"
-status: "🔲"
+status: "✅"
 summary: >-
   Reconcile the engine's two parse-skip gates — the static
   rulelayer.IsLayer0 set (block rules) and the config-aware
@@ -40,21 +40,30 @@ signals.
 
 ## Tasks
 
-1. Resolve each enabled rule's effective config first, then ask its
+1. [x] Resolve each enabled rule's effective config first, then ask its
    layer. A rule is skip-safe when it is `rulelayer.IsLayer0` OR its
-   configured instance reports `rule.LineCapable`.
-2. Replace `allEnabledRulesLayer0` with that per-file, config-aware
-   check. Keep the unknown-rule-is-AST-forcing default.
-3. Make the skip File serve both projections: the `ClassifyLines`
-   line classes (already wired) and the block-span scan.
-4. Extend `TestLayer0Gate_CorpusDiagnosticsEquivalence` to run the
-   parity config (not only the Layer-0-only config), so a
-   config-dependent rule's skip output is diffed against its parse
-   output across the corpus.
+   configured instance reports `rule.LineCapable`
+   (`ruleConfiguredLineCapable`).
+2. [x] Replace `allEnabledRulesLayer0` with that per-file, config-aware
+   check (`allEnabledRulesSkipSafe`). The unknown-rule-is-AST-forcing
+   default is kept.
+3. [x] The skip File already serves both projections: it is built with
+   `NewFileFlatPooled`, which carries the `ClassifyLines` line classes,
+   and `Layer0(f).BlockSpans` drives the block-span rules. No change
+   needed here.
+4. [x] Added `TestLayer0Gate_LineCapableCorpusEquivalence`: enables the
+   static Layer 0 rules plus line-length and diffs the parse-skip run
+   against the full-parse run across the corpus. (The full parity config
+   cannot skip yet — the other AST-forcing rules still block — so the
+   guard adds the one config-dependent rule rather than the whole set.)
 
 ## Acceptance Criteria
 
-- [ ] MDS001 line-length skips the parse under the parity config and is
-      byte-identical to the parse path on the corpus.
-- [ ] The two gate code paths share one eligibility function.
-- [ ] `go test ./...` passes.
+- [x] MDS001 line-length skips the parse and is byte-identical to the
+      parse path on the corpus
+      (`TestLayer0Gate_LineCapableCorpusEquivalence`,
+      `TestLayer0Gate_LineCapableRuleSkipsParse`).
+- [x] The two gate code paths share one eligibility helper
+      (`ruleConfiguredLineCapable`, used by both `allEnabledRulesSkipSafe`
+      and `computeFlatLayer0Active`).
+- [x] `go test ./...` passes.


### PR DESCRIPTION
## Summary

Implements plan **`2606171400`** — the prerequisite for the parity parse-skip migration. Unifies the engine's two separate parse-skip decisions into one config-aware check.

### The problem

Two gates decided parse-skip independently:
- `layer0SkipEligible` → static `rulelayer.IsLayer0` set (block rules via `BlockChecker`).
- `computeFlatLayer0Active` → config-aware `rule.LineCapable` check (line rules via `ClassifyLines`).

A rule whose layer depends on config — **MDS001 line-length**, line-capable until a per-heading limit is set — was marked AST-forcing by the block gate for *every* config, so it forced the parse even under a config (like parity) where it reads only `f.Lines`.

### The fix

`allEnabledRulesSkipSafe` accepts a rule when it is `rulelayer.IsLayer0` **OR** its configured instance reports `rule.LineCapable` (`ruleConfiguredLineCapable`, now shared with `computeFlatLayer0Active` — one eligibility helper). The skip File is already `NewFileFlatPooled`, which carries both the `ClassifyLines` projection and the block-span scan, so a line-capable rule serves the nil-AST path with no further change. The unknown-rule default stays AST-forcing.

### Tests (TDD red→green)

- `TestLayer0Gate_LineCapableRuleSkipsParse` — line-length now skips the parse (was the failing test).
- `TestLayer0Gate_LineCapableDiagnosticsMatchFullParse` — skip vs full-parse identical.
- `TestLayer0Gate_LineCapableCorpusEquivalence` — **corpus-wide** byte-identical guard with line-length on the skip path.
- `TestLayer0Gate_ParsesWhenAnASTRuleIsEnabled` updated to use line-length **with** `heading-max`, so it still exercises a genuinely AST-forcing rule.

## Scope

This does **not** move the benchmark on its own — the full parity set still has unmigrated AST-forcing rules that block the all-or-nothing gate. It's the foundation that lets config-dependent line rules count once their batches land. Full `go test ./...` passes; `gofmt`/`vet` clean (golangci-lint runs in CI — the sandbox Go is below the dev-tool floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt)_