### PR TITLE
chore(ci): bump pinned baseline to v0.53.0 and adopt scoped .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,14 +4,23 @@
 # BEGIN mdsmith merge-driver
 *.md merge=mdsmith
 *.markdown merge=mdsmith
-.git/** -merge
-demo/** -merge
-internal/rules/*/bad/** -merge
+.git/**/*.md -merge
+.git/**/*.markdown -merge
+demo/**/*.md -merge
+demo/**/*.markdown -merge
+internal/rules/*/bad/**/*.md -merge
+internal/rules/*/bad/**/*.markdown -merge
 internal/rules/*/bad.md -merge
-internal/rules/*/good/** -merge
-internal/rules/*/fixed/** -merge
-internal/rules/*/pattern/** -merge
-.claude/worktrees/** -merge
-editors/**/node_modules/** -merge
-editors/**/dist/** -merge
+internal/rules/*/good/**/*.md -merge
+internal/rules/*/good/**/*.markdown -merge
+internal/rules/*/fixed/**/*.md -merge
+internal/rules/*/fixed/**/*.markdown -merge
+internal/rules/*/pattern/**/*.md -merge
+internal/rules/*/pattern/**/*.markdown -merge
+.claude/worktrees/**/*.md -merge
+.claude/worktrees/**/*.markdown -merge
+editors/**/node_modules/**/*.md -merge
+editors/**/node_modules/**/*.markdown -merge
+editors/**/dist/**/*.md -merge
+editors/**/dist/**/*.markdown -merge
 # END mdsmith merge-driver

--- a/.github/actions/setup-mdsmith-pinned-version/action.yml
+++ b/.github/actions/setup-mdsmith-pinned-version/action.yml
@@ -12,8 +12,8 @@ runs:
         # Bump here only when intentionally updating that baseline.
         # After bumping, scan PLAN.md for plans waiting to adopt the
         # newly-released syntax. See docs/development/adopt-new-directive-syntax.md.
-        MDSMITH_VERSION: v0.41.0
-        MDSMITH_SHA256: 4df9683fe598db9ea7e55789fd8b78db6390760fb88d0f46beb9bfc25e775dde
+        MDSMITH_VERSION: v0.53.0
+        MDSMITH_SHA256: bfee797520d02d7b0132d09bd273ced9334a8d858872a8f65a348c028fbb0a0e
       # The binary is downloaded over HTTPS and SHA256-verified above
       # before $HOME/.local/bin is appended to PATH, so the github-env
       # write is safe to ignore.

--- a/internal/githooks/githooks.go
+++ b/internal/githooks/githooks.go
@@ -216,36 +216,6 @@ func GlobsFromConfig(cfg *config.Config) (Globs, []string) {
 	return g, skipped
 }
 
-// LegacyGlobs renders cfg.Ignore the pre-#750 way: the default include
-// set plus each representable ignore pattern copied verbatim, without
-// markdown scoping (`demo/** -merge`). This is the managed block that a
-// mdsmith release from before the markdown-scoping change produces and
-// expects — including the pinned CI baseline that validates
-// .gitattributes in the merge queue via `merge-driver ci-install`.
-//
-// It exists only for the transition window (see
-// docs/development/adopt-new-directive-syntax.md): a change to the
-// managed-block format cannot reach main through the merge queue while
-// the queue is gated by a pinned binary that predates the format. So
-// the repository keeps its committed .gitattributes in this legacy form
-// — validated by TestRepoGitattributesInSyncWithConfig against this
-// render — while GlobsFromConfig renders the markdown-scoped form that
-// `install` now writes for users and that the repository itself adopts
-// once the feature ships in a release and the pin is bumped.
-func LegacyGlobs(cfg *config.Config) Globs {
-	g := Globs{Include: DefaultIncludes()}
-	if cfg == nil || len(cfg.Ignore) == 0 {
-		return g
-	}
-	g.Exclude = make([]string, 0, len(cfg.Ignore))
-	for _, p := range cfg.Ignore {
-		if isRepresentableGitattributesPattern(p) {
-			g.Exclude = append(g.Exclude, p)
-		}
-	}
-	return g
-}
-
 // scopeExcludeToMarkdown rewrites one .mdsmith.yml ignore pattern into
 // the .gitattributes exclude patterns that turn off the mdsmith merge
 // driver for the Markdown files the pattern grandfathers — and only

--- a/internal/githooks/githooks_test.go
+++ b/internal/githooks/githooks_test.go
@@ -1045,26 +1045,6 @@ func TestGlobsFromConfig_TranslatesIgnore(t *testing.T) {
 	assert.Empty(t, skipped, "representable patterns must not be reported as skipped")
 }
 
-func TestLegacyGlobs(t *testing.T) {
-	// The pre-#750 render: representable ignore patterns copied verbatim
-	// and unscoped, with negation/whitespace patterns dropped — exactly
-	// what the pinned merge-queue baseline produces and expects.
-	cfg := &config.Config{Ignore: []string{"demo/**", "vendor/*.md", "!neg.md", "with space"}}
-	got := LegacyGlobs(cfg)
-	assert.Equal(t, DefaultIncludes(), got.Include)
-	assert.Equal(t, []string{"demo/**", "vendor/*.md"}, got.Exclude)
-}
-
-func TestLegacyGlobs_NilAndEmpty(t *testing.T) {
-	got := LegacyGlobs(nil)
-	assert.Equal(t, DefaultIncludes(), got.Include)
-	assert.Empty(t, got.Exclude)
-
-	got = LegacyGlobs(&config.Config{})
-	assert.Equal(t, DefaultIncludes(), got.Include)
-	assert.Empty(t, got.Exclude)
-}
-
 func TestGlobsFromConfig_KeepsMarkdownScopedIgnoreVerbatim(t *testing.T) {
 	// An ignore pattern that already targets a specific Markdown
 	// extension can only affect Markdown, so its -merge line is safe

--- a/internal/integration/gitattributes_sync_test.go
+++ b/internal/integration/gitattributes_sync_test.go
@@ -60,19 +60,7 @@ func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
 	// misleading "run merge-driver install" message).
 	cfg, err := config.Load(filepath.Join(root, ".mdsmith.yml"))
 	require.NoError(t, err, "repository .mdsmith.yml must load and parse")
-
-	// During the transition to markdown-scoped merge-driver excludes
-	// (#750), the committed .gitattributes deliberately stays in the
-	// legacy bare form (`demo/** -merge`). The merge queue validates it
-	// with `mdsmith merge-driver ci-install` run by the *pinned* release
-	// baseline (see .github/actions/setup-mdsmith-pinned-version), which
-	// predates markdown scoping and expects that legacy render — so the
-	// committed file must match LegacyGlobs, not the branch's
-	// markdown-scoped GlobsFromConfig. Once the scoped format ships in a
-	// release and the pin is bumped, regenerate .gitattributes with
-	// `mdsmith merge-driver install` and switch this assertion to
-	// GlobsFromConfig. See docs/development/adopt-new-directive-syntax.md.
-	expected := githooks.LegacyGlobs(cfg)
+	expected, _ := githooks.GlobsFromConfig(cfg)
 
 	data, err := os.ReadFile(filepath.Join(root, ".gitattributes"))
 	require.NoError(t, err, "repository .gitattributes must exist")
@@ -82,9 +70,8 @@ func TestRepoGitattributesInSyncWithConfig(t *testing.T) {
 		"committed .gitattributes has no mdsmith merge-driver managed block")
 
 	assert.True(t, githooks.GlobsEqual(installed, expected),
-		"committed .gitattributes is out of sync with .mdsmith.yml's legacy "+
-			"(pinned-baseline) render — keep it in the bare form the pinned "+
-			"merge-queue binary expects until the pin is bumped.\n"+
-			"  committed: include=%v exclude=%v\n  expected:  include=%v exclude=%v",
+		"committed .gitattributes is out of sync with .mdsmith.yml — run "+
+			"`mdsmith merge-driver install` (or `mdsmith fix`) and commit the "+
+			"result.\n  committed: include=%v exclude=%v\n  expected:  include=%v exclude=%v",
 		installed.Include, installed.Exclude, expected.Include, expected.Exclude)
 }


### PR DESCRIPTION
## Summary

Follow-up to #752 (issue #750). That PR shipped the markdown-scoped merge-driver excludes but deliberately kept the repository's own committed `.gitattributes` in the legacy bare form, because the merge queue validated it with the **pinned** baseline (v0.41.0), which predates the format. v0.53.0 is now released with the scoped format, so this completes the adoption.

## Changes

- **Bump the pinned baseline** in `.github/actions/setup-mdsmith-pinned-version/action.yml` from `v0.41.0` to `v0.53.0` (with its verified `mdsmith-linux-amd64` SHA256).
- **Regenerate `.gitattributes`** to the markdown-scoped managed block — the exact block v0.53.0's `merge-driver install` writes — so ignore-derived `-merge` lines only ever match Markdown (e.g. `demo/**` → `demo/**/*.md` + `demo/**/*.markdown`), and git's default merge is preserved for non-Markdown files in ignored trees.
- **Point the dogfood `TestRepoGitattributesInSyncWithConfig` back at `GlobsFromConfig`** and drop the transition-only `githooks.LegacyGlobs` helper (and its tests), now that the committed file matches the scoped render again.

## Verification

Ran the actual released **v0.53.0** binary against this branch's files:

- `merge-driver ci-install` reports the new `.gitattributes` **in sync** (exit 0) — so the merge-queue `queue` job passes.
- `check .` lints the repo **clean** (563 files, 0 failures) — so the `mdsmith-fixed-version` job passes under the bumped pin.

Plus `go test ./...`, `go vet ./...`, `golangci-lint` (0 issues), `gofmt`, and the branch's own `mdsmith check .` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NK7yWgvWUN5xD1NTuGVZvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NK7yWgvWUN5xD1NTuGVZvZ)_