### PR TITLE
fix(merge-driver): scope ignore-derived -merge lines to Markdown (#750)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,14 +4,23 @@
 # BEGIN mdsmith merge-driver
 *.md merge=mdsmith
 *.markdown merge=mdsmith
-.git/** -merge
-demo/** -merge
-internal/rules/*/bad/** -merge
+.git/**/*.md -merge
+.git/**/*.markdown -merge
+demo/**/*.md -merge
+demo/**/*.markdown -merge
+internal/rules/*/bad/**/*.md -merge
+internal/rules/*/bad/**/*.markdown -merge
 internal/rules/*/bad.md -merge
-internal/rules/*/good/** -merge
-internal/rules/*/fixed/** -merge
-internal/rules/*/pattern/** -merge
-.claude/worktrees/** -merge
-editors/**/node_modules/** -merge
-editors/**/dist/** -merge
+internal/rules/*/good/**/*.md -merge
+internal/rules/*/good/**/*.markdown -merge
+internal/rules/*/fixed/**/*.md -merge
+internal/rules/*/fixed/**/*.markdown -merge
+internal/rules/*/pattern/**/*.md -merge
+internal/rules/*/pattern/**/*.markdown -merge
+.claude/worktrees/**/*.md -merge
+.claude/worktrees/**/*.markdown -merge
+editors/**/node_modules/**/*.md -merge
+editors/**/node_modules/**/*.markdown -merge
+editors/**/dist/**/*.md -merge
+editors/**/dist/**/*.markdown -merge
 # END mdsmith merge-driver

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,23 +4,14 @@
 # BEGIN mdsmith merge-driver
 *.md merge=mdsmith
 *.markdown merge=mdsmith
-.git/**/*.md -merge
-.git/**/*.markdown -merge
-demo/**/*.md -merge
-demo/**/*.markdown -merge
-internal/rules/*/bad/**/*.md -merge
-internal/rules/*/bad/**/*.markdown -merge
+.git/** -merge
+demo/** -merge
+internal/rules/*/bad/** -merge
 internal/rules/*/bad.md -merge
-internal/rules/*/good/**/*.md -merge
-internal/rules/*/good/**/*.markdown -merge
-internal/rules/*/fixed/**/*.md -merge
-internal/rules/*/fixed/**/*.markdown -merge
-internal/rules/*/pattern/**/*.md -merge
-internal/rules/*/pattern/**/*.markdown -merge
-.claude/worktrees/**/*.md -merge
-.claude/worktrees/**/*.markdown -merge
-editors/**/node_modules/**/*.md -merge
-editors/**/node_modules/**/*.markdown -merge
-editors/**/dist/**/*.md -merge
-editors/**/dist/**/*.markdown -merge
+internal/rules/*/good/** -merge
+internal/rules/*/fixed/** -merge
+internal/rules/*/pattern/** -merge
+.claude/worktrees/** -merge
+editors/**/node_modules/** -merge
+editors/**/dist/** -merge
 # END mdsmith merge-driver

--- a/cmd/mdsmith/mergedriver.go
+++ b/cmd/mdsmith/mergedriver.go
@@ -32,8 +32,13 @@ Subcommands:
         Register the merge driver in git config and ensure
         .gitattributes assigns it. The managed block uses globs
         derived from the project's .mdsmith.yml: include patterns
-        (default: *.md and *.markdown) followed by an exclude line
-        for each ignore pattern (last-match-wins overrides).
+        (default: *.md and *.markdown) followed by markdown-scoped
+        exclude lines for each ignore pattern (last-match-wins
+        overrides). Each ignore pattern is intersected with the
+        markdown include extensions, so an ignore of demo/** emits
+        demo/**/*.md -merge and demo/**/*.markdown -merge rather
+        than a bare demo/** -merge that would also disable git's
+        merge for non-markdown files in that tree.
 
         Optional positional args replace the default include set
         when callers want to scope the merge driver to a custom
@@ -466,16 +471,18 @@ func hasConflictMarkers(content []byte) bool {
 // resolveManagedGlobs returns the merge-driver glob set for an
 // install command. With no args, the default include set
 // (`*.md`, `*.markdown`) is used and the project's .mdsmith.yml
-// `ignore:` patterns become exclude overrides — patterns that
-// cannot appear verbatim in `.gitattributes` (whitespace, leading
-// `!`) are silently dropped by `GlobsFromConfig`. Explicit args
-// replace the include set so callers can scope the merge driver to
-// a custom pattern (e.g. `docs/**/*.md`); whitespace in any
-// caller-provided include is rejected up front because
-// .gitattributes splits attribute lines on whitespace and the bad
-// pattern would corrupt the managed block. The second return is
-// the process exit code: 0 on success, 2 on a user-facing error
-// (already printed to stderr).
+// `ignore:` patterns become markdown-scoped exclude overrides —
+// each pattern is intersected with the markdown include extensions
+// (see githooks.GlobsFromConfig) so a `-merge` line never disables
+// git's merge for non-markdown files. Patterns that cannot appear
+// verbatim in `.gitattributes` (whitespace, leading `!`) are
+// silently dropped by `GlobsFromConfig`. Explicit args replace the
+// include set so callers can scope the merge driver to a custom
+// pattern (e.g. `docs/**/*.md`); whitespace in any caller-provided
+// include is rejected up front because .gitattributes splits
+// attribute lines on whitespace and the bad pattern would corrupt
+// the managed block. The second return is the process exit code: 0
+// on success, 2 on a user-facing error (already printed to stderr).
 func resolveManagedGlobs(_ string, args []string) (githooks.Globs, int) {
 	cfg, _, err := loadConfig("")
 	if err != nil {

--- a/cmd/mdsmith/mergedriver_test.go
+++ b/cmd/mdsmith/mergedriver_test.go
@@ -318,8 +318,12 @@ func TestRunMergeDriverInstall_NoArgsWritesCanonicalGlobs(t *testing.T) {
 	content := string(attrs)
 	assert.Contains(t, content, "*.md merge=mdsmith")
 	assert.Contains(t, content, "*.markdown merge=mdsmith")
-	assert.Contains(t, content, "vendor/** -merge",
-		"ignore patterns from .mdsmith.yml must appear as -merge overrides")
+	assert.Contains(t, content, "vendor/**/*.md -merge",
+		"ignore patterns from .mdsmith.yml must appear as markdown-scoped -merge overrides")
+	assert.Contains(t, content, "vendor/**/*.markdown -merge",
+		"ignore patterns are scoped to every markdown include extension")
+	assert.NotContains(t, content, "vendor/** -merge",
+		"a bare -merge line would disable git's merge for non-markdown files (issue #750)")
 }
 
 // --- resolveInstalledBinary ---
@@ -773,8 +777,10 @@ func TestRunMergeDriverInstall_DropsAndWarnsForUnrepresentableIgnore(t *testing.
 	attrs, err := os.ReadFile(filepath.Join(dir, ".gitattributes"))
 	require.NoError(t, err)
 	content := string(attrs)
-	assert.Contains(t, content, "vendor/** -merge",
-		"representable ignore patterns survive")
+	assert.Contains(t, content, "vendor/**/*.md -merge",
+		"representable ignore patterns survive, scoped to markdown")
+	assert.Contains(t, content, "vendor/**/*.markdown -merge",
+		"representable ignore patterns survive, scoped to every markdown extension")
 	assert.NotContains(t, content, "with space.md",
 		"unrepresentable ignore patterns are dropped from the managed block")
 	assert.NotContains(t, content, "!negated.md",

--- a/docs/reference/cli/merge-driver.md
+++ b/docs/reference/cli/merge-driver.md
@@ -20,14 +20,23 @@ mdsmith merge-driver <subcommand> [args]
 ### `install [globs...]`
 
 Register the merge driver in `git config` and ensure
-`.gitattributes` assigns it. The managed block uses globs
-derived from `.mdsmith.yml`: include patterns (default
-`*.md` and `*.markdown`) followed by an `-merge` exclude
-line for each representable `ignore:` pattern (last-match
-wins). `ignore:` entries that cannot be expressed in
-`.gitattributes` — `!` negation patterns and patterns
-containing whitespace — are skipped, so the hook's scope
-may include files the merge driver isn't registered for.
+`.gitattributes` assigns it. The managed block is derived
+from `.mdsmith.yml`. It lists include patterns first
+(default `*.md` and `*.markdown`). Then it lists one
+`-merge` exclude line per representable `ignore:` pattern.
+Last match wins.
+
+Each `ignore:` pattern is scoped to the markdown include
+extensions. So `ignore: ["demo/**"]` emits
+`demo/**/*.md -merge` and `demo/**/*.markdown -merge`. A
+bare `demo/** -merge` is not used. It would also turn off
+git's 3-way merge for the source code in that tree.
+
+Some `ignore:` entries cannot be expressed in
+`.gitattributes`: `!` negation patterns and patterns with
+whitespace. Those are skipped. As a result, the hook's
+scope may include files the merge driver isn't registered
+for.
 
 Optional positional args replace the default include set
 when scoping to a custom pattern (e.g. `docs/**/*.md`).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/jeduden/mdsmith/internal/mdpath"
 )
 
 // ValidCategories lists the recognized rule category names.
@@ -22,8 +24,10 @@ var ValidCategories = []string{
 }
 
 // DefaultFiles is the built-in list of glob patterns used for file
-// discovery when no file arguments are given on the command line.
-var DefaultFiles = []string{"**/*.md", "**/*.markdown"}
+// discovery when no file arguments are given on the command line. It is
+// derived from the canonical Markdown extension set in mdpath so the
+// linter's default scope tracks that single source of truth.
+var DefaultFiles = mdpath.RecursiveGlobs()
 
 // UserConvention is a user-defined convention bundle declared either
 // inline under the top-level `conventions:` block in .mdsmith.yml or

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -219,12 +219,13 @@ func GlobsFromConfig(cfg *config.Config) (Globs, []string) {
 // leading dot) of each DefaultIncludes glob — ".md" and ".markdown".
 // Deriving them from DefaultIncludes keeps the exclude scoping in
 // GlobsFromConfig aligned with the include set it pairs with, so a
-// change to the include globs flows through to the excludes.
+// change to the include globs (say, adding "*.mdx") flows through to
+// the excludes automatically.
 func defaultMarkdownExtensions() []string {
 	inc := DefaultIncludes()
 	exts := make([]string, 0, len(inc))
 	for _, g := range inc {
-		exts = append(exts, strings.TrimPrefix(g, "*"))
+		exts = append(exts, filepath.Ext(g))
 	}
 	return exts
 }
@@ -241,6 +242,7 @@ func defaultMarkdownExtensions() []string {
 // path segment:
 //
 //   - `dir/**` -> `dir/**/*.md`, `dir/**/*.markdown` (recursive tree)
+//   - `dir/`   -> `dir/**/*.md`, `dir/**/*.markdown` (trailing slash)
 //   - `dir/*`  -> `dir/*.md`,    `dir/*.markdown`    (one level)
 //   - `dir`    -> `dir/**/*.md`, `dir/**/*.markdown` (name as a tree)
 //
@@ -254,20 +256,26 @@ func scopeExcludeToMarkdown(pattern string, exts []string) []string {
 		}
 	}
 	dir, last := splitLastSegment(pattern)
+	var base string
+	switch last {
+	case "**", "":
+		// Recursive tree (`dir/**`) or a bare directory with a trailing
+		// slash (`dir/`, where the final segment is empty): all Markdown
+		// under dir at any depth. Folding the empty segment in here also
+		// avoids the `dir//**` double slash the default branch would
+		// produce for a trailing-slash pattern.
+		base = dir + "**/*"
+	case "*":
+		// Single segment (`dir/*`): Markdown directly under dir.
+		base = dir + "*"
+	default:
+		// A plain directory name (or any other shape) is treated as a
+		// directory scope covering all Markdown beneath it.
+		base = pattern + "/**/*"
+	}
 	out := make([]string, 0, len(exts))
 	for _, ext := range exts {
-		switch last {
-		case "**":
-			// Recursive tree: all Markdown under dir at any depth.
-			out = append(out, dir+"**/*"+ext)
-		case "*":
-			// Single segment: Markdown directly under dir.
-			out = append(out, dir+"*"+ext)
-		default:
-			// A plain directory name (or any other shape) is treated
-			// as a directory scope covering all Markdown beneath it.
-			out = append(out, pattern+"/**/*"+ext)
-		}
+		out = append(out, base+ext)
 	}
 	return out
 }

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -216,6 +216,36 @@ func GlobsFromConfig(cfg *config.Config) (Globs, []string) {
 	return g, skipped
 }
 
+// LegacyGlobs renders cfg.Ignore the pre-#750 way: the default include
+// set plus each representable ignore pattern copied verbatim, without
+// markdown scoping (`demo/** -merge`). This is the managed block that a
+// mdsmith release from before the markdown-scoping change produces and
+// expects — including the pinned CI baseline that validates
+// .gitattributes in the merge queue via `merge-driver ci-install`.
+//
+// It exists only for the transition window (see
+// docs/development/adopt-new-directive-syntax.md): a change to the
+// managed-block format cannot reach main through the merge queue while
+// the queue is gated by a pinned binary that predates the format. So
+// the repository keeps its committed .gitattributes in this legacy form
+// — validated by TestRepoGitattributesInSyncWithConfig against this
+// render — while GlobsFromConfig renders the markdown-scoped form that
+// `install` now writes for users and that the repository itself adopts
+// once the feature ships in a release and the pin is bumped.
+func LegacyGlobs(cfg *config.Config) Globs {
+	g := Globs{Include: DefaultIncludes()}
+	if cfg == nil || len(cfg.Ignore) == 0 {
+		return g
+	}
+	g.Exclude = make([]string, 0, len(cfg.Ignore))
+	for _, p := range cfg.Ignore {
+		if isRepresentableGitattributesPattern(p) {
+			g.Exclude = append(g.Exclude, p)
+		}
+	}
+	return g
+}
+
 // scopeExcludeToMarkdown rewrites one .mdsmith.yml ignore pattern into
 // the .gitattributes exclude patterns that turn off the mdsmith merge
 // driver for the Markdown files the pattern grandfathers — and only

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -160,9 +160,25 @@ const configFileName = ".mdsmith.yml"
 
 // GlobsFromConfig returns the canonical merge-driver glob set for a
 // repository: every markdown extension is included, and the project's
-// .mdsmith.yml ignore patterns are translated as exclude patterns.
-// Last-match-wins in .gitattributes lets the excludes override the
-// broader markdown includes. cfg may be nil (no exclusions then).
+// .mdsmith.yml ignore patterns are translated into markdown-scoped
+// exclude patterns. Last-match-wins in .gitattributes lets the excludes
+// override the broader markdown includes. cfg may be nil (no exclusions
+// then).
+//
+// Each representable ignore pattern is intersected with the include
+// set's markdown extensions before it becomes an exclude line, so a
+// coarse directory ignore like `demo/**` emits
+//
+//	demo/**/*.md -merge
+//	demo/**/*.markdown -merge
+//
+// rather than a bare `demo/** -merge`. The `ignore:` list scopes the
+// markdown linter (files: is *.md / *.markdown), so an ignore pattern
+// is only ever meant to affect markdown; a bare `-merge` line, by
+// contrast, is not extension-scoped and would disable git's 3-way
+// merge for every file in the tree — including source code that
+// nobody asked to grandfather (issue #750). scopeExcludeToMarkdown
+// guarantees every emitted exclude ends in a markdown extension.
 //
 // Patterns that cannot be represented directly in .gitattributes
 // are dropped from the exclude set so MDS048's auto-fix never
@@ -186,16 +202,84 @@ func GlobsFromConfig(cfg *config.Config) (Globs, []string) {
 	if cfg == nil || len(cfg.Ignore) == 0 {
 		return g, nil
 	}
-	g.Exclude = make([]string, 0, len(cfg.Ignore))
+	exts := defaultMarkdownExtensions()
+	g.Exclude = make([]string, 0, len(cfg.Ignore)*len(exts))
 	var skipped []string
 	for _, p := range cfg.Ignore {
 		if !isRepresentableGitattributesPattern(p) {
 			skipped = append(skipped, p)
 			continue
 		}
-		g.Exclude = append(g.Exclude, p)
+		g.Exclude = append(g.Exclude, scopeExcludeToMarkdown(p, exts)...)
 	}
 	return g, skipped
+}
+
+// defaultMarkdownExtensions returns the extension suffix (including the
+// leading dot) of each DefaultIncludes glob — ".md" and ".markdown".
+// Deriving them from DefaultIncludes keeps the exclude scoping in
+// GlobsFromConfig aligned with the include set it pairs with, so a
+// change to the include globs flows through to the excludes.
+func defaultMarkdownExtensions() []string {
+	inc := DefaultIncludes()
+	exts := make([]string, 0, len(inc))
+	for _, g := range inc {
+		exts = append(exts, strings.TrimPrefix(g, "*"))
+	}
+	return exts
+}
+
+// scopeExcludeToMarkdown rewrites one .mdsmith.yml ignore pattern into
+// the .gitattributes exclude patterns that turn off the mdsmith merge
+// driver for the Markdown files the pattern grandfathers — and only
+// those files (issue #750).
+//
+// A pattern that already ends in one of exts targets a specific
+// Markdown extension, so its -merge line can only affect Markdown; it
+// is returned unchanged. Otherwise the pattern is treated as a path
+// scope and one exclude is emitted per extension, keyed on the final
+// path segment:
+//
+//   - `dir/**` -> `dir/**/*.md`, `dir/**/*.markdown` (recursive tree)
+//   - `dir/*`  -> `dir/*.md`,    `dir/*.markdown`    (one level)
+//   - `dir`    -> `dir/**/*.md`, `dir/**/*.markdown` (name as a tree)
+//
+// Every branch appends a Markdown extension to the emitted pattern, so
+// the invariant "a derived -merge line never matches a non-Markdown
+// file" holds for any input.
+func scopeExcludeToMarkdown(pattern string, exts []string) []string {
+	for _, ext := range exts {
+		if strings.HasSuffix(pattern, ext) {
+			return []string{pattern}
+		}
+	}
+	dir, last := splitLastSegment(pattern)
+	out := make([]string, 0, len(exts))
+	for _, ext := range exts {
+		switch last {
+		case "**":
+			// Recursive tree: all Markdown under dir at any depth.
+			out = append(out, dir+"**/*"+ext)
+		case "*":
+			// Single segment: Markdown directly under dir.
+			out = append(out, dir+"*"+ext)
+		default:
+			// A plain directory name (or any other shape) is treated
+			// as a directory scope covering all Markdown beneath it.
+			out = append(out, pattern+"/**/*"+ext)
+		}
+	}
+	return out
+}
+
+// splitLastSegment splits p at the final "/" into the directory prefix
+// (including the trailing slash; empty when p has no slash) and the
+// final path segment.
+func splitLastSegment(p string) (dir, last string) {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[:i+1], p[i+1:]
+	}
+	return "", p
 }
 
 // isRepresentableGitattributesPattern reports whether pattern can be
@@ -589,6 +673,12 @@ func findManagedBlockLines(lines []string) (int, int) {
 // -merge`. .gitattributes uses last-match-wins, so an exclude line
 // after the include lines effectively removes the merge driver from
 // any path the include patterns matched.
+//
+// Exclude patterns derived from .mdsmith.yml ignore entries are
+// markdown-scoped (see GlobsFromConfig): a `-merge` line only ever
+// matches a markdown file, so it disables the mdsmith driver for
+// grandfathered markdown without touching git's default merge for
+// non-markdown files in the same tree (issue #750).
 //
 // `.gitattributes` itself does not support negative patterns (`!*.md`
 // is a syntax error there). Order-sensitive override via -merge is the

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/bytelimit"
 	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/mdpath"
 	"github.com/jeduden/mdsmith/internal/oscompat"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/setutil"
@@ -117,7 +118,7 @@ func DiscoverFiles(repoRoot string, maxBytes int64) []string {
 			return nil
 		}
 		name := info.Name()
-		if !strings.HasSuffix(name, ".md") && !strings.HasSuffix(name, ".markdown") {
+		if !mdpath.IsMarkdownPath(name) {
 			return nil
 		}
 		rel, err := filepath.Rel(repoRoot, path)
@@ -202,7 +203,7 @@ func GlobsFromConfig(cfg *config.Config) (Globs, []string) {
 	if cfg == nil || len(cfg.Ignore) == 0 {
 		return g, nil
 	}
-	exts := defaultMarkdownExtensions()
+	exts := mdpath.Extensions()
 	g.Exclude = make([]string, 0, len(cfg.Ignore)*len(exts))
 	var skipped []string
 	for _, p := range cfg.Ignore {
@@ -213,21 +214,6 @@ func GlobsFromConfig(cfg *config.Config) (Globs, []string) {
 		g.Exclude = append(g.Exclude, scopeExcludeToMarkdown(p, exts)...)
 	}
 	return g, skipped
-}
-
-// defaultMarkdownExtensions returns the extension suffix (including the
-// leading dot) of each DefaultIncludes glob — ".md" and ".markdown".
-// Deriving them from DefaultIncludes keeps the exclude scoping in
-// GlobsFromConfig aligned with the include set it pairs with, so a
-// change to the include globs (say, adding "*.mdx") flows through to
-// the excludes automatically.
-func defaultMarkdownExtensions() []string {
-	inc := DefaultIncludes()
-	exts := make([]string, 0, len(inc))
-	for _, g := range inc {
-		exts = append(exts, filepath.Ext(g))
-	}
-	return exts
 }
 
 // scopeExcludeToMarkdown rewrites one .mdsmith.yml ignore pattern into
@@ -697,11 +683,13 @@ type Globs struct {
 	Exclude []string
 }
 
-// DefaultIncludes is the canonical include pattern set: every
-// markdown extension mdsmith processes. Kept as a function so callers
-// always get a fresh slice rather than sharing a package-level value.
+// DefaultIncludes is the canonical merge-driver include pattern set:
+// one basename glob per markdown extension mdsmith processes. It is
+// derived from mdpath, the single source of truth for the extension
+// set, and returns a fresh slice each call so callers may mutate it
+// without sharing a package-level value.
 func DefaultIncludes() []string {
-	return []string{"*.md", "*.markdown"}
+	return mdpath.FileGlobs()
 }
 
 // RenderManagedBlock returns the .gitattributes managed block content

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -921,6 +921,108 @@ func TestDefaultIncludes(t *testing.T) {
 	assert.Equal(t, []string{"*.md", "*.markdown"}, DefaultIncludes())
 }
 
+func TestDefaultMarkdownExtensions(t *testing.T) {
+	// Derived from DefaultIncludes so the exclude scoping stays aligned
+	// with the include set: strip the leading "*" from each glob.
+	assert.Equal(t, []string{".md", ".markdown"}, defaultMarkdownExtensions())
+}
+
+func TestSplitLastSegment(t *testing.T) {
+	cases := []struct {
+		in       string
+		dir      string
+		lastPart string
+	}{
+		{"demo/**", "demo/", "**"},
+		{"editors/**/dist/**", "editors/**/dist/", "**"},
+		{"vendor/*", "vendor/", "*"},
+		{"generated", "", "generated"},
+		{"**", "", "**"},
+		{"a/b/c.md", "a/b/", "c.md"},
+	}
+	for _, tc := range cases {
+		dir, last := splitLastSegment(tc.in)
+		assert.Equal(t, tc.dir, dir, "dir for %q", tc.in)
+		assert.Equal(t, tc.lastPart, last, "last for %q", tc.in)
+	}
+}
+
+func TestScopeExcludeToMarkdown(t *testing.T) {
+	exts := []string{".md", ".markdown"}
+	cases := []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{
+			name:    "recursive tree",
+			pattern: "demo/**",
+			want:    []string{"demo/**/*.md", "demo/**/*.markdown"},
+		},
+		{
+			name:    "recursive tree with intermediate glob",
+			pattern: "internal/rules/*/bad/**",
+			want: []string{
+				"internal/rules/*/bad/**/*.md",
+				"internal/rules/*/bad/**/*.markdown",
+			},
+		},
+		{
+			name:    "single level glob",
+			pattern: "vendor/*",
+			want:    []string{"vendor/*.md", "vendor/*.markdown"},
+		},
+		{
+			name:    "bare recursive glob",
+			pattern: "**",
+			want:    []string{"**/*.md", "**/*.markdown"},
+		},
+		{
+			name:    "already markdown md",
+			pattern: "internal/rules/*/bad.md",
+			want:    []string{"internal/rules/*/bad.md"},
+		},
+		{
+			name:    "already markdown markdown",
+			pattern: "notes/draft.markdown",
+			want:    []string{"notes/draft.markdown"},
+		},
+		{
+			name:    "bare directory name treated as a tree",
+			pattern: "generated",
+			want:    []string{"generated/**/*.md", "generated/**/*.markdown"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, scopeExcludeToMarkdown(tc.pattern, exts))
+		})
+	}
+}
+
+func TestScopeExcludeToMarkdown_AlwaysMarkdownScoped(t *testing.T) {
+	// The safety invariant: every emitted exclude ends in a Markdown
+	// extension, so a derived -merge line can never match a
+	// non-Markdown file — regardless of the ignore pattern's shape.
+	exts := []string{".md", ".markdown"}
+	patterns := []string{
+		"demo/**", "vendor/*", "src", "a/b/c", "weird/*.txt", "**", "x/",
+	}
+	for _, p := range patterns {
+		for _, got := range scopeExcludeToMarkdown(p, exts) {
+			hasMarkdownExt := false
+			for _, ext := range exts {
+				if strings.HasSuffix(got, ext) {
+					hasMarkdownExt = true
+					break
+				}
+			}
+			assert.True(t, hasMarkdownExt,
+				"exclude %q derived from ignore %q must end in a Markdown extension", got, p)
+		}
+	}
+}
+
 func TestGlobsFromConfig_NilConfig(t *testing.T) {
 	got, skipped := GlobsFromConfig(nil)
 	assert.Equal(t, DefaultIncludes(), got.Include)
@@ -932,8 +1034,43 @@ func TestGlobsFromConfig_TranslatesIgnore(t *testing.T) {
 	cfg := &config.Config{Ignore: []string{"demo/**", "vendor/**"}}
 	got, skipped := GlobsFromConfig(cfg)
 	assert.Equal(t, DefaultIncludes(), got.Include)
-	assert.Equal(t, []string{"demo/**", "vendor/**"}, got.Exclude)
+	// Each recursive ignore tree is scoped to the Markdown include
+	// extensions so the -merge lines never disable git's merge for
+	// non-Markdown files in that tree (issue #750).
+	assert.Equal(t, []string{
+		"demo/**/*.md", "demo/**/*.markdown",
+		"vendor/**/*.md", "vendor/**/*.markdown",
+	}, got.Exclude)
 	assert.Empty(t, skipped, "representable patterns must not be reported as skipped")
+}
+
+func TestGlobsFromConfig_KeepsMarkdownScopedIgnoreVerbatim(t *testing.T) {
+	// An ignore pattern that already targets a specific Markdown
+	// extension can only affect Markdown, so its -merge line is safe
+	// as-is and must not be doubled or rewritten.
+	cfg := &config.Config{Ignore: []string{"vendor/*.md", "notes/draft.markdown"}}
+	got, skipped := GlobsFromConfig(cfg)
+	assert.Equal(t, []string{"vendor/*.md", "notes/draft.markdown"}, got.Exclude)
+	assert.Empty(t, skipped)
+}
+
+func TestGlobsFromConfig_MixedIgnoreShapes(t *testing.T) {
+	// A mix of a recursive tree, a single-level glob, an already-
+	// Markdown pattern, and a bare directory name — each scoped so
+	// every emitted exclude ends in a Markdown extension.
+	cfg := &config.Config{Ignore: []string{
+		"demo/**",
+		"vendor/*",
+		"internal/rules/*/bad.md",
+		"generated",
+	}}
+	got, _ := GlobsFromConfig(cfg)
+	assert.Equal(t, []string{
+		"demo/**/*.md", "demo/**/*.markdown",
+		"vendor/*.md", "vendor/*.markdown",
+		"internal/rules/*/bad.md",
+		"generated/**/*.md", "generated/**/*.markdown",
+	}, got.Exclude)
 }
 
 func TestGlobsFromConfig_IsolatesIgnoreSlice(t *testing.T) {
@@ -958,7 +1095,10 @@ func TestLoadGlobs_ReadsIgnorePatterns(t *testing.T) {
 		[]byte("ignore:\n  - \"demo/**\"\n  - \"vendor/**\"\n"), 0644))
 	got := LoadGlobs(dir)
 	assert.Equal(t, DefaultIncludes(), got.Include)
-	assert.Equal(t, []string{"demo/**", "vendor/**"}, got.Exclude)
+	assert.Equal(t, []string{
+		"demo/**/*.md", "demo/**/*.markdown",
+		"vendor/**/*.md", "vendor/**/*.markdown",
+	}, got.Exclude)
 }
 
 func TestLoadGlobs_UnparseableConfigFallsBackToDefaults(t *testing.T) {
@@ -1139,8 +1279,11 @@ func TestGlobsFromConfig_DropsUnrepresentablePatterns(t *testing.T) {
 		"vendor/**",
 	}}
 	got, skipped := GlobsFromConfig(cfg)
-	assert.Equal(t, []string{"demo/**", "vendor/**"}, got.Exclude,
-		"only representable patterns survive the validation filter")
+	assert.Equal(t, []string{
+		"demo/**/*.md", "demo/**/*.markdown",
+		"vendor/**/*.md", "vendor/**/*.markdown",
+	}, got.Exclude,
+		"only representable patterns survive the validation filter, each scoped to Markdown")
 	assert.Equal(t, []string{"!docs/*.md", "with space"}, skipped,
 		"dropped patterns are returned in input order so callers can warn")
 }

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1045,6 +1045,26 @@ func TestGlobsFromConfig_TranslatesIgnore(t *testing.T) {
 	assert.Empty(t, skipped, "representable patterns must not be reported as skipped")
 }
 
+func TestLegacyGlobs(t *testing.T) {
+	// The pre-#750 render: representable ignore patterns copied verbatim
+	// and unscoped, with negation/whitespace patterns dropped — exactly
+	// what the pinned merge-queue baseline produces and expects.
+	cfg := &config.Config{Ignore: []string{"demo/**", "vendor/*.md", "!neg.md", "with space"}}
+	got := LegacyGlobs(cfg)
+	assert.Equal(t, DefaultIncludes(), got.Include)
+	assert.Equal(t, []string{"demo/**", "vendor/*.md"}, got.Exclude)
+}
+
+func TestLegacyGlobs_NilAndEmpty(t *testing.T) {
+	got := LegacyGlobs(nil)
+	assert.Equal(t, DefaultIncludes(), got.Include)
+	assert.Empty(t, got.Exclude)
+
+	got = LegacyGlobs(&config.Config{})
+	assert.Equal(t, DefaultIncludes(), got.Include)
+	assert.Empty(t, got.Exclude)
+}
+
 func TestGlobsFromConfig_KeepsMarkdownScopedIgnoreVerbatim(t *testing.T) {
 	// An ignore pattern that already targets a specific Markdown
 	// extension can only affect Markdown, so its -merge line is safe

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -921,12 +921,6 @@ func TestDefaultIncludes(t *testing.T) {
 	assert.Equal(t, []string{"*.md", "*.markdown"}, DefaultIncludes())
 }
 
-func TestDefaultMarkdownExtensions(t *testing.T) {
-	// Derived from DefaultIncludes so the exclude scoping stays aligned
-	// with the include set: strip the leading "*" from each glob.
-	assert.Equal(t, []string{".md", ".markdown"}, defaultMarkdownExtensions())
-}
-
 func TestSplitLastSegment(t *testing.T) {
 	cases := []struct {
 		in       string

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -973,6 +973,13 @@ func TestScopeExcludeToMarkdown(t *testing.T) {
 			want:    []string{"vendor/*.md", "vendor/*.markdown"},
 		},
 		{
+			// A gitignore-style trailing-slash directory must not
+			// produce a `build//**/*.md` double slash.
+			name:    "trailing slash directory",
+			pattern: "build/",
+			want:    []string{"build/**/*.md", "build/**/*.markdown"},
+		},
+		{
 			name:    "bare recursive glob",
 			pattern: "**",
 			want:    []string{"**/*.md", "**/*.markdown"},

--- a/internal/integration/gitattributes_sync_test.go
+++ b/internal/integration/gitattributes_sync_test.go
@@ -60,7 +60,19 @@ func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
 	// misleading "run merge-driver install" message).
 	cfg, err := config.Load(filepath.Join(root, ".mdsmith.yml"))
 	require.NoError(t, err, "repository .mdsmith.yml must load and parse")
-	expected, _ := githooks.GlobsFromConfig(cfg)
+
+	// During the transition to markdown-scoped merge-driver excludes
+	// (#750), the committed .gitattributes deliberately stays in the
+	// legacy bare form (`demo/** -merge`). The merge queue validates it
+	// with `mdsmith merge-driver ci-install` run by the *pinned* release
+	// baseline (see .github/actions/setup-mdsmith-pinned-version), which
+	// predates markdown scoping and expects that legacy render — so the
+	// committed file must match LegacyGlobs, not the branch's
+	// markdown-scoped GlobsFromConfig. Once the scoped format ships in a
+	// release and the pin is bumped, regenerate .gitattributes with
+	// `mdsmith merge-driver install` and switch this assertion to
+	// GlobsFromConfig. See docs/development/adopt-new-directive-syntax.md.
+	expected := githooks.LegacyGlobs(cfg)
 
 	data, err := os.ReadFile(filepath.Join(root, ".gitattributes"))
 	require.NoError(t, err, "repository .gitattributes must exist")
@@ -70,8 +82,9 @@ func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
 		"committed .gitattributes has no mdsmith merge-driver managed block")
 
 	assert.True(t, githooks.GlobsEqual(installed, expected),
-		"committed .gitattributes is out of sync with .mdsmith.yml — run "+
-			"`mdsmith merge-driver install` (or `mdsmith fix`) and commit the "+
-			"result.\n  committed: include=%v exclude=%v\n  expected:  include=%v exclude=%v",
+		"committed .gitattributes is out of sync with .mdsmith.yml's legacy "+
+			"(pinned-baseline) render — keep it in the bare form the pinned "+
+			"merge-queue binary expects until the pin is bumped.\n"+
+			"  committed: include=%v exclude=%v\n  expected:  include=%v exclude=%v",
 		installed.Include, installed.Exclude, expected.Include, expected.Exclude)
 }

--- a/internal/linkgraph/wikilinks.go
+++ b/internal/linkgraph/wikilinks.go
@@ -318,12 +318,12 @@ func ResolveWikiLink(root fs.FS, _ string, target string) (string, bool) {
 // — the typed-extension case (`![[diagram.png]]`).
 func wikilinkSearchKey(target string) (wantName, wantStem string, stemMode bool) {
 	base := path.Base(target)
-	ext := strings.ToLower(path.Ext(base))
-	switch ext {
-	case "", ".md", ".markdown":
-		stem := strings.TrimSuffix(base, path.Ext(base))
-		return "", stem, true
-	default:
-		return base, "", false
+	ext := path.Ext(base)
+	// An empty extension (bare page, e.g. [[Notes]]) or a Markdown
+	// extension resolves by stem; a typed non-Markdown extension
+	// (e.g. ![[diagram.png]]) resolves by exact filename.
+	if ext == "" || mdpath.HasMarkdownExt(ext) {
+		return "", strings.TrimSuffix(base, ext), true
 	}
+	return base, "", false
 }

--- a/internal/lint/files.go
+++ b/internal/lint/files.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jeduden/mdsmith/internal/gitignore"
+	"github.com/jeduden/mdsmith/internal/mdpath"
 )
 
 // getwdFn resolves the process working directory. It is a package-level
@@ -25,11 +26,12 @@ var volumeNameFn = filepath.VolumeName
 // failure without running on Windows.
 var absPathFn = filepath.Abs
 
-// isMarkdown returns true if the file extension is .md or .markdown.
-// strings.EqualFold avoids a heap allocation vs strings.ToLower + ==.
+// isMarkdown returns true if the file has a recognised Markdown
+// extension. Membership is delegated to mdpath, the single source of
+// truth for the extension set; mdpath.HasMarkdownExt folds case without
+// the heap allocation strings.ToLower would make.
 func isMarkdown(path string) bool {
-	ext := filepath.Ext(path)
-	return strings.EqualFold(ext, ".md") || strings.EqualFold(ext, ".markdown")
+	return mdpath.HasMarkdownExt(filepath.Ext(path))
 }
 
 // hasGlobChars returns true if the string contains glob meta-characters.

--- a/internal/lsp/server_lifecycle.go
+++ b/internal/lsp/server_lifecycle.go
@@ -3,6 +3,8 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/jeduden/mdsmith/internal/mdpath"
 )
 
 // LSP lifecycle handlers: initialize, initialized, and the dynamic
@@ -119,16 +121,21 @@ func (s *Server) registerWatchers() {
 	id := s.nextReqID.Add(1)
 	// json.Marshal(int64) cannot fail; ignoring the error is safe.
 	idJSON, _ := json.Marshal(id)
+	// Watch .mdsmith.yml plus every Markdown file, the extension set
+	// derived from mdpath so the watch scope tracks the single source
+	// of truth alongside discovery and the merge driver.
+	globs := mdpath.RecursiveGlobs()
+	watchers := make([]fileSystemWatcher, 0, len(globs)+1)
+	watchers = append(watchers, fileSystemWatcher{GlobPattern: "**/.mdsmith.yml"})
+	for _, g := range globs {
+		watchers = append(watchers, fileSystemWatcher{GlobPattern: g})
+	}
 	_ = s.t.writeRequest(idJSON, "client/registerCapability",
 		registrationParams{Registrations: []registration{{
 			ID:     "mdsmith-watch",
 			Method: "workspace/didChangeWatchedFiles",
 			RegisterOptions: didChangeWatchedFilesRegistrationOptions{
-				Watchers: []fileSystemWatcher{
-					{GlobPattern: "**/.mdsmith.yml"},
-					{GlobPattern: "**/*.md"},
-					{GlobPattern: "**/*.markdown"},
-				},
+				Watchers: watchers,
 			},
 		}}})
 }

--- a/internal/lsp/symbols.go
+++ b/internal/lsp/symbols.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jeduden/mdsmith/internal/discovery"
 	"github.com/jeduden/mdsmith/internal/index"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdpath"
 	"github.com/jeduden/mdsmith/internal/mdtext"
 	"github.com/jeduden/mdsmith/internal/oscompat"
 	"github.com/jeduden/mdsmith/internal/yamlutil"
@@ -232,7 +233,7 @@ func (s *Server) indexReloadFromDisk(absOrRel string) {
 // vendored content, fixtures, and generated trees stay out of the
 // outline / symbol picker.
 func indexPatterns() []string {
-	return []string{"**/*.md", "**/*.markdown"}
+	return mdpath.RecursiveGlobs()
 }
 
 // filterIgnored drops paths matching cfg.Ignore from files. The
@@ -428,11 +429,11 @@ func resolveAbsAndSymlinks(p string) string {
 	return filepath.Clean(abs)
 }
 
-// isMarkdownExt reports whether p has a .md or .markdown extension.
-// Case-insensitive.
+// isMarkdownExt reports whether p has a recognised Markdown extension.
+// Membership is delegated to mdpath, the single source of truth;
+// mdpath.HasMarkdownExt folds case without allocating.
 func isMarkdownExt(p string) bool {
-	ext := strings.ToLower(filepath.Ext(p))
-	return ext == ".md" || ext == ".markdown"
+	return mdpath.HasMarkdownExt(filepath.Ext(p))
 }
 
 // rangeForLines returns an LSP Range covering 1-based start..end

--- a/internal/mdpath/mdpath.go
+++ b/internal/mdpath/mdpath.go
@@ -1,10 +1,68 @@
-// Package mdpath provides path predicates shared across rule packages.
+// Package mdpath is the single source of truth for the set of file
+// extensions mdsmith treats as Markdown, together with the path
+// predicates and glob builders derived from that set.
+//
+// Default file discovery (config.DefaultFiles), the CLI directory
+// walk, the merge-driver include set (githooks.DefaultIncludes), the
+// merge-driver discovery walk, wikilink resolution, the link-style
+// rule, and the LSP document selector all derive from Extensions here,
+// so teaching mdsmith a new extension (say ".mdx") is a one-line change
+// in this file rather than a hunt across a dozen packages.
 package mdpath
 
 import "strings"
 
-// IsMarkdownPath reports whether p has a Markdown extension (.md or
-// .markdown, case-insensitively).
+// extensions is the canonical, lowercased Markdown extension set — each
+// element including the leading dot. It is unexported so callers cannot
+// mutate the shared slice; read a copy through Extensions, or test
+// membership through HasMarkdownExt / IsMarkdownPath.
+var extensions = []string{".md", ".markdown"}
+
+// Extensions returns a fresh copy of the canonical Markdown extension
+// list (each element includes the leading dot, lowercased), so callers
+// may sort or append without disturbing the shared source of truth.
+func Extensions() []string {
+	return append([]string(nil), extensions...)
+}
+
+// FileGlobs returns a basename glob per Markdown extension — "*.md",
+// "*.markdown". Used for the merge-driver include set, where each
+// pattern is matched against a file's name at any depth.
+func FileGlobs() []string {
+	out := make([]string, len(extensions))
+	for i, ext := range extensions {
+		out[i] = "*" + ext
+	}
+	return out
+}
+
+// RecursiveGlobs returns a recursive doublestar glob per Markdown
+// extension — "**/*.md", "**/*.markdown". Used for default file
+// discovery (config.DefaultFiles) and the LSP document selector.
+func RecursiveGlobs() []string {
+	out := make([]string, len(extensions))
+	for i, ext := range extensions {
+		out[i] = "**/*" + ext
+	}
+	return out
+}
+
+// HasMarkdownExt reports whether ext — a file extension including the
+// leading dot, as returned by path.Ext or filepath.Ext — is one of the
+// recognised Markdown extensions, compared case-insensitively. It does
+// not allocate: strings.EqualFold folds case without the copy that
+// strings.ToLower would make.
+func HasMarkdownExt(ext string) bool {
+	for _, e := range extensions {
+		if strings.EqualFold(ext, e) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsMarkdownPath reports whether p has a Markdown extension (one of
+// Extensions, case-insensitively).
 //
 // Callers pass paths of two different shapes: fs.WalkDir-sourced paths
 // are always forward-slash regardless of host OS, while a link target
@@ -15,8 +73,8 @@ import "strings"
 // earlier path segment; path.Ext never treats '\' as a separator at
 // all, so a Windows-native path with a dot in an earlier directory
 // segment (e.g. `some.dir\README`) would misdetect that segment's dot
-// as the extension. ext finds the last '.' after the last occurrence
-// of either separator, independent of the host OS.
+// as the extension. The scan below finds the last '.' after the last
+// occurrence of either separator, independent of the host OS.
 func IsMarkdownPath(p string) bool {
 	base := p
 	if i := strings.LastIndexAny(p, `/\`); i >= 0 {
@@ -26,6 +84,5 @@ func IsMarkdownPath(p string) bool {
 	if dot < 0 {
 		return false
 	}
-	ext := base[dot:]
-	return strings.EqualFold(ext, ".md") || strings.EqualFold(ext, ".markdown")
+	return HasMarkdownExt(base[dot:])
 }

--- a/internal/mdpath/mdpath.go
+++ b/internal/mdpath/mdpath.go
@@ -10,7 +10,10 @@
 // in this file rather than a hunt across a dozen packages.
 package mdpath
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // extensions is the canonical, lowercased Markdown extension set — each
 // element including the leading dot. It is unexported so callers cannot
@@ -22,7 +25,7 @@ var extensions = []string{".md", ".markdown"}
 // list (each element includes the leading dot, lowercased), so callers
 // may sort or append without disturbing the shared source of truth.
 func Extensions() []string {
-	return append([]string(nil), extensions...)
+	return slices.Clone(extensions)
 }
 
 // FileGlobs returns a basename glob per Markdown extension — "*.md",

--- a/internal/mdpath/mdpath_test.go
+++ b/internal/mdpath/mdpath_test.go
@@ -1,6 +1,56 @@
 package mdpath
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtensions(t *testing.T) {
+	got := Extensions()
+	want := []string{".md", ".markdown"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Extensions() = %v, want %v", got, want)
+	}
+	// Must return a fresh slice each call so a mutating caller cannot
+	// corrupt the shared source of truth.
+	got[0] = "mutated"
+	if Extensions()[0] != ".md" {
+		t.Fatalf("Extensions() returned a slice aliasing the package state")
+	}
+}
+
+func TestFileGlobs(t *testing.T) {
+	if got, want := FileGlobs(), []string{"*.md", "*.markdown"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FileGlobs() = %v, want %v", got, want)
+	}
+}
+
+func TestRecursiveGlobs(t *testing.T) {
+	if got, want := RecursiveGlobs(), []string{"**/*.md", "**/*.markdown"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RecursiveGlobs() = %v, want %v", got, want)
+	}
+}
+
+func TestHasMarkdownExt(t *testing.T) {
+	cases := []struct {
+		ext  string
+		want bool
+	}{
+		{".md", true},
+		{".markdown", true},
+		{".MD", true},
+		{".Markdown", true},
+		{".mdx", false},
+		{".txt", false},
+		{"", false},
+		{"md", false}, // missing leading dot
+	}
+	for _, tc := range cases {
+		if got := HasMarkdownExt(tc.ext); got != tc.want {
+			t.Errorf("HasMarkdownExt(%q) = %v, want %v", tc.ext, got, tc.want)
+		}
+	}
+}
 
 func TestIsMarkdownPath(t *testing.T) {
 	cases := []struct {

--- a/internal/rules/MDS048-git-hook-sync/README.md
+++ b/internal/rules/MDS048-git-hook-sync/README.md
@@ -42,10 +42,13 @@ and avoid conflicts. Two artifacts cooperate:
 
 - `.gitattributes` assigns the `mdsmith` merge driver to
   markdown files. The managed block uses globs (e.g.
-  `*.md merge=mdsmith`) plus exclude overrides
-  (`<pattern> -merge`) so the assignment scope tracks
-  `.mdsmith.yml` ignore patterns rather than enumerating
-  individual files.
+  `*.md merge=mdsmith`) plus markdown-scoped exclude
+  overrides (e.g. `demo/**/*.md -merge`) so the assignment
+  scope tracks `.mdsmith.yml` ignore patterns rather than
+  enumerating individual files. Each ignore pattern is
+  intersected with the markdown include extensions, so an
+  exclude line never disables git's merge for a
+  non-markdown file in a grandfathered tree.
 - The pre-merge-commit hook re-runs `mdsmith fix .` once
   every per-file merge has resolved, so generated sections
   reflect the final merged state. The hook script is
@@ -82,8 +85,9 @@ The rule:
 
 1. Reads `.mdsmith.yml` ignore patterns and computes the
    canonical glob set: include patterns (default: `*.md`,
-   `*.markdown`) followed by an exclude pattern for each
-   `ignore:` entry.
+   `*.markdown`) followed by markdown-scoped exclude
+   patterns for each `ignore:` entry (a `demo/**` ignore
+   becomes `demo/**/*.md` and `demo/**/*.markdown`).
 2. If `merge.mdsmith.driver` is registered in git config,
    reads `.gitattributes` and compares the BEGIN/END
    managed block against the canonical render.
@@ -169,8 +173,10 @@ ignore:
 # BEGIN mdsmith merge-driver
 *.md merge=mdsmith
 *.markdown merge=mdsmith
-demo/** -merge
-vendor/** -merge
+demo/**/*.md -merge
+demo/**/*.markdown -merge
+vendor/**/*.md -merge
+vendor/**/*.markdown -merge
 # END mdsmith merge-driver
 ```
 

--- a/internal/rules/githooksync/rule_test.go
+++ b/internal/rules/githooksync/rule_test.go
@@ -140,7 +140,10 @@ func TestRule_Check_HonorsConfigIgnorePatterns(t *testing.T) {
 
 	expectedBlock := githooks.RenderManagedBlock(githooks.Globs{
 		Include: githooks.DefaultIncludes(),
-		Exclude: []string{"demo/**", "vendor/**"},
+		Exclude: []string{
+			"demo/**/*.md", "demo/**/*.markdown",
+			"vendor/**/*.md", "vendor/**/*.markdown",
+		},
 	})
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitattributes"),
 		[]byte(expectedBlock), 0o644))
@@ -566,7 +569,10 @@ func TestRule_Fix_EncodesConfigIgnoreAsExcludes(t *testing.T) {
 	require.NoError(t, err)
 	expected := githooks.RenderManagedBlock(githooks.Globs{
 		Include: githooks.DefaultIncludes(),
-		Exclude: []string{"demo/**", "vendor/**"},
+		Exclude: []string{
+			"demo/**/*.md", "demo/**/*.markdown",
+			"vendor/**/*.md", "vendor/**/*.markdown",
+		},
 	})
 	assert.Equal(t, expected, string(content))
 }

--- a/internal/rules/linkstyle/rule.go
+++ b/internal/rules/linkstyle/rule.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jeduden/mdsmith/internal/linkgraph"
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/mdpath"
 	"github.com/jeduden/mdsmith/internal/rule"
 )
 
@@ -408,7 +409,7 @@ func checkExtension(policy, targetPath string) string {
 		return ""
 	}
 	ext := path.Ext(base)
-	isMD := strings.EqualFold(ext, ".md") || strings.EqualFold(ext, ".markdown")
+	isMD := mdpath.HasMarkdownExt(ext)
 	hasOtherExt := ext != "" && !isMD
 	if hasOtherExt {
 		return ""


### PR DESCRIPTION
## Summary

Fixes #750.

`mdsmith merge-driver install` derived its `.gitattributes` exclude lines from the `ignore:` patterns in `.mdsmith.yml`, emitting one bare ` -merge` line per pattern. But `ignore:` is a **markdown-lint** scoping list (`files:` is `**/*.md` / `**/*.markdown`), while a bare `demo/** -merge` attribute is **not** extension-scoped — it disabled git's 3-way merge for *every* file in that tree, including source code that nobody asked to grandfather. Two branches editing disjoint regions of the same non-Markdown file then conflicted irreconcilably (git treats the file as binary for merging).

This scopes each ignore-derived exclude to Markdown, then centralizes the Markdown-extension set so the fix (and every other extension check) has a single source of truth.

> **Note on the committed `.gitattributes`:** it deliberately stays in the **legacy bare form** in this PR. The merge queue validates `.gitattributes` with `merge-driver ci-install` run by the **pinned release baseline** (`setup-mdsmith-pinned-version`), which predates markdown scoping — so changing the committed file's format would fail the queue. `install` writes the new scoped form for users; the repository migrates its own `.gitattributes` in a follow-up once this ships in a release and the pin is bumped (see `docs/development/adopt-new-directive-syntax.md`).

## Commits

### 1. `fix(merge-driver)`: scope ignore-derived `-merge` lines to Markdown (#750)

`githooks.GlobsFromConfig` now intersects each representable ignore pattern with the Markdown include extensions. For `ignore: ["demo/**"]` it emits:

```gitattributes
demo/**/*.md -merge
demo/**/*.markdown -merge
```

instead of a bare `demo/** -merge`. Every emitted exclude ends in a Markdown extension, so a derived `-merge` line can **never** match a non-Markdown file. A pattern that already targets a specific Markdown extension (e.g. `internal/rules/*/bad.md`) is kept verbatim. This is what `merge-driver install` writes.

Pattern handling:

| `ignore:` pattern | emitted excludes |
| --- | --- |
| `demo/**` | `demo/**/*.md`, `demo/**/*.markdown` |
| `vendor/*` | `vendor/*.md`, `vendor/*.markdown` |
| `internal/rules/*/bad.md` | `internal/rules/*/bad.md` (already Markdown — verbatim) |
| `build/` | `build/**/*.md`, `build/**/*.markdown` |

Verified with `git check-attr`: a non-Markdown file in an ignored tree (`demo/world.zig`) keeps git's default merge (`unspecified`), while Markdown in that tree (`demo/x.md`, `demo/x.markdown`) is `unset`. Unrepresentable patterns (`!` negation, whitespace) are still skipped and reported exactly as before.

### 2. `fix(merge-driver)`: handle trailing-slash ignore patterns

Self-review follow-up: a gitignore-style trailing-slash ignore (`build/`, `node_modules/`) has an empty final path segment and produced a malformed `build//**/*.md` double slash. Folded into the recursive-tree branch so it emits `build/**/*.md`; added a dedicated test.

### 3. `refactor(mdpath)`: make the Markdown extension set a single source of truth

The `.md`/`.markdown` set was duplicated across ~8 packages (discovery globs, the CLI walk, the merge-driver include set and discovery walk, the LSP document selector and file watcher, wikilink resolution, the link-style rule). Centralized it in `internal/mdpath`:

- `Extensions()` → `[".md", ".markdown"]`
- `FileGlobs()` → `["*.md", "*.markdown"]`
- `RecursiveGlobs()` → `["**/*.md", "**/*.markdown"]`
- `HasMarkdownExt()` → case-insensitive, zero-alloc membership test

`config.DefaultFiles`, `lint.isMarkdown`, `githooks.DefaultIncludes`/`GlobsFromConfig`/`DiscoverFiles`, `linkgraph` wikilink resolution, `linkstyle`, and the LSP `indexPatterns`/`isMarkdownExt`/file-watcher now all derive from these helpers. **No change to which extensions are recognized**; adding a new one (e.g. `.mdx`) is now a one-line change in `mdpath`.

### 4. `refactor(mdpath)`: use `slices.Clone` in `Extensions`

Match the repo's established clone pattern. No behavior change.

### 5. `fix(merge-driver)`: keep the committed `.gitattributes` on the legacy format for the pinned queue

The merge queue's `ci-install` runs the **pinned** v0.41.0 baseline, which expects the bare `demo/** -merge` render; regenerating the committed file to the scoped form made it report drift and fail the queue. Reverted the committed `.gitattributes` to the legacy bare form (so the pinned baseline stays green — for this PR and every later one, since main never changes format), added `githooks.LegacyGlobs` (the pinned-baseline render), and repointed the dogfood `TestRepoGitattributesInSyncWithConfig` at it. `GlobsFromConfig` still renders the scoped form that `install` writes.

## Testing

- New unit tests for the scoping helpers (`scopeExcludeToMarkdown`, `splitLastSegment`, trailing-slash, markdown-scoped invariant), the `mdpath` helpers (`Extensions`, `FileGlobs`, `RecursiveGlobs`, `HasMarkdownExt`), and `LegacyGlobs`.
- Updated the `GlobsFromConfig`/`LoadGlobs`, MDS048 rule, and CLI install tests to the scoped output; the dogfood test verifies the committed legacy `.gitattributes` against `LegacyGlobs`.
- `go test ./...`, `go vet ./...`, `golangci-lint` (0 issues), `gofmt`, the `mdpath` 0-alloc gate, and `mdsmith check .` (556 files, 0 failures) all pass. Codecov: all modified lines covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK7yWgvWUN5xD1NTuGVZvZ