### PR TITLE
arch(engine): split runner.go SRP violation into sibling files

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -218,4 +218,8 @@ footer: |
 | 2606192027 | ✅     | sonnet | [Security hardening batch — 2026-06-19 full-repo audit (low/info)](plan/2606192027_security-hardening-batch-2026-06-19-full-repo.md)    |
 | 2606202100 | 🔲     | opus   | [Parity perf: make InlineBlocks a light inline scan, not a goldmark re-parse](plan/2606202100_parity-light-inline-scan.md)              |
 | 2606210840 | 🔲     | sonnet | [Same-file anchor-resolution rule for true gomarklint parity](plan/2606210840_same-file-anchor-resolution-rule.md)                      |
+| 2606211907 | ✅     |        | [arch-fix: split internal/engine/runner.go](plan/2606211907_arch-fix-runner-srp-split.md)                                               |
+| 2606211908 | 🔲     |        | [arch-fix: split internal/lint/layer0.go](plan/2606211908_arch-fix-layer0-split.md)                                                     |
+| 2606211909 | 🔲     |        | [arch-fix: split internal/lsp/server.go](plan/2606211909_arch-fix-lsp-server-split.md)                                                  |
+| 2606211910 | 🔲     |        | [arch-fix: add trivial-accessor exemption comments in workspace.go](plan/2606211910_arch-fix-workspace-exemptions.md)                   |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: 7793b974e35ec7260ae986e9e0dd48cf5df30574
+audit-from: e701b94b5640dfb4f5d07d1fc38d49e0dba23e75
 ---
 # Architecture audit log
 
@@ -132,3 +132,64 @@ Tax: [build→rules DIP](../../plan/2606141910_arch-fix-build-rules-dip.md),
 Lazy-parse series (plans 2606141901–2606141904).
 Tax: [new-pkg-docs](../../plan/2606162213_arch-fix-new-pkg-docs.md),
 [helper-tests](../../plan/2606162214_arch-fix-missing-helper-tests.md).
+
+## Audit 2026-06-21 (range: 7793b97..e701b94)
+
+Parity + Layer-0 parse-skip series; symlink
+containment; engine panic recovery; VS Code
+`kinds` and `rule-doc` commands; security
+hardening batch. 270 Go/TS sources outside
+fixtures.
+
+No blockers. New rule / convention packages
+follow the OCP barrel pattern correctly; no
+rule-to-rule imports added; no DIP violations
+in the new `internal/rules/listscan` helper
+(it follows the established `astutil` /
+`fencepos` pattern).
+
+### tax (2026-06-21)
+
+- `internal/engine/runner.go` (1 290 lines) —
+  SRP violation. Seven concerns in one file:
+  file dispatch, Layer-0 skip gate,
+  config-resolution cache, source-mode lint
+  path, front-matter parsing, config-target
+  rules, and logging. Go arch doc
+  §"Common violations to flag" names engine
+  as a dumping-ground risk. Fixed this cycle:
+  split into `runner_layer0.go`,
+  `runner_cache.go`, `runner_log.go` —
+  [plan/2606211907][2606211907].
+
+- `internal/lint/layer0.go` (1 203 lines) —
+  the full Layer-0 block scanner in one file:
+  types, scanner state machine, HTML-block
+  detection (types 1–7), fence handling, ATX
+  heading, indented code, paragraph. Maintenance
+  risk at this size. Fix: split along
+  block-type sub-parsers —
+  [plan/2606211908][2606211908].
+
+- `internal/lsp/server.go` (1 007 lines) —
+  plan 203 was green but the file has crept
+  back over 1 000 lines with the new `kinds`
+  and `rule-doc` capability wiring. Checklist
+  names it explicitly. Fix: apply the same
+  dispatch-group split plan 203 described —
+  [plan/2606211909][2606211909].
+
+### nice-to-have (2026-06-21)
+
+- `pkg/mdsmith/workspace.go` trivial methods
+  (`memFile.Close`, `memDir.Close`,
+  `memDirEntry.Name`, `memDirEntry.IsDir`,
+  `memFileInfo.Name`, `memFileInfo.Size`) lack
+  the one-line "no test by design" exemption
+  comment the audit policy requires. Tests doc
+  §"Exemptions" — [plan/2606211910][2606211910].
+
+[2606211907]: ../../plan/2606211907_arch-fix-runner-srp-split.md
+[2606211908]: ../../plan/2606211908_arch-fix-layer0-split.md
+[2606211909]: ../../plan/2606211909_arch-fix-lsp-server-split.md
+[2606211910]: ../../plan/2606211910_arch-fix-workspace-exemptions.md

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -928,4 +928,3 @@ func (r *Runner) anyRepoScopedEnabled() bool {
 	}
 	return false
 }
-

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
-	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -21,7 +19,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
 	"github.com/jeduden/mdsmith/internal/rule"
-	"github.com/jeduden/mdsmith/internal/rulelayer"
 )
 
 // sourceBufPool recycles the per-file source-read buffer across the
@@ -557,42 +554,6 @@ func (r *Runner) pooledFileConstructor(source []byte) func(string, []byte, bool)
 	return lint.NewFileFromSourcePooled
 }
 
-// computeFlatLayer0Active reports whether this run may skip the goldmark
-// parse for line-capable files. It requires the opt-in Runner.FlatLayer0
-// flag and a config simple enough that the globally-enabled rule set is
-// the whole story: every enabled markdown rule must be rule.LineCapable,
-// and the config must declare no kinds or overrides (either could enable a
-// non-line-capable rule for some file that the empty-path effective config
-// does not surface). This conservative gate is sufficient for the prototype
-// (plan 2606142147) measurement, whose single-rule line-length config has
-// neither; the full Layer-0 plan refines it to a per-file resolution.
-func (r *Runner) computeFlatLayer0Active() bool {
-	if !r.FlatLayer0 {
-		return false
-	}
-	if len(r.Config.Kinds) > 0 || len(r.Config.Overrides) > 0 {
-		return false
-	}
-	mdRules := markdownRulesFrom(r.Rules, r.ConfigPath)
-	effective := r.effectiveWithCategories("", nil, nil)
-	for _, rl := range mdRules {
-		cfg, ok := effective[rl.Name()]
-		if !ok || !cfg.Enabled {
-			continue
-		}
-		// A rule's line-capability can depend on its config (line-length
-		// is not line-capable once a per-heading limit is set). With no
-		// kinds or overrides, the empty-path effective config is the
-		// rule's settings for every file. ruleConfiguredLineCapable
-		// applies those settings before asking — the same check the
-		// unified parse-skip gate uses.
-		if !ruleConfiguredLineCapable(rl, cfg) {
-			return false
-		}
-	}
-	return true
-}
-
 // frontMatterPrefix returns the leading YAML front-matter block of source
 // (including its --- delimiters), or nil when stripping is off or source
 // has none. It mirrors what NewFileFromSource stores in File.FrontMatter,
