### PR TITLE
fix(deps): bump markdown-it to 14.2.0 and js-yaml to 4.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/docs/research/benchmarks/npm"
+    open-pull-requests-limit: 1
+    schedule:
+      interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ e2e-cover/
 unit.cov
 merged.cov
 .github/scripts/node_modules/
+docs/research/benchmarks/npm/node_modules/
 .claude/worktrees/
 # Pulled from the orphan assets branch at site-build time by
 # mdsmith-release pull-site-assets; never committed.

--- a/docs/research/benchmarks/npm/package-lock.json
+++ b/docs/research/benchmarks/npm/package-lock.json
@@ -396,9 +396,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -439,23 +449,43 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/docs/research/benchmarks/npm/package.json
+++ b/docs/research/benchmarks/npm/package.json
@@ -6,5 +6,9 @@
   "license": "MIT",
   "dependencies": {
     "markdownlint-cli2": "0.22.1"
+  },
+  "overrides": {
+    "js-yaml": "4.2.0",
+    "markdown-it": "14.2.0"
   }
 }

--- a/docs/research/benchmarks/npm/package.json
+++ b/docs/research/benchmarks/npm/package.json
@@ -9,6 +9,7 @@
   },
   "overrides": {
     "js-yaml": "4.2.0",
-    "markdown-it": "14.2.0"
+    "markdown-it": "14.2.0",
+    "linkify-it": "5.0.1"
   }
 }


### PR DESCRIPTION
## Summary

Fixes two medium-severity Dependabot alerts in `docs/research/benchmarks/npm/`:

- **GHSA-6v5v-wf23-fmfq** (CVE-2026-48988): `markdown-it` ≤ 14.1.1 — quadratic DoS via smartquotes `replaceAt` string operations. Fixed in 14.2.0.
- **GHSA-h67p-54hq-rp68** (CVE-2026-53550): `js-yaml` ≤ 4.1.1 — quadratic DoS via repeated YAML merge-key aliases. Fixed in 4.2.0.

## Changes

- Added `overrides` in `package.json` to force the patched versions, since `markdownlint-cli2@0.22.1` pins both packages at the vulnerable exact versions.
- Regenerated `package-lock.json` via `npm install` — `npm audit` reports 0 vulnerabilities.
- Also bumps `linkify-it` 5.0.0 → 5.0.1, required by `markdown-it` 14.2.0 (`^5.0.1`).
- Added `docs/research/benchmarks/npm/node_modules/` to `.gitignore` (the directory is produced by `npm ci`/`npm install` but was not previously ignored).

## Test plan

- [ ] `npm audit` in `docs/research/benchmarks/npm/` reports 0 vulnerabilities
- [ ] `npm ci` installs cleanly from the updated lockfile
- [ ] `mdsmith check .` passes (no markdown regressions)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLZLLoyvN1dTTUVTd6Bvng

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLZLLoyvN1dTTUVTd6Bvng)_