### PR TITLE
ci(merge-queue): only run queue job when the queue label is added

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -29,7 +29,7 @@ jobs:
     # run for routine labels like Dependabot's `dependencies`/`go`, where
     # secrets.MERGE_QUEUE_TOKEN is withheld from the run and the action fails
     # with "Input required and not supplied: token". Guarding on the label
-    # name skips those events cleanly instead of exposing the token.
+    # name skips those events cleanly instead of failing on the absent token.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.label.name == 'queue'

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -24,6 +24,15 @@ permissions:
 
 jobs:
   queue:
+    # Only engage the merge-queue action when the `queue` label is the one
+    # being added (or on manual dispatch). Firing on any label makes the job
+    # run for routine labels like Dependabot's `dependencies`/`go`, where
+    # secrets.MERGE_QUEUE_TOKEN is withheld from the run and the action fails
+    # with "Input required and not supplied: token". Guarding on the label
+    # name skips those events cleanly instead of exposing the token.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'queue'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What

Guard the `queue` job in `.github/workflows/merge-queue.yml` so the merge-queue action only engages when the label that triggered the run is `queue`, or on manual `workflow_dispatch`:

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  github.event.label.name == 'queue'
```

## Why

The workflow triggers on `pull_request: types: [labeled]` — i.e. on *any* label being added — and the job unconditionally ran `jeduden/merge-queue-action`, which requires `token: ${{ secrets.MERGE_QUEUE_TOKEN }}`.

On **Dependabot** PRs, GitHub withholds repository secrets from the run, so the token resolved to empty and the action failed immediately with:

```
##[error]Input required and not supplied: token
```

This surfaced on #716 (bump `golang.org/x/tools`): the `queue` check went red the moment Dependabot's auto-applied `dependencies` / `go` labels landed, even though every other check was green.

## Effect

- Non-`queue` label events (Dependabot's `dependencies`/`go`, or any stray human label) skip the job cleanly — a skipped check, not a red failure.
- The merge-queue action still runs exactly as before when a maintainer adds the `queue` label, or on manual dispatch.
- **No secret is exposed to Dependabot-authored runs** — the fix is a trigger guard, not a permissions change.

Note: `queue` is not a required status check (the workflow never runs on an unlabeled PR), so the previous red X was non-blocking but noisy. This removes the noise and stops the action from firing on unrelated labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKpGw8pbTZHUJsyoFQBs4o)_