### PR TITLE
perf: replace map[string]bool sets with map[string]struct{} across hot paths

### DIFF
--- a/internal/config/kind_extends.go
+++ b/internal/config/kind_extends.go
@@ -101,7 +101,7 @@ func extendsChainSchemas(
 	kinds map[string]KindBody, name string,
 ) ([]schemaChainEntry, error) {
 	visited := make(map[string]struct{})
-	chain := []string{}
+	var chain []string
 	current := name
 	for current != "" {
 		if _, ok := visited[current]; ok {

--- a/internal/config/kind_extends.go
+++ b/internal/config/kind_extends.go
@@ -100,17 +100,17 @@ type schemaChainEntry struct {
 func extendsChainSchemas(
 	kinds map[string]KindBody, name string,
 ) ([]schemaChainEntry, error) {
-	visited := map[string]bool{}
+	visited := make(map[string]struct{})
 	chain := []string{}
 	current := name
 	for current != "" {
-		if visited[current] {
+		if _, ok := visited[current]; ok {
 			chain = append(chain, current)
 			return nil, fmt.Errorf(
 				"kind %q: extends cycle detected: %s",
 				name, strings.Join(chain, " -> "))
 		}
-		visited[current] = true
+		visited[current] = struct{}{}
 		chain = append(chain, current)
 		body, ok := kinds[current]
 		if !ok {
@@ -138,14 +138,14 @@ func extendsChainSchemas(
 // returns a one-element slice containing just its own name. The
 // chain is the inheritance audit list `mdsmith kinds show` prints.
 func KindExtendsChain(kinds map[string]KindBody, name string) []string {
-	visited := map[string]bool{}
-	out := []string{}
+	visited := make(map[string]struct{})
+	var out []string
 	current := name
 	for current != "" {
-		if visited[current] {
+		if _, ok := visited[current]; ok {
 			return out
 		}
-		visited[current] = true
+		visited[current] = struct{}{}
 		out = append(out, current)
 		body, ok := kinds[current]
 		if !ok {

--- a/internal/config/kind_extends_test.go
+++ b/internal/config/kind_extends_test.go
@@ -357,6 +357,14 @@ func TestResolveLayerInlineSchema_DefensiveFallbackOnResolverError(t *testing.T)
 	assert.Equal(t, "a.md", out["filename"])
 }
 
+// TestKindExtendsChain_EmptyNameReturnsNil pins the project convention
+// that functions return nil, not []T{}, for an empty result.
+// An empty name produces no chain entries, so the return must be nil.
+func TestKindExtendsChain_EmptyNameReturnsNil(t *testing.T) {
+	chain := KindExtendsChain(nil, "")
+	assert.Nil(t, chain, "empty name must return nil, not []string{}")
+}
+
 // TestKindExtendsChain_UnknownIntermediateBreaksChain covers the
 // defensive branch in KindExtendsChain that stops when a parent
 // name is not declared in `kinds`. The chain returned still

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -293,13 +293,13 @@ func mergeCategories(base, override map[string]bool) map[string]bool {
 // caller has no FM info — such entries simply won't match.
 func EffectiveKinds(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) []string {
 	if cfg == nil {
-		seen := make(map[string]bool, len(fmKinds))
+		seen := make(map[string]struct{}, len(fmKinds))
 		out := make([]string, 0, len(fmKinds))
 		for _, k := range fmKinds {
-			if seen[k] {
+			if _, ok := seen[k]; ok {
 				continue
 			}
-			seen[k] = true
+			seen[k] = struct{}{}
 			out = append(out, k)
 		}
 		return out
@@ -312,12 +312,12 @@ func EffectiveKinds(cfg *Config, filePath string, fmKinds []string, fmFields map
 // they come first. kind-assignment matches are appended in config order.
 // Duplicate names are dropped after their first occurrence.
 func resolveEffectiveKinds(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) []string {
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var result []string
 
 	add := func(name string) {
-		if !seen[name] {
-			seen[name] = true
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
 			result = append(result, name)
 		}
 	}

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -354,10 +354,10 @@ func splitRulesByExplicit(cfg *Config) (defaults, user map[string]RuleCfg) {
 }
 
 func allRuleNames(layers []layerInfo) []string {
-	seen := map[string]bool{}
+	seen := make(map[string]struct{})
 	for _, l := range layers {
 		for name := range l.Rules {
-			seen[name] = true
+			seen[name] = struct{}{}
 		}
 	}
 	names := make([]string, 0, len(seen))

--- a/internal/config/provenance.go
+++ b/internal/config/provenance.go
@@ -482,13 +482,13 @@ func kindSchemaSourcePath(body KindBody) string {
 }
 
 func resolveKindsWithSources(cfg *Config, filePath string, fmKinds []string, fmFields map[string]any) []ResolvedKind {
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var result []ResolvedKind
 	add := func(name string, source KindAssignmentSource, selector string) {
-		if seen[name] {
+		if _, ok := seen[name]; ok {
 			return
 		}
-		seen[name] = true
+		seen[name] = struct{}{}
 		// SourcePath comes from the kind body, not the assignment —
 		// every assignment route to the same name resolves to the
 		// same defining file. SchemaSourcePath, when the kind's schema

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -75,17 +75,17 @@ func ValidateKinds(cfg *Config) error {
 // order in ValidateKinds is sorted, so the diagnostic stays
 // deterministic across runs.
 func validateKindExtends(kinds map[string]KindBody, name string) error {
-	visited := map[string]bool{}
+	visited := make(map[string]struct{})
 	chain := []string{}
 	current := name
 	for current != "" {
-		if visited[current] {
+		if _, ok := visited[current]; ok {
 			chain = append(chain, current)
 			return fmt.Errorf(
 				"kind %q: extends cycle detected: %s",
 				name, strings.Join(chain, " -> "))
 		}
-		visited[current] = true
+		visited[current] = struct{}{}
 		chain = append(chain, current)
 		body, ok := kinds[current]
 		if !ok {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -76,7 +76,7 @@ func ValidateKinds(cfg *Config) error {
 // deterministic across runs.
 func validateKindExtends(kinds map[string]KindBody, name string) error {
 	visited := make(map[string]struct{})
-	chain := []string{}
+	var chain []string
 	current := name
 	for current != "" {
 		if _, ok := visited[current]; ok {

--- a/internal/lint/files.go
+++ b/internal/lint/files.go
@@ -115,7 +115,7 @@ func ResolveFiles(args []string) ([]string, error) {
 // ResolveFilesWithOpts is like ResolveFiles but accepts options to control
 // behavior such as gitignore filtering.
 func ResolveFilesWithOpts(args []string, opts ResolveOpts) ([]string, error) {
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var result []string
 
 	addFile := func(path string) {
@@ -123,8 +123,8 @@ func ResolveFilesWithOpts(args []string, opts ResolveOpts) ([]string, error) {
 		if err != nil {
 			abs = path
 		}
-		if !seen[abs] {
-			seen[abs] = true
+		if _, ok := seen[abs]; !ok {
+			seen[abs] = struct{}{}
 			result = append(result, path)
 		}
 	}

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -401,7 +401,7 @@ func (c *RunCache) CompiledCUE(source string, build func() any) any {
 // the workspace; the LSP must InvalidateWikilinks (or build a
 // fresh RunCache) when the filesystem layout changes.
 func (c *RunCache) Invalidate(absPath string) {
-	c.invalidate(absPath, map[string]bool{})
+	c.invalidate(absPath, map[string]struct{}{})
 }
 
 // invalidate is the recursive worker for Invalidate. The visited set
@@ -412,11 +412,11 @@ func (c *RunCache) Invalidate(absPath string) {
 // encounter. The set is per-call (allocated by the public
 // Invalidate entry point) so independent Invalidate calls do not
 // share visited state.
-func (c *RunCache) invalidate(absPath string, visited map[string]bool) {
-	if visited[absPath] {
+func (c *RunCache) invalidate(absPath string, visited map[string]struct{}) {
+	if _, ok := visited[absPath]; ok {
 		return
 	}
-	visited[absPath] = true
+	visited[absPath] = struct{}{}
 
 	c.frontMatter.Delete(absPath)
 	c.includes.Delete(absPath)
@@ -471,7 +471,7 @@ func (c *RunCache) evictSchemaArtifacts(absPath string) (includes []string) {
 // with only the live dependents. The visited set carried through the recursion
 // is the cycle guard — a dependent already invalidated in this top-level call
 // is skipped.
-func (c *RunCache) invalidateDependents(absPath string, visited map[string]bool) {
+func (c *RunCache) invalidateDependents(absPath string, visited map[string]struct{}) {
 	c.depsMu.Lock()
 	set, ok := c.schemaDependents[absPath]
 	c.depsMu.Unlock()

--- a/internal/rules/catalog/helpers_test.go
+++ b/internal/rules/catalog/helpers_test.go
@@ -236,7 +236,7 @@ func TestScanIncludesForTargetAbs_DepthLimit(t *testing.T) {
 		"a.md": &fstest.MapFile{Data: []byte("# A\n")},
 	}
 	cf := &lint.File{Path: "host.md", FS: fsys, RunCache: lint.NewRunCache()}
-	visited := map[string]bool{}
+	visited := map[string]struct{}{}
 	got := scanIncludesForTargetAbs(cf, fsys, "/host",
 		"/host/a.md", "/host/target.md",
 		visited, maxIncludeDepth+1, 1024)
@@ -254,7 +254,7 @@ func TestScanIncludesForTargetAbs_DirectMatch(t *testing.T) {
 		"target.md": &fstest.MapFile{Data: []byte("# T\n")},
 	}
 	cf := &lint.File{Path: "host.md", FS: fsys, RunCache: lint.NewRunCache()}
-	visited := map[string]bool{filepath.Join(tmp, "a.md"): true}
+	visited := map[string]struct{}{filepath.Join(tmp, "a.md"): {}}
 	got := scanIncludesForTargetAbs(cf, fsys, tmp,
 		filepath.Join(tmp, "a.md"),
 		filepath.Join(tmp, "target.md"),
@@ -276,7 +276,7 @@ func TestScanIncludesForTargetAbs_VisitedCycleSkipped(t *testing.T) {
 	absA := filepath.Join(tmp, "a.md")
 	absB := filepath.Join(tmp, "b.md")
 	absTarget := filepath.Join(tmp, "target.md")
-	visited := map[string]bool{absA: true, absB: true}
+	visited := map[string]struct{}{absA: {}, absB: {}}
 	got := scanIncludesForTargetAbs(cf, fsys, tmp,
 		absA, absTarget, visited, 0, 1024)
 	assert.False(t, got,
@@ -298,7 +298,7 @@ func TestScanIncludesForTargetAbs_IndirectMatch(t *testing.T) {
 		"target.md": &fstest.MapFile{Data: []byte("# T\n")},
 	}
 	cf := &lint.File{Path: "host.md", FS: fsys, RunCache: lint.NewRunCache()}
-	visited := map[string]bool{filepath.Join(tmp, "a.md"): true}
+	visited := map[string]struct{}{filepath.Join(tmp, "a.md"): {}}
 	got := scanIncludesForTargetAbs(cf, fsys, tmp,
 		filepath.Join(tmp, "a.md"),
 		filepath.Join(tmp, "target.md"),

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -1376,7 +1376,7 @@ func hostAbsDir(f *lint.File) (string, bool) {
 func fileIncludesTarget(
 	cf *lint.File, fsys fs.FS, filePath, target string, maxBytes int64,
 ) bool {
-	visited := map[string]bool{filePath: true}
+	visited := map[string]struct{}{filePath: {}}
 	return scanIncludesForTarget(cf, fsys, filePath, target, visited, 0, maxBytes)
 }
 
@@ -1394,7 +1394,7 @@ func fileIncludesTargetAbs(
 	cf *lint.File, fsys fs.FS, hostAbsDir, absFilePath, absTarget string,
 	maxBytes int64,
 ) bool {
-	visited := map[string]bool{absFilePath: true}
+	visited := map[string]struct{}{absFilePath: {}}
 	return scanIncludesForTargetAbs(cf, fsys, hostAbsDir,
 		absFilePath, absTarget, visited, 0, maxBytes)
 }
@@ -1523,7 +1523,7 @@ func relToHost(hostAbsDir, absPath string) (string, bool) {
 
 func scanIncludesForTarget(
 	cf *lint.File, fsys fs.FS, filePath, target string,
-	visited map[string]bool, depth int, maxBytes int64,
+	visited map[string]struct{}, depth int, maxBytes int64,
 ) bool {
 	if depth > maxIncludeDepth {
 		return false
@@ -1532,10 +1532,10 @@ func scanIncludesForTarget(
 		if resolved == target {
 			return true
 		}
-		if visited[resolved] {
+		if _, ok := visited[resolved]; ok {
 			continue
 		}
-		visited[resolved] = true
+		visited[resolved] = struct{}{}
 		found := scanIncludesForTarget(cf, fsys, resolved, target, visited, depth+1, maxBytes)
 		delete(visited, resolved)
 		if found {
@@ -1552,7 +1552,7 @@ func scanIncludesForTarget(
 // shares across host files.
 func scanIncludesForTargetAbs(
 	cf *lint.File, fsys fs.FS, hostAbsDir, absFilePath, absTarget string,
-	visited map[string]bool, depth int, maxBytes int64,
+	visited map[string]struct{}, depth int, maxBytes int64,
 ) bool {
 	if depth > maxIncludeDepth {
 		return false
@@ -1561,10 +1561,10 @@ func scanIncludesForTargetAbs(
 		if absResolved == absTarget {
 			return true
 		}
-		if visited[absResolved] {
+		if _, ok := visited[absResolved]; ok {
 			continue
 		}
-		visited[absResolved] = true
+		visited[absResolved] = struct{}{}
 		found := scanIncludesForTargetAbs(cf, fsys, hostAbsDir,
 			absResolved, absTarget, visited, depth+1, maxBytes)
 		delete(visited, absResolved)

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -4264,7 +4264,7 @@ func TestScanIncludesForTarget_MaxDepthExceeded(t *testing.T) {
 	fsys := fstest.MapFS{
 		"a.md": &fstest.MapFile{Data: []byte("# A\n")},
 	}
-	visited := map[string]bool{}
+	visited := map[string]struct{}{}
 	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, maxIncludeDepth+1, 1000)
 	assert.False(t, result)
 }
@@ -4272,7 +4272,7 @@ func TestScanIncludesForTarget_MaxDepthExceeded(t *testing.T) {
 func TestScanIncludesForTarget_FileReadError(t *testing.T) {
 	// File does not exist in FS → read error → returns false.
 	fsys := fstest.MapFS{}
-	visited := map[string]bool{}
+	visited := map[string]struct{}{}
 	result := scanIncludesForTarget(&lint.File{}, fsys, "nonexistent.md", "target.md", visited, 0, 1000)
 	assert.False(t, result)
 }
@@ -4282,7 +4282,7 @@ func TestScanIncludesForTarget_NoIncludes(t *testing.T) {
 	fsys := fstest.MapFS{
 		"a.md": &fstest.MapFile{Data: []byte("# A\n\nNo includes here.\n")},
 	}
-	visited := map[string]bool{}
+	visited := map[string]struct{}{}
 	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.False(t, result)
 }
@@ -4294,7 +4294,7 @@ func TestScanIncludesForTarget_DirectMatch(t *testing.T) {
 			Data: []byte("<?include\nfile: target.md\n?>\nsome content\n<?/include?>"),
 		},
 	}
-	visited := map[string]bool{"a.md": true}
+	visited := map[string]struct{}{"a.md": {}}
 	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.True(t, result)
 }
@@ -4307,7 +4307,7 @@ func TestScanIncludesForTarget_VisitedCycleSkipped(t *testing.T) {
 		},
 	}
 	// Mark b.md as already visited to prevent recursion.
-	visited := map[string]bool{"a.md": true, "b.md": true}
+	visited := map[string]struct{}{"a.md": {}, "b.md": {}}
 	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.False(t, result)
 }
@@ -4357,7 +4357,7 @@ func TestScanIncludesForTarget_IndirectMatch(t *testing.T) {
 			Data: []byte("<?include\nfile: target.md\n?>\ncontent\n<?/include?>"),
 		},
 	}
-	visited := map[string]bool{"a.md": true}
+	visited := map[string]struct{}{"a.md": {}}
 	result := scanIncludesForTarget(&lint.File{}, fsys, "a.md", "target.md", visited, 0, 1000)
 	assert.True(t, result)
 }

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -275,15 +275,19 @@ func (m memFS) dirEntries(dir string) []fs.DirEntry {
 		rest := key[len(prefix):]
 		if i := indexSlash(rest); i >= 0 {
 			name := rest[:i]
-			if _, ok := seen[name]; name != "" && !ok {
-				seen[name] = struct{}{}
-				ents = append(ents, memDirEntry{name: name, dir: true})
+			if name != "" {
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					ents = append(ents, memDirEntry{name: name, dir: true})
+				}
 			}
 			continue
 		}
-		if _, ok := seen[rest]; rest != "" && !ok {
-			seen[rest] = struct{}{}
-			ents = append(ents, memDirEntry{name: rest, size: int64(len(m[key])), dir: false})
+		if rest != "" {
+			if _, ok := seen[rest]; !ok {
+				seen[rest] = struct{}{}
+				ents = append(ents, memDirEntry{name: rest, size: int64(len(m[key])), dir: false})
+			}
 		}
 	}
 	sort.Slice(ents, func(i, j int) bool { return ents[i].Name() < ents[j].Name() })

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -264,7 +264,7 @@ func (m memFS) dirEntries(dir string) []fs.DirEntry {
 	if dir != "." {
 		prefix = dir + "/"
 	}
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var ents []fs.DirEntry
 	for key := range m {
 		if prefix != "" {
@@ -275,14 +275,14 @@ func (m memFS) dirEntries(dir string) []fs.DirEntry {
 		rest := key[len(prefix):]
 		if i := indexSlash(rest); i >= 0 {
 			name := rest[:i]
-			if name != "" && !seen[name] {
-				seen[name] = true
+			if _, ok := seen[name]; name != "" && !ok {
+				seen[name] = struct{}{}
 				ents = append(ents, memDirEntry{name: name, dir: true})
 			}
 			continue
 		}
-		if rest != "" && !seen[rest] {
-			seen[rest] = true
+		if _, ok := seen[rest]; rest != "" && !ok {
+			seen[rest] = struct{}{}
 			ents = append(ents, memDirEntry{name: rest, size: int64(len(m[key])), dir: false})
 		}
 	}

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -290,6 +290,34 @@ func TestMemFileInfo_Mode(t *testing.T) {
 	}
 }
 
+// TestMemFSDirEntriesIgnoresEmptySegment verifies that a key whose first
+// segment after the directory prefix is empty (produced by a double-slash
+// in the raw key, bypassing NewMemWorkspace cleanup) does not produce an
+// empty-name directory entry. The guard `if name != ""` in dirEntries must
+// be checked before the seen-map probe to prevent probing with key "".
+func TestMemFSDirEntriesIgnoresEmptySegment(t *testing.T) {
+	// Construct memFS directly to bypass NewMemWorkspace path.Clean so the
+	// double-slash key is preserved; "a//b.md" after stripping prefix "a/"
+	// leaves "/b.md", whose first segment is "".
+	m := memFS{
+		"a//b.md": []byte("b"),
+		"a/c.md":  []byte("c"),
+	}
+	ents := m.dirEntries("a")
+	for _, e := range ents {
+		if e.Name() == "" {
+			t.Fatalf("dirEntries emitted an entry with empty name: %#v", e)
+		}
+	}
+	if len(ents) != 1 || ents[0].Name() != "c.md" {
+		names := make([]string, len(ents))
+		for i, e := range ents {
+			names[i] = e.Name()
+		}
+		t.Fatalf("dirEntries(\"a\") with double-slash key = %v, want [c.md]", names)
+	}
+}
+
 // --- indexSlash ---
 
 // TestIndexSlash covers the four boundary cases: no slash, slash at


### PR DESCRIPTION
## Summary

Performance audit against [docs/development/high-performance-go.md](docs/development/high-performance-go.md), which states: "map[K]struct{} for sets — zero-byte value type." Five hot-path locations and two related cleanup sites used `map[string]bool` as presence-only sets, paying one wasted byte per entry and one wasted `bool` comparison per read.

### Fixes (5 hot-path locations + 2 follow-ons)

**1. `internal/rules/catalog/rule.go` — include-graph traversal (hottest path)**
`fileIncludesTarget` / `fileIncludesTargetAbs` and their recursive workers `scanIncludesForTarget` / `scanIncludesForTargetAbs` carried `visited map[string]bool` through every per-file catalog directive evaluation. Changed to `map[string]struct{}`. DFS `delete(visited, resolved)` backtracking preserved.

**2. `internal/lint/runcache.go` — LSP invalidation cycle guard**
`Invalidate` → `invalidate` → `invalidateDependents` passed a `map[string]bool` cycle guard on every LSP file-edit event. Changed to `map[string]struct{}`.

**3. `internal/config/kind_extends.go` + `validate.go` — extends chain walkers**
Three chain-walking functions (`KindExtendsChain`, `extendsChainSchemas`, `validateKindExtends`) used `map[string]bool` for cycle detection. Changed to `map[string]struct{}`. `KindExtendsChain` also fixed to return `nil` instead of `[]string{}` on empty result (project nil-not-empty convention). Two intermediate `chain := []string{}` accumulators changed to `var chain []string` (defers first allocation to first append).

**4. `internal/config/merge.go` + `provenance.go` — per-file kind resolution**
`EffectiveKinds`, `resolveEffectiveKinds`, `resolveKindsWithSources`, and `allRuleNames` de-dup sets changed from `map[string]bool` to `map[string]struct{}`.

**5. `internal/lint/files.go` — CLI file deduplication**
`ResolveFilesWithOpts` seen-set changed to `map[string]struct{}`.

**6. `pkg/mdsmith/workspace.go` — memFS directory enumeration**
`memFS.dirEntries` seen-set changed. Also fixed a short-circuit evaluation bug in the conversion: the `if init; cond` form `if _, ok := seen[name]; name != "" && !ok` ran the map probe before the guard (init always executes in Go's `if init; cond` form). Restored guard-first order with nested `if` blocks.

### TDD

- **Red test:** `TestKindExtendsChain_EmptyNameReturnsNil` (fails against old `[]string{}` return; passes after `var out []string`)
- **Red state:** Updating catalog test call sites to `map[string]struct{}` before updating function signatures produces type-mismatch compile errors; fixing signatures restores green
- **Workspace test:** `TestMemFSDirEntriesIgnoresEmptySegment` added to document and pin the empty-name-segment guard in `dirEntries`

### Code review passes

Three `--max` code review passes were run:
- **Pass 1:** Found confirmed bug (short-circuit inversion in `workspace.go`) → fixed in `9b0fa79`
- **Pass 2:** No new confirmed correctness bugs
- **Pass 3:** Found `chain := []string{}` allocation (confirmed), `allRuleNames` not converted (plausible), missing workspace test (confirmed TDD gap) → fixed in `ef818c0`

## Test plan

- [ ] `go test ./...` — all packages green
- [ ] `go build ./...` — clean build
- [ ] Verify `internal/integration/alloc_budget_test.go` passes (allocation budget gate)
- [ ] Run `go run ./cmd/mdsmith check .` to confirm markdown lints clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjbjBieiWMBKURdKVNnPvy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjbjBieiWMBKURdKVNnPvy)_