### PR TITLE
fix(plan): resolve merge conflict markers in plan 2606260615

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -16,7 +16,24 @@ footer: |
 
 | ID         | Status | Model  | Title                                                                                                                                          |
 | ---------- | ------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-|            |        |        | [](plan/2606260615_arch-fix-cuelite-engine-helper-tests.md)                                                                                    |
+| 52         | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                                     |
+| 61         | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                                   |
+| 65         | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                               |
+| 78         | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                                        |
+| 83         | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                                                |
+| 84         | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                                     |
+| 85         | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                                           |
+| 86         | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                                            |
+| 89         | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                                              |
+| 90         | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                                                |
+| 91         | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                                                 |
+| 92         | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                                         |
+| 93         | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                                                |
+| 94         | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                                        |
+| 95         | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                                               |
+| 96         | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                                            |
+| 97         | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                                             |
+| 98         | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                                                  |
 | 100        | ✅     | sonnet | [build config block and MDS040 recipe-safety rule](plan/100_build-config-and-mds040.md)                                                        |
 | 101        | ✅     | sonnet | [build directive and MDS039 lint rule](plan/101_build-directive-mds039.md)                                                                     |
 | 102        | ✅     | opus   | [Multi-output `<?build?>` directive](plan/102_build-subcommand.md)                                                                             |
@@ -215,22 +232,5 @@ footer: |
 | 2606241815 | ✅     | sonnet | [Add unit tests for three remaining unexported helpers in internal/index/locate.go](plan/2606241815_arch-fix-locate-remaining-helper-tests.md) |
 | 2606260211 | ✅     | sonnet | [Add dedicated unit tests for layer0_html.go helpers](plan/2606260211_arch-fix-layer0-html-helper-tests.md)                                    |
 | 2606260614 | ✅     | sonnet | [arch-fix: add dedicated unit tests for lineclass_scan.go HTML-scanning helpers](plan/2606260614_arch-fix-lineclass-scan-helper-tests.md)      |
-| 52         | ✅     |        | [Archetype / Template Library for Agentic Patterns](plan/52_archetype-template-library.md)                                                     |
-| 61         | ✅     |        | [Required Structure Rule Hardening](plan/61_required-structure-hardening.md)                                                                   |
-| 65         | ✅     |        | [Spike WASM-Embedded Weasel Inference](plan/65_spike-wasm-embedded-inference.md)                                                               |
-| 78         | ✅     |        | [Query subcommand for front-matter filtering](plan/78_query-command.md)                                                                        |
-| 83         | ✅     |        | [Security hardening batch](plan/83_security-hardening-batch.md)                                                                                |
-| 84         | ✅     |        | [Symlink default-deny for file discovery](plan/84_symlink-default-deny.md)                                                                     |
-| 85         | ✅     |        | [Increase test coverage to 95% by extracting shared rule helpers](plan/85_coverage-to-95-percent.md)                                           |
-| 86         | ✅     |        | [Markdown flavor validation](plan/86_markdown-flavor-validation.md)                                                                            |
-| 89         | ✅     |        | [TOC generator directive and MDS035 auto-fix](plan/89_toc-generator-directive.md)                                                              |
-| 90         | ✅     |        | [Isolate corpus test git config from host signing](plan/90_corpus-test-git-config-isolation.md)                                                |
-| 91         | ✅     |        | [MDS037 skips paragraphs inside generated sections](plan/91_mds037-skip-generated-sections.md)                                                 |
-| 92         | ✅     | sonnet | [File kinds — config schema, assignment, merge](plan/92_file-kinds.md)                                                                         |
-| 93         | ✅     | sonnet | [Placeholder grammar — opt-in token vocabulary](plan/93_placeholder-grammar.md)                                                                |
-| 94         | ✅     | sonnet | [Lint-once for `<?include?>` and `<?catalog?>` embeds](plan/94_lint-once-for-embeds.md)                                                        |
-| 95         | ✅     | opus   | [Kind/rule resolution observability via `kinds` subcommand](plan/95_kind-rule-resolution-cli.md)                                               |
-| 96         | ✅     | sonnet | [Adopt kinds in mdsmith repo and ship the docs](plan/96_kinds-adoption-and-docs.md)                                                            |
-| 97         | ✅     | opus   | [Deep-merge for kinds and overrides](plan/97_deep-merge-config.md)                                                                             |
-| 98         | ✅     | sonnet | [Replace `archetypes` with `kinds`](plan/98_replace-archetypes-with-kinds.md)                                                                  |
+| 2606260615 | ✅     | sonnet | [Add dedicated unit tests for unexported helpers in cue/cuelite/engine.go](plan/2606260615_arch-fix-cuelite-engine-helper-tests.md)            |
 <?/catalog?>

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -252,20 +252,22 @@ line-count violations.
 
 ### tax (2026-06-26)
 
+Plans 2606260211, 2606260614, 2606260615 green.
+
 - `internal/lint/layer0_html.go` — seven
   helpers lack dedicated tests. File entered
   the touched set via a perf commit. Tests doc
   §"every function by name" —
-  [plan/2606260211][2606260211].
+  [plan/2606260211][2606260211]. ✅
 
 - `internal/lint/lineclass_scan.go` — 9
   unexported helpers lack tests.
   Sub-functions of `htmlType7Start` —
-  [plan/2606260614][2606260614].
+  [plan/2606260614][2606260614]. ✅
 
 - `cue/cuelite/engine.go` — 7 unexported
   helpers lack tests —
-  [plan/2606260615][2606260615].
+  [plan/2606260615][2606260615]. ✅
 
 [2606260211]: ../../plan/2606260211_arch-fix-layer0-html-helper-tests.md
 [2606260614]: ../../plan/2606260614_arch-fix-lineclass-scan-helper-tests.md

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -249,25 +249,24 @@ fixes (map→struct, fmt→strconv); type-6 tag
 gap fix; plan-2606241814/15 test additions.
 No new production functions, DIP, SRP, or
 line-count violations.
+Plans 2606260211, 2606260614, 2606260615 green.
 
 ### tax (2026-06-26)
-
-Plans 2606260211, 2606260614, 2606260615 green.
 
 - `internal/lint/layer0_html.go` — seven
   helpers lack dedicated tests. File entered
   the touched set via a perf commit. Tests doc
   §"every function by name" —
-  [plan/2606260211][2606260211]. ✅
+  [plan/2606260211][2606260211].
 
 - `internal/lint/lineclass_scan.go` — 9
   unexported helpers lack tests.
   Sub-functions of `htmlType7Start` —
-  [plan/2606260614][2606260614]. ✅
+  [plan/2606260614][2606260614].
 
 - `cue/cuelite/engine.go` — 7 unexported
   helpers lack tests —
-  [plan/2606260615][2606260615]. ✅
+  [plan/2606260615][2606260615].
 
 [2606260211]: ../../plan/2606260211_arch-fix-layer0-html-helper-tests.md
 [2606260614]: ../../plan/2606260614_arch-fix-lineclass-scan-helper-tests.md

--- a/plan/2606260615_arch-fix-cuelite-engine-helper-tests.md
+++ b/plan/2606260615_arch-fix-cuelite-engine-helper-tests.md
@@ -1,20 +1,6 @@
 ---
 id: 2606260615
 title: >-
-<<<<<<< .merge_file_CyC6Z1
-  arch-fix: add dedicated unit tests for
-  cue/cuelite/engine.go unexported helpers
-status: "🔲"
-summary: >-
-  Seven unexported helpers in
-  cue/cuelite/engine.go lack dedicated
-  unit tests: combineMode, mkBottom,
-  topValue, engineValue.isBottomV,
-  engineValue.defaultValue,
-  engineValue.describeBound, and
-  bound.describe. This plan adds a
-  dedicated TestFoo for each.
-=======
   Add dedicated unit tests for unexported
   helpers in cue/cuelite/engine.go
 status: "✅"
@@ -27,7 +13,6 @@ summary: >-
   TestEngineValue_DefaultValue,
   TestEngineValue_DescribeBound,
   and TestBound_Describe.
->>>>>>> .merge_file_rqVTnH
 model: sonnet
 ---
 # arch-fix: cuelite engine helper tests
@@ -64,31 +49,6 @@ by name" requires one.
 
 ## Tasks
 
-<<<<<<< .merge_file_CyC6Z1
-
-1. [ ] Add `TestCombineMode` in
-   `cue/cuelite/engine_test.go` or a new
-   `engine_helpers_test.go`. Cover all
-   four `combineMode` table entries.
-2. [ ] Add `TestMkBottom`. Confirm the
-   returned value satisfies `isBottomV()`
-   and that `describe()` includes the
-   formatted message.
-3. [ ] Add `TestTopValue`. Confirm
-   `describe() == "_"` and
-   `isBottomV() == false`.
-4. [ ] Add `TestEngineValue_IsBottomV`.
-   Cover `nil` receiver (false), `kBottom`
-   (true), and a non-bottom value (false).
-5. [ ] Add `TestEngineValue_DefaultValue`.
-   Cover a value with a default (returns
-   default and `true`) and a value with no
-   default (returns `false`).
-6. [ ] Add `TestEngineValue_DescribeBound`.
-   Cover a bounded integer (`>=1 & <=10`)
-   and a string match constraint.
-7. [ ] Add `TestBound_Describe`. Cover each
-=======
 1. [x] Add `TestCombineMode` in
    `cue/cuelite/engine_test.go` or a new
    `engine_helpers_test.go`. Cover all
@@ -111,25 +71,13 @@ by name" requires one.
    Cover a bounded integer (`>=1 & <=10`)
    and a string match constraint.
 7. [x] Add `TestBound_Describe`. Cover each
-
->>>>>>> .merge_file_rqVTnH
    operator (`>=`, `<=`, `>`, `<`, `!=`,
    `=~`, `!~`) and `strings.MinRunes`.
 
 ## Acceptance Criteria
 
-<<<<<<< .merge_file_CyC6Z1
-
-- [ ] Each of the seven functions has a
-  dedicated top-level test.
-- [ ] `go test ./cue/cuelite/...` green.
-- [ ] `go vet ./...` clean.
-- [ ] No production code changed; tests only.
-=======
 - [x] Each of the seven functions has a
   dedicated top-level test.
 - [x] `go test ./cue/cuelite/...` green.
 - [x] `go vet ./...` clean.
 - [x] No production code changed; tests only.
-
->>>>>>> .merge_file_rqVTnH


### PR DESCRIPTION
## Summary

- Plan `2606260615_arch-fix-cuelite-engine-helper-tests.md` was completed via PR #703 but the file was committed with unresolved merge conflict markers (`<<<<<<< .merge_file_CyC6Z1` / `>>>>>>> .merge_file_rqVTnH`)
- Resolves the conflict to the completed (✅) state, matching the already-merged `engine_helpers_test.go` implementation
- All 7 engine helper tests (`TestCombineMode`, `TestMkBottom`, `TestTopValue`, `TestEngineValue_IsBottomV`, `TestEngineValue_DefaultValue`, `TestEngineValue_DescribeBound`, `TestBound_Describe`) pass green

## Test plan

- [x] `mdsmith check plan/2606260615_arch-fix-cuelite-engine-helper-tests.md` — 0 failures
- [x] `go test ./cue/cuelite/...` — PASS (the underlying tests from plan 2606260615 were already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUPbs2Vx7sDMnA5gbx5HrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUPbs2Vx7sDMnA5gbx5HrW)_