### PR TITLE
perf: fix top 5 high-performance-go.md violations found by codebase audit

### DIFF
--- a/docs/background/concepts/engine-api.md
+++ b/docs/background/concepts/engine-api.md
@@ -129,6 +129,11 @@ a `Root`, `ReadFile` resolves a relative URI against it, exactly as the
 different files. An absolute path is read unchanged, and an empty `Root`
 reads paths as passed. `MemWorkspace` keys both paths off the same map.
 
+`Session.Kinds` caps its front-matter read at the session's
+`max-input-size`, the same cap `Check`/`Fix` already apply to the
+engine's parse input. A file over the cap resolves the same lenient way
+a missing file does: no error, and no front-matter-derived kinds.
+
 A third implementation, `OverlayWorkspace`, is the LSP server's. It
 reads disk rooted at `Root` but lets `Set(uri, bytes)` shadow a path's
 content with an editor's unsaved buffer, so cross-file rules read the

--- a/internal/bytelimit/bytelimit.go
+++ b/internal/bytelimit/bytelimit.go
@@ -4,6 +4,7 @@
 package bytelimit
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -13,6 +14,21 @@ import (
 
 // DefaultMaxInputBytes is the default file-size cap (2 MB, binary).
 const DefaultMaxInputBytes int64 = 2 * 1024 * 1024
+
+// ErrFileTooLarge is the sentinel every "file too large" error wraps, so
+// a caller can test for it with errors.Is instead of matching the
+// message text. Callers outside this package that build their own
+// oversized-file error against a Workspace's own read path (e.g.
+// pkg/mdsmith's post-read size check for a Workspace that does not
+// implement a bounded read) use [FileTooLargeError] so the same
+// sentinel and message shape apply everywhere.
+var ErrFileTooLarge = errors.New("file too large")
+
+// FileTooLargeError formats the standard "file too large" error for a
+// file of size bytes against a max cap, wrapping [ErrFileTooLarge].
+func FileTooLargeError(size, max int64) error {
+	return fmt.Errorf("%w (%d bytes, max %d)", ErrFileTooLarge, size, max)
+}
 
 // ReadFileLimited reads path from disk, returning an error if the file
 // exceeds max bytes. When max <= 0 or max == math.MaxInt64 no limit is
@@ -110,7 +126,7 @@ func fileTooLargeErr(actualSize, dataLen, max int64) error {
 	if reported < 0 {
 		reported = dataLen
 	}
-	return fmt.Errorf("file too large (%d bytes, max %d)", reported, max)
+	return FileTooLargeError(reported, max)
 }
 
 // statSize returns r's file size, or -1 when it cannot be determined.

--- a/internal/bytelimit/bytelimit.go
+++ b/internal/bytelimit/bytelimit.go
@@ -15,13 +15,20 @@ import (
 // DefaultMaxInputBytes is the default file-size cap (2 MB, binary).
 const DefaultMaxInputBytes int64 = 2 * 1024 * 1024
 
-// ErrFileTooLarge is the sentinel every "file too large" error wraps, so
-// a caller can test for it with errors.Is instead of matching the
-// message text. Callers outside this package that build their own
-// oversized-file error against a Workspace's own read path (e.g.
-// pkg/mdsmith's post-read size check for a Workspace that does not
-// implement a bounded read) use [FileTooLargeError] so the same
-// sentinel and message shape apply everywhere.
+// ErrFileTooLarge is the sentinel every error this package's read
+// functions return for an oversized file wraps, so a caller can test
+// for it with errors.Is instead of matching the message text. Callers
+// outside this package that build their own oversized-file error
+// against a Workspace's own read path (e.g. pkg/mdsmith's post-read
+// size check for a Workspace that does not implement a bounded read)
+// use [FileTooLargeError] so the same sentinel and message shape apply.
+//
+// Not every "file too large" message in the repository wraps this
+// sentinel: cmd/mdsmith's stdin path, internal/engine's in-memory
+// source path, and internal/fix's FixSource each format their own
+// oversized-input error independently of this package. Do not assume
+// errors.Is(err, ErrFileTooLarge) covers every size-limit failure in
+// mdsmith — only ones that read through bytelimit or [FileTooLargeError].
 var ErrFileTooLarge = errors.New("file too large")
 
 // FileTooLargeError formats the standard "file too large" error for a

--- a/internal/rules/linkvalidity/alloc_test.go
+++ b/internal/rules/linkvalidity/alloc_test.go
@@ -6,10 +6,13 @@ import (
 
 // allocBudgetReversedInLine is the per-call ceiling for reversedInLine
 // on a line with several reversed-link matches. idx (the regex
-// submatch-index slice) already gives the exact match count before the
-// result loop starts, so out's final size is known up front — see
-// docs/development/high-performance-go.md "Pre-size slices."
-const allocBudgetReversedInLine = 6
+// submatch-index slice) already gives the exact upper bound on match
+// count before the result loop starts, so out's final size is knowable
+// up front — see docs/development/high-performance-go.md "Pre-size
+// slices." Baseline measured 6; +4 headroom follows the project's
+// "baseline plus max(20%, 4)" convention so an unrelated +1 (regexp
+// internals, GOARCH) doesn't turn CI red.
+const allocBudgetReversedInLine = 10
 
 // reversedInLineMultiMatchFixture has four reversed-link matches on one
 // line, so an unpresized `out` (starting nil, doubling via append) pays
@@ -23,6 +26,9 @@ func TestReversedInLineAllocBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("alloc gate skipped in -short mode")
 	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
 	line := reversedInLineMultiMatchFixture
 
 	_ = reversedInLine(line, line) // warm up regex program cache
@@ -34,5 +40,48 @@ func TestReversedInLineAllocBudget(t *testing.T) {
 		t.Fatalf("reversedInLine allocs/op = %.0f, budget = %d: out must be presized with "+
 			"make([]revMatch, 0, len(idx)) instead of growing via bare append",
 			allocs, allocBudgetReversedInLine)
+	}
+}
+
+// reversedInLineAllFilteredFixture has a regex match (an ordinary
+// [text](url)[ref] — a link immediately followed by a reference or
+// footnote) that the `]`-preceding-byte guard always drops, so
+// reversedInLine must return nil, not a discarded non-nil empty slice,
+// and must not pay for a slice it never uses.
+var reversedInLineAllFilteredFixture = []byte(
+	"see [text](https://example.com)[^1] for more",
+)
+
+// TestReversedInLineAllFilteredReturnsNil pins both the nilness and the
+// zero-extra-alloc property of the all-matches-filtered path. A version
+// that presizes `out` unconditionally before the guard loop allocates a
+// slice it then discards and returns non-nil — a regression this test
+// exists to catch.
+func TestReversedInLineAllFilteredReturnsNil(t *testing.T) {
+	line := reversedInLineAllFilteredFixture
+
+	if got := reversedInLine(line, line); got != nil {
+		t.Fatalf("reversedInLine on an all-filtered line = %#v, want nil", got)
+	}
+
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	_ = reversedInLine(line, line) // warm up regex program cache
+	withGuardedMatch := testing.AllocsPerRun(200, func() {
+		_ = reversedInLine(line, line)
+	})
+	noMatch := testing.AllocsPerRun(200, func() {
+		_ = reversedInLine([]byte("no parens here at all"), []byte("no parens here at all"))
+	})
+	t.Logf("reversedInLine allocs/op: all-filtered=%.0f, no-candidate=%.0f", withGuardedMatch, noMatch)
+	if withGuardedMatch > noMatch {
+		t.Fatalf("reversedInLine allocs/op on an all-filtered line (%.0f) exceeds a line with no "+
+			"parenthesis candidate at all (%.0f): out must be allocated lazily on the first "+
+			"surviving match, not unconditionally before the guard loop",
+			withGuardedMatch, noMatch)
 	}
 }

--- a/internal/rules/linkvalidity/alloc_test.go
+++ b/internal/rules/linkvalidity/alloc_test.go
@@ -1,0 +1,38 @@
+package linkvalidity
+
+import (
+	"testing"
+)
+
+// allocBudgetReversedInLine is the per-call ceiling for reversedInLine
+// on a line with several reversed-link matches. idx (the regex
+// submatch-index slice) already gives the exact match count before the
+// result loop starts, so out's final size is known up front — see
+// docs/development/high-performance-go.md "Pre-size slices."
+const allocBudgetReversedInLine = 6
+
+// reversedInLineMultiMatchFixture has four reversed-link matches on one
+// line, so an unpresized `out` (starting nil, doubling via append) pays
+// extra grow-and-copy allocations a presized make([]revMatch, 0,
+// len(idx)) would not.
+var reversedInLineMultiMatchFixture = []byte(
+	"(one)[a] (two)[b] (three)[c] (four)[d]",
+)
+
+func TestReversedInLineAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	line := reversedInLineMultiMatchFixture
+
+	_ = reversedInLine(line, line) // warm up regex program cache
+	allocs := testing.AllocsPerRun(200, func() {
+		_ = reversedInLine(line, line)
+	})
+	t.Logf("reversedInLine allocs/op = %.0f (budget = %d)", allocs, allocBudgetReversedInLine)
+	if allocs > float64(allocBudgetReversedInLine) {
+		t.Fatalf("reversedInLine allocs/op = %.0f, budget = %d: out must be presized with "+
+			"make([]revMatch, 0, len(idx)) instead of growing via bare append",
+			allocs, allocBudgetReversedInLine)
+	}
+}

--- a/internal/rules/linkvalidity/alloc_test.go
+++ b/internal/rules/linkvalidity/alloc_test.go
@@ -9,10 +9,15 @@ import (
 // submatch-index slice) already gives the exact upper bound on match
 // count before the result loop starts, so out's final size is knowable
 // up front — see docs/development/high-performance-go.md "Pre-size
-// slices." Baseline measured 6; +4 headroom follows the project's
-// "baseline plus max(20%, 4)" convention so an unrelated +1 (regexp
-// internals, GOARCH) doesn't turn CI red.
-const allocBudgetReversedInLine = 10
+// slices." Baseline measured 6. The project's usual "baseline plus
+// max(20%, 4)" headroom (from internal/integration/perrule_bench_test.go,
+// which governs whole-rule Check ceilings with 20+ alloc baselines) does
+// NOT transfer here: this gate's entire regression signal is the +2
+// allocs an unpresized nil-append pays growing 1→2→4 elements, which a
+// flat +4 headroom fully absorbs — verified by reverting the presize fix
+// and confirming the gate stayed green at the wider budget. +1 keeps the
+// gate meaningful while still tolerating one incidental alloc.
+const allocBudgetReversedInLine = 7
 
 // reversedInLineMultiMatchFixture has four reversed-link matches on one
 // line, so an unpresized `out` (starting nil, doubling via append) pays
@@ -54,13 +59,15 @@ var reversedInLineAllFilteredFixture = []byte(
 
 // allocBudgetReversedInLineAllFiltered is the per-call ceiling on
 // reversedInLineAllFilteredFixture: only reversedRe's own match-finding
-// cost (no result slice, since every candidate is filtered). Measured
-// 2; +4 headroom per the project's "baseline plus max(20%, 4)"
-// convention. A version that presizes `out` unconditionally before the
-// guard loop pays one extra allocation for a slice it then discards —
-// this budget catches that regression on top of the nilness check
-// below.
-const allocBudgetReversedInLineAllFiltered = 6
+// cost (no result slice, since every candidate is filtered). Measured 2.
+// Kept tight (+1, not the usual "baseline plus max(20%, 4)" — see
+// allocBudgetReversedInLine's comment on why that convention doesn't
+// transfer to a micro-gate): a version that presizes `out`
+// unconditionally before the guard loop pays exactly one extra
+// allocation for a slice it then discards, and a +4 headroom would
+// absorb that regression entirely. This budget catches it on top of the
+// nilness check below.
+const allocBudgetReversedInLineAllFiltered = 3
 
 // TestReversedInLineAllFilteredReturnsNil pins both the nilness and the
 // zero-extra-alloc property of the all-matches-filtered path. A version

--- a/internal/rules/linkvalidity/alloc_test.go
+++ b/internal/rules/linkvalidity/alloc_test.go
@@ -52,6 +52,16 @@ var reversedInLineAllFilteredFixture = []byte(
 	"see [text](https://example.com)[^1] for more",
 )
 
+// allocBudgetReversedInLineAllFiltered is the per-call ceiling on
+// reversedInLineAllFilteredFixture: only reversedRe's own match-finding
+// cost (no result slice, since every candidate is filtered). Measured
+// 2; +4 headroom per the project's "baseline plus max(20%, 4)"
+// convention. A version that presizes `out` unconditionally before the
+// guard loop pays one extra allocation for a slice it then discards —
+// this budget catches that regression on top of the nilness check
+// below.
+const allocBudgetReversedInLineAllFiltered = 6
+
 // TestReversedInLineAllFilteredReturnsNil pins both the nilness and the
 // zero-extra-alloc property of the all-matches-filtered path. A version
 // that presizes `out` unconditionally before the guard loop allocates a
@@ -71,17 +81,15 @@ func TestReversedInLineAllFilteredReturnsNil(t *testing.T) {
 		t.Skip("alloc gate skipped under -race")
 	}
 	_ = reversedInLine(line, line) // warm up regex program cache
-	withGuardedMatch := testing.AllocsPerRun(200, func() {
+	allocs := testing.AllocsPerRun(200, func() {
 		_ = reversedInLine(line, line)
 	})
-	noMatch := testing.AllocsPerRun(200, func() {
-		_ = reversedInLine([]byte("no parens here at all"), []byte("no parens here at all"))
-	})
-	t.Logf("reversedInLine allocs/op: all-filtered=%.0f, no-candidate=%.0f", withGuardedMatch, noMatch)
-	if withGuardedMatch > noMatch {
-		t.Fatalf("reversedInLine allocs/op on an all-filtered line (%.0f) exceeds a line with no "+
-			"parenthesis candidate at all (%.0f): out must be allocated lazily on the first "+
-			"surviving match, not unconditionally before the guard loop",
-			withGuardedMatch, noMatch)
+	t.Logf("reversedInLine allocs/op (all-filtered) = %.0f (budget = %d)",
+		allocs, allocBudgetReversedInLineAllFiltered)
+	if allocs > float64(allocBudgetReversedInLineAllFiltered) {
+		t.Fatalf("reversedInLine allocs/op on an all-filtered line = %.0f, budget = %d: out must "+
+			"be allocated lazily on the first surviving match, not unconditionally before the "+
+			"guard loop",
+			allocs, allocBudgetReversedInLineAllFiltered)
 	}
 }

--- a/internal/rules/linkvalidity/race_off_test.go
+++ b/internal/rules/linkvalidity/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package linkvalidity
+
+const raceEnabled = false

--- a/internal/rules/linkvalidity/race_on_test.go
+++ b/internal/rules/linkvalidity/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package linkvalidity
+
+const raceEnabled = true

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -299,9 +299,14 @@ func reversedInLine(orig, masked []byte) []revMatch {
 	if idx == nil {
 		return nil
 	}
-	// idx already gives the exact match count, so out's upper bound is
-	// known before the loop starts.
-	out := make([]revMatch, 0, len(idx))
+	// idx already gives the exact upper bound on match count, but every
+	// entry can still be dropped by the guards below (e.g. an ordinary
+	// [text](url)[ref] — a link immediately followed by a reference or
+	// footnote). Allocate lazily on the first survivor so an all-filtered
+	// line costs nothing extra and returns nil, not a discarded non-nil
+	// empty slice — see docs/development/high-performance-go.md
+	// "Return nil, not []T{}."
+	var out []revMatch
 	for _, m := range idx {
 		s, e := m[0], m[1]
 		if s > 0 && orig[s-1] == '\\' {
@@ -312,6 +317,9 @@ func reversedInLine(orig, masked []byte) []revMatch {
 		}
 		if e < len(orig) && orig[e] == '(' {
 			continue // [text](url) — a normal link, not reversed
+		}
+		if out == nil {
+			out = make([]revMatch, 0, len(idx))
 		}
 		out = append(out, revMatch{
 			col0:     s,

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -299,7 +299,9 @@ func reversedInLine(orig, masked []byte) []revMatch {
 	if idx == nil {
 		return nil
 	}
-	var out []revMatch
+	// idx already gives the exact match count, so out's upper bound is
+	// known before the loop starts.
+	out := make([]revMatch, 0, len(idx))
 	for _, m := range idx {
 		s, e := m[0], m[1]
 		if s > 0 && orig[s-1] == '\\' {

--- a/internal/rules/markdownflavor/alloc_test.go
+++ b/internal/rules/markdownflavor/alloc_test.go
@@ -1,0 +1,58 @@
+package markdownflavor
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// allocBudgetFixGitHubAlerts is the per-call ceiling for fixGitHubAlerts
+// itself (called directly, not through Fix, which always re-parses the
+// stripped result afterward — a legitimate, unrelated allocation this
+// budget must not have to absorb) on a file whose alert blockquote spans
+// many lines. fixGitHubAlerts used to build its result line-by-line in
+// an unpresized []string (only the marker line is skipped, so the final
+// size is knowable up front — see docs/development/high-performance-go.md
+// "Pre-size slices") joined via strings.Join (one string() copy per
+// line plus the join), and buildAlertSkipMaps converted every
+// continuation line to a string just to test its first byte. Both are
+// now byte-native.
+const allocBudgetFixGitHubAlerts = 4
+
+// fixGitHubAlertsFixture is a single alert blockquote with many content
+// lines, so both the unpresized `out` slice and the per-line string()
+// conversion in buildAlertSkipMaps would have scaled with line count.
+func fixGitHubAlertsFixture(lines int) string {
+	var b strings.Builder
+	b.WriteString("> [!NOTE]\n")
+	for i := 0; i < lines; i++ {
+		b.WriteString("> content line " + strconv.Itoa(i) + "\n")
+	}
+	return b.String()
+}
+
+// TestFixGitHubAlertsAllocBudget pins fixGitHubAlerts' own per-call
+// allocation count on a many-line alert blockquote, calling it directly
+// so Fix's unrelated re-parse pass does not swamp the measurement.
+func TestFixGitHubAlertsAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	src := fixGitHubAlertsFixture(63)
+	r := &Rule{}
+
+	f := mkFile(t, src)
+	_ = r.fixGitHubAlerts(f) // warm up any cached state
+
+	const runs = 50
+	allocs := testing.AllocsPerRun(runs, func() {
+		_ = r.fixGitHubAlerts(f)
+	})
+	t.Logf("fixGitHubAlerts allocs/op = %.0f (budget = %d)", allocs, allocBudgetFixGitHubAlerts)
+	if allocs > float64(allocBudgetFixGitHubAlerts) {
+		t.Fatalf("fixGitHubAlerts allocs/op = %.0f, budget = %d: the per-line result must be "+
+			"built via a presized buffer, not an unpresized []string + strings.Join, and the "+
+			"continuation-line scan in buildAlertSkipMaps must not copy each line to a string",
+			allocs, allocBudgetFixGitHubAlerts)
+	}
+}

--- a/internal/rules/markdownflavor/alloc_test.go
+++ b/internal/rules/markdownflavor/alloc_test.go
@@ -24,6 +24,13 @@ import (
 // +1 doesn't turn CI red.
 const allocBudgetFixGitHubAlerts = 14
 
+// fixGitHubAlertsFixtureLinePadding pads each fixture line's content
+// past 32 bytes: Go's compiler keeps a short, non-escaping string(b)
+// conversion on the stack (no allocation), so a fixture with short
+// lines cannot tell an unfixed strings.TrimLeft(string(line), …) apart
+// from the byte-native bytes.TrimLeft this gate exists to lock in.
+const fixGitHubAlertsFixtureLinePadding = "with enough padding text to exceed the stack-conversion threshold "
+
 // fixGitHubAlertsFixture is a single alert blockquote with many content
 // lines, so both the unpresized `out` slice and the per-line string()
 // conversion in buildAlertSkipMaps would have scaled with line count.
@@ -31,13 +38,14 @@ const allocBudgetFixGitHubAlerts = 14
 // fixture also exercises fixGitHubAlerts' addPrefix rewrite branch
 // instead of only the pass-through branch.
 func fixGitHubAlertsFixture(lines int) string {
+	const padding = fixGitHubAlertsFixtureLinePadding
 	var b strings.Builder
 	b.WriteString("> [!NOTE]\n")
 	for i := 0; i < lines; i++ {
 		if i%4 == 3 {
-			b.WriteString("content line " + strconv.Itoa(i) + "\n")
+			b.WriteString("content line " + padding + strconv.Itoa(i) + "\n")
 		} else {
-			b.WriteString("> content line " + strconv.Itoa(i) + "\n")
+			b.WriteString("> content line " + padding + strconv.Itoa(i) + "\n")
 		}
 	}
 	return b.String()
@@ -58,7 +66,8 @@ func TestFixGitHubAlertsAllocBudget(t *testing.T) {
 
 	f := mkFile(t, src)
 	got := r.fixGitHubAlerts(f) // warm up any cached state
-	if !strings.Contains(string(got), "> content line 3\n") {
+	wantPrefixed := "> content line " + fixGitHubAlertsFixtureLinePadding + "3\n"
+	if !strings.Contains(string(got), wantPrefixed) {
 		t.Fatalf("fixGitHubAlerts did not re-add the \"> \" prefix on a lazy-continuation line:\n%s", got)
 	}
 

--- a/internal/rules/markdownflavor/alloc_test.go
+++ b/internal/rules/markdownflavor/alloc_test.go
@@ -17,11 +17,13 @@ import (
 // line plus the join), and buildAlertSkipMaps converted every
 // continuation line to a string just to test its first byte. Both are
 // now byte-native. Baseline measured 10 on this mixed prefixed/lazy-
-// continuation fixture (the buf.Grow estimate under-shoots once
-// addPrefix lines are present, so one re-grow is expected — see the
-// comment on the buf.Grow call in fixGitHubAlerts); +4 headroom follows
-// the project's "baseline plus max(20%, 4)" convention so an unrelated
-// +1 doesn't turn CI red.
+// continuation fixture (bytes.Buffer.Grow rounds up to a size class
+// that already absorbs this fixture's addPrefix overrun, so no re-grow
+// actually occurs here — see the comment on the buf.Grow call in
+// fixGitHubAlerts for the general case, which can re-grow on a fixture
+// with more addPrefix lines relative to len(f.Source)); +4 headroom
+// follows the project's "baseline plus max(20%, 4)" convention so an
+// unrelated +1 doesn't turn CI red.
 const allocBudgetFixGitHubAlerts = 14
 
 // fixGitHubAlertsFixtureLinePadding pads each fixture line's content

--- a/internal/rules/markdownflavor/alloc_test.go
+++ b/internal/rules/markdownflavor/alloc_test.go
@@ -16,17 +16,29 @@ import (
 // "Pre-size slices") joined via strings.Join (one string() copy per
 // line plus the join), and buildAlertSkipMaps converted every
 // continuation line to a string just to test its first byte. Both are
-// now byte-native.
-const allocBudgetFixGitHubAlerts = 4
+// now byte-native. Baseline measured 10 on this mixed prefixed/lazy-
+// continuation fixture (the buf.Grow estimate under-shoots once
+// addPrefix lines are present, so one re-grow is expected — see the
+// comment on the buf.Grow call in fixGitHubAlerts); +4 headroom follows
+// the project's "baseline plus max(20%, 4)" convention so an unrelated
+// +1 doesn't turn CI red.
+const allocBudgetFixGitHubAlerts = 14
 
 // fixGitHubAlertsFixture is a single alert blockquote with many content
 // lines, so both the unpresized `out` slice and the per-line string()
 // conversion in buildAlertSkipMaps would have scaled with line count.
+// Every fourth line drops the "> " prefix (a lazy continuation), so the
+// fixture also exercises fixGitHubAlerts' addPrefix rewrite branch
+// instead of only the pass-through branch.
 func fixGitHubAlertsFixture(lines int) string {
 	var b strings.Builder
 	b.WriteString("> [!NOTE]\n")
 	for i := 0; i < lines; i++ {
-		b.WriteString("> content line " + strconv.Itoa(i) + "\n")
+		if i%4 == 3 {
+			b.WriteString("content line " + strconv.Itoa(i) + "\n")
+		} else {
+			b.WriteString("> content line " + strconv.Itoa(i) + "\n")
+		}
 	}
 	return b.String()
 }
@@ -38,11 +50,17 @@ func TestFixGitHubAlertsAllocBudget(t *testing.T) {
 	if testing.Short() {
 		t.Skip("alloc gate skipped in -short mode")
 	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
 	src := fixGitHubAlertsFixture(63)
 	r := &Rule{}
 
 	f := mkFile(t, src)
-	_ = r.fixGitHubAlerts(f) // warm up any cached state
+	got := r.fixGitHubAlerts(f) // warm up any cached state
+	if !strings.Contains(string(got), "> content line 3\n") {
+		t.Fatalf("fixGitHubAlerts did not re-add the \"> \" prefix on a lazy-continuation line:\n%s", got)
+	}
 
 	const runs = 50
 	allocs := testing.AllocsPerRun(runs, func() {

--- a/internal/rules/markdownflavor/bench_test.go
+++ b/internal/rules/markdownflavor/bench_test.go
@@ -7,13 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BenchmarkBuildAlertSkipMaps guards buildAlertSkipMaps' continuation-
-// line scan against reverting to a per-line O(offset) line lookup.
-// f.LineOfOffset is a binary search over f's cached newline index;
-// flavor.LineCol, used here before, rescans source[:offset] with
-// bytes.Count/LastIndexByte on every call, which made this loop
-// O(n) per continuation line (O(n^2) over a long alert paragraph).
-// Compare before/after with benchstat on a change to this function.
+// BenchmarkBuildAlertSkipMaps is a manual regression-detection tool for
+// buildAlertSkipMaps' continuation-line scan, not a CI-enforced gate:
+// MDS034 is opt-in, so no CI benchmark job runs this package, and the
+// metric here (ns/op) is too environment-sensitive for a hard b.Fatalf
+// budget the way the allocs-based gates in alloc_test.go are. Run it
+// manually with `-bench` and compare via benchstat before/after a
+// change to this function — f.LineOfOffset is a binary search over f's
+// cached newline index; flavor.LineCol, used here before, rescans
+// source[:offset] with bytes.Count/LastIndexByte on every call, which
+// made this loop O(n) per continuation line (O(n^2) over a long alert
+// paragraph). See the commit that introduced this benchmark for a
+// recorded benchstat comparison.
 func BenchmarkBuildAlertSkipMaps(b *testing.B) {
 	src := []byte(fixGitHubAlertsFixture(500))
 	f, err := lint.NewFile("bench.md", src)

--- a/internal/rules/markdownflavor/bench_test.go
+++ b/internal/rules/markdownflavor/bench_test.go
@@ -1,0 +1,26 @@
+package markdownflavor
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkBuildAlertSkipMaps guards buildAlertSkipMaps' continuation-
+// line scan against reverting to a per-line O(offset) line lookup.
+// f.LineOfOffset is a binary search over f's cached newline index;
+// flavor.LineCol, used here before, rescans source[:offset] with
+// bytes.Count/LastIndexByte on every call, which made this loop
+// O(n) per continuation line (O(n^2) over a long alert paragraph).
+// Compare before/after with benchstat on a change to this function.
+func BenchmarkBuildAlertSkipMaps(b *testing.B) {
+	src := []byte(fixGitHubAlertsFixture(500))
+	f, err := lint.NewFile("bench.md", src)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = buildAlertSkipMaps(f)
+	}
+}

--- a/internal/rules/markdownflavor/race_off_test.go
+++ b/internal/rules/markdownflavor/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package markdownflavor
+
+const raceEnabled = false

--- a/internal/rules/markdownflavor/race_on_test.go
+++ b/internal/rules/markdownflavor/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package markdownflavor
+
+const raceEnabled = true

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -260,7 +260,14 @@ func buildAlertSkipMaps(f *lint.File) (skip, addPrefix map[int]struct{}) {
 		para := bq.FirstChild().(*ast.Paragraph)
 		lines := para.Lines()
 		seg := lines.At(0)
-		markerLine, _ := flavor.LineCol(f.Source, seg.Start)
+		// f.LineOfOffset is f's memoized, binary-search line index —
+		// flavor.LineCol recomputes with a fresh bytes.Count/LastIndexByte
+		// scan of source[:offset] on every call, so calling it once per
+		// continuation line below made this loop O(n) per line (O(n^2)
+		// over a long alert paragraph) instead of O(log n). Both share the
+		// same "newlines strictly before offset" line-1 contract, so the
+		// swap is exact, not approximate.
+		markerLine := f.LineOfOffset(seg.Start)
 		skip[markerLine] = struct{}{}
 
 		// Remaining lines of the first paragraph may use lazy continuation
@@ -268,7 +275,7 @@ func buildAlertSkipMaps(f *lint.File) (skip, addPrefix map[int]struct{}) {
 		// would no longer be inside a blockquote, so re-add the prefix.
 		for i := 1; i < lines.Len(); i++ {
 			contSeg := lines.At(i)
-			contLine, _ := flavor.LineCol(f.Source, contSeg.Start)
+			contLine := f.LineOfOffset(contSeg.Start)
 			// bytes.TrimLeft + a first-byte check replace the earlier
 			// strings.TrimLeft(string(...), ...) + strings.HasPrefix,
 			// which copied every paragraph line in this loop just to

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
 
@@ -270,8 +269,12 @@ func buildAlertSkipMaps(f *lint.File) (skip, addPrefix map[int]struct{}) {
 		for i := 1; i < lines.Len(); i++ {
 			contSeg := lines.At(i)
 			contLine, _ := flavor.LineCol(f.Source, contSeg.Start)
-			raw := strings.TrimLeft(string(f.Lines[contLine-1]), " \t")
-			if !strings.HasPrefix(raw, ">") {
+			// bytes.TrimLeft + a first-byte check replace the earlier
+			// strings.TrimLeft(string(...), ...) + strings.HasPrefix,
+			// which copied every paragraph line in this loop just to
+			// test its first non-blank byte.
+			raw := bytes.TrimLeft(f.Lines[contLine-1], " \t")
+			if len(raw) == 0 || raw[0] != '>' {
 				addPrefix[contLine] = struct{}{}
 			}
 		}
@@ -291,20 +294,33 @@ func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 		return f.Source
 	}
 
-	var out []string
+	// A single buffer grown to len(f.Source) — the removed marker lines
+	// make this an overestimate, never a re-grow — replaces the earlier
+	// []string+strings.Join, which cost one string() copy per surviving
+	// line plus the join's own allocation. Mirrors blockquotewhitespace's
+	// Fix, the sibling rule that already made this switch.
+	var buf bytes.Buffer
+	buf.Grow(len(f.Source))
+	wroteLine := false
 	for i, line := range f.Lines {
 		lineNum := i + 1
 		if _, ok := skip[lineNum]; ok {
 			continue
 		}
-		s := string(line)
-		if _, ok := addPrefix[lineNum]; ok {
-			trimmed := strings.TrimLeft(s, " \t")
-			s = s[:len(s)-len(trimmed)] + "> " + trimmed
+		if wroteLine {
+			buf.WriteByte('\n')
 		}
-		out = append(out, s)
+		wroteLine = true
+		if _, ok := addPrefix[lineNum]; ok {
+			trimmed := bytes.TrimLeft(line, " \t")
+			buf.Write(line[:len(line)-len(trimmed)])
+			buf.WriteString("> ")
+			buf.Write(trimmed)
+		} else {
+			buf.Write(line)
+		}
 	}
-	return []byte(strings.Join(out, "\n"))
+	return buf.Bytes()
 }
 
 var (

--- a/internal/rules/markdownflavor/rule.go
+++ b/internal/rules/markdownflavor/rule.go
@@ -301,11 +301,13 @@ func (r *Rule) fixGitHubAlerts(f *lint.File) []byte {
 		return f.Source
 	}
 
-	// A single buffer grown to len(f.Source) — the removed marker lines
-	// make this an overestimate, never a re-grow — replaces the earlier
-	// []string+strings.Join, which cost one string() copy per surviving
-	// line plus the join's own allocation. Mirrors blockquotewhitespace's
-	// Fix, the sibling rule that already made this switch.
+	// A single buffer grown to len(f.Source) — usually an overestimate
+	// since marker lines are dropped, though a heavily lazy-continuation
+	// alert (many 2-byte "> " insertions from addPrefix) can still make
+	// buf re-grow once — replaces the earlier []string+strings.Join,
+	// which cost one string() copy per surviving line plus the join's
+	// own allocation. Mirrors blockquotewhitespace's Fix, the sibling
+	// rule that already made this switch.
 	var buf bytes.Buffer
 	buf.Grow(len(f.Source))
 	wroteLine := false

--- a/internal/rules/noundefinedreferencelabels/alloc_test.go
+++ b/internal/rules/noundefinedreferencelabels/alloc_test.go
@@ -11,9 +11,11 @@ import (
 // Plan 195 task 7 landed: collectNormalisedDefs returns a sized
 // []string instead of a map, labelDefined linear-scans it, the
 // no-bracket early-exit short-circuits prose files, and the
-// `len(r.Placeholders) > 0 &&` guard avoids the per-match
-// `string(label)` cast when no placeholder vocabulary is
-// configured (the default).
+// `len(r.Placeholders) > 0 &&` guard skips the ContainsBodyToken call
+// (and, since this PR, the zero-copy util.BytesToReadOnlyString view it
+// takes its argument through) when no placeholder vocabulary is
+// configured (the default) — see allocBudgetMDS054PlaceholdersMarginal
+// below for the placeholders-configured case this budget does not cover.
 const allocBudgetMDS054 = 10
 
 // allocBudgetFixture mirrors the integration alloc-budget fixture

--- a/internal/rules/noundefinedreferencelabels/alloc_test.go
+++ b/internal/rules/noundefinedreferencelabels/alloc_test.go
@@ -40,6 +40,99 @@ const allocBudgetFixture = "# Document title\n" +
 	"\n" +
 	"[ref]: https://example.com/\n"
 
+// allocBudgetMDS054PlaceholdersMarginal is the ceiling on how many more
+// allocations enabling a `placeholders:` vocabulary may add on top of
+// the same fixture's no-placeholder Check cost — isolating the
+// per-bracket-candidate placeholder check in scanFullRefs,
+// scanCollapsedRefs, and scanShortcutRefs from the fixture's other,
+// reference-count-proportional costs (normalizeLabel etc.), which scale
+// with either code path and would otherwise swamp the comparison. The
+// check reads label/text as a zero-copy string view (unsafe.String over
+// the f.Source sub-slice, per docs/development/high-performance-go.md)
+// instead of allocating a copy with string() for every candidate, so
+// the marginal cost of turning placeholders on stays ~0.
+const allocBudgetMDS054PlaceholdersMarginal = 1
+
+// allocBudgetPlaceholderFixture has five full reference-style links so
+// the per-match placeholder check (gated by len(r.Placeholders) > 0)
+// runs five times per Check, making a per-match string() allocation in
+// that path show up clearly against the budget.
+// Reference labels are multiple bytes long (not the single-char "a"
+// style) so a string() copy of the label actually allocates — Go's
+// runtime returns a static, non-allocating string for a one-byte
+// string(b) conversion, which would mask the very allocation this test
+// exists to catch.
+const allocBudgetPlaceholderFixture = "# Document title\n" +
+	"\n" +
+	"See [alpha][alpha-ref], [beta][beta-ref], [gamma][gamma-ref], " +
+	"[delta][delta-ref], and [epsilon][epsilon-ref] for examples.\n" +
+	"\n" +
+	"[alpha-ref]: https://example.com/a\n" +
+	"[beta-ref]: https://example.com/b\n" +
+	"[gamma-ref]: https://example.com/c\n" +
+	"[delta-ref]: https://example.com/d\n" +
+	"[epsilon-ref]: https://example.com/e\n"
+
+// checkAllocsPerOpOn is checkAllocsPerOp against an arbitrary source
+// rather than the fixed allocBudgetFixture, reusing the same
+// warm/parse/Check-delta measurement.
+func checkAllocsPerOpOn(tb testing.TB, r *Rule, src []byte) float64 {
+	tb.Helper()
+	warm, err := lint.NewFile("warm.md", src)
+	require.NoError(tb, err)
+	_ = r.Check(warm)
+	const runs = 100
+	parse := testing.AllocsPerRun(runs, func() {
+		_, err := lint.NewFile("parse.md", src)
+		require.NoError(tb, err)
+	})
+	full := testing.AllocsPerRun(runs, func() {
+		f, err := lint.NewFile("check.md", src)
+		require.NoError(tb, err)
+		_ = r.Check(f)
+	})
+	delta := full - parse
+	if delta < 0 {
+		delta = 0
+	}
+	return delta
+}
+
+// TestCheckAllocBudgetWithPlaceholders pins how many additional
+// allocations turning on a `placeholders:` vocabulary may cost, over
+// the same fixture's no-placeholder Check. Before this budget was met,
+// each of the fixture's five bracket candidates cost an extra string()
+// copy in the ContainsBodyToken call regardless of which token was
+// configured.
+func TestCheckAllocBudgetWithPlaceholders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	src := []byte(allocBudgetPlaceholderFixture)
+
+	// heading-question's check (strings.TrimSpace(text) == "?") does not
+	// itself allocate on a no-match input, unlike var-token's fieldinterp
+	// path (a regexp scan with its own allocation cost) — isolating the
+	// per-candidate string() copy this test targets from that unrelated
+	// cost.
+	without := checkAllocsPerOpOn(t, &Rule{}, src)
+	with := checkAllocsPerOpOn(t, &Rule{Placeholders: []string{"heading-question"}}, src)
+	marginal := with - without
+	if marginal < 0 {
+		marginal = 0
+	}
+	t.Logf("MDS054 Check allocs/op: without placeholders=%.0f, with=%.0f, marginal=%.0f (budget = %d)",
+		without, with, marginal, allocBudgetMDS054PlaceholdersMarginal)
+	require.LessOrEqualf(t, marginal, float64(allocBudgetMDS054PlaceholdersMarginal),
+		"MDS054 Check allocs/op: enabling placeholders costs %.0f more allocs than the same "+
+			"fixture without them (budget = %d): the per-bracket-candidate placeholder check "+
+			"must not allocate a string() copy of label/text on every candidate",
+		marginal, allocBudgetMDS054PlaceholdersMarginal)
+}
+
 func checkAllocsPerOp(tb testing.TB, r *Rule) float64 {
 	tb.Helper()
 	src := []byte(allocBudgetFixture)

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -9,22 +9,12 @@ import (
 	"sync"
 	"unicode"
 	"unicode/utf8"
-	"unsafe"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/pkg/goldmark/util"
 )
-
-// bytesToString returns a zero-copy string view of b, avoiding the
-// allocating copy string(b) would make. Safe here: every caller passes
-// a sub-slice of f.Source, which Check treats as read-only for the
-// duration of the call and which outlives it — the invariant
-// unsafe.String requires (see docs/development/high-performance-go.md).
-func bytesToString(b []byte) string {
-	return unsafe.String(unsafe.SliceData(b), len(b))
-}
 
 func init() {
 	rule.Register(&Rule{})
@@ -324,7 +314,8 @@ func (r *Rule) scanFullRefs(
 			continue
 		}
 		label := source[cs2:ce2]
-		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(bytesToString(label), r.Placeholders) {
+		if len(r.Placeholders) > 0 &&
+			placeholders.ContainsBodyToken(util.BytesToReadOnlyString(label), r.Placeholders) {
 			i = advanceBracket(brs, i, ca2)
 			continue
 		}
@@ -378,7 +369,7 @@ func (r *Rule) scanCollapsedRefs(
 			i = advanceBracket(brs, i+1, ca+2)
 			continue
 		}
-		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(bytesToString(text), r.Placeholders) {
+		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(util.BytesToReadOnlyString(text), r.Placeholders) {
 			i = advanceBracket(brs, i+1, ca+2)
 			continue
 		}
@@ -450,7 +441,8 @@ func (r *Rule) scanShortcutRefs(
 			i = advanceBracket(brs, i+1, ca)
 			continue
 		}
-		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(bytesToString(label), r.Placeholders) {
+		if len(r.Placeholders) > 0 &&
+			placeholders.ContainsBodyToken(util.BytesToReadOnlyString(label), r.Placeholders) {
 			i = advanceBracket(brs, i+1, ca)
 			continue
 		}

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -9,12 +9,22 @@ import (
 	"sync"
 	"unicode"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/placeholders"
 	"github.com/jeduden/mdsmith/internal/rule"
 	"github.com/jeduden/mdsmith/pkg/goldmark/util"
 )
+
+// bytesToString returns a zero-copy string view of b, avoiding the
+// allocating copy string(b) would make. Safe here: every caller passes
+// a sub-slice of f.Source, which Check treats as read-only for the
+// duration of the call and which outlives it — the invariant
+// unsafe.String requires (see docs/development/high-performance-go.md).
+func bytesToString(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
 
 func init() {
 	rule.Register(&Rule{})
@@ -314,7 +324,7 @@ func (r *Rule) scanFullRefs(
 			continue
 		}
 		label := source[cs2:ce2]
-		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(string(label), r.Placeholders) {
+		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(bytesToString(label), r.Placeholders) {
 			i = advanceBracket(brs, i, ca2)
 			continue
 		}
@@ -368,7 +378,7 @@ func (r *Rule) scanCollapsedRefs(
 			i = advanceBracket(brs, i+1, ca+2)
 			continue
 		}
-		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(string(text), r.Placeholders) {
+		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(bytesToString(text), r.Placeholders) {
 			i = advanceBracket(brs, i+1, ca+2)
 			continue
 		}
@@ -440,7 +450,7 @@ func (r *Rule) scanShortcutRefs(
 			i = advanceBracket(brs, i+1, ca)
 			continue
 		}
-		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(string(label), r.Placeholders) {
+		if len(r.Placeholders) > 0 && placeholders.ContainsBodyToken(bytesToString(label), r.Placeholders) {
 			i = advanceBracket(brs, i+1, ca)
 			continue
 		}

--- a/pkg/mdsmith/overlay.go
+++ b/pkg/mdsmith/overlay.go
@@ -2,7 +2,6 @@ package mdsmith
 
 import (
 	"bytes"
-	"fmt"
 	"io/fs"
 	"math"
 	"os"
@@ -88,7 +87,7 @@ func (w *OverlayWorkspace) readFileLimited(p string, max int64) ([]byte, error) 
 	w.mu.RUnlock()
 	if ok {
 		if max > 0 && max != math.MaxInt64 && int64(len(data)) > max {
-			return nil, fmt.Errorf("file too large (%d bytes, max %d)", len(data), max)
+			return nil, bytelimit.FileTooLargeError(int64(len(data)), max)
 		}
 		return bytes.Clone(data), nil
 	}

--- a/pkg/mdsmith/overlay.go
+++ b/pkg/mdsmith/overlay.go
@@ -2,7 +2,9 @@ package mdsmith
 
 import (
 	"bytes"
+	"fmt"
 	"io/fs"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 	"github.com/jeduden/mdsmith/internal/lint"
 )
 
@@ -68,6 +71,31 @@ func (w *OverlayWorkspace) ReadFile(p string) ([]byte, error) {
 		return os.ReadFile(p) //nolint:gosec // path is caller-controlled; this is the native disk seam
 	}
 	return fs.ReadFile(w.ensureDiskFS(), key)
+}
+
+// readFileLimited is ReadFile's bounded counterpart: an overlaid buffer
+// over max is rejected with a "file too large" error (the buffer is
+// already resident — Set copies open-editor bytes the LSP already
+// holds — so this is a size-cap check, not a read reduction), and the
+// disk fall-through is capped via bytelimit so an oversized on-disk file
+// is never fully read into memory. frontMatterFor uses this so
+// resolving a file's kind never pulls an arbitrarily large document
+// fully resident just to read its leading front-matter block.
+func (w *OverlayWorkspace) readFileLimited(p string, max int64) ([]byte, error) {
+	key := cleanKey(p)
+	w.mu.RLock()
+	data, ok := w.overlay[key]
+	w.mu.RUnlock()
+	if ok {
+		if max > 0 && max != math.MaxInt64 && int64(len(data)) > max {
+			return nil, fmt.Errorf("file too large (%d bytes, max %d)", len(data), max)
+		}
+		return bytes.Clone(data), nil
+	}
+	if w.root == "" || filepath.IsAbs(p) {
+		return bytelimit.ReadFileLimited(p, max)
+	}
+	return bytelimit.ReadFSFileLimited(w.ensureDiskFS(), key, max)
 }
 
 // Glob expands a doublestar pattern against the on-disk tree rooted at

--- a/pkg/mdsmith/overlay_test.go
+++ b/pkg/mdsmith/overlay_test.go
@@ -422,3 +422,53 @@ func TestSessionOverlayBufferReachesCrossFileRule(t *testing.T) {
 		t.Fatalf("Fix 2: open-buffer summary did not reach the catalog rule:\n%s", res2.Source)
 	}
 }
+
+// TestOverlayWorkspaceReadFileLimitedOverlayHit verifies readFileLimited
+// applies the same cap to an overlaid buffer as it does to a disk read,
+// and returns the buffer bytes unchanged when under the cap.
+func TestOverlayWorkspaceReadFileLimitedOverlayHit(t *testing.T) {
+	ws := NewOverlayWorkspace(t.TempDir())
+	ws.Set("a.md", []byte("buffer-a"))
+
+	got, err := ws.readFileLimited("a.md", 100)
+	if err != nil {
+		t.Fatalf("readFileLimited within limit: %v", err)
+	}
+	if string(got) != "buffer-a" {
+		t.Fatalf("readFileLimited = %q, want %q", got, "buffer-a")
+	}
+
+	if _, err := ws.readFileLimited("a.md", 3); err == nil {
+		t.Fatal("readFileLimited over limit on overlaid buffer: want error, got nil")
+	} else if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("readFileLimited over limit: got err %q, want it to mention 'file too large'", err)
+	}
+}
+
+// TestOverlayWorkspaceReadFileLimitedDiskFallthrough verifies
+// readFileLimited rejects an oversized on-disk file (the non-overlaid
+// fall-through path) instead of reading it fully into memory.
+func TestOverlayWorkspaceReadFileLimitedDiskFallthrough(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "huge.md"), make([]byte, 100), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	ws := NewOverlayWorkspace(root)
+
+	if _, err := ws.readFileLimited("huge.md", 50); err == nil {
+		t.Fatal("readFileLimited over limit on disk fall-through: want error, got nil")
+	} else if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("readFileLimited over limit: got err %q, want it to mention 'file too large'", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "small.md"), []byte("ok"), 0o600); err != nil {
+		t.Fatalf("WriteFile small: %v", err)
+	}
+	got, err := ws.readFileLimited("small.md", 50)
+	if err != nil {
+		t.Fatalf("readFileLimited within limit: %v", err)
+	}
+	if string(got) != "ok" {
+		t.Fatalf("readFileLimited = %q, want %q", got, "ok")
+	}
+}

--- a/pkg/mdsmith/overlay_test.go
+++ b/pkg/mdsmith/overlay_test.go
@@ -1,6 +1,7 @@
 package mdsmith
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -8,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 )
 
 // TestOverlayWorkspaceReadFilePrefersOverlay verifies an
@@ -440,8 +443,8 @@ func TestOverlayWorkspaceReadFileLimitedOverlayHit(t *testing.T) {
 
 	if _, err := ws.readFileLimited("a.md", 3); err == nil {
 		t.Fatal("readFileLimited over limit on overlaid buffer: want error, got nil")
-	} else if !strings.Contains(err.Error(), "file too large") {
-		t.Fatalf("readFileLimited over limit: got err %q, want it to mention 'file too large'", err)
+	} else if !errors.Is(err, bytelimit.ErrFileTooLarge) {
+		t.Fatalf("readFileLimited over limit: got err %v, want it to wrap bytelimit.ErrFileTooLarge", err)
 	}
 }
 
@@ -457,8 +460,8 @@ func TestOverlayWorkspaceReadFileLimitedDiskFallthrough(t *testing.T) {
 
 	if _, err := ws.readFileLimited("huge.md", 50); err == nil {
 		t.Fatal("readFileLimited over limit on disk fall-through: want error, got nil")
-	} else if !strings.Contains(err.Error(), "file too large") {
-		t.Fatalf("readFileLimited over limit: got err %q, want it to mention 'file too large'", err)
+	} else if !errors.Is(err, bytelimit.ErrFileTooLarge) {
+		t.Fatalf("readFileLimited over limit: got err %v, want it to wrap bytelimit.ErrFileTooLarge", err)
 	}
 
 	if err := os.WriteFile(filepath.Join(root, "small.md"), []byte("ok"), 0o600); err != nil {
@@ -496,7 +499,7 @@ func TestOverlayWorkspaceReadFileLimitedAbsolutePathIgnoresRoot(t *testing.T) {
 
 	if _, err := ws.readFileLimited(abs, 3); err == nil {
 		t.Fatal("readFileLimited(abs) over limit: want error, got nil")
-	} else if !strings.Contains(err.Error(), "file too large") {
-		t.Fatalf("readFileLimited(abs) over limit: got err %q, want it to mention 'file too large'", err)
+	} else if !errors.Is(err, bytelimit.ErrFileTooLarge) {
+		t.Fatalf("readFileLimited(abs) over limit: got err %v, want it to wrap bytelimit.ErrFileTooLarge", err)
 	}
 }

--- a/pkg/mdsmith/overlay_test.go
+++ b/pkg/mdsmith/overlay_test.go
@@ -472,3 +472,31 @@ func TestOverlayWorkspaceReadFileLimitedDiskFallthrough(t *testing.T) {
 		t.Fatalf("readFileLimited = %q, want %q", got, "ok")
 	}
 }
+
+// TestOverlayWorkspaceReadFileLimitedAbsolutePathIgnoresRoot verifies
+// readFileLimited's absolute-path branch: an absolute path bypasses the
+// rooted disk FS the same way ReadFile's does, even when Root is set,
+// and still enforces the size cap via bytelimit.ReadFileLimited.
+func TestOverlayWorkspaceReadFileLimitedAbsolutePathIgnoresRoot(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	abs := filepath.Join(other, "x.md")
+	if err := os.WriteFile(abs, []byte("absolute"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	ws := NewOverlayWorkspace(root)
+
+	got, err := ws.readFileLimited(abs, 50)
+	if err != nil {
+		t.Fatalf("readFileLimited(abs) within limit: %v", err)
+	}
+	if string(got) != "absolute" {
+		t.Fatalf("readFileLimited(abs) = %q, want %q", got, "absolute")
+	}
+
+	if _, err := ws.readFileLimited(abs, 3); err == nil {
+		t.Fatal("readFileLimited(abs) over limit: want error, got nil")
+	} else if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("readFileLimited(abs) over limit: got err %q, want it to mention 'file too large'", err)
+	}
+}

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -14,7 +14,6 @@ package mdsmith
 
 import (
 	"bytes"
-	"fmt"
 	"hash/fnv"
 	"math"
 	"path/filepath"
@@ -436,6 +435,16 @@ type boundedWorkspaceReader interface {
 	readFileLimited(path string, max int64) ([]byte, error)
 }
 
+// Pins that the two disk-backed Workspace implementations actually
+// satisfy boundedWorkspaceReader, so a future refactor that drops or
+// renames readFileLimited on either fails to compile here instead of
+// silently falling back to readBoundedFrontMatterSource's unbounded
+// ws.ReadFile path with no test failure to catch it.
+var (
+	_ boundedWorkspaceReader = OSWorkspace{}
+	_ boundedWorkspaceReader = (*OverlayWorkspace)(nil)
+)
+
 // readBoundedFrontMatterSource reads uri from ws, capped at max bytes.
 // It prefers ws's bounded read when available (avoiding a full read of
 // an oversized file); otherwise it falls back to a plain ReadFile
@@ -451,7 +460,7 @@ func readBoundedFrontMatterSource(ws Workspace, uri string, max int64) ([]byte, 
 		return nil, err
 	}
 	if max > 0 && max != math.MaxInt64 && int64(len(data)) > max {
-		return nil, fmt.Errorf("file too large (%d bytes, max %d)", len(data), max)
+		return nil, bytelimit.FileTooLargeError(int64(len(data)), max)
 	}
 	return data, nil
 }

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -400,7 +400,11 @@ func (s *Session) FixRule(uri string, source []byte, names []string) (FixResult,
 // uri, including per-leaf provenance. It reads the file's bytes through
 // the workspace to parse its front matter (the `kinds:` list and any
 // `fields-present:` selector inputs); a missing file resolves against
-// path-pattern and override globs alone.
+// path-pattern and override globs alone. A file over the session's
+// max-input-size resolves the same lenient way: the read is capped
+// (never fully loading an oversized file just to read its leading
+// front-matter block), and front-matter-derived kinds are silently
+// skipped rather than surfacing a size error.
 func (s *Session) Kinds(uri string) (KindResolution, error) {
 	fmKinds, fmFields, err := s.frontMatterFor(uri)
 	if err != nil {
@@ -424,13 +428,16 @@ func (s *Session) ResolveFile(uri string, fmKinds []string, fmFields map[string]
 	return config.ResolveFile(s.cfg, uri, fmKinds, fmFields)
 }
 
-// boundedWorkspaceReader is the optional Workspace capability that reads
-// a file capped at a byte limit without first loading an oversized file
-// fully into memory. OSWorkspace and OverlayWorkspace (the two disk-
-// backed implementations) implement it via bytelimit; frontMatterFor
-// uses it through readBoundedFrontMatterSource so resolving a file's
-// kind never pulls an arbitrarily large document fully resident just to
-// read its leading front-matter block.
+// boundedWorkspaceReader is the package-internal Workspace capability
+// that reads a file capped at a byte limit without first loading an
+// oversized file fully into memory. Its method is unexported, so only
+// the two disk-backed implementations declared in this package —
+// OSWorkspace and OverlayWorkspace, both via bytelimit — can satisfy
+// it; a host-supplied Workspace can never implement it and always
+// takes readBoundedFrontMatterSource's fallback path below.
+// frontMatterFor uses it through readBoundedFrontMatterSource so
+// resolving a file's kind never pulls an arbitrarily large document
+// fully resident just to read its leading front-matter block.
 type boundedWorkspaceReader interface {
 	readFileLimited(path string, max int64) ([]byte, error)
 }
@@ -449,8 +456,10 @@ var (
 // It prefers ws's bounded read when available (avoiding a full read of
 // an oversized file); otherwise it falls back to a plain ReadFile
 // followed by a size check, for any Workspace implementation that does
-// not opt into the bounded capability (e.g. a host-supplied one, or
-// MemWorkspace, whose bytes are already resident regardless).
+// not satisfy boundedWorkspaceReader (every host-supplied Workspace,
+// since the interface is unexported and unimplementable from outside
+// this package; also MemWorkspace, whose bytes are already resident
+// regardless).
 func readBoundedFrontMatterSource(ws Workspace, uri string, max int64) ([]byte, error) {
 	if br, ok := ws.(boundedWorkspaceReader); ok {
 		return br.readFileLimited(uri, max)

--- a/pkg/mdsmith/session.go
+++ b/pkg/mdsmith/session.go
@@ -14,7 +14,9 @@ package mdsmith
 
 import (
 	"bytes"
+	"fmt"
 	"hash/fnv"
+	"math"
 	"path/filepath"
 	"sync"
 
@@ -423,16 +425,51 @@ func (s *Session) ResolveFile(uri string, fmKinds []string, fmFields map[string]
 	return config.ResolveFile(s.cfg, uri, fmKinds, fmFields)
 }
 
+// boundedWorkspaceReader is the optional Workspace capability that reads
+// a file capped at a byte limit without first loading an oversized file
+// fully into memory. OSWorkspace and OverlayWorkspace (the two disk-
+// backed implementations) implement it via bytelimit; frontMatterFor
+// uses it through readBoundedFrontMatterSource so resolving a file's
+// kind never pulls an arbitrarily large document fully resident just to
+// read its leading front-matter block.
+type boundedWorkspaceReader interface {
+	readFileLimited(path string, max int64) ([]byte, error)
+}
+
+// readBoundedFrontMatterSource reads uri from ws, capped at max bytes.
+// It prefers ws's bounded read when available (avoiding a full read of
+// an oversized file); otherwise it falls back to a plain ReadFile
+// followed by a size check, for any Workspace implementation that does
+// not opt into the bounded capability (e.g. a host-supplied one, or
+// MemWorkspace, whose bytes are already resident regardless).
+func readBoundedFrontMatterSource(ws Workspace, uri string, max int64) ([]byte, error) {
+	if br, ok := ws.(boundedWorkspaceReader); ok {
+		return br.readFileLimited(uri, max)
+	}
+	data, err := ws.ReadFile(uri)
+	if err != nil {
+		return nil, err
+	}
+	if max > 0 && max != math.MaxInt64 && int64(len(data)) > max {
+		return nil, fmt.Errorf("file too large (%d bytes, max %d)", len(data), max)
+	}
+	return data, nil
+}
+
 // frontMatterFor reads uri through the workspace and parses its
 // front-matter kinds and fields. A workspace miss is not an error: the
 // file may be unsaved or new, so resolution proceeds with no
-// front-matter inputs.
+// front-matter inputs. A file over the session's max-input-size is
+// treated the same lenient way — see readBoundedFrontMatterSource,
+// which caps the read so an oversized file is never fully loaded just
+// to read its leading front-matter block.
 func (s *Session) frontMatterFor(uri string) ([]string, map[string]any, error) {
-	source, err := s.ws.ReadFile(uri)
+	source, err := readBoundedFrontMatterSource(s.ws, uri, s.maxBytes)
 	if err != nil {
-		// Treat a missing file as "no front matter" rather than an
-		// error so Kinds works for unsaved buffers.
-		return nil, nil, nil //nolint:nilerr // intentional: missing file means empty front matter
+		// Treat a missing or oversized file as "no front matter" rather
+		// than an error so Kinds works for unsaved buffers and never
+		// surfaces a size error from a read-only resolution call.
+		return nil, nil, nil //nolint:nilerr // intentional: missing/oversized file means empty front matter
 	}
 	// Extract the front-matter block directly. lint.StripFrontMatter is
 	// the same extraction NewFileFromSource performs; the full document

--- a/pkg/mdsmith/session_test.go
+++ b/pkg/mdsmith/session_test.go
@@ -1,6 +1,8 @@
 package mdsmith
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -161,6 +163,44 @@ func TestSessionKindsResolvesKind(t *testing.T) {
 	}
 	if !hasDoc {
 		t.Fatalf("Kinds: expected kind 'doc' for docs/guide.md, got %+v", res.Kinds)
+	}
+}
+
+// TestSessionKindsOversizedFileTreatedLikeMissing verifies frontMatterFor
+// caps its read at the session's max-input-size instead of loading an
+// oversized file fully into memory to parse its front matter. Kinds
+// must resolve the same lenient "no front-matter inputs" way it already
+// does for a missing file (frontMatterFor's documented contract), not
+// surface a size error.
+func TestSessionKindsOversizedFileTreatedLikeMissing(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	huge := append([]byte("---\nkinds: [doc]\n---\n"), make([]byte, 200)...)
+	if err := os.WriteFile(filepath.Join(root, "docs", "guide.md"), huge, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg := "max-input-size: \"50\"\n" +
+		"kinds:\n  doc: {}\n"
+	s, err := NewSession(SessionOptions{
+		Workspace: OSWorkspace{Root: root},
+		Config:    ConfigYAML(cfg),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(s.Dispose)
+
+	res, err := s.Kinds("docs/guide.md")
+	if err != nil {
+		t.Fatalf("Kinds on oversized file: want no error (treated like missing), got %v", err)
+	}
+	for _, k := range res.Kinds {
+		if k.Name == "doc" {
+			t.Fatalf("Kinds on oversized file: front matter should not have been read, got kind %q assigned via front matter", k.Name)
+		}
 	}
 }
 

--- a/pkg/mdsmith/session_test.go
+++ b/pkg/mdsmith/session_test.go
@@ -205,6 +205,37 @@ func TestSessionKindsOversizedFileTreatedLikeMissing(t *testing.T) {
 	}
 }
 
+// TestSessionKindsOversizedFileOnUnboundedWorkspaceFallback verifies
+// readBoundedFrontMatterSource's fallback path: a Workspace that does
+// not implement boundedWorkspaceReader (MemWorkspace here) still gets
+// the same lenient oversized-file treatment via the post-read size
+// check, not just the bytelimit-backed OSWorkspace/OverlayWorkspace
+// fast path.
+func TestSessionKindsOversizedFileOnUnboundedWorkspaceFallback(t *testing.T) {
+	huge := append([]byte("---\nkinds: [doc]\n---\n"), make([]byte, 200)...)
+	cfg := "max-input-size: \"50\"\n" +
+		"kinds:\n  doc: {}\n"
+	s, err := NewSession(SessionOptions{
+		Workspace: NewMemWorkspace(map[string][]byte{"docs/guide.md": huge}),
+		Config:    ConfigYAML(cfg),
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	t.Cleanup(s.Dispose)
+
+	res, err := s.Kinds("docs/guide.md")
+	if err != nil {
+		t.Fatalf("Kinds on oversized file (MemWorkspace fallback): want no error, got %v", err)
+	}
+	for _, k := range res.Kinds {
+		if k.Name == "doc" {
+			t.Fatalf("Kinds on oversized file (MemWorkspace fallback): front matter should not "+
+				"have been read, got kind %q assigned via front matter", k.Name)
+		}
+	}
+}
+
 func TestSessionCapabilities(t *testing.T) {
 	s := newTestSession(t, "", nil)
 

--- a/pkg/mdsmith/session_test.go
+++ b/pkg/mdsmith/session_test.go
@@ -199,7 +199,8 @@ func TestSessionKindsOversizedFileTreatedLikeMissing(t *testing.T) {
 	}
 	for _, k := range res.Kinds {
 		if k.Name == "doc" {
-			t.Fatalf("Kinds on oversized file: front matter should not have been read, got kind %q assigned via front matter", k.Name)
+			t.Fatalf("Kinds on oversized file: front matter should not have been read, "+
+				"got kind %q assigned via front matter", k.Name)
 		}
 	}
 }

--- a/pkg/mdsmith/workspace.go
+++ b/pkg/mdsmith/workspace.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 )
 
 // Workspace is the filesystem seam the engine reads through. The same
@@ -80,6 +82,20 @@ func (w OSWorkspace) ReadFile(p string) ([]byte, error) {
 		return os.ReadFile(p) //nolint:gosec // path is caller-controlled; OSWorkspace is the native disk seam
 	}
 	return readFileRooted(w.Root, path.Clean(filepath.ToSlash(p)))
+}
+
+// readFileLimited is ReadFile's bounded counterpart: it stops reading at
+// max+1 bytes via bytelimit rather than loading an oversized file fully
+// into memory first, and returns a "file too large" error when the file
+// exceeds max. frontMatterFor uses it so resolving a file's kind never
+// pulls an arbitrarily large document fully resident just to read its
+// leading front-matter block. Shares ReadFile's Root/absolute-path
+// dispatch and containment.
+func (w OSWorkspace) readFileLimited(p string, max int64) ([]byte, error) {
+	if w.Root == "" || filepath.IsAbs(p) {
+		return bytelimit.ReadFileLimited(p, max)
+	}
+	return readFileRootedLimited(w.Root, path.Clean(filepath.ToSlash(p)), max)
 }
 
 // Glob expands a doublestar pattern against the host filesystem.

--- a/pkg/mdsmith/workspace_fs.go
+++ b/pkg/mdsmith/workspace_fs.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 	"github.com/jeduden/mdsmith/internal/lint"
 )
 
@@ -42,4 +43,16 @@ func readFileRooted(root, relPath string) ([]byte, error) {
 	}
 	defer r.Close() //nolint:errcheck // best-effort close on read-only handle
 	return fs.ReadFile(r.FS(), relPath)
+}
+
+// readFileRootedLimited mirrors readFileRooted but caps the read via
+// bytelimit, so a file over max is rejected without being fully read
+// into memory — see OSWorkspace.readFileLimited.
+func readFileRootedLimited(root, relPath string, max int64) ([]byte, error) {
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close() //nolint:errcheck // best-effort close on read-only handle
+	return bytelimit.ReadFSFileLimited(r.FS(), relPath, max)
 }

--- a/pkg/mdsmith/workspace_fs_tinygo.go
+++ b/pkg/mdsmith/workspace_fs_tinygo.go
@@ -5,6 +5,8 @@ package mdsmith
 import (
 	"io/fs"
 	"os"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 )
 
 // FS returns os.DirFS(Root) on tinygo/wasm builds. The wasm sandbox has no
@@ -25,4 +27,10 @@ func (w OSWorkspace) FS() fs.FS {
 // guard against.
 func readFileRooted(root, relPath string) ([]byte, error) {
 	return fs.ReadFile(os.DirFS(root), relPath)
+}
+
+// readFileRootedLimited mirrors readFileRooted but caps the read via
+// bytelimit — see OSWorkspace.readFileLimited.
+func readFileRootedLimited(root, relPath string, max int64) ([]byte, error) {
+	return bytelimit.ReadFSFileLimited(os.DirFS(root), relPath, max)
 }

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
 )
 
 func TestMemWorkspaceReadFile(t *testing.T) {
@@ -507,16 +508,16 @@ func TestOSWorkspaceReadFileLimitedOverLimit(t *testing.T) {
 	rooted := OSWorkspace{Root: root}
 	if _, err := rooted.readFileLimited("huge.md", 50); err == nil {
 		t.Fatal("readFileLimited(rooted) over limit: want error, got nil")
-	} else if !strings.Contains(err.Error(), "file too large") {
-		t.Fatalf("readFileLimited(rooted) over limit: got err %q, want it to mention 'file too large'", err)
+	} else if !errors.Is(err, bytelimit.ErrFileTooLarge) {
+		t.Fatalf("readFileLimited(rooted) over limit: got err %v, want it to wrap bytelimit.ErrFileTooLarge", err)
 	}
 
 	abs := filepath.Join(root, "huge.md")
 	unrooted := OSWorkspace{}
 	if _, err := unrooted.readFileLimited(abs, 50); err == nil {
 		t.Fatal("readFileLimited(absolute) over limit: want error, got nil")
-	} else if !strings.Contains(err.Error(), "file too large") {
-		t.Fatalf("readFileLimited(absolute) over limit: got err %q, want it to mention 'file too large'", err)
+	} else if !errors.Is(err, bytelimit.ErrFileTooLarge) {
+		t.Fatalf("readFileLimited(absolute) over limit: got err %v, want it to wrap bytelimit.ErrFileTooLarge", err)
 	}
 }
 

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -462,3 +463,59 @@ var (
 	_ Workspace = OSWorkspace{}
 	_ Workspace = (*MemWorkspace)(nil)
 )
+
+// TestOSWorkspaceReadFileLimitedWithinLimit verifies readFileLimited
+// returns the file's bytes when the file is at or under max, for both
+// the rooted and unrooted (absolute-path) dispatch in ReadFile.
+func TestOSWorkspaceReadFileLimitedWithinLimit(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	rooted := OSWorkspace{Root: root}
+	got, err := rooted.readFileLimited("a.md", 100)
+	if err != nil {
+		t.Fatalf("readFileLimited(rooted): %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("readFileLimited(rooted) = %q, want %q", got, "hello")
+	}
+
+	abs := filepath.Join(root, "a.md")
+	unrooted := OSWorkspace{}
+	got, err = unrooted.readFileLimited(abs, 100)
+	if err != nil {
+		t.Fatalf("readFileLimited(absolute): %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("readFileLimited(absolute) = %q, want %q", got, "hello")
+	}
+}
+
+// TestOSWorkspaceReadFileLimitedOverLimit verifies readFileLimited
+// rejects a file larger than max with a "file too large" error instead
+// of returning its full content — the bounded counterpart to ReadFile,
+// which has no such cap. Covers both the rooted and unrooted dispatch.
+func TestOSWorkspaceReadFileLimitedOverLimit(t *testing.T) {
+	content := make([]byte, 100)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "huge.md"), content, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	rooted := OSWorkspace{Root: root}
+	if _, err := rooted.readFileLimited("huge.md", 50); err == nil {
+		t.Fatal("readFileLimited(rooted) over limit: want error, got nil")
+	} else if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("readFileLimited(rooted) over limit: got err %q, want it to mention 'file too large'", err)
+	}
+
+	abs := filepath.Join(root, "huge.md")
+	unrooted := OSWorkspace{}
+	if _, err := unrooted.readFileLimited(abs, 50); err == nil {
+		t.Fatal("readFileLimited(absolute) over limit: want error, got nil")
+	} else if !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("readFileLimited(absolute) over limit: got err %q, want it to mention 'file too large'", err)
+	}
+}

--- a/pkg/mdsmith/workspace_test.go
+++ b/pkg/mdsmith/workspace_test.go
@@ -519,3 +519,15 @@ func TestOSWorkspaceReadFileLimitedOverLimit(t *testing.T) {
 		t.Fatalf("readFileLimited(absolute) over limit: got err %q, want it to mention 'file too large'", err)
 	}
 }
+
+// TestOSWorkspaceReadFileLimitedOpenRootFails mirrors
+// TestOSWorkspaceReadFileOpenRootFails for the bounded read path:
+// readFileLimited must propagate the os.OpenRoot error (e.g. a
+// non-existent Root) through readFileRootedLimited rather than panic.
+func TestOSWorkspaceReadFileLimitedOpenRootFails(t *testing.T) {
+	nonExistent := t.TempDir() + "/does-not-exist"
+	ws := OSWorkspace{Root: nonExistent}
+	if _, err := ws.readFileLimited("any.md", 100); err == nil {
+		t.Fatal("readFileLimited on a non-existent root must return an error")
+	}
+}


### PR DESCRIPTION
## Summary

Audited the codebase against [`docs/development/high-performance-go.md`](docs/development/high-performance-go.md) using four parallel research agents, each sweeping a different category of anti-pattern from the guideline (non-package-scope regex compiles, `fmt.Sprintf`/`string()` conversions on hot paths, un-presized slices and `[]T{}`-vs-`nil` returns, and the misc "patterns to avoid" table — `defer` in loops, `time.Now()` in loops, `log.Printf` per item, unbounded `os.ReadFile`, `context.Background()` deep in a call chain).

The codebase turned out to already be quite disciplined (four prior PRs — #762, #764, #765, #767 — already swept the obvious violations), so this pass found a small number of genuine, verifiable issues rather than a long tail. Two additional candidates the agents initially flagged (a `string()` conversion in `horizontalrulestyle.checkHR`, and a `[]string{}`-vs-`nil` return in `concisenessscoring.extractFeatures`) were investigated and **ruled out** after measurement — the guideline's own process ("profile before you rewrite — a flat profile in your suspected hot path stops a useless fix") caught them before they became no-op changes: the first is proven not to escape to the heap by the compiler's own escape analysis (`go build -gcflags="-m=2"` confirms "does not escape"), and the second is intentionally non-nil per an existing test (`TestClassify_EmptyInputKeepsCueSliceNonNil`).

### Fixes (each its own commit, red/green TDD)

1. **`pkg/mdsmith`: bound `frontMatterFor`'s read at the session's max-input-size.** `Session.Kinds` was the one `Workspace` read path with no size cap at all — every other read (`Check`/`Fix`) already threads `MaxInputBytes` through the engine runner. Added a `readFileLimited` capability to `OSWorkspace` and `OverlayWorkspace` (bytelimit-backed, so an oversized file is never read past `max+1` bytes) instead of `os.ReadFile`'s unbounded read.
2. **MDS054 (`no-undefined-reference-labels`): avoid a `string()` copy per bracket candidate.** When a `placeholders:` vocabulary is configured, three scanners each converted every reference-style bracket candidate to a string just to check it against the vocabulary — on a rule that's enabled by default. Replaced with a documented zero-copy `unsafe.String` view.
3. **MDS034 (`markdown-flavor`): avoid per-line allocation in `fixGitHubAlerts`.** The `Fix` path built its result in an un-presized `[]string` joined via `strings.Join`, and its skip-map builder converted every alert-paragraph line to a string just to test its first byte. Rewrote around a single pre-grown `bytes.Buffer` (mirroring `blockquotewhitespace.Fix`, the sibling rule that already made this switch) plus `bytes.TrimLeft`.
4. **MDS062 (`link-validity`): presize `reversedInLine`'s match slice.** The regex submatch-index slice already gives the exact upper bound before the result loop starts; presized instead of growing via bare `append`.
5. **MDS034: use the memoized line index instead of a per-call rescan.** `buildAlertSkipMaps` called `flavor.LineCol` (a fresh `bytes.Count`/`bytes.LastIndexByte` scan from byte 0) once per continuation line in a loop — O(n) per line, O(n²) over a long alert paragraph — instead of `lint.File`'s existing O(log n) memoized `LineOfOffset`. This is a pure CPU fix (allocations unchanged), so it's validated via `benchstat` rather than an alloc-budget test: **−52.00% time (p=0.000, n=10)** on a 500-line fixture.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (161/161 packages pass)
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run ./...` (0 issues)
- [x] `go run ./cmd/mdsmith check .` (567 files, 0 failures)
- [x] Each fix has a dedicated alloc-budget (or, for the CPU-only fix, benchmark/benchstat) test that fails before the change and passes after — confirmed by temporarily reverting each fix and re-running its test.


---
_Generated by [Claude Code](https://claude.ai/code/session_0143ESqh4f4KhojH5myCBRJv)_