### PR TITLE
refactor(astutil): export CountLeadingSpaces and IsBlank, remove per-rule duplicates

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -243,7 +243,7 @@ footer: |
 | 2607040822 | 🔲     | opus   | [Refactor engine redesign: unify move and rename behind one Plan, across CLI, LSP, and WASM hosts](plan/2607040822_refactor-move-rename-redesign.md)    |
 | 2607051918 | ✅     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
 | 2607051919 | 🔲     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
-| 2607051920 | 🔲     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
+| 2607051920 | ✅     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
 | 2607071642 | 🔲     | sonnet | [Single-file metric extraction via `mdsmith metrics get` (readability first)](plan/2607071642_extractable-file-metrics.md)                              |
 | 2607082048 | 🔲     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |
 | 2607082049 | 🔲     | opus   | [Foreign managed-region protection for `mdsmith fix`](plan/2607082049_foreign-managed-regions.md)                                                       |

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -347,6 +347,17 @@ func extractTextBase(n ast.Node, source []byte, base int, buf *bytes.Buffer) {
 	}
 }
 
+// CountLeadingSpaces returns the number of leading space characters
+// (ASCII 0x20 only) in line.
+func CountLeadingSpaces(line []byte) int {
+	return len(line) - len(bytes.TrimLeft(line, " "))
+}
+
+// IsBlank reports whether line contains only space and tab characters.
+func IsBlank(line []byte) bool {
+	return len(bytes.TrimLeft(line, " \t")) == 0
+}
+
 // HeadingLineBase returns the 1-based source line of a heading whose inline
 // children carry run-local segment offsets (the parse-skipped path). base is
 // the run's start byte offset in f.Source. It mirrors HeadingLine exactly with

--- a/internal/rules/astutil/astutil_test.go
+++ b/internal/rules/astutil/astutil_test.go
@@ -813,3 +813,22 @@ func TestCollectSectionParagraphs_MemoizedPerFile(t *testing.T) {
 	require.Len(t, o, 1)
 	assert.Equal(t, "Different.", o[0].ExtractText(f2.Source))
 }
+
+// --- CountLeadingSpaces ---
+
+func TestCountLeadingSpaces(t *testing.T) {
+	assert.Equal(t, 0, CountLeadingSpaces([]byte("abc")))
+	assert.Equal(t, 2, CountLeadingSpaces([]byte("  abc")))
+	assert.Equal(t, 0, CountLeadingSpaces([]byte("")))
+	assert.Equal(t, 3, CountLeadingSpaces([]byte("   ")))
+}
+
+// --- IsBlank ---
+
+func TestIsBlank(t *testing.T) {
+	assert.True(t, IsBlank([]byte("")))
+	assert.True(t, IsBlank([]byte("   ")))
+	assert.True(t, IsBlank([]byte(" \t ")))
+	assert.False(t, IsBlank([]byte("a")))
+	assert.False(t, IsBlank([]byte("  a")))
+}

--- a/internal/rules/listindent/helpers_test.go
+++ b/internal/rules/listindent/helpers_test.go
@@ -3,6 +3,7 @@ package listindent
 import (
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,6 +19,6 @@ func TestCountLeadingSpaces(t *testing.T) {
 		{[]byte(" \tabc"), 1}, // tab is not a space; counting stops
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, countLeadingSpaces(tc.in), "countLeadingSpaces(%q)", tc.in)
+		assert.Equal(t, tc.want, astutil.CountLeadingSpaces(tc.in), "CountLeadingSpaces(%q)", tc.in)
 	}
 }

--- a/internal/rules/listindent/rule.go
+++ b/internal/rules/listindent/rule.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/listscan"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 )
@@ -96,7 +97,7 @@ func (r *Rule) verdict(f *lint.File, level, line int) (lint.Diagnostic, bool) {
 		return lint.Diagnostic{}, false
 	}
 	expectedIndent := level * spaces
-	actualIndent := countLeadingSpaces(f.Lines[line-1])
+	actualIndent := astutil.CountLeadingSpaces(f.Lines[line-1])
 	if actualIndent == expectedIndent {
 		return lint.Diagnostic{}, false
 	}
@@ -181,10 +182,6 @@ func firstLineOfChild(f *lint.File, n ast.Node) int {
 	return 0
 }
 
-func countLeadingSpaces(line []byte) int {
-	return len(line) - len(bytes.TrimLeft(line, " "))
-}
-
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
 	spaces := r.Spaces
@@ -246,7 +243,7 @@ func collectIndentAdjustments(f *lint.File, spaces int) map[int]int {
 			return ast.WalkContinue, nil
 		}
 
-		if countLeadingSpaces(f.Lines[line-1]) != expectedIndent {
+		if astutil.CountLeadingSpaces(f.Lines[line-1]) != expectedIndent {
 			adjMap[line] = expectedIndent
 		}
 

--- a/internal/rules/listscan/listscan.go
+++ b/internal/rules/listscan/listscan.go
@@ -27,7 +27,11 @@
 // (already in internal/lint/layer0.go) into this parser.
 package listscan
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
+)
 
 // Item is one parsed list item.
 type Item struct {
@@ -180,7 +184,7 @@ func (p *parser) run() {
 // new list item, or a continuation line.
 func (p *parser) scanLine(i int, line []byte) int {
 	lineNo := i + 1
-	indent := leadingSpaces(line)
+	indent := astutil.CountLeadingSpaces(line)
 	markerToken := hasMarkerToken(line, indent)
 	interrupts := interruptsParagraph(line, indent)
 
@@ -672,10 +676,6 @@ func contentColumn(line []byte, afterMarker int) int {
 	return afterMarker + spaces
 }
 
-func leadingSpaces(line []byte) int {
-	return len(line) - len(bytes.TrimLeft(line, " "))
-}
-
 func isBlankLine(line []byte) bool {
 	for _, c := range line {
 		if c != ' ' && c != '\t' && c != '\r' {
@@ -735,7 +735,7 @@ func openingFenceRel(line []byte, indent, baseCol int) (fenceInfo, bool) {
 // fence run sits no more than 3 columns past fi.baseCol, runs >= fi.length
 // identical fence characters, and is followed only by whitespace.
 func closingFence(line []byte, fi fenceInfo) bool {
-	indent := leadingSpaces(line)
+	indent := astutil.CountLeadingSpaces(line)
 	if indent-fi.baseCol >= 4 {
 		return false
 	}
@@ -752,7 +752,7 @@ func closingFence(line []byte, fi fenceInfo) bool {
 // isThematicBreak reports whether line is a thematic break (3+ of a
 // single -, *, or _ with only spaces between), which is not a list item.
 func isThematicBreak(line []byte) bool {
-	indent := leadingSpaces(line)
+	indent := astutil.CountLeadingSpaces(line)
 	if indent >= 4 || indent >= len(line) {
 		return false
 	}

--- a/internal/rules/noreferencestyle/helpers_test.go
+++ b/internal/rules/noreferencestyle/helpers_test.go
@@ -3,6 +3,7 @@ package noreferencestyle
 import (
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,6 +21,6 @@ func TestIsBlankLine(t *testing.T) {
 		{[]byte(" x"), false},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, isBlankLine(tc.in), "isBlankLine(%q)", tc.in)
+		assert.Equal(t, tc.want, astutil.IsBlank(tc.in), "IsBlank(%q)", tc.in)
 	}
 }

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -504,7 +504,6 @@ func paragraphEndLine(lines [][]byte, line int, defLines map[int]struct{}) int {
 	return end
 }
 
-
 func isNumericSlug(s string) bool {
 	if s == "" {
 		return false

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/setutil"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 	"github.com/jeduden/mdsmith/pkg/goldmark/text"
@@ -494,7 +495,7 @@ func footnotePlacementMessage(
 // end of file. lines is f.Lines (pre-split by lint.NewFile).
 func paragraphEndLine(lines [][]byte, line int, defLines map[int]struct{}) int {
 	end := line
-	for end < len(lines) && !isBlankLine(lines[end]) {
+	for end < len(lines) && !astutil.IsBlank(lines[end]) {
 		if _, ok := defLines[end+1]; ok {
 			break
 		}
@@ -503,9 +504,6 @@ func paragraphEndLine(lines [][]byte, line int, defLines map[int]struct{}) int {
 	return end
 }
 
-func isBlankLine(line []byte) bool {
-	return len(bytes.TrimLeft(line, " \t")) == 0
-}
 
 func isNumericSlug(s string) bool {
 	if s == "" {

--- a/internal/rules/orderedlistnumbering/helpers_test.go
+++ b/internal/rules/orderedlistnumbering/helpers_test.go
@@ -3,6 +3,7 @@ package orderedlistnumbering
 import (
 	"testing"
 
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ func TestCountLeadingSpaces(t *testing.T) {
 		{[]byte(" \tabc"), 1}, // tab is not a space; counting stops
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, countLeadingSpaces(tc.in), "countLeadingSpaces(%q)", tc.in)
+		assert.Equal(t, tc.want, astutil.CountLeadingSpaces(tc.in), "CountLeadingSpaces(%q)", tc.in)
 	}
 }
 
@@ -37,7 +38,7 @@ func TestIsBlank(t *testing.T) {
 		{[]byte(" x"), false},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, isBlank(tc.in), "isBlank(%q)", tc.in)
+		assert.Equal(t, tc.want, astutil.IsBlank(tc.in), "IsBlank(%q)", tc.in)
 	}
 }
 

--- a/internal/rules/orderedlistnumbering/rule.go
+++ b/internal/rules/orderedlistnumbering/rule.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/fencepos"
 	"github.com/jeduden/mdsmith/internal/rules/listscan"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
@@ -271,7 +272,7 @@ func (r *Rule) collectItemEdits(
 // existing leading whitespace are ignored to avoid eating non-space
 // content.
 func applyIndentShift(line []byte, shift int) []byte {
-	if shift == 0 || isBlank(line) {
+	if shift == 0 || astutil.IsBlank(line) {
 		return line
 	}
 	if shift > 0 {
@@ -279,20 +280,16 @@ func applyIndentShift(line []byte, shift int) []byte {
 		return append(pad, line...)
 	}
 	n := -shift
-	if countLeadingSpaces(line) < n {
+	if astutil.CountLeadingSpaces(line) < n {
 		return line
 	}
 	return line[n:]
 }
 
-func isBlank(line []byte) bool {
-	return len(bytes.TrimLeft(line, " \t")) == 0
-}
-
 // replaceLeadingDigits replaces a run of digits at the start of a line
 // (after any leading whitespace) with the decimal form of n.
 func replaceLeadingDigits(line []byte, n int) []byte {
-	leading := countLeadingSpaces(line)
+	leading := astutil.CountLeadingSpaces(line)
 	digitStart := leading
 	digitEnd := leading
 	for digitEnd < len(line) && isDigit(line[digitEnd]) {
@@ -371,10 +368,6 @@ func digitWidth(n int) int {
 		w++
 	}
 	return w
-}
-
-func countLeadingSpaces(line []byte) int {
-	return len(line) - len(bytes.TrimLeft(line, " "))
 }
 
 // firstLineOfListItem returns the 1-based source line of an item's

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/piparser"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	rulesettings "github.com/jeduden/mdsmith/internal/rules/settings"
 	"github.com/jeduden/mdsmith/internal/schema"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
@@ -1437,7 +1438,7 @@ func fenceOpenRun(raw, lineB []byte) (byte, int) {
 	if len(lineB) == 0 || (lineB[0] != '`' && lineB[0] != '~') {
 		return 0, 0
 	}
-	if lineIndent(raw) > 3 {
+	if astutil.CountLeadingSpaces(raw) > 3 {
 		return 0, 0
 	}
 	n := fenceRun(lineB, lineB[0])
@@ -1452,7 +1453,7 @@ func fenceOpenRun(raw, lineB []byte) (byte, int) {
 // opener, nothing but the run on the trimmed line, and at most three
 // spaces of indentation.
 func fenceClose(raw, lineB []byte, ch byte, openLen int) bool {
-	if lineIndent(raw) > 3 {
+	if astutil.CountLeadingSpaces(raw) > 3 {
 		return false
 	}
 	n := fenceRun(lineB, ch)
@@ -1468,18 +1469,13 @@ func fenceRun(line []byte, ch byte) int {
 	return n
 }
 
-// lineIndent returns the number of leading spaces on the raw line.
-func lineIndent(raw []byte) int {
-	return len(raw) - len(bytes.TrimLeft(raw, " "))
-}
-
 // isPIOpenLine reports whether a raw body line opens a processing
 // instruction, mirroring the block parser in pkg/markdown: at most
 // three spaces of indentation, a `<?` opener, and a non-empty name
 // (the bytes up to the first whitespace or `?>`). An indented code
 // example showing a directive is therefore not mistaken for one.
 func isPIOpenLine(raw []byte) bool {
-	if lineIndent(raw) > 3 {
+	if astutil.CountLeadingSpaces(raw) > 3 {
 		return false
 	}
 	trimmed := bytes.TrimLeft(raw, " ")

--- a/plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md
+++ b/plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md
@@ -3,7 +3,7 @@ id: 2607051920
 title: >-
   Consolidate duplicated leading-space/blank-line rule
   helpers into internal/rules/astutil
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   countLeadingSpaces and isBlank/isBlankLine are
@@ -75,11 +75,11 @@ stays as-is.
 
 ## Acceptance Criteria
 
-- [ ] `internal/rules/astutil` exports the shared
+- [x] `internal/rules/astutil` exports the shared
       leading-space and blank-line helpers, each with a
       dedicated test.
-- [ ] `listindent`, `orderedlistnumbering`, and
+- [x] `listindent`, `orderedlistnumbering`, and
       `noreferencestyle` no longer define their own
       copies.
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

- Exports `CountLeadingSpaces` and `IsBlank` from `internal/rules/astutil`, the doc-sanctioned shared home for rule helpers.
- Removes identical private copies from `listindent`, `orderedlistnumbering`, and `noreferencestyle`.
- Updates per-package helper tests to call the canonical astutil versions.
- Marks plan/2607051920 complete.

## Changes

**`internal/rules/astutil/astutil.go`** — two new exported helpers:
- `CountLeadingSpaces(line []byte) int` — counts leading ASCII spaces (cutset `" "`), replaces `countLeadingSpaces` in listindent and orderedlistnumbering.
- `IsBlank(line []byte) bool` — reports whether a line is all whitespace (cutset `" \t"`), replaces `isBlank` in orderedlistnumbering and `isBlankLine` in noreferencestyle.

**`internal/rules/astutil/astutil_test.go`** — `TestCountLeadingSpaces` and `TestIsBlank`.

**`internal/rules/listindent/rule.go`** — imports astutil; removes local `countLeadingSpaces`.

**`internal/rules/orderedlistnumbering/rule.go`** — imports astutil; removes local `countLeadingSpaces` and `isBlank`.

**`internal/rules/noreferencestyle/rule.go`** — imports astutil; removes local `isBlankLine`.

**Per-package helper tests** — updated to call `astutil.CountLeadingSpaces` / `astutil.IsBlank` directly.

## Test plan

- `go test ./internal/rules/astutil/...` — green (new unit tests)
- `go test ./internal/rules/listindent/... ./internal/rules/orderedlistnumbering/... ./internal/rules/noreferencestyle/...` — green
- `go test ./...` — all green
- `go build ./...` — clean
- `mdsmith check .` — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gj8AvSb7r12iqa7r3vYYof

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gj8AvSb7r12iqa7r3vYYof)_