### PR TITLE
feat: foreign managed-region protection for `mdsmith fix`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,6 +141,7 @@ row: "- [{summary}](../{filename})"
 - [Print the mdsmith build version and exit.](../docs/reference/cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](../docs/reference/convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](../docs/reference/conventions.md)
+- [The top-level `foreign-regions:` config lists `{start, end}` marker pairs whose spanned bytes mdsmith treats as opaque — style rules skip diagnostics inside a matched pair and fixers never rewrite it, while whole-file rules still count the bytes. Glob-scopable via `overrides:`; a start with no matching end reports MDS073.](../docs/reference/foreign-regions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](../docs/reference/globs.md)
 - [Look up exact CLI commands, config glob and schema syntax, the built-in conventions, and the section-schema grammar.](../docs/reference/index.md)
 - [Each file under `.mdsmith/kinds/` declares one kind. The basename is the kind name; the file body carries the full `KindBody` — schema, rules, `path-pattern:`, `extends:`. Sits alongside inline `kinds.<name>:` in `.mdsmith.yml`.](../docs/reference/kind-files.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ row: "- [{summary}]({filename})"
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](docs/reference/convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
+- [The top-level `foreign-regions:` config lists `{start, end}` marker pairs whose spanned bytes mdsmith treats as opaque — style rules skip diagnostics inside a matched pair and fixers never rewrite it, while whole-file rules still count the bytes. Glob-scopable via `overrides:`; a start with no matching end reports MDS073.](docs/reference/foreign-regions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 - [Look up exact CLI commands, config glob and schema syntax, the built-in conventions, and the section-schema grammar.](docs/reference/index.md)
 - [Each file under `.mdsmith/kinds/` declares one kind. The basename is the kind name; the file body carries the full `KindBody` — schema, rules, `path-pattern:`, `extends:`. Sits alongside inline `kinds.<name>:` in `.mdsmith.yml`.](docs/reference/kind-files.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ row: "- [{summary}]({filename})"
 - [Print the mdsmith build version and exit.](docs/reference/cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](docs/reference/convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](docs/reference/conventions.md)
+- [The top-level `foreign-regions:` config lists `{start, end}` marker pairs whose spanned bytes mdsmith treats as opaque — style rules skip diagnostics inside a matched pair and fixers never rewrite it, while whole-file rules still count the bytes. Glob-scopable via `overrides:`; a start with no matching end reports MDS073.](docs/reference/foreign-regions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](docs/reference/globs.md)
 - [Look up exact CLI commands, config glob and schema syntax, the built-in conventions, and the section-schema grammar.](docs/reference/index.md)
 - [Each file under `.mdsmith/kinds/` declares one kind. The basename is the kind name; the file body carries the full `KindBody` — schema, rules, `path-pattern:`, `extends:`. Sits alongside inline `kinds.<name>:` in `.mdsmith.yml`.](docs/reference/kind-files.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -247,7 +247,7 @@ footer: |
 | 2607051920 | ✅     | sonnet | [Consolidate duplicated leading-space/blank-line rule helpers into internal/rules/astutil](plan/2607051920_arch-fix-rule-whitespace-helpers-astutil.md) |
 | 2607071642 | ✅     | sonnet | [Single-file metric extraction via `mdsmith metrics get` (readability first)](plan/2607071642_extractable-file-metrics.md)                              |
 | 2607082048 | ✅     | sonnet | [Placeholder token for APM `${input:name}` prompt parameters](plan/2607082048_apm-input-placeholder-token.md)                                           |
-| 2607082049 | 🔲     | opus   | [Foreign managed-region protection for `mdsmith fix`](plan/2607082049_foreign-managed-regions.md)                                                       |
+| 2607082049 | ✅     | opus   | [Foreign managed-region protection for `mdsmith fix`](plan/2607082049_foreign-managed-regions.md)                                                       |
 | 2607082050 | 🔲     | sonnet | [APM coexistence: `mdsmith init --apm`, guide, and kind pack](plan/2607082050_apm-coexist-guide-and-kind-pack.md)                                       |
 | 2607082051 | 🔲     | opus   | [Schema extensions: closed frontmatter and filename agreement](plan/2607082051_apm-schema-extensions.md)                                                |
 | 2607082052 | ✅     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |

--- a/docs/reference/foreign-regions.md
+++ b/docs/reference/foreign-regions.md
@@ -1,0 +1,98 @@
+---
+weight: 30
+summary: >-
+  The top-level `foreign-regions:` config lists `{start, end}` marker
+  pairs whose spanned bytes mdsmith treats as opaque — style rules skip
+  diagnostics inside a matched pair and fixers never rewrite it, while
+  whole-file rules still count the bytes. Glob-scopable via `overrides:`;
+  a start with no matching end reports MDS073.
+---
+# Foreign regions
+
+A **foreign region** is a span of a Markdown file that another
+generator owns. The top-level `foreign-regions:` key lists the marker
+pairs that bound such spans, so `mdsmith fix` leaves those bytes
+byte-for-byte unchanged and the style rules raise no diagnostics inside
+them. The first case is [APM][apm], whose `managed_section` mode writes
+a block bounded by `<!-- apm:start -->` and `<!-- apm:end -->` and pins
+a SHA-256 of the file; any reflow inside that block trips its drift
+check.
+
+This is the same exclusion the [generated-section engine][gensection]
+applies to `<?include?>` and `<?catalog?>` bodies. The difference is
+ownership: mdsmith regenerates its own directive bodies, but never
+touches a foreign region — the owning tool regenerates it.
+
+## Configuration
+
+Declare each marker pair under `foreign-regions:`. mdsmith matches
+`start` and `end` against whole lines with surrounding whitespace
+trimmed. A marker may be indented, but it must sit on its own line:
+
+```yaml
+foreign-regions:
+  - start: "<!-- apm:start -->"
+    end: "<!-- apm:end -->"
+```
+
+Both markers must be non-empty and must differ from each other; a pair
+that violates either rule is a config error.
+
+### Scoping to a subtree
+
+`foreign-regions:` is glob-scopable through
+[`overrides:`](globs.md). An override's `foreign-regions:` list is
+**appended** to the top-level list for every file its glob matches — it
+never replaces the global pairs. Use this to protect an extra marker
+pair that only appears under one path:
+
+```yaml
+foreign-regions:
+  - start: "<!-- apm:start -->"
+    end: "<!-- apm:end -->"
+overrides:
+  - glob: ["AGENTS.md"]
+    foreign-regions:
+      - start: "<!-- gen:start -->"
+        end: "<!-- gen:end -->"
+```
+
+## What the region protects
+
+mdsmith scans each file for every declared marker pair. It records the
+span from a `start` line through its matching `end` line. The markers
+themselves are part of the span.
+
+| Surface                           | Behavior inside a matched region                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `mdsmith fix`                     | Bytes round-trip unchanged, even otherwise-fixable trailing spaces and table misalignment. |
+| Style and content rules           | Emit no diagnostics; the same violation outside the region still fires.                    |
+| Whole-file rules (MDS022, MDS028) | Still count the region's bytes toward file length and token budget.                        |
+
+Whole-file rules read the raw source. A large foreign region still
+counts against `max-file-length` and `token-budget`. The region is
+opaque to editing, not invisible to size accounting.
+
+## Malformed regions (MDS073)
+
+APM requires each marker exactly once. mdsmith reports **MDS073** on a
+malformed region and protects no bytes for it:
+
+| Condition                                       | Reported on                |
+| ----------------------------------------------- | -------------------------- |
+| A `start` marker with no matching `end`         | the `start` line           |
+| An `end` marker with no preceding `start`       | the `end` line             |
+| A second `start` before the first region closes | the duplicate `start` line |
+
+## Non-goals
+
+- **Regenerating the region.** mdsmith treats it as opaque; the owning
+  tool regenerates it.
+- **Resolving merge conflicts inside it.** The
+  [merge driver](cli/merge-driver.md) stays scoped to mdsmith's own
+  directive blocks.
+- **Auto-detecting markers.** Regions are declared in config, never
+  inferred.
+
+[apm]: ../research/apm-mdsmith/apm-model.md
+[gensection]: ../background/concepts/generated-section.md

--- a/docs/reference/foreign-regions.md
+++ b/docs/reference/foreign-regions.md
@@ -76,13 +76,17 @@ opaque to editing, not invisible to size accounting.
 ## Malformed regions (MDS073)
 
 APM requires each marker exactly once. mdsmith reports **MDS073** on a
-malformed region and protects no bytes for it:
+malformed region:
 
-| Condition                                       | Reported on                |
-| ----------------------------------------------- | -------------------------- |
-| A `start` marker with no matching `end`         | the `start` line           |
-| An `end` marker with no preceding `start`       | the `end` line             |
-| A second `start` before the first region closes | the duplicate `start` line |
+| Condition                                       | Reported on                | Bytes protected                              |
+| ----------------------------------------------- | -------------------------- | -------------------------------------------- |
+| A `start` marker with no matching `end`         | the `start` line           | none                                         |
+| An `end` marker with no preceding `start`       | the `end` line             | none                                         |
+| A second `start` before the first region closes | the duplicate `start` line | the first `start` through the matching `end` |
+
+An unmatched `start` or `end` protects no bytes. A duplicate `start`
+still pairs the first `start` with the next `end`, so that span is
+protected while the extra marker only draws the diagnostic.
 
 ## Non-goals
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -37,6 +37,7 @@ row: "- [{summary}]({filename})"
 - [Print the mdsmith build version and exit.](cli/version.md)
 - [Each file under `.mdsmith/conventions/` declares one user convention. The basename is the convention name; the file body carries a `flavor:` plus a `rules:` map. Sits alongside inline `conventions.<name>:` in `.mdsmith.yml`.](convention-files.md)
 - [Built-in Markdown conventions, the rule presets each one applies, and how user config layers on top via deep-merge.](conventions.md)
+- [The top-level `foreign-regions:` config lists `{start, end}` marker pairs whose spanned bytes mdsmith treats as opaque — style rules skip diagnostics inside a matched pair and fixers never rewrite it, while whole-file rules still count the bytes. Glob-scopable via `overrides:`; a start with no matching end reports MDS073.](foreign-regions.md)
 - [Glob pattern syntax across mdsmith config, directives, and CLI argument expansion, with the supported exclusion semantics for each surface.](globs.md)
 - [Each file under `.mdsmith/kinds/` declares one kind. The basename is the kind name; the file body carries the full `KindBody` — schema, rules, `path-pattern:`, `extends:`. Sits alongside inline `kinds.<name>:` in `.mdsmith.yml`.](kind-files.md)
 - [Every markdownlint rule and the mdsmith rule that covers it, generated from the rule README front matter — the same data `mdsmith init --from-markdownlint` reads.](markdownlint-mapping.md)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,15 @@ type Config struct {
 	KindAssignment []KindAssignmentEntry `yaml:"kind-assignment,omitempty"`
 	Build          BuildConfig           `yaml:"build,omitempty"`
 
+	// ForeignRegions lists marker pairs that bound content another
+	// generator owns (e.g. APM's `<!-- apm:start -->` /
+	// `<!-- apm:end -->`). The fix pipeline treats the bytes inside a
+	// matched pair as opaque — no fixer rewrites them and style rules
+	// skip diagnostics there — while whole-file rules (MDS022, MDS028)
+	// still count the bytes. Glob-scopable via `overrides:`, which
+	// append their own pairs to this base list per matching file.
+	ForeignRegions []ForeignRegion `yaml:"foreign-regions,omitempty"`
+
 	// Convention names a Markdown convention bundle. Built-in
 	// values: "portable", "github", "plain". User-defined
 	// conventions may also be referenced here after being declared
@@ -155,6 +164,19 @@ type Override struct {
 	Files      []string           `yaml:"files,omitempty"`
 	Rules      map[string]RuleCfg `yaml:"rules"`
 	Categories map[string]bool    `yaml:"categories"`
+	// ForeignRegions are marker pairs scoped to this override's glob.
+	// They append to the top-level `foreign-regions:` list for files
+	// matching Patterns(); see config.EffectiveForeignRegions.
+	ForeignRegions []ForeignRegion `yaml:"foreign-regions,omitempty"`
+}
+
+// ForeignRegion declares one foreign-owned marker pair. Start and End
+// are matched against whole trimmed source lines; the bytes spanned by
+// a matched pair (markers included) are treated as opaque by the fix
+// pipeline and skipped by style rules.
+type ForeignRegion struct {
+	Start string `yaml:"start"`
+	End   string `yaml:"end"`
 }
 
 // Patterns returns the effective set of glob patterns for the override.

--- a/internal/config/foreignregion.go
+++ b/internal/config/foreignregion.go
@@ -37,16 +37,25 @@ func EffectiveForeignRegions(cfg *Config, filePath string) []ForeignRegion {
 	return out
 }
 
-// containsForeignRegion reports whether list already holds an identical
+// containsForeignRegion reports whether list already holds an equivalent
 // marker pair. EffectiveForeignRegions dedups with it so a pair declared
 // both top-level and on a matching override (or repeated within a list)
 // contributes one protected span and one MDS073 diagnostic, not two —
-// the check path does not otherwise dedup per-file diagnostics. The
-// marker-pair lists are short (a handful of entries), so the linear scan
-// is cheaper than allocating a set on this per-file hot path.
+// the check path does not otherwise dedup per-file diagnostics.
+//
+// Equivalence is by trimmed markers, matching how the scanner compares a
+// marker against a source line (whole-line equality after TrimSpace). Two
+// pairs that differ only in surrounding whitespace — e.g. "<!-- x -->" and
+// " <!-- x -->" — scan identically, so they must dedup to one span and one
+// diagnostic; a raw `==` comparison would let the whitespace variant slip
+// past and re-introduce the double report. The marker-pair lists are short
+// (a handful of entries), so the linear scan is cheaper than allocating a
+// set on this per-file hot path.
 func containsForeignRegion(list []ForeignRegion, r ForeignRegion) bool {
+	start := strings.TrimSpace(r.Start)
+	end := strings.TrimSpace(r.End)
 	for _, e := range list {
-		if e == r {
+		if strings.TrimSpace(e.Start) == start && strings.TrimSpace(e.End) == end {
 			return true
 		}
 	}

--- a/internal/config/foreignregion.go
+++ b/internal/config/foreignregion.go
@@ -16,16 +16,41 @@ func EffectiveForeignRegions(cfg *Config, filePath string) []ForeignRegion {
 		return nil
 	}
 	var out []ForeignRegion
-	out = append(out, cfg.ForeignRegions...)
+	for _, r := range cfg.ForeignRegions {
+		if !containsForeignRegion(out, r) {
+			out = append(out, r)
+		}
+	}
 	for _, o := range cfg.Overrides {
 		if len(o.ForeignRegions) == 0 {
 			continue
 		}
-		if matchesAny(o.Patterns(), filePath) {
-			out = append(out, o.ForeignRegions...)
+		if !matchesAny(o.Patterns(), filePath) {
+			continue
+		}
+		for _, r := range o.ForeignRegions {
+			if !containsForeignRegion(out, r) {
+				out = append(out, r)
+			}
 		}
 	}
 	return out
+}
+
+// containsForeignRegion reports whether list already holds an identical
+// marker pair. EffectiveForeignRegions dedups with it so a pair declared
+// both top-level and on a matching override (or repeated within a list)
+// contributes one protected span and one MDS073 diagnostic, not two —
+// the check path does not otherwise dedup per-file diagnostics. The
+// marker-pair lists are short (a handful of entries), so the linear scan
+// is cheaper than allocating a set on this per-file hot path.
+func containsForeignRegion(list []ForeignRegion, r ForeignRegion) bool {
+	for _, e := range list {
+		if e == r {
+			return true
+		}
+	}
+	return false
 }
 
 // validateConfigSemantics runs the post-parse structural checks that
@@ -44,31 +69,36 @@ func validateConfigSemantics(cfg *Config) error {
 // (the scanner could never tell which line opens and which closes a
 // region). It checks the top-level list and every override's list.
 func validateForeignRegions(cfg *Config) error {
-	if err := checkForeignRegionList(cfg.ForeignRegions); err != nil {
+	if err := checkForeignRegionList("foreign-regions", cfg.ForeignRegions); err != nil {
 		return err
 	}
 	for i := range cfg.Overrides {
-		if err := checkForeignRegionList(cfg.Overrides[i].ForeignRegions); err != nil {
+		label := fmt.Sprintf("overrides[%d].foreign-regions", i)
+		if err := checkForeignRegionList(label, cfg.Overrides[i].ForeignRegions); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func checkForeignRegionList(regions []ForeignRegion) error {
+// checkForeignRegionList validates one marker-pair list. label names the
+// list's location in the config ("foreign-regions" or
+// "overrides[i].foreign-regions") so an error points at the offending
+// override rather than an ambiguous top-level index.
+func checkForeignRegionList(label string, regions []ForeignRegion) error {
 	for i, r := range regions {
 		start := strings.TrimSpace(r.Start)
 		end := strings.TrimSpace(r.End)
 		if start == "" {
-			return fmt.Errorf("foreign-regions[%d]: start marker must not be empty", i)
+			return fmt.Errorf("%s[%d]: start marker must not be empty", label, i)
 		}
 		if end == "" {
-			return fmt.Errorf("foreign-regions[%d]: end marker must not be empty", i)
+			return fmt.Errorf("%s[%d]: end marker must not be empty", label, i)
 		}
 		if start == end {
 			return fmt.Errorf(
-				"foreign-regions[%d]: start and end markers must differ (both %q)",
-				i, start)
+				"%s[%d]: start and end markers must differ (both %q)",
+				label, i, start)
 		}
 	}
 	return nil

--- a/internal/config/foreignregion.go
+++ b/internal/config/foreignregion.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EffectiveForeignRegions returns the foreign-region marker pairs that
+// apply to filePath: the top-level `foreign-regions:` list followed by
+// the pairs declared on every override whose glob matches the file.
+// Override pairs append to (never replace) the base list, so a project
+// can protect an extra marker pair in a subtree without restating the
+// global ones. Returns nil when no pairs apply.
+func EffectiveForeignRegions(cfg *Config, filePath string) []ForeignRegion {
+	if cfg == nil {
+		return nil
+	}
+	var out []ForeignRegion
+	out = append(out, cfg.ForeignRegions...)
+	for _, o := range cfg.Overrides {
+		if len(o.ForeignRegions) == 0 {
+			continue
+		}
+		if matchesAny(o.Patterns(), filePath) {
+			out = append(out, o.ForeignRegions...)
+		}
+	}
+	return out
+}
+
+// validateForeignRegions rejects malformed marker-pair declarations:
+// a blank start or end marker, or a pair whose start equals its end
+// (the scanner could never tell which line opens and which closes a
+// region). It checks the top-level list and every override's list.
+func validateForeignRegions(cfg *Config) error {
+	if err := checkForeignRegionList(cfg.ForeignRegions); err != nil {
+		return err
+	}
+	for i := range cfg.Overrides {
+		if err := checkForeignRegionList(cfg.Overrides[i].ForeignRegions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkForeignRegionList(regions []ForeignRegion) error {
+	for i, r := range regions {
+		if strings.TrimSpace(r.Start) == "" {
+			return fmt.Errorf("foreign-regions[%d]: start marker must not be empty", i)
+		}
+		if strings.TrimSpace(r.End) == "" {
+			return fmt.Errorf("foreign-regions[%d]: end marker must not be empty", i)
+		}
+		if strings.TrimSpace(r.Start) == strings.TrimSpace(r.End) {
+			return fmt.Errorf(
+				"foreign-regions[%d]: start and end markers must differ (both %q)",
+				i, strings.TrimSpace(r.Start))
+		}
+	}
+	return nil
+}

--- a/internal/config/foreignregion.go
+++ b/internal/config/foreignregion.go
@@ -57,16 +57,18 @@ func validateForeignRegions(cfg *Config) error {
 
 func checkForeignRegionList(regions []ForeignRegion) error {
 	for i, r := range regions {
-		if strings.TrimSpace(r.Start) == "" {
+		start := strings.TrimSpace(r.Start)
+		end := strings.TrimSpace(r.End)
+		if start == "" {
 			return fmt.Errorf("foreign-regions[%d]: start marker must not be empty", i)
 		}
-		if strings.TrimSpace(r.End) == "" {
+		if end == "" {
 			return fmt.Errorf("foreign-regions[%d]: end marker must not be empty", i)
 		}
-		if strings.TrimSpace(r.Start) == strings.TrimSpace(r.End) {
+		if start == end {
 			return fmt.Errorf(
 				"foreign-regions[%d]: start and end markers must differ (both %q)",
-				i, strings.TrimSpace(r.Start))
+				i, start)
 		}
 	}
 	return nil

--- a/internal/config/foreignregion.go
+++ b/internal/config/foreignregion.go
@@ -28,6 +28,17 @@ func EffectiveForeignRegions(cfg *Config, filePath string) []ForeignRegion {
 	return out
 }
 
+// validateConfigSemantics runs the post-parse structural checks that
+// depend on the fully-decoded config: kind graph validity and
+// foreign-region marker-pair well-formedness. Kept together so
+// loadFromBytes carries one call site rather than one per check.
+func validateConfigSemantics(cfg *Config) error {
+	if err := ValidateKinds(cfg); err != nil {
+		return err
+	}
+	return validateForeignRegions(cfg)
+}
+
 // validateForeignRegions rejects malformed marker-pair declarations:
 // a blank start or end marker, or a pair whose start equals its end
 // (the scanner could never tell which line opens and which closes a

--- a/internal/config/foreignregion_more_test.go
+++ b/internal/config/foreignregion_more_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEffectiveForeignRegionsNilConfig returns nil for a nil config.
+func TestEffectiveForeignRegionsNilConfig(t *testing.T) {
+	assert.Nil(t, EffectiveForeignRegions(nil, "README.md"))
+}
+
+// TestEffectiveForeignRegionsSkipsEmptyOverride ignores an override that
+// declares no foreign regions, even when its glob matches.
+func TestEffectiveForeignRegionsSkipsEmptyOverride(t *testing.T) {
+	cfg := &Config{
+		ForeignRegions: []ForeignRegion{{Start: "<!-- a -->", End: "<!-- b -->"}},
+		Overrides: []Override{
+			{Glob: []string{"README.md"}}, // matches, but has no ForeignRegions
+		},
+	}
+	got := EffectiveForeignRegions(cfg, "README.md")
+	require.Len(t, got, 1)
+	assert.Equal(t, "<!-- a -->", got[0].Start)
+}
+
+// TestParseForeignRegionsEmptyEndRejected rejects a marker pair with a
+// blank end marker.
+func TestParseForeignRegionsEmptyEndRejected(t *testing.T) {
+	yml := `foreign-regions:
+  - start: "<!-- apm:start -->"
+    end: ""
+`
+	_, err := ParseBytes([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "end marker must not be empty")
+}
+
+// TestParseForeignRegionsOverrideInvalidRejected surfaces a malformed
+// marker pair declared on an override, not just the top-level list.
+func TestParseForeignRegionsOverrideInvalidRejected(t *testing.T) {
+	yml := `overrides:
+  - glob: ["AGENTS.md"]
+    foreign-regions:
+      - start: ""
+        end: "<!-- gen:end -->"
+`
+	_, err := ParseBytes([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start marker must not be empty")
+}
+
+// TestCopyForeignRegionsNil returns nil for a nil input.
+func TestCopyForeignRegionsNil(t *testing.T) {
+	assert.Nil(t, copyForeignRegions(nil))
+}
+
+// TestCopyForeignRegionsIsolatesBackingArray returns an independent copy
+// whose mutation does not touch the source slice.
+func TestCopyForeignRegionsIsolatesBackingArray(t *testing.T) {
+	src := []ForeignRegion{{Start: "<!-- a -->", End: "<!-- b -->"}}
+	out := copyForeignRegions(src)
+	require.Len(t, out, 1)
+	assert.Equal(t, src[0], out[0])
+	out[0].Start = "mutated"
+	assert.Equal(t, "<!-- a -->", src[0].Start, "copy must not alias the source")
+}

--- a/internal/config/foreignregion_more_test.go
+++ b/internal/config/foreignregion_more_test.go
@@ -52,6 +52,46 @@ func TestParseForeignRegionsOverrideInvalidRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "start marker must not be empty")
 }
 
+// TestParseForeignRegionsOverrideErrorNamesOverride reports which
+// override carries a malformed marker pair, not an ambiguous top-level
+// index.
+func TestParseForeignRegionsOverrideErrorNamesOverride(t *testing.T) {
+	yml := `overrides:
+  - glob: ["README.md"]
+  - glob: ["AGENTS.md"]
+    foreign-regions:
+      - start: "<!-- gen:start -->"
+        end: ""
+`
+	_, err := ParseBytes([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overrides[1].foreign-regions[0]")
+	assert.Contains(t, err.Error(), "end marker must not be empty")
+}
+
+// TestEffectiveForeignRegionsDedupes collapses a marker pair declared
+// both top-level and on a matching override into a single entry, so the
+// check path (which does not dedup per-file MDS073 diagnostics) does not
+// double-report or double-protect it.
+func TestEffectiveForeignRegionsDedupes(t *testing.T) {
+	cfg := &Config{
+		ForeignRegions: []ForeignRegion{{Start: "<!-- a -->", End: "<!-- b -->"}},
+		Overrides: []Override{
+			{
+				Glob: []string{"AGENTS.md"},
+				ForeignRegions: []ForeignRegion{
+					{Start: "<!-- a -->", End: "<!-- b -->"}, // duplicate of top-level
+					{Start: "<!-- c -->", End: "<!-- d -->"}, // distinct
+				},
+			},
+		},
+	}
+	got := EffectiveForeignRegions(cfg, "AGENTS.md")
+	require.Len(t, got, 2)
+	assert.Equal(t, ForeignRegion{Start: "<!-- a -->", End: "<!-- b -->"}, got[0])
+	assert.Equal(t, ForeignRegion{Start: "<!-- c -->", End: "<!-- d -->"}, got[1])
+}
+
 // TestCopyForeignRegionsNil returns nil for a nil input.
 func TestCopyForeignRegionsNil(t *testing.T) {
 	assert.Nil(t, copyForeignRegions(nil))

--- a/internal/config/foreignregion_more_test.go
+++ b/internal/config/foreignregion_more_test.go
@@ -92,6 +92,28 @@ func TestEffectiveForeignRegionsDedupes(t *testing.T) {
 	assert.Equal(t, ForeignRegion{Start: "<!-- c -->", End: "<!-- d -->"}, got[1])
 }
 
+// TestEffectiveForeignRegionsDedupesWhitespaceVariant collapses two pairs
+// that differ only in surrounding marker whitespace into one entry: the
+// scanner compares markers by trimmed-line equality, so the variant scans
+// identically and must protect one span and report one MDS073, not two.
+func TestEffectiveForeignRegionsDedupesWhitespaceVariant(t *testing.T) {
+	cfg := &Config{
+		ForeignRegions: []ForeignRegion{{Start: "<!-- a -->", End: "<!-- b -->"}},
+		Overrides: []Override{
+			{
+				Glob: []string{"AGENTS.md"},
+				ForeignRegions: []ForeignRegion{
+					// Same markers, extra surrounding whitespace.
+					{Start: "  <!-- a -->", End: "<!-- b -->  "},
+				},
+			},
+		},
+	}
+	got := EffectiveForeignRegions(cfg, "AGENTS.md")
+	require.Len(t, got, 1)
+	assert.Equal(t, ForeignRegion{Start: "<!-- a -->", End: "<!-- b -->"}, got[0])
+}
+
 // TestCopyForeignRegionsNil returns nil for a nil input.
 func TestCopyForeignRegionsNil(t *testing.T) {
 	assert.Nil(t, copyForeignRegions(nil))

--- a/internal/config/foreignregion_test.go
+++ b/internal/config/foreignregion_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseForeignRegions parses a top-level foreign-regions: list of
+// {start, end} marker pairs.
+func TestParseForeignRegions(t *testing.T) {
+	yml := `foreign-regions:
+  - start: "<!-- apm:start -->"
+    end: "<!-- apm:end -->"
+`
+	cfg, err := ParseBytes([]byte(yml))
+	require.NoError(t, err)
+	require.Len(t, cfg.ForeignRegions, 1)
+	assert.Equal(t, "<!-- apm:start -->", cfg.ForeignRegions[0].Start)
+	assert.Equal(t, "<!-- apm:end -->", cfg.ForeignRegions[0].End)
+}
+
+// TestParseForeignRegionsEmptyStartRejected rejects a marker pair with
+// a blank start marker.
+func TestParseForeignRegionsEmptyStartRejected(t *testing.T) {
+	yml := `foreign-regions:
+  - start: ""
+    end: "<!-- apm:end -->"
+`
+	_, err := ParseBytes([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "foreign-regions")
+}
+
+// TestParseForeignRegionsSameMarkerRejected rejects a pair whose start
+// and end markers are identical (the scanner could never bound a
+// region).
+func TestParseForeignRegionsSameMarkerRejected(t *testing.T) {
+	yml := `foreign-regions:
+  - start: "<!-- x -->"
+    end: "<!-- x -->"
+`
+	_, err := ParseBytes([]byte(yml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "foreign-regions")
+}
+
+// TestEffectiveForeignRegionsGlobScoped resolves foreign-regions from
+// the top-level list plus any matching overrides.
+func TestEffectiveForeignRegionsGlobScoped(t *testing.T) {
+	yml := `foreign-regions:
+  - start: "<!-- apm:start -->"
+    end: "<!-- apm:end -->"
+overrides:
+  - glob: ["AGENTS.md"]
+    foreign-regions:
+      - start: "<!-- gen:start -->"
+        end: "<!-- gen:end -->"
+`
+	cfg, err := ParseBytes([]byte(yml))
+	require.NoError(t, err)
+
+	// A file outside the override glob sees only the top-level pair.
+	base := EffectiveForeignRegions(cfg, "README.md")
+	require.Len(t, base, 1)
+	assert.Equal(t, "<!-- apm:start -->", base[0].Start)
+
+	// A file matching the override glob sees both pairs.
+	scoped := EffectiveForeignRegions(cfg, "AGENTS.md")
+	require.Len(t, scoped, 2)
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -105,6 +105,10 @@ func loadFromBytes(data []byte, sourcePath string, mergeKinds bool) (*Config, er
 		return nil, fmt.Errorf("validating config: %w", err)
 	}
 
+	if err := validateForeignRegions(&cfg); err != nil {
+		return nil, fmt.Errorf("validating config: %w", err)
+	}
+
 	if err := checkBuildConfig(data, &cfg); err != nil {
 		return nil, err
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -101,11 +101,7 @@ func loadFromBytes(data []byte, sourcePath string, mergeKinds bool) (*Config, er
 		return nil, err
 	}
 
-	if err := ValidateKinds(&cfg); err != nil {
-		return nil, fmt.Errorf("validating config: %w", err)
-	}
-
-	if err := validateForeignRegions(&cfg); err != nil {
+	if err := validateConfigSemantics(&cfg); err != nil {
 		return nil, fmt.Errorf("validating config: %w", err)
 	}
 

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -53,6 +53,7 @@ func Merge(defaults, loaded *Config) *Config {
 		Kinds:                  copyKinds(loaded.Kinds),
 		KindAssignment:         copyKindAssignment(loaded.KindAssignment),
 		Build:                  copyBuildConfig(loaded.Build),
+		ForeignRegions:         copyForeignRegions(loaded.ForeignRegions),
 		Convention:             loaded.Convention,
 		Conventions:            copyUserConventions(loaded.Conventions),
 		ConventionPreset:       copyConventionPreset(loaded.ConventionPreset),
@@ -107,6 +108,7 @@ func copyConfig(cfg *Config) *Config {
 		Kinds:                  copyKinds(cfg.Kinds),
 		KindAssignment:         copyKindAssignment(cfg.KindAssignment),
 		Build:                  copyBuildConfig(cfg.Build),
+		ForeignRegions:         copyForeignRegions(cfg.ForeignRegions),
 		Convention:             cfg.Convention,
 		Conventions:            copyUserConventions(cfg.Conventions),
 		ConventionPreset:       copyConventionPreset(cfg.ConventionPreset),
@@ -255,6 +257,18 @@ func copyKindAssignment(entries []KindAssignmentEntry) []KindAssignmentEntry {
 		}
 	}
 	return result
+}
+
+// copyForeignRegions returns a copy of a foreign-region marker-pair
+// slice. Returns nil if the input is nil. Each ForeignRegion is a pure
+// value (two strings), so a shallow slice copy fully isolates it.
+func copyForeignRegions(regions []ForeignRegion) []ForeignRegion {
+	if regions == nil {
+		return nil
+	}
+	out := make([]ForeignRegion, len(regions))
+	copy(out, regions)
+	return out
 }
 
 // copyStrings returns a copy of a string slice. Returns nil if the input is nil.

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/checker"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/explain"
+	"github.com/jeduden/mdsmith/internal/foreignregion"
 	"github.com/jeduden/mdsmith/internal/gitignore"
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
@@ -485,11 +486,18 @@ func (r *Runner) lintFile(path string, intraFileCap int, cache *lint.RunCache, r
 	// directives, so it has no generated sections — leave the ranges nil.
 	populateGeneratedRanges(f)
 
+	// Foreign-region ranges extend the same exclusion set from a plain
+	// line scan (no AST needed), so style rules skip diagnostics inside a
+	// marker pair another generator owns. Malformed pairs surface as
+	// MDS073 diagnostics appended after the rule check.
+	foreignDiags := foreignregion.Apply(f, r.Config, path)
+
 	// Configure the enabled rules once per config signature (cached on the
 	// worker's confCache) and reuse the result across every file that shares
 	// that config, instead of re-cloning every Configurable rule per file.
 	configured, cfgErrs := rr.configured(sigKey, effective)
 	diags := checker.CheckConfiguredRules(f, configured, r.SkipSourceContext, intraFileCap)
+	diags = append(diags, foreignDiags...)
 	if r.Explain {
 		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
@@ -737,6 +745,10 @@ func (r *Runner) populateFileFields(f *lint.File, path string) {
 		}
 	}
 	f.GeneratedRanges = gensection.FindAllGeneratedRanges(f)
+	// Extend the exclusion set with foreign-region spans before the *File
+	// is published to the parse cache, so the read-only diagnostic pass
+	// (runSourceCheckRules) never has to mutate the shared File.
+	foreignregion.AppendRanges(f, r.Config, path)
 }
 
 // runSourceCheckRules wraps the post-parse check pipeline for
@@ -765,6 +777,7 @@ func (r *Runner) runSourceCheckRules(
 		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
 	res.Diagnostics = append(res.Diagnostics, diags...)
+	res.Diagnostics = append(res.Diagnostics, foreignregion.Diagnostics(f, r.Config, path)...)
 	res.Errors = append(res.Errors, errs...)
 }
 

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -486,18 +486,11 @@ func (r *Runner) lintFile(path string, intraFileCap int, cache *lint.RunCache, r
 	// directives, so it has no generated sections — leave the ranges nil.
 	populateGeneratedRanges(f)
 
-	// Foreign-region ranges extend the same exclusion set from a plain
-	// line scan (no AST needed), so style rules skip diagnostics inside a
-	// marker pair another generator owns. Malformed pairs surface as
-	// MDS073 diagnostics appended after the rule check.
-	foreignDiags := foreignregion.Apply(f, r.Config, path)
-
 	// Configure the enabled rules once per config signature (cached on the
 	// worker's confCache) and reuse the result across every file that shares
 	// that config, instead of re-cloning every Configurable rule per file.
 	configured, cfgErrs := rr.configured(sigKey, effective)
-	diags := checker.CheckConfiguredRules(f, configured, r.SkipSourceContext, intraFileCap)
-	diags = append(diags, foreignDiags...)
+	diags := r.checkWithForeignRegions(f, configured, path, intraFileCap)
 	if r.Explain {
 		explain.Attach(diags, r.Config, path, fmKinds, fmFields)
 	}
@@ -506,6 +499,19 @@ func (r *Runner) lintFile(path string, intraFileCap int, cache *lint.RunCache, r
 	// across files that hit the same cache entry is safe. It is nil on
 	// every well-formed config (the common path).
 	return fileOutcome{diags: diags, errs: cfgErrs}
+}
+
+// checkWithForeignRegions extends f.GeneratedRanges with the foreign-
+// region spans that apply to path (a plain line scan, no AST needed) so
+// style rules skip diagnostics inside a marker pair another generator
+// owns, runs the configured rules, and appends the malformed-region
+// (MDS073) diagnostics for any unmatched or duplicated marker.
+func (r *Runner) checkWithForeignRegions(
+	f *lint.File, configured []rule.Rule, path string, intraFileCap int,
+) []lint.Diagnostic {
+	foreignDiags := foreignregion.Apply(f, r.Config, path)
+	diags := checker.CheckConfiguredRules(f, configured, r.SkipSourceContext, intraFileCap)
+	return append(diags, foreignDiags...)
 }
 
 // populateGeneratedRanges fills f.GeneratedRanges from the include/catalog

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/checker"
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/explain"
+	"github.com/jeduden/mdsmith/internal/foreignregion"
 	"github.com/jeduden/mdsmith/internal/gitignore"
 	"github.com/jeduden/mdsmith/internal/lint"
 	vlog "github.com/jeduden/mdsmith/internal/log"
@@ -401,10 +402,16 @@ func (f *Fixer) fixFile(path string) (
 
 	fc := f.configuredFor(key, effective)
 	lf.GeneratedRanges = gensection.FindAllGeneratedRanges(lf)
+	foreignDiags := foreignregion.Apply(lf, f.Config, path)
 	beforeDiags := checker.CheckConfiguredRules(lf, fc.all, false, 1)
+	beforeDiags = append(beforeDiags, foreignDiags...)
 	errs = append(errs, fc.errs...)
 
 	current := f.applyFixPasses(path, lf.Source, fc.fixable, lf, dirFS, &errs)
+	// Undo any fixer edit that landed inside a declared foreign region —
+	// the owning generator's bytes must round-trip unchanged even when a
+	// fixer ignores GeneratedRanges (e.g. trailing-space trimming).
+	current = foreignregion.Restore(lf.Source, current, config.EffectiveForeignRegions(f.Config, path))
 
 	bytesChanged := !bytes.Equal(lf.Source, current)
 	var modified string
@@ -421,9 +428,10 @@ func (f *Fixer) fixFile(path string) (
 		modified = path
 	}
 
-	finalFile := buildPostFixFile(path, current, lf, dirFS)
+	finalFile := buildPostFixFile(path, current, lf, dirFS, f.Config)
 
 	diags := checker.CheckConfiguredRules(finalFile, fc.all, false, 1)
+	diags = append(diags, foreignregion.Diagnostics(finalFile, f.Config, path)...)
 	if f.DryRun {
 		diags = subtractPredictedDryRunFixes(diags, fc.fixable, finalFile)
 	}
@@ -592,7 +600,7 @@ func countByRule(diags []lint.Diagnostic) map[string]int {
 // different post-fix bytes than `mdsmith check` would have validated,
 // and side-effect-only fixers (e.g. MDS048 checking DryRun) would see
 // DryRun=false on re-parsed files and ignore the contract.
-func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS) {
+func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS, cfg *config.Config, path string) {
 	parsed.FS = dirFS
 	parsed.RootFS = lf.RootFS
 	parsed.RootDir = lf.RootDir
@@ -603,14 +611,18 @@ func hydrateLintFile(parsed *lint.File, lf *lint.File, dirFS fs.FS) {
 	parsed.DryRun = lf.DryRun
 	parsed.GitignoreFunc = lf.GitignoreFunc
 	parsed.GeneratedRanges = gensection.FindAllGeneratedRanges(parsed)
+	// Extend the exclusion set with foreign-region spans so fixable
+	// rules skip a marker pair another generator owns, exactly as the
+	// pre-fix lf did (see fixFile).
+	foreignregion.AppendRanges(parsed, cfg, path)
 }
 
 // buildPostFixFile parses post-fix bytes and hydrates them with the
 // per-file context from lf so the post-fix CheckRules call sees the
 // same lint.File the runner would.
-func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS) *lint.File {
+func buildPostFixFile(path string, source []byte, lf *lint.File, dirFS fs.FS, cfg *config.Config) *lint.File {
 	finalFile, _ := lint.NewFile(path, source) // NewFile never errors with current implementation
-	hydrateLintFile(finalFile, lf, dirFS)
+	hydrateLintFile(finalFile, lf, dirFS, cfg, path)
 	return finalFile
 }
 
@@ -629,7 +641,7 @@ func (f *Fixer) applyFixPasses(
 				*errs = append(*errs, fmt.Errorf("parsing %q: %w", path, err))
 				break
 			}
-			hydrateLintFile(parsedFile, lf, dirFS)
+			hydrateLintFile(parsedFile, lf, dirFS, f.Config, path)
 
 			diags := fr.Check(parsedFile)
 			if len(diags) == 0 {

--- a/internal/fix/fix_foreign_region_test.go
+++ b/internal/fix/fix_foreign_region_test.go
@@ -1,0 +1,146 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/foreignregion"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rule"
+	"github.com/jeduden/mdsmith/internal/rules/maxfilelength"
+	"github.com/jeduden/mdsmith/internal/rules/notrailingspaces"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const apmStart = "<!-- apm:start -->"
+const apmEnd = "<!-- apm:end -->"
+
+func apmConfig(rules map[string]config.RuleCfg) *config.Config {
+	return &config.Config{
+		Rules: rules,
+		ForeignRegions: []config.ForeignRegion{
+			{Start: apmStart, End: apmEnd},
+		},
+	}
+}
+
+// TestFix_ForeignRegionBytesUnchanged proves the fix pipeline leaves the
+// bytes between a declared marker pair untouched — including the
+// otherwise-fixable trailing spaces inside — while still trimming the
+// trailing spaces outside the region.
+func TestFix_ForeignRegionBytesUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	src := "# Title\n\noutside line   \n\n" +
+		apmStart + "\ninside line   \n" + apmEnd + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	fixer := &Fixer{
+		Config: apmConfig(map[string]config.RuleCfg{
+			"no-trailing-spaces": {Enabled: true},
+		}),
+		Rules: []rule.Rule{&notrailingspaces.Rule{}},
+	}
+
+	result := fixer.Fix([]string{path})
+	require.Empty(t, result.Errors, "unexpected errors: %v", result.Errors)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	want := "# Title\n\noutside line\n\n" +
+		apmStart + "\ninside line   \n" + apmEnd + "\n"
+	assert.Equal(t, want, string(got),
+		"trailing spaces outside the region must be trimmed; inside must be preserved verbatim")
+}
+
+// TestFix_ForeignRegionSuppressesDiagnostics proves a style-rule
+// violation inside the region emits no diagnostic while the same
+// violation outside it still does.
+func TestFix_ForeignRegionSuppressesDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	// Only an inside violation: after fixing the outside (none here),
+	// the post-fix check must report nothing from inside the region.
+	src := "# Title\n\n" + apmStart + "\ninside line   \n" + apmEnd + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	fixer := &Fixer{
+		Config: apmConfig(map[string]config.RuleCfg{
+			"no-trailing-spaces": {Enabled: true},
+		}),
+		Rules: []rule.Rule{&notrailingspaces.Rule{}},
+	}
+	result := fixer.Fix([]string{path})
+	require.Empty(t, result.Errors)
+	for _, d := range result.Diagnostics {
+		if d.RuleName == "no-trailing-spaces" {
+			t.Errorf("trailing-spaces diagnostic surfaced from inside foreign region: line %d", d.Line)
+		}
+	}
+	assert.Zero(t, result.Failures,
+		"pre-fix Failures must exclude the in-region trailing-space violation")
+}
+
+// TestFix_ForeignRegionWholeFileRulesStillCount proves MDS022 counts the
+// bytes inside the region toward file length.
+func TestFix_ForeignRegionWholeFileRulesStillCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	// 3 lines outside + a 4-line region = 7 content lines. Set max to 5
+	// so the file is over budget only because the region's lines count.
+	src := "# Title\n\nbody\n" + apmStart + "\na\nb\n" + apmEnd + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	maxRule := &maxfilelength.Rule{Max: 5}
+	fixer := &Fixer{
+		Config: apmConfig(map[string]config.RuleCfg{
+			"max-file-length": {Enabled: true},
+		}),
+		Rules: []rule.Rule{maxRule},
+	}
+	result := fixer.Fix([]string{path})
+	require.Empty(t, result.Errors)
+
+	found := false
+	for _, d := range result.Diagnostics {
+		if d.RuleID == "MDS022" {
+			found = true
+		}
+	}
+	assert.True(t, found,
+		"MDS022 must still fire — the region's lines count toward file length")
+}
+
+// TestFix_ForeignRegionMalformedDiagnostic proves a start marker with no
+// matching end produces an MDS073 diagnostic.
+func TestFix_ForeignRegionMalformedDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	src := "# Title\n\n" + apmStart + "\ndangling body\n"
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	fixer := &Fixer{
+		Config: apmConfig(map[string]config.RuleCfg{
+			"no-trailing-spaces": {Enabled: true},
+		}),
+		Rules: []rule.Rule{&notrailingspaces.Rule{}},
+	}
+	result := fixer.Fix([]string{path})
+	require.Empty(t, result.Errors)
+
+	found := false
+	for _, d := range result.Diagnostics {
+		if d.RuleID == foreignregion.RuleID {
+			found = true
+			assert.Contains(t, d.Message, "no matching end")
+			assert.Equal(t, 3, d.Line)
+		}
+	}
+	assert.True(t, found, "expected a malformed foreign-region diagnostic (MDS073)")
+}
+
+var _ = lint.File{}

--- a/internal/foreignregion/apply_test.go
+++ b/internal/foreignregion/apply_test.go
@@ -1,0 +1,72 @@
+package foreignregion
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func apmCfg() *config.Config {
+	return &config.Config{ForeignRegions: []config.ForeignRegion{apm}}
+}
+
+// TestScanNilFile returns nothing for a nil *File rather than panicking.
+func TestScanNilFile(t *testing.T) {
+	ranges, diags := Scan(nil, []config.ForeignRegion{apm})
+	assert.Nil(t, ranges)
+	assert.Nil(t, diags)
+}
+
+// TestApplyExtendsRangesAndReturnsDiags appends the matched-pair spans to
+// f.GeneratedRanges and returns the malformed-region diagnostics.
+func TestApplyExtendsRangesAndReturnsDiags(t *testing.T) {
+	// A matched pair plus a trailing unmatched start (malformed).
+	src := "<!-- apm:start -->\nbody\n<!-- apm:end -->\n<!-- apm:start -->\ndangling\n"
+	f := newFile(t, src)
+	diags := Apply(f, apmCfg(), "test.md")
+	require.Len(t, f.GeneratedRanges, 1)
+	assert.Equal(t, lint.LineRange{From: 1, To: 3}, f.GeneratedRanges[0])
+	require.Len(t, diags, 1)
+	assert.Equal(t, "test.md", diags[0].File)
+	assert.Contains(t, diags[0].Message, "no matching end")
+}
+
+// TestApplyNoRegions leaves GeneratedRanges untouched and returns no
+// diagnostics when the config declares no marker pairs.
+func TestApplyNoRegions(t *testing.T) {
+	f := newFile(t, "# Title\n\nbody\n")
+	diags := Apply(f, &config.Config{}, "test.md")
+	assert.Empty(t, f.GeneratedRanges)
+	assert.Nil(t, diags)
+}
+
+// TestAppendRangesPopulatesWithoutDiags extends the exclusion set but
+// discards the malformed diagnostics (the read-only RunSource path).
+func TestAppendRangesPopulatesWithoutDiags(t *testing.T) {
+	src := "<!-- apm:start -->\nbody\n<!-- apm:end -->\n"
+	f := newFile(t, src)
+	AppendRanges(f, apmCfg(), "test.md")
+	require.Len(t, f.GeneratedRanges, 1)
+	assert.Equal(t, lint.LineRange{From: 1, To: 3}, f.GeneratedRanges[0])
+}
+
+// TestDiagnosticsReturnsWithoutMutating rebuilds the malformed diagnostics
+// without touching f.GeneratedRanges.
+func TestDiagnosticsReturnsWithoutMutating(t *testing.T) {
+	src := "<!-- apm:end -->\n"
+	f := newFile(t, src)
+	diags := Diagnostics(f, apmCfg(), "test.md")
+	assert.Empty(t, f.GeneratedRanges)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "without a matching start")
+	assert.Equal(t, "test.md", diags[0].File)
+}
+
+// TestDiagnosticsNoRegions returns nil when no marker pairs apply.
+func TestDiagnosticsNoRegions(t *testing.T) {
+	f := newFile(t, "# Title\n")
+	assert.Nil(t, Diagnostics(f, &config.Config{}, "test.md"))
+}

--- a/internal/foreignregion/restore.go
+++ b/internal/foreignregion/restore.go
@@ -27,19 +27,24 @@ func Restore(original, fixed []byte, regions []config.ForeignRegion) []byte {
 		if len(origSpans) == 0 || len(origSpans) != len(fixedSpans) {
 			continue
 		}
-		// Replace from the last span to the first so each splice leaves
-		// the earlier spans' byte offsets valid.
-		for i := len(fixedSpans) - 1; i >= 0; i-- {
-			origText := original[origSpans[i].start:origSpans[i].end]
-			fs := fixedSpans[i]
-			out := make([]byte, 0, len(fixed)-(fs.end-fs.start)+len(origText))
-			out = append(out, fixed[:fs.start]...)
-			out = append(out, origText...)
-			out = append(out, fixed[fs.end:]...)
-			fixed = out
-		}
+		fixed = spliceSpans(original, fixed, origSpans, fixedSpans)
 	}
 	return fixed
+}
+
+// spliceSpans rebuilds fixed in one pass, replacing each fixed span with
+// the corresponding original span's bytes. Spans are in document order,
+// so a single forward walk suffices — one allocation instead of the
+// per-span full-buffer rebuild a reverse splice would cost.
+func spliceSpans(original, fixed []byte, origSpans, fixedSpans []byteSpan) []byte {
+	out := make([]byte, 0, len(fixed))
+	prev := 0
+	for i, fs := range fixedSpans {
+		out = append(out, fixed[prev:fs.start]...)
+		out = append(out, original[origSpans[i].start:origSpans[i].end]...)
+		prev = fs.end
+	}
+	return append(out, fixed[prev:]...)
 }
 
 // byteSpan is a half-open [start, end) byte range within a buffer.

--- a/internal/foreignregion/restore.go
+++ b/internal/foreignregion/restore.go
@@ -1,0 +1,84 @@
+package foreignregion
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/config"
+)
+
+// Restore overwrites, in fixed, the bytes of every foreign region with
+// the corresponding bytes from original, so no fixer's edit inside a
+// marker pair survives. Not every fixer consults lint.File.GeneratedRanges
+// (trailing-space trimming and blank-line collapsing, for instance, do
+// not), so appending the region spans to that set is not enough on its
+// own — this byte-level restore is the hard guarantee that a declared
+// region is opaque to the whole fix pipeline.
+//
+// Regions are located in both buffers by a matched-pair marker scan and
+// paired in document order. When a marker type yields a different count
+// of matched pairs in the two buffers — a fixer added or removed a
+// marker line — that type is left untouched, since the pairing would be
+// ambiguous. Returns fixed unchanged when no marker pairs apply.
+func Restore(original, fixed []byte, regions []config.ForeignRegion) []byte {
+	for _, reg := range regions {
+		origSpans := matchedRegionSpans(original, reg)
+		fixedSpans := matchedRegionSpans(fixed, reg)
+		if len(origSpans) == 0 || len(origSpans) != len(fixedSpans) {
+			continue
+		}
+		// Replace from the last span to the first so each splice leaves
+		// the earlier spans' byte offsets valid.
+		for i := len(fixedSpans) - 1; i >= 0; i-- {
+			origText := original[origSpans[i].start:origSpans[i].end]
+			fs := fixedSpans[i]
+			out := make([]byte, 0, len(fixed)-(fs.end-fs.start)+len(origText))
+			out = append(out, fixed[:fs.start]...)
+			out = append(out, origText...)
+			out = append(out, fixed[fs.end:]...)
+			fixed = out
+		}
+	}
+	return fixed
+}
+
+// byteSpan is a half-open [start, end) byte range within a buffer.
+type byteSpan struct {
+	start int
+	end   int
+}
+
+// matchedRegionSpans returns one byte span per well-formed marker pair
+// in src for reg — from the first byte of the start-marker line through
+// the last byte of the end-marker line (excluding that line's trailing
+// newline). Unmatched or orphaned markers contribute no span, matching
+// Scan's range set.
+func matchedRegionSpans(src []byte, reg config.ForeignRegion) []byteSpan {
+	start := strings.TrimSpace(reg.Start)
+	end := strings.TrimSpace(reg.End)
+	var spans []byteSpan
+	openStart := -1
+	lineStart := 0
+	n := len(src)
+	for lineStart <= n {
+		lineEnd := n
+		next := n + 1
+		if rel := bytes.IndexByte(src[lineStart:], '\n'); rel >= 0 {
+			lineEnd = lineStart + rel
+			next = lineEnd + 1
+		}
+		switch strings.TrimSpace(string(src[lineStart:lineEnd])) {
+		case start:
+			if openStart < 0 {
+				openStart = lineStart
+			}
+		case end:
+			if openStart >= 0 {
+				spans = append(spans, byteSpan{start: openStart, end: lineEnd})
+				openStart = -1
+			}
+		}
+		lineStart = next
+	}
+	return spans
+}

--- a/internal/foreignregion/restore_test.go
+++ b/internal/foreignregion/restore_test.go
@@ -1,0 +1,44 @@
+package foreignregion
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRestorePreservesInteriorBytes puts the original in-region bytes
+// back over a fixer's edit while keeping the out-of-region edit.
+func TestRestorePreservesInteriorBytes(t *testing.T) {
+	original := "# T\n\nout   \n" + apm.Start + "\nin   \n" + apm.End + "\n"
+	// Simulate a fixer that trimmed trailing spaces everywhere.
+	fixed := "# T\n\nout\n" + apm.Start + "\nin\n" + apm.End + "\n"
+	got := Restore([]byte(original), []byte(fixed), []config.ForeignRegion{apm})
+	want := "# T\n\nout\n" + apm.Start + "\nin   \n" + apm.End + "\n"
+	assert.Equal(t, want, string(got))
+}
+
+// TestRestoreNoRegions returns the fixed bytes untouched.
+func TestRestoreNoRegions(t *testing.T) {
+	fixed := "# T\n\nbody\n"
+	got := Restore([]byte("# T\n\nbody   \n"), []byte(fixed), []config.ForeignRegion{apm})
+	assert.Equal(t, fixed, string(got))
+}
+
+// TestRestoreCountMismatchLeavesFixed leaves the fixed bytes alone when
+// the region counts differ between the two buffers (ambiguous pairing).
+func TestRestoreCountMismatchLeavesFixed(t *testing.T) {
+	original := apm.Start + "\nin\n" + apm.End + "\n"
+	fixed := "no markers at all\n"
+	got := Restore([]byte(original), []byte(fixed), []config.ForeignRegion{apm})
+	assert.Equal(t, fixed, string(got))
+}
+
+// TestRestoreMultipleRegions restores each matched pair independently.
+func TestRestoreMultipleRegions(t *testing.T) {
+	s, e := apm.Start, apm.End
+	original := s + "\nA   \n" + e + "\nmid\n" + s + "\nB   \n" + e + "\n"
+	fixed := s + "\nA\n" + e + "\nmid\n" + s + "\nB\n" + e + "\n"
+	got := Restore([]byte(original), []byte(fixed), []config.ForeignRegion{apm})
+	assert.Equal(t, original, string(got))
+}

--- a/internal/foreignregion/restore_test.go
+++ b/internal/foreignregion/restore_test.go
@@ -42,3 +42,15 @@ func TestRestoreMultipleRegions(t *testing.T) {
 	got := Restore([]byte(original), []byte(fixed), []config.ForeignRegion{apm})
 	assert.Equal(t, original, string(got))
 }
+
+// TestRestoreDuplicateStartProtectsFirstSpan mirrors Scan's duplicate-start
+// pairing on the byte path: the first start pairs with the following end, so
+// a fixer's edit inside that span is restored even though the region is
+// malformed (a second start opened before it closed).
+func TestRestoreDuplicateStartProtectsFirstSpan(t *testing.T) {
+	s, e := apm.Start, apm.End
+	original := s + "\nA   \n" + s + "\nB   \n" + e + "\n"
+	fixed := s + "\nA\n" + s + "\nB\n" + e + "\n"
+	got := Restore([]byte(original), []byte(fixed), []config.ForeignRegion{apm})
+	assert.Equal(t, original, string(got))
+}

--- a/internal/foreignregion/scan.go
+++ b/internal/foreignregion/scan.go
@@ -45,6 +45,55 @@ func Scan(f *lint.File, regions []config.ForeignRegion) ([]lint.LineRange, []lin
 	return ranges, diags
 }
 
+// Apply appends the foreign-region spans for path to f.GeneratedRanges —
+// the same exclusion set that keeps style rules and fixers out of
+// `<?include?>` / `<?catalog?>` bodies — and returns the malformed-region
+// diagnostics with File and the file's front-matter line offset already
+// applied, ready to append to the file's diagnostic set after the rule
+// check has run. It is the single-scan entry point for the pooled check
+// and fix paths, where f is local to one goroutine. Returns nil when no
+// marker pairs apply to path.
+func Apply(f *lint.File, cfg *config.Config, path string) []lint.Diagnostic {
+	ranges, diags := resolve(f, cfg, path)
+	f.GeneratedRanges = append(f.GeneratedRanges, ranges...)
+	return diags
+}
+
+// AppendRanges appends the foreign-region spans for path to
+// f.GeneratedRanges and discards the malformed diagnostics. The
+// RunSource (LSP) path uses it to populate the exclusion set once,
+// before f is published to the parse cache, so the diagnostic pass can
+// stay read-only on the shared *File (see Diagnostics).
+func AppendRanges(f *lint.File, cfg *config.Config, path string) {
+	ranges, _ := resolve(f, cfg, path)
+	f.GeneratedRanges = append(f.GeneratedRanges, ranges...)
+}
+
+// Diagnostics returns the malformed-region diagnostics for path without
+// mutating f. The RunSource path calls it during the check pass, whose
+// contract forbids writing to the cached *File; AppendRanges has already
+// set the ranges, so re-scanning here only rebuilds the diagnostics.
+func Diagnostics(f *lint.File, cfg *config.Config, path string) []lint.Diagnostic {
+	_, diags := resolve(f, cfg, path)
+	return diags
+}
+
+// resolve scans f for the marker pairs that apply to path and returns
+// their ranges plus the malformed diagnostics, with each diagnostic's
+// File set and Line shifted into display coordinates by f.LineOffset.
+func resolve(f *lint.File, cfg *config.Config, path string) ([]lint.LineRange, []lint.Diagnostic) {
+	regions := config.EffectiveForeignRegions(cfg, path)
+	if len(regions) == 0 {
+		return nil, nil
+	}
+	ranges, diags := Scan(f, regions)
+	for i := range diags {
+		diags[i].File = path
+		diags[i].Line += f.LineOffset
+	}
+	return ranges, diags
+}
+
 // scanOne walks f.Lines once for a single marker pair, matching a line
 // against a marker by trimmed-line equality so leading indentation does
 // not defeat the match while incidental in-prose mentions do not.

--- a/internal/foreignregion/scan.go
+++ b/internal/foreignregion/scan.go
@@ -1,0 +1,99 @@
+// Package foreignregion locates the line spans a foreign generator owns
+// inside a Markdown file — the bytes bounded by a declared marker pair
+// such as APM's `<!-- apm:start -->` / `<!-- apm:end -->`. The fix
+// pipeline feeds the returned spans into lint.File.GeneratedRanges so
+// style rules skip diagnostics there and fixers never rewrite the bytes,
+// exactly as it already does for `<?include?>` / `<?catalog?>` bodies.
+// Whole-file rules (MDS022, MDS028) read the raw source, so they keep
+// counting the protected bytes.
+package foreignregion
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// RuleID and RuleName identify the malformed-region diagnostic. It is
+// not a registered rule.Rule: the spans are computed in the fix/check
+// pipeline (like generated-section ranges), so the malformed check
+// rides along there rather than through the per-rule engine.
+const (
+	RuleID   = "MDS073"
+	RuleName = "foreign-region"
+)
+
+// Scan locates every matched marker pair in f for each declared region
+// and returns their inclusive line ranges (start marker line through end
+// marker line, in f.Lines coordinates) plus a diagnostic for each
+// malformed region — a start with no matching end, an end with no
+// matching start, or a second start opening before the first closes.
+// Both slices are nil when regions is empty.
+func Scan(f *lint.File, regions []config.ForeignRegion) ([]lint.LineRange, []lint.Diagnostic) {
+	if len(regions) == 0 || f == nil {
+		return nil, nil
+	}
+	var ranges []lint.LineRange
+	var diags []lint.Diagnostic
+	for _, reg := range regions {
+		rs, ds := scanOne(f, reg)
+		ranges = append(ranges, rs...)
+		diags = append(diags, ds...)
+	}
+	return ranges, diags
+}
+
+// scanOne walks f.Lines once for a single marker pair, matching a line
+// against a marker by trimmed-line equality so leading indentation does
+// not defeat the match while incidental in-prose mentions do not.
+func scanOne(f *lint.File, reg config.ForeignRegion) ([]lint.LineRange, []lint.Diagnostic) {
+	start := strings.TrimSpace(reg.Start)
+	end := strings.TrimSpace(reg.End)
+	var ranges []lint.LineRange
+	var diags []lint.Diagnostic
+	openLine := 0 // 1-based line of the current unclosed start; 0 when none
+	for i, line := range f.Lines {
+		lineNum := i + 1
+		trimmed := strings.TrimSpace(string(line))
+		switch trimmed {
+		case start:
+			if openLine != 0 {
+				diags = append(diags, diag(lineNum, fmt.Sprintf(
+					"duplicate foreign-region start marker %q before %q closed the open region",
+					start, end)))
+				continue
+			}
+			openLine = lineNum
+		case end:
+			if openLine == 0 {
+				diags = append(diags, diag(lineNum, fmt.Sprintf(
+					"foreign-region end marker %q without a matching start marker %q",
+					end, start)))
+				continue
+			}
+			ranges = append(ranges, lint.LineRange{From: openLine, To: lineNum})
+			openLine = 0
+		}
+	}
+	if openLine != 0 {
+		diags = append(diags, diag(openLine, fmt.Sprintf(
+			"foreign-region start marker %q has no matching end marker %q",
+			start, end)))
+	}
+	return ranges, diags
+}
+
+// diag builds one malformed-region diagnostic at the given 1-based line
+// (in f.Lines coordinates; the caller adds any front-matter offset).
+func diag(line int, msg string) lint.Diagnostic {
+	return lint.Diagnostic{
+		RuleID:   RuleID,
+		RuleName: RuleName,
+		Severity: lint.Warning,
+		Message:  msg,
+		Line:     line,
+		Column:   1,
+	}
+}

--- a/internal/foreignregion/scan_test.go
+++ b/internal/foreignregion/scan_test.go
@@ -65,14 +65,20 @@ func TestScanOrphanedEnd(t *testing.T) {
 }
 
 // TestScanDuplicateStart reports a diagnostic when a second start marker
-// opens before the first region closes.
+// opens before the first region closes, and still pairs the first start
+// with the following end so that span stays protected (the duplicate
+// marker only draws the diagnostic).
 func TestScanDuplicateStart(t *testing.T) {
 	src := "<!-- apm:start -->\na\n<!-- apm:start -->\nb\n<!-- apm:end -->\n"
 	f := newFile(t, src)
-	_, diags := Scan(f, []config.ForeignRegion{apm})
-	require.NotEmpty(t, diags)
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message, "duplicate")
 	assert.Equal(t, 3, diags[0].Line)
+	// The first start (line 1) still pairs with the end (line 5): the
+	// span is protected even though the region is flagged malformed.
+	require.Len(t, ranges, 1)
+	assert.Equal(t, lint.LineRange{From: 1, To: 5}, ranges[0])
 }
 
 // TestScanMultiplePairs returns a range for each independent matched

--- a/internal/foreignregion/scan_test.go
+++ b/internal/foreignregion/scan_test.go
@@ -1,0 +1,99 @@
+package foreignregion
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newFile(t *testing.T, src string) *lint.File {
+	t.Helper()
+	f, err := lint.NewFile("test.md", []byte(src))
+	require.NoError(t, err)
+	return f
+}
+
+var apm = config.ForeignRegion{Start: "<!-- apm:start -->", End: "<!-- apm:end -->"}
+
+// TestScanNoMarkers returns no ranges and no diagnostics when the file
+// holds neither marker.
+func TestScanNoMarkers(t *testing.T) {
+	f := newFile(t, "# Title\n\nplain body\n")
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	assert.Empty(t, ranges)
+	assert.Empty(t, diags)
+}
+
+// TestScanMatchedPair returns one inclusive range spanning the start
+// marker line through the end marker line.
+func TestScanMatchedPair(t *testing.T) {
+	src := "# Title\n\n<!-- apm:start -->\nowned\ncontent\n<!-- apm:end -->\n\ntail\n"
+	f := newFile(t, src)
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	require.Empty(t, diags)
+	require.Len(t, ranges, 1)
+	// Lines: 1 "# Title", 3 start, 6 end.
+	assert.Equal(t, lint.LineRange{From: 3, To: 6}, ranges[0])
+}
+
+// TestScanUnmatchedStart reports a diagnostic on the start line when no
+// end marker follows.
+func TestScanUnmatchedStart(t *testing.T) {
+	src := "# Title\n\n<!-- apm:start -->\nowned\n"
+	f := newFile(t, src)
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	assert.Empty(t, ranges)
+	require.Len(t, diags, 1)
+	assert.Equal(t, 3, diags[0].Line)
+	assert.Equal(t, RuleID, diags[0].RuleID)
+	assert.Contains(t, diags[0].Message, "no matching end")
+}
+
+// TestScanOrphanedEnd reports a diagnostic when an end marker appears
+// without a preceding start.
+func TestScanOrphanedEnd(t *testing.T) {
+	src := "# Title\n\n<!-- apm:end -->\n"
+	f := newFile(t, src)
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	assert.Empty(t, ranges)
+	require.Len(t, diags, 1)
+	assert.Equal(t, 3, diags[0].Line)
+	assert.Contains(t, diags[0].Message, "without a matching start")
+}
+
+// TestScanDuplicateStart reports a diagnostic when a second start marker
+// opens before the first region closes.
+func TestScanDuplicateStart(t *testing.T) {
+	src := "<!-- apm:start -->\na\n<!-- apm:start -->\nb\n<!-- apm:end -->\n"
+	f := newFile(t, src)
+	_, diags := Scan(f, []config.ForeignRegion{apm})
+	require.NotEmpty(t, diags)
+	assert.Contains(t, diags[0].Message, "duplicate")
+	assert.Equal(t, 3, diags[0].Line)
+}
+
+// TestScanMultiplePairs returns a range for each independent matched
+// pair of the same marker type.
+func TestScanMultiplePairs(t *testing.T) {
+	src := "<!-- apm:start -->\na\n<!-- apm:end -->\n\n<!-- apm:start -->\nb\n<!-- apm:end -->\n"
+	f := newFile(t, src)
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	require.Empty(t, diags)
+	require.Len(t, ranges, 2)
+	assert.Equal(t, lint.LineRange{From: 1, To: 3}, ranges[0])
+	assert.Equal(t, lint.LineRange{From: 5, To: 7}, ranges[1])
+}
+
+// TestScanIndentedMarkerMatches matches a marker even when the line is
+// indented, since markers are compared against the trimmed line.
+func TestScanIndentedMarkerMatches(t *testing.T) {
+	src := "  <!-- apm:start -->\nx\n  <!-- apm:end -->\n"
+	f := newFile(t, src)
+	ranges, diags := Scan(f, []config.ForeignRegion{apm})
+	require.Empty(t, diags)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, lint.LineRange{From: 1, To: 3}, ranges[0])
+}

--- a/plan/2607082049_foreign-managed-regions.md
+++ b/plan/2607082049_foreign-managed-regions.md
@@ -1,7 +1,7 @@
 ---
 id: 2607082049
 title: "Foreign managed-region protection for `mdsmith fix`"
-status: "🔲"
+status: "🔳"
 model: opus
 summary: >-
   Add a `foreign-regions:` config listing `{start, end}` marker

--- a/plan/2607082049_foreign-managed-regions.md
+++ b/plan/2607082049_foreign-managed-regions.md
@@ -1,7 +1,7 @@
 ---
 id: 2607082049
 title: "Foreign managed-region protection for `mdsmith fix`"
-status: "🔳"
+status: "✅"
 model: opus
 summary: >-
   Add a `foreign-regions:` config listing `{start, end}` marker
@@ -87,20 +87,20 @@ metrics still count those bytes.
 
 ## Acceptance Criteria
 
-- [ ] `mdsmith fix` leaves bytes between a declared
+- [x] `mdsmith fix` leaves bytes between a declared
       `{start, end}` pair unchanged, including
       otherwise-fixable trailing spaces and table
       misalignment.
-- [ ] A style-rule violation inside the region emits
+- [x] A style-rule violation inside the region emits
       no diagnostic; the same violation outside it
       still does.
-- [ ] MDS022 and MDS028 still count the region's
+- [x] MDS022 and MDS028 still count the region's
       bytes toward file length and token budget.
-- [ ] A start marker with no matching end marker
+- [x] A start marker with no matching end marker
       produces a diagnostic.
-- [ ] The region config is glob-scopable via
+- [x] The region config is glob-scopable via
       `overrides:`.
-- [ ] All tests pass: `go test ./...`
-- [ ] `go tool -modfile=tools/go.mod golangci-lint
+- [x] All tests pass: `go test ./...`
+- [x] `go tool -modfile=tools/go.mod golangci-lint
       run` reports no issues.
-- [ ] `mdsmith check .` — 0 failures.
+- [x] `mdsmith check .` — 0 failures.


### PR DESCRIPTION
Implements plan `2607082049_foreign-managed-regions`.

## What

Adds a top-level `foreign-regions:` config key listing `{start, end}` marker pairs (e.g. APM's `<!-- apm:start -->` / `<!-- apm:end -->`) whose spanned bytes mdsmith treats as opaque:

- **Style/content rules skip diagnostics** inside a matched region (the spans are appended to `lint.File.GeneratedRanges`, reusing the generated-section exclusion path).
- **`mdsmith fix` never rewrites the bytes** — a byte-level `Restore` step in the fix pipeline puts the original in-region bytes back after fixing, so even fixers that ignore `GeneratedRanges` (trailing-space trimming, blank-line collapsing) can't touch a region.
- **Whole-file rules (MDS022, MDS028) still count the bytes** — they read raw source, so the region is opaque to editing but not invisible to size accounting.
- **Glob-scopable via `overrides:`** — an override's `foreign-regions:` list appends to the top-level list for matching files.
- **Malformed regions report `MDS073`** — a start with no matching end, an orphaned end, or a duplicate start.

## How

- `internal/config`: `ForeignRegion` type + `foreign-regions:` on `Config` and `Override`; `EffectiveForeignRegions` resolver; validation (non-empty, distinct markers).
- `internal/foreignregion` (new): line scanner (`Scan`), pipeline helpers (`Apply`, `AppendRanges`, `Diagnostics`), and the byte-level `Restore`.
- Wired into the check path (`engine.Runner.lintFile`, `RunSource`) and the fix path (`fix.Fixer.fixFile`, `hydrateLintFile`, post-fix restore).
- Reference doc at `docs/reference/foreign-regions.md`.

## Tests

- Config parse/validation/override-scoping unit tests.
- Scanner unit tests (zero markers, matched pair, unmatched start, orphaned end, duplicate start, multiple pairs, indented markers).
- `Restore` unit tests (interior preserved, count-mismatch left alone, multiple regions).
- Fix-pipeline integration tests: bytes unchanged, diagnostics suppressed, MDS022 still counts, MDS073 malformed.

`go test ./...`, `golangci-lint run`, and `mdsmith check .` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwKxDxhjkTQPPkBrNhsrNG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwKxDxhjkTQPPkBrNhsrNG)_