### PR TITLE
perf: eliminate allocation in isMarkdownPath; add coverage tests for map-set changes

### DIFF
--- a/internal/rules/callouttype/rule_test.go
+++ b/internal/rules/callouttype/rule_test.go
@@ -119,6 +119,21 @@ func TestApplySettings_AllowUnknown(t *testing.T) {
 	assert.True(t, r.AllowUnknown)
 }
 
+// TestBuildAllowSet_ContainsBuiltInTypes verifies that every built-in
+// type is present and that user-supplied names are stored lowercase.
+func TestBuildAllowSet_ContainsBuiltInTypes(t *testing.T) {
+	r := &Rule{Allow: []string{"CUSTOM"}}
+	allowed := r.buildAllowSet()
+	for want := range builtInTypes {
+		if _, ok := allowed[want]; !ok {
+			t.Errorf("buildAllowSet: missing built-in type %q", want)
+		}
+	}
+	if _, ok := allowed["custom"]; !ok {
+		t.Error("buildAllowSet: user-supplied 'CUSTOM' not stored as 'custom'")
+	}
+}
+
 func TestApplySettings_BadTypes(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{"allow": "string-not-list"})

--- a/internal/rules/crossfilereferenceintegrity/ismarkdownpath_test.go
+++ b/internal/rules/crossfilereferenceintegrity/ismarkdownpath_test.go
@@ -1,0 +1,22 @@
+package crossfilereferenceintegrity
+
+import "testing"
+
+// TestIsMarkdownPath_UpperCaseZeroAllocs guards against strings.ToLower
+// allocating when the extension is uppercase. strings.EqualFold compares
+// without allocating; strings.ToLower + "==" allocates a new string for
+// any extension that contains an upper-case byte.
+func TestIsMarkdownPath_UpperCaseZeroAllocs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = isMarkdownPath("docs/README.MD")
+	})
+	if allocs > 0 {
+		t.Fatalf("isMarkdownPath: expected 0 allocs/op for upper-case extension, got %.0f", allocs)
+	}
+}

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -987,8 +987,8 @@ func resolveWorkspaceRelTarget(sourcePath, linkPath string) (string, bool) {
 }
 
 func isMarkdownPath(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	return ext == ".md" || ext == ".markdown"
+	ext := filepath.Ext(path)
+	return strings.EqualFold(ext, ".md") || strings.EqualFold(ext, ".markdown")
 }
 
 func normalizeLinkPath(linkPath string) string {

--- a/internal/rules/markdownflavor/fix_test.go
+++ b/internal/rules/markdownflavor/fix_test.go
@@ -137,6 +137,18 @@ func TestRuleFixAlertAndByteRangeFeatureCompose(t *testing.T) {
 		"> Visit <https://example.com> for old details.\n", got)
 }
 
+// TestFixGitHubAlerts_LazyContinuation verifies that fixGitHubAlerts
+// re-adds the "> " prefix to lazy-continuation lines (lines in the
+// first paragraph that lack a blockquote marker in the raw source)
+// after stripping the [!TYPE] marker line. This exercises the addPrefix
+// map in fixGitHubAlerts.
+func TestFixGitHubAlerts_LazyContinuation(t *testing.T) {
+	// The second line is a CommonMark lazy continuation: no "> " prefix.
+	src := "> [!NOTE]\nThis is lazy-continuation body.\n"
+	got := fixWith(t, "commonmark", src)
+	assert.Equal(t, "> This is lazy-continuation body.\n", got)
+}
+
 // TestRuleFixStrikethroughWithNestedInlineSkips guards the robustness
 // of delimiterPairEdits: a wrapper containing nested inline markup
 // (emphasis, link, code span) cannot be safely unwrapped without

--- a/internal/rules/noinlinehtml/rule_test.go
+++ b/internal/rules/noinlinehtml/rule_test.go
@@ -19,6 +19,22 @@ func newRawHTMLNode() *ast.RawHTML {
 
 // --- extractTag unit tests ---
 
+// TestAllowSet_ContainsLowercasedTags verifies allowSet stores tag names in
+// lowercase and uses struct{} as the zero-byte set value.
+func TestAllowSet_ContainsLowercasedTags(t *testing.T) {
+	r := &Rule{Allow: []string{"DIV", "span"}}
+	m := r.allowSet()
+	if _, ok := m["div"]; !ok {
+		t.Error("allowSet: 'DIV' should be stored as 'div'")
+	}
+	if _, ok := m["span"]; !ok {
+		t.Error("allowSet: 'span' should be present")
+	}
+	if _, ok := m["DIV"]; ok {
+		t.Error("allowSet: original-case 'DIV' should not be present")
+	}
+}
+
 func TestExtractTag_Opening(t *testing.T) {
 	assert.Equal(t, "div", extractTag([]byte("<div>")))
 }

--- a/internal/rules/noreferencestyle/rule_test.go
+++ b/internal/rules/noreferencestyle/rule_test.go
@@ -27,6 +27,19 @@ func TestRuleMetadata(t *testing.T) {
 	assert.False(t, r.EnabledByDefault())
 }
 
+// TestCollectLinkRewrites_UsedLabelsSet verifies that collectLinkRewrites
+// populates the usedLabels set with the normalized reference labels of all
+// reference-style links so that collectDefinitionCuts can remove the
+// corresponding definitions.
+func TestCollectLinkRewrites_UsedLabelsSet(t *testing.T) {
+	src := "[link][ref]\n\n[ref]: https://example.com\n"
+	f := newFile(t, src)
+	_, usedLabels := collectLinkRewrites(f)
+	if _, ok := usedLabels["ref"]; !ok {
+		t.Error("collectLinkRewrites: label 'ref' not in usedLabels set")
+	}
+}
+
 func TestCheck_InlineLink_NoDiagnostic(t *testing.T) {
 	f := newFile(t, "See [example](https://example.com).\n")
 	diags := (&Rule{}).Check(f)


### PR DESCRIPTION
## Summary

After rebasing onto main (which absorbed PR #658's `map[K]bool → map[K]struct{}` changes),
this PR contributes:

- **One performance fix** in `crossfilereferenceintegrity` — the only `strings.ToLower + ==`
  pattern that PR #658 did not cover.
- **Five coverage tests** that pin the correctness of the set-type changes already on main,
  discovered during the same high-performance-go audit.

### Fix — `isMarkdownPath`: `strings.EqualFold` instead of `strings.ToLower` + `==`

**File:** `internal/rules/crossfilereferenceintegrity/rule.go`  
**Guideline:** "strings.EqualFold for case-insensitive compare — one pass, no allocation"  
**Motivation:** `isMarkdownPath` is called up to 3× per link during `Check()` across every
file in the workspace. `strings.ToLower` allocates a new string heap object for any
upper-case extension (e.g. `.MD` on a Linux repo); `strings.EqualFold` compares in one pass
with zero allocation.  
**Red/Green test:** `TestIsMarkdownPath_UpperCaseZeroAllocs` asserts 0 allocs/op via
`testing.AllocsPerRun`; fails on the old code (1 alloc), passes after the fix.

### Coverage tests (complement PR #658's set-type changes)

| Test | Package | What it pins |
|------|---------|-------------|
| `TestBuildAllowSet_ContainsBuiltInTypes` | `callouttype` | All 27 built-in types present; user names stored lowercase |
| `TestAllowSet_ContainsLowercasedTags` | `noinlinehtml` | Tag names normalised to lowercase in the `struct{}` set |
| `TestFixGitHubAlerts_LazyContinuation` | `markdownflavor` | `"> "` prefix re-added to lazy-continuation lines after alert-marker removal |
| `TestCollectLinkRewrites_UsedLabelsSet` | `noreferencestyle` | `usedLabels` set is populated with the correct normalised key |
| `TestIsMarkdownPath_UpperCaseZeroAllocs` | `crossfilereferenceintegrity` | Zero heap allocs for upper-case extension (regression guard) |

## Test plan

- [x] `TestIsMarkdownPath_UpperCaseZeroAllocs` — fails before fix, passes after
- [x] All five new tests pass in their respective packages
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kdnYXxE5VvmYQvtJFVQ77