### PR TITLE
feat(rules): add MDS073 slide-structure — Slidev structural validation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -254,7 +254,7 @@ footer: |
 | 2607082052 | ✅     | sonnet | [SARIF output format for `mdsmith check`](plan/2607082052_check-sarif-output.md)                                                                        |
 | 2607121915 | ✅     | sonnet | [Resolve the internal/linkgraph purity-contract mismatch for wikilink resolution](plan/2607121915_arch-fix-linkgraph-wikilink-purity.md)                |
 | 2607170527 | 🔳     | opus   | [External link checking on WASM hosts (MDS072)](plan/2607170527_wasm-external-link-check.md)                                                            |
-| 2607171900 | 🔳     | opus   | [Slidev structure rule (MDS073) — validate layouts, slots, fields, and frontmatter keys per slide](plan/2607171900_slidev-structure-rule.md)            |
+| 2607171900 | ✅     | opus   | [Slidev structure rule (MDS073) — validate layouts, slots, fields, and frontmatter keys per slide](plan/2607171900_slidev-structure-rule.md)            |
 | 2607191917 | 🔲     | haiku  | [Add dedicated unit tests for printInitCatalog and setInitUsage](plan/2607191917_arch-fix-printinitcatalog-unit-test.md)                                |
 | 2607191918 | 🔲     | haiku  | [Deduplicate isClaimed between internal/schema and requiredstructure](plan/2607191918_arch-fix-isclaimed-dedup.md)                                      |
 <?/catalog?>

--- a/internal/rules/MDS073-slide-structure/bad/unknown-frontmatter-key.md
+++ b/internal/rules/MDS073-slide-structure/bad/unknown-frontmatter-key.md
@@ -2,7 +2,7 @@
 diagnostics:
   - line: 7
     column: 1
-    message: 'unknown Slidev frontmatter key "transiton" — did you mean "transition"?'
+    message: 'unknown Slidev frontmatter key "transiton" — did you mean "transition"'
 ---
 # Slide
 

--- a/internal/rules/MDS073-slide-structure/bad/unknown-layout.md
+++ b/internal/rules/MDS073-slide-structure/bad/unknown-layout.md
@@ -2,7 +2,7 @@
 diagnostics:
   - line: 6
     column: 1
-    message: 'unknown Slidev layout "centre" — did you mean "center"?'
+    message: 'unknown Slidev layout "centre" — did you mean "center"'
 ---
 # Slide one
 

--- a/internal/rules/slidevstructure/rule.go
+++ b/internal/rules/slidevstructure/rule.go
@@ -26,6 +26,18 @@ import (
 
 func init() {
 	rule.Register(&Rule{})
+
+	sortedBuiltinLayouts = make([]string, 0, len(builtinLayouts))
+	for k := range builtinLayouts {
+		sortedBuiltinLayouts = append(sortedBuiltinLayouts, k)
+	}
+	sort.Strings(sortedBuiltinLayouts)
+
+	sortedKnownFMKeys = make([]string, 0, len(knownFMKeys))
+	for k := range knownFMKeys {
+		sortedKnownFMKeys = append(sortedKnownFMKeys, k)
+	}
+	sort.Strings(sortedKnownFMKeys)
 }
 
 // Rule implements MDS073.
@@ -49,7 +61,7 @@ func (r *Rule) Category() string { return "structural" }
 // by the `slidev` convention.
 func (r *Rule) EnabledByDefault() bool { return false }
 
-// builtinLayouts is the set of Slidev's 18 built-in layout names.
+// builtinLayouts is the set of Slidev's 19 built-in layout names.
 var builtinLayouts = map[string]bool{
 	"center": true, "cover": true, "default": true, "end": true,
 	"fact": true, "full": true, "image": true, "image-left": true,
@@ -58,6 +70,10 @@ var builtinLayouts = map[string]bool{
 	"section": true, "statement": true, "two-cols": true,
 	"two-cols-header": true,
 }
+
+// sortedBuiltinLayouts is the sorted slice of builtinLayouts keys,
+// populated by init. Avoids re-building from map on every call.
+var sortedBuiltinLayouts []string
 
 // layoutSlots maps a layout to the named slots it exposes. A ::slot::
 // for any other name is orphaned — its content will not render. The
@@ -88,6 +104,10 @@ var knownFMKeys = map[string]bool{
 	"transition": true, "background": true, "backgroundSize": true,
 	"name": true, "image": true, "url": true, "default": true,
 }
+
+// sortedKnownFMKeys is the sorted slice of knownFMKeys keys, populated
+// by init. Avoids rebuilding the candidate list on every check-5 call.
+var sortedKnownFMKeys []string
 
 var fenceBytes = []byte("---")
 
@@ -136,8 +156,8 @@ func parseFrontMatterBytes(b []byte) map[string]string {
 		if c <= 0 {
 			continue
 		}
-		// Skip indented (nested) keys — top-level slide keys only.
-		if ln[0] == ' ' || ln[0] == '\t' || ln[0] == '-' {
+		// Skip indented (nested) keys and list entries — top-level slide keys only.
+		if len(ln) > 0 && (ln[0] == ' ' || ln[0] == '\t' || ln[0] == '-') {
 			continue
 		}
 		fm[string(bytes.TrimSpace(t[:c]))] = string(bytes.TrimSpace(t[c+1:]))
@@ -242,23 +262,69 @@ func isFence(line []byte) bool {
 // hasFrontmatterAfter reports whether the block after a boundary at
 // index sep is a YAML frontmatter block: key/list lines closed by a
 // second `---` with no blank line breaking into body first.
+//
+// A line is treated as a YAML key line only when the raw (untrimmed)
+// line starts with a non-whitespace, non-dash character and the portion
+// before the colon is a YAML-safe identifier (letters, digits, dash,
+// underscore). List entries (`- …`) are accepted only after at least
+// one key line has been seen, as continuation values of a sequence.
 func hasFrontmatterAfter(lines [][]byte, sep int) bool {
 	sawKey := false
 	for j := sep + 1; j < len(lines); j++ {
-		if isFence(lines[j]) {
+		raw := lines[j]
+		if isFence(raw) {
 			return sawKey
 		}
-		t := bytes.TrimSpace(lines[j])
+		t := bytes.TrimSpace(raw)
 		if len(t) == 0 {
 			return false
 		}
-		if bytes.IndexByte(t, ':') >= 0 || bytes.HasPrefix(t, []byte("- ")) {
+		// Indented lines are nested YAML values; not evidence of a new key.
+		if len(raw) > 0 && (raw[0] == ' ' || raw[0] == '\t') {
+			if sawKey {
+				continue
+			}
+			return false
+		}
+		// List entries (`- value`) are accepted only after a key has been
+		// seen; a block that opens with a list item is not a mapping.
+		if bytes.HasPrefix(t, []byte("- ")) {
+			if sawKey {
+				continue
+			}
+			return false
+		}
+		// Accept as a key line only when a colon follows a valid YAML
+		// identifier (letters, digits, dash, underscore; no spaces).
+		c := bytes.IndexByte(t, ':')
+		if c > 0 && isYAMLIdent(t[:c]) {
 			sawKey = true
 			continue
 		}
 		return false
 	}
 	return false
+}
+
+// isYAMLIdent reports whether b looks like a bare YAML mapping key:
+// starts with a letter or underscore, contains only letters, digits,
+// dashes, and underscores. This excludes prose sentences from being
+// misidentified as frontmatter keys.
+func isYAMLIdent(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	c := b[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
+		return false
+	}
+	for _, c := range b[1:] {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 // readFrontmatter parses a `---`\nYAML\n`---` block opening at index
@@ -269,7 +335,13 @@ func readFrontmatter(lines [][]byte, open int) (map[string]string, map[string]in
 	fmLine := map[string]int{}
 	j := open + 1
 	for ; j < len(lines) && !isFence(lines[j]); j++ {
-		t := bytes.TrimSpace(lines[j])
+		raw := lines[j]
+		// Skip indented (nested) values and list entries — same guard as
+		// parseFrontMatterBytes so both parsers treat the same lines as keys.
+		if len(raw) > 0 && (raw[0] == ' ' || raw[0] == '\t' || raw[0] == '-') {
+			continue
+		}
+		t := bytes.TrimSpace(raw)
 		c := bytes.IndexByte(t, ':')
 		if c <= 0 {
 			continue
@@ -300,15 +372,19 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 		layout, hasLayout = s.fm["layout"]
 	}
 	anchor := s.startLine
-	if ln, ok := s.fmLine["layout"]; ok {
-		anchor = ln
+	if s.fmLine != nil {
+		if ln, ok := s.fmLine["layout"]; ok {
+			anchor = ln
+		}
 	}
 
 	// 1. Unknown layout name.
+	unknownLayout := false
 	if hasLayout && !builtinLayouts[layout] && !r.isCustomLayout(layout) {
+		unknownLayout = true
 		msg := fmt.Sprintf("unknown Slidev layout %q", layout)
 		if sug := nearest(layout, r.layoutCandidates()); sug != "" {
-			msg += fmt.Sprintf(" — did you mean %q?", sug)
+			msg += fmt.Sprintf(" — did you mean %q", sug)
 		}
 		diags = append(diags, r.diag(f, anchor, msg))
 	}
@@ -318,22 +394,28 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 		effLayout = "default"
 	}
 
-	// 2. Missing required slot(s).
-	for _, need := range layoutSlots[effLayout] {
-		if !slotProvided(s.slots, need) {
-			diags = append(diags, r.diag(f, anchor, fmt.Sprintf(
-				"layout %q requires a ::%s:: slot — that column will be empty",
-				effLayout, need)))
+	// 2. Missing required slot(s). Skip when check 1 already fired: the
+	// layout is unknown so we cannot know what slots it requires.
+	if !unknownLayout {
+		for _, need := range layoutSlots[effLayout] {
+			if !slotProvided(s.slots, need) {
+				diags = append(diags, r.diag(f, anchor, fmt.Sprintf(
+					"layout %q requires a ::%s:: slot — that column will be empty",
+					effLayout, need)))
+			}
 		}
 	}
 
-	// 3. Orphaned slot(s): content that will not render.
-	accepted := layoutSlots[effLayout]
-	for _, sl := range s.slots {
-		if !contains(accepted, sl.name) {
-			diags = append(diags, r.diag(f, sl.line, fmt.Sprintf(
-				"::%s:: has no matching slot in layout %q — this content will not render",
-				sl.name, effLayout)))
+	// 3. Orphaned slot(s): content that will not render. Skip when check 1
+	// already fired: the layout is unknown so we cannot judge valid slots.
+	if !unknownLayout {
+		accepted := layoutSlots[effLayout]
+		for _, sl := range s.slots {
+			if !contains(accepted, sl.name) {
+				diags = append(diags, r.diag(f, sl.line, fmt.Sprintf(
+					"::%s:: has no matching slot in layout %q — this content will not render",
+					sl.name, effLayout)))
+			}
 		}
 	}
 
@@ -345,14 +427,20 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 		}
 	}
 
-	// 5. Unknown frontmatter key (typo — passes through silently).
+	// 5. Unknown frontmatter key (typo — passes through silently in Slidev).
 	for _, k := range sortedKeys(s.fm) {
 		if knownFMKeys[k] {
 			continue
 		}
-		if sug := nearest(k, knownKeyList()); sug != "" {
-			diags = append(diags, r.diag(f, s.fmLine[k], fmt.Sprintf(
-				"unknown Slidev frontmatter key %q — did you mean %q?", k, sug)))
+		lineNo := s.startLine
+		if s.fmLine != nil {
+			if ln, ok := s.fmLine[k]; ok {
+				lineNo = ln
+			}
+		}
+		if sug := nearest(k, sortedKnownFMKeys); sug != "" {
+			diags = append(diags, r.diag(f, lineNo, fmt.Sprintf(
+				"unknown Slidev frontmatter key %q — did you mean %q", k, sug)))
 		}
 	}
 
@@ -411,21 +499,15 @@ func sortedKeys(m map[string]string) []string {
 }
 
 // layoutCandidates returns builtin plus custom layout names for
-// did-you-mean matching.
+// did-you-mean matching. The builtin portion comes from the package-level
+// sorted var; CustomLayouts are appended (sorted by ApplySettings).
 func (r *Rule) layoutCandidates() []string {
-	out := make([]string, 0, len(builtinLayouts)+len(r.CustomLayouts))
-	for k := range builtinLayouts {
-		out = append(out, k)
+	if len(r.CustomLayouts) == 0 {
+		return sortedBuiltinLayouts
 	}
+	out := make([]string, 0, len(sortedBuiltinLayouts)+len(r.CustomLayouts))
+	out = append(out, sortedBuiltinLayouts...)
 	out = append(out, r.CustomLayouts...)
-	return out
-}
-
-func knownKeyList() []string {
-	out := make([]string, 0, len(knownFMKeys))
-	for k := range knownFMKeys {
-		out = append(out, k)
-	}
 	return out
 }
 
@@ -440,6 +522,9 @@ func nearest(s string, cands []string) string {
 	return best
 }
 
+// editDistance computes the Levenshtein edit distance between a and b.
+// Uses fixed-size stack arrays for inputs up to 64 bytes (all Slidev
+// identifiers are shorter), avoiding heap allocations on the hot path.
 func editDistance(a, b string) int {
 	la, lb := len(a), len(b)
 	if la == 0 {
@@ -448,8 +533,12 @@ func editDistance(a, b string) int {
 	if lb == 0 {
 		return la
 	}
-	prev := make([]int, lb+1)
-	cur := make([]int, lb+1)
+	if la > 64 || lb > 64 {
+		return la + lb
+	}
+	var prevBuf, curBuf [65]int
+	prev := prevBuf[:lb+1]
+	cur := curBuf[:lb+1]
 	for j := 0; j <= lb; j++ {
 		prev[j] = j
 	}

--- a/internal/rules/slidevstructure/rule.go
+++ b/internal/rules/slidevstructure/rule.go
@@ -217,7 +217,15 @@ type slotRef struct {
 // treated as the first slide's frontmatter (headmatter, when the
 // engine has not already stripped it).
 func parseSlides(lines [][]byte) []slide {
-	var slides []slide
+	// Pre-count fence lines as an upper bound on slide count so the slice
+	// is allocated once rather than growing via repeated appends.
+	n := 0
+	for _, ln := range lines {
+		if isFence(ln) {
+			n++
+		}
+	}
+	slides := make([]slide, 0, n+1)
 	i := 0
 	cur := slide{startLine: 1}
 	if isFence(lines[0]) {
@@ -281,7 +289,15 @@ func hasFrontmatterAfter(lines [][]byte, sep int) bool {
 		}
 		t := bytes.TrimSpace(raw)
 		if len(t) == 0 {
+			// Blank lines between YAML keys are allowed (YAML 1.2 §8.1.2).
+			if sawKey {
+				continue
+			}
 			return false
+		}
+		// YAML comment lines are valid inside a mapping block.
+		if bytes.HasPrefix(t, []byte("#")) {
+			continue
 		}
 		// Indented lines are nested YAML values; not evidence of a new key.
 		if len(raw) > 0 && (raw[0] == ' ' || raw[0] == '\t') {
@@ -441,12 +457,7 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 }
 
 func (r *Rule) isCustomLayout(name string) bool {
-	for _, c := range r.CustomLayouts {
-		if c == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.CustomLayouts, name)
 }
 
 func (r *Rule) diag(f *lint.File, line int, msg string) lint.Diagnostic {
@@ -524,21 +535,11 @@ func editDistance(a, b string) int {
 			if a[i-1] == b[j-1] {
 				cost = 0
 			}
-			cur[j] = min3(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+			cur[j] = min(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
 		}
 		prev, cur = cur, prev
 	}
 	return prev[lb]
-}
-
-func min3(a, b, c int) int {
-	if b < a {
-		a = b
-	}
-	if c < a {
-		a = c
-	}
-	return a
 }
 
 // ApplySettings implements rule.Configurable.

--- a/internal/rules/slidevstructure/rule.go
+++ b/internal/rules/slidevstructure/rule.go
@@ -17,6 +17,7 @@ package slidevstructure
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -221,7 +222,10 @@ func parseSlides(lines [][]byte) []slide {
 	cur := slide{startLine: 1}
 	if isFence(lines[0]) {
 		cur.fm, cur.fmLine, i = readFrontmatter(lines, 0)
-		cur.startLine = i + 1
+		// Clamp: a headmatter block with no closing fence causes i to
+		// exceed len(lines); cap startLine so it stays in valid range.
+		cur.startLine = min(i+1, len(lines)+1)
+		i = min(i, len(lines))
 	}
 	inCode := false
 	for i < len(lines) {
@@ -263,11 +267,11 @@ func isFence(line []byte) bool {
 // index sep is a YAML frontmatter block: key/list lines closed by a
 // second `---` with no blank line breaking into body first.
 //
-// A line is treated as a YAML key line only when the raw (untrimmed)
-// line starts with a non-whitespace, non-dash character and the portion
-// before the colon is a YAML-safe identifier (letters, digits, dash,
-// underscore). List entries (`- …`) are accepted only after at least
-// one key line has been seen, as continuation values of a sequence.
+// A line is treated as a key line when the portion before the colon
+// contains no spaces — this accepts both standard Slidev keys
+// (layout, transition) and arbitrary pass-through data keys with dots
+// or digits (v1.url, 2col-data), while rejecting prose sentences whose
+// key part would contain spaces ("Visit the site: foo").
 func hasFrontmatterAfter(lines [][]byte, sep int) bool {
 	sawKey := false
 	for j := sep + 1; j < len(lines); j++ {
@@ -294,37 +298,16 @@ func hasFrontmatterAfter(lines [][]byte, sep int) bool {
 			}
 			return false
 		}
-		// Accept as a key line only when a colon follows a valid YAML
-		// identifier (letters, digits, dash, underscore; no spaces).
+		// Accept as a key line when colon is present and the key part
+		// contains no spaces (distinguishes keys from prose sentences).
 		c := bytes.IndexByte(t, ':')
-		if c > 0 && isYAMLIdent(t[:c]) {
+		if c > 0 && bytes.IndexByte(t[:c], ' ') < 0 {
 			sawKey = true
 			continue
 		}
 		return false
 	}
 	return false
-}
-
-// isYAMLIdent reports whether b looks like a bare YAML mapping key:
-// starts with a letter or underscore, contains only letters, digits,
-// dashes, and underscores. This excludes prose sentences from being
-// misidentified as frontmatter keys.
-func isYAMLIdent(b []byte) bool {
-	if len(b) == 0 {
-		return false
-	}
-	c := b[0]
-	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
-		return false
-	}
-	for _, c := range b[1:] {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-			(c >= '0' && c <= '9') || c == '-' || c == '_') {
-			return false
-		}
-	}
-	return true
 }
 
 // readFrontmatter parses a `---`\nYAML\n`---` block opening at index
@@ -398,7 +381,7 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 	// layout is unknown so we cannot know what slots it requires.
 	if !unknownLayout {
 		for _, need := range layoutSlots[effLayout] {
-			if !slotProvided(s.slots, need) {
+			if !slices.ContainsFunc(s.slots, func(sl slotRef) bool { return sl.name == need }) {
 				diags = append(diags, r.diag(f, anchor, fmt.Sprintf(
 					"layout %q requires a ::%s:: slot — that column will be empty",
 					effLayout, need)))
@@ -411,7 +394,7 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 	if !unknownLayout {
 		accepted := layoutSlots[effLayout]
 		for _, sl := range s.slots {
-			if !contains(accepted, sl.name) {
+			if !slices.Contains(accepted, sl.name) {
 				diags = append(diags, r.diag(f, sl.line, fmt.Sprintf(
 					"::%s:: has no matching slot in layout %q — this content will not render",
 					sl.name, effLayout)))
@@ -428,19 +411,29 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 	}
 
 	// 5. Unknown frontmatter key (typo — passes through silently in Slidev).
-	for _, k := range sortedKeys(s.fm) {
-		if knownFMKeys[k] {
-			continue
+	// Pre-scan without allocating; only call sortedKeys when unknown keys exist.
+	hasUnknown := false
+	for k := range s.fm {
+		if !knownFMKeys[k] {
+			hasUnknown = true
+			break
 		}
-		lineNo := s.startLine
-		if s.fmLine != nil {
-			if ln, ok := s.fmLine[k]; ok {
-				lineNo = ln
+	}
+	if hasUnknown {
+		for _, k := range sortedKeys(s.fm) {
+			if knownFMKeys[k] {
+				continue
 			}
-		}
-		if sug := nearest(k, sortedKnownFMKeys); sug != "" {
-			diags = append(diags, r.diag(f, lineNo, fmt.Sprintf(
-				"unknown Slidev frontmatter key %q — did you mean %q", k, sug)))
+			lineNo := s.startLine
+			if s.fmLine != nil {
+				if ln, ok := s.fmLine[k]; ok {
+					lineNo = ln
+				}
+			}
+			if sug := nearest(k, sortedKnownFMKeys); sug != "" {
+				diags = append(diags, r.diag(f, lineNo, fmt.Sprintf(
+					"unknown Slidev frontmatter key %q — did you mean %q", k, sug)))
+			}
 		}
 	}
 
@@ -466,24 +459,6 @@ func (r *Rule) diag(f *lint.File, line int, msg string) lint.Diagnostic {
 		Severity: lint.Warning,
 		Message:  msg,
 	}
-}
-
-func slotProvided(slots []slotRef, name string) bool {
-	for _, s := range slots {
-		if s.name == name {
-			return true
-		}
-	}
-	return false
-}
-
-func contains(list []string, v string) bool {
-	for _, s := range list {
-		if s == v {
-			return true
-		}
-	}
-	return false
 }
 
 func sortedKeys(m map[string]string) []string {

--- a/internal/rules/slidevstructure/rule.go
+++ b/internal/rules/slidevstructure/rule.go
@@ -370,64 +370,99 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 	if s.fm != nil {
 		layout, hasLayout = s.fm["layout"]
 	}
-	anchor := s.startLine
-	if s.fmLine != nil {
-		if ln, ok := s.fmLine["layout"]; ok {
-			anchor = ln
-		}
-	}
+	anchor := r.slideAnchor(s)
 
-	// 1. Unknown layout name.
-	unknownLayout := false
-	if hasLayout && !builtinLayouts[layout] && !r.isCustomLayout(layout) {
-		unknownLayout = true
-		msg := fmt.Sprintf("unknown Slidev layout %q", layout)
-		if sug := nearest(layout, r.layoutCandidates()); sug != "" {
-			msg += fmt.Sprintf(" — did you mean %q", sug)
-		}
-		diags = append(diags, r.diag(f, anchor, msg))
-	}
-
+	unknownLayout, diags := r.checkUnknownLayout(f, diags, layout, hasLayout, anchor)
 	effLayout := layout
 	if !hasLayout {
 		effLayout = "default"
 	}
-
-	// 2. Missing required slot(s). Skip when check 1 already fired: the
-	// layout is unknown so we cannot know what slots it requires.
 	if !unknownLayout {
-		for _, need := range layoutSlots[effLayout] {
-			if !slices.ContainsFunc(s.slots, func(sl slotRef) bool { return sl.name == need }) {
-				diags = append(diags, r.diag(f, anchor, fmt.Sprintf(
-					"layout %q requires a ::%s:: slot — that column will be empty",
-					effLayout, need)))
-			}
+		diags = r.checkMissingSlots(s, f, diags, effLayout, anchor)
+		diags = r.checkOrphanedSlots(s, f, diags, effLayout)
+	}
+	diags = r.checkRequiredField(s, f, diags, effLayout, anchor)
+	diags = r.checkUnknownFMKeys(s, f, diags)
+	return diags
+}
+
+func (r *Rule) slideAnchor(s *slide) int {
+	if s.fmLine != nil {
+		if ln, ok := s.fmLine["layout"]; ok {
+			return ln
 		}
 	}
+	return s.startLine
+}
 
-	// 3. Orphaned slot(s): content that will not render. Skip when check 1
-	// already fired: the layout is unknown so we cannot judge valid slots.
-	if !unknownLayout {
-		accepted := layoutSlots[effLayout]
-		for _, sl := range s.slots {
-			if !slices.Contains(accepted, sl.name) {
-				diags = append(diags, r.diag(f, sl.line, fmt.Sprintf(
-					"::%s:: has no matching slot in layout %q — this content will not render",
-					sl.name, effLayout)))
-			}
-		}
+// checkUnknownLayout emits a diagnostic when the layout name is not
+// a builtin or declared custom layout, and returns whether it fired.
+func (r *Rule) checkUnknownLayout(
+	f *lint.File, diags []lint.Diagnostic,
+	layout string, hasLayout bool, anchor int,
+) (bool, []lint.Diagnostic) {
+	if !hasLayout || builtinLayouts[layout] || r.isCustomLayout(layout) {
+		return false, diags
 	}
+	msg := fmt.Sprintf("unknown Slidev layout %q", layout)
+	if sug := nearest(layout, r.layoutCandidates()); sug != "" {
+		msg += fmt.Sprintf(" — did you mean %q", sug)
+	}
+	return true, append(diags, r.diag(f, anchor, msg))
+}
 
-	// 4. Missing layout-required field.
-	if field, ok := layoutRequiredField[effLayout]; ok {
-		if _, present := s.fm[field]; !present {
+// checkMissingSlots emits a diagnostic for each named slot that the
+// layout requires but the slide body does not provide.
+func (r *Rule) checkMissingSlots(
+	s *slide, f *lint.File, diags []lint.Diagnostic,
+	effLayout string, anchor int,
+) []lint.Diagnostic {
+	for _, need := range layoutSlots[effLayout] {
+		if !slices.ContainsFunc(s.slots, func(sl slotRef) bool { return sl.name == need }) {
 			diags = append(diags, r.diag(f, anchor, fmt.Sprintf(
-				"layout %q requires the %q frontmatter field", effLayout, field)))
+				"layout %q requires a ::%s:: slot — that column will be empty",
+				effLayout, need)))
 		}
 	}
+	return diags
+}
 
-	// 5. Unknown frontmatter key (typo — passes through silently in Slidev).
-	// Pre-scan without allocating; only call sortedKeys when unknown keys exist.
+// checkOrphanedSlots emits a diagnostic for each ::slot:: the slide
+// declares that the effective layout does not expose.
+func (r *Rule) checkOrphanedSlots(s *slide, f *lint.File, diags []lint.Diagnostic, effLayout string) []lint.Diagnostic {
+	accepted := layoutSlots[effLayout]
+	for _, sl := range s.slots {
+		if !slices.Contains(accepted, sl.name) {
+			diags = append(diags, r.diag(f, sl.line, fmt.Sprintf(
+				"::%s:: has no matching slot in layout %q — this content will not render",
+				sl.name, effLayout)))
+		}
+	}
+	return diags
+}
+
+// checkRequiredField emits a diagnostic when the layout demands a
+// specific frontmatter field (e.g. image:) and it is absent.
+func (r *Rule) checkRequiredField(
+	s *slide, f *lint.File, diags []lint.Diagnostic,
+	effLayout string, anchor int,
+) []lint.Diagnostic {
+	field, ok := layoutRequiredField[effLayout]
+	if !ok {
+		return diags
+	}
+	if _, present := s.fm[field]; !present {
+		diags = append(diags, r.diag(f, anchor, fmt.Sprintf(
+			"layout %q requires the %q frontmatter field", effLayout, field)))
+	}
+	return diags
+}
+
+// checkUnknownFMKeys emits a did-you-mean diagnostic for each
+// frontmatter key that is not in the known-key set and is within
+// edit distance 2 of a real key (typos only — arbitrary pass-through
+// data keys that are far from any real key are not flagged).
+func (r *Rule) checkUnknownFMKeys(s *slide, f *lint.File, diags []lint.Diagnostic) []lint.Diagnostic {
 	hasUnknown := false
 	for k := range s.fm {
 		if !knownFMKeys[k] {
@@ -435,24 +470,24 @@ func (r *Rule) checkSlide(s *slide, f *lint.File, diags []lint.Diagnostic) []lin
 			break
 		}
 	}
-	if hasUnknown {
-		for _, k := range sortedKeys(s.fm) {
-			if knownFMKeys[k] {
-				continue
-			}
-			lineNo := s.startLine
-			if s.fmLine != nil {
-				if ln, ok := s.fmLine[k]; ok {
-					lineNo = ln
-				}
-			}
-			if sug := nearest(k, sortedKnownFMKeys); sug != "" {
-				diags = append(diags, r.diag(f, lineNo, fmt.Sprintf(
-					"unknown Slidev frontmatter key %q — did you mean %q", k, sug)))
+	if !hasUnknown {
+		return diags
+	}
+	for _, k := range sortedKeys(s.fm) {
+		if knownFMKeys[k] {
+			continue
+		}
+		lineNo := s.startLine
+		if s.fmLine != nil {
+			if ln, ok := s.fmLine[k]; ok {
+				lineNo = ln
 			}
 		}
+		if sug := nearest(k, sortedKnownFMKeys); sug != "" {
+			diags = append(diags, r.diag(f, lineNo, fmt.Sprintf(
+				"unknown Slidev frontmatter key %q — did you mean %q", k, sug)))
+		}
 	}
-
 	return diags
 }
 
@@ -473,9 +508,6 @@ func (r *Rule) diag(f *lint.File, line int, msg string) lint.Diagnostic {
 }
 
 func sortedKeys(m map[string]string) []string {
-	if len(m) == 0 {
-		return nil
-	}
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)

--- a/internal/rules/slidevstructure/rule_test.go
+++ b/internal/rules/slidevstructure/rule_test.go
@@ -264,3 +264,14 @@ func TestEditDistance_EmptyStrings(t *testing.T) {
 	assert.Equal(t, 3, editDistance("abc", ""))
 	assert.Equal(t, 0, editDistance("", ""))
 }
+
+func TestDottedPassThroughKey_DoesNotBlockFrontmatterParsing(t *testing.T) {
+	// A mid-deck frontmatter block that contains a dotted pass-through data
+	// key (valid in Slidev, not a pure YAML identifier) must not cause the
+	// entire block to be dropped. The layout key in the same block must still
+	// be parsed and checked.
+	src := "# Slide 1\n\n---\nlayout: image-left\nv1.data: foo\n---\n\n# Slide 2\n"
+	diags := check(t, src)
+	require.Len(t, diags, 1, "got: %s", messages(diags))
+	assert.Contains(t, diags[0].Message, `layout "image-left" requires the "image" frontmatter field`)
+}

--- a/internal/rules/slidevstructure/rule_test.go
+++ b/internal/rules/slidevstructure/rule_test.go
@@ -301,3 +301,56 @@ func TestDottedPassThroughKey_DoesNotBlockFrontmatterParsing(t *testing.T) {
 	require.Len(t, diags, 1, "got: %s", messages(diags))
 	assert.Contains(t, diags[0].Message, `layout "image-left" requires the "image" frontmatter field`)
 }
+
+func TestHasFrontmatterAfter_IndentedLineBeforeKey_NotFrontmatter(t *testing.T) {
+	// An indented line that appears BEFORE any key in the block that follows a
+	// separator causes hasFrontmatterAfter to return false — the block is plain
+	// content, not a frontmatter mapping.  The separator is treated as a
+	// horizontal rule so neither slide gains a layout and no diagnostic fires.
+	src := "# A\n\n---\n  nested: x\nlayout: center\n---\n\n# B\n"
+	assert.Empty(t, check(t, src))
+}
+
+func TestHasFrontmatterAfter_IndentedLineAfterKey_OK(t *testing.T) {
+	// An indented line that appears AFTER at least one key is a nested YAML
+	// value; hasFrontmatterAfter continues past it and the block is parsed as
+	// frontmatter normally.
+	src := "# A\n\n---\nlayout: center\n  nested: x\n---\n\n# B\n"
+	assert.Empty(t, check(t, src))
+}
+
+func TestHasFrontmatterAfter_ListEntryBeforeKey_NotFrontmatter(t *testing.T) {
+	// A list entry (`- value`) before any key means the block is a YAML
+	// sequence, not a mapping — hasFrontmatterAfter returns false and the
+	// separator is treated as a horizontal rule.
+	src := "# A\n\n---\n- list-item\nlayout: center\n---\n\n# B\n"
+	assert.Empty(t, check(t, src))
+}
+
+func TestFrontmatterWithListEntry_AfterKey_OK(t *testing.T) {
+	// A list entry that appears after a real key (e.g. a YAML multi-value
+	// field) is accepted by hasFrontmatterAfter (sawKey=true) and skipped by
+	// readFrontmatter — the layout key is still parsed correctly.
+	src := "# A\n\n---\nlayout: center\n- list-item\n---\n\n# B\n"
+	assert.Empty(t, check(t, src))
+}
+
+func TestLayoutCandidates_WithCustomLayouts_DidYouMean(t *testing.T) {
+	// When custom layouts are declared, layoutCandidates merges them with the
+	// builtins so a near-miss against a custom name is suggested.
+	src := "---\nlayout: my-typo\n---\n\n# Slide\n"
+	f := &lint.File{Path: "slides.md", Source: []byte(src), Lines: splitLines(src)}
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"custom-layouts": []any{"my-type"}}))
+	diags := r.Check(f)
+	require.Len(t, diags, 1, "got: %s", messages(diags))
+	assert.Contains(t, diags[0].Message, `did you mean "my-type"`)
+}
+
+func TestEditDistance_LongStrings(t *testing.T) {
+	// Strings longer than 64 bytes are handled by the fast-path guard that
+	// returns la+lb without running the DP table.
+	long := "a string that is definitely longer than sixty-four characters total!"
+	assert.Equal(t, len(long)+1, editDistance(long, "x"))
+	assert.Equal(t, 1+len(long), editDistance("x", long))
+}

--- a/internal/rules/slidevstructure/rule_test.go
+++ b/internal/rules/slidevstructure/rule_test.go
@@ -265,6 +265,32 @@ func TestEditDistance_EmptyStrings(t *testing.T) {
 	assert.Equal(t, 0, editDistance("", ""))
 }
 
+func TestFrontmatterWithBlankLineBetweenKeys_OK(t *testing.T) {
+	// YAML 1.2 allows blank lines between mapping entries. A frontmatter block
+	// like "layout: cover\n\nbackground: /bg.png" must not be dropped — the
+	// blank line should not terminate the block early.
+	src := "# Slide 1\n\n---\nlayout: image-left\n\nimage: ./bg.png\n---\n\n# Content\n"
+	diags := check(t, src)
+	assert.Empty(t, diags, "frontmatter with blank line between keys is valid: %s", messages(diags))
+}
+
+func TestFrontmatterWithBlankLine_MissingField_Flagged(t *testing.T) {
+	// Blank line inside frontmatter does not swallow the layout key: if the
+	// required image field is absent, MDS073 must still report it.
+	src := "# Slide 1\n\n---\nlayout: image-left\n\n---\n\n# Content\n"
+	diags := check(t, src)
+	require.Len(t, diags, 1, "got: %s", messages(diags))
+	assert.Contains(t, diags[0].Message, `"image" frontmatter field`)
+}
+
+func TestFrontmatterWithYAMLComment_OK(t *testing.T) {
+	// YAML comment lines (# …) are valid inside a frontmatter block and must
+	// not cause the block to be misidentified as plain prose.
+	src := "# Slide 1\n\n---\n# set by theme\nlayout: center\n---\n\n# Content\n"
+	diags := check(t, src)
+	assert.Empty(t, diags, "frontmatter with YAML comment is valid: %s", messages(diags))
+}
+
 func TestDottedPassThroughKey_DoesNotBlockFrontmatterParsing(t *testing.T) {
 	// A mid-deck frontmatter block that contains a dotted pass-through data
 	// key (valid in Slidev, not a pure YAML identifier) must not cause the

--- a/plan/2607171900_slidev-structure-rule.md
+++ b/plan/2607171900_slidev-structure-rule.md
@@ -4,7 +4,7 @@ title: >-
   Slidev structure rule (MDS073) — validate
   layouts, slots, fields, and frontmatter keys
   per slide
-status: "🔳"
+status: "✅"
 model: opus
 depends-on: []
 summary: >-
@@ -77,46 +77,46 @@ it never resolves theme packages.
 
 ## Tasks
 
-1. [ ] `internal/rules/slidevstructure/` — rule
+1. [x] `internal/rules/slidevstructure/` — rule
    package. `Check` does a zero-alloc pre-scan of
    `f.Lines`; returns `nil` when the file has no
    `---` fence and no `::slot::` line (keeps the
    ≤10 allocs/op budget on ordinary Markdown).
-2. [ ] Slide parser: split `f.Lines` into slides,
+2. [x] Slide parser: split `f.Lines` into slides,
    parse each per-slide frontmatter block, collect
    `::slot::` markers, with body-relative line
    numbers.
-3. [ ] The five checks above, each a table-driven
+3. [x] The five checks above, each a table-driven
    unit test (red then green).
-4. [ ] Register the rule; add to
+4. [x] Register the rule; add to
    `internal/rules/all/all.go` and the integration
    import list. `EnabledByDefault() == false`.
-5. [ ] `Configurable`: `custom-layouts` list
+5. [x] `Configurable`: `custom-layouts` list
    setting with `ApplySettings` validation and a
    `DefaultSettings`.
-6. [ ] Wire `slide-structure: {Enabled: true}` into
+6. [x] Wire `slide-structure: {Enabled: true}` into
    the `slidev` convention so the convention finally
    adds a check.
-7. [ ] Fixtures under
+7. [x] Fixtures under
    `internal/rules/MDS073-slide-structure/` —
    `bad/` with expected diagnostics, `good/` a
    clean deck that also passes all default rules.
-8. [ ] Rule `README.md` with the meta-information
+8. [x] Rule `README.md` with the meta-information
    front matter (MDS169) and peer-linter mapping
    (all empty — no peer covers this).
-9. [ ] Document the rule in
+9. [x] Document the rule in
    `docs/reference/conventions.md` (the `slidev`
    section) and the rule reference.
 
 ## Acceptance Criteria
 
-- [ ] `go test ./...` green, including the
+- [x] `go test ./...` green, including the
   per-rule fixture and alloc-budget gates.
-- [ ] `MDS073` stays ≤ 10 allocs/op on the shared
+- [x] `MDS073` stays ≤ 10 allocs/op on the shared
   alloc-budget fixture.
-- [ ] `go run ./cmd/mdsmith check .` — 0 failures.
-- [ ] The `slidev` convention enables
+- [x] `go run ./cmd/mdsmith check .` — 0 failures.
+- [x] The `slidev` convention enables
   `slide-structure`; a deck with a missing
   `::right::`, an unknown layout, and a typo'd key
   produces three diagnostics with precise lines.
-- [ ] `go vet ./...` clean.
+- [x] `go vet ./...` clean.


### PR DESCRIPTION
## Summary

- Adds MDS073 `slide-structure`, an opt-in rule for Slidev (`.sli.dev`) decks that catches the structural failures Slidev renders silently: unknown layouts, missing required `::slot::` separators, orphaned slots, missing layout-required frontmatter fields, and misspelled per-slide frontmatter keys with did-you-mean suggestions.
- Enables MDS073 via the `slidev` convention so the convention now actively checks decks rather than only disabling noisy rules.
- `custom-layouts` setting provides an escape hatch for theme-provided layout names without requiring node_modules resolution.
- Three sequential xhigh code-review rounds cleaned up 14 findings: nil-map reads, YAML frontmatter parser correctness (blank lines, YAML comments, dotted pass-through keys), allocation budget improvements, `slices` stdlib adoption, dead-code removal (`min3`, `isCustomLayout` hand-rolled loop), and non-deterministic map iteration.

## What the rule checks

| Check | Example silent Slidev failure |
|---|---|
| Unknown layout | `layout: centre` → renders blank |
| Missing required slot | `layout: two-cols` with no `::right::` → empty column |
| Orphaned slot | `::right::` under `layout: default` → content vanishes |
| Missing required field | `layout: image-left` with no `image:` → broken render |
| Unknown FM key (typo) | `transiton: fade` → passes through as data, never applied |

## Test plan

- [ ] `go test ./internal/rules/slidevstructure/...` — 31 unit tests green
- [ ] `go test ./...` — full suite green
- [ ] `go vet ./...` — clean
- [ ] Integration fixture tests in `internal/rules/MDS073-slide-structure/bad/` and `good/` pass via `internal/integration/rules_test.go`
- [ ] `go run ./cmd/mdsmith check .` — 0 failures on repo Markdown

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuZxrLeEEvhipjbH6Uueuk)_