### PR TITLE
Generalize the B-prose-only Layer-0 promotion (supersedes blockSkipSafe)

### DIFF
--- a/internal/engine/parity_layer0_test.go
+++ b/internal/engine/parity_layer0_test.go
@@ -27,9 +27,9 @@ func parityConfig(t *testing.T) *config.Config {
 // acceptance criterion 1: every parity-enabled rule resolves to a parse-skip
 // layer (rulelayer Layer 0 or, for line-length, configured rule.LineCapable).
 // MDS066 (commands-show-output) was the lone holdout — a "B-prose-only" rule
-// the static category withheld from Layer 0 — until it was promoted via the
-// blockSkipSafe override. If a future parity rule regrows an AST dependency,
-// this fails and names it.
+// the static category withheld from Layer 0 — until rulelayer.nilASTBackable
+// began promoting the nil-AST-safe "B-prose-only" category. If a future parity
+// rule regrows an AST dependency, this fails and names it.
 func TestParityConvention_AllEnabledRulesSkipSafe(t *testing.T) {
 	cfg := parityConfig(t)
 	eff := config.Effective(cfg, "doc.md", nil, nil)

--- a/internal/rulelayer/rulelayer.go
+++ b/internal/rulelayer/rulelayer.go
@@ -2,8 +2,8 @@
 // to, derived from the rule-walk audit manifest (plan 2606022126). The
 // engine consults it to decide whether a run can skip the goldmark parse:
 // the parse is skippable only when every enabled rule is a Layer 0 rule —
-// one that reads f.Lines and the block-level projections but never
-// navigates f.AST.
+// one that never *requires* f.AST because it has a nil-AST path served by
+// the Layer-0 line/block scan and the Layer-1 inline index.
 //
 // The manifest is embedded from a checked-in copy of
 // internal/integration/testdata/rule_walk_audit.json; a contract test
@@ -27,9 +27,11 @@ const (
 	// LayerUnknown is the zero value for a rule absent from the manifest.
 	// The engine treats it conservatively as AST-requiring.
 	LayerUnknown Layer = iota
-	// Layer0 means the rule reads only f.Lines and the block-level
-	// projections — it can run with a nil AST. These are the manifest's
-	// "A-no-skipping" rules.
+	// Layer0 means the rule can run with a nil AST: it reads f.Lines, the
+	// block-level projections, and the Layer-1 inline index, never requiring
+	// the goldmark tree. These are the manifest's "A-no-skipping" rules plus
+	// the nil-AST-safe "B-prose-only" rules — rules that read code-block,
+	// code-span, or inline-HTML content the validated projections reproduce.
 	Layer0
 	// LayerAST means the rule needs the goldmark AST (the manifest's
 	// "hybrid", "ast-required", and inconclusive categories). The engine
@@ -38,21 +40,24 @@ const (
 )
 
 // auditEntry is the subset of the rule-walk manifest the layer mapping
-// needs: the rule id and its AST-dependence category.
+// needs: the rule id, its AST-dependence category, and the probe's
+// nil-AST-safety signal (which gates the B-prose-only promotion).
 type auditEntry struct {
-	ID       string `json:"id"`
-	Category string `json:"category"`
+	ID         string `json:"id"`
+	Category   string `json:"category"`
+	NilASTSafe bool   `json:"nil_ast_safe"`
 }
 
 // layerByID maps each rule id to its resolved layer, built once from the
 // embedded manifest at package init.
 var layerByID = buildLayerMap()
 
-// astProjectionConsumers lists rules the audit manifest marks
-// "A-no-skipping" — they never crash with a nil AST — but which still read
-// an AST-derived projection that Layer 0 does not reproduce, so their
-// output silently diverges on a parse-skipped File. The audit's probe
-// measured crash-safety, not output equivalence.
+// astProjectionConsumers lists rules the audit manifest would otherwise
+// promote to Layer 0 ("A-no-skipping" or nil-AST-safe "B-prose-only") — they
+// never crash with a nil AST — but which still read an AST-derived projection
+// that Layer 0 / Layer 1 does not reproduce, so their output silently diverges
+// on a parse-skipped File. The audit's probe measured crash-safety, not output
+// equivalence.
 //
 // MDS047 (ambiguous-emphasis) and MDS054 (no-undefined-reference-labels)
 // formerly sat here: both consume the inline code-span ranges
@@ -82,35 +87,10 @@ var knownNilASTSafe = map[string]bool{
 	"MDS069": true, // unique-frontmatter: reads f.FrontMatter + RunCache, never f.AST
 }
 
-// blockSkipSafe lists rules the audit marks "B-prose-only" — nil-AST-safe but
-// code-content-sensitive, so the static category withholds Layer 0 — that are
-// nonetheless safe to skip the parse for, because the only code-content they
-// read is reproduced by the Layer 0 block scan plus f.Lines. The audit's
-// code-perturbation probe measures whether a rule's diagnostics move when
-// code-block bytes change; a rule that lints code-block *bodies* (as opposed
-// to ignoring them) is sensitive by construction and lands in B-prose-only,
-// even when its rule.BlockChecker nil-AST path produces byte-identical output.
-//
-// MDS066 (commands-show-output) is the canonical entry: it flags a fenced
-// block whose every body line is a "$ " prompt. Its CheckBlock reads the
-// BlockFencedCode span's body lines straight from f.Lines, which the Layer 0
-// scan delimits exactly as goldmark does — confirmed byte-identical across the
-// full corpus and gated by TestLayer0Gate_CorpusDiagnosticsEquivalence. It was
-// the lone parity-enabled rule still forcing the AST; promoting it lets
-// `mdsmith check -c parity` skip the parse.
-//
-// Adding a rule here is a manual commitment that (1) its Check is nil-AST-safe
-// (enforced by rulelayer_test.go against the manifest's nil_ast_safe signal)
-// and (2) its nil-AST output matches the AST output across the corpus
-// equivalence gate.
-var blockSkipSafe = map[string]bool{
-	"MDS066": true, // commands-show-output: CheckBlock reads the fenced-code body from f.Lines
-}
-
 // buildLayerMap decodes the embedded manifest into the id→layer table.
-// "A-no-skipping" rules are Layer 0 unless they appear in
-// astProjectionConsumers (which need an AST-only inline projection); a rule in
-// knownNilASTSafe or blockSkipSafe is promoted to Layer 0 from another
+// "A-no-skipping" and nil-AST-safe "B-prose-only" rules are Layer 0 unless
+// they appear in astProjectionConsumers (which need an AST-only projection
+// Layer N does not back); a rule in knownNilASTSafe is promoted from another
 // category; every other category needs the AST. A decode failure is a
 // build-time contract violation (the embedded JSON is checked in), so it
 // panics rather than silently degrading.
@@ -130,14 +110,47 @@ func buildLayerMapFrom(manifest []byte) map[string]Layer {
 	}
 	m := make(map[string]Layer, len(entries))
 	for _, e := range entries {
-		if !astProjectionConsumers[e.ID] &&
-			(knownNilASTSafe[e.ID] || blockSkipSafe[e.ID] || e.Category == "A-no-skipping") {
+		if !astProjectionConsumers[e.ID] && nilASTBackable(e) {
 			m[e.ID] = Layer0
 		} else {
 			m[e.ID] = LayerAST
 		}
 	}
 	return m
+}
+
+// nilASTBackable reports whether a manifest entry's rule can lint on the
+// parse-skipped (nil-AST) File, before the astProjectionConsumers veto the
+// caller applies. Three classes qualify:
+//
+//   - knownNilASTSafe: a manual override for a rule the bad-fixture probe
+//     cannot fire, confirmed by inspection to never read f.AST
+//     (reads_file_ast: false, enforced by rulelayer_test.go).
+//   - "A-no-skipping": the probe fired the rule, the nil-AST run neither
+//     panicked nor diverged from the AST run, and scrambling code bytes did
+//     not change its output — it reads no code content, so the Layer-0 /
+//     Layer-1 projections back it trivially.
+//   - "B-prose-only" with nil_ast_safe: the probe fired the rule and the
+//     nil-AST run matched the AST run, but the rule is code-content-sensitive
+//     (scrambling code bytes changed its output). It reads code-block bodies,
+//     code spans, or inline HTML — content the validated ClassifyLines and
+//     Layer-1 inline projections reproduce byte-identically on the nil-AST
+//     File (the parse-skip-on-code measurement, plan 2606171258, plus each
+//     rule's TestCheck_NilASTMatchesAST guard). The code guard that once
+//     forced these rules to parse is gone, so code-sensitivity alone no
+//     longer requires the AST. The nil_ast_safe gate is belt-and-braces: the
+//     B-prose-only category already implies it (a divergent rule lands in
+//     "hybrid"), but reading the signal keeps the promotion honest if the
+//     manifest is ever hand-edited, and TestBProseOnlyRulesAreNilASTSafe pins
+//     the live invariant.
+func nilASTBackable(e auditEntry) bool {
+	if knownNilASTSafe[e.ID] {
+		return true
+	}
+	if e.Category == "A-no-skipping" {
+		return true
+	}
+	return e.Category == "B-prose-only" && e.NilASTSafe
 }
 
 // Of returns the resolved layer for a rule id, or LayerUnknown when the id

--- a/internal/rulelayer/rulelayer_test.go
+++ b/internal/rulelayer/rulelayer_test.go
@@ -26,10 +26,12 @@ func auditSignal(t *testing.T, sel func(auditSignalEntry) bool) map[string]bool 
 	return m
 }
 
-// auditSignalEntry is the subset of the rule-walk manifest the override tests
-// read: the rule id plus the two boolean signals the override contracts pin.
+// auditSignalEntry is the subset of the rule-walk manifest the override and
+// promotion tests read: the rule id, its category, and the two boolean signals
+// the soundness contracts pin.
 type auditSignalEntry struct {
 	ID           string `json:"id"`
+	Category     string `json:"category"`
 	NilASTSafe   bool   `json:"nil_ast_safe"`
 	ReadsFileAST bool   `json:"reads_file_ast"`
 }
@@ -95,12 +97,21 @@ func TestIsLayer0(t *testing.T) {
 	// (lint.InlineBlocks) — heading rules and MDS053's def/use map walk it,
 	// MDS034 also reads the Layer 0 BlockQuote spans for alert blockquotes —
 	// so the audit classes them "A-no-skipping" and the gate admits them.
-	// MDS041, MDS050, and MDS052 are nil-AST-safe too but stay
-	// "B-prose-only": each reads content the audit's code-perturbation probe
-	// scrambles (inline HTML, code-block bodies, code-span content), so they
-	// are code-content-sensitive by design and do not resolve to Layer 0.
 	for _, id := range []string{"MDS005", "MDS017", "MDS034", "MDS042", "MDS049", "MDS053", "MDS063", "MDS068"} {
 		assert.True(t, IsLayer0(id), "%s should be Layer 0 once re-backed on Layer 1", id)
+		assert.Equal(t, Layer0, Of(id))
+	}
+	// The "B-prose-only" rules (plan 2606171258) are nil-AST-safe but read
+	// code content the audit's code-perturbation probe scrambles: MDS041
+	// inline HTML / HTML blocks, MDS050 code-block + HTML-block bodies under
+	// check-code / check-html, MDS052 code-span content, MDS066 fenced-code
+	// bodies. The code guard that once forced them to parse is gone and the
+	// validated ClassifyLines / Layer-1 inline projections reproduce that
+	// content byte-identically on the nil-AST File, so nilASTBackable promotes
+	// them to Layer 0 (gated on nil_ast_safe). The corpus equivalence harness
+	// and each rule's TestCheck_NilASTMatchesAST guard the promotion.
+	for _, id := range []string{"MDS041", "MDS050", "MDS052", "MDS066"} {
+		assert.True(t, IsLayer0(id), "%s (B-prose-only, nil-AST-safe) should be Layer 0", id)
 		assert.Equal(t, Layer0, Of(id))
 	}
 	// AST-requiring rules are not Layer 0.
@@ -110,49 +121,73 @@ func TestIsLayer0(t *testing.T) {
 	}
 }
 
-// TestBlockSkipSafeAreLayer0 confirms every rule in the blockSkipSafe
-// override resolves to Layer 0 even though its audit category is
-// "B-prose-only". MDS066 (commands-show-output) is the canonical entry: the
-// audit's code-perturbation probe marks it code-content-sensitive
-// ("B-prose-only"), but its only code-content read is the fenced-code body,
-// which the Layer 0 block scan plus f.Lines reproduces byte-identically (a
-// rule.BlockChecker nil-AST path gated across the corpus by
-// TestLayer0Gate_CorpusDiagnosticsEquivalence). Promoting it lets
-// `mdsmith check -c parity` skip the parse: parity enables MDS066 and it was
-// the lone rule still forcing the AST.
-func TestBlockSkipSafeAreLayer0(t *testing.T) {
-	for id := range blockSkipSafe {
-		assert.True(t, IsLayer0(id), "%s is in blockSkipSafe; must be Layer 0", id)
-		assert.Equal(t, Layer0, Of(id))
-	}
-	assert.True(t, blockSkipSafe["MDS066"], "MDS066 must be in the block-skip-safe set")
+// TestNilASTBackable is the dedicated unit test for nilASTBackable, the
+// predicate buildLayerMapFrom uses to decide Layer 0 promotion (before the
+// astProjectionConsumers veto). It covers all four arms: the knownNilASTSafe
+// override, the "A-no-skipping" category, a nil-AST-safe "B-prose-only" rule
+// (promoted), a "B-prose-only" rule the manifest marks NOT nil-AST-safe
+// (withheld), and an AST-requiring category (withheld).
+func TestNilASTBackable(t *testing.T) {
+	t.Cleanup(func() { delete(knownNilASTSafe, "MDS950") })
+	knownNilASTSafe["MDS950"] = true
+
+	assert.True(t, nilASTBackable(auditEntry{ID: "MDS950", Category: "ast-required"}),
+		"knownNilASTSafe override promotes regardless of category")
+	assert.True(t, nilASTBackable(auditEntry{ID: "MDS951", Category: "A-no-skipping"}),
+		"A-no-skipping is backable")
+	assert.True(t, nilASTBackable(auditEntry{ID: "MDS952", Category: "B-prose-only", NilASTSafe: true}),
+		"nil-AST-safe B-prose-only is backable")
+	assert.False(t, nilASTBackable(auditEntry{ID: "MDS953", Category: "B-prose-only", NilASTSafe: false}),
+		"B-prose-only without nil_ast_safe is not backable")
+	assert.False(t, nilASTBackable(auditEntry{ID: "MDS954", Category: "ast-required", NilASTSafe: true}),
+		"ast-required is not backable even when nil_ast_safe")
 }
 
-// TestBlockSkipSafeAreNilASTSafe guards the override's manual commitment: a
-// rule may only be force-classified Layer 0 here when its audit manifest
-// entry reports nil_ast_safe: true (its Check survives a nil AST with the
-// same diagnostics). A rule whose nil-AST path regresses trips its
-// nil_ast_safe signal and this test fails until the override is reconsidered.
-func TestBlockSkipSafeAreNilASTSafe(t *testing.T) {
-	nilSafe := auditSignal(t, func(e auditSignalEntry) bool { return e.NilASTSafe })
-	for id := range blockSkipSafe {
-		_, present := nilSafe[id]
-		assert.True(t, present, "%s in blockSkipSafe must appear in the audit manifest", id)
-		assert.True(t, nilSafe[id],
-			"%s in blockSkipSafe must have nil_ast_safe: true", id)
+// TestBProseOnlyRulesAreNilASTSafe pins the soundness invariant behind the
+// category-wide B-prose-only promotion: every rule the live manifest marks
+// "B-prose-only" also reports nil_ast_safe: true, so nilASTBackable never
+// promotes a B-prose-only rule whose nil-AST run diverged from the AST run
+// (such a rule lands in "hybrid", not "B-prose-only"). If the audit ever
+// emits a B-prose-only entry with nil_ast_safe: false, this fails and the
+// promotion must be reconsidered.
+func TestBProseOnlyRulesAreNilASTSafe(t *testing.T) {
+	var entries []auditSignalEntry
+	require.NoError(t, json.Unmarshal(auditJSON, &entries))
+	saw := false
+	for _, e := range entries {
+		if e.Category != "B-prose-only" {
+			continue
+		}
+		saw = true
+		assert.True(t, e.NilASTSafe,
+			"%s is B-prose-only; the category promotion requires nil_ast_safe: true", e.ID)
+		assert.True(t, IsLayer0(e.ID), "%s (nil-AST-safe B-prose-only) must resolve to Layer 0", e.ID)
 	}
+	assert.True(t, saw, "manifest must contain at least one B-prose-only rule or the check is vacuous")
 }
 
-// TestBuildLayerMapFromBlockSkipSafePromotesToLayer0 exercises the
-// blockSkipSafe branch of buildLayerMapFrom directly with a synthetic entry:
-// a "B-prose-only" rule listed in blockSkipSafe must resolve to Layer0.
-func TestBuildLayerMapFromBlockSkipSafePromotesToLayer0(t *testing.T) {
-	blockSkipSafe["MDS905"] = true
-	t.Cleanup(func() { delete(blockSkipSafe, "MDS905") })
+// TestBuildLayerMapFromBProseOnlyPromotesToLayer0 exercises the B-prose-only
+// arm of buildLayerMapFrom directly with a synthetic entry: a "B-prose-only"
+// rule reporting nil_ast_safe must resolve to Layer0.
+func TestBuildLayerMapFromBProseOnlyPromotesToLayer0(t *testing.T) {
 	m := buildLayerMapFrom([]byte(`[
-		{"id":"MDS905","category":"B-prose-only"}
+		{"id":"MDS905","category":"B-prose-only","nil_ast_safe":true}
 	]`))
-	assert.Equal(t, Layer0, m["MDS905"], "blockSkipSafe promotes B-prose-only rule to Layer0")
+	assert.Equal(t, Layer0, m["MDS905"], "nil-AST-safe B-prose-only promotes to Layer0")
+}
+
+// TestBuildLayerMapFromBProseOnlyRequiresNilASTSafe pins the nil_ast_safe gate
+// on the B-prose-only arm: a B-prose-only entry the manifest marks NOT
+// nil-AST-safe must stay LayerAST, so a hand-edit that mislabels an
+// AST-fragile rule B-prose-only cannot silently admit it to the parse-skip
+// gate. The live audit never emits this combination, so the guard is
+// exercised here with a synthetic entry.
+func TestBuildLayerMapFromBProseOnlyRequiresNilASTSafe(t *testing.T) {
+	m := buildLayerMapFrom([]byte(`[
+		{"id":"MDS906","category":"B-prose-only","nil_ast_safe":false}
+	]`))
+	assert.Equal(t, LayerAST, m["MDS906"],
+		"a B-prose-only entry without nil_ast_safe must stay AST")
 }
 
 // TestAstProjectionConsumersAreNotLayer0 guards the parse-skip gate's
@@ -213,15 +248,18 @@ func TestBuildLayerMapFromPanicsOnMalformedManifest(t *testing.T) {
 }
 
 // TestBuildLayerMapFromClassifies confirms the standard category arms of
-// buildLayerMapFrom: an "A-no-skipping" rule maps to Layer0 and any other
-// category maps to LayerAST (absent a knownNilASTSafe override).
+// buildLayerMapFrom: an "A-no-skipping" rule maps to Layer0, a nil-AST-safe
+// "B-prose-only" rule maps to Layer0, and any other category maps to LayerAST
+// (absent a knownNilASTSafe override).
 func TestBuildLayerMapFromClassifies(t *testing.T) {
 	m := buildLayerMapFrom([]byte(`[
-		{"id":"MDS900","category":"A-no-skipping"},
-		{"id":"MDS901","category":"ast-required"}
+		{"id":"MDS900","category":"A-no-skipping","nil_ast_safe":true},
+		{"id":"MDS901","category":"ast-required","nil_ast_safe":false},
+		{"id":"MDS907","category":"B-prose-only","nil_ast_safe":true}
 	]`))
 	assert.Equal(t, Layer0, m["MDS900"])
 	assert.Equal(t, LayerAST, m["MDS901"])
+	assert.Equal(t, Layer0, m["MDS907"])
 }
 
 // TestBuildLayerMapFromKnownNilASTSafePromotesToLayer0 exercises the
@@ -269,20 +307,17 @@ func TestAstProjectionConsumerOverridesKnownNilASTSafe(t *testing.T) {
 	assert.Equal(t, LayerAST, m["MDS903"], "astProjectionConsumers must override knownNilASTSafe")
 }
 
-// TestAstProjectionConsumerOverridesBlockSkipSafe pins that astProjectionConsumers
-// wins over blockSkipSafe: a rule in both must still resolve to LayerAST because it
-// reads an AST-only projection the Layer 0 block scan does not back, regardless of
-// the block-skip override. This guards the soundness escape hatch — buildLayerMapFrom
-// gates the whole Layer 0 promotion behind !astProjectionConsumers[e.ID].
-func TestAstProjectionConsumerOverridesBlockSkipSafe(t *testing.T) {
+// TestAstProjectionConsumerOverridesBProseOnly pins that astProjectionConsumers
+// wins over the B-prose-only promotion: a rule in astProjectionConsumers must
+// still resolve to LayerAST because it reads an AST-only projection the Layer 0
+// / Layer 1 path does not back, regardless of its nil-AST-safe B-prose-only
+// category. This guards the soundness escape hatch — buildLayerMapFrom gates
+// the whole Layer 0 promotion behind !astProjectionConsumers[e.ID].
+func TestAstProjectionConsumerOverridesBProseOnly(t *testing.T) {
 	astProjectionConsumers["MDS904"] = true
-	blockSkipSafe["MDS904"] = true
-	t.Cleanup(func() {
-		delete(astProjectionConsumers, "MDS904")
-		delete(blockSkipSafe, "MDS904")
-	})
+	t.Cleanup(func() { delete(astProjectionConsumers, "MDS904") })
 	m := buildLayerMapFrom([]byte(`[
-		{"id":"MDS904","category":"B-prose-only"}
+		{"id":"MDS904","category":"B-prose-only","nil_ast_safe":true}
 	]`))
-	assert.Equal(t, LayerAST, m["MDS904"], "astProjectionConsumers must override blockSkipSafe")
+	assert.Equal(t, LayerAST, m["MDS904"], "astProjectionConsumers must override the B-prose-only promotion")
 }

--- a/internal/rules/propernames/rule.go
+++ b/internal/rules/propernames/rule.go
@@ -317,9 +317,11 @@ func reparsed(f *lint.File) *lint.File {
 // goldmark's tab-aware indent stripping; rather than re-derive that offset
 // math from the Layer 0 line scan, the rule re-parses the document once and
 // reuses the AST collectMatches, so the opt-in path is byte-identical by
-// construction. check-code / check-html are opt-in and MDS050 stays
-// B-prose-only, so the engine keeps such files on the parse path anyway —
-// this branch is reached only by a directly constructed nil-AST File.
+// construction. MDS050 now resolves to Layer 0 (a nil-AST-safe B-prose-only
+// rule), so when it is enabled and the engine skips the shared parse this
+// branch is reached in production; the one-shot reparse keeps it
+// byte-identical to the shared-AST path (TestCheck_NilASTMatchesAST covers
+// the check-code and check-html cases).
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var matches []wrongMatch
 	switch {

--- a/plan/2606171258_parity-layer0-parse-skip.md
+++ b/plan/2606171258_parity-layer0-parse-skip.md
@@ -139,11 +139,22 @@ fires on one). MDS066 is the only `B-prose-only` rule parity enables —
 MDS041, MDS050, MDS052 are all disabled by the convention — so it was the
 lone blocker.
 
-The fix is a `blockSkipSafe` override in `rulelayer`, parallel to
-`knownNilASTSafe`. It promotes a nil-AST-safe, block-scan-backed rule to
-Layer 0 from `B-prose-only`. A contract test pins that every entry has
-`nil_ast_safe: true`. The corpus equivalence gate now exercises MDS066 on
-the parse-skipped path.
+The fix generalizes the layer mapping rather than special-casing MDS066.
+`rulelayer.nilASTBackable` promotes the whole nil-AST-safe `B-prose-only`
+category to Layer 0, gated on the manifest's `nil_ast_safe` signal. A
+`B-prose-only` rule already matched the AST run on its fixture; a
+divergent rule lands in `hybrid`. The only withheld signal was
+code-sensitivity. The validated `ClassifyLines` and Layer-1 projections
+now reproduce that code content. This admits MDS066, parity's lone
+blocker, plus the opt-in MDS041, MDS050, and MDS052.
+
+`astProjectionConsumers` stays as the veto for a future rule that reads an
+unbacked AST projection. Three guards back the promotion.
+`TestBProseOnlyRulesAreNilASTSafe` pins that every `B-prose-only` entry is
+`nil_ast_safe`. Each rule's `TestCheck_NilASTMatchesAST` checks its own
+nil-AST path against the AST path. For MDS066 — the only one parity
+enables — `TestParityConvention_SkipsParse` drives the nil-AST path on a
+skip-eligible file and asserts it fires.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary

Plan [`2606171258`](plan/2606171258_parity-layer0-parse-skip.md) was completed on `main` with a `blockSkipSafe` allow-list that promotes the single rule **MDS066** to Layer 0. This PR replaces that per-rule special case with a **category rule**: `rulelayer.nilASTBackable` promotes the whole nil-AST-safe `B-prose-only` category to Layer 0, gated on the manifest's `nil_ast_safe` signal.

Per maintainer direction, this is the deeper "generalize the mechanism over a special case" approach. (Supersedes the now-superseded blockSkipSafe; closed #664 was an earlier take on the same branch.)

## Why it's sound

`B-prose-only` already implies the audit probe saw **no** nil-AST divergence on the unperturbed fixture (a divergent rule lands in `hybrid`). The only withheld signal is code-sensitivity — and the code guard that once made that a disqualifier is gone, with the `ClassifyLines` and Layer-1 inline projections proven byte-identical to the AST on code content. `astProjectionConsumers` stays as the veto for any rule that reads an unbacked AST projection.

This admits all four nil-AST-safe `B-prose-only` rules (MDS041, MDS050, MDS052, MDS066), not just MDS066. Parity enables only MDS066; the other three are opt-in.

## Soundness guards

- `TestBProseOnlyRulesAreNilASTSafe` — every live `B-prose-only` manifest entry is `nil_ast_safe` and resolves to Layer 0 (the category-promotion invariant).
- `TestNilASTBackable` — dedicated unit test for the promotion predicate (all arms).
- `TestLayer0Gate_ParityCorpusDiagnosticsEquivalence` — parse-skip vs full-parse diagnostics match across the whole corpus with the **full** parity set enabled (line-length + the B-prose-only rules), not just the static Layer 0 subset.
- Each rule's existing `TestCheck_NilASTMatchesAST` checks its own nil-AST path.

## Notes

- Updates the `propernames` reachability comment: MDS050's check-code/check-html reparse branch is now reachable in production (and stays byte-identical).
- `go test ./...` green; `mdsmith check .` clean (500 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM8EiiEQZq2Eq1Tvv7w4b2)_