### PR TITLE
test(init): add unit tests for printInitCatalog and setInitUsage (plan 2607191917)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -255,6 +255,6 @@ footer: |
 | 2607121915 | ✅     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
 | 2607170527 | 🔳     | opus   | [External link checking on WASM hosts (MDS072)](plan/2607170527_wasm-external-link-check.md)                                                            |
 | 2607171900 | 🔳     | opus   | [Slidev structure rule (MDS073) — validate layouts, slots, fields, and frontmatter keys per slide](plan/2607171900_slidev-structure-rule.md)            |
-| 2607191917 | 🔲     | haiku  | [Add dedicated unit tests for printInitCatalog and setInitUsage](plan/2607191917_arch-fix-printinitcatalog-unit-test.md)                                |
+| 2607191917 | ✅     | haiku  | [Add dedicated unit tests for printInitCatalog and setInitUsage](plan/2607191917_arch-fix-printinitcatalog-unit-test.md)                                |
 | 2607191918 | 🔲     | haiku  | [Deduplicate isClaimed between internal/schema and requiredstructure](plan/2607191918_arch-fix-isclaimed-dedup.md)                                      |
 <?/catalog?>

--- a/cmd/mdsmith/init.go
+++ b/cmd/mdsmith/init.go
@@ -23,7 +23,7 @@ import (
 func setInitUsage(fs *flag.FlagSet, w io.Writer) {
 	fs.SetOutput(w)
 	fs.Usage = func() {
-		fmt.Fprintf(w,
+		_, _ = fmt.Fprintf(w,
 			"Usage: mdsmith init [--starter <name>] [--from-markdownlint[=path]] [--add <pack>] [--force] [--list]\n\n"+
 				"Write .mdsmith.yml in the current directory and, optionally, scaffold\n"+
 				"additive .mdsmith/ packs beside it.\n\n"+

--- a/cmd/mdsmith/init.go
+++ b/cmd/mdsmith/init.go
@@ -18,10 +18,10 @@ import (
 	"github.com/jeduden/mdsmith/internal/yamlutil"
 )
 
-// setInitUsage installs the `mdsmith init` usage text on fs.
-func setInitUsage(fs *flag.FlagSet) {
+// setInitUsage installs the `mdsmith init` usage text on fs, writing to w.
+func setInitUsage(fs *flag.FlagSet, w io.Writer) {
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr,
+		fmt.Fprintf(w,
 			"Usage: mdsmith init [--starter <name>] [--from-markdownlint[=path]] [--add <pack>] [--force] [--list]\n\n"+
 				"Write .mdsmith.yml in the current directory and, optionally, scaffold\n"+
 				"additive .mdsmith/ packs beside it.\n\n"+
@@ -62,7 +62,7 @@ func runInit(args []string) int {
 	var list bool
 	fs.BoolVar(&list, "list", false,
 		"List the available starters and packs, then exit")
-	setInitUsage(fs)
+	setInitUsage(fs, os.Stderr)
 
 	if err := fs.Parse(args); err != nil {
 		if code := reportFlagParseErr(err, os.Stderr, "mdsmith: init"); code >= 0 {

--- a/cmd/mdsmith/init.go
+++ b/cmd/mdsmith/init.go
@@ -19,7 +19,9 @@ import (
 )
 
 // setInitUsage installs the `mdsmith init` usage text on fs, writing to w.
+// It also calls fs.SetOutput(w) so fs.PrintDefaults() flows to the same writer.
 func setInitUsage(fs *flag.FlagSet, w io.Writer) {
+	fs.SetOutput(w)
 	fs.Usage = func() {
 		fmt.Fprintf(w,
 			"Usage: mdsmith init [--starter <name>] [--from-markdownlint[=path]] [--add <pack>] [--force] [--list]\n\n"+

--- a/cmd/mdsmith/init_unit_test.go
+++ b/cmd/mdsmith/init_unit_test.go
@@ -33,9 +33,7 @@ func TestPrintInitCatalog(t *testing.T) {
 func TestSetInitUsage(t *testing.T) {
 	var buf bytes.Buffer
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
-	fs.SetOutput(&buf)
-	var force bool
-	fs.BoolVar(&force, "force", false, "overwrite existing .mdsmith.yml")
+	fs.BoolVar(new(bool), "force", false, "overwrite existing .mdsmith.yml")
 	setInitUsage(fs, &buf)
 	fs.Usage()
 	out := buf.String()
@@ -44,6 +42,8 @@ func TestSetInitUsage(t *testing.T) {
 	assert.Contains(t, out, "--add")
 	assert.Contains(t, out, "--force")
 	assert.Contains(t, out, "--list")
+	// Pins that fs.PrintDefaults() ran: description only appears via PrintDefaults, not the static header.
+	assert.Contains(t, out, "overwrite existing .mdsmith.yml")
 }
 
 // --- runInit ---

--- a/cmd/mdsmith/init_unit_test.go
+++ b/cmd/mdsmith/init_unit_test.go
@@ -25,7 +25,9 @@ func TestPrintInitCatalog(t *testing.T) {
 	assert.Contains(t, out, "Starters (mdsmith init --starter <name>):")
 	assert.Contains(t, out, "Packs (mdsmith init --add <name>):")
 	assert.Contains(t, out, "okf")
+	assert.Contains(t, out, "Open Knowledge Format bundle config")
 	assert.Contains(t, out, "wordlists")
+	assert.Contains(t, out, "Curated no-llm-tells word-lists")
 }
 
 // --- setInitUsage ---
@@ -33,7 +35,7 @@ func TestPrintInitCatalog(t *testing.T) {
 func TestSetInitUsage(t *testing.T) {
 	var buf bytes.Buffer
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
-	fs.BoolVar(new(bool), "force", false, "overwrite existing .mdsmith.yml")
+	fs.BoolVar(new(bool), "force", false, "Overwrite an existing .mdsmith.yml instead of leaving it unchanged")
 	setInitUsage(fs, &buf)
 	fs.Usage()
 	out := buf.String()
@@ -43,7 +45,7 @@ func TestSetInitUsage(t *testing.T) {
 	assert.Contains(t, out, "--force")
 	assert.Contains(t, out, "--list")
 	// Pins that fs.PrintDefaults() ran: description only appears via PrintDefaults, not the static header.
-	assert.Contains(t, out, "overwrite existing .mdsmith.yml")
+	assert.Contains(t, out, "Overwrite an existing .mdsmith.yml instead of leaving it unchanged")
 }
 
 // --- runInit ---

--- a/cmd/mdsmith/init_unit_test.go
+++ b/cmd/mdsmith/init_unit_test.go
@@ -31,9 +31,14 @@ func TestPrintInitCatalog(t *testing.T) {
 // --- setInitUsage ---
 
 func TestSetInitUsage(t *testing.T) {
+	var buf bytes.Buffer
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
-	setInitUsage(fs)
-	out := captureStderr(func() { fs.Usage() })
+	fs.SetOutput(&buf)
+	var force bool
+	fs.BoolVar(&force, "force", false, "overwrite existing .mdsmith.yml")
+	setInitUsage(fs, &buf)
+	fs.Usage()
+	out := buf.String()
 	assert.Contains(t, out, "--starter")
 	assert.Contains(t, out, "--from-markdownlint")
 	assert.Contains(t, out, "--add")

--- a/cmd/mdsmith/init_unit_test.go
+++ b/cmd/mdsmith/init_unit_test.go
@@ -11,8 +11,35 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	flag "github.com/spf13/pflag"
+
 	"github.com/jeduden/mdsmith/internal/pack"
 )
+
+// --- printInitCatalog ---
+
+func TestPrintInitCatalog(t *testing.T) {
+	var buf bytes.Buffer
+	printInitCatalog(&buf)
+	out := buf.String()
+	assert.Contains(t, out, "Starters (mdsmith init --starter <name>):")
+	assert.Contains(t, out, "Packs (mdsmith init --add <name>):")
+	assert.Contains(t, out, "okf")
+	assert.Contains(t, out, "wordlists")
+}
+
+// --- setInitUsage ---
+
+func TestSetInitUsage(t *testing.T) {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	setInitUsage(fs)
+	out := captureStderr(func() { fs.Usage() })
+	assert.Contains(t, out, "--starter")
+	assert.Contains(t, out, "--from-markdownlint")
+	assert.Contains(t, out, "--add")
+	assert.Contains(t, out, "--force")
+	assert.Contains(t, out, "--list")
+}
 
 // --- runInit ---
 

--- a/plan/2607191917_arch-fix-printinitcatalog-unit-test.md
+++ b/plan/2607191917_arch-fix-printinitcatalog-unit-test.md
@@ -3,7 +3,7 @@ id: 2607191917
 title: >-
   Add dedicated unit tests for printInitCatalog and
   setInitUsage
-status: "🔲"
+status: "✅"
 model: haiku
 summary: >-
   printInitCatalog and setInitUsage (cmd/mdsmith/init.go)
@@ -83,11 +83,11 @@ method — both are helpers `runInit` wires up.
 
 ## Acceptance Criteria
 
-- [ ] `TestPrintInitCatalog` exists in
+- [x] `TestPrintInitCatalog` exists in
       [init_unit_test.go](../cmd/mdsmith/init_unit_test.go) and
       exercises `printInitCatalog` directly (no subprocess).
-- [ ] `TestSetInitUsage` exists in
+- [x] `TestSetInitUsage` exists in
       [init_unit_test.go](../cmd/mdsmith/init_unit_test.go) and
       exercises `setInitUsage` directly (no subprocess).
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

- Adds `TestPrintInitCatalog` directly exercising `printInitCatalog` via a `bytes.Buffer` — no subprocess, asserts both section headers and concrete description text for the `okf` starter and `wordlists` pack.
- Adds `TestSetInitUsage` directly exercising `setInitUsage` via a `bytes.Buffer` injected into the new `w io.Writer` parameter — no subprocess, asserts the static header flag names and pins `fs.PrintDefaults()` via the production `--force` description.
- Refactors `setInitUsage` to accept `io.Writer` (matching `printInitCatalog`) and calls `fs.SetOutput(w)` so both the header and `PrintDefaults()` output flow to the same writer without callers having to align them independently.

Closes plan 2607191917.

## Test plan

- [ ] `go test ./cmd/mdsmith/...` passes
- [ ] `TestPrintInitCatalog` and `TestSetInitUsage` appear in output with no subprocess
- [ ] `mdsmith check .` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_013KgrSLVGA3ioVKvpNkK9ar)_