### PR TITLE
test(inline_scan): add dedicated unit tests for 12 unexported helpers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -222,5 +222,6 @@ footer: |
 | 2606211908 | ✅     |        | [arch-fix: split internal/lint/layer0.go](plan/2606211908_arch-fix-layer0-split.md)                                                     |
 | 2606211909 | ✅     |        | [arch-fix: split internal/lsp/server.go](plan/2606211909_arch-fix-lsp-server-split.md)                                                  |
 | 2606211910 | ✅     |        | [arch-fix: add trivial-accessor exemption comments in workspace.go](plan/2606211910_arch-fix-workspace-exemptions.md)                   |
+| 2606231013 | ✅     | sonnet | [Add dedicated unit tests for inline_scan.go helpers](plan/2606231013_arch-fix-inline-scan-helper-tests.md)                             |
 | 2606231014 | ✅     | sonnet | [Add dedicated unit tests for samefileanchor helper functions](plan/2606231014_arch-fix-samefileanchor-helper-tests.md)                 |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: e701b94b5640dfb4f5d07d1fc38d49e0dba23e75
+audit-from: 1599c9f17336b36d4d06d10677b2510bfe33665b
 ---
 # Architecture audit log
 
@@ -193,3 +193,30 @@ in the new `internal/rules/listscan` helper
 [2606211908]: ../../plan/2606211908_arch-fix-layer0-split.md
 [2606211909]: ../../plan/2606211909_arch-fix-lsp-server-split.md
 [2606211910]: ../../plan/2606211910_arch-fix-workspace-exemptions.md
+
+## Audit 2026-06-23 (range: e701b94..1599c9f)
+
+Performance + struct-alignment series;
+inline scanner refinements; benchmark
+additions. No TypeScript changes. 273 Go
+sources outside fixtures.
+
+No blockers. No rule-to-rule imports added.
+No DIP violations. New files are under 800
+lines. Struct alignment and `map[string]struct{}`
+changes are mechanical rewrites with no
+layering impact.
+
+### tax (2026-06-23)
+
+- `internal/lint/inline_scan.go` — 13
+  unexported helpers lack dedicated unit
+  tests. Tests doc §"every function by
+  name" — [plan/2606231013][2606231013].
+
+- `internal/rules/samefileanchor/rule.go`
+  — 12 unexported helpers lack dedicated
+  unit tests — [plan/2606231014][2606231014].
+
+[2606231013]: ../../plan/2606231013_arch-fix-inline-scan-helper-tests.md
+[2606231014]: ../../plan/2606231014_arch-fix-samefileanchor-helper-tests.md

--- a/internal/lint/inline_scan.go
+++ b/internal/lint/inline_scan.go
@@ -325,7 +325,6 @@ func codeSpanTrim(run []byte, start, stop int) (int, int) {
 	return start, stop
 }
 
-// no test by design: trivial one-liner with no branch.
 func isSpaceOrNewlineByte(c byte) bool {
 	return c == ' ' || c == '\n'
 }

--- a/internal/lint/inline_scan.go
+++ b/internal/lint/inline_scan.go
@@ -325,6 +325,7 @@ func codeSpanTrim(run []byte, start, stop int) (int, int) {
 	return start, stop
 }
 
+// no test by design: trivial one-liner with no branch.
 func isSpaceOrNewlineByte(c byte) bool {
 	return c == ' ' || c == '\n'
 }

--- a/internal/lint/inline_scan_test.go
+++ b/internal/lint/inline_scan_test.go
@@ -449,3 +449,258 @@ func TestInlineBlocks_ScannerHandlesSimpleFile(t *testing.T) {
 		assert.Nil(t, first.NextSibling(), "scanner run has a single paragraph")
 	}
 }
+
+// --- Dedicated helper tests (plan 2606231013) ---
+
+func TestScanRunEligible(t *testing.T) {
+	assert.False(t, scanRunEligible(nil), "nil is not eligible")
+	assert.False(t, scanRunEligible([]byte("")), "empty is not eligible")
+	assert.False(t, scanRunEligible([]byte("line one\nline two")), "multiline not eligible")
+	assert.False(t, scanRunEligible([]byte("# heading")), "ATX heading not eligible")
+	assert.False(t, scanRunEligible([]byte("- list")), "list item not eligible")
+	assert.False(t, scanRunEligible([]byte("> quote")), "block quote not eligible")
+	assert.False(t, scanRunEligible([]byte("*em*")), "emphasis asterisk not eligible")
+	assert.False(t, scanRunEligible([]byte("_em_")), "emphasis underscore not eligible")
+	assert.False(t, scanRunEligible([]byte(`a\b`)), "backslash not eligible")
+	assert.False(t, scanRunEligible([]byte("a&amp;b")), "entity not eligible")
+	assert.True(t, scanRunEligible([]byte("plain text")), "plain text eligible")
+	assert.True(t, scanRunEligible([]byte("[link](url)")), "link chars eligible")
+	assert.True(t, scanRunEligible([]byte("`code`")), "backtick eligible")
+	assert.True(t, scanRunEligible([]byte("<autolink>")), "angle bracket eligible")
+}
+
+func TestMergeAppendText(t *testing.T) {
+	a := arena.New()
+	run := []byte("hello world")
+	para := a.Paragraph()
+
+	// end <= start: no child appended.
+	mergeAppendText(run, 3, 3, para, a)
+	assert.Nil(t, para.FirstChild(), "end==start emits nothing")
+
+	// Normal range: appends a Text node.
+	mergeAppendText(run, 0, 5, para, a)
+	child := para.FirstChild()
+	require.NotNil(t, child, "Text node appended")
+	txt, ok := child.(*ast.Text)
+	require.True(t, ok, "child is *ast.Text")
+	assert.Equal(t, "hello", string(txt.Segment.Value(run)))
+
+	// Adjacent range [5:11): merges into the existing Text node.
+	mergeAppendText(run, 5, 11, para, a)
+	assert.Nil(t, child.NextSibling(), "adjacent text merged, no new sibling")
+	assert.Equal(t, "hello world", string(txt.Segment.Value(run)), "merged bounds")
+}
+
+func TestFinalAppendText(t *testing.T) {
+	a := arena.New()
+	run := []byte("hello   ")
+	para := a.Paragraph()
+
+	// Trailing spaces trimmed: appends "hello".
+	finalAppendText(run, 0, len(run), para, a)
+	child := para.FirstChild()
+	require.NotNil(t, child)
+	txt, ok := child.(*ast.Text)
+	require.True(t, ok)
+	assert.Equal(t, "hello", string(txt.Segment.Value(run)))
+
+	// All whitespace: nothing appended.
+	para2 := a.Paragraph()
+	finalAppendText([]byte("   "), 0, 3, para2, a)
+	assert.Nil(t, para2.FirstChild(), "all-space run appends nothing")
+
+	// end <= start: nothing appended.
+	para3 := a.Paragraph()
+	finalAppendText(run, 5, 5, para3, a)
+	assert.Nil(t, para3.FirstChild(), "empty range appends nothing")
+}
+
+func TestScanParagraphInlines(t *testing.T) {
+	a := arena.New()
+
+	// Plain text: returns true, one Text child.
+	para := a.Paragraph()
+	ok := scanParagraphInlines([]byte("hello"), para, a)
+	require.True(t, ok)
+	require.NotNil(t, para.FirstChild(), "Text child added")
+
+	// Unclosed backtick: scanCodeSpan declines, returns false.
+	para2 := a.Paragraph()
+	ok2 := scanParagraphInlines([]byte("`unclosed"), para2, a)
+	assert.False(t, ok2)
+}
+
+func TestApplyCodeSpan(t *testing.T) {
+	a := arena.New()
+	// Run starts at the backtick so no prior text is flushed first.
+	run := []byte("`code` after")
+	para := a.Paragraph()
+
+	// i=0 points at the opening backtick; textStart=0 so nothing is flushed.
+	ni, ns, ok := applyCodeSpan(run, 0, 0, para, a)
+	require.True(t, ok)
+	assert.Equal(t, 6, ni, "ni just past closing backtick")
+	assert.Equal(t, 6, ns, "textStart reset to ni")
+	child := para.FirstChild()
+	require.NotNil(t, child)
+	_, isCode := child.(*ast.CodeSpan)
+	assert.True(t, isCode, "CodeSpan appended")
+
+	// Unclosed backtick: returns false.
+	para2 := a.Paragraph()
+	_, _, ok2 := applyCodeSpan([]byte("`unclosed"), 0, 0, para2, a)
+	assert.False(t, ok2)
+}
+
+func TestApplyAutolink(t *testing.T) {
+	a := arena.New()
+	run := []byte("<https://example.com>")
+	para := a.Paragraph()
+
+	ni, ns, ok := applyAutolink(run, 0, 0, para, a)
+	require.True(t, ok)
+	assert.Equal(t, len(run), ni)
+	assert.Equal(t, len(run), ns)
+	child := para.FirstChild()
+	require.NotNil(t, child)
+	_, isAL := child.(*ast.AutoLink)
+	assert.True(t, isAL, "AutoLink appended")
+
+	// Raw HTML angle: returns false.
+	para2 := a.Paragraph()
+	_, _, ok2 := applyAutolink([]byte("<div>"), 0, 0, para2, a)
+	assert.False(t, ok2)
+}
+
+func TestApplyBang(t *testing.T) {
+	a := arena.New()
+
+	// `!` without `[`: flushes pending text, returns i+1 with textStart at i.
+	run := []byte("a! text")
+	para := a.Paragraph()
+	ni, ns, ok := applyBang(run, 1, 0, para, a)
+	require.True(t, ok)
+	assert.Equal(t, 2, ni, "i advanced past `!`")
+	assert.Equal(t, 1, ns, "textStart set to position of `!`")
+
+	// `![alt](url)`: appends Image node.
+	run2 := []byte("![alt](url)")
+	para2 := a.Paragraph()
+	ni2, _, ok2 := applyBang(run2, 0, 0, para2, a)
+	require.True(t, ok2)
+	assert.Equal(t, len(run2), ni2)
+	child := para2.FirstChild()
+	require.NotNil(t, child)
+	_, isImg := child.(*ast.Image)
+	assert.True(t, isImg, "Image appended")
+
+	// `![` with unclosed label: returns false.
+	para3 := a.Paragraph()
+	_, _, ok3 := applyBang([]byte("![alt"), 0, 0, para3, a)
+	assert.False(t, ok3)
+}
+
+func TestApplyLink(t *testing.T) {
+	a := arena.New()
+	run := []byte("[text](url)")
+	para := a.Paragraph()
+
+	ni, ns, ok := applyLink(run, 0, 0, para, a)
+	require.True(t, ok)
+	assert.Equal(t, len(run), ni)
+	assert.Equal(t, len(run), ns)
+	child := para.FirstChild()
+	require.NotNil(t, child)
+	_, isLink := child.(*ast.Link)
+	assert.True(t, isLink, "Link appended")
+
+	// Reference link `[text][ref]`: returns false.
+	para2 := a.Paragraph()
+	_, _, ok2 := applyLink([]byte("[text][ref]"), 0, 0, para2, a)
+	assert.False(t, ok2)
+}
+
+func TestScanCodeSpan(t *testing.T) {
+	a := arena.New()
+
+	// Single-backtick span.
+	node, after, ok := scanCodeSpan([]byte("`code`"), 0, a)
+	require.True(t, ok)
+	assert.Equal(t, 6, after)
+	require.NotNil(t, node)
+	_, isCode := node.(*ast.CodeSpan)
+	assert.True(t, isCode)
+
+	// Double-backtick span containing a single backtick.
+	node2, after2, ok2 := scanCodeSpan([]byte("`` a`b ``"), 0, a)
+	require.True(t, ok2)
+	assert.Equal(t, 9, after2)
+	require.NotNil(t, node2)
+
+	// No closing backtick: returns false.
+	_, _, ok3 := scanCodeSpan([]byte("`unclosed"), 0, a)
+	assert.False(t, ok3)
+}
+
+func TestScanLinkOrImage(t *testing.T) {
+	a := arena.New()
+
+	// Inline link.
+	node, after, ok := scanLinkOrImage([]byte("[text](url)"), 0, false, a)
+	require.True(t, ok)
+	assert.Equal(t, 11, after)
+	_, isLink := node.(*ast.Link)
+	assert.True(t, isLink, "Link node")
+
+	// Inline image.
+	node2, _, ok2 := scanLinkOrImage([]byte("![alt](url)"), 0, true, a)
+	require.True(t, ok2)
+	_, isImg := node2.(*ast.Image)
+	assert.True(t, isImg, "Image node")
+
+	// Reference link `[text][ref]`: returns false.
+	_, _, ok3 := scanLinkOrImage([]byte("[text][ref]"), 0, false, a)
+	assert.False(t, ok3)
+
+	// Nested brackets in label: returns false.
+	_, _, ok4 := scanLinkOrImage([]byte("[[a]](url)"), 0, false, a)
+	assert.False(t, ok4)
+}
+
+func TestScanLinkParens(t *testing.T) {
+	// Empty parens.
+	dest, title, after, ok := scanLinkParens([]byte("()"), 0)
+	require.True(t, ok)
+	assert.Nil(t, dest)
+	assert.Nil(t, title)
+	assert.Equal(t, 2, after)
+
+	// Destination only.
+	dest2, title2, after2, ok2 := scanLinkParens([]byte("(url)"), 0)
+	require.True(t, ok2)
+	assert.Equal(t, "url", string(dest2))
+	assert.Nil(t, title2)
+	assert.Equal(t, 5, after2)
+
+	// Destination and title.
+	dest3, title3, after3, ok3 := scanLinkParens([]byte(`(url "ttl")`), 0)
+	require.True(t, ok3)
+	assert.Equal(t, "url", string(dest3))
+	assert.Equal(t, "ttl", string(title3))
+	assert.Equal(t, 11, after3)
+
+	// Missing closing paren.
+	_, _, _, ok4 := scanLinkParens([]byte("(url"), 0)
+	assert.False(t, ok4)
+}
+
+func TestSkipSpacesAt(t *testing.T) {
+	run := []byte("   hello")
+	assert.Equal(t, 3, skipSpacesAt(run, 0), "leading spaces skipped")
+	assert.Equal(t, 3, skipSpacesAt(run, 3), "no spaces from non-space pos")
+	assert.Equal(t, len(run), skipSpacesAt(run, len(run)), "past end stays at end")
+
+	allSpace := []byte("   ")
+	assert.Equal(t, 3, skipSpacesAt(allSpace, 0), "all spaces → past end")
+}

--- a/internal/lint/inline_scan_test.go
+++ b/internal/lint/inline_scan_test.go
@@ -583,6 +583,7 @@ func TestApplyBang(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 2, ni, "i advanced past `!`")
 	assert.Equal(t, 1, ns, "textStart set to position of `!`")
+	require.NotNil(t, para.FirstChild(), "pending text flushed as child")
 
 	// `![alt](url)`: appends Image node.
 	run2 := []byte("![alt](url)")
@@ -637,6 +638,8 @@ func TestScanCodeSpan(t *testing.T) {
 	require.True(t, ok2)
 	assert.Equal(t, 9, after2)
 	require.NotNil(t, node2)
+	_, isCode2 := node2.(*ast.CodeSpan)
+	assert.True(t, isCode2, "double-backtick produces CodeSpan")
 
 	// No closing backtick: returns false.
 	_, _, ok3 := scanCodeSpan([]byte("`unclosed"), 0, a)
@@ -654,8 +657,9 @@ func TestScanLinkOrImage(t *testing.T) {
 	assert.True(t, isLink, "Link node")
 
 	// Inline image.
-	node2, _, ok2 := scanLinkOrImage([]byte("![alt](url)"), 0, true, a)
+	node2, after2, ok2 := scanLinkOrImage([]byte("![alt](url)"), 0, true, a)
 	require.True(t, ok2)
+	assert.Equal(t, 11, after2, "image after matches run length")
 	_, isImg := node2.(*ast.Image)
 	assert.True(t, isImg, "Image node")
 

--- a/internal/lint/inline_scan_test.go
+++ b/internal/lint/inline_scan_test.go
@@ -704,3 +704,9 @@ func TestSkipSpacesAt(t *testing.T) {
 	allSpace := []byte("   ")
 	assert.Equal(t, 3, skipSpacesAt(allSpace, 0), "all spaces → past end")
 }
+
+func TestIsSpaceOrNewlineByte(t *testing.T) {
+	assert.True(t, isSpaceOrNewlineByte(' '))
+	assert.True(t, isSpaceOrNewlineByte('\n'))
+	assert.False(t, isSpaceOrNewlineByte('\t'), "tab is not a space-or-newline byte")
+}

--- a/plan/2606231013_arch-fix-inline-scan-helper-tests.md
+++ b/plan/2606231013_arch-fix-inline-scan-helper-tests.md
@@ -77,10 +77,11 @@ test as of commit 1599c9f:
       `TestApplyCodeSpan`, `TestApplyAutolink`,
       `TestApplyBang`, `TestApplyLink`,
       `TestScanCodeSpan`, `TestScanLinkOrImage`,
-      `TestScanLinkParens`, `TestSkipSpacesAt`
-      (12 new test functions).
-- [x] `isSpaceOrNewlineByte` carries a
-      `// no test by design: trivial one-liner`
-      comment in `inline_scan.go`.
+      `TestScanLinkParens`, `TestSkipSpacesAt`,
+      `TestIsSpaceOrNewlineByte` (13 new test functions).
+- [x] `isSpaceOrNewlineByte` has a dedicated test
+      (`TestIsSpaceOrNewlineByte`); the predicate has
+      two branches so the trivial-accessor exemption
+      does not apply.
 - [x] `go test ./internal/lint/...` is green.
 - [x] No new golangci-lint warnings.

--- a/plan/2606231013_arch-fix-inline-scan-helper-tests.md
+++ b/plan/2606231013_arch-fix-inline-scan-helper-tests.md
@@ -1,0 +1,86 @@
+---
+id: 2606231013
+title: Add dedicated unit tests for inline_scan.go helpers
+status: "✅"
+model: sonnet
+summary: >-
+  internal/lint/inline_scan.go has 13 unexported
+  helper functions exercised only via the
+  higher-level TestScanInlineRun_* suite. Add a
+  named unit test for each so the audit policy
+  (every function has a TestFoo / TestReceiver_Foo
+  by name) is satisfied.
+---
+# Add dedicated unit tests for inline_scan.go helpers
+
+## Goal
+
+`internal/lint/inline_scan.go` (plan 2606141904 /
+PR #632) has 13 unexported helper functions. They
+are tested only through the 55 higher-level
+`TestScanInlineRun_*` behavioral tests. The audit
+policy requires a named test for every function.
+This plan adds those tests.
+
+## Background
+
+The audit policy (tests.md) requires a named
+test for every production function. Use `TestFoo`
+for a package function `Foo`. Use
+`TestReceiver_Foo` for a method on `Receiver`.
+
+Functions in `inline_scan.go` with no dedicated
+test as of commit 1599c9f:
+
+- `scanRunEligible`
+- `mergeAppendText`
+- `finalAppendText`
+- `scanParagraphInlines`
+- `applyCodeSpan`
+- `applyAutolink`
+- `applyBang`
+- `applyLink`
+- `scanCodeSpan` (covered by `TestScanInlineRun_*`
+  but not by `TestScanCodeSpan`)
+- `scanLinkOrImage`
+- `scanLinkParens`
+- `skipSpacesAt`
+- `isSpaceOrNewlineByte`
+
+## Tasks
+
+1. For each function above, add at least one
+   test function named `TestFunctionName` (or
+   `TestFunctionName_Variant` for multiple cases)
+   to `internal/lint/inline_scan_test.go`.
+2. Each test must be a standalone unit test:
+   drive the helper directly, not via
+   `scanInlineRun`.
+3. Keep each test function short (≤ 15 lines).
+   Use table-driven style only when three or
+   more cases differ in one dimension.
+4. `isSpaceOrNewlineByte` is a one-liner with
+   no branch; add the one-line "no test by design"
+   exemption comment in `inline_scan.go` instead
+   of a test.
+5. Run `go test ./internal/lint/... -run TestScan`
+   to confirm all pass.
+6. Run `go vet ./internal/lint/...` and
+   `go tool -modfile=tools/go.mod golangci-lint run
+   ./internal/lint/...` — both must pass.
+
+## Acceptance Criteria
+
+- [x] `internal/lint/inline_scan_test.go` contains
+      `TestScanRunEligible`, `TestMergeAppendText`,
+      `TestFinalAppendText`, `TestScanParagraphInlines`,
+      `TestApplyCodeSpan`, `TestApplyAutolink`,
+      `TestApplyBang`, `TestApplyLink`,
+      `TestScanCodeSpan`, `TestScanLinkOrImage`,
+      `TestScanLinkParens`, `TestSkipSpacesAt`
+      (12 new test functions).
+- [x] `isSpaceOrNewlineByte` carries a
+      `// no test by design: trivial one-liner`
+      comment in `inline_scan.go`.
+- [x] `go test ./internal/lint/...` is green.
+- [x] No new golangci-lint warnings.

--- a/plan/2606231013_arch-fix-inline-scan-helper-tests.md
+++ b/plan/2606231013_arch-fix-inline-scan-helper-tests.md
@@ -59,10 +59,10 @@ test as of commit 1599c9f:
 3. Keep each test function short (≤ 15 lines).
    Use table-driven style only when three or
    more cases differ in one dimension.
-4. `isSpaceOrNewlineByte` is a one-liner with
-   no branch; add the one-line "no test by design"
-   exemption comment in `inline_scan.go` instead
-   of a test.
+4. `isSpaceOrNewlineByte` has two boolean branches
+   (`c == ' '` and `c == '\n'`), so the trivial-
+   accessor exemption does not apply. Add
+   `TestIsSpaceOrNewlineByte` instead.
 5. Run `go test ./internal/lint/... -run TestScan`
    to confirm all pass.
 6. Run `go vet ./internal/lint/...` and


### PR DESCRIPTION
## Summary

- Adds 12 named unit tests for the unexported helper functions in `internal/lint/inline_scan.go`, satisfying the audit policy (every function has a `TestFoo` by name)
- Adds a `// no test by design: trivial one-liner with no branch.` exemption comment for `isSpaceOrNewlineByte`
- Records the 2026-06-23 architecture audit in `docs/development/architecture-audit.md`, filing two new tax plans (2606231013 ✅ and 2606231014 🔲)

Closes plan `2606231013_arch-fix-inline-scan-helper-tests`.

## Test plan

- [x] `go test ./internal/lint/... -run "TestScanRunEligible|TestMergeAppendText|TestFinalAppendText|TestScanParagraphInlines|TestApplyCodeSpan|TestApplyAutolink|TestApplyBang|TestApplyLink|TestScanCodeSpan|TestScanLinkOrImage|TestScanLinkParens|TestSkipSpacesAt"` — all 12 pass
- [x] `go test ./internal/lint/...` — full package green
- [x] `go vet ./internal/lint/...` — clean
- [x] `go run ./cmd/mdsmith check .` — no markdown lint failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYs45JNFoMgto6dk5mSSXb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYs45JNFoMgto6dk5mSSXb)_