### PR TITLE
test(cuelite): add dedicated unit tests for 7 engine.go unexported helpers (plan 2606260615)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -231,4 +231,5 @@ footer: |
 | 2606241814 | ✅     | sonnet | [Add unit tests for lsp/rename dispatch helpers and workspace adapter methods](plan/2606241814_arch-fix-lsp-rename-dispatch-tests.md)          |
 | 2606241815 | ✅     | sonnet | [Add unit tests for three remaining unexported helpers in internal/index/locate.go](plan/2606241815_arch-fix-locate-remaining-helper-tests.md) |
 | 2606260211 | ✅     | sonnet | [Add dedicated unit tests for layer0_html.go helpers](plan/2606260211_arch-fix-layer0-html-helper-tests.md)                                    |
+| 2606260615 | ✅     | sonnet | [arch-fix: add dedicated unit tests for cue/cuelite/engine.go unexported helpers](plan/2606260615_arch-fix-cuelite-engine-helper-tests.md)     |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -231,5 +231,5 @@ footer: |
 | 2606241814 | ✅     | sonnet | [Add unit tests for lsp/rename dispatch helpers and workspace adapter methods](plan/2606241814_arch-fix-lsp-rename-dispatch-tests.md)          |
 | 2606241815 | ✅     | sonnet | [Add unit tests for three remaining unexported helpers in internal/index/locate.go](plan/2606241815_arch-fix-locate-remaining-helper-tests.md) |
 | 2606260211 | ✅     | sonnet | [Add dedicated unit tests for layer0_html.go helpers](plan/2606260211_arch-fix-layer0-html-helper-tests.md)                                    |
-| 2606260615 | ✅     | sonnet | [arch-fix: add dedicated unit tests for cue/cuelite/engine.go unexported helpers](plan/2606260615_arch-fix-cuelite-engine-helper-tests.md)     |
+| 2606260615 | ✅     | sonnet | [Add dedicated unit tests for unexported helpers in cue/cuelite/engine.go](plan/2606260615_arch-fix-cuelite-engine-helper-tests.md)            |
 <?/catalog?>

--- a/cue/cuelite/engine_helpers_test.go
+++ b/cue/cuelite/engine_helpers_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestCombineMode verifies that combineMode returns max(a,b) across all
-// pairings of the three defaultMode values.
 func TestCombineMode(t *testing.T) {
 	assert.Equal(t, dfltMaybe, combineMode(dfltMaybe, dfltMaybe))
 	assert.Equal(t, dfltNot, combineMode(dfltMaybe, dfltNot))
@@ -20,42 +18,38 @@ func TestCombineMode(t *testing.T) {
 	assert.Equal(t, dfltIs, combineMode(dfltIs, dfltIs))
 }
 
-// TestMkBottom verifies that mkBottom builds a ⊥ value carrying the
-// formatted reason and the supplied path.
 func TestMkBottom(t *testing.T) {
 	v := mkBottom([]string{"a", "b"}, "conflict: %s vs %s", "x", "y")
-	assert.True(t, v.isBottomV(), "mkBottom must produce a ⊥ value")
+	assert.True(t, v.isBottomV())
 	assert.Equal(t, "conflict: x vs y", v.reason)
 	assert.Equal(t, []string{"a", "b"}, v.path)
 	assert.Equal(t, "_|_", v.describe())
 
-	// nil path is preserved as nil.
 	v2 := mkBottom(nil, "no path")
 	assert.True(t, v2.isBottomV())
 	assert.Nil(t, v2.path)
 }
 
-// TestTopValue verifies that topValue produces the lattice identity: not ⊥,
-// and describing as "_".
 func TestTopValue(t *testing.T) {
 	v := topValue()
 	assert.Equal(t, "_", v.describe())
-	assert.False(t, v.isBottomV(), "topValue must not be ⊥")
+	assert.False(t, v.isBottomV())
 }
 
-// TestEngineValue_IsBottomV covers the nil receiver, a kBottom value, and
-// several non-bottom values.
+// TestEngineValue_IsBottomV pins the nil-safe method contract: a nil receiver
+// must return false, not panic.
 func TestEngineValue_IsBottomV(t *testing.T) {
 	var nilV *engineValue
-	assert.False(t, nilV.isBottomV(), "nil receiver must return false")
+	assert.False(t, nilV.isBottomV())
 	assert.True(t, mkBottom(nil, "x").isBottomV())
 	assert.False(t, topValue().isBottomV())
 	assert.False(t, (&engineValue{kind: kString, str: "hello"}).isBottomV())
 	assert.False(t, (&engineValue{kind: kNull}).isBottomV())
 }
 
-// TestEngineValue_DefaultValue covers no default (returns nil,false), a
-// single default (returns the branch, false), and ambiguous defaults (nil,true).
+// TestEngineValue_DefaultValue pins the ambig bool semantics: false means
+// "zero or one default" while true means "more than one dfltIs branch",
+// which CUE treats as ambiguous and non-concrete.
 func TestEngineValue_DefaultValue(t *testing.T) {
 	a := &engineValue{kind: kString, str: "a"}
 	b := &engineValue{kind: kString, str: "b"}
@@ -71,7 +65,7 @@ func TestEngineValue_DefaultValue(t *testing.T) {
 		assert.False(t, ambig)
 	})
 
-	t.Run("single default", func(t *testing.T) {
+	t.Run("first branch is default", func(t *testing.T) {
 		v := &engineValue{
 			kind:     kDisjoint,
 			branches: []*engineValue{a, b},
@@ -79,6 +73,17 @@ func TestEngineValue_DefaultValue(t *testing.T) {
 		}
 		got, ambig := v.defaultValue()
 		assert.Same(t, a, got)
+		assert.False(t, ambig)
+	})
+
+	t.Run("second branch is default", func(t *testing.T) {
+		v := &engineValue{
+			kind:     kDisjoint,
+			branches: []*engineValue{a, b},
+			modes:    []defaultMode{dfltNot, dfltIs},
+		}
+		got, ambig := v.defaultValue()
+		assert.Same(t, b, got)
 		assert.False(t, ambig)
 	})
 
@@ -94,36 +99,50 @@ func TestEngineValue_DefaultValue(t *testing.T) {
 	})
 }
 
-// TestEngineValue_DescribeBound verifies that describeBound renders the base
-// atom type followed by each bound joined with " & ".
 func TestEngineValue_DescribeBound(t *testing.T) {
-	t.Run("int with two numeric bounds", func(t *testing.T) {
-		v := &engineValue{
-			kind: kBound,
-			atom: akInt,
-			bounds: []bound{
-				{op: opGe, num: 0},
-				{op: opLe, num: 100},
-			},
-		}
-		assert.Equal(t, "int & >=0 & <=100", v.describeBound())
-	})
-	t.Run("string with regex match constraint", func(t *testing.T) {
-		v := &engineValue{
-			kind:   kBound,
-			atom:   akString,
-			bounds: []bound{{op: opMatch, src: `^[a-z]+$`}},
-		}
-		assert.Equal(t, `string & =~"^[a-z]+$"`, v.describeBound())
-	})
-	t.Run("no bounds renders atom only", func(t *testing.T) {
-		v := &engineValue{kind: kBound, atom: akFloat}
-		assert.Equal(t, "float", v.describeBound())
-	})
+	cases := []struct {
+		name string
+		v    *engineValue
+		want string
+	}{
+		{
+			"int with two numeric bounds",
+			&engineValue{kind: kBound, atom: akInt, bounds: []bound{{op: opGe, num: 0}, {op: opLe, num: 100}}},
+			"int & >=0 & <=100",
+		},
+		{
+			"string with regex match constraint",
+			&engineValue{kind: kBound, atom: akString, bounds: []bound{{op: opMatch, src: `^[a-z]+$`}}},
+			`string & =~"^[a-z]+$"`,
+		},
+		{
+			"float atom no bounds",
+			&engineValue{kind: kBound, atom: akFloat},
+			"float",
+		},
+		{
+			"number atom no bounds",
+			&engineValue{kind: kBound, atom: akNumber},
+			"number",
+		},
+		{
+			"bool atom no bounds",
+			&engineValue{kind: kBound, atom: akBool},
+			"bool",
+		},
+		{
+			"bytes atom no bounds",
+			&engineValue{kind: kBound, atom: akBytes},
+			"bytes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.v.describeBound())
+		})
+	}
 }
 
-// TestBound_Describe covers every boundOp, integral vs float numeric
-// operands, and string operands.
 func TestBound_Describe(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cue/cuelite/engine_helpers_test.go
+++ b/cue/cuelite/engine_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCombineMode(t *testing.T) {
@@ -20,13 +21,13 @@ func TestCombineMode(t *testing.T) {
 
 func TestMkBottom(t *testing.T) {
 	v := mkBottom([]string{"a", "b"}, "conflict: %s vs %s", "x", "y")
-	assert.True(t, v.isBottomV())
+	require.True(t, v.isBottomV())
 	assert.Equal(t, "conflict: x vs y", v.reason)
 	assert.Equal(t, []string{"a", "b"}, v.path)
 	assert.Equal(t, "_|_", v.describe())
 
 	v2 := mkBottom(nil, "no path")
-	assert.True(t, v2.isBottomV())
+	require.True(t, v2.isBottomV())
 	assert.Nil(t, v2.path)
 }
 

--- a/cue/cuelite/engine_helpers_test.go
+++ b/cue/cuelite/engine_helpers_test.go
@@ -23,11 +23,10 @@ func TestCombineMode(t *testing.T) {
 // TestMkBottom verifies that mkBottom builds a ⊥ value carrying the
 // formatted reason and the supplied path.
 func TestMkBottom(t *testing.T) {
-	path := []string{"a", "b"}
-	v := mkBottom(path, "conflict: %s vs %s", "x", "y")
+	v := mkBottom([]string{"a", "b"}, "conflict: %s vs %s", "x", "y")
 	assert.True(t, v.isBottomV(), "mkBottom must produce a ⊥ value")
 	assert.Equal(t, "conflict: x vs y", v.reason)
-	assert.Equal(t, path, v.path)
+	assert.Equal(t, []string{"a", "b"}, v.path)
 	assert.Equal(t, "_|_", v.describe())
 
 	// nil path is preserved as nil.
@@ -136,6 +135,7 @@ func TestBound_Describe(t *testing.T) {
 		{"gt int", bound{op: opGt, num: 0}, ">0"},
 		{"lt int", bound{op: opLt, num: 100}, "<100"},
 		{"ne string", bound{op: opNe, isStr: true, str: ""}, `!=""`},
+		{"ne int", bound{op: opNe, num: 5}, "!=5"},
 		{"match", bound{op: opMatch, src: `^[a-z]+$`}, `=~"^[a-z]+$"`},
 		{"not match", bound{op: opNotMatch, src: `^[0-9]+$`}, `!~"^[0-9]+$"`},
 		{"min runes", bound{op: opMinRunes, num: 5}, "strings.MinRunes(5)"},

--- a/cue/cuelite/engine_helpers_test.go
+++ b/cue/cuelite/engine_helpers_test.go
@@ -1,0 +1,150 @@
+package cuelite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCombineMode verifies that combineMode returns max(a,b) across all
+// pairings of the three defaultMode values.
+func TestCombineMode(t *testing.T) {
+	assert.Equal(t, dfltMaybe, combineMode(dfltMaybe, dfltMaybe))
+	assert.Equal(t, dfltNot, combineMode(dfltMaybe, dfltNot))
+	assert.Equal(t, dfltNot, combineMode(dfltNot, dfltMaybe)) // commutative
+	assert.Equal(t, dfltNot, combineMode(dfltNot, dfltNot))
+	assert.Equal(t, dfltIs, combineMode(dfltMaybe, dfltIs))
+	assert.Equal(t, dfltIs, combineMode(dfltIs, dfltMaybe)) // commutative
+	assert.Equal(t, dfltIs, combineMode(dfltNot, dfltIs))
+	assert.Equal(t, dfltIs, combineMode(dfltIs, dfltNot)) // commutative
+	assert.Equal(t, dfltIs, combineMode(dfltIs, dfltIs))
+}
+
+// TestMkBottom verifies that mkBottom builds a ⊥ value carrying the
+// formatted reason and the supplied path.
+func TestMkBottom(t *testing.T) {
+	path := []string{"a", "b"}
+	v := mkBottom(path, "conflict: %s vs %s", "x", "y")
+	assert.True(t, v.isBottomV(), "mkBottom must produce a ⊥ value")
+	assert.Equal(t, "conflict: x vs y", v.reason)
+	assert.Equal(t, path, v.path)
+	assert.Equal(t, "_|_", v.describe())
+
+	// nil path is preserved as nil.
+	v2 := mkBottom(nil, "no path")
+	assert.True(t, v2.isBottomV())
+	assert.Nil(t, v2.path)
+}
+
+// TestTopValue verifies that topValue produces the lattice identity: not ⊥,
+// and describing as "_".
+func TestTopValue(t *testing.T) {
+	v := topValue()
+	assert.Equal(t, "_", v.describe())
+	assert.False(t, v.isBottomV(), "topValue must not be ⊥")
+}
+
+// TestEngineValue_IsBottomV covers the nil receiver, a kBottom value, and
+// several non-bottom values.
+func TestEngineValue_IsBottomV(t *testing.T) {
+	var nilV *engineValue
+	assert.False(t, nilV.isBottomV(), "nil receiver must return false")
+	assert.True(t, mkBottom(nil, "x").isBottomV())
+	assert.False(t, topValue().isBottomV())
+	assert.False(t, (&engineValue{kind: kString, str: "hello"}).isBottomV())
+	assert.False(t, (&engineValue{kind: kNull}).isBottomV())
+}
+
+// TestEngineValue_DefaultValue covers no default (returns nil,false), a
+// single default (returns the branch, false), and ambiguous defaults (nil,true).
+func TestEngineValue_DefaultValue(t *testing.T) {
+	a := &engineValue{kind: kString, str: "a"}
+	b := &engineValue{kind: kString, str: "b"}
+
+	t.Run("no default", func(t *testing.T) {
+		v := &engineValue{
+			kind:     kDisjoint,
+			branches: []*engineValue{a, b},
+			modes:    []defaultMode{dfltMaybe, dfltNot},
+		}
+		got, ambig := v.defaultValue()
+		assert.Nil(t, got)
+		assert.False(t, ambig)
+	})
+
+	t.Run("single default", func(t *testing.T) {
+		v := &engineValue{
+			kind:     kDisjoint,
+			branches: []*engineValue{a, b},
+			modes:    []defaultMode{dfltIs, dfltNot},
+		}
+		got, ambig := v.defaultValue()
+		assert.Same(t, a, got)
+		assert.False(t, ambig)
+	})
+
+	t.Run("ambiguous defaults", func(t *testing.T) {
+		v := &engineValue{
+			kind:     kDisjoint,
+			branches: []*engineValue{a, b},
+			modes:    []defaultMode{dfltIs, dfltIs},
+		}
+		got, ambig := v.defaultValue()
+		assert.Nil(t, got)
+		assert.True(t, ambig)
+	})
+}
+
+// TestEngineValue_DescribeBound verifies that describeBound renders the base
+// atom type followed by each bound joined with " & ".
+func TestEngineValue_DescribeBound(t *testing.T) {
+	t.Run("int with two numeric bounds", func(t *testing.T) {
+		v := &engineValue{
+			kind: kBound,
+			atom: akInt,
+			bounds: []bound{
+				{op: opGe, num: 0},
+				{op: opLe, num: 100},
+			},
+		}
+		assert.Equal(t, "int & >=0 & <=100", v.describeBound())
+	})
+	t.Run("string with regex match constraint", func(t *testing.T) {
+		v := &engineValue{
+			kind:   kBound,
+			atom:   akString,
+			bounds: []bound{{op: opMatch, src: `^[a-z]+$`}},
+		}
+		assert.Equal(t, `string & =~"^[a-z]+$"`, v.describeBound())
+	})
+	t.Run("no bounds renders atom only", func(t *testing.T) {
+		v := &engineValue{kind: kBound, atom: akFloat}
+		assert.Equal(t, "float", v.describeBound())
+	})
+}
+
+// TestBound_Describe covers every boundOp, integral vs float numeric
+// operands, and string operands.
+func TestBound_Describe(t *testing.T) {
+	cases := []struct {
+		name string
+		b    bound
+		want string
+	}{
+		{"ge int", bound{op: opGe, num: 0}, ">=0"},
+		{"le int", bound{op: opLe, num: 10}, "<=10"},
+		{"gt int", bound{op: opGt, num: 0}, ">0"},
+		{"lt int", bound{op: opLt, num: 100}, "<100"},
+		{"ne string", bound{op: opNe, isStr: true, str: ""}, `!=""`},
+		{"match", bound{op: opMatch, src: `^[a-z]+$`}, `=~"^[a-z]+$"`},
+		{"not match", bound{op: opNotMatch, src: `^[0-9]+$`}, `!~"^[0-9]+$"`},
+		{"min runes", bound{op: opMinRunes, num: 5}, "strings.MinRunes(5)"},
+		{"float operand", bound{op: opGe, num: 1.5}, ">=1.5"},
+		{"negative int", bound{op: opGt, num: -1}, ">-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.b.describe())
+		})
+	}
+}

--- a/plan/2606260615_arch-fix-cuelite-engine-helper-tests.md
+++ b/plan/2606260615_arch-fix-cuelite-engine-helper-tests.md
@@ -1,0 +1,83 @@
+---
+id: 2606260615
+title: >-
+  arch-fix: add dedicated unit tests for
+  cue/cuelite/engine.go unexported helpers
+status: "✅"
+summary: >-
+  Seven unexported helpers in
+  cue/cuelite/engine.go lack dedicated
+  unit tests: combineMode, mkBottom,
+  topValue, engineValue.isBottomV,
+  engineValue.defaultValue,
+  engineValue.describeBound, and
+  bound.describe. This plan adds a
+  dedicated TestFoo for each.
+model: sonnet
+---
+# arch-fix: cuelite engine helper tests
+
+## Goal
+
+Seven unexported helpers in
+`cue/cuelite/engine.go` lack dedicated
+unit tests. Add a `TestFoo` for each one.
+Closes the 2026-06-26 audit finding.
+
+## Context
+
+Audit 2026-06-26 (range: 3d35b77..fe7141b)
+flagged seven unexported helpers. The file
+was touched in the perf commit `e7cb8b0`
+(fmt.Sprintf → strconv in `describe`).
+
+Functions lacking dedicated tests:
+
+- `combineMode(a, b defaultMode) defaultMode`
+- `mkBottom(path []string, format string, args ...any) *engineValue`
+- `topValue() *engineValue`
+- `(v *engineValue) isBottomV() bool`
+- `(v *engineValue) defaultValue() (*engineValue, bool)`
+- `(v *engineValue) describeBound() string`
+- `(b bound) describe() string`
+
+Several are used in existing coverage
+tests (`mkBottom`, `topValue`, `isBottomV`)
+but lack a `TestFunctionName`-style test.
+The architecture tests doc §"every function
+by name" requires one.
+
+## Tasks
+
+1. [x] Add `TestCombineMode` in
+   `cue/cuelite/engine_test.go` or a new
+   `engine_helpers_test.go`. Cover all
+   four `combineMode` table entries.
+2. [x] Add `TestMkBottom`. Confirm the
+   returned value satisfies `isBottomV()`
+   and that `describe()` includes the
+   formatted message.
+3. [x] Add `TestTopValue`. Confirm
+   `describe() == "_"` and
+   `isBottomV() == false`.
+4. [x] Add `TestEngineValue_IsBottomV`.
+   Cover `nil` receiver (false), `kBottom`
+   (true), and a non-bottom value (false).
+5. [x] Add `TestEngineValue_DefaultValue`.
+   Cover a value with a default (returns
+   default and `true`) and a value with no
+   default (returns `false`).
+6. [x] Add `TestEngineValue_DescribeBound`.
+   Cover a bounded integer (`>=1 & <=10`)
+   and a string match constraint.
+7. [x] Add `TestBound_Describe`. Cover each
+   operator (`>=`, `<=`, `>`, `<`, `!=`,
+   `=~`, `!~`) and `strings.MinRunes`.
+
+## Acceptance Criteria
+
+- [x] Each of the seven functions has a
+  dedicated top-level test.
+- [x] `go test ./cue/cuelite/...` green.
+- [x] `go vet ./...` clean.
+- [x] No production code changed; tests only.

--- a/plan/2606260615_arch-fix-cuelite-engine-helper-tests.md
+++ b/plan/2606260615_arch-fix-cuelite-engine-helper-tests.md
@@ -1,18 +1,18 @@
 ---
 id: 2606260615
 title: >-
-  arch-fix: add dedicated unit tests for
-  cue/cuelite/engine.go unexported helpers
+  Add dedicated unit tests for unexported
+  helpers in cue/cuelite/engine.go
 status: "✅"
 summary: >-
   Seven unexported helpers in
   cue/cuelite/engine.go lack dedicated
-  unit tests: combineMode, mkBottom,
-  topValue, engineValue.isBottomV,
-  engineValue.defaultValue,
-  engineValue.describeBound, and
-  bound.describe. This plan adds a
-  dedicated TestFoo for each.
+  unit tests. Adds TestCombineMode,
+  TestMkBottom, TestTopValue,
+  TestEngineValue_IsBottomV,
+  TestEngineValue_DefaultValue,
+  TestEngineValue_DescribeBound,
+  and TestBound_Describe.
 model: sonnet
 ---
 # arch-fix: cuelite engine helper tests


### PR DESCRIPTION
## Summary

- Implements plan 2606260615 (filed by the 2026-06-26 architecture audit sweep)
- Adds 7 dedicated `TestFunctionName`-style unit tests for unexported helpers in `cue/cuelite/engine.go` that lacked per-function coverage
- No production code changed; tests only

## Tests added

`TestCombineMode`, `TestMkBottom`, `TestTopValue`,
`TestEngineValue_IsBottomV`, `TestEngineValue_DefaultValue`,
`TestEngineValue_DescribeBound`, `TestBound_Describe` — all in a new
`cue/cuelite/engine_helpers_test.go`.

## Test plan

- [x] `go test ./cue/cuelite/...` green
- [x] `go vet ./...` clean
- [x] `go test ./...` green (full suite)
- [x] Plan 2606260615 status → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA8coRomPRZ9u51NjKeeMM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YA8coRomPRZ9u51NjKeeMM)_