### PR TITLE
test: add dedicated unit tests for unexported helpers (plan 2607051919)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -242,7 +242,7 @@ footer: |
 | 2607040635 | ⛔     | opus   | [Add mdsmith move: move a file and rewrite every incoming reference](plan/2607040635_move-command.md)                                                   |
 | 2607040822 | 🔲     | opus   | [Refactor engine redesign: unify move and rename behind one Plan, across CLI, LSP, and WASM hosts](plan/2607040822_refactor-move-rename-redesign.md)    |
 | 2607051918 | ✅     | sonnet | [Export wordlist.Dedup and remove the identical dedupStrings copy in internal/config](plan/2607051918_arch-fix-wordlist-config-dedup.md)                |
-| 2607051919 | 🔲     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
+| 2607051919 | ✅     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
 | 2607051920 | ✅     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
 | 2607071642 | 🔲     | sonnet | [Single-file metric extraction via `mdsmith metrics get` (readability first)](plan/2607071642_extractable-file-metrics.md)                              |
 | 2607082048 | 🔲     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |

--- a/internal/config/wordlist_files_test.go
+++ b/internal/config/wordlist_files_test.go
@@ -61,3 +61,76 @@ func TestParseWordlistFile_RejectsUnknownKey(t *testing.T) {
 	_, err := parseWordlistFile(filepath.Join(dir, ".mdsmith", "wordlists", "bad.yaml"))
 	require.Error(t, err)
 }
+
+func TestToWordlistMap_Nil(t *testing.T) {
+	assert.Nil(t, toWordlistMap(nil))
+	assert.Nil(t, toWordlistMap(map[string]UserWordlist{}))
+}
+
+func TestToWordlistMap_Populated(t *testing.T) {
+	m := map[string]UserWordlist{
+		"team": {Extends: "base", Entries: []string{"delve"}, SourcePath: "/cfg"},
+	}
+	got := toWordlistMap(m)
+	require.Len(t, got, 1)
+	wl := got["team"]
+	assert.Equal(t, "team", wl.Name)
+	assert.Equal(t, "base", wl.Extends)
+	assert.Equal(t, []string{"delve"}, wl.Entries)
+	assert.Equal(t, "/cfg", wl.SourcePath)
+}
+
+func TestStripLists_RemovesKey(t *testing.T) {
+	in := map[string]any{"lists": []any{"x"}, "contains": []any{"y"}}
+	out := stripLists(in)
+	_, hasLists := out["lists"]
+	assert.False(t, hasLists, "lists key must be absent after strip")
+	assert.Equal(t, []any{"y"}, out["contains"])
+}
+
+func TestStripLists_NoListsKey(t *testing.T) {
+	in := map[string]any{"contains": []any{"a"}}
+	out := stripLists(in)
+	assert.Equal(t, map[string]any{"contains": []any{"a"}}, out)
+}
+
+func TestResolveListEntries_Empty(t *testing.T) {
+	assert.Nil(t, resolveListEntries(nil, nil))
+}
+
+func TestResolveListEntries_SkipsUnresolvable(t *testing.T) {
+	got := resolveListEntries([]string{"ghost"}, nil)
+	assert.Nil(t, got)
+}
+
+func TestResolveListEntries_ResolvesEntry(t *testing.T) {
+	userMap := map[string]wordlist.Wordlist{
+		"base": {Name: "base", Entries: []string{"delve", "robust"}},
+	}
+	got := resolveListEntries([]string{"base"}, userMap)
+	assert.Equal(t, []string{"delve", "robust"}, got)
+}
+
+func TestExpandRuleLists_NonListValueIsNoop(t *testing.T) {
+	settings := map[string]any{"contains": []any{"existing"}}
+	expandRuleLists("not-a-list", "contains", settings, nil)
+	assert.Equal(t, []any{"existing"}, settings["contains"])
+}
+
+func TestExpandRuleLists_UnionsResolvedFirst(t *testing.T) {
+	userMap := map[string]wordlist.Wordlist{
+		"base": {Name: "base", Entries: []string{"delve"}},
+	}
+	settings := map[string]any{"contains": []any{"robust"}}
+	expandRuleLists([]any{"base"}, "contains", settings, userMap)
+	assert.Equal(t, []any{"delve", "robust"}, settings["contains"])
+}
+
+func TestExpandRuleLists_DeduplicatesEntries(t *testing.T) {
+	userMap := map[string]wordlist.Wordlist{
+		"base": {Name: "base", Entries: []string{"delve", "robust"}},
+	}
+	settings := map[string]any{"contains": []any{"delve"}}
+	expandRuleLists([]any{"base"}, "contains", settings, userMap)
+	assert.Equal(t, []any{"delve", "robust"}, settings["contains"])
+}

--- a/internal/convention/nollmtells_test.go
+++ b/internal/convention/nollmtells_test.go
@@ -1,0 +1,38 @@
+package convention
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLlmVocabulary(t *testing.T) {
+	got := llmVocabulary()
+	assert.NotEmpty(t, got)
+	assert.Contains(t, got, "delve")
+	assert.Contains(t, got, "leverage")
+}
+
+func TestLlmPhrases(t *testing.T) {
+	got := llmPhrases()
+	assert.NotEmpty(t, got)
+	assert.Contains(t, got, "it's important to note that")
+	assert.Contains(t, got, "in the realm of")
+}
+
+func TestLlmVocabularyAndPhrases(t *testing.T) {
+	got := llmVocabularyAndPhrases()
+	vocab := llmVocabulary()
+	phrases := llmPhrases()
+	assert.Len(t, got, len(vocab)+len(phrases))
+	assert.Equal(t, vocab[0], got[0], "vocabulary entries appear first")
+	assert.Contains(t, got, "delve")
+	assert.Contains(t, got, "it's important to note that")
+}
+
+func TestLlmParagraphOpeners(t *testing.T) {
+	got := llmParagraphOpeners()
+	assert.NotEmpty(t, got)
+	assert.Contains(t, got, "Moreover,")
+	assert.Contains(t, got, "Certainly,")
+}

--- a/internal/convention/nollmtells_test.go
+++ b/internal/convention/nollmtells_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLlmVocabulary(t *testing.T) {
@@ -24,7 +25,7 @@ func TestLlmVocabularyAndPhrases(t *testing.T) {
 	got := llmVocabularyAndPhrases()
 	vocab := llmVocabulary()
 	phrases := llmPhrases()
-	assert.Len(t, got, len(vocab)+len(phrases))
+	require.Len(t, got, len(vocab)+len(phrases))
 	assert.Equal(t, vocab[0], got[0], "vocabulary entries appear first")
 	assert.Contains(t, got, "delve")
 	assert.Contains(t, got, "it's important to note that")

--- a/internal/rules/concisenessscoring/classifier/model_test.go
+++ b/internal/rules/concisenessscoring/classifier/model_test.go
@@ -622,6 +622,35 @@ func TestDedupeSorted_DuplicatesRemoved(t *testing.T) {
 	}
 }
 
+func TestBuildPhraseMarkers_EmptyInput(t *testing.T) {
+	got := buildPhraseMarkers(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty markers for nil input, got %v", got)
+	}
+}
+
+func TestBuildPhraseMarkers_AppliesPhraseMarker(t *testing.T) {
+	phrases := []string{"in order to", "at this point"}
+	got := buildPhraseMarkers(phrases)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 markers, got %d", len(got))
+	}
+	if got[0] != " in order to " {
+		t.Errorf("marker[0] = %q, want %q", got[0], " in order to ")
+	}
+	if got[1] != " at this point " {
+		t.Errorf("marker[1] = %q, want %q", got[1], " at this point ")
+	}
+}
+
+func TestBuildPhraseMarkers_LengthPreserving(t *testing.T) {
+	phrases := []string{"foo bar", "baz"}
+	got := buildPhraseMarkers(phrases)
+	if len(got) != len(phrases) {
+		t.Fatalf("buildPhraseMarkers must be length-preserving: got %d, want %d", len(got), len(phrases))
+	}
+}
+
 func BenchmarkClassify(b *testing.B) {
 	model, err := LoadEmbedded()
 	if err != nil {

--- a/internal/rules/concisenessscoring/classifier/model_test.go
+++ b/internal/rules/concisenessscoring/classifier/model_test.go
@@ -643,14 +643,6 @@ func TestBuildPhraseMarkers_AppliesPhraseMarker(t *testing.T) {
 	}
 }
 
-func TestBuildPhraseMarkers_LengthPreserving(t *testing.T) {
-	phrases := []string{"foo bar", "baz"}
-	got := buildPhraseMarkers(phrases)
-	if len(got) != len(phrases) {
-		t.Fatalf("buildPhraseMarkers must be length-preserving: got %d, want %d", len(got), len(phrases))
-	}
-}
-
 func BenchmarkClassify(b *testing.B) {
 	model, err := LoadEmbedded()
 	if err != nil {

--- a/internal/rules/linelength/fix_test.go
+++ b/internal/rules/linelength/fix_test.go
@@ -161,3 +161,56 @@ func TestFix_PreservesCRLFLineEndings(t *testing.T) {
 		"CRLF source must not produce bare LF in output: %q", got)
 	assert.Contains(t, got, "\r\n", "CRLF source must produce CRLF output")
 }
+
+func TestOverlapsGeneratedRange_NoRanges(t *testing.T) {
+	f := &lint.File{}
+	assert.False(t, overlapsGeneratedRange(f, 1, 5))
+}
+
+func TestOverlapsGeneratedRange_Disjoint(t *testing.T) {
+	f := &lint.File{GeneratedRanges: []lint.LineRange{{From: 10, To: 20}}}
+	assert.False(t, overlapsGeneratedRange(f, 1, 5))
+	assert.False(t, overlapsGeneratedRange(f, 21, 25))
+}
+
+func TestOverlapsGeneratedRange_Overlaps(t *testing.T) {
+	f := &lint.File{GeneratedRanges: []lint.LineRange{{From: 5, To: 10}}}
+	assert.True(t, overlapsGeneratedRange(f, 1, 5), "touches lower bound")
+	assert.True(t, overlapsGeneratedRange(f, 10, 15), "touches upper bound")
+	assert.True(t, overlapsGeneratedRange(f, 6, 9), "fully inside")
+	assert.True(t, overlapsGeneratedRange(f, 1, 20), "range spans the generated block")
+}
+
+func TestTrimTrailingCR_CRLFMode(t *testing.T) {
+	assert.Equal(t, []byte("line"), trimTrailingCR([]byte("line\r"), true))
+}
+
+func TestTrimTrailingCR_CRLFModeNoCR(t *testing.T) {
+	assert.Equal(t, []byte("line"), trimTrailingCR([]byte("line"), true))
+}
+
+func TestTrimTrailingCR_NonCRLFModePreservesCR(t *testing.T) {
+	assert.Equal(t, []byte("line\r"), trimTrailingCR([]byte("line\r"), false))
+}
+
+func TestTrimTrailingCR_EmptySlice(t *testing.T) {
+	assert.Equal(t, []byte{}, trimTrailingCR([]byte{}, true))
+}
+
+func TestCloneBytes_ProducesEqualContent(t *testing.T) {
+	src := []byte("hello world")
+	got := cloneBytes(src)
+	assert.Equal(t, src, got)
+}
+
+func TestCloneBytes_IsolatesFromSource(t *testing.T) {
+	src := []byte("hello")
+	got := cloneBytes(src)
+	got[0] = 'X'
+	assert.Equal(t, byte('h'), src[0], "mutating clone must not affect source")
+}
+
+func TestCloneBytes_Nil(t *testing.T) {
+	got := cloneBytes(nil)
+	assert.Equal(t, []byte{}, got)
+}

--- a/internal/rules/linelength/reflow_test.go
+++ b/internal/rules/linelength/reflow_test.go
@@ -274,19 +274,15 @@ func TestLeadingWhitespace(t *testing.T) {
 }
 
 func TestParagraphHasRawHTML_NoHTML(t *testing.T) {
-	doc := ast.NewDocument()
 	p := ast.NewParagraph()
-	doc.AppendChild(doc, p)
 	if paragraphHasRawHTML(p) {
 		t.Errorf("paragraphHasRawHTML = true for paragraph without raw HTML, want false")
 	}
 }
 
 func TestParagraphHasRawHTML_WithHTML(t *testing.T) {
-	doc := ast.NewDocument()
 	p := ast.NewParagraph()
 	p.AppendChild(p, ast.NewRawHTML())
-	doc.AppendChild(doc, p)
 	if !paragraphHasRawHTML(p) {
 		t.Errorf("paragraphHasRawHTML = false for paragraph with raw HTML, want true")
 	}

--- a/internal/rules/linelength/reflow_test.go
+++ b/internal/rules/linelength/reflow_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 )
 
 func TestIsAbbrev_TrainedModel(t *testing.T) {
@@ -269,5 +270,24 @@ func TestLeadingWhitespace(t *testing.T) {
 	}
 	if got := leadingWhitespace([]byte("text")); got != "" {
 		t.Errorf("leadingWhitespace = %q, want empty", got)
+	}
+}
+
+func TestParagraphHasRawHTML_NoHTML(t *testing.T) {
+	doc := ast.NewDocument()
+	p := ast.NewParagraph()
+	doc.AppendChild(doc, p)
+	if paragraphHasRawHTML(p) {
+		t.Errorf("paragraphHasRawHTML = true for paragraph without raw HTML, want false")
+	}
+}
+
+func TestParagraphHasRawHTML_WithHTML(t *testing.T) {
+	doc := ast.NewDocument()
+	p := ast.NewParagraph()
+	p.AppendChild(p, ast.NewRawHTML())
+	doc.AppendChild(doc, p)
+	if !paragraphHasRawHTML(p) {
+		t.Errorf("paragraphHasRawHTML = false for paragraph with raw HTML, want true")
 	}
 }

--- a/internal/wordlist/wordlist_test.go
+++ b/internal/wordlist/wordlist_test.go
@@ -170,3 +170,61 @@ func TestResolve_MissingParent(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ghost")
 }
+
+func TestAllNames_Empty(t *testing.T) {
+	assert.Empty(t, allNames(nil))
+	assert.Empty(t, allNames(map[string]Wordlist{}))
+}
+
+func TestAllNames_Single(t *testing.T) {
+	user := map[string]Wordlist{"solo": {Name: "solo"}}
+	assert.Equal(t, []string{"solo"}, allNames(user))
+}
+
+func TestAllNames_Sorted(t *testing.T) {
+	user := map[string]Wordlist{
+		"zebra": {Name: "zebra"},
+		"alpha": {Name: "alpha"},
+		"beta":  {Name: "beta"},
+	}
+	got := allNames(user)
+	assert.Equal(t, []string{"alpha", "beta", "zebra"}, got)
+}
+
+func TestFlatten_Single(t *testing.T) {
+	user := map[string]Wordlist{
+		"a": {Name: "a", Entries: []string{"x", "y"}},
+	}
+	got, err := flatten("a", user, map[string]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x", "y"}, got)
+}
+
+func TestFlatten_ExtendsChain(t *testing.T) {
+	user := map[string]Wordlist{
+		"base":  {Name: "base", Entries: []string{"a", "b"}},
+		"child": {Name: "child", Extends: "base", Entries: []string{"c"}},
+	}
+	got, err := flatten("child", user, map[string]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+func TestFlatten_Cycle(t *testing.T) {
+	user := map[string]Wordlist{
+		"a": {Name: "a", Extends: "b", Entries: []string{"1"}},
+		"b": {Name: "b", Extends: "a", Entries: []string{"2"}},
+	}
+	_, err := flatten("a", user, map[string]bool{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle")
+}
+
+func TestFlatten_UnknownParent(t *testing.T) {
+	user := map[string]Wordlist{
+		"a": {Name: "a", Extends: "ghost", Entries: []string{"1"}},
+	}
+	_, err := flatten("a", user, map[string]bool{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}

--- a/plan/2607051919_arch-fix-new-helper-tests.md
+++ b/plan/2607051919_arch-fix-new-helper-tests.md
@@ -3,7 +3,7 @@ id: 2607051919
 title: >-
   Add dedicated unit tests for helpers added by the
   word-list and reflow features
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Several unexported helpers added for word-lists,
@@ -75,7 +75,7 @@ needed here.
 
 ## Acceptance Criteria
 
-- [ ] Every helper named above has a dedicated test by
+- [x] Every helper named above has a dedicated test by
       name in a sibling `_test.go` file.
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

Implements plan `2607051919_arch-fix-new-helper-tests.md`: gives every unexported helper flagged by the 2026-07-05 architecture audit its own named `TestFoo` test. Previously these helpers were covered only transitively through end-to-end caller tests.

## Changes

**`internal/wordlist/wordlist_test.go`** — `TestAllNames` (empty, single, sorted) and `TestFlatten` (single-entry, extends-chain, cycle, unknown-parent).

**`internal/config/wordlist_files_test.go`** (created) — `TestToWordlistMap`, `TestStripLists`, `TestResolveListEntries`, `TestExpandRuleLists`; these four helpers had zero test-file references before this PR.

**`internal/convention/nollmtells_test.go`** (created) — `TestLlmVocabulary`, `TestLlmPhrases`, `TestLlmVocabularyAndPhrases`, `TestLlmParagraphOpeners`; each asserts non-empty output and a couple of known entries, mirroring `TestNoLLMTellsWordlists`.

**`internal/rules/linelength/fix_test.go`** — `TestOverlapsGeneratedRange`, `TestTrimTrailingCR`, `TestCloneBytes`.

**`internal/rules/linelength/reflow_test.go`** — `TestParagraphHasRawHTML` (without HTML and with inline raw HTML node).

**`internal/rules/concisenessscoring/classifier/model_test.go`** — `TestBuildPhraseMarkers` (empty input, applies phrase marker).

**`plan/2607051919_arch-fix-new-helper-tests.md`** — status marked ✅, all acceptance criteria checked.

## xhigh Code-Review Fixes (3 rounds, opus)

- `nollmtells_test.go`: `assert.Len` → `require.Len` before `got[0]` access so a length mismatch produces a clean test failure instead of a panic.
- `reflow_test.go`: removed dead `doc` parent-link scaffolding from both `TestParagraphHasRawHTML` tests (`paragraphHasRawHTML` never calls `Parent()`).
- `model_test.go`: deleted `TestBuildPhraseMarkers_LengthPreserving`; its `len(got)==2` assertion was already fully covered by `TestBuildPhraseMarkers_AppliesPhraseMarker`.

## Test plan

- `go test ./...` — green
- `go run ./cmd/mdsmith check .` — 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_015qYnUAc5XUmrQBwiEYyd4j)_