### PR TITLE
perf: top-5 hot-path optimizations per high-performance-go.md audit

### DIFF
--- a/internal/markdownlint/emit.go
+++ b/internal/markdownlint/emit.go
@@ -50,19 +50,25 @@ func EmitConfig(conv *Conversion, source string) ([]byte, error) {
 func wrapComment(text string, width int) []string {
 	const first, cont = "# - ", "#   "
 	var lines []string
-	line := first
+	var cur strings.Builder
+	cur.Grow(len(first) + len(text))
+	cur.WriteString(first)
+	prefix := first
 	for _, word := range strings.Fields(text) {
 		sep := ""
-		if line != first && line != cont {
+		if cur.Len() != len(prefix) {
 			sep = " "
 		}
-		if len(line)+len(sep)+len(word) > width && sep != "" {
-			lines = append(lines, line)
-			line = cont
+		if cur.Len()+len(sep)+len(word) > width && sep != "" {
+			lines = append(lines, cur.String())
+			cur.Reset()
+			cur.WriteString(cont)
+			prefix = cont
 			sep = ""
 		}
-		line += sep + word
+		cur.WriteString(sep)
+		cur.WriteString(word)
 	}
-	lines = append(lines, line)
+	lines = append(lines, cur.String())
 	return lines
 }

--- a/internal/markdownlint/emit.go
+++ b/internal/markdownlint/emit.go
@@ -53,17 +53,15 @@ func wrapComment(text string, width int) []string {
 	var cur strings.Builder
 	cur.Grow(len(first) + len(text))
 	cur.WriteString(first)
-	prefix := first
 	for _, word := range strings.Fields(text) {
 		sep := ""
-		if cur.Len() != len(prefix) {
+		if cur.Len() != len(first) {
 			sep = " "
 		}
 		if cur.Len()+len(sep)+len(word) > width && sep != "" {
 			lines = append(lines, cur.String())
 			cur.Reset()
 			cur.WriteString(cont)
-			prefix = cont
 			sep = ""
 		}
 		cur.WriteString(sep)

--- a/internal/markdownlint/emit_test.go
+++ b/internal/markdownlint/emit_test.go
@@ -107,3 +107,25 @@ func TestWrapComment(t *testing.T) {
 	assert.Equal(t, []string{"# - aaaaaaaaaaaaaaaaaaaaaaaa"},
 		wrapComment("aaaaaaaaaaaaaaaaaaaaaaaa", 10))
 }
+
+// TestWrapComment_AllocsPerCall verifies that wrapComment uses strings.Builder
+// rather than += in a loop, keeping allocations low regardless of word count.
+// Per the high-performance Go guidelines: "strings.Builder over +".
+// Before the fix, each iteration allocates a new backing array for the string.
+func TestWrapComment_AllocsPerCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc count skipped in short mode")
+	}
+	// 20 words all fitting within width=200 — one long line.
+	// With +=, each of the 20 words triggers a string copy (≥20 allocs).
+	// With strings.Builder, the entire call uses ≤3 allocs.
+	text := "one two three four five six seven eight nine ten " +
+		"eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty"
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = wrapComment(text, 200)
+	})
+	if allocs > 5 {
+		t.Fatalf("wrapComment allocates %.0f/call for 20-word input; want ≤5 "+
+			"(guideline: use strings.Builder instead of += in a loop)", allocs)
+	}
+}

--- a/internal/markdownlint/emit_test.go
+++ b/internal/markdownlint/emit_test.go
@@ -124,8 +124,7 @@ func TestWrapComment_AllocsPerCall(t *testing.T) {
 	allocs := testing.AllocsPerRun(100, func() {
 		_ = wrapComment(text, 200)
 	})
-	if allocs > 5 {
-		t.Fatalf("wrapComment allocates %.0f/call for 20-word input; want ≤5 "+
+	assert.LessOrEqualf(t, allocs, float64(5),
+		"wrapComment allocates %.0f/call for 20-word input; want ≤5 "+
 			"(guideline: use strings.Builder instead of += in a loop)", allocs)
-	}
 }

--- a/internal/rules/callouttype/rule.go
+++ b/internal/rules/callouttype/rule.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 func init() {
@@ -123,7 +124,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		if !ok {
 			return ast.WalkContinue, nil
 		}
-		if _, ok := allowed[strings.ToLower(token)]; ok {
+		if setutil.Contains(allowed, strings.ToLower(token)) {
 			return ast.WalkContinue, nil
 		}
 		diags = append(diags, r.unknownTypeDiag(f.Path, line, col, token))
@@ -174,7 +175,7 @@ func (r *Rule) checkLayer0(f *lint.File) []lint.Diagnostic {
 			prevDepth = d
 			continue
 		}
-		if _, inAllowed := allowed[strings.ToLower(token)]; inAllowed {
+		if setutil.Contains(allowed, strings.ToLower(token)) {
 			prevDepth = d
 			continue
 		}

--- a/internal/rules/callouttype/rule.go
+++ b/internal/rules/callouttype/rule.go
@@ -50,34 +50,34 @@ func (r *Rule) EnabledByDefault() bool { return false }
 // vocabulary; the diagnostic message orders names via
 // validTypeOrder below, so map iteration order does not affect
 // output stability.
-var builtInTypes = map[string]bool{
-	"note":      true,
-	"abstract":  true,
-	"summary":   true,
-	"tldr":      true,
-	"info":      true,
-	"todo":      true,
-	"tip":       true,
-	"hint":      true,
-	"important": true,
-	"success":   true,
-	"check":     true,
-	"done":      true,
-	"question":  true,
-	"help":      true,
-	"faq":       true,
-	"warning":   true,
-	"caution":   true,
-	"attention": true,
-	"failure":   true,
-	"fail":      true,
-	"missing":   true,
-	"danger":    true,
-	"error":     true,
-	"bug":       true,
-	"example":   true,
-	"quote":     true,
-	"cite":      true,
+var builtInTypes = map[string]struct{}{
+	"note":      {},
+	"abstract":  {},
+	"summary":   {},
+	"tldr":      {},
+	"info":      {},
+	"todo":      {},
+	"tip":       {},
+	"hint":      {},
+	"important": {},
+	"success":   {},
+	"check":     {},
+	"done":      {},
+	"question":  {},
+	"help":      {},
+	"faq":       {},
+	"warning":   {},
+	"caution":   {},
+	"attention": {},
+	"failure":   {},
+	"fail":      {},
+	"missing":   {},
+	"danger":    {},
+	"error":     {},
+	"bug":       {},
+	"example":   {},
+	"quote":     {},
+	"cite":      {},
 }
 
 // validTypeOrder is the message-facing list of base type names. The
@@ -123,7 +123,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		if !ok {
 			return ast.WalkContinue, nil
 		}
-		if allowed[strings.ToLower(token)] {
+		if _, ok := allowed[strings.ToLower(token)]; ok {
 			return ast.WalkContinue, nil
 		}
 		diags = append(diags, r.unknownTypeDiag(f.Path, line, col, token))
@@ -170,7 +170,11 @@ func (r *Rule) checkLayer0(f *lint.File) []lint.Diagnostic {
 		}
 		// d > prevDepth: first content line at this nesting depth.
 		token, line, col, ok := calloutTokenFromLine(f, lineNum, d)
-		if !ok || allowed[strings.ToLower(token)] {
+		if !ok {
+			prevDepth = d
+			continue
+		}
+		if _, inAllowed := allowed[strings.ToLower(token)]; inAllowed {
 			prevDepth = d
 			continue
 		}
@@ -246,13 +250,13 @@ func quoteMarkerLen(line []byte) int {
 // so it runs at most once per file. Rule instances are shared across concurrent
 // LSP calls, so mutable caching on the Rule struct itself would race; the
 // per-File memo is sync.Map + sync.Once protected and avoids that entirely.
-func (r *Rule) buildAllowSet() map[string]bool {
-	out := make(map[string]bool, len(builtInTypes)+len(r.Allow))
+func (r *Rule) buildAllowSet() map[string]struct{} {
+	out := make(map[string]struct{}, len(builtInTypes)+len(r.Allow))
 	for k := range builtInTypes {
-		out[k] = true
+		out[k] = struct{}{}
 	}
 	for _, name := range r.Allow {
-		out[strings.ToLower(name)] = true
+		out[strings.ToLower(name)] = struct{}{}
 	}
 	return out
 }
@@ -260,9 +264,9 @@ func (r *Rule) buildAllowSet() map[string]bool {
 // cachedAllowSet returns the effective allow set memoised on the per-Check
 // *lint.File, so the map is built at most once per file regardless of how
 // many callout blockquotes the file contains.
-func (r *Rule) cachedAllowSet(f *lint.File) map[string]bool {
+func (r *Rule) cachedAllowSet(f *lint.File) map[string]struct{} {
 	v := f.Memo("MDS067.allowSet", func() any { return r.buildAllowSet() })
-	return v.(map[string]bool)
+	return v.(map[string]struct{})
 }
 
 // calloutToken returns the `[!type]` token, body-relative line, and

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -255,8 +255,11 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 // map[string]struct{} rather than map[string]bool. Per the high-performance
 // Go guidelines: "map[K]struct{} for sets — zero-byte value type."
 func TestBuildAllowSet_SetType(t *testing.T) {
-	r := &Rule{}
-	got := reflect.TypeOf(r.buildAllowSet()).String()
+	r := &Rule{Allow: []string{"custom"}}
+	m := r.buildAllowSet()
+	got := reflect.TypeOf(m).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
 	assert.Equal(t, want, got, "buildAllowSet must return map[string]struct{} (guideline: use map[K]struct{} for sets)")
+	assert.Contains(t, m, "note", "built-in type 'note' must be present in the returned set")
+	assert.Contains(t, m, "custom", "user-configured Allow entry must be present")
 }

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -258,7 +258,5 @@ func TestBuildAllowSet_SetType(t *testing.T) {
 	r := &Rule{}
 	got := reflect.TypeOf(r.buildAllowSet()).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
-	if got != want {
-		t.Fatalf("buildAllowSet returns %s; want %s (guideline: use map[K]struct{} for sets)", got, want)
-	}
+	assert.Equal(t, want, got, "buildAllowSet must return map[string]struct{} (guideline: use map[K]struct{} for sets)")
 }

--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -1,6 +1,7 @@
 package callouttype
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -247,5 +248,17 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 		l0Diags := (&Rule{}).Check(lint.NewFileLines("f.md", b))
 		assert.Equal(t, astDiags, l0Diags,
 			"nil-AST diagnostics must match AST for %q", src)
+	}
+}
+
+// TestBuildAllowSet_SetType verifies that buildAllowSet returns
+// map[string]struct{} rather than map[string]bool. Per the high-performance
+// Go guidelines: "map[K]struct{} for sets — zero-byte value type."
+func TestBuildAllowSet_SetType(t *testing.T) {
+	r := &Rule{}
+	got := reflect.TypeOf(r.buildAllowSet()).String()
+	want := reflect.TypeOf(map[string]struct{}{}).String()
+	if got != want {
+		t.Fatalf("buildAllowSet returns %s; want %s (guideline: use map[K]struct{} for sets)", got, want)
 	}
 }

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -231,13 +231,15 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	return r.fixByteRangeFeatures(current)
 }
 
-// fixGitHubAlerts strips [!TOKEN] alert markers from blockquotes,
-// re-adding "> " on lazy-continuation lines so the blockquote stays
-// well-formed after the marker line goes away. If the marker is the
-// only line in the blockquote, the whole blockquote is removed.
-func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
-	skip := map[int]bool{}
-	addPrefix := map[int]bool{} // lazy-continuation lines that lose blockquote context
+// buildAlertSkipMaps walks the AST of f and returns two zero-byte-value
+// sets: skip holds the 1-based line numbers of GitHub Alert marker lines
+// that should be dropped, and addPrefix holds the line numbers of lazy-
+// continuation lines that need a "> " prefix re-added after the marker
+// is removed. Using map[int]struct{} rather than map[int]bool follows the
+// high-performance Go guideline "map[K]struct{} for sets — zero-byte value type."
+func buildAlertSkipMaps(f *lint.File) (skip, addPrefix map[int]struct{}) {
+	skip = map[int]struct{}{}
+	addPrefix = map[int]struct{}{} // lazy-continuation lines that lose blockquote context
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
@@ -260,7 +262,7 @@ func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 		lines := para.Lines()
 		seg := lines.At(0)
 		markerLine, _ := flavor.LineCol(f.Source, seg.Start)
-		skip[markerLine] = true
+		skip[markerLine] = struct{}{}
 
 		// Remaining lines of the first paragraph may use lazy continuation
 		// (no "> " prefix in the raw source). After removing the marker they
@@ -270,11 +272,20 @@ func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 			contLine, _ := flavor.LineCol(f.Source, contSeg.Start)
 			raw := strings.TrimLeft(string(f.Lines[contLine-1]), " \t")
 			if !strings.HasPrefix(raw, ">") {
-				addPrefix[contLine] = true
+				addPrefix[contLine] = struct{}{}
 			}
 		}
 		return ast.WalkContinue, nil
 	})
+	return
+}
+
+// fixGitHubAlerts strips [!TOKEN] alert markers from blockquotes,
+// re-adding "> " on lazy-continuation lines so the blockquote stays
+// well-formed after the marker line goes away. If the marker is the
+// only line in the blockquote, the whole blockquote is removed.
+func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
+	skip, addPrefix := buildAlertSkipMaps(f)
 
 	if len(skip) == 0 {
 		return f.Source
@@ -283,11 +294,11 @@ func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 	var out []string
 	for i, line := range f.Lines {
 		lineNum := i + 1
-		if skip[lineNum] {
+		if _, ok := skip[lineNum]; ok {
 			continue
 		}
 		s := string(line)
-		if addPrefix[lineNum] {
+		if _, ok := addPrefix[lineNum]; ok {
 			trimmed := strings.TrimLeft(s, " \t")
 			s = s[:len(s)-len(trimmed)] + "> " + trimmed
 		}

--- a/internal/rules/markdownflavor/rule_test.go
+++ b/internal/rules/markdownflavor/rule_test.go
@@ -1,6 +1,7 @@
 package markdownflavor
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -404,5 +405,22 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 
 			assert.Equal(t, astDiags, nilDiags)
 		})
+	}
+}
+
+// TestBuildAlertSkipMaps_SetType verifies that buildAlertSkipMaps returns
+// map[int]struct{} rather than map[int]bool for its skip and addPrefix sets.
+// Per the high-performance Go guidelines: "map[K]struct{} for sets — zero-byte value type."
+func TestBuildAlertSkipMaps_SetType(t *testing.T) {
+	f := mkFile(t, "> [!NOTE]\n> body\n")
+	skip, addPrefix := buildAlertSkipMaps(f)
+	skipType := reflect.TypeOf(skip).String()
+	addPrefixType := reflect.TypeOf(addPrefix).String()
+	wantType := reflect.TypeOf(map[int]struct{}{}).String()
+	if skipType != wantType {
+		t.Fatalf("skip uses %s; want %s (guideline: use map[K]struct{} for sets)", skipType, wantType)
+	}
+	if addPrefixType != wantType {
+		t.Fatalf("addPrefix uses %s; want %s (guideline: use map[K]struct{} for sets)", addPrefixType, wantType)
 	}
 }

--- a/internal/rules/markdownflavor/rule_test.go
+++ b/internal/rules/markdownflavor/rule_test.go
@@ -417,10 +417,6 @@ func TestBuildAlertSkipMaps_SetType(t *testing.T) {
 	skipType := reflect.TypeOf(skip).String()
 	addPrefixType := reflect.TypeOf(addPrefix).String()
 	wantType := reflect.TypeOf(map[int]struct{}{}).String()
-	if skipType != wantType {
-		t.Fatalf("skip uses %s; want %s (guideline: use map[K]struct{} for sets)", skipType, wantType)
-	}
-	if addPrefixType != wantType {
-		t.Fatalf("addPrefix uses %s; want %s (guideline: use map[K]struct{} for sets)", addPrefixType, wantType)
-	}
+	assert.Equal(t, wantType, skipType, "skip must be map[int]struct{} (guideline: use map[K]struct{} for sets)")
+	assert.Equal(t, wantType, addPrefixType, "addPrefix must be map[int]struct{} (guideline: use map[K]struct{} for sets)")
 }

--- a/internal/rules/markdownflavor/rule_test.go
+++ b/internal/rules/markdownflavor/rule_test.go
@@ -419,4 +419,6 @@ func TestBuildAlertSkipMaps_SetType(t *testing.T) {
 	wantType := reflect.TypeOf(map[int]struct{}{}).String()
 	assert.Equal(t, wantType, skipType, "skip must be map[int]struct{} per high-performance Go guideline")
 	assert.Equal(t, wantType, addPrefixType, "addPrefix must be map[int]struct{} per high-performance Go guideline")
+	assert.Contains(t, skip, 1, "skip must hold the 1-based marker line number")
+	assert.Empty(t, addPrefix, "addPrefix must be empty when body line already has '>' prefix")
 }

--- a/internal/rules/markdownflavor/rule_test.go
+++ b/internal/rules/markdownflavor/rule_test.go
@@ -417,6 +417,6 @@ func TestBuildAlertSkipMaps_SetType(t *testing.T) {
 	skipType := reflect.TypeOf(skip).String()
 	addPrefixType := reflect.TypeOf(addPrefix).String()
 	wantType := reflect.TypeOf(map[int]struct{}{}).String()
-	assert.Equal(t, wantType, skipType, "skip must be map[int]struct{} (guideline: use map[K]struct{} for sets)")
-	assert.Equal(t, wantType, addPrefixType, "addPrefix must be map[int]struct{} (guideline: use map[K]struct{} for sets)")
+	assert.Equal(t, wantType, skipType, "skip must be map[int]struct{} per high-performance Go guideline")
+	assert.Equal(t, wantType, addPrefixType, "addPrefix must be map[int]struct{} per high-performance Go guideline")
 }

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -154,7 +154,7 @@ func (r *Rule) checkFromLayers(f *lint.File) []lint.Diagnostic {
 // on it, exactly as the AST branch does. It also returns that anchor offset so
 // the caller can order block and inline HTML findings by document position.
 func (r *Rule) checkHTMLBlockSpan(
-	f *lint.File, allowed map[string]bool, span lint.BlockSpan,
+	f *lint.File, allowed map[string]struct{}, span lint.BlockSpan,
 ) (lint.Diagnostic, int, bool) {
 	raw := f.Lines[span.Start-1]
 	offset := f.LineStartOffset(span.Start - 1)

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -199,7 +199,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 
 // checkRaw inspects raw HTML bytes and returns a diagnostic if the HTML
 // should be flagged. offset is the byte position of the HTML in f.Source.
-func (r *Rule) checkRaw(f *lint.File, allowed map[string]bool, raw []byte, offset int) (lint.Diagnostic, bool) {
+func (r *Rule) checkRaw(f *lint.File, allowed map[string]struct{}, raw []byte, offset int) (lint.Diagnostic, bool) {
 	tag := extractTag(raw)
 	switch {
 	case tag == "":
@@ -213,17 +213,18 @@ func (r *Rule) checkRaw(f *lint.File, allowed map[string]bool, raw []byte, offse
 	case isClosingTag(raw):
 		// Closing tags produce no extra diagnostic
 		return lint.Diagnostic{}, false
-	case allowed[tag]:
-		return lint.Diagnostic{}, false
 	default:
+		if _, ok := allowed[tag]; ok {
+			return lint.Diagnostic{}, false
+		}
 		return r.diag(f, offset, "<"+tag+">"), true
 	}
 }
 
-func (r *Rule) allowSet() map[string]bool {
-	m := make(map[string]bool, len(r.Allow))
+func (r *Rule) allowSet() map[string]struct{} {
+	m := make(map[string]struct{}, len(r.Allow))
 	for _, t := range r.Allow {
-		m[strings.ToLower(t)] = true
+		m[strings.ToLower(t)] = struct{}{}
 	}
 	return m
 }
@@ -234,9 +235,9 @@ func (r *Rule) allowSet() map[string]bool {
 // the LSP's concurrent reader pattern, where the same rule
 // instance is shared across goroutines (config defaults set
 // cfg.Settings=nil, which makes ConfigureRule a no-op).
-func (r *Rule) cachedAllowSet(f *lint.File) map[string]bool {
+func (r *Rule) cachedAllowSet(f *lint.File) map[string]struct{} {
 	v := f.Memo("MDS041.allowSet", func() any { return r.allowSet() })
-	return v.(map[string]bool)
+	return v.(map[string]struct{})
 }
 
 func (r *Rule) diag(f *lint.File, offset int, display string) lint.Diagnostic {

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	rulesettings "github.com/jeduden/mdsmith/internal/rules/settings"
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 func init() {
@@ -214,7 +215,7 @@ func (r *Rule) checkRaw(f *lint.File, allowed map[string]struct{}, raw []byte, o
 		// Closing tags produce no extra diagnostic
 		return lint.Diagnostic{}, false
 	default:
-		if _, ok := allowed[tag]; ok {
+		if setutil.Contains(allowed, tag) {
 			return lint.Diagnostic{}, false
 		}
 		return r.diag(f, offset, "<"+tag+">"), true

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -365,9 +365,7 @@ func TestAllowSet_SetType(t *testing.T) {
 	r := &Rule{Allow: []string{"kbd"}}
 	got := reflect.TypeOf(r.allowSet()).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
-	if got != want {
-		t.Fatalf("allowSet returns %s; want %s (guideline: use map[K]struct{} for sets)", got, want)
-	}
+	assert.Equal(t, want, got, "allowSet must return map[string]struct{} (guideline: use map[K]struct{} for sets)")
 }
 	}
 }

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -369,5 +369,3 @@ func TestAllowSet_SetType(t *testing.T) {
 	assert.Equal(t, want, got, "allowSet must return map[string]struct{} (guideline: use map[K]struct{} for sets)")
 	assert.Contains(t, m, "kbd", "allowSet must contain the lowercased Allow entry")
 }
-	}
-}

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -243,7 +243,7 @@ func TestCachedAllowSet(t *testing.T) {
 	require.NoError(t, err)
 
 	first := r.cachedAllowSet(f)
-	require.Equal(t, map[string]bool{"span": true, "div": true, "strong": true}, first,
+	require.Equal(t, map[string]struct{}{"span": {}, "div": {}, "strong": {}}, first,
 		"lookup keys must be lowercase normalisations of r.Allow")
 
 	second := r.cachedAllowSet(f)
@@ -355,5 +355,19 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 
 			assert.Equal(t, astDiags, nilDiags)
 		})
+	}
+}
+
+// TestAllowSet_SetType verifies that allowSet returns map[string]struct{}
+// rather than map[string]bool. Per the high-performance Go guidelines:
+// “map[K]struct{} for sets — zero-byte value type.”
+func TestAllowSet_SetType(t *testing.T) {
+	r := &Rule{Allow: []string{"kbd"}}
+	got := reflect.TypeOf(r.allowSet()).String()
+	want := reflect.TypeOf(map[string]struct{}{}).String()
+	if got != want {
+		t.Fatalf("allowSet returns %s; want %s (guideline: use map[K]struct{} for sets)", got, want)
+	}
+}
 	}
 }

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -363,9 +363,11 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 // “map[K]struct{} for sets — zero-byte value type.”
 func TestAllowSet_SetType(t *testing.T) {
 	r := &Rule{Allow: []string{"kbd"}}
-	got := reflect.TypeOf(r.allowSet()).String()
+	m := r.allowSet()
+	got := reflect.TypeOf(m).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
 	assert.Equal(t, want, got, "allowSet must return map[string]struct{} (guideline: use map[K]struct{} for sets)")
+	assert.Contains(t, m, "kbd", "allowSet must contain the lowercased Allow entry")
 }
 	}
 }

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/setutil"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 	"github.com/jeduden/mdsmith/pkg/goldmark/text"
 	"github.com/jeduden/mdsmith/pkg/goldmark/util"
@@ -634,7 +635,7 @@ func collectDefinitionCuts(f *lint.File, usedLabels map[string]struct{}) []fixCu
 	defs := collectReferenceDefinitions(f)
 	var cuts []fixCut
 	for _, d := range defs {
-		if _, ok := usedLabels[util.ToLinkReference([]byte(d.label))]; !ok {
+		if !setutil.Contains(usedLabels, util.ToLinkReference([]byte(d.label))) {
 			continue
 		}
 		start := d.start

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -577,9 +577,9 @@ func (r *Rule) Fix(f *lint.File) []byte {
 	return applyCuts(f.Source, cuts)
 }
 
-func collectLinkRewrites(f *lint.File) ([]fixCut, map[string]bool) {
+func collectLinkRewrites(f *lint.File) ([]fixCut, map[string]struct{}) {
 	var cuts []fixCut
-	usedLabels := map[string]bool{}
+	usedLabels := map[string]struct{}{}
 	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
@@ -615,7 +615,7 @@ func collectLinkRewrites(f *lint.File) ([]fixCut, map[string]bool) {
 		if isImage && start > 0 && f.Source[start-1] == '!' {
 			start--
 		}
-		usedLabels[util.ToLinkReference(ref.Value)] = true
+		usedLabels[util.ToLinkReference(ref.Value)] = struct{}{}
 		cuts = append(cuts, fixCut{
 			start: start,
 			end:   end,
@@ -626,7 +626,7 @@ func collectLinkRewrites(f *lint.File) ([]fixCut, map[string]bool) {
 	return cuts, usedLabels
 }
 
-func collectDefinitionCuts(f *lint.File, usedLabels map[string]bool) []fixCut {
+func collectDefinitionCuts(f *lint.File, usedLabels map[string]struct{}) []fixCut {
 	if len(usedLabels) == 0 {
 		return nil
 	}
@@ -634,7 +634,7 @@ func collectDefinitionCuts(f *lint.File, usedLabels map[string]bool) []fixCut {
 	defs := collectReferenceDefinitions(f)
 	var cuts []fixCut
 	for _, d := range defs {
-		if !usedLabels[util.ToLinkReference([]byte(d.label))] {
+		if _, ok := usedLabels[util.ToLinkReference([]byte(d.label))]; !ok {
 			continue
 		}
 		start := d.start

--- a/internal/rules/noreferencestyle/rule_test.go
+++ b/internal/rules/noreferencestyle/rule_test.go
@@ -507,4 +507,5 @@ func TestCollectLinkRewrites_UsedLabels_SetType(t *testing.T) {
 	got := reflect.TypeOf(usedLabels).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
 	assert.Equal(t, want, got, "usedLabels must be map[string]struct{} per high-performance Go guideline")
+	assert.Contains(t, usedLabels, "ref", "the used reference label must appear in usedLabels")
 }

--- a/internal/rules/noreferencestyle/rule_test.go
+++ b/internal/rules/noreferencestyle/rule_test.go
@@ -506,7 +506,5 @@ func TestCollectLinkRewrites_UsedLabels_SetType(t *testing.T) {
 	_, usedLabels := collectLinkRewrites(f)
 	got := reflect.TypeOf(usedLabels).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
-	if got != want {
-		t.Fatalf("collectLinkRewrites usedLabels is %s; want %s (guideline: use map[K]struct{} for sets)", got, want)
-	}
+	assert.Equal(t, want, got, "collectLinkRewrites usedLabels must be map[string]struct{} (guideline: use map[K]struct{} for sets)")
 }

--- a/internal/rules/noreferencestyle/rule_test.go
+++ b/internal/rules/noreferencestyle/rule_test.go
@@ -1,6 +1,7 @@
 package noreferencestyle
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -494,5 +495,18 @@ func TestIsFootnoteDefinitionAt(t *testing.T) {
 			assert.Equalf(t, c.want, got,
 				"isFootnoteDefinitionAt(%q, %d)", c.source, c.start)
 		})
+	}
+}
+
+// TestCollectLinkRewrites_UsedLabels_SetType verifies that collectLinkRewrites
+// returns map[string]struct{} for its usedLabels set rather than map[string]bool.
+// Per the high-performance Go guidelines: "map[K]struct{} for sets — zero-byte value type."
+func TestCollectLinkRewrites_UsedLabels_SetType(t *testing.T) {
+	f := newFile(t, "See [example][ref].\n\n[ref]: https://example.com/\n")
+	_, usedLabels := collectLinkRewrites(f)
+	got := reflect.TypeOf(usedLabels).String()
+	want := reflect.TypeOf(map[string]struct{}{}).String()
+	if got != want {
+		t.Fatalf("collectLinkRewrites usedLabels is %s; want %s (guideline: use map[K]struct{} for sets)", got, want)
 	}
 }

--- a/internal/rules/noreferencestyle/rule_test.go
+++ b/internal/rules/noreferencestyle/rule_test.go
@@ -506,5 +506,5 @@ func TestCollectLinkRewrites_UsedLabels_SetType(t *testing.T) {
 	_, usedLabels := collectLinkRewrites(f)
 	got := reflect.TypeOf(usedLabels).String()
 	want := reflect.TypeOf(map[string]struct{}{}).String()
-	assert.Equal(t, want, got, "collectLinkRewrites usedLabels must be map[string]struct{} (guideline: use map[K]struct{} for sets)")
+	assert.Equal(t, want, got, "usedLabels must be map[string]struct{} per high-performance Go guideline")
 }


### PR DESCRIPTION
## Summary

Performance audit of the mdsmith codebase against `docs/development/high-performance-go.md`, implementing the top 5 fixes identified. All changes follow Red/Green TDD and were reviewed at xhigh severity through three rounds.

### Fixes

| # | Guideline | Change | Location |
|---|-----------|--------|----------|
| 1 | `map[K]struct{}` for sets — zero-byte value type | `builtInTypes`, `buildAllowSet`, `cachedAllowSet` changed from `map[string]bool` to `map[string]struct{}` | `callouttype/rule.go` |
| 2 | `map[K]struct{}` for sets | `allowSet`, `cachedAllowSet`, `checkRaw` parameter changed from `map[string]bool` to `map[string]struct{}` | `noinlinehtml/rule.go` |
| 3 | `map[K]struct{}` for sets | `collectLinkRewrites` return and `collectDefinitionCuts` parameter changed from `map[string]bool` to `map[string]struct{}`; lookups use `setutil.Contains` | `noreferencestyle/rule.go` |
| 4 | `strings.Builder` over `+=` in a loop | `wrapComment` rewritten to use `strings.Builder` with `Grow()`, eliminating per-word string-copy allocations | `markdownlint/emit.go` |
| 5 | `map[K]struct{}` for sets | `fixGitHubAlerts` split into `buildAlertSkipMaps` (extracted, testable) + caller; internal sets changed from `map[int]bool` to `map[int]struct{}` | `markdownflavor/rule.go` |

### Motivation

`map[K]bool` uses 1 byte per value; `map[K]struct{}` uses 0 bytes. For the allow-sets and skip-sets in these rules the value is never read — only key presence matters. The `strings.Builder` change in `wrapComment` eliminates `O(n)` string copies where `n` is the word count, replacing them with a single pre-grown buffer that resets in place.

### Review process

Three xhigh-severity code reviews were run. Issues addressed:

- **Round 1**: Replaced inline `_, ok := m[k]` patterns with `setutil.Contains` for consistency; replaced `t.Fatalf` with `assert.Equal` in type-assertion tests.
- **Round 2**: Fixed lll-violating lines in two test files (126 chars → 106 chars with tab=4).
- **Round 3**: Removed redundant `prefix` variable in `wrapComment` (both constants are 4 chars so `len(prefix)` was always `len(first)`); added value assertions to all four set-type tests so a correctly-typed but empty map would be caught.

All correctness candidates raised across three rounds were **REFUTED** — trailing-newline handling, nil-AST path, case-sensitivity in tag lookup, and compound short-circuit split were all confirmed correct by reading the code and existing tests.

## Test plan

- [x] Each fix was preceded by a failing test (type assertion via `reflect.TypeOf` / alloc count via `testing.AllocsPerRun`)
- [x] `go test ./...` passes
- [x] Codecov patch coverage: 100%
- [x] `golangci-lint` passes (lll, prealloc, all other checks)
- [x] Three xhigh code reviews completed; all issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QURsYz9kzfdM95dPkjS3Fy