### PR TITLE
chore(arch): architecture audit 2026-06-28 — clean pass

### DIFF
--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: 0ededb39c2adb946a11814540c1409393db040ca
+audit-from: 82583fc444cce4d7ed42ddb15cf32e2390f956ec
 ---
 # Architecture audit log
 
@@ -281,3 +281,19 @@ line-count crossings. Plans 2606260211,
 2606260614, and 2606260615 closed.
 
 No blockers, tax, or nice-to-have.
+
+## Audit 2026-06-28 (range: 0ededb3..82583fc)
+
+Plan 219 routes `cmd/mdsmith` and the LSP
+through `pkg/mdsmith.Session`. Five perf
+hot-path commits land. Plan 233 adds a
+numeric heading-level option to `<?include?>`.
+Plan 217 ships the Obsidian plugin WASM
+runtime. VS Code and LSP TypeScript fixes.
+479 Go sources; 26 TypeScript sources outside
+fixtures.
+
+No blockers. No rule-to-rule DIP violations.
+No SRP breaches. No file crossed 1 000 lines.
+All new production functions have dedicated
+unit tests.


### PR DESCRIPTION
## Summary

- Advances `audit-from` in `docs/development/architecture-audit.md` from `0ededb3` to `82583fc`
- Appends clean audit entry for range `0ededb3..82583fc` covering Plan 219 (Session routing), Plan 217 (Obsidian WASM plugin), Plan 233 (`<?include?>` heading-level option), and five perf hot-path commits
- Correctly accounts for both Go (479 sources) and TypeScript (26 sources) in the range — the initial draft omitted TypeScript coverage; fixed during the `--fix` pass

## Changes

**`docs/development/architecture-audit.md`**
- Updated `audit-from` front-matter SHA
- Added "Audit 2026-06-28" section with accurate source counts (Go + TypeScript), plan references, and clean-bill findings

## Audit findings

No blockers. No rule-to-rule DIP violations. No SRP breaches. No file crossed 1 000 lines. All new production functions have dedicated unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4BB2koJ1ppbKhDs5b4UkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4BB2koJ1ppbKhDs5b4UkC)_