### PR TITLE
test(architecture): add missing tests for public rule/directive contract methods

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -250,4 +250,5 @@ footer: |
 | 2607082050 | 🔲     | sonnet | [APM coexistence: `mdsmith init --apm`, guide, and kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                       |
 | 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |
 | 2607082052 | 🔲     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |
+| 2607121915 | 🔲     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
 <?/catalog?>

--- a/docs/development/architecture-audit-archive.md
+++ b/docs/development/architecture-audit-archive.md
@@ -158,3 +158,87 @@ rule-to-rule imports, or DIP violations.
 [2606211908]: ../../plan/2606211908_arch-fix-layer0-split.md
 [2606211909]: ../../plan/2606211909_arch-fix-lsp-server-split.md
 [2606211910]: ../../plan/2606211910_arch-fix-workspace-exemptions.md
+
+## Audit 2026-06-23 (range: e701b94..1599c9f)
+
+Performance + struct-alignment series;
+inline scanner refinements; benchmark
+additions. No TypeScript changes. 273 Go
+sources outside fixtures.
+
+No blockers. No rule-to-rule imports added.
+No DIP violations. New files are under 800
+lines. Struct alignment and `map[string]struct{}`
+changes are mechanical rewrites with no
+layering impact.
+
+### tax (2026-06-23)
+
+- `internal/lint/inline_scan.go` — 13
+  unexported helpers lack dedicated unit
+  tests. Tests doc §"every function by
+  name" — [plan/2606231013][2606231013].
+
+- `internal/rules/samefileanchor/rule.go`
+  — 12 unexported helpers lack dedicated
+  unit tests — [plan/2606231014][2606231014].
+
+[2606231013]: ../../plan/2606231013_arch-fix-inline-scan-helper-tests.md
+[2606231014]: ../../plan/2606231014_arch-fix-samefileanchor-helper-tests.md
+
+## Audit 2026-06-24 (range: 1599c9f..09f22d3)
+
+Perf series (struct-alignment, Sprintf→strconv,
+`[]byte` FindSubmatch, Builder). Plans 2606231013
+and 2606231014 closed. Benchmark docs and security
+SARIF retired. No TypeScript changes. 273 Go
+sources outside fixtures.
+
+No blockers. No rule-to-rule imports. No DIP
+violations. No file crossed 1 000 lines.
+
+### tax (2026-06-24)
+
+- `internal/index/locate.go` — 12 unexported
+  helpers lack dedicated unit tests. Tests doc
+  §"every function by name" —
+  [plan/2606240211][2606240211].
+
+- `internal/lsp/rename.go` — 15 unexported
+  helpers lack dedicated unit tests. Tests doc
+  §"every function by name" —
+  [plan/2606240212][2606240212].
+
+- `internal/export/export.go` — 11 unexported
+  helpers lack dedicated unit tests. Tests doc
+  §"every function by name" —
+  [plan/2606240213][2606240213].
+
+- `internal/lsp/rename.go` and
+  `internal/rename/rename.go` — `normalizedLabel`
+  and `refDefBracketBytes` are duplicated. Both
+  have identical bodies. Hub §"Anti-patterns" —
+  [plan/2606240214][2606240214].
+
+- `internal/rules/concisenessscoring/rule.go`
+  and `internal/rename/rename.go` —
+  `countClassifierTokens` and
+  `contentBlockLines` lack dedicated unit tests.
+  Batched into [plan/2606240213][2606240213].
+
+### nice-to-have (2026-06-24)
+
+- `internal/index/locate.go` —
+  `isGlobPattern` is a trivial one-liner with no
+  branch. Add "// no test by design" so the audit
+  can distinguish it from forgotten test debt.
+
+[2606240211]: ../../plan/2606240211_arch-fix-locate-helper-tests.md
+[2606240212]: ../../plan/2606240212_arch-fix-lsp-rename-helper-tests.md
+[2606240213]: ../../plan/2606240213_arch-fix-export-helper-tests.md
+[2606240214]: ../../plan/2606240214_arch-fix-rename-dedup.md
+
+## Audit 2026-06-24 (range: 09f22d3..3d35b77)
+
+Plans 2606241814/2606241815 green.
+No DIP, SRP, or line-count violations.

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,100 +6,165 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: 528ce4cf7df4f2fe7d15051e5a39390c27fdc82d
+audit-from: 834b56092d85c815c01bd6a8e4d955f43396ae3e
 ---
 # Architecture audit log
 
 This file is maintained by the
 solid-architecture skill in audit mode.
-Entries from 2026-04-28 through 2026-06-21 moved
+Entries from 2026-04-28 through 2026-06-24 moved
 to [the archive](architecture-audit-archive.md)
 this cycle to stay under the file-length budget;
 every finding there is resolved.
 
-## Audit 2026-06-23 (range: e701b94..1599c9f)
+## Audit 2026-07-12 (range: 528ce4c..834b560)
 
-Performance + struct-alignment series;
-inline scanner refinements; benchmark
-additions. No TypeScript changes. 273 Go
-sources outside fixtures.
+66 touched production Go files. No TypeScript changes.
 
-No blockers. No rule-to-rule imports added.
-No DIP violations. New files are under 800
-lines. Struct alignment and `map[string]struct{}`
-changes are mechanical rewrites with no
-layering impact.
+Scope:
 
-### tax (2026-06-23)
+- Every `internal/rules/*` package modified since the
+  last checkpoint.
+- `cmd/mdsmith`, `cmd/mdsmith-release`, `cue/cuelite`.
+- A dozen core `internal/*` packages: config,
+  convention, fix, index, linkgraph, lint, mdpath,
+  mdtext, punkt, release, schema, starter,
+  structlayout, wordlist.
+- The `pkg/goldmark`, `pkg/markdown/flavor`, and
+  `pkg/mdsmith` public-API layer.
 
-- `internal/lint/inline_scan.go` — 13
-  unexported helpers lack dedicated unit
-  tests. Tests doc §"every function by
-  name" — [plan/2606231013][2606231013].
+No rule-to-rule imports, no reverse-layer imports,
+no circular-import tells anywhere in the touched
+set.
 
-- `internal/rules/samefileanchor/rule.go`
-  — 12 unexported helpers lack dedicated
-  unit tests — [plan/2606231014][2606231014].
+### blockers (2026-07-12)
 
-[2606231013]: ../../plan/2606231013_arch-fix-inline-scan-helper-tests.md
-[2606231014]: ../../plan/2606231014_arch-fix-samefileanchor-helper-tests.md
+- `internal/rules/catalog/rule.go` and
+  `internal/rules/build/rule.go` — `RuleID`,
+  `RuleName`, `Validate` (both rules), and
+  `Generate` (build) implement
+  `gensection.Directive`, a generated-markers
+  contract surface per CLAUDE.md's cross-system
+  list. None had a dedicated unit test. Tests doc
+  §"blocker if the function is on a public
+  surface." Fixed: added `TestRule_RuleID`,
+  `TestRule_RuleName`, `TestRule_Validate` (both
+  rules) and `TestRule_Generate` (build); also
+  added the same pair for `include/rule.go`'s
+  `RuleID`/`RuleName`, which had the identical gap.
+- `internal/rules/listindent/rule.go` — `ID()` and
+  `Name()` (the `rule.Rule` contract) had no
+  dedicated test. Same doc citation. Fixed: added
+  `TestID`/`TestName`.
+- `internal/index/index.go` — `File()` is the
+  LSP/rename/deps query surface's primary lookup
+  and had no dedicated test of its hit/miss,
+  path-normalization, or copy-not-alias behavior.
+  Fixed: added `TestNew`/`TestIndex_File`.
+- `internal/linkgraph/wikilinks.go` —
+  `NewWikilinkIndex`/`ResolveWikiLink` call
+  `fs.WalkDir`, contradicting go.md's "Pure (no
+  file reads, no workspace walks)" claim for
+  `internal/linkgraph`. Go arch doc §"Single
+  responsibility per package" —
+  [plan/2607121915][2607121915].
 
-## Audit 2026-06-24 (range: 1599c9f..09f22d3)
+[2607121915]: ../../plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
 
-Perf series (struct-alignment, Sprintf→strconv,
-`[]byte` FindSubmatch, Builder). Plans 2606231013
-and 2606231014 closed. Benchmark docs and security
-SARIF retired. No TypeScript changes. 273 Go
-sources outside fixtures.
+### tax (2026-07-12)
 
-No blockers. No rule-to-rule imports. No DIP
-violations. No file crossed 1 000 lines.
+- Widespread missing-dedicated-test debt on
+  unexported helpers across nearly every touched
+  rule package (`catalog`, `build`,
+  `crossfilereferenceintegrity`, `duplicatedcontent`,
+  `firstlineheading`, `headingincrement`, `include`,
+  `linelength`, `linkstyle`, `listindent`, `listscan`,
+  `noreferencestyle`, `orderedlistnumbering`,
+  `propernames`, `requiredfrontmatter`,
+  `requiredstructure`, `requiredtextpatterns`,
+  `tableformat`, `tokenbudget`) and in `cue/cuelite`,
+  `internal/index`, `internal/lint`, `internal/config`,
+  `internal/release`, `pkg/mdsmith`, and
+  `pkg/goldmark/{ast,internal/fieldorder}`. All are
+  exercised transitively through `Check`/`Fix`/
+  `ApplySettings` integration-style tests, so behavior
+  is covered — only the by-name unit test is missing.
+  Candidate for a batched cleanup plan next cycle.
+- `internal/release/bench.go` — `fetchTool` and
+  `installMarkdownlint` are genuinely untested (not
+  just missing a name), despite the file already
+  having the fake HTTP/runner seams needed to test
+  them.
+- `internal/mdtext/upstreampunct.go`'s
+  `mdtext_punkt_upstream` build tag is never passed
+  in any CI workflow, unlike the analogous
+  `goldmark_upstream` tag — silent bit-rot risk for
+  `neurosnap/sentences` API drift.
+- `internal/config/deepmerge.go`'s `settingMergeMode`
+  hardcodes `settingKey == "lists"` instead of going
+  through the `rule.ListMerger` extension point built
+  for this. Go arch doc §"Interface segregation."
+- Cross-cutting duplication, all doing the same
+  "recompute line count minus trailing empty split
+  element" — `maxfilelength`, `maxsectionlength`,
+  `requiredmentions`, `requiredtextpatterns`, and
+  `metrics.Document.LineCount()` each carry their own
+  copy.
+- `internal/rules/crossfilereferenceintegrity/rule.go`'s
+  `toStringSlice` is byte-for-byte identical to
+  `internal/rules/settings.ToStringSlice`.
+- `firstlineheading.headingLevelFromSpan` and
+  `headingincrement.atxLevelFromLine`/
+  `setextLevelFromSpan` duplicate the same ATX/setext
+  leading-space-cap parsing verbatim; no shared home
+  in `astutil` yet.
+- `requiredfrontmatter.extractYAMLBody` and
+  `requiredstructure.extractYAML` are near-identical
+  front-matter-fence-stripping helpers, each written
+  independently on top of `lint.StripFrontMatter`.
+- `internal/fix.Fixer.effectiveWithCategories` and
+  `internal/engine.Runner.effectiveWithCategories`
+  duplicate the same `config.EffectiveAll` +
+  `config.ApplyCategories` pattern; only `Runner`'s
+  reuses a shared lookup helper.
+- SRP file-size bloat past the point of easy review:
+  `internal/rules/requiredstructure/rule.go` (2606
+  lines, 5 concerns), `internal/rules/catalog/rule.go`
+  (1761 lines, ~6 concerns beyond what the package's
+  existing file split already covers),
+  `internal/rules/crossfilereferenceintegrity/rule.go`
+  (~1130 lines, 3 concerns), `internal/schema/validate.go`
+  (1733 lines, 5 concerns), `internal/fix/fix.go` (838
+  lines, 5 concerns), `cmd/mdsmith/mergedriver.go` (905
+  lines, 4 concerns), `cmd/mdsmith/main.go` (911 lines,
+  nearing the ~1000-line smell threshold, with real
+  domain logic that could move to `internal/*`),
+  `internal/release/bench.go` (701 lines, 5 concerns).
+  None are DIP violations; all are readability/review-cost
+  friction, split candidates along the seams each
+  finding's source agent already named.
+- `overlay.go`'s `cleanKey` path-normalizer is
+  reimplemented inline five times in `MemWorkspace`
+  (`workspace.go`) instead of shared.
 
-### tax (2026-06-24)
+### nice-to-have (2026-07-12)
 
-- `internal/index/locate.go` — 12 unexported
-  helpers lack dedicated unit tests. Tests doc
-  §"every function by name" —
-  [plan/2606240211][2606240211].
-
-- `internal/lsp/rename.go` — 15 unexported
-  helpers lack dedicated unit tests. Tests doc
-  §"every function by name" —
-  [plan/2606240212][2606240212].
-
-- `internal/export/export.go` — 11 unexported
-  helpers lack dedicated unit tests. Tests doc
-  §"every function by name" —
-  [plan/2606240213][2606240213].
-
-- `internal/lsp/rename.go` and
-  `internal/rename/rename.go` — `normalizedLabel`
-  and `refDefBracketBytes` are duplicated. Both
-  have identical bodies. Hub §"Anti-patterns" —
-  [plan/2606240214][2606240214].
-
-- `internal/rules/concisenessscoring/rule.go`
-  and `internal/rename/rename.go` —
-  `countClassifierTokens` and
-  `contentBlockLines` lack dedicated unit tests.
-  Batched into [plan/2606240213][2606240213].
-
-### nice-to-have (2026-06-24)
-
-- `internal/index/locate.go` —
-  `isGlobPattern` is a trivial one-liner with no
-  branch. Add "// no test by design" so the audit
-  can distinguish it from forgotten test debt.
-
-[2606240211]: ../../plan/2606240211_arch-fix-locate-helper-tests.md
-[2606240212]: ../../plan/2606240212_arch-fix-lsp-rename-helper-tests.md
-[2606240213]: ../../plan/2606240213_arch-fix-export-helper-tests.md
-[2606240214]: ../../plan/2606240214_arch-fix-rename-dedup.md
-
-## Audit 2026-06-24 (range: 09f22d3..3d35b77)
-
-Plans 2606241814/2606241815 green.
-No DIP, SRP, or line-count violations.
+- `pkg/mdsmith`'s `OSWorkspace.Glob` ignores `Root`
+  while `OverlayWorkspace.Glob` joins against it —
+  both documented individually, worth one line on the
+  `Workspace` interface noting `Glob`'s
+  root-relativity is implementation-defined.
+- `internal/mdtext/mdtext.go`'s `CountSentences` (fast
+  heuristic) and `SplitSentences` (trained Punkt) both
+  exist with no doc cross-reference explaining the
+  trade-off, unlike the file's other paired functions.
+- `internal/rules/catalog/rule.go`'s `isGitignored` is
+  dead in production, kept only as a test oracle for
+  `isGitignoredMemo` — undocumented as intentional.
+- `internal/rules/requiredstructure/rule.go` has two
+  same-named-in-spirit symbols, package func
+  `isSchemaFile` and method `(*Rule).isSchemaFile` —
+  naming clash, not a coverage gap.
 
 ## Audit 2026-06-26 (range: 3d35b77..fe7141b)
 

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -128,9 +128,9 @@ set.
   `config.ApplyCategories` pattern; only `Runner`'s
   reuses a shared lookup helper.
 - SRP file-size bloat past the point of easy review:
-  `internal/rules/requiredstructure/rule.go` (2606
+  `internal/rules/requiredstructure/rule.go` (2605
   lines, 5 concerns), `internal/rules/catalog/rule.go`
-  (1761 lines, ~6 concerns beyond what the package's
+  (1760 lines, ~6 concerns beyond what the package's
   existing file split already covers),
   `internal/rules/crossfilereferenceintegrity/rule.go`
   (~1130 lines, 3 concerns), `internal/schema/validate.go`
@@ -139,7 +139,7 @@ set.
   lines, 4 concerns), `cmd/mdsmith/main.go` (911 lines,
   nearing the ~1000-line smell threshold, with real
   domain logic that could move to `internal/*`),
-  `internal/release/bench.go` (701 lines, 5 concerns).
+  `internal/release/bench.go` (700 lines, 5 concerns).
   None are DIP violations; all are readability/review-cost
   friction, split candidates along the seams each
   finding's source agent already named.

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -401,9 +401,8 @@ func TestRootAndFiles(t *testing.T) {
 func TestNew(t *testing.T) {
 	t.Parallel()
 	idx := New("/root")
-	assert.Equal(t, "/root", idx.root)
-	assert.NotNil(t, idx.files)
-	assert.Empty(t, idx.files)
+	assert.Equal(t, "/root", idx.Root())
+	assert.Empty(t, idx.Files())
 }
 
 func TestIndex_File(t *testing.T) {

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -398,6 +398,33 @@ func TestRootAndFiles(t *testing.T) {
 	assert.ElementsMatch(t, []string{"a.md", "b.md"}, idx.Files())
 }
 
+func TestNew(t *testing.T) {
+	t.Parallel()
+	idx := New("/root")
+	assert.Equal(t, "/root", idx.root)
+	assert.NotNil(t, idx.files)
+	assert.Empty(t, idx.files)
+}
+
+func TestIndex_File(t *testing.T) {
+	t.Parallel()
+	idx := New("/root")
+
+	_, ok := idx.File("missing.md")
+	assert.False(t, ok, "expected miss on an unindexed path")
+
+	idx.Update("./docs/a.md", []byte("# A\n"))
+	fe, ok := idx.File("docs\\a.md")
+	require.True(t, ok, "expected File to normalize path separators and ./ prefixes")
+	require.NotNil(t, fe)
+
+	fe.Title = "mutated"
+	fe2, ok := idx.File("docs/a.md")
+	require.True(t, ok)
+	assert.NotEqual(t, "mutated", fe2.Title,
+		"File must return a copy so callers cannot mutate the stored entry")
+}
+
 func TestRootAndFilesOnNilIndex(t *testing.T) {
 	t.Parallel()
 	var idx *Index

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -418,11 +418,12 @@ func TestIndex_File(t *testing.T) {
 	require.True(t, ok, "expected File to normalize path separators and ./ prefixes")
 	require.NotNil(t, fe)
 
-	fe.Title = "mutated"
 	fe2, ok := idx.File("docs/a.md")
 	require.True(t, ok)
-	assert.NotEqual(t, "mutated", fe2.Title,
+	assert.NotSame(t, fe, fe2,
 		"File must return a copy so callers cannot mutate the stored entry")
+	fe.Title = "mutated"
+	assert.NotEqual(t, "mutated", fe2.Title)
 }
 
 func TestRootAndFilesOnNilIndex(t *testing.T) {

--- a/internal/rules/build/rule_test.go
+++ b/internal/rules/build/rule_test.go
@@ -39,6 +39,35 @@ func TestRule_Name(t *testing.T) {
 	assert.Equal(t, "build", (&Rule{}).Name())
 }
 
+func TestRule_RuleID(t *testing.T) {
+	assert.Equal(t, "MDS039", (&Rule{}).RuleID())
+}
+
+func TestRule_RuleName(t *testing.T) {
+	assert.Equal(t, "build", (&Rule{}).RuleName())
+}
+
+func TestRule_Validate(t *testing.T) {
+	r := ruleWithRender()
+
+	diags := r.Validate("test.md", 1,
+		map[string]string{"recipe": "render", "outputs": "out.png", "source": "a.svg"}, nil)
+	assert.Empty(t, diags, "expected no diagnostics for a valid directive")
+
+	diags = r.Validate("test.md", 1, map[string]string{"outputs": "out.png"}, nil)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, `missing required "recipe"`)
+}
+
+func TestRule_Generate(t *testing.T) {
+	r := ruleWithRender()
+
+	body, diags := r.Generate(nil, "test.md", 1,
+		map[string]string{"recipe": "render", "outputs": "out.png", "source": "a.svg"}, nil)
+	assert.Empty(t, diags)
+	assert.Equal(t, "![render output: out.png](out.png)\n", body)
+}
+
 func TestRule_Category(t *testing.T) {
 	assert.Equal(t, "directive", (&Rule{}).Category())
 }

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -91,16 +91,12 @@ func TestRule_Name(t *testing.T) {
 
 func TestRule_RuleID(t *testing.T) {
 	r := &Rule{}
-	if r.RuleID() != "MDS019" {
-		t.Errorf("expected RuleID MDS019, got %s", r.RuleID())
-	}
+	assert.Equal(t, "MDS019", r.RuleID())
 }
 
 func TestRule_RuleName(t *testing.T) {
 	r := &Rule{}
-	if r.RuleName() != "catalog" {
-		t.Errorf("expected RuleName catalog, got %s", r.RuleName())
-	}
+	assert.Equal(t, "catalog", r.RuleName())
 }
 
 func TestRule_Validate(t *testing.T) {

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -89,6 +89,33 @@ func TestRule_Name(t *testing.T) {
 	}
 }
 
+func TestRule_RuleID(t *testing.T) {
+	r := &Rule{}
+	if r.RuleID() != "MDS019" {
+		t.Errorf("expected RuleID MDS019, got %s", r.RuleID())
+	}
+}
+
+func TestRule_RuleName(t *testing.T) {
+	r := &Rule{}
+	if r.RuleName() != "catalog" {
+		t.Errorf("expected RuleName catalog, got %s", r.RuleName())
+	}
+}
+
+func TestRule_Validate(t *testing.T) {
+	r := &Rule{}
+
+	diags := r.Validate("f.md", 1,
+		map[string]string{"row": "{name}", "glob": "*.md"}, nil)
+	assert.Empty(t, diags, "expected no diagnostics for a valid directive")
+
+	diags = r.Validate("f.md", 1,
+		map[string]string{"row": "{name}", "row-expr": "name"}, nil)
+	expectDiags(t, diags, 1)
+	expectDiagMsg(t, diags, `sets both "row" and "row-expr"; choose one`)
+}
+
 // =====================================================================
 // Core rendering
 // =====================================================================

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -84,6 +84,20 @@ func TestRule_Name(t *testing.T) {
 	}
 }
 
+func TestRule_RuleID(t *testing.T) {
+	r := &Rule{}
+	if r.RuleID() != "MDS021" {
+		t.Errorf("expected RuleID MDS021, got %s", r.RuleID())
+	}
+}
+
+func TestRule_RuleName(t *testing.T) {
+	r := &Rule{}
+	if r.RuleName() != "include" {
+		t.Errorf("expected RuleName include, got %s", r.RuleName())
+	}
+}
+
 // =====================================================================
 // Basic include
 // =====================================================================

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -86,16 +86,12 @@ func TestRule_Name(t *testing.T) {
 
 func TestRule_RuleID(t *testing.T) {
 	r := &Rule{}
-	if r.RuleID() != "MDS021" {
-		t.Errorf("expected RuleID MDS021, got %s", r.RuleID())
-	}
+	assert.Equal(t, "MDS021", r.RuleID())
 }
 
 func TestRule_RuleName(t *testing.T) {
 	r := &Rule{}
-	if r.RuleName() != "include" {
-		t.Errorf("expected RuleName include, got %s", r.RuleName())
-	}
+	assert.Equal(t, "include", r.RuleName())
 }
 
 // =====================================================================

--- a/internal/rules/listindent/rule_test.go
+++ b/internal/rules/listindent/rule_test.go
@@ -162,6 +162,16 @@ func TestCategory(t *testing.T) {
 	}
 }
 
+func TestID(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "MDS016", r.ID())
+}
+
+func TestName(t *testing.T) {
+	r := &Rule{}
+	assert.Equal(t, "list-indent", r.Name())
+}
+
 // TestFirstLineOfListItem_LinesPath pins the
 // `li.Lines().Len() > 0` branch. Goldmark's parser does not
 // populate Lines() on ListItem nodes in normal source — content

--- a/plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
+++ b/plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
@@ -1,0 +1,90 @@
+---
+id: 2607121915
+title: >-
+  Resolve the internal/linkgraph purity-contract
+  mismatch for wikilink resolution
+status: "🔲"
+model: sonnet
+summary: >-
+  go.md documents internal/linkgraph as pure (no file
+  reads, no workspace walks), but NewWikilinkIndex and
+  ResolveWikiLink both call fs.WalkDir. Flagged by the
+  2026-07-12 audit.
+---
+# Resolve the linkgraph purity-contract mismatch
+
+## Goal
+
+Make [go.md](../docs/development/architecture/go.md) match
+what `internal/linkgraph` actually does. Callers should be
+able to trust the documented concurrency contract.
+
+## Background
+
+The 2026-07-12 audit (see
+[the audit log](../docs/development/architecture-audit.md))
+found that
+[go.md](../docs/development/architecture/go.md) states:
+
+> `internal/linkgraph` — canonical Markdown link /
+> directive / reference extractor; ... Pure (no file
+> reads, no workspace walks); callers can fan it out
+> across goroutines.
+
+But `NewWikilinkIndex` and `ResolveWikiLink` in
+[wikilinks.go](../internal/linkgraph/wikilinks.go) both
+call `fs.WalkDir`. They resolve `[[wikilink]]` targets by
+walking the workspace tree. This is the only file in the
+package that touches the filesystem. Every other
+extractor (`ExtractWikiLinks` and friends) is genuinely
+pure, matching the doc.
+
+Two call sites depend on the current behavior:
+
+- [backlinks.go](../cmd/mdsmith/backlinks.go)
+- [crossfilereferenceintegrity/rule.go](
+  ../internal/rules/crossfilereferenceintegrity/rule.go)
+
+`internal/index` already owns workspace-wide graph
+building per go.md's package table. That makes it the
+natural home for a workspace walk, if the walk moves
+rather than the doc.
+
+The audit found one more thing. `NewWikilinkIndex` and
+`ResolveWikiLink` each reimplement the same stem/name
+walk-and-match algorithm. They share only
+`sortByDepthThenName`, `skipHeavyDirs`, and
+`wikilinkSearchKey`. Fixing the purity question likely
+means rewriting one in terms of the other anyway, so
+resolve both in the same pass.
+
+## Tasks
+
+1. Decide the resolution: either (a) move the
+   `fs.WalkDir`-based index build into `internal/index`
+   and have `internal/linkgraph` expose only extraction +
+   resolution-against-precomputed-data, or (b) narrow
+   go.md's purity claim to scope it correctly to the
+   per-file extraction functions and document
+   `WikilinkIndex`/`ResolveWikiLink` as the sanctioned
+   workspace-walking exception.
+2. If (a): implement `ResolveWikiLink` as
+   `NewWikilinkIndex(root).Resolve(target)` so the walk
+   logic exists in one place, then move the index-building
+   code and update both call sites.
+3. If (b): update go.md's `internal/linkgraph` entry with
+   the precise scope of the purity guarantee.
+4. `go build ./...` passes.
+5. `go test ./internal/linkgraph/... ./cmd/mdsmith/...
+   ./internal/rules/crossfilereferenceintegrity/...`
+   passes.
+
+## Acceptance Criteria
+
+- [ ] go.md's description of `internal/linkgraph` matches
+      the package's actual behavior.
+- [ ] `NewWikilinkIndex` and `ResolveWikiLink` no longer
+      maintain two independent copies of the walk/match
+      algorithm.
+- [ ] `go test ./...` is green.
+- [ ] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

Scheduled SOLID-architecture audit of the 66 production Go files touched since the last checkpoint (`528ce4c..834b560`) — every modified `internal/rules/*` package, `cmd/mdsmith`, `cmd/mdsmith-release`, `cue/cuelite`, a dozen core `internal/*` packages, and the `pkg/goldmark`/`pkg/markdown/flavor`/`pkg/mdsmith` public-API layer.

Full findings are recorded under `## Audit 2026-07-12` in [docs/development/architecture-audit.md](docs/development/architecture-audit.md). This PR fixes the highest-priority (blocker-severity) finding that was safe to fix without a behavior change:

- `internal/rules/catalog/rule.go`, `internal/rules/build/rule.go`, and `internal/rules/include/rule.go` implement `gensection.Directive` — a generated-markers contract surface. Their `RuleID`/`RuleName`/`Validate`/`Generate` methods had no dedicated unit test.
- `internal/rules/listindent/rule.go`'s `rule.Rule` contract methods `ID()`/`Name()` had the same gap.
- `internal/index.File()` — the LSP/rename/deps query surface's primary lookup — had no dedicated test of its hit/miss, path-normalization, or copy-not-alias behavior.

Per the project's test-pyramid rule (`docs/development/architecture/tests.md`), a missing unit test is `blocker`-severity when the function sits on a public surface. All five gaps qualify. No production code changed — this is test-only.

## Other findings

- **1 blocker not fixed here** — `internal/linkgraph/wikilinks.go`'s `NewWikilinkIndex`/`ResolveWikiLink` call `fs.WalkDir`, contradicting go.md's "Pure (no file reads, no workspace walks)" claim for the package. This needs an actual design decision (move the walk into `internal/index`, or rescope the doc) rather than a mechanical fix, so it's filed as [plan/2607121915](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md).
- **tax / nice-to-have** — a long tail of missing-dedicated-test debt on private helpers (covered transitively via integration-style tests), a handful of real duplication findings (e.g. `crossfilereferenceintegrity.toStringSlice` duplicating `settings.ToStringSlice`), and several oversized files that are split candidates. Left in the audit log per the audit workflow's own severity rubric — see the log for details.

Three resolved 2026-06 entries were archived to `docs/development/architecture-audit-archive.md` to keep the log under its file-length budget.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run` on the changed packages (0 issues)
- [x] `mdsmith check .` (via `go run ./cmd/mdsmith check .`)
- [x] `mdsmith fix .` to refresh the generated `PLAN.md` catalog entry for the new plan file


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1kmGuaSz2SrJbWSTe8JRR)_