### PR TITLE
arch: add trivial-accessor exemption comments in workspace.go

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -221,5 +221,5 @@ footer: |
 | 2606211907 | ✅     |        | [arch-fix: split internal/engine/runner.go](plan/2606211907_arch-fix-runner-srp-split.md)                                               |
 | 2606211908 | 🔲     |        | [arch-fix: split internal/lint/layer0.go](plan/2606211908_arch-fix-layer0-split.md)                                                     |
 | 2606211909 | 🔲     |        | [arch-fix: split internal/lsp/server.go](plan/2606211909_arch-fix-lsp-server-split.md)                                                  |
-| 2606211910 | 🔲     |        | [arch-fix: add trivial-accessor exemption comments in workspace.go](plan/2606211910_arch-fix-workspace-exemptions.md)                   |
+| 2606211910 | ✅     |        | [arch-fix: add trivial-accessor exemption comments in workspace.go](plan/2606211910_arch-fix-workspace-exemptions.md)                   |
 <?/catalog?>

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -319,7 +319,10 @@ func (f *memFile) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-func (f *memFile) Close() error { return nil }
+func (f *memFile) Close() error {
+	// no test by design — trivial accessor
+	return nil
+}
 
 // memDir is an fs.ReadDirFile for in-memory directories.
 type memDir struct {
@@ -333,10 +336,14 @@ func (d *memDir) Stat() (fs.FileInfo, error) {
 }
 
 func (d *memDir) Read([]byte) (int, error) {
+	// no test by design — trivial accessor
 	return 0, &fs.PathError{Op: "read", Path: d.name, Err: fs.ErrInvalid}
 }
 
-func (d *memDir) Close() error { return nil }
+func (d *memDir) Close() error {
+	// no test by design — trivial accessor
+	return nil
+}
 
 func (d *memDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	if n <= 0 {
@@ -363,15 +370,23 @@ type memDirEntry struct {
 	dir  bool
 }
 
-func (e memDirEntry) Name() string { return e.name }
-func (e memDirEntry) IsDir() bool  { return e.dir }
+func (e memDirEntry) Name() string {
+	// no test by design — trivial accessor
+	return e.name
+}
+func (e memDirEntry) IsDir() bool {
+	// no test by design — trivial accessor
+	return e.dir
+}
 func (e memDirEntry) Type() fs.FileMode {
+	// no test by design — trivial accessor
 	if e.dir {
 		return fs.ModeDir
 	}
 	return 0
 }
 func (e memDirEntry) Info() (fs.FileInfo, error) {
+	// no test by design — trivial accessor
 	// memDirEntry and memFileInfo share an identical field layout, so
 	// the conversion copies name/size/dir across one-for-one.
 	return memFileInfo(e), nil
@@ -384,14 +399,30 @@ type memFileInfo struct {
 	dir  bool
 }
 
-func (i memFileInfo) Name() string { return i.name }
-func (i memFileInfo) Size() int64  { return i.size }
+func (i memFileInfo) Name() string {
+	// no test by design — trivial accessor
+	return i.name
+}
+func (i memFileInfo) Size() int64 {
+	// no test by design — trivial accessor
+	return i.size
+}
 func (i memFileInfo) Mode() fs.FileMode {
+	// no test by design — trivial accessor
 	if i.dir {
 		return fs.ModeDir | 0o555
 	}
 	return 0o444
 }
-func (i memFileInfo) ModTime() time.Time { return time.Time{} }
-func (i memFileInfo) IsDir() bool        { return i.dir }
-func (i memFileInfo) Sys() any           { return nil }
+func (i memFileInfo) ModTime() time.Time {
+	// no test by design — trivial accessor
+	return time.Time{}
+}
+func (i memFileInfo) IsDir() bool {
+	// no test by design — trivial accessor
+	return i.dir
+}
+func (i memFileInfo) Sys() any {
+	// no test by design — trivial accessor
+	return nil
+}

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -379,7 +379,6 @@ func (e memDirEntry) IsDir() bool {
 	return e.dir
 }
 func (e memDirEntry) Type() fs.FileMode {
-	// no test by design — trivial accessor
 	if e.dir {
 		return fs.ModeDir
 	}
@@ -408,7 +407,6 @@ func (i memFileInfo) Size() int64 {
 	return i.size
 }
 func (i memFileInfo) Mode() fs.FileMode {
-	// no test by design — trivial accessor
 	if i.dir {
 		return fs.ModeDir | 0o555
 	}

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -266,6 +266,30 @@ func TestMemFSGlobDoublestar(t *testing.T) {
 	}
 }
 
+// TestMemDirEntry_Type covers both branches of the fs.DirEntry.Type() path.
+func TestMemDirEntry_Type(t *testing.T) {
+	dir := memDirEntry{name: "docs", dir: true}
+	if got := dir.Type(); got != fs.ModeDir {
+		t.Errorf("Type() dir = %v, want %v", got, fs.ModeDir)
+	}
+	file := memDirEntry{name: "a.md", dir: false}
+	if got := file.Type(); got != 0 {
+		t.Errorf("Type() file = %v, want 0", got)
+	}
+}
+
+// TestMemFileInfo_Mode covers both branches of the fs.FileInfo.Mode() path.
+func TestMemFileInfo_Mode(t *testing.T) {
+	dir := memFileInfo{name: "docs", dir: true}
+	if got := dir.Mode(); got != fs.ModeDir|0o555 {
+		t.Errorf("Mode() dir = %v, want %v", got, fs.ModeDir|0o555)
+	}
+	file := memFileInfo{name: "a.md", size: 10, dir: false}
+	if got := file.Mode(); got != 0o444 {
+		t.Errorf("Mode() file = %v, want 0o444", got)
+	}
+}
+
 // --- indexSlash ---
 
 // TestIndexSlash covers the four boundary cases: no slash, slash at

--- a/plan/2606211910_arch-fix-workspace-exemptions.md
+++ b/plan/2606211910_arch-fix-workspace-exemptions.md
@@ -3,7 +3,7 @@ id: 2606211910
 title: >-
   arch-fix: add trivial-accessor exemption
   comments in workspace.go
-status: '🔲'
+status: '✅'
 summary: >-
   Add one-line "no test by design" comments
   to the trivial one-liner methods in
@@ -55,9 +55,9 @@ Future audits pass without flagging them.
 
 ## Acceptance Criteria
 
-- [ ] Every trivial one-liner method in
+- [x] Every trivial one-liner method in
   `pkg/mdsmith/workspace.go` carries an
   exemption comment.
-- [ ] `go build ./...` passes.
-- [ ] `mdsmith check pkg/mdsmith/workspace.go`
+- [x] `go build ./...` passes.
+- [x] `mdsmith check pkg/mdsmith/workspace.go`
   reports no new violations.


### PR DESCRIPTION
## Summary

- Adds `// no test by design — trivial accessor` to every truly trivial one-liner method in `pkg/mdsmith/workspace.go` so the architecture audit can distinguish intentional exemptions from forgotten tests (plan 2606211910)
- `memDirEntry.Type()` and `memFileInfo.Mode()` were initially mis-labelled (both have `if/else` branches and do not qualify for the no-branch exemption per `docs/development/architecture/tests.md §Exemptions`) — their incorrect exemption comments were removed and dedicated unit tests added instead
- Marks plan `2606211910` complete

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/mdsmith/...` passes (includes new `TestMemDirEntry_Type` and `TestMemFileInfo_Mode`)
- [x] 3 × `/code-review xhigh --fix` rounds applied; rounds 2 and 3 returned `[]`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018UGkejhkQXgkXqgii9tVKw)_