### PR TITLE
docs(plan/145): update blocker state and add 2026-06-21 review sweep

### DIFF
--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -152,23 +152,21 @@ plugin, its CI, and the release.yml smoke-test matrix.
 The plan stays open until adoption clears the
 registries' bar.
 
-**Review 2026-06-21.** Re-swept the in-repo surfaces.
-These were checked:
+**Review 2026-06-21.** No in-repo actions remain. Specific
+verifications:
 
-- the smoke-test matrix in
-  [release.yml](../.github/workflows/release.yml)
+- `release.yml` smoke-test matrix: the `asdf` job is
+  `required: true`; the `mise-registry` job is
+  `required: false` with a `::warning::` soft-skip.
 - `RequiredSmokeChannels` in
-  `internal/release/releasesmoke.go`
-- [docs/guides/install.md](../docs/guides/install.md)
-- the `asdf` and `mise` release-channel docs, whose
-  summaries generate `website/data/channels.yaml`
+  `internal/release/releasesmoke.go`: includes `"asdf"`,
+  excludes the bare `"mise-registry"` form.
+- `docs/guides/install.md`: "neither registry entry
+  exists yet" note at the channel-comparison table, and
+  per-section notes for the bare `asdf` and `mise` forms.
+- The `asdf` and `mise` release-channel docs: their full
+  frontmatter feeds `website/data/channels.yaml` via
+  `mdsmith-release sync-channels`; both docs carry "needs
+  a registry entry" for the bare forms.
 
-All are accurate and consistent. The `asdf` channel is
-required-green via the explicit plugin URL. The bare
-`mise-registry` channel stays best-effort with a warning.
-Both docs flag the prefix-less forms as awaiting a
-registry entry.
-
-No stale TODOs or contradictions remain. Both external
-registry PRs are still gated on adoption. Nothing else is
-actionable in-repo, so the plan stays open.
+Plan stays open until registry adoption clears.

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -155,15 +155,19 @@ registries' bar.
 **Review 2026-06-21.** No in-repo actions remain. Specific
 verifications:
 
-- `release.yml` smoke-test matrix: the `asdf` job is
-  `required: true`; the `mise-registry` job is
-  `required: false` with a `::warning::` soft-skip.
-- `RequiredSmokeChannels` in
-  `internal/release/releasesmoke.go`: includes `"asdf"`,
-  excludes the bare `"mise-registry"` form.
+- `release.yml` smoke-test matrix: the `asdf` channel
+  install script exits non-zero on failure; the
+  `mise-registry` channel uses `skipped=true` and
+  `::warning::` then exits 0 (soft-skip, not gating).
+- [`internal/release/releasesmoke.go`](../internal/release/releasesmoke.go)
+  `RequiredSmokeChannels`: `{"asdf", "go", "mise",
+  "npm", "pip"}` — includes `"asdf"` and the explicit-URL
+  `"mise"` form; excludes the bare `"mise-registry"` form.
 - `docs/guides/install.md`: "neither registry entry
-  exists yet" note at the channel-comparison table, and
-  per-section notes for the bare `asdf` and `mise` forms.
+  exists yet" note just below the channel-comparison
+  table, and per-section notes warning that bare
+  `asdf plugin add mdsmith` and bare
+  `mise use mdsmith@VER` do not yet resolve.
 - The `asdf` and `mise` release-channel docs: their full
   frontmatter feeds `website/data/channels.yaml` via
   `mdsmith-release sync-channels`; both docs carry "needs

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -157,12 +157,14 @@ verifications:
 
 - `release.yml` smoke-test matrix: the `asdf` channel
   install script exits non-zero on failure; the
-  `mise-registry` channel uses `skipped=true` and
-  `::warning::` then exits 0 (soft-skip, not gating).
-- [`internal/release/releasesmoke.go`](../internal/release/releasesmoke.go)
-  `RequiredSmokeChannels`: `{"asdf", "go", "mise",
-  "npm", "pip"}` — includes `"asdf"` and the explicit-URL
-  `"mise"` form; excludes the bare `"mise-registry"` form.
+  `mise-registry` channel emits `::warning::`, sets
+  `skipped=true` in `$GITHUB_OUTPUT`, then exits 0
+  (soft-skip, not gating).
+- [`RequiredSmokeChannels`](../internal/release/releasesmoke.go)
+  in `internal/release/releasesmoke.go`:
+  `{"asdf", "go", "mise", "npm", "pip"}` — includes
+  `"asdf"` and the explicit-URL `"mise"` form; excludes
+  the bare `"mise-registry"` form.
 - `docs/guides/install.md`: "neither registry entry
   exists yet" note just below the channel-comparison
   table, and per-section notes warning that bare

--- a/plan/145_asdf-mise-registry-submissions.md
+++ b/plan/145_asdf-mise-registry-submissions.md
@@ -132,7 +132,7 @@ current adoption level:
   re-submission is accepted.
 - **asdf (Task 3):** the one-successful-release-cycle
   precondition is now met — the pipeline has shipped
-  through `v0.47.0` (2026-06-14) — so the only remaining
+  through `v0.51.0` (2026-06-20) — so the only remaining
   gate is adoption. No PR to
   [`asdf-vm/asdf-plugins`](https://github.com/asdf-vm/asdf-plugins)
   has been filed; that index has comparable curation
@@ -151,3 +151,24 @@ In-repo work is done: the `jeduden/asdf-mdsmith`
 plugin, its CI, and the release.yml smoke-test matrix.
 The plan stays open until adoption clears the
 registries' bar.
+
+**Review 2026-06-21.** Re-swept the in-repo surfaces.
+These were checked:
+
+- the smoke-test matrix in
+  [release.yml](../.github/workflows/release.yml)
+- `RequiredSmokeChannels` in
+  `internal/release/releasesmoke.go`
+- [docs/guides/install.md](../docs/guides/install.md)
+- the `asdf` and `mise` release-channel docs, whose
+  summaries generate `website/data/channels.yaml`
+
+All are accurate and consistent. The `asdf` channel is
+required-green via the explicit plugin URL. The bare
+`mise-registry` channel stays best-effort with a warning.
+Both docs flag the prefix-less forms as awaiting a
+registry entry.
+
+No stale TODOs or contradictions remain. Both external
+registry PRs are still gated on adoption. Nothing else is
+actionable in-repo, so the plan stays open.


### PR DESCRIPTION
## Summary

- Bumps the latest shipped release reference in plan/145's asdf blocker note from `v0.47.0` to `v0.51.0`
- Adds a dated (2026-06-21) review entry confirming all in-repo surfaces are accurate and consistent:
  - `release.yml` smoke-test matrix
  - `RequiredSmokeChannels` in `internal/release/releasesmoke.go`
  - `docs/guides/install.md`
  - The `asdf` and `mise` release-channel docs (whose summaries feed `website/data/channels.yaml`)
- No stale TODOs or contradictions found; both external registry PRs remain gated on adoption

## Context

Plan 145 (`plan/145_asdf-mise-registry-submissions.md`) is the only in-progress plan (🔳) with no open PR. The in-repo work was already complete; this PR records a sweep confirming that state as of today and updates the version reference in the blockers section.

## Test plan

- [x] `go run ./cmd/mdsmith check plan/145_asdf-mise-registry-submissions.md` — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015N68QBoYgieHxfTLqXpRDU

---
_Generated by [Claude Code](https://claude.ai/code/session_015N68QBoYgieHxfTLqXpRDU)_