### PR TITLE
refactor: export wordlist.Dedup/ToAnySlice, remove duplicate implementations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -240,7 +240,7 @@ footer: |
 | 2607022120 | 🔲     | opus   | [Substitution rule — deterministic word-choice swaps with auto-fix](plan/2607022120_substitution-rule.md)                                               |
 | 2607040635 | ⛔     | opus   | [Add mdsmith move: move a file and rewrite every incoming reference](plan/2607040635_move-command.md)                                                   |
 | 2607040822 | 🔲     | opus   | [Refactor engine redesign: unify move and rename behind one Plan, across CLI, LSP, and WASM hosts](plan/2607040822_refactor-move-rename-redesign.md)    |
-| 2607051918 | 🔲     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
+| 2607051918 | ✅     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
 | 2607051919 | 🔲     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
 | 2607051920 | 🔲     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
 <?/catalog?>

--- a/internal/config/deepmerge.go
+++ b/internal/config/deepmerge.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/jeduden/mdsmith/internal/rule"
+import (
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/wordlist"
+)
 
 // mergeRuleCfg deep-merges later on top of earlier and returns the
 // result. Both layers configure the same rule; later sits after earlier
@@ -106,11 +109,7 @@ func toAnySlice(v any) ([]any, bool) {
 		}
 		return out, true
 	case []string:
-		out := make([]any, len(x))
-		for i, s := range x {
-			out[i] = s
-		}
-		return out, true
+		return wordlist.ToAnySlice(x), true
 	case []int:
 		out := make([]any, len(x))
 		for i, n := range x {

--- a/internal/config/deepmerge_test.go
+++ b/internal/config/deepmerge_test.go
@@ -200,19 +200,22 @@ func TestToAnySlice_StringSlice(t *testing.T) {
 }
 
 func TestToAnySlice_NilStringSlice(t *testing.T) {
-	// Pin the nil []string → []any{} contract at the deepmerge layer so a
-	// change to wordlist.ToAnySlice's nil semantics doesn't silently alter
-	// merge behavior.
+	// Verify that nil []string is normalized to []any{} by toAnySlice so the
+	// MergeAppend path sees an empty accumulator rather than bypassing list-merge
+	// entirely (which would leave a []string in the output instead of []any).
+	// If nil []string were treated as a non-slice value (ok=false), cloneAny
+	// would return []string{} here instead of the expected []any{}.
 	earlier := RuleCfg{
 		Enabled:  true,
-		Settings: map[string]any{"words": ([]string)(nil)},
+		Settings: map[string]any{"placeholders": ([]string)(nil)},
 	}
 	later := RuleCfg{
 		Enabled:  true,
-		Settings: map[string]any{"words": []string{"c"}},
+		Settings: map[string]any{"placeholders": ([]string)(nil)},
 	}
-	got := mergeRuleCfg("some-rule", earlier, later)
-	assert.Equal(t, []any{"c"}, got.Settings["words"])
+	got := mergeRuleCfg("first-line-heading", earlier, later)
+	assert.Equal(t, []any{}, got.Settings["placeholders"],
+		"nil []string must normalize to []any{}, not bypass the list-merge path")
 }
 
 // --- effectiveRules deep-merge through the layer chain ---

--- a/internal/config/deepmerge_test.go
+++ b/internal/config/deepmerge_test.go
@@ -184,6 +184,21 @@ func TestToAnySlice_IntSlice(t *testing.T) {
 	assert.Equal(t, []any{3}, got.Settings["nums"])
 }
 
+func TestToAnySlice_StringSlice(t *testing.T) {
+	// Exercise the []string case in toAnySlice via mergeAny (replace path,
+	// non-ListMerger rule), symmetric to TestToAnySlice_IntSlice.
+	earlier := RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"words": []string{"a", "b"}},
+	}
+	later := RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"words": []string{"c"}},
+	}
+	got := mergeRuleCfg("some-rule", earlier, later)
+	assert.Equal(t, []any{"c"}, got.Settings["words"])
+}
+
 // --- effectiveRules deep-merge through the layer chain ---
 
 func TestEffectiveTwoKindsContributeDifferentKeys(t *testing.T) {

--- a/internal/config/deepmerge_test.go
+++ b/internal/config/deepmerge_test.go
@@ -199,6 +199,22 @@ func TestToAnySlice_StringSlice(t *testing.T) {
 	assert.Equal(t, []any{"c"}, got.Settings["words"])
 }
 
+func TestToAnySlice_NilStringSlice(t *testing.T) {
+	// Pin the nil []string → []any{} contract at the deepmerge layer so a
+	// change to wordlist.ToAnySlice's nil semantics doesn't silently alter
+	// merge behavior.
+	earlier := RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"words": ([]string)(nil)},
+	}
+	later := RuleCfg{
+		Enabled:  true,
+		Settings: map[string]any{"words": []string{"c"}},
+	}
+	got := mergeRuleCfg("some-rule", earlier, later)
+	assert.Equal(t, []any{"c"}, got.Settings["words"])
+}
+
 // --- effectiveRules deep-merge through the layer chain ---
 
 func TestEffectiveTwoKindsContributeDifferentKeys(t *testing.T) {

--- a/internal/config/wordlist_coverage_test.go
+++ b/internal/config/wordlist_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/wordlist"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -237,11 +238,11 @@ func TestAnyToStrings_Variants(t *testing.T) {
 	assert.False(t, ok, "non-list rejected")
 }
 
-// --- dedupStrings branches ---
+// --- wordlist.Dedup branches (formerly dedupStrings) ---
 
 func TestDedupStrings_EmptyAndDuplicates(t *testing.T) {
-	assert.Nil(t, dedupStrings(nil))
-	assert.Equal(t, []string{"a", "b"}, dedupStrings([]string{"a", "b", "a"}))
+	assert.Nil(t, wordlist.Dedup(nil))
+	assert.Equal(t, []string{"a", "b"}, wordlist.Dedup([]string{"a", "b", "a"}))
 }
 
 // --- load.go error branches ---

--- a/internal/config/wordlist_coverage_test.go
+++ b/internal/config/wordlist_coverage_test.go
@@ -240,7 +240,7 @@ func TestAnyToStrings_Variants(t *testing.T) {
 
 // --- wordlist.Dedup branches (formerly dedupStrings) ---
 
-func TestDedupStrings_EmptyAndDuplicates(t *testing.T) {
+func TestWordlistDedup_EmptyAndDuplicates(t *testing.T) {
 	assert.Nil(t, wordlist.Dedup(nil))
 	assert.Equal(t, []string{"a", "b"}, wordlist.Dedup([]string{"a", "b", "a"}))
 }

--- a/internal/config/wordlist_files.go
+++ b/internal/config/wordlist_files.go
@@ -235,7 +235,7 @@ func expandRuleLists(listsValue any, target string, settings map[string]any, use
 	}
 	resolved := resolveListEntries(listNames, userMap)
 	if existing, ok := anyToStrings(settings[target]); ok {
-		settings[target] = stringsToAny(dedupStrings(append(resolved, existing...)))
+		settings[target] = wordlist.ToAnySlice(wordlist.Dedup(append(resolved, existing...)))
 	}
 }
 
@@ -331,33 +331,4 @@ func anyToStrings(v any) ([]string, bool) {
 	default:
 		return nil, false
 	}
-}
-
-// stringsToAny widens a []string to the []any shape settings maps carry
-// after YAML decode, so a rule's ApplySettings sees the same type
-// whether the list came from YAML or from word-list expansion.
-func stringsToAny(ss []string) []any {
-	out := make([]any, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
-}
-
-// dedupStrings returns ss with later duplicates removed, preserving the
-// first occurrence's position. Returns nil for an empty input.
-func dedupStrings(ss []string) []string {
-	if len(ss) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{}, len(ss))
-	out := make([]string, 0, len(ss))
-	for _, s := range ss {
-		if _, ok := seen[s]; ok {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
-	}
-	return out
 }

--- a/internal/convention/convention.go
+++ b/internal/convention/convention.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/jeduden/mdsmith/internal/wordlist"
 )
 
 // Convention is an opinionated bundle that pairs a Markdown flavor
@@ -206,13 +208,13 @@ var conventions = map[string]Convention{
 			"forbidden-text": {
 				Enabled: true,
 				Settings: map[string]any{
-					"contains": toAnySlice(llmVocabularyAndPhrases()),
+					"contains": wordlist.ToAnySlice(llmVocabularyAndPhrases()),
 				},
 			},
 			"forbidden-paragraph-starts": {
 				Enabled: true,
 				Settings: map[string]any{
-					"starts": toAnySlice(llmParagraphOpeners()),
+					"starts": wordlist.ToAnySlice(llmParagraphOpeners()),
 				},
 			},
 			"paragraph-structure": {

--- a/internal/convention/nollmtells.go
+++ b/internal/convention/nollmtells.go
@@ -157,14 +157,3 @@ func NoLLMTellsWordlists() []NamedWordlist {
 		{Name: "ai-openers", Rule: "forbidden-paragraph-starts", Entries: llmParagraphOpeners()},
 	}
 }
-
-// toAnySlice converts a []string to []any so it can populate a
-// convention RulePreset Settings map (which the config loader treats
-// as []any after YAML decode).
-func toAnySlice(ss []string) []any {
-	out := make([]any, len(ss))
-	for i, s := range ss {
-		out[i] = s
-	}
-	return out
-}

--- a/internal/wordlist/wordlist.go
+++ b/internal/wordlist/wordlist.go
@@ -125,7 +125,7 @@ func Resolve(name string, user map[string]Wordlist) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return dedup(raw), nil
+	return Dedup(raw), nil
 }
 
 // flatten walks the (single-parent) extends chain parent-first,
@@ -154,9 +154,9 @@ func flatten(name string, user map[string]Wordlist, seen map[string]bool) ([]str
 	return out, nil
 }
 
-// dedup returns ss with later duplicates removed, preserving the first
+// Dedup returns ss with later duplicates removed, preserving the first
 // occurrence's position. Returns nil for an empty input.
-func dedup(ss []string) []string {
+func Dedup(ss []string) []string {
 	if len(ss) == 0 {
 		return nil
 	}
@@ -168,6 +168,17 @@ func dedup(ss []string) []string {
 		}
 		seen[s] = struct{}{}
 		out = append(out, s)
+	}
+	return out
+}
+
+// ToAnySlice widens a []string to the []any shape settings maps carry
+// after YAML decode, so a rule's ApplySettings sees the same type
+// whether the list came from YAML or from word-list expansion.
+func ToAnySlice(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
 	}
 	return out
 }

--- a/internal/wordlist/wordlist.go
+++ b/internal/wordlist/wordlist.go
@@ -172,9 +172,9 @@ func Dedup(ss []string) []string {
 	return out
 }
 
-// ToAnySlice widens a []string to the []any shape settings maps carry
-// after YAML decode, so a rule's ApplySettings sees the same type
-// whether the list came from YAML or from word-list expansion.
+// ToAnySlice widens ss to the []any shape that YAML-decoded and
+// programmatically-constructed settings maps both use, so callers
+// receive a uniform type regardless of how the list was built.
 func ToAnySlice(ss []string) []any {
 	out := make([]any, len(ss))
 	for i, s := range ss {

--- a/internal/wordlist/wordlist_test.go
+++ b/internal/wordlist/wordlist_test.go
@@ -53,6 +53,10 @@ func TestDedup_PreservesFirstOccurrence(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, Dedup([]string{"a", "b", "a"}))
 }
 
+func TestToAnySlice_Nil(t *testing.T) {
+	assert.Equal(t, []any{}, ToAnySlice(nil))
+}
+
 func TestToAnySlice_Empty(t *testing.T) {
 	assert.Equal(t, []any{}, ToAnySlice([]string{}))
 }

--- a/internal/wordlist/wordlist_test.go
+++ b/internal/wordlist/wordlist_test.go
@@ -47,6 +47,7 @@ func TestParse_NoEntriesErrors(t *testing.T) {
 
 func TestDedup_Empty(t *testing.T) {
 	assert.Nil(t, Dedup(nil))
+	assert.Nil(t, Dedup([]string{}))
 }
 
 func TestDedup_PreservesFirstOccurrence(t *testing.T) {

--- a/internal/wordlist/wordlist_test.go
+++ b/internal/wordlist/wordlist_test.go
@@ -46,7 +46,20 @@ func TestParse_NoEntriesErrors(t *testing.T) {
 }
 
 func TestDedup_Empty(t *testing.T) {
-	assert.Nil(t, dedup(nil))
+	assert.Nil(t, Dedup(nil))
+}
+
+func TestDedup_PreservesFirstOccurrence(t *testing.T) {
+	assert.Equal(t, []string{"a", "b"}, Dedup([]string{"a", "b", "a"}))
+}
+
+func TestToAnySlice_Empty(t *testing.T) {
+	assert.Equal(t, []any{}, ToAnySlice([]string{}))
+}
+
+func TestToAnySlice_Strings(t *testing.T) {
+	got := ToAnySlice([]string{"foo", "bar"})
+	assert.Equal(t, []any{"foo", "bar"}, got)
 }
 
 func TestRenderFile_RoundTrips(t *testing.T) {

--- a/plan/2607051918_arch-fix-wordlist-config-dedup.md
+++ b/plan/2607051918_arch-fix-wordlist-config-dedup.md
@@ -3,7 +3,7 @@ id: 2607051918
 title: >-
   Export wordlist.Dedup and remove the identical
   dedupStrings copy in internal/config
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   internal/wordlist.dedup and
@@ -86,11 +86,11 @@ import just for `internal/config`'s copy.
 
 ## Acceptance Criteria
 
-- [ ] `internal/wordlist` exports `Dedup` and
+- [x] `internal/wordlist` exports `Dedup` and
       `ToAnySlice`, each with a dedicated test.
-- [ ] `internal/config/wordlist_files.go` has no private
+- [x] `internal/config/wordlist_files.go` has no private
       `dedupStrings` or `stringsToAny`.
-- [ ] `internal/convention/nollmtells.go` has no private
+- [x] `internal/convention/nollmtells.go` has no private
       `toAnySlice`.
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
Implements plan `2607051918_arch-fix-wordlist-config-dedup`.

## Summary

- **Export `wordlist.Dedup`** — promotes the private `dedup` helper to an exported function; `Resolve` now calls it. Returns nil for nil/empty input (first-occurrence order preserved).
- **Export `wordlist.ToAnySlice`** — new exported function that widens `[]string` to the `[]any` shape settings maps carry, so YAML-decoded and programmatically-constructed lists are uniform at call sites.
- **Remove `stringsToAny` and `dedupStrings` from `internal/config/wordlist_files.go`** — call sites replaced with `wordlist.ToAnySlice(wordlist.Dedup(...))`.
- **Remove `toAnySlice` from `internal/convention/nollmtells.go`** — call sites in `convention.go` replaced with `wordlist.ToAnySlice(...)`.
- **Eliminate the duplicated `[]string` branch in `internal/config/deepmerge.go`** — the inline five-line loop was byte-for-byte identical to `wordlist.ToAnySlice`; replaced with a single delegate call.

Three sequential rounds of `code-review xhigh` were run and all confirmed/plausible findings addressed:

- **Round 1**: deepmerge.go `[]string` branch was a silent copy of `wordlist.ToAnySlice` — replaced with delegation; added `TestToAnySlice_Nil`.
- **Round 2**: `TestDedup_Empty` lacked `Dedup([]string{})` coverage; no symmetric test for deepmerge's `[]string` branch; `ToAnySlice` doc comment was too narrow. All fixed.
- **Round 3**: `TestToAnySlice_StringSlice` did not cover the `nil []string` path — added `TestToAnySlice_NilStringSlice` to pin the `nil → []any{}` contract at the deepmerge layer.

One remaining PLAUSIBLE finding (altitude): a private generic `toAnySliceOf[T any]` in `deepmerge.go` would eliminate the `[]string`/`[]int` inconsistency and remove the `wordlist` import from that file. Left as a follow-up since it requires a broader refactor and `wordlist.ToAnySlice` is still needed by other callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmUt3bgjLsYDghMMvpN4oB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmUt3bgjLsYDghMMvpN4oB)_