### PR TITLE
perf: fix top 5 high-performance-go.md violations (round 6)

### DIFF
--- a/internal/lint/layer0_fence.go
+++ b/internal/lint/layer0_fence.go
@@ -82,8 +82,7 @@ func closingFence(line []byte, fi fenceInfo) bool {
 func advanceFenceState(open *fenceInfo, line []byte, fi fenceInfo, opensFence bool) *fenceInfo {
 	if open == nil {
 		if opensFence {
-			f := fi
-			return &f
+			return &fi
 		}
 		return nil
 	}

--- a/internal/lint/layer0_fence.go
+++ b/internal/lint/layer0_fence.go
@@ -2,11 +2,15 @@ package lint
 
 import "bytes"
 
-// fenceInfo describes an opening fenced-code fence line.
+// fenceInfo describes an opening fenced-code fence line. Fields are
+// ordered large-to-small (both ints before the two single-byte
+// fields) to avoid the padding a byte-then-int layout would cost;
+// openingFence returns this by value on the hottest per-line scan
+// path (docs/development/high-performance-go.md "Struct layout").
 type fenceInfo struct {
-	char   byte
 	indent int
 	length int
+	char   byte
 	// hasInfo records whether the opening fence carries a non-empty info
 	// string after the fence run. goldmark exposes no source position for
 	// an info-less, content-less fence, so the projection emits no lines

--- a/internal/lint/layer0_fence_test.go
+++ b/internal/lint/layer0_fence_test.go
@@ -1,0 +1,22 @@
+package lint
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestFenceInfo_FieldOrderMinimizesPadding pins fenceInfo's memory
+// layout at 24 bytes. openingFence returns fenceInfo by value on the
+// hottest per-line scan path (tryFence, tried first for every
+// non-blank line of every file), so struct padding is copied
+// repeatedly. Ordering fields large-to-small (both ints, then the two
+// single-byte fields) avoids the 8 bytes of padding a byte-then-int
+// layout costs. See docs/development/high-performance-go.md
+// "Struct layout" / "Order fields large-to-small".
+func TestFenceInfo_FieldOrderMinimizesPadding(t *testing.T) {
+	got := unsafe.Sizeof(fenceInfo{})
+	if got > 24 {
+		t.Fatalf("unsafe.Sizeof(fenceInfo{}) = %d, want <= 24 (large-to-small field order); "+
+			"see docs/development/high-performance-go.md", got)
+	}
+}

--- a/internal/rules/ambiguousemphasis/alloc_test.go
+++ b/internal/rules/ambiguousemphasis/alloc_test.go
@@ -1,0 +1,87 @@
+package ambiguousemphasis
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/require"
+)
+
+// allocBudgetMDS047 pins Check's allocation cost on ordinary prose
+// that actually uses emphasis (**bold**, *italic*, _underscore_) —
+// the shape that dominates real documents. The shared integration
+// alloc-budget fixture (internal/integration/alloc_budget_test.go)
+// carries no emphasis at all, so it never exercised this cost and
+// the rule reported 0 allocs/op on BenchmarkPerRuleAllocBudget
+// despite scanLine allocating a fresh *emphRun per delimiter run
+// (~10 allocs/line on emphasis-heavy prose) — see
+// docs/development/high-performance-go.md "Gate expensive analyzers
+// behind a cheap pre-check" and "Fixed-size arrays beat slices".
+// scanLine now gates on a cheap bytes.Count pre-check and tracks the
+// in-progress run by value instead of by pointer, landing at 1
+// alloc/line (the pre-sized runs slice) on this fixture.
+const allocBudgetMDS047 = 15
+
+// allocBudgetFixtureMDS047 is a representative prose document that
+// actually contains emphasis, unlike the shared integration fixture.
+const allocBudgetFixtureMDS047 = "# Document title\n" +
+	"\n" +
+	"A short prose paragraph with **bold** text, *italic* text, and\n" +
+	"some _underscore_ emphasis too. It stays a few lines long, the\n" +
+	"way *real* Markdown reads.\n" +
+	"\n" +
+	"## Section\n" +
+	"\n" +
+	"See [other](other.md) for **more** examples of *emphasis* in the\n" +
+	"wild, including _nested_ cases and **double** markers.\n" +
+	"\n" +
+	"- one **bold** item\n" +
+	"- two *italic* items\n"
+
+// checkAllocsPerOpMDS047 returns parse-subtracted allocs/op for
+// r.Check on src. Fresh File per iteration so per-File memos start
+// cold, matching the integration gate's shape.
+func checkAllocsPerOpMDS047(tb testing.TB, r *Rule, src []byte) float64 {
+	tb.Helper()
+	warm, err := lint.NewFile("warm.md", src)
+	require.NoError(tb, err)
+	_ = r.Check(warm)
+	const runs = 100
+	parse := testing.AllocsPerRun(runs, func() {
+		_, err := lint.NewFile("parse.md", src)
+		require.NoError(tb, err)
+	})
+	full := testing.AllocsPerRun(runs, func() {
+		f, err := lint.NewFile("check.md", src)
+		require.NoError(tb, err)
+		_ = r.Check(f)
+	})
+	delta := full - parse
+	if delta < 0 {
+		delta = 0
+	}
+	return delta
+}
+
+// TestCheckAllocBudget_EmphasisHeavyProse pins MDS047 at <= 20
+// allocs/op on a short document that actually uses emphasis, with
+// every detector active. Skipped under -race and -short, matching
+// the integration gate.
+func TestCheckAllocBudget_EmphasisHeavyProse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race; the race detector " +
+			"adds allocation bookkeeping that perturbs the count")
+	}
+	r := activeRule()
+	src := []byte(allocBudgetFixtureMDS047)
+	allocs := checkAllocsPerOpMDS047(t, r, src)
+	t.Logf("MDS047 Check allocs/op on emphasis-heavy prose = %.0f (budget = %d)",
+		allocs, allocBudgetMDS047)
+	require.LessOrEqualf(t, allocs, float64(allocBudgetMDS047),
+		"MDS047 Check allocs/op = %.0f, budget = %d; see "+
+			"docs/development/high-performance-go.md",
+		allocs, allocBudgetMDS047)
+}

--- a/internal/rules/ambiguousemphasis/alloc_test.go
+++ b/internal/rules/ambiguousemphasis/alloc_test.go
@@ -7,20 +7,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// allocBudgetMDS047 pins Check's allocation cost on ordinary prose
-// that actually uses emphasis (**bold**, *italic*, _underscore_) —
-// the shape that dominates real documents. The shared integration
-// alloc-budget fixture (internal/integration/alloc_budget_test.go)
-// carries no emphasis at all, so it never exercised this cost and
-// the rule reported 0 allocs/op on BenchmarkPerRuleAllocBudget
-// despite scanLine allocating a fresh *emphRun per delimiter run
-// (~10 allocs/line on emphasis-heavy prose) — see
-// docs/development/high-performance-go.md "Gate expensive analyzers
-// behind a cheap pre-check" and "Fixed-size arrays beat slices".
-// scanLine now gates on a cheap bytes.Count pre-check and tracks the
-// in-progress run by value instead of by pointer, landing at 1
-// alloc/line (the pre-sized runs slice) on this fixture.
-const allocBudgetMDS047 = 15
+// allocBudgetMDS047 mirrors the CLAUDE.md per-Check ceiling ("A
+// rule's Check allocates ≤ 10 times per call on representative
+// input") on ordinary prose that actually uses emphasis (**bold**,
+// *italic*, _underscore_) — the shape that dominates real documents.
+// The shared integration alloc-budget fixture
+// (internal/integration/alloc_budget_test.go) carries no emphasis at
+// all, so it never exercised this cost and the rule reported 0
+// allocs/op on BenchmarkPerRuleAllocBudget despite scanLine
+// allocating a fresh *emphRun per delimiter run (~10 allocs/line on
+// emphasis-heavy prose) — see docs/development/high-performance-go.md
+// "Gate expensive analyzers behind a cheap pre-check" and "Fixed-size
+// arrays beat slices". scanLine now gates on a cheap byte-count
+// pre-check and tracks the in-progress run by value instead of by
+// pointer; escapedInRunDiags and adjacentSameDelimDiags skip building
+// their tracking maps when no escape or fewer than three runs can
+// possibly produce a diagnostic; and Check no longer pre-sizes diags
+// for a violation rate real documents rarely hit. Landed at 9
+// allocs/op on this fixture (was 41 before any of these fixes).
+const allocBudgetMDS047 = 10
 
 // allocBudgetFixtureMDS047 is a representative prose document that
 // actually contains emphasis, unlike the shared integration fixture.
@@ -63,10 +68,10 @@ func checkAllocsPerOpMDS047(tb testing.TB, r *Rule, src []byte) float64 {
 	return delta
 }
 
-// TestCheckAllocBudget_EmphasisHeavyProse pins MDS047 at <= 20
-// allocs/op on a short document that actually uses emphasis, with
-// every detector active. Skipped under -race and -short, matching
-// the integration gate.
+// TestCheckAllocBudget_EmphasisHeavyProse pins MDS047 at <= 10
+// allocs/op (CLAUDE.md's documented ceiling) on a short document
+// that actually uses emphasis, with every detector active. Skipped
+// under -race and -short, matching the integration gate.
 func TestCheckAllocBudget_EmphasisHeavyProse(t *testing.T) {
 	if testing.Short() {
 		t.Skip("alloc gate skipped in -short mode")

--- a/internal/rules/ambiguousemphasis/race_off_test.go
+++ b/internal/rules/ambiguousemphasis/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package ambiguousemphasis
+
+const raceEnabled = false

--- a/internal/rules/ambiguousemphasis/race_on_test.go
+++ b/internal/rules/ambiguousemphasis/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package ambiguousemphasis
+
+const raceEnabled = true

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -13,12 +13,23 @@
 package ambiguousemphasis
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
+)
+
+// starNeedle and underscoreNeedle are single-byte needles for
+// bytes.Count, held at package scope so scanLine never allocates a
+// slice literal per call (docs/development/high-performance-go.md
+// "Compile regexes at package scope" applies equally to byte
+// needles).
+var (
+	starNeedle       = []byte{'*'}
+	underscoreNeedle = []byte{'_'}
 )
 
 func init() {
@@ -98,16 +109,37 @@ type escape struct {
 
 // scanLine walks line bytes tracking backslash-escape state and
 // returns the unescaped delimiter runs and escaped-delimiter
-// positions.
+// positions. A cheap byte count gates the walk: a line with no '*' or
+// '_' at all can hold no run or escape, so it returns immediately
+// without touching the per-byte loop
+// (docs/development/high-performance-go.md "Gate expensive analyzers
+// behind a cheap pre-check"). When delimiters are present, the count
+// also bounds runs' capacity — no run can exceed the total delimiter
+// byte count — so the common multi-emphasis line (`**bold** *and*
+// _more_`) fills runs via one pre-sized slice instead of growing it
+// through repeated append reallocations.
 func scanLine(line []byte) ([]emphRun, []escape) {
-	var runs []emphRun
+	numDelims := bytes.Count(line, starNeedle) + bytes.Count(line, underscoreNeedle)
+	if numDelims == 0 {
+		return nil, nil
+	}
+
+	runs := make([]emphRun, 0, numDelims)
 	var escapes []escape
 
-	var cur *emphRun
+	// cur/open track the in-progress run by value instead of *emphRun:
+	// taking the address of a composite literal reassigned across loop
+	// iterations forces the compiler to heap-allocate a fresh emphRun
+	// per delimiter run (docs/development/high-performance-go.md
+	// "Fixed-size arrays beat slices" / avoid unnecessary pointers). A
+	// value plus a bool keeps the in-progress run on the stack; only
+	// the copy appended to runs is ever observed outside this loop.
+	var cur emphRun
+	open := false
 	closeRun := func() {
-		if cur != nil {
-			runs = append(runs, *cur)
-			cur = nil
+		if open {
+			runs = append(runs, cur)
+			open = false
 		}
 	}
 
@@ -127,11 +159,12 @@ func scanLine(line []byte) ([]emphRun, []escape) {
 			escaped = true
 			closeRun()
 		case '*', '_':
-			if cur != nil && cur.char == b {
+			if open && cur.char == b {
 				cur.end = i + 1
 			} else {
 				closeRun()
-				cur = &emphRun{char: b, start: i, end: i + 1}
+				cur = emphRun{char: b, start: i, end: i + 1}
+				open = true
 			}
 		default:
 			closeRun()

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -69,7 +69,14 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	skip := lint.CollectCodeBlockLines(f)
 	codeSpanRanges := f.CodeSpanContentRanges()
 
-	diags := make([]lint.Diagnostic, 0, len(f.Lines)/4+1)
+	// Unlike most per-Check diagnostic slices, this one is not pre-sized:
+	// len(f.Lines)/4+1 guesses at a violation rate real documents rarely
+	// hit (MDS047 fires on ambiguous emphasis, not on every paragraph),
+	// so the guess cost an allocation on the common zero-diagnostic
+	// path. A nil start also means Check returns nil rather than a
+	// non-nil empty slice when nothing is found, per project convention
+	// (docs/development/index.md "Return nil, not []T{}").
+	var diags []lint.Diagnostic
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := skip[lineNum]; ok {
@@ -117,7 +124,14 @@ type escape struct {
 // also bounds runs' capacity — no run can exceed the total delimiter
 // byte count — so the common multi-emphasis line (`**bold** *and*
 // _more_`) fills runs via one pre-sized slice instead of growing it
-// through repeated append reallocations.
+// through repeated append reallocations. Measured against a single
+// bytes.IndexAny presence check (one pass, no capacity hint): that
+// alternative costs fewer scanned bytes on a delimiter-free line but
+// nearly doubles allocs/op on delimiter-bearing lines (21 vs 11 on
+// this package's alloc-budget fixture) by forcing runs to grow via
+// repeated append — allocation count, not scan count, is the metric
+// CLAUDE.md's ceiling and the CI gate enforce, so the two-count form
+// wins here.
 func scanLine(line []byte) ([]emphRun, []escape) {
 	numDelims := bytes.Count(line, starNeedle) + bytes.Count(line, underscoreNeedle)
 	if numDelims == 0 {
@@ -194,6 +208,9 @@ func (r *Rule) checkLine(f *lint.File, lineNum int, line []byte) []lint.Diagnost
 // run that exceeds MaxRun, anchored at the first occurrence on the
 // line.
 func (r *Rule) longRunDiags(f *lint.File, lineNum int, runs []emphRun) []lint.Diagnostic {
+	if len(runs) == 0 {
+		return nil
+	}
 	type key struct {
 		char   byte
 		length int
@@ -229,6 +246,15 @@ func (r *Rule) longRunDiags(f *lint.File, lineNum int, runs []emphRun) []lint.Di
 // escapedInRunDiags emits one diagnostic for each escaped delimiter
 // that sits immediately after an unescaped run of the same character.
 func (r *Rule) escapedInRunDiags(f *lint.File, lineNum int, runs []emphRun, escapes []escape) []lint.Diagnostic {
+	// Without an escape there is nothing to match against a run end, so
+	// skip building runEnds — most emphasis-bearing lines have runs but
+	// no escapes, and make(map[K]V, len(runs)) with a nonzero hint
+	// allocates real bucket storage immediately, unlike a zero-hint map
+	// literal (docs/development/high-performance-go.md "Gate expensive
+	// analyzers behind a cheap pre-check").
+	if len(escapes) == 0 || len(runs) == 0 {
+		return nil
+	}
 	type runEndKey struct {
 		char byte
 		end  int
@@ -265,6 +291,13 @@ const minAdjacentRunsForAmbiguity = 3
 // length) where three runs of that shape appear on the line with at
 // least one non-whitespace byte between consecutive occurrences.
 func (r *Rule) adjacentSameDelimDiags(f *lint.File, lineNum int, line []byte, runs []emphRun) []lint.Diagnostic {
+	// Fewer than three runs can never satisfy the three-in-a-row
+	// pattern, so skip building the tracking maps entirely — most
+	// emphasis-bearing lines (one bold, one italic span) fall well
+	// short of this.
+	if len(runs) < minAdjacentRunsForAmbiguity {
+		return nil
+	}
 	type key struct {
 		char   byte
 		length int

--- a/internal/rules/linelength/reflow.go
+++ b/internal/rules/linelength/reflow.go
@@ -102,20 +102,25 @@ func wrapTokens(tokens []string, indent string, width int, glue func(prev string
 	units := buildWrapUnits(tokens, glue)
 	indentW := utf8.RuneCountInString(indent)
 	var lines []string
-	cur := indent + units[0]
+	var b strings.Builder
+	b.WriteString(indent)
+	b.WriteString(units[0])
 	curW := indentW + utf8.RuneCountInString(units[0])
 	for _, u := range units[1:] {
 		uW := utf8.RuneCountInString(u)
 		if curW+1+uW <= width {
-			cur += " " + u
+			b.WriteByte(' ')
+			b.WriteString(u)
 			curW += 1 + uW
 		} else {
-			lines = append(lines, cur)
-			cur = indent + u
+			lines = append(lines, b.String())
+			b.Reset()
+			b.WriteString(indent)
+			b.WriteString(u)
 			curW = indentW + uW
 		}
 	}
-	return append(lines, cur)
+	return append(lines, b.String())
 }
 
 // buildWrapUnits coalesces tokens into space-joined units. A new token

--- a/internal/rules/linelength/reflow_test.go
+++ b/internal/rules/linelength/reflow_test.go
@@ -184,6 +184,43 @@ func TestBuildWrapUnitsAllocBudget(t *testing.T) {
 	}
 }
 
+// wrapTokensAllocBudget pins wrapTokens's allocation count for a wide
+// line that packs many short units onto one output line. The
+// line-packing loop used to grow `cur` with `cur += " " + u` on every
+// packed unit, allocating a new backing array each step — the same
+// anti-pattern buildWrapUnits was fixed for above, left unconverted
+// in the surrounding loop. See docs/development/high-performance-go.md
+// "Strings and bytes" / "strings.Builder over +".
+const wrapTokensAllocBudget = 6
+
+// TestWrapTokensAllocBudget exercises wrapTokens with a width wide
+// enough that every unit packs onto a single output line, maximizing
+// the number of times the line-packing loop grows `cur`.
+func TestWrapTokensAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race; the race detector " +
+			"adds allocation bookkeeping that perturbs the count")
+	}
+	tokens := []string{
+		"one", "two", "three", "four", "five", "six", "seven",
+		"eight", "nine", "ten",
+	}
+	noGlue := func(string) bool { return false }
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = wrapTokens(tokens, "", 200, noGlue)
+	})
+	t.Logf("wrapTokens allocs/op = %.0f (budget = %d)",
+		allocs, wrapTokensAllocBudget)
+	if allocs > float64(wrapTokensAllocBudget) {
+		t.Fatalf("wrapTokens allocs/op = %.0f, budget = %d; see "+
+			"docs/development/high-performance-go.md",
+			allocs, wrapTokensAllocBudget)
+	}
+}
+
 func TestWrapTokens_LongTokenOwnsLine(t *testing.T) {
 	tokens := []string{"short", "thisisaverylongunbreakabletoken", "tail"}
 	got := wrapTokens(tokens, "", 10, func(string) bool { return false })

--- a/internal/rules/propernames/alloc_test.go
+++ b/internal/rules/propernames/alloc_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// allocBudgetMDS050 pins Check's steady-state allocation cost when
-// the rule is configured with real names. buildNameEntries()
-// rebuilds every nameEntry (a fresh []byte plus an asciiToLower copy
-// per name) on every single Check call, even though r.Names is
-// immutable for the life of the Rule instance — a per-Rule
-// memoization case, not a per-file one
+// allocBudgetMDS050 pins Check's steady-state allocation cost once
+// the rule is configured with real names via ApplySettings (which
+// precomputes entries once — see effectiveEntries). Before that fix,
+// buildNameEntries() rebuilt every nameEntry (a fresh []byte plus an
+// asciiToLower copy per name) on every single Check call, even
+// though r.Names is immutable for the life of the Rule instance — a
+// per-Rule memoization case, not a per-file one
 // (docs/development/high-performance-go.md "Memoize per-input
 // computations"). The shared integration alloc-budget fixture never
 // sets Names, so len(entries)==0 short-circuits before any of this
@@ -91,7 +92,11 @@ func TestCheckAllocBudget(t *testing.T) {
 	for i := range names {
 		names[i] = fmt.Sprintf("ProperName%d", i)
 	}
-	r := &Rule{Names: names}
+	// Construct via ApplySettings, not a struct literal: entries is
+	// only precomputed on that path (see effectiveEntries), matching
+	// how the engine configures every rule before Check ever runs.
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"names": names}))
 	allocs := checkAllocsPerOpMDS050(t, r)
 	t.Logf("MDS050 Check allocs/op = %.0f (budget = %d)",
 		allocs, allocBudgetMDS050)

--- a/internal/rules/propernames/alloc_test.go
+++ b/internal/rules/propernames/alloc_test.go
@@ -1,0 +1,102 @@
+package propernames
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/require"
+)
+
+// allocBudgetMDS050 pins Check's steady-state allocation cost when
+// the rule is configured with real names. buildNameEntries()
+// rebuilds every nameEntry (a fresh []byte plus an asciiToLower copy
+// per name) on every single Check call, even though r.Names is
+// immutable for the life of the Rule instance — a per-Rule
+// memoization case, not a per-file one
+// (docs/development/high-performance-go.md "Memoize per-input
+// computations"). The shared integration alloc-budget fixture never
+// sets Names, so len(entries)==0 short-circuits before any of this
+// runs and MDS050 reports 0 allocs/op on
+// BenchmarkPerRuleAllocBudget, leaving the real per-Check cost
+// invisible to CI.
+const allocBudgetMDS050 = 10
+
+// allocBudgetFixtureMDS050 is the shared integration alloc-budget
+// fixture (internal/integration/alloc_budget_test.go), duplicated
+// here so the per-rule unit gate catches a regression before the
+// matrix would.
+const allocBudgetFixtureMDS050 = "# Document title\n" +
+	"\n" +
+	"A short prose paragraph for the readability and structural\n" +
+	"rules to scan. It stays one paragraph long.\n" +
+	"\n" +
+	"## Section\n" +
+	"\n" +
+	"See [other](other.md) and [label][ref] for examples.\n" +
+	"\n" +
+	"```go\nfunc f() int { return 0 }\n```\n" +
+	"\n" +
+	"- one item\n" +
+	"- two items\n" +
+	"\n" +
+	"| Col | Other |\n" +
+	"|-----|-------|\n" +
+	"| a   | b     |\n" +
+	"\n" +
+	"[ref]: https://example.com/\n"
+
+// checkAllocsPerOpMDS050 returns parse-subtracted allocs/op for
+// r.Check on the fixture. r (not just the File) is reused across
+// every measured iteration, matching what the engine does across a
+// workspace walk: one configured Rule instance checks many files.
+// A cold-cache warm-up call runs first so the measured loop reflects
+// the steady-state per-file cost.
+func checkAllocsPerOpMDS050(tb testing.TB, r *Rule) float64 {
+	tb.Helper()
+	src := []byte(allocBudgetFixtureMDS050)
+	warm, err := lint.NewFile("warm.md", src)
+	require.NoError(tb, err)
+	_ = r.Check(warm)
+	const runs = 100
+	parse := testing.AllocsPerRun(runs, func() {
+		_, err := lint.NewFile("parse.md", src)
+		require.NoError(tb, err)
+	})
+	full := testing.AllocsPerRun(runs, func() {
+		f, err := lint.NewFile("check.md", src)
+		require.NoError(tb, err)
+		_ = r.Check(f)
+	})
+	delta := full - parse
+	if delta < 0 {
+		delta = 0
+	}
+	return delta
+}
+
+// TestCheckAllocBudget pins MDS050 at <= 10 allocs/op on the
+// representative fixture once configured with a realistic 20-name
+// vocabulary. Skipped under -race and -short, matching the
+// integration gate.
+func TestCheckAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race; the race detector " +
+			"adds allocation bookkeeping that perturbs the count")
+	}
+	names := make([]string, 20)
+	for i := range names {
+		names[i] = fmt.Sprintf("ProperName%d", i)
+	}
+	r := &Rule{Names: names}
+	allocs := checkAllocsPerOpMDS050(t, r)
+	t.Logf("MDS050 Check allocs/op = %.0f (budget = %d)",
+		allocs, allocBudgetMDS050)
+	require.LessOrEqualf(t, allocs, float64(allocBudgetMDS050),
+		"MDS050 Check allocs/op = %.0f, budget = %d; see "+
+			"docs/development/high-performance-go.md",
+		allocs, allocBudgetMDS050)
+}

--- a/internal/rules/propernames/race_off_test.go
+++ b/internal/rules/propernames/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package propernames
+
+const raceEnabled = false

--- a/internal/rules/propernames/race_on_test.go
+++ b/internal/rules/propernames/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package propernames
+
+const raceEnabled = true

--- a/internal/rules/propernames/rule.go
+++ b/internal/rules/propernames/rule.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -21,6 +23,18 @@ func init() {
 
 // Rule reports occurrences of configured proper names that do not match
 // their canonical casing (e.g. "Javascript" when "JavaScript" is configured).
+//
+// The nameEntry form of Names is memoised on the rule instance behind
+// entriesPtr + entriesMu (a double-checked-lock pattern, not
+// sync.Once: ApplySettings is allowed to swap Names and the cache
+// must follow — same pattern as MDS063's bannedSetPtr). Rule
+// instances are shared across concurrent LSP calls, but every
+// concurrent reader during a Check sees the same entries; ApplySettings
+// runs only during config load, before any Check, so the swap path
+// never races a reader. Moving the cache off the per-Check call
+// (buildNameEntries rebuilt a fresh []byte plus an asciiToLower copy
+// per name on every Check) to the per-rule instance pays that cost
+// once per rule instance instead of once per file.
 type Rule struct {
 	// Names is the list of proper names with their canonical casing.
 	// The names list appends across config layers so kind layers extend
@@ -31,6 +45,9 @@ type Rule struct {
 	CheckCode bool
 	// CheckHTML enables checking inside raw HTML and HTML blocks.
 	CheckHTML bool
+
+	entriesPtr atomic.Pointer[[]nameEntry]
+	entriesMu  sync.Mutex
 }
 
 // ID implements rule.Rule.
@@ -89,6 +106,27 @@ type nameEntry struct {
 	canonical []byte // original spelling, e.g. []byte("JavaScript")
 	lower     []byte // ASCII-lowercased, e.g. []byte("javascript")
 	str       string // canonical as string, used in diagnostics
+}
+
+// cachedNameEntries returns the nameEntry form of r.Names, memoised on
+// the rule instance behind an atomic pointer guarded by a mutex. The
+// warm path is a single atomic load and serves every Check after the
+// cache is populated. The cold path serialises on the mutex so
+// concurrent first-callers see one another's build instead of
+// multiple racing builds; on the extremely narrow window where two
+// goroutines see the pointer nil before either acquires the mutex,
+// the second one will rebuild the same entries after the first
+// releases — a one-shot cost, vastly cheaper than paying it on every
+// Check (see MDS063's cachedBannedSet, the model for this pattern).
+func (r *Rule) cachedNameEntries() []nameEntry {
+	if p := r.entriesPtr.Load(); p != nil {
+		return *p
+	}
+	r.entriesMu.Lock()
+	defer r.entriesMu.Unlock()
+	entries := r.buildNameEntries()
+	r.entriesPtr.Store(&entries)
+	return entries
 }
 
 // buildNameEntries precomputes nameEntry values for all configured names.
@@ -191,9 +229,10 @@ func scanRawHTMLSegments(entries []nameEntry, v *ast.RawHTML, f *lint.File, acc 
 }
 
 // collectMatches walks the AST and gathers all wrong-cased matches.
-// nameEntry values are precomputed once here and reused across all segments.
+// nameEntry values are precomputed once per rule instance (cachedNameEntries)
+// and reused across all segments and all files that instance checks.
 func (r *Rule) collectMatches(f *lint.File) []wrongMatch {
-	entries := r.buildNameEntries()
+	entries := r.cachedNameEntries()
 	if len(entries) == 0 {
 		return nil
 	}
@@ -272,7 +311,7 @@ func normalizeMatches(matches []wrongMatch) []wrongMatch {
 // they never appear in the runs — so this reproduces the AST walk's match set
 // for the no-code, no-HTML case.
 func (r *Rule) collectMatchesInline(f *lint.File) []wrongMatch {
-	entries := r.buildNameEntries()
+	entries := r.cachedNameEntries()
 	if len(entries) == 0 {
 		return nil
 	}
@@ -413,6 +452,10 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 			return fmt.Errorf("proper-names: unknown setting %q", k)
 		}
 	}
+	// Invalidate the entries cache so the next Check rebuilds against
+	// the new Names; ApplySettings is the only path that mutates
+	// r.Names, so clearing here is sufficient.
+	r.entriesPtr.Store(nil)
 	return nil
 }
 

--- a/internal/rules/propernames/rule.go
+++ b/internal/rules/propernames/rule.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"sync"
-	"sync/atomic"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -24,17 +22,21 @@ func init() {
 // Rule reports occurrences of configured proper names that do not match
 // their canonical casing (e.g. "Javascript" when "JavaScript" is configured).
 //
-// The nameEntry form of Names is memoised on the rule instance behind
-// entriesPtr + entriesMu (a double-checked-lock pattern, not
-// sync.Once: ApplySettings is allowed to swap Names and the cache
-// must follow — same pattern as MDS063's bannedSetPtr). Rule
-// instances are shared across concurrent LSP calls, but every
-// concurrent reader during a Check sees the same entries; ApplySettings
-// runs only during config load, before any Check, so the swap path
-// never races a reader. Moving the cache off the per-Check call
-// (buildNameEntries rebuilt a fresh []byte plus an asciiToLower copy
-// per name on every Check) to the per-rule instance pays that cost
-// once per rule instance instead of once per file.
+// The nameEntry form of Names is precomputed once by ApplySettings into
+// the plain entries/entriesReady fields below, rather than lazily
+// memoised behind a mutex/atomic pointer on first Check (the pattern
+// MDS063's cachedBannedSet uses): internal/rule.CloneInstance produces
+// a worker's copy of a rule via a raw, unsynchronized field-by-field
+// copy (reflect.Value.Set), which races the target/source's own field
+// writes if anything can still be writing them concurrently. A
+// lazily-built cache guarded by a mutex or atomic.Pointer is exactly
+// such a field — go test -race catches CloneInstance's copy racing a
+// concurrent Check's first cache build every time. Building entries
+// once, synchronously, inside ApplySettings — which always finishes
+// before any Check or CloneInstance touches the instance — avoids the
+// hazard entirely: entries/entriesReady become plain, write-once,
+// read-only-after-setup fields, exactly as safe for CloneInstance to
+// shallow-copy as Names itself.
 type Rule struct {
 	// Names is the list of proper names with their canonical casing.
 	// The names list appends across config layers so kind layers extend
@@ -46,8 +48,12 @@ type Rule struct {
 	// CheckHTML enables checking inside raw HTML and HTML blocks.
 	CheckHTML bool
 
-	entriesPtr atomic.Pointer[[]nameEntry]
-	entriesMu  sync.Mutex
+	// entries and entriesReady are set together, once, by ApplySettings.
+	// A Rule built directly (bypassing ApplySettings, as most unit
+	// tests do) leaves entriesReady false; effectiveEntries falls back
+	// to building entries fresh on every call in that case.
+	entries      []nameEntry
+	entriesReady bool
 }
 
 // ID implements rule.Rule.
@@ -108,25 +114,15 @@ type nameEntry struct {
 	str       string // canonical as string, used in diagnostics
 }
 
-// cachedNameEntries returns the nameEntry form of r.Names, memoised on
-// the rule instance behind an atomic pointer guarded by a mutex. The
-// warm path is a single atomic load and serves every Check after the
-// cache is populated. The cold path serialises on the mutex so
-// concurrent first-callers see one another's build instead of
-// multiple racing builds; on the extremely narrow window where two
-// goroutines see the pointer nil before either acquires the mutex,
-// the second one will rebuild the same entries after the first
-// releases — a one-shot cost, vastly cheaper than paying it on every
-// Check (see MDS063's cachedBannedSet, the model for this pattern).
-func (r *Rule) cachedNameEntries() []nameEntry {
-	if p := r.entriesPtr.Load(); p != nil {
-		return *p
+// effectiveEntries returns the nameEntry form of r.Names: the
+// precomputed entries field when ApplySettings has run, or a freshly
+// built one otherwise (a directly-constructed *Rule, as most unit
+// tests use).
+func (r *Rule) effectiveEntries() []nameEntry {
+	if r.entriesReady {
+		return r.entries
 	}
-	r.entriesMu.Lock()
-	defer r.entriesMu.Unlock()
-	entries := r.buildNameEntries()
-	r.entriesPtr.Store(&entries)
-	return entries
+	return r.buildNameEntries()
 }
 
 // buildNameEntries precomputes nameEntry values for all configured names.
@@ -229,10 +225,11 @@ func scanRawHTMLSegments(entries []nameEntry, v *ast.RawHTML, f *lint.File, acc 
 }
 
 // collectMatches walks the AST and gathers all wrong-cased matches.
-// nameEntry values are precomputed once per rule instance (cachedNameEntries)
-// and reused across all segments and all files that instance checks.
+// nameEntry values are precomputed once per rule instance
+// (effectiveEntries) and reused across all segments and all files
+// that instance checks.
 func (r *Rule) collectMatches(f *lint.File) []wrongMatch {
-	entries := r.cachedNameEntries()
+	entries := r.effectiveEntries()
 	if len(entries) == 0 {
 		return nil
 	}
@@ -311,7 +308,7 @@ func normalizeMatches(matches []wrongMatch) []wrongMatch {
 // they never appear in the runs — so this reproduces the AST walk's match set
 // for the no-code, no-HTML case.
 func (r *Rule) collectMatchesInline(f *lint.File) []wrongMatch {
-	entries := r.cachedNameEntries()
+	entries := r.effectiveEntries()
 	if len(entries) == 0 {
 		return nil
 	}
@@ -436,6 +433,12 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 				return fmt.Errorf("proper-names: names must be a list of strings, got %T", v)
 			}
 			r.Names = names
+			// Rebuild entries immediately, in lockstep with r.Names, so
+			// a later key failing this same ApplySettings call (map
+			// iteration order is unspecified) can never leave entries
+			// stale relative to the Names this call already committed.
+			r.entries = r.buildNameEntries()
+			r.entriesReady = true
 		case "check-code":
 			b, ok := v.(bool)
 			if !ok {
@@ -452,10 +455,6 @@ func (r *Rule) ApplySettings(s map[string]any) error {
 			return fmt.Errorf("proper-names: unknown setting %q", k)
 		}
 	}
-	// Invalidate the entries cache so the next Check rebuilds against
-	// the new Names; ApplySettings is the only path that mutates
-	// r.Names, so clearing here is sufficient.
-	r.entriesPtr.Store(nil)
 	return nil
 }
 

--- a/internal/rules/propernames/rule_test.go
+++ b/internal/rules/propernames/rule_test.go
@@ -397,31 +397,63 @@ func TestWordlistTarget(t *testing.T) {
 	assert.Equal(t, "names", (&Rule{}).WordlistTarget())
 }
 
-// TestCachedNameEntries pins the per-rule memoization contract:
-// subsequent calls on the same rule return the same cached slice
-// (reference identity); ApplySettings invalidates the cache so the
-// next call rebuilds against the new Names. The cache lives on the
-// rule instance, not on the per-Check File, so multiple Checks on the
-// same rule instance share one build.
-func TestCachedNameEntries(t *testing.T) {
-	r := &Rule{Names: []string{"JavaScript", "GitHub"}}
+// TestEffectiveEntries_PrecomputedByApplySettings pins the per-rule
+// memoization contract: ApplySettings precomputes entries once, and
+// effectiveEntries then returns that same slice (reference identity)
+// on every call rather than rebuilding it — the cache lives on the
+// rule instance, not the per-Check File, so multiple Checks on the
+// same rule instance share one build. A second ApplySettings call
+// rebuilds entries in lockstep with the new Names.
+func TestEffectiveEntries_PrecomputedByApplySettings(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"names": []string{"JavaScript", "GitHub"}}))
 
-	first := r.cachedNameEntries()
+	first := r.effectiveEntries()
 	require.Len(t, first, 2)
 
-	second := r.cachedNameEntries()
+	second := r.effectiveEntries()
 	assert.Equal(t,
 		reflect.ValueOf(first).Pointer(),
 		reflect.ValueOf(second).Pointer(),
-		"subsequent calls on the same rule must return the same cached entries")
+		"subsequent calls on the same rule must return the same precomputed entries")
 
-	// ApplySettings invalidates the cache; the next call rebuilds.
 	require.NoError(t, r.ApplySettings(map[string]any{"names": []string{"TypeScript"}}))
-	third := r.cachedNameEntries()
+	third := r.effectiveEntries()
 	assert.NotEqual(t,
 		reflect.ValueOf(first).Pointer(),
 		reflect.ValueOf(third).Pointer(),
-		"ApplySettings must clear the cache so the next call rebuilds")
+		"a second ApplySettings call must rebuild entries against the new Names")
 	require.Len(t, third, 1)
 	assert.Equal(t, "TypeScript", third[0].str)
+}
+
+// TestEffectiveEntries_DirectlyConstructedRuleFallsBack pins the
+// fallback path a directly-constructed *Rule takes (as every other
+// test in this file does): with entriesReady never set, effectiveEntries
+// builds fresh on every call instead of reading a stale zero value.
+func TestEffectiveEntries_DirectlyConstructedRuleFallsBack(t *testing.T) {
+	r := &Rule{Names: []string{"JavaScript"}}
+	entries := r.effectiveEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "JavaScript", entries[0].str)
+}
+
+// TestApplySettings_EntriesSurviveUnrelatedFailedReconfigure pins
+// that a later ApplySettings call which fails on a key other than
+// "names" leaves the already-committed Names/entries pair untouched,
+// rather than the old design's trailing-only invalidation silently
+// desyncing them. Uses two sequential single-key calls (rather than
+// one multi-key map) so the scenario is deterministic: Go map
+// iteration order is unspecified, so a single call combining "names"
+// and an invalid key would process them in a random order.
+func TestApplySettings_EntriesSurviveUnrelatedFailedReconfigure(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"names": []string{"JavaScript"}}))
+	warmed := r.effectiveEntries()
+
+	err := r.ApplySettings(map[string]any{"check-code": "not-a-bool"})
+	require.Error(t, err)
+
+	assert.Equal(t, []string{"JavaScript"}, r.Names)
+	assert.Equal(t, warmed, r.effectiveEntries())
 }

--- a/internal/rules/propernames/rule_test.go
+++ b/internal/rules/propernames/rule_test.go
@@ -1,6 +1,7 @@
 package propernames
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -394,4 +395,33 @@ func TestCheck_NilASTMatchesAST(t *testing.T) {
 
 func TestWordlistTarget(t *testing.T) {
 	assert.Equal(t, "names", (&Rule{}).WordlistTarget())
+}
+
+// TestCachedNameEntries pins the per-rule memoization contract:
+// subsequent calls on the same rule return the same cached slice
+// (reference identity); ApplySettings invalidates the cache so the
+// next call rebuilds against the new Names. The cache lives on the
+// rule instance, not on the per-Check File, so multiple Checks on the
+// same rule instance share one build.
+func TestCachedNameEntries(t *testing.T) {
+	r := &Rule{Names: []string{"JavaScript", "GitHub"}}
+
+	first := r.cachedNameEntries()
+	require.Len(t, first, 2)
+
+	second := r.cachedNameEntries()
+	assert.Equal(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(second).Pointer(),
+		"subsequent calls on the same rule must return the same cached entries")
+
+	// ApplySettings invalidates the cache; the next call rebuilds.
+	require.NoError(t, r.ApplySettings(map[string]any{"names": []string{"TypeScript"}}))
+	third := r.cachedNameEntries()
+	assert.NotEqual(t,
+		reflect.ValueOf(first).Pointer(),
+		reflect.ValueOf(third).Pointer(),
+		"ApplySettings must clear the cache so the next call rebuilds")
+	require.Len(t, third, 1)
+	assert.Equal(t, "TypeScript", third[0].str)
 }

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1985,7 +1985,7 @@ func walkRequiredHeadings(
 	requiredByText map[string][]int, ref string,
 ) ([]lint.Diagnostic, int, bool) {
 	var diags []lint.Diagnostic
-	claimed := make(map[int]bool)
+	claimed := make(map[int]struct{})
 	docIdx := 0
 	allowExtra := false
 	for schIdx, req := range sch.Headings {
@@ -1993,7 +1993,7 @@ func walkRequiredHeadings(
 			allowExtra = true
 			continue
 		}
-		if claimed[schIdx] {
+		if _, ok := claimed[schIdx]; ok {
 			continue
 		}
 		// Save the position before the scan so that a missing-section
@@ -2009,7 +2009,7 @@ func walkRequiredHeadings(
 		if found {
 			allowExtra = false
 		}
-		if !found && !claimed[schIdx] {
+		if _, ok := claimed[schIdx]; !found && !ok {
 			diags = append(diags, missingSectionDiagLegacy(
 				f, req, ref, legacyPrecedingLine(docHeadings, preScanIdx)))
 		}
@@ -2088,7 +2088,7 @@ func matchRequired(
 	docHeadings []docHeading,
 	docIdx, schIdx int,
 	requiredByText map[string][]int,
-	claimed map[int]bool,
+	claimed map[int]struct{},
 	allowExtra bool,
 	schemaRef string,
 ) ([]lint.Diagnostic, int, bool) {
@@ -2100,7 +2100,7 @@ func matchRequired(
 			if dh.Level != req.Level {
 				diags = append(diags, levelMismatchDiag(f, dh, req, schemaRef))
 			}
-			claimed[schIdx] = true
+			claimed[schIdx] = struct{}{}
 			return diags, docIdx + 1, true
 		}
 		if ooIdx := nextUnclaimed(requiredByText[dh.Text], claimed, schIdx+1); ooIdx >= 0 {
@@ -2116,7 +2116,7 @@ func matchRequired(
 			if dh.Level != other.Level {
 				diags = append(diags, levelMismatchDiag(f, dh, other, schemaRef))
 			}
-			claimed[ooIdx] = true
+			claimed[ooIdx] = struct{}{}
 			docIdx++
 			continue
 		}
@@ -2151,9 +2151,12 @@ func levelMismatchDiag(
 
 // nextUnclaimed returns the first index in candidates that is >= minIdx
 // and not yet claimed, or -1 if none qualifies.
-func nextUnclaimed(candidates []int, claimed map[int]bool, minIdx int) int {
+func nextUnclaimed(candidates []int, claimed map[int]struct{}, minIdx int) int {
 	for _, idx := range candidates {
-		if idx >= minIdx && !claimed[idx] {
+		if idx < minIdx {
+			continue
+		}
+		if _, ok := claimed[idx]; !ok {
 			return idx
 		}
 	}

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1592,7 +1592,7 @@ func parseSchemaWithRootFS(
 	var includes []string
 	if schemaPath != "" {
 		cleanPath := filepath.Clean(schemaPath)
-		visited := map[string]bool{cleanPath: true}
+		visited := map[string]struct{}{cleanPath: {}}
 		chain := []string{cleanPath}
 		var fp string
 		headings, fp, includes, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes, rootFS)
@@ -1656,7 +1656,7 @@ func parseSchemaWithRootFS(
 // transitive set appended after the fragment's own path.
 func extractSchemaHeadings(
 	schemaFile *lint.File, schemaPath string,
-	visited map[string]bool, chain []string, maxBytes int64, rootFS fs.FS,
+	visited map[string]struct{}, chain []string, maxBytes int64, rootFS fs.FS,
 ) ([]docHeading, string, []string, error) {
 	var headings []docHeading
 	var filenamePattern string
@@ -1758,7 +1758,7 @@ func resolveSchemaIncludePath(
 // full dependency footprint on RunCache's reverse-include index.
 func expandSchemaInclude(
 	pi *piparser.ProcessingInstruction, source []byte,
-	schemaPath string, visited map[string]bool, chain []string, maxBytes int64, rootFS fs.FS,
+	schemaPath string, visited map[string]struct{}, chain []string, maxBytes int64, rootFS fs.FS,
 ) ([]docHeading, string, string, []string, error) {
 	includedPath, err := resolveSchemaIncludePath(pi, source, schemaPath)
 	if err != nil {
@@ -1775,7 +1775,7 @@ func expandSchemaInclude(
 		return nil, "", includedPath, nil, fmt.Errorf(
 			"schema include depth exceeds maximum (%d)", maxSchemaIncludeDepth)
 	}
-	if visited[includedPath] {
+	if _, ok := visited[includedPath]; ok {
 		chainCopy := make([]string, len(chain), len(chain)+1)
 		copy(chainCopy, chain)
 		chainCopy = append(chainCopy, includedPath)
@@ -1801,7 +1801,7 @@ func expandSchemaInclude(
 		return nil, "", includedPath, nil, err
 	}
 
-	visited[includedPath] = true
+	visited[includedPath] = struct{}{}
 	chain = append(chain, includedPath)
 	fragHeadings, fp2, subIncludes, err := extractSchemaHeadings(
 		fragFile, includedPath, visited, chain, maxBytes, rootFS)
@@ -1993,7 +1993,7 @@ func walkRequiredHeadings(
 			allowExtra = true
 			continue
 		}
-		if _, ok := claimed[schIdx]; ok {
+		if isClaimed(claimed, schIdx) {
 			continue
 		}
 		// Save the position before the scan so that a missing-section
@@ -2009,7 +2009,7 @@ func walkRequiredHeadings(
 		if found {
 			allowExtra = false
 		}
-		if _, ok := claimed[schIdx]; !found && !ok {
+		if !found && !isClaimed(claimed, schIdx) {
 			diags = append(diags, missingSectionDiagLegacy(
 				f, req, ref, legacyPrecedingLine(docHeadings, preScanIdx)))
 		}
@@ -2149,6 +2149,16 @@ func levelMismatchDiag(
 	return d.Emit(makeDiag, f.Path, dh.Line)
 }
 
+// isClaimed reports whether idx is a member of claimed. claimed is a
+// set — every entry is written exactly once, via claimed[idx] =
+// struct{}{} — so map[int]struct{} (zero-byte value) replaces the
+// map[int]bool this file used to spell as a truthy map read. Mirrors
+// internal/schema/validate.go's isClaimed for the identical pattern.
+func isClaimed(claimed map[int]struct{}, idx int) bool {
+	_, ok := claimed[idx]
+	return ok
+}
+
 // nextUnclaimed returns the first index in candidates that is >= minIdx
 // and not yet claimed, or -1 if none qualifies.
 func nextUnclaimed(candidates []int, claimed map[int]struct{}, minIdx int) int {
@@ -2156,7 +2166,7 @@ func nextUnclaimed(candidates []int, claimed map[int]struct{}, minIdx int) int {
 		if idx < minIdx {
 			continue
 		}
-		if _, ok := claimed[idx]; !ok {
+		if !isClaimed(claimed, idx) {
 			return idx
 		}
 	}

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2609,3 +2609,17 @@ func TestLegacyPrecedingLine(t *testing.T) {
 func TestWordlistTarget(t *testing.T) {
 	assert.Equal(t, "placeholders", (&Rule{}).WordlistTarget())
 }
+
+// TestNextUnclaimed_SetValueType pins claimed's value type at
+// map[int]struct{} rather than map[int]bool: claimed is a pure
+// presence set (only ever written struct{}{}/true, never explicitly
+// cleared), so the zero-byte value type is the right one
+// (docs/development/high-performance-go.md "map[K]struct{} for
+// sets"). This test only compiles once nextUnclaimed's signature
+// uses map[int]struct{}.
+func TestNextUnclaimed_SetValueType(t *testing.T) {
+	claimed := map[int]struct{}{1: {}, 3: {}}
+	assert.Equal(t, 0, nextUnclaimed([]int{0, 1, 2, 3}, claimed, 0))
+	assert.Equal(t, 2, nextUnclaimed([]int{1, 2, 3}, claimed, 0))
+	assert.Equal(t, -1, nextUnclaimed([]int{1, 3}, claimed, 0))
+}

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -2622,4 +2622,8 @@ func TestNextUnclaimed_SetValueType(t *testing.T) {
 	assert.Equal(t, 0, nextUnclaimed([]int{0, 1, 2, 3}, claimed, 0))
 	assert.Equal(t, 2, nextUnclaimed([]int{1, 2, 3}, claimed, 0))
 	assert.Equal(t, -1, nextUnclaimed([]int{1, 3}, claimed, 0))
+	// A candidate below minIdx is skipped without a claimed lookup: 0
+	// and 1 are both < minIdx here, so the first index actually
+	// considered is 2 (unclaimed).
+	assert.Equal(t, 2, nextUnclaimed([]int{0, 1, 2, 3}, claimed, 2))
 }

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -205,15 +205,15 @@ func dedupedCUEErrorDiags(
 	cueErrs []*cuelite.PathError, keyLines map[string]int, mkDiag MakeDiag,
 ) []lint.Diagnostic {
 	type dedupKey struct{ field, actual, expected string }
-	seen := make(map[dedupKey]bool, len(cueErrs))
+	seen := make(map[dedupKey]struct{}, len(cueErrs))
 	out := make([]lint.Diagnostic, 0, len(cueErrs))
 	for _, ce := range cueErrs {
 		d := schemaDiagFromCUEError(sch, docFM, ce)
 		key := dedupKey{field: d.Field, actual: d.Actual, expected: d.Expected}
-		if seen[key] {
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[key] = true
+		seen[key] = struct{}{}
 		out = append(out, d.Emit(mkDiag, f.Path, fmDiagLine(f, ce.Path(), keyLines)))
 	}
 	return out

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jeduden/mdsmith/cue/cuelite"
 	"github.com/jeduden/mdsmith/internal/lint"
 
 	"github.com/stretchr/testify/assert"
@@ -377,4 +378,34 @@ func TestLevelMismatchSchemaDiag_HeadingLevelFormat(t *testing.T) {
 	assert.Equal(t, "Introduction", d.Field)
 	assert.Equal(t, "h2", d.Expected, "expected heading level must be formatted as h<n>")
 	assert.Equal(t, "h3", d.Actual, "actual heading level must be formatted as h<n>")
+}
+
+// TestDedupedCUEErrorDiags_DuplicateKeyCollapses covers
+// dedupedCUEErrorDiags's dedup branch (seen[key] already present):
+// two cueErrs entries that render to the identical field/actual/
+// expected must collapse to one diagnostic, not two. Uses a real
+// *cuelite.PathError from an actual CUE validation failure,
+// duplicated in the input slice, rather than a synthetic error —
+// PathError's constructor is unexported outside cue/cuelite.
+func TestDedupedCUEErrorDiags_DuplicateKeyCollapses(t *testing.T) {
+	sch := &Schema{
+		Source:      "kind t",
+		Frontmatter: map[string]string{"id": `int`},
+	}
+	f, err := lint.NewFileFromSource("doc.md", []byte("# T\n"), true)
+	require.NoError(t, err)
+	docFM := map[string]any{"id": "not-an-int"}
+
+	compiled := CachedCompile(nil, sch.FrontmatterCUE())
+	require.NoError(t, compiled.Err())
+	merged := compiled.Value.CompileMap(docFM)
+	verr := merged.Validate()
+	require.Error(t, verr)
+	cueErrs := cuelite.Errors(verr)
+	require.NotEmpty(t, cueErrs)
+
+	dup := []*cuelite.PathError{cueErrs[0], cueErrs[0]}
+	keyLines := docFrontmatterKeyLines(f)
+	diags := dedupedCUEErrorDiags(f, sch, docFM, dup, keyLines, makeDiagForTest)
+	assert.Len(t, diags, 1, "two identical cueErrs entries must collapse to one diagnostic")
 }


### PR DESCRIPTION
## Summary

An audit against `docs/development/high-performance-go.md` (dispatched as three parallel research agents scanning for regexp/fmt/string, allocation/prealloc, and struct-layout/data-structure anti-patterns) surfaced several violations of the project's performance guidelines that survived earlier perf-cleanup rounds (#723, #725, #729, #731, #732). This PR fixes the top 5, ranked by hotness and impact, each with red/green TDD and a benchmark or deterministic test pinning the win — then went through three rounds of xhigh-severity code review, one of which caught a real, `-race`-confirmed data race and fixed it before merge.

Three of the five findings share a pattern worth calling out: the shared `internal/integration/alloc_budget_test.go` fixture carries plain prose with no emphasis markup, no configured proper-name vocabulary, and empty schema/dedup maps, so it reports 0 allocs/op for these rules on `BenchmarkPerRuleAllocBudget` even though the real per-Check cost is substantial once the rule is actually configured/exercised the way it is in practice. Each fix below adds a dedicated, rule-local alloc test with a fixture that does exercise the cost, closing that blind spot for its rule going forward.

1. **MDS047 `ambiguous-emphasis`** — `scanLine` tracked the in-progress delimiter run through a `*emphRun` reassigned across loop iterations, forcing a fresh heap allocation for every delimiter run on a line. On ordinary emphasis-heavy prose (`**bold**`, `*italic*`, `_underscore_`) this cost ~10 allocs/line, invisible to the shared fixture because it carries no emphasis at all. Track the run by value plus an `open` bool instead, gate `scanLine` behind a cheap byte-count pre-check, skip building the escape/adjacency tracking maps when they can't possibly produce a diagnostic, and stop pre-sizing `diags` for a violation rate real documents rarely hit. Lands at **9 allocs/op** (was 41), under CLAUDE.md's documented ≤10 ceiling.

2. **`internal/rules/linelength` `wrapTokens`** — the line-packing loop grew its output line with `cur += " " + u` on every packed unit, reallocating the backing array each step — the same anti-pattern the sibling function `buildWrapUnits` in the same file was already fixed for. Switched to `strings.Builder`. 11 → 6 allocs/op on a 10-unit line packed onto one output line.

3. **MDS050 `proper-names`** — `buildNameEntries()` rebuilt a fresh `[]byte` plus an ASCII-lowercase copy per configured name on every single `Check` call, even though `r.Names` is immutable for the life of the `Rule` instance — a per-*Rule* memoization case, not a per-file one. First cached behind a lazy atomic-pointer/mutex (mirroring MDS063's `cachedBannedSet`), then **redesigned after code review found that pattern unsafe**: `internal/rule.CloneInstance` clones a rule via a raw, unsynchronized field copy, which races a concurrent `Check` on the source instance populating that lazy cache — confirmed with `go test -race` every time, and a real, reachable scenario given how `pkg/mdsmith.Session` shares rule instances across concurrent `Check`/`CheckVersion` calls. The final design precomputes `entries` synchronously inside `ApplySettings`, before any `Check` or clone can touch the instance — plain, write-once fields, no synchronization needed, verified race-free. 43 → 2 allocs/op with 20 configured names.

4. **MDS020 `required-structure` + `internal/schema`** — three `map[K]bool` sets used purely for presence checks (every write `true`/`struct{}{}`, never explicitly cleared): `requiredstructure`'s `claimed` (schema-heading walk) and `visited` (`<?include?>` cycle detection), and `schema.dedupedCUEErrorDiags`'s `seen` (dedup key set). Added an `isClaimed` helper mirroring the one `internal/schema/validate.go` already has for the identical pattern.

5. **`internal/lint` `fenceInfo`** — `char byte` sitting before `indent int`/`length int` cost 7 bytes of padding, landing the struct at 32 bytes. `openingFence` returns it by value on the hottest per-line scan path (`tryFence`, tried first for every non-blank line of every file via `scanBlock`'s dispatch), so the padding is copied repeatedly. Reordered large-to-small to 24 bytes, pinned by a new `unsafe.Sizeof` test; also dropped a redundant extra copy in `advanceFenceState` found in review.

Each fix is its own commit with a full red/green TDD trail (failing test first, then the fix) and cites the specific guideline section it addresses.

## Code review

Three rounds of xhigh-severity review (8 independent finder angles per round), each addressed before the next:

- **Round 1** found and fixed: the MDS050 data race described above; an MDS047 alloc-budget test that pinned 15 allocs/op without going through CLAUDE.md's documented grandfather mechanism (now 9, under the ≤10 ceiling); two codecov patch-coverage gaps (`nextUnclaimed`'s new branch, `dedupedCUEErrorDiags`'s dedup branch); and a redundant struct copy in `advanceFenceState`.
- **Round 2** re-verified every round-1 fix empirically (including re-running the race probe against the redesigned code) and found no new correctness or concurrency bugs; it flagged one process issue (a commit that bundled 4 unrelated fixes, since split into 4 separate commits) plus two informational, no-action notes.
- **Round 3** re-verified the entire diff from scratch, ran the full build/vet/test/race/lint/`mdsmith check` matrix directly rather than trusting commit messages, and found no correctness or concurrency issues — only minor documentation nits.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `go test -race` on every touched package, including an adversarial `CloneInstance`-vs-`Check` race probe for the MDS050 fix
- [x] `go vet ./...` on every touched package
- [x] `go tool -modfile=tools/go.mod golangci-lint run ./...` (0 issues)
- [x] `go run ./cmd/mdsmith check .` (548 files, 0 failures)
- [x] Codecov patch coverage: 100% of modified/coverable lines
- [x] `internal/integration` per-rule alloc-budget gate still green for every touched rule (MDS047, MDS020)
- [x] Three rounds of xhigh code review, all findings addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgVEsnKFFaoHjwN3JbvkNy)_