### PR TITLE
refactor(schema): deduplicate isClaimed — export as schema.IsClaimed (plan 2607191918)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -256,5 +256,5 @@ footer: |
 | 2607170527 | 🔳     | opus   | [External link checking on WASM hosts (MDS072)](plan/2607170527_wasm-external-link-check.md)                                                            |
 | 2607171900 | 🔳     | opus   | [Slidev structure rule (MDS073) — validate layouts, slots, fields, and frontmatter keys per slide](plan/2607171900_slidev-structure-rule.md)            |
 | 2607191917 | 🔲     | haiku  | [Add dedicated unit tests for printInitCatalog and setInitUsage](plan/2607191917_arch-fix-printinitcatalog-unit-test.md)                                |
-| 2607191918 | 🔲     | haiku  | [Deduplicate isClaimed between internal/schema and requiredstructure](plan/2607191918_arch-fix-isclaimed-dedup.md)                                      |
+| 2607191918 | ✅     | haiku  | [Deduplicate isClaimed between internal/schema and requiredstructure](plan/2607191918_arch-fix-isclaimed-dedup.md)                                      |
 <?/catalog?>

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -2153,7 +2153,6 @@ func levelMismatchDiag(
 	return d.Emit(makeDiag, f.Path, dh.Line)
 }
 
-
 // nextUnclaimed returns the first index in candidates that is >= minIdx
 // and not yet claimed, or -1 if none qualifies.
 func nextUnclaimed(candidates []int, claimed map[int]struct{}, minIdx int) int {

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1997,7 +1997,7 @@ func walkRequiredHeadings(
 			allowExtra = true
 			continue
 		}
-		if isClaimed(claimed, schIdx) {
+		if schema.IsClaimed(claimed, schIdx) {
 			continue
 		}
 		// Save the position before the scan so that a missing-section
@@ -2013,7 +2013,7 @@ func walkRequiredHeadings(
 		if found {
 			allowExtra = false
 		}
-		if !found && !isClaimed(claimed, schIdx) {
+		if !found && !schema.IsClaimed(claimed, schIdx) {
 			diags = append(diags, missingSectionDiagLegacy(
 				f, req, ref, legacyPrecedingLine(docHeadings, preScanIdx)))
 		}
@@ -2153,15 +2153,6 @@ func levelMismatchDiag(
 	return d.Emit(makeDiag, f.Path, dh.Line)
 }
 
-// isClaimed reports whether idx is a member of claimed. claimed is a
-// set — every entry is written exactly once, via claimed[idx] =
-// struct{}{} — so map[int]struct{} (zero-byte value) replaces the
-// map[int]bool this file used to spell as a truthy map read. Mirrors
-// internal/schema/validate.go's isClaimed for the identical pattern.
-func isClaimed(claimed map[int]struct{}, idx int) bool {
-	_, ok := claimed[idx]
-	return ok
-}
 
 // nextUnclaimed returns the first index in candidates that is >= minIdx
 // and not yet claimed, or -1 if none qualifies.
@@ -2170,7 +2161,7 @@ func nextUnclaimed(candidates []int, claimed map[int]struct{}, minIdx int) int {
 		if idx < minIdx {
 			continue
 		}
-		if !isClaimed(claimed, idx) {
+		if !schema.IsClaimed(claimed, idx) {
 			return idx
 		}
 	}

--- a/internal/schema/matchtree.go
+++ b/internal/schema/matchtree.go
@@ -183,7 +183,7 @@ func collectUnlistedBlockMatches(
 	claimed map[int]struct{}, blocks []contentBlock, parent *ScopeMatch,
 ) {
 	for i, dh := range heads {
-		if isClaimed(claimed, i) || dh.Level != rootLevel {
+		if IsClaimed(claimed, i) || dh.Level != rootLevel {
 			continue
 		}
 		end := contentScopeEndLine(heads, i, dh.Level, docEnd)

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -683,6 +683,13 @@ func isClaimed(claimed map[int]struct{}, idx int) bool {
 	return ok
 }
 
+// IsClaimed reports whether idx is a member of claimed. Exported so
+// callers outside the schema package (e.g. requiredstructure) share the
+// same set-membership helper without duplicating it.
+func IsClaimed(claimed map[int]struct{}, idx int) bool {
+	return isClaimed(claimed, idx)
+}
+
 // validateScopes walks scopes (the listed children of a single level)
 // against docHeads starting at docIdx. expectedLevel is the heading
 // level these scopes should appear at. Returns the new docIdx

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -672,12 +672,7 @@ func skipBelow(heads []DocHeading, rootLevel int) []DocHeading {
 	return out
 }
 
-// IsClaimed reports whether idx is a member of claimed. claimed is a
-// set — every entry is written exactly once, via claimed[idx] =
-// struct{}{} — so map[int]struct{} (zero-byte value) replaces the
-// map[int]bool every read/write site in this file, matchtree.go, and
-// validate_content.go used to spell as a truthy map read. See
-// docs/development/high-performance-go.md "map[K]struct{} for sets".
+// IsClaimed reports whether idx is a member of the claimed set.
 func IsClaimed(claimed map[int]struct{}, idx int) bool {
 	_, ok := claimed[idx]
 	return ok

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -672,22 +672,15 @@ func skipBelow(heads []DocHeading, rootLevel int) []DocHeading {
 	return out
 }
 
-// isClaimed reports whether idx is a member of claimed. claimed is a
+// IsClaimed reports whether idx is a member of claimed. claimed is a
 // set — every entry is written exactly once, via claimed[idx] =
 // struct{}{} — so map[int]struct{} (zero-byte value) replaces the
 // map[int]bool every read/write site in this file, matchtree.go, and
 // validate_content.go used to spell as a truthy map read. See
 // docs/development/high-performance-go.md "map[K]struct{} for sets".
-func isClaimed(claimed map[int]struct{}, idx int) bool {
+func IsClaimed(claimed map[int]struct{}, idx int) bool {
 	_, ok := claimed[idx]
 	return ok
-}
-
-// IsClaimed reports whether idx is a member of claimed. Exported so
-// callers outside the schema package (e.g. requiredstructure) share the
-// same set-membership helper without duplicating it.
-func IsClaimed(claimed map[int]struct{}, idx int) bool {
-	return isClaimed(claimed, idx)
 }
 
 // validateScopes walks scopes (the listed children of a single level)
@@ -722,7 +715,7 @@ func validateScopes(
 			claimed[i] = struct{}{}
 			continue
 		}
-		if isClaimed(claimed, i) {
+		if IsClaimed(claimed, i) {
 			continue
 		}
 		newIdx, scDiags, claimedThis := matchScope(
@@ -732,7 +725,7 @@ func validateScopes(
 		docIdx = newIdx
 		if claimedThis {
 			allowExtra = false
-		} else if !isClaimed(claimed, i) && sc.Required() {
+		} else if !IsClaimed(claimed, i) && sc.Required() {
 			// Anchor the missing section at the heading it should
 			// follow (the preceding document heading), so the
 			// squiggle lands where the section belongs rather than
@@ -905,7 +898,7 @@ func claimedScopeMatches(
 	claimCounts map[int]int, docFM map[string]any,
 ) (int, bool) {
 	for i, sc := range scopes {
-		if !isClaimed(claimed, i) {
+		if !IsClaimed(claimed, i) {
 			continue
 		}
 		if sc.Preamble || isSlotMatcher(sc.Matcher) {
@@ -968,7 +961,7 @@ func unclaimedListedScope(
 	docFM map[string]any,
 ) int {
 	for i, sc := range scopes {
-		if isClaimed(claimed, i) || sc.Preamble || isSlotMatcher(sc.Matcher) {
+		if IsClaimed(claimed, i) || sc.Preamble || isSlotMatcher(sc.Matcher) {
 			continue
 		}
 		if scopeMatchesHeading(sc, dh, docFM) {
@@ -1313,7 +1306,7 @@ func anyLaterScopeClaims(
 ) bool {
 	for i := startIdx; i < len(scopes); i++ {
 		sc := scopes[i]
-		if isClaimed(claimed, i) || sc.Preamble || isSlotMatcher(sc.Matcher) {
+		if IsClaimed(claimed, i) || sc.Preamble || isSlotMatcher(sc.Matcher) {
 			continue
 		}
 		if scopeMatchesHeading(sc, dh, docFM) {
@@ -1337,7 +1330,7 @@ func claimsLaterLiteral(
 ) bool {
 	for i := startIdx; i < len(scopes); i++ {
 		sc := scopes[i]
-		if isClaimed(claimed, i) || sc.Preamble ||
+		if IsClaimed(claimed, i) || sc.Preamble ||
 			isSlotMatcher(sc.Matcher) || isBroadMatcher(sc.Matcher) {
 			continue
 		}
@@ -1472,7 +1465,7 @@ func findOutOfOrderIdx(
 ) int {
 	for i := minIdx; i < len(scopes); i++ {
 		sc := scopes[i]
-		if isClaimed(claimed, i) || sc.Preamble || isSlotMatcher(sc.Matcher) {
+		if IsClaimed(claimed, i) || sc.Preamble || isSlotMatcher(sc.Matcher) {
 			continue
 		}
 		if scopeMatchesHeading(sc, dh, docFM) {
@@ -1544,7 +1537,7 @@ func scanScopeRunAtLevel(
 	var out []int
 	started := false
 	for i, h := range heads {
-		if isClaimed(claimed, i) {
+		if IsClaimed(claimed, i) {
 			continue
 		}
 		if h.Line < parentStart || h.Line >= parentEnd {
@@ -1592,7 +1585,7 @@ func firstWrongLevelMatch(
 		return -1
 	}
 	for i, h := range heads {
-		if isClaimed(claimed, i) {
+		if IsClaimed(claimed, i) {
 			continue
 		}
 		if h.Line < parentStart || h.Line >= parentEnd {

--- a/internal/schema/validate_content.go
+++ b/internal/schema/validate_content.go
@@ -394,7 +394,7 @@ func (w *contentWalker) run(diags *[]lint.Diagnostic) {
 			w.allowExtra = true
 			continue
 		}
-		if isClaimed(w.claimed, i) {
+		if IsClaimed(w.claimed, i) {
 			continue
 		}
 		w.matchEntry(i, entry, diags)
@@ -445,7 +445,7 @@ func (w *contentWalker) matchEntry(
 		}
 		w.nodeIdx++
 	}
-	if !isClaimed(w.claimed, i) && entry.Required {
+	if !IsClaimed(w.claimed, i) && entry.Required {
 		*diags = append(*diags, w.mkDiag(
 			w.f.Path, w.sectionLine,
 			fmt.Sprintf("missing required content %q inside %s",
@@ -460,7 +460,7 @@ func (w *contentWalker) matchEntry(
 // node by kind.
 func (w *contentWalker) findLaterEntry(startIdx int, n ast.Node) int {
 	for j := startIdx; j < len(w.sc.Content); j++ {
-		if isClaimed(w.claimed, j) {
+		if IsClaimed(w.claimed, j) {
 			continue
 		}
 		e := w.sc.Content[j]

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -417,3 +417,20 @@ func TestIsClaimed(t *testing.T) {
 	assert.True(t, IsClaimed(claimed, 3), "present idx must be claimed")
 	assert.False(t, IsClaimed(claimed, 7), "absent idx must not be claimed")
 }
+
+func TestIsClaimed_Nil(t *testing.T) {
+	assert.False(t, IsClaimed(nil, 0))
+}
+
+func TestIsClaimed_Empty(t *testing.T) {
+	assert.False(t, IsClaimed(map[int]struct{}{}, 0))
+}
+
+// TestIsClaimedAcceptsStructSet pins IsClaimed's "claimed" parameter to
+// map[int]struct{}, not map[int]bool. The struct{} value drops per-entry
+// map overhead versus bool. See
+// docs/development/high-performance-go.md "map[K]struct{} for sets".
+func TestIsClaimedAcceptsStructSet(t *testing.T) {
+	accept := func(func(map[int]struct{}, int) bool) {}
+	accept(IsClaimed)
+}

--- a/internal/schema/validate_coverage_test.go
+++ b/internal/schema/validate_coverage_test.go
@@ -409,3 +409,11 @@ func TestDedupedCUEErrorDiags_DuplicateKeyCollapses(t *testing.T) {
 	diags := dedupedCUEErrorDiags(f, sch, docFM, dup, keyLines, makeDiagForTest)
 	assert.Len(t, diags, 1, "two identical cueErrs entries must collapse to one diagnostic")
 }
+
+// TestIsClaimed covers both branches of IsClaimed: a present idx
+// reports true; an absent idx reports false.
+func TestIsClaimed(t *testing.T) {
+	claimed := map[int]struct{}{3: {}}
+	assert.True(t, IsClaimed(claimed, 3), "present idx must be claimed")
+	assert.False(t, IsClaimed(claimed, 7), "absent idx must not be claimed")
+}

--- a/plan/2607191918_arch-fix-isclaimed-dedup.md
+++ b/plan/2607191918_arch-fix-isclaimed-dedup.md
@@ -3,7 +3,7 @@ id: 2607191918
 title: >-
   Deduplicate isClaimed between internal/schema and
   requiredstructure
-status: "🔲"
+status: "✅"
 model: haiku
 summary: >-
   internal/rules/requiredstructure/rule.go carries a
@@ -58,7 +58,7 @@ found this duplication:
 
 ## Acceptance Criteria
 
-- [ ] Only one implementation of the claimed-range check
+- [x] Only one implementation of the claimed-range check
       exists in the repository.
-- [ ] `go test ./...` is green.
-- [ ] `mdsmith check .` is green.
+- [x] `go test ./...` is green.
+- [x] `mdsmith check .` is green.


### PR DESCRIPTION
## Summary

- Exports `IsClaimed` from `internal/schema/validate.go` as the single implementation of the claimed-range set check.
- Removes the byte-for-byte private `isClaimed` copy from `internal/rules/requiredstructure/rule.go` (which already imported `internal/schema`), replacing the three call sites with `schema.IsClaimed`.
- Renames the private `isClaimed` → `IsClaimed` throughout the schema package (`validate.go`, `matchtree.go`, `validate_content.go`), eliminating the now-redundant forwarding wrapper.
- Adds `TestIsClaimed` in `internal/schema/validate_coverage_test.go` covering the present-index and absent-index branches per the project's Red/Green TDD convention.
- Trims the doc comment to one line, removing the caller enumeration and refactor-history narration that violated CLAUDE.md's no-caller-reference rule.
- Removes the double blank line left by the deletion in `requiredstructure/rule.go`.

Closes plan 2607191918.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/schema/... ./internal/rules/requiredstructure/...` passes
- [x] `go test ./...` passes (no regressions)
- [x] `mdsmith check .` passes (0 failures)
- [x] `TestIsClaimed` covers present-idx (true) and absent-idx (false) branches

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZhZLDQbbu9MyHzgL1Sfjs)_