### PR TITLE
APM research: how mdsmith supports Agent Package Manager workflows

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -245,7 +245,7 @@ footer: |
 | 2607051920 | 🔲     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
 | 2607082048 | 🔲     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |
 | 2607082049 | 🔲     | opus   | [Foreign managed-region protection for `mdsmith fix`](plan/2607082049_foreign-managed-regions.md)                                                       |
-| 2607082050 | 🔲     | sonnet | [Coexist-with-APM guide and primitive kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                                    |
+| 2607082050 | 🔲     | sonnet | [APM coexistence: `mdsmith init --apm`, guide, and kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                       |
 | 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |
 | 2607082052 | 🔲     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -243,4 +243,9 @@ footer: |
 | 2607051918 | 🔲     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
 | 2607051919 | 🔲     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
 | 2607051920 | 🔲     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
+| 2607082048 | 🔲     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |
+| 2607082049 | 🔲     | opus   | [Foreign managed-region protection for `mdsmith fix`](plan/2607082049_foreign-managed-regions.md)                                                       |
+| 2607082050 | 🔲     | sonnet | [Coexist-with-APM guide and primitive kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                                    |
+| 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |
+| 2607082052 | 🔲     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |
 <?/catalog?>

--- a/docs/research/apm-mdsmith/README.md
+++ b/docs/research/apm-mdsmith/README.md
@@ -1,0 +1,55 @@
+---
+summary: >-
+  How mdsmith can support APM (Microsoft's Agent Package Manager)
+  workflows: APM's Markdown-heavy package model, a two-axis sweep of
+  its workflows and subcommands, and a catalogue of opportunities
+  with per-item mini-plans.
+---
+# mdsmith and APM
+
+This research note analyzes how mdsmith — a Go Markdown linter —
+can support, improve, or augment workflows built around
+[APM](https://github.com/microsoft/apm), Microsoft's Agent Package
+Manager. APM installs and compiles AI-agent context (skills,
+prompts, instructions, agents) across ten harnesses. Its payload
+is Markdown with contractual YAML front matter; its outputs are
+committed files sitting next to — sometimes inside — the files
+mdsmith already lints and generates.
+
+The analysis is systematic on two axes: every user workflow the
+APM docs describe (axis 1) and every `apm` subcommand (axis 2).
+Both axes were swept against a complete map of mdsmith's shipped
+features, so each finding is labeled with whether mdsmith covers
+it today, almost covers it, or needs a new feature.
+
+## Documents in this folder
+
+- [README.md](README.md) — this overview
+- [apm-model.md](apm-model.md) — APM's package model as a linter
+  sees it: manifest, lockfile, the seven primitive types and their
+  front-matter contracts, compile targets, and the validation APM
+  ships today
+- [workflows.md](workflows.md) — axis 1: the 29 APM user
+  workflows, their Markdown surfaces, and the five clusters where
+  mdsmith changes the outcome
+- [subcommands.md](subcommands.md) — axis 2: all 32 `apm`
+  subcommands and the Markdown each reads or writes
+- [opportunities.md](opportunities.md) — the merged catalogue:
+  every opportunity with status (exists / partial / new), effort,
+  trigger, and a mini-plan
+
+## The one-paragraph conclusion
+
+APM validates dependency integrity (hashes, lockfile, hidden
+Unicode) and stops where content quality starts. mdsmith owns
+content quality (schemas, style, size, links, generated sections)
+and knows nothing about APM's file shapes. The pairing needs three
+things: an APM preset (kinds and schemas for `SKILL.md`,
+`*.prompt.md`, `*.instructions.md`, `*.agent.md`, plus a
+`${input:…}` placeholder token), a coexistence posture for
+consumer repos (ignore/override boundaries so `mdsmith fix` never
+rewrites hash-pinned deployed files, and awareness of APM's
+`<!-- apm:start -->` managed sections), and a documented CI
+composition (`apm audit --ci` beside `mdsmith check .`). Most of
+the machinery exists; the connective config, one vocabulary token,
+and the docs do not.

--- a/docs/research/apm-mdsmith/apm-model.md
+++ b/docs/research/apm-mdsmith/apm-model.md
@@ -1,0 +1,186 @@
+---
+summary: >-
+  APM's package model as it looks to a Markdown linter: the manifest
+  and lockfile, the seven primitive types and their frontmatter
+  contracts, the compile targets, and the validation surface APM
+  ships today.
+---
+# APM's package model
+
+[APM](https://github.com/microsoft/apm) (Agent Package Manager) is
+Microsoft's open-source dependency manager for AI agent context.
+A project declares skills, prompts, instructions, agents, MCP
+servers, and LSP servers in one `apm.yml`; `apm install` reproduces
+the same agent setup across GitHub Copilot, Claude Code, Cursor,
+OpenCode, Codex, Gemini, Windsurf, and Kiro. A lockfile
+(`apm.lock.yaml`) pins every dependency to a commit SHA and per-file
+content hashes, and an `apm-policy.yml` lets an organization
+allow-list sources, scopes, and primitive types.
+
+The part that matters for mdsmith: almost everything APM manages is
+a Markdown file with YAML front matter, and most of those files are
+**committed to the consumer's repository**. APM is a package manager
+whose payload is lintable prose.
+
+## Personas and lifecycle
+
+APM's docs split users into three ramps:
+
+- **Consumer** — adds packages to a repo: `apm init`, `apm install`,
+  `apm update`, `apm run`. Commits `apm.yml`, `apm.lock.yaml`, and
+  the deployed files under `.github/`, `.claude/`, `.agents/`, etc.
+  `apm_modules/` is the gitignored cache.
+- **Producer** — authors a package: writes primitives under `.apm/`,
+  then `apm compile` → `apm preview` → `apm pack` → publish to a
+  marketplace or serve straight from the git repo.
+- **Enterprise** — governs at scale: `apm-policy.yml`, `apm audit
+  --ci` as a merge gate, GitHub rulesets, registry proxies.
+
+The lifecycle concept page names five stages: `init` → `install` →
+`compile` → `run` → `audit`, with audit feeding back into install
+when drift is found.
+
+## Files on disk
+
+| File / dir                | Format         | Committed | Role                                  |
+| ------------------------- | -------------- | --------- | ------------------------------------- |
+| `apm.yml`                 | YAML           | yes       | manifest: deps, targets, scripts      |
+| `apm.lock.yaml`           | YAML           | yes       | pinned SHAs + per-file content hashes |
+| `apm_modules/`            | mixed          | no        | package cache, rebuilt from lockfile  |
+| `.apm/`                   | Markdown, JSON | yes       | producer-authored primitives          |
+| `.github/`, `.claude/`, … | Markdown       | yes       | deployed primitives per harness       |
+| `AGENTS.md` / `CLAUDE.md` | Markdown       | yes       | compiled root context                 |
+| `apm-policy.yml`          | YAML           | yes       | org allow-lists (sources, primitives) |
+
+Two facts follow. First, a consumer repo accumulates third-party
+Markdown that its own linters walk. Second, the compiled context
+files sit in exactly the spot where a repo's hand-written agent
+docs already live.
+
+## Primitive types and their contracts
+
+Producers author primitives under `.apm/` as "a markdown file (or
+directory containing a primary markdown file) with frontmatter
+declaring its name and its trigger conditions". The contracts are
+concrete:
+
+### `.apm/prompts/<name>.prompt.md`
+
+The compiler preserves exactly five front-matter keys and drops the
+rest with diagnostics:
+
+| Field           | Required | Notes                                       |
+| --------------- | -------- | ------------------------------------------- |
+| `description`   | yes      | one line, shown in command pickers          |
+| `input`         | no       | argument names; regex `[A-Za-z][\w-]{0,63}` |
+| `allowed-tools` | no       | honored by Claude/Cursor only               |
+| `model`         | no       | preferred model id                          |
+| `argument-hint` | no       | derived from `input` when omitted           |
+
+The body references inputs as `${input:name}`; the compiler rewrites
+the token per target (Claude gets `$name`, Gemini gets TOML). The
+file basename becomes the slash-command name on every harness.
+
+### `.apm/instructions/<name>.instructions.md`
+
+Front matter carries `description` plus `applyTo` — a glob (or
+comma-separated globs) binding the rule to files. An instruction
+without `applyTo` loses its scope and folds into the root context
+file instead. Deployment rewrites the key per harness: Claude gets
+`paths:`, Cursor gets `globs:` in an `.mdc` file, Windsurf gets
+`trigger: glob`.
+
+### `.apm/agents/<name>.agent.md`
+
+Front matter: `name`, `description` (required), `model`, `tools`
+(a mapping, not a list), `color`, `handoffs`. The docs tell authors
+to keep the body under 300 lines, open with role and scope in two
+sentences, and list expected outputs.
+
+### `.apm/skills/<name>/SKILL.md`
+
+The [agentskills.io](https://agentskills.io) format: `name`
+(lowercase alphanumeric with hyphens, 1–64 chars, must equal the
+directory name) and `description` (imperative, under 1024 chars).
+The docs cap guidance at 500 lines / 5000 tokens for `SKILL.md` and
+push overflow into `references/<topic>.md` files loaded on demand.
+Optional subdirectories: `scripts/`, `references/`, `assets/`,
+`examples/`.
+
+### The rest
+
+Hooks are JSON (`.apm/hooks/*.json`); commands ship as prompts; MCP
+servers and LSP servers are `apm.yml` entries, not files. Five
+package layouts exist (`.apm/` package, root `SKILL.md` bundle,
+`skills/<name>/SKILL.md` collection, hooks-only, Claude
+`plugin.json` collection).
+
+## Compilation
+
+`apm compile` reads instructions primitives and writes root context
+files. Two strategies:
+
+- **single-file** — one `AGENTS.md` (plus `CLAUDE.md` for Claude,
+  `GEMINI.md` for Gemini) holding every unconditional instruction.
+- **distributed** — per-harness rule directories
+  (`.github/instructions/`, `.claude/rules/`, `.cursor/rules/`,
+  `.windsurf/rules/`, `.kiro/steering/`), with `applyTo` scoping
+  preserved.
+
+A `compilation.agents_md.mode: managed_section` setting confines
+APM's output to a marker-delimited block:
+
+```markdown
+<!-- apm:start -->
+<!-- apm will insert content here -->
+<!-- apm:end -->
+```
+
+Content outside the markers survives every compile run. The markers
+must appear exactly once. `compile` covers only instructions — a
+changed prompt, skill, agent, or hook redeploys via `apm install`,
+not `apm compile`.
+
+## Link handling
+
+`apm install` rewrites relative links in deployed prompts,
+instructions, agents, and commands so they point back into
+`apm_modules/<owner>/<pkg>/…`. The rewrite applies only when the
+target exists and stays inside the package root. Cross-package
+links are unsupported; packages are "independent deployment units".
+Skills skip the rewrite because the whole skill directory deploys
+as a bundle.
+
+The consequence: a consumer repo's committed Markdown contains
+links into a gitignored directory, and those links are only valid
+after `apm install` has run.
+
+## What APM validates today
+
+- `apm compile --validate` — strict parse of primitive front matter
+  and structure.
+- `apm install` — hidden-Unicode scan (bidi overrides, tag
+  characters, zero-width), content-hash pinning, policy gates,
+  trust prompts for transitive MCP servers.
+- `apm audit` — the same Unicode scan on demand, `--strip`
+  remediation, and in `--ci` mode eight baseline checks: lockfile
+  presence, reference consistency, deployed-file existence, no
+  orphaned packages, skill-subset consistency, MCP config
+  consistency, per-file SHA-256 hash drift, and `includes` consent.
+  Output formats: text, JSON, SARIF, Markdown.
+- `apm outdated` — locked refs vs. remote versions.
+
+What APM does **not** validate: Markdown quality of any kind. No
+formatting or style checks, no heading or structure rules beyond
+front-matter parsing, no link integrity beyond the install-time
+rewrite, no size or token budgets (the SKILL.md caps are prose
+guidance, not checks), no prose-quality rules. The producer docs
+carry body conventions — "lead with bullet points", "one topic per
+file", "keep under 300 lines" — that nothing enforces.
+
+## Sources
+
+- [APM docs](https://microsoft.github.io/apm/) — quickstart,
+  producer ramp, manifest schema, package types, CLI reference,
+  lifecycle, drift detection (fetched 2026-07-08).
+- [microsoft/apm README](https://github.com/microsoft/apm).

--- a/docs/research/apm-mdsmith/opportunities.md
+++ b/docs/research/apm-mdsmith/opportunities.md
@@ -42,7 +42,7 @@ plan files (linked inline); the rest wait on their triggers.
 | ID  | Opportunity                                         | Status  | Effort | Trigger                                         |
 | --- | --------------------------------------------------- | ------- | ------ | ----------------------------------------------- |
 | C-1 | Foreign managed-region protection (`apm:start/end`) | new     | M      | `mdsmith fix` corrupts an APM-managed block     |
-| C-2 | Coexist-with-APM guide + preset config              | partial | S      | first repo runs both tools and hits fix-vs-hash |
+| C-2 | `mdsmith init --apm` template + coexist guide       | partial | S      | first repo runs both tools and hits fix-vs-hash |
 | C-3 | Token/size budget canary on compiled context files  | exists  | S      | an assembled `AGENTS.md` blows a context window |
 | C-4 | Wrap `apm compile` in a `<?build?>` recipe          | exists  | S      | a team wants edit-time compile freshness        |
 
@@ -83,9 +83,8 @@ for its own `skill` and `plan` kinds. A-2 layers `max-file-length`
 and `token-budget` per kind (`SKILL.md` 500 lines / 5000 tokens,
 agents 300 lines).
 
-**Surface.** A copy-paste `.mdsmith.yml` block in the
-coexist-with-APM guide (C-2), plus optionally an `.mdsmith/kinds/`
-file set. Ships together with C-2's guide as
+**Surface.** The `.mdsmith/kinds/apm-*` files that `mdsmith init
+--apm` writes (C-2). Ships together with C-2's template and guide as
 [plan 2607082050](../../../plan/2607082050_apm-coexist-guide-and-kind-pack.md).
 
 ### A-3 — `${input:name}` placeholder token (new)
@@ -163,10 +162,15 @@ Ship the canonical `ignore:` list naming APM's deploy dirs
 `apm_modules/**`) so `mdsmith fix` never rewrites a hash-pinned
 file, plus `overrides:` disabling fix-capable rules on the compiled
 root files, plus the A-1 kind pack for the `.apm/` source tree. The
-config exists today; the guide that assembles it does not.
+config exists today; the command that assembles it does not. So the
+plan ships it as an `mdsmith init --apm` template — additive and
+non-clobbering, on the `--wordlists` model — that writes the
+`.mdsmith/kinds/apm-*` pack and the coexistence posture, scoped to
+the harness directories the repo actually has. The guide documents
+what the template writes.
 
-**Surface.** `docs/guides/coexist-with-apm.md` and a preset config
-block. Scheduled as
+**Surface.** An `mdsmith init --apm` flag plus
+`docs/guides/coexist-with-apm.md`. Scheduled as
 [plan 2607082050](../../../plan/2607082050_apm-coexist-guide-and-kind-pack.md).
 
 ### G-2 — SARIF output for `mdsmith check` (partial)

--- a/docs/research/apm-mdsmith/opportunities.md
+++ b/docs/research/apm-mdsmith/opportunities.md
@@ -27,15 +27,15 @@ plan files (linked inline); the rest wait on their triggers.
 
 ### Author a package (A)
 
-| ID  | Opportunity                                        | Status | Effort | Trigger                                             |
-| --- | -------------------------------------------------- | ------ | ------ | --------------------------------------------------- |
-| A-1 | APM primitive kind pack (schemas for the 4 types)  | exists | S–M    | first author wants their `.apm/` tree linted        |
-| A-2 | Numeric body budgets per primitive kind            | exists | S      | folds into A-1                                      |
-| A-3 | `${input:name}` placeholder token                  | new    | S      | first prompt body false-positives on a content rule |
-| A-4 | Closed frontmatter (flag keys `apm compile` drops) | new    | M      | an author ships a key APM silently drops            |
-| A-5 | Filename ↔ frontmatter-field agreement             | new    | M      | a `SKILL.md` `name` drifts from its directory       |
-| A-6 | Prompt-input declaration/usage cross-check rule    | new    | M      | a typo'd `${input:Scope}` reaches an LLM verbatim   |
-| A-7 | Dead `applyTo` glob detection                      | new    | M      | an instruction compiles to a rule no file activates |
+| ID  | Opportunity                                        | Status | Effort | Trigger                                              |
+| --- | -------------------------------------------------- | ------ | ------ | ---------------------------------------------------- |
+| A-1 | APM primitive kind pack (schemas for the 4 types)  | exists | S–M    | first author wants their `.apm/` tree linted         |
+| A-2 | Numeric body budgets per primitive kind            | exists | S      | folds into A-1                                       |
+| A-3 | `${input:name}` placeholder token                  | new    | S      | first prompt body false-positives on a content rule  |
+| A-4 | Closed frontmatter (flag keys `apm compile` drops) | new    | M      | an author ships a key `apm compile` drops at compile |
+| A-5 | Filename ↔ frontmatter-field agreement             | new    | M      | a `SKILL.md` `name` drifts from its directory        |
+| A-6 | Prompt-input declaration/usage cross-check rule    | new    | M      | a typo'd `${input:Scope}` reaches an LLM verbatim    |
+| A-7 | Dead `applyTo` glob detection                      | new    | M      | an instruction compiles to a rule no file activates  |
 
 ### Compile and coexist (C)
 
@@ -117,8 +117,9 @@ match a frontmatter field.
 MDS020 diagnose any frontmatter key not declared in the
 `frontmatter:` map — `closed:` exists but applies only to sections
 (`docs/reference/section-schema.md:243`), and on a frontmatter-only
-kind it is dropped. This catches the sixth `.prompt.md` key APM
-silently drops. (b) `\#(fmvar(name))` interpolation inside the
+kind it is dropped. This catches the sixth `.prompt.md` key at edit
+time, where `apm compile` flags it only at compile time, after the
+file ships. (b) `\#(fmvar(name))` interpolation inside the
 schema `path-pattern:` / `filename:` matcher, reusing the existing
 `fmvar` resolver that already works in heading regexes — so
 `path-pattern: ".apm/skills/\#(fmvar(name))/SKILL.md"` enforces

--- a/docs/research/apm-mdsmith/opportunities.md
+++ b/docs/research/apm-mdsmith/opportunities.md
@@ -201,8 +201,12 @@ editor, before the file is ever committed.
 **Sketch.** APM's only content check is the install/audit-time
 hidden-Unicode scan; `apm compile` does not run it after hand-edits,
 and detection happens only when an APM command runs. mdsmith has no
-rule here (verified: nothing under `internal/rules/` scans for
-invisible characters). A new default-enabled rule mirroring APM's
+rule dedicated to hidden-Unicode detection: no check flags bidi
+overrides, tag characters, or zero-width payloads as a finding.
+(A few rules recognize specific invisible characters incidentally —
+`line-length` counts NBSP and ZWJ for word-wrapping, `table-format`
+handles Unicode whitespace — but none reports them.) A new
+default-enabled rule mirroring APM's
 three severity tiers (critical: tag chars, bidi overrides,
 variation selectors 17–256; warning: zero-width, VS 1–15; info:
 NBSP, ZWJ), with a `Fix()` that strips flagged characters —

--- a/docs/research/apm-mdsmith/opportunities.md
+++ b/docs/research/apm-mdsmith/opportunities.md
@@ -1,0 +1,220 @@
+---
+summary: >-
+  The merged APM opportunity catalogue: every place mdsmith can
+  support, improve, or augment an APM workflow, tagged with status
+  (exists / partial / new), effort, trigger, and a mini-plan.
+---
+# APM opportunity catalogue
+
+This is the merged output of the two-axis sweep in
+[workflows.md](workflows.md) (axis 1) and
+[subcommands.md](subcommands.md) (axis 2), cross-referenced against
+a full map of mdsmith's shipped features. Each opportunity carries:
+
+- a **status** — `exists` (config alone, today), `partial` (a small
+  tweak away), or `new` (a new mdsmith feature);
+- an **effort** — S (a day), M (a week), L (a month);
+- a **trigger** — the condition under which building it is worth
+  the cost;
+- a **mini-plan** — goal, sketch, and the surface a user sees.
+
+The method mirrors
+[learn-from-mdbase.md](../mdbase-vs-mdsmith/learn-from-mdbase.md):
+this is a map of candidates, not a roadmap. Five of these have
+plan files (linked inline); the rest wait on their triggers.
+
+## Summary tables
+
+### Author a package (A)
+
+| ID  | Opportunity                                        | Status | Effort | Trigger                                             |
+| --- | -------------------------------------------------- | ------ | ------ | --------------------------------------------------- |
+| A-1 | APM primitive kind pack (schemas for the 4 types)  | exists | S–M    | first author wants their `.apm/` tree linted        |
+| A-2 | Numeric body budgets per primitive kind            | exists | S      | folds into A-1                                      |
+| A-3 | `${input:name}` placeholder token                  | new    | S      | first prompt body false-positives on a content rule |
+| A-4 | Closed frontmatter (flag keys `apm compile` drops) | new    | M      | an author ships a key APM silently drops            |
+| A-5 | Filename ↔ frontmatter-field agreement             | new    | M      | a `SKILL.md` `name` drifts from its directory       |
+| A-6 | Prompt-input declaration/usage cross-check rule    | new    | M      | a typo'd `${input:Scope}` reaches an LLM verbatim   |
+| A-7 | Dead `applyTo` glob detection                      | new    | M      | an instruction compiles to a rule no file activates |
+
+### Compile and coexist (C)
+
+| ID  | Opportunity                                         | Status  | Effort | Trigger                                         |
+| --- | --------------------------------------------------- | ------- | ------ | ----------------------------------------------- |
+| C-1 | Foreign managed-region protection (`apm:start/end`) | new     | M      | `mdsmith fix` corrupts an APM-managed block     |
+| C-2 | Coexist-with-APM guide + preset config              | partial | S      | first repo runs both tools and hits fix-vs-hash |
+| C-3 | Token/size budget canary on compiled context files  | exists  | S      | an assembled `AGENTS.md` blows a context window |
+| C-4 | Wrap `apm compile` in a `<?build?>` recipe          | exists  | S      | a team wants edit-time compile freshness        |
+
+### Consume and link (L)
+
+| ID  | Opportunity                                          | Status | Effort | Trigger                                        |
+| --- | ---------------------------------------------------- | ------ | ------ | ---------------------------------------------- |
+| L-1 | Consumer-side content vetting of deployed primitives | exists | S      | folds into C-2                                 |
+| L-2 | Uninstall/prune dangling-reference gate              | exists | S      | an `apm uninstall` orphans an incoming link    |
+| L-3 | Drift-gated `<?catalog?>` index of installed skills  | exists | S      | a repo wants a live table of what it installed |
+
+### Govern and gate in CI (G)
+
+| ID  | Opportunity                            | Status  | Effort | Trigger                                                  |
+| --- | -------------------------------------- | ------- | ------ | -------------------------------------------------------- |
+| G-1 | mdsmith Action beside `apm audit --ci` | exists  | S      | a repo wants a content gate next to the integrity gate   |
+| G-2 | SARIF output for `mdsmith check`       | partial | S–M    | a team wants mdsmith findings in Code Scanning           |
+| G-3 | Hidden-Unicode rule                    | new     | M      | an author wants the APM install-block check at edit time |
+| G-4 | Migration worklist via MDS037 + MDS033 | exists  | S      | a team migrates hand-copied instructions into `.apm/`    |
+
+## Mini-plans
+
+### A-1 — APM primitive kind pack (exists)
+
+**Goal.** Ship a documented set of mdsmith kinds so an APM author
+runs `mdsmith check .apm/` and gets the front-matter and size
+contracts APM's own docs state but never enforce.
+
+**Sketch.** Four kinds keyed by `path-pattern`: `apm-skill`
+(`.apm/skills/*/SKILL.md` — `name: nonEmpty`, `description:
+nonEmpty`), `apm-prompt` (`.apm/prompts/*.prompt.md` —
+`description: nonEmpty`, optional `input`, `allowed-tools`,
+`model`, `argument-hint`), `apm-instruction`
+(`.apm/instructions/*.instructions.md` — `description` + `applyTo`),
+`apm-agent` (`.apm/agents/*.agent.md` — `name`, `description`,
+`model`, `tools`). This is the exact pattern the repo already runs
+for its own `skill` and `plan` kinds. A-2 layers `max-file-length`
+and `token-budget` per kind (`SKILL.md` 500 lines / 5000 tokens,
+agents 300 lines).
+
+**Surface.** A copy-paste `.mdsmith.yml` block in the
+coexist-with-APM guide (C-2), plus optionally an `.mdsmith/kinds/`
+file set. Ships together with C-2's guide as
+[plan 2607082050](../../../plan/2607082050_apm-coexist-guide-and-kind-pack.md).
+
+### A-3 — `${input:name}` placeholder token (new)
+
+**Goal.** Let content rules treat APM's `${input:name}` prompt
+parameters as opaque, the way `var-token` already handles
+`{identifier}`.
+
+**Sketch.** `var-token` matches only `{identifier}` (verified at
+`internal/placeholders/placeholders.go`), so `${input:pr_url}` is
+opaque to nothing: MDS023, MDS024, MDS018, and MDS004 all see it as
+prose. Add one token to the closed vocabulary matching
+`${input:NAME}` with `NAME` on APM's documented grammar
+`[A-Za-z][\w-]{0,63}`, wired into `ContainsBodyToken` and
+`MaskBodyTokens`. Small, self-contained, TDD-shaped.
+
+**Surface.** A new token name in `placeholders:` and a row in
+[placeholder-grammar.md](../../background/concepts/placeholder-grammar.md).
+Scheduled as
+[plan 2607082048](../../../plan/2607082048_apm-input-placeholder-token.md).
+
+### A-4 / A-5 — schema grammar extensions (new)
+
+**Goal.** Express two APM contracts the schema engine cannot today:
+frontmatter that rejects unknown keys, and a filename that must
+match a frontmatter field.
+
+**Sketch.** (a) A `frontmatter-closed: true` schema flag that makes
+MDS020 diagnose any frontmatter key not declared in the
+`frontmatter:` map — `closed:` exists but applies only to sections
+(`docs/reference/section-schema.md:243`), and on a frontmatter-only
+kind it is dropped. This catches the sixth `.prompt.md` key APM
+silently drops. (b) `\#(fmvar(name))` interpolation inside the
+schema `path-pattern:` / `filename:` matcher, reusing the existing
+`fmvar` resolver that already works in heading regexes — so
+`path-pattern: ".apm/skills/\#(fmvar(name))/SKILL.md"` enforces
+APM's "`name` equals directory name" rule.
+
+**Surface.** Two schema keys; both extend MDS020. Scheduled as
+[plan 2607082051](../../../plan/2607082051_apm-schema-extensions.md).
+
+### C-1 — foreign managed-region protection (new)
+
+**Goal.** Make `mdsmith fix` and the style rules safe inside a
+region another generator owns — starting with APM's
+`<!-- apm:start -->` … `<!-- apm:end -->` managed section.
+
+**Sketch.** mdsmith's generated-section engine recognizes only its
+own `<?directive?>` markers. When APM writes a managed section into
+`AGENTS.md`, `mdsmith fix` reflows the bytes inside it (table
+alignment, trailing whitespace), which breaks the SHA-256 APM
+pins in `apm.lock.yaml` and trips `apm audit --ci`. Add a
+`foreign-regions:` config listing `{start, end}` marker pairs
+(glob-scopable via overrides): fixers never rewrite bytes inside a
+declared region, style/content rules skip diagnostics there, but
+whole-file rules (MDS022, MDS028) still count the bytes — mirroring
+how generated bodies are already handled. A companion check
+diagnoses malformed pairs (zero or multiple markers).
+
+**Surface.** A `foreign-regions:` top-level key. Scheduled as
+[plan 2607082049](../../../plan/2607082049_foreign-managed-regions.md).
+
+### C-2 — coexist-with-APM guide + preset (partial)
+
+**Goal.** One guide that tells a repo running both tools exactly
+which globs mdsmith must leave alone and which kinds to apply to
+the `.apm/` source it *should* lint.
+
+**Sketch.** Model it on
+[coexist-with-prettier.md](../../guides/coexist-with-prettier.md).
+Ship the canonical `ignore:` list naming APM's deploy dirs
+(`.github/prompts/**`, `.github/instructions/**`, `.claude/rules/**`,
+`.agents/skills/**`, `.kiro/steering/**`, `.windsurf/rules/**`,
+`apm_modules/**`) so `mdsmith fix` never rewrites a hash-pinned
+file, plus `overrides:` disabling fix-capable rules on the compiled
+root files, plus the A-1 kind pack for the `.apm/` source tree. The
+config exists today; the guide that assembles it does not.
+
+**Surface.** `docs/guides/coexist-with-apm.md` and a preset config
+block. Scheduled as
+[plan 2607082050](../../../plan/2607082050_apm-coexist-guide-and-kind-pack.md).
+
+### G-2 — SARIF output for `mdsmith check` (partial)
+
+**Goal.** Let mdsmith diagnostics land in the same GitHub Code
+Scanning dashboard APM's `apm audit --ci -f sarif` already feeds.
+
+**Sketch.** `mdsmith check` emits text or JSON only
+(`docs/reference/cli/check.md`). mdsmith already renders SARIF in
+`internal/release/auditsarif.go` and `internal/secreview/sarif.go`
+for the security-review engine, so the emission machinery exists —
+it is not wired to the check command's diagnostic stream. Add
+`-f sarif`: one `reportingDescriptor` per fired rule (`ruleId =
+MDS###`, `helpUri` to the rule doc), one result per diagnostic with
+a `physicalLocation` region. Generalize the existing SARIF structs
+into a shared internal package.
+
+**Surface.** A new `-f sarif` value on `check` (and `fix
+--dry-run`). Scheduled as
+[plan 2607082052](../../../plan/2607082052_check-sarif-output.md).
+
+### G-3 — hidden-Unicode rule (new)
+
+**Goal.** Catch the bidi-override, tag-character, and zero-width
+payloads APM blocks at install time — but at edit time, in the
+editor, before the file is ever committed.
+
+**Sketch.** APM's only content check is the install/audit-time
+hidden-Unicode scan; `apm compile` does not run it after hand-edits,
+and detection happens only when an APM command runs. mdsmith has no
+rule here (verified: nothing under `internal/rules/` scans for
+invisible characters). A new default-enabled rule mirroring APM's
+three severity tiers (critical: tag chars, bidi overrides,
+variation selectors 17–256; warning: zero-width, VS 1–15; info:
+NBSP, ZWJ), with a `Fix()` that strips flagged characters —
+delivered live through `mdsmith lsp` and the autofix hook. This
+overlaps APM's scanner deliberately: the value is edit-time
+delivery, not novelty. Not yet scheduled; awaits the trigger.
+
+**Surface.** A new `no-hidden-unicode` rule (next free id, MDS071).
+
+## What does not fit
+
+Some APM surfaces have no mdsmith angle and are recorded here so
+the sweep is complete: the `apm.yml` / `apm.lock.yaml` /
+`apm-policy.yml` manifests (YAML, not Markdown — outside mdsmith's
+domain), executable-trust lists (`apm approve`/`deny`), lifecycle
+scripts, runtime-CLI management (`apm runtime`), the SBOM export,
+and the cache/config/self-update plumbing. The marketplace
+`packages[]` block is YAML too; only the package `README.md` it
+points at is mdsmith's concern (covered by the repo's existing
+docs-quality stack).

--- a/docs/research/apm-mdsmith/subcommands.md
+++ b/docs/research/apm-mdsmith/subcommands.md
@@ -1,0 +1,130 @@
+---
+summary: >-
+  Axis 2 of the APM analysis: all 32 apm subcommands, the Markdown
+  each one reads or writes, and where mdsmith intersects — today or
+  as a candidate feature.
+---
+# APM subcommands and their Markdown surface
+
+Axis 2 of the analysis walks every `apm` subcommand and asks two
+questions: which Markdown does the subcommand read or write, and
+what does mdsmith offer around that Markdown? The opportunity ids
+(`A-1`, `C-2`, …) resolve in
+[opportunities.md](opportunities.md).
+
+Subcommand behavior below comes from the
+[APM CLI reference](https://microsoft.github.io/apm/reference/)
+(fetched 2026-07-08). Groups follow the reference layout.
+
+## Dependency lifecycle
+
+| Subcommand  | Markdown surface                                                                                           |
+| ----------- | ---------------------------------------------------------------------------------------------------------- |
+| `init`      | writes `apm.yml` only; no Markdown                                                                         |
+| `install`   | deploys primitives into `.github/`, `.claude/`, `.agents/`, …; rewrites relative links into `apm_modules/` |
+| `uninstall` | deletes deployed files listed in the lockfile                                                              |
+| `update`    | re-resolves refs, redeploys the same Markdown surface                                                      |
+| `lock`      | resolves and pins; deploys nothing                                                                         |
+| `prune`     | deletes deployed files of orphaned packages                                                                |
+| `outdated`  | read-only; compares locked refs to remotes                                                                 |
+| `deps`      | lists / explains what sits under `apm_modules/`                                                            |
+| `find`      | reverse lookup: which package deployed a given file                                                        |
+
+`install`, `uninstall`, `update`, and `prune` all mutate committed
+Markdown in bulk. Every run raises the same three questions for a
+repo that lints its Markdown:
+
+- Do the arriving third-party files pass the repo's `mdsmith
+  check`, and should they have to? Deployed primitives are
+  vendored content; a repo needs a deliberate `ignore:` posture
+  for `.github/prompts/`, `.claude/commands/`, `.agents/skills/`,
+  and friends — or a relaxed kind per directory.
+- Links: deployed files point into the gitignored `apm_modules/`,
+  so MDS027 (cross-file reference integrity) sees dangling targets
+  on a fresh clone until `apm install` runs. `find` and `deps`
+  answer provenance questions that [mdsmith
+  deps](../../reference/cli/deps.md) answers for include/link
+  graphs — the two graphs never join today.
+- Staleness: `uninstall`/`prune` delete files that other Markdown
+  may link to; nothing rewrites those incoming references.
+
+## Compile
+
+`apm compile` turns `.apm/instructions/*.instructions.md` into the
+root context files: `AGENTS.md` (root plus per-directory scoped
+files in distributed mode), `CLAUDE.md`, `GEMINI.md`, and
+`.github/copilot-instructions.md`. With
+`agents_md.mode: managed_section` it edits only the block between
+`<!-- apm:start -->` and `<!-- apm:end -->`.
+
+This is the deepest intersection with mdsmith, which already owns
+a [generated-section model](../../background/concepts/generated-section.md)
+(`<?directive?>` … `<?/directive?>`), a fix loop that keeps bodies
+in sync, a git merge driver for conflicts inside generated blocks,
+and rules that skip generated content. The two managed-block
+grammars live in the same files — AGENTS.md and CLAUDE.md — and do
+not know about each other. mdsmith's own `CLAUDE.md` is
+directive-generated; a repo using both tools has two generators
+writing one file.
+
+## Prompt execution
+
+| Subcommand | Markdown surface                                   |
+| ---------- | -------------------------------------------------- |
+| `list`     | none (prints `scripts:` from `apm.yml`)            |
+| `run`      | compiles `*.prompt.md` with `--param` substitution |
+| `preview`  | same compilation, rendered without executing       |
+| `runtime`  | none (manages AI CLI binaries)                     |
+
+`run` and `preview` substitute `${input:name}` tokens inside
+prompt bodies. mdsmith's
+[placeholder grammar](../../background/concepts/placeholder-grammar.md)
+exists for exactly this file shape — template tokens inside
+Markdown that rules must treat as opaque — but its vocabulary is
+config-declared per project and does not ship an APM preset.
+
+## Author and distribute
+
+| Subcommand    | Markdown surface                                             |
+| ------------- | ------------------------------------------------------------ |
+| `pack`        | bundles `.apm/` primitives + `README.md` and other root docs |
+| `publish`     | zips `apm.yml`, `.apm/`, `README.md`, `CHANGELOG.md`         |
+| `unpack`      | extracts bundle Markdown into a project (deprecated)         |
+| `plugin`      | scaffolds `plugin.json` + `apm.yml`; no Markdown             |
+| `marketplace` | authoring side reads package `README.md` descriptions        |
+| `search`      | none (queries a marketplace index)                           |
+| `view`        | prints package metadata, primitive counts                    |
+
+Everything a producer packs or publishes is authored Markdown with
+contractual front matter (see
+[apm-model.md](apm-model.md)). APM validates the front matter
+parse (`apm compile --validate`) and scans for hidden Unicode
+(`apm audit`), and stops there. Body conventions in APM's own docs
+— one topic per file, bullets over prose, agent bodies under 300
+lines, `SKILL.md` under 500 lines / 5000 tokens — have no checker.
+mdsmith's kinds, schemas, size rules, and token budget rule are
+that checker, minus a published preset for APM's file shapes.
+
+## Governance and trust
+
+| Subcommand       | Markdown surface                                                            |
+| ---------------- | --------------------------------------------------------------------------- |
+| `audit`          | scans deployed Markdown for hidden Unicode; replays install to detect drift |
+| `policy`         | none (YAML policy diagnostics)                                              |
+| `approve`/`deny` | none (executable-trust lists)                                               |
+| `lifecycle`      | none (install-hook scripts)                                                 |
+
+`apm audit --ci` is the natural CI neighbor of `mdsmith check .`:
+one gates dependency integrity, the other content quality. They
+emit different report formats (APM: text/JSON/SARIF/Markdown;
+mdsmith: text/JSON) and neither references the other. A repo that
+adopts both wants a documented composition — ordering, ignore
+boundaries, and which tool owns which failure.
+
+## Plumbing
+
+`cache`, `config`, `self-update`, `targets`, `experimental`, and
+`mcp` touch no project Markdown. `targets` matters indirectly: its
+filesystem detection (`.claude/` present → claude target active)
+is the same signal a repo's mdsmith config uses to decide which
+deployed directories exist and need lint posture.

--- a/docs/research/apm-mdsmith/subcommands.md
+++ b/docs/research/apm-mdsmith/subcommands.md
@@ -42,9 +42,9 @@ repo that lints its Markdown:
 - Links: deployed files point into the gitignored `apm_modules/`,
   so MDS027 (cross-file reference integrity) sees dangling targets
   on a fresh clone until `apm install` runs. `find` and `deps`
-  answer provenance questions that [mdsmith
-  deps](../../reference/cli/deps.md) answers for include/link
-  graphs — the two graphs never join today.
+  answer provenance questions that
+  [mdsmith deps](../../reference/cli/deps.md) answers for
+  include/link graphs — the two graphs never join today.
 - Staleness: `uninstall`/`prune` delete files that other Markdown
   may link to; nothing rewrites those incoming references.
 

--- a/docs/research/apm-mdsmith/workflows.md
+++ b/docs/research/apm-mdsmith/workflows.md
@@ -1,0 +1,143 @@
+---
+summary: >-
+  Axis 1 of the APM analysis: the 29 user workflows the APM docs
+  describe, each one's Markdown surface, and the five workflow
+  clusters where mdsmith changes the outcome.
+---
+# APM workflows and where mdsmith fits
+
+Axis 1 of the analysis walks the user workflows the
+[APM docs](https://microsoft.github.io/apm/) describe — consumer,
+producer, and enterprise ramps — and asks what mdsmith changes in
+each. The short answer: five workflow clusters carry nearly all of
+the intersection, because they are the ones that create, mutate,
+or gate committed Markdown. The opportunity ids (`A-1`, `C-2`, …)
+resolve in [opportunities.md](opportunities.md).
+
+## Inventory
+
+Workflows with no project-Markdown surface are listed for
+completeness and not analyzed further: installing or updating the
+`apm` CLI itself, managing runtime CLI binaries (`apm runtime`),
+user-scope global installs (outside the repo), REST-registry
+operation, SBOM export, multi-host authentication, lifecycle
+scripts, executable-trust approval (`apm approve`/`deny`), and
+policy authoring (YAML, not Markdown).
+
+The remaining workflows group into five clusters:
+
+| Cluster               | Workflows                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| author a package      | author primitives under `.apm/`; maintain and evolve a package; preview and validate           |
+| compile agent context | compile `AGENTS.md` and per-harness root files; multi-harness targeting                        |
+| consume packages      | install; clone-and-install onboarding; update, inspect, remove; monorepos and virtual packages |
+| distribute            | pack a bundle; publish via git; operate a marketplace                                          |
+| gate in CI            | CI/CD integration; security audit and drift detection; migrate from ad-hoc setups              |
+
+## Author a package
+
+A producer's package is a tree of Markdown files with contractual
+front matter (the exact contracts are in
+[apm-model.md](apm-model.md)): `SKILL.md` with `name` +
+`description`, `*.prompt.md` with five allowed keys,
+`*.instructions.md` with `description` + `applyTo`, `*.agent.md`
+with persona fields. APM's own docs add body conventions — one
+topic per file, bullets over prose, agents under 300 lines,
+`SKILL.md` under 500 lines and 5000 tokens, prompt inputs matching
+`[A-Za-z][\w-]{0,63}` — and provide no checker for any of them.
+
+Everything in that paragraph maps onto an mdsmith kind: a
+`path-pattern` per primitive type, an inline schema for the front
+matter, `max-file-length` and `token-budget` per kind, and the
+placeholder vocabulary for `${input:name}` tokens so content rules
+treat them as opaque. mdsmith already runs this exact pattern on
+its own repo — the `skill` kind validates `SKILL.md` files against
+a proto schema, and the `plan` kind gates `plan/*.md` front matter.
+What is missing is a published preset, so every APM producer today
+would have to hand-write the kinds.
+
+The pre-release sequence APM recommends (`compile --validate` →
+`compile --dry-run` → `view` → `outdated` → `audit` → `pack`) has
+an obvious sixth read-only step: `mdsmith check .apm/`.
+
+## Compile agent context
+
+`apm compile` generates `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and
+per-harness rule directories. In `managed_section` mode it owns
+only the block between `<!-- apm:start -->` and `<!-- apm:end -->`
+and preserves everything outside. Migrating teams wrap their
+hand-written `AGENTS.md` with those markers.
+
+mdsmith's generated-section model lives in the same files. A repo
+like mdsmith's own — whose `CLAUDE.md` body is `<?catalog?>` and
+`<?include?>` output — that also adopted APM would have two
+generators writing one file, each blind to the other's markers.
+Questions a shared user hits immediately:
+
+- Does `mdsmith fix` reflow or edit content inside the APM block?
+  (Nothing marks it as foreign; rules and fixers see plain
+  Markdown and an HTML comment.)
+- Does the mdsmith merge driver handle conflicts inside
+  `<!-- apm:start -->` blocks? (No — it resolves conflicts inside
+  `<?directive?>` blocks only.)
+- Who wins when both tools' fix loops run in one pre-commit hook?
+
+The compiled root files are also where token budgets bite: every
+installed package appends instructions, and no tool reports what
+the assembled `AGENTS.md` costs. mdsmith's `token-budget` rule and
+`mdsmith metrics` already measure exactly this per file.
+
+## Consume packages
+
+`apm install` drops third-party Markdown into committed paths
+(`.github/prompts/`, `.claude/commands/`, `.agents/skills/`, …)
+and pins a SHA-256 per deployed file in `apm.lock.yaml`. Two
+mechanical conflicts follow for any repo that also runs mdsmith:
+
+- **Fix-vs-hash.** `mdsmith fix .` reformats every Markdown file
+  it walks. Reformatting a deployed file changes its hash, so the
+  next `apm audit --ci` reports drift and the next `apm install`
+  warns before cleanup. The two tools' invariants collide unless
+  the deployed globs are excluded from fixing.
+- **Check-vs-vendored.** Third-party primitives were written to
+  their author's conventions, not the consumer repo's `.mdsmith.yml`.
+  Without an `ignore:` entry or a relaxed kind per deployed
+  directory, `mdsmith check .` fails on files the team cannot
+  edit.
+
+Link integrity adds a third wrinkle: deployed primitives carry
+links rewritten into the gitignored `apm_modules/`, valid only
+after an install. MDS027 walks and flags them on a fresh clone.
+
+None of this needs new machinery to resolve — `ignore:`,
+overrides, and kinds express the posture — but the posture is
+subtle enough that it needs to ship as documentation or a preset,
+not be rediscovered per repo.
+
+## Distribute
+
+`apm pack` and `apm publish` bundle `apm.yml`, the `.apm/` tree,
+and the root docs — `README.md` is the marketplace listing page.
+A package's README quality is its storefront; mdsmith's content
+rules plus the repo's own docs-quality stack (readability,
+anti-slop conventions, link integrity) apply as-is. The
+marketplace `packages[]` descriptions in `apm.yml` are YAML and
+out of mdsmith's lane.
+
+## Gate in CI
+
+APM's CI story is `apm install --frozen` plus `apm audit --ci`
+(eight baseline checks, SARIF output, GitHub rulesets). mdsmith's
+CI story is `mdsmith check .` via the GitHub Action. They gate
+different failure classes — dependency integrity vs. content
+quality — and compose cleanly if ordered install → audit → check,
+with the fix-vs-hash exclusion above in place. Neither tool's docs
+mention the other today; the composition is unwritten.
+
+Migration is the workflow where the pairing is strongest: a team
+moving scattered instruction files into `.apm/` is doing a bulk
+Markdown restructuring — exactly what `mdsmith check`, kinds with
+`path-pattern`, and MDS033 (directory structure) are built to
+police, and what the repo's own
+[markdown-audit skill](../../../.claude/skills/markdown-audit/SKILL.md)
+automates.

--- a/plan/2607082048_apm-input-placeholder-token.md
+++ b/plan/2607082048_apm-input-placeholder-token.md
@@ -1,0 +1,93 @@
+---
+id: 2607082048
+title: "Placeholder token for APM `${input:name}` prompt parameters"
+status: "🔲"
+model: sonnet
+summary: >-
+  Add one token to the closed placeholder vocabulary that matches
+  APM `${input:NAME}` prompt parameters, so MDS023, MDS024, MDS018,
+  and MDS004 treat them as opaque instead of prose. Opportunity A-3
+  in the APM research.
+depends-on: []
+---
+# Placeholder token for APM `${input:name}`
+
+## Goal
+
+Let a rule treat APM's `${input:name}` prompt
+parameters as opaque, the same way
+[`var-token`](../docs/background/concepts/placeholder-grammar.md)
+already handles `{identifier}` interpolations. An
+APM `.prompt.md` body dense with `${input:pr_url}`
+tokens should not trip the prose rules on text that
+is a template variable, not content.
+
+## Background
+
+APM `.prompt.md` bodies interpolate `${input:NAME}`
+tokens; `apm run` substitutes `--param` values into
+them, and `apm install` rewrites them per harness
+(kept verbatim for Copilot, rewritten to `$name` for
+Claude). The input-name grammar APM documents is
+`[A-Za-z][\w-]{0,63}`.
+
+mdsmith's placeholder vocabulary is a closed set. The
+`var-token` matcher recognizes only `{identifier}`
+forms, so `${input:pr_url}` is opaque to nothing:
+[MDS023](../internal/rules/MDS023-paragraph-readability/README.md),
+[MDS024](../internal/rules/MDS024-paragraph-structure/README.md),
+[MDS018](../internal/rules/MDS018-no-emphasis-as-heading/README.md),
+and
+[MDS004](../internal/rules/MDS004-first-line-heading/README.md)
+all read the token as prose. This is opportunity A-3
+in the
+[APM opportunity catalogue](../docs/research/apm-mdsmith/opportunities.md).
+
+## Non-Goals
+
+- Declaration/usage cross-checking (an undeclared or
+  case-mismatched `${input:Scope}`). That is a
+  separate rule, opportunity A-6.
+- The post-Claude `$name` bare form. This plan covers
+  the source `${input:NAME}` form only.
+- Shipping the full APM kind pack. That is
+  [plan 2607082050](2607082050_apm-coexist-guide-and-kind-pack.md);
+  this token is a dependency it names.
+
+## Tasks
+
+1. Red/green: unit tests in
+   [`internal/placeholders`](../internal/placeholders/)
+   for `ContainsBodyToken` and `MaskBodyTokens` on
+   `${input:pr_url}`, `${input:focus-area}`, and a
+   non-matching `${output:x}`.
+2. Add the token constant and its matcher to the
+   closed vocabulary: shape `${input:NAME}` with
+   `NAME` matching `[A-Za-z][\w-]{0,63}`. Compile the
+   pattern at package scope per the allocation budget.
+3. Wire the token into `ContainsBodyToken` (skip
+   check) and `MaskBodyTokens` (mask to a neutral
+   word) so readability and structure rules score the
+   non-placeholder text.
+4. Document the token in
+   [placeholder-grammar.md](../docs/background/concepts/placeholder-grammar.md):
+   add the vocabulary-table row and the opt-in rule
+   list.
+5. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] A paragraph whose only non-prose content is
+      `${input:pr_url}` produces no MDS023 or MDS024
+      diagnostic when the token is configured.
+- [ ] The token name appears in the placeholder
+      vocabulary table and the opt-in rule list.
+- [ ] The matcher rejects `${notinput:x}` and
+      `${input:bad name}` (space is outside the
+      grammar).
+- [ ] `Check` stays within the allocation budget
+      (regexp compiled at package scope).
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint
+      run` reports no issues.
+- [ ] `mdsmith check .` — 0 failures.

--- a/plan/2607082049_foreign-managed-regions.md
+++ b/plan/2607082049_foreign-managed-regions.md
@@ -1,0 +1,106 @@
+---
+id: 2607082049
+title: "Foreign managed-region protection for `mdsmith fix`"
+status: "🔲"
+model: opus
+summary: >-
+  Add a `foreign-regions:` config listing `{start, end}` marker
+  pairs (e.g. APM's `<!-- apm:start -->`/`<!-- apm:end -->`) that
+  the fix pipeline treats as opaque and style rules skip, while
+  whole-file rules still count the bytes. Opportunity C-1.
+depends-on: []
+---
+# Foreign managed-region protection
+
+## Goal
+
+Make `mdsmith fix` and the style rules safe inside a
+region another generator owns. APM is the first case.
+Its `managed_section` mode writes a block bounded by
+`<!-- apm:start -->` and `<!-- apm:end -->`. A repo
+must be able to declare that block so mdsmith never
+rewrites its bytes.
+
+## Background
+
+APM's `managed_section` compile mode writes agent
+context into a block bounded by `<!-- apm:start -->`
+and `<!-- apm:end -->` and pins a SHA-256 of the
+file in `apm.lock.yaml`. The sanctioned migration
+path wraps a hand-written `AGENTS.md` with those
+markers.
+
+mdsmith's
+[generated-section engine](../docs/background/concepts/generated-section.md)
+recognizes only its own `<?directive?>` markers. It
+has no concept of a foreign generator's region, so
+`mdsmith fix` reflows the bytes inside an APM block
+(table alignment, trailing-space trimming, optional
+reflow). That changes the bytes `apm audit --ci`
+verifies and trips its drift check. This is
+opportunity C-1 in the
+[APM opportunity catalogue](../docs/research/apm-mdsmith/opportunities.md);
+the collision is documented in the
+[workflows analysis](../docs/research/apm-mdsmith/workflows.md).
+
+The generated-section engine is the template here. It
+already keeps fixers out of directive bodies. Whole-file
+metrics still count those bytes.
+
+## Non-Goals
+
+- Regenerating the foreign region. mdsmith treats it
+  as opaque; the owning tool regenerates it.
+- Resolving merge conflicts inside a foreign region.
+  The
+  [merge driver](../docs/reference/cli/merge-driver.md)
+  stays scoped to mdsmith's own directive blocks.
+- Auto-detecting markers. Regions are declared in
+  config, not inferred.
+
+## Tasks
+
+1. Red/green: config parse tests for a top-level
+   `foreign-regions:` key — a list of
+   `{start, end}` string pairs, glob-scopable through
+   [`overrides:`](../docs/reference/globs.md).
+2. Red/green: region-scanner tests that locate
+   matched marker pairs in a file and report byte
+   ranges; cover zero markers, a single unmatched
+   marker, and nested/duplicate pairs.
+3. Wire the fix pipeline to treat bytes inside a
+   matched region as opaque — no fixer rewrites them
+   — reusing the exclusion path the generated-section
+   engine already uses.
+4. Make style and content rules skip diagnostics
+   inside a region, while whole-file rules
+   ([MDS022](../internal/rules/MDS022-max-file-length/README.md),
+   [MDS028](../internal/rules/MDS028-token-budget/README.md))
+   still count the bytes.
+5. Add a check that diagnoses a malformed region
+   (start without end, or a duplicated marker), since
+   APM requires each marker exactly once.
+6. Write the reference doc for `foreign-regions:` and
+   link it from the
+   [coexist-with-APM guide](2607082050_apm-coexist-guide-and-kind-pack.md).
+7. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] `mdsmith fix` leaves bytes between a declared
+      `{start, end}` pair unchanged, including
+      otherwise-fixable trailing spaces and table
+      misalignment.
+- [ ] A style-rule violation inside the region emits
+      no diagnostic; the same violation outside it
+      still does.
+- [ ] MDS022 and MDS028 still count the region's
+      bytes toward file length and token budget.
+- [ ] A start marker with no matching end marker
+      produces a diagnostic.
+- [ ] The region config is glob-scopable via
+      `overrides:`.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint
+      run` reports no issues.
+- [ ] `mdsmith check .` — 0 failures.

--- a/plan/2607082050_apm-coexist-guide-and-kind-pack.md
+++ b/plan/2607082050_apm-coexist-guide-and-kind-pack.md
@@ -1,0 +1,107 @@
+---
+id: 2607082050
+title: "Coexist-with-APM guide and primitive kind pack"
+status: "🔲"
+model: sonnet
+summary: >-
+  Ship docs/guides/coexist-with-apm.md with the canonical `ignore:`
+  and `overrides:` set that keeps `mdsmith fix` off APM's
+  hash-pinned deployed files, plus a copy-paste kind pack that lints
+  the `.apm/` primitive sources. Opportunities C-2, A-1, A-2, L-1.
+depends-on: [2607082048]
+---
+# Coexist-with-APM guide and kind pack
+
+## Goal
+
+Give a repo that runs both mdsmith and APM one guide
+that says exactly which files mdsmith must leave
+alone and which kinds to apply to the `.apm/` source
+it should lint. Today both invariants are expressible
+in config, but no page assembles them, so every team
+rediscovers the boundary.
+
+## Background
+
+[APM](https://github.com/microsoft/apm) deploys
+third-party Markdown into committed paths
+(`.github/prompts/`, `.claude/rules/`,
+`.agents/skills/`, and more) and pins a SHA-256 per
+file in `apm.lock.yaml`. A repo-wide `mdsmith fix`
+rewrites those bytes and trips `apm audit --ci`. The
+same files were authored to their package's
+conventions, not the consumer's, so `mdsmith check`
+fails on files the team cannot edit. Both problems
+are laid out in the
+[APM workflows analysis](../docs/research/apm-mdsmith/workflows.md)
+and catalogued as C-2, L-1, A-1, and A-2 in the
+[opportunity catalogue](../docs/research/apm-mdsmith/opportunities.md).
+
+The `.apm/` source tree is the opposite case: it is
+the author's own Markdown, with contractual front
+matter APM's docs state but never enforce. mdsmith
+kinds are the checker — the exact pattern the repo
+already runs for its own `skill` and `plan` kinds.
+
+This guide follows the pattern of the
+[Prettier guide](../docs/guides/coexist-with-prettier.md)
+and the
+[Vale + remark guide](../docs/guides/coexist-with-vale-and-remark.md).
+
+## Non-Goals
+
+- Foreign managed-region support inside the compiled
+  files. That is
+  [plan 2607082049](2607082049_foreign-managed-regions.md);
+  this guide references it and, until it lands, tells
+  users to `ignore:` the compiled root files.
+- Schema grammar changes. Closed frontmatter and
+  filename agreement are
+  [plan 2607082051](2607082051_apm-schema-extensions.md);
+  the kind pack here uses only today's grammar.
+- Running APM. The guide documents coexistence, not
+  APM setup.
+
+## Tasks
+
+1. Write `docs/guides/coexist-with-apm.md` with an
+   ownership table: which tool owns each file class
+   (APM-deployed, APM-compiled, `.apm/` source,
+   hand-authored).
+2. Ship the canonical `ignore:` list naming APM's
+   deploy directories, plus `overrides:` disabling
+   fix-capable rules on the compiled root files
+   (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
+   `.github/copilot-instructions.md`) when
+   APM-managed.
+3. Ship the kind pack: `apm-skill`, `apm-prompt`,
+   `apm-instruction`, and `apm-agent` kinds with
+   `path-pattern` and inline frontmatter schemas
+   matching the
+   [primitive contracts](../docs/research/apm-mdsmith/apm-model.md),
+   plus per-kind `max-file-length` and `token-budget`
+   (500 lines / 5000 tokens for `SKILL.md`, 300 lines
+   for agents). The `apm-prompt` kind opts its content
+   rules into the
+   [`${input:name}` token](2607082048_apm-input-placeholder-token.md).
+4. Add the guide to the features/guides catalog and
+   cross-link it from the research README.
+5. Verify the shipped config: create a scratch `.apm/`
+   fixture and confirm `mdsmith check` passes on a
+   conformant tree and flags a missing `description`.
+6. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] `docs/guides/coexist-with-apm.md` exists and
+      passes `mdsmith check` under the guides kind.
+- [ ] The guide's `ignore:` block, pasted into a
+      consumer `.mdsmith.yml`, stops `mdsmith fix`
+      from rewriting a file under `.github/prompts/`.
+- [ ] The kind pack flags a `.apm/skills/x/SKILL.md`
+      missing `name` or `description`.
+- [ ] The kind pack flags an `.apm/agents/x.agent.md`
+      body over 300 lines.
+- [ ] The guide is reachable from the guides catalog
+      and the research README.
+- [ ] `mdsmith check .` — 0 failures.

--- a/plan/2607082050_apm-coexist-guide-and-kind-pack.md
+++ b/plan/2607082050_apm-coexist-guide-and-kind-pack.md
@@ -1,25 +1,26 @@
 ---
 id: 2607082050
-title: "Coexist-with-APM guide and primitive kind pack"
+title: "APM coexistence: `mdsmith init --apm`, guide, and kind pack"
 status: "🔲"
 model: sonnet
 summary: >-
-  Ship docs/guides/coexist-with-apm.md with the canonical `ignore:`
-  and `overrides:` set that keeps `mdsmith fix` off APM's
-  hash-pinned deployed files, plus a copy-paste kind pack that lints
-  the `.apm/` primitive sources. Opportunities C-2, A-1, A-2, L-1.
+  Add an `mdsmith init --apm` template that scaffolds the APM kind
+  pack (`.mdsmith/kinds/apm-*`) plus the `ignore:`/`overrides:`
+  posture that keeps `mdsmith fix` off APM's hash-pinned deployed
+  files, and document it in a coexist guide. Opportunities C-2, A-1,
+  A-2, L-1.
 depends-on: [2607082048]
 ---
-# Coexist-with-APM guide and kind pack
+# APM coexistence template and guide
 
 ## Goal
 
-Give a repo that runs both mdsmith and APM one guide
-that says exactly which files mdsmith must leave
-alone and which kinds to apply to the `.apm/` source
-it should lint. Today both invariants are expressible
-in config, but no page assembles them, so every team
-rediscovers the boundary.
+Let one command set up a repo that runs both mdsmith
+and APM. `mdsmith init --apm` scaffolds the kind pack
+that lints the `.apm/` sources and the
+`ignore:`/`overrides:` posture that keeps `mdsmith
+fix` off APM's hash-pinned deployed files. A guide
+documents what the template writes and why.
 
 ## Background
 
@@ -29,10 +30,9 @@ third-party Markdown into committed paths
 `.agents/skills/`, and more) and pins a SHA-256 per
 file in `apm.lock.yaml`. A repo-wide `mdsmith fix`
 rewrites those bytes and trips `apm audit --ci`. The
-same files were authored to their package's
-conventions, not the consumer's, so `mdsmith check`
-fails on files the team cannot edit. Both problems
-are laid out in the
+same files follow their package's conventions, not
+the consumer's, so `mdsmith check` fails on files the
+team cannot edit. Both problems are laid out in the
 [APM workflows analysis](../docs/research/apm-mdsmith/workflows.md)
 and catalogued as C-2, L-1, A-1, and A-2 in the
 [opportunity catalogue](../docs/research/apm-mdsmith/opportunities.md).
@@ -40,68 +40,96 @@ and catalogued as C-2, L-1, A-1, and A-2 in the
 The `.apm/` source tree is the opposite case: it is
 the author's own Markdown, with contractual front
 matter APM's docs state but never enforce. mdsmith
-kinds are the checker — the exact pattern the repo
-already runs for its own `skill` and `plan` kinds.
+kinds are the checker — the pattern the repo already
+runs for its own `skill` and `plan` kinds.
 
-This guide follows the pattern of the
-[Prettier guide](../docs/guides/coexist-with-prettier.md)
-and the
-[Vale + remark guide](../docs/guides/coexist-with-vale-and-remark.md).
+Both halves are expressible in config today. But no
+command assembles them, so every team rediscovers the
+boundary by hand.
+[`mdsmith init`](../docs/reference/cli/init.md) already
+scaffolds config two ways. `--from-markdownlint`
+converts a peer config. `--wordlists` writes the
+curated `.mdsmith/wordlists/` files, additively, and
+never clobbers an existing setup. `--apm` follows the
+`--wordlists` model.
 
 ## Non-Goals
 
 - Foreign managed-region support inside the compiled
   files. That is
   [plan 2607082049](2607082049_foreign-managed-regions.md);
-  this guide references it and, until it lands, tells
-  users to `ignore:` the compiled root files.
+  the template `ignore:`s the compiled root files
+  until it lands.
 - Schema grammar changes. Closed frontmatter and
   filename agreement are
   [plan 2607082051](2607082051_apm-schema-extensions.md);
-  the kind pack here uses only today's grammar.
-- Running APM. The guide documents coexistence, not
-  APM setup.
+  the kind pack uses only today's grammar.
+- Running APM, or editing `apm.yml`. The template
+  writes mdsmith config only.
 
 ## Tasks
 
-1. Write `docs/guides/coexist-with-apm.md` with an
-   ownership table: which tool owns each file class
-   (APM-deployed, APM-compiled, `.apm/` source,
-   hand-authored).
-2. Ship the canonical `ignore:` list naming APM's
-   deploy directories, plus `overrides:` disabling
-   fix-capable rules on the compiled root files
-   (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
-   `.github/copilot-instructions.md`) when
-   APM-managed.
-3. Ship the kind pack: `apm-skill`, `apm-prompt`,
-   `apm-instruction`, and `apm-agent` kinds with
-   `path-pattern` and inline frontmatter schemas
-   matching the
+1. Add `--apm` to
+   [`mdsmith init`](../docs/reference/cli/init.md),
+   modeled on `--wordlists`: additive, refuses to
+   clobber, works on an already-initialized project.
+2. Have `--apm` write the kind pack as
+   `.mdsmith/kinds/` files — `apm-skill`,
+   `apm-prompt`, `apm-instruction`, `apm-agent` —
+   each with `path-pattern` and an inline frontmatter
+   schema matching the
    [primitive contracts](../docs/research/apm-mdsmith/apm-model.md),
    plus per-kind `max-file-length` and `token-budget`
    (500 lines / 5000 tokens for `SKILL.md`, 300 lines
    for agents). The `apm-prompt` kind opts its content
    rules into the
    [`${input:name}` token](2607082048_apm-input-placeholder-token.md).
-4. Add the guide to the features/guides catalog and
-   cross-link it from the research README.
-5. Verify the shipped config: create a scratch `.apm/`
-   fixture and confirm `mdsmith check` passes on a
-   conformant tree and flags a missing `description`.
-6. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
+3. Have `--apm` write the coexistence posture: the
+   `ignore:` list naming APM's deploy directories and
+   `overrides:` disabling fix-capable rules on the
+   compiled root files (`AGENTS.md`, `CLAUDE.md`,
+   `GEMINI.md`, `.github/copilot-instructions.md`).
+   On a fresh repo it lands in a new `.mdsmith.yml`;
+   on an existing one it prints the block to merge,
+   never rewriting the file — the `--wordlists` rule.
+4. Scope the `ignore:` set to the harness directories
+   actually present, reusing the filesystem detection
+   `apm targets` uses (`.claude/` present → claude
+   dirs), so the config names only real paths.
+5. Write `docs/guides/coexist-with-apm.md`: the
+   ownership table (APM-deployed, APM-compiled,
+   `.apm/` source, hand-authored), what `--apm`
+   writes, and the `apm audit --ci` + `mdsmith check`
+   CI ordering. Follow the
+   [Prettier guide](../docs/guides/coexist-with-prettier.md)
+   and
+   [Vale + remark guide](../docs/guides/coexist-with-vale-and-remark.md).
+6. Add the guide to the guides catalog, cross-link the
+   research README, and document `--apm` in the init
+   reference and its `--wordlists` neighbor.
+7. Verify end to end: run `mdsmith init --apm` in a
+   scratch `.apm/` fixture and confirm `mdsmith check`
+   passes on a conformant tree and flags a missing
+   `description`.
+8. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
 
 ## Acceptance Criteria
 
-- [ ] `docs/guides/coexist-with-apm.md` exists and
-      passes `mdsmith check` under the guides kind.
-- [ ] The guide's `ignore:` block, pasted into a
-      consumer `.mdsmith.yml`, stops `mdsmith fix`
-      from rewriting a file under `.github/prompts/`.
+- [ ] `mdsmith init --apm` writes the `apm-*` kind
+      files and the coexistence posture, and refuses
+      to clobber an existing `.mdsmith.yml`.
+- [ ] After `mdsmith init --apm`, `mdsmith fix` does
+      not rewrite a file under `.github/prompts/`.
 - [ ] The kind pack flags a `.apm/skills/x/SKILL.md`
       missing `name` or `description`.
 - [ ] The kind pack flags an `.apm/agents/x.agent.md`
       body over 300 lines.
-- [ ] The guide is reachable from the guides catalog
-      and the research README.
+- [ ] The `ignore:` set names only harness
+      directories present in the repo.
+- [ ] `docs/guides/coexist-with-apm.md` exists, is
+      reachable from the guides catalog and research
+      README, and the init reference lists `--apm`.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint
+      run` reports no issues.
 - [ ] `mdsmith check .` — 0 failures.

--- a/plan/2607082051_apm-schema-extensions.md
+++ b/plan/2607082051_apm-schema-extensions.md
@@ -5,7 +5,7 @@ status: "🔲"
 model: opus
 summary: >-
   Two MDS020 schema-engine features for APM's primitive contracts: a
-  `frontmatter-closed: true` flag that flags undeclared frontmatter
+  `frontmatter-closed: true` flag that reports undeclared frontmatter
   keys, and `\#(fmvar(name))` interpolation in the schema
   path/filename matcher. Opportunities A-4 and A-5.
 depends-on: []

--- a/plan/2607082051_apm-schema-extensions.md
+++ b/plan/2607082051_apm-schema-extensions.md
@@ -1,0 +1,106 @@
+---
+id: 2607082051
+title: "Schema extensions: closed frontmatter and filename agreement"
+status: "🔲"
+model: opus
+summary: >-
+  Two MDS020 schema-engine features for APM's primitive contracts: a
+  `frontmatter-closed: true` flag that flags undeclared frontmatter
+  keys, and `\#(fmvar(name))` interpolation in the schema
+  path/filename matcher. Opportunities A-4 and A-5.
+depends-on: []
+---
+# Schema extensions for APM contracts
+
+## Goal
+
+Two APM rules have no home in mdsmith's
+[schema grammar](../docs/reference/section-schema.md)
+today. One rejects front-matter keys a schema does
+not declare. The other makes a filename match a
+front-matter field.
+
+## Background
+
+Two APM contracts have no mdsmith expression, both
+verified against the schema engine:
+
+- `.apm/prompts/*.prompt.md` preserves exactly five
+  frontmatter keys (`description`, `input`,
+  `allowed-tools`, `model`, `argument-hint`); `apm
+  compile` silently drops every other key. Catching a
+  dropped key at author time needs a closed
+  frontmatter check, but mdsmith's `closed:` applies
+  only to sections
+  ([section-schema.md](../docs/reference/section-schema.md)),
+  and on a frontmatter-only kind the setting is
+  dropped.
+- `.apm/skills/<name>/SKILL.md` requires the `name`
+  field to equal the directory name. mdsmith's
+  `path-pattern:` / `filename:` matcher validates the
+  filename against a static glob, never against a
+  frontmatter value.
+
+Both are catalogued as A-4 and A-5 in the
+[APM opportunity catalogue](../docs/research/apm-mdsmith/opportunities.md).
+The `\#(fmvar(name))` interpolation already exists for
+heading regexes in the schema engine, so feature (b)
+extends a resolver that is already present rather than
+adding one.
+
+## Non-Goals
+
+- New rules. Both features extend the existing
+  [MDS020](../internal/rules/MDS020-required-structure/README.md)
+  required-structure host rule.
+- Changing the default. `frontmatter-closed` defaults
+  to false; every existing schema keeps its current
+  behavior.
+- The APM kind pack itself. That is
+  [plan 2607082050](2607082050_apm-coexist-guide-and-kind-pack.md),
+  which consumes these features once they land.
+
+## Tasks
+
+1. Red/green: schema-parse and MDS020 tests for a
+   `frontmatter-closed: true` flag that emits one
+   diagnostic per frontmatter key absent from the
+   `frontmatter:` map. Cover the multi-kind case
+   (a file matching two kinds: the key is allowed if
+   any kind declares it).
+2. Implement `frontmatter-closed` on the frontmatter
+   schema, defaulting to false and composing across
+   kinds by union.
+3. Red/green: matcher tests for `\#(fmvar(name))`
+   inside `path-pattern:` / `filename:`, resolving the
+   token from front matter before the filename
+   comparison. Cover a match, a mismatch, and a
+   missing field.
+4. Implement `\#(fmvar(...))` interpolation in the
+   path/filename matcher, reusing the existing `fmvar`
+   resolver.
+5. Document both keys in
+   [section-schema.md](../docs/reference/section-schema.md)
+   with an APM example for each.
+6. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] A kind with `frontmatter-closed: true` flags a
+      frontmatter key not in its `frontmatter:` map,
+      and stays silent when the flag is false or
+      absent.
+- [ ] A file matching two kinds accepts a key
+      declared by either kind under
+      `frontmatter-closed`.
+- [ ] `path-pattern: ".apm/skills/\#(fmvar(name))/SKILL.md"`
+      passes when `name` equals the directory and
+      fails when it does not.
+- [ ] A missing `name` field under an `fmvar` path
+      matcher produces a clear diagnostic, not a
+      panic.
+- [ ] Both keys are documented with an APM example.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint
+      run` reports no issues.
+- [ ] `mdsmith check .` — 0 failures.

--- a/plan/2607082051_apm-schema-extensions.md
+++ b/plan/2607082051_apm-schema-extensions.md
@@ -28,12 +28,13 @@ verified against the schema engine:
 - `.apm/prompts/*.prompt.md` preserves exactly five
   frontmatter keys (`description`, `input`,
   `allowed-tools`, `model`, `argument-hint`); `apm
-  compile` silently drops every other key. Catching a
-  dropped key at author time needs a closed
-  frontmatter check, but mdsmith's `closed:` applies
-  only to sections
+  compile` drops every other key with a diagnostic,
+  but only at compile time, after the file is written
+  and shipped. Catching a dropped key at author time
+  needs a closed frontmatter check, and mdsmith's
+  `closed:` applies only to sections
   ([section-schema.md](../docs/reference/section-schema.md)),
-  and on a frontmatter-only kind the setting is
+  so on a frontmatter-only kind the setting is
   dropped.
 - `.apm/skills/<name>/SKILL.md` requires the `name`
   field to equal the directory name. mdsmith's

--- a/plan/2607082052_check-sarif-output.md
+++ b/plan/2607082052_check-sarif-output.md
@@ -7,7 +7,7 @@ summary: >-
   Add `-f sarif` to `mdsmith check` (and `fix --dry-run`) so its
   diagnostics land in the same GitHub Code Scanning dashboard APM's
   `apm audit --ci -f sarif` feeds. Generalize the SARIF machinery
-  the security-review engine already ships. Opportunity G-2.
+  that the security-review engine already ships. Opportunity G-2.
 depends-on: []
 ---
 # SARIF output for `mdsmith check`

--- a/plan/2607082052_check-sarif-output.md
+++ b/plan/2607082052_check-sarif-output.md
@@ -1,0 +1,94 @@
+---
+id: 2607082052
+title: "SARIF output format for `mdsmith check`"
+status: "🔲"
+model: sonnet
+summary: >-
+  Add `-f sarif` to `mdsmith check` (and `fix --dry-run`) so its
+  diagnostics land in the same GitHub Code Scanning dashboard APM's
+  `apm audit --ci -f sarif` feeds. Generalize the SARIF machinery
+  the security-review engine already ships. Opportunity G-2.
+depends-on: []
+---
+# SARIF output for `mdsmith check`
+
+## Goal
+
+Let `mdsmith check` emit SARIF. Its findings then
+show up as GitHub Code Scanning alerts on a PR. That
+is where APM's `apm audit --ci` already uploads its
+own findings.
+
+## Background
+
+The documented APM CI pattern is `apm audit --ci
+--policy org -f sarif -o report.sarif`, uploaded via
+`github/codeql-action/upload-sarif`, so agent-context
+findings appear as Code Scanning alerts.
+[`mdsmith check`](../docs/reference/cli/check.md)
+emits only `text` or `json`, so its diagnostics on
+the same `.apm/` files cannot join that dashboard.
+This is opportunity G-2 in the
+[APM opportunity catalogue](../docs/research/apm-mdsmith/opportunities.md).
+
+mdsmith already renders SARIF today. The
+[security-review engine](../internal/secreview/sarif.go)
+and the
+[release audit](../internal/release/auditsarif.go)
+both emit it. So the renderer exists; it is just not
+wired to the check command. This plan moves those
+structs into a shared package and routes the check
+command's diagnostics through them. That makes the
+work `partial`, not new.
+
+## Non-Goals
+
+- Changing the default format. `text` stays the
+  default; SARIF is opt-in.
+- SARIF for the LSP surface. Editor diagnostics
+  already flow through LSP; this plan is the CLI
+  output path.
+- New diagnostic data. SARIF maps the file, line,
+  column, rule id, and severity the JSON format
+  already carries.
+
+## Tasks
+
+1. Red/green: extract the SARIF structs shared by
+   `internal/secreview` and `internal/release` into a
+   shared internal package with a stable rendering
+   test.
+2. Red/green: `formatDiagnostics` tests for a `sarif`
+   format that maps each diagnostic to a SARIF 2.1.0
+   result — `ruleId = MDS###`, `physicalLocation`
+   region from file/line/column, `level` from
+   severity.
+3. Emit one `reportingDescriptor` per fired rule with
+   a `helpUri` to the rule's doc page, and
+   `tool.driver.name = mdsmith` with the build
+   version.
+4. Add `sarif` to the `-f`/`--format` value set on
+   `check` and on `fix --dry-run`; update
+   [check.md](../docs/reference/cli/check.md) and
+   [fix.md](../docs/reference/cli/fix.md).
+5. Show the GitHub Actions upload snippet in the
+   coexist-with-APM guide's CI section.
+6. Run `mdsmith fix PLAN.md` and `mdsmith check .`.
+
+## Acceptance Criteria
+
+- [ ] `mdsmith check -f sarif docs/` emits valid
+      SARIF 2.1.0 with one result per diagnostic and
+      correct file/line/column regions.
+- [ ] Each fired rule appears once in
+      `tool.driver.rules` with a `helpUri`.
+- [ ] `fix --dry-run -f sarif` emits the same shape
+      for the diagnostics it would fix.
+- [ ] `text` remains the default when `-f` is
+      omitted.
+- [ ] The `check` and `fix` reference pages list the
+      `sarif` value.
+- [ ] All tests pass: `go test ./...`
+- [ ] `go tool -modfile=tools/go.mod golangci-lint
+      run` reports no issues.
+- [ ] `mdsmith check .` — 0 failures.


### PR DESCRIPTION
Research notes under `docs/research/apm-mdsmith/` analyzing how mdsmith can support, improve, or augment workflows built around [APM](https://github.com/microsoft/apm), Microsoft's Agent Package Manager. APM's payload is Markdown with contractual YAML front matter, deployed into committed paths and compiled into `AGENTS.md`/`CLAUDE.md` — the exact files mdsmith already lints and generates.

The analysis is systematic on two axes, both swept against a full map of mdsmith's shipped features:

- **Axis 1 — workflows** (`workflows.md`): the 29 APM user workflows, their Markdown surfaces, and the five clusters where mdsmith changes the outcome (authoring, compile, consume, distribute, CI gating).
- **Axis 2 — subcommands** (`subcommands.md`): all 32 `apm` subcommands and the Markdown each one reads or writes.
- `apm-model.md`: APM's manifest/lockfile, the seven primitive types and their exact front-matter contracts, compile targets (including `<!-- apm:start -->` managed sections), and the validation APM ships today.
- `opportunities.md`: the merged gap catalogue (A/C/L/G groups) with per-item status (`exists` / `partial` / `new`), effort, trigger, and a mini-plan — mirroring the `learn-from-mdbase.md` format.

## Plan files for the top opportunities

| Plan | Opportunity | Status |
|------|-------------|--------|
| 2607082048 | `${input:name}` placeholder token | new (S) |
| 2607082049 | Foreign managed-region protection for `mdsmith fix` | new (M) |
| 2607082050 | `mdsmith init --apm` coexistence template + guide + kind pack | partial (S) |
| 2607082051 | Schema extensions: closed frontmatter + `fmvar` path | new (M) |
| 2607082052 | SARIF output for `mdsmith check` | partial (S–M) |

## Headline conclusion

APM validates dependency integrity (hashes, lockfile, hidden Unicode) and stops where content quality starts. mdsmith owns content quality (schemas, style, size, links, generated sections) and knows nothing about APM's file shapes. The pairing needs an APM preset (scaffolded by `mdsmith init --apm`), a coexistence posture so `mdsmith fix` never rewrites hash-pinned deployed files, one new placeholder token, and a documented CI composition. Most machinery already exists; the connective config and docs do not.

`mdsmith check .` passes across the repo (542 files, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFG6Kp4hFdTkatnraDJsvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFG6Kp4hFdTkatnraDJsvZ)_