### PR TITLE
refactor(rename): export NormalizedLabel/RefDefBracketBytes, remove lsp duplicates

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -227,5 +227,5 @@ footer: |
 | 2606240211 | ✅     | sonnet | [Add dedicated unit tests for locate.go helpers](plan/2606240211_arch-fix-locate-helper-tests.md)                                       |
 | 2606240212 | 🔲     | sonnet | [Add dedicated unit tests for lsp/rename.go helpers](plan/2606240212_arch-fix-lsp-rename-helper-tests.md)                               |
 | 2606240213 | 🔲     | sonnet | [Add dedicated unit tests for export.go helpers and two small rename helpers](plan/2606240213_arch-fix-export-helper-tests.md)          |
-| 2606240214 | 🔲     | sonnet | [Remove duplicated helpers between lsp/rename.go and rename/rename.go](plan/2606240214_arch-fix-rename-dedup.md)                        |
+| 2606240214 | ✅     | sonnet | [Remove duplicated helpers between lsp/rename.go and rename/rename.go](plan/2606240214_arch-fix-rename-dedup.md)                        |
 <?/catalog?>

--- a/cmd/mdsmith/rename.go
+++ b/cmd/mdsmith/rename.go
@@ -244,7 +244,7 @@ func computeRenameChanges(
 		}
 		return changes, -1
 	}
-	edits, err := rename.LinkRef(src, rename.NormalizeLabel(oldName), newName)
+	edits, err := rename.LinkRef(src, rename.NormalizedLabel([]byte(oldName)), newName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2

--- a/cmd/mdsmith/rename.go
+++ b/cmd/mdsmith/rename.go
@@ -244,7 +244,7 @@ func computeRenameChanges(
 		}
 		return changes, -1
 	}
-	edits, err := rename.LinkRef(src, rename.NormalizedLabel([]byte(oldName)), newName)
+	edits, err := rename.LinkRef(src, oldName, newName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mdsmith: %v\n", err)
 		return nil, 2

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/rename"
-	"github.com/jeduden/mdsmith/pkg/goldmark/util"
 )
 
 // handlePrepareRename answers textDocument/prepareRename. The
@@ -225,7 +224,7 @@ func refDefPrepareRange(source []byte, line int, _ string) (prepareRenameResult,
 		return prepareRenameResult{}, false
 	}
 	row := lines[line-1]
-	m := refDefBracketBytes(row)
+	m := rename.RefDefBracketBytes(row)
 	if m == nil {
 		return prepareRenameResult{}, false
 	}
@@ -240,34 +239,6 @@ func refDefPrepareRange(source []byte, line int, _ string) (prepareRenameResult,
 	}, true
 }
 
-// refDefBracketBytes returns the [start, end) byte offsets of the
-// label inside a CommonMark reference-definition line, or nil when
-// row is not a reference definition.
-func refDefBracketBytes(row []byte) []int {
-	i := 0
-	for i < len(row) && i < 3 && row[i] == ' ' {
-		i++
-	}
-	if i >= len(row) || row[i] != '[' {
-		return nil
-	}
-	open := i + 1
-	closeIdx := -1
-	for j := open; j < len(row); j++ {
-		if row[j] == ']' {
-			closeIdx = j
-			break
-		}
-	}
-	if closeIdx < 0 || closeIdx == open {
-		return nil
-	}
-	// After `]` we need `:` to qualify as a definition.
-	if closeIdx+1 >= len(row) || row[closeIdx+1] != ':' {
-		return nil
-	}
-	return []int{open, closeIdx}
-}
 
 // refUsePrepareRange builds the rename range for a reference-style
 // link use (`[text][label]`, `[label][]`, or `[label]`). The cursor
@@ -319,7 +290,7 @@ func refUseLabelBytes(row []byte, cursorByte int, label string) (int, int, bool)
 			return start, end, true
 		}
 		// Shortcut `[label]`: this pair's content normalizes to label.
-		if normalizedLabel(row[pr.open+1:pr.close]) == label {
+		if rename.NormalizedLabel(row[pr.open+1:pr.close]) == label {
 			return pr.open + 1, pr.close, true
 		}
 	}
@@ -340,10 +311,10 @@ func matchLeadingPair(row []byte, pairs []bracketPair, i int, label string) (int
 	if next.open != pr.close+1 {
 		return 0, 0, false
 	}
-	if normalizedLabel(row[next.open+1:next.close]) == label {
+	if rename.NormalizedLabel(row[next.open+1:next.close]) == label {
 		return next.open + 1, next.close, true
 	}
-	if next.close == next.open+1 && normalizedLabel(row[pr.open+1:pr.close]) == label {
+	if next.close == next.open+1 && rename.NormalizedLabel(row[pr.open+1:pr.close]) == label {
 		return pr.open + 1, pr.close, true
 	}
 	return 0, 0, false
@@ -363,18 +334,15 @@ func matchTrailingPair(row []byte, pairs []bracketPair, i int, label string) (in
 	if prev.close+1 != pr.open {
 		return 0, 0, false
 	}
-	if pr.close == pr.open+1 && normalizedLabel(row[prev.open+1:prev.close]) == label {
+	if pr.close == pr.open+1 && rename.NormalizedLabel(row[prev.open+1:prev.close]) == label {
 		return prev.open + 1, prev.close, true
 	}
-	if normalizedLabel(row[pr.open+1:pr.close]) == label {
+	if rename.NormalizedLabel(row[pr.open+1:pr.close]) == label {
 		return pr.open + 1, pr.close, true
 	}
 	return 0, 0, false
 }
 
-func normalizedLabel(b []byte) string {
-	return string(util.ToLinkReference(b))
-}
 
 // bracketPairs returns every top-level `[` / `]` pair on row, in
 // left-to-right order. The walker is depth-aware: a `[` opens a new

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -239,7 +239,6 @@ func refDefPrepareRange(source []byte, line int, _ string) (prepareRenameResult,
 	}, true
 }
 
-
 // refUsePrepareRange builds the rename range for a reference-style
 // link use (`[text][label]`, `[label][]`, or `[label]`). The cursor
 // position determines whether the user is editing the label or the
@@ -342,7 +341,6 @@ func matchTrailingPair(row []byte, pairs []bracketPair, i int, label string) (in
 	}
 	return 0, 0, false
 }
-
 
 // bracketPairs returns every top-level `[` / `]` pair on row, in
 // left-to-right order. The walker is depth-aware: a `[` opens a new

--- a/internal/lsp/rename_coverage_test.go
+++ b/internal/lsp/rename_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jeduden/mdsmith/internal/rename"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -199,7 +200,7 @@ func TestRefDefBracketBytesEdgeCases(t *testing.T) {
 		{"    [over]: x", nil}, // 4 leading spaces is over the limit
 	}
 	for _, tc := range cases {
-		got := refDefBracketBytes([]byte(tc.row))
+		got := rename.RefDefBracketBytes([]byte(tc.row))
 		assert.Equal(t, tc.want, got, "row=%q", tc.row)
 	}
 }

--- a/internal/rename/heading.go
+++ b/internal/rename/heading.go
@@ -141,7 +141,7 @@ func FindHeadingLine(source []byte, headingText string) (int, bool) {
 // normalizes `--link-ref oldlabel` through this before calling
 // LinkRef.
 func NormalizeLabel(s string) string {
-	return normalizedLabel([]byte(s))
+	return NormalizedLabel([]byte(s))
 }
 
 // firstControlRune returns the first newline / carriage return in s,

--- a/internal/rename/heading.go
+++ b/internal/rename/heading.go
@@ -135,15 +135,6 @@ func FindHeadingLine(source []byte, headingText string) (int, bool) {
 	return 0, false
 }
 
-// NormalizeLabel collapses a link-reference label to its canonical
-// matching form (lowercased, whitespace-collapsed), the same
-// normalization LinkRef expects its oldLabel argument in. The CLI
-// normalizes `--link-ref oldlabel` through this before calling
-// LinkRef.
-func NormalizeLabel(s string) string {
-	return NormalizedLabel([]byte(s))
-}
-
 // firstControlRune returns the first newline / carriage return in s,
 // or 0 when s is a single line. Heading text and link-ref labels are
 // single-line surfaces; a control rune would rewrite them into

--- a/internal/rename/heading_test.go
+++ b/internal/rename/heading_test.go
@@ -218,11 +218,6 @@ func TestFindHeadingLine(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestNormalizeLabel(t *testing.T) {
-	assert.Equal(t, "docs api", NormalizeLabel("Docs  API"))
-	assert.Equal(t, "x", NormalizeLabel("X"))
-}
-
 func TestFirstControlRune(t *testing.T) {
 	assert.Equal(t, '\r', firstControlRune("a\rb"))
 	assert.Equal(t, rune(0), firstControlRune("clean"))

--- a/internal/rename/helpers_test.go
+++ b/internal/rename/helpers_test.go
@@ -32,7 +32,7 @@ func TestRefDefBracketBytes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, refDefBracketBytes([]byte(tc.row)))
+			assert.Equal(t, tc.want, RefDefBracketBytes([]byte(tc.row)))
 		})
 	}
 }

--- a/internal/rename/rename.go
+++ b/internal/rename/rename.go
@@ -62,14 +62,17 @@ func (e LabelConflictError) Error() string {
 }
 
 // LinkRef computes the in-file edits that rename a link-reference
-// label from oldLabel (already normalized via util.ToLinkReference)
-// to newName. The rewrite is file-local: the `[label]: url`
-// definition plus every `[text][label]` and shortcut `[label]` use.
+// label from oldLabel to newName. The rewrite is file-local: the
+// `[label]: url` definition plus every `[text][label]` and shortcut
+// `[label]` use. oldLabel is normalized internally (CommonMark
+// link-label normalization: lowercase, whitespace collapsed) so
+// callers may pass raw label text or a pre-normalized form.
 //
 // Returns ErrEmptyLabel, an InvalidLabelRuneError, or a
 // LabelConflictError without producing any edit when the rename is
 // unsafe, so callers can surface the failure before applying.
 func LinkRef(source []byte, oldLabel, newName string) ([]Edit, error) {
+	oldLabel = NormalizedLabel([]byte(oldLabel))
 	if strings.TrimSpace(newName) == "" {
 		return nil, ErrEmptyLabel
 	}
@@ -250,9 +253,6 @@ func refDefEditsInBody(
 		}
 		row := lines[fileLine-1]
 		bracket := RefDefBracketBytes(row)
-		if bracket == nil {
-			continue
-		}
 		startCh := mdtext.UTF16FromByteOffset(row, bracket[0])
 		endCh := mdtext.UTF16FromByteOffset(row, bracket[1])
 		out = append(out, Edit{

--- a/internal/rename/rename.go
+++ b/internal/rename/rename.go
@@ -80,7 +80,7 @@ func LinkRef(source []byte, oldLabel, newName string) ([]Edit, error) {
 	// → "Docs API") is allowed — it refreshes casing/spacing across
 	// the def and every use. labelConflict matches on the normalized
 	// form so such a rename never collides with itself.
-	newLabel := normalizedLabel([]byte(newName))
+	newLabel := NormalizedLabel([]byte(newName))
 	if conflict := labelConflict(source, oldLabel, newLabel); conflict != "" {
 		return nil, LabelConflictError{Conflict: conflict}
 	}
@@ -124,7 +124,10 @@ func invalidLinkRefRune(s string) rune {
 	return 0
 }
 
-func normalizedLabel(b []byte) string {
+// NormalizedLabel returns the CommonMark-normalized form of a link
+// label — lowercase with internal whitespace collapsed — by delegating
+// to goldmark's util.ToLinkReference.
+func NormalizedLabel(b []byte) string {
 	return string(util.ToLinkReference(b))
 }
 
@@ -173,7 +176,7 @@ func validRefDefMatches(body []byte) []validRefDefMatch {
 			continue
 		}
 		raw := body[m[2]:m[3]]
-		norm := normalizedLabel(raw)
+		norm := NormalizedLabel(raw)
 		out = append(out, validRefDefMatch{
 			bodyLine:  bodyLine,
 			rawLabel:  string(raw),
@@ -246,7 +249,7 @@ func refDefEditsInBody(
 			continue
 		}
 		row := lines[fileLine-1]
-		bracket := refDefBracketBytes(row)
+		bracket := RefDefBracketBytes(row)
 		startCh := mdtext.UTF16FromByteOffset(row, bracket[0])
 		endCh := mdtext.UTF16FromByteOffset(row, bracket[1])
 		out = append(out, Edit{
@@ -276,7 +279,7 @@ func refUseEditsInBody(
 		if !ok || l.Reference == nil {
 			return ast.WalkContinue, nil
 		}
-		if normalizedLabel(l.Reference.Value) != oldLabel {
+		if NormalizedLabel(l.Reference.Value) != oldLabel {
 			return ast.WalkContinue, nil
 		}
 		edit, ok := refUseEdit(l, body, lines, fmOffset, newName, idx)
@@ -376,10 +379,10 @@ func linkTextBounds(l *ast.Link, body []byte) (int, int) {
 	return start, end
 }
 
-// refDefBracketBytes returns the [start, end) byte offsets of the
+// RefDefBracketBytes returns the [start, end) byte offsets of the
 // label inside a CommonMark reference-definition line, or nil when
 // row is not a reference definition.
-func refDefBracketBytes(row []byte) []int {
+func RefDefBracketBytes(row []byte) []int {
 	i := 0
 	for i < len(row) && i < 3 && row[i] == ' ' {
 		i++

--- a/internal/rename/rename.go
+++ b/internal/rename/rename.go
@@ -250,6 +250,9 @@ func refDefEditsInBody(
 		}
 		row := lines[fileLine-1]
 		bracket := RefDefBracketBytes(row)
+		if bracket == nil {
+			continue
+		}
 		startCh := mdtext.UTF16FromByteOffset(row, bracket[0])
 		endCh := mdtext.UTF16FromByteOffset(row, bracket[1])
 		out = append(out, Edit{

--- a/internal/rename/rename_test.go
+++ b/internal/rename/rename_test.go
@@ -63,6 +63,15 @@ func TestLinkRef_SameNormalizedFormRefreshesCasing(t *testing.T) {
 	require.Len(t, edits, 2)
 }
 
+func TestLinkRef_NormalizesOldLabel(t *testing.T) {
+	// LinkRef normalizes oldLabel internally, so callers may pass
+	// the raw label text without pre-normalizing it.
+	src := []byte("See [spec].\n\n[spec]: u\n")
+	edits, err := LinkRef(src, "Spec", "rfc")
+	require.NoError(t, err)
+	require.Len(t, edits, 2)
+}
+
 func TestLinkRef_CodeFenceDefNotRewritten(t *testing.T) {
 	src := []byte("Use [spec].\n\n```\n[spec]: fake\n```\n\n[spec]: real\n")
 	edits, err := LinkRef(src, "spec", "rfc")

--- a/internal/rename/rename_test.go
+++ b/internal/rename/rename_test.go
@@ -142,10 +142,3 @@ func TestNormalizedLabel(t *testing.T) {
 		})
 	}
 }
-
-func TestRefDefBracketBytes_Exported(t *testing.T) {
-	// Exported wrapper: spot-check that the function is reachable and
-	// returns the right label bounds.
-	assert.Equal(t, []int{1, 4}, RefDefBracketBytes([]byte("[lbl]: u")))
-	assert.Nil(t, RefDefBracketBytes([]byte("not a def")))
-}

--- a/internal/rename/rename_test.go
+++ b/internal/rename/rename_test.go
@@ -124,3 +124,28 @@ func TestLinkRef_NoMatchingLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, edits)
 }
+
+func TestNormalizedLabel(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"spec", "spec"},
+		{"Spec", "spec"},
+		{"API Docs", "api docs"},
+		{"API  Docs", "api docs"},
+		{"  leading  ", "leading"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizedLabel([]byte(tc.input)))
+		})
+	}
+}
+
+func TestRefDefBracketBytes_Exported(t *testing.T) {
+	// Exported wrapper: spot-check that the function is reachable and
+	// returns the right label bounds.
+	assert.Equal(t, []int{1, 4}, RefDefBracketBytes([]byte("[lbl]: u")))
+	assert.Nil(t, RefDefBracketBytes([]byte("not a def")))
+}

--- a/plan/2606240212_arch-fix-lsp-rename-helper-tests.md
+++ b/plan/2606240212_arch-fix-lsp-rename-helper-tests.md
@@ -23,14 +23,11 @@ Go arch doc §"Tests" requires every production function
 to have a dedicated test by name. The 2026-06-24 audit
 (range: 1599c9f..09f22d3) flagged this file.
 
-`atxHeadingTextByteRange` already has a test. The
-three trivial pass-through methods on the workspace
-adapter carry exemption comments. `refDefBracketBytes`
-and `normalizedLabel` were removed from lsp/rename.go
-in PR claude/youthful-knuth-hsz74x (exported as
-`rename.RefDefBracketBytes` and `rename.NormalizedLabel`
-with tests in `internal/rename`). The 13 helpers
-below need dedicated tests:
+`atxHeadingTextByteRange` already has a test.
+Three pass-through adapter methods carry exemption
+comments. Two helpers were removed from this file.
+Both now live in `internal/rename` with tests.
+The 13 helpers below need tests:
 
 - `isValidRefDefLine`
 - `headingPrepareRange`

--- a/plan/2606240212_arch-fix-lsp-rename-helper-tests.md
+++ b/plan/2606240212_arch-fix-lsp-rename-helper-tests.md
@@ -4,7 +4,7 @@ title: Add dedicated unit tests for lsp/rename.go helpers
 status: "🔲"
 model: sonnet
 summary: >-
-  internal/lsp/rename.go has 15 unexported
+  internal/lsp/rename.go has 13 unexported
   helpers without dedicated unit tests. Add a
   named test for each so the audit policy is
   satisfied.
@@ -13,7 +13,7 @@ summary: >-
 
 ## Goal
 
-Add a named unit test for each of the 15 unexported
+Add a named unit test for each of the 13 unexported
 helpers in `internal/lsp/rename.go`. The 2026-06-24
 audit requires it.
 
@@ -25,7 +25,11 @@ to have a dedicated test by name. The 2026-06-24 audit
 
 `atxHeadingTextByteRange` already has a test. The
 three trivial pass-through methods on the workspace
-adapter carry exemption comments. The 15 helpers
+adapter carry exemption comments. `refDefBracketBytes`
+and `normalizedLabel` were removed from lsp/rename.go
+in PR claude/youthful-knuth-hsz74x (exported as
+`rename.RefDefBracketBytes` and `rename.NormalizedLabel`
+with tests in `internal/rename`). The 13 helpers
 below need dedicated tests:
 
 - `isValidRefDefLine`
@@ -36,13 +40,11 @@ below need dedicated tests:
 - `trimRightSpace`
 - `trimmedRange`
 - `refDefPrepareRange`
-- `refDefBracketBytes`
 - `refUsePrepareRange`
 - `refUseLabelBytes` (one partial test exists;
   add broader coverage)
 - `matchLeadingPair`
 - `matchTrailingPair`
-- `normalizedLabel`
 - `bracketPairs`
 
 ## Tasks
@@ -64,11 +66,10 @@ below need dedicated tests:
       `TestskipLeadingSpaces`,
       `TesttrimRightSpace`, `TesttrimmedRange`,
       `TestrefDefPrepareRange`,
-      `TestrefDefBracketBytes`,
       `TestrefUsePrepareRange`,
       `TestrefUseLabelBytes`,
       `TestmatchLeadingPair`,
       `TestmatchTrailingPair`,
-      `TestnormalizedLabel`, `TestbracketPairs`.
+      `TestbracketPairs`.
 - [ ] `go test ./internal/lsp/...` is green.
 - [ ] `mdsmith check .` is green.

--- a/plan/2606240214_arch-fix-rename-dedup.md
+++ b/plan/2606240214_arch-fix-rename-dedup.md
@@ -3,7 +3,7 @@ id: 2606240214
 title: >-
   Remove duplicated helpers between lsp/rename.go
   and rename/rename.go
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   normalizedLabel and refDefBracketBytes are
@@ -56,11 +56,11 @@ a compile error.
 
 ## Acceptance Criteria
 
-- [ ] `internal/lsp/rename.go` has no private
+- [x] `internal/lsp/rename.go` has no private
       `normalizedLabel` or `refDefBracketBytes`.
-- [ ] `internal/rename/rename.go` exports
+- [x] `internal/rename/rename.go` exports
       `NormalizedLabel` and `RefDefBracketBytes`.
-- [ ] `internal/rename/rename_test.go` has dedicated
+- [x] `internal/rename/rename_test.go` has dedicated
       tests for both helpers.
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

- Export `NormalizedLabel` and `RefDefBracketBytes` from `internal/rename`, deleting the identical private copies in `internal/lsp/rename.go` (flagged by the 2026-06-24 arch audit)
- `LinkRef` now normalizes `oldLabel` internally so callers may pass raw or pre-normalized text; the CLI no longer needs to call `NormalizedLabel` before calling `LinkRef`
- Delete the now-redundant `NormalizeLabel(string) string` wrapper from `heading.go` (confusable with `NormalizedLabel([]byte) string`, differing only by trailing `d`)
- Update `ValidRefDefBodyLines` / `contentBlockLines` return types from `map[int]bool` to `map[int]struct{}` consistent with the repo's `map[K]bool → map[K]struct{}` migration
- Fix two gofmt double-blank-line violations in `lsp/rename.go` left by the function deletion

## Test plan

- [ ] `go test ./...` is green (3 commits, each passing)
- [ ] `TestLinkRef_NormalizesOldLabel` covers the new internal normalization (red → green TDD)
- [ ] `TestNormalizedLabel` covers `NormalizedLabel([]byte)` directly
- [ ] `TestRefDefBracketBytes` / `TestRefDefBracketBytesEdgeCases` cover the exported helper
- [ ] `gofmt -l internal/lsp/rename.go` produces no output

## Code review rounds

3 sequential `/code-review xhigh` rounds completed. All confirmed findings addressed:

- Round 1: nil guard on `RefDefBracketBytes` (added then removed as dead code after analysis); duplicate test removed; confusable `NormalizeLabel` API deleted
- Round 2: nil guard confirmed dead code and removed; `LinkRef` normalization internalized; plan/2606240212 stale entries removed
- Round 3: gofmt double blank lines fixed (only confirmed finding introduced by this PR)

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQQBtYXUNuyr4HmoGGk26T)_