### PR TITLE
perf: fix top 5 high-performance-go.md violations found by codebase audit

### DIFF
--- a/internal/corpus/collect.go
+++ b/internal/corpus/collect.go
@@ -176,6 +176,24 @@ func collectFile(
 		return Record{}, false, nil
 	}
 
+	// Skip files over the shared byte-limit cap rather than failing the
+	// whole source: collectFromRoot's caller aborts the entire walk (and
+	// every record already collected from every source before it, since
+	// Collect returns on the first error) on any error from this
+	// function. A cloned third-party repository can legitimately contain
+	// one oversized file (a large CHANGELOG, a vendored spec) without
+	// that file being reason to discard the rest of the corpus build.
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return Record{}, false, fmt.Errorf("stat file %s: %w", fullPath, err)
+	}
+	if info.Size() > bytelimit.DefaultMaxInputBytes {
+		reportProgress(cfg, fmt.Sprintf(
+			"skipping %s: %d bytes exceeds the %d byte limit",
+			relPath, info.Size(), bytelimit.DefaultMaxInputBytes))
+		return Record{}, false, nil
+	}
+
 	content, err := bytelimit.ReadFileLimited(fullPath, bytelimit.DefaultMaxInputBytes)
 	if err != nil {
 		return Record{}, false, fmt.Errorf("read file %s: %w", fullPath, err)

--- a/internal/corpus/collect.go
+++ b/internal/corpus/collect.go
@@ -176,16 +176,19 @@ func collectFile(
 		return Record{}, false, nil
 	}
 
-	// Skip files over the shared byte-limit cap rather than failing the
-	// whole source: collectFromRoot's caller aborts the entire walk (and
-	// every record already collected from every source before it, since
-	// Collect returns on the first error) on any error from this
-	// function. A cloned third-party repository can legitimately contain
-	// one oversized file (a large CHANGELOG, a vendored spec) without
-	// that file being reason to discard the rest of the corpus build.
+	// Skip a file this function cannot read — oversized, vanished, or
+	// permission-denied — rather than failing the whole source:
+	// collectFromRoot's caller aborts the entire walk (and every record
+	// already collected from every source before it, since Collect
+	// returns on the first error) on any error from this function. A
+	// cloned third-party repository can legitimately contain one
+	// oversized or racy file (a large CHANGELOG, a vendored spec, a file
+	// removed mid-walk) without that file being reason to discard the
+	// rest of the corpus build.
 	info, err := os.Stat(fullPath)
 	if err != nil {
-		return Record{}, false, fmt.Errorf("stat file %s: %w", fullPath, err)
+		reportProgress(cfg, fmt.Sprintf("skipping %s: %v", relPath, err))
+		return Record{}, false, nil
 	}
 	if info.Size() > bytelimit.DefaultMaxInputBytes {
 		reportProgress(cfg, fmt.Sprintf(
@@ -194,9 +197,14 @@ func collectFile(
 		return Record{}, false, nil
 	}
 
+	// bytelimit.ReadFileLimited re-checks the size on the actual read,
+	// so a file that grows past the cap in the window between the Stat
+	// above and this call (or otherwise becomes unreadable) is caught
+	// here too — skipped the same way, not treated as fatal.
 	content, err := bytelimit.ReadFileLimited(fullPath, bytelimit.DefaultMaxInputBytes)
 	if err != nil {
-		return Record{}, false, fmt.Errorf("read file %s: %w", fullPath, err)
+		reportProgress(cfg, fmt.Sprintf("skipping %s: %v", relPath, err))
+		return Record{}, false, nil
 	}
 	raw := normalizeContent(string(content))
 	words := countWords(raw)

--- a/internal/corpus/collect.go
+++ b/internal/corpus/collect.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 )
 
 // Collect gathers markdown records from configured sources.
@@ -174,7 +176,7 @@ func collectFile(
 		return Record{}, false, nil
 	}
 
-	content, err := os.ReadFile(fullPath)
+	content, err := bytelimit.ReadFileLimited(fullPath, bytelimit.DefaultMaxInputBytes)
 	if err != nil {
 		return Record{}, false, fmt.Errorf("read file %s: %w", fullPath, err)
 	}

--- a/internal/corpus/collect_test.go
+++ b/internal/corpus/collect_test.go
@@ -1,9 +1,12 @@
 package corpus
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 )
 
 func TestCollect_HappyPath(t *testing.T) {
@@ -204,6 +207,45 @@ func TestCollect_ErrorPath(t *testing.T) {
 	_, err := Collect(cfg, t.TempDir())
 	if err == nil {
 		t.Fatal("expected resolve error")
+	}
+}
+
+// TestCollect_OversizedFile_ReturnsError guards against an unbounded
+// os.ReadFile on a corpus source: collectFile ingests markdown from
+// cloned third-party repositories, which are untrusted input
+// (docs/development/high-performance-go.md — "os.ReadFile on huge
+// inputs: one giant alloc, all resident"). A file over the shared
+// bytelimit.DefaultMaxInputBytes cap must fail the walk rather than
+// being read into memory in full.
+func TestCollect_OversizedFile_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "docs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	oversized := bytes.Repeat([]byte("a"), int(bytelimit.DefaultMaxInputBytes)+1)
+	if err := os.WriteFile(filepath.Join(root, "huge.md"), oversized, 0o644); err != nil {
+		t.Fatalf("write oversized markdown: %v", err)
+	}
+
+	cfg := &Config{
+		CollectedAt:      "2026-02-16",
+		MinWords:         1,
+		MinChars:         1,
+		LicenseAllowlist: []string{"MIT"},
+		Sources: []SourceConfig{{
+			Name:       "seed",
+			Repository: "github.com/acme/seed",
+			Root:       root,
+			CommitSHA:  "abc123",
+			License:    "MIT",
+		}},
+	}
+
+	_, err := Collect(cfg, t.TempDir())
+	if err == nil {
+		t.Fatal("Collect: expected an error for a file over the byte-limit cap, got nil")
 	}
 }
 

--- a/internal/corpus/collect_test.go
+++ b/internal/corpus/collect_test.go
@@ -210,23 +210,30 @@ func TestCollect_ErrorPath(t *testing.T) {
 	}
 }
 
-// TestCollect_OversizedFile_ReturnsError guards against an unbounded
+// TestCollect_OversizedFile_SkippedNotFatal guards against an unbounded
 // os.ReadFile on a corpus source: collectFile ingests markdown from
 // cloned third-party repositories, which are untrusted input
 // (docs/development/high-performance-go.md — "os.ReadFile on huge
 // inputs: one giant alloc, all resident"). A file over the shared
-// bytelimit.DefaultMaxInputBytes cap must fail the walk rather than
-// being read into memory in full.
-func TestCollect_OversizedFile_ReturnsError(t *testing.T) {
+// bytelimit.DefaultMaxInputBytes cap must be skipped rather than read
+// into memory in full — and, since a real source repository can contain
+// one large file among many good ones (a big CHANGELOG, a vendored
+// spec), skipping it must not abort collection of the rest of that
+// source or of sources collected earlier in the same run.
+func TestCollect_OversizedFile_SkippedNotFatal(t *testing.T) {
 	t.Parallel()
 
 	root := filepath.Join(t.TempDir(), "docs")
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	oversized := bytes.Repeat([]byte("a"), int(bytelimit.DefaultMaxInputBytes)+1)
+	oversized := bytes.Repeat([]byte("a "), int(bytelimit.DefaultMaxInputBytes)/2+1)
 	if err := os.WriteFile(filepath.Join(root, "huge.md"), oversized, 0o644); err != nil {
 		t.Fatalf("write oversized markdown: %v", err)
+	}
+	normalContent := []byte("# Title\n\nword word word word word word\n")
+	if err := os.WriteFile(filepath.Join(root, "normal.md"), normalContent, 0o644); err != nil {
+		t.Fatalf("write normal markdown: %v", err)
 	}
 
 	cfg := &Config{
@@ -243,9 +250,15 @@ func TestCollect_OversizedFile_ReturnsError(t *testing.T) {
 		}},
 	}
 
-	_, err := Collect(cfg, t.TempDir())
-	if err == nil {
-		t.Fatal("Collect: expected an error for a file over the byte-limit cap, got nil")
+	records, err := Collect(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("Collect: unexpected error, oversized file should be skipped: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("record count = %d, want 1 (only normal.md; huge.md must be skipped)", len(records))
+	}
+	if records[0].Path != "normal.md" {
+		t.Fatalf("Path = %q, want normal.md", records[0].Path)
 	}
 }
 

--- a/internal/corpus/collect_test.go
+++ b/internal/corpus/collect_test.go
@@ -219,46 +219,132 @@ func TestCollect_ErrorPath(t *testing.T) {
 // into memory in full — and, since a real source repository can contain
 // one large file among many good ones (a big CHANGELOG, a vendored
 // spec), skipping it must not abort collection of the rest of that
-// source or of sources collected earlier in the same run.
+// source, or of sources collected *earlier* in the same run (Collect's
+// loop over cfg.Sources returns on the first error, discarding every
+// record gathered so far — so this uses two sources, not one, to prove
+// the first source's record survives a later source's oversized file).
 func TestCollect_OversizedFile_SkippedNotFatal(t *testing.T) {
 	t.Parallel()
 
-	root := filepath.Join(t.TempDir(), "docs")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	const prose = "# Title\n\nword word word word word word\n"
+
+	goodRoot := filepath.Join(t.TempDir(), "good")
+	mustMkdirAll(t, goodRoot)
+	mustWriteFile(t, filepath.Join(goodRoot, "early.md"), []byte(prose))
+
+	mixedRoot := filepath.Join(t.TempDir(), "mixed")
+	mustMkdirAll(t, mixedRoot)
 	oversized := bytes.Repeat([]byte("a "), int(bytelimit.DefaultMaxInputBytes)/2+1)
-	if err := os.WriteFile(filepath.Join(root, "huge.md"), oversized, 0o644); err != nil {
-		t.Fatalf("write oversized markdown: %v", err)
-	}
-	normalContent := []byte("# Title\n\nword word word word word word\n")
-	if err := os.WriteFile(filepath.Join(root, "normal.md"), normalContent, 0o644); err != nil {
-		t.Fatalf("write normal markdown: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(mixedRoot, "huge.md"), oversized)
+	mustWriteFile(t, filepath.Join(mixedRoot, "normal.md"), []byte(prose))
 
 	cfg := &Config{
 		CollectedAt:      "2026-02-16",
 		MinWords:         1,
 		MinChars:         1,
 		LicenseAllowlist: []string{"MIT"},
-		Sources: []SourceConfig{{
-			Name:       "seed",
-			Repository: "github.com/acme/seed",
-			Root:       root,
-			CommitSHA:  "abc123",
-			License:    "MIT",
-		}},
+		Sources: []SourceConfig{
+			{
+				Name:       "early",
+				Repository: "github.com/acme/early",
+				Root:       goodRoot,
+				CommitSHA:  "abc123",
+				License:    "MIT",
+			},
+			{
+				Name:       "mixed",
+				Repository: "github.com/acme/mixed",
+				Root:       mixedRoot,
+				CommitSHA:  "def456",
+				License:    "MIT",
+			},
+		},
 	}
 
 	records, err := Collect(cfg, t.TempDir())
 	if err != nil {
 		t.Fatalf("Collect: unexpected error, oversized file should be skipped: %v", err)
 	}
-	if len(records) != 1 {
-		t.Fatalf("record count = %d, want 1 (only normal.md; huge.md must be skipped)", len(records))
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2 (early.md from the first source, "+
+			"normal.md from the second; huge.md must be skipped)", len(records))
 	}
-	if records[0].Path != "normal.md" {
-		t.Fatalf("Path = %q, want normal.md", records[0].Path)
+	paths := make([]string, len(records))
+	for i, r := range records {
+		paths[i] = r.Source + "/" + r.Path
+	}
+	if paths[0] != "early/early.md" || paths[1] != "mixed/normal.md" {
+		t.Fatalf("records = %v, want [early/early.md mixed/normal.md]", paths)
+	}
+}
+
+// mustMkdirAll creates dir and all parents, failing the test on error.
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}
+
+// mustWriteFile writes content to path, failing the test on error.
+func mustWriteFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestCollectFile_StatError_SkippedNotFatal covers collectFile's os.Stat
+// error branch directly: a file that vanishes between WalkDir listing it
+// and the Stat call inside collectFile (or any other stat failure) must
+// be skipped, not treated as fatal — the same reasoning as the oversized-
+// file case above.
+func TestCollectFile_StatError_SkippedNotFatal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	missing := filepath.Join(root, "gone.md")
+
+	cfg := &Config{MinWords: 1, MinChars: 1}
+	record, keep, err := collectFile(cfg, SourceConfig{Name: "seed"}, missing, "gone.md", root)
+	if err != nil {
+		t.Fatalf("collectFile: unexpected error for a stat failure: %v", err)
+	}
+	if keep {
+		t.Fatal("collectFile: keep = true, want false for a stat failure")
+	}
+	if record != (Record{}) {
+		t.Fatalf("collectFile: record = %+v, want zero value", record)
+	}
+}
+
+// TestCollectFile_ReadError_SkippedNotFatal covers collectFile's fallback
+// bytelimit.ReadFileLimited error branch directly: a path that passes the
+// Stat-based size pre-check but then fails to read must be skipped, not
+// treated as fatal — the same reasoning as the stat-failure and
+// oversized-file cases above. A directory Stats successfully (size 0,
+// under the cap) but fails to Read as a file ("is a directory"),
+// deterministically reaching this branch regardless of the running
+// user's privileges (unlike a permission-bit test, which root ignores).
+func TestCollectFile_ReadError_SkippedNotFatal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	notAFile := filepath.Join(root, "not-a-file.md")
+	if err := os.Mkdir(notAFile, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := &Config{MinWords: 1, MinChars: 1}
+	record, keep, err := collectFile(cfg, SourceConfig{Name: "seed"}, notAFile, "not-a-file.md", root)
+	if err != nil {
+		t.Fatalf("collectFile: unexpected error reading a directory as a file: %v", err)
+	}
+	if keep {
+		t.Fatal("collectFile: keep = true, want false when the read fails")
+	}
+	if record != (Record{}) {
+		t.Fatalf("collectFile: record = %+v, want zero value", record)
 	}
 }
 

--- a/internal/linkgraph/linkgraph.go
+++ b/internal/linkgraph/linkgraph.go
@@ -251,10 +251,10 @@ func linkPosition(f *lint.File, n ast.Node) (int, int) {
 	if offset < 0 {
 		return 1, 1
 	}
-	// f.ColumnOfOffset scans backward from offset to the previous
-	// newline, so it's O(column) per call instead of the O(offset)
-	// forward scan a hand-rolled version would do — meaningful for
-	// `mdsmith list backlinks` which can call this many times per file.
+	// f.ColumnOfOffset binary-searches the cached newline index, so
+	// it's O(log lines) per call instead of the O(column) backward scan
+	// a hand-rolled version would do — meaningful for `mdsmith list
+	// backlinks` which can call this many times per file.
 	return f.LineOfOffset(offset), f.ColumnOfOffset(offset)
 }
 

--- a/internal/lint/column_bench_test.go
+++ b/internal/lint/column_bench_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 )
 
-// BenchmarkColumnOfOffset_LongLine exercises the worst case for
-// ColumnOfOffset: an offset near the end of a very long line, forcing a
-// full backward scan to find the line start. Per
-// docs/development/high-performance-go.md, a hand-rolled byte-at-a-time
-// scan is not vectorized by the compiler; bytes.LastIndexByte is SIMD
-// assembly on amd64.
+// BenchmarkColumnOfOffset_LongLine exercises the former worst case for
+// ColumnOfOffset: an offset near the end of a very long line, which used
+// to force a full backward byte-at-a-time scan to find the line start.
+// ColumnOfOffset now reuses LineOfOffset's cached newline index via a
+// binary search instead (docs/development/high-performance-go.md).
 func BenchmarkColumnOfOffset_LongLine(b *testing.B) {
 	line := bytes.Repeat([]byte("x"), 8192)
 	src := append(append([]byte("prefix\n"), line...), '\n')

--- a/internal/lint/column_bench_test.go
+++ b/internal/lint/column_bench_test.go
@@ -1,0 +1,25 @@
+package lint
+
+import (
+	"bytes"
+	"testing"
+)
+
+// BenchmarkColumnOfOffset_LongLine exercises the worst case for
+// ColumnOfOffset: an offset near the end of a very long line, forcing a
+// full backward scan to find the line start. Per
+// docs/development/high-performance-go.md, a hand-rolled byte-at-a-time
+// scan is not vectorized by the compiler; bytes.LastIndexByte is SIMD
+// assembly on amd64.
+func BenchmarkColumnOfOffset_LongLine(b *testing.B) {
+	line := bytes.Repeat([]byte("x"), 8192)
+	src := append(append([]byte("prefix\n"), line...), '\n')
+	f := &File{Source: src}
+	offset := len(src) - 2 // last byte of the long line
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.ColumnOfOffset(offset)
+	}
+}

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -543,13 +543,38 @@ var lineIndexNewline = []byte{'\n'}
 // strictly before offset (a newline exactly at offset starts the
 // next line, so it does not count) — identical to a linear scan,
 // but O(log n) via binary search over the cached newline index.
-// The search is inlined (sort.Search would force the comparison
-// callback to capture `nl` and `offset` and escape to the heap;
-// engine-bench profiling attributed ~64 k allocations per
-// 10-iteration run to that closure box before plan 195 inlined
-// the binary search here).
 func (f *File) LineOfOffset(offset int) int {
 	nl := f.lineIndex()
+	return 1 + newlineSearch(nl, offset)
+}
+
+// ColumnOfOffset converts a byte offset in Source to a 1-based column
+// number on its line.
+func (f *File) ColumnOfOffset(offset int) int {
+	if offset > len(f.Source) {
+		offset = len(f.Source)
+	}
+	// Reuses LineOfOffset's cached newline index via the same binary
+	// search instead of scanning backward from offset byte by byte —
+	// O(log n) in the newline count instead of O(line length). A single
+	// very long line (a minified table, a long URL list) used to make
+	// every diagnostic on that line pay for a full backward scan.
+	nl := f.lineIndex()
+	lo := newlineSearch(nl, offset)
+	start := 0
+	if lo > 0 {
+		start = nl[lo-1] + 1
+	}
+	return offset - start + 1
+}
+
+// newlineSearch returns the index of the first entry in nl (a sorted
+// list of newline byte offsets) that is >= offset, or len(nl) if none.
+// Inlined rather than sort.Search: sort.Search's comparison closure
+// would capture nl and offset and escape to the heap (engine-bench
+// profiling attributed ~64 k allocations per 10-iteration run to that
+// closure box before plan 195 inlined the binary search here).
+func newlineSearch(nl []int, offset int) int {
 	lo, hi := 0, len(nl)
 	for lo < hi {
 		mid := int(uint(lo+hi) >> 1)
@@ -559,18 +584,5 @@ func (f *File) LineOfOffset(offset int) int {
 			lo = mid + 1
 		}
 	}
-	return 1 + lo
-}
-
-// ColumnOfOffset converts a byte offset in Source to a 1-based column
-// number on its line.
-func (f *File) ColumnOfOffset(offset int) int {
-	if offset > len(f.Source) {
-		offset = len(f.Source)
-	}
-	start := offset
-	for start > 0 && f.Source[start-1] != '\n' {
-		start--
-	}
-	return offset - start + 1
+	return lo
 }

--- a/internal/lint/file.go
+++ b/internal/lint/file.go
@@ -554,6 +554,9 @@ func (f *File) ColumnOfOffset(offset int) int {
 	if offset > len(f.Source) {
 		offset = len(f.Source)
 	}
+	if offset < 0 {
+		offset = 0
+	}
 	// Reuses LineOfOffset's cached newline index via the same binary
 	// search instead of scanning backward from offset byte by byte —
 	// O(log n) in the newline count instead of O(line length). A single

--- a/internal/lint/lint_coverage_test.go
+++ b/internal/lint/lint_coverage_test.go
@@ -280,6 +280,14 @@ func TestColumnOfOffset_PastEOFClamps(t *testing.T) {
 	assert.Equal(t, 4, f.ColumnOfOffset(999))
 }
 
+func TestColumnOfOffset_NegativeOffsetClamps(t *testing.T) {
+	// A negative offset clamps to the start of the file (column 1),
+	// mirroring the upper-bound EOF clamp above.
+	f := &File{Source: []byte("line1\nline2\n")}
+	assert.Equal(t, 1, f.ColumnOfOffset(-1))
+	assert.Equal(t, 1, f.ColumnOfOffset(-100))
+}
+
 func TestColumnOfOffset_AtNewline(t *testing.T) {
 	// The newline itself sits at the end of its line.
 	f := &File{Source: []byte("ab\nc")}

--- a/internal/rules/tablefmt/prealloc_test.go
+++ b/internal/rules/tablefmt/prealloc_test.go
@@ -1,0 +1,44 @@
+package tablefmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// wideTableLines builds a table with n data rows, used to make append
+// slice-growth in tryParseTable/findTables visible in an alloc count.
+func wideTableLines(n int) [][]byte {
+	lines := [][]byte{
+		[]byte("| Col A | Col B |"),
+		[]byte("| --- | --- |"),
+	}
+	for i := 0; i < n; i++ {
+		lines = append(lines, []byte("| a | b |"))
+	}
+	return lines
+}
+
+// TestFindTables_PreSizedRowSlices pins the allocation count for parsing
+// one large table. rawLines and rows in tryParseTable used to grow via
+// plain append with no capacity hint, paying several slice-growth
+// reallocs per table (docs/development/high-performance-go.md); a
+// pre-sizing pass ahead of the capture loop removes them.
+func TestFindTables_PreSizedRowSlices(t *testing.T) {
+	lines := wideTableLines(50)
+	codeLines := map[int]struct{}{}
+
+	allocs := testing.AllocsPerRun(50, func() {
+		tables := findTables(lines, codeLines)
+		require.Len(t, tables, 1)
+	})
+	t.Logf("findTables allocs/op for a 52-row table = %.0f", allocs)
+	// Most of the remaining allocs come from splitRowBytes's per-row
+	// cells slice, unrelated to this fix. Before pre-sizing
+	// rawLines/rows in tryParseTable, this fixture measured 174
+	// allocs/op; pre-sizing removed the slice-growth reallocs on both
+	// slices, dropping it to 162.
+	require.LessOrEqualf(t, allocs, float64(162),
+		"findTables allocs/op = %.0f; want <= 162 (rawLines+rows pre-sized "+
+			"in tryParseTable)", allocs)
+}

--- a/internal/rules/tablefmt/tablefmt.go
+++ b/internal/rules/tablefmt/tablefmt.go
@@ -355,9 +355,15 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]struct{}) (*tabl
 		return nil, start
 	}
 
-	// Collect all table rows.
-	var rawLines [][]byte
-	var rows []row
+	// Collect all table rows. dataRows counts the run of consecutive
+	// data-row lines without allocating (mirrors the loop below's
+	// stopping condition), so rawLines/rows can be pre-sized for the
+	// header, separator, and every data row up front — the capture
+	// loop below never triggers a slice-growth realloc
+	// (docs/development/high-performance-go.md).
+	dataRows := countDataRows(lines, prefix, start+2, codeLines)
+	rawLines := make([][]byte, 0, 2+dataRows)
+	rows := make([]row, 0, 2+dataRows)
 
 	// Header row.
 	headerCells := splitRowBytes(content)
@@ -391,6 +397,25 @@ func tryParseTable(lines [][]byte, start int, codeLines map[int]struct{}) (*tabl
 		prefix:    prefix,
 		rows:      rows,
 	}, end
+}
+
+// countDataRows returns the number of consecutive data-row lines starting
+// at i, mirroring the stopping condition of the data-row capture loop in
+// tryParseTable without allocating. Used only to pre-size that loop's
+// output slices.
+func countDataRows(lines [][]byte, prefix string, i int, codeLines map[int]struct{}) int {
+	n := 0
+	for i < len(lines) {
+		if _, ok := codeLines[i+1]; ok { // i is 0-based, codeLines is 1-based
+			break
+		}
+		if !isTableRow(stripPrefix(lines[i], prefix)) {
+			break
+		}
+		n++
+		i++
+	}
+	return n
 }
 
 // detectPrefix extracts the blockquote or list prefix from a line.

--- a/internal/rules/tocdirective/alloc_test.go
+++ b/internal/rules/tocdirective/alloc_test.go
@@ -11,8 +11,11 @@ import (
 // 195 task 14 replaces the per-File re-parse helper
 // (hasTOCLinkReference) with a linear scan over the parsed
 // f.LinkReferences() table, eliminating ~200 alloc/op the
-// extra parse paid for on every fresh File.
-const allocBudgetMDS035 = 10
+// extra parse paid for on every fresh File. matchVariant scanning
+// []byte directly (docs/development/high-performance-go.md) instead
+// of converting each paragraph line to a string before regexp
+// matching dropped the remaining 6 allocs/op to 0.
+const allocBudgetMDS035 = 0
 
 const allocBudgetFixture = "# Document title\n" +
 	"\n" +

--- a/internal/rules/tocdirective/rule.go
+++ b/internal/rules/tocdirective/rule.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -109,9 +108,7 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 	lines := para.Lines()
 	for i := 0; i < lines.Len(); i++ {
 		seg := lines.At(i)
-		lineText := strings.TrimRight(
-			string(seg.Value(f.Source)), "\r\n",
-		)
+		lineText := bytes.TrimRight(seg.Value(f.Source), "\r\n")
 		v, matched := matchVariant(lineText)
 		if !matched {
 			continue
@@ -134,9 +131,9 @@ func (r *Rule) CheckNode(n ast.Node, entering bool, f *lint.File) []lint.Diagnos
 
 var _ rule.NodeChecker = (*Rule)(nil)
 
-func matchVariant(line string) (tocVariant, bool) {
+func matchVariant(line []byte) (tocVariant, bool) {
 	for _, v := range variants {
-		if v.pattern.MatchString(line) {
+		if v.pattern.Match(line) {
 			return v, true
 		}
 	}
@@ -187,9 +184,7 @@ func collectReplacements(f *lint.File, hasTOCRef bool) []struct{ start, end int 
 		lines := para.Lines()
 		for i := 0; i < lines.Len(); i++ {
 			seg := lines.At(i)
-			lineText := strings.TrimRight(
-				string(seg.Value(f.Source)), "\r\n",
-			)
+			lineText := bytes.TrimRight(seg.Value(f.Source), "\r\n")
 			v, matched := matchVariant(lineText)
 			if !matched {
 				continue

--- a/pkg/goldmark/parser/html_block.go
+++ b/pkg/goldmark/parser/html_block.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"bytes"
 	"regexp"
-	"strings"
 
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 	"github.com/jeduden/mdsmith/pkg/goldmark/text"
@@ -76,6 +75,54 @@ var allowedBlockTags = map[string]struct{}{
 	"ul":         {},
 }
 
+// tagBuf is a fixed-capacity stack buffer for an ASCII tag name, sized so
+// the longest HTML tag (and longer non-tags, truncated harmlessly) fits
+// without a heap allocation.
+type tagBuf struct {
+	buf [32]byte
+	n   int
+}
+
+// lowerInto copies the ASCII-lowercased bytes of b into the stack buffer,
+// truncating anything past its capacity (a name that long is not in
+// allowedBlockTags or the raw-text set, so truncation cannot cause a
+// false match against the short tag names they contain).
+func (t *tagBuf) lowerInto(b []byte) []byte {
+	t.n = 0
+	for _, c := range b {
+		if t.n >= len(t.buf) {
+			break
+		}
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		t.buf[t.n] = c
+		t.n++
+	}
+	return t.buf[:t.n]
+}
+
+// tagInAllowedSet reports whether b is (case-insensitively) one of the
+// type-6 HTML block tags, lowercasing into a stack buffer so the lookup
+// allocates nothing — strings.ToLower(string(b)) allocated a new string
+// on every trigger candidate line (docs/development/high-performance-go.md).
+func tagInAllowedSet(b []byte) bool {
+	var t tagBuf
+	_, ok := allowedBlockTags[string(t.lowerInto(b))]
+	return ok
+}
+
+// isRawTextTag reports whether b is (case-insensitively) one of the
+// raw-text tags that type-7 openers defer to type 1 for.
+func isRawTextTag(b []byte) bool {
+	var t tagBuf
+	switch string(t.lowerInto(b)) {
+	case "script", "style", "pre":
+		return true
+	}
+	return false
+}
+
 var htmlBlockType1OpenRegexp = regexp.MustCompile(`(?i)^[ ]{0,3}<(script|pre|style|textarea)(?:\s.*|>.*|/>.*|)(?:\r\n|\n)?$`) //nolint:golint,lll
 var htmlBlockType1CloseRegexp = regexp.MustCompile(`(?i)^.*</(?:script|pre|style|textarea)>.*`)
 
@@ -128,20 +175,17 @@ func (b *htmlBlockParser) Open(parent ast.Node, reader text.Reader, pc Context) 
 	} else if match := htmlBlockType7Regexp.FindSubmatchIndex(line); match != nil {
 		isCloseTag := match[2] > -1 && bytes.Equal(line[match[2]:match[3]], []byte("/"))
 		hasAttr := match[6] != match[7]
-		tagName := strings.ToLower(string(line[match[4]:match[5]]))
-		_, ok := allowedBlockTags[tagName]
-		if ok {
+		tagBytes := line[match[4]:match[5]]
+		if tagInAllowedSet(tagBytes) {
 			node = ast.NewHTMLBlock(ast.HTMLBlockType6)
-		} else if tagName != "script" && tagName != "style" &&
-			tagName != "pre" && !ast.IsParagraph(last) && !(isCloseTag && hasAttr) { // type 7 can not interrupt paragraph
+		} else if !isRawTextTag(tagBytes) &&
+			!ast.IsParagraph(last) && !(isCloseTag && hasAttr) { // type 7 can not interrupt paragraph
 			node = ast.NewHTMLBlock(ast.HTMLBlockType7)
 		}
 	}
 	if node == nil {
 		if match := htmlBlockType6Regexp.FindSubmatchIndex(line); match != nil {
-			tagName := string(line[match[2]:match[3]])
-			_, ok := allowedBlockTags[strings.ToLower(tagName)]
-			if ok {
+			if tagInAllowedSet(line[match[2]:match[3]]) {
 				node = ast.NewHTMLBlock(ast.HTMLBlockType6)
 			}
 		}

--- a/pkg/goldmark/parser/html_block_tag_test.go
+++ b/pkg/goldmark/parser/html_block_tag_test.go
@@ -1,0 +1,61 @@
+package parser
+
+import "testing"
+
+// TestTagInAllowedSet_CaseInsensitive mirrors the case-insensitive lookup
+// strings.ToLower(string(b)) used to perform, without allocating.
+func TestTagInAllowedSet_CaseInsensitive(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want bool
+	}{
+		{"div", true},
+		{"DIV", true},
+		{"DiV", true},
+		{"blockquote", true},
+		{"notarealtag", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := tagInAllowedSet([]byte(tc.tag)); got != tc.want {
+			t.Errorf("tagInAllowedSet(%q) = %v; want %v", tc.tag, got, tc.want)
+		}
+	}
+}
+
+// TestIsRawTextTag_CaseInsensitive mirrors the tagName != "script" &&
+// tagName != "style" && tagName != "pre" checks the type-7 opener used to
+// perform against a lowercased string.
+func TestIsRawTextTag_CaseInsensitive(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want bool
+	}{
+		{"script", true},
+		{"SCRIPT", true},
+		{"Style", true},
+		{"pre", true},
+		{"div", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isRawTextTag([]byte(tc.tag)); got != tc.want {
+			t.Errorf("isRawTextTag(%q) = %v; want %v", tc.tag, got, tc.want)
+		}
+	}
+}
+
+// TestTagLookups_ZeroAlloc pins the allocation-free lookup path
+// (docs/development/high-performance-go.md): strings.ToLower(string(b))
+// allocated a new string on every HTML-block trigger candidate line;
+// lowering into a stack buffer removes it.
+func TestTagLookups_ZeroAlloc(t *testing.T) {
+	b := []byte("BLOCKQUOTE")
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = tagInAllowedSet(b)
+		_ = isRawTextTag(b)
+	})
+	if allocs != 0 {
+		t.Errorf("tagInAllowedSet+isRawTextTag allocs/op = %.0f; want 0", allocs)
+	}
+}

--- a/pkg/goldmark/parser/html_blocks_test.go
+++ b/pkg/goldmark/parser/html_blocks_test.go
@@ -56,6 +56,38 @@ func TestHTMLBlock_AllSevenTypes(t *testing.T) {
 	}
 }
 
+// TestHTMLBlock_TagCaseInsensitive drives the full Open() path (not just
+// the tagInAllowedSet/isRawTextTag unit tests) with mixed-case tag names,
+// so a wiring mistake in html_block.go's tag lookups (e.g. swapping which
+// helper a call site uses) would be caught here even though
+// TestHTMLBlock_AllSevenTypes only exercises lowercase tags.
+func TestHTMLBlock_TagCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		kind ast.NodeKind
+	}{
+		{"type1-script-mixed-case", "<Script>alert('x')</Script>\n", ast.KindHTMLBlock},
+		{"type6-block-tag-uppercase", "<DIV>\nblock\n</DIV>\n", ast.KindHTMLBlock},
+		{"type7-tag-mixed-case", "<A href=\"x\">\n\n", ast.KindHTMLBlock},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := parseWithDefaults(tc.src)
+			found := false
+			_ = ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+				if entering && n.Kind() == tc.kind {
+					found = true
+				}
+				return ast.WalkContinue, nil
+			})
+			if !found {
+				t.Errorf("expected %v for %q", tc.kind, tc.src)
+			}
+		})
+	}
+}
+
 func TestRawHTML_InlineTags(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

A fleet of scan agents audited `internal/` and `pkg/` against
[`docs/development/high-performance-go.md`](docs/development/high-performance-go.md),
covering allocation/regex patterns, string/bytes handling, data-structure
layout, and concurrency/misc anti-patterns. Findings were ranked by how hot
the code path is (per-file, per-line, per-diagnostic) and whether the
benefit was empirically confirmed with a benchmark or alloc count — not
just plausible on paper. Two initially promising findings didn't survive
that check and were dropped (see "Findings considered and not taken",
below).

This PR fixes the top 5 that did survive, each with a red/green test
(a benchmark or `testing.AllocsPerRun` assertion that fails before the fix
and passes after) and a measured before/after number. Three rounds of
xhigh-severity adversarial code review then found and fixed a real
behavioral regression in one of the five fixes (see "Review findings",
below) plus a latent edge-case bug and a stale comment.

## Fixes

1. **`internal/lint/file.go` — `ColumnOfOffset`**: hand-rolled backward byte
   scan → binary search reusing `LineOfOffset`'s cached newline index.
   O(line length) → O(log newline count). Benchmarked on an 8 KB line:
   **~5.3µs/op → ~9ns/op**. This function has ~26 call sites (once per
   diagnostic across many rules), so a single very long line used to make
   every diagnostic on it pay for a full backward scan.

2. **`internal/rules/tocdirective/rule.go` (MDS035) — `matchVariant`**:
   converted every paragraph line to a `string` before regexp matching, in
   both the Check and Fix paths. Switched to `regexp.Match([]byte)` +
   `bytes.TrimRight`. **6 → 0 allocs/op** on the rule's alloc-budget
   fixture; the budget constant is tightened to match.

3. **`internal/rules/tablefmt/tablefmt.go` (MDS025) — `tryParseTable`**:
   `rawLines`/`rows` grew via plain `append` with no capacity hint, so a
   multi-row table paid several slice-growth reallocs. Added a
   non-allocating `countDataRows` pre-scan (mirroring the sibling rule
   `tablereadability`'s established pattern) so both slices are pre-sized
   once. **174 → 162 allocs/op** parsing a 52-row table (residual allocs
   are `splitRowBytes`'s per-row cell slice, out of scope for this fix).

4. **`pkg/goldmark/parser/html_block.go`**: the type-6/type-7 HTML block
   openers called `strings.ToLower(string(tagBytes))` on every trigger
   candidate line (any line starting with `<`). `internal/lint/layer0_html.go`
   already solved the identical problem with a stack-buffer lowering
   (`tagBuf.lowerInto`); this mirrors that pattern locally (this package
   can't import `internal/lint`). Confirmed **0 allocs/op** for the new
   `tagInAllowedSet`/`isRawTextTag` helpers, plus a new
   `TestHTMLBlock_TagCaseInsensitive` integration test driving the full
   parser `Open()` path with mixed-case tags. Full `pkg/goldmark` suite,
   including the upstream-equivalence harness, still passes.

5. **`internal/corpus/collect.go` — `collectFile`**: used a bare
   `os.ReadFile` while walking cloned third-party repositories for the
   training corpus — the one file-ingestion loop reading genuinely
   untrusted external content without the byte cap every other read site
   in the codebase already applies (`bytelimit`, `githooksync`, `schema`).
   Now stats the file first and **skips** it (via `reportProgress` +
   `return Record{}, false, nil`) when it exceeds
   `bytelimit.DefaultMaxInputBytes` — falling through to
   `bytelimit.ReadFileLimited` as a second check against the file growing
   past the cap between the stat and the read. Either check failing skips
   the file; it does **not** fail the walk (see below for why that
   distinction needed its own fix).

## Review findings (fixed during the 3 xhigh review passes)

- **Corpus collection aborted the whole multi-source build on one bad
  file.** The first version of fix #5 returned `collectFile`'s read error
  as fatal. Since `collectFromRoot`'s `WalkDir` callback aborts its whole
  walk on any error, and `Collect`'s loop over `cfg.Sources` returns on the
  first source error, a single oversized (or momentarily unreadable) file
  anywhere discarded every record already gathered from every source in
  the run — the opposite of resilient batch collection. Fixed in two
  steps: the stat-based size pre-check skips instead of erroring, and the
  fallback `bytelimit.ReadFileLimited` error (covering the TOCTOU race
  where a file grows past the cap between the stat and the read) does
  too. Added direct `collectFile` unit tests for both error branches, and
  rewrote the oversized-file test to use two `Sources` (not one) to prove
  an earlier source's records survive a later source's bad file.
- **Latent negative-offset regression in `ColumnOfOffset`.** The
  binary-search rewrite only clamped the upper bound; a negative offset
  echoed back out unclamped instead of the prior implementation's
  always-return-1 behavior. Not reachable through any shipped rule (every
  call site already guards against negative input), but fixed to match
  `LineOfOffset`'s and the old implementation's contract.
- **Stale comment** in `internal/linkgraph/linkgraph.go` still described
  `ColumnOfOffset`'s old O(column) backward scan after fix #1 changed it
  to O(log lines).

## Findings considered and not taken

- A scan agent flagged `ColumnOfOffset`'s backward scan as fixable via
  `bytes.LastIndexByte` (claimed SIMD-accelerated like the forward
  `bytes.IndexByte`). Benchmarking showed **no measurable difference**
  (~5.3µs/op both ways) — Go's `bytes.LastIndexByte` has no assembly
  implementation on any platform, only a plain Go loop
  (`internal/bytealg/lastindexbyte_generic.go`). Went with the binary-search
  fix above instead, which is a real algorithmic win.
- `context.Background()` created per-request in
  `internal/rules/externallink/probe_net.go` loses cancellation
  (Ctrl-C won't interrupt in-flight probes). Real, but the `rule.Rule.Check`
  interface has no `context.Context` parameter anywhere in its ~150
  implementations — threading one through is an interface-wide change out
  of scope for this fix set. Worth a dedicated follow-up plan.
- Struct field-reordering candidates (`docHeading`, `heading`, `revMatch`)
  reduce GC scan surface (`ptrdata`) but don't change `unsafe.Sizeof`, so
  there's no straightforward way to pin the improvement with a red/green
  test. Left for a follow-up that can also cover the small `map[string]bool`
  → `map[string]struct{}` set candidates found in the same pass.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (repo-wide, all green)
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run ./...` (0 issues)
- [x] `go test -tags goldmark_upstream ./pkg/goldmark/...` (equivalence harness green; one pre-existing, unrelated failure in `pkg/markdown`'s arena tests confirmed present on `main` too)
- [x] `internal/integration` alloc-budget and per-rule bench-budget gates pass
- [x] `mdsmith check .` — 563 files checked, 0 failures
- [x] Codecov patch coverage: 100% (all modified/coverable lines covered)
- [x] Each fix has its own commit with a benchmark/alloc test that fails before the change and passes after
- [x] 3 rounds of xhigh-severity adversarial code review, each with findings addressed in a follow-up commit before the next round

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCh2j2oeSw6UgNsmpjRonL
