### PR TITLE
perf: fix top 5 high-performance-go.md violations (round 8)

### DIFF
--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -13,7 +13,18 @@ import (
 	"github.com/jeduden/mdsmith/pkg/markdown"
 )
 
-// File holds a parsed Markdown document and its source.
+// File holds a parsed Markdown document and its source. File is
+// allocated once per NewFile call — the single most common
+// allocation across the engine's per-file Check path — so its field
+// order follows docs/development/high-performance-go.md#struct-layout
+// large-to-small: every pointer/slice/map/interface field first,
+// then the block of 4-byte-aligned lazy-init guards (gitignoreOnce,
+// every *Done atomic.Bool, every *Mu sync.Mutex, and the two bools),
+// then the two remaining 8-byte scalars last. Each guard field still
+// documents which cache slice/map above it protects; only the
+// declaration site moved, to let same-size fields pack without the
+// per-pair padding that interleaving them costs. See
+// file_size_test.go for the pinned budget.
 type File struct {
 	Path        string
 	Source      []byte
@@ -23,26 +34,6 @@ type File struct {
 	RootFS      fs.FS
 	RootDir     string
 	FrontMatter []byte
-	LineOffset  int
-
-	// StripFrontMatter records whether this file was parsed in
-	// front-matter-stripping mode. Rules that read other files
-	// from the corpus should mirror the same mode so that line
-	// numbers in cross-file diagnostics are computed against the
-	// same coordinate system as the current file.
-	StripFrontMatter bool
-
-	// DryRun, when true, signals that the surrounding fix run must
-	// not touch the filesystem or the git index. Fixable rules whose
-	// Fix method has side effects beyond returning the new file
-	// bytes (e.g. writing a sibling repo file, staging via git)
-	// must check this flag and skip the side effect.
-	DryRun bool
-
-	// MaxInputBytes is the maximum file size in bytes that rules
-	// should enforce when reading secondary files (includes, schemas,
-	// cross-references). Zero or negative means unlimited.
-	MaxInputBytes int64
 
 	// GitignoreFunc is a lazy factory for the gitignore matcher.
 	// It is called at most once (on first access via GetGitignore)
@@ -50,7 +41,6 @@ type File struct {
 	// never trigger matcher construction. sync.Once keeps the lazy
 	// build race-free if a *File is shared across goroutines.
 	GitignoreFunc func() *gitignore.Matcher
-	gitignoreOnce sync.Once
 	gitignoreVal  *gitignore.Matcher
 
 	// GeneratedRanges records the content line ranges of generated
@@ -73,9 +63,9 @@ type File struct {
 	// runs at most once, concurrent callers serialise on the mutex,
 	// a panic inside build leaves `done` set so subsequent calls
 	// observe the (zero-valued) cached result rather than retrying.
-	newlineOffsets     []int
-	newlineOffsetsDone atomic.Bool
-	newlineOffsetsMu   sync.Mutex
+	// newlineOffsetsDone / newlineOffsetsMu live in the guard block
+	// below.
+	newlineOffsets []int
 
 	// codeBlockLines / piBlockLines cache the line-set walks behind
 	// CollectCodeBlockLines / CollectPIBlockLines. Both are pure
@@ -84,10 +74,9 @@ type File struct {
 	// walks per file over the 600-file check gate (plan 175
 	// profiling). The cached map is shared read-only with every
 	// caller; no caller mutates it. atomic.Bool + mutex matches
-	// newlineOffsets above for the same closure-box reason.
-	codeBlockLines     map[int]struct{}
-	codeBlockLinesDone atomic.Bool
-	codeBlockLinesMu   sync.Mutex
+	// newlineOffsets above for the same closure-box reason, in the
+	// guard block below.
+	codeBlockLines map[int]struct{}
 
 	// lineClass, when non-nil, is the flat Layer-0 line classifier built
 	// in place of the goldmark parse on the engine's parse-skip path
@@ -95,29 +84,25 @@ type File struct {
 	// FlatHeadingLines serve from it instead of walking f.AST, which is
 	// nil on that path. Set only by NewFileFlatPooled; nil on every
 	// normal (AST) parse, so the AST fallback is the default everywhere.
-	lineClass        *LineClassifier
-	piBlockLines     map[int]struct{}
-	piBlockLinesDone atomic.Bool
-	piBlockLinesMu   sync.Mutex
+	lineClass    *LineClassifier
+	piBlockLines map[int]struct{}
 
 	// layer0 caches the single-pass block scan (layer0.go) behind
 	// Layer0. It is the block-level projection source whenever f.AST is
 	// nil (the parse-skipped path) and the cheap re-backing for
-	// CollectCodeBlockLines / CollectPIBlockLines once computed. atomic.Bool
-	// + mutex matches the caches above for the same closure-box reason.
-	layer0     *Layer0Scan
-	layer0Done atomic.Bool
-	layer0Mu   sync.Mutex
+	// CollectCodeBlockLines / CollectPIBlockLines once computed.
+	// atomic.Bool + mutex matches the caches above for the same
+	// closure-box reason, in the guard block below.
+	layer0 *Layer0Scan
 
 	// inlineBlocks caches the run-grouped per-block inline parse
 	// (inline_blocks.go) behind InlineBlocks. It is the single shared
 	// inline-node stream every inline rule consumes on the parse-skipped
 	// path (f.AST nil), so each contiguous run of inline-bearing lines is
 	// parsed once per file rather than once per rule. atomic.Bool + mutex
-	// matches the caches above for the same closure-box reason.
-	inlineBlocks     []InlineBlock
-	inlineBlocksDone atomic.Bool
-	inlineBlocksMu   sync.Mutex
+	// matches the caches above for the same closure-box reason, in the
+	// guard block below.
+	inlineBlocks []InlineBlock
 
 	// emphasisParas caches the lone-emphasis-paragraph projection
 	// (inline_emphasis.go) behind WholeParagraphEmphasis, MDS018's
@@ -125,10 +110,8 @@ type File struct {
 	// single full-document parse on the loose-list fallback path; either
 	// way it runs once per file so a list-bearing file is not re-parsed on
 	// a second call. atomic.Bool + mutex matches the caches above for the
-	// same closure-box reason.
-	emphasisParas     []EmphasisParagraph
-	emphasisParasDone atomic.Bool
-	emphasisParasMu   sync.Mutex
+	// same closure-box reason, in the guard block below.
+	emphasisParas []EmphasisParagraph
 
 	// proseRanges caches the byte-offset projection behind ProseRanges:
 	// the source spans inside prose nodes (paragraph, heading, list-item
@@ -138,27 +121,24 @@ type File struct {
 	// (proper-name casing, forbidden text, …) through it instead of each
 	// rule re-walking the tree to rediscover the same code-skipping
 	// filter: one walk per file, amortized across all of them. atomic.Bool
-	// + mutex matches codeBlockLines above for the same closure-box reason
-	// (sync.Once would heap-allocate the build closure on the alloc gate).
-	proseRanges     []Range
-	proseRangesDone atomic.Bool
-	proseRangesMu   sync.Mutex
+	// + mutex matches codeBlockLines above for the same closure-box
+	// reason, in the guard block below (sync.Once would heap-allocate
+	// the build closure on the alloc gate).
+	proseRanges []Range
 
 	// codeSpanContent / codeSpanLiteral cache the projections behind
 	// CodeSpanContentRanges / CodeSpanLiteralRanges: each inline code
 	// span's text bounds and its backtick-extended literal range.
 	// Several rules each re-walked the AST for these; one walk now
-	// fills both. atomic.Bool + mutex matches the caches above.
+	// fills both. atomic.Bool + mutex matches the caches above, in the
+	// guard block below.
 	codeSpanContent []Range
 	codeSpanLiteral []Range
-	codeSpansDone   atomic.Bool
-	codeSpansMu     sync.Mutex
 
 	// lineStrings caches the zero-copy string views of Lines behind
-	// LineStrings. atomic.Bool + mutex matches the caches above.
-	lineStrings     []string
-	lineStringsDone atomic.Bool
-	lineStringsMu   sync.Mutex
+	// LineStrings. atomic.Bool + mutex matches the caches above, in
+	// the guard block below.
+	lineStrings []string
 
 	// parseCtx is the goldmark parser.Context produced by the one
 	// parse NewFile already runs. It is the source for LinkReferences
@@ -168,10 +148,8 @@ type File struct {
 	// 175 profiling). nil when the File was built as a struct literal
 	// rather than via NewFile; LinkReferences then parses once on
 	// demand. Released once linkRefs is materialized.
-	parseCtx     parser.Context
-	linkRefs     []Reference
-	linkRefsDone atomic.Bool
-	linkRefsMu   sync.Mutex
+	parseCtx parser.Context
+	linkRefs []Reference
 
 	// scratch backs Memo: per-Check rule memoization. A *File is
 	// built fresh for each Check and discarded after, so values
@@ -196,6 +174,56 @@ type File struct {
 	// facets of the parsed-file model, not standalone utilities, so
 	// they belong with File anyway. See plan/224.
 	RunCache *RunCache
+
+	// --- lazy-init guards -------------------------------------------
+	// Every *Done atomic.Bool / *Mu sync.Mutex pair below guards the
+	// same-named cache field above; see that field's comment for what
+	// it caches and why. Grouping every guard here (instead of beside
+	// its cache field) lets the two 4-byte-aligned kinds pack without
+	// the padding a pointer-sized field would force between them —
+	// see file_size_test.go.
+	gitignoreOnce      sync.Once
+	newlineOffsetsDone atomic.Bool
+	codeBlockLinesDone atomic.Bool
+	piBlockLinesDone   atomic.Bool
+	layer0Done         atomic.Bool
+	inlineBlocksDone   atomic.Bool
+	emphasisParasDone  atomic.Bool
+	proseRangesDone    atomic.Bool
+	codeSpansDone      atomic.Bool
+	lineStringsDone    atomic.Bool
+	linkRefsDone       atomic.Bool
+	newlineOffsetsMu   sync.Mutex
+	codeBlockLinesMu   sync.Mutex
+	piBlockLinesMu     sync.Mutex
+	layer0Mu           sync.Mutex
+	inlineBlocksMu     sync.Mutex
+	emphasisParasMu    sync.Mutex
+	proseRangesMu      sync.Mutex
+	codeSpansMu        sync.Mutex
+	lineStringsMu      sync.Mutex
+	linkRefsMu         sync.Mutex
+
+	// StripFrontMatter records whether this file was parsed in
+	// front-matter-stripping mode. Rules that read other files
+	// from the corpus should mirror the same mode so that line
+	// numbers in cross-file diagnostics are computed against the
+	// same coordinate system as the current file.
+	StripFrontMatter bool
+
+	// DryRun, when true, signals that the surrounding fix run must
+	// not touch the filesystem or the git index. Fixable rules whose
+	// Fix method has side effects beyond returning the new file
+	// bytes (e.g. writing a sibling repo file, staging via git)
+	// must check this flag and skip the side effect.
+	DryRun bool
+
+	LineOffset int
+
+	// MaxInputBytes is the maximum file size in bytes that rules
+	// should enforce when reading secondary files (includes, schemas,
+	// cross-references). Zero or negative means unlimited.
+	MaxInputBytes int64
 }
 
 // memoEntry guards a single Memo key so build runs exactly once even

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -149,15 +149,6 @@ type File struct {
 	// rather than via NewFile; LinkReferences then parses once on
 	// demand. Released once linkRefs is materialized.
 	parseCtx parser.Context
-	linkRefs []Reference
-
-	// scratch backs Memo: per-Check rule memoization. A *File is
-	// built fresh for each Check and discarded after, so values
-	// cached here never outlive a single Check — no cross-file or
-	// cross-run staleness, the same scope as the cross-file rule's
-	// per-Check cache. sync.Map keeps it safe for the concurrent
-	// readers the LSP may run against one document.
-	scratch sync.Map
 
 	// RunCache is the engine-owned read cache shared by every File
 	// processed in one engine.Run pass. Catalog and include rules
@@ -174,6 +165,23 @@ type File struct {
 	// facets of the parsed-file model, not standalone utilities, so
 	// they belong with File anyway. See plan/224.
 	RunCache *RunCache
+
+	// scratch backs Memo: per-Check rule memoization. A *File is
+	// built fresh for each Check and discarded after, so values
+	// cached here never outlive a single Check — no cross-file or
+	// cross-run staleness, the same scope as the cross-file rule's
+	// per-Check cache. sync.Map keeps it safe for the concurrent
+	// readers the LSP may run against one document.
+	scratch sync.Map
+
+	// linkRefs is declared last among the pointer-bearing fields on
+	// purpose: as a slice, only its 8-byte data-pointer word is
+	// GC-scanned when nothing after it holds a pointer, so its
+	// trailing len/cap words (16 bytes) fall outside ptrdata for
+	// free — unlike ending on a bare pointer field (e.g. RunCache),
+	// whose single word carries no such free tail. See parseCtx's
+	// comment above for what linkRefs caches.
+	linkRefs []Reference
 
 	// --- lazy-init guards -------------------------------------------
 	// Every *Done atomic.Bool / *Mu sync.Mutex pair below guards the

--- a/internal/lint/file_size_test.go
+++ b/internal/lint/file_size_test.go
@@ -1,0 +1,26 @@
+package lint
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// fileSizeBudget pins File's struct size. File is allocated exactly
+// once per NewFile call — the single most common allocation across
+// the engine's per-file Check path, so shaving its size compounds
+// across every file in the workspace. The four scalar fields
+// (LineOffset, MaxInputBytes, StripFrontMatter, DryRun) previously
+// sat at the top of the struct, interleaved with 8-byte-aligned
+// pointer/slice/string fields; large-to-small ordering — pointer and
+// slice fields first, the two 8-byte scalars next, the two
+// byte-sized bools last — packs the struct into 640 bytes instead of
+// 688 (docs/development/high-performance-go.md#struct-layout).
+const fileSizeBudget = 640
+
+func TestFile_SizeBudget(t *testing.T) {
+	got := unsafe.Sizeof(File{})
+	if got > fileSizeBudget {
+		t.Fatalf("unsafe.Sizeof(File{}) = %d, budget = %d (field order wastes padding)",
+			got, fileSizeBudget)
+	}
+}

--- a/internal/lint/file_size_test.go
+++ b/internal/lint/file_size_test.go
@@ -14,10 +14,11 @@ import (
 // across every file in the workspace. The four scalar fields
 // (LineOffset, MaxInputBytes, StripFrontMatter, DryRun) previously
 // sat at the top of the struct, interleaved with 8-byte-aligned
-// pointer/slice/string fields; large-to-small ordering — pointer and
-// slice fields first, the two 8-byte scalars next, the two
-// byte-sized bools last — packs the struct into 640 bytes instead of
-// 688 (docs/development/high-performance-go.md#struct-layout).
+// pointer/slice/string fields; grouping every pointer-bearing field
+// first, then the two byte-sized bools (packed alongside the other
+// 4-byte-aligned lazy-init guards), then the two 8-byte scalars last
+// — packs the struct into 640 bytes instead of 688
+// (docs/development/high-performance-go.md#struct-layout).
 const fileSizeBudget = 640
 
 func TestFile_SizeBudget(t *testing.T) {

--- a/internal/lint/file_size_test.go
+++ b/internal/lint/file_size_test.go
@@ -1,8 +1,11 @@
 package lint
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
 )
 
 // fileSizeBudget pins File's struct size. File is allocated exactly
@@ -23,4 +26,14 @@ func TestFile_SizeBudget(t *testing.T) {
 		t.Fatalf("unsafe.Sizeof(File{}) = %d, budget = %d (field order wastes padding)",
 			got, fileSizeBudget)
 	}
+}
+
+// TestFile_PointerFieldsPrecedeScalars guards the ordering half of
+// the same layout: every pointer/slice/map/interface field (and the
+// lazy-init guards, all pointer-free) must precede the four trailing
+// scalars. TestFile_SizeBudget alone would not catch a future edit
+// that keeps total size at 640 bytes while moving a pointer-bearing
+// field below a scalar guard field.
+func TestFile_PointerFieldsPrecedeScalars(t *testing.T) {
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(File{}))
 }

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -37,10 +37,18 @@ type SectionHeading struct {
 // ""). [CollectSectionParagraphsWithText] sets it so per-heading
 // SectionBody sweeps hit the cache for every paragraph,
 // regardless of whether the extracted text is empty.
+//
+// Node and Text are declared before Line/HasText: buildSectionParagraphs
+// allocates one SectionParagraph per document paragraph, so this is
+// among the highest-frequency struct constructions in the rule set
+// (MDS023, MDS024). Node (an interface) and Text (a string) are the
+// struct's only pointer-bearing fields; declaring the plain-int Line
+// field ahead of them would force the GC's per-word ptrdata scan to
+// cover Line's word too. See sectionparagraph_layout_test.go.
 type SectionParagraph struct {
-	Line    int
 	Node    ast.Node
 	Text    string
+	Line    int
 	HasText bool
 }
 

--- a/internal/rules/astutil/sectionparagraph_layout_test.go
+++ b/internal/rules/astutil/sectionparagraph_layout_test.go
@@ -1,0 +1,20 @@
+package astutil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
+)
+
+// TestSectionParagraph_PointerFieldsPrecedeScalars guards the GC
+// ptrdata region of SectionParagraph: Node and Text (its only
+// pointer-bearing fields) must precede the scalar Line/HasText
+// fields, per docs/development/high-performance-go.md#struct-layout.
+// buildSectionParagraphs allocates one SectionParagraph per document
+// paragraph, backing MDS023 (paragraph-readability) and MDS024
+// (paragraph-structure) — both default-enabled — so this is likely
+// the highest-frequency struct construction in the rule set.
+func TestSectionParagraph_PointerFieldsPrecedeScalars(t *testing.T) {
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(SectionParagraph{}))
+}

--- a/internal/rules/tablereadability/layout_test.go
+++ b/internal/rules/tablereadability/layout_test.go
@@ -1,0 +1,25 @@
+package tablereadability
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
+)
+
+// TestTable_PointerFieldsPrecedeScalars and
+// TestTableRow_PointerFieldsPrecedeScalars guard the GC ptrdata
+// region of table/tableRow, per
+// docs/development/high-performance-go.md#struct-layout. parseTables
+// allocates one table (and one tableRow per source row) for every
+// table MDS026 scans — the same per-row hot path the sibling
+// tablefmt package already reordered for this reason (commit
+// 9284744f, "GC scan reduction for ... table, row structs"); this
+// package's local copy was never updated to match.
+func TestTable_PointerFieldsPrecedeScalars(t *testing.T) {
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(table{}))
+}
+
+func TestTableRow_PointerFieldsPrecedeScalars(t *testing.T) {
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(tableRow{}))
+}

--- a/internal/rules/tablereadability/rule.go
+++ b/internal/rules/tablereadability/rule.go
@@ -198,9 +198,14 @@ func positiveFloatOrDefault(value, fallback float64) float64 {
 	return value
 }
 
+// table holds one parsed table. rows precedes startLine so the
+// GC's ptrdata scan does not also cover the scalar int — mirroring
+// tablefmt.table, which this local copy otherwise duplicates
+// (docs/development/high-performance-go.md#struct-layout; see
+// layout_test.go).
 type table struct {
-	startLine int
 	rows      []tableRow
+	startLine int
 }
 
 // tableRow holds one parsed source row. cells are sub-slices into
@@ -208,10 +213,12 @@ type table struct {
 // row pays one slice allocation rather than one per cell — the
 // dominant per-Check allocator on table-bearing files (plan 195
 // task 2). Consumers convert to string only when emitting a
-// diagnostic message, never on the hot count/width paths.
+// diagnostic message, never on the hot count/width paths. cells
+// precedes line/isSeparator so the GC's ptrdata scan does not also
+// cover those scalars — mirroring tablefmt.row (see layout_test.go).
 type tableRow struct {
-	line        int
 	cells       [][]byte
+	line        int
 	isSeparator bool
 }
 

--- a/internal/schema/index.go
+++ b/internal/schema/index.go
@@ -391,18 +391,6 @@ func hasDriveLetterPrefix(p string) bool {
 		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z'))
 }
 
-// indexMaxBytes returns the read cap ValidateIndex applies to the
-// on-disk index side-output, falling back to
-// bytelimit.DefaultMaxInputBytes when f carries no explicit limit —
-// mirroring FileReader.readPath in parse_file.go so every
-// cross-file read in this package respects the same contract.
-func indexMaxBytes(f *lint.File) int64 {
-	if f.MaxInputBytes > 0 {
-		return f.MaxInputBytes
-	}
-	return bytelimit.DefaultMaxInputBytes
-}
-
 // ValidateIndex compares the on-disk index file (if any) against
 // the bytes BuildIndex would emit. When the file is missing or its
 // content differs, a diagnostic asks the user to run `mdsmith fix`
@@ -434,7 +422,7 @@ func ValidateIndex(f *lint.File, sch *Schema, mkDiag MakeDiag) []lint.Diagnostic
 				"index side-output %q write failed on the last `mdsmith fix`: %v",
 				sch.Index.Output, writeErr))}
 	}
-	got, readErr := bytelimit.ReadFileLimited(target, indexMaxBytes(f))
+	got, readErr := bytelimit.ReadFileLimited(target, f.MaxInputBytes)
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
 			return []lint.Diagnostic{mkDiag(f.Path, 1,

--- a/internal/schema/index.go
+++ b/internal/schema/index.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/oscompat"
@@ -390,6 +391,18 @@ func hasDriveLetterPrefix(p string) bool {
 		((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z'))
 }
 
+// indexMaxBytes returns the read cap ValidateIndex applies to the
+// on-disk index side-output, falling back to
+// bytelimit.DefaultMaxInputBytes when f carries no explicit limit —
+// mirroring FileReader.readPath in parse_file.go so every
+// cross-file read in this package respects the same contract.
+func indexMaxBytes(f *lint.File) int64 {
+	if f.MaxInputBytes > 0 {
+		return f.MaxInputBytes
+	}
+	return bytelimit.DefaultMaxInputBytes
+}
+
 // ValidateIndex compares the on-disk index file (if any) against
 // the bytes BuildIndex would emit. When the file is missing or its
 // content differs, a diagnostic asks the user to run `mdsmith fix`
@@ -421,7 +434,7 @@ func ValidateIndex(f *lint.File, sch *Schema, mkDiag MakeDiag) []lint.Diagnostic
 				"index side-output %q write failed on the last `mdsmith fix`: %v",
 				sch.Index.Output, writeErr))}
 	}
-	got, readErr := os.ReadFile(target)
+	got, readErr := bytelimit.ReadFileLimited(target, indexMaxBytes(f))
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
 			return []lint.Diagnostic{mkDiag(f.Path, 1,

--- a/internal/schema/index_maxbytes_test.go
+++ b/internal/schema/index_maxbytes_test.go
@@ -40,3 +40,35 @@ func TestValidateIndex_RespectsMaxInputBytes(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "cannot be read")
 	assert.Contains(t, diags[0].Message, "too large")
 }
+
+// TestValidateIndex_ZeroMaxInputBytesIsUnlimited pins the "zero or
+// negative means unlimited" contract lint.File.MaxInputBytes
+// documents, and that every other f.MaxInputBytes consumer in the
+// codebase honors by passing it straight into bytelimit.Read*Limited
+// with no fallback. An on-disk index larger than
+// bytelimit.DefaultMaxInputBytes must still read successfully when
+// f.MaxInputBytes is left at its zero value: a caller (the LSP
+// server, a direct pkg/mdsmith.Session, --max-input-size 0) that
+// asked for no cap must not have one silently reimposed for this one
+// read path.
+func TestValidateIndex_ZeroMaxInputBytesIsUnlimited(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte("# T\n"), 0o644))
+	big := strings.Repeat("x", int(2*1024*1024)+100) // over the 2 MB default cap
+	require.NoError(t, os.WriteFile(filepath.Join(root, "out.json"), []byte(big), 0o644))
+
+	f, err := lint.NewFile(path, []byte("# T\n"))
+	require.NoError(t, err)
+	f.RootDir = root
+	require.Zero(t, f.MaxInputBytes)
+
+	sch := &Schema{Source: "test", RootLevel: 2, Index: &IndexSpec{
+		Output:  "out.json",
+		Include: []string{IndexIncludeHeadingsFlat},
+	}}
+	diags := ValidateIndex(f, sch, makeDiagForTest)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "out of date")
+	assert.NotContains(t, diags[0].Message, "too large")
+}

--- a/internal/schema/index_maxbytes_test.go
+++ b/internal/schema/index_maxbytes_test.go
@@ -1,0 +1,42 @@
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateIndex_RespectsMaxInputBytes pins ValidateIndex's read
+// of the on-disk index side-output to f.MaxInputBytes, mirroring
+// every other cross-file read in this package (readPath) and rule
+// package (include, catalog, cross-file-reference-integrity). A raw
+// os.ReadFile ignores the file-size contract those callers all
+// respect (docs/development/high-performance-go.md "os.ReadFile on
+// huge inputs"): an on-disk index larger than the configured cap
+// must surface as a "too large" read error, not be read in full.
+func TestValidateIndex_RespectsMaxInputBytes(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "doc.md")
+	require.NoError(t, os.WriteFile(path, []byte("# T\n"), 0o644))
+	big := strings.Repeat("x", 100)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "out.json"), []byte(big), 0o644))
+
+	f, err := lint.NewFile(path, []byte("# T\n"))
+	require.NoError(t, err)
+	f.RootDir = root
+	f.MaxInputBytes = 10
+
+	sch := &Schema{Source: "test", RootLevel: 2, Index: &IndexSpec{
+		Output:  "out.json",
+		Include: []string{IndexIncludeHeadingsFlat},
+	}}
+	diags := ValidateIndex(f, sch, makeDiagForTest)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "cannot be read")
+	assert.Contains(t, diags[0].Message, "too large")
+}

--- a/pkg/markdown/flavor/ext/abbreviation.go
+++ b/pkg/markdown/flavor/ext/abbreviation.go
@@ -174,6 +174,12 @@ func (t *abbreviationTransformer) Transform(doc *ast.Document, reader text.Reade
 	if len(table) == 0 {
 		return
 	}
+	// Precomputed once per Transform call (per document) rather than
+	// once per Text node: table is fixed for the whole walk below, so
+	// rebuilding the []byte term forms per node would repeat the same
+	// conversion once per paragraph/heading/list-item instead of once
+	// total (docs/development/high-performance-go.md "Stay in []byte").
+	terms := tableTerms(table)
 	source := reader.Source()
 
 	// Walk every Text descendant in the document and rewrite
@@ -190,7 +196,7 @@ func (t *abbreviationTransformer) Transform(doc *ast.Document, reader text.Reade
 			*AbbreviationDefinition:
 			return ast.WalkSkipChildren, nil
 		case *ast.Text:
-			rewriteText(node, table, source)
+			rewriteText(node, terms, source)
 			return ast.WalkSkipChildren, nil
 		}
 		return ast.WalkContinue, nil
@@ -208,13 +214,13 @@ type abbrMatch struct {
 // inserts AbbreviationReference nodes in their place. The original
 // Text node's segment is shrunk to the prefix before the first
 // match; subsequent content is appended as sibling nodes.
-func rewriteText(t *ast.Text, table abbrTable, source []byte) {
+func rewriteText(t *ast.Text, terms []tableTerm, source []byte) {
 	seg := t.Segment
 	body := seg.Value(source)
 	if len(body) == 0 {
 		return
 	}
-	matches := findMatches(body, table)
+	matches := findMatches(body, terms)
 	if len(matches) == 0 {
 		return
 	}
@@ -234,12 +240,14 @@ type tableTerm struct {
 }
 
 // tableTerms converts every key of table to its []byte form once.
-// findMatches calls bestMatchAt once per word-boundary candidate
-// position in a Text node's body, and bestMatchAt used to convert
-// every term from its map key to []byte on every such call — the
+// Transform calls this once per document (table is fixed for the
+// whole AST walk) and threads the result through rewriteText and
+// findMatches, which otherwise call bestMatchAt once per
+// word-boundary candidate position in every Text node's body —
+// without precomputing, that per-(position, term) probe converts
+// every term from its map key to []byte on every single call, the
 // dominant allocator on documents with defined abbreviations, since
-// positions vastly outnumber terms. Precomputing here, once per
-// findMatches call, keeps that per-(position, term) probe alloc-free
+// positions vastly outnumber terms
 // (docs/development/high-performance-go.md "Stay in []byte").
 func tableTerms(table abbrTable) []tableTerm {
 	terms := make([]tableTerm, 0, len(table))
@@ -252,11 +260,7 @@ func tableTerms(table abbrTable) []tableTerm {
 // findMatches scans body for the longest whole-word match of any
 // defined term at each word-boundary position and advances past each
 // hit so occurrences never overlap.
-func findMatches(body []byte, table abbrTable) []abbrMatch {
-	if len(table) == 0 {
-		return nil
-	}
-	terms := tableTerms(table)
+func findMatches(body []byte, terms []tableTerm) []abbrMatch {
 	var matches []abbrMatch
 	for i := 0; i < len(body); {
 		if i > 0 && isWordByte(body[i-1]) {

--- a/pkg/markdown/flavor/ext/abbreviation.go
+++ b/pkg/markdown/flavor/ext/abbreviation.go
@@ -225,17 +225,45 @@ func rewriteText(t *ast.Text, table abbrTable, source []byte) {
 	applyMatches(parent, t, seg, body, matches)
 }
 
+// tableTerm pairs a defined term's precomputed []byte form (used for
+// the prefix probe) with its original string form (stored on a match,
+// matching buildReference's []byte(m.term) conversion).
+type tableTerm struct {
+	bytes []byte
+	str   string
+}
+
+// tableTerms converts every key of table to its []byte form once.
+// findMatches calls bestMatchAt once per word-boundary candidate
+// position in a Text node's body, and bestMatchAt used to convert
+// every term from its map key to []byte on every such call — the
+// dominant allocator on documents with defined abbreviations, since
+// positions vastly outnumber terms. Precomputing here, once per
+// findMatches call, keeps that per-(position, term) probe alloc-free
+// (docs/development/high-performance-go.md "Stay in []byte").
+func tableTerms(table abbrTable) []tableTerm {
+	terms := make([]tableTerm, 0, len(table))
+	for term := range table {
+		terms = append(terms, tableTerm{bytes: []byte(term), str: term})
+	}
+	return terms
+}
+
 // findMatches scans body for the longest whole-word match of any
 // defined term at each word-boundary position and advances past each
 // hit so occurrences never overlap.
 func findMatches(body []byte, table abbrTable) []abbrMatch {
+	if len(table) == 0 {
+		return nil
+	}
+	terms := tableTerms(table)
 	var matches []abbrMatch
 	for i := 0; i < len(body); {
 		if i > 0 && isWordByte(body[i-1]) {
 			i++
 			continue
 		}
-		m, ok := bestMatchAt(body, i, table)
+		m, ok := bestMatchAt(body, i, terms)
 		if !ok {
 			i++
 			continue
@@ -246,21 +274,20 @@ func findMatches(body []byte, table abbrTable) []abbrMatch {
 	return matches
 }
 
-// bestMatchAt returns the longest term in table that matches body
+// bestMatchAt returns the longest term in terms that matches body
 // starting at i, requiring a word boundary after the term.
-func bestMatchAt(body []byte, i int, table abbrTable) (abbrMatch, bool) {
+func bestMatchAt(body []byte, i int, terms []tableTerm) (abbrMatch, bool) {
 	best := abbrMatch{start: -1}
-	for term := range table {
-		tb := []byte(term)
-		if !bytes.HasPrefix(body[i:], tb) {
+	for _, term := range terms {
+		if !bytes.HasPrefix(body[i:], term.bytes) {
 			continue
 		}
-		endIdx := i + len(tb)
+		endIdx := i + len(term.bytes)
 		if endIdx < len(body) && isWordByte(body[endIdx]) {
 			continue
 		}
-		if len(tb) > best.end-best.start {
-			best = abbrMatch{start: i, end: endIdx, term: term}
+		if len(term.bytes) > best.end-best.start {
+			best = abbrMatch{start: i, end: endIdx, term: term.str}
 		}
 	}
 	if best.start < 0 {

--- a/pkg/markdown/flavor/ext/abbreviation_alloc_test.go
+++ b/pkg/markdown/flavor/ext/abbreviation_alloc_test.go
@@ -25,3 +25,26 @@ func TestBestMatchAt_AllocBudget(t *testing.T) {
 		t.Fatalf("bestMatchAt allocs per call: want 0, got %v", allocs)
 	}
 }
+
+// TestFindMatches_AllocBudget pins findMatches's own per-call
+// allocation count given a precomputed terms slice. Transform builds
+// terms once per document via tableTerms and threads it through
+// rewriteText into findMatches, which is otherwise called once per
+// Text node in the document (one or more per paragraph/heading/
+// list-item) — tableTerms itself must not run again inside
+// findMatches, or the per-node cost this hoist is meant to eliminate
+// would reappear (docs/development/high-performance-go.md "Skip work
+// you don't need").
+func TestFindMatches_AllocBudget(t *testing.T) {
+	tbl := abbrTable{
+		"HTML": nil, "CSS": nil, "API": nil, "URL": nil, "SQL": nil,
+	}
+	terms := tableTerms(tbl)
+	body := []byte("some plain prose with no matching terms at all")
+	allocs := testing.AllocsPerRun(1000, func() {
+		_ = findMatches(body, terms)
+	})
+	if allocs > 0 {
+		t.Fatalf("findMatches allocs per call: want 0, got %v", allocs)
+	}
+}

--- a/pkg/markdown/flavor/ext/abbreviation_alloc_test.go
+++ b/pkg/markdown/flavor/ext/abbreviation_alloc_test.go
@@ -1,0 +1,27 @@
+package ext
+
+import "testing"
+
+// TestBestMatchAt_AllocBudget pins bestMatchAt's per-call allocation
+// count. findMatches calls bestMatchAt once per word-boundary
+// candidate position in a Text node's body — on a prose-heavy
+// document with several defined abbreviations that is the dominant
+// allocator in the whole-document parse (every parse installs the
+// Abbreviation extender by default). The previous implementation
+// converted every table term from its map key to []byte on every
+// (position, term) probe; bestMatchAt must not allocate at all once
+// the term byte forms are precomputed
+// (docs/development/high-performance-go.md "Stay in []byte").
+func TestBestMatchAt_AllocBudget(t *testing.T) {
+	tbl := abbrTable{
+		"HTML": nil, "CSS": nil, "API": nil, "URL": nil, "SQL": nil,
+	}
+	terms := tableTerms(tbl)
+	body := []byte("some plain prose with no matching terms at all")
+	allocs := testing.AllocsPerRun(1000, func() {
+		_, _ = bestMatchAt(body, 0, terms)
+	})
+	if allocs > 0 {
+		t.Fatalf("bestMatchAt allocs per call: want 0, got %v", allocs)
+	}
+}

--- a/pkg/markdown/flavor/ext/abbreviation_edge_test.go
+++ b/pkg/markdown/flavor/ext/abbreviation_edge_test.go
@@ -15,7 +15,7 @@ func TestRewriteTextEmptyBody(t *testing.T) {
 	tbl := abbrTable{"HTML": []byte("Hyper Text Markup Language")}
 	src := []byte("")
 	tn := ast.NewTextSegment(text.NewSegment(0, 0))
-	assert.NotPanics(t, func() { rewriteText(tn, tbl, src) })
+	assert.NotPanics(t, func() { rewriteText(tn, tableTerms(tbl), src) })
 }
 
 // TestRewriteTextOrphanParent covers the early-return when the Text
@@ -24,7 +24,7 @@ func TestRewriteTextOrphanParent(t *testing.T) {
 	src := []byte("HTML")
 	tbl := abbrTable{"HTML": []byte("Hyper Text Markup Language")}
 	tn := ast.NewTextSegment(text.NewSegment(0, len(src)))
-	assert.NotPanics(t, func() { rewriteText(tn, tbl, src) })
+	assert.NotPanics(t, func() { rewriteText(tn, tableTerms(tbl), src) })
 }
 
 // TestBestMatchAtWordBoundaryRejectsSuffix exercises the

--- a/pkg/markdown/flavor/ext/abbreviation_edge_test.go
+++ b/pkg/markdown/flavor/ext/abbreviation_edge_test.go
@@ -33,7 +33,7 @@ func TestRewriteTextOrphanParent(t *testing.T) {
 func TestBestMatchAtWordBoundaryRejectsSuffix(t *testing.T) {
 	tbl := abbrTable{"API": []byte("Application Programming Interface")}
 	body := []byte("APIserver does things")
-	_, ok := bestMatchAt(body, 0, tbl)
+	_, ok := bestMatchAt(body, 0, tableTerms(tbl))
 	assert.False(t, ok,
 		"API followed by word byte 's' must not match")
 }


### PR DESCRIPTION
## Summary

An audit against `docs/development/high-performance-go.md` (dispatched as four parallel research agents scanning for regexp/allocation, memoization/skip-work, struct-layout/data-structure, and concurrency/misc anti-patterns) surfaced several violations that survived seven earlier perf-cleanup rounds (#723, #725, #729, #731, #732, #735, #737). Prior rounds had already cleared `golangci-lint`'s `perfsprint`/`prealloc`/`gocritic`(performance) checks to 0 issues repo-wide, so this round's findings are all outside what those linters catch. This PR fixes the top 5, ranked by hotness and impact, each with red/green TDD — then went through three rounds of xhigh-severity code review, each of which found and fixed real issues before the next round.

1. **`internal/lint.File` struct size (688 → 640 bytes), plus a residual ptrdata refinement** — `File` is allocated once per `NewFile` call, the single most common allocation across the engine's per-file `Check` path. Its 24 lazy-init guard fields (10 `atomic.Bool` + 10 `sync.Mutex` + one `sync.Once`) were each declared beside the cache field they protect, interleaving 4-byte-aligned scalars between 8-byte-aligned pointer/slice/map fields and forcing a padding gap after nearly every guard pair. Grouped every guard into one block after all pointer-bearing fields — each guard's comment still names the cache field it protects, only the declaration site moved. Guarded by both a pinned `unsafe.Sizeof` budget and a `structlayout.AssertPointerFieldsFirst` ordering assertion (round-2 review added the latter; the size test alone couldn't catch a future field-order regression). A further round-2 finding shaved a residual 16 bytes of GC ptrdata: ending the pointer-bearing field block on a slice (`linkRefs`) instead of a bare pointer (`RunCache`) lets the slice's free len/cap tail fall outside the GC scan region.

2. **`internal/rules/astutil.SectionParagraph` ptrdata (32 → 24 bytes)** — `CollectSectionParagraphs` allocates one `SectionParagraph` per document paragraph, backing MDS023 (paragraph-readability) and MDS024 (paragraph-structure), both default-enabled — likely the highest-frequency struct construction in the rule set. `Line` (a plain int) was declared before `Node`/`Text`, its only pointer-bearing fields, so the GC's per-word ptrdata scan covered `Line`'s word too. Moved `Node`/`Text` first.

3. **`internal/rules/tablereadability` `table`/`tableRow` ptrdata (16 → 8 bytes each)** — the sibling `tablefmt` package already reordered its near-identical `table`/`row` structs for this exact reason (commit `9284744f`), but `tablereadability`'s local copy — kept separate for its zero-alloc `[][]byte` cell representation — was never updated to match. `parseTables` allocates one of each per table/row MDS026 scans.

4. **`internal/schema.ValidateIndex` read path** — read the on-disk `<?catalog?>`/index side-output via a raw `os.ReadFile`, the only cross-file read in the package that bypassed the `bytelimit` convention every sibling call site follows. Routed through `bytelimit.ReadFileLimited`, passing `f.MaxInputBytes` straight through — matching that field's documented "zero or negative means unlimited" contract and every other consumer of it. (Round-1 review caught an intermediate version of this fix that substituted a 2 MB default whenever `MaxInputBytes` was `<= 0`, silently breaking that contract for any caller — LSP server, direct `pkg/mdsmith.Session`, `--max-input-size 0` — that asked for no cap; fixed before it shipped.)

5. **`pkg/markdown/flavor/ext` abbreviation matching** — `findMatches` probes every word-boundary candidate position in a Text node's body against every defined abbreviation term, and `bestMatchAt` converted each term from its map key to `[]byte` on *every single* (position, term) probe — the dominant allocator on any document with a defined abbreviation. Precomputed each term's `[]byte` form once per document: `tableTerms(table)` is called once in `Transform`, and the resulting slice threads through `rewriteText`/`findMatches`/`bestMatchAt` for every Text node in that parse. (Round-1 review caught an intermediate version that recomputed this once per `findMatches` call — i.e. once per Text node rather than once per document — before it shipped; round-2 review added a dedicated `TestFindMatches_AllocBudget` to guard the corrected scope going forward.)

Each fix is its own commit with a full red/green TDD trail (failing test first, then the fix) and cites the specific guideline section it addresses.

## Code review

Three rounds of xhigh-severity review (8 independent finder angles per round), each addressed before the next:

- **Round 1** found and fixed: the `MaxInputBytes`/`ValidateIndex` contract bug described above; an unreachable defensive branch in `findMatches` added without a driving test (also the direct cause of a codecov/patch failure); the `tableTerms` per-Text-node-instead-of-per-document scoping gap; and a missing `structlayout.AssertPointerFieldsFirst` test for `File` (added alongside the existing size budget).
- **Round 2** re-verified every round-1 fix from scratch and found: a backwards doc comment in `file_size_test.go` (fixed), a residual 16-byte GC-ptrdata optimization in `File` (fixed, described above), and evaluated two "could go further" suggestions it explicitly framed as optional follow-up rather than blocking — a package-wide inconsistency between two *different*, differently-documented fields' zero-value policies (`FileReader.MaxBytes` vs `lint.File.MaxInputBytes`), and storing abbreviation `[]byte` term forms at definition time instead of `Transform` time — both deferred as out of this round's scope. It also flagged a test fixture that was intentionally kept oversized after evaluation: shrinking it would have let it pass under both the correct and the previously-buggy behavior, defeating its purpose as a regression guard.
- **Round 3** re-verified the full build/vet/test/lint/`mdsmith check`/`fieldalignment` matrix from scratch across all 10 commits and found no further correctness issues; it did flag that this PR description itself had drifted out of sync with the final code after two rounds of fix-up commits, which is what this text now corrects.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run ./...` (0 issues)
- [x] `go run ./cmd/mdsmith check .` (549 files, 0 failures)
- [x] `internal/integration` per-rule alloc-budget gate still green for every rule
- [x] `fieldalignment` re-run after the final commit: no remaining findings for `File`, `SectionParagraph`, `table`, or `tableRow`
- [x] Codecov patch coverage: 100% of modified/coverable lines
- [x] Each fix's red test confirmed failing before the corresponding implementation change, and passing after
- [x] Three rounds of xhigh code review, all findings addressed or explicitly deferred with rationale

---
_Generated by [Claude Code](https://claude.ai/code/session_016cg8TcTdbY2cVaHaMUKyjX)_