### PR TITLE
feat(2606171258): promote MDS066 to Layer 0 so parity skips the parse

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -205,7 +205,7 @@ footer: |
 | 2606162213 | ✅     | sonnet | [Document internal/checker and internal/rulelayer; remove engine shim](plan/2606162213_arch-fix-new-pkg-docs.md)                        |
 | 2606162214 | ✅     | sonnet | [Add named unit tests for unexported helpers in new lazy-parse packages](plan/2606162214_arch-fix-missing-helper-tests.md)              |
 | 2606171136 | ✅     | opus   | [Parity perf: per-worker configured-rule cache + the Layer-0 path to gomarklint](plan/2606171136_parity-perf-configured-rule-cache.md)  |
-| 2606171258 | 🔳     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
+| 2606171258 | ✅     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
 | 2606171400 | ✅     | opus   | [Parity parse-skip: unify the two Layer-0 gate mechanisms](plan/2606171400_parity-gate-unification.md)                                  |
 | 2606171401 | ✅     | opus   | [Parity parse-skip: migrate the Layer-0 heading and front-matter rules](plan/2606171401_parity-layer0-heading-rules.md)                 |
 | 2606171402 | ✅     | sonnet | [Parity parse-skip: migrate the Layer-0 fenced-code rules](plan/2606171402_parity-layer0-fenced-code-rules.md)                          |

--- a/internal/engine/parity_layer0_test.go
+++ b/internal/engine/parity_layer0_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
@@ -74,17 +75,30 @@ func TestParityConvention_SkipsParse(t *testing.T) {
 	require.Empty(t, res.Errors)
 	assert.True(t, probe.sawNilAST,
 		"a parity run on a benchmark-shaped file must skip the parse")
+
+	firedMDS066 := false
+	for _, d := range res.Diagnostics {
+		if d.RuleID == "MDS066" {
+			firedMDS066 = true
+			break
+		}
+	}
+	assert.True(t, firedMDS066,
+		"MDS066 must fire on the parse-skipped path so the skip is exercised, not just observed")
 }
 
 // TestParityConvention_DiagnosticsMatchFullParse is the equivalence guarantee
 // for the parity parse-skip: the diagnostics a parity run produces with the
 // gate on (nil AST) are identical to the same run with the gate off (full
-// parse). The fixture trips MDS066 so the comparison is not vacuous.
+// parse). The comparison is on the full diagnostic slice — rule id, line,
+// column, message — not just the count, so a regression that moves MDS066's
+// diagnostic or swaps it for another rule's is caught. The fixture trips
+// MDS066 so the comparison is not vacuous.
 func TestParityConvention_DiagnosticsMatchFullParse(t *testing.T) {
 	dir, path := writeDoc(t, "# Title\n\nProse line.\n\n```sh\n$ make\n$ make test\n```\n")
 	cfg := parityConfig(t)
 
-	run := func(skip bool) int {
+	run := func(skip bool) []lint.Diagnostic {
 		withLayer0Skip(t, skip)
 		r := &Runner{
 			Config:           cfg,
@@ -94,12 +108,12 @@ func TestParityConvention_DiagnosticsMatchFullParse(t *testing.T) {
 		}
 		res := r.Run([]string{path})
 		require.Empty(t, res.Errors)
-		return len(res.Diagnostics)
+		return res.Diagnostics
 	}
 
 	skipped := run(true)
 	parsed := run(false)
-	require.NotZero(t, parsed, "MDS066 must fire so the comparison is not vacuous")
+	require.NotEmpty(t, parsed, "MDS066 must fire so the comparison is not vacuous")
 	assert.Equal(t, parsed, skipped,
 		"parity parse-skip must produce the same diagnostics as a full parse")
 }

--- a/internal/engine/parity_layer0_test.go
+++ b/internal/engine/parity_layer0_test.go
@@ -1,0 +1,105 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+// parityConfig resolves the built-in `parity` convention the way the CLI
+// does: parse a `.mdsmith.yml` selecting it, then merge it onto the defaults
+// so the convention preset disables the mdsmith-only rules while the
+// markdownlint-parity rules stay enabled.
+func parityConfig(t *testing.T) *config.Config {
+	t.Helper()
+	loaded, err := config.ParseBytes([]byte("convention: parity\n"))
+	require.NoError(t, err)
+	return config.Merge(config.Defaults(), loaded)
+}
+
+// TestParityConvention_AllEnabledRulesSkipSafe is the parent plan's
+// acceptance criterion 1: every parity-enabled rule resolves to a parse-skip
+// layer (rulelayer Layer 0 or, for line-length, configured rule.LineCapable).
+// MDS066 (commands-show-output) was the lone holdout — a "B-prose-only" rule
+// the static category withheld from Layer 0 — until it was promoted via the
+// blockSkipSafe override. If a future parity rule regrows an AST dependency,
+// this fails and names it.
+func TestParityConvention_AllEnabledRulesSkipSafe(t *testing.T) {
+	cfg := parityConfig(t)
+	eff := config.Effective(cfg, "doc.md", nil, nil)
+
+	enabled := 0
+	var notSafe []string
+	for _, rl := range rule.All() {
+		c, ok := eff[rl.Name()]
+		if !ok || !c.Enabled {
+			continue
+		}
+		enabled++
+		if !allEnabledRulesSkipSafe([]rule.Rule{rl}, eff) {
+			notSafe = append(notSafe, rl.ID()+" "+rl.Name())
+		}
+	}
+	sort.Strings(notSafe)
+	require.NotZero(t, enabled, "parity must enable some rules or the check is vacuous")
+	assert.Empty(t, notSafe, "every parity-enabled rule must be parse-skip-safe")
+}
+
+// TestParityConvention_SkipsParse is the parent plan's acceptance criterion
+// 3: with the gate on, `mdsmith check -c parity` skips the goldmark parse for
+// a benchmark-style file (no directive, no list, no block quote — the neutral
+// corpus shape). The probe records whether the File it received had a nil AST.
+func TestParityConvention_SkipsParse(t *testing.T) {
+	withLayer0Skip(t, true)
+	// Headings, prose, and a fenced code block of shell prompts so MDS066
+	// (commands-show-output) is exercised on the parse-skipped path.
+	dir, path := writeDoc(t, "# Title\n\nSome prose paragraph.\n\n```sh\n$ build\n$ test\n```\n")
+
+	probe := &astProbeRule{}
+	cfg := parityConfig(t)
+	cfg.Rules[probe.Name()] = config.RuleCfg{Enabled: true}
+
+	r := &Runner{
+		Config:           cfg,
+		Rules:            append(rule.All(), probe),
+		StripFrontMatter: true,
+		RootDir:          dir,
+	}
+	res := r.Run([]string{path})
+	require.Empty(t, res.Errors)
+	assert.True(t, probe.sawNilAST,
+		"a parity run on a benchmark-shaped file must skip the parse")
+}
+
+// TestParityConvention_DiagnosticsMatchFullParse is the equivalence guarantee
+// for the parity parse-skip: the diagnostics a parity run produces with the
+// gate on (nil AST) are identical to the same run with the gate off (full
+// parse). The fixture trips MDS066 so the comparison is not vacuous.
+func TestParityConvention_DiagnosticsMatchFullParse(t *testing.T) {
+	dir, path := writeDoc(t, "# Title\n\nProse line.\n\n```sh\n$ make\n$ make test\n```\n")
+	cfg := parityConfig(t)
+
+	run := func(skip bool) int {
+		withLayer0Skip(t, skip)
+		r := &Runner{
+			Config:           cfg,
+			Rules:            rule.All(),
+			StripFrontMatter: true,
+			RootDir:          dir,
+		}
+		res := r.Run([]string{path})
+		require.Empty(t, res.Errors)
+		return len(res.Diagnostics)
+	}
+
+	skipped := run(true)
+	parsed := run(false)
+	require.NotZero(t, parsed, "MDS066 must fire so the comparison is not vacuous")
+	assert.Equal(t, parsed, skipped,
+		"parity parse-skip must produce the same diagnostics as a full parse")
+}

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -1219,9 +1219,13 @@ func (r *Runner) anyRepoScopedEnabled() bool {
 	return false
 }
 
-// sortDiagnostics sorts diagnostics by file, line, column, then message.
-// sort.SliceStable preserves the input order only for diagnostics that are
-// equal on all compared fields, including Message.
+// sortDiagnostics sorts diagnostics by file, line, column, message, then
+// rule id. The RuleID tiebreak makes the order independent of the walk path
+// that produced the diagnostics: the parse-skip block-walk and the full-parse
+// node-walk can emit two same-position, same-message diagnostics from
+// different rules in different input orders, and the Layer-0 equivalence
+// assertions compare full ordered slices. sort.SliceStable then preserves
+// input order only for diagnostics equal on every compared field.
 func sortDiagnostics(diags []lint.Diagnostic) {
 	sort.SliceStable(diags, func(i, j int) bool {
 		di, dj := diags[i], diags[j]
@@ -1234,6 +1238,9 @@ func sortDiagnostics(diags []lint.Diagnostic) {
 		if di.Column != dj.Column {
 			return di.Column < dj.Column
 		}
-		return di.Message < dj.Message
+		if di.Message != dj.Message {
+			return di.Message < dj.Message
+		}
+		return di.RuleID < dj.RuleID
 	})
 }

--- a/internal/engine/runner_helpers_test.go
+++ b/internal/engine/runner_helpers_test.go
@@ -172,3 +172,22 @@ func TestEffectiveCached_MemoizesBySignature(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(a).Pointer(), reflect.ValueOf(b).Pointer(),
 		"a matching signature must return the memoized map instance")
 }
+
+// TestSortDiagnostics_TieBreaksByRuleID pins that sortDiagnostics produces a
+// deterministic order even when two diagnostics share File, Line, Column, and
+// Message but come from different rules. Without a RuleID tiebreak, the order
+// of such a pair depends on the caller's input order — which differs between
+// the parse-skip block-walk path and the full-parse node-walk path — so the
+// Layer-0 equivalence assertions (TestParityConvention_DiagnosticsMatchFullParse,
+// the corpus gate) that compare full ordered slices could fail spuriously.
+func TestSortDiagnostics_TieBreaksByRuleID(t *testing.T) {
+	// Same File/Line/Column/Message, different RuleID, fed in reverse order.
+	diags := []lint.Diagnostic{
+		{File: "a.md", Line: 1, Column: 1, RuleID: "MDS099", Message: "same"},
+		{File: "a.md", Line: 1, Column: 1, RuleID: "MDS001", Message: "same"},
+	}
+	sortDiagnostics(diags)
+	assert.Equal(t, "MDS001", diags[0].RuleID,
+		"diagnostics equal on File/Line/Column/Message must order by RuleID")
+	assert.Equal(t, "MDS099", diags[1].RuleID)
+}

--- a/internal/rulelayer/rulelayer.go
+++ b/internal/rulelayer/rulelayer.go
@@ -82,12 +82,38 @@ var knownNilASTSafe = map[string]bool{
 	"MDS069": true, // unique-frontmatter: reads f.FrontMatter + RunCache, never f.AST
 }
 
+// blockSkipSafe lists rules the audit marks "B-prose-only" — nil-AST-safe but
+// code-content-sensitive, so the static category withholds Layer 0 — that are
+// nonetheless safe to skip the parse for, because the only code-content they
+// read is reproduced by the Layer 0 block scan plus f.Lines. The audit's
+// code-perturbation probe measures whether a rule's diagnostics move when
+// code-block bytes change; a rule that lints code-block *bodies* (as opposed
+// to ignoring them) is sensitive by construction and lands in B-prose-only,
+// even when its rule.BlockChecker nil-AST path produces byte-identical output.
+//
+// MDS066 (commands-show-output) is the canonical entry: it flags a fenced
+// block whose every body line is a "$ " prompt. Its CheckBlock reads the
+// BlockFencedCode span's body lines straight from f.Lines, which the Layer 0
+// scan delimits exactly as goldmark does — confirmed byte-identical across the
+// full corpus and gated by TestLayer0Gate_CorpusDiagnosticsEquivalence. It was
+// the lone parity-enabled rule still forcing the AST; promoting it lets
+// `mdsmith check -c parity` skip the parse.
+//
+// Adding a rule here is a manual commitment that (1) its Check is nil-AST-safe
+// (enforced by rulelayer_test.go against the manifest's nil_ast_safe signal)
+// and (2) its nil-AST output matches the AST output across the corpus
+// equivalence gate.
+var blockSkipSafe = map[string]bool{
+	"MDS066": true, // commands-show-output: CheckBlock reads the fenced-code body from f.Lines
+}
+
 // buildLayerMap decodes the embedded manifest into the id→layer table.
 // "A-no-skipping" rules are Layer 0 unless they appear in
-// astProjectionConsumers (which need an AST-only inline projection); every
-// other category needs the AST. A decode failure is a build-time contract
-// violation (the embedded JSON is checked in), so it panics rather than
-// silently degrading.
+// astProjectionConsumers (which need an AST-only inline projection); a rule in
+// knownNilASTSafe or blockSkipSafe is promoted to Layer 0 from another
+// category; every other category needs the AST. A decode failure is a
+// build-time contract violation (the embedded JSON is checked in), so it
+// panics rather than silently degrading.
 func buildLayerMap() map[string]Layer {
 	return buildLayerMapFrom(auditJSON)
 }
@@ -105,7 +131,7 @@ func buildLayerMapFrom(manifest []byte) map[string]Layer {
 	m := make(map[string]Layer, len(entries))
 	for _, e := range entries {
 		if !astProjectionConsumers[e.ID] &&
-			(knownNilASTSafe[e.ID] || e.Category == "A-no-skipping") {
+			(knownNilASTSafe[e.ID] || blockSkipSafe[e.ID] || e.Category == "A-no-skipping") {
 			m[e.ID] = Layer0
 		} else {
 			m[e.ID] = LayerAST

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -125,10 +125,7 @@ func TestBlockSkipSafeAreNilASTSafe(t *testing.T) {
 		nilSafe[e.ID] = e.NilASTSafe
 	}
 	for id := range blockSkipSafe {
-		present := false
-		if _, ok := nilSafe[id]; ok {
-			present = true
-		}
+		_, present := nilSafe[id]
 		assert.True(t, present, "%s in blockSkipSafe must appear in the audit manifest", id)
 		assert.True(t, nilSafe[id],
 			"%s in blockSkipSafe must have nil_ast_safe: true", id)
@@ -272,4 +269,22 @@ func TestAstProjectionConsumerOverridesKnownNilASTSafe(t *testing.T) {
 		{"id":"MDS903","category":"inconclusive-not-fired"}
 	]`))
 	assert.Equal(t, LayerAST, m["MDS903"], "astProjectionConsumers must override knownNilASTSafe")
+}
+
+// TestAstProjectionConsumerOverridesBlockSkipSafe pins that astProjectionConsumers
+// wins over blockSkipSafe: a rule in both must still resolve to LayerAST because it
+// reads an AST-only projection the Layer 0 block scan does not back, regardless of
+// the block-skip override. This guards the soundness escape hatch — buildLayerMapFrom
+// gates the whole Layer 0 promotion behind !astProjectionConsumers[e.ID].
+func TestAstProjectionConsumerOverridesBlockSkipSafe(t *testing.T) {
+	astProjectionConsumers["MDS904"] = true
+	blockSkipSafe["MDS904"] = true
+	t.Cleanup(func() {
+		delete(astProjectionConsumers, "MDS904")
+		delete(blockSkipSafe, "MDS904")
+	})
+	m := buildLayerMapFrom([]byte(`[
+		{"id":"MDS904","category":"B-prose-only"}
+	]`))
+	assert.Equal(t, LayerAST, m["MDS904"], "astProjectionConsumers must override blockSkipSafe")
 }

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -86,6 +86,67 @@ func TestIsLayer0(t *testing.T) {
 	}
 }
 
+// TestBlockSkipSafeAreLayer0 confirms every rule in the blockSkipSafe
+// override resolves to Layer 0 even though its audit category is
+// "B-prose-only". MDS066 (commands-show-output) is the canonical entry: the
+// audit's code-perturbation probe marks it code-content-sensitive
+// ("B-prose-only"), but its only code-content read is the fenced-code body,
+// which the Layer 0 block scan plus f.Lines reproduces byte-identically (a
+// rule.BlockChecker nil-AST path gated across the corpus by
+// TestLayer0Gate_CorpusDiagnosticsEquivalence). Promoting it lets
+// `mdsmith check -c parity` skip the parse: parity enables MDS066 and it was
+// the lone rule still forcing the AST.
+func TestBlockSkipSafeAreLayer0(t *testing.T) {
+	for id := range blockSkipSafe {
+		assert.True(t, IsLayer0(id), "%s is in blockSkipSafe; must be Layer 0", id)
+		assert.Equal(t, Layer0, Of(id))
+	}
+	assert.True(t, blockSkipSafe["MDS066"], "MDS066 must be in the block-skip-safe set")
+}
+
+// TestBlockSkipSafeAreNilASTSafe guards the override's manual commitment: a
+// rule may only be force-classified Layer 0 here when its audit manifest
+// entry reports nil_ast_safe: true (its Check survives a nil AST with the
+// same diagnostics). A rule whose nil-AST path regresses trips its
+// nil_ast_safe signal and this test fails until the override is reconsidered.
+func TestBlockSkipSafeAreNilASTSafe(t *testing.T) {
+	oracle, err := os.ReadFile(filepath.Join(
+		"..", "integration", "testdata", "rule_walk_audit.json"))
+	require.NoError(t, err)
+
+	var entries []struct {
+		ID         string `json:"id"`
+		NilASTSafe bool   `json:"nil_ast_safe"`
+	}
+	require.NoError(t, json.Unmarshal(oracle, &entries))
+
+	nilSafe := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		nilSafe[e.ID] = e.NilASTSafe
+	}
+	for id := range blockSkipSafe {
+		present := false
+		if _, ok := nilSafe[id]; ok {
+			present = true
+		}
+		assert.True(t, present, "%s in blockSkipSafe must appear in the audit manifest", id)
+		assert.True(t, nilSafe[id],
+			"%s in blockSkipSafe must have nil_ast_safe: true", id)
+	}
+}
+
+// TestBuildLayerMapFromBlockSkipSafePromotesToLayer0 exercises the
+// blockSkipSafe branch of buildLayerMapFrom directly with a synthetic entry:
+// a "B-prose-only" rule listed in blockSkipSafe must resolve to Layer0.
+func TestBuildLayerMapFromBlockSkipSafePromotesToLayer0(t *testing.T) {
+	blockSkipSafe["MDS905"] = true
+	t.Cleanup(func() { delete(blockSkipSafe, "MDS905") })
+	m := buildLayerMapFrom([]byte(`[
+		{"id":"MDS905","category":"B-prose-only"}
+	]`))
+	assert.Equal(t, Layer0, m["MDS905"], "blockSkipSafe promotes B-prose-only rule to Layer0")
+}
+
 // TestAstProjectionConsumersAreNotLayer0 guards the parse-skip gate's
 // soundness invariant: any rule the manifest marks "A-no-skipping" yet
 // listed in astProjectionConsumers (because it reads an AST-only projection

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -10,6 +10,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// auditSignal decodes the embedded manifest and returns an id→signal map for
+// one boolean field (selected by sel). It reads auditJSON — the embedded copy
+// TestEmbeddedManifestMatchesAuditOracle keeps byte-identical to the on-disk
+// oracle — so the override-soundness tests share one decode path and no longer
+// duplicate the os.ReadFile/filepath.Join/Unmarshal boilerplate.
+func auditSignal(t *testing.T, sel func(auditSignalEntry) bool) map[string]bool {
+	t.Helper()
+	var entries []auditSignalEntry
+	require.NoError(t, json.Unmarshal(auditJSON, &entries))
+	m := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		m[e.ID] = sel(e)
+	}
+	return m
+}
+
+// auditSignalEntry is the subset of the rule-walk manifest the override tests
+// read: the rule id plus the two boolean signals the override contracts pin.
+type auditSignalEntry struct {
+	ID           string `json:"id"`
+	NilASTSafe   bool   `json:"nil_ast_safe"`
+	ReadsFileAST bool   `json:"reads_file_ast"`
+}
+
 // TestEmbeddedManifestMatchesAuditOracle keeps the embedded copy of the
 // rule-walk manifest byte-identical to the audit oracle the integration
 // gate enforces. If the audit re-classifies a rule, this fails until the
@@ -110,20 +134,7 @@ func TestBlockSkipSafeAreLayer0(t *testing.T) {
 // same diagnostics). A rule whose nil-AST path regresses trips its
 // nil_ast_safe signal and this test fails until the override is reconsidered.
 func TestBlockSkipSafeAreNilASTSafe(t *testing.T) {
-	oracle, err := os.ReadFile(filepath.Join(
-		"..", "integration", "testdata", "rule_walk_audit.json"))
-	require.NoError(t, err)
-
-	var entries []struct {
-		ID         string `json:"id"`
-		NilASTSafe bool   `json:"nil_ast_safe"`
-	}
-	require.NoError(t, json.Unmarshal(oracle, &entries))
-
-	nilSafe := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		nilSafe[e.ID] = e.NilASTSafe
-	}
+	nilSafe := auditSignal(t, func(e auditSignalEntry) bool { return e.NilASTSafe })
 	for id := range blockSkipSafe {
 		_, present := nilSafe[id]
 		assert.True(t, present, "%s in blockSkipSafe must appear in the audit manifest", id)
@@ -178,20 +189,7 @@ func TestKnownNilASTSafeAreLayer0(t *testing.T) {
 // f.AST read trips its static signal and this test fails until the override
 // is reconsidered.
 func TestKnownNilASTSafeOnlyListsNonASTReaders(t *testing.T) {
-	oracle, err := os.ReadFile(filepath.Join(
-		"..", "integration", "testdata", "rule_walk_audit.json"))
-	require.NoError(t, err)
-
-	var entries []struct {
-		ID           string `json:"id"`
-		ReadsFileAST bool   `json:"reads_file_ast"`
-	}
-	require.NoError(t, json.Unmarshal(oracle, &entries))
-
-	readsAST := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		readsAST[e.ID] = e.ReadsFileAST
-	}
+	readsAST := auditSignal(t, func(e auditSignalEntry) bool { return e.ReadsFileAST })
 	for id := range knownNilASTSafe {
 		_, present := readsAST[id]
 		assert.True(t, present, "%s in knownNilASTSafe must appear in the audit manifest", id)

--- a/plan/2606171258_parity-layer0-parse-skip.md
+++ b/plan/2606171258_parity-layer0-parse-skip.md
@@ -1,7 +1,7 @@
 ---
 id: 2606171258
 title: "Parity Layer-0 parse-skip: migrate the AST-forcing parity rules"
-status: "🔳"
+status: "✅"
 summary: >-
   Move every parity-active rule that still forces the goldmark parse onto
   the Layer-0 / Layer-1 projections so `mdsmith check -c parity` can skip
@@ -122,10 +122,35 @@ fix plus a guard removal.
 - [x] Code guard removed; skip File carries `ClassifyLines`; the corpus
       equivalence gate engages on code files and is green.
 
+## Closing the set: MDS066
+
+The five batch plans landed every rule's nil-AST path. But one rule still
+forced the parse under parity: MDS066 commands-show-output. The walk audit
+marks it `B-prose-only`, because it lints the fenced-code *body* (a block of
+`$ ` prompts) rather than ignoring it. The static category withholds Layer 0
+from any code-content-sensitive rule. So `IsLayer0(MDS066)` stayed false and
+the all-or-nothing gate kept parsing.
+
+MDS066 is nonetheless parse-skip-safe: its `CheckBlock` reads the
+`BlockFencedCode` span's body straight from `f.Lines`, which the Layer 0
+scan delimits exactly as goldmark does. A corpus sweep confirmed its
+nil-AST output is byte-identical to the AST output on all 1054 files (it
+fires on one). MDS066 is the only `B-prose-only` rule parity enables —
+MDS041, MDS050, MDS052 are all disabled by the convention — so it was the
+lone blocker.
+
+The fix is a `blockSkipSafe` override in `rulelayer`, parallel to
+`knownNilASTSafe`. It promotes a nil-AST-safe, block-scan-backed rule to
+Layer 0 from `B-prose-only`. A contract test pins that every entry has
+`nil_ast_safe: true`. The corpus equivalence gate now exercises MDS066 on
+the parse-skipped path.
+
 ## Acceptance Criteria
 
-- [ ] Every AST-forcing parity rule resolves to Layer 0 / Layer 1.
-- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with the full
+- [x] Every AST-forcing parity rule resolves to Layer 0 / Layer 1.
+- [x] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with the full
       parity set enabled.
-- [ ] `mdsmith check -c parity` skips the parse on benchmark 2.
-- [ ] All tests pass: `go test ./...`.
+- [x] `mdsmith check -c parity` skips the parse on benchmark 2
+      (`TestParityConvention_SkipsParse` and
+      `TestParityConvention_AllEnabledRulesSkipSafe`).
+- [x] All tests pass: `go test ./...`.


### PR DESCRIPTION
Closes plan `plan/2606171258_parity-layer0-parse-skip.md`.

## Context

The five batch sub-plans (2606171400–2606171404) all landed their rules' nil-AST paths, but one parity-enabled rule still forced the goldmark parse: **MDS066 commands-show-output**. The walk audit marks it `B-prose-only` because it lints fenced-code *bodies* (a block of `$ ` prompts), which makes it code-content-sensitive. `IsLayer0` withholds Layer 0 from that category, so the all-or-nothing parse-skip gate kept parsing for `-c parity`.

## What changed

- **`internal/rulelayer`**: added a `blockSkipSafe` override (parallel to `knownNilASTSafe`) that promotes a nil-AST-safe, block-scan-backed `B-prose-only` rule to Layer 0. MDS066's `CheckBlock` reads the `BlockFencedCode` span body straight from `f.Lines`, which the Layer 0 scan reproduces byte-identically — confirmed across all 1054 corpus files (it fires on one). A contract test pins that every `blockSkipSafe` entry has `nil_ast_safe: true`.
- **`internal/engine/parity_layer0_test.go`**: new acceptance tests — every parity-enabled rule is parse-skip-safe, a parity run on a benchmark-shaped file skips the parse, and parse-skip diagnostics match the full parse.
- MDS066 is the only `B-prose-only` rule parity enables (MDS041, MDS050, MDS052 are all disabled by the convention), so this was the lone blocker.

## Acceptance criteria (all met)

- [x] Every AST-forcing parity rule resolves to Layer 0 / Layer 1
- [x] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green (now exercises MDS066 on the parse-skipped path)
- [x] `mdsmith check -c parity` skips the parse on benchmark 2
- [x] `go test ./...` passes

Followed Red/Green TDD: the rulelayer override and the engine acceptance tests were written failing first, then made green. `go vet ./...` and `mdsmith check .` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up1W62JDrMHov8Kvv5SnUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up1W62JDrMHov8Kvv5SnUj)_