### PR TITLE
perf: fix top 5 high-performance-go.md violations

### DIFF
--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -1,6 +1,9 @@
 package lint
 
-import "sync"
+import (
+	"strings"
+	"sync"
+)
 
 // RunCache memoizes per-target-file reads (front matter, include
 // adjacency) across every host file processed in one engine.Run pass.
@@ -16,13 +19,14 @@ import "sync"
 // lifetime and calls Invalidate when a document edit could change
 // what the next Check would read from disk.
 type RunCache struct {
-	frontMatter  sync.Map // string (absPath) -> *runCacheEntry
-	includes     sync.Map // string (absPath) -> *runCacheEntry
-	anchors      sync.Map // string (absPath) -> *anchorEntry
-	wikilinks    sync.Map // string (root key) -> *runCacheEntry
-	globMatches  sync.Map // string (base+patterns key) -> *runCacheEntry
-	parsedSchema sync.Map // string (absPath) -> *runCacheEntry
-	compiledCUE  sync.Map // string (CUE source) -> *runCacheEntry
+	frontMatter         sync.Map // string (absPath) -> *runCacheEntry
+	includes            sync.Map // string (absPath) -> *runCacheEntry
+	anchors             sync.Map // string (absPath) -> *anchorEntry
+	wikilinks           sync.Map // string (root key) -> *runCacheEntry
+	globMatches         sync.Map // string (base+patterns key) -> *runCacheEntry
+	parsedSchema        sync.Map // string (absPath) -> *runCacheEntry
+	compiledCUE         sync.Map // string (CUE source) -> *runCacheEntry
+	duplicateParagraphs sync.Map // string (absPath+"\x00"+settings key) -> *runCacheEntry
 
 	// uniqueFieldIndex memoizes MDS069's per-scope value→first-file
 	// index. Keys encode a rule scope (field + globs), not a path.
@@ -160,6 +164,19 @@ func (c *RunCache) dropUniqueFieldIndexes(absPath string) {
 	})
 }
 
+// dropDuplicateParagraphs evicts every DuplicateParagraphs slot whose
+// key was built from absPath, regardless of the settings suffix
+// (e.g. min-chars) a caller appended after the "\x00" separator.
+func (c *RunCache) dropDuplicateParagraphs(absPath string) {
+	prefix := absPath + "\x00"
+	c.duplicateParagraphs.Range(func(k, _ any) bool {
+		if key, ok := k.(string); ok && strings.HasPrefix(key, prefix) {
+			c.duplicateParagraphs.Delete(k)
+		}
+		return true
+	})
+}
+
 // Includes returns build's result for absPath. The value is the list
 // of absolute filesystem paths every <?include?> in the file at
 // absPath resolves to. Position-independent so two host files whose
@@ -235,6 +252,24 @@ func (c *RunCache) InvalidateGlobMatches() {
 		c.globMatches.Delete(k)
 		return true
 	})
+}
+
+// DuplicateParagraphs returns build's result for key, computed at
+// most once per key in this cache's lifetime. The canonical caller
+// is MDS037 (duplicated-content): a corpus file's fingerprinted
+// paragraphs are a pure function of its bytes plus the rule's
+// min-chars setting, so memoizing them here collapses the per-host-
+// file corpus walk from re-reading and re-parsing every sibling file
+// to reading each sibling at most once per Run.
+//
+// key must be the target's absolute on-disk path followed by a NUL
+// byte and a settings suffix (e.g. min-chars), never a bare path —
+// Invalidate(absPath) below drops every slot whose key starts with
+// "absPath\x00" so an LSP document edit evicts the right entries
+// regardless of which settings suffix produced them. A caller with
+// no stable absolute path (an in-memory FS) must not use this cache.
+func (c *RunCache) DuplicateParagraphs(key string, build func() any) any {
+	return load(&c.duplicateParagraphs, key, build)
 }
 
 // Wikilinks returns build's result keyed by rootKey, computed at
@@ -421,6 +456,7 @@ func (c *RunCache) invalidate(absPath string, visited map[string]struct{}) {
 	c.frontMatter.Delete(absPath)
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
+	c.dropDuplicateParagraphs(absPath)
 
 	c.dropUniqueFieldIndexes(absPath)
 

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -1037,3 +1037,37 @@ func TestInvalidatePath_LeavesGlobMatchesIntact(t *testing.T) {
 	_ = c.GlobMatches("k", func() []string { builds++; return nil })
 	assert.Equal(t, 1, builds)
 }
+
+func TestDuplicateParagraphs_BuildsOncePerKey(t *testing.T) {
+	c := NewRunCache()
+	builds := 0
+	build := func() any { builds++; return []string{"p1"} }
+	first := c.DuplicateParagraphs("/root/a.md\x0010", build)
+	second := c.DuplicateParagraphs("/root/a.md\x0010", build)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, builds, "same key must build once")
+
+	_ = c.DuplicateParagraphs("/root/a.md\x0050", build)
+	assert.Equal(t, 2, builds, "a distinct min-chars suffix builds separately")
+}
+
+func TestDuplicateParagraphs_InvalidateDropsEveryKeyForPath(t *testing.T) {
+	// A content edit to /root/a.md must drop every cached slot built
+	// from it, regardless of which min-chars suffix produced the key
+	// — Invalidate does not know which suffixes are in use.
+	c := NewRunCache()
+	builds := 0
+	build := func() any { builds++; return []string{"p1"} }
+	_ = c.DuplicateParagraphs("/root/a.md\x0010", build)
+	_ = c.DuplicateParagraphs("/root/a.md\x0050", build)
+	_ = c.DuplicateParagraphs("/root/b.md\x0010", build)
+	require.Equal(t, 3, builds)
+
+	c.Invalidate("/root/a.md")
+
+	_ = c.DuplicateParagraphs("/root/a.md\x0010", build)
+	_ = c.DuplicateParagraphs("/root/a.md\x0050", build)
+	_ = c.DuplicateParagraphs("/root/b.md\x0010", build)
+	assert.Equal(t, 5, builds,
+		"both a.md keys must rebuild; b.md's slot must survive untouched")
+}

--- a/internal/rules/build/rule.go
+++ b/internal/rules/build/rule.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/buildpathutil"
+	"github.com/jeduden/mdsmith/internal/setutil"
 )
 
 func init() {
@@ -257,7 +258,7 @@ func (r *Rule) warnUnknownParams(
 
 	var unknown []string
 	for k := range params {
-		if _, ok := known[k]; !ok {
+		if !setutil.Contains(known, k) {
 			unknown = append(unknown, k)
 		}
 	}
@@ -392,7 +393,7 @@ func hasReservedDeviceName(p string) bool {
 		if dot := strings.IndexByte(seg, '.'); dot >= 0 {
 			seg = seg[:dot]
 		}
-		if _, ok := reservedDeviceNames[strings.ToUpper(seg)]; ok {
+		if setutil.Contains(reservedDeviceNames, strings.ToUpper(seg)) {
 			return true
 		}
 	}

--- a/internal/rules/build/rule.go
+++ b/internal/rules/build/rule.go
@@ -247,17 +247,17 @@ func (r *Rule) warnUnknownParams(
 	recipeName string, schema recipeSchema,
 	params map[string]string,
 ) []lint.Diagnostic {
-	known := map[string]bool{"recipe": true, "outputs": true, "inputs": true}
+	known := map[string]struct{}{"recipe": {}, "outputs": {}, "inputs": {}}
 	for _, p := range schema.Required {
-		known[p] = true
+		known[p] = struct{}{}
 	}
 	for _, p := range schema.Optional {
-		known[p] = true
+		known[p] = struct{}{}
 	}
 
 	var unknown []string
 	for k := range params {
-		if !known[k] {
+		if _, ok := known[k]; !ok {
 			unknown = append(unknown, k)
 		}
 	}
@@ -318,12 +318,12 @@ func (r *Rule) resolveRecipe(name string) (recipeSchema, bool) {
 // reservedDeviceNames is the set of Windows reserved device names,
 // rejected on every platform so a path that is harmless on Linux does
 // not become a device handle when the same repo is built on Windows.
-var reservedDeviceNames = map[string]bool{
-	"CON": true, "PRN": true, "AUX": true, "NUL": true,
-	"COM1": true, "COM2": true, "COM3": true, "COM4": true, "COM5": true,
-	"COM6": true, "COM7": true, "COM8": true, "COM9": true,
-	"LPT1": true, "LPT2": true, "LPT3": true, "LPT4": true, "LPT5": true,
-	"LPT6": true, "LPT7": true, "LPT8": true, "LPT9": true,
+var reservedDeviceNames = map[string]struct{}{
+	"CON": {}, "PRN": {}, "AUX": {}, "NUL": {},
+	"COM1": {}, "COM2": {}, "COM3": {}, "COM4": {}, "COM5": {},
+	"COM6": {}, "COM7": {}, "COM8": {}, "COM9": {},
+	"LPT1": {}, "LPT2": {}, "LPT3": {}, "LPT4": {}, "LPT5": {},
+	"LPT6": {}, "LPT7": {}, "LPT8": {}, "LPT9": {},
 }
 
 // splitList splits a newline-joined directive list value (the form
@@ -392,7 +392,7 @@ func hasReservedDeviceName(p string) bool {
 		if dot := strings.IndexByte(seg, '.'); dot >= 0 {
 			seg = seg[:dot]
 		}
-		if reservedDeviceNames[strings.ToUpper(seg)] {
+		if _, ok := reservedDeviceNames[strings.ToUpper(seg)]; ok {
 			return true
 		}
 	}

--- a/internal/rules/build/rule_test.go
+++ b/internal/rules/build/rule_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -764,4 +765,16 @@ func TestValidatePathEntry_InputsAcceptGlobChars(t *testing.T) {
 	} {
 		assert.Empty(t, validatePathEntry(p, true), "path %q should be accepted for inputs", p)
 	}
+}
+
+// TestReservedDeviceNames_ZeroByteValues pins reservedDeviceNames as a
+// map[string]struct{} membership set rather than map[string]bool: the
+// set is only ever probed for presence, and struct{} is a zero-byte
+// value type per docs/development/high-performance-go.md "map[K]struct{}
+// for sets".
+func TestReservedDeviceNames_ZeroByteValues(t *testing.T) {
+	typ := reflect.TypeOf(reservedDeviceNames)
+	require.Equal(t, reflect.Map, typ.Kind())
+	assert.Equal(t, uintptr(0), typ.Elem().Size(),
+		"reservedDeviceNames values should be zero-byte struct{}, not bool")
 }

--- a/internal/rules/duplicatedcontent/rule.go
+++ b/internal/rules/duplicatedcontent/rule.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -91,10 +92,10 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// resolveCorpus is guaranteed non-nil here: the f.FS == nil
 	// guard above short-circuits, and resolveCorpus falls back to
 	// f.FS when RootFS is missing or rootRelative fails.
-	corpus, selfName := resolveCorpus(f)
+	corpus, selfName, rootDir := resolveCorpus(f)
 
 	index := buildCorpusIndex(
-		corpus, selfName, f.MaxInputBytes, minChars,
+		f.RunCache, rootDir, corpus, selfName, f.MaxInputBytes, minChars,
 		f.StripFrontMatter, r.Include, r.Exclude,
 	)
 
@@ -290,7 +291,11 @@ func appendNormalized(dst, src []byte) []byte {
 // resolveCorpus picks the filesystem to scan and the path of the current
 // file within it. RootFS (the project root) is preferred; otherwise the
 // file's own directory is used. The returned selfName is forward-slash,
-// fs.FS-style so it can be compared to fs.WalkDir's path argument.
+// fs.FS-style so it can be compared to fs.WalkDir's path argument. The
+// returned rootDir is f.RootDir when RootFS is in play, or "" for the
+// FS-only fallback — buildCorpusIndex uses it to form the absolute
+// on-disk path that keys the per-file RunCache memo; an empty rootDir
+// signals "no stable absolute path, skip the RunCache".
 //
 // f.Path may be absolute (CLI runs with a discovered root) or relative
 // to the project root (ResolveFiles returns things like "./docs/a.md").
@@ -299,13 +304,13 @@ func appendNormalized(dst, src []byte) []byte {
 // falls through to the FS scope rather than walking the whole project
 // root behind the user's back. Callers guarantee f.FS != nil before
 // invoking this.
-func resolveCorpus(f *lint.File) (fs.FS, string) {
+func resolveCorpus(f *lint.File) (corpus fs.FS, selfName string, rootDir string) {
 	if f.RootFS != nil && f.RootDir != "" {
 		if selfName, ok := rootRelative(f.RootDir, f.Path); ok {
-			return f.RootFS, selfName
+			return f.RootFS, selfName, f.RootDir
 		}
 	}
-	return f.FS, filepath.Base(f.Path)
+	return f.FS, filepath.Base(f.Path), ""
 }
 
 // rootRelative returns path expressed relative to rootDir using forward
@@ -345,7 +350,16 @@ func rootRelative(rootDir, path string) (string, bool) {
 // Files that can't be read or parsed are silently skipped — this rule is
 // advisory and should never fail a run because a sibling file is
 // malformed or oversize.
+//
+// runCache and rootDir (both from resolveCorpus) let
+// candidateParagraphs memoize each sibling's fingerprinted paragraphs
+// on the engine's RunCache: a workspace of N files enabling MDS037
+// otherwise re-reads and re-parses every sibling from scratch on
+// every host file's Check, an O(N^2) cost across the run. rootDir =="
+// "" (FS-only fallback, no stable absolute path) skips the cache.
 func buildCorpusIndex(
+	runCache *lint.RunCache,
+	rootDir string,
 	corpus fs.FS,
 	selfName string,
 	maxBytes int64,
@@ -362,7 +376,7 @@ func buildCorpusIndex(
 			return walkDirDecision(path, exclude)
 		}
 		indexFileIfEligible(
-			index, corpus, path, selfName,
+			index, runCache, rootDir, corpus, path, selfName,
 			maxBytes, minChars, stripFrontMatter,
 			include, exclude,
 		)
@@ -410,6 +424,8 @@ func walkDirDecision(p string, exclude []string) error {
 // advisory and must not fail a run because of a sibling.
 func indexFileIfEligible(
 	index map[string][]externalMatch,
+	runCache *lint.RunCache,
+	rootDir string,
 	corpus fs.FS,
 	path, selfName string,
 	maxBytes int64,
@@ -423,21 +439,60 @@ func indexFileIfEligible(
 	if !matchesFilters(path, include, exclude) {
 		return
 	}
-	data, err := bytelimit.ReadFSFileLimited(corpus, path, maxBytes)
-	if err != nil {
-		return
-	}
-	// NewFileFromSource cannot fail for in-memory bytes that came
-	// out of ReadFSFileLimited successfully; goldmark's parser does
-	// not error on any input. The error return is kept in the
-	// signature for future-proofing but is dead here.
-	other, _ := lint.NewFileFromSource(path, data, stripFrontMatter) //nolint:errcheck
-	for _, p := range extractParagraphs(other, minChars) {
+	for _, p := range candidateParagraphs(
+		runCache, rootDir, corpus, path, maxBytes, minChars, stripFrontMatter,
+	) {
 		index[p.fingerprint] = append(index[p.fingerprint], externalMatch{
 			path: path,
-			line: p.line + other.LineOffset,
+			line: p.line,
 		})
 	}
+}
+
+// candidateParagraphs returns a corpus candidate's fingerprinted
+// paragraphs, adjusted for its own front-matter line offset. When
+// runCache and rootDir are both available, the result is memoized on
+// runCache keyed by the candidate's absolute on-disk path plus
+// minChars (the one rule setting that can vary per file kind and
+// therefore change which paragraphs qualify) — RunCache.Invalidate
+// evicts by the absPath prefix, so an LSP document edit still refreshes
+// the right slot. Without a stable absolute path (in-memory FS, or no
+// RunCache at all), every call reads and re-parses the file directly.
+func candidateParagraphs(
+	runCache *lint.RunCache,
+	rootDir string,
+	corpus fs.FS,
+	path string,
+	maxBytes int64,
+	minChars int,
+	stripFrontMatter bool,
+) []paragraph {
+	build := func() []paragraph {
+		data, err := bytelimit.ReadFSFileLimited(corpus, path, maxBytes)
+		if err != nil {
+			return nil
+		}
+		// NewFileFromSource cannot fail for in-memory bytes that came
+		// out of ReadFSFileLimited successfully; goldmark's parser
+		// does not error on any input. The error return is kept in
+		// the signature for future-proofing but is dead here.
+		other, _ := lint.NewFileFromSource(path, data, stripFrontMatter) //nolint:errcheck
+		paragraphs := extractParagraphs(other, minChars)
+		if other.LineOffset != 0 {
+			for i := range paragraphs {
+				paragraphs[i].line += other.LineOffset
+			}
+		}
+		return paragraphs
+	}
+	if runCache == nil || rootDir == "" {
+		return build()
+	}
+	absPath := filepath.Join(rootDir, filepath.FromSlash(path))
+	key := absPath + "\x00" + strconv.Itoa(minChars)
+	v := runCache.DuplicateParagraphs(key, func() any { return build() })
+	paragraphs, _ := v.([]paragraph)
+	return paragraphs
 }
 
 func isMarkdownPath(p string) bool {

--- a/internal/rules/duplicatedcontent/rule.go
+++ b/internal/rules/duplicatedcontent/rule.go
@@ -94,10 +94,18 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// f.FS when RootFS is missing or rootRelative fails.
 	corpus, selfName, rootDir := resolveCorpus(f)
 
-	index := buildCorpusIndex(
-		f.RunCache, rootDir, corpus, selfName, f.MaxInputBytes, minChars,
-		f.StripFrontMatter, r.Include, r.Exclude,
-	)
+	index := buildCorpusIndex(corpusScanConfig{
+		runCache:         f.RunCache,
+		rootDir:          rootDir,
+		corpus:           corpus,
+		selfName:         selfName,
+		maxBytes:         f.MaxInputBytes,
+		minChars:         minChars,
+		keySuffix:        "\x00" + strconv.Itoa(minChars),
+		stripFrontMatter: f.StripFrontMatter,
+		include:          r.Include,
+		exclude:          r.Exclude,
+	})
 
 	var diags []lint.Diagnostic
 	for _, p := range self {
@@ -345,45 +353,51 @@ func rootRelative(rootDir, path string) (string, bool) {
 	return slash, true
 }
 
-// buildCorpusIndex walks corpus for .md files (excluding selfName) and
-// returns a map from paragraph fingerprint to every occurrence found.
-// Files that can't be read or parsed are silently skipped — this rule is
-// advisory and should never fail a run because a sibling file is
-// malformed or oversize.
+// corpusScanConfig bundles the settings buildCorpusIndex,
+// indexFileIfEligible, and candidateParagraphs all need to walk one
+// corpus for one host file's Check call. Building it once in Check
+// instead of re-threading each setting as its own positional
+// parameter keeps a future setting addition (RunCache and keySuffix
+// were both added this way) from growing an already-long parameter
+// list further.
+type corpusScanConfig struct {
+	runCache *lint.RunCache
+	corpus   fs.FS
+	// rootDir is the absolute on-disk directory corpus is rooted at,
+	// or "" for the FS-only fallback (no stable absolute path) —
+	// candidateParagraphs skips the RunCache in that case.
+	rootDir  string
+	selfName string
+	maxBytes int64
+	minChars int
+	// keySuffix is "\x00"+minChars, built once per Check call since
+	// minChars is fixed for the whole corpus walk.
+	keySuffix        string
+	stripFrontMatter bool
+	include, exclude []string
+}
+
+// buildCorpusIndex walks cfg.corpus for .md files (excluding
+// cfg.selfName) and returns a map from paragraph fingerprint to every
+// occurrence found. Files that can't be read or parsed are silently
+// skipped — this rule is advisory and should never fail a run because
+// a sibling file is malformed or oversize.
 //
-// runCache and rootDir (both from resolveCorpus) let
-// candidateParagraphs memoize each sibling's fingerprinted paragraphs
-// on the engine's RunCache: a workspace of N files enabling MDS037
-// otherwise re-reads and re-parses every sibling from scratch on
-// every host file's Check, an O(N^2) cost across the run. rootDir =="
-// "" (FS-only fallback, no stable absolute path) skips the cache.
-func buildCorpusIndex(
-	runCache *lint.RunCache,
-	rootDir string,
-	corpus fs.FS,
-	selfName string,
-	maxBytes int64,
-	minChars int,
-	stripFrontMatter bool,
-	include, exclude []string,
-) map[string][]externalMatch {
-	// keySuffix is the same for every candidate file in this walk
-	// (minChars is fixed for the whole Check call), so it is built
-	// once here rather than on every indexFileIfEligible call.
-	keySuffix := "\x00" + strconv.Itoa(minChars)
+// cfg.runCache and cfg.rootDir let candidateParagraphs memoize each
+// sibling's fingerprinted paragraphs on the engine's RunCache: a
+// workspace of N files enabling MDS037 otherwise re-reads and
+// re-parses every sibling from scratch on every host file's Check, an
+// O(N^2) cost across the run.
+func buildCorpusIndex(cfg corpusScanConfig) map[string][]externalMatch {
 	index := make(map[string][]externalMatch)
-	_ = fs.WalkDir(corpus, ".", func(path string, d fs.DirEntry, err error) error {
+	_ = fs.WalkDir(cfg.corpus, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if d.IsDir() {
-			return walkDirDecision(path, exclude)
+			return walkDirDecision(path, cfg.exclude)
 		}
-		indexFileIfEligible(
-			index, runCache, rootDir, corpus, path, selfName,
-			maxBytes, minChars, keySuffix, stripFrontMatter,
-			include, exclude,
-		)
+		indexFileIfEligible(index, cfg, path)
 		return nil
 	})
 
@@ -426,27 +440,14 @@ func walkDirDecision(p string, exclude []string) error {
 // Markdown, match the current file, fail include/exclude, are
 // unreadable, or unparseable are silently dropped — this rule is
 // advisory and must not fail a run because of a sibling.
-func indexFileIfEligible(
-	index map[string][]externalMatch,
-	runCache *lint.RunCache,
-	rootDir string,
-	corpus fs.FS,
-	path, selfName string,
-	maxBytes int64,
-	minChars int,
-	keySuffix string,
-	stripFrontMatter bool,
-	include, exclude []string,
-) {
-	if !isMarkdownPath(path) || path == selfName {
+func indexFileIfEligible(index map[string][]externalMatch, cfg corpusScanConfig, path string) {
+	if !isMarkdownPath(path) || path == cfg.selfName {
 		return
 	}
-	if !matchesFilters(path, include, exclude) {
+	if !matchesFilters(path, cfg.include, cfg.exclude) {
 		return
 	}
-	for _, p := range candidateParagraphs(
-		runCache, rootDir, corpus, path, maxBytes, minChars, keySuffix, stripFrontMatter,
-	) {
+	for _, p := range candidateParagraphs(cfg, path) {
 		index[p.fingerprint] = append(index[p.fingerprint], externalMatch{
 			path: path,
 			line: p.line,
@@ -456,26 +457,17 @@ func indexFileIfEligible(
 
 // candidateParagraphs returns a corpus candidate's fingerprinted
 // paragraphs, adjusted for its own front-matter line offset. When
-// runCache and rootDir are both available, the result is memoized on
-// runCache keyed by the candidate's absolute on-disk path plus
-// keySuffix (built from minChars, the one rule setting that can vary
-// per file kind and therefore change which paragraphs qualify) —
-// RunCache.Invalidate evicts by the absPath prefix, so an LSP
-// document edit still refreshes the right slot. Without a stable
+// cfg.runCache and cfg.rootDir are both available, the result is
+// memoized on the RunCache keyed by the candidate's absolute on-disk
+// path plus cfg.keySuffix (built from minChars, the one rule setting
+// that can vary per file kind and therefore change which paragraphs
+// qualify) — RunCache.Invalidate evicts by the absPath prefix, so an
+// LSP document edit still refreshes the right slot. Without a stable
 // absolute path (in-memory FS, or no RunCache at all), every call
 // reads and re-parses the file directly.
-func candidateParagraphs(
-	runCache *lint.RunCache,
-	rootDir string,
-	corpus fs.FS,
-	path string,
-	maxBytes int64,
-	minChars int,
-	keySuffix string,
-	stripFrontMatter bool,
-) []paragraph {
+func candidateParagraphs(cfg corpusScanConfig, path string) []paragraph {
 	build := func() []paragraph {
-		data, err := bytelimit.ReadFSFileLimited(corpus, path, maxBytes)
+		data, err := bytelimit.ReadFSFileLimited(cfg.corpus, path, cfg.maxBytes)
 		if err != nil {
 			return nil
 		}
@@ -483,18 +475,18 @@ func candidateParagraphs(
 		// out of ReadFSFileLimited successfully; goldmark's parser
 		// does not error on any input. The error return is kept in
 		// the signature for future-proofing but is dead here.
-		other, _ := lint.NewFileFromSource(path, data, stripFrontMatter) //nolint:errcheck
-		paragraphs := extractParagraphs(other, minChars)
+		other, _ := lint.NewFileFromSource(path, data, cfg.stripFrontMatter) //nolint:errcheck
+		paragraphs := extractParagraphs(other, cfg.minChars)
 		for i := range paragraphs {
 			paragraphs[i].line += other.LineOffset
 		}
 		return paragraphs
 	}
-	if runCache == nil || rootDir == "" {
+	if cfg.runCache == nil || cfg.rootDir == "" {
 		return build()
 	}
-	absPath := filepath.Join(rootDir, filepath.FromSlash(path))
-	v := runCache.DuplicateParagraphs(absPath+keySuffix, func() any { return build() })
+	absPath := filepath.Join(cfg.rootDir, filepath.FromSlash(path))
+	v := cfg.runCache.DuplicateParagraphs(absPath+cfg.keySuffix, func() any { return build() })
 	paragraphs, _ := v.([]paragraph)
 	return paragraphs
 }

--- a/internal/rules/duplicatedcontent/rule.go
+++ b/internal/rules/duplicatedcontent/rule.go
@@ -367,6 +367,10 @@ func buildCorpusIndex(
 	stripFrontMatter bool,
 	include, exclude []string,
 ) map[string][]externalMatch {
+	// keySuffix is the same for every candidate file in this walk
+	// (minChars is fixed for the whole Check call), so it is built
+	// once here rather than on every indexFileIfEligible call.
+	keySuffix := "\x00" + strconv.Itoa(minChars)
 	index := make(map[string][]externalMatch)
 	_ = fs.WalkDir(corpus, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -377,7 +381,7 @@ func buildCorpusIndex(
 		}
 		indexFileIfEligible(
 			index, runCache, rootDir, corpus, path, selfName,
-			maxBytes, minChars, stripFrontMatter,
+			maxBytes, minChars, keySuffix, stripFrontMatter,
 			include, exclude,
 		)
 		return nil
@@ -430,6 +434,7 @@ func indexFileIfEligible(
 	path, selfName string,
 	maxBytes int64,
 	minChars int,
+	keySuffix string,
 	stripFrontMatter bool,
 	include, exclude []string,
 ) {
@@ -440,7 +445,7 @@ func indexFileIfEligible(
 		return
 	}
 	for _, p := range candidateParagraphs(
-		runCache, rootDir, corpus, path, maxBytes, minChars, stripFrontMatter,
+		runCache, rootDir, corpus, path, maxBytes, minChars, keySuffix, stripFrontMatter,
 	) {
 		index[p.fingerprint] = append(index[p.fingerprint], externalMatch{
 			path: path,
@@ -453,11 +458,12 @@ func indexFileIfEligible(
 // paragraphs, adjusted for its own front-matter line offset. When
 // runCache and rootDir are both available, the result is memoized on
 // runCache keyed by the candidate's absolute on-disk path plus
-// minChars (the one rule setting that can vary per file kind and
-// therefore change which paragraphs qualify) — RunCache.Invalidate
-// evicts by the absPath prefix, so an LSP document edit still refreshes
-// the right slot. Without a stable absolute path (in-memory FS, or no
-// RunCache at all), every call reads and re-parses the file directly.
+// keySuffix (built from minChars, the one rule setting that can vary
+// per file kind and therefore change which paragraphs qualify) —
+// RunCache.Invalidate evicts by the absPath prefix, so an LSP
+// document edit still refreshes the right slot. Without a stable
+// absolute path (in-memory FS, or no RunCache at all), every call
+// reads and re-parses the file directly.
 func candidateParagraphs(
 	runCache *lint.RunCache,
 	rootDir string,
@@ -465,6 +471,7 @@ func candidateParagraphs(
 	path string,
 	maxBytes int64,
 	minChars int,
+	keySuffix string,
 	stripFrontMatter bool,
 ) []paragraph {
 	build := func() []paragraph {
@@ -478,10 +485,8 @@ func candidateParagraphs(
 		// the signature for future-proofing but is dead here.
 		other, _ := lint.NewFileFromSource(path, data, stripFrontMatter) //nolint:errcheck
 		paragraphs := extractParagraphs(other, minChars)
-		if other.LineOffset != 0 {
-			for i := range paragraphs {
-				paragraphs[i].line += other.LineOffset
-			}
+		for i := range paragraphs {
+			paragraphs[i].line += other.LineOffset
 		}
 		return paragraphs
 	}
@@ -489,8 +494,7 @@ func candidateParagraphs(
 		return build()
 	}
 	absPath := filepath.Join(rootDir, filepath.FromSlash(path))
-	key := absPath + "\x00" + strconv.Itoa(minChars)
-	v := runCache.DuplicateParagraphs(key, func() any { return build() })
+	v := runCache.DuplicateParagraphs(absPath+keySuffix, func() any { return build() })
 	paragraphs, _ := v.([]paragraph)
 	return paragraphs
 }

--- a/internal/rules/duplicatedcontent/rule_test.go
+++ b/internal/rules/duplicatedcontent/rule_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -638,6 +639,60 @@ func TestCheck_MultipleMatchesSortDeterministically(t *testing.T) {
 	require.Len(t, diags, 2)
 	assert.Contains(t, diags[0].Message, "b.md")
 	assert.Contains(t, diags[1].Message, "c.md")
+}
+
+// countingFS wraps an fs.FS and counts Open calls per name, so a test
+// can assert a file is read from disk at most once across several
+// Check calls that share one lint.RunCache.
+type countingFS struct {
+	fs.FS
+	mu    sync.Mutex
+	opens map[string]int
+}
+
+func (c *countingFS) Open(name string) (fs.File, error) {
+	c.mu.Lock()
+	c.opens[name]++
+	c.mu.Unlock()
+	return c.FS.Open(name)
+}
+
+// TestCheck_RunCacheReusesCorpusParseAcrossHostFiles pins the fix for
+// MDS037's O(N^2) corpus rebuild: buildCorpusIndex used to re-read,
+// re-parse, and re-fingerprint every sibling file from scratch on
+// every host file's Check call. When host files share one RunCache
+// (the engine's per-Run cache), each sibling's fingerprinted
+// paragraphs must be computed at most once across the whole run.
+func TestCheck_RunCacheReusesCorpusParseAcrossHostFiles(t *testing.T) {
+	dir := t.TempDir()
+	p := longParagraph("shared paragraph text for the run cache test")
+	writeFile(t, filepath.Join(dir, "a.md"), "# A\n\n"+p+"\n")
+	writeFile(t, filepath.Join(dir, "b.md"), "# B\n\n"+p+"\n")
+	writeFile(t, filepath.Join(dir, "c.md"), "# C\n\nunrelated short text\n")
+
+	counting := &countingFS{FS: os.DirFS(dir), opens: map[string]int{}}
+	runCache := lint.NewRunCache()
+
+	for _, name := range []string{"a.md", "b.md", "c.md"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, err)
+		// f.Path must be absolute (as a discovered-root CLI run would
+		// produce it) so rootRelative resolves it against dir instead
+		// of the test process's working directory.
+		f, err := lint.NewFile(filepath.Join(dir, name), data)
+		require.NoError(t, err)
+		f.FS = counting
+		f.RootDir = dir
+		f.RootFS = counting
+		f.RunCache = runCache
+		_ = (&Rule{}).Check(f)
+	}
+
+	for _, name := range []string{"a.md", "b.md", "c.md"} {
+		assert.LessOrEqualf(t, counting.opens[name], 1,
+			"expected %s to be read from disk at most once across Check "+
+				"calls sharing a RunCache, got %d opens", name, counting.opens[name])
+	}
 }
 
 func TestApplySettings_RejectsBadExcludeType(t *testing.T) {

--- a/internal/rules/duplicatedcontent/rule_test.go
+++ b/internal/rules/duplicatedcontent/rule_test.go
@@ -695,6 +695,48 @@ func TestCheck_RunCacheReusesCorpusParseAcrossHostFiles(t *testing.T) {
 	}
 }
 
+// TestCheck_RunCacheAppliesFrontMatterOffsetOnce pins that a corpus
+// candidate's front-matter line offset is baked into its cached
+// paragraphs exactly once: candidateParagraphs adds other.LineOffset
+// inside the RunCache build closure, which runs at most once per key.
+// Checking the same host file twice against a shared RunCache drives
+// the offset-add on the first call (cache miss, build runs) and
+// reads the cached value on the second (cache hit) — a double-add
+// regression would report b.md at line 10 (7 + 3) on the second call
+// instead of 7 on both.
+func TestCheck_RunCacheAppliesFrontMatterOffsetOnce(t *testing.T) {
+	dir := t.TempDir()
+	p := longParagraph("shared paragraph text for the offset cache test")
+	fm := "---\ntitle: B\n---\n"
+	// b.md's paragraph sits at raw line 7: front matter lines 1-3,
+	// blank line 4, heading line 5 ("# B"), blank line 6, paragraph
+	// line 7. Stripping front matter (stripFrontMatter=true) removes
+	// lines 1-3 before the AST walk, so extractParagraphs sees the
+	// paragraph at line 4 and other.LineOffset must add 3 back to
+	// report the correct raw line.
+	writeFile(t, filepath.Join(dir, "b.md"), fm+"\n# B\n\n"+p+"\n")
+	writeFile(t, filepath.Join(dir, "a.md"), "# A\n\n"+p+"\n")
+
+	runCache := lint.NewRunCache()
+	data, err := os.ReadFile(filepath.Join(dir, "a.md"))
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		f, err := lint.NewFileFromSource(filepath.Join(dir, "a.md"), data, true)
+		require.NoError(t, err)
+		f.FS = os.DirFS(dir)
+		f.RootDir = dir
+		f.RootFS = os.DirFS(dir)
+		f.RunCache = runCache
+
+		diags := (&Rule{}).Check(f)
+		require.Len(t, diags, 1)
+		assert.Contains(t, diags[0].Message, "b.md:7",
+			"b.md's paragraph line must include its front-matter offset "+
+				"on every Check call sharing the RunCache, not just the first")
+	}
+}
+
 func TestApplySettings_RejectsBadExcludeType(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{"exclude": "not-a-list"})

--- a/pkg/goldmark/ast/inline.go
+++ b/pkg/goldmark/ast/inline.go
@@ -588,15 +588,22 @@ const (
 )
 
 // An AutoLink struct represents an autolink of the Markdown text.
+//
+// Protocol and value (pointer-bearing) are declared before
+// AutoLinkType (a scalar) so the GC ptrdata scan does not extend
+// across it; see docs/development/high-performance-go.md "Group
+// pointer fields first, scalars last". One AutoLink is allocated per
+// autolink node parsed.
 type AutoLink struct {
 	BaseInline
-	// Type is a type of this autolink.
-	AutoLinkType AutoLinkType
 
 	// Protocol specified a protocol of the link.
 	Protocol []byte
 
 	value *Text
+
+	// Type is a type of this autolink.
+	AutoLinkType AutoLinkType
 }
 
 // Inline implements Inline.Inline.

--- a/pkg/goldmark/ast/structlayout_test.go
+++ b/pkg/goldmark/ast/structlayout_test.go
@@ -10,31 +10,10 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/pkg/goldmark/internal/fieldorder"
-	"github.com/stretchr/testify/assert"
 )
-
-// assertOwnFieldsPointersBeforeScalars checks that, among typ's
-// fields starting at index skip (use 1 to skip an embedded base
-// struct), no scalar (non-pointerish) field is followed by a
-// pointerish one.
-func assertOwnFieldsPointersBeforeScalars(t *testing.T, typ reflect.Type, skip int) {
-	t.Helper()
-	seenScalar := false
-	for i := skip; i < typ.NumField(); i++ {
-		f := typ.Field(i)
-		if fieldorder.IsPointerish(f.Type.Kind()) {
-			assert.Falsef(t, seenScalar,
-				"field %s (%s, pointer-ish) is declared after a scalar field; "+
-					"pointer fields should precede scalars to shrink GC ptrdata",
-				f.Name, f.Type)
-		} else {
-			seenScalar = true
-		}
-	}
-}
 
 func TestAutoLink_PointerFieldsBeforeScalars(t *testing.T) {
 	// Index 0 is the embedded BaseInline; only AutoLink's own
 	// declared fields are checked here.
-	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(AutoLink{}), 1)
+	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(AutoLink{}), 1)
 }

--- a/pkg/goldmark/ast/structlayout_test.go
+++ b/pkg/goldmark/ast/structlayout_test.go
@@ -9,17 +9,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jeduden/mdsmith/pkg/goldmark/internal/fieldorder"
 	"github.com/stretchr/testify/assert"
 )
-
-func isPointerish(k reflect.Kind) bool {
-	switch k {
-	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map,
-		reflect.Chan, reflect.Func, reflect.String, reflect.UnsafePointer:
-		return true
-	}
-	return false
-}
 
 // assertOwnFieldsPointersBeforeScalars checks that, among typ's
 // fields starting at index skip (use 1 to skip an embedded base
@@ -30,7 +22,7 @@ func assertOwnFieldsPointersBeforeScalars(t *testing.T, typ reflect.Type, skip i
 	seenScalar := false
 	for i := skip; i < typ.NumField(); i++ {
 		f := typ.Field(i)
-		if isPointerish(f.Type.Kind()) {
+		if fieldorder.IsPointerish(f.Type.Kind()) {
 			assert.Falsef(t, seenScalar,
 				"field %s (%s, pointer-ish) is declared after a scalar field; "+
 					"pointer fields should precede scalars to shrink GC ptrdata",

--- a/pkg/goldmark/ast/structlayout_test.go
+++ b/pkg/goldmark/ast/structlayout_test.go
@@ -1,0 +1,48 @@
+package ast
+
+// Pins the struct-layout guidance in
+// docs/development/high-performance-go.md ("Group pointer fields
+// first, scalars last — GC ptrdata spans through the last pointer
+// field") for AutoLink, allocated once per autolink node parsed.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func isPointerish(k reflect.Kind) bool {
+	switch k {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map,
+		reflect.Chan, reflect.Func, reflect.String, reflect.UnsafePointer:
+		return true
+	}
+	return false
+}
+
+// assertOwnFieldsPointersBeforeScalars checks that, among typ's
+// fields starting at index skip (use 1 to skip an embedded base
+// struct), no scalar (non-pointerish) field is followed by a
+// pointerish one.
+func assertOwnFieldsPointersBeforeScalars(t *testing.T, typ reflect.Type, skip int) {
+	t.Helper()
+	seenScalar := false
+	for i := skip; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if isPointerish(f.Type.Kind()) {
+			assert.Falsef(t, seenScalar,
+				"field %s (%s, pointer-ish) is declared after a scalar field; "+
+					"pointer fields should precede scalars to shrink GC ptrdata",
+				f.Name, f.Type)
+		} else {
+			seenScalar = true
+		}
+	}
+}
+
+func TestAutoLink_PointerFieldsBeforeScalars(t *testing.T) {
+	// Index 0 is the embedded BaseInline; only AutoLink's own
+	// declared fields are checked here.
+	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(AutoLink{}), 1)
+}

--- a/pkg/goldmark/internal/fieldorder/fieldorder.go
+++ b/pkg/goldmark/internal/fieldorder/fieldorder.go
@@ -1,0 +1,22 @@
+// Package fieldorder checks that a struct's pointer-bearing fields
+// are declared before its scalar fields, per
+// docs/development/high-performance-go.md "Group pointer fields
+// first, scalars last — GC ptrdata spans through the last pointer
+// field". Shared between pkg/goldmark/ast and pkg/goldmark/parser so
+// their hot per-token struct layout tests do not each carry their own
+// copy of the same reflection logic.
+package fieldorder
+
+import "reflect"
+
+// IsPointerish reports whether a field's kind carries at least one
+// pointer word that the GC must scan (a pointer, interface, slice,
+// map, chan, func, string header, or unsafe.Pointer).
+func IsPointerish(k reflect.Kind) bool {
+	switch k {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map,
+		reflect.Chan, reflect.Func, reflect.String, reflect.UnsafePointer:
+		return true
+	}
+	return false
+}

--- a/pkg/goldmark/internal/fieldorder/fieldorder.go
+++ b/pkg/goldmark/internal/fieldorder/fieldorder.go
@@ -7,7 +7,10 @@
 // copy of the same reflection logic.
 package fieldorder
 
-import "reflect"
+import (
+	"reflect"
+	"testing"
+)
 
 // IsPointerish reports whether a field's kind carries at least one
 // pointer word that the GC must scan (a pointer, interface, slice,
@@ -19,4 +22,26 @@ func IsPointerish(k reflect.Kind) bool {
 		return true
 	}
 	return false
+}
+
+// AssertPointersBeforeScalars checks that, among typ's fields
+// starting at index skip (use 1 to skip an embedded base struct), no
+// scalar (non-pointerish) field is followed by a pointerish one. A
+// pointerish field declared after a scalar field extends the struct's
+// GC ptrdata past that scalar for no reason.
+func AssertPointersBeforeScalars(t testing.TB, typ reflect.Type, skip int) {
+	t.Helper()
+	seenScalar := false
+	for i := skip; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if IsPointerish(f.Type.Kind()) {
+			if seenScalar {
+				t.Errorf("field %s (%s, pointer-ish) is declared after a scalar field; "+
+					"pointer fields should precede scalars to shrink GC ptrdata",
+					f.Name, f.Type)
+			}
+		} else {
+			seenScalar = true
+		}
+	}
 }

--- a/pkg/goldmark/internal/fieldorder/fieldorder.go
+++ b/pkg/goldmark/internal/fieldorder/fieldorder.go
@@ -12,14 +12,27 @@ import (
 	"testing"
 )
 
-// IsPointerish reports whether a field's kind carries at least one
-// pointer word that the GC must scan (a pointer, interface, slice,
-// map, chan, func, string header, or unsafe.Pointer).
-func IsPointerish(k reflect.Kind) bool {
-	switch k {
+// IsPointerish reports whether t carries at least one pointer word
+// that the GC must scan: directly (a pointer, interface, slice, map,
+// chan, func, string header, or unsafe.Pointer), or indirectly
+// through a struct field or array element of such a type, checked
+// recursively. A struct's reflect.Kind is always reflect.Struct
+// regardless of what its fields hold, so a Kind-only check would
+// misclassify e.g. a struct wrapping a []byte as scalar.
+func IsPointerish(t reflect.Type) bool {
+	switch t.Kind() {
 	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map,
 		reflect.Chan, reflect.Func, reflect.String, reflect.UnsafePointer:
 		return true
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if IsPointerish(t.Field(i).Type) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		return IsPointerish(t.Elem())
 	}
 	return false
 }
@@ -34,7 +47,7 @@ func AssertPointersBeforeScalars(t testing.TB, typ reflect.Type, skip int) {
 	seenScalar := false
 	for i := skip; i < typ.NumField(); i++ {
 		f := typ.Field(i)
-		if IsPointerish(f.Type.Kind()) {
+		if IsPointerish(f.Type) {
 			if seenScalar {
 				t.Errorf("field %s (%s, pointer-ish) is declared after a scalar field; "+
 					"pointer fields should precede scalars to shrink GC ptrdata",

--- a/pkg/goldmark/internal/fieldorder/fieldorder_test.go
+++ b/pkg/goldmark/internal/fieldorder/fieldorder_test.go
@@ -1,0 +1,46 @@
+package fieldorder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// nestedPointerish is a struct whose Kind is reflect.Struct but which
+// carries a pointer word (Data) via a nested field — the shape
+// IsPointerish must recognise even though the field itself is not
+// directly a pointer/interface/slice/map/chan/func/string/
+// unsafe.Pointer kind.
+type nestedPointerish struct {
+	Data []byte
+}
+
+func TestIsPointerish_DetectsNestedStructField(t *testing.T) {
+	typ := reflect.TypeOf(nestedPointerish{})
+	assert.True(t, IsPointerish(typ),
+		"a struct containing a pointer-bearing field (here, a []byte) must itself be pointer-ish")
+}
+
+func TestIsPointerish_DetectsArrayOfPointerish(t *testing.T) {
+	typ := reflect.TypeOf([2]nestedPointerish{})
+	assert.True(t, IsPointerish(typ),
+		"an array of pointer-bearing elements must itself be pointer-ish")
+}
+
+func TestIsPointerish_ScalarStructIsNotPointerish(t *testing.T) {
+	type allScalar struct {
+		A int
+		B bool
+		C byte
+	}
+	assert.False(t, IsPointerish(reflect.TypeOf(allScalar{})))
+}
+
+func TestIsPointerish_DirectKinds(t *testing.T) {
+	assert.True(t, IsPointerish(reflect.TypeOf((*int)(nil))))
+	assert.True(t, IsPointerish(reflect.TypeOf("")))
+	assert.True(t, IsPointerish(reflect.TypeOf([]int(nil))))
+	assert.False(t, IsPointerish(reflect.TypeOf(0)))
+	assert.False(t, IsPointerish(reflect.TypeOf(byte(0))))
+}

--- a/pkg/goldmark/parser/delimiter.go
+++ b/pkg/goldmark/parser/delimiter.go
@@ -24,27 +24,17 @@ type DelimiterProcessor interface {
 }
 
 // A Delimiter struct represents a delimiter like '*' of the Markdown text.
+//
+// Pointer-bearing fields (PreviousDelimiter, NextDelimiter, Processor)
+// are declared before the scalar fields (Segment, CanOpen, CanClose,
+// Length, OriginalLength, Char): GC ptrdata spans through the last
+// pointer field, so this ordering keeps the scalar tail out of the
+// pointer scan. One Delimiter is allocated per emphasis-run candidate
+// in every file's inline parse. See
+// docs/development/high-performance-go.md "Group pointer fields
+// first, scalars last".
 type Delimiter struct {
 	ast.BaseInline
-
-	Segment text.Segment
-
-	// CanOpen is set true if this delimiter can open a span for a new node.
-	// See https://spec.commonmark.org/0.30/#can-open-emphasis for details.
-	CanOpen bool
-
-	// CanClose is set true if this delimiter can close a span for a new node.
-	// See https://spec.commonmark.org/0.30/#can-open-emphasis for details.
-	CanClose bool
-
-	// Length is a remaining length of this delimiter.
-	Length int
-
-	// OriginalLength is a original length of this delimiter.
-	OriginalLength int
-
-	// Char is a character of this delimiter.
-	Char byte
 
 	// PreviousDelimiter is a previous sibling delimiter node of this delimiter.
 	PreviousDelimiter *Delimiter
@@ -54,6 +44,25 @@ type Delimiter struct {
 
 	// Processor is a DelimiterProcessor associated with this delimiter.
 	Processor DelimiterProcessor
+
+	Segment text.Segment
+
+	// Length is a remaining length of this delimiter.
+	Length int
+
+	// OriginalLength is a original length of this delimiter.
+	OriginalLength int
+
+	// CanOpen is set true if this delimiter can open a span for a new node.
+	// See https://spec.commonmark.org/0.30/#can-open-emphasis for details.
+	CanOpen bool
+
+	// CanClose is set true if this delimiter can close a span for a new node.
+	// See https://spec.commonmark.org/0.30/#can-open-emphasis for details.
+	CanClose bool
+
+	// Char is a character of this delimiter.
+	Char byte
 }
 
 // Inline implements Inline.Inline.

--- a/pkg/goldmark/parser/fcode_block.go
+++ b/pkg/goldmark/parser/fcode_block.go
@@ -19,11 +19,16 @@ func NewFencedCodeBlockParser() BlockParser {
 	return defaultFencedCodeBlockParser
 }
 
+// node (a pointer-bearing interface) is declared first so the GC
+// ptrdata scan does not extend across the scalar fields that follow;
+// see docs/development/high-performance-go.md "Group pointer fields
+// first, scalars last". One instance is allocated per fenced-code-
+// block open.
 type fenceData struct {
+	node   ast.Node
 	char   byte
 	indent int
 	length int
-	node   ast.Node
 }
 
 var fencedCodeBlockInfoKey = NewContextKey()
@@ -60,7 +65,12 @@ func (b *fencedCodeBlockParser) Open(parent ast.Node, reader text.Reader, pc Con
 		}
 	}
 	node := ast.NewFencedCodeBlock(info)
-	pc.Set(fencedCodeBlockInfoKey, &fenceData{fenceChar, findent, oFenceLength, node})
+	pc.Set(fencedCodeBlockInfoKey, &fenceData{
+		node:   node,
+		char:   fenceChar,
+		indent: findent,
+		length: oFenceLength,
+	})
 	return node, NoChildren
 
 }

--- a/pkg/goldmark/parser/link.go
+++ b/pkg/goldmark/parser/link.go
@@ -11,12 +11,14 @@ import (
 
 var linkLabelStateKey = NewContextKey()
 
+// linkLabelState's pointer-bearing fields (Prev, Next, First, Last)
+// are declared before the scalar fields (Segment, IsImage) to keep
+// the GC ptrdata scan from spanning the whole struct; see
+// docs/development/high-performance-go.md "Group pointer fields
+// first, scalars last". One instance is allocated per bracket
+// candidate during every file's inline parse.
 type linkLabelState struct {
 	ast.BaseInline
-
-	Segment text.Segment
-
-	IsImage bool
 
 	Prev *linkLabelState
 
@@ -25,6 +27,10 @@ type linkLabelState struct {
 	First *linkLabelState
 
 	Last *linkLabelState
+
+	Segment text.Segment
+
+	IsImage bool
 }
 
 func newLinkLabelState(segment text.Segment, isImage bool) *linkLabelState {

--- a/pkg/goldmark/parser/structlayout_test.go
+++ b/pkg/goldmark/parser/structlayout_test.go
@@ -13,41 +13,19 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/pkg/goldmark/internal/fieldorder"
-	"github.com/stretchr/testify/assert"
 )
-
-// assertOwnFieldsPointersBeforeScalars checks that, among typ's
-// fields starting at index skip (use 1 to skip an embedded base
-// struct), no scalar (non-pointerish) field is followed by a
-// pointerish one. A pointerish field declared after a scalar field
-// extends the struct's GC ptrdata past that scalar for no reason.
-func assertOwnFieldsPointersBeforeScalars(t *testing.T, typ reflect.Type, skip int) {
-	t.Helper()
-	seenScalar := false
-	for i := skip; i < typ.NumField(); i++ {
-		f := typ.Field(i)
-		if fieldorder.IsPointerish(f.Type.Kind()) {
-			assert.Falsef(t, seenScalar,
-				"field %s (%s, pointer-ish) is declared after a scalar field; "+
-					"pointer fields should precede scalars to shrink GC ptrdata",
-				f.Name, f.Type)
-		} else {
-			seenScalar = true
-		}
-	}
-}
 
 func TestDelimiter_PointerFieldsBeforeScalars(t *testing.T) {
 	// Index 0 is the embedded ast.BaseInline; only Delimiter's own
 	// declared fields are checked here.
-	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(Delimiter{}), 1)
+	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(Delimiter{}), 1)
 }
 
 func TestLinkLabelState_PointerFieldsBeforeScalars(t *testing.T) {
-	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(linkLabelState{}), 1)
+	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(linkLabelState{}), 1)
 }
 
 func TestFenceData_PointerFieldsBeforeScalars(t *testing.T) {
 	// fenceData has no embedded base struct, so every field is checked.
-	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(fenceData{}), 0)
+	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(fenceData{}), 0)
 }

--- a/pkg/goldmark/parser/structlayout_test.go
+++ b/pkg/goldmark/parser/structlayout_test.go
@@ -1,0 +1,64 @@
+package parser
+
+// Pins the struct-layout guidance in
+// docs/development/high-performance-go.md ("Group pointer fields
+// first, scalars last — GC ptrdata spans through the last pointer
+// field") for the parser package's hottest per-token structs:
+// Delimiter (one per emphasis-run candidate in every file's inline
+// parse), linkLabelState (one per bracket candidate), and fenceData
+// (one per fenced-code-block open).
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// isPointerish reports whether a field's kind carries at least one
+// pointer word that the GC must scan (a pointer, interface, slice,
+// map, chan, func, string header, or unsafe.Pointer).
+func isPointerish(k reflect.Kind) bool {
+	switch k {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map,
+		reflect.Chan, reflect.Func, reflect.String, reflect.UnsafePointer:
+		return true
+	}
+	return false
+}
+
+// assertOwnFieldsPointersBeforeScalars checks that, among typ's
+// fields starting at index skip (use 1 to skip an embedded base
+// struct), no scalar (non-pointerish) field is followed by a
+// pointerish one. A pointerish field declared after a scalar field
+// extends the struct's GC ptrdata past that scalar for no reason.
+func assertOwnFieldsPointersBeforeScalars(t *testing.T, typ reflect.Type, skip int) {
+	t.Helper()
+	seenScalar := false
+	for i := skip; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if isPointerish(f.Type.Kind()) {
+			assert.Falsef(t, seenScalar,
+				"field %s (%s, pointer-ish) is declared after a scalar field; "+
+					"pointer fields should precede scalars to shrink GC ptrdata",
+				f.Name, f.Type)
+		} else {
+			seenScalar = true
+		}
+	}
+}
+
+func TestDelimiter_PointerFieldsBeforeScalars(t *testing.T) {
+	// Index 0 is the embedded ast.BaseInline; only Delimiter's own
+	// declared fields are checked here.
+	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(Delimiter{}), 1)
+}
+
+func TestLinkLabelState_PointerFieldsBeforeScalars(t *testing.T) {
+	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(linkLabelState{}), 1)
+}
+
+func TestFenceData_PointerFieldsBeforeScalars(t *testing.T) {
+	// fenceData has no embedded base struct, so every field is checked.
+	assertOwnFieldsPointersBeforeScalars(t, reflect.TypeOf(fenceData{}), 0)
+}

--- a/pkg/goldmark/parser/structlayout_test.go
+++ b/pkg/goldmark/parser/structlayout_test.go
@@ -12,20 +12,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jeduden/mdsmith/pkg/goldmark/internal/fieldorder"
 	"github.com/stretchr/testify/assert"
 )
-
-// isPointerish reports whether a field's kind carries at least one
-// pointer word that the GC must scan (a pointer, interface, slice,
-// map, chan, func, string header, or unsafe.Pointer).
-func isPointerish(k reflect.Kind) bool {
-	switch k {
-	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map,
-		reflect.Chan, reflect.Func, reflect.String, reflect.UnsafePointer:
-		return true
-	}
-	return false
-}
 
 // assertOwnFieldsPointersBeforeScalars checks that, among typ's
 // fields starting at index skip (use 1 to skip an embedded base
@@ -37,7 +26,7 @@ func assertOwnFieldsPointersBeforeScalars(t *testing.T, typ reflect.Type, skip i
 	seenScalar := false
 	for i := skip; i < typ.NumField(); i++ {
 		f := typ.Field(i)
-		if isPointerish(f.Type.Kind()) {
+		if fieldorder.IsPointerish(f.Type.Kind()) {
 			assert.Falsef(t, seenScalar,
 				"field %s (%s, pointer-ish) is declared after a scalar field; "+
 					"pointer fields should precede scalars to shrink GC ptrdata",

--- a/pkg/markdown/flavor/feature.go
+++ b/pkg/markdown/flavor/feature.go
@@ -150,11 +150,12 @@ var support = [flavorCount][featureCount]bool{
 }
 
 // Supports reports whether the flavor accepts the given feature.
-// FlavorAny accepts every feature; other flavors consult the support
-// table. An f or feat outside the declared enum range (pkg/markdown
-// is a public package, so a caller-supplied value is not guaranteed
-// in range) returns false rather than panicking on an out-of-bounds
-// array index — the same behavior a map's missing-key lookup gave.
+// FlavorAny is special-cased to accept every feature and never
+// reaches the bounds check below. For every other f, an f or feat
+// outside the declared enum range (pkg/markdown is a public package,
+// so a caller-supplied value is not guaranteed in range) returns
+// false rather than panicking on an out-of-bounds array index — the
+// same behavior a map's missing-key lookup gave.
 func Supports(f Flavor, feat Feature) bool {
 	if f == FlavorAny {
 		return true

--- a/pkg/markdown/flavor/feature.go
+++ b/pkg/markdown/flavor/feature.go
@@ -73,13 +73,28 @@ func (f Feature) Name() string {
 	return ""
 }
 
-// support maps (flavor, feature) to whether the flavor accepts it.
+// flavorCount and featureCount size the support table below: one
+// slot per declared Flavor / Feature constant, indexed directly by
+// the enum's underlying int.
+const (
+	flavorCount  = FlavorMyST + 1
+	featureCount = FeatureGitHubAlerts + 1
+)
+
+// support indexes (flavor, feature) to whether the flavor accepts it.
 // CommonMark rejects every tracked feature. GFM adds tables, task
 // lists, strikethrough, and bare-URL autolinks. The goldmark flavor
 // further adds heading IDs. Pandoc, PHP Markdown Extra, MultiMarkdown,
 // and MyST each pick a different combination of the optional
 // features; FlavorAny is handled specially in Supports.
-var support = map[Flavor]map[Feature]bool{
+//
+// A flat array instead of map[Flavor]map[Feature]bool: both Flavor
+// and Feature are small dense int enums, so direct indexing removes
+// two map-indirection lookups from every Supports call (Supports runs
+// per candidate AST node during flavor detection — see
+// docs/development/high-performance-go.md's "Sorted slice + binary
+// search beats a map for n < ~100" and small-fixed-set guidance).
+var support = [flavorCount][featureCount]bool{
 	FlavorGFM: {
 		FeatureTables:           true,
 		FeatureTaskLists:        true,
@@ -136,10 +151,16 @@ var support = map[Flavor]map[Feature]bool{
 
 // Supports reports whether the flavor accepts the given feature.
 // FlavorAny accepts every feature; other flavors consult the support
-// table.
+// table. An f or feat outside the declared enum range (pkg/markdown
+// is a public package, so a caller-supplied value is not guaranteed
+// in range) returns false rather than panicking on an out-of-bounds
+// array index — the same behavior a map's missing-key lookup gave.
 func Supports(f Flavor, feat Feature) bool {
 	if f == FlavorAny {
 		return true
+	}
+	if f < 0 || f >= flavorCount || feat < 0 || feat >= featureCount {
+		return false
 	}
 	return support[f][feat]
 }

--- a/pkg/markdown/flavor/feature_test.go
+++ b/pkg/markdown/flavor/feature_test.go
@@ -89,8 +89,15 @@ func TestAllFeaturesComplete(t *testing.T) {
 // search beats a map for n < ~100" / small fixed-set guidance.
 func TestSupportTable_IsArrayNotMap(t *testing.T) {
 	typ := reflect.TypeOf(support)
-	assert.Equal(t, reflect.Array, typ.Kind(),
+	require.Equal(t, reflect.Array, typ.Kind(),
 		"support table should be a flat array, not a nested map")
+	// Pin the element type too: a regression to [flavorCount]map[Feature]bool
+	// would still satisfy the outer Array check above while reintroducing a
+	// per-call map lookup for every row.
+	require.Equal(t, reflect.Array, typ.Elem().Kind(),
+		"support table's rows should be arrays, not maps")
+	assert.Equal(t, reflect.Bool, typ.Elem().Elem().Kind(),
+		"support table should hold bool values directly, not through another indirection")
 }
 
 // TestSupports_OutOfRangeReturnsFalse pins Supports' documented

--- a/pkg/markdown/flavor/feature_test.go
+++ b/pkg/markdown/flavor/feature_test.go
@@ -117,14 +117,21 @@ func TestFeatureCount_MatchesAllFeatures(t *testing.T) {
 	assert.Equal(t, len(AllFeatures()), int(featureCount))
 }
 
+// flavorScanSlack is how far past the last declared Flavor constant
+// TestFlavorCount_CoversEveryValidFlavor scans. New Flavor constants
+// are added one (or a small handful) at a time, so a slack of 10
+// comfortably catches the next one added without a matching
+// flavorCount bump; it is not tied to any specific count.
+const flavorScanSlack = 10
+
 // TestFlavorCount_CoversEveryValidFlavor pins flavorCount against
 // every Flavor value Flavor.String (and so IsValid) recognises — the
-// Flavor equivalent of TestFeatureCount_MatchesAllFeatures. Scans a
-// generous range past the last declared constant so a newly added
-// Flavor with no matching flavorCount bump fails this test instead of
-// silently losing its row in the support table.
+// Flavor equivalent of TestFeatureCount_MatchesAllFeatures. Scans past
+// the last declared constant so a newly added Flavor with no matching
+// flavorCount bump fails this test instead of silently losing its row
+// in the support table.
 func TestFlavorCount_CoversEveryValidFlavor(t *testing.T) {
-	for f := Flavor(0); f <= FlavorMyST+10; f++ {
+	for f := Flavor(0); f <= FlavorMyST+flavorScanSlack; f++ {
 		if f.IsValid() {
 			assert.Lessf(t, int(f), flavorCount,
 				"flavor %s (%d) is valid but falls outside the support table bounds", f, int(f))

--- a/pkg/markdown/flavor/feature_test.go
+++ b/pkg/markdown/flavor/feature_test.go
@@ -1,6 +1,7 @@
 package flavor
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,6 +79,31 @@ func TestFeatureSupportMyST(t *testing.T) {
 func TestAllFeaturesComplete(t *testing.T) {
 	// Ensure AllFeatures enumerates exactly the 13 features we track.
 	require.Len(t, AllFeatures(), 13)
+}
+
+// TestSupportTable_IsArrayNotMap pins the (Flavor, Feature) support
+// table as a flat array rather than a map[Flavor]map[Feature]bool.
+// Both types are small dense int enums, so a 2D array removes two
+// map-indirection lookups per Supports call per
+// docs/development/high-performance-go.md "Sorted slice + binary
+// search beats a map for n < ~100" / small fixed-set guidance.
+func TestSupportTable_IsArrayNotMap(t *testing.T) {
+	typ := reflect.TypeOf(support)
+	assert.Equal(t, reflect.Array, typ.Kind(),
+		"support table should be a flat array, not a nested map")
+}
+
+// TestSupports_OutOfRangeReturnsFalse pins Supports' documented
+// contract for an unrecognised Flavor or Feature: false, not a panic
+// — the same behavior the map-based implementation gave for a missing
+// key. pkg/markdown is a public package (see
+// docs/development/markdown-library.md), so an out-of-range caller
+// value must degrade gracefully rather than index out of bounds.
+func TestSupports_OutOfRangeReturnsFalse(t *testing.T) {
+	assert.False(t, Supports(Flavor(999), FeatureTables))
+	assert.False(t, Supports(FlavorGFM, Feature(999)))
+	assert.False(t, Supports(Flavor(-1), FeatureTables))
+	assert.False(t, Supports(FlavorGFM, Feature(-1)))
 }
 
 func TestFeatureName(t *testing.T) {

--- a/pkg/markdown/flavor/feature_test.go
+++ b/pkg/markdown/flavor/feature_test.go
@@ -106,6 +106,32 @@ func TestSupports_OutOfRangeReturnsFalse(t *testing.T) {
 	assert.False(t, Supports(FlavorGFM, Feature(-1)))
 }
 
+// TestFeatureCount_MatchesAllFeatures pins featureCount (sizing the
+// support array) against the actual number of declared Feature
+// constants. featureCount = FeatureGitHubAlerts + 1 is a "last enum
+// value" idiom: adding a new Feature constant without also touching
+// this line would silently undersize the array, and every flavor
+// would report false for the new feature with no compile error. This
+// test fails the moment that drift happens.
+func TestFeatureCount_MatchesAllFeatures(t *testing.T) {
+	assert.Equal(t, len(AllFeatures()), int(featureCount))
+}
+
+// TestFlavorCount_CoversEveryValidFlavor pins flavorCount against
+// every Flavor value Flavor.String (and so IsValid) recognises — the
+// Flavor equivalent of TestFeatureCount_MatchesAllFeatures. Scans a
+// generous range past the last declared constant so a newly added
+// Flavor with no matching flavorCount bump fails this test instead of
+// silently losing its row in the support table.
+func TestFlavorCount_CoversEveryValidFlavor(t *testing.T) {
+	for f := Flavor(0); f <= FlavorMyST+10; f++ {
+		if f.IsValid() {
+			assert.Lessf(t, int(f), flavorCount,
+				"flavor %s (%d) is valid but falls outside the support table bounds", f, int(f))
+		}
+	}
+}
+
 func TestFeatureName(t *testing.T) {
 	assert.Equal(t, "tables", FeatureTables.Name())
 	assert.Equal(t, "task lists", FeatureTaskLists.Name())


### PR DESCRIPTION
## Summary

An audit against [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md) (using a team of exploration agents covering allocations/regexp, data-structure/struct-layout, and memoization/concurrency anti-patterns) surfaced a ranked list of violations. Several strong candidates were already tracked by existing plans with deliberate grandfathered debt (`plan/195` for `tableformat`'s double table-parse, `plan/2606130838` for `crossfilereferenceintegrity`'s 12-alloc budget, `plan/189` for the AST-walk migration, which explicitly excludes MDS003/MDS005/MDS059/MDS065 as stateful passes) — those were left alone to avoid duplicating or contradicting in-flight work.

The five fixes below are fresh, safe, and each independently testable:

1. **`internal/rules/astutil`**: memoize `CollectSectionHeadings` via `f.MemoFile`, mirroring the already-memoized `CollectSectionParagraphs` in the same file. MDS057 and MDS058 each re-walked the AST from scratch; now the walk is shared.
2. **`internal/rules/build`**: `warnUnknownParams`'s per-directive `known` set and the package-level `reservedDeviceNames` set used `map[string]bool` for membership-only checks. Converted to `map[string]struct{}` per the "zero-byte value type" guidance, reading through the existing `internal/setutil.Contains` helper.
3. **`pkg/markdown/flavor`**: replaced the `map[Flavor]map[Feature]bool` support table (consulted once per candidate AST node during flavor detection) with a flat `[flavorCount][featureCount]bool` array, removing two map indirections per call. `Supports` keeps its "false for an out-of-range value" contract (this is a public package) via an explicit bounds check, and two new regression tests pin `flavorCount`/`featureCount` against the real enum surface so a future constant added without updating them fails a test instead of silently losing its row.
4. **`pkg/goldmark/parser` and `pkg/goldmark/ast`**: reordered `Delimiter`, `linkLabelState`, `fenceData`, and `AutoLink` so pointer/interface fields precede scalar fields. GC ptrdata spans through the last pointer field, so the previous ordering forced the GC to scan scalar tails on every one of these hot per-token structs (allocated per emphasis-run, per bracket candidate, per fenced-code-block, and per autolink in every file's inline parse). The reflection-based layout tests share one helper (`pkg/goldmark/internal/fieldorder`) instead of duplicating it per package.
5. **`internal/rules/duplicatedcontent`**: MDS037's `buildCorpusIndex` re-read, re-parsed, and re-fingerprinted every sibling markdown file from scratch on *every* host file's `Check` call — O(N²) file parses across a workspace of N files. Now memoized on the engine's `RunCache`, keyed by absolute path + `min-chars`, mirroring the `crossfilereferenceintegrity`/`RunCache.Anchors` precedent. `RunCache.Invalidate(absPath)` (already wired to the LSP's per-edit lifecycle) evicts the right slots with no new LSP plumbing. The settings threaded through the corpus-scan helpers are bundled into one `corpusScanConfig` struct, matching the pattern sibling cross-file rules already use for grouped scan state.

Each fix follows red/green TDD: a failing test first (an allocation/behavior/struct-layout assertion), then the minimal change to pass it. Full details and reasoning are in each commit message.

This PR went through three rounds of `xhigh`-severity code review (24 finder agents total across the three rounds). Round 1 surfaced cleanup-tier findings — a Codecov coverage gap in the RunCache front-matter-offset path, an unhoisted cache-key allocation, a duplicated test helper across two goldmark packages, and an unenforced enum-count invariant in the flavor support table — all fixed in follow-up commits. Round 2 caught that the test-helper dedup was incomplete and that the corpus-scan helpers' parameter lists had grown unwieldy across the fixes; both addressed. Round 3 found no further issues.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run` (0 issues)
- [x] `go run ./cmd/mdsmith check .` (531 files checked, 0 failures)
- [x] Each fix verified as a genuine red→green pair (confirmed via `git stash` that the new test fails against the pre-fix code)
- [x] All 31 CI checks green (build, test, bench, lint, CodeQL, WASM, LSP, VS Code extension, Obsidian plugin, coverage gate)
- [x] Three rounds of `xhigh` code review (24 finder agents), all findings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJTrn4DizYTMdYj4tbswVJ