### PR TITLE
test: add dedicated unit tests for export helpers and two small rename helpers (plan 2606240213)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -226,6 +226,6 @@ footer: |
 | 2606231014 | ✅     | sonnet | [Add dedicated unit tests for samefileanchor helper functions](plan/2606231014_arch-fix-samefileanchor-helper-tests.md)                 |
 | 2606240211 | ✅     | sonnet | [Add dedicated unit tests for locate.go helpers](plan/2606240211_arch-fix-locate-helper-tests.md)                                       |
 | 2606240212 | ✅     | sonnet | [Add dedicated unit tests for lsp/rename.go helpers](plan/2606240212_arch-fix-lsp-rename-helper-tests.md)                               |
-| 2606240213 | 🔲     | sonnet | [Add dedicated unit tests for export.go helpers and two small rename helpers](plan/2606240213_arch-fix-export-helper-tests.md)          |
+| 2606240213 | ✅     | sonnet | [Add dedicated unit tests for export.go helpers and two small rename helpers](plan/2606240213_arch-fix-export-helper-tests.md)          |
 | 2606240214 | ✅     | sonnet | [Remove duplicated helpers between lsp/rename.go and rename/rename.go](plan/2606240214_arch-fix-rename-dedup.md)                        |
 <?/catalog?>

--- a/internal/export/helpers_test.go
+++ b/internal/export/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/jeduden/mdsmith/internal/gitignore"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/piparser"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -61,6 +62,8 @@ func TestHydrate(t *testing.T) {
 	orig.FS = fstest.MapFS{"a.md": &fstest.MapFile{Data: []byte("a")}}
 	orig.RootDir = "/repo"
 	orig.MaxInputBytes = int64(999)
+	orig.RootFS = fstest.MapFS{"b.md": &fstest.MapFile{Data: []byte("b")}}
+	orig.GitignoreFunc = func() *gitignore.Matcher { return nil }
 
 	parsed, err := lint.NewFile("parsed.md", []byte("# World\n"))
 	require.NoError(t, err)
@@ -69,7 +72,9 @@ func TestHydrate(t *testing.T) {
 
 	assert.Equal(t, "/repo", parsed.RootDir)
 	assert.Equal(t, int64(999), parsed.MaxInputBytes)
-	assert.NotNil(t, parsed.FS)
+	assert.Equal(t, orig.FS, parsed.FS)
+	assert.Equal(t, orig.RootFS, parsed.RootFS)
+	assert.NotNil(t, parsed.GitignoreFunc)
 }
 
 func TestCheckStaleness(t *testing.T) {
@@ -152,7 +157,7 @@ func TestPiLineRange(t *testing.T) {
 		pi := helperFirstPI(t, f)
 		start, end := piLineRange(pi, f)
 		assert.Equal(t, 1, start)
-		assert.Greater(t, end, start)
+		assert.Equal(t, 3, end)
 	})
 }
 
@@ -230,17 +235,16 @@ func TestNormalizeBlankLines(t *testing.T) {
 
 	t.Run("result ends with exactly one newline", func(t *testing.T) {
 		got := normalizeBlankLines([]byte("a\nb\n"), noCode)
-		assert.True(t, len(got) > 0 && got[len(got)-1] == '\n')
-		assert.False(t, len(got) >= 2 && got[len(got)-2] == '\n')
+		assert.Equal(t, "a\nb\n", string(got))
 	})
 
 	t.Run("blank lines inside code block preserved", func(t *testing.T) {
-		// Lines 2 and 3 are in a code block; the blank line 3 is treated as
-		// non-blank and survives normalisation.
-		codeLines := map[int]struct{}{2: {}, 3: {}, 4: {}}
+		// Lines 2 and 3 are blank lines inside a code block; normaliseBlankLines
+		// treats inCode blank lines as non-blank so they survive collapse.
+		codeLines := map[int]struct{}{2: {}, 3: {}}
 		src := []byte("text\n\n\ncode blank\ntext2\n")
 		got := normalizeBlankLines(src, codeLines)
-		assert.Contains(t, string(got), "\n\n")
+		assert.Equal(t, "text\n\n\ncode blank\ntext2\n", string(got))
 	})
 
 	t.Run("all blank content normalises to nil", func(t *testing.T) {

--- a/internal/export/helpers_test.go
+++ b/internal/export/helpers_test.go
@@ -1,0 +1,250 @@
+package export
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/piparser"
+	"github.com/jeduden/mdsmith/internal/rule"
+	_ "github.com/jeduden/mdsmith/internal/rules/all"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectDirectives(t *testing.T) {
+	assert.Nil(t, selectDirectives(nil))
+	assert.Nil(t, selectDirectives([]rule.Rule{}))
+
+	got := selectDirectives(rule.All())
+	require.NotEmpty(t, got)
+
+	for i := 1; i < len(got); i++ {
+		assert.LessOrEqual(t, got[i-1].directive.Name(), got[i].directive.Name())
+	}
+	for _, d := range got {
+		assert.NotNil(t, d.rule)
+		assert.NotNil(t, d.directive)
+	}
+}
+
+func TestAllDirectiveNames(t *testing.T) {
+	got := allDirectiveNames()
+	require.NotEmpty(t, got)
+
+	for i := 1; i < len(got); i++ {
+		assert.LessOrEqual(t, got[i-1].name, got[i].name)
+	}
+	for _, d := range got {
+		assert.NotEmpty(t, d.name)
+		assert.NotEmpty(t, d.ruleID)
+		assert.NotEmpty(t, d.ruleName)
+	}
+}
+
+func TestRegenerate(t *testing.T) {
+	src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+	orig, err := lint.NewFile("doc.md", []byte(src))
+	require.NoError(t, err)
+
+	result := regenerate(orig, selectDirectives(rule.All()))
+
+	require.NotNil(t, result)
+	assert.NotEqual(t, src, string(result.Source))
+	assert.Contains(t, string(result.Source), "[Section](#section)")
+}
+
+func TestHydrate(t *testing.T) {
+	orig, err := lint.NewFile("orig.md", []byte("# Hello\n"))
+	require.NoError(t, err)
+	orig.FS = fstest.MapFS{"a.md": &fstest.MapFile{Data: []byte("a")}}
+	orig.RootDir = "/repo"
+	orig.MaxInputBytes = int64(999)
+
+	parsed, err := lint.NewFile("parsed.md", []byte("# World\n"))
+	require.NoError(t, err)
+
+	hydrate(parsed, orig)
+
+	assert.Equal(t, "/repo", parsed.RootDir)
+	assert.Equal(t, int64(999), parsed.MaxInputBytes)
+	assert.NotNil(t, parsed.FS)
+}
+
+func TestCheckStaleness(t *testing.T) {
+	directives := selectDirectives(rule.All())
+
+	t.Run("fresh body produces no diagnostics", func(t *testing.T) {
+		src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		assert.Empty(t, checkStaleness(f, directives))
+	})
+
+	t.Run("stale body produces error diagnostics", func(t *testing.T) {
+		src := "# Title\n\n<?toc?>\n\n- [Wrong](#wrong)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		diags := checkStaleness(f, directives)
+		require.NotEmpty(t, diags)
+		assert.Equal(t, lint.Error, diags[0].Severity)
+	})
+}
+
+func TestInGeneratedRange(t *testing.T) {
+	ranges := []lint.LineRange{{From: 3, To: 7}}
+
+	assert.True(t, inGeneratedRange(3, ranges))
+	assert.True(t, inGeneratedRange(5, ranges))
+	assert.True(t, inGeneratedRange(7, ranges))
+	assert.False(t, inGeneratedRange(2, ranges))
+	assert.False(t, inGeneratedRange(8, ranges))
+	assert.False(t, inGeneratedRange(5, nil))
+}
+
+func TestStripDirectives(t *testing.T) {
+	t.Run("directive-free file passes through verbatim", func(t *testing.T) {
+		src := "# Title\n\nbody\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		got := stripDirectives(f, allDirectiveNames())
+		assert.Equal(t, src, string(got))
+	})
+
+	t.Run("toc markers removed body kept", func(t *testing.T) {
+		src := "# Title\n\n<?toc?>\n\n- [Section](#section)\n\n<?/toc?>\n\n## Section\n\nbody\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		got := stripDirectives(f, allDirectiveNames())
+		s := string(got)
+		assert.NotContains(t, s, "<?toc")
+		assert.Contains(t, s, "- [Section](#section)")
+	})
+
+	t.Run("markerless PI removed", func(t *testing.T) {
+		src := "# Title\n\n<?allow-empty-section?>\n\nbody\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		got := stripDirectives(f, allDirectiveNames())
+		assert.NotContains(t, string(got), "<?allow-empty-section?>")
+		assert.Contains(t, string(got), "body")
+	})
+}
+
+func TestPiLineRange(t *testing.T) {
+	t.Run("single-line PI returns same start and end", func(t *testing.T) {
+		src := "<?allow-empty-section?>\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+
+		pi := helperFirstPI(t, f)
+		start, end := piLineRange(pi, f)
+		assert.Equal(t, 1, start)
+		assert.Equal(t, 1, end)
+	})
+
+	t.Run("multi-line PI closure on later line", func(t *testing.T) {
+		src := "<?require\nfilename: \"*.md\"\n?>\n"
+		f, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+
+		pi := helperFirstPI(t, f)
+		start, end := piLineRange(pi, f)
+		assert.Equal(t, 1, start)
+		assert.Greater(t, end, start)
+	})
+}
+
+// helperFirstPI walks f.AST and returns the first ProcessingInstruction node.
+func helperFirstPI(t *testing.T, f *lint.File) *piparser.ProcessingInstruction {
+	t.Helper()
+	for n := f.AST.FirstChild(); n != nil; n = n.NextSibling() {
+		if pi, ok := n.(*piparser.ProcessingInstruction); ok {
+			return pi
+		}
+	}
+	t.Fatal("no ProcessingInstruction node found in AST")
+	return nil
+}
+
+func TestOverlapsAny(t *testing.T) {
+	set := map[int]struct{}{2: {}, 5: {}}
+
+	assert.True(t, overlapsAny(1, 3, set))
+	assert.True(t, overlapsAny(5, 5, set))
+	assert.False(t, overlapsAny(3, 4, set))
+	assert.False(t, overlapsAny(6, 8, set))
+	// from > to: loop never executes
+	assert.False(t, overlapsAny(3, 1, set))
+}
+
+func TestEmitLines(t *testing.T) {
+	lines := [][]byte{
+		[]byte("line one"),
+		[]byte("line two"),
+		[]byte("line three"),
+	}
+
+	t.Run("empty strip set emits all lines", func(t *testing.T) {
+		got := emitLines(lines, map[int]struct{}{})
+		assert.Equal(t, "line one\nline two\nline three", string(got))
+	})
+
+	t.Run("strip middle line", func(t *testing.T) {
+		got := emitLines(lines, map[int]struct{}{2: {}})
+		assert.Equal(t, "line one\nline three", string(got))
+	})
+
+	t.Run("strip first line", func(t *testing.T) {
+		got := emitLines(lines, map[int]struct{}{1: {}})
+		assert.Equal(t, "line two\nline three", string(got))
+	})
+
+	t.Run("strip all lines produces empty", func(t *testing.T) {
+		got := emitLines(lines, map[int]struct{}{1: {}, 2: {}, 3: {}})
+		assert.Empty(t, string(got))
+	})
+}
+
+func TestNormalizeBlankLines(t *testing.T) {
+	noCode := map[int]struct{}{}
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, normalizeBlankLines(nil, noCode))
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.Empty(t, normalizeBlankLines([]byte{}, noCode))
+	})
+
+	t.Run("leading and trailing blanks trimmed", func(t *testing.T) {
+		got := normalizeBlankLines([]byte("\n\nparagraph\n\n"), noCode)
+		assert.Equal(t, "paragraph\n", string(got))
+	})
+
+	t.Run("multiple consecutive blanks collapsed to one", func(t *testing.T) {
+		got := normalizeBlankLines([]byte("a\n\n\n\nb\n"), noCode)
+		assert.Equal(t, "a\n\nb\n", string(got))
+	})
+
+	t.Run("result ends with exactly one newline", func(t *testing.T) {
+		got := normalizeBlankLines([]byte("a\nb\n"), noCode)
+		assert.True(t, len(got) > 0 && got[len(got)-1] == '\n')
+		assert.False(t, len(got) >= 2 && got[len(got)-2] == '\n')
+	})
+
+	t.Run("blank lines inside code block preserved", func(t *testing.T) {
+		// Lines 2 and 3 are in a code block; the blank line 3 is treated as
+		// non-blank and survives normalisation.
+		codeLines := map[int]struct{}{2: {}, 3: {}, 4: {}}
+		src := []byte("text\n\n\ncode blank\ntext2\n")
+		got := normalizeBlankLines(src, codeLines)
+		assert.Contains(t, string(got), "\n\n")
+	})
+
+	t.Run("all blank content normalises to nil", func(t *testing.T) {
+		got := normalizeBlankLines([]byte("\n\n\n"), noCode)
+		assert.Nil(t, got)
+	})
+}

--- a/internal/rename/helpers_test.go
+++ b/internal/rename/helpers_test.go
@@ -3,8 +3,12 @@ package rename
 import (
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
+	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
+	"github.com/jeduden/mdsmith/pkg/goldmark/text"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidLabelRuneError_Error(t *testing.T) {
@@ -127,6 +131,43 @@ func TestRefDefEditsInBody_DefLinePastLineTable(t *testing.T) {
 	body := []byte("[a]: u\n")
 	edits := refDefEditsInBody(body, [][]byte{}, 0, "a", "z")
 	assert.Empty(t, edits)
+}
+
+func TestContentBlockLines(t *testing.T) {
+	// A paragraph's lines are consumed into the AST block; a ref def's are not.
+	// contentBlockLines skips LinkReferenceDefinition nodes, so the ref def
+	// line does not appear in the result.
+	body := []byte("paragraph text\n\n[label]: https://example.com\n")
+	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
+	got := contentBlockLines(root, body)
+
+	_, hasPara := got[1]
+	assert.True(t, hasPara, "paragraph line should appear in content block lines")
+
+	_, hasDef := got[3]
+	assert.False(t, hasDef, "ref def line must not appear (LinkReferenceDefinition skipped)")
+}
+
+func TestContentBlockLines_EmptyBody(t *testing.T) {
+	body := []byte{}
+	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
+	got := contentBlockLines(root, body)
+	require.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestContentBlockLines_CodeBlockLinesConsumed(t *testing.T) {
+	// Lines inside a fenced code block are block-level AST nodes;
+	// their lines appear in the result.
+	body := []byte("```\ncode line\n```\n\n[ref]: u\n")
+	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
+	got := contentBlockLines(root, body)
+
+	_, hasCode := got[2]
+	assert.True(t, hasCode, "code block content line should appear in content block lines")
+
+	_, hasDef := got[5]
+	assert.False(t, hasDef, "ref def line must not appear")
 }
 
 func TestLinkRef_EmptyTextReferenceUseSkipped(t *testing.T) {

--- a/internal/rename/helpers_test.go
+++ b/internal/rename/helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
 	"github.com/jeduden/mdsmith/pkg/goldmark/text"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidLabelRuneError_Error(t *testing.T) {
@@ -152,7 +151,7 @@ func TestContentBlockLines_EmptyBody(t *testing.T) {
 	body := []byte{}
 	root := lint.NewParser().Parse(text.NewReader(body), parser.WithContext(parser.NewContext()))
 	got := contentBlockLines(root, body)
-	require.NotNil(t, got)
+	assert.NotNil(t, got)
 	assert.Empty(t, got)
 }
 

--- a/internal/rules/concisenessscoring/rule_test.go
+++ b/internal/rules/concisenessscoring/rule_test.go
@@ -321,6 +321,31 @@ func TestCheck_MessageNoConcatenationWhenExamplesPresent(t *testing.T) {
 	assert.Contains(t, msg, "e.g.,", "message with cues must include formatted examples")
 }
 
+func TestCountClassifierTokens(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"empty string", "", 0},
+		{"single word", "hello", 1},
+		{"two words", "hello world", 2},
+		{"apostrophe keeps token together", "can't", 1},
+		{"hyphen splits tokens", "hello-world", 2},
+		{"digit sequence counts as token", "abc 123", 2},
+		{"punctuation separates tokens", "hello, world!", 2},
+		{"leading and trailing spaces", "  hello  ", 1},
+		{"uppercase letters included", "Hello World", 2},
+		{"only punctuation", "!@#$", 0},
+		{"mixed alphanumeric token", "abc123", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, countClassifierTokens(tc.input))
+		})
+	}
+}
+
 func TestCheck_NoCuesMessage(t *testing.T) {
 	// Exercises the if examples == "" branch: a paragraph that scores as
 	// verbose but produces no cue phrases yields the base message only.

--- a/plan/2606240213_arch-fix-export-helper-tests.md
+++ b/plan/2606240213_arch-fix-export-helper-tests.md
@@ -3,7 +3,7 @@ id: 2606240213
 title: >-
   Add dedicated unit tests for export.go helpers
   and two small rename helpers
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   internal/export/export.go has 11 unexported
@@ -66,16 +66,17 @@ Functions without a dedicated test:
 
 ## Acceptance Criteria
 
-- [ ] `export_test.go` contains
-      `TestselectDirectives`, `TestallDirectiveNames`,
-      `Testregenerate`, `Testhydrate`,
-      `TestcheckStaleness`, `TestinGeneratedRange`,
-      `TeststripDirectives`, `TestpiLineRange`,
-      `TestoverlapsAny`, `TestemitLines`,
-      `TestnormalizeBlankLines`.
-- [ ] `rule_test.go` contains
-      `TestcountClassifierTokens`.
-- [ ] `rename_test.go` contains
-      `TestcontentBlockLines`.
-- [ ] All three `go test` commands are green.
-- [ ] `mdsmith check .` is green.
+- [x] `helpers_test.go` (package export) contains
+      `TestSelectDirectives`, `TestAllDirectiveNames`,
+      `TestRegenerate`, `TestHydrate`,
+      `TestCheckStaleness`, `TestInGeneratedRange`,
+      `TestStripDirectives`, `TestPiLineRange`,
+      `TestOverlapsAny`, `TestEmitLines`,
+      `TestNormalizeBlankLines`. (Go requires
+      uppercase after `Test`; plan names adjusted.)
+- [x] `rule_test.go` contains
+      `TestCountClassifierTokens`.
+- [x] `helpers_test.go` (package rename) contains
+      `TestContentBlockLines`.
+- [x] All three `go test` commands are green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

- Adds `TestSelectDirectives`, `TestAllDirectiveNames`, `TestRegenerate`, `TestHydrate`, `TestCheckStaleness`, `TestInGeneratedRange`, `TestStripDirectives`, `TestPiLineRange`, `TestOverlapsAny`, `TestEmitLines`, `TestNormalizeBlankLines` in `internal/export/helpers_test.go` (package `export`)
- Adds `TestCountClassifierTokens` in `internal/rules/concisenessscoring/rule_test.go`
- Adds `TestContentBlockLines`, `TestContentBlockLines_EmptyBody`, `TestContentBlockLines_CodeBlockLinesConsumed` in `internal/rename/helpers_test.go`
- Three rounds of `/code-review xhigh` applied: tightened FS/RootFS identity assertions in `TestHydrate`, replaced compound boolean expressions with `assert.Equal` in `TestNormalizeBlankLines`, fixed `codeLines` fixture, switched `require`→`assert` for non-precondition checks

Closes plan `2606240213` (2026-06-24 audit — every function needs a dedicated test).

## Test plan

- [x] `go test ./internal/export/...` green
- [x] `go test ./internal/rules/concisenessscoring/...` green
- [x] `go test ./internal/rename/...` green
- [x] `mdsmith check .` green (514 files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VToX4hjv9Qw7DtetiDA1Bx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VToX4hjv9Qw7DtetiDA1Bx)_