### PR TITLE
Parity Layer-0 parse-skip: admit nil-AST-safe B-prose-only rules (closes plan 2606171258)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -205,7 +205,7 @@ footer: |
 | 2606162213 | ✅     | sonnet | [Document internal/checker and internal/rulelayer; remove engine shim](plan/2606162213_arch-fix-new-pkg-docs.md)                        |
 | 2606162214 | ✅     | sonnet | [Add named unit tests for unexported helpers in new lazy-parse packages](plan/2606162214_arch-fix-missing-helper-tests.md)              |
 | 2606171136 | ✅     | opus   | [Parity perf: per-worker configured-rule cache + the Layer-0 path to gomarklint](plan/2606171136_parity-perf-configured-rule-cache.md)  |
-| 2606171258 | 🔳     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
+| 2606171258 | ✅     | opus   | [Parity Layer-0 parse-skip: migrate the AST-forcing parity rules](plan/2606171258_parity-layer0-parse-skip.md)                          |
 | 2606171400 | ✅     | opus   | [Parity parse-skip: unify the two Layer-0 gate mechanisms](plan/2606171400_parity-gate-unification.md)                                  |
 | 2606171401 | ✅     | opus   | [Parity parse-skip: migrate the Layer-0 heading and front-matter rules](plan/2606171401_parity-layer0-heading-rules.md)                 |
 | 2606171402 | ✅     | sonnet | [Parity parse-skip: migrate the Layer-0 fenced-code rules](plan/2606171402_parity-layer0-fenced-code-rules.md)                          |

--- a/internal/engine/layer0_gate_test.go
+++ b/internal/engine/layer0_gate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rulelayer"
 )
 
 // withLayer0Skip flips the package gate toggle for the duration of a test
@@ -402,6 +403,80 @@ func TestLayer0Gate_BlockCheckerDiagnosticsMatchFullParse(t *testing.T) {
 	require.NotEmpty(t, parsed)
 	assert.Equal(t, parsed, skipped,
 		"block-checker parse-skip must match the full parse")
+}
+
+// parityConfig loads the built-in `parity` convention the way `mdsmith
+// check -c parity` does — a `convention: parity` config file merged onto the
+// registry defaults — so the test exercises the real parity rule set rather
+// than a hand-listed subset.
+func parityConfig(t *testing.T, dir string) *config.Config {
+	t.Helper()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("convention: parity\n"), 0o644))
+	loaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	return config.Merge(config.Defaults(), loaded)
+}
+
+// TestLayer0Gate_ParitySkipsParse is the headline proof of plan 2606171258's
+// acceptance criterion 3: `mdsmith check -c parity` sheds the goldmark parse.
+// The parity convention enables 30 rules; every one now resolves to Layer 0
+// or reports rule.LineCapable — MDS066 (commands-show-output), a nil-AST-safe
+// B-prose-only rule, was the last AST-forcing member to migrate. With the
+// full set enabled the gate admits the run, so a directive/list/quote-free
+// file (code included) is linted with a nil AST.
+func TestLayer0Gate_ParitySkipsParse(t *testing.T) {
+	withLayer0Skip(t, true)
+	dir := t.TempDir()
+	cfg := parityConfig(t, dir)
+
+	probe := &astProbeRule{}
+	cfg.Rules[probe.Name()] = config.RuleCfg{Enabled: true}
+
+	// Directive-free, list-free, quote-free, but code-bearing so the parity
+	// fenced-code / command rules (MDS010, MDS011, MDS031, MDS065, MDS066)
+	// are in play on the parse-skipped path.
+	path := filepath.Join(dir, "doc.md")
+	doc := "# Title\n\nSome short prose line.\n\n```sh\necho hello\n```\n\nMore prose.\n"
+	require.NoError(t, os.WriteFile(path, []byte(doc), 0o644))
+
+	r := &Runner{
+		Config:           cfg,
+		Rules:            append(rule.All(), probe),
+		StripFrontMatter: true,
+		RootDir:          dir,
+	}
+	res := r.Run([]string{path})
+	require.Empty(t, res.Errors)
+	assert.True(t, probe.sawNilAST,
+		"the full parity rule set must skip the parse on a directive/list/quote-free file")
+}
+
+// TestParityRuleSetIsSkipSafe pins the gate decision behind criterion 3
+// directly: every rule the parity convention enables is either a Layer 0 rule
+// or reports rule.LineCapable, so allEnabledRulesSkipSafe accepts the whole
+// set. This is the all-or-nothing condition the benchmark turns on — if any
+// future parity rule regresses to AST-forcing, this fails before the
+// end-to-end skip test does.
+func TestParityRuleSetIsSkipSafe(t *testing.T) {
+	dir := t.TempDir()
+	cfg := parityConfig(t, dir)
+	r := &Runner{Config: cfg, Rules: rule.All()}
+	mdRules := markdownRulesFrom(r.Rules, r.ConfigPath)
+	effective := r.effectiveWithCategories("", nil, nil)
+
+	var blockers []string
+	for _, rl := range mdRules {
+		c, ok := effective[rl.Name()]
+		if !ok || !c.Enabled {
+			continue
+		}
+		if !rulelayer.IsLayer0(rl.ID()) && !ruleConfiguredLineCapable(rl, c) {
+			blockers = append(blockers, rl.ID()+" "+rl.Name())
+		}
+	}
+	assert.Empty(t, blockers, "parity-enabled rules that still force the parse")
+	assert.True(t, allEnabledRulesSkipSafe(mdRules, effective))
 }
 
 // astProbeRule is a test rule that records whether the File it checked had

--- a/internal/integration/layer0_gate_equivalence_test.go
+++ b/internal/integration/layer0_gate_equivalence_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -106,6 +108,50 @@ func TestLayer0Gate_LineCapableCorpusEquivalence(t *testing.T) {
 	require.NotEmpty(t, parsed, "line-length must fire somewhere in the corpus")
 	assert.Equal(t, diagKeys(parsed), diagKeys(skipped),
 		"line-capable parse-skip must match the full-parse run across the corpus")
+}
+
+// TestLayer0Gate_ParityCorpusDiagnosticsEquivalence is plan 2606171258's
+// acceptance criterion 2: the parse-skip run matches the full-parse run
+// across the repository corpus with the FULL parity rule set enabled — not
+// just the static Layer 0 subset. It loads the built-in `parity` convention
+// exactly as `mdsmith check -c parity` does (a `convention: parity` file
+// merged onto the registry defaults) and diffs the two runs. With every
+// parity rule now Layer 0 (MDS066 commands-show-output was the last to
+// migrate), the gate engages for every directive/list/quote-free file, so
+// this exercises the parse-skip path on real corpus content for the whole
+// set the benchmark runs.
+func TestLayer0Gate_ParityCorpusDiagnosticsEquivalence(t *testing.T) {
+	root := repoRoot(t)
+	files := collectMarkdownCorpus(t, root)
+	require.NotEmpty(t, files)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".mdsmith.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("convention: parity\n"), 0o644))
+	loaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	cfg := config.Merge(config.Defaults(), loaded)
+
+	run := func(skip bool) []lint.Diagnostic {
+		if skip {
+			t.Setenv("MDSMITH_LAYER0_SKIP", "1")
+		} else {
+			t.Setenv("MDSMITH_LAYER0_SKIP", "")
+		}
+		r := &engine.Runner{
+			Config:           cfg,
+			Rules:            rule.All(),
+			StripFrontMatter: true,
+			RootDir:          root,
+		}
+		return r.Run(files).Diagnostics
+	}
+
+	skipped := run(true)
+	parsed := run(false)
+	require.NotEmpty(t, parsed, "the parity set must fire somewhere in the corpus")
+	assert.Equal(t, diagKeys(parsed), diagKeys(skipped),
+		"parity parse-skip diagnostics must match the full-parse run across the corpus")
 }
 
 // diagKeys reduces diagnostics to comparable tuples (file, line, column,

--- a/internal/rulelayer/rulelayer.go
+++ b/internal/rulelayer/rulelayer.go
@@ -2,8 +2,8 @@
 // to, derived from the rule-walk audit manifest (plan 2606022126). The
 // engine consults it to decide whether a run can skip the goldmark parse:
 // the parse is skippable only when every enabled rule is a Layer 0 rule —
-// one that reads f.Lines and the block-level projections but never
-// navigates f.AST.
+// one that never *requires* f.AST because it has a nil-AST path served by
+// the Layer-0 line/block scan and the Layer-1 inline index.
 //
 // The manifest is embedded from a checked-in copy of
 // internal/integration/testdata/rule_walk_audit.json; a contract test
@@ -27,9 +27,11 @@ const (
 	// LayerUnknown is the zero value for a rule absent from the manifest.
 	// The engine treats it conservatively as AST-requiring.
 	LayerUnknown Layer = iota
-	// Layer0 means the rule reads only f.Lines and the block-level
-	// projections — it can run with a nil AST. These are the manifest's
-	// "A-no-skipping" rules.
+	// Layer0 means the rule can run with a nil AST: it reads f.Lines, the
+	// block-level projections, and the Layer-1 inline index, never requiring
+	// the goldmark tree. These are the manifest's "A-no-skipping" rules plus
+	// the "B-prose-only" rules — nil-AST-safe rules that read code-block,
+	// code-span, or inline-HTML content the validated projections reproduce.
 	Layer0
 	// LayerAST means the rule needs the goldmark AST (the manifest's
 	// "hybrid", "ast-required", and inconclusive categories). The engine
@@ -38,21 +40,24 @@ const (
 )
 
 // auditEntry is the subset of the rule-walk manifest the layer mapping
-// needs: the rule id and its AST-dependence category.
+// needs: the rule id, its AST-dependence category, and the probe's
+// nil-AST-safety signal (which gates the B-prose-only promotion).
 type auditEntry struct {
-	ID       string `json:"id"`
-	Category string `json:"category"`
+	ID         string `json:"id"`
+	Category   string `json:"category"`
+	NilASTSafe bool   `json:"nil_ast_safe"`
 }
 
 // layerByID maps each rule id to its resolved layer, built once from the
 // embedded manifest at package init.
 var layerByID = buildLayerMap()
 
-// astProjectionConsumers lists rules the audit manifest marks
-// "A-no-skipping" — they never crash with a nil AST — but which still read
-// an AST-derived projection that Layer 0 does not reproduce, so their
-// output silently diverges on a parse-skipped File. The audit's probe
-// measured crash-safety, not output equivalence.
+// astProjectionConsumers lists rules the audit manifest would otherwise
+// promote to Layer 0 ("A-no-skipping" or nil-AST-safe "B-prose-only") — they
+// never crash with a nil AST — but which still read an AST-derived projection
+// that Layer 0 / Layer 1 does not reproduce, so their output silently diverges
+// on a parse-skipped File. The audit's probe measured crash-safety, not output
+// equivalence.
 //
 // MDS047 (ambiguous-emphasis) and MDS054 (no-undefined-reference-labels)
 // formerly sat here: both consume the inline code-span ranges
@@ -83,11 +88,11 @@ var knownNilASTSafe = map[string]bool{
 }
 
 // buildLayerMap decodes the embedded manifest into the id→layer table.
-// "A-no-skipping" rules are Layer 0 unless they appear in
-// astProjectionConsumers (which need an AST-only inline projection); every
-// other category needs the AST. A decode failure is a build-time contract
-// violation (the embedded JSON is checked in), so it panics rather than
-// silently degrading.
+// "A-no-skipping" and nil-AST-safe "B-prose-only" rules are Layer 0 unless
+// they appear in astProjectionConsumers (which need an AST-only projection
+// Layer N does not back); every other category needs the AST. A decode
+// failure is a build-time contract violation (the embedded JSON is checked
+// in), so it panics rather than silently degrading.
 func buildLayerMap() map[string]Layer {
 	return buildLayerMapFrom(auditJSON)
 }
@@ -104,14 +109,45 @@ func buildLayerMapFrom(manifest []byte) map[string]Layer {
 	}
 	m := make(map[string]Layer, len(entries))
 	for _, e := range entries {
-		if !astProjectionConsumers[e.ID] &&
-			(knownNilASTSafe[e.ID] || e.Category == "A-no-skipping") {
+		if !astProjectionConsumers[e.ID] && nilASTBackable(e) {
 			m[e.ID] = Layer0
 		} else {
 			m[e.ID] = LayerAST
 		}
 	}
 	return m
+}
+
+// nilASTBackable reports whether a manifest entry's rule can lint on the
+// parse-skipped (nil-AST) File, before the astProjectionConsumers veto the
+// caller applies. Three classes qualify:
+//
+//   - knownNilASTSafe: a manual override for a rule the bad-fixture probe
+//     cannot fire, confirmed by inspection to never read f.AST
+//     (reads_file_ast: false, enforced by rulelayer_test.go).
+//   - "A-no-skipping": the probe fired the rule, the nil-AST run neither
+//     panicked nor diverged from the AST run, and scrambling code bytes did
+//     not change its output — it reads no code content, so the Layer-0 /
+//     Layer-1 projections back it trivially.
+//   - "B-prose-only" with nil_ast_safe: the probe fired the rule and the
+//     nil-AST run matched the AST run, but the rule is code-content-sensitive
+//     (scrambling code bytes changed its output). It reads code-block bodies,
+//     code spans, or inline HTML — content the validated ClassifyLines and
+//     Layer-1 inline projections reproduce byte-identically on the nil-AST
+//     File (the parse-skip-on-code measurement, plan 2606171258, plus each
+//     rule's TestCheck_NilASTMatchesAST guard). The code guard that once
+//     forced these rules to parse is gone, so code-sensitivity alone no
+//     longer requires the AST. The nil_ast_safe gate is belt-and-braces: the
+//     B-prose-only category already implies it, but reading the signal keeps
+//     the promotion honest if the manifest is ever hand-edited.
+func nilASTBackable(e auditEntry) bool {
+	if knownNilASTSafe[e.ID] {
+		return true
+	}
+	if e.Category == "A-no-skipping" {
+		return true
+	}
+	return e.Category == "B-prose-only" && e.NilASTSafe
 }
 
 // Of returns the resolved layer for a rule id, or LayerUnknown when the id

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -71,12 +71,21 @@ func TestIsLayer0(t *testing.T) {
 	// (lint.InlineBlocks) — heading rules and MDS053's def/use map walk it,
 	// MDS034 also reads the Layer 0 BlockQuote spans for alert blockquotes —
 	// so the audit classes them "A-no-skipping" and the gate admits them.
-	// MDS041, MDS050, and MDS052 are nil-AST-safe too but stay
-	// "B-prose-only": each reads content the audit's code-perturbation probe
-	// scrambles (inline HTML, code-block bodies, code-span content), so they
-	// are code-content-sensitive by design and do not resolve to Layer 0.
 	for _, id := range []string{"MDS005", "MDS017", "MDS034", "MDS042", "MDS049", "MDS053", "MDS063", "MDS068"} {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0 once re-backed on Layer 1", id)
+		assert.Equal(t, Layer0, Of(id))
+	}
+	// The "B-prose-only" rules (plan 2606171258) are nil-AST-safe but read
+	// code content the audit's code-perturbation probe scrambles: MDS041
+	// inline HTML / HTML blocks, MDS050 code-block + HTML-block bodies under
+	// check-code / check-html, MDS052 code-span content, MDS066 fenced-code
+	// bodies. The code guard that once forced them to parse is gone and the
+	// validated ClassifyLines / Layer-1 inline projections reproduce that
+	// content byte-identically on the nil-AST File, so they now resolve to
+	// Layer 0 (gated on nil_ast_safe). The corpus equivalence harness and
+	// each rule's TestCheck_NilASTMatchesAST guard the promotion.
+	for _, id := range []string{"MDS041", "MDS050", "MDS052", "MDS066"} {
+		assert.True(t, IsLayer0(id), "%s (B-prose-only, nil-AST-safe) should be Layer 0", id)
 		assert.Equal(t, Layer0, Of(id))
 	}
 	// AST-requiring rules are not Layer 0.
@@ -157,15 +166,33 @@ func TestBuildLayerMapFromPanicsOnMalformedManifest(t *testing.T) {
 }
 
 // TestBuildLayerMapFromClassifies confirms the standard category arms of
-// buildLayerMapFrom: an "A-no-skipping" rule maps to Layer0 and any other
-// category maps to LayerAST (absent a knownNilASTSafe override).
+// buildLayerMapFrom: an "A-no-skipping" rule maps to Layer0, a nil-AST-safe
+// "B-prose-only" rule maps to Layer0, and any other category maps to LayerAST
+// (absent a knownNilASTSafe override).
 func TestBuildLayerMapFromClassifies(t *testing.T) {
 	m := buildLayerMapFrom([]byte(`[
-		{"id":"MDS900","category":"A-no-skipping"},
-		{"id":"MDS901","category":"ast-required"}
+		{"id":"MDS900","category":"A-no-skipping","nil_ast_safe":true},
+		{"id":"MDS901","category":"ast-required","nil_ast_safe":false},
+		{"id":"MDS905","category":"B-prose-only","nil_ast_safe":true}
 	]`))
 	assert.Equal(t, Layer0, m["MDS900"])
 	assert.Equal(t, LayerAST, m["MDS901"])
+	assert.Equal(t, Layer0, m["MDS905"], "nil-AST-safe B-prose-only promotes to Layer0")
+}
+
+// TestBuildLayerMapFromBProseOnlyRequiresNilASTSafe pins the nil_ast_safe
+// gate on the B-prose-only promotion: a B-prose-only entry whose manifest
+// signal says it is NOT nil-AST-safe must stay LayerAST, so a hand-edit that
+// mislabels an AST-fragile rule B-prose-only cannot silently admit it to the
+// parse-skip gate. The live audit never emits this combination (the classifier
+// only assigns B-prose-only when the nil-AST run matched the AST run), so the
+// guard is exercised here with a synthetic entry.
+func TestBuildLayerMapFromBProseOnlyRequiresNilASTSafe(t *testing.T) {
+	m := buildLayerMapFrom([]byte(`[
+		{"id":"MDS906","category":"B-prose-only","nil_ast_safe":false}
+	]`))
+	assert.Equal(t, LayerAST, m["MDS906"],
+		"a B-prose-only entry without nil_ast_safe must stay AST")
 }
 
 // TestBuildLayerMapFromKnownNilASTSafePromotesToLayer0 exercises the

--- a/internal/rules/propernames/rule.go
+++ b/internal/rules/propernames/rule.go
@@ -317,9 +317,11 @@ func reparsed(f *lint.File) *lint.File {
 // goldmark's tab-aware indent stripping; rather than re-derive that offset
 // math from the Layer 0 line scan, the rule re-parses the document once and
 // reuses the AST collectMatches, so the opt-in path is byte-identical by
-// construction. check-code / check-html are opt-in and MDS050 stays
-// B-prose-only, so the engine keeps such files on the parse path anyway —
-// this branch is reached only by a directly constructed nil-AST File.
+// construction. MDS050 now resolves to Layer 0 (a nil-AST-safe B-prose-only
+// rule), so when it is enabled and the engine skips the shared parse this
+// branch is reached in production; the one-shot reparse keeps it
+// byte-identical to the shared-AST path (TestCheck_NilASTMatchesAST covers
+// the check-code and check-html cases).
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var matches []wrongMatch
 	switch {

--- a/plan/2606171258_parity-layer0-parse-skip.md
+++ b/plan/2606171258_parity-layer0-parse-skip.md
@@ -1,7 +1,7 @@
 ---
 id: 2606171258
 title: "Parity Layer-0 parse-skip: migrate the AST-forcing parity rules"
-status: "🔳"
+status: "✅"
 summary: >-
   Move every parity-active rule that still forces the goldmark parse onto
   the Layer-0 / Layer-1 projections so `mdsmith check -c parity` can skip
@@ -79,7 +79,11 @@ heading spans (or the gate excludes container-nested headings). See
    reusing the existing extraction where possible.
 2. Regenerate the walk audit (`MDSMITH_REGEN_WALK_AUDIT=1`) and sync the
    embedded [rulelayer copy](../internal/rulelayer/rule_walk_audit.json)
-   so the rule flips to `A-no-skipping`.
+   so the rule flips to `A-no-skipping`. A code-content rule cannot reach
+   `A-no-skipping` (the probe's code perturbation marks it
+   code-sensitive); it terminates at `B-prose-only`, which `rulelayer`
+   now promotes to Layer 0 when `nil_ast_safe` holds (see the closing
+   section).
 3. Confirm `TestLayer0Gate_CorpusDiagnosticsEquivalence` stays green — it
    enables every Layer-0 rule and diffs parse-skip vs full-parse across
    the corpus, so a divergent rule fails it.
@@ -112,7 +116,7 @@ be Layer 0 (the remaining migration). But it removes the blocker that
 framed parse-skip on code as a scanner rewrite — it was a one-line rule
 fix plus a guard removal.
 
-## Result so far
+## Result
 
 - [x] MDS002 heading-style: reads only the heading line (style + level),
       never the inline tree. `CheckBlock` serves the nil-AST path
@@ -121,11 +125,48 @@ fix plus a guard removal.
       453 code-bearing corpus files (the sweep above).
 - [x] Code guard removed; skip File carries `ClassifyLines`; the corpus
       equivalence gate engages on code files and is green.
+- [x] All five batch plans landed
+      ([2606171400](2606171400_parity-gate-unification.md),
+      [2606171401](2606171401_parity-layer0-heading-rules.md),
+      [2606171402](2606171402_parity-layer0-fenced-code-rules.md),
+      [2606171403](2606171403_parity-layer0-list-quote-rules.md),
+      [2606171404](2606171404_parity-layer1-inline-rules.md)). A scope
+      sweep of the merged parity config (30 enabled rules) found **one**
+      remaining gate blocker: MDS066 commands-show-output.
+
+## Closing the all-or-nothing gate: B-prose-only is nil-AST-safe
+
+Four migrated rules read code content: MDS041 no-inline-html, MDS050
+proper-names, MDS052 no-space-in-code-spans, and MDS066
+commands-show-output. Each gained a working nil-AST path. But the audit
+filed them under `B-prose-only`, not `A-no-skipping`. Its probe scrambles
+the very content they read, so they register as code-sensitive.
+
+`rulelayer` mapped only `A-no-skipping` to Layer 0. Parity enables just
+one of the four — MDS066; the rest are opt-in. So MDS066 alone kept
+forcing the parse, and the parity set never qualified for the skip.
+
+Yet `B-prose-only` already means the probe saw *no* nil-AST divergence on
+the unperturbed fixture. (A divergent rule lands in `hybrid` instead.)
+The only extra signal is code-sensitivity. The code guard that made that
+a disqualifier is gone. The measurement above proved the `ClassifyLines`
+and Layer-1 projections reproduce code content byte for byte.
+
+So `rulelayer` now lifts a `B-prose-only` rule to Layer 0 when its
+`nil_ast_safe` signal holds. `astProjectionConsumers` stays as the veto
+for a future rule that reads an unbacked AST projection. Two guards back
+the change: the corpus equivalence harness (now run over the full parity
+set) and each rule's `TestCheck_NilASTMatchesAST`.
 
 ## Acceptance Criteria
 
-- [ ] Every AST-forcing parity rule resolves to Layer 0 / Layer 1.
-- [ ] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green with the full
-      parity set enabled.
-- [ ] `mdsmith check -c parity` skips the parse on benchmark 2.
-- [ ] All tests pass: `go test ./...`.
+- [x] Every AST-forcing parity rule resolves to Layer 0 / Layer 1
+      (`TestParityRuleSetIsSkipSafe`: zero parity-enabled rules force the
+      parse).
+- [x] `TestLayer0Gate_CorpusDiagnosticsEquivalence` green; added
+      `TestLayer0Gate_ParityCorpusDiagnosticsEquivalence` to diff
+      parse-skip vs full-parse across the corpus with the full parity set.
+- [x] `mdsmith check -c parity` skips the parse on benchmark 2
+      (`TestLayer0Gate_ParitySkipsParse`: the parity set lints a
+      code-bearing, directive/list/quote-free file with a nil AST).
+- [x] All tests pass: `go test ./...`.


### PR DESCRIPTION
## Summary

Plan [`2606171258`](plan/2606171258_parity-layer0-parse-skip.md) was completed on `main` with a `blockSkipSafe` allow-list that promotes the single rule **MDS066** to Layer 0. This PR replaces that per-rule special case with a **category rule**: `rulelayer.nilASTBackable` promotes the whole nil-AST-safe `B-prose-only` category to Layer 0, gated on the manifest's `nil_ast_safe` signal.

Per maintainer direction, this is the deeper "generalize the mechanism over a special case" approach.

## Why it's sound

`B-prose-only` already implies the audit probe saw **no** nil-AST divergence on the unperturbed fixture (a divergent rule lands in `hybrid`). The only withheld signal is code-sensitivity — and the code guard that once made that a disqualifier is gone, with the `ClassifyLines` and Layer-1 inline projections proven byte-identical to the AST on code content. `astProjectionConsumers` stays as the veto for any rule that reads an unbacked AST projection.

This admits all four nil-AST-safe `B-prose-only` rules (MDS041, MDS050, MDS052, MDS066), not just MDS066. Parity enables only MDS066; the other three are opt-in.

## Soundness guards

- `TestBProseOnlyRulesAreNilASTSafe` — every live `B-prose-only` manifest entry is `nil_ast_safe` and resolves to Layer 0 (the category-promotion invariant).
- `TestNilASTBackable` — dedicated unit test for the promotion predicate (all arms).
- `TestLayer0Gate_ParityCorpusDiagnosticsEquivalence` — parse-skip vs full-parse diagnostics match across the whole corpus with the **full** parity set enabled (line-length + the B-prose-only rules), not just the static Layer 0 subset.
- Each rule's existing `TestCheck_NilASTMatchesAST` checks its own nil-AST path.

## Notes

- Updates the `propernames` reachability comment: MDS050's check-code/check-html reparse branch is now reachable in production (and stays byte-identical).
- `go test ./...` green; `mdsmith check .` clean (500 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)