### PR TITLE
feat(placeholders): add apm-input-token for APM ${input:NAME} prompt parameters

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -245,7 +245,7 @@ footer: |
 | 2607051919 | ✅     | sonnet | [Add dedicated unit tests for helpers added by the word-list and reflow features](plan/2607051919_arch-fix-new-helper-tests.md)                         |
 | 2607051920 | ✅     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
 | 2607071642 | 🔲     | sonnet | [Single-file metric extraction via `mdsmith metrics get` (readability first)](plan/2607071642_extractable-file-metrics.md)                              |
-| 2607082048 | 🔲     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |
+| 2607082048 | ✅     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |
 | 2607082049 | 🔲     | opus   | [Foreign managed-region protection for `mdsmith fix`](plan/2607082049_foreign-managed-regions.md)                                                       |
 | 2607082050 | 🔲     | sonnet | [APM coexistence: `mdsmith init --apm`, guide, and kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                       |
 | 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |

--- a/docs/background/concepts/placeholder-grammar.md
+++ b/docs/background/concepts/placeholder-grammar.md
@@ -74,10 +74,10 @@ from `internal/placeholders`:
 
 | Rule ID | Rule name                        | Useful tokens                                                             |
 | ------- | -------------------------------- | ------------------------------------------------------------------------- |
-| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token`                    |
+| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token`, `apm-input-token` |
 | MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section`, `apm-input-token` |
 | MDS018  | `no-emphasis-as-heading`         | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
 | MDS020  | `required-structure`             | `cue-frontmatter`                                                         |
 | MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
 | MDS024  | `paragraph-structure`            | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
-| MDS027  | `cross-file-reference-integrity` | `var-token`, `heading-question`, `placeholder-section`                    |
+| MDS027  | `cross-file-reference-integrity` | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |

--- a/docs/background/concepts/placeholder-grammar.md
+++ b/docs/background/concepts/placeholder-grammar.md
@@ -75,7 +75,7 @@ from `internal/placeholders`:
 | Rule ID | Rule name                        | Useful tokens                                                             |
 | ------- | -------------------------------- | ------------------------------------------------------------------------- |
 | MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token`                    |
-| MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section`                    |
+| MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section`, `apm-input-token` |
 | MDS018  | `no-emphasis-as-heading`         | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
 | MDS020  | `required-structure`             | `cue-frontmatter`                                                         |
 | MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |

--- a/docs/background/concepts/placeholder-grammar.md
+++ b/docs/background/concepts/placeholder-grammar.md
@@ -14,12 +14,13 @@ trigger false positives.
 
 ## Token vocabulary
 
-| Token name            | Matches                                                          |
-| --------------------- | ---------------------------------------------------------------- |
-| `var-token`           | `{identifier}` interpolation placeholders (`{title}`, `{a.b.c}`) |
-| `heading-question`    | A heading whose text is exactly `?`                              |
-| `placeholder-section` | A heading whose text is exactly `...`                            |
-| `cue-frontmatter`     | CUE constraint expressions in front-matter values                |
+| Token name            | Matches                                                                                    |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| `var-token`           | `{identifier}` interpolation placeholders (`{title}`, `{a.b.c}`)                           |
+| `heading-question`    | A heading whose text is exactly `?`                                                        |
+| `placeholder-section` | A heading whose text is exactly `...`                                                      |
+| `cue-frontmatter`     | CUE constraint expressions in front-matter values                                          |
+| `apm-input-token`     | APM prompt parameters of the form `${input:NAME}` where NAME matches `[A-Za-z][\w-]{0,63}` |
 
 The vocabulary is closed: the token list lives in one place inside
 the engine, and no rule hardcodes token names in its own logic.
@@ -71,12 +72,12 @@ from `internal/placeholders`:
 
 ## Opt-in rules
 
-| Rule ID | Rule name                        | Useful tokens                                          |
-| ------- | -------------------------------- | ------------------------------------------------------ |
-| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token` |
-| MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section` |
-| MDS018  | `no-emphasis-as-heading`         | `var-token`, `heading-question`, `placeholder-section` |
-| MDS020  | `required-structure`             | `cue-frontmatter`                                      |
-| MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section` |
-| MDS024  | `paragraph-structure`            | `var-token`, `heading-question`, `placeholder-section` |
-| MDS027  | `cross-file-reference-integrity` | `var-token`, `heading-question`, `placeholder-section` |
+| Rule ID | Rule name                        | Useful tokens                                                             |
+| ------- | -------------------------------- | ------------------------------------------------------------------------- |
+| MDS003  | `heading-increment`              | `heading-question`, `placeholder-section`, `var-token`                    |
+| MDS004  | `first-line-heading`             | `heading-question`, `var-token`, `placeholder-section`                    |
+| MDS018  | `no-emphasis-as-heading`         | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
+| MDS020  | `required-structure`             | `cue-frontmatter`                                                         |
+| MDS023  | `paragraph-readability`          | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
+| MDS024  | `paragraph-structure`            | `var-token`, `heading-question`, `placeholder-section`, `apm-input-token` |
+| MDS027  | `cross-file-reference-integrity` | `var-token`, `heading-question`, `placeholder-section`                    |

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -110,7 +110,7 @@ func MaskBodyTokens(text string, tokens []string) string {
 				return neutralText[PlaceholderSection]
 			}
 		case APMInputToken:
-			if strings.Contains(text, apmInputPrefix) && apmInputRe.MatchString(text) {
+			if strings.Contains(text, apmInputPrefix) {
 				text = apmInputRe.ReplaceAllLiteralString(text, neutralText[APMInputToken])
 			}
 		}
@@ -147,7 +147,7 @@ func stripBodyTokens(text string, tokens []string) string {
 				return ""
 			}
 		case APMInputToken:
-			if strings.Contains(text, apmInputPrefix) && apmInputRe.MatchString(text) {
+			if strings.Contains(text, apmInputPrefix) {
 				text = apmInputRe.ReplaceAllLiteralString(text, "")
 			}
 		}

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -6,20 +6,26 @@
 // Configurable interface. When checking a node it calls ContainsBodyToken
 // or MaskBodyTokens to decide whether to skip or neutralize the content.
 //
-// The four initial tokens are:
+// The five tokens are:
 //
-//   - var-token       — {identifier} interpolation placeholders
-//   - heading-question — headings whose text is exactly "?"
+//   - var-token           — {identifier} interpolation placeholders
+//   - heading-question    — headings whose text is exactly "?"
 //   - placeholder-section — headings whose text is exactly "..."
-//   - cue-frontmatter  — CUE constraint expressions in front-matter values
+//   - cue-frontmatter     — CUE constraint expressions in front-matter values
+//   - apm-input-token     — APM ${input:NAME} prompt parameters
 package placeholders
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
 )
+
+// apmInputRe matches APM ${input:NAME} prompt parameters.
+// NAME must start with a letter and contain only letters, digits, underscores, and hyphens.
+var apmInputRe = regexp.MustCompile(`\$\{input:[A-Za-z][\w-]{0,63}\}`)
 
 // Named placeholder tokens.
 const (
@@ -27,6 +33,7 @@ const (
 	HeadingQuestion    = "heading-question"
 	PlaceholderSection = "placeholder-section"
 	CUEFrontmatter     = "cue-frontmatter"
+	APMInputToken      = "apm-input-token"
 )
 
 // neutralText is the neutral replacement per body token.
@@ -34,12 +41,13 @@ var neutralText = map[string]string{
 	VarToken:           "word",
 	HeadingQuestion:    "Placeholder",
 	PlaceholderSection: "Placeholder Section",
+	APMInputToken:      "word",
 }
 
 // IsKnown reports whether name is a recognized token name.
 func IsKnown(name string) bool {
 	switch name {
-	case VarToken, HeadingQuestion, PlaceholderSection, CUEFrontmatter:
+	case VarToken, HeadingQuestion, PlaceholderSection, CUEFrontmatter, APMInputToken:
 		return true
 	}
 	return false
@@ -72,6 +80,10 @@ func ContainsBodyToken(text string, tokens []string) bool {
 			if strings.TrimSpace(text) == "..." {
 				return true
 			}
+		case APMInputToken:
+			if apmInputRe.MatchString(text) {
+				return true
+			}
 		}
 	}
 	return false
@@ -80,8 +92,8 @@ func ContainsBodyToken(text string, tokens []string) bool {
 // MaskBodyTokens replaces placeholder token patterns in text with neutral
 // content. cue-frontmatter is not a body token and is left unchanged.
 // Whole-text tokens (heading-question, placeholder-section) replace the
-// entire text when they match; substring tokens (var-token) replace each
-// occurrence in place.
+// entire text when they match; substring tokens (var-token, apm-input-token)
+// replace each occurrence in place.
 func MaskBodyTokens(text string, tokens []string) string {
 	for _, tok := range tokens {
 		switch tok {
@@ -96,6 +108,8 @@ func MaskBodyTokens(text string, tokens []string) string {
 			if strings.TrimSpace(text) == "..." {
 				return neutralText[PlaceholderSection]
 			}
+		case APMInputToken:
+			text = apmInputRe.ReplaceAllLiteralString(text, neutralText[APMInputToken])
 		}
 	}
 	return text
@@ -129,6 +143,8 @@ func stripBodyTokens(text string, tokens []string) string {
 			if strings.TrimSpace(text) == "..." {
 				return ""
 			}
+		case APMInputToken:
+			text = apmInputRe.ReplaceAllLiteralString(text, "")
 		}
 	}
 	return text

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -81,7 +81,7 @@ func ContainsBodyToken(text string, tokens []string) bool {
 				return true
 			}
 		case APMInputToken:
-			if apmInputRe.MatchString(text) {
+			if strings.Contains(text, "${input:") && apmInputRe.MatchString(text) {
 				return true
 			}
 		}
@@ -109,7 +109,9 @@ func MaskBodyTokens(text string, tokens []string) string {
 				return neutralText[PlaceholderSection]
 			}
 		case APMInputToken:
-			text = apmInputRe.ReplaceAllLiteralString(text, neutralText[APMInputToken])
+			if strings.Contains(text, "${input:") {
+				text = apmInputRe.ReplaceAllLiteralString(text, neutralText[APMInputToken])
+			}
 		}
 	}
 	return text
@@ -144,7 +146,9 @@ func stripBodyTokens(text string, tokens []string) string {
 				return ""
 			}
 		case APMInputToken:
-			text = apmInputRe.ReplaceAllLiteralString(text, "")
+			if strings.Contains(text, "${input:") {
+				text = apmInputRe.ReplaceAllLiteralString(text, "")
+			}
 		}
 	}
 	return text

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -23,8 +23,9 @@ import (
 	"github.com/jeduden/mdsmith/internal/fieldinterp"
 )
 
-// apmInputRe matches APM ${input:NAME} prompt parameters.
-// NAME must start with a letter and contain only letters, digits, underscores, and hyphens.
+// apmInputPrefix is the byte sequence that uniquely opens an APM input parameter.
+const apmInputPrefix = "${input:"
+
 var apmInputRe = regexp.MustCompile(`\$\{input:[A-Za-z][\w-]{0,63}\}`)
 
 // Named placeholder tokens.
@@ -81,7 +82,7 @@ func ContainsBodyToken(text string, tokens []string) bool {
 				return true
 			}
 		case APMInputToken:
-			if strings.Contains(text, "${input:") && apmInputRe.MatchString(text) {
+			if strings.Contains(text, apmInputPrefix) && apmInputRe.MatchString(text) {
 				return true
 			}
 		}
@@ -109,7 +110,7 @@ func MaskBodyTokens(text string, tokens []string) string {
 				return neutralText[PlaceholderSection]
 			}
 		case APMInputToken:
-			if strings.Contains(text, "${input:") {
+			if strings.Contains(text, apmInputPrefix) && apmInputRe.MatchString(text) {
 				text = apmInputRe.ReplaceAllLiteralString(text, neutralText[APMInputToken])
 			}
 		}
@@ -146,7 +147,7 @@ func stripBodyTokens(text string, tokens []string) string {
 				return ""
 			}
 		case APMInputToken:
-			if strings.Contains(text, "${input:") {
+			if strings.Contains(text, apmInputPrefix) && apmInputRe.MatchString(text) {
 				text = apmInputRe.ReplaceAllLiteralString(text, "")
 			}
 		}

--- a/internal/placeholders/placeholders_test.go
+++ b/internal/placeholders/placeholders_test.go
@@ -292,3 +292,60 @@ func TestHasCUEFrontmatter(t *testing.T) {
 	assert.False(t, placeholders.HasCUEFrontmatter(nil))
 	assert.False(t, placeholders.HasCUEFrontmatter([]string{}))
 }
+
+func TestAPMInputToken_IsKnown(t *testing.T) {
+	assert.True(t, placeholders.IsKnown(placeholders.APMInputToken))
+}
+
+func TestAPMInputToken_ContainsBodyToken(t *testing.T) {
+	tok := []string{placeholders.APMInputToken}
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"simple input param", "${input:pr_url}", true},
+		{"hyphenated name", "${input:focus-area}", true},
+		{"mixed case start", "${input:FocusArea}", true},
+		{"embedded in sentence", "review ${input:pr_url} now", true},
+		{"multiple tokens", "${input:a} and ${input:b}", true},
+		{"non-matching form output", "${output:x}", false},
+		{"no dollar", "{input:x}", false},
+		{"space in name", "${input:bad name}", false},
+		{"not input prefix", "${notinput:x}", false},
+		{"empty text", "", false},
+		{"plain text", "some prose", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, placeholders.ContainsBodyToken(tt.text, tok))
+		})
+	}
+}
+
+func TestAPMInputToken_MaskBodyTokens(t *testing.T) {
+	tok := []string{placeholders.APMInputToken}
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"single token replaced", "${input:pr_url}", "word"},
+		{"token in sentence", "review ${input:pr_url} now", "review word now"},
+		{"two tokens replaced", "${input:a} and ${input:b}", "word and word"},
+		{"non-matching unchanged", "${output:x}", "${output:x}"},
+		{"plain text unchanged", "some prose", "some prose"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, placeholders.MaskBodyTokens(tt.text, tok))
+		})
+	}
+}
+
+func TestAPMInputToken_IsAllBodyTokens(t *testing.T) {
+	tok := []string{placeholders.APMInputToken}
+	assert.True(t, placeholders.IsAllBodyTokens("${input:pr_url}", tok))
+	assert.True(t, placeholders.IsAllBodyTokens("${input:a} ${input:b}", tok))
+	assert.False(t, placeholders.IsAllBodyTokens("${input:a} extra", tok))
+}

--- a/internal/placeholders/placeholders_test.go
+++ b/internal/placeholders/placeholders_test.go
@@ -335,6 +335,7 @@ func TestAPMInputToken_MaskBodyTokens(t *testing.T) {
 		{"single token replaced", "${input:pr_url}", "word"},
 		{"token in sentence", "review ${input:pr_url} now", "review word now"},
 		{"two tokens replaced", "${input:a} and ${input:b}", "word and word"},
+		{"malformed prefix unchanged", "${input:}", "${input:}"},
 		{"non-matching unchanged", "${output:x}", "${output:x}"},
 		{"plain text unchanged", "some prose", "some prose"},
 	}

--- a/internal/placeholders/placeholders_test.go
+++ b/internal/placeholders/placeholders_test.go
@@ -12,6 +12,7 @@ func TestIsKnown(t *testing.T) {
 	assert.True(t, placeholders.IsKnown(placeholders.HeadingQuestion))
 	assert.True(t, placeholders.IsKnown(placeholders.PlaceholderSection))
 	assert.True(t, placeholders.IsKnown(placeholders.CUEFrontmatter))
+	assert.True(t, placeholders.IsKnown(placeholders.APMInputToken))
 	assert.False(t, placeholders.IsKnown("unknown-token"))
 	assert.False(t, placeholders.IsKnown(""))
 }
@@ -25,6 +26,7 @@ func TestValidate(t *testing.T) {
 		placeholders.HeadingQuestion,
 		placeholders.PlaceholderSection,
 		placeholders.CUEFrontmatter,
+		placeholders.APMInputToken,
 	}))
 	err := placeholders.Validate([]string{"bad-token"})
 	assert.ErrorContains(t, err, `unknown placeholder token "bad-token"`)

--- a/internal/rules/MDS003-heading-increment/README.md
+++ b/internal/rules/MDS003-heading-increment/README.md
@@ -47,7 +47,7 @@ Heading levels should increment by one. No jumping from `#` to `###`.
 | -------------- | ---- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Useful tokens: `heading-question`, `placeholder-section`, `var-token`.
+Useful tokens: `heading-question`, `placeholder-section`, `var-token`, `apm-input-token`.
 
 ## Config
 

--- a/internal/rules/MDS004-first-line-heading/README.md
+++ b/internal/rules/MDS004-first-line-heading/README.md
@@ -36,7 +36,7 @@ First line of the file should be a heading.
 | `level`        | int  | 1       | Required heading level for the first line                                                                                  |
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Useful tokens: `heading-question`, `var-token`, `placeholder-section`.
+Useful tokens: `heading-question`, `var-token`, `placeholder-section`, `apm-input-token`.
 
 ## Config
 

--- a/internal/rules/MDS018-no-emphasis-as-heading/README.md
+++ b/internal/rules/MDS018-no-emphasis-as-heading/README.md
@@ -39,7 +39,7 @@ Don't use bold or emphasis on a standalone line as a heading substitute.
 | -------------- | ---- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `placeholders` | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`, `apm-input-token`.
 
 ## Config
 

--- a/internal/rules/MDS023-paragraph-readability/README.md
+++ b/internal/rules/MDS023-paragraph-readability/README.md
@@ -25,7 +25,7 @@ Paragraph readability index must not exceed a threshold.
 | `min-words`    | int   | 20      | Minimum word count to check a paragraph                                                                                    |
 | `placeholders` | list  | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`, `apm-input-token`.
 
 Paragraphs with fewer words than `min-words` are skipped.
 Markdown tables and code blocks are skipped.

--- a/internal/rules/MDS024-paragraph-structure/README.md
+++ b/internal/rules/MDS024-paragraph-structure/README.md
@@ -25,7 +25,7 @@ Paragraphs must not exceed sentence and word limits.
 | `max-words-per-sentence` | int  | 40      | Maximum words per sentence                                                                                                 |
 | `placeholders`           | list | `[]`    | Placeholder tokens to treat as opaque; see [placeholder grammar](../../../docs/background/concepts/placeholder-grammar.md) |
 
-Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`, `apm-input-token`.
 
 Markdown tables and code blocks are skipped.
 

--- a/internal/rules/MDS027-cross-file-reference-integrity/README.md
+++ b/internal/rules/MDS027-cross-file-reference-integrity/README.md
@@ -44,7 +44,7 @@ Links to local files and heading anchors must resolve.
 | `wikilinks`      | bool   | `false`      | Validate Obsidian-style `[[Page]]`, `[[Page#anchor]]`, `[[Page\|alias]]`, and `![[file.png]]` targets against the workspace. |
 | `wikilink-style` | string | `"obsidian"` | Resolution style for wikilinks. Only `obsidian` ships today; other values are rejected at config load.                       |
 
-Useful tokens: `var-token`, `heading-question`, `placeholder-section`.
+Useful tokens: `var-token`, `heading-question`, `placeholder-section`, `apm-input-token`.
 
 With `strict: false`, only Markdown targets (`.md`, `.markdown`)
 are checked (except images — see `links.validate-images`).

--- a/plan/2607082048_apm-input-placeholder-token.md
+++ b/plan/2607082048_apm-input-placeholder-token.md
@@ -1,7 +1,7 @@
 ---
 id: 2607082048
 title: "Placeholder token for APM `${input:name}` prompt parameters"
-status: "🔲"
+status: "✅"
 model: sonnet
 summary: >-
   Add one token to the closed placeholder vocabulary that matches
@@ -77,17 +77,17 @@ in the
 
 ## Acceptance Criteria
 
-- [ ] A paragraph whose only non-prose content is
+- [x] A paragraph whose only non-prose content is
       `${input:pr_url}` produces no MDS023 or MDS024
       diagnostic when the token is configured.
-- [ ] The token name appears in the placeholder
+- [x] The token name appears in the placeholder
       vocabulary table and the opt-in rule list.
-- [ ] The matcher rejects `${notinput:x}` and
+- [x] The matcher rejects `${notinput:x}` and
       `${input:bad name}` (space is outside the
       grammar).
-- [ ] `Check` stays within the allocation budget
+- [x] `Check` stays within the allocation budget
       (regexp compiled at package scope).
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool -modfile=tools/go.mod golangci-lint
+- [x] All tests pass: `go test ./...`
+- [x] `go tool -modfile=tools/go.mod golangci-lint
       run` reports no issues.
-- [ ] `mdsmith check .` — 0 failures.
+- [x] `mdsmith check .` — 0 failures.


### PR DESCRIPTION
## Summary

- Adds `apm-input-token` to the closed placeholder vocabulary so rules can treat APM `${input:NAME}` prompt parameters as opaque template content rather than prose.
- The token matches APM's documented input-name grammar `[A-Za-z][\w-]{0,63}`, compiled at package scope to stay within the allocation budget.
- Wired into `ContainsBodyToken` (skip check), `MaskBodyTokens` (replace with neutral `"word"`), and `stripBodyTokens` (strip for `IsAllBodyTokens`).
- Documents the token in the vocabulary table and opt-in rules table in `docs/background/concepts/placeholder-grammar.md`.
- Closes plan `2607082048_apm-input-placeholder-token.md`.

## Changes

**`internal/placeholders/placeholders.go`**
- New `APMInputToken = "apm-input-token"` constant.
- Package-scope `apmInputRe` regexp for `${input:NAME}`.
- Added to `neutralText` map (`"word"`), `IsKnown` switch, `ContainsBodyToken`, `MaskBodyTokens`, and `stripBodyTokens`.

**`internal/placeholders/placeholders_test.go`**
- `TestAPMInputToken_IsKnown` — verifies `IsKnown` recognizes the new constant.
- `TestAPMInputToken_ContainsBodyToken` — 11 cases: matching forms (`${input:pr_url}`, `${input:focus-area}`, mixed-case, embedded, multiple), and rejections (`${output:x}`, bare `{input:x}`, space in name, wrong prefix, empty, plain prose).
- `TestAPMInputToken_MaskBodyTokens` — 5 cases covering single replacement, embedded, two tokens, non-matching, and plain text.
- `TestAPMInputToken_IsAllBodyTokens` — 3 cases.

**`docs/background/concepts/placeholder-grammar.md`**
- New row in the token vocabulary table for `apm-input-token`.
- MDS018, MDS023, MDS024 rows in the opt-in rules table updated to include `apm-input-token`.

## Test plan

- `go test ./internal/placeholders/...` — all new tests pass
- `go test ./...` — full suite green
- `go tool -modfile=tools/go.mod golangci-lint run ./internal/placeholders/...` — 0 issues
- `go run ./cmd/mdsmith check .` — 0 failures (549 files)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Cua8NLiPy6fhj58LvUWf1)_