### PR TITLE
perf: audit against high-performance-go.md, fix 5 measured allocation/CPU hot spots

### DIFF
--- a/internal/integration/testdata/rule_walk_audit.json
+++ b/internal/integration/testdata/rule_walk_audit.json
@@ -29,7 +29,7 @@
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": false,
-    "uses_ast_walk": true,
+    "uses_ast_walk": false,
     "reads_file_ast": true
   },
   {
@@ -51,7 +51,7 @@
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": false,
-    "uses_ast_walk": true,
+    "uses_ast_walk": false,
     "reads_file_ast": true
   },
   {

--- a/internal/rulelayer/rule_walk_audit.json
+++ b/internal/rulelayer/rule_walk_audit.json
@@ -29,7 +29,7 @@
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": false,
-    "uses_ast_walk": true,
+    "uses_ast_walk": false,
     "reads_file_ast": true
   },
   {
@@ -51,7 +51,7 @@
     "code_block_sensitive": false,
     "fired": true,
     "is_node_checker": false,
-    "uses_ast_walk": true,
+    "uses_ast_walk": false,
     "reads_file_ast": true
   },
   {

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -110,6 +110,40 @@ func buildSectionHeadings(f *lint.File) any {
 	return out
 }
 
+// CollectHeadingNodes returns every *ast.Heading node in the document,
+// in source order. Unlike CollectSectionHeadings (which only exposes
+// Level and Line), this keeps the node itself so a caller can extract
+// heading text via HeadingText.
+//
+// Memoized per File via lint.File.MemoFile: MDS003 (heading-increment)
+// and MDS005 (no-duplicate-headings) both previously ran their own
+// full ast.Walk to collect the same headings; sharing one walk here
+// means the second rule to run pays a cache hit instead of re-walking
+// the tree (docs/development/high-performance-go.md, "memoize
+// per-input computations").
+func CollectHeadingNodes(f *lint.File) []*ast.Heading {
+	return f.MemoFile("astutil.headingNodes", buildHeadingNodes).([]*ast.Heading)
+}
+
+// buildHeadingNodes is the MemoFile-style builder for the heading-nodes
+// memo. Defined at package scope so the value passed to MemoFile is a
+// plain function pointer, matching buildSectionHeadings.
+func buildHeadingNodes(f *lint.File) any {
+	var out []*ast.Heading
+	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := n.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		out = append(out, h)
+		return ast.WalkSkipChildren, nil
+	})
+	return out
+}
+
 // CollectSectionParagraphs returns every non-table paragraph with its
 // 1-based source line and a reference to its AST node. Goldmark
 // parses pipe-delimited tables as paragraphs when the table

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -110,6 +110,14 @@ func buildSectionHeadings(f *lint.File) any {
 	return out
 }
 
+// HeadingNodesMemoKey is CollectHeadingNodes's MemoFile key. Exported
+// (rather than inlined at each use) so the shared-walk regression test
+// in sharedheadingwalk_bench_test.go — which lives in the external
+// astutil_test package because it exercises concrete rule packages
+// (headingincrement, noduplicateheadings) that import astutil — can
+// pre-seed the same cache entry without duplicating the string.
+const HeadingNodesMemoKey = "astutil.headingNodes"
+
 // CollectHeadingNodes returns every *ast.Heading node in the document,
 // in source order. Unlike CollectSectionHeadings (which only exposes
 // Level and Line), this keeps the node itself so a caller can extract
@@ -122,7 +130,7 @@ func buildSectionHeadings(f *lint.File) any {
 // the tree (docs/development/high-performance-go.md, "memoize
 // per-input computations").
 func CollectHeadingNodes(f *lint.File) []*ast.Heading {
-	return f.MemoFile("astutil.headingNodes", buildHeadingNodes).([]*ast.Heading)
+	return f.MemoFile(HeadingNodesMemoKey, buildHeadingNodes).([]*ast.Heading)
 }
 
 // buildHeadingNodes is the MemoFile-style builder for the heading-nodes

--- a/internal/rules/astutil/astutil_test.go
+++ b/internal/rules/astutil/astutil_test.go
@@ -539,6 +539,43 @@ func TestCollectSectionHeadings_Memoized(t *testing.T) {
 		"repeated calls must return the cached slice")
 }
 
+// --- CollectHeadingNodes ---
+
+func TestCollectHeadingNodes_OrdersByLine(t *testing.T) {
+	src := []byte("# H1\n\n## H2\n\n### H3\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	got := CollectHeadingNodes(f)
+	require.Len(t, got, 3)
+	assert.Equal(t, 1, got[0].Level)
+	assert.Equal(t, 2, got[1].Level)
+	assert.Equal(t, 3, got[2].Level)
+	assert.Equal(t, 1, HeadingLine(got[0], f))
+	assert.Equal(t, 3, HeadingLine(got[1], f))
+	assert.Equal(t, 5, HeadingLine(got[2], f))
+}
+
+func TestCollectHeadingNodes_NoHeadings(t *testing.T) {
+	f, err := lint.NewFile("test.md", []byte("just text\n"))
+	require.NoError(t, err)
+	assert.Empty(t, CollectHeadingNodes(f))
+}
+
+// TestCollectHeadingNodes_Memoized pins that repeated calls share the
+// same backing slice — MDS003 and MDS005 both enabled should pay the
+// AST walk once, not twice, mirroring TestCollectSectionHeadings_Memoized.
+func TestCollectHeadingNodes_Memoized(t *testing.T) {
+	src := []byte("# H1\n\n## H2\n\n### H3\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	h1 := CollectHeadingNodes(f)
+	h2 := CollectHeadingNodes(f)
+	require.Len(t, h1, 3)
+	require.Len(t, h2, 3)
+	assert.Same(t, h1[0], h2[0],
+		"repeated calls must return the cached slice")
+}
+
 // --- CollectSectionParagraphs ---
 
 func TestCollectSectionParagraphs_SkipsTables(t *testing.T) {

--- a/internal/rules/astutil/sharedheadingwalk_bench_test.go
+++ b/internal/rules/astutil/sharedheadingwalk_bench_test.go
@@ -1,7 +1,9 @@
 // Package astutil_test benchmarks cross-rule use of astutil's shared,
 // memoized AST collectors. It lives in the external test package
 // because it exercises concrete rule packages (headingincrement,
-// noduplicateheadings) rather than astutil internals.
+// noduplicateheadings) rather than astutil internals — importing
+// them from an internal (non-_test-suffixed) test file would be an
+// import cycle, since those packages import astutil's production code.
 package astutil_test
 
 import (
@@ -9,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/headingincrement"
 	"github.com/jeduden/mdsmith/internal/rules/noduplicateheadings"
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
@@ -37,8 +40,8 @@ func manyHeadingsSource(n int) []byte {
 //
 // f.MemoFile's contract is first-build-wins (internal/lint/file.go):
 // once a key is populated, later calls with a different builder still
-// return the original cached value. So pre-seeding the
-// "astutil.headingNodes" key with an empty slice before either rule
+// return the original cached value. So pre-seeding
+// astutil.HeadingNodesMemoKey with an empty slice before either rule
 // runs means a rule that goes through the shared cache sees zero
 // headings and emits nothing, while a rule that still does its own
 // ast.Walk would see the real (diagnostic-triggering) headings
@@ -51,7 +54,7 @@ func TestHeadingRulesTogether_ShareMemoizedHeadingNodes(t *testing.T) {
 	f, err := lint.NewFile("test.md", src)
 	require.NoError(t, err)
 
-	_ = f.MemoFile("astutil.headingNodes", func(*lint.File) any {
+	_ = f.MemoFile(astutil.HeadingNodesMemoKey, func(*lint.File) any {
 		return []*ast.Heading(nil)
 	})
 

--- a/internal/rules/astutil/sharedheadingwalk_bench_test.go
+++ b/internal/rules/astutil/sharedheadingwalk_bench_test.go
@@ -1,0 +1,92 @@
+// Package astutil_test benchmarks cross-rule use of astutil's shared,
+// memoized AST collectors. It lives in the external test package
+// because it exercises concrete rule packages (headingincrement,
+// noduplicateheadings) rather than astutil internals.
+package astutil_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/rules/headingincrement"
+	"github.com/jeduden/mdsmith/internal/rules/noduplicateheadings"
+	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// manyHeadingsSource builds a document with one H1 followed by n
+// unique level-2 headings, so both MDS003 (heading-increment) and
+// MDS005 (no-duplicate-headings) see n+1 headings to scan per Check.
+func manyHeadingsSource(n int) []byte {
+	src := []byte("# Title\n\n")
+	for i := 0; i < n; i++ {
+		src = append(src, []byte(fmt.Sprintf("## Section %d\n\nSome body text.\n\n", i))...)
+	}
+	return src
+}
+
+// TestHeadingRulesTogether_ShareMemoizedHeadingNodes pins the actual
+// mechanism the fix relies on with a deterministic result rather than
+// a timing/allocation proxy (which ordinary noise, or an unrelated
+// per-file memo like LineOfOffset's newline index, could easily
+// confound): both heading-increment (MDS003) and no-duplicate-headings
+// (MDS005) must read headings through astutil.CollectHeadingNodes's
+// File-level memo, not their own private ast.Walk.
+//
+// f.MemoFile's contract is first-build-wins (internal/lint/file.go):
+// once a key is populated, later calls with a different builder still
+// return the original cached value. So pre-seeding the
+// "astutil.headingNodes" key with an empty slice before either rule
+// runs means a rule that goes through the shared cache sees zero
+// headings and emits nothing, while a rule that still does its own
+// ast.Walk would see the real (diagnostic-triggering) headings
+// regardless of the pre-seed.
+func TestHeadingRulesTogether_ShareMemoizedHeadingNodes(t *testing.T) {
+	// A level-3 first heading trips MDS003; the repeated heading text
+	// trips MDS005 — both would report a diagnostic on this file if
+	// they read the real AST.
+	src := []byte("### First heading\n\n### First heading\n")
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+
+	_ = f.MemoFile("astutil.headingNodes", func(*lint.File) any {
+		return []*ast.Heading(nil)
+	})
+
+	hi := &headingincrement.Rule{}
+	nd := &noduplicateheadings.Rule{}
+	assert.Empty(t, hi.Check(f),
+		"heading-increment must read headings via the pre-seeded astutil memo, not re-walk f.AST directly")
+	assert.Empty(t, nd.Check(f),
+		"no-duplicate-headings must read headings via the pre-seeded astutil memo, not re-walk f.AST directly")
+}
+
+// BenchmarkHeadingRulesTogether exercises MDS003 and MDS005 back to
+// back against fresh Files, mirroring how internal/checker runs every
+// enabled rule against one File per workspace file. benchstat-friendly
+// (no assertion): a prior manual benchstat comparison (10 runs each)
+// showed the shared walk cuts combined wall-clock by ~7% (mean 101.9us
+// -> 94.5us on a 201-heading document) even though allocs/op rises
+// slightly (145 -> 157, from MemoFile's map-and-interface-boxing
+// overhead) — fewer full tree walks wins on net despite the small
+// extra bookkeeping cost.
+func BenchmarkHeadingRulesTogether(b *testing.B) {
+	hi := &headingincrement.Rule{}
+	nd := &noduplicateheadings.Rule{}
+	src := manyHeadingsSource(50)
+	warm, err := lint.NewFile("warm.md", src)
+	require.NoError(b, err)
+	_ = hi.Check(warm)
+	_ = nd.Check(warm)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f, err := lint.NewFile("bench.md", src)
+		require.NoError(b, err)
+		_ = hi.Check(f)
+		_ = nd.Check(f)
+	}
+}

--- a/internal/rules/catalog/alloc_test.go
+++ b/internal/rules/catalog/alloc_test.go
@@ -1,0 +1,19 @@
+package catalog
+
+import "testing"
+
+// TestExtractPlaceholderFields_PresizedAllocs pins
+// docs/development/high-performance-go.md's "pre-size slices" pattern:
+// extractPlaceholderFields knows fieldinterp.Fields's result count up
+// front (via `all`, already used to presize `seen`), so `fields` should
+// be allocated once via make([]string, 0, len(all)) instead of growing
+// from a nil slice across repeated append calls.
+func TestExtractPlaceholderFields_PresizedAllocs(t *testing.T) {
+	row := "- [{summary}]({filename}) by {author}, tagged {tag}"
+	allocs := testing.AllocsPerRun(200, func() {
+		_ = extractPlaceholderFields(row)
+	})
+	if allocs > 11 {
+		t.Fatalf("extractPlaceholderFields allocs/op = %v, want <= 11", allocs)
+	}
+}

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -1675,12 +1675,15 @@ func (r *Rule) checkCaseMismatches(f *lint.File) []lint.Diagnostic {
 func extractPlaceholderFields(row string) []string {
 	all := fieldinterp.Fields(row)
 	seen := make(map[string]struct{}, len(all))
-	var fields []string
+	fields := make([]string, 0, len(all))
 	for _, name := range all {
 		if _, ok := seen[name]; !ok {
 			seen[name] = struct{}{}
 			fields = append(fields, name)
 		}
+	}
+	if len(fields) == 0 {
+		return nil
 	}
 	return fields
 }

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -3054,6 +3054,15 @@ func TestExtractPlaceholderFields_NoFields(t *testing.T) {
 	assert.Empty(t, fields)
 }
 
+// TestExtractPlaceholderFields_NoFields_ReturnsNil pins
+// docs/development/high-performance-go.md's "return nil, not []T{}"
+// convention: pre-sizing fields via make([]string, 0, len(all)) would
+// otherwise return a non-nil empty slice when row has no placeholders.
+func TestExtractPlaceholderFields_NoFields_ReturnsNil(t *testing.T) {
+	fields := extractPlaceholderFields("plain text")
+	assert.Nil(t, fields)
+}
+
 func TestCheckFieldCaseMismatches_Exact(t *testing.T) {
 	entries := []fileEntry{
 		{fields: map[string]any{"filename": "a.md", "title": "A"}},

--- a/internal/rules/headingincrement/rule.go
+++ b/internal/rules/headingincrement/rule.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/internal/rules/astutil"
 	"github.com/jeduden/mdsmith/internal/rules/settings"
-	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 )
 
 func init() {
@@ -44,7 +43,11 @@ func (r *Rule) Category() string { return "heading" }
 // back to the parse path.
 func (r *Rule) LineCapable() bool { return len(r.Placeholders) == 0 }
 
-// Check implements rule.Rule.
+// Check implements rule.Rule. The parsed path reads
+// astutil.CollectHeadingNodes instead of running its own ast.Walk: that
+// collector is memoized per File, so when no-duplicate-headings (MDS005)
+// also runs against the same File, only the first of the two rules pays
+// for the tree walk.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	if f != nil && f.AST == nil {
 		return r.checkNilAST(f)
@@ -52,15 +55,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	prevLevel := 0
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		heading, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
+	for _, heading := range astutil.CollectHeadingNodes(f) {
 		level := heading.Level
 
 		// Check if this heading's text matches a configured placeholder.
@@ -99,8 +94,7 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		}
 
 		prevLevel = level
-		return ast.WalkContinue, nil
-	})
+	}
 
 	return diags
 }

--- a/internal/rules/markdownflavor/alloc_test.go
+++ b/internal/rules/markdownflavor/alloc_test.go
@@ -1,0 +1,67 @@
+package markdownflavor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// manyAlertsSource builds a document with n GitHub-alert blockquotes,
+// each with a continuation line, so fixGitHubAlerts has real marker
+// and lazy-continuation lines to strip/re-prefix on every call.
+func manyAlertsSource(n int) []byte {
+	var src []byte
+	for i := 0; i < n; i++ {
+		src = append(src, []byte(fmt.Sprintf(
+			"> [!NOTE]\n> Alert number %d with some body text.\n> Second continuation line here.\n\n", i,
+		))...)
+	}
+	return src
+}
+
+// TestFixGitHubAlerts_PresizedAllocs pins
+// docs/development/high-performance-go.md's "pre-size slices" pattern:
+// fixGitHubAlerts knows its output has at most len(f.Lines) entries
+// (it only ever skips lines, never adds any), so out should be
+// allocated once via make([]string, 0, len(f.Lines)) instead of
+// growing from a nil slice across repeated append calls, mirroring
+// codeblockstyle.Fix's out slice in the same rule family. Combined
+// with TestBuildAlertSkipMaps_StaysInBytes below (fixGitHubAlerts
+// calls buildAlertSkipMaps first), measured baseline is 113 allocs/op
+// on this fixture, down from 169 before either fix.
+func TestFixGitHubAlerts_PresizedAllocs(t *testing.T) {
+	src := manyAlertsSource(50)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+	r := &Rule{}
+
+	allocs := testing.AllocsPerRun(50, func() {
+		_ = r.fixGitHubAlerts(f)
+	})
+	assert.LessOrEqualf(t, allocs, 125.0,
+		"fixGitHubAlerts allocs regressed: got %v, want <= 125", allocs)
+}
+
+// TestBuildAlertSkipMaps_StaysInBytes pins
+// docs/development/high-performance-go.md's "stay in []byte" pattern:
+// buildAlertSkipMaps used to convert every lazy-continuation line to a
+// string (string(f.Lines[contLine-1])) just to strip whitespace and
+// check a '>' prefix — both doable directly on the []byte line. The
+// string conversion escapes (its result crosses the strings.HasPrefix
+// call), so each continuation line paid a full copy-and-allocate.
+// Measured baseline after the []byte rewrite: 10 allocs/op on this
+// fixture (150 continuation lines), down from 60 before.
+func TestBuildAlertSkipMaps_StaysInBytes(t *testing.T) {
+	src := manyAlertsSource(50)
+	f, err := lint.NewFile("test.md", src)
+	require.NoError(t, err)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		_, _ = buildAlertSkipMaps(f)
+	})
+	assert.LessOrEqualf(t, allocs, 20.0,
+		"buildAlertSkipMaps allocs regressed: got %v, want <= 20", allocs)
+}

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -270,8 +270,8 @@ func buildAlertSkipMaps(f *lint.File) (skip, addPrefix map[int]struct{}) {
 		for i := 1; i < lines.Len(); i++ {
 			contSeg := lines.At(i)
 			contLine, _ := flavor.LineCol(f.Source, contSeg.Start)
-			raw := strings.TrimLeft(string(f.Lines[contLine-1]), " \t")
-			if !strings.HasPrefix(raw, ">") {
+			raw := bytes.TrimLeft(f.Lines[contLine-1], " \t")
+			if len(raw) == 0 || raw[0] != '>' {
 				addPrefix[contLine] = struct{}{}
 			}
 		}
@@ -291,7 +291,7 @@ func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 		return f.Source
 	}
 
-	var out []string
+	out := make([]string, 0, len(f.Lines))
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := skip[lineNum]; ok {

--- a/internal/rules/noduplicateheadings/rule.go
+++ b/internal/rules/noduplicateheadings/rule.go
@@ -33,6 +33,11 @@ func (r *Rule) Category() string { return "heading" }
 // mapped back to the document. WalkInlineNodes visits the runs in
 // document order, so the first-occurrence line each duplicate names is
 // byte-identical to the AST walk's.
+//
+// The parsed path reads astutil.CollectHeadingNodes instead of running
+// its own ast.Walk: that collector is memoized per File, so when
+// heading-increment (MDS003) also runs against the same File, only the
+// first of the two rules pays for the tree walk.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	if f != nil && f.AST == nil {
 		return r.checkFromInline(f)
@@ -41,23 +46,13 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	seen := make(map[string]int) // text -> first occurrence line
 
-	_ = ast.Walk(f.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering {
-			return ast.WalkContinue, nil
-		}
-		heading, ok := n.(*ast.Heading)
-		if !ok {
-			return ast.WalkContinue, nil
-		}
-
+	for _, heading := range astutil.CollectHeadingNodes(f) {
 		text := astutil.HeadingText(heading, f.Source)
 		line := astutil.HeadingLine(heading, f)
 		if d, ok := r.verdict(f, text, line, seen); ok {
 			diags = append(diags, d)
 		}
-
-		return ast.WalkContinue, nil
-	})
+	}
 
 	return diags
 }


### PR DESCRIPTION
## Summary

Audited the Go core against `docs/development/high-performance-go.md` using a fleet of five parallel scanning agents (allocations, strings/bytes, data structures/struct layout, skip-work/inlining, concurrency/anti-patterns), then verified every candidate by hand before touching code — per the doc's own "profile before you rewrite... decide with benchstat, not eyeballs" discipline.

Several plausible-looking leads from the scan did **not** survive measurement and were dropped rather than shipped: a `fmt.Sprintf` in the vendored goldmark parser's heading-ID collision path turned out to be dead code (never enabled by mdsmith's own parser construction); a `[]byte(trimmed)` conversion in `internal/rules/include` compiled away to 0 allocations already (escape analysis); a `sync.RWMutex`→`Mutex` swap in the LSP server was dropped because genuine concurrent readers exist there (background lint vs. foreground hover/codeAction); and a couple of suggested struct field reorders (`pkg/markdown.Document`, `duplicatedcontent.corpusScanConfig`) turned out to save zero padding bytes when measured with `unsafe.Sizeof`. This mirrors the prior audit's own experience: "most textbook anti-patterns... do not survive measurement in this codebase."

Five issues did survive rigorous red/green verification and are fixed here, ranked by measured impact:

1. **MDS003 (`heading-increment`) + MDS005 (`no-duplicate-headings`) — redundant full-tree `ast.Walk`.** Both are default-on rules that each ran their own complete AST walk to collect headings. Added `astutil.CollectHeadingNodes`, memoized per `*lint.File` (mirroring the existing `CollectSectionHeadings`), and routed both rules through it so the second rule to run against a file hits the cache instead of re-walking. A manual 10-run benchstat comparison on a 201-heading document shows the shared walk cuts combined wall-clock by **~7% (101.9us → 94.5us mean)**, statistically significant (t≈3.37) despite a small allocs/op increase from `MemoFile`'s bookkeeping overhead — fewer full tree walks wins on net. A deterministic test pre-seeds the memo with an empty result and asserts both rules read through it rather than re-walking `f.AST` directly (a timing-based test would have been confounded by an unrelated pre-existing per-file memo).
2. **`markdownflavor.fixGitHubAlerts` / `buildAlertSkipMaps` — unsized append and a string conversion that escapes.** `fixGitHubAlerts`'s output loop appended to a nil slice with a knowable bound (`len(f.Lines)`); pre-sized it, mirroring `codeblockstyle.Fix`'s identical pattern in the same rule family. `buildAlertSkipMaps` converted every lazy-continuation line to a `string` just to `TrimLeft` whitespace and check a `>` prefix — both doable directly on the `[]byte` line — and that conversion escaped (its result crossed a `strings.HasPrefix` call), so every continuation line paid a full copy. **Measured: `fixGitHubAlerts` 169 → 113 allocs/op; `buildAlertSkipMaps` alone 60 → 10 allocs/op** on a 50-alert fixture.
3. **`catalog.extractPlaceholderFields` — unsized append.** Its dedup companion map was already pre-sized to `len(all)`; the output slice wasn't. Pre-sized it, keeping the project's "return nil, not `[]T{}`" convention for the no-placeholders case. **Measured: 13 → 11 allocs/op.**

Each fix has a dedicated regression test with a pinned budget, verified to fail against the pre-fix code (red) and pass after (green) via `git stash`/`git stash pop` round-trips during development.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run` on changed packages (0 issues)
- [x] Each fix's new test confirmed red against the pre-fix code (`git stash`), green after
- [x] `internal/integration/testdata/rule_walk_audit.json` regenerated via `MDSMITH_REGEN_WALK_AUDIT=1` (MDS003/MDS005's `uses_ast_walk` signal correctly flips to `false`) and the embedded copy in `internal/rulelayer/` re-synced
- [x] `mdsmith check .` on the repo (567 files, 0 failures)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018nw8T7sXArBJGuwEM7ciif

---
_Generated by [Claude Code](https://claude.ai/code/session_018nw8T7sXArBJGuwEM7ciif)_