### PR TITLE
perf: audit against high-performance-go.md, fix top 5 hot-path violations

### DIFF
--- a/internal/lint/lineclass.go
+++ b/internal/lint/lineclass.go
@@ -121,10 +121,27 @@ type lc0Container struct {
 }
 
 // lc0Pass carries the mutable state of one ClassifyLines walk.
+//
+// The pointer-containing fields (lines, out, stack, htmlEnd,
+// pendingBlanks) are grouped first, followed by every scalar field:
+// GC ptrdata spans through the last pointer-containing field, so
+// interleaving them — as htmlEnd and pendingBlanks previously were —
+// forces the scan across the whole struct on every heap-allocated
+// instance. See docs/development/high-performance-go.md "Struct
+// layout".
 type lc0Pass struct {
-	lines [][]byte
-	out   *LineClassifier
-	stack []lc0Container
+	lines   [][]byte
+	out     *LineClassifier
+	stack   []lc0Container
+	htmlEnd []byte // closing string for a marker-terminated HTML block (htmlMarker)
+
+	// pendingBlanks holds blank lines seen while inside an indented code
+	// run. A blank inside indented code belongs to the block only if more
+	// indented content follows, so the lines are held here and flushed into
+	// the code set when the run continues (flushPendingBlanks) or discarded
+	// when it ends (endIndentRun) — matching goldmark, which folds interior
+	// blanks into the block but drops trailing ones.
+	pendingBlanks []int
 
 	inFence       bool
 	fenceChar     byte
@@ -133,7 +150,6 @@ type lc0Pass struct {
 	fenceOpenLine int // 1-based
 
 	inHTML   bool     // inside an HTML block
-	htmlEnd  []byte   // closing string for a marker-terminated HTML block (htmlMarker)
 	htmlKind htmlKind // how the open HTML block ends
 
 	prevParagraph bool // previous emitted line was paragraph text (setext gate)
@@ -145,14 +161,6 @@ type lc0Pass struct {
 	// boundary (code and HTML blocks get no lazy continuation), so the
 	// classifier closes it too — see closeBlockAtBoundary.
 	openBlockDepth int
-
-	// pendingBlanks holds blank lines seen while inside an indented code
-	// run. A blank inside indented code belongs to the block only if more
-	// indented content follows, so the lines are held here and flushed into
-	// the code set when the run continues (flushPendingBlanks) or discarded
-	// when it ends (endIndentRun) — matching goldmark, which folds interior
-	// blanks into the block but drops trailing ones.
-	pendingBlanks []int
 }
 
 // run walks every line, handling the optional leading front matter first,

--- a/internal/lint/lineclass.go
+++ b/internal/lint/lineclass.go
@@ -126,9 +126,12 @@ type lc0Container struct {
 // pendingBlanks) are grouped first, followed by every scalar field:
 // GC ptrdata spans through the last pointer-containing field, so
 // interleaving them — as htmlEnd and pendingBlanks previously were —
-// forces the scan across the whole struct on every heap-allocated
-// instance. See docs/development/high-performance-go.md "Struct
-// layout".
+// would force the scan across the whole struct on any instance that
+// escapes to the heap. lc0Pass does not escape today (ClassifyLines
+// is a default-off measurement seam; see its doc comment above), so
+// this is layout hygiene per docs/development/high-performance-go.md
+// "Struct layout" rather than a measured GC win — insurance against
+// the day it does escape.
 type lc0Pass struct {
 	lines   [][]byte
 	out     *LineClassifier

--- a/internal/lint/lineclass_test.go
+++ b/internal/lint/lineclass_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/jeduden/mdsmith/internal/structlayout"
 )
 
-// TestLC0Pass_PointerFieldsFirst pins lc0Pass's layout. lc0Pass is
-// heap-allocated once per ClassifyLines call — the flat-path
-// classifier that runs on every file's Layer-0 pass — so a scalar
-// sandwiched between pointer fields costs one GC-scanned struct per
-// file for nothing. See docs/development/high-performance-go.md
-// "Struct layout".
+// TestLC0Pass_PointerFieldsFirst pins lc0Pass's layout. lc0Pass
+// itself does not escape to the heap today (ClassifyLines is a
+// default-off measurement seam, not part of the default lint path),
+// so a scalar sandwiched between pointer fields costs nothing right
+// now; this pins the layout as hygiene per
+// docs/development/high-performance-go.md "Struct layout" so it
+// stays correct if that ever changes.
 func TestLC0Pass_PointerFieldsFirst(t *testing.T) {
 	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(lc0Pass{}))
 }

--- a/internal/lint/lineclass_test.go
+++ b/internal/lint/lineclass_test.go
@@ -2,12 +2,25 @@ package lint
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
 )
+
+// TestLC0Pass_PointerFieldsFirst pins lc0Pass's layout. lc0Pass is
+// heap-allocated once per ClassifyLines call — the flat-path
+// classifier that runs on every file's Layer-0 pass — so a scalar
+// sandwiched between pointer fields costs one GC-scanned struct per
+// file for nothing. See docs/development/high-performance-go.md
+// "Struct layout".
+func TestLC0Pass_PointerFieldsFirst(t *testing.T) {
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(lc0Pass{}))
+}
 
 // equivCases are markdown snippets whose flat-classifier code-block line
 // set must equal the AST-derived set. They cover the block shapes the

--- a/internal/metrics/conciseness.go
+++ b/internal/metrics/conciseness.go
@@ -4,8 +4,6 @@ import (
 	"math"
 	"regexp"
 	"strings"
-
-	"github.com/jeduden/mdsmith/internal/mdtext"
 )
 
 var tokenPattern = regexp.MustCompile(`[a-z0-9']+`)
@@ -47,7 +45,7 @@ var verbosePhrases = []string{
 	"in most cases",
 }
 
-func concisenessScore(text string) float64 {
+func concisenessScore(text string, sentences int) float64 {
 	lower := strings.ToLower(text)
 	tokens := tokenPattern.FindAllString(lower, -1)
 	if len(tokens) == 0 {
@@ -68,7 +66,6 @@ func concisenessScore(text string) float64 {
 	lexicalDensity := float64(contentWords) / float64(len(tokens))
 	fillerRatio := float64(fillerCount) / float64(len(tokens))
 
-	sentences := mdtext.CountSentences(text)
 	if sentences < 1 {
 		sentences = 1
 	}

--- a/internal/metrics/document.go
+++ b/internal/metrics/document.go
@@ -30,7 +30,17 @@ type Document struct {
 	headingCount      int
 	headingCountReady bool
 	headingCountErr   error
+
+	sentenceCount      int
+	sentenceCountReady bool
+	sentenceCountErr   error
 }
+
+// countSentencesFn is a package variable so tests can substitute a
+// counting stub and assert SentenceCount memoizes its result instead
+// of recounting on every call — MET006, MET009, and MET010 (see
+// registry.go) each need the sentence count for the same Document.
+var countSentencesFn = mdtext.CountSentences
 
 // NewDocument constructs a Document wrapper for metric computation.
 func NewDocument(path string, source []byte) *Document {
@@ -109,6 +119,26 @@ func (d *Document) WordCount() (int, error) {
 	d.wordCount = mdtext.CountWords(text)
 	d.wordCountReady = true
 	return d.wordCount, nil
+}
+
+// SentenceCount returns the sentence count of the extracted plain
+// text, memoized so callers that each need it (MET006, MET009,
+// MET010) share one count per Document instead of recomputing it.
+func (d *Document) SentenceCount() (int, error) {
+	if d.sentenceCountReady {
+		return d.sentenceCount, d.sentenceCountErr
+	}
+
+	text, err := d.PlainText()
+	if err != nil {
+		d.sentenceCountErr = err
+		d.sentenceCountReady = true
+		return 0, err
+	}
+
+	d.sentenceCount = countSentencesFn(text)
+	d.sentenceCountReady = true
+	return d.sentenceCount, nil
 }
 
 // HeadingCount returns number of heading nodes.

--- a/internal/metrics/document_sentencecount_test.go
+++ b/internal/metrics/document_sentencecount_test.go
@@ -1,0 +1,93 @@
+package metrics
+
+// Pins the "skip work you don't need" fix in
+// docs/development/high-performance-go.md: MET006 (conciseness,
+// default-enabled), MET009 (sentences), and MET010
+// (avg-words-per-sentence) each independently called
+// mdtext.CountSentences on the same Document's plain text. Document
+// now memoizes the result via SentenceCount, so a run computing more
+// than one of these metrics on one file counts sentences once instead
+// of up to three times.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocument_SentenceCount_MemoizesAcrossCalls(t *testing.T) {
+	orig := countSentencesFn
+	t.Cleanup(func() { countSentencesFn = orig })
+
+	calls := 0
+	countSentencesFn = func(text string) int {
+		calls++
+		return orig(text)
+	}
+
+	doc := NewDocument("test.md", []byte("# Hello\n\nOne. Two. Three.\n"))
+
+	n1, err := doc.SentenceCount()
+	require.NoError(t, err)
+	n2, err := doc.SentenceCount()
+	require.NoError(t, err)
+	n3, err := doc.SentenceCount()
+	require.NoError(t, err)
+
+	assert.Equal(t, n1, n2)
+	assert.Equal(t, n1, n3)
+	assert.Equal(t, 1, calls,
+		"SentenceCount should call mdtext.CountSentences exactly once across repeated calls, not once per call")
+}
+
+// TestDocument_SentenceCount_PropagatesPlainTextError verifies that
+// when PlainText() fails, SentenceCount propagates the error and
+// caches it, matching PlainText's/WordCount's own cached-error tests.
+func TestDocument_SentenceCount_PropagatesPlainTextError(t *testing.T) {
+	doc := NewDocument("test.md", []byte("# Hello\n"))
+	sentinel := errors.New("injected plain-text error")
+	doc.plainTextReady = true
+	doc.plainTextErr = sentinel
+
+	n, err := doc.SentenceCount()
+	assert.Equal(t, 0, n)
+	assert.ErrorIs(t, err, sentinel)
+
+	// Cached error path: a second call must not re-derive plain text.
+	n2, err2 := doc.SentenceCount()
+	assert.Equal(t, 0, n2)
+	assert.ErrorIs(t, err2, sentinel)
+}
+
+func TestMetrics_MET006AndMET009_ShareSentenceCount(t *testing.T) {
+	orig := countSentencesFn
+	t.Cleanup(func() { countSentencesFn = orig })
+
+	calls := 0
+	countSentencesFn = func(text string) int {
+		calls++
+		return orig(text)
+	}
+
+	doc := NewDocument("test.md", []byte("# Hello\n\nOne. Two. Three. Four.\n"))
+
+	conciseness, ok := Lookup("MET006")
+	require.True(t, ok)
+	_, err := conciseness.Compute(doc)
+	require.NoError(t, err)
+
+	sentences, ok := Lookup("MET009")
+	require.True(t, ok)
+	_, err = sentences.Compute(doc)
+	require.NoError(t, err)
+
+	avgWords, ok := Lookup("MET010")
+	require.True(t, ok)
+	_, err = avgWords.Compute(doc)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls,
+		"MET006+MET009+MET010 on one Document should count sentences once, not once per metric")
+}

--- a/internal/metrics/metrics_morecoverage_test.go
+++ b/internal/metrics/metrics_morecoverage_test.go
@@ -16,22 +16,23 @@ import (
 
 func TestConcisenessScore_EmptyText(t *testing.T) {
 	// Empty text produces no tokens — should return 100.0.
-	score := concisenessScore("")
+	score := concisenessScore("", 0)
 	assert.Equal(t, 100.0, score)
 }
 
 func TestConcisenessScore_PunctuationOnly(t *testing.T) {
 	// Only punctuation: no token-pattern matches → returns 100.0.
-	score := concisenessScore("!!! ??? ---")
+	score := concisenessScore("!!! ??? ---", 0)
 	assert.Equal(t, 100.0, score)
 }
 
 // --- concisenessScore: sentences < 1 → set to 1 branch ---
 
 func TestConcisenessScore_NoSentenceEnding(t *testing.T) {
-	// A phrase with no sentence-ending punctuation: CountSentences may
-	// return 0, which is then clamped to 1 inside concisenessScore.
-	score := concisenessScore("hello world foo bar")
+	// A phrase with no sentence-ending punctuation: the caller's
+	// sentence count (from mdtext.CountSentences) may be 0, which is
+	// then clamped to 1 inside concisenessScore.
+	score := concisenessScore("hello world foo bar", 0)
 	assert.GreaterOrEqual(t, score, 0.0)
 	assert.LessOrEqual(t, score, 100.0)
 }

--- a/internal/metrics/metrics_morecoverage_test.go
+++ b/internal/metrics/metrics_morecoverage_test.go
@@ -29,9 +29,9 @@ func TestConcisenessScore_PunctuationOnly(t *testing.T) {
 // --- concisenessScore: sentences < 1 → set to 1 branch ---
 
 func TestConcisenessScore_NoSentenceEnding(t *testing.T) {
-	// A phrase with no sentence-ending punctuation: the caller's
-	// sentence count (from mdtext.CountSentences) may be 0, which is
-	// then clamped to 1 inside concisenessScore.
+	// A phrase with no sentence-ending punctuation: mdtext.CountSentences
+	// would return 0 for it, so the caller passes 0 directly here to
+	// drive the sentences < 1 clamp inside concisenessScore.
 	score := concisenessScore("hello world foo bar", 0)
 	assert.GreaterOrEqual(t, score, 0.0)
 	assert.LessOrEqual(t, score, 100.0)
@@ -262,6 +262,26 @@ func TestMET008_Readability_PlainTextErrorAfterWordCountSuccess(t *testing.T) {
 	doc.wordCountErr = nil
 	doc.plainTextReady = true
 	doc.plainTextErr = sentinel
+
+	v, err := def.Compute(doc)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+	assert.False(t, v.Available)
+}
+
+func TestMET006_Conciseness_SentenceCountError(t *testing.T) {
+	def, ok := Lookup("MET006")
+	require.True(t, ok, "MET006 must be registered")
+
+	doc := NewDocument("test.md", []byte("# Hello\n\nSome text.\n"))
+	sentinel := errors.New("sentence-count failure")
+	// MET006's own PlainText() call succeeds first, so the only way to
+	// reach its SentenceCount() error check is to prime SentenceCount's
+	// own cache directly: SentenceCount's internal PlainText() call
+	// would otherwise share the same already-successful PlainText()
+	// cache slot MET006 just populated.
+	doc.sentenceCountReady = true
+	doc.sentenceCountErr = sentinel
 
 	v, err := def.Compute(doc)
 	require.Error(t, err)

--- a/internal/metrics/metrics_morecoverage_test.go
+++ b/internal/metrics/metrics_morecoverage_test.go
@@ -29,9 +29,10 @@ func TestConcisenessScore_PunctuationOnly(t *testing.T) {
 // --- concisenessScore: sentences < 1 → set to 1 branch ---
 
 func TestConcisenessScore_NoSentenceEnding(t *testing.T) {
-	// A phrase with no sentence-ending punctuation: mdtext.CountSentences
-	// would return 0 for it, so the caller passes 0 directly here to
-	// drive the sentences < 1 clamp inside concisenessScore.
+	// The caller passes 0 directly here to drive the sentences < 1
+	// clamp inside concisenessScore; mdtext.CountSentences itself
+	// returns at least 1 for any non-empty text, so no real input
+	// produces 0 — this only exercises the clamp in isolation.
 	score := concisenessScore("hello world foo bar", 0)
 	assert.GreaterOrEqual(t, score, 0.0)
 	assert.LessOrEqual(t, score, 100.0)

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -102,7 +102,11 @@ var registry = []Definition{
 			if err != nil {
 				return UnavailableValue(), err
 			}
-			return AvailableValue(concisenessScore(text)), nil
+			sentences, err := doc.SentenceCount()
+			if err != nil {
+				return UnavailableValue(), err
+			}
+			return AvailableValue(concisenessScore(text, sentences)), nil
 		},
 	},
 	{
@@ -139,11 +143,11 @@ var registry = []Definition{
 		Default:      false,
 		DefaultOrder: OrderDesc,
 		Compute: func(doc *Document) (Value, error) {
-			text, err := doc.PlainText()
+			sentences, err := doc.SentenceCount()
 			if err != nil {
 				return UnavailableValue(), err
 			}
-			return AvailableValue(float64(mdtext.CountSentences(text))), nil
+			return AvailableValue(float64(sentences)), nil
 		},
 	},
 	{
@@ -160,11 +164,10 @@ var registry = []Definition{
 			if err != nil {
 				return UnavailableValue(), err
 			}
-			text, err := doc.PlainText()
+			sentences, err := doc.SentenceCount()
 			if err != nil {
 				return UnavailableValue(), err
 			}
-			sentences := mdtext.CountSentences(text)
 			if sentences == 0 {
 				return AvailableValue(0), nil
 			}

--- a/pkg/goldmark/ast/ast.go
+++ b/pkg/goldmark/ast/ast.go
@@ -210,6 +210,14 @@ func (p *pos) SetPos(v int) {
 }
 
 // A BaseNode struct implements the Node interface partialliy.
+//
+// attributes (a slice, pointer-bearing) is declared before childCount
+// and pos (both scalars): GC ptrdata spans through the last
+// pointer-bearing field, so a scalar sandwiched between two pointer
+// fields extends the scan for nothing. See
+// docs/development/high-performance-go.md "Group pointer fields
+// first, scalars last". BaseNode is embedded in every AST node, so
+// this is the single most-allocated struct in the parser.
 type BaseNode struct {
 	firstChild Node
 	lastChild  Node

--- a/pkg/goldmark/ast/structlayout_test.go
+++ b/pkg/goldmark/ast/structlayout_test.go
@@ -17,3 +17,11 @@ func TestAutoLink_PointerFieldsBeforeScalars(t *testing.T) {
 	// declared fields are checked here.
 	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(AutoLink{}), 1)
 }
+
+// TestBaseNode_PointerFieldsBeforeScalars pins BaseNode's layout.
+// BaseNode is embedded in every AST node (Document, Heading,
+// Paragraph, Text, Emphasis, Link, …), so it is the single
+// most-allocated struct in the parser.
+func TestBaseNode_PointerFieldsBeforeScalars(t *testing.T) {
+	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(BaseNode{}), 0)
+}

--- a/pkg/goldmark/ast/structlayout_test.go
+++ b/pkg/goldmark/ast/structlayout_test.go
@@ -18,10 +18,6 @@ func TestAutoLink_PointerFieldsBeforeScalars(t *testing.T) {
 	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(AutoLink{}), 1)
 }
 
-// TestBaseNode_PointerFieldsBeforeScalars pins BaseNode's layout.
-// BaseNode is embedded in every AST node (Document, Heading,
-// Paragraph, Text, Emphasis, Link, …), so it is the single
-// most-allocated struct in the parser.
-func TestBaseNode_PointerFieldsBeforeScalars(t *testing.T) {
-	fieldorder.AssertPointersBeforeScalars(t, reflect.TypeOf(BaseNode{}), 0)
-}
+// BaseNode's own layout is pinned by
+// TestBaseNode_PointerFieldsBeforeScalars in
+// basenode_structlayout_test.go.

--- a/pkg/goldmark/extension/extension_coverage_test.go
+++ b/pkg/goldmark/extension/extension_coverage_test.go
@@ -119,6 +119,31 @@ func TestTable_NotATable(t *testing.T) {
 	}
 }
 
+// TestTable_BarePipeLineBeforeRealTable is a regression test: a bare
+// "|" line earlier in the same paragraph must not abort the scan for
+// a real table later in that paragraph. parseDelimiter used to return
+// a non-nil empty slice for a delimiter line with zero columns
+// (bytes.Split("|", "|") splits down to nothing after the leading/
+// trailing blank-column trim), which satisfied Transform's
+// `alignments == nil` "skip this line" sentinel by accident only
+// because it was actually nil; a pre-sized-but-empty slice broke
+// that.
+func TestTable_BarePipeLineBeforeRealTable(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(extension.Table))
+	src := []byte("x\n|\nA | B\n--- | ---\n1 | 2\n")
+	root := md.Parser().Parse(text.NewReader(src))
+	if !walkContains(root, extast.KindTable) {
+		t.Error("expected Table in AST for the real delimiter row after a bare '|' line")
+	}
+	var buf bytes.Buffer
+	if err := md.Convert(src, &buf); err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("<table>")) {
+		t.Errorf("HTML output missing <table>: %s", buf.String())
+	}
+}
+
 func TestDefinitionList_Parse(t *testing.T) {
 	md := goldmark.New(goldmark.WithExtensions(extension.DefinitionList))
 	src := []byte("Term 1\n: Definition 1\n\nTerm 2\n: Definition 2a\n: Definition 2b\n")

--- a/pkg/goldmark/extension/internal_test.go
+++ b/pkg/goldmark/extension/internal_test.go
@@ -124,11 +124,11 @@ func TestParseDelimiter_AllocBudget(t *testing.T) {
 	reader := newTextReader(row)
 	seg := text.NewSegment(0, len(row))
 
+	if got := defaultTableParagraphTransformer.parseDelimiter(seg, reader); len(got) != cols {
+		t.Fatalf("parseDelimiter returned %d alignments, want %d", len(got), cols)
+	}
 	allocs := testing.AllocsPerRun(20, func() {
-		got := defaultTableParagraphTransformer.parseDelimiter(seg, reader)
-		if len(got) != cols {
-			t.Fatalf("parseDelimiter returned %d alignments, want %d", len(got), cols)
-		}
+		defaultTableParagraphTransformer.parseDelimiter(seg, reader)
 	})
 	// One alloc for the pre-sized alignments slice, plus bytes.Split's
 	// own backing array; a doubling append would add several more
@@ -136,5 +136,23 @@ func TestParseDelimiter_AllocBudget(t *testing.T) {
 	if allocs > 3 {
 		t.Errorf("parseDelimiter allocates %.1f/op on a %d-column row (bound 3); "+
 			"want alignments pre-sized to len(cols) instead of grown via append", allocs, cols)
+	}
+}
+
+// TestParseDelimiter_EmptyColsReturnsNil pins parseDelimiter's nil
+// contract for a delimiter line with no columns (e.g. a bare "|").
+// Transform (table.go) uses `alignments == nil` as its "not a
+// delimiter row" sentinel; a pre-sized-but-empty non-nil slice would
+// satisfy isTableDelim and bytes.Split down to zero columns, pass
+// that sentinel check, then fail the header child-count check and
+// return — aborting the whole paragraph's table scan instead of just
+// skipping this line.
+func TestParseDelimiter_EmptyColsReturnsNil(t *testing.T) {
+	row := "|"
+	reader := newTextReader(row)
+	seg := text.NewSegment(0, len(row))
+	got := defaultTableParagraphTransformer.parseDelimiter(seg, reader)
+	if got != nil {
+		t.Errorf("parseDelimiter(%q) = %#v, want nil", row, got)
 	}
 }

--- a/pkg/goldmark/extension/internal_test.go
+++ b/pkg/goldmark/extension/internal_test.go
@@ -5,6 +5,7 @@ package extension
 // internals.
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jeduden/mdsmith/pkg/goldmark/parser"
@@ -104,5 +105,36 @@ func TestIsTableDelim_AllBranches(t *testing.T) {
 				t.Errorf("isTableDelim(%q) = %v, want %v", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+// TestParseDelimiter_AllocBudget pins parseDelimiter's allocation
+// cost on a wide table row. cols is already known before the
+// alignment loop (bytes.Split has already produced it), so growing
+// alignments via a bare append() forces repeated reallocation-and-copy
+// as the slice doubles past its initial nil capacity. Pre-sizing with
+// make([]ast.Alignment, 0, len(cols)) allocates once. See
+// docs/development/high-performance-go.md "Pre-size slices".
+func TestParseDelimiter_AllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc budget skipped in -short mode")
+	}
+	const cols = 40
+	row := strings.Repeat("---|", cols)
+	reader := newTextReader(row)
+	seg := text.NewSegment(0, len(row))
+
+	allocs := testing.AllocsPerRun(20, func() {
+		got := defaultTableParagraphTransformer.parseDelimiter(seg, reader)
+		if len(got) != cols {
+			t.Fatalf("parseDelimiter returned %d alignments, want %d", len(got), cols)
+		}
+	})
+	// One alloc for the pre-sized alignments slice, plus bytes.Split's
+	// own backing array; a doubling append would add several more
+	// reallocations on a 40-column row.
+	if allocs > 3 {
+		t.Errorf("parseDelimiter allocates %.1f/op on a %d-column row (bound 3); "+
+			"want alignments pre-sized to len(cols) instead of grown via append", allocs, cols)
 	}
 }

--- a/pkg/goldmark/extension/internal_test.go
+++ b/pkg/goldmark/extension/internal_test.go
@@ -119,6 +119,10 @@ func TestParseDelimiter_AllocBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("alloc budget skipped in -short mode")
 	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race; the race detector " +
+			"adds allocation bookkeeping that perturbs the count")
+	}
 	const cols = 40
 	row := strings.Repeat("---|", cols)
 	reader := newTextReader(row)

--- a/pkg/goldmark/extension/race_off_test.go
+++ b/pkg/goldmark/extension/race_off_test.go
@@ -1,0 +1,12 @@
+//go:build !race
+
+package extension
+
+// raceEnabled is the build-tag sentinel for `-race`. Under the
+// default build (no race), it is false; the race_on_test.go variant
+// flips it. TestParseDelimiter_AllocBudget keys off this constant to
+// skip when the race detector is instrumenting allocations — the
+// detector's bookkeeping adds enough extra allocations to make the
+// per-op count flaky on the edge of the budget, and the budget is
+// for production behaviour, not race-instrumented test runs.
+const raceEnabled = false

--- a/pkg/goldmark/extension/race_on_test.go
+++ b/pkg/goldmark/extension/race_on_test.go
@@ -1,0 +1,9 @@
+//go:build race
+
+package extension
+
+// raceEnabled is the build-tag sentinel for `-race`. See the
+// race_off_test.go variant for the rationale; this file is selected
+// when the race detector is active, so TestParseDelimiter_AllocBudget
+// skips instead of fighting the detector's allocation bookkeeping.
+const raceEnabled = true

--- a/pkg/goldmark/extension/table.go
+++ b/pkg/goldmark/extension/table.go
@@ -269,7 +269,10 @@ func (b *tableParagraphTransformer) parseDelimiter(segment text.Segment, reader 
 		cols = cols[:len(cols)-1]
 	}
 
-	var alignments []ast.Alignment
+	// cols is already known here, so alignments is pre-sized to its
+	// length instead of growing via a doubling append. See
+	// docs/development/high-performance-go.md "Pre-size slices".
+	alignments := make([]ast.Alignment, 0, len(cols))
 	for _, col := range cols {
 		if tableDelimLeft.Match(col) {
 			alignments = append(alignments, ast.AlignLeft)

--- a/pkg/goldmark/extension/table.go
+++ b/pkg/goldmark/extension/table.go
@@ -269,6 +269,15 @@ func (b *tableParagraphTransformer) parseDelimiter(segment text.Segment, reader 
 		cols = cols[:len(cols)-1]
 	}
 
+	if len(cols) == 0 {
+		// Transform (below) uses a nil return as its "not a delimiter
+		// row" sentinel; a zero-length-but-non-nil slice from
+		// make([]ast.Alignment, 0, 0) would satisfy that check and let
+		// a bare "|" line reach the header/child-count mismatch,
+		// aborting the whole paragraph's table scan instead of just
+		// skipping this line.
+		return nil
+	}
 	// cols is already known here, so alignments is pre-sized to its
 	// length instead of growing via a doubling append. See
 	// docs/development/high-performance-go.md "Pre-size slices".

--- a/pkg/goldmark/parser/internal_test.go
+++ b/pkg/goldmark/parser/internal_test.go
@@ -80,6 +80,42 @@ func TestIDs_GenerateSequenceCollision(t *testing.T) {
 	}
 }
 
+// TestIDs_Generate_AllocBudget pins the collision loop's allocation
+// cost. Generate used to build each candidate suffix with
+// fmt.Sprintf("%s-%d", ...), allocating a new string on every
+// attempted suffix — a heading collision N deep costs N allocations
+// just walking the loop, on every document with a repeated heading
+// (changelogs, release notes). The fix reuses one []byte buffer via
+// strconv.AppendInt and only allocates once the final id is decided.
+// See docs/development/high-performance-go.md "strconv over
+// fmt.Sprintf".
+func TestIDs_Generate_AllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc budget skipped in -short mode")
+	}
+	const seedDepth = 30
+
+	s := newIDs().(*ids)
+	s.Put([]byte("heading"))
+	for i := 1; i <= seedDepth; i++ {
+		s.Put([]byte(fmt.Sprintf("heading-%d", i)))
+	}
+
+	allocs := testing.AllocsPerRun(10, func() {
+		_ = s.Generate([]byte("Heading"), ast.KindHeading)
+	})
+	// Each call resolves one more collision than the last (heading-31,
+	// heading-32, ...), so a per-attempt allocation would push this
+	// well past single digits by the tenth run. The bound is generous
+	// above the one genuinely necessary allocation (the winning id's
+	// final string/[]byte copy) to avoid pinning an exact count.
+	if allocs > 5 {
+		t.Errorf("Generate allocates %.1f/op walking a %d-deep collision chain (bound 5); "+
+			"want the loop to reuse one buffer instead of allocating per attempted suffix",
+			allocs, seedDepth)
+	}
+}
+
 // silenceStdout swallows fmt.Print output from a function so
 // Dump-style prints don't litter test output.
 func silenceStdout(t *testing.T, fn func()) {

--- a/pkg/goldmark/parser/internal_test.go
+++ b/pkg/goldmark/parser/internal_test.go
@@ -93,6 +93,10 @@ func TestIDs_Generate_AllocBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("alloc budget skipped in -short mode")
 	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race; the race detector " +
+			"adds allocation bookkeeping that perturbs the count")
+	}
 	const seedDepth = 30
 
 	s := newIDs().(*ids)

--- a/pkg/goldmark/parser/parser.go
+++ b/pkg/goldmark/parser/parser.go
@@ -141,9 +141,13 @@ func (s *ids) Generate(value []byte, kind ast.NodeKind) []byte {
 	for i := 1; ; i++ {
 		buf = strconv.AppendInt(buf[:prefixLen], int64(i), 10)
 		if _, ok := s.values[util.BytesToReadOnlyString(buf)]; !ok {
-			key := string(buf)
-			s.values[key] = struct{}{}
-			return []byte(key)
+			// The map key must be an immutable copy (buf is reused across
+			// loop iterations via buf[:prefixLen]), but buf itself is not
+			// retained anywhere else once decided, so it can be returned
+			// directly instead of round-tripping through a second []byte
+			// conversion of the same bytes.
+			s.values[string(buf)] = struct{}{}
+			return buf
 		}
 	}
 }

--- a/pkg/goldmark/parser/parser.go
+++ b/pkg/goldmark/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -128,13 +129,22 @@ func (s *ids) Generate(value []byte, kind ast.NodeKind) []byte {
 		s.values[util.BytesToReadOnlyString(result)] = struct{}{}
 		return result
 	}
+	// Reuse one buffer across attempted suffixes instead of building a
+	// new string per attempt with fmt.Sprintf: a collision N deep would
+	// otherwise allocate N times just walking this loop, on every
+	// document with a repeated heading. strconv.AppendInt also skips
+	// fmt's reflection overhead. See
+	// docs/development/high-performance-go.md "strconv over
+	// fmt.Sprintf".
+	buf := append(result, '-')
+	prefixLen := len(buf)
 	for i := 1; ; i++ {
-		newResult := fmt.Sprintf("%s-%d", result, i)
-		if _, ok := s.values[newResult]; !ok {
-			s.values[newResult] = struct{}{}
-			return []byte(newResult)
+		buf = strconv.AppendInt(buf[:prefixLen], int64(i), 10)
+		if _, ok := s.values[util.BytesToReadOnlyString(buf)]; !ok {
+			key := string(buf)
+			s.values[key] = struct{}{}
+			return []byte(key)
 		}
-
 	}
 }
 

--- a/pkg/goldmark/parser/race_off_test.go
+++ b/pkg/goldmark/parser/race_off_test.go
@@ -1,0 +1,12 @@
+//go:build !race
+
+package parser
+
+// raceEnabled is the build-tag sentinel for `-race`. Under the
+// default build (no race), it is false; the race_on_test.go variant
+// flips it. TestIDs_Generate_AllocBudget keys off this constant to
+// skip when the race detector is instrumenting allocations — the
+// detector's bookkeeping adds enough extra allocations to make the
+// per-op count flaky on the edge of the budget, and the budget is
+// for production behaviour, not race-instrumented test runs.
+const raceEnabled = false

--- a/pkg/goldmark/parser/race_on_test.go
+++ b/pkg/goldmark/parser/race_on_test.go
@@ -1,0 +1,9 @@
+//go:build race
+
+package parser
+
+// raceEnabled is the build-tag sentinel for `-race`. See the
+// race_off_test.go variant for the rationale; this file is selected
+// when the race detector is active, so TestIDs_Generate_AllocBudget
+// skips instead of fighting the detector's allocation bookkeeping.
+const raceEnabled = true


### PR DESCRIPTION
## Summary

A fresh audit against [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md), run after 13+ prior rounds of the same audit had already cleared most low-hanging fruit in `internal/rules/**`. Four parallel scans (allocation budget, string/byte patterns, data structures/struct layout, and skip-work/anti-patterns) turned up real, currently-present violations concentrated in `pkg/goldmark` (the vendored parser — excluded from `.golangci.yml` linting, so it had drifted from the linted tree) and `internal/metrics`. Each fix below is a separate red/green TDD commit: a failing test first (confirmed failing against the pre-fix code), then the minimal fix to make it pass.

## Fixes

1. **`pkg/goldmark/ast`: `BaseNode` field reorder** — `BaseNode` is embedded in every AST node (Document, Heading, Paragraph, Text, Emphasis, Link, …), making it the single most-allocated struct in the parser. `childCount` (a scalar) sat between the pointer-typed sibling/parent fields and `attributes` (a pointer-bearing slice), forcing GC ptrdata to scan past it for nothing. Reordered per "Group pointer fields first, scalars last."

2. **`internal/lint`: `lc0Pass` field reorder** — grouped its pointer-bearing fields ahead of its scalars for layout hygiene. (Reviewed down to: `lc0Pass` is actually stack-allocated and only reached via a default-off measurement seam today, so this is insurance against a future escape rather than a measured production win — comments were corrected to say so.)

3. **`pkg/goldmark/parser`: heading-ID collision loop** — `ids.Generate` built each disambiguation suffix with `fmt.Sprintf("%s-%d", result, i)` inside its collision loop. A heading colliding N deep (common in changelogs/release notes where a heading like "Changed" repeats every version) allocated N times just walking the loop. Now reuses one `[]byte` buffer via `strconv.AppendInt`.

4. **`pkg/goldmark/extension`: table delimiter alignments pre-size** — `parseDelimiter` already knows the exact column count from `bytes.Split` before its alignment loop, but grew `alignments` via a bare `append()` from nil, causing repeated reallocate-and-copy on wide tables. Now pre-sized with `make([]ast.Alignment, 0, len(cols))`.

5. **`internal/metrics`: memoized sentence count** — MET006 (conciseness, enabled by default), MET009 (sentences), and MET010 (avg-words-per-sentence) each independently called `mdtext.CountSentences` on the same `Document`'s plain text, recounting up to 3x per file when more than one is requested. Added `Document.SentenceCount()` following the existing `PlainText`/`WordCount`/`HeadingCount` lazy-cache pattern.

## Caught during review (3 rounds of xhigh-severity review, each addressed before the next)

- **Round 1** caught a real correctness regression: the pre-sized `alignments` slice in fix #4 is non-nil even when empty, but `Transform` used `alignments == nil` as its "not a delimiter row" sentinel — a bare `|` line ahead of a real table silently dropped the whole table. Fixed with an explicit `len(cols) == 0` guard, plus an end-to-end regression test.
- **Round 2** caught the two new alloc-budget tests failing under `go test -race` (the race detector's own bookkeeping perturbs allocation counts) and a factually incorrect test comment. Both fixed.
- **Round 3** caught overstated comments on the `lc0Pass` reorder (claimed heap allocation on every file in production; it's actually stack-allocated behind a default-off flag) and a minor redundant copy in `ids.Generate`. Both corrected.

## Test plan

- [x] Each fix has a failing test confirmed red against the pre-fix code, then green after the fix (see commit messages for exact red numbers)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] `go test -race` on all changed package trees — green (repo-wide `-race` has pre-existing, unrelated flakiness in other packages not touched by this PR)
- [x] `go tool -modfile=tools/go.mod golangci-lint run` — 0 issues
- [x] `go run ./cmd/mdsmith check .` — 567 files checked, 0 failures
- [x] Codecov patch coverage — 100% of new lines covered

🤖 Generated with [Claude Code](https://claude.ai/code)