@@ -604,137 +565,6 @@ func frontMatterPrefix(source []byte, stripFrontMatter bool) []byte {
 	}
 	prefix, _ := lint.StripFrontMatter(source)
 	return prefix
-}
-
-// layer0SkipOverride, when non-nil, forces the Layer 0 parse-skip gate
-// on (*true) or off (*false), bypassing the environment. The gate's
-// in-package equivalence tests set it so they can flip the toggle without
-// mutating the process environment. nil (the default) defers to
-// MDSMITH_LAYER0_SKIP.
-var layer0SkipOverride *bool
-
-// layer0SkipEnabled reports whether the master Layer 0 parse-skip toggle
-// is on. It honours an in-process override when set, otherwise reads the
-// MDSMITH_LAYER0_SKIP environment variable each call so a test in any
-// package can flip it via t.Setenv.
-//
-// Default OFF. The parse-skip path is correct (byte-identical to the parsed
-// path, held so by the TestLayer0Gate_* corpus equivalence gates, now for
-// list-bearing files too), but it is not yet a measured net win. Profiled
-// on the eligible-only subset it is cost-neutral: the skip path's cost is
-// dominated by lint.InlineBlocks (~51%), which the parity link/reference
-// rules read on the nil-AST path and which still runs a full goldmark parse
-// per run — so skipping the block parse saves almost nothing while the
-// cheap line scans (~10%) ride on top. It stays an opt-in seam
-// (MDSMITH_LAYER0_SKIP=1) until InlineBlocks becomes the light inline scan
-// Layer 1 was meant to be — see
-// docs/research/benchmarks/parity-parse-skip-findings.md.
-func layer0SkipEnabled() bool {
-	if layer0SkipOverride != nil {
-		return *layer0SkipOverride
-	}
-	return os.Getenv("MDSMITH_LAYER0_SKIP") != ""
-}
-
-// layer0SkipEligible reports whether this file's run can skip the goldmark
-// parse and lint from the Layer 0 scan alone. Five conditions must hold:
-//
-//  1. The MDSMITH_LAYER0_SKIP toggle is set (default off).
-//  2. Every enabled rule resolves to Layer 0 (rulelayer.IsLayer0) — no
-//     enabled rule navigates f.AST. An unknown rule id is treated as
-//     AST-requiring, so a rule the audit does not cover is never skipped.
-//  3. The source carries no `<?` directive marker. Generated-section
-//     suppression walks the AST for processing instructions, so a file
-//     with directives must be parsed.
-//  4. The source may contain no block quote (lint.SourceMayHaveBlockQuote
-//     is false — i.e. no `>` byte). The block-span scanner collapses a
-//     block quote into a single BlockQuote span and never emits the
-//     heading/fenced-code spans that block-kind rules (MDS002, MDS015)
-//     react to for quote-nested content, so a quote-nested heading would
-//     be flagged on the AST path but missed on the parse-skip path.
-//     This `>`-free condition doubles as the HTML-block guard: every HTML
-//     block opener carries a `>` somewhere it can be excluded on (`<div>`,
-//     a closed `-->` comment, a self-closing `<br/>`), and listscan does
-//     not model an HTML block's opaque interior, so excluding any `>`
-//     keeps those files on the parse path too. A more precise per-line
-//     quote scan (so code-heavy `>`-bearing files could skip) needs the
-//     block-span scanner to descend into block quotes first; until then
-//     the coarse `>` guard is the sound choice.
-//
-// Lists no longer disqualify the skip. The list rules (MDS014/016/045/
-// 046/061) re-derive list structure from f.Lines via listscan on the
-// nil-AST path (rule.LinesChecker routes them to Check), and the flat
-// ClassifyLines code-line projection descends into list items, so a fence
-// or indent nested in a list is classified correctly. Block-kind rules
-// read the scanLayer0 block spans, which match goldmark on every
-// list-nested heading/fence the corpus exercises. All of this is held
-// byte-identical to the AST by TestLayer0Gate_CorpusDiagnosticsEquivalence,
-// which now engages on list-bearing files.
-//
-// The block-only and flat-Layer-0 spike flags force their own
-// constructors, so the gate stands down when either is set.
-func (r *Runner) layer0SkipEligible(
-	source []byte, rules []rule.Rule, effective map[string]config.RuleCfg,
-) bool {
-	if !layer0SkipEnabled() || r.BlockOnlyParse || r.FlatLayer0 {
-		return false
-	}
-	if bytes.Contains(source, piOpenScan) {
-		return false
-	}
-	if lint.SourceMayHaveBlockQuote(source) {
-		return false
-	}
-	return allEnabledRulesSkipSafe(rules, effective)
-}
-
-// piOpenScan is the directive opener the gate scans for; any occurrence
-// disqualifies the parse skip.
-var piOpenScan = []byte("<?")
-
-// allEnabledRulesSkipSafe reports whether every enabled rule in effective
-// can lint the parse-skipped (nil-AST) File. A rule qualifies two ways,
-// unifying the engine's two parse-skip signals (plan 2606171400):
-//
-//   - It is a static Layer 0 rule (rulelayer.IsLayer0). Block rules serve
-//     the nil-AST path through their rule.BlockChecker dispatch.
-//   - Its configured instance reports rule.LineCapable. Line rules whose
-//     layer depends on config — line-length is line-capable only without a
-//     per-heading limit — serve the nil-AST path through the File's
-//     ClassifyLines projection.
-//
-// A run with no enabled rules trivially qualifies. A disabled rule is
-// ignored. An unknown rule that is neither Layer 0 nor line-capable forces
-// the parse.
-func allEnabledRulesSkipSafe(rules []rule.Rule, effective map[string]config.RuleCfg) bool {
-	for _, rl := range rules {
-		cfg, ok := effective[rl.Name()]
-		if !ok || !cfg.Enabled {
-			continue
-		}
-		if rulelayer.IsLayer0(rl.ID()) {
-			continue
-		}
-		if ruleConfiguredLineCapable(rl, cfg) {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-// ruleConfiguredLineCapable reports whether rl, once configured with cfg,
-// can lint from f.Lines alone (rule.LineCapable). A rule's line-capability
-// can depend on its settings, so the rule is configured before the check —
-// line-length is line-capable until a per-heading limit is set. A config
-// error makes the rule non-skip-safe (the parse path surfaces the error).
-func ruleConfiguredLineCapable(rl rule.Rule, cfg config.RuleCfg) bool {
-	configured, err := checker.ConfigureRule(rl, cfg)
-	if err != nil {
-		return false
-	}
-	lc, ok := configured.(rule.LineCapable)
-	return ok && lc.LineCapable()
 }
 
 // RunSource lints in-memory source bytes (e.g. from stdin or an LSP
@@ -1017,170 +847,6 @@ func (r *Runner) effectiveWithCategories(
 	return config.ApplyCategories(effective, categories, ruleCategoryLookup(r.Rules), explicit)
 }
 
-// effectiveCache memoizes effective rule configs by config signature for
-// the span of one runFiles call. File workers read and write it
-// concurrently, so it wraps sync.Map. The stored maps are read-only
-// downstream — classifyRules clones a rule's settings before applying
-// them — so sharing one map across files is safe.
-type effectiveCache struct{ m sync.Map }
-
-func (c *effectiveCache) get(key string) (map[string]config.RuleCfg, bool) {
-	v, ok := c.m.Load(key)
-	if !ok {
-		return nil, false
-	}
-	return v.(map[string]config.RuleCfg), true
-}
-
-// loadOrStore returns the cached map for key, storing and returning v
-// when none exists yet. Concurrent misses on the same key thus converge
-// on one shared instance instead of each keeping its own equal copy.
-func (c *effectiveCache) loadOrStore(key string, v map[string]config.RuleCfg) map[string]config.RuleCfg {
-	actual, _ := c.m.LoadOrStore(key, v)
-	return actual.(map[string]config.RuleCfg)
-}
-
-// runResolve bundles the resolution state lintFile needs, across two
-// lifetimes: mdRules is per-worker (each worker filters its own rule
-// clones), while catLookup and effCache are per-run — built once and
-// shared across all workers (effCache is concurrency-safe). Bundling
-// keeps lintFile's signature small and hoists work the per-file loop
-// used to repeat.
-type runResolve struct {
-	mdRules   []rule.Rule
-	catLookup func(string) string
-	effCache  *effectiveCache
-	// confCache memoizes the configured (cloned + settings-applied) enabled
-	// rule list per effective-config signature. It is private to one worker,
-	// so it needs no lock: each worker builds its own runResolve and walks
-	// its files sequentially. A corpus that shares one config configures its
-	// rules once here instead of once per file — the clone + ApplySettings
-	// work the allocation profile showed as per-file overhead. Reusing a
-	// configured rule across files is safe for the same reason the worker
-	// reuses its mdRules clones across files: a rule's Check holds no state
-	// between calls (see checker.ConfigureEnabledRules).
-	confCache map[string]configuredRules
-}
-
-// configuredRules is one cache entry: the enabled, configured rule list
-// for a config signature plus the settings-application errors that
-// configuring it produced (surfaced once, not re-derived per file).
-type configuredRules struct {
-	rules []rule.Rule
-	errs  []error
-}
-
-// configured returns the configured enabled rule list for the effective
-// config identified by key, building and memoizing it on first use. The
-// map is written through the by-value runResolve copy, which is safe
-// because the map header aliases the one instance the worker created.
-func (rr runResolve) configured(
-	key string, effective map[string]config.RuleCfg,
-) ([]rule.Rule, []error) {
-	if c, ok := rr.confCache[key]; ok {
-		return c.rules, c.errs
-	}
-	rules, errs := checker.ConfigureEnabledRules(rr.mdRules, effective)
-	rr.confCache[key] = configuredRules{rules: rules, errs: errs}
-	return rules, errs
-}
-
-// effectiveCached is the hot-path config resolver: it memoizes the
-// effective rule config on rr.effCache keyed by the file's config
-// signature and reuses the prebuilt rr.catLookup, so a corpus that
-// shares one config resolves it once instead of per file. It returns the
-// signature key alongside the config so the caller can reuse it to key the
-// per-worker configured-rule cache without recomputing it. Cold callers
-// (RunSource, config-target, defaults) keep using effectiveWithCategories.
-func (r *Runner) effectiveCached(
-	path string, fmKinds []string, fmFields map[string]any, rr runResolve,
-) (map[string]config.RuleCfg, string) {
-	key, kinds := config.EffectiveSignature(r.Config, path, fmKinds, fmFields)
-	if v, ok := rr.effCache.get(key); ok {
-		return v, key
-	}
-	effective, categories, explicit := config.EffectiveAllForKinds(r.Config, path, kinds)
-	res := config.ApplyCategories(effective, categories, rr.catLookup, explicit)
-	return rr.effCache.loadOrStore(key, res), key
-}
-
-// runCacheForCall returns the run-scoped read cache to thread through
-// the next Run / RunSource pass. A caller-supplied r.RunCache (the
-// LSP installs one on Server and invalidates entries on document
-// events) is reused as-is. When nil, a fresh cache is built for this
-// call only and never stored on r — a Runner re-used for a second
-// Run starts clean and cannot serve stale reads from the previous
-// corpus.
-func (r *Runner) runCacheForCall() *lint.RunCache {
-	if r.RunCache != nil {
-		return r.RunCache
-	}
-	return lint.NewRunCache()
-}
-
-// cachedGitignore returns a *gitignore.Matcher for the given directory,
-// creating and caching it on first use to avoid re-walking the filesystem.
-// The cache key is normalized to an absolute path so equivalent paths
-// (e.g. "sub" vs "./sub") share the same entry.
-func (r *Runner) cachedGitignore(dir string) *gitignore.Matcher {
-	r.gitignoreMu.Lock()
-	defer r.gitignoreMu.Unlock()
-	if r.gitignoreCache == nil {
-		r.gitignoreCache = make(map[string]*gitignore.Matcher)
-	}
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		absDir = filepath.Clean(dir)
-	}
-	if m, ok := r.gitignoreCache[absDir]; ok {
-		return m
-	}
-	m := gitignore.NewMatcher(absDir)
-	r.gitignoreCache[absDir] = m
-	return m
-}
-
-// log returns the runner's logger. If no logger is set, it returns a
-// disabled logger so callers don't need nil checks.
-func (r *Runner) log() *vlog.Logger {
-	if r.Logger != nil {
-		return r.Logger
-	}
-	return &vlog.Logger{}
-}
-
-// logRules logs each enabled rule in the effective config from the provided slice.
-func (r *Runner) logRules(rules []rule.Rule, effective map[string]config.RuleCfg) {
-	logRulesTo(r.log(), rules, effective)
-}
-
-// logRulesTo logs each enabled rule to l. Split from logRules so the
-// per-file buffered logger in lintFile can reuse the same formatting
-// without going through the shared Runner logger.
-func logRulesTo(l *vlog.Logger, rules []rule.Rule, effective map[string]config.RuleCfg) {
-	if !l.Enabled {
-		return
-	}
-	for _, rl := range rules {
-		cfg, ok := effective[rl.Name()]
-		if !ok || !cfg.Enabled {
-			continue
-		}
-		l.Printf("rule: %s %s", rl.ID(), rl.Name())
-	}
-}
-
-// ruleCategoryLookup returns a function that maps a rule name to its category.
-func ruleCategoryLookup(rules []rule.Rule) func(string) string {
-	m := make(map[string]string, len(rules))
-	for _, rl := range rules {
-		m[rl.Name()] = rl.Category()
-	}
-	return func(name string) string {
-		return m[name]
-	}
-}
-
 // runConfigTargetRules runs rules that implement rule.ConfigTarget once
 // against a synthetic lint.File for the config file. These rules validate
 // the project config rather than individual Markdown files. They are skipped
@@ -1263,28 +929,3 @@ func (r *Runner) anyRepoScopedEnabled() bool {
 	return false
 }
 
-// sortDiagnostics sorts diagnostics by file, line, column, message, then
-// rule id. The RuleID tiebreak makes the order independent of the walk path
-// that produced the diagnostics: the parse-skip block-walk and the full-parse
-// node-walk can emit two same-position, same-message diagnostics from
-// different rules in different input orders, and the Layer-0 equivalence
-// assertions compare full ordered slices. sort.SliceStable then preserves
-// input order only for diagnostics equal on every compared field.
-func sortDiagnostics(diags []lint.Diagnostic) {
-	sort.SliceStable(diags, func(i, j int) bool {
-		di, dj := diags[i], diags[j]
-		if di.File != dj.File {
-			return di.File < dj.File
-		}
-		if di.Line != dj.Line {
-			return di.Line < dj.Line
-		}
-		if di.Column != dj.Column {
-			return di.Column < dj.Column
-		}
-		if di.Message != dj.Message {
-			return di.Message < dj.Message
-		}
-		return di.RuleID < dj.RuleID
-	})
-}

--- a/internal/engine/runner_cache.go
+++ b/internal/engine/runner_cache.go
@@ -1,0 +1,135 @@
+package engine
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/jeduden/mdsmith/internal/checker"
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/gitignore"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+// effectiveCache memoizes effective rule configs by config signature for
+// the span of one runFiles call. File workers read and write it
+// concurrently, so it wraps sync.Map. The stored maps are read-only
+// downstream — classifyRules clones a rule's settings before applying
+// them — so sharing one map across files is safe.
+type effectiveCache struct{ m sync.Map }
+
+func (c *effectiveCache) get(key string) (map[string]config.RuleCfg, bool) {
+	v, ok := c.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return v.(map[string]config.RuleCfg), true
+}
+
+// loadOrStore returns the cached map for key, storing and returning v
+// when none exists yet. Concurrent misses on the same key thus converge
+// on one shared instance instead of each keeping its own equal copy.
+func (c *effectiveCache) loadOrStore(key string, v map[string]config.RuleCfg) map[string]config.RuleCfg {
+	actual, _ := c.m.LoadOrStore(key, v)
+	return actual.(map[string]config.RuleCfg)
+}
+
+// runResolve bundles the resolution state lintFile needs, across two
+// lifetimes: mdRules is per-worker (each worker filters its own rule
+// clones), while catLookup and effCache are per-run — built once and
+// shared across all workers (effCache is concurrency-safe). Bundling
+// keeps lintFile's signature small and hoists work the per-file loop
+// used to repeat.
+type runResolve struct {
+	mdRules   []rule.Rule
+	catLookup func(string) string
+	effCache  *effectiveCache
+	// confCache memoizes the configured (cloned + settings-applied) enabled
+	// rule list per effective-config signature. It is private to one worker,
+	// so it needs no lock: each worker builds its own runResolve and walks
+	// its files sequentially. A corpus that shares one config configures its
+	// rules once here instead of once per file — the clone + ApplySettings
+	// work the allocation profile showed as per-file overhead. Reusing a
+	// configured rule across files is safe for the same reason the worker
+	// reuses its mdRules clones across files: a rule's Check holds no state
+	// between calls (see checker.ConfigureEnabledRules).
+	confCache map[string]configuredRules
+}
+
+// configuredRules is one cache entry: the enabled, configured rule list
+// for a config signature plus the settings-application errors that
+// configuring it produced (surfaced once, not re-derived per file).
+type configuredRules struct {
+	rules []rule.Rule
+	errs  []error
+}
+
+// configured returns the configured enabled rule list for the effective
+// config identified by key, building and memoizing it on first use. The
+// map is written through the by-value runResolve copy, which is safe
+// because the map header aliases the one instance the worker created.
+func (rr runResolve) configured(
+	key string, effective map[string]config.RuleCfg,
+) ([]rule.Rule, []error) {
+	if c, ok := rr.confCache[key]; ok {
+		return c.rules, c.errs
+	}
+	rules, errs := checker.ConfigureEnabledRules(rr.mdRules, effective)
+	rr.confCache[key] = configuredRules{rules: rules, errs: errs}
+	return rules, errs
+}
+
+// effectiveCached is the hot-path config resolver: it memoizes the
+// effective rule config on rr.effCache keyed by the file's config
+// signature and reuses the prebuilt rr.catLookup, so a corpus that
+// shares one config resolves it once instead of per file. It returns the
+// signature key alongside the config so the caller can reuse it to key the
+// per-worker configured-rule cache without recomputing it. Cold callers
+// (RunSource, config-target, defaults) keep using effectiveWithCategories.
+func (r *Runner) effectiveCached(
+	path string, fmKinds []string, fmFields map[string]any, rr runResolve,
+) (map[string]config.RuleCfg, string) {
+	key, kinds := config.EffectiveSignature(r.Config, path, fmKinds, fmFields)
+	if v, ok := rr.effCache.get(key); ok {
+		return v, key
+	}
+	effective, categories, explicit := config.EffectiveAllForKinds(r.Config, path, kinds)
+	res := config.ApplyCategories(effective, categories, rr.catLookup, explicit)
+	return rr.effCache.loadOrStore(key, res), key
+}
+
+// runCacheForCall returns the run-scoped read cache to thread through
+// the next Run / RunSource pass. A caller-supplied r.RunCache (the
+// LSP installs one on Server and invalidates entries on document
+// events) is reused as-is. When nil, a fresh cache is built for this
+// call only and never stored on r — a Runner re-used for a second
+// Run starts clean and cannot serve stale reads from the previous
+// corpus.
+func (r *Runner) runCacheForCall() *lint.RunCache {
+	if r.RunCache != nil {
+		return r.RunCache
+	}
+	return lint.NewRunCache()
+}
+
+// cachedGitignore returns a *gitignore.Matcher for the given directory,
+// creating and caching it on first use to avoid re-walking the filesystem.
+// The cache key is normalized to an absolute path so equivalent paths
+// (e.g. "sub" vs "./sub") share the same entry.
+func (r *Runner) cachedGitignore(dir string) *gitignore.Matcher {
+	r.gitignoreMu.Lock()
+	defer r.gitignoreMu.Unlock()
+	if r.gitignoreCache == nil {
+		r.gitignoreCache = make(map[string]*gitignore.Matcher)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		absDir = filepath.Clean(dir)
+	}
+	if m, ok := r.gitignoreCache[absDir]; ok {
+		return m
+	}
+	m := gitignore.NewMatcher(absDir)
+	r.gitignoreCache[absDir] = m
+	return m
+}

--- a/internal/engine/runner_coverage_test.go
+++ b/internal/engine/runner_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/config"
@@ -45,6 +46,35 @@ func TestCachedGitignore_CacheHit(t *testing.T) {
 }
 
 // (dead test removed — filepath.Join(dir, ".") normalizes to dir, so both args are identical)
+
+// TestCachedGitignore_AbsPathFallback covers the filepath.Abs error branch by
+// removing the process cwd (only possible on Linux) so os.Getwd fails when
+// given a relative path. Must not run in parallel — mutates the process cwd.
+func TestCachedGitignore_AbsPathFallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("deleting cwd only works on Linux")
+	}
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+
+	dir, err := os.MkdirTemp("", "engine-cwd-test-*")
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		_ = os.Chdir(orig)
+		_ = os.RemoveAll(dir)
+	})
+
+	// Removing the cwd makes os.Getwd (and hence filepath.Abs) fail for
+	// relative paths while leaving the process still operational.
+	require.NoError(t, os.Remove(dir))
+
+	runner := &Runner{Config: &config.Config{}}
+	// Relative path triggers filepath.Abs → os.Getwd error → Clean fallback.
+	m := runner.cachedGitignore(".")
+	require.NotNil(t, m, "expected non-nil matcher even when Abs fails")
+}
 
 func TestCachedGitignore_InitializesNilCache(t *testing.T) {
 	runner := &Runner{

--- a/internal/engine/runner_layer0.go
+++ b/internal/engine/runner_layer0.go
@@ -1,0 +1,179 @@
+package engine
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/jeduden/mdsmith/internal/checker"
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rulelayer"
+)
+
+// layer0SkipOverride, when non-nil, forces the Layer 0 parse-skip gate
+// on (*true) or off (*false), bypassing the environment. The gate's
+// in-package equivalence tests set it so they can flip the toggle without
+// mutating the process environment. nil (the default) defers to
+// MDSMITH_LAYER0_SKIP.
+var layer0SkipOverride *bool
+
+// piOpenScan is the directive opener the gate scans for; any occurrence
+// disqualifies the parse skip.
+var piOpenScan = []byte("<?")
+
+// layer0SkipEnabled reports whether the master Layer 0 parse-skip toggle
+// is on. It honours an in-process override when set, otherwise reads the
+// MDSMITH_LAYER0_SKIP environment variable each call so a test in any
+// package can flip it via t.Setenv.
+//
+// Default OFF. The parse-skip path is correct (byte-identical to the parsed
+// path, held so by the TestLayer0Gate_* corpus equivalence gates, now for
+// list-bearing files too), but it is not yet a measured net win. Profiled
+// on the eligible-only subset it is cost-neutral: the skip path's cost is
+// dominated by lint.InlineBlocks (~51%), which the parity link/reference
+// rules read on the nil-AST path and which still runs a full goldmark parse
+// per run — so skipping the block parse saves almost nothing while the
+// cheap line scans (~10%) ride on top. It stays an opt-in seam
+// (MDSMITH_LAYER0_SKIP=1) until InlineBlocks becomes the light inline scan
+// Layer 1 was meant to be — see
+// docs/research/benchmarks/parity-parse-skip-findings.md.
+func layer0SkipEnabled() bool {
+	if layer0SkipOverride != nil {
+		return *layer0SkipOverride
+	}
+	return os.Getenv("MDSMITH_LAYER0_SKIP") != ""
+}
+
+// layer0SkipEligible reports whether this file's run can skip the goldmark
+// parse and lint from the Layer 0 scan alone. Five conditions must hold:
+//
+//  1. The MDSMITH_LAYER0_SKIP toggle is set (default off).
+//  2. Every enabled rule resolves to Layer 0 (rulelayer.IsLayer0) — no
+//     enabled rule navigates f.AST. An unknown rule id is treated as
+//     AST-requiring, so a rule the audit does not cover is never skipped.
+//  3. The source carries no `<?` directive marker. Generated-section
+//     suppression walks the AST for processing instructions, so a file
+//     with directives must be parsed.
+//  4. The source may contain no block quote (lint.SourceMayHaveBlockQuote
+//     is false — i.e. no `>` byte). The block-span scanner collapses a
+//     block quote into a single BlockQuote span and never emits the
+//     heading/fenced-code spans that block-kind rules (MDS002, MDS015)
+//     react to for quote-nested content, so a quote-nested heading would
+//     be flagged on the AST path but missed on the parse-skip path.
+//     This `>`-free condition doubles as the HTML-block guard: every HTML
+//     block opener carries a `>` somewhere it can be excluded on (`<div>`,
+//     a closed `-->` comment, a self-closing `<br/>`), and listscan does
+//     not model an HTML block's opaque interior, so excluding any `>`
+//     keeps those files on the parse path too. A more precise per-line
+//     quote scan (so code-heavy `>`-bearing files could skip) needs the
+//     block-span scanner to descend into block quotes first; until then
+//     the coarse `>` guard is the sound choice.
+//
+// Lists no longer disqualify the skip. The list rules (MDS014/016/045/
+// 046/061) re-derive list structure from f.Lines via listscan on the
+// nil-AST path (rule.LinesChecker routes them to Check), and the flat
+// ClassifyLines code-line projection descends into list items, so a fence
+// or indent nested in a list is classified correctly. Block-kind rules
+// read the scanLayer0 block spans, which match goldmark on every
+// list-nested heading/fence the corpus exercises. All of this is held
+// byte-identical to the AST by TestLayer0Gate_CorpusDiagnosticsEquivalence,
+// which now engages on list-bearing files.
+//
+// The block-only and flat-Layer-0 spike flags force their own
+// constructors, so the gate stands down when either is set.
+func (r *Runner) layer0SkipEligible(
+	source []byte, rules []rule.Rule, effective map[string]config.RuleCfg,
+) bool {
+	if !layer0SkipEnabled() || r.BlockOnlyParse || r.FlatLayer0 {
+		return false
+	}
+	if bytes.Contains(source, piOpenScan) {
+		return false
+	}
+	if lint.SourceMayHaveBlockQuote(source) {
+		return false
+	}
+	return allEnabledRulesSkipSafe(rules, effective)
+}
+
+// allEnabledRulesSkipSafe reports whether every enabled rule in effective
+// can lint the parse-skipped (nil-AST) File. A rule qualifies two ways,
+// unifying the engine's two parse-skip signals (plan 2606171400):
+//
+//   - It is a static Layer 0 rule (rulelayer.IsLayer0). Block rules serve
+//     the nil-AST path through their rule.BlockChecker dispatch.
+//   - Its configured instance reports rule.LineCapable. Line rules whose
+//     layer depends on config — line-length is line-capable only without a
+//     per-heading limit — serve the nil-AST path through the File's
+//     ClassifyLines projection.
+//
+// A run with no enabled rules trivially qualifies. A disabled rule is
+// ignored. An unknown rule that is neither Layer 0 nor line-capable forces
+// the parse.
+func allEnabledRulesSkipSafe(rules []rule.Rule, effective map[string]config.RuleCfg) bool {
+	for _, rl := range rules {
+		cfg, ok := effective[rl.Name()]
+		if !ok || !cfg.Enabled {
+			continue
+		}
+		if rulelayer.IsLayer0(rl.ID()) {
+			continue
+		}
+		if ruleConfiguredLineCapable(rl, cfg) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// ruleConfiguredLineCapable reports whether rl, once configured with cfg,
+// can lint from f.Lines alone (rule.LineCapable). A rule's line-capability
+// can depend on its settings, so the rule is configured before the check —
+// line-length is line-capable until a per-heading limit is set. A config
+// error makes the rule non-skip-safe (the parse path surfaces the error).
+func ruleConfiguredLineCapable(rl rule.Rule, cfg config.RuleCfg) bool {
+	configured, err := checker.ConfigureRule(rl, cfg)
+	if err != nil {
+		return false
+	}
+	lc, ok := configured.(rule.LineCapable)
+	return ok && lc.LineCapable()
+}
+
+// computeFlatLayer0Active reports whether this run may skip the goldmark
+// parse for line-capable files. It requires the opt-in Runner.FlatLayer0
+// flag and a config simple enough that the globally-enabled rule set is
+// the whole story: every enabled markdown rule must be rule.LineCapable,
+// and the config must declare no kinds or overrides (either could enable a
+// non-line-capable rule for some file that the empty-path effective config
+// does not surface). This conservative gate is sufficient for the prototype
+// (plan 2606142147) measurement, whose single-rule line-length config has
+// neither; the full Layer-0 plan refines it to a per-file resolution.
+func (r *Runner) computeFlatLayer0Active() bool {
+	if !r.FlatLayer0 {
+		return false
+	}
+	if len(r.Config.Kinds) > 0 || len(r.Config.Overrides) > 0 {
+		return false
+	}
+	mdRules := markdownRulesFrom(r.Rules, r.ConfigPath)
+	effective := r.effectiveWithCategories("", nil, nil)
+	for _, rl := range mdRules {
+		cfg, ok := effective[rl.Name()]
+		if !ok || !cfg.Enabled {
+			continue
+		}
+		// A rule's line-capability can depend on its config (line-length
+		// is not line-capable once a per-heading limit is set). With no
+		// kinds or overrides, the empty-path effective config is the
+		// rule's settings for every file. ruleConfiguredLineCapable
+		// applies those settings before asking — the same check the
+		// unified parse-skip gate uses.
+		if !ruleConfiguredLineCapable(rl, cfg) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/runner_log.go
+++ b/internal/engine/runner_log.go
@@ -1,0 +1,77 @@
+package engine
+
+import (
+	"sort"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	vlog "github.com/jeduden/mdsmith/internal/log"
+	"github.com/jeduden/mdsmith/internal/rule"
+)
+
+// log returns the runner's logger. If no logger is set, it returns a
+// disabled logger so callers don't need nil checks.
+func (r *Runner) log() *vlog.Logger {
+	if r.Logger != nil {
+		return r.Logger
+	}
+	return &vlog.Logger{}
+}
+
+// logRules logs each enabled rule in the effective config from the provided slice.
+func (r *Runner) logRules(rules []rule.Rule, effective map[string]config.RuleCfg) {
+	logRulesTo(r.log(), rules, effective)
+}
+
+// logRulesTo logs each enabled rule to l. Split from logRules so the
+// per-file buffered logger in lintFile can reuse the same formatting
+// without going through the shared Runner logger.
+func logRulesTo(l *vlog.Logger, rules []rule.Rule, effective map[string]config.RuleCfg) {
+	if !l.Enabled {
+		return
+	}
+	for _, rl := range rules {
+		cfg, ok := effective[rl.Name()]
+		if !ok || !cfg.Enabled {
+			continue
+		}
+		l.Printf("rule: %s %s", rl.ID(), rl.Name())
+	}
+}
+
+// ruleCategoryLookup returns a function that maps a rule name to its category.
+func ruleCategoryLookup(rules []rule.Rule) func(string) string {
+	m := make(map[string]string, len(rules))
+	for _, rl := range rules {
+		m[rl.Name()] = rl.Category()
+	}
+	return func(name string) string {
+		return m[name]
+	}
+}
+
+// sortDiagnostics sorts diagnostics by file, line, column, message, then
+// rule id. The RuleID tiebreak makes the order independent of the walk path
+// that produced the diagnostics: the parse-skip block-walk and the full-parse
+// node-walk can emit two same-position, same-message diagnostics from
+// different rules in different input orders, and the Layer-0 equivalence
+// assertions compare full ordered slices. sort.SliceStable then preserves
+// input order only for diagnostics equal on every compared field.
+func sortDiagnostics(diags []lint.Diagnostic) {
+	sort.SliceStable(diags, func(i, j int) bool {
+		di, dj := diags[i], diags[j]
+		if di.File != dj.File {
+			return di.File < dj.File
+		}
+		if di.Line != dj.Line {
+			return di.Line < dj.Line
+		}
+		if di.Column != dj.Column {
+			return di.Column < dj.Column
+		}
+		if di.Message != dj.Message {
+			return di.Message < dj.Message
+		}
+		return di.RuleID < dj.RuleID
+	})
+}

--- a/plan/2606211907_arch-fix-runner-srp-split.md
+++ b/plan/2606211907_arch-fix-runner-srp-split.md
@@ -1,0 +1,87 @@
+---
+id: 2606211907
+title: 'arch-fix: split internal/engine/runner.go'
+status: '✅'
+summary: >-
+  Split runner.go (1 290 lines) into sibling
+  files along its logical groups to restore the
+  1 000-line guideline and satisfy SRP for the
+  engine package.
+model: ''
+depends-on: []
+---
+# arch-fix: split internal/engine/runner.go
+
+## Context
+
+Closes audit entry 2026-06-21.
+[`internal/engine/runner.go`](../internal/engine/runner.go)
+reached 1 290 lines.
+
+Go arch doc §"Common violations to flag"
+names engine as a place that grows unbounded
+when it becomes a dumping ground.
+The audit checklist calls out the 1 000-line
+threshold explicitly.
+
+The file mixes seven concerns:
+
+- File dispatch (`Run`, `runFiles`,
+  `lintFile`, `filterIgnored`, …)
+- Layer-0 parse-skip gate
+  (`layer0SkipEnabled`,
+  `layer0SkipEligible`,
+  `allEnabledRulesSkipSafe`,
+  `computeFlatLayer0Active`, …)
+- Config-resolution cache
+  (`effectiveCache`, `runResolve`,
+  `configuredRules`, `effectiveCached`,
+  `runCacheForCall`, …)
+- Source-mode lint path (`RunSource`,
+  `runSource`, `parseForSource`,
+  `populateFileFields`, …)
+- Front-matter parsing
+  (`parseFrontMatterKinds`,
+  `parseFrontMatter`, …)
+- Config-target rules
+  (`runConfigTargetRules`,
+  `runConfigRule`, `anyRepoScopedEnabled`)
+- Logging and sorting (`log`, `logRules`,
+  `ruleCategoryLookup`, `sortDiagnostics`)
+
+## Goal
+
+Split `runner.go` into sibling files within
+the same package. Each sibling answers one
+question. The primary file stays under
+1 000 lines.
+
+## Tasks
+
+1. Create `internal/engine/runner_layer0.go`:
+   move Layer-0 gate functions and
+   `computeFlatLayer0Active`.
+2. Create `internal/engine/runner_cache.go`:
+   move cache types and their methods.
+3. Create `internal/engine/runner_log.go`:
+   move logging helpers and
+   `sortDiagnostics`.
+4. Remove the moved blocks from `runner.go`
+   and trim now-unused imports.
+5. Run `go build ./...` — confirm no errors.
+6. Run `go test ./...` — confirm no
+   regressions.
+7. Confirm `wc -l runner.go` is under
+   1 000 lines.
+
+## Acceptance Criteria
+
+- [x] `internal/engine/runner.go` is under
+  1 000 lines.
+- [x] `go build ./...` passes.
+- [x] `go test ./...` passes.
+- [x] `go tool golangci-lint run` reports
+  no new issues.
+- [x] No logic changed — pure file
+  reorganisation within the `engine`
+  package.

--- a/plan/2606211908_arch-fix-layer0-split.md
+++ b/plan/2606211908_arch-fix-layer0-split.md
@@ -1,0 +1,74 @@
+---
+id: 2606211908
+title: 'arch-fix: split internal/lint/layer0.go'
+status: '🔲'
+summary: >-
+  Split layer0.go (1 203 lines) into focused
+  sibling files along block-type sub-parsers
+  to stay within the 1 000-line guideline.
+model: ''
+depends-on: []
+---
+# arch-fix: split internal/lint/layer0.go
+
+## Context
+
+Audit 2026-06-21 flagged
+[`internal/lint/layer0.go`](../internal/lint/layer0.go)
+at 1 203 lines.
+
+The file holds the entire Layer-0 block
+scanner. It packs seven sub-parsers together:
+
+- Exported types (`BlockKind`, `BlockSpan`,
+  `Layer0Scan`)
+- Scanner state machine
+- HTML-block detection (types 1–7)
+- Fence handling
+- ATX-heading detection
+- Indented-code detection
+- Paragraph scanning
+
+One file for all of these makes targeted
+changes risky. Locating the relevant section
+is slow.
+
+## Goal
+
+Split `layer0.go` into sibling files within
+`internal/lint`. Each sibling covers one or
+two block-type sub-parsers. The primary file
+stays under 600 lines.
+
+## Tasks
+
+1. Create `internal/lint/layer0_html.go`:
+   move HTML-block detection (types 1–7),
+   `openHTMLBlock`, `htmlBlockCloses`,
+   `tagName`, and related helpers.
+2. Create `internal/lint/layer0_fence.go`:
+   move fence-state logic (`fenceInfo`,
+   `openingFence`, `closingFence`,
+   `advanceFenceState`, `tryFence`).
+3. Create `internal/lint/layer0_para.go`:
+   move paragraph scanning (`scanParagraph`,
+   `markSetextRun`, `paragraphLeadKind`,
+   `SourceMayHaveCodeBlock`).
+4. Remove the moved blocks from `layer0.go`
+   and trim now-unused file-local symbols.
+5. Run `go build ./...` — confirm no errors.
+6. Run `go test ./...` — confirm no
+   regressions.
+7. Confirm `wc -l layer0.go` is under
+   600 lines.
+
+## Acceptance Criteria
+
+- [ ] `internal/lint/layer0.go` is under
+  600 lines.
+- [ ] `go build ./...` passes.
+- [ ] `go test ./...` passes.
+- [ ] `go tool golangci-lint run` reports
+  no new issues.
+- [ ] No logic changed — pure file
+  reorganisation within the `lint` package.

--- a/plan/2606211909_arch-fix-lsp-server-split.md
+++ b/plan/2606211909_arch-fix-lsp-server-split.md
@@ -1,0 +1,67 @@
+---
+id: 2606211909
+title: 'arch-fix: split internal/lsp/server.go'
+status: '🔲'
+summary: >-
+  server.go crept back to 1 007 lines after
+  plan 203 green. Split along dispatch groups
+  to stay under the 1 000-line threshold named
+  in the checklist.
+model: ''
+depends-on: []
+---
+# arch-fix: split internal/lsp/server.go
+
+## Context
+
+Audit 2026-06-21 flagged
+[`internal/lsp/server.go`](../internal/lsp/server.go)
+at 1 007 lines.
+
+Plan 203 (`arch-fix-lsp-server-split`) was
+green. The VS Code `kinds` and `rule-doc`
+capability wiring added in the security and
+editor-integration series grew the file back
+over the threshold.
+
+The audit checklist names `server.go`
+explicitly as a file to split by dispatch
+group when it exceeds 1 000 lines.
+
+## Goal
+
+Split `server.go` into sibling files within
+`internal/lsp` by dispatch group.
+The primary file stays under 800 lines.
+
+## Tasks
+
+1. Identify the new capability dispatch
+   blocks added since plan 203 (`kinds`
+   handlers, `rule-doc` / hover-rewrite
+   handlers).
+2. Create `internal/lsp/server_kinds.go`:
+   move the `kinds` request handlers and
+   their helpers.
+3. Move hover-rewrite and rule-doc
+   registration into a dedicated sibling
+   (or extend the existing one from
+   plan 203).
+4. Remove the moved blocks from `server.go`
+   and trim unused imports.
+5. Run `go build ./...` — confirm no errors.
+6. Run `go test ./...` — confirm no
+   regressions.
+7. Confirm `wc -l server.go` is under
+   800 lines.
+
+## Acceptance Criteria
+
+- [ ] `internal/lsp/server.go` is under
+  800 lines.
+- [ ] `go build ./...` passes.
+- [ ] `go test ./...` passes.
+- [ ] `go tool golangci-lint run` reports
+  no new issues.
+- [ ] No LSP behaviour changed — pure file
+  reorganisation within the `lsp` package.

--- a/plan/2606211910_arch-fix-workspace-exemptions.md
+++ b/plan/2606211910_arch-fix-workspace-exemptions.md
@@ -1,0 +1,63 @@
+---
+id: 2606211910
+title: >-
+  arch-fix: add trivial-accessor exemption
+  comments in workspace.go
+status: '🔲'
+summary: >-
+  Add one-line "no test by design" comments
+  to the trivial one-liner methods in
+  pkg/mdsmith/workspace.go so the audit can
+  distinguish intentional exemptions from
+  forgotten tests.
+model: ''
+depends-on: []
+---
+# arch-fix: workspace.go trivial-accessor exemptions
+
+## Context
+
+Audit 2026-06-21 flagged trivial one-liner
+methods in
+[`pkg/mdsmith/workspace.go`](../pkg/mdsmith/workspace.go).
+
+Tests doc §"Exemptions" says:
+
+> Add a one-line comment on the function so
+> the audit can distinguish "no test by
+> design" from "no test, forgotten".
+
+The affected methods are:
+
+- `memFile.Close`
+- `memDir.Read`
+- `memDir.Close`
+- `memDirEntry.Name`, `.IsDir`, `.Type`,
+  `.Info`
+- `memFileInfo.Name`, `.Size`, and the
+  remaining one-liner interface methods
+
+## Goal
+
+Add a one-line exemption comment to each
+affected trivial method.
+Future audits pass without flagging them.
+
+## Tasks
+
+1. For each trivial one-liner method in
+   `pkg/mdsmith/workspace.go`, add a comment:
+   `// no test by design — trivial accessor`
+2. Run `go build ./...` — confirm no errors.
+3. Run `go run ./cmd/mdsmith check
+   pkg/mdsmith/workspace.go` — confirm no
+   new lint violations.
+
+## Acceptance Criteria
+
+- [ ] Every trivial one-liner method in
+  `pkg/mdsmith/workspace.go` carries an
+  exemption comment.
+- [ ] `go build ./...` passes.
+- [ ] `mdsmith check pkg/mdsmith/workspace.go`
+  reports no new violations.


### PR DESCRIPTION
## Summary

- `internal/engine/runner.go` reached 1 290 lines mixing seven concerns (file dispatch, Layer-0 gate, config-resolution cache, source-mode lint path, front-matter parsing, config-target rules, logging). The Go architecture doc names `engine` as a dumping-ground risk; the audit checklist calls out the 1 000-line threshold explicitly.
- Split the three most cohesive concern groups into same-package sibling files: `runner_layer0.go` (Layer-0 parse-skip gate, 179 lines), `runner_cache.go` (effective-config cache + gitignore cache, 135 lines), `runner_log.go` (logging helpers + `sortDiagnostics`, 77 lines).
- Primary file is now **931 lines**. Pure file reorganisation — no logic changed, confirmed byte-identical by the removed-behavior audit angle.

## Plans filed

Three remaining tax items from the 2026-06-21 SOLID audit are captured as new plan files:

| Plan | File | Issue |
|------|------|-------|
| 2606211908 | `internal/lint/layer0.go` (1 203 lines) | Split along block-type sub-parsers |
| 2606211909 | `internal/lsp/server.go` (1 007 lines) | Split `kinds` handlers into sibling |
| 2606211910 | `pkg/mdsmith/workspace.go` trivial methods | Add "no test by design" exemption comments |

## Test plan

- [x] `go build ./...` — no errors
- [x] `go test ./...` — all green (engine + full suite)
- [x] `wc -l internal/engine/runner.go` → 931 (under 1 000)
- [x] `go run ./cmd/mdsmith check` on changed markdown files — no violations
- [x] 3× code-review (line-by-line, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) — no correctness bugs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2S14pCS1WAv6p7n8ZHHb2

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2S14pCS1WAv6p7n8ZHHb2)_