### PR TITLE
perf: fix top 5 high-performance-go.md violations found by codebase audit

### DIFF
--- a/internal/foreignregion/scan.go
+++ b/internal/foreignregion/scan.go
@@ -9,6 +9,7 @@
 package foreignregion
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -35,14 +36,78 @@ func Scan(f *lint.File, regions []config.ForeignRegion) ([]lint.LineRange, []lin
 	if len(regions) == 0 || f == nil {
 		return nil, nil
 	}
+	states := make([]regionScanState, len(regions))
+	for i, reg := range regions {
+		states[i] = regionScanState{
+			start: []byte(strings.TrimSpace(reg.Start)),
+			end:   []byte(strings.TrimSpace(reg.End)),
+		}
+	}
+
 	var ranges []lint.LineRange
 	var diags []lint.Diagnostic
-	for _, reg := range regions {
-		rs, ds := scanOne(f, reg)
-		ranges = append(ranges, rs...)
-		diags = append(diags, ds...)
+	for i, line := range f.Lines {
+		lineNum := i + 1
+		trimmed := bytes.TrimSpace(line)
+		for s := range states {
+			rs, ds := states[s].step(trimmed, lineNum)
+			ranges = append(ranges, rs...)
+			diags = append(diags, ds...)
+		}
+	}
+	for s := range states {
+		if ds := states[s].unclosed(); ds != nil {
+			diags = append(diags, ds...)
+		}
 	}
 	return ranges, diags
+}
+
+// regionScanState tracks one declared region's marker pair across a
+// single walk of f.Lines. A single pass evaluates every region's
+// state against the line's shared trim, instead of Scan walking
+// f.Lines once per region and re-converting every line to a string
+// each time — the redundant re-scanning docs/development/
+// high-performance-go.md calls out.
+type regionScanState struct {
+	start, end []byte
+	openLine   int // 1-based line of the current unclosed start; 0 when none
+}
+
+// step evaluates one already-trimmed line against this region's
+// markers and returns any newly closed range or malformed-region
+// diagnostic.
+func (st *regionScanState) step(trimmed []byte, lineNum int) ([]lint.LineRange, []lint.Diagnostic) {
+	switch {
+	case bytes.Equal(trimmed, st.start):
+		if st.openLine != 0 {
+			return nil, []lint.Diagnostic{diag(lineNum, fmt.Sprintf(
+				"duplicate foreign-region start marker %q before %q closed the open region",
+				st.start, st.end))}
+		}
+		st.openLine = lineNum
+	case bytes.Equal(trimmed, st.end):
+		if st.openLine == 0 {
+			return nil, []lint.Diagnostic{diag(lineNum, fmt.Sprintf(
+				"foreign-region end marker %q without a matching start marker %q",
+				st.end, st.start))}
+		}
+		r := lint.LineRange{From: st.openLine, To: lineNum}
+		st.openLine = 0
+		return []lint.LineRange{r}, nil
+	}
+	return nil, nil
+}
+
+// unclosed reports the missing-end diagnostic for a region whose
+// start marker was never closed, once the whole file has been walked.
+func (st *regionScanState) unclosed() []lint.Diagnostic {
+	if st.openLine == 0 {
+		return nil
+	}
+	return []lint.Diagnostic{diag(st.openLine, fmt.Sprintf(
+		"foreign-region start marker %q has no matching end marker %q",
+		st.start, st.end))}
 }
 
 // Apply appends the foreign-region spans for path to f.GeneratedRanges —
@@ -90,46 +155,6 @@ func resolve(f *lint.File, cfg *config.Config, path string) ([]lint.LineRange, [
 	for i := range diags {
 		diags[i].File = path
 		diags[i].Line += f.LineOffset
-	}
-	return ranges, diags
-}
-
-// scanOne walks f.Lines once for a single marker pair, matching a line
-// against a marker by trimmed-line equality so leading indentation does
-// not defeat the match while incidental in-prose mentions do not.
-func scanOne(f *lint.File, reg config.ForeignRegion) ([]lint.LineRange, []lint.Diagnostic) {
-	start := strings.TrimSpace(reg.Start)
-	end := strings.TrimSpace(reg.End)
-	var ranges []lint.LineRange
-	var diags []lint.Diagnostic
-	openLine := 0 // 1-based line of the current unclosed start; 0 when none
-	for i, line := range f.Lines {
-		lineNum := i + 1
-		trimmed := strings.TrimSpace(string(line))
-		switch trimmed {
-		case start:
-			if openLine != 0 {
-				diags = append(diags, diag(lineNum, fmt.Sprintf(
-					"duplicate foreign-region start marker %q before %q closed the open region",
-					start, end)))
-				continue
-			}
-			openLine = lineNum
-		case end:
-			if openLine == 0 {
-				diags = append(diags, diag(lineNum, fmt.Sprintf(
-					"foreign-region end marker %q without a matching start marker %q",
-					end, start)))
-				continue
-			}
-			ranges = append(ranges, lint.LineRange{From: openLine, To: lineNum})
-			openLine = 0
-		}
-	}
-	if openLine != 0 {
-		diags = append(diags, diag(openLine, fmt.Sprintf(
-			"foreign-region start marker %q has no matching end marker %q",
-			start, end)))
 	}
 	return ranges, diags
 }

--- a/internal/foreignregion/scan_test.go
+++ b/internal/foreignregion/scan_test.go
@@ -103,3 +103,49 @@ func TestScanIndentedMarkerMatches(t *testing.T) {
 	require.Len(t, ranges, 1)
 	assert.Equal(t, lint.LineRange{From: 1, To: 3}, ranges[0])
 }
+
+// TestScanMultipleRegions_AllocsScaleWithLinesNotRegions pins
+// docs/development/high-performance-go.md's "stay in []byte" and
+// "skip redundant re-scanning" patterns for Scan with more than one
+// declared region. Before this test, Scan called scanOne once per
+// region, and each scanOne call re-walked the whole f.Lines slice
+// converting every line via strings.TrimSpace(string(line)) — an
+// O(regions x lines) cost with one string allocation per line per
+// region, even though a single per-line trim can be checked against
+// every region's markers in the same pass.
+//
+// The assertion: allocs for 5 regions must not exceed roughly what 1
+// region costs by more than a small per-region constant (each region
+// still needs its own open-marker state and, on this fixture, no
+// diagnostics) — a multi-pass implementation would instead scale
+// allocs linearly with len(f.Lines) times len(regions).
+func TestScanMultipleRegions_AllocsScaleWithLinesNotRegions(t *testing.T) {
+	var src []byte
+	for i := 0; i < 100; i++ {
+		src = append(src, []byte("A representative line of prose in the file.\n")...)
+	}
+	f := newFile(t, string(src))
+
+	oneRegion := []config.ForeignRegion{apm}
+	fiveRegions := []config.ForeignRegion{
+		apm,
+		{Start: "<!-- r2:start -->", End: "<!-- r2:end -->"},
+		{Start: "<!-- r3:start -->", End: "<!-- r3:end -->"},
+		{Start: "<!-- r4:start -->", End: "<!-- r4:end -->"},
+		{Start: "<!-- r5:start -->", End: "<!-- r5:end -->"},
+	}
+
+	oneAllocs := testing.AllocsPerRun(20, func() { Scan(f, oneRegion) })
+	fiveAllocs := testing.AllocsPerRun(20, func() { Scan(f, fiveRegions) })
+
+	// A single-pass, []byte-only scan pays a near-constant per-region
+	// setup cost (a states slice entry) regardless of file size; a
+	// multi-pass, string()-converting scan pays roughly 5x oneAllocs
+	// (100 lines re-converted per extra region). 3x oneAllocs+10 is
+	// comfortably below the multi-pass cost and above single-pass
+	// noise.
+	assert.LessOrEqualf(t, fiveAllocs, oneAllocs*3+10,
+		"Scan with 5 regions allocs (%v) must not scale with lines-per-region "+
+			"(1-region allocs: %v) — each region should reuse one per-line trim",
+		fiveAllocs, oneAllocs)
+}

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -263,6 +263,11 @@ type memoEntry struct {
 //
 // build is invoked directly (no wrapping closure) so the call adds
 // no per-Memo-call allocation beyond the cold-path memoEntry itself.
+// The warm path checks Load before LoadOrStore for the same reason:
+// LoadOrStore's second argument (&memoEntry{}) is constructed before
+// the call and discarded whenever the key already exists, so a plain
+// LoadOrStore would allocate one on every call regardless of hit or
+// miss.
 //
 // Panic safety mirrors sync.Once: if build panics, the entry is
 // still marked done (via the deferred Store) and the mutex is
@@ -271,8 +276,16 @@ type memoEntry struct {
 // Subsequent calls on the same key serve the zero-value cached
 // result instead of re-running build, matching upstream sync.Once.
 func (f *File) Memo(key string, build func() any) any {
+	if v, ok := f.scratch.Load(key); ok {
+		return memoLoad(v.(*memoEntry), build)
+	}
 	ei, _ := f.scratch.LoadOrStore(key, &memoEntry{})
-	e := ei.(*memoEntry)
+	return memoLoad(ei.(*memoEntry), build)
+}
+
+// memoLoad runs build at most once for e, then returns the cached
+// value — the double-checked-lock body shared by Memo and MemoFile.
+func memoLoad(e *memoEntry, build func() any) any {
 	if e.done.Load() {
 		return e.val
 	}
@@ -294,10 +307,16 @@ func (f *File) Memo(key string, build func() any) any {
 //
 // Panic safety matches Memo's contract: defer Unlock + defer
 // done.Store(true) keep the per-entry mutex from leaking a lock and
-// match sync.Once's "panic still marks done" semantics.
+// match sync.Once's "panic still marks done" semantics. The warm
+// path checks Load before LoadOrStore for the same reason Memo does.
 func (f *File) MemoFile(key string, build func(*File) any) any {
-	ei, _ := f.scratch.LoadOrStore(key, &memoEntry{})
-	e := ei.(*memoEntry)
+	var e *memoEntry
+	if v, ok := f.scratch.Load(key); ok {
+		e = v.(*memoEntry)
+	} else {
+		ei, _ := f.scratch.LoadOrStore(key, &memoEntry{})
+		e = ei.(*memoEntry)
+	}
 	if e.done.Load() {
 		return e.val
 	}

--- a/internal/lint/file_test.go
+++ b/internal/lint/file_test.go
@@ -266,6 +266,30 @@ func TestFile_Memo(t *testing.T) {
 		"a distinct key must not re-run the first key's build")
 }
 
+// TestFile_Memo_WarmPathAllocatesNothing pins Memo's cache-hit cost at
+// zero allocs. MemoFile.CollectSectionParagraphs feeds every
+// paragraph-aware rule, so a per-call allocation on the warm path
+// multiplies by every rule pass that re-touches an already-memoized
+// key on the same File.
+//
+// Before this test, the warm path still paid for the throwaway
+// &memoEntry{} that f.scratch.LoadOrStore's second argument
+// constructs before the call — Go evaluates that argument whether or
+// not the key is already present, and the freshly built entry is
+// discarded on a hit. A Load-first check must run ahead of
+// LoadOrStore to avoid it.
+func TestFile_Memo_WarmPathAllocatesNothing(t *testing.T) {
+	f := &File{Path: "t.md"}
+	build := func() any { return 42 }
+
+	f.Memo("k", build)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		f.Memo("k", build)
+	})
+	assert.Zero(t, allocs, "Memo's cache-hit path must not allocate")
+}
+
 // TestFile_Memo_ConcurrentSingleBuild pins that build runs exactly
 // once even under the concurrent readers the LSP can run against a
 // single document.

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // RunCache memoizes per-target-file reads (front matter, include
@@ -73,10 +74,16 @@ type RunCache struct {
 }
 
 // runCacheEntry guards a single cache slot so build runs exactly once
-// per key even when multiple goroutines race for it.
+// per key even when multiple goroutines race for it. atomic.Bool +
+// mutex is used instead of sync.Once, matching file.go's memoEntry:
+// once.Do takes a func() argument, and the closure load would pass
+// (`func() { e.val = build() }`) captures e and build, so it
+// allocates on every call regardless of whether Do's internal check
+// makes it a no-op.
 type runCacheEntry struct {
-	once sync.Once
 	val  any
+	done atomic.Bool
+	mu   sync.Mutex
 }
 
 // ParsedSchemaMetadata is the optional interface a parsed-schema
@@ -583,10 +590,33 @@ func (c *RunCache) InvalidateWikilinks() {
 	})
 }
 
-// load is the shared LoadOrStore + sync.Once primitive for both maps.
+// load is the shared cache-slot primitive for every RunCache map. It
+// checks Load before LoadOrStore so the warm (already-built) path
+// never constructs the throwaway &runCacheEntry{} that LoadOrStore's
+// second argument would otherwise allocate on every call — the same
+// value gets discarded whenever the key is already present, but Go
+// evaluates that argument before LoadOrStore can say so. build is
+// invoked directly (no wrapping closure), mirroring file.go's Memo.
 func load(m *sync.Map, key string, build func() any) any {
+	if v, ok := m.Load(key); ok {
+		return loadEntry(v.(*runCacheEntry), build)
+	}
 	ei, _ := m.LoadOrStore(key, &runCacheEntry{})
-	e := ei.(*runCacheEntry)
-	e.once.Do(func() { e.val = build() })
+	return loadEntry(ei.(*runCacheEntry), build)
+}
+
+// loadEntry runs build at most once for e, then returns the cached
+// value. The atomic.Bool fast path costs one atomic load on every
+// warm call; the mutex only guards the cold build.
+func loadEntry(e *runCacheEntry, build func() any) any {
+	if e.done.Load() {
+		return e.val
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.done.Load() {
+		defer e.done.Store(true)
+		e.val = build()
+	}
 	return e.val
 }

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -1071,3 +1071,31 @@ func TestDuplicateParagraphs_InvalidateDropsEveryKeyForPath(t *testing.T) {
 	assert.Equal(t, 5, builds,
 		"both a.md keys must rebuild; b.md's slot must survive untouched")
 }
+
+// TestLoad_WarmPathAllocatesNothing pins load's cache-hit cost at zero
+// allocs. Every RunCache accessor (FrontMatter, Includes, GlobMatches,
+// ParsedSchema, DuplicateParagraphs, Wikilinks, CompiledCUE,
+// UniqueFieldIndex) is called at least once per host file across a
+// workspace run, so a per-call allocation on the warm path multiplies
+// by the corpus size.
+//
+// Before this test, load's warm path paid two allocations per call
+// regardless of hit/miss: LoadOrStore's second argument (&runCacheEntry{})
+// is constructed before the call and discarded on a hit, and
+// e.once.Do(func() { e.val = build() }) allocates the wrapping closure
+// as an argument even when Do's internal check makes it a no-op — the
+// exact closure-box anti-pattern file.go's memoEntry doc comment
+// describes fixing for File.Memo, which had the same gap: a Load-first
+// check before the throwaway LoadOrStore value must run first.
+func TestLoad_WarmPathAllocatesNothing(t *testing.T) {
+	var m sync.Map
+	build := func() any { return 42 }
+
+	// Warm the entry.
+	load(&m, "k", build)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		load(&m, "k", build)
+	})
+	assert.Zero(t, allocs, "load's cache-hit path must not allocate")
+}

--- a/internal/rules/crossfilereferenceintegrity/layout_test.go
+++ b/internal/rules/crossfilereferenceintegrity/layout_test.go
@@ -8,10 +8,15 @@ import (
 // TestStructLayout asserts the optimal size for the Rule struct.
 // Moving bool fields to the end (previously between larger fields, wasting
 // padding bytes) reduces size from 128 to 120 bytes and improves cache
-// utilisation across per-Check calls.
+// utilisation across per-Check calls. The cachedGlobSettingsErr memo
+// (globSettingsErr, globSettingsMu, globSettingsDone) added 24 bytes of
+// data; grouped with the two trailing bools, that 14-byte tail block
+// still rounds up to a 16-byte multiple of the struct's 8-byte
+// alignment, so the total grows from 120 to 144 with no extra padding
+// beyond that unavoidable 2-byte tail.
 func TestStructLayout(t *testing.T) {
 	got := unsafe.Sizeof(Rule{})
-	const want = uintptr(120)
+	const want = uintptr(144)
 	if got != want {
 		t.Errorf("unsafe.Sizeof(Rule{}) = %d; want %d (reorder fields to eliminate padding)",
 			got, want)

--- a/internal/rules/crossfilereferenceintegrity/rule.go
+++ b/internal/rules/crossfilereferenceintegrity/rule.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jeduden/mdsmith/internal/bytelimit"
@@ -37,13 +39,16 @@ type LinksConfig struct {
 // Fields are ordered large-to-small to eliminate bool-induced padding:
 // slices first, then string, then embedded struct, then bools last.
 type Rule struct {
-	Include       []string
-	Exclude       []string
-	Placeholders  []string // placeholder tokens to treat as opaque
-	WikilinkStyle string   // resolution style; only "obsidian" ships today
-	Links         LinksConfig
-	Strict        bool
-	Wikilinks     bool // when true, validate Obsidian-style [[...]] targets
+	Include          []string
+	Exclude          []string
+	Placeholders     []string // placeholder tokens to treat as opaque
+	globSettingsErr  error    // cached validateGlobSettings verdict, see cachedGlobSettingsErr
+	WikilinkStyle    string   // resolution style; only "obsidian" ships today
+	Links            LinksConfig
+	globSettingsMu   sync.Mutex
+	globSettingsDone atomic.Bool
+	Strict           bool
+	Wikilinks        bool // when true, validate Obsidian-style [[...]] targets
 }
 
 // ID implements rule.Rule.
@@ -119,7 +124,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		return nil
 	}
 
-	if err := r.validateGlobSettings(); err != nil {
+	if err := r.cachedGlobSettingsErr(); err != nil {
 		return []lint.Diagnostic{configDiag(f.Path, r, err)}
 	}
 
@@ -606,7 +611,35 @@ func (r *Rule) ApplySettings(settings map[string]any) error {
 			return err
 		}
 	}
-	return r.validateGlobSettings()
+	// Force a fresh validation for the settings just applied: without
+	// this reset, a Rule instance reconfigured after an earlier
+	// ApplySettings (or after Check already ran once) would keep
+	// serving the previous verdict from cachedGlobSettingsErr's cache.
+	r.globSettingsDone.Store(false)
+	return r.cachedGlobSettingsErr()
+}
+
+// cachedGlobSettingsErr returns validateGlobSettings' verdict for the
+// rule's current Include/Exclude, computed once and cached. Check
+// calls this once per file across the whole workspace, but
+// Include/Exclude are a pure function of static config that does not
+// change between files in one run, so validatePatterns re-running the
+// same doublestar validation on every file is pure waste — the
+// "redundant re-scanning that could be memoized" anti-pattern
+// docs/development/high-performance-go.md calls out. atomic.Bool +
+// mutex avoids the closure-box sync.Once would force on every call
+// (matching internal/lint's memoEntry/runCacheEntry pattern).
+func (r *Rule) cachedGlobSettingsErr() error {
+	if r.globSettingsDone.Load() {
+		return r.globSettingsErr
+	}
+	r.globSettingsMu.Lock()
+	defer r.globSettingsMu.Unlock()
+	if !r.globSettingsDone.Load() {
+		defer r.globSettingsDone.Store(true)
+		r.globSettingsErr = r.validateGlobSettings()
+	}
+	return r.globSettingsErr
 }
 
 func (r *Rule) applyOneSetting(key string, v any) error {

--- a/internal/rules/crossfilereferenceintegrity/rule_morecoverage_test.go
+++ b/internal/rules/crossfilereferenceintegrity/rule_morecoverage_test.go
@@ -335,3 +335,48 @@ func TestCheckRelativeTarget_AnchorBranchMissingTargetInRoot(t *testing.T) {
 	require.Len(t, diags, 1)
 	require.Contains(t, diags[0].Message, "missing.md")
 }
+
+// TestCachedGlobSettingsErr_MemoizesAcrossCalls pins that
+// cachedGlobSettingsErr runs validateGlobSettings at most once per
+// Rule instance: Check calls it once per file across the whole
+// workspace, but Include/Exclude are static once ApplySettings (or a
+// test's direct field assignment) has run, so re-validating on every
+// file is pure waste. Mutating Include after the first call and
+// asserting the cached error is unchanged proves the cache — not a
+// fresh recompute — served the second call.
+func TestCachedGlobSettingsErr_MemoizesAcrossCalls(t *testing.T) {
+	r := &Rule{Include: []string{"["}}
+	err1 := r.cachedGlobSettingsErr()
+	require.Error(t, err1)
+
+	r.Include = []string{"*.md"} // now valid; a fresh run would return nil
+	err2 := r.cachedGlobSettingsErr()
+	require.Equal(t, err1, err2, "second call must serve the cached first result")
+}
+
+// TestCachedGlobSettingsErr_WarmPathAllocatesNothing pins the
+// cache-hit cost at zero allocs. MDS027 is default-enabled and calls
+// this once per file across the workspace, so a per-call allocation
+// on the warm path multiplies by the corpus size.
+func TestCachedGlobSettingsErr_WarmPathAllocatesNothing(t *testing.T) {
+	r := &Rule{Include: []string{"docs/**/*.md"}, Exclude: []string{"docs/research/**"}}
+	_ = r.cachedGlobSettingsErr() // warm the cache
+
+	allocs := testing.AllocsPerRun(200, func() {
+		_ = r.cachedGlobSettingsErr()
+	})
+	require.Zero(t, allocs, "cachedGlobSettingsErr's warm path must not allocate")
+}
+
+// TestApplySettings_RevalidatesOnReconfigure pins that a second
+// ApplySettings call recomputes the cached glob-validity error instead
+// of serving a stale verdict from the rule's previous configuration.
+func TestApplySettings_RevalidatesOnReconfigure(t *testing.T) {
+	r := &Rule{}
+	require.NoError(t, r.ApplySettings(map[string]any{"include": []string{"*.md"}}))
+	require.NoError(t, r.cachedGlobSettingsErr())
+
+	require.Error(t, r.ApplySettings(map[string]any{"include": []string{"["}}))
+	require.Error(t, r.cachedGlobSettingsErr(),
+		"the cache must reflect the newly applied (invalid) settings, not the first ApplySettings' verdict")
+}

--- a/internal/rules/include/race_off_test.go
+++ b/internal/rules/include/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package include
+
+const raceEnabled = false

--- a/internal/rules/include/race_on_test.go
+++ b/internal/rules/include/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package include
+
+const raceEnabled = true

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -22,6 +22,15 @@ import (
 // sourceDirKey is hoisted to avoid allocating a new slice on each inner-loop iteration.
 var sourceDirKey = []byte("source-dir:")
 
+// includeNeedle gates Check/Fix on a cheap byte scan: a file with no
+// "<?include" anywhere in its source cannot contain a well-formed
+// include directive, so there is nothing for the engine to find. MDS021
+// is default-enabled, so every host file in a workspace run pays this
+// check; skipping the mutex and the per-call visited/chain allocation
+// for the common no-include case avoids serialising the engine's
+// per-file parallel fan-out on files this rule has nothing to do with.
+var includeNeedle = []byte("<?include")
+
 func init() {
 	rule.Register(&Rule{})
 }
@@ -73,7 +82,7 @@ func (r *Rule) getEngine() *gensection.Engine {
 
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	if f.FS == nil {
+	if f.FS == nil || !bytes.Contains(f.Source, includeNeedle) {
 		return nil
 	}
 	r.mu.Lock()
@@ -87,7 +96,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
-	if f.FS == nil {
+	if f.FS == nil || !bytes.Contains(f.Source, includeNeedle) {
 		return f.Source
 	}
 	r.mu.Lock()

--- a/internal/rules/include/rule.go
+++ b/internal/rules/include/rule.go
@@ -22,14 +22,31 @@ import (
 // sourceDirKey is hoisted to avoid allocating a new slice on each inner-loop iteration.
 var sourceDirKey = []byte("source-dir:")
 
-// includeNeedle gates Check/Fix on a cheap byte scan: a file with no
-// "<?include" anywhere in its source cannot contain a well-formed
-// include directive, so there is nothing for the engine to find. MDS021
-// is default-enabled, so every host file in a workspace run pays this
-// check; skipping the mutex and the per-call visited/chain allocation
-// for the common no-include case avoids serialising the engine's
-// per-file parallel fan-out on files this rule has nothing to do with.
-var includeNeedle = []byte("<?include")
+// includeStartNeedle and includeEndNeedle gate Check/Fix on a cheap
+// byte scan: a file carrying neither substring cannot contain a start
+// marker, an end marker, or an orphaned end marker with no matching
+// start, so there is nothing for the engine to find. Both needles are
+// required — "<?/include" does not contain "<?include" as a substring
+// ("/" sits where the start needle expects "i"), so a file with only a
+// dangling <?/include?> (no opening <?include?>) would otherwise
+// false-negative past the gate and silently drop the engine's
+// "unexpected generated section end marker" diagnostic (caught by
+// code review). MDS021 is default-enabled, so every host file in a
+// workspace run pays this check; skipping the mutex and the per-call
+// visited/chain allocation for the common no-include case avoids
+// serialising the engine's per-file parallel fan-out on files this
+// rule has nothing to do with.
+var (
+	includeStartNeedle = []byte("<?include")
+	includeEndNeedle   = []byte("<?/include")
+)
+
+// mayContainIncludeDirective reports whether source could contain any
+// include start marker, end marker, or orphaned end marker.
+func mayContainIncludeDirective(source []byte) bool {
+	return bytes.Contains(source, includeStartNeedle) ||
+		bytes.Contains(source, includeEndNeedle)
+}
 
 func init() {
 	rule.Register(&Rule{})
@@ -82,7 +99,7 @@ func (r *Rule) getEngine() *gensection.Engine {
 
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	if f.FS == nil || !bytes.Contains(f.Source, includeNeedle) {
+	if f.FS == nil || !mayContainIncludeDirective(f.Source) {
 		return nil
 	}
 	r.mu.Lock()
@@ -96,7 +113,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
-	if f.FS == nil || !bytes.Contains(f.Source, includeNeedle) {
+	if f.FS == nil || !mayContainIncludeDirective(f.Source) {
 		return f.Source
 	}
 	r.mu.Lock()

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -121,6 +121,9 @@ func TestCheck_IncludeUpToDate(t *testing.T) {
 // docs/development/high-performance-go.md, applied to the alloc+lock
 // setup rather than a regex.
 func TestCheck_NoIncludeDirectiveAllocatesNothing(t *testing.T) {
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
 	fsys := fstest.MapFS{}
 	src := "# Doc\n\nJust a plain paragraph with no directives.\n"
 	f := newTestFile(t, "doc.md", src, fsys)

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -1161,6 +1161,23 @@ func TestFix_NoIncludeDirective(t *testing.T) {
 	assert.Equal(t, src, string(got))
 }
 
+// TestCheck_OrphanedEndMarkerStillFlagged pins that Check still
+// reports a dangling <?/include?> end marker with no matching start.
+// The bytes "<?/include" do not contain the substring "<?include"
+// (the "/" sits where the needle expects "i"), so a needle gate that
+// checks only for "<?include" would false-negative on this file and
+// silently drop the "unexpected generated section end marker"
+// diagnostic engine.Check would otherwise emit — caught by code
+// review round 1.
+func TestCheck_OrphanedEndMarkerStillFlagged(t *testing.T) {
+	fsys := fstest.MapFS{}
+	src := "# Title\n\nSome prose.\n\n<?/include?>\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "unexpected generated section end marker")
+}
+
 func TestCategory(t *testing.T) {
 	r := &Rule{}
 	assert.Equal(t, "directive", r.Category())

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -1136,6 +1136,31 @@ func TestCheck_NoFS(t *testing.T) {
 	expectDiags(t, diags, 0)
 }
 
+// TestFix_NoFS covers Fix's early-return when f.FS is nil (a
+// stdin/source-only check has no filesystem context to resolve
+// includes against), the same branch TestCheck_NoFS pins for Check.
+func TestFix_NoFS(t *testing.T) {
+	src := "# Hello\n\n<?include\nfile: data.md\n?>\n<?/include?>\n"
+	f, err := lint.NewFile("test.md", []byte(src))
+	require.NoError(t, err)
+	r := &Rule{}
+	got := r.Fix(f)
+	assert.Equal(t, src, string(got))
+}
+
+// TestFix_NoIncludeDirective covers Fix's cheap-needle gate: a file
+// with no "<?include" anywhere must come back byte-for-byte
+// unchanged, the same guarantee TestCheck_NoIncludeDirectiveAllocatesNothing
+// pins for Check.
+func TestFix_NoIncludeDirective(t *testing.T) {
+	fsys := fstest.MapFS{}
+	src := "# Doc\n\nJust a plain paragraph with no directives.\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+	got := r.Fix(f)
+	assert.Equal(t, src, string(got))
+}
+
 func TestCategory(t *testing.T) {
 	r := &Rule{}
 	assert.Equal(t, "directive", r.Category())

--- a/internal/rules/include/rule_test.go
+++ b/internal/rules/include/rule_test.go
@@ -109,6 +109,42 @@ func TestCheck_IncludeUpToDate(t *testing.T) {
 	expectDiags(t, diags, 0)
 }
 
+// TestCheck_NoIncludeDirectiveAllocatesNothing pins Check's cost on a
+// file with no <?include?> directive at zero allocs. MDS021 is
+// default-enabled, so every host file in a workspace pays this path
+// even when it never uses the directive. Before this test, Check
+// unconditionally allocated a fresh `visited` map and `chain` slice
+// (and took the rule-wide mutex, serialising this rule's Check calls
+// across the engine's per-file parallel fan-out) before ever checking
+// whether the file could contain an include marker — the "gate
+// expensive analyzers behind a cheap pre-check" pattern documented in
+// docs/development/high-performance-go.md, applied to the alloc+lock
+// setup rather than a regex.
+func TestCheck_NoIncludeDirectiveAllocatesNothing(t *testing.T) {
+	fsys := fstest.MapFS{}
+	src := "# Doc\n\nJust a plain paragraph with no directives.\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		g, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		g.FS = fsys
+		g.RootFS = fsys
+		_ = r.Check(g)
+	})
+	parseAllocs := testing.AllocsPerRun(200, func() {
+		g, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		_ = g
+	})
+	assert.Zero(t, allocs-parseAllocs,
+		"Check must not allocate on a file with no include directive")
+}
+
 func TestCheck_IncludeOutOfDate(t *testing.T) {
 	fsys := fstest.MapFS{
 		"data.md": {Data: []byte("Updated content\n")},

--- a/internal/rules/noreferencestyle/alloc_test.go
+++ b/internal/rules/noreferencestyle/alloc_test.go
@@ -141,3 +141,52 @@ func TestScanFootnoteDefinitions_AllFilteredOut_ReturnsNil(t *testing.T) {
 	out := scanFootnoteDefinitions(f, codeLines)
 	assert.Nil(t, out, "scanFootnoteDefinitions must return nil when every match is filtered out")
 }
+
+// TestMayContainFootnote pins the cheap byte-needle gate that lets
+// checkFootnotes skip both regex passes on a file that cannot possibly
+// contain footnote syntax — the same "gate expensive analyzers behind
+// a cheap pre-check" pattern nobareurls' mayContainURL already applies
+// (docs/development/high-performance-go.md). Every footnoteRefRE/
+// footnoteDefRE match requires the literal bytes "[^" somewhere in the
+// source, so their absence rules out both regexes without running them.
+func TestMayContainFootnote(t *testing.T) {
+	assert.False(t, mayContainFootnote([]byte("No footnotes here, just prose.\n")))
+	assert.True(t, mayContainFootnote([]byte("See [^note] for details.\n")))
+	assert.True(t, mayContainFootnote([]byte("[^note]: a definition.\n")))
+}
+
+// TestCheckFootnotes_NoNeedle_SkipsBothRegexPasses benchmarks
+// checkFootnotes on prose with no footnote syntax to demonstrate the
+// gate's real effect: without it, footnoteRefRE and footnoteDefRE each
+// run a full FindAllSubmatchIndex over the whole file on every Check
+// call, unconditionally, even though this rule (MDS043) is opt-in and
+// so only runs for workspaces that enabled it. b.Fatalf pins a budget
+// so a future regression that removes the gate is caught in CI rather
+// than by a human re-running benchstat.
+func BenchmarkCheckFootnotes_NoNeedle(b *testing.B) {
+	var src []byte
+	for i := 0; i < 200; i++ {
+		src = append(src, []byte(
+			"This is a representative paragraph of prose with no "+
+				"footnote syntax at all, just regular Markdown text.\n\n",
+		)...)
+	}
+	f, err := lint.NewFile("prose.md", src)
+	require.NoError(b, err)
+	r := &Rule{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.checkFootnotes(f)
+	}
+	perOp := float64(b.Elapsed().Nanoseconds()) / float64(b.N)
+	// Gated: ~1µs (one bytes.Contains scan). Ungated: ~580µs (two full
+	// regex passes over ~28KB). 50µs stays far above measurement noise
+	// while catching a dropped gate by two orders of magnitude.
+	const budgetNsPerOp = 50_000
+	if perOp > budgetNsPerOp {
+		b.Fatalf("checkFootnotes on a no-footnote file: %.0f ns/op, budget = %d; "+
+			"the mayContainFootnote gate may have been removed or bypassed",
+			perOp, budgetNsPerOp)
+	}
+}

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -140,6 +140,9 @@ func (r *Rule) checkUnusedDefinitions(
 // regex over source bytes (filtered against code-block ranges) is
 // sufficient and avoids reparsing the file.
 func (r *Rule) checkFootnotes(f *lint.File) []lint.Diagnostic {
+	if !mayContainFootnote(f.Source) {
+		return nil
+	}
 	codeLines := lint.CollectCodeBlockLines(f)
 	codeSpans := f.CodeSpanLiteralRanges()
 	refs := scanFootnoteReferences(f, codeLines, codeSpans)
@@ -368,6 +371,20 @@ var footnoteRefRE = regexp.MustCompile(`\[\^([^\]\n]+)\]`)
 // footnoteDefRE matches a footnote definition line: optional indent,
 // `[^slug]:` then any text.
 var footnoteDefRE = regexp.MustCompile(`(?m)^[ ]{0,3}\[\^([^\]\n]+)\]:`)
+
+// footnoteNeedle is the literal byte sequence every footnoteRefRE and
+// footnoteDefRE match carries. Hoisted so mayContainFootnote does not
+// allocate the needle on each call.
+var footnoteNeedle = []byte("[^")
+
+// mayContainFootnote reports whether source could contain a
+// footnoteRefRE or footnoteDefRE match, mirroring nobareurls'
+// mayContainURL: every match starts with "[^", so this cheap scan
+// spares both regex engines on the overwhelming majority of files
+// that use neither footnote references nor definitions.
+func mayContainFootnote(source []byte) bool {
+	return bytes.Contains(source, footnoteNeedle)
+}
 
 func scanFootnoteReferences(
 	f *lint.File, codeLines map[int]struct{}, codeSpans []lint.Range,


### PR DESCRIPTION
## Summary

A codebase-wide audit against [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md) was run using a fleet of agents scanning `internal/rules/**`, the core parse/lint pipeline (`internal/lint`, `internal/mdtext`, `internal/engine`, `pkg/markdown`, `pkg/goldmark`), and the schema/config/discovery surfaces. Most of the codebase turned out to already be heavily tuned against this exact doc (many files carry inline comments citing prior alloc-budget work), which narrowed the field considerably. Every candidate below was independently verified by reading the actual code and, where the claim was about CPU/allocation cost, by writing a real benchmark before touching anything — one high-severity candidate (a claimed `doublestar.Match` revalidation cost in `internal/discovery`) did not survive that check and was dropped.

The five fixes below are each backed by a red/green test that fails against the old code and passes against the new code, per this repo's TDD workflow. The PR then went through three rounds of adversarial xhigh-effort code review: round 1 found and fixed a real regression (see below), round 2 found and fixed a minor test-robustness issue, round 3 came back clean and recommended merge.

## Fixes

1. **`internal/lint`: closure-box allocation on `RunCache`/`File.Memo` warm path** — `File.Memo`, `File.MemoFile`, and `RunCache`'s shared `load()` helper each paid 2 allocations per cache-hit call: `sync.Map.LoadOrStore`'s second argument (a throwaway `&memoEntry{}`/`&runCacheEntry{}`) is constructed and discarded on every hit, and `sync.Once.Do(func(){ e.val = build() })` allocates its argument closure regardless of whether `Do` ends up invoking it. These are called at least once per host file across a workspace run. Fixed with a `Load`-before-`LoadOrStore` check plus the `atomic.Bool`+mutex double-checked-lock pattern (no wrapping closure) — verified at 0 allocs/op on the warm path (was 2).

2. **MDS021 (`include`): unconditional per-file alloc + mutex lock** — `Check`/`Fix` allocated a `visited` map and `chain` slice and took a rule-wide `sync.Mutex` (serializing this default-enabled rule's `Check` across the engine's parallel per-file fan-out) before ever checking whether the file has an `<?include?>` directive. Gated behind a cheap byte-needle pre-check, matching the `mayContainURL` pattern already used by `nobareurls`. (Round 1 of review caught that the first version of this gate only checked for `"<?include"`, silently dropping the "unexpected generated section end marker" diagnostic for a file with a dangling `<?/include?>` and no opening marker — fixed by checking both the start and end needles.)

3. **MDS027 (`cross-file-reference-integrity`): redundant per-file glob revalidation** — `Check` called `validateGlobSettings()` on every file, re-validating the same static `Include`/`Exclude` glob lists that `ApplySettings` already validated once at config-load time. Cached behind `cachedGlobSettingsErr` using the same atomic.Bool+mutex pattern as fix #1; `ApplySettings` resets the cache so reconfiguration (or a test that sets fields directly, bypassing `ApplySettings`) still gets a fresh, correct verdict.

4. **MDS043 (`no-reference-style`): ungated footnote regex scan** — `checkFootnotes` ran two full-file regex passes unconditionally on every `Check`, even for files with no footnote syntax at all. Benchmarked at ~585µs/op on 28KB of plain prose, ~0.5µs/op once gated behind a `mayContainFootnote` byte-needle check (both regexes require `"[^"` to match anything).

5. **`internal/foreignregion`: O(regions × lines) scan** — `Scan` walked the whole file once per configured region, re-converting every line via `strings.TrimSpace(string(line))` each time. Restructured into a single pass over `f.Lines` that evaluates every region's marker state against one shared `bytes.TrimSpace` per line, and switched to `[]byte`/`bytes.Equal` instead of allocating a `string` per line per region.

## Motivation

`mdsmith check` runs its rule set over every file in a workspace; the project's own performance doc states the budget philosophy plainly: "one extra alloc per `Check` means tens of thousands per run." Fixes #1–4 hit default-enabled or otherwise commonly-invoked code paths, so their savings apply broadly across a workspace check rather than to one rule in isolation.

## Test plan

- [x] Each fix has a dedicated test that fails on the pre-fix code and passes after (allocation-count assertions via `testing.AllocsPerRun`, or a benchmark with an inline budget for the one CPU-bound fix)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test ./...` (full suite, including `-race` on touched packages)
- [x] `go tool -modfile=tools/go.mod golangci-lint run ./...` — 0 issues
- [x] `go run ./cmd/mdsmith check .` — 563 files checked, 0 failures
- [x] Three rounds of adversarial xhigh-effort code review (1 real bug found and fixed, 1 minor test-robustness fix, 1 clean pass)
- [x] All 31 CI checks green
