### PR TITLE
Fix linkgraph purity-contract mismatch for wikilink resolution

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -250,5 +250,5 @@ footer: |
 | 2607082050 | 🔲     | sonnet | [APM coexistence: `mdsmith init --apm`, guide, and kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                       |
 | 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |
 | 2607082052 | 🔲     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |
-| 2607121915 | 🔳     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
+| 2607121915 | ✅     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -250,5 +250,5 @@ footer: |
 | 2607082050 | 🔲     | sonnet | [APM coexistence: `mdsmith init --apm`, guide, and kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                       |
 | 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |
 | 2607082052 | 🔲     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |
-| 2607121915 | 🔲     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
+| 2607121915 | 🔳     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
 <?/catalog?>

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -38,9 +38,9 @@ question. The current production set:
   Split from `internal/lint`.
 - `internal/fix` — produce edits that make a file stop violating rules.
 - `internal/linkgraph` — canonical Markdown link / directive / reference
-  extractor; MDS027, `mdsmith list backlinks`, and `internal/index` all
-  consult it for normalised path and anchor resolution. Pure (no file reads,
-  no workspace walks); callers can fan it out across goroutines.
+  extractor; MDS027, `mdsmith list backlinks`, and `internal/index` consult
+  it. Per-file functions are pure and goroutine-safe; `NewWikilinkIndex` and
+  `ResolveWikiLink` walk the workspace (prefer `WikilinkIndexFor` per run).
 - `internal/index` — the workspace symbol / edge graph (headings, link-ref
   defs, directives, front-matter keys, reverse edges); queried by the LSP,
   schema, and the rename / deps surfaces.

--- a/docs/development/architecture/go.md
+++ b/docs/development/architecture/go.md
@@ -39,8 +39,8 @@ question. The current production set:
 - `internal/fix` — produce edits that make a file stop violating rules.
 - `internal/linkgraph` — canonical Markdown link / directive / reference
   extractor; MDS027, `mdsmith list backlinks`, and `internal/index` consult
-  it. Per-file functions are pure and goroutine-safe; `NewWikilinkIndex` and
-  `ResolveWikiLink` walk the workspace (prefer `WikilinkIndexFor` per run).
+  it. Per-file extractors are pure and goroutine-safe; `NewWikilinkIndex` and
+  `ResolveWikiLink` walk the workspace; `WikilinkIndexFor` memoizes per run.
 - `internal/index` — the workspace symbol / edge graph (headings, link-ref
   defs, directives, front-matter keys, reverse edges); queried by the LSP,
   schema, and the rename / deps surfaces.

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -298,92 +298,16 @@ func sortByDepthThenName(paths []string) {
 
 // ResolveWikiLink resolves an Obsidian-style wikilink target against
 // root, returning the workspace-relative path of the resolved file.
+// Delegates to NewWikilinkIndex so the walk/match algorithm lives in
+// one place. For repeated resolutions against the same root, build
+// a WikilinkIndex once (via WikilinkIndexFor) and call Resolve
+// directly instead.
 //
-// Resolution rules:
-//
-//   - When target has no extension or ends in `.md`/`.markdown`, the
-//     search matches files whose stem (filename minus extension)
-//     equals target, case-insensitive. The target itself is also
-//     considered a stem when it lacks an extension.
-//   - When target has any other extension (an embed like `image.png`),
-//     the search matches files by exact filename, case-insensitive.
-//   - Ties are broken by the shortest path (fewest separators); then
-//     alphabetically. Two matches at the same depth never both win.
-//   - The walk is sandboxed to root: paths that would escape via `..`
-//     are rejected before the walk starts.
-//
-// from is the workspace-relative path of the source file. It is
-// reserved for future per-directory resolution preference; today it
-// only blocks empty targets the same way `ParseTarget` does for
-// regular links.
+// from is reserved for future per-directory resolution preference and
+// is currently unused.
 func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
-	if root == nil || target == "" {
-		return "", false
-	}
-	target = strings.TrimSpace(target)
-	if target == "" {
-		return "", false
-	}
-	// Reject Windows-style absolute forms (drive-letter, UNC) before
-	// path.Clean — those would otherwise pass the POSIX guards below
-	// and be searched as workspace-relative names on POSIX hosts.
-	if isDriveOrUNC(target) {
-		return "", false
-	}
-	// Normalize backslashes manually: filepath.ToSlash is OS-dependent
-	// (no-op on POSIX), so a Windows-authored `[[sub\page]]` would
-	// otherwise stay as a single literal segment on Linux CI and
-	// never resolve. Match the strings.ReplaceAll pattern
-	// ResolveRelTarget uses for the same reason.
-	target = strings.ReplaceAll(target, `\`, `/`)
-	cleaned := path.Clean(target)
-	if cleaned == "." || strings.HasPrefix(cleaned, "/") {
-		return "", false
-	}
-	// path.Clean reduces "../x" to "../x", "../../x" to "../../x", and
-	// "a/../b" to "b" — so the only escape forms left after Clean are a
-	// leading ".." segment or the bare "..". A name like "v1..v2" never
-	// produces either; this rejects only real parent-directory traversal.
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return "", false
-	}
-
-	wantName, wantStem, stemMode := wikilinkSearchKey(target)
 	_ = from
-
-	var matches []string
-	walkErr := fs.WalkDir(root, ".", func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			return skipHeavyDirs(p)
-		}
-		base := path.Base(p)
-		if stemMode {
-			stem := strings.TrimSuffix(base, path.Ext(base))
-			if strings.EqualFold(stem, wantStem) && mdpath.IsMarkdownPath(base) {
-				matches = append(matches, p)
-			}
-			return nil
-		}
-		if strings.EqualFold(base, wantName) {
-			matches = append(matches, p)
-		}
-		return nil
-	})
-	if walkErr != nil || len(matches) == 0 {
-		return "", false
-	}
-	sort.Slice(matches, func(i, j int) bool {
-		di := strings.Count(matches[i], "/")
-		dj := strings.Count(matches[j], "/")
-		if di != dj {
-			return di < dj
-		}
-		return matches[i] < matches[j]
-	})
-	return matches[0], true
+	return NewWikilinkIndex(root).Resolve(target)
 }
 
 // wikilinkSearchKey splits target into the lookup parameters

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -184,12 +184,11 @@ type WikilinkIndex struct {
 }
 
 // NewWikilinkIndex walks root once and returns a lookup table that
-// future ResolveWikiLink-style queries can serve from memory.
-// Returns nil when root is nil or the workspace walk itself fails
-// (e.g. Open(".") on root returns an error). A nil return lets the
-// caller fall back to per-call walks via ResolveWikiLink rather
-// than serving an empty index that would silently report every
-// target as "not found".
+// future Resolve calls can serve from memory. Returns nil when root
+// is nil or the workspace walk itself fails (e.g. Open(".") on root
+// returns an error). A nil return causes Resolve to return ("", false)
+// for every target; this is preferable to returning an empty index that
+// would silently report every target as not found.
 func NewWikilinkIndex(root fs.FS) *WikilinkIndex {
 	if root == nil {
 		return nil
@@ -303,25 +302,21 @@ func sortByDepthThenName(paths []string) {
 // a WikilinkIndex once (via WikilinkIndexFor) and call Resolve
 // directly instead.
 //
-// from is reserved for future per-directory resolution preference and
-// is currently unused.
-func ResolveWikiLink(root fs.FS, from, target string) (string, bool) {
-	_ = from
+// from is reserved for future per-directory resolution preference
+// and is currently unused.
+func ResolveWikiLink(root fs.FS, _ string, target string) (string, bool) {
 	return NewWikilinkIndex(root).Resolve(target)
 }
 
 // wikilinkSearchKey splits target into the lookup parameters
-// ResolveWikiLink walks the FS with.
+// WikilinkIndex.Resolve uses. target must already have backslashes
+// normalised to forward slashes (Resolve does this before calling).
 //
 // stemMode true means "match by filename stem against .md/.markdown
 // files only" — the bare-page case (`[[Notes]]` or
 // `[[Notes.md]]`). stemMode false means "match by exact filename"
 // — the typed-extension case (`![[diagram.png]]`).
 func wikilinkSearchKey(target string) (wantName, wantStem string, stemMode bool) {
-	// Match the host-independent normalisation ResolveWikiLink uses
-	// up front so a Windows-authored `[[sub\page]]` reaches this
-	// helper as `sub/page`.
-	target = strings.ReplaceAll(target, `\`, `/`)
 	base := path.Base(target)
 	ext := strings.ToLower(path.Ext(base))
 	switch ext {

--- a/internal/linkgraph/wikilinks_test.go
+++ b/internal/linkgraph/wikilinks_test.go
@@ -478,7 +478,6 @@ func TestWikilinkSearchKey(t *testing.T) {
 		{"md extension → stem mode", "Notes.md", "", "Notes", true},
 		{"markdown extension → stem mode", "Notes.markdown", "", "Notes", true},
 		{"PNG embed → exact name", "image.png", "image.png", "", false},
-		{"backslash normalised", `sub\page`, "", "page", true},
 		{"nested path → basename only", "deep/sub/page", "", "page", true},
 	}
 	for _, tc := range cases {

--- a/plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
+++ b/plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
@@ -3,7 +3,7 @@ id: 2607121915
 title: >-
   Resolve the internal/linkgraph purity-contract
   mismatch for wikilink resolution
-status: "🔳"
+status: "✅"
 model: sonnet
 summary: >-
   go.md documents internal/linkgraph as pure (no file
@@ -81,10 +81,10 @@ resolve both in the same pass.
 
 ## Acceptance Criteria
 
-- [ ] go.md's description of `internal/linkgraph` matches
+- [x] go.md's description of `internal/linkgraph` matches
       the package's actual behavior.
-- [ ] `NewWikilinkIndex` and `ResolveWikiLink` no longer
+- [x] `NewWikilinkIndex` and `ResolveWikiLink` no longer
       maintain two independent copies of the walk/match
       algorithm.
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.

--- a/plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
+++ b/plan/2607121915_arch-fix-linkgraph-wikilink-purity.md
@@ -3,7 +3,7 @@ id: 2607121915
 title: >-
   Resolve the internal/linkgraph purity-contract
   mismatch for wikilink resolution
-status: "🔲"
+status: "🔳"
 model: sonnet
 summary: >-
   go.md documents internal/linkgraph as pure (no file


### PR DESCRIPTION
## Summary

Resolves plan `2607121915`: `go.md` documented `internal/linkgraph` as "pure (no file reads, no workspace walks)" but `NewWikilinkIndex` and `ResolveWikiLink` both called `fs.WalkDir`, and they maintained two independent copies of the walk/match algorithm.

- **Deduplication**: `ResolveWikiLink` now delegates to `NewWikilinkIndex(root).Resolve(target)` — the walk/match algorithm lives in one place.
- **Doc accuracy**: `go.md`'s `internal/linkgraph` entry now correctly scopes the purity guarantee to per-file extraction functions and documents `NewWikilinkIndex`, `ResolveWikiLink`, and `WikilinkIndexFor` as workspace-walking (with `WikilinkIndexFor` memoizing per run via `lint.RunCache`).
- **Stale comments fixed**: `NewWikilinkIndex`'s comment no longer claims a `ResolveWikiLink` fallback (circular after the refactor); `wikilinkSearchKey`'s comment now references `WikilinkIndex.Resolve` and documents its pre-normalized-input contract.
- **Dead code removed**: `_ = from` in `ResolveWikiLink` (Go function parameters don't need silencing); redundant `strings.ReplaceAll` backslash normalization in `wikilinkSearchKey` (already done by `Resolve` before calling it).
- **Test updated**: `TestWikilinkSearchKey` drops the raw-backslash case (now belongs at the `Resolve` level, which already has it in `TestWikilinkIndex_ResolveSemantics`).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/linkgraph/... ./cmd/mdsmith/... ./internal/rules/crossfilereferenceintegrity/...` passes
- [ ] `go test ./...` passes
- [ ] `mdsmith check .` — 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_018boGj6rmVRTQPFqEYKK1rb)_