### PR TITLE
plan: extractable per-file metrics (readability) with YAML output

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -243,5 +243,5 @@ footer: |
 | 2607051918 | 🔲     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
 | 2607051919 | 🔲     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
 | 2607051920 | 🔲     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
-| 2607071642 | 🔲     | sonnet | [Extractable per-file metrics (readability first) with YAML output](plan/2607071642_extractable-file-metrics.md)                                        |
+| 2607071642 | 🔲     | sonnet | [Single-file metric extraction via `mdsmith metrics get` (readability first)](plan/2607071642_extractable-file-metrics.md)                              |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -243,4 +243,5 @@ footer: |
 | 2607051918 | 🔲     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
 | 2607051919 | 🔲     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
 | 2607051920 | 🔲     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
+| 2607071642 | 🔲     | sonnet | [Extractable per-file metrics (readability first) with YAML output](plan/2607071642_extractable-file-metrics.md)                                        |
 <?/catalog?>

--- a/plan/2607071642_extractable-file-metrics.md
+++ b/plan/2607071642_extractable-file-metrics.md
@@ -87,13 +87,16 @@ file and emits a single object, not an array — the shape a
 single-document read wants. It reuses `metrics.Collect` with a
 one-path slice and the existing `JSONValue` conversion.
 
-- By default it emits every registered file-scope metric, since a
-  single-file read has no column-bloat concern. So `readability`
-  appears with no flag.
-- `--metrics a,b` narrows to a subset.
-- `-f json|yaml|text` picks the format. Text is an aligned
-  `name  value` table.
-- Exactly one file argument; zero or many is a usage error.
+- It emits every registered file-scope metric. There is no metric
+  selector: a single-file read has no column-bloat concern, and a
+  reader narrows downstream with `jq` or `yq` — exactly as
+  [`mdsmith extract`][extractdoc] emits its whole projection. So
+  `readability` appears with no flag, and the surface stays as
+  small as `extract`'s.
+- `-f json|yaml|text` picks the format, the same short and long
+  flag `extract` uses. Text is an aligned `name  value` table.
+- Exactly one positional file, like `extract` / `export` / `deps`.
+  Zero or many is a usage error.
 
 **Add the `yaml` format.** `get`, `rank`, and `list` all accept
 `yaml`. Encode the same map the json path builds, through the
@@ -101,27 +104,31 @@ shared YAML encoder that [`mdsmith extract`][extractdoc] uses, so
 json and yaml stay structurally identical. Each `unknown format`
 message reads `text, json, yaml`.
 
+## CLI design
+
+Every choice above is derived from an existing command, not
+invented, so the surface stays predictable. The rules:
+
+- **Match the grammar.** `mdsmith`'s single-file emitters —
+  `extract`, `export`, `deps` — take a positional `<file>` and,
+  for data, `-f/--format`. `get` copies that exactly.
+- **Least surprise.** `get` adds no flag that a neighbour command
+  does not already have. It has no metric selector because
+  `extract` has no field selector; filtering is a downstream
+  `jq`/`yq` job. `rank` keeps `--metrics` because it alone needs
+  it (columns and the `--by` sort key across many files).
+- **One direction per stream.** Data to stdout, errors to stderr,
+  exit `0` on success and `2` on a usage or runtime error, as the
+  other emitters do.
+- **Discoverable.** `mdsmith help metrics` and the usage text name
+  `get`, its one argument, and its formats.
+- **Proven by running it.** Acceptance runs `metrics get` on a
+  real repo file and checks the printed object, not just the
+  tests.
+
 ## Example output
 
-Reading one file's readability score as JSON:
-
-```console
-$ mdsmith metrics get --metrics readability -f json README.md
-{
-  "path": "README.md",
-  "readability": 11.2
-}
-```
-
-The same query as YAML:
-
-```console
-$ mdsmith metrics get --metrics readability -f yaml README.md
-path: README.md
-readability: 11.2
-```
-
-With no `--metrics`, every registered metric is emitted:
+One file's metrics as a single YAML object:
 
 ```console
 $ mdsmith metrics get -f yaml docs/guides/install.md
@@ -137,13 +144,36 @@ sentences: 148
 avg-words-per-sentence: 14.6
 ```
 
+The same file as JSON:
+
+```console
+$ mdsmith metrics get -f json README.md
+{
+  "path": "README.md",
+  "bytes": 4096,
+  ...
+  "readability": 11.2
+}
+```
+
+Just the readability score is a downstream filter, as with
+`extract`:
+
+```console
+$ mdsmith metrics get -f json README.md | jq .readability
+11.2
+```
+
 The text format is an aligned table:
 
 ```console
-$ mdsmith metrics get --metrics readability,sentences README.md
-NAME         VALUE
-readability  11.2
-sentences    96
+$ mdsmith metrics get README.md
+NAME                    VALUE
+bytes                   4096
+...
+readability             11.2
+sentences               96
+avg-words-per-sentence  14.2
 ```
 
 An unavailable value (an unreadable or empty file) prints `null`
@@ -160,29 +190,32 @@ behavior.
    test covers the value on a known fixture.
 3. Add MET009 `sentences` and MET010 `avg-words-per-sentence`
    with their READMEs and registry tests.
-4. Add the `metrics get` subcommand: flag parsing (one file,
-   `--metrics`, `-f`), single-object json/yaml/text writers, and
-   unit tests. Route it from `runMetrics` beside `list` and
-   `rank`.
+4. Add the `metrics get` subcommand: parse exactly one positional
+   file and `-f`, emit single-object json/yaml/text writers, and
+   unit tests including the zero-and-many-argument usage errors.
+   Route it from `runMetrics` beside `list` and `rank`, and name
+   it in the `metrics` usage text and `mdsmith help metrics`.
 5. Add the `yaml` format to `get`, `rank`, and `list`. Extend the
    format switches, the `unknown format` errors, and the unit
    tests ([`metrics_unit_test.go`][mtest]). Assert json and yaml
    agree structurally.
 6. Add [`docs/reference/cli/metrics.md`][rankdoc] coverage for
-   `get` (flags, an example) and the new metrics. Update
-   [`docs/guides/metrics-tradeoffs.md`][tradeoffs]. Regenerate the
-   `CLAUDE.md` and `PLAN.md` catalogs with `mdsmith fix`.
+   `get` (its one argument, its formats, an example) and the new
+   metrics. Update [`docs/guides/metrics-tradeoffs.md`][tradeoffs].
+   Regenerate the `CLAUDE.md` and `PLAN.md` catalogs with
+   `mdsmith fix`.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith metrics get --metrics readability -f json FILE`
-      prints a single JSON object with the file's ARI score under
-      a `readability` key — an object, not an array.
-- [ ] `mdsmith metrics get -f yaml FILE` prints every registered
-      metric as a YAML mapping; a test pins json and yaml
-      together.
+- [ ] `mdsmith metrics get -f json FILE` prints a single JSON
+      object (not an array) carrying every registered metric,
+      including the file's ARI score under a `readability` key.
+- [ ] `mdsmith metrics get -f yaml FILE` prints the same values as
+      a YAML mapping; a test pins json and yaml together.
 - [ ] `mdsmith metrics get` with zero or two file arguments is a
-      usage error.
+      usage error; the command takes no metric-selector flag.
+- [ ] Running `mdsmith metrics get` on a real repo file (dogfood,
+      not only unit tests) prints the expected object.
 - [ ] `mdsmith metrics list` shows `readability`, `sentences`,
       and `avg-words-per-sentence`; none appears in a
       no-`--metrics` `rank` run.

--- a/plan/2607071642_extractable-file-metrics.md
+++ b/plan/2607071642_extractable-file-metrics.md
@@ -1,25 +1,24 @@
 ---
 id: 2607071642
-title: Extractable per-file metrics (readability first) with YAML output
+title: Single-file metric extraction via `mdsmith metrics get` (readability first)
 status: "🔲"
 summary: >-
-  Make per-file Markdown measurements extractable as structured
-  data: add a readability metric (Automated Readability Index over
-  the file's plain text) plus sentence-count and
-  words-per-sentence metrics, teach `mdsmith metrics rank` and
-  `metrics list` a `yaml` output format alongside `json`, and move
-  the ARI formula into `internal/mdtext` so the metrics package
-  never imports a rule package.
+  Add a `mdsmith metrics get <file>` command that emits one file's
+  metrics as a single JSON or YAML object, add a readability metric
+  (Automated Readability Index over the file's plain text) plus
+  sentence-count and words-per-sentence metrics, and move the ARI
+  formula into `internal/mdtext` so the metrics package never
+  imports a rule package.
 model: sonnet
 depends-on: []
 ---
-# Extractable per-file metrics (readability first) with YAML output
+# Single-file metric extraction via `mdsmith metrics get`
 
 ## Goal
 
 Let a caller read one file's readability score as JSON or YAML
-from a single command. Make the next metric cheap to add: one
-registry entry plus a README.
+from a command built for a single file. Make the next metric cheap
+to add: one registry entry plus a README.
 
 ## Context
 
@@ -33,12 +32,17 @@ The data-shaped subsystem is [`internal/metrics`][metrics]. It is
 a registry of file-scope metrics. The current set is MET001 bytes,
 MET002 lines, MET003 words, MET004 headings, MET005
 token-estimate, and MET006 conciseness.
-[`mdsmith metrics rank`][rankdoc] computes them and prints them.
 
-Two gaps block the request. First, no metric reports readability.
-Second, `metrics rank` and `metrics list` print only `text` and
-`json`. There is no `yaml`. Yet [`mdsmith extract`][extractdoc]
-already offers both json and yaml.
+The only command that emits them is
+[`mdsmith metrics rank`][rankdoc]. Rank is a cross-file ordering.
+It sorts many files by a metric and prints a JSON array. Asking it
+for one file is a category error: ranking a single document is
+meaningless, and the output is a one-element array a caller must
+unwrap. There is no command that reads one file's metrics.
+
+Two more gaps block the request. No metric reports readability.
+And no metrics command prints `yaml`, though
+[`mdsmith extract`][extractdoc] already offers both json and yaml.
 
 MET007 is reserved by plan [2607022119][wordfreq]. So this plan
 takes MET008 onward.
@@ -51,7 +55,8 @@ sentence, and character counters already live there.
 
 ## Design
 
-Three parts: move the formula, add metrics, add the format.
+Four parts: move the formula, add metrics, add the command, add
+the format.
 
 **Move ARI into `mdtext`.** Add `mdtext.ARI(text string) float64`
 holding the current formula and returning zero on zero words. The
@@ -72,77 +77,78 @@ Document's cached `PlainText()`:
 - MET010 `avg-words-per-sentence` — words over sentences, or zero
   with no sentences. Float, precision 1, `desc`.
 
-All three ship `Default: false`. So the default `metrics rank`
-table keeps its six columns. A caller opts in with
-`--metrics readability`. They still show in `metrics list`, which
-lists every registered metric.
+The three ship `Default: false` so the default `rank` table keeps
+its six columns. That flag governs `rank` only. `metrics get` and
+`metrics list` show every registered metric.
 
-**Add the `yaml` format.** Extend `writeRankOutput` and the
-`metrics list` switch to accept `yaml`. Encode the same map the
-json path builds. Use the shared YAML encoder that
-[`mdsmith extract`][extractdoc] uses. So json and yaml stay
-structurally identical. Update the two `unknown format` messages
-to read `text, json, yaml`.
+**Add `metrics get`.** A new subcommand for one file:
+`mdsmith metrics get [flags] <file>`. It computes metrics for that
+file and emits a single object, not an array — the shape a
+single-document read wants. It reuses `metrics.Collect` with a
+one-path slice and the existing `JSONValue` conversion.
 
-**Single-file usage.** `mdsmith metrics rank <file> -f yaml`
-already targets one file, and its output is a one-element list, so
-a reader takes `.[0].readability`. A single-file object view is
-out of scope here; the list shape stays consistent and pipeable,
-and it is noted as a possible follow-up.
+- By default it emits every registered file-scope metric, since a
+  single-file read has no column-bloat concern. So `readability`
+  appears with no flag.
+- `--metrics a,b` narrows to a subset.
+- `-f json|yaml|text` picks the format. Text is an aligned
+  `name  value` table.
+- Exactly one file argument; zero or many is a usage error.
+
+**Add the `yaml` format.** `get`, `rank`, and `list` all accept
+`yaml`. Encode the same map the json path builds, through the
+shared YAML encoder that [`mdsmith extract`][extractdoc] uses, so
+json and yaml stay structurally identical. Each `unknown format`
+message reads `text, json, yaml`.
 
 ## Example output
 
 Reading one file's readability score as JSON:
 
 ```console
-$ mdsmith metrics rank --metrics readability -f json README.md
-[
-  {
-    "path": "README.md",
-    "readability": 11.2
-  }
-]
+$ mdsmith metrics get --metrics readability -f json README.md
+{
+  "path": "README.md",
+  "readability": 11.2
+}
 ```
 
 The same query as YAML:
 
 ```console
-$ mdsmith metrics rank --metrics readability -f yaml README.md
-- path: README.md
-  readability: 11.2
+$ mdsmith metrics get --metrics readability -f yaml README.md
+path: README.md
+readability: 11.2
 ```
 
-Several new metrics at once, ranked by readability:
+With no `--metrics`, every registered metric is emitted:
 
 ```console
-$ mdsmith metrics rank \
-    --metrics readability,sentences,avg-words-per-sentence \
-    --by readability -f json docs/guides/install.md
-[
-  {
-    "path": "docs/guides/install.md",
-    "readability": 9.4,
-    "sentences": 148,
-    "avg-words-per-sentence": 14.6
-  }
-]
+$ mdsmith metrics get -f yaml docs/guides/install.md
+path: docs/guides/install.md
+bytes: 5120
+lines: 132
+words: 812
+headings: 14
+token-estimate: 609
+conciseness: 71.5
+readability: 9.4
+sentences: 148
+avg-words-per-sentence: 14.6
 ```
 
-`mdsmith metrics list` gains the three rows (opt-in, so
-`DEFAULT` is `false`):
+The text format is an aligned table:
 
 ```console
-$ mdsmith metrics list
-ID      NAME                    SCOPE  ORDER  DEFAULT  DESCRIPTION
-...
-MET008  readability             file   desc   false    Automated Readability Index ...
-MET009  sentences               file   desc   false    Sentence count ...
-MET010  avg-words-per-sentence  file   desc   false    Mean words per sentence ...
+$ mdsmith metrics get --metrics readability,sentences README.md
+NAME         VALUE
+readability  11.2
+sentences    96
 ```
 
-A single unavailable value (an unreadable or empty file) prints
-`null` in json and yaml and `-` in text, matching the current
-metrics behavior.
+An unavailable value (an unreadable or empty file) prints `null`
+in json and yaml and `-` in text, matching the current metrics
+behavior.
 
 ## Tasks
 
@@ -154,22 +160,29 @@ metrics behavior.
    test covers the value on a known fixture.
 3. Add MET009 `sentences` and MET010 `avg-words-per-sentence`
    with their READMEs and registry tests.
-4. Add the `yaml` format to `metrics rank` and `metrics list`.
-   Extend the format switches, the `unknown format` errors, and
-   the unit tests ([`metrics_unit_test.go`][mtest]). Assert json
-   and yaml agree structurally.
-5. Update [`docs/reference/cli/metrics.md`][rankdoc]: the format
-   flags, the metric list, a readability example. Update
+4. Add the `metrics get` subcommand: flag parsing (one file,
+   `--metrics`, `-f`), single-object json/yaml/text writers, and
+   unit tests. Route it from `runMetrics` beside `list` and
+   `rank`.
+5. Add the `yaml` format to `get`, `rank`, and `list`. Extend the
+   format switches, the `unknown format` errors, and the unit
+   tests ([`metrics_unit_test.go`][mtest]). Assert json and yaml
+   agree structurally.
+6. Add [`docs/reference/cli/metrics.md`][rankdoc] coverage for
+   `get` (flags, an example) and the new metrics. Update
    [`docs/guides/metrics-tradeoffs.md`][tradeoffs]. Regenerate the
    `CLAUDE.md` and `PLAN.md` catalogs with `mdsmith fix`.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith metrics rank --metrics readability -f json FILE`
-      prints the file's ARI score under a `readability` key.
-- [ ] `mdsmith metrics rank --metrics readability -f yaml FILE`
-      prints the same value as YAML; a test pins json and yaml
+- [ ] `mdsmith metrics get --metrics readability -f json FILE`
+      prints a single JSON object with the file's ARI score under
+      a `readability` key — an object, not an array.
+- [ ] `mdsmith metrics get -f yaml FILE` prints every registered
+      metric as a YAML mapping; a test pins json and yaml
       together.
+- [ ] `mdsmith metrics get` with zero or two file arguments is a
+      usage error.
 - [ ] `mdsmith metrics list` shows `readability`, `sentences`,
       and `avg-words-per-sentence`; none appears in a
       no-`--metrics` `rank` run.

--- a/plan/2607071642_extractable-file-metrics.md
+++ b/plan/2607071642_extractable-file-metrics.md
@@ -90,6 +90,60 @@ a reader takes `.[0].readability`. A single-file object view is
 out of scope here; the list shape stays consistent and pipeable,
 and it is noted as a possible follow-up.
 
+## Example output
+
+Reading one file's readability score as JSON:
+
+```console
+$ mdsmith metrics rank --metrics readability -f json README.md
+[
+  {
+    "path": "README.md",
+    "readability": 11.2
+  }
+]
+```
+
+The same query as YAML:
+
+```console
+$ mdsmith metrics rank --metrics readability -f yaml README.md
+- path: README.md
+  readability: 11.2
+```
+
+Several new metrics at once, ranked by readability:
+
+```console
+$ mdsmith metrics rank \
+    --metrics readability,sentences,avg-words-per-sentence \
+    --by readability -f json docs/guides/install.md
+[
+  {
+    "path": "docs/guides/install.md",
+    "readability": 9.4,
+    "sentences": 148,
+    "avg-words-per-sentence": 14.6
+  }
+]
+```
+
+`mdsmith metrics list` gains the three rows (opt-in, so
+`DEFAULT` is `false`):
+
+```console
+$ mdsmith metrics list
+ID      NAME                    SCOPE  ORDER  DEFAULT  DESCRIPTION
+...
+MET008  readability             file   desc   false    Automated Readability Index ...
+MET009  sentences               file   desc   false    Sentence count ...
+MET010  avg-words-per-sentence  file   desc   false    Mean words per sentence ...
+```
+
+A single unavailable value (an unreadable or empty file) prints
+`null` in json and yaml and `-` in text, matching the current
+metrics behavior.
+
 ## Tasks
 
 1. Add `mdtext.ARI` with a unit test. Rewrite

--- a/plan/2607071642_extractable-file-metrics.md
+++ b/plan/2607071642_extractable-file-metrics.md
@@ -1,0 +1,138 @@
+---
+id: 2607071642
+title: Extractable per-file metrics (readability first) with YAML output
+status: "🔲"
+summary: >-
+  Make per-file Markdown measurements extractable as structured
+  data: add a readability metric (Automated Readability Index over
+  the file's plain text) plus sentence-count and
+  words-per-sentence metrics, teach `mdsmith metrics rank` and
+  `metrics list` a `yaml` output format alongside `json`, and move
+  the ARI formula into `internal/mdtext` so the metrics package
+  never imports a rule package.
+model: sonnet
+depends-on: []
+---
+# Extractable per-file metrics (readability first) with YAML output
+
+## Goal
+
+Let a caller read one file's readability score as JSON or YAML
+from a single command. Make the next metric cheap to add: one
+registry entry plus a README.
+
+## Context
+
+Today the readability number lives inside a lint rule,
+[MDS023 paragraph-readability][mds023]. That rule scores each
+paragraph with the Automated Readability Index (ARI). It emits a
+pass or fail against `max-index`. The raw score is never returned
+as data.
+
+The data-shaped subsystem is [`internal/metrics`][metrics]. It is
+a registry of file-scope metrics. The current set is MET001 bytes,
+MET002 lines, MET003 words, MET004 headings, MET005
+token-estimate, and MET006 conciseness.
+[`mdsmith metrics rank`][rankdoc] computes them and prints them.
+
+Two gaps block the request. First, no metric reports readability.
+Second, `metrics rank` and `metrics list` print only `text` and
+`json`. There is no `yaml`. Yet [`mdsmith extract`][extractdoc]
+already offers both json and yaml.
+
+MET007 is reserved by plan [2607022119][wordfreq]. So this plan
+takes MET008 onward.
+
+The ARI formula sits in
+[`readability.go`][ari]. It depends only on `internal/mdtext`
+counters. A metric must not import a rule package. Metrics is a
+lower layer. So the formula moves down into `mdtext`. Its word,
+sentence, and character counters already live there.
+
+## Design
+
+Three parts: move the formula, add metrics, add the format.
+
+**Move ARI into `mdtext`.** Add `mdtext.ARI(text string) float64`
+holding the current formula and returning zero on zero words. The
+rule's `ARI` becomes a thin delegate, so `IndexFunc` still works
+and every MDS023 test still passes. This is the clean-architecture
+step: afterward `internal/metrics` depends on `mdtext`, not on a
+rule.
+
+**Add the metrics.** Three registry entries. Each gets a
+`MET###-<name>/README.md` that mirrors MET006. Each reads the
+Document's cached `PlainText()`:
+
+- MET008 `readability` — `mdtext.ARI(text)`. Float, precision 1,
+  default order `desc`. Higher means harder to read. It is an
+  approximate US grade level.
+- MET009 `sentences` — `mdtext.CountSentences(text)`. Integer,
+  `desc`.
+- MET010 `avg-words-per-sentence` — words over sentences, or zero
+  with no sentences. Float, precision 1, `desc`.
+
+All three ship `Default: false`. So the default `metrics rank`
+table keeps its six columns. A caller opts in with
+`--metrics readability`. They still show in `metrics list`, which
+lists every registered metric.
+
+**Add the `yaml` format.** Extend `writeRankOutput` and the
+`metrics list` switch to accept `yaml`. Encode the same map the
+json path builds. Use the shared YAML encoder that
+[`mdsmith extract`][extractdoc] uses. So json and yaml stay
+structurally identical. Update the two `unknown format` messages
+to read `text, json, yaml`.
+
+**Single-file usage.** `mdsmith metrics rank <file> -f yaml`
+already targets one file, and its output is a one-element list, so
+a reader takes `.[0].readability`. A single-file object view is
+out of scope here; the list shape stays consistent and pipeable,
+and it is noted as a possible follow-up.
+
+## Tasks
+
+1. Add `mdtext.ARI` with a unit test. Rewrite
+   `paragraphreadability.ARI` to delegate. Confirm the MDS023
+   tests and the alloc budget still pass (red/green).
+2. Add MET008 `readability` to the registry. Add its
+   `internal/metrics/MET008-readability/README.md`. A registry
+   test covers the value on a known fixture.
+3. Add MET009 `sentences` and MET010 `avg-words-per-sentence`
+   with their READMEs and registry tests.
+4. Add the `yaml` format to `metrics rank` and `metrics list`.
+   Extend the format switches, the `unknown format` errors, and
+   the unit tests ([`metrics_unit_test.go`][mtest]). Assert json
+   and yaml agree structurally.
+5. Update [`docs/reference/cli/metrics.md`][rankdoc]: the format
+   flags, the metric list, a readability example. Update
+   [`docs/guides/metrics-tradeoffs.md`][tradeoffs]. Regenerate the
+   `CLAUDE.md` and `PLAN.md` catalogs with `mdsmith fix`.
+
+## Acceptance Criteria
+
+- [ ] `mdsmith metrics rank --metrics readability -f json FILE`
+      prints the file's ARI score under a `readability` key.
+- [ ] `mdsmith metrics rank --metrics readability -f yaml FILE`
+      prints the same value as YAML; a test pins json and yaml
+      together.
+- [ ] `mdsmith metrics list` shows `readability`, `sentences`,
+      and `avg-words-per-sentence`; none appears in a
+      no-`--metrics` `rank` run.
+- [ ] `internal/metrics` imports `mdtext` for ARI and no rule
+      package (a test or the import audit proves it); MDS023
+      behavior is unchanged.
+- [ ] An unknown `-f` value reports `text, json, yaml`.
+- [ ] All Markdown passes: `mdsmith check .`
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint run` reports
+      no issues.
+
+[mds023]: ../internal/rules/MDS023-paragraph-readability/README.md
+[metrics]: ../internal/metrics/registry.go
+[ari]: ../internal/rules/paragraphreadability/readability.go
+[mtest]: ../cmd/mdsmith/metrics_unit_test.go
+[rankdoc]: ../docs/reference/cli/metrics.md
+[extractdoc]: ../docs/reference/cli/extract.md
+[tradeoffs]: ../docs/guides/metrics-tradeoffs.md
+[wordfreq]: 2607022119_word-frequency-metric-rule.md


### PR DESCRIPTION
## What

Adds plan `2607071642` — a design for surfacing a Markdown file's **readability score** (and other shared measurements) as JSON or YAML from `mdsmith metrics`.

This answers the question "can we extract the readability score from a file, in yaml/json?" — today the answer is *no*: readability exists only as a lint rule (MDS023 ARI), which emits pass/fail against a threshold and never returns the raw number, and `metrics rank`/`metrics list` emit only `text`/`json`, no `yaml`.

## The plan, in brief

- **New metrics** (MET007 is reserved by plan 2607022119, so this takes MET008+):
  - `readability` — Automated Readability Index over the file's plain text (approx US grade level)
  - `sentences`
  - `avg-words-per-sentence`
  - All ship `Default: false` so the default `metrics rank` table keeps its six columns; opt in with `--metrics readability`.
- **`yaml` output format** for `metrics rank` and `metrics list`, reusing the same YAML encoder `mdsmith extract` uses, so json and yaml stay structurally identical.
- **Clean-architecture prerequisite:** move the ARI formula from the rule package down into `internal/mdtext` (where its word/sentence/char counters already live) so `internal/metrics` never imports a rule package. The rule keeps its `IndexFunc` and delegates.

End result: `mdsmith metrics rank --metrics readability -f yaml FILE`.

## Scope

This PR is the **plan only** — no engine code yet. Implementation is tracked by the plan's tasks and acceptance criteria.

## Validation

- `mdsmith check plan/ PLAN.md` passes (the plan's own prose satisfies MDS023/MDS024 — dogfooded).
- `PLAN.md` catalog regenerated via `mdsmith fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eku9EPDp5f5CeJhjRzAYwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eku9EPDp5f5CeJhjRzAYwA)_