### PR TITLE
plan(2606171401): correct the heading-rule migration approach (config-aware, depends on #647)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -207,7 +207,7 @@ footer: |
 | 2606171136 | 🔳     | opus   | [Parity perf: per-worker configured-rule cache + the Layer-0 path to gomarklint](plan/2606171136_parity-perf-configured-rule-cache.md)  |
 | 2606171258 | 🔳     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
 | 2606171400 | ✅     | opus   | [Parity parse-skip: unify the two Layer-0 gate mechanisms](plan/2606171400_parity-gate-unification.md)                                  |
-| 2606171401 | 🔲     | sonnet | [Parity parse-skip: migrate the Layer-0 heading and front-matter rules](plan/2606171401_parity-layer0-heading-rules.md)                 |
+| 2606171401 | 🔲     | opus   | [Parity parse-skip: migrate the Layer-0 heading and front-matter rules](plan/2606171401_parity-layer0-heading-rules.md)                 |
 | 2606171402 | 🔲     | sonnet | [Parity parse-skip: migrate the Layer-0 fenced-code rules](plan/2606171402_parity-layer0-fenced-code-rules.md)                          |
 | 2606171403 | 🔲     | opus   | [Parity parse-skip: migrate the Layer-0 list and blockquote rules](plan/2606171403_parity-layer0-list-quote-rules.md)                   |
 | 2606171404 | 🔲     | opus   | [Parity parse-skip: migrate the Layer-1 inline rules](plan/2606171404_parity-layer1-inline-rules.md)                                    |

--- a/plan/2606171401_parity-layer0-heading-rules.md
+++ b/plan/2606171401_parity-layer0-heading-rules.md
@@ -42,15 +42,27 @@ MDS003 and MDS004 are **config-dependent**, not statically Layer 0. They
 carry a placeholder setting; a placeholder match reads the heading text,
 which is inline. With an empty placeholder list (the parity case) that
 branch is dead and the line-only path is exact. This is the same shape
-as line-length, so they use the config-aware gate from
-[2606171400](2606171400_parity-gate-unification.md): implement
-`rule.LineCapable` returning `len(Placeholders) == 0`, plus a nil-AST
-`Check` that walks heading lines from the block scan. The static
-`rulelayer` audit cannot express that config dependence, so do **not**
-mark them `A-no-skipping`. This is why the plan now depends on 2606171400.
+as line-length, so they ride the config-aware gate from
+[2606171400](2606171400_parity-gate-unification.md), whose
+`ruleConfiguredLineCapable` admits a rule when its configured instance
+reports `rule.LineCapable`. The static `rulelayer` audit cannot express
+that config dependence, so they cannot be marked `A-no-skipping`. This is
+why the plan now depends on 2606171400.
+
+**Caveat on `LineCapable`.** Its doc comment commits the interface to the
+flat line classifier — "reading only `f.Lines` and the classifier-backed
+projections", not `Layer0(f).BlockSpans`. A heading rule that reads
+heading *levels* from block spans therefore does not fit the contract as
+written. Resolve this before coding, one of two ways. Option one widens
+the `rule.LineCapable` doc to admit the block-span projection. Option two
+adds a config-aware *block* eligibility to the gate, gating a
+`BlockChecker`'s skip on `len(Placeholders) == 0` so these rules stay
+`BlockChecker`s like MDS002 (cleaner; prefer it).
 
 MDS051 single-h1 is opt-in. It reads only level-1 heading counts plus a
-front-matter title. The same `LineCapable`-when-simple treatment fits.
+front-matter title — no placeholder branch — so it is unconditionally
+nil-AST-safe, not "when-simple". It can take the static `BlockChecker`
+path (like MDS002), no config gate needed.
 
 MDS069 unique-frontmatter never touches `f.AST`. Its `Check` builds a
 cross-file front-matter index. The walk audit reports it
@@ -60,23 +72,54 @@ that never fires. The fix is an audit probe that fires (an include glob
 over a multi-file fixture) or an explicit nil-AST-safe classification.
 It is not a `CheckBlock` migration.
 
+## Blocker: the scanner emits no nested heading spans
+
+`scanLayer0` ([layer0.go](../internal/lint/layer0.go)) emits
+`BlockATXHeading` / `BlockSetextHeading` spans only for **top-level**
+headings. It emits one `BlockList` span per list line with no descent
+into the item body, and one `BlockQuote` span that maps back only
+`CodeBlockLines`, never the inner scan's heading spans. The AST path
+(`ast.Walk`) visits headings nested in list items and blockquotes too.
+
+So a nil-AST path that walks heading spans **diverges** from the AST for
+any document with a heading inside a list or quote. A missed nested
+heading is a false negative. It also corrupts MDS003's `prevLevel`
+sequence for every later heading, and MDS004/MDS051 miscount. The
+repository corpus has few such headings, so the equivalence gate would
+not reliably catch the divergence.
+
+This must be fixed first. One option extends `scanLayer0` to emit nested
+heading spans in `ast.Walk` order, recursing into list-item and
+blockquote bodies and mapping their spans back the way `CodeBlockLines`
+already is. The other has the gate force the parse for any document whose
+headings are container-nested. Until then these rules cannot migrate.
+Note also that the `BlockSpans` doc in layer0.go still says they have "no
+production consumer yet" — stale once MDS010/011/031 land; update it.
+
 ## Tasks
 
 For each rule:
 
-1. Add the nil-AST `Check` path that walks the Layer 0 heading spans
+1. First resolve the nested-heading blocker above (scanner emits nested
+   heading spans, or the gate excludes container-nested headings).
+2. Add the nil-AST `Check` path that walks the Layer 0 heading spans
    (levels, position), reusing the existing extraction.
-2. Implement `rule.LineCapable` returning true only for the simple
-   config (empty placeholders for MDS003/004), so the 2606171400 gate
-   admits the rule under parity and forces the parse otherwise.
-3. Keep the diagnostic byte-identical: same line, column, message.
-4. Add a `TestCheck_NilASTMatchesAST` unit test, the shape MDS002 uses,
-   plus the gate-level skip + corpus-equivalence guards 2606171400 added.
+3. Wire config-aware skip eligibility (the `LineCapable` caveat above:
+   widen the doc, or add a block-eligibility gate) for MDS003/MDS004.
+   MDS051 takes the static `BlockChecker` path, no config gate.
+4. Keep the diagnostic byte-identical: same line, column, message.
+5. Add a `TestCheck_NilASTMatchesAST` unit test, the shape MDS002 uses,
+   with a heading inside a list and inside a blockquote, plus the
+   gate-level skip + corpus-equivalence guards 2606171400 added.
 
 ## Acceptance Criteria
 
-- [ ] MDS003, MDS004, MDS051 skip the parse under parity (empty
-      placeholders) and force it otherwise, byte-identical both ways.
+- [ ] The nested-heading blocker is resolved: a heading inside a list or
+      blockquote yields identical diagnostics on the parse-skip and
+      full-parse paths (scanner extension or gate exclusion).
+- [ ] MDS003, MDS004 skip the parse under parity (empty placeholders) and
+      force it otherwise, byte-identical both ways; MDS051 via the static
+      `BlockChecker` path.
 - [ ] MDS069's nil-AST safety is resolved (audit probe or classification).
 - [ ] `TestLayer0Gate_LineCapableCorpusEquivalence`-style guard green
       with these rules on.

--- a/plan/2606171401_parity-layer0-heading-rules.md
+++ b/plan/2606171401_parity-layer0-heading-rules.md
@@ -8,8 +8,8 @@ summary: >-
   first-line-heading, MDS051 single-h1, MDS069 unique-frontmatter — so
   each resolves to Layer 0 and stops forcing the goldmark parse, gated
   byte-identical to the AST path across the corpus.
-model: sonnet
-depends-on: [2606171258]
+model: opus
+depends-on: [2606171258, 2606171400]
 ---
 # Parity parse-skip: migrate the Layer-0 heading and front-matter rules
 
@@ -36,26 +36,48 @@ keys. None needs the inline tree.
 | MDS051 | single-h1          | count of level-1 headings |
 | MDS069 | unique-frontmatter | front-matter keys         |
 
-MDS003 and MDS004 carry a placeholder setting. A placeholder match
-needs the heading text, which is inline. When the placeholder list is
-empty (the parity case) that branch is dead, so the line-only path is
-exact. Guard the nil-AST path so it only claims Layer 0 when the
-placeholder list is empty; otherwise it stays on the AST.
+## Implementation notes (found while scoping)
+
+MDS003 and MDS004 are **config-dependent**, not statically Layer 0. They
+carry a placeholder setting; a placeholder match reads the heading text,
+which is inline. With an empty placeholder list (the parity case) that
+branch is dead and the line-only path is exact. This is the same shape
+as line-length, so they use the config-aware gate from
+[2606171400](2606171400_parity-gate-unification.md): implement
+`rule.LineCapable` returning `len(Placeholders) == 0`, plus a nil-AST
+`Check` that walks heading lines from the block scan. The static
+`rulelayer` audit cannot express that config dependence, so do **not**
+mark them `A-no-skipping`. This is why the plan now depends on 2606171400.
+
+MDS051 single-h1 is opt-in. It reads only level-1 heading counts plus a
+front-matter title. The same `LineCapable`-when-simple treatment fits.
+
+MDS069 unique-frontmatter never touches `f.AST`. Its `Check` builds a
+cross-file front-matter index. The walk audit reports it
+`inconclusive-not-fired`: the fixture probe has no include globs, so the
+rule never emits. The audit cannot confirm nil-AST safety from a probe
+that never fires. The fix is an audit probe that fires (an include glob
+over a multi-file fixture) or an explicit nil-AST-safe classification.
+It is not a `CheckBlock` migration.
 
 ## Tasks
 
 For each rule:
 
-1. Add the nil-AST path — a `CheckBlock` for the per-heading rules, or
-   a span/line walk in `Check` for the document-order rules (MDS003,
-   MDS051). Reuse the existing level/position extraction.
-2. Keep the diagnostic byte-identical: same line, column, message.
-3. Regenerate the walk audit (`MDSMITH_REGEN_WALK_AUDIT=1`) and sync
-   the embedded [rulelayer copy](../internal/rulelayer/rule_walk_audit.json).
-4. Add a `TestCheck_NilASTMatchesAST` unit test, the shape MDS002 uses.
+1. Add the nil-AST `Check` path that walks the Layer 0 heading spans
+   (levels, position), reusing the existing extraction.
+2. Implement `rule.LineCapable` returning true only for the simple
+   config (empty placeholders for MDS003/004), so the 2606171400 gate
+   admits the rule under parity and forces the parse otherwise.
+3. Keep the diagnostic byte-identical: same line, column, message.
+4. Add a `TestCheck_NilASTMatchesAST` unit test, the shape MDS002 uses,
+   plus the gate-level skip + corpus-equivalence guards 2606171400 added.
 
 ## Acceptance Criteria
 
-- [ ] Each rule resolves to Layer 0 (audit `A-no-skipping`).
-- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with them on.
+- [ ] MDS003, MDS004, MDS051 skip the parse under parity (empty
+      placeholders) and force it otherwise, byte-identical both ways.
+- [ ] MDS069's nil-AST safety is resolved (audit probe or classification).
+- [ ] `TestLayer0Gate_LineCapableCorpusEquivalence`-style guard green
+      with these rules on.
 - [ ] `go test ./...` passes.


### PR DESCRIPTION
## Summary

Corrects plan `2606171401` (Layer-0 heading & front-matter rules) based on what I found scoping it against the actual rules and the walk audit. **Plan-only; no code.** The implementation lands once #647 (plan `2606171400`) is in main, which this now depends on.

## Corrections

- **MDS003 / MDS004 are config-dependent, not statically Layer 0.** Their placeholder branch reads inline heading text, so they're Layer-0-safe only with an empty placeholder list — the same shape as line-length. They should implement `rule.LineCapable` (returning `len(Placeholders)==0`) and ride #647's config-aware gate, **not** a static `rulelayer` `A-no-skipping` mark (which can't express config dependence). Hence the new `depends-on: [2606171258, 2606171400]`.
- **MDS051** single-h1 fits the same `LineCapable`-when-simple treatment.
- **MDS069** never touches `f.AST`, but the walk audit reports it `inconclusive-not-fired` — its cross-file front-matter index never fires in the fixture probe, so the audit can't confirm nil-AST safety. It needs an audit probe that fires (an include glob over a multi-file fixture) or an explicit classification — **not** a `CheckBlock` migration.

Tasks and acceptance criteria updated to match. Passes `mdsmith check plan/`.

This is the kind of correction the review agent on #645 flagged as a possible missing dependency — confirmed here by implementation scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmDJshZDHCDwWzv5jCnRgt)_